### PR TITLE
fix(xray): the dead-frame sentinel gets no public exit; reagent-slim spec + React-19 floor reconciliation

### DIFF
--- a/implementation/adapters/reagent-slim/DESIGN-RATIONALE.md
+++ b/implementation/adapters/reagent-slim/DESIGN-RATIONALE.md
@@ -91,7 +91,9 @@ re-frame2 was already React-18-or-better in practice — every example mounts vi
 
 ### Migration note
 
-Adopting reagent-slim means bumping `react` and `react-dom` to 19.x in your `package.json`. Replace `reagent.dom/render` calls with `reagent2.dom.client/{create-root, render}`. Replace `reagent.dom/unmount-component-at-node` with `reagent2.dom.client/unmount`. If you have a `r/dom-node` call, it must move to a `:ref` callback — `findDOMNode` is gone. Stock-Reagent users on React 17 or 18 stay on `re-frame2-reagent`.
+Adopting reagent-slim means bumping `react` and `react-dom` to 19.x in your `package.json`. Replace `reagent.dom/render` calls with `reagent2.dom.client/{create-root, render}`. Replace `reagent.dom/unmount-component-at-node` with `reagent2.dom.client/unmount`. If you have a `reagent.dom/dom-node` call (historically written `(rdom/dom-node this)` against `[reagent.dom :as rdom]`), it must move to a `:ref` callback — `findDOMNode` is gone.
+
+**Staying on the bridge is not a way to avoid that work (rf2-6r9j.37).** `day8/re-frame2-reagent` is itself pinned to Reagent 2.0.1 on React 19 — see [`../reagent/README.md`](../reagent/README.md) — and the React-19 removals are React's, not the rewrite's. Reagent 2.0.1 deleted `reagent.dom/dom-node` outright, so that call site fails to compile on the bridge too; `reagent.dom/render`, `unmount-component-at-node` and `force-update-all` still exist there as Vars but call `react-dom` functions React 19 no longer provides, so they warn and then fail at runtime. The migration corpus's [M-42](../../../migration/from-re-frame-v1/README.md) is the canonical reference for both targets.
 
 ---
 
@@ -384,13 +386,13 @@ This honesty matters because the doc you are reading is for adopters making a re
 | Dimension | re-frame2-reagent | reagent-slim |
 |---|---|---|
 | Maven coord | `day8/re-frame2-reagent` | `day8/reagent-slim` |
-| React floor | React 17/18 (stock-Reagent constrained) | React 19 |
+| React floor | React 19 (Reagent 2.0.1 pinned; no 17/18 fallback) | React 19 |
 | Surface | full Reagent surface (~30+ symbols) | ~20 symbols, re-com/re-frame2 scoped |
 | Bundle (gzip) vs stock Reagent 1.3 | baseline | -25% to -33% (typical), -70% (SSR-using) |
 | Form-3 keys | all React lifecycle keys | 7-key cap |
 | `convert-prop-value` | stringifies all keywords | HTML-attribute names only |
-| `r/dom-node` / `findDOMNode` | works | absent (React 19 — API gone; compile error) |
-| `reagent.dom/render` | works | absent (React 19 — API gone; compile error) |
+| `reagent.dom/dom-node` / `findDOMNode` | absent (Reagent 2.0.1 deleted the Var; compile error) | absent (React 19 — API gone; compile error) |
+| `reagent.dom/render`, `unmount-component-at-node`, `force-update-all` | Vars still defined, but they call `react-dom` functions React 19 removed — warn, then fail at runtime. Use `reagent.dom.client` | absent (compile error) |
 | Trace integration | requires 10x v1 monkey-patches | native to renderer |
 | Source-coord stamping | post-render tree walk | native to renderer |
 | `r/flush` | brittle under React 18+ concurrent | `flush-views!` deterministic |
@@ -401,8 +403,8 @@ This honesty matters because the doc you are reading is for adopters making a re
 
 Adoption shape:
 
-- **Stock Reagent codebase, full surface usage, on React 17/18:** stay on `re-frame2-reagent`. No reason to migrate.
-- **Stock Reagent codebase, re-com surface only, on React 19:** migrate to `reagent-slim`. The migration is a require-rewrite plus mount-API swap; everything else is unchanged.
+- **Stock Reagent codebase, full surface usage:** stay on `re-frame2-reagent`. No reason to migrate. Note this is not a React-17/18 escape hatch — the bridge is pinned to Reagent 2.0.1 on React 19 as well; what it buys you is the full Reagent surface, not an older React.
+- **Stock Reagent codebase, re-com surface only:** migrate to `reagent-slim`. The migration is a require-rewrite plus mount-API swap; everything else is unchanged.
 - **re-frame2-native codebase, on React 19:** migrate to `reagent-slim`. You get the full integration (trace bus, source-coord, frame-context, deterministic flush) plus the bundle savings.
 - **Codebase using a banned surface (`with-let`, `cursor`, banned Form-3 key, etc.):** either rewrite into the supported surface, or stay on `re-frame2-reagent`. Both are first-class.
 

--- a/implementation/adapters/reagent-slim/IMPL-SPEC.md
+++ b/implementation/adapters/reagent-slim/IMPL-SPEC.md
@@ -29,9 +29,13 @@ The new artefact lives at `implementation/adapters/reagent-slim/` mirroring the 
 
 ### §1.1 Directory shape
 
+As shipped (this block mirrors `src/` file-for-file; keep it in step with
+`git ls-files implementation/adapters/reagent-slim/src`):
+
 ```
 implementation/adapters/reagent-slim/
 ├── deps.edn
+├── README.md · DESIGN-RATIONALE.md · FORM-3.md · IMPL-SPEC.md · LICENSE
 ├── src/
 │   ├── re_frame/
 │   │   └── adapter/
@@ -42,26 +46,19 @@ implementation/adapters/reagent-slim/
 │       ├── ratom.cljs                 ; reactive primitives
 │       ├── ratom.clj                  ; the ratom-spelled reaction macro (CLJS-only consumer)
 │       ├── dom/
-│       │   ├── client.cljs            ; create-root / render / unmount / hydrate-root / flush-views!
+│       │   ├── client.cljs            ; create-root / render / unmount / hydrate-root /
+│       │   │                          ;   flush-views! (test) + flush-render! (production)
 │       │   └── server.cljs            ; pure-CLJS render-to-static-markup
-│       ├── impl/
-│       │   ├── batching.cljs          ; microtask scheduler + dirty-set
-│       │   ├── component.cljs         ; create-class + 7-key dispatch
-│       │   ├── template.cljs          ; hiccup → React element
-│       │   └── util.cljs              ; the few internal helpers we keep
 │       └── impl/
-│           └── component.clj          ; defview macro (S3-003 optional path)
-└── test/
-    └── reagent2/
-        ├── core_test.cljs
-        ├── ratom_test.cljs
-        ├── dom_client_test.cljs
-        ├── dom_server_test.cljs
-        ├── impl/
-        │   ├── batching_test.cljs
-        │   ├── component_test.cljs
-        │   └── template_test.cljs
-        └── parity_test.cljs           ; render-to-static-markup vs react-dom/server (R-004)
+│           ├── batching.cljs          ; microtask scheduler (the RenderQueue) — §2.9
+│           ├── component.cljs         ; create-class + 7-key dispatch, runtime Form detection
+│           ├── component.clj          ; compile-time form classification for `reg-view` — §5.2
+│           ├── diag.cljs              ; EP-0015-safe diagnostic value summaries — §2.10
+│           └── template.cljs          ; hiccup → React element
+├── test/                              ; namespaces end in `-cljs-test`, files in
+│   ├── re_frame/adapter/              ;   `_cljs_test.cljs`, so shadow-cljs's
+│   └── reagent2/{,dom/,impl/}         ;   :node-test build picks them up — §12.1
+└── testbed/                           ; the adapter-level browser smoke (index.html + smoke.cjs)
 ```
 
 ### §1.2 `deps.edn` shape
@@ -282,10 +279,15 @@ Public Vars:
 | `render` | `[root el]` | Render hiccup `el` into a created root. Walks `el` via `reagent2.impl.template/as-element`. |
 | `unmount` | `[root]` | Detach a root. Wraps `(.unmount root)`. |
 | `hydrate-root` | `[container el]`, `[container el options]` | SSR hydration entry. Wraps `react-dom-client/hydrateRoot`. |
-| `flush-views!` | `[]` | The new test-flush primitive (Stage 1 §1.12; Stage 2 top-3 #3). Microtask drain + `react/act` integration. See §4. |
+| `flush-views!` | `[]` | The test-flush primitive (Stage 1 §1.12; Stage 2 top-3 #3). Microtask drain + `react/act` integration, gated on `goog.DEBUG`. See §4. |
+| `flush-render!` | `[f]` | The PRODUCTION synchronous render-commit servicing the adapter's `:flush-render!` slot (rf2-40a84 / rf2-0bz5ah): runs `f`, then `batching/flush!` inside a `react-dom/flushSync` boundary. No `goog.DEBUG` gate. See §4.2. |
 
 Internal helpers:
-- `apply-hiccup` — internal: walks the hiccup tree once and produces a React-element tree. Used by both `render` and `hydrate-root`.
+- `resolve-act` — probes `(.-act react)`, the ONE act location above the React-19 floor (rf2-6r9j.35). Nil means React's production bundle, where `flush-views!` degrades to a plain synchronous flush.
+- `microtask-tick` — a resolved Promise; the microtask boundaries either side of the `act` drain (§4.2, rf2-w6ef).
+
+There is no `apply-hiccup` indirection: `render` and `hydrate-root` each call
+`reagent2.impl.template/as-element` directly.
 
 ### §2.5 `reagent2.dom.server` — pure-CLJS static-markup serializer
 
@@ -315,52 +317,84 @@ Internal Vars (no public surface — these are the renderer's load-bearing inter
 - `convert-prop-value` — narrowed per DECISION-2; see §7.
 - `cached-prop-name` — kebab→camel cache for prop names (kept; same as stock).
 
-Compile-time helpers: none in this ns. (The defview macro lives in `reagent2.impl.component.clj`.)
+Compile-time helpers: none in this ns. (The artefact's only CLJ-side namespaces are `reagent2.core`/`reagent2.ratom` — the `reaction` macro, §14.2 — and `reagent2.impl.component`, the form-classification helpers `reg-view`'s expansion calls, §5.2.)
 
 ### §2.8 `reagent2.impl.component` — class-component plumbing
 
 Files:
 - `src/reagent2/impl/component.cljs` — runtime.
-- `src/reagent2/impl/component.clj` — `defview` macro (S3-003 optional path).
+- `src/reagent2/impl/component.clj` — the compile-time form-classification helpers `re-frame.core/reg-view`'s expansion calls (§5.2). **No `defview` macro ships** (rf2-yfbx; §14.1).
 
-Internal Vars:
+Vars:
 - `*current-component*` — dynamic var; mirrors stock Reagent's `reagent.impl.component/*current-component*`. `reagent2.core/current-component` reads through this.
-- `create-class*` `[spec]` — internal create-class. Validates the spec map's keys against the cap (§6); throws on unsupported. Builds a React component class.
-- `wrap-render` — internal Form-1/Form-2 detection at runtime (so plain `defn` + `reg-view` keeps working — per S3-003).
-- `do-render` — internal lifecycle helper.
-- `wrap-funs` — translates the 7 supported lifecycle keys into React lifecycle methods.
-- `cancel-cleanup`, `queue-cleanup` — disposal lifecycle plumbing.
+- `create-class*` `[spec]` — create-class. Validates the spec map's keys against `cap-keys` (§6); throws on unsupported. Builds a React component class.
+- `fn-to-class` — promote a bare render fn to the class shape the mount path expects.
+- `wrap-render` `[c render-fn]` — runtime Form-1/Form-2 detection, plus the compile-time fold: when `render-fn` carries the `:reagent2/form` meta `reg-view`'s expansion stamped, the classification cond is skipped. The runtime cond stays load-bearing for plain `(reg-view* :id (fn ...))` callers.
+- `set-as-element-fn!` / `as-element-fn` — the late-bound hiccup→element hook (avoids a `template` ↔ `component` cycle).
 - `get-argv`, `get-props`, `get-children` — Form-3 accessors.
 - `state-atom` — Form-3 state cell.
 - `reagent-class?`, `react-class?` — type predicates (kept; re-com / 10x type-check).
 
-Compile-time macros (`component.clj`):
-- `(defview name [args] body)` — optional Form-detection-at-compile-time macro per S3-003. Stage 4 implements the runtime detection first; the macro is an additive optimisation. The current re-frame2 `reg-view` macro (`re-frame.core/reg-view`) is NOT replaced — `defview` is a Reagent-flavoured user surface for apps that don't use re-frame2's reg-view.
+Private lifecycle plumbing (contract-level; names are not API):
+- `validate-class-spec!` — the 7-key cap check that `create-class*` fails fast on.
+- `install-lifecycle-methods!` — translates the supported lifecycle keys onto the React class prototype.
+- `make-render-method` — builds the class's `render`, threading `*current-component*` via `call-with-current-component`.
+- `argv-should-update?` — the argv-equality `shouldComponentUpdate` gate; `previous-argv-from-props` / `copy-argv-from-props!` / `argv-args` / `form-tag` feed it and `wrap-render`.
+- `sync-error-state!` — error-boundary state propagation for `:component-did-catch` (§6.5).
+- `->react-element` — the class → element step.
+
+There is no `do-render`, `wrap-funs`, `cancel-cleanup` or `queue-cleanup`.
+Disposal is not a deferred cleanup queue: `install-lifecycle-methods!` ALWAYS
+installs `componentWillUnmount` (whether or not the spec supplies
+`:component-will-unmount`) and it disposes the per-instance render Reaction and
+clears the dirty flag inline — see §3.4.
 
 ### §2.9 `reagent2.impl.batching` — render scheduler
 
 File: `src/reagent2/impl/batching.cljs`.
 
-Internal Vars:
-- `dirty-set` — atom holding the set of components queued for re-render.
-- `scheduled?` — atom flag; true between microtask-schedule and microtask-fire.
-- `queue-render!` `[component]` — enqueue a component for re-render; schedules a microtask if not already scheduled.
-- `flush!` `[]` — synchronous drain of the dirty set + cooperation with React commit. The implementation hook for `reagent2.dom.client/flush-views!`.
-- `after-render` `[f]` — schedule `f` after the next render. Kept as the public ABI for `reagent2.core/after-render`.
-- `do-after-render` — internal lifecycle hook.
+The queue is ONE object, not a set of atoms: `RenderQueue`, a `deftype` with
+three mutable fields (`scheduled?`, `component-queue`, `after-render-queue`)
+whose queues are JS arrays allocated lazily, and a single `defonce` instance
+`render-queue`. Its methods are `schedule`, `queue-render`, `add-after-render`,
+`run-queues`, `flush-render`, `flush-after-render`, `flush-queues`.
+
+Vars:
+- `render-queue` — the `defonce` singleton (private).
+- `queue-render!` `[component]` — enqueue a component for re-render; schedules a microtask if one is not already scheduled.
+- `schedule` `[]` — arm the microtask without enqueueing.
+- `flush!` `[]` — synchronous drain: `ratom/flush!` first (Reaction recomputes may enqueue further component renders), then the component queue's `forceUpdate` pass, then the after-render queue. The implementation hook for `reagent2.dom.client/flush-views!` and `flush-render!`.
+- `do-after-render` `[f]` — schedule `f` after the next render. The public ABI behind `reagent2.core/after-render`.
+- `mark-rendered` `[component]` — clear a component's dirty flag.
+- `installed?` — the `defonce` guard for late-bind hook installation.
+
+Two properties of the shipped queue are contract, not incidental: a Reaction
+that fires DURING a flush is held for the NEXT turn rather than flattened into
+the current drain, and the after-render pass swallows a per-callback throw so
+one misbehaving callback cannot strand the rest of the queue (rf2-p27yih).
 
 See §4 for the scheduler's full design.
 
-### §2.10 `reagent2.impl.util` — small internals
+### §2.10 `reagent2.impl.diag` — EP-0015-safe diagnostics
 
-File: `src/reagent2/impl/util.cljs`.
+File: `src/reagent2/impl/diag.cljs`.
 
-Internal Vars:
-- `fun-name` — extract a usable name from a fn for error messages and React `displayName` defaulting.
-- `*non-reactive*` — dynamic flag suppressing reactive subscription within its body. Internal to `wrap-render` machinery; not exported.
-- `dont-camel-case-pattern` — regex distinguishing `data-*` / `aria-*` props from kebab-cased prop names.
+- `value-summary` `[v]` — returns a small map describing a value's SHAPE (type, and `:count` for a counted collection or string), never the value itself. Spec 015 §Data-Classification forbids raw application values in framework exception messages and ex-data, because consoles, error boundaries and host logs capture them before `project-egress` can classify anything (rf2-uwqale).
 
-The stock `reagent.impl.util` exports `partial`, `class-names`, `merge-props`, `is-client` — none are kept (DECISION-7 Class A).
+A dependency-free leaf: it requires nothing inside `reagent2`, so `template`,
+`server` and `component` can all pull it without a cycle. It is a
+content-for-content mirror of `re-frame.error/diag-value-summary`, replicated
+inline rather than required because the artefact is bundle-isolated and must not
+`:require` `re-frame.*`.
+
+**There is no `reagent2.impl.util` namespace**, and none of `fun-name`,
+`*non-reactive*` or `dont-camel-case-pattern` exists. The prop-name work those
+were sketched for lives in `reagent2.impl.template` (`verbatim-prop-prefixes`,
+`cached-prop-name`, `html-attr-names`). Stock's `reagent.impl.util` exports
+`partial`, `class-names`, `merge-props` and `is-client`; none is re-exported as
+a user surface (DECISION-7 Class A — see §13.3 for the migration recipes). A
+`class-names` helper does exist inside `reagent2.impl.template`, as that
+renderer's own `:class` merge, not as compat.
 
 ---
 
@@ -428,12 +462,19 @@ Stage 2's third top-3 commitment: a microtask-based render scheduler that compos
 
 ### §4.1 Microtask scheduling
 
-`reagent2.impl.batching/queue-render!` enqueues a component into the dirty-set atom. If `scheduled?` is false, it sets `scheduled?` true and schedules a microtask via `js/Promise.resolve().then` (or `js/queueMicrotask` where available). The microtask body:
+`reagent2.impl.batching/queue-render!` pushes a component onto the single
+`RenderQueue`'s component queue (§2.9) and arms it. Arming sets the queue's
+`scheduled?` field and schedules a microtask via `js/queueMicrotask` (falling
+back to `js/Promise.resolve().then`). The microtask body (`run-queues`):
 
-1. Sets `scheduled?` false.
-2. Drains the `dirty-set` into a local seq, clearing the atom.
-3. For each dirty component, calls its React `forceUpdate` (or equivalent — under React 19 the dirty notification rides through the component's `useSyncExternalStore` subscription, where present).
-4. Runs the `after-render` callback queue.
+1. Clears `scheduled?`.
+2. Drains the REACTIVE queue first (`ratom/flush!`) — Reaction recomputes can enqueue further component renders, which step 3 then picks up.
+3. Takes the component queue, replaces it with nil, and for each still-dirty component marks it rendered and calls its React `forceUpdate`.
+4. Takes the after-render queue, replaces it with nil, and runs each callback inside a per-callback `try` (rf2-p27yih), so one throw cannot strand the rest.
+
+Each queue is taken-and-nilled before it is walked, which is what makes a
+Reaction that fires DURING the drain land on the NEXT turn rather than being
+flattened into this one — the ordering §4.6 and the Suspense test depend on.
 
 The microtask boundary is universal across React 19's host platforms (browser, server-component runtimes, React Native via Hermes). No `requestAnimationFrame` fallback is required; React 19 itself does not target environments without microtask support.
 
@@ -441,18 +482,35 @@ The microtask boundary is universal across React 19's host platforms (browser, s
 
 The scheduler **does not interfere** with React 19's transition / suspense / concurrent rendering. The mechanism: the rewrite's components consume their reactive state via `useSyncExternalStore`-shaped subscriptions to RAtom / Reaction objects (mirroring the UIx adapter's `use-subscribe` pattern at `uix.cljs:225+`). When an RAtom changes, the subscriber fires; React's reconciler then schedules its own re-render through normal React channels. The microtask scheduler is the path for **legacy Reagent-shape components** (Form-1/2/3) that don't use `useSyncExternalStore`; those components call `forceUpdate` from inside the microtask.
 
-For test code, `flush-views!` calls `react/act` (from `react` 19+'s test entry) wrapping the synchronous drain. `act` is the React-19-blessed test primitive that drains React's pending work. The compose:
+For test code, `flush-views!` runs the synchronous drain inside React's `act` —
+the React-19-blessed test primitive that drains React's pending work. As
+shipped, the drain is bracketed by microtask ticks either side (the rf2-w6ef
+ordering, §14.5), and `act` is looked up rather than called directly:
 
 ```clojure
+(defn- resolve-act []
+  (.-act react))                        ; the ONE location above the React-19 floor
+
 (defn flush-views! []
   (when ^boolean js/goog.DEBUG
-    (react/act
-      (fn []
-        (batching/flush!)               ; synchronous drain of the dirty-set
-        (js/Promise.resolve)))))         ; await one microtask turn
+    (let [act (resolve-act)]
+      (if (nil? act)
+        (do (batching/flush!) nil)      ; React's production bundle omits `act`
+        (act (fn []
+               (-> (microtask-tick)     ; let a pending rea-schedule microtask run
+                   (.then (fn [_]
+                            (batching/flush!)
+                            (microtask-tick))))))))))
 ```
 
-(Pseudocode — Stage 4 finalises the precise CLJS invocation; the `act` import is `["react" :refer [act]]` under React 19.)
+The lookup is a lookup for two reasons, and neither is React-18 compatibility:
+React's PRODUCTION bundle deliberately omits `act`, so the nil branch is the
+documented safe degradation there; and re-resolving on every call (rather than
+caching) lets a test fixture swap the `react` module mid-run. The pre-18.3
+`react-dom/test-utils` location is below the artefact's React floor and is not
+probed (rf2-6r9j.35); `implementation/package.json` and its lock pin react /
+react-dom 19.2.0, and generated consumers are pinned to the same version by
+`tools/template`, held in lockstep by `version_lockstep_test.clj`.
 
 In production builds, `flush-views!` is gated on `js/goog.DEBUG` and DCEs entirely under `:advanced` + `goog.DEBUG=false` — the flush primitive is a test concern.
 
@@ -478,7 +536,7 @@ Three pathways enqueue a component:
 
 ### §4.5 Dedup strategy
 
-`dirty-set` is a CLJS `set?` — adding the same component twice is a no-op. Stable component identity is the React component instance object; the set is keyed on object identity (`equiv?` / hash on identity).
+Dedup is a FLAG ON THE INSTANCE, not set membership: `queue-render!` marks the component's `cljsIsDirty` field on first enqueue and skips the enqueue while it is set; `mark-rendered` clears it after `forceUpdate` runs, and `componentWillUnmount` clears it too (rf2-mdgt8t) so an unmounted-while-dirty instance is never force-updated. The field name is stock Reagent's, so introspection hooks observing it keep working. The queue itself is therefore a plain JS array of instances, and identity is the React component instance object.
 
 A component that is queued, rendered, then re-queued during the same render cycle (e.g. an `:after-render` callback that mutates an upstream RAtom) gets re-queued for the next microtask turn — the scheduler does not flatten "queued during drain" into the current drain. This matches React 19's transition semantics: in-flight work commits, downstream cascades schedule a new turn.
 
@@ -498,58 +556,73 @@ A test that does `(rf/dispatch-sync ...)` followed by `(flush-views!)` followed 
 
 ---
 
-## §5 Component-shape detection (Form-1/2/3, compile-time)
+## §5 Component-shape detection (Form-1/2/3)
 
-Stage 1 §1.10 + Stage 2 §3.3 + S3-003: ship runtime detection (so plain `defn` + `reg-view` keeps working) and an optional `defview` macro for compile-time dispatch. The runtime detection lives in `reagent2.impl.component/wrap-render`; the macro lives in `reagent2.impl.component.clj`.
+Runtime detection is the load-bearing correctness mechanism, in
+`reagent2.impl.component/wrap-render`. Compile-time classification is an
+additive fold **inside `re-frame.core/reg-view`'s expansion** — it is not a
+separate user surface. **No `defview` macro ships** (rf2-yfbx; §14.1 records
+the decision): `reg-view` is the single canonical view-registration macro.
 
 ### §5.1 Runtime detection (`wrap-render`)
 
-Per Stage 2 §3.3 — Reagent's runtime detection costs ~3-5 ns per render; the savings of moving to compile-time are negligible. The runtime path stays:
-
-```
-(defn- wrap-render [c]
-  (let [out ((.-cljsRender c))]
-    (cond
-      (vector? out)  out                   ; Form-1
-      (fn? out)      (do (set! (.-cljsLegacyRender c) out)
-                         (out (get-argv c)))   ; Form-2 cache + recall
-      (seq? out)     (vec out)              ; legacy seq-as-fragment
-      :else          out)))                 ; primitive
-```
-
-This is essentially the stock-Reagent shape (`reagent.impl.component:54-73`). Under the rewrite the detection sits inside the create-class-derived React component class; `reg-view*`'s wrapper continues to attach `:contextType frame-context` (per views.cljs:312-367).
-
-### §5.2 Compile-time `defview` macro (optional)
-
-Per S3-003: an optional `defview` macro that compile-time-classifies the user form. **Stage 4 ships this AFTER the runtime path** — Stage 4-A is the runtime; Stage 4-B layers on the macro.
-
-Shape (sketch — Stage 4 finalises):
+Per Stage 2 §3.3 — Reagent's runtime detection costs ~3-5 ns per render; moving
+it to compile time saves little, so the runtime path stays canonical. As
+shipped, `wrap-render` takes the component AND the user render fn, caches a
+Form-2 inner closure on `cljsRenderFn`, and consults the compile-time form tag
+before falling through to the classification cond:
 
 ```clojure
-(defmacro defview
-  [sym arglist & body]
-  (let [form (last body)]
+(defn wrap-render [^js c render-fn]
+  (let [args   (argv-args c)                    ; argv minus its head
+        cached (.-cljsRenderFn c)]
     (cond
-      ;; Form-3: (create-class spec)
-      (and (seq? form) (= 'create-class (first form)))
-      `(def ~sym (reagent2.core/create-class ~(second form)))
+      (some? cached)                            ; Form-2 hot path: recall inner
+      (apply cached args)
 
-      ;; Form-2: (fn [args] hiccup)
-      (and (seq? form) (= 'fn (first form)))
-      `(def ~sym (form-2-wrapper (fn ~arglist ~@body)))
+      (= :reagent2/form-2 (form-tag render-fn))  ; compile-time-tagged Form-2
+      (let [inner (apply render-fn args)]
+        (set! (.-cljsRenderFn c) inner)
+        (apply inner args))
 
-      ;; Form-1: anything else, treat as render fn
-      :else
-      `(def ~sym (form-1-wrapper (fn ~arglist ~@body))))))
+      ;; …compile-time-tagged Form-1 (which still keeps the runtime `fn?`
+      ;; fallback, because a Form-1 tag is assigned to any body whose LAST
+      ;; form is not a literal `(fn …)` — the idiomatic `(let [s (atom 0)]
+      ;; (fn [] …))` shape included), then the untagged classification cond.
+      )))
 ```
 
-The macro is **purely additive**: existing `(defn my-view [args] [:div ...])` users do nothing. The macro's value is for users who want compile-time dispatch; the runtime detection covers correctness for everyone else.
+The full cond is in the source; what is contract here is that the runtime cond
+stays load-bearing for plain `(reg-view* :id (fn ...))` callers and for any path
+the fold does not reach, so correctness never depends on the macro. The
+detection sits inside the create-class-derived React component class;
+`reg-view*`'s wrapper continues to attach `:contextType frame-context`.
 
-**Note on re-frame2's `reg-view`**: `reg-view` (`re-frame.core/reg-view`) is the canonical re-frame2 view-registration macro and is NOT replaced by `defview`. `reg-view` registers an id in the `:view` registrar and attaches `:contextType frame-context`; `defview` is a Reagent-flavoured user surface for code that doesn't go through re-frame2's registrar. They coexist.
+Form-3 needs no detection here — see §5.3.
+
+### §5.2 Compile-time fold inside `reg-view` (`component.clj`)
+
+`reagent2.impl.component` (the CLJ side) ships two pure compile-time helpers,
+consumed by `re-frame.core/reg-view`'s expansion:
+
+- `classify-form-body` — returns a form tag (`:reagent2/form-1` / `:reagent2/form-2`) for a body.
+- `tag-form-meta` — wraps a tag in the `{:reagent2/form ...}` metadata map `reg-view` stamps onto the emitted wrapper fn.
+
+They run at macroexpansion time and are plain `defn`s, not macros, so any macro
+that wants to amortise the runtime detection can call them. The fold is
+**purely additive**: an existing `(defn my-view [args] [:div ...])` registered
+through `reg-view` does nothing differently, and `wrap-render`'s runtime cond
+covers every untagged path.
+
+This is the shipped answer to S3-003's "optional compile-time dispatch". S3-003
+sketched it as a standalone `defview` macro; that was rejected under rf2-yfbx
+because it would have stood beside `reg-view` as a second, near-identically
+named view surface. The classification moved inside `reg-view` instead, and the
+user-facing API is unchanged. §14.1 records the question and its disposition.
 
 ### §5.3 Form-3 detection
 
-Form-3 is **explicit**: `(reagent2.core/create-class spec-map)`. The macro doesn't need to detect it because it's a function call at the user's site, not a shape inferred from the body. The runtime path validates the spec at `create-class` call time — see §6.
+Form-3 is **explicit**: `(reagent2.core/create-class spec-map)`. Nothing needs to detect it — it is a function call at the user's site, not a shape inferred from a body — so the compile-time fold classifies only Form-1 vs Form-2. The runtime path validates the spec at `create-class` call time — see §6.
 
 ### §5.4 Source-coord meta stamping through each Form path
 
@@ -1048,12 +1121,14 @@ Per the bead description and Stage 2 §5 risk register R-001..R-007.
 | Namespace | Test file | Coverage |
 |---|---|---|
 | `reagent2.core` | `core_cljs_test.cljs` | All 14 public surfaces (re-export integrity); the `reaction` macro from the consumer side — body deferred until the first deref, reagent2-atom dependency capture and recompute, and the expansion shape `(make-reaction (fn [] body...))`. |
-| `reagent2.ratom` | `ratom_test.cljs` | RAtom + Reaction lifecycle; protocol satisfaction; equality memoisation; `IDisposable` reify; cross-substrate cache-wiring contract. |
-| `reagent2.dom.client` | `dom_client_test.cljs` | create-root / render / unmount / hydrate-root happy-paths; flush-views! determinism contract per §4.6; React-19 `act` cooperation. |
-| `reagent2.dom.server` | `dom_server_test.cljs` + `parity_test.cljs` | render-to-static-markup output for representative corpus; parity against `react-dom/server` per §8.7. |
-| `reagent2.impl.template` | `impl/template_test.cljs` | hiccup → React-element shapes; narrowed convert-prop-value (R-001); kebab-camel cache; tag parsing; sequence-children handling; `:>` / `:<>` / `:r>` / `:f>` interop. |
-| `reagent2.impl.component` | `impl/component_test.cljs` | create-class 7-key cap (R-002); throw-on-unsupported-key per banned key; lifecycle method mapping per §6.4; `:component-did-catch` error-boundary integration per §6.5; `:get-snapshot-before-update` pairing per §6.6. |
-| `reagent2.impl.batching` | `impl/batching_test.cljs` | microtask scheduling; dirty-set dedup; flush! synchronous drain; after-render queue; React 19 transition cooperation (R-005). |
+| `reagent2.ratom` | `ratom_cljs_test.cljs` | RAtom + Reaction lifecycle; protocol satisfaction; equality memoisation; `IDisposable` reify; cross-substrate cache-wiring contract. |
+| `reagent2.dom.client` | `dom/client_cljs_test.cljs` | create-root / render / unmount / hydrate-root happy-paths; flush-views! determinism contract per §4.6; React-19 `act` cooperation (a spy on `react.act` proves the drain routes through it — rf2-6r9j.35). |
+| `reagent2.dom.server` | `dom/server_cljs_test.cljs` + `dom/parity_cljs_test.cljs` + `dom/server_subscribe_ssr_cljs_test.cljs` | render-to-static-markup output for representative corpus; parity against `react-dom/server` per §8.7; the SSR non-reactive deref branch. |
+| `reagent2.impl.template` | `impl/template_cljs_test.cljs` (+ the reserved-head and keyword-prop-warn-once siblings) | hiccup → React-element shapes; narrowed convert-prop-value (R-001); kebab-camel cache; tag parsing; sequence-children handling; `:>` / `:<>` / `:r>` / `:f>` interop. |
+| `reagent2.impl.component` | `impl/component_cljs_test.cljs` (runtime) + `impl/component_test.clj` (the compile-time classifiers, §5.2) | create-class 7-key cap (R-002); throw-on-unsupported-key per banned key; lifecycle method mapping per §6.4; `:component-did-catch` error-boundary integration per §6.5; `:get-snapshot-before-update` pairing per §6.6; and, on the CLJ side, `classify-form-body` / `tag-form-meta` — including that there is no separate `defview` macro. |
+| `reagent2.impl.batching` | `impl/batching_cljs_test.cljs` | microtask scheduling; dirty-flag dedup; flush! synchronous drain; after-render queue; React 19 transition cooperation (R-005). |
+| `reagent2.impl.diag` | `impl/diag_cljs_test.cljs` | the EP-0015-safe value summary (§2.10) — shape only, never the value. |
+| `re-frame.adapter.reagent-slim` | `re_frame/adapter/*_cljs_test.cljs` | the adapter-Var surface: slot parity, client roots, dispose drains, flush-render!/flush-views!, source-coord stamping, StrictMode. |
 
 ### §12.2 Integration tests
 
@@ -1085,11 +1160,11 @@ Per §1.5 — Stage 4 confirms `verify-version-lockstep.sh` recognises the new a
 
 | Risk | Test |
 |---|---|
-| **R-001** Narrowed `convert-prop-value` may break apps relying on silent stringification | `template_test.cljs` exercises every `html-attr-name?` branch; tests assert the dev-mode `console.warn` fires once per `[k name-of-v]` pair. |
-| **R-002** 7-key Form-3 cap may break niche consumers | `component_test.cljs` constructs `create-class` with each of {`:component-will-mount`, `:UNSAFE_componentWillMount`, `:component-will-receive-props`, `:UNSAFE_componentWillReceiveProps`, `:component-will-update`, `:UNSAFE_componentWillUpdate`, `:should-component-update`, `:get-derived-state-from-props`, `:get-initial-state`} and asserts each throws `:rf.error/create-class-key-unsupported` with the unsupported key in `:keys`. |
-| **R-003** Compile-time Form-detection macro changes user-facing API | The runtime path is the canonical (mandatory) implementation; the `defview` macro is optional. Tests assert plain `defn` + `reg-view` works with all three Form shapes. |
-| **R-004** Pure-CLJS `render-to-static-markup` differs from `react-dom/server` | `parity_test.cljs` per §8.7 — corpus-based diff. Known-difference allow-list documented in the parity test itself. |
-| **R-005** Microtask scheduler interacts unexpectedly with React 19 transitions | `dom_client_test.cljs` exercises `useTransition` boundaries; `flush-views!` drains React's pending work without race. |
+| **R-001** Narrowed `convert-prop-value` may break apps relying on silent stringification | `impl/template_cljs_test.cljs` exercises every `html-attr-name?` branch; tests assert the dev-mode `console.warn` fires once per `[k name-of-v]` pair. |
+| **R-002** 7-key Form-3 cap may break niche consumers | `impl/component_cljs_test.cljs` constructs `create-class` with each of {`:component-will-mount`, `:UNSAFE_componentWillMount`, `:component-will-receive-props`, `:UNSAFE_componentWillReceiveProps`, `:component-will-update`, `:UNSAFE_componentWillUpdate`, `:should-component-update`, `:get-derived-state-from-props`, `:get-initial-state`} and asserts each throws `:rf.error/create-class-key-unsupported` with the unsupported key in `:keys`. |
+| **R-003** Compile-time Form-detection changes user-facing API | Retired as a risk: no separate `defview` surface ships (rf2-yfbx; §5.2 + §14.1), so the classification is invisible to users. The runtime path in `wrap-render` remains the canonical (mandatory) implementation, and tests assert plain `defn` + `reg-view` works with all three Form shapes whether or not the fold applies. |
+| **R-004** Pure-CLJS `render-to-static-markup` differs from `react-dom/server` | `dom/parity_cljs_test.cljs` per §8.7 — corpus-based diff. Known-difference allow-list documented in the parity test itself. |
+| **R-005** Microtask scheduler interacts unexpectedly with React 19 transitions | `dom/client_cljs_test.cljs` exercises `useTransition` boundaries; `flush-views!` drains React's pending work without race. |
 | **R-006** 10x v1 monkey-patches break | NOT tested in this artefact — documented as a known breakage in the migration corpus (`migration/from-re-frame-v1/README.md`). 10x v1 doesn't load against the rewrite; Xray is the contract. Apps running 10x v1 stay on the bridge `day8/re-frame2-reagent`. |
 | **R-007** Bundle estimates may be off by 30-50% | Per S3-008, the comparison build is delivered (rf2-5lbx) — see §12.2 + §12.3. The S3-008 *contract* (no stock-Reagent impl-leak, no `react-dom/server` leak) is enforced quantitatively by the symbol grep. The *size* half of R-007 remains a Stage-5 follow-up: in the in-tree shadow-cljs build both adapter trees live on the same classpath, and `re-frame.interop` still statically `:require`s stock `reagent.core` / `reagent.ratom`, so a per-build classpath-pruning hook is needed before the realised-gzip-reduction measurement is meaningful. The current in-tree numbers (stock counter ~93 KB gz, slim counter ~93 KB gz) reflect that shared-classpath shape and are NOT the binding "slim" claim. |
 
@@ -1182,9 +1257,9 @@ The following surfaced during drafting as Stage-4-or-later calls. Stage 4 (rf2-6
 
 ### §14.1 The `defview` macro vs `reg-view` — namespace collision
 
-Stage 4 ships `reagent2.impl.component/defview` as an optional Form-detection macro (per S3-003). re-frame2 already ships `re-frame.core/reg-view` as the canonical view-registration macro. They serve different purposes (`reg-view` registers in the view registrar; `defview` just emits a Form-typed component) but the names are close and may confuse.
+**The question, as it stood before Stage 4** (recorded verbatim as history — the answer is below, and the shipped tree follows the answer): S3-003 proposed `reagent2.impl.component/defview` as an optional Form-detection macro. re-frame2 already shipped `re-frame.core/reg-view` as the canonical view-registration macro. They would have served different purposes (`reg-view` registers in the view registrar; `defview` would just emit a Form-typed component) but the names are close and would confuse.
 
-**Open question for Mike**: does `defview` ship as a Reagent-flavoured user surface, or is it simply absorbed into `reg-view` as an internal optimisation (Form detection moves into the macro that already exists)? If the latter, S3-003's "optional macro" framing changes — the runtime detection path stays load-bearing for `reg-view*` and direct `defn`-and-register paths, and `reg-view` quietly classifies at compile time.
+**Open question for Mike (as put)**: does `defview` ship as a Reagent-flavoured user surface, or is it simply absorbed into `reg-view` as an internal optimisation (Form detection moves into the macro that already exists)? If the latter, S3-003's "optional macro" framing changes — the runtime detection path stays load-bearing for `reg-view*` and direct `defn`-and-register paths, and `reg-view` quietly classifies at compile time.
 
 **Disposition (as shipped)**: resolved per the rf2-yfbx decision — `defview` is **not** shipped. The runtime Form-detection path is the canonical implementation; no separate `defview` macro exists (see `reagent2/impl/component.cljs:31` and `component.clj:10`: "No separate `defview` macro is shipped"). This matches the original recommendation (ship runtime detection, skip `defview`).
 
@@ -1214,7 +1289,7 @@ A child component throws a Promise (Suspense's standard pattern); the parent's `
 
 **Open question**: the spec says "drains React's pending work as a single composed operation" (§4.2). React 19's `act` does drain Suspense — but the precise sequencing (microtask-microtask vs microtask-then-act vs act-then-microtask) is non-trivial. Stage 4 picks an order and tests it; Stage 3 doesn't pre-commit.
 
-**Disposition (as shipped)**: settled and tracked as bead **rf2-w6ef**. Stage 4 picked the **microtask → act → microtask** ordering for `flush-views!`: a leading microtask flushes pending re-frame2 state changes before handing off to React's `act`; `act` drains React's commit phase and any Suspense boundaries (awaiting the thrown Promise, re-rendering on resolution); a trailing microtask settles re-frame2 effects that ran inside the React commit. The choice + rationale are documented at `reagent2/dom/client.cljs:24-59` and exercised by the Suspense test in `dom_client_cljs_test.cljs`.
+**Disposition (as shipped)**: settled and tracked as bead **rf2-w6ef**. Stage 4 picked the **microtask → act → microtask** ordering for `flush-views!`: a leading microtask flushes pending re-frame2 state changes before handing off to React's `act`; `act` drains React's commit phase and any Suspense boundaries (awaiting the thrown Promise, re-rendering on resolution); a trailing microtask settles re-frame2 effects that ran inside the React commit. The choice + rationale are documented at `reagent2/dom/client.cljs:24-59` and exercised by the Suspense test in `test/reagent2/dom/client_cljs_test.cljs`.
 
 ### §14.6 Source-coord stamping + `:>` interop
 

--- a/implementation/adapters/reagent-slim/src/reagent2/dom/client.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/client.cljs
@@ -70,47 +70,47 @@
 ;; flush-views! — test-flush primitive (Stage 4-B)
 ;; ---------------------------------------------------------------------------
 ;;
-;; Implementation note on `react/act`: under React 18.3+ `act` is a
-;; top-level export of `react`. Under React 18.2 `act` lived in
-;; `react-dom/test-utils`. The artefact targets React 19 (Stage 1
-;; commitment); we still feature-detect to stay graceful under the
-;; React 18.3 dev tree the implementation/ tests run under, since
-;; that ALSO has `react/act`.
+;; Implementation note on `react/act`: `act` is a top-level export of
+;; `react` from 18.3 onward, and the repository's React floor is 19
+;; (`implementation/package.json` + its lock pin react / react-dom
+;; 19.2.0; generated consumers are pinned to the same version by
+;; `tools/template/src/day8/re_frame2_template/hooks.clj`, held in
+;; lockstep by `version_lockstep_test.clj`). So `(.-act react)` is the
+;; ONE lookup on every supported tree, and the pre-18.3
+;; `react-dom/test-utils` location is below the floor.
+;;
+;; The probe stays a probe rather than a direct call because React's
+;; PRODUCTION bundle deliberately omits `act`; `flush-views!` degrades to
+;; a plain synchronous flush there (see below) rather than calling an
+;; absent export.
 ;;
 ;; Per IMPL-SPEC §4.2 `flush-views!` is dev-only: gated on `js/goog.DEBUG`
 ;; so :advanced + `goog.DEBUG=false` DCEs the body entirely.
 ;; ---------------------------------------------------------------------------
 
 (defn- resolve-act
-  "Look up React's `act`. Returns the fn or nil. Re-resolved on every
-  call (not cached) so a test fixture that swaps the React module
-  mid-run sees the swap on the next `flush-views!`.
+  "Look up React's `act`. Returns the fn, or nil when the export is absent
+  (a missing JS property reads as `nil?` in CLJS, so `flush-views!`'s
+  `nil?` branch covers it). Re-resolved on every call (not cached) so a
+  test fixture that swaps the React module mid-run sees the swap on the
+  next `flush-views!`.
 
-  React-floor asymmetry (rf2-uuzkp). This SUBSTRATE-level resolver is
-  React-19-floored BY INTENT: it probes only `(.-act react)` and has NO
-  `react-dom/test-utils` fallback, so under a React-18.2 dev tree (where
-  `act` lived in test-utils) the substrate-level `flush-views!` below
-  degrades to a plain synchronous flush. This is NOT in conflict with the
-  CANONICAL cross-substrate test-flush path: the adapter-ns `flush-views!`
-  Var (`re-frame.adapter.reagent-slim/flush-views!`, surfaced identically
-  across all four substrates per rf2-b6nm5 Decision 6) routes through the
-  spine's `resolve-act-fn` (`re-frame.substrate.spine`), which DOES carry
-  the test-utils fallback (rf2-jk7hr) and so works under React 18.x. The
-  fallback there is load-bearing for the stock-Reagent (non-slim) adapter;
-  this substrate-level resolver intentionally omits it. A future React-floor
-  change, or a caller reaching this substrate-level `flush-views!` directly
-  (e.g. for its Promise return / Suspense ordering), should expect the
-  React-19 floor here and use the adapter-ns Var when React-18 graceful
-  degradation is required."
+  React-19 floor (rf2-uuzkp, rf2-6r9j.35). `(.-act react)` is the ONE
+  lookup: the repository pins react / react-dom 19.2.0 and generated
+  consumers with it, so the pre-18.3 `react-dom/test-utils` location is
+  below the floor and probing it would buy nothing. A nil result therefore
+  means React's PRODUCTION bundle (which omits `act` by design), and
+  `flush-views!` degrades to a plain synchronous flush — the documented
+  safe behaviour, not a compatibility path.
+
+  The canonical cross-substrate test-flush entry point remains the
+  adapter-ns Var `re-frame.adapter.reagent-slim/flush-views!` (surfaced
+  identically across substrates per rf2-b6nm5 Decision 6), which routes
+  through the spine's `resolve-act-fn`. Reach this substrate-level
+  `flush-views!` directly only for its Promise return / Suspense
+  ordering."
   []
-  (or (.-act react)
-      ;; Fallback: pre-18.3 lived in react-dom/test-utils. We don't
-      ;; require that ns up top because Stage 4-B's React floor is
-      ;; 19+; the .-act check on the react module is the only path
-      ;; we exercise. See the React-floor asymmetry note above for why
-      ;; the canonical adapter-ns flush-views! (via the spine resolver)
-      ;; still degrades gracefully under React 18.x while this one does not.
-      nil))
+  (.-act react))
 
 (defn- microtask-tick
   "Return a Promise that resolves on the next microtask turn. Awaiting

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -22,8 +22,9 @@
   Compile-time fold (rf2-yfbx): the runtime detection in `wrap-render`
   is the load-bearing correctness mechanism. Per IMPL-SPEC §14.1 the
   recommended fold is for `re-frame.core/reg-view`'s expansion to add
-  a compile-time form-tag (via the `reagent2.impl.component/-form-tag`
-  meta on the wrapped fn), letting `wrap-render` skip the runtime
+  a compile-time form-tag (the `:reagent2/form` meta stamped onto the
+  wrapped fn, built by `reagent2.impl.component/tag-form-meta` on the
+  CLJ side), letting `wrap-render` skip the runtime
   classification on the hot path. The runtime path stays load-bearing
   for plain `(reg-view* :id (fn ...))` callers and for paths where the
   fold isn't applied — i.e. correctness without the macro is preserved.

--- a/implementation/adapters/reagent-slim/test/reagent2/dom/client_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/dom/client_cljs_test.cljs
@@ -19,10 +19,51 @@
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing async]]
+            ["react" :as react]
             [reagent2.ratom :as ratom]
             [reagent2.impl.batching :as batching]
             [reagent2.impl.component :as component]
             [reagent2.dom.client :as dom-client]))
+
+;; ---------------------------------------------------------------------------
+;; The React-19 act floor (rf2-6r9j.35).
+;;
+;; `reagent2.dom.client/resolve-act` probes `(.-act react)` and NOTHING else —
+;; the pre-18.3 `react-dom/test-utils` location is below the repository's React
+;; floor (react / react-dom 19.2.0, pinned in implementation/package.json and
+;; its lock, and for generated consumers in tools/template's hooks.clj).
+;;
+;; This is the non-vacuous proof that the ONE lookup is the live path: swap a
+;; spy onto `react.act`, call `flush-views!`, and observe the callback pass
+;; THROUGH the spy. Remove the `act` call from `flush-views!` (or resolve `act`
+;; from anywhere but the `react` module) and the spy count stays 0 and this
+;; goes red.
+;; ---------------------------------------------------------------------------
+
+(deftest flush-views-routes-the-drain-through-react-act
+  (testing "flush-views! obtains act from the `react` module and runs its drain
+            inside it"
+    (async done
+      (let [original (.-act react)
+            seen     (atom 0)
+            restore! (fn [] (set! (.-act react) original))]
+        (is (fn? original)
+            "PRECONDITION: React 19 exports `act` on the `react` module — if this
+             fails the floor moved and the spy below would pass vacuously")
+        (set! (.-act react)
+              (fn [thunk]
+                (swap! seen inc)
+                (original thunk)))
+        (-> (js/Promise.resolve (dom-client/flush-views!))
+            (.then (fn [_]
+                     (restore!)
+                     (is (= 1 @seen)
+                         "flush-views! must route its drain through react/act")
+                     (done)))
+            (.catch (fn [e]
+                      (restore!)
+                      (is false (str "flush-views! threw: " e))
+                      (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; flush-views! basic — drains the dirty-set + after-render

--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -712,10 +712,9 @@ the picker / focus selects). The contract — the shared seam
   content.
 - **Fail-closed.** An unreachable observed frame (nil / destroyed /
   never-registered) is stamped with a **non-nil dead-frame sentinel** as the
-  `:frame` opt — an id that can never resolve to a live frame — so the
-  underlying `elide-wire-value` walker takes its **unresolvable-frame**
-  redact-whole branch, redacting the entire value rather than shipping it raw
-  under no policy. The sentinel is stamped, **not** omitted: an absent / nil
+  `:frame` opt — so the underlying `elide-wire-value` walker takes its
+  **unresolvable-frame** redact-whole branch, redacting the entire value rather
+  than shipping it raw under no policy. The sentinel is stamped, **not** omitted: an absent / nil
   `:frame` opt would let the walker fall through to the **ambient**
   dynamically-bound frame (`frame/resolve-current-frame`) and ship
   value-bearing fields RAW under that borrowed frame's (possibly empty)
@@ -724,6 +723,26 @@ the picker / focus selects). The contract — the shared seam
   `:rf.egress/local-raw` opt-in (explicit `:rf.size/include-sensitive? true`)
   the walker ships the value raw even under the sentinel — the operator has
   deliberately waived redaction.
+
+  **What makes the sentinel unresolvable is that nothing outside the seam can
+  ever hold one (rf2-ws60).** The naive reading — "pick an id no app would
+  register" — is wrong three times over, and each wrong reading shipped: a
+  `::`-namespaced keyword is an ordinary public keyword an app CAN register;
+  a private host object handed back to a caller is an id that caller can
+  register; and a per-call host object still travels inside an opts map the
+  caller can register against and then replay. `make-frame` validates no `:id`
+  type and the registry is keyed by whatever id it is handed, so ANY value a
+  caller can obtain is a value a caller can register a live frame under —
+  which makes the stamp RESOLVE, takes the walker's live-frame branch, and
+  ships the value raw under that frame's empty declaration registry. The
+  invariant is therefore about the SEAM, not the sentinel's spelling: the
+  sentinel is minted and consumed entirely inside
+  `panels/local-render`, the opts builder that carries it is private, and the
+  only structure crossing the namespace boundary is the projected value
+  `local-render-value` / `local-render-value-at` return. Sibling egress
+  carriers (`day8.re-frame2-xray.egress`, `re-frame.derivation.egress`) hold
+  the same invariant by building their opts inline as the walker's argument.
+  Pinned by `local_render_cljs_test` §7c.
 
 Revealing sensitive values is **not** a process-global toggle. Per
 [Spec 015 §Cross-tool visibility grain](../../../spec/015-Data-Classification.md#cross-tool-visibility-grain)

--- a/tools/xray/src/day8/re_frame2_xray/panels/local_render.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/local_render.cljc
@@ -133,33 +133,46 @@
   value — so no registration a caller writes by hand can match it, and
   `frame/frame` misses on it exactly as on a destroyed id.
 
-  ## Why per-call, and not one shared private singleton (rf2-ws60, second pass)
+  ## No public exit — the invariant, and the two passes that missed it
 
-  Making the identity private is NECESSARY AND NOT SUFFICIENT. The second pass
-  bound one `(Object.)` to a `^:private def` and claimed 'no frame can be
-  registered under it' — but the PUBLIC `local-render-opts` RETURNS that value
-  in `:frame` for every nil / unreachable target, so a caller never had to
-  manufacture an equal object: it was HANDED the identical one. Registering a
-  frame under the value it received made every SUBSEQUENT unreachable
-  projection resolve to that live frame and ship the secret raw — the same
-  fail-OPEN outcome as the keyword, reached through the return value instead of
-  through the spelling. Reproduced on the JVM lane at the merged commit:
-  `{:same-sentinel? true, :registered? true, :rendered {:auth {:token \"…\"}}}`.
+  A private identity is NECESSARY AND NOT SUFFICIENT. The second pass bound one
+  `(Object.)` to a `^:private def` and claimed 'no frame can be registered under
+  it' — but `local-render-opts` was PUBLIC and RETURNED that value in `:frame`
+  for every nil / unreachable target, so a caller never had to manufacture an
+  equal object: it was HANDED the identical one. Registering a frame under the
+  value it received made every SUBSEQUENT unreachable projection resolve to that
+  live frame and ship the secret raw — the same fail-OPEN outcome as the
+  keyword, reached through the return value instead of through the spelling.
 
-  So the discriminating question is NOT 'is the definition private' but **does
-  any PUBLIC fn RETURN a structure containing it** — and here one does, by
-  design, because `local-render-opts` is the seam's opts builder. Minting a
-  FRESH identity per call answers it without withdrawing that seam: the value
-  governing any one projection is created inside that call and is not
-  observable by anyone before the walk consumes it, so there is no longer a
-  durable identity to poison. What a direct caller of `local-render-opts`
-  receives is a single-use id that governs nothing else — registering a frame
-  under it cannot affect any other projection.
+  The third pass minted a FRESH identity per call and kept the builder public.
+  That closed the *durable* poisoning route and left an immediate one open: the
+  caller registers a frame under `(:frame opts)` and then hands THAT SAME opts
+  map back to `rf/project-egress`. Reproduced on the JVM lane at the merged
+  commit, source untouched:
+  `{:registered? true, :projected {:auth {:token \"audit-secret-jwt-9f3a\"}}}`.
 
-  Contrast the two sibling carriers, which are clean for the OTHER reason
-  available: in `day8.re-frame2-xray.egress` and `re-frame.derivation.egress`
-  the sentinel is consumed by a walk whose caller only ever receives the
-  PROJECTED VALUE / TRANSFORMED GRAPH, so it has no public exit at all.
+  So the discriminating question is not 'is the definition private', nor 'is the
+  identity fresh', but **does any PUBLIC fn RETURN a structure containing it**.
+  Both sibling carriers answer NO and are clean for exactly that reason: in
+  `day8.re-frame2-xray.egress` `egress-value` builds its opts map INLINE as the
+  argument to the walker and returns the walker's result; in
+  `re-frame.derivation.egress` `walk-opts` is bound inside `project-graph`'s
+  `let` and `project-graph` returns the transformed graph. Neither ever hands an
+  opts map to anyone.
+
+  This namespace now answers NO the same way: `local-render-opts` is PRIVATE, so
+  the only structures crossing the namespace boundary are the projected values
+  `local-render-value` / `local-render-value-at` return. Nothing outside can
+  obtain a sentinel to register a frame under, or an opts map to replay.
+
+  ## Why per-call as well (defence in depth, and it is free)
+
+  Freshness is no longer the invariant, but it is kept, because it costs a bare
+  allocation on a branch that is already the cold one and it removes the
+  DURABLE identity a future re-exposure of the builder would otherwise hand out.
+  With both properties in place, a sentinel that somehow escaped would govern
+  its own single projection and nothing else. Do not cache, intern, or hoist it,
+  and do not make the builder public again.
 
   Mirrors the off-box derivation-graph fix (rf2-udkj69); applied to
   local-render by rf2-cra0nq. Third carrier of the sentinel class, alongside
@@ -181,9 +194,15 @@
   [raw?]
   (if (true? raw?) local-raw-profile local-redacted-profile))
 
-(defn local-render-opts
+(defn- local-render-opts
   "Build the `rf/project-egress` opts map for an on-box local render of a
   value sourced from `frame-id`.
+
+  **PRIVATE, and that is the load-bearing half of the rf2-ws60 fix — see
+  §No public exit in `fresh-dead-frame-sentinel`.** This is the one structure
+  that carries a dead-frame sentinel, so it must never leave the namespace:
+  `local-render-value` / `local-render-value-at` build it and hand it straight
+  to `rf/project-egress`, and a caller receives only the PROJECTED VALUE.
 
   - **profile** — `local-render-profile` resolves the named boundary from
     the per-(tool,frame) `raw?` grain (default `:rf.egress/local-redacted`).
@@ -198,16 +217,14 @@
     unresolvable-frame fail-closed branch (redact the whole value) rather
     than borrow another frame's policy.
 
-    **The sentinel this returns is SINGLE-USE, and that is load-bearing
-    rather than incidental (rf2-ws60).** This fn is PUBLIC and hands the
-    stamped `:frame` straight to its caller, so any sentinel it returned
-    twice would be an id the caller could register a live frame under —
-    making every later unreachable projection resolve to that frame and
-    egress raw, which is exactly how the first two passes at this bug
-    stayed fail-OPEN (a namespaced keyword, then a shared private
-    singleton). Because each call mints a new identity instead, the value
-    you receive governs this opts map only: registering a frame under it
-    cannot affect any other projection. Do not cache, intern, or hoist it.
+    **The opts map this returns must not escape the namespace, and the
+    sentinel it carries is SINGLE-USE (rf2-ws60).** The three passes at
+    this bug were a public keyword, a public shared private-def object,
+    and a public per-call object; each stayed fail-OPEN because the
+    caller could get its hands on the sentinel (or on this very map) and
+    register a live frame under it. Privacy is what closes that, and
+    freshness is what keeps any future escape harmless. Do not cache,
+    intern, or hoist the sentinel, and do not make this fn public.
   - **`:rf.size/include-large? true`** — the on-box 'keep large' override
     (EP-0015 §10: `local-redacted` *suppresses sensitive display*; the
     local operator IS entitled to large values — Xray's own size-bounding

--- a/tools/xray/test/day8/re_frame2_xray/panels/local_render_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/local_render_cljs_test.cljc
@@ -90,6 +90,24 @@
    :ui      {:open? true :tab :home}})
 
 ;; ---------------------------------------------------------------------------
+;; WHITE-BOX REACH, JVM LANE ONLY (rf2-ws60, third pass).
+;;
+;; `local-render-opts` is PRIVATE — that privacy IS the fix (see §7c), so the
+;; arms that inspect the opts map have to reach the var by name rather than by
+;; reference. `resolve` is used instead of `#'`: Clojure's `var` special form
+;; refuses a non-public var from another namespace, and in ClojureScript a
+;; cross-namespace private reference compiles with a warning, which would put
+;; the very escape hatch this bead closes back into the CLJS build. So the
+;; reach exists on the JVM lane only; the source is one shared `.cljc`
+;; definition, and every arm that can be written against the PUBLIC surface is
+;; written there and runs in both lanes.
+;; ---------------------------------------------------------------------------
+
+#?(:clj
+   (def ^:private local-render-opts*
+     (deref (resolve 'day8.re-frame2-xray.panels.local-render/local-render-opts))))
+
+;; ---------------------------------------------------------------------------
 ;; 1 + 2. DEFAULT — redact sensitive, KEEP large.
 ;; ---------------------------------------------------------------------------
 
@@ -161,27 +179,28 @@
          walker's frameless redact-whole branch)"))
   (testing "a nil observed frame likewise fails closed"
     (is (= :rf/redacted (local-render/local-render-value app-db-value nil))))
-  (testing "the live frame is carried as the :frame opt; an unreachable one is
-            stamped with a NON-NIL dead-frame sentinel (NOT omitted / nil) so
-            the walker takes its unresolvable-frame fail-closed branch rather
-            than fall through to the ambient frame (rf2-cra0nq)"
-    (is (= secure-frame (:frame (local-render/local-render-opts secure-frame))))
-    (let [unreachable-opts (local-render/local-render-opts :app/does-not-exist)
-          nil-opts         (local-render/local-render-opts nil)]
-      (is (contains? unreachable-opts :frame)
-          "an unreachable frame MUST still stamp :frame (a sentinel), never omit it")
-      (is (some? (:frame unreachable-opts))
-          "the stamped :frame is NON-NIL — a nil/absent :frame borrows the ambient frame")
-      (is (not= :app/does-not-exist (:frame unreachable-opts))
-          "the stamped :frame is a sentinel, not the unreachable id itself")
-      (is (contains? nil-opts :frame)
-          "a nil frame-id MUST stamp the sentinel, not leave :frame nil/absent")
-      (is (some? (:frame nil-opts))
-          "the nil-frame :frame opt is the NON-NIL sentinel"))
-    (is (= :rf.egress/local-redacted
-           (:rf.egress/profile (local-render/local-render-opts secure-frame))))
-    (is (true? (:rf.size/include-large? (local-render/local-render-opts secure-frame)))
-        "the keep-large overlay is always present")))
+  #?(:clj
+     (testing "the live frame is carried as the :frame opt; an unreachable one is
+               stamped with a NON-NIL dead-frame sentinel (NOT omitted / nil) so
+               the walker takes its unresolvable-frame fail-closed branch rather
+               than fall through to the ambient frame (rf2-cra0nq)"
+       (is (= secure-frame (:frame (local-render-opts* secure-frame))))
+       (let [unreachable-opts (local-render-opts* :app/does-not-exist)
+             nil-opts         (local-render-opts* nil)]
+         (is (contains? unreachable-opts :frame)
+             "an unreachable frame MUST still stamp :frame (a sentinel), never omit it")
+         (is (some? (:frame unreachable-opts))
+             "the stamped :frame is NON-NIL — a nil/absent :frame borrows the ambient frame")
+         (is (not= :app/does-not-exist (:frame unreachable-opts))
+             "the stamped :frame is a sentinel, not the unreachable id itself")
+         (is (contains? nil-opts :frame)
+             "a nil frame-id MUST stamp the sentinel, not leave :frame nil/absent")
+         (is (some? (:frame nil-opts))
+             "the nil-frame :frame opt is the NON-NIL sentinel"))
+       (is (= :rf.egress/local-redacted
+              (:rf.egress/profile (local-render-opts* secure-frame))))
+       (is (true? (:rf.size/include-large? (local-render-opts* secure-frame)))
+           "the keep-large overlay is always present"))))
 
 ;; ---------------------------------------------------------------------------
 ;; 5b. THE AMBIENT-BORROW ARM — fail-closed EVEN WHEN an ambient frame is bound
@@ -300,97 +319,160 @@
                    "collision. got: " (pr-str rendered)))
           (is (not= "secret-session-jwt-abc123" (get-in rendered [:auth :token]))
               "the session token leaked through the colliding sentinel frame")))
-      (testing "the stamped :frame is NOT a value the app could have registered
-                — the structural half of the fix, so a future re-spelling as a
-                keyword is caught even if the projection happens to redact"
-        (let [stamped (:frame (local-render/local-render-opts nil))]
-          (is (some? stamped) "the sentinel is still stamped, never nil/absent")
-          (is (not (keyword? stamped))
-              (str "the dead-frame sentinel must not be a keyword — every "
-                   "keyword is an id an app can register. got: " (pr-str stamped)))
-          (is (not= colliding-sentinel-id stamped)
-              "the sentinel must not be the colliding public keyword")))
+      #?(:clj
+         (testing "the stamped :frame is NOT a value the app could have registered
+                   — the structural half of the fix, so a future re-spelling as a
+                   keyword is caught even if the projection happens to redact"
+           (let [stamped (:frame (local-render-opts* nil))]
+             (is (some? stamped) "the sentinel is still stamped, never nil/absent")
+             (is (not (keyword? stamped))
+                 (str "the dead-frame sentinel must not be a keyword — every "
+                      "keyword is an id an app can register. got: " (pr-str stamped)))
+             (is (not= colliding-sentinel-id stamped)
+                 "the sentinel must not be the colliding public keyword"))))
       (finally
         ;; Never leave the colliding id live for a sibling test.
         (rf/destroy-frame! colliding-sentinel-id)))))
 
 ;; ---------------------------------------------------------------------------
+;; 7c. THE PUBLIC-SURFACE INVARIANT (rf2-ws60, THIRD pass — the audit of #9056).
+;;
+;; This is the arm that actually pins the fix, and each earlier regression is
+;; here as a record of what it could not see:
+;;
+;;   §7   registers the RETIRED KEYWORD and asserts structurally that the
+;;        replacement is not a keyword — a test about the SHAPE of the sentinel.
+;;        It stayed GREEN while the second and third passes still leaked.
+;;   §7b  (below) takes the value a caller was HANDED and registers a frame
+;;        under it — a test about the DURABILITY of the sentinel. It stayed
+;;        GREEN while the third pass still leaked, because minting a fresh
+;;        identity per call defeats the *later*-projection route and not the
+;;        *same*-opts-map route: the caller registers a frame under
+;;        `(:frame opts)` and hands THAT SAME opts map back to
+;;        `rf/project-egress`. Reproduced at the merged commit, source
+;;        untouched:
+;;          {:registered? true,
+;;           :projected {:auth {:token "audit-secret-jwt-9f3a"}}}
+;;
+;; Neither shape nor freshness is the invariant. The invariant is **does any
+;; PUBLIC fn of this namespace RETURN a structure containing the sentinel** —
+;; the question both sibling carriers answer NO to (`egress-value` builds its
+;; opts INLINE as the walker's argument; `project-graph` binds `walk-opts` in a
+;; `let` and returns the transformed graph). So `local-render-opts` is PRIVATE,
+;; and what this arm pins is exactly that: no opts map crosses the namespace
+;; boundary, under that name or any other. It fails on all three pre-fix
+;; sources, where the builder was public.
+;;
+;; JVM lane only, because it reads the namespace's var table. The source is one
+;; shared `.cljc` definition, so a CLJS-lane copy would pin nothing further.
+;; ---------------------------------------------------------------------------
+
+#?(:clj
+   (deftest the-opts-map-carrying-the-sentinel-has-no-public-exit
+     (let [publics (ns-publics 'day8.re-frame2-xray.panels.local-render)]
+       (testing "rf2-ws60 — the opts BUILDER is private, so nothing outside the
+                 namespace can obtain a dead-frame sentinel to register a live
+                 frame under, nor an opts map to replay against project-egress"
+         (is (nil? (get publics 'local-render-opts))
+             (str "local-render-opts must NOT be public: it is the one structure "
+                  "that carries a dead-frame sentinel, and a caller holding it "
+                  "can register a frame under (:frame opts) and hand the SAME "
+                  "map back to rf/project-egress — the #9056 leak.")))
+
+       (testing "POSITIVE CONTROL — the projection seam itself IS public, so a
+                 green above is coverage rather than an empty namespace"
+         (doseq [sym '[local-render-value local-render-value-at
+                       local-render-profile local-redacted-profile
+                       local-raw-profile]]
+           (is (contains? publics sym)
+               (str "the public seam lost " sym " — the invariant above would "
+                    "then be passing vacuously"))))
+
+       (testing "and the invariant stated GENERALLY, so a re-exposed builder
+                 under a DIFFERENT name is caught too: no public fn of this
+                 namespace returns a project-egress opts map"
+         (doseq [[sym v] publics
+                 :when   (fn? (deref v))
+                 arity   [1 2 3]
+                 :let    [args (repeat arity nil)
+                          ret  (try (apply (deref v) args)
+                                    (catch Throwable _ ::not-applicable))]
+                 :when   (not= ::not-applicable ret)]
+           (is (not (and (map? ret) (contains? ret :frame)))
+               (str "public fn " sym " (arity " arity ") returned a map carrying "
+                    "a :frame opt: " (pr-str ret) ". An opts map must never "
+                    "cross the namespace boundary (rf2-ws60).")))))))
+
+;; ---------------------------------------------------------------------------
 ;; 7b. THE CALLER-VISIBLE ARM (rf2-ws60, SECOND pass — the audit of PR #9044).
 ;;
-;; §7 above registers the RETIRED KEYWORD and then asserts STRUCTURALLY that the
-;; replacement is not a keyword. That is a test about the SHAPE of the sentinel,
-;; and it is why the first repair passed its own regression while still leaking:
-;; making the identity `^:private` is NECESSARY AND NOT SUFFICIENT, because the
-;; PUBLIC `local-render-opts` RETURNS the stamped `:frame` to its caller. Nobody
-;; had to manufacture an equal object — they were handed the identical one, and
-;; a frame registered under it made the next unreachable projection resolve to
-;; that live frame and ship the secret RAW.
-;;
-;; So these arms exercise the value A REAL CALLER RECEIVES, never the definition:
-;; take `(:frame (local-render-opts nil))`, register a live frame under THAT
-;; EXACT VALUE, and assert an unreachable projection still redacts. Against the
-;; pre-fix code this failed with
+;; Retained as DEFENCE IN DEPTH beneath §7c, not as the invariant. It pins the
+;; property that keeps any future escape harmless: each call MINTS A FRESH
+;; identity, so a sentinel obtained once governs one projection and no other.
+;; Against the second-pass source (one `(Object.)` on a shared `^:private def`)
+;; this failed with
 ;;   {:same-sentinel? true, :registered? true,
 ;;    :rendered {:auth {:token "secret-session-jwt-abc123"}}}
 ;;
-;; The discriminator this pins is not "is the def private" but "does any PUBLIC
-;; fn RETURN a structure containing it" — answered here by minting a FRESH
-;; identity per call, so the escaped value governs nothing else.
+;; JVM lane only now — the sentinel is no longer obtainable from the public
+;; surface, which is the point of §7c, so there is nothing for a CLJS-lane copy
+;; of these arms to reach.
 ;; ---------------------------------------------------------------------------
 
-(deftest local-render-fails-closed-when-a-frame-is-registered-under-the-handed-out-sentinel
-  (testing "rf2-ws60 — an app registers a live frame under the sentinel the
-            PUBLIC local-render-opts handed it. A nil / unreachable observed
-            frame MUST still redact the whole value"
-    (let [handed-out (:frame (local-render/local-render-opts nil))]
-      (rf/make-frame {:id handed-out})
-      (try
-        (testing "a NIL observed frame fails closed despite the registration"
-          (let [rendered (local-render/local-render-value app-db-value nil)]
-            (is (= :rf/redacted rendered)
-                (str "nil observed frame must redact WHOLE even with a live "
-                     "frame registered under the sentinel local-render-opts "
-                     "returned. got: " (pr-str rendered)))
-            (is (not= "secret-session-jwt-abc123" (get-in rendered [:auth :token]))
-                "the session token leaked through the handed-out sentinel")))
+#?(:clj
+   (deftest local-render-fails-closed-when-a-frame-is-registered-under-a-leaked-sentinel
+     (testing "rf2-ws60 — a frame is registered under a sentinel obtained from
+               one opts build. A nil / unreachable observed frame MUST still
+               redact the whole value on every LATER projection"
+       (let [leaked (:frame (local-render-opts* nil))]
+         (rf/make-frame {:id leaked})
+         (try
+           (testing "a NIL observed frame fails closed despite the registration"
+             (let [rendered (local-render/local-render-value app-db-value nil)]
+               (is (= :rf/redacted rendered)
+                   (str "nil observed frame must redact WHOLE even with a live "
+                        "frame registered under a previously minted sentinel. "
+                        "got: " (pr-str rendered)))
+               (is (not= "secret-session-jwt-abc123" (get-in rendered [:auth :token]))
+                   "the session token leaked through the registered sentinel")))
 
-        (testing "an UNREACHABLE observed frame likewise fails closed"
-          (let [rendered (local-render/local-render-value app-db-value
-                                                          :app/does-not-exist)]
-            (is (= :rf/redacted rendered)
-                (str "unreachable observed frame must redact WHOLE. got: "
-                     (pr-str rendered)))))
+           (testing "an UNREACHABLE observed frame likewise fails closed"
+             (let [rendered (local-render/local-render-value app-db-value
+                                                             :app/does-not-exist)]
+               (is (= :rf/redacted rendered)
+                   (str "unreachable observed frame must redact WHOLE. got: "
+                        (pr-str rendered)))))
 
-        (testing "the PATH-AWARE sibling shares the seam, so it fails closed too"
-          (let [rendered (local-render/local-render-value-at
-                           (:auth app-db-value) nil [:auth])]
-            (is (= :rf/redacted rendered)
-                (str "local-render-value-at must redact WHOLE under the same "
-                     "registration. got: " (pr-str rendered)))))
+           (testing "the PATH-AWARE sibling shares the seam, so it fails closed too"
+             (let [rendered (local-render/local-render-value-at
+                              (:auth app-db-value) nil [:auth])]
+               (is (= :rf/redacted rendered)
+                   (str "local-render-value-at must redact WHOLE under the same "
+                        "registration. got: " (pr-str rendered)))))
 
-        (finally
-          (rf/destroy-frame! handed-out))))))
+           (finally
+             (rf/destroy-frame! leaked)))))))
 
-(deftest dead-frame-sentinel-is-single-use-per-projection
-  (testing "rf2-ws60 — the property that makes the handed-out value harmless:
-            each call MINTS A FRESH identity, so a sentinel a caller obtained
-            (and could register a frame under) governs no other projection. A
-            shared singleton is the defect, so assert the values are DISTINCT"
-    (let [a (:frame (local-render/local-render-opts nil))
-          b (:frame (local-render/local-render-opts nil))
-          c (:frame (local-render/local-render-opts :app/does-not-exist))]
-      (is (some? a) "the sentinel is still stamped, never nil/absent")
-      (is (not (identical? a b))
-          (str "two nil-frame opts must NOT share one dead-frame sentinel — a "
-               "reusable identity is registrable by whoever receives it. got: "
-               (pr-str a)))
-      (is (not= a b)
-          "the two sentinels must not be equal either (identity, not a datum)")
-      (is (not (identical? a c))
-          "the nil-frame and unreachable-frame sentinels must differ too")))
+#?(:clj
+   (deftest dead-frame-sentinel-is-single-use-per-projection
+     (testing "rf2-ws60 — each call MINTS A FRESH identity, so a sentinel that
+               somehow escaped governs no other projection. A shared singleton
+               is the second-pass defect, so assert the values are DISTINCT"
+       (let [a (:frame (local-render-opts* nil))
+             b (:frame (local-render-opts* nil))
+             c (:frame (local-render-opts* :app/does-not-exist))]
+         (is (some? a) "the sentinel is still stamped, never nil/absent")
+         (is (not (identical? a b))
+             (str "two nil-frame opts must NOT share one dead-frame sentinel — a "
+                  "reusable identity is registrable by whoever receives it. got: "
+                  (pr-str a)))
+         (is (not= a b)
+             "the two sentinels must not be equal either (identity, not a datum)")
+         (is (not (identical? a c))
+             "the nil-frame and unreachable-frame sentinels must differ too")))
 
-  (testing "a LIVE frame is still carried verbatim — minting applies only to the
-            unreachable branch, so the reachable hot path is unchanged"
-    (is (= secure-frame (:frame (local-render/local-render-opts secure-frame))))
-    (is (identical? secure-frame
-                    (:frame (local-render/local-render-opts secure-frame))))))
+     (testing "a LIVE frame is still carried verbatim — minting applies only to the
+               unreachable branch, so the reachable hot path is unchanged"
+       (is (= secure-frame (:frame (local-render-opts* secure-frame))))
+       (is (identical? secure-frame
+                       (:frame (local-render-opts* secure-frame)))))))


### PR DESCRIPTION
Three surfaces, four beads. `rf2-ws60` is the real defect; the rest is documentation reconciled against what actually ships.

## rf2-ws60 — the local-render opts builder is withdrawn from the public surface

**Third pass at this bug, and the first that names the right invariant.** A dead-frame sentinel is unresolvable only while nothing outside the seam can hold one. `make-frame` validates no `:id` type and the registry is keyed by whatever id it is handed, so *any value a caller can obtain is a value a caller can register a live frame under* — which makes the stamp RESOLVE, takes `elide-wire-value`'s live-frame branch, and ships the value raw under that frame's empty declaration registry.

The two earlier fixes both got the sentinel right and the seam wrong:

| pass | sentinel | still fail-OPEN because |
|---|---|---|
| #9044 | `^:private` `(Object.)` | public `local-render-opts` RETURNED it; register a frame under the handed-out value and every LATER projection resolves |
| #9056 | fresh `(Object.)` per call | public `local-render-opts` still returned the opts MAP; register under `(:frame opts)`, hand THAT map back to `project-egress` |

**Leak reproduced first**, at base `da4bfce174`, JVM lane, source untouched:

```
REPRO {:registered? true,
       :projected {:auth {:token "audit-secret-jwt-9f3a"}, :cart {:items 3}},
       :leaked? true}
exit=1
```

**The fix.** `local-render-opts` becomes `defn-`. That matches the two sibling carriers, which are clean for exactly this reason and not for their sentinel's spelling: `day8.re-frame2-xray.egress/egress-value` builds its opts INLINE as the walker's argument and returns the walker's result; `re-frame.derivation.egress`'s `walk-opts` is bound inside `project-graph`'s `let` and `project-graph` returns the transformed graph. Neither ever hands an opts map to anyone, and now neither does this namespace — the only structures crossing the boundary are the projected values `local-render-value` / `local-render-value-at` return. Per-call minting is KEPT, but as defence in depth rather than as the invariant: it is one allocation on a branch that is already the cold one, and it removes the durable identity a future re-exposure would otherwise hand out.

**The same repro program no longer compiles** against the fixed source:

```
Syntax error (IllegalStateException) compiling lr/local-render-opts
var: #'day8.re-frame2-xray.panels.local-render/local-render-opts is not public
exit=1
```

**The regression (§7c) is written against the invariant, not the sentinel.** It asserts `local-render-opts` is absent from `ns-publics`; carries a positive control that the five real public vars ARE present, so a green cannot come from an empty namespace; and states the rule generally — no public fn of the namespace may return a map carrying a `:frame` key — so a re-exposed builder under a *different* name is caught too. §7 (shape) and §7b (durability) are retained beneath it as a record of what each earlier regression could not see; §7b is now defence in depth.

**Plant, showing it bites and showing the blindness it repairs.** Reverting the single `defn-` to `defn`:

```
FAIL in (the-opts-map-carrying-the-sentinel-has-no-public-exit) (local_render_cljs_test.cljc:376)
FAIL in (the-opts-map-carrying-the-sentinel-has-no-public-exit) (local_render_cljs_test.cljc:401)  x2
Ran 1273 tests containing 6108 assertions.  3 failures, 0 errors.  exit=1
```

All three failures land in the new deftest; the #9044 collision test and the #9056 caller-visible test stayed GREEN under the same plant. Restored by `git hash-object` equality.

`tools/xray/spec/004-App-DB-Diff.md` §Fail-closed carried the claim the code got wrong — "an id that can never resolve to a live frame". It now states the seam invariant instead, with all three wrong readings named so the next pass does not re-derive them.

## rf2-6r9j.35 — React-18 `act` fallbacks (reagent-slim slice only)

**Floor measured from the resolved dependency, not from prose.** `implementation/package-lock.json` resolves react and react-dom at **19.2.0**; `implementation/package.json` devDependencies pin the same; `tools/template/src/day8/re_frame2_template/hooks.clj:191` pins generated consumers to 19.2.0 with a lockstep test against package.json. The one 18.3.1 pin anywhere in the repo is `skills/re-frame2-pair/tests/fixture/package.json` — a skill fixture, outside this fence. **So the premise holds: the React-18 `react-dom/test-utils` location is below the floor.**

In-fence work: `reagent2.dom.client/resolve-act` loses its inert `(or (.-act react) nil)` for the single `(.-act react)` lookup — behaviour-identical, since a missing JS property is already `nil?` in CLJS — and the commentary claiming "the React 18.3 dev tree the implementation/ tests run under" and the React-floor asymmetry note are replaced with the current contract. The probe stays a probe, and the docstring now says why: React's *production* bundle omits `act` by design, so the nil branch is documented safe degradation, not a compatibility path.

Added the acceptance criteria's **non-vacuous `React.act` spy** — swap a spy onto `react.act`, call `flush-views!`, observe the callback pass through it, with a precondition assertion that `act` exists at all so the spy cannot pass vacuously. Plant (`(let [act (resolve-act)]` becomes `(let [act (fn [thunk] (thunk))]`):

```
FAIL in (flush-views-routes-the-drain-through-react-act) (reagent2/dom/client_cljs_test.cljs:60:26)
Ran 11169 tests containing 55731 assertions.  1 failures, 0 errors.  exit=1
```

Exactly one failure, precisely attributable. Restored by hash.

**The bead stays OPEN.** Its other ~13 files — `implementation/core/src/re_frame/substrate/spine.cljs`, the UIx and stock-Reagent adapters and their DOM harnesses, `react_shared_suite`, SSR, machines-viz, Story — are outside this worker's fence, and its acceptance criterion "a repository-wide search for `react-dom/test-utils` returns zero" cannot be met from here. The measurement above is the evidence whoever takes the rest needs.

## rf2-6r9j.33 — reagent-slim IMPL-SPEC reconciled with the shipped tree

Every premise verified at source before editing. Retirement-category call for each thing touched:

**Corrected as false current-tense claims** (the doc calls itself the implementation contract, so these were buildable-against):

- §1.1 layout listed `impl/util.cljs` (no such file), duplicated the `impl/` node, labelled `component.clj` "defview macro", omitted `impl/diag.cljs`, and named test files under a `_test.cljs` convention the tree does not use. Now mirrors `git ls-files .../src` file-for-file.
- §2.4 specified an internal `apply-hiccup` used by `render`/`hydrate-root`; no such def — both call `template/as-element` directly. The public table also omitted `flush-render!`, which ships.
- §2.7's "the defview macro lives in `component.clj`".
- §2.8 listed `do-render`, `wrap-funs`, `cancel-cleanup`, `queue-cleanup` — none exist. Replaced with the actual lifecycle helper structure at contract level, plus the note that disposal is inline in an always-installed `componentWillUnmount`, not a deferred cleanup queue.
- §2.9 + §4.1 + §4.5 described atom-backed `dirty-set` / `scheduled?` and set-membership dedup. Shipped batching is one `RenderQueue` deftype with three mutable fields and lazily-allocated JS arrays; dedup is a `cljsIsDirty` flag on the instance.
- §2.10 specified the whole nonexistent `reagent2.impl.util` namespace (`fun-name`, `*non-reactive*`, `dont-camel-case-pattern`). Replaced by `reagent2.impl.diag`, which does ship and which §2 never documented.
- §4.2's `flush-views!` pseudocode and its "Stage 4 finalises; the import is react :refer [act]" forward-looking note.
- §5's `defview` framing, §5.1's stale `wrap-render` sketch (wrong arity, wrong cached-field name, no compile-time fold), §5.2's `defview` macro sketch — §5.2 is now the compile-time fold inside `reg-view` that actually ships, which is what `component.clj`'s own ns docstring already cites it as.
- §12.1 / §12.5 test filenames.

**Preserved as deliberate history — not deleted:**

- §14's "Disposition (as shipped)" records throughout. §14.1 is the one that needed care: its opening two paragraphs were written in the present tense ("Stage 4 ships `defview`...") *above* a disposition saying it was never shipped. Marked as the question **as it stood before Stage 4**, verbatim, with the disposition left untouched. The decision history is the point of §14; only its tense was lying.
- §14.3–§14.6's rationale, and every "not shipped" / DECISION-n row.
- R-003 in the risk register reframed as retired-with-reason rather than removed.

One in-fence source docstring corrected alongside: `component.cljs` named a `-form-tag` meta that does not exist; the real key is `:reagent2/form`, built by `tag-form-meta`.

## rf2-6r9j.37 — the bridge is React 19 too (audit reopen of #9090)

The audit's narrow ruling: `reagent-slim/DESIGN-RATIONALE.md` §11 still presented `day8/re-frame2-reagent` as a React 17/18 escape hatch on which `r/dom-node` and `reagent.dom/render` "work".

**Measured by unpacking the resolved Maven jars, not from the repo's own docs:**

- `reagent-1.2.0.jar` — `reagent/dom.cljs` defines `dom-node` at line 58; `reagent/core.cljs` mentions it nowhere, so `reagent.core/dom-node` never existed and the historical spelling is `reagent.dom/dom-node`.
- `reagent-2.0.1.jar`, the pin at `implementation/adapters/reagent/deps.edn:15` — **neither** `reagent/dom.cljs` nor `reagent/core.cljs` mentions `dom-node` at all.
- 2.0.1 **does** still define `render`, `unmount-component-at-node` and `force-update-all`. `render`'s own docstring reads *"Usable only with React 18 or older. React 19 doesn't provide react-dom/render function"*, and `render-comp` warns *"react-dom/render function doesn't exist, you are likely trying to use the old DOM api with React 19"* before calling it.

So the rows now distinguish the two cases honestly: `dom-node` **absent on both targets** (compile error either way), and render/unmount/force-update-all **present as Vars on the bridge but non-functional under React 19**. That respects the bead's explicit caution not to generalise the verified absence of `dom-node` to Vars 2.0.1 still defines. The migration note and the adoption bullet no longer offer the bridge as a way to stay on React 17/18.

Skills copies (`skills/re-frame-migration`, `skills/reagent-migration`) were **not** touched — out of fence, automated pass live.

## Gates (foreground, unfiltered, exit codes captured to file)

| gate | result |
|---|---|
| `tools/xray` JVM `clojure -M:test` | **exit 0** — 1273 tests / 6106 assertions (baseline 1272 / 6096: +1 deftest, +10 assertions) |
| `npm run test:cljs` | **exit 0** — 11169 tests / 55731 assertions; compiles both the `.cljc` xray test and the new reagent-slim spy |
| `clj-kondo` on all 5 changed clj/cljs/cljc files | **exit 0** — 0 errors, 0 warnings |
| `scripts/check_readme_links.py --ci` | **exit 0** |
| `scripts/check_doc_slugs.py` | **exit 0** |

**Controls that fired** — three plants, each restored and verified by `git hash-object` equality:

1. broken link planted in `DESIGN-RATIONALE.md` → `check_readme_links.py --ci` **exit 1**, naming file, line and missing target.
2. `defn-` → `defn` on the opts builder → xray JVM **exit 1**, 3 failures, all in §7c.
3. `act` bypassed in `flush-views!` → CLJS suite **exit 1**, 1 failure, the spy.

Not run, deliberately: `mkdocs build --strict` (nothing here is under `docs/`, `spec/` or `migration/`, the only trees its hook stages) and `test:xray-feature-gate` (no scenario mounts an unreachable frame, so it does not reach the changed branch).

Anchors and table column counts in the four changed markdown files were checked by hand — no gate validates markdown prose, tables or rendering.
