### PR TITLE
docs(reagent-adapter): repair the stale Reagent dependency pointer; drop two vestigial test bindings (rf2-6r9j.27, rf2-6r9j.98)

### DIFF
--- a/implementation/adapters/reagent/README.md
+++ b/implementation/adapters/reagent/README.md
@@ -8,7 +8,7 @@ See [`../README.md`](../README.md) for the wider adapter tier and the substrate 
 
 ## Floor: Reagent 2.x + React 19
 
-The bridge supports exactly one combination: Reagent 2.x (currently pinned to `2.0.1` in [`implementation/core/deps.edn`](../../core/deps.edn)) running against React 19. There is no Reagent 1.x compat path and no React 17/18 fallback.
+The bridge supports exactly one combination: Reagent 2.x (currently pinned to `2.0.1` in [this adapter's own `deps.edn`](deps.edn)) running against React 19. This artefact is the sole owner of the stock `reagent/reagent` coordinate — [`implementation/core/deps.edn`](../../core/deps.edn) deliberately carries no stock-Reagent dep, so a UIx or `reagent-slim` consumer gets a Reagent-free core classpath. There is no Reagent 1.x compat path and no React 17/18 fallback.
 
 Rationale, mirroring the `reagent-slim` `DECISION-5` framing ([`../reagent-slim/IMPL-SPEC.md`](../reagent-slim/IMPL-SPEC.md) §Hard constraints, Stage 1 §2.3a):
 

--- a/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
+++ b/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
@@ -47,8 +47,7 @@
             [re-frame.subs.tooling :as subs-tooling]
             [re-frame.flows.tooling :as flows-tooling]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace]))
+            [re-frame.test-support :as test-support]))
 
 ;; ---------------------------------------------------------------------------
 ;; Closed vocabularies from `spec/Derivations.md` and `spec/Spec-Schemas.md`.
@@ -1092,8 +1091,10 @@
   ;; Snapshot both durable partitions, read the on-demand nodes, re-snapshot.
   (let [app-before (frame/frame-app-db-value :rf/default)
         rt-before  (frame/frame-runtime-db-value :rf/default)
-        ;; Read the ordinary subscription.
-        sub-val    @(rf/subscribe [:cart/items])
+        ;; Read the ordinary subscription. The value is deliberately
+        ;; discarded — it may be nil (no cart seeded); the point is that the
+        ;; read RAN, between the two durable-state snapshots.
+        _          @(rf/subscribe [:cart/items])
         ;; Read the resource selector for an unmaterialized key — the idle
         ;; empty-state projection. Reading it must not start work or write a
         ;; cache entry / work-ledger record.
@@ -1102,7 +1103,8 @@
         app-after  (frame/frame-app-db-value :rf/default)
         rt-after   (frame/frame-runtime-db-value :rf/default)]
     (testing "the reads return values (the reads actually happened)"
-      ;; sub-val may be nil (no cart seeded) — the point is the read ran.
+      ;; The subscription read above is unasserted by design (see its comment);
+      ;; the selector read carries the observable claim.
       (is (= :idle (:status sel-val))
           "reading the selector for an unmaterialized key yields the idle empty-state"))
     (testing "neither durable partition changed merely because a reader read"


### PR DESCRIPTION
Two small repairs from the `rf2-6r9j` vestige audit. A third bead in the same
batch (`rf2-6r9j.87`) is verified but deliberately NOT fixed here - see the
last section.

## rf2-6r9j.27 - the Reagent adapter README pointed at the wrong manifest

`implementation/adapters/reagent/README.md` said the `2.0.1` pin lived in
`implementation/core/deps.edn` and linked there. Verified at source:

- `grep -i reagent implementation/core/deps.edn` returns eleven lines, every
  one of them prose. There is no `reagent/reagent` coordinate; the file's own
  comment says stock Reagent is "intentionally NOT a dep of this artefact" and
  that the coordinate "lives in the Reagent adapter artefact".
- `clojure -Spath` from `implementation/core` resolves **no** reagent jar
  (grep exit 1).
- `clojure -Spath` from `implementation/adapters/reagent` resolves
  `reagent-2.0.1.jar`, and that jar's own
  `META-INF/maven/reagent/reagent/pom.xml` reads `<version>2.0.1</version>`.
  So the version was right; only the pointer was wrong.

The line now points at the adapter's own `deps.edn` and states the ownership
split explicitly. The Reagent 2.x / React 19 floor and the no-compat-shim
policy are untouched.

## rf2-6r9j.98 - two vestigial bindings in the derivation-algebra suite

`implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc`:

- **the direct `[re-frame.trace]` require.** `re-frame.core` has required
  `re-frame.trace` since before this suite existed (`core.cljc:52`), and this
  namespace requires `re-frame.core`. An execution probe on this artefact's own
  test classpath - require `re-frame.core` alone, then `(find-ns
  're-frame.trace)` - reports the namespace already loaded, so the direct edge
  performed no registration or load work. Two instruments agree that nothing in
  the file referenced a trace Var: a line-oriented `grep` and a
  whitespace-flattened scan both find exactly one occurrence of the string
  `trace` in the whole 90KB file, and it is the require itself.
- **`sub-val`.** Bound only to force a subscription deref between the
  before/after durable-state snapshots, never read. Replaced with `_` so the
  deref - which is load-bearing for the experiment - stays exactly where it
  was in the sequential `let`, with the comment moved onto it.

`re-frame.subs` is retained: its `subscribe` / `unsubscribe` calls at lines
1047 and 1063 are live inside the `#?(:cljs ...)` arm opened at line 1033.

## Gates

Every number below is the runner's own captured exit code, not a
harness-reported one.

| Gate | Exit | Result |
|---|---|---|
| `python scripts/check_readme_links.py --ci` | 0 | silent |
| `clojure -M:test` in `implementation/derivation-conformance` | 0 | 23 tests, 526 assertions, 0 failures |
| `clj-kondo --lint` on the changed test file | 2 | 1 warning, pre-existing |

Both were re-run on the final rebased base (`caaa7cbf8e`), not only on the
original one.

**Controls that fired.** Neither gate is taken on trust:

- README link gate: a broken target planted at the line this PR edits returned
  exit **1** naming `implementation/adapters/reagent/README.md:11 ->
  deps-rf2planted-nonexistent.edn`. The fault existed in one checkout only, so
  a run that had wandered elsewhere would have come back green.
- Derivation JVM suite: a sentinel planted in the very deftest this PR edits
  returned exit **1** with `expected: (= :rf2-planted-sentinel (:status
  sel-val))` and the namespace/assertion counts unchanged at 23/526 - so the
  plant was scoped and the runtime demonstrably read the edited source.
- Both files were restored by git-blob hash comparison, not by eyeballing a
  diff (`f5f699d6a7...` and `89fb376e60...` matched before and after).
- clj-kondo on the **pre-change** file from `origin/main` reports two warnings:
  `unused binding sub-val` (the one this PR removes) and `namespace
  re-frame.subs is required but never used`. After the change only the second
  remains. That second one is a reader-conditional artefact of a bare lint pass
  - a default `.cljc` lint reads the `:clj` branch and cannot see the
  `#?(:cljs ...)` call sites - and it is unchanged by this PR.

**Gate nomination, by path.** The changed README lives beside source under
`implementation/`, which is outside `scripts/check_doc_slugs.py`'s roots; its
gate is `scripts/check_readme_links.py --ci`. Both run in the
`verify-readme-links` job, but only the second covers this path.

**Hand-verified, because nothing gates it.** Neither link gate inspects prose
or tables, so: the changed README contains no markdown table outside a fenced
block (checked programmatically, zero table rows), so no column count is
affected by this diff. The two new relative link targets both resolve -
`deps.edn` and `../../core/deps.edn` from
`implementation/adapters/reagent/README.md` - and the link gate confirms it.
Line endings were checked by byte count rather than by eye: both files are
pure CRLF before and after (108/108 and 1524/1524, zero bare LF), and both
still decode as valid UTF-8.

## rf2-6r9j.87 - verified, NOT fixed here

The premise reproduces exactly. All four Test-React paths - `src`, `test`,
`deps.edn` and `README.md` - drive the identical twelve surface outputs, and
those outputs gate **45 distinct job-level conditions** in `test.yml`
(independently counted: 21 `implementation_jvm`, 5 `cljs_prod`, 4 each of
`adapter_diagnostic` / `tools_jvm` / `mcp_conformance`, and 7 singletons).
The classifier discriminates - `docs/README.md` produces zero true outputs -
so this is real fan-out, not a broken measurement.

The repair belongs in `.github/scripts/report-changed-surfaces.sh` and its
mirror `implementation/scripts/_changed-surfaces.test.cjs`, which are a
one-toucher pair, plus `.github/workflows/test.yml` and
`scripts/test-fast-pr.sh`. All four are outside this worker's fence, so the
bead stays open with the measurement recorded on it.
