### PR TITLE
ci(surfaces): give local Test-React changes a precise CI surface (rf2-6r9j.87)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -151,6 +151,14 @@ fi
 implementation_jvm=false
 cljs_node_test=false
 adapter_diagnostic=false
+# rf2-6r9j.87 — Test-React is the documented exception to the shipped-adapter
+# population: a local-only CLJC test fixture with no Maven coordinate, no
+# production/example consumer and no browser testbed. It gets its OWN output
+# rather than riding `adapter_diagnostic`, because that output gates the OTHER
+# three adapter JVM jobs (reagent / reagent-slim / uix) as well, none of which
+# runs this artefact. The reverse edge still works: the core arm keeps setting
+# `adapter_diagnostic`, and `jvm-adapters-test-react` reads the disjunction.
+test_react_jvm=false
 cljs_browser=false
 examples_compile=false
 cljs_prod=false
@@ -225,6 +233,10 @@ mark_all() {
   implementation_jvm=true
   cljs_node_test=true
   adapter_diagnostic=true
+  # rf2-6r9j.87 — not optional. `force_all` and the workflow-file arms rely on
+  # mark_all being TOTAL; a signal missing here makes a forced full run skip
+  # `jvm-adapters-test-react` outright.
+  test_react_jvm=true
   cljs_browser=true
   examples_compile=true
   cljs_prod=true
@@ -610,6 +622,17 @@ else
       # generic feature arm that happened to set five outputs — and the toll
       # was real: security-only commit d1fa5ff493 made the ~10-minute
       # all-examples job its critical path.
+      # rf2-6r9j.87 — Test-React is carved out ABOVE the alternation below
+      # (shell `case` is first-match, so the narrowing has to precede the
+      # pattern it narrows). It is a local-only CLJC test fixture: nothing
+      # under `examples/` requires `re-frame.adapter.test-react`, so it cannot
+      # appear in any compiled example closure. Deliberately sets NO output
+      # here — the second `case` further down arms its two real lanes. Without
+      # this arm a prose-only README edit still schedules the ~10-minute
+      # all-examples compile, which is the half of the fan-out that lives in
+      # THIS case statement rather than in the adapter arm.
+      implementation/adapters/test-react/*)
+        ;;
       examples/*|implementation/adapters/*|implementation/epoch/*|implementation/schemas/*|implementation/machines/*|implementation/routing/*|implementation/flows/*|implementation/http/*|implementation/ssr/*|implementation/ssr-ring/*|implementation/resources/*|implementation/deps.edn|implementation/shadow-cljs.edn|implementation/package.json|implementation/package-lock.json|implementation/scripts/check-examples-compile.cjs)
         examples_compile=true
         ;;
@@ -913,6 +936,50 @@ else
         # there, since the example dev runner and the Story launchers
         # share them.)
         adapter_testbed_smokes=true
+        ;;
+      # rf2-6r9j.87 — Test-React, routed by the files each lane actually
+      # consumes. Sits ABOVE the generic adapter arm because `case` is
+      # first-match; the src/test/deps arm sits above the prose catch-all for
+      # the same reason. TWO owning lanes, and only two:
+      #
+      #   * `jvm-adapters-test-react` — this artefact's own `clojure -M:test`,
+      #     scheduled by the `test_react_jvm` output added here.
+      #   * the consolidated `cljs` job — Shadow's `:node-test`, whose
+      #     `cljs-test$` selector discovers both `.cljc` test namespaces
+      #     because implementation/shadow-cljs.edn lists this artefact's
+      #     `src` + `test` roots.
+      #
+      # Everything the broad arm below adds has no edge to this fixture:
+      # browser DOM, examples compile, production/release builds, bundle
+      # isolation, the `<reagent|uix>/testbed` smokes (Test-React owns no
+      # testbed), tools JVM, template, MCP. Nothing outside the artefact
+      # requires `re-frame.adapter.test-react` — the only out-of-tree mentions
+      # are a QUOTED `:producer-ns` symbol roster in
+      # implementation/core/src/re_frame/late_bind/directory.cljc (data, not a
+      # require) and prose comments. What this narrowing does NOT touch, and
+      # does not need to, are the always-on jobs: `verify-version-lockstep`,
+      # `check_jvm_lane_rosters.py` and `check_test_lane_bijection.py` all run
+      # unconditionally in test.yml, so a deps.edn edit that added a
+      # `:clein/build` alias, or a test file that no lane reaches, is still
+      # caught with no surface signal involved.
+      implementation/adapters/test-react/src/*|implementation/adapters/test-react/test/*|implementation/adapters/test-react/deps.edn)
+        test_react_jvm=true
+        case "$file" in
+          # deps.edn feeds the JVM lane only: shadow reads its own
+          # `:source-paths` from implementation/shadow-cljs.edn and its deps
+          # from implementation/deps.edn, so this file cannot change what the
+          # node lane compiles.
+          implementation/adapters/test-react/deps.edn) ;;
+          *) cljs_node_test=true ;;
+        esac
+        ;;
+      implementation/adapters/test-react/*)
+        # Prose and anything else at the artefact root — README.md is the case
+        # that matters. No gate pins its bytes or its content, so it opens no
+        # executable lane. Its markdown links are still gated: test.yml's
+        # always-on `verify-readme-links` job runs
+        # `scripts/check_readme_links.py --ci`, which covers READMEs beside
+        # source, and the README inventory validator runs in the same job.
         ;;
       implementation/adapters/*)
         # rf2-bxdk8 + rf2-cjp0i — the adapter-testbed-smokes gate is
@@ -2513,6 +2580,7 @@ emit() {
 emit implementation_jvm "$implementation_jvm"
 emit cljs_node_test "$cljs_node_test"
 emit adapter_diagnostic "$adapter_diagnostic"
+emit test_react_jvm "$test_react_jvm"
 emit cljs_browser "$cljs_browser"
 emit examples_compile "$examples_compile"
 emit cljs_prod "$cljs_prod"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,13 @@ jobs:
       implementation_jvm: ${{ steps.detect.outputs.implementation_jvm }}
       cljs_node_test: ${{ steps.detect.outputs.cljs_node_test }}
       adapter_diagnostic: ${{ steps.detect.outputs.adapter_diagnostic }}
+      # rf2-6r9j.87 — Test-React's own signal. Declared HERE and not only
+      # emitted: a job reads `needs.<job>.outputs.<name>`, which resolves to
+      # the empty string unless the producing job declares it, so an
+      # emitted-but-undeclared output makes every `== 'true'` false — a gate
+      # that can never fire, and silently. Same never-fires mode rf2-9n2cv /
+      # rf2-65ajl pinned for the Story outputs.
+      test_react_jvm: ${{ steps.detect.outputs.test_react_jvm }}
       cljs_browser: ${{ steps.detect.outputs.cljs_browser }}
       examples_compile: ${{ steps.detect.outputs.examples_compile }}
       cljs_prod: ${{ steps.detect.outputs.cljs_prod }}
@@ -1753,7 +1760,14 @@ jobs:
   jvm-adapters-test-react:
     name: JVM test-react (clojure -M:test)
     needs: detect_changed_surfaces
-    if: needs.detect_changed_surfaces.outputs.adapter_diagnostic == 'true'
+    # rf2-6r9j.87 — a DISJUNCTION, and both halves are load-bearing.
+    # `adapter_diagnostic` is the REVERSE edge: the fixture depends on core, so
+    # a core change must still schedule this job, and the core arm of the
+    # classifier is what fires that output. `test_react_jvm` is the forward
+    # edge: a change to this artefact's own src/test/deps now arms this job
+    # WITHOUT arming jvm-adapters-{reagent,reagent-slim,uix}, which stay on
+    # `adapter_diagnostic` alone and cannot reach this local-only CLJC fixture.
+    if: needs.detect_changed_surfaces.outputs.adapter_diagnostic == 'true' || needs.detect_changed_surfaces.outputs.test_react_jvm == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -3385,6 +3385,189 @@ test('adapter-smoke harness edit fires ONLY adapter_testbed_smokes, not the adap
   assert.notEqual(result.mcp_conformance, 'true', 'harness edit must not fire mcp_conformance');
 });
 
+// ---------------------------------------------------------------------------
+// rf2-6r9j.87 — Test-React is the documented exception to the shipped-adapter
+// population, and before this bead the classifier did not know it. Every path
+// under implementation/adapters/test-react/ — source, test, deps.edn AND a
+// prose-only README — produced the identical twelve outputs, fanning out to 45
+// distinct jobs in test.yml. Test-React has no Maven coordinate, no production
+// or example consumer and no browser testbed: nothing outside its own tree
+// requires `re-frame.adapter.test-react` (the only out-of-tree mentions are a
+// QUOTED `:producer-ns` symbol roster in
+// implementation/core/src/re_frame/late_bind/directory.cljc — data, not a
+// require — and prose comments). Exactly two lanes can reach the code:
+// `jvm-adapters-test-react` and Shadow's consolidated `:node-test`.
+//
+// The eleven retired outputs. This is the twelve the artefact used to fire
+// MINUS `cljs_node_test`, which is genuinely retained — the fixture is CLJC
+// specifically so it runs under BOTH hosts, and narrowing away either host
+// would be the fail-open this bead exists to remove, not the fix.
+const TEST_REACT_RETIRED_OUTPUTS = [
+  'implementation_jvm',
+  'adapter_diagnostic',
+  'cljs_browser',
+  'examples_compile',
+  'cljs_prod',
+  'bundle_isolation',
+  'adapter_testbed_smokes',
+  'tools_jvm',
+  'template_expensive',
+  'mcp_conformance',
+  'mcp_live',
+];
+
+function assertTestReactFanOutRetired(result, label) {
+  for (const output of TEST_REACT_RETIRED_OUTPUTS) {
+    assert.notEqual(
+      result[output],
+      'true',
+      `${label} must not fire ${output} — no lane it gates can reach this fixture`,
+    );
+  }
+}
+
+// Source and test both arm BOTH real hosts: the artefact's own JVM suite and
+// the consolidated Node suite that discovers its two .cljc test namespaces.
+for (const file of [
+  'implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc',
+  'implementation/adapters/test-react/test/re_frame/adapter/test_react_cljs_test.cljc',
+]) {
+  test(`${file} arms the Test-React JVM + Node lanes and nothing else (rf2-6r9j.87)`, () => {
+    const result = classify(file);
+    assert.equal(result.test_react_jvm, 'true');
+    assert.equal(result.cljs_node_test, 'true');
+    assertTestReactFanOutRetired(result, file);
+  });
+}
+
+// deps.edn feeds the JVM lane ONLY. Shadow reads its `:source-paths` from
+// implementation/shadow-cljs.edn and its dependencies from
+// implementation/deps.edn, so this artefact's own deps.edn cannot change what
+// the node lane compiles.
+test('Test-React deps.edn arms the JVM lane only (rf2-6r9j.87)', () => {
+  const result = classify('implementation/adapters/test-react/deps.edn');
+  assert.equal(result.test_react_jvm, 'true');
+  assert.notEqual(
+    result.cljs_node_test,
+    'true',
+    'deps.edn cannot change what the node lane compiles',
+  );
+  assertTestReactFanOutRetired(result, 'implementation/adapters/test-react/deps.edn');
+});
+
+// The case that proves the FIRST case statement was carved out too. There are
+// TWO `case "$file" in` blocks in report-changed-surfaces.sh that a
+// `implementation/adapters/*` path reaches: the adapter fan-out, and an
+// EARLIER one whose long alternation sets `examples_compile`. A carve-out
+// added only to the adapter block leaves `examples_compile=true` firing on a
+// prose-only README edit — scheduling the ~10-minute all-examples compile —
+// and this is the only case that catches it.
+test('Test-React README.md arms NO executable lane (rf2-6r9j.87)', () => {
+  const result = classify('implementation/adapters/test-react/README.md');
+  assert.notEqual(result.test_react_jvm, 'true', 'prose must not open the JVM lane');
+  assert.notEqual(result.cljs_node_test, 'true', 'prose must not open the node lane');
+  assertTestReactFanOutRetired(result, 'implementation/adapters/test-react/README.md');
+});
+
+// The REVERSE edge, which the narrowing must not cut: the fixture depends on
+// core, so a core change still has to run its JVM suite. That edge rides
+// `adapter_diagnostic` (which core already sets and which the job condition
+// keeps in a disjunction), NOT `test_react_jvm` — so this asserts both halves,
+// because setting `test_react_jvm` on the core arm would work too and would be
+// the wrong repair: it would put a second name on an edge that already has one.
+test('implementation/core still schedules the Test-React JVM job (rf2-6r9j.87)', () => {
+  const result = classify('implementation/core/src/re_frame/core.cljc');
+  assert.equal(result.adapter_diagnostic, 'true');
+  assert.notEqual(
+    result.test_react_jvm,
+    'true',
+    'the core reverse edge rides adapter_diagnostic, not the narrow signal',
+  );
+});
+
+// The published adapters are untouched by the carve-out. This is the guard
+// against a narrowing that reached one pattern too far: `case` is first-match,
+// so a carve-out written with a loose glob would swallow its siblings silently.
+test('published adapters keep the full fan-out after the Test-React carve-out (rf2-6r9j.87)', () => {
+  for (const file of [
+    'implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs',
+    'implementation/adapters/uix/src/re_frame/adapter/uix.cljs',
+  ]) {
+    const result = classify(file);
+    for (const output of TEST_REACT_RETIRED_OUTPUTS) {
+      assert.equal(
+        result[output],
+        'true',
+        `${file} must still fire ${output} — only Test-React was narrowed`,
+      );
+    }
+    assert.equal(result.cljs_node_test, 'true');
+  }
+});
+
+// The never-fires mode. A job reads `needs.<job>.outputs.<name>`, which
+// resolves to the empty string unless the producing job DECLARES it, so an
+// emitted-but-undeclared output makes every `== 'true'` false — a gate that can
+// never fire, and silently. Same shape rf2-9n2cv / rf2-65ajl pinned for the
+// Story outputs, and the same phantom-pending family as rf2-dtvmb.
+test('detect_changed_surfaces exports test_react_jvm (rf2-6r9j.87)', () => {
+  const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'detect_changed_surfaces');
+  assert.match(
+    block,
+    /test_react_jvm: \$\{\{ steps\.detect\.outputs\.test_react_jvm \}\}/,
+  );
+});
+
+// Both halves of the job condition, and the siblings' conditions, in one place
+// — the narrow signal is only a narrowing if the other three adapter JVM jobs
+// stay OFF it.
+test('jvm-adapters-test-react is gated on the disjunction; siblings are not (rf2-6r9j.87)', () => {
+  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
+  const block = jobBlock(workflow, 'jvm-adapters-test-react');
+  const header = block.slice(0, block.indexOf('steps:'));
+  assert.match(header, /outputs\.adapter_diagnostic == 'true'/, 'core reverse edge');
+  assert.match(header, /outputs\.test_react_jvm == 'true'/, 'narrow forward edge');
+  assert.match(header, /\|\|/, 'the two edges must be a disjunction');
+  for (const sibling of ['jvm-reagent', 'jvm-reagent-slim', 'jvm-uix']) {
+    const siblingBlock = jobBlock(workflow, sibling);
+    const siblingHeader = siblingBlock.slice(0, siblingBlock.indexOf('steps:'));
+    assert.doesNotMatch(
+      siblingHeader,
+      /test_react_jvm/,
+      `${sibling} must not be armed by the Test-React signal`,
+    );
+  }
+});
+
+// mark_all() has to stay TOTAL. `force_all` and the workflow-file arms rely on
+// it, so a signal missing there makes a forced full run SKIP the job — the
+// narrowing's own fail-open.
+test('a forced full run still arms test_react_jvm (rf2-6r9j.87)', () => {
+  assert.equal(classify('--all').test_react_jvm, 'true');
+  assert.equal(classify('.github/workflows/test.yml').test_react_jvm, 'true');
+});
+
+// The negative control the bead names, one level down. scripts/test-fast-pr.sh
+// gates its whole JVM tier on the classifier's output; before this change that
+// was `implementation_jvm` alone, and the per-artefact selector that would pick
+// implementation/adapters/test-react by path prefix only ever runs INSIDE that
+// tier. So dropping `implementation_jvm` from the Test-React arm without
+// teaching the spine the new signal makes a Test-React-only LOCAL diff skip its
+// own JVM suite silently.
+test('the local spine consumes test_react_jvm for its JVM tier (rf2-6r9j.87)', () => {
+  const spine = fs.readFileSync(path.join(REPO_ROOT, 'scripts', 'test-fast-pr.sh'), 'utf8');
+  assert.match(
+    spine,
+    /test_react_jvm\)\s+test_react_jvm="\$value" ;;/,
+    'the spine must read test_react_jvm out of the classifier output',
+  );
+  assert.match(
+    spine,
+    /\[ "\$test_react_jvm" = true \][^\n]*run_jvm=true/,
+    'the spine must arm its JVM tier on test_react_jvm',
+  );
+});
+
 // rf2-y9o5e3 — every EXECUTABLE examples/scripts gate file must fire the
 // browser gate it drives, so a PR breaking a launcher / shared port
 // resolver can't avoid the gate it can break. The two adapter-smoke helpers

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -71,7 +71,11 @@ set -euo pipefail
 # `.github/scripts/report-changed-surfaces.sh`, invoked with the changed-file
 # list as explicit paths (it prints `key=value` to stdout when GITHUB_OUTPUT
 # is unset).  `implementation_jvm` gates the JVM artefact suites exactly as it
-# gates test.yml's per-artefact JVM jobs; `cljs_node_test` gates the npm/CLJS/JS-harness/
+# gates test.yml's per-artefact JVM jobs; `test_react_jvm` gates that same tier
+# for the one artefact carrying its OWN narrow signal (rf2-6r9j.87 — Test-React
+# is a local-only CLJC fixture, so the classifier no longer opens the broad
+# `implementation_jvm` fan-out for it, and the spine has to read the narrow
+# signal or its JVM tier goes quiet); `cljs_node_test` gates the npm/CLJS/JS-harness/
 # isolation suites exactly as it gates test.yml's cljs job.  Reusing that one
 # script — rather than re-deriving a divergent surface map here — is what keeps
 # local selection aligned with test.yml by construction.  The documentation
@@ -167,8 +171,8 @@ Usage:
 
 Runtime tiers are gated on the SAME changed-surface classifier CI uses
 (.github/scripts/report-changed-surfaces.sh): the JVM artefact suites run when
-implementation_jvm is set, and the npm/CLJS/JS-harness/isolation suites run
-when cljs_node_test is set.  The documentation gates run when the diff
+implementation_jvm or test_react_jvm is set, and the npm/CLJS/JS-harness/
+isolation suites run when cljs_node_test is set.  The documentation gates run when the diff
 touches documentation content.  The cheap static/drift checks always run.
 
 Within the JVM tier the spine runs implementation/core plus the suite of every
@@ -375,9 +379,20 @@ fi
 # ---- runtime tier, delegated to the CI classifier ----
 # Feed the changed-file list to report-changed-surfaces.sh as explicit paths;
 # it prints `key=value` for every surface when GITHUB_OUTPUT is unset.  We read
-# `implementation_jvm` (core JVM) and `cljs_node_test` (npm/CLJS/JS-harness/
-# isolation), and note whether ANY surface was recognised at all.
+# `implementation_jvm` (core JVM), `test_react_jvm` (the Test-React artefact's
+# own JVM lane) and `cljs_node_test` (npm/CLJS/JS-harness/isolation), and note
+# whether ANY surface was recognised at all.
+#
+# rf2-6r9j.87 — `test_react_jvm` is read here because the classifier no longer
+# sets `implementation_jvm` for a Test-React-only diff. The per-artefact
+# selector below is a PATH-PREFIX match over the roster in
+# scripts/test-jvm-implementation.sh (which lists
+# implementation/adapters/test-react), but it only ever runs INSIDE the
+# `run_jvm = true` branch. Without this key a Test-React-only local diff would
+# skip the JVM tier entirely and the selector would never fire — the same
+# fail-open, one level down, that the classifier narrowing exists to close.
 impl_jvm=false
+test_react_jvm=false
 cljs_node=false
 recognised_surface=false
 classifier_failed=false
@@ -393,6 +408,7 @@ if [ -n "$changed_files" ]; then
     while IFS='=' read -r key value; do
       case "$key" in
         implementation_jvm) impl_jvm="$value" ;;
+        test_react_jvm)     test_react_jvm="$value" ;;
         cljs_node_test)     cljs_node="$value" ;;
       esac
     done <<< "$classify_out"
@@ -485,7 +501,11 @@ elif [ "$recognised_surface" != true ] && [ "$doc_surface" != true ]; then
   run_node=true
   plan_reason="conservative fallback (unknown surface)"
 else
-  [ "$impl_jvm" = true ] && run_jvm=true
+  # rf2-6r9j.87 — either broad JVM signal arms the tier. `test_react_jvm` is
+  # the narrow one the classifier now sets for a Test-React-only diff; the
+  # per-artefact selector then picks implementation/adapters/test-react by
+  # prefix, so the artefact still runs exactly its own suite.
+  { [ "$impl_jvm" = true ] || [ "$test_react_jvm" = true ]; } && run_jvm=true
   [ "$cljs_node" = true ] && run_node=true
   run_docs="$doc_surface"
 fi


### PR DESCRIPTION
Closes rf2-6r9j.87.

## The problem

Every path under `implementation/adapters/test-react/` went through the generic
shipped-adapter arm of `report-changed-surfaces.sh` and produced the same twelve
outputs — source, test, `deps.edn` and a prose-only `README.md` alike — fanning
out to 45 distinct jobs in `test.yml`.

Test-React is the documented exception to that population: a local-only CLJC
test fixture with no Maven coordinate, no production or example consumer and no
browser testbed. Nothing outside its own tree requires
`re-frame.adapter.test-react`; the only out-of-tree mentions are a quoted
`:producer-ns` symbol roster in `late_bind/directory.cljc` (data, not a require)
and prose comments. Exactly two lanes can reach the code:
`jvm-adapters-test-react`, and Shadow's consolidated `:node-test`.

A prose-only README edit scheduling the ~10-minute all-examples compile is what
makes this stale path classification rather than conservative coverage.

## The change

| path | before | after |
| --- | --- | --- |
| `test-react/src/**`, `test-react/test/**` | 12 outputs | `test_react_jvm` + `cljs_node_test` |
| `test-react/deps.edn` | 12 outputs | `test_react_jvm` |
| `test-react/README.md` | 12 outputs | none |
| `adapters/{reagent,uix,reagent-slim}/**` | unchanged | unchanged |
| `implementation/core/**` | unchanged | unchanged |

* A new `test_react_jvm` output: declared in `detect_changed_surfaces.outputs`,
  set in `mark_all()` so a forced full run cannot skip the job, and emitted.
* `deps.edn` feeds the JVM lane only — shadow reads its `:source-paths` from
  `implementation/shadow-cljs.edn` and its deps from `implementation/deps.edn`,
  so this artefact's own `deps.edn` cannot change what the node lane compiles.
* **Carve-outs in BOTH `case` statements the path reaches.** `examples_compile`
  is set by an earlier, different `case` whose long alternation lists
  `implementation/adapters/*`; a carve-out in the adapter block alone would
  leave a README edit still scheduling the all-examples compile. Both new arms
  sit above the pattern they narrow, because shell `case` is first-match.
* `jvm-adapters-test-react` now reads a disjunction. `adapter_diagnostic` stays
  as the **reverse edge** from core, which the fixture depends on;
  `test_react_jvm` is the forward edge. `jvm-reagent`, `jvm-reagent-slim` and
  `jvm-uix` keep `adapter_diagnostic` alone, so a Test-React change no longer
  opens them.
* `scripts/test-fast-pr.sh` consumes the new signal. Its per-artefact selector
  runs only *inside* the JVM tier, so without this a Test-React-only local diff
  would silently skip its own JVM suite — the same fail-open one level down.

## No coverage is lost

The narrowed jobs are the ones with no edge to the fixture: browser DOM,
examples compile, production/release builds, bundle isolation, the
`<reagent|uix>/testbed` smokes (Test-React owns no testbed), tools JVM,
template, MCP, and the 20 other per-artefact JVM suites.

The checks that do **not** ride a surface signal are untouched and still run on
every PR — this was verified rather than assumed, since a surface narrowed too
far fails open:

* `verify-version-lockstep` — always-on, and the gate that would catch this
  `deps.edn` gaining a real `:clein/build` alias (it currently only *mentions*
  the alias in prose, which the structural EDN authority correctly reads as
  not-publishable).
* `check_jvm_lane_rosters.py` and `check_test_lane_bijection.py` — both in the
  always-on `verify-readme-links` job, so roster/lane drift is still caught with
  no signal involved.
* `check_readme_links.py --ci` and the README inventory validator — same
  always-on job, so a README edit still gets its link and inventory gates. That
  is why arming no executable lane for prose is safe.

## Verification

`implementation/scripts/_changed-surfaces.test.cjs` gains ten cases pinning
source, test, deps, README, the core reverse edge, the sibling adapters keeping
their full fan-out, the workflow output declaration, both halves of the job
condition with the three siblings held off the new signal, `mark_all` totality,
and the spine consuming the signal. Suite: **345 passed, exit 0**.

Also run green, exit code captured per run: `check_workflow_yaml.py`,
`check_jvm_lane_rosters.py` (`--self-test` and `--verbose`),
`check_test_lane_bijection.py` (`--self-test` and full),
`check_fast_pr_gap.py` (`--self-test` and full), `check_workflow_job_timeouts.py`,
and a YAML parse of `test.yml` (71 jobs; the three sibling adapter jobs confirmed
still on `adapter_diagnostic` alone).

**Both controls, in both directions.** The classifier is an instrument that can
answer "nothing here", so it was exercised against inputs it should flag as well
as ones it should not: `docs/README.md` → 0 outputs and Test-React README → 0
outputs, against `reagent` → 13, `uix` → 12, `core` → 16, `--all` → 29.

**Two planted faults, each restored and verified by git blob hash.**

1. Neutralising the *first* `case`'s carve-out — the subtle half — brought
   `examples_compile` back and turned the suite red on all four Test-React
   cases, naming the planted output. Without that arm only the README case
   catches it.
2. Reverting the `test-fast-pr.sh` widening made the spine report
   `PLAN docs=false jvm=false node=true` with an empty `PLAN-JVM` for a
   Test-React-only diff — the fail-open the bead names — and reddened the new
   spine pin.

The spine's tiering was exercised through its own `--repo-root` fixture
mechanism: a Test-React-only diff plans
`PLAN-JVM implementation/core implementation/adapters/test-react`, and a
docs-only diff plans `docs=true jvm=false node=false`.

This PR touches `.github/workflows/**`, which arms `mark_all`, so
`test_react_jvm=true` on its own diff — CI exercises the new job condition here.

## Not done, and why

`TESTING.md`'s surface-signal table (lines 193 and 241) describes
`adapter_diagnostic`'s trigger as "an adapter artefact changes", which is no
longer true of Test-React, and it carries no row for `test_react_jvm`. That file
is outside this dispatch's fence; a follow-up bead is filed.
