### PR TITLE
test(event-conformance): prune three vacuous/duplicate rows, arm the fourth (rf2-6r9j.96, .97, .99, .101)

### DIFF
--- a/implementation/event-conformance/test/re_frame/event_frame_isolation_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_frame_isolation_conformance_cljs_test.cljc
@@ -6,10 +6,16 @@
   `rf/dispatch-sync`, same-id global sentinels, and committed app-db values to
   prove that handler resolution and effects stay inside the target frame.
 
-  The cases also lock two less obvious boundaries: child `:fx` dispatches retain
-  the frame's image generation, while a frame without an image uses the default
-  registrar with no generation binding. `:ambient-frame nil` keeps every target
-  explicit so ambient resolution cannot conceal a routing error."
+  The cases lock the boundaries this suite OWNS: exact per-frame app-db under
+  two images resolving one id through DIFFERENT generations, same-id runtime-db
+  partition isolation with an untouched sibling, and a child `:fx` dispatch
+  retaining the frame's image generation. Absence-is-default — an image-less
+  frame resolving through the default registrar with no generation binding, and
+  two frames sharing ONE image keeping independent state — belongs to
+  `re-frame.live-run-frame-resolution-cljs-test`, which asserts strictly more
+  (subscription values and sub-cache identity as well as app-db), so it is not
+  restated here (rf2-6r9j.96). `:ambient-frame nil` keeps every target explicit
+  so ambient resolution cannot conceal a routing error."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core           :as rf]
@@ -72,6 +78,9 @@
           counter-frame
           (lf/make-frame {:id :counter/main :images [counter-image]}
                          counter-registrations)]
+      (is (some? (registrar/lookup :event :boot/init))
+          "the same-id global sentinel is genuinely armed on the default registrar
+           (so the `not= :global` rows below are not vacuous)")
       (rf/dispatch-sync [:boot/init] {:frame :todo/main})
       (rf/dispatch-sync [:boot/init] {:frame :counter/main})
       (testing "each frame ran ITS OWN image's handler"
@@ -211,44 +220,6 @@
         (is (nil? registrar/*generation*)
             "after the dispatches, no generation is bound (the resolution seam unwound)")))))
 
-;; Prove the fallback sentinel is reachable rather than relying on a vacuous
-;; `not= :global` assertion.
-(deftest the-global-sentinel-is-genuinely-registered
-  (testing "the default handler used as the fallback sentinel is live"
-    (rf/reg-event :boot/init (fn [{:keys [db]} _] {:db (assoc db :booted-by :global)}))
-    (is (some? (registrar/lookup :event :boot/init))
-        "the global handler is on the default registrar (the armed sentinel)")
-    (rf/make-frame {:id :plain/main :doc "no image-loaded object"})
-    (rf/dispatch-sync [:boot/init] {:frame :plain/main})
-    (is (= :global (:booted-by (rf/app-db-value :plain/main)))
-        "an image-less frame DOES run the global handler — the sentinel fires when reached")))
-
-(deftest two-frames-sharing-one-image-keep-independent-app-db
-  (testing "frames sharing an image still have independent runnable state"
-    ;; Distinguish image resolution from an accidental default lookup.
-    (rf/reg-event :counter/inc (fn [{:keys [db]} _] {:db (assoc db :n :global)}))
-    (let [pool [(event-desc "ex.counter" :counter/inc
-                            (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))]
-          img  (image/image {:id :ex/counter :select-ns {:include ["ex.counter"]}})
-          fa   (lf/make-frame {:images [img] :initial-events [[:rf/set-db {:n 0}]]}   pool)
-          fb   (lf/make-frame {:images [img] :initial-events [[:rf/set-db {:n 100}]]} pool)]
-      (is (= (lf/frame-generation fa) (lf/frame-generation fb))
-          "both frames run the SAME resolved image generation (one shared image)")
-      (is (not= (:rf.frame/runnable-id fa) (:rf.frame/runnable-id fb))
-          "yet they are DISTINCT runnable frames (distinct backing records)")
-      (rf/dispatch-sync [:counter/inc] {:frame fa})
-      (rf/dispatch-sync [:counter/inc] {:frame fa})
-      (rf/dispatch-sync [:counter/inc] {:frame fb})
-      (testing "each frame's app-db reflects ONLY its own dispatch stream"
-        (is (= 2 (:n (rf/app-db-value fa)))
-            "frame A: seeded 0, inc'd twice on A's OWN app-db")
-        (is (= 101 (:n (rf/app-db-value fb)))
-            "frame B: seeded 100, inc'd once — fully isolated from A"))
-      (testing "the IMAGE inc ran on both (generation routed to the shared image),
-                NOT the global"
-        (is (not= :global (:n (rf/app-db-value fa))))
-        (is (not= :global (:n (rf/app-db-value fb))))))))
-
 (deftest child-dispatch-stays-in-the-frames-image-and-commits-only-that-frame
   (testing "a child dispatch keeps the parent frame's image and state boundary"
     ;; A wrong fallback at either cascade step writes a global marker.
@@ -291,16 +262,3 @@
             "the sibling frame received no write at all — its app-db is the fresh empty map")
         (is (not= :sibling (:inc (rf/app-db-value :counter/main)))
             "no sibling-image handler ran on the target frame")))))
-
-(deftest absence-is-default-no-image-frame-uses-the-global-registrar
-  (testing "an image-less frame uses the default registrar without a generation"
-    (rf/make-frame {:id :plain/main :doc "no image-loaded object for this frame"})
-    (rf/reg-event :plain/set (fn [{:keys [db]} _] {:db (assoc db :written-by :global)}))
-    (rf/reg-sub  :plain/value (fn [db _] (:written-by db)))
-    (rf/dispatch-sync [:plain/set] {:frame :plain/main})
-    (is (= :global (:written-by (rf/app-db-value :plain/main)))
-        "with no image generation, the dispatch resolved the GLOBAL handler")
-    (is (= :global @(rf/subscribe [:plain/value] {:frame :plain/main}))
-        "with no image generation, the subscribe resolved the GLOBAL sub")
-    (is (nil? registrar/*generation*)
-        "no generation was ever bound for an image-less frame")))

--- a/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
@@ -249,19 +249,42 @@
         (is (false? @handler-ran?)
             "the handler never ran — missing-required halts the cascade before the handler")))))
 
-(deftest reg-event-explicit-live-mint-policy-mints-the-declared-nondeterminism-escape
-  (testing "explicit-live policy opts into minting a missing recordable fact"
-    (let [delivered (atom ::unset)]
+(deftest reg-event-explicit-live-mint-policy-overrides-a-strict-frame
+  (testing "the per-call :explicit-live opt is the DISCRIMINATOR: on a `:preset
+            :test` frame — whose mint policy defaults to :strict — the SAME
+            dispatch mints only when the opt rides it (EP-0017 §6). Dispatched
+            into the fixture's ambient :rf/default frame the row would pass
+            whether or not the opt was honoured, since that frame is already
+            :live (rf2-6r9j.99)."
+    (let [generator-call-count (atom 0)
+          delivered            (atom ::unset)]
+      (rf/make-frame {:id :evt-conf/escape-frame :preset :test})
       (rf/reg-cofx :evt-conf/escape-fact
         {:recordable? true}
-        (fn [] :minted-under-escape))
+        (fn [] (swap! generator-call-count inc) :minted-under-escape))
       (rf/reg-event :evt-conf/uses-escape-fact
         {:rf.cofx/requires [:evt-conf/escape-fact]}
         (fn [{:keys [evt-conf/escape-fact]} _] (reset! delivered escape-fact) {}))
-      (rf/dispatch-sync [:evt-conf/uses-escape-fact]
-                        {:rf.cofx/mint-policy :explicit-live})
-      (is (= :minted-under-escape @delivered)
-          ":explicit-live mints a declared-absent generator-backed fact (the declared-nondeterminism escape, NOT strict)"))))
+      (testing "CONTROL — the SAME dispatch WITHOUT the opt is refused by the
+                frame's :strict default: no mint, no host read, no delivery"
+        (is (= :rf.error/missing-required-cofx
+               (thrown-error-id
+                 #(rf/dispatch-sync [:evt-conf/uses-escape-fact]
+                                    {:frame :evt-conf/escape-frame})))
+            "without the opt the :test frame's :strict default refuses the declared-absent fact")
+        (is (zero? @generator-call-count)
+            "the generator NEVER ran under the frame's :strict default")
+        (is (= ::unset @delivered)
+            "the handler never ran — missing-required halted the cascade"))
+      (testing "the per-call :explicit-live opt ALONE flips that same dispatch
+                to exactly one mint plus flat delivery"
+        (rf/dispatch-sync [:evt-conf/uses-escape-fact]
+                          {:frame               :evt-conf/escape-frame
+                           :rf.cofx/mint-policy :explicit-live})
+        (is (= 1 @generator-call-count)
+            ":explicit-live overrode the frame's :strict — the generator ran exactly once")
+        (is (= :minted-under-escape @delivered)
+            "the minted fact was delivered flat (the declared-nondeterminism escape, NOT strict)")))))
 
 (deftest reg-event-typo-cofx-is-the-hard-error
   (testing "requiring an unregistered coeffect is a hard error"
@@ -691,6 +714,13 @@
       (is (not (contains? event-metadata :event/kind))
           "the `:event/kind` sub-tag is GONE (one form, no kind discriminator)")
       ;; THE wrapper lock — exactly ONE framework wrapper, named :rf/event-handler.
+      ;; This EXACT-VECTOR equality is also what excludes the retired per-kind
+      ;; wrapper ids (`:rf/db-handler` / `:rf/fx-handler` / `:rf/ctx-handler`):
+      ;; a singleton `[:rf/event-handler]` cannot contain any of them, and it
+      ;; refuses an extra wrapper and a wrong order too. A second registration
+      ;; asserting those three non-memberships restates a consequence of this
+      ;; line rather than exercising another path — every `reg-event` takes the
+      ;; one form (rf2-6r9j.101).
       (is (= [:rf/event-handler] (mapv :id (:interceptors event-metadata)))
           "the ONLY framework wrapper is the single :rf/event-handler interceptor")
       (let [event-wrapper (first (:interceptors event-metadata))]
@@ -698,16 +728,6 @@
             "the wrapper id is :rf/event-handler")
         (is (true? (:rf/default? event-wrapper))
             "the wrapper carries :rf/default? true (filtered as a framework auto-wrapper)")))))
-
-(deftest reg-event-no-per-kind-wrapper-ids-survive
-  (testing "the unified event wrapper excludes the retired per-kind wrapper ids"
-    (rf/reg-event :evt-conf/wrapper-drift (fn [_ _] {}))
-    (let [ids (set (mapv :id (:interceptors (rf/handler-meta :event :evt-conf/wrapper-drift))))]
-      (is (= #{:rf/event-handler} ids)
-          "exactly one wrapper id; the unified :rf/event-handler")
-      (is (not (contains? ids :rf/db-handler))  "the retired :rf/db-handler wrapper is gone")
-      (is (not (contains? ids :rf/fx-handler))  "the retired :rf/fx-handler wrapper is gone")
-      (is (not (contains? ids :rf/ctx-handler)) "the retired :rf/ctx-handler wrapper is gone"))))
 
 (deftest reg-event-chain-references-an-interceptor-from-public-reg-interceptor
   (testing "an event chain resolves an interceptor registered through the public facade"

--- a/implementation/event-conformance/test/re_frame/event_reply_envelope_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_reply_envelope_conformance_cljs_test.cljc
@@ -20,10 +20,19 @@
       stale reply is a well-formed envelope, so non-delivery is not confused with
       malformed data.
 
-  Both stale cases route to an EXPLICIT non-default frame carrying its OWN image
+  The stale case routes to an EXPLICIT non-default frame carrying its OWN image
   handler PLUS a same-id default-registrar sentinel, so neither a targeting
   fall-through (to the ambient default frame) nor a resolution fall-through (to
-  the default registrar) can hide behind an ambient dispatch."
+  the default registrar) can hide behind an ambient dispatch. Its non-delivery
+  tooth is the PAIR of call-count reads that straddle the observer's dispatch —
+  zero before, exactly one after — so a runtime that app-delivered the stale
+  reply itself would be caught. A second row that only built the `suppress`
+  outcome and then asserted nothing had happened was removed (rf2-6r9j.97): it
+  invoked no delivery code, so its zero-call and unchanged-app-db assertions
+  followed from the test rather than from the runtime. The pure `suppress` laws
+  — universal `:deliver? false`, the stale envelope's shape, the absent
+  `:value` — are `re-frame.reply-cljs-test`'s, asserted there across every
+  target shape; this suite does not restate them."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
@@ -213,57 +222,3 @@
             "targeting did NOT fall through to the ambient default frame")
         (is (nil? registrar/*generation*)
             "the image generation binding unwound after the dispatch")))))
-
-(deftest a-stale-completion-is-non-delivering-without-an-explicit-observer
-  (testing "an app reply target with a superseded correlation is NON-delivering:
-            with NO observer self-dispatch, the app handler never runs on ANY
-            frame, yet the stale reply is well-formed data"
-    ;; Same-id global sentinel again: a leaked delivery WOULD be observable.
-    (rf/reg-event :article/loaded
-      (fn [{:keys [db]} _] {:db (assoc db :delivered-by :global)}))
-    (is (some? (registrar/lookup :event :article/loaded))
-        "the same-id global sentinel is armed (a delivery WOULD be observable)")
-    (let [seen-event (atom ::unset)
-          call-count (atom 0)
-          pool [(event-desc "evt.reply.app" :article/loaded
-                  (fn [{:keys [db]} event]
-                    (swap! call-count inc)
-                    (reset! seen-event event)
-                    {:db (assoc db :delivered-by :image)}))]
-          img  (image/image {:id :evt.reply/app-img :select-ns {:include ["evt.reply.app"]}})
-          _    (lf/make-frame {:id :evt.reply/app-frame :images [img]} pool)
-          ;; A NORMAL app target: the bare public short form built from
-          ;; `:rf/reply-to` data. `suppress` is UNIVERSALLY non-delivering, and
-          ;; nobody self-dispatches — so the app handler never runs.
-          target  [:article/loaded {:id 42}]
-          carried {:work/id [:rf.work/resource [:rf.scope/global :r {}] 4] :generation 4}
-          current {:work/id [:rf.work/resource [:rf.scope/global :r {}] 5] :generation 5}
-          outcome (reply/suppress target carried current
-                    {:rf.reply/work-id (:work/id carried)
-                     :work/kind        :resource
-                     :rf.frame/id      :evt.reply/app-frame})]
-      (testing "the suppression outcome is NON-delivering"
-        (is (false? (:deliver? outcome))
-            "a stale outcome yields :deliver? false — no app delivery"))
-      (testing "no handler ran and NO app-db mutated — on EITHER the explicit
-                frame or the ambient default frame (nobody self-dispatched)"
-        (is (= ::unset @seen-event) "the app handler was never invoked")
-        (is (zero? @call-count)     "the target handler ran zero times")
-        (is (nil? (:delivered-by (rf/app-db-value :evt.reply/app-frame)))
-            "the explicit frame's app-db is unmutated (no stale write leaked in)")
-        (is (nil? (:delivered-by (rf/app-db-value :rf/default)))
-            "the ambient default frame's app-db is unmutated"))
-      (testing "non-delivery is NOT malformed data (AC #4) — the suppressed reply
-                is still a valid, well-formed stale envelope"
-        (let [reply (:reply outcome)]
-          (is (reply/valid-reply? reply)
-              (str "the non-delivered reply is still a canonical stale envelope: "
-                   (reply/validate-reply reply)))
-          (is (= :stale (:status reply))                    ":status :stale")
-          (is (= :suppressed (:rf.reply/work-status reply)) ":rf.reply/work-status :suppressed")
-          (is (true? (:stale? reply))                       "the :stale? marker rides")
-          (is (some? (:rf.reply/stale-reason reply))        "a :rf.reply/stale-reason rides")
-          (is (not (contains? reply :value))
-              "a stale reply carries NO :value — non-delivery, not a partial write")
-          (is (contains? reply/statuses (:status reply))
-              ":stale is in the ONE closed status vocabulary"))))))


### PR DESCRIPTION
Four audit findings on the event-conformance surface (rf2-6r9j.96, .97, .99, .101). Every verdict below was reached by **planting** the fault the row claims to guard and reading whether it goes red — a census would not have separated these cases.

## rf2-6r9j.101 — the duplicate wrapper row

`reg-event-no-per-kind-wrapper-ids-survive` asserted the SET form of the exact singleton interceptor vector that `reg-event-registers-under-event-kind-with-the-one-wrapper` already pins, plus three non-memberships entailed by that equality. Both use the same public `reg-event`, the same fixture, the same no-metadata path.

**Plant** — `events/event-handler-interceptor-id` `:rf/event-handler` → `:rf/db-handler` (a retired per-kind id, i.e. exactly what the three negatives claim to guard):

| test | exit | result |
|---|---|---|
| `reg-event-registers-under-event-kind-with-the-one-wrapper` (survivor) | 1 | 2 failures / 6 assertions |
| `reg-event-no-per-kind-wrapper-ids-survive` (removed) | 1 | 2 failures / 4 assertions |

The survivor catches it. Removed; the retired ids now ride as commentary on the exact-vector assertion, which also refuses an extra wrapper and a wrong order.

## rf2-6r9j.99 — the non-discriminating explicit-live row

The row dispatched into the fixture's ambient `:rf/default` frame, whose mint policy is already `:live`, so `{:rf.cofx/mint-policy :explicit-live}` was not the discriminator.

**Plant** — `cofx/resolve-mint-policy` drops its `per-call` argument (the option is honoured nowhere):

| test | exit | result |
|---|---|---|
| `…explicit-live-mint-policy-mints-the-declared-nondeterminism-escape` (old row) | **0** | passes with the option ignored |
| core's `explicit-live-overrides-strict-frame-generates` | 1 | 1 error |

Reshaped rather than removed (the bead's title asks for a discriminating row, and the public dispatch-options path is worth keeping at this tier): a `:preset :test` frame supplies the `:strict` baseline, a paired control dispatches WITHOUT the opt, and the escape leg then flips the same dispatch. Both legs were re-planted against the new row:

| plant | exit | which leg went red |
|---|---|---|
| per-call opt ignored (`(or frame-policy default)`) | 1 | escape leg — `missing-required-cofx` |
| frame `:strict` ignored (`(or per-call default)`) | 1 | control leg — 4 failures |

## rf2-6r9j.97 — the vacuous stale non-delivery row

`a-stale-completion-is-non-delivering-without-an-explicit-observer` called only the pure `reply/suppress` and then asserted nothing had happened. Its zero-call and unchanged-app-db assertions followed from the test never invoking delivery code.

**Plant** — `reply/complete`'s `:append` stops appending the reply:

| test | failures |
|---|---|
| `reply-completion-is-an-ordinary-reg-event-dispatch` | 13 |
| `an-observer-self-dispatches-a-stale-reply-on-its-own-authority` | 6 |
| `a-stale-completion-is-non-delivering-…` (removed) | **0** |

Removed rather than re-pointed, and the reason is worth recording: **no production code anywhere reads `:deliver?`**. `reply/suppress` returns `false` unconditionally, and every family (`http`, `resources`, `routing`, `machines`) branches on its own staleness decision instead. AC #1's alternative — "a real production completion path with a reachable delivery branch" — has no target that does not first invent the delivery gate `ca7fd0bd93` deliberately deleted. Nothing is lost: the retained observer row keeps a **live** non-delivery tooth (zero calls read before the self-dispatch, exactly one after, so a runtime that app-delivered a stale reply itself is caught by the pair), and the pure `suppress` laws are `re-frame.reply-cljs-test`'s across six target shapes including forged authority.

## rf2-6r9j.96 — three strict-subset frame-resolution rows

- `absence-is-default-no-image-frame-uses-the-global-registrar` is **operationally identical** to core's `no-image-frame-resolves-through-the-global-registrar` — same frame, event, sub and three assertions, modulo prose. No fault can distinguish two copies of one program, so this is stronger evidence than a plant.
- `the-global-sentinel-is-genuinely-registered` repeats that same path plus a registration probe. The probe's value is real but its placement was not: the `:each` fixture means a probe in one test can never arm another's sentinel, so it has been moved **into** the headline isolation row, where it backs the `not= :global` assertions that actually depend on it.
- `two-frames-sharing-one-image-keep-independent-app-db` is a strict subset of core's `two-frames-from-one-image-keep-independent-state` (identical image, seeds, dispatch stream and five assertions; the sixth, `not= :global` on frame B, is entailed by the exact `= 101`). Core adds subscription values and sub-cache identity. **Plant** — a constant `frame/anon-frame-id`, collapsing two no-id frames onto one record: conformance 3 failures / 6 assertions, core 6 failures / 11.

Event-conformance keeps the three teeth it owns: the exact two-image app-db with distinct generations, runtime-db partition isolation with an untouched sibling, and child/sibling dispatch isolation.

## Verification

| gate | exit | result |
|---|---|---|
| `clojure -M:test` (event-conformance, baseline) | 0 | 49 tests / 209 assertions |
| `clojure -M:test` (event-conformance, after) | 0 | 44 tests / 186 assertions |
| `clojure -M:test` (event-conformance, after rebase) | 0 | 44 tests / 186 assertions |
| `npm run test:cljs` (consolidated `:node-test`) | 0 | 11163 tests / 55721 assertions, 0 failures |
| `clj-kondo --lint` (the three files) | 0 | 0 errors, 0 warnings |
| core `live-run-frame-resolution` + `reply` (JVM) | 0 | 46 tests / 232 assertions |

The tally delta reconciles exactly: −28 assertions from the five removed rows, +1 for the relocated sentinel probe, +4 for the reshaped explicit-live row = −23, and 209 − 23 = 186.

Every plant was restored and verified against the committed blob by `git hash-object` before the working tree was committed. No non-test file is touched; `implementation/shadow-cljs.edn` was NOT modified (the files stay enrolled — no build-id change was needed).
