### PR TITLE
docs: truth the reply-conformance inventory and the Story build count

### DIFF
--- a/implementation/README.md
+++ b/implementation/README.md
@@ -230,8 +230,9 @@ implementation/
                              that sit above several artefacts: the shared :status /
                              :rf.reply/work-status / :work/id / canonical-stale vocabulary across
                              every managed-async family (HTTP, resources, mutations,
-                             machines, routing) plus the family-level functor/naturality
-                             law at the target-relocating families.
+                             machines, routing) plus the shared egress-projection
+                             boundaries (`trace-summary`, `project-egress`). Reply-target
+                             functor laws are owned by core and its timer probe.
     test/re_frame/                 JVM + CLJS cross-family reply conformance suites.
 
   derivation-conformance/    Cross-family derivation/process-algebra conformance tier

--- a/implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc
@@ -102,10 +102,12 @@
 ;;   :work-head     — the expected `[:rf.work/* …]` head keyword
 ;;   :success       — () → success reply map, or nil if N/A
 ;;   :error         — () → error reply map, or nil if N/A
-;;   :error-work-status — the expected error :rf.reply/work-status (:failed default;
-;;                    HTTP timeout family also proves :timed-out separately)
 ;;   :cancel        — () → cancelled reply map, or nil if N/A
 ;;   :stale         — () → stale reply map, or nil if N/A
+;;
+;; Situations that pair a completion-time present/absent case add the
+;; matching `:<situation>-with-time` / `:<situation>-no-time` builders (and,
+;; where a suppression call returns more than the reply, `:stale-out`).
 ;;
 ;; A nil builder means that implementation does not produce a reply for the
 ;; situation. For example, route errors and cancellation remain HTTP transport

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -227,9 +227,10 @@
                 ;; family — HTTP, resources, mutations, machines, routing —
                 ;; produces the ONE shared :status/:work/status/:work/id/
                 ;; canonical-stale shape, the axis rf2-mn4j89 violated) and
-                ;; the family-level functor/naturality law at the
-                ;; TARGET-RELOCATING families (route-loader relay,
-                ;; machine-spawn :on-done). The tests sit ABOVE several
+                ;; the shared egress-projection boundaries (`trace-summary`,
+                ;; `project-egress`) that keep classified and large reply
+                ;; slots off the wire. Reply-target functor laws stay owned
+                ;; by core and its timer probe. The tests sit ABOVE several
                 ;; artefacts (core, http, resources, machines, routing), so
                 ;; — like security/ — they live in their own top-level
                 ;; reply-conformance/ surface; the cross-artefact node-test

--- a/tools/story/README.md
+++ b/tools/story/README.md
@@ -139,7 +139,7 @@ The substantive implementation contract is decomposed into
 
 ## Running the Story examples
 
-Four Story-enabled builds are wired into the top-level `:dev-http` map
+Five Story-enabled builds are wired into the top-level `:dev-http` map
 (`implementation/shadow-cljs.edn`) on the `804x` band, so each runs
 one-command — `npx shadow-cljs watch <build-id>` then open the URL. Each is
 hash-routed: `/#/` is the live app, `/#/stories` mounts the Story shell (the


### PR DESCRIPTION
Closes the documentation half of two audit follow-ups. Comment- and prose-only:
no build id, port, root, path, namespace, identifier, output contract, fixture
or behaviour changes anywhere in the diff.

## rf2-6r9j.91 — reply-conformance inventory vs. its live suites

`540c8af134` deleted `reply_functor_law_cljs_test.cljc` (it only re-proved core
laws with synthetic transforms) and narrowed this tier to two guarantees. Two
inventory comments were not updated with it and still claimed the tier owns
"the family-level functor/naturality law at the target-relocating families":

* `implementation/README.md`
* `implementation/shadow-cljs.edn`

No such test lives here. Ownership sits with core's `reply_cljs_test.cljc` and
the machine timer probe — which is already what both surviving namespace
docstrings and `implementation/reply-conformance/deps.edn` say, so those three
files needed no change. The two stale comments now name the guarantees the tier
actually holds: the cross-family reply **vocabulary** and the shared
**egress-projection** boundaries (`trace-summary`, `project-egress`).

The descriptor doc block in `reply_vocab_conformance_cljs_test.cljc` also listed
`:error-work-status`, a key no `families` row supplies and no consumer reads —
documentation-only since the surface was introduced. Removed, and the
completion-time pair keys the matrix *does* consume (`:<situation>-with-time` /
`:<situation>-no-time`, plus `:stale-out`) are noted in its place.

**The live surface, established from the build config and the filesystem rather
than from the inventory under suspicion:** four tracked files —
`deps.edn`, `reply_conformance_fixtures.cljc`, `reply_vocab_conformance_cljs_test.cljc`,
`reply_egress_projection_conformance_cljs_test.cljc`. `shadow-cljs.edn` enrols
`reply-conformance/test` in the consolidated `:node-test` build; `deps.edn`
`:test` is the JVM counterpart.

### Not done here — acceptance criteria 3 and part of 5 remain open

`implementation/scripts/_changed-surfaces.test.cjs` pins a **phantom** path in
its `CONFORMANCE_TIERS` array:
`implementation/reply-conformance/test/re_frame/reply_vocabulary_conformance_cljs_test.cljc`.
The tracked file is `reply_vocab_conformance_cljs_test.cljc`. `git log
--diff-filter=A` over all refs confirms the phantom spelling was never a tracked
path. The other two entries in that same array *are* tracked, so this is the
only bad row. That file is outside this PR's fence — and per `CLAUDE.md` it is
one half of the classifier/mirror one-toucher pair — so **rf2-6r9j.91 stays
open** for it.

## rf2-6r9j.234 — Story build inventory count

`tools/story/README.md` said "Four Story-enabled builds" directly above a
five-row table. Corrected to "Five".

**How the count was derived** (re-measured, not copied from the bead): the EDN
was parsed with `clojure.edn/read-string` and the `:dev-http` keys in the `804x`
band enumerated — `8040 8041 8042 8043 8044 8045`, six entries. Each Story
port's `:roots` were then matched against every build's `:output-dir`, yielding
exactly five build ids:

| Port | Build id |
|---|---|
| 8040 | `:examples/nine-states-with-stories` |
| 8041 | `:examples/login-with-stories` |
| 8042 | `:examples/counter-with-stories` |
| 8043 | `:examples/login-form` |
| 8045 | `:examples/hicasso-counter` |

8044 is in the band but is **not** Story-enabled: its root
(`examples/capabilities/resources/linearlite`) contains zero occurrences of the
string `story`, where each of the five above contains at least one `reg-story`
registration. So "Five Story-enabled builds ... on the `804x` band" is accurate
as written. Count = **5**, agreeing with the five table rows.

## Verification

Every captured exit code is the runner's own, echoed on the same command line as
its redirect — never a filtered pipeline's status.

| Check | Captured exit | Result |
|---|---|---|
| `python scripts/check_readme_links.py --ci` | 0 | green on final base |
| `python scripts/check_doc_slugs.py` | 0 | green on final base |
| `clj-kondo --lint implementation/reply-conformance/test` | 0 | 0 errors, 0 warnings |
| `clojure -M:test` in `implementation/reply-conformance` | 0 | 30 tests / 556 assertions, 0 failures |
| `git diff --check origin/main...HEAD` | 0 | clean |

All re-run after the rebase onto the current `origin/main`, not before it.

### Gate discrimination (both gates prove they read this branch's tree)

* **`check_readme_links.py`** prints nothing on success, so a plant was the only
  available route. A broken target planted at `tools/story/README.md`'s
  `./spec/000-Vision.md` link returned **exit 1** naming exactly the planted
  filename — while `check_doc_slugs.py` returned **exit 0** on the same tree,
  confirming the docs gate is blind to `tools/*/README.md` and that
  `check_readme_links.py` is the correct gate to nominate by path.
* **`clojure -M:test`**: a failing assertion planted in the vocab suite returned
  **exit 1** naming the planted string, and the assertion count moved
  556 → 557 with the namespace count unchanged at 30 — positive evidence the
  runtime observed the plant rather than serving a stale compile, and that the
  plant crashed no namespace.
* Both plants were restored and the restore verified by **git blob hash** against
  the committed object, not by reading a diff.

### Verified by hand, because no gate covers it

* **Prose and counts are ungated.** Nothing in this repo validates a count
  sentence, so the Story figure was derived from the parsed EDN as set out above
  rather than trusted from the table or the bead.
* **Table column counts.** `tools/story/README.md`'s build table: 4-cell header,
  4-cell separator, 5 data rows of 4 cells each — consistent, and the 5 data
  rows are what the corrected count now agrees with. The one table added to this
  PR body is 2-cell throughout.
* **The `implementation/README.md` hunk sits inside a fenced code block**, and
  both link gates strip fences before extracting links — so that edit is
  **ungated by construction**. It is checked by hand: it is descriptive prose in
  the directory-tree listing and contains no link and no heading anchor.
* **`implementation/shadow-cljs.edn`** is a `;;` comment change no markdown gate
  reaches. The file was re-parsed with `clojure.edn/read-string` after the edit
  (80 builds, `:dev-http` keys intact) to prove the EDN still reads.
* **Encoding and line endings** were checked as bytes on every file before and
  after editing: all four are pure CRLF and valid UTF-8, each patch was anchored
  on a single line and its match count asserted to be exactly 1 before applying,
  and the resulting diff touches only the intended lines.
