### PR TITLE
Retire the unconsumed transport-request-id and sixteen dead imports/bindings (rf2-6r9j.43, rf2-6r9j.46)

### DIFF
--- a/implementation/http/src/re_frame/http/reply.cljc
+++ b/implementation/http/src/re_frame/http/reply.cljc
@@ -28,7 +28,8 @@
       metadata on the reply map. The frame-qualified transport
       request-id `[:rf.req frame-id work-id]` (landed in Spec 016) is the
       sanctioned second identity for process-global transport
-      correlation; `transport-request-id` builds it.
+      correlation; the Resources work-ledger's `managed-request-id` is
+      its only shipped constructor.
 
    2. **Canonical reply map** (`success-reply` / `failure-reply`). The
       transport's success / failure / abort
@@ -96,16 +97,6 @@
   (let [logical-id (if (some? request-id) request-id (first origin-event))]
     [:rf.work/http logical-id (or issuance 1) (or attempt 1)]))
 
-(defn transport-request-id
-  "Build the frame-qualified transport request-id `[:rf.req frame-id
-  work-id]` (Managed-Effects §Work-id correlation — the sanctioned second
-  identity for process-global transport-level in-flight correlation, landed
-  in Spec 016). The frame-local `:rf.reply/work-id` carries no frame id, so it is not
-  a safe process-global transport token on its own; this qualified form is.
-  Intra-frame stale suppression still keys on `:rf.reply/work-id`, not this."
-  [frame-id wid]
-  [:rf.req frame-id wid])
-
 ;; ---------------------------------------------------------------------------
 ;; Self-identifying failure maps (rf2-1u9dja; debugging-dx finding 3). Every
 ;; public HTTP failure map (the classified `:rf.http/*` shape that rides under
@@ -166,7 +157,7 @@
   `:completed-at`, and `:correlation {:request-id …}`. Optional facts
   (`:completed-at`, `:correlation`) are omitted when absent rather than
   filled with nil sentinels (Managed-Effects §The reply map)."
-  [{:keys [request-id origin-event issuance attempt frame completed-at] :as ctx}]
+  [{:keys [request-id attempt frame completed-at] :as ctx}]
   (let [wid (work-id ctx)]
     (cond-> {:rf.reply/work-id     wid
              :rf.reply/work-kind   :http

--- a/implementation/http/src/re_frame/http/transport.cljc
+++ b/implementation/http/src/re_frame/http/transport.cljc
@@ -1240,7 +1240,7 @@
   arming the timer, leaving the request invisible to every cancellation
   path for the whole backoff — the timer fired regardless."
   [ctx failure]
-  (let [{:keys [retry attempt request-id]} ctx
+  (let [{:keys [retry attempt]} ctx
         {:keys [on max-attempts backoff]} retry
         on-set      (or on #{})
         kind        (:kind failure)

--- a/implementation/http/src/re_frame/http/transport_jvm.cljc
+++ b/implementation/http/src/re_frame/http/transport_jvm.cljc
@@ -36,8 +36,7 @@
                                   HttpRequest$BodyPublishers
                                   HttpResponse HttpResponse$BodyHandlers]
                    [java.nio.charset Charset StandardCharsets]
-                   [java.time Duration]
-                   [java.util.concurrent CompletableFuture])))
+                   [java.time Duration])))
 
 ;; Reflection warnings catch unhinted calls in this interop-heavy namespace.
 #?(:clj (set! *warn-on-reflection* true))

--- a/implementation/http/test/re_frame/http_jvm_headers_shape_test.clj
+++ b/implementation/http/test/re_frame/http_jvm_headers_shape_test.clj
@@ -31,7 +31,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.http.transport-jvm :as http-transport-jvm])
   (:import [java.net.http HttpHeaders]
-           [java.util List Map]
+           [java.util Map]
            [java.util.function BiPredicate]))
 
 ;; ---- helper: build a real HttpHeaders the JDK way -------------------------

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -15,7 +15,6 @@
             [re-frame.http.json :as http-json]
             [re-frame.registrar :as registrar]
             [re-frame.http.decode :as http-decode]
-            [re-frame.http.encoding :as http-encoding]
             [re-frame.http.managed :as http-managed]
             [re-frame.http.registry :as registry]
             [re-frame.late-bind :as late-bind]
@@ -399,7 +398,7 @@
 
 (deftest jvm-real-get-success
   (testing "java.net.http.HttpClient transport — GET, JSON decode, default reply"
-    (let [{:keys [server port] :as srv}
+    (let [{:keys [port] :as srv}
           (start-server!
             (fn [^HttpExchange ex]
               (write-response! ex 200 "application/json"
@@ -423,7 +422,7 @@
 
 (deftest jvm-real-http-4xx
   (testing "non-2xx 4xx response classifies as :rf.http/http-4xx"
-    (let [{:keys [server port] :as srv}
+    (let [{:keys [port] :as srv}
           (start-server!
             (fn [^HttpExchange ex]
               (write-response! ex 404 "application/json" "{\"error\":\"not-found\"}")))]
@@ -452,7 +451,7 @@
 
 (deftest jvm-html-404-with-json-decode-routes-to-http-4xx
   (testing "HTML 4xx response with :decode :json classifies as :rf.http/http-4xx (not :rf.http/decode-failure)"
-    (let [{:keys [server port] :as srv}
+    (let [{:keys [port] :as srv}
           (start-server!
             (fn [^HttpExchange ex]
               (write-response! ex 404 "text/html"
@@ -488,7 +487,7 @@
 
 (deftest jvm-throwing-decoder-on-200-routes-to-decode-failure
   (testing "200 response whose decode pipeline throws classifies as :rf.http/decode-failure"
-    (let [{:keys [server port] :as srv}
+    (let [{:keys [port] :as srv}
           (start-server!
             (fn [^HttpExchange ex]
               (write-response! ex 200 "application/json" "{\"ok\":true}")))]

--- a/implementation/http/test/re_frame/http_privacy_integration_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_integration_test.clj
@@ -17,7 +17,6 @@
             [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.fx :as fx]
-            [re-frame.registrar :as registrar]
             [re-frame.http.managed :as http-managed]
             ;; load-bearing: binds the shared schema walker hooks the
             ;; `:decode`-schema redaction/elision path late-binds (rf2-zvbm9).

--- a/implementation/http/test/re_frame/http_reply_lowering_cljs_test.cljc
+++ b/implementation/http/test/re_frame/http_reply_lowering_cljs_test.cljc
@@ -21,7 +21,7 @@
    :frame        :app/main
    :completed-at 1781078400456})
 
-(deftest work-id-and-transport-id
+(deftest work-id-head
   (testing "HTTP work-id head [:rf.work/http logical-id issuance attempt]"
     (is (= [:rf.work/http :article/by-id 1 1] (http-reply/work-id ctx)))
     (is (= [:rf.work/http :article/load 1 1]
@@ -34,10 +34,7 @@
       (is (= [:rf.work/http :article/by-id 2 1]
              (http-reply/work-id (assoc ctx :issuance 2))))
       (is (not= (http-reply/work-id ctx)
-                (http-reply/work-id (assoc ctx :issuance 2))))))
-  (testing "frame-qualified transport request-id [:rf.req frame-id work-id]"
-    (is (= [:rf.req :app/main [:rf.work/http :article/by-id 1 1]]
-           (http-reply/transport-request-id :app/main (http-reply/work-id ctx))))))
+                (http-reply/work-id (assoc ctx :issuance 2)))))))
 
 (deftest suppress-builds-canonical-stale-reply
   (testing "rf2-azcmd3 — http-reply/suppress produces a :status :stale / :rf.reply/work-status :suppressed reply with carried/current work-id correlation, joined to :work/id"

--- a/implementation/http/test/re_frame/http_reply_lowering_test.clj
+++ b/implementation/http/test/re_frame/http_reply_lowering_test.clj
@@ -134,10 +134,7 @@
       (is (= [:rf.work/http :article/by-id 2 1]
              (http-reply/work-id (assoc base-ctx :issuance 2))))
       (is (not= (http-reply/work-id base-ctx)
-                (http-reply/work-id (assoc base-ctx :issuance 2))))))
-  (testing "the frame-qualified transport request-id is [:rf.req frame-id work-id]"
-    (is (= [:rf.req :app/main [:rf.work/http :article/by-id 1 1]]
-           (http-reply/transport-request-id :app/main (http-reply/work-id base-ctx))))))
+                (http-reply/work-id (assoc base-ctx :issuance 2)))))))
 
 (deftest success-reply-is-canonical
   (testing "a success completion builds a schema-valid :status :ok reply"

--- a/implementation/http/test/re_frame/http_restore_quiesce_test.clj
+++ b/implementation/http/test/re_frame/http_restore_quiesce_test.clj
@@ -25,7 +25,6 @@
             [re-frame.core :as rf]
             [re-frame.http.managed :as http-managed]
             [re-frame.http.registry :as http-registry]
-            [re-frame.http.transport :as http-transport]
             [re-frame.late-bind :as late-bind]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]

--- a/implementation/http/test/re_frame/http_transport_security_test.clj
+++ b/implementation/http/test/re_frame/http_transport_security_test.clj
@@ -1,9 +1,8 @@
 (ns re-frame.http-transport-security-test
   "Security-relevant JVM transport guards: invalid-header warnings,
   privacy composition, timeout application, and host degradation."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.test :refer [deftest is testing]]
             [re-frame.http.handlers]
-            [re-frame.http.privacy :as privacy]
             [re-frame.http.transport]
             [re-frame.http.transport-jvm]
             [re-frame.late-bind :as late-bind]
@@ -200,7 +199,7 @@
   param (`?api_key=…`), the JVM header-validation warning trace MUST
   scrub the value and stamp `:sensitive?` on the event. The previous
   shape leaked the secret because the trace bypassed
-  `privacy/prepare-emit-tags`."
+  `re-frame.http.privacy/prepare-emit-tags`."
     (with-trace-capture
       (fn [captured]
         (let [_req (jvm-build-request

--- a/implementation/http/test/re_frame/http_url_percent_encoded_redaction_cljs_test.cljc
+++ b/implementation/http/test/re_frame/http_url_percent_encoded_redaction_cljs_test.cljc
@@ -14,8 +14,8 @@
   `:rf/redacted`. A malformed escape decodes to nil and falls back to
   the raw-name match path — redaction is total and never throws."
   (:require
-   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
-      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   #?(:clj  [clojure.test :refer [deftest is testing]]
+      :cljs [cljs.test :refer-macros [deftest is testing]])
    [re-frame.http.url :as url]))
 
 ;; App-specific carrier policy is passed explicitly to this leaf API, so no


### PR DESCRIPTION
Two `implementation/http` vestige beads. A third, rf2-6r9j.44, is **not** in this PR — see the bottom.

## rf2-6r9j.43 — `http.reply/transport-request-id` removed

`re-frame.http.reply/transport-request-id` had **no production caller**. Repo-wide `git grep -F` over tracked files (excluding `.beads`) returned exactly four hits: its own `defn`, one namespace-prose sentence, and two shape assertions in the reply-lowering tests. clj-kondo var-usage analysis over `implementation/` agreed: 3 usage records, all from test namespaces, **0 from `src`**.

**The surviving original** is `re-frame.resources.work-ledger/managed-request-id` (`implementation/resources/src/re_frame/resources/work_ledger.cljc:148`). It is genuinely equivalent — both are `[frame-id work-id] -> [:rf.req frame-id work-id]`, identical bodies — and unlike the HTTP copy it is live, with four production callers in `resources/events.cljc` (653, 977, 1149) and `resources/mutation_events.cljc` (1271), plus Resources tests for issuance, supersession and opportunistic abort.

Removed: the helper, its two shape assertions, and the sentence claiming it builds the identity. The namespace prose now names the surviving constructor instead, so the `[:rf.req frame-id work-id]` shape stays documented where it was. **No HTTP -> Resources dependency is added** — this is a prose reference only. The CLJS `deftest work-id-and-transport-id` is renamed `work-id-head` to match what it still asserts (no other reference to the old name exists).

## rf2-6r9j.46 — census re-derived, then sixteen findings removed

The bead's census predates PR #9081, which landed in this artefact. **It was re-derived from the current tree rather than taken from the bead.** Result: all sixteen listed findings were still present, only line numbers had moved (`transport.cljc` 1248 -> 1243), and #9081 had created no new orphan here.

| file | finding |
|---|---|
| `reply.cljc` | unused `origin-event`, `issuance` destructurings (`:as ctx` is what `work-id` reads) |
| `transport.cljc` | unused `request-id` destructuring in `maybe-retry!` |
| `transport_jvm.cljc` | unused `CompletableFuture` import |
| `http_jvm_headers_shape_test.clj` | unused `java.util.List` import |
| `http_managed_test.clj` | unused `re-frame.http.encoding` alias; four `server` destructurings |
| `http_privacy_integration_test.clj` | unused `re-frame.registrar` alias |
| `http_restore_quiesce_test.clj` | unused `re-frame.http.transport` alias |
| `http_transport_security_test.clj` | unused `use-fixtures` refer; unused `privacy` alias |
| `http_url_percent_encoded_redaction_cljs_test.cljc` | unused `use-fixtures` refer, both reader branches |

The four `server` destructurings narrow to `{:keys [port] :as srv}` — **the form 27 sibling sites in the same file already use**; these four were the outliers. `srv` is retained for teardown.

Nothing load-bearing was removed, and each transitive closure was checked rather than assumed: `re-frame.http.transport` is reached via `managed -> handlers -> transport` (`handlers.cljc:29`), and `re-frame.http.privacy` via that same `transport` require, which the security test keeps.

Where the alias removal would have left a dangling prose reference, the reference is fully qualified rather than deleted — `http_transport_security_test.clj:203` now reads `re-frame.http.privacy/prepare-emit-tags`.

## Evidence

Every deletion was proven with **two independent instruments, each with a control that fired** — exact `git grep -F` over tracked files, and clj-kondo var-usage analysis. The controls mattered: a coarse `grep -F "rf/"` reported 59 hits in `http_privacy_test.clj` that are all the `:rf/redacted` **keyword**, not the alias.

## Gates

| gate | result |
|---|---|
| `clj-kondo --lint implementation/http/src implementation/http/test --cache false` | **50 -> 34 warnings**, exactly the sixteen, no new finding surfaced |
| http JVM suite (`clojure -M:test`) | exit **0** — 506 tests, 3882 assertions, 0 failures, 0 errors |
| `npm run test:cljs` | exit **0** — 11169 tests, 55740 assertions, 0 failures, 0 errors |

**Gate proven live**, not merely green: a planted assertion break in `http_reply_lowering_test.clj` (one of the files carrying a structural paren edit) reddened the JVM suite — exit 1, `FAIL in (work-id-head)`, naming the file. Restored and verified byte-identical by `git hash-object` (`cedc9166ab43...`) before committing.

The remaining 34 clj-kondo warnings are the exclusions the audit itself named — opposite-host reader-conditional requires, the load-bearing `re-frame.http.managed` test requires, `with-new-frame`'s `f` binding, `ctx` / `abort-signal`.

## Three findings deliberately left, reported on the beads

- `http_privacy_test.clj:22` and `http_retry_on_validation_test.clj:19`, both unused `re-frame.core` aliases — **not dead**. `re-frame.core` carries a top-level `(rf.late-bind/set-fns! …)` at `core.cljc:228` publishing `:core/dispatch-impl` / `:core/dispatch-sync-impl` / `:core/subscribe-impl`, and nothing else in either file's require closure loads it (the facade sits above everything that could). These are load-bearing requires, which is exactly the case the bead's Risks section reserves. The first was newly orphaned by #9081.
- `routing_http_composed_corners_test.clj:265`, unused binding `url` — a real finding but a different class: the fx-handler arity `[_ url]` is load-bearing, so the repair is a rename to `_url`, which is neither a removal nor a narrowing and falls outside the bead's stated disposition.

## rf2-6r9j.44 is not in this PR

Its premise as briefed does not hold. It is described as an `implementation/http` bead, but every file it names — `ssr/ring/pipeline.clj`, `ssr/ring.clj`, `resource_payload_projection_test.clj` — is in `implementation/ssr-ring/`, which another worker holds. Left open with a note; no work was done on it and no `ssr-ring` file is touched here.
