### PR TITLE
refactor(machines): the canonical rf.* require-alias dialect (rf2-j5or)

### DIFF
--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -107,10 +107,14 @@
 ;; ---- the pure transition (Spec 005 §Testing §Level 1) --------------------
 ;;
 ;; The engine seam (`rf.machines.parallel/machine-transition`) returns the engine's
-;; internal Result, which rides lifecycle bookkeeping (`::rf.machines.result/handled?`,
-;; `::rf.machines.result/microsteps`, `::rf.machines.result/cascade`, `::rf.machines.result/parallel-done-
-;; handled?`) and a `::rf.machines.result/depth-abort?` sentinel inside a failure's
-;; diagnostic map. None of that is the app's business. The public fn
+;; internal Result, which rides lifecycle bookkeeping keyed in
+;; `re-frame.machines.result` (`handled?`, `microsteps`, `cascade`,
+;; `parallel-done-handled?`) and a `:re-frame.machines.result/depth-abort?`
+;; sentinel inside a failure's diagnostic map. That sentinel is spelled
+;; FULLY-QUALIFIED below rather than auto-resolved: under the canonical
+;; `rf.<tail>` require alias, `::rf.machines.result/depth-abort?` reads to a text
+;; scanner as a literal reserved-root `:rf.*` keyword, which it is not.
+;; None of that is the app's business. The public fn
 ;; projects the Result onto the one plain map Spec 005 §Level 1 defines,
 ;; and stamps `:kind` with the Spec 009 category the runtime would emit
 ;; for the same failure — so a test reads the pure result with the same
@@ -129,7 +133,7 @@
                  :rf.error/machine-action-exception)]
       {:status :error
        :error  (merge {:kind kind}
-                      (dissoc info ::rf.machines.result/depth-abort? :error-id))})))
+                      (dissoc info :re-frame.machines.result/depth-abort? :error-id))})))
 
 (defn machine-transition
   "The pure transition. Given a machine `definition`, the current

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -41,31 +41,31 @@
       `re-frame.machines.lifecycle-fx.spawn`
     - `destroy-machine-fx` — `re-frame.machines.lifecycle-fx.destroy`
     - `after-schedule-fx`, `after-cancel-fx` — `re-frame.machines.timer`"
-  (:require [re-frame.frame :as frame]
-            [re-frame.fx :as fx]
-            [re-frame.image-assembly :as image-assembly]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.machines.data-validation :as data-validation]
-            [re-frame.machines.hydrate :as machines-hydrate]
-            [re-frame.machines.lifecycle-fx.destroy :as destroy]
-            [re-frame.machines.lifecycle-fx.frame-destroy :as frame-destroy]
-            [re-frame.machines.lifecycle-fx.join :as join]
-            [re-frame.machines.lifecycle-fx.registration :as registration]
-            [re-frame.machines.lifecycle-fx.resolver :as resolver]
-            [re-frame.machines.lifecycle-fx.spawn :as spawn]
-            [re-frame.machines.lifecycle-fx.update-snapshot :as update-snapshot]
-            [re-frame.machines.lifecycle-fx.validation :as validation]
-            [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.paths :as paths]
-            [re-frame.machines.result :as result]
-            [re-frame.machines.spawn-order :as spawn-order]
-            [re-frame.machines.ssr :as machines-ssr]
-            [re-frame.machines.timer :as timer]
-            [re-frame.registrar :as registrar]
-            [re-frame.subs :as subs]
+  (:require [re-frame.frame :as rf.frame]
+            [re-frame.fx :as rf.fx]
+            [re-frame.image-assembly :as rf.image-assembly]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.machines.data-validation :as rf.machines.data-validation]
+            [re-frame.machines.hydrate :as rf.machines.hydrate]
+            [re-frame.machines.lifecycle-fx.destroy :as rf.machines.lifecycle-fx.destroy]
+            [re-frame.machines.lifecycle-fx.frame-destroy :as rf.machines.lifecycle-fx.frame-destroy]
+            [re-frame.machines.lifecycle-fx.join :as rf.machines.lifecycle-fx.join]
+            [re-frame.machines.lifecycle-fx.registration :as rf.machines.lifecycle-fx.registration]
+            [re-frame.machines.lifecycle-fx.resolver :as rf.machines.lifecycle-fx.resolver]
+            [re-frame.machines.lifecycle-fx.spawn :as rf.machines.lifecycle-fx.spawn]
+            [re-frame.machines.lifecycle-fx.update-snapshot :as rf.machines.lifecycle-fx.update-snapshot]
+            [re-frame.machines.lifecycle-fx.validation :as rf.machines.lifecycle-fx.validation]
+            [re-frame.machines.parallel :as rf.machines.parallel]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.machines.result :as rf.machines.result]
+            [re-frame.machines.spawn-order :as rf.machines.spawn-order]
+            [re-frame.machines.ssr :as rf.machines.ssr]
+            [re-frame.machines.timer :as rf.machines.timer]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.subs :as rf.subs]
             ;; Keep tooling out of CLJS production bundles. CLJS tools require
             ;; the tooling namespace directly; JVM callers get facade aliases.
-            #?@(:clj [[re-frame.machines.tooling :as machines-tooling]])))
+            #?@(:clj [[re-frame.machines.tooling :as rf.machines.tooling]])))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -74,42 +74,42 @@
 ;; These `def`s make the sub-namespace fns reachable as
 ;; `re-frame.machines/<name>` so consumers (the `re-frame.core` late-bind
 ;; bridge, the conformance corpus, the test fixtures, examples that
-;; `:require [re-frame.machines :as machines]`) all see one surface.
+;; `:require [re-frame.machines :as rf.machines]`) all see one surface.
 
 ;; Declarative spawns allocate ids in the parent snapshot's
 ;; `:rf/spawn-counter`; hand-emitted spawns use the frame's runtime-db
 ;; `[:rf.runtime/machines :spawn-counter <machine-id>]` slot.
 
-(def reg-machine*           registration/reg-machine*)
-(def make-machine-handler registration/make-machine-handler)
+(def reg-machine*           rf.machines.lifecycle-fx.registration/reg-machine*)
+(def make-machine-handler rf.machines.lifecycle-fx.registration/make-machine-handler)
 ;; Boundary-validation surface for the `[:schemas :data]` schema on `reg-machine`
 ;; (Spec 005 §Schema validation, Spec 010 §Per-step recovery row 7). The
 ;; post-commit walker validates every snapshot's `:data` against its
 ;; registered machine's `[:schemas :data]` schema; the spawn-time sibling
 ;; validates a spawned actor's initial `:data` before install.
-(def validate-machine-data! data-validation/validate-machine-data!)
-(def validate-spawn-data!   data-validation/validate-spawn-data!)
+(def validate-machine-data! rf.machines.data-validation/validate-machine-data!)
+(def validate-spawn-data!   rf.machines.data-validation/validate-spawn-data!)
 ;; The `:rf.machine/update-snapshot` escape-hatch sibling validates the
 ;; would-be-merged snapshot's `:data` BEFORE the fx writes it, so the
 ;; `[:schemas :data]` boundary covers the escape hatch too.
-(def validate-update-snapshot-data! data-validation/validate-update-snapshot-data!)
+(def validate-update-snapshot-data! rf.machines.data-validation/validate-update-snapshot-data!)
 ;; The pure registration-time validator (Spec 005 §registration validators).
 ;; Re-exported so the conformance corpus's `:reg-machine` Mode-B call op can
 ;; pin the registration-error taxonomy (Spec 009 §thrown-error shape)
-;; directly against the leaf fn — no registrar/substrate fixture.
-(def validate-machine!      validation/validate-machine!)
-(def spawn-fx               spawn/spawn-fx)
-(def spawn-all-init-fx      spawn/spawn-all-init-fx)
-(def destroy-machine-fx     destroy/destroy-machine-fx)
-(def after-schedule-fx      timer/after-schedule-fx)
-(def after-cancel-fx        timer/after-cancel-fx)
+;; directly against the leaf fn — no rf.registrar/substrate fixture.
+(def validate-machine!      rf.machines.lifecycle-fx.validation/validate-machine!)
+(def spawn-fx               rf.machines.lifecycle-fx.spawn/spawn-fx)
+(def spawn-all-init-fx      rf.machines.lifecycle-fx.spawn/spawn-all-init-fx)
+(def destroy-machine-fx     rf.machines.lifecycle-fx.destroy/destroy-machine-fx)
+(def after-schedule-fx      rf.machines.timer/after-schedule-fx)
+(def after-cancel-fx        rf.machines.timer/after-cancel-fx)
 
 ;; ---- the pure transition (Spec 005 §Testing §Level 1) --------------------
 ;;
-;; The engine seam (`parallel/machine-transition`) returns the engine's
-;; internal Result, which rides lifecycle bookkeeping (`::result/handled?`,
-;; `::result/microsteps`, `::result/cascade`, `::result/parallel-done-
-;; handled?`) and a `::result/depth-abort?` sentinel inside a failure's
+;; The engine seam (`rf.machines.parallel/machine-transition`) returns the engine's
+;; internal Result, which rides lifecycle bookkeeping (`::rf.machines.result/handled?`,
+;; `::rf.machines.result/microsteps`, `::rf.machines.result/cascade`, `::rf.machines.result/parallel-done-
+;; handled?`) and a `::rf.machines.result/depth-abort?` sentinel inside a failure's
 ;; diagnostic map. None of that is the app's business. The public fn
 ;; projects the Result onto the one plain map Spec 005 §Level 1 defines,
 ;; and stamps `:kind` with the Spec 009 category the runtime would emit
@@ -119,17 +119,17 @@
 (defn- public-result
   "Project the engine's Result onto the Spec 005 §Level 1 public map."
   [r]
-  (if (result/ok? r)
+  (if (rf.machines.result/ok? r)
     {:status   :ok
-     :snapshot (result/snap r)
-     :fx       (vec (result/fx r))}
-    (let [info (result/info r)
-          kind (if (result/depth-abort? r)
+     :snapshot (rf.machines.result/snap r)
+     :fx       (vec (rf.machines.result/fx r))}
+    (let [info (rf.machines.result/info r)
+          kind (if (rf.machines.result/depth-abort? r)
                  (:error-id info)
                  :rf.error/machine-action-exception)]
       {:status :error
        :error  (merge {:kind kind}
-                      (dissoc info ::result/depth-abort? :error-id))})))
+                      (dissoc info ::rf.machines.result/depth-abort? :error-id))})))
 
 (defn machine-transition
   "The pure transition. Given a machine `definition`, the current
@@ -157,7 +157,7 @@
   module-level state; JVM- and CLJS-runnable. `re-frame.machines` is the
   only namespace a caller needs."
   [definition snapshot event]
-  (public-result (parallel/machine-transition definition snapshot event)))
+  (public-result (rf.machines.parallel/machine-transition definition snapshot event)))
 
 ;; ---- query API (Spec 005 §Querying machines) -----------------------------
 ;;
@@ -178,7 +178,7 @@
   registration metadata carries `:rf/machine? true`. Per Spec 005
   §Querying machines."
   []
-  (->> (registrar/registrations :event)
+  (->> (rf.registrar/registrations :event)
        (keep (fn [[id m]] (when (:rf/machine? m) id)))
        (vec)))
 
@@ -188,14 +188,14 @@
   coords) for `machine-id`, or nil if no machine is registered under
   that id. Per Spec 005 §Querying machines."
   [machine-id]
-  (resolver/spec-from-registry machine-id))
+  (rf.machines.lifecycle-fx.resolver/spec-from-registry machine-id))
 
 (defn machine-by-system-id
   "Look up the spawned-machine id currently bound to `system-id` in the
   active frame's `[:rf.runtime/machines :system-ids]` reverse index, or nil.
 
   The 1-arity ambient form resolves the frame through the scope/hold chain
-  via `frame/require-current-frame!` — a lookup issued under no established
+  via `rf.frame/require-current-frame!` — a lookup issued under no established
   scope raises `:rf.error/no-frame-context` rather than reading an invented
   default's reverse index. Pass the public opts form `(machine-by-system-id
   system-id {:frame target})` to look up a named frame from outside any
@@ -212,18 +212,18 @@
   ([system-id]
    (machine-by-system-id
      system-id
-     (frame/require-current-frame!
+     (rf.frame/require-current-frame!
        :machine-by-system-id
        {:where 're-frame.machines/machine-by-system-id})))
   ([system-id frame-or-opts]
    ;; A live frame is map-shaped, so exclude frame values from the opts branch.
-   (if (and (map? frame-or-opts) (not (frame/frame-value? frame-or-opts)))
+   (if (and (map? frame-or-opts) (not (rf.frame/frame-value? frame-or-opts)))
      (if-some [target (:frame frame-or-opts)]
        (machine-by-system-id system-id target)
        (machine-by-system-id system-id))
      ;; The reverse index is runtime-db state keyed by the bare frame id.
-     (get-in (frame/frame-runtime-db-value (frame/frame-target->id frame-or-opts))
-             (paths/system-id-path system-id)))))
+     (get-in (rf.frame/frame-runtime-db-value (rf.frame/frame-target->id frame-or-opts))
+             (rf.machines.paths/system-id-path system-id)))))
 
 ;; ---- derivation/process algebra views -------------------------------------
 ;;
@@ -242,10 +242,10 @@
 ;; export. Mirrors the `re-frame.flows/flow-algebra-view` JVM alias.
 #?(:clj
    (do
-     (def machine-algebra-view          machines-tooling/machine-algebra-view)
-     (def machine-instance-algebra-view machines-tooling/machine-instance-algebra-view)
-     (def machine-selector?             machines-tooling/machine-selector?)
-     (def machine-selector-targets      machines-tooling/machine-selector-targets)))
+     (def machine-algebra-view          rf.machines.tooling/machine-algebra-view)
+     (def machine-instance-algebra-view rf.machines.tooling/machine-instance-algebra-view)
+     (def machine-selector?             rf.machines.tooling/machine-selector?)
+     (def machine-selector-targets      rf.machines.tooling/machine-selector-targets)))
 
 ;; ---- :rf.machine/dispatch-to-system — action→spawned-actor messaging fx --
 ;;
@@ -280,11 +280,11 @@
   ;; The cascade envelope frame is the fx-context `:frame`; a nil stamp is
   ;; an invariant failure (`:rf.error/no-frame-context`), never a
   ;; synthesised `:rf/default`.
-  (let [frame-id (frame/require-frame-stamp!
+  (let [frame-id (rf.frame/require-frame-stamp!
                    frame-id :rf.machine/dispatch-to-system
                    {:where 'rf.machine/dispatch-to-system :event-id system-id})]
     (when-let [machine-id (machine-by-system-id system-id frame-id)]
-      (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+      (when-let [dispatch! (rf.late-bind/get-fn :router/dispatch!)]
         (dispatch! [machine-id event] {:frame frame-id}))))
   nil)
 
@@ -295,7 +295,7 @@
   `re-frame.test-support`'s `reset-runtime` and per-feature artefact test
   fixtures. Clears the entire frame-scoped table.
 
-  1-arity: just the given frame's timers — the `frame/destroy-frame!`
+  1-arity: just the given frame's timers — the `rf.frame/destroy-frame!`
   hook shape used to release a destroyed frame's host-clock handles and
   subscription watchers without touching sibling frames.
 
@@ -308,9 +308,9 @@
   aligns with the test-fixture and frame-destroy call sites
   respectively."
   ([]
-   (timer/cancel-all-timers!))
+   (rf.machines.timer/cancel-all-timers!))
   ([frame-id]
-   (timer/cancel-all-timers! frame-id)))
+   (rf.machines.timer/cancel-all-timers! frame-id)))
 
 ;; ---- machine-internal effect handlers ------------------------------------
 ;;
@@ -324,23 +324,23 @@
 ;; `:rf.machine/destroyed`) nor the handler symbols on its production-
 ;; elision bundle.
 
-(fx/reg-fx :rf.machine/spawn
+(rf.fx/reg-fx :rf.machine/spawn
   {:doc "Spawn a machine instance. Per Spec 005 §Declarative :spawn (sugar over spawn). Args carry `:machine-id`, optional `:system-id`, and optional `:data`."}
   spawn-fx)
 
-(fx/reg-fx :rf.machine/destroy
+(rf.fx/reg-fx :rf.machine/destroy
   {:doc "Destroy a spawned machine instance and clear its `[:rf.runtime/machines :snapshots machine-id]` slot. Per Spec 005 §Declarative :spawn."}
   destroy-machine-fx)
 
-(fx/reg-fx :rf.machine/spawn-all-init
+(rf.fx/reg-fx :rf.machine/spawn-all-init
   {:doc "Machine-internal: fire `:initial-entry` cascades for every machine spawned at app boot. Per Spec 005 §Initial entry. Not for direct application use."}
   spawn-all-init-fx)
 
-(fx/reg-fx :rf.machine/after-schedule
+(rf.fx/reg-fx :rf.machine/after-schedule
   {:doc "Machine-internal: schedule an `:after` timer event for a machine state. Per Spec 005 §Timed transitions. Not for direct application use."}
   after-schedule-fx)
 
-(fx/reg-fx :rf.machine/after-cancel
+(rf.fx/reg-fx :rf.machine/after-cancel
   {:doc "Machine-internal: cancel a previously-scheduled `:after` timer. Per Spec 005 §Timed transitions. Not for direct application use."}
   after-cancel-fx)
 
@@ -350,30 +350,30 @@
 ;; both partitions before `run-fx-effects!` walks `:fx`, which is exactly
 ;; the ordering the re-arm needs: it reads the just-installed snapshots.
 ;; Deliberately NOT a state-entry replay — see `re-frame.machines.hydrate`.
-(fx/reg-fx :rf.machine/hydrate-rearm
+(rf.fx/reg-fx :rf.machine/hydrate-rearm
   {:doc "Machine-internal: reconstruct the host `:after` timer table for the frame's just-hydrated machine snapshots, at each snapshot's existing `:rf/after-epoch` and without replaying entry effects. Per Spec 011 §`:after` is no-op under SSR (\"`:after` timers begin running on the client\"). Not for direct application use."}
   (fn [{frame-id :frame} _args]
     (let [;; The cascade envelope frame is the fx-context `:frame`; a nil
           ;; stamp is an invariant failure (`:rf.error/no-frame-context`),
           ;; never a synthesised `:rf/default` — the timers would otherwise
           ;; be armed against a frame nobody hydrated.
-          frame-id (frame/require-frame-stamp!
+          frame-id (rf.frame/require-frame-stamp!
                      frame-id :rf.machine/hydrate-rearm
                      {:where 'rf.machine/hydrate-rearm})]
-      (machines-hydrate/rearm-after-timers! frame-id))
+      (rf.machines.hydrate/rearm-after-timers! frame-id))
     nil))
 
-(fx/reg-fx :rf.machine/update-snapshot
+(rf.fx/reg-fx :rf.machine/update-snapshot
   {:doc "Snapshot-level escape hatch. Emit `[:rf.machine/update-snapshot {:rf/machine-id <id> :rf/patch {:data {...}}}]` from a callback's `:fx` vector to touch `:state` / `:meta` / `:data` atomically. Per Spec 005 §Snapshot-level escape hatch."}
-  update-snapshot/update-snapshot-fx)
+  rf.machines.lifecycle-fx.update-snapshot/update-snapshot-fx)
 
-(fx/reg-fx :rf.machine/dispatch-to-system
+(rf.fx/reg-fx :rf.machine/dispatch-to-system
   {:doc "Dispatch an event to a spawned actor addressed by `:system-id`. Emit `[:rf.machine/dispatch-to-system [<system-id> <event-vector>]]` from a machine action's `:fx` vector. No-op when the system-id is unbound. The single named-addressing escape (advanced/parity tier); zero in-repo consumers, retained for XState v6 actor-system parity. Per Spec 005 §Cross-machine messaging by name."}
   dispatch-to-system-fx)
 
-(fx/reg-fx :rf.machine/join-dispatch
+(rf.fx/reg-fx :rf.machine/join-dispatch
   {:doc "Machine-internal (rf2-t154jx): the recordable transport for a `:spawn-all` child's completion carrier. The runtime rewrites a member child's own outbound `:dispatch` / `:dispatch-later` completion into this fx so the exact-attempt coordinate rides the recordable `:rf.cofx` `:rf.machine/join-attempt` fact (surviving strict replay + delayed dispatch), not event metadata. The coordinate is a recordable correlation record, not authentication; the fold gate accepts it only on exact-current equality (rf2-cpbjfp). Reserved / non-overridable / non-redirectable to protect the framework path from capture or suppression; direct app emission is UNSUPPORTED but not security-prohibited. Per Spec 005 §Spawn-and-join via :spawn-all."}
-  join/join-dispatch-fx)
+  rf.machines.lifecycle-fx.join/join-dispatch-fx)
 
 ;; ---- framework-shipped subs -----------------------------------------------
 ;;
@@ -384,17 +384,17 @@
 ;;
 ;; Registered at the façade (rather than in `re-frame.machines.lifecycle-
 ;; fx`) so the smoke-test fixture's `(require 're-frame.machines :reload)`
-;; re-installs the subs after `registrar/clear-all!`. `:reload` is
+;; re-installs the subs after `rf.registrar/clear-all!`. `:reload` is
 ;; shallow — a sub registered inside the sub-namespace wouldn't re-fire.
 
 ;; Machine snapshots are durable runtime-db state, so the framework machine
 ;; subs read the frame's RUNTIME-DB projection (`reg-runtime-sub`) — the
 ;; `db`-position arg is the runtime-db value (Spec 002 §Subscriptions read
 ;; the partition they belong to).
-(subs/reg-runtime-sub :rf/machine
+(rf.subs/reg-runtime-sub :rf/machine
   {:doc "Subscribe to a machine's current snapshot `{:state <kw> :data <map> :tags <set>}`. Returns nil for an unknown or not-yet-initialised machine. Per Spec 005 §Subscribing to machines via the :rf/machine sub."}
   (fn [runtime-db [_ machine-id]]
-    (get-in runtime-db (paths/snapshot-path machine-id))))
+    (get-in runtime-db (rf.machines.paths/snapshot-path machine-id))))
 
 ;; Per Spec 005 §State tags: the `:rf.machine/has-tag?` framework sub
 ;; returns `true` iff the named machine's current snapshot's `:tags` set
@@ -404,10 +404,10 @@
 ;; Derived sub — reads the snapshot via `get-in` rather than chaining
 ;; off `:rf/machine` — so a view that only cares about whether a specific
 ;; tag is present re-renders only when the containment-bit flips.
-(subs/reg-runtime-sub :rf.machine/has-tag?
+(rf.subs/reg-runtime-sub :rf.machine/has-tag?
   {:doc "Subscribe to a machine's `:tags` containment-bit for `tag`. Returns `true` iff the named machine's snapshot's `:tags` set contains `tag`, `false` otherwise (including unknown / not-yet-initialised machines). Per Spec 005 §State tags."}
   (fn [runtime-db [_ machine-id tag]]
-    (contains? (get-in runtime-db (paths/snapshot-path machine-id :tags)) tag)))
+    (contains? (get-in runtime-db (rf.machines.paths/snapshot-path machine-id :tags)) tag)))
 
 ;; ---- framework-standard registration -------------------------------------
 ;;
@@ -416,17 +416,17 @@
 ;; discover them; the framework-standard union is their generation path.
 ;; Standards are non-replaceable and use the same descriptors as the regular
 ;; registrar. Capture those descriptors at namespace load so reset can restore
-;; both registries after `registrar/clear-all!`.
+;; both registries after `rf.registrar/clear-all!`.
 
 (def ^:private machine-runtime-descriptors
   "Captured at ns-load: the `[kind id descriptor]` triples for every machine
   runtime effect + sub registered above. `descriptor` is the full registration
   metadata map (carrying `:handler-fn`) read off the registrar right after the
   `reg-fx` / `reg-runtime-sub` form ran. `install-machine-runtime!` re-registers
-  from these so the machine runtime survives a `registrar/clear-all!`."
+  from these so the machine runtime survives a `rf.registrar/clear-all!`."
   (vec
     (keep (fn [[kind id]]
-            (when-let [desc (registrar/lookup kind id)]
+            (when-let [desc (rf.registrar/lookup kind id)]
               [kind id desc]))
           [[:fx  :rf.machine/spawn]
            [:fx  :rf.machine/destroy]
@@ -450,8 +450,8 @@
   registrar has been cleared."
   []
   (doseq [[kind id desc] machine-runtime-descriptors]
-    (registrar/register! kind id desc)
-    (image-assembly/register-standard! kind id desc))
+    (rf.registrar/register! kind id desc)
+    (rf.image-assembly/register-standard! kind id desc))
   nil)
 
 ;; Register at namespace load so an image-loaded frame created by a standalone
@@ -461,11 +461,11 @@
 
 ;; Publish a late-bind hook so `re-frame.test-support`'s reset fixture can
 ;; re-install the machine runtime (registrar + standards) after a sibling ns's
-;; `registrar/clear-all!` / `image-assembly/clear-standards!` wipes them — the
+;; `rf.registrar/clear-all!` / `rf.image-assembly/clear-standards!` wipes them — the
 ;; SAME re-seed-on-reset contract `:rf/set-db` carries. test_support ships in
 ;; core and must not static-require machines (separate Maven coordinate), so the
 ;; re-install is reached through this hook (a no-op when machines is not loaded).
-(late-bind/set-fn! :machines/install-runtime! install-machine-runtime!)
+(rf.late-bind/set-fn! :machines/install-runtime! install-machine-runtime!)
 
 ;; ---- spawned-actor ownership ----------------------------------------------
 ;;
@@ -485,9 +485,9 @@
   artefact or duplicate its runtime-db shape. The lookup is a direct snapshot
   path read; it does not scan the actor table."
   [frame-id event-id]
-  (let [rt (frame/frame-runtime-db-value frame-id)]
+  (let [rt (rf.frame/frame-runtime-db-value frame-id)]
     (when (map? rt)
-      (let [snapshot (get-in rt (paths/snapshot-path event-id))]
+      (let [snapshot (get-in rt (rf.machines.paths/snapshot-path event-id))]
         (when (some? (:rf/machine-type snapshot))
           event-id)))))
 
@@ -509,20 +509,20 @@
 ;; import-time-only (CLJS macroexpansion runs before ns-load); the
 ;; runtime always reaches through this hook to the plain-fn surface.
 
-(late-bind/set-fn! :machines/reg-machine            reg-machine*)
-(late-bind/set-fn! :machines/make-machine-handler make-machine-handler)
-(late-bind/set-fn! :machines/machine-transition     machine-transition)
-(late-bind/set-fn! :machines/machines               machines)
-(late-bind/set-fn! :machines/machine-meta           machine-meta)
-(late-bind/set-fn! :machines/machine-by-system-id   machine-by-system-id)
-(late-bind/set-fn! :machines/reset-timers!          reset-timers!)
-;; Per-frame timer-table cleanup wired into `frame/destroy-frame!`.
+(rf.late-bind/set-fn! :machines/reg-machine            reg-machine*)
+(rf.late-bind/set-fn! :machines/make-machine-handler make-machine-handler)
+(rf.late-bind/set-fn! :machines/machine-transition     machine-transition)
+(rf.late-bind/set-fn! :machines/machines               machines)
+(rf.late-bind/set-fn! :machines/machine-meta           machine-meta)
+(rf.late-bind/set-fn! :machines/machine-by-system-id   machine-by-system-id)
+(rf.late-bind/set-fn! :machines/reset-timers!          reset-timers!)
+;; Per-frame timer-table cleanup wired into `rf.frame/destroy-frame!`.
 ;; The timer table is partitioned `{<frame-id> {…}}`; without this
 ;; hook a destroyed frame's inner table would linger as dead
 ;; bookkeeping and in-flight host-clock handles would survive teardown.
 ;; Late-bound so core never statically requires the machines artefact.
-(late-bind/set-fn! :machines/on-frame-destroyed!
-                   (fn [frame-id] (timer/cancel-all-timers! frame-id)))
+(rf.late-bind/set-fn! :machines/on-frame-destroyed!
+                   (fn [frame-id] (rf.machines.timer/cancel-all-timers! frame-id)))
 ;; Epoch-restore host-transient quiesce. The epoch restore boundary
 ;; (`perform-restore!`) installs the captured durable frame-state WHOLESALE,
 ;; but the in-flight `:after` host-clock timers the unwound epochs armed are
@@ -533,8 +533,8 @@
 ;; carries no leaked timers from the discarded epochs (Managed-Effects §restore:
 ;; "epoch restore MUST NOT revive host work"). Late-bound so core / epoch never
 ;; statically require the machines artefact.
-(late-bind/set-fn! :machines/on-frame-restored!
-                   (fn [frame-id] (timer/cancel-frame-timers-on-restore! frame-id)))
+(rf.late-bind/set-fn! :machines/on-frame-restored!
+                   (fn [frame-id] (rf.machines.timer/cancel-frame-timers-on-restore! frame-id)))
 ;; SSR hydration re-arm hook. `re-frame.ssr.hydrate/hydrate-event-handler*`
 ;; consults it purely as a PRESENCE gate — an SSR app without the machines
 ;; artefact finds it unbound and emits no re-arm fx — and the
@@ -546,22 +546,22 @@
 ;; and must keep cancelling (Managed-Effects: "epoch restore MUST NOT revive
 ;; host work"); hydration arms timers that were never armed at all.
 ;; Late-bound so SSR never statically requires the machines artefact.
-(late-bind/set-fn! :machines/rearm-after-hydration!
-                   machines-hydrate/rearm-after-timers!)
-;; Frame-destroy machine-cascade hook. `frame/destroy-frame!` calls this
+(rf.late-bind/set-fn! :machines/rearm-after-hydration!
+                   rf.machines.hydrate/rearm-after-timers!)
+;; Frame-destroy machine-cascade hook. `rf.frame/destroy-frame!` calls this
 ;; hook BEFORE the sub-cache / adapter teardown so each active machine's
 ;; `:exit` cascade runs against a live container in reverse-creation order
 ;; per Spec 005 §Cross-Spec Interactions §1.
-(late-bind/set-fn! :machines/teardown-on-frame-destroy!
-                   frame-destroy/teardown-on-frame-destroy!)
+(rf.late-bind/set-fn! :machines/teardown-on-frame-destroy!
+                   rf.machines.lifecycle-fx.frame-destroy/teardown-on-frame-destroy!)
 ;; Test-isolation hook fired by
 ;; `re-frame.test-support/make-reset-runtime-fixture`. Drops the per-frame
 ;; spawn-order vectors so a stale entry from a sibling test cannot
 ;; contaminate a frame-destroy walk in the next test.
-(late-bind/set-fn! :machines/reset-spawn-order!
-                   spawn-order/reset-all!)
-(late-bind/set-fn! :machines/spawn-fx               spawn-fx)
-(late-bind/set-fn! :machines/destroy-machine-fx     destroy-machine-fx)
+(rf.late-bind/set-fn! :machines/reset-spawn-order!
+                   rf.machines.spawn-order/reset-all!)
+(rf.late-bind/set-fn! :machines/spawn-fx               spawn-fx)
+(rf.late-bind/set-fn! :machines/destroy-machine-fx     destroy-machine-fx)
 ;; The lazy actor-handler resolver. Core's dispatch consults this hook on
 ;; `:rf.error/no-such-handler` BEFORE erroring:
 ;; given an unresolved event-id (a spawned actor-id with no per-instance
@@ -573,9 +573,9 @@
 ;; `:machines/actor-resolvable?` lets the epoch restore precondition
 ;; treat a spawned-actor snapshot whose TYPE still resolves as a VALID
 ;; restore target (not a `:rf.epoch/restore-missing-handler`).
-(late-bind/set-fn! :machines/resolve-actor-handler-meta
-                   registration/resolve-actor-handler-meta)
-(late-bind/set-fn! :machines/actor-resolvable?      resolver/resolvable?)
+(rf.late-bind/set-fn! :machines/resolve-actor-handler-meta
+                   rf.machines.lifecycle-fx.registration/resolve-actor-handler-meta)
+(rf.late-bind/set-fn! :machines/actor-resolvable?      rf.machines.lifecycle-fx.resolver/resolvable?)
 ;; The epoch restore version-drift precondition resolves a SPAWNED actor's
 ;; CURRENT definition the same way dispatch does: from the
 ;; snapshot's `:rf/machine-type` (a registered TYPE keyword resolved through
@@ -585,12 +585,12 @@
 ;; forward surfaces `:rf.epoch/restore-version-mismatch` instead of silently
 ;; accepting an incompatible older snapshot (the snapshot key is an instance id,
 ;; not a registered handler, so the singleton registrar probe never matched it).
-(late-bind/set-fn! :machines/spec-from-snapshot     resolver/spec-from-snapshot)
+(rf.late-bind/set-fn! :machines/spec-from-snapshot     rf.machines.lifecycle-fx.resolver/spec-from-snapshot)
 ;; The post-commit walker the router AND-conjoins with
 ;; `validate-app-schema!` to gate the `:db` commit on the
 ;; `:where :machine-data` boundary (Spec 005 §Schema validation, Spec
 ;; 010 §Per-step recovery row 7).
-(late-bind/set-fn! :machines/validate-machine-data! validate-machine-data!)
+(rf.late-bind/set-fn! :machines/validate-machine-data! validate-machine-data!)
 ;; The SSR hydration projector for durable machine snapshots.
 ;; `re-frame.ssr.payload-policy/project-runtime-db` consults this hook to project
 ;; the `:rf.runtime/machines` slice so each snapshot's `:data` is redacted /
@@ -599,8 +599,8 @@
 ;; keeping classified machine data out of the hydration payload. Machine
 ;; declarations are lowered per actor under `:source :machine`.
 ;; Late-bound so SSR never statically requires the machines artefact.
-(late-bind/set-fn! :machines/project-ssr-runtime-db
-                   machines-ssr/project-ssr-runtime-db)
+(rf.late-bind/set-fn! :machines/project-ssr-runtime-db
+                   rf.machines.ssr/project-ssr-runtime-db)
 ;; Spawned-actor ownership resolver. The http artefact consults this to
 ;; classify whether a managed request's originating event-id belongs to a
 ;; spawned actor (so an actor-destroy cascade can abort it). Machines OWNS
@@ -609,11 +609,11 @@
 ;; state machines pay nothing). See the `owning-actor-id` docstring for the
 ;; set semantics (snapshot `:rf/machine-type` membership — declarative AND
 ;; imperative spawns).
-(late-bind/set-fn! :machines/owning-actor-id        owning-actor-id)
-(late-bind/set-fn! :machines/spawn-all-init-fx      spawn-all-init-fx)
-(late-bind/set-fn! :machines/after-schedule-fx      after-schedule-fx)
-(late-bind/set-fn! :machines/after-cancel-fx        after-cancel-fx)
-(late-bind/set-fn! :machines/update-snapshot-fx     update-snapshot/update-snapshot-fx)
+(rf.late-bind/set-fn! :machines/owning-actor-id        owning-actor-id)
+(rf.late-bind/set-fn! :machines/spawn-all-init-fx      spawn-all-init-fx)
+(rf.late-bind/set-fn! :machines/after-schedule-fx      after-schedule-fx)
+(rf.late-bind/set-fn! :machines/after-cancel-fx        after-cancel-fx)
+(rf.late-bind/set-fn! :machines/update-snapshot-fx     rf.machines.lifecycle-fx.update-snapshot/update-snapshot-fx)
 
 ;; Load-order resilience for the `:rf.http/managed` machine-shape wrapper.
 ;; The wrapper is registered by re-frame.http.managed via the
@@ -624,5 +624,5 @@
 ;; re-invoking the http artefact's `:http/register-managed-machine!` hook
 ;; from here — if http-managed is on the classpath the hook is set and the
 ;; wrapper registers now; if it isn't, the hook is nil and this is a no-op.
-(when-let [reg-fn (late-bind/get-fn :http/register-managed-machine!)]
+(when-let [reg-fn (rf.late-bind/get-fn :http/register-managed-machine!)]
   (reg-fn))

--- a/implementation/machines/src/re_frame/machines/choice.cljc
+++ b/implementation/machines/src/re_frame/machines/choice.cljc
@@ -75,7 +75,7 @@
     - a choice candidate that targets the choice state's OWN declaring
       state is a self-loop (an immediate eventless cycle), rejected exactly
       as an `:always` self-loop is (`:rf.error/machine-choice-self-loop`)."
-  (:require [re-frame.error :as error]))
+  (:require [re-frame.error :as rf.error]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -202,7 +202,7 @@
   discriminator; `reason` is the human diagnostic; `extra` merges
   per-site slots."
   [error-id reason extra]
-  (error/thrown-ex-info error-id 'rf/reg-machine reason
+  (rf.error/thrown-ex-info error-id 'rf/reg-machine reason
                         {:recovery :fix-registration :extra extra}))
 
 (defn- candidate-vector?

--- a/implementation/machines/src/re_frame/machines/classification.cljc
+++ b/implementation/machines/src/re_frame/machines/classification.cljc
@@ -17,10 +17,10 @@
   so existing trace, SSR, and projection readers need no machine-specific path.
   A malformed declaration fails at registration. Omitting classification leaves
   the data unclassified."
-  (:require [re-frame.elision :as elision]
-            [re-frame.error :as error]
-            [re-frame.machines.paths :as paths]
-            [re-frame.path :as path]))
+  (:require [re-frame.elision :as rf.elision]
+            [re-frame.error :as rf.error]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.path :as rf.path]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -51,7 +51,7 @@
                    "must be a path vector; got " (pr-str p))
               :else
               (try
-                (path/normalize-concrete p)
+                (rf.path/normalize-concrete p)
                 nil
                 (catch #?(:clj Throwable :cljs :default) e
                   (str "an invalid path in the machine `" k "` classification "
@@ -70,7 +70,7 @@
   (doseq [k classification-axis-keys]
     (when (contains? spec k)
       (when-let [reason (declaration-defect k (get spec k))]
-        (error/throw-error!
+        (rf.error/throw-error!
           :rf.error/invalid-machine-classification
           'rf-machines/reg-machine
           (str "reg-machine " machine-id " declares a malformed " k
@@ -92,7 +92,7 @@
   Returns nil when the spec declares NEITHER axis (the common no-op).
   Assumes the spec already passed `validate-machine-classification!`. Pure."
   [spec]
-  (let [norm (fn [k] (into [] (map #(vec (path/normalize-concrete %))) (get spec k)))
+  (let [norm (fn [k] (into [] (map #(vec (rf.path/normalize-concrete %))) (get spec k)))
         sens (when (seq (get spec :sensitive)) (norm :sensitive))
         larg (when (seq (get spec :large))     (norm :large))]
     (when (or (seq sens) (seq larg))
@@ -107,7 +107,7 @@
   — the exact shape `re-frame.classification/frame-snapshot-classification` re-roots back
   snapshot-relative at egress. Pure."
   [actor-id path]
-  (into (paths/snapshot-path actor-id) path))
+  (into (rf.machines.paths/snapshot-path actor-id) path))
 
 (defn- machine-owner
   "The multi-owner elision-registry owner identity a machine actor's lowered
@@ -129,7 +129,7 @@
   owner on the same absolute path (Spec 015 L149 explicitly permits an app to
   additionally classify a subsystem absolute path from a handler effect,
   `:source :effect`); DROP removes ONLY this actor's own owner
-  (`elision/remove-claims`) at the named absolute paths — a path ALSO claimed
+  (`rf.elision/remove-claims`) at the named absolute paths — a path ALSO claimed
   by another owner is LEFT INTACT, so an actor teardown never silently
   un-redacts a path another owner still classifies (a privacy fail-open,
   rf2-wdm1vg). An emptied axis slot is pruned by the core ops. Returns the new
@@ -143,8 +143,8 @@
             registry
             (let [absolute-paths (map #(absolute-snapshot-path actor-id %) paths)]
               (if add?
-                (elision/add-claims registry slot owner absolute-paths)
-                (elision/remove-claims registry slot owner absolute-paths))))))
+                (rf.elision/add-claims registry slot owner absolute-paths)
+                (rf.elision/remove-claims registry slot owner absolute-paths))))))
       (or registry {})
       {:sensitive :sensitive-declarations
        :large     :declarations})))
@@ -180,8 +180,8 @@
        (let [transform (fn [registry]
                          (apply-declarations registry actor-id declarations true))]
          (if owner-token
-           (elision/swap-elision-slot! frame-id owner-token transform)
-           (elision/swap-elision-slot! frame-id transform)))))
+           (rf.elision/swap-elision-slot! frame-id owner-token transform)
+           (rf.elision/swap-elision-slot! frame-id transform)))))
    nil))
 
 (defn drop-at-destroy!
@@ -206,6 +206,6 @@
        (let [transform (fn [registry]
                          (apply-declarations registry actor-id declarations false))]
          (if owner-token
-           (elision/swap-elision-slot! frame-id owner-token transform)
-           (elision/swap-elision-slot! frame-id transform)))))
+           (rf.elision/swap-elision-slot! frame-id owner-token transform)
+           (rf.elision/swap-elision-slot! frame-id transform)))))
    nil))

--- a/implementation/machines/src/re_frame/machines/cofx_attach.cljc
+++ b/implementation/machines/src/re_frame/machines/cofx_attach.cljc
@@ -76,7 +76,7 @@
   ## Pre-desugar surfaces (`:choice` / state-level `:after`)
 
   The index + ensure-set computation run on the RAW machine (before
-  `choice/desugar-choices` / `timeout/desugar-timeouts` lower the authoring
+  `rf.machines.choice/desugar-choices` / `timeout/desugar-timeouts` lower the authoring
   sugar at transition / birth time). So this ns settles the sugar the way the
   runtime does: a `:type :choice` transient node's `:choice` candidate vector
   is its `:always` candidate set (`always-entries`), and a state-level `:after`
@@ -89,16 +89,16 @@
   for machines)."
   (:require #?(:clj  [clojure.edn :as edn]
                :cljs [cljs.reader :as edn])
-            [re-frame.cofx :as cofx]
-            [re-frame.error :as error]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.machines.choice :as choice]
-            [re-frame.machines.grammar :as grammar]
-            [re-frame.registrar :as registrar]
-            [re-frame.subs :as subs]
-            [re-frame.trace :as trace
+            [re-frame.cofx :as rf.cofx]
+            [re-frame.error :as rf.error]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.machines.choice :as rf.machines.choice]
+            [re-frame.machines.grammar :as rf.machines.grammar]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.subs :as rf.subs]
+            [re-frame.trace :as rf.trace
              #?@(:cljs [:include-macros true])]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -149,7 +149,7 @@
   §Consumer attachment §Inline callbacks cannot declare requirements +
   Spec 009 §Error catalogue."
   [where detail]
-  (error/throw-error!
+  (rf.error/throw-error!
     :rf.error/machine-cofx-requires-inline
     'rf/reg-machine
     (str ":rf.cofx/requires may be declared ONLY on a NAMED "
@@ -215,7 +215,7 @@
       (not (entry-map? v))
       (requires-inline-error (str slot " " entry-id) {:offending v})
       :else
-      (cofx/parse-requires [slot entry-id] raw true))))
+      (rf.cofx/parse-requires [slot entry-id] raw true))))
 
 ;; ---- machine walkers (mirror validation's coverage) -----------------------
 ;;
@@ -225,7 +225,7 @@
 
 (defn- always-entries
   "Normalise a state-node's `:always` slot to a vector of entry maps through
-  the shared `grammar/candidate-maps`. Two
+  the shared `rf.machines.grammar/candidate-maps`. Two
   caller-specific policies stay HERE, not in the shared normaliser:
 
     1. the optional `:always` nil semantics — an absent `:always` (missing
@@ -239,7 +239,7 @@
 
   A `:type :choice` transient node carries its candidate vector under
   `:choice`, NOT `:always` — the choice lowers to `:always` only at
-  `choice/desugar-node-choice`, and the index + ensure-set run on the RAW
+  `rf.machines.choice/desugar-node-choice`, and the index + ensure-set run on the RAW
   pre-desugar machine. Since a choice state routes through the
   IDENTICAL `:always` cascade the runtime settles it into, treat a choice
   node's `:choice` vector as its `:always` candidates here; validation
@@ -247,10 +247,10 @@
   there is no ambiguity. This choice-node source selection likewise stays at
   the caller — the shared normaliser sees only the resolved slot value."
   [node]
-  (let [a (if (choice/choice-node? node) (:choice node) (:always node))]
+  (let [a (if (rf.machines.choice/choice-node? node) (:choice node) (:always node))]
     (if (nil? a)
       []
-      (or (grammar/candidate-maps a) []))))
+      (or (rf.machines.grammar/candidate-maps a) []))))
 
 (defn- walk-nodes-with-path
   "Yield `[absolute-path node]` pairs for every state node, recursing
@@ -284,7 +284,7 @@
           (let [where       (str "state " (if (seq path) (peek path) :rf/root))
                 ;; a choice node's candidates ride `:choice`; `always-entries`
                 ;; surfaces them, but label the site `:choice` not `:always`.
-                always-label (if (choice/choice-node? node) " :choice" " :always")]
+                always-label (if (rf.machines.choice/choice-node? node) " :choice" " :always")]
             (doseq [[_ev v] (:on node)]    (check-no-inline-requires! (str where " :on") v))
             (doseq [[_d v]  (:after node)] (check-no-inline-requires! (str where " :after") v))
             (doseq [e (always-entries node)] (check-no-inline-requires! (str where always-label) e))
@@ -328,19 +328,19 @@
 
 (defn- candidate-maps
   "Normalise a transition-slot value to its candidate maps (each carrying
-  `:guard` / `:action` / `:target`) via the shared `grammar/candidate-maps`,
+  `:guard` / `:action` / `:target`) via the shared `rf.machines.grammar/candidate-maps`,
   mapping the malformed form (grammar returns
   nil) to NO candidates: `validation` is the designated throw surface, so a
   malformed shape contributes nothing to the static ensure-set here."
   [v]
-  (or (grammar/candidate-maps v) []))
+  (or (rf.machines.grammar/candidate-maps v) []))
 
 (defn- node-at
   "Root→leaf descent into `machine`'s `:states` (or a region body's).
-  Thin wrapper over `grammar/node-at` so the closure walk resolves targets
+  Thin wrapper over `rf.machines.grammar/node-at` so the closure walk resolves targets
   against EXACTLY the tree the runtime drives."
   [states path]
-  (grammar/node-at states (vec path)))
+  (rf.machines.grammar/node-at states (vec path)))
 
 (defn- resolve-target-path
   "Resolve a candidate `:target` (declared at `decl-path`) to an absolute
@@ -876,7 +876,7 @@
   (if (empty? ensure-set)
     recorded
     (:rf.cofx
-     (cofx/deliver-declared-cofx {} ensure-set (or recorded {}) failing-id
+     (rf.cofx/deliver-declared-cofx {} ensure-set (or recorded {}) failing-id
                                  frame-id mint-policy))))
 
 (defn ensure-cofx
@@ -908,7 +908,7 @@
   A no-op (returns `recorded`) when the ensure-set is empty."
   ([machine snapshot event recorded frame-id failing-id]
    (ensure-cofx machine snapshot event recorded frame-id failing-id
-                cofx/default-mint-policy))
+                rf.cofx/default-mint-policy))
   ([machine snapshot event recorded frame-id failing-id mint-policy]
    (ensure-diet-onto (ensure-set-for machine snapshot event)
                      recorded frame-id failing-id mint-policy)))
@@ -923,7 +923,7 @@
   (returns `recorded`) when the bootstrap ensure-set is empty."
   ([machine recorded frame-id failing-id]
    (bootstrap-ensure-cofx machine recorded frame-id failing-id
-                          cofx/default-mint-policy))
+                          rf.cofx/default-mint-policy))
   ([machine recorded frame-id failing-id mint-policy]
    (ensure-diet-onto (bootstrap-ensure-set-for machine)
                      recorded frame-id failing-id mint-policy)))
@@ -977,7 +977,7 @@
 (defn- emit-consume-undeclared!
   "Emit `:rf.warning/machine-cofx-consume-undeclared` (dev-only diagnostic)."
   [machine-id slot entry-id leaf]
-  (trace/emit! :warning :rf.warning/machine-cofx-consume-undeclared
+  (rf.trace/emit! :warning :rf.warning/machine-cofx-consume-undeclared
                {:machine-id machine-id
                 :slot       slot
                 :entry-id   entry-id
@@ -987,7 +987,7 @@
 (defn- emit-ambient-durable!
   "Emit `:rf.warning/machine-cofx-ambient-durable` (dev-only diagnostic)."
   [machine-id slot entry-id cofx-id]
-  (trace/emit! :warning :rf.warning/machine-cofx-ambient-durable
+  (rf.trace/emit! :warning :rf.warning/machine-cofx-ambient-durable
                {:machine-id machine-id
                 :slot       slot
                 :entry-id   entry-id
@@ -997,14 +997,14 @@
 (defn lint-machine!
   "Run the dev-only consumer-attachment lints over `machine` (carrying the
   registration index), tagging diagnostics with `machine-id`. Per Spec 005
-  §Consumer attachment. A no-op under `interop/debug-enabled?
+  §Consumer attachment. A no-op under `rf.interop/debug-enabled?
   false` (production) and when the machine declares no requires.
 
   Recommendation-grade: emits `:rf.warning/*` diagnostics, never throws.
   Called from the registration home AFTER the index is built (so it can read
   the parsed diets and the entry source-forms)."
   [machine-id machine]
-  (when interop/debug-enabled?
+  (when rf.interop/debug-enabled?
     (let [{:keys [by-entry]} (get machine ensure-index-key)]
       (when (seq by-entry)
         (doseq [[[slot entry-id] parsed] by-entry]
@@ -1014,7 +1014,7 @@
             ;; (2) ambient-durable — an ACTION declaring an ambient-grade id.
             (when (= slot :actions)
               (doseq [{:keys [id]} parsed]
-                (let [meta (registrar/lookup :cofx id)]
+                (let [meta (rf.registrar/lookup :cofx id)]
                   (when (and meta (not (:recordable? meta)))
                     (emit-ambient-durable! machine-id slot entry-id id)))))
             ;; (1) consume-without-declaring — heuristic source scan. The
@@ -1037,7 +1037,7 @@
                 (doseq [t tokens
                         :when (and (qualified-keyword? t)
                                    (not (contains? declared t))
-                                   (some? (registrar/lookup :cofx t)))]
+                                   (some? (rf.registrar/lookup :cofx t)))]
                   (emit-consume-undeclared! machine-id slot entry-id t))))))))))
 
 ;; ---- sub-valued recordable source evaluator -------------------------------
@@ -1057,6 +1057,6 @@
 ;; back onto the token under `fact-id`; a same-macrostep `:raise` re-ensure
 ;; then finds it present and re-presents it (no re-evaluation).
 
-(late-bind/set-fn! :cofx/eval-recordable-sub
+(rf.late-bind/set-fn! :cofx/eval-recordable-sub
   (fn eval-recordable-sub [query-v frame-id]
-    (subs/compute-sub query-v (frame/frame-state-value frame-id))))
+    (rf.subs/compute-sub query-v (rf.frame/frame-state-value frame-id))))

--- a/implementation/machines/src/re_frame/machines/data_validation.cljc
+++ b/implementation/machines/src/re_frame/machines/data_validation.cljc
@@ -41,7 +41,7 @@
   goes ENTIRELY through the late-bound `:schemas/validate-with-registered-fn`
   hook: an app that registers a Malli (or any other) adapter validates; an
   app that registers none pays zero cost (the hot path short-circuits at
-  `(late-bind/get-fn-cached ...)` returning nil). The declaration grammar and
+  `(rf.late-bind/get-fn-cached ...)` returning nil). The declaration grammar and
   the optional validator adapter are therefore fully decoupled — machine core
   requires neither Malli nor JS Standard Schema.
 
@@ -54,17 +54,17 @@
   hooks (`:schemas/validate-with-registered-fn` /
   `:schemas/explain-with-registered-fn`) so an app that ships no
   schemas artefact pays zero validation cost — the hot path
-  short-circuits at `(late-bind/get-fn-cached ...)` returning nil.
+  short-circuits at `(rf.late-bind/get-fn-cached ...)` returning nil.
 
   Per Spec 009 §Production builds the hot-path body lives inside
-  `(when interop/debug-enabled? ...)` so `:advanced` +
+  `(when rf.interop/debug-enabled? ...)` so `:advanced` +
   `goog.DEBUG=false` DCE-elides every literal reason string,
   keyword, validator deref, and trace call."
-  (:require [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.machines.paths :as paths]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -104,8 +104,8 @@
   contract. Shared with `lifecycle-fx.spawn` so the spawn cascade and its
   `validate-spawn-data!` callback fence against the SAME token."
   [frame-id]
-  (if-let [owner-token (frame/current-event-owner-token)]
-    #(frame/event-continuation-live? frame-id owner-token)
+  (if-let [owner-token (rf.frame/current-event-owner-token)]
+    #(rf.frame/event-continuation-live? frame-id owner-token)
     (constantly true)))
 
 (defn- current-owner-continuation
@@ -115,9 +115,9 @@
   they run inside the owning event's fx drain / finalize cascade, so the
   dequeue-time event owner IS their frame."
   []
-  (if-let [owner-token (frame/current-event-owner-token)]
-    (let [owner-frame (frame/current-event-owner-frame-id)]
-      #(frame/event-continuation-live? owner-frame owner-token))
+  (if-let [owner-token (rf.frame/current-event-owner-token)]
+    (let [owner-frame (rf.frame/current-event-owner-frame-id)]
+      #(rf.frame/event-continuation-live? owner-frame owner-token))
     (constantly true)))
 
 (defn- emit-failure!
@@ -166,14 +166,14 @@
    (emit-failure! machine-id where phase value schema explanation rollback?
                   reason (constantly true)))
   ([machine-id where phase value schema explanation rollback? reason continue?]
-   (let [explain-fn (late-bind/get-fn-cached :schemas/explain-with-registered-fn)
+   (let [explain-fn (rf.late-bind/get-fn-cached :schemas/explain-with-registered-fn)
          explanation (or explanation
                          (when (and (continue?) explain-fn)
                            (try
                              (explain-fn schema value)
                              (catch #?(:clj Throwable :cljs :default) e
                                (if (continue?) (throw e) nil)))))
-         redact     (late-bind/get-fn-cached :schemas/redact-validation-tags)
+         redact     (rf.late-bind/get-fn-cached :schemas/redact-validation-tags)
          tags       {:where      where
                      :failing-id machine-id
                      :machine-id machine-id
@@ -192,7 +192,7 @@
                           (if (continue?) (throw e) nil)))
                       tags)]
      (when (continue?)
-       (trace/emit-error! :rf.error/schema-validation-failure tags)))))
+       (rf.trace/emit-error! :rf.error/schema-validation-failure tags)))))
 
 (defn validate-snapshot-data!
   "Validate a single machine snapshot's `:data` against the registered
@@ -215,7 +215,7 @@
   ([machine-id snapshot schema phase]
    (validate-snapshot-data! machine-id snapshot schema phase (constantly true)))
   ([machine-id snapshot schema phase continue?]
-   (if-let [validate-fn (late-bind/get-fn-cached
+   (if-let [validate-fn (rf.late-bind/get-fn-cached
                           :schemas/validate-with-registered-fn)]
      (let [data   (:data snapshot)
            result (try
@@ -259,7 +259,7 @@
   ([machine-id snapshot continue?]
    (let [meta-entry
          (when (continue?)
-           (some-> (when-let [meta-fn (late-bind/get-fn-cached :machines/machine-meta)]
+           (some-> (when-let [meta-fn (rf.late-bind/get-fn-cached :machines/machine-meta)]
                      (try
                        (meta-fn machine-id)
                        (catch #?(:clj Throwable :cljs :default) e
@@ -268,7 +268,7 @@
                    (find :data)))]
      (or meta-entry
          (when (continue?)
-           (some-> (when-let [spec-fn (late-bind/get-fn-cached :machines/spec-from-snapshot)]
+           (some-> (when-let [spec-fn (rf.late-bind/get-fn-cached :machines/spec-from-snapshot)]
                      (try
                        (spec-fn snapshot)
                        (catch #?(:clj Throwable :cljs :default) e
@@ -299,7 +299,7 @@
   pre-install (same mechanism as the `:where :app-db` rejection).
 
   Per Spec 009 §Production builds the body lives inside a
-  `(when interop/debug-enabled? ...)` gate so production builds
+  `(when rf.interop/debug-enabled? ...)` gate so production builds
   return `true` unconditionally."
   ([runtime-db event-id frame-id]
    (validate-machine-data! runtime-db event-id frame-id
@@ -309,7 +309,7 @@
   ;; (the per-snapshot emit already names the machine); the arity matches
   ;; `validate-app-schema!` so the late-bind hook the router consumes can
   ;; be invoked uniformly.
-  (if interop/debug-enabled?
+  (if rf.interop/debug-enabled?
     ;; Per the validate-app-schema! pattern: validate EVERY snapshot (no
     ;; short-circuit) so each failing machine surfaces its
     ;; own trace (consumers see the full set), AND-conjoining the per-
@@ -317,7 +317,7 @@
     ;; deterministically. A snapshot whose machine declares no `[:schemas
     ;; :data]` (or whose spec resolves to nil for both a singleton AND a
     ;; spawned actor) conforms vacuously.
-    (loop [entries (seq (get-in runtime-db (paths/snapshot-path)))
+    (loop [entries (seq (get-in runtime-db (rf.machines.paths/snapshot-path)))
            ok?     true]
       (cond
         (not (continue?)) :rf/stale-incarnation
@@ -360,13 +360,13 @@
   fences its post-callback cascade with so both agree on the token.
 
   Per Spec 009 §Production builds the body lives inside a
-  `(when interop/debug-enabled? ...)` gate so production builds
+  `(when rf.interop/debug-enabled? ...)` gate so production builds
   return `true` unconditionally — the install proceeds unvalidated
   under `:advanced` + `goog.DEBUG=false`."
   ([spawned-id spec snapshot]
    (validate-spawn-data! spawned-id spec snapshot (current-owner-continuation)))
   ([spawned-id spec snapshot continue?]
-   (if interop/debug-enabled?
+   (if rf.interop/debug-enabled?
      ;; KEY-presence, not value truthiness (rf2-6eh5h): a present nil /
      ;; false `[:schemas :data]` is a declaration whose exact token is
      ;; delegated to the registered validator; only an ABSENT key means
@@ -409,12 +409,12 @@
   suppressed too (the callback lost A), so no diagnostic is attributed to B.
 
   Per Spec 009 §Production builds the body lives inside a
-  `(when interop/debug-enabled? ...)` gate so production builds
+  `(when rf.interop/debug-enabled? ...)` gate so production builds
   return `true` unconditionally — the merge proceeds unvalidated under
   `:advanced` + `goog.DEBUG=false`, parity with the macrostep / spawn
   boundaries."
   [machine-id merged-snapshot]
-  (if interop/debug-enabled?
+  (if rf.interop/debug-enabled?
     (let [continue? (current-owner-continuation)]
       ;; Presence-carrying [:data schema] map entry (rf2-6eh5h): the entry
       ;; is truthy whenever the spec DECLARES [:schemas :data], so a
@@ -467,11 +467,11 @@
   suppressed.
 
   Per Spec 009 §Production builds the body lives inside a
-  `(when interop/debug-enabled? ...)` gate so production builds return `true`
+  `(when rf.interop/debug-enabled? ...)` gate so production builds return `true`
   unconditionally — the completion proceeds unvalidated under `:advanced` +
   `goog.DEBUG=false`, parity with the `:where :machine-data` boundaries."
   [machine-id spec result]
-  (if interop/debug-enabled?
+  (if rf.interop/debug-enabled?
     ;; KEY-presence, not value truthiness (rf2-6eh5h): a present nil /
     ;; false `[:schemas :output]` is a declaration whose exact token is
     ;; delegated to the registered validator (default Malli then throws
@@ -481,7 +481,7 @@
     (if-not (contains? (get spec :schemas) :output)
       true
       (let [schema (get-in spec [:schemas :output])]
-        (if-let [validate-fn (late-bind/get-fn-cached
+        (if-let [validate-fn (rf.late-bind/get-fn-cached
                                :schemas/validate-with-registered-fn)]
           ;; A MALFORMED `[:schemas :output]` schema (a bad Malli form) makes the
           ;; registered validator THROW at validate-time (Malli validates forms
@@ -514,7 +514,7 @@
                 ;; Owner still live → a genuine malformed-schema diagnostic.
                 ;; Owner lost (the callback threw AND destroyed A) → suppress it.
                 (if (continue?)
-                  (do (trace/emit-error! :rf.error/malformed-schema
+                  (do (rf.trace/emit-error! :rf.error/malformed-schema
                                          {:where    :machine-output
                                           :reason   (str "Machine " machine-id
                                                          "'s [:schemas :output] schema is malformed — "

--- a/implementation/machines/src/re_frame/machines/error_emit.cljc
+++ b/implementation/machines/src/re_frame/machines/error_emit.cljc
@@ -14,8 +14,8 @@
   `:recovery`, `:frame`, and the raw `:exception`. Value-bearing `:event`,
   `:input`, `:exception-data`, and free-text diagnostics belong only in the
   privacy-gated dev trace. Per Spec 009 §Error event catalogue."
-  (:require [re-frame.interop   :as interop]
-            [re-frame.late-bind :as late-bind]))
+  (:require [re-frame.interop   :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -31,8 +31,8 @@
   maps can be eliminated from production bundles."
   [always-on]
   ;; Late-bound because this optional artefact cannot require the core emitter.
-  (when-let [dispatch-record! (late-bind/get-fn :error-emit/dispatch-error-record)]
+  (when-let [dispatch-record! (rf.late-bind/get-fn :error-emit/dispatch-error-record)]
     (dispatch-record! (assoc always-on
                              :error :rf.error/machine-action-exception
-                             :time  (interop/now-ms))))
+                             :time  (rf.interop/now-ms))))
   nil)

--- a/implementation/machines/src/re_frame/machines/hydrate.cljc
+++ b/implementation/machines/src/re_frame/machines/hydrate.cljc
@@ -50,7 +50,7 @@
   Enumeration is ACTIVE-configuration-shaped, not whole-spec-shaped:
 
     - flat / compound — every node from the root down to the active leaf
-      (`transition/nodes-along-path`), because a still-active ANCESTOR's
+      (`rf.machines.transition/nodes-along-path`), because a still-active ANCESTOR's
       `:after` is as live as the leaf's;
     - parallel — the same walk inside each region's own active path,
       against the synthetic region-spec so the region's per-region epoch
@@ -83,7 +83,7 @@
 
   Epoch restore is the mirror image and stays that way: it CANCELS the
   frame's in-flight `:after` handles (`:machines/on-frame-restored!` →
-  `timer/cancel-frame-timers-on-restore!`, one
+  `rf.machines.timer/cancel-frame-timers-on-restore!`, one
   `:rf.machine.timer/cancelled :reason :on-restore` per entry) and never
   re-arms, because Managed-Effects §SSR, preload, hydration, and restore
   rules that restore MUST NOT revive host work. The asymmetry is real and
@@ -94,18 +94,18 @@
 
   Pure / host-agnostic CLJC apart from the one arming call — the walk is a
   pure function of `[spec snapshot]` and is tested as such."
-  (:require [re-frame.frame :as frame]
-            [re-frame.machines.lifecycle-fx.resolver :as resolver]
-            [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.paths :as paths]
-            [re-frame.machines.timeout :as timeout]
-            [re-frame.machines.timer :as timer]
-            [re-frame.machines.transition :as transition]))
+  (:require [re-frame.frame :as rf.frame]
+            [re-frame.machines.lifecycle-fx.resolver :as rf.machines.lifecycle-fx.resolver]
+            [re-frame.machines.parallel :as rf.machines.parallel]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.machines.timeout :as rf.machines.timeout]
+            [re-frame.machines.timer :as rf.machines.timer]
+            [re-frame.machines.transition :as rf.machines.transition]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
 (defn- walkable-state?
-  "True iff `state` is a shape `transition/state-path` can normalise — a
+  "True iff `state` is a shape `rf.machines.transition/state-path` can normalise — a
   leaf keyword or a vector path.
 
   A snapshot arriving from the wire is deserialised, untrusted data. Per
@@ -130,7 +130,7 @@
   `prefix-fn` maps the in-scope decl-path to the invoke-id the timer table
   is keyed by: identity-ish (`vec`) for a flat/compound machine, and the
   region-name prepend for a region — the same shape
-  `parallel/prefix-region-invoke-id` stamps on the region's own
+  `rf.machines.parallel/prefix-region-invoke-id` stamps on the region's own
   `:rf.machine/after-schedule` fxs, so a hydrated timer lands in the slot
   a subsequent state exit will cancel.
 
@@ -141,14 +141,14 @@
   (into []
         (mapcat (fn [[decl-path node]]
                   (when-let [after-map (:after node)]
-                    (let [epoch (transition/node-epoch machine snapshot decl-path)]
+                    (let [epoch (rf.machines.transition/node-epoch machine snapshot decl-path)]
                       (map (fn [[delay-key _target]]
                              {:invoke-id (prefix-fn decl-path)
                               :state     (last decl-path)
                               :delay-key delay-key
                               :epoch     epoch})
                            after-map)))))
-        (transition/nodes-along-path machine path)))
+        (rf.machines.transition/nodes-along-path machine path)))
 
 (defn- root-parallel-decls
   "The ROOT-owned `:after` declarations of a parallel machine (Spec 005
@@ -159,7 +159,7 @@
   what `root-after-match` expects when the timer fires."
   [spec snapshot]
   (if-let [after-map (:after spec)]
-    (let [epoch (transition/node-epoch spec snapshot [])]
+    (let [epoch (rf.machines.transition/node-epoch spec snapshot [])]
       (mapv (fn [[delay-key _target]]
               {:invoke-id []
                :state     :rf/parallel-root
@@ -173,7 +173,7 @@
   live under `spec`, as
   `[{:invoke-id … :state … :delay-key … :epoch …} …]`.
 
-  `spec` is desugared first (`timeout/desugar-timeouts` — idempotent, and
+  `spec` is desugared first (`rf.machines.timeout/desugar-timeouts` — idempotent, and
   a no-rebuild fast path for the timeout-free common case) so an authored
   `:timeout` / `:on-timeout` is enumerated through the `:after` it lowers
   onto, exactly as the transition engine sees it.
@@ -183,10 +183,10 @@
   correctness point of enumerating the ACTIVE configuration rather than
   the spec."
   [spec snapshot]
-  (let [spec (timeout/desugar-timeouts spec)
+  (let [spec (rf.machines.timeout/desugar-timeouts spec)
         st   (:state snapshot)]
     (cond
-      (parallel/parallel? spec)
+      (rf.machines.parallel/parallel? spec)
       ;; A parallel snapshot's `:state` is a region-name → region-state
       ;; map. Walk each region's own active path against the synthetic
       ;; region-spec (which carries `:rf/region`, so `node-epoch` reads the
@@ -195,14 +195,14 @@
             (mapcat (fn [[region-name region-state]]
                       (when (and (contains? (:regions spec) region-name)
                                  (walkable-state? region-state))
-                        (decls-along-path (parallel/region-machine spec region-name)
+                        (decls-along-path (rf.machines.parallel/region-machine spec region-name)
                                           snapshot
-                                          (transition/state-path region-state)
+                                          (rf.machines.transition/state-path region-state)
                                           #(vec (cons region-name %))))))
             (when (map? st) st))
 
       (walkable-state? st)
-      (decls-along-path spec snapshot (transition/state-path st) vec)
+      (decls-along-path spec snapshot (rf.machines.transition/state-path st) vec)
 
       :else [])))
 
@@ -223,7 +223,7 @@
   [snapshots]
   (vec (for [[actor-id snapshot] snapshots
              :when (map? snapshot)
-             :let  [spec (resolver/spec-from-id-or-snapshot actor-id snapshot)]
+             :let  [spec (rf.machines.lifecycle-fx.resolver/spec-from-id-or-snapshot actor-id snapshot)]
              :when (map? spec)
              decl  (active-after-decls spec snapshot)]
          (assoc decl :actor-id actor-id :snapshot snapshot))))
@@ -245,7 +245,7 @@
   Superseding cannot reach them (`schedule-after-timer!` only ever touches
   the one key it is arming), so the two phases are explicit:
 
-    1. CANCEL — `timer/cancel-timers-absent-from!` takes the set
+    1. CANCEL — `rf.machines.timer/cancel-timers-absent-from!` takes the set
        difference and releases every entry outside the live set, each with
        the ordinary closed-set `:reason` naming why it went
        (`:on-destroy` for a dropped actor, `:on-exit` for a declaring node
@@ -307,17 +307,17 @@
   `:rf.machine.timer/cancelled` trace per released one."
   [frame-id]
   (when (and frame-id
-             (not= :server (or (:platform (frame/frame-meta frame-id)) :client)))
+             (not= :server (or (:platform (rf.frame/frame-meta frame-id)) :client)))
     ;; Captured BEFORE anything callback-bearing runs, so it names the
     ;; incarnation whose runtime-db the declarations below are read from.
-    (let [owner-gone? (timer/successor-published?-fn frame-id)
-          snapshots   (get-in (frame/frame-runtime-db-value frame-id)
-                              (paths/snapshot-path))
+    (let [owner-gone? (rf.machines.timer/successor-published?-fn frame-id)
+          snapshots   (get-in (rf.frame/frame-runtime-db-value frame-id)
+                              (rf.machines.paths/snapshot-path))
           live        (live-declarations snapshots)]
       ;; PHASE 1 — release the host work the replacement snapshots dropped.
       ;; Before the arm, so a declaration that survives is superseded by its
       ;; own re-arm rather than cancelled and re-created.
-      (timer/cancel-timers-absent-from!
+      (rf.machines.timer/cancel-timers-absent-from!
         frame-id
         (into #{} (map (juxt :actor-id :invoke-id :delay-key)) live)
         (set (keys snapshots))
@@ -327,7 +327,7 @@
       (loop [decls live]
         (when (and (seq decls) (not (owner-gone?)))
           (let [decl (first decls)]
-            (timer/rearm-hydrated-after-timer!
+            (rf.machines.timer/rearm-hydrated-after-timer!
               frame-id (:actor-id decl) (:invoke-id decl) (:state decl)
               (:delay-key decl) (:epoch decl) (:snapshot decl) owner-gone?))
           (recur (rest decls))))))

--- a/implementation/machines/src/re_frame/machines/internal_events.cljc
+++ b/implementation/machines/src/re_frame/machines/internal_events.cljc
@@ -74,7 +74,7 @@
   can both require it without a load cycle — the sibling of
   `re-frame.machines.choice` / `re-frame.machines.timeout`."
   (:require [clojure.string :as str]
-            [re-frame.error :as error]))
+            [re-frame.error :as rf.error]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -118,7 +118,7 @@
   discriminator; `reason` is the human diagnostic; `extra` merges per-site
   slots."
   [error-id reason extra]
-  (error/thrown-ex-info error-id 'rf/reg-machine reason
+  (rf.error/thrown-ex-info error-id 'rf/reg-machine reason
                         {:recovery :fix-registration :extra extra}))
 
 (defn- reserved-rf-event?

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -57,19 +57,19 @@
   The actor-teardown runtime-db dance lives in
   `re-frame.machines.lifecycle-fx.teardown` — one helper, three
   call-sites."
-  (:require [re-frame.frame :as frame]
-            [re-frame.machines.classification :as classification]
-            [re-frame.machines.data-validation :as data-validation]
-            [re-frame.machines.lifecycle-fx.exit-cascade :as exit-cascade]
-            [re-frame.machines.lifecycle-fx.finalize :as finalize]
-            [re-frame.machines.lifecycle-fx.resolver :as resolver]
-            [re-frame.machines.lifecycle-fx.resource-release :as resource-release]
-            [re-frame.machines.lifecycle-fx.teardown :as teardown]
-            [re-frame.machines.lifecycle-fx.traces :as traces]
-            [re-frame.machines.paths :as paths]
-            [re-frame.machines.spawn-order :as spawn-order]
-            [re-frame.machines.timer :as timer]
-            [re-frame.registrar :as registrar]))
+  (:require [re-frame.frame :as rf.frame]
+            [re-frame.machines.classification :as rf.machines.classification]
+            [re-frame.machines.data-validation :as rf.machines.data-validation]
+            [re-frame.machines.lifecycle-fx.exit-cascade :as rf.machines.lifecycle-fx.exit-cascade]
+            [re-frame.machines.lifecycle-fx.finalize :as rf.machines.lifecycle-fx.finalize]
+            [re-frame.machines.lifecycle-fx.resolver :as rf.machines.lifecycle-fx.resolver]
+            [re-frame.machines.lifecycle-fx.resource-release :as rf.machines.lifecycle-fx.resource-release]
+            [re-frame.machines.lifecycle-fx.teardown :as rf.machines.lifecycle-fx.teardown]
+            [re-frame.machines.lifecycle-fx.traces :as rf.machines.lifecycle-fx.traces]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.machines.spawn-order :as rf.machines.spawn-order]
+            [re-frame.machines.timer :as rf.machines.timer]
+            [re-frame.registrar :as rf.registrar]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -102,22 +102,22 @@
 (defn- effect-fence
   "Capture the exact event-owner continuation + raw token at the
   `:rf.machine/destroy` EFFECT entry. `owner-gone?` is true once a synchronous
-  callback has destroyed A / published same-id B (`data-validation/owner-
+  callback has destroyed A / published same-id B (`rf.machines.data-validation/owner-
   continuation` yields `(constantly true)` when no event owner is bound, so
   `owner-gone?` is then always false — an eventless caller gets full authority);
   `owner-token` is A's raw token (nil with no owner), threaded into the durable
   writes so they bind to A's own container."
   [frame-id]
-  (let [continue? (data-validation/owner-continuation frame-id)]
+  (let [continue? (rf.machines.data-validation/owner-continuation frame-id)]
     {:owner-gone? (fn [] (not (continue?)))
-     :owner-token (frame/current-event-owner-token)}))
+     :owner-token (rf.frame/current-event-owner-token)}))
 
 (defn- snapshot-present?
   "True iff `runtime-db` carries a machine snapshot at `actor-id`. A nil
   `runtime-db` (unknown / destroyed frame) carries nothing."
   [runtime-db actor-id]
   (and (some? runtime-db)
-       (contains? (get-in runtime-db (paths/snapshot-path)) actor-id)))
+       (contains? (get-in runtime-db (rf.machines.paths/snapshot-path)) actor-id)))
 
 (defn- actor-live?
   "The silent-idempotent liveness probe, shared by the
@@ -149,7 +149,7 @@
   reported such an actor live and ran a full teardown — trace, `:exit`
   cascade and all — for something no longer in the frame, in violation of
   Spec 005 §Destroy is silent-idempotent. Re-reading the LIVE runtime-db
-  covers the stale-`old-db` window exactly (`spawn-order/record!` runs
+  covers the stale-`old-db` window exactly (`rf.machines.spawn-order/record!` runs
   only after `install-spawn!` commits, so a cached id whose actor is live
   always has a live snapshot) while giving durable state the last word.
 
@@ -164,10 +164,10 @@
   ownership bookkeeping, never a liveness signal."
   [frame-id actor-id runtime-db]
   (and actor-id
-       (or (some? (registrar/lookup :event actor-id))
+       (or (some? (rf.registrar/lookup :event actor-id))
            (snapshot-present? runtime-db actor-id)
-           (and (some #(= actor-id %) (spawn-order/frame-order frame-id))
-                (snapshot-present? (frame/frame-runtime-db-value frame-id) actor-id)))))
+           (and (some #(= actor-id %) (rf.machines.spawn-order/frame-order frame-id))
+                (snapshot-present? (rf.frame/frame-runtime-db-value frame-id) actor-id)))))
 
 (defn- teardown-live-actor!
   "The shared ordered teardown pipeline for a LIVE actor (the caller has
@@ -188,7 +188,7 @@
        per-instance marks table, so there is no marks-table residue to drop;
     4. cancel armed `:after` timers, one
        `:rf.machine.timer/cancelled :reason :on-destroy` trace per timer;
-    5. apply the unified teardown projection (`teardown/teardown-actor`),
+    5. apply the unified teardown projection (`rf.machines.lifecycle-fx.teardown/teardown-actor`),
        capturing the released `:system-id` via a side channel so we keep a
        single runtime-db read + single write (machine snapshots are durable
        runtime-db state). `teardown-args` selects the slots the
@@ -227,14 +227,14 @@
   ;; (1) run the active configuration's `:exit` cascade — its `:exit` actions
   ;; are authored callbacks that may destroy A. An already-entered callback
   ;; stands; recheck before every subsequent framework action.
-  (exit-cascade/run-child-exit! frame-id actor-id)
+  (rf.machines.lifecycle-fx.exit-cascade/run-child-exit! frame-id actor-id)
   ;; (2) abort in-flight HTTP — the late-bound `:http/abort-on-actor-destroy`
   ;; hook is callback-bearing.
   (when-not (owner-gone?)
-    (finalize/abort-actor-in-flight-http! actor-id))
+    (rf.machines.lifecycle-fx.finalize/abort-actor-in-flight-http! actor-id))
   ;; (3) Drop this actor's
   ;; per-instance classification declarations from the per-frame elision
-  ;; registry — the teardown half of `classification/lower-at-spawn!`. A
+  ;; registry — the teardown half of `rf.machines.classification/lower-at-spawn!`. A
   ;; subsystem instance's classification lives and dies with the instance,
   ;; so the absolute snapshot-rooted `:sensitive` / `:large` decls the spawn
   ;; lowered are dissoc'd here (no leak — an emptied axis slot is pruned).
@@ -245,15 +245,15 @@
   ;; HTTP-abort callback and route the drop through the EXACT elision write so a
   ;; mid-write watch cannot re-root the removal onto same-id B.
   (when-not (owner-gone?)
-    (let [snapshot (get-in (frame/frame-runtime-db-value frame-id)
-                           (paths/snapshot-path actor-id))]
-      (when-let [spec (resolver/spec-from-id-or-snapshot actor-id snapshot)]
-        (classification/drop-at-destroy! frame-id actor-id spec owner-token))))
+    (let [snapshot (get-in (rf.frame/frame-runtime-db-value frame-id)
+                           (rf.machines.paths/snapshot-path actor-id))]
+      (when-let [spec (rf.machines.lifecycle-fx.resolver/spec-from-id-or-snapshot actor-id snapshot)]
+        (rf.machines.classification/drop-at-destroy! frame-id actor-id spec owner-token))))
   ;; (4) cancel armed `:after` timers — the 3-arity threads `owner-gone?` so the
   ;; cancellation loop short-circuits on A→B loss AND each entry's within-cancel
   ;; subscription release is skipped once A is gone (rf2-4ipqe4 + rf2-i4aj9c).
   (when-not (owner-gone?)
-    (timer/cancel-actor-timers! frame-id actor-id owner-gone?))
+    (rf.machines.timer/cancel-actor-timers! frame-id actor-id owner-gone?))
   ;; (5) apply the unified teardown projection through the EXACT durable write:
   ;; `teardown-actor` returns [new-runtime-db released-sid], captured via a
   ;; volatile side channel. `swap-runtime-db-exact!` binds the write to A's own
@@ -266,12 +266,12 @@
     (let [sid         (volatile! nil)
           swap-fn     (fn [runtime-db]
                         (let [[new-rt released-sid]
-                              (teardown/teardown-actor runtime-db teardown-args)]
+                              (rf.machines.lifecycle-fx.teardown/teardown-actor runtime-db teardown-args)]
                           (vreset! sid released-sid)
                           new-rt))
           new-rt      (if owner-token
-                        (frame/swap-runtime-db-exact! frame-id owner-token swap-fn)
-                        (frame/swap-runtime-db! frame-id swap-fn))
+                        (rf.frame/swap-runtime-db-exact! frame-id owner-token swap-fn)
+                        (rf.frame/swap-runtime-db! frame-id swap-fn))
           db-swapped? (some? new-rt)]
       ;; (6) emit `:rf.machine/destroyed` (callback-bearing) — only while the
       ;; exact owner survives (a mid-write watch that lost A flips `owner-gone?`).
@@ -281,30 +281,30 @@
       ;; after the destroyed trace so a listener that published same-id B cannot
       ;; have A's forget erase B's own freshly-recorded spawn-order entry.
       (when-not (owner-gone?)
-        (spawn-order/forget! frame-id actor-id))
+        (rf.machines.spawn-order/forget! frame-id actor-id))
       ;; (8) when the projection landed, emit `:rf.machine/system-id-released`
       ;; (callback-bearing) and clear any registrar entry (`:rf.registry/handler-
       ;; cleared`, callback-bearing). rf2-rbxdxa — the system-id-released trace is
       ;; ITSELF a callback boundary: a listener can destroy A and publish same-id
       ;; B, registering B's fresh event handler at `actor-id` ON THAT TRACE's own
-      ;; stack. The trace + `registrar/unregister!` must NOT share one precheck —
+      ;; stack. The trace + `rf.registrar/unregister!` must NOT share one precheck —
       ;; recheck ownership AFTER the trace, so A's teardown never clears B's
       ;; just-registered handler (the ordinary-destroy terminal-fence law, Spec
       ;; 005 §Destroy is silent-idempotent).
       (when (and db-swapped? (not (owner-gone?)))
-        (traces/emit-system-id-released! frame-id @sid actor-id)
+        (rf.machines.lifecycle-fx.traces/emit-system-id-released! frame-id @sid actor-id)
         (when-not (owner-gone?)
-          (registrar/unregister! :event actor-id)))
+          (rf.registrar/unregister! :event actor-id)))
       ;; (9) release the actor's resource owners once it is gone, so
       ;; a `[:machine actor-id]`-owned resource does not outlive the actor and
       ;; keep refetching/polling. Rechecked after the unregister callback: a lost
       ;; owner must not fire `:rf.resource/release-owner` against B's live owners.
       ;; Guarded on resources being loaded (machines never depends on resources).
       ;; The `:final?`-state auto-destroy path (`finalize-machine`) does NOT route
-      ;; through here; it appends the symmetric `resource-release/release-fx-entry`
+      ;; through here; it appends the symmetric `rf.machines.lifecycle-fx.resource-release/release-fx-entry`
       ;; to its returned `:fx` instead — together they cover every destroy cause.
       (when-not (owner-gone?)
-        (resource-release/release-actor-resource-owners! frame-id actor-id))
+        (rf.machines.lifecycle-fx.resource-release/release-actor-resource-owners! frame-id actor-id))
       db-swapped?)))
 
 (defn destroy-single-actor!
@@ -345,7 +345,7 @@
   `:spawn-all` children iteration (which runs inside `destroy-machine-fx`)."
   ([frame-id actor-id] (destroy-single-actor! frame-id actor-id eventless-fence))
   ([frame-id actor-id fence]
-   (when (actor-live? frame-id actor-id (frame/frame-runtime-db-value frame-id))
+   (when (actor-live? frame-id actor-id (rf.frame/frame-runtime-db-value frame-id))
      ;; This site does NOT emit `:rf.machine/destroyed` — its callers
      ;; (`destroy-spawn-all-children!`, the frame-destroy walker) own that
      ;; emit, gating it on this fn's truthy return so each actor's destroyed
@@ -370,14 +370,14 @@
   that this exact attempt already published its terminal reply."
   [runtime-db actor-id]
   (let [join-child (get-in runtime-db
-                           (conj (paths/snapshot-path actor-id)
+                           (conj (rf.machines.paths/snapshot-path actor-id)
                                  :data :rf/join-child))
         parent-id  (:parent-id join-child)
         invoke-id  (:invoke-id join-child)
         child-id   (:child-id join-child)
         join-state (when (and (keyword? parent-id) (vector? invoke-id))
                      (get-in runtime-db
-                             (paths/spawned-path parent-id invoke-id)))]
+                             (rf.machines.paths/spawned-path parent-id invoke-id)))]
     (when (and (map? join-child)
                (map? join-state)
                (some? child-id)
@@ -410,7 +410,7 @@
   [frame-id actor-id requested-reason
    {:keys [owner-gone? owner-token]}]
   (when-not (owner-gone?)
-    (let [runtime-db     (frame/frame-runtime-db-value frame-id)
+    (let [runtime-db     (rf.frame/frame-runtime-db-value frame-id)
           current        (authenticated-join-child runtime-db actor-id)
           classification (if current
                            (assoc current
@@ -437,7 +437,7 @@
                              (if (= :explicit reason)
                                (update-in
                                  latest-db
-                                 (conj (paths/spawned-path
+                                 (conj (rf.machines.paths/spawned-path
                                          (:parent-id latest)
                                          (:invoke-id latest))
                                        :cancelled)
@@ -448,9 +448,9 @@
                              (vreset! prepared {:reason requested-reason})
                              latest-db)))
               written  (if owner-token
-                         (frame/swap-runtime-db-exact!
+                         (rf.frame/swap-runtime-db-exact!
                            frame-id owner-token mark-fn)
-                         (frame/swap-runtime-db! frame-id mark-fn))]
+                         (rf.frame/swap-runtime-db! frame-id mark-fn))]
           (when (some? written)
             @prepared))))))
 
@@ -471,10 +471,10 @@
   teardown, so the form fails loud (`:cause :slot-shape-mismatch`) and
   mutates nothing."
   [frame-id parent-id invoke-id args fence]
-  (let [join-state (get-in (frame/frame-runtime-db-value frame-id)
-                           (paths/spawned-path parent-id invoke-id))]
+  (let [join-state (get-in (rf.frame/frame-runtime-db-value frame-id)
+                           (rf.machines.paths/spawned-path parent-id invoke-id))]
     (if-not (or (nil? join-state) (map? join-state))
-      (traces/emit-destroy-bad-arg! frame-id :slot-shape-mismatch args)
+      (rf.machines.lifecycle-fx.traces/emit-destroy-bad-arg! frame-id :slot-shape-mismatch args)
       (destroy-spawn-all-children!* frame-id parent-id invoke-id join-state fence))))
 
 (defn- destroy-spawn-all-children!*
@@ -514,7 +514,7 @@
                  (prepare-join-child-teardown!
                    frame-id spawned-id :explicit fence)]
         (when (destroy-single-actor! frame-id spawned-id fence)
-          (traces/emit-destroyed!
+          (rf.machines.lifecycle-fx.traces/emit-destroyed!
             {:frame           frame-id
              :actor-id        spawned-id
              :parent-id       parent-id
@@ -528,12 +528,12 @@
     ;; this A-derived clear vacate B's freshly-seeded join slot.
     (when-not (owner-gone?)
       (let [clear-fn (fn [runtime-db]
-                       (first (teardown/teardown-actor
+                       (first (rf.machines.lifecycle-fx.teardown/teardown-actor
                                 runtime-db {:parent-id parent-id
                                             :invoke-id invoke-id})))]
         (if owner-token
-          (frame/swap-runtime-db-exact! frame-id owner-token clear-fn)
-          (frame/swap-runtime-db! frame-id clear-fn))))
+          (rf.frame/swap-runtime-db-exact! frame-id owner-token clear-fn)
+          (rf.frame/swap-runtime-db! frame-id clear-fn))))
     nil))
 
 (defn- destroy-resolved!
@@ -559,7 +559,7 @@
   lifecycle teardown, never a liveness signal).
 
   A truly-already-destroyed actor has ALL the probe's signals gone — the
-  unified teardown projection, registrar cleanup, and `spawn-order/forget!`
+  unified teardown projection, registrar cleanup, and `rf.machines.spawn-order/forget!`
   run atomically per `destroy-single-actor!` and `finalize-machine`.
   See Spec 005 §Destroy is silent-idempotent for the normative paragraph.
 
@@ -599,7 +599,7 @@
         ;; binding the teardown projection released — resolved from the reverse
         ;; index BEFORE the dissoc, symmetric with `finalize-machine`.
         (fn [released-sid]
-          (traces/emit-destroyed!
+          (rf.machines.lifecycle-fx.traces/emit-destroyed!
             (cond-> {:frame             frame-id
                      :actor-id          actor-id
                      :system-id         released-sid
@@ -663,7 +663,7 @@
   (let [parent-id  (:rf/parent-id args)
         invoke-id  (:rf/invoke-id args)
         child-id   (:rf/child-id args)
-        join-state (when old-db (get-in old-db (paths/spawned-path parent-id invoke-id)))
+        join-state (when old-db (get-in old-db (rf.machines.paths/spawned-path parent-id invoke-id)))
         children   (when (map? join-state) (:children join-state))
         actor-id   (get children child-id)
         completed? (and (some? actor-id)
@@ -673,7 +673,7 @@
       ;; The join state cannot substantiate the claim at all — no live join,
       ;; foreign child-id, or an in-progress (never-completed) child.
       (not completed?)
-      (traces/emit-destroy-bad-arg! frame-id :unverified-reap args)
+      (rf.machines.lifecycle-fx.traces/emit-destroy-bad-arg! frame-id :unverified-reap args)
 
       ;; Substantiated terminal, but the join attempt has NOT resolved
       ;; (rf2-nvxehu): a non-decisive completed child of a still-waiting
@@ -683,7 +683,7 @@
       ;; against the post-resolution join state — the `:rf.db/runtime` write
       ;; commits before the `:fx` drain — so genuine reaps see `true` here.)
       (not (true? (:resolved? join-state)))
-      (traces/emit-destroy-bad-arg! frame-id :unresolved-join args)
+      (rf.machines.lifecycle-fx.traces/emit-destroy-bad-arg! frame-id :unresolved-join args)
 
       :else
       ;; Tear down ONLY the child actor — pass NIL parent/invoke so
@@ -745,7 +745,7 @@
   runtime-db instead) has no stamps to contradict the slot, so it counts as owned —
   the tracked destroy retains its pre-existing behaviour there."
   [runtime-db actor-id parent-id invoke-id]
-  (let [snap (when runtime-db (get-in runtime-db (paths/snapshot-path actor-id)))]
+  (let [snap (when runtime-db (get-in runtime-db (rf.machines.paths/snapshot-path actor-id)))]
     (if (map? snap)
       (let [d (:data snap)]
         (and (= parent-id (:rf/parent-id d))
@@ -757,7 +757,7 @@
   (rf2-s2bsmw): clear the `[:spawned parent-id invoke-id]` slot and the
   parent snapshot's mirroring `[:data :rf/spawned <invoke-id>]` entry via
   the unified projection (slot-only: nil actor-id), WITHOUT re-running exit
-  handlers, child cascades, timer/resource cleanup, terminal replies, or a
+  handlers, child cascades, rf.machines.timer/resource cleanup, terminal replies, or a
   `:rf.machine/destroyed` trace — the actor the slot names is either
   already dead for this incarnation (its own destroy ran the full pipeline
   once) or a live replacement this slot does not own.
@@ -768,12 +768,12 @@
   token (eventless caller) falls back to the historical bare write."
   [frame-id parent-id invoke-id owner-token]
   (let [prune-fn (fn [runtime-db]
-                   (first (teardown/teardown-actor
+                   (first (rf.machines.lifecycle-fx.teardown/teardown-actor
                             runtime-db {:parent-id parent-id
                                         :invoke-id invoke-id})))]
     (if owner-token
-      (frame/swap-runtime-db-exact! frame-id owner-token prune-fn)
-      (frame/swap-runtime-db! frame-id prune-fn)))
+      (rf.frame/swap-runtime-db-exact! frame-id owner-token prune-fn)
+      (rf.frame/swap-runtime-db! frame-id prune-fn)))
   nil)
 
 (defn- destroy-tracked!
@@ -805,13 +805,13 @@
   [frame-id args old-db {:keys [owner-token] :as fence}]
   (let [parent-id (:rf/parent-id args)
         invoke-id (:rf/invoke-id args)
-        slot-id   (when old-db (get-in old-db (paths/spawned-path parent-id invoke-id)))]
+        slot-id   (when old-db (get-in old-db (rf.machines.paths/spawned-path parent-id invoke-id)))]
     (cond
       (nil? slot-id)
       nil
 
       (not (keyword? slot-id))
-      (traces/emit-destroy-bad-arg! frame-id :slot-shape-mismatch args)
+      (rf.machines.lifecycle-fx.traces/emit-destroy-bad-arg! frame-id :slot-shape-mismatch args)
 
       (and (actor-live? frame-id slot-id old-db)
            (slot-owned-incarnation? old-db slot-id parent-id invoke-id))
@@ -841,11 +841,11 @@
   (let [;; EP-0002 carried invariant — the cascade envelope frame is the
         ;; fx-context `:frame`; a nil stamp is an invariant failure
         ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
-        frame-id (frame/require-frame-stamp!
+        frame-id (rf.frame/require-frame-stamp!
                    frame-id :rf.machine/destroy
                    {:where 'rf.machine/destroy
                     :event-id (when (map? args) (:rf/parent-id args))})
-        old-db   (frame/frame-runtime-db-value frame-id)
+        old-db   (rf.frame/frame-runtime-db-value frame-id)
         ;; rf2-i4aj9c — capture the exact event-owner continuation + raw token
         ;; ONCE at the destroy EFFECT entry. The `:rf.machine/destroy` fx runs
         ;; inside the destroying event's drain, so this names the incarnation A
@@ -869,7 +869,7 @@
                    (join-coordinates-ok? args)
                    (keyword? (:rf/child-id args)))
             (destroy-join-reap! frame-id args old-db fence)
-            (traces/emit-destroy-bad-arg! frame-id :unknown-shape args))
+            (rf.machines.lifecycle-fx.traces/emit-destroy-bad-arg! frame-id :unknown-shape args))
 
           (contains? args :rf/spawn-all)
           (if (and (= shape spawn-all-form-keys)
@@ -880,15 +880,15 @@
                                          (:rf/invoke-id args)
                                          args
                                          fence)
-            (traces/emit-destroy-bad-arg! frame-id :unknown-shape args))
+            (rf.machines.lifecycle-fx.traces/emit-destroy-bad-arg! frame-id :unknown-shape args))
 
           (= shape tracked-form-keys)
           (if (join-coordinates-ok? args)
             (destroy-tracked! frame-id args old-db fence)
-            (traces/emit-destroy-bad-arg! frame-id :unknown-shape args))
+            (rf.machines.lifecycle-fx.traces/emit-destroy-bad-arg! frame-id :unknown-shape args))
 
           :else
-          (traces/emit-destroy-bad-arg! frame-id :unknown-shape args)))
+          (rf.machines.lifecycle-fx.traces/emit-destroy-bad-arg! frame-id :unknown-shape args)))
 
       :else
-      (traces/emit-destroy-bad-arg! frame-id :unknown-shape args))))
+      (rf.machines.lifecycle-fx.traces/emit-destroy-bad-arg! frame-id :unknown-shape args))))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/exit_cascade.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/exit_cascade.cljc
@@ -40,13 +40,13 @@
   Idempotent / safe to call when the actor has no live snapshot or no
   registered machine spec — both reduce to a benign no-op (the destroy
   proceeds as before)."
-  (:require [re-frame.fx :as fx]
-            [re-frame.frame :as frame]
-            [re-frame.machines.lifecycle-fx.resolver :as resolver]
-            [re-frame.machines.lifecycle-fx.traces :as traces]
-            [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.paths :as paths]
-            [re-frame.machines.result :as result]))
+  (:require [re-frame.fx :as rf.fx]
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines.lifecycle-fx.resolver :as rf.machines.lifecycle-fx.resolver]
+            [re-frame.machines.lifecycle-fx.traces :as rf.machines.lifecycle-fx.traces]
+            [re-frame.machines.parallel :as rf.machines.parallel]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.machines.result :as rf.machines.result]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -59,7 +59,7 @@
   nil when neither resolves — the actor was already torn down, or the
   destroy targets a non-machine event id."
   [actor-id snapshot]
-  (resolver/spec-from-id-or-snapshot actor-id snapshot))
+  (rf.machines.lifecycle-fx.resolver/spec-from-id-or-snapshot actor-id snapshot))
 
 (defn run-child-exit!
   "Run the destroy-time `:exit` cascade for the actor identified by
@@ -80,19 +80,19 @@
   final snapshot before clearing."
   [frame-id actor-id]
   (when actor-id
-    (let [runtime-db (frame/frame-runtime-db-value frame-id)
-          snapshot   (when runtime-db (get-in runtime-db (paths/snapshot-path actor-id)))
+    (let [runtime-db (rf.frame/frame-runtime-db-value frame-id)
+          snapshot   (when runtime-db (get-in runtime-db (rf.machines.paths/snapshot-path actor-id)))
           machine    (resolve-machine-spec actor-id snapshot)]
       (when (and snapshot machine)
-        (let [r (parallel/run-active-exit-cascade machine snapshot)]
-          (if (result/fail? r)
+        (let [r (rf.machines.parallel/run-active-exit-cascade machine snapshot)]
+          (if (rf.machines.result/fail? r)
             ;; Match `apply-transition-once`'s exit-cascade failure
             ;; trace shape — same category, with a destroy-time
             ;; discriminator so consumers can disambiguate. Shared with
             ;; `finalize-machine`'s final-state auto-destroy via
-            ;; `traces/emit-destroy-exit-failure!`.
-            (traces/emit-destroy-exit-failure! actor-id frame-id (result/info r))
-            (result/with-ok [new-snap exit-fx] r
+            ;; `rf.machines.lifecycle-fx.traces/emit-destroy-exit-failure!`.
+            (rf.machines.lifecycle-fx.traces/emit-destroy-exit-failure! actor-id frame-id (rf.machines.result/info r))
+            (rf.machines.result/with-ok [new-snap exit-fx] r
               ;; (4) Write the post-exit snapshot back to runtime-db. The
               ;; write is transient — the unified teardown projection runs
               ;; immediately after this and dissocs `[:rf.runtime/machines :snapshots
@@ -102,13 +102,13 @@
               ;; swap-runtime-db! per destroy. Machine snapshots are
               ;; durable runtime-db state.
               (when (not= snapshot new-snap)
-                (frame/swap-runtime-db! frame-id
-                                        (fn [rt] (assoc-in rt (paths/snapshot-path actor-id) new-snap))))
+                (rf.frame/swap-runtime-db! frame-id
+                                        (fn [rt] (assoc-in rt (rf.machines.paths/snapshot-path actor-id) new-snap))))
               ;; (5) Fire the `:exit`-emitted fx via the standard fx
               ;; interpreter. Use the frame's `:platform` (defaults to
               ;; :client) so platform-gated fx behave consistently with
               ;; transition-time fx fires.
               (when (seq exit-fx)
-                (let [platform (or (:platform (frame/frame-meta frame-id)) :client)]
-                  (fx/do-fx frame-id (vec exit-fx) platform))))))))
+                (let [platform (or (:platform (rf.frame/frame-meta frame-id)) :client)]
+                  (rf.fx/do-fx frame-id (vec exit-fx) platform))))))))
     nil))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -34,26 +34,26 @@
   The actor-teardown runtime-db projection lives in
   `re-frame.machines.lifecycle-fx.teardown` — one helper, three
   call-sites."
-  (:require [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.machines.error-emit :as machine-error-emit]
-            [re-frame.machines.classification :as classification]
-            [re-frame.machines.data-validation :as data-validation]
-            [re-frame.machines.lifecycle-fx.resolver :as resolver]
-            [re-frame.machines.lifecycle-fx.resource-release :as resource-release]
-            [re-frame.machines.lifecycle-fx.spawn-error :as spawn-error]
-            [re-frame.machines.lifecycle-fx.teardown :as teardown]
-            [re-frame.machines.lifecycle-fx.traces :as traces]
-            [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.paths :as paths]
-            [re-frame.machines.reply :as m-reply]
-            [re-frame.machines.result :as result]
-            [re-frame.machines.spawn-order :as spawn-order]
-            [re-frame.machines.timer :as timer]
-            [re-frame.machines.transition :as transition]
-            [re-frame.registrar :as registrar]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.machines.error-emit :as rf.machines.error-emit]
+            [re-frame.machines.classification :as rf.machines.classification]
+            [re-frame.machines.data-validation :as rf.machines.data-validation]
+            [re-frame.machines.lifecycle-fx.resolver :as rf.machines.lifecycle-fx.resolver]
+            [re-frame.machines.lifecycle-fx.resource-release :as rf.machines.lifecycle-fx.resource-release]
+            [re-frame.machines.lifecycle-fx.spawn-error :as rf.machines.lifecycle-fx.spawn-error]
+            [re-frame.machines.lifecycle-fx.teardown :as rf.machines.lifecycle-fx.teardown]
+            [re-frame.machines.lifecycle-fx.traces :as rf.machines.lifecycle-fx.traces]
+            [re-frame.machines.parallel :as rf.machines.parallel]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.machines.reply :as rf.machines.reply]
+            [re-frame.machines.result :as rf.machines.result]
+            [re-frame.machines.spawn-order :as rf.machines.spawn-order]
+            [re-frame.machines.timer :as rf.machines.timer]
+            [re-frame.machines.transition :as rf.machines.transition]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -73,7 +73,7 @@
   the http artefact is absent (returns nil)."
   [actor-id]
   (when actor-id
-    (when-let [abort! (late-bind/get-fn :http/abort-on-actor-destroy)]
+    (when-let [abort! (rf.late-bind/get-fn :http/abort-on-actor-destroy)]
       (try (abort! actor-id)
            (catch #?(:clj Throwable :cljs :default) _ nil))))
   nil)
@@ -94,14 +94,14 @@
 ;; this whole-machine finalize path). Re-exported here so callers
 ;; (and the conformance corpus) reach it at the `finalize/all-regions-final?`
 ;; address. `finalize` requires `parallel`, never the reverse — no cycle.
-(def all-regions-final? parallel/all-regions-final?)
+(def all-regions-final? rf.machines.parallel/all-regions-final?)
 
 (defn- region-final-leaf-nodes
   "Per Spec 005 §Final states + §Parallel regions: resolve
   every region's active final leaf-node from the post-transition `state`
   map (a `{region-name region-state}` map). Returns an ordered seq of
   `[region-name leaf-node]` in canonical region DECLARATION order
-  (`parallel/region-order`) — the basis for the cross-region `:output-key` /
+  (`rf.machines.parallel/region-order`) — the basis for the cross-region `:output-key` /
   `:error?` scans below, whose first-region tie-break must follow authored
   order, NEVER state-map hash iteration (>8 regions). `state` is a valid
   all-final configuration here (gated by `all-regions-final?`), so every
@@ -109,9 +109,9 @@
   [machine state]
   (map (fn [region-name]
          [region-name
-          (transition/node-at (get-in machine [:regions region-name])
-                              (transition/state-path (get state region-name)))])
-       (parallel/region-order machine)))
+          (rf.machines.transition/node-at (get-in machine [:regions region-name])
+                              (rf.machines.transition/state-path (get state region-name)))])
+       (rf.machines.parallel/region-order machine)))
 
 (defn- parallel-output-key
   "Per Spec 005 §Final states: resolve a finishing PARALLEL
@@ -131,7 +131,7 @@
                       (filter (fn [[_ node]] (contains? node :output-key))))
         keys'    (distinct (map (fn [[_ node]] (:output-key node)) declared))]
     (when (> (count keys') 1)
-      (trace/emit-error! :rf.error/machine-parallel-output-key-conflict
+      (rf.trace/emit-error! :rf.error/machine-parallel-output-key-conflict
                          {:actor-id    machine-id
                           :frame       frame-id
                           :output-keys (vec keys')
@@ -205,10 +205,10 @@
   ;; failure trace and proceed with the pre-cascade snapshot (fail-
   ;; soft — the destroy must complete to keep the registrar +
   ;; spawn-slot consistent).
-  (let [exit-result   (parallel/run-active-exit-cascade machine next-snapshot)
-        exit-ok?      (result/ok? exit-result)
-        next-snapshot (if exit-ok? (result/snap exit-result) next-snapshot)
-        exit-fx       (if exit-ok? (vec (result/fx exit-result)) [])
+  (let [exit-result   (rf.machines.parallel/run-active-exit-cascade machine next-snapshot)
+        exit-ok?      (rf.machines.result/ok? exit-result)
+        next-snapshot (if exit-ok? (rf.machines.result/snap exit-result) next-snapshot)
+        exit-fx       (if exit-ok? (vec (rf.machines.result/fx exit-result)) [])
         runtime-db    (if exit-ok?
                         ;; Project the post-`:exit` CHILD snapshot back into
                         ;; runtime-db so any reader of the runtime-db between
@@ -219,14 +219,14 @@
                         ;; runtime-db, and `:on-done` reads the PARENT's
                         ;; `:data`; the projection's purpose is runtime-db
                         ;; consistency for the finalize cascade's own reads.)
-                        (assoc-in runtime-db (paths/snapshot-path machine-id) next-snapshot)
+                        (assoc-in runtime-db (rf.machines.paths/snapshot-path machine-id) next-snapshot)
                         runtime-db)
         _             (when (not exit-ok?)
                         ;; Same destroy-exit failure shape as the explicit-
                         ;; destroy path (`exit-cascade/run-child-exit!`) —
-                        ;; shared via `traces/emit-destroy-exit-failure!`.
-                        (traces/emit-destroy-exit-failure!
-                          machine-id frame-id (result/info exit-result)))]
+                        ;; shared via `rf.machines.lifecycle-fx.traces/emit-destroy-exit-failure!`.
+                        (rf.machines.lifecycle-fx.traces/emit-destroy-exit-failure!
+                          machine-id frame-id (rf.machines.result/info exit-result)))]
   (let [;; A's exact-frame-incarnation continuation predicate (rf2-3evq0x —
         ;; the completion-tail half of the incarnation-fencing family
         ;; established by #5849). The completion-output validator, the
@@ -235,21 +235,21 @@
         ;; the frame incarnation A that owns the in-flight event and publish a
         ;; same-id successor B. Every subsequent framework-owned action —
         ;; teardown, registrar unregister, HTTP/timer cancellation,
-        ;; classification/spawn-order drop, the `:on-error` dispatch, and the
+        ;; rf.machines.classification/spawn-order drop, the `:on-error` dispatch, and the
         ;; runtime-db / fx publication — is A-derived tail; running it after A
         ;; is lost erases or mutates B. `owner-continuation` yields
         ;; `(constantly true)` for a non-router pure-fn / conformance caller
         ;; (no event owner), so that path stays unaffected.
-        continue?  (data-validation/owner-continuation frame-id)
+        continue?  (rf.machines.data-validation/owner-continuation frame-id)
         ;; rf2-i4aj9c — the RAW exact owner token (`continue?` closes over it),
         ;; threaded into the teardown classification drop so it rides the EXACT
         ;; elision write: a container watch that destroys A / publishes same-id B
         ;; DURING the drop cannot re-root the removal onto B's registry or bump
         ;; B's commit epoch. nil for a non-router pure-fn / conformance caller
         ;; (no event owner) — the drop falls back to the historical bare write.
-        owner-token (frame/current-event-owner-token)
+        owner-token (rf.frame/current-event-owner-token)
         child-data (:data next-snapshot)
-        parallel?  (parallel/parallel? machine)
+        parallel?  (rf.machines.parallel/parallel? machine)
         ;; Resolve the ERROR-classifying leaf. For a PARALLEL
         ;; machine, scan EVERY region's final leaf — a parallel finish is an
         ;; ERROR when ANY region's reached final declares `:error? true`, not
@@ -258,8 +258,8 @@
         ;; error-classifying leaf.
         error-node  (if parallel?
                       (parallel-error-leaf-node machine (:state next-snapshot))
-                      (transition/node-at machine
-                                          (transition/state-path (:state next-snapshot))))
+                      (rf.machines.transition/node-at machine
+                                          (rf.machines.transition/state-path (:state next-snapshot))))
         error-leaf? (true? (:error? error-node))
         ;; A PARALLEL machine's `:output-key` may live on ANY region's
         ;; terminal leaf, not just the first. Scan all regions (error on
@@ -289,14 +289,14 @@
         ;; finishing actor's runtime-stamped spec held directly by this
         ;; cascade, so the `[:schemas :output]` schema resolves off it without
         ;; a registrar / snapshot lookup. Production-elided
-        ;; (`interop/debug-enabled?`-gated inside the validator).
+        ;; (`rf.interop/debug-enabled?`-gated inside the validator).
         ;; The completion-output validator is APPLICATION code (rf2-3evq0x): a
         ;; validator that destroys A / publishes same-id B returns
         ;; `:rf/stale-incarnation` (NOT a schema verdict). Capture it — the
         ;; original `_` binding dropped the verdict and let the whole finalize
         ;; tail run against B. A stale return terminally fences every
         ;; subsequent framework-owned action below (the `owner-gone?` gate).
-        output-validation (data-validation/validate-completion-output! machine-id machine result)
+        output-validation (rf.machines.data-validation/validate-completion-output! machine-id machine result)
         stale-output?     (= :rf/stale-incarnation output-validation)
         ;; Re-checked (live) after each callback-bearing completion trace /
         ;; fanout and before every framework-owned action: true once the
@@ -368,15 +368,15 @@
         ;; singleton parent) OR, for a NESTED spawn whose parent is itself a
         ;; spawned actor (no per-instance registration), from the parent's own
         ;; snapshot `:rf/machine-type`.
-        parent-path (paths/snapshot-path parent-id)
+        parent-path (rf.machines.paths/snapshot-path parent-id)
         parent-snap (when parent-id (get-in runtime-db parent-path))
-        parent-reg  (when parent-id (registrar/lookup :event parent-id))
+        parent-reg  (when parent-id (rf.registrar/lookup :event parent-id))
         parent-meta (when parent-id
                       (cond
                         (:rf/machine? parent-reg) (:rf/machine parent-reg)
-                        :else                     (resolver/spec-from-snapshot parent-snap)))
+                        :else                     (rf.machines.lifecycle-fx.resolver/spec-from-snapshot parent-snap)))
         spawn-spec  (when (and parent-meta invoke-id)
-                      (resolver/spawn-spec-at parent-meta invoke-id))
+                      (rf.machines.lifecycle-fx.resolver/spawn-spec-at parent-meta invoke-id))
         on-done-fn  (:on-done spawn-spec)
         ;; `:on-error` is a transition spec (not a fn) — its PRESENCE on the
         ;; resolved `:spawn` map decides whether the error-leaf trigger routes
@@ -421,16 +421,16 @@
         ;; the trace via `stale-spawn-reply`'s correlation.
         current-generation
         (when (and parent-live? parent-id invoke-id)
-          (m-reply/actor-generation
-            (get-in runtime-db (paths/spawned-path parent-id invoke-id))))
+          (rf.machines.reply/actor-generation
+            (get-in runtime-db (rf.machines.paths/spawned-path parent-id invoke-id))))
         reply       (cond
                       stale-spawn?
-                      (m-reply/stale-spawn-reply
+                      (rf.machines.reply/stale-spawn-reply
                         (assoc reply-ctx :current-generation current-generation))
                       error-leaf?
-                      (m-reply/error-reply reply-ctx result)
+                      (rf.machines.reply/error-reply reply-ctx result)
                       :else
-                      (m-reply/success-reply reply-ctx result))
+                      (rf.machines.reply/success-reply reply-ctx result))
         ;; (2) Emit `:rf.machine/done` trace BEFORE the destroy cascade
         ;; (D6 ordering). Fired for EVERY finish (success / error / STALE) —
         ;; `:on-error` is additive, the done trace is the actor-finality
@@ -441,25 +441,25 @@
         ;; resources do; the public `:output` / `:parent-id` / `:error?`
         ;; shape is preserved. Wire-bearing slots (`:value` / `:error` /
         ;; `:correlation`) route through the shared elision walker via
-        ;; `m-reply/trace-reply`.
+        ;; `rf.machines.reply/trace-reply`.
         ;;
         ;; A STALE late completion (parent destroyed before the
         ;; child finished) additionally rides `:rf.reply/stale-reason`
         ;; (`:rf.machine/actor-not-live`) and `:rf.reply/correlation` (the
         ;; carried/current generation gate) — the parity counterpart of the
         ;; `:after` path's `:rf.machine.timer/stale-after` stale-suppression
-        ;; trace. The summary is built via `m-reply/stale-spawn-trace` for a
+        ;; trace. The summary is built via `rf.machines.reply/stale-spawn-trace` for a
         ;; stale reply so the spawn-stale path reads as the spawn analogue of
         ;; `after-stale-reply` → `trace-reply`.
         done-summary (if stale-spawn?
-                       (m-reply/stale-spawn-trace reply {:frame frame-id})
-                       (m-reply/trace-reply reply {:frame frame-id}))
+                       (rf.machines.reply/stale-spawn-trace reply {:frame frame-id})
+                       (rf.machines.reply/trace-reply reply {:frame frame-id}))
         ;; The `:rf.machine/done` trace fan-out is callback-bearing
         ;; (rf2-3evq0x): a listener can destroy A / publish same-id B. Skip it
         ;; when A is already gone (a stale completion-output validator), and
         ;; re-check liveness after it before any framework-owned action below.
         _ (when-not (owner-gone?)
-            (trace/emit! :rf.machine :rf.machine/done
+            (rf.trace/emit! :rf.machine :rf.machine/done
                        ;; `:actor-id` is the finishing actor's
                        ;; live INSTANCE address (singleton: its registration
                        ;; id; spawned: the `<type>#<n>` / fixed instance id).
@@ -518,7 +518,7 @@
         ;; unchanged; the value flows through the uniform reply envelope
         ;; internally. `(:value reply)` is `=` to the pre-lowering `result`
         ;; for a success leaf (behavioural parity), but it is sourced from
-        ;; the one canonical reply map so the value the trace/ledger see and
+        ;; the one canonical reply map so the value the rf.trace/ledger see and
         ;; the value the callback receives are the SAME fact.
         db-after-on-done
         ;; `:on-done` is an application callback (rf2-3evq0x) — skip it once A
@@ -539,7 +539,7 @@
                                     ;; record (no prose; see error-emit).
                                     ;; `:state` is the final leaf the actor
                                     ;; rests on as its `:on-done` fired.
-                                    (machine-error-emit/emit-machine-action-exception!
+                                    (rf.machines.error-emit/emit-machine-action-exception!
                                       {:actor-id   machine-id
                                        :failing-id :rf.machine.spawn/on-done
                                        :state      (:state next-snapshot)
@@ -547,7 +547,7 @@
                                        :recovery   :no-recovery
                                        :exception  e})
                                     ;; Axis 2 — dev-only trace. Wrapped in an
-                                    ;; EXPLICIT `interop/debug-enabled?` call-site
+                                    ;; EXPLICIT `rf.interop/debug-enabled?` call-site
                                     ;; gate so Closure constant-folds the whole
                                     ;; form — the PROSE `:reason` /
                                     ;; `:exception-message` included — away under
@@ -555,8 +555,8 @@
                                     ;; through the always-on helper (or leaving
                                     ;; the direct call ungated beside the live
                                     ;; always-on call above) would leak the prose.
-                                    (when interop/debug-enabled?
-                                      (trace/emit-error! :rf.error/machine-action-exception
+                                    (when rf.interop/debug-enabled?
+                                      (rf.trace/emit-error! :rf.error/machine-action-exception
                                         {:actor-id   machine-id
                                          :machine-id machine-id
                                          :action-id  :rf.machine.spawn/on-done
@@ -600,13 +600,13 @@
             ;; `released-sid` is resolved against db-after-on-done before the
             ;; reverse index is mutated.
             [db-after-destroy released-sid]
-            (teardown/teardown-actor db-after-on-done
+            (rf.machines.lifecycle-fx.teardown/teardown-actor db-after-on-done
                                      {:actor-id  machine-id
                                       :parent-id parent-id
                                       :invoke-id invoke-id})]
         ;; (5) Emit :rf.machine/destroyed with :reason :rf.machine/finished
         ;; (D6 enrichment) before registrar cleanup.
-        (traces/emit-destroyed! {:frame     frame-id
+        (rf.machines.lifecycle-fx.traces/emit-destroyed! {:frame     frame-id
                                  :actor-id  machine-id
                                  :system-id released-sid
                                  :parent-id parent-id
@@ -619,12 +619,12 @@
         ;; completion callbacks (validator / done trace / `:on-done`) with the
         ;; top-level `owner-gone?` gate, but NOTHING rechecked ownership between
         ;; these LATER teardown callbacks and the framework-owned actions that
-        ;; follow — so the HTTP/timer cancellation, classification/spawn-order
+        ;; follow — so the HTTP/timer cancellation, rf.machines.classification/spawn-order
         ;; drop, registrar unregister, and `:on-error` dispatch could all run
         ;; against B (a bare frame-id / machine-id resolves to the CURRENT
         ;; incarnation). Recheck `owner-gone?` before each next framework action;
         ;; it is MONOTONIC (once A→B it stays gone), so a per-action guard
-        ;; short-circuits the whole tail. Already-delivered traces/hooks stand —
+        ;; short-circuits the whole tail. Already-delivered rf.machines.lifecycle-fx.traces/hooks stand —
         ;; the ruled unwind posture, no rollback.
         (when-not (owner-gone?)
           ;; (6) Abort in-flight HTTP (late-bound hook — callback-bearing).
@@ -637,28 +637,28 @@
           ;; timer under a later snapshotted key. Thread `owner-gone?` so the
           ;; cancellation loop short-circuits the instant A is lost (it is
           ;; MONOTONIC), leaving B's re-armed timers untouched.
-          (timer/cancel-actor-timers! frame-id machine-id owner-gone?))
+          (rf.machines.timer/cancel-actor-timers! frame-id machine-id owner-gone?))
         ;; rf2-4ipqe4 — RECHECK after the timer-cancellation callbacks before the
         ;; classification / spawn-order / system-id-release work. #5856/#5873
         ;; grouped these under the timer cancel with NO recheck, so a
         ;; `:rf.machine.timer/cancelled` listener that published same-id B let the
         ;; A-derived classification drop, spawn-order forget, and system-id-released
-        ;; trace resolve their bare frame/actor ids to the CURRENT incarnation B.
+        ;; trace resolve their bare rf.frame/actor ids to the CURRENT incarnation B.
         (when-not (owner-gone?)
           ;; Drop this actor's per-instance classification declarations from the
           ;; per-frame elision registry — the teardown half of
-          ;; `classification/lower-at-spawn!` on the final-state AUTO-DESTROY path
+          ;; `rf.machines.classification/lower-at-spawn!` on the final-state AUTO-DESTROY path
           ;; (which does NOT route through `destroy/teardown-live-actor!`). A spec
           ;; that declared no classification is a clean no-op, so the registry
           ;; entry added at spawn dies with the instance (no leak). rf2-i4aj9c —
           ;; thread `owner-token` so the drop rides the EXACT elision write (a
           ;; mid-write watch cannot re-root the removal onto same-id B).
-          (classification/drop-at-destroy! frame-id machine-id machine owner-token))
+          (rf.machines.classification/drop-at-destroy! frame-id machine-id machine owner-token))
         ;; rf2-rbxdxa — `drop-at-destroy!` writes through the EXACT elision swap, a
         ;; container-write boundary: a synchronous watch can destroy A / publish
         ;; same-id B DURING the drop. Recheck ownership AFTER it before the
         ;; spawn-order forget + system-id release — grouping them under the SAME
-        ;; precheck let a mid-drop successor B see the bare-id `spawn-order/forget!`
+        ;; precheck let a mid-drop successor B see the bare-id `rf.machines.spawn-order/forget!`
         ;; erase B's freshly-recorded entry and the system-id-released trace resolve
         ;; against B (the finalize sibling of the ordinary-destroy drop seam). The
         ;; drop write is already exact; this fences the forget/release the grouped
@@ -672,15 +672,15 @@
           ;; RE-RUNS (phantom destroyed trace + re-fired resource release,
           ;; violating silent-idempotent destroy) and frame-destroy emits a
           ;; phantom straggler destroy for it.
-          (spawn-order/forget! frame-id machine-id)
+          (rf.machines.spawn-order/forget! frame-id machine-id)
           ;; The `:rf.machine/system-id-released` trace is callback-bearing and is
           ;; the LAST action in this group, so the recheck below fences the
           ;; registrar unregister + `:on-error` dispatch against a B it published.
-          (traces/emit-system-id-released! frame-id released-sid machine-id))
+          (rf.machines.lifecycle-fx.traces/emit-system-id-released! frame-id released-sid machine-id))
         (when-not (owner-gone?)
-          ;; `registrar/unregister!` emits a synchronous callback-bearing
+          ;; `rf.registrar/unregister!` emits a synchronous callback-bearing
           ;; `:rf.registry/handler-cleared` trace.
-          (registrar/unregister! :event machine-id))
+          (rf.registrar/unregister! :event machine-id))
         ;; rf2-4ipqe4 — RECHECK after the registrar unregister before the
         ;; `:on-error` dispatch. #5856/#5873 grouped the unregister with the
         ;; dispatch under ONE check, so a `:rf.registry/handler-cleared` listener
@@ -698,7 +698,7 @@
           ;; `:final?`); this only ROUTES the failure. The dispatched payload is
           ;; the RAW error (`result`); the parent transition reads it off `:event`.
           (when on-error?
-            (spawn-error/dispatch-spawn-error! frame-id parent-id invoke-id result)))
+            (rf.machines.lifecycle-fx.spawn-error/dispatch-spawn-error! frame-id parent-id invoke-id result)))
         ;; Publish the teardown runtime-db + fx ONLY if the exact owner survived
         ;; the WHOLE tail (rf2-hloj0g). If any post-`emit-destroyed!` callback
         ;; published same-id B, return the inert outcome — the A-derived
@@ -710,10 +710,10 @@
         ;; framework-authority partition effect), NOT `:db`. Append the
         ;; destroy-time `:exit` cascade's fx + the resource-owner release for
         ;; this actor's `[:machine machine-id]` owner (nil + filtered out when
-        ;; resources is absent — see `resource-release/release-fx-entry`).
+        ;; resources is absent — see `rf.machines.lifecycle-fx.resource-release/release-fx-entry`).
         (if (owner-gone?)
           {:rf.db/runtime runtime-db :fx []}
           {:rf.db/runtime db-after-destroy
            :fx (vec (concat extra-fx exit-fx
-                            (when-let [e (resource-release/release-fx-entry machine-id)]
+                            (when-let [e (rf.machines.lifecycle-fx.resource-release/release-fx-entry machine-id)]
                               [e])))}))))))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
@@ -24,13 +24,13 @@
        emits-per-active-machine`.
 
   After every machine has settled, sub-cache disposes / substrate
-  releases / `:frame/destroyed` trace fires from `frame/destroy-frame!`
+  releases / `:frame/destroyed` trace fires from `rf.frame/destroy-frame!`
   itself.
 
   Surfaces:
    - `teardown-on-frame-destroy!` — late-bound at
      `:machines/teardown-on-frame-destroy!`; called from
-     `frame/destroy-frame!`.
+     `rf.frame/destroy-frame!`.
 
   Source-of-truth on order: the DURABLE `[:rf.runtime/machines
   :spawn-order]` vector, appended by `install-spawn!` in the same
@@ -73,17 +73,17 @@
   root (stamped by `install-spawn!`; a SINGLETON snapshot never carries it
   — actor_liveness_test:213). The walk SPLITS on that durable
   discriminator: spawned actors run the full
-  `destroy/destroy-single-actor!` teardown (registrar cleanup, system-id
+  `rf.machines.lifecycle-fx.destroy/destroy-single-actor!` teardown (registrar cleanup, system-id
   release, timer cancel, snapshot dissoc); true singletons keep the
   exit-cascade-only straggler path."
-  (:require [re-frame.frame :as frame]
-            [re-frame.machines.lifecycle-fx.destroy :as destroy]
-            [re-frame.machines.lifecycle-fx.exit-cascade :as exit-cascade]
-            [re-frame.machines.lifecycle-fx.finalize :as finalize]
-            [re-frame.machines.paths :as paths]
-            [re-frame.machines.spawn-order :as spawn-order]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.frame :as rf.frame]
+            [re-frame.machines.lifecycle-fx.destroy :as rf.machines.lifecycle-fx.destroy]
+            [re-frame.machines.lifecycle-fx.exit-cascade :as rf.machines.lifecycle-fx.exit-cascade]
+            [re-frame.machines.lifecycle-fx.finalize :as rf.machines.lifecycle-fx.finalize]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.machines.spawn-order :as rf.machines.spawn-order]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -94,8 +94,8 @@
   container and this read is not re-evaluated.
   EP-0001: machine snapshots are durable runtime-db state."
   [frame-id]
-  (when-let [container (frame/runtime-db-container frame-id)]
-    (adapter/read-container container)))
+  (when-let [container (rf.frame/runtime-db-container frame-id)]
+    (rf.substrate.adapter/read-container container)))
 
 (defn- spawned-snapshot?
   "True iff `snapshot` is a spawned actor's snapshot, not
@@ -143,7 +143,7 @@
   cascade emits this event. Preserves the trace contract observable in
   `frame_lifecycle_test/destroy-frame-cascade-emits-per-active-machine`."
   [frame-id actor-id snapshot]
-  (trace/emit! :rf.machine.lifecycle/destroyed :rf.machine.lifecycle/destroyed
+  (rf.trace/emit! :rf.machine.lifecycle/destroyed :rf.machine.lifecycle/destroyed
                {:frame      frame-id
                 ;; The reaped actor's live INSTANCE address;
                 ;; `:machine-id` is reserved for the registered TYPE.
@@ -161,7 +161,7 @@
   (the frame's runtime-db is about to be released).
 
   The HTTP-abort fires the shared `:http/abort-on-actor-destroy`
-  late-bind hook via `finalize/abort-actor-in-flight-http!` — the same
+  late-bind hook via `rf.machines.lifecycle-fx.finalize/abort-actor-in-flight-http!` — the same
   best-effort, idempotent helper the spawn-destroy + final-state
   teardowns use, so the abort contract has one home.
 
@@ -169,8 +169,8 @@
   a per-instance marks table. There are therefore no schema marks for any
   teardown path — singleton or spawned — to clear or preserve."
   [frame-id actor-id]
-  (exit-cascade/run-child-exit! frame-id actor-id)
-  (finalize/abort-actor-in-flight-http! actor-id)
+  (rf.machines.lifecycle-fx.exit-cascade/run-child-exit! frame-id actor-id)
+  (rf.machines.lifecycle-fx.finalize/abort-actor-in-flight-http! actor-id)
   nil)
 
 (defn teardown-on-frame-destroy!
@@ -216,14 +216,14 @@
   [frame-id]
   (when frame-id
     (let [runtime-db   (frame-runtime-db frame-id)
-          snapshots    (or (get-in runtime-db (paths/snapshot-path)) {})
+          snapshots    (or (get-in runtime-db (rf.machines.paths/snapshot-path)) {})
           ;; The DURABLE total creation order, oldest → newest. Written by
           ;; `install-spawn!` inside the swap that landed each snapshot and
           ;; pruned by the teardown projection inside the swap that removed
           ;; it, so it names exactly the live spawned actors — and it says so
           ;; identically before and after a restore / hydration /
           ;; `replace-runtime-db!`, which is the whole point (rf2-1vlyg).
-          durable      (spawn-order/durable-order runtime-db)
+          durable      (rf.machines.spawn-order/durable-order runtime-db)
           durable-set  (set durable)
           ;; Reverse the durable vector → newest spawn first. THE
           ;; reverse-creation walk, per Spec 005 §Cross-Spec Interactions §1.
@@ -262,7 +262,7 @@
         ;; `destroy-single-actor!` is fail-soft against a vanished
         ;; container and missing artefacts; wrap defensively so one
         ;; bad actor can't strand the rest of the cascade.
-        (try (destroy/destroy-single-actor! frame-id actor-id)
+        (try (rf.machines.lifecycle-fx.destroy/destroy-single-actor! frame-id actor-id)
              (catch #?(:clj Throwable :cljs :default) _ nil)))
       ;; (b) Unsequenced spawned actors: the SAME full teardown, in a
       ;; deterministic order that claims no creation sequence — nothing ever
@@ -270,7 +270,7 @@
       (doseq [actor-id unsequenced-spawned]
         (let [snapshot (get snapshots actor-id)]
           (emit-lifecycle-destroyed! frame-id actor-id snapshot))
-        (try (destroy/destroy-single-actor! frame-id actor-id)
+        (try (rf.machines.lifecycle-fx.destroy/destroy-single-actor! frame-id actor-id)
              (catch #?(:clj Throwable :cljs :default) _ nil)))
       ;; (c) Singletons: trace + exit cascade + HTTP abort only. The
       ;; handler stays registered (lives in the global registrar, outlives
@@ -283,5 +283,5 @@
       ;; Drop the frame's spawn-order slot — every recorded actor is
       ;; gone, and a fresh construction under the same id starts with a
       ;; clean order channel.
-      (spawn-order/clear-frame! frame-id))
+      (rf.machines.spawn-order/clear-frame! frame-id))
     nil))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -62,15 +62,15 @@
   the handler-factory in `re-frame.machines.lifecycle-fx.registration`
   routes every inbound event through it before the machine's normal `:on`
   lookup."
-  (:require [re-frame.frame :as frame]
-            [re-frame.fx :as fx]
-            [re-frame.machines.data-validation :as data-validation]
-            [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.path-walk :as path-walk]
-            [re-frame.machines.paths :as paths]
-            [re-frame.machines.reply :as m-reply]
-            [re-frame.machines.transition :as transition]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.frame :as rf.frame]
+            [re-frame.fx :as rf.fx]
+            [re-frame.machines.data-validation :as rf.machines.data-validation]
+            [re-frame.machines.parallel :as rf.machines.parallel]
+            [re-frame.machines.path-walk :as rf.machines.path-walk]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.machines.reply :as rf.machines.reply]
+            [re-frame.machines.transition :as rf.machines.transition]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -227,7 +227,7 @@
   after A was gone, and a delayed completion reserved a `dispatch-later-timers`
   slot AFTER destroy had already released that table (a post-cleanup timer that
   fires dead-on-arrival). So we recheck exact-owner continuation
-  (`data-validation/owner-continuation`, bound to A's raw owner token) AFTER the
+  (`rf.machines.data-validation/owner-continuation`, bound to A's raw owner token) AFTER the
   emit and BEFORE the router dispatch / numeric-ms timer reservation: if A is
   gone, neither lands on A nor on an unrelated same-id B. The `:applied-*`
   branch's `handle-one-fx` is itself exact-owner-fenced by core, so it needs no
@@ -255,14 +255,14 @@
   rf2-21hsb1) arms a frame-owned delayed dispatch; a nil `:ms` (a direct
   `:dispatch` completion) dispatches immediately in the current drain."
   [{:keys [frame envelope] origin-event :event} {:keys [event ms] attempt :rf/join-attempt}]
-  (let [frame-id     (frame/require-frame-stamp!
+  (let [frame-id     (rf.frame/require-frame-stamp!
                        frame :rf.machine/join-dispatch
                        {:where 'rf.machine/join-dispatch :event-id (first event)})
         ;; The CANONICAL authored effect this completion was lowered from: a
         ;; `:dispatch-later` completion carries a numeric `:ms` (zero or
         ;; positive); a direct `:dispatch` completion carries none.
         canonical-id (if (number? ms) :dispatch-later :dispatch)
-        frame-record (frame/frame frame-id)
+        frame-record (rf.frame/frame frame-id)
         ;; The SAME effective override map `do-fx` resolved against — per-frame
         ;; ⋈ per-call, per-call winning (mirrors `router/apply-overrides`). The
         ;; per-call tier rides the emitting child's dispatch envelope.
@@ -275,13 +275,13 @@
         ;; flip an applies-preflight into a coordinate-less transport. This is
         ;; the SAME policy `resolve-fx-with-overrides` consumes — join
         ;; duplicates no registrar / protected-target lookup.
-        disposition  (fx/classify-fx-override overrides canonical-id)
+        disposition  (rf.fx/classify-fx-override overrides canonical-id)
         ;; Exact-owner continuation predicate, captured ONCE against A's raw
         ;; owner token (rf2-5g6qq / rf2-8nxsh): true while the incarnation that
         ;; owns the in-flight event may still run framework continuation, false
         ;; once a synchronous callback (a fallthrough `:errors` listener) has
         ;; destroyed A / published same-id B.
-        continue?    (data-validation/owner-continuation frame-id)]
+        continue?    (rf.machines.data-validation/owner-continuation frame-id)]
     (case (:disposition disposition)
       ;; OVERRIDE GENUINELY APPLIES (rf2-ulsbgr / rf2-2lzk8a): route the
       ;; PRE-RESOLVED effect through the shared core seam. `handle-one-fx` (not
@@ -292,10 +292,10 @@
       ;; A fn-value override is churn-immune (no registrar dependency); pass it
       ;; as the sole override so execution resolves to the SAME fn.
       :applied-fn
-      (fx/handle-one-fx
+      (rf.fx/handle-one-fx
         frame-id
         (if (number? ms) [canonical-id {:ms ms :event event}] [canonical-id event])
-        (fx/platform-for-frame-record frame-record)
+        (rf.fx/platform-for-frame-record frame-record)
         {canonical-id (:override disposition)}
         origin-event
         envelope)
@@ -307,12 +307,12 @@
       ;; classification, this is an honest `:rf.error/no-such-fx` — never a
       ;; coordinate-less completion.
       :applied-redirect
-      (fx/handle-one-fx
+      (rf.fx/handle-one-fx
         frame-id
         (if (number? ms)
           [(:target disposition) {:ms ms :event event}]
           [(:target disposition) event])
-        (fx/platform-for-frame-record frame-record)
+        (rf.fx/platform-for-frame-record frame-record)
         {}
         origin-event
         envelope)
@@ -338,10 +338,10 @@
       ;; folding synchronously. A direct `:dispatch` completion (nil `:ms`)
       ;; enqueues immediately in the current drain.
       (do
-        (fx/emit-override-fallthrough!
+        (rf.fx/emit-override-fallthrough!
           disposition canonical-id overrides frame-id origin-event origin-event-id)
         (when (continue?)
-          (fx/child-dispatch!
+          (rf.fx/child-dispatch!
             frame-id envelope event
             (cond-> {:source  :machine-action
                      :rf.cofx {:rf.machine/join-attempt attempt}}
@@ -446,7 +446,7 @@
                               (get-in join-state [:spec :children]))]
     (if (contains? child-spec :fixed-actor-id)
       attempt
-      (m-reply/actor-generation spawned-id))))
+      (rf.machines.reply/actor-generation spawned-id))))
 
 (defn- suppress-stale-completion!
   "Fail-closed suppression of a completion carrier that may NOT fold
@@ -477,7 +477,7 @@
   attempt's work identity."
   [frame-id parent-id invoke-id child-id spawned-id work-generation kind
    completed-at runtime-db stale-reason]
-  (let [stale-reply (m-reply/stale-join-child-reply
+  (let [stale-reply (rf.machines.reply/stale-join-child-reply
                       {:parent-id    parent-id
                        :invoke-id    invoke-id
                        :child-id     child-id
@@ -486,8 +486,8 @@
                        :frame        frame-id
                        :completed-at completed-at}
                       kind stale-reason)
-        summary     (m-reply/trace-reply stale-reply {:frame frame-id})]
-    (trace/emit! :rf.machine :rf.machine.spawn-all/stale-completion
+        summary     (rf.machines.reply/trace-reply stale-reply {:frame frame-id})]
+    (rf.trace/emit! :rf.machine :rf.machine.spawn-all/stale-completion
                  (cond-> {:actor-id  parent-id
                           :invoke-id invoke-id
                           :child-id  child-id
@@ -511,9 +511,9 @@
   region of a parallel machine, the region body) and a path inside
   that tree, walk leaf→root for a `:spawn-all`-bearing state whose
   `:on-child-done` or `:on-child-error` matches inner-event-id (the
-  deepest-wins rule named in `path-walk/walk-path-leaf-to-root`)."
+  deepest-wins rule named in `rf.machines.path-walk/walk-path-leaf-to-root`)."
   [tree path inner-event-id]
-  (path-walk/walk-path-leaf-to-root
+  (rf.machines.path-walk/walk-path-leaf-to-root
     tree path
     (fn [prefix n]
       (when-let [ia (:spawn-all n)]
@@ -545,11 +545,11 @@
   join."
   [machine snapshot inner-event-id]
   (cond
-    (parallel/parallel? machine)
+    (rf.machines.parallel/parallel? machine)
     (into []
           (keep (fn [[region-name region-state]]
-                  (let [region-body (parallel/region-machine machine region-name)
-                        region-path (transition/state-path region-state)
+                  (let [region-body (rf.machines.parallel/region-machine machine region-name)
+                        region-path (rf.machines.transition/state-path region-state)
                         match       (find-active-spawn-all-in-tree
                                       region-body region-path inner-event-id)]
                     (when match
@@ -558,7 +558,7 @@
 
     :else
     (if-let [m (find-active-spawn-all-in-tree
-                 machine (transition/state-path (:state snapshot)) inner-event-id)]
+                 machine (rf.machines.transition/state-path (:state snapshot)) inner-event-id)]
       [m]
       [])))
 
@@ -682,7 +682,7 @@
   [frame-id parent-id invoke-id join-state'' child-id work-generation kind
    child-extra completed-at]
   (let [spawned-id (get-in join-state'' [:children child-id])
-        reply      (m-reply/join-child-reply
+        reply      (rf.machines.reply/join-child-reply
                      {:parent-id    parent-id
                       :invoke-id    invoke-id
                       :child-id     child-id
@@ -691,7 +691,7 @@
                       :frame        frame-id
                       :completed-at completed-at}
                      kind child-extra)
-        summary    (m-reply/trace-reply reply {:frame frame-id})]
+        summary    (rf.machines.reply/trace-reply reply {:frame frame-id})]
     (cond-> {:rf.reply/work-kind            (:rf.reply/work-kind summary)
              :rf.reply/status      (:status summary)
              :rf.reply/work-id     (:rf.reply/work-id summary)
@@ -720,7 +720,7 @@
   [frame-id parent-id invoke-id join-state'' child-id work-generation kind
    child-extra completed-at]
   (let [spawned-id (get-in join-state'' [:children child-id])]
-    (trace/emit! :rf.machine :rf.machine.spawn-all/child-completed
+    (rf.trace/emit! :rf.machine :rf.machine.spawn-all/child-completed
                  (merge {:actor-id   parent-id
                          :invoke-id  invoke-id
                          :child-id   child-id
@@ -755,7 +755,7 @@
   [frame-id parent-id invoke-id spec join-state'' child-id work-generation
    child-extra completed-at {:keys [fail-fired? success-fired?]}]
   (when fail-fired?
-    (trace/emit! :rf.machine :rf.machine.spawn-all/any-failed
+    (rf.trace/emit! :rf.machine :rf.machine.spawn-all/any-failed
                  (merge {:actor-id parent-id
                          :invoke-id invoke-id
                          :failed-id  child-id
@@ -773,13 +773,13 @@
                         child-id work-generation :done child-extra
                         completed-at)]
       (if (= :all (:join spec :all))
-        (trace/emit! :rf.machine :rf.machine.spawn-all/all-completed
+        (rf.trace/emit! :rf.machine :rf.machine.spawn-all/all-completed
                      (merge {:actor-id parent-id
                              :invoke-id invoke-id
                              :done       (:done join-state'')
                              :frame      frame-id}
                             reply-facts))
-        (trace/emit! :rf.machine :rf.machine.spawn-all/some-completed
+        (rf.trace/emit! :rf.machine :rf.machine.spawn-all/some-completed
                      (merge {:actor-id parent-id
                              :invoke-id invoke-id
                              :done       (:done join-state'')
@@ -828,8 +828,8 @@
               ;; through the `:rf.machine/destroyed` cancelled reply; this
               ;; trace carries the join-resolution attribution.
               (let [survivor-summary
-                    (m-reply/trace-reply
-                      (m-reply/cancelled-actor-reply
+                    (rf.machines.reply/trace-reply
+                      (rf.machines.reply/cancelled-actor-reply
                         {:actor-id          spawned-id
                          :parent-id         parent-id
                          :work-bearing-path invoke-id
@@ -839,7 +839,7 @@
                          :frame             frame-id
                          :reason            :on-join-resolution})
                       {:frame frame-id})]
-                (trace/emit! :rf.machine :rf.machine.spawn/cancelled-on-join-resolution
+                (rf.trace/emit! :rf.machine :rf.machine.spawn/cancelled-on-join-resolution
                              {:actor-id parent-id
                               :invoke-id invoke-id
                               :child-id   cid
@@ -949,7 +949,7 @@
                (= parent-id (:parent-id attempt))
                (= invoke-id (:invoke-id attempt))
                (some? (:attempt attempt))
-               (let [js (get-in runtime-db (paths/spawned-path parent-id invoke-id))]
+               (let [js (get-in runtime-db (rf.machines.paths/spawned-path parent-id invoke-id))]
                  (and (map? js)
                       (= (:rf/attempt js) (:attempt attempt))
                       (= (get-in js [:children child-id]) (:spawned-id attempt))))))
@@ -960,7 +960,7 @@
         ;; owns the child (genuinely forged child-id), fall back to the first
         ;; match so the bad-child-id error trace still fires against a real join.
         owns?    (fn [{invoke-id :invoke-id}]
-                   (let [js (get-in runtime-db (paths/spawned-path parent-id invoke-id))]
+                   (let [js (get-in runtime-db (rf.machines.paths/spawned-path parent-id invoke-id))]
                      (and (map? js) (contains? (:children js) child-id))))
         match    (or (some #(when (exact-attempt-match? %) %) matches)
                      (some #(when (owns? %) %) matches)
@@ -993,7 +993,7 @@
             child-extra (vec (drop 2 inner-event))
             ;; Read the live join state from runtime-db (the seed was written
             ;; by :rf.machine/spawn-all-init on entry).
-            join-state (get-in runtime-db (paths/spawned-path parent-id invoke-id))]
+            join-state (get-in runtime-db (rf.machines.paths/spawned-path parent-id invoke-id))]
         (cond
           ;; No LIVE child-bearing join state at the slot — fall through to
           ;; no-op. Both no-`:children` cases land here: a pure-call snapshot
@@ -1029,7 +1029,7 @@
           ;; join state). Per Spec 005 §Spawn-and-join and the machines
           ;; security-audit finding F1.
           (not (contains? (:children join-state) child-id))
-          (do (trace/emit-error! :rf.error/machine-spawn-all-bad-child-id
+          (do (rf.trace/emit-error! :rf.error/machine-spawn-all-bad-child-id
                                  {:actor-id parent-id
                                   :invoke-id invoke-id
                                   :child-id   child-id
@@ -1102,7 +1102,7 @@
                 work-generation (join-work-generation
                                   join-state child-id spawned-id
                                   (:rf/attempt join-state))
-                stale-reply (m-reply/stale-join-child-reply
+                stale-reply (rf.machines.reply/stale-join-child-reply
                               {:parent-id    parent-id
                                :invoke-id    invoke-id
                                :child-id     child-id
@@ -1111,8 +1111,8 @@
                                :frame        frame-id
                                :completed-at completed-at}
                               kind)
-                summary    (m-reply/trace-reply stale-reply {:frame frame-id})]
-            (trace/emit! :rf.machine :rf.machine.spawn-all/late-completion
+                summary    (rf.machines.reply/trace-reply stale-reply {:frame frame-id})]
+            (rf.trace/emit! :rf.machine :rf.machine.spawn-all/late-completion
                          (cond-> {:actor-id parent-id
                                   :invoke-id invoke-id
                                   :child-id   child-id
@@ -1190,7 +1190,7 @@
     (when (and (not (:resolved? resolution))
                (join-unsatisfiable? spec join-state')
                (not (join-unsatisfiable? spec join-state)))
-      (trace/emit! :warning :rf.warning/spawn-all-join-unsatisfiable
+      (rf.trace/emit! :warning :rf.warning/spawn-all-join-unsatisfiable
                    {:actor-id  parent-id
                     :invoke-id invoke-id
                     :join      (:join spec :all)
@@ -1216,5 +1216,5 @@
                                  completed-at))
     (let [fx (build-resolution-fx frame-id parent-id invoke-id spec join-state''
                                   child-id child-extra resolution)]
-      {:rf.db/runtime (assoc-in runtime-db (paths/spawned-path parent-id invoke-id) join-state'')
+      {:rf.db/runtime (assoc-in runtime-db (rf.machines.paths/spawned-path parent-id invoke-id) join-state'')
        :fx fx})))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -12,7 +12,7 @@
       `re-frame.machines.lifecycle-fx.validation`: parallel shape,
       `:spawn-all` shape, dropped `:timeout-ms` slots, guard/action
       ref resolution, final-state shape).
-    - `parallel/build-initial-snapshot` — initial-state
+    - `rf.machines.parallel/build-initial-snapshot` — initial-state
       cascade, `:data` / `:meta` / `:rf/spawn-counter` seeding, tag union
       stamping (lazily, on first event). Single source of truth shared
       with the spawn path.
@@ -21,26 +21,26 @@
       detection + initial-entry cascade, machine-transition dispatch,
       action-failure projection, finalize delegation (in
       `lifecycle-fx.finalize`)."
-  (:require [re-frame.cofx :as cofx]
-            [re-frame.error :as error]
-            [re-frame.events :as events]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.machines.classification :as classification]
-            [re-frame.machines.cofx-attach :as cofx-attach]
-            [re-frame.machines.error-emit :as machine-error-emit]
-            [re-frame.machines.internal-events :as internal-events]
-            [re-frame.machines.lifecycle-fx.finalize :as finalize]
-            [re-frame.machines.lifecycle-fx.join :as join]
-            [re-frame.machines.lifecycle-fx.resolver :as resolver]
-            [re-frame.machines.lifecycle-fx.spawn-error :as spawn-error]
-            [re-frame.machines.lifecycle-fx.validation :as validation]
-            [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.paths :as paths]
-            [re-frame.machines.result :as result
+  (:require [re-frame.cofx :as rf.cofx]
+            [re-frame.error :as rf.error]
+            [re-frame.events :as rf.events]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.machines.classification :as rf.machines.classification]
+            [re-frame.machines.cofx-attach :as rf.machines.cofx-attach]
+            [re-frame.machines.error-emit :as rf.machines.error-emit]
+            [re-frame.machines.internal-events :as rf.machines.internal-events]
+            [re-frame.machines.lifecycle-fx.finalize :as rf.machines.lifecycle-fx.finalize]
+            [re-frame.machines.lifecycle-fx.join :as rf.machines.lifecycle-fx.join]
+            [re-frame.machines.lifecycle-fx.resolver :as rf.machines.lifecycle-fx.resolver]
+            [re-frame.machines.lifecycle-fx.spawn-error :as rf.machines.lifecycle-fx.spawn-error]
+            [re-frame.machines.lifecycle-fx.validation :as rf.machines.lifecycle-fx.validation]
+            [re-frame.machines.parallel :as rf.machines.parallel]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.machines.result :as rf.machines.result
              #?@(:cljs [:include-macros true])]
-            [re-frame.machines.transition :as transition]
-            [re-frame.trace :as trace]))
+            [re-frame.machines.transition :as rf.machines.transition]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -80,7 +80,7 @@
   false)
 
 ;; The reserved creation marker is `:rf.machine/start`. It is defined once in
-;; the leaf engine namespace as `transition/start-marker` so the handler here
+;; the leaf engine namespace as `rf.machines.transition/start-marker` so the handler here
 ;; and the cascade in `parallel` share one source of truth without a require
 ;; cycle. It is a PURE init-kick: `maybe-boot` runs the initial-entry
 ;; cascade, then the handler STOPS — the marker is NEVER fed into `run-step`
@@ -90,7 +90,7 @@
 ;; `build-initial-snapshot` — single source of truth for both the
 ;; singleton-registration path (here) and the spawn path
 ;; (`lifecycle-fx.spawn/install-spawn!`), so both seed `:rf/spawn-counter` and
-;; `:meta` identically. See `parallel/build-initial-snapshot` for the canonical
+;; `:meta` identically. See `rf.machines.parallel/build-initial-snapshot` for the canonical
 ;; 6-step shape.
 
 ;; ---- handler factory ------------------------------------------------------
@@ -116,7 +116,7 @@
     event))
 
 (defn- trace-action-failure!
-  "Emit `:rf.error/machine-action-exception` for a `result/fail` Result's
+  "Emit `:rf.error/machine-action-exception` for a `rf.machines.result/fail` Result's
   `:error` info map. Returns `{}` so the handler short-circuits.
 
   Privacy (AI/MCP egress + logs threat model): the
@@ -139,7 +139,7 @@
   trigger in addition to the observability trace. When the
   THROWING actor is a `:spawn`-spawned child whose spawning parent declares
   `:spawn :on-error`, route the failure to the parent's declarative
-  `:on-error` transition via `spawn-error/dispatch-spawn-error!` — additive to
+  `:on-error` transition via `rf.machines.lifecycle-fx.spawn-error/dispatch-spawn-error!` — additive to
   (not a replacement for) the trace above, which still fires for every action
   exception. `ctx` carries the failing actor's runtime-db and snapshot (whose
   `:data` was stamped with `:rf/parent-id` / `:rf/invoke-id` at spawn time);
@@ -161,7 +161,7 @@
     ;; Fan out both error channels: the always-on
     ;; production-survivable record (surface #4, carrying `:failing-id` +
     ;; `:state`) AND the dev-only trace. Guard throws converge here too
-    ;; (`transition/guard-threw->fail-info` projects the guard-ref onto
+    ;; (`rf.machines.transition/guard-threw->fail-info` projects the guard-ref onto
     ;; `:action-ref`), so this single site fixes BOTH action and guard throws.
     ;; Axis 1 — STRUCTURAL-ONLY always-on record (no prose / no value-bearing
     ;; slots; see error-emit). The throwing action ran in a LIVE actor's
@@ -170,22 +170,22 @@
     ;; names the registered TYPE only). `:failing-id` is the throwing action /
     ;; guard keyword (else the actor instance); `:state` is the active state
     ;; path (the attribution slot `:rf.machine/guard-evaluated` also uses).
-    (machine-error-emit/emit-machine-action-exception!
+    (rf.machines.error-emit/emit-machine-action-exception!
       {:actor-id          machine-id
        :failing-id        failing-id
        :state             state-path
        :frame             frame-id
        :exception         ex
        :recovery          :no-recovery})
-    ;; Axis 2 — dev-only trace. Wrapped in an EXPLICIT `interop/debug-enabled?`
+    ;; Axis 2 — dev-only trace. Wrapped in an EXPLICIT `rf.interop/debug-enabled?`
     ;; call-site gate so Closure constant-folds the whole form — the dev-only
     ;; PROSE `:reason` / `:exception-message` and the value-bearing `:event` /
     ;; `:exception-data` (redacted downstream at the marks chokepoint) all
     ;; included — away under :advanced + goog.DEBUG=false. Leaving the direct
     ;; call ungated beside the live always-on call above would leak the prose.
     ;; `:state-path` is retained for the dev-trace shape.
-    (when interop/debug-enabled?
-      (trace/emit-error! :rf.error/machine-action-exception
+    (when rf.interop/debug-enabled?
+      (rf.trace/emit-error! :rf.error/machine-action-exception
         {:actor-id          machine-id
          :action-id         action-ref
          :state-path        state-path
@@ -208,8 +208,8 @@
     (let [child-data (:data snapshot)
           parent-id  (:rf/parent-id child-data)
           invoke-id  (:rf/invoke-id child-data)]
-      (when (spawn-error/parent-declares-on-error? runtime-db parent-id invoke-id)
-        (spawn-error/dispatch-spawn-error!
+      (when (rf.machines.lifecycle-fx.spawn-error/parent-declares-on-error? runtime-db parent-id invoke-id)
+        (rf.machines.lifecycle-fx.spawn-error/dispatch-spawn-error!
           frame-id parent-id invoke-id
           {:rf.error/id       :rf.error/machine-action-exception
            ;; The failing child is a LIVE actor INSTANCE.
@@ -222,7 +222,7 @@
     {}))
 
 (defn- handle-step-failure!
-  "Route a `result/fail` macrostep to the handler's `{}` short-circuit
+  "Route a `rf.machines.result/fail` macrostep to the handler's `{}` short-circuit
   (atomic rollback — no snapshot write reaches runtime-db) per Spec 005
   §Bounded depth / §Final states §`:on-error`.
 
@@ -240,9 +240,9 @@
   `{}`, so neither writes the post-event snapshot — the pre-event snapshot
   stays committed in runtime-db (the atomic-rollback contract)."
   [ctx event reason r]
-  (if (result/depth-abort? r)
+  (if (rf.machines.result/depth-abort? r)
     {}
-    (trace-action-failure! ctx event reason (result/info r))))
+    (trace-action-failure! ctx event reason (rf.machines.result/info r))))
 
 ;; ---- 4-step pipeline ------------------------------------------------------
 ;;
@@ -302,21 +302,21 @@
 
   For PARALLEL machines this requires EXACTLY the declared region key set
   (no missing region, no extra/stale region) AND every region's path to
-  resolve to a real non-history leaf — `parallel/parallel-state-valid?`
+  resolve to a real non-history leaf — `rf.machines.parallel/parallel-state-valid?`
   (bz0ox.2 / x4s9t.2). A partial map like `{:left :done}` for a 2-region
   machine fails to resolve, so it can never run a partial configuration that
   vacuously fires root `:on-done` / auto-destroy.
 
   For FLAT / COMPOUND machines the path must resolve to a real, OCCUPIABLE
-  leaf — `transition/state-occupiable?` rejects both a missing state AND a
+  leaf — `rf.machines.transition/state-occupiable?` rejects both a missing state AND a
   `:type :history` pseudo-state, which is targetable but never occupied
   (bz0ox.2). A malformed `:state` shape is caught inside `state-occupiable?`
   and surfaces as not-resolving, so the same reset path covers shape-error,
   missing-state, AND occupied-history alike."
   [machine state]
-  (if (parallel/parallel? machine)
-    (parallel/parallel-state-valid? machine state)
-    (transition/state-occupiable? machine state)))
+  (if (rf.machines.parallel/parallel? machine)
+    (rf.machines.parallel/parallel-state-valid? machine state)
+    (rf.machines.transition/state-occupiable? machine state)))
 
 (defn- snapshot-version
   "Read the `:rf/snapshot-version` int from `(get-in m [:meta :rf/snapshot-version])`.
@@ -339,14 +339,14 @@
   [kind machine-id frame-id machine existing-snap base-initial]
   (case kind
     :state-not-in-definition
-    (trace/emit-error! :rf.error/machine-state-not-in-definition
+    (rf.trace/emit-error! :rf.error/machine-state-not-in-definition
                        {:machine-id machine-id
                         :state      (:state existing-snap)
                         :frame      frame-id
                         :recovery   :reset-to-initial})
 
     :version-mismatch
-    (trace/emit-error! :rf.error/machine-snapshot-version-mismatch
+    (rf.trace/emit-error! :rf.error/machine-snapshot-version-mismatch
                        {:machine-id       machine-id
                         :version-recorded (snapshot-version existing-snap)
                         :version-current  (snapshot-version machine)
@@ -426,7 +426,7 @@
         ;; calling machine handler already asserted via
         ;; `require-frame-stamp!`; no `:rf/default` repair here.
         frame-id      frame
-        platform      (or (:platform (frame/frame-meta frame-id)) :client)
+        platform      (or (:platform (rf.frame/frame-meta frame-id)) :client)
         machine       (cond-> (assoc machine
                                      :rf/frame     frame-id
                                      :rf/platform  platform
@@ -449,8 +449,8 @@
                         ;; SAME stamped policy. Stamped only alongside a
                         ;; threaded token so pure-fn callers stay untouched.
                         (some? cofx) (assoc :rf/cofx-mint-policy
-                                            (or mint-policy cofx/default-mint-policy)))
-        path          (paths/snapshot-path machine-id)
+                                            (or mint-policy rf.cofx/default-mint-policy)))
+        path          (rf.machines.paths/snapshot-path machine-id)
         existing-snap (get-in runtime-db path)
         snapshot      (cond
                         (nil? existing-snap)
@@ -494,7 +494,7 @@
   [ctx]
   (cond
     (:existing-snap? ctx)                                  :spawned
-    (= transition/start-marker (first (:inner-event ctx))) :explicit
+    (= rf.machines.transition/start-marker (first (:inner-event ctx))) :explicit
     :else                                                  :lazy))
 
 (defn- ensure-bootstrap-cofx
@@ -505,7 +505,7 @@
   action (or birth-`:always`-reached action) declaring `:rf.cofx/requires` must
   have its facts ensured BEFORE the cascade runs — otherwise it reads an
   unensured token (the bootstrap hole). Computes
-  `cofx-attach/bootstrap-ensure-set-for` and ensures it onto the in-flight
+  `rf.machines.cofx-attach/bootstrap-ensure-set-for` and ensures it onto the in-flight
   `:rf.cofx` record (re-stamped onto the machine def under `:rf/cofx` so
   `callback-ctx` surfaces it to the bootstrap `:entry` callbacks).
 
@@ -521,7 +521,7 @@
             ;; router stamped (`:rf/cofx-mint-policy`), so a `:strict` replay /
             ;; `:test` birth refuses to mint a declared-absent generator-backed
             ;; `:entry` / birth-`:always` fact (surfacing missing-required).
-            augmented (cofx-attach/bootstrap-ensure-cofx
+            augmented (rf.machines.cofx-attach/bootstrap-ensure-cofx
                         machine recorded (:frame-id ctx) (:machine-id ctx)
                         (:rf/cofx-mint-policy machine))]
         (if (identical? augmented recorded)
@@ -550,12 +550,12 @@
   `:rf.machine/started` fires — the snapshot IS the state."
   [ctx]
   (if (:needs-bootstrap? ctx)
-    (let [r (parallel/apply-initial-entry-cascade (:machine ctx) (:snapshot ctx))]
-      (if (result/fail? r)
+    (let [r (rf.machines.parallel/apply-initial-entry-cascade (:machine ctx) (:snapshot ctx))]
+      (if (rf.machines.result/fail? r)
         r
-        (result/with-ok [snap fx] r
+        (rf.machines.result/with-ok [snap fx] r
           (let [booted (dissoc snap :rf/bootstrap-pending?)]
-            (trace/emit! :rf.machine :rf.machine/started
+            (rf.trace/emit! :rf.machine :rf.machine/started
                          {:machine-id (:machine-id ctx)
                           :frame      (:frame-id ctx)
                           :state      (:state booted)
@@ -564,24 +564,24 @@
             ;; Preserve the bootstrap-entry `::cascade` so
             ;; `commit-or-finalize` can prepend the initial-descent `:entry`
             ;; steps when bootstrap and the user event land in the same call.
-            (result/with-cascade
-              (result/ok booted fx)
-              (result/cascade r))))))
-    (result/ok (:snapshot ctx) [])))
+            (rf.machines.result/with-cascade
+              (rf.machines.result/ok booted fx)
+              (rf.machines.result/cascade r))))))
+    (rf.machines.result/ok (:snapshot ctx) [])))
 
 (defn- run-step
   "Step 3 of 4. Run the pure macrostep against the post-boot
   snapshot + the routed inner event. Returns the Result from
-  `parallel/machine-transition` — caller inspects `result/fail?` /
-  `result/ok?` and projects accordingly."
+  `rf.machines.parallel/machine-transition` — caller inspects `rf.machines.result/fail?` /
+  `rf.machines.result/ok?` and projects accordingly."
   [ctx post-boot-snap]
-  (parallel/machine-transition (:machine ctx) post-boot-snap (:inner-event ctx)))
+  (rf.machines.parallel/machine-transition (:machine ctx) post-boot-snap (:inner-event ctx)))
 
 (defn- ensure-ctx-cofx
   "The dispatch-time consumer-attachment
   ensure step, run between `maybe-boot` and `run-step`. Computes the derived
   per-(state × event-type) ensure-set for the POST-BOOT snapshot's active
-  state + the routed inner event (`cofx-attach/ensure-set-for`, incl. the
+  state + the routed inner event (`rf.machines.cofx-attach/ensure-set-for`, incl. the
   `:always` closure) and ensures it onto the in-flight `:rf.cofx` record
   carried under the machine def's `:rf/cofx`, BEFORE transition selection.
 
@@ -608,7 +608,7 @@
             ;; router stamped (`:rf/cofx-mint-policy`); `:strict` replay / `:test`
             ;; refuses to mint a declared-absent generator-backed guard/action
             ;; fact (surfacing missing-required) rather than defaulting `:live`.
-            augmented (cofx-attach/ensure-cofx
+            augmented (rf.machines.cofx-attach/ensure-cofx
                         machine post-boot-snap (:inner-event ctx)
                         recorded (:frame-id ctx) (:machine-id ctx)
                         (:rf/cofx-mint-policy machine))]
@@ -629,9 +629,9 @@
   only when every region's leaf is `:final?`. The pure-transition
   surface stays free of runtime-only metadata."
   [ctx step-result boot-result]
-  (result/with-ok [next-snapshot fx] step-result
+  (rf.machines.result/with-ok [next-snapshot fx] step-result
     (let [{:keys [machine machine-id frame-id runtime-db path snapshot inner-event]} ctx
-          boot-fx   (result/fx boot-result)
+          boot-fx   (rf.machines.result/fx boot-result)
           merged-fx (vec (concat boot-fx fx))
           ;; When this handler call both bootstrapped the
           ;; machine AND processed a user event, the `:before`/`:after`
@@ -639,8 +639,8 @@
           ;; cascade (the initial-descent `:entry` steps) ahead of the
           ;; event-driven cascade, matching the macrostep the trace reports.
           ;; A no-bootstrap call's `boot-result` carries an empty cascade.
-          cascade   (into (vec (result/cascade boot-result))
-                          (result/cascade step-result))
+          cascade   (into (vec (rf.machines.result/cascade boot-result))
+                          (rf.machines.result/cascade step-result))
           ;; A genuine no-op macrostep emits NO
           ;; `:rf.machine/transition`. An unhandled / guard-blocked event
           ;; already signals the benign `:rf.machine.event/unhandled-no-op`
@@ -666,7 +666,7 @@
           ;; `:action` cascade step, so it is never classified a no-op.
           no-op?    (and (= snapshot next-snapshot)
                          (empty? cascade)
-                         (zero? (result/microsteps step-result)))
+                         (zero? (rf.machines.result/microsteps step-result)))
           ;; Per Spec 005 §Final states §Embedded vs top-level — the D7
           ;; reconciliation. Whole-machine finality (route
           ;; to `finalize-machine`: singleton auto-destroy / spawning parent's
@@ -688,9 +688,9 @@
           ;;     too — `:on-done` fires once on entry (the edge guard) yet
           ;;     the machine must not tear down on the later resting macrosteps
           ;;     where the flag is (correctly) absent.
-          finished? (or (and (not (parallel/parallel? machine))
-                             (transition/top-level-final? machine (:state next-snapshot)))
-                        (and (finalize/all-regions-final? machine (:state next-snapshot))
+          finished? (or (and (not (rf.machines.parallel/parallel? machine))
+                             (rf.machines.transition/top-level-final? machine (:state next-snapshot)))
+                        (and (rf.machines.lifecycle-fx.finalize/all-regions-final? machine (:state next-snapshot))
                              (nil? (:on-done machine))))
           ;; Machine snapshots are durable runtime-db state:
           ;; write the new snapshot into the runtime-db partition value;
@@ -731,7 +731,7 @@
       ;; (per Spec 005 §Privacy), so a sensitive machine's cascade
       ;; `:data-delta`s are scrubbed at egress alongside the snapshot slots.
       (when-not no-op?
-        (trace/emit! :rf.machine :rf.machine/transition
+        (rf.trace/emit! :rf.machine :rf.machine/transition
                      {:frame      frame-id
                       ;; The LIVE actor instance address (the
                       ;; event-handler key: a singleton's registration id, or
@@ -741,10 +741,10 @@
                       :event      inner-event
                       :before     snapshot
                       :after      next-snapshot
-                      :microsteps (result/microsteps step-result)
+                      :microsteps (rf.machines.result/microsteps step-result)
                       :cascade    cascade}))
       (when (not= snapshot next-snapshot)
-        (trace/emit! :rf.machine :rf.machine/snapshot-updated
+        (rf.trace/emit! :rf.machine :rf.machine/snapshot-updated
                      {:actor-id   machine-id
                       :path       path
                       :before     snapshot
@@ -761,9 +761,9 @@
       ;; A non-join-child actor (record nil — the common case) rides through
       ;; untouched. The framework-produced path always stamps the coordinate; the
       ;; parent's fold gate then folds only on exact-current equality.
-      (join/stamp-join-completion-fx
+      (rf.machines.lifecycle-fx.join/stamp-join-completion-fx
         (if finished?
-          (finalize/finalize-machine machine machine-id frame-id
+          (rf.machines.lifecycle-fx.finalize/finalize-machine machine machine-id frame-id
                                      new-runtime-db next-snapshot inner-event merged-fx)
           {:rf.db/runtime new-runtime-db
            :fx            merged-fx})
@@ -788,8 +788,8 @@
   internal event); the `internal-event-external?` membership check naturally
   excludes it."
   [machine machine-id frame-id inner-event]
-  (when (internal-events/internal-event-external? machine inner-event)
-    (trace/emit-error! :rf.error/machine-internal-event-external-dispatch
+  (when (rf.machines.internal-events/internal-event-external? machine inner-event)
+    (rf.trace/emit-error! :rf.error/machine-internal-event-external-dispatch
                        {;; The LIVE actor instance address that received the
                         ;; rejected external dispatch (the running INSTANCE —
                         ;; a singleton's registration id, or a spawned actor's
@@ -815,8 +815,8 @@
   dispatched event vector's first element.
 
   The body is decomposed into:
-    - `validation/validate-machine!` — every registration-time check.
-    - `parallel/build-initial-snapshot` — initial-state cascade, `:data` /
+    - `rf.machines.lifecycle-fx.validation/validate-machine!` — every registration-time check.
+    - `rf.machines.parallel/build-initial-snapshot` — initial-state cascade, `:data` /
       `:meta` seeding, `:rf/spawn-counter` seeding, tag union stamping
       (unified with the spawn path).
     - the returned handler fn — frame stamping, intercept-spawn-all-
@@ -837,8 +837,8 @@
   ;; bare-entry-map-with-requires-no-`:fn` as the generic
   ;; `:rf.error/machine-unresolved-guard`. The indexed spec carries
   ;; `:rf/cofx-ensure-index` for the dispatch-time `ensure-ctx-cofx` to read.
-  (let [machine (cofx-attach/index-ensure-sets machine)]
-  (validation/validate-machine! machine)
+  (let [machine (rf.machines.cofx-attach/index-ensure-sets machine)]
+  (rf.machines.lifecycle-fx.validation/validate-machine! machine)
   ;; Fail-loud guard. A `[:schemas :data]`-bearing spec MUST be
   ;; registered through the single home (`reg-machine` / `reg-machine*` / the
   ;; event-`:schema` arity), which is the ONLY place the `:rf/machine?` /
@@ -855,7 +855,7 @@
   ;; egress — schema is validation-only.)
   (when (and (get-in machine [:schemas :data])
              (not *in-registration-home?*))
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/machine-schema-requires-reg-machine
       'rf-machines/make-machine-handler
       (str "make-machine-handler was handed a machine spec carrying a "
@@ -881,12 +881,12 @@
   ;; to the handler keeps registration tolerant of such specs.
   ;;
   ;; `machine` already carries the consumer-attachment index
-  ;; (`:rf/cofx-ensure-index`, stamped above by `cofx-attach/index-ensure-sets`
+  ;; (`:rf/cofx-ensure-index`, stamped above by `rf.machines.cofx-attach/index-ensure-sets`
   ;; ahead of `validate-machine!`), so the handler closure captures it and
   ;; `prepare-machine-ctx` threads it onto the machine def — the dispatch-time
   ;; `ensure-ctx-cofx` reads it to derive the per-(state × event-type)
   ;; ensure-set (incl. the `:always` closure).
-  (let [base-initial (delay (parallel/build-initial-snapshot
+  (let [base-initial (delay (rf.machines.parallel/build-initial-snapshot
                               machine {:bootstrap-pending? false}))]
     (fn [{:keys [db] frame :rf.frame/id rt :rf.db/runtime
           cofx :rf.cofx mint-policy :rf.cofx/mint-policy :as _cofx} event]
@@ -895,13 +895,13 @@
       ;; `:rf.frame/id` (the HELD stamp). A nil stamp is an invariant
       ;; failure — surface `:rf.error/no-frame-context`, never repair to a
       ;; synthesised `:rf/default`.
-      (frame/require-frame-stamp!
+      (rf.frame/require-frame-stamp!
         frame :rf.machine/event-received
         {:where 'rf-machines/make-machine-handler :event-id (first event)})
       ;; Per Spec 009 §:op-type vocabulary: `:rf.machine/event-received`
       ;; fires at the top of the handler so consumers see the inbound
       ;; event before any state derivation.
-      (trace/emit! :rf.machine :rf.machine/event-received
+      (rf.trace/emit! :rf.machine :rf.machine/event-received
                    {:machine-id (first event)
                     :event      event
                     :frame      frame})
@@ -912,7 +912,7 @@
       ;; and returns its snapshot write under `:rf.db/runtime`.
       (let [runtime-db  (or rt {})
             ctx         (prepare-machine-ctx db runtime-db frame cofx mint-policy event machine base-initial)
-            intercepted (join/intercept-spawn-all-event
+            intercepted (rf.machines.lifecycle-fx.join/intercept-spawn-all-event
                           (:machine ctx) runtime-db (:path ctx) (:snapshot ctx)
                           (:machine-id ctx) (:inner-event ctx))]
         (if intercepted
@@ -936,13 +936,13 @@
           ;; is written back into the record the epoch captures.
           (let [ctx         (ensure-bootstrap-cofx ctx)
                 boot-result (maybe-boot ctx)]
-            (if (result/fail? boot-result)
+            (if (rf.machines.result/fail? boot-result)
               ;; Route both a thrown initial-entry action AND a
               ;; birth-time bounded-depth abort (a born-state `:always` / raise
               ;; runaway) through the shared failure handler: a depth-abort
               ;; skips the misleading action-exception re-emit (its precise
               ;; category fired in-engine) while both atomically roll back.
-              (handle-step-failure! ctx [transition/start-marker]
+              (handle-step-failure! ctx [rf.machines.transition/start-marker]
                                     "Machine initial-entry action threw."
                                     boot-result)
               (let [;; Singleton first-boot: a singleton's actor-id IS its
@@ -987,15 +987,15 @@
                 ;; onto B or bump B's commit epoch. nil token (no event owner)
                 ;; falls back to the historical bare write.
                 (when boot?
-                  (classification/lower-at-spawn! (:frame-id ctx) (:machine-id ctx)
+                  (rf.machines.classification/lower-at-spawn! (:frame-id ctx) (:machine-id ctx)
                                                   (:machine ctx)
-                                                  (frame/current-event-owner-token)))
-              (result/with-ok [post-boot-snap boot-fx] boot-result
+                                                  (rf.frame/current-event-owner-token)))
+              (rf.machines.result/with-ok [post-boot-snap boot-fx] boot-result
                 ;; PURE init-kick: when the routed inner event IS the
                 ;; reserved `:rf.machine/start` marker, `maybe-boot` has
                 ;; already run the INITIAL MACROSTEP — the initial-entry
                 ;; cascade AND the birth-time `:always` + raise settle,
-                ;; via `parallel/apply-initial-entry-cascade`
+                ;; via `rf.machines.parallel/apply-initial-entry-cascade`
                 ;; — and emitted `:rf.machine/started`. STOP here — never
                 ;; feed the synthetic marker into `run-step` as a trigger.
                 ;; This avoids a misleading `before == after` self-
@@ -1022,13 +1022,13 @@
                 ;; birth macrostep is the entry edge — and keeps the machine
                 ;; alive), and an embedded compound born final already raised
                 ;; `[:rf.machine/done …]` through the birth settle's queue.
-                (if (= transition/start-marker (first (:inner-event ctx)))
+                (if (= rf.machines.transition/start-marker (first (:inner-event ctx)))
                   (let [m (:machine ctx)]
-                    (if (or (and (not (parallel/parallel? m))
-                                 (transition/top-level-final? m (:state post-boot-snap)))
-                            (and (finalize/all-regions-final? m (:state post-boot-snap))
+                    (if (or (and (not (rf.machines.parallel/parallel? m))
+                                 (rf.machines.transition/top-level-final? m (:state post-boot-snap)))
+                            (and (rf.machines.lifecycle-fx.finalize/all-regions-final? m (:state post-boot-snap))
                                  (nil? (:on-done m))))
-                      (finalize/finalize-machine m (:machine-id ctx) (:frame-id ctx)
+                      (rf.machines.lifecycle-fx.finalize/finalize-machine m (:machine-id ctx) (:frame-id ctx)
                                                  (assoc-in runtime-db (:path ctx) post-boot-snap)
                                                  post-boot-snap
                                                  (:inner-event ctx)
@@ -1050,7 +1050,7 @@
                   ;; unchanged) and `ctx` is untouched.
                   (let [ctx (ensure-ctx-cofx ctx post-boot-snap)
                         step-result (run-step ctx post-boot-snap)]
-                    (if (result/fail? step-result)
+                    (if (rf.machines.result/fail? step-result)
                       ;; Route both a thrown transition action AND
                       ;; a bounded-depth abort (the runaway `:always` / `:raise`
                       ;; cycle, XState-v5-throws case) through the shared
@@ -1105,7 +1105,7 @@
 ;; and warn. A runtime-built spec structurally CANNOT carry author coords, so
 ;; this is a WARNING (advisory, recoverable), never an error — the message
 ;; tells a runtime-built author they may ignore it. Dev-only (DCE'd in
-;; production via the call-site `interop/debug-enabled?` gate), once per id.
+;; production via the call-site `rf.interop/debug-enabled?` gate), once per id.
 
 (defonce ^:private source-unstamped-warned
   ;; The set of machine-ids already advised (once-per-id). Reset by
@@ -1136,14 +1136,14 @@
 (defn- maybe-warn-source-unstamped!
   "Emit `:rf.warning/machine-source-unstamped` once per `machine-id` when the
   spec arriving at the registration home carries no per-element source
-  metadata. Callers MUST wrap the invocation in `(when interop/debug-enabled?
+  metadata. Callers MUST wrap the invocation in `(when rf.interop/debug-enabled?
   …)` so the production bundle DCEs the consult + emit branch (Spec 009
   §Production builds), mirroring the schema-walker-opaque advisory."
   [machine-id machine]
   (when (and (not (spec-carries-source-metadata? machine))
              (not (contains? @source-unstamped-warned machine-id)))
     (swap! source-unstamped-warned conj machine-id)
-    (trace/emit! :warning :rf.warning/machine-source-unstamped
+    (rf.trace/emit! :warning :rf.warning/machine-source-unstamped
                  {:machine-id machine-id
                   :recovery   :warned-and-proceeded
                   :reason
@@ -1200,7 +1200,7 @@
   ;; diagnostic. Mirrors reg-route's `route-bad-metadata` non-map guard +
   ;; reg-resource/reg-mutation's metadata-slot map gate.
   (when (and (some? opts) (not (map? opts)))
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/invalid-machine-opts
       'rf-machines/reg-machine*
       (str "reg-machine " machine-id "'s opts (the MIDDLE slot) must be a "
@@ -1214,7 +1214,7 @@
                   :value      opts}}))
   (let [opts (or opts {})]
    (when (or (contains? opts :rf/machine?) (contains? opts :rf/machine))
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/machine-reserved-meta-in-opts
       'rf-machines/reg-machine*
       (str "reg-machine opts must not carry the "
@@ -1228,19 +1228,19 @@
    ;; entry). The declaration travels with the machine def and is lowered
    ;; per actor instance at spawn / first-boot — so a shape fault must be
    ;; caught at definition, like every other registration-shape fault.
-   (classification/validate-machine-classification! machine-id machine)
+   (rf.machines.classification/validate-machine-classification! machine-id machine)
    ;; Dev-only source-metadata advisory (once per id). Checked on the RAW
    ;; incoming spec — a bare-def symbol / runtime-built spec arrives here
    ;; source-blind, an inline literal / `defmachine` value source-bearing.
-   ;; Call-site `interop/debug-enabled?`-gated so production DCEs it.
-   (when interop/debug-enabled?
+   ;; Call-site `rf.interop/debug-enabled?`-gated so production DCEs it.
+   (when rf.interop/debug-enabled?
      (maybe-warn-source-unstamped! machine-id machine))
    ;; Install a per-machine region-machine cache before
    ;; the machine value is threaded through the handler closure and
    ;; published to the registrar. Re-registration replaces the machine
    ;; map and its attached cache atom, so no separate invalidation step
    ;; is needed.
-   (let [machine    (parallel/install-region-cache machine)
+   (let [machine    (rf.machines.parallel/install-region-cache machine)
         ;; The home is the legitimate `make-machine-handler` site for a
         ;; `[:schemas :data]`-bearing spec — bind the flag so the fail-loud
         ;; guard passes (the guard exists to catch the bare direct path, not us).
@@ -1251,7 +1251,7 @@
         meta       (assoc opts
                           :rf/machine? true
                           :rf/machine  machine)]
-    (events/reg-event machine-id meta handler-fn)
+    (rf.events/reg-event machine-id meta handler-fn)
     ;; The `[:schemas :data]` schema VALIDATES `:data` (via the
     ;; `:where :machine-data` post-commit walker, resolved through the
     ;; `:rf/machine` meta stamped above); its per-slot props do not classify the
@@ -1262,10 +1262,10 @@
     ;; lints (consume-without-declaring + ambient-durable). Run here in the
     ;; home (with the machine-id known) over a locally-indexed copy so the
     ;; lints read the parsed diets without altering the stored `:rf/machine`
-    ;; meta shape. DCE'd in production (`interop/debug-enabled?`-gated inside
+    ;; meta shape. DCE'd in production (`rf.interop/debug-enabled?`-gated inside
     ;; `lint-machine!`). Idempotent — `index-ensure-sets` is pure.
-    (cofx-attach/lint-machine! machine-id (cofx-attach/index-ensure-sets machine))
-    (trace/emit! :rf.machine.lifecycle/created :rf.machine.lifecycle/created
+    (rf.machines.cofx-attach/lint-machine! machine-id (rf.machines.cofx-attach/index-ensure-sets machine))
+    (rf.trace/emit! :rf.machine.lifecycle/created :rf.machine.lifecycle/created
                  {:machine-id machine-id
                   :initial    (:initial machine)})
     machine-id)))
@@ -1325,7 +1325,7 @@
 
   The region-machine cache is installed (mirroring `reg-machine*`) so
   parallel-region transitions resolve, then `make-machine-handler` builds
-  the handler-fn and `events/event-handler-meta` wraps it into the same
+  the handler-fn and `rf.events/event-handler-meta` wraps it into the same
   `{:rf/machine? true :rf/machine <spec> :handler-fn …
   :interceptors […]}` shape the registrar holds for a registered
   machine. `process-event*` runs the returned meta unchanged — the
@@ -1333,14 +1333,14 @@
   first element, so a single materialised handler serves every instance
   of the type."
   [spec]
-  (let [machine    (parallel/install-region-cache spec)
+  (let [machine    (rf.machines.parallel/install-region-cache spec)
         ;; This materialisation seam stamps the `:rf/machine?` /
         ;; `:rf/machine` meta below, so it is a legitimate `make-machine-handler`
         ;; home for a `[:schemas :data]`-bearing spec — bind the flag so the
         ;; fail-loud guard passes.
         handler-fn (binding [*in-registration-home?* true]
                      (make-machine-handler machine))]
-    (events/event-handler-meta {:rf/machine? true :rf/machine machine}
+    (rf.events/event-handler-meta {:rf/machine? true :rf/machine machine}
                                []
                                handler-fn)))
 
@@ -1355,7 +1355,7 @@
 
   Resolution is purely runtime-db-derived: read the actor's live
   snapshot from the frame's runtime-db, resolve its TYPE spec via
-  `resolver/spec-from-snapshot`, and materialise the handler-meta from
+  `rf.machines.lifecycle-fx.resolver/spec-from-snapshot`, and materialise the handler-meta from
   the spec. No live snapshot (or no resolvable type) → nil: the actor
   isn't alive in this frame value, which is the correct
   `:no-such-handler` — and exactly the property `restore-epoch!` reverts.
@@ -1382,8 +1382,8 @@
         ;; directly, no `:rf/default` repair. (A nil frame-id yields nil
         ;; runtime-db → the genuine `:no-such-handler`, never a read against
         ;; a synthesised default.)
-        runtime-db (frame/frame-runtime-db-value frame-id)
-        snapshot   (when runtime-db (get-in runtime-db (paths/snapshot-path actor-id)))
-        spec       (when snapshot (resolver/spec-from-snapshot snapshot))]
+        runtime-db (rf.frame/frame-runtime-db-value frame-id)
+        snapshot   (when runtime-db (get-in runtime-db (rf.machines.paths/snapshot-path actor-id)))
+        spec       (when snapshot (rf.machines.lifecycle-fx.resolver/spec-from-snapshot snapshot))]
     (when spec
       (handler-meta-for spec))))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/resolver.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/resolver.cljc
@@ -37,10 +37,10 @@
   `make-machine-handler`) lives in
   `lifecycle-fx.registration/resolve-actor-handler-meta`, the late-bound
   `:machines/resolve-actor-handler-meta` hook body."
-  (:require [re-frame.machines.grammar :as grammar]
-            [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.paths :as paths]
-            [re-frame.registrar :as registrar]))
+  (:require [re-frame.machines.grammar :as rf.machines.grammar]
+            [re-frame.machines.parallel :as rf.machines.parallel]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.registrar :as rf.registrar]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -51,12 +51,12 @@
   a registered machine (a plain event handler, or no entry at all).
 
   This is the canonical one-liner over the
-  `(let [m (registrar/lookup :event id)] (when (:rf/machine? m) (:rf/machine m)))`
+  `(let [m (rf.registrar/lookup :event id)] (when (:rf/machine? m) (:rf/machine m)))`
   idiom that several lifecycle-fx + querying call sites repeat — the
   registered-TYPE leg of spawned-actor / parent / singleton spec
   resolution."
   [machine-id]
-  (let [m (registrar/lookup :event machine-id)]
+  (let [m (rf.registrar/lookup :event machine-id)]
     (when (:rf/machine? m)
       (:rf/machine m))))
 
@@ -110,14 +110,14 @@
   no snapshot, or its snapshot carries no resolvable `:rf/machine-type`."
   [db actor-id]
   (boolean
-    (some-> (get-in db (paths/snapshot-path actor-id))
+    (some-> (get-in db (rf.machines.paths/snapshot-path actor-id))
             (spec-from-snapshot))))
 
 (defn spawn-spec-at
   "Walk `parent-spec`'s state tree to the `:spawn`-bearing node at `invoke-id`
   (the absolute prefix-path stamped at spawn time) and return that node's
   `:spawn` map, resolving flat AND region-prefixed invoke paths through
-  `grammar/node-at`. For a parallel-region parent the first element of
+  `rf.machines.grammar/node-at`. For a parallel-region parent the first element of
   `invoke-id` is the region name; strip it and descend into that region's
   body. Returns nil if `parent-spec` is absent, `invoke-id` is not a
   non-empty vector, the path doesn't resolve, or the node declares no
@@ -129,8 +129,8 @@
   [parent-spec invoke-id]
   (when (and parent-spec (vector? invoke-id) (seq invoke-id))
     (let [[head & tail] invoke-id
-          [tree path]   (if (and (parallel/parallel? parent-spec)
+          [tree path]   (if (and (rf.machines.parallel/parallel? parent-spec)
                                  (contains? (:regions parent-spec) head))
                           [(get-in parent-spec [:regions head]) (vec tail)]
                           [parent-spec invoke-id])]
-      (:spawn (grammar/node-at (:states tree) path)))))
+      (:spawn (rf.machines.grammar/node-at (:states tree) path)))))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/resource_release.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/resource_release.cljc
@@ -58,9 +58,9 @@
   Together these cover EVERY destroy cause — explicit `:rf.machine/destroy`,
   declarative-`:spawn` exit cascade, `:spawn-all` per-child teardown, the
   frame-destroy cascade, AND the `:final?`-state auto-destroy."
-  (:require [re-frame.fx :as fx]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]))
+  (:require [re-frame.fx :as rf.fx]
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -69,7 +69,7 @@
   is registered (i.e. resources is loaded into this runtime). The guard that
   keeps a no-resources app's actor-destroy a clean no-op."
   []
-  (some? (registrar/lookup :event :rf.resource/release-owner)))
+  (some? (rf.registrar/lookup :event :rf.resource/release-owner)))
 
 (defn release-fx-entry
   "The `[:dispatch [:rf.resource/release-owner {:owner [:machine actor-id]}]]`
@@ -90,6 +90,6 @@
   behave consistently with the destroy-time `:exit`-cascade fx fire."
   [frame-id actor-id]
   (when-let [entry (release-fx-entry actor-id)]
-    (let [platform (or (:platform (frame/frame-meta frame-id)) :client)]
-      (fx/do-fx frame-id [entry] platform)))
+    (let [platform (or (:platform (rf.frame/frame-meta frame-id)) :client)]
+      (rf.fx/do-fx frame-id [entry] platform)))
   nil)

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -21,18 +21,18 @@
   emits `[:rf.machine/spawn-all-init args]` alongside per-child
   `:rf.machine/spawn` fxs on entry to a `:spawn-all`-bearing state to
   seed the join state at `[:rf.runtime/machines :spawned <parent> <invoke-id>]`."
-  (:require [re-frame.error :as error]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.machines.classification :as classification]
-            [re-frame.machines.data-validation :as data-validation]
-            [re-frame.machines.lifecycle-fx.resolver :as resolver]
-            [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.paths :as paths]
-            [re-frame.machines.reply :as m-reply]
-            [re-frame.machines.spawn-order :as spawn-order]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.error :as rf.error]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.machines.classification :as rf.machines.classification]
+            [re-frame.machines.data-validation :as rf.machines.data-validation]
+            [re-frame.machines.lifecycle-fx.resolver :as rf.machines.lifecycle-fx.resolver]
+            [re-frame.machines.parallel :as rf.machines.parallel]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.machines.reply :as rf.machines.reply]
+            [re-frame.machines.spawn-order :as rf.machines.spawn-order]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -90,7 +90,7 @@
         defn       (:definition args)]
     (cond
       defn        defn
-      machine-id  (resolver/spec-from-registry machine-id))))
+      machine-id  (rf.machines.lifecycle-fx.resolver/spec-from-registry machine-id))))
 
 (defn- unregistered-spawn-type?
   "A `:spawn` / `:spawn-all` per-child whose `:machine-id` names an
@@ -119,7 +119,7 @@
   `goog.DEBUG=false` build must still see it — so it rides the always-on
   `:error-emit/dispatch-error-record` late-bind hook (the non-event sibling of
   `dispatch-on-error!`, shared with the frame-teardown report). A dev error
-  trace (`trace/emit-error!`, DCE'd in production) ALSO fires for the
+  trace (`rf.trace/emit-error!`, DCE'd in production) ALSO fires for the
   in-process tooling surface — the same always-on-plus-dev-trace shape
   `:rf.error/write-after-destroy` / `:rf.error/on-destroy-handler-exception`
   carry.
@@ -130,7 +130,7 @@
   and this record is production-surviving and NOT privacy-gated. `:reason`
   names the id and the fix without echoing any value-bearing slot."
   [frame-id machine-id]
-  (let [reason (error/human-message
+  (let [reason (rf.error/human-message
                  :rf.error/machine-spawn-unregistered-type
                  (str "Cannot spawn machine " machine-id
                       ": no machine TYPE is registered under that :machine-id "
@@ -140,15 +140,15 @@
     ;; Always-on (surface #4): the non-event union record. Structural-only —
     ;; no spawn args. Late-bound: machines ships above core's require graph;
     ;; the hook is bound once `re-frame.error-emit` loads.
-    (when-let [dispatch-record! (late-bind/get-fn :error-emit/dispatch-error-record)]
+    (when-let [dispatch-record! (rf.late-bind/get-fn :error-emit/dispatch-error-record)]
       (dispatch-record! {:error      :rf.error/machine-spawn-unregistered-type
                          :frame      frame-id
                          :machine-id machine-id
                          :recovery   :no-recovery
                          :reason     reason
-                         :time       (interop/now-ms)}))
+                         :time       (rf.interop/now-ms)}))
     ;; Dev trace (DCE'd in production) for the in-process tooling surface.
-    (trace/emit-error! :rf.error/machine-spawn-unregistered-type
+    (rf.trace/emit-error! :rf.error/machine-spawn-unregistered-type
                        {:machine-id machine-id
                         :failing-id machine-id
                         :frame      frame-id
@@ -195,7 +195,7 @@
   was resolved and no `[:schemas :data]` validator ran, so there is no
   unregistered-type or schema-validation reject to order against."
   [frame-id parent-id invoke-id collisions]
-  (let [reason (error/human-message
+  (let [reason (rf.error/human-message
                  :rf.error/machine-spawn-all-duplicate-id
                  (str "Cannot start :spawn-all invoke " invoke-id " on " parent-id
                       ": distinct logical children resolve to the SAME actor "
@@ -205,7 +205,7 @@
                       "Give each colliding child a distinct :fixed-actor-id, or "
                       "drop the fixed id so the runtime allocates a unique "
                       "generated address."))]
-    (trace/emit-error! :rf.error/machine-spawn-all-duplicate-id
+    (rf.trace/emit-error! :rf.error/machine-spawn-all-duplicate-id
                        {:parent-id  parent-id
                         :invoke-id  invoke-id
                         :collisions collisions
@@ -245,8 +245,8 @@
   the preflight already fanned (rf2-smya7a)."
   [frame-id args]
   (when-let [invoke-id (:rf/spawn-all-id args)]
-    (let [slot (get-in (frame/frame-runtime-db-value frame-id)
-                       (paths/spawned-path (:rf/parent-id args) invoke-id))]
+    (let [slot (get-in (rf.frame/frame-runtime-db-value frame-id)
+                       (rf.machines.paths/spawned-path (:rf/parent-id args) invoke-id))]
       (boolean (and (map? slot) (:rf/spawn-all-rejected? slot))))))
 
 (defn- machine-type-ref
@@ -312,7 +312,7 @@
      ;; public/pure spawn effect shape remains unchanged.
      :work-generation (if (contains? args :fixed-actor-id)
                         (:rf/attempt join-state)
-                        (m-reply/actor-generation spawned-id))}))
+                        (rf.machines.reply/actor-generation spawned-id))}))
 
 (defn- join-child-record
   "Build the PRIVATE join-membership record the runtime stamps into a
@@ -341,7 +341,7 @@
   [runtime-db args spawned-id]
   (when-let [invoke-id (:rf/spawn-all-id args)]
     (join-child-record-from-state
-      (get-in runtime-db (paths/spawned-path (:rf/parent-id args) invoke-id))
+      (get-in runtime-db (rf.machines.paths/spawned-path (:rf/parent-id args) invoke-id))
       args spawned-id)))
 
 (defn- stamp-spawn-spec
@@ -383,7 +383,7 @@
   (stamp-spawn-spec (resolve-spawn-machine args) args spawned-id join-child))
 
 ;; The spawned actor's initial snapshot is built by
-;; `parallel/build-initial-snapshot` — the single source of truth shared
+;; `rf.machines.parallel/build-initial-snapshot` — the single source of truth shared
 ;; with the singleton-registration path
 ;; (`lifecycle-fx.registration/make-machine-handler`); the shared builder
 ;; seeds `:rf/spawn-counter` and `:meta` consistently across both paths.
@@ -414,7 +414,7 @@
   spawn; `true` only on a genuine schema violation."
   [spec spawned-id initial-snap continue?]
   (and (some? spec)
-       (false? (data-validation/validate-spawn-data!
+       (false? (rf.machines.data-validation/validate-spawn-data!
                  spawned-id spec initial-snap continue?))))
 
 (defn- install-spawn!
@@ -431,7 +431,7 @@
   runs NO post-install tail (classification / spawn-order /
   `:rf.machine.lifecycle/spawned` / `:start`) unless install COMMITTED and
   the exact owner is STILL current — a bare-id `swap-runtime-db!` /
-  `spawn-order/record!` otherwise resolves to the CURRENT incarnation B.
+  `rf.machines.spawn-order/record!` otherwise resolves to the CURRENT incarnation B.
 
   There is NO per-instance handler registration — the
   actor's liveness IS the presence of this snapshot in the (revertible)
@@ -475,9 +475,9 @@
   decide against the registrar as it stands at COMMIT."
   [frame-id rt-after-alloc spec spawned-id initial-snap
    {:keys [system-id parent-id invoke-id track? type-ref-fn continue? owner-token]}]
-  (let [existing (when system-id (get-in rt-after-alloc (paths/system-id-path system-id)))]
+  (let [existing (when system-id (get-in rt-after-alloc (rf.machines.paths/system-id-path system-id)))]
     (when (and system-id existing (not= existing spawned-id))
-      (trace/emit-error! :rf.error/system-id-collision
+      (rf.trace/emit-error! :rf.error/system-id-collision
                          {:frame             frame-id
                           :system-id         system-id
                           :existing-machine  existing
@@ -557,7 +557,7 @@
                            (and spec type-ref) (assoc :rf/machine-type type-ref))
             install-fn (fn [_rt]
                          (cond-> rt-after-alloc
-                           spec      (assoc-in (paths/snapshot-path spawned-id) initial-snap)
+                           spec      (assoc-in (rf.machines.paths/snapshot-path spawned-id) initial-snap)
                            ;; rf2-1vlyg — append the actor to the DURABLE
                            ;; spawn-order vector in the SAME swap that lands its
                            ;; snapshot, so the frame's total creation order is
@@ -566,20 +566,20 @@
                            ;; of different machine types and is absent entirely
                            ;; on a `:fixed-actor-id`, so frame destroy has no
                            ;; other durable fact to read; the transient
-                           ;; `spawn-order/record!` below is a cache that any
+                           ;; `rf.machines.spawn-order/record!` below is a cache that any
                            ;; restore / hydration / `replace-runtime-db!` wipes.
                            ;; Gated on the same `spec` as the snapshot assoc: the
                            ;; order tracks exactly the actors that have snapshots.
-                           spec      (spawn-order/record-in-runtime-db spawned-id)
-                           system-id (assoc-in (paths/system-id-path system-id) spawned-id)
-                           track?    (assoc-in (paths/spawned-path parent-id invoke-id) spawned-id)))
+                           spec      (rf.machines.spawn-order/record-in-runtime-db spawned-id)
+                           system-id (assoc-in (rf.machines.paths/system-id-path system-id) spawned-id)
+                           track?    (assoc-in (rf.machines.paths/spawned-path parent-id invoke-id) spawned-id)))
             written    (if owner-token
-                         (frame/swap-runtime-db-exact! frame-id owner-token install-fn)
-                         (frame/swap-runtime-db! frame-id install-fn))]
+                         (rf.frame/swap-runtime-db-exact! frame-id owner-token install-fn)
+                         (rf.frame/swap-runtime-db! frame-id install-fn))]
         (if (some? written)
           (do
             (when system-id
-              (trace/emit! :rf.machine :rf.machine/system-id-bound
+              (rf.trace/emit! :rf.machine :rf.machine/system-id-bound
                            {:frame      frame-id
                             :system-id  system-id
                             ;; The live actor INSTANCE address (the spawned id),
@@ -641,7 +641,7 @@
   entry is always present by the time this child's spawn fx runs."
   [runtime-db args spawned-id]
   (when-let [invoke-id (:rf/spawn-all-id args)]
-    (get-in runtime-db (conj (paths/spawned-path (:rf/parent-id args) invoke-id)
+    (get-in runtime-db (conj (rf.machines.paths/spawned-path (:rf/parent-id args) invoke-id)
                              prepared-children-key spawned-id))))
 
 (defn- drop-prepared-entry
@@ -652,7 +652,7 @@
   drop rides the SAME runtime-db swap that lands the snapshot; a no-op if the
   join slot is not a live join (belt-and-braces)."
   [runtime-db args spawned-id]
-  (update-in runtime-db (paths/spawned-path (:rf/parent-id args) (:rf/spawn-all-id args))
+  (update-in runtime-db (rf.machines.paths/spawned-path (:rf/parent-id args) (:rf/spawn-all-id args))
              (fn [join-state]
                (if (map? join-state)
                  (let [remaining (dissoc (get join-state prepared-children-key) spawned-id)]
@@ -683,7 +683,7 @@
   entry): both keep the child-local `unregistered-spawn-type?` fail-closed gate."
   [frame-id args]
   (some? (spawn-all-prepared-child
-           (frame/frame-runtime-db-value frame-id)
+           (rf.frame/frame-runtime-db-value frame-id)
            args
            (pre-allocated-actor-id args))))
 
@@ -749,7 +749,7 @@
       ;; The registrar still holds the prepared definition — keep the revertible
       ;; keyword so the child tracks its TYPE like every other spawned actor.
       (and (some? machine-id)
-           (= type-spec (resolver/spec-from-registry machine-id)))
+           (= type-spec (rf.machines.lifecycle-fx.resolver/spec-from-registry machine-id)))
       machine-id
 
       ;; Diverged (unregistered, or replaced by another spec) — or an inline
@@ -809,7 +809,7 @@
         ;; frame as `:frame` (the HELD stamp). A nil stamp is an invariant
         ;; failure — surface `:rf.error/no-frame-context`, never repair to
         ;; a synthesised `:rf/default`.
-        frame-id   (frame/require-frame-stamp!
+        frame-id   (rf.frame/require-frame-stamp!
                      frame-id :rf.machine/spawn
                      {:where 'rf.machine/spawn :event-id (:system-id args)})]
     ;; Step 0 — the two fail-closed gates, INVOKE-level before CHILD-local.
@@ -882,7 +882,7 @@
         ;; `swap-runtime-db!` would otherwise resolve to B). Built ONCE here and
         ;; threaded into `spawn-rejected?` so the callback and the cascade fence
         ;; against the SAME token.
-        continue?  (data-validation/owner-continuation frame-id)
+        continue?  (rf.machines.data-validation/owner-continuation frame-id)
         ;; rf2-4ipqe4 — the RAW exact owner token (`continue?` closes over it),
         ;; threaded into `install-spawn!` so the snapshot / system-id / spawn-slot
         ;; install rides `swap-runtime-db-exact!`: a synchronous container watch
@@ -893,7 +893,7 @@
         ;; non-router pure-fn / conformance caller (no event owner) — the install
         ;; falls back to the historical bare-id write and that path stays
         ;; unaffected, symmetric with `continue?`'s `(constantly true)`.
-        owner-token (frame/current-event-owner-token)
+        owner-token (rf.frame/current-event-owner-token)
         ;; Prefer the pre-allocated id (declarative :spawn
         ;; routes through the transition reducer which bumps the parent
         ;; snapshot's `:rf/spawn-counter`). Hand-emitted spawn fxs carry
@@ -915,10 +915,10 @@
         ;; the same id the snapshot install / registry bind will use. The
         ;; runtime-db swap re-applies the increment to the (potentially-
         ;; newer) runtime-db at write time — for the JVM atom container the
-        ;; read is consistent because `frame/swap-runtime-db!` is the only
+        ;; read is consistent because `rf.frame/swap-runtime-db!` is the only
         ;; writer during fx drain (Spec 002 §Single drainer per frame).
         ;; Machine snapshots are durable runtime-db state.
-        old-rt     (frame/frame-runtime-db-value frame-id)
+        old-rt     (rf.frame/frame-runtime-db-value frame-id)
         machine-id-for-alloc (or (:id-prefix args) (:machine-id args))
         [rt-after-alloc-raw spawned-id]
         (cond
@@ -992,7 +992,7 @@
         initial-snap (if prepared
                        (:snap prepared)
                        (when spec''
-                         (parallel/build-initial-snapshot
+                         (rf.machines.parallel/build-initial-snapshot
                            spec'' {:bootstrap-pending? true})))
         ;; Decide schema rejection BEFORE the trace and the
         ;; install. Gating both on `(not rejected?)` makes a rejected spawn
@@ -1029,7 +1029,7 @@
     ;; A destroyed-frame or owner-lost spawn is a clean no-op — no trace, no
     ;; install, no dispatch — symmetric with the schema-reject path's atomicity.
     (when (and (not rejected?) old-rt (continue?))
-      (trace/emit! :rf.machine :rf.machine.spawn/spawned
+      (rf.trace/emit! :rf.machine :rf.machine.spawn/spawned
                    {:frame      frame-id
                     ;; `:machine-id` is the spec-time registered TYPE (xor
                     ;; an inline `:definition`); `:spawned-id` is the live
@@ -1084,7 +1084,7 @@
         ;; per-instance classification, the spawn-order record, and the
         ;; `:rf.machine.lifecycle/spawned` trace — ONLY when install COMMITTED
         ;; AND the exact owner is STILL current after those callbacks. Otherwise
-        ;; the bare-id `spawn-order/record!` / classification writes + the
+        ;; the bare-id `rf.machines.spawn-order/record!` / classification writes + the
         ;; lifecycle-spawned trace would commit into B's name. The initial
         ;; `(continue?)` gate at the cascade top fenced only the earlier
         ;; `:rf.machine.spawn/spawned` trace-listener callback; this fences the
@@ -1107,12 +1107,12 @@
         ;; declarations onto B's snapshot path or bump B's commit epoch (the
         ;; install itself is already exact; this closes the sibling classification
         ;; write the earlier fences ran ahead of).
-        (classification/lower-at-spawn! frame-id spawned-id spec'' owner-token)
+        (rf.machines.classification/lower-at-spawn! frame-id spawned-id spec'' owner-token)
         ;; rf2-rbxdxa — `lower-at-spawn!` writes through the EXACT elision swap, a
         ;; container-write boundary: a synchronous watch can destroy A / publish
         ;; same-id B DURING the classification lowering. Recheck `(continue?)`
         ;; AFTER it before the spawn-order record / lifecycle trace / `:start`
-        ;; dispatch tail — otherwise the bare-id `spawn-order/record!` records A's
+        ;; dispatch tail — otherwise the bare-id `rf.machines.spawn-order/record!` records A's
         ;; ghost child into B's spawn-order channel and the lifecycle-spawned
         ;; trace / bootstrap dispatch land against B. The install itself is already
         ;; exact (`install-spawn!`); this fences the classification-lowering seam
@@ -1121,7 +1121,7 @@
         ;; Record the spawned actor in the frame's spawn-order channel so
         ;; frame-destroy can walk in reverse-creation order per Spec 005
         ;; §Cross-Spec Interactions §1.
-        (spawn-order/record! frame-id spawned-id)
+        (rf.machines.spawn-order/record! frame-id spawned-id)
         ;; The REGISTRAR-substrate "instance appeared" observation, the
         ;; symmetric partner of
         ;; `:rf.machine.lifecycle/created` (handler registered) and
@@ -1135,7 +1135,7 @@
         ;; The `:state` tag carries the actor's initial state so the Xray
         ;; managed-fx invoke adapter can render it without re-reading
         ;; runtime-db (`managed_fx_helpers/machine-invoke-adapter`).
-        (trace/emit! :rf.machine.lifecycle/spawned :rf.machine.lifecycle/spawned
+        (rf.trace/emit! :rf.machine.lifecycle/spawned :rf.machine.lifecycle/spawned
                      {:frame      frame-id
                       ;; `:machine-id` = spec-time registered TYPE;
                       ;; `:spawned-id` = live instance address;
@@ -1155,7 +1155,7 @@
         ;; supply :start receive a synthetic [:rf.machine.spawn/spawned] so
         ;; generic child machines can declare their first transition out of an
         ;; :initial state at spec-write time.
-        (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+        (when-let [dispatch! (rf.late-bind/get-fn :router/dispatch!)]
         ;; Stamp `:source :machine-spawn` on the actor-bootstrap dispatch so
         ;; the Epoch panel's DISPATCH step labels it "from machine spawn"
         ;; rather than `:unknown` or `:fx-dispatch` (which would be the value
@@ -1249,7 +1249,7 @@
                                     (nil? (:definition args))
                                     (nil? spec)))
         snap       (when spec
-                     (parallel/build-initial-snapshot spec {:bootstrap-pending? true}))
+                     (rf.machines.parallel/build-initial-snapshot spec {:bootstrap-pending? true}))
         schema-reject? (boolean (and spec (some? spawned-id)
                                      (spawn-rejected? spec spawned-id snap continue?)))]
     {:args           args
@@ -1306,7 +1306,7 @@
   its admission preflight has run application `[:schemas :data]` validators and
   (on the reject path) fanned callback-bearing reject records — either of which
   can synchronously destroy owner frame A and publish a same-id successor B on
-  its own stack. A bare-id `frame/swap-runtime-db!` resolves to the CURRENT
+  its own stack. A bare-id `rf.frame/swap-runtime-db!` resolves to the CURRENT
   incarnation, so it would land A's join-state / reject sentinel on B (and bump
   B's commit epoch), leaving B holding an IMPOSSIBLE join it never spawned.
 
@@ -1319,10 +1319,10 @@
   no incarnation to lose, symmetric with `continue?`'s `(constantly true)`.
   Returns the new runtime-db slice, or nil on owner loss."
   [frame-id owner-token parent-id invoke-id value]
-  (let [swap-fn #(assoc-in % (paths/spawned-path parent-id invoke-id) value)]
+  (let [swap-fn #(assoc-in % (rf.machines.paths/spawned-path parent-id invoke-id) value)]
     (if owner-token
-      (frame/swap-runtime-db-exact! frame-id owner-token swap-fn)
-      (frame/swap-runtime-db! frame-id swap-fn))))
+      (rf.frame/swap-runtime-db-exact! frame-id owner-token swap-fn)
+      (rf.frame/swap-runtime-db! frame-id swap-fn))))
 
 (defn- seed-reject-sentinel!
   "Seed the childless `spawn-all-reject-sentinel` at the invoke's join slot,
@@ -1445,7 +1445,7 @@
   (let [;; EP-0002 carried invariant — the fx context carries the cascade
         ;; envelope frame; a nil stamp is an invariant failure
         ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
-        frame-id   (frame/require-frame-stamp!
+        frame-id   (rf.frame/require-frame-stamp!
                      frame-id :rf.machine/spawn-all-init
                      {:where 'rf.machine/spawn-all-init
                       :event-id (:rf/parent-id args)})
@@ -1463,7 +1463,7 @@
         ;;
         ;; rf2-ek435 — re-stamp each child-arg's `:rf/spawn-all-id` (and
         ;; `:rf/parent-id`) to THIS fx's own `invoke-id` / `parent-id`. For a
-        ;; PARALLEL-region invoke, `parallel/prefix-region-invoke-id` region-
+        ;; PARALLEL-region invoke, `rf.machines.parallel/prefix-region-invoke-id` region-
         ;; prefixes the init-fx's top-level `:rf/invoke-id` AND every per-child
         ;; `:rf.machine/spawn` fx's top-level `:rf/spawn-all-id`, but NOT the
         ;; `:child-args` nested here — so their `:rf/spawn-all-id` is the
@@ -1488,7 +1488,7 @@
         join-state (assoc (:join-state args)
                           :cancelled #{}
                           :rf/attempt (next-join-attempt-token))
-        continue?  (data-validation/owner-continuation frame-id)
+        continue?  (rf.machines.data-validation/owner-continuation frame-id)
         ;; rf2-8nxsh — the RAW exact owner token (`continue?` closes over the
         ;; same authority). The admission preflight below runs application
         ;; `[:schemas :data]` validators (`prepare-spawn-all-child`), and the
@@ -1500,7 +1500,7 @@
         ;; byte-identical even under a mid-write container watch; nil for a
         ;; non-router caller falls back to the bare write, symmetric with
         ;; `continue?`'s `(constantly true)`.
-        owner-token (frame/current-event-owner-token)
+        owner-token (rf.frame/current-event-owner-token)
         ;; ---- The invoke-level admission preflight ------------------------
         ;; ONE authoritative preparation per child, then ONE decision — both
         ;; taken BEFORE a live join or ANY child side effect is published
@@ -1635,7 +1635,7 @@
                                                   (map (juxt :spawned-id
                                                              #(select-keys % [:spec :snap :type-spec]))))
                                             prepared))))
-                  (trace/emit! :rf.machine :rf.machine.spawn-all/started
+                  (rf.trace/emit! :rf.machine :rf.machine.spawn-all/started
                                {;; The parent's live actor INSTANCE address;
                                 ;; `:invoke-id` is the declarative invocation path.
                                 :actor-id   parent-id

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn_error.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn_error.cljc
@@ -17,7 +17,7 @@
   Both route through `dispatch-spawn-error!`, which dispatches the reserved
   event `[<parent-id> [:rf.machine.spawn/error <invoke-id> <error>]]` into the
   parent. The parent's macrostep resolves it natively via
-  `transition/pick-spawn-error-transition` (the `:on-error` transition is
+  `rf.machines.transition/pick-spawn-error-transition` (the `:on-error` transition is
   resolved at the `:spawn`-bearing state's level — a keyword target is a
   sibling), so the parent transition fires with full engine semantics (entry /
   exit cascade, `:always` / `:raise` drain, traces, and the parent's own
@@ -34,12 +34,12 @@
   This namespace is a LEAF over the spawn-resolution helpers it needs
   (`resolver` + `paths` + `transition` + `late-bind`), so both `finalize` and
   `registration` may require it without a load cycle. The `:spawn`-at-invoke-id
-  lookup lives in `resolver/spawn-spec-at`;
+  lookup lives in `rf.machines.lifecycle-fx.resolver/spawn-spec-at`;
   `transition` is retained only for the reserved `spawn-error-event-id`."
-  (:require [re-frame.late-bind :as late-bind]
-            [re-frame.machines.lifecycle-fx.resolver :as resolver]
-            [re-frame.machines.paths :as paths]
-            [re-frame.machines.transition :as transition]))
+  (:require [re-frame.late-bind :as rf.late-bind]
+            [re-frame.machines.lifecycle-fx.resolver :as rf.machines.lifecycle-fx.resolver]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.machines.transition :as rf.machines.transition]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -51,9 +51,9 @@
   `finalize-machine` does for `:on-done`."
   [db parent-id]
   (when parent-id
-    (resolver/spec-from-id-or-snapshot
+    (rf.machines.lifecycle-fx.resolver/spec-from-id-or-snapshot
       parent-id
-      (get-in db (paths/snapshot-path parent-id)))))
+      (get-in db (rf.machines.paths/snapshot-path parent-id)))))
 
 (defn parent-declares-on-error?
   "True iff the child identified by `parent-id` / `invoke-id` was spawned by a
@@ -65,7 +65,7 @@
   (boolean
     (when (and parent-id invoke-id)
       (some-> (resolve-parent-spec db parent-id)
-              (resolver/spawn-spec-at invoke-id)
+              (rf.machines.lifecycle-fx.resolver/spawn-spec-at invoke-id)
               :on-error
               some?))))
 
@@ -80,7 +80,7 @@
   conformance callers). `:source :machine-spawn` labels the dispatch so the
   Epoch panel attributes it to the spawn lifecycle."
   [frame-id parent-id invoke-id error]
-  (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
-    (dispatch! [parent-id [transition/spawn-error-event-id invoke-id error]]
+  (when-let [dispatch! (rf.late-bind/get-fn :router/dispatch!)]
+    (dispatch! [parent-id [rf.machines.transition/spawn-error-event-id invoke-id error]]
                {:frame frame-id :source :machine-spawn}))
   nil)

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/teardown.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/teardown.cljc
@@ -50,8 +50,8 @@
   likewise pure runtime-db → runtime-db; the transient atom that ns also
   owns is untouched here (its `forget!` stays a caller side effect,
   because it must run even when no runtime-db swap lands)."
-  (:require [re-frame.machines.paths :as paths]
-            [re-frame.machines.spawn-order :as spawn-order]))
+  (:require [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.machines.spawn-order :as rf.machines.spawn-order]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -64,7 +64,7 @@
   (when actor-id
     (some (fn [[sid mid]]
             (when (= mid actor-id) sid))
-          (get-in db (paths/system-id-path)))))
+          (get-in db (rf.machines.paths/system-id-path)))))
 
 (defn teardown-actor
   "Apply the unified runtime-db teardown projection to `db`. Returns a tuple
@@ -105,14 +105,14 @@
         ;; touching it would materialise a phantom `{:data {:rf/spawned {}}}`
         ;; on a dead parent — so guard the parent-side clear on presence.
         clear-parent-data? (and track?
-                                (contains? (get-in db (paths/snapshot-path))
+                                (contains? (get-in db (rf.machines.paths/snapshot-path))
                                            parent-id))
         ;; (1)+(2)+(3)+(4): the primary slot mutations. (4) clears the
         ;; PARENT snapshot's own `[:data :rf/spawned <invoke-id>]` slot so
         ;; the parent-side data slot (mechanism 1) mirrors the runtime
         ;; registry (step 3) EXACTLY — see ns docstring + Spec 005:2938.
         new-db       (cond-> db
-                       actor-id     (update-in (paths/snapshot-path)
+                       actor-id     (update-in (rf.machines.paths/snapshot-path)
                                                dissoc actor-id)
                        ;; (1b) rf2-1vlyg — drop the actor from the DURABLE
                        ;; spawn-order vector in the same swap that dissocs its
@@ -124,26 +124,26 @@
                        ;; second time by a later frame destroy nor accumulate as
                        ;; an unbounded stale entry. The slot is pruned when it
                        ;; empties (`forget-in-runtime-db`), mirroring `:spawned`.
-                       actor-id     (spawn-order/forget-in-runtime-db actor-id)
-                       released-sid (update-in (paths/system-id-path)
+                       actor-id     (rf.machines.spawn-order/forget-in-runtime-db actor-id)
+                       released-sid (update-in (rf.machines.paths/system-id-path)
                                                dissoc released-sid)
-                       track?       (update-in (paths/spawned-path parent-id)
+                       track?       (update-in (rf.machines.paths/spawned-path parent-id)
                                                 dissoc invoke-id)
                        clear-parent-data?
-                       (update-in (paths/snapshot-path parent-id :data :rf/spawned)
+                       (update-in (rf.machines.paths/snapshot-path parent-id :data :rf/spawned)
                                   dissoc invoke-id))
         ;; (5a): prune the per-parent `:spawned` map if empty.
         new-db       (cond-> new-db
                        (and track?
-                            (empty? (get-in new-db (paths/spawned-path parent-id))))
-                       (update-in (paths/spawned-path) dissoc parent-id))
+                            (empty? (get-in new-db (rf.machines.paths/spawned-path parent-id))))
+                       (update-in (rf.machines.paths/spawned-path) dissoc parent-id))
         ;; (5b): prune the `[:rf.runtime/machines :spawned]` slot if
         ;; empty (lazy-allocation mirror — :snapshots and :system-ids
         ;; stay present per fixture contract).
         new-db       (cond-> new-db
                        (and (contains? (get-in new-db [:rf.runtime/machines])
                                        :spawned)
-                            (empty? (get-in new-db (paths/spawned-path))))
+                            (empty? (get-in new-db (rf.machines.paths/spawned-path))))
                        (update-in [:rf.runtime/machines] dissoc :spawned))
         ;; (5c): prune the parent snapshot's now-empty `:rf/spawned` data
         ;; map (lazy-allocation mirror of the registry prune above) so a
@@ -152,8 +152,8 @@
         ;; Only touch a still-present parent snapshot.
         new-db       (cond-> new-db
                        (and clear-parent-data?
-                            (empty? (get-in new-db (paths/snapshot-path parent-id
+                            (empty? (get-in new-db (rf.machines.paths/snapshot-path parent-id
                                                                         :data :rf/spawned))))
-                       (update-in (paths/snapshot-path parent-id :data)
+                       (update-in (rf.machines.paths/snapshot-path parent-id :data)
                                   dissoc :rf/spawned))]
     [new-db released-sid]))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/traces.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/traces.cljc
@@ -11,10 +11,10 @@
   because `teardown.cljc` is the unified pure runtime-db projection; it
   deliberately emits NO traces so the projection stays a value→value
   function. These helpers ARE side effects, so they live separately."
-  (:require [re-frame.interop :as interop]
-            [re-frame.machines.error-emit :as machine-error-emit]
-            [re-frame.machines.reply :as m-reply]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.interop :as rf.interop]
+            [re-frame.machines.error-emit :as rf.machines.error-emit]
+            [re-frame.machines.reply :as rf.machines.reply]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -81,10 +81,10 @@
                     (contains? args :work-generation)
                     (assoc :work-generation work-generation))
         summary    (when cancelled?
-                     (m-reply/trace-reply
-                       (m-reply/cancelled-actor-reply reply-ctx)
+                     (rf.machines.reply/trace-reply
+                       (rf.machines.reply/cancelled-actor-reply reply-ctx)
                        {:frame frame}))]
-    (trace/emit! :rf.machine :rf.machine/destroyed
+    (rf.trace/emit! :rf.machine :rf.machine/destroyed
                  (cond-> {:frame    frame
                           :actor-id actor-id
                           :reason   reason}
@@ -145,7 +145,7 @@
   teardown, no dishonest terminal) holds in every build; the loud dev trace
   names the offending arg. Per Spec 009 §Error event catalogue."
   [frame-id cause args]
-  (trace/emit-error! :rf.error/machine-destroy-bad-arg
+  (rf.trace/emit-error! :rf.error/machine-destroy-bad-arg
                      {:cause    cause
                       :arg      args
                       :frame    frame-id
@@ -158,7 +158,7 @@
   was released as part of teardown. No-op when `sid` is nil."
   [frame-id sid actor-id]
   (when sid
-    (trace/emit! :rf.machine :rf.machine/system-id-released
+    (rf.trace/emit! :rf.machine :rf.machine/system-id-released
                  {:frame      frame-id
                   :system-id  sid
                   ;; the released actor's live INSTANCE address;
@@ -186,7 +186,7 @@
         state-path (:state-path result-info)
         exception  (:exception result-info)]
     ;; Axis 1 — STRUCTURAL-ONLY always-on record (no prose; see error-emit).
-    (machine-error-emit/emit-machine-action-exception!
+    (rf.machines.error-emit/emit-machine-action-exception!
       {:actor-id   actor-id
        :failing-id failing-id
        :state      state-path
@@ -194,15 +194,15 @@
        :phase      :rf.machine/destroy-exit
        :recovery   :skipped
        :exception  exception})
-    ;; Axis 2 — dev-only trace. Wrapped in an EXPLICIT `interop/debug-enabled?`
+    ;; Axis 2 — dev-only trace. Wrapped in an EXPLICIT `rf.interop/debug-enabled?`
     ;; call-site gate so Closure constant-folds the whole form — including the
     ;; dev-only diagnostic PROSE `:reason` — away under :advanced +
     ;; goog.DEBUG=false (009 elision probe: `emit-destroy-exit-failure!` prose
-    ;; sentinel). The internal gate inside `trace/emit-error!` is not enough on
+    ;; sentinel). The internal gate inside `rf.trace/emit-error!` is not enough on
     ;; its own here because this function also contains the live always-on call;
     ;; the explicit gate lets Closure eliminate the dev-only map and prose.
-    (when interop/debug-enabled?
-      (trace/emit-error! :rf.error/machine-action-exception
+    (when rf.interop/debug-enabled?
+      (rf.trace/emit-error! :rf.error/machine-action-exception
                          {:actor-id   actor-id
                           :machine-id actor-id
                           :failing-id failing-id

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/update_snapshot.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/update_snapshot.cljc
@@ -24,10 +24,10 @@
   `:data` (schema-covered) — not as bare snapshot-root keys. A `:db` key
   in the patch is the same hard-disallow the action-effect path enforces
   (Spec 005:463), surfaced as `:rf.error/machine-action-wrote-db`."
-  (:require [re-frame.frame :as frame]
-            [re-frame.machines.data-validation :as data-validation]
-            [re-frame.machines.paths :as paths]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.frame :as rf.frame]
+            [re-frame.machines.data-validation :as rf.machines.data-validation]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -71,7 +71,7 @@
   (let [;; The cascade envelope frame is the fx-context `:frame`; a nil
         ;; stamp is an invariant failure (`:rf.error/no-frame-context`),
         ;; never a synthesised `:rf/default`.
-        frame-id   (frame/require-frame-stamp!
+        frame-id   (rf.frame/require-frame-stamp!
                      frame-id :rf.machine/update-snapshot
                      {:where 'rf.machine/update-snapshot
                       :event-id (:rf/machine-id args)})
@@ -88,9 +88,9 @@
         ;; same-id successor B; `owner-token` binds the store-write to A's OWN
         ;; container. An eventless caller (no owner bound) yields
         ;; `(constantly false)` / nil — the historical full-authority bare write.
-        continue?   (data-validation/owner-continuation frame-id)
+        continue?   (rf.machines.data-validation/owner-continuation frame-id)
         owner-gone? (fn [] (not (continue?)))
-        owner-token (frame/current-event-owner-token)]
+        owner-token (rf.frame/current-event-owner-token)]
     (when (and machine-id (map? patch))
       ;; Hard-disallow `:db` — symmetric with the action-effect path
       ;; (Spec 005:463). Canonical id / tags per Spec 009 §Error event
@@ -106,7 +106,7 @@
       ;; carried) is summarized at the trace egress chokepoint by
       ;; `re-frame.classification/project-machine-wrote-db-tags` so it never egresses raw.
       (when (contains? patch :db)
-        (trace/emit-error! :rf.error/machine-action-wrote-db
+        (rf.trace/emit-error! :rf.error/machine-action-wrote-db
                            {:actor-id        machine-id
                             :action-id       :rf.machine/update-snapshot
                             :offending-value (:db patch)
@@ -143,11 +143,11 @@
             ;; no `[:schemas :data]` schema — writes exactly as before. Absent actor
             ;; (destroyed / unknown) is a no-op: nothing to merge into, and
             ;; nothing to validate.
-            (let [snapshots (get-in (frame/frame-runtime-db-value frame-id)
-                                    (paths/snapshot-path))]
+            (let [snapshots (get-in (rf.frame/frame-runtime-db-value frame-id)
+                                    (rf.machines.paths/snapshot-path))]
               (when (contains? snapshots machine-id)
                 (let [merged (merge (get snapshots machine-id) clean-patch)]
-                  (when (data-validation/validate-update-snapshot-data!
+                  (when (rf.machines.data-validation/validate-update-snapshot-data!
                           machine-id merged)
                     ;; rf2-vxgfnd.22 — route the store-write through the EXACT
                     ;; durable write so it NO-OPS on owner loss: no merge onto
@@ -162,10 +162,10 @@
                             ;; Re-check presence inside the swap — never conjure
                             ;; a snapshot for an actor torn down between the read
                             ;; and the write.
-                            (if (contains? (get-in runtime-db (paths/snapshot-path)) machine-id)
-                              (update-in runtime-db (paths/snapshot-path machine-id) merge clean-patch)
+                            (if (contains? (get-in runtime-db (rf.machines.paths/snapshot-path)) machine-id)
+                              (update-in runtime-db (rf.machines.paths/snapshot-path machine-id) merge clean-patch)
                               runtime-db))]
                       (if owner-token
-                        (frame/swap-runtime-db-exact! frame-id owner-token swap-fn)
-                        (frame/swap-runtime-db! frame-id swap-fn)))))))))))
+                        (rf.frame/swap-runtime-db-exact! frame-id owner-token swap-fn)
+                        (rf.frame/swap-runtime-db! frame-id swap-fn)))))))))))
     nil))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -34,12 +34,12 @@
   node under `:states`, recursing through `:states` maps; used by the
   top-level dispatch."
   (:require [clojure.string :as str]
-            [re-frame.error :as error]
-            [re-frame.machines.choice :as choice]
-            [re-frame.machines.grammar :as grammar]
-            [re-frame.machines.internal-events :as internal-events]
-            [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.timeout :as timeout]))
+            [re-frame.error :as rf.error]
+            [re-frame.machines.choice :as rf.machines.choice]
+            [re-frame.machines.grammar :as rf.machines.grammar]
+            [re-frame.machines.internal-events :as rf.machines.internal-events]
+            [re-frame.machines.parallel :as rf.machines.parallel]
+            [re-frame.machines.timeout :as rf.machines.timeout]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -67,7 +67,7 @@
   `:guard`)."
   ([error-kw reason] (validation-error error-kw reason nil))
   ([error-kw reason extras]
-   (error/thrown-ex-info error-kw 'rf/reg-machine reason
+   (rf.error/thrown-ex-info error-kw 'rf/reg-machine reason
                          {:recovery :fix-registration :extra extras})))
 
 ;; ---------------------------------------------------------------------------
@@ -108,7 +108,7 @@
        (some? (namespace k))))
 
 (def ^:private literally-printable-types
-  "The `error/diag-value-summary` `:type` tags whose values `pr-str` renders
+  "The `rf.error/diag-value-summary` `:type` tags whose values `pr-str` renders
   TOTALLY — no `toString` on an opaque host object, and no element-wise descent
   into a collection that might be holding one."
   #{:keyword :symbol :string :number :boolean :nil})
@@ -124,12 +124,12 @@
   shape only.
 
   Anything else — an opaque host object, or a collection that may contain one —
-  renders as its `error/diag-value-summary` shape tag (`<scalar>`, `<vector>`,
+  renders as its `rf.error/diag-value-summary` shape tag (`<scalar>`, `<vector>`,
   …). `pr-str` on such a value reaches `toString`, and a `toString` that throws
   would replace the structured rejection with a host exception: the same defect
   one level down from the one `namespaced-key?` fixes."
   [k]
-  (let [{tag :type} (error/diag-value-summary k)]
+  (let [{tag :type} (rf.error/diag-value-summary k)]
     (if (literally-printable-types tag)
       (pr-str k)
       (str "<" (name tag) ">"))))
@@ -174,7 +174,7 @@
   "Per Spec 005 §`:timeout` / `:on-timeout` — the legacy `:timeout-ms` slot
   on `:spawn` / `:spawn-all` is REMOVED: registration throws
   `:rf.error/spawn-timeout-ms-removed`. Use the spawn-level `:timeout` /
-  `:on-timeout` grammar validated by `timeout/validate-timeouts!`."
+  `:on-timeout` grammar validated by `rf.machines.timeout/validate-timeouts!`."
   [state-key state-node]
   (doseq [[slot-key spec]
           [[:spawn     (:spawn state-node)]
@@ -386,7 +386,7 @@
     rather than the semantically-weaker region-`:after`-that-`:raise`s
     workaround (whose timer is bound to an arbitrary region's lifecycle)."
   [machine]
-  (when (parallel/parallel? machine)
+  (when (rf.machines.parallel/parallel? machine)
     (when-not (and (map? (:regions machine)) (seq (:regions machine)))
       (throw (validation-error
                :rf.error/machine-parallel-bad-shape
@@ -394,7 +394,7 @@
     ;; The parallel root's `:on-done` must not carry an in-machine `:target`
     ;; in ANY form (root-only parallel has no flat sibling to land on).
     ;; Normalise every value-form `:on-done` admits via
-    ;; `grammar/candidate-maps`, the same grammar
+    ;; `rf.machines.grammar/candidate-maps`, the same grammar
     ;; the runtime parallel-root `apply-on-done-action` resolves through), then
     ;; reject if any candidate declares `:target`.
     ;;
@@ -410,7 +410,7 @@
     ;; accepted. A malformed shape (grammar nil) degrades to no candidates.
     (when (contains? machine :on-done)
       (let [on-done (:on-done machine)
-            cands   (or (grammar/candidate-maps on-done) [])]
+            cands   (or (rf.machines.grammar/candidate-maps on-done) [])]
         (when (some #(contains? % :target) cands)
           (throw (validation-error
                    :rf.error/machine-parallel-on-done-target
@@ -439,7 +439,7 @@
     ;; fallback), so a non-region-qualified root `:after` target is rejected
     ;; with the SAME `:rf.error/machine-parallel-root-on-bad-target` keyword.
     ;; `candidates-of` is the SHARED `:on` / `:after` value-form normaliser —
-    ;; the shared `grammar/candidate-maps`; malformed values produce `[]`.
+    ;; the shared `rf.machines.grammar/candidate-maps`; malformed values produce `[]`.
     (let [region-names (set (keys (:regions machine)))
           declared?    (fn [t] (contains? region-names t))
           bad-target!  (fn [slot target]
@@ -471,7 +471,7 @@
                              (bad-target! slot target))
                            ;; bare keyword / any other shape — no flat sibling
                            :else (bad-target! slot target)))
-          candidates-of (fn [v] (or (grammar/candidate-maps v) []))]
+          candidates-of (fn [v] (or (rf.machines.grammar/candidate-maps v) []))]
       (doseq [[_event v] (:on machine)
               cand        (candidates-of v)]
         (check-one! ":on" (:target cand)))
@@ -521,18 +521,18 @@
 ;; the feature is scoped to a `:type :parallel` machine root. Its runtime
 ;; support is likewise parallel-only — `transition/schedule-root-after-fx`
 ;; (the birth-time scheduler) is called ONLY from
-;; `parallel/run-initial-cascade`'s parallel branch; a flat/compound
-;; machine's birth (`parallel/bootstrap-step`) never calls it, and there is
+;; `rf.machines.parallel/run-initial-cascade`'s parallel branch; a flat/compound
+;; machine's birth (`rf.machines.parallel/bootstrap-step`) never calls it, and there is
 ;; no root resolver that would fire a flat root `:after` at the decl-path
-;; `[]` empty-path node (`grammar/node-at` resolves an empty path to nil).
-;; `timeout/validate-timeouts!` + `validate-after-delays!` both happily
+;; `[]` empty-path node (`rf.machines.grammar/node-at` resolves an empty path to nil).
+;; `rf.machines.timeout/validate-timeouts!` + `validate-after-delays!` both happily
 ;; accept a WELL-FORMED root `:timeout` / `:after` on a flat/compound
 ;; machine (they validate the pairing / duration / delay-key SHAPE, not
 ;; whether the runtime can ever schedule or resolve it), so — absent this
 ;; check — such a machine registers cleanly and its "whole-machine
 ;; deadline" silently never fires. Reject it loudly here instead, on the
 ;; DESUGARED machine (`validate-machine!` calls this after
-;; `timeout/desugar-timeouts`), so a root `:timeout` — which lowers onto
+;; `rf.machines.timeout/desugar-timeouts`), so a root `:timeout` — which lowers onto
 ;; `:after` — is caught via its lowered form in the SAME check as a
 ;; directly-authored root `:after`.
 ;;
@@ -565,7 +565,7 @@
   supported, scheduled, resolved feature per Spec 005. Absent / empty `:after`
   is fine everywhere."
   [machine]
-  (if (parallel/parallel? machine)
+  (if (rf.machines.parallel/parallel? machine)
     ;; The machine's own parallel-root `:after` is supported; only a
     ;; REGION-ROOT `:after` is the unscheduled shape.
     (doseq [[rn region-body] (:regions machine)]
@@ -617,7 +617,7 @@
                         (walk (conj path k) (:states n)))))
               nodes))]
     (cond
-      (parallel/parallel? machine)
+      (rf.machines.parallel/parallel? machine)
       (mapcat (fn [[_region region-body]] (walk [] (:states region-body)))
               (:regions machine))
 
@@ -660,22 +660,22 @@
 
 (def ^:private history-node?
   "True iff `node` is a history pseudo-state (`:type :history`). The
-  shared `grammar/history-node?` — registration and the runtime read the
+  shared `rf.machines.grammar/history-node?` — registration and the runtime read the
   one predicate."
-  grammar/history-node?)
+  rf.machines.grammar/history-node?)
 
 (defn- node-at-states
   "Walk a `:states` map down absolute `path`, returning the leaf
   state-node (or nil if `path` doesn't resolve). Scope-local resolver —
   `states` is the flat machine's `:states` or a single region body's
   `:states`, so `path` is scope-relative (region names are never part of
-  a within-region path). Delegates to the shared `grammar/node-at` (the
+  a within-region path). Delegates to the shared `rf.machines.grammar/node-at` (the
   same root→leaf descent the runtime `transition/node-at` uses) so
   registration resolves targets against EXACTLY the tree the runtime
   drives. `path` is coerced to a vector for the shared fn's count/seq
   semantics."
   [states path]
-  (grammar/node-at states (vec path)))
+  (rf.machines.grammar/node-at states (vec path)))
 
 (defn- resolves-to-state?
   "True iff `target` resolves to a real state under `owning-path` within
@@ -819,7 +819,7 @@
              (str "a machine root cannot be a :type :history pseudo-state — "
                   "history is a child node under a compound's :states.")
              {:state :rf/root :feature :history})))
-  (if (parallel/parallel? machine)
+  (if (rf.machines.parallel/parallel? machine)
     ;; A region body declared as `:type :history`, or with history nodes
     ;; under its `:states`, is validated per-region (region names are the
     ;; scope root — a history node directly under the region's `:states`
@@ -1022,7 +1022,7 @@
 
 (defn- always-entries
   "Normalise a state-node's `:always` slot to a vector of entry maps through
-  the shared `grammar/candidate-maps`. Absent
+  the shared `rf.machines.grammar/candidate-maps`. Absent
   `:always` — the key missing, OR present with an explicit nil value — yields
   the empty vector (no ancestor-blocking use case for `:always`, unlike `:on`
   / `:after`'s nil-is-forbidden-transition form), so the nil is gated BEFORE
@@ -1034,7 +1034,7 @@
   (let [a (:always state-node)]
     (if (nil? a)
       []
-      (or (grammar/candidate-maps a) []))))
+      (or (rf.machines.grammar/candidate-maps a) []))))
 
 (defn- always-self-loop?
   "True iff an `:always` entry's `:target` resolves to its own declaring
@@ -1104,7 +1104,7 @@
                           (walk p (:states n))))))
               nodes))]
     (cond
-      (parallel/parallel? machine)
+      (rf.machines.parallel/parallel? machine)
       (mapcat (fn [[_region region-body]] (walk [] (:states region-body)))
               (:regions machine))
 
@@ -1131,7 +1131,7 @@
                           (walk scope p (:states n))))))
               nodes))]
     (cond
-      (parallel/parallel? machine)
+      (rf.machines.parallel/parallel? machine)
       (mapcat (fn [[_region region-body]]
                 (walk (:states region-body) [] (:states region-body)))
               (:regions machine))
@@ -1161,14 +1161,14 @@
 (def ^:private candidate-targets
   "Normalise a transition slot's value (an `:on` entry, an `:after` entry,
   an `:on-done`, a `:spawn :on-error`) to the seq of `:target`s it declares,
-  each tagged with `:present?`. The shared `grammar/candidate-targets`,
-  built on the SAME `grammar/transition-value-form` recogniser the runtime
+  each tagged with `:present?`. The shared `rf.machines.grammar/candidate-targets`,
+  built on the SAME `rf.machines.grammar/transition-value-form` recogniser the runtime
   normaliser (`transition/normalise-candidates`) uses — so registration and
   the runtime share one grammar layer by construction. The `:present?` marker
   distinguishes \"`:target` key absent\" (internal
   transition — always fine) from \"`:target` present but malformed\" (e.g.
   `{:target nil}`)."
-  grammar/candidate-targets)
+  rf.machines.grammar/candidate-targets)
 
 (defn- validate-target!
   "Validate one `:target` against the declaring state's `scope` (its region /
@@ -1296,7 +1296,7 @@
                      {:state     state-key
                       :slot      :after
                       :delay-key delay-key}))))
-        roots (if (parallel/parallel? machine)
+        roots (if (rf.machines.parallel/parallel? machine)
                 (cons machine (vals (:regions machine)))
                 [machine])]
     (doseq [[state-key state-node] (walk-state-nodes machine)
@@ -1351,7 +1351,7 @@
         (check! :on-done (:on-done node)))
       (when-let [oe (get-in node [:spawn :on-error])]
         (check! :spawn/on-error oe))))
-  (when-not (parallel/parallel? machine)
+  (when-not (rf.machines.parallel/parallel? machine)
     (let [scope  (:states machine)
           check! (fn [v]
                    (doseq [{:keys [present? target]} (candidate-targets v)]
@@ -1431,13 +1431,13 @@
   row.
 
   `:type :history` and `:type :choice` pseudo-states carry their OWN closed
-  key-sets (`validate-history!` / `choice/validate-node-choice!`), so the node-key
+  key-sets (`validate-history!` / `rf.machines.choice/validate-node-choice!`), so the node-key
   walk SKIPS them — their validators already reject foreign keys with the
   node-kind-specific error id."
   #{;; root-shape / pseudo-state
     :type :deep? :default-target :regions
     ;; parallel-root region declaration order — the explicit registration
-    ;; contract (`parallel/normalise-region-order`); author-supplied OR derived
+    ;; contract (`rf.machines.parallel/normalise-region-order`); author-supplied OR derived
     ;; and stamped once at registration. Root-only, but harmless on the set,
     ;; exactly like `:regions`.
     :region-order
@@ -1518,7 +1518,7 @@
   [state-key state-node at-root?]
   (when (and (map? state-node)
              (not (history-node? state-node))
-             (not (choice/choice-node? state-node)))
+             (not (rf.machines.choice/choice-node? state-node)))
     (let [known     (cond-> known-state-node-keys
                        at-root? (into known-machine-root-extra-keys))
           offending (unknown-bare-keys state-node known)]
@@ -1698,7 +1698,7 @@
   ;; target flows through the same target-resolution check `:after` uses, a
   ;; `:final?` state carrying a `:timeout` is rejected as it would be for an
   ;; `:after`, and the desugared form is exactly what the runtime drives.
-  (timeout/validate-timeouts! machine)
+  (rf.machines.timeout/validate-timeouts! machine)
   ;; Validate the `:type :choice` / `:choice` grammar on the
   ;; RAW spec (before BOTH desugars) so diagnostics name the `:type :choice`
   ;; / `:choice` keys the author wrote AND a choice state that also declares
@@ -1706,22 +1706,22 @@
   ;; The path-aware walker yields the declaring node's absolute path so a
   ;; self-targeting candidate is resolved.
   (doseq [[path n] (walk-state-nodes-with-path machine)]
-    (choice/validate-node-choice! path (peek path) n))
+    (rf.machines.choice/validate-node-choice! path (peek path) n))
   ;; A parallel region ROOT (a region body) may itself be a `:type :choice`
   ;; node only in a degenerate sense; the walker above does not yield region
   ;; roots, so validate them here for completeness (rejected via the same
   ;; reserved-key / shape rules — a region root carries `:states`, a
   ;; reserved key, so a `:type :choice` region root fails loud).
-  (when (parallel/parallel? machine)
+  (when (rf.machines.parallel/parallel? machine)
     (doseq [[rn body] (:regions machine)]
-      (choice/validate-node-choice! [rn] rn body)))
+      (rf.machines.choice/validate-node-choice! [rn] rn body)))
   ;; Validate the `:internal-events` declaration on the raw
   ;; spec: it must be a set of keywords, and reserved `:rf/*` lifecycle names
   ;; are forbidden. A declared internal event is expected to have an ordinary
   ;; `:on` handler; the visibility boundary rejects only external dispatch.
   ;; Neither named-intent desugar touches `:internal-events`,
   ;; so the raw spec is the right basis.
-  (internal-events/validate-internal-events! machine)
+  (rf.machines.internal-events/validate-internal-events! machine)
   ;; No-silent-swallow on state-node / spawn-spec keys + the `:tags` shape, on
   ;; the RAW spec (before BOTH desugars) so diagnostics name the exact keys the
   ;; author wrote — a `:choice` / `:timeout` / `:on-timeout` key is still present
@@ -1746,7 +1746,7 @@
   ;; region body too (a typo'd bare key on a region root must not slip through).
   ;; A region body is NOT the machine root — the root-only registration-metadata
   ;; keys (`:doc` / `:sensitive` / …) live on the machine root, not per region.
-  (when (parallel/parallel? machine)
+  (when (rf.machines.parallel/parallel? machine)
     (doseq [[rn body] (:regions machine)]
       (validate-node-keys! rn body false)
       (validate-spawn-spec-keys! rn body)
@@ -1755,7 +1755,7 @@
   ;; (`:timeout` → `:after`, `:choice` → `:always`) so every subsequent
   ;; structural validator (transition targets, self-loop, after delays) and
   ;; the runtime see the lowered form.
-  (let [machine (choice/desugar-choices (timeout/desugar-timeouts machine))]
+  (let [machine (rf.machines.choice/desugar-choices (rf.machines.timeout/desugar-timeouts machine))]
   (validate-history! machine)
   (validate-parallel! machine)
   ;; A non-parallel root's `:after` (hand-authored or lowered
@@ -1868,7 +1868,7 @@
     ;; region-qualified — is validated by `validate-parallel!`; this block
     ;; validates only the guard/action refs, like every other transition
     ;; slot.)
-    (let [roots (if (parallel/parallel? machine)
+    (let [roots (if (rf.machines.parallel/parallel? machine)
                   (cons machine (vals (:regions machine)))
                   [machine])]
       (doseq [root roots
@@ -1881,5 +1881,5 @@
     ;; regions reach final) carries `:guard` / `:action` refs that must
     ;; resolve at registration. (`walk-state-nodes` yields per-region nodes,
     ;; not the parallel root itself, so this is validated explicitly.)
-    (when (parallel/parallel? machine)
+    (when (rf.machines.parallel/parallel? machine)
       (check-transition! (:on-done machine) :rf/root)))))

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -37,13 +37,13 @@
   parent macrostep, matching what a self-`[:dispatch [<self-id> …]]` would
   broadcast (pre-commit, in one macrostep)."
   (:require [clojure.set :as set]
-            [re-frame.error :as error]
-            [re-frame.machines.choice :as choice]
-            [re-frame.machines.result :as result
+            [re-frame.error :as rf.error]
+            [re-frame.machines.choice :as rf.machines.choice]
+            [re-frame.machines.result :as rf.machines.result
              #?@(:cljs [:include-macros true])]
-            [re-frame.machines.timeout :as timeout]
-            [re-frame.machines.transition :as transition]
-            [re-frame.trace :as trace]))
+            [re-frame.machines.timeout :as rf.machines.timeout]
+            [re-frame.machines.transition :as rf.machines.transition]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -126,7 +126,7 @@
             machine                       ; already canonical — idempotent re-run
 
             (some? declared)
-            (error/throw-error!
+            (rf.error/throw-error!
               :rf.error/machine-parallel-region-order-mismatch
               'rf/reg-machine
               (str ":region-order must be a vector that is an exact permutation of "
@@ -140,7 +140,7 @@
             (assoc machine :region-order (vec (keys regions)))
 
             :else
-            (error/throw-error!
+            (rf.error/throw-error!
               :rf.error/machine-parallel-region-order-required
               'rf/reg-machine
               (str "a :type :parallel machine with more than eight regions must "
@@ -178,7 +178,7 @@
       is malformed), and no extra/stale region (a hot-reload that dropped a
       region, or a corrupted restore), AND
    3. every region's active path resolves to a REAL, OCCUPIABLE leaf under
-      that region's body — i.e. `transition/state-occupiable?` (non-nil node,
+      that region's body — i.e. `rf.machines.transition/state-occupiable?` (non-nil node,
       not a `:type :history` pseudo-state).
 
   Reused by `all-regions-final?`, the snapshot-compatibility reconcile
@@ -195,7 +195,7 @@
          (and (= declared present)
               (every?
                 (fn [[region-name region-state]]
-                  (transition/state-occupiable?
+                  (rf.machines.transition/state-occupiable?
                     (get-in machine [:regions region-name])
                     region-state))
                 state)))))
@@ -225,9 +225,9 @@
        (every?
          (fn [[region-name region-state]]
            (let [region-body (get-in machine [:regions region-name])
-                 leaf-node   (transition/node-at region-body
-                                                  (transition/state-path region-state))]
-             (transition/final-state-node? leaf-node)))
+                 leaf-node   (rf.machines.transition/node-at region-body
+                                                  (rf.machines.transition/state-path region-state))]
+             (rf.machines.transition/final-state-node? leaf-node)))
          state)))
 
 (defn- build-region-machine
@@ -248,14 +248,14 @@
   `:type :choice` stayed stuck at its transient node (rf2-x76af2.7): the raw
   region body was faulted into the cache during `build-initial-snapshot`'s tag
   computation, then served — still raw — on those direct-apply paths. Both
-  desugars are idempotent and short-circuit for the common timeout/choice-free
+  desugars are idempotent and short-circuit for the common rf.machines.timeout/choice-free
   region, so this costs one structural scan on the once-per-region cache miss.
   A region-ROOT `:after` / `:timeout` is rejected at registration
   (`validate-non-parallel-root-after!`, rf2-x76af2.10), so only region STATE
   nodes carry lowerable `:timeout` / `:choice` by the time a body reaches here."
   [parent-machine region-name]
-  (let [region-body (choice/desugar-choices
-                      (timeout/desugar-timeouts
+  (let [region-body (rf.machines.choice/desugar-choices
+                      (rf.machines.timeout/desugar-timeouts
                        (get-in parent-machine [:regions region-name])))]
     (-> region-body
         (assoc :guards            (:guards parent-machine))
@@ -324,8 +324,8 @@
   (let [decl      (:initial region-body)
         ;; `region-body` already carries `:states` — `initial-cascade`
         ;; reads it through `node-at`, so pass it directly.
-        full-path (transition/initial-cascade region-body (transition/state-path decl))]
-    (transition/denormalise-state full-path decl)))
+        full-path (rf.machines.transition/initial-cascade region-body (rf.machines.transition/state-path decl))]
+    (rf.machines.transition/denormalise-state full-path decl)))
 
 (defn- compute-tags-parallel
   "Per Spec 005 §Tags compose across regions: union every active state's
@@ -333,7 +333,7 @@
   [machine state-map]
   (transduce
     (map (fn [[region-name region-state]]
-           (transition/compute-tags (region-machine machine region-name) region-state)))
+           (rf.machines.transition/compute-tags (region-machine machine region-name) region-state)))
     set/union
     #{}
     state-map))
@@ -345,10 +345,10 @@
   [machine snapshot]
   (let [tags (if (parallel? machine)
                (compute-tags-parallel machine (:state snapshot))
-               (transition/compute-tags machine (:state snapshot)))]
+               (rf.machines.transition/compute-tags machine (:state snapshot)))]
     ;; The empty→dissoc / else→assoc elision lives
-    ;; once in `transition/stamp-tags`; both tag-commit fns delegate to it.
-    (transition/stamp-tags snapshot tags)))
+    ;; once in `rf.machines.transition/stamp-tags`; both tag-commit fns delegate to it.
+    (rf.machines.transition/stamp-tags snapshot tags)))
 
 (defn build-initial-snapshot
   "Build the freshly-derived initial snapshot for `machine`.
@@ -390,8 +390,8 @@
                                            (get-in machine [:regions rn]))]))
                               (region-order machine))
                         (let [decl (:initial machine)]
-                          (transition/denormalise-state
-                            (transition/initial-cascade machine (transition/state-path decl))
+                          (rf.machines.transition/denormalise-state
+                            (rf.machines.transition/initial-cascade machine (rf.machines.transition/state-path decl))
                             decl)))
         base          (cond-> {:state            initial-state
                                :data             (or (:data machine) {})
@@ -447,8 +447,8 @@
 
 (defn- bootstrap-step
   "Single bootstrap step for one (flat or per-region) machine. Returns
-  a `result/ok` Result carrying the post-cascade snapshot + fx, or a
-  `result/fail` Result if any `:entry` action threw.
+  a `rf.machines.result/ok` Result carrying the post-cascade snapshot + fx, or a
+  `rf.machines.result/fail` Result if any `:entry` action threw.
 
   Every initial-entry cascade action carries `:phase
   :initial-entry` on its `:rf.machine/action-ran` emit so the Handler
@@ -458,11 +458,11 @@
   (let [original-state (:state initial-snapshot)
         boot-target    (if (keyword? original-state)
                          original-state
-                         (vec (transition/state-path original-state)))]
-    (transition/apply-transition-once
+                         (vec (rf.machines.transition/state-path original-state)))]
+    (rf.machines.transition/apply-transition-once
       machine
       (assoc initial-snapshot :state [])
-      [transition/start-marker]
+      [rf.machines.transition/start-marker]
       {:target    boot-target
        :decl-path []}
       :initial-entry)))
@@ -485,7 +485,7 @@
 ;;   - prefix per-region fx with the region name via
 ;;     `prefix-region-invoke-id` so per-region `[:rf.runtime/machines :spawned ...]` /
 ;;     `:after`-epoch tracking slots stay distinct from siblings,
-;;   - short-circuit to a `result/fail` if any region's step fails,
+;;   - short-circuit to a `rf.machines.result/fail` if any region's step fails,
 ;;   - commit `:tags` via `commit-tags-parallel` AFTER every region has
 ;;     transitioned, since `:tags` is the union across active leaves.
 ;;
@@ -554,9 +554,9 @@
   transition-selection phase but retain the same deterministic action/fx
   ordering and shared-data threading.
 
-  Returns a `result/ok` Result carrying the merged snapshot (post-
+  Returns a `rf.machines.result/ok` Result carrying the merged snapshot (post-
   `commit-tags-parallel`) + accumulated fx, or the first region's
-  `result/fail` (cascade short-circuits).
+  `rf.machines.result/fail` (cascade short-circuits).
 
   This helper assumes `parent-machine` is `:type :parallel`. Flat /
   compound callers run their step directly — the broadcast invariant
@@ -646,10 +646,10 @@
           ;; engine from the synthetic region-spec's `:rf/region`), so the
           ;; flat concatenation stays per-region addressable for the
           ;; consumer.
-          (-> (result/ok (commit-tags-parallel parent-machine merged) acc-fx)
-              (result/with-handled any-handled?)
-              (result/with-microsteps micro-total)
-              (result/with-cascade cascade)))
+          (-> (rf.machines.result/ok (commit-tags-parallel parent-machine merged) acc-fx)
+              (rf.machines.result/with-handled any-handled?)
+              (rf.machines.result/with-microsteps micro-total)
+              (rf.machines.result/with-cascade cascade)))
         (let [rn          (first pending)
               ;; Stamp the REAL parent machine-id onto the
               ;; synthetic region-spec so any declarative `:spawn` / `:after`
@@ -734,12 +734,12 @@
                             (some? cur-history)
                             (assoc :rf/history cur-history))
               step-result (step-fn region-spec region-snap)]
-          (if (result/fail? step-result)
+          (if (rf.machines.result/fail? step-result)
             step-result
-            (let [region-handled? (result/handled? step-result)
-                  region-micro    (result/microsteps step-result)
-                  region-cascade  (result/cascade step-result)]
-              (result/with-ok [reg-snap reg-fx] step-result
+            (let [region-handled? (rf.machines.result/handled? step-result)
+                  region-micro    (rf.machines.result/microsteps step-result)
+                  region-cascade  (rf.machines.result/cascade step-result)]
+              (rf.machines.result/with-ok [reg-snap reg-fx] step-result
                 ;; Accumulate fx via `into` so the region
                 ;; loop doesn't rebuild the accumulator as a fresh vector
                 ;; on every region step: `into` uses a transient
@@ -765,8 +765,8 @@
 (defn- run-initial-cascade
   "Synthesise the bootstrap ENTRY cascade for `machine` against the
   freshly-synthesised `initial-snapshot` — the initial-descent `:entry`
-  actions only. Returns a `result/ok` Result carrying the post-cascade
-  snapshot + fx (+ `::cascade`), or a `result/fail` Result if any
+  actions only. Returns a `rf.machines.result/ok` Result carrying the post-cascade
+  snapshot + fx (+ `::cascade`), or a `rf.machines.result/fail` Result if any
   `:entry` action threw.
 
   For parallel-region machines (`:type :parallel`), delegates to
@@ -786,21 +786,21 @@
   cascade's Result. `reduce-regions` walks each REGION's `:after`; the root's
   own `:after` lives on the machine map itself (decl-path `[]`) and is never an
   entered region node, so it is scheduled explicitly via
-  `transition/schedule-root-after-fx` (which bumps the root's per-path epoch on
+  `rf.machines.transition/schedule-root-after-fx` (which bumps the root's per-path epoch on
   the snapshot and emits the same `:scheduled` trace + `:after-schedule` fx a
   state's `:after` emits)."
   [machine initial-snapshot]
   (if (parallel? machine)
     (let [regions-r (reduce-regions machine initial-snapshot bootstrap-step)]
-      (if (result/fail? regions-r)
+      (if (rf.machines.result/fail? regions-r)
         regions-r
-        (result/with-ok [snap fx] regions-r
+        (rf.machines.result/with-ok [snap fx] regions-r
           (let [[snap' root-after-fx]
-                (transition/schedule-root-after-fx machine snap false)]
-            (-> (result/ok snap' (into (vec fx) root-after-fx))
-                (result/with-handled (result/handled? regions-r))
-                (result/with-microsteps (result/microsteps regions-r))
-                (result/with-cascade (result/cascade regions-r)))))))
+                (rf.machines.transition/schedule-root-after-fx machine snap false)]
+            (-> (rf.machines.result/ok snap' (into (vec fx) root-after-fx))
+                (rf.machines.result/with-handled (rf.machines.result/handled? regions-r))
+                (rf.machines.result/with-microsteps (rf.machines.result/microsteps regions-r))
+                (rf.machines.result/with-cascade (rf.machines.result/cascade regions-r)))))))
     (bootstrap-step machine initial-snapshot)))
 
 (declare machine-transition)
@@ -859,11 +859,11 @@
   harvest."
   [region-spec region-snap event match phase]
   (try
-    (transition/apply-preselected-transition
+    (rf.machines.transition/apply-preselected-transition
       region-spec region-snap event match phase)
     (catch #?(:clj Throwable :cljs :default) e
-      (if (transition/guard-threw-signal? e)
-        (result/fail (transition/guard-threw->fail-info e))
+      (if (rf.machines.transition/guard-threw-signal? e)
+        (rf.machines.result/fail (rf.machines.transition/guard-threw->fail-info e))
         (throw e)))))
 
 (defn- broadcast-once
@@ -872,7 +872,7 @@
   APPLY — XState v5 / SCXML parity):
 
     SELECT — resolve EVERY region's enabled transition
-    (`transition/pick-transition`) against ONE frozen pre-event view: `:data`,
+    (`rf.machines.transition/pick-transition`) against ONE frozen pre-event view: `:data`,
     `:all-state` and `:tags` are all taken from `snapshot` BEFORE any region
     applies. So a later region's guard SELECTION never observes an earlier
     region's same-macrostep `:data` write — selection is DECLARATION-ORDER-
@@ -888,8 +888,8 @@
 
   Regions DEFER their raises, so the returned Result's `fx` may carry surfaced
   `[:raise …]` entries for the parent loop to harvest. Returns the merged
-  `result/ok` (carrying `::handled?` / `::microsteps` / `::cascade`) or the
-  first region's `result/fail`. Each raised-event re-broadcast re-enters here
+  `rf.machines.result/ok` (carrying `::handled?` / `::microsteps` / `::cascade`) or the
+  first region's `rf.machines.result/fail`. Each raised-event re-broadcast re-enters here
   with a FRESH `snapshot`, so it re-freezes the selection view against the
   config as of that microstep's start."
   [machine snapshot event]
@@ -920,9 +920,9 @@
                                             (some? sc)   (assoc :rf/spawn-counter sc)
                                             (some? hist) (assoc :rf/history hist))]
                           (assoc! acc rn
-                                  (transition/pick-transition
+                                  (rf.machines.transition/pick-transition
                                     region-spec
-                                    (transition/state-path (get state-map rn))
+                                    (rf.machines.transition/state-path (get state-map rn))
                                     event region-snap))))
                       (transient {})
                       ordered))]
@@ -958,9 +958,9 @@
                                      :tags      frozen-tags}
                               (some? sc)   (assoc :rf/spawn-counter sc)
                               (some? hist) (assoc :rf/history hist))
-                match       (transition/pick-always-transition
+                match       (rf.machines.transition/pick-always-transition
                               region-spec
-                              (transition/state-path (get state-map rn))
+                              (rf.machines.transition/state-path (get state-map rn))
                               region-snap)]
             (cond-> acc match (assoc! rn match))))
         (transient {})
@@ -972,7 +972,7 @@
   canonical declaration order with `:data` accumulation. No region drains a
   local `:always` tail.
 
-  Every taken regional transition gets its own trace/cascade row, but all
+  Every taken regional transition gets its own rf.trace/cascade row, but all
   co-selected transitions share `round-index`; the returned Result counts the
   SET as exactly one `::microsteps` round."
   [machine snapshot matches round-index]
@@ -985,10 +985,10 @@
                   from  (:state region-snap)
                   step  (apply-region-transition
                           region-spec region-snap nil match :always)]
-              (if (or (nil? match) (result/fail? step))
+              (if (or (nil? match) (rf.machines.result/fail? step))
                 step
-                (result/with-ok [snap2 _] step
-                  (trace/emit! :rf.machine :rf.machine.microstep/transition
+                (rf.machines.result/with-ok [snap2 _] step
+                  (rf.trace/emit! :rf.machine :rf.machine.microstep/transition
                                {:actor-id        (or (:rf/parent-id region-spec)
                                                      (:id region-spec))
                                 :from            from
@@ -1000,24 +1000,24 @@
                   (-> step
                       ;; The parent owns the count. `reduce-regions` must not
                       ;; sum one per selected region.
-                      (result/with-microsteps 0)
-                      (result/with-cascade
+                      (rf.machines.result/with-microsteps 0)
+                      (rf.machines.result/with-cascade
                         [{:kind            :microstep
                           :region          rn
                           :microstep-index round-index
                           :from            from
                           :to              (:state snap2)
-                          :steps           (result/cascade step)}])))))))]
-    (if (result/fail? round-r)
+                          :steps           (rf.machines.result/cascade step)}])))))))]
+    (if (rf.machines.result/fail? round-r)
       round-r
-      (result/with-microsteps round-r 1))))
+      (rf.machines.result/with-microsteps round-r 1))))
 
 ;; ---- root parallel `:on` — the ancestor fallback --------------------------
 ;;
 ;; XState v5 / SCXML: a transition declared on a `<parallel>`
 ;; node is the ANCESTOR FALLBACK for its regions — deepest-wins with parent
 ;; fallthrough, the parallel analog of the machine-root `:on` fallback every
-;; flat / compound machine already has (`transition/pick-transition` steps
+;; flat / compound machine already has (`rf.machines.transition/pick-transition` steps
 ;; 6-7) and of re-frame2's own compound-root `:on` fallthrough. The selection
 ;; semantic (verified against xstate@5.32.0):
 ;;
@@ -1074,14 +1074,14 @@
   cascade, `:after` (re)scheduling, declarative `:spawn` / history all fire
   exactly as a region-local transition to that target would. The transition
   carries NO `:action` — the root action already ran once at the root level
-  (`transition/run-root-transition-action`); a region target is a pure
+  (`rf.machines.transition/run-root-transition-action`); a region target is a pure
   configuration change. Threads the shared `:data` / `:rf/spawn-counter` /
   `:rf/history` through `acc` `{:data :rf/spawn-counter :rf/history :state-map
   :fx}` (the same flow `reduce-regions` uses) and prefixes per-region fx with
-  the region name. Returns the updated `acc`, or a `result/fail` (a region
+  the region name. Returns the updated `acc`, or a `rf.machines.result/fail` (a region
   `:entry` / `:exit` action threw)."
   [parent-machine event acc [region-name & in-region-path]]
-  (if (result/fail? acc)
+  (if (rf.machines.result/fail? acc)
     acc
     (let [region-spec (region-spec-overlaid parent-machine region-name)
           region-snap (cond-> {:state (get-in acc [:state-map region-name])
@@ -1101,11 +1101,11 @@
                                     (first in-region)
                                     in-region)
                        :decl-path []}
-          step        (transition/apply-transition-once
+          step        (rf.machines.transition/apply-transition-once
                         region-spec region-snap event synthetic :transition)]
-      (if (result/fail? step)
+      (if (rf.machines.result/fail? step)
         step
-        (result/with-ok [reg-snap reg-fx] step
+        (rf.machines.result/with-ok [reg-snap reg-fx] step
           (-> acc
               (assoc :data (:data reg-snap))
               (cond-> (some? (:rf/spawn-counter reg-snap))
@@ -1127,14 +1127,14 @@
   `region-order`, filtered to the targeted regions) so `:data` accumulation
   across multiple region targets is deterministic, consistent with
   `reduce-regions`. Returns
-  a `result/ok` carrying `[merged-snapshot fx]` stamped `::handled? true` (the
-  root transition resolved the event), or a `result/fail` if the root action
+  a `rf.machines.result/ok` carrying `[merged-snapshot fx]` stamped `::handled? true` (the
+  root transition resolved the event), or a `rf.machines.result/fail` if the root action
   or any region cascade threw."
   [machine snapshot event transition]
-  (let [action-r (transition/run-root-transition-action machine snapshot transition event)]
-    (if (result/fail? action-r)
+  (let [action-r (rf.machines.transition/run-root-transition-action machine snapshot transition event)]
+    (if (rf.machines.result/fail? action-r)
       action-r
-      (result/with-ok [snap-after-action action-fx] action-r
+      (rf.machines.result/with-ok [snap-after-action action-fx] action-r
         (let [targets        (normalise-root-targets (:target transition))
               ;; Apply in canonical region-declaration order (`region-order`,
               ;; filtered to targeted regions) for deterministic `:data`
@@ -1152,7 +1152,7 @@
               acc            (reduce (partial apply-root-region-target machine event)
                                      seed
                                      ordered-targets)]
-          (if (result/fail? acc)
+          (if (rf.machines.result/fail? acc)
             acc
             (let [merged (cond-> (-> snapshot
                                      (assoc :state (:state-map acc))
@@ -1161,8 +1161,8 @@
                            (assoc :rf/spawn-counter (:rf/spawn-counter acc))
                            (some? (:rf/history acc))
                            (assoc :rf/history (:rf/history acc)))]
-              (-> (result/ok (commit-tags-parallel machine merged) (:fx acc))
-                  (result/with-handled true)))))))))
+              (-> (rf.machines.result/ok (commit-tags-parallel machine merged) (:fx acc))
+                  (rf.machines.result/with-handled true)))))))))
 
 (defn- drain-parent-queue
   "Stabilize a parallel macrostep under the parent's unified eventless /
@@ -1187,18 +1187,18 @@
   atomic-rollback target on `:raise-depth-limit` abort (the input
   snapshot — for birth, the pre-settle post-cascade snapshot).
 
-  Returns a `result/ok` (snapshot + fx, with `::handled?` / `::microsteps`
-  / `::cascade`) or the first region's `result/fail`."
+  Returns a `rf.machines.result/ok` (snapshot + fx, with `::handled?` / `::microsteps`
+  / `::cascade`) or the first region's `rf.machines.result/fail`."
   [machine snapshot event first-r]
   (let [raise-limit  (get machine :raise-depth-limit
-                          transition/raise-depth-limit-default)
+                          rf.machines.transition/raise-depth-limit-default)
         always-limit (get machine :always-depth-limit
-                          transition/always-depth-limit-default)]
-    (if (result/fail? first-r)
+                          rf.machines.transition/always-depth-limit-default)]
+    (if (rf.machines.result/fail? first-r)
       first-r
-      (result/with-ok [snap0 fx0] first-r
+      (rf.machines.result/with-ok [snap0 fx0] first-r
         (let [[raises0 real0] (split-raises fx0)
-              external-handled? (result/handled? first-r)]
+              external-handled? (rf.machines.result/handled? first-r)]
           ;; `m` is the live parent machine threaded through the
           ;; re-broadcast loop. Each dequeued raise's `ensure-raised-cofx`
           ;; re-stamps it with an augmented `:rf/cofx` so the raised event's
@@ -1213,8 +1213,8 @@
                  ;; queue — symmetric with the flat drain's per-raise count
                  ;; and bounded by the SAME limit / `>=` boundary.
                  depth      0
-                 acc-micro  (result/microsteps first-r)
-                 acc-casc   (result/cascade first-r)
+                 acc-micro  (rf.machines.result/microsteps first-r)
+                 acc-casc   (rf.machines.result/cascade first-r)
                  visited    [(:state snap0)]]
             (let [always-matches (select-always-matches m cur-snap)]
              (cond
@@ -1229,13 +1229,13 @@
                              :path visited
                              :frame (:rf/frame m)
                              :recovery :no-recovery}]
-                   (trace/emit-error! :rf.error/machine-always-depth-exceeded info)
-                   (result/depth-abort info))
+                   (rf.trace/emit-error! :rf.error/machine-always-depth-exceeded info)
+                   (rf.machines.result/depth-abort info))
                  (let [round-r (apply-always-round
                                  m cur-snap always-matches acc-micro)]
-                   (if (result/fail? round-r)
+                   (if (rf.machines.result/fail? round-r)
                      round-r
-                     (result/with-ok [snap2 fx2] round-r
+                     (rf.machines.result/with-ok [snap2 fx2] round-r
                        (let [[new-raises real-fx] (split-raises fx2)]
                          (recur snap2
                                 m
@@ -1243,14 +1243,14 @@
                                 (into acc-fx real-fx)
                                 depth
                                 (inc acc-micro)
-                                (into acc-casc (result/cascade round-r))
+                                (into acc-casc (rf.machines.result/cascade round-r))
                                 (conj visited (:state snap2))))))))
 
                (empty? pending)
-              (let [result (-> (result/ok cur-snap acc-fx)
-                               (result/with-handled external-handled?)
-                               (result/with-microsteps acc-micro)
-                               (result/with-cascade acc-casc))]
+              (let [result (-> (rf.machines.result/ok cur-snap acc-fx)
+                               (rf.machines.result/with-handled external-handled?)
+                               (rf.machines.result/with-microsteps acc-micro)
+                               (rf.machines.result/with-cascade acc-casc))]
                 ;; Per Spec 005 §Transition broadcast: when EVERY region
                 ;; declines the EXTERNAL event the machine emits a SINGLE
                 ;; benign `:rf.machine.event/unhandled-no-op` (op-type
@@ -1258,18 +1258,18 @@
                 ;; parity; canonical id / op-type / tags per Spec 009
                 ;; §`:op-type` vocabulary). Gated on the inbound `event`
                 ;; (not any re-broadcast raise) and on
-                ;; `transition/unhandled-event-no-op?` so reserved-`:rf/*`
+                ;; `rf.machines.transition/unhandled-event-no-op?` so reserved-`:rf/*`
                 ;; framework lifecycle traffic — the synthetic bootstrap,
                 ;; the spawn kick-off, the stories-runtime pings — is NOT
                 ;; classified as an unknown-user-event no-op. On the BIRTH
                 ;; path `event` is `nil`, so the
                 ;; `unhandled-event-no-op?` gate is never reached — birth
                 ;; never emits the no-op. Mirrors the flat-machine emission
-                ;; in `transition/machine-transition-single`.
+                ;; in `rf.machines.transition/machine-transition-single`.
                 (when (and (not external-handled?)
                            (some? event)
-                           (transition/unhandled-event-no-op? event))
-                  (trace/emit! :rf.machine :rf.machine.event/unhandled-no-op
+                           (rf.machines.transition/unhandled-event-no-op? event))
+                  (rf.trace/emit! :rf.machine :rf.machine.event/unhandled-no-op
                                ;; A LIVE actor (every region
                                ;; declined) received the unknown event; address
                                ;; it by `:actor-id`, not `:machine-id` (the
@@ -1289,8 +1289,8 @@
               (>= depth raise-limit)
               ;; A tripped re-broadcast `:raise` depth limit is a
               ;; FAILED macrostep, not a benign no-op (parity with the flat
-              ;; drain in `transition/drain-to-fixed-point`). Emit the precise
-              ;; category, then return a `result/fail` carrying the
+              ;; drain in `rf.machines.transition/drain-to-fixed-point`). Emit the precise
+              ;; category, then return a `rf.machines.result/fail` carrying the
               ;; `::depth-abort?` sentinel so the runaway region raise cycle
               ;; routes through the handler's failure path (atomic rollback
               ;; preserved — no snapshot write reaches runtime-db) instead of
@@ -1304,8 +1304,8 @@
                           :depth      depth
                           :frame      (:rf/frame machine)
                           :recovery   :no-recovery}]
-                (trace/emit-error! :rf.error/machine-raise-depth-exceeded info)
-                (result/depth-abort info))
+                (rf.trace/emit-error! :rf.error/machine-raise-depth-exceeded info)
+                (rf.machines.result/depth-abort info))
 
               :else
               (let [ev   (first pending)
@@ -1318,7 +1318,7 @@
                     ;; augmented `:rf/cofx` overlays onto each region spec via
                     ;; `region-spec-overlaid`, and threads forward so a later
                     ;; re-broadcast re-presents the generated value.
-                    m'    (transition/ensure-raised-cofx m cur-snap ev)
+                    m'    (rf.machines.transition/ensure-raised-cofx m cur-snap ev)
                     bstep (broadcast-once m' cur-snap ev)
                     ;; A raised internal event declined by EVERY region consults
                     ;; the parallel root's own `:on` as the ancestor fallback —
@@ -1336,13 +1336,13 @@
                     ;; transition without local settling. The next parent-loop
                     ;; iteration selects `:always` across the complete moved
                     ;; configuration before any surfaced raises drain FIFO
-                    ;; (rf2-x76af2.8). A `result/fail` short-circuits.
-                    step  (if (result/fail? bstep)
+                    ;; (rf2-x76af2.8). A `rf.machines.result/fail` short-circuits.
+                    step  (if (rf.machines.result/fail? bstep)
                             bstep
                             (root-fallback-seed m' cur-snap ev bstep))]
-                (if (result/fail? step)
+                (if (rf.machines.result/fail? step)
                   step
-                  (result/with-ok [snap2 fx2] step
+                  (rf.machines.result/with-ok [snap2 fx2] step
                     (let [[new-raises real-fx] (split-raises fx2)
                           ;; rf2-nb8nj — group the rebroadcast's rows under ONE
                           ;; `:kind :raised-transition` boundary instead of
@@ -1359,7 +1359,7 @@
                           ;; phantom event edge.
                           ;;
                           ;; Identical shape and gate to the flat/compound drain
-                          ;; (`transition/drain-to-fixed-point`) — one schema-
+                          ;; (`rf.machines.transition/drain-to-fixed-point`) — one schema-
                           ;; approved wrapper across both engines, so a consumer
                           ;; traverses one thing. `:region` is nil: a raise is
                           ;; re-broadcast across EVERY region, so the boundary
@@ -1372,14 +1372,14 @@
                           ;; completion signal enters this same queue, so it is
                           ;; represented by the same mechanism — no parallel
                           ;; done-state dialect.
-                          acc-casc' (if (result/handled? step)
+                          acc-casc' (if (rf.machines.result/handled? step)
                                       (conj acc-casc
                                             {:kind   :raised-transition
                                              :region nil
                                              :event  ev
                                              :from   (:state cur-snap)
                                              :to     (:state snap2)
-                                             :steps  (result/cascade step)})
+                                             :steps  (rf.machines.result/cascade step)})
                                       acc-casc)]
                       (recur snap2
                              m'
@@ -1389,7 +1389,7 @@
                              (into (vec (rest pending)) new-raises)
                              (into acc-fx real-fx)
                              (inc depth)
-                             (+ acc-micro (result/microsteps step))
+                             (+ acc-micro (rf.machines.result/microsteps step))
                              acc-casc'
                              (conj visited (:state snap2)))))))))))))))
 
@@ -1429,7 +1429,7 @@
   declares `:on-done`, run that `:on-done` transition's `:action` against
   `:data` and append its `:fx`, marking the Result so the lifecycle boundary
   does NOT auto-destroy. Returns the (possibly enriched) Result; a
-  `result/fail` (the `:on-done` action threw) short-circuits. A `result/fail`
+  `rf.machines.result/fail` (the `:on-done` action threw) short-circuits. A `rf.machines.result/fail`
   input passes through. When the machine is not parallel, was NOT newly made
   all-final this macrostep, or declares no `:on-done`, returns `result`
   unchanged (the whole-machine finalize path then runs at the lifecycle
@@ -1448,15 +1448,15 @@
   is dispatched exactly once and `:data` does not accumulate on resting
   macrosteps."
   [machine result newly-reached?]
-  (if (result/fail? result)
+  (if (rf.machines.result/fail? result)
     result
     (let [on-done (:on-done machine)]
       (if (or (not (parallel? machine))
               (nil? on-done)
               (not newly-reached?)
-              (not (all-regions-final? machine (:state (result/snap result)))))
+              (not (all-regions-final? machine (:state (rf.machines.result/snap result)))))
         result
-        (result/with-ok [snap fx] result
+        (rf.machines.result/with-ok [snap fx] result
           ;; `:on-done` is an `:on`-shaped transition spec; a parallel root's
           ;; `:on-done` carries only `:action` / `:guard` / `:fx` (registration
           ;; rejects an in-machine `:target`). Run its `:action` against the
@@ -1464,15 +1464,15 @@
           ;; effects-map contract (`{:data .. :fx ..}`). A bare keyword /
           ;; map without `:action` is a no-op data-wise but still suppresses
           ;; auto-destroy (the author opted into "stay done, don't destroy").
-          (let [on-done-r (transition/apply-on-done-action machine snap on-done)]
-            (if (result/fail? on-done-r)
+          (let [on-done-r (rf.machines.transition/apply-on-done-action machine snap on-done)]
+            (if (rf.machines.result/fail? on-done-r)
               on-done-r
-              (result/with-ok [snap2 fx2] on-done-r
-                (-> (result/ok snap2 (into (vec fx) fx2))
-                    (result/with-parallel-done)
-                    (result/with-handled (result/handled? result))
-                    (result/with-microsteps (result/microsteps result))
-                    (result/with-cascade (result/cascade result)))))))))))
+              (rf.machines.result/with-ok [snap2 fx2] on-done-r
+                (-> (rf.machines.result/ok snap2 (into (vec fx) fx2))
+                    (rf.machines.result/with-parallel-done)
+                    (rf.machines.result/with-handled (rf.machines.result/handled? result))
+                    (rf.machines.result/with-microsteps (rf.machines.result/microsteps result))
+                    (rf.machines.result/with-cascade (rf.machines.result/cascade result)))))))))))
 
 (defn- root-fallback-seed
   "Per Spec 005 §Transition broadcast §Root parallel `:on`: when
@@ -1494,11 +1494,11 @@
   the complete post-root configuration and owns the same frozen
   select-then-apply rounds used after regional events and at birth."
   [machine snapshot event first-r]
-  (if (or (result/fail? first-r)
-          (result/handled? first-r)
-          (not (transition/unhandled-event-no-op? event)))
+  (if (or (rf.machines.result/fail? first-r)
+          (rf.machines.result/handled? first-r)
+          (not (rf.machines.transition/unhandled-event-no-op? event)))
     first-r
-    (if-let [t (transition/root-on-match machine event snapshot)]
+    (if-let [t (rf.machines.transition/root-on-match machine event snapshot)]
       (apply-root-parallel-transition machine snapshot event t)
       first-r)))
 
@@ -1516,7 +1516,7 @@
 
   Emits the same timer traces a state's `:after` does (`:rf.machine.timer/
   fired` on a live fire, `/stale-after` on an epoch-stale drop, `/fired
-  :fired? false` on a guard-suppressed drop) via `transition/emit-pick-
+  :fired? false` on a guard-suppressed drop) via `rf.machines.transition/emit-pick-
   traces!`. Returns the SEED Result the macrostep drains from:
    - the applied root-`:after` transition Result (handled) on a live fire;
    - a no-op `(ok snapshot [])` on a stale / guard-suppressed timer (the
@@ -1525,18 +1525,18 @@
   The returned seed is stabilized by the same parent-owned eventless/raise
   loop as every other parallel transition."
   [machine snapshot event]
-  (let [match (transition/root-after-match machine event snapshot)]
+  (let [match (rf.machines.transition/root-after-match machine event snapshot)]
     ;; Trace the firing / staleness / guard-suppression BEFORE applying, so
     ;; listeners observe events in occurrence order (single-machine parity).
     ;; Thread the causal completion timestamp (the firing
     ;; dispatch's router-stamped `:rf/time-ms` off `:rf.cofx`) so the
     ;; parallel-root `:after` completion carries `:completed-at` like the
     ;; single-machine path.
-    (transition/emit-pick-traces! (:rf/frame machine) match
+    (rf.machines.transition/emit-pick-traces! (:rf/frame machine) match
                                   (get-in machine [:rf/cofx :rf/time-ms]))
     (cond
       (or (nil? match) (:stale? match) (:guard-suppressed? match))
-      (result/ok snapshot [])
+      (rf.machines.result/ok snapshot [])
 
       :else
       (apply-root-parallel-transition machine snapshot event
@@ -1547,8 +1547,8 @@
   event, run the parallel MACROSTEP — broadcast the event to every region,
   then run the parent's eventless-round / internal-event loop (region-
   surfaced `:raise`s re-broadcast FIFO across all regions) to a fixed point, and
-  return the merged result. Returns a `result/ok` Result on success or a
-  `result/fail` Result if any region's action threw.
+  return the merged result. Returns a `rf.machines.result/ok` Result on success or a
+  `rf.machines.result/fail` Result if any region's action threw.
 
   Per Spec 005 §Transition broadcast §Root parallel `:on`: when
   NO region selects a transition for the event, the parallel ROOT's own `:on`
@@ -1607,7 +1607,7 @@
         ;; root-owned, not region-scoped: resolve it through the root `:on`
         ;; apply path rather than broadcasting it to the regions (which key off
         ;; a region-name-prefixed decl-path and would all decline it).
-        root-after?   (transition/root-after-elapsed? event)
+        root-after?   (rf.machines.transition/root-after-elapsed? event)
         first-r       (if root-after?
                         (root-after-seed machine snapshot event)
                         (broadcast-once machine snapshot event))
@@ -1633,8 +1633,8 @@
         ;; `:on-done` does not re-fire.
         was-final?    (all-regions-final? machine (:state snapshot))
         newly-final?  (and (not was-final?)
-                           (not (result/fail? settled))
-                           (all-regions-final? machine (:state (result/snap settled))))]
+                           (not (rf.machines.result/fail? settled))
+                           (all-regions-final? machine (:state (rf.machines.result/snap settled))))]
     ;; Per Spec 005 §Final states §The done-state signal: when this
     ;; macrostep NEWLY makes every region final and the parallel root declares
     ;; `:on-done`, fire it (run its action + emit its fx) WITHOUT auto-
@@ -1645,10 +1645,10 @@
 
 (defn machine-transition
   "Pure function. Given a machine definition, current snapshot, and event,
-  return the engine's `re-frame.machines.result` Result — `result/ok`
+  return the engine's `re-frame.machines.result` Result — `rf.machines.result/ok`
   carrying the new snapshot and effects vector (plus the engine-internal
   `::handled?` / `::microsteps` / `::cascade` riders the lifecycle handler
-  reads), or `result/fail` carrying diagnostic info if any guard / action
+  reads), or `rf.machines.result/fail` carrying diagnostic info if any guard / action
   / `:data`-fn threw or a depth limit tripped. This is the engine seam;
   the PUBLIC `re-frame.machines/machine-transition` wraps it and projects
   the Result onto the plain Spec 005 §Level 1 map.
@@ -1670,13 +1670,13 @@
   Flat / compound machines drop straight into the
   single-machine engine in `re-frame.machines.transition`.
 
-  ## Guard-throw → `result/fail` (XState v5 alignment)
+  ## Guard-throw → `rf.machines.result/fail` (XState v5 alignment)
 
   A user GUARD body that throws during transition selection surfaces the
   error and ABORTS the macrostep (XState v5 does not swallow guard
   exceptions). The throw rides up as a tagged signal
-  (`transition/guard-threw-signal?`) from the candidate-walk; this single
-  pure-engine boundary catches it ONCE and converts it to a `result/fail`,
+  (`rf.machines.transition/guard-threw-signal?`) from the candidate-walk; this single
+  pure-engine boundary catches it ONCE and converts it to a `rf.machines.result/fail`,
   so a guard throw routes through the SAME failed-macrostep / atomic-
   rollback surface a thrown ACTION (and a bounded-depth abort) already
   takes. The original exception rides in the failure `::info` so the
@@ -1695,14 +1695,14 @@
   ;; the desugars, so `region-order` is canonical before the parallel engine
   ;; reads it.
   (let [machine (normalise-region-order
-                  (choice/desugar-choices (timeout/desugar-timeouts machine)))]
+                  (rf.machines.choice/desugar-choices (rf.machines.timeout/desugar-timeouts machine)))]
     (try
       (if (parallel? machine)
         (parallel-machine-transition machine snapshot event)
-        (transition/machine-transition-single machine snapshot event))
+        (rf.machines.transition/machine-transition-single machine snapshot event))
       (catch #?(:clj Throwable :cljs :default) e
-        (if (transition/guard-threw-signal? e)
-          (result/fail (transition/guard-threw->fail-info e))
+        (if (rf.machines.transition/guard-threw-signal? e)
+          (rf.machines.result/fail (rf.machines.transition/guard-threw->fail-info e))
           (throw e))))))
 
 ;; ---- birth-time `:always` + raise settle ----------------------------------
@@ -1734,7 +1734,7 @@
   the caller (`apply-initial-entry-cascade`) does NOT re-prepend the entry fx.
 
   For flat / compound machines, seeds the single-machine
-  `transition/drain-to-fixed-point` directly with `entry-r` (its boot
+  `rf.machines.transition/drain-to-fixed-point` directly with `entry-r` (its boot
   snapshot + entry fx).
 
   For parallel-region machines, `drain-parent-queue` starts directly from the
@@ -1744,22 +1744,22 @@
   declaration order, and the loop repeats before any queued initial-entry
   raise is dequeued.
 
-  Returns a `result/ok` carrying the settled snapshot + fx (with
+  Returns a `rf.machines.result/ok` carrying the settled snapshot + fx (with
   `::microsteps` = the count of `:always` iterations and `::cascade` = the
   `:always`-microstep steps; the caller prepends the entry cascade), or a
-  `result/fail` if an `:always` action or a drained raise threw. The
+  `rf.machines.result/fail` if an `:always` action or a drained raise threw. The
   atomic-rollback target on `:always`/`:raise`-depth abort is the
   post-cascade `boot-snapshot` (the initial configuration is the committed
   state — only a runaway settle is abandoned)."
   [machine entry-r]
-  (result/with-ok [boot-snapshot entry-fx] entry-r
+  (rf.machines.result/with-ok [boot-snapshot entry-fx] entry-r
     (if (parallel? machine)
       (let [;; The entry cascade is prepended by the caller. Seed this settle
             ;; with only its snapshot/fx so it contributes eventless rows once.
-            first-r (-> (result/ok boot-snapshot (vec entry-fx))
-                        (result/with-handled false)
-                        (result/with-microsteps 0)
-                        (result/with-cascade []))]
+            first-r (-> (rf.machines.result/ok boot-snapshot (vec entry-fx))
+                        (rf.machines.result/with-handled false)
+                        (rf.machines.result/with-microsteps 0)
+                        (rf.machines.result/with-cascade []))]
         ;; A parallel machine BORN all-regions-final (each
         ;; region's initial+`:always` settles onto a `:final?` leaf) fires the
         ;; parallel root's `:on-done` on birth too — same transitionable signal
@@ -1773,12 +1773,12 @@
         (fire-parallel-on-done machine
                                (drain-parent-queue machine boot-snapshot nil first-r)
                                true))
-      (transition/drain-to-fixed-point
+      (rf.machines.transition/drain-to-fixed-point
         machine
         ;; Seed with the entry Result's fx so an initial-`:entry` `[:raise ...]`
         ;; drains FIFO inside the birth macrostep instead of escaping to the
         ;; outbound fx layer (bz0ox.1).
-        (result/ok boot-snapshot (vec entry-fx))
+        (rf.machines.result/ok boot-snapshot (vec entry-fx))
         0
         false))))
 
@@ -1797,10 +1797,10 @@
       post-cascade snapshot, BEFORE commit, so a transient initial leaf
       whose `:always` guard already holds settles past, unobserved.
 
-  Returns a `result/ok` carrying the settled snapshot + the (drained) entry
+  Returns a `rf.machines.result/ok` carrying the settled snapshot + the (drained) entry
   fx ++ any settle fx, with `::cascade` = the entry cascade ++ the `:always`
   microsteps (so the `:rf.machine/transition` / `:rf.machine/started`
-  trace surfaces both). A `result/fail` from either phase short-circuits.
+  trace surfaces both). A `rf.machines.result/fail` from either phase short-circuits.
 
   `settle-birth` is seeded with the WHOLE `run-initial-cascade` Result so any
   `[:raise ...]` emitted by an initial `:entry` action drains FIFO inside this
@@ -1815,13 +1815,13 @@
   the post-cascade snapshot + the entry fx verbatim with the tag union
   re-stamped.
 
-  Guard-throw → `result/fail` (XState v5 alignment): a guard
+  Guard-throw → `rf.machines.result/fail` (XState v5 alignment): a guard
   body that throws during the birth-time `:always` selection surfaces the
   error and aborts the birth macrostep through the SAME failed-macrostep
   surface a thrown initial-`:entry` action takes. The tagged guard-throw
-  signal (`transition/guard-threw-signal?`) is caught at this birth
+  signal (`rf.machines.transition/guard-threw-signal?`) is caught at this birth
   boundary — the second pure-engine entry point alongside
-  `machine-transition` — and converted to a `result/fail`."
+  `machine-transition` — and converted to a `rf.machines.result/fail`."
   [machine initial-snapshot]
   ;; Desugar `:timeout` / `:on-timeout` so an initial state's
   ;; timeout arms at birth via the same `:after`-schedule fx the cascade
@@ -1831,25 +1831,25 @@
   ;; unaffected. Mirrors the desugar + region-order normalisation at the
   ;; `machine-transition` entry so the birth cascade reads canonical order.
   (let [machine (normalise-region-order
-                  (choice/desugar-choices (timeout/desugar-timeouts machine)))]
+                  (rf.machines.choice/desugar-choices (rf.machines.timeout/desugar-timeouts machine)))]
     (try
       (apply-initial-entry-cascade* machine initial-snapshot)
       (catch #?(:clj Throwable :cljs :default) e
-        (if (transition/guard-threw-signal? e)
-          (result/fail (transition/guard-threw->fail-info e))
+        (if (rf.machines.transition/guard-threw-signal? e)
+          (rf.machines.result/fail (rf.machines.transition/guard-threw->fail-info e))
           (throw e))))))
 
 (defn- apply-initial-entry-cascade*
   "Inner body of `apply-initial-entry-cascade` — wrapped by it for the
-  guard-throw → `result/fail` conversion at the birth boundary."
+  guard-throw → `rf.machines.result/fail` conversion at the birth boundary."
   [machine initial-snapshot]
   (let [entry-r (run-initial-cascade machine initial-snapshot)]
-    (if (result/fail? entry-r)
+    (if (rf.machines.result/fail? entry-r)
       entry-r
       (let [settle-r (settle-birth machine entry-r)]
-        (if (result/fail? settle-r)
+        (if (rf.machines.result/fail? settle-r)
           settle-r
-          (result/with-ok [settled-snap settle-fx] settle-r
+          (rf.machines.result/with-ok [settled-snap settle-fx] settle-r
             ;; `settle-fx` already = entry (non-raise) fx ++ settle fx, with
             ;; the initial-`:entry` raises drained internally (bz0ox.1).
             ;; Cascade: entry cascade ++ the `:always` microstep cascade.
@@ -1857,12 +1857,12 @@
             ;; `:always`). The settle's `parallel-done-handled?`
             ;; flag (set when a parallel machine born all-final fired its root
             ;; `:on-done`) rides through so the birth finalize gate sees it.
-            (cond-> (-> (result/ok settled-snap (vec settle-fx))
-                        (result/with-cascade
-                          (into (vec (result/cascade entry-r))
-                                (result/cascade settle-r)))
-                        (result/with-microsteps (result/microsteps settle-r)))
-              (result/parallel-done-handled? settle-r) (result/with-parallel-done))))))))
+            (cond-> (-> (rf.machines.result/ok settled-snap (vec settle-fx))
+                        (rf.machines.result/with-cascade
+                          (into (vec (rf.machines.result/cascade entry-r))
+                                (rf.machines.result/cascade settle-r)))
+                        (rf.machines.result/with-microsteps (rf.machines.result/microsteps settle-r)))
+              (rf.machines.result/parallel-done-handled? settle-r) (rf.machines.result/with-parallel-done))))))))
 
 ;; ---- destroy-time exit cascade --------------------------------------------
 ;;
@@ -1880,12 +1880,12 @@
   "Synthesise the destroy-time exit cascade for `machine` against its
   active `snapshot`. For parallel-region machines, runs the exit cascade
   for every region in declaration order via `reduce-regions` (the
-  per-region step delegates to `transition/run-active-exit-cascade`).
+  per-region step delegates to `rf.machines.transition/run-active-exit-cascade`).
   For flat / compound machines, drops straight into the single-machine
   helper.
 
   Returns a `re-frame.machines.result/Result` carrying the post-cascade
-  snapshot + accumulated fx, or a `result/fail` if any region's `:exit`
+  snapshot + accumulated fx, or a `rf.machines.result/fail` if any region's `:exit`
   action threw."
   [machine snapshot]
   (if (parallel? machine)
@@ -1893,5 +1893,5 @@
     ;; destroy exit cascade is a public engine entry NOT behind the transition
     ;; desugar seam, so canonicalise here too before `reduce-regions` reads it.
     (reduce-regions (normalise-region-order machine) snapshot
-                    transition/run-active-exit-cascade)
-    (transition/run-active-exit-cascade machine snapshot)))
+                    rf.machines.transition/run-active-exit-cascade)
+    (rf.machines.transition/run-active-exit-cascade machine snapshot)))

--- a/implementation/machines/src/re_frame/machines/reply.cljc
+++ b/implementation/machines/src/re_frame/machines/reply.cljc
@@ -83,7 +83,7 @@
   the shared `re-frame.reply/suppress` and spell `:cancelled` identically —
   uniform where it matters; the obsolescence DETERMINATION is correctly
   surface-specific."
-  (:require [re-frame.reply :as reply]))
+  (:require [re-frame.reply :as rf.reply]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -652,7 +652,7 @@
   `:rf.reply/stale-reason`) ride verbatim. `opts` is forwarded to the walker (e.g.
   `:frame`)."
   ([reply] (trace-reply reply nil))
-  ([reply opts] (reply/trace-summary reply opts)))
+  ([reply opts] (rf.reply/trace-summary reply opts)))
 
 (defn stale-spawn-trace
   "Build a DATA-ONLY trace summary of a `stale-spawn-reply` for the

--- a/implementation/machines/src/re_frame/machines/spawn_order.cljc
+++ b/implementation/machines/src/re_frame/machines/spawn_order.cljc
@@ -13,7 +13,7 @@
   ## Two channels, one authority
 
   **The DURABLE vector at `[:rf.runtime/machines :spawn-order]` is the
-  source of truth** (`paths/spawn-order-path`; see that ns docstring for
+  source of truth** (`rf.machines.paths/spawn-order-path`; see that ns docstring for
   the slot's contract). It is an oldest-to-newest vector of live spawned
   actor-ids, written by `record-in-runtime-db` / `forget-in-runtime-db`
   below — each called from inside the SAME runtime-db swap as the
@@ -70,7 +70,7 @@
   final-state auto-destroy) removes; frame destroy walks in reverse and
   clears. The transient atom follows the same pattern as the `:after`
   timer table in `re-frame.machines.timer/after-timers`."
-  (:require [re-frame.machines.paths :as paths]))
+  (:require [re-frame.machines.paths :as rf.machines.paths]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -87,7 +87,7 @@
   lazily) or when every spawned actor has been torn down (it is pruned
   when it empties)."
   [runtime-db]
-  (or (get-in runtime-db (paths/spawn-order-path)) []))
+  (or (get-in runtime-db (rf.machines.paths/spawn-order-path)) []))
 
 (defn record-in-runtime-db
   "Append `actor-id` to the durable spawn-order vector in `runtime-db`,
@@ -98,7 +98,7 @@
   [runtime-db actor-id]
   (if (nil? actor-id)
     runtime-db
-    (update-in runtime-db (paths/spawn-order-path)
+    (update-in runtime-db (rf.machines.paths/spawn-order-path)
                (fn [v]
                  (let [v (or v [])]
                    (if (some #(= actor-id %) v)
@@ -116,10 +116,10 @@
           (not (contains? (get runtime-db :rf.runtime/machines) :spawn-order)))
     runtime-db
     (let [remaining (filterv #(not= actor-id %)
-                             (get-in runtime-db (paths/spawn-order-path)))]
+                             (get-in runtime-db (rf.machines.paths/spawn-order-path)))]
       (if (empty? remaining)
         (update-in runtime-db [:rf.runtime/machines] dissoc :spawn-order)
-        (assoc-in runtime-db (paths/spawn-order-path) remaining)))))
+        (assoc-in runtime-db (rf.machines.paths/spawn-order-path) remaining)))))
 
 ;; ---- transient channel: the process-side cache ---------------------------
 

--- a/implementation/machines/src/re_frame/machines/ssr.cljc
+++ b/implementation/machines/src/re_frame/machines/ssr.cljc
@@ -51,7 +51,7 @@
   does not SSR carries none of this path; an SSR app without machines sees the
   hook unbound and ships the (already machine-less) runtime-db unchanged.
   Pure / host-agnostic CLJC — SSR runs on the JVM."
-  (:require [re-frame.classification :as classification]))
+  (:require [re-frame.classification :as rf.classification]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -86,7 +86,7 @@
   [actor-id snapshot frame-id]
   (if-not (and (map? snapshot) (contains? snapshot :data) frame-id)
     snapshot
-    (let [{:keys [sensitive large]} (classification/frame-snapshot-classification frame-id actor-id)
+    (let [{:keys [sensitive large]} (rf.classification/frame-snapshot-classification frame-id actor-id)
           ;; frame-snapshot-classification returns snapshot-rooted paths ([:data …]);
           ;; the SSR projector walks the bare :data MAP, so strip the leading
           ;; :data segment to index into it directly.
@@ -96,7 +96,7 @@
           s-paths (strip sensitive)
           l-paths (strip large)]
       (if (or (seq s-paths) (seq l-paths))
-        (update snapshot :data classification/redact-with-paths s-paths l-paths)
+        (update snapshot :data rf.classification/redact-with-paths s-paths l-paths)
         snapshot))))
 
 (defn project-ssr-runtime-db

--- a/implementation/machines/src/re_frame/machines/timeout.cljc
+++ b/implementation/machines/src/re_frame/machines/timeout.cljc
@@ -57,7 +57,7 @@
   `:after`, `:timeout` does NOT admit sub-vector / fn dynamic delays — a
   timeout is a fixed wall-clock deadline.)"
   (:require [clojure.string :as str]
-            [re-frame.error :as error]))
+            [re-frame.error :as rf.error]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -327,7 +327,7 @@
   discriminator; `reason` is the human diagnostic; `extra` merges
   per-site slots."
   [error-id reason extra]
-  (error/thrown-ex-info error-id 'rf/reg-machine reason
+  (rf.error/thrown-ex-info error-id 'rf/reg-machine reason
                         {:recovery :fix-registration :extra extra}))
 
 (defn- validate-one-timeout!

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -6,7 +6,7 @@
   (`re-frame.machines.transition`) emits one `:rf.machine/after-schedule`
   fx per `:after` entry. The fx handler here resolves the delay (pos-int?
   literal / subscription vector / fn-form), schedules a real timer via
-  `interop/schedule-after!` (the Spec 005 §Clock abstraction primitive —
+  `rf.interop/schedule-after!` (the Spec 005 §Clock abstraction primitive —
   `set-timeout!`'s spec-named machines surface), and (for sub-vec delays)
   installs a watcher
   that triggers cancel-and-reschedule on sub-value change. On expiry the
@@ -35,15 +35,15 @@
   No-op under `:platform :server` (per Spec 005 §SSR mode); the pure side
   already emitted `:rf.machine.timer/skipped-on-server` in place of
   /scheduled."
-  (:require [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.machines.paths :as paths]
-            [re-frame.machines.reply :as m-reply]
-            [re-frame.machines.transition :as transition]
-            [re-frame.managed-timer :as managed-timer]
-            [re-frame.subs :as subs]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.machines.reply :as rf.machines.reply]
+            [re-frame.machines.transition :as rf.machines.transition]
+            [re-frame.managed-timer :as rf.managed-timer]
+            [re-frame.subs :as rf.subs]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -84,7 +84,7 @@
   ;; Cancellation (state exit + sub re-resolution) clears the entry and
   ;; releases the handle / detaches the watcher. Frame-teardown clears the
   ;; entire inner map via the `:machines/on-frame-destroyed!` late-bind
-  ;; hook invoked from `frame/destroy-frame!`.
+  ;; hook invoked from `rf.frame/destroy-frame!`.
   (atom {}))
 
 (defn- after-timer-key
@@ -131,7 +131,7 @@
     ;; `{:snapshot ...}` and returns a positive-int ms delay.
     (let [v (try (delay-key {:snapshot snapshot})
                  (catch #?(:clj Throwable :cljs :default) e
-                   (trace/emit-error! :rf.error/machine-after-fn-threw
+                   (rf.trace/emit-error! :rf.error/machine-after-fn-threw
                                       {:exception e
                                        :frame     frame-id
                                        :recovery  :no-clock-configured})
@@ -141,13 +141,13 @@
     (vector? delay-key)
     ;; subscribe to keep the reaction live; caller will add-watch for
     ;; change-detection then unsubscribe on cancellation.
-    (let [reaction (subs/subscribe delay-key {:frame frame-id})
+    (let [reaction (rf.subs/subscribe delay-key {:frame frame-id})
           v        (when reaction
                      (try @reaction
                           (catch #?(:clj Throwable :cljs :default) e
                             ;; Canonical subscription identity: `:rf.sub/id`
                             ;; (+ `:rf.sub/query-v` for the full vector).
-                            (trace/emit-error! :rf.error/machine-after-sub-threw
+                            (rf.trace/emit-error! :rf.error/machine-after-sub-threw
                                                {:exception      e
                                                 :rf.sub/id      (first delay-key)
                                                 :rf.sub/query-v (vec delay-key)
@@ -170,7 +170,7 @@
 
   rf2-i4aj9c — the host-clock cancel and `remove-watch` release THIS entry's
   own captured handle / reaction (A's own host work), so they always run. The
-  `subs/unsubscribe frame-id delay-key` is the ONE shared release: the
+  `rf.subs/unsubscribe frame-id delay-key` is the ONE shared release: the
   subscription cache is ref-counted by `(frame-id, query-v)`, so once the
   cancellation trace has destroyed A and re-armed the SAME query in same-id
   B (bumping the shared count), A's decrement would dispose B's fresh
@@ -184,12 +184,12 @@
    ;; Shared best-effort host-clock cancel — swallows throws and no-ops a nil
    ;; handle, tolerating the partial-state entries (literal- / fn-form delays
    ;; whose watcher / reaction slots are nil).
-   (managed-timer/cancel! (:handle entry))
+   (rf.managed-timer/cancel! (:handle entry))
    (when (and (:reaction entry) (:sub-watcher-key entry))
      (try (remove-watch (:reaction entry) (:sub-watcher-key entry))
           (catch #?(:clj Throwable :cljs :default) _ nil))
      (when (and (vector? delay-key) frame-id (not (owner-gone?)))
-       (try (subs/unsubscribe frame-id delay-key)
+       (try (rf.subs/unsubscribe frame-id delay-key)
             (catch #?(:clj Throwable :cljs :default) _ nil))))))
 
 (defonce ^:private after-attempt-counter
@@ -281,7 +281,7 @@
         ;; discriminator. The reply facts ride ADDITIVELY — the public trace
         ;; shape (`:actor-id` / `:state` / `:delay` / `:epoch` / `:reason` /
         ;; sub identity) is preserved.
-        cancel-reply (m-reply/cancelled-timer-reply
+        cancel-reply (rf.machines.reply/cancelled-timer-reply
                        {:actor-id  (:parent k)
                         :state     (:state entry)
                         :delay     (:resolved-ms entry)
@@ -289,8 +289,8 @@
                         :epoch     (:epoch entry)
                         :frame     frame-id
                         :reason    reason})
-        summary      (m-reply/trace-reply cancel-reply {:frame frame-id})]
-    (trace/emit! :rf.machine :rf.machine.timer/cancelled
+        summary      (rf.machines.reply/trace-reply cancel-reply {:frame frame-id})]
+    (rf.trace/emit! :rf.machine :rf.machine.timer/cancelled
                  (cond-> {;; the timer's owning actor INSTANCE;
                           ;; `:machine-id` is reserved for the registered TYPE.
                           :actor-id   (:parent k)
@@ -343,9 +343,9 @@
   destroyed there, so the frame incarnation is stable and the token check would be
   too weak)."
   [frame-id]
-  (let [captured-incarnation (frame/frame-incarnation-token frame-id)]
+  (let [captured-incarnation (rf.frame/frame-incarnation-token frame-id)]
     (if (some? captured-incarnation)
-      (fn [] (not (frame/frame-incarnation-live? frame-id captured-incarnation)))
+      (fn [] (not (rf.frame/frame-incarnation-live? frame-id captured-incarnation)))
       (constantly false))))
 
 (def ^:dynamic ^:private *announcing-attempt-tokens*
@@ -449,7 +449,7 @@
 
   rf2-i4aj9c / rf2-rbxdxa — `emit-cancelled!` is CALLBACK-BEARING; `owner-gone?`
   (defaulting to a same-id-successor predicate captured BEFORE the trace) is
-  threaded into `release-entry-resources!` so the shared `subs/unsubscribe`
+  threaded into `release-entry-resources!` so the shared `rf.subs/unsubscribe`
   decrement is skipped once A is lost, while an ordinary cancellation with no
   successor still releases fully."
   ([frame-id k reason] (cancel-after-timer-entry! frame-id k reason (successor-published?-fn frame-id)))
@@ -501,8 +501,8 @@
       ;; once a cancellation listener has replaced A with B, nothing A-derived is
       ;; read from or installed into the successor.
       (when-let [rt (and (not (owner-gone?))
-                         (frame/frame-runtime-db-value frame-id))]
-        (let [snap (get-in rt (paths/snapshot-path parent-id))
+                         (rf.frame/frame-runtime-db-value frame-id))]
+        (let [snap (get-in rt (rf.machines.paths/snapshot-path parent-id))
               ;; Per Spec 005 §Per-region :after scoping: for parallel-region
               ;; machines the snapshot's :state is a map
               ;; of region-name → that region's state, and the invoke-id
@@ -519,9 +519,9 @@
                 (let [rn (first invoke-id)
                       iid-tail (vec (rest invoke-id))]
                   [iid-tail
-                   (when-let [rs (get (:state snap) rn)] (transition/state-path rs))
+                   (when-let [rs (get (:state snap) rn)] (rf.machines.transition/state-path rs))
                    [:data :rf/after-epoch-by-region rn iid-tail]])
-                [invoke-id (when snap (transition/state-path (:state snap)))
+                [invoke-id (when snap (rf.machines.transition/state-path (:state snap)))
                  [:data :rf/after-epoch (vec invoke-id)]])
               still-here? (and active
                                 (= (vec in-region-invoke-id)
@@ -610,7 +610,7 @@
   involved: the deferred row carries the claimant's own reason."
   [frame-id parent-id invoke-id state delay-key epoch server? snapshot
    {:keys [emit-scheduled-trace? owner-gone?]}]
-  (let [delay-source (transition/classify-delay-source delay-key)
+  (let [delay-source (rf.machines.transition/classify-delay-source delay-key)
         k            (after-timer-key parent-id invoke-id delay-key)
         ;; rf2-ijlhj — the owning incarnation, captured BEFORE the callback-bearing
         ;; `:on-supersede` cancel and rechecked before the durable arm below.
@@ -652,7 +652,7 @@
           ;; Bad delay resolution — emit advisory and skip.
           ;;
           ;; `resolve-delay-ms` for a subscription-vector delay calls
-          ;; `subs/subscribe` (bumping the sub-cache ref-count) BEFORE we
+          ;; `rf.subs/subscribe` (bumping the sub-cache ref-count) BEFORE we
           ;; know whether the resolved value is usable. The bad-delay branch
           ;; short-circuits and stores nothing in `after-timers`, so no
           ;; future `cancel-after-timer-entry!` will ever run
@@ -661,9 +661,9 @@
           ;; ref-count. Per Spec 006 §Reference counting and disposal.
           (do
             (when (and reaction (vector? delay-key))
-              (try (subs/unsubscribe frame-id delay-key)
+              (try (rf.subs/unsubscribe frame-id delay-key)
                    (catch #?(:clj Throwable :cljs :default) _ nil)))
-            (trace/emit! :warning :rf.warning/no-clock-configured
+            (rf.trace/emit! :warning :rf.warning/no-clock-configured
                          ;; the timer's owning actor is a LIVE INSTANCE;
                          ;; address it by `:actor-id`, not `:machine-id`
                          ;; (reserved for the registered TYPE).
@@ -729,7 +729,7 @@
               ;; already out and emits its `/cancelled` at once, in place.
               (binding [*announcing-attempt-tokens*
                         (conj *announcing-attempt-tokens* token)]
-                (trace/emit! :rf.machine :rf.machine.timer/scheduled
+                (rf.trace/emit! :rf.machine :rf.machine.timer/scheduled
                              (cond-> {;; the timer's owning actor INSTANCE;
                                       ;; `:machine-id` is reserved for the
                                       ;; registered TYPE.
@@ -745,7 +745,7 @@
                                (assoc :rf.sub/id      (first delay-key)
                                       :rf.sub/query-v (vec delay-key))))))
             ;; rf2-jqvgp — that `/scheduled` emit is the LAST callback-bearing
-            ;; step before the durable arm. `trace/emit!` invokes listeners
+            ;; step before the durable arm. `rf.trace/emit!` invokes listeners
             ;; SYNCHRONOUSLY, so a `:rf.machine.timer/scheduled` listener can
             ;; `destroy-frame!` the owning incarnation A and publish a same-id
             ;; successor B right here — after the post-supersede recheck above.
@@ -761,7 +761,7 @@
             ;; ref-count, bumped by `resolve-delay-ms` against A's OWN sub-cache
             ;; — which `destroy-frame!` disposed wholesale
             ;; (`:subs.cache/dispose-all-for-frame-destroy!`) on this very
-            ;; stack. `subs/unsubscribe` addresses the frame by bare id, so a
+            ;; stack. `rf.subs/unsubscribe` addresses the frame by bare id, so a
             ;; decrement here would land on B and could dispose a reaction B
             ;; holds for the same query. Nothing of A's survives to release, and
             ;; the release that would reach it is the one that must not run —
@@ -806,7 +806,7 @@
                     ;; known-positive here (the non-positive case was handled by
                     ;; the prior `cond` branch), so the guard is a no-op
                     ;; pass-through.
-                    (managed-timer/arm!
+                    (rf.managed-timer/arm!
                       (fn []
                         ;; ATOMICALLY claim THIS fire's slot — dispatch AUTHORITY
                         ;; + reap in a single swap (mirrors core `:dispatch-later`,
@@ -817,7 +817,7 @@
                         ;; dispatch and touch nothing (the claimer already released
                         ;; our resources). On the live path the claim wins:
                         (when-let [claimed (claim-entry! frame-id k token)]
-                          (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+                          (when-let [dispatch! (rf.late-bind/get-fn :router/dispatch!)]
                             ;; Stamp `:source :after-timer` so the Epoch panel's
                             ;; DISPATCH step labels it "from :after timer" and
                             ;; Xray's L2 timeline can prefix the row + per-source
@@ -899,7 +899,7 @@
                         ;; step. A throw here lands on the same
                         ;; `:recovery :static-delay` signal as a failed
                         ;; `add-watch` — both mean the dynamic delay is not wired.
-                        (interop/activate-derived-value! reaction)
+                        (rf.interop/activate-derived-value! reaction)
                         (add-watch reaction watch-key
                                    (fn [_ _ old-v new-v]
                                      (on-sub-changed! frame-id parent-id invoke-id
@@ -907,7 +907,7 @@
                         (catch #?(:clj Throwable :cljs :default) e
                           ;; Owning actor INSTANCE under `:actor-id`; canonical
                           ;; subscription identity (`:rf.sub/id` + `:rf.sub/query-v`).
-                          (trace/emit-error! :rf.error/machine-after-watch-failed
+                          (rf.trace/emit-error! :rf.error/machine-after-watch-failed
                                              {:exception      e
                                               :actor-id       parent-id
                                               :rf.sub/id      (first delay-key)
@@ -920,7 +920,7 @@
                   ;; (idempotent even if it already fired). The claimer already
                   ;; released the reaction and emitted the single owed `:cancelled`
                   ;; trace (or, for a self-fire, dispatched + released silently).
-                  (do (managed-timer/cancel! handle)
+                  (do (rf.managed-timer/cancel! handle)
                       nil))))))))))))
 
 (defn after-schedule-fx
@@ -928,7 +928,7 @@
   `:after` transitions, on entry to an :after-bearing state node the
   runtime emits one of these per :after entry. The handler
   resolves the delay (literal pos-int? / subscription vector / fn),
-  schedules a real wall-clock timer via `interop/schedule-after!` (Spec
+  schedules a real wall-clock timer via `rf.interop/schedule-after!` (Spec
   005 §Clock abstraction), and (for
   subscription delays) installs an add-watch that triggers
   cancel-and-reschedule on sub-value change.
@@ -947,7 +947,7 @@
   (let [;; The cascade envelope frame is the fx-context `:frame`; a nil
         ;; stamp is an invariant failure (`:rf.error/no-frame-context`),
         ;; never a synthesised `:rf/default`.
-        frame-id   (frame/require-frame-stamp!
+        frame-id   (rf.frame/require-frame-stamp!
                      frame-id :rf.machine/after-schedule
                      {:where 'rf.machine/after-schedule
                       :event-id (:rf/parent-id args)})
@@ -958,8 +958,8 @@
         epoch      (:epoch args)
         server?    (boolean (:server? args))
         ;; Machine snapshots are durable runtime-db state.
-        snapshot   (get-in (frame/frame-runtime-db-value frame-id)
-                           (paths/snapshot-path parent-id))]
+        snapshot   (get-in (rf.frame/frame-runtime-db-value frame-id)
+                           (rf.machines.paths/snapshot-path parent-id))]
     ;; Initial state-entry scheduling — the :scheduled trace was already
     ;; emitted synchronously by apply-transition-once (the pure side). For
     ;; sub-vec delays, the fx layer's resolution may yield a different
@@ -1101,7 +1101,7 @@
   (let [;; The cascade envelope frame is the fx-context `:frame`; a nil
         ;; stamp is an invariant failure (`:rf.error/no-frame-context`),
         ;; never a synthesised `:rf/default`.
-        frame-id  (frame/require-frame-stamp!
+        frame-id  (rf.frame/require-frame-stamp!
                     frame-id :rf.machine/after-cancel
                     {:where 'rf.machine/after-cancel
                      :event-id (:rf/parent-id args)})
@@ -1150,11 +1150,11 @@
   SNAPSHOTS A's `[k entry]` pairs up front and cancels each by its snapshotted
   attempt token (`cancel-snapshotted-entry!`), so a re-read can never claim B's
   fresh-token entry; the destroy tail that follows this call (classification /
-  spawn-order / system-id release) resolves bare frame/actor ids to the CURRENT
+  spawn-order / system-id release) resolves bare rf.frame/actor ids to the CURRENT
   incarnation B. The optional `owner-gone?` predicate (the finalize cascade's
   exact-incarnation gate) is rechecked BEFORE each cancellation, so once the first
   cancellation loses A the loop short-circuits and never touches B's timer, and it
-  is threaded into the release so A's `subs/unsubscribe` cannot decrement a
+  is threaded into the release so A's `rf.subs/unsubscribe` cannot decrement a
   reaction B re-armed for the same query. `owner-gone?` is MONOTONIC (once A→B it
   stays gone). The 2-arity (the imperative `destroy` tail, which carries no event
   owner) passes `(constantly false)` — its historical behaviour, now still safe
@@ -1180,7 +1180,7 @@
   cancellation event; emitting traces here would pollute the trace
   stream observed by the next test.
 
-  1-arity: just the given frame's timers (`frame/destroy-frame!` hook).
+  1-arity: just the given frame's timers (`rf.frame/destroy-frame!` hook).
   Each cancelled timer emits one `:rf.machine.timer/cancelled` trace with
   `:reason :on-frame-destroy` so the Handler section's AFTER TIMERS
   sub-section can pair scheduled → cancelled on frame teardown.

--- a/implementation/machines/src/re_frame/machines/tooling.cljc
+++ b/implementation/machines/src/re_frame/machines/tooling.cljc
@@ -40,12 +40,12 @@
   Per [Derivations.md](../../../../../../spec/Derivations.md) §Machines expose
   algebra views and the projected Malli shapes in
   [Spec-Schemas §`:rf/derivation-node`](../../../../../../spec/Spec-Schemas.md)."
-  (:require [re-frame.derivation.node :as node]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.machines.lifecycle-fx.resolver :as resolver]
-            [re-frame.machines.paths :as paths]
-            [re-frame.registrar :as registrar]))
+  (:require [re-frame.derivation.node :as rf.derivation.node]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.machines.lifecycle-fx.resolver :as rf.machines.lifecycle-fx.resolver]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.registrar :as rf.registrar]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -106,19 +106,19 @@
 (defn- machine-spec
   "The registered machine SPEC for `machine-id` (the value at `:rf/machine`),
   or nil when no machine is registered under that id. Delegates to the leaf
-  `resolver/spec-from-registry` — the same registrar read
+  `rf.machines.lifecycle-fx.resolver/spec-from-registry` — the same registrar read
   `re-frame.machines/machine-meta` performs (this sibling requires `resolver`
   directly, NOT the `re-frame.machines` facade, which requires THIS sibling for
   its JVM alias — the dependency must point one way)."
   [machine-id]
-  (resolver/spec-from-registry machine-id))
+  (rf.machines.lifecycle-fx.resolver/spec-from-registry machine-id))
 
 (defn- registered-machine-ids
   "Every registered machine-id — every `:event` registration whose metadata
   carries `:rf/machine? true`. The same filter `re-frame.machines/machines`
   performs, inlined to avoid the facade require (see `machine-spec`)."
   []
-  (->> (registrar/registrations :event)
+  (->> (rf.registrar/registrations :event)
        (keep (fn [[id m]] (when (:rf/machine? m) id)))))
 
 (defn- declared-event?
@@ -207,7 +207,7 @@
   user-supplied spec keys. Functions stay opaque — a machine's transition
   logic is its `:states` / `:actions` / `:guards`, never serialized here."
   [node machine meta]
-  (cond-> (node/attach-source node meta)
+  (cond-> (rf.derivation.node/attach-source node meta)
     (contains? machine :doc)              (assoc :doc (:doc machine))
     (get-in machine [:schemas :data])     (assoc :schema (get-in machine [:schemas :data]))))
 
@@ -227,7 +227,7 @@
   declared `[:event …]` triggers), `:output` (the runtime-db snapshot path),
   `:source-form`, `:spawns?` flag, and source coords / schema / doc."
   [id source-id machine meta]
-  (-> (node/node-base id [:runtime (paths/snapshot-path id)]
+  (-> (rf.derivation.node/node-base id [:runtime (rf.machines.paths/snapshot-path id)]
                       {:kind          :process
                        :storage       :runtime-db
                        :evaluation    (evaluation-policy machine)
@@ -308,14 +308,14 @@
        (if-let [machine (machine-spec machine-id)]
          (assoc acc machine-id
                 (node-for machine-id machine-id machine
-                          (registrar/lookup :event machine-id)))
+                          (rf.registrar/lookup :event machine-id)))
          acc))
      {}
      (registered-machine-ids)))
   ([machine-id]
    (when-let [machine (machine-spec machine-id)]
      (node-for machine-id machine-id machine
-               (registrar/lookup :event machine-id)))))
+               (rf.registrar/lookup :event machine-id)))))
 
 (defn machine-instance-algebra-view
   "Return the LIVE derivation/process algebra view of a frame's machine
@@ -364,15 +364,15 @@
   one-arity form takes an explicit `frame-id` (the form the graph composer's
   `:live-fn` calls).
 
-  CLJS-and-JVM runnable, but dev-gated on `interop/debug-enabled?` (the
+  CLJS-and-JVM runnable, but dev-gated on `rf.interop/debug-enabled?` (the
   `goog.DEBUG` mirror) so production builds DCE the runtime-db walk. Returns
   `nil` for a missing/destroyed frame and in production builds, `{}` for a
   frame with no live machine snapshots."
-  ([] (machine-instance-algebra-view (frame/current-frame)))
+  ([] (machine-instance-algebra-view (rf.frame/current-frame)))
   ([frame-id]
-   (when interop/debug-enabled?
-     (when-let [runtime-db (frame/frame-runtime-db-value frame-id)]
-       (let [snapshots (get-in runtime-db (paths/snapshot-path))]
+   (when rf.interop/debug-enabled?
+     (when-let [runtime-db (rf.frame/frame-runtime-db-value frame-id)]
+       (let [snapshots (get-in runtime-db (rf.machines.paths/snapshot-path))]
          (reduce-kv
            (fn [acc actor-id snapshot]
              (let [machine-type (:rf/machine-type snapshot)
@@ -383,7 +383,7 @@
                    ;; map → verbatim) via the leaf resolver.
                    spawned?     (some? machine-type)
                    spec         (if spawned?
-                                  (resolver/spec-from-snapshot snapshot)
+                                  (rf.machines.lifecycle-fx.resolver/spec-from-snapshot snapshot)
                                   (machine-spec actor-id))
                    ;; The source-id whose coords / source-form we inherit: the
                    ;; registered type keyword (a keyword `:rf/machine-type`,
@@ -397,7 +397,7 @@
                (if spec
                  (assoc acc actor-id
                         (-> (node-for actor-id source-id spec
-                                      (registrar/lookup :event source-id))
+                                      (rf.registrar/lookup :event source-id))
                             (assoc :spawned? spawned?)
                             (cond-> (contains? snapshot :state)
                               (assoc :state (:state snapshot)))))
@@ -425,7 +425,7 @@
   Returns `false` for a non-machine sub, an unregistered id, and a parametric
   input-fn sub. JVM-runnable — pure data over the registrar."
   [sub-id]
-  (let [meta (registrar/lookup :sub sub-id)]
+  (let [meta (rf.registrar/lookup :sub sub-id)]
     (boolean
       (and meta
            (= :static (:input-kind meta))
@@ -463,7 +463,7 @@
   input-fn sub, or a selector whose machine-id is non-literal. JVM-runnable
   — pure data over the registrar."
   [sub-id]
-  (let [meta (registrar/lookup :sub sub-id)]
+  (let [meta (rf.registrar/lookup :sub sub-id)]
     (if-not (and meta (= :static (:input-kind meta)))
       #{}
       (into #{}

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -20,7 +20,7 @@
   determinism the conformance corpus, the SSR pure-fn surface, and
   `machine_transition_purity_test` rely on.
 
-  It is NOT effect-free of observability: the reducer emits `trace/emit!`
+  It is NOT effect-free of observability: the reducer emits `rf.trace/emit!`
   diagnostic events (guard outcomes, action runs, history record/restore,
   timer scheduling, microsteps, depth-limit aborts, unhandled-event
   no-ops) on the process-wide Spec 009 trace stream, exactly as the rest
@@ -49,14 +49,14 @@
   fixtures (Spec 005 §Conformance fixtures)."
   (:require [clojure.set :as set]
             [clojure.string :as str]
-            [re-frame.error :as error]
-            [re-frame.machines.cofx-attach :as cofx-attach]
-            [re-frame.machines.grammar :as grammar]
-            [re-frame.machines.path-walk :as path-walk]
-            [re-frame.machines.reply :as m-reply]
-            [re-frame.machines.result :as result
+            [re-frame.error :as rf.error]
+            [re-frame.machines.cofx-attach :as rf.machines.cofx-attach]
+            [re-frame.machines.grammar :as rf.machines.grammar]
+            [re-frame.machines.path-walk :as rf.machines.path-walk]
+            [re-frame.machines.reply :as rf.machines.reply]
+            [re-frame.machines.result :as rf.machines.result
              #?@(:cljs [:include-macros true])]
-            [re-frame.trace :as trace]))
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -159,7 +159,7 @@
   `:recovery` defaults to `:fix-registration` (these are caller-fixable
   registration-shape errors) unless overridden in `extras` via `:rf/recovery`."
   [category reason extras]
-  (error/thrown-ex-info category 'rf/reg-machine reason
+  (rf.error/thrown-ex-info category 'rf/reg-machine reason
                         {:recovery (or (:rf/recovery extras) :fix-registration)
                          :extra    (dissoc extras :rf/recovery)}))
 
@@ -355,11 +355,11 @@
 ;; guard SURFACES the error and ABORTS transition selection — it is never
 ;; silently demoted to a lower-priority candidate, a wildcard tier, or an
 ;; ancestor edge. re-frame2 aligns by routing a guard throw through the
-;; SAME failure surface a THROWING ACTION takes: a `result/fail` macrostep
+;; SAME failure surface a THROWING ACTION takes: a `rf.machines.result/fail` macrostep
 ;; (atomic rollback — no snapshot write reaches runtime-db; the handler
 ;; short-circuits to `{}`). This is the exact contract the bounded-depth
 ;; abort already uses (XState v5 THROWS on a runaway cycle → re-frame2's
-;; `result/depth-abort` `:fail`), so a guard throw, an action throw, and a
+;; `rf.machines.result/depth-abort` `:fail`), so a guard throw, an action throw, and a
 ;; depth abort all converge on one failed-macrostep semantic.
 ;;
 ;; `evaluate-guard` is invoked DEEP inside the candidate-walk (`some` over
@@ -368,9 +368,9 @@
 ;; surface across the whole engine. Instead the throw is rethrown as a
 ;; TAGGED signal that the two pure-engine entry boundaries
 ;; (`parallel/machine-transition` + `parallel/apply-initial-entry-cascade`)
-;; catch once and convert to a `result/fail` — the same single-chokepoint
+;; catch once and convert to a `rf.machines.result/fail` — the same single-chokepoint
 ;; shape the engine already uses, and symmetric with how `run-action`
-;; returns its `result/fail` straight out of the cascade.
+;; returns its `rf.machines.result/fail` straight out of the cascade.
 
 (def ^:private guard-threw-key
   "Marker key stamped on the `ex-data` of the tagged guard-throw signal so
@@ -383,17 +383,17 @@
   "True iff `e` is the tagged guard-throw signal `evaluate-guard` rethrows
   when a user guard body throws — distinguishing it from the bad-form /
   unresolved-ref `ex-info`s (which propagate as raw exceptions, never
-  demoted to a `result/fail`)."
+  demoted to a `rf.machines.result/fail`)."
   [e]
   (and #?(:clj (instance? clojure.lang.ExceptionInfo e)
           :cljs (instance? cljs.core/ExceptionInfo e))
        (get (ex-data e) guard-threw-key)))
 
 (defn guard-threw->fail-info
-  "Project a tagged guard-throw signal's `ex-data` into a `result/fail`
+  "Project a tagged guard-throw signal's `ex-data` into a `rf.machines.result/fail`
   `::info` map — carrying the original `:exception`, the throwing
   `:guard-ref`, and the `:state-path` — for the engine boundary to wrap
-  via `result/fail`. The shape mirrors `run-action`'s failure info
+  via `rf.machines.result/fail`. The shape mirrors `run-action`'s failure info
   (`:exception` is the key `trace-action-failure!` reads) so a guard throw
   routes through the SAME `:rf.error/machine-action-exception` handler
   surface as an action throw, per the XState-v5 alignment ruling."
@@ -421,7 +421,7 @@
   selection — it is never swallowed and demoted to a lower-priority
   candidate. The engine boundaries (`parallel/machine-transition` /
   `apply-initial-entry-cascade`) catch the tagged signal and convert it to
-  a `result/fail`, routing it through the SAME failed-macrostep /
+  a `rf.machines.result/fail`, routing it through the SAME failed-macrostep /
   atomic-rollback surface a throwing ACTION takes (and the bounded-depth
   abort takes for the XState-v5-throws runaway cycle). This makes a guard
   throw, an action throw, and a depth abort converge on one failure
@@ -459,7 +459,7 @@
           input      {:data (:data snapshot) :event event}]
       (try
         (let [outcome (boolean (call-guard machine g snapshot event))]
-          (trace/emit! :rf.machine :rf.machine/guard-evaluated
+          (rf.trace/emit! :rf.machine :rf.machine/guard-evaluated
                        {:actor-id   actor-id
                         :guard-id   guard-ref
                         :input      input
@@ -468,7 +468,7 @@
                         :frame      frame-id})
           outcome)
         (catch #?(:clj Throwable :cljs :default) e
-          (trace/emit! :rf.machine :rf.machine/guard-evaluated
+          (rf.trace/emit! :rf.machine :rf.machine/guard-evaluated
                        {:actor-id   actor-id
                         :guard-id   guard-ref
                         :input      input
@@ -479,7 +479,7 @@
           ;; XState v5 alignment: surface the guard error and
           ;; abort selection — do NOT swallow it as `:fail` and walk to the
           ;; next candidate. Rethrow a TAGGED signal the engine boundary
-          ;; converts to a `result/fail` (the same failed-macrostep surface
+          ;; converts to a `rf.machines.result/fail` (the same failed-macrostep surface
           ;; an action throw / depth abort takes). The original exception
           ;; rides under `:exception` so the boundary's failure info matches
           ;; `run-action`'s shape.
@@ -618,14 +618,14 @@
 
 (defn node-at
   "Walk machine.:states down `path` returning the leaf state-node (or nil
-  if path doesn't resolve). Thin wrapper over `grammar/node-at` (the
+  if path doesn't resolve). Thin wrapper over `rf.machines.grammar/node-at` (the
   shared root→leaf descent the registration validators also consume) —
   passes the machine's `:states` scope. Kept as a public name here so
   the engine's many call sites (and `parallel` / `finalize` /
   `registration` / `spawn-error`) need not reach into `grammar`
   directly."
   [machine path]
-  (grammar/node-at (:states machine) path))
+  (rf.machines.grammar/node-at (:states machine) path))
 
 (defn nodes-along-path
   "Return [[prefix-path node] ...] from root down to leaf. Skips nodes
@@ -747,16 +747,16 @@
   `:always` → `machine-bad-always`).
 
   Delegates the value-form → candidate-maps mapping to the SHARED
-  `grammar/candidate-maps`, which returns nil
+  `rf.machines.grammar/candidate-maps`, which returns nil
   for the malformed form so THIS runtime caller keeps its slot-specific error
   taxonomy (`bad-value-id`) while the static cofx / validation walkers degrade
-  malformed input to `[]`. `grammar/candidate-maps` builds on the same
-  `grammar/transition-value-form` recogniser the registration target validator
-  (`grammar/candidate-targets`) also uses, so the runtime normaliser and the
+  malformed input to `[]`. `rf.machines.grammar/candidate-maps` builds on the same
+  `rf.machines.grammar/transition-value-form` recogniser the registration target validator
+  (`rf.machines.grammar/candidate-targets`) also uses, so the runtime normaliser and the
   registration walker can never drift on what shapes the grammar admits."
   [v bad-value-id]
-  (or (grammar/candidate-maps v)
-      ;; `grammar/candidate-maps` returns nil ONLY for the malformed
+  (or (rf.machines.grammar/candidate-maps v)
+      ;; `rf.machines.grammar/candidate-maps` returns nil ONLY for the malformed
       ;; (`:other`) form — every recognised form (incl. the `:nil`
       ;; forbidden-transition / internal no-op → `[{}]`) yields a candidate
       ;; vector. This runtime caller maps that nil to its slot-specific throw.
@@ -780,10 +780,10 @@
   spec-path discriminator: for the index-free forms the
   carried `:candidate-idx` is nil so `cascade-row-source-key` emits the
   bare-slot shape that matches the macro's keying. Delegates to the
-  shared `grammar/candidate-vector-form?` so the per-index decision and
+  shared `rf.machines.grammar/candidate-vector-form?` so the per-index decision and
   the `normalise-candidates` arm read the same recogniser."
   [v]
-  (grammar/candidate-vector-form? v))
+  (rf.machines.grammar/candidate-vector-form? v))
 
 (defn- transition-slot
   "Build the structured spec-path DISCRIMINATOR carried on a
@@ -1284,7 +1284,7 @@
         ;; Fall through to the standard leaf→root `:on` walk (an ancestor's
         ;; explicit `:on {:rf.machine/done …}`), then the root `:on`.
         (or
-          (path-walk/walk-path-leaf-to-root
+          (rf.machines.path-walk/walk-path-leaf-to-root
             machine path
             (fn [prefix n]
               (when-let [hit (match-on-clause machine n done-event-id event snapshot)]
@@ -1387,7 +1387,7 @@
         ;; Fall through to the standard leaf→root `:on` walk (an ancestor's
         ;; explicit `:on {:rf.machine.spawn/error …}`), then the root `:on`.
         (or
-          (path-walk/walk-path-leaf-to-root
+          (rf.machines.path-walk/walk-path-leaf-to-root
             machine path
             (fn [prefix n]
               (when-let [hit (match-on-clause machine n spawn-error-event-id event snapshot)]
@@ -1398,7 +1398,7 @@
 (defn pick-transition
   "Walk path leaf→root looking for a transition that matches event-id and
   whose guard passes. Per Spec 005 §Transition resolution — deepest-wins
-  with parent fallthrough (the rule named in `path-walk/walk-path-leaf-
+  with parent fallthrough (the rule named in `rf.machines.path-walk/walk-path-leaf-
   to-root`).
 
   The walk terminates at the **machine root's own `:on`** (Spec 005
@@ -1431,7 +1431,7 @@
       :else
       (or
         ;; Steps 1-5: leaf→root over the active state-path nodes.
-        (path-walk/walk-path-leaf-to-root
+        (rf.machines.path-walk/walk-path-leaf-to-root
           machine path
           (fn [prefix n]
             (when-let [hit (match-on-clause machine n event-id event snapshot)]
@@ -1563,9 +1563,9 @@
 
 (def history-node?
   "True iff `node` is a history pseudo-state (`:type :history`). The
-  shared `grammar/history-node?` — re-exported here so the engine's
+  shared `rf.machines.grammar/history-node?` — re-exported here so the engine's
   internal call sites need not require `grammar` directly."
-  grammar/history-node?)
+  rf.machines.grammar/history-node?)
 
 (defn state-occupiable?
   "True iff `state` (a flat keyword or compound vector path) resolves
@@ -1790,7 +1790,7 @@
   path `fallback` is absent and `restored-config` carries the recorded
   value."
   [machine compound-path resolved-leaf source kind restored-config fallback]
-  (trace/emit! :rf.machine :rf.machine.history/restored
+  (rf.trace/emit! :rf.machine :rf.machine.history/restored
                ;; The actor whose live transition restored
                ;; history is a running INSTANCE; address it by `:actor-id`
                ;; (`:machine-id` is the registered TYPE).
@@ -1809,7 +1809,7 @@
   `:recorded-config`, `:kind`, and (when not the first-ever recording)
   `:prev-config`."
   [machine recorded]
-  (trace/emit! :rf.machine :rf.machine.history/recorded
+  (rf.trace/emit! :rf.machine :rf.machine.history/recorded
                ;; The actor whose live exit recorded history is
                ;; a running INSTANCE; address it by `:actor-id`
                ;; (`:machine-id` is the registered TYPE).
@@ -1817,7 +1817,7 @@
                        :frame    (:rf/frame machine)}
                       recorded)))
 
-;; When an action throws, `run-action` returns a `result/fail` carrying
+;; When an action throws, `run-action` returns a `rf.machines.result/fail` carrying
 ;; `{:action-ref :exception}`. `collect-actions` propagates the failure;
 ;; `apply-transition-once` / `machine-transition-single` enrich it with
 ;; transition-level context; the outer event handler converts it into a
@@ -1827,7 +1827,7 @@
 
 (defn- run-action
   "Run one action ref and return either a plain effects map (success) or a
-  `result/fail` Result (the action threw). Successful actions may return
+  `rf.machines.result/fail` Result (the action threw). Successful actions may return
   `nil` (treated as `{}`).
 
   Every user-declared action invocation emits
@@ -1870,15 +1870,15 @@
                       transition-slot (assoc :transition-slot transition-slot))]
       (try
         (let [r (call-action machine f snap event)]
-          (trace/emit! :rf.machine :rf.machine/action-ran
+          (rf.trace/emit! :rf.machine :rf.machine/action-ran
                        (assoc base-tags :outcome (if (nil? r) :ok r)))
           (or r {}))
         (catch #?(:clj Throwable :cljs :default) e
-          (trace/emit! :rf.machine :rf.machine/action-ran
+          (rf.trace/emit! :rf.machine :rf.machine/action-ran
                        (assoc base-tags
                               :outcome   :rf.error/action-threw
                               :exception e))
-          (result/fail {:action-ref action-ref
+          (rf.machines.result/fail {:action-ref action-ref
                         :exception  e}))))
     {})))
 
@@ -1896,14 +1896,14 @@
   `{:machine-id :action-id :state-path :offending-value}`, recovery
   `:logged-and-skipped`.
 
-  `r` is the action's plain effects map (a `result/fail` has already been
+  `r` is the action's plain effects map (a `rf.machines.result/fail` has already been
   short-circuited by the caller, so this only ever sees a success map);
   `action-ref` and the `:state` path ride the diagnostic so the operator
   can locate the offending action."
   [machine r action-ref state-path]
   (if (and (map? r) (contains? r :db))
     (do
-      (trace/emit-error! :rf.error/machine-action-wrote-db
+      (rf.trace/emit-error! :rf.error/machine-action-wrote-db
                          ;; The offending action ran against a
                          ;; LIVE actor; address it by `:actor-id` (the
                          ;; running INSTANCE), not `:machine-id` (the TYPE).
@@ -1964,9 +1964,9 @@
 (defn- collect-actions
   "Walk `step` maps in order, calling each step's `:action` with snap+event
   and threading the resulting :data updates forward (so each action sees
-  the previous one's data). Returns a `result/ok` carrying
+  the previous one's data). Returns a `rf.machines.result/ok` carrying
   `[final-snapshot fx-vec cascade-steps]` (the third slot rides the Result
-  via `result/with-cascade`), or the `result/fail` Result the first
+  via `rf.machines.result/with-cascade`), or the `rf.machines.result/fail` Result the first
   throwing action produced — per Spec 005 §Errors, the cascade halts on
   the first throw and the snapshot does not commit.
 
@@ -1992,16 +1992,16 @@
   `:action` / `:data-delta`) — the driver `:phase` is an input that routes
   the emit, not part of the step shape the consumer reads. The accumulated
   cascade-step vector rides the returned `:ok` Result via
-  `result/with-cascade`; a `:fail` (a throwing action) carries no cascade —
+  `rf.machines.result/with-cascade`; a `:fail` (a throwing action) carries no cascade —
   the snapshot does not commit, so the partial walk is not surfaced."
   [machine snap event steps]
   ;; Internal accumulator is a `[result cascade-steps]` tuple so the
-  ;; cascade threads alongside the Result without widening `result/ok`'s
+  ;; cascade threads alongside the Result without widening `rf.machines.result/ok`'s
   ;; arity (which would churn every caller). `reduced` short-circuits on
   ;; the first throwing action, carrying the bare `:fail` Result.
   (let [acc (reduce
               (fn [[acc-r cascade] {:keys [kind phase action state region source transition-slot]}]
-                (result/with-ok [snap fx] acc-r
+                (rf.machines.result/with-ok [snap fx] acc-r
                   (let [before-data (:data snap)
                         emit-phase  (or phase kind)
                         ;; Per spec/009 §History trace events (line 291): a
@@ -2016,7 +2016,7 @@
                                       source (assoc :source source))]
                     (if action
                       (let [r0 (run-action machine snap action event emit-phase transition-slot)]
-                        (if (result/fail? r0)
+                        (if (rf.machines.result/fail? r0)
                           (reduced [r0 cascade])
                           ;; Per Spec 005 §Hard-disallow `:db`: strip any `:db`
                           ;; write (emitting the structured error) through the
@@ -2029,16 +2029,16 @@
                                 new-fx   (vec (concat fx (or (:fx r) [])))
                                 step     (assoc base-step
                                                 :data-delta (data-delta before-data new-data))]
-                            [(result/ok new-snap new-fx) (conj cascade step)])))
+                            [(rf.machines.result/ok new-snap new-fx) (conj cascade step)])))
                       ;; No action declared for this boundary — record the
                       ;; state-entered/exited step anyway (empty delta) so the
                       ;; cascade carries the full configuration walk, then
                       ;; carry the snapshot + fx unchanged.
                       [acc-r (conj cascade (assoc base-step :data-delta {}))]))))
-              [(result/ok snap []) []]
+              [(rf.machines.result/ok snap []) []]
               steps)
         [final-r cascade] acc]
-    (result/with-cascade final-r cascade)))
+    (rf.machines.result/with-cascade final-r cascade)))
 
 ;; ---- apply-transition-once helpers ----------------------------------------
 ;;
@@ -2056,7 +2056,7 @@
   the moment of entry. The fn is invoked with
   the unified context-map shape. The fn runs against the post-action
   snapshot (any :action :data writes are visible). Returns
-  `[::ok-data <materialised-data>]` on success, or a `result/fail` Result
+  `[::ok-data <materialised-data>]` on success, or a `rf.machines.result/fail` Result
   carrying `{:exception <e>}` if the fn threw — caller stamps
   `:action-ref` / `:invoke-id` / `:child-id` onto the Result before
   propagating."
@@ -2065,7 +2065,7 @@
     (try
       [::ok-data (d {:snapshot snap :event event})]
       (catch #?(:clj Throwable :cljs :default) e
-        (result/fail {:exception e})))
+        (rf.machines.result/fail {:exception e})))
     [::ok-data d]))
 
 (defn- build-after-fx
@@ -2116,7 +2116,7 @@
                           ;; actual resolved-ms once it has frame access).
                           ms-tag       delay-key]
                       (if server?
-                        (trace/emit! :rf.machine :rf.machine.timer/skipped-on-server
+                        (rf.trace/emit! :rf.machine :rf.machine.timer/skipped-on-server
                                      (cond-> {;; Owning actor INSTANCE.
                                               :actor-id     parent-id
                                               :state        leaf-state
@@ -2131,7 +2131,7 @@
                                        (= :sub delay-source)
                                        (assoc :rf.sub/id      (first delay-key)
                                               :rf.sub/query-v (vec delay-key))))
-                        (trace/emit! :rf.machine :rf.machine.timer/scheduled
+                        (rf.trace/emit! :rf.machine :rf.machine.timer/scheduled
                                      (cond-> {;; Owning actor INSTANCE.
                                               :actor-id     parent-id
                                               :state        leaf-state
@@ -2334,7 +2334,7 @@
   `(assoc data :pending id)`) has that value silently dropped, which is the
   exact trap the advisory contract sets. Surface it: emit a dev-only
   `:rf.warning/on-spawn-return-ignored` advisory naming the three working
-  id-recording alternatives. `trace/emit!` is gated on
+  id-recording alternatives. `rf.trace/emit!` is gated on
   `interop/debug-enabled?` (Closure DCE / JVM flag) so this is production-
   free and adds no module-level mutable state — the engine stays a pure
   function of `[machine snapshot event]`.
@@ -2343,7 +2343,7 @@
   action like any other, so a THROW must route through the documented
   machine action exception contract — NOT escape as a generic
   `:rf.error/handler-exception`. Mirroring `run-action` / `materialise-data`,
-  the call is wrapped in try/catch: on throw, return a `result/fail`
+  the call is wrapped in try/catch: on throw, return a `rf.machines.result/fail`
   Result stamped with the stable action id `:rf.machine.spawn/on-spawn` plus
   enough context to locate the spawn (`:spawned-id`; the caller adds
   `:invoke-id` / `:child-id`, and `apply-transition-once` stamps
@@ -2364,7 +2364,7 @@
     (try
       (let [ret (f {:data (:data snap) :id spawned-id})]
         (when (some? ret)
-          (trace/emit! :warning :rf.warning/on-spawn-return-ignored
+          (rf.trace/emit! :warning :rf.warning/on-spawn-return-ignored
                        ;; The spawning parent is a LIVE actor
                        ;; INSTANCE; address it by `:actor-id`. `:spawned-id`
                        ;; is the freshly-spawned child's instance address.
@@ -2376,7 +2376,7 @@
                                      :rf.machine/update-snapshot]}))
         snap)
       (catch #?(:clj Throwable :cljs :default) e
-        (result/fail {:action-ref :rf.machine.spawn/on-spawn
+        (rf.machines.result/fail {:action-ref :rf.machine.spawn/on-spawn
                       :spawned-id spawned-id
                       :exception  e})))
     snap))
@@ -2384,10 +2384,10 @@
 (defn- spawn-one
   "Single-spawn primitive shared by `:spawn` and `:spawn-all` per-child.
   Materialises any `:data` fn-form against `mat-snap` + `event` (Spec 005
-  §Spec-spec keys); on failure returns a `result/fail` Result
+  §Spec-spec keys); on failure returns a `rf.machines.result/fail` Result
   stamped with `failure-extra`. On success builds the spawn-args via
   `args-builder` (mode-specific wiring of `:rf/parent-id` /
-  `:rf/invoke-id` / `:rf/spawn-all-id` keys) and returns a `result/ok`
+  `:rf/invoke-id` / `:rf/spawn-all-id` keys) and returns a `rf.machines.result/ok`
   Result carrying the single-element `[[:rf.machine/spawn args]]` fx vec.
 
   `:on-spawn` is intentionally NOT invoked here — the caller threads it
@@ -2397,14 +2397,14 @@
   (let [mat-result (if (contains? spawn-spec :data)
                      (materialise-data (:data spawn-spec) mat-snap event)
                      [::ok-data nil])]
-    (if (result/fail? mat-result)
-      (result/fail-with mat-result failure-extra)
+    (if (rf.machines.result/fail? mat-result)
+      (rf.machines.result/fail-with mat-result failure-extra)
       (let [mat-data    (second mat-result)
             spawn-spec' (if (contains? spawn-spec :data)
                           (assoc spawn-spec :data mat-data)
                           spawn-spec)
             spawn-args  (args-builder spawn-spec' spawned-id)]
-        (result/ok spawn-args [[:rf.machine/spawn spawn-args]])))))
+        (rf.machines.result/ok spawn-args [[:rf.machine/spawn spawn-args]])))))
 
 ;; ---- :spawn / :spawn-all spawn reducers ----------------------------------
 
@@ -2415,7 +2415,7 @@
   runs the `:on-spawn` advisory callback.
 
   Returns `[snap-after acc-fx']` for the reducer, or a `reduced` wrapper
-  around a `result/fail` Result on failure. The failure is stamped
+  around a `rf.machines.result/fail` Result on failure. The failure is stamped
   `:action-ref :rf.machine.spawn/data-fn` + `:invoke-id` for a `:data`-fn throw,
   or `:action-ref :rf.machine.spawn/on-spawn` + `:invoke-id`
   (carried up from `apply-on-spawn`) for a throwing `:on-spawn` callback,
@@ -2435,16 +2435,16 @@
         spawn-r      (spawn-one spawn-spec s-alloc event id args-builder
                                 {:action-ref :rf.machine.spawn/data-fn
                                  :invoke-id  invoke-id})]
-    (if (result/fail? spawn-r)
+    (if (rf.machines.result/fail? spawn-r)
       (reduced spawn-r)
-      (let [spawn-fx (result/fx spawn-r)
+      (let [spawn-fx (rf.machines.result/fx spawn-r)
             ;; A throwing `:on-spawn` callback returns a
-            ;; `result/fail` (not a snapshot) — short-circuit the spawn
+            ;; `rf.machines.result/fail` (not a snapshot) — short-circuit the spawn
             ;; reducer so no parent/child snapshot or registry slot commits
             ;; and the accumulated fx is dropped at the lifecycle boundary.
             s'       (apply-on-spawn machine s-alloc spawn-spec id)]
-        (if (result/fail? s')
-          (reduced (result/fail-with s' {:invoke-id invoke-id}))
+        (if (rf.machines.result/fail? s')
+          (reduced (rf.machines.result/fail-with s' {:invoke-id invoke-id}))
           ;; Bind the assigned actor id into the parent's
           ;; own `:data` under `[:rf/spawned <invoke-id>]` (XState-context
           ;; parity). Threaded onto the parent snapshot AFTER the advisory
@@ -2478,7 +2478,7 @@
       threading `:data` writes across siblings.
 
   Returns `[snap-after acc-fx']` for the reducer, or a `reduced` wrapper
-  around a `result/fail` Result (stamped with
+  around a `rf.machines.result/fail` Result (stamped with
   `:action-ref :rf.machine.spawn-all/data-fn`, `:invoke-id`, and the failing
   `:child-id`) on `:data` failure."
   [machine parent-id s acc-fx prefix n event]
@@ -2520,15 +2520,15 @@
                                {:action-ref :rf.machine.spawn-all/data-fn
                                 :invoke-id  invoke-id
                                 :child-id   (:id child)})]
-              (if (result/fail? r)
+              (if (rf.machines.result/fail? r)
                 (reduced r)
-                (into acc (result/fx r)))))
+                (into acc (rf.machines.result/fx r)))))
           []
           children-with-ids)]
-    (if (result/fail? spawn-fxs-r)
+    (if (rf.machines.result/fail? spawn-fxs-r)
       (reduced spawn-fxs-r)
       ;; (4) Thread :on-spawn advisory callbacks across siblings. Per
-      ;; A throwing child `:on-spawn` returns a `result/fail`
+      ;; A throwing child `:on-spawn` returns a `rf.machines.result/fail`
       ;; (not the threaded snapshot); short-circuit the sibling reduce on
       ;; the FIRST throw — stamping the failing `:child-id` + `:invoke-id`
       ;; onto the failure — so the reducer never terminates mid-spawn
@@ -2557,13 +2557,13 @@
             s' (reduce
                  (fn [snap child]
                    (let [r (apply-on-spawn machine snap child (:rf/spawned-id child))]
-                     (if (result/fail? r)
-                       (reduced (result/fail-with r {:invoke-id invoke-id
+                     (if (rf.machines.result/fail? r)
+                       (reduced (rf.machines.result/fail-with r {:invoke-id invoke-id
                                                      :child-id (:id child)}))
                        r)))
                  s-alloc
                  children-with-ids)]
-        (if (result/fail? s')
+        (if (rf.machines.result/fail? s')
           (reduced s')
           ;; Bind the `:spawn-all`'s children id-map into the
           ;; parent's own `:data` under `[:rf/spawned <invoke-id>]` (the whole
@@ -2754,9 +2754,9 @@
   selected candidate's `:action` and collects its `:fx`. The `:on-done` value
   is normalised through the SAME candidate machinery as an `:on` clause
   (a guarded candidate-vector resolves first-guard-pass-wins; a bare action-
-  less keyword / map is a data no-op). Returns a `result/ok` carrying
+  less keyword / map is a data no-op). Returns a `rf.machines.result/ok` carrying
   `[snap' fx]` (the action's `:data` merged, `:fx` collected), or a
-  `result/fail` if the action threw. A nil / no-candidate `:on-done` returns
+  `rf.machines.result/fail` if the action threw. A nil / no-candidate `:on-done` returns
   `(ok snap [])` unchanged. Invoked with the synthetic
   `[:rf.machine/done []]` event so a 3-arity action introspecting `:event`
   sees the reserved done discriminator.
@@ -2777,14 +2777,14 @@
         event [done-event-id []]
         tspec (select-passing-candidate machine cands snap event)]
     (if (nil? tspec)
-      (result/ok snap [])
+      (rf.machines.result/ok snap [])
       (let [r0 (run-action machine snap (:action tspec) event :transition)]
-        (if (result/fail? r0)
+        (if (rf.machines.result/fail? r0)
           r0
           (let [r        (enforce-db-disallow machine r0 (:action tspec) (:state snap))
                 new-data (cond-> (:data snap)
                            (contains? r :data) (merge (:data r)))]
-            (result/ok (assoc snap :data new-data) (vec (or (:fx r) [])))))))))
+            (rf.machines.result/ok (assoc snap :data new-data) (vec (or (:fx r) [])))))))))
 
 (defn run-root-transition-action
   "Per Spec 005 §Transition broadcast §Root parallel `:on`: run a
@@ -2802,8 +2802,8 @@
   compound `:on-done` path. The action's effects flow through the shared
   `enforce-db-disallow` choke-point so a `:db` write produces the same
   `:rf.error/machine-action-wrote-db` diagnostic + strip as every other
-  phase. Returns a `result/ok` carrying `[snap' fx]` (action's `:data`
-  merged, `:fx` collected), or a `result/fail` if the action threw. A
+  phase. Returns a `rf.machines.result/ok` carrying `[snap' fx]` (action's `:data`
+  merged, `:fx` collected), or a `rf.machines.result/fail` if the action threw. A
   targetless / action-less transition returns `(ok snap [])`."
   [machine snap transition event]
   (let [;; The root `:on` lives OUTSIDE `:states` (decl-path
@@ -2814,12 +2814,12 @@
         transition (finalize-on-transition-slot transition [])
         r0 (run-action machine snap (:action transition) event :transition
                        (:rf/transition-slot transition))]
-    (if (result/fail? r0)
+    (if (rf.machines.result/fail? r0)
       r0
       (let [r        (enforce-db-disallow machine r0 (:action transition) (:state snap))
             new-data (cond-> (:data snap)
                        (contains? r :data) (merge (:data r)))]
-        (result/ok (assoc snap :data new-data) (vec (or (:fx r) [])))))))
+        (rf.machines.result/ok (assoc snap :data new-data) (vec (or (:fx r) [])))))))
 
 ;; ---- destroy-time exit cascade --------------------------------------------
 ;;
@@ -2846,8 +2846,8 @@
   matching how `compute-transition-geometry` orders the exit cascade with
   `lca-len = 0`). Runs them via `collect-actions`.
 
-  Returns a `re-frame.machines.result/Result` — a `result/ok` carrying
-  the post-cascade snapshot + accumulated fx, or a `result/fail` if any
+  Returns a `re-frame.machines.result/Result` — a `rf.machines.result/ok` carrying
+  the post-cascade snapshot + accumulated fx, or a `rf.machines.result/fail` if any
   `:exit` action threw. This cascade threads a `[:rf.machine/destroy-exit]`
   synthetic event (destroy / finalize / `:spawn-all` per-child teardown
   all funnel through here) so 3-arity `:exit` fns that introspect the
@@ -2914,7 +2914,7 @@
 ;;   run-spawn-phase        — reduce over `entered-pairs` dispatching to
 ;;                            `handle-spawn-decl` / `handle-spawn-all-decl`.
 ;;                            Threads snapshot + acc-fx; short-circuits to
-;;                            `result/fail` on `:data`-fn throws.
+;;                            `rf.machines.result/fail` on `:data`-fn throws.
 
 (defn- compute-transition-geometry
   "Phase 1 — derive the transition's geometry. Returns a map with:
@@ -3315,9 +3315,9 @@
 (defn- run-cascade
   "Phase 2 — run the ordered cascade (`exit` deepest-first → `action`
   at LCA → `entry` shallowest-first) via `collect-actions`. Returns the
-  Result from `collect-actions` — either `result/ok` with the post-cascade
+  Result from `collect-actions` — either `rf.machines.result/ok` with the post-cascade
   snapshot + accumulated fx (and the structured `::cascade` step vector
-  via `result/with-cascade`), or a `result/fail` carrying the
+  via `rf.machines.result/with-cascade`), or a `rf.machines.result/fail` carrying the
   throwing action's diagnostic map."
   [machine snapshot event geometry]
   (collect-actions machine snapshot event (:cascade-steps geometry)))
@@ -3399,14 +3399,14 @@
   "Phase 4 — reduce over `entered-pairs` dispatching `:spawn` /
   `:spawn-all` declarations to their respective spawn handlers. Threads
   the post-commit snapshot + an fx accumulator; a `reduced` from either
-  handler short-circuits to a `result/fail` Result. Returns either
-  `result/ok` carrying `[snap-after-spawns spawn-fx]` or the propagated
+  handler short-circuits to a `rf.machines.result/fail` Result. Returns either
+  `rf.machines.result/ok` carrying `[snap-after-spawns spawn-fx]` or the propagated
   failure."
   [machine event snap-final geometry]
   (let [{:keys [internal? entered-pairs]} geometry
         parent-id (or (:rf/parent-id machine) :rf/transition-pure)]
     (if internal?
-      (result/ok snap-final [])
+      (rf.machines.result/ok snap-final [])
       (let [step (reduce
                    (fn [[s acc-fx] [prefix n]]
                      (cond
@@ -3420,15 +3420,15 @@
                        [s acc-fx]))
                    [snap-final []]
                    entered-pairs)]
-        (if (result/fail? step)
+        (if (rf.machines.result/fail? step)
           step
           (let [[snap-after-spawns spawn-fx] step]
-            (result/ok snap-after-spawns spawn-fx)))))))
+            (rf.machines.result/ok snap-after-spawns spawn-fx)))))))
 
 (defn apply-transition-once
   "Apply one transition (exit cascade → action → entry cascade → state
-  change). Returns a `result/ok` Result carrying the new snapshot + fx,
-  or a `result/fail` Result if any action or `:data` fn threw.
+  change). Returns a `rf.machines.result/ok` Result carrying the new snapshot + fx,
+  or a `rf.machines.result/fail` Result if any action or `:data` fn threw.
 
   Per Spec 005 §Entry/exit cascading along the LCA:
    1. Compute LCA of source-path and target-leaf-path.
@@ -3469,17 +3469,17 @@
   ([machine snapshot event transition transition-phase]
   (let [geometry  (compute-transition-geometry machine snapshot transition transition-phase)
         cascade-r (run-cascade machine snapshot event geometry)]
-    (if (result/fail? cascade-r)
-      (result/fail-with cascade-r {:decl-path  (:decl-path geometry)
+    (if (rf.machines.result/fail? cascade-r)
+      (rf.machines.result/fail-with cascade-r {:decl-path  (:decl-path geometry)
                                    :transition transition
                                    :state-path (:src-path geometry)})
-      (result/with-ok [snap-after fx] cascade-r
+      (rf.machines.result/with-ok [snap-after fx] cascade-r
         (let [;; The structured cascade steps `collect-actions`
               ;; recorded ride `cascade-r` via `::cascade`; re-stamp them onto
-              ;; the final Result (the `result/ok` below builds a fresh Result
+              ;; the final Result (the `rf.machines.result/ok` below builds a fresh Result
               ;; that would otherwise drop them) so `machine-transition-single`
               ;; can accumulate the macrostep's full step sequence.
-              cascade-steps   (result/cascade cascade-r)
+              cascade-steps   (rf.machines.result/cascade cascade-r)
               snap-committed  (commit-snapshot machine snapshot snap-after geometry)
               ;; Per Spec 005 §Recording — on compound-state exit:
               ;; as part of the exit-cascade commit, write
@@ -3512,11 +3512,11 @@
               destroy-fx      (build-destroy-fx parent-id (:exited-pairs geometry)
                                                 (:internal? geometry))
               spawn-r         (run-spawn-phase machine event snap-final geometry)]
-          (if (result/fail? spawn-r)
-            (result/fail-with spawn-r {:decl-path  (:decl-path geometry)
+          (if (rf.machines.result/fail? spawn-r)
+            (rf.machines.result/fail-with spawn-r {:decl-path  (:decl-path geometry)
                                        :transition transition
                                        :state-path (:src-path geometry)})
-            (result/with-ok [snap-after-spawns spawn-fx] spawn-r
+            (rf.machines.result/with-ok [snap-after-spawns spawn-fx] spawn-r
               (let [;; Per Spec 005 §Final states §The done-state signal:
                     ;; if the committed configuration
                     ;; makes an EMBEDDED compound newly done (its active direct
@@ -3543,14 +3543,14 @@
                                         spawn-fx
                                         (or after-fx [])
                                         (or done-fx [])))]
-                (result/with-cascade
-                  (result/ok snap-after-spawns all-fx)
+                (rf.machines.result/with-cascade
+                  (rf.machines.result/ok snap-after-spawns all-fx)
                   cascade-steps))))))))))
 
 (defn pick-always-transition
   "Per Spec 005 §Eventless :always transitions: walk path leaf→root for
   an `:always` whose guard passes (the deepest-wins rule named in
-  `path-walk/walk-path-leaf-to-root`). The raw `:always` slot value is
+  `rf.machines.path-walk/walk-path-leaf-to-root`). The raw `:always` slot value is
   normalised through `normalise-candidates` — the SAME shared candidate
   grammar `:on` / `:after` use, so a bare keyword (sibling
   target), a vector-target (absolute path), a single transition map, and
@@ -3572,7 +3572,7 @@
 
   Returns `{:transition t :decl-path p}` or nil."
   [machine path snapshot]
-  (path-walk/walk-path-leaf-to-root
+  (rf.machines.path-walk/walk-path-leaf-to-root
     machine path
     (fn [prefix n]
       (let [raw-always (:always n)
@@ -3688,7 +3688,7 @@
       ;; so the trace stream classifies the drop the same way HTTP /
       ;; resources / routing do (m-reply). The timer's transition does not
       ;; fire.
-      (let [stale-reply (m-reply/after-stale-reply
+      (let [stale-reply (rf.machines.reply/after-stale-reply
                           {:actor-id        (:actor-id match)
                            :state           (:state match)
                            :delay           (:delay match)
@@ -3697,8 +3697,8 @@
                            :current-epoch   (:current-epoch match)
                            :frame           frame-id
                            :completed-at    completed-at})
-            summary     (m-reply/trace-reply stale-reply {:frame frame-id})]
-        (trace/emit! :rf.machine :rf.machine.timer/stale-after
+            summary     (rf.machines.reply/trace-reply stale-reply {:frame frame-id})]
+        (rf.trace/emit! :rf.machine :rf.machine.timer/stale-after
                      (cond->
                      {;; The timer's owning actor
                       ;; INSTANCE (spec/009 §`:rf.machine.timer/*`);
@@ -3734,7 +3734,7 @@
     ;; `:rf.machine.timer/fired` trace so it joins the uniform work/reply rows
     ;; (Managed-Effects §Tracing).
     (when (:guard-suppressed? match)
-      (let [fired-reply (m-reply/after-fired-reply
+      (let [fired-reply (rf.machines.reply/after-fired-reply
                           {:actor-id          (:actor-id match)
                            :state             (:state match)
                            :delay             (:delay match)
@@ -3743,8 +3743,8 @@
                            :frame             frame-id
                            :guard-suppressed? true
                            :completed-at      completed-at})
-            summary     (m-reply/trace-reply fired-reply {:frame frame-id})]
-        (trace/emit! :rf.machine :rf.machine.timer/fired
+            summary     (rf.machines.reply/trace-reply fired-reply {:frame frame-id})]
+        (rf.trace/emit! :rf.machine :rf.machine.timer/fired
                      (cond->
                      {;; Owning actor INSTANCE.
                       :actor-id (:actor-id match)
@@ -3771,7 +3771,7 @@
       ;; suppressed branches' root marker) rather than emitting `:state nil`.
       (let [fired-state (or (last (:decl-path match))
                             (when (empty? (:decl-path match)) :rf/parallel-root))
-            fired-reply (m-reply/after-fired-reply
+            fired-reply (rf.machines.reply/after-fired-reply
                           {:actor-id     (:actor-id match)
                            :state        fired-state
                            :delay        (:delay match)
@@ -3779,8 +3779,8 @@
                            :epoch        (:epoch match)
                            :frame        frame-id
                            :completed-at completed-at})
-            summary     (m-reply/trace-reply fired-reply {:frame frame-id})]
-        (trace/emit! :rf.machine :rf.machine.timer/fired
+            summary     (rf.machines.reply/trace-reply fired-reply {:frame frame-id})]
+        (rf.trace/emit! :rf.machine :rf.machine.timer/fired
                      (cond->
                      {;; Owning actor INSTANCE.
                       :actor-id (:actor-id match)
@@ -3822,7 +3822,7 @@
 
   This is a no-op (returns `machine` unchanged) for the pure-fn engine callers
   (conformance corpus / SSR / JVM fixtures): they carry no `:rf/cofx`, so
-  `cofx-attach/ensure-cofx` short-circuits, the determinism contract is
+  `rf.machines.cofx-attach/ensure-cofx` short-circuits, the determinism contract is
   preserved, and the reduction stays a pure function of its arguments. When a
   router dispatch DID thread the token (`:rf/cofx` present), the ensure mints
   under the resolved effective mint policy stamped on the machine def
@@ -3836,7 +3836,7 @@
   (if-not (contains? machine :rf/cofx)
     machine
     (let [recorded  (:rf/cofx machine)
-          augmented (cofx-attach/ensure-cofx
+          augmented (rf.machines.cofx-attach/ensure-cofx
                       machine snap event recorded
                       (:rf/frame machine)
                       (or (:rf/parent-id machine) (:id machine))
@@ -3880,7 +3880,7 @@
   union (`commit-tags`), `::microsteps` (the count of `:always` iterations),
   and `::cascade` (the structured step vector).
 
-  `start-result` is the `result/ok` carrying the snapshot + fx + cascade
+  `start-result` is the `rf.machines.result/ok` carrying the snapshot + fx + cascade
   that SEEDS the drain. For the event-driven macrostep that is the
   post-exit/action/entry `apply-transition-once` Result; for machine birth
   it is the post-initial-entry cascade Result. Either way its `::cascade`
@@ -3889,7 +3889,7 @@
 
   Atomic rollback on a tripped `:always-depth-limit` / `:raise-depth-limit`
   (Spec 005 §Bounded depth) is enforced by the FAILURE SURFACE:
-  the abort returns a `result/depth-abort` `:fail`, which threads NO snapshot
+  the abort returns a `rf.machines.result/depth-abort` `:fail`, which threads NO snapshot
   / fx, and the lifecycle handler short-circuits to `{}` — so neither a
   partially-advanced snapshot nor accumulated fx reaches runtime-db, and the
   last committed snapshot (the pre-event snapshot for the event-driven caller,
@@ -3906,14 +3906,14 @@
   When `defer?` is false (the queue-owning flat / compound drain) the loop
   drains the queue to quiescence here.
 
-  Returns a `result/ok` (snapshot + fx, with `::microsteps` / `::cascade`)
-  or a `result/fail` if an `:always` action or a handled raise threw."
+  Returns a `rf.machines.result/ok` (snapshot + fx, with `::microsteps` / `::cascade`)
+  or a `rf.machines.result/fail` if an `:always` action or a handled raise threw."
   [machine start-result raise-depth defer?]
   (let [always-limit (get machine :always-depth-limit always-depth-limit-default)
         raise-limit  (get machine :raise-depth-limit  raise-depth-limit-default)]
-    (if (result/fail? start-result)
+    (if (rf.machines.result/fail? start-result)
       start-result
-      (result/with-ok [snap-after-event fx-after-event] start-result
+      (rf.machines.result/with-ok [snap-after-event fx-after-event] start-result
         ;; Split the seeding transition's fx into its raised internal events
         ;; (the seed of the FIFO internal-event queue) and its real
         ;; (do-fx-bound) fx. Per Spec 005 §Drain semantics the raises are
@@ -3927,7 +3927,7 @@
               ;; microstep's own nested cascade). The accumulated vector is
               ;; the structured explanation the outer `:rf.machine/
               ;; transition` trace carries.
-              base-cascade (result/cascade start-result)]
+              base-cascade (rf.machines.result/cascade start-result)]
           ;; The unified SCXML microstep loop. `always-depth` counts the
           ;; `:always` iterations (→ `::microsteps`); `raise-depth` counts
           ;; internal events dequeued (→ `:raise-depth-limit`, seeded from the
@@ -3958,7 +3958,7 @@
                   ;; A tripped `:always` depth limit is a FAILED
                   ;; macrostep, not a benign no-op. XState v5 THROWS on such a
                   ;; runaway eventless cycle. Emit the precise error category
-                  ;; (the single trace for the trip) and return a `result/fail`
+                  ;; (the single trace for the trip) and return a `rf.machines.result/fail`
                   ;; carrying the `::depth-abort?` sentinel so it routes through
                   ;; the handler's failure path (`trace-action-failure!`
                   ;; short-circuits to `{}` — no snapshot write reaches
@@ -3983,10 +3983,10 @@
                               ;; `:frame`.
                               :frame      (:rf/frame m)
                               :recovery   :no-recovery}]
-                    (trace/emit-error! :rf.error/machine-always-depth-exceeded info)
+                    (rf.trace/emit-error! :rf.error/machine-always-depth-exceeded info)
                     ;; Macrostep rolls back atomically — no cascade survives the
-                    ;; abort; the `result/fail` carries no `::snap`/`::fx`.
-                    (result/depth-abort info))
+                    ;; abort; the `rf.machines.result/fail` carries no `::snap`/`::fx`.
+                    (rf.machines.result/depth-abort info))
                   ;; `:always` microstep's transition `:action`
                   ;; `action-ran` emit carries `:phase :always` so the Handler
                   ;; section can group eventless cascades distinctly from
@@ -3994,9 +3994,9 @@
                   (let [step-result (apply-transition-once m snap nil
                                                             (:transition always-m)
                                                             :always)]
-                    (if (result/fail? step-result)
+                    (if (rf.machines.result/fail? step-result)
                       step-result
-                      (result/with-ok [snap2 fx2] step-result
+                      (rf.machines.result/with-ok [snap2 fx2] step-result
                         ;; Per Spec 005 §Trace events: one
                         ;; `:rf.machine.microstep/transition` per microstep,
                         ;; carrying the from/to states and the 0-based
@@ -4009,7 +4009,7 @@
                         ;; do not produce their own envelope (intra-
                         ;; macrostep); the trace is the surface where the
                         ;; closed-set value is observable.
-                        (trace/emit! :rf.machine :rf.machine.microstep/transition
+                        (rf.trace/emit! :rf.machine :rf.machine.microstep/transition
                                      {;; A microstep belongs to a
                                       ;; LIVE actor's macrostep; address it by
                                       ;; `:actor-id` (the running INSTANCE),
@@ -4034,7 +4034,7 @@
                                           :microstep-index always-depth
                                           :from            (:state snap)
                                           :to              (:state snap2)
-                                          :steps           (result/cascade step-result)}
+                                          :steps           (rf.machines.result/cascade step-result)}
                               ;; An `:always` step's OWN raises
                               ;; go to the BACK of the internal-event queue —
                               ;; NOT drained immediately. The loop re-checks
@@ -4065,14 +4065,14 @@
                   ;; internal-event queue back un-drained for the queue-owner
                   ;; above (`drain-to-fixed-point` with `defer?` false, or the
                   ;; parallel parent queue) to harvest and re-feed FIFO.
-                  (-> (result/ok (commit-tags m snap) (into fx pending))
-                      (result/with-microsteps always-depth)
-                      (result/with-cascade cascade))
+                  (-> (rf.machines.result/ok (commit-tags m snap) (into fx pending))
+                      (rf.machines.result/with-microsteps always-depth)
+                      (rf.machines.result/with-cascade cascade))
                   (if (>= raise-depth raise-limit)
                     ;; A tripped `:raise` depth limit is a FAILED
                     ;; macrostep, not a benign no-op (mirrors the `:always`
                     ;; abort above). Emit the precise category, then return a
-                    ;; `result/fail` carrying the `::depth-abort?` sentinel so
+                    ;; `rf.machines.result/fail` carrying the `::depth-abort?` sentinel so
                     ;; the runaway raise cycle routes through the handler's
                     ;; failure path and the triggering event is surfaced as an
                     ;; error rather than silently swallowed.
@@ -4090,11 +4090,11 @@
                                 ;; requires `:frame`.
                                 :frame      (:rf/frame m)
                                 :recovery   :no-recovery}]
-                      (trace/emit-error! :rf.error/machine-raise-depth-exceeded info)
+                      (rf.trace/emit-error! :rf.error/machine-raise-depth-exceeded info)
                       ;; Macrostep rolls back atomically — neither the
                       ;; partially-advanced snapshot nor the accumulated effects
                       ;; survive the abort.
-                      (result/depth-abort info))
+                      (rf.machines.result/depth-abort info))
                     (let [[_ ev]       (first pending)
                           rest-pending (subvec pending 1)
                           ;; Re-run the consumer-attachment ensure
@@ -4122,9 +4122,9 @@
                           ;; drain's count.
                           step-result  (machine-transition-single
                                          m' snap ev (inc raise-depth) true)]
-                      (if (result/fail? step-result)
+                      (if (rf.machines.result/fail? step-result)
                         step-result
-                        (result/with-ok [snap2 fx2] step-result
+                        (rf.machines.result/with-ok [snap2 fx2] step-result
                           ;; Split the deferred result's fx into the surfaced
                           ;; raised events (append to the BACK, behind pending
                           ;; siblings — FIFO) and the real do-fx-bound fx.
@@ -4168,14 +4168,14 @@
                                 ;;
                                 ;; `::microsteps` is untouched: it stays the
                                 ;; `:always`-iteration count, not a step count.
-                                cascade' (if (result/handled? step-result)
+                                cascade' (if (rf.machines.result/handled? step-result)
                                            (conj cascade
                                                  {:kind   :raised-transition
                                                   :region (:rf/region m)
                                                   :event  ev
                                                   :from   (:state snap)
                                                   :to     (:state snap2)
-                                                  :steps  (result/cascade step-result)})
+                                                  :steps  (rf.machines.result/cascade step-result)})
                                            cascade)]
                             (recur snap2
                                    ;; Thread the augmented machine forward so the
@@ -4204,9 +4204,9 @@
                 ;; §Trace events). The `cascade` rides via
                 ;; `::cascade`.
                 :else
-                (-> (result/ok (commit-tags m snap) fx)
-                    (result/with-microsteps always-depth)
-                    (result/with-cascade cascade))))))))))
+                (-> (rf.machines.result/ok (commit-tags m snap) fx)
+                    (rf.machines.result/with-microsteps always-depth)
+                    (rf.machines.result/with-cascade cascade))))))))))
 
 (defn apply-preselected-transition
   "Apply one already-selected `match` without running the `:always` / raised-
@@ -4230,10 +4230,10 @@
         applied
         (cond
           (and match (:stale? match))
-          (result/ok snapshot [])
+          (rf.machines.result/ok snapshot [])
 
           (and match (:guard-suppressed? match))
-          (result/ok snapshot [])
+          (rf.machines.result/ok snapshot [])
 
           match
           (let [phase (or transition-phase
@@ -4254,13 +4254,13 @@
             ;; no-op only when every region and its root fallback decline.
             (when (and (nil? (:rf/region machine))
                        (unhandled-event-no-op? event))
-              (trace/emit! :rf.machine :rf.machine.event/unhandled-no-op
+              (rf.trace/emit! :rf.machine :rf.machine.event/unhandled-no-op
                            {:actor-id (or (:rf/parent-id machine) (:id machine))
                             :event    event
                             :state    (:state snapshot)
                             :frame    (:rf/frame machine)}))
-            (result/ok snapshot [])))]
-    (result/with-handled applied handled?)))
+            (rf.machines.result/ok snapshot [])))]
+    (rf.machines.result/with-handled applied handled?)))
 
 (defn machine-transition-single
   "Pure function. Single-machine (flat or compound) implementation of the
@@ -4281,7 +4281,7 @@
   identical settling tail — see `re-frame.machines.parallel`'s
   `settle-birth` / `apply-initial-entry-cascade`.
 
-  Returns a `result/ok` Result on success or a `result/fail` Result if
+  Returns a `rf.machines.result/ok` Result on success or a `rf.machines.result/fail` Result if
   any action or `:data`-fn threw. Bounded by `:raise-depth-limit` and
   `:always-depth-limit` (both default 16). Parallel-region routing lives
   in `re-frame.machines.parallel`'s `machine-transition` — the dispatch
@@ -4340,6 +4340,6 @@
      ;; Steps 3-5: flat/compound ownership remains here. The parallel parent
      ;; calls `apply-preselected-transition` directly and owns settling across
      ;; the complete regional configuration.
-     (result/with-handled
+     (rf.machines.result/with-handled
        (drain-to-fixed-point machine seed raise-depth defer?)
-       (result/handled? seed)))))
+       (rf.machines.result/handled? seed)))))

--- a/implementation/machines/test/re_frame/actor_liveness_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/actor_liveness_cljs_test.cljc
@@ -26,27 +26,27 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.frame :as frame]
-   [re-frame.machines.test-support :as mtest]
-   [re-frame.registrar :as registrar]
-   [re-frame.substrate.adapter :as adapter]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.frame :as rf.frame]
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   [re-frame.registrar :as rf.registrar]
+   [re-frame.substrate.adapter :as rf.substrate.adapter]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter})))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter})))
 
 ;; snapshot lookup via the shared machines test-support — no hardcoded
 ;; `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (defn- registrar-event-snapshot
   "A value-snapshot of every registered :event id — the bit we assert is
   UNCHANGED across a spawn/destroy (no registrar drift)."
   []
-  (set (keys (registrar/registrations :event))))
+  (set (keys (rf.registrar/registrations :event))))
 
 (defn- revert-app-db!
   "Reset `frame-id`'s RUNTIME-DB to `runtime-db` — the partition a
@@ -56,11 +56,11 @@
 
   A spawned actor's LIVENESS is its snapshot's presence in the **runtime-db**
   partition (machine snapshots are durable runtime-db state), so reverting
-  liveness means reverting runtime-db — written via `frame/swap-runtime-db!`.
+  liveness means reverting runtime-db — written via `rf.frame/swap-runtime-db!`.
   This helper installs just the runtime-db partition (the full frame-state
   restore PROJECTIONS live elsewhere)."
   [frame-id runtime-db]
-  (frame/swap-runtime-db! frame-id (constantly runtime-db)))
+  (rf.frame/swap-runtime-db! frame-id (constantly runtime-db)))
 
 ;; A parent that spawns one child of a registered TYPE on `:go` and
 ;; destroys it on `:drop`. The child increments a counter on `:bump` so
@@ -95,7 +95,7 @@
       (rf/dispatch-sync [:al/parent [:go]])
       (is (some? (snapshot :al/child#1))
           "spawned actor's snapshot is installed (it is alive)")
-      (is (nil? (registrar/lookup :event :al/child#1))
+      (is (nil? (rf.registrar/lookup :event :al/child#1))
           "spawn registered NO per-instance handler")
       (is (= reg-before (registrar-event-snapshot))
           "spawn mutated the :event registrar by exactly nothing")
@@ -118,7 +118,7 @@
     (rf/reg-machine :al2/child  (counter-child))
     (rf/reg-machine :al2/parent (spawning-parent :al2/child))
     (rf/dispatch-sync [:al2/parent [:go]])
-    (is (nil? (registrar/lookup :event :al2/child#1))
+    (is (nil? (rf.registrar/lookup :event :al2/child#1))
         "no per-instance handler is registered for the spawned actor")
     (is (= 0 (:n (:data (snapshot :al2/child#1)))))
     ;; Dispatch straight at the spawned actor-id — this only resolves via
@@ -180,7 +180,7 @@
         (revert-app-db! :rf/default db-before-spawn)
         (is (nil? (snapshot :al4/child#1))
             "rewind-past-spawn: the actor's snapshot is gone")
-        (is (nil? (registrar/lookup :event :al4/child#1))
+        (is (nil? (rf.registrar/lookup :event :al4/child#1))
             "rewind-past-spawn: NO orphaned handler survives the revert
              (the {:handler-survived-restore? true} leak is closed)")
 
@@ -202,7 +202,7 @@
             registers a handler and dispatches normally; the lazy
             resolver does not change the singleton path"
     (rf/reg-machine :al5/single (counter-child))
-    (is (some? (registrar/lookup :event :al5/single))
+    (is (some? (rf.registrar/lookup :event :al5/single))
         "a reg-machine singleton IS registered in the :event registrar")
     (rf/dispatch-sync [:al5/single [:bump]])
     (is (= 1 (:n (:data (snapshot :al5/single))))

--- a/implementation/machines/test/re_frame/actor_resource_owner_release_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/actor_resource_owner_release_cljs_test.cljc
@@ -37,18 +37,18 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.events :as events]
+   [re-frame.events :as rf.events]
    [re-frame.machines]
-   [re-frame.machines.test-support :as mtest]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter})))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter})))
 
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 ;; ---- stub release-owner handler (stand-in for the resources artefact) ------
 
@@ -59,7 +59,7 @@
   ;; Register a stub `:rf.resource/release-owner` event handler that records
   ;; the released owner — the machine side dispatches this by NAME (it never
   ;; :requires resources). This stands in for the real resources handler.
-  (events/reg-event :rf.resource/release-owner
+  (rf.events/reg-event :rf.resource/release-owner
     (fn [_ [_ {:keys [owner]}]]
       (swap! released conj owner)
       {})))

--- a/implementation/machines/test/re_frame/after_delay_validation_test.clj
+++ b/implementation/machines/test/re_frame/after_delay_validation_test.clj
@@ -14,11 +14,11 @@
   `re-frame.after-test`)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- registration-throws?
   "Try registering `machine` under `machine-id`. Returns the

--- a/implementation/machines/test/re_frame/after_dynamic_delay_reresolve_ratom_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/after_dynamic_delay_reresolve_ratom_cljs_test.cljs
@@ -35,24 +35,24 @@
   claim is about a notification channel, not a render."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent.ratom :as ratom]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
+            [re-frame.interop :as rf.interop]
             ;; Loading `re-frame.machines` installs the machines-artefact
             ;; late-bind hooks (`reg-machine`, `reset-timers!`); under a
             ;; single-ns run nothing else pulls it in.
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.machines.timer :as timer]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.machines.timer :as rf.machines.timer]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter reagent-adapter/adapter})
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.adapter.reagent/adapter})
+  rf.machines.test-support/trace-capture-fixture)
 
 (defn- live-entry
   "The `:rf/default` frame's single live `:after` timer entry, or nil."
   []
-  (first (vals (get @timer/after-timers :rf/default {}))))
+  (first (vals (get @rf.machines.timer/after-timers :rf/default {}))))
 
 ;; White-box, and only ever CORROBORATING: `watching` is the Reagent field that
 ;; says \"this reaction is subscribed to its sources\". Read against anything
@@ -87,11 +87,11 @@
       ;; and hand back an opaque sentinel instead of a real setTimeout handle.
       ;; `managed-timer/cancel!` swallows throws, so the sentinel is safe on
       ;; the cancellation path.
-      (with-redefs [interop/schedule-after!
+      (with-redefs [rf.interop/schedule-after!
                     (fn [_thunk ms] (swap! arms conj ms) (js-obj "rf-fake-handle" ms))]
 
         (rf/dispatch-sync [:dyn/timer [:go]])
-        (is (= :running (mtest/machine-state :dyn/timer))
+        (is (= :running (rf.machines.test-support/machine-state :dyn/timer))
             "precondition — entered the `:after`-bearing state")
         (is (= [5000] @arms)
             "precondition — armed once, at the delay sub's current value")
@@ -119,7 +119,7 @@
         (is (= 9000 (:resolved-ms (live-entry)))
             "…and the live registry entry carries the re-resolved duration")
         (is (some #(= :on-resolution (:reason (:tags %)))
-                  (mtest/events-of :rf.machine.timer/cancelled))
+                  (rf.machines.test-support/events-of :rf.machine.timer/cancelled))
             "the cancellation was traced with `:reason :on-resolution` — the
              re-resolution path ran, not some other cancel")
 
@@ -151,7 +151,7 @@
     (register-dynamic-delay-machine!)
     (rf/dispatch-sync [:dyn/set-ms 5000])
     (let [arms (atom [])]
-      (with-redefs [interop/schedule-after!
+      (with-redefs [rf.interop/schedule-after!
                     (fn [_thunk ms] (swap! arms conj ms) (js-obj "rf-fake-handle" ms))]
         (rf/dispatch-sync [:dyn/timer [:go]])
         (is (= [5000] @arms) "precondition — one arming")

--- a/implementation/machines/test/re_frame/after_fire_reap_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/after_fire_reap_cljs_test.cljc
@@ -19,24 +19,24 @@
   change are synchronous on both platforms)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
+            [re-frame.interop :as rf.interop]
             ;; Loading `re-frame.machines` installs the machines-artefact
             ;; late-bind hooks (`reg-machine`, `reset-timers!`) the test relies
             ;; on; under a single-ns test run nothing else pulls it in.
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.machines.timer :as timer]
-            [re-frame.subs :as subs]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.machines.timer :as rf.machines.timer]
+            [re-frame.subs :as rf.subs]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- default-inner
   "The `:rf/default` frame's inner timer table (the `{inner-key entry}`
   map), or `{}` when the frame holds no live `:after` timers."
   []
-  (get @timer/after-timers :rf/default {}))
+  (get @rf.machines.timer/after-timers :rf/default {}))
 
 (deftest guard-suppressed-sub-delay-fire-reaps-entry-and-does-not-rearm
   ;; A sub-vec `:after` delay whose transition is guard-suppressed. The host
@@ -69,18 +69,18 @@
       (rf/reg-machine :reap/sub m)
       (with-redefs [;; Resolve the sub-vec delay to our controllable reaction
                     ;; (both the schedule path and the re-arm path read it).
-                    subs/subscribe   (fn
+                    rf.subs/subscribe   (fn
                                        ([_query-v] delay-reaction)
                                        ([_query-v _opts] delay-reaction))
-                    subs/unsubscribe (fn ([_] nil) ([_ _] nil))
+                    rf.subs/unsubscribe (fn ([_] nil) ([_ _] nil))
                     ;; Capture the host-clock thunk instead of arming a real
                     ;; wall-clock timer; return an opaque sentinel handle.
-                    interop/schedule-after! (fn [thunk _ms]
+                    rf.interop/schedule-after! (fn [thunk _ms]
                                               (swap! arm-count inc)
                                               (reset! last-thunk thunk)
                                               ::handle)]
         (rf/dispatch-sync [:reap/sub [:go]])
-        (is (= :running (mtest/machine-state :reap/sub))
+        (is (= :running (rf.machines.test-support/machine-state :reap/sub))
             "entered the :after-bearing state")
         (is (= 1 (count (default-inner)))
             "precondition: the sub-delay :after timer registered one entry")
@@ -96,7 +96,7 @@
         (@last-thunk)
 
         ;; (a) NO LEAK — the firing entry is reaped.
-        (is (= :running (mtest/machine-state :reap/sub))
+        (is (= :running (rf.machines.test-support/machine-state :reap/sub))
             "guard-suppressed fire did not transition the state")
         (is (empty? (default-inner))
             "(a) the guard-suppressed fire REAPED its registry entry — no leak")
@@ -126,11 +126,11 @@
                        :done    {}}}]
       (rf/reg-sub :t/dyn-delay2 (fn [_db _] @delay-reaction))
       (rf/reg-machine :reap/sub2 m)
-      (with-redefs [subs/subscribe   (fn
+      (with-redefs [rf.subs/subscribe   (fn
                                        ([_query-v] delay-reaction)
                                        ([_query-v _opts] delay-reaction))
-                    subs/unsubscribe (fn ([_] nil) ([_ _] nil))
-                    interop/schedule-after! (fn [_thunk _ms]
+                    rf.subs/unsubscribe (fn ([_] nil) ([_ _] nil))
+                    rf.interop/schedule-after! (fn [_thunk _ms]
                                               (swap! arm-count inc)
                                               ::handle)]
         (rf/dispatch-sync [:reap/sub2 [:go]])

--- a/implementation/machines/test/re_frame/after_test.clj
+++ b/implementation/machines/test/re_frame/after_test.clj
@@ -25,17 +25,17 @@
   machines_cljs_test.cljs."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
             [re-frame.subs]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; runtime-db / snapshot lookup via the shared machines test-support.
-(def ^:private frame-db mtest/runtime-db)
-(def ^:private snapshot mtest/snapshot)
+(def ^:private frame-db rf.machines.test-support/runtime-db)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 ;; ---- registration-time handling of the legacy :timeout-ms slot -------------
 ;;
@@ -548,7 +548,7 @@
                      (throw (ex-info "fn-form delay blew up" {:where :test})))]
       ;; Shared `with-trace-capture` — guaranteed unregister in a `finally`,
       ;; no hand-rolled register/try/finally.
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         (rf/reg-machine :a/throws
                         {:initial :idle
                          :data    {}
@@ -574,7 +574,7 @@
 ;; ---- sub-cache ref-count balance on bad-delay early-return ----------------
 
 (defn- default-sub-cache []
-  @(:sub-cache (frame/frame :rf/default)))
+  @(:sub-cache (rf.frame/frame :rf/default)))
 
 (deftest after-sub-vec-bad-delay-does-not-leak-subscription
   ;; `schedule-after-timer!` resolves a subscription-vector `:after` delay
@@ -683,7 +683,7 @@
                               (deref [_]
                                 (throw (ex-info throw-msg {:where :test}))))]
       ;; Shared `with-trace-capture`.
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         (rf/reg-sub :s/well-formed (fn [_db _] 1000))
         (rf/reg-machine
           :s/throws-machine
@@ -742,7 +742,7 @@
                                            {:where :test :key key}))
                            (real-add target key f)))]
       ;; Shared `with-trace-capture`.
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         ;; A well-behaved sub returning a positive delay — subscribe
         ;; succeeds, deref returns 1000 (so the bad-delay branch
         ;; doesn't short-circuit before reaching add-watch).

--- a/implementation/machines/test/re_frame/after_timer_announce_claim_race_test.clj
+++ b/implementation/machines/test/re_frame/after_timer_announce_claim_race_test.clj
@@ -21,7 +21,7 @@
 
   ## The interleaving is driven, not raced
 
-  `trace/emit!` is wrapped for the duration of one hydration. On the attempt's
+  `rf.trace/emit!` is wrapped for the duration of one hydration. On the attempt's
   own `/scheduled` row — the point at which the sentinel is reserved and the
   row is not yet delivered — the cleanup runs to completion on a second
   thread and is joined before the real emit proceeds. That reaches the exact
@@ -46,21 +46,21 @@
   `machine_hydration_reconcile_incarnation_fence_cljs_test`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
             ;; Loading `re-frame.machines` installs the artefact's late-bind
             ;; hooks + reserved fxs; under a single-ns run nothing else does.
             [re-frame.machines]
-            [re-frame.machines.hydrate :as m-hydrate]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.machines.timer :as timer]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.machines.hydrate :as rf.machines.hydrate]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.machines.timer :as rf.machines.timer]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace :as rf.trace]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter})
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter})
+  rf.machines.test-support/trace-capture-fixture)
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures
@@ -79,7 +79,7 @@
 (defn- inner
   "`frame-id`'s inner `:after` timer table, or `{}` when it holds none."
   [frame-id]
-  (get @timer/after-timers frame-id {}))
+  (get @rf.machines.timer/after-timers frame-id {}))
 
 (defn- server-runtime-db
   "Run `machine-id` into its `:after`-bearing state on a real SERVER frame,
@@ -90,15 +90,15 @@
     (rf/dispatch-sync [machine-id [:go]] {:frame sfid})
     (is (empty? (inner sfid))
         "precondition: the SERVER armed no `:after` host timer")
-    (frame/frame-runtime-db-value sfid)))
+    (rf.frame/frame-runtime-db-value sfid)))
 
 (defn- install!
   "Replace `frame-id`'s runtime-db with `runtime-db` and run the machines
   hydration seam — what `:rf/hydrate` does once its runtime-db effect has
   committed."
   [frame-id runtime-db]
-  (frame/replace-runtime-db! frame-id runtime-db)
-  (m-hydrate/rearm-after-timers! frame-id))
+  (rf.frame/replace-runtime-db! frame-id runtime-db)
+  (rf.machines.hydrate/rearm-after-timers! frame-id))
 
 (def ^:private literal-machine
   "One literal-delay `:after`, so the hydration arm is exactly one attempt and
@@ -119,7 +119,7 @@
   []
   (filterv (comp #{:rf.machine.timer/scheduled :rf.machine.timer/cancelled}
                  :operation)
-           (mtest/captured-events)))
+           (rf.machines.test-support/captured-events)))
 
 (defn- on-another-thread!
   "Run `f` to completion on a fresh raw `Thread` and join it, rethrowing
@@ -140,13 +140,13 @@
   reached, whether the sentinel was already in the table there, and how many
   host clocks were armed."
   [frame-id runtime-db cleanup!]
-  (let [orig-emit! trace/emit!
+  (let [orig-emit! rf.trace/emit!
         bit?       (atom false)
         reserved?  (atom nil)
         arms       (atom 0)]
-    (with-redefs [interop/schedule-after!   (fn [_thunk _ms] (swap! arms inc) ::handle)
-                  interop/cancel-scheduled! (fn [_h] nil)
-                  trace/emit!
+    (with-redefs [rf.interop/schedule-after!   (fn [_thunk _ms] (swap! arms inc) ::handle)
+                  rf.interop/cancel-scheduled! (fn [_h] nil)
+                  rf.trace/emit!
                   (fn [op operation tags]
                     (when (and (= :rf.machine.timer/scheduled operation)
                                (compare-and-set! bit? false true))
@@ -166,13 +166,13 @@
 (deftest a-claim-before-the-row-is-out-closes-the-row-rather-than-preceding-it
   (doseq [[label reason cleanup!]
           [["frame destroy" :on-frame-destroy
-            (fn [frame _k] (timer/cancel-all-timers! frame))]
+            (fn [frame _k] (rf.machines.timer/cancel-all-timers! frame))]
            ["epoch restore" :on-restore
-            (fn [frame _k] (timer/cancel-frame-timers-on-restore! frame))]
+            (fn [frame _k] (rf.machines.timer/cancel-frame-timers-on-restore! frame))]
            ["actor destroy" :on-destroy
-            (fn [frame k] (timer/cancel-actor-timers! frame (:parent k)))]
+            (fn [frame k] (rf.machines.timer/cancel-actor-timers! frame (:parent k)))]
            ["state exit" :on-exit
-            (fn [frame k] (timer/after-cancel-fx {:frame frame}
+            (fn [frame k] (rf.machines.timer/after-cancel-fx {:frame frame}
                                                  {:rf/parent-id (:parent k)
                                                   :rf/invoke-id (:spawn k)}))]]]
     (testing (str "cleanup owner: " label)
@@ -183,11 +183,11 @@
         (is (empty? (inner cfid))
             "precondition: the client frame holds no prior timer, so the
              hydration is exactly one arm")
-        (mtest/reset-captured!)
+        (rf.machines.test-support/reset-captured!)
         (let [{:keys [bit? reserved? arms]}
               (hydrate-with-cleanup-in-the-window! cfid rt cleanup!)
-              scheduled (mtest/events-of :rf.machine.timer/scheduled)
-              cancelled (mtest/events-of :rf.machine.timer/cancelled)]
+              scheduled (rf.machines.test-support/events-of :rf.machine.timer/scheduled)
+              cancelled (rf.machines.test-support/events-of :rf.machine.timer/cancelled)]
           (is (true? bit?)
               "the arm's own `/scheduled` row was intercepted (seam exercised)")
           (is (true? reserved?)
@@ -232,24 +232,24 @@
     (rf/reg-machine :announce/succ literal-machine)
     (let [rt      (server-runtime-db :announce/succ)
           cfid    (fresh-frame! :client)
-          token-a (frame/frame-incarnation-token cfid)
+          token-a (rf.frame/frame-incarnation-token cfid)
           fired?  (atom false)
           token-b (atom nil)]
-      (with-redefs [interop/schedule-after!   (fn [_thunk _ms] ::handle)
-                    interop/cancel-scheduled! (fn [_h] nil)]
-        (mtest/reset-captured!)
-        (trace-tooling/register-listener!
+      (with-redefs [rf.interop/schedule-after!   (fn [_thunk _ms] ::handle)
+                    rf.interop/cancel-scheduled! (fn [_h] nil)]
+        (rf.machines.test-support/reset-captured!)
+        (rf.trace.tooling/register-listener!
           ::succ
           (fn [ev]
             (when (and (= :rf.machine.timer/scheduled (:operation ev))
                        (compare-and-set! fired? false true))
-              (frame/destroy-frame! cfid)
+              (rf.frame/destroy-frame! cfid)
               (rf/make-frame {:id cfid :platform :client})
-              (reset! token-b (frame/frame-incarnation-token cfid))
+              (reset! token-b (rf.frame/frame-incarnation-token cfid))
               (install! cfid rt))))
         (try
           (install! cfid rt)
-          (finally (trace-tooling/unregister-listener! ::succ))))
+          (finally (rf.trace.tooling/unregister-listener! ::succ))))
       (is (true? @fired?) "the `/scheduled` listener ran (seam exercised)")
       (is (not (identical? token-a @token-b))
           "and B is a DISTINCT incarnation from A")
@@ -262,7 +262,7 @@
                "out, so its `/cancelled` follows immediately rather than "
                "waiting for the announcer to return"))
       (is (= :on-frame-destroy
-             (:reason (:tags (first (mtest/events-of :rf.machine.timer/cancelled)))))
+             (:reason (:tags (first (rf.machines.test-support/events-of :rf.machine.timer/cancelled)))))
           "A's closure carries the sweep's reason")
       (is (= 1 (count (inner cfid)))
           "B's own timer is armed and survives A's token-exact abort"))))

--- a/implementation/machines/test/re_frame/after_timer_arm_publish_race_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/after_timer_arm_publish_race_cljs_test.cljc
@@ -29,16 +29,16 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
+            [re-frame.interop :as rf.interop]
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.machines.timer :as timer]
-            [re-frame.subs :as subs]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.machines.timer :as rf.machines.timer]
+            [re-frame.subs :as rf.subs]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- fresh-handle
   "A process-unique opaque host handle, distinguishable by `identical?` on both
@@ -49,7 +49,7 @@
 (defn- inner
   "The `:rf/default` frame's inner `:after` timer table, or `{}`."
   []
-  (get @timer/after-timers :rf/default {}))
+  (get @rf.machines.timer/after-timers :rf/default {}))
 
 ;; A literal-delay `:after` state — the host clock is stubbed, so the 1-hour
 ;; delay never fires on its own; it lingers as an armed entry we can race.
@@ -79,10 +79,10 @@
         traces       (atom [])
         armed-handle (fresh-handle)
         lkey         ::arm-cleanup-rec]
-    (trace-tooling/register-listener! lkey (cancelled-listener traces))
+    (rf.trace.tooling/register-listener! lkey (cancelled-listener traces))
     (try
-      (with-redefs [interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)
-                    interop/schedule-after!
+      (with-redefs [rf.interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)
+                    rf.interop/schedule-after!
                     (fn [_thunk _ms]
                       ;; The slot is reserved (sentinel) but not yet published:
                       ;; a lifecycle cleanup wins here.
@@ -90,19 +90,19 @@
                         (cleanup! :rf/default k))
                       armed-handle)]
         (rf/dispatch-sync [machine-id [:go]]))
-      (finally (trace-tooling/unregister-listener! lkey)))
+      (finally (rf.trace.tooling/unregister-listener! lkey)))
     {:cancelled @cancelled :traces @traces :handle armed-handle}))
 
 (deftest arm-after-cleanup-leaves-no-entry-and-cancels-orphan-handle
   (doseq [[label reason cleanup!]
           [["frame destroy" :on-frame-destroy
-            (fn [frame _k] (timer/cancel-all-timers! frame))]
+            (fn [frame _k] (rf.machines.timer/cancel-all-timers! frame))]
            ["epoch restore" :on-restore
-            (fn [frame _k] (timer/cancel-frame-timers-on-restore! frame))]
+            (fn [frame _k] (rf.machines.timer/cancel-frame-timers-on-restore! frame))]
            ["actor destroy" :on-destroy
-            (fn [frame k] (timer/cancel-actor-timers! frame (:parent k)))]
+            (fn [frame k] (rf.machines.timer/cancel-actor-timers! frame (:parent k)))]
            ["state exit (:on-exit)" :on-exit
-            (fn [frame k] (timer/after-cancel-fx {:frame frame}
+            (fn [frame k] (rf.machines.timer/after-cancel-fx {:frame frame}
                                                  {:rf/parent-id (:parent k)
                                                   :rf/invoke-id (:spawn k)}))]]]
     (testing (str "cleanup owner: " label)
@@ -132,13 +132,13 @@
         unsub-count  (atom 0)
         cancelled    (atom [])
         armed-handle (fresh-handle)]
-    (with-redefs [subs/subscribe   (fn ([_] reaction) ([_ _] reaction))
-                  subs/unsubscribe (fn ([_] (swap! unsub-count inc) nil)
+    (with-redefs [rf.subs/subscribe   (fn ([_] reaction) ([_ _] reaction))
+                  rf.subs/unsubscribe (fn ([_] (swap! unsub-count inc) nil)
                                      ([_ _] (swap! unsub-count inc) nil))
-                  interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)
-                  interop/schedule-after!
+                  rf.interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)
+                  rf.interop/schedule-after!
                   (fn [_thunk _ms]
-                    (timer/cancel-all-timers! :rf/default) ;; frame destroy mid-arm
+                    (rf.machines.timer/cancel-all-timers! :rf/default) ;; frame destroy mid-arm
                     armed-handle)]
       (rf/dispatch-sync [:armrace/sub [:go]])
       (is (empty? (inner)) "no entry survives the mid-arm frame destroy")
@@ -169,22 +169,22 @@
   (let [hA        (fresh-handle)
         hB        (fresh-handle)
         cancelled (atom [])]
-    (with-redefs [interop/schedule-after! (fn [_thunk _ms] hA)]
+    (with-redefs [rf.interop/schedule-after! (fn [_thunk _ms] hA)]
       (rf/dispatch-sync [:succ/m [:go]]))
     (let [[k a-entry] (first (inner))
           b-entry     (assoc a-entry :handle hB :token ::successor-token)]
       (is (identical? hA (:handle a-entry)) "precondition: A armed with handle hA")
-      (with-redefs [interop/cancel-scheduled!
+      (with-redefs [rf.interop/cancel-scheduled!
                     (fn [h]
                       (swap! cancelled conj h)
                       ;; B lands at the same key while A's handle is being
                       ;; released — the concurrent re-arm publishing a successor.
                       (when (identical? h hA)
-                        (swap! timer/after-timers assoc-in [:rf/default k] b-entry))
+                        (swap! rf.machines.timer/after-timers assoc-in [:rf/default k] b-entry))
                       nil)]
         ;; cancel A (actor destroy) — reads A, claims A by A's token, releases A
-        (timer/cancel-actor-timers! :rf/default (:parent k)))
-      (let [slot (get-in @timer/after-timers [:rf/default k])]
+        (rf.machines.timer/cancel-actor-timers! :rf/default (:parent k)))
+      (let [slot (get-in @rf.machines.timer/after-timers [:rf/default k])]
         (is (= b-entry slot)
             "successor B SURVIVES A's cancellation — the old cancel did not delete it")
         (is (identical? hB (:handle slot)) "B's host handle is intact")
@@ -210,12 +210,12 @@
                             :done    {}}})
   (let [reaction (atom 5000)
         thunks   (atom [])]
-    (with-redefs [subs/subscribe   (fn ([_] reaction) ([_ _] reaction))
-                  subs/unsubscribe (fn ([_] nil) ([_ _] nil))
-                  interop/schedule-after! (fn [thunk _ms]
+    (with-redefs [rf.subs/subscribe   (fn ([_] reaction) ([_ _] reaction))
+                  rf.subs/unsubscribe (fn ([_] nil) ([_ _] nil))
+                  rf.interop/schedule-after! (fn [thunk _ms]
                                             (swap! thunks conj thunk)
                                             (fresh-handle))
-                  interop/cancel-scheduled! (fn [_h] nil)]
+                  rf.interop/cancel-scheduled! (fn [_h] nil)]
       (rf/dispatch-sync [:lose/m [:go]])            ;; arm attempt-1 → thunk-1
       (is (= 1 (count (inner))) "attempt-1 armed")
       (is (= 1 (count @thunks)) "captured thunk-1")
@@ -248,8 +248,8 @@
                             :waiting {:after {3600000 {:guard :no :target :done}}}
                             :done    {}}})
   (let [cancelled (atom [])]
-    (with-redefs [interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)
-                  interop/schedule-after! (fn [thunk _ms]
+    (with-redefs [rf.interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)
+                  rf.interop/schedule-after! (fn [thunk _ms]
                                             (let [h (fresh-handle)]
                                               ;; the host fires the callback
                                               ;; synchronously BEFORE returning

--- a/implementation/machines/test/re_frame/after_timer_completed_at_test.clj
+++ b/implementation/machines/test/re_frame/after_timer_completed_at_test.clj
@@ -12,7 +12,7 @@
   fired-timer reply, and §Tracing carries it on the stale-timer suppression
   trace too.
 
-  These tests drive the REAL `interop/schedule-after!` fire boundary so the
+  These tests drive the REAL `rf.interop/schedule-after!` fire boundary so the
   timer-fire dispatch is router-stamped with a known fire-time clock value,
   then assert `:rf.reply/completed-at` rides the `:rf.machine.timer/fired`
   and `:rf.machine.timer/stale-after` traces. rf2-o6c2jr — the reply MAP still
@@ -20,18 +20,18 @@
   reply-envelope `:rf.reply/completed-at` (the bare duplicate was dropped)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
             [re-frame.machines]
-            [re-frame.machines.reply :as m-reply]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.router :as router]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.reply :as rf.machines.reply]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.router :as rf.router]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (def ^:private PARENT-TIME-MS 1000000000)
 (def ^:private FIRE-TIME-MS   2000000000)
@@ -40,7 +40,7 @@
 
 (deftest after-fired-reply-carries-completed-at
   (testing "rf2-hawtjr — after-fired-reply threads :completed-at when supplied"
-    (let [r (m-reply/after-fired-reply
+    (let [r (rf.machines.reply/after-fired-reply
               {:actor-id :a/m :state :loading :delay 5000
                :decl-path [:loading] :epoch 1 :frame :rf/default
                :completed-at FIRE-TIME-MS})]
@@ -48,7 +48,7 @@
           "fired reply carries the causal completion timestamp")
       (is (= :ok (:status r))))
     (testing "omitted (not nil-filled) when absent"
-      (let [r (m-reply/after-fired-reply
+      (let [r (rf.machines.reply/after-fired-reply
                 {:actor-id :a/m :state :loading :delay 5000
                  :decl-path [:loading] :epoch 1 :frame :rf/default})]
         (is (not (contains? r :completed-at))
@@ -56,14 +56,14 @@
 
 (deftest after-stale-reply-carries-completed-at
   (testing "rf2-hawtjr — after-stale-reply threads :completed-at when supplied"
-    (let [r (m-reply/after-stale-reply
+    (let [r (rf.machines.reply/after-stale-reply
               {:actor-id :a/m :state :loading :delay 5000
                :decl-path [:loading] :scheduled-epoch 1 :current-epoch 2
                :frame :rf/default :completed-at FIRE-TIME-MS})]
       (is (= FIRE-TIME-MS (:completed-at r)))
       (is (= :stale (:status r))))
     (testing "omitted (not nil-filled) when absent"
-      (let [r (m-reply/after-stale-reply
+      (let [r (rf.machines.reply/after-stale-reply
                 {:actor-id :a/m :state :loading :delay 5000
                  :decl-path [:loading] :scheduled-epoch 1 :current-epoch 2
                  :frame :rf/default})]
@@ -82,12 +82,12 @@
              :states  {:idle    {:on {:fetch :loading}}
                        :loading {:after {5000 :timeout}}
                        :timeout {}}}
-          orig-dispatch! (late-bind/get-fn :router/dispatch!)]
+          orig-dispatch! (rf.late-bind/get-fn :router/dispatch!)]
       (rf/reg-machine :hawtjr/fired m)
-      (mtest/with-trace-capture captured
-        (with-redefs [interop/schedule-after!
+      (rf.machines.test-support/with-trace-capture captured
+        (with-redefs [rf.interop/schedule-after!
                       (fn [f _ms] (reset! captured-thunk f) ::stub-handle)
-                      interop/epoch-now-ms (fn [] @clock)]
+                      rf.interop/epoch-now-ms (fn [] @clock)]
           (rf/dispatch-sync [:hawtjr/fired [:fetch]]
                             {:rf.cofx {:rf/time-ms PARENT-TIME-MS}})
           (is (= :loading (:state (snapshot :hawtjr/fired))))
@@ -95,10 +95,10 @@
           ;; advance the wall clock to a DISTINCT fire-time value
           (reset! clock FIRE-TIME-MS)
           (try
-            (late-bind/set-fn! :router/dispatch! router/dispatch-sync!)
+            (rf.late-bind/set-fn! :router/dispatch! rf.router/dispatch-sync!)
             (@captured-thunk)
             (finally
-              (late-bind/set-fn! :router/dispatch! orig-dispatch!))))
+              (rf.late-bind/set-fn! :router/dispatch! orig-dispatch!))))
         (is (= :timeout (:state (snapshot :hawtjr/fired)))
             "the timer fired and drove the transition")
         (let [fired (->> @captured
@@ -127,7 +127,7 @@
                        :warn    {}
                        :ready   {}}}]
       (rf/reg-machine :hawtjr/stale m)
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         (rf/dispatch-sync [:hawtjr/stale [:fetch]])
         (let [epoch (get-in (snapshot :hawtjr/stale)
                             [:data :rf/after-epoch [:loading]])]

--- a/implementation/machines/test/re_frame/after_value_forms_test.clj
+++ b/implementation/machines/test/re_frame/after_value_forms_test.clj
@@ -24,14 +24,14 @@
   unguarded candidate acts as the fallback. Cases (e), (f), (g) — the
   candidate-vector forms — pin this resolution against regression.
 
-  These tests drive the PURE `machines/machine-transition` surface with the
+  These tests drive the PURE `rf.machines/machine-transition` surface with the
   synthetic `[:rf.machine.timer/after-elapsed delay-key epoch decl-path]`
   event so the value-form resolution is observable without any wall-clock
   scheduling or runtime fixture. The snapshot's `:data` carries the
   per-decl-path `:rf/after-epoch` map so the timer is `live` (carried-epoch
   == current per-path epoch)."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.machines :as machines]))
+            [re-frame.machines :as rf.machines]))
 
 ;; ---- helpers --------------------------------------------------------------
 
@@ -46,7 +46,7 @@
   return `[next-state next-snapshot fx-vec]`. `next-state` is read off the
   returned snapshot's `:state` for the common state-change assertion."
   [spec snapshot event]
-  (let [{snap :snapshot fx :fx} (machines/machine-transition spec snapshot event)]
+  (let [{snap :snapshot fx :fx} (rf.machines/machine-transition spec snapshot event)]
     [(:state snap) snap fx]))
 
 (defn- snap-at
@@ -367,9 +367,9 @@
                                 :calm      {}}}]
       (testing "guard passes → first candidate target + action on both paths"
         (let [{on-snap :snapshot}
-              (machines/machine-transition on-spec {:state :idle :data {:hot? true}} [:poke])
+              (rf.machines/machine-transition on-spec {:state :idle :data {:hot? true}} [:poke])
               {after-snap :snapshot}
-              (machines/machine-transition
+              (rf.machines/machine-transition
                 after-spec
                 {:state :idle
                  :data  {:hot? true :rf/after-epoch {[:idle] 1}}}
@@ -382,9 +382,9 @@
               ":on and :after land on the SAME target for the same candidate-vector")))
       (testing "guard fails → unguarded fallback on both paths"
         (let [{on-snap :snapshot}
-              (machines/machine-transition on-spec {:state :idle :data {:hot? false}} [:poke])
+              (rf.machines/machine-transition on-spec {:state :idle :data {:hot? false}} [:poke])
               {after-snap :snapshot}
-              (machines/machine-transition
+              (rf.machines/machine-transition
                 after-spec
                 {:state :idle
                  :data  {:hot? false :rf/after-epoch {[:idle] 1}}}

--- a/implementation/machines/test/re_frame/birth_always_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/birth_always_cljs_test.cljc
@@ -18,7 +18,7 @@
 
   Two layers of coverage:
 
-   - PURE — drives `parallel/apply-initial-entry-cascade` directly (the
+   - PURE — drives `rf.machines.parallel/apply-initial-entry-cascade` directly (the
      birth site for BOTH paths; runtime-free, deterministic, JVM- and
      CLJS-runnable from arguments alone). This is the SCXML-conformance-
      style proof of the birth-eventless settle (mirrors W3C test 372/388
@@ -43,9 +43,9 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.machines.parallel :as parallel]
-   [re-frame.machines.result :as result]
-   [re-frame.machines.test-support :as mtest]
+   [re-frame.machines.parallel :as rf.machines.parallel]
+   [re-frame.machines.result :as rf.machines.result]
+   [re-frame.machines.test-support :as rf.machines.test-support]
    #?(:clj  [re-frame.substrate.plain-atom :as substrate-adapter]
       :cljs [re-frame.adapter.reagent :as substrate-adapter])))
 
@@ -65,8 +65,8 @@
   the initial macrostep (`apply-initial-entry-cascade`), and return
   `{:state :data}` from the settled snapshot. Asserts the Result is `:ok`."
   [machine]
-  (let [initial (parallel/build-initial-snapshot machine {:bootstrap-pending? false})
-        r       (parallel/apply-initial-entry-cascade machine initial)]
+  (let [initial (rf.machines.parallel/build-initial-snapshot machine {:bootstrap-pending? false})
+        r       (rf.machines.parallel/apply-initial-entry-cascade machine initial)]
     (is (= :ok (:status r)) "birth macrostep succeeds")
     (let [snap (:snapshot r)]
       {:state (:state snap) :data (:data snap)})))
@@ -76,8 +76,8 @@
   the OUTBOUND effect vector (e.g. that an initial-`:entry` `:raise` drained
   internally and left no reserved `:raise` fx)."
   [machine]
-  (let [initial (parallel/build-initial-snapshot machine {:bootstrap-pending? false})
-        r       (parallel/apply-initial-entry-cascade machine initial)]
+  (let [initial (rf.machines.parallel/build-initial-snapshot machine {:bootstrap-pending? false})
+        r       (rf.machines.parallel/apply-initial-entry-cascade machine initial)]
     (is (= :ok (:status r)) "birth macrostep succeeds")
     (let [snap (:snapshot r)]
       {:state (:state snap) :data (:data snap) :fx (:fx r)})))
@@ -322,10 +322,10 @@
              :guards  {:p? (fn [_] true)}
              :states  {:a {:always [{:guard :p? :target :b}]}
                        :b {:always [{:guard :p? :target :a}]}}}
-          initial (parallel/build-initial-snapshot m {:bootstrap-pending? false})
-          r       (parallel/apply-initial-entry-cascade m initial)]
+          initial (rf.machines.parallel/build-initial-snapshot m {:bootstrap-pending? false})
+          r       (rf.machines.parallel/apply-initial-entry-cascade m initial)]
       (is (= :error (:status r)) "birth returns a :fail (failed macrostep), not an :ok no-op")
-      (is (result/depth-abort? r)
+      (is (rf.machines.result/depth-abort? r)
           "the :fail carries the ::depth-abort? sentinel (a bounded-depth trip)")
       (is (nil? (:snapshot r))
           "a :fail threads no snapshot — the runaway settle commits nothing"))))
@@ -335,11 +335,11 @@
 ;; ===========================================================================
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter substrate-adapter/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter substrate-adapter/adapter}))
 
 ;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (deftest live-eager-start-settles-birth-always
   (testing "(a) eager `[:rf.machine/start]` — a transient initial leaf whose

--- a/implementation/machines/test/re_frame/cancellation_reply_envelope_test.clj
+++ b/implementation/machines/test/re_frame/cancellation_reply_envelope_test.clj
@@ -21,11 +21,11 @@
       `:rf.reply/status :cancelled` + `:rf.reply/cancel-reason :on-join-resolution`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- timer cancel (state exit) -----------------------------------------
 
@@ -40,13 +40,13 @@
                        :timeout {}
                        :ready   {}}}]
       (rf/reg-machine :sfunt8/timer m)
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         (rf/dispatch-sync [:sfunt8/timer [:fetch]])
-        (is (= :loading (:state (mtest/snapshot :sfunt8/timer))))
+        (is (= :loading (:state (rf.machines.test-support/snapshot :sfunt8/timer))))
         ;; Exit :loading before the timer fires — cancels the :after timer
         ;; with :reason :on-exit.
         (rf/dispatch-sync [:sfunt8/timer [:loaded]])
-        (is (= :ready (:state (mtest/snapshot :sfunt8/timer))))
+        (is (= :ready (:state (rf.machines.test-support/snapshot :sfunt8/timer))))
         (let [cancelled (->> @captured
                              (filter #(= :rf.machine.timer/cancelled (:operation %)))
                              first)]
@@ -86,11 +86,11 @@
                                     :timeout {}}}
                  :other  {:initial :idle
                           :states  {:idle {}}}}})
-    (mtest/with-trace-capture captured
+    (rf.machines.test-support/with-trace-capture captured
       ;; Birth the singleton parallel machine (schedules :loader/:working's
       ;; :after at its per-region epoch — a still-pending 30s host handle).
       (rf/dispatch-sync [:cttpk4-tw/timer [:rf.machine.spawn/spawned]])
-      (let [snap  (mtest/snapshot :cttpk4-tw/timer)
+      (let [snap  (rf.machines.test-support/snapshot :cttpk4-tw/timer)
             epoch (get-in snap [:data :rf/after-epoch-by-region :loader [:working]])]
         (is (= :working (get-in snap [:state :loader])) ":loader entered :working")
         (is (some? epoch) "the region :after was scheduled at a per-region epoch")
@@ -102,7 +102,7 @@
         (rf/dispatch-sync
           [:cttpk4-tw/timer
            [:rf.machine.timer/after-elapsed 30000 epoch [:loader :working]]])
-        (is (= :timeout (get-in (mtest/snapshot :cttpk4-tw/timer) [:state :loader]))
+        (is (= :timeout (get-in (rf.machines.test-support/snapshot :cttpk4-tw/timer) [:state :loader]))
             "the region :after fired → :loader moved to :timeout")
         (let [fired         (->> @captured
                                  (filter #(and (= :rf.machine.timer/fired (:operation %))
@@ -147,7 +147,7 @@
        :after   {30000 {:target [[:a :two]]}}
        :regions {:a {:initial :one :states {:one {} :two {}}}}})
     (rf/make-frame {:id :cttpk4-root/f :doc "root-after :state test frame"})
-    (mtest/with-trace-capture captured
+    (rf.machines.test-support/with-trace-capture captured
       ;; Birth in the named frame → schedules the root :after (a still-pending
       ;; 30s host handle) and emits the :scheduled trace.
       (rf/dispatch-sync [:cttpk4-root/m [:rf.machine/start]] {:frame :cttpk4-root/f})
@@ -184,7 +184,7 @@
                              :on     {:stop :idle}}}}]
       (rf/reg-machine :sfunt8/child child)
       (rf/reg-machine :sfunt8/parent parent)
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         (rf/dispatch-sync [:sfunt8/parent [:start]])
         ;; Exit the :spawn-bearing state — the spawned child is destroyed
         ;; (cancelled) before reaching a :final? leaf.
@@ -214,9 +214,9 @@
                   :states  {:working {:spawn {:machine-id :sfunt8/fchild}}}}]
       (rf/reg-machine :sfunt8/fchild child)
       (rf/reg-machine :sfunt8/fparent parent)
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         (rf/dispatch-sync [:sfunt8/fparent [:rf.machine.spawn/spawned]])
-        (let [spawned-id (get-in (mtest/runtime-db)
+        (let [spawned-id (get-in (rf.machines.test-support/runtime-db)
                                  [:rf.runtime/machines :spawned :sfunt8/fparent [:working]])]
           (rf/dispatch-sync [spawned-id [:end]]))
         (let [finished (->> @captured
@@ -269,9 +269,9 @@
       (rf/reg-machine :sfunt8/sa child)
       (rf/reg-machine :sfunt8/sb child)
       (rf/reg-machine :sup/sfunt8 parent)
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         (rf/dispatch-sync [:sup/sfunt8 [:start]])
-        (let [ids (get-in (mtest/runtime-db)
+        (let [ids (get-in (rf.machines.test-support/runtime-db)
                           [:rf.runtime/machines :spawned :sup/sfunt8 [:hydrating] :children])]
           ;; First child resolves the :any join; sibling :b is cancelled.
           (rf/dispatch-sync [(:a ids) [:go]]))

--- a/implementation/machines/test/re_frame/choice_test.clj
+++ b/implementation/machines/test/re_frame/choice_test.clj
@@ -22,15 +22,15 @@
   desugar."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.choice :as choice]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.machines.choice :as rf.machines.choice]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
             [re-frame.subs]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 ;; ---- desugaring (distinct intent, one mechanism) --------------------------
 
@@ -42,7 +42,7 @@
                      :checking {:always [{:guard :valid? :target :ok}
                                          {:target :bad}]}
                      :ok {} :bad {}}}
-           (choice/desugar-choices
+           (rf.machines.choice/desugar-choices
              {:initial :start
               :states {:start {:on {:go :checking}}
                        :checking {:type :choice
@@ -53,18 +53,18 @@
 (deftest desugar-choice-free-unchanged
   (testing "a machine with no :type :choice is returned UNCHANGED (fast-path)"
     (let [m {:initial :a :states {:a {:on {:go :b}} :b {}}}]
-      (is (identical? m (choice/desugar-choices m))))))
+      (is (identical? m (rf.machines.choice/desugar-choices m))))))
 
 (deftest desugar-choice-idempotent
   (testing "desugaring an already-desugared spec is a no-op"
     (let [m {:initial :c
              :states {:c {:always [{:guard :g :target :x} {:target :y}]}
                       :x {} :y {}}}]
-      (is (= m (choice/desugar-choices (choice/desugar-choices m)))))))
+      (is (= m (rf.machines.choice/desugar-choices (rf.machines.choice/desugar-choices m)))))))
 
 (deftest desugar-nested-choice
   (testing "a :type :choice nested inside a compound desugars in place"
-    (let [out (choice/desugar-choices
+    (let [out (rf.machines.choice/desugar-choices
                 {:initial :outer
                  :states {:outer {:initial :pick
                                   :states {:pick {:type :choice

--- a/implementation/machines/test/re_frame/cross_region_guard_ctx_test.clj
+++ b/implementation/machines/test/re_frame/cross_region_guard_ctx_test.clj
@@ -34,17 +34,17 @@
     (f) action ctx gets the same `:tags` + `:all-state` threading."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.parallel :as rf.machines.parallel]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; snapshot lookup via the shared machines test-support — no hardcoded
 ;; `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 ;; ---- (a) region guard reads a sibling region's tag ------------------------
 
@@ -183,7 +183,7 @@
                                :open   {}}}}}
           initial {:state {:form :invalid :gate :closed}
                    :data  {} :tags #{:form/invalid}}
-          {snap :snapshot} (parallel/machine-transition m initial [:go])]
+          {snap :snapshot} (rf.machines.parallel/machine-transition m initial [:go])]
       (is (= {:form :valid :gate :closed} (:state snap))
           "pure transition: :gate's guard read the FROZEN :form/invalid → blocked")
       (is (= #{:form/valid} (:tags snap))

--- a/implementation/machines/test/re_frame/destroy_closed_grammar_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/destroy_closed_grammar_cljs_test.cljc
@@ -27,24 +27,24 @@
    ;; load the machines artefact so its fx handlers + late-bind hooks are
    ;; installed when this ns runs in isolation.
    [re-frame.machines]
-   [re-frame.machines.test-support :as mtest]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
+  rf.machines.test-support/trace-capture-fixture)
 
 (defn- destroyed-traces []
-  (mtest/events-of :rf.machine/destroyed))
+  (rf.machines.test-support/events-of :rf.machine/destroyed))
 
 (defn- bad-arg-traces []
-  (mtest/events-of :rf.error/machine-destroy-bad-arg))
+  (rf.machines.test-support/events-of :rf.error/machine-destroy-bad-arg))
 
 (defn- join-state [parent-id invoke-id]
-  (get-in (mtest/runtime-db)
+  (get-in (rf.machines.test-support/runtime-db)
           [:rf.runtime/machines :spawned parent-id invoke-id]))
 
 ;; A child that stays LIVE (its states are not :final?) and never
@@ -90,7 +90,7 @@
     (is (= pre-join post-join)
         "the join slot is byte-identical — no slot mutation")
     (doseq [[cid spawned-id] children]
-      (is (some? (mtest/snapshot spawned-id))
+      (is (some? (rf.machines.test-support/snapshot spawned-id))
           (str "child " cid " (" spawned-id ") is still live")))
     (is (empty? (destroyed-traces))
         (str "no :rf.machine/destroyed fired; saw "
@@ -107,7 +107,7 @@
             emitted a bogus destroyed trace with zero bad-arg errors."
     (let [pre-join (reg-join-parent! :dcg/p1 :dcg/p1a :dcg/p1b)]
       (is (map? (:children pre-join)) "live two-child join seeded")
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (destroy-with! {:rf/reap      false
                       :rf/parent-id :dcg/p1
                       :rf/invoke-id [:racing]
@@ -124,7 +124,7 @@
   (testing "rf2-3phait — {:rf/reap nil …}: presence of :rf/reap selects the
             reap shape; a nil value is malformed (fail closed, zero mutation)"
     (let [pre-join (reg-join-parent! :dcg/p2 :dcg/p2a :dcg/p2b)]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (destroy-with! {:rf/reap      nil
                       :rf/parent-id :dcg/p2
                       :rf/invoke-id [:racing]
@@ -136,7 +136,7 @@
   (testing "rf2-3phait — {:rf/reap \"true\" …}: only the exact value true is
             the reap discriminator; truthy aliases are malformed"
     (let [pre-join (reg-join-parent! :dcg/p3 :dcg/p3a :dcg/p3b)]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (destroy-with! {:rf/reap      "true"
                       :rf/parent-id :dcg/p3
                       :rf/invoke-id [:racing]
@@ -149,7 +149,7 @@
 (deftest reap-missing-coordinate-fails-closed
   (testing "rf2-3phait — a reap missing :rf/invoke-id is malformed"
     (let [pre-join (reg-join-parent! :dcg/p4 :dcg/p4a :dcg/p4b)]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (destroy-with! {:rf/reap      true
                       :rf/parent-id :dcg/p4
                       :rf/child-id  :a})
@@ -160,7 +160,7 @@
   (testing "rf2-3phait — a reap whose :rf/invoke-id is not a path vector is
             malformed (exact coordinate types, no permissive coercion)"
     (let [pre-join (reg-join-parent! :dcg/p5 :dcg/p5a :dcg/p5b)]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (destroy-with! {:rf/reap      true
                       :rf/parent-id :dcg/p5
                       :rf/invoke-id :racing
@@ -174,7 +174,7 @@
   (testing "rf2-3phait — a carrier declaring BOTH :rf/reap and :rf/spawn-all
             is an overlapping shape: fail closed, zero mutation"
     (let [pre-join (reg-join-parent! :dcg/p6 :dcg/p6a :dcg/p6b)]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (destroy-with! {:rf/reap      true
                       :rf/spawn-all true
                       :rf/parent-id :dcg/p6
@@ -189,7 +189,7 @@
             Pre-fix it fell through destroy-machine-fx's truthy routing into
             the tracked branch and corrupted the join slot"
     (let [pre-join (reg-join-parent! :dcg/p7 :dcg/p7a :dcg/p7b)]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (destroy-with! {:rf/spawn-all false
                       :rf/parent-id :dcg/p7
                       :rf/invoke-id [:racing]})
@@ -200,7 +200,7 @@
   (testing "rf2-3phait — a well-discriminated reap carrying an EXTRA unknown
             key is outside the closed grammar: fail closed"
     (let [pre-join (reg-join-parent! :dcg/p8 :dcg/p8a :dcg/p8b)]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (destroy-with! {:rf/reap      true
                       :rf/parent-id :dcg/p8
                       :rf/invoke-id [:racing]
@@ -217,7 +217,7 @@
             MAP must fail closed: the tracked branch can never consume a
             join-state map as an actor id"
     (let [pre-join (reg-join-parent! :dcg/p9 :dcg/p9a :dcg/p9b)]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (destroy-with! {:rf/parent-id :dcg/p9
                       :rf/invoke-id [:racing]})
       (is (= 1 (count (bad-arg-traces)))
@@ -230,7 +230,7 @@
   (testing "rf2-3phait — the imperative form requires a keyword actor id;
             any other non-map arg is outside the closed grammar"
     (let [pre-join (reg-join-parent! :dcg/p10 :dcg/p10a :dcg/p10b)]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (destroy-with! "not-an-actor-id")
       (is (= 1 (count (bad-arg-traces))))
       (assert-zero-mutation! :dcg/p10 pre-join))))
@@ -247,12 +247,12 @@
                  :working {:spawn {:machine-id :dcg/live-child}
                            :on    {:stop :idle}}}})
     (rf/dispatch-sync [:dcg/tracked-parent [:start]])
-    (let [child-id (get-in (mtest/runtime-db)
+    (let [child-id (get-in (rf.machines.test-support/runtime-db)
                            [:rf.runtime/machines :spawned :dcg/tracked-parent [:working]])]
       (is (keyword? child-id) "single tracked :spawn child live")
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (rf/dispatch-sync [:dcg/tracked-parent [:stop]])
-      (is (nil? (mtest/snapshot child-id)) "tracked child torn down on exit")
+      (is (nil? (rf.machines.test-support/snapshot child-id)) "tracked child torn down on exit")
       (is (= 1 (count (filterv #(= child-id (:actor-id (:tags %)))
                                (destroyed-traces))))
           "exactly one destroyed trace for the tracked child")
@@ -277,11 +277,11 @@
     (rf/dispatch-sync [:dcg/sa-parent [:start]])
     (let [children (:children (join-state :dcg/sa-parent [:racing]))]
       (is (= 2 (count children)))
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (rf/dispatch-sync [:dcg/sa-parent [:abort]])
       (is (nil? (join-state :dcg/sa-parent [:racing])) "join slot cleared")
       (doseq [[cid spawned-id] children]
-        (is (nil? (mtest/snapshot spawned-id))
+        (is (nil? (rf.machines.test-support/snapshot spawned-id))
             (str "child " cid " torn down on exit")))
       (is (empty? (bad-arg-traces))
           "no bad-arg error for the genuine spawn-all exit form"))))

--- a/implementation/machines/test/re_frame/destroy_exit_cascade_test.clj
+++ b/implementation/machines/test/re_frame/destroy_exit_cascade_test.clj
@@ -28,11 +28,11 @@
       reading the db between `:exit` and `:rf.machine/destroyed`)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- (1) explicit [:rf.machine/destroy actor-id] -------------------------
 

--- a/implementation/machines/test/re_frame/destroy_silent_idempotent_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/destroy_silent_idempotent_cljs_test.cljc
@@ -33,24 +33,24 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.machines.test-support :as mtest]
+   [re-frame.machines.test-support :as rf.machines.test-support]
    ;; listener surface lives in `re-frame.trace.tooling`
    ;; (production-DCE split).
-   [re-frame.trace.tooling :as trace-tooling]
-   [re-frame.registrar :as registrar]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   [re-frame.registrar :as rf.registrar]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter})))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter})))
 
 ;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
-;; Intentional RAW register-only listener (not mtest/with-trace-capture):
+;; Intentional RAW register-only listener (not rf.machines.test-support/with-trace-capture):
 ;; returns the live capture atom for the caller to read across multiple
 ;; macrosteps; the per-test fixture reset clears the listener table — a fresh
 ;; capture scope per call would lose the cross-step accumulation the silent-
@@ -58,7 +58,7 @@
 (defn- record-traces!
   [k]
   (let [a (atom [])]
-    (trace-tooling/register-listener! k (fn [ev] (swap! a conj ev)))
+    (rf.trace.tooling/register-listener! k (fn [ev] (swap! a conj ev)))
     a))
 
 (defn- destroyed-traces
@@ -83,7 +83,7 @@
       ;; Sanity: the auto-destroy fully tore the actor down.
       (is (nil? (snapshot :rf2-lbjnz/finisher))
           "auto-destroy cleared the snapshot")
-      (is (nil? (registrar/lookup :event :rf2-lbjnz/finisher))
+      (is (nil? (rf.registrar/lookup :event :rf2-lbjnz/finisher))
           "auto-destroy unregistered the handler")
       (let [dests-after-auto (destroyed-traces traces)
             finish-count     (count (filter #(= :rf.machine/finished
@@ -120,7 +120,7 @@
       ;; World is unchanged.
       (is (nil? (snapshot :rf2-lbjnz/finisher))
           "snapshot stays gone after the silent no-op")
-      (is (nil? (registrar/lookup :event :rf2-lbjnz/finisher))
+      (is (nil? (rf.registrar/lookup :event :rf2-lbjnz/finisher))
           "handler stays unregistered after the silent no-op"))))
 
 ;; ---- Test 2: double-explicit destroy in the same cascade -----------------
@@ -140,7 +140,7 @@
       (rf/dispatch-sync [:rf2-lbjnz/target [:noop]])
       (is (some? (snapshot :rf2-lbjnz/target))
           "target actor's snapshot is live before the cascade")
-      (is (some? (registrar/lookup :event :rf2-lbjnz/target))
+      (is (some? (rf.registrar/lookup :event :rf2-lbjnz/target))
           "target actor's handler is registered before the cascade")
       ;; Emit two destroy fxs against the same id in one cascade. The
       ;; first one tears the actor down; the second must be a silent
@@ -165,7 +165,7 @@
       ;; World is destroyed exactly once.
       (is (nil? (snapshot :rf2-lbjnz/target))
           "snapshot is cleared exactly once")
-      (is (nil? (registrar/lookup :event :rf2-lbjnz/target))
+      (is (nil? (rf.registrar/lookup :event :rf2-lbjnz/target))
           "handler is unregistered exactly once"))))
 
 ;; ---- Test 3: spawn-all join-cancelled survivor destroyed exactly once ------

--- a/implementation/machines/test/re_frame/destroyed_exit_order_test.clj
+++ b/implementation/machines/test/re_frame/destroyed_exit_order_test.clj
@@ -37,15 +37,15 @@
   the observable ordering."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace :as rf.trace]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; `record-order!` intentionally uses a RAW listener (not
-;; `mtest/with-trace-capture`): it conjes its `:destroyed` sentinel onto the
+;; `rf.machines.test-support/with-trace-capture`): it conjes its `:destroyed` sentinel onto the
 ;; SAME caller-supplied ordering log the machine `:exit` action writes to, so
 ;; the interleaved marker order is the observable — a fresh capture atom
 ;; could not share that log.
@@ -54,12 +54,12 @@
   onto `log`; returns an unregister thunk."
   [log]
   (let [id ::order-listener]
-    (trace/register-listener!
+    (rf.trace/register-listener!
       id
       (fn [ev]
         (when (= :rf.machine/destroyed (:operation ev))
           (swap! log conj :destroyed))))
-    #(trace/unregister-listener! id)))
+    #(rf.trace/unregister-listener! id)))
 
 (defn- exit-then-destroyed?
   "True iff the first `:exit` marker precedes the first `:destroyed`

--- a/implementation/machines/test/re_frame/destroyed_reason_channel_conformance_test.clj
+++ b/implementation/machines/test/re_frame/destroyed_reason_channel_conformance_test.clj
@@ -57,8 +57,8 @@
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom])
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom])
   (:import [java.io PushbackReader]))
 
 ;; ---------------------------------------------------------------------------
@@ -715,7 +715,7 @@
 ;; ---------------------------------------------------------------------------
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (deftest executable-explicit-destroy-emits-fx-explicit
   (testing "an explicit teardown (declarative :spawn exit cascade) emits EXACTLY
@@ -726,7 +726,7 @@
                      :states  {:idle    {:on {:start :working}}
                                :working {:spawn {:machine-id :dre/child}
                                          :on    {:stop :idle}}}})
-    (mtest/with-trace-capture captured
+    (rf.machines.test-support/with-trace-capture captured
       (rf/dispatch-sync [:dre/parent [:start]])
       (rf/dispatch-sync [:dre/parent [:stop]])          ; exit :working → destroy-single!
       (let [fx (filter #(= fx-channel (:operation %)) @captured)]
@@ -744,9 +744,9 @@
                      :states  {:running {:on {:end :done}} :done {:final? true}}})
     (rf/reg-machine :drf/parent
                     {:initial :working :states {:working {:spawn {:machine-id :drf/child}}}})
-    (mtest/with-trace-capture captured
+    (rf.machines.test-support/with-trace-capture captured
       (rf/dispatch-sync [:drf/parent [:rf.machine.spawn/spawned]])
-      (let [spawned (get-in (mtest/runtime-db)
+      (let [spawned (get-in (rf.machines.test-support/runtime-db)
                             [:rf.runtime/machines :spawned :drf/parent [:working]])]
         (rf/dispatch-sync [spawned [:end]]))          ; child → :final? → finalize
       (let [fin (filter #(= :rf.machine/finished (-> % :tags :reason)) @captured)]
@@ -782,9 +782,9 @@
                                            :on-child-done    :asset/loaded
                                            :on-child-error   :asset/failed
                                            :on-some-complete [:race/won]}}}})
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         (rf/dispatch-sync [:drj/sup [:start]])
-        (let [a-id (get-in (mtest/runtime-db)
+        (let [a-id (get-in (rf.machines.test-support/runtime-db)
                            [:rf.runtime/machines :spawned :drj/sup [:racing] :children :a])]
           (rf/dispatch-sync [a-id [:go]])              ; :a completes → :any resolves → :a reaped
           (let [reaped (filter #(and (= fx-channel (:operation %))
@@ -808,7 +808,7 @@
                                                                     {:machine-id :drl/child
                                                                      :id-prefix  :drl/child}]]})}}}}})
     (rf/dispatch-sync [:drl/boot [:start]] {:frame :drl/auth})
-    (mtest/with-trace-capture captured
+    (rf.machines.test-support/with-trace-capture captured
       (rf/destroy-frame! :drl/auth)
       (let [lc (filter #(= lifecycle-channel (:operation %)) @captured)]
         (is (seq lc) "a lifecycle-channel destroyed fired on frame destroy")

--- a/implementation/machines/test/re_frame/destroyed_trace_shape_test.clj
+++ b/implementation/machines/test/re_frame/destroyed_trace_shape_test.clj
@@ -33,12 +33,12 @@
       those slots (no nil-stamping)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace :as rf.trace]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; Canonical key-set that the destroyed-trace emission sites are
 ;; responsible for assembling. The trace framework auto-stamps
@@ -75,7 +75,7 @@
 (defn- destroyed-traces [captured]
   (filter #(= :rf.machine/destroyed (:operation %)) @captured))
 
-;; Intentional RAW manual-stop listener (not mtest/with-trace-capture): this
+;; Intentional RAW manual-stop listener (not rf.machines.test-support/with-trace-capture): this
 ;; is the destroyed-trace SHAPE probe — it returns a [capture-atom
 ;; unregister-fn] pair so a test can inspect the raw envelope key-set and
 ;; control exactly when it stops capturing (the scope-macro form cannot
@@ -84,8 +84,8 @@
   []
   (let [a  (atom [])
         id ::shape-listener]
-    (trace/register-listener! id (fn [ev] (swap! a conj ev)))
-    [a #(trace/unregister-listener! id)]))
+    (rf.trace/register-listener! id (fn [ev] (swap! a conj ev)))
+    [a #(rf.trace/unregister-listener! id)]))
 
 (defn- assert-shape!
   [traces label]

--- a/implementation/machines/test/re_frame/dispatch_to_system_fx_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/dispatch_to_system_fx_cljs_test.cljc
@@ -33,19 +33,19 @@
    ;; requiring `re-frame.machines` wires the machines artefact into the
    ;; late-bind registry so `rf/reg-machine` resolves AND registers the
    ;; `:rf.machine/dispatch-to-system` fx under test.
-   [re-frame.machines :as machines]
-   [re-frame.machines.test-support :as mtest]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.machines :as rf.machines]
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter})))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter})))
 
 ;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (deftest dispatch-to-system-fx-reaches-spawned-actor
   (testing "a machine action's [:rf.machine/dispatch-to-system [<sys> [:msg]]]
@@ -70,7 +70,7 @@
                                       {:fx [[:rf.machine/dispatch-to-system
                                              [:notifier [:notify "hello"]]]]})}}}}})
     (rf/dispatch-sync [:sup/flow [:go]])
-    (let [spawned (machines/machine-by-system-id :notifier)]
+    (let [spawned (rf.machines/machine-by-system-id :notifier)]
       (is (= :notifier/proc#1 spawned)
           ":system-id resolves to the spawned actor")
       (is (= [] (get-in (snapshot spawned) [:data :msgs]))
@@ -91,5 +91,5 @@
         {:fx [[:rf.machine/dispatch-to-system [:nobody [:whatever]]]]}))
     (is (nil? (rf/dispatch-sync [::poke]))
         "emitting the fx against an unbound system-id is a harmless no-op")
-    (is (nil? (machines/machine-by-system-id :nobody))
+    (is (nil? (rf.machines/machine-by-system-id :nobody))
         "the unbound name still resolves to nil")))

--- a/implementation/machines/test/re_frame/done_signal_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/done_signal_cljs_test.cljc
@@ -25,24 +25,24 @@
    ;; late-bind registry so `rf/reg-machine` resolves (mirrors
    ;; `final_state_cljs_test`).
    [re-frame.machines]
-   [re-frame.machines.test-support :as mtest]
-   [re-frame.trace.tooling :as trace-tooling]
-   [re-frame.registrar :as registrar]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   [re-frame.registrar :as rf.registrar]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter})))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter})))
 
 ;; snapshot lookup via the shared machines test-support — no hardcoded
 ;; `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (defn- record-traces! [k]
   (let [a (atom [])]
-    (trace-tooling/register-listener! k (fn [ev] (swap! a conj ev)))
+    (rf.trace.tooling/register-listener! k (fn [ev] (swap! a conj ev)))
     a))
 
 (defn- traces-for [traces operation]
@@ -70,7 +70,7 @@
         "the compound :flow reached its final child; :on-done advanced to :next")
     (is (some? (snapshot :rf2-zlmz7/flow))
         "the machine snapshot is INTACT — embedded final did NOT auto-destroy")
-    (is (some? (registrar/lookup :event :rf2-zlmz7/flow))
+    (is (some? (rf.registrar/lookup :event :rf2-zlmz7/flow))
         "the handler is still registered — the machine keeps running")))
 
 (deftest compound-done-no-on-done-rests-without-destroy
@@ -88,7 +88,7 @@
       (rf/dispatch-sync [:rf2-zlmz7/rest [:finish]])
       (is (= [:flow :inner-done] (:state (snapshot :rf2-zlmz7/rest)))
           "machine RESTS at the embedded final leaf — no teardown")
-      (is (some? (registrar/lookup :event :rf2-zlmz7/rest))
+      (is (some? (rf.registrar/lookup :event :rf2-zlmz7/rest))
           "handler still live — the embedded final did not auto-destroy")
       (is (empty? (traces-for traces :rf.machine/done))
           "no whole-machine :rf.machine/done fired (this is an in-machine
@@ -127,7 +127,7 @@
       (rf/dispatch-sync [:rf2-bnjb3/top [:end]])
       (is (nil? (snapshot :rf2-bnjb3/top))
           "top-level final auto-destroyed (snapshot cleared)")
-      (is (nil? (registrar/lookup :event :rf2-bnjb3/top))
+      (is (nil? (rf.registrar/lookup :event :rf2-bnjb3/top))
           "handler unregistered on top-level final")
       (is (= 1 (count (traces-for traces :rf.machine/done)))
           "the whole-machine :rf.machine/done fired (actor finality)"))))
@@ -153,7 +153,7 @@
         "both regions reached :final?")
     (is (= 1 (get-in (snapshot :rf2-bnjb3/par) [:data :completions]))
         "the parallel root :on-done action fired once on all-regions-final")
-    (is (some? (registrar/lookup :event :rf2-bnjb3/par))
+    (is (some? (rf.registrar/lookup :event :rf2-bnjb3/par))
         "the machine SURVIVES (no auto-destroy) — :on-done is the
          transitionable signal, distinct from actor teardown")))
 
@@ -214,7 +214,7 @@
           ":completions did NOT drift — :on-done did not re-fire on resting macrosteps")
       (is (= 1 @continued)
           "the coordinator was NOT re-dispatched on later resting events")
-      (is (some? (registrar/lookup :event :rf2-h3wca/once))
+      (is (some? (rf.registrar/lookup :event :rf2-h3wca/once))
           "machine still alive (no-op events don't tear it down)"))))
 
 (deftest parallel-no-on-done-still-auto-destroys
@@ -227,7 +227,7 @@
     (rf/dispatch-sync [:rf2-bnjb3/par-destroy [:fin]])
     (is (nil? (snapshot :rf2-bnjb3/par-destroy))
         "no :on-done ⇒ all-regions-final auto-destroys (snapshot cleared)")
-    (is (nil? (registrar/lookup :event :rf2-bnjb3/par-destroy))
+    (is (nil? (rf.registrar/lookup :event :rf2-bnjb3/par-destroy))
         "handler unregistered")))
 
 (deftest parallel-one-region-pending-no-on-done-no-destroy
@@ -245,7 +245,7 @@
         "only :a reached final")
     (is (= 0 (get-in (snapshot :rf2-bnjb3/par-partial) [:data :completions]))
         ":on-done did NOT fire (not all-regions-final)")
-    (is (some? (registrar/lookup :event :rf2-bnjb3/par-partial))
+    (is (some? (rf.registrar/lookup :event :rf2-bnjb3/par-partial))
         "machine alive — :b still pending")))
 
 ;; ===========================================================================
@@ -337,7 +337,7 @@
     (is (= {:work :work-done :status :idle}
            (:state (snapshot :rf2-bnjb3/par-compound)))
         ":work's compound advanced via its :on-done; :status untouched")
-    (is (some? (registrar/lookup :event :rf2-bnjb3/par-compound))
+    (is (some? (rf.registrar/lookup :event :rf2-bnjb3/par-compound))
         "the parallel machine survives — only one region's compound is done")))
 
 ;; ===========================================================================

--- a/implementation/machines/test/re_frame/dropped_snapshot_diagnostic_test.clj
+++ b/implementation/machines/test/re_frame/dropped_snapshot_diagnostic_test.clj
@@ -16,29 +16,29 @@
   JVM-only by intent — the commit path is substrate-independent."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.machines :as machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace :as rf.trace]
             [re-frame.trace.tooling]))
 
 ;; This ns keeps a bespoke reset-runtime fixture (it ALSO clears listeners
 ;; and reloads the machines ns) rather than reusing the shared
 ;; make-reset-runtime-fixture.
 (defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (trace/clear-listeners!)
-  (rf/init! plain-atom/adapter)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (rf.trace/clear-listeners!)
+  (rf/init! rf.substrate.plain-atom/adapter)
   ;; `init!` does not synthesise `:rf/default`, and machine fxs require a
   ;; carried frame stamp. Register `:rf/default` explicitly and pin it as the
   ;; established scope for the body.
-  (frame/ensure-default-frame!)
+  (rf.frame/ensure-default-frame!)
   (require 're-frame.machines :reload)
-  (machines/reset-timers!)
+  (rf.machines/reset-timers!)
   (rf/with-frame :rf/default
     (test-fn)))
 
@@ -54,14 +54,14 @@
 ;; snapshot lookup via the shared machines test-support.
 (defn- live-snapshot?
   [machine-id]
-  (some? (mtest/snapshot machine-id)))
+  (some? (rf.machines.test-support/snapshot machine-id)))
 
 (defn- with-recorder
   "Register a recorder, run `body-fn`, return captured
   :rf.warning/runtime-state-dropped events. Routed through the shared
-  `mtest/with-trace-capture` — guaranteed unregister in a `finally`."
+  `rf.machines.test-support/with-trace-capture` — guaranteed unregister in a `finally`."
   [body-fn]
-  (mtest/with-trace-capture recorded
+  (rf.machines.test-support/with-trace-capture recorded
     (body-fn)
     (->> @recorded
          (filter #(= :rf.warning/runtime-state-dropped (:operation %)))
@@ -110,11 +110,11 @@
     (register-live-machine!)
     ;; Reproduce the revertible-restore path: install a fresh runtime-db that
     ;; carries NO machine snapshot (e.g. restoring to a pre-spawn epoch) via
-    ;; the runtime-db PARTITION write `frame/swap-runtime-db!`. This is the
+    ;; the runtime-db PARTITION write `rf.frame/swap-runtime-db!`. This is the
     ;; LEGITIMATE way machine liveness reverts (Goal 2 — frame state
     ;; revertibility); no warning, the snapshot is gone by design.
     (let [warnings (with-recorder
-                     #(frame/swap-runtime-db! :rf/default (constantly {})))]
+                     #(rf.frame/swap-runtime-db! :rf/default (constantly {})))]
       (is (empty? warnings)
           "a direct runtime-db replace is the revertible-restore path — no footgun")
       (is (not (live-snapshot? :diag/m1))

--- a/implementation/machines/test/re_frame/final_state_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/final_state_cljs_test.cljc
@@ -32,21 +32,21 @@
    ;; (production-DCE split). On JVM the convenience aliases in
    ;; re-frame.core preserve the `rf/<name>` shape, but on CLJS the
    ;; tooling sibling must be referenced directly.
-   [re-frame.trace.tooling :as trace-tooling]
-   [re-frame.machines :as machines]
-   [re-frame.machines.test-support :as mtest]
-   [re-frame.registrar :as registrar]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   [re-frame.machines :as rf.machines]
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   [re-frame.registrar :as rf.registrar]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter})))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter})))
 
 ;; snapshot lookup via the shared machines test-support — no hardcoded
 ;; `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (defn- traces-for
   [traces operation]
@@ -55,7 +55,7 @@
 (defn- record-traces!
   [k]
   (let [a (atom [])]
-    (trace-tooling/register-listener! k (fn [ev] (swap! a conj ev)))
+    (rf.trace.tooling/register-listener! k (fn [ev] (swap! a conj ev)))
     a))
 
 ;; ---- (a) entering :final? triggers :on-done with the right output ---------
@@ -110,7 +110,7 @@
     (rf/dispatch-sync [:rf2-gn80/standalone [:end]])
     (is (nil? (snapshot :rf2-gn80/standalone))
         "snapshot was synchronously cleared (D4 + D7 singleton)")
-    (is (nil? (registrar/lookup :event :rf2-gn80/standalone))
+    (is (nil? (rf.registrar/lookup :event :rf2-gn80/standalone))
         "event handler was synchronously unregistered (D4)")))
 
 ;; ---- (c) :rf.machine/done trace emitted with the right payload -----------
@@ -185,7 +185,7 @@
       (rf/dispatch-sync [:rf2-gn80/sing [:end]])
       (is (nil? (snapshot :rf2-gn80/sing))
           "singleton snapshot was cleared on :final? entry")
-      (is (nil? (registrar/lookup :event :rf2-gn80/sing))
+      (is (nil? (rf.registrar/lookup :event :rf2-gn80/sing))
           "singleton handler was unregistered")
       (let [dones (traces-for traces :rf.machine/done)]
         (is (= 1 (count dones))
@@ -216,17 +216,17 @@
                                   ;; binding MUST still resolve — only
                                   ;; cleared after the hook returns.
                                   (reset! on-done-saw-sid
-                                          (machines/machine-by-system-id :auth-actor))
+                                          (rf.machines/machine-by-system-id :auth-actor))
                                   (assoc d :result r))}}}})
       (rf/dispatch-sync [:rf2-gn80/sid-parent [:rf.machine.spawn/spawned]])
       (let [spawned-id (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
                                [:rf.runtime/machines :spawned :rf2-gn80/sid-parent [:working]])]
-        (is (= spawned-id (machines/machine-by-system-id :auth-actor))
+        (is (= spawned-id (rf.machines/machine-by-system-id :auth-actor))
             ":system-id is bound while the child is running")
         (rf/dispatch-sync [spawned-id [:fin]])
         (is (= spawned-id @on-done-saw-sid)
             ":on-done saw the :system-id binding still live (D8)")
-        (is (nil? (machines/machine-by-system-id :auth-actor))
+        (is (nil? (rf.machines/machine-by-system-id :auth-actor))
             ":system-id binding was cleared AFTER :on-done ran (D8)")))))
 
 ;; ---- (g) dispatch to done-then-destroyed actor reuses destroyed-frame path
@@ -313,7 +313,7 @@
     ;; final and the auto-destroy fires synchronously.
     (is (nil? (snapshot :rf2-gn80/par))
         "snapshot cleared once every region reached :final?")
-    (is (nil? (registrar/lookup :event :rf2-gn80/par))
+    (is (nil? (rf.registrar/lookup :event :rf2-gn80/par))
         "parallel machine handler unregistered once every region reached :final?")))
 
 (deftest parallel-one-region-final-stays-alive
@@ -329,7 +329,7 @@
     (rf/dispatch-sync [:rf2-gn80/par-partial [:end-left]])
     (is (= {:left :z :right :a} (:state (snapshot :rf2-gn80/par-partial)))
         "only the :left region reached :final?")
-    (is (some? (registrar/lookup :event :rf2-gn80/par-partial))
+    (is (some? (rf.registrar/lookup :event :rf2-gn80/par-partial))
         "machine handler is still live — :right hasn't reached :final? yet")))
 
 ;; ---- (C2) :output-key on a NON-FIRST region's terminal leaf ----

--- a/implementation/machines/test/re_frame/final_state_spawn_order_forget_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/final_state_spawn_order_forget_cljs_test.cljc
@@ -41,20 +41,20 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.events :as events]
+   [re-frame.events :as rf.events]
    [re-frame.machines]
-   [re-frame.machines.spawn-order :as spawn-order]
-   [re-frame.machines.test-support :as mtest]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.machines.spawn-order :as rf.machines.spawn-order]
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
+  rf.machines.test-support/trace-capture-fixture)
 
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 ;; A stub `:rf.resource/release-owner` handler recording every released
 ;; owner — the machine side dispatches this by NAME (machines never
@@ -64,7 +64,7 @@
 
 (defn- install-release-stub! []
   (reset! released [])
-  (events/reg-event :rf.resource/release-owner
+  (rf.events/reg-event :rf.resource/release-owner
     (fn [_ [_ {:keys [owner]}]]
       (swap! released conj owner)
       {})))
@@ -85,7 +85,7 @@
 
 (defn- spawn-child! [parent-id frame-id]
   (rf/dispatch-sync [parent-id [:rf.machine.spawn/spawned]] {:frame frame-id})
-  (get-in (mtest/runtime-db frame-id)
+  (get-in (rf.machines.test-support/runtime-db frame-id)
           [:rf.runtime/machines :spawned parent-id [:working]]))
 
 ;; ===========================================================================
@@ -98,13 +98,13 @@
     (reg-parent-and-child! :fsf1/parent :fsf1/child)
     (let [spawned-id (spawn-child! :fsf1/parent :rf/default)]
       (is (some? spawned-id) "child was spawned")
-      (is (some #(= spawned-id %) (spawn-order/frame-order :rf/default))
+      (is (some #(= spawned-id %) (rf.machines.spawn-order/frame-order :rf/default))
           "the live spawned child is recorded in spawn-order")
       ;; Drive the child into its :final? leaf → auto-destroy.
       (rf/dispatch-sync [spawned-id [:fin]])
       (is (nil? (snapshot spawned-id))
           "the finished child's snapshot was synchronously dissoc'd")
-      (is (not-any? #(= spawned-id %) (spawn-order/frame-order :rf/default))
+      (is (not-any? #(= spawned-id %) (rf.machines.spawn-order/frame-order :rf/default))
           "the finished child was forgotten from spawn-order (the fix) —
            without it the liveness bit strands and destroy re-runs"))))
 
@@ -128,9 +128,9 @@
       (is (= [[:machine spawned-id]] @released)
           "the finish released the actor's [:machine actor-id] owner exactly once")
       ;; Scope the phantom check to the stale-destroy window only.
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (rf/dispatch-sync [::stale-destroy spawned-id])
-      (is (empty? (mtest/events-of :rf.machine/destroyed))
+      (is (empty? (rf.machines.test-support/events-of :rf.machine/destroyed))
           "the stale destroy fired NO phantom :rf.machine/destroyed trace
            (silent-idempotent) — without the forget! it RE-RUNS teardown")
       (is (= [[:machine spawned-id]] @released)
@@ -142,7 +142,7 @@
 ;; ===========================================================================
 
 (defn- parent-frame-destroyed-actor-ids []
-  (->> (mtest/events-of :rf.machine.lifecycle/destroyed)
+  (->> (rf.machines.test-support/events-of :rf.machine.lifecycle/destroyed)
        (filter #(= :parent-frame-destroyed (-> % :tags :reason)))
        (map #(-> % :tags :actor-id))
        set))
@@ -159,10 +159,10 @@
       (rf/dispatch-sync [spawned-id [:fin]] {:frame :fsf3/scratch})
       (is (nil? (snapshot :fsf3/scratch spawned-id))
           "the child auto-destroyed in the scratch frame")
-      (is (not-any? #(= spawned-id %) (spawn-order/frame-order :fsf3/scratch))
+      (is (not-any? #(= spawned-id %) (rf.machines.spawn-order/frame-order :fsf3/scratch))
           "the finished child was forgotten from the scratch frame's spawn-order")
       ;; Scope the trace check to the frame-destroy window.
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (rf/destroy-frame! :fsf3/scratch)
       (is (not (contains? (parent-frame-destroyed-actor-ids) spawned-id))
           "frame-destroy emitted NO :parent-frame-destroyed phantom for the

--- a/implementation/machines/test/re_frame/frame_destroy_cascade_test.clj
+++ b/implementation/machines/test/re_frame/frame_destroy_cascade_test.clj
@@ -16,23 +16,23 @@
 
   These JVM-side tests run on the plain-atom substrate against the
   late-bound `:machines/teardown-on-frame-destroy!` hook that the
-  machines artefact publishes for `frame/destroy-frame!`."
+  machines artefact publishes for `rf.frame/destroy-frame!`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.frame :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]
             ;; Loading `re-frame.machines` registers the late-bind hooks
             ;; (`:machines/reg-machine`, `:machines/teardown-on-frame-destroy!`,
             ;; …) that the tests below exercise — keep the require even
             ;; when the test ns doesn't reach `machines/...` directly.
             [re-frame.machines]
-            [re-frame.machines.spawn-order :as spawn-order]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.spawn-order :as rf.machines.spawn-order]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- spawn-order channel — record / forget / clear ----------------------
 
@@ -62,12 +62,12 @@
       (rf/dispatch-sync [:spo/parent [:spawn-it]])
       ;; Two spawns recorded — ids match the per-machine counter.
       (is (= [:spo/child#1 :spo/child#2]
-             (spawn-order/frame-order :rf/default))
+             (rf.machines.spawn-order/frame-order :rf/default))
           "spawn-order vector grew by exactly the two spawned actor-ids")
       ;; Explicit destroy of the first actor: it leaves the second behind.
       (rf/dispatch-sync [:spo/parent [:drop-first]])
       (is (= [:spo/child#2]
-             (spawn-order/frame-order :rf/default))
+             (rf.machines.spawn-order/frame-order :rf/default))
           "explicit destroy forgets the first actor; the second remains tracked"))))
 
 ;; ---- frame destroy walks recorded actors in reverse-creation order -------
@@ -105,7 +105,7 @@
       (rf/dispatch-sync [:fc/boot [:spawn-three]] {:frame :fc/auth})
       ;; All 3 actors are live.
       (is (= [:fc/child#1 :fc/child#2 :fc/child#3]
-             (spawn-order/frame-order :fc/auth))
+             (rf.machines.spawn-order/frame-order :fc/auth))
           "spawn-order vector ordered oldest → newest")
       ;; Destroy the frame.
       (rf/destroy-frame! :fc/auth)
@@ -113,21 +113,21 @@
       (is (= [:fc/child#3 :fc/child#2 :fc/child#1] @exit-log)
           ":exit ran newest-first per Spec 005 §Cross-Spec Interactions §1")
       ;; Every spawned actor handler is unregistered.
-      (is (nil? (registrar/lookup :event :fc/child#1))
+      (is (nil? (rf.registrar/lookup :event :fc/child#1))
           "spawned actor handler #1 was unregistered")
-      (is (nil? (registrar/lookup :event :fc/child#2))
+      (is (nil? (rf.registrar/lookup :event :fc/child#2))
           "spawned actor handler #2 was unregistered")
-      (is (nil? (registrar/lookup :event :fc/child#3))
+      (is (nil? (rf.registrar/lookup :event :fc/child#3))
           "spawned actor handler #3 was unregistered")
       ;; The spawn-order entry for the frame is gone.
-      (is (= [] (spawn-order/frame-order :fc/auth))
+      (is (= [] (rf.machines.spawn-order/frame-order :fc/auth))
           "spawn-order slot for the destroyed frame is cleared")
       ;; The registered (non-spawned) `:fc/child` and `:fc/boot`
       ;; machines stay registered — they're global singletons that
       ;; happen to share the address space with the spawned actors.
-      (is (some? (registrar/lookup :event :fc/child))
+      (is (some? (rf.registrar/lookup :event :fc/child))
           "the singleton `:fc/child` machine handler stays globally registered")
-      (is (some? (registrar/lookup :event :fc/boot))
+      (is (some? (rf.registrar/lookup :event :fc/boot))
           "the singleton `:fc/boot` machine handler stays globally registered"))))
 
 ;; ---- [:rf.runtime/machines :system-ids] reverse index is released -------
@@ -154,9 +154,9 @@
       (rf/destroy-frame! :si/auth)
       ;; Frame is gone — and the actor's handler was unregistered as
       ;; part of the cascade.
-      (is (nil? (frame/frame :si/auth))
+      (is (nil? (rf.frame/frame :si/auth))
           "frame was destroyed")
-      (is (nil? (registrar/lookup :event :si/child#1))
+      (is (nil? (rf.registrar/lookup :event :si/child#1))
           "the system-id-bound spawned actor was unregistered (its [:rf.runtime/machines :system-ids] entry was implicitly released as part of the unified teardown projection)"))))
 
 ;; ---- :rf.machine.lifecycle/destroyed trace contract ----------------------
@@ -179,7 +179,7 @@
       (rf/reg-machine :lt/boot boot)
       (rf/dispatch-sync [:lt/boot [:start]] {:frame :lt/auth})
       ;; Shared `with-trace-capture` — guaranteed unregister in a `finally`.
-      (mtest/with-trace-capture traces
+      (rf.machines.test-support/with-trace-capture traces
         (rf/destroy-frame! :lt/auth)
         (let [destroyed (filter #(= :rf.machine.lifecycle/destroyed (:operation %))
                                 @traces)]
@@ -204,7 +204,7 @@
           ;; Install the hook explicitly. `re-frame.http.managed`
           ;; isn't loaded in this leaf-artefact's classpath, so we
           ;; register the hook directly to stand in for it.
-          _ (late-bind/set-fn!
+          _ (rf.late-bind/set-fn!
               :http/abort-on-actor-destroy
               (fn [actor-id] (swap! aborted conj actor-id)))
           child  {:initial :running :data {} :states {:running {}}}
@@ -261,8 +261,8 @@
       (rf/dispatch-sync [:iso/boot-a [:go]] {:frame :iso/frame-a})
       (rf/dispatch-sync [:iso/boot-b [:go]] {:frame :iso/frame-b})
       ;; Each frame has its own spawn-order vector.
-      (is (= [:iso/child-a#1] (spawn-order/frame-order :iso/frame-a)))
-      (is (= [:iso/child-b#1] (spawn-order/frame-order :iso/frame-b)))
+      (is (= [:iso/child-a#1] (rf.machines.spawn-order/frame-order :iso/frame-a)))
+      (is (= [:iso/child-b#1] (rf.machines.spawn-order/frame-order :iso/frame-b)))
       ;; A spawned actor carries NO per-instance registrar entry; its
       ;; liveness IS its snapshot's presence in the frame's (revertible)
       ;; app-db. Cross-frame isolation is therefore asserted on the
@@ -274,23 +274,23 @@
                          [:rf.runtime/machines :snapshots :iso/child-b#1]))
           "frame B's spawned actor is live (snapshot present) before destroy")
       ;; Spawned actors never register a per-instance handler.
-      (is (nil? (registrar/lookup :event :iso/child-a#1))
+      (is (nil? (rf.registrar/lookup :event :iso/child-a#1))
           "frame A's spawned actor has no per-instance registrar entry")
-      (is (nil? (registrar/lookup :event :iso/child-b#1))
+      (is (nil? (rf.registrar/lookup :event :iso/child-b#1))
           "frame B's spawned actor has no per-instance registrar entry")
       ;; Destroy A; B's actor stays alive (its snapshot survives).
       (rf/destroy-frame! :iso/frame-a)
       (is (= [:iso/child-a#1] @exit-log)
           "only frame A's spawned actor ran its :exit")
-      (is (some? (registrar/lookup :event :iso/child-b)
+      (is (some? (rf.registrar/lookup :event :iso/child-b)
                  )
           "frame B's TYPE machine stays globally registered after A's destroy")
       (is (some? (get-in (:rf.db/runtime (rf/frame-state-value :iso/frame-b))
                          [:rf.runtime/machines :snapshots :iso/child-b#1]))
           "frame B's spawned actor stays alive (snapshot present) after A's destroy")
-      (is (= [] (spawn-order/frame-order :iso/frame-a))
+      (is (= [] (rf.machines.spawn-order/frame-order :iso/frame-a))
           "frame A's spawn-order slot is cleared")
-      (is (= [:iso/child-b#1] (spawn-order/frame-order :iso/frame-b))
+      (is (= [:iso/child-b#1] (rf.machines.spawn-order/frame-order :iso/frame-b))
           "frame B's spawn-order slot is untouched"))))
 
 ;; ---- restore / hydration: spawned snapshots absent from spawn-order ------
@@ -310,7 +310,7 @@
 ;;
 ;; The tests in THIS section model an SSR / preload hydration into a FRESH
 ;; PROCESS: durable snapshots arrive on the wire and the transient atom was
-;; never populated at all. `spawn-order/reset-all!` reproduces exactly that —
+;; never populated at all. `rf.machines.spawn-order/reset-all!` reproduces exactly that —
 ;; an empty cache beside a full runtime-db.
 ;;
 ;; It is NOT a model of an IN-PROCESS `restore-epoch!` / `replace-frame-state!`,
@@ -362,8 +362,8 @@
           "three spawned snapshots are live (each carrying :rf/machine-type) before restore")
       ;; Simulate restore / hydration: the durable snapshots survive, but
       ;; the transient spawn-order atom is wiped (it is NOT serialized).
-      (spawn-order/reset-all!)
-      (is (= [] (spawn-order/frame-order :rs/auth))
+      (rf.machines.spawn-order/reset-all!)
+      (is (= [] (rf.machines.spawn-order/frame-order :rs/auth))
           "spawn-order atom is empty post-restore (the bug's precondition)")
       ;; Destroy the frame.
       (rf/destroy-frame! :rs/auth)
@@ -408,7 +408,7 @@
           "system-id bound before restore")
       ;; Restore: wipe the transient spawn-order; the durable snapshot +
       ;; system-id reverse index survive.
-      (spawn-order/reset-all!)
+      (rf.machines.spawn-order/reset-all!)
       (rf/destroy-frame! :rsi/auth)
       (is (nil? (get-in (:rf.db/runtime (rf/frame-state-value :rsi/auth))
                         [:rf.runtime/machines :system-ids :session/primary]))
@@ -438,13 +438,13 @@
                   (get-in (:rf.db/runtime (rf/frame-state-value :rsg/auth))
                           [:rf.runtime/machines :snapshots :rsg/single])))
           "singleton snapshot carries NO :rf/machine-type (the discriminator)")
-      (spawn-order/reset-all!)
+      (rf.machines.spawn-order/reset-all!)
       (rf/destroy-frame! :rsg/auth)
       ;; The singleton's :exit ran (straggler path runs the exit cascade)...
       (is (= [:rsg/single] @exit-log)
           "singleton :exit cascade ran via the straggler path")
       ;; ...but its TYPE handler stays globally registered (outlives the frame).
-      (is (some? (registrar/lookup :event :rsg/single))
+      (is (some? (rf.registrar/lookup :event :rsg/single))
           "singleton handler stays registered — NOT unregistered by the straggler path"))))
 
 ;; ---- durable spawn-order: the frame-global creation sequence (rf2-1vlyg) ----
@@ -512,8 +512,8 @@
       ;; --- the loss boundary --------------------------------------------
       ;; Model epoch restore / SSR hydration: the durable runtime-db
       ;; survives, the transient process-side atom does not.
-      (spawn-order/reset-all!)
-      (is (= [] (spawn-order/frame-order :probe/auth))
+      (rf.machines.spawn-order/reset-all!)
+      (is (= [] (rf.machines.spawn-order/frame-order :probe/auth))
           "transient spawn-order atom is empty post-restore (the bug's precondition)")
       (is (= [:probe/a#1 :probe/a#2 :probe/b#1]
              (runtime-spawn-order :probe/auth))
@@ -596,7 +596,7 @@
 ;; EVERY install path, including those that fire no hook at all, which is why it
 ;; is enforced where the cache is READ rather than at each install site.
 ;;
-;; These tests drive the loss boundary through `frame/replace-frame-state!` —
+;; These tests drive the loss boundary through `rf.frame/replace-frame-state!` —
 ;; core's ONE frame-state write surface, and the very fn
 ;; `epoch/perform-restore!` calls to install a restored epoch. No test below
 ;; resets a machines internal by hand.
@@ -658,16 +658,16 @@
         (rf/dispatch-sync [:stage/boot [:spawn-b]] {:frame :stage/auth})
         (is (= [:stage/a#1 :stage/b#1] (runtime-spawn-order :stage/auth))
             "b#1 is recorded NEWER than a#1 in the durable order (non-vacuity control)")
-        (is (= [:stage/a#1 :stage/b#1] (spawn-order/frame-order :stage/auth))
+        (is (= [:stage/a#1 :stage/b#1] (rf.machines.spawn-order/frame-order :stage/auth))
             "the transient cache carries both (non-vacuity control)")
         ;; --- the loss boundary: a whole frame-state install through core's
         ;; ONE write surface, the same fn epoch/perform-restore! calls.
-        (frame/replace-frame-state! :stage/auth captured)
+        (rf.frame/replace-frame-state! :stage/auth captured)
         (is (= [:stage/a#1] (runtime-spawn-order :stage/auth))
             "the durable order rewound past b#1")
         (is (nil? (get (runtime-snapshots :stage/auth) :stage/b#1))
             "b#1's snapshot is gone from durable state — the install DISCARDED that actor")
-        (is (= [:stage/a#1 :stage/b#1] (spawn-order/frame-order :stage/auth))
+        (is (= [:stage/a#1 :stage/b#1] (rf.machines.spawn-order/frame-order :stage/auth))
             (str "the transient cache still names the discarded b#1 — no production "
                  "install path clears it. This is the CONDITION under test, not a "
                  "defect the fix papers over by clearing it."))
@@ -694,10 +694,10 @@
         (rf/dispatch-sync [:stage/boot [:spawn-b]] {:frame :stagex/auth})
         (is (some? (get (runtime-snapshots :stagex/auth) :stage/b#1))
             "b#1 is live before the install (non-vacuity control)")
-        (frame/replace-frame-state! :stagex/auth captured)
+        (rf.frame/replace-frame-state! :stagex/auth captured)
         (is (nil? (get (runtime-snapshots :stagex/auth) :stage/b#1))
             "b#1 was discarded by the install")
-        (is (some? (some #{:stage/b#1} (spawn-order/frame-order :stagex/auth)))
+        (is (some? (some #{:stage/b#1} (rf.machines.spawn-order/frame-order :stagex/auth)))
             "the stale cache entry for b#1 survives the install (the condition under test)")
         (reset! exit-log [])
         (let [traces (collect-traces!
@@ -727,19 +727,19 @@
         (is (= [:probe/a#1 :probe/a#2 :probe/b#1] (runtime-spawn-order :probere/auth))
             "the durable order is recorded at capture time (non-vacuity control)")
         ;; Empty the transient cache the ORDINARY way — three explicit
-        ;; destroys, each running `spawn-order/forget!`. No internals reset.
+        ;; destroys, each running `rf.machines.spawn-order/forget!`. No internals reset.
         (rf/dispatch-sync [:probere/boot [:drop-all]] {:frame :probere/auth})
-        (is (= [] (spawn-order/frame-order :probere/auth))
+        (is (= [] (rf.machines.spawn-order/frame-order :probere/auth))
             "the transient cache is empty after the destroys (non-vacuity control)")
         (is (nil? (runtime-spawn-order :probere/auth))
             "and the durable slot is pruned once it empties")
         (reset! exit-log [])
         ;; Reinstall the captured frame-state — the whole-value install
         ;; `restore-epoch!` performs. Only the DURABLE order comes back.
-        (frame/replace-frame-state! :probere/auth captured)
+        (rf.frame/replace-frame-state! :probere/auth captured)
         (is (= [:probe/a#1 :probe/a#2 :probe/b#1] (runtime-spawn-order :probere/auth))
             "the durable order rode the install back in")
-        (is (= [] (spawn-order/frame-order :probere/auth))
+        (is (= [] (rf.machines.spawn-order/frame-order :probere/auth))
             (str "the transient cache is STILL empty — no install path repopulates it, "
                  "so the walk below has nothing but the durable vector to read"))
         (rf/destroy-frame! :probere/auth)

--- a/implementation/machines/test/re_frame/frozen_region_select_test.clj
+++ b/implementation/machines/test/re_frame/frozen_region_select_test.clj
@@ -31,17 +31,17 @@
         selected set / same committed state."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.parallel :as rf.machines.parallel]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 ;; ---- (1) :data write in A is NOT visible to B's same-event guard -----------
 ;;
@@ -280,9 +280,9 @@
   (testing "pure machine-transition is also declaration-order-independent"
     (let [initial-ab {:state {:a :idle :b :idle} :data {}}
           initial-ba {:state {:b :idle :a :idle} :data {}}
-          {snap-ab :snapshot} (parallel/machine-transition
+          {snap-ab :snapshot} (rf.machines.parallel/machine-transition
                                     (order-machine [:a :b]) initial-ab [:go])
-          {snap-ba :snapshot} (parallel/machine-transition
+          {snap-ba :snapshot} (rf.machines.parallel/machine-transition
                                     (order-machine [:b :a]) initial-ba [:go])]
       (is (= {:a :done :b :idle} (:state snap-ab)))
       (is (= {:a :done :b :idle} (:state snap-ba)))
@@ -294,10 +294,10 @@
             frozen pre-event :data in BOTH orders → same committed state
             (rf2-lq5yo3). Pre-fix, a-then-b leaked a's :x=1 into b's guard and
             b fired → the two orders diverged."
-    (let [{snap-ab :snapshot} (parallel/machine-transition
+    (let [{snap-ab :snapshot} (rf.machines.parallel/machine-transition
                                     (data-order-machine [:a :b])
                                     {:state {:a :idle :b :idle} :data {:x 0}} [:go])
-          {snap-ba :snapshot} (parallel/machine-transition
+          {snap-ba :snapshot} (rf.machines.parallel/machine-transition
                                     (data-order-machine [:b :a])
                                     {:state {:b :idle :a :idle} :data {:x 0}} [:go])]
       (is (= {:a :done :b :idle} (:state snap-ab))

--- a/implementation/machines/test/re_frame/grammar_parity_test.clj
+++ b/implementation/machines/test/re_frame/grammar_parity_test.clj
@@ -20,18 +20,18 @@
   the two layers drifting if the grammar evolves.
 
   Both the registration walk (via `rf/reg-machine`) and the runtime
-  resolution (via the pure `machines/machine-transition`) run on the JVM
+  resolution (via the pure `rf.machines/machine-transition`) run on the JVM
   through the plain-atom substrate."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.machines.grammar :as grammar]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.machines.transition :as transition]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.grammar :as rf.machines.grammar]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.machines.transition :as rf.machines.transition]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- registration-error-id
   "Register `machine` and return the thrown `:rf.error/id` discriminator,
@@ -48,37 +48,37 @@
 
 (deftest transition-value-form-closed-set
   (testing "every transition-value form classifies into the closed set"
-    (is (= :nil              (grammar/transition-value-form nil)))
-    (is (= :keyword          (grammar/transition-value-form :authenticated)))
-    (is (= :vec-target       (grammar/transition-value-form [:a :b])))
-    (is (= :vec-target       (grammar/transition-value-form [])))
-    (is (= :candidate-vector (grammar/transition-value-form [{:target :a}
+    (is (= :nil              (rf.machines.grammar/transition-value-form nil)))
+    (is (= :keyword          (rf.machines.grammar/transition-value-form :authenticated)))
+    (is (= :vec-target       (rf.machines.grammar/transition-value-form [:a :b])))
+    (is (= :vec-target       (rf.machines.grammar/transition-value-form [])))
+    (is (= :candidate-vector (rf.machines.grammar/transition-value-form [{:target :a}
                                                              {:target :b}])))
-    (is (= :map              (grammar/transition-value-form {:target :a})))
-    (is (= :other            (grammar/transition-value-form 42)))
-    (is (= :other            (grammar/transition-value-form "soon")))))
+    (is (= :map              (rf.machines.grammar/transition-value-form {:target :a})))
+    (is (= :other            (rf.machines.grammar/transition-value-form 42)))
+    (is (= :other            (rf.machines.grammar/transition-value-form "soon")))))
 
 (deftest candidate-targets-present-marker
   (testing "candidate-targets tags each declared :target with :present?"
-    (is (= [] (grammar/candidate-targets nil))
+    (is (= [] (rf.machines.grammar/candidate-targets nil))
         "nil value (forbidden-transition / internal) declares no target")
     (is (= [{:present? true :target :authed}]
-           (grammar/candidate-targets :authed)))
+           (rf.machines.grammar/candidate-targets :authed)))
     (is (= [{:present? true :target [:a :b]}]
-           (grammar/candidate-targets [:a :b])))
+           (rf.machines.grammar/candidate-targets [:a :b])))
     (is (= [{:present? true :target :x} {:present? false :target nil}]
-           (grammar/candidate-targets [{:target :x} {:action :a}]))
+           (rf.machines.grammar/candidate-targets [{:target :x} {:action :a}]))
         "a vector-of-maps tags each candidate; an action-only map is :target-absent")
     (is (= [{:present? false :target nil}]
-           (grammar/candidate-targets {:action :a}))
+           (rf.machines.grammar/candidate-targets {:action :a}))
         "a single action-only map is an internal transition (:target absent)")))
 
 (deftest node-at-shared-descent
   (testing "node-at resolves an absolute path through a :states scope"
     (let [states {:a {:states {:b {:states {:c {}}}}}}]
-      (is (= {} (grammar/node-at states [:a :b :c])))
-      (is (nil? (grammar/node-at states [:a :missing])))
-      (is (nil? (grammar/node-at states []))
+      (is (= {} (rf.machines.grammar/node-at states [:a :b :c])))
+      (is (nil? (rf.machines.grammar/node-at states [:a :missing])))
+      (is (nil? (rf.machines.grammar/node-at states []))
           "an empty path resolves to nil (the scope root is not a node)"))))
 
 ;; ---- keyword sibling targets ---------------------------------------------
@@ -90,7 +90,7 @@
                        :running {}}}]
       (is (nil? (registration-error-id :kw/ok m))
           "registration accepts the sibling keyword target")
-      (let [{snap :snapshot} (machines/machine-transition
+      (let [{snap :snapshot} (rf.machines/machine-transition
                                    m {:state :idle :data {}} [:go])]
         (is (= :running (:state snap))
             "runtime resolves the SAME keyword to the sibling state"))))
@@ -113,7 +113,7 @@
                                :states  {:leaf {}}}}}]
       (is (nil? (registration-error-id :vec/ok m))
           "registration accepts the absolute vector path")
-      (let [{snap :snapshot} (machines/machine-transition
+      (let [{snap :snapshot} (rf.machines/machine-transition
                                    m {:state [:outer :inner] :data {}} [:deep])]
         (is (= [:other :leaf] (:state snap))
             "runtime resolves the SAME vector to the absolute leaf"))))
@@ -139,7 +139,7 @@
                                 :on    {:ping {:target :same-state}}}}}]
       (is (nil? (registration-error-id :same/ok m))
           "registration accepts the :same-state sentinel")
-      (let [{snap :snapshot} (machines/machine-transition
+      (let [{snap :snapshot} (rf.machines/machine-transition
                                    m {:state :active :data {}} [:ping])]
         (is (= :active (:state snap))
             "runtime keeps the configuration (external self-transition)")))))
@@ -161,15 +161,15 @@
       ;; recorded leaf (:b), proving the SAME pseudo-state both layers
       ;; agree is targetable resolves to a real configuration.
       (let [s0 {:state [:region :a] :data {}}
-            {s1 :snapshot} (machines/machine-transition m s0 [:next])]
+            {s1 :snapshot} (rf.machines/machine-transition m s0 [:next])]
         (is (= [:region :b] (:state s1)) "advanced to :region :b"))))
 
   (testing "the shared history-node? predicate recognises the pseudo-state node"
     (let [states {:region {:states {:hist {:type :history}
                                     :a    {}}}}]
-      (is (grammar/history-node? (grammar/node-at states [:region :hist]))
+      (is (rf.machines.grammar/history-node? (rf.machines.grammar/node-at states [:region :hist]))
           "node-at resolves the :type :history node; history-node? flags it")
-      (is (not (grammar/history-node? (grammar/node-at states [:region :a])))
+      (is (not (rf.machines.grammar/history-node? (rf.machines.grammar/node-at states [:region :a])))
           "a real state node is not a history pseudo-state"))))
 
 (deftest history-node-not-occupiable
@@ -183,9 +183,9 @@
       ;; uses to decide reset) returns false, using the SAME grammar
       ;; history-node? the registration validator uses to accept it as a
       ;; target.
-      (is (false? (transition/state-occupiable? m [:region :hist]))
+      (is (false? (rf.machines.transition/state-occupiable? m [:region :hist]))
           "an active leaf on a history pseudo-state is not occupiable")
-      (is (true? (transition/state-occupiable? m [:region :a]))
+      (is (true? (rf.machines.transition/state-occupiable? m [:region :a]))
           "a real leaf is occupiable"))))
 
 ;; ---- malformed target shapes ---------------------------------------------

--- a/implementation/machines/test/re_frame/guard_action_traces_test.clj
+++ b/implementation/machines/test/re_frame/guard_action_traces_test.clj
@@ -33,18 +33,18 @@
       `:outcome :rf.error/action-threw` AND carries the exception"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- record-traces!
   "Register a trace listener for the duration of `body-fn`, returning
   the captured trace vec. Routed through the shared
-  `mtest/with-trace-capture` — guaranteed unregister in a `finally`."
+  `rf.machines.test-support/with-trace-capture` — guaranteed unregister in a `finally`."
   [body-fn]
-  (mtest/with-trace-capture seen
+  (rf.machines.test-support/with-trace-capture seen
     (body-fn)
     @seen))
 

--- a/implementation/machines/test/re_frame/handler_source_egress_strip_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/handler_source_egress_strip_cljs_test.cljc
@@ -31,14 +31,14 @@
    ;; resolves through the Spec-005 implementation rather than throwing
    ;; `:rf.error/machines-artefact-missing` (the hooks install on ns load).
    [re-frame.machines]
-   [re-frame.machines.test-support :as mtest]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter})))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter})))
 
 ;; The three source-as-data keys the boundary must never carry. `:source-code`
 ;; / `:source-coords` are the machine spec's INTERNAL co-location slots;
@@ -114,7 +114,7 @@
           "the snapshot carries the seeded app-db value")
       (is (contains? state :rf.db/runtime)
           "the snapshot carries the runtime-db partition")
-      (is (some? (mtest/snapshot :tlf4if/probed))
+      (is (some? (rf.machines.test-support/snapshot :tlf4if/probed))
           "the started machine's snapshot is live in runtime-db")
       ;; The invariant: no source-as-data key anywhere in the egress snapshot —
       ;; neither the event's `:rf.handler/source` nor the machine spec's

--- a/implementation/machines/test/re_frame/initial_entry_test.clj
+++ b/implementation/machines/test/re_frame/initial_entry_test.clj
@@ -28,17 +28,17 @@
       shallowest-first (per Spec 005 §Initial cascading)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.fx :as rf.fx]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 ;; ---- (1) singleton-machine initial :entry firing -------------------------
 
@@ -208,8 +208,8 @@
       ;; Hook the :rf.machine/spawn fx so we can observe if it fires.
       ;; Per Spec 005 §spawn-fx the runtime emits this when a :spawn
       ;; slot is declared on the entering state.
-      (let [orig (registrar/lookup :fx :rf.machine/spawn)]
-        (fx/reg-fx :rf.machine/spawn
+      (let [orig (rf.registrar/lookup :fx :rf.machine/spawn)]
+        (rf.fx/reg-fx :rf.machine/spawn
                    {:platforms #{:client :server}}
                    (fn [_ _]
                      (reset! spawn-fired? true)))
@@ -236,7 +236,7 @@
               "the snapshot was not committed; no machine record exists"))
         ;; Restore.
         (when orig
-          (fx/reg-fx :rf.machine/spawn orig (fn [_ _] nil)))))))
+          (rf.fx/reg-fx :rf.machine/spawn orig (fn [_ _] nil)))))))
 
 (deftest initial-entry-throw-in-compound-cascade
   (testing "with a compound :initial cascade, a throw at the inner :entry

--- a/implementation/machines/test/re_frame/initial_snapshot_unification_test.clj
+++ b/implementation/machines/test/re_frame/initial_snapshot_unification_test.clj
@@ -17,27 +17,27 @@
   (unit-level) and the end-to-end spawn path (integration-level)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.machines :as machines]
-            [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.parallel :as rf.machines.parallel]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 ;; This ns keeps a bespoke reset-runtime fixture (clear-all! + frame reset +
 ;; machines :reload + reset-timers!) — it exercises registration-time
 ;; snapshot unification, so it deliberately reloads the machines ns rather
 ;; than reusing the shared make-reset-runtime-fixture.
 (defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (rf/init! plain-atom/adapter)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (rf/init! rf.substrate.plain-atom/adapter)
   ;; `init!` does not synthesise `:rf/default`, and machine fxs require a
   ;; carried frame stamp. Register `:rf/default` explicitly and pin it as
   ;; the established scope for the body.
-  (frame/ensure-default-frame!)
+  (rf.frame/ensure-default-frame!)
   (require 're-frame.machines :reload)
-  (machines/reset-timers!)
+  (rf.machines/reset-timers!)
   (rf/with-frame :rf/default
     (test-fn)))
 
@@ -45,9 +45,9 @@
 
 ;; snapshot lookup via the shared machines test-support — no hardcoded
 ;; `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
-;; ---- (1) `parallel/build-initial-snapshot` unit contract -------------------
+;; ---- (1) `rf.machines.parallel/build-initial-snapshot` unit contract -------------------
 ;;
 ;; Pin the helper's shape directly. Both `:rf/spawn-counter` and `:meta`
 ;; (when declared) are always present on the synthesised snapshot;
@@ -59,7 +59,7 @@
                 :data    {:counter 0}
                 :meta    {:schema-version 7}
                 :states  {:idle {}}}
-          snap (parallel/build-initial-snapshot spec {:bootstrap-pending? false})]
+          snap (rf.machines.parallel/build-initial-snapshot spec {:bootstrap-pending? false})]
       (is (contains? snap :rf/spawn-counter)
           ":rf/spawn-counter MUST always be present on live snapshots (rf2-gr8q)")
       (is (= {} (:rf/spawn-counter snap))
@@ -73,7 +73,7 @@
                 :data    {:counter 0}
                 :meta    {:schema-version 7}
                 :states  {:idle {}}}
-          snap (parallel/build-initial-snapshot spec {:bootstrap-pending? true})]
+          snap (rf.machines.parallel/build-initial-snapshot spec {:bootstrap-pending? true})]
       (is (contains? snap :rf/spawn-counter)
           "the spawn-path snapshot ALSO carries :rf/spawn-counter — pre-rf2-fgqs4 this slot was missing")
       (is (= {} (:rf/spawn-counter snap)))
@@ -83,7 +83,7 @@
           "the spawn path stamps the bootstrap marker so the actor's first dispatch fires the :entry cascade (rf2-0z73)")))
   (testing ":meta absent from spec → :meta absent from snapshot"
     (let [spec {:initial :idle :data {} :states {:idle {}}}
-          snap (parallel/build-initial-snapshot spec {:bootstrap-pending? true})]
+          snap (rf.machines.parallel/build-initial-snapshot spec {:bootstrap-pending? true})]
       (is (not (contains? snap :meta))
           "no :meta in spec — the helper does not invent one"))))
 

--- a/implementation/machines/test/re_frame/internal_events_test.clj
+++ b/implementation/machines/test/re_frame/internal_events_test.clj
@@ -21,37 +21,37 @@
             ;; `:machines/reg-machine`) are registered — `rf/reg-machine`
             ;; routes through them.
             [re-frame.machines]
-            [re-frame.machines.internal-events :as internal-events]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.machines.internal-events :as rf.machines.internal-events]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
             [re-frame.subs]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 ;; ---- declaration accessor + boundary predicate ----------------------------
 
 (deftest internal-events-accessor
   (testing "internal-events returns the declared SET (or nil when absent)"
-    (is (= #{:tick} (internal-events/internal-events {:internal-events #{:tick}})))
-    (is (nil? (internal-events/internal-events {:initial :a})))))
+    (is (= #{:tick} (rf.machines.internal-events/internal-events {:internal-events #{:tick}})))
+    (is (nil? (rf.machines.internal-events/internal-events {:initial :a})))))
 
 (deftest boundary-predicate-recognises-declared-internal-events
   (testing "internal-event-external? is true ONLY for a declared internal event"
     (let [m {:internal-events #{:tick :retry/internal}}]
-      (is (true?  (internal-events/internal-event-external? m [:tick])))
-      (is (true?  (internal-events/internal-event-external? m [:retry/internal])))
-      (is (false? (internal-events/internal-event-external? m [:public-event])))
-      (is (true?  (internal-events/internal-event-external? m [:tick :arg]))
+      (is (true?  (rf.machines.internal-events/internal-event-external? m [:tick])))
+      (is (true?  (rf.machines.internal-events/internal-event-external? m [:retry/internal])))
+      (is (false? (rf.machines.internal-events/internal-event-external? m [:public-event])))
+      (is (true?  (rf.machines.internal-events/internal-event-external? m [:tick :arg]))
           "the first element is the event id — a declared internal id is rejected even with args")
-      (is (false? (internal-events/internal-event-external? m [:public-event :arg]))
+      (is (false? (rf.machines.internal-events/internal-event-external? m [:public-event :arg]))
           "a non-declared id is public even with args")))
   (testing "internal-event-external? is nil-safe and false for a no-internal-events machine"
-    (is (false? (internal-events/internal-event-external? {:initial :a} [:tick])))
-    (is (false? (internal-events/internal-event-external? {:internal-events #{:tick}} nil)))
-    (is (false? (internal-events/internal-event-external? {:internal-events #{:tick}} [])))))
+    (is (false? (rf.machines.internal-events/internal-event-external? {:initial :a} [:tick])))
+    (is (false? (rf.machines.internal-events/internal-event-external? {:internal-events #{:tick}} nil)))
+    (is (false? (rf.machines.internal-events/internal-event-external? {:internal-events #{:tick}} [])))))
 
 ;; ---- registration-time validation (fail-loud) -----------------------------
 
@@ -130,7 +130,7 @@
       ;; with the private event from outside.
       (rf/dispatch-sync [:iet/reject [:rf.machine/start]])
       (is (= :waiting (:state (snapshot :iet/reject))) "booted at :waiting")
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         (rf/dispatch-sync [:iet/reject [:tick]])
         (is (= :waiting (:state (snapshot :iet/reject)))
             "the external :tick was REJECTED — the machine stayed at :waiting (no transition)")

--- a/implementation/machines/test/re_frame/join_attempt_effect_path_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_attempt_effect_path_cljs_test.cljc
@@ -67,30 +67,30 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
-   [re-frame.interop :as interop]
-   [re-frame.late-bind :as late-bind]
+   [re-frame.fx :as rf.fx]
+   [re-frame.interop :as rf.interop]
+   [re-frame.late-bind :as rf.late-bind]
    [re-frame.machines]
-   [re-frame.machines.test-support :as mtest]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
+  rf.machines.test-support/trace-capture-fixture)
 
 ;; ---------------------------------------------------------------------------
 ;; helpers (mirroring the sibling join transport tests)
 ;; ---------------------------------------------------------------------------
 
 (defn- join-state [parent-id]
-  (get-in (mtest/runtime-db) [:rf.runtime/machines :spawned parent-id [:racing]]))
+  (get-in (rf.machines.test-support/runtime-db) [:rf.runtime/machines :spawned parent-id [:racing]]))
 
 (defn- stale-reasons []
   (mapv (comp :rf.reply/stale-reason :tags)
-        (mtest/events-of :rf.machine.spawn-all/stale-completion)))
+        (rf.machines.test-support/events-of :rf.machine.spawn-all/stale-completion)))
 
 (defn- mk-child
   "A dispatching child: on `:go` transitions to a plain terminal and dispatches
@@ -150,12 +150,12 @@
   completion's re-dispatch is observed deterministically on both platforms.
   Restores the real hook in a finally."
   [sink body-fn]
-  (let [real (late-bind/get-fn :router/dispatch!)]
+  (let [real (rf.late-bind/get-fn :router/dispatch!)]
     (try
-      (late-bind/set-fn! :router/dispatch! (fn [event opts] (swap! sink conj [event opts])))
+      (rf.late-bind/set-fn! :router/dispatch! (fn [event opts] (swap! sink conj [event opts])))
       (body-fn)
       (finally
-        (late-bind/set-fn! :router/dispatch! real)))))
+        (rf.late-bind/set-fn! :router/dispatch! real)))))
 
 (defn- completion-opts
   "The opts of the FIRST recorded re-dispatch whose event is the completion
@@ -339,7 +339,7 @@
           a          (get-in j [:children :a])
           mismatched {:parent-id :jae.ha/rp :invoke-id [:racing]
                       :child-id  :a :spawned-id a :attempt -999}]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (rf/dispatch-sync [:jae.ha/forge [:jae.ha/rp [:child/done :a]] mismatched])
       (is (= #{} (:done (join-state :jae.ha/rp)))
           "the mismatched hand-authored coordinate folded nothing (fail-closed)")
@@ -365,7 +365,7 @@
           a     (get-in j [:children :a])
           exact {:parent-id :jae.hx/rp :invoke-id [:racing]
                  :child-id  :a :spawned-id a :attempt (:rf/attempt j)}]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (rf/dispatch-sync [:jae.hx/emit [:jae.hx/rp [:child/done :a]] exact])
       (is (= #{:a} (:done (join-state :jae.hx/rp)))
           "the EXACT-CURRENT hand-authored coordinate folded :a — accepted regardless of source")
@@ -395,8 +395,8 @@
         (fn []
           (with-dispatch-stub sink
             (fn []
-              (with-redefs [interop/set-timeout!   (fn [f _ms] (reset! captured-cb f) ::handle)
-                            interop/clear-timeout! (fn [_] nil)]
+              (with-redefs [rf.interop/set-timeout!   (fn [f _ms] (reset! captured-cb f) ::handle)
+                            rf.interop/clear-timeout! (fn [_] nil)]
                 (rf/dispatch-sync [a [:go]] {:fx-overrides {:dispatch-later :jae.dl/nonexistent}})
                 (is (= #{} (:done (join-state :jae.dl/rp)))
                     "the zero-delay completion deferred (did not fold synchronously)")
@@ -438,10 +438,10 @@
       ;; Redirectable TARGET — was WRONGLY `:protected-rejection` under the
       ;; conflated set; now the redirect reaches the real registered handler.
       (is (= {:disposition :applied-redirect :target id}
-             (fx/classify-fx-override {:my/custom id} :my/custom))
+             (rf.fx/classify-fx-override {:my/custom id} :my/custom))
           (str id " is a REDIRECTABLE target — a custom effect reaches the real handler"))
       ;; Non-overridable SOURCE — a direct override is still stripped loudly.
-      (is (= {} (fx/strip-rejected-overrides {id (fn [_ _] :stub)} :rf/default [:some/event]))
+      (is (= {} (rf.fx/strip-rejected-overrides {id (fn [_ _] :stub)} :rf/default [:some/event]))
           (str id " is a NON-OVERRIDABLE source — a direct override is stripped"))))
 
   (testing "rf2-1w4af — vice-versa: `:rf.machine/join-dispatch` retains BOTH
@@ -451,9 +451,9 @@
             redirect-target case above."
     ;; Non-redirectable TARGET — `{:dispatch :rf.machine/join-dispatch}` refused.
     (is (= {:disposition :protected-rejection :target :rf.machine/join-dispatch}
-           (fx/classify-fx-override {:dispatch :rf.machine/join-dispatch} :dispatch))
+           (rf.fx/classify-fx-override {:dispatch :rf.machine/join-dispatch} :dispatch))
         ":rf.machine/join-dispatch stays a NON-REDIRECTABLE target (no recursion escape)")
     ;; Non-overridable SOURCE — a direct override is stripped loudly.
-    (is (= {} (fx/strip-rejected-overrides
+    (is (= {} (rf.fx/strip-rejected-overrides
                 {:rf.machine/join-dispatch (fn [_ _] :stub)} :rf/default [:some/event]))
         ":rf.machine/join-dispatch stays a NON-OVERRIDABLE source")))

--- a/implementation/machines/test/re_frame/join_child_terminal_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_child_terminal_cljs_test.cljc
@@ -31,15 +31,15 @@
    ;; load the machines artefact so its fx handlers + late-bind hooks are
    ;; installed when this ns runs in isolation.
    [re-frame.machines]
-   [re-frame.machines.test-support :as mtest]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
+  rf.machines.test-support/trace-capture-fixture)
 
 (def ^:private terminal-work-statuses
   "The closed TERMINAL work-status set — a child attempt closes on exactly
@@ -56,16 +56,16 @@
         (comp (map :tags)
               (filter #(= spawned-id (second (:rf.reply/work-id %))))
               (keep :rf.reply/work-status))
-        (or (mtest/captured-events) [])))
+        (or (rf.machines.test-support/captured-events) [])))
 
 (defn- terminals-for [spawned-id]
   (filterv terminal-work-statuses (work-statuses-for spawned-id)))
 
 (defn- child-completed-traces []
-  (mtest/events-of :rf.machine.spawn-all/child-completed))
+  (rf.machines.test-support/events-of :rf.machine.spawn-all/child-completed))
 
 (defn- join-state [parent-id]
-  (get-in (mtest/runtime-db)
+  (get-in (rf.machines.test-support/runtime-db)
           [:rf.runtime/machines :spawned parent-id [:racing]]))
 
 (defn- mk-child [parent-id]
@@ -186,7 +186,7 @@
           "decisive :any child closes exactly one :completed")
       (is (empty? (child-completed-traces))
           "no fold-time trace for a decisive fold"))
-    (mtest/reset-captured!)
+    (rf.machines.test-support/reset-captured!)
     ;; :on-any-failed failure — the first failure is decisive.
     (let [j (reg-join-parent! :jct/p4 :jct/p4a :jct/p4b
                               {:join :all :on-all-complete [:all/done]
@@ -239,7 +239,7 @@
       (is (= [:completed] (terminals-for a))
           "the post-resolution straggler stayed :stale — still one terminal")
       (is (some #(= :stale (:rf.reply/status (:tags %)))
-                (mtest/events-of :rf.machine.spawn-all/late-completion))
+                (rf.machines.test-support/events-of :rf.machine.spawn-all/late-completion))
           "the straggler was classified through the stale late-completion path"))))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/machines/test/re_frame/join_completion_fence_test.clj
+++ b/implementation/machines/test/re_frame/join_completion_fence_test.clj
@@ -35,17 +35,17 @@
   `override-applies?` had) makes the churn test flip to `:attempt-unverified`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.interop :as interop]
+            [re-frame.fx :as rf.fx]
+            [re-frame.interop :as rf.interop]
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter})
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter})
+  rf.machines.test-support/trace-capture-fixture)
 
 ;; ---------------------------------------------------------------------------
 ;; helpers (mirroring the sibling join transport tests)
@@ -54,12 +54,12 @@
 (defn- join-state
   ([parent-id] (join-state :rf/default parent-id))
   ([frame-id parent-id]
-   (get-in (mtest/runtime-db frame-id)
+   (get-in (rf.machines.test-support/runtime-db frame-id)
            [:rf.runtime/machines :spawned parent-id [:racing]])))
 
 (defn- stale-reasons []
   (mapv (comp :rf.reply/stale-reason :tags)
-        (mtest/events-of :rf.machine.spawn-all/stale-completion)))
+        (rf.machines.test-support/events-of :rf.machine.spawn-all/stale-completion)))
 
 (defn- mk-child
   "A dispatching child: on `:go` transitions to a plain terminal and dispatches
@@ -108,12 +108,12 @@
   captures each `[event opts]` into `sink` WITHOUT draining. Restores the real
   hook in a finally."
   [sink body-fn]
-  (let [real (late-bind/get-fn :router/dispatch!)]
+  (let [real (rf.late-bind/get-fn :router/dispatch!)]
     (try
-      (late-bind/set-fn! :router/dispatch! (fn [event opts] (swap! sink conj [event opts])))
+      (rf.late-bind/set-fn! :router/dispatch! (fn [event opts] (swap! sink conj [event opts])))
       (body-fn)
       (finally
-        (late-bind/set-fn! :router/dispatch! real)))))
+        (rf.late-bind/set-fn! :router/dispatch! real)))))
 
 (defn- completion-dispatched?
   "True iff the completion carrier `[parent-id [:child/done child-id]]` was
@@ -186,7 +186,7 @@
             (and none leaks onto a recreated same-id B). Pre-fix the unconditional
             `child-dispatch!` armed `[frame-id tid]` AFTER destroy — a
             fires-dead-on-arrival timer."
-    (fx/reset-dispatch-later-timers!)
+    (rf.fx/reset-dispatch-later-timers!)
     (rf/make-frame {:id :fence/pos :doc "rf2-5g6qq positive-delay destroy frame"})
     (rf/reg-machine :fence.pos/ca (mk-child-delayed :fence.pos/rp 600000))
     (rf/reg-machine :fence.pos/cb (mk-child-delayed :fence.pos/rp 600000))
@@ -207,7 +207,7 @@
       (rf/make-frame {:id :fence/pos :doc "rf2-5g6qq successor B"})
       (is (zero? (count (timers-for-frame :fence/pos)))
           "same-id successor B carries no timer leaked from A's transport"))
-    (fx/reset-dispatch-later-timers!)))
+    (rf.fx/reset-dispatch-later-timers!)))
 
 (deftest zero-delay-completion-fallthrough-listener-destroy-arms-no-timer
   (testing "rf2-5g6qq — the zero-ms boundary: a `:dispatch-later {:ms 0}`
@@ -215,10 +215,10 @@
             too rides the timer reservation the exact-owner recheck now guards. The
             host clock is captured (never fired), so the observable is whether the
             transport armed a timer AT ALL: with the fallthrough listener
-            destroying A during the emit, `interop/set-timeout!` is NEVER reached.
+            destroying A during the emit, `rf.interop/set-timeout!` is NEVER reached.
             Pre-fix the unconditional transport armed it — a dead-on-arrival ms-0
             re-dispatch into the gone frame."
-    (fx/reset-dispatch-later-timers!)
+    (rf.fx/reset-dispatch-later-timers!)
     (rf/make-frame {:id :fence/zero :doc "rf2-5g6qq zero-delay destroy frame"})
     (rf/reg-machine :fence.zero/ca (mk-child-delayed :fence.zero/rp 0))
     (rf/reg-machine :fence.zero/cb (mk-child-delayed :fence.zero/rp 0))
@@ -227,8 +227,8 @@
     (let [a     (get-in (join-state :fence/zero :fence.zero/rp) [:children :a])
           errs  (atom [])
           armed (atom [])]
-      (with-redefs [interop/set-timeout!   (fn [f _ms] (swap! armed conj f) ::handle)
-                    interop/clear-timeout! (fn [_] nil)]
+      (with-redefs [rf.interop/set-timeout!   (fn [f _ms] (swap! armed conj f) ::handle)
+                    rf.interop/clear-timeout! (fn [_] nil)]
         (with-destroying-error-listener errs :fence/zero
           (fn []
             (rf/dispatch-sync [a [:go]]
@@ -238,7 +238,7 @@
           "the fallthrough diagnostic fired (the destroy trigger)")
       (is (empty? @armed)
           "no :ms 0 host timer was armed after the listener destroyed A"))
-    (fx/reset-dispatch-later-timers!)))
+    (rf.fx/reset-dispatch-later-timers!)))
 
 ;; ---------------------------------------------------------------------------
 ;; (B) CHURN — a register/unregister between the single classification and its
@@ -264,13 +264,13 @@
     (let [a     (get-in (join-state :churn/rp) [:children :a])
           errs  (atom [])
           calls (atom 0)
-          real  registrar/lookup]
+          real  rf.registrar/lookup]
       (rf/register-listener! :errors ::churn (fn [r] (swap! errs conj (:error r))))
       (try
         ;; The target is REGISTERED at the single classification (lookup #1) and
         ;; UNREGISTERED for every later read (lookup #2, the execution meta) —
         ;; the exact preflight→execution churn window.
-        (with-redefs [registrar/lookup
+        (with-redefs [rf.registrar/lookup
                       (fn [kind id]
                         (if (and (= kind :fx) (= id :churn/target))
                           (when (= 1 (swap! calls inc)) (real kind id))

--- a/implementation/machines/test/re_frame/join_dispatch_override_intercept_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_dispatch_override_intercept_cljs_test.cljc
@@ -28,18 +28,18 @@
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
    [re-frame.machines]
-   [re-frame.machines.test-support :as mtest]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
+  rf.machines.test-support/trace-capture-fixture)
 
 (defn- join-state [parent-id]
-  (get-in (mtest/runtime-db) [:rf.runtime/machines :spawned parent-id [:racing]]))
+  (get-in (rf.machines.test-support/runtime-db) [:rf.runtime/machines :spawned parent-id [:racing]]))
 
 (defn- mk-child
   "A dispatching child: on `:go` transitions to a terminal and dispatches its
@@ -152,14 +152,14 @@
         (rf/reg-machine cb (mk-child-delayed rp ms))
         (reg-parent! rp ca cb)
         (rf/dispatch-sync [rp [:start]])
-        (let [a (get-in (get-in (mtest/runtime-db)
+        (let [a (get-in (get-in (rf.machines.test-support/runtime-db)
                                 [:rf.runtime/machines :spawned rp [:racing]])
                         [:children :a])]
           (rf/dispatch-sync [a [:go]]
                             {:fx-overrides {:dispatch-later (fn [_ctx args] (swap! captured conj args))}})
           (is (= [{:ms ms :event [rp [:child/done :a]]}] @captured)
               (str ":dispatch-later completion captured with the canonical delayed payload (ms=" ms ")"))
-          (is (= #{} (:done (get-in (mtest/runtime-db)
+          (is (= #{} (:done (get-in (rf.machines.test-support/runtime-db)
                                     [:rf.runtime/machines :spawned rp [:racing]])))
               (str "the parent join folded nothing under the :dispatch-later override (ms=" ms ")")))))))
 

--- a/implementation/machines/test/re_frame/join_exact_attempt_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_exact_attempt_cljs_test.cljc
@@ -39,32 +39,32 @@
    ;; load the machines artefact so its fx handlers + late-bind hooks are
    ;; installed when this ns runs in isolation.
    [re-frame.machines]
-   [re-frame.machines.test-support :as mtest]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
+  rf.machines.test-support/trace-capture-fixture)
 
 (defn- join-state [parent-id]
-  (get-in (mtest/runtime-db)
+  (get-in (rf.machines.test-support/runtime-db)
           [:rf.runtime/machines :spawned parent-id [:racing]]))
 
 (defn- stale-completions []
-  (mtest/events-of :rf.machine.spawn-all/stale-completion))
+  (rf.machines.test-support/events-of :rf.machine.spawn-all/stale-completion))
 
 (defn- stale-reasons []
   (mapv (comp :rf.reply/stale-reason :tags) (stale-completions)))
 
 (defn- destroyed-for [actor-id]
   (filterv #(= actor-id (:actor-id (:tags %)))
-           (mtest/events-of :rf.machine/destroyed)))
+           (rf.machines.test-support/events-of :rf.machine/destroyed)))
 
 (defn- bad-arg-causes []
-  (mapv (comp :cause :tags) (mtest/events-of :rf.error/machine-destroy-bad-arg)))
+  (mapv (comp :cause :tags) (rf.machines.test-support/events-of :rf.error/machine-destroy-bad-arg)))
 
 (defn- mk-child
   "A dispatching child: on `:go` / `:fail` it transitions to a PLAIN
@@ -156,7 +156,7 @@
                  :attempt    (:rf/attempt j)}]
       ;; (1) exact-current coordinate on the recordable cofx — ACCEPTED + folds,
       ;;     from deliberate app authoring.
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (rf/dispatch-sync [:jea/meta1 [:child/done :a]]
                         {:rf.cofx {:rf.machine/join-attempt exact}})
       (is (= #{:a} (:done (join-state :jea/meta1)))
@@ -168,7 +168,7 @@
       (let [j2 (join-state :jea/meta2)
             a2 (get-in j2 [:children :a])
             exact2 (assoc exact :parent-id :jea/meta2 :spawned-id a2 :attempt (:rf/attempt j2))]
-        (mtest/reset-captured!)
+        (rf.machines.test-support/reset-captured!)
         (rf/dispatch-sync [:jea/meta2 (with-meta [:child/done :a] {:rf/join-attempt exact2})])
         (is (= #{} (:done (join-state :jea/meta2)))
             "the metadata-borne exact-current tuple folded nothing (metadata slot not read)")
@@ -199,7 +199,7 @@
             a2     (get-in j2 [:children :a])]
         (is (some? token2) "attempt 2 minted its own token")
         (is (not= token1 token2) "per-attempt tokens are distinct")
-        (mtest/reset-captured!)
+        (rf.machines.test-support/reset-captured!)
         ;; The stale straggler: attempt 1's exact carrier.
         (dispatch-forged! :jea/p1 [:child/done :a]
                           {:parent-id  :jea/p1
@@ -213,7 +213,7 @@
           (is (false? (:resolved? j2')) "the successor join did not resolve"))
         (is (= [:rf.machine.spawn-all/attempt-superseded] (stale-reasons))
             "exactly one stale-completion with :attempt-superseded evidence")
-        (is (some? (mtest/snapshot a2)) "current child :a (A2) is untouched")
+        (is (some? (rf.machines.test-support/snapshot a2)) "current child :a (A2) is untouched")
         (is (empty? (destroyed-for a2)) "A2 was never reaped or destroyed")))))
 
 (deftest old-token-with-current-actor-id-is-superseded
@@ -227,7 +227,7 @@
       (rf/dispatch-sync [:jea/p2 [:start]])
       (let [j2 (join-state :jea/p2)
             a2 (get-in j2 [:children :a])]
-        (mtest/reset-captured!)
+        (rf.machines.test-support/reset-captured!)
         (dispatch-forged! :jea/p2 [:child/done :a]
                           {:parent-id  :jea/p2
                            :invoke-id  [:racing]
@@ -247,7 +247,7 @@
             through the member child's boundary, so no runtime stamp) is
             classified :attempt-unverified and folds nothing"
     (reg-join-parent! :jea/p3 :jea/p3a :jea/p3b)
-    (mtest/reset-captured!)
+    (rf.machines.test-support/reset-captured!)
     (dispatch-forged! :jea/p3 [:child/done :a] nil)
     (is (= #{} (:done (join-state :jea/p3))) "no fold")
     (is (false? (:resolved? (join-state :jea/p3))) "no resolution")
@@ -259,7 +259,7 @@
             actor (sibling :b's id, current token) fails the exact
             actor-identity clause"
     (let [j (reg-join-parent! :jea/p4 :jea/p4a :jea/p4b)]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (dispatch-forged! :jea/p4 [:child/done :a]
                         {:parent-id  :jea/p4
                          :invoke-id  [:racing]
@@ -274,7 +274,7 @@
             minted for child :a (correct actor A, correct token) fails the
             logical-child-id clause"
     (let [j (reg-join-parent! :jea/p5 :jea/p5a :jea/p5b)]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (dispatch-forged! :jea/p5 [:child/done :b]
                         {:parent-id  :jea/p5
                          :invoke-id  [:racing]
@@ -288,7 +288,7 @@
   (testing "rf2-nvxehu — a carrier stamped for a DIFFERENT invoke path fails
             the parent/invoke identity clause"
     (let [j (reg-join-parent! :jea/p6 :jea/p6a :jea/p6b)]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (dispatch-forged! :jea/p6 [:child/done :a]
                         {:parent-id  :jea/p6
                          :invoke-id  [:other-invoke]           ;; WRONG invoke
@@ -313,7 +313,7 @@
       ;; Legit fold of :a (non-decisive in a 2-child :all).
       (rf/dispatch-sync [a [:go]])
       (is (= #{:a} (:done (join-state :jea/p7))) ":a folded")
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       ;; Exact duplicate: an exact-current coordinate for the CURRENT attempt.
       (dispatch-forged! :jea/p7 [:child/done :a]
                         {:parent-id  :jea/p7
@@ -354,20 +354,20 @@
       (rf/dispatch-sync [a [:go]])
       (is (= #{:a} (:done (join-state :jea/p8))))
       (is (false? (:resolved? (join-state :jea/p8))))
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       ;; The early reap — refused ahead of the :resolved? latch.
       (rf/dispatch-sync [::forge-reap :jea/p8 [:racing] :a])
       (is (= [:unresolved-join] (bad-arg-causes))
           "refused with the distinct :unresolved-join cause")
-      (is (some? (mtest/snapshot a)) "the folded child stays live — no teardown")
+      (is (some? (rf.machines.test-support/snapshot a)) "the folded child stays live — no teardown")
       (is (empty? (destroyed-for a)) "no destroyed trace for the refused reap")
       ;; Genuine resolution: :b completes, the join resolves, and the
       ;; resolution cascade reaps BOTH completed children with the
       ;; non-cancellation reason.
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (rf/dispatch-sync [b [:go]])
       (is (true? (:resolved? (join-state :jea/p8))))
-      (is (nil? (mtest/snapshot a)) "post-resolution, :a is reaped")
+      (is (nil? (rf.machines.test-support/snapshot a)) "post-resolution, :a is reaped")
       (is (= [:rf.machine/join-reaped]
              (mapv (comp :reason :tags) (destroyed-for a)))
           "exactly one destroyed trace for :a — the genuine post-resolution reap"))))
@@ -407,10 +407,10 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- late-completions []
-  (mtest/events-of :rf.machine.spawn-all/late-completion))
+  (rf.machines.test-support/events-of :rf.machine.spawn-all/late-completion))
 
 (defn- bad-child-errors []
-  (mtest/events-of :rf.error/machine-spawn-all-bad-child-id))
+  (rf.machines.test-support/events-of :rf.error/machine-spawn-all-bad-child-id))
 
 (defn- resolve-all-join!
   "Resolve a fresh `reg-join-parent!` `:all` join by completing BOTH children
@@ -444,7 +444,7 @@
             a2 (get-in j2 [:children :a])]
         (is (true? (:resolved? j2)) "attempt B resolved")
         (is (not= a1 a2) "attempt B respawned :a as a fresh instance")
-        (mtest/reset-captured!)
+        (rf.machines.test-support/reset-captured!)
         ;; Attempt A's exact carrier drains AFTER B resolved.
         (dispatch-forged! :jea/pr1 [:child/done :a]
                           {:parent-id  :jea/pr1
@@ -479,7 +479,7 @@
     (let [j (resolve-all-join! :jea/pr2)
           a (get-in j [:children :a])]
       (is (true? (:resolved? j)))
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (dispatch-forged! :jea/pr2 [:child/done :a]
                         {:parent-id  :jea/pr2
                          :invoke-id  [:racing]
@@ -502,7 +502,7 @@
             `:resolved?` branch attributed it before checking the exact-attempt coordinate."
     (reg-join-parent! :jea/pr3 :jea/pr3a :jea/pr3b)
     (resolve-all-join! :jea/pr3)
-    (mtest/reset-captured!)
+    (rf.machines.test-support/reset-captured!)
     (dispatch-forged! :jea/pr3 [:child/done :a] nil)
     (is (empty? (late-completions))
         "no late-completion for a coordinate-less carrier")
@@ -517,7 +517,7 @@
             from a nil `[:children child-id]`)."
     (reg-join-parent! :jea/pr4 :jea/pr4a :jea/pr4b)
     (resolve-all-join! :jea/pr4)
-    (mtest/reset-captured!)
+    (rf.machines.test-support/reset-captured!)
     (dispatch-forged! :jea/pr4 [:child/done :zzz] nil)
     (is (empty? (late-completions))
         "no late-completion for an unknown child")

--- a/implementation/machines/test/re_frame/join_parallel_attempt_select_test.clj
+++ b/implementation/machines/test/re_frame/join_parallel_attempt_select_test.clj
@@ -22,15 +22,15 @@
   untouched; and no stale/bad-child evidence fires for the legitimate carrier."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
-(def ^:private _artefact machines/machine-transition)
+(def ^:private _artefact rf.machines/machine-transition)
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter})
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter})
+  rf.machines.test-support/trace-capture-fixture)
 
 (defn- mk-worker
   "A worker child that dispatches `done-kw` / `err-kw` back to `parent-id`
@@ -87,7 +87,7 @@
   (rf/dispatch-sync [parent-kw [:start]]))
 
 (defn- spawned-joins []
-  (get-in (mtest/runtime-db) [:rf.runtime/machines :spawned parent-kw]))
+  (get-in (rf.machines.test-support/runtime-db) [:rf.runtime/machines :spawned parent-kw]))
 
 (defn- join-for
   "The join-state whose `:spec` resolves to `on-complete` (region-distinct)."
@@ -115,7 +115,7 @@
           "the two regions spawned DISTINCT worker instances")
       (is (not= (:rf/attempt r1-join) (:rf/attempt r2-join))
           "each region minted its own per-attempt token")
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       ;; Complete :r2's worker first — through its own boundary, so its carrier
       ;; carries an exact-current coordinate for :r2's attempt. Non-decisive (the two-child
       ;; :all join still awaits :helper), so both joins persist to assert on.
@@ -128,11 +128,11 @@
         (is (= #{} (:done r1'))
             ":r1's join is UNTOUCHED — the completion did not mis-route to it")
         (is (false? (:resolved? r1')) ":r1 stays open, folded nothing")
-        (is (some? (mtest/snapshot (get-in r1-join [:children :worker])))
+        (is (some? (rf.machines.test-support/snapshot (get-in r1-join [:children :worker])))
             ":r1's worker actor is still live (never reaped by a mis-routed fold)")
-        (is (empty? (mtest/events-of :rf.machine.spawn-all/stale-completion))
+        (is (empty? (rf.machines.test-support/events-of :rf.machine.spawn-all/stale-completion))
             "no stale-completion evidence fired for the legitimate carrier")
-        (is (empty? (mtest/events-of :rf.error/machine-spawn-all-bad-child-id))
+        (is (empty? (rf.machines.test-support/events-of :rf.error/machine-spawn-all-bad-child-id))
             "no bad-child-id evidence fired for the legitimate carrier")))))
 
 (deftest later-region-failure-folds-only-itself-by-exact-attempt
@@ -142,11 +142,11 @@
     (reg-and-start!)
     (let [r1-join (join-for [:r1/done])
           r2-join (join-for [:r2/done])]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (rf/dispatch-sync [(get-in r2-join [:children :worker]) [:fail]])
       (let [r1' (join-for [:r1/done])
             r2' (join-for [:r2/done])]
         (is (= #{:worker} (:failed r2')) ":r2 folded :worker into :failed")
         (is (= #{} (:failed r1')) ":r1 folded no failure (not mis-routed)")
-        (is (empty? (mtest/events-of :rf.machine.spawn-all/stale-completion))
+        (is (empty? (rf.machines.test-support/events-of :rf.machine.spawn-all/stale-completion))
             "no stale-completion evidence for the legitimate failure carrier")))))

--- a/implementation/machines/test/re_frame/join_parallel_recordable_controls_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_parallel_recordable_controls_cljs_test.cljc
@@ -19,18 +19,18 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.machines :as machines]
-   [re-frame.machines.test-support :as mtest]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.machines :as rf.machines]
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
-(def ^:private _artefact machines/machine-transition)
+(def ^:private _artefact rf.machines/machine-transition)
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
+  rf.machines.test-support/trace-capture-fixture)
 
 (def ^:private parent-kw :lud4af-par/parent)
 
@@ -79,7 +79,7 @@
   (rf/dispatch-sync [parent-kw [:start]]))
 
 (defn- spawned-joins []
-  (get-in (mtest/runtime-db) [:rf.runtime/machines :spawned parent-kw]))
+  (get-in (rf.machines.test-support/runtime-db) [:rf.runtime/machines :spawned parent-kw]))
 
 (defn- region-invoke+join
   "`[invoke-id join-state]` for the region whose `:on-all-complete` is
@@ -113,10 +113,10 @@
 
 (defn- stale-reasons []
   (mapv (comp :rf.reply/stale-reason :tags)
-        (mtest/events-of :rf.machine.spawn-all/stale-completion)))
+        (rf.machines.test-support/events-of :rf.machine.spawn-all/stale-completion)))
 
 (defn- bad-child-ids []
-  (mtest/events-of :rf.error/machine-spawn-all-bad-child-id))
+  (rf.machines.test-support/events-of :rf.error/machine-spawn-all-bad-child-id))
 
 ;; ---------------------------------------------------------------------------
 ;; legitimate success / failure through the recordable transport
@@ -128,7 +128,7 @@
             untouched and no stale / bad-child evidence fires."
     (reg-and-start!)
     (let [[_ r2-js] (region-invoke+join [:r2/done])]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (rf/dispatch-sync [(get-in r2-js [:children :worker]) [:go]])
       (let [[_ r1'] (region-invoke+join [:r1/done])
             [_ r2'] (region-invoke+join [:r2/done])]
@@ -142,7 +142,7 @@
             recordable transport folds ONLY into :r2 (:failed #{:worker})."
     (reg-and-start!)
     (let [[_ r2-js] (region-invoke+join [:r2/done])]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (rf/dispatch-sync [(get-in r2-js [:children :worker]) [:fail]])
       (let [[_ r1'] (region-invoke+join [:r1/done])
             [_ r2'] (region-invoke+join [:r2/done])]
@@ -159,7 +159,7 @@
             (never flowed through a member child's boundary) folds nothing in
             either region and is classified :attempt-unverified."
     (reg-and-start!)
-    (mtest/reset-captured!)
+    (rf.machines.test-support/reset-captured!)
     (dispatch-carrier! [:child/done :worker] nil)
     (let [[_ r1'] (region-invoke+join [:r1/done])
           [_ r2'] (region-invoke+join [:r2/done])]
@@ -174,7 +174,7 @@
             clause and folds nothing (:attempt-superseded)."
     (reg-and-start!)
     (let [[r2-invoke r2-js] (region-invoke+join [:r2/done])]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (dispatch-carrier! [:child/done :worker]
                          (attempt-for r2-invoke r2-js {:spawned-id :lud4af-par/bogus-instance}))
       (let [[_ r2'] (region-invoke+join [:r2/done])]
@@ -187,7 +187,7 @@
             parent/invoke identity clause and folds nothing (:attempt-superseded)."
     (reg-and-start!)
     (let [[r2-invoke r2-js] (region-invoke+join [:r2/done])]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (dispatch-carrier! [:child/done :worker]
                          (attempt-for r2-invoke r2-js {:invoke-id [:r9 :nope]}))
       (let [[_ r1'] (region-invoke+join [:r1/done])
@@ -203,7 +203,7 @@
             :rf.error/machine-spawn-all-bad-child-id error trace fires."
     (reg-and-start!)
     (let [[r2-invoke r2-js] (region-invoke+join [:r2/done])]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (dispatch-carrier! [:child/done :ghost]
                          (attempt-for r2-invoke r2-js {:child-id :ghost}))
       (let [[_ r1'] (region-invoke+join [:r1/done])

--- a/implementation/machines/test/re_frame/join_reap_auth_test.clj
+++ b/implementation/machines/test/re_frame/join_reap_auth_test.clj
@@ -46,11 +46,11 @@
             ;; load the machines artefact so its fx handlers + late-bind hooks
             ;; are installed when this ns runs in isolation (`-n`).
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- destroyed-for
   "Captured `:rf.machine/destroyed` traces whose `:actor-id` is `actor-id`."
@@ -91,12 +91,12 @@
       (fn [_ [_ victim]]
         {:fx [[:rf.machine/destroy {:rf/actor-id victim
                                     :rf/reason   :rf.machine/join-reaped}]]}))
-    (mtest/with-trace-capture captured
+    (rf.machines.test-support/with-trace-capture captured
       (rf/dispatch-sync [:jra/parent [:start]])
-      (let [victim (get-in (mtest/runtime-db)
+      (let [victim (get-in (rf.machines.test-support/runtime-db)
                            [:rf.runtime/machines :spawned :jra/parent [:working]])]
         (is (keyword? victim) "the single :spawn child resolved to a live actor id")
-        (is (some? (mtest/snapshot victim)) "the child actor is live before the forged reap")
+        (is (some? (rf.machines.test-support/snapshot victim)) "the child actor is live before the forged reap")
         (rf/dispatch-sync [::forge-old-reap victim])
         ;; Load-bearing forgery assertion: the forged reap did NOT tear the
         ;; live actor down. Pre-fix this fires a :rf.machine/join-reaped
@@ -104,7 +104,7 @@
         (is (empty? (destroyed-for captured victim))
             (str "the forged reap must NOT emit any :rf.machine/destroyed for the "
                  "live actor; saw " (mapv (comp :reason :tags) (destroyed-for captured victim))))
-        (is (some? (mtest/snapshot victim))
+        (is (some? (rf.machines.test-support/snapshot victim))
             "the live actor's snapshot survives the refused forgery")
         (is (seq (bad-arg-errors captured :unknown-shape))
             "the forged {:rf/actor-id …} shape failed loud with :cause :unknown-shape")))))
@@ -119,7 +119,7 @@
                                     :rf/parent-id :no/such-parent
                                     :rf/invoke-id [:nowhere]
                                     :rf/child-id  :ghost}]]}))
-    (mtest/with-trace-capture captured
+    (rf.machines.test-support/with-trace-capture captured
       (rf/dispatch-sync [::forge-bogus-reap])
       (is (seq (bad-arg-errors captured :unverified-reap))
           "a reap against a non-existent join fails loud with :cause :unverified-reap")
@@ -157,9 +157,9 @@
                                       :rf/parent-id p
                                       :rf/invoke-id invoke
                                       :rf/child-id  child-id}]]}))
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         (rf/dispatch-sync [:jra2/parent [:start]])
-        (let [children (get-in (mtest/runtime-db)
+        (let [children (get-in (rf.machines.test-support/runtime-db)
                                [:rf.runtime/machines :spawned :jra2/parent [:racing] :children])
               a-id     (:a children)]
           (is (keyword? a-id) "child :a spawned live and un-completed")
@@ -169,5 +169,5 @@
               "reaping an in-progress join child fails loud with :cause :unverified-reap")
           (is (empty? (destroyed-for captured a-id))
               "the in-progress child is NOT torn down by the refused reap")
-          (is (some? (mtest/snapshot a-id))
+          (is (some? (rf.machines.test-support/snapshot a-id))
               "the in-progress child stays live"))))))

--- a/implementation/machines/test/re_frame/join_recordable_transport_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_recordable_transport_cljs_test.cljc
@@ -27,18 +27,18 @@
    #?(:clj  [clojure.edn :as edn]
       :cljs [cljs.reader :as edn])
    [re-frame.core :as rf]
-   [re-frame.interop :as interop]
-   [re-frame.late-bind :as late-bind]
+   [re-frame.interop :as rf.interop]
+   [re-frame.late-bind :as rf.late-bind]
    [re-frame.machines]
-   [re-frame.machines.test-support :as mtest]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
+  rf.machines.test-support/trace-capture-fixture)
 
 (defn- edn-roundtrip
   "Serialize + re-read `x` through EDN — the same value-only round-trip a
@@ -48,11 +48,11 @@
   (edn/read-string (pr-str x)))
 
 (defn- join-state [parent-id]
-  (get-in (mtest/runtime-db) [:rf.runtime/machines :spawned parent-id [:racing]]))
+  (get-in (rf.machines.test-support/runtime-db) [:rf.runtime/machines :spawned parent-id [:racing]]))
 
 (defn- stale-reasons []
   (mapv (comp :rf.reply/stale-reason :tags)
-        (mtest/events-of :rf.machine.spawn-all/stale-completion)))
+        (rf.machines.test-support/events-of :rf.machine.spawn-all/stale-completion)))
 
 (defn- mk-child
   "A dispatching child: on `:go` transitions to a plain terminal and dispatches
@@ -116,12 +116,12 @@
   completion's re-dispatch is observed deterministically on both platforms (no
   async router drain to await). Restores the real hook in a `finally`."
   [sink body-fn]
-  (let [real (late-bind/get-fn :router/dispatch!)]
+  (let [real (rf.late-bind/get-fn :router/dispatch!)]
     (try
-      (late-bind/set-fn! :router/dispatch! (fn [event opts] (swap! sink conj [event opts])))
+      (rf.late-bind/set-fn! :router/dispatch! (fn [event opts] (swap! sink conj [event opts])))
       (body-fn)
       (finally
-        (late-bind/set-fn! :router/dispatch! real)))))
+        (rf.late-bind/set-fn! :router/dispatch! real)))))
 
 (defn- completion-opts
   "The opts of the FIRST recorded re-dispatch whose event is the completion
@@ -148,7 +148,7 @@
     (let [attempt     (attempt-for :jt/rp)
           rec-event   (edn-roundtrip [:jt/rp [:child/done :a]])
           rec-cofx    (edn-roundtrip {:rf.machine/join-attempt attempt})]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       ;; Strict replay: redispatch the recorded event PLUS its recorded causal
       ;; coeffects (the `:rf.cofx` map, EDN-roundtripped).
       (rf/dispatch-sync rec-event {:rf.cofx rec-cofx})
@@ -156,7 +156,7 @@
           "the EDN-roundtripped completion + recorded cofx folded :a (replay-faithful)")
       (is (empty? (stale-reasons)) "no stale suppression for the faithful replay")
       ;; Remove the recordable coordinate fact → fail-closed stale drop.
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (rf/dispatch-sync (edn-roundtrip [:jt/rp [:child/done :b]])
                         {:rf.cofx (edn-roundtrip {})})
       (is (= #{:a} (:done (join-state :jt/rp)))
@@ -177,7 +177,7 @@
           ;; The #5839 wire shape: coordinate on inner-event METADATA.
           meta-event  [:jt/mp (with-meta [:child/done :a] {:rf/join-attempt attempt})]
           replayed    (edn-roundtrip meta-event)]  ;; EDN drops metadata
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (rf/dispatch-sync replayed)
       (is (= #{} (:done (join-state :jt/mp)))
           "the metadata-stripped replay folded nothing")
@@ -206,11 +206,11 @@
     (let [a           (get-in (join-state :jt/dp) [:children :a])
           captured-cb (atom nil)
           sink        (atom [])]
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       (with-dispatch-stub sink
         (fn []
-          (with-redefs [interop/set-timeout!   (fn [f _ms] (reset! captured-cb f) ::handle)
-                        interop/clear-timeout! (fn [_] nil)]
+          (with-redefs [rf.interop/set-timeout!   (fn [f _ms] (reset! captured-cb f) ::handle)
+                        rf.interop/clear-timeout! (fn [_] nil)]
             ;; The zero-delay :dispatch-later completion is DEFERRED — armed on
             ;; the host clock, NOT folded synchronously (rf2-21hsb1). Restoring
             ;; the (pos? ms) guard would fold it in THIS drain and fail here.
@@ -247,7 +247,7 @@
       (rf/dispatch-sync [:jt/op [:start]])
       (let [j2 (join-state :jt/op)]
         (is (not= (:attempt attempt1-coord) (:rf/attempt j2)) "attempt 2 minted a new token")
-        (mtest/reset-captured!)
+        (rf.machines.test-support/reset-captured!)
         ;; The stale straggler delivered with attempt-1 coordinate on the cofx.
         (rf/dispatch-sync [:jt/op [:child/done :a]]
                           {:rf.cofx {:rf.machine/join-attempt attempt1-coord}})

--- a/implementation/machines/test/re_frame/join_reserved_dispatch_semantics_test.clj
+++ b/implementation/machines/test/re_frame/join_reserved_dispatch_semantics_test.clj
@@ -29,15 +29,15 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.edn :as edn]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
+            [re-frame.fx :as rf.fx]
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter})
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter})
+  rf.machines.test-support/trace-capture-fixture)
 
 ;; ---------------------------------------------------------------------------
 ;; helpers
@@ -46,12 +46,12 @@
 (defn- join-state
   ([parent-id] (join-state :rf/default parent-id))
   ([frame-id parent-id]
-   (get-in (mtest/runtime-db frame-id)
+   (get-in (rf.machines.test-support/runtime-db frame-id)
            [:rf.runtime/machines :spawned parent-id [:racing]])))
 
 (defn- stale-reasons []
   (mapv (comp :rf.reply/stale-reason :tags)
-        (mtest/events-of :rf.machine.spawn-all/stale-completion)))
+        (rf.machines.test-support/events-of :rf.machine.spawn-all/stale-completion)))
 
 (defn- mk-child
   "A dispatching child: on `:go` transitions to a plain terminal and dispatches
@@ -105,15 +105,15 @@
   Unlike a full stub, this observes the EXACT opts `child-dispatch!` produced
   for the completion re-dispatch without perturbing the fold."
   [sink body-fn]
-  (let [real (late-bind/get-fn :router/dispatch!)]
+  (let [real (rf.late-bind/get-fn :router/dispatch!)]
     (try
-      (late-bind/set-fn! :router/dispatch!
+      (rf.late-bind/set-fn! :router/dispatch!
                          (fn [event opts]
                            (swap! sink conj [event opts])
                            (real event opts)))
       (body-fn)
       (finally
-        (late-bind/set-fn! :router/dispatch! real)))))
+        (rf.late-bind/set-fn! :router/dispatch! real)))))
 
 (defn- completion-opts
   "The opts of the FIRST observed re-dispatch whose event is the completion
@@ -203,7 +203,7 @@
             destroy-frame! cancels it. Pre-fix the raw interop/set-timeout!
             retained NOTHING, so the table stays empty and destroy cannot cancel
             it (mutation tooth for the raw timeout)."
-    (fx/reset-dispatch-later-timers!)
+    (rf.fx/reset-dispatch-later-timers!)
     (rf/make-frame {:id df-frame :doc "rf2-lud4af frame-owned-timer frame"})
     (rf/reg-machine :lud4af/dfa (mk-child-delayed :lud4af/dfp 600000))
     (rf/reg-machine :lud4af/dfb (mk-child-delayed :lud4af/dfp 600000))
@@ -222,7 +222,7 @@
       (is (zero? (count (timers-for-frame df-frame)))
           "destroy-frame! cancelled + dropped the frame's pending completion
            timer (pre-fix the raw timeout could not be cancelled)"))
-    (fx/reset-dispatch-later-timers!)))
+    (rf.fx/reset-dispatch-later-timers!)))
 
 (def ^:private short-frame :lud4af/short)
 
@@ -231,7 +231,7 @@
             before it fires NEVER re-dispatches into the dead frame: no
             :rf.error/frame-destroyed, no fold, and the sibling child receives
             no stale completion. Pre-fix the raw timer fired dead-on-arrival."
-    (fx/reset-dispatch-later-timers!)
+    (rf.fx/reset-dispatch-later-timers!)
     (let [errors (atom [])]
       (rf/register-listener! :errors ::rec (fn [r] (swap! errors conj r)))
       (rf/make-frame {:id short-frame :doc "rf2-lud4af short-delay frame"})
@@ -250,7 +250,7 @@
              enqueued a dead-on-arrival dispatch into the destroyed frame")
         (is (empty? (stale-reasons))
             "no stale completion surfaced against the sibling from a leaked timer")))
-    (fx/reset-dispatch-later-timers!)))
+    (rf.fx/reset-dispatch-later-timers!)))
 
 ;; ---------------------------------------------------------------------------
 ;; (4) — real-completion strict replay: record an ACTUAL child completion, restore
@@ -273,7 +273,7 @@
     (rf/reg-machine :lud4af/rcb (mk-child :lud4af/rcp))
     (reg-parent! :lud4af/rcp :lud4af/rca :lud4af/rcb)
     (rf/dispatch-sync [:lud4af/rcp [:start]])
-    (let [pre-fold-runtime (mtest/runtime-db)          ;; attempt-1 join, :done #{}
+    (let [pre-fold-runtime (rf.machines.test-support/runtime-db)          ;; attempt-1 join, :done #{}
           a                (get-in (join-state :lud4af/rcp) [:children :a])
           sink             (atom [])]
       ;; RECORD an actual completion by driving child :a through its boundary.
@@ -291,7 +291,7 @@
         ;; attempt-1 tokens + spawned instances, :done #{}.
         (rf/dispatch-sync [::restore-runtime pre-fold-runtime])
         (is (= #{} (:done (join-state :lud4af/rcp))) "restored to the pre-fold epoch")
-        (mtest/reset-captured!)
+        (rf.machines.test-support/reset-captured!)
         ;; STRICT REPLAY the recorded pair, both halves EDN-roundtripped.
         (rf/dispatch-sync (edn-roundtrip rec-event) {:rf.cofx (edn-roundtrip rec-cofx)})
         (is (= #{:a} (:done (join-state :lud4af/rcp)))
@@ -299,7 +299,7 @@
         (is (empty? (stale-reasons)) "faithful replay — no stale suppression")
         ;; Restore + replay WITHOUT the recorded coordinate → fail-closed stale drop.
         (rf/dispatch-sync [::restore-runtime pre-fold-runtime])
-        (mtest/reset-captured!)
+        (rf.machines.test-support/reset-captured!)
         (rf/dispatch-sync (edn-roundtrip rec-event) {:rf.cofx (edn-roundtrip {})})
         (is (= #{} (:done (join-state :lud4af/rcp)))
             "replay with the coordinate fact stripped folded nothing")

--- a/implementation/machines/test/re_frame/join_strict_mint_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_strict_mint_cljs_test.cljc
@@ -30,34 +30,34 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.late-bind :as late-bind]
+   [re-frame.late-bind :as rf.late-bind]
    [re-frame.machines]
-   [re-frame.machines.test-support :as mtest]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
+  rf.machines.test-support/trace-capture-fixture)
 
 ;; ---------------------------------------------------------------------------
 ;; helpers
 ;; ---------------------------------------------------------------------------
 
 (defn- join-state [parent-id]
-  (get-in (mtest/runtime-db) [:rf.runtime/machines :spawned parent-id [:racing]]))
+  (get-in (rf.machines.test-support/runtime-db) [:rf.runtime/machines :spawned parent-id [:racing]]))
 
 (defn- stale-reasons []
   (mapv (comp :rf.reply/stale-reason :tags)
-        (mtest/events-of :rf.machine.spawn-all/stale-completion)))
+        (rf.machines.test-support/events-of :rf.machine.spawn-all/stale-completion)))
 
 (defn- missing-required-errors []
-  (mtest/events-of :rf.error/missing-required-cofx))
+  (rf.machines.test-support/events-of :rf.error/missing-required-cofx))
 
 (defn- child-completed-terminals []
-  (mtest/events-of :rf.machine.spawn-all/child-completed))
+  (rf.machines.test-support/events-of :rf.machine.spawn-all/child-completed))
 
 ;; The generator-call ledger. Registered fresh per test (`reg-roll!`) closing
 ;; over a caller-owned atom, so "the generator is never called" is a HARD
@@ -135,15 +135,15 @@
   observed. Cross-platform (late-bind is bound on JVM + CLJS). Restores in a
   `finally`."
   [sink body-fn]
-  (let [real (late-bind/get-fn :router/dispatch!)]
+  (let [real (rf.late-bind/get-fn :router/dispatch!)]
     (try
-      (late-bind/set-fn! :router/dispatch!
+      (rf.late-bind/set-fn! :router/dispatch!
                          (fn [event opts]
                            (swap! sink conj [event opts])
                            (real event opts)))
       (body-fn)
       (finally
-        (late-bind/set-fn! :router/dispatch! real)))))
+        (rf.late-bind/set-fn! :router/dispatch! real)))))
 
 (defn- completion-of
   "The FIRST observed completion carrier `[parent-id [:child/done child-id v]]` in
@@ -180,7 +180,7 @@
       (reg-parent! :sm1/rp :sm1/ta :sm1/pb)
       (rf/dispatch-sync [:sm1/rp [:start]])
       (let [a (get-in (join-state :sm1/rp) [:children :a])]
-        (mtest/reset-captured!)
+        (rf.machines.test-support/reset-captured!)
         ;; STRICT, and the recorded token carries NO :strictmint/roll.
         (rf/dispatch-sync [a [:go]]
                           {:rf.cofx {:rf/time-ms 1} :rf.cofx/mint-policy :strict})
@@ -190,7 +190,7 @@
             "the parent did NOT fold — the completion never reached it")
         (is (= 1 (count (missing-required-errors)))
             "the canonical missing-fact outcome fired: :rf.error/missing-required-cofx")
-        (is (= :running (mtest/machine-state a))
+        (is (= :running (rf.machines.test-support/machine-state a))
             "the target child stayed :running — its completion action was skipped")
         (is (empty? (child-completed-terminals))
             "no child-completed terminal — no work attempt closed")))))
@@ -213,7 +213,7 @@
       (rf/dispatch-sync [:sm2/rp [:start]])
       (let [a    (get-in (join-state :sm2/rp) [:children :a])
             sink (atom [])]
-        (mtest/reset-captured!)
+        (rf.machines.test-support/reset-captured!)
         (with-dispatch-observer sink
           (fn [] (rf/dispatch-sync [a [:go]])))   ;; default :live
         (is (= 1 @calls) "the generator ran exactly once under :live")
@@ -251,7 +251,7 @@
       (rf/reg-machine :sm3/pb (mk-plain-child :sm3/rp))
       (reg-parent! :sm3/rp :sm3/ta :sm3/pb)
       (rf/dispatch-sync [:sm3/rp [:start]])
-      (let [pre-fold (mtest/runtime-db)                      ;; attempt-1 join, :done #{}
+      (let [pre-fold (rf.machines.test-support/runtime-db)                      ;; attempt-1 join, :done #{}
             a        (get-in (join-state :sm3/rp) [:children :a])
             sink     (atom [])]
         ;; RECORD a genuine completion under :live; capture the minted roll off
@@ -269,7 +269,7 @@
           (rf/dispatch-sync [:sm3/restore-runtime pre-fold])
           (is (= #{} (:done (join-state :sm3/rp))) "restored to the pre-fold epoch")
           (reset! calls 0)
-          (mtest/reset-captured!)
+          (rf.machines.test-support/reset-captured!)
 
           ;; STRICT REPLAY with the recorded fact present.
           (rf/dispatch-sync [a [:go]]
@@ -286,7 +286,7 @@
           ;; RESTORE + strict replay WITHOUT the recorded fact → canonical fail.
           (rf/dispatch-sync [:sm3/restore-runtime pre-fold])
           (reset! calls 0)
-          (mtest/reset-captured!)
+          (rf.machines.test-support/reset-captured!)
           (rf/dispatch-sync [a [:go]]
                             {:rf.cofx {:rf/time-ms 1} :rf.cofx/mint-policy :strict})
           (is (zero? @calls) "the stripped strict replay did NOT mint")
@@ -353,7 +353,7 @@
       (let [a (get-in (join-state :sm4l/rp) [:children :a])]
         (rf/dispatch-sync [a [:go]])                        ;; :live
         (is (= 1 @live-calls) "the :live resolution minted its downstream fact")
-        (is (= :ready (mtest/machine-state :sm4l/rp))
+        (is (= :ready (rf.machines.test-support/machine-state :sm4l/rp))
             "the :live join resolved and advanced through the resolution action")))
     (let [strict-calls (atom 0)]
       (reg-roll! strict-calls 6)
@@ -361,13 +361,13 @@
       (reg-resolution-parent! :sm4s/rp :sm4s/ca)
       (rf/dispatch-sync [:sm4s/rp [:start]])
       (let [a (get-in (join-state :sm4s/rp) [:children :a])]
-        (mtest/reset-captured!)
+        (rf.machines.test-support/reset-captured!)
         (rf/dispatch-sync [a [:go]]
                           {:rf.cofx {:rf/time-ms 1} :rf.cofx/mint-policy :strict})
         (is (zero? @strict-calls)
             "the inherited :strict propagated through the transport — the
              downstream resolution generator was NOT run")
-        (is (not= :ready (mtest/machine-state :sm4s/rp))
+        (is (not= :ready (rf.machines.test-support/machine-state :sm4s/rp))
             "the resolution action failed missing-required, so the parent did not advance")
         (is (= 1 (count (missing-required-errors)))
             "the canonical missing-fact outcome fired at the inherited resolution")))))

--- a/implementation/machines/test/re_frame/join_work_identity_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_work_identity_cljs_test.cljc
@@ -11,19 +11,19 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.interop :as interop]
-   [re-frame.late-bind :as late-bind]
+   [re-frame.interop :as rf.interop]
+   [re-frame.late-bind :as rf.late-bind]
    [re-frame.machines]
-   [re-frame.machines.reply :as m-reply]
-   [re-frame.machines.test-support :as mtest]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.machines.reply :as rf.machines.reply]
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
+  rf.machines.test-support/trace-capture-fixture)
 
 (defn- dispatching-child [parent-id]
   {:initial :running
@@ -145,15 +145,15 @@
             :done {}}})
 
 (defn- join-state [parent-id]
-  (get-in (mtest/runtime-db)
+  (get-in (rf.machines.test-support/runtime-db)
           [:rf.runtime/machines :spawned parent-id [:racing]]))
 
 (defn- join-attempt [actor-id]
-  (get-in (mtest/runtime-db)
+  (get-in (rf.machines.test-support/runtime-db)
           [:rf.runtime/machines :snapshots actor-id :data :rf/join-child]))
 
 (defn- events-of [op]
-  (mtest/events-of op))
+  (rf.machines.test-support/events-of op))
 
 (defn- work-id-of [event]
   (:rf.reply/work-id (:tags event)))
@@ -164,7 +164,7 @@
               (filter #(= work-id (:rf.reply/work-id %)))
               (keep :rf.reply/work-status)
               (filter #{:completed :failed :cancelled}))
-        (mtest/captured-events)))
+        (rf.machines.test-support/captured-events)))
 
 (defn- forged-completion! [parent-id auth]
   ;; The coordinate rides the recordable `:rf.cofx` slot (rf2-nsbwft) —
@@ -174,14 +174,14 @@
     {:rf.cofx {:rf.machine/join-attempt auth}}))
 
 (defn- capture-dispatch! [sink f]
-  (let [real (late-bind/get-fn :router/dispatch!)]
+  (let [real (rf.late-bind/get-fn :router/dispatch!)]
     (try
-      (late-bind/set-fn! :router/dispatch!
+      (rf.late-bind/set-fn! :router/dispatch!
                          (fn [event opts]
                            (swap! sink conj [event opts])))
       (f)
       (finally
-        (late-bind/set-fn! :router/dispatch! real)))))
+        (rf.late-bind/set-fn! :router/dispatch! real)))))
 
 (deftest numeric-tail-fixed-id-uses-runtime-attempt-not-keyword-spelling
   (testing "sequential attempts at a fixed address ending in #7 get distinct work ids"
@@ -202,7 +202,7 @@
               ;; durable join spec/attempt, never trust this carried value.
               tampered-auth (assoc (join-attempt :jwi/fixed-a#7)
                                    :work-generation tampered-generation)]
-          (mtest/reset-captured!)
+          (rf.machines.test-support/reset-captured!)
           (forged-completion! :jwi/numeric-parent tampered-auth)
           (let [work-b (work-id-of
                          (first (events-of :rf.machine.spawn-all/child-completed)))]
@@ -236,7 +236,7 @@
                               [:children :a])]
         (is (not= :jwi/spec-change-fixed-a#7 successor))
         (is (not= attempt-a (:rf/attempt (join-state :jwi/spec-change-parent))))
-        (mtest/reset-captured!)
+        (rf.machines.test-support/reset-captured!)
         (forged-completion! :jwi/spec-change-parent auth-a)
         (let [stale-work (work-id-of
                            (first (events-of
@@ -307,10 +307,10 @@
   (testing "a delayed exact-attempt carrier is suppressed after its attempt closes"
     (let [callback (atom nil)
           pending  (atom [])]
-      (with-redefs [interop/set-timeout! (fn [f _ms]
+      (with-redefs [rf.interop/set-timeout! (fn [f _ms]
                                           (reset! callback f)
                                           ::timer)
-                    interop/clear-timeout! (fn [_] nil)]
+                    rf.interop/clear-timeout! (fn [_] nil)]
         (register-imperative-destroy-parent!
           :jwi/delayed-cancel-parent
           :jwi/delayed-cancel-a-type :jwi/delayed-cancel-b-type
@@ -397,7 +397,7 @@
             (is (not= attempt-1 attempt-2))
             (is (= :jwi/fixed-a (get-in (join-state :jwi/parent)
                                         [:children :a])))
-            (mtest/reset-captured!)
+            (rf.machines.test-support/reset-captured!)
             (forged-completion! :jwi/parent auth-a-1)
             (let [old-stale (work-id-of (first (events-of
                                                  :rf.machine.spawn-all/stale-completion)))]
@@ -412,7 +412,7 @@
                     "attempt A suppression cannot land on attempt B's arc"))))))))
 
   (testing "join resolution cancellation uses the same exact fixed-id attempt"
-    (mtest/reset-captured!)
+    (rf.machines.test-support/reset-captured!)
     (register-fixed-parent! :jwi/some-parent :jwi/c-type :jwi/d-type
                             :jwi/fixed-c :jwi/fixed-d :any)
     (let [attempt (:rf/attempt (join-state :jwi/some-parent))]
@@ -430,7 +430,7 @@
             "the destroy-side cancellation reuses the join attempt identity"))))
 
   (testing "a fixed join child final leaf and its accepted fold share one id"
-    (mtest/reset-captured!)
+    (rf.machines.test-support/reset-captured!)
     (rf/reg-machine
       :jwi/final-child-type
       {:initial :running
@@ -465,7 +465,7 @@
   (testing "generated actor and ordinary single-spawn identities are unchanged"
     (is (= [:rf.work/machine :jwi/generated#7 [:racing] 7]
            (:rf.reply/work-id
-             (m-reply/join-child-reply
+             (rf.machines.reply/join-child-reply
                {:parent-id :jwi/parent :invoke-id [:racing]
                 :child-id :a :spawned-id :jwi/generated#7
                 :work-generation 7}
@@ -473,7 +473,7 @@
         "a generated actor keeps its exact #n generation")
     (is (= [:rf.work/machine :jwi/single-fixed [:working] 1]
            (:rf.reply/work-id
-             (m-reply/success-reply
+             (rf.machines.reply/success-reply
                {:actor-id :jwi/single-fixed :work-bearing-path [:working]}
                :ok)))
         "normal fixed-id single spawn remains generation 1")))

--- a/implementation/machines/test/re_frame/join_zero_delay_boundary_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_zero_delay_boundary_cljs_test.cljc
@@ -16,7 +16,7 @@
   direct `:dispatch` (no numeric `:ms`) remains immediate.
 
   These fixtures control the host clock deterministically through the
-  `interop/set-timeout!` seam (capturing the deferred callback without firing or
+  `rf.interop/set-timeout!` seam (capturing the deferred callback without firing or
   scheduling), so they pin the boundary identically on CLJ and CLJS.
 
   MUTATION TOOTH: restoring the `(pos? ms)` guard folds a zero-delay completion
@@ -25,20 +25,20 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.interop :as interop]
+   [re-frame.interop :as rf.interop]
    [re-frame.machines]
-   [re-frame.machines.test-support :as mtest]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
+  rf.machines.test-support/trace-capture-fixture)
 
 (defn- join-state [parent-id]
-  (get-in (mtest/runtime-db) [:rf.runtime/machines :spawned parent-id [:racing]]))
+  (get-in (rf.machines.test-support/runtime-db) [:rf.runtime/machines :spawned parent-id [:racing]]))
 
 (defn- mk-child
   "A child completing through a DIRECT `:dispatch` (no numeric `:ms`)."
@@ -96,8 +96,8 @@
     (let [a           (get-in (join-state :hsb.z/rp) [:children :a])
           captured-cb (atom nil)
           captured-ms (atom ::none)]
-      (with-redefs [interop/set-timeout!   (fn [f ms] (reset! captured-cb f) (reset! captured-ms ms) ::handle)
-                    interop/clear-timeout! (fn [_] nil)]
+      (with-redefs [rf.interop/set-timeout!   (fn [f ms] (reset! captured-cb f) (reset! captured-ms ms) ::handle)
+                    rf.interop/clear-timeout! (fn [_] nil)]
         (rf/dispatch-sync [a [:go]]))
       (is (= 0 @captured-ms)
           "the numeric :ms 0 was forwarded to the host-clock timer (host-clock-delayed)")
@@ -123,8 +123,8 @@
     (rf/dispatch-sync [:hsb.d/rp [:start]])
     (let [a           (get-in (join-state :hsb.d/rp) [:children :a])
           armed?      (atom false)]
-      (with-redefs [interop/set-timeout!   (fn [_f _ms] (reset! armed? true) ::handle)
-                    interop/clear-timeout! (fn [_] nil)]
+      (with-redefs [rf.interop/set-timeout!   (fn [_f _ms] (reset! armed? true) ::handle)
+                    rf.interop/clear-timeout! (fn [_] nil)]
         (rf/dispatch-sync [a [:go]]))
       (is (false? @armed?)
           "a direct :dispatch completion armed NO host-clock timer")
@@ -147,8 +147,8 @@
     (let [a           (get-in (join-state :hsb.p/rp) [:children :a])
           captured-cb (atom nil)
           captured-ms (atom ::none)]
-      (with-redefs [interop/set-timeout!   (fn [f ms] (reset! captured-cb f) (reset! captured-ms ms) ::handle)
-                    interop/clear-timeout! (fn [_] nil)]
+      (with-redefs [rf.interop/set-timeout!   (fn [f ms] (reset! captured-cb f) (reset! captured-ms ms) ::handle)
+                    rf.interop/clear-timeout! (fn [_] nil)]
         (rf/dispatch-sync [a [:go]]))
       (is (= 500 @captured-ms) "the positive :ms was forwarded to the host-clock timer")
       (is (some? @captured-cb) "the positive-delay completion armed a delayed dispatch")

--- a/implementation/machines/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/machines/test/re_frame/late_bind_missing_test.clj
@@ -29,7 +29,7 @@
   apply to them)."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.core :as rf]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.late-bind :as rf.late-bind]
             ;; Loading machines registers its late-bind hooks. The
             ;; `with-hook-as-nil` helper below re-establishes the absent
             ;; state by flipping the hook value at runtime; restoration
@@ -40,12 +40,12 @@
   "Run `f` with the named late-bind hook set to nil. Restores the
   original value after `f` returns or throws."
   [hook-key f]
-  (let [original (late-bind/get-fn hook-key)]
+  (let [original (rf.late-bind/get-fn hook-key)]
     (try
-      (late-bind/set-fn! hook-key nil)
+      (rf.late-bind/set-fn! hook-key nil)
       (f)
       (finally
-        (late-bind/set-fn! hook-key original)))))
+        (rf.late-bind/set-fn! hook-key original)))))
 
 
 (deftest reg-machine-macro-raises-when-machines-artefact-missing

--- a/implementation/machines/test/re_frame/lifecycle_composed_corners_test.clj
+++ b/implementation/machines/test/re_frame/lifecycle_composed_corners_test.clj
@@ -23,29 +23,29 @@
   contractual — the runtime always emits the 4-element shape)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
+            [re-frame.frame :as rf.frame]
             [re-frame.machines]
-            [re-frame.machines.spawn-order :as spawn-order]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.machines.timer :as timer]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]))
+            [re-frame.machines.spawn-order :as rf.machines.spawn-order]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.machines.timer :as rf.machines.timer]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace :as rf.trace]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- helpers --------------------------------------------------------------
 
-;; Intentional RAW manual-stop listener (not mtest/with-trace-capture): hands
+;; Intentional RAW manual-stop listener (not rf.machines.test-support/with-trace-capture): hands
 ;; the caller a [observation-atom unregister-fn] pair so the test controls
 ;; exactly WHEN it stops listening — the scope-macro form cannot express that.
 (defn- record!
   "Attach a trace listener and return [observation-atom unreg-fn]."
   [id]
   (let [a (atom [])]
-    (trace/register-listener! id (fn [ev] (swap! a conj ev)))
-    [a #(trace/unregister-listener! id)]))
+    (rf.trace/register-listener! id (fn [ev] (swap! a conj ev)))
+    [a #(rf.trace/unregister-listener! id)]))
 
 ;; ---------------------------------------------------------------------------
 ;; 1. Stale :after firing AFTER frame destroy
@@ -75,13 +75,13 @@
       (rf/reg-machine :corner.timer/m m)
       (rf/dispatch-sync [:corner.timer/m [:fetch]] {:frame :corner.timer/scoped})
       ;; The timer table now has an entry for the frame.
-      (is (contains? @timer/after-timers :corner.timer/scoped)
+      (is (contains? @rf.machines.timer/after-timers :corner.timer/scoped)
           "precondition: timer table holds an entry for the frame")
 
       ;; Destroy the frame. The :machines/on-frame-destroyed! late-bind
       ;; hook releases the host-clock handle and drops the inner entry.
-      (frame/destroy-frame! :corner.timer/scoped)
-      (is (not (contains? @timer/after-timers :corner.timer/scoped))
+      (rf.frame/destroy-frame! :corner.timer/scoped)
+      (is (not (contains? @rf.machines.timer/after-timers :corner.timer/scoped))
           "post-destroy: timer table no longer holds a residue for the destroyed frame")
 
       ;; The synthetic stale firing — emulates the host clock waking up
@@ -150,7 +150,7 @@
             "actor A snapshot is gone")
         (is (some? (get-in db [:rf.runtime/machines :snapshots :corner.sid/child#2]))
             "actor B snapshot is live")
-        (is (nil? (registrar/lookup :event :corner.sid/child#1))
+        (is (nil? (rf.registrar/lookup :event :corner.sid/child#1))
             "actor A handler is unregistered post-destroy"))
 
       ;; Fire the stale synthetic :after-elapsed keyed on A's id.
@@ -216,8 +216,8 @@
         (is (false? (:resolved? j)) "join not yet resolved"))
 
       ;; Destroy the parent frame BEFORE any child completes.
-      (frame/destroy-frame! :corner.ia/scoped)
-      (is (nil? (frame/frame :corner.ia/scoped))
+      (rf.frame/destroy-frame! :corner.ia/scoped)
+      (is (nil? (rf.frame/frame :corner.ia/scoped))
           "frame is destroyed")
 
       ;; Late child completion: synthetic dispatch into the
@@ -263,7 +263,7 @@
       (rf/reg-machine :corner.dyn/m m)
       (rf/dispatch-sync [:corner.dyn/m [:fetch]])
       ;; Timer table has an entry.
-      (is (seq (get @timer/after-timers :rf/default))
+      (is (seq (get @rf.machines.timer/after-timers :rf/default))
           "precondition: timer table holds the in-flight entry")
 
       ;; Capture the entry's epoch BEFORE we exit :loading.
@@ -281,8 +281,8 @@
         ;; The timer table's inner map should have the entry dropped;
         ;; per timer.cljc when the inner map empties the OUTER frame
         ;; entry is also dropped.
-        (is (or (not (contains? @timer/after-timers :rf/default))
-                (empty? (get @timer/after-timers :rf/default)))
+        (is (or (not (contains? @rf.machines.timer/after-timers :rf/default))
+                (empty? (get @rf.machines.timer/after-timers :rf/default)))
             "timer table residue for the frame is cleared on state exit")
 
         ;; Now the stale firing — synthetic carrying epoch-loading
@@ -364,7 +364,7 @@
       (rf/dispatch-sync [:corner.leak/ia-parent [:start]] {:frame :corner.leak/scoped}))
 
     ;; --- preconditions ----------------------------------------------------
-    (is (contains? @timer/after-timers :corner.leak/scoped)
+    (is (contains? @rf.machines.timer/after-timers :corner.leak/scoped)
         "precondition: timer table holds the :after entry for the frame")
     (let [db (:rf.db/runtime (rf/frame-state-value :corner.leak/scoped))]
       (is (= :corner.leak/child#1
@@ -374,31 +374,31 @@
           "precondition: invoke-all join slot is seeded")
       (is (some? (get-in db [:rf.runtime/machines :snapshots :corner.leak/child#1]))
           "precondition: spawned actor snapshot is live"))
-    (is (pos? (count (spawn-order/frame-order :corner.leak/scoped)))
+    (is (pos? (count (rf.machines.spawn-order/frame-order :corner.leak/scoped)))
         "precondition: spawn-order channel has entries")
     ;; A spawned actor carries NO per-instance registrar entry; its
     ;; liveness is its snapshot's presence in app-db (asserted live above).
     ;; The registrar precondition is therefore inverted.
-    (is (nil? (registrar/lookup :event :corner.leak/child#1))
+    (is (nil? (rf.registrar/lookup :event :corner.leak/child#1))
         "precondition: spawned actor has no per-instance registrar entry (liveness lives in its app-db snapshot)")
 
     ;; --- destroy ----------------------------------------------------------
-    (frame/destroy-frame! :corner.leak/scoped)
+    (rf.frame/destroy-frame! :corner.leak/scoped)
 
     ;; --- composed post-condition: every per-frame slot is cleared -------
-    (is (not (contains? @timer/after-timers :corner.leak/scoped))
+    (is (not (contains? @rf.machines.timer/after-timers :corner.leak/scoped))
         "post: timer table no longer holds an entry for the destroyed frame")
-    (is (nil? (frame/frame :corner.leak/scoped))
+    (is (nil? (rf.frame/frame :corner.leak/scoped))
         "post: frame is dissoc'd from the frames atom")
     (is (nil? (get-in (:rf.db/runtime (rf/frame-state-value :corner.leak/scoped))
                       [:rf.runtime/machines :snapshots :corner.leak/child#1]))
         "post: spawned actor's snapshot is gone — its liveness (snapshot-based) is cleared (rf2-a2sn1)")
-    (is (= [] (spawn-order/frame-order :corner.leak/scoped))
+    (is (= [] (rf.machines.spawn-order/frame-order :corner.leak/scoped))
         "post: spawn-order channel is empty for the destroyed frame")
     ;; The singletons (:corner.leak/timer, :corner.leak/boot, :corner.leak/
     ;; ia-parent, :corner.leak/ia-child, :corner.leak/child) stay
     ;; registered — they're global handlers, not frame-scoped.
-    (is (some? (registrar/lookup :event :corner.leak/timer))
+    (is (some? (rf.registrar/lookup :event :corner.leak/timer))
         "post: singleton timer handler stays globally registered (not frame-scoped)")
-    (is (some? (registrar/lookup :event :corner.leak/ia-parent))
+    (is (some? (rf.registrar/lookup :event :corner.leak/ia-parent))
         "post: singleton invoke-all parent handler stays globally registered")))

--- a/implementation/machines/test/re_frame/machine_action_exception_always_on_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_action_exception_always_on_cljs_test.cljc
@@ -13,22 +13,22 @@
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
+            [re-frame.error-emit :as rf.error-emit]
             ;; Loading the machines facade installs the late-bind hooks
             ;; `reg-machine` resolves through.
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 ;; Fresh registrar + plain-atom adapter per test; the always-on error-listener
 ;; registry (a `defonce` atom) cleared so a listener from one test cannot leak
 ;; into the next (mirrors machine_spawn_unregistered_type_test /
 ;; write_after_destroy_always_on_cljs_test).
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn (fn [] (error-emit/clear-error-listeners!))}))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
+     :init-fn (fn [] (rf.error-emit/clear-error-listeners!))}))
 
 (defn- throwable? [x]
   #?(:clj  (instance? Throwable x)
@@ -60,11 +60,11 @@
   rather than routing around it."
   [op thunk]
   (let [seen (atom [])]
-    (trace-tooling/register-listener! ::trace (fn [ev] (swap! seen conj ev)))
+    (rf.trace.tooling/register-listener! ::trace (fn [ev] (swap! seen conj ev)))
     (try
       (thunk)
       (filterv #(= op (:operation %)) @seen)
-      (finally (trace-tooling/clear-listeners!)))))
+      (finally (rf.trace.tooling/clear-listeners!)))))
 
 ;; ===========================================================================
 ;; (1)+(2) A throwing ACTION reaches the always-on axis WITH attribution.

--- a/implementation/machines/test/re_frame/machine_active_path_geometry_test.clj
+++ b/implementation/machines/test/re_frame/machine_active_path_geometry_test.clj
@@ -38,11 +38,11 @@
             ;; Loading the machines facade registers `rf/reg-machine` + the
             ;; reserved machine fxs when this ns runs alone.
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- tag
   "An `:actions` entry that appends `k` to `log` when it fires."
@@ -101,7 +101,7 @@
              (drive! log :geo/parent-leaf (parent-declared-leaf-machine log)
                      [:target-leaf]))
           "the targeted leaf IS re-entered; :parent is neither exited nor entered")
-      (is (= [:parent :leaf] (mtest/machine-state :geo/parent-leaf))
+      (is (= [:parent :leaf] (rf.machines.test-support/machine-state :geo/parent-leaf))
           "the configuration is unchanged in VALUE — the churn is the point"))))
 
 (deftest targetless-control-on-the-same-leaf-runs-the-action-alone
@@ -202,7 +202,7 @@
              (drive! log :geo/ancestor (ancestor-target-machine log)
                      [[:next]] [:restart]))
           "descendants re-resolve; the target node survives")
-      (is (= [:process :step1] (mtest/machine-state :geo/ancestor))
+      (is (= [:process :step1] (rf.machines.test-support/machine-state :geo/ancestor))
           "the active descendant really was reset to :initial"))))
 
 (deftest ancestor-target-with-reenter-restarts-the-target

--- a/implementation/machines/test/re_frame/machine_actor_concurrency_stress_test.clj
+++ b/implementation/machines/test/re_frame/machine_actor_concurrency_stress_test.clj
@@ -85,13 +85,13 @@
             ;; first `rf/reg-machine` call would otherwise raise
             ;; `:rf.error/machines-artefact-missing`.
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom])
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom])
   (:import [java.util.concurrent CountDownLatch]
            [java.util.concurrent.atomic AtomicLong]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; Per-thread iteration count. Kept at the standard 5000 so CI stays under
 ;; ~60s wall-clock with the default thread count.

--- a/implementation/machines/test/re_frame/machine_after_hydration_rearm_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_after_hydration_rearm_cljs_test.cljc
@@ -15,7 +15,7 @@
   ## These tests FIRE the timer
 
   Every positive case here captures the host-clock thunk
-  (`with-redefs` on `interop/schedule-after!`, the pattern
+  (`with-redefs` on `rf.interop/schedule-after!`, the pattern
   `after_fire_reap_cljs_test` established) and INVOKES it, then asserts the
   machine actually transitioned. Asserting that the timer table is
   non-empty would have passed for the whole life of this defect had the
@@ -37,20 +37,20 @@
   defect, so the CLJS arm is the load-bearing one."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
             ;; Loading `re-frame.machines` installs the artefact's late-bind
             ;; hooks + reserved fxs; under a single-ns run nothing else does.
             [re-frame.machines]
-            [re-frame.machines.hydrate :as m-hydrate]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.machines.timer :as timer]
-            [re-frame.subs :as subs]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.hydrate :as rf.machines.hydrate]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.machines.timer :as rf.machines.timer]
+            [re-frame.subs :as rf.subs]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter})
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter})
+  rf.machines.test-support/trace-capture-fixture)
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures
@@ -76,7 +76,7 @@
 (defn- inner
   "`frame-id`'s inner `:after` timer table, or `{}` when it holds none."
   [frame-id]
-  (get @timer/after-timers frame-id {}))
+  (get @rf.machines.timer/after-timers frame-id {}))
 
 (defn- server-runtime-db
   "Run `machine` on a real SERVER frame through `events`, assert it armed
@@ -88,7 +88,7 @@
       (rf/dispatch-sync [machine-id e] {:frame sfid}))
     (is (empty? (inner sfid))
         "precondition: the SERVER armed no `:after` host timer")
-    (frame/frame-runtime-db-value sfid)))
+    (rf.frame/frame-runtime-db-value sfid)))
 
 (defn- fire!
   "Run a captured host-clock thunk to completion.
@@ -96,7 +96,7 @@
   The thunk dispatches the synthetic
   `[:rf.machine.timer/after-elapsed <delay-key> <epoch> <decl-path>]`
   through the REAL async router (`:router/dispatch!`), whose drain is
-  scheduled on `interop/next-tick` — a background executor on the JVM and
+  scheduled on `rf.interop/next-tick` — a background executor on the JVM and
   a macrotask in CLJS, so a bare call would race every assertion after it.
   Collapsing `next-tick` to an inline call for the duration is the
   established seam (`core/test/re_frame/drain_test.clj`,
@@ -105,7 +105,7 @@
   fail. Nothing here re-implements the timer's own event, which is
   precisely the part under test."
   [thunk]
-  (with-redefs [interop/next-tick (fn [f] (f) nil)]
+  (with-redefs [rf.interop/next-tick (fn [f] (f) nil)]
     (thunk)))
 
 (defn- hydrate-into!
@@ -114,8 +114,8 @@
   has committed. Returns the frame id."
   [runtime-db]
   (let [cfid (fresh-frame! :client)]
-    (frame/replace-runtime-db! cfid runtime-db)
-    (m-hydrate/rearm-after-timers! cfid)
+    (rf.frame/replace-runtime-db! cfid runtime-db)
+    (rf.machines.hydrate/rearm-after-timers! cfid)
     cfid))
 
 ;; ---------------------------------------------------------------------------
@@ -180,7 +180,7 @@
       (is (and (integer? epoch) (pos? epoch))
           "precondition: the durable per-decl-path epoch rode the snapshot")
 
-      (let [cfid (with-redefs [interop/schedule-after!
+      (let [cfid (with-redefs [rf.interop/schedule-after!
                               (fn [thunk ms]
                                 (swap! thunks conj thunk)
                                 (swap! arms conj ms)
@@ -208,10 +208,10 @@
 
         ;; THE FIRE. Not "a table is populated" — the reconstructed timer
         ;; must actually drive the transition.
-        (is (= :waiting (mtest/machine-state cfid :hyd/flat))
+        (is (= :waiting (rf.machines.test-support/machine-state cfid :hyd/flat))
             "precondition: still waiting before the clock runs out")
         (fire! (first @thunks))
-        (is (= :timeout (mtest/machine-state cfid :hyd/flat))
+        (is (= :timeout (rf.machines.test-support/machine-state cfid :hyd/flat))
             (str "the hydrated timer FIRED and performed the declared "
                  "`:after` transition. This is the whole bug: before the fix "
                  "no timer existed, so this state was terminal in practice."))))))
@@ -224,14 +224,14 @@
           snap (get-in rt [:rf.runtime/machines :snapshots :hyd/noreplay])]
       (is (= 1 (get-in snap [:data :entries]))
           "precondition: the server ran `:entry` exactly once")
-      (let [cfid (with-redefs [interop/schedule-after!
+      (let [cfid (with-redefs [rf.interop/schedule-after!
                               (fn [_thunk _ms] ::handle)]
                    (hydrate-into! rt))]
-        (is (= 1 (:entries (mtest/machine-data cfid :hyd/noreplay)))
+        (is (= 1 (:entries (rf.machines.test-support/machine-data cfid :hyd/noreplay)))
             (str "still 1. Re-running entry would have re-armed the timers "
                  "AND re-fired every entry effect the server already "
                  "performed — a different and worse bug than the one fixed."))
-        (is (= :waiting (mtest/machine-state cfid :hyd/noreplay))
+        (is (= :waiting (rf.machines.test-support/machine-state cfid :hyd/noreplay))
             "and the durable state is untouched by the re-arm")))))
 
 (deftest hydration-re-arm-is-idempotent
@@ -239,10 +239,10 @@
             duplicating — one live handle per declaration, always"
     (rf/reg-machine :hyd/idem flat-machine)
     (let [rt (server-runtime-db :hyd/idem flat-machine [[:go]])]
-      (with-redefs [interop/schedule-after! (fn [_thunk _ms] ::handle)]
+      (with-redefs [rf.interop/schedule-after! (fn [_thunk _ms] ::handle)]
         (let [cfid (hydrate-into! rt)]
           (is (= 1 (count (inner cfid))))
-          (m-hydrate/rearm-after-timers! cfid)
+          (rf.machines.hydrate/rearm-after-timers! cfid)
           (is (= 1 (count (inner cfid)))
               "still one entry — the ordinary timer-table key superseded"))))))
 
@@ -259,7 +259,7 @@
           snap   (get-in rt [:rf.runtime/machines :snapshots :hyd/compound])]
       (is (= [:outer :inner] (:state snap))
           "precondition: the server settled on the compound leaf")
-      (let [cfid  (with-redefs [interop/schedule-after!
+      (let [cfid  (with-redefs [rf.interop/schedule-after!
                                (fn [thunk ms] (swap! thunks assoc ms thunk) ::handle)]
                     (hydrate-into! rt))
             table (inner cfid)]
@@ -275,7 +275,7 @@
 
         ;; Fire the ANCESTOR's timer — the one an entry-shaped fix misses.
         (fire! (get @thunks 9000))
-        (is (= :outer-fired (mtest/machine-state cfid :hyd/compound))
+        (is (= :outer-fired (rf.machines.test-support/machine-state cfid :hyd/compound))
             "the hydrated ANCESTOR timer fired and transitioned")))))
 
 ;; ---------------------------------------------------------------------------
@@ -291,7 +291,7 @@
           snap   (get-in rt [:rf.runtime/machines :snapshots :hyd/par])]
       (is (= :ticking (get-in snap [:state :left]))
           "precondition: the `:after`-bearing region is on its timed state")
-      (let [cfid  (with-redefs [interop/schedule-after!
+      (let [cfid  (with-redefs [rf.interop/schedule-after!
                                (fn [thunk ms] (swap! thunks assoc ms thunk) ::handle)]
                     (hydrate-into! rt))
             table (inner cfid)]
@@ -314,9 +314,9 @@
               "root sentinel, matching what birth-time scheduling stamps"))
 
         (fire! (get @thunks 3000))
-        (is (= :left-done (get-in (mtest/snapshot cfid :hyd/par) [:state :left]))
+        (is (= :left-done (get-in (rf.machines.test-support/snapshot cfid :hyd/par) [:state :left]))
             "the hydrated REGION timer fired and moved that region alone")
-        (is (= :steady (get-in (mtest/snapshot cfid :hyd/par) [:state :right])
+        (is (= :steady (get-in (rf.machines.test-support/snapshot cfid :hyd/par) [:state :right])
                )
             "and left its sibling region untouched")))))
 
@@ -338,9 +338,9 @@
           thunk    (atom nil)]
       (rf/reg-sub :t/dyn (fn [_db _] @reaction))
       (rf/reg-machine :hyd/dyn m)
-      (with-redefs [subs/subscribe   (fn ([_q] reaction) ([_q _o] reaction))
-                    subs/unsubscribe (fn ([_] nil) ([_ _] nil))
-                    interop/schedule-after! (fn [t ms]
+      (with-redefs [rf.subs/subscribe   (fn ([_q] reaction) ([_q _o] reaction))
+                    rf.subs/unsubscribe (fn ([_] nil) ([_ _] nil))
+                    rf.interop/schedule-after! (fn [t ms]
                                               (reset! thunk t)
                                               (swap! armed conj ms)
                                               ::handle)]
@@ -358,7 +358,7 @@
                 "and its re-resolution watcher is attached"))
           (is (= [2500] @armed))
           (fire! @thunk)
-          (is (= :fired (mtest/machine-state cfid :hyd/dyn))
+          (is (= :fired (rf.machines.test-support/machine-state cfid :hyd/dyn))
               "the client-resolved dynamic delay fired the transition")
           (is (empty? (inner cfid))
               "and the spent one-shot reaped its entry, releasing the watch"))))))
@@ -377,7 +377,7 @@
     (let [rt (server-runtime-db :hyd/none flat-machine [[:noop]])]
       (is (= :idle (get-in rt [:rf.runtime/machines :snapshots :hyd/none :state]))
           "precondition: parked on the `:after`-free initial state")
-      (with-redefs [interop/schedule-after! (fn [_t _ms] ::handle)]
+      (with-redefs [rf.interop/schedule-after! (fn [_t _ms] ::handle)]
         (let [cfid (hydrate-into! rt)]
           (is (empty? (inner cfid))
               "no live declaration, so nothing armed"))))))
@@ -387,10 +387,10 @@
             loopback or server-side `:rf/hydrate` must not start host clocks"
     (rf/reg-machine :hyd/srv flat-machine)
     (let [rt (server-runtime-db :hyd/srv flat-machine [[:go]])]
-      (with-redefs [interop/schedule-after! (fn [_t _ms] ::handle)]
+      (with-redefs [rf.interop/schedule-after! (fn [_t _ms] ::handle)]
         (let [sfid (fresh-frame! :server)]
-          (frame/replace-runtime-db! sfid rt)
-          (m-hydrate/rearm-after-timers! sfid)
+          (rf.frame/replace-runtime-db! sfid rt)
+          (rf.machines.hydrate/rearm-after-timers! sfid)
           (is (empty? (inner sfid))
               (str "same refusal `build-after-fx` applies, read off the same "
                    "frame `:platform` — the two cannot disagree")))))))
@@ -403,7 +403,7 @@
           ;; A wire-shaped snapshot for an actor no registration backs.
           poisoned (assoc-in rt [:rf.runtime/machines :snapshots :hyd/ghost]
                              {:state :waiting :data {} :rf/machine-type :hyd/never-registered})]
-      (with-redefs [interop/schedule-after! (fn [_t _ms] ::handle)]
+      (with-redefs [rf.interop/schedule-after! (fn [_t _ms] ::handle)]
         (let [cfid (hydrate-into! poisoned)]
           (is (= #{{:parent :hyd/mixed :spawn [:waiting] :delay 5000}}
                  (set (keys (inner cfid))))
@@ -420,13 +420,13 @@
             and not nothing"
     (rf/reg-machine :hyd/trace flat-machine)
     (let [rt (server-runtime-db :hyd/trace flat-machine [[:go]])]
-      (mtest/reset-captured!)
-      (with-redefs [interop/schedule-after! (fn [_t _ms] ::handle)]
+      (rf.machines.test-support/reset-captured!)
+      (with-redefs [rf.interop/schedule-after! (fn [_t _ms] ::handle)]
         (let [cfid  (hydrate-into! rt)
               ;; A trace event carries its payload under `:tags`, not at the
               ;; top level (the shape `after_test` reads).
               rows  (filterv #(= :hyd/trace (:actor-id (:tags %)))
-                             (mtest/events-of :rf.machine.timer/scheduled))
+                             (rf.machines.test-support/events-of :rf.machine.timer/scheduled))
               epoch (get-in rt [:rf.runtime/machines :snapshots :hyd/trace
                                 :data :rf/after-epoch [:waiting]])]
           (is (= 1 (count rows)) "exactly one scheduled row")
@@ -437,5 +437,5 @@
             (is (= epoch (:epoch row))
                 "carrying the persisted epoch, so scheduled→fired pairs")
             (is (= cfid (:frame row))))
-          (is (empty? (mtest/events-of :rf.machine.timer/skipped-on-server))
+          (is (empty? (rf.machines.test-support/events-of :rf.machine.timer/skipped-on-server))
               "and no server-skip row: this arm happened on a client"))))))

--- a/implementation/machines/test/re_frame/machine_after_hydration_reconcile_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_after_hydration_reconcile_cljs_test.cljc
@@ -42,20 +42,20 @@
   runner (`npm run test:cljs`)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
             ;; Loading `re-frame.machines` installs the artefact's late-bind
             ;; hooks + reserved fxs; under a single-ns run nothing else does.
             [re-frame.machines]
-            [re-frame.machines.hydrate :as m-hydrate]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.machines.timer :as timer]
-            [re-frame.subs :as subs]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.hydrate :as rf.machines.hydrate]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.machines.timer :as rf.machines.timer]
+            [re-frame.subs :as rf.subs]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter})
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter})
+  rf.machines.test-support/trace-capture-fixture)
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures
@@ -76,7 +76,7 @@
 (defn- inner
   "`frame-id`'s inner `:after` timer table, or `{}` when it holds none."
   [frame-id]
-  (get @timer/after-timers frame-id {}))
+  (get @rf.machines.timer/after-timers frame-id {}))
 
 (defn- server-runtime-db
   "Run `machine` on a real SERVER frame through `events`, assert it armed no
@@ -88,7 +88,7 @@
       (rf/dispatch-sync [machine-id e] {:frame sfid}))
     (is (empty? (inner sfid))
         "precondition: the SERVER armed no `:after` host timer")
-    (frame/frame-runtime-db-value sfid)))
+    (rf.frame/frame-runtime-db-value sfid)))
 
 (defn- install!
   "Replace `frame-id`'s runtime-db with `runtime-db` and run the machines
@@ -97,8 +97,8 @@
   the wholesale runtime-db replacement, and that survival is the subject of
   this namespace."
   [frame-id runtime-db]
-  (frame/replace-runtime-db! frame-id runtime-db)
-  (m-hydrate/rearm-after-timers! frame-id))
+  (rf.frame/replace-runtime-db! frame-id runtime-db)
+  (rf.machines.hydrate/rearm-after-timers! frame-id))
 
 (defn- snap-of
   [runtime-db actor-id]
@@ -109,7 +109,7 @@
   event carries its payload under `:tags`, not at the top level."
   [actor-id]
   (into [] (comp (map :tags) (filter #(= actor-id (:actor-id %))))
-        (mtest/events-of :rf.machine.timer/cancelled)))
+        (rf.machines.test-support/events-of :rf.machine.timer/cancelled)))
 
 ;; ---------------------------------------------------------------------------
 ;; Machines under test
@@ -164,19 +164,19 @@
       (is (= :settled (:state (snap-of rt-settled :hydrec/changed)))
           "precondition: the replacement snapshot declares NO `:after`")
 
-      (with-redefs [interop/schedule-after!
+      (with-redefs [rf.interop/schedule-after!
                     (fn [_thunk _ms]
                       (let [h (keyword "handle" (str (count @armed)))]
                         (swap! armed conj h)
                         h))
-                    interop/cancel-scheduled!
+                    rf.interop/cancel-scheduled!
                     (fn [h] (swap! released conj h) nil)]
         (let [cfid (fresh-frame! :client)]
           (install! cfid rt-waiting)
           (is (= 1 (count (inner cfid)))
               "precondition: the pre-replacement timer is armed")
 
-          (mtest/reset-captured!)
+          (rf.machines.test-support/reset-captured!)
           (reset! released [])
           (install! cfid rt-settled)
 
@@ -202,10 +202,10 @@
               (is (= epoch (:epoch row))
                   "stamped with the epoch the cancelled timer was armed at")
               (is (= cfid (:frame row)))))
-          (is (empty? (mtest/events-of :rf.machine.timer/scheduled))
+          (is (empty? (rf.machines.test-support/events-of :rf.machine.timer/scheduled))
               "and nothing was armed for the replacement — `:settled` declares
                no `:after`")
-          (is (= 1 (:entries (mtest/machine-data cfid :hydrec/changed)))
+          (is (= 1 (:entries (rf.machines.test-support/machine-data cfid :hydrec/changed)))
               (str "no entry replay in either phase: the count is the "
                    "server's, unchanged by the reconcile")))))))
 
@@ -219,13 +219,13 @@
           released   (atom [])]
       (is (nil? (snap-of rt-gone :hydrec/dropped))
           "precondition: the replacement holds no snapshot for the actor")
-      (with-redefs [interop/schedule-after!   (fn [_thunk _ms] ::handle)
-                    interop/cancel-scheduled! (fn [h] (swap! released conj h) nil)]
+      (with-redefs [rf.interop/schedule-after!   (fn [_thunk _ms] ::handle)
+                    rf.interop/cancel-scheduled! (fn [h] (swap! released conj h) nil)]
         (let [cfid (fresh-frame! :client)]
           (install! cfid rt-waiting)
           (is (= 1 (count (inner cfid))) "precondition: armed")
 
-          (mtest/reset-captured!)
+          (rf.machines.test-support/reset-captured!)
           (install! cfid rt-gone)
 
           (is (empty? (inner cfid))
@@ -253,11 +253,11 @@
           unsubs   (atom [])]
       (rf/reg-sub :hydrec/dyn-delay (fn [_db _] @reaction))
       (rf/reg-machine :hydrec/dyn dynamic-delay-machine)
-      (with-redefs [subs/subscribe            (fn ([_q] reaction) ([_q _o] reaction))
-                    subs/unsubscribe          (fn ([_q] nil)
+      (with-redefs [rf.subs/subscribe            (fn ([_q] reaction) ([_q _o] reaction))
+                    rf.subs/unsubscribe          (fn ([_q] nil)
                                                 ([_frame q] (swap! unsubs conj q) nil))
-                    interop/schedule-after!   (fn [_thunk _ms] ::handle)
-                    interop/cancel-scheduled! (fn [_h] nil)]
+                    rf.interop/schedule-after!   (fn [_thunk _ms] ::handle)
+                    rf.interop/cancel-scheduled! (fn [_h] nil)]
         (let [rt-waiting (server-runtime-db :hydrec/dyn dynamic-delay-machine [[:go]])
               rt-settled (server-runtime-db :hydrec/dyn dynamic-delay-machine
                                             [[:go] [:settle]])
@@ -273,7 +273,7 @@
                 "precondition: the re-resolution watcher is attached"))
 
           (reset! unsubs [])
-          (mtest/reset-captured!)
+          (rf.machines.test-support/reset-captured!)
           (install! cfid rt-settled)
 
           (is (empty? (inner cfid))
@@ -289,17 +289,17 @@
           ;; The watcher is DETACHED, which is the half a table check alone
           ;; cannot see: a surviving watcher re-enters the timer machinery on
           ;; the next value change.
-          (mtest/reset-captured!)
+          (rf.machines.test-support/reset-captured!)
           (reset! reaction 9000)
           (is (empty? (inner cfid))
               "a change in the delay's value arms nothing")
-          (is (empty? (mtest/events-of :rf.machine.timer/cancelled))
+          (is (empty? (rf.machines.test-support/events-of :rf.machine.timer/cancelled))
               (str "and reaches NOTHING at all. Under a union the stale "
                    "entry's watcher is still attached here, and this change "
                    "drives it into `on-sub-changed!` — an `:on-resolution` "
                    "cancellation of a timer that should have been released "
                    "one hydration ago."))
-          (is (empty? (mtest/events-of :rf.machine.timer/scheduled))
+          (is (empty? (rf.machines.test-support/events-of :rf.machine.timer/scheduled))
               "and re-resolves nothing"))))))
 
 ;; ---------------------------------------------------------------------------
@@ -312,12 +312,12 @@
             cancel-everything-then-re-arm"
     (rf/reg-machine :hydrec/same toggling-machine)
     (let [rt (server-runtime-db :hydrec/same toggling-machine [[:go]])]
-      (with-redefs [interop/schedule-after!   (fn [_thunk _ms] ::handle)
-                    interop/cancel-scheduled! (fn [_h] nil)]
+      (with-redefs [rf.interop/schedule-after!   (fn [_thunk _ms] ::handle)
+                    rf.interop/cancel-scheduled! (fn [_h] nil)]
         (let [cfid (fresh-frame! :client)]
           (install! cfid rt)
           (is (= 1 (count (inner cfid))))
-          (mtest/reset-captured!)
+          (rf.machines.test-support/reset-captured!)
           (install! cfid rt)
           (is (= 1 (count (inner cfid)))
               "still exactly one handle for the one live declaration")
@@ -333,8 +333,8 @@
     (rf/reg-machine :hydrec/sib toggling-machine)
     (let [rt-waiting (server-runtime-db :hydrec/sib toggling-machine [[:go]])
           rt-settled (server-runtime-db :hydrec/sib toggling-machine [[:go] [:settle]])]
-      (with-redefs [interop/schedule-after!   (fn [_thunk _ms] ::handle)
-                    interop/cancel-scheduled! (fn [_h] nil)]
+      (with-redefs [rf.interop/schedule-after!   (fn [_thunk _ms] ::handle)
+                    rf.interop/cancel-scheduled! (fn [_h] nil)]
         (let [keeper (fresh-frame! :client)
               mover  (fresh-frame! :client)]
           (install! keeper rt-waiting)
@@ -357,7 +357,7 @@
           ;; contract under test upstream), so the only way to put one in
           ;; front of the cancel phase is to place it there.
           k          {:parent :hydrec/srv :spawn [:waiting] :delay 5000}]
-      (swap! timer/after-timers assoc-in [sfid k]
+      (swap! rf.machines.timer/after-timers assoc-in [sfid k]
              {:handle ::handle :resolved-ms 5000 :epoch 1 :state :waiting
               :delay-source :literal :token -1})
       (try
@@ -367,4 +367,4 @@
         (is (empty? (cancelled-rows :hydrec/srv))
             "and no cancellation trace was emitted")
         (finally
-          (swap! timer/after-timers dissoc sfid))))))
+          (swap! rf.machines.timer/after-timers dissoc sfid))))))

--- a/implementation/machines/test/re_frame/machine_after_timer_fresh_causal_token_test.clj
+++ b/implementation/machines/test/re_frame/machine_after_timer_fresh_causal_token_test.clj
@@ -11,10 +11,10 @@
 
   THE IMPL (verified correct, NOT changed by this test). `timer.cljc`'s
   `schedule-after-timer!` installs the host-clock callback via
-  `interop/schedule-after!`; that callback calls the late-bound
+  `rf.interop/schedule-after!`; that callback calls the late-bound
   `:router/dispatch!` with `{:frame ... :source :after-timer}` and
   DELIBERATELY supplies NO `:rf.cofx`. So the router (build-envelope)
-  stamps a fresh `{:rf/time-ms (interop/epoch-now-ms)}` at fire time — the
+  stamps a fresh `{:rf/time-ms (rf.interop/epoch-now-ms)}` at fire time — the
   timer-driven guard/action reads the FIRE-time token, not the scheduling-
   time parent token.
 
@@ -30,10 +30,10 @@
   test fails on exactly that regression.
 
   THE RECIPE (adversarial clock separation).
-    1. Stub `interop/schedule-after!` to CAPTURE the timer-callback thunk
+    1. Stub `rf.interop/schedule-after!` to CAPTURE the timer-callback thunk
        (rather than scheduling it on the host clock) so the test owns the
        fire boundary deterministically.
-    2. Stub `interop/epoch-now-ms` to read a MUTABLE clock atom — the
+    2. Stub `rf.interop/epoch-now-ms` to read a MUTABLE clock atom — the
        router's fire-time stamp source.
     3. Enter the `:after`-bearing state under a parent dispatch supplying a
        known PARENT `:time-ms`. The clock atom holds the PARENT value at
@@ -47,19 +47,19 @@
        (fire-time, router-stamped) `:time-ms`, NOT the PARENT scripted one."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
             ;; Loaded for its boot side-effect: installs the machines
             ;; artefact's late-bind hooks (`rf/reg-machine` requires them).
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.router :as router]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.router :as rf.router]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 ;; Two clearly-non-ambient, clearly-distinct sentinels. PARENT is the
 ;; scripted token on the state-entry dispatch; CHILD is what the mutable
@@ -73,7 +73,7 @@
   (testing "the :after timer's dispatched event carries a FRESH router-
             stamped :rf.cofx :time-ms at FIRE time (not the parent
             scheduling-time token) — driven through the REAL
-            interop/schedule-after! fire boundary (rf2-hg39nf)"
+            rf.interop/schedule-after! fire boundary (rf2-hg39nf)"
     (let [;; The mutable host clock the router's epoch-now-ms reads. Starts
           ;; at the PARENT value; advanced to CHILD between schedule + fire.
           clock           (atom PARENT-TIME-MS)
@@ -102,16 +102,16 @@
                                                :action :stamp-fire-time}}}
                        :timeout {}}}
           ;; Preserve the production hooks/clock we are about to redefine.
-          orig-schedule   interop/schedule-after!
-          orig-dispatch!  (late-bind/get-fn :router/dispatch!)]
+          orig-schedule   rf.interop/schedule-after!
+          orig-dispatch!  (rf.late-bind/get-fn :router/dispatch!)]
       (rf/reg-machine :after-fresh/m m)
       (with-redefs [;; Capture the callback thunk instead of arming a real
                     ;; host timer — the test owns the fire boundary.
-                    interop/schedule-after!
+                    rf.interop/schedule-after!
                     (fn [f _ms] (reset! captured-thunk f) ::stub-handle)
                     ;; The router's fire-time stamp source — reads the
                     ;; mutable clock so advancing it shifts the fresh stamp.
-                    interop/epoch-now-ms (fn [] @clock)]
+                    rf.interop/epoch-now-ms (fn [] @clock)]
         ;; (1) Enter :loading under the PARENT token. The clock holds PARENT,
         ;; so even if the timer-fire wrongly inherited the parent token it
         ;; would equal PARENT here — but we ADVANCE the clock before firing,
@@ -134,10 +134,10 @@
         ;; {:frame ... :source :after-timer} and NO :rf.cofx, so the
         ;; router stamps {:rf/time-ms @clock} = CHILD afresh.
         (try
-          (late-bind/set-fn! :router/dispatch! router/dispatch-sync!)
+          (rf.late-bind/set-fn! :router/dispatch! rf.router/dispatch-sync!)
           (@captured-thunk)
           (finally
-            (late-bind/set-fn! :router/dispatch! orig-dispatch!))))
+            (rf.late-bind/set-fn! :router/dispatch! orig-dispatch!))))
 
       ;; (4) The transition actually fired through the real boundary.
       (is (= :timeout (:state (snapshot :after-fresh/m)))
@@ -160,5 +160,5 @@
            replay-stable causal write keyed off the timer-fire token")
 
       ;; sanity-restore guard (with-redefs already restored the clock + stub)
-      (is (identical? orig-schedule interop/schedule-after!)
-          "interop/schedule-after! restored after the redef scope"))))
+      (is (identical? orig-schedule rf.interop/schedule-after!)
+          "rf.interop/schedule-after! restored after the redef scope"))))

--- a/implementation/machines/test/re_frame/machine_after_timer_restore_quiesce_test.clj
+++ b/implementation/machines/test/re_frame/machine_after_timer_restore_quiesce_test.clj
@@ -18,15 +18,15 @@
   revive host work\")."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.machines :as machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.machines.timer :as timer]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.machines.timer :as rf.machines.timer]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; A :loading state with a long-delay :after — the host clock will not fire it
 ;; during the test; it lingers in the timer table so we can assert the handle
@@ -43,7 +43,7 @@
 
 (deftest hook-published
   (testing "the :machines/on-frame-restored! late-bind hook is published"
-    (is (some? (late-bind/get-fn :machines/on-frame-restored!)))))
+    (is (some? (rf.late-bind/get-fn :machines/on-frame-restored!)))))
 
 (deftest cancel-frame-timers-on-restore-releases-the-frames-handles
   (testing "rf2-u5kmf8 — cancel-frame-timers-on-restore! drops the frame's
@@ -53,13 +53,13 @@
     (rf/make-frame {:id :rq/sibling :doc "an unrelated concurrent frame"})
     (rf/dispatch-sync [:rq/m [:fetch]] {:frame :rq/restored})
     (rf/dispatch-sync [:rq/m [:fetch]] {:frame :rq/sibling})
-    (is (and (contains? @timer/after-timers :rq/restored)
-             (contains? @timer/after-timers :rq/sibling))
+    (is (and (contains? @rf.machines.timer/after-timers :rq/restored)
+             (contains? @rf.machines.timer/after-timers :rq/sibling))
         "precondition: both frames armed an :after timer")
-    (timer/cancel-frame-timers-on-restore! :rq/restored)
-    (is (not (contains? @timer/after-timers :rq/restored))
+    (rf.machines.timer/cancel-frame-timers-on-restore! :rq/restored)
+    (is (not (contains? @rf.machines.timer/after-timers :rq/restored))
         "the restored frame's armed timer handles are GONE after the quiesce")
-    (is (contains? @timer/after-timers :rq/sibling)
+    (is (contains? @rf.machines.timer/after-timers :rq/sibling)
         "a sibling frame's timers are untouched (frame-scoped quiesce)")))
 
 (deftest cancel-frame-timers-on-restore-emits-on-restore-reason
@@ -68,15 +68,15 @@
     (rf/reg-machine :rq2/m spec)
     (rf/make-frame {:id :rq2/f :doc "restore-reason trace frame"})
     (rf/dispatch-sync [:rq2/m [:fetch]] {:frame :rq2/f})
-    (is (seq (get @timer/after-timers :rq2/f)) "precondition: a timer is armed")
+    (is (seq (get @rf.machines.timer/after-timers :rq2/f)) "precondition: a timer is armed")
     (let [seen (atom [])
           k    ::on-restore-recorder]
-      (trace-tooling/register-listener!
+      (rf.trace.tooling/register-listener!
         k (fn [ev] (when (= :rf.machine.timer/cancelled (:operation ev))
                      (swap! seen conj ev))))
       (try
-        (timer/cancel-frame-timers-on-restore! :rq2/f)
-        (finally (trace-tooling/unregister-listener! k)))
+        (rf.machines.timer/cancel-frame-timers-on-restore! :rq2/f)
+        (finally (rf.trace.tooling/unregister-listener! k)))
       (is (seq @seen) "a :rf.machine.timer/cancelled trace fired")
       (is (every? #(= :on-restore (:reason (:tags %))) @seen)
           "every cancelled row carries :reason :on-restore")
@@ -85,7 +85,7 @@
 
 (deftest cancel-frame-timers-on-restore-noop-on-unarmed-frame
   (testing "rf2-u5kmf8 — quiescing a frame with no armed timers is a no-op"
-    (is (nil? (timer/cancel-frame-timers-on-restore! :rq/never-armed)))))
+    (is (nil? (rf.machines.timer/cancel-frame-timers-on-restore! :rq/never-armed)))))
 
 (deftest restore-quiesce-hook-clears-the-restored-frames-timers-end-to-end
   (testing "rf2-u5kmf8 — driving the published :machines/on-frame-restored!
@@ -93,7 +93,7 @@
     (rf/reg-machine :rq3/m spec)
     (rf/make-frame {:id :rq3/f :doc "end-to-end hook frame"})
     (rf/dispatch-sync [:rq3/m [:fetch]] {:frame :rq3/f})
-    (is (contains? @timer/after-timers :rq3/f) "precondition: a timer is armed")
-    ((late-bind/get-fn :machines/on-frame-restored!) :rq3/f)
-    (is (not (contains? @timer/after-timers :rq3/f))
+    (is (contains? @rf.machines.timer/after-timers :rq3/f) "precondition: a timer is armed")
+    ((rf.late-bind/get-fn :machines/on-frame-restored!) :rq3/f)
+    (is (not (contains? @rf.machines.timer/after-timers :rq3/f))
         "the published restore hook released the frame's armed timer handles")))

--- a/implementation/machines/test/re_frame/machine_algebra_view_test.clj
+++ b/implementation/machines/test/re_frame/machine_algebra_view_test.clj
@@ -30,16 +30,16 @@
   public facade export."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.machines.paths :as paths]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.machines.tooling :as mtooling]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as core-test-support]))
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.machines.tooling :as rf.machines.tooling]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; The fixed classifications EVERY machine-process node carries (Derivations
 ;; §Machines expose algebra views — the machine column: the canonical
@@ -79,26 +79,26 @@
   ;; registered by a sibling test ns (the reset fixture snapshot/restores rather
   ;; than `clear-all!`s), so assert the empty-registry contract against a
   ;; freshly-cleared registrar bracketed by snapshot/restore.
-  (let [snap (core-test-support/snapshot-registrar)]
+  (let [snap (rf.test-support/snapshot-registrar)]
     (try
-      (registrar/clear-all!)
+      (rf.registrar/clear-all!)
       (testing "(machine-algebra-view) returns {} (not nil) when no machines are registered"
-        (is (= {} (mtooling/machine-algebra-view)))
-        (is (map? (mtooling/machine-algebra-view))))
+        (is (= {} (rf.machines.tooling/machine-algebra-view)))
+        (is (map? (rf.machines.tooling/machine-algebra-view))))
       (testing "(machine-algebra-view machine-id) returns nil for an unregistered id"
-        (is (nil? (mtooling/machine-algebra-view :nope/missing))))
+        (is (nil? (rf.machines.tooling/machine-algebra-view :nope/missing))))
       (finally
-        (core-test-support/restore-registrar! snap)))))
+        (rf.test-support/restore-registrar! snap)))))
 
 (deftest jvm-alias-mirrors-the-tooling-fn
   (testing "the JVM `re-frame.machines/machine-*` aliases are the tooling fns"
     (rf/reg-machine :upload/main upload-machine)
-    (is (= (mtooling/machine-algebra-view)
-           (machines/machine-algebra-view))
+    (is (= (rf.machines.tooling/machine-algebra-view)
+           (rf.machines/machine-algebra-view))
         "machine-algebra-view alias projects identically to the tooling sibling")
-    (is (= mtooling/machine-selector? machines/machine-selector?)
+    (is (= rf.machines.tooling/machine-selector? rf.machines/machine-selector?)
         "machine-selector? alias is the tooling fn")
-    (is (= mtooling/machine-instance-algebra-view machines/machine-instance-algebra-view)
+    (is (= rf.machines.tooling/machine-instance-algebra-view rf.machines/machine-instance-algebra-view)
         "machine-instance-algebra-view alias is the tooling fn")))
 
 ;; ---- a registered machine exposes its process node -----------------------
@@ -106,13 +106,13 @@
 (deftest machine-exposes-its-full-process-node
   (testing "a reg-machine exposes the full machine-process / runtime-db / machine-instance node"
     (rf/reg-machine :upload/main upload-machine)
-    (let [node (get (mtooling/machine-algebra-view) :upload/main)]
+    (let [node (get (rf.machines.tooling/machine-algebra-view) :upload/main)]
       (is (some? node) "the machine is present in the static view")
       (is (has-fixed-classifications? node)
           "machine carries the fixed machine-process / runtime-db / machine-instance / materialized classifications")
       (is (= :upload/main (:id node)))
       (is (= {:kind :reg-machine :id :upload/main} (:source-form node)))
-      (is (= [:runtime (paths/snapshot-path :upload/main)] (:output node))
+      (is (= [:runtime (rf.machines.paths/snapshot-path :upload/main)] (:output node))
           "the output materializes the snapshot into runtime-db at the machine's snapshot path")
       (is (= [:machine :upload/main] (:owner node)))
       (is (false? (:spawns? node)) "this machine declares no :spawn"))))
@@ -120,7 +120,7 @@
 (deftest declared-event-inputs-are-walked-from-the-whole-state-tree
   (testing ":on event triggers across all states lower to sorted, de-duped [:event …] inputs"
     (rf/reg-machine :upload/main upload-machine)
-    (let [node (get (mtooling/machine-algebra-view) :upload/main)]
+    (let [node (get (rf.machines.tooling/machine-algebra-view) :upload/main)]
       (is (= [[:event :upload/failed]
               [:event :upload/progress]
               [:event :upload/start]
@@ -137,7 +137,7 @@
                           :*             :a            ;; wildcard — not a concrete input
                           :rf.machine/x  :b}}          ;; reserved ns — framework plumbing
                  :b {}}})
-    (let [node (get (mtooling/machine-algebra-view) :guarded/main)]
+    (let [node (get (rf.machines.tooling/machine-algebra-view) :guarded/main)]
       (is (= [[:event :go]] (:inputs node))
           "only the concrete app event :go survives the reserved-ns / wildcard filter"))))
 
@@ -146,7 +146,7 @@
 (deftest evaluation-is-on-transition-by-default
   (testing "a timer-less, spawn-less machine evaluates only :on-transition"
     (rf/reg-machine :plain/main {:initial :a :data {} :states {:a {:on {:go :b}} :b {}}})
-    (let [node (get (mtooling/machine-algebra-view) :plain/main)]
+    (let [node (get (rf.machines.tooling/machine-algebra-view) :plain/main)]
       (is (= #{:on-transition} (:evaluation node))))))
 
 (deftest after-timer-adds-scheduled-policy
@@ -156,7 +156,7 @@
        :data    {}
        :states  {:waiting {:after {1000 :timed-out}}
                  :timed-out {}}})
-    (let [node (get (mtooling/machine-algebra-view) :timed/main)]
+    (let [node (get (rf.machines.tooling/machine-algebra-view) :timed/main)]
       (is (= #{:on-transition :scheduled} (:evaluation node))
           ":after timer means a scheduler delivers a synthetic timer event"))))
 
@@ -168,7 +168,7 @@
        :data    {}
        :states  {:idle    {:on {:go :working}}
                  :working {:spawn {:machine-id :worker/child}}}})
-    (let [node (get (mtooling/machine-algebra-view) :parent/main)]
+    (let [node (get (rf.machines.tooling/machine-algebra-view) :parent/main)]
       (is (= #{:on-transition :on-reply} (:evaluation node))
           "a spawning parent reacts to its children's reply events")
       (is (true? (:spawns? node))))))
@@ -186,7 +186,7 @@
                   :states  {:dashboard {:on {:open-settings :settings}}
                             :settings  {:on {:close :dashboard}}}}
                  :loggedout {}}})
-    (let [node (get (mtooling/machine-algebra-view) :auth/flow)]
+    (let [node (get (rf.machines.tooling/machine-algebra-view) :auth/flow)]
       (is (= [[:event :close] [:event :logout] [:event :open-settings]]
              (:inputs node))
           "leaf + parent :on keys collected across the hierarchy, sorted"))))
@@ -200,7 +200,7 @@
                  {:type    :parallel
                   :regions {:left  {:initial :l0 :states {:l0 {:on {:left/go :l1}} :l1 {}}}
                             :right {:initial :r0 :states {:r0 {:on {:right/go :r1}} :r1 {}}}}}}})
-    (let [node (get (mtooling/machine-algebra-view) :par/main)]
+    (let [node (get (rf.machines.tooling/machine-algebra-view) :par/main)]
       (is (= [[:event :left/go] [:event :right/go]] (:inputs node))
           "both regions' :on keys surface as inputs"))))
 
@@ -209,7 +209,7 @@
 (deftest source-coords-surface-in-the-node
   (testing ":ns / :line / :file captured by reg-machine surface under :source"
     (rf/reg-machine :upload/main upload-machine)
-    (let [node   (get (mtooling/machine-algebra-view) :upload/main)
+    (let [node   (get (rf.machines.tooling/machine-algebra-view) :upload/main)
           source (:source node)]
       (is (some? source) ":source map is present when the registration carried coords")
       (is (some? (:ns source)) ":ns captured at the call site"))))
@@ -222,7 +222,7 @@
        :data    {:n 0}
        :schemas {:data [:map [:n :int]]}
        :states  {:a {:on {:go :b}} :b {}}})
-    (let [node (get (mtooling/machine-algebra-view) :doced/main)]
+    (let [node (get (rf.machines.tooling/machine-algebra-view) :doced/main)]
       (is (= [:map [:n :int]] (:schema node))
           "the machine's [:schemas :data] schema surfaces as the node :schema fact")
       (is (= "a documented machine" (:doc node))))))
@@ -230,7 +230,7 @@
 (deftest no-schema-or-doc-when-absent
   (testing ":schema / :doc are absent when the registration didn't supply them"
     (rf/reg-machine :upload/main upload-machine)
-    (let [node (get (mtooling/machine-algebra-view) :upload/main)]
+    (let [node (get (rf.machines.tooling/machine-algebra-view) :upload/main)]
       (is (not (contains? node :schema)))
       (is (not (contains? node :doc))))))
 
@@ -245,14 +245,14 @@
   (let [seed-id (keyword "test" (str "seed-" (name machine-id)))]
     (rf/reg-event seed-id
       (fn [{rt :rf.db/runtime} _]
-        {:rf.db/runtime (assoc-in (or rt {}) (paths/snapshot-path machine-id) snap)}))
+        {:rf.db/runtime (assoc-in (or rt {}) (rf.machines.paths/snapshot-path machine-id) snap)}))
     (rf/dispatch-sync [seed-id])))
 
 (deftest live-singleton-instance-projects
   (testing "a live singleton snapshot projects to an instance node with :state, not :spawned?"
     (rf/reg-machine :upload/main upload-machine)
     (seed-snapshot! :upload/main {:state :uploading :data {:progress 42}})
-    (let [view (mtooling/machine-instance-algebra-view :rf/default)
+    (let [view (rf.machines.tooling/machine-instance-algebra-view :rf/default)
           node (get view :upload/main)]
       (is (some? node) "the live singleton appears in the instance view")
       (is (has-fixed-classifications? node))
@@ -268,7 +268,7 @@
     ;; A spawned actor has NO per-instance registration — its snapshot carries
     ;; the reserved :rf/machine-type discriminator naming its registered type.
     (seed-snapshot! :worker#1 {:state :running :data {} :rf/machine-type :worker/child})
-    (let [view (mtooling/machine-instance-algebra-view :rf/default)
+    (let [view (rf.machines.tooling/machine-instance-algebra-view :rf/default)
           node (get view :worker#1)]
       (is (some? node) "the spawned actor appears in the instance view")
       (is (has-fixed-classifications? node))
@@ -276,7 +276,7 @@
       (is (= :running (:state node)))
       (is (= {:kind :reg-machine :id :worker/child} (:source-form node))
           "the actor's source-form names its resolved TYPE, not the actor-id")
-      (is (= [:runtime (paths/snapshot-path :worker#1)] (:output node))
+      (is (= [:runtime (rf.machines.paths/snapshot-path :worker#1)] (:output node))
           "the output is this INSTANCE's own snapshot slot")
       (is (= [[:event :tick]] (:inputs node))
           "inputs are derived from the resolved type spec"))))
@@ -284,7 +284,7 @@
 (deftest live-instance-view-empty-without-snapshots
   (testing "instance view is {} for a frame with registered-but-uninstantiated machines"
     (rf/reg-machine :upload/main upload-machine)
-    (is (= {} (mtooling/machine-instance-algebra-view :rf/default))
+    (is (= {} (rf.machines.tooling/machine-instance-algebra-view :rf/default))
         "no snapshot materialized yet → no live instance node")))
 
 ;; ---- machine-selector? recognizer ----------------------------------------
@@ -295,17 +295,17 @@
     (rf/reg-sub :upload/progress
       :<- [:rf/machine :upload/main]
       (fn [snapshot _] (get-in snapshot [:data :progress] 0)))
-    (is (true? (mtooling/machine-selector? :upload/progress))
+    (is (true? (rf.machines.tooling/machine-selector? :upload/progress))
         "a sub reading [:rf/machine …] is a machine selector"))
   (testing "a sub reading [:rf.machine/has-tag? …] is also a selector"
     (rf/reg-sub :upload/has-tag
       :<- [:rf.machine/has-tag? :upload/main :busy]
       (fn [has? _] has?))
-    (is (true? (mtooling/machine-selector? :upload/has-tag))))
+    (is (true? (rf.machines.tooling/machine-selector? :upload/has-tag))))
   (testing "an ordinary sub is NOT a machine selector; nor is an unregistered id"
     (rf/reg-sub :plain/sub (fn [db _] (:x db)))
-    (is (false? (mtooling/machine-selector? :plain/sub)))
-    (is (false? (mtooling/machine-selector? :nope/missing)))))
+    (is (false? (rf.machines.tooling/machine-selector? :plain/sub)))
+    (is (false? (rf.machines.tooling/machine-selector? :nope/missing)))))
 
 ;; ---- machine-selector-targets extractor ----------------------------------
 
@@ -315,13 +315,13 @@
     (rf/reg-sub :upload/progress
       :<- [:rf/machine :upload/main]
       (fn [snapshot _] (get-in snapshot [:data :progress] 0)))
-    (is (= #{:upload/main} (mtooling/machine-selector-targets :upload/progress))
+    (is (= #{:upload/main} (rf.machines.tooling/machine-selector-targets :upload/progress))
         "the second element of the [:rf/machine …] input is the target id"))
   (testing "extracts the target from a [:rf.machine/has-tag? machine-id tag] selector"
     (rf/reg-sub :upload/has-tag
       :<- [:rf.machine/has-tag? :upload/main :busy]
       (fn [has? _] has?))
-    (is (= #{:upload/main} (mtooling/machine-selector-targets :upload/has-tag))
+    (is (= #{:upload/main} (rf.machines.tooling/machine-selector-targets :upload/has-tag))
         "the has-tag? form's machine id (second element) is the target"))
   (testing "a selector reading two machines yields both targets"
     (rf/reg-sub :combined
@@ -329,12 +329,12 @@
       :<- [:rf/machine :download/main]
       (fn [[u d] _] [u d]))
     (is (= #{:upload/main :download/main}
-           (mtooling/machine-selector-targets :combined))
+           (rf.machines.tooling/machine-selector-targets :combined))
         "every [:rf/machine …] input contributes its target id"))
   (testing "a non-selector sub and an unregistered id yield #{}"
     (rf/reg-sub :plain/sub (fn [db _] (:x db)))
-    (is (= #{} (mtooling/machine-selector-targets :plain/sub)))
-    (is (= #{} (mtooling/machine-selector-targets :nope/missing))))
+    (is (= #{} (rf.machines.tooling/machine-selector-targets :plain/sub)))
+    (is (= #{} (rf.machines.tooling/machine-selector-targets :nope/missing))))
   (testing "the JVM facade alias is the tooling fn"
-    (is (= mtooling/machine-selector-targets machines/machine-selector-targets)
+    (is (= rf.machines.tooling/machine-selector-targets rf.machines/machine-selector-targets)
         "machine-selector-targets alias is the tooling fn")))

--- a/implementation/machines/test/re_frame/machine_cascade_instrumentation_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_cascade_instrumentation_cljs_test.cljc
@@ -28,24 +28,24 @@
   nowhere but the JVM and reads as covered (rf2-dn6v7, rf2-lgozq)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom])
-  ;; `mtest/with-trace-capture` is a `#?(:clj (defmacro …))` in a `.cljc`
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom])
+  ;; `rf.machines.test-support/with-trace-capture` is a `#?(:clj (defmacro …))` in a `.cljc`
   ;; support ns, so the CLJS analyzer needs it required as a MACRO ns under
   ;; the same alias; a plain `:require` leaves the call compiling to a
   ;; function call on an undefined var. This is the JVM-only assumption the
   ;; rf2-lgozq rename exposed — all seven tests here errored on the CLJS lane
   ;; with `No protocol method IDeref.-deref defined for type undefined` until
   ;; this line existed.
-  #?(:cljs (:require-macros [re-frame.machines.test-support :as mtest])))
+  #?(:cljs (:require-macros [re-frame.machines.test-support :as rf.machines.test-support])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
-;; Routed through the shared `mtest/with-trace-capture`
+;; Routed through the shared `rf.machines.test-support/with-trace-capture`
 ;; — guaranteed unregister in a `finally`.
 (defn- record-traces! [body-fn]
-  (mtest/with-trace-capture seen
+  (rf.machines.test-support/with-trace-capture seen
     (body-fn)
     @seen))
 
@@ -348,7 +348,7 @@
           cascade (cascade-of evs)
           raised  (raised-steps cascade)]
       ;; Premise: the FOLD is already correct — only the record was lossy.
-      (is (= :done (:state (mtest/snapshot :casc/settle)))
+      (is (= :done (:state (rf.machines.test-support/snapshot :casc/settle)))
           "the committed snapshot is :done — FIFO raise semantics")
       (is (= :idle (get-in tr [:tags :before :state])))
       (is (= :done (get-in tr [:tags :after :state]))
@@ -400,7 +400,7 @@
     (let [evs    (record-traces!
                    (fn [] (rf/dispatch-sync [:casc/fifo [:go]])))
           raised (raised-steps (cascade-of evs))]
-      (is (= :d (:state (mtest/snapshot :casc/fifo))))
+      (is (= :d (:state (rf.machines.test-support/snapshot :casc/fifo))))
       (is (= [[:first] [:second]] (mapv :event raised))
           "wrappers are ordered by actual FIFO dequeue order")
       (is (= [[:b :c] [:c :d]] (mapv (juxt :from :to) raised))
@@ -426,7 +426,7 @@
           cascade (cascade-of evs)
           raised  (raised-steps cascade)
           w       (first raised)]
-      (is (= :d (:state (mtest/snapshot :casc/raise-always))))
+      (is (= :d (:state (rf.machines.test-support/snapshot :casc/raise-always))))
       (is (= 1 (count raised)))
       (is (empty? (filterv #(= :microstep (:kind %)) cascade))
           "the :always did NOT settle at top level — it was enabled by the raise")
@@ -456,7 +456,7 @@
     (rf/dispatch-sync [:casc/ignored [:rf.machine/start]])
     (let [evs (record-traces!
                 (fn [] (rf/dispatch-sync [:casc/ignored [:go]])))]
-      (is (= :b (:state (mtest/snapshot :casc/ignored))))
+      (is (= :b (:state (rf.machines.test-support/snapshot :casc/ignored))))
       (is (empty? (raised-steps (cascade-of evs)))
           "an IGNORED raised event fabricates no handled-transition wrapper"))
     ;; reset to :a is not needed — re-register a fresh machine for the guard leg
@@ -472,7 +472,7 @@
     (rf/dispatch-sync [:casc/guarded [:rf.machine/start]])
     (let [evs (record-traces!
                 (fn [] (rf/dispatch-sync [:casc/guarded [:go]])))]
-      (is (= :b (:state (mtest/snapshot :casc/guarded)))
+      (is (= :b (:state (rf.machines.test-support/snapshot :casc/guarded)))
           "the guard blocked the raised transition — the machine rests at :b")
       (is (empty? (raised-steps (cascade-of evs)))
           "a GUARD-BLOCKED raised event fabricates no handled-transition wrapper"))))
@@ -520,7 +520,7 @@
                    (fn [] (rf/dispatch-sync [:casc/done [:go]])))
           raised (raised-steps (cascade-of evs))
           w      (first raised)]
-      (is (= :wrapped (:state (mtest/snapshot :casc/done)))
+      (is (= :wrapped (:state (rf.machines.test-support/snapshot :casc/done)))
           "the done signal advanced the enclosing compound")
       (is (= 1 (count raised))
           "the synthetic done signal rides the same raised-transition boundary")
@@ -557,7 +557,7 @@
           cascade (cascade-of evs)
           raised  (raised-steps cascade)
           w       (first raised)]
-      (is (= {:left :l1 :right :r1} (:state (mtest/snapshot :casc/par)))
+      (is (= {:left :l1 :right :r1} (:state (rf.machines.test-support/snapshot :casc/par)))
           "both regions moved — :go in :left, the raised :settle in :right")
       (is (= 1 (count raised))
           "the rebroadcast contributes ONE boundary (RED before rf2-nb8nj:
@@ -608,7 +608,7 @@
           cascade (cascade-of evs)
           w       (first (raised-steps cascade))
           round   (first (filterv #(= :microstep (:kind %)) cascade))]
-      (is (= {:main :r3 :aux :a0} (:state (mtest/snapshot :casc/par-chain)))
+      (is (= {:main :r3 :aux :a0} (:state (rf.machines.test-support/snapshot :casc/par-chain)))
           "the event, the raise it emitted, and the round the raise enabled all
            settle inside ONE macrostep")
       (is (= {:main :r0 :aux :a0} (get-in tr [:tags :before :state])))

--- a/implementation/machines/test/re_frame/machine_cofx_attach_test.clj
+++ b/implementation/machines/test/re_frame/machine_cofx_attach_test.clj
@@ -29,17 +29,17 @@
   routed-around green)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.machines :as machines]
-            [re-frame.machines.cofx-attach :as cofx-attach]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom])
+            [re-frame.interop :as rf.interop]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.cofx-attach :as rf.machines.cofx-attach]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom])
   (:import [clojure.lang ExceptionInfo]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 ;; A fixed wall-clock sentinel the host clock never spontaneously returns.
 (def ^:private SCRIPTED-TIME-MS 1234500000)
@@ -58,7 +58,7 @@
                                         :target :done}}}
                        :done {}}}
           e (is (thrown? ExceptionInfo
-                         (machines/make-machine-handler m)))]
+                         (rf.machines/make-machine-handler m)))]
       (is (= :rf.error/machine-cofx-requires-inline
              (:rf.error/id (ex-data e)))
           "the inline-on-slot declaration is the named error category"))))
@@ -74,7 +74,7 @@
              :states  {:idle {:on {:go {:target :done :guard :bad}}}
                        :done {}}}
           e (is (thrown? ExceptionInfo
-                         (machines/make-machine-handler m)))]
+                         (rf.machines/make-machine-handler m)))]
       (is (= :rf.error/machine-cofx-requires-inline
              (:rf.error/id (ex-data e)))))))
 
@@ -88,7 +88,7 @@
                                   (some? (:rf/time-ms cofx)))}}
              :states  {:idle {:on {:go {:target :done :guard :ok}}}
                        :done {}}}]
-      (is (some? (machines/make-machine-handler m))
+      (is (some? (rf.machines/make-machine-handler m))
           "the named entry form constructs a handler without throwing"))))
 
 ;; ===========================================================================
@@ -124,7 +124,7 @@
                         {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
       (is (= 6 @seen)
           "the guard read the GENERATED fact (not nil) — ensured before selection")
-      (is (= :done (mtest/machine-state :attach/guard-gen))
+      (is (= :done (rf.machines.test-support/machine-state :attach/guard-gen))
           "the guard fired the transition on the ensured generated value"))))
 
 (deftest always-closure-fact-ensured-in-same-macrostep
@@ -159,18 +159,18 @@
       ;; is generated BEFORE the macrostep that runs the :always action.
       (rf/dispatch-sync [:attach/always-closure [:go]]
                         {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
-      (let [d (mtest/machine-data :attach/always-closure)]
+      (let [d (rf.machines.test-support/machine-data :attach/always-closure)]
         (is (= 42 (:jitter d))
             "the :always action wrote the GENERATED jitter — the ensure-set
              closure reached through the candidate target")
-        (is (= :done (mtest/machine-state :attach/always-closure))
+        (is (= :done (rf.machines.test-support/machine-state :attach/always-closure))
             "the :always cascade settled on :done")))))
 
 (deftest ensure-set-for-includes-always-closure
   (testing "white-box: ensure-set-for derives the :always-closure id from a
             candidate target, not just the directly-touched guard/action"
     (rf/reg-cofx :test/jitter2 {:recordable? true} (fn [] 1))
-    (let [m (cofx-attach/index-ensure-sets
+    (let [m (rf.machines.cofx-attach/index-ensure-sets
               {:initial :idle
                :actions {:rec {:rf.cofx/requires [:test/jitter2]
                                :fn (fn [_] nil)}}
@@ -179,7 +179,7 @@
                          :done    {}}})
           ;; active state :idle, event [:go] → target :pending whose :always
           ;; action :rec requires :test/jitter2.
-          es (cofx-attach/ensure-set-for m {:state :idle :data {}} [:go])]
+          es (rf.machines.cofx-attach/ensure-set-for m {:state :idle :data {}} [:go])]
       (is (contains? (set (map :id es)) :test/jitter2)
           "the ensure-set for [:go] at :idle includes the :always-closure
            fact reachable through the :pending target"))))
@@ -201,7 +201,7 @@
             so a depth>=2 :always-reached guard's :rf.cofx/requires is in the
             ensure-set (not just the one-hop case)"
     (rf/reg-cofx :test/deep-roll {:recordable? true} (fn [] 6))
-    (let [m (cofx-attach/index-ensure-sets
+    (let [m (rf.machines.cofx-attach/index-ensure-sets
               {:initial :a
                :guards  {;; the deep guard sits TWO :always hops from :a's target
                          :deep? {:rf.cofx/requires [:test/deep-roll]
@@ -214,7 +214,7 @@
                          :c {:always {:guard :deep? :target :done}}
                          :done {}}})
           ;; active :a, [:go] → :b → (always) :c → (always, guarded) :done.
-          es (cofx-attach/ensure-set-for m {:state :a :data {}} [:go])]
+          es (rf.machines.cofx-attach/ensure-set-for m {:state :a :data {}} [:go])]
       (is (contains? (set (map :id es)) :test/deep-roll)
           "the ensure-set chases B:always→C, then C:always's guard — the
            depth>=2 fact is ensured, not dropped at the one-hop boundary"))))
@@ -245,7 +245,7 @@
       (is (= 6 @seen)
           "the depth>=2 :always guard read the GENERATED fact (not nil) —
            ensured before the macrostep settled the multi-hop :always chain")
-      (is (= :done (mtest/machine-state :attach/multi-hop-gen))
+      (is (= :done (rf.machines.test-support/machine-state :attach/multi-hop-gen))
           "the deep guard fired on the ensured value, settling the chain"))))
 
 (deftest multi-hop-always-missing-provided-fact-throws
@@ -255,13 +255,13 @@
             ensure step — the depth>=2 diet IS in the ensure-set, so the
             ensure step's missing-required check fires rather than the guard
             SILENTLY reading nil (the rf2-h9gwkx hole). Drives the real
-            ensure path (`cofx-attach/ensure-cofx`, run by `ensure-ctx-cofx`
+            ensure path (`rf.machines.cofx-attach/ensure-cofx`, run by `ensure-ctx-cofx`
             before the macrostep) so the throw surfaces verbatim rather than
             being routed into the dispatch-sync error pipeline."
     ;; :rf/time-ms is recordable + provided (no generator) — a strict
     ;; required fact. Declared on a depth>=2 :always guard but NOT present on
     ;; the record: the ensure step must surface missing-required, not nil.
-    (let [m (cofx-attach/index-ensure-sets
+    (let [m (rf.machines.cofx-attach/index-ensure-sets
               {:initial :a
                :data    {}
                :guards  {:needs-time?
@@ -274,7 +274,7 @@
                          :done {}}})
           ;; the empty record deliberately omits :rf/time-ms.
           e (is (thrown? ExceptionInfo
-                         (cofx-attach/ensure-cofx
+                         (rf.machines.cofx-attach/ensure-cofx
                            m {:state :a :data {}} [:go]
                            {} nil :attach/multi-hop-missing)))]
       (is (= :rf.error/missing-required-cofx
@@ -284,7 +284,7 @@
       ;; counter-check: confirm the depth>=2 fact is present in the derived
       ;; ensure-set (the positive of the throw) — the closure reaches it, so
       ;; it is never dropped to a silent-nil read.
-      (is (contains? (set (map :id (cofx-attach/ensure-set-for
+      (is (contains? (set (map :id (rf.machines.cofx-attach/ensure-set-for
                                      m {:state :a :data {}} [:go])))
                      :rf/time-ms)
           "the depth>=2 :always-guard's provided requires is in the ensure-set"))))
@@ -292,12 +292,12 @@
 (deftest no-requires-machine-ensure-set-empty
   (testing "a machine with no :rf.cofx/requires anywhere derives an empty
             ensure-set (the no-op fast path)"
-    (let [m (cofx-attach/index-ensure-sets
+    (let [m (rf.machines.cofx-attach/index-ensure-sets
               {:initial :idle
                :guards  {:g (fn [_] true)}
                :states  {:idle {:on {:go {:target :done :guard :g}}}
                          :done {}}})]
-      (is (empty? (cofx-attach/ensure-set-for m {:state :idle :data {}} [:go]))
+      (is (empty? (rf.machines.cofx-attach/ensure-set-for m {:state :idle :data {}} [:go]))
           "no declared requires → empty ensure-set"))))
 
 ;; ===========================================================================
@@ -322,7 +322,7 @@
                         {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
       (is (= SCRIPTED-TIME-MS @seen)
           "the named guard read the provided :rf/time-ms off the record")
-      (is (= :done (mtest/machine-state :attach/entry-guard))
+      (is (= :done (rf.machines.test-support/machine-state :attach/entry-guard))
           "the guard fired on the delivered fact"))))
 
 (deftest named-action-requires-fact-folded-into-data
@@ -340,7 +340,7 @@
       (rf/dispatch-sync [:attach/entry-action [:go]]
                         {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
       (is (= SCRIPTED-TIME-MS
-             (:stamped-at (mtest/machine-data :attach/entry-action)))
+             (:stamped-at (rf.machines.test-support/machine-data :attach/entry-action)))
           "the named action wrote the recorded :rf/time-ms into :data"))))
 
 (deftest generated-fact-written-back-into-causal-record
@@ -359,7 +359,7 @@
       (rf/reg-machine :attach/writeback m)
       (rf/dispatch-sync [:attach/writeback [:go]]
                         {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
-      (is (= :GENERATED (:captured (mtest/machine-data :attach/writeback)))
+      (is (= :GENERATED (:captured (rf.machines.test-support/machine-data :attach/writeback)))
           "the action read the GENERATED fact off the augmented record"))))
 
 ;; ===========================================================================
@@ -376,12 +376,12 @@
              :states  {:idle {:on {:go {:target :done :guard :g}}}
                        :done {}}}
           ;; reg-machine* installs the index; drive the pure engine directly.
-          handler (machines/make-machine-handler m)]
+          handler (rf.machines/make-machine-handler m)]
       (is (some? handler)
           "registration succeeds (named entry, legal)")
       ;; The pure engine path carries no :rf/cofx, so the guard's cofx is nil
       ;; and the ensure step is bypassed — no throw.
-      (is (some? (machines/machine-transition m {:state :idle :data {}} [:go]))
+      (is (some? (rf.machines/machine-transition m {:state :idle :data {}} [:go]))
           "the pure engine runs without a token and without an ensure error"))))
 
 ;; ===========================================================================
@@ -406,7 +406,7 @@
             ROOT :on candidate's guard/action requires (the ancestor fallback
             the runtime resolves separately) — not just the regions' scopes"
     (rf/reg-cofx :test/root-roll {:recordable? true} (fn [] 6))
-    (let [m (cofx-attach/index-ensure-sets
+    (let [m (rf.machines.cofx-attach/index-ensure-sets
               {:type    :parallel
                :data    {}
                :guards  {:root-rolled-six?
@@ -418,7 +418,7 @@
                                   :guard  :root-rolled-six?}}
                :regions {:a {:initial :one :states {:one {} :two {}}}
                          :b {:initial :one :states {:one {} :two {}}}}})
-          es (cofx-attach/ensure-set-for
+          es (rf.machines.cofx-attach/ensure-set-for
                m {:state {:a :one :b :one} :data {}} [:go-all])]
       (is (contains? (set (map :id es)) :test/root-roll)
           "the ensure-set includes the ROOT :on guard's requires — before
@@ -430,7 +430,7 @@
             ([:rf.machine.timer/after-elapsed delay epoch []]) includes the
             ROOT :after candidate's requires"
     (rf/reg-cofx :test/root-jitter {:recordable? true} (fn [] 7))
-    (let [m (cofx-attach/index-ensure-sets
+    (let [m (rf.machines.cofx-attach/index-ensure-sets
               {:type    :parallel
                :data    {}
                :actions {:root-stamp
@@ -442,7 +442,7 @@
                :regions {:a {:initial :one :states {:one {} :two {}}}
                          :b {:initial :one :states {:one {} :two {}}}}})
           ;; the root timer carries decl-path [] (root-owned, not region-prefixed)
-          es (cofx-attach/ensure-set-for
+          es (rf.machines.cofx-attach/ensure-set-for
                m {:state {:a :one :b :one}
                   :data  {:rf/after-epoch {[] 1}}}
                [:rf.machine.timer/after-elapsed 1000 1 []])]
@@ -486,7 +486,7 @@
             required from the dispatch-time ensure step — the root surface IS
             in the ensure-set now (before rf2-bu106a it was dropped, so the
             guard would have silently read nil)"
-    (let [m (cofx-attach/index-ensure-sets
+    (let [m (rf.machines.cofx-attach/index-ensure-sets
               {:type    :parallel
                :data    {}
                :guards  {:needs-time?
@@ -498,13 +498,13 @@
                          :b {:initial :one :states {:one {} :two {}}}}})
           ;; empty record deliberately omits :rf/time-ms.
           e (is (thrown? ExceptionInfo
-                         (cofx-attach/ensure-cofx
+                         (rf.machines.cofx-attach/ensure-cofx
                            m {:state {:a :one :b :one} :data {}} [:go-all]
                            {} nil :attach/parallel-root-missing)))]
       (is (= :rf.error/missing-required-cofx (:rf.error/id (ex-data e)))
           "the root :on-required provided fact, absent, throws missing-required
            (it WAS in the ensure-set) — not a silent nil")
-      (is (contains? (set (map :id (cofx-attach/ensure-set-for
+      (is (contains? (set (map :id (rf.machines.cofx-attach/ensure-set-for
                                      m {:state {:a :one :b :one} :data {}}
                                      [:go-all])))
                      :rf/time-ms)
@@ -537,7 +537,7 @@
                                            {:target :b}]}
                        :a {} :b {}}}
           e (is (thrown? ExceptionInfo
-                         (machines/make-machine-handler m)))]
+                         (rf.machines/make-machine-handler m)))]
       (is (= :rf.error/machine-cofx-requires-inline
              (:rf.error/id (ex-data e)))
           "the inline-on-choice-candidate declaration is rejected"))))
@@ -549,7 +549,7 @@
             choice target) — before rf2-4y4bzq always-entries read (:always
             choice-node)=nil and the fact was dropped"
     (rf/reg-cofx :test/choice-roll {:recordable? true} (fn [] 6))
-    (let [m (cofx-attach/index-ensure-sets
+    (let [m (rf.machines.cofx-attach/index-ensure-sets
               {:initial :idle
                :guards  {:needs-roll {:rf.cofx/requires [:test/choice-roll]
                                       :fn (fn [_] true)}}
@@ -558,7 +558,7 @@
                                     :choice [{:guard :needs-roll :target :a}
                                              {:target :b}]}
                          :a {} :b {}}})
-          es (cofx-attach/ensure-set-for m {:state :idle :data {}} [:go])]
+          es (rf.machines.cofx-attach/ensure-set-for m {:state :idle :data {}} [:go])]
       (is (contains? (set (map :id es)) :test/choice-roll)
           "the ensure-set for [:go] at :idle includes the choice candidate
            guard's requires — reachable through the :checking choice target"))))
@@ -592,7 +592,7 @@
       (is (= 6 @seen)
           "the choice candidate guard read the GENERATED :test/roll (not nil) —
            ensured before the choice settled")
-      (is (= :hit (mtest/machine-state :attach/choice-guard))
+      (is (= :hit (rf.machines.test-support/machine-state :attach/choice-guard))
           "the choice routed to :hit on the ensured value"))))
 
 ;; ===========================================================================
@@ -613,7 +613,7 @@
             :after candidate's requires — the :after slot the :on walk missed
             (rf2-iyrc9t)"
     (rf/reg-cofx :test/token {:recordable? true} (fn [] :T))
-    (let [m (cofx-attach/index-ensure-sets
+    (let [m (rf.machines.cofx-attach/index-ensure-sets
               {:initial :waiting
                :data    {}
                :guards  {:needs-token
@@ -623,7 +623,7 @@
                                                  :target :done}}}
                          :done    {}}})
           ;; the state timer carries the scheduling node's decl-path [:waiting].
-          es (cofx-attach/ensure-set-for
+          es (rf.machines.cofx-attach/ensure-set-for
                m {:state :waiting :data {}}
                [:rf.machine.timer/after-elapsed 5000 1 [:waiting]])]
       (is (contains? (set (map :id es)) :test/token)
@@ -637,7 +637,7 @@
             scope (region head stripped) and adds the region-state :after
             candidate's requires (rf2-iyrc9t — the region path)"
     (rf/reg-cofx :test/region-token {:recordable? true} (fn [] :RT))
-    (let [m (cofx-attach/index-ensure-sets
+    (let [m (rf.machines.cofx-attach/index-ensure-sets
               {:type    :parallel
                :data    {}
                :guards  {:needs-region-token
@@ -649,7 +649,7 @@
                                        :done    {}}}
                          :b {:initial :one :states {:one {} :two {}}}}})
           ;; region-a timer: decl-path is region-qualified [:a :waiting].
-          es (cofx-attach/ensure-set-for
+          es (rf.machines.cofx-attach/ensure-set-for
                m {:state {:a :waiting :b :one} :data {}}
                [:rf.machine.timer/after-elapsed 3000 1 [:a :waiting]])]
       (is (contains? (set (map :id es)) :test/region-token)
@@ -711,18 +711,18 @@
       (is (= 6 @seen)
           "the inline-literal guard read the ENSURED generated fact (not nil) —
            the ensure-index saw :rf.cofx/requires at the entry top level")
-      (is (= :done (mtest/machine-state :ful212/inline-dev))
+      (is (= :done (rf.machines.test-support/machine-state :ful212/inline-dev))
           "the guard :fn resolved to the fn (not the double-wrapped map) and
            fired the transition"))))
 
 (deftest inline-literal-named-cofx-guard-fires-prod-arm
   (testing "rf2-ful212 (prod arm): the SAME inline-literal named-cofx guard,
-            registered under `interop/debug-enabled? false` (macro prod arm →
+            registered under `rf.interop/debug-enabled? false` (macro prod arm →
             wrap-element-fns), also resolves + fires — wrap-element-fns
             preserves the entry-map verbatim rather than double-wrapping it. The
             ensure-index is NOT dev-gated, so the fix must hold in prod too."
     (rf/reg-cofx :test/roll {:recordable? true} (fn [] 6))
-    (with-redefs [interop/debug-enabled? false]
+    (with-redefs [rf.interop/debug-enabled? false]
       (rf/reg-machine :ful212/inline-prod
         {:initial :idle
          :data    {}
@@ -733,7 +733,7 @@
                    :done {}}}))
     (rf/dispatch-sync [:ful212/inline-prod [:go]]
                       {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
-    (is (= :done (mtest/machine-state :ful212/inline-prod))
+    (is (= :done (rf.machines.test-support/machine-state :ful212/inline-prod))
         "the prod-arm (wrap-element-fns) entry-map is preserved verbatim, so the
          guard resolves + fires on the ensured generated value")))
 
@@ -747,6 +747,6 @@
     (rf/reg-machine :ful212/defmachine ful212-defmachine)
     (rf/dispatch-sync [:ful212/defmachine [:go]]
                       {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
-    (is (= :done (mtest/machine-state :ful212/defmachine))
+    (is (= :done (rf.machines.test-support/machine-state :ful212/defmachine))
         "the defmachine-stamped named-cofx guard resolved its cofx and fired —
          the entry-map was collocated without double-wrapping")))

--- a/implementation/machines/test/re_frame/machine_cofx_lifecycle_test.clj
+++ b/implementation/machines/test/re_frame/machine_cofx_lifecycle_test.clj
@@ -24,14 +24,14 @@
   action, and a bootstrap initial-entry action."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.machines.cofx-attach :as cofx-attach]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom])
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.cofx-attach :as rf.machines.cofx-attach]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom])
   (:import [clojure.lang ExceptionInfo]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (def ^:private SCRIPTED-TIME-MS 1234500000)
 
@@ -44,13 +44,13 @@
             :rf.cofx/requires of the TARGET state's named :entry action — the
             exit→action→entry cascade will run it"
     (rf/reg-cofx :test/entry-roll {:recordable? true} (fn [] 6))
-    (let [m  (cofx-attach/index-ensure-sets
+    (let [m  (rf.machines.cofx-attach/index-ensure-sets
                {:initial :idle
                 :actions {:stamp-entry {:rf.cofx/requires [:test/entry-roll]
                                         :fn (fn [_] nil)}}
                 :states  {:idle {:on {:go :active}}
                           :active {:entry :stamp-entry}}})
-          es (cofx-attach/ensure-set-for m {:state :idle :data {}} [:go])]
+          es (rf.machines.cofx-attach/ensure-set-for m {:state :idle :data {}} [:go])]
       (is (contains? (set (map :id es)) :test/entry-roll)
           "target-state :entry action's required fact is in the ensure-set"))))
 
@@ -59,13 +59,13 @@
             :rf.cofx/requires of the ACTIVE state's named :exit action — it
             runs as the first leg of the exit→action→entry cascade"
     (rf/reg-cofx :test/exit-roll {:recordable? true} (fn [] 6))
-    (let [m  (cofx-attach/index-ensure-sets
+    (let [m  (rf.machines.cofx-attach/index-ensure-sets
                {:initial :active
                 :actions {:stamp-exit {:rf.cofx/requires [:test/exit-roll]
                                        :fn (fn [_] nil)}}
                 :states  {:active {:exit :stamp-exit :on {:go :idle}}
                           :idle   {}}})
-          es (cofx-attach/ensure-set-for m {:state :active :data {}} [:go])]
+          es (rf.machines.cofx-attach/ensure-set-for m {:state :active :data {}} [:go])]
       (is (contains? (set (map :id es)) :test/exit-roll)
           "active-state :exit action's required fact is in the ensure-set"))))
 
@@ -74,14 +74,14 @@
             ensure-set includes the :entry actions of every node entered on the
             initial-descent path"
     (rf/reg-cofx :test/descent-roll {:recordable? true} (fn [] 6))
-    (let [m  (cofx-attach/index-ensure-sets
+    (let [m  (rf.machines.cofx-attach/index-ensure-sets
                {:initial :idle
                 :actions {:descent-stamp {:rf.cofx/requires [:test/descent-roll]
                                           :fn (fn [_] nil)}}
                 :states  {:idle {:on {:go :parent}}
                           :parent {:initial :child
                                    :states {:child {:entry :descent-stamp}}}}})
-          es (cofx-attach/ensure-set-for m {:state :idle :data {}} [:go])]
+          es (rf.machines.cofx-attach/ensure-set-for m {:state :idle :data {}} [:go])]
       (is (contains? (set (map :id es)) :test/descent-roll)
           "the initial-descent :child :entry action's fact is in the ensure-set"))))
 
@@ -105,7 +105,7 @@
       (rf/reg-machine :lifecycle/entry-gen m)
       (rf/dispatch-sync [:lifecycle/entry-gen [:go]]
                         {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
-      (is (= 6 (:roll (mtest/machine-data :lifecycle/entry-gen)))
+      (is (= 6 (:roll (rf.machines.test-support/machine-data :lifecycle/entry-gen)))
           "the :entry action wrote the GENERATED fact — ensured before the cascade"))))
 
 (deftest exit-action-reads-generated-fact
@@ -123,7 +123,7 @@
       (rf/reg-machine :lifecycle/exit-gen m)
       (rf/dispatch-sync [:lifecycle/exit-gen [:go]]
                         {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
-      (is (= 7 (:exit-roll (mtest/machine-data :lifecycle/exit-gen)))
+      (is (= 7 (:exit-roll (rf.machines.test-support/machine-data :lifecycle/exit-gen)))
           "the :exit action wrote the GENERATED fact — ensured before the cascade"))))
 
 (deftest exit-action-missing-provided-fact-throws
@@ -131,7 +131,7 @@
             action, absent from the in-flight record, raises missing-required
             from the dispatch-time ensure step — the :exit diet IS in the
             ensure-set (drives the real ensure path)"
-    (let [m (cofx-attach/index-ensure-sets
+    (let [m (rf.machines.cofx-attach/index-ensure-sets
               {:initial :active
                :data    {}
                :actions {:needs-time {:rf.cofx/requires [:rf/time-ms]
@@ -140,7 +140,7 @@
                :states  {:active {:exit :needs-time :on {:go :idle}}
                          :idle   {}}})
           e (is (thrown? ExceptionInfo
-                         (cofx-attach/ensure-cofx
+                         (rf.machines.cofx-attach/ensure-cofx
                            m {:state :active :data {}} [:go]
                            {} nil :lifecycle/exit-missing)))]
       (is (= :rf.error/missing-required-cofx (:rf.error/id (ex-data e)))
@@ -168,7 +168,7 @@
       ;; The eager start kick runs the initial-entry cascade in maybe-boot.
       (rf/dispatch-sync [:lifecycle/birth-gen [:rf.machine/start]]
                         {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
-      (is (= 9 (:birth (mtest/machine-data :lifecycle/birth-gen)))
+      (is (= 9 (:birth (rf.machines.test-support/machine-data :lifecycle/birth-gen)))
           "the initial-entry action wrote the GENERATED fact — ensured before
            maybe-boot ran the bootstrap cascade"))))
 
@@ -188,5 +188,5 @@
       (rf/reg-machine :lifecycle/descent-gen m)
       (rf/dispatch-sync [:lifecycle/descent-gen [:rf.machine/start]]
                         {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
-      (is (= 11 (:d (mtest/machine-data :lifecycle/descent-gen)))
+      (is (= 11 (:d (rf.machines.test-support/machine-data :lifecycle/descent-gen)))
           "the initial-descent :entry action read the GENERATED fact at birth"))))

--- a/implementation/machines/test/re_frame/machine_cofx_lint_test.clj
+++ b/implementation/machines/test/re_frame/machine_cofx_lint_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.machine-cofx-lint-test
-  "Dev-only consumer-attachment LINTS (`cofx-attach/lint-machine!`, wired
+  "Dev-only consumer-attachment LINTS (`rf.machines.cofx-attach/lint-machine!`, wired
   into the registration home at `lifecycle_fx/registration.cljc:1140` via
   `(lint-machine! machine-id (index-ensure-sets machine))`). Two
   recommendation-grade diagnostics, both DCE'd in production:
@@ -21,15 +21,15 @@
   maps."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.machines :as machines]
-            [re-frame.machines.cofx-attach :as cofx-attach]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.interop :as rf.interop]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.cofx-attach :as rf.machines.cofx-attach]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter})
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter})
+  rf.machines.test-support/trace-capture-fixture)
 
 (def ^:private AMBIENT :rf.warning/machine-cofx-ambient-durable)
 (def ^:private CONSUME :rf.warning/machine-cofx-consume-undeclared)
@@ -38,9 +38,9 @@
   "Drive the lint exactly as the registration home does (registration.cljc
   :1140): index the raw machine, then run the lints tagged with `machine-id`."
   [machine-id machine]
-  (cofx-attach/lint-machine! machine-id (cofx-attach/index-ensure-sets machine)))
+  (rf.machines.cofx-attach/lint-machine! machine-id (rf.machines.cofx-attach/index-ensure-sets machine)))
 
-(defn- warns [op] (mtest/events-of op))
+(defn- warns [op] (rf.machines.test-support/events-of op))
 
 ;; ===========================================================================
 ;; 1. ambient-durable — POSITIVE + negatives (works end-to-end today)
@@ -286,7 +286,7 @@
 ;; ===========================================================================
 
 (deftest lint-is-a-noop-in-production
-  (testing "under `interop/debug-enabled? false` (the production gate)
+  (testing "under `rf.interop/debug-enabled? false` (the production gate)
             lint-machine! runs no checks and emits nothing — for BOTH a
             machine that would trip ambient-durable and one that would trip
             consume-undeclared"
@@ -304,7 +304,7 @@
                                                    (:lint/undeclared4 cofx))}}
                      :states  {:idle {:on {:go {:target :done :guard :g}}}
                                :done {}}}]
-      (with-redefs [interop/debug-enabled? false]
+      (with-redefs [rf.interop/debug-enabled? false]
         (lint! :prod/ambient ambient-m)
         (lint! :prod/consume consume-m))
       (is (empty? (warns AMBIENT))  "no ambient-durable warning in production")

--- a/implementation/machines/test/re_frame/machine_cofx_mint_policy_test.clj
+++ b/implementation/machines/test/re_frame/machine_cofx_mint_policy_test.clj
@@ -22,14 +22,14 @@
   not a routed-around green."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.machines.cofx-attach :as cofx-attach]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom])
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.cofx-attach :as rf.machines.cofx-attach]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom])
   (:import [clojure.lang ExceptionInfo]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (def ^:private SCRIPTED-TIME-MS 1234500000)
 
@@ -46,7 +46,7 @@
             such throws into its error pipeline, so this white-box path is the
             deterministic throw surface."
     (rf/reg-cofx :mint/roll {:recordable? true} (fn [] 6))
-    (let [m (cofx-attach/index-ensure-sets
+    (let [m (rf.machines.cofx-attach/index-ensure-sets
               {:initial :idle
                :data    {}
                :guards  {:rolled-six?
@@ -57,7 +57,7 @@
           ;; the token has no :mint/roll; under :strict the ensure must throw
           ;; missing-required (not mint).
           e (is (thrown? ExceptionInfo
-                         (cofx-attach/ensure-cofx
+                         (rf.machines.cofx-attach/ensure-cofx
                            m {:state :idle :data {}} [:go]
                            {} nil :mint/strict-guard :strict)))]
       (is (= :rf.error/missing-required-cofx (:rf.error/id (ex-data e)))
@@ -82,7 +82,7 @@
       (rf/dispatch-sync [:mint/strict-noadvance [:go]]
                         {:rf.cofx           {:rf/time-ms SCRIPTED-TIME-MS}
                          :rf.cofx/mint-policy :strict})
-      (is (not= :done (mtest/machine-state :mint/strict-noadvance))
+      (is (not= :done (rf.machines.test-support/machine-state :mint/strict-noadvance))
           "strict refused to mint → the guard fact was missing-required → the
            macrostep failed atomically → the machine did NOT advance to :done"))))
 
@@ -108,7 +108,7 @@
                         {:rf.cofx           {:rf/time-ms SCRIPTED-TIME-MS}
                          :rf.cofx/mint-policy :explicit-live})
       (is (= 6 @seen) "explicit-live generated the fact the guard read")
-      (is (= :done (mtest/machine-state :mint/live-guard))
+      (is (= :done (rf.machines.test-support/machine-state :mint/live-guard))
           "the guard fired on the generated value"))))
 
 (deftest default-live-still-mints
@@ -130,16 +130,16 @@
       (rf/dispatch-sync [:mint/default-guard [:go]]
                         {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
       (is (= 6 @seen) "default :live minted the fact")
-      (is (= :done (mtest/machine-state :mint/default-guard))))))
+      (is (= :done (rf.machines.test-support/machine-state :mint/default-guard))))))
 
 (deftest strict-bootstrap-ensure-refuses-to-mint-birth-fact-throws
-  (testing "white-box: the BIRTH ensure step (`cofx-attach/bootstrap-ensure-
+  (testing "white-box: the BIRTH ensure step (`rf.machines.cofx-attach/bootstrap-ensure-
             cofx`) under `:strict` refuses to mint a generator-backed initial-
             entry action fact and raises missing-required — the frame-config /
             replay path the :test preset selects. Drives the real bootstrap
             ensure path"
     (rf/reg-cofx :mint/birth-roll {:recordable? true} (fn [] 9))
-    (let [m (cofx-attach/index-ensure-sets
+    (let [m (rf.machines.cofx-attach/index-ensure-sets
               {:initial :booting
                :data    {}
                :actions {:stamp-birth
@@ -148,7 +148,7 @@
                                 {:data (assoc data :birth (:mint/birth-roll cofx))})}}
                :states  {:booting {:entry :stamp-birth}}})
           e (is (thrown? ExceptionInfo
-                         (cofx-attach/bootstrap-ensure-cofx
+                         (rf.machines.cofx-attach/bootstrap-ensure-cofx
                            m {} nil :mint/strict-birth :strict)))]
       (is (= :rf.error/missing-required-cofx (:rf.error/id (ex-data e)))
           "strict refused to mint the birth :entry action's generator-backed fact"))))
@@ -168,7 +168,7 @@
       (rf/reg-machine :mint/live-birth m)
       (rf/dispatch-sync [:mint/live-birth [:rf.machine/start]]
                         {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
-      (is (= 9 (:birth (mtest/machine-data :mint/live-birth)))
+      (is (= 9 (:birth (rf.machines.test-support/machine-data :mint/live-birth)))
           "default :live minted the birth :entry fact"))))
 
 ;; ===========================================================================
@@ -202,7 +202,7 @@
       (is (= 6 @seen)
           "the RAISED event's guard read the GENERATED fact (not nil) —
            ensured before the raised transition's selection")
-      (is (= :done (mtest/machine-state :raise/user-guard))
+      (is (= :done (rf.machines.test-support/machine-state :raise/user-guard))
           "the raised event's guard fired on the ensured value"))))
 
 (deftest raised-user-event-strict-missing-fact-throws
@@ -213,7 +213,7 @@
             nil (the rf2-xsdn5h hole). Drives `machine-transition` directly with
             a `:rf/cofx`-carrying machine so the throw surfaces verbatim
             (dispatch-sync captures it into the error pipeline)"
-    (let [m (-> (cofx-attach/index-ensure-sets
+    (let [m (-> (rf.machines.cofx-attach/index-ensure-sets
                   {:initial :a
                    :data    {}
                    :guards  {:needs-time?
@@ -227,7 +227,7 @@
                 ;; + the :strict policy, exactly as the live handler stamps them.
                 (assoc :rf/cofx {} :rf/cofx-mint-policy :strict))
           e (is (thrown? ExceptionInfo
-                         (machines/machine-transition m {:state :a :data {}} [:go])))]
+                         (rf.machines/machine-transition m {:state :a :data {}} [:go])))]
       (is (= :rf.error/missing-required-cofx (:rf.error/id (ex-data e)))
           "the RAISED event's provided-fact requirement surfaced missing-required
            from the in-engine ensure — not a silent nil"))))
@@ -260,7 +260,7 @@
       (is (= 6 @seen)
           "the synthetic :on-done raised-done guard read the GENERATED fact —
            ensured for the raised done signal")
-      (is (= :done (mtest/machine-state :raise/compound-done))
+      (is (= :done (rf.machines.test-support/machine-state :raise/compound-done))
           "the :on-done fired on the ensured value"))))
 
 (deftest parallel-region-raise-guard-fact-ensured
@@ -293,7 +293,7 @@
           "the re-broadcast raised event's region guard read the GENERATED fact
            — ensured at the parent before the re-broadcast")
       (is (= {:left :two :right :two}
-             (:state (mtest/snapshot :raise/parallel-region)))
+             (:state (rf.machines.test-support/snapshot :raise/parallel-region)))
           "both regions advanced: :left on :go, :right on the ensured :inner"))))
 
 ;; ===========================================================================
@@ -310,7 +310,7 @@
                                      :data {:legit 1}})}
              :states  {:a {:on {:go {:target :b :action :bad}}} :b {}}}]
       (rf/reg-machine :wrote-db/sensitive m)
-      (mtest/with-trace-capture seen
+      (rf.machines.test-support/with-trace-capture seen
         (rf/dispatch-sync [:wrote-db/sensitive [:go]])
         (let [errs (filterv #(= :rf.error/machine-action-wrote-db (:operation %)) @seen)]
           (is (= 1 (count errs)) "exactly one wrote-db error")
@@ -337,7 +337,7 @@
              :states  {:a {:on {:go {:target :a :action :patch}}}}}]
       (rf/reg-machine :wrote-db/upd m)
       (rf/dispatch-sync [:wrote-db/upd [:noop]])
-      (mtest/with-trace-capture seen
+      (rf.machines.test-support/with-trace-capture seen
         (rf/dispatch-sync [:wrote-db/upd [:go]])
         (let [errs (filterv #(= :rf.error/machine-action-wrote-db (:operation %)) @seen)]
           (is (= 1 (count errs)) "exactly one wrote-db error from the escape hatch")

--- a/implementation/machines/test/re_frame/machine_cofx_sub_source_test.clj
+++ b/implementation/machines/test/re_frame/machine_cofx_sub_source_test.clj
@@ -26,15 +26,15 @@
        `:rf.error/missing-required-cofx` (loud, never re-derived)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.cofx :as cofx]
-            [re-frame.machines :as machines]
-            [re-frame.machines.cofx-attach :as cofx-attach]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom])
+            [re-frame.cofx :as rf.cofx]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.cofx-attach :as rf.machines.cofx-attach]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom])
   (:import [clojure.lang ExceptionInfo]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; A fixed wall-clock sentinel the host clock never spontaneously returns.
 (def ^:private SCRIPTED-TIME-MS 1234500000)
@@ -47,7 +47,7 @@
   (testing "the machines `allow-sub?` arity parses `{:rf/sub qv :as fact-id}`
             into `{:id fact-id :arg ::no-arg :rf.cofx/sub qv}` — the :as
             fact-id is the dedup / delivery key, NOT the bare :rf/sub id"
-    (let [parsed (cofx/parse-requires
+    (let [parsed (rf.cofx/parse-requires
                    [:actions :capture]
                    [{:rf/sub [:editor/can-submit?] :as :editor/can-submit}]
                    true)
@@ -59,7 +59,7 @@
           "the query rides under :rf.cofx/sub for the delivery step")))
   (testing "two DISTINCT sub queries under distinct fact-ids do NOT collide
             (the reason the map form is mandatory over `[id arg]`)"
-    (is (= 2 (count (cofx/parse-requires
+    (is (= 2 (count (rf.cofx/parse-requires
                       [:actions :capture]
                       [{:rf/sub [:a/x] :as :app/x}
                        {:rf/sub [:a/y] :as :app/y}]
@@ -70,7 +70,7 @@
             `{:rf/sub …}` source is `:rf.error/cofx-request-invalid` — its
             handler already holds :db"
     (let [e (is (thrown? ExceptionInfo
-                  (cofx/parse-requires :some/evt
+                  (rf.cofx/parse-requires :some/evt
                                        [{:rf/sub [:a/x] :as :app/x}])))]
       (is (= :rf.error/cofx-request-invalid (:rf.error/id (ex-data e)))))))
 
@@ -88,7 +88,7 @@
                                :fn (fn [_] nil)}}
            :states  {:idle {:on {:go {:target :done :action :capture}}}
                      :done {}}}]
-    (-> (try (machines/make-machine-handler m) nil
+    (-> (try (rf.machines/make-machine-handler m) nil
              (catch ExceptionInfo e e))
         ex-data
         :rf.error/id)))
@@ -149,7 +149,7 @@
                         {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
       (is (= true @seen)
           "the action read the resolved (recorded) sub value under fact-id")
-      (is (= :done (mtest/machine-state :sub/records))
+      (is (= :done (rf.machines.test-support/machine-state :sub/records))
           "the transition fired"))))
 
 ;; ===========================================================================
@@ -191,7 +191,7 @@
             `ensure-cofx` (frame-id nil, empty token, `:strict`) so the throw
             surfaces verbatim — dispatch-sync would capture it into the error
             pipeline (macrostep fails atomically, machine does not advance)"
-    (let [m (cofx-attach/index-ensure-sets
+    (let [m (rf.machines.cofx-attach/index-ensure-sets
               {:initial :idle
                :data    {}
                :actions {:capture
@@ -201,7 +201,7 @@
                :states  {:idle {:on {:go {:target :done :action :capture}}}
                          :done {}}})
           e (is (thrown? ExceptionInfo
-                  (cofx-attach/ensure-cofx m {:state :idle :data {}} [:go]
+                  (rf.machines.cofx-attach/ensure-cofx m {:state :idle :data {}} [:go]
                                            {} nil :sub/strict :strict)))]
       (is (= :rf.error/missing-required-cofx (:rf.error/id (ex-data e)))
           "strict refused to re-derive the absent sub fact"))))

--- a/implementation/machines/test/re_frame/machine_completion_spawn_incarnation_fence_test.clj
+++ b/implementation/machines/test/re_frame/machine_completion_spawn_incarnation_fence_test.clj
@@ -32,23 +32,23 @@
   published on the callback's own stack)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.machines :as machines]
-            [re-frame.machines.lifecycle-fx.finalize :as finalize]
-            [re-frame.machines.lifecycle-fx.spawn :as spawn]
-            [re-frame.machines.spawn-order :as spawn-order]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.lifecycle-fx.finalize :as rf.machines.lifecycle-fx.finalize]
+            [re-frame.machines.lifecycle-fx.spawn :as rf.machines.lifecycle-fx.spawn]
+            [re-frame.machines.spawn-order :as rf.machines.spawn-order]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 ;; Touch the artefact so the machines registration hooks are wired even when
 ;; this ns runs in isolation.
-(def ^:private _artefact machines/machine-transition)
+(def ^:private _artefact rf.machines/machine-transition)
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- completion-tail fence (finalize-machine) -----------------------------
 
@@ -71,7 +71,7 @@
   "Install `machine-id`'s finishing snapshot into `frame-id`'s runtime-db so
   the finalize teardown has a live snapshot to (attempt to) reap."
   [frame-id machine-id]
-  (frame/swap-runtime-db!
+  (rf.frame/swap-runtime-db!
     frame-id
     (fn [rt] (assoc-in rt [:rf.runtime/machines :snapshots machine-id]
                        (finishing-snapshot)))))
@@ -84,22 +84,22 @@
   (a `:rf.machine/done` trace listener that destroys A). Returns the observable
   post-finalize state."
   [frame-a machine-id trigger]
-  (spawn-order/reset-all!)
+  (rf.machines.spawn-order/reset-all!)
   (let [schema?   (= trigger :validator)]
     (rf/reg-machine machine-id (finishing-machine frame-a schema?))
     (rf/make-frame {:id frame-a})
     (seed-finishing-runtime-db! frame-a machine-id)
-    (let [token-a        (frame/frame-incarnation-token frame-a)
+    (let [token-a        (rf.frame/frame-incarnation-token frame-a)
           fired?         (atom false)
           done-traces    (atom [])
           destroyed      (atom [])
-          orig-validate  (late-bind/get-fn :schemas/validate-with-registered-fn)
+          orig-validate  (rf.late-bind/get-fn :schemas/validate-with-registered-fn)
           destroy+B!     (fn []
                            (when (compare-and-set! fired? false true)
-                             (frame/destroy-frame! frame-a)   ;; destroy A
+                             (rf.frame/destroy-frame! frame-a)   ;; destroy A
                              (rf/make-frame {:id frame-a})     ;; same-id B
                              (seed-finishing-runtime-db! frame-a machine-id)))]
-      (trace-tooling/register-listener!
+      (rf.trace.tooling/register-listener!
         ::completion-fence
         (fn [ev]
           (case (:operation ev)
@@ -109,30 +109,30 @@
             nil)))
       (try
         (when (= trigger :validator)
-          (late-bind/set-fn! :schemas/validate-with-registered-fn
+          (rf.late-bind/set-fn! :schemas/validate-with-registered-fn
             (fn [schema _result]
               (when (= schema ::output-schema) (destroy+B!))
               false)))                                       ;; violation verdict
-        (let [ret (frame/call-with-event-owner-token frame-a token-a
+        (let [ret (rf.frame/call-with-event-owner-token frame-a token-a
                     (fn []
-                      (finalize/finalize-machine
+                      (rf.machines.lifecycle-fx.finalize/finalize-machine
                         (finishing-machine frame-a schema?)
-                        machine-id frame-a (mtest/runtime-db frame-a)
+                        machine-id frame-a (rf.machines.test-support/runtime-db frame-a)
                         (finishing-snapshot) [:some-completing-event] [])))]
           {:fired?       @fired?
            :ret          ret
-           :b-runtime    (mtest/runtime-db frame-a)
-           :b-snapshot   (mtest/snapshot frame-a machine-id)
-           :reg-entry    (registrar/lookup :event machine-id)
-           :spawn-order  (spawn-order/frame-order frame-a)
+           :b-runtime    (rf.machines.test-support/runtime-db frame-a)
+           :b-snapshot   (rf.machines.test-support/snapshot frame-a machine-id)
+           :reg-entry    (rf.registrar/lookup :event machine-id)
+           :spawn-order  (rf.machines.spawn-order/frame-order frame-a)
            :done-traces  @done-traces
            :destroyed    @destroyed})
         (finally
-          (trace-tooling/unregister-listener! ::completion-fence)
-          (late-bind/set-fn! :schemas/validate-with-registered-fn orig-validate))))))
+          (rf.trace.tooling/unregister-listener! ::completion-fence)
+          (rf.late-bind/set-fn! :schemas/validate-with-registered-fn orig-validate))))))
 
 (defn- assert-completion-inert [{:keys [ret b-snapshot reg-entry spawn-order destroyed]} frame-a machine-id]
-  (is (= {:rf.db/runtime (mtest/runtime-db frame-a) :fx []} ret)
+  (is (= {:rf.db/runtime (rf.machines.test-support/runtime-db frame-a) :fx []} ret)
       "finalize returns the inert outcome — runtime-db untouched, no fx, before every framework-owned action")
   (is (some? b-snapshot)
       "successor B's finishing snapshot was NOT dissoc'd by the A-derived teardown")
@@ -171,24 +171,24 @@
 (deftest live-owner-completion-tears-down-normally
   (testing "control: a completion whose validator does NOT destroy A tears down
             fully — the fence is scoped to owner-loss only."
-    (spawn-order/reset-all!)
+    (rf.machines.spawn-order/reset-all!)
     (let [frame-a    :rf2-3evq0x/live-completion-frame
           machine-id :rf2-3evq0x/live-completion]
       (rf/reg-machine machine-id (finishing-machine frame-a false))
       (rf/make-frame {:id frame-a})
       (seed-finishing-runtime-db! frame-a machine-id)
-      (let [token-a  (frame/frame-incarnation-token frame-a)
+      (let [token-a  (rf.frame/frame-incarnation-token frame-a)
             destroyed (atom [])]
-        (trace-tooling/register-listener!
+        (rf.trace.tooling/register-listener!
           ::live-completion
           (fn [ev] (when (= :rf.machine/destroyed (:operation ev))
                      (swap! destroyed conj ev))))
         (try
-          (let [ret (frame/call-with-event-owner-token frame-a token-a
+          (let [ret (rf.frame/call-with-event-owner-token frame-a token-a
                       (fn []
-                        (finalize/finalize-machine
+                        (rf.machines.lifecycle-fx.finalize/finalize-machine
                           (finishing-machine frame-a false)
-                          machine-id frame-a (mtest/runtime-db frame-a)
+                          machine-id frame-a (rf.machines.test-support/runtime-db frame-a)
                           (finishing-snapshot) [:some-completing-event] [])))]
             ;; finalize returns the teardown as a runtime-db EFFECT (it never
             ;; imperatively writes the live frame); check the returned value.
@@ -200,7 +200,7 @@
             (is (contains? ret :rf.db/runtime)
                 "the live completion returns a runtime-db effect"))
           (finally
-            (trace-tooling/unregister-listener! ::live-completion)))))))
+            (rf.trace.tooling/unregister-listener! ::live-completion)))))))
 
 ;; ---- spawn-tail fence (trace listener replaces A with B) -------------------
 
@@ -213,7 +213,7 @@
             / :start dispatch tail is fenced — B stays byte-identical. Mutation
             tooth: with only the pre-trace cascade gate the A-derived snapshot +
             spawn-order + :start dispatch land on B."
-    (spawn-order/reset-all!)
+    (rf.machines.spawn-order/reset-all!)
     (rf/reg-machine :rf2-3evq0x/spawn-child
       {:initial :running
        :states  {:running {:on {:go :done}}
@@ -221,35 +221,35 @@
     (let [frame-a        :rf2-3evq0x/spawn-frame
           fired?         (atom false)
           dispatches     (atom [])
-          orig-dispatch! (late-bind/get-fn :router/dispatch!)]
+          orig-dispatch! (rf.late-bind/get-fn :router/dispatch!)]
       (rf/make-frame {:id frame-a})
-      (let [token-a (frame/frame-incarnation-token frame-a)
+      (let [token-a (rf.frame/frame-incarnation-token frame-a)
             b-birth (atom nil)]
-        (trace-tooling/register-listener!
+        (rf.trace.tooling/register-listener!
           ::spawn-trace-fence
           (fn [ev]
             (when (and (= :rf.machine.spawn/spawned (:operation ev))
                        (compare-and-set! fired? false true))
-              (frame/destroy-frame! frame-a)     ;; destroy A during the spawned trace
+              (rf.frame/destroy-frame! frame-a)     ;; destroy A during the spawned trace
               (rf/make-frame {:id frame-a})       ;; publish same-id B
-              (reset! b-birth (mtest/runtime-db frame-a)))))
+              (reset! b-birth (rf.machines.test-support/runtime-db frame-a)))))
         (try
           ;; Capture (never route) any dispatch the cascade attempts.
-          (late-bind/set-fn! :router/dispatch!
+          (rf.late-bind/set-fn! :router/dispatch!
                              (fn [ev opts] (swap! dispatches conj [ev opts]) nil))
-          (frame/call-with-event-owner-token frame-a token-a
-            (fn [] (spawn/spawn-fx {:frame frame-a}
+          (rf.frame/call-with-event-owner-token frame-a token-a
+            (fn [] (rf.machines.lifecycle-fx.spawn/spawn-fx {:frame frame-a}
                                    {:machine-id :rf2-3evq0x/spawn-child :start [:go]})))
           (is (true? @fired?) "the :rf.machine.spawn/spawned trace listener ran (fence exercised)")
-          (is (nil? (mtest/snapshot frame-a spawn-child-instance-id))
+          (is (nil? (rf.machines.test-support/snapshot frame-a spawn-child-instance-id))
               "no A-derived child snapshot installed onto same-id B")
-          (is (= @b-birth (mtest/runtime-db frame-a))
+          (is (= @b-birth (rf.machines.test-support/runtime-db frame-a))
               "B's runtime-db is byte-identical to its birth value (no A-derived install)")
-          (is (empty? (spawn-order/frame-order frame-a))
+          (is (empty? (rf.machines.spawn-order/frame-order frame-a))
               "no A-derived spawn-order entry recorded against B")
           (is (empty? @dispatches)
               "no :start dispatch fired into B after the spawned-trace loss")
           (finally
-            (trace-tooling/unregister-listener! ::spawn-trace-fence)
+            (rf.trace.tooling/unregister-listener! ::spawn-trace-fence)
             (when orig-dispatch!
-              (late-bind/set-fn! :router/dispatch! orig-dispatch!))))))))
+              (rf.late-bind/set-fn! :router/dispatch! orig-dispatch!))))))))

--- a/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
+++ b/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
@@ -17,7 +17,7 @@
   written under `:source :effect` — by the commit-plane classification effects
   or the projection-relative machine declaration lowered per actor; the trace
   egress chokepoint re-roots that snapshot-relative
-  (`classification/frame-snapshot-classification`) and redacts the matching
+  (`rf.classification/frame-snapshot-classification`) and redacts the matching
   slot. A `:sensitive?` / `:large?` Malli prop on a `[:schemas :data]` slot is
   VALIDATION ONLY and does not classify durable `:data` for egress.
 
@@ -50,18 +50,18 @@
             [re-frame.core :as rf]
             ;; Loading the machines artefact publishes its late-bind hooks
             ;; (`:machines/reg-machine` etc.) so `rf/reg-machine` resolves.
-            [re-frame.machines :as machines]
-            [re-frame.classification :as classification]
-            [re-frame.elision :as elision]
-            [re-frame.machines.test-support :as mtest]
+            [re-frame.machines :as rf.machines]
+            [re-frame.classification :as rf.classification]
+            [re-frame.elision :as rf.elision]
+            [re-frame.machines.test-support :as rf.machines.test-support]
             ;; The schemas artefact + Malli adapter — `[:schemas :data]` VALIDATION
             ;; runs; the props do not classify durable :data.
             [re-frame.schemas]
             [re-frame.schemas.malli]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- fixtures -------------------------------------------------------------
 
@@ -82,7 +82,7 @@
   "Register the auth machine carrying `auth-schema` at `[:schemas :data]`."
   ([] (reg-auth-machine! auth-id))
   ([machine-id]
-   (machines/reg-machine* machine-id
+   (rf.machines/reg-machine* machine-id
      {:initial :anon
       :data    {:retries 0 :token nil :blob nil}
       :schemas {:data auth-schema}
@@ -99,12 +99,12 @@
   `frame-snapshot-classification` reads at trace egress."
   ([] (declare-frame-marks! auth-id))
   ([actor-id]
-   (elision/swap-elision-slot! :rf/default
+   (rf.elision/swap-elision-slot! :rf/default
      (fn [reg]
        (-> (or reg {})
-           (elision/add-claims :sensitive-declarations {:source :effect}
+           (rf.elision/add-claims :sensitive-declarations {:source :effect}
                                [[:rf.runtime/machines :snapshots actor-id :data :token]])
-           (elision/add-claims :declarations {:source :effect}
+           (rf.elision/add-claims :declarations {:source :effect}
                                [[:rf.runtime/machines :snapshots actor-id :data :blob]]))))))
 
 (defn- machine-transition-event*
@@ -133,9 +133,9 @@
 
 (deftest frame-snapshot-marks-rooted-under-data
   (testing "the frame's absolute snapshot-path declarations re-root snapshot-
-            relative under [:data …] via classification/frame-snapshot-classification"
+            relative under [:data …] via rf.classification/frame-snapshot-classification"
     (declare-frame-marks!)
-    (let [m (classification/frame-snapshot-classification :rf/default auth-id)]
+    (let [m (rf.classification/frame-snapshot-classification :rf/default auth-id)]
       (is (some? m) "a frame-declared marks set exists for the snapshot")
       (is (= #{[:data :token]} (set (:sensitive m)))
           "sensitive path re-rooted snapshot-relative")
@@ -145,7 +145,7 @@
 (deftest no-frame-declaration-no-marks
   (testing "a machine whose frame declares nothing has no snapshot marks"
     (reg-auth-machine!)
-    (is (nil? (classification/frame-snapshot-classification :rf/default auth-id))
+    (is (nil? (rf.classification/frame-snapshot-classification :rf/default auth-id))
         "no frame declaration → no snapshot marks")))
 
 ;; ---- (2) egress redaction at the chokepoint -------------------------------
@@ -155,7 +155,7 @@
             :before / :after snapshot egress; the plain sibling rides verbatim"
     (reg-auth-machine!)
     (declare-frame-marks!)
-    (let [out  (classification/project-trace-event (machine-transition-event auth-id))
+    (let [out  (rf.classification/project-trace-event (machine-transition-event auth-id))
           tags (:tags out)]
       (is (= :rf/redacted (get-in tags [:before :data :token])))
       (is (= :rf/redacted (get-in tags [:after :data :token])))
@@ -169,7 +169,7 @@
             :rf.size/large-elided marker in snapshot egress"
     (reg-auth-machine!)
     (declare-frame-marks!)
-    (let [out  (classification/project-trace-event (machine-transition-event auth-id))
+    (let [out  (rf.classification/project-trace-event (machine-transition-event auth-id))
           tags (:tags out)]
       (is (contains? (get-in tags [:before :data :blob]) :rf.size/large-elided))
       (is (contains? (get-in tags [:after :data :blob]) :rf.size/large-elided))
@@ -187,7 +187,7 @@
                                          :data  {:retries 2
                                                  :token   "secret-jwt-snap"
                                                  :blob    nil}}}}
-          out  (classification/project-trace-event ev)]
+          out  (rf.classification/project-trace-event ev)]
       (is (= :rf/redacted (get-in out [:tags :snapshot :data :token])))
       (is (not (.contains (pr-str out) "secret-jwt-snap"))))))
 
@@ -206,7 +206,7 @@
                             :data       {:retries 0
                                          :token   "secret-jwt-started"
                                          :blob    "huge-started"}}}
-          out  (classification/project-trace-event ev)
+          out  (rf.classification/project-trace-event ev)
           tags (:tags out)]
       (is (= :rf/redacted (get-in tags [:data :token])))
       (is (contains? (get-in tags [:data :blob]) :rf.size/large-elided))
@@ -228,7 +228,7 @@
                                                  :token   "secret-jwt-guard"
                                                  :blob    "huge-guard"}
                                          :event [:login]}}}
-          out  (classification/project-trace-event ev)
+          out  (rf.classification/project-trace-event ev)
           tags (:tags out)]
       (is (= :rf/redacted (get-in tags [:input :data :token])))
       (is (contains? (get-in tags [:input :data :blob]) :rf.size/large-elided))
@@ -251,7 +251,7 @@
                                                  :token   "secret-jwt-action"
                                                  :blob    "huge-action"}
                                          :event [:login]}}}
-          out  (classification/project-trace-event ev)
+          out  (rf.classification/project-trace-event ev)
           tags (:tags out)]
       (is (= :rf/redacted (get-in tags [:input :data :token])))
       (is (contains? (get-in tags [:input :data :blob]) :rf.size/large-elided))
@@ -282,7 +282,7 @@
                                           :region nil
                                           :action nil
                                           :data-delta {}}]}}
-          out     (classification/project-trace-event ev)
+          out     (rf.classification/project-trace-event ev)
           cascade (get-in out [:tags :cascade])
           step0   (first cascade)]
       (is (= :rf/redacted (get-in step0 [:data-delta :token])))
@@ -303,7 +303,7 @@
                             :frame      :rf/default
                             :state      :idle
                             :data       {:token "not-secret"}}}
-          out  (classification/project-trace-event ev)]
+          out  (rf.classification/project-trace-event ev)]
       (is (= "not-secret" (get-in out [:tags :data :token]))
           "no frame declaration → :data slot verbatim"))))
 
@@ -315,7 +315,7 @@
             :after exactly like the :machine-id case"
     (reg-auth-machine!)
     (declare-frame-marks!)
-    (let [out  (classification/project-trace-event
+    (let [out  (rf.classification/project-trace-event
                  (machine-transition-event* :actor-id auth-id))
           tags (:tags out)]
       (is (= :rf/redacted (get-in tags [:before :data :token])))
@@ -335,7 +335,7 @@
     (declare-frame-marks! auth-id)
     (let [ev   (-> (machine-transition-event* :actor-id auth-id)
                    (assoc-in [:tags :machine-id] :rf.machine-redaction/undeclared-sibling))
-          out  (classification/project-trace-event ev)]
+          out  (rf.classification/project-trace-event ev)]
       (is (= :rf/redacted (get-in out [:tags :after :data :token]))
           "redacted via the PREFERRED :actor-id (declared), not the :machine-id sibling")
       (is (not (.contains (pr-str out) "secret-jwt"))))))
@@ -351,7 +351,7 @@
     ;; auth-schema carries :token {:sensitive? true} + :blob {:large? true},
     ;; but we declare NOTHING on the frame.
     (reg-auth-machine!)
-    (let [out  (classification/project-trace-event (machine-transition-event auth-id))
+    (let [out  (rf.classification/project-trace-event (machine-transition-event auth-id))
           tags (:tags out)]
       (is (= "secret-jwt-after" (get-in tags [:after :data :token]))
           "a :sensitive? [:schemas :data] slot does NOT redact without a frame declaration")
@@ -406,7 +406,7 @@
             "large `:data` path lowered at boot"))
       ;; the lowered registry entry redacts at the egress chokepoint, via the
       ;; SAME read path (frame-snapshot-marks) the frame-declared mechanism uses
-      (let [out  (classification/project-trace-event (machine-transition-event mid))
+      (let [out  (rf.classification/project-trace-event (machine-transition-event mid))
             tags (:tags out)]
         (is (= :rf/redacted (get-in tags [:after :data :token]))
             "machine-declared sensitive slot redacts at snapshot egress")
@@ -462,7 +462,7 @@
               "the spawned instance's :data :token lowered at spawn (per-instance)")
           (is (some #(= :machine (:source %)) (get-in reg [:sensitive-declarations abs-token])))
           ;; egress redacts the spawned instance's declared slot
-          (let [out (classification/project-trace-event
+          (let [out (rf.classification/project-trace-event
                       {:operation :rf.machine/snapshot-updated
                        :tags      {:actor-id spawned-id
                                    :frame    :rf/default
@@ -540,7 +540,7 @@
         (is (contains? (get-in reg [:sensitive-declarations abs-token]) {:source :effect})
             "the app's :source :effect owner survives the actor teardown"))
       ;; And egress still redacts — the fail-open is sealed.
-      (let [out  (classification/project-trace-event (machine-transition-event mid))
+      (let [out  (rf.classification/project-trace-event (machine-transition-event mid))
             tags (:tags out)]
         (is (= :rf/redacted (get-in tags [:after :data :token]))
             "the value stays REDACTED at egress — the teardown did not un-redact it")
@@ -596,12 +596,12 @@
 ;; ---- (6) EFFECT-FIRST boot: the machine's own claim must land DURABLY ------
 ;; rf2-dr0pfi — when an effect PRE-classifies a machine's absolute snapshot
 ;; path BEFORE the singleton boots, the machine's own `:source :machine` claim
-;; (lowered LIVE by `classification/lower-at-spawn!` at first-boot) must SURVIVE
+;; (lowered LIVE by `rf.classification/lower-at-spawn!` at first-boot) must SURVIVE
 ;; the boot snapshot `:rf.db/runtime` commit. Before the fix, that commit was
 ;; built from the STALE `:rf.db/runtime` coeffect — which already carried the
 ;; effect's `[:rf.runtime/elision]` sub-tree — so the returned effect value
 ;; INCLUDED `:rf.runtime/elision` (effect-owner only). At commit,
-;; `elision/reconcile-runtime-db-effect` reads an effect-carried
+;; `rf.elision/reconcile-runtime-db-effect` reads an effect-carried
 ;; `:rf.runtime/elision` as an explicit full-frame install and honours it
 ;; VERBATIM, clobbering the machine owner the live swap had just unioned in.
 ;; The effect owner survived (so the path stayed redacted — BENIGN, no leak),
@@ -655,7 +655,7 @@
       (is (some #(= :machine (:source %)) (owners))
           "the machine's own claim SURVIVES the effect clear — the path stays classified")
       ;; (4) And egress STILL redacts via the machine's surviving claim alone.
-      (let [out  (classification/project-trace-event (machine-transition-event mid))
+      (let [out  (rf.classification/project-trace-event (machine-transition-event mid))
             tags (:tags out)]
         (is (= :rf/redacted (get-in tags [:after :data :token]))
             "the machine's surviving claim keeps the value redacted after the effect cleared")

--- a/implementation/machines/test/re_frame/machine_decl_path_default_test.clj
+++ b/implementation/machines/test/re_frame/machine_decl_path_default_test.clj
@@ -24,7 +24,7 @@
   directly with a transition map carrying NO `:decl-path`, so it exercises the
   default. JVM-runnable from arguments alone."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.machines.transition :as transition]))
+            [re-frame.machines.transition :as rf.machines.transition]))
 
 ;; A deep compound machine. `:p` is a top-level compound (initial :q); `:q` and
 ;; `:r` are its children; `:r` is itself compound (initial :s). Each state
@@ -66,7 +66,7 @@
     ;; stay on the active path while the machine dives to :s.
     (let [snapshot {:state [:p :q] :data {:log []}}
           ;; NB: no :decl-path key — exercises the default.
-          r        (transition/apply-transition-once
+          r        (rf.machines.transition/apply-transition-once
                      deep-machine snapshot [:go] {:target [:p :r :s]})]
       (is (= :ok (:status r)) "the transition applies cleanly")
       (let [snap (:snapshot r)]
@@ -80,7 +80,7 @@
   (testing "control — the SAME transition WITH an explicit root `:decl-path []`
    produces the identical cascade (the default and the explicit root agree)"
     (let [snapshot {:state [:p :q] :data {:log []}}
-          r        (transition/apply-transition-once
+          r        (rf.machines.transition/apply-transition-once
                      deep-machine snapshot [:go] {:target [:p :r :s] :decl-path []})]
       (is (= :ok (:status r)))
       (is (= [:exit-q :enter-r :enter-s] (get-in (:snapshot r) [:data :log]))

--- a/implementation/machines/test/re_frame/machine_depth_abort_failure_test.clj
+++ b/implementation/machines/test/re_frame/machine_depth_abort_failure_test.clj
@@ -20,14 +20,14 @@
             ;; Loading `re-frame.machines` installs the late-bind hooks +
             ;; reserved fxs `reg-machine` relies on.
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- record-traces! [body-fn]
-  (mtest/with-trace-capture seen
+  (rf.machines.test-support/with-trace-capture seen
     (body-fn)
     @seen))
 
@@ -76,7 +76,7 @@
       ;; Atomic rollback (Spec 005 §Bounded depth): the macrostep failed, so
       ;; no post-event snapshot reaches runtime-db — the pre-event :start
       ;; snapshot stays committed.
-      (is (= :start (mtest/machine-state :rf2-y3jv8q/always))
+      (is (= :start (rf.machines.test-support/machine-state :rf2-y3jv8q/always))
           "macrostep is atomic; the cycle aborts; snapshot rolls back to :start"))))
 
 ;; ---------------------------------------------------------------------------
@@ -119,7 +119,7 @@
           "the depth-exceeded trace is error-grade (a failed macrostep)")
       (is (= 0 (count no-ops))
           "a runaway raise cycle is NOT a benign no-op — no unhandled-no-op")
-      (is (= :start (mtest/machine-state :rf2-y3jv8q/raise))
+      (is (= :start (rf.machines.test-support/machine-state :rf2-y3jv8q/raise))
           "macrostep is atomic; the cycle aborts; snapshot rolls back to :start"))))
 
 ;; ---------------------------------------------------------------------------
@@ -150,5 +150,5 @@
           "the guard-blocked no-op still emits exactly one unhandled-no-op")
       (is (= 0 (+ (count always-err) (count raise-err)))
           "a benign no-op emits NO depth-exceeded error")
-      (is (= :red (mtest/machine-state :rf2-y3jv8q/blocked))
+      (is (= :red (rf.machines.test-support/machine-state :rf2-y3jv8q/blocked))
           "the guard-blocked event leaves the snapshot at :red"))))

--- a/implementation/machines/test/re_frame/machine_destroy_tail_incarnation_fence_test.clj
+++ b/implementation/machines/test/re_frame/machine_destroy_tail_incarnation_fence_test.clj
@@ -27,7 +27,7 @@
 
     3. SUBSCRIPTION-VECTOR TIMER — `cancel-after-timer-entry!` emits the
        callback-bearing `:rf.machine.timer/cancelled` trace and THEN releases
-       the timer entry, whose `subs/unsubscribe frame-id delay-key` decrements
+       the timer entry, whose `rf.subs/unsubscribe frame-id delay-key` decrements
        the subscription cache ref-count keyed by `(frame-id, query-v)`. A
        listener that re-armed the SAME query in same-id B would have A's release
        dispose B's fresh reaction. FIX: skip ONLY that shared decrement once A
@@ -43,26 +43,26 @@
   authority."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.machines :as machines]
-            [re-frame.machines.classification :as classification]
-            [re-frame.machines.lifecycle-fx.destroy :as destroy]
-            [re-frame.machines.spawn-order :as spawn-order]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.machines.timer :as timer]
-            [re-frame.subs :as subs]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.classification :as rf.machines.classification]
+            [re-frame.machines.lifecycle-fx.destroy :as rf.machines.lifecycle-fx.destroy]
+            [re-frame.machines.spawn-order :as rf.machines.spawn-order]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.machines.timer :as rf.machines.timer]
+            [re-frame.subs :as rf.subs]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace :as rf.trace]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 ;; Touch the artefact so the machines registration hooks are wired even when
 ;; this ns runs in isolation.
-(def ^:private _artefact machines/machine-transition)
+(def ^:private _artefact rf.machines/machine-transition)
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- shared seed ----------------------------------------------------------
 
@@ -96,7 +96,7 @@
   resolves off the snapshot."
   [frame-id on-exit]
   (rf/reg-machine actor-type (classified-spec on-exit))
-  (frame/swap-runtime-db!
+  (rf.frame/swap-runtime-db!
     frame-id
     (fn [rt] (-> rt
                  (assoc-in (snapshot-path actor-id)
@@ -104,14 +104,14 @@
                             :data            {:rf/self-id actor-id :token "secret"}
                             :rf/machine-type actor-type})
                  (assoc-in (system-id-path the-sid) actor-id))))
-  (spawn-order/record! frame-id actor-id)
-  (classification/lower-at-spawn! frame-id actor-id (classified-spec on-exit)))
+  (rf.machines.spawn-order/record! frame-id actor-id)
+  (rf.machines.classification/lower-at-spawn! frame-id actor-id (classified-spec on-exit)))
 
 ;; ---- ordinary-destroy tail loss fixtures ----------------------------------
 
 (defn- run-destroy-tail
   "Seed a live actor in frame A, install a destroyer keyed on `trigger`, then
-  drive `destroy/destroy-machine-fx` (the imperative keyword form) DIRECTLY under
+  drive `rf.machines.lifecycle-fx.destroy/destroy-machine-fx` (the imperative keyword form) DIRECTLY under
   A's bound event owner. The destroyer — fired EXACTLY once on the trigger's
   callback / hook stack — destroys frame A and republishes same-id B (re-seeding
   B identically: snapshot, system-id, spawn-order, classification). Returns the
@@ -119,17 +119,17 @@
 
   `trigger` ∈ {:exit :http-abort :timer-cancelled :destroyed :system-id-released}."
   [frame-a trigger]
-  (spawn-order/reset-all!)
+  (rf.machines.spawn-order/reset-all!)
   (rf/make-frame {:id frame-a})
   (let [fired?     (atom false)
         b-birth    (atom nil)
-        orig-abort (late-bind/get-fn :http/abort-on-actor-destroy)
+        orig-abort (rf.late-bind/get-fn :http/abort-on-actor-destroy)
         destroy+B! (fn []
                      (when (compare-and-set! fired? false true)
-                       (frame/destroy-frame! frame-a)     ;; destroy A
+                       (rf.frame/destroy-frame! frame-a)     ;; destroy A
                        (rf/make-frame {:id frame-a})        ;; same-id B
                        ;; Re-seed B identically (no :exit hook on B).
-                       (frame/swap-runtime-db!
+                       (rf.frame/swap-runtime-db!
                          frame-a
                          (fn [rt] (-> rt
                                       (assoc-in (snapshot-path actor-id)
@@ -137,19 +137,19 @@
                                                  :data            {:rf/self-id actor-id :token "secret"}
                                                  :rf/machine-type actor-type})
                                       (assoc-in (system-id-path the-sid) actor-id))))
-                       (spawn-order/record! frame-a actor-id)
-                       (classification/lower-at-spawn! frame-a actor-id (classified-spec nil))
+                       (rf.machines.spawn-order/record! frame-a actor-id)
+                       (rf.machines.classification/lower-at-spawn! frame-a actor-id (classified-spec nil))
                        (reset! b-birth (runtime-db frame-a))))]
     (seed-live-actor! frame-a (when (= trigger :exit) destroy+B!))
     (when (= trigger :timer-cancelled)
       ;; Seed one armed `:after` timer entry so `cancel-actor-timers!` emits a
       ;; `:rf.machine.timer/cancelled` trace we can hook.
-      (swap! timer/after-timers assoc-in
+      (swap! rf.machines.timer/after-timers assoc-in
              [frame-a {:parent actor-id :spawn [] :delay 3600000}]
              {:handle nil :reaction nil :sub-watcher-key nil
               :resolved-ms 3600000 :epoch 0 :state :running
               :region nil :delay-source :literal :token ::a-timer}))
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       ::destroy-tail-fence
       (fn [ev]
         (case (:operation ev)
@@ -159,22 +159,22 @@
           nil)))
     (try
       (when (= trigger :http-abort)
-        (late-bind/set-fn! :http/abort-on-actor-destroy
+        (rf.late-bind/set-fn! :http/abort-on-actor-destroy
                            (fn [_actor-id] (destroy+B!) nil)))
-      (let [token-a (frame/frame-incarnation-token frame-a)]
-        (frame/call-with-event-owner-token frame-a token-a
-          (fn [] (destroy/destroy-machine-fx {:frame frame-a} actor-id))))
+      (let [token-a (rf.frame/frame-incarnation-token frame-a)]
+        (rf.frame/call-with-event-owner-token frame-a token-a
+          (fn [] (rf.machines.lifecycle-fx.destroy/destroy-machine-fx {:frame frame-a} actor-id))))
       {:fired?      @fired?
        :b-birth     @b-birth
        :b-runtime   (runtime-db frame-a)
        :b-snapshot  (snapshot frame-a actor-id)
        :b-system-id (get-in (runtime-db frame-a) (system-id-path the-sid))
        :b-elision   (elision-slot frame-a)
-       :spawn-order (vec (spawn-order/frame-order frame-a))}
+       :spawn-order (vec (rf.machines.spawn-order/frame-order frame-a))}
       (finally
-        (trace-tooling/unregister-listener! ::destroy-tail-fence)
-        (late-bind/set-fn! :http/abort-on-actor-destroy orig-abort)
-        (swap! timer/after-timers dissoc frame-a)))))
+        (rf.trace.tooling/unregister-listener! ::destroy-tail-fence)
+        (rf.late-bind/set-fn! :http/abort-on-actor-destroy orig-abort)
+        (swap! rf.machines.timer/after-timers dissoc frame-a)))))
 
 (defn- assert-b-inert [{:keys [b-birth b-runtime b-snapshot b-system-id b-elision spawn-order]}]
   (is (some? b-snapshot)
@@ -243,31 +243,31 @@
             destroyer tears the actor down FULLY — snapshot dissoc'd, system-id
             released, spawn-order forgotten, classification dropped, destroyed
             trace fired exactly once. The fence is scoped to owner-loss only."
-    (spawn-order/reset-all!)
+    (rf.machines.spawn-order/reset-all!)
     (let [frame-a   :rf2-i4aj9c/live-destroy-frame
           destroyed (atom [])]
       (rf/make-frame {:id frame-a})
       (seed-live-actor! frame-a nil)
-      (trace-tooling/register-listener!
+      (rf.trace.tooling/register-listener!
         ::live-destroy
         (fn [ev] (when (= :rf.machine/destroyed (:operation ev))
                    (swap! destroyed conj ev))))
       (try
-        (let [token-a (frame/frame-incarnation-token frame-a)]
-          (frame/call-with-event-owner-token frame-a token-a
-            (fn [] (destroy/destroy-machine-fx {:frame frame-a} actor-id))))
+        (let [token-a (rf.frame/frame-incarnation-token frame-a)]
+          (rf.frame/call-with-event-owner-token frame-a token-a
+            (fn [] (rf.machines.lifecycle-fx.destroy/destroy-machine-fx {:frame frame-a} actor-id))))
         (is (nil? (snapshot frame-a actor-id))
             "the live destroy dissoc'd the actor's snapshot")
         (is (nil? (get-in (runtime-db frame-a) (system-id-path the-sid)))
             "the live destroy released the :system-id binding")
-        (is (empty? (spawn-order/frame-order frame-a))
+        (is (empty? (rf.machines.spawn-order/frame-order frame-a))
             "the live destroy forgot the actor from spawn-order")
         (is (empty? (or (elision-slot frame-a) {}))
             "the live destroy dropped the actor's classification claim")
         (is (= 1 (count @destroyed))
             "exactly one :rf.machine/destroyed trace fired")
         (finally
-          (trace-tooling/unregister-listener! ::live-destroy))))))
+          (rf.trace.tooling/unregister-listener! ::live-destroy))))))
 
 ;; ---- eventless frame-destroy control (retains authority) ------------------
 
@@ -276,30 +276,30 @@
             frame-destroy cascade) uses the inert eventless fence — it tears the
             actor down fully regardless of any ambient ownership. A wrongly-eager
             fence would strand the actor on frame teardown."
-    (spawn-order/reset-all!)
+    (rf.machines.spawn-order/reset-all!)
     (let [frame-a :rf2-i4aj9c/eventless-frame]
       (rf/make-frame {:id frame-a})
       (seed-live-actor! frame-a nil)
       ;; No `call-with-event-owner-token` — genuinely eventless.
-      (destroy/destroy-single-actor! frame-a actor-id)
+      (rf.machines.lifecycle-fx.destroy/destroy-single-actor! frame-a actor-id)
       (is (nil? (snapshot frame-a actor-id))
           "the eventless teardown dissoc'd the snapshot")
       (is (nil? (get-in (runtime-db frame-a) (system-id-path the-sid)))
           "the eventless teardown released the :system-id binding")
-      (is (empty? (spawn-order/frame-order frame-a))
+      (is (empty? (rf.machines.spawn-order/frame-order frame-a))
           "the eventless teardown forgot the actor from spawn-order"))))
 
 ;; ===========================================================================
-;; SUBSCRIPTION-VECTOR TIMER seam — release fence (subs/unsubscribe)
+;; SUBSCRIPTION-VECTOR TIMER seam — release fence (rf.subs/unsubscribe)
 ;; ===========================================================================
 
 (defn- seed-sub-vec-timer!
   "Seed one armed subscription-vector `:after` timer entry for `parent-id` under
   `frame-id`, carrying a `:reaction` + `:sub-watcher-key` and a vector
-  `delay-key` (so `release-entry-resources!` reaches the `subs/unsubscribe`
+  `delay-key` (so `release-entry-resources!` reaches the `rf.subs/unsubscribe`
   branch)."
   [frame-id parent-id delay-key reaction]
-  (swap! timer/after-timers assoc-in
+  (swap! rf.machines.timer/after-timers assoc-in
          [frame-id {:parent parent-id :spawn [] :delay delay-key}]
          {:handle          nil
           :reaction        reaction
@@ -315,7 +315,7 @@
   (testing "a subscription-vector `:after` timer is cancelled on actor destroy; a
             :rf.machine.timer/cancelled listener re-arms the SAME query in same-id
             B (bumping the shared (frame,query-v) ref-count), then A's release runs.
-            The shared `subs/unsubscribe` decrement is SKIPPED once A is lost, so
+            The shared `rf.subs/unsubscribe` decrement is SKIPPED once A is lost, so
             B's fresh reaction ref is not disposed. Mutation tooth: the unfenced
             release decrements B's ref."
     (let [frame-a     :rf2-i4aj9c/subvec-frame
@@ -325,26 +325,26 @@
           fired?      (atom false)]
       (rf/make-frame {:id frame-a})
       (seed-sub-vec-timer! frame-a actor-id delay-key reaction)
-      (with-redefs [subs/unsubscribe (fn ([_] (swap! unsub-count inc) nil)
+      (with-redefs [rf.subs/unsubscribe (fn ([_] (swap! unsub-count inc) nil)
                                         ([_ _] (swap! unsub-count inc) nil))]
-        (trace-tooling/register-listener!
+        (rf.trace.tooling/register-listener!
           ::subvec-fence
           (fn [ev]
             (when (and (= :rf.machine.timer/cancelled (:operation ev))
                        (compare-and-set! fired? false true))
-              (frame/destroy-frame! frame-a)   ;; destroy A
+              (rf.frame/destroy-frame! frame-a)   ;; destroy A
               (rf/make-frame {:id frame-a}))))   ;; same-id B re-arms the same query
         (try
-          (let [token-a   (frame/frame-incarnation-token frame-a)
-                owner-gone? (fn [] (not (frame/event-continuation-live? frame-a token-a)))]
-            (frame/call-with-event-owner-token frame-a token-a
-              (fn [] (timer/cancel-actor-timers! frame-a actor-id owner-gone?))))
+          (let [token-a   (rf.frame/frame-incarnation-token frame-a)
+                owner-gone? (fn [] (not (rf.frame/event-continuation-live? frame-a token-a)))]
+            (rf.frame/call-with-event-owner-token frame-a token-a
+              (fn [] (rf.machines.timer/cancel-actor-timers! frame-a actor-id owner-gone?))))
           (is (true? @fired?) "the timer-cancelled listener ran (fence exercised)")
           (is (zero? @unsub-count)
               "A's release did NOT decrement the shared (frame,query-v) ref-count after the loss")
           (finally
-            (trace-tooling/unregister-listener! ::subvec-fence)
-            (swap! timer/after-timers dissoc frame-a)))))))
+            (rf.trace.tooling/unregister-listener! ::subvec-fence)
+            (swap! rf.machines.timer/after-timers dissoc frame-a)))))))
 
 (deftest sub-vec-timer-release-live-owner-unsubscribes-once
   (testing "control: when the cancelled listener does NOT destroy A, the
@@ -356,17 +356,17 @@
           unsub-count (atom 0)]
       (rf/make-frame {:id frame-a})
       (seed-sub-vec-timer! frame-a actor-id delay-key reaction)
-      (with-redefs [subs/unsubscribe (fn ([_] (swap! unsub-count inc) nil)
+      (with-redefs [rf.subs/unsubscribe (fn ([_] (swap! unsub-count inc) nil)
                                         ([_ _] (swap! unsub-count inc) nil))]
         (try
-          (let [token-a     (frame/frame-incarnation-token frame-a)
-                owner-gone? (fn [] (not (frame/event-continuation-live? frame-a token-a)))]
-            (frame/call-with-event-owner-token frame-a token-a
-              (fn [] (timer/cancel-actor-timers! frame-a actor-id owner-gone?))))
+          (let [token-a     (rf.frame/frame-incarnation-token frame-a)
+                owner-gone? (fn [] (not (rf.frame/event-continuation-live? frame-a token-a)))]
+            (rf.frame/call-with-event-owner-token frame-a token-a
+              (fn [] (rf.machines.timer/cancel-actor-timers! frame-a actor-id owner-gone?))))
           (is (= 1 @unsub-count)
               "the live-owner release decremented the subscription ref-count exactly once")
           (finally
-            (swap! timer/after-timers dissoc frame-a)))))))
+            (swap! rf.machines.timer/after-timers dissoc frame-a)))))))
 
 ;; ===========================================================================
 ;; SPAWN-ALL seam — children iteration + final join-slot cleanup fence
@@ -382,7 +382,7 @@
 
 (defn- seed-spawn-all! [frame-id]
   (rf/reg-machine actor-type (classified-spec nil))
-  (frame/swap-runtime-db!
+  (rf.frame/swap-runtime-db!
     frame-id
     (fn [rt] (-> rt
                  (assoc-in (snapshot-path sa-child-a) (child-snap sa-child-a))
@@ -394,8 +394,8 @@
                             :resolved?  false
                             :spec       {}
                             :rf/attempt 1}))))
-  (spawn-order/record! frame-id sa-child-a)
-  (spawn-order/record! frame-id sa-child-b))
+  (rf.machines.spawn-order/record! frame-id sa-child-a)
+  (rf.machines.spawn-order/record! frame-id sa-child-b))
 
 (deftest spawn-all-iteration-loss-fences-remaining-children-and-clear
   (testing "a `:spawn-all` teardown iterates its children, firing a
@@ -406,25 +406,25 @@
             children survive byte-identical. Mutation tooth: the unfenced
             iteration tears down B's children and the unfenced clear vacates B's
             join slot."
-    (spawn-order/reset-all!)
+    (rf.machines.spawn-order/reset-all!)
     (let [frame-a :rf2-i4aj9c/spawn-all-frame
           fired?  (atom false)
           b-birth (atom nil)]
       (rf/make-frame {:id frame-a})
       (seed-spawn-all! frame-a)
-      (trace-tooling/register-listener!
+      (rf.trace.tooling/register-listener!
         ::spawn-all-fence
         (fn [ev]
           (when (and (= :rf.machine/destroyed (:operation ev))
                      (compare-and-set! fired? false true))
-            (frame/destroy-frame! frame-a)       ;; destroy A
+            (rf.frame/destroy-frame! frame-a)       ;; destroy A
             (rf/make-frame {:id frame-a})          ;; same-id B
             (seed-spawn-all! frame-a)              ;; re-seed the whole join
             (reset! b-birth (runtime-db frame-a)))))
       (try
-        (let [token-a (frame/frame-incarnation-token frame-a)]
-          (frame/call-with-event-owner-token frame-a token-a
-            (fn [] (destroy/destroy-machine-fx
+        (let [token-a (rf.frame/frame-incarnation-token frame-a)]
+          (rf.frame/call-with-event-owner-token frame-a token-a
+            (fn [] (rf.machines.lifecycle-fx.destroy/destroy-machine-fx
                      {:frame frame-a}
                      {:rf/spawn-all true :rf/parent-id sa-parent :rf/invoke-id sa-invoke}))))
         (is (true? @fired?) "the per-child :rf.machine/destroyed listener ran (fence exercised)")
@@ -434,19 +434,19 @@
         (is (= @b-birth (runtime-db frame-a))
             "B's runtime-db is byte-identical to its birth (no A-derived iteration / clear landed)")
         (finally
-          (trace-tooling/unregister-listener! ::spawn-all-fence))))))
+          (rf.trace.tooling/unregister-listener! ::spawn-all-fence))))))
 
 (deftest spawn-all-live-owner-tears-down-all-children
   (testing "control: a `:spawn-all` teardown whose per-child destroyed traces fire
             no destroyer tears down EVERY child and clears the join slot. The
             fence must not suppress the live path."
-    (spawn-order/reset-all!)
+    (rf.machines.spawn-order/reset-all!)
     (let [frame-a :rf2-i4aj9c/spawn-all-live-frame]
       (rf/make-frame {:id frame-a})
       (seed-spawn-all! frame-a)
-      (let [token-a (frame/frame-incarnation-token frame-a)]
-        (frame/call-with-event-owner-token frame-a token-a
-          (fn [] (destroy/destroy-machine-fx
+      (let [token-a (rf.frame/frame-incarnation-token frame-a)]
+        (rf.frame/call-with-event-owner-token frame-a token-a
+          (fn [] (rf.machines.lifecycle-fx.destroy/destroy-machine-fx
                    {:frame frame-a}
                    {:rf/spawn-all true :rf/parent-id sa-parent :rf/invoke-id sa-invoke}))))
       (is (nil? (snapshot frame-a sa-child-a)) "child A torn down")
@@ -464,11 +464,11 @@
   The physical write always lands FIRST so A's write that linearized before the
   loss stands in A's captured container. Mirrors the #5889 spawn-write seam."
   [armed? on-write]
-  (let [base-replace (:replace-container! plain-atom/adapter)]
-    (adapter/dispose-adapter!)
-    (reset! frame/frames {})
-    (adapter/install-adapter!
-      (assoc plain-atom/adapter
+  (let [base-replace (:replace-container! rf.substrate.plain-atom/adapter)]
+    (rf.substrate.adapter/dispose-adapter!)
+    (reset! rf.frame/frames {})
+    (rf.substrate.adapter/install-adapter!
+      (assoc rf.substrate.plain-atom/adapter
              :kind :custom
              :replace-container!
              (fn [container value]
@@ -477,9 +477,9 @@
                  (on-write)))))))
 
 (defn- restore-plain-adapter! []
-  (reset! frame/frames {})
-  (adapter/dispose-adapter!)
-  (adapter/install-adapter! plain-atom/adapter))
+  (reset! rf.frame/frames {})
+  (rf.substrate.adapter/dispose-adapter!)
+  (rf.substrate.adapter/install-adapter! rf.substrate.plain-atom/adapter))
 
 (deftest classification-drop-write-watch-loss-fences-removal
   (testing "a container watch that destroys A + publishes same-id B DURING the
@@ -498,26 +498,26 @@
         armed?
         (fn []
           (when (compare-and-set! fired? false true)
-            (frame/destroy-frame! frame-a)         ;; destroy A during the drop write
+            (rf.frame/destroy-frame! frame-a)         ;; destroy A during the drop write
             (rf/make-frame {:id frame-a})            ;; same-id B
             ;; B re-lowers the SAME owner's classification claim.
-            (classification/lower-at-spawn! frame-a actor-id (classified-spec nil))
+            (rf.machines.classification/lower-at-spawn! frame-a actor-id (classified-spec nil))
             (reset! b-claim (elision-slot frame-a))
-            (reset! b-commit (frame/frame-commit-epoch frame-a)))))
+            (reset! b-commit (rf.frame/frame-commit-epoch frame-a)))))
       (try
         (rf/reg-machine actor-type (classified-spec nil))
         (rf/make-frame {:id frame-a})
-        (let [token-a (frame/frame-incarnation-token frame-a)]
+        (let [token-a (rf.frame/frame-incarnation-token frame-a)]
           (reset! armed? true)
-          (frame/call-with-event-owner-token frame-a token-a
-            (fn [] (classification/drop-at-destroy!
+          (rf.frame/call-with-event-owner-token frame-a token-a
+            (fn [] (rf.machines.classification/drop-at-destroy!
                      frame-a actor-id (classified-spec nil) token-a))))
         (is (true? @fired?) "the drop-write container watch ran (fence exercised)")
         (is (and (some? @b-claim) (seq @b-claim))
             "B re-lowered its classification claim")
         (is (= @b-claim (elision-slot frame-a))
             "B's classification claim SURVIVES — A's mid-write drop did not re-root onto B")
-        (is (= @b-commit (frame/frame-commit-epoch frame-a))
+        (is (= @b-commit (rf.frame/frame-commit-epoch frame-a))
             "A's mid-write loss never bumped B's commit epoch")
         (finally
           (restore-plain-adapter!))))))

--- a/implementation/machines/test/re_frame/machine_doc_opts_prod_elision_test.clj
+++ b/implementation/machines/test/re_frame/machine_doc_opts_prod_elision_test.clj
@@ -10,13 +10,13 @@
    1. SEMANTIC handler-meta strip — `(reg-machine :id {:doc \"…\"} spec)`
       registers under `:event`, funnelling through the single
       `re-frame.registrar/register!` `strip-pure-documentation` chokepoint, so
-      under the production posture (`interop/debug-enabled?` rebound to false,
+      under the production posture (`rf.interop/debug-enabled?` rebound to false,
       semantically equivalent to CLJS `:advanced` + `goog.DEBUG=false`)
       `(rf/handler-meta :event id)` carries no `:doc`; in dev it is retained.
 
    2. CLJS BUNDLE-string DCE — the macro's `expand-reg-machine` routes a literal
       doc-bearing opts map through `gate-doc-arg`, emitting an
-      `(if interop/debug-enabled? <full-opts> <opts-without-:doc>)` gate Closure
+      `(if rf.interop/debug-enabled? <full-opts> <opts-without-:doc>)` gate Closure
       constant-folds, so the user-authored `:doc` STRING bytes DCE from the
       :advanced bundle (a runtime strip cannot DCE a call-site string). That
       half is pinned by the elision probe (`scripts/check-elision.cjs`, the
@@ -25,22 +25,22 @@
   This file pins the SEMANTIC half for the machine surface."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
+            [re-frame.interop :as rf.interop]
             ;; Side-effect require: loads the machines artefact and publishes the
             ;; machine-registration late-bind hook `rf/reg-machine` resolves.
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (deftest reg-machine-opts-doc-stripped-under-disabled-debug-gate
   (testing "Per rf2-tfiutq: a `(reg-machine :id {:doc \"…\"} spec)` literal
             opts-map `:doc` is stripped from the stored registration metadata
             in prod, while a load-bearing opts key (`:schema`, the event-vector
             validator) is retained."
-    (with-redefs [interop/debug-enabled? false]
+    (with-redefs [rf.interop/debug-enabled? false]
       (rf/reg-machine :rf2-tfiutq/prod-machine
         {:doc "machine opts doc elided" :schema [:tuple :keyword]}
         {:initial :idle

--- a/implementation/machines/test/re_frame/machine_finality_purity_test.clj
+++ b/implementation/machines/test/re_frame/machine_finality_purity_test.clj
@@ -3,9 +3,9 @@
   lifecycle handler recomputes at the macrostep boundary to decide whether
   to fire `:on-done` + auto-destroy:
 
-    - `transition/final-state-node?` — the per-node `:final? true` flag.
-    - `transition/final-on-leaf?`    — the active LEAF of a snapshot is final.
-    - `finalize/all-regions-final?`  — a parallel machine is final iff
+    - `rf.machines.transition/final-state-node?` — the per-node `:final? true` flag.
+    - `rf.machines.transition/final-on-leaf?`    — the active LEAF of a snapshot is final.
+    - `rf.machines.lifecycle-fx.finalize/all-regions-final?`  — a parallel machine is final iff
       EVERY region's active leaf is final.
 
   The riskiest of the three is the parallel union (`all-regions-final?`,
@@ -21,9 +21,9 @@
     - A parallel-region machine is `:final?` only when EVERY region's
       active leaf is `:final?` (§Parallel regions and `:final?`)."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.machines.lifecycle-fx.finalize :as finalize]
-            [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.transition :as transition]))
+            [re-frame.machines.lifecycle-fx.finalize :as rf.machines.lifecycle-fx.finalize]
+            [re-frame.machines.parallel :as rf.machines.parallel]
+            [re-frame.machines.transition :as rf.machines.transition]))
 
 ;; ---------------------------------------------------------------------------
 ;; final-state-node? — the per-node :final? flag (transition.cljc:914)
@@ -31,24 +31,24 @@
 
 (deftest final-state-node?-reads-the-first-class-flag
   (testing ":final? true on a state-node ⇒ true"
-    (is (true? (transition/final-state-node? {:final? true}))
+    (is (true? (rf.machines.transition/final-state-node? {:final? true}))
         "a node declaring :final? true is final"))
 
   (testing "absent / false / non-true :final? ⇒ false (strict true? check)"
-    (is (false? (transition/final-state-node? {}))
+    (is (false? (rf.machines.transition/final-state-node? {}))
         "a node with no :final? key is not final")
-    (is (false? (transition/final-state-node? {:final? false}))
+    (is (false? (rf.machines.transition/final-state-node? {:final? false}))
         ":final? false is explicitly not final")
-    (is (false? (transition/final-state-node? {:on {:go :other}}))
+    (is (false? (rf.machines.transition/final-state-node? {:on {:go :other}}))
         "an ordinary transition-bearing node is not final")
     ;; Per Spec 005 D1 the flag is a FIRST-CLASS key. A truthy-
     ;; but-not-true value (e.g. stashed under :meta, or a non-boolean) is
     ;; NOT final — the predicate is `(true? ...)`, not `(boolean ...)`.
-    (is (false? (transition/final-state-node? {:meta {:final? true}}))
+    (is (false? (rf.machines.transition/final-state-node? {:meta {:final? true}}))
         ":final? under :meta is NOT the first-class key (D1) — not final")
-    (is (false? (transition/final-state-node? {:final? :yes}))
+    (is (false? (rf.machines.transition/final-state-node? {:final? :yes}))
         "a non-true truthy :final? value is not final (strict true? check)")
-    (is (false? (transition/final-state-node? nil))
+    (is (false? (rf.machines.transition/final-state-node? nil))
         "a nil node (path did not resolve) is not final")))
 
 ;; ---------------------------------------------------------------------------
@@ -73,22 +73,22 @@
 
 (deftest final-on-leaf?-flat-state
   (testing "a flat snapshot whose :state is the :final? leaf ⇒ true"
-    (is (true? (transition/final-on-leaf? flat-final-machine :done))
+    (is (true? (rf.machines.transition/final-on-leaf? flat-final-machine :done))
         "the :done leaf is :final?")
-    (is (true? (transition/final-on-leaf? flat-final-machine [:done]))
+    (is (true? (rf.machines.transition/final-on-leaf? flat-final-machine [:done]))
         "vector-form :state resolves to the same leaf"))
 
   (testing "a flat snapshot at a non-final leaf ⇒ false"
-    (is (false? (transition/final-on-leaf? flat-final-machine :running))
+    (is (false? (rf.machines.transition/final-on-leaf? flat-final-machine :running))
         "the :running leaf is not :final?")))
 
 (deftest final-on-leaf?-compound-state
   (testing "a compound snapshot whose active leaf is :final? ⇒ true"
-    (is (true? (transition/final-on-leaf? compound-final-machine [:wrapper :done]))
+    (is (true? (rf.machines.transition/final-on-leaf? compound-final-machine [:wrapper :done]))
         "the deeply-resolved [:wrapper :done] leaf is :final?"))
 
   (testing "a compound snapshot at a non-final leaf ⇒ false"
-    (is (false? (transition/final-on-leaf? compound-final-machine [:wrapper :running]))
+    (is (false? (rf.machines.transition/final-on-leaf? compound-final-machine [:wrapper :running]))
         "the [:wrapper :running] leaf is not :final?"))
 
   (testing "finality keys off the LEAF, not an ancestor"
@@ -96,8 +96,8 @@
     ;; a leaf property. Resolving the parent path (which final-on-leaf?
     ;; never does for a committed leaf snapshot, but pin the leaf-only
     ;; contract anyway via node-at) returns the non-final compound node.
-    (is (false? (transition/final-state-node?
-                  (transition/node-at compound-final-machine [:wrapper])))
+    (is (false? (rf.machines.transition/final-state-node?
+                  (rf.machines.transition/node-at compound-final-machine [:wrapper])))
         "the compound :wrapper ancestor is not itself :final?")))
 
 ;; ---------------------------------------------------------------------------
@@ -124,7 +124,7 @@
 
 (deftest all-regions-final?-every-region-final
   (testing "BOTH regions at their :final? leaf ⇒ true"
-    (is (true? (finalize/all-regions-final?
+    (is (true? (rf.machines.lifecycle-fx.finalize/all-regions-final?
                  parallel-machine
                  {:left :done :right :done}))
         "a parallel machine is final iff EVERY region's leaf is :final?")))
@@ -133,29 +133,29 @@
   (testing "ONE region final, the other still running ⇒ false (the risky branch)"
     ;; This is the premature-finalisation guard: a snapshot where :left has
     ;; reached :done but :right is still :running must NOT report final.
-    (is (false? (finalize/all-regions-final?
+    (is (false? (rf.machines.lifecycle-fx.finalize/all-regions-final?
                   parallel-machine
                   {:left :done :right :running}))
         "left-final + right-running must NOT finalise (partial-final guard)")
-    (is (false? (finalize/all-regions-final?
+    (is (false? (rf.machines.lifecycle-fx.finalize/all-regions-final?
                   parallel-machine
                   {:left :running :right :done}))
         "right-final + left-running must NOT finalise (symmetric)"))
 
   (testing "NEITHER region final ⇒ false"
-    (is (false? (finalize/all-regions-final?
+    (is (false? (rf.machines.lifecycle-fx.finalize/all-regions-final?
                   parallel-machine
                   {:left :running :right :running}))
         "both regions running ⇒ not final")))
 
 (deftest all-regions-final?-non-parallel-or-non-map-state
   (testing "a non-parallel machine ⇒ false regardless of state"
-    (is (false? (finalize/all-regions-final?
+    (is (false? (rf.machines.lifecycle-fx.finalize/all-regions-final?
                   flat-final-machine :done))
         "all-regions-final? short-circuits false for a non-parallel machine"))
 
   (testing "a parallel machine with a non-map :state ⇒ false"
-    (is (false? (finalize/all-regions-final? parallel-machine :done))
+    (is (false? (rf.machines.lifecycle-fx.finalize/all-regions-final? parallel-machine :done))
         "a keyword :state is not a region→leaf map ⇒ not all-regions-final")))
 
 (deftest all-regions-final?-vector-region-leaves
@@ -172,10 +172,10 @@
                        :right {:initial :running
                                :states  {:running {:on {:finish :done}}
                                          :done    {:final? true}}}}}]
-      (is (true? (finalize/all-regions-final?
+      (is (true? (rf.machines.lifecycle-fx.finalize/all-regions-final?
                    m {:left [:wrap :done] :right :done}))
           "a nested region leaf at [:wrap :done] resolves and is :final?")
-      (is (false? (finalize/all-regions-final?
+      (is (false? (rf.machines.lifecycle-fx.finalize/all-regions-final?
                     m {:left [:wrap :running] :right :done}))
           "a nested NON-final region leaf prevents finalisation"))))
 
@@ -192,19 +192,19 @@
 
 (deftest all-regions-final?-missing-region-is-not-final
   (testing "a snapshot MISSING a declared region is NOT all-final (no vacuous done)"
-    (is (false? (finalize/all-regions-final?
+    (is (false? (rf.machines.lifecycle-fx.finalize/all-regions-final?
                   parallel-machine {:left :done}))
         "{:left :done} for a 2-region machine must NOT read all-final — :right is absent")
-    (is (false? (finalize/all-regions-final?
+    (is (false? (rf.machines.lifecycle-fx.finalize/all-regions-final?
                   parallel-machine {:right :done}))
         "symmetric — :left absent")
-    (is (false? (finalize/all-regions-final?
+    (is (false? (rf.machines.lifecycle-fx.finalize/all-regions-final?
                   parallel-machine {}))
         "an empty region map is not all-final (every declared region absent)")))
 
 (deftest all-regions-final?-extra-region-is-not-final
   (testing "a snapshot carrying an EXTRA/stale region is NOT all-final (key parity)"
-    (is (false? (finalize/all-regions-final?
+    (is (false? (rf.machines.lifecycle-fx.finalize/all-regions-final?
                   parallel-machine {:left :done :right :done :middle :done}))
         "a stale :middle region (not declared) breaks exact key parity ⇒ not final")))
 
@@ -219,7 +219,7 @@
                        :right {:initial :running
                                :states  {:running {:on {:finish :done}}
                                          :done    {:final? true}}}}}]
-      (is (false? (finalize/all-regions-final?
+      (is (false? (rf.machines.lifecycle-fx.finalize/all-regions-final?
                     m {:left :hist :right :done}))
           "a region occupying a history pseudo-state is malformed ⇒ not all-final"))))
 
@@ -229,21 +229,21 @@
 
 (deftest parallel-state-valid?-requires-exact-key-parity-and-occupiable-leaves
   (testing "valid iff map? + EXACT declared region keys + every region occupiable"
-    (is (true? (parallel/parallel-state-valid?
+    (is (true? (rf.machines.parallel/parallel-state-valid?
                  parallel-machine {:left :running :right :done}))
         "exactly the declared regions, each resolving to a real leaf ⇒ valid")
-    (is (false? (parallel/parallel-state-valid?
+    (is (false? (rf.machines.parallel/parallel-state-valid?
                   parallel-machine {:left :running}))
         "missing a declared region ⇒ invalid")
-    (is (false? (parallel/parallel-state-valid?
+    (is (false? (rf.machines.parallel/parallel-state-valid?
                   parallel-machine {:left :running :right :done :extra :running}))
         "an extra/stale region ⇒ invalid")
-    (is (false? (parallel/parallel-state-valid?
+    (is (false? (rf.machines.parallel/parallel-state-valid?
                   parallel-machine {:left :nope :right :done}))
         "a region path that does not resolve ⇒ invalid")
-    (is (false? (parallel/parallel-state-valid? parallel-machine :running))
+    (is (false? (rf.machines.parallel/parallel-state-valid? parallel-machine :running))
         "a non-map :state ⇒ invalid")
-    (is (false? (parallel/parallel-state-valid? flat-final-machine {:left :running :right :done}))
+    (is (false? (rf.machines.parallel/parallel-state-valid? flat-final-machine {:left :running :right :done}))
         "a non-parallel machine ⇒ invalid (the predicate is parallel-only)")))
 
 ;; ---------------------------------------------------------------------------
@@ -258,12 +258,12 @@
                                          :b    {}
                                          :hist {:type :history}}}}}]
     (testing "a real occupiable leaf ⇒ true"
-      (is (true? (transition/state-occupiable? m [:playing :a]))
+      (is (true? (rf.machines.transition/state-occupiable? m [:playing :a]))
           "[:playing :a] resolves to a real leaf")
-      (is (true? (transition/state-occupiable? m [:playing :b]))))
+      (is (true? (rf.machines.transition/state-occupiable? m [:playing :b]))))
     (testing "a :type :history pseudo-state is targetable but NEVER occupied ⇒ false"
-      (is (false? (transition/state-occupiable? m [:playing :hist]))
+      (is (false? (rf.machines.transition/state-occupiable? m [:playing :hist]))
           "an occupied history pseudo-state is malformed"))
     (testing "a path that does not resolve ⇒ false"
-      (is (false? (transition/state-occupiable? m [:playing :gone])))
-      (is (false? (transition/state-occupiable? m :no-such-state))))))
+      (is (false? (rf.machines.transition/state-occupiable? m [:playing :gone])))
+      (is (false? (rf.machines.transition/state-occupiable? m :no-such-state))))))

--- a/implementation/machines/test/re_frame/machine_front_of_queue_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_front_of_queue_cljs_test.cljc
@@ -24,13 +24,13 @@
   nowhere but the JVM and reads as covered (rf2-dn6v7, rf2-lgozq)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.router :as router]
+            [re-frame.router :as rf.router]
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (def ^:private run-log (atom []))
 
@@ -62,8 +62,8 @@
       (fn [_ _]
         (log! :seed)
         ;; Machine event queued FIRST, external event SECOND.
-        (router/dispatch! [:rf2-j20a7/leapfrog [:go]] {})
-        (router/dispatch! [:ext] {})
+        (rf.router/dispatch! [:rf2-j20a7/leapfrog [:go]] {})
+        (rf.router/dispatch! [:ext] {})
         {}))
     (rf/dispatch-sync [:seed])
     (is (= [:seed :machine-action :cont :ext] @run-log)
@@ -89,8 +89,8 @@
         ;; Both are EXTERNAL dispatches (origin = this plain handler's fx
         ;; emit). The machine event is queued first; targeting a machine
         ;; must NOT move it relative to the later plain event.
-        (router/dispatch! [:rf2-j20a7/fifo-target [:go]] {})
-        (router/dispatch! [:plain] {})
+        (rf.router/dispatch! [:rf2-j20a7/fifo-target [:go]] {})
+        (rf.router/dispatch! [:plain] {})
         {}))
     (rf/dispatch-sync [:seed])
     (is (= [:seed :machine-ran :plain] @run-log)
@@ -112,7 +112,7 @@
     (rf/reg-event :cont-1
       (fn [_ _]
         (log! :cont-1)
-        (router/dispatch! [:cont-2] {}) ;; plain origin → back of queue
+        (rf.router/dispatch! [:cont-2] {}) ;; plain origin → back of queue
         {}))
     (reg-marker :cont-2)
     (rf/reg-machine :rf2-j20a7/quiesce
@@ -126,8 +126,8 @@
     (rf/reg-event :seed
       (fn [_ _]
         (log! :seed)
-        (router/dispatch! [:rf2-j20a7/quiesce [:go]] {})
-        (router/dispatch! [:ext] {})
+        (rf.router/dispatch! [:rf2-j20a7/quiesce [:go]] {})
+        (rf.router/dispatch! [:ext] {})
         {}))
     (rf/dispatch-sync [:seed])
     ;; Trace through the queue:

--- a/implementation/machines/test/re_frame/machine_history_smoke_test.clj
+++ b/implementation/machines/test/re_frame/machine_history_smoke_test.clj
@@ -348,7 +348,7 @@
 (deftest cascade-step-source-stamping
   (testing "history-driven :entry cascade steps carry :source (spec/009 line 291)"
     ;; Re-run the restore and read the structured cascade off the ENGINE
-    ;; seam's Result (the `::rf.machines.result/cascade` rider is lifecycle bookkeeping
+    ;; seam's Result (the `:re-frame.machines.result/cascade` rider is lifecycle bookkeeping
     ;; the public map does not carry) — each :entry step must carry :source
     ;; matching the restored event; non-history steps (exit) carry none.
     (let [after-stop (step deep-player (seed [:player :playing :mid-track]) [:stop])

--- a/implementation/machines/test/re_frame/machine_history_smoke_test.clj
+++ b/implementation/machines/test/re_frame/machine_history_smoke_test.clj
@@ -28,32 +28,32 @@
   `:prev-config` / `:resolved-leaf`) + the cascade-step `:source` stamping
   (spec/009 line 291)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.machines :as machines]
-            [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.result :as result]
-            [re-frame.machines.test-support :as mtest]))
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.parallel :as rf.machines.parallel]
+            [re-frame.machines.result :as rf.machines.result]
+            [re-frame.machines.test-support :as rf.machines.test-support]))
 
 ;; ---- trace capture (spec/009 shape proof) --------------------------------
 ;;
 ;; Trace capture via the shared machines test-support:
-;; the `:each` `trace-capture-fixture` feeds `mtest/*captured*` with guaranteed
+;; the `:each` `trace-capture-fixture` feeds `rf.machines.test-support/*captured*` with guaranteed
 ;; unregister in a `finally`; `events-of` / `reset-captured!` read + clear it.
 
-(use-fixtures :each mtest/trace-capture-fixture)
+(use-fixtures :each rf.machines.test-support/trace-capture-fixture)
 
 (defn- history-events
   "The captured events for the given history `operation`
   (`:rf.machine.history/restored` | `:rf.machine.history/recorded`)."
   [operation]
-  (mtest/events-of operation))
+  (rf.machines.test-support/events-of operation))
 
-(defn- reset-capture! [] (mtest/reset-captured!))
+(defn- reset-capture! [] (rf.machines.test-support/reset-captured!))
 
 (defn- step
   "Apply one macrostep and return the post-transition snapshot. Asserts the
   step did not fail."
   [machine snapshot event]
-  (let [r (machines/machine-transition machine snapshot event)]
+  (let [r (rf.machines/machine-transition machine snapshot event)]
     (is (= :ok (:status r)) (str "transition ok for event " (pr-str event)))
     (:snapshot r)))
 
@@ -165,7 +165,7 @@
     ;; dead path. Benign — no :rf.error/*.
     (let [snap     (assoc (seed [:player :stopped])
                           :rf/history {[:player :playing] [:player :playing :gone]})
-          r        (machines/machine-transition deep-player snap [:play])]
+          r        (rf.machines/machine-transition deep-player snap [:play])]
       (is (= :ok (:status r)) "dangling path is benign — no failure")
       (let [restored (:snapshot r)]
         (is (= [:player :playing :at-start] (:state restored))
@@ -348,13 +348,13 @@
 (deftest cascade-step-source-stamping
   (testing "history-driven :entry cascade steps carry :source (spec/009 line 291)"
     ;; Re-run the restore and read the structured cascade off the ENGINE
-    ;; seam's Result (the `::result/cascade` rider is lifecycle bookkeeping
+    ;; seam's Result (the `::rf.machines.result/cascade` rider is lifecycle bookkeeping
     ;; the public map does not carry) — each :entry step must carry :source
     ;; matching the restored event; non-history steps (exit) carry none.
     (let [after-stop (step deep-player (seed [:player :playing :mid-track]) [:stop])
-          r          (parallel/machine-transition deep-player after-stop [:play])]
-      (is (result/ok? r))
-      (let [cascade (result/cascade r)
+          r          (rf.machines.parallel/machine-transition deep-player after-stop [:play])]
+      (is (rf.machines.result/ok? r))
+      (let [cascade (rf.machines.result/cascade r)
             entries (filterv #(= :entry (:kind %)) cascade)
             exits   (filterv #(= :exit (:kind %)) cascade)]
         (is (seq entries) "the restore produced entry steps")
@@ -366,10 +366,10 @@
 (deftest non-history-transition-has-no-source-on-steps
   (testing "an ordinary (non-history) transition stamps NO :source on cascade steps"
     ;; :seek :at-start→:mid-track is a plain leaf transition — no history.
-    (let [r       (parallel/machine-transition
+    (let [r       (rf.machines.parallel/machine-transition
                     deep-player (seed [:player :playing :at-start]) [:seek])
-          cascade (result/cascade r)]
-      (is (result/ok? r))
+          cascade (rf.machines.result/cascade r)]
+      (is (rf.machines.result/ok? r))
       (is (every? #(not (contains? % :source))
                   (filterv #(= :entry (:kind %)) cascade))
           "no :source on entry steps of a non-history transition")

--- a/implementation/machines/test/re_frame/machine_history_unit_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_history_unit_cljs_test.cljc
@@ -44,31 +44,31 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    #?(:cljs [cljs.reader])
-   [re-frame.machines :as machines]
-   [re-frame.machines.parallel :as parallel]
-   [re-frame.machines.result :as result]
-   [re-frame.machines.test-support :as mtest]))
+   [re-frame.machines :as rf.machines]
+   [re-frame.machines.parallel :as rf.machines.parallel]
+   [re-frame.machines.result :as rf.machines.result]
+   [re-frame.machines.test-support :as rf.machines.test-support]))
 
 ;; ===========================================================================
 ;; Harness — pure engine + trace capture (shared)
 ;; ===========================================================================
 ;;
 ;; Trace capture (register + guaranteed unregister, CLJ/CLJS-compatible) is
-;; the shared `mtest/trace-capture-fixture`; `history-events` / `reset-
+;; the shared `rf.machines.test-support/trace-capture-fixture`; `history-events` / `reset-
 ;; capture!` are thin wrappers over its `events-of` / `reset-captured!`.
 
-(use-fixtures :each mtest/trace-capture-fixture)
+(use-fixtures :each rf.machines.test-support/trace-capture-fixture)
 
 (defn- history-events
   [operation]
-  (mtest/events-of operation))
+  (rf.machines.test-support/events-of operation))
 
-(defn- reset-capture! [] (mtest/reset-captured!))
+(defn- reset-capture! [] (rf.machines.test-support/reset-captured!))
 
 (defn- step
   "Apply one macrostep; assert it succeeded; return the post snapshot."
   [machine snapshot event]
-  (let [r (machines/machine-transition machine snapshot event)]
+  (let [r (rf.machines/machine-transition machine snapshot event)]
     (is (= :ok (:status r)) (str "transition ok for event " (pr-str event)))
     (:snapshot r)))
 
@@ -267,11 +267,11 @@
     (let [m    (player true)
           snap (assoc (seed :away)
                       :rf/history {[:player] [:player :playing :gone]})
-          r    (machines/machine-transition m snap [:resume])]
+          r    (rf.machines/machine-transition m snap [:resume])]
       (is (= :ok (:status r)) "dangling deep path is benign — no failure Result")
       (is (= [:player :playing :at-start] (:state (:snapshot r)))
           "discarded the dead leaf ⇒ fell back to :default-target → :at-start")
-      (is (empty? (filterv #(= :error (:op-type %)) (mtest/captured-events)))
+      (is (empty? (filterv #(= :error (:op-type %)) (rf.machines.test-support/captured-events)))
           "no :rf.error/* trace for a dangling-at-runtime recording"))))
 
 (deftest dangling-shallow-child-falls-back-no-error
@@ -279,11 +279,11 @@
     (let [m    (player false)
           ;; :ghost is not a child of :player in the current definition.
           snap (assoc (seed :away) :rf/history {[:player] :ghost})
-          r    (machines/machine-transition m snap [:resume])]
+          r    (rf.machines/machine-transition m snap [:resume])]
       (is (= :ok (:status r)) "dangling shallow child is benign")
       (is (= [:player :playing :at-start] (:state (:snapshot r)))
           "discarded the dead child ⇒ fell back to :default-target → :at-start")
-      (is (empty? (filterv #(= :error (:op-type %)) (mtest/captured-events)))
+      (is (empty? (filterv #(= :error (:op-type %)) (rf.machines.test-support/captured-events)))
           "no :rf.error/* for a dangling shallow child"))))
 
 ;; ===========================================================================
@@ -417,11 +417,11 @@
       (reset-capture!)
       ;; The cascade rider is engine bookkeeping the public map does not
       ;; carry, so this one assertion reads the engine seam's Result.
-      (let [r       (parallel/machine-transition nested away [:return])
-            cascade (result/cascade r)
+      (let [r       (rf.machines.parallel/machine-transition nested away [:return])
+            cascade (rf.machines.result/cascade r)
             entries (filterv #(= :entry (:kind %)) cascade)
             restored (history-events :rf.machine.history/restored)]
-        (is (result/ok? r))
+        (is (rf.machines.result/ok? r))
         (is (= 1 (count restored)) "one restored event for the outer history re-entry")
         (is (= :recorded (:source (first restored))) ":source :recorded (hoisted to envelope)")
         (is (= [:outer] (:compound-path (:tags (first restored))))

--- a/implementation/machines/test/re_frame/machine_hostile_keys_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_hostile_keys_cljs_test.cljc
@@ -37,14 +37,14 @@
    ;; Load the machines facade so `rf/reg-machine` routes through its
    ;; late-bind hook (`:machines/reg-machine`).
    [re-frame.machines]
-   [re-frame.machines.test-support :as mtest]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter})))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter})))
 
 ;; ---------------------------------------------------------------------------
 ;; The forged key.

--- a/implementation/machines/test/re_frame/machine_hydration_reconcile_incarnation_fence_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_hydration_reconcile_incarnation_fence_cljs_test.cljc
@@ -81,21 +81,21 @@
   published on the cancellation callback's own stack."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
             ;; Loading `re-frame.machines` installs the artefact's late-bind
             ;; hooks + reserved fxs; under a single-ns run nothing else does.
             [re-frame.machines]
-            [re-frame.machines.hydrate :as m-hydrate]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.machines.timer :as timer]
-            [re-frame.subs :as subs]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.machines.hydrate :as rf.machines.hydrate]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.machines.timer :as rf.machines.timer]
+            [re-frame.subs :as rf.subs]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter})
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter})
+  rf.machines.test-support/trace-capture-fixture)
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures
@@ -116,7 +116,7 @@
 (defn- inner
   "`frame-id`'s inner `:after` timer table, or `{}` when it holds none."
   [frame-id]
-  (get @timer/after-timers frame-id {}))
+  (get @rf.machines.timer/after-timers frame-id {}))
 
 (defn- server-runtime-db
   "Run every `[machine-id events]` pair on ONE real SERVER frame, assert it
@@ -130,15 +130,15 @@
       (rf/dispatch-sync [machine-id e] {:frame sfid}))
     (is (empty? (inner sfid))
         "precondition: the SERVER armed no `:after` host timer")
-    (frame/frame-runtime-db-value sfid)))
+    (rf.frame/frame-runtime-db-value sfid)))
 
 (defn- install!
   "Replace `frame-id`'s runtime-db with `runtime-db` and run the machines
   hydration seam — what `:rf/hydrate` does once its runtime-db effect has
   committed."
   [frame-id runtime-db]
-  (frame/replace-runtime-db! frame-id runtime-db)
-  (m-hydrate/rearm-after-timers! frame-id))
+  (rf.frame/replace-runtime-db! frame-id runtime-db)
+  (rf.machines.hydrate/rearm-after-timers! frame-id))
 
 (defn- republish-frame-once!
   "Register a `:rf.machine.timer/cancelled` listener under `listener-id` that,
@@ -150,14 +150,14 @@
   token so the test can prove B is a genuinely distinct incarnation rather than
   the same frame under a new name."
   [listener-id frame-id fired? token-b]
-  (trace-tooling/register-listener!
+  (rf.trace.tooling/register-listener!
     listener-id
     (fn [ev]
       (when (and (= :rf.machine.timer/cancelled (:operation ev))
                  (compare-and-set! fired? false true))
-        (frame/destroy-frame! frame-id)
+        (rf.frame/destroy-frame! frame-id)
         (rf/make-frame {:id frame-id :platform :client})
-        (reset! token-b (frame/frame-incarnation-token frame-id))))))
+        (reset! token-b (rf.frame/frame-incarnation-token frame-id))))))
 
 (defn- assert-successor-took-no-a-work!
   "The four readings of successor B. A dropped table entry is the obvious one;
@@ -167,7 +167,7 @@
       (str "successor B holds NO timer. Under a per-step capture the arm phase "
            "reads B as its current owner and installs A-derived host work into "
            "a frame that never enumerated it."))
-  (is (empty? (mtest/events-of :rf.machine.timer/scheduled))
+  (is (empty? (rf.machines.test-support/events-of :rf.machine.timer/scheduled))
       (str "and no `:rf.machine.timer/scheduled` row was emitted for B — a "
            "hydrated-timer trace naming a frame that hydrated nothing"))
   (is (zero? @subscribes)
@@ -175,11 +175,11 @@
            "name — the ref-count an A-derived arm bumps is B's to release"))
   ;; The watcher is the half a table read cannot reach: an attached one
   ;; re-enters the timer machinery on the next value change.
-  (mtest/reset-captured!)
+  (rf.machines.test-support/reset-captured!)
   (reset! reaction 9000)
-  (is (empty? (mtest/events-of :rf.machine.timer/scheduled))
+  (is (empty? (rf.machines.test-support/events-of :rf.machine.timer/scheduled))
       "a change in the delay's value re-resolves nothing in B")
-  (is (empty? (mtest/events-of :rf.machine.timer/cancelled))
+  (is (empty? (rf.machines.test-support/events-of :rf.machine.timer/cancelled))
       (str "and reaches NOTHING at all — an A-derived arm would have left its "
            "re-resolution watcher attached to the reaction here")))
 
@@ -233,11 +233,11 @@
           subscribes (atom 0)
           fired?     (atom false)
           token-b    (atom nil)]
-      (with-redefs [subs/subscribe            (fn ([_q] (swap! subscribes inc) reaction)
+      (with-redefs [rf.subs/subscribe            (fn ([_q] (swap! subscribes inc) reaction)
                                                 ([_q _o] (swap! subscribes inc) reaction))
-                    subs/unsubscribe          (fn ([_q] nil) ([_f _q] nil))
-                    interop/schedule-after!   (fn [_thunk _ms] ::handle)
-                    interop/cancel-scheduled! (fn [_h] nil)]
+                    rf.subs/unsubscribe          (fn ([_q] nil) ([_f _q] nil))
+                    rf.interop/schedule-after!   (fn [_thunk _ms] ::handle)
+                    rf.interop/cancel-scheduled! (fn [_h] nil)]
         (let [rt-both (server-runtime-db [[:hydfence/kept [[:go]]]
                                           [:hydfence/gone [[:go]]]])
               rt-kept (update-in rt-both [:rf.runtime/machines :snapshots]
@@ -253,13 +253,13 @@
           (is (= 2 (count (inner cfid)))
               "precondition: both actors' timers are armed under incarnation A")
 
-          (let [token-a (frame/frame-incarnation-token cfid)]
+          (let [token-a (rf.frame/frame-incarnation-token cfid)]
             (reset! subscribes 0)
-            (mtest/reset-captured!)
+            (rf.machines.test-support/reset-captured!)
             (republish-frame-once! ::cancel-phase cfid fired? token-b)
             (try
               (install! cfid rt-kept)
-              (finally (trace-tooling/unregister-listener! ::cancel-phase)))
+              (finally (rf.trace.tooling/unregister-listener! ::cancel-phase)))
 
             (is (true? @fired?)
                 "the phase-1 cancellation's listener ran (the seam is exercised)")
@@ -282,11 +282,11 @@
           subscribes (atom 0)
           fired?     (atom false)
           token-b    (atom nil)]
-      (with-redefs [subs/subscribe            (fn ([_q] (swap! subscribes inc) reaction)
+      (with-redefs [rf.subs/subscribe            (fn ([_q] (swap! subscribes inc) reaction)
                                                 ([_q _o] (swap! subscribes inc) reaction))
-                    subs/unsubscribe          (fn ([_q] nil) ([_f _q] nil))
-                    interop/schedule-after!   (fn [_thunk _ms] ::handle)
-                    interop/cancel-scheduled! (fn [_h] nil)]
+                    rf.subs/unsubscribe          (fn ([_q] nil) ([_f _q] nil))
+                    rf.interop/schedule-after!   (fn [_thunk _ms] ::handle)
+                    rf.interop/cancel-scheduled! (fn [_h] nil)]
         (let [rt   (server-runtime-db [[:hydfence/multi [[:go]]]])
               cfid (fresh-frame! :client)]
           (install! cfid rt)
@@ -294,13 +294,13 @@
               "precondition: BOTH live declarations are armed, so both arms of
                the re-hydration supersede a LIVE entry and are callback-bearing")
 
-          (let [token-a (frame/frame-incarnation-token cfid)]
+          (let [token-a (rf.frame/frame-incarnation-token cfid)]
             (reset! subscribes 0)
-            (mtest/reset-captured!)
+            (rf.machines.test-support/reset-captured!)
             (republish-frame-once! ::arm-phase cfid fired? token-b)
             (try
               (install! cfid rt)
-              (finally (trace-tooling/unregister-listener! ::arm-phase)))
+              (finally (rf.trace.tooling/unregister-listener! ::arm-phase)))
 
             (is (true? @fired?)
                 "arm 1's `:on-supersede` fired and swapped A→B (seam exercised)")
@@ -323,14 +323,14 @@
   hold and the delay resolution both precede the trace and belong to A; what is
   under test is what the arm does with them once A is gone."
   [listener-id frame-id fired? token-b zero!]
-  (trace-tooling/register-listener!
+  (rf.trace.tooling/register-listener!
     listener-id
     (fn [ev]
       (when (and (= :rf.machine.timer/scheduled (:operation ev))
                  (compare-and-set! fired? false true))
-        (frame/destroy-frame! frame-id)
+        (rf.frame/destroy-frame! frame-id)
         (rf/make-frame {:id frame-id :platform :client})
-        (reset! token-b (frame/frame-incarnation-token frame-id))
+        (reset! token-b (rf.frame/frame-incarnation-token frame-id))
         (zero!)))))
 
 (defn- assert-no-orphan-scheduled-row!
@@ -347,13 +347,13 @@
   that never opened. Nothing downstream can retract it: the epoch and
   active-path gates suppress a stale FIRE, and there is no fire."
   []
-  (let [scheduled (mtest/events-of :rf.machine.timer/scheduled)
-        cancelled (mtest/events-of :rf.machine.timer/cancelled)
+  (let [scheduled (rf.machines.test-support/events-of :rf.machine.timer/scheduled)
+        cancelled (rf.machines.test-support/events-of :rf.machine.timer/cancelled)
         pair-keys [:actor-id :state :delay :epoch :frame]
         timer-ops (filterv (comp #{:rf.machine.timer/scheduled
                                    :rf.machine.timer/cancelled}
                                  :operation)
-                           (mtest/captured-events))]
+                           (rf.machines.test-support/captured-events))]
     (is (= 1 (count scheduled))
         (str "precondition: the aborted arm DID announce itself — exactly one "
              "`:rf.machine.timer/scheduled` row reached the stream before the "
@@ -392,27 +392,27 @@
           arms         (atom 0)
           fired?       (atom false)
           token-b      (atom nil)]
-      (with-redefs [subs/subscribe            (fn ([_q] (swap! subscribes inc) reaction)
+      (with-redefs [rf.subs/subscribe            (fn ([_q] (swap! subscribes inc) reaction)
                                                 ([_q _o] (swap! subscribes inc) reaction))
-                    subs/unsubscribe          (fn ([_q] (swap! unsubscribes inc) nil)
+                    rf.subs/unsubscribe          (fn ([_q] (swap! unsubscribes inc) nil)
                                                 ([_f _q] (swap! unsubscribes inc) nil))
-                    interop/schedule-after!   (fn [_thunk _ms] (swap! arms inc) ::handle)
-                    interop/cancel-scheduled! (fn [_h] nil)]
+                    rf.interop/schedule-after!   (fn [_thunk _ms] (swap! arms inc) ::handle)
+                    rf.interop/cancel-scheduled! (fn [_h] nil)]
         (let [rt      (server-runtime-db [[:hydfence/sched [[:go]]]])
               cfid    (fresh-frame! :client)
-              token-a (frame/frame-incarnation-token cfid)]
+              token-a (rf.frame/frame-incarnation-token cfid)]
           (is (empty? (inner cfid))
               (str "precondition: a FRESH client frame holds no `:after` timer, "
                    "so phase 1 cancels nothing and the single arm supersedes an "
                    "empty slot — the `/scheduled` row is therefore the FIRST "
                    "callback-bearing trace of the whole reconcile"))
-          (mtest/reset-captured!)
+          (rf.machines.test-support/reset-captured!)
           (republish-on-scheduled-once!
             ::sched-phase cfid fired? token-b
             #(do (reset! subscribes 0) (reset! unsubscribes 0) (reset! arms 0)))
           (try
             (install! cfid rt)
-            (finally (trace-tooling/unregister-listener! ::sched-phase)))
+            (finally (rf.trace.tooling/unregister-listener! ::sched-phase)))
 
           (is (true? @fired?)
               "the `/scheduled` listener ran (the seam is exercised)")
@@ -434,17 +434,17 @@
               (str "and the abort issued NO `(frame, query-v)` decrement: A's "
                    "hold was taken against A's own sub-cache, which "
                    "`destroy-frame!` disposed wholesale on this very stack, "
-                   "while `subs/unsubscribe` addresses the frame by bare id — "
+                   "while `rf.subs/unsubscribe` addresses the frame by bare id — "
                    "which now denotes B. There is nothing of A's left to "
                    "release, and releasing would drop a count B holds "
                    "(rf2-i4aj9c)"))
           (assert-no-orphan-scheduled-row!)
 
-          (mtest/reset-captured!)
+          (rf.machines.test-support/reset-captured!)
           (reset! reaction 9000)
-          (is (empty? (mtest/events-of :rf.machine.timer/scheduled))
+          (is (empty? (rf.machines.test-support/events-of :rf.machine.timer/scheduled))
               "a change in the delay's value re-resolves nothing in B")
-          (is (empty? (mtest/events-of :rf.machine.timer/cancelled))
+          (is (empty? (rf.machines.test-support/events-of :rf.machine.timer/cancelled))
               (str "and reaches NOTHING at all — an arm that ran past the "
                    "`/scheduled` callback attaches its re-resolution watcher to "
                    "the reaction here, and the watcher re-enters the timer "
@@ -459,19 +459,19 @@
     (let [arms    (atom 0)
           fired?  (atom false)
           token-b (atom nil)]
-      (with-redefs [interop/schedule-after!   (fn [_thunk _ms] (swap! arms inc) ::handle)
-                    interop/cancel-scheduled! (fn [_h] nil)]
+      (with-redefs [rf.interop/schedule-after!   (fn [_thunk _ms] (swap! arms inc) ::handle)
+                    rf.interop/cancel-scheduled! (fn [_h] nil)]
         (let [rt      (server-runtime-db [[:hydfence/sched-lit [[:go]]]])
               cfid    (fresh-frame! :client)
-              token-a (frame/frame-incarnation-token cfid)]
+              token-a (rf.frame/frame-incarnation-token cfid)]
           (is (empty? (inner cfid))
               "precondition: the client frame holds no prior timer")
-          (mtest/reset-captured!)
+          (rf.machines.test-support/reset-captured!)
           (republish-on-scheduled-once!
             ::sched-phase-lit cfid fired? token-b #(reset! arms 0))
           (try
             (install! cfid rt)
-            (finally (trace-tooling/unregister-listener! ::sched-phase-lit)))
+            (finally (rf.trace.tooling/unregister-listener! ::sched-phase-lit)))
 
           (is (true? @fired?) "the `/scheduled` listener ran")
           (is (not (identical? token-a @token-b))
@@ -497,30 +497,30 @@
     (rf/reg-machine :hydfence/live two-delay-machine)
     (let [reaction   (atom 2500)
           subscribes (atom 0)]
-      (with-redefs [subs/subscribe            (fn ([_q] (swap! subscribes inc) reaction)
+      (with-redefs [rf.subs/subscribe            (fn ([_q] (swap! subscribes inc) reaction)
                                                 ([_q _o] (swap! subscribes inc) reaction))
-                    subs/unsubscribe          (fn ([_q] nil) ([_f _q] nil))
-                    interop/schedule-after!   (fn [_thunk _ms] ::handle)
-                    interop/cancel-scheduled! (fn [_h] nil)]
+                    rf.subs/unsubscribe          (fn ([_q] nil) ([_f _q] nil))
+                    rf.interop/schedule-after!   (fn [_thunk _ms] ::handle)
+                    rf.interop/cancel-scheduled! (fn [_h] nil)]
         (let [rt   (server-runtime-db [[:hydfence/live [[:go]]]])
               cfid (fresh-frame! :client)]
-          (mtest/reset-captured!)
+          (rf.machines.test-support/reset-captured!)
           (install! cfid rt)
           (is (= 2 (count (inner cfid)))
               "both declarations armed on the first hydration")
-          (is (= 2 (count (mtest/events-of :rf.machine.timer/scheduled)))
+          (is (= 2 (count (rf.machines.test-support/events-of :rf.machine.timer/scheduled)))
               "one `/scheduled` row apiece")
 
-          (mtest/reset-captured!)
+          (rf.machines.test-support/reset-captured!)
           (install! cfid rt)
           (is (= 2 (count (inner cfid)))
               "and still exactly two handles after an identical re-hydration —
                each live declaration superseded in place, neither truncated")
-          (is (= 2 (count (mtest/events-of :rf.machine.timer/scheduled)))
+          (is (= 2 (count (rf.machines.test-support/events-of :rf.machine.timer/scheduled)))
               "both arms ran")
           (is (= [:on-supersede :on-supersede]
                  (mapv #(:reason (:tags %))
-                       (mtest/events-of :rf.machine.timer/cancelled)))
+                       (rf.machines.test-support/events-of :rf.machine.timer/cancelled)))
               (str "and each was the ordinary same-key supersede — an arm loop "
                    "that stopped early would leave the second declaration's "
                    "prior handle uncancelled and unre-armed")))))))

--- a/implementation/machines/test/re_frame/machine_identity_naming_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machine_identity_naming_cljs_test.cljs
@@ -21,15 +21,15 @@
       keyword address vs a state-path vector)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.trace.tooling :as trace-tooling]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.machines.test-support :as mtest]))
+            [re-frame.trace.tooling :as rf.trace.tooling]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.machines.test-support :as rf.machines.test-support]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (defn- ops [traces op]
   (filter #(= op (:operation %)) traces))
@@ -55,7 +55,7 @@
           traces (atom [])]
       (rf/reg-machine :idn/child child)
       (rf/reg-machine :idn/parent parent)
-      (trace-tooling/register-listener! ::idn (fn [ev] (swap! traces conj ev)))
+      (rf.trace.tooling/register-listener! ::idn (fn [ev] (swap! traces conj ev)))
       ;; Spawn the child (deterministic instance id :idn/child#1).
       (rf/dispatch-sync [:idn/parent [:go]])
       (let [spawned-id (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
@@ -105,7 +105,7 @@
           traces (atom [])]
       (rf/reg-machine :idn2/child child)
       (rf/reg-machine :idn2/parent parent)
-      (trace-tooling/register-listener! ::idn2 (fn [ev] (swap! traces conj ev)))
+      (rf.trace.tooling/register-listener! ::idn2 (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:idn2/parent [:go]])
       (let [spawned (first (ops @traces :rf.machine.lifecycle/spawned))]
         (is (some? spawned) ":rf.machine.lifecycle/spawned fired")
@@ -164,7 +164,7 @@
     (let [m {:initial :a :states {:a {:on {:go :b}} :b {}}}
           traces (atom [])]
       (rf/reg-machine :idn4/single m)
-      (trace-tooling/register-listener! ::idn4 (fn [ev] (swap! traces conj ev)))
+      (rf.trace.tooling/register-listener! ::idn4 (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:idn4/single [:go]])
       (let [tr (first (ops @traces :rf.machine/transition))]
         (is (some? tr))

--- a/implementation/machines/test/re_frame/machine_identity_naming_pure_test.clj
+++ b/implementation/machines/test/re_frame/machine_identity_naming_pure_test.clj
@@ -16,7 +16,7 @@
       names the registered TYPE; the allocated `:rf/spawned-id` is the live
       INSTANCE address (`<type>#<n>`) — never conflated."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.machines :as machines]))
+            [re-frame.machines :as rf.machines]))
 
 (deftest gensym-spawn-emits-distinct-type-instance-and-invoke-path
   (testing "rf2-ws5thu/rf2-0ggtr5 — a gensym spawn fx carries TYPE (:machine-id), INSTANCE (:rf/spawned-id) and invocation PATH (:rf/invoke-id) as distinct facts"
@@ -25,7 +25,7 @@
                 :states  {:idle    {:on {:go :working}}
                           :working {:spawn {:machine-id :idn/worker
                                             :data       {:k :v}}}}}
-          {fx :fx} (machines/machine-transition spec {:state :idle :data {}} [:go])
+          {fx :fx} (rf.machines/machine-transition spec {:state :idle :data {}} [:go])
           [[fx-id args]]   fx]
       (is (= :rf.machine/spawn fx-id))
       (is (= :idn/worker (:machine-id args))
@@ -52,7 +52,7 @@
                 :states  {:idle    {:on {:go :working}}
                           :working {:spawn {:machine-id     :idn/worker
                                             :fixed-actor-id :idn/pinned}}}}
-          {fx :fx} (machines/machine-transition spec {:state :idle :data {}} [:go])
+          {fx :fx} (rf.machines/machine-transition spec {:state :idle :data {}} [:go])
           [[_ args]]       fx]
       (is (= :idn/pinned (:rf/spawned-id args))
           "the explicit :fixed-actor-id is used verbatim as the instance address (no gensym, no #n)")
@@ -69,7 +69,7 @@
                           :working {:spawn {:machine-id :idn/worker}
                                     :on    {:back :idle}}}}
           ;; Snapshot positioned in :working so :back exits the :spawn-bearing state.
-          {fx :fx} (machines/machine-transition spec {:state :working :data {}} [:back])
+          {fx :fx} (rf.machines/machine-transition spec {:state :working :data {}} [:back])
           destroy (some (fn [[fx-id args]] (when (= :rf.machine/destroy fx-id) args)) fx)]
       (is (some? destroy) "exiting the :spawn-bearing state emits a :rf.machine/destroy fx")
       (is (= [:working] (:rf/invoke-id destroy))

--- a/implementation/machines/test/re_frame/machine_lifecycle_schema_incarnation_fence_test.clj
+++ b/implementation/machines/test/re_frame/machine_lifecycle_schema_incarnation_fence_test.clj
@@ -28,22 +28,22 @@
   callback's own stack, exactly the synchronous re-entry the fence guards."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.machines :as machines]
-            [re-frame.machines.data-validation :as data-validation]
-            [re-frame.machines.lifecycle-fx.spawn :as spawn]
-            [re-frame.machines.lifecycle-fx.update-snapshot :as update-snapshot]
-            [re-frame.machines.spawn-order :as spawn-order]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.data-validation :as rf.machines.data-validation]
+            [re-frame.machines.lifecycle-fx.spawn :as rf.machines.lifecycle-fx.spawn]
+            [re-frame.machines.lifecycle-fx.update-snapshot :as rf.machines.lifecycle-fx.update-snapshot]
+            [re-frame.machines.spawn-order :as rf.machines.spawn-order]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 ;; Touch the artefact so the machines registration hooks are wired even when
 ;; this ns runs in isolation (`re-frame.machines` require has side effects).
-(def ^:private _artefact machines/machine-transition)
+(def ^:private _artefact rf.machines/machine-transition)
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; The instance address the fallback allocator mints for the first
 ;; hand-emitted `:machine-id` spawn: `<type>#1`. Constructed the way
@@ -69,7 +69,7 @@
   forbids nested frame creation. The direct call also bypasses the fx-walk's
   outer owner fence, so the assertions pin the MACHINE-layer fence itself."
   [frame-a on-validate]
-  (spawn-order/reset-all!)
+  (rf.machines.spawn-order/reset-all!)
   (rf/reg-machine :rf2-vxgfnd153/child
     {:initial :running
      :data    {:seed :a}
@@ -77,15 +77,15 @@
      :states  {:running {:on {:go :done}}
                :done    {:final? true}}})
   (rf/make-frame {:id frame-a})
-  (let [token-a        (frame/frame-incarnation-token frame-a)
+  (let [token-a        (rf.frame/frame-incarnation-token frame-a)
         b-birth        (atom ::unset)
         fired?         (atom false)
         threw?         (atom false)
         spawn-traces   (atom [])
         fail-traces    (atom [])
         dispatches     (atom [])
-        orig-validate  (late-bind/get-fn :schemas/validate-with-registered-fn)
-        orig-dispatch! (late-bind/get-fn :router/dispatch!)]
+        orig-validate  (rf.late-bind/get-fn :schemas/validate-with-registered-fn)
+        orig-dispatch! (rf.late-bind/get-fn :router/dispatch!)]
     (rf/register-listener! :trace ::spawn-fence
       (fn [ev]
         (let [op (:operation ev)]
@@ -100,27 +100,27 @@
       ;; Capture (never route) any dispatch the spawn cascade attempts — a
       ;; `[<child> <start>]` for an actor that was never legitimately installed
       ;; is itself a fence violation.
-      (late-bind/set-fn! :router/dispatch!
+      (rf.late-bind/set-fn! :router/dispatch!
                          (fn [ev opts] (swap! dispatches conj [ev opts]) nil))
-      (late-bind/set-fn! :schemas/validate-with-registered-fn
+      (rf.late-bind/set-fn! :schemas/validate-with-registered-fn
         (fn [schema data]
           (if (and (= schema ::child-schema)
                    (compare-and-set! fired? false true))
             (do
-              (frame/destroy-frame! frame-a)     ;; destroy incarnation A
+              (rf.frame/destroy-frame! frame-a)     ;; destroy incarnation A
               (rf/make-frame {:id frame-a})       ;; publish same-id successor B
-              (reset! b-birth (mtest/runtime-db frame-a))
+              (reset! b-birth (rf.machines.test-support/runtime-db frame-a))
               (on-validate data))                 ;; verdict / throw
             true)))
       (try
-        (frame/call-with-event-owner-token frame-a token-a
-          (fn [] (spawn/spawn-fx {:frame frame-a}
+        (rf.frame/call-with-event-owner-token frame-a token-a
+          (fn [] (rf.machines.lifecycle-fx.spawn/spawn-fx {:frame frame-a}
                                  {:machine-id :rf2-vxgfnd153/child})))
         (catch Throwable _ (reset! threw? true)))
       {:b-birth      @b-birth
-       :b-after      (mtest/runtime-db frame-a)
-       :child-snap   (mtest/snapshot frame-a child-instance-id)
-       :spawn-order  (spawn-order/frame-order frame-a)
+       :b-after      (rf.machines.test-support/runtime-db frame-a)
+       :child-snap   (rf.machines.test-support/snapshot frame-a child-instance-id)
+       :spawn-order  (rf.machines.spawn-order/frame-order frame-a)
        :spawn-traces @spawn-traces
        :fail-traces  @fail-traces
        :dispatches   @dispatches
@@ -128,8 +128,8 @@
        :threw?       @threw?}
       (finally
         (rf/unregister-listener! :trace ::spawn-fence)
-        (late-bind/set-fn! :schemas/validate-with-registered-fn orig-validate)
-        (late-bind/set-fn! :router/dispatch! orig-dispatch!)))))
+        (rf.late-bind/set-fn! :schemas/validate-with-registered-fn orig-validate)
+        (rf.late-bind/set-fn! :router/dispatch! orig-dispatch!)))))
 
 (defn- assert-successor-untouched
   "Assertions shared by every destroyer variant: the callback ran, and NONE of
@@ -186,7 +186,7 @@
   (testing "control: a CONFORMING validator that does NOT destroy A leaves the
             spawn cascade fully intact — the fence is scoped to owner-loss only,
             so normal successful spawn behavior stays green."
-    (spawn-order/reset-all!)
+    (rf.machines.spawn-order/reset-all!)
     (rf/reg-machine :rf2-vxgfnd153/live-child
       {:initial :running
        :data    {:seed :a}
@@ -197,23 +197,23 @@
       (fn [_ _] {:fx [[:rf.machine/spawn {:machine-id :rf2-vxgfnd153/live-child}]]}))
     (let [frame-a      :rf2-vxgfnd153/live-frame
           spawn-traces (atom [])
-          orig         (late-bind/get-fn :schemas/validate-with-registered-fn)]
+          orig         (rf.late-bind/get-fn :schemas/validate-with-registered-fn)]
       (rf/make-frame {:id frame-a})
       (rf/register-listener! :trace ::live-spawn
         (fn [ev] (when (= :rf.machine.spawn/spawned (:operation ev))
                    (swap! spawn-traces conj ev))))
       (try
-        (late-bind/set-fn! :schemas/validate-with-registered-fn (fn [_ _] true))
+        (rf.late-bind/set-fn! :schemas/validate-with-registered-fn (fn [_ _] true))
         (rf/dispatch-sync [:rf2-vxgfnd153/live-spawn-event] {:frame frame-a})
-        (is (some? (mtest/snapshot frame-a live-child-instance-id))
+        (is (some? (rf.machines.test-support/snapshot frame-a live-child-instance-id))
             "the child snapshot installed (live-owner spawn is unaffected)")
         (is (seq @spawn-traces)
             "the :rf.machine.spawn/spawned trace fired for the live-owner spawn")
-        (is (= [live-child-instance-id] (spawn-order/frame-order frame-a))
+        (is (= [live-child-instance-id] (rf.machines.spawn-order/frame-order frame-a))
             "the spawn-order entry was recorded for the live-owner spawn")
         (finally
           (rf/unregister-listener! :trace ::live-spawn)
-          (late-bind/set-fn! :schemas/validate-with-registered-fn orig))))))
+          (rf.late-bind/set-fn! :schemas/validate-with-registered-fn orig))))))
 
 ;; ---- update-snapshot escape-hatch fence -----------------------------------
 
@@ -232,39 +232,39 @@
                  :done    {:final? true}}})
     (let [frame-a :rf2-vxgfnd153/us-frame
           fired?  (atom false)
-          orig    (late-bind/get-fn :schemas/validate-with-registered-fn)]
+          orig    (rf.late-bind/get-fn :schemas/validate-with-registered-fn)]
       (rf/make-frame {:id frame-a})
-      (let [token-a (frame/frame-incarnation-token frame-a)]
+      (let [token-a (rf.frame/frame-incarnation-token frame-a)]
         ;; Seed A's singleton snapshot so the escape hatch has a live target.
-        (frame/swap-runtime-db! frame-a
+        (rf.frame/swap-runtime-db! frame-a
           (fn [rt] (assoc-in rt [:rf.runtime/machines :snapshots :rf2-vxgfnd153/sing]
                              {:state :running :data {:v :a-init}})))
         (try
-          (late-bind/set-fn! :schemas/validate-with-registered-fn
+          (rf.late-bind/set-fn! :schemas/validate-with-registered-fn
             (fn [schema _data]
               (if (and (= schema ::sing-schema)
                        (compare-and-set! fired? false true))
                 (do
-                  (frame/destroy-frame! frame-a)      ;; destroy A
+                  (rf.frame/destroy-frame! frame-a)      ;; destroy A
                   (rf/make-frame {:id frame-a})        ;; same-id B
-                  (frame/swap-runtime-db! frame-a
+                  (rf.frame/swap-runtime-db! frame-a
                     (fn [rt] (assoc-in rt [:rf.runtime/machines :snapshots :rf2-vxgfnd153/sing]
                                        {:state :running :data {:v :b-sentinel}})))
                   true)                                ;; conforms → red would write
                 true)))
           ;; Drive the escape-hatch fx DIRECTLY under A's bound event owner (the
           ;; destroyer publishes same-id B via make-frame on its own stack).
-          (frame/call-with-event-owner-token frame-a token-a
-            (fn [] (update-snapshot/update-snapshot-fx
+          (rf.frame/call-with-event-owner-token frame-a token-a
+            (fn [] (rf.machines.lifecycle-fx.update-snapshot/update-snapshot-fx
                      {:frame frame-a}
                      {:rf/machine-id :rf2-vxgfnd153/sing
                       :rf/patch      {:data {:v :patched}}})))
           (is (true? @fired?) "the escape-hatch schema validator callback ran")
           (is (= {:v :b-sentinel}
-                 (:data (mtest/snapshot frame-a :rf2-vxgfnd153/sing)))
+                 (:data (rf.machines.test-support/snapshot frame-a :rf2-vxgfnd153/sing)))
               "B's snapshot :data is untouched — the A-derived patch did not merge onto same-id B")
           (finally
-            (late-bind/set-fn! :schemas/validate-with-registered-fn orig)))))))
+            (rf.late-bind/set-fn! :schemas/validate-with-registered-fn orig)))))))
 
 (deftest update-snapshot-db-trace-listener-fences-write-to-successor
   (testing "the :rf.machine/update-snapshot escape hatch, :db-TRACE path (the
@@ -295,11 +295,11 @@
           fired?  (atom false)
           b-snap  (atom ::unset)
           b-epoch (atom ::unset)
-          orig    (late-bind/get-fn :schemas/validate-with-registered-fn)]
+          orig    (rf.late-bind/get-fn :schemas/validate-with-registered-fn)]
       (rf/make-frame {:id frame-a})
-      (let [token-a (frame/frame-incarnation-token frame-a)]
+      (let [token-a (rf.frame/frame-incarnation-token frame-a)]
         ;; Seed A's singleton snapshot so the escape hatch has a live target.
-        (frame/swap-runtime-db! frame-a
+        (rf.frame/swap-runtime-db! frame-a
           (fn [rt] (assoc-in rt [:rf.runtime/machines :snapshots :rf2-vxgfnd22/sing]
                              {:state :running :data {:v :a-init}})))
         ;; The DESTROYER is a :trace listener on the :db hard-disallow trace (NOT
@@ -309,26 +309,26 @@
           (fn [ev]
             (when (and (= :rf.error/machine-action-wrote-db (:operation ev))
                        (compare-and-set! fired? false true))
-              (frame/destroy-frame! frame-a)      ;; destroy incarnation A
+              (rf.frame/destroy-frame! frame-a)      ;; destroy incarnation A
               (rf/make-frame {:id frame-a})        ;; publish same-id successor B
-              (frame/swap-runtime-db! frame-a      ;; B's DISTINCT sentinel snapshot
+              (rf.frame/swap-runtime-db! frame-a      ;; B's DISTINCT sentinel snapshot
                 (fn [rt] (assoc-in rt [:rf.runtime/machines :snapshots :rf2-vxgfnd22/sing]
                                    {:state :running :data {:v :b-sentinel}})))
-              (reset! b-snap  (mtest/snapshot frame-a :rf2-vxgfnd22/sing))
-              (reset! b-epoch (frame/frame-commit-epoch frame-a)))))
+              (reset! b-snap  (rf.machines.test-support/snapshot frame-a :rf2-vxgfnd22/sing))
+              (reset! b-epoch (rf.frame/frame-commit-epoch frame-a)))))
         (try
           ;; A REJECTING validator (false for the machine's schema). It is NEVER
           ;; consulted on the destroyed-A path (`resolve-data-schema` goes nil
           ;; once A is lost) — registered only to prove the validator-callback
           ;; fence leaves this :db-trace path open.
-          (late-bind/set-fn! :schemas/validate-with-registered-fn
+          (rf.late-bind/set-fn! :schemas/validate-with-registered-fn
             (fn [schema _data] (not= schema ::db-trace-schema)))
           ;; Drive the escape-hatch fx DIRECTLY under A's bound event owner. The
           ;; patch carries a `:db` key (the hard-disallow) so the trace fires and
           ;; the listener destroys A on its own stack; `:data` is the escape-hatch
           ;; payload that must not reach same-id B.
-          (frame/call-with-event-owner-token frame-a token-a
-            (fn [] (update-snapshot/update-snapshot-fx
+          (rf.frame/call-with-event-owner-token frame-a token-a
+            (fn [] (rf.machines.lifecycle-fx.update-snapshot/update-snapshot-fx
                      {:frame frame-a}
                      {:rf/machine-id :rf2-vxgfnd22/sing
                       :rf/patch      {:db   {:naughty :write}
@@ -338,13 +338,13 @@
           (is (= {:v :b-sentinel} (:data @b-snap))
               "sanity: B's snapshot at birth carried the distinct sentinel")
           (is (= {:v :b-sentinel}
-                 (:data (mtest/snapshot frame-a :rf2-vxgfnd22/sing)))
+                 (:data (rf.machines.test-support/snapshot frame-a :rf2-vxgfnd22/sing)))
               "B's snapshot :data is untouched — the A-derived patch did not merge onto same-id B")
-          (is (= @b-epoch (frame/frame-commit-epoch frame-a))
+          (is (= @b-epoch (rf.frame/frame-commit-epoch frame-a))
               "B's commit epoch is unbumped — no phantom observation-port signal from an A-derived write")
           (finally
             (rf/unregister-listener! :trace ::db-trace-destroyer)
-            (late-bind/set-fn! :schemas/validate-with-registered-fn orig)))))))
+            (rf.late-bind/set-fn! :schemas/validate-with-registered-fn orig)))))))
 
 ;; ---- completion-output finalize diagnostic fence --------------------------
 
@@ -355,30 +355,30 @@
   `:where :machine-output` schema-validation-failure traces emitted."
   [id destroy?]
   (rf/make-frame {:id id})
-  (let [token-a (frame/frame-incarnation-token id)
+  (let [token-a (rf.frame/frame-incarnation-token id)
         traces  (atom [])
-        orig    (late-bind/get-fn :schemas/validate-with-registered-fn)]
+        orig    (rf.late-bind/get-fn :schemas/validate-with-registered-fn)]
     (rf/register-listener! :trace ::completion-fence
       (fn [ev] (when (and (= :rf.error/schema-validation-failure (:operation ev))
                           (= :machine-output (get-in ev [:tags :where])))
                  (swap! traces conj ev))))
     (try
-      (late-bind/set-fn! :schemas/validate-with-registered-fn
+      (rf.late-bind/set-fn! :schemas/validate-with-registered-fn
         (fn [schema _result]
           (when (and destroy? (= schema ::output-schema))
-            (frame/destroy-frame! id)     ;; destroy A
+            (rf.frame/destroy-frame! id)     ;; destroy A
             (rf/make-frame {:id id}))      ;; same-id B
           false))                          ;; violation
-      (frame/call-with-event-owner-token id token-a
+      (rf.frame/call-with-event-owner-token id token-a
         (fn []
-          (data-validation/validate-completion-output!
+          (rf.machines.data-validation/validate-completion-output!
             :rf2-vxgfnd153/completion-actor
             {:schemas {:output ::output-schema}}
             "bad-output")))
       (count @traces)
       (finally
         (rf/unregister-listener! :trace ::completion-fence)
-        (late-bind/set-fn! :schemas/validate-with-registered-fn orig)))))
+        (rf.late-bind/set-fn! :schemas/validate-with-registered-fn orig)))))
 
 (deftest completion-output-validator-honors-exact-continuation
   (testing "a completion-output validator that destroys A + publishes same-id B

--- a/implementation/machines/test/re_frame/machine_lifecycle_tail_exact_handoff_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_lifecycle_tail_exact_handoff_cljs_test.cljc
@@ -17,45 +17,45 @@
   only, never over-eager):
 
     1. ORDINARY DESTROY terminal fence — the `:rf.machine/system-id-released`
-       trace + `registrar/unregister!` no longer share one precheck: a listener
+       trace + `rf.registrar/unregister!` no longer share one precheck: a listener
        that publishes same-id B and registers B's handler survives A's unregister.
     2. SPAWN classification-lowering seam — a container-write loss DURING
-       `lower-at-spawn!` fences the bare-id `spawn-order/record!` (A's ghost child
+       `lower-at-spawn!` fences the bare-id `rf.machines.spawn-order/record!` (A's ghost child
        must not land in B's spawn-order).
     3. FINALIZE classification-drop seam — a loss DURING `drop-at-destroy!` fences
-       the bare-id `spawn-order/forget!` + system-id release (B's spawn-order must
+       the bare-id `rf.machines.spawn-order/forget!` + system-id release (B's spawn-order must
        survive; finalize returns inert).
     4. `destroy-single-actor!` success report — reports success ONLY when the
        teardown actually committed while authority stayed exact, so `:spawn-all`
        never emits a phantom `:rf.machine/destroyed`.
     5. NON-DESTROY timer-cancellation reasons — `:on-exit` (and every sibling
-       reason) now self-fences the shared `subs/unsubscribe` decrement, so a
+       reason) now self-fences the shared `rf.subs/unsubscribe` decrement, so a
        cancellation listener re-arming successor B's same query keeps B's fresh
        reaction."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.machines :as machines]
-            [re-frame.machines.classification :as classification]
-            [re-frame.machines.lifecycle-fx.destroy :as destroy]
-            [re-frame.machines.lifecycle-fx.finalize :as finalize]
-            [re-frame.machines.lifecycle-fx.spawn :as spawn]
-            [re-frame.machines.spawn-order :as spawn-order]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.machines.timer :as timer]
-            [re-frame.registrar :as registrar]
-            [re-frame.subs :as subs]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.classification :as rf.machines.classification]
+            [re-frame.machines.lifecycle-fx.destroy :as rf.machines.lifecycle-fx.destroy]
+            [re-frame.machines.lifecycle-fx.finalize :as rf.machines.lifecycle-fx.finalize]
+            [re-frame.machines.lifecycle-fx.spawn :as rf.machines.lifecycle-fx.spawn]
+            [re-frame.machines.spawn-order :as rf.machines.spawn-order]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.machines.timer :as rf.machines.timer]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.subs :as rf.subs]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 ;; Touch the artefact so the machines registration hooks are wired even when
 ;; this ns runs in isolation.
-(def ^:private _artefact machines/machine-transition)
+(def ^:private _artefact rf.machines/machine-transition)
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- shared seed ----------------------------------------------------------
 
@@ -80,7 +80,7 @@
   hook) resolves off the snapshot."
   [frame-id actor-id sid on-exit]
   (rf/reg-machine actor-type (actor-spec on-exit))
-  (frame/swap-runtime-db!
+  (rf.frame/swap-runtime-db!
     frame-id
     (fn [rt] (-> rt
                  (assoc-in (snapshot-path actor-id)
@@ -88,21 +88,21 @@
                             :data            {:rf/self-id actor-id}
                             :rf/machine-type actor-type})
                  (assoc-in (system-id-path sid) actor-id))))
-  (spawn-order/record! frame-id actor-id))
+  (rf.machines.spawn-order/record! frame-id actor-id))
 
 ;; ===========================================================================
 ;; (1) ORDINARY DESTROY — the terminal fence: `:rf.machine/system-id-released`
-;;     trace + `registrar/unregister!` must NOT share one precheck.
+;;     trace + `rf.registrar/unregister!` must NOT share one precheck.
 ;; ===========================================================================
 
 (deftest ordinary-destroy-preserves-successor-registrar-handoff
   (testing "a `:rf.machine/system-id-released` listener destroys A, publishes
             same-id B and registers B's fresh event handler at `actor-id` ON THAT
             TRACE's stack: ownership is rechecked AFTER the trace, so A's
-            `registrar/unregister!` cannot clear B's just-registered handler.
+            `rf.registrar/unregister!` cannot clear B's just-registered handler.
             Mutation tooth: the historically-grouped unregister erases B's
             handler + its provenance."
-    (spawn-order/reset-all!)
+    (rf.machines.spawn-order/reset-all!)
     (let [frame-a  :rf2-rbxdxa/released-frame
           actor-id (keyword "rf2-rbxdxa" "released#1")
           sid      :rf2-rbxdxa/released-sid
@@ -110,126 +110,126 @@
           fired?   (atom false)]
       (rf/make-frame {:id frame-a})
       (seed-actor! frame-a actor-id sid nil)          ;; spawned actor: NO registrar entry
-      (trace-tooling/register-listener!
+      (rf.trace.tooling/register-listener!
         ::released-handoff
         (fn [ev]
           (when (and (= :rf.machine/system-id-released (:operation ev))
                      (compare-and-set! fired? false true))
-            (frame/destroy-frame! frame-a)            ;; destroy A
+            (rf.frame/destroy-frame! frame-a)            ;; destroy A
             (rf/make-frame {:id frame-a})             ;; same-id B
             ;; B registers its own event handler at `actor-id`.
-            (registrar/register! :event actor-id b-meta))))
+            (rf.registrar/register! :event actor-id b-meta))))
       (try
-        (let [token-a (frame/frame-incarnation-token frame-a)]
-          (frame/call-with-event-owner-token frame-a token-a
-            (fn [] (destroy/destroy-machine-fx {:frame frame-a} actor-id))))
+        (let [token-a (rf.frame/frame-incarnation-token frame-a)]
+          (rf.frame/call-with-event-owner-token frame-a token-a
+            (fn [] (rf.machines.lifecycle-fx.destroy/destroy-machine-fx {:frame frame-a} actor-id))))
         (is (true? @fired?) "the system-id-released listener ran (fence exercised)")
-        (is (= b-meta (registrar/lookup :event actor-id))
+        (is (= b-meta (rf.registrar/lookup :event actor-id))
             "successor B's event handler + provenance SURVIVED — A's unregister was fenced")
         (finally
-          (trace-tooling/unregister-listener! ::released-handoff)
-          (registrar/unregister! :event actor-id))))))
+          (rf.trace.tooling/unregister-listener! ::released-handoff)
+          (rf.registrar/unregister! :event actor-id))))))
 
 (deftest live-owner-destroy-unregisters-exactly-once
   (testing "control: an ordinary destroy whose tail fires no destroyer clears the
             actor's registrar entry EXACTLY once. The terminal fence is scoped to
             owner-loss only — a live destroy still unregisters."
-    (spawn-order/reset-all!)
+    (rf.machines.spawn-order/reset-all!)
     (let [frame-a  :rf2-rbxdxa/live-unregister-frame
           actor-id (keyword "rf2-rbxdxa" "live-unregister#1")
           sid      :rf2-rbxdxa/live-unregister-sid]
       (rf/make-frame {:id frame-a})
       (seed-actor! frame-a actor-id sid nil)
       ;; Install a registrar entry so there is something to clear.
-      (registrar/register! :event actor-id {:fn (fn [db _] db) :rf/provenance :A})
+      (rf.registrar/register! :event actor-id {:fn (fn [db _] db) :rf/provenance :A})
       (try
-        (let [token-a (frame/frame-incarnation-token frame-a)]
-          (frame/call-with-event-owner-token frame-a token-a
-            (fn [] (destroy/destroy-machine-fx {:frame frame-a} actor-id))))
-        (is (nil? (registrar/lookup :event actor-id))
+        (let [token-a (rf.frame/frame-incarnation-token frame-a)]
+          (rf.frame/call-with-event-owner-token frame-a token-a
+            (fn [] (rf.machines.lifecycle-fx.destroy/destroy-machine-fx {:frame frame-a} actor-id))))
+        (is (nil? (rf.registrar/lookup :event actor-id))
             "the live destroy unregistered the actor's handler exactly once")
-        (is (nil? (mtest/snapshot frame-a actor-id))
+        (is (nil? (rf.machines.test-support/snapshot frame-a actor-id))
             "the live destroy dissoc'd the snapshot")
         (finally
-          (registrar/unregister! :event actor-id))))))
+          (rf.registrar/unregister! :event actor-id))))))
 
 ;; ===========================================================================
 ;; (2) SPAWN — the classification-lowering seam: a loss DURING `lower-at-spawn!`
-;;     must fence the bare-id `spawn-order/record!`.
+;;     must fence the bare-id `rf.machines.spawn-order/record!`.
 ;; ===========================================================================
 
 (deftest spawn-classification-lowering-loss-fences-spawn-order-record
   (testing "a container-write loss DURING `lower-at-spawn!` (destroy A + publish
             same-id B): the spawn rechecks `(continue?)` AFTER the classification
-            lowering, so the bare-id `spawn-order/record!` — which resolves to the
+            lowering, so the bare-id `rf.machines.spawn-order/record!` — which resolves to the
             CURRENT incarnation B — never records A's ghost child into B's
             spawn-order channel. Mutation tooth: the unfenced record! puts A's
             ghost child in B's spawn-order."
-    (spawn-order/reset-all!)
+    (rf.machines.spawn-order/reset-all!)
     (rf/reg-machine actor-type (actor-spec nil))
     (let [frame-a        :rf2-rbxdxa/spawn-class-frame
           fired?         (atom false)
-          orig-dispatch! (late-bind/get-fn :router/dispatch!)]
+          orig-dispatch! (rf.late-bind/get-fn :router/dispatch!)]
       (rf/make-frame {:id frame-a})
       (try
         ;; Keep the actor-bootstrap dispatch synchronous + inert so no async
         ;; drain races the assertions (mirrors the #5889 spawn-write fixtures).
-        (late-bind/set-fn! :router/dispatch! (fn [_ev _opts] nil))
+        (rf.late-bind/set-fn! :router/dispatch! (fn [_ev _opts] nil))
         ;; `with-redefs` restores `lower-at-spawn!` automatically on body exit.
         ;; MULTI-arity stub matching the real `[3]`/`[4]` arities: spawn.cljc calls
         ;; the 4-arity, which CLJS compiles to a DIRECT `arity$4` invoke — a
         ;; single- or variadic-arity replacement would not expose `arity$4` and
         ;; the CLJS run would `TypeError` (rf2-rbxdxa CI-gap: only a multi-arity
         ;; CLJS fn emits the `cljs$core$IFn$_invoke$arity$N` methods).
-        (with-redefs [classification/lower-at-spawn!
+        (with-redefs [rf.machines.classification/lower-at-spawn!
                       (fn ([_frame _actor _spec] nil)
                           ([_frame _actor _spec _token]
                            ;; The exact elision write's container watch: destroy A
                            ;; / publish same-id B ON the classification write's stack.
                            (when (compare-and-set! fired? false true)
-                             (frame/destroy-frame! frame-a)
+                             (rf.frame/destroy-frame! frame-a)
                              (rf/make-frame {:id frame-a}))
                            nil))]
-          (let [token-a (frame/frame-incarnation-token frame-a)]
-            (frame/call-with-event-owner-token frame-a token-a
-              (fn [] (spawn/spawn-fx {:frame frame-a}
+          (let [token-a (rf.frame/frame-incarnation-token frame-a)]
+            (rf.frame/call-with-event-owner-token frame-a token-a
+              (fn [] (rf.machines.lifecycle-fx.spawn/spawn-fx {:frame frame-a}
                                      {:machine-id actor-type
                                       :system-id  :rf2-rbxdxa/spawn-class-sid
                                       :start      [:go]})))))
         (is (true? @fired?) "the classification-lowering loss ran (fence exercised)")
-        (is (empty? (spawn-order/frame-order frame-a))
+        (is (empty? (rf.machines.spawn-order/frame-order frame-a))
             "successor B's spawn-order is empty — A's ghost child was NOT recorded after the loss")
         (finally
-          (late-bind/set-fn! :router/dispatch! orig-dispatch!))))))
+          (rf.late-bind/set-fn! :router/dispatch! orig-dispatch!))))))
 
 (deftest spawn-classification-live-records-child-once
   (testing "control: a spawn whose classification lowering runs cleanly records
             the child in spawn-order exactly once. The recheck must not suppress
             the live spawn-order record."
-    (spawn-order/reset-all!)
+    (rf.machines.spawn-order/reset-all!)
     (rf/reg-machine actor-type (actor-spec nil))
     (let [frame-a        :rf2-rbxdxa/spawn-class-live-frame
-          orig-dispatch! (late-bind/get-fn :router/dispatch!)]
+          orig-dispatch! (rf.late-bind/get-fn :router/dispatch!)]
       (rf/make-frame {:id frame-a})
       (try
-        (late-bind/set-fn! :router/dispatch! (fn [_ev _opts] nil))
-        (let [token-a (frame/frame-incarnation-token frame-a)]
-          (frame/call-with-event-owner-token frame-a token-a
-            (fn [] (spawn/spawn-fx {:frame frame-a}
+        (rf.late-bind/set-fn! :router/dispatch! (fn [_ev _opts] nil))
+        (let [token-a (rf.frame/frame-incarnation-token frame-a)]
+          (rf.frame/call-with-event-owner-token frame-a token-a
+            (fn [] (rf.machines.lifecycle-fx.spawn/spawn-fx {:frame frame-a}
                                    {:machine-id actor-type
                                     :system-id  :rf2-rbxdxa/spawn-class-live-sid
                                     :start      [:go]}))))
-        (let [order (vec (spawn-order/frame-order frame-a))]
+        (let [order (vec (rf.machines.spawn-order/frame-order frame-a))]
           (is (= 1 (count order))
               "the live spawn recorded exactly one spawn-order entry")
-          (is (some? (mtest/snapshot frame-a (first order)))
+          (is (some? (rf.machines.test-support/snapshot frame-a (first order)))
               "the live spawn installed the recorded child's snapshot"))
         (finally
-          (late-bind/set-fn! :router/dispatch! orig-dispatch!))))))
+          (rf.late-bind/set-fn! :router/dispatch! orig-dispatch!))))))
 
 ;; ===========================================================================
 ;; (3) FINALIZE — the classification-drop seam: a loss DURING `drop-at-destroy!`
-;;     must fence the bare-id `spawn-order/forget!` + system-id release.
+;;     must fence the bare-id `rf.machines.spawn-order/forget!` + system-id release.
 ;; ===========================================================================
 
 (defn- finishing-machine [frame-id]
@@ -242,21 +242,21 @@
 (defn- finishing-snapshot [] {:state :done :data {:result 42}})
 
 (defn- seed-finishing! [frame-id machine-id sid]
-  (frame/swap-runtime-db!
+  (rf.frame/swap-runtime-db!
     frame-id
     (fn [rt] (-> rt
                  (assoc-in (snapshot-path machine-id) (finishing-snapshot))
                  (assoc-in (system-id-path sid) machine-id))))
-  (spawn-order/record! frame-id machine-id))
+  (rf.machines.spawn-order/record! frame-id machine-id))
 
 (deftest finalize-classification-drop-loss-fences-spawn-order-forget
   (testing "a loss DURING the finalize `drop-at-destroy!` (destroy A + publish
             same-id B, re-seeding B's spawn-order entry): ownership is rechecked
-            AFTER the classification drop, so the bare-id `spawn-order/forget!` +
+            AFTER the classification drop, so the bare-id `rf.machines.spawn-order/forget!` +
             system-id release do NOT run against B, and finalize returns the inert
             outcome. Mutation tooth: the grouped precheck lets the forget erase B's
             freshly-recorded spawn-order entry."
-    (spawn-order/reset-all!)
+    (rf.machines.spawn-order/reset-all!)
     (let [frame-a    :rf2-rbxdxa/finalize-class-frame
           machine-id :rf2-rbxdxa/finalize-class-machine
           sid        :rf2-rbxdxa/finalize-class-sid
@@ -269,25 +269,25 @@
       ;; fixture note): finalize.cljc calls the 4-arity, a direct `arity$4` invoke
       ;; under CLJS.
       (let [ret (with-redefs
-                  [classification/drop-at-destroy!
+                  [rf.machines.classification/drop-at-destroy!
                    (fn ([_frame _mid _machine] nil)
                        ([_frame _mid _machine _token]
                         ;; The exact elision drop's container watch: destroy A /
                         ;; publish same-id B, re-seeding B's spawn-order entry.
                         (when (compare-and-set! fired? false true)
-                          (frame/destroy-frame! frame-a)
+                          (rf.frame/destroy-frame! frame-a)
                           (rf/make-frame {:id frame-a})
-                          (spawn-order/record! frame-a machine-id))
+                          (rf.machines.spawn-order/record! frame-a machine-id))
                         nil))]
-                  (let [token-a (frame/frame-incarnation-token frame-a)]
-                    (frame/call-with-event-owner-token frame-a token-a
+                  (let [token-a (rf.frame/frame-incarnation-token frame-a)]
+                    (rf.frame/call-with-event-owner-token frame-a token-a
                       (fn []
-                        (finalize/finalize-machine
+                        (rf.machines.lifecycle-fx.finalize/finalize-machine
                           (finishing-machine frame-a)
-                          machine-id frame-a (mtest/runtime-db frame-a)
+                          machine-id frame-a (rf.machines.test-support/runtime-db frame-a)
                           (finishing-snapshot) [:some-completing-event] [])))))]
         (is (true? @fired?) "the classification-drop loss ran (fence exercised)")
-        (is (= [machine-id] (vec (spawn-order/frame-order frame-a)))
+        (is (= [machine-id] (vec (rf.machines.spawn-order/frame-order frame-a)))
             "successor B's spawn-order entry SURVIVED — A's forget was fenced after the drop")
         (is (= [] (:fx ret))
             "finalize returned the inert outcome — no A-derived fx published onto B")))))
@@ -296,21 +296,21 @@
   (testing "control: a finalize whose classification drop runs cleanly forgets the
             actor from spawn-order and dissocs its snapshot in the returned
             runtime-db. The recheck must not suppress the live teardown."
-    (spawn-order/reset-all!)
+    (rf.machines.spawn-order/reset-all!)
     (let [frame-a    :rf2-rbxdxa/finalize-class-live-frame
           machine-id :rf2-rbxdxa/finalize-class-live-machine
           sid        :rf2-rbxdxa/finalize-class-live-sid]
       (rf/reg-machine machine-id (finishing-machine frame-a))
       (rf/make-frame {:id frame-a})
       (seed-finishing! frame-a machine-id sid)
-      (let [token-a (frame/frame-incarnation-token frame-a)
-            ret     (frame/call-with-event-owner-token frame-a token-a
+      (let [token-a (rf.frame/frame-incarnation-token frame-a)
+            ret     (rf.frame/call-with-event-owner-token frame-a token-a
                       (fn []
-                        (finalize/finalize-machine
+                        (rf.machines.lifecycle-fx.finalize/finalize-machine
                           (finishing-machine frame-a)
-                          machine-id frame-a (mtest/runtime-db frame-a)
+                          machine-id frame-a (rf.machines.test-support/runtime-db frame-a)
                           (finishing-snapshot) [:some-completing-event] [])))]
-        (is (empty? (spawn-order/frame-order frame-a))
+        (is (empty? (rf.machines.spawn-order/frame-order frame-a))
             "the live finalize forgot the actor from spawn-order")
         (is (nil? (get-in (:rf.db/runtime ret) (snapshot-path machine-id)))
             "the live finalize dissoc'd the actor's snapshot in the returned runtime-db")
@@ -328,7 +328,7 @@
             NO phantom `:rf.machine/destroyed`. Mutation tooth: the unconditional
             `true` return emits a phantom destroyed for a child whose teardown
             never committed."
-    (spawn-order/reset-all!)
+    (rf.machines.spawn-order/reset-all!)
     (let [frame-a  :rf2-rbxdxa/single-abort-frame
           actor-id (keyword "rf2-rbxdxa" "single-abort#1")
           sid      :rf2-rbxdxa/single-abort-sid
@@ -336,14 +336,14 @@
       (rf/make-frame {:id frame-a})
       (let [destroy+B! (fn []
                          (when (compare-and-set! fired? false true)
-                           (frame/destroy-frame! frame-a)
+                           (rf.frame/destroy-frame! frame-a)
                            (rf/make-frame {:id frame-a})))]
         (seed-actor! frame-a actor-id sid destroy+B!)   ;; :exit fires destroy+B!
-        (let [token-a (frame/frame-incarnation-token frame-a)
-              fence   {:owner-gone? (fn [] (not (frame/event-continuation-live? frame-a token-a)))
+        (let [token-a (rf.frame/frame-incarnation-token frame-a)
+              fence   {:owner-gone? (fn [] (not (rf.frame/event-continuation-live? frame-a token-a)))
                        :owner-token token-a}
-              ret     (frame/call-with-event-owner-token frame-a token-a
-                        (fn [] (destroy/destroy-single-actor! frame-a actor-id fence)))]
+              ret     (rf.frame/call-with-event-owner-token frame-a token-a
+                        (fn [] (rf.machines.lifecycle-fx.destroy/destroy-single-actor! frame-a actor-id fence)))]
           (is (true? @fired?) "the actor's :exit cascade ran + lost the owner (fence exercised)")
           (is (not ret)
               "destroy-single-actor! reported falsey — teardown aborted on owner loss, no phantom destroyed"))))))
@@ -353,20 +353,20 @@
             no destroyer reports TRUTHY (the teardown projection committed) and
             dissocs the snapshot — so a `:spawn-all` caller emits `destroyed`
             exactly once for a genuinely-torn-down child."
-    (spawn-order/reset-all!)
+    (rf.machines.spawn-order/reset-all!)
     (let [frame-a  :rf2-rbxdxa/single-live-frame
           actor-id (keyword "rf2-rbxdxa" "single-live#1")
           sid      :rf2-rbxdxa/single-live-sid]
       (rf/make-frame {:id frame-a})
       (seed-actor! frame-a actor-id sid nil)
-      (let [token-a (frame/frame-incarnation-token frame-a)
-            fence   {:owner-gone? (fn [] (not (frame/event-continuation-live? frame-a token-a)))
+      (let [token-a (rf.frame/frame-incarnation-token frame-a)
+            fence   {:owner-gone? (fn [] (not (rf.frame/event-continuation-live? frame-a token-a)))
                      :owner-token token-a}
-            ret     (frame/call-with-event-owner-token frame-a token-a
-                      (fn [] (destroy/destroy-single-actor! frame-a actor-id fence)))]
+            ret     (rf.frame/call-with-event-owner-token frame-a token-a
+                      (fn [] (rf.machines.lifecycle-fx.destroy/destroy-single-actor! frame-a actor-id fence)))]
         (is (true? (boolean ret))
             "destroy-single-actor! reported truthy — the teardown committed while exact")
-        (is (nil? (mtest/snapshot frame-a actor-id))
+        (is (nil? (rf.machines.test-support/snapshot frame-a actor-id))
             "the live teardown dissoc'd the actor's snapshot")))))
 
 ;; ===========================================================================
@@ -377,9 +377,9 @@
 (defn- seed-sub-vec-timer!
   "Seed one armed subscription-vector `:after` timer entry keyed under
   `parent-id` / `[]` invoke with a vector `delay-key` (so
-  `release-entry-resources!` reaches the shared `subs/unsubscribe` decrement)."
+  `release-entry-resources!` reaches the shared `rf.subs/unsubscribe` decrement)."
   [frame-id parent-id delay-key reaction]
-  (swap! timer/after-timers assoc-in
+  (swap! rf.machines.timer/after-timers assoc-in
          [frame-id {:parent parent-id :spawn [] :delay delay-key}]
          {:handle          nil
           :reaction        reaction
@@ -407,24 +407,24 @@
           fired?      (atom false)]
       (rf/make-frame {:id frame-a})
       (seed-sub-vec-timer! frame-a actor-id delay-key reaction)
-      (with-redefs [subs/unsubscribe (fn ([_] (swap! unsub-count inc) nil)
+      (with-redefs [rf.subs/unsubscribe (fn ([_] (swap! unsub-count inc) nil)
                                         ([_ _] (swap! unsub-count inc) nil))]
-        (trace-tooling/register-listener!
+        (rf.trace.tooling/register-listener!
           ::subvec-exit-fence
           (fn [ev]
             (when (and (= :rf.machine.timer/cancelled (:operation ev))
                        (compare-and-set! fired? false true))
-              (frame/destroy-frame! frame-a)          ;; destroy A
+              (rf.frame/destroy-frame! frame-a)          ;; destroy A
               (rf/make-frame {:id frame-a}))))        ;; same-id B re-arms the query
         (try
-          (timer/after-cancel-fx {:frame frame-a}
+          (rf.machines.timer/after-cancel-fx {:frame frame-a}
                                  {:rf/parent-id actor-id :rf/invoke-id []})
           (is (true? @fired?) "the :on-exit timer-cancelled listener ran (fence exercised)")
           (is (zero? @unsub-count)
               "A's release did NOT decrement the shared ref-count after the same-id successor swap")
           (finally
-            (trace-tooling/unregister-listener! ::subvec-exit-fence)
-            (swap! timer/after-timers dissoc frame-a)))))))
+            (rf.trace.tooling/unregister-listener! ::subvec-exit-fence)
+            (swap! rf.machines.timer/after-timers dissoc frame-a)))))))
 
 (deftest on-exit-timer-cancel-live-decrements-once
   (testing "control: an `:on-exit` cancellation whose trace does NOT publish a
@@ -437,12 +437,12 @@
           unsub-count (atom 0)]
       (rf/make-frame {:id frame-a})
       (seed-sub-vec-timer! frame-a actor-id delay-key reaction)
-      (with-redefs [subs/unsubscribe (fn ([_] (swap! unsub-count inc) nil)
+      (with-redefs [rf.subs/unsubscribe (fn ([_] (swap! unsub-count inc) nil)
                                         ([_ _] (swap! unsub-count inc) nil))]
         (try
-          (timer/after-cancel-fx {:frame frame-a}
+          (rf.machines.timer/after-cancel-fx {:frame frame-a}
                                  {:rf/parent-id actor-id :rf/invoke-id []})
           (is (= 1 @unsub-count)
               "the ordinary :on-exit release decremented the subscription ref-count exactly once")
           (finally
-            (swap! timer/after-timers dissoc frame-a)))))))
+            (swap! rf.machines.timer/after-timers dissoc frame-a)))))))

--- a/implementation/machines/test/re_frame/machine_lifecycle_tail_incarnation_fence_test.clj
+++ b/implementation/machines/test/re_frame/machine_lifecycle_tail_incarnation_fence_test.clj
@@ -8,7 +8,7 @@
 
   Three seams, one per callback class:
 
-    - TIMER: `timer/cancel-actor-timers!` emits a SYNCHRONOUS
+    - TIMER: `rf.machines.timer/cancel-actor-timers!` emits a SYNCHRONOUS
       `:rf.machine.timer/cancelled` per cancellation. A listener replaces A with
       same-id B after the FIRST cancellation; the stale snapshot loop then reads
       B's LIVE entry under a later key and cancels B's timer, and the finalize
@@ -18,17 +18,17 @@
       it at the finalize call-site before the classification / spawn-order /
       system-id-release work.
 
-    - REGISTRAR: `registrar/unregister!` emits a SYNCHRONOUS
+    - REGISTRAR: `rf.registrar/unregister!` emits a SYNCHRONOUS
       `:rf.registry/handler-cleared`. A listener replaces A with B; the stale
       A-derived `:on-error` (spawn-error) dispatch then routes into B. FIX:
       recheck `owner-gone?` immediately after the unregister, before the
       `:on-error` dispatch.
 
-    - SPAWN-WRITE: `install-spawn!` used a non-exact `frame/swap-runtime-db!`. A
+    - SPAWN-WRITE: `install-spawn!` used a non-exact `rf.frame/swap-runtime-db!`. A
       container watch replaces A DURING the physical write; the bare write bumps
       B's id-keyed commit epoch and emits `:rf.machine/system-id-bound` before
       the later owner check. FIX: route the install through the exact owner token
-      + `frame/swap-runtime-db-exact!`, which binds the write to A's own
+      + `rf.frame/swap-runtime-db-exact!`, which binds the write to A's own
       container and returns nil on mid-write loss (no epoch bump, no
       system-id-bound, no lifecycle tail).
 
@@ -41,26 +41,26 @@
   install exactly once — the mutation tooth against an over-eager fence."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.machines :as machines]
-            [re-frame.machines.lifecycle-fx.finalize :as finalize]
-            [re-frame.machines.lifecycle-fx.spawn :as spawn]
-            [re-frame.machines.spawn-order :as spawn-order]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.machines.timer :as timer]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.lifecycle-fx.finalize :as rf.machines.lifecycle-fx.finalize]
+            [re-frame.machines.lifecycle-fx.spawn :as rf.machines.lifecycle-fx.spawn]
+            [re-frame.machines.spawn-order :as rf.machines.spawn-order]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.machines.timer :as rf.machines.timer]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace :as rf.trace]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 ;; Touch the artefact so the machines registration hooks are wired even when
 ;; this ns runs in isolation.
-(def ^:private _artefact machines/machine-transition)
+(def ^:private _artefact rf.machines/machine-transition)
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ===========================================================================
 ;; TIMER seam — cancel-actor-timers! per-cancellation fence + finalize recheck
@@ -79,7 +79,7 @@
   {:state :done :data {:result 42}})
 
 (defn- seed-finishing-runtime-db! [frame-id machine-id]
-  (frame/swap-runtime-db!
+  (rf.frame/swap-runtime-db!
     frame-id
     (fn [rt] (assoc-in rt [:rf.runtime/machines :snapshots machine-id]
                        (finishing-snapshot)))))
@@ -93,7 +93,7 @@
   (release is then a no-op). Enough for `cancel-actor-timers!` to claim + emit
   a `:rf.machine.timer/cancelled` trace."
   [frame-id parent-id delay-key token]
-  (swap! timer/after-timers assoc-in
+  (swap! rf.machines.timer/after-timers assoc-in
          [frame-id (timer-key parent-id delay-key)]
          {:handle          nil
           :reaction        nil
@@ -113,9 +113,9 @@
             survives), and the finalize call-site rechecks ownership so the
             A-derived spawn-order forget never lands on B. Mutation tooth:
             without the fences the loop cancels B's timer under the second key
-            and `spawn-order/forget!` drops B's entry."
-    (spawn-order/reset-all!)
-    (reset! timer/after-timers {})
+            and `rf.machines.spawn-order/forget!` drops B's entry."
+    (rf.machines.spawn-order/reset-all!)
+    (reset! rf.machines.timer/after-timers {})
     (let [frame-a    :rf2-4ipqe4/timer-loss-frame
           machine-id :rf2-4ipqe4/timer-loss
           k1         (timer-key machine-id 100)
@@ -127,37 +127,37 @@
       ;; PersistentArrayMap seq processes k1 first).
       (seed-timer! frame-a machine-id 100 ::a-tok-1)
       (seed-timer! frame-a machine-id 200 ::a-tok-2)
-      (let [token-a       (frame/frame-incarnation-token frame-a)
+      (let [token-a       (rf.frame/frame-incarnation-token frame-a)
             fired?        (atom false)
             first-delay   (atom nil)
             cancelled     (atom [])
             b-runtime     (atom nil)]
-        (trace-tooling/register-listener!
+        (rf.trace.tooling/register-listener!
           ::timer-fence
           (fn [ev]
             (when (= :rf.machine.timer/cancelled (:operation ev))
               (swap! cancelled conj ev)
               (when (compare-and-set! fired? false true)
                 (reset! first-delay (get-in ev [:tags :delay]))
-                (frame/destroy-frame! frame-a)          ;; destroy A
+                (rf.frame/destroy-frame! frame-a)          ;; destroy A
                 (rf/make-frame {:id frame-a})            ;; publish same-id B
-                (reset! b-runtime (mtest/runtime-db frame-a))
+                (reset! b-runtime (rf.machines.test-support/runtime-db frame-a))
                 ;; B re-arms a timer under the SECOND snapshot key + records its
                 ;; own spawn-order entry — the A-derived tail must touch neither.
                 (seed-timer! frame-a machine-id 200 ::b-tok-2)
-                (spawn-order/record! frame-a machine-id)))))
+                (rf.machines.spawn-order/record! frame-a machine-id)))))
         (try
-          (let [ret (frame/call-with-event-owner-token frame-a token-a
+          (let [ret (rf.frame/call-with-event-owner-token frame-a token-a
                       (fn []
-                        (finalize/finalize-machine
+                        (rf.machines.lifecycle-fx.finalize/finalize-machine
                           (finishing-machine frame-a)
-                          machine-id frame-a (mtest/runtime-db frame-a)
+                          machine-id frame-a (rf.machines.test-support/runtime-db frame-a)
                           (finishing-snapshot) [:some-completing-event] [])))]
             (is (true? @fired?) "the timer-cancelled listener ran (fence exercised)")
             (is (= 100 @first-delay)
                 "the FIRST cancellation was A's k1 (delay 100) — insertion order held")
             ;; --- loop fence: B's k2 timer survives ---
-            (is (= ::b-tok-2 (get-in @timer/after-timers [frame-a k2 :token]))
+            (is (= ::b-tok-2 (get-in @rf.machines.timer/after-timers [frame-a k2 :token]))
                 "B's timer under the second key survives — the cancellation loop
                  short-circuited after losing A and never cancelled B's timer")
             (is (= 1 (count (filter #(= :on-destroy (get-in % [:tags :reason])) @cancelled)))
@@ -165,25 +165,25 @@
                  loop short-circuited before cancelling B's k2 timer. (A's OTHER
                  timer is cancelled by destroy-frame!'s own timer-table clear with
                  :reason :on-frame-destroy — the loop itself never reached it.)")
-            (is (nil? (get-in @timer/after-timers [frame-a k1]))
+            (is (nil? (get-in @rf.machines.timer/after-timers [frame-a k1]))
                 "A's own k1 timer was cancelled (already-delivered — it stands)")
             ;; --- call-site recheck: A-derived spawn-order forget never lands ---
-            (is (= [machine-id] (spawn-order/frame-order frame-a))
+            (is (= [machine-id] (rf.machines.spawn-order/frame-order frame-a))
                 "B's spawn-order entry survives — the finalize call-site rechecked
                  ownership before the classification / spawn-order / system-id
-                 tail, so `spawn-order/forget!` never ran against B")
+                 tail, so `rf.machines.spawn-order/forget!` never ran against B")
             ;; --- inert publication ---
             (is (= [] (:fx ret)) "finalize published no fx after the loss")
             (is (contains? ret :rf.db/runtime) "finalize returns a runtime-db effect"))
           (finally
-            (trace-tooling/unregister-listener! ::timer-fence)))))))
+            (rf.trace.tooling/unregister-listener! ::timer-fence)))))))
 
 (deftest timer-cancel-live-owner-cancels-all
   (testing "control: a completion whose timer-cancelled callbacks do NOT destroy
             A cancels BOTH armed timers and continues the teardown normally — the
             fence is scoped to owner-loss only."
-    (spawn-order/reset-all!)
-    (reset! timer/after-timers {})
+    (rf.machines.spawn-order/reset-all!)
+    (reset! rf.machines.timer/after-timers {})
     (let [frame-a    :rf2-4ipqe4/timer-live-frame
           machine-id :rf2-4ipqe4/timer-live]
       (rf/reg-machine machine-id (finishing-machine frame-a))
@@ -191,28 +191,28 @@
       (seed-finishing-runtime-db! frame-a machine-id)
       (seed-timer! frame-a machine-id 100 ::live-tok-1)
       (seed-timer! frame-a machine-id 200 ::live-tok-2)
-      (let [token-a   (frame/frame-incarnation-token frame-a)
+      (let [token-a   (rf.frame/frame-incarnation-token frame-a)
             cancelled (atom [])]
-        (trace-tooling/register-listener!
+        (rf.trace.tooling/register-listener!
           ::timer-live
           (fn [ev] (when (= :rf.machine.timer/cancelled (:operation ev))
                      (swap! cancelled conj ev))))
         (try
-          (let [ret (frame/call-with-event-owner-token frame-a token-a
+          (let [ret (rf.frame/call-with-event-owner-token frame-a token-a
                       (fn []
-                        (finalize/finalize-machine
+                        (rf.machines.lifecycle-fx.finalize/finalize-machine
                           (finishing-machine frame-a)
-                          machine-id frame-a (mtest/runtime-db frame-a)
+                          machine-id frame-a (rf.machines.test-support/runtime-db frame-a)
                           (finishing-snapshot) [:some-completing-event] [])))]
             (is (= 2 (count @cancelled))
                 "both armed timers were cancelled (:reason :on-destroy) under the live owner")
-            (is (empty? (get @timer/after-timers frame-a))
+            (is (empty? (get @rf.machines.timer/after-timers frame-a))
                 "the live-owner teardown released both host-clock entries")
             (is (nil? (get-in (:rf.db/runtime ret)
                               [:rf.runtime/machines :snapshots machine-id]))
                 "the live-owner completion tore down the actor's snapshot in the returned runtime-db"))
           (finally
-            (trace-tooling/unregister-listener! ::timer-live)))))))
+            (rf.trace.tooling/unregister-listener! ::timer-live)))))))
 
 ;; ===========================================================================
 ;; REGISTRAR seam — recheck after handler-cleared before the :on-error dispatch
@@ -244,42 +244,42 @@
   `:rf.registry/handler-cleared` listener, and drive `finalize-machine` for the
   child under A's bound event owner. Captures every `:router/dispatch!`."
   [frame-a parent-id child-id on-cleared]
-  (spawn-order/reset-all!)
+  (rf.machines.spawn-order/reset-all!)
   (let [invoke-id [:waiting]]
     (rf/reg-machine parent-id (on-error-parent-machine))
     (rf/reg-machine child-id  (erroring-child-machine parent-id invoke-id))
     (rf/make-frame {:id frame-a})
-    (frame/swap-runtime-db!
+    (rf.frame/swap-runtime-db!
       frame-a (fn [rt] (assoc-in rt [:rf.runtime/machines :snapshots child-id]
                                  (erroring-child-snapshot parent-id invoke-id))))
-    (let [token-a        (frame/frame-incarnation-token frame-a)
+    (let [token-a        (rf.frame/frame-incarnation-token frame-a)
           dispatches     (atom [])
-          orig-dispatch! (late-bind/get-fn :router/dispatch!)]
-      (trace-tooling/register-listener!
+          orig-dispatch! (rf.late-bind/get-fn :router/dispatch!)]
+      (rf.trace.tooling/register-listener!
         ::registrar-fence
         (fn [ev] (when (= :rf.registry/handler-cleared (:operation ev))
                    (on-cleared ev))))
       (try
-        (late-bind/set-fn! :router/dispatch!
+        (rf.late-bind/set-fn! :router/dispatch!
                            (fn [ev opts] (swap! dispatches conj [ev opts]) nil))
-        (let [ret (frame/call-with-event-owner-token frame-a token-a
+        (let [ret (rf.frame/call-with-event-owner-token frame-a token-a
                     (fn []
-                      (finalize/finalize-machine
+                      (rf.machines.lifecycle-fx.finalize/finalize-machine
                         (erroring-child-machine parent-id invoke-id)
-                        child-id frame-a (mtest/runtime-db frame-a)
+                        child-id frame-a (rf.machines.test-support/runtime-db frame-a)
                         (erroring-child-snapshot parent-id invoke-id)
                         [:some-completing-event] [])))]
           {:ret        ret
            :dispatches @dispatches})
         (finally
-          (trace-tooling/unregister-listener! ::registrar-fence)
+          (rf.trace.tooling/unregister-listener! ::registrar-fence)
           ;; Restore the prior hook (nil re-registers as absent, matching a
           ;; conformance / no-router baseline).
-          (late-bind/set-fn! :router/dispatch! orig-dispatch!))))))
+          (rf.late-bind/set-fn! :router/dispatch! orig-dispatch!))))))
 
 (deftest registrar-clear-loss-fences-on-error-dispatch
   (testing "a `:rf.registry/handler-cleared` listener (fired by the child's
-            `registrar/unregister!`) destroys A + publishes same-id B: ownership
+            `rf.registrar/unregister!`) destroys A + publishes same-id B: ownership
             is rechecked AFTER the unregister, so the stale A-derived spawn-error
             (:on-error) dispatch is fenced and finalize publishes no fx. Mutation
             tooth: without the post-unregister recheck the spawn-error dispatch
@@ -293,7 +293,7 @@
               frame-a parent-id child-id
               (fn [_ev]
                 (when (compare-and-set! fired? false true)
-                  (frame/destroy-frame! frame-a)     ;; destroy A
+                  (rf.frame/destroy-frame! frame-a)     ;; destroy A
                   (rf/make-frame {:id frame-a}))))]   ;; publish same-id B
         (is (true? @fired?) "the handler-cleared listener ran (fence exercised)")
         (is (empty? (filter (fn [[ev _]]
@@ -337,11 +337,11 @@
   The physical write always lands FIRST so A's write that linearized before the
   loss stands in A's captured container."
   [armed? on-write]
-  (let [base-replace (:replace-container! plain-atom/adapter)]
-    (adapter/dispose-adapter!)
-    (reset! frame/frames {})
-    (adapter/install-adapter!
-      (assoc plain-atom/adapter
+  (let [base-replace (:replace-container! rf.substrate.plain-atom/adapter)]
+    (rf.substrate.adapter/dispose-adapter!)
+    (reset! rf.frame/frames {})
+    (rf.substrate.adapter/install-adapter!
+      (assoc rf.substrate.plain-atom/adapter
              :kind :custom
              :replace-container!
              (fn [container value]
@@ -350,9 +350,9 @@
                  (on-write)))))))
 
 (defn- restore-plain-adapter! []
-  (reset! frame/frames {})
-  (adapter/dispose-adapter!)
-  (adapter/install-adapter! plain-atom/adapter))
+  (reset! rf.frame/frames {})
+  (rf.substrate.adapter/dispose-adapter!)
+  (rf.substrate.adapter/install-adapter! rf.substrate.plain-atom/adapter))
 
 (def ^:private spawn-child-instance-id (keyword "rf2-4ipqe4" "spawn-write-child#1"))
 
@@ -364,7 +364,7 @@
             system-id-bound` / `:rf.machine.lifecycle/spawned` / spawn-order tail
             is attributed after loss. Mutation tooth: the bare `swap-runtime-db!`
             bumps B's commit epoch and fires system-id-bound for B."
-    (spawn-order/reset-all!)
+    (rf.machines.spawn-order/reset-all!)
     (rf/reg-machine :rf2-4ipqe4/spawn-write-child
       {:initial :running
        :states  {:running {:on {:go :done}}
@@ -375,15 +375,15 @@
           traces         (atom [])
           b-birth        (atom nil)
           b-commit       (atom nil)
-          orig-dispatch! (late-bind/get-fn :router/dispatch!)]
+          orig-dispatch! (rf.late-bind/get-fn :router/dispatch!)]
       (install-watching-adapter!
         armed?
         (fn []
           (when (compare-and-set! fired? false true)
-            (frame/destroy-frame! frame-a)       ;; destroy A during the install write
+            (rf.frame/destroy-frame! frame-a)       ;; destroy A during the install write
             (rf/make-frame {:id frame-a})          ;; publish same-id B
-            (reset! b-birth (mtest/runtime-db frame-a))
-            (reset! b-commit (frame/frame-commit-epoch frame-a)))))
+            (reset! b-birth (rf.machines.test-support/runtime-db frame-a))
+            (reset! b-commit (rf.frame/frame-commit-epoch frame-a)))))
       (try
         ;; DETERMINISM FENCE (rf2-kz0bmb) — sibling of the live-owner test's
         ;; guard: hold the actor-bootstrap `:start` dispatch on a SYNCHRONOUS
@@ -391,35 +391,35 @@
         ;; next-tick`) races the assertions. The loss path fences the `:start`
         ;; before it fires, so this is a pure guard here — but it keeps the
         ;; whole spawn-write seam single-threaded and symmetric.
-        (late-bind/set-fn! :router/dispatch! (fn [_ev _opts] nil))
+        (rf.late-bind/set-fn! :router/dispatch! (fn [_ev _opts] nil))
         (rf/make-frame {:id frame-a})
-        (trace/register-listener!
+        (rf.trace/register-listener!
           ::spawn-write-fence
           (fn [ev] (swap! traces conj ev)))
-        (let [token-a (frame/frame-incarnation-token frame-a)]
+        (let [token-a (rf.frame/frame-incarnation-token frame-a)]
           (reset! armed? true)
-          (frame/call-with-event-owner-token frame-a token-a
-            (fn [] (spawn/spawn-fx {:frame frame-a}
+          (rf.frame/call-with-event-owner-token frame-a token-a
+            (fn [] (rf.machines.lifecycle-fx.spawn/spawn-fx {:frame frame-a}
                                    {:machine-id :rf2-4ipqe4/spawn-write-child
                                     :system-id  :rf2-4ipqe4/sys-1
                                     :start      [:go]})))
           (is (true? @fired?) "the install-write container watch ran (fence exercised)")
           (is (some? @b-birth) "the watch published a same-id B")
-          (is (nil? (mtest/snapshot frame-a spawn-child-instance-id))
+          (is (nil? (rf.machines.test-support/snapshot frame-a spawn-child-instance-id))
               "no A-derived child snapshot installed onto same-id B")
-          (is (= @b-birth (mtest/runtime-db frame-a))
+          (is (= @b-birth (rf.machines.test-support/runtime-db frame-a))
               "B's runtime-db is byte-identical to its birth value (no A-derived install)")
-          (is (= @b-commit (frame/frame-commit-epoch frame-a))
+          (is (= @b-commit (rf.frame/frame-commit-epoch frame-a))
               "A's mid-write loss never bumped B's id-keyed commit epoch")
-          (is (empty? (spawn-order/frame-order frame-a))
+          (is (empty? (rf.machines.spawn-order/frame-order frame-a))
               "no A-derived spawn-order entry recorded against B")
           (is (empty? (filter #(= :rf.machine/system-id-bound (:operation %)) @traces))
               "no :rf.machine/system-id-bound trace attributed after the write loss")
           (is (empty? (filter #(= :rf.machine.lifecycle/spawned (:operation %)) @traces))
               "no :rf.machine.lifecycle/spawned tail attributed after the write loss"))
         (finally
-          (trace/unregister-listener! ::spawn-write-fence)
-          (late-bind/set-fn! :router/dispatch! orig-dispatch!)
+          (rf.trace/unregister-listener! ::spawn-write-fence)
+          (rf.late-bind/set-fn! :router/dispatch! orig-dispatch!)
           (restore-plain-adapter!))))))
 
 (deftest spawn-install-write-live-owner-installs-once
@@ -427,7 +427,7 @@
             exact write commits, the child snapshot installs, and the
             system-id-bound / lifecycle-spawned / spawn-order tail all fire
             exactly once. A wrongly-fencing exact write would skip the install."
-    (spawn-order/reset-all!)
+    (rf.machines.spawn-order/reset-all!)
     (rf/reg-machine :rf2-4ipqe4/spawn-write-live-child
       {:initial :running
        :states  {:running {:on {:go :done}}
@@ -437,7 +437,7 @@
           watch-runs     (atom 0)
           traces         (atom [])
           child-id       (keyword "rf2-4ipqe4" "spawn-write-live-child#1")
-          orig-dispatch! (late-bind/get-fn :router/dispatch!)]
+          orig-dispatch! (rf.late-bind/get-fn :router/dispatch!)]
       (install-watching-adapter!
         armed?
         (fn [] (swap! watch-runs inc)))          ; observe only — A stays live
@@ -454,28 +454,28 @@
         ;; bootstrap leaves every assertion's subject unchanged while making the
         ;; fixture single-threaded and deterministic (was green in isolation /
         ;; 8/8 reruns, red under CI load).
-        (late-bind/set-fn! :router/dispatch! (fn [_ev _opts] nil))
+        (rf.late-bind/set-fn! :router/dispatch! (fn [_ev _opts] nil))
         (rf/make-frame {:id frame-a})
-        (trace/register-listener!
+        (rf.trace/register-listener!
           ::spawn-write-live
           (fn [ev] (swap! traces conj ev)))
-        (let [token-a (frame/frame-incarnation-token frame-a)]
+        (let [token-a (rf.frame/frame-incarnation-token frame-a)]
           (reset! armed? true)
-          (frame/call-with-event-owner-token frame-a token-a
-            (fn [] (spawn/spawn-fx {:frame frame-a}
+          (rf.frame/call-with-event-owner-token frame-a token-a
+            (fn [] (rf.machines.lifecycle-fx.spawn/spawn-fx {:frame frame-a}
                                    {:machine-id :rf2-4ipqe4/spawn-write-live-child
                                     :system-id  :rf2-4ipqe4/sys-live
                                     :start      [:go]})))
           (is (pos? @watch-runs) "the install-write watch fired (the exact write hit the container)")
-          (is (some? (mtest/snapshot frame-a child-id))
+          (is (some? (rf.machines.test-support/snapshot frame-a child-id))
               "the live-owner install committed the child snapshot through the exact write")
-          (is (= [child-id] (spawn-order/frame-order frame-a))
+          (is (= [child-id] (rf.machines.spawn-order/frame-order frame-a))
               "the live-owner install recorded the child in spawn-order")
           (is (= 1 (count (filter #(= :rf.machine/system-id-bound (:operation %)) @traces)))
               "the live-owner install emitted :rf.machine/system-id-bound exactly once")
           (is (= 1 (count (filter #(= :rf.machine.lifecycle/spawned (:operation %)) @traces)))
               "the live-owner install emitted :rf.machine.lifecycle/spawned exactly once"))
         (finally
-          (trace/unregister-listener! ::spawn-write-live)
-          (late-bind/set-fn! :router/dispatch! orig-dispatch!)
+          (rf.trace/unregister-listener! ::spawn-write-live)
+          (rf.late-bind/set-fn! :router/dispatch! orig-dispatch!)
           (restore-plain-adapter!))))))

--- a/implementation/machines/test/re_frame/machine_macrostep_snapshot_rules_test.clj
+++ b/implementation/machines/test/re_frame/machine_macrostep_snapshot_rules_test.clj
@@ -15,16 +15,16 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
-;; Routed through the shared `mtest/with-trace-capture` — guaranteed
+;; Routed through the shared `rf.machines.test-support/with-trace-capture` — guaranteed
 ;; unregister in a `finally`.
 (defn- record-traces! [body-fn]
-  (mtest/with-trace-capture seen
+  (rf.machines.test-support/with-trace-capture seen
     (body-fn)
     @seen))
 

--- a/implementation/machines/test/re_frame/machine_node_keys_test.clj
+++ b/implementation/machines/test/re_frame/machine_node_keys_test.clj
@@ -14,14 +14,14 @@
             ;; Load the machines facade so `rf/reg-machine` routes through its
             ;; late-bind hook (`:machines/reg-machine`).
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
             [re-frame.subs]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (defn- reg-error-id
   "Register `machine` under a fresh id, returning the thrown

--- a/implementation/machines/test/re_frame/machine_noop_signal_test.clj
+++ b/implementation/machines/test/re_frame/machine_noop_signal_test.clj
@@ -26,16 +26,16 @@
             ;; throws `:rf.error/machines-artefact-missing` when run in
             ;; isolation via `-n`).
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
-;; Routed through the shared `mtest/with-trace-capture`
+;; Routed through the shared `rf.machines.test-support/with-trace-capture`
 ;; — guaranteed unregister in a `finally`.
 (defn- record-traces! [body-fn]
-  (mtest/with-trace-capture seen
+  (rf.machines.test-support/with-trace-capture seen
     (body-fn)
     @seen))
 

--- a/implementation/machines/test/re_frame/machine_output_schema_test.clj
+++ b/implementation/machines/test/re_frame/machine_output_schema_test.clj
@@ -38,20 +38,20 @@
   :machine-data` boundary routes through."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.machines.test-support :as mtest]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
             [re-frame.schemas]
             [re-frame.schemas.malli]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- collect-output-traces!
   "Run `f` while collecting every `:rf.error/schema-validation-failure` trace
   whose `:where` is `:machine-output`. Returns the captured trace events."
   [f]
-  (mtest/with-trace-capture traces
+  (rf.machines.test-support/with-trace-capture traces
     (f)
     (filterv #(and (= :rf.error/schema-validation-failure (:operation %))
                    (= :machine-output (-> % :tags :where)))
@@ -68,7 +68,7 @@
                                   :done    {:final?     true
                                             :output-key :result}}}]
       (rf/reg-machine :rf.machine-output/accepted spec)
-      (let [meta (machines/machine-meta :rf.machine-output/accepted)]
+      (let [meta (rf.machines/machine-meta :rf.machine-output/accepted)]
         (is (some? meta) "machine-meta returns the registered spec")
         (is (= OutputSchema (get-in meta [:schemas :output]))
             "the [:schemas :output] schema round-trips through machine-meta")))))
@@ -93,7 +93,7 @@
                        (rf/dispatch-sync [:rf.machine-output/ok [:fin]])))]
         (is (empty? traces)
             "no :where :machine-output trace for a conforming output")
-        (is (nil? (mtest/snapshot :rf.machine-output/ok))
+        (is (nil? (rf.machines.test-support/snapshot :rf.machine-output/ok))
             "the machine finished + auto-destroyed normally")))))
 
 ;; ---- (3) violating completion output → one trace, completion still flows ---
@@ -129,7 +129,7 @@
             "completion is best-effort — :rollback? false (machine already finished)")
         ;; The completion STILL flows: the machine auto-destroyed despite the
         ;; output schema violation (best-effort fail-loud, not suppression).
-        (is (nil? (mtest/snapshot :rf.machine-output/bad))
+        (is (nil? (rf.machines.test-support/snapshot :rf.machine-output/bad))
             "the machine STILL finished + auto-destroyed (completion flows)")))))
 
 ;; ---- (4) spawned child: violating output → trace + parent :on-done STILL runs
@@ -170,7 +170,7 @@
             "the trace carries the child's violating output payload")
         (is (= "bad" @seen-result)
             "the parent's :on-done STILL received the result — validation observes, not suppresses")
-        (is (= "bad" (get-in (mtest/snapshot :rf.machine-output/spawn-parent) [:data :reported]))
+        (is (= "bad" (get-in (rf.machines.test-support/snapshot :rf.machine-output/spawn-parent) [:data :reported]))
             "the parent's :data mutation from :on-done still landed")))))
 
 ;; ---- (5) no schema → no validation (control) ------------------------------

--- a/implementation/machines/test/re_frame/machine_post_callback_tail_fence_test.clj
+++ b/implementation/machines/test/re_frame/machine_post_callback_tail_fence_test.clj
@@ -33,23 +33,23 @@
   hook, so the same-id successor B is published on the callback's own stack."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.machines :as machines]
-            [re-frame.machines.lifecycle-fx.finalize :as finalize]
-            [re-frame.machines.lifecycle-fx.spawn :as spawn]
-            [re-frame.machines.spawn-order :as spawn-order]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.lifecycle-fx.finalize :as rf.machines.lifecycle-fx.finalize]
+            [re-frame.machines.lifecycle-fx.spawn :as rf.machines.lifecycle-fx.spawn]
+            [re-frame.machines.spawn-order :as rf.machines.spawn-order]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 ;; Touch the artefact so the machines registration hooks are wired even when
 ;; this ns runs in isolation.
-(def ^:private _artefact machines/machine-transition)
+(def ^:private _artefact rf.machines/machine-transition)
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- spawn-tail fence (install-spawn! callbacks) --------------------------
 ;;
@@ -69,28 +69,28 @@
   event owner. `trigger` is `:system-id-collision`, `:system-id-bound`, or
   `:lifecycle-spawned`. Returns the observable post-spawn state on B."
   [frame-a trigger {:keys [system-id pre-existing-sid]}]
-  (spawn-order/reset-all!)
+  (rf.machines.spawn-order/reset-all!)
   (rf/reg-machine spawn-child-type
     {:initial :running
      :states  {:running {:on {:go :done}}
                :done    {:final? true}}})
   (rf/make-frame {:id frame-a})
   (when pre-existing-sid
-    (frame/swap-runtime-db!
+    (rf.frame/swap-runtime-db!
       frame-a
       (fn [rt] (assoc-in rt [:rf.runtime/machines :system-ids system-id] pre-existing-sid))))
-  (let [token-a          (frame/frame-incarnation-token frame-a)
+  (let [token-a          (rf.frame/frame-incarnation-token frame-a)
         fired?           (atom false)
         dispatches       (atom [])
         lifecycle-traces (atom [])
         b-birth          (atom nil)
-        orig-dispatch!   (late-bind/get-fn :router/dispatch!)
+        orig-dispatch!   (rf.late-bind/get-fn :router/dispatch!)
         destroy+B!       (fn []
                            (when (compare-and-set! fired? false true)
-                             (frame/destroy-frame! frame-a)   ;; destroy A
+                             (rf.frame/destroy-frame! frame-a)   ;; destroy A
                              (rf/make-frame {:id frame-a})     ;; same-id B
-                             (reset! b-birth (mtest/runtime-db frame-a))))]
-    (trace-tooling/register-listener!
+                             (reset! b-birth (rf.machines.test-support/runtime-db frame-a))))]
+    (rf.trace.tooling/register-listener!
       ::spawn-tail-fence
       (fn [ev]
         (case (:operation ev)
@@ -101,23 +101,23 @@
           nil)))
     (try
       ;; Capture (never route) any dispatch the cascade attempts.
-      (late-bind/set-fn! :router/dispatch!
+      (rf.late-bind/set-fn! :router/dispatch!
                          (fn [ev opts] (swap! dispatches conj [ev opts]) nil))
-      (frame/call-with-event-owner-token frame-a token-a
-        (fn [] (spawn/spawn-fx {:frame frame-a}
+      (rf.frame/call-with-event-owner-token frame-a token-a
+        (fn [] (rf.machines.lifecycle-fx.spawn/spawn-fx {:frame frame-a}
                                (cond-> {:machine-id spawn-child-type :start [:go]}
                                  system-id (assoc :system-id system-id)))))
       {:fired?           @fired?
        :b-birth          @b-birth
-       :b-runtime        (mtest/runtime-db frame-a)
-       :b-snapshot       (mtest/snapshot frame-a spawn-child-instance-id)
-       :spawn-order      (spawn-order/frame-order frame-a)
+       :b-runtime        (rf.machines.test-support/runtime-db frame-a)
+       :b-snapshot       (rf.machines.test-support/snapshot frame-a spawn-child-instance-id)
+       :spawn-order      (rf.machines.spawn-order/frame-order frame-a)
        :dispatches       @dispatches
        :lifecycle-traces @lifecycle-traces}
       (finally
-        (trace-tooling/unregister-listener! ::spawn-tail-fence)
+        (rf.trace.tooling/unregister-listener! ::spawn-tail-fence)
         (when orig-dispatch!
-          (late-bind/set-fn! :router/dispatch! orig-dispatch!))))))
+          (rf.late-bind/set-fn! :router/dispatch! orig-dispatch!))))))
 
 (defn- assert-spawn-tail-inert [{:keys [b-birth b-runtime b-snapshot spawn-order
                                         dispatches lifecycle-traces]}]
@@ -178,37 +178,37 @@
             once — snapshot installed, system-id bound, spawn-order recorded,
             lifecycle-spawned emitted, :start dispatched. The fence is scoped to
             owner-loss only."
-    (spawn-order/reset-all!)
+    (rf.machines.spawn-order/reset-all!)
     (rf/reg-machine spawn-child-type
       {:initial :running
        :states  {:running {:on {:go :done}}
                  :done    {:final? true}}})
     (let [frame-a        :rf2-hloj0g/live-spawn-frame
           dispatches     (atom [])
-          orig-dispatch! (late-bind/get-fn :router/dispatch!)]
+          orig-dispatch! (rf.late-bind/get-fn :router/dispatch!)]
       (rf/make-frame {:id frame-a})
-      (let [token-a (frame/frame-incarnation-token frame-a)]
+      (let [token-a (rf.frame/frame-incarnation-token frame-a)]
         (try
-          (late-bind/set-fn! :router/dispatch!
+          (rf.late-bind/set-fn! :router/dispatch!
                              (fn [ev opts] (swap! dispatches conj [ev opts]) nil))
-          (frame/call-with-event-owner-token frame-a token-a
-            (fn [] (spawn/spawn-fx {:frame frame-a}
+          (rf.frame/call-with-event-owner-token frame-a token-a
+            (fn [] (rf.machines.lifecycle-fx.spawn/spawn-fx {:frame frame-a}
                                    {:machine-id spawn-child-type
                                     :system-id  :rf2-hloj0g/live-sid
                                     :start      [:go]})))
-          (is (some? (mtest/snapshot frame-a spawn-child-instance-id))
+          (is (some? (rf.machines.test-support/snapshot frame-a spawn-child-instance-id))
               "the live spawn installed the child snapshot")
           (is (= spawn-child-instance-id
-                 (get-in (mtest/runtime-db frame-a)
+                 (get-in (rf.machines.test-support/runtime-db frame-a)
                          [:rf.runtime/machines :system-ids :rf2-hloj0g/live-sid]))
               "the live spawn bound the :system-id")
-          (is (= [spawn-child-instance-id] (vec (spawn-order/frame-order frame-a)))
+          (is (= [spawn-child-instance-id] (vec (rf.machines.spawn-order/frame-order frame-a)))
               "the live spawn recorded exactly one spawn-order entry")
           (is (= 1 (count @dispatches))
               "the live spawn dispatched :start exactly once")
           (finally
             (when orig-dispatch!
-              (late-bind/set-fn! :router/dispatch! orig-dispatch!))))))))
+              (rf.late-bind/set-fn! :router/dispatch! orig-dispatch!))))))))
 
 ;; ---- finalization-tail fence (teardown callbacks) -------------------------
 ;;
@@ -236,7 +236,7 @@
   binding into `frame-id`'s runtime-db, so the finalize teardown resolves a
   non-nil released-sid (exercising the `:rf.machine/system-id-released` trace)."
   [frame-id machine-id sid]
-  (frame/swap-runtime-db!
+  (rf.frame/swap-runtime-db!
     frame-id
     (fn [rt] (-> rt
                  (assoc-in [:rf.runtime/machines :snapshots machine-id] (finishing-snapshot))
@@ -249,21 +249,21 @@
   `:destroyed-trace`, `:system-id-released`, or `:http-abort`. Returns the
   observable post-finalize state."
   [frame-a machine-id sid trigger]
-  (spawn-order/reset-all!)
+  (rf.machines.spawn-order/reset-all!)
   (rf/reg-machine machine-id (finishing-machine frame-a))
   (rf/make-frame {:id frame-a})
   (seed-finishing+sid! frame-a machine-id sid)
-  (let [token-a    (frame/frame-incarnation-token frame-a)
+  (let [token-a    (rf.frame/frame-incarnation-token frame-a)
         fired?     (atom false)
         destroyed  (atom [])
         released   (atom [])
-        orig-abort (late-bind/get-fn :http/abort-on-actor-destroy)
+        orig-abort (rf.late-bind/get-fn :http/abort-on-actor-destroy)
         destroy+B! (fn []
                      (when (compare-and-set! fired? false true)
-                       (frame/destroy-frame! frame-a)   ;; destroy A
+                       (rf.frame/destroy-frame! frame-a)   ;; destroy A
                        (rf/make-frame {:id frame-a})     ;; same-id B
                        (seed-finishing+sid! frame-a machine-id sid)))]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       ::teardown-fence
       (fn [ev]
         (case (:operation ev)
@@ -274,24 +274,24 @@
           nil)))
     (try
       (when (= trigger :http-abort)
-        (late-bind/set-fn! :http/abort-on-actor-destroy
+        (rf.late-bind/set-fn! :http/abort-on-actor-destroy
                            (fn [_actor-id] (destroy+B!) nil)))
-      (let [ret (frame/call-with-event-owner-token frame-a token-a
+      (let [ret (rf.frame/call-with-event-owner-token frame-a token-a
                   (fn []
-                    (finalize/finalize-machine
+                    (rf.machines.lifecycle-fx.finalize/finalize-machine
                       (finishing-machine frame-a)
-                      machine-id frame-a (mtest/runtime-db frame-a)
+                      machine-id frame-a (rf.machines.test-support/runtime-db frame-a)
                       (finishing-snapshot) [:some-completing-event] [])))]
         {:fired?     @fired?
          :ret        ret
-         :b-runtime  (mtest/runtime-db frame-a)
-         :b-snapshot (mtest/snapshot frame-a machine-id)
-         :reg-entry  (registrar/lookup :event machine-id)
+         :b-runtime  (rf.machines.test-support/runtime-db frame-a)
+         :b-snapshot (rf.machines.test-support/snapshot frame-a machine-id)
+         :reg-entry  (rf.registrar/lookup :event machine-id)
          :destroyed  @destroyed
          :released   @released})
       (finally
-        (trace-tooling/unregister-listener! ::teardown-fence)
-        (late-bind/set-fn! :http/abort-on-actor-destroy orig-abort)))))
+        (rf.trace.tooling/unregister-listener! ::teardown-fence)
+        (rf.late-bind/set-fn! :http/abort-on-actor-destroy orig-abort)))))
 
 (defn- assert-teardown-inert
   "Assert the finalize tail was fenced: B kept its snapshot + registrar entry,
@@ -360,7 +360,7 @@
             fully — the destroyed + system-id-released traces fire and finalize
             returns a runtime-db effect that dissoc'd the snapshot. The fence is
             scoped to owner-loss only."
-    (spawn-order/reset-all!)
+    (rf.machines.spawn-order/reset-all!)
     (let [frame-a    :rf2-hloj0g/live-finalize-frame
           machine-id :rf2-hloj0g/live-finalize-machine
           sid        :rf2-hloj0g/live-finalize-sid
@@ -369,19 +369,19 @@
       (rf/reg-machine machine-id (finishing-machine frame-a))
       (rf/make-frame {:id frame-a})
       (seed-finishing+sid! frame-a machine-id sid)
-      (let [token-a (frame/frame-incarnation-token frame-a)]
-        (trace-tooling/register-listener!
+      (let [token-a (rf.frame/frame-incarnation-token frame-a)]
+        (rf.trace.tooling/register-listener!
           ::live-finalize
           (fn [ev] (case (:operation ev)
                      :rf.machine/destroyed          (swap! destroyed conj ev)
                      :rf.machine/system-id-released (swap! released conj ev)
                      nil)))
         (try
-          (let [ret (frame/call-with-event-owner-token frame-a token-a
+          (let [ret (rf.frame/call-with-event-owner-token frame-a token-a
                       (fn []
-                        (finalize/finalize-machine
+                        (rf.machines.lifecycle-fx.finalize/finalize-machine
                           (finishing-machine frame-a)
-                          machine-id frame-a (mtest/runtime-db frame-a)
+                          machine-id frame-a (rf.machines.test-support/runtime-db frame-a)
                           (finishing-snapshot) [:some-completing-event] [])))]
             (is (nil? (get-in (:rf.db/runtime ret)
                               [:rf.runtime/machines :snapshots machine-id]))
@@ -392,4 +392,4 @@
             (is (= 1 (count @destroyed)) "exactly one :rf.machine/destroyed trace fired")
             (is (= 1 (count @released)) "exactly one :rf.machine/system-id-released trace fired"))
           (finally
-            (trace-tooling/unregister-listener! ::live-finalize)))))))
+            (rf.trace.tooling/unregister-listener! ::live-finalize)))))))

--- a/implementation/machines/test/re_frame/machine_property_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_property_cljs_test.cljc
@@ -17,7 +17,7 @@
   ## Properties asserted (over deterministic draws)
 
   For every drawn `[machine event-sequence]` threaded through the pure
-  `machines/machine-transition` engine from its `build-initial-snapshot`
+  `rf.machines/machine-transition` engine from its `build-initial-snapshot`
   initial snapshot:
 
     1. STATE-IS-LEAF — the snapshot's `:state` is ALWAYS a leaf
@@ -92,16 +92,16 @@
   engine's invariants are exercised on both hosts from this one file.
 
   Pure-engine only — no frame, no app-db, no `reg-machine`: every property
-  drives `machines/machine-transition` (a pure fn of its arguments) from a
-  `parallel/build-initial-snapshot` initial snapshot, so the layer is
+  drives `rf.machines/machine-transition` (a pure fn of its arguments) from a
+  `rf.machines.parallel/build-initial-snapshot` initial snapshot, so the layer is
   JVM-runnable from arguments alone and has no fixture."
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing]]
       :cljs [cljs.test :refer-macros [deftest is testing]])
    [clojure.set :as set]
-   [re-frame.machines :as machines]
-   [re-frame.machines.parallel :as parallel]
-   [re-frame.machines.transition :as transition]))
+   [re-frame.machines :as rf.machines]
+   [re-frame.machines.parallel :as rf.machines.parallel]
+   [re-frame.machines.transition :as rf.machines.transition]))
 
 ;; ---- a deterministic, host-portable PRNG ----------------------------------
 ;;
@@ -277,7 +277,7 @@
               (recur (inc i) s1
                      (assoc acc (nth region-names i)
                             (select-keys fm [:initial :states]))))))]
-    [(parallel/install-region-cache
+    [(rf.machines.parallel/install-region-cache
        {:type    :parallel
         :data    {:n 0}
         :guards  shared-guards
@@ -366,7 +366,7 @@
             [acc s]
             (let [[rb s1] (gen-independent-region s)]
               (recur (inc i) s1 (assoc acc (nth region-names i) rb)))))]
-    [(parallel/install-region-cache
+    [(rf.machines.parallel/install-region-cache
        {:type    :parallel
         :data    {:n 0}
         :guards  shared-guards
@@ -402,7 +402,7 @@
   registration + spawn paths use). `bootstrap-pending? false` ⇒ a clean
   post-cascade snapshot to drive the pure engine from."
   [machine]
-  (parallel/build-initial-snapshot machine {:bootstrap-pending? false}))
+  (rf.machines.parallel/build-initial-snapshot machine {:bootstrap-pending? false}))
 
 (defn- run-sequence
   "Thread `events` through the pure engine from `machine`'s initial
@@ -413,7 +413,7 @@
   (loop [snap (initial-snapshot machine), evs events, acc []]
     (if (empty? evs)
       acc
-      (let [r     (machines/machine-transition machine snap (first evs))
+      (let [r     (rf.machines/machine-transition machine snap (first evs))
             snap' (if (= :ok (:status r)) (:snapshot r) snap)]
         (recur snap' (rest evs)
                (conj acc {:snap snap' :fx (when (= :ok (:status r)) (:fx r))
@@ -438,15 +438,15 @@
     ;; parallel: every region value resolves to a leaf of its region body
     (every?
       (fn [[rn rstate]]
-        (let [rbody (parallel/region-machine machine rn)]
-          (leaf-node? (transition/node-at rbody (transition/state-path rstate)))))
+        (let [rbody (rf.machines.parallel/region-machine machine rn)]
+          (leaf-node? (rf.machines.transition/node-at rbody (rf.machines.transition/state-path rstate)))))
       state)
-    (leaf-node? (transition/node-at machine (transition/state-path state)))))
+    (leaf-node? (rf.machines.transition/node-at machine (rf.machines.transition/state-path state)))))
 
 ;; ---- INVARIANT 2 oracle: an INDEPENDENT tag computation -------------------
 ;;
 ;; The oracle must NOT recompute the expected tag union via
-;; `transition/compute-tags` — that is the SAME fn the engine's commit-tags
+;; `rf.machines.transition/compute-tags` — that is the SAME fn the engine's commit-tags
 ;; calls (`transition.cljc` `commit-tags` → `compute-tags`), so reusing it
 ;; only cross-checks the elision rule + state/tag consistency, never the
 ;; union math itself. Instead, walk the active-state ancestor
@@ -471,7 +471,7 @@
 (defn- path->vec
   "Normalise a single-machine `:state` (keyword or vector path) to a vector
   path — reimplemented here so the oracle does not lean on
-  `transition/state-path`."
+  `rf.machines.transition/state-path`."
   [state]
   (cond
     (vector? state)  state
@@ -498,7 +498,7 @@
   "INVARIANT 2 oracle. Independently recompute the active-configuration tag
   union for `machine` + `state` (the projection the engine must stamp), via
   a HAND-WRITTEN ancestor-chain walk over the machine spec — NOT via
-  `transition/compute-tags` (which the engine itself uses, so reusing it
+  `rf.machines.transition/compute-tags` (which the engine itself uses, so reusing it
   would be circular). For parallel, union the independent walk
   across every region; for flat/compound, walk the single path."
   [machine state]
@@ -506,7 +506,7 @@
     ;; parallel: independently walk each region's own :states by its leaf path
     (transduce
       (map (fn [[rn rstate]]
-             (let [rbody (parallel/region-machine machine rn)]
+             (let [rbody (rf.machines.parallel/region-machine machine rn)]
                (ancestor-chain-tags (:states rbody) (path->vec rstate)))))
       set/union #{} state)
     (ancestor-chain-tags (:states machine) (path->vec state))))
@@ -594,9 +594,9 @@
           ;; cycle surfaces as a FAILED macrostep at the depth bound (XState
           ;; v5 throws on such a runaway) — `:status :error` with the
           ;; depth-exceeded `:kind`, NOT an :ok rollback no-op.
-          r-always (machines/machine-transition
+          r-always (rf.machines/machine-transition
                      always-cycle (initial-snapshot always-cycle) [:noop])
-          r-raise  (machines/machine-transition
+          r-raise  (rf.machines/machine-transition
                      raise-cycle (initial-snapshot raise-cycle) [:e0])]
       (is (= :rf.error/machine-always-depth-exceeded (get-in r-always [:error :kind]))
           "always-cycle aborts at the depth bound as a depth-abort :fail (settled, not hung)")
@@ -640,8 +640,8 @@
                            (if (empty? todo)
                              nil
                              (let [ev (first todo)
-                                   r1 (machines/machine-transition m snap ev)
-                                   r2 (machines/machine-transition m snap ev)]
+                                   r1 (rf.machines/machine-transition m snap ev)
+                                   r2 (rf.machines/machine-transition m snap ev)]
                                (cond
                                  (not= r1 r2)
                                  {:why :nondeterministic :state (:state snap) :event ev}
@@ -730,7 +730,7 @@
                                :working {:spawn {:machine-id :child/worker :start [:begin]}
                                          :on    {:e1 :idle}}}}
             s0 (initial-snapshot spawner)
-            r  (machines/machine-transition spawner s0 [:e0])]
+            r  (rf.machines/machine-transition spawner s0 [:e0])]
         (is (= 1 (reduce + 0 (vals (:rf/spawn-counter (:snapshot r)))))
             "entering a :spawn state bumps the in-snapshot counter to 1")))))
 
@@ -771,10 +771,10 @@
                                  :done    {:on {:e3 :idle}}}}
                     s0       (initial-snapshot m)
                     ;; enter the spawn state
-                    r-enter  (machines/machine-transition m s0 [:e0])
+                    r-enter  (rf.machines/machine-transition m s0 [:e0])
                     spawned  (spawn-invoke-ids (:fx r-enter))
                     ;; exit the spawn state (→ :done)
-                    r-exit   (machines/machine-transition m (:snapshot r-enter) [:e1])
+                    r-exit   (rf.machines/machine-transition m (:snapshot r-enter) [:e1])
                     destroyed (destroy-invoke-ids (:fx r-exit))]
                 (cond
                   (not= #{[:working]} spawned)
@@ -794,9 +794,9 @@
                        :working {:spawn {:machine-id :child/worker :start [:begin]}
                                  :on    {:e1 :idle}}}}
           s0 (initial-snapshot m)
-          r1 (machines/machine-transition m s0 [:e0])           ;; spawn #1
-          r2 (machines/machine-transition m (:snapshot r1) [:e1]) ;; exit (destroy)
-          r3 (machines/machine-transition m (:snapshot r2) [:e0])] ;; spawn #2
+          r1 (rf.machines/machine-transition m s0 [:e0])           ;; spawn #1
+          r2 (rf.machines/machine-transition m (:snapshot r1) [:e1]) ;; exit (destroy)
+          r3 (rf.machines/machine-transition m (:snapshot r2) [:e0])] ;; spawn #2
       (is (= 1 (get-in (:snapshot r1) [:rf/spawn-counter :child/worker])))
       (is (= 2 (get-in (:snapshot r3) [:rf/spawn-counter :child/worker]))
           "re-entering the spawn state allocates the NEXT id — counter monotone, never rewound"))))
@@ -851,7 +851,7 @@
             (let [rs    (:regions machine)
                   order (vec (reverse (keys rs)))
                   rev   (into {} (map (fn [k] [k (get rs k)])) order)]
-              (parallel/install-region-cache
+              (rf.machines.parallel/install-region-cache
                 (-> machine
                     (assoc :regions rev)
                     (assoc :region-order order)))))
@@ -912,7 +912,7 @@
                                         :c-one {}
                                         :c-two {}}}}}
           run  (fn [order]
-                 (let [m (parallel/install-region-cache (assoc base :region-order order))]
+                 (let [m (rf.machines.parallel/install-region-cache (assoc base :region-order order))]
                    (:snap (last (run-sequence m [[:ev]])))))
           ab   (run [:a :b :c])
           ba   (run [:b :a :c])]
@@ -1047,7 +1047,7 @@
                   watched   (nth names (mod (inc i) n))
                   [body s1] (cross-region-body s self watched)]
               (recur (inc i) s1 (assoc acc self body)))))]
-    [(parallel/install-region-cache
+    [(rf.machines.parallel/install-region-cache
        {:type    :parallel
         :data    {}
         :guards  (merge shared-guards cross-region-guards)
@@ -1078,7 +1078,7 @@
   mechanism and is validated as an exact permutation of the keyset."
   [machine order]
   (let [rs (:regions machine)]
-    (parallel/install-region-cache
+    (rf.machines.parallel/install-region-cache
       (-> machine
           (assoc :regions (into {} (map (fn [k] [k (get rs k)])) order))
           (assoc :region-order (vec order))))))
@@ -1149,7 +1149,7 @@
                   :s2 {}}}})
 
 (defn- watcher-machine [order]
-  (parallel/install-region-cache
+  (rf.machines.parallel/install-region-cache
     {:type    :parallel
      :data    {}
      :guards  (merge shared-guards cross-region-guards)
@@ -1161,7 +1161,7 @@
             event that enables it — the first post-event round observes the
             complete applied event set (NOT 'settles on the next event')"
     (let [m (watcher-machine [:rA :rB])
-          r (machines/machine-transition m (initial-snapshot m) [:e0])]
+          r (rf.machines/machine-transition m (initial-snapshot m) [:e0])]
       (is (= :ok (:status r)))
       (is (= {:rA :s1 :rB :s2} (:state (:snapshot r)))
           ":rB's :always read :rA's same-macrostep flag write and moved in THIS
@@ -1173,7 +1173,7 @@
             any :always round selects"
     (let [final (fn [order]
                   (let [m (watcher-machine order)]
-                    (:state (:snapshot (machines/machine-transition
+                    (:state (:snapshot (rf.machines/machine-transition
                                 m (initial-snapshot m) [:e0])))))]
       (is (= {:rA :s1 :rB :s2} (final [:rA :rB])))
       (is (= {:rA :s1 :rB :s2} (final [:rB :rA]))

--- a/implementation/machines/test/re_frame/machine_pure_error_contract_test.clj
+++ b/implementation/machines/test/re_frame/machine_pure_error_contract_test.clj
@@ -14,7 +14,7 @@
       marker `[:rf.machine/start]`, the spawn kick-off
       `[:rf.machine.spawn/spawned]`, the stories-runtime lifecycle pings)
       is NOT classified as an unknown-user-event no-op —
-      `transition/unhandled-event-no-op?` gates the emit. Severity is
+      `rf.machines.transition/unhandled-event-no-op?` gates the emit. Severity is
       benign (nothing throws); the SEMANTIC carve-out means the machine's
       BIRTH renders its `:initial-entry` cascade rather than a no-op.
       Domain (non-`:rf/*`) events emit the benign no-op.
@@ -47,11 +47,11 @@
   dispatch loop, no app-db, no wall-clock — so they are deterministic by
   construction (the determinism canon)."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.error :as error]
-            [re-frame.machines :as machines]
-            [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.machines.transition :as transition]))
+            [re-frame.error :as rf.error]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.parallel :as rf.machines.parallel]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.machines.transition :as rf.machines.transition]))
 
 ;; ---------------------------------------------------------------------------
 ;; The BENIGN unhandled-event no-op (xstate-v5 parity) WITH the
@@ -70,10 +70,10 @@
   "Drive a pure `machine-transition` while a tooling listener records every
   emitted trace event (full envelope). Returns the vector of events
   (deterministic — no wall-clock / random). Routed through the shared
-  `mtest/with-trace-capture` — guaranteed unregister in a `finally`."
+  `rf.machines.test-support/with-trace-capture` — guaranteed unregister in a `finally`."
   [definition snapshot event]
-  (mtest/with-trace-capture seen
-    (machines/machine-transition definition snapshot event)
+  (rf.machines.test-support/with-trace-capture seen
+    (rf.machines/machine-transition definition snapshot event)
     @seen))
 
 (defn- capture-ops!
@@ -111,7 +111,7 @@
           (is (= :a (:state tags)))))))
 
   (testing "the snapshot is unchanged on an unhandled event (no state churn)"
-    (let [{s :snapshot} (machines/machine-transition
+    (let [{s :snapshot} (rf.machines/machine-transition
                               no-handler-spec {:state :a :data {}} [:nope])]
       (is (= :a (:state s)) "state unchanged"))))
 
@@ -133,22 +133,22 @@
 
   (testing "the reserved-namespace ping still returns an unchanged snapshot
    (no transition, no churn — benign, just unlabelled)"
-    (let [{s :snapshot} (machines/machine-transition
+    (let [{s :snapshot} (rf.machines/machine-transition
                              no-handler-spec {:state :a :data {}}
                              [:rf.story.lifecycle/events-complete])]
       (is (= :a (:state s)) "state unchanged for the benign reserved ping")))
 
   (testing "the negative guard — `unhandled-event-no-op?` is TRUE for a
    domain event (still a no-op) and FALSE for any reserved-:rf/* event"
-    (is (transition/unhandled-event-no-op? [:nope])
+    (is (rf.machines.transition/unhandled-event-no-op? [:nope])
         "a domain event is classified as an unknown-user-event no-op")
-    (is (not (transition/unhandled-event-no-op? [:rf.machine/start]))
+    (is (not (rf.machines.transition/unhandled-event-no-op? [:rf.machine/start]))
         "the synthetic creation marker is framework init, not a no-op")
-    (is (not (transition/unhandled-event-no-op? [:rf.machine.spawn/spawned]))
+    (is (not (rf.machines.transition/unhandled-event-no-op? [:rf.machine.spawn/spawned]))
         "the spawn kick-off is framework init, not a no-op")
-    (is (not (transition/unhandled-event-no-op? [:rf.story.lifecycle/events-complete]))
+    (is (not (rf.machines.transition/unhandled-event-no-op? [:rf.story.lifecycle/events-complete]))
         "a stories lifecycle ping rides the reserved root")
-    (is (not (transition/unhandled-event-no-op? [:rf/anything]))
+    (is (not (rf.machines.transition/unhandled-event-no-op? [:rf/anything]))
         "the bare reserved root is exempt")))
 
 ;; ---------------------------------------------------------------------------
@@ -176,8 +176,8 @@
    and installs the initial state — NOT an unhandled-no-op for
    [:rf.machine/start]"
     ;; Shared `with-trace-capture` — guaranteed unregister in a `finally`.
-    (mtest/with-trace-capture seen
-      (let [r    (parallel/apply-initial-entry-cascade
+    (rf.machines.test-support/with-trace-capture seen
+      (let [r    (rf.machines.parallel/apply-initial-entry-cascade
                    boot-entry-spec {:state :a :data {}})
             evs  @seen
             ops  (mapv :operation evs)
@@ -201,14 +201,14 @@
 
 (deftest state-path-rejects-malformed-state
   (testing "state-path coerces the two legal forms"
-    (is (= [:a] (transition/state-path :a))
+    (is (= [:a] (rf.machines.transition/state-path :a))
         "a keyword normalises to a 1-element path")
-    (is (= [:a :b] (transition/state-path [:a :b]))
+    (is (= [:a :b] (rf.machines.transition/state-path [:a :b]))
         "a vector path passes through"))
 
   (testing "a :state that is neither keyword nor vector throws
    :rf.error/machine-bad-state-form"
-    (let [e (try (transition/state-path "not-a-state") nil
+    (let [e (try (rf.machines.transition/state-path "not-a-state") nil
                  (catch clojure.lang.ExceptionInfo ex ex))]
       (is (some? e) "a string :state throws")
       (is (= "not-a-state" (:state (ex-data e)))
@@ -219,7 +219,7 @@
 (deftest bad-state-form-propagates-through-machine-transition
   (testing "a malformed snapshot :state surfaces the bad-state-form error
    out of the pure macrostep (the engine does not swallow it)"
-    (let [e (try (machines/machine-transition no-handler-spec
+    (let [e (try (rf.machines/machine-transition no-handler-spec
                                               {:state 42 :data {}} [:known])
                  nil
                  (catch clojure.lang.ExceptionInfo ex ex))]
@@ -243,7 +243,7 @@
                 :data    {}
                 :states  {:a {:on {:go {:target :b :guard "not-a-guard"}}}
                           :b {}}}
-          e    (try (machines/machine-transition spec {:state :a :data {}} [:go])
+          e    (try (rf.machines/machine-transition spec {:state :a :data {}} [:go])
                     nil
                     (catch clojure.lang.ExceptionInfo ex ex))]
       (is (some? e) "a string :guard form throws")
@@ -260,7 +260,7 @@
                 :data    {}
                 :states  {:a {:on {:go {:target :b :action 99}}}
                           :b {}}}
-          e    (try (machines/machine-transition spec {:state :a :data {}} [:go])
+          e    (try (rf.machines/machine-transition spec {:state :a :data {}} [:go])
                     nil
                     (catch clojure.lang.ExceptionInfo ex ex))]
       (is (some? e) "a numeric :action form throws")
@@ -285,7 +285,7 @@
                 :guards  {}                         ;; :nope is not registered
                 :states  {:a {:on {:go {:target :b :guard :nope}}}
                           :b {}}}
-          e    (try (machines/machine-transition spec {:state :a :data {}} [:go])
+          e    (try (rf.machines/machine-transition spec {:state :a :data {}} [:go])
                     nil
                     (catch clojure.lang.ExceptionInfo ex ex))]
       (is (some? e) "a dangling guard keyword throws at transition time")
@@ -305,7 +305,7 @@
                 :actions {}                          ;; :nope is not registered
                 :states  {:a {:on {:go {:target :b :action :nope}}}
                           :b {}}}
-          e    (try (machines/machine-transition spec {:state :a :data {}} [:go])
+          e    (try (rf.machines/machine-transition spec {:state :a :data {}} [:go])
                     nil
                     (catch clojure.lang.ExceptionInfo ex ex))]
       (is (some? e) "a dangling action keyword throws at transition time")
@@ -331,7 +331,7 @@
                 :data    {}
                 :states  {:a {:on {:go "not-a-transition-value"}}
                           :b {}}}
-          e    (try (machines/machine-transition spec {:state :a :data {}} [:go])
+          e    (try (rf.machines/machine-transition spec {:state :a :data {}} [:go])
                     nil
                     (catch clojure.lang.ExceptionInfo ex ex))]
       (is (some? e) "a malformed :on value throws")
@@ -351,7 +351,7 @@
                 :data    {}
                 :states  {:a {:on {:go {:target :b}}}
                           :b {:always 42}}}
-          e    (try (machines/machine-transition spec {:state :a :data {}} [:go])
+          e    (try (rf.machines/machine-transition spec {:state :a :data {}} [:go])
                     nil
                     (catch clojure.lang.ExceptionInfo ex ex))]
       (is (some? e) "a malformed :always value throws")
@@ -376,14 +376,14 @@
              ["malformed :always value"
               {:id :probe/s4 :initial :a :data {}
                :states {:a {:on {:go {:target :b}}} :b {:always 99}}}]]]
-      (let [e   (try (machines/machine-transition spec {:state :a :data {}} [:go])
+      (let [e   (try (rf.machines/machine-transition spec {:state :a :data {}} [:go])
                      nil
                      (catch clojure.lang.ExceptionInfo ex ex))
             msg (ex-message e)]
         (is (some? e) (str label " throws"))
-        (is (not (error/keyword-only-message? msg))
+        (is (not (rf.error/keyword-only-message? msg))
             (str label " message is a human sentence, never a bare keyword"))
-        (is (error/message-has-id-token? msg)
+        (is (rf.error/message-has-id-token? msg)
             (str label " message carries the [:rf.error/<id>] token"))
         (is (string? (:reason (ex-data e))) (str label " carries a :reason sentence"))
         (is (= 'rf/reg-machine (:where (ex-data e))) (str label " carries :where"))
@@ -405,9 +405,9 @@
                           :is-open? (fn [{d :data}] (:open? d))}  ;; registered id → fn
                 :states  {:a {:on {:go {:target :b :guard :gate}}}
                           :b {}}}
-          {s-pass :snapshot} (machines/machine-transition
+          {s-pass :snapshot} (rf.machines/machine-transition
                                   spec {:state :a :data {:open? true}} [:go])
-          {s-fail :snapshot} (machines/machine-transition
+          {s-fail :snapshot} (rf.machines/machine-transition
                                   spec {:state :a :data {:open? false}} [:go])]
       (is (= :b (:state s-pass))
           "indirected guard resolved + passed ⇒ transition fires")

--- a/implementation/machines/test/re_frame/machine_raise_cofx_replay_test.clj
+++ b/implementation/machines/test/re_frame/machine_raise_cofx_replay_test.clj
@@ -52,12 +52,12 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace :as rf.trace]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; The shared machine spec. `:go`'s action raises `[:inner]`; `:inner`'s guard
 ;; requires the generator-backed `:replay/gen`, NOT in `:go`'s ensure-set, so it
@@ -86,18 +86,18 @@
           run-start (atom nil)]
       (rf/reg-cofx :replay/gen {:recordable? true} (fn [] 100))
       (rf/reg-machine :replay/mint (mint-machine seen))
-      (trace/register-listener!
+      (rf.trace/register-listener!
         ::cap (fn [ev] (when (= :rf.event/run-start (:operation ev))
                          (reset! run-start ev))))
       ;; LIVE dispatch — only :rf/time-ms in the external token. :replay/gen is
       ;; minted mid-drain by the raised :inner's guard ensure.
       (rf/dispatch-sync [:replay/mint [:go]] {:rf.cofx {:rf/time-ms 111}})
-      (trace/unregister-listener! ::cap)
+      (rf.trace/unregister-listener! ::cap)
 
       ;; (1) The mint DID happen and the guard decided on the fresh value.
       (is (= 100 @seen)
           "the raised guard read the MINTED generator-backed fact (mid-drain)")
-      (is (= :done (mtest/machine-state :replay/mint))
+      (is (= :done (rf.machines.test-support/machine-state :replay/mint))
           "the machine advanced on the minted value")
 
       ;; (2) The run-start TRACE is the PRE-handler token — only :rf/time-ms.
@@ -131,7 +131,7 @@
       (is (= 100 @seen)
           "STRICT delivered the recorded :replay/gen verbatim — same value the
            live run's guard read")
-      (is (= :done (mtest/machine-state :replay/strict))
+      (is (= :done (rf.machines.test-support/machine-state :replay/strict))
           "STRICT replay reproduced the live decision deterministically"))))
 
 (deftest strict-replay-without-the-minted-fact-diverges-control
@@ -147,6 +147,6 @@
       (rf/dispatch-sync [:replay/strict-nofact [:go]]
                         {:rf.cofx {:rf/time-ms 111}
                          :rf.cofx/mint-policy :strict})
-      (is (not= :done (mtest/machine-state :replay/strict-nofact))
+      (is (not= :done (rf.machines.test-support/machine-state :replay/strict-nofact))
           "strict refused to mint the absent :replay/gen → the machine did NOT
            reach :done (the pre-fix replay divergence)"))))

--- a/implementation/machines/test/re_frame/machine_raise_fifo_test.clj
+++ b/implementation/machines/test/re_frame/machine_raise_fifo_test.clj
@@ -19,7 +19,7 @@
   Pairs with the flat-machine drain in
   `re-frame.machines.transition/drain-raises`."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.machines :as machines]))
+            [re-frame.machines :as rf.machines]))
 
 (defn- log-action
   "Build an action that appends `label` to `:data :log` and optionally
@@ -48,7 +48,7 @@
                                      :b  {:action :b}
                                      :c  {:action :c}
                                      :d  {:action :d}}}}}
-          {snap :snapshot} (machines/machine-transition
+          {snap :snapshot} (rf.machines/machine-transition
                                  spec {:state :hub :data {}} [:go])]
       (is (= [:go :b :c :d] (:log (:data snap)))
           "FIFO (XState/SCXML): the nested raise D lands behind sibling C —
@@ -66,7 +66,7 @@
                 :states  {:hub {:on {:go {:action :go}
                                      :b  {:action :b}
                                      :c  {:action :c}}}}}
-          {snap :snapshot} (machines/machine-transition
+          {snap :snapshot} (rf.machines/machine-transition
                                  spec {:state :hub :data {}} [:go])]
       (is (= [:go :b :c] (:log (:data snap)))
           "sibling raises drain in the order they entered the queue"))))
@@ -90,7 +90,7 @@
                                      :c  {:action :c}
                                      :d  {:action :d}
                                      :e  {:action :e}}}}}
-          {snap :snapshot} (machines/machine-transition
+          {snap :snapshot} (rf.machines/machine-transition
                                  spec {:state :hub :data {}} [:go])]
       (is (= [:go :b :c :d :e] (:log (:data snap)))
           "both first-level siblings (B, C) drain before either's nested
@@ -113,7 +113,7 @@
                           :s1 {:on {:e2 {:target :s2 :action :a2}}}
                           :s2 {:on {:e3 {:target :s3 :action :a3}}}
                           :s3 {}}}
-          {snap :snapshot} (machines/machine-transition
+          {snap :snapshot} (rf.machines/machine-transition
                                  spec {:state :s0 :data {}} [:e1])]
       (is (= :s3 (:state snap))
           "linear chain still settles to the terminal state")
@@ -154,7 +154,7 @@
         ;; snapshot / fx, so nothing intermediate escapes the abort. (The
         ;; lifecycle handler short-circuits to `{}`, leaving the pre-event
         ;; snapshot committed in runtime-db.)
-        (let [r (machines/machine-transition spec {:state :idle :data {}} [:start])]
+        (let [r (rf.machines/machine-transition spec {:state :idle :data {}} [:start])]
           (is (= :error (:status r))
               "depth-exceeded returns a :fail (failed macrostep), not an :ok no-op")
           (is (= :rf.error/machine-raise-depth-exceeded (get-in r [:error :kind]))
@@ -196,7 +196,7 @@
                                        :fx   [[:raise [:to-a]] [:side-effect-b 1]]})
                              :on {:to-a :a}}}}
           original {:state :idle :data {:n 0}}
-          r        (machines/machine-transition spec original [:start])]
+          r        (rf.machines/machine-transition spec original [:start])]
       ;; The abort is a FAILED macrostep. Atomic rollback is enforced by the
       ;; `:fail` threading NO snapshot / fx: every intermediate :a/:b state,
       ;; bumped :n, and accumulated :side-effect fx is discarded with the

--- a/implementation/machines/test/re_frame/machine_registration_grammar_validation_test.clj
+++ b/implementation/machines/test/re_frame/machine_registration_grammar_validation_test.clj
@@ -13,12 +13,12 @@
   Each rule is pinned in both directions: the malformed declaration is
   rejected, and a well-formed one validates silently."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.machines :as machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- history placement --------------------------------------------------
 
@@ -30,7 +30,7 @@
                  {:type :history :initial :a :states {:a {}}}
                  ;; flat top-level `:type :history` (no enclosing compound)
                  {:initial :a :states {:a {} :h {:type :history}}}]]
-      (let [e (try (machines/validate-machine! bad) nil
+      (let [e (try (rf.machines/validate-machine! bad) nil
                    (catch clojure.lang.ExceptionInfo ex ex))]
         (is (= :rf.error/machine-history-misplaced
                (:rf.error/id (ex-data e)))
@@ -38,12 +38,12 @@
         (is (= :history (:feature (ex-data e))) ":feature names the history grammar"))))
   (testing "a WELL-PLACED `:type :history` node (inside a compound's :states)
    validates silently"
-    (is (nil? (machines/validate-machine!
+    (is (nil? (rf.machines/validate-machine!
                 {:initial :c
                  :states  {:c {:initial :a
                                :states  {:a {} :h {:type :history :deep? true}}}}}))))
   (testing "a well-formed history-free hierarchical machine validates silently"
-    (is (nil? (machines/validate-machine!
+    (is (nil? (rf.machines/validate-machine!
                 {:initial :p
                  :states  {:p {:initial :a :states {:a {} :b {}}}}})))))
 
@@ -51,13 +51,13 @@
 
 (deftest after-guard-action-refs-validated-at-registration
   (testing "a dangling :after :guard ref fails registration (not at runtime)"
-    (let [e (try (machines/validate-machine!
+    (let [e (try (rf.machines/validate-machine!
                    {:initial :a
                     :states  {:a {:after {1000 {:target :b :guard :missing?}}}
                               :b {}}})
                  nil (catch clojure.lang.ExceptionInfo ex ex))]
       (is (= :rf.error/machine-unresolved-guard (:rf.error/id (ex-data e)))))
-    (let [e (try (machines/validate-machine!
+    (let [e (try (rf.machines/validate-machine!
                    {:initial :a
                     :states  {:a {:after {1000 {:target :b :action :nope}}}
                               :b {}}})

--- a/implementation/machines/test/re_frame/machine_reply_lowering_test.clj
+++ b/implementation/machines/test/re_frame/machine_reply_lowering_test.clj
@@ -28,18 +28,18 @@
             ;; (`reg-machine`, the `:rf.machine/spawn` / `:rf.machine/destroy`
             ;; / `:rf.machine/after-*` reserved fxs) the runtime needs.
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace :as rf.trace]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (defn- capture-traces [id]
   (let [a (atom [])]
-    (trace/register-listener! id (fn [ev] (swap! a conj ev)))
+    (rf.trace/register-listener! id (fn [ev] (swap! a conj ev)))
     a))
 
 ;; ===========================================================================
@@ -78,7 +78,7 @@
                            (filter #(= :rf.machine.timer/stale-after (:operation %)))
                            first)]
             (is (some? stale) ":rf.machine.timer/stale-after trace fired")
-            ;; `:recovery` is hoisted to the top-level event by `trace/emit!`
+            ;; `:recovery` is hoisted to the top-level event by `rf.trace/emit!`
             ;; (it is not a `:tags` key) — assert it there.
             (is (= :replaced-with-default (:recovery stale)))
             (let [tags (:tags stale)]
@@ -111,7 +111,7 @@
                 (is (= [:loading] (-> corr :current :path)))
                 (is (not= scheduled-epoch (-> corr :current :rf/after-epoch))
                     "current epoch advanced — the gate mismatch")))))
-        (finally (trace/unregister-listener! ::after-stale))))))
+        (finally (rf.trace/unregister-listener! ::after-stale))))))
 
 (deftest after-live-still-fires
   (testing "behavioural parity: a LIVE :after timer still fires its transition (lowering did not perturb the live path)"
@@ -179,7 +179,7 @@
             (is (not (contains? tags :work/id))
                 "no bare :work/id duplicate on the reply-envelope done trace")
             (is (= :machine (:rf.reply/work-kind tags)))))
-        (finally (trace/unregister-listener! ::done-ok))))))
+        (finally (rf.trace/unregister-listener! ::done-ok))))))
 
 (deftest spawned-error-drives-on-error-transition
   (testing "a child reaching an :error? terminal forms a :status :error reply and drives the parent's :on-error TRANSITION (raw payload on :event preserved)"
@@ -226,7 +226,7 @@
             (is (true? (:error? tags)))
             (is (= :error (:rf.reply/status tags)))
             (is (= :failed (:rf.reply/work-status tags)))))
-        (finally (trace/unregister-listener! ::done-err))))))
+        (finally (rf.trace/unregister-listener! ::done-err))))))
 
 ;; ===========================================================================
 ;; (3) spawn-stale — parent destroyed BEFORE the child finishes.
@@ -321,7 +321,7 @@
               (is (nil? (-> corr :generation :current))
                   "current generation is nil — the spawn slot is gone (no live counterpart)")
               (is (= :rl/schild#1 (:actor-id corr))))))
-        (finally (trace/unregister-listener! ::spawn-stale))))))
+        (finally (rf.trace/unregister-listener! ::spawn-stale))))))
 
 (deftest spawn-live-parent-still-drives-on-done
   (testing "behavioural parity: with the parent STILL alive, the child's completion is :ok and :on-done runs (the rf2-lohbfg stale detection did not perturb the live path)"
@@ -407,7 +407,7 @@
             ;; sanity: the rest of the canonical envelope is intact.
             (is (= :ok (:rf.reply/status tags)))
             (is (= :completed (:rf.reply/work-status tags)))))
-        (finally (trace/unregister-listener! ::completed-at))))))
+        (finally (rf.trace/unregister-listener! ::completed-at))))))
 
 (deftest unscripted-completion-omits-completed-at
   (testing "adversarial: an UNSCRIPTED completion (no :rf.cofx) carries NO :completed-at — the fact is OMITTED, never nil-filled or stamped from an ambient clock (Managed-Effects §The reply map)"
@@ -454,4 +454,4 @@
           (is (not (and (contains? tags :rf.reply/completed-at)
                         (nil? (:rf.reply/completed-at tags))))
               ":rf.reply/completed-at is never an explicit nil sentinel"))
-        (finally (trace/unregister-listener! ::no-completed-at))))))
+        (finally (rf.trace/unregister-listener! ::no-completed-at))))))

--- a/implementation/machines/test/re_frame/machine_root_on_fallback_test.clj
+++ b/implementation/machines/test/re_frame/machine_root_on_fallback_test.clj
@@ -21,17 +21,17 @@
       (Spec 005:1334), not left to fail at dispatch."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
-;; Routed through the shared `mtest/with-trace-capture` — guaranteed
+;; Routed through the shared `rf.machines.test-support/with-trace-capture` — guaranteed
 ;; unregister in a `finally`.
 (defn- record-traces! [body-fn]
-  (mtest/with-trace-capture seen
+  (rf.machines.test-support/with-trace-capture seen
     (body-fn)
     @seen))
 
@@ -138,14 +138,14 @@
 
 (deftest root-on-refs-validated-at-registration
   (testing "a dangling root-`:on` :guard / :action ref fails registration"
-    (let [e (try (machines/validate-machine!
+    (let [e (try (rf.machines/validate-machine!
                    {:initial :a
                     :on      {:go {:target :a :guard :missing?}}
                     :states  {:a {}}})
                  nil (catch clojure.lang.ExceptionInfo ex ex))]
       (is (= :rf.error/machine-unresolved-guard (:rf.error/id (ex-data e)))))
     (testing "a resolvable root-`:on` ref validates silently"
-      (is (nil? (machines/validate-machine!
+      (is (nil? (rf.machines/validate-machine!
                   {:initial :a
                    :guards  {:ok? (fn [_] true)}
                    :on      {:go {:target :a :guard :ok?}}

--- a/implementation/machines/test/re_frame/machine_schema_arity_test.clj
+++ b/implementation/machines/test/re_frame/machine_schema_arity_test.clj
@@ -38,24 +38,24 @@
             [re-frame.core :as rf]
             ;; Loading the machines artefact publishes its late-bind hooks
             ;; (`:machines/reg-machine` etc.) so `rf/reg-machine` resolves.
-            [re-frame.machines :as machines]
-            [re-frame.machines.test-support :as mtest]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
             ;; The schemas artefact ships the registered-validator hot path the
             ;; `:where :machine-data` / `:where :event` boundaries route through;
             ;; the `.malli` adapter ns publishes Malli validate/explain into the
             ;; late-bind table.
             [re-frame.schemas]
             [re-frame.schemas.malli]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- collect-machine-data-traces!
   "Run `f` while collecting every `:rf.error/schema-validation-failure`
   trace event whose `:where` is `:machine-data`."
   [f]
-  (mtest/with-trace-capture traces
+  (rf.machines.test-support/with-trace-capture traces
     (f)
     (filterv #(and (= :rf.error/schema-validation-failure (:operation %))
                    (= :machine-data (-> % :tags :where)))
@@ -65,7 +65,7 @@
   "Run `f` while collecting every `:rf.error/schema-validation-failure`
   trace event whose `:where` is `:event` (the outer-vector boundary)."
   [f]
-  (mtest/with-trace-capture traces
+  (rf.machines.test-support/with-trace-capture traces
     (f)
     (filterv #(and (= :rf.error/schema-validation-failure (:operation %))
                    (= :event (-> % :tags :where)))
@@ -133,10 +133,10 @@
                 :schemas {:data AuthLoginData}
                 :actions {:break (fn [_] {:data {:attempts "nope" :token nil :error nil}})}
                 :states  {:idle {:on {:auth.login/break {:target :idle :action :break}}}}}]
-      (machines/reg-machine* flow-id {:schema AuthLoginEvent} spec)
+      (rf.machines/reg-machine* flow-id {:schema AuthLoginEvent} spec)
       ;; The machine meta is stamped — machine-meta reads the spec + [:schemas :data]
       ;; back (so the schema is live, not inert).
-      (let [meta (machines/machine-meta flow-id)]
+      (let [meta (rf.machines/machine-meta flow-id)]
         (is (some? meta) "machine-meta is non-nil (meta WAS stamped)")
         (is (= AuthLoginData (get-in meta [:schemas :data]))
             "[:schemas :data] round-trips through machine-meta — it is LIVE"))
@@ -166,7 +166,7 @@
     ;; rather than flattened by `:cat`'s sequence-regex semantics.
     (let [StrictEvent [:tuple [:= flow-id]
                        [:tuple [:= :auth.login/submit] Credentials]]]
-      (machines/reg-machine* flow-id
+      (rf.machines/reg-machine* flow-id
         {:schema StrictEvent}
         {:initial :idle
          :data    {:attempts 0 :token nil :error nil}
@@ -182,12 +182,12 @@
                         [flow-id [:auth.login/submit {:email "a@b.com" :password "short"}]]))]
         (is (<= 1 (count traces))
             "a :where :event boundary trace fired for the malformed event vector")
-        (is (not= :submitting (mtest/machine-state flow-id))
+        (is (not= :submitting (rf.machines.test-support/machine-state flow-id))
             "the malformed event did NOT drive the transition"))
       ;; Well-formed submit transitions normally — :schema accepts it.
       (rf/dispatch-sync
         [flow-id [:auth.login/submit {:email "a@b.com" :password "longenough"}]])
-      (is (= :submitting (mtest/machine-state flow-id))
+      (is (= :submitting (rf.machines.test-support/machine-state flow-id))
           "a well-formed event vector passes the :schema boundary and transitions"))))
 
 ;; ---- (3b) the login examples' SHIPPED event schema rejects malformed submit -
@@ -205,7 +205,7 @@
             :submit at the :where :event boundary (no machine transition, no
             login HTTP effect), while a valid submit + framework reply events
             still pass"
-    (machines/reg-machine* flow-id
+    (rf.machines/reg-machine* flow-id
       {:schema LoginExampleEvent}
       {:initial :idle
        :data    {:attempts 0 :token nil :error nil}
@@ -223,7 +223,7 @@
                       [flow-id [:auth.login/submit {:email "a@b.com" :password "short"}]]))]
       (is (<= 1 (count traces))
           "a :where :event boundary trace fired for the malformed short-password submit")
-      (is (not= :submitting (mtest/machine-state flow-id))
+      (is (not= :submitting (rf.machines.test-support/machine-state flow-id))
           "the malformed submit did NOT transition the machine (no login effect issued)"))
     ;; (b) bad email — also rejected; never reaches :submitting (the rejected
     ;; submits never reached the handler, so the machine is still un-bootstrapped
@@ -233,12 +233,12 @@
                       [flow-id [:auth.login/submit {:email "noat" :password "longenough"}]]))]
       (is (<= 1 (count traces))
           "a :where :event boundary trace fired for the bad-email submit")
-      (is (not= :submitting (mtest/machine-state flow-id))
+      (is (not= :submitting (rf.machines.test-support/machine-state flow-id))
           "the bad-email submit did NOT transition the machine"))
     ;; (c) valid submit passes the boundary and transitions to :submitting.
     (rf/dispatch-sync
       [flow-id [:auth.login/submit {:email "a@b.com" :password "longenough"}]])
-    (is (= :submitting (mtest/machine-state flow-id))
+    (is (= :submitting (rf.machines.test-support/machine-state flow-id))
         "a well-formed submit passes the boundary and transitions")
     ;; (d) the framework reply event (success + trailing payload) still passes —
     ;; the corrected schema must not reject the managed-HTTP reply addressing.
@@ -247,7 +247,7 @@
                       [flow-id [:auth.login/success] {:kind :ok :value {:token "t"}}]))]
       (is (zero? (count traces))
           "the framework success-reply event passes the boundary (no validation failure)")
-      (is (= :authed (mtest/machine-state flow-id))
+      (is (= :authed (rf.machines.test-support/machine-state flow-id))
           "the reply event drove the transition to :authed"))))
 
 ;; ---- (4) fail-loud guard on the bare unstamped-with-schema direct path -----
@@ -257,7 +257,7 @@
             a [:schemas :data]-bearing spec RAISES :rf.error/machine-schema-requires-
             reg-machine rather than silently no-opping"
     (let [ex (try
-               (machines/make-machine-handler
+               (rf.machines/make-machine-handler
                  {:initial :idle
                   :data    {:attempts 0 :token nil :error nil}
                   :schemas {:data AuthLoginData}
@@ -272,7 +272,7 @@
 (deftest bare-direct-path-without-data-schema-stays-legal
   (testing "a schema-LESS spec on the bare make-machine-handler path is
             unaffected — nothing inert to leak, so the guard does NOT fire"
-    (is (fn? (machines/make-machine-handler
+    (is (fn? (rf.machines/make-machine-handler
                {:initial :idle
                 :data    {:n 0}
                 :states  {:idle {}}}))
@@ -284,7 +284,7 @@
   (testing "supplying the framework-owned :rf/machine? / :rf/machine keys in
             opts is rejected — the home stamps them"
     (let [ex (try
-               (machines/reg-machine* :rf.machine-arity/reserved
+               (rf.machines/reg-machine* :rf.machine-arity/reserved
                  {:rf/machine? true}
                  {:initial :idle :states {:idle {}}})
                nil
@@ -302,7 +302,7 @@
   ;; reg-mutation metadata-slot map gate.
   (testing "a vector opts slot is rejected with the canonical error id"
     (let [ex (try
-               (machines/reg-machine* :rf.machine-arity/bad-vec
+               (rf.machines/reg-machine* :rf.machine-arity/bad-vec
                  []
                  {:initial :idle :states {:idle {}}})
                nil
@@ -314,7 +314,7 @@
           "the rejected non-map value rides the :value ex-data slot")))
   (testing "a string opts slot is rejected with the canonical error id"
     (let [ex (try
-               (machines/reg-machine* :rf.machine-arity/bad-str
+               (rf.machines/reg-machine* :rf.machine-arity/bad-str
                  "nope"
                  {:initial :idle :states {:idle {}}})
                nil
@@ -323,7 +323,7 @@
   (testing "the 3-arity with an explicit nil opts is the no-opts path (legal)"
     ;; nil normalises to {} — equivalent to the 2-arity, not a rejection.
     (is (= :rf.machine-arity/nil-opts
-           (machines/reg-machine* :rf.machine-arity/nil-opts
+           (rf.machines/reg-machine* :rf.machine-arity/nil-opts
              nil
              {:initial :idle :states {:idle {}}}))
         "an explicit nil opts is the no-opts path (normalised to {}), not rejected")))
@@ -331,12 +331,12 @@
 (deftest two-arity-reg-machine-still-works
   (testing "the existing 2-arity (reg-machine* id machine) is unchanged — it
             stamps the meta so the [:schemas :data] schema is LIVE"
-    (machines/reg-machine* :rf.machine-arity/plain
+    (rf.machines/reg-machine* :rf.machine-arity/plain
       {:initial :idle
        :data    {:attempts 0 :token nil :error nil}
        :schemas {:data AuthLoginData}
        :states  {:idle {}}})
-    (is (some? (machines/machine-meta :rf.machine-arity/plain))
+    (is (some? (rf.machines/machine-meta :rf.machine-arity/plain))
         "2-arity still stamps machine-meta")
-    (is (= AuthLoginData (get-in (machines/machine-meta :rf.machine-arity/plain) [:schemas :data]))
+    (is (= AuthLoginData (get-in (rf.machines/machine-meta :rf.machine-arity/plain) [:schemas :data]))
         "2-arity stamps the [:schemas :data] schema so it round-trips (validation is LIVE)")))

--- a/implementation/machines/test/re_frame/machine_schema_test.clj
+++ b/implementation/machines/test/re_frame/machine_schema_test.clj
@@ -33,27 +33,27 @@
   Tests use Malli schemas (the framework default validator)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as registrar]
+            [re-frame.machines :as rf.machines]
+            [re-frame.registrar :as rf.registrar]
             ;; The schemas artefact ships the registered-validator hot
             ;; path the `:where :machine-data` boundary routes through;
             ;; the `.malli` adapter ns publishes Malli's validate/explain
             ;; into the late-bind table.
-            [re-frame.machines.test-support :as mtest]
+            [re-frame.machines.test-support :as rf.machines.test-support]
             [re-frame.schemas]
             [re-frame.schemas.malli]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- collect-traces!
   "Run `f` while collecting every `:rf.error/schema-validation-failure`
   trace event. Returns the captured trace events as a vector. Routed through
-  the shared `mtest/with-trace-capture` — guaranteed unregister in a
+  the shared `rf.machines.test-support/with-trace-capture` — guaranteed unregister in a
   `finally`."
   [f]
-  (mtest/with-trace-capture traces
+  (rf.machines.test-support/with-trace-capture traces
     (f)
     (filterv #(= :rf.error/schema-validation-failure (:operation %))
              @traces)))
@@ -68,7 +68,7 @@
                       :schemas {:data DataSchema}
                       :states  {:idle {}}}]
       (rf/reg-machine :rf.machine-schema/accepted spec)
-      (let [meta (machines/machine-meta :rf.machine-schema/accepted)]
+      (let [meta (rf.machines/machine-meta :rf.machine-schema/accepted)]
         (is (some? meta) "machine-meta returns the registered spec")
         (is (= DataSchema (get-in meta [:schemas :data]))
             "the [:schemas :data] schema round-trips through machine-meta")))))
@@ -263,9 +263,9 @@
         ;; Atomic reject: a schema-rejected spawn registers NOTHING —
         ;; no event handler, no `(rf.machines/machines)` entry — the install gate
         ;; and registration are in lockstep.
-        (is (nil? (registrar/lookup :event :rf.machine-schema/spawned))
+        (is (nil? (rf.registrar/lookup :event :rf.machine-schema/spawned))
             "rejected spawn: NO event handler is registered (rf2-f3kp7)")
-        (is (not (contains? (set (machines/machines)) :rf.machine-schema/spawned))
+        (is (not (contains? (set (rf.machines/machines)) :rf.machine-schema/spawned))
             "rejected spawn: the actor does NOT appear in (rf.machines/machines) (rf2-f3kp7)")))))
 
 ;; ---- (5) no schema → no validation (control) ------------------------------

--- a/implementation/machines/test/re_frame/machine_schemas_grammar_test.clj
+++ b/implementation/machines/test/re_frame/machine_schemas_grammar_test.clj
@@ -23,12 +23,12 @@
       registers cleanly."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- registration-throws?
   "Register `machine` under `machine-id`; return the ExceptionInfo if it
@@ -49,7 +49,7 @@
                    :meta   [:map [:rf/snapshot-version :int]]}]
       (rf/reg-machine :rf.machine-schemas/full
         {:initial :idle :schemas schemas :states {:idle {}}})
-      (let [meta (machines/machine-meta :rf.machine-schemas/full)]
+      (let [meta (rf.machines/machine-meta :rf.machine-schemas/full)]
         (is (some? meta) "registration completed")
         (is (= schemas (:schemas meta))
             "the whole :schemas map round-trips through machine-meta")

--- a/implementation/machines/test/re_frame/machine_source_coord_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machine_source_coord_cljs_test.cljs
@@ -24,21 +24,21 @@
   (unlike on JVM where the standard LispReader only decorates list forms)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.machines.test-support :as mtest]))
+            [re-frame.machines :as rf.machines]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.machines.test-support :as rf.machines.test-support]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 (defn- element-coords [machine-id slot id]
-  (get-in (machines/machine-meta machine-id) [slot id :source-coords]))
+  (get-in (rf.machines/machine-meta machine-id) [slot id :source-coords]))
 
 ;; Read a co-located reference-site `:source-coords` off the MAP node
 ;; (state-node / transition map) at `spec-path` in the registered spec.
 (defn- node-coords [machine-id spec-path]
-  (get-in (machines/machine-meta machine-id) (conj (vec spec-path) :source-coords)))
+  (get-in (rf.machines/machine-meta machine-id) (conj (vec spec-path) :source-coords)))
 
 ;; ---- definition-site stamping --------------------------------------------
 
@@ -74,7 +74,7 @@
     (is (some? (node-coords :rf2-8bp3/refs [:states :idle :on :cancel]))
         "transition map for :cancel carries co-located :source-coords")
     ;; Inline-fn :action holds a fn VALUE, not a map — no coord on the slot.
-    (is (fn? (get-in (machines/machine-meta :rf2-8bp3/refs)
+    (is (fn? (get-in (rf.machines/machine-meta :rf2-8bp3/refs)
                      [:states :idle :on :cancel :action]))
         "inline-fn :action value round-trips at its slot")))
 
@@ -139,8 +139,8 @@
     (is (some? (node-coords :rf2-8bp3/ee [:states :a]))
         "state-node :a carries the coord standing in for its :entry / :exit")
     ;; The inline-fn :exit value round-trips; the keyword :entry too.
-    (is (fn? (get-in (machines/machine-meta :rf2-8bp3/ee) [:states :a :exit])))
-    (is (= :enter-a (get-in (machines/machine-meta :rf2-8bp3/ee) [:states :a :entry])))
+    (is (fn? (get-in (rf.machines/machine-meta :rf2-8bp3/ee) [:states :a :exit])))
+    (is (= :enter-a (get-in (rf.machines/machine-meta :rf2-8bp3/ee) [:states :a :entry])))
     ;; Definition coord co-located on the named action.
     (is (some? (element-coords :rf2-8bp3/ee :actions :enter-a)))))
 
@@ -165,7 +165,7 @@
 ;; Read the inline-fn `:source-code` string for an inline slot off the
 ;; enclosing `:states`-tree map node.
 (defn- inline-source [machine-id enclosing-path slot]
-  (get-in (machines/machine-meta machine-id)
+  (get-in (rf.machines/machine-meta machine-id)
           (conj (vec enclosing-path) :source-code slot)))
 
 (deftest reg-machine-stamps-inline-action-source-code-cljs
@@ -192,8 +192,8 @@
     ;; Inline transition :guard.
     (is (re-find #":ready\?"   (inline-source :rf2-se70xj/inline [:states :idle :on :submit] :guard)))
     ;; Slot values stay bare fns — not wrapped into a map.
-    (is (fn? (get-in (machines/machine-meta :rf2-se70xj/inline) [:states :idle :on :cancel :action])))
-    (is (fn? (get-in (machines/machine-meta :rf2-se70xj/inline) [:states :idle :entry])))))
+    (is (fn? (get-in (rf.machines/machine-meta :rf2-se70xj/inline) [:states :idle :on :cancel :action])))
+    (is (fn? (get-in (rf.machines/machine-meta :rf2-se70xj/inline) [:states :idle :entry])))))
 
 (deftest reg-machine-stamps-inline-always-single-map-source-code-cljs
   (testing "an inline `:always` `:action` written as a SINGLE MAP (not a
@@ -222,9 +222,9 @@
           "single-map :always :guard carries :source-code at [:states :a :always]")
       (is (re-find #":pending\?" guard-src)))
     ;; The slot values stay bare fns (the runtime resolves them via fn?).
-    (is (fn? (get-in (machines/machine-meta :rf2-k7yqod/always-single-map)
+    (is (fn? (get-in (rf.machines/machine-meta :rf2-k7yqod/always-single-map)
                      [:states :a :always :action])))
-    (is (fn? (get-in (machines/machine-meta :rf2-k7yqod/always-single-map)
+    (is (fn? (get-in (rf.machines/machine-meta :rf2-k7yqod/always-single-map)
                      [:states :a :always :guard])))
     ;; The single-map form does NOT mistakenly key under an index 0.
     (is (nil? (inline-source :rf2-k7yqod/always-single-map [:states :a :always 0] :action))
@@ -270,7 +270,7 @@
         :done {}}})
     (is (nil? (inline-source :rf2-se70xj/kw [:states :idle :on :submit] :action)))
     (is (nil? (inline-source :rf2-se70xj/kw [:states :idle :on :submit] :guard)))
-    (is (string? (get-in (machines/machine-meta :rf2-se70xj/kw) [:actions :do :source-code])))))
+    (is (string? (get-in (rf.machines/machine-meta :rf2-se70xj/kw) [:actions :do :source-code])))))
 
 ;; ---- >8 stampable nodes: transient promotion must not drop stamps --------
 
@@ -315,7 +315,7 @@
     (let [spec {:initial :a :states {:a {}}}]
       (rf/reg-machine :rf2-8bp3/programmatic spec))
     (is (= {:initial :a :states {:a {}}}
-           (machines/machine-meta :rf2-8bp3/programmatic))
+           (rf.machines/machine-meta :rf2-8bp3/programmatic))
         "registered spec round-trips with no co-located source")))
 
 ;; ---- reg-machine* plain-fn surface ---------------------------------------
@@ -323,10 +323,10 @@
 (deftest reg-machine*-plain-fn-surface-cljs
   (testing "reg-machine* registers without macro walking — equivalent to
   the legacy reg-machine defn"
-    (machines/reg-machine* :rf2-8bp3/plain
+    (rf.machines/reg-machine* :rf2-8bp3/plain
                      {:initial :a :states {:a {}}})
-    (is (some? (some #{:rf2-8bp3/plain} (machines/machines)))
+    (is (some? (some #{:rf2-8bp3/plain} (rf.machines/machines)))
         "(rf.machines/machines) lists the plain-fn registered machine")
     (is (= {:initial :a :states {:a {}}}
-           (machines/machine-meta :rf2-8bp3/plain))
+           (rf.machines/machine-meta :rf2-8bp3/plain))
         "spec round-trips verbatim")))

--- a/implementation/machines/test/re_frame/machine_source_coord_test.clj
+++ b/implementation/machines/test/re_frame/machine_source_coord_test.clj
@@ -36,23 +36,23 @@
   exercises the full co-located state-node / transition-map surface."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; Helper: read a co-located element entry's source-coords off a
 ;; registered machine. `slot` is :guards / :actions / :on-spawn-actions.
 (defn- element-coords [machine-id slot id]
-  (get-in (machines/machine-meta machine-id) [slot id :source-coords]))
+  (get-in (rf.machines/machine-meta machine-id) [slot id :source-coords]))
 
 ;; Helper: read a co-located reference-site `:source-coords` off the MAP
 ;; node (state-node / transition map) at `spec-path` inside the registered
 ;; spec's `:states` tree.
 (defn- node-coords [machine-id spec-path]
-  (get-in (machines/machine-meta machine-id) (conj (vec spec-path) :source-coords)))
+  (get-in (rf.machines/machine-meta machine-id) (conj (vec spec-path) :source-coords)))
 
 ;; ---- top-level call-site coords (smoke; covered also in core/source-coords-test) ----
 
@@ -79,7 +79,7 @@
        :guards  {:always-true (fn [_] true)
                  :n-positive? (fn [{data :data}] (pos? (or (:n data) 0)))}
        :states  {:idle {}}})
-    (let [m (machines/machine-meta :rf2-8bp3/guard-defs)]
+    (let [m (rf.machines/machine-meta :rf2-8bp3/guard-defs)]
       (is (some? (get-in m [:guards :always-true :fn]))
           "the :always-true guard entry carries its :fn")
       (is (some? (element-coords :rf2-8bp3/guard-defs :guards :always-true))
@@ -135,7 +135,7 @@
 ;; enclosing `:states`-tree map node. `enclosing-path` is the spec-path to the
 ;; enclosing state-node / transition map; `slot` is :entry/:exit/:guard/:action.
 (defn- inline-source [machine-id enclosing-path slot]
-  (get-in (machines/machine-meta machine-id)
+  (get-in (rf.machines/machine-meta machine-id)
           (conj (vec enclosing-path) :source-code slot)))
 
 (deftest reg-machine-stamps-inline-transition-action-source-code
@@ -150,7 +150,7 @@
                     :cancel {:target :idle :action (fn [_] {:data {:cancelled? true}})}}}
         :done {}}})
     ;; The named guard's :source-code (the parity baseline — already worked).
-    (is (string? (get-in (machines/machine-meta :rf2-se70xj/inline-action)
+    (is (string? (get-in (rf.machines/machine-meta :rf2-se70xj/inline-action)
                          [:guards :ok? :source-code]))
         "named guard carries :source-code (parity baseline)")
     ;; The inline transition :action carries :source-code on the
@@ -164,7 +164,7 @@
           "the captured :source-code is the action body, not the enclosing map"))
     ;; The inline-fn slot value itself stays a BARE fn (the runtime engine
     ;; resolves it via fn? and stamps it as the trace :action-id) — NOT wrapped.
-    (is (fn? (get-in (machines/machine-meta :rf2-se70xj/inline-action)
+    (is (fn? (get-in (rf.machines/machine-meta :rf2-se70xj/inline-action)
                      [:states :idle :on :cancel :action]))
         "inline :action slot value stays a bare fn (not wrapped into a map)")))
 
@@ -185,8 +185,8 @@
       (is (string? exit-src) "inline :exit carries :source-code")
       (is (re-find #":exited\?" exit-src)))
     ;; Slot values stay bare fns.
-    (is (fn? (get-in (machines/machine-meta :rf2-se70xj/inline-ee) [:states :a :entry])))
-    (is (fn? (get-in (machines/machine-meta :rf2-se70xj/inline-ee) [:states :a :exit])))))
+    (is (fn? (get-in (rf.machines/machine-meta :rf2-se70xj/inline-ee) [:states :a :entry])))
+    (is (fn? (get-in (rf.machines/machine-meta :rf2-se70xj/inline-ee) [:states :a :exit])))))
 
 (deftest reg-machine-stamps-inline-guard-source-code
   (testing "an inline transition `:guard` fn carries its `:source-code` on the
@@ -227,9 +227,9 @@
       (is (string? guard-src) "single-map :always :guard carries :source-code")
       (is (re-find #":pending\?" guard-src)))
     ;; The inline-fn slot values stay BARE fns (the runtime resolves via fn?).
-    (is (fn? (get-in (machines/machine-meta :rf2-k7yqod/always-single)
+    (is (fn? (get-in (rf.machines/machine-meta :rf2-k7yqod/always-single)
                      [:states :a :always :action])))
-    (is (fn? (get-in (machines/machine-meta :rf2-k7yqod/always-single)
+    (is (fn? (get-in (rf.machines/machine-meta :rf2-k7yqod/always-single)
                      [:states :a :always :guard])))
     ;; The single-map form does NOT mistakenly key at index 0.
     (is (nil? (inline-source :rf2-k7yqod/always-single [:states :a :always 0] :action))
@@ -276,8 +276,8 @@
     (is (nil? (inline-source :rf2-se70xj/kw-refs [:states :idle :on :submit] :action)))
     (is (nil? (inline-source :rf2-se70xj/kw-refs [:states :idle :on :submit] :guard)))
     ;; The named entries DO carry their own :source-code (the existing path).
-    (is (string? (get-in (machines/machine-meta :rf2-se70xj/kw-refs) [:actions :do :source-code])))
-    (is (string? (get-in (machines/machine-meta :rf2-se70xj/kw-refs) [:guards :ok? :source-code])))))
+    (is (string? (get-in (rf.machines/machine-meta :rf2-se70xj/kw-refs) [:actions :do :source-code])))
+    (is (string? (get-in (rf.machines/machine-meta :rf2-se70xj/kw-refs) [:guards :ok? :source-code])))))
 
 ;; ---- reference-site stamping inside the :states tree ----------------------
 
@@ -320,7 +320,7 @@
                           :guard (fn [_] true)
                           :action (fn [_] {})}}}
         :done {}}})
-    (let [m (machines/machine-meta :rf2-8bp3/inline-refs)]
+    (let [m (rf.machines/machine-meta :rf2-8bp3/inline-refs)]
       ;; No coord co-located on map nodes (JVM map literals carry no meta).
       (is (nil? (node-coords :rf2-8bp3/inline-refs [:states :idle])))
       (is (nil? (node-coords :rf2-8bp3/inline-refs [:states :idle :on :submit])))
@@ -414,7 +414,7 @@
                 {:inner   {:entry (fn [_] {})
                            :on    {:go {:target :sibling}}}
                  :sibling {}}}}})
-    (let [m (machines/machine-meta :rf2-8bp3/hier)]
+    (let [m (rf.machines/machine-meta :rf2-8bp3/hier)]
       ;; No coord on JVM (map literals carry no reader meta); structure intact.
       (is (nil? (node-coords :rf2-8bp3/hier [:states :outer :states :inner])))
       (is (fn? (get-in m [:states :outer :states :inner :entry]))
@@ -433,7 +433,7 @@
       (rf/reg-machine :rf2-8bp3/programmatic my-spec))
     ;; The spec itself round-trips; no co-located entries / state-coords.
     (is (= {:initial :a :states {:a {}}}
-           (machines/machine-meta :rf2-8bp3/programmatic))
+           (rf.machines/machine-meta :rf2-8bp3/programmatic))
         "round-tripped spec carries no co-located source / state-coords")
     ;; Top-level handler-meta still carries the macro's call-site coords.
     (let [meta (rf/handler-meta :event :rf2-8bp3/programmatic)]
@@ -446,13 +446,13 @@
   (testing "reg-machine* (the plain-fn surface) registers a machine without
   any macro walking — equivalent to the legacy reg-machine defn. Used by
   code-gen pipelines that already carry a stamped spec."
-    (machines/reg-machine* :rf2-8bp3/plain
+    (rf.machines/reg-machine* :rf2-8bp3/plain
                      {:initial :a :states {:a {}}})
     (is (= :rf2-8bp3/plain
-           (some #{:rf2-8bp3/plain} (machines/machines)))
+           (some #{:rf2-8bp3/plain} (rf.machines/machines)))
         "plain-fn registration shows up in (rf.machines/machines) like macro registrations")
     (is (= {:initial :a :states {:a {}}}
-           (machines/machine-meta :rf2-8bp3/plain))
+           (rf.machines/machine-meta :rf2-8bp3/plain))
         "spec round-trips verbatim")))
 
 ;; ---- defmachine: value-registered per-element source capture --
@@ -495,7 +495,7 @@
   handler-metas are nil — the rf2-gwj8l bug shape (the foil for defmachine
   below)"
     (rf/reg-machine :rf2-gwj8l/plain-door plain-door-machine)
-    (let [meta (machines/machine-meta :rf2-gwj8l/plain-door)]
+    (let [meta (rf.machines/machine-meta :rf2-gwj8l/plain-door)]
       ;; Bare-fn entries — no co-located source-coords / source-code.
       (is (fn? (get-in meta [:guards :may-close?]))
           "plain (def) machine carries bare fns, not co-located entry maps")
@@ -514,7 +514,7 @@
   coords — exactly what the Epoch machine-cascade reads (cascade-row-coord /
   cascade-row-source-form). rf2-gwj8l + rf2-npvsx."
     (rf/reg-machine :rf2-gwj8l/value-door value-door-machine)
-    (let [meta (machines/machine-meta :rf2-gwj8l/value-door)]
+    (let [meta (rf.machines/machine-meta :rf2-gwj8l/value-door)]
       ;; Co-located entries carry :fn + :source-coords + :source-code.
       (is (fn? (get-in meta [:guards :may-close? :fn]))
           "value-registered defmachine entry carries its :fn")

--- a/implementation/machines/test/re_frame/machine_source_unstamped_warning_test.clj
+++ b/implementation/machines/test/re_frame/machine_source_unstamped_warning_test.clj
@@ -24,21 +24,21 @@
   reader."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.machines :as machines]
-            [re-frame.machines.lifecycle-fx.registration :as registration]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.interop :as rf.interop]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.lifecycle-fx.registration :as rf.machines.lifecycle-fx.registration]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (def ^:private WARN :rf.warning/machine-source-unstamped)
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter})
-  mtest/trace-capture-fixture
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter})
+  rf.machines.test-support/trace-capture-fixture
   ;; Start each case from a clean once-per-id slate.
-  (fn [t] (registration/clear-source-unstamped-warned!) (t)))
+  (fn [t] (rf.machines.lifecycle-fx.registration/clear-source-unstamped-warned!) (t)))
 
-(defn- warns [] (mtest/events-of WARN))
+(defn- warns [] (rf.machines.test-support/events-of WARN))
 
 ;; A plain `(def …)` value — the SOURCE-BLIND foil. The macro sees only the
 ;; `blind-spec` symbol at the reg-machine call site, so nothing is stamped.
@@ -121,15 +121,15 @@
             source-blind and warns — the check keys on the OBSERVABLE property,
             not the registration surface. The message tells a runtime-built
             author they may ignore it"
-    (machines/reg-machine* :src-warn/plain blind-spec)
+    (rf.machines/reg-machine* :src-warn/plain blind-spec)
     (is (= 1 (count (warns)))
         "a runtime-built spec is source-blind — the advisory fires")))
 
 ;; ---- production DCE gate ---------------------------------------------------
 
 (deftest noop-in-production
-  (testing "under interop/debug-enabled? false (the production gate) the
+  (testing "under rf.interop/debug-enabled? false (the production gate) the
             advisory is not emitted — the consult + emit branch DCEs"
-    (with-redefs [interop/debug-enabled? false]
+    (with-redefs [rf.interop/debug-enabled? false]
       (rf/reg-machine :src-warn/prod blind-spec))
     (is (empty? (warns)) "no advisory in production")))

--- a/implementation/machines/test/re_frame/machine_spawn_trace_egress_test.clj
+++ b/implementation/machines/test/re_frame/machine_spawn_trace_egress_test.clj
@@ -33,7 +33,7 @@
   summarized to the `:rf/redacted` sentinel before it crosses the bus /
   epoch-capture / AI-MCP egress boundary."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.classification :as classification]))
+            [re-frame.classification :as rf.classification]))
 
 ;; ---- shared helpers -------------------------------------------------------
 
@@ -71,7 +71,7 @@
                             :invoke-id  invoke-id
                             :start      [:begin {:token "secret-start-jwt"
                                                  :password "hunter2"}]}}
-          out  (classification/project-trace-event ev)
+          out  (rf.classification/project-trace-event ev)
           tags (:tags out)]
       ;; structural slots survive — consumers locate the spawn
       (is (= :rf.spawn-egress/worker#1 (:spawned-id tags)))
@@ -98,7 +98,7 @@
                 :tags      {:machine-id parent-id
                             :frame      :rf/default
                             :event      (spawn-error-event err)}}
-          out  (classification/project-trace-event ev)
+          out  (rf.classification/project-trace-event ev)
           tags (:tags out)
           proj-event (:event tags)]
       (is (= :rf.machine.spawn/error (first proj-event))
@@ -120,7 +120,7 @@
                             :event    (spawn-error-event err)
                             :before   {:state :working :data {}}
                             :after    {:state :failed  :data {}}}}
-          out  (classification/project-trace-event ev)
+          out  (rf.classification/project-trace-event ev)
           proj-event (get-in out [:tags :event])]
       (is (= :rf.machine.spawn/error (first proj-event)))
       (is (= invoke-id (second proj-event)))
@@ -140,7 +140,7 @@
                             :outcome  :pass
                             :input    {:data  {}
                                        :event (spawn-error-event err)}}}
-          out  (classification/project-trace-event ev)
+          out  (rf.classification/project-trace-event ev)
           proj-event (get-in out [:tags :input :event])]
       (is (= :rf.machine.spawn/error (first proj-event)))
       (is (= invoke-id (second proj-event)))
@@ -161,7 +161,7 @@
                             :outcome   :ok
                             :input     {:data  {}
                                         :event (spawn-error-event err)}}}
-          out  (classification/project-trace-event ev)
+          out  (rf.classification/project-trace-event ev)
           proj-event (get-in out [:tags :input :event])]
       (is (= :rf.machine.spawn/error (first proj-event)))
       (is (not (.contains (pr-str out) "4111-1111-1111-1111")))
@@ -179,7 +179,7 @@
                             :frame      :rf/default
                             ;; a plain app event with a plain payload
                             :event      [:user/login {:user "alice"}]}}
-          out  (classification/project-trace-event ev)
+          out  (rf.classification/project-trace-event ev)
           proj-event (get-in out [:tags :event])]
       (is (= [:user/login {:user "alice"}] proj-event)
           "a non-spawn-error machine event vector is not summarized"))))

--- a/implementation/machines/test/re_frame/machine_spawn_unregistered_type_test.clj
+++ b/implementation/machines/test/re_frame/machine_spawn_unregistered_type_test.clj
@@ -43,27 +43,27 @@
       unregistered-type case)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.late-bind :as rf.late-bind]
             ;; Loading the machines facade registers its late-bind hooks +
             ;; the `:rf.machine/spawn` / `:rf.machine/destroy` reserved fxs
             ;; (so `rf/reg-machine` is available when this ns runs alone).
             [re-frame.machines]
-            [re-frame.machines.spawn-order :as spawn-order]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.spawn-order :as rf.machines.spawn-order]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 ;; Fresh registrar + plain-atom adapter per test; the always-on
 ;; error-listener registry (a `defonce` atom) cleared so a listener from
 ;; one test cannot leak into the next (mirrors
 ;; write_after_destroy_always_on_cljs_test).
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn (fn [] (error-emit/clear-error-listeners!))})
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
+     :init-fn (fn [] (rf.error-emit/clear-error-listeners!))})
+  rf.machines.test-support/trace-capture-fixture)
 
-(def ^:private frame-db mtest/runtime-db)
+(def ^:private frame-db rf.machines.test-support/runtime-db)
 
 (defn- with-error-records
   "Run `thunk` while a corpus-wide always-on error listener records every
@@ -109,16 +109,16 @@
         (is (nil? (get-in db [:rf.runtime/machines :system-ids :ghost-actor]))
             "no :system-id binding for the rejected spawn")
         ;; No spawn-order entry for the rejected actor.
-        (is (not (some #{:ghost/worker#1} (spawn-order/frame-order :rf/default)))
+        (is (not (some #{:ghost/worker#1} (rf.machines.spawn-order/frame-order :rf/default)))
             "no spawn-order entry recorded for the rejected actor")
         ;; The parent itself transitioned to :working (the parent macrostep
         ;; is independent — only the child spawn is rejected).
-        (is (= :working (mtest/machine-state :sup/ghost))
+        (is (= :working (rf.machines.test-support/machine-state :sup/ghost))
             "the parent still transitions; only the unregistered child is rejected"))
       ;; No fx-substrate spawn trace fired for the rejected actor.
-      (is (empty? (mtest/events-of :rf.machine.spawn/spawned))
+      (is (empty? (rf.machines.test-support/events-of :rf.machine.spawn/spawned))
           "NO :rf.machine.spawn/spawned trace for the rejected spawn")
-      (is (empty? (mtest/events-of :rf.machine.lifecycle/spawned))
+      (is (empty? (rf.machines.test-support/events-of :rf.machine.lifecycle/spawned))
           "NO :rf.machine.lifecycle/spawned (registrar-substrate) trace either"))))
 
 ;; ===========================================================================
@@ -178,7 +178,7 @@
                        (vals r)))
             "no record value contains the secret :start / :data payload")
         ;; The dev trace likewise carries no spawn args / secret.
-        (let [trace-ev (first (mtest/events-of :rf.error/machine-spawn-unregistered-type))]
+        (let [trace-ev (first (rf.machines.test-support/events-of :rf.error/machine-spawn-unregistered-type))]
           (is (some? trace-ev) "(precondition) the dev trace fired")
           (is (nil? (get-in trace-ev [:tags :args]))
               "dev trace carries no :args slot")
@@ -239,12 +239,12 @@
         ;; orphan actor installed (rf2-qb1j5z).
         (is (nil? (get-in (frame-db) [:rf.runtime/machines :snapshots :gc/ok#1]))
             "the registered sibling was suppressed — no orphan snapshot")
-        (is (not (some #{:gc/ok#1} (spawn-order/frame-order :rf/default)))
+        (is (not (some #{:gc/ok#1} (rf.machines.spawn-order/frame-order :rf/default)))
             "the registered sibling was suppressed — nothing recorded in spawn-order")
         ;; The parent is still in :forking — it did NOT advance to :ready
         ;; (the join never resolves) but it also did NOT hang the dispatch
         ;; (dispatch-sync returned).
-        (is (= :forking (mtest/machine-state :sup/join))
+        (is (= :forking (rf.machines.test-support/machine-state :sup/join))
             "parent stays in :forking — no deadlock, just a refused join")))))
 
 ;; ---------------------------------------------------------------------------
@@ -256,7 +256,7 @@
   fanned (the always-on axis is captured separately by `with-error-records`)."
   []
   (mapv #(get-in % [:tags :machine-id])
-        (mtest/events-of :rf.error/machine-spawn-unregistered-type)))
+        (rf.machines.test-support/events-of :rf.error/machine-spawn-unregistered-type)))
 
 (defn- spawn-all-parent
   "A `:spawn-all :all` parent over `children`, for cardinality fixtures."
@@ -301,9 +301,9 @@
         ;; The registered sibling was suppressed, not merely un-rejected.
         (is (nil? (get-in (frame-db) [:rf.runtime/machines :snapshots :card/ok#1]))
             "the registered sibling installs no snapshot under the rejected invoke")
-        (is (not (some #{:card/ok#1} (spawn-order/frame-order :rf/default)))
+        (is (not (some #{:card/ok#1} (rf.machines.spawn-order/frame-order :rf/default)))
             "the registered sibling records no spawn-order entry")
-        (is (empty? (mtest/events-of :rf.machine.spawn/spawned))
+        (is (empty? (rf.machines.test-support/events-of :rf.machine.spawn/spawned))
             "no :rf.machine.spawn/spawned trace for ANY child of a rejected invoke")))))
 
 (deftest spawn-all-reject-cardinality-is-order-invariant
@@ -347,7 +347,7 @@
       ;; Leave :forking — `destroy-spawn-all-children!` finds nothing to tear
       ;; down and clears the slot.
       (rf/dispatch-sync [:sup/card3 [:back]])
-      (is (= :idle (mtest/machine-state :sup/card3))
+      (is (= :idle (rf.machines.test-support/machine-state :sup/card3))
           "(precondition) the parent left the :spawn-all state")
       (is (nil? (get-in (frame-db) [:rf.runtime/machines :spawned :sup/card3 [:forking]]))
           "parent exit CLEARS the reject sentinel")
@@ -386,7 +386,7 @@
       ;; the interceptor sees the childless sentinel, treats it as no live
       ;; child-bearing join, and it is a documented no-op — it does NOT throw and does NOT hang.
       (rf/dispatch-sync [:sup/join2 [:gc/done :ok]])
-      (is (= :forking (mtest/machine-state :sup/join2))
+      (is (= :forking (rf.machines.test-support/machine-state :sup/join2))
           "a child-done against a childless reject sentinel (no live join) is a no-op — never resolves, never hangs"))))
 
 ;; ===========================================================================
@@ -444,5 +444,5 @@
             reject reaches the listener via the
             :error-emit/dispatch-error-record late-bind hook — published at
             error-emit ns-load, so the lookup never misses in production"
-    (is (some? (late-bind/get-fn :error-emit/dispatch-error-record))
+    (is (some? (rf.late-bind/get-fn :error-emit/dispatch-error-record))
         "the non-event union-record hook is registered at error-emit ns-load")))

--- a/implementation/machines/test/re_frame/machine_timer_incarnation_fence_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_timer_incarnation_fence_cljs_test.cljc
@@ -37,22 +37,22 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.machines :as machines]
-            [re-frame.machines.paths :as paths]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.machines.timer :as timer]
-            [re-frame.subs :as subs]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.machines.timer :as rf.machines.timer]
+            [re-frame.subs :as rf.subs]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 ;; Touch the artefact so the machines registration hooks (incl. the
 ;; `:machines/on-frame-destroyed!` timer cleanup) are wired even in isolation.
-(def ^:private _artefact machines/machine-transition)
+(def ^:private _artefact rf.machines/machine-transition)
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- fresh-handle
   "A process-unique opaque host handle, distinguishable by `identical?`."
@@ -79,9 +79,9 @@
 (defn- k-for [delay] {:parent parent-id :spawn [] :delay delay})
 
 (defn- install-entry! [frame-id k entry]
-  (swap! timer/after-timers assoc-in [frame-id k] entry))
+  (swap! rf.machines.timer/after-timers assoc-in [frame-id k] entry))
 
-(defn- inner [frame-id] (get @timer/after-timers frame-id {}))
+(defn- inner [frame-id] (get @rf.machines.timer/after-timers frame-id {}))
 
 ;; ===========================================================================
 ;; TEST 1 — CAPTURE→READ: the batch cancels by the SNAPSHOTTED attempt token, so
@@ -104,7 +104,7 @@
         fired?    (atom false)]
     (install-entry! frame-id k1 (literal-entry ::a1-token hA1))
     (install-entry! frame-id k2 (literal-entry ::a2-token hA2))
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       ::cr
       (fn [ev]
         (when (and (= :rf.machine.timer/cancelled (:operation ev))
@@ -115,14 +115,14 @@
           ;; snapshot and k2's claim.
           (install-entry! frame-id k2 b-entry))))
     (try
-      (with-redefs [interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)]
-        (timer/after-cancel-fx {:frame frame-id}
+      (with-redefs [rf.interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)]
+        (rf.machines.timer/after-cancel-fx {:frame frame-id}
                                {:rf/parent-id parent-id :rf/invoke-id []}))
-      (finally (trace-tooling/unregister-listener! ::cr)))
+      (finally (rf.trace.tooling/unregister-listener! ::cr)))
     (is (true? @fired?) "the first cancellation's trace listener ran (seam exercised)")
-    (is (= b-entry (get-in @timer/after-timers [frame-id k2]))
+    (is (= b-entry (get-in @rf.machines.timer/after-timers [frame-id k2]))
         "successor B at k2 SURVIVES — the batch claimed only its snapshotted a2-token, never B's fresh token")
-    (is (identical? hB2 (:handle (get-in @timer/after-timers [frame-id k2])))
+    (is (identical? hB2 (:handle (get-in @rf.machines.timer/after-timers [frame-id k2])))
         "B's host handle at k2 is intact")
     (is (not (some #(identical? hB2 %) @cancelled))
         "B's handle was NOT cancelled by the A-scoped batch")
@@ -138,7 +138,7 @@
 (deftest two-key-batch-destroy-during-cancel-spares-successor
   (rf/make-frame {:id :rf2-ijlhj/tk-frame})
   (let [frame-id  :rf2-ijlhj/tk-frame
-        token-a   (frame/frame-incarnation-token frame-id)
+        token-a   (rf.frame/frame-incarnation-token frame-id)
         k1        (k-for 1000)
         k2        (k-for 2000)
         hA1       (fresh-handle)
@@ -151,7 +151,7 @@
         b-token   (atom nil)]
     (install-entry! frame-id k1 (literal-entry ::a1-token hA1))
     (install-entry! frame-id k2 (literal-entry ::a2-token hA2))
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       ::tk
       (fn [ev]
         (when (= :rf.machine.timer/cancelled (:operation ev))
@@ -159,19 +159,19 @@
           (when (compare-and-set! fired? false true)
             ;; Destroy A (its on-frame-destroyed hook releases A's remaining k2),
             ;; then publish same-id B and re-arm B/k2 on this trace's own stack.
-            (frame/destroy-frame! frame-id)
+            (rf.frame/destroy-frame! frame-id)
             (rf/make-frame {:id frame-id})
-            (reset! b-token (frame/frame-incarnation-token frame-id))
+            (reset! b-token (rf.frame/frame-incarnation-token frame-id))
             (install-entry! frame-id k2 b-entry)))))
     (try
-      (with-redefs [interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)]
-        (timer/after-cancel-fx {:frame frame-id}
+      (with-redefs [rf.interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)]
+        (rf.machines.timer/after-cancel-fx {:frame frame-id}
                                {:rf/parent-id parent-id :rf/invoke-id []}))
-      (finally (trace-tooling/unregister-listener! ::tk)))
+      (finally (rf.trace.tooling/unregister-listener! ::tk)))
     (is (true? @fired?) "a cancellation fired and destroyed A / published B (seam exercised)")
     (is (some? @b-token) "same-id successor B is live after the swap")
     (is (not (identical? token-a @b-token)) "B is a DISTINCT incarnation from A")
-    (is (= b-entry (get-in @timer/after-timers [frame-id k2]))
+    (is (= b-entry (get-in @rf.machines.timer/after-timers [frame-id k2]))
         "B's re-armed k2 SURVIVES — the A-bound batch short-circuited and never reached it")
     (is (not (some #(identical? hB2 %) @cancelled))
         "B's host handle was NOT cancelled by A's batch")
@@ -207,7 +207,7 @@
         reasons    (atom [])
         unsub      (atom 0)
         fired?     (atom false)]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       ::res
       (fn [ev]
         (when (= :rf.machine.timer/cancelled (:operation ev))
@@ -217,33 +217,33 @@
             ;; destroy A, publish same-id B, re-arm B/k, and seed B's snapshot so
             ;; the (unfenced) reschedule's `still-here?` would be TRUE — the
             ;; mutation tooth that supersedes B if the fence is absent.
-            (frame/destroy-frame! frame-id)
+            (rf.frame/destroy-frame! frame-id)
             (rf/make-frame {:id frame-id})
-            (frame/swap-runtime-db!
+            (rf.frame/swap-runtime-db!
               frame-id
-              (fn [rt] (assoc-in rt (paths/snapshot-path parent-id)
+              (fn [rt] (assoc-in rt (rf.machines.paths/snapshot-path parent-id)
                                  {:state :waiting :data {}})))
             (install-entry! frame-id k b-entry)))))
     (try
-      (with-redefs [subs/subscribe   (fn ([_] reaction) ([_ _] reaction))
-                    subs/unsubscribe (fn ([_] (swap! unsub inc) nil)
+      (with-redefs [rf.subs/subscribe   (fn ([_] reaction) ([_ _] reaction))
+                    rf.subs/unsubscribe (fn ([_] (swap! unsub inc) nil)
                                        ([_ _] (swap! unsub inc) nil))
-                    interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)
-                    interop/schedule-after!   (fn [_thunk _ms] (fresh-handle))]
+                    rf.interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)
+                    rf.interop/schedule-after!   (fn [_thunk _ms] (fresh-handle))]
         ;; Arm a real sub-vec `:after` timer — installs A's entry + attaches the
         ;; `on-sub-changed!` watcher to `reaction`.
-        (timer/after-schedule-fx
+        (rf.machines.timer/after-schedule-fx
           {:frame frame-id}
           {:rf/parent-id parent-id :rf/invoke-id [] :state :waiting
            :delay-key delay-key :epoch 0 :server? false})
         (is (= 1 (count (inner frame-id))) "precondition: A's sub-vec timer is armed")
         ;; A sub-value change fires on-sub-changed! via the real add-watch.
         (reset! reaction 6000))
-      (finally (trace-tooling/unregister-listener! ::res)))
+      (finally (rf.trace.tooling/unregister-listener! ::res)))
     (is (true? @fired?) "the :on-resolution cancel fired and swapped A→B (seam exercised)")
-    (is (= b-entry (get-in @timer/after-timers [frame-id k]))
+    (is (= b-entry (get-in @rf.machines.timer/after-timers [frame-id k]))
         "B's re-armed entry SURVIVES — no A-derived reschedule / supersede touched it")
-    (is (identical? hB (:handle (get-in @timer/after-timers [frame-id k])))
+    (is (identical? hB (:handle (get-in @rf.machines.timer/after-timers [frame-id k])))
         "B's host handle is intact (not cancelled by a supersede)")
     (is (not (some #(identical? hB %) @cancelled))
         "B's handle was NOT cancelled — the reschedule continuation was fenced off")
@@ -268,15 +268,15 @@
         reasons   (atom [])]
     (install-entry! frame-id k1 (literal-entry ::a1-token hA1))
     (install-entry! frame-id k2 (literal-entry ::a2-token hA2))
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       ::live
       (fn [ev] (when (= :rf.machine.timer/cancelled (:operation ev))
                  (swap! reasons conj (:reason (:tags ev))))))
     (try
-      (with-redefs [interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)]
-        (timer/after-cancel-fx {:frame frame-id}
+      (with-redefs [rf.interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)]
+        (rf.machines.timer/after-cancel-fx {:frame frame-id}
                                {:rf/parent-id parent-id :rf/invoke-id []}))
-      (finally (trace-tooling/unregister-listener! ::live)))
+      (finally (rf.trace.tooling/unregister-listener! ::live)))
     (is (empty? (inner frame-id))
         "both entries cancelled + cleared for the live owner (no fence wrongly skipped)")
     (is (some #(identical? hA1 %) @cancelled) "k1 handle cancelled")

--- a/implementation/machines/test/re_frame/machine_trace_frame_tag_sweep_test.clj
+++ b/implementation/machines/test/re_frame/machine_trace_frame_tag_sweep_test.clj
@@ -29,20 +29,20 @@
   before the upstack epoch / Xray gates notice the absent trace events."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 
 (defn- record-traces!
   "Register a trace listener for the duration of `body-fn`, returning
   the captured trace vec. Routed through the shared
-  `mtest/with-trace-capture` — guaranteed unregister in a `finally`."
+  `rf.machines.test-support/with-trace-capture` — guaranteed unregister in a `finally`."
   [body-fn]
-  (mtest/with-trace-capture seen
+  (rf.machines.test-support/with-trace-capture seen
     (body-fn)
     @seen))
 

--- a/implementation/machines/test/re_frame/machine_trace_payload_shapes_test.clj
+++ b/implementation/machines/test/re_frame/machine_trace_payload_shapes_test.clj
@@ -19,21 +19,21 @@
        :on-supersede / :on-frame-destroy`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
+            [re-frame.frame :as rf.frame]
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 
-;; Routed through the shared `mtest/with-trace-capture`
+;; Routed through the shared `rf.machines.test-support/with-trace-capture`
 ;; — guaranteed unregister in a `finally`.
 (defn- record-traces!
   [body-fn]
-  (mtest/with-trace-capture seen
+  (rf.machines.test-support/with-trace-capture seen
     (body-fn)
     @seen))
 
@@ -188,7 +188,7 @@
           "the guard throw surfaces a :rf.error/machine-action-exception
            (the machine-scoped throw category — same surface as an action throw)")
       ;; Atomic rollback: no transition fired, the snapshot stays at :idle.
-      (let [db   (frame/frame-runtime-db-value :rf/default)
+      (let [db   (rf.frame/frame-runtime-db-value :rf/default)
             snap (get-in db [:rf.runtime/machines :snapshots :rf2-82a0u/guard-throws])]
         (is (= :idle (:state snap))
             "macrostep aborted atomically — neither :A nor :B was entered")))))
@@ -213,7 +213,7 @@
     ;; The throwing-guard candidate aborts the macrostep — the engine does
     ;; NOT walk past it to the unguarded fallback. Atomic rollback: the
     ;; snapshot stays at :idle and :bump never ran.
-    (let [db   (frame/frame-runtime-db-value :rf/default)
+    (let [db   (rf.frame/frame-runtime-db-value :rf/default)
           snap (get-in db [:rf.runtime/machines :snapshots :rf2-82a0u/threw-fall])]
       (is (= :idle (:state snap))
           "the guard throw aborted the macrostep — the fallback candidate

--- a/implementation/machines/test/re_frame/machine_transition_purity_test.clj
+++ b/implementation/machines/test/re_frame/machine_transition_purity_test.clj
@@ -10,7 +10,7 @@
   \"Pure\" is scoped to the REDUCTION: the Result depends only on the
   arguments, with no module-level mutable state and no `app-db` read. It
   is NOT a claim that the engine emits zero observability — the reducer
-  emits `trace/emit!` diagnostic events on the process-wide Spec 009
+  emits `rf.trace/emit!` diagnostic events on the process-wide Spec 009
   trace stream, inline, exactly as the rest of the framework does (and
   this very namespace's `capture-error-depth!` helper OBSERVES those
   emits through a global listener to read the depth-limit boundary). Per
@@ -40,9 +40,9 @@
       counter 0 still allocates `:worker#1`, not `:worker#3`.
   "
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.machines :as machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.trace :as trace]))
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.trace :as rf.trace]))
 
 (def auth-flow-spec
   "A tiny declarative-`:spawn` machine. On `[:submit]` from `:idle` it
@@ -62,8 +62,8 @@
   (testing "identical args produce identical Result values"
     (let [snap     {:state :idle :data {}}
           event    [:submit]
-          {snap1 :snapshot fx1 :fx} (machines/machine-transition auth-flow-spec snap event)
-          {snap2 :snapshot fx2 :fx} (machines/machine-transition auth-flow-spec snap event)]
+          {snap1 :snapshot fx1 :fx} (rf.machines/machine-transition auth-flow-spec snap event)
+          {snap2 :snapshot fx2 :fx} (rf.machines/machine-transition auth-flow-spec snap event)]
       (is (= snap1 snap2)
           "two pure-call invocations from the same input produce the same next-snapshot")
       (is (= fx1 fx2)
@@ -114,8 +114,8 @@
     ;; snapshot, so the two calls never share state.
     (let [snap-a {:state :idle :data {:tag :a}}
           snap-b {:state :idle :data {:tag :b}}
-          {fx-a :fx} (machines/machine-transition auth-flow-spec snap-a [:submit])
-          {fx-b :fx} (machines/machine-transition auth-flow-spec snap-b [:submit])]
+          {fx-a :fx} (rf.machines/machine-transition auth-flow-spec snap-a [:submit])
+          {fx-b :fx} (rf.machines/machine-transition auth-flow-spec snap-b [:submit])]
       (is (= :http/post#1 (-> fx-a first second :rf/spawned-id))
           "first snapshot's spawn is :http/post#1")
       (is (= :http/post#1 (-> fx-b first second :rf/spawned-id))
@@ -129,7 +129,7 @@
     (let [snap     {:state            :idle
                     :data             {}
                     :rf/spawn-counter {:http/post 3}}
-          {snap' :snapshot fx :fx} (machines/machine-transition auth-flow-spec snap [:submit])]
+          {snap' :snapshot fx :fx} (rf.machines/machine-transition auth-flow-spec snap [:submit])]
       (is (= :http/post#4 (-> fx first second :rf/spawned-id))
           "spawn allocates :http/post#4 — bump of the pre-existing 3")
       (is (= {:http/post 4} (:rf/spawn-counter snap'))
@@ -137,7 +137,7 @@
 
 ;; ---- trace is an observability side channel, not part of the reduction ----
 ;;
-;; The honest-purity contract: the reducer emits `trace/emit!` diagnostic
+;; The honest-purity contract: the reducer emits `rf.trace/emit!` diagnostic
 ;; events inline, but those emits are pure OBSERVABILITY — they never feed
 ;; back into the returned Result. This test pins both halves: (a) the
 ;; RETURNED transition value is identical whether or not a listener is
@@ -155,19 +155,19 @@
                        :done {}}}
           input {:state :idle :data {:n 0}}
           ;; No listener registered: the trace emits are no-op-delivered.
-          r-no-listener (machines/machine-transition m input [:go])
+          r-no-listener (rf.machines/machine-transition m input [:go])
           ;; A listener registered: same call, listener observes the
           ;; emitted diagnostics; assert the RETURNED Result is unchanged.
-          ;; Intentional RAW register/unregister (not mtest/with-trace-capture):
+          ;; Intentional RAW register/unregister (not rf.machines.test-support/with-trace-capture):
           ;; this test's whole point is to compare the reduction WITH a raw
           ;; listener present vs WITHOUT one, binding `r-with-listener` from the
           ;; guarded call and reading `@seen` in the surrounding `let` — the
           ;; scope-macro form cannot express the with/without comparison.
           seen          (atom [])
           r-with-listener
-          (do (trace/register-listener! ::purity-probe (fn [ev] (swap! seen conj ev)))
-              (try (machines/machine-transition m input [:go])
-                   (finally (trace/unregister-listener! ::purity-probe))))]
+          (do (rf.trace/register-listener! ::purity-probe (fn [ev] (swap! seen conj ev)))
+              (try (rf.machines/machine-transition m input [:go])
+                   (finally (rf.trace/unregister-listener! ::purity-probe))))]
       (is (= r-no-listener r-with-listener)
           "the reduction (snapshot + fx) does not depend on listener presence")
       (is (= :done (-> r-with-listener :snapshot :state))
@@ -191,7 +191,7 @@
                                        :join     :all}
                                       :on        {:done :ready}}
                           :ready     {}}}
-          {snap' :snapshot} (machines/machine-transition spec {:state :idle :data {}} [:start])]
+          {snap' :snapshot} (rf.machines/machine-transition spec {:state :idle :data {}} [:start])]
       (is (= {:worker 3} (:rf/spawn-counter snap'))
           "three :worker children bumped the slot to 3"))))
 
@@ -200,7 +200,7 @@
 ;; These pin baseline machine-transition behaviours — flat transitions,
 ;; :always microsteps, and pre-commit :raise routing. Co-located with the
 ;; allocator-purity contract above because they all exercise the pure
-;; `machines/machine-transition` surface from argument to Result.
+;; `rf.machines/machine-transition` surface from argument to Result.
 
 (deftest pure-machine-transition
   (testing "machine-transition is pure"
@@ -211,9 +211,9 @@
              {:red    {:on {:tick {:target :green}}}
               :green  {:on {:tick {:target :yellow}}}
               :yellow {:on {:tick {:target :red}}}}}]
-      (let [{s1 :snapshot} (machines/machine-transition m {:state :red :data {}} [:tick])]
+      (let [{s1 :snapshot} (rf.machines/machine-transition m {:state :red :data {}} [:tick])]
         (is (= :green (:state s1))))
-      (let [{s2 :snapshot} (machines/machine-transition m {:state :green :data {}} [:tick])]
+      (let [{s2 :snapshot} (rf.machines/machine-transition m {:state :green :data {}} [:tick])]
         (is (= :yellow (:state s2)))))))
 
 (deftest machine-always-microstep
@@ -228,7 +228,7 @@
               :idle     {}}}
           ;; Even with a no-op event (no match in :on), :always is checked
           ;; and the guard passes — transition to :authed.
-          {s :snapshot} (machines/machine-transition m {:state :checking :data {:authed? true}} [:noop])]
+          {s :snapshot} (rf.machines/machine-transition m {:state :checking :data {:authed? true}} [:noop])]
       (is (= :authed (:state s))))))
 
 ;; ---- depth-limit boundary parity ------------------------------------------
@@ -249,10 +249,10 @@
   "Drive a pure `machine-transition` while a tooling listener records traces,
   returning the `:depth` tag of the first error trace whose `:operation`
   matches `error-op` (or nil if none fired). Routed through the shared
-  `mtest/with-trace-capture` — guaranteed unregister in a `finally`."
+  `rf.machines.test-support/with-trace-capture` — guaranteed unregister in a `finally`."
   [error-op definition snapshot event]
-  (mtest/with-trace-capture seen
-    (machines/machine-transition definition snapshot event)
+  (rf.machines.test-support/with-trace-capture seen
+    (rf.machines/machine-transition definition snapshot event)
     (->> @seen
          (filter #(= error-op (:operation %)))
          first
@@ -357,7 +357,7 @@
                           :s1 {:on {:e2 {:target :s2 :action :r2}}}
                           :s2 {:on {:e3 {:target :s3 :action :r3}}}
                           :s3 {}}}
-          {s :snapshot} (machines/machine-transition
+          {s :snapshot} (rf.machines/machine-transition
                               spec {:state :s0 :data {}} [:e1])]
       (is (= :s3 (:state s))
           "a 3-deep self-chain under the default limit reaches the terminal
@@ -378,7 +378,7 @@
              {:idle {:on {:start {:target :busy :action :start}
                           :bump  {:action :bump}}}
               :busy {:on {:bump {:action :bump}}}}}
-          {s :snapshot fx :fx} (machines/machine-transition m {:state :idle :data {:n 0}} [:start])]
+          {s :snapshot fx :fx} (rf.machines/machine-transition m {:state :idle :data {:n 0}} [:start])]
       ;; Two raised :bump events should have been processed pre-commit;
       ;; final data :n should be 2.
       (is (= 2 (:n (:data s))))

--- a/implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj
+++ b/implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj
@@ -24,17 +24,17 @@
   JVM-only — the dynamic-var binding is platform-agnostic."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
-;; Routed through the shared `mtest/with-trace-capture` — guaranteed
+;; Routed through the shared `rf.machines.test-support/with-trace-capture` — guaranteed
 ;; unregister in a `finally`.
 (defn- record-traces
   [body-fn]
-  (mtest/with-trace-capture seen
+  (rf.machines.test-support/with-trace-capture seen
     (body-fn)
     @seen))
 

--- a/implementation/machines/test/re_frame/machine_view_unmount_teardown_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_view_unmount_teardown_cljs_test.cljc
@@ -81,30 +81,30 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.events :as events]
-   [re-frame.interop :as interop]
-   [re-frame.late-bind :as late-bind]
+   [re-frame.events :as rf.events]
+   [re-frame.interop :as rf.interop]
+   [re-frame.late-bind :as rf.late-bind]
    ;; Loading `re-frame.machines` installs the machines-artefact late-bind
    ;; hooks (`reg-machine`, the `:rf.machine/spawn` / `:rf.machine/destroy`
    ;; reserved fxs); under a single-ns test run nothing else pulls it in.
    [re-frame.machines]
-   [re-frame.machines.test-support :as mtest]
-   [re-frame.machines.timer :as timer]
-   [re-frame.registrar :as registrar]
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   [re-frame.machines.timer :as rf.machines.timer]
+   [re-frame.registrar :as rf.registrar]
    ;; listener surface lives in `re-frame.trace.tooling` (production-DCE split).
-   [re-frame.trace.tooling :as trace-tooling]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]
-              [re-frame.views :as views]])))
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]
+              [re-frame.views :as rf.views]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter})))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter})))
 
 ;; snapshot lookup via the shared machines test-support — no hardcoded
 ;; `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 ;; The two teardown channels + the view marker (Spec 009 §Two-channel
 ;; teardown). A reason belongs to exactly one channel.
@@ -119,7 +119,7 @@
   unregister is needed."
   [k]
   (let [a (atom [])]
-    (trace-tooling/register-listener! k (fn [ev] (swap! a conj ev)))
+    (rf.trace.tooling/register-listener! k (fn [ev] (swap! a conj ev)))
     a))
 
 (defn- ops-of
@@ -140,8 +140,8 @@
   with the identical op-type (`:rf.view`), channel (`:rf.view/unmounted`),
   and tags."
   [view-id render-key frame-id]
-  #?(:cljs (views/emit-view-unmounted! view-id render-key frame-id)
-     :clj  (when-let [emit! (late-bind/get-fn-cached :trace/emit!)]
+  #?(:cljs (rf.views/emit-view-unmounted! view-id render-key frame-id)
+     :clj  (when-let [emit! (rf.late-bind/get-fn-cached :trace/emit!)]
              (emit! :rf.view view-unmounted
                     {:rf.view/render-key render-key
                      :rf.view/id         view-id
@@ -191,7 +191,7 @@
           (is (= before after)
               "machine snapshot is UNCHANGED by the unmount (same :state + :data)")
           (is (= :active (:state after)) "machine is still in :active"))
-        (is (some? (registrar/lookup :event :vut/session))
+        (is (some? (rf.registrar/lookup :event :vut/session))
             "the machine's event handler is still registered after the unmount")
 
         ;; (4) belt — NO machine-category (`:op-type :rf.machine`) trace of any
@@ -213,7 +213,7 @@
     ;; machines depends only on core, so it dispatches the release by NAME). The
     ;; recorded owner proves the machine's resource owner is released on destroy.
     (let [released (atom [])]
-      (events/reg-event :rf.resource/release-owner
+      (rf.events/reg-event :rf.resource/release-owner
         (fn [_ [_ {:keys [owner]}]] (swap! released conj owner) {}))
       (rf/reg-machine :ed/session
         {:initial :active :data {} :states {:active {}}})
@@ -243,7 +243,7 @@
         ;; --- resource release (snapshot storage, handler, resource owner) ---
         (is (nil? (snapshot :ed/session))
             "snapshot cleared — the machine's state storage is released")
-        (is (nil? (registrar/lookup :event :ed/session))
+        (is (nil? (rf.registrar/lookup :event :ed/session))
             "event handler unregistered — the machine's handler resource is released")
         (is (= [[:machine :ed/session]] @released)
             "EXACTLY ONE [:machine actor-id] resource owner released on destroy")))))
@@ -261,7 +261,7 @@
     ;; This closes the vacuous "never fired" gap: the old redef discarded the
     ;; thunk, so "no :after-elapsed" was trivially true — nothing ever drove it.
     (let [captured-thunk (atom nil)]
-      (with-redefs [interop/schedule-after!
+      (with-redefs [rf.interop/schedule-after!
                     (fn [thunk _ms] (reset! captured-thunk thunk) ::handle)]
         (rf/reg-machine :edt/waiter
           {:initial :idle :data {}
@@ -270,7 +270,7 @@
                      :done    {}}})
         (rf/dispatch-sync [:edt/waiter [:rf.machine/start]])
         (rf/dispatch-sync [:edt/waiter [:go]])
-        (is (= :waiting (mtest/machine-state :edt/waiter))
+        (is (= :waiting (rf.machines.test-support/machine-state :edt/waiter))
             "precondition: entered the :after-bearing state")
         (is (fn? @captured-thunk)
             "precondition: the host clock CAPTURED the actor's :after thunk — the
@@ -278,7 +278,7 @@
         ;; The actor owns its :after timers via the registry key's `:parent`
         ;; (`re-frame.machines.timer/after-timer-key`); destroy filters on the
         ;; same `:parent = actor-id` to cancel them.
-        (let [owned #(->> (get @timer/after-timers :rf/default {})
+        (let [owned #(->> (get @rf.machines.timer/after-timers :rf/default {})
                           keys
                           (filter (fn [k] (= :edt/waiter (:parent k)))))]
           (is (= 1 (count (owned)))

--- a/implementation/machines/test/re_frame/machine_view_unmount_teardown_mounted_dom_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machine_view_unmount_teardown_mounted_dom_cljs_test.cljs
@@ -56,18 +56,18 @@
             [reagent.dom.client :as rdc]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
-            [re-frame.events :as events]
-            [re-frame.registrar :as registrar]
+            [re-frame.events :as rf.events]
+            [re-frame.registrar :as rf.registrar]
             ;; Loading `re-frame.machines` installs the machines-artefact
             ;; late-bind hooks (`reg-machine`, the `[:rf/machine …]` snapshot
             ;; sub, the `:rf.machine/*` reserved fxs).
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
+            [re-frame.machines.test-support :as rf.machines.test-support]
             ;; Loaded for side effect: publishes the `:views/emit-view-unmounted!`
             ;; late-bind hook + the unmount-hook machinery `reg-view*` arms.
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 ;; EP-0002 (rf2-9o48ih): `:ambient-frame nil` opts out of the fixture's default
 ;; ambient `*current-frame*` :rf/default scope. The mounted views resolve their
@@ -75,8 +75,8 @@
 ;; ambient :rf/default scope would shadow that tier and the participating view
 ;; would read the wrong frame. Every dispatch carries an explicit `{:frame …}`.
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter
      :async? true
      :ambient-frame nil}))
 
@@ -170,18 +170,18 @@
             ;; Bring the machine to a live snapshot in the view's frame
             ;; (xstate `createActor(m).start()`).
             (rf/dispatch-sync [machine-id [:rf.machine/start]] {:frame frame-id})
-            (let [before (mtest/snapshot frame-id machine-id)]
+            (let [before (rf.machines.test-support/snapshot frame-id machine-id)]
               (is (some? before) "precondition: machine snapshot live before mount")
               (is (= :active (:state before)) "precondition: machine in :active")
 
               ;; Capture the REAL teardown emit — register before mount/unmount.
-              (trace-tooling/register-listener! ::mvut-a (fn [ev] (swap! traces conj ev)))
+              (rf.trace.tooling/register-listener! ::mvut-a (fn [ev] (swap! traces conj ev)))
 
               ;; MOUNT the participating view through a real React root.
               (act-fn #(rdc/render root
                                    [rf/frame-provider {:frame frame-id}
                                     [(rf/view :mvut/session-view)]]))
-              (is (some? (mtest/snapshot frame-id machine-id))
+              (is (some? (rf.machines.test-support/snapshot frame-id machine-id))
                   "machine still live while the view is mounted")
               (is (zero? (count (view-ops-of @traces view-unmounted :mvut/session-view)))
                   "no :rf.view/unmounted before the unmount (nothing torn down yet)")
@@ -208,12 +208,12 @@
                           "NO :rf.machine.lifecycle/destroyed (registrar channel) —
                            a view unmount is not a frame-exit reap")
                       ;; (3) snapshot byte-identical + handler still registered.
-                      (let [after (mtest/snapshot frame-id machine-id)]
+                      (let [after (rf.machines.test-support/snapshot frame-id machine-id)]
                         (is (some? after) "machine snapshot STILL LIVE after real unmount")
                         (is (= before after)
                             "machine snapshot UNCHANGED by the unmount (same :state + :data)")
                         (is (= :active (:state after)) "machine still in :active"))
-                      (is (some? (registrar/lookup :event machine-id))
+                      (is (some? (rf.registrar/lookup :event machine-id))
                           "the machine's event handler is still registered after the unmount")
                       ;; (4) belt — no machine-category trace fired at all.
                       (is (empty? (filterv #(= :rf.machine (:op-type %)) @traces))
@@ -262,7 +262,7 @@
             ;; artefact — machines depends only on core, so it dispatches the
             ;; release by NAME). The recorded owner proves the machine's resource
             ;; owner is released on destroy.
-            (events/reg-event :rf.resource/release-owner
+            (rf.events/reg-event :rf.resource/release-owner
               (fn [_ [_ {:keys [owner]}]] (swap! released conj owner) {}))
             (rf/reg-machine machine-id
               {:initial :active :data {} :states {:active {}}})
@@ -271,16 +271,16 @@
                 (let [snap @(rf/subscribe [:rf/machine machine-id])]
                   [:div.mvut-ed (str (:state snap))])))
             (rf/dispatch-sync [machine-id [:rf.machine/start]] {:frame frame-id})
-            (is (some? (mtest/snapshot frame-id machine-id))
+            (is (some? (rf.machines.test-support/snapshot frame-id machine-id))
                 "precondition: machine is live before mount")
 
-            (trace-tooling/register-listener! ::mvut-ed (fn [ev] (swap! traces conj ev)))
+            (rf.trace.tooling/register-listener! ::mvut-ed (fn [ev] (swap! traces conj ev)))
 
             ;; MOUNT the participating view.
             (act-fn #(rdc/render root
                                  [rf/frame-provider {:frame frame-id}
                                   [(rf/view :mvut/ed-view)]]))
-            (is (some? (mtest/snapshot frame-id machine-id))
+            (is (some? (rf.machines.test-support/snapshot frame-id machine-id))
                 "machine live while the view is mounted")
 
             ;; EXPLICIT destroy while the view is still mounted. flushSync so the
@@ -301,9 +301,9 @@
                    NOT a frame-exit reap, so the registrar channel stays silent"))
 
             ;; --- resource release (snapshot storage, handler, resource owner) ---
-            (is (nil? (mtest/snapshot frame-id machine-id))
+            (is (nil? (rf.machines.test-support/snapshot frame-id machine-id))
                 "snapshot cleared — the machine's state storage is released")
-            (is (nil? (registrar/lookup :event machine-id))
+            (is (nil? (rf.registrar/lookup :event machine-id))
                 "event handler unregistered — the machine's handler resource is released")
             (is (= [[:machine machine-id]] @released)
                 "EXACTLY ONE [:machine actor-id] resource owner released on destroy")

--- a/implementation/machines/test/re_frame/machine_world_inputs_ctx_test.clj
+++ b/implementation/machines/test/re_frame/machine_world_inputs_ctx_test.clj
@@ -33,14 +33,14 @@
         unaffected."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 ;; A clearly-non-ambient sentinel: a fixed wall-clock epoch ms that the
 ;; host clock will never spontaneously return. If a callback read the
@@ -205,7 +205,7 @@
                        :done {}}}]
       ;; Drive the PURE engine directly — no dispatch, no handler, so the
       ;; machine def carries no :rf/cofx stamp.
-      (machines/machine-transition m {:state :idle :data {}} [:go])
+      (rf.machines/machine-transition m {:state :idle :data {}} [:go])
       (is (some? @captured) "the guard ran")
       (is (not (contains? @captured :rf.cofx))
           "no :rf.cofx key when the engine is driven without a token")

--- a/implementation/machines/test/re_frame/machines/test_support.cljc
+++ b/implementation/machines/test/re_frame/machines/test_support.cljc
@@ -29,9 +29,9 @@
   storage shape or RAW listener registration still touch those surfaces
   directly; everything else reaches for these helpers."
   (:require [re-frame.core :as rf]
-            [re-frame.machines.paths :as paths]
-            [re-frame.test-support :as core-test-support]
-            [re-frame.trace :as trace]))
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace]))
 
 ;; ---- reset-runtime fixture (re-export) ------------------------------------
 
@@ -39,7 +39,7 @@
   "Core's `make-reset-runtime-fixture`, re-exported so a machines test
   requires ONE support ns. Same options (`{:adapter …}`). See
   `re-frame.test-support/make-reset-runtime-fixture`."
-  core-test-support/make-reset-runtime-fixture)
+  rf.test-support/make-reset-runtime-fixture)
 
 ;; ---- runtime-db + snapshot lookup -----------------------------------------
 
@@ -54,12 +54,12 @@
 (defn snapshot
   "The machine snapshot for `machine-id` (an actor / singleton id) in
   `frame-id` (default `:rf/default`), read through the canonical
-  `paths/snapshot-path` constructor rather than a hardcoded path vector.
+  `rf.machines.paths/snapshot-path` constructor rather than a hardcoded path vector.
   Returns nil when the actor has no snapshot (never spawned, or already
   destroyed)."
   ([machine-id] (snapshot :rf/default machine-id))
   ([frame-id machine-id]
-   (get-in (runtime-db frame-id) (paths/snapshot-path machine-id))))
+   (get-in (runtime-db frame-id) (rf.machines.paths/snapshot-path machine-id))))
 
 (defn machine-state
   "Convenience: the `:state` of `machine-id`'s snapshot (nil if absent)."
@@ -112,9 +112,9 @@
   (let [a  (atom [])
         id ::trace-capture]
     (binding [*captured* a]
-      (trace/register-listener! id (fn [ev] (swap! a conj ev)))
+      (rf.trace/register-listener! id (fn [ev] (swap! a conj ev)))
       (try (f)
-           (finally (trace/unregister-listener! id))))))
+           (finally (rf.trace/unregister-listener! id))))))
 
 #?(:clj
    (defmacro with-trace-capture
@@ -135,6 +135,6 @@
        `(let [~binding-sym (atom [])
               id#          (keyword "re-frame.machines.test-support"
                                     (name '~id-sym))]
-          (trace/register-listener! id# (fn [ev#] (swap! ~binding-sym conj ev#)))
+          (rf.trace/register-listener! id# (fn [ev#] (swap! ~binding-sym conj ev#)))
           (try ~@body
-               (finally (trace/unregister-listener! id#)))))))
+               (finally (rf.trace/unregister-listener! id#)))))))

--- a/implementation/machines/test/re_frame/machines_after_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_after_cljs_test.cljs
@@ -22,18 +22,18 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             ;; listener / buffer surface lives in re-frame.trace.tooling.
-            [re-frame.trace.tooling :as trace-tooling]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.machines.test-support :as mtest]))
+            [re-frame.trace.tooling :as rf.trace.tooling]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.machines.test-support :as rf.machines.test-support]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path. Inline trace
 ;; captures below keep their raw trace.tooling register/unregister.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (deftest machine-after-cljs
   (testing ":after schedules with current epoch on entry; fires on synthetic timer event"
@@ -48,7 +48,7 @@
             :ready   {}}}
           traces (atom [])]
       (rf/reg-machine :http/flow machine)
-      (trace-tooling/register-listener! ::after (fn [ev] (swap! traces conj ev)))
+      (rf.trace.tooling/register-listener! ::after (fn [ev] (swap! traces conj ev)))
       ;; Step 1 — enter :loading; timer schedules at epoch 1.
       (rf/dispatch-sync [:http/flow [:fetch]])
       (let [s (snapshot :http/flow)]
@@ -77,7 +77,7 @@
                        (= 1    (:epoch  (:tags ev)))))
                 @traces)
           "expected :rf.machine.timer/fired trace with matching epoch")
-      (trace-tooling/unregister-listener! ::after)))
+      (rf.trace.tooling/unregister-listener! ::after)))
 
   (testing ":after stale detection — real event beats timer; stale firing must not transition"
     (let [machine
@@ -106,9 +106,9 @@
       ;; (b) the runtime emits :rf.machine.timer/stale-after as the
       ;; canonical signal so observers can distinguish "suppressed stale
       ;; firing" from "no firing at all".
-      (trace-tooling/register-listener! ::stale (fn [ev] (swap! traces conj ev)))
+      (rf.trace.tooling/register-listener! ::stale (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:http2/flow [:rf.machine.timer/after-elapsed 5000 1 [:loading]]])
-      (trace-tooling/unregister-listener! ::stale)
+      (rf.trace.tooling/unregister-listener! ::stale)
       (is (= :ready (:state (snapshot :http2/flow)))
           "stale timer must not fire its transition")
       (is (= 2 (get-in (snapshot :http2/flow) [:data :rf/after-epoch [:loading]]))
@@ -151,7 +151,7 @@
               :ready   {}}}
           traces (atom [])]
       (rf/reg-machine :a/multi-cljs m)
-      (trace-tooling/register-listener! ::mg (fn [ev] (swap! traces conj ev)))
+      (rf.trace.tooling/register-listener! ::mg (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:a/multi-cljs [:fetch]])
       (let [epoch (get-in (snapshot :a/multi-cljs) [:data :rf/after-epoch [:loading]])]
         ;; The 5s timer fires first; guard :slow? false → suppressed.
@@ -167,7 +167,7 @@
         (rf/dispatch-sync [:a/multi-cljs [:rf.machine.timer/after-elapsed 30000 epoch [:loading]]])
         (is (= :timeout (:state (snapshot :a/multi-cljs)))
             "sibling timer transitions on its own")
-        (trace-tooling/unregister-listener! ::mg)))))
+        (rf.trace.tooling/unregister-listener! ::mg)))))
 
 ;; ---- guarded candidate-vector :after -------------------------------------
 ;;
@@ -242,7 +242,7 @@
               :ready   {}}}
           traces (atom [])]
       (rf/reg-machine :a/sub-cljs m)
-      (trace-tooling/register-listener! ::sub (fn [ev] (swap! traces conj ev)))
+      (rf.trace.tooling/register-listener! ::sub (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:a/sub-cljs [:fetch]])
       (is (= :loading (:state (snapshot :a/sub-cljs))))
       (is (some (fn [ev]
@@ -252,4 +252,4 @@
                        (= [:a/timeout-config] (:rf.sub/query-v (:tags ev)))))
                 @traces)
           ":scheduled trace emitted with :delay-source :sub + canonical :rf.sub/id + :rf.sub/query-v (rf2-1b6uh5)")
-      (trace-tooling/unregister-listener! ::sub))))
+      (rf.trace.tooling/unregister-listener! ::sub))))

--- a/implementation/machines/test/re_frame/machines_always_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_always_cljs_test.cljs
@@ -9,18 +9,18 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             ;; listener / buffer surface lives in re-frame.trace.tooling.
-            [re-frame.trace.tooling :as trace-tooling]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.machines.test-support :as mtest]))
+            [re-frame.trace.tooling :as rf.trace.tooling]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.machines.test-support :as rf.machines.test-support]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path. Inline trace
 ;; captures below keep their raw trace.tooling register/unregister.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (deftest machine-always-cljs
   (testing ":always fires once after the resolving event under a true guard"
@@ -92,9 +92,9 @@
           traces (atom [])]
       (rf/reg-machine :osc/flow machine)
       (rf/dispatch-sync [:osc/flow [:rf.machine/start]])  ;; commit :start first
-      (trace-tooling/register-listener! ::osc (fn [ev] (swap! traces conj ev)))
+      (rf.trace.tooling/register-listener! ::osc (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:osc/flow [:go]])
-      (trace-tooling/unregister-listener! ::osc)
+      (rf.trace.tooling/unregister-listener! ::osc)
       ;; Atomic rollback: the committed snapshot stays at :start (the failing
       ;; [:go] macrostep commits nothing).
       (is (= :start (:state (snapshot :osc/flow)))

--- a/implementation/machines/test/re_frame/machines_choice_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_choice_cljs_test.cljs
@@ -15,22 +15,22 @@
   Mirrors the JVM choice_test.clj."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.choice :as choice]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.machines.test-support :as mtest]))
+            [re-frame.machines.choice :as rf.machines.choice]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.machines.test-support :as rf.machines.test-support]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (deftest desugar-choice-to-always-cljs
   (testing ":type :choice lowers to an :always candidate vector cross-host"
     (is (= {:initial :c
             :states {:c {:always [{:guard :g :target :a} {:target :b}]}
                      :a {} :b {}}}
-           (choice/desugar-choices
+           (rf.machines.choice/desugar-choices
              {:initial :c
               :states {:c {:type :choice
                            :choice [{:guard :g :target :a} {:target :b}]}

--- a/implementation/machines/test/re_frame/machines_conformance_test.clj
+++ b/implementation/machines/test/re_frame/machines_conformance_test.clj
@@ -39,8 +39,8 @@
             [clojure.java.io :as io]
             [clojure.edn :as edn]
             [clojure.string :as str]
-            [re-frame.conformance :as conformance]
-            [re-frame.machines :as machines]))
+            [re-frame.conformance :as rf.conformance]
+            [re-frame.machines :as rf.machines]))
 
 ;; ---- fixture discovery ----------------------------------------------------
 
@@ -279,7 +279,7 @@
      :on-spawn-actions
      (into {}
            (for [[id steps] (:machine-action handlers)]
-             [id (conformance/realise-on-spawn-handler steps)]))}))
+             [id (rf.conformance/realise-on-spawn-handler steps)]))}))
 
 ;; ---- single :machine-transition call --------------------------------------
 
@@ -297,7 +297,7 @@
                        (update :actions          #(merge actions %))
                        (update :guards           #(merge guards %))
                        (update :on-spawn-actions #(merge on-spawn-actions %)))
-        r          (try (machines/machine-transition definition
+        r          (try (rf.machines/machine-transition definition
                                                      (:snapshot call)
                                                      (:event call))
                         (catch Throwable e
@@ -352,7 +352,7 @@
   [call]
   (let [definition (:definition call)
         want-error (:expect-error call)
-        thrown     (try (machines/validate-machine! definition) nil
+        thrown     (try (rf.machines/validate-machine! definition) nil
                         (catch clojure.lang.ExceptionInfo e e)
                         (catch Throwable e e))]
     (if want-error

--- a/implementation/machines/test/re_frame/machines_forbidden_transition_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_forbidden_transition_cljs_test.cljs
@@ -25,16 +25,16 @@
   surface real apps use (mirrors machines-wildcard-fallthrough-cljs-test)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.machines.test-support :as mtest]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.machines.test-support :as rf.machines.test-support]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; snapshot lookup via the shared machines test-support — no hardcoded
 ;; `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (defn- seed-snapshot!
   "Force the snapshot for `machine-id` to a known value via a `reg-event`

--- a/implementation/machines/test/re_frame/machines_hierarchical_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_hierarchical_cljs_test.cljs
@@ -18,16 +18,16 @@
   Counterpart to the non-hierarchical coverage in `machines_cljs_test.cljs`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.machines.test-support :as mtest]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.machines.test-support :as rf.machines.test-support]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (defn- seed-snapshot!
   "Force the snapshot for `machine-id` to a known value via a `reg-event`

--- a/implementation/machines/test/re_frame/machines_initial_cascade_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_initial_cascade_cljs_test.cljs
@@ -6,16 +6,16 @@
   Without this, the first event resolves against the wrong state-node level."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.machines.test-support :as mtest]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.machines.test-support :as rf.machines.test-support]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (deftest machine-initial-cascade-on-first-dispatch
   (testing "compound :initial chain descends to a leaf on first-dispatch snapshot synthesis (rf2-m1tv)"

--- a/implementation/machines/test/re_frame/machines_internal_events_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_internal_events_cljs_test.cljs
@@ -15,23 +15,23 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines]
-            [re-frame.machines.internal-events :as internal-events]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.machines.test-support :as mtest]))
+            [re-frame.machines.internal-events :as rf.machines.internal-events]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.machines.test-support :as rf.machines.test-support]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (deftest boundary-predicate-cljs
   (testing "internal-event-external? recognises declared internal events cross-host"
     (let [m {:internal-events #{:tick :retry/internal}}]
-      (is (true?  (internal-events/internal-event-external? m [:tick])))
-      (is (true?  (internal-events/internal-event-external? m [:retry/internal])))
-      (is (false? (internal-events/internal-event-external? m [:public-event])))
-      (is (false? (internal-events/internal-event-external? {:initial :a} [:tick]))))))
+      (is (true?  (rf.machines.internal-events/internal-event-external? m [:tick])))
+      (is (true?  (rf.machines.internal-events/internal-event-external? m [:retry/internal])))
+      (is (false? (rf.machines.internal-events/internal-event-external? m [:public-event])))
+      (is (false? (rf.machines.internal-events/internal-event-external? {:initial :a} [:tick]))))))
 
 (defn- reg-error-id [machine]
   (try (rf/reg-machine (keyword "iet" (str (gensym))) machine) nil

--- a/implementation/machines/test/re_frame/machines_ns_wildcard_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_ns_wildcard_cljs_test.cljs
@@ -16,16 +16,16 @@
   surface real apps use."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.machines.test-support :as mtest]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.machines.test-support :as rf.machines.test-support]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; snapshot lookup via the shared machines test-support — no hardcoded
 ;; `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (defn- seed-snapshot!
   "Force the snapshot for `machine-id` to a known value via a `reg-event`

--- a/implementation/machines/test/re_frame/machines_on_error_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machines_on_error_cljs_test.cljc
@@ -52,19 +52,19 @@
    ;; resolves through (without it, `rf/reg-machine` throws
    ;; `:rf.error/machines-artefact-missing`).
    [re-frame.machines]
-   [re-frame.machines.test-support :as mtest]
-   [re-frame.trace.tooling :as trace-tooling]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter})))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter})))
 
 ;; snapshot lookup via the shared machines test-support — no hardcoded
 ;; `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (defn- spawned-id-for
   [parent-id invoke-id]
@@ -78,7 +78,7 @@
 (defn- record-traces!
   [k]
   (let [a (atom [])]
-    (trace-tooling/register-listener! k (fn [ev] (swap! a conj ev)))
+    (rf.trace.tooling/register-listener! k (fn [ev] (swap! a conj ev)))
     a))
 
 ;; ---- (a) child reaches error :final? leaf → parent :on-error :target fires ----

--- a/implementation/machines/test/re_frame/machines_raise_chain_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_raise_chain_cljs_test.cljs
@@ -14,16 +14,16 @@
   point."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.machines.test-support :as mtest]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.machines.test-support :as rf.machines.test-support]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (deftest machine-raise-chain-cljs
   (testing "an action's [:raise <event>] re-enters machine-transition and fires the chained transition (rf2-c0nt)"

--- a/implementation/machines/test/re_frame/machines_reply_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machines_reply_cljs_test.cljc
@@ -13,29 +13,29 @@
   value/error conventions + data-only invariant hold uniformly."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.edn :as edn]
-            [re-frame.machines.reply :as m-reply]
-            [re-frame.reply :as reply]))
+            [re-frame.machines.reply :as rf.machines.reply]
+            [re-frame.reply :as rf.reply]))
 
 ;; ---- work-id correlation --------------------------------------------------
 
 (deftest spawn-work-id-shape
   (testing "machine work-id head [:rf.work/machine actor-id work-bearing-path generation]"
     (is (= [:rf.work/machine :auth/flow#1 [:authenticating] 1]
-           (m-reply/spawn-work-id :auth/flow#1 [:authenticating]))
+           (rf.machines.reply/spawn-work-id :auth/flow#1 [:authenticating]))
         "EP-0011 §Work-id correlation example shape")
     (is (= [:rf.work/machine :auth/flow#7 [:authenticating] 7]
-           (m-reply/spawn-work-id :auth/flow#7 [:authenticating]))
+           (rf.machines.reply/spawn-work-id :auth/flow#7 [:authenticating]))
         "generation parsed off the <type>#<n> instance-id suffix")
     (is (= [:rf.work/machine :app/child#12 [:p :working] 12]
-           (m-reply/spawn-work-id :app/child#12 [:p :working]))
+           (rf.machines.reply/spawn-work-id :app/child#12 [:p :working]))
         "multi-digit generation + nested declaring path"))
   (testing "explicit per-state-singleton :fixed-actor-id (no #n suffix) → generation 1"
     (is (= [:rf.work/machine :explicit/actor [:s] 1]
-           (m-reply/spawn-work-id :explicit/actor [:s]))
+           (rf.machines.reply/spawn-work-id :explicit/actor [:s]))
         "one attempt, generation 1 (EP-0007)"))
   (testing "work-id is =-comparable and EDN-serializable"
-    (let [wid (m-reply/spawn-work-id :a/b#3 [:x])]
-      (is (= wid (m-reply/spawn-work-id :a/b#3 [:x])))
+    (let [wid (rf.machines.reply/spawn-work-id :a/b#3 [:x])]
+      (is (= wid (rf.machines.reply/spawn-work-id :a/b#3 [:x])))
       (is (= wid (edn/read-string (pr-str wid)))))))
 
 ;; ---- cross-platform actor-generation determinism --------------------------
@@ -47,38 +47,38 @@
 
 (deftest actor-generation-numeric-suffix
   (testing "a fully-numeric #n suffix parses to n on both platforms"
-    (is (= 1  (m-reply/actor-generation :auth/flow#1)))
-    (is (= 7  (m-reply/actor-generation :auth/flow#7)))
-    (is (= 12 (m-reply/actor-generation :app/child#12)))))
+    (is (= 1  (rf.machines.reply/actor-generation :auth/flow#1)))
+    (is (= 7  (rf.machines.reply/actor-generation :auth/flow#7)))
+    (is (= 12 (rf.machines.reply/actor-generation :app/child#12)))))
 
 (deftest actor-generation-no-suffix-is-one
   (testing "an id with no #n suffix is generation 1 (explicit :fixed-actor-id)"
-    (is (= 1 (m-reply/actor-generation :explicit/actor)))))
+    (is (= 1 (rf.machines.reply/actor-generation :explicit/actor)))))
 
 (deftest actor-generation-malformed-suffix-is-one-cross-platform
   (testing "C4: a # followed by a NON-fully-numeric suffix is generation 1 on
             BOTH CLJ and CLJS (no lenient js/parseInt divergence)"
     ;; partially-numeric: a lenient CLJS js/parseInt would yield 3 here, CLJ
     ;; would throw — the `#"\d+"` pre-check defaults both to 1
-    (is (= 1 (m-reply/actor-generation :weird/actor#3abc))
+    (is (= 1 (rf.machines.reply/actor-generation :weird/actor#3abc))
         "partially-numeric suffix defaults to generation 1 on both platforms")
     ;; non-numeric suffix: NaN (CLJS) / throw (CLJ) — both already → 1
-    (is (= 1 (m-reply/actor-generation :weird/actor#abc)))
+    (is (= 1 (rf.machines.reply/actor-generation :weird/actor#abc)))
     ;; empty suffix (trailing #): both → 1
-    (is (= 1 (m-reply/actor-generation :weird/actor#)))
+    (is (= 1 (rf.machines.reply/actor-generation :weird/actor#)))
     ;; whitespace / sign-prefixed: js/parseInt is lenient about leading
     ;; whitespace; CLJ Long/parseLong is not — both must agree on 1.
-    (is (= 1 (m-reply/actor-generation (keyword "weird" "actor# 4"))))))
+    (is (= 1 (rf.machines.reply/actor-generation (keyword "weird" "actor# 4"))))))
 
 (deftest actor-generation-nil-safe
   (testing "nil id (no live counterpart) → nil"
-    (is (nil? (m-reply/actor-generation nil)))))
+    (is (nil? (rf.machines.reply/actor-generation nil)))))
 
 ;; ---- canonical spawned-actor reply maps -----------------------------------
 
 (deftest success-reply-is-canonical
   (testing ":status :ok reply for a plain :final? leaf"
-    (let [r (m-reply/success-reply
+    (let [r (rf.machines.reply/success-reply
               {:actor-id          :auth/flow#1
                :parent-id         :auth/main
                :work-bearing-path [:authenticating]
@@ -95,15 +95,15 @@
       (is (= {:actor-id :auth/flow#1 :parent-id :auth/main :invoke-id [:authenticating]}
              (:correlation r)))
       (is (nil? (:error r)) ":ok carries no :error")
-      (is (reply/valid-reply? r) "conforms to the shared reply-map contract")))
+      (is (rf.reply/valid-reply? r) "conforms to the shared reply-map contract")))
   (testing "no :output-key ⇒ :value nil, still valid :ok"
-    (let [r (m-reply/success-reply {:actor-id :a/b#1 :work-bearing-path [:s]} nil)]
+    (let [r (rf.machines.reply/success-reply {:actor-id :a/b#1 :work-bearing-path [:s]} nil)]
       (is (= :ok (:status r)))
       (is (contains? r :value))
       (is (nil? (:value r)))
-      (is (reply/valid-reply? r))))
+      (is (rf.reply/valid-reply? r))))
   (testing "optional facts omitted when absent (no nil sentinels)"
-    (let [r (m-reply/success-reply {:actor-id :a/b#1 :work-bearing-path [:s]} :v)]
+    (let [r (rf.machines.reply/success-reply {:actor-id :a/b#1 :work-bearing-path [:s]} :v)]
       (is (not (contains? r :rf.frame/id)))
       (is (not (contains? r :completed-at)))
       (is (= {:actor-id :a/b#1 :invoke-id [:s]} (:correlation r))
@@ -111,7 +111,7 @@
 
 (deftest error-reply-is-canonical
   (testing ":status :error reply for an :error? terminal leaf"
-    (let [r (m-reply/error-reply
+    (let [r (rf.machines.reply/error-reply
               {:actor-id :auth/flow#2 :parent-id :auth/main :work-bearing-path [:authenticating]}
               {:reason :bad-creds})]
       (is (= :error (:status r)))
@@ -119,22 +119,22 @@
       (is (= :machine (:rf.reply/work-kind r)))
       (is (some? (:error r)))
       (is (some? (:kind (:error r))) ":error carries a family :kind")
-      (is (reply/valid-reply? r))))
+      (is (rf.reply/valid-reply? r))))
   (testing "a raw (kind-less) error payload is wrapped with a family :kind"
-    (let [r (m-reply/error-reply {:actor-id :a/b#1 :work-bearing-path [:s]} :boom)]
+    (let [r (rf.machines.reply/error-reply {:actor-id :a/b#1 :work-bearing-path [:s]} :boom)]
       (is (= {:kind :rf.machine/spawn-error :value :boom} (:error r)))
-      (is (reply/valid-reply? r))))
+      (is (rf.reply/valid-reply? r))))
   (testing "an error map already carrying :kind rides verbatim"
     (let [err {:kind :app/custom :detail 99}
-          r   (m-reply/error-reply {:actor-id :a/b#1 :work-bearing-path [:s]} err)]
+          r   (rf.machines.reply/error-reply {:actor-id :a/b#1 :work-bearing-path [:s]} err)]
       (is (= err (:error r)) "no double-wrapping")
-      (is (reply/valid-reply? r)))))
+      (is (rf.reply/valid-reply? r)))))
 
 ;; ---- late spawned-actor completion — stale suppression --------------------
 
 (deftest stale-spawn-reply-suppresses
   (testing "a late child completion is :status :stale with no :value"
-    (let [r (m-reply/stale-spawn-reply
+    (let [r (rf.machines.reply/stale-spawn-reply
               {:actor-id :auth/flow#1 :parent-id :auth/main :work-bearing-path [:authenticating]})]
       (is (= :stale (:status r)))
       (is (true? (:stale? r)))
@@ -142,45 +142,45 @@
       (is (= :suppressed (:rf.reply/work-status r)))
       (is (not (contains? r :value)) ":stale MUST NOT carry :value (no app mutation)")
       (is (= [:rf.work/machine :auth/flow#1 [:authenticating] 1] (:rf.reply/work-id r)))
-      (is (reply/valid-reply? r) "conforms to the shared reply-map contract"))))
+      (is (rf.reply/valid-reply? r) "conforms to the shared reply-map contract"))))
 
 ;; ---- :after timer suppression gate ----------------------------------------
 
 (deftest after-suppression-gate-shape
   (testing "the gate is {:path decl-path :rf/after-epoch epoch} (data-only)"
     (is (= {:path [:loading] :rf/after-epoch 3}
-           (m-reply/after-suppression-gate [:loading] 3)))
+           (rf.machines.reply/after-suppression-gate [:loading] 3)))
     (is (= {:path nil :rf/after-epoch nil}
-           (m-reply/after-suppression-gate nil nil))
+           (rf.machines.reply/after-suppression-gate nil nil))
         "exited node ⇒ nil path (no live counterpart)")))
 
 (deftest after-suppression-gate-drives-reply-stale?
   (testing "carried vs current gate matched by re-frame.reply/stale?"
-    (let [carried (m-reply/after-suppression-gate [:loading] 1)]
-      (is (false? (reply/stale? carried (m-reply/after-suppression-gate [:loading] 1)))
+    (let [carried (rf.machines.reply/after-suppression-gate [:loading] 1)]
+      (is (false? (rf.reply/stale? carried (rf.machines.reply/after-suppression-gate [:loading] 1)))
           "same path + epoch ⇒ live")
-      (is (true? (reply/stale? carried (m-reply/after-suppression-gate [:loading] 2)))
+      (is (true? (rf.reply/stale? carried (rf.machines.reply/after-suppression-gate [:loading] 2)))
           "epoch advanced (re-entry) ⇒ stale")
-      (is (true? (reply/stale? carried (m-reply/after-suppression-gate nil nil)))
+      (is (true? (rf.reply/stale? carried (rf.machines.reply/after-suppression-gate nil nil)))
           "node exited ⇒ stale"))))
 
 (deftest timer-work-id-head
   (testing "rf2-niarhz — machine :after timer work-id [:rf.work/timer logical-id epoch]"
     ;; logical-id = [machine-id decl-path...] when both known
     (is (= [:rf.work/timer [:a/multi :loading] 3]
-           (m-reply/timer-work-id :a/multi [:loading] 3)))
+           (rf.machines.reply/timer-work-id :a/multi [:loading] 3)))
     ;; bare decl-path when no machine-id
     (is (= [:rf.work/timer [:loading] 3]
-           (m-reply/timer-work-id nil [:loading] 3)))
+           (rf.machines.reply/timer-work-id nil [:loading] 3)))
     ;; the epoch discriminates a re-armed timer on node re-entry (distinct ids)
-    (is (not= (m-reply/timer-work-id :a/multi [:loading] 1)
-              (m-reply/timer-work-id :a/multi [:loading] 2)))
+    (is (not= (rf.machines.reply/timer-work-id :a/multi [:loading] 1)
+              (rf.machines.reply/timer-work-id :a/multi [:loading] 2)))
     ;; exited node (nil decl-path) is still a valid distinct id
-    (is (= [:rf.work/timer nil 3] (m-reply/timer-work-id nil nil 3)))))
+    (is (= [:rf.work/timer nil 3] (rf.machines.reply/timer-work-id nil nil 3)))))
 
 (deftest after-stale-reply-is-canonical
   (testing ":after stale reply carries the timer work-id + work-kind + suppression facts"
-    (let [r (m-reply/after-stale-reply
+    (let [r (rf.machines.reply/after-stale-reply
               {:actor-id        :a/multi
                :state           :loading
                :delay           30000
@@ -198,11 +198,11 @@
       (is (not (contains? r :value)))
       (is (= {:path [:loading] :rf/after-epoch 1} (-> r :correlation :carried)))
       (is (= {:path [:loading] :rf/after-epoch 2} (-> r :correlation :current)))
-      (is (reply/valid-reply? r)))))
+      (is (rf.reply/valid-reply? r)))))
 
 (deftest after-fired-reply-is-canonical
   (testing "rf2-niarhz — a FIRED (live) :after timer is a closed :status :ok / :rf.reply/work-status :completed completion carrying the canonical :work/id"
-    (let [r (m-reply/after-fired-reply
+    (let [r (rf.machines.reply/after-fired-reply
               {:actor-id   :a/multi
                :state      :loading
                :delay      30000
@@ -214,23 +214,23 @@
       (is (= :completed (:rf.reply/work-status r)))
       (is (= [:rf.work/timer [:a/multi :loading] 2] (:rf.reply/work-id r)))
       (is (nil? (:value r)) "a timer carries no payload — :value is an explicit nil (completed-with-no-payload)")
-      (is (reply/valid-reply? r) (str (reply/validate-reply r))))
+      (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r))))
     (testing "a guard-suppressed fired timer stays :ok/:completed (NOT stale) — the
               guard decision rides under :correlation, work-status stays closed"
-      (let [r (m-reply/after-fired-reply
+      (let [r (rf.machines.reply/after-fired-reply
                 {:actor-id :a/multi :state :loading :delay 30000
                  :decl-path [:loading] :epoch 2 :frame :rf/default
                  :guard-suppressed? true})]
         (is (= :ok (:status r)))
         (is (= :completed (:rf.reply/work-status r)))
         (is (true? (-> r :correlation :guard-suppressed?)))
-        (is (reply/valid-reply? r))))))
+        (is (rf.reply/valid-reply? r))))))
 
 ;; ---- terminal cancellation replies ----------------------------------------
 
 (deftest cancelled-timer-reply-is-canonical
   (testing "rf2-sfunt8 — a cancelled :after timer is :status :cancelled DATA"
-    (let [r (m-reply/cancelled-timer-reply
+    (let [r (rf.machines.reply/cancelled-timer-reply
               {:actor-id :a/multi :state :loading :delay 30000
                :decl-path [:loading] :epoch 1 :frame :rf/default
                :reason :on-exit})]
@@ -242,35 +242,35 @@
       ;; matches the fired / stale reply's work-id (same scheduling attempt row)
       (is (= [:rf.work/timer [:a/multi :loading] 1] (:rf.reply/work-id r)))
       (is (not (contains? r :value)) "a cancelled timer never fired — no :value")
-      (is (reply/valid-reply? r) (str (reply/validate-reply r)))))
+      (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r)))))
   (testing "every closed cancel reason produces a valid reply"
-    (doseq [reason m-reply/timer-cancel-reasons]
-      (let [r (m-reply/cancelled-timer-reply
+    (doseq [reason rf.machines.reply/timer-cancel-reasons]
+      (let [r (rf.machines.reply/cancelled-timer-reply
                 {:actor-id :a/m :state :s :delay 100
                  :decl-path [:s] :epoch 1 :frame :rf/default :reason reason})]
         (is (= reason (:rf.reply/cancel-reason r)))
-        (is (reply/valid-reply? r) (str reason " ⇒ " (reply/validate-reply r)))))))
+        (is (rf.reply/valid-reply? r) (str reason " ⇒ " (rf.reply/validate-reply r)))))))
 
 (deftest on-restore-cancel-reason-in-closed-vocab
   (testing "rf2-e3ryis — :on-restore (epoch-restore host-timer cleanup) is a
             member of the closed timer-cancel-reasons vocab and produces a valid
             cancelled-timer reply. `timer/cancel-frame-timers-on-restore!` emits
             :reason :on-restore, so the closed set MUST sanction it — otherwise a
-            downstream reply/trace-schema validator or a consumer branching on
+            downstream rf.reply/trace-schema validator or a consumer branching on
             the vocab (exhaustive case / filter-pill enum) rejects or
             misclassifies the epoch-restore cancellation."
-    (is (contains? m-reply/timer-cancel-reasons :on-restore)
+    (is (contains? rf.machines.reply/timer-cancel-reasons :on-restore)
         ":on-restore is a member of the closed cancel-reason vocabulary")
-    (let [r (m-reply/cancelled-timer-reply
+    (let [r (rf.machines.reply/cancelled-timer-reply
               {:actor-id :a/m :state :waiting :delay 5000
                :decl-path [:waiting] :epoch 2 :frame :rf/default
                :reason :on-restore})]
       (is (= :on-restore (:rf.reply/cancel-reason r)))
-      (is (reply/valid-reply? r) (str "on-restore ⇒ " (reply/validate-reply r))))))
+      (is (rf.reply/valid-reply? r) (str "on-restore ⇒ " (rf.reply/validate-reply r))))))
 
 (deftest cancelled-actor-reply-is-canonical
   (testing "rf2-sfunt8 — a cancelled (destroyed) spawned actor is :status :cancelled"
-    (let [r (m-reply/cancelled-actor-reply
+    (let [r (rf.machines.reply/cancelled-actor-reply
               {:actor-id :auth/flow#1 :parent-id :auth/main
                :work-bearing-path [:authenticating] :frame :rf/default
                :reason :explicit})]
@@ -282,11 +282,11 @@
       (is (= [:rf.work/machine :auth/flow#1 [:authenticating] 1] (:rf.reply/work-id r))
           "reuses the machine work-id so the cancel joins the spawn's row")
       (is (not (contains? r :value)) "the actor never produced an :output-key result")
-      (is (reply/valid-reply? r) (str (reply/validate-reply r)))))
+      (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r)))))
   (testing "join-survivor cancel reason rides as :rf.reply/cancel-reason"
-    (let [r (m-reply/cancelled-actor-reply
+    (let [r (rf.machines.reply/cancelled-actor-reply
               {:actor-id :child/c#2 :parent-id :sup/all
                :work-bearing-path [:hydrating] :frame :rf/default
                :reason :on-join-resolution})]
       (is (= :on-join-resolution (:rf.reply/cancel-reason r)))
-      (is (reply/valid-reply? r)))))
+      (is (rf.reply/valid-reply? r)))))

--- a/implementation/machines/test/re_frame/machines_spawn_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_spawn_cljs_test.cljs
@@ -27,31 +27,31 @@
   `[:rf.runtime/machines :spawned <parent> <invoke-id>]`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.machines.lifecycle-fx.spawn :as spawn]
-            [re-frame.machines.paths :as paths]
-            [re-frame.machines.spawn-order :as spawn-order]
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.frame :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.machines.lifecycle-fx.spawn :as rf.machines.lifecycle-fx.spawn]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.machines.spawn-order :as rf.machines.spawn-order]
             ;; listener / buffer surface lives in re-frame.trace.tooling.
-            [re-frame.trace.tooling :as trace-tooling]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.machines.test-support :as mtest]))
+            [re-frame.trace.tooling :as rf.trace.tooling]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.machines.test-support :as rf.machines.test-support]))
 
 ;; The always-on error-listener registry (a `defonce` atom) is cleared per test
 ;; so an `:errors` listener from one test cannot leak into the next (the
 ;; unregistered-rejection cardinality + incarnation-fence tests register them).
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter
-     :init-fn (fn [] (error-emit/clear-error-listeners!))}))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter
+     :init-fn (fn [] (rf.error-emit/clear-error-listeners!))}))
 
 ;; snapshot lookup via the shared machines test-support — no hardcoded
 ;; `[:rf.runtime/machines :snapshots …]` path. The per-section
 ;; trace captures below keep their raw trace.tooling register/unregister: they
 ;; reset and re-scope the capture mid-test (interleaved with assertions), which
 ;; the scope-macro / :each-fixture forms cannot express.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (deftest machine-spawn-cljs
   (testing ":spawn spawns child on entry and destroys it on exit"
@@ -95,7 +95,7 @@
       ;; Entering :authenticating: :rf.machine/spawn fx fires
       ;; (→ :rf.machine.spawn/spawned trace), :on-spawn callback records the
       ;; deterministic actor id into :data.:pending.
-      (trace-tooling/register-listener! ::inv (fn [ev] (swap! traces conj ev)))
+      (rf.trace.tooling/register-listener! ::inv (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:auth3/flow [:submit]])
       (let [s (snapshot :auth3/flow)]
         (is (= :authenticating (:state s)))
@@ -115,7 +115,7 @@
       ;; fires targeting the recorded actor id.
       (reset! traces [])
       (rf/dispatch-sync [:auth3/flow [:auth/failed]])
-      (trace-tooling/unregister-listener! ::inv)
+      (rf.trace.tooling/unregister-listener! ::inv)
       (is (= :idle (:state (snapshot :auth3/flow))))
       (is (some (fn [ev]
                   (and (= :rf.machine/destroyed (:operation ev))
@@ -143,9 +143,9 @@
           traces (atom [])]
       (rf/reg-machine :qpuk4/worker child)
       (rf/reg-machine :qpuk4/sup    parent)
-      (trace-tooling/register-listener! ::two-axis (fn [ev] (swap! traces conj ev)))
+      (rf.trace.tooling/register-listener! ::two-axis (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:qpuk4/sup [:go]])
-      (trace-tooling/unregister-listener! ::two-axis)
+      (rf.trace.tooling/unregister-listener! ::two-axis)
       ;; fx-substrate axis
       (is (some (fn [ev]
                   (and (= :rf.machine.spawn/spawned (:operation ev))
@@ -237,7 +237,7 @@
           traces (atom [])]
       (rf/reg-machine :child/auth-after child)
       (rf/reg-machine :sup/auth-after  parent)
-      (trace-tooling/register-listener! ::ato (fn [ev] (swap! traces conj ev)))
+      (rf.trace.tooling/register-listener! ::ato (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:sup/auth-after [:go]])
       (is (= :authenticating (:state (snapshot :sup/auth-after)))
           "parent transitioned :idle → :authenticating")
@@ -260,7 +260,7 @@
         (is (nil? (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
                           [:rf.runtime/machines :snapshots child-id]))
             "child machine snapshot torn down by the standard exit cascade"))
-      (trace-tooling/unregister-listener! ::ato))))
+      (rf.trace.tooling/unregister-listener! ::ato))))
 
 ;; ---- the legacy :timeout-ms slot stays removed ------------------------
 ;;
@@ -365,10 +365,10 @@
                       (spawn-all-parent [{:id :a  :machine-id :card/missing-a}
                                          {:id :ok :machine-id :card/ok}
                                          {:id :b  :machine-id :card/missing-b}]))
-      (trace-tooling/register-listener! ::card (fn [ev] (swap! traces conj ev)))
+      (rf.trace.tooling/register-listener! ::card (fn [ev] (swap! traces conj ev)))
       (let [records (with-error-records
                       #(rf/dispatch-sync [:sup/card [:start]]))]
-        (trace-tooling/unregister-listener! ::card)
+        (rf.trace.tooling/unregister-listener! ::card)
         ;; TWO offending children ⇒ TWO always-on records — the OLD gate order
         ;; produced FOUR (each offending child re-emitting from its per-child fx).
         (is (= 2 (count records))
@@ -389,7 +389,7 @@
         (is (nil? (get-in (runtime-db-value)
                           [:rf.runtime/machines :snapshots :card/ok#1]))
             "the registered sibling installs no snapshot under the rejected invoke")
-        (is (not (some #{:card/ok#1} (spawn-order/frame-order :rf/default)))
+        (is (not (some #{:card/ok#1} (rf.machines.spawn-order/frame-order :rf/default)))
             "the registered sibling records no spawn-order entry")
         (is (not (some (fn [ev] (= :rf.machine.spawn/spawned (:operation ev)))
                        @traces))
@@ -408,10 +408,10 @@
           traces (atom [])]
       ;; :ghost/worker is NEVER reg-machine'd.
       (rf/reg-machine :sup/ghost parent)
-      (trace-tooling/register-listener! ::ghost (fn [ev] (swap! traces conj ev)))
+      (rf.trace.tooling/register-listener! ::ghost (fn [ev] (swap! traces conj ev)))
       (let [records (with-error-records
                       #(rf/dispatch-sync [:sup/ghost [:start]]))]
-        (trace-tooling/unregister-listener! ::ghost)
+        (rf.trace.tooling/unregister-listener! ::ghost)
         (is (= 1 (count records))
             "exactly ONE always-on record for the standalone unregistered spawn")
         (is (= :ghost/worker (:machine-id (first records)))
@@ -428,7 +428,7 @@
         (is (nil? (get-in (runtime-db-value)
                           [:rf.runtime/machines :system-ids :ghost-actor]))
             "no :system-id binding for the rejected spawn")
-        (is (not (some #{:ghost/worker#1} (spawn-order/frame-order :rf/default)))
+        (is (not (some #{:ghost/worker#1} (rf.machines.spawn-order/frame-order :rf/default)))
             "no spawn-order entry for the rejected actor")))))
 
 ;; ===========================================================================
@@ -479,39 +479,39 @@
           invoke-id [:forking]
           fired?    (atom false)
           b-birth   (atom nil)
-          orig      (late-bind/get-fn :schemas/validate-with-registered-fn)]
+          orig      (rf.late-bind/get-fn :schemas/validate-with-registered-fn)]
       (rf/make-frame {:id frame-a})
-      (let [token-a (frame/frame-incarnation-token frame-a)
+      (let [token-a (rf.frame/frame-incarnation-token frame-a)
             started (atom [])]
-        (trace-tooling/register-listener!
+        (rf.trace.tooling/register-listener!
           ::accept (fn [ev] (when (= :rf.machine.spawn-all/started (:operation ev))
                               (swap! started conj ev))))
         (try
-          (late-bind/set-fn! :schemas/validate-with-registered-fn
+          (rf.late-bind/set-fn! :schemas/validate-with-registered-fn
             (fn [schema _data]
               (when (= schema fence-child-schema)
                 (when (compare-and-set! fired? false true)
-                  (frame/destroy-frame! frame-a)   ;; destroy A
+                  (rf.frame/destroy-frame! frame-a)   ;; destroy A
                   (rf/make-frame {:id frame-a})      ;; publish same-id B
-                  (reset! b-birth (mtest/runtime-db frame-a))))
+                  (reset! b-birth (rf.machines.test-support/runtime-db frame-a))))
               true))                                  ;; conform verdict
-          (frame/call-with-event-owner-token frame-a token-a
-            (fn [] (spawn/spawn-all-init-fx
+          (rf.frame/call-with-event-owner-token frame-a token-a
+            (fn [] (rf.machines.lifecycle-fx.spawn/spawn-all-init-fx
                      {:frame frame-a}
                      (fence-init-args parent-id invoke-id
                                       [{:child-id :bad :machine-id :fence/strict
                                         :spawned-id :fence/strict#1 :data {:n 1}}]))))
           (is (true? @fired?) "the conforming validator ran (fence exercised)")
-          (is (nil? (get-in (mtest/runtime-db frame-a)
-                            (paths/spawned-path parent-id invoke-id)))
+          (is (nil? (get-in (rf.machines.test-support/runtime-db frame-a)
+                            (rf.machines.paths/spawned-path parent-id invoke-id)))
               "no A-derived live join landed on same-id successor B")
-          (is (= @b-birth (mtest/runtime-db frame-a))
+          (is (= @b-birth (rf.machines.test-support/runtime-db frame-a))
               "B's runtime-db is byte-identical to its birth value")
           (is (empty? @started)
               "no :rf.machine.spawn-all/started trace fired against B")
           (finally
-            (trace-tooling/unregister-listener! ::accept)
-            (late-bind/set-fn! :schemas/validate-with-registered-fn orig)))))))
+            (rf.trace.tooling/unregister-listener! ::accept)
+            (rf.late-bind/set-fn! :schemas/validate-with-registered-fn orig)))))))
 
 (deftest spawn-all-init-reject-listener-loss-fences-sentinel-cljs
   (testing "an unregistered child fans a reject record; an :errors LISTENER on
@@ -527,18 +527,18 @@
           records   (atom [])
           b-birth   (atom nil)]
       (rf/make-frame {:id frame-a})
-      (let [token-a (frame/frame-incarnation-token frame-a)]
+      (let [token-a (rf.frame/frame-incarnation-token frame-a)]
         (rf/register-listener! :errors ::rej
           (fn [r]
             (when (= :rf.error/machine-spawn-unregistered-type (:error r))
               (swap! records conj r)
               (when (compare-and-set! fired? false true)
-                (frame/destroy-frame! frame-a)   ;; destroy A on the record's stack
+                (rf.frame/destroy-frame! frame-a)   ;; destroy A on the record's stack
                 (rf/make-frame {:id frame-a})      ;; publish same-id B
-                (reset! b-birth (mtest/runtime-db frame-a))))))
+                (reset! b-birth (rf.machines.test-support/runtime-db frame-a))))))
         (try
-          (frame/call-with-event-owner-token frame-a token-a
-            (fn [] (spawn/spawn-all-init-fx
+          (rf.frame/call-with-event-owner-token frame-a token-a
+            (fn [] (rf.machines.lifecycle-fx.spawn/spawn-all-init-fx
                      {:frame frame-a}
                      (fence-init-args parent-id invoke-id
                                       [{:child-id :ok      :machine-id :fence/ok
@@ -548,10 +548,10 @@
           (is (true? @fired?) "the reject-record listener ran (fence exercised)")
           (is (= 1 (count @records))
               "the reject record fired once (it precedes the loss)")
-          (is (nil? (get-in (mtest/runtime-db frame-a)
-                            (paths/spawned-path parent-id invoke-id)))
+          (is (nil? (get-in (rf.machines.test-support/runtime-db frame-a)
+                            (rf.machines.paths/spawned-path parent-id invoke-id)))
               "no reject sentinel landed on same-id successor B")
-          (is (= @b-birth (mtest/runtime-db frame-a))
+          (is (= @b-birth (rf.machines.test-support/runtime-db frame-a))
               "B's runtime-db is byte-identical to its birth value")
           (finally
             (rf/unregister-listener! :errors ::rej)))))))

--- a/implementation/machines/test/re_frame/machines_system_id_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_system_id_cljs_test.cljs
@@ -13,15 +13,15 @@
   running actor."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
+            [re-frame.machines :as rf.machines]
             ;; listener / buffer surface lives in re-frame.trace.tooling.
-            [re-frame.trace.tooling :as trace-tooling]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.machines.test-support :as mtest]))
+            [re-frame.trace.tooling :as rf.trace.tooling]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.machines.test-support :as rf.machines.test-support]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 (deftest machine-system-id-cljs
   (testing "spawn-with-system-id binds the index, lookup resolves to spawned id, destroy clears"
@@ -45,7 +45,7 @@
       (rf/reg-machine :sup/flow parent)
       (rf/dispatch-sync [:sup/flow [:start]])
       ;; (1) Lookup-by-system-id returns the spawned id.
-      (let [spawned (machines/machine-by-system-id :worker)]
+      (let [spawned (rf.machines/machine-by-system-id :worker)]
         (is (= :worker/proc#1 spawned)
             ":system-id resolves to the spawned machine id")
         (is (= spawned (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
@@ -61,7 +61,7 @@
             "dispatch routed via system-id reached the live actor"))
       ;; (3) Destroy clears system-id binding and snapshot.
       (rf/dispatch-sync [:sup/flow [:done]])
-      (is (nil? (machines/machine-by-system-id :worker))
+      (is (nil? (rf.machines/machine-by-system-id :worker))
           "post-destroy lookup returns nil")
       (is (nil? (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
                         [:rf.runtime/machines :system-ids :worker]))
@@ -87,13 +87,13 @@
       (rf/reg-machine :notifier/proc child)
       (rf/reg-machine :sup2/flow parent)
       (rf/dispatch-sync [:sup2/flow [:go]])
-      (let [spawned (machines/machine-by-system-id :notifier)]
+      (let [spawned (rf.machines/machine-by-system-id :notifier)]
         (is (= :notifier/proc#1 spawned))
         ;; A machine IS an event handler: resolve the actor by its
         ;; :system-id, then dispatch to the id you hold — the everyday
         ;; cross-machine send. We use dispatch-sync through the resolved id
         ;; so the assert reads post-drain state without async timing.
-        (rf/dispatch-sync [(machines/machine-by-system-id :notifier) [:notify "hello"]])
+        (rf/dispatch-sync [(rf.machines/machine-by-system-id :notifier) [:notify "hello"]])
         (is (= ["hello"] (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
                                  [:rf.runtime/machines :snapshots spawned :data :msgs]))
             "dispatch via system-id lookup reached the live actor"))))
@@ -113,12 +113,12 @@
           {:fx [[:rf.machine/spawn {:machine-id :w/proc
                                     :id-prefix  :w/proc
                                     :system-id  :primary}]]}))
-      (trace-tooling/register-listener! ::col (fn [ev] (swap! traces conj ev)))
+      (rf.trace.tooling/register-listener! ::col (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [::spawn1])
       (rf/dispatch-sync [::spawn2])
-      (trace-tooling/unregister-listener! ::col)
+      (rf.trace.tooling/unregister-listener! ::col)
       ;; Second spawn rebinds.
-      (is (= :w/proc#2 (machines/machine-by-system-id :primary))
+      (is (= :w/proc#2 (rf.machines/machine-by-system-id :primary))
           "second spawn rebound :primary to the new actor")
       (is (some (fn [ev]
                   (and (= :rf.error/system-id-collision (:operation ev))
@@ -141,22 +141,22 @@
       (rf/reg-machine :fa/proc child)
       (rf/reg-machine :fa/sup parent)
       (rf/dispatch-sync [:fa/sup [:go]])
-      (let [ambient (machines/machine-by-system-id :fa/named)]
+      (let [ambient (rf.machines/machine-by-system-id :fa/named)]
         (is (= :fa/proc#1 ambient)
             "ambient 1-arity resolves the spawned id under the :rf/default scope")
         ;; (1) PUBLIC opts form — the canonical public shape (mirrors subscribe's frame-first arity).
-        (is (= ambient (machines/machine-by-system-id :fa/named {:frame :rf/default}))
+        (is (= ambient (rf.machines/machine-by-system-id :fa/named {:frame :rf/default}))
             "opts form {:frame :rf/default} binds the same frame and resolves the same id")
         ;; (2) INTERNAL frame-last plumbing — a bare frame-id keyword still resolves.
-        (is (= ambient (machines/machine-by-system-id :fa/named :rf/default))
+        (is (= ambient (rf.machines/machine-by-system-id :fa/named :rf/default))
             "internal frame-last (sid frame-id) plumbing is retained")
         ;; (3) The opts :frame is genuinely threaded: a DIFFERENT frame reads nil
         ;; (proving the frame key is honoured, not the old misbind where the opts
         ;; map would have been mistaken for the frame target).
-        (is (nil? (machines/machine-by-system-id :fa/named {:frame :no/such-frame}))
+        (is (nil? (rf.machines/machine-by-system-id :fa/named {:frame :no/such-frame}))
             "opts {:frame <other>} targets that frame's index (empty) — nil, not the ambient hit")
         ;; (4) Ambient opts (no :frame) falls back to the scope-resolved frame.
-        (is (= ambient (machines/machine-by-system-id :fa/named {}))
+        (is (= ambient (rf.machines/machine-by-system-id :fa/named {}))
             "empty opts map resolves the ambient frame (no :frame ⇒ scope chain)")))))
 
 (deftest machine-spawn-without-system-id-leaves-index-empty-cljs
@@ -169,5 +169,5 @@
       (rf/dispatch-sync [::spawn-anon])
       (is (nil? (get-in (:rf.db/runtime (rf/frame-state-value :rf/default)) [:rf.runtime/machines :system-ids]))
           "[:rf.runtime/machines :system-ids] not allocated when no spawns carry :system-id")
-      (is (nil? (machines/machine-by-system-id :anything))
+      (is (nil? (rf.machines/machine-by-system-id :anything))
           "lookup against an unbound system-id returns nil"))))

--- a/implementation/machines/test/re_frame/machines_tags_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_tags_cljs_test.cljs
@@ -15,16 +15,16 @@
     - `:tags` reflects the post-`:always`-microstep state."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.machines.test-support :as mtest]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.machines.test-support :as rf.machines.test-support]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (deftest machine-tags-flat-active-state-cljs
   (testing "flat machine — snapshot's :tags is the active state's tag set"

--- a/implementation/machines/test/re_frame/machines_timeout_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_timeout_cljs_test.cljs
@@ -15,28 +15,28 @@
   so the test is deterministic under Node."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.timeout :as timeout]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.machines.test-support :as mtest]))
+            [re-frame.machines.timeout :as rf.machines.timeout]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.machines.test-support :as rf.machines.test-support]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (deftest duration-grammar-cljs
   (testing "integer-ms + ISO-8601 resolve cross-host (CLJS parse path)"
-    (is (= 5000   (timeout/resolve-duration-ms 5000)))
-    (is (= 5000   (timeout/resolve-duration-ms "PT5S")))
-    (is (= 120000 (timeout/resolve-duration-ms "PT2M")))
-    (is (= 500    (timeout/resolve-duration-ms "PT0.5S")))
-    (is (= 5400000 (timeout/resolve-duration-ms "PT1H30M"))))
+    (is (= 5000   (rf.machines.timeout/resolve-duration-ms 5000)))
+    (is (= 5000   (rf.machines.timeout/resolve-duration-ms "PT5S")))
+    (is (= 120000 (rf.machines.timeout/resolve-duration-ms "PT2M")))
+    (is (= 500    (rf.machines.timeout/resolve-duration-ms "PT0.5S")))
+    (is (= 5400000 (rf.machines.timeout/resolve-duration-ms "PT1H30M"))))
   (testing "the XState `5s` / `10ms` shorthand is rejected cross-host"
-    (is (nil? (timeout/resolve-duration-ms "5s")))
-    (is (nil? (timeout/resolve-duration-ms "10ms")))
-    (is (nil? (timeout/resolve-duration-ms "P")))
-    (is (nil? (timeout/resolve-duration-ms 0)))))
+    (is (nil? (rf.machines.timeout/resolve-duration-ms "5s")))
+    (is (nil? (rf.machines.timeout/resolve-duration-ms "10ms")))
+    (is (nil? (rf.machines.timeout/resolve-duration-ms "P")))
+    (is (nil? (rf.machines.timeout/resolve-duration-ms 0)))))
 
 (defn- reg-error-id [machine]
   (try (rf/reg-machine (keyword "ttc" (str (gensym))) machine) nil

--- a/implementation/machines/test/re_frame/machines_wildcard_fallthrough_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_wildcard_fallthrough_cljs_test.cljs
@@ -18,16 +18,16 @@
   here only as a regression guard."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.machines.test-support :as mtest]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.machines.test-support :as rf.machines.test-support]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; snapshot lookup via the shared machines test-support — no hardcoded
 ;; `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (defn- seed-snapshot!
   "Force the snapshot for `machine-id` to a known value via a `reg-event`

--- a/implementation/machines/test/re_frame/nested_validation_test.clj
+++ b/implementation/machines/test/re_frame/nested_validation_test.clj
@@ -12,11 +12,11 @@
   from a single misuse site, isolated so the failure mode is unambiguous."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- registration-throws?
   "Try registering `machine` under `machine-id`. Returns the

--- a/implementation/machines/test/re_frame/on_spawn_ref_validation_test.clj
+++ b/implementation/machines/test/re_frame/on_spawn_ref_validation_test.clj
@@ -23,11 +23,11 @@
       like the runtime `chase-ref`'s cycle guard."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- registration-throws?
   "Try registering `machine` under `machine-id`. Returns the ExceptionInfo
@@ -69,7 +69,7 @@
       (rf/reg-machine :rf.on-spawn-tv/child2 child-def)
       (rf/reg-machine :rf.on-spawn-tv/via-on-spawn-actions parent)
       (rf/dispatch-sync [:rf.on-spawn-tv/via-on-spawn-actions [:start]])
-      (is (= :working (:state (mtest/snapshot :rf.on-spawn-tv/via-on-spawn-actions)))
+      (is (= :working (:state (rf.machines.test-support/snapshot :rf.on-spawn-tv/via-on-spawn-actions)))
           "registration + dispatch both succeed — the spawn-bearing state was entered"))))
 
 ;; ---- (3) resolves via the :actions FALLBACK --------------------------------

--- a/implementation/machines/test/re_frame/parallel_always_round_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/parallel_always_round_cljs_test.cljc
@@ -7,19 +7,19 @@
   semantics in both runtimes."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
+            [re-frame.frame :as rf.frame]
             [re-frame.machines]
-            [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.result :as result]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]))
+            [re-frame.machines.parallel :as rf.machines.parallel]
+            [re-frame.machines.result :as rf.machines.result]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace :as rf.trace]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- initial-snapshot [m]
-  (parallel/build-initial-snapshot m {:bootstrap-pending? false}))
+  (rf.machines.parallel/build-initial-snapshot m {:bootstrap-pending? false}))
 
 (defn- ordered-regions [order bodies]
   (into {} (map (fn [rn] [rn (get bodies rn)])) order))
@@ -51,8 +51,8 @@
           reads-ba (atom [])
           m-ab (event-order-machine [:a :b] reads-ab)
           m-ba (event-order-machine [:b :a] reads-ba)
-          r-ab (parallel/machine-transition m-ab (initial-snapshot m-ab) [:go])
-          r-ba (parallel/machine-transition m-ba (initial-snapshot m-ba) [:go])]
+          r-ab (rf.machines.parallel/machine-transition m-ab (initial-snapshot m-ab) [:go])
+          r-ba (rf.machines.parallel/machine-transition m-ba (initial-snapshot m-ba) [:go])]
       (is (and (= :ok (:status r-ab)) (= :ok (:status r-ba))))
       (is (= {:a :done :b :ready} (:state (:snapshot r-ab)))
           "A/B reaches the eventless target in the triggering macrostep")
@@ -81,15 +81,15 @@
   (testing "all regions enter before the identical parent loop converges birth"
     (let [m-ab (birth-order-machine [:a :b])
           m-ba (birth-order-machine [:b :a])
-          r-ab (parallel/apply-initial-entry-cascade m-ab (initial-snapshot m-ab))
-          r-ba (parallel/apply-initial-entry-cascade m-ba (initial-snapshot m-ba))]
+          r-ab (rf.machines.parallel/apply-initial-entry-cascade m-ab (initial-snapshot m-ab))
+          r-ba (rf.machines.parallel/apply-initial-entry-cascade m-ba (initial-snapshot m-ba))]
       (is (and (= :ok (:status r-ab)) (= :ok (:status r-ba))))
       (is (= {:a :done :b :ready} (:state (:snapshot r-ab))))
       (is (= (select-keys (:snapshot r-ab) [:state :data])
              (select-keys (:snapshot r-ba) [:state :data])))
-      (is (= 2 (result/microsteps r-ab))
+      (is (= 2 (rf.machines.result/microsteps r-ab))
           "A writes in round 0; B observes it from a fresh snapshot in round 1")
-      (is (= 2 (result/microsteps r-ba))
+      (is (= 2 (rf.machines.result/microsteps r-ba))
           "microsteps count parent rounds, independent of region order"))))
 
 (defn- co-selected-machine []
@@ -116,13 +116,13 @@
   (testing "two regional transitions share index 0 and count as one round"
     (let [emits (atom [])
           m (co-selected-machine)
-          r (with-redefs [trace/emit! (fn [& xs] (swap! emits conj xs))]
-              (parallel/machine-transition m (initial-snapshot m) [:go]))
-          micros (filterv #(= :microstep (:kind %)) (result/cascade r))
+          r (with-redefs [rf.trace/emit! (fn [& xs] (swap! emits conj xs))]
+              (rf.machines.parallel/machine-transition m (initial-snapshot m) [:go]))
+          micros (filterv #(= :microstep (:kind %)) (rf.machines.result/cascade r))
           micro-traces (filterv #(= :rf.machine.microstep/transition
                                     (second %)) @emits)]
       (is (= :ok (:status r)))
-      (is (= 1 (result/microsteps r)))
+      (is (= 1 (rf.machines.result/microsteps r)))
       (is (= [:a :b] (mapv :region micros)))
       (is (= [0 0] (mapv :microstep-index micros)))
       (is (= [0 0] (mapv #(-> % last :microstep-index) micro-traces)))
@@ -152,7 +152,7 @@
               :b {:initial :waiting
                   :states {:waiting {:on {:tick {:target :seen :action :raised}}}
                            :seen {}}}}}
-          r (parallel/machine-transition m (initial-snapshot m) [:go])]
+          r (rf.machines.parallel/machine-transition m (initial-snapshot m) [:go])]
       (is (= :ok (:status r)))
       (is (= [:event :always :raised] (get-in (:snapshot r) [:data :log])))
       (is (= {:a :done :b :seen} (:state (:snapshot r)))))))
@@ -169,7 +169,7 @@
                          :done {}}}
             :b {:initial :idle
                 :states {:idle {:on {:go :moved}} :moved {}}}}}
-        r (parallel/machine-transition m (initial-snapshot m) [:go])]
+        r (rf.machines.parallel/machine-transition m (initial-snapshot m) [:go])]
     (is (= :error (:status r)))
     (is (nil? (:snapshot r)) "failed macrostep publishes no partial snapshot")
     (is (nil? (:fx r)) "failed macrostep releases no partial effects")))
@@ -184,7 +184,7 @@
                 :states {:idle {:on {:go :x}}
                          :x {:always :y}
                          :y {:always :x}}}}}
-        r (parallel/machine-transition m (initial-snapshot m) [:go])]
+        r (rf.machines.parallel/machine-transition m (initial-snapshot m) [:go])]
     (is (= :error (:status r)))
     (is (= :rf.error/machine-always-depth-exceeded
            (:error-id (:error r))))
@@ -201,7 +201,7 @@
       ;; Registration is outside the observation window. The first dispatch
       ;; performs lazy birth (including both parent rounds) and the declined
       ;; external event in one handler result / frame-state transform.
-      (let [container (frame/frame-state-container :parallel-round/frame)
+      (let [container (rf.frame/frame-state-container :parallel-round/frame)
             writes    (atom 0)
             watch-key ::publication]
         (add-watch container watch-key
@@ -215,5 +215,5 @@
         (is (= 1 @writes)
             "birth entry + every eventless round commits through one write")
         (is (= {:a :done :b :ready}
-               (:state (mtest/snapshot :parallel-round/frame
+               (:state (rf.machines.test-support/snapshot :parallel-round/frame
                                       :parallel-round/publication))))))))

--- a/implementation/machines/test/re_frame/parallel_raise_broadcast_test.clj
+++ b/implementation/machines/test/re_frame/parallel_raise_broadcast_test.clj
@@ -25,7 +25,7 @@
   threads sequentially through regions in declaration order, so the log is
   the deterministic pure record of the broadcast/re-broadcast order)."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.machines :as machines]))
+            [re-frame.machines :as rf.machines]))
 
 (defn- log!
   "Append `label` to the shared `:data :log`."
@@ -58,7 +58,7 @@
                                                     :action :right-pong}}}
                               :ponged  {}}}}}
           {snap :snapshot}
-          (machines/machine-transition spec
+          (rf.machines/machine-transition spec
                                        {:state {:left :idle :right :waiting} :data {}}
                                        [:trigger])]
       (is (= :fired (get-in snap [:state :left]))
@@ -98,7 +98,7 @@
                                                    :action :admit}}}
                              :open   {}}}}}
           {snap :snapshot}
-          (machines/machine-transition spec
+          (rf.machines/machine-transition spec
                                        {:state {:auth :anon :gate :closed}
                                         :data  {:token nil}}
                                        [:login])]
@@ -127,7 +127,7 @@
                              :b {:on {:again {:target :c :action :land}}}
                              :c {}}}}}
           {snap :snapshot}
-          (machines/machine-transition spec
+          (rf.machines/machine-transition spec
                                        {:state {:solo :a} :data {}}
                                        [:start])]
       (is (= :c (get-in snap [:state :solo]))
@@ -169,7 +169,7 @@
                   :states  {:s {:on {:go {:action :two-go}
                                      :q  {:action :two-q}}}}}}}
           {snap :snapshot}
-          (machines/machine-transition spec
+          (rf.machines/machine-transition spec
                                        {:state {:one :s :two :s} :data {}}
                                        [:go])]
       ;; First broadcast (external :go): one-go then two-go (region order),
@@ -201,7 +201,7 @@
             :idle {:initial :z
                    :states  {:z {:on {:go {:action :start}}}}}}}
           original {:state {:loop :run :idle :z} :data {:token :keep}}
-          r        (machines/machine-transition spec original [:go])]
+          r        (rf.machines/machine-transition spec original [:go])]
       ;; A parallel re-broadcast depth-bound abort is a FAILED macrostep,
       ;; not an :ok rollback no-op (parity with the flat drain; XState v5
       ;; throws on the runaway). The `:fail` threads NO snapshot / fx, so the
@@ -244,7 +244,7 @@
                              :c {:always {:guard :ready? :target :done :action :auto}}
                              :done {}}}}}
           {snap :snapshot}
-          (machines/machine-transition spec
+          (rf.machines/machine-transition spec
                                        {:state {:flow :a} :data {:ready? false}}
                                        [:go])]
       (is (= :done (get-in snap [:state :flow]))
@@ -280,11 +280,11 @@
                                    :done  {}}}}}
         initial {:state {:left :idle} :data {}}]
     (testing "control: an EXTERNAL [:reset] fires the root :on"
-      (let [{snap :snapshot} (machines/machine-transition spec initial [:reset])]
+      (let [{snap :snapshot} (rf.machines/machine-transition spec initial [:reset])]
         (is (= :done (get-in snap [:state :left])) "root :on moved :left to :done")
         (is (true? (get-in snap [:data :root-fired])) "root :root-reset action ran")))
     (testing "a RAISED [:reset] declined by every region ALSO fires the root :on"
-      (let [{snap :snapshot} (machines/machine-transition spec initial [:trigger])]
+      (let [{snap :snapshot} (rf.machines/machine-transition spec initial [:trigger])]
         (is (= :done (get-in snap [:state :left]))
             "the raised [:reset] consulted the root :on (pre-fix: stuck at :fired)")
         (is (true? (get-in snap [:data :root-fired]))
@@ -317,7 +317,7 @@
                                    :region-done {}
                                    :root-done   {}}}}}
         initial {:state {:left :idle} :data {}}
-        {snap :snapshot} (machines/machine-transition spec initial [:trigger])]
+        {snap :snapshot} (rf.machines/machine-transition spec initial [:trigger])]
     (is (= :region-done (get-in snap [:state :left]))
         "the region handled the raised [:reset] locally — root suppressed")
     (is (nil? (get-in snap [:data :root-fired]))

--- a/implementation/machines/test/re_frame/parallel_region_runtime_overlay_test.clj
+++ b/implementation/machines/test/re_frame/parallel_region_runtime_overlay_test.clj
@@ -22,13 +22,13 @@
     - Region timer/action traces carry the LIVE `:rf/frame`, so
       epoch-capture / frame-isolation attribution is correct.
 
-  These tests drive `parallel/machine-transition` directly (pure) with an
+  These tests drive `rf.machines.parallel/machine-transition` directly (pure) with an
   explicitly-stamped parent so the assertion does not depend on a live SSR
   frame."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.core :as rf]
-            [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.test-support :as mtest]))
+            [re-frame.machines.parallel :as rf.machines.parallel]
+            [re-frame.machines.test-support :as rf.machines.test-support]))
 
 ;; ---- helpers ---------------------------------------------------------------
 
@@ -36,10 +36,10 @@
   "Register a trace listener for the duration of `body-fn`; return the
   captured trace vec. (`trace/emit!` delivers to listeners synchronously,
   so a PURE `machine-transition` call surfaces its traces here without a
-  dispatch cycle.) Routed through the shared `mtest/with-trace-capture` —
+  dispatch cycle.) Routed through the shared `rf.machines.test-support/with-trace-capture` —
   guaranteed unregister in a `finally`."
   [body-fn]
-  (mtest/with-trace-capture seen
+  (rf.machines.test-support/with-trace-capture seen
     (body-fn)
     @seen))
 
@@ -62,7 +62,7 @@
   "Build a live initial snapshot for `machine` (region → initial-state map
   + seeded :data / spawn-counter)."
   [machine]
-  (parallel/build-initial-snapshot machine {:bootstrap-pending? false}))
+  (rf.machines.parallel/build-initial-snapshot machine {:bootstrap-pending? false}))
 
 (deftest server-region-after-skips-host-timer-despite-stale-cache
   (testing "rf2-z522n: a parallel-region :after under a `:platform :server`
@@ -73,9 +73,9 @@
     ;; 1. Install the region cache and PRIME it from the UNSTAMPED machine
     ;;    (no :rf/platform / :rf/frame) — reproducing the bug's origin: the
     ;;    cached region spec captures a nil platform.
-    (let [unstamped (parallel/install-region-cache base-spec)]
-      (parallel/region-machine unstamped :climate)   ;; fault the stale entry in
-      (parallel/region-machine unstamped :lights)
+    (let [unstamped (rf.machines.parallel/install-region-cache base-spec)]
+      (rf.machines.parallel/region-machine unstamped :climate)   ;; fault the stale entry in
+      (rf.machines.parallel/region-machine unstamped :lights)
       ;; 2. The LIVE transition runs under a `:platform :server` frame.
       (let [server-machine (assoc unstamped
                                   :rf/platform  :server
@@ -84,7 +84,7 @@
             snap   (parallel-snapshot server-machine)
             traces (record-traces!
                      (fn []
-                       (parallel/machine-transition
+                       (rf.machines.parallel/machine-transition
                          server-machine snap [:start])))
             skipped   (of-op traces :rf.machine.timer/skipped-on-server)
             scheduled (of-op traces :rf.machine.timer/scheduled)]
@@ -102,9 +102,9 @@
    under a `:platform :client` frame DOES schedule (`:scheduled`) and the
    trace carries the live frame — confirming the overlay threads the real
    runtime frame through region pure logic, not a stale cached value."
-    (let [unstamped (parallel/install-region-cache base-spec)]
+    (let [unstamped (rf.machines.parallel/install-region-cache base-spec)]
       ;; Prime the cache from the unstamped machine again.
-      (parallel/region-machine unstamped :climate)
+      (rf.machines.parallel/region-machine unstamped :climate)
       (let [client-machine (assoc unstamped
                                   :rf/platform  :client
                                   :rf/frame     :test/client-frame
@@ -112,7 +112,7 @@
             snap   (parallel-snapshot client-machine)
             traces (record-traces!
                      (fn []
-                       (parallel/machine-transition
+                       (rf.machines.parallel/machine-transition
                          client-machine snap [:start])))
             scheduled (of-op traces :rf.machine.timer/scheduled)]
         (is (= 1 (count scheduled))
@@ -125,13 +125,13 @@
    the SHARED cached region spec — two transitions on different platforms
    must each see their OWN platform (the cache stays platform-agnostic;
    the overlay is per-step)."
-    (let [unstamped (parallel/install-region-cache base-spec)]
-      (parallel/region-machine unstamped :climate)
+    (let [unstamped (rf.machines.parallel/install-region-cache base-spec)]
+      (rf.machines.parallel/region-machine unstamped :climate)
       ;; Server transition first.
       (let [srv  (assoc unstamped :rf/platform :server :rf/frame :test/srv
                         :rf/parent-id :ov/srv)
             srv-tr (record-traces!
-                     (fn [] (parallel/machine-transition
+                     (fn [] (rf.machines.parallel/machine-transition
                               srv (parallel-snapshot srv) [:start])))]
         (is (= 1 (count (of-op srv-tr :rf.machine.timer/skipped-on-server)))
             "server run skipped"))
@@ -139,7 +139,7 @@
       (let [cli  (assoc unstamped :rf/platform :client :rf/frame :test/cli
                         :rf/parent-id :ov/cli)
             cli-tr (record-traces!
-                     (fn [] (parallel/machine-transition
+                     (fn [] (rf.machines.parallel/machine-transition
                               cli (parallel-snapshot cli) [:start])))]
         (is (= 1 (count (of-op cli-tr :rf.machine.timer/scheduled)))
             "client run scheduled — the cache was NOT poisoned by the prior server overlay")
@@ -173,16 +173,16 @@
                                 (swap! seen conj {:has? (contains? ctx :rf.cofx)
                                                   :cofx cofx})
                                 {:data (:data ctx)}))
-          installed (parallel/install-region-cache spec)]
+          installed (rf.machines.parallel/install-region-cache spec)]
       ;; 1. PRIME the cache from a parent carrying a causal coeffect token —
       ;;    reproducing the bug origin: the cached region spec captures the
       ;;    coeffect-carrying parent.
-      (parallel/region-machine (assoc installed :rf/cofx {:rf/time-ms 1}) :a)
-      (parallel/region-machine (assoc installed :rf/cofx {:rf/time-ms 1}) :b)
+      (rf.machines.parallel/region-machine (assoc installed :rf/cofx {:rf/time-ms 1}) :a)
+      (rf.machines.parallel/region-machine (assoc installed :rf/cofx {:rf/time-ms 1}) :b)
       ;; 2. The LIVE transition's parent carries NO `:rf/cofx` (a pure-fn / no-
       ;;    router caller, or a dispatch that simply did not thread the token).
       (let [snap (parallel-snapshot installed)]
-        (parallel/machine-transition installed snap [:go]))
+        (rf.machines.parallel/machine-transition installed snap [:go]))
       (is (= 1 (count @seen)) "the region :capture action ran exactly once")
       (is (false? (:has? (first @seen)))
           "the action ctx carried NO :rf.cofx — the cached coeffect did not leak
@@ -201,13 +201,13 @@
                                 (swap! seen conj {:has? (contains? ctx :rf.cofx)
                                                   :cofx cofx})
                                 {:data (:data ctx)}))
-          installed (parallel/install-region-cache spec)]
+          installed (rf.machines.parallel/install-region-cache spec)]
       ;; Prime under one coeffect …
-      (parallel/region-machine (assoc installed :rf/cofx {:rf/time-ms 1}) :a)
+      (rf.machines.parallel/region-machine (assoc installed :rf/cofx {:rf/time-ms 1}) :a)
       ;; … then transition under a DIFFERENT live coeffect.
       (let [live (assoc installed :rf/cofx {:rf/time-ms 99})
             snap (parallel-snapshot live)]
-        (parallel/machine-transition live snap [:go]))
+        (rf.machines.parallel/machine-transition live snap [:go]))
       (is (= 1 (count @seen)) "the region :capture action ran exactly once")
       (is (true? (:has? (first @seen)))
           "the action ctx carried :rf.cofx (the live parent supplied it)")

--- a/implementation/machines/test/re_frame/parallel_root_on_test.clj
+++ b/implementation/machines/test/re_frame/parallel_root_on_test.clj
@@ -30,16 +30,16 @@
   spec/conformance/fixtures/parallel-root-on-*.edn."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 ;; A two-region machine. Each region: :one -> :two on :go. No region handles
 ;; :all (only the root will). Used by several cases.
@@ -67,7 +67,7 @@
              :regions {:a {:initial :two :states {:one {} :two {}}}
                        :b {:initial :two :states {:one {} :two {}}}}}
           initial {:state {:a :two :b :two} :data {}}
-          {snap :snapshot} (machines/machine-transition m initial [:reset-all])]
+          {snap :snapshot} (rf.machines/machine-transition m initial [:reset-all])]
       (is (= {:a :one :b :one} (:state snap))
           "root :on fired and moved BOTH regions — NOT silently dropped"))))
 
@@ -81,7 +81,7 @@
              :regions {:a {:initial :one :states {:one {} :two {}}}
                        :b {:initial :one :states {:one {} :two {}}}}}
           initial {:state {:a :one :b :one} :data {}}
-          {snap :snapshot} (machines/machine-transition m initial [:go-all])]
+          {snap :snapshot} (rf.machines/machine-transition m initial [:go-all])]
       (is (= {:a :two :b :two} (:state snap))
           "root :on fired; both targeted regions moved (v5: GO -> {a:two,b:two})"))))
 
@@ -95,7 +95,7 @@
              :regions {:a {:initial :one :states {:one {} :two {}}}
                        :b {:initial :one :states {:one {} :two {}}}}}
           initial {:state {:a :one :b :one} :data {}}
-          {snap :snapshot} (machines/machine-transition m initial [:one])]
+          {snap :snapshot} (rf.machines/machine-transition m initial [:one])]
       (is (= {:a :two :b :one} (:state snap))
           "root :on moved :a; :b untargeted -> unchanged (v5: ONE -> {a:two,b:one})"))))
 
@@ -111,7 +111,7 @@
              :regions {:a {:initial :one :states {:one {:on {:go :two}} :two {}}}
                        :b {:initial :one :states {:one {} :two {}}}}}
           initial {:state {:a :one :b :one} :data {}}
-          {snap :snapshot} (machines/machine-transition m initial [:go])]
+          {snap :snapshot} (rf.machines/machine-transition m initial [:go])]
       (is (= {:a :two :b :one} (:state snap))
           (str "region :a handled :go (deeper wins); the root :on was NOT merged "
                "in -> :b stays :one (v5: GO -> {a:two,b:one})")))))
@@ -134,7 +134,7 @@
                        :b {:initial :resting
                            :states  {:initial {} :resting {}}}}}
           initial {:state {:a :initial :b :resting} :data {}}
-          {snap :snapshot} (machines/machine-transition m initial [:reset])]
+          {snap :snapshot} (rf.machines/machine-transition m initial [:reset])]
       (is (= {:a :special :b :resting} (:state snap))
           (str "the WHOLE root RESET is suppressed because :a competed; :b stays "
                ":resting (NOT :initial). Broadcast decomposition would wrongly give "
@@ -151,7 +151,7 @@
                        :b {:initial :one :states {:one {} :y {}}}
                        :c {:initial :one :states {:one {}}}}}     ; untargeted
           initial {:state {:a :one :b :one :c :one} :data {}}
-          {snap :snapshot} (machines/machine-transition m initial [:advance])]
+          {snap :snapshot} (rf.machines/machine-transition m initial [:advance])]
       (is (= {:a :x :b :y :c :one} (:state snap))
           ":a and :b moved to their named targets; :c (untargeted) unchanged"))))
 
@@ -166,7 +166,7 @@
              :regions {:a {:initial :one :states {:one {} :two {}}}
                        :b {:initial :one :states {:one {} :two {}}}}}
           initial {:state {:a :one :b :one} :data {:count 0}}
-          {snap :snapshot} (machines/machine-transition m initial [:tick])]
+          {snap :snapshot} (rf.machines/machine-transition m initial [:tick])]
       (is (= {:a :two :b :two} (:state snap)) "both regions moved")
       (is (= 1 (get-in snap [:data :count]))
           "root :action ran ONCE (not once per targeted region)"))))
@@ -182,7 +182,7 @@
              :regions {:a {:initial :one :states {:one {}}}
                        :b {:initial :one :states {:one {}}}}}
           initial {:state {:a :one :b :one} :data {:log []}}
-          {snap :snapshot} (machines/machine-transition m initial [:ping])]
+          {snap :snapshot} (rf.machines/machine-transition m initial [:ping])]
       (is (= {:a :one :b :one} (:state snap)) "no region moved (targetless)")
       (is (= [:noted] (get-in snap [:data :log])) "the root action ran once"))))
 
@@ -197,12 +197,12 @@
              :regions {:a {:initial :one :states {:one {} :two {}}}
                        :b {:initial :one :states {:one {} :two {}}}}}]
       (testing "guard false -> root declines -> no move"
-        (let [{snap :snapshot} (machines/machine-transition
+        (let [{snap :snapshot} (rf.machines/machine-transition
                                      m {:state {:a :one :b :one} :data {:armed? false}}
                                      [:fire])]
           (is (= {:a :one :b :one} (:state snap)) "guard false -> root :on not selected")))
       (testing "guard true -> root fires"
-        (let [{snap :snapshot} (machines/machine-transition
+        (let [{snap :snapshot} (rf.machines/machine-transition
                                      m {:state {:a :one :b :one} :data {:armed? true}}
                                      [:fire])]
           (is (= {:a :two :b :two} (:state snap)) "guard true -> root :on moves both"))))))
@@ -220,7 +220,7 @@
                                      :done {:tags #{:a/done}}}}
                        :b {:initial :one :states {:one {}}}}}
           initial {:state {:a :one :b :one} :data {}}
-          {snap :snapshot} (machines/machine-transition m initial [:advance])]
+          {snap :snapshot} (rf.machines/machine-transition m initial [:advance])]
       (is (= :done (get-in snap [:state :a]))
           ":a was moved to :mid by the root, then :always settled past to :done")
       (is (= :one (get-in snap [:state :b])) ":b unchanged")
@@ -252,7 +252,7 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf.error/machine-unresolved-guard"
-          (machines/make-machine-handler
+          (rf.machines/make-machine-handler
             {:type    :parallel
              :on      {:fire {:target [:a :two] :guard :nope}}  ; :nope not in :guards
              :regions {:a {:initial :one :states {:one {} :two {}}}}}))
@@ -262,7 +262,7 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf.error/machine-unresolved-action"
-          (machines/make-machine-handler
+          (rf.machines/make-machine-handler
             {:type    :parallel
              :on      {:fire {:target [:a :two] :action :nope}}
              :regions {:a {:initial :one :states {:one {} :two {}}}}}))
@@ -272,7 +272,7 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf.error/machine-parallel-root-on-bad-target"
-          (machines/make-machine-handler
+          (rf.machines/make-machine-handler
             {:type    :parallel
              :on      {:go :somewhere}     ; bare keyword — no flat sibling state
              :regions {:a {:initial :one :states {:one {}}}}}))
@@ -282,7 +282,7 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf.error/machine-parallel-root-on-bad-target"
-          (machines/make-machine-handler
+          (rf.machines/make-machine-handler
             {:type    :parallel
              :on      {:go {:target [:nonregion :x]}}
              :regions {:a {:initial :one :states {:one {} :x {}}}}}))
@@ -292,14 +292,14 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf.error/machine-parallel-root-on-bad-target"
-          (machines/make-machine-handler
+          (rf.machines/make-machine-handler
             {:type    :parallel
              :on      {:go {:target [[:a :two] [:nope :two]]}}
              :regions {:a {:initial :one :states {:one {} :two {}}}
                        :b {:initial :one :states {:one {} :two {}}}}}))))
 
   (testing "a well-formed root parallel :on validates silently"
-    (is (nil? (machines/validate-machine!
+    (is (nil? (rf.machines/validate-machine!
                 {:type    :parallel
                  :guards  {:ok? (fn [_] true)}
                  :actions {:act (fn [_] nil)}
@@ -321,14 +321,14 @@
 
 (deftest root-after-registers-and-validates
   (testing "a :type :parallel root declaring :after now REGISTERS (was rejected loudly)"
-    (is (nil? (machines/validate-machine!
+    (is (nil? (rf.machines/validate-machine!
                 {:type    :parallel
                  :after   {1000 {:target [:a :two]}}
                  :regions {:a {:initial :one :states {:one {} :two {}}}
                            :b {:initial :one :states {:one {} :two {}}}}}))
         "region-qualified single-target root :after validates silently"))
   (testing "multi-region + action/fx-only root :after value-forms validate"
-    (is (nil? (machines/validate-machine!
+    (is (nil? (rf.machines/validate-machine!
                 {:type    :parallel
                  :guards  {:ok? (fn [_] true)}
                  :actions {:act (fn [_] nil)}
@@ -346,7 +346,7 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf.error/machine-parallel-root-on-bad-target"
-          (machines/make-machine-handler
+          (rf.machines/make-machine-handler
             {:type    :parallel
              :after   {1000 {:target :two}}    ; bare keyword — no flat sibling
              :regions {:a {:initial :one :states {:one {} :two {}}}}}))
@@ -355,7 +355,7 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf.error/machine-parallel-root-on-bad-target"
-          (machines/make-machine-handler
+          (rf.machines/make-machine-handler
             {:type    :parallel
              :after   {1000 {:target [:nonregion :x]}}
              :regions {:a {:initial :one :states {:one {:on {}} :x {}}}}})))))
@@ -377,7 +377,7 @@
           initial {:state {:a :one :b :one}
                    :data  {:rf/after-epoch {[] 1}}}
           {snap :snapshot}
-          (machines/machine-transition
+          (rf.machines/machine-transition
             m initial [:rf.machine.timer/after-elapsed 1000 1 []])]
       (is (= {:a :two :b :two} (:state snap))
           "live root :after (matching epoch) moved BOTH targeted regions")))
@@ -390,7 +390,7 @@
           initial {:state {:a :one :b :one}
                    :data  {:rf/after-epoch {[] 1}}}
           {snap :snapshot}
-          (machines/machine-transition
+          (rf.machines/machine-transition
             m initial [:rf.machine.timer/after-elapsed 500 1 []])]
       (is (= {:a :two :b :one} (:state snap))
           ":a moved; :b untargeted -> unchanged"))))
@@ -406,7 +406,7 @@
           initial {:state {:a :one :b :one}
                    :data  {:fired 0 :rf/after-epoch {[] 1}}}
           {snap :snapshot}
-          (machines/machine-transition
+          (rf.machines/machine-transition
             m initial [:rf.machine.timer/after-elapsed 1000 1 []])]
       (is (= {:a :one :b :one} (:state snap)) "no region moved (action-only)")
       (is (= 1 (get-in snap [:data :fired])) "the root :after :action ran once"))))
@@ -422,7 +422,7 @@
           initial {:state {:a :one :b :one}
                    :data  {:rf/after-epoch {[] 1}}}
           {snap :snapshot}
-          (machines/machine-transition
+          (rf.machines/machine-transition
             m initial [:rf.machine.timer/after-elapsed 1000 1 []])]
       (is (= {:a :one :b :one} (:state snap))
           "guard false -> the root :after timer fires-and-discards; no region moved"))))
@@ -446,7 +446,7 @@
           initial {:state {:a :one :b :one}
                    :data  {:rf/after-epoch {[] 2}}}
           {snap :snapshot}
-          (machines/machine-transition
+          (rf.machines/machine-transition
             m initial [:rf.machine.timer/after-elapsed 1000 1 []])]
       (is (= {:a :one :b :one} (:state snap))
           "stale-epoch root :after dropped; no region moved (cancel-on-exit via epoch)"))))

--- a/implementation/machines/test/re_frame/parallel_test.clj
+++ b/implementation/machines/test/re_frame/parallel_test.clj
@@ -30,16 +30,16 @@
   (:require [clojure.edn :as edn]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 ;; ---- 1. flat two-region parallel machine — initial state map ------------
 
@@ -199,7 +199,7 @@
                                :states  {:x {:tags #{:right/x} :on {:flip :y}}
                                          :y {:tags #{:right/y}}}}}}
           initial {:state {:left :a :right :x} :data {} :tags #{:left/a :right/x}}
-          {snap1 :snapshot fx1 :fx} (machines/machine-transition m initial [:flip])]
+          {snap1 :snapshot fx1 :fx} (rf.machines/machine-transition m initial [:flip])]
       (is (= {:left :b :right :y} (:state snap1))
           "pure transition broadcasts to both regions")
       (is (= #{:left/b :right/y} (:tags snap1))
@@ -235,14 +235,14 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf.error/machine-parallel-bad-shape"
-          (machines/make-machine-handler {:type :parallel}))
+          (rf.machines/make-machine-handler {:type :parallel}))
         ":type :parallel requires :regions"))
 
   (testing ":type :parallel with :initial / :states is rejected at registration"
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf.error/machine-parallel-bad-shape"
-          (machines/make-machine-handler {:type :parallel
+          (rf.machines/make-machine-handler {:type :parallel
                                             :initial :foo
                                             :regions {:r {:initial :s :states {:s {}}}}}))
         ":type :parallel is mutually exclusive with :initial / :states at the root"))
@@ -251,7 +251,7 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf.error/machine-parallel-bad-shape"
-          (machines/make-machine-handler {:type :parallel
+          (rf.machines/make-machine-handler {:type :parallel
                                             :regions {:r {:states {:s {}}}}}))
         "each region body must declare :initial"))
 
@@ -259,7 +259,7 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf.error/machine-parallel-nested-not-supported"
-          (machines/make-machine-handler
+          (rf.machines/make-machine-handler
             {:type    :parallel
              :regions {:outer {:type    :parallel
                                :regions {:inner {:initial :s :states {:s {}}}}}}}))
@@ -269,7 +269,7 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf.error/machine-parallel-nested-not-supported"
-          (machines/make-machine-handler
+          (rf.machines/make-machine-handler
             {:type    :parallel
              :regions {:r {:initial :compound
                            :states  {:compound {:type    :parallel
@@ -314,7 +314,7 @@
              :regions {:a {:initial :one :states {:one {}}}
                        :b {:initial :two :states {:two {}}}}}]
       (rf/reg-machine :par/cache m)
-      (let [cached  (machines/machine-meta :par/cache)
+      (let [cached  (rf.machines/machine-meta :par/cache)
             first-a (re-frame.machines.parallel/region-machine cached :a)
             again-a (re-frame.machines.parallel/region-machine cached :a)
             first-b (re-frame.machines.parallel/region-machine cached :b)]

--- a/implementation/machines/test/re_frame/reduce_regions_test.clj
+++ b/implementation/machines/test/re_frame/reduce_regions_test.clj
@@ -12,7 +12,7 @@
       `[:rf.runtime/machines :spawned ...]` slot key stays unique per region.
 
   And the contract:
-   5. A `result/fail` from any region short-circuits the reduce — later
+   5. A `rf.machines.result/fail` from any region short-circuits the reduce — later
       regions don't run and the failure propagates verbatim.
 
   The helper is a `defn-` so the test reaches in via the var to invoke
@@ -20,13 +20,13 @@
   bootstrap-step / machine-transition step-fns the two production
   callers supply."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.result :as result]))
+            [re-frame.machines.parallel :as rf.machines.parallel]
+            [re-frame.machines.result :as rf.machines.result]))
 
 (def ^:private reduce-regions
   ;; Reach in to the private helper. This test isolates the broadcast
   ;; invariant from the two production step-fns.
-  #'parallel/reduce-regions)
+  #'rf.machines.parallel/reduce-regions)
 
 (defn- two-region-spec
   "Synthetic parallel-region spec — :a authored before :b."
@@ -52,7 +52,7 @@
           calls   (atom [])
           step    (fn [region-spec region-snap]
                     (swap! calls conj (:rf/region region-spec))
-                    (result/ok region-snap []))
+                    (rf.machines.result/ok region-snap []))
           snap    (snapshot {:a :a/idle :b :b/idle})
           r       (reduce-regions machine snap step)]
       (is (= :ok (:status r)))
@@ -67,9 +67,9 @@
           seen-data-by-b (atom nil)
           step    (fn [region-spec region-snap]
                     (case (:rf/region region-spec)
-                      :a (result/ok (assoc-in region-snap [:data :written-by] :a) [])
+                      :a (rf.machines.result/ok (assoc-in region-snap [:data :written-by] :a) [])
                       :b (do (reset! seen-data-by-b (:data region-snap))
-                             (result/ok region-snap []))))
+                             (rf.machines.result/ok region-snap []))))
           snap    (snapshot {:a :a/idle :b :b/idle} {:seed 1})
           r       (reduce-regions machine snap step)]
       (is (= :ok (:status r)))
@@ -86,9 +86,9 @@
           seen-counter-by-b (atom nil)
           step    (fn [region-spec region-snap]
                     (case (:rf/region region-spec)
-                      :a (result/ok (assoc region-snap :rf/spawn-counter {:ix 5}) [])
+                      :a (rf.machines.result/ok (assoc region-snap :rf/spawn-counter {:ix 5}) [])
                       :b (do (reset! seen-counter-by-b (:rf/spawn-counter region-snap))
-                             (result/ok (assoc region-snap :rf/spawn-counter {:ix 5 :iy 7}) []))))
+                             (rf.machines.result/ok (assoc region-snap :rf/spawn-counter {:ix 5 :iy 7}) []))))
           snap    (snapshot {:a :a/idle :b :b/idle} {} {})
           r       (reduce-regions machine snap step)]
       (is (= :ok (:status r)))
@@ -99,7 +99,7 @@
 
   (testing "absent :rf/spawn-counter stays absent (no defensive seeding)"
     (let [machine (two-region-spec)
-          step    (fn [_ region-snap] (result/ok region-snap []))
+          step    (fn [_ region-snap] (rf.machines.result/ok region-snap []))
           snap    (snapshot {:a :a/idle :b :b/idle})            ;; no :rf/spawn-counter
           r       (reduce-regions machine snap step)]
       (is (= :ok (:status r)))
@@ -113,7 +113,7 @@
     (let [machine (two-region-spec)
           step    (fn [region-spec region-snap]
                     (let [rn (:rf/region region-spec)]
-                      (result/ok region-snap
+                      (rf.machines.result/ok region-snap
                                  [[:rf.machine/spawn {:rf/invoke-id [rn :child]}]])))
           snap    (snapshot {:a :a/idle :b :b/idle})
           r       (reduce-regions machine snap step)]
@@ -133,12 +133,12 @@
   (testing "if region :a's step fails, region :b's step does NOT run"
     (let [machine (two-region-spec)
           b-ran?  (atom false)
-          fail-r  (result/fail {:reason :test-failure})
+          fail-r  (rf.machines.result/fail {:reason :test-failure})
           step    (fn [region-spec _region-snap]
                     (case (:rf/region region-spec)
                       :a fail-r
                       :b (do (reset! b-ran? true)
-                             (result/ok {:state :b/idle :data {}} []))))
+                             (rf.machines.result/ok {:state :b/idle :data {}} []))))
           snap    (snapshot {:a :a/idle :b :b/idle})
           r       (reduce-regions machine snap step)]
       (is (= :error (:status r)))

--- a/implementation/machines/test/re_frame/region_initial_desugar_test.clj
+++ b/implementation/machines/test/re_frame/region_initial_desugar_test.clj
@@ -22,13 +22,13 @@
   (the JVM plain-atom substrate the audit reproduced on)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (defn- scheduled-delays
   "The set of `:delay`s across all `:rf.machine.timer/scheduled` traces."

--- a/implementation/machines/test/re_frame/region_order_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/region_order_cljs_test.cljc
@@ -23,8 +23,8 @@
   lane's CLJS filter, and the CLJ/CLJS parity this file exists to pin had
   never once been checked on CLJS (rf2-lgozq)."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.result :as result]))
+            [re-frame.machines.parallel :as rf.machines.parallel]
+            [re-frame.machines.result :as rf.machines.result]))
 
 ;; ---- helpers --------------------------------------------------------------
 
@@ -35,7 +35,7 @@
 (defn- boot
   "Fresh initial snapshot for a parallel machine spec."
   [m]
-  (parallel/build-initial-snapshot m {:bootstrap-pending? false}))
+  (rf.machines.parallel/build-initial-snapshot m {:bootstrap-pending? false}))
 
 (defn- go-machine
   "A parallel machine whose regions are exactly `order` (a vector of region
@@ -96,7 +96,7 @@
   (testing ">8 regions (computed :regions): shared :data accumulates in
             DECLARATION order r0..r9, NOT :regions hash order"
     (let [m (go-machine r10 true)
-          r (parallel/machine-transition m (boot m) [:go])]
+          r (rf.machines.parallel/machine-transition m (boot m) [:go])]
       (is (= :ok (:status r)))
       (is (instance? #?(:clj clojure.lang.PersistentHashMap
                         :cljs cljs.core/PersistentHashMap)
@@ -108,7 +108,7 @@
 (deftest action-data-order-preserved-literal
   (testing ">8 regions (LITERAL :regions map): shared :data accumulates in
             DECLARATION order r0..r9"
-    (let [r (parallel/machine-transition literal-ten (boot literal-ten) [:go])]
+    (let [r (rf.machines.parallel/machine-transition literal-ten (boot literal-ten) [:go])]
       (is (= :ok (:status r)))
       (is (= r10 (get-in (:snapshot r) [:data :order]))))))
 
@@ -117,9 +117,9 @@
 (deftest cascade-region-order-preserved
   (testing ">8 regions: cascade steps are concatenated in declaration order"
     (let [m (go-machine r10 true)
-          r (parallel/machine-transition m (boot m) [:go])]
+          r (rf.machines.parallel/machine-transition m (boot m) [:go])]
       (is (= :ok (:status r)))
-      (is (= r10 (vec (distinct (keep :region (result/cascade r)))))
+      (is (= r10 (vec (distinct (keep :region (rf.machines.result/cascade r)))))
           "distinct region sequence across cascade steps is authored r0..r9"))))
 
 ;; ---- 3. fx order ----------------------------------------------------------
@@ -127,7 +127,7 @@
 (deftest fx-order-preserved
   (testing ">8 regions: per-region fx accumulate in declaration order"
     (let [m (go-machine r10 true)
-          r (parallel/machine-transition m (boot m) [:go])]
+          r (rf.machines.parallel/machine-transition m (boot m) [:go])]
       (is (= :ok (:status r)))
       (is (= (mapv (fn [rn] [:noted rn]) r10) (noted-fx r))
           "emitted [:noted rN] fx are ordered r0..r9"))))
@@ -143,7 +143,7 @@
                                        :states  {:idle {:spawn {:machine-id rn}}}}]))
                         order)
           m       {:type :parallel :data {} :region-order order :regions regions}
-          r       (parallel/apply-initial-entry-cascade m (boot m))
+          r       (rf.machines.parallel/apply-initial-entry-cascade m (boot m))
           spawned (->> (:fx r)
                        (filterv #(= :rf.machine/spawn (first %)))
                        (mapv #(:machine-id (second %))))]
@@ -166,7 +166,7 @@
                         order)
           m       {:type :parallel :data {:birth []} :region-order order
                    :actions actions :regions regions}
-          r       (parallel/apply-initial-entry-cascade m (boot m))]
+          r       (rf.machines.parallel/apply-initial-entry-cascade m (boot m))]
       (is (= :ok (:status r)))
       (is (= order (get-in (:snapshot r) [:data :birth]))
           "birth entry-action order is authored r0..r9"))))
@@ -187,7 +187,7 @@
                         order)
           m       {:type :parallel :data {:exit []} :region-order order
                    :actions actions :regions regions}
-          r       (parallel/run-active-exit-cascade m (boot m))]
+          r       (rf.machines.parallel/run-active-exit-cascade m (boot m))]
       (is (= :ok (:status r)))
       (is (= order (get-in (:snapshot r) [:data :exit]))
           "destroy exit-action order is authored r0..r9"))))
@@ -213,7 +213,7 @@
           m       {:type :parallel :data {:entered []} :region-order order
                    :actions actions :regions regions
                    :on {:go {:target targets}}}
-          r       (parallel/machine-transition m (boot m) [:go])]
+          r       (rf.machines.parallel/machine-transition m (boot m) [:go])]
       (is (= :ok (:status r)))
       (is (= (into {} (map (fn [rn] [rn :two])) order)
              (:state (:snapshot r)))
@@ -229,15 +229,15 @@
     (let [fwd (go-machine r10 true)
           rev-order (vec (reverse r10))
           rev (go-machine rev-order true)
-          rf  (parallel/machine-transition fwd (boot fwd) [:go])
-          rr  (parallel/machine-transition rev (boot rev) [:go])]
+          rf  (rf.machines.parallel/machine-transition fwd (boot fwd) [:go])
+          rr  (rf.machines.parallel/machine-transition rev (boot rev) [:go])]
       (is (= r10 (get-in (:snapshot rf) [:data :order])))
       (is (= rev-order (get-in (:snapshot rr) [:data :order]))
           "apply order follows the declared :region-order")
       (is (= (:state (:snapshot rf)) (:state (:snapshot rr)))
           "the selected / committed state is IDENTICAL regardless of order")
-      (is (= (set r10) (set (keep :region (result/cascade rf)))
-             (set (keep :region (result/cascade rr))))
+      (is (= (set r10) (set (keep :region (rf.machines.result/cascade rf)))
+             (set (keep :region (rf.machines.result/cascade rr))))
           "the SET of regions that fired is identical — selection is
            declaration-order-independent"))))
 
@@ -250,7 +250,7 @@
           #?(:clj Exception :cljs js/Error)
           #":rf.error/machine-parallel-region-order-required"
           (let [m (go-machine r10 false)]
-            (parallel/machine-transition m {:state {} :data {}} [:go]))))))
+            (rf.machines.parallel/machine-transition m {:state {} :data {}} [:go]))))))
 
 ;; ---- 10. registration outcome: mismatched :region-order rejected ----------
 
@@ -262,21 +262,21 @@
         (is (thrown-with-msg?
               #?(:clj Exception :cljs js/Error)
               #":rf.error/machine-parallel-region-order-mismatch"
-              (parallel/machine-transition
+              (rf.machines.parallel/machine-transition
                 (assoc base :region-order (vec (butlast r10)))
                 {:state {} :data {}} [:go]))))
       (testing "an extra (non-declared) region"
         (is (thrown-with-msg?
               #?(:clj Exception :cljs js/Error)
               #":rf.error/machine-parallel-region-order-mismatch"
-              (parallel/machine-transition
+              (rf.machines.parallel/machine-transition
                 (assoc base :region-order (conj r10 :r99))
                 {:state {} :data {}} [:go]))))
       (testing "a duplicate region"
         (is (thrown-with-msg?
               #?(:clj Exception :cljs js/Error)
               #":rf.error/machine-parallel-region-order-mismatch"
-              (parallel/machine-transition
+              (rf.machines.parallel/machine-transition
                 (assoc base :region-order (assoc r10 9 :r0))  ; :r9 → dup :r0
                 {:state {} :data {}} [:go])))))))
 
@@ -299,9 +299,9 @@
                         :cljs cljs.core/PersistentArrayMap)
                      (:regions m))
           "a 3-entry :regions literal is an order-preserving array-map")
-      (is (= [:a :b :c] (parallel/region-order m))
+      (is (= [:a :b :c] (rf.machines.parallel/region-order m))
           "region-order is derived from the array-map's insertion order")
-      (let [r (parallel/machine-transition m (boot m) [:go])]
+      (let [r (rf.machines.parallel/machine-transition m (boot m) [:go])]
         (is (= [:a :b :c] (get-in (:snapshot r) [:data :order])))))))
 
 ;; ---- 12. normalisation is idempotent --------------------------------------
@@ -309,7 +309,7 @@
 (deftest normalise-region-order-idempotent
   (testing "re-normalising a canonical machine is a no-op"
     (let [m  (go-machine r10 true)
-          m1 (parallel/normalise-region-order m)
-          m2 (parallel/normalise-region-order m1)]
+          m1 (rf.machines.parallel/normalise-region-order m)
+          m2 (rf.machines.parallel/normalise-region-order m1)]
       (is (= r10 (:region-order m1)))
       (is (identical? m1 m2) "second normalise returns the same value"))))

--- a/implementation/machines/test/re_frame/region_order_lifecycle_test.clj
+++ b/implementation/machines/test/re_frame/region_order_lifecycle_test.clj
@@ -12,13 +12,13 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (def ^:private r10
   (mapv #(keyword (str "r" %)) (range 10)))

--- a/implementation/machines/test/re_frame/root_after_non_parallel_test.clj
+++ b/implementation/machines/test/re_frame/root_after_non_parallel_test.clj
@@ -29,12 +29,12 @@
       rejected via the SAME error category too."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- registration-throws?
   "Try registering `machine` under `machine-id`. Returns the ExceptionInfo
@@ -98,14 +98,14 @@
                        :b {}}}]
       (rf/reg-machine :rf.root-after-np/plain m)
       (rf/dispatch-sync [:rf.root-after-np/plain [:go]])
-      (is (= :b (:state (mtest/snapshot :rf.root-after-np/plain)))
+      (is (= :b (:state (rf.machines.test-support/snapshot :rf.root-after-np/plain)))
           "unaffected machine transitions normally"))))
 
 ;; ---- (5) sanity: a :type :parallel root's :after is UNAFFECTED ------------
 
 (deftest parallel-root-after-still-registers
   (testing "a :type :parallel root's :after is NOT rejected — it is the supported feature"
-    (is (nil? (machines/validate-machine!
+    (is (nil? (rf.machines/validate-machine!
                 {:type    :parallel
                  :after   {1000 {:target [:a :two]}}
                  :regions {:a {:initial :one :states {:one {} :two {}}}
@@ -165,7 +165,7 @@
 
 (deftest region-state-after-still-registers
   (testing "an :after on a region STATE (not the region root) is unaffected"
-    (is (nil? (machines/validate-machine!
+    (is (nil? (rf.machines/validate-machine!
                 {:type    :parallel
                  :regions {:left {:initial :a
                                  :states  {:a {:after {5000 {:target :b}}}

--- a/implementation/machines/test/re_frame/root_on_target_validation_test.clj
+++ b/implementation/machines/test/re_frame/root_on_target_validation_test.clj
@@ -22,12 +22,12 @@
       this addition."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- registration-throws?
   "Try registering `machine` under `machine-id`. Returns the ExceptionInfo
@@ -90,17 +90,17 @@
                        :signed-out {}}}]
       (rf/reg-machine :rf.root-on-tv/valid m)
       (rf/dispatch-sync [:rf.root-on-tv/valid [:next]])
-      (is (= :b (:state (mtest/snapshot :rf.root-on-tv/valid)))
+      (is (= :b (:state (rf.machines.test-support/snapshot :rf.root-on-tv/valid)))
           "(precondition) local :on transition still works")
       (rf/dispatch-sync [:rf.root-on-tv/valid [:logout]])
-      (is (= :signed-out (:state (mtest/snapshot :rf.root-on-tv/valid)))
+      (is (= :signed-out (:state (rf.machines.test-support/snapshot :rf.root-on-tv/valid)))
           "the root :on ancestor fallback fired from ANY state, landing on the top-level target"))))
 
 ;; ---- (5) a parallel root's :on is unaffected (validate-parallel!'s job) ---
 
 (deftest parallel-root-on-unaffected-by-this-check
   (testing "a :type :parallel root's region-qualified :on still validates via validate-parallel!, not this new check"
-    (is (nil? (machines/validate-machine!
+    (is (nil? (rf.machines/validate-machine!
                 {:type    :parallel
                  :on      {:go-all {:target [[:a :two] [:b :two]]}}
                  :regions {:a {:initial :one :states {:one {} :two {}}}

--- a/implementation/machines/test/re_frame/scxml_conformance_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/scxml_conformance_cljs_test.cljc
@@ -121,9 +121,9 @@
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing]]
       :cljs [cljs.test :refer-macros [deftest is testing]])
-   [re-frame.machines :as machines]
-   [re-frame.machines.transition :as transition]
-   [re-frame.machines.lifecycle-fx.finalize :as finalize])
+   [re-frame.machines :as rf.machines]
+   [re-frame.machines.transition :as rf.machines.transition]
+   [re-frame.machines.lifecycle-fx.finalize :as rf.machines.lifecycle-fx.finalize])
   #?(:clj (:import [clojure.lang ExceptionInfo])))
 
 ;; ---------------------------------------------------------------------------
@@ -142,7 +142,7 @@
   emitted fx vector, and (for convenience) the snapshot's `:state` /
   `:data` / `:tags`."
   [machine snapshot event]
-  (let [r (machines/machine-transition machine snapshot event)]
+  (let [r (rf.machines/machine-transition machine snapshot event)]
     {:snapshot (:snapshot r)
      :fx       (vec (:fx r))
      :state    (:state (:snapshot r))
@@ -438,7 +438,7 @@
           ;; First :fin: both regions reach :done in one broadcast.
           both (step m {:state {:left :run :right :run} :data {}} [:fin])]
       (is (= {:left :done :right :done} (:state both)))
-      (is (true? (finalize/all-regions-final? m (:state both)))
+      (is (true? (rf.machines.lifecycle-fx.finalize/all-regions-final? m (:state both)))
           "every region's leaf is :final? ⇒ the parallel machine is done"))))
 
 (deftest scxml-parallel-NOT-done-when-one-region-pending
@@ -452,7 +452,7 @@
           ;; Only :left reaches :done; :right is still :run.
           left-only (step m {:state {:left :run :right :run} :data {}} [:fin-left])]
       (is (= {:left :done :right :run} (:state left-only)))
-      (is (false? (finalize/all-regions-final? m (:state left-only)))
+      (is (false? (rf.machines.lifecycle-fx.finalize/all-regions-final? m (:state left-only)))
           "one region still pending ⇒ the parallel machine is NOT done"))))
 
 (deftest scxml-parallel-region-ancestor-restart-is-region-local
@@ -986,7 +986,7 @@
     (let [m {:initial :a :data {}
              :actions {:boom (fn [_] (throw (ex-info "unknown event" {})))}
              :states  {:a {:on {:* {:target :a :action :boom}}}}}
-          r (machines/machine-transition m {:state :a :data {}} [:surprise])]
+          r (rf.machines/machine-transition m {:state :a :data {}} [:surprise])]
       (is (= :error (:status r))
           "a throwing `:*` action produces a failure Result (no silent no-op)"))))
 
@@ -1007,7 +1007,7 @@
             Spec 005 §Transition resolution — benign no-op."
     (let [m {:initial :a :data {:k 1}
              :states  {:a {:on {:real :b}} :b {}}}
-          r (machines/machine-transition m {:state :a :data {:k 1}} [:never-declared])]
+          r (rf.machines/machine-transition m {:state :a :data {:k 1}} [:never-declared])]
       (is (= :ok (:status r)) "an unhandled event is NOT a failure")
       (is (= :a (:state (step m {:state :a :data {:k 1}} [:never-declared])))
           "configuration is unchanged")
@@ -1547,9 +1547,9 @@
                        :done {:final? true}}}
           r (step m {:state :run :data {}} [:finish])]
       (is (= :done (:state r)) "transition into the final leaf")
-      (is (true? (transition/final-on-leaf? m (:state r)))
+      (is (true? (rf.machines.transition/final-on-leaf? m (:state r)))
           "the active leaf is recognised as final (raises done.state)")
-      (is (false? (transition/final-on-leaf? m :run))
+      (is (false? (rf.machines.transition/final-on-leaf? m :run))
           "a non-final leaf is not final"))))
 
 (deftest scxml-final-leaf-compound
@@ -1562,10 +1562,10 @@
                                            :done {:final? true}}}}}
           r (step m {:state [:wrapper :run] :data {}} [:finish])]
       (is (= [:wrapper :done] (:state r)) "transition into the nested final leaf")
-      (is (true? (transition/final-on-leaf? m (:state r)))
+      (is (true? (rf.machines.transition/final-on-leaf? m (:state r)))
           "the nested [:wrapper :done] leaf is final")
-      (is (false? (transition/final-state-node?
-                    (transition/node-at m [:wrapper])))
+      (is (false? (rf.machines.transition/final-state-node?
+                    (rf.machines.transition/node-at m [:wrapper])))
           "the compound :wrapper ancestor is NOT itself final (leaf-only property)"))))
 
 ;; ===========================================================================
@@ -1602,7 +1602,7 @@
   no frame."
   [machine]
   (try
-    (machines/validate-machine! machine)
+    (rf.machines/validate-machine! machine)
     ::no-throw
     (catch #?(:clj ExceptionInfo :cljs :default) e
       (:rf.error/id (ex-data e)))))

--- a/implementation/machines/test/re_frame/scxml_irp_semantic_core_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/scxml_irp_semantic_core_cljs_test.cljc
@@ -161,8 +161,8 @@
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing]]
       :cljs [cljs.test :refer-macros [deftest is testing]])
-   [re-frame.machines :as machines]
-   [re-frame.machines.transition :as transition]))
+   [re-frame.machines :as rf.machines]
+   [re-frame.machines.transition :as rf.machines.transition]))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness — the pure engine surface (mirrors the sibling corpus file).
@@ -173,7 +173,7 @@
   `machine-transition` engine. Returns the post-macrostep snapshot, the
   emitted fx vector, and the snapshot's `:state` / `:data`."
   [machine snapshot event]
-  (let [r (machines/machine-transition machine snapshot event)]
+  (let [r (rf.machines/machine-transition machine snapshot event)]
     {:snapshot (:snapshot r)
      :fx       (vec (:fx r))
      :state    (:state (:snapshot r))
@@ -434,7 +434,7 @@
     (let [m {:initial :a :data {}
              :states {:a {:on {:go :b}}
                       :b {:entry (fn [_] (throw (ex-info "onentry boom" {})))}}}
-          r (machines/machine-transition m {:state :a :data {}} [:go])]
+          r (rf.machines/machine-transition m {:state :a :data {}} [:go])]
       (is (= :error (:status r))
           "a throwing :entry action produces a failure Result (no partial commit) — re-frame2's single-block divergence from SCXML 376/378 independent-block isolation"))))
 
@@ -467,13 +467,13 @@
                       :done {:final? true}}}
           r (step m {:state :run :data {}} [:finish])]
       (is (= :done (:state r)) "transitioned into the top-level final leaf")
-      (is (true? (transition/top-level-final? m (:state r)))
+      (is (true? (rf.machines.transition/top-level-final? m (:state r)))
           "a top-level :final? leaf IS whole-machine finality (415 — root final halts)")
-      (is (true? (transition/final-on-leaf? m (:state r)))
+      (is (true? (rf.machines.transition/final-on-leaf? m (:state r)))
           "the active leaf is also final (final-on-leaf? agrees on a top-level final)")
-      (is (false? (transition/top-level-final? m :run))
+      (is (false? (rf.machines.transition/top-level-final? m :run))
           "a non-final leaf is not machine-final")
-      (is (false? (transition/final-on-leaf? m :run))
+      (is (false? (rf.machines.transition/final-on-leaf? m :run))
           "a non-final leaf is not a final leaf"))))
 
 (deftest scxml-irp-test415-embedded-final-is-not-machine-final
@@ -494,9 +494,9 @@
           r (step m {:state [:work :step1] :data {}} [:finish])]
       (is (= [:work :step-done] (:state r))
           "transitioned into the embedded final leaf (still inside :work)")
-      (is (true? (transition/final-on-leaf? m (:state r)))
+      (is (true? (rf.machines.transition/final-on-leaf? m (:state r)))
           "final-on-leaf? is TRUE — the active leaf :step-done is :final?")
-      (is (false? (transition/top-level-final? m (:state r)))
+      (is (false? (rf.machines.transition/top-level-final? m (:state r)))
           "top-level-final? is FALSE — an embedded final is compound-done, NOT
            whole-machine finality (the predicates DIVERGE here — this is the
            root-vs-embedded distinction test415 claims to prove)"))))

--- a/implementation/machines/test/re_frame/snapshot_compat_test.clj
+++ b/implementation/machines/test/re_frame/snapshot_compat_test.clj
@@ -17,29 +17,29 @@
   `:rf/after-epoch`, region-scoped epochs) reset with the snapshot."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace :as rf.trace]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; snapshot lookup via the shared machines test-support. The bespoke
 ;; `capture-error-traces` below stays local — it is an intentional
 ;; manual-stop idiom (returns a `:stop!` thunk the call sites invoke
 ;; explicitly) rather than a `finally`-scoped block.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (defn- capture-error-traces []
   (let [captured (atom [])
         cb-id    (gensym "snapshot-compat-test")]
-    (trace/register-listener! cb-id
+    (rf.trace/register-listener! cb-id
                               (fn [ev]
                                 (when (= :error (:op-type ev))
                                   (swap! captured conj ev))))
     {:captured captured
-     :stop!    #(trace/unregister-listener! cb-id)}))
+     :stop!    #(rf.trace/unregister-listener! cb-id)}))
 
 ;; ---- (3) state-not-in-definition -----------------------------------------
 
@@ -59,7 +59,7 @@
         ;; Seed an incompatible snapshot directly — a state that's no
         ;; longer in `:states`. Mirrors a hot-reload that dropped a
         ;; state while the snapshot was still live.
-        (frame/swap-runtime-db! :rf/default
+        (rf.frame/swap-runtime-db! :rf/default
                               assoc-in
                               [:rf.runtime/machines :snapshots :compat/m1]
                               {:state :gone
@@ -113,7 +113,7 @@
         ;; Seed a partial snapshot missing :right — :left already final.
         ;; Without strict key parity a snapshot missing :right could vacuously
         ;; read all-final and auto-destroy the machine with a region missing.
-        (frame/swap-runtime-db! :rf/default
+        (rf.frame/swap-runtime-db! :rf/default
                               assoc-in
                               [:rf.runtime/machines :snapshots :compat/par-missing]
                               {:state {:left :done} :data {:corrupt true}})
@@ -140,7 +140,7 @@
       (try
         (rf/reg-machine :compat/par-extra spec)
         ;; Seed a snapshot with a stale :middle region a hot reload removed.
-        (frame/swap-runtime-db! :rf/default
+        (rf.frame/swap-runtime-db! :rf/default
                               assoc-in
                               [:rf.runtime/machines :snapshots :compat/par-extra]
                               {:state {:left :run :right :run :middle :run} :data {}})
@@ -176,7 +176,7 @@
         (rf/reg-machine :compat/hist spec)
         ;; Seed a snapshot occupying the history pseudo-state — node-at
         ;; resolves it, but it is never occupiable.
-        (frame/swap-runtime-db! :rf/default
+        (rf.frame/swap-runtime-db! :rf/default
                               assoc-in
                               [:rf.runtime/machines :snapshots :compat/hist]
                               {:state [:playing :hist] :data {:stale true}})
@@ -207,7 +207,7 @@
         ;; Seed an old-version snapshot — `:state` is otherwise valid
         ;; in the new definition (so we're isolating version-check
         ;; from state-not-in-definition).
-        (frame/swap-runtime-db! :rf/default
+        (rf.frame/swap-runtime-db! :rf/default
                               assoc-in
                               [:rf.runtime/machines :snapshots :compat/m2]
                               {:state :idle
@@ -267,7 +267,7 @@
         (rf/reg-machine :compat/m4 spec)
         ;; Seed a snapshot whose version matches and whose :state is
         ;; in the definition.
-        (frame/swap-runtime-db! :rf/default
+        (rf.frame/swap-runtime-db! :rf/default
                               assoc-in
                               [:rf.runtime/machines :snapshots :compat/m4]
                               {:state :idle

--- a/implementation/machines/test/re_frame/spawn_all_address_collision_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/spawn_all_address_collision_cljs_test.cljc
@@ -40,7 +40,7 @@
    ;; Loading the machines facade registers `rf/reg-machine` + the reserved
    ;; machine fxs when this ns runs alone.
    [re-frame.machines]
-   [re-frame.machines.test-support :as mtest]
+   [re-frame.machines.test-support :as rf.machines.test-support]
    ;; The schemas artefact ships the registered-validator hot path the
    ;; `:where :machine-data` boundary routes through; the `.malli` adapter
    ;; publishes Malli's validate/explain into the late-bind table. Needed by
@@ -48,14 +48,14 @@
    ;; child's `[:schemas :data]` validator at all.
    [re-frame.schemas]
    [re-frame.schemas.malli]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
+  rf.machines.test-support/trace-capture-fixture)
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures under test.
@@ -81,13 +81,13 @@
     :ready   {}}})
 
 (defn- join-slot [parent-id]
-  (get-in (mtest/runtime-db) [:rf.runtime/machines :spawned parent-id [:forking]]))
+  (get-in (rf.machines.test-support/runtime-db) [:rf.runtime/machines :spawned parent-id [:forking]]))
 
 (defn- snap-of [actor-id]
-  (get-in (mtest/runtime-db) [:rf.runtime/machines :snapshots actor-id]))
+  (get-in (rf.machines.test-support/runtime-db) [:rf.runtime/machines :snapshots actor-id]))
 
 (defn- collision-rejects []
-  (mtest/events-of :rf.error/machine-spawn-all-duplicate-id))
+  (rf.machines.test-support/events-of :rf.error/machine-spawn-all-duplicate-id))
 
 ;; ---------------------------------------------------------------------------
 ;; Ordering probes (rf2-ri19s).
@@ -108,7 +108,7 @@
   ONLY entry."
   []
   (into [] (comp (map :operation) (filter reject-operations))
-        (or (mtest/captured-events) [])))
+        (or (rf.machines.test-support/captured-events) [])))
 
 (def ^:private validator-calls
   "Counts every invocation of the counting child validator below, so the ORDER

--- a/implementation/machines/test/re_frame/spawn_all_authoritative_preflight_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/spawn_all_authoritative_preflight_cljs_test.cljc
@@ -49,20 +49,20 @@
    ;; Loading the machines facade registers `rf/reg-machine` + the reserved
    ;; machine fxs when this ns runs alone.
    [re-frame.machines]
-   [re-frame.machines.test-support :as mtest]
+   [re-frame.machines.test-support :as rf.machines.test-support]
    ;; The schemas artefact ships the registered-validator hot path the
    ;; `:where :machine-data` boundary routes through; the `.malli` adapter
    ;; publishes Malli's validate/explain into the late-bind table.
    [re-frame.schemas]
    [re-frame.schemas.malli]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
+  rf.machines.test-support/trace-capture-fixture)
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures under test.
@@ -98,14 +98,14 @@
     :ready   {}}})
 
 (defn- join-slot [parent-id]
-  (get-in (mtest/runtime-db) [:rf.runtime/machines :spawned parent-id [:forking]]))
+  (get-in (rf.machines.test-support/runtime-db) [:rf.runtime/machines :spawned parent-id [:forking]]))
 
 (defn- snap-of [actor-id]
-  (get-in (mtest/runtime-db) [:rf.runtime/machines :snapshots actor-id]))
+  (get-in (rf.machines.test-support/runtime-db) [:rf.runtime/machines :snapshots actor-id]))
 
 (defn- spawn-phase-failures []
   (filterv #(= :spawn (get-in % [:tags :phase]))
-           (mtest/events-of :rf.error/schema-validation-failure)))
+           (rf.machines.test-support/events-of :rf.error/schema-validation-failure)))
 
 ;; ===========================================================================
 ;; (1) Validator cardinality — the accepted per-child install does NOT
@@ -199,11 +199,11 @@
     ;; consumed the prepared v1 rather than re-resolving/re-validating v2 (which
     ;; would have omitted the snapshot, stranding an impossible half-live join).
     (is (seq (filterv #(= :sa/strict#1 (get-in % [:tags :spawned-id]))
-                      (mtest/events-of :rf.machine.lifecycle/spawned)))
+                      (rf.machines.test-support/events-of :rf.machine.lifecycle/spawned)))
         "the child's install COMMITTED (a lifecycle/spawned trace fired) — a second verdict did not omit it")
     (is (some? (snap-of :sa/strict#1))
         "the child's snapshot INSTALLED — the install consumed the preflight's prepared v1")
-    (is (= :running (mtest/machine-state :sa/strict#1))
+    (is (= :running (rf.machines.test-support/machine-state :sa/strict#1))
         "the installed snapshot is v1's (state :running) — the prepared result was consumed verbatim, not re-derived from v2")))
 
 ;; ===========================================================================

--- a/implementation/machines/test/re_frame/spawn_all_authority_catalogue_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_authority_catalogue_test.clj
@@ -56,40 +56,40 @@
             [clojure.test :refer [deftest is testing use-fixtures]]
             [malli.core :as m]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
+            [re-frame.error-emit :as rf.error-emit]
             ;; load the machines artefact so its fx handlers + late-bind
             ;; hooks are installed when this ns runs in isolation.
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.spawn-all-schema-extract :as extract]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.spawn-all-schema-extract :as rf.spawn-all-schema-extract]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      ;; the reject fixture fans an always-on `:rf.error/machine-spawn-
      ;; unregistered-type` record; clear the always-on listener registry so a
      ;; leaked listener from an earlier test cannot see it.
-     :init-fn (fn [] (error-emit/clear-error-listeners!))})
-  mtest/trace-capture-fixture)
+     :init-fn (fn [] (rf.error-emit/clear-error-listeners!))})
+  rf.machines.test-support/trace-capture-fixture)
 
 ;; The canonical `:spawn-all` runtime-db schema forms, EXTRACTED from
 ;; spec/Spec-Schemas.md (rf2-2ai15g) — NOT hand-copied. Removing / renaming a
 ;; def, or weakening `:rf/attempt` to `{:optional true}`, or dropping the
 ;; `InvokeAllRejectedState` arm from the markdown is a test-build / assertion
 ;; failure here, so the schema surface and the document cannot drift silently.
-(def ^:private InvokeAllJoinState     (extract/canonical-invoke-all-join-schema))
-(def ^:private InvokeAllRejectedState (extract/canonical-invoke-all-rejected-schema))
-(def ^:private SpawnedSlot            (extract/canonical-spawned-slot-schema))
-(def ^:private Machines               (extract/canonical-machines-schema))
+(def ^:private InvokeAllJoinState     (rf.spawn-all-schema-extract/canonical-invoke-all-join-schema))
+(def ^:private InvokeAllRejectedState (rf.spawn-all-schema-extract/canonical-invoke-all-rejected-schema))
+(def ^:private SpawnedSlot            (rf.spawn-all-schema-extract/canonical-spawned-slot-schema))
+(def ^:private Machines               (rf.spawn-all-schema-extract/canonical-machines-schema))
 
 (defn- machines-runtime-db
   "The frame's live `:rf.runtime/machines` runtime-db partition value."
   []
-  (get (mtest/runtime-db) :rf.runtime/machines))
+  (get (rf.machines.test-support/runtime-db) :rf.runtime/machines))
 
 (defn- join-state [parent-id invoke-id]
-  (get-in (mtest/runtime-db)
+  (get-in (rf.machines.test-support/runtime-db)
           [:rf.runtime/machines :spawned parent-id invoke-id]))
 
 (defn- mk-child
@@ -321,11 +321,11 @@
         ;; a LATE exact-current completion carrier for :a cannot resurrect
         ;; it. The coordinate rides the recordable `:rf.cofx` slot
         ;; (rf2-nsbwft — the metadata slot is not read).
-        (mtest/reset-captured!)
+        (rf.machines.test-support/reset-captured!)
         (rf/dispatch-sync [:sac/tomb [:child/done :a]]
                           {:rf.cofx {:rf.machine/join-attempt attempt}})
         (let [after (join-state :sac/tomb [:racing])
-              stale (first (mtest/events-of :rf.machine.spawn-all/stale-completion))]
+              stale (first (rf.machines.test-support/events-of :rf.machine.spawn-all/stale-completion))]
           (is (= #{} (:done after))
               "the late exact-attempt carrier did NOT fold — :a is never marked done")
           (is (= #{:a} (:cancelled after))
@@ -366,13 +366,13 @@
                          :spawned-id a
                          :attempt    (:rf/attempt j)}]
       (is (= #{} (:done j)) "precondition: child :a has not completed")
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       ;; Present the exact-current coordinate on event-vector metadata — the
       ;; pre-fix metadata fallback read it; the fence no longer does.
       (rf/dispatch-sync [:sac/forge (with-meta [:child/done :a]
                                       {:rf/join-attempt exact-current})])
       (let [after (join-state :sac/forge [:racing])
-            stale (first (mtest/events-of :rf.machine.spawn-all/stale-completion))]
+            stale (first (rf.machines.test-support/events-of :rf.machine.spawn-all/stale-completion))]
         (is (= #{} (:done after))
             "the metadata-borne coordinate folded NOTHING (slot not read)")
         (is (false? (:resolved? after))
@@ -464,7 +464,7 @@
           a (get-in j [:children :a])]
       ;; A folds first — non-decisive in a two-child :all join.
       (rf/dispatch-sync [a [:go]])
-      (let [traces (mtest/events-of :rf.machine.spawn-all/child-completed)]
+      (let [traces (rf.machines.test-support/events-of :rf.machine.spawn-all/child-completed)]
         (is (= 1 (count traces)) "one child-completed fold trace for A")
         (let [tags        (:tags (first traces))
               correlation (:rf.reply/correlation tags)]
@@ -493,7 +493,7 @@
       ;; A resolves the :any join; the parent stays on :racing.
       (rf/dispatch-sync [a [:go]])
       (is (true? (:resolved? (join-state :sac/p3 [:racing]))) "the :any join resolved")
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       ;; :a's EXACT-CURRENT completion re-completes AFTER the :resolved? latch
       ;; flipped — the late-completion path is gated on the exact-attempt fence
       ;; (rf2-ixjd48), so the carrier presents the current attempt's coordinate
@@ -505,7 +505,7 @@
                                           :child-id   :a
                                           :spawned-id a
                                           :attempt    (:rf/attempt (join-state :sac/p3 [:racing]))}}})
-      (let [late (first (mtest/events-of :rf.machine.spawn-all/late-completion))]
+      (let [late (first (rf.machines.test-support/events-of :rf.machine.spawn-all/late-completion))]
         (is (some? late) "the late-completion op fired")
         (is (= :stale (:rf.reply/status (:tags late))))
         (is (= :suppressed (:rf.reply/work-status (:tags late))))
@@ -521,11 +521,11 @@
             against a drift back to the bare `:reason`."
     (reg-join-parent! :sac/p4 :sac/p4a :sac/p4b
                       {:join :all :on-all-complete [:all/done]})
-    (mtest/reset-captured!)
+    (rf.machines.test-support/reset-captured!)
     ;; A bare hand-dispatched completion never flowed through the member
     ;; child's boundary, so it carries no runtime `:rf/join-attempt` stamp.
     (rf/dispatch-sync [:sac/p4 [:child/done :a]])
-    (let [stale (first (mtest/events-of :rf.machine.spawn-all/stale-completion))]
+    (let [stale (first (rf.machines.test-support/events-of :rf.machine.spawn-all/stale-completion))]
       (is (some? stale) "the stale-completion op fired")
       (is (= :stale (:rf.reply/status (:tags stale))))
       (is (= :rf.machine.spawn-all/attempt-unverified
@@ -560,7 +560,7 @@
 (deftest spec-009-catalogue-pins-the-spawn-all-ops
   (testing "rf2-2ai15g — the authoritative Spec-009 rows carry the exact
             vocabulary the runtime emits; each fact fails independently."
-    (let [text (extract/spec-009-text)
+    (let [text (rf.spawn-all-schema-extract/spec-009-text)
           qidx (quick-index-row text)
           cc   (detailed-row text :rf.machine.spawn-all/child-completed)
           sc   (detailed-row text :rf.machine.spawn-all/stale-completion)]

--- a/implementation/machines/test/re_frame/spawn_all_init_incarnation_fence_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_init_incarnation_fence_test.clj
@@ -4,7 +4,7 @@
 
   `spawn-all-init-fx` captures an exact-incarnation `continue?` before the
   admission preflight, but on current main it wrote the reject sentinel and the
-  live join through a bare-id `frame/swap-runtime-db!` WITHOUT rechecking
+  live join through a bare-id `rf.frame/swap-runtime-db!` WITHOUT rechecking
   ownership after:
 
     - the preflight's `[:schemas :data]` validators (application code that can
@@ -34,26 +34,26 @@
   scoped to owner-loss only — the two live-owner controls)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.frame :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]
             ;; Loading the machines facade registers `rf/reg-machine` + the
             ;; reserved machine fxs when this ns runs alone.
             [re-frame.machines]
-            [re-frame.machines.lifecycle-fx.spawn :as spawn]
-            [re-frame.machines.paths :as paths]
-            [re-frame.machines.spawn-order :as spawn-order]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.lifecycle-fx.spawn :as rf.machines.lifecycle-fx.spawn]
+            [re-frame.machines.paths :as rf.machines.paths]
+            [re-frame.machines.spawn-order :as rf.machines.spawn-order]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 ;; Fresh registrar + plain-atom adapter per test; the always-on error-listener
 ;; registry (a `defonce` atom) cleared so an `:errors` listener from one test
 ;; cannot leak into the next.
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn (fn [] (error-emit/clear-error-listeners!))})
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
+     :init-fn (fn [] (rf.error-emit/clear-error-listeners!))})
+  rf.machines.test-support/trace-capture-fixture)
 
 ;; The opaque schema marker the strict child declares; the destroyer validator
 ;; keys on it. The schemas artefact is NOT loaded — the test provides the
@@ -101,7 +101,7 @@
      :child-args   (mapv child-arg children)}))
 
 (defn- join-slot [frame-a parent-id invoke-id]
-  (get-in (mtest/runtime-db frame-a) (paths/spawned-path parent-id invoke-id)))
+  (get-in (rf.machines.test-support/runtime-db frame-a) (rf.machines.paths/spawned-path parent-id invoke-id)))
 
 ;; ---- direct-invocation runner ---------------------------------------------
 
@@ -117,18 +117,18 @@
        A on the first `:rf.error/machine-spawn-unregistered-type` record.
   Returns observables read off B."
   [frame-a parent-id invoke-id children {:keys [trigger destroy?]}]
-  (spawn-order/reset-all!)
+  (rf.machines.spawn-order/reset-all!)
   (rf/make-frame {:id frame-a})
-  (let [token-a       (frame/frame-incarnation-token frame-a)
+  (let [token-a       (rf.frame/frame-incarnation-token frame-a)
         fired?        (atom false)
         records       (atom [])
         b-birth       (atom nil)
-        orig-validate (late-bind/get-fn :schemas/validate-with-registered-fn)
+        orig-validate (rf.late-bind/get-fn :schemas/validate-with-registered-fn)
         destroy+B!    (fn []
                         (when (and destroy? (compare-and-set! fired? false true))
-                          (frame/destroy-frame! frame-a)  ;; destroy A
+                          (rf.frame/destroy-frame! frame-a)  ;; destroy A
                           (rf/make-frame {:id frame-a})    ;; publish same-id B
-                          (reset! b-birth (mtest/runtime-db frame-a))))]
+                          (reset! b-birth (rf.machines.test-support/runtime-db frame-a))))]
     (rf/register-listener! :errors ::recorder
                            (fn [r]
                              (when (= :rf.error/machine-spawn-unregistered-type (:error r))
@@ -137,7 +137,7 @@
                                  (destroy+B!)))))
     (try
       (when (= :validator (:kind trigger))
-        (late-bind/set-fn! :schemas/validate-with-registered-fn
+        (rf.late-bind/set-fn! :schemas/validate-with-registered-fn
           (fn [schema _data]
             (when (= schema child-schema)
               (destroy+B!)
@@ -145,19 +145,19 @@
                 :throw (throw (ex-info "validator boom" {}))
                 :false false
                 true)))))
-      (frame/call-with-event-owner-token frame-a token-a
-        (fn [] (spawn/spawn-all-init-fx
+      (rf.frame/call-with-event-owner-token frame-a token-a
+        (fn [] (rf.machines.lifecycle-fx.spawn/spawn-all-init-fx
                  {:frame frame-a}
                  (init-args parent-id invoke-id children))))
       {:fired?     @fired?
        :records    @records
        :b-birth    @b-birth
-       :b-runtime  (mtest/runtime-db frame-a)
+       :b-runtime  (rf.machines.test-support/runtime-db frame-a)
        :join-slot  (join-slot frame-a parent-id invoke-id)
-       :started    (mtest/events-of :rf.machine.spawn-all/started)}
+       :started    (rf.machines.test-support/events-of :rf.machine.spawn-all/started)}
       (finally
         (rf/unregister-listener! :errors ::recorder)
-        (late-bind/set-fn! :schemas/validate-with-registered-fn orig-validate)))))
+        (rf.late-bind/set-fn! :schemas/validate-with-registered-fn orig-validate)))))
 
 (defn- assert-b-inert
   "The successor B carries NONE of A's derived spawn-all state: no join slot,

--- a/implementation/machines/test/re_frame/spawn_all_lifecycle_leak_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_lifecycle_leak_test.clj
@@ -26,15 +26,15 @@
             ;; (`:machines/reg-machine`, …) the tests below exercise — keep the
             ;; require even though the ns is reached only via `rf/...` facades.
             [re-frame.machines]
-            [re-frame.machines.spawn-order :as spawn-order]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.spawn-order :as rf.machines.spawn-order]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
-(def ^:private frame-db mtest/runtime-db)
-(def ^:private snapshot mtest/snapshot)
+(def ^:private frame-db rf.machines.test-support/runtime-db)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (defn- mk-child
   "A child that on :go / :fail transitions to a PLAIN (non-:final?) terminal
@@ -101,7 +101,7 @@
           "the sentinel carries no :children, so the join interceptor treats it as no live join")
       (is (= #{:qb/parent-a} (set (keys snaps)))
           "NO orphan: the ONLY snapshot is the parent's — the registered sibling never installed")
-      (is (= [] (spawn-order/frame-order :rf/default))
+      (is (= [] (rf.machines.spawn-order/frame-order :rf/default))
           "NO orphan: nothing recorded in spawn-order (the registered sibling was suppressed)")
       (is (= :hydrating (:state (snapshot :qb/parent-a)))
           "the parent rests on the (malformed) :spawn-all state — the config error to fix"))))

--- a/implementation/machines/test/re_frame/spawn_all_prepared_unregister_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/spawn_all_prepared_unregister_cljs_test.cljc
@@ -52,24 +52,24 @@
    ;; Loading the machines facade registers `rf/reg-machine` + the reserved
    ;; machine fxs when this ns runs alone.
    [re-frame.machines]
-   [re-frame.machines.test-support :as mtest]
+   [re-frame.machines.test-support :as rf.machines.test-support]
    ;; Unregister a machine TYPE mid-drain (from the child's own `[:schemas :data]`
    ;; validator) by dropping its `:event` registrar entry — the seam the recheck
    ;; tripped on.
-   [re-frame.registrar :as registrar]
+   [re-frame.registrar :as rf.registrar]
    ;; The schemas artefact ships the registered-validator hot path the
    ;; `:where :machine-data` boundary routes through; the `.malli` adapter
    ;; publishes Malli's validate/explain into the late-bind table.
    [re-frame.schemas]
    [re-frame.schemas.malli]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
+  rf.machines.test-support/trace-capture-fixture)
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures under test.
@@ -159,16 +159,16 @@
     :ready   {}}})
 
 (defn- join-slot [parent-id]
-  (get-in (mtest/runtime-db) [:rf.runtime/machines :spawned parent-id [:forking]]))
+  (get-in (rf.machines.test-support/runtime-db) [:rf.runtime/machines :spawned parent-id [:forking]]))
 
 (defn- snap-of [actor-id]
-  (get-in (mtest/runtime-db) [:rf.runtime/machines :snapshots actor-id]))
+  (get-in (rf.machines.test-support/runtime-db) [:rf.runtime/machines :snapshots actor-id]))
 
 (defn- unregistered-rejects []
-  (mtest/events-of :rf.error/machine-spawn-unregistered-type))
+  (rf.machines.test-support/events-of :rf.error/machine-spawn-unregistered-type))
 
 (defn- no-such-handler-errors []
-  (mtest/events-of :rf.error/no-such-handler))
+  (rf.machines.test-support/events-of :rf.error/no-such-handler))
 
 (defn- type-ref-of
   "The installed snapshot's revertible `:rf/machine-type` TYPE reference — the
@@ -196,7 +196,7 @@
             :rf.error/machine-spawn-unregistered-type reject fires (the pre-fix
             recheck rejected the child + stranded a snapshotless half-live join)."
     (let [child-a (mutating-child plain-child
-                                  #(registrar/unregister! :event :sa/plain-a))]
+                                  #(rf.registrar/unregister! :event :sa/plain-a))]
       (rf/reg-machine :sa/plain-a child-a)
       (rf/reg-machine :sa/plain-b plain-child)
       (rf/reg-machine :sup/unreg (parent-over [{:id :a :machine-id :sa/plain-a}
@@ -212,7 +212,7 @@
         (doseq [id (vals (:children slot))]
           (is (some? (snap-of id))
               (str "child " id " INSTALLED its prepared snapshot even though its TYPE was unregistered mid-drain"))
-          (is (= :running (mtest/machine-state id))
+          (is (= :running (rf.machines.test-support/machine-state id))
               (str "child " id " installed the PREPARED spec verbatim (state :running), not a re-derivation")))
         (is (= child-a (type-ref-of (get (:children slot) :a)))
             "the DIVERGED child pinned its prepared definition — the registrar no longer speaks for it")
@@ -233,9 +233,9 @@
             its prepared entry: the whole batch consumes its authoritative
             verdict; no reject, no partial install."
     (rf/reg-machine :sa/one (mutating-child plain-child
-                                            #(registrar/unregister! :event :sa/one)))
+                                            #(rf.registrar/unregister! :event :sa/one)))
     (rf/reg-machine :sa/two (mutating-child plain-child
-                                            #(registrar/unregister! :event :sa/two)))
+                                            #(rf.registrar/unregister! :event :sa/two)))
     (rf/reg-machine :sup/allunreg (parent-over [{:id :a :machine-id :sa/one}
                                                 {:id :b :machine-id :sa/two}]))
     (rf/dispatch-sync [:sup/allunreg [:start]])
@@ -294,7 +294,7 @@
                                               ;; the preflight→install window.
                                               (when-not @fired
                                                 (reset! fired true)
-                                                (registrar/unregister! :event :sa/counted))
+                                                (rf.registrar/unregister! :event :sa/counted))
                                               (pos-int? (:n v)))]}
                        :states  {:running {}}})
       (rf/reg-machine :sup/count1 (parent-over [{:id :c :machine-id :sa/counted}]))
@@ -353,7 +353,7 @@
             clears, no :rf.error/no-such-handler fires, and a LATER ordinary
             event still runs (:ready → :working)."
     (let [child (mutating-child booting-child
-                                #(registrar/unregister! :event :sa/boot))]
+                                #(rf.registrar/unregister! :event :sa/boot))]
       (rf/reg-machine :sa/boot child)
       (rf/reg-machine :sup/bootunreg (parent-over [{:id :c :machine-id :sa/boot}]))
       (rf/dispatch-sync [:sup/bootunreg [:start]])
@@ -362,7 +362,7 @@
             "the admitted child installed its prepared snapshot (rf2-v4oqd)")
         (is (= child (type-ref-of id))
             "the prepared definition is PINNED verbatim — the diverged registrar keyword is not the authority")
-        (is (= :ready (mtest/machine-state id))
+        (is (= :ready (rf.machines.test-support/machine-state id))
             "the child COMPLETED its synthetic bootstrap — it resolved a handler despite the mid-drain unregister")
         (is (not (:rf/bootstrap-pending? (snap-of id)))
             "the :rf/bootstrap-pending? marker cleared — the initial-entry cascade actually ran")
@@ -370,7 +370,7 @@
             "NO :rf.error/no-such-handler fired — the prepared child's definition rides its snapshot")
         ;; A LATER ordinary event executes against the same coherent definition.
         (rf/dispatch-sync [id [:go]])
-        (is (= :working (mtest/machine-state id))
+        (is (= :working (rf.machines.test-support/machine-state id))
             "a later ordinary event ran against the prepared definition too")
         (is (empty? (no-such-handler-errors))
             "still no :rf.error/no-such-handler after the ordinary event"))
@@ -399,12 +399,12 @@
       (let [id (get (:children (join-slot :sup/swap)) :c)]
         (is (= child (type-ref-of id))
             "the prepared v1 definition is pinned on the snapshot — the diverged registrar keyword is not the authority")
-        (is (= :ready (mtest/machine-state id))
+        (is (= :ready (rf.machines.test-support/machine-state id))
             "the child bootstrapped through the PREPARED v1 definition (:idle → :ready)")
-        (is (not= :v2-boot (mtest/machine-state id))
+        (is (not= :v2-boot (rf.machines.test-support/machine-state id))
             "the child did NOT resolve its handler from the unrelated current v2")
         (rf/dispatch-sync [id [:go]])
-        (is (= :working (mtest/machine-state id))
+        (is (= :working (rf.machines.test-support/machine-state id))
             "a later ordinary event ran against v1 too — one coherent authority, not a v1 snapshot on a v2 handler"))
       (is (empty? (no-such-handler-errors))
           "no :rf.error/no-such-handler fired"))))
@@ -426,12 +426,12 @@
     (let [child (get (:children (join-slot :sup/hot)) :c)]
       (is (= :sa/hot (type-ref-of child))
           "the undisturbed install kept the revertible TYPE keyword — no pinned definition copy")
-      (is (= :ready (mtest/machine-state child))
+      (is (= :ready (rf.machines.test-support/machine-state child))
           "the child bootstrapped through the registered definition")
       ;; Hot-reload the TYPE: `:go` now targets :hot-reloaded instead of :working.
       (rf/reg-machine :sa/hot booting-child-v2)
       (rf/dispatch-sync [child [:go]])
-      (is (= :hot-reloaded (mtest/machine-state child))
+      (is (= :hot-reloaded (rf.machines.test-support/machine-state child))
           "the live child picked up the hot-reloaded definition — hot-reload semantics preserved"))
     (is (empty? (no-such-handler-errors))
         "no :rf.error/no-such-handler fired")))
@@ -452,7 +452,7 @@
             pins its prepared definition and bootstraps to :ready, and exactly
             one collision trace fans for the invoke."
     (let [child-b (mutating-child booting-child
-                                  #(registrar/unregister! :event :sa/sys-b))]
+                                  #(rf.registrar/unregister! :event :sa/sys-b))]
       (rf/reg-machine :sa/sys-a booting-child)
       (rf/reg-machine :sa/sys-b child-b)
       (rf/reg-machine :sup/sys (parent-over
@@ -461,11 +461,11 @@
       (rf/dispatch-sync [:sup/sys [:start]])
       (let [slot  (join-slot :sup/sys)
             child (get (:children slot) :b)]
-        (is (= 1 (count (mtest/events-of :rf.error/system-id-collision)))
+        (is (= 1 (count (rf.machines.test-support/events-of :rf.error/system-id-collision)))
             "the shared :system-id fanned exactly one collision trace (the second child's install)")
         (is (= child-b (type-ref-of child))
             "the rebound child pinned its prepared definition")
-        (is (= :ready (mtest/machine-state child))
+        (is (= :ready (rf.machines.test-support/machine-state child))
             "the rebound child bootstrapped — it is live, not inert")
         (is (empty? (no-such-handler-errors))
             "no :rf.error/no-such-handler fired")))))

--- a/implementation/machines/test/re_frame/spawn_all_reply_envelope_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_reply_envelope_test.clj
@@ -23,13 +23,13 @@
   in the pure `machines-reply` test."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.reply :as m-reply]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.reply :as reply]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.reply :as rf.machines.reply]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.reply :as rf.reply]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- mk-child
   [parent-id done-event-kw error-event-kw]
@@ -55,7 +55,7 @@
 
 (deftest join-child-reply-is-canonical
   (testing "rf2-d63qtp — a done join-child reply is canonical :status :ok"
-    (let [r (m-reply/join-child-reply
+    (let [r (rf.machines.reply/join-child-reply
               {:parent-id :sup/all :invoke-id [:hydrating]
                :child-id :a :spawned-id :child/a#1
                :work-generation 1 :frame :rf/default}
@@ -67,9 +67,9 @@
       (is (= [:rf.work/machine :child/a#1 [:hydrating] 1] (:rf.reply/work-id r)))
       (is (= :a (-> r :correlation :child-id)))
       (is (= :child/a#1 (-> r :correlation :spawned-id)))
-      (is (reply/valid-reply? r) (str (reply/validate-reply r)))))
+      (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r)))))
   (testing "a failed join-child reply is canonical :status :error with family :kind"
-    (let [r (m-reply/join-child-reply
+    (let [r (rf.machines.reply/join-child-reply
               {:parent-id :sup/all :invoke-id [:hydrating]
                :child-id :b :spawned-id :child/b#1
                :work-generation 1 :frame :rf/default}
@@ -77,11 +77,11 @@
       (is (= :error (:status r)))
       (is (= :failed (:rf.reply/work-status r)))
       (is (some? (:kind (:error r))) ":error carries a family :kind")
-      (is (reply/valid-reply? r) (str (reply/validate-reply r))))))
+      (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r))))))
 
 (deftest stale-join-child-reply-is-canonical
   (testing "rf2-d63qtp — a post-resolution late join-child completion is :status :stale"
-    (let [r (m-reply/stale-join-child-reply
+    (let [r (rf.machines.reply/stale-join-child-reply
               {:parent-id :sup/all :invoke-id [:hydrating]
                :child-id :c :spawned-id :child/c#1
                :work-generation 1 :frame :rf/default}
@@ -92,7 +92,7 @@
       (is (= :suppressed (:rf.reply/work-status r)))
       (is (not (contains? r :value)) ":stale carries no :value (no app mutation)")
       (is (= [:rf.work/machine :child/c#1 [:hydrating] 1] (:rf.reply/work-id r)))
-      (is (reply/valid-reply? r) (str (reply/validate-reply r))))))
+      (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r))))))
 
 ;; ---- integration: resolution trace carries reply facts ----------------
 
@@ -119,7 +119,7 @@
       (rf/reg-machine :relp1/a child)
       (rf/reg-machine :relp1/b child)
       (rf/reg-machine :sup/relp1 parent)
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         (rf/dispatch-sync [:sup/relp1 [:start]])
         (rf/dispatch-sync [:relp1/a#1 [:go]])
         (rf/dispatch-sync [:relp1/b#1 [:go]])
@@ -158,7 +158,7 @@
       (rf/reg-machine :relp2/a child)
       (rf/reg-machine :relp2/b child)
       (rf/reg-machine :sup/relp2 parent)
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         (rf/dispatch-sync [:sup/relp2 [:start]])
         (rf/dispatch-sync [:relp2/a#1 [:fail]])
         (let [failed (->> @captured
@@ -196,9 +196,9 @@
       (rf/reg-machine :relp3/a child)
       (rf/reg-machine :relp3/b child)
       (rf/reg-machine :sup/relp3 parent)
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         (rf/dispatch-sync [:sup/relp3 [:start]])
-        (let [ids (get-in (mtest/runtime-db)
+        (let [ids (get-in (rf.machines.test-support/runtime-db)
                           [:rf.runtime/machines :spawned :sup/relp3 [:hydrating] :children])]
           ;; First child resolves the :any join.
           (rf/dispatch-sync [(:a ids) [:go]])
@@ -207,7 +207,7 @@
           ;; post-resolution late-completion — the fix gates that path on exact
           ;; authority, so the carrier is stamped for the current attempt
           ;; (rf2-ixjd48).
-          (let [j (get-in (mtest/runtime-db)
+          (let [j (get-in (rf.machines.test-support/runtime-db)
                           [:rf.runtime/machines :spawned :sup/relp3 [:hydrating]])]
             (rf/dispatch-sync
               [:sup/relp3 [:asset/loaded :a]]
@@ -288,9 +288,9 @@
       (rf/reg-machine :tjok/a child)
       (rf/reg-machine :tjok/b child)
       (rf/reg-machine :sup/tj-ok parent)
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         (rf/dispatch-sync [:sup/tj-ok [:start]])
-        (let [ids  (get-in (mtest/runtime-db)
+        (let [ids  (get-in (rf.machines.test-support/runtime-db)
                            [:rf.runtime/machines :spawned :sup/tj-ok [:racing] :children])
               a-id (:a ids)
               b-id (:b ids)]
@@ -341,9 +341,9 @@
       (rf/reg-machine :tjf/a child)
       (rf/reg-machine :tjf/b child)
       (rf/reg-machine :sup/tj-fail parent)
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         (rf/dispatch-sync [:sup/tj-fail [:start]])
-        (let [ids  (get-in (mtest/runtime-db)
+        (let [ids  (get-in (rf.machines.test-support/runtime-db)
                            [:rf.runtime/machines :spawned :sup/tj-fail [:racing] :children])
               a-id (:a ids)
               b-id (:b ids)]
@@ -386,9 +386,9 @@
       (rf/reg-machine :tja/a child)
       (rf/reg-machine :tja/b child)
       (rf/reg-machine :sup/tj-all parent)
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         (rf/dispatch-sync [:sup/tj-all [:start]])
-        (let [ids  (get-in (mtest/runtime-db)
+        (let [ids  (get-in (rf.machines.test-support/runtime-db)
                            [:rf.runtime/machines :spawned :sup/tj-all [:hydrating] :children])
               a-id (:a ids)
               b-id (:b ids)]
@@ -465,9 +465,9 @@
       (rf/reg-machine :evok/a child)
       (rf/reg-machine :evok/b child)
       (rf/reg-machine :sup/ev-ok parent)
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         (rf/dispatch-sync [:sup/ev-ok [:start]])
-        (let [a-id (get-in (mtest/runtime-db)
+        (let [a-id (get-in (rf.machines.test-support/runtime-db)
                            [:rf.runtime/machines :spawned :sup/ev-ok [:racing] :children :a])]
           ;; :a completes → :any resolves; :a (live, non-final) is reaped.
           (rf/dispatch-sync [a-id [:go]])
@@ -505,9 +505,9 @@
       (rf/reg-machine :evf/a child)
       (rf/reg-machine :evf/b child)
       (rf/reg-machine :sup/ev-fail parent)
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         (rf/dispatch-sync [:sup/ev-fail [:start]])
-        (let [a-id (get-in (mtest/runtime-db)
+        (let [a-id (get-in (rf.machines.test-support/runtime-db)
                            [:rf.runtime/machines :spawned :sup/ev-fail [:racing] :children :a])]
           ;; :a fails → :on-any-failed resolves; :a (live, non-final) is reaped.
           (rf/dispatch-sync [a-id [:fail]])
@@ -544,9 +544,9 @@
                                 :on-all-complete [:done/all]}}}}]
       (rf/reg-machine :evfin/a final-child)
       (rf/reg-machine :sup/ev-fin parent)
-      (mtest/with-trace-capture captured
+      (rf.machines.test-support/with-trace-capture captured
         (rf/dispatch-sync [:sup/ev-fin [:start]])
-        (let [a-id (get-in (mtest/runtime-db)
+        (let [a-id (get-in (rf.machines.test-support/runtime-db)
                            [:rf.runtime/machines :spawned :sup/ev-fin [:hydrating] :children :a])]
           (is (keyword? a-id) "the final child spawned")
           ;; :go → child dispatches completion AND enters :final? (auto-destroy),
@@ -567,5 +567,5 @@
                 "the auto-finalized child is never classified :cancelled")
             (is (some #(= :rf.machine.spawn-all/all-completed (:operation %)) @captured)
                 "the parent :all join still resolved (:all-completed fired)")
-            (is (nil? (mtest/snapshot a-id))
+            (is (nil? (rf.machines.test-support/snapshot a-id))
                 "no leaked snapshot for the auto-destroyed final child")))))))

--- a/implementation/machines/test/re_frame/spawn_all_schema_atomic_reject_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_schema_atomic_reject_test.clj
@@ -44,21 +44,21 @@
             ;; Loading the machines facade registers `rf/reg-machine` + the
             ;; reserved machine fxs when this ns runs alone.
             [re-frame.machines]
-            [re-frame.machines.spawn-order :as spawn-order]
-            [re-frame.machines.test-support :as mtest]
+            [re-frame.machines.spawn-order :as rf.machines.spawn-order]
+            [re-frame.machines.test-support :as rf.machines.test-support]
             ;; The schemas artefact ships the registered-validator hot path the
             ;; `:where :machine-data` boundary routes through; the `.malli`
             ;; adapter publishes Malli's validate/explain into the late-bind
             ;; table.
             [re-frame.schemas]
             [re-frame.schemas.malli]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter})
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter})
+  rf.machines.test-support/trace-capture-fixture)
 
-(def ^:private frame-db mtest/runtime-db)
+(def ^:private frame-db rf.machines.test-support/runtime-db)
 
 (def ^:private ChildSchema
   "`:n` must be a positive int — the spawn-time `[:schemas :data]` gate."
@@ -99,7 +99,7 @@
   "Every `:rf.error/schema-validation-failure` trace with `:phase :spawn`."
   []
   (filterv #(= :spawn (get-in % [:tags :phase]))
-           (mtest/events-of :rf.error/schema-validation-failure)))
+           (rf.machines.test-support/events-of :rf.error/schema-validation-failure)))
 
 (defn- join-slot [parent-id]
   (get-in (frame-db) [:rf.runtime/machines :spawned parent-id [:forking]]))
@@ -137,18 +137,18 @@
     (is (nil? (get-in (frame-db) [:rf.runtime/machines :system-ids :ok-actor]))
         "no :system-id binding for the suppressed sibling")
     (is (empty? (filterv #{:sa/strict#1 :sa/plain#1}
-                         (spawn-order/frame-order :rf/default)))
+                         (rf.machines.spawn-order/frame-order :rf/default)))
         "no spawn-order entry for either child")
-    (is (empty? (mtest/events-of :rf.machine/spawn-all-started))
+    (is (empty? (rf.machines.test-support/events-of :rf.machine/spawn-all-started))
         "no spawn-all started trace for a rejected invoke")
-    (is (empty? (mtest/events-of :rf.machine.spawn/spawned))
+    (is (empty? (rf.machines.test-support/events-of :rf.machine.spawn/spawned))
         "no :rf.machine.spawn/spawned trace for ANY child")
-    (is (empty? (mtest/events-of :rf.machine.lifecycle/spawned))
+    (is (empty? (rf.machines.test-support/events-of :rf.machine.lifecycle/spawned))
         "no :rf.machine.lifecycle/spawned trace either — nothing landed")
     ;; Exactly one schema error, naming the offending child.
     (is (= 1 (count (schema-failures)))
         "exactly ONE :phase :spawn schema failure — for the one invalid child")
-    (is (= :forking (mtest/machine-state :sup/mixed))
+    (is (= :forking (rf.machines.test-support/machine-state :sup/mixed))
         "the parent stays in :forking — a refused join, not a deadlock")))
 
 (deftest invalid-child-position-does-not-change-the-reject
@@ -234,7 +234,7 @@
         "(precondition) the childless reject sentinel is seeded")
     ;; Hand-drive the completion the (suppressed) valid sibling would have sent.
     (rf/dispatch-sync [:sup/stray [:sa/done :ok]])
-    (is (= :forking (mtest/machine-state :sup/stray))
+    (is (= :forking (rf.machines.test-support/machine-state :sup/stray))
         "a completion against a childless sentinel resolves nothing and hangs nothing")))
 
 ;; ===========================================================================
@@ -253,7 +253,7 @@
     (is (= {:rf/spawn-all-rejected? true} (join-slot :sup/exit))
         "(precondition) the childless reject sentinel is seeded")
     (rf/dispatch-sync [:sup/exit [:back]])
-    (is (= :idle (mtest/machine-state :sup/exit))
+    (is (= :idle (rf.machines.test-support/machine-state :sup/exit))
         "(precondition) the parent left the :spawn-all state")
     (is (nil? (join-slot :sup/exit))
         "parent exit CLEARS the reject sentinel")

--- a/implementation/machines/test/re_frame/spawn_all_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_test.clj
@@ -20,17 +20,17 @@
   All tests run on the JVM through the plain-atom substrate."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; runtime-db / snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines …]` path.
-(def ^:private frame-db mtest/runtime-db)
-(def ^:private snapshot mtest/snapshot)
+(def ^:private frame-db rf.machines.test-support/runtime-db)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 ;; ---- common child machine -------------------------------------------------
 ;;
@@ -190,11 +190,11 @@
   traces into an atom; returns [atom unregister-fn]."
   [k]
   (let [a (atom [])]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev]
           (when (= :rf.warning/spawn-all-join-unsatisfiable (:operation ev))
             (swap! a conj ev))))
-    [a #(trace-tooling/unregister-listener! k)]))
+    [a #(rf.trace.tooling/unregister-listener! k)]))
 
 (deftest all-join-unsatisfiable-after-failure-warns
   (testing "C5: an :all join with no :on-any-failed warns once when a failure

--- a/implementation/machines/test/re_frame/spawn_data_fn_form_test.clj
+++ b/implementation/machines/test/re_frame/spawn_data_fn_form_test.clj
@@ -24,16 +24,16 @@
   the same fn-form per Spec 005 §Spec-spec keys (line 1818)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; runtime-db / snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines …]` path.
-(def ^:private snapshot mtest/snapshot)
-(def ^:private frame-db mtest/runtime-db)
+(def ^:private snapshot rf.machines.test-support/snapshot)
+(def ^:private frame-db rf.machines.test-support/runtime-db)
 
 ;; ---- (1) literal-map :data — passes through verbatim ----------------------
 
@@ -141,7 +141,7 @@
       (rf/reg-machine :sup/throwing parent)
       ;; Shared `with-trace-capture` — guaranteed unregister in a `finally`,
       ;; no hand-rolled register/try/finally.
-      (mtest/with-trace-capture traces
+      (rf.machines.test-support/with-trace-capture traces
         (rf/dispatch-sync [:sup/throwing [:start]])
         ;; The cascade halted: no actor was spawned. Per Spec 005 §Errors,
         ;; the snapshot does NOT commit — the parent's lazy initial snapshot

--- a/implementation/machines/test/re_frame/spawn_destroyed_frame_atomicity_test.clj
+++ b/implementation/machines/test/re_frame/spawn_destroyed_frame_atomicity_test.clj
@@ -15,19 +15,19 @@
   installed."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.machines :as machines]
-            [re-frame.machines.lifecycle-fx.spawn :as spawn]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.lifecycle-fx.spawn :as rf.machines.lifecycle-fx.spawn]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 ;; touch the artefact so the machines registration hook is wired even when
 ;; this ns is run in isolation (`re-frame.machines` require has side effects).
-(def ^:private _artefact machines/machine-transition)
+(def ^:private _artefact rf.machines/machine-transition)
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (deftest destroyed-frame-spawn-fires-no-trace-no-dispatch
   (testing "C3: spawning into a never-created / destroyed frame installs nothing,
@@ -40,8 +40,8 @@
     (let [spawned-traces (atom [])
           dispatches     (atom [])
           ghost-frame    :rf2-g13nm2/never-created-frame
-          orig-dispatch! (late-bind/get-fn :router/dispatch!)]
-      (trace-tooling/register-listener!
+          orig-dispatch! (rf.late-bind/get-fn :router/dispatch!)]
+      (rf.trace.tooling/register-listener!
         ::ghost-spawn
         (fn [ev]
           (when (= :rf.machine.spawn/spawned (:operation ev))
@@ -49,10 +49,10 @@
       ;; Wrap the dispatch hook so any dispatch the spawn fx attempts is
       ;; captured (and NOT actually routed — a [nil <start>] dispatch would
       ;; otherwise blow up downstream).
-      (late-bind/set-fn! :router/dispatch!
+      (rf.late-bind/set-fn! :router/dispatch!
                          (fn [ev opts] (swap! dispatches conj [ev opts]) nil))
       (try
-        (let [ret (spawn/spawn-fx {:frame ghost-frame}
+        (let [ret (rf.machines.lifecycle-fx.spawn/spawn-fx {:frame ghost-frame}
                                   {:machine-id :rf2-g13nm2/ghost-child
                                    :start      [:go]})]
           (is (nil? ret)
@@ -65,9 +65,9 @@
                             [:rf.runtime/machines :snapshots]))
               "no snapshot was installed into the dead frame"))
         (finally
-          (trace-tooling/unregister-listener! ::ghost-spawn)
+          (rf.trace.tooling/unregister-listener! ::ghost-spawn)
           (when orig-dispatch!
-            (late-bind/set-fn! :router/dispatch! orig-dispatch!)))))))
+            (rf.late-bind/set-fn! :router/dispatch! orig-dispatch!)))))))
 
 (deftest live-frame-spawn-still-fires-trace-and-dispatch
   (testing "C3 control: a LIVE-frame spawn still emits the spawned trace,
@@ -85,7 +85,7 @@
        :states  {:idle     {:on {:start :spawning}}
                  :spawning {:spawn {:machine-id :rf2-g13nm2/live-child}}}})
     (let [spawned-traces (atom [])]
-      (trace-tooling/register-listener!
+      (rf.trace.tooling/register-listener!
         ::live-spawn
         (fn [ev]
           (when (= :rf.machine.spawn/spawned (:operation ev))
@@ -100,4 +100,4 @@
           (is (seq @spawned-traces)
               "the :rf.machine.spawn/spawned trace fired for the live-frame spawn"))
         (finally
-          (trace-tooling/unregister-listener! ::live-spawn))))))
+          (rf.trace.tooling/unregister-listener! ::live-spawn))))))

--- a/implementation/machines/test/re_frame/spawn_on_spawn_throw_test.clj
+++ b/implementation/machines/test/re_frame/spawn_on_spawn_throw_test.clj
@@ -27,26 +27,26 @@
   the full lifecycle handler (the path where the bug surfaced)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; runtime-db / snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines …]` path.
-(def ^:private snapshot mtest/snapshot)
-(def ^:private frame-db mtest/runtime-db)
+(def ^:private snapshot rf.machines.test-support/snapshot)
+(def ^:private frame-db rf.machines.test-support/runtime-db)
 
 (defn- capture-traces!
   "Drive `thunk` while recording every emitted trace envelope; return the
   vector of envelopes (deterministic on the JVM — no wall-clock / random).
-  The VALUE-returning counterpart to `mtest/with-trace-capture` (which is a
+  The VALUE-returning counterpart to `rf.machines.test-support/with-trace-capture` (which is a
   scope macro, not a value-producing call) — kept local because the call
   sites below bind the returned vector in a `let`. Still guarantees
   unregister in a `finally` via the shared helper's listener."
   [thunk]
-  (mtest/with-trace-capture seen
+  (rf.machines.test-support/with-trace-capture seen
     (thunk)
     @seen))
 

--- a/implementation/machines/test/re_frame/spawn_ordering_ep0029_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/spawn_ordering_ep0029_cljs_test.cljc
@@ -32,18 +32,18 @@
    ;; Loading `re-frame.machines` installs the late-bind hooks
    ;; `reg-machine` resolves through.
    [re-frame.machines]
-   [re-frame.machines.test-support :as mtest]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter})))
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter})))
 
 ;; snapshot lookup via the shared machines test-support — no hardcoded
 ;; `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 (defn- spawned-id-for
   [parent-id invoke-id]

--- a/implementation/machines/test/re_frame/spawn_registry_test.clj
+++ b/implementation/machines/test/re_frame/spawn_registry_test.clj
@@ -37,16 +37,16 @@
   the in-app-db slot directly."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; runtime-db / snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines …]` path.
-(def ^:private snapshot mtest/snapshot)
-(def ^:private frame-db mtest/runtime-db)
+(def ^:private snapshot rf.machines.test-support/snapshot)
+(def ^:private frame-db rf.machines.test-support/runtime-db)
 
 ;; ---- (1) spawn writes [:rf.runtime/machines :spawned <parent> <invoke-id>] ------------------
 
@@ -562,10 +562,10 @@
 (defn- capture-warn-ops!
   "Run `thunk` while a trace listener records every emitted `:operation`.
   Returns the vector of operations seen during the body. Routed through the
-  shared `mtest/with-trace-capture` — guaranteed unregister in a `finally`
+  shared `rf.machines.test-support/with-trace-capture` — guaranteed unregister in a `finally`
   — then projects each envelope to its `:operation`."
   [thunk]
-  (mtest/with-trace-capture seen
+  (rf.machines.test-support/with-trace-capture seen
     (thunk)
     (mapv :operation @seen)))
 

--- a/implementation/machines/test/re_frame/substrate_source_machine_test.clj
+++ b/implementation/machines/test/re_frame/substrate_source_machine_test.clj
@@ -23,22 +23,22 @@
   real stamp site in `re-frame.machines.timer`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
+            [re-frame.interop :as rf.interop]
             ;; Load the machines artefact so the late-bind hooks for
             ;; `rf/reg-machine`, the `:rf.machine/spawn` / `:rf.machine/destroy`
             ;; reserved fxs, and the `:after`-timer surface register at ns load.
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
             ;; Source-axis tests register listeners through `trace.tooling`
-            ;; directly (not mtest/with-trace-capture): each listener FILTERS
+            ;; directly (not rf.machines.test-support/with-trace-capture): each listener FILTERS
             ;; on a specific :operation at capture time and the test reads
             ;; `@seen` in the surrounding `let` — kept as inline try/finally
             ;; blocks (which already guarantee unregister).
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- :after-timer --------------------------------------------------------
 
@@ -49,11 +49,11 @@
     ;; substrate's real dispatch path (the stamp site lives in
     ;; re-frame.machines.timer; the executor only governs timing).
     (let [seen (atom [])]
-      (trace-tooling/register-listener! ::after-src
+      (rf.trace.tooling/register-listener! ::after-src
         (fn [ev] (when (= :rf.event/dispatched (:operation ev))
                    (swap! seen conj ev))))
       (try
-        (with-redefs [interop/schedule-after! (fn [f _ms] (f) :stub-handle)]
+        (with-redefs [rf.interop/schedule-after! (fn [f _ms] (f) :stub-handle)]
           (let [machine
                 {:initial :idle
                  :data    {}
@@ -89,7 +89,7 @@
           ;; `:rf/dispatch-origin` tag rides alongside.
           (is (nil? (get-in timer-ev [:tags :rf/dispatch-origin]))
               ":rf/dispatch-origin retired per rf2-1ve9h — `:source` carries the axis"))
-        (finally (trace-tooling/unregister-listener! ::after-src))))))
+        (finally (rf.trace.tooling/unregister-listener! ::after-src))))))
 
 ;; ---- :machine-spawn ------------------------------------------------------
 
@@ -119,7 +119,7 @@
           seen (atom [])]
       (rf/reg-machine :parent-source/proto parent-machine)
       (rf/reg-machine :child-source/worker  child-machine)
-      (trace-tooling/register-listener! ::spawn-src
+      (rf.trace.tooling/register-listener! ::spawn-src
         (fn [ev] (when (= :rf.event/dispatched (:operation ev))
                    (swap! seen conj ev))))
       (try
@@ -136,7 +136,7 @@
               "the substrate dispatched the spawned actor's :start event")
           (is (= :machine-spawn (:source spawn-ev))
               ":source :machine-spawn stamped on the spawn dispatch (rf2-ejtpd)"))
-        (finally (trace-tooling/unregister-listener! ::spawn-src))))))
+        (finally (rf.trace.tooling/unregister-listener! ::spawn-src))))))
 
 (deftest machine-spawn-synthetic-spawned-stamps-source-machine-spawn
   (testing "machine spawn fx stamps :source :machine-spawn on the synthetic [:rf.machine.spawn/spawned] event"
@@ -159,7 +159,7 @@
           seen (atom [])]
       (rf/reg-machine :parent-source2/proto parent-machine)
       (rf/reg-machine :child-source2/proto  child-machine)
-      (trace-tooling/register-listener! ::spawn-src2
+      (rf.trace.tooling/register-listener! ::spawn-src2
         (fn [ev] (when (= :rf.event/dispatched (:operation ev))
                    (swap! seen conj ev))))
       (try
@@ -174,7 +174,7 @@
               "the substrate dispatched the synthetic [:rf.machine.spawn/spawned] event")
           (is (= :machine-spawn (:source synthetic-ev))
               ":source :machine-spawn stamped on the synthetic spawn dispatch (rf2-ejtpd)"))
-        (finally (trace-tooling/unregister-listener! ::spawn-src2))))))
+        (finally (rf.trace.tooling/unregister-listener! ::spawn-src2))))))
 
 ;; ---- :machine-action (actor messages) -----------------------------------
 
@@ -199,7 +199,7 @@
       (rf/reg-event :downstream/note
         (fn [{:keys [db]} _] {:db (assoc db :noted? true)}))
       (rf/reg-machine :machine-action/parent parent-machine)
-      (trace-tooling/register-listener! ::machine-action
+      (rf.trace.tooling/register-listener! ::machine-action
         (fn [ev] (when (= :rf.event/dispatched (:operation ev))
                    (swap! seen conj ev))))
       (try
@@ -213,7 +213,7 @@
               "the machine-emitted :dispatch reached the downstream handler")
           (is (= :machine-action (:source downstream-ev))
               ":source :machine-action stamped on the machine-emitted child envelope (rf2-c3990)"))
-        (finally (trace-tooling/unregister-listener! ::machine-action))))))
+        (finally (rf.trace.tooling/unregister-listener! ::machine-action))))))
 
 (deftest non-machine-dispatch-still-stamps-source-fx-dispatch
   (testing ":dispatch fx from a NON-machine event handler retains :source :fx-dispatch (rf2-c3990)"
@@ -227,7 +227,7 @@
           {:fx [[:dispatch [:downstream/from-ordinary]]]}))
       (rf/reg-event :downstream/from-ordinary
         (fn [{:keys [db]} _] {:db (assoc db :noted? true)}))
-      (trace-tooling/register-listener! ::ordinary
+      (rf.trace.tooling/register-listener! ::ordinary
         (fn [ev] (when (= :rf.event/dispatched (:operation ev))
                    (swap! seen conj ev))))
       (try
@@ -241,7 +241,7 @@
               "the ordinary :dispatch reached the downstream handler")
           (is (= :fx-dispatch (:source downstream-ev))
               ":source :fx-dispatch stamped on the ordinary-handler child envelope (regression guard)"))
-        (finally (trace-tooling/unregister-listener! ::ordinary))))))
+        (finally (rf.trace.tooling/unregister-listener! ::ordinary))))))
 
 ;; ---- :always (microstep trace) ------------------------------------------
 
@@ -263,7 +263,7 @@
             :c {}}}
           microsteps (atom [])]
       (rf/reg-machine :always-source/flow machine)
-      (trace-tooling/register-listener! ::always-src
+      (rf.trace.tooling/register-listener! ::always-src
         (fn [ev]
           (when (= :rf.machine.microstep/transition (:operation ev))
             (swap! microsteps conj ev))))
@@ -278,4 +278,4 @@
               ":source :always stamped on the microstep trace (rf2-ejtpd)")
           (is (= :b (get-in step [:tags :from])))
           (is (= :c (get-in step [:tags :to]))))
-        (finally (trace-tooling/unregister-listener! ::always-src))))))
+        (finally (rf.trace.tooling/unregister-listener! ::always-src))))))

--- a/implementation/machines/test/re_frame/tags_test.clj
+++ b/implementation/machines/test/re_frame/tags_test.clj
@@ -20,16 +20,16 @@
   (:require [clojure.edn :as edn]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; snapshot lookup via the shared machines test-support
 ;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 ;; ---- 1. flat machine, tags on each state ---------------------------------
 
@@ -145,11 +145,11 @@
              :states  {:a {:tags #{:start} :on {:next :b}}
                        :b {:tags #{:middle :transient} :on {:next :c}}
                        :c {:tags #{:end}}}}
-          {snap1 :snapshot} (machines/machine-transition m {:state :a :data {}} [:next])]
+          {snap1 :snapshot} (rf.machines/machine-transition m {:state :a :data {}} [:next])]
       (is (= :b (:state snap1)))
       (is (= #{:middle :transient} (:tags snap1))
           ":tags stamped on the pure-transition output")
-      (let [{snap2 :snapshot} (machines/machine-transition m snap1 [:next])]
+      (let [{snap2 :snapshot} (rf.machines/machine-transition m snap1 [:next])]
         (is (= :c (:state snap2)))
         (is (= #{:end} (:tags snap2))))))
 
@@ -158,7 +158,7 @@
              :data    {}
              :states  {:a {:on {:next :b}}
                        :b {}}}
-          {snap :snapshot}  (machines/machine-transition m {:state :a :data {}} [:next])]
+          {snap :snapshot}  (rf.machines/machine-transition m {:state :a :data {}} [:next])]
       (is (= :b (:state snap)))
       (is (not (contains? snap :tags))
           "empty tag union elided on pure-transition output"))))

--- a/implementation/machines/test/re_frame/timeout_test.clj
+++ b/implementation/machines/test/re_frame/timeout_test.clj
@@ -22,53 +22,53 @@
   end-to-end."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.machines.timeout :as timeout]
-            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.machines.timeout :as rf.machines.timeout]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
             [re-frame.subs]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
-(def ^:private snapshot mtest/snapshot)
+(def ^:private snapshot rf.machines.test-support/snapshot)
 
 ;; ---- duration grammar -----------------------------------------------------
 
 (deftest duration-integer-ms
   (testing "a positive integer is literal ms"
-    (is (= 5000 (timeout/resolve-duration-ms 5000)))
-    (is (= 1    (timeout/resolve-duration-ms 1))))
+    (is (= 5000 (rf.machines.timeout/resolve-duration-ms 5000)))
+    (is (= 1    (rf.machines.timeout/resolve-duration-ms 1))))
   (testing "a non-positive / non-integer number resolves to nil"
-    (is (nil? (timeout/resolve-duration-ms 0)))
-    (is (nil? (timeout/resolve-duration-ms -5)))
-    (is (nil? (timeout/resolve-duration-ms 1.5)))))
+    (is (nil? (rf.machines.timeout/resolve-duration-ms 0)))
+    (is (nil? (rf.machines.timeout/resolve-duration-ms -5)))
+    (is (nil? (rf.machines.timeout/resolve-duration-ms 1.5)))))
 
 (deftest duration-iso-8601
   (testing "ISO-8601 durations resolve to ms"
-    (is (= 5000    (timeout/resolve-duration-ms "PT5S")))
-    (is (= 120000  (timeout/resolve-duration-ms "PT2M")))
-    (is (= 5400000 (timeout/resolve-duration-ms "PT1H30M")))
-    (is (= 500     (timeout/resolve-duration-ms "PT0.5S")))
-    (is (= 86400000 (timeout/resolve-duration-ms "P1D")))
-    (is (= 1800000  (timeout/resolve-duration-ms "PT30M"))))
+    (is (= 5000    (rf.machines.timeout/resolve-duration-ms "PT5S")))
+    (is (= 120000  (rf.machines.timeout/resolve-duration-ms "PT2M")))
+    (is (= 5400000 (rf.machines.timeout/resolve-duration-ms "PT1H30M")))
+    (is (= 500     (rf.machines.timeout/resolve-duration-ms "PT0.5S")))
+    (is (= 86400000 (rf.machines.timeout/resolve-duration-ms "P1D")))
+    (is (= 1800000  (rf.machines.timeout/resolve-duration-ms "PT30M"))))
   (testing "lower-case `pt5s` is accepted (case-insensitive)"
-    (is (= 5000 (timeout/resolve-duration-ms "pt5s"))))
+    (is (= 5000 (rf.machines.timeout/resolve-duration-ms "pt5s"))))
   (testing "the bare `P` (no component) is not a duration"
-    (is (nil? (timeout/resolve-duration-ms "P")))
-    (is (nil? (timeout/resolve-duration-ms "PT")))))
+    (is (nil? (rf.machines.timeout/resolve-duration-ms "P")))
+    (is (nil? (rf.machines.timeout/resolve-duration-ms "PT")))))
 
 (deftest duration-rejects-xstate-shorthand
   (testing "the XState `5s` / `10ms` shorthand is REJECTED (operator-ruled divergence)"
-    (is (nil? (timeout/resolve-duration-ms "5s")))
-    (is (nil? (timeout/resolve-duration-ms "10ms")))
-    (is (nil? (timeout/resolve-duration-ms "2m")))
-    (is (nil? (timeout/resolve-duration-ms "1h"))))
+    (is (nil? (rf.machines.timeout/resolve-duration-ms "5s")))
+    (is (nil? (rf.machines.timeout/resolve-duration-ms "10ms")))
+    (is (nil? (rf.machines.timeout/resolve-duration-ms "2m")))
+    (is (nil? (rf.machines.timeout/resolve-duration-ms "1h"))))
   (testing "other malformed / non-duration forms resolve to nil"
-    (is (nil? (timeout/resolve-duration-ms "soon")))
-    (is (nil? (timeout/resolve-duration-ms "")))
-    (is (nil? (timeout/resolve-duration-ms nil)))
-    (is (nil? (timeout/resolve-duration-ms [1000])))
-    (is (nil? (timeout/resolve-duration-ms (fn [_] 5000))))))
+    (is (nil? (rf.machines.timeout/resolve-duration-ms "soon")))
+    (is (nil? (rf.machines.timeout/resolve-duration-ms "")))
+    (is (nil? (rf.machines.timeout/resolve-duration-ms nil)))
+    (is (nil? (rf.machines.timeout/resolve-duration-ms [1000])))
+    (is (nil? (rf.machines.timeout/resolve-duration-ms (fn [_] 5000))))))
 
 ;; ---- registration-time fail-loud validation -------------------------------
 
@@ -157,7 +157,7 @@
 (deftest desugar-state-timeout
   (testing "state :timeout / :on-timeout lowers to an :after entry keyed by ms"
     (is (= {:initial :w :states {:w {:after {5000 {:target :d}}} :d {}}}
-           (timeout/desugar-timeouts
+           (rf.machines.timeout/desugar-timeouts
              {:initial :w :states {:w {:timeout "PT5S" :on-timeout {:target :d}} :d {}}})))))
 
 (deftest desugar-spawn-timeout
@@ -165,14 +165,14 @@
     (is (= {:initial :l
             :states {:l {:spawn {:machine-id :c} :after {10000 {:target :to}}}
                      :to {}}}
-           (timeout/desugar-timeouts
+           (rf.machines.timeout/desugar-timeouts
              {:initial :l
               :states {:l {:spawn {:machine-id :c :timeout 10000 :on-timeout {:target :to}}}
                        :to {}}})))))
 
 (deftest desugar-coexists-with-after
   (testing ":timeout and an explicit :after coexist on the same node (A4)"
-    (let [out (timeout/desugar-timeouts
+    (let [out (rf.machines.timeout/desugar-timeouts
                 {:initial :w
                  :states {:w {:after {1000 :warn} :timeout "PT5S" :on-timeout :done}
                           :warn {} :done {}}})]
@@ -182,7 +182,7 @@
 (deftest desugar-idempotent
   (testing "desugaring an already-desugared spec is a no-op"
     (let [m {:initial :w :states {:w {:after {5000 {:target :d}}} :d {}}}]
-      (is (= m (timeout/desugar-timeouts (timeout/desugar-timeouts m)))))))
+      (is (= m (rf.machines.timeout/desugar-timeouts (rf.machines.timeout/desugar-timeouts m)))))))
 
 ;; ---- dispatch boundary — the timeout actually fires the transition --------
 

--- a/implementation/machines/test/re_frame/timer_frame_scope_test.clj
+++ b/implementation/machines/test/re_frame/timer_frame_scope_test.clj
@@ -17,13 +17,13 @@
   the targeted frame."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.machines.timer :as timer]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.machines.timer :as rf.machines.timer]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- the machine under test -----------------------------------------------
 ;;
@@ -59,7 +59,7 @@
     (rf/dispatch-sync [:iso/m [:fetch]] {:frame :iso/left})
     (rf/dispatch-sync [:iso/m [:fetch]] {:frame :iso/right})
 
-    (let [tt @timer/after-timers]
+    (let [tt @rf.machines.timer/after-timers]
       (is (contains? tt :iso/left)
           "the timer table partitions entries under the left frame")
       (is (contains? tt :iso/right)
@@ -82,8 +82,8 @@
             "inner-key shape is {:parent ... :spawn ... :delay ...}")))
 
     ;; 1-arity reset clears only the targeted frame.
-    (machines/reset-timers! :iso/left)
-    (let [tt @timer/after-timers]
+    (rf.machines/reset-timers! :iso/left)
+    (let [tt @rf.machines.timer/after-timers]
       (is (not (contains? tt :iso/left))
           "1-arity reset-timers! drops the left frame's entire inner table")
       (is (contains? tt :iso/right)
@@ -98,13 +98,13 @@
     (rf/make-frame {:id :ds/discard :doc "destroyed"})
     (rf/dispatch-sync [:ds/m [:fetch]] {:frame :ds/keep})
     (rf/dispatch-sync [:ds/m [:fetch]] {:frame :ds/discard})
-    (is (and (contains? @timer/after-timers :ds/keep)
-             (contains? @timer/after-timers :ds/discard))
+    (is (and (contains? @rf.machines.timer/after-timers :ds/keep)
+             (contains? @rf.machines.timer/after-timers :ds/discard))
         "preconditions: both frames have entries")
     (rf/destroy-frame! :ds/discard)
-    (is (not (contains? @timer/after-timers :ds/discard))
+    (is (not (contains? @rf.machines.timer/after-timers :ds/discard))
         ":machines/on-frame-destroyed! hook clears the destroyed frame's entries")
-    (is (contains? @timer/after-timers :ds/keep)
+    (is (contains? @rf.machines.timer/after-timers :ds/keep)
         "destroy-frame! on the discarded frame must not touch the survivor's entries")))
 
 ;; ---- regression: 0-arity reset still clears everything --------------------
@@ -116,9 +116,9 @@
     (rf/make-frame {:id :iso0/b})
     (rf/dispatch-sync [:iso0/m [:fetch]] {:frame :iso0/a})
     (rf/dispatch-sync [:iso0/m [:fetch]] {:frame :iso0/b})
-    (is (seq @timer/after-timers) "preconditions: both frames have entries")
-    (machines/reset-timers!)
-    (is (= {} @timer/after-timers)
+    (is (seq @rf.machines.timer/after-timers) "preconditions: both frames have entries")
+    (rf.machines/reset-timers!)
+    (is (= {} @rf.machines.timer/after-timers)
         "0-arity clears the whole table — the fixture-teardown shape")))
 
 ;; ---- regression: after-cancel-fx is scoped to the active frame -----------
@@ -130,14 +130,14 @@
     (rf/make-frame {:id :sc/B})
     (rf/dispatch-sync [:sc/m [:fetch]] {:frame :sc/A})
     (rf/dispatch-sync [:sc/m [:fetch]] {:frame :sc/B})
-    (is (and (contains? @timer/after-timers :sc/A)
-             (contains? @timer/after-timers :sc/B))
+    (is (and (contains? @rf.machines.timer/after-timers :sc/A)
+             (contains? @rf.machines.timer/after-timers :sc/B))
         "both frames installed a timer entry on :loading entry")
     ;; Exiting :loading (via :loaded → :ready) on frame :sc/A emits
     ;; :rf.machine/after-cancel; after-cancel-fx must clear only the
     ;; active frame's matching entries.
     (rf/dispatch-sync [:sc/m [:loaded]] {:frame :sc/A})
-    (is (not (contains? @timer/after-timers :sc/A))
+    (is (not (contains? @rf.machines.timer/after-timers :sc/A))
         "frame A's timer table is empty after the state exit")
-    (is (contains? @timer/after-timers :sc/B)
+    (is (contains? @rf.machines.timer/after-timers :sc/B)
         "frame B's table is untouched by frame A's :rf.machine/after-cancel")))

--- a/implementation/machines/test/re_frame/trace_listener_post_drain_mutation_test.clj
+++ b/implementation/machines/test/re_frame/trace_listener_post_drain_mutation_test.clj
@@ -46,14 +46,14 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace :as rf.trace]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter})
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter})
+  rf.machines.test-support/trace-capture-fixture)
 
 (def ^:private booting-child
   "A child whose synthetic `[:rf.machine.spawn/spawned]` bootstrap causes an
@@ -79,7 +79,7 @@
     :ready   {}}})
 
 (defn- snap-of [actor-id]
-  (get-in (mtest/runtime-db) [:rf.runtime/machines :snapshots actor-id]))
+  (get-in (rf.machines.test-support/runtime-db) [:rf.runtime/machines :snapshots actor-id]))
 
 (defn- observe
   "The arm's observable end state — deliberately NOT a delivery-mechanics
@@ -99,9 +99,9 @@
   (rf/dispatch-sync [child-id [:go]])
   {:pinned?         (map? (:rf/machine-type (snap-of child-id)))
    :installed?      (some? (snap-of child-id))
-   :state           (mtest/machine-state child-id)
+   :state           (rf.machines.test-support/machine-state child-id)
    :no-such-handler (count (filterv #(= child-id (get-in % [:tags :rf.trace/event-id]))
-                                    (mtest/events-of :rf.error/no-such-handler)))})
+                                    (rf.machines.test-support/events-of :rf.error/no-such-handler)))})
 
 (defn- run-arm
   "Register `type-kw` + a `:spawn-all` parent over it, dispatch the fork, and
@@ -114,7 +114,7 @@
   (let [listener-id ::arm
         fired       (atom false)]
     (when during
-      (trace/register-listener!
+      (rf.trace/register-listener!
         listener-id
         (fn [ev]
           (when (and (= :rf.machine.spawn-all/started (:operation ev))
@@ -125,11 +125,11 @@
       (rf/dispatch-sync [parent-kw [:start]])
       (when after (after))
       (finally
-        (when during (trace/unregister-listener! listener-id))))
+        (when during (rf.trace/unregister-listener! listener-id))))
     (when during
       (is (true? @fired)
           "(precondition) the listener ran — deferred delivery still DELIVERS"))
-    (observe (get-in (mtest/runtime-db)
+    (observe (get-in (rf.machines.test-support/runtime-db)
                      [:rf.runtime/machines :spawned parent-kw [:forking] :children :c]))))
 
 ;; ===========================================================================
@@ -144,9 +144,9 @@
             listener body runs at the post-drain boundary, so it cannot
             influence the install it appears to precede (rf2-wxy1c)."
     (let [arm-1 (run-arm :pd/a1 :pd/sup-a1
-                         {:during #(registrar/unregister! :event :pd/a1)})
+                         {:during #(rf.registrar/unregister! :event :pd/a1)})
           arm-2 (run-arm :pd/a2 :pd/sup-a2
-                         {:after  #(registrar/unregister! :event :pd/a2)})
+                         {:after  #(rf.registrar/unregister! :event :pd/a2)})
           arm-3 (run-arm :pd/a3 :pd/sup-a3 {})]
       (is (= arm-1 arm-2)
           (str "ARM 1 ≡ ARM 2 — mid-drain listener mutation lands post-drain. "

--- a/implementation/machines/test/re_frame/tracked_slot_prune_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/tracked_slot_prune_cljs_test.cljc
@@ -35,28 +35,28 @@
    ;; load the machines artefact so its fx handlers + late-bind hooks are
    ;; installed when this ns runs in isolation.
    [re-frame.machines]
-   [re-frame.machines.test-support :as mtest]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.machines.test-support :as rf.machines.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
-  mtest/trace-capture-fixture)
+  (rf.machines.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
+  rf.machines.test-support/trace-capture-fixture)
 
 (defn- destroyed-reasons-for [actor-id]
   (into []
         (comp (filter #(= actor-id (:actor-id (:tags %))))
               (map (comp :reason :tags)))
-        (mtest/events-of :rf.machine/destroyed)))
+        (rf.machines.test-support/events-of :rf.machine/destroyed)))
 
 (defn- tracked-slot [parent-id]
-  (get-in (mtest/runtime-db)
+  (get-in (rf.machines.test-support/runtime-db)
           [:rf.runtime/machines :spawned parent-id [:working]]))
 
 (defn- parent-mirror [parent-id]
-  (get-in (mtest/snapshot parent-id) [:data :rf/spawned [:working]]))
+  (get-in (rf.machines.test-support/snapshot parent-id) [:data :rf/spawned [:working]]))
 
 (defn- destroy-imperatively!
   "Fire one imperative keyword destroy through an ordinary app event."
@@ -103,7 +103,7 @@
       ;; Imperative destroy: full teardown ONCE; the tracked slot survives
       ;; (its teardown-args carry no parent/invoke) — the bug's precondition.
       (destroy-imperatively! child-id)
-      (is (nil? (mtest/snapshot child-id)) "actor dead after imperative destroy")
+      (is (nil? (rf.machines.test-support/snapshot child-id)) "actor dead after imperative destroy")
       (is (= child-id (tracked-slot :tsp/p1))
           "precondition: the tracked slot still names the now-dead actor")
       (is (= [:explicit] (destroyed-reasons-for child-id))
@@ -128,15 +128,15 @@
                                           exit-count)]
       (destroy-imperatively! child-id)
       (rf/dispatch-sync [:tsp/p2 [:stop]])
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       ;; Hand-fire the tracked form again — the slot is already gone.
       (rf/reg-event ::refire-tracked
         (fn [_ _] {:fx [[:rf.machine/destroy {:rf/parent-id :tsp/p2
                                               :rf/invoke-id [:working]}]]}))
       (rf/dispatch-sync [::refire-tracked])
-      (is (empty? (mtest/events-of :rf.machine/destroyed))
+      (is (empty? (rf.machines.test-support/events-of :rf.machine/destroyed))
           "repeat exit emits no destroyed trace")
-      (is (empty? (mtest/events-of :rf.error/machine-destroy-bad-arg))
+      (is (empty? (rf.machines.test-support/events-of :rf.error/machine-destroy-bad-arg))
           "repeat exit raises no error — silent idempotence")
       (is (= 1 @exit-count) "no further :exit runs"))))
 
@@ -157,7 +157,7 @@
       (is (= :tsp/fixed-3 (tracked-slot :tsp/p3)))
       ;; Kill the tracked incarnation.
       (destroy-imperatively! :tsp/fixed-3)
-      (is (nil? (mtest/snapshot :tsp/fixed-3)))
+      (is (nil? (rf.machines.test-support/snapshot :tsp/fixed-3)))
       ;; Hand-emit a same-id REPLACEMENT through the imperative spawn path —
       ;; no :rf/parent-id / :rf/invoke-id args, so its :data carries no
       ;; ownership stamps for the old slot.
@@ -165,17 +165,17 @@
         (fn [_ _] {:fx [[:rf.machine/spawn {:machine-id     :tsp/p3-child
                                             :fixed-actor-id :tsp/fixed-3}]]}))
       (rf/dispatch-sync [::respawn-fixed])
-      (is (some? (mtest/snapshot :tsp/fixed-3)) "replacement incarnation live")
+      (is (some? (rf.machines.test-support/snapshot :tsp/fixed-3)) "replacement incarnation live")
       (is (= :tsp/fixed-3 (tracked-slot :tsp/p3))
           "precondition: the STALE slot still names the (reused) id")
-      (mtest/reset-captured!)
+      (rf.machines.test-support/reset-captured!)
       ;; Old parent exits: the stale slot may prune itself, never the
       ;; replacement.
       (rf/dispatch-sync [:tsp/p3 [:stop]])
       (is (nil? (tracked-slot :tsp/p3)) "the stale slot is pruned")
-      (is (some? (mtest/snapshot :tsp/fixed-3))
+      (is (some? (rf.machines.test-support/snapshot :tsp/fixed-3))
           "the same-id replacement incarnation SURVIVES the old parent's exit")
-      (is (empty? (mtest/events-of :rf.machine/destroyed))
+      (is (empty? (rf.machines.test-support/events-of :rf.machine/destroyed))
           "no destroyed trace fired against the replacement"))))
 
 ;; ---------------------------------------------------------------------------
@@ -191,7 +191,7 @@
                                           {:machine-id :tsp/p4-child}
                                           exit-count)]
       (rf/dispatch-sync [:tsp/p4 [:stop]])
-      (is (nil? (mtest/snapshot child-id)) "live child torn down on exit")
+      (is (nil? (rf.machines.test-support/snapshot child-id)) "live child torn down on exit")
       (is (= [:explicit] (destroyed-reasons-for child-id))
           "exactly one :explicit destroyed trace")
       (is (= 1 @exit-count) "exactly one :exit cascade run")

--- a/implementation/machines/test/re_frame/transition_frame_tag_test.clj
+++ b/implementation/machines/test/re_frame/transition_frame_tag_test.clj
@@ -18,11 +18,11 @@
   drops the tag fails at this site test first (clear cause)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- shared spec ----------------------------------------------------------
 
@@ -32,7 +32,7 @@
              :green  {:on {:tick {:target :yellow}}}
              :yellow {:on {:tick {:target :red}}}}})
 
-;; Intentional RAW manual-stop listener (not mtest/with-trace-capture): this
+;; Intentional RAW manual-stop listener (not rf.machines.test-support/with-trace-capture): this
 ;; helper hands the caller a [capture-atom unregister-thunk] pair so the test
 ;; controls exactly WHEN it stops listening — a behaviour the scope-macro form
 ;; (which unregisters at body exit) cannot express.

--- a/implementation/machines/test/re_frame/transition_slot_spec_path_test.clj
+++ b/implementation/machines/test/re_frame/transition_slot_spec_path_test.clj
@@ -16,16 +16,16 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines]
-            [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
-;; Routed through the shared `mtest/with-trace-capture`
+;; Routed through the shared `rf.machines.test-support/with-trace-capture`
 ;; — guaranteed unregister in a `finally`.
 (defn- record-traces! [body-fn]
-  (mtest/with-trace-capture seen
+  (rf.machines.test-support/with-trace-capture seen
     (body-fn)
     @seen))
 

--- a/implementation/machines/test/re_frame/update_snapshot_schema_test.clj
+++ b/implementation/machines/test/re_frame/update_snapshot_schema_test.clj
@@ -27,20 +27,20 @@
   Uses Malli (the framework default validator)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as machines]
-            [re-frame.machines.test-support :as mtest]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
             [re-frame.schemas]
             [re-frame.schemas.malli]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
-  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- collect-traces!
   "Run `f` while capturing every trace event; return the
   `:rf.error/schema-validation-failure` events as a vector."
   [f]
-  (mtest/with-trace-capture traces
+  (rf.machines.test-support/with-trace-capture traces
     (f)
     (filterv #(= :rf.error/schema-validation-failure (:operation %))
              @traces)))
@@ -49,7 +49,7 @@
   "Run `f` while capturing every trace event; return ALL events with the
   given `op` as a vector."
   [op f]
-  (mtest/with-trace-capture traces
+  (rf.machines.test-support/with-trace-capture traces
     (f)
     (filterv #(= op (:operation %)) @traces)))
 


### PR DESCRIPTION
## What

`implementation/machines` now speaks the canonical require-alias dialect from
[`spec/Conventions.md` §Require-alias dialect](../blob/main/spec/Conventions.md#require-alias-dialect--a-framework-subsystem-namespace-is-aliased-rf):
`re-frame.core` keeps the bare root alias `rf`, every other `re-frame.<tail>`
takes the dotted `rf.<tail>`, and the bare leaf form goes back to being reserved
for application namespaces.

Core and routing moved in #9103; machines was the artefact neither bead covered.
That PR deliberately left the three machines files it renamed in the artefact's
old dialect rather than half-migrating it — this closes that.

**839 noncanonical require edges across 194 files**, plus the **3449 qualified
use sites** that move with them. Auto-resolved `::alias/key` keywords move too
(`::result/depth-abort?` → `::rf.machines.result/depth-abort?` denotes the same
keyword either way). No behaviour changes: aliases are compile-time source
vocabulary.

## Census

Fixed-string, before → after, over `implementation/machines` only:

| | before | after |
|---|---|---|
| noncanonical `re-frame.*` require edges | 841 | 2 (both exempt, below) |
| files carrying one | 194 | 1 |
| `mtest/` (boundary-aware) | 681 | 0 |
| `rf.machines.test-support/` | 0 | 681 |
| `trace-tooling/` | 104 | 0 |
| `rf.trace.tooling/` | 0 | 104 |
| `late-bind/` | 134 | 0 |
| `rf.late-bind/` | 0 | 134 |
| `:as machines` | 59 | 0 |

Controls that had to stay **constant**, and did:

| control | before | after |
|---|---|---|
| namespace string `re-frame.machines.test-support` | 151 | 151 |
| namespace string `re-frame.substrate.plain-atom` | 125 | 125 |
| keyword `:rf.machine/` | 1177 | 1177 |
| keyword `:rf.machines/` (would betray a rewritten literal keyword) | 0 | 0 |

And the strongest one: the **multiset of every literal single-colon
`:ns/name` keyword across the artefact is identical before and after** — 0
entries changed. That is what proves no `:machines/rearm-after-hydration!`
late-bind key, no `:router/dispatch!`, no `:corner.timer/scoped` frame id and no
`:rf.*/*` reserved key was touched by a rename that shares their first segment.

## What was deliberately left alone

- **The host-conditional exemption.** `birth_always_cljs_test.cljc` binds ONE
  alias `substrate-adapter` to TWO namespaces across reader arms
  (`#?(:clj re-frame.substrate.plain-atom :cljs re-frame.adapter.reagent)`). The
  shared name **is** the point — per-arm dotted tails would give the single use
  site two names. It is the only such shape in the artefact (the check is
  derived, not listed: an alias bound to 2+ namespaces in one file).
- **Literal keywords** (`:machines/…`, `:router/…`, `:cofx/…`, `:frame/destroyed`,
  `:error-emit/…`), **fully-qualified references** (`re-frame.machines.paths/snapshot-path`),
  **quoted symbols** (`'re-frame.fx/dispatch-later-timers`,
  `(requiring-resolve 're-frame.conformance/eval-value*)`) and **repo-relative
  paths** (`spec/conformance/fixtures/`, `docs/machines/…`, `core/test/re_frame`) —
  876 occurrences that a naive `alias/` sweep would have rewritten. `#'parallel/reduce-regions`
  var-quotes DO move, and did.
- **Docstring prose that names an alias as code** moves with the code, including
  the five sites where the symbol wraps across a line
  (`` `cofx-attach/bootstrap-ensure-\n  cofx` ``).

## Source-scanning gates: no widening needed

Both gates that read publication call sites as TEXT across every artefact's
`src` — `late_bind_drift_test` and `warn_once_clear_governance_test` — were
already widened by #9103 to accept `#"(?:rf\.)?late-bind/"`, so machines'
rename lands inside a pattern that already covers it. Re-run against this tree:
**9 tests / 696 assertions, 0 failures**. The governance gate is the one that
fails OPEN (it forbids a call shape, so a spelling it cannot see is an offender
it waves through), which is why it was checked rather than assumed.

Also checked and unaffected: `destroyed_reason_channel_conformance_test.clj`'s
`(str/includes? s "trace/emit!")` pre-filter still matches, because
`rf.trace/emit!` contains it, and its structural `call-name` reads
`(name (first form))` — alias-insensitive. `tools/mcp-conformance/wire-vocab`
reads five machines source files but reader-parses them and asserts on keyword
map keys. No `route-hook!` call site exists in machines `src`.

## Gates

| gate | result |
|---|---|
| `implementation/machines` JVM (`clojure -M:test`) | 1241 tests / 4495 assertions, **0 failures 0 errors**, exit 0 |
| node CLJS bundle (`npm run test:cljs`) | 11170 tests / 55746 assertions, **0 failures 0 errors**, exit 0 |
| `implementation/core` late-bind-drift + warn-once-clear-governance | 9 tests / 696 assertions, 0 failures, exit 0 |
| `tools/mcp-conformance/wire-vocab` | 94 tests / 1031 assertions, 0 failures, exit 0 |
| `clj-kondo --parallel --fail-level error --lint implementation` | identical to the pristine baseline once columns and alias text are normalised — 1623 warnings before and after, zero delta |
| `git diff --check` | clean |

**The JVM gate was proven live before it was believed.** Planting
`rf.machines.pathsX/snapshot-path` in `classification.cljc` returned exit 1 with
`Syntax error (ClassNotFoundException) compiling at (re_frame\machines\classification.cljc:110:9)`;
restoring returned blob `0aa312e11b024e2a9de853c26cdacfe305d76fcd`, identical to
the pre-plant hash.

The one clj-kondo `error` (`implementation/epoch/…_cljs_test.cljc:939:72`) is
present identically on the pristine baseline, is outside this diff, and is an
artefact of the locally-installed clj-kondo v2025.10.23 against CI's pinned
2026.04.15.

## Not in this PR

The syntax-aware CI ratchet the parent beads asked for. It belongs in `scripts/`
plus `.github/workflows/` as ONE repo-wide ratchet rather than one per artefact,
and both are hot-zone. The design — with the four textual traps this sweep
measured, the derived (not listed) exemption rule, and the per-surface floor
shape — is written onto rf2-j5or for a workflow lane to pick up.

## A third gate did have to move — inside the artefact, not in `scripts/`

The alias sweep left one auto-resolved keyword in framework **source**:
`(dissoc info ::rf.machines.result/depth-abort? :error-id)` in `machines.cljc`.
CI's `check_keyword_catalogue_drift` CHECK B went red on it — that checker reads
every `:rf.*` keyword namespace out of `implementation/**/src` and demands a
`:rf.<ns>/*` row in `spec/Conventions.md`'s reserved set, and its extractor
cannot tell `::rf.x/y` from `:rf.x/y`. The auto-resolved form denotes
`:re-frame.machines.result/depth-abort?` and reserves nothing, so the row it
asked for would have been a **false reservation** — and `spec/Conventions.md` is
hot-zone one-toucher besides.

This is inherent to the dialect, not to this keyword: the canonical `rf.<tail>`
require alias textually shadows the `:rf.<area>` reserved keyword root, so every
`::rf.<tail>/key` in framework source reads to a text scanner as a literal
reserved-root keyword. Machines is the first artefact to produce one —
`git grep '::rf\.' -- implementation/*/src` returns nothing on main, so core's
sweep never met it.

The fix stays inside the fence and is right on the merits: spell the sentinel
fully-qualified, `:re-frame.machines.result/depth-abort?`, which says exactly
what it is to a reader and to a scanner alike. Value unchanged — the three
spellings are one keyword. A comment above it records why, so a later sweep does
not "canonicalise" it back. Second commit; the checker went findings=1 →
findings=0 across it, which is that gate proven live in both directions.

`scripts/check_keyword_catalogue_drift.py` still cannot tell the two forms
apart, and the next artefact's sweep will meet the same red. That is recorded on
rf2-ydpr (the repo-wide ratchet bead) rather than fixed here — `scripts/` is
outside this fence.
