### PR TITLE
test(test-quiet): exercise the exit-integrity safeguards instead of around them (rf2-6r9j.89, .76, .92)

### DIFF
--- a/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
+++ b/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
@@ -133,6 +133,14 @@
 ;;      match the `[:cljs.test/default …]` dispatch key — leaves the process
 ;;      to drain its event loop and exit with the seeded 1, failing loudly
 ;;      instead of a silent false-green.
+;;
+;; Neither hazard is reachable from an ORDINARY red run, so each has its own
+;; fault fixture in `re-frame.test-quiet-exit-integrity-fixture-cljs-test`,
+;; driven across a real process boundary by
+;; `re-frame.test-quiet-shadow-node-cljs-test`: one buffers a warning whose
+;; printing throws, the other replaces this defmethod with a no-op so the run
+;; drains on the seeded code.  Removing either safeguard reds its own row and
+;; only that row (rf2-6r9j.89).
 
 (defmethod ct/report [:cljs.test/default :end-run-tests] [summary]
   (if (ct/successful? summary)
@@ -168,19 +176,21 @@
       (env/reset-test-data!)))
 
 ;; ----------------------------------------------------------------------
-;; CLI arg parsing lives in `re-frame.test-quiet.shadow-node-cli` so it
-;; can be unit-pinned without a compile cycle (this ns is `:dev/always`
-;; + expands the `env/get-test-data` test-ns-enumeration macro).
+;; CLI arg parsing AND the pure `--test=` selection rule live in
+;; `re-frame.test-quiet.shadow-node-cli` so they can be unit-pinned without a
+;; compile cycle (this ns is `:dev/always` + expands the `env/get-test-data`
+;; test-ns-enumeration macro).
 
-(defn find-matching-test-vars [test-selectors]
-  (let [test-namespaces  (->> test-selectors (filter simple-symbol?) set)
-        test-var-symbols (->> test-selectors (filter qualified-symbol?) set)]
-    (->> (env/get-test-vars)
-         (filter (fn [test-var]
-                   (let [{test-name :name test-namespace :ns} (meta test-var)]
-                     (or (contains? test-namespaces test-namespace)
-                         (contains? test-var-symbols
-                                    (symbol test-namespace test-name)))))))))
+(defn find-matching-test-vars
+  "`cli/select-matching-test-vars` over the build's live test-var registry.
+
+  The selection RULE deliberately does NOT live here.  No test can require
+  this ns (`:dev/always` + the test-ns-enumeration macro is a compile cycle),
+  so a rule kept here could only ever be pinned by a second copy of itself —
+  and that copy drifted silently for as long as it existed (rf2-6r9j.76).
+  What stays here is the registry lookup the cycle actually forces."
+  [test-selectors]
+  (cli/select-matching-test-vars test-selectors (env/get-test-vars)))
 
 (def ^:private min-tests-env-var
   "Environment variable naming this lane's test-count floor. ONE name across

--- a/implementation/test-quiet/src/re_frame/test_quiet/shadow_node_cli.cljs
+++ b/implementation/test-quiet/src/re_frame/test_quiet/shadow_node_cli.cljs
@@ -51,6 +51,30 @@
     {:test-syms []}
     args))
 
+(defn select-matching-test-vars
+  "The `--test=` selection rule over an explicit `test-vars` collection: a
+  SIMPLE symbol in `test-selectors` selects every var in that namespace, a
+  QUALIFIED symbol selects exactly the var with that fully-qualified name.
+  Vars are matched through their `{:ns :name}` metadata and returned in
+  `test-vars` order.
+
+  This IS the shipped selector — `shadow-node/find-matching-test-vars` is
+  this function over `shadow.test.env/get-test-vars`.  It lives here, apart
+  from the `:dev/always` runner ns, for the same reason `unmatched-selectors`
+  below does: a test cannot require that ns without forming a compile cycle,
+  so a rule kept there could only be pinned by a second, handwritten copy of
+  the predicate — which is exactly the false green this move closes
+  (rf2-6r9j.76)."
+  [test-selectors test-vars]
+  (let [selected-namespaces  (->> test-selectors (filter simple-symbol?) set)
+        selected-var-symbols (->> test-selectors (filter qualified-symbol?) set)]
+    (filter (fn [test-var]
+              (let [{test-name :name test-namespace :ns} (meta test-var)]
+                (or (contains? selected-namespaces test-namespace)
+                    (contains? selected-var-symbols
+                               (symbol test-namespace test-name)))))
+            test-vars)))
+
 ;; ----------------------------------------------------------------------
 ;; Whole-suite test-count floor (rf2-qqzmf).
 ;;

--- a/implementation/test-quiet/src/re_frame/test_quiet/shadow_node_cli.cljs
+++ b/implementation/test-quiet/src/re_frame/test_quiet/shadow_node_cli.cljs
@@ -51,6 +51,26 @@
     {:test-syms []}
     args))
 
+(defn- test-var-names
+  "The `[namespace-symbol fully-qualified-symbol]` a test var's `{:ns :name}`
+  metadata names — both rebuilt through `str`, deliberately.
+
+  `(symbol <ns-symbol> <name-symbol>)` keeps the two parts UNCONVERTED, and
+  ClojureScript hashes a symbol by hashing those parts as strings: a Symbol
+  object has no `.length`, so every symbol built that way hashes to the same
+  constant.  It stays `=` to the reader's `ns/name`, which is what made this
+  invisible — a set finds such a key by `=` while it is small enough to be
+  array-map-backed, and stops finding it above eight entries, where the set
+  hashes.  So `--test=` selected correctly for up to eight qualified
+  selectors and silently selected NOTHING at nine.  Measured, then fixed,
+  while pointing the contract test at this function (rf2-6r9j.76); the copy
+  of the predicate it replaced could not have found it.  The namespace half
+  is rebuilt the same way so the two cannot drift apart."
+  [test-var]
+  (let [{test-namespace :ns test-name :name} (meta test-var)]
+    [(symbol (str test-namespace))
+     (symbol (str test-namespace) (str test-name))]))
+
 (defn select-matching-test-vars
   "The `--test=` selection rule over an explicit `test-vars` collection: a
   SIMPLE symbol in `test-selectors` selects every var in that namespace, a
@@ -69,10 +89,9 @@
   (let [selected-namespaces  (->> test-selectors (filter simple-symbol?) set)
         selected-var-symbols (->> test-selectors (filter qualified-symbol?) set)]
     (filter (fn [test-var]
-              (let [{test-name :name test-namespace :ns} (meta test-var)]
+              (let [[test-namespace test-var-symbol] (test-var-names test-var)]
                 (or (contains? selected-namespaces test-namespace)
-                    (contains? selected-var-symbols
-                               (symbol test-namespace test-name)))))
+                    (contains? selected-var-symbols test-var-symbol))))
             test-vars)))
 
 ;; ----------------------------------------------------------------------
@@ -127,16 +146,9 @@
   that matches nothing must be rejected, not
   reported as a 0-test success."
   [test-selectors matched-test-vars]
-  (let [matched-namespaces (->> matched-test-vars
-                                (map (comp :ns meta))
-                                set)
-        matched-var-symbols (->> matched-test-vars
-                                 (map (fn [test-var]
-                                        (let [{test-namespace :ns
-                                               test-name      :name}
-                                              (meta test-var)]
-                                          (symbol test-namespace test-name))))
-                                 set)]
+  (let [matched-names       (map test-var-names matched-test-vars)
+        matched-namespaces  (set (map first matched-names))
+        matched-var-symbols (set (map second matched-names))]
     (remove (fn [selector]
               (if (qualified-symbol? selector)
                 (contains? matched-var-symbols selector)

--- a/implementation/test-quiet/test/re_frame/test_quiet_exit_integrity_fixture_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_exit_integrity_fixture_cljs_test.cljs
@@ -1,0 +1,82 @@
+(ns re-frame.test-quiet-exit-integrity-fixture-cljs-test
+  "Fault fixtures for the two EXIT-CODE INTEGRITY safeguards in
+  `re-frame.test-quiet.shadow-node` (see the comment above its
+  `:end-run-tests` defmethod).  Both exist so a red or torn-down run can
+  never drain to exit 0, and NEITHER is reachable from an ordinary red run —
+  an ordinary red already exited 1 before either safeguard existed.  So each
+  needs a run that deliberately enters the failure mode it guards
+  (rf2-6r9j.89).
+
+  Like the warning-replay fixture beside it, each fault is GATED on its own
+  env var.  Unset — the default for the consolidated whole-suite run — both
+  tests here are trivially green and emit nothing.  The regressions in
+  `re-frame.test-quiet-shadow-node-cljs-test` spawn the REAL built
+  `out/node-test.js` runner focused on this ns with exactly one flag set.
+
+  Each armed fixture emits a distinctive REACHED-STATE marker before it
+  breaks anything, because a nonzero child status on its own proves nothing:
+  a spawn error, a timeout, a parse error, an unrelated uncaught exception
+  and a skipped suite are all nonzero too."
+  (:require [cljs.test :as ct :refer-macros [deftest is]]))
+
+(defn- armed?
+  "True when environment variable `env-var` is exactly \"1\"."
+  [env-var]
+  (= "1" (unchecked-get js/process.env env-var)))
+
+;; ----------------------------------------------------------------------
+;; Fault 1 — the red warning replay itself throws.
+;;
+;; `replay-buffered-warnings!` is diagnostic-only, so the `:end-run-tests`
+;; defmethod wraps it: a throw there must never pre-empt `js/process.exit 1`.
+;; Nothing about an ordinary red run makes the replay throw, so this fixture
+;; buffers a warning whose PRINTING throws — the replay renders buffered
+;; values through `println`, and a value whose `-pr-writer` throws aborts the
+;; replay part-way.  A plain `js/Error` (not `ex-info`) carries the marker so
+;; that, with the guard REMOVED, the escaping exception's message is printed
+;; by node's uncaught handler: the regression discriminates the guarded case
+;; from the unguarded one by that message being ABSENT.  Status cannot
+;; discriminate — an uncaught exception exits 1 as well.
+;;
+;; A second, ordinary warning is buffered AFTER the poison: the replay's own
+;; header reaches stderr, that tail marker never does, which is how the
+;; regression tells "entered and aborted" from "completed".
+
+(def ^:private replay-throw-flag "RF2_TQ_REPLAY_THROW_FIXTURE")
+
+(deftest replay-throws-when-armed
+  (when (armed? replay-throw-flag)
+    ;; Buffered FIRST, so the replay hits it before the tail marker.
+    (js/console.warn
+      (reify IPrintWithWriter
+        (-pr-writer [_this _writer _opts]
+          (throw (js/Error. "EXIT-INTEGRITY-REPLAY-POISON")))))
+    (js/console.warn "EXIT-INTEGRITY-REPLAY-TAIL-MARKER"))
+  ;; GREEN unless armed: the consolidated whole-suite run keeps passing.
+  (is (or (not (armed? replay-throw-flag)) (= :expected :actual))
+      "the armed fixture fails, so the run is RED and the poisoned replay runs"))
+
+;; ----------------------------------------------------------------------
+;; Fault 2 — the run never dispatches the exit defmethod.
+;;
+;; Reaching a green `:end-run-tests` is the ONLY path that clears the
+;; `process.exitCode = 1` that `execute-cli` seeds before a run.  A run that
+;; executes tests but never dispatches the runner's defmethod — a torn-down
+;; async run, or a reporter env that does not match the dispatch key — must
+;; drain to that seeded 1 rather than a silent false green.  This fixture
+;; reproduces it by replacing the defmethod with a no-op IN THIS CHILD
+;; PROCESS ONLY (the swap is inside an env-gated test body, so it never runs
+;; in the whole-suite build), then passing: every test is green, nothing
+;; calls `js/process.exit`, and the seed is the only thing left that can make
+;; the child exit nonzero.
+
+(def ^:private no-exit-dispatch-flag "RF2_TQ_NO_EXIT_DISPATCH_FIXTURE")
+
+(deftest bypasses-exit-dispatch-when-armed
+  (when (armed? no-exit-dispatch-flag)
+    ;; Printed BEFORE the swap, so a child that never got here is
+    ;; distinguishable from one that did.
+    (println "EXIT-INTEGRITY-NO-EXIT-DISPATCH-INSTALLED")
+    (defmethod ct/report [:cljs.test/default :end-run-tests] [_summary] nil))
+  (is true
+      "green when unarmed; green-but-seeded-nonzero when armed"))

--- a/implementation/test-quiet/test/re_frame/test_quiet_green_fixture_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_green_fixture_cljs_test.cljs
@@ -1,15 +1,26 @@
 (ns re-frame.test-quiet-green-fixture-cljs-test
   "A deliberately minimal, always-GREEN CLJS suite used as the focused
-  target for the process-level quiet-shape regression in
-  `re-frame.test-quiet-shadow-node-cljs-test`.
+  target for the process-level quiet-shape and `--test=` selection
+  regressions in `re-frame.test-quiet-shadow-node-cljs-test`.
 
-  The quiet-shape regression spawns the REAL built `out/node-test.js`
-  shadow-node entry point with `--test=<this-ns>` and asserts the green
-  stdout collapses to exactly the canonical summary — so this suite must
-  stay trivially green and emit NOTHING of its own (no `println`, no
-  warnings).  Keep it that way: any output here would be a false
-  positive for the regression."
+  It carries exactly TWO passing tests, and the count is load-bearing.  The
+  namespace selector `--test=<this-ns>` must run BOTH (`Ran 2 tests`) while
+  the qualified selector `--test=<this-ns>/a-passing-test` must run exactly
+  ONE (`Ran 1 tests`); that difference is the only end-to-end proof that the
+  runner's simple-symbol and qualified-symbol selector branches are distinct,
+  and a one-test namespace makes them indistinguishable (rf2-6r9j.76).
+  Adding or removing a test here moves both counts.
+
+  The quiet-shape regression additionally asserts the green stdout collapses
+  to exactly the canonical summary, so this suite must emit NOTHING of its
+  own (no `println`, no warnings).  Keep it that way: any output here would
+  be a false positive for that regression."
   (:require [cljs.test :refer-macros [deftest is]]))
 
 (deftest a-passing-test
   (is (= 1 1)))
+
+(deftest another-passing-test
+  ;; The second var: selected by the namespace selector, NOT by
+  ;; `--test=<this-ns>/a-passing-test`.
+  (is (= 2 2)))

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -193,32 +193,15 @@
           (.delete ^java.io.File file))))))
 
 ;; ----------------------------------------------------------------------
-;; Green path.
-
-(deftest green-runner-contract
-  (testing "a green suite through the real -main: exit 0, silent-on-success"
-    (with-fixture-dir
-      (fn [dir]
-        (write-fixture! dir "green_jvm_fixture_test" "green-jvm-fixture-test"
-                        "(deftest a-passing-test (is (= 1 1)))")
-        (let [{:keys [exit out err]} (invoke-quiet-runner dir)
-              non-blank (->> (str/split-lines out)
-                             (remove str/blank?))]
-          (is (zero? exit)
-              (str "green suite must exit 0; got " exit
-                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
-          (is (not (str/includes? out discovery-banner-marker))
-              (str "the cognitect discovery banner must be swallowed on"
-                   " green; captured stdout:\n" out))
-          (is (<= (count non-blank) 3)
-              (str "green stdout must be the canonical <=3-line summary;"
-                   " got " (count non-blank) " non-blank lines:\n"
-                   (str/join "\n" non-blank)))
-          (is (str/includes? out "0 failures, 0 errors.")
-              (str "green stdout must carry the summary line; got:\n" out)))))))
-
-;; ----------------------------------------------------------------------
-;; Exact green stdout shape.
+;; Green path — the exact green stdout shape.
+;;
+;; This is the ONE one-passing-test green subprocess row. A weaker sibling
+;; (`green-runner-contract`) spawned the same fixture through the same
+;; `-main` and asserted a strict subset of what follows: exit 0, no
+;; `Running tests in`, at most three non-blank lines, and `0 failures,
+;; 0 errors.` appearing somewhere. Every one of those clauses follows from
+;; the pins below, which fix the exact line at each position, so it bought
+;; nothing but a second JVM process start (rf2-6r9j.92).
 ;;
 ;; cognitect's banner is `\nRunning tests in #{...}\n` — it opens with a
 ;; BLANK LINE.  Dropping only the `Running tests in #{...}` text left that

--- a/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
@@ -192,7 +192,24 @@
     (testing "an unmatched selector yields nothing"
       (is (= '[] (select-syms '[absent.ns]))))
     (testing "no selectors select nothing (the whole-suite path, not this one)"
-      (is (= '[] (select-syms '[]))))))
+      (is (= '[] (select-syms '[]))))
+    (testing "selection does not depend on HOW MANY selectors were given"
+      ;; Nine, because eight is where ClojureScript's set representation
+      ;; changes: up to eight entries a set is array-map-backed and finds a
+      ;; key by `=`, above that it hashes. A qualified selector is matched
+      ;; against a symbol rebuilt from a var's `{:ns :name}` METADATA, whose
+      ;; parts are symbols, not strings — `=` to the reader's `ns/name` but
+      ;; not hash-equal to it — so every qualified selector silently stopped
+      ;; matching at the ninth. Found by driving the shipped selector; the
+      ;; copied predicate this row replaced could not see it (rf2-6r9j.76).
+      (let [many-vars (mapv #(fake-var 'many.ns (symbol (str "t" %))) (range 9))
+            many-syms (mapv #(symbol "many.ns" (str "t" %)) (range 9))]
+        (is (= many-syms
+               (mapv (fn [test-var]
+                       (let [{test-namespace :ns test-name :name} (meta test-var)]
+                         (symbol (str test-namespace) (str test-name))))
+                     (cli/select-matching-test-vars many-syms many-vars)))
+            "nine qualified selectors must select all nine of their vars")))))
 
 ;; ----------------------------------------------------------------------
 ;; Unmatched-selector guard: a `--test=<selector>` that

--- a/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
@@ -15,9 +15,17 @@
      the pure parser (into `:unknown-args`) and rejected as a fatal parse
      error by `execute-cli`; the process-level pins below
      prove that boundary.
-   - FAILURE EXIT: the `:end-run-tests` defmethod exits 0 iff the
-     summary is `cljs.test/successful?`, 1 otherwise. The predicate is
-     unit-pinned and child-process tests cover the real exit boundary.
+   - EXIT-CODE INTEGRITY: the `:end-run-tests` defmethod exits 0 on a
+     green summary and 1 on a red one, and two safeguards stop a run
+     draining to a false green — the red warning replay is wrapped so a
+     throw cannot pre-empt the nonzero exit, and `execute-cli` seeds
+     `process.exitCode = 1` so a run that never dispatches the defmethod
+     still fails.  All four are pinned at the REAL process boundary, the
+     two safeguards each through their own fault fixture.  None is pinned
+     in-process: a summary predicate is upstream `cljs.test`'s, and the
+     mere presence of a `[:cljs.test/default :end-run-tests]` method is
+     ClojureScript's own no-op — neither is evidence about this runner
+     (rf2-6r9j.89).
    - console.warn CAPTURE COMPAT: the ns-load `console.warn` stub does
      not break the local save/shim/restore capture pattern that
      warning-assertion tests use — a shim installed over the stub still
@@ -28,7 +36,7 @@
   `cljs.test/run-tests` cannot be exercised in-process under this
   runner: `run-tests` is block-based/async and unconditionally fires
   `:end-run-tests`, which shadow-node overrides to `js/process.exit`
-  (see `end-run-tests-exit-decision` below) — a nested run would tear
+  — a nested run would tear
   down the node runner before the outer assertion. The implementation is shared
   CLJC (the banner ns is derived from the failing var's metadata, not a
   clobberable global cell), so the CLJS reporter benefits identically
@@ -38,7 +46,7 @@
   ;; requiring it forms a compile cycle. Pure CLI parsing lives in the
   ;; `-cli` ns; the console.warn stub it installs is live at runtime
   ;; anyway because shadow-node is the :node-test build's :main.
-  (:require [cljs.test :refer-macros [deftest is testing] :refer [successful?]]
+  (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
             [re-frame.test-quiet.shadow-node-cli :as cli]
             [re-frame.test-quiet.warn-buffer :as wb]))
@@ -148,54 +156,43 @@
 
 (defn- fake-var
   "A stand-in for a test var: `meta` returns namespace/name metadata, matching
-  what `find-matching-test-vars` reads."
+  what `cli/select-matching-test-vars` reads."
   [test-namespace test-name]
   (with-meta (fn []) {:ns test-namespace :name test-name}))
 
 (deftest find-matching-test-vars-filtering
-  ;; find-matching-test-vars reads (env/get-test-vars); we cannot inject
-  ;; that registry here, but we CAN pin the selection predicate it builds
-  ;; — the (or (contains? selected-namespaces test-namespace)
-  ;;           (contains? selected-var-symbols
-  ;;                      (symbol test-namespace test-name)))
-  ;; rule — by reproducing it over fake vars. This locks the documented
-  ;; "simple symbol = whole namespace, qualified symbol = single var" contract.
-  (let [test-vars         [(fake-var 'my.ns 'a-test)
-                           (fake-var 'my.ns 'b-test)
-                           (fake-var 'other.ns 'c-test)]
-        select-test-vars  (fn [test-selectors]
-                            (let [selected-namespaces (->> test-selectors
-                                                           (filter simple-symbol?)
-                                                           set)
-                                  selected-var-symbols (->> test-selectors
-                                                            (filter qualified-symbol?)
-                                                            set)]
-                              (->> test-vars
-                                   (filter (fn [test-var]
-                                             (let [{test-name :name
-                                                    test-namespace :ns}
-                                                   (meta test-var)]
-                                               (or (contains? selected-namespaces
-                                                              test-namespace)
-                                                   (contains? selected-var-symbols
-                                                              (symbol test-namespace
-                                                                      test-name))))))
-                                   (map (fn [test-var]
-                                          (let [{test-namespace :ns
-                                                 test-name :name}
-                                                (meta test-var)]
-                                            (symbol test-namespace test-name)))))))]
+  ;; This drives the SHIPPED selector. `shadow-node/find-matching-test-vars`
+  ;; is `cli/select-matching-test-vars` over the live `(env/get-test-vars)`
+  ;; registry, which cannot be injected here — so the registry lookup is the
+  ;; only part this cannot reach, and the RULE is exercised directly.
+  ;;
+  ;; It used to be a handwritten COPY of the predicate, which is a false
+  ;; green by construction: production could stop matching qualified symbols
+  ;; entirely and this stayed green (rf2-6r9j.76). `select-syms` below only
+  ;; RENDERS the returned vars as symbols; it makes no selection decision.
+  (let [test-vars   [(fake-var 'my.ns 'a-test)
+                     (fake-var 'my.ns 'b-test)
+                     (fake-var 'other.ns 'c-test)]
+        select-syms (fn [test-selectors]
+                      (->> (cli/select-matching-test-vars test-selectors
+                                                          test-vars)
+                           (map (fn [test-var]
+                                  (let [{test-namespace :ns test-name :name}
+                                        (meta test-var)]
+                                    (symbol test-namespace test-name))))))]
     (testing "a simple symbol selects every var in that namespace"
       (is (= '[my.ns/a-test my.ns/b-test]
-             (select-test-vars '[my.ns]))))
+             (select-syms '[my.ns]))))
     (testing "a qualified symbol selects exactly that var"
       (is (= '[my.ns/b-test]
-             (select-test-vars '[my.ns/b-test]))))
+             (select-syms '[my.ns/b-test]))))
     (testing "namespace + fully-qualified selectors combine"
       (is (= '[my.ns/a-test my.ns/b-test other.ns/c-test]
-             (select-test-vars '[my.ns other.ns/c-test]))))
+             (select-syms '[my.ns other.ns/c-test]))))
     (testing "an unmatched selector yields nothing"
-      (is (= '[] (select-test-vars '[absent.ns]))))))
+      (is (= '[] (select-syms '[absent.ns]))))
+    (testing "no selectors select nothing (the whole-suite path, not this one)"
+      (is (= '[] (select-syms '[]))))))
 
 ;; ----------------------------------------------------------------------
 ;; Unmatched-selector guard: a `--test=<selector>` that
@@ -286,22 +283,21 @@
           (str (pr-str bad) " must be rejected, not coerced")))))
 
 ;; ----------------------------------------------------------------------
-;; Failure-exit decision — pinned via the predicate the :end-run-tests
-;; defmethod branches on. (Invoking the defmethod itself calls
-;; js/process.exit, which would tear down this runner.)
-
-(deftest end-run-tests-exit-decision
-  (testing "successful? is the green/red branch the exit defmethod uses"
-    (is (true? (successful? {:fail 0 :error 0}))
-        "0 failures + 0 errors is green -> the defmethod exits 0")
-    (is (false? (successful? {:fail 1 :error 0}))
-        "any failure is red -> the defmethod exits 1")
-    (is (false? (successful? {:fail 0 :error 1}))
-        "any error is red -> the defmethod exits 1"))
-  (testing "the exit defmethod is registered for the default reporter"
-    (is (some? (get-method cljs.test/report
-                           [:cljs.test/default :end-run-tests]))
-        "shadow-node must own the process-exit signal")))
+;; NO in-process failure-exit unit test lives here, deliberately (rf2-6r9j.89).
+;;
+;; The one that did asserted upstream `cljs.test/successful?`'s own
+;; behaviour, and that SOME method is registered for
+;; `[:cljs.test/default :end-run-tests]` — but ClojureScript itself defines a
+;; no-op method under exactly that key (cljs/test.cljs), so neither clause
+;; said anything about this runner.  Invoking the real defmethod in-process
+;; is not an option either: it calls `js/process.exit`.
+;;
+;; The decision is pinned end-to-end instead, by the process rows below:
+;; a green focused run exits 0, a red one exits 1, and — because
+;; `execute-cli` seeds `process.exitCode = 1` before every run — a build that
+;; LOST the runner's defmethod and fell back to ClojureScript's no-op would
+;; drain to 1 and red `real-shadow-node-green-run-is-quiet`.  Ownership of
+;; the exit signal is therefore proven, not asserted.
 
 ;; ----------------------------------------------------------------------
 ;; console.warn stub compatibility — the ns-load stub must not break the
@@ -356,7 +352,8 @@
 ;;
 ;; This test spawns the same built `out/node-test.js` shadow-node
 ;; runner this very process is executing, focused on a known-GREEN suite
-;; (`re-frame.test-quiet-green-fixture-cljs-test`, a single `is (= 1 1)`),
+;; (`re-frame.test-quiet-green-fixture-cljs-test`, two trivially passing
+;; tests),
 ;; captures its stdout, and fails if any green line other than the
 ;; allowed canonical summary appears. The `console.warn` stub itself is
 ;; pinned separately above because this fixture deliberately emits no warning.
@@ -538,11 +535,43 @@
                  stdout))
         (is (not (str/includes? stdout "Testing "))
             (str "no per-ns banner may leak on green; got:\n" stdout))
-        (is (some #(str/starts-with? % "Ran ") non-blank)
-            (str "the summary `Ran ...` line must still be present; got:\n"
-                 stdout))
+        ;; The fixture ns holds exactly TWO test vars, so `Ran 2` is also the
+        ;; end-to-end proof that a SIMPLE symbol selects EVERY var in the
+        ;; namespace — `Ran 1` would mean the namespace branch selected only
+        ;; one. Its qualified-symbol sibling is the row below (rf2-6r9j.76).
+        (is (some #(str/starts-with? % "Ran 2 tests") non-blank)
+            (str "the namespace selector must run BOTH vars in the fixture"
+                 " ns, and the `Ran ...` summary must still be present;"
+                 " got:\n" stdout))
         (is (some #(re-matches #"0 failures, 0 errors\." %) non-blank)
             (str "the green tally line must be present; got:\n" stdout))))))
+
+(deftest real-shadow-node-qualified-selector-runs-exactly-that-var
+  (testing "--test=<ns>/<var> runs exactly that var, not its whole namespace"
+    ;; The shipped selector's QUALIFIED-symbol branch, end to end.
+    ;; `--test=<ns>/<var>` is a documented CLI form (`--help` names it) that
+    ;; had no process-level proof at all: every other spawn here selects a
+    ;; namespace or nothing (rf2-6r9j.76).  Paired with the `Ran 2` pin
+    ;; above — same fixture ns, two vars — the two rows discriminate the two
+    ;; branches: a runner treating a qualified symbol as a namespace selector
+    ;; runs both HERE, one that dropped the namespace branch runs one THERE.
+    (let [{status :status stdout :stdout stderr :stderr err :error}
+          (spawn-runner
+            ["--test=re-frame.test-quiet-green-fixture-cljs-test/a-passing-test"])]
+      (is (nil? err)
+          (spawn-error-explanation err))
+      (is (zero? status)
+          (str "a valid qualified selector must run and exit 0; got " status
+               "\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr))
+      (let [non-blank (->> (str/split-lines stdout)
+                           (map str/trim)
+                           (remove str/blank?))]
+        (is (some #(str/starts-with? % "Ran 1 tests") non-blank)
+            (str "exactly ONE var must run — `Ran 2` means the qualified"
+                 " selector was treated as a namespace selector; got:\n"
+                 stdout))
+        (is (some #(re-matches #"0 failures, 0 errors\." %) non-blank)
+            (str "the selected var passes; got:\n" stdout))))))
 
 ;; ----------------------------------------------------------------------
 ;; Process-level unknown-arg false-green guard.
@@ -587,19 +616,13 @@
       (is (not (str/includes? stdout "Ran "))
           (str "the suite must NOT have run; a `Ran ...` summary means the"
                " false-green fall-through to run-all-tests; got:\n" stdout))))
-  (testing "a clean focused invocation still exits 0 (negative control)"
-    ;; The guard must reject ONLY malformed args — a correct `--test=`
-    ;; selector against a real green ns must still run and exit 0.
-    (let [{status :status stdout :stdout stderr :stderr err :error}
-          (spawn-runner ["--test=re-frame.test-quiet-green-fixture-cljs-test"])]
-      (is (nil? err)
-          (spawn-error-explanation err))
-      (is (zero? status)
-          (str "a clean focused run must STILL exit 0 — the guard must not"
-               " reject valid args; got status " status
-               "\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr))
-      (is (not (str/includes? stdout "Unknown arg"))
-          (str "a clean invocation must emit no `Unknown arg`; got:\n" stdout)))))
+  ;; NO clean-focused-invocation control here, deliberately (rf2-6r9j.92).
+  ;; It spawned the exact `--test=re-frame.test-quiet-green-fixture-cljs-test`
+  ;; invocation `real-shadow-node-green-run-is-quiet` above already spawns,
+  ;; and asserted a strict subset of that row's pins — no spawn error, exit 0,
+  ;; no `Unknown arg` — for the price of another whole-bundle child start.
+  ;; That row IS the positive control that valid args are not rejected.
+  )
 
 (deftest unmatched-selector-is-fatal-at-real-runner
   (testing "a parsed but unmatched selector exits nonzero at the real runner"
@@ -635,8 +658,14 @@
 ;; run stays green): with the env var set the fixture warns + fails, and
 ;; the buffered warning must surface in the red output; with it UNSET the
 ;; same fixture is green and emits no warning.
+;;
+;; This row is ALSO the ordinary printed-failure/exit-status agreement pin: a
+;; red run prints its `FAIL in` block and must exit nonzero, and the unarmed
+;; control proves the exit tracks the real result rather than always being
+;; nonzero. A separate regression used to spawn this same armed/unarmed pair
+;; a second time for exactly those assertions (rf2-6r9j.89).
 
-(deftest red-run-replays-buffered-console-warn
+(deftest red-run-replays-warnings-and-exits-nonzero
   (testing "a red run replays the buffered console.warn diagnostic"
     (let [red-ns "re-frame.test-quiet-red-warn-fixture-cljs-test"
           {status :status stdout :stdout stderr :stderr err :error
@@ -659,7 +688,16 @@
                "\n--- stderr ---\n" stderr))
       (is (str/includes? (str stdout stderr) "[test-quiet] console.warn:")
           (str "the replay must label the buffered warnings; got\n"
-               "--- stderr ---\n" stderr))))
+               "--- stderr ---\n" stderr))
+      ;; It genuinely RAN — a nonzero exit with no run is a different failure.
+      (is (str/includes? stdout "Ran ")
+          (str "the suite must have actually run (a `Ran ...` summary);"
+               " got:\n" stdout))
+      ;; …and the failure was PRINTED: the printed symptom and the exit code
+      ;; must never disagree, which is the local-green-not-CI-red trap.
+      (is (str/includes? stdout "FAIL in")
+          (str "the FAIL block must reach stdout AND the exit must be"
+               " nonzero — the two must never disagree; got:\n" stdout))))
   (testing "the SAME fixture is GREEN + quiet when unarmed (negative control)"
     ;; Without the env arming flag the fixture passes and emits no
     ;; warning, so the green-path quiet contract holds and the marker is
@@ -676,6 +714,9 @@
       (is (not (str/includes? stdout "RED-WARN-FIXTURE-MARKER"))
           (str "an unarmed (green) run must NOT emit the warning marker on"
                " stdout — green stays quiet; got:\n" stdout))
+      (is (not (str/includes? stdout "FAIL in"))
+          (str "the unarmed fixture prints no failure — the nonzero exit"
+               " above tracks the REAL result; got:\n" stdout))
       (let [non-blank (->> (str/split-lines stdout)
                            (map str/trim)
                            (remove str/blank?))]
@@ -730,57 +771,103 @@
                "\n--- stderr ---\n" stderr)))))
 
 ;; ----------------------------------------------------------------------
-;; Exit-code integrity: a printed failure must exit nonzero.
+;; Exit-code integrity: the two safeguards, one fault fixture each.
 ;;
-;; This drives the real runner across a process boundary and asserts both
-;; halves: the failure block reaches stdout and the process exits nonzero.
-;; The negative control proves the exit tracks the actual result.
+;; `shadow-node`'s `:end-run-tests` defmethod is the only thing that turns a
+;; red cljs.test summary into a nonzero node exit, and it carries two
+;; safeguards against a run draining to a false green: the red warning replay
+;; is wrapped so a throw cannot pre-empt `js/process.exit 1`, and
+;; `execute-cli` seeds `process.exitCode = 1` before running so a run that
+;; never dispatches the defmethod still fails.
+;;
+;; An ORDINARY red or green run traverses NEITHER — both already exited
+;; correctly before either safeguard existed, so a regression could delete
+;; either one and every ordinary row stayed green (rf2-6r9j.89). Each
+;; safeguard therefore gets a run that ENTERS its own failure mode, driven
+;; against `re-frame.test-quiet-exit-integrity-fixture-cljs-test`, and each
+;; fixture emits a reached-state marker: a nonzero child status by itself is
+;; also what a spawn error, a timeout, a parse error, a skipped suite or an
+;; unrelated uncaught exception look like, and none of those may satisfy
+;; these rows.
 
-(deftest deliberately-failing-test-exits-nonzero
-  (testing "a real failing test prints its failure block and exits nonzero"
-    ;; The armed red fixture runs a genuine `(is (= :expected :actual))` that
-    ;; fails through the ordinary counted-failure path.
-    (let [red-ns "re-frame.test-quiet-red-warn-fixture-cljs-test"
-          {status :status stdout :stdout stderr :stderr err :error
+(def ^:private exit-integrity-fixture-ns
+  "re-frame.test-quiet-exit-integrity-fixture-cljs-test")
+
+(deftest red-replay-throw-cannot-mask-the-nonzero-exit
+  (testing "a red run whose warning replay THROWS still exits 1, quietly"
+    (let [{status :status stdout :stdout stderr :stderr err :error
            timed-out? :timed-out?}
-          (spawn-runner [(str "--test=" red-ns)]
-                        {:env {:RF2_TQ_RED_WARN_FIXTURE "1"}})]
+          (spawn-runner [(str "--test=" exit-integrity-fixture-ns)]
+                        {:env {:RF2_TQ_REPLAY_THROW_FIXTURE "1"}})
+          combined (str stdout stderr)]
       (is (nil? err)
           (spawn-error-explanation err))
       (is (not timed-out?)
-          "the armed fixture run must not time out")
-      ;; The CORE pin: a printed failure MUST drive a non-zero exit.
-      (is (and (number? status) (not (zero? status)))
-          (str "a deliberately-failing test must exit NON-ZERO — a printed"
-               " failure with a 0 exit is the local-green≠CI-red trap"
-               "; got status " status
-               "\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr))
-      ;; It genuinely RAN (not a false green from running nothing)…
+          "the armed replay-throw fixture run must not time out")
+      ;; A GENUINE counted failure was reached — not a parse error, not a
+      ;; skipped suite, not a namespace that failed to load.
       (is (str/includes? stdout "Ran ")
-          (str "the suite must have actually run (a `Ran ...` summary) — a"
-               " non-zero exit with no run would be a different failure;"
-               " got:\n" stdout))
-      ;; …and the failure was PRINTED — the exact symptom the exit code must
-      ;; now agree with.
+          (str "the suite must have actually run; got:\n" stdout))
       (is (str/includes? stdout "FAIL in")
-          (str "the FAIL block must reach stdout AND the exit must be"
-               " non-zero - the two must never disagree; got:\n"
-               stdout))))
-  (testing "the SAME fixture is GREEN + exits 0 when unarmed (negative control)"
-    ;; Proving the non-zero exit is tied to the ACTUAL failure, not a runner
-    ;; that always exits non-zero.
-    (let [red-ns "re-frame.test-quiet-red-warn-fixture-cljs-test"
-          {status :status stdout :stdout stderr :stderr err :error}
-          (spawn-runner [(str "--test=" red-ns)])]
+          (str "a genuine counted failure must have been reached — without"
+               " one the red replay never fires at all; got:\n" stdout))
+      ;; The replay was ENTERED: its header is written before the poison.
+      (is (str/includes? combined
+                         "console.warn message(s) buffered during this run")
+          (str "the red replay must have been entered; got\n"
+               "--- stderr ---\n" stderr))
+      ;; …and ABORTED part-way: the marker buffered AFTER the poison, which a
+      ;; completed replay would print, never arrives.
+      (is (not (str/includes? combined "EXIT-INTEGRITY-REPLAY-TAIL-MARKER"))
+          (str "the replay must have THROWN part-way — the warning buffered"
+               " after the poisoned one must not have been replayed; got\n"
+               "--- stderr ---\n" stderr))
+      ;; The CORE pin. Note that STATUS alone cannot discriminate: with the
+      ;; try/catch removed the same exception escapes, node prints it and
+      ;; exits 1 too. What discriminates is that the exception was SWALLOWED
+      ;; — its message never reaches the output — so the exit is the
+      ;; deliberate `js/process.exit 1`, not a crash that happened to agree.
+      (is (= 1 status)
+          (str "a red run whose replay throws must still exit 1; got " status
+               "\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr))
+      (is (not (str/includes? combined "EXIT-INTEGRITY-REPLAY-POISON"))
+          (str "the replay exception must be swallowed by the guard, never"
+               " surfaced as an uncaught runner crash; got\n"
+               "--- stdout ---\n" stdout "\n--- stderr ---\n" stderr)))))
+
+(deftest run-that-never-dispatches-the-exit-defmethod-drains-nonzero
+  (testing "a GREEN run whose exit defmethod is a no-op drains on the seed"
+    (let [{status :status stdout :stdout stderr :stderr err :error
+           timed-out? :timed-out?}
+          (spawn-runner [(str "--test=" exit-integrity-fixture-ns)]
+                        {:env {:RF2_TQ_NO_EXIT_DISPATCH_FIXTURE "1"}})]
       (is (nil? err)
           (spawn-error-explanation err))
-      (is (zero? status)
-          (str "the unarmed fixture is GREEN; a correct run must still exit 0"
-               " — the exit code tracks the real result, it is not always"
-               " non-zero; got status " status
-               "\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr))
-      (is (not (str/includes? stdout "FAIL in"))
-          (str "the unarmed fixture prints no failure; got:\n" stdout)))))
+      (is (not timed-out?)
+          "a run draining on the seeded exit code must not hang")
+      ;; The fixture reached the state under test. Without this marker a
+      ;; nonzero status proves nothing about the seed.
+      (is (str/includes? stdout "EXIT-INTEGRITY-NO-EXIT-DISPATCH-INSTALLED")
+          (str "the fixture must have replaced the exit defmethod; got:\n"
+               stdout))
+      ;; The suite RAN and was GREEN, so nothing but the seed is left to
+      ;; explain a nonzero status: no parse error, no failure, no crash.
+      (is (str/includes? stdout "Ran ")
+          (str "the suite must have actually run; got:\n" stdout))
+      (is (str/includes? stdout "0 failures, 0 errors.")
+          (str "the run must be GREEN — a real failure would explain the"
+               " nonzero exit without the seed; got:\n" stdout))
+      (is (not (str/includes? stdout "Unknown arg"))
+          (str "no parse error may explain the exit; got:\n" stdout))
+      (is (not (str/includes? stdout "no tests matched"))
+          (str "no unmatched selector may explain the exit; got:\n" stdout))
+      ;; The CORE pin: exit 1 out of `process.exitCode`, drained after a green
+      ;; run that never called `js/process.exit`. Without `seed-failure-exit!`
+      ;; this child exits 0 — the silent false green the seed exists to stop.
+      (is (= 1 status)
+          (str "a run that never dispatches the exit defmethod must drain"
+               " with the SEEDED 1, never 0; got status " status
+               "\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr)))))
 
 ;; ----------------------------------------------------------------------
 ;; Shared spawn timeout/output policy.


### PR DESCRIPTION
Three audit children in `implementation/test-quiet/**`, all the same shape: a row that reports coverage it does not have. Fixing the second one surfaced a real defect in the shipped `--test=` selector, fixed here too.

## rf2-6r9j.89 — exit-integrity regression missed both safeguarded branches

`shadow-node`'s `:end-run-tests` defmethod carries two safeguards: the red warning replay is wrapped so a throw cannot pre-empt `js/process.exit 1`, and `execute-cli` seeds `process.exitCode = 1` so a run that never dispatches the defmethod still fails. Neither is reachable from an ordinary red run — an ordinary red already exited 1 before either existed — so `deliberately-failing-test-exits-nonzero` traversed neither and both safeguards could be deleted while it stayed green.

Each safeguard now has its own fault fixture in the new `re-frame.test-quiet-exit-integrity-fixture-cljs-test`, env-gated exactly like the warning-replay fixture beside it (unarmed, both tests are trivially green and silent):

- **replay throws** — buffers a warning whose `-pr-writer` throws, plus a tail marker buffered after it. The row asserts a genuine counted failure was reached, the replay header printed (entered), the tail marker did **not** (aborted), status is 1, and the poison's message never reaches the output. That last clause is the discriminator: with the `try/catch` removed the same exception escapes and node exits 1 too, so status alone cannot tell the two apart.
- **no exit dispatch** — replaces the defmethod with a no-op in that child only, then passes. The run is green and prints a reached-state marker, so nothing but the seed can explain a nonzero status.

`deliberately-failing-test-exits-nonzero` re-spawned the armed/unarmed warning-replay pair a second time purely for its `Ran`/`FAIL in` assertions; those fold into `red-run-replays-warnings-and-exits-nonzero` (renamed to say so) and the duplicate pair is gone.

`end-run-tests-exit-decision` is retired. It asserted upstream `cljs.test/successful?`'s behaviour and that *some* method is registered for `[:cljs.test/default :end-run-tests]` — a key ClojureScript itself defines a no-op under. The seeded exit code now makes the green process row prove that ownership: a build that lost the runner's defmethod would drain to 1 and red it.

## rf2-6r9j.76 — var-filter regression tested only a copied predicate

`find-matching-test-vars-filtering` asserted against a handwritten copy of the selection predicate, so production could stop matching qualified symbols entirely and the row stayed green. The rule moves to `shadow-node-cli/select-matching-test-vars` — the compile-cycle-safe ns `unmatched-selectors` already lives in for this exact reason — and `find-matching-test-vars` becomes that function over `env/get-test-vars`. The test drives the shipped function; the local helper only renders results as symbols.

`--test=<ns>/<var>` is a documented CLI form (`--help` names it) that had no process-level proof at all. The green fixture ns gains a second passing test so two rows discriminate the branches end to end: the namespace selector must see `Ran 2 tests`, the qualified selector `Ran 1 tests`.

### The defect that found

Driving the shipped selector immediately exposed a real bug. `select-matching-test-vars` matched a qualified selector against a symbol rebuilt from a var's `{:ns :name}` metadata, whose parts are **symbols, not strings**. ClojureScript's `(symbol <ns-symbol> <name-symbol>)` keeps both parts unconverted and hashes a symbol by hashing those parts *as strings* — a Symbol object has no `.length`, so every such symbol hashes to the same constant. It stays `=` to the reader's `ns/name`, which is what hid it: a set finds the key by `=` while small enough to be array-map-backed, and stops finding it above eight entries where the set hashes.

So `--test=` selected correctly for up to eight qualified selectors and silently selected **nothing** at nine, landing in `unmatched-selectors` — which refuses the run — so the symptom is a confusing `no tests matched` red rather than a false green. Measured on the real runner with nine selectors naming nine real test vars: eight reported unmatched. `unmatched-selectors` rebuilt the same symbol the same way; both now route through one `test-var-names` helper, namespace half included so the two cannot drift. The regression pins nine selectors and names why eight is the boundary.

## rf2-6r9j.92 — superseded green subprocess rows

- **JVM**: `green-runner-contract` asserted a strict subset of `green-runner-exact-shape` over the same fixture and the same `-main` — exit 0, no `Running tests in` (which *is* `discovery-banner-marker`), at most three non-blank lines, and `0 failures, 0 errors.` somewhere. The successor fixes the exact line at each position (`(is (= 2 (count non-blank)))`, `(is (str/starts-with? (first non-blank) "Ran "))`, `(is (= "0 failures, 0 errors." (second non-blank)))`) and normalises CRLF, so every clause follows.
- **CLJS**: the clean-focused-invocation control inside `unknown-arg-is-fatal-not-false-green` spawned the exact `--test=re-frame.test-quiet-green-fixture-cljs-test` invocation `real-shadow-node-green-run-is-quiet` already spawns, asserting a strict subset of its pins.

Both retired, each with a comment naming the row that now carries the contract.

## Verification

Per-branch plants, each restored and verified by `git hash-object` against the committed blob:

| plant | row | result |
|---|---|---|
| remove the replay `try/catch` | `red-replay-throw-cannot-mask-the-nonzero-exit` | RED at `:833:11` — poison message escapes as an uncaught crash |
| neuter `seed-failure-exit!` (both call sites) | `run-that-never-dispatches-the-exit-defmethod-drains-nonzero` | RED at `:867:11` — `got status 0` |
| remove the simple-symbol branch | `find-matching-test-vars-filtering` | RED at `:184:11`, `:190:11` |
| remove the qualified-symbol branch | `find-matching-test-vars-filtering` | RED at `:187:11`, `:190:11`; the FQN selector itself then matches nothing at the runner |

Control for the last plant: the identical whole-namespace invocation on the restored tree reports **0** `find-matching-test-vars-filtering` failures against **2** under the plant (44 vs 46 total; the delta is exactly the plant).

Gates, foreground, exit codes captured to files:

- `clj-kondo --lint implementation/test-quiet/{src,test}` — exit 0, 0 errors, 0 warnings.
- JVM `clojure -M:test` in `implementation/test-quiet` — exit 0, `Ran 53 tests containing 275 assertions. 0 failures, 0 errors.`
- CLJS `out/node-test.js`, all 16 contract rows over four runs (chunked to keep each in the foreground): 9/63, 2/13, 2/17, 3/18 assertions, every exit 0. The first chunk passes nine qualified selectors, so the run is itself an end-to-end exercise of the fix — that same invocation exited 1 with eight unmatched before it.
- The three fixture namespaces unarmed: `Ran 6 tests`, exit 0, canonical summary only — the new fixture ns does not perturb the consolidated whole-suite run.

Process-row ledger: CLJS 10 runner spawns before, 10 after (−1 duplicate green, −2 duplicate red/green pair, +2 fault fixtures, +1 qualified-selector proof). JVM one fewer.

Nothing outside `implementation/test-quiet/**` is touched; no spec change is needed.
