### PR TITLE
Schemas tests: the facade is the single adapter-wiring boundary; clarify the Hicasso reverse-edge tool name (rf2-6r9j.51, rf2-6r9j.244)

### DIFF
--- a/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
@@ -45,16 +45,15 @@
   prod-mode assertions would fail under `goog.DEBUG=true` because the
   boundary is a no-op in dev (per Spec 010 L145)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            ;; Per rf2-t0hq the CLJS default validator routes through
-            ;; the late-bind hook `:schemas/malli-validate`, which the
-            ;; `re-frame.schemas.malli` adapter ns publishes at load
-            ;; time. Without it the default validator soft-passes and
-            ;; the boundary interceptor never sees a failure. The
-            ;; canonical opt-in for CLJS apps that want Malli validation
-            ;; at the boundary is to require the adapter ns at boot.
-            [re-frame.schemas.malli]
             [re-frame.core :as rf]
             [re-frame.late-bind :as late-bind]
+            ;; Per rf2-t0hq the CLJS default validator routes through the
+            ;; late-bind hook `:schemas/malli-validate`, published at load
+            ;; time by the `re-frame.schemas.malli` adapter ns — which the
+            ;; facade below `:require`s in its own ns-form (rf2-v96fh,
+            ;; Ruling A). Requiring `re-frame.schemas` is the whole opt-in,
+            ;; so the boundary interceptor sees real Malli verdicts here
+            ;; with no second require at app boot.
             [re-frame.schemas :as schemas]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support])

--- a/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
@@ -15,16 +15,15 @@
   fixtures (schema-app-db-slice-validates.edn et al.) cover the broader
   contract."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            ;; Per rf2-t0hq the CLJS default validator routes through
-            ;; the late-bind hook `:schemas/malli-validate`, which the
-            ;; `re-frame.schemas.malli` adapter ns publishes at load
-            ;; time. The require is the canonical opt-in pattern for
-            ;; CLJS apps that want Malli validation; without it, the
-            ;; default validator soft-passes (per Spec 010
-            ;; §Recommended soft-pass) and no failure trace fires.
-            [re-frame.schemas.malli]
             [re-frame.core :as rf]
             [re-frame.late-bind :as late-bind]
+            ;; Per rf2-t0hq the CLJS default validator routes through the
+            ;; late-bind hook `:schemas/malli-validate`, published at load
+            ;; time by the `re-frame.schemas.malli` adapter ns — which the
+            ;; facade below `:require`s in its own ns-form (rf2-v96fh,
+            ;; Ruling A). Requiring `re-frame.schemas` is therefore the
+            ;; whole opt-in: there is no second require for an app to make,
+            ;; and no "schemas loaded, adapter absent" posture to model.
             [re-frame.schemas :as schemas]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support])
@@ -95,25 +94,28 @@
 
 ;; ---- rf2-t0hq — Malli adapter late-bind seam ------------------------------
 ;;
-;; Two contract tests pin the rf2-t0hq fix. The first asserts that with
-;; the canonical opt-in (`(:require [re-frame.schemas.malli])` — done at
-;; the top of this file) the default validator DOES consult Malli on
+;; Two contract tests pin the rf2-t0hq fix. The first asserts that once
+;; `re-frame.schemas` is loaded — and it `:require`s the Malli adapter in
+;; its own ns-form — the default validator DOES consult Malli on
 ;; CLJS, so a malformed commit fires :rf.error/schema-validation-failure.
 ;; This is the contract the historical bug silently violated — the
 ;; `:cljs (resolve 'malli.core/validate)` runtime resolve returned nil
 ;; and every value was treated as conforming.
 ;;
-;; The second test pins the soft-pass arm: with the late-bind hook
-;; cleared (simulating an app that doesn't require `re-frame.schemas.
-;; malli`), the default validator returns true for every value per
-;; Spec 010 §Recommended soft-pass and no failure trace fires. We
-;; restore the hook on the way out so downstream tests see the canonical
-;; opt-in's behaviour.
+;; The second test pins the soft-pass arm. That arm is NOT an app that
+;; forgot a require: since rf2-v96fh (Ruling A) the facade loads the
+;; adapter, so "schemas loaded, hook unbound" cannot arise from an
+;; application's require list at all. It is the defensive fallback
+;; Spec 010 §Recommended soft-pass reserves for a substitute validator
+;; port that never bound the Malli hook, and for a harness that unbinds
+;; it deliberately — which is exactly what the test does. We restore the
+;; hook on the way out so downstream tests see the wired default again.
 
 (deftest cljs-malli-adapter-enables-validation
-  (testing "Per rf2-t0hq: with `re-frame.schemas.malli` required at
-            app boot, the default validator consults Malli on CLJS and
-            a malformed commit fires :rf.error/schema-validation-failure.
+  (testing "Per rf2-t0hq: with the `re-frame.schemas` facade loaded — and
+            it `:require`s the Malli adapter itself — the default
+            validator consults Malli on CLJS and a malformed commit
+            fires :rf.error/schema-validation-failure.
             The fix's load-bearing contract — historically the CLJS
             runtime `resolve` returned nil and Malli was never consulted,
             so this trace silently never fired."
@@ -133,13 +135,15 @@
           (is (= [:user :age] (-> v :tags :path)))
           (is (= "twenty-three" (-> v :tags :value))))))))
 
-(deftest cljs-no-adapter-soft-passes
-  (testing "Per Spec 010 §Recommended soft-pass: when an app does NOT
-            require `re-frame.schemas.malli`, the late-bind hook
-            `:schemas/malli-validate` is absent, the default validator
-            returns true for every value, and no failure trace fires.
-            We simulate the no-adapter case by temporarily clearing the
-            hook — the implementation must take its soft-pass arm."
+(deftest cljs-unbound-validate-hook-soft-passes
+  (testing "Per Spec 010 §Recommended soft-pass: when the late-bind hook
+            `:schemas/malli-validate` is UNBOUND — a substitute validator
+            port that never published it, or a harness that cleared it —
+            the default validator returns true for every value and no
+            failure trace fires. This is not an app that skipped a
+            require: the facade loads the Malli adapter (rf2-v96fh), so
+            the hook is bound by the time any app code runs. We unbind it
+            deliberately here and restore it in the `finally`."
     (let [prior-v (late-bind/get-fn :schemas/malli-validate)
           prior-e (late-bind/get-fn :schemas/malli-explain)]
       (late-bind/set-fn! :schemas/malli-validate nil)
@@ -152,9 +156,9 @@
           (is (empty? (filter #(= :rf.error/schema-validation-failure
                                   (:operation %))
                               @traces))
-              "soft-pass arm — no validator hook, no failure trace, the
+              "soft-pass arm — hook unbound, no failure trace, the
                malformed commit silently 'conforms' to the spec's
-               new-user-friendly default"))
+               defensive default"))
         (finally
           (late-bind/set-fn! :schemas/malli-validate prior-v)
           (late-bind/set-fn! :schemas/malli-explain  prior-e))))))

--- a/implementation/schemas/test/re_frame/schemas_concurrency_stress_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_concurrency_stress_test.clj
@@ -82,8 +82,6 @@
             [re-frame.core :as rf]
             [re-frame.schemas :as schemas]
             [re-frame.schemas.storage :as storage]
-            ;; Explicit test dependency; the facade also loads this adapter.
-            [re-frame.schemas.malli]
             [re-frame.schemas.test-fixture :as tf])
   (:import [java.util.concurrent CountDownLatch]
            [java.util.concurrent.atomic AtomicLong]))

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -67,9 +67,11 @@
             [re-frame.conformance :as conformance]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            ;; Load-bearing beyond its alias: loading the facade is what
+            ;; publishes the Malli validate/explain hooks (rf2-v96fh) and
+            ;; binds core's `reg-app-schema` re-export through late-bind.
+            ;; clj-kondo reports the ALIAS unused here; the require is not.
             [re-frame.schemas :as schemas]
-            ;; Explicit test dependency; the facade also loads this adapter.
-            [re-frame.schemas.malli]
             [re-frame.schemas.test-fixture :as tf]
             [re-frame.subs :as subs]
             [re-frame.test-support :refer [with-trace-recorder!]]))

--- a/implementation/schemas/test/re_frame/schemas_fail_open_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_fail_open_test.clj
@@ -38,7 +38,6 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.schemas :as schemas]
-            [re-frame.schemas.malli]
             [re-frame.schemas.test-fixture :as tf]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 

--- a/implementation/schemas/test/re_frame/schemas_failure_paths_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_failure_paths_test.clj
@@ -41,7 +41,6 @@
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.schemas :as schemas]
-            [re-frame.schemas.malli]
             [re-frame.schemas.test-fixture :as tf]
             [re-frame.schemas.validate :as validate]
             [re-frame.schemas.validator :as validator]

--- a/implementation/schemas/test/re_frame/schemas_presence_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_presence_test.clj
@@ -37,7 +37,6 @@
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
-            [re-frame.schemas.malli]
             [re-frame.schemas.test-fixture :as tf]
             [re-frame.spec :as spec]
             [re-frame.test-support :refer [with-trace-recorder!]]))

--- a/implementation/schemas/test/re_frame/schemas_reg_side_effects_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_reg_side_effects_test.clj
@@ -34,8 +34,11 @@
             [malli.core :as m]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            ;; Load-bearing beyond its alias: loading the facade is what
+            ;; publishes the Malli validate/explain hooks (rf2-v96fh) and
+            ;; binds core's `reg-app-schema` re-export through late-bind.
+            ;; clj-kondo reports the ALIAS unused here; the require is not.
             [re-frame.schemas :as schemas]
-            [re-frame.schemas.malli]
             [re-frame.schemas.test-fixture :as tf]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -42,8 +42,6 @@
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.schemas :as schemas]
-            ;; Explicit test dependency; the facade also loads this adapter.
-            [re-frame.schemas.malli]
             ;; Compiled schemas exercise fail-closed opaque handling.
             [malli.core :as m]
             ;; White-box tests cover the internal path sanitizer.

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -33,8 +33,6 @@
             ;; callers outside this artefact use the encapsulated facade.
             [re-frame.schemas.validator :as validator]
             [re-frame.schemas.storage :as storage]
-            ;; Explicit test dependency; the facade also loads this adapter.
-            [re-frame.schemas.malli]
             ;; Reuse the shared empty-set digest fixture.
             [re-frame.schemas.digest-parity-fixtures :as digest-fixtures]
             [re-frame.schemas.test-fixture :as tf]

--- a/implementation/schemas/test/re_frame/schemas_walker_literal_operand_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_walker_literal_operand_cljs_test.cljs
@@ -10,13 +10,13 @@
   functions — so a CLJS regression that diverged from the JVM classification is
   caught here.
 
-  `re-frame.schemas.malli` is required so `malli.core` (the fixtures'
-  compiled-schema dependency) is on the `:node-test` classpath, mirroring
-  `re-frame.schemas-cljs-test`."
+  `malli.core` — the fixtures' compiled-schema dependency — reaches the
+  `:node-test` classpath through the fixtures namespace's own require, and
+  through the `re-frame.schemas` facade, which `:require`s the Malli
+  adapter in its own ns-form."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
             [re-frame.schemas :as schemas]
-            [re-frame.schemas.malli]
             [re-frame.schemas.walker-literal-operand-fixtures :as fx]))
 
 ;; ---- pure walker: shared cross-host corpus (parity anchor) ----------------

--- a/implementation/schemas/test/re_frame/schemas_walker_literal_operand_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_walker_literal_operand_test.clj
@@ -26,7 +26,6 @@
             [malli.core :as m]
             [re-frame.core :as rf]
             [re-frame.schemas :as schemas]
-            [re-frame.schemas.malli]
             [re-frame.schemas.test-fixture :as tf]
             [re-frame.schemas.walker-literal-operand-fixtures :as fx]
             [re-frame.test-support :refer [with-trace-recorder!]]))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/hicasso_tool.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/hicasso_tool.cljs
@@ -24,6 +24,25 @@
   scan or a `:require` grep can see stands between a rename on the provider
   and a runtime failure on the wire.
 
+  `read-read-attribution` reads its verb twice on purpose, and the doubling is
+  PREFIX + CONCEPT rather than a stutter. The outer `read-` is the door's own
+  prefix, carried by every read on it, and it marks these as pure PROJECTIONS
+  of state the runtime already retains — against a provider that keeps no
+  accumulator, no occurrence index and no history store. `read-attribution` is
+  the payload's own noun for what is projected, and it is the literal the
+  envelope's `:read` slot carries. (`explain-render` is deliberately unprefixed
+  for the same reason read the other way: it FOLDS Spec 009's ring rather than
+  reading a current table.)
+
+  So the name is not Pair's to shorten. It is ruled rather than incidental —
+  the Hicasso naming ledger read this door name by name and kept all four as
+  shipped, calling the `read-` prefix load-bearing (`rf2-hic-065`, row 51 of
+  `docs/design/hicasso/product/naming-ledger.md`) — and the string below is
+  BOTH the wire tool name and the provider fn name, munged and looked up on the
+  door at runtime by [[projection-form]]. A wire-only rename would either break
+  that lookup or force the two names apart, which is exactly the agreement the
+  paragraph above exists to keep.
+
   ## Three reads, not five — the door answers a different question set
 
   This namespace replaced a five-tool family aimed at


### PR DESCRIPTION
Two independent surfaces, one bead each.

## rf2-6r9j.51 — the facade is the single adapter-wiring boundary in the schemas tests

Ruling A (rf2-v96fh, `d0b95fdc54`) made `re-frame.schemas` `:require` `re-frame.schemas.malli` in its own ns-form, so requiring the artefact publishes the Malli validate/explain hooks. Twelve schemas test namespaces that already required the facade went on requiring the adapter separately, and two CLJS suites still taught that second require as the canonical application opt-in — the exact boot step Ruling A retired.

- **Twelve redundant requires removed.** Census re-run at source before acting: 12 direct `[re-frame.schemas.malli]` requires under `implementation/schemas/test`, every one of them in a namespace that also requires the facade. The premise held exactly as written. `schemas_implies_validation_test.clj` is untouched — it requires only the facade and stays the authority for the transitive contract.
- **Two comment blocks rewritten** (`schemas_cljs_test.cljs`, `schemas_boundary_prod_test.cljs`) to state the automatic facade wiring rather than a second require at app boot.
- **`cljs-no-adapter-soft-passes` becomes `cljs-unbound-validate-hook-soft-passes`.** Behaviour under test is unchanged: the default validator still soft-passes with `:schemas/malli-validate` unbound. What changes is the framing — per Spec 010 §Recommended soft-pass the arm exists for a substitute validator port that never bound the hook, and for a harness that unbinds it deliberately, which is what the test does. It is not an app that forgot a require; the facade makes that posture unreachable.
- **Two load-bearing requires annotated.** `schemas_conformance_test.clj` and `schemas_reg_side_effects_test.clj` each carry `[re-frame.schemas :as schemas]` whose *alias* clj-kondo reports unused (their `schemas/` hits are all `:schemas/*` keywords). With the direct adapter require gone, that one require is the whole wiring — a note now says so, so a future dead-import sweep does not take it.

The walker CLJS suite's docstring justified its require as putting `malli.core` on the `:node-test` classpath. Checked at source: the fixtures namespace requires `[malli.core :as m]` itself, and the facade pulls the adapter regardless. The docstring now says that.

## rf2-6r9j.244 — the reverse-edge MCP tool name: clarified, not renamed

The bead proposes renaming the wire tool `read-read-attribution` to `read-attribution` with a deprecated alias. **That premise does not hold**, on three grounds checked at source; the bead is left open with these recorded rather than closed.

1. **It is ruled.** `docs/design/hicasso/product/naming-ledger.md` row 51 (`rf2-hic-065`) read this door name by name and kept all four reads as shipped, calling the `read-` prefix *load-bearing rather than decorative* — it marks them as pure projections of retained state, against a namespace that keeps no accumulator, no occurrence index and no history store.
2. **The wire name IS the provider fn name.** `projection-form` munges the same string and looks it up on `re-frame.hicasso.tool`'s namespace object at runtime. A wire-only rename either breaks that lookup or forces the two names apart — the agreement the namespace docstring exists to keep, and which `hicasso-wire-test` asserts against the provider's own source.
3. **The provider fn is out of reach and widely consumed** — `implementation/hicasso/`, plus `tools/xray`, `skills/re-frame2-pair/` and `spec/api-manifest.edn`.

The bead's stated ambiguity cost is tool-selection friction, and that is already paid: the descriptor's first clause reads *"Which boundaries read each subscription — the reverse edge, exactly"*, so `tools/list` never leaves the operation ambiguous. What was genuinely unexplained is why the verb doubles, so this PR says it where the next reader meets the name: prefix + concept, `read-` being the door's own marker and `read-attribution` the payload's noun (the literal the envelope's `:read` slot carries). Docstring only — no wire name, payload key, schema, id, path, handler or fixture changes, and `tool-descriptors.edn` is untouched.

## Gates — foreground, exit codes captured to file and read from the file

| gate | result | exit |
|---|---|---|
| `implementation/schemas` `clojure -M:test` (JVM) | 373 tests / 19223 assertions, 0 failures, 0 errors | 0 |
| node-test, focused: `re-frame.schemas-cljs-test`, `...-walker-literal-operand-cljs-test`, `...-sensitive-path-cljs-test`, `re-frame.schemas.digest-parity-cljs-test` | 23 tests / 163 assertions, 0 failures | 0 |
| `npm run test:browser-schemas-boundary-prod` (`:advanced` + `goog.DEBUG=false`) | 11 tests / 20 assertions, 0 failures | 0 |
| `tools/re-frame2-pair-mcp` `node out/server-test.js` | 1120 tests / 4070 assertions, 0 failures, 0 errors | 0 |
| `node scripts/descriptor-manifest-gen.cjs --check` | in sync (30 tools) | 0 |
| `clj-kondo --parallel --fail-level error --lint implementation/schemas --lint tools/re-frame2-pair-mcp` | errors: 0; 10 warnings, all pre-existing and none in a changed file | 0 |

Both hosts were run for `.51` because it is explicitly a CLJS/JVM-divergence bead.

## Controls that fired

- **`.51` negative control** — deleted `[re-frame.schemas.malli]` from the facade's own ns-form and re-ran the JVM suite: **494 failures / 1 error, exit 1**, with `malli-hook-is-wired-by-requiring-the-facade` and `bad-write-to-registered-slot-validates` among them. Restored. This is the acceptance criterion's own control, and it also settles the load-order question the twelve removed requires raised: the facade require carries the whole wiring, and the twelve carried none of it.
- **`.244` negative control** — renamed the wire string to `read-attribution` while the provider kept `read-read-attribution`: **4 failures** — `hicasso-wire-test/every-emitted-read-is-defined-by-the-provider`, `hicasso-wire-test/the-emitter-names-nothing-the-provider-does-not-publish`, `hicasso-tool-test/each-tool-emits-a-runtime-resolved-door-call`, and the pair-mcp conformance corpus. Restored; the final suite run is green.
- **Test-selector control** — the focused node-test selector was verified live: one namespace alone runs 14 tests versus 23 for the four, and a bogus namespace exits 1 with `no tests matched --test=`. The rename was confirmed through `node out/node-test.js --list`: `cljs-unbound-validate-hook-soft-passes` present, `cljs-no-adapter-soft-passes` absent.
- **Residual-require control** — `git grep -E '\[re-frame\.schemas\.malli\]' -- implementation/schemas/test` returns only the prose mention inside `schemas_implies_validation_test.clj`'s docstring (deliberate: it describes the historical footgun); the same command shape over `src` returns the facade's own require, so the instrument was live rather than false-empty.
- **Peer-worktree control** — every live worktree was probed for dirty edits on both surfaces and none had any; a planted edit in this worktree returned through the same command shape, so that probe was not false-empty either.

## By hand

Line endings and encoding were checked as **bytes** after every edit: all twelve schemas files and `hicasso_tool.cljs` remain uniformly CRLF and valid UTF-8. No markdown is touched, so neither doc-link gate is in scope.

## Not done, deliberately

`implementation/schemas/src/re_frame/schemas/storage.cljc`'s `:rf.warning/schema-validator-unavailable` message still advises *"Require `re-frame.schemas.malli` at app boot"*. It is a runtime diagnostic on the unbound-hook path rather than test posture, so it sits outside this bead's scope — but it is the same stale-instruction class and may warrant its own bead.
