### PR TITLE
refactor(reagent-slim): drop two dead surfaces from the slim adapter (rf2-6r9j.28, rf2-6r9j.29)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.clj
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.clj
@@ -11,19 +11,19 @@
   macro is shipped — `reg-view` is the single canonical view-registration
   surface (per the rf2-yfbx decision).
 
-  Public fns (compile-time helpers, consumed by `reg-view`'s expansion):
+  Public fn (the one compile-time helper, consumed by `reg-view`'s
+  expansion):
 
     classify-form-body — return a keyword form-tag for the body.
-    tag-form-meta      — wrap a form-tag in the `{:reagent2/form ...}`
-                         metadata map `reg-view` stamps onto the
-                         wrapper fn so the runtime can read it.
 
-  These run at macroexpansion time (CLJ), not at runtime — the macro
-  invoking them folds the result into the emitted CLJS. They are plain
-  `defn`s (the classification logic is pure-data), so any macro that
-  wants to amortise the runtime detection — `re-frame.core/reg-view`
-  or otherwise — can call them directly. No CLJS-side runtime code
-  lives in this ns.")
+  It runs at macroexpansion time (CLJ), not at runtime — the macro
+  invoking it folds the result into the emitted CLJS. It is a plain
+  `defn` (the classification logic is pure-data), which is how
+  `re-frame.core/expand-reg-view` can reach it through
+  `requiring-resolve` without core carrying a static reagent-slim
+  dep. The `{:reagent2/form ...}` metadata map itself is built at
+  the macro's own expansion site, not here. No CLJS-side runtime
+  code lives in this ns.")
 
 ;; ---------------------------------------------------------------------------
 ;; Compile-time form classification
@@ -67,10 +67,3 @@
                (or (= "fn" n) (= "fn*" n))))
       :reagent2/form-2
       :reagent2/form-1)))
-
-(defn tag-form-meta
-  "Return a metadata map carrying the form-tag for runtime consumption.
-  Stamped onto wrapper fns so `wrap-render` can short-circuit the
-  classification cond on the hot path."
-  [form-tag]
-  {:reagent2/form form-tag})

--- a/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
@@ -143,7 +143,7 @@
           (watch-fn watch-key watchable old-value new-value))
         (recur (+ 2 i))))))
 
-(defn- pr-atom [a writer opts type-tag body]
+(defn- pr-atom [writer opts type-tag body]
   (-write writer (str "#object[reagent2.ratom." type-tag " "))
   ;; `pr-writer` is marked private in cljs.core but is the documented
   ;; entrypoint for nested `IPrintWithWriter` dispatch (every reagent2
@@ -234,7 +234,7 @@
   (-meta [_] meta)
 
   IPrintWithWriter
-  (-pr-writer [a w opts] (pr-atom a w opts "RAtom" {:val (-deref a)}))
+  (-pr-writer [a w opts] (pr-atom w opts "RAtom" {:val (-deref a)}))
 
   IWatchable
   (-notify-watches [this old new] (notify-watches! this old new))
@@ -459,7 +459,7 @@
   (-equiv [o other] (identical? o other))
 
   IPrintWithWriter
-  (-pr-writer [a w opts] (pr-atom a w opts "Reaction" {:val (-deref a)}))
+  (-pr-writer [a w opts] (pr-atom w opts "Reaction" {:val (-deref a)}))
 
   IHash
   (-hash [this] (goog/getUid this)))

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/component_test.clj
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/component_test.clj
@@ -57,17 +57,6 @@
     (is (= :reagent2/form-1 (component/classify-form-body '())))))
 
 ;; ---------------------------------------------------------------------------
-;; tag-form-meta — produces the meta map stamped on wrapper fns
-;; ---------------------------------------------------------------------------
-
-(deftest tag-form-meta-shape
-  (testing "tag-form-meta returns a single-key map under :reagent2/form"
-    (is (= {:reagent2/form :reagent2/form-1}
-           (component/tag-form-meta :reagent2/form-1)))
-    (is (= {:reagent2/form :reagent2/form-2}
-           (component/tag-form-meta :reagent2/form-2)))))
-
-;; ---------------------------------------------------------------------------
 ;; End-to-end fold integration: reg-view's expansion stamps the tag
 ;;
 ;; When reagent-slim is on the classpath (as it is here),

--- a/implementation/adapters/reagent-slim/test/reagent2/ratom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/ratom_cljs_test.cljs
@@ -450,3 +450,35 @@
       (ratom/add-on-dispose! r (fn [_] (reset! fired true)))
       (ratom/dispose! r)
       (is (true? @fired)))))
+
+;; ---------------------------------------------------------------------------
+;; IPrintWithWriter — RAtom / Reaction printed representation
+;;
+;; The shared `pr-atom` helper writes `#object[reagent2.ratom.<Type> `,
+;; delegates the value to `pr-writer` for recursive printing, then closes
+;; the bracket. Both print methods deref their receiver at the call site to
+;; build the `{:val ...}` map, so the helper only ever formats a supplied
+;; type tag and body. These pin the exact strings.
+;; ---------------------------------------------------------------------------
+
+(deftest ratom-printed-representation
+  (testing "an RAtom prints as #object[reagent2.ratom.RAtom {:val <v>}]"
+    (is (= "#object[reagent2.ratom.RAtom {:val 1}]"
+           (pr-str (ratom/atom 1)))))
+
+  (testing "the value is printed recursively, not as a summary"
+    (is (= "#object[reagent2.ratom.RAtom {:val {:a [1 2], :b \"s\"}}]"
+           (pr-str (ratom/atom {:a [1 2] :b "s"})))))
+
+  (testing "a nested RAtom prints through the same helper"
+    (is (= "#object[reagent2.ratom.RAtom {:val {:inner #object[reagent2.ratom.RAtom {:val 7}]}}]"
+           (pr-str (ratom/atom {:inner (ratom/atom 7)}))))))
+
+(deftest reaction-printed-representation
+  (testing "a Reaction prints as #object[reagent2.ratom.Reaction {:val <v>}]"
+    (is (= "#object[reagent2.ratom.Reaction {:val 42}]"
+           (pr-str (ratom/make-reaction (fn [] 42))))))
+
+  (testing "the Reaction's value is printed recursively too"
+    (is (= "#object[reagent2.ratom.Reaction {:val [:p 1]}]"
+           (pr-str (ratom/make-reaction (fn [] [:p 1])))))))


### PR DESCRIPTION
Two dead-code removals in `implementation/adapters/reagent-slim/`, both audit
findings under rf2-6r9j. Each premise was checked at source with two
independent instruments and a control that fired.

## rf2-6r9j.29 — `reagent2.ratom/pr-atom`'s unused receiver argument

`(defn- pr-atom [a writer opts type-tag body] …)` never referenced `a`. Both
call sites deref the receiver themselves to build the `{:val …}` body *before*
entering the helper, so the argument could not affect output, dispatch,
identity or reactive capture.

**Removed rather than renamed to `_`.** The rename is the right repair where an
arity is load-bearing because a caller passes positionally and cannot be
changed in the same commit — in CLJS a silently changed arity breaks callers at
runtime, not at compile time. That does not apply here: `pr-atom` is `defn-`,
and a census established that its only two call sites are the `IPrintWithWriter`
methods in the same file, both changed with it. There is no external arity
contract to preserve, and the bead's acceptance criteria ask for the
four-parameter signature.

The `*ratom-context*` nil binding and the point at which each receiver is
dereferenced are untouched.

Census (tracked files, `.beads` excluded), run twice — line-oriented and again
over whitespace-flattened text, since neither result is a superset of the other:
three sites, all in `ratom.cljs`, all in this diff.

**New print pins.** The criterion "existing printed representations remain
unchanged" had no instrument — the suite asserted nothing about either type's
printed form. `ratom_cljs_test.cljs` now pins the exact
`#object[reagent2.ratom.RAtom …]` / `#object[reagent2.ratom.Reaction …]`
strings, recursive value printing, and a nested ratom printing through the same
helper.

## rf2-6r9j.28 — the zero-consumer `tag-form-meta` compile helper

`reagent2.impl.component/tag-form-meta` had no consumer. Removed along with its
dedicated unit test and the namespace docstring's claim that `reg-view`
consumed it. No alias or forwarding wrapper replaces it. `classify-form-body`
and the `reg-view` expansion's own metadata construction are unchanged.

**Ruling out a macro-time consumer**, which a runtime var-usage census cannot
see:

1. Exact-symbol census over tracked files, line-oriented and flattened: only
   the docstring, the `defn`, and the dedicated test. All three are in this
   diff; the post-edit census returns zero on both instruments while the
   control still reports seven files.
2. Every reference to the namespace `reagent2.impl.component` from outside
   reagent-slim was enumerated and read. All name `classify-form-body`,
   `wrap-render`, `create-class*` or `reagent-class?` — none names
   `tag-form-meta`. `expand-reg-view` builds `{:reagent2/form …}` at its own
   expansion site.
3. Both `requiring-resolve` sites in the repository pass a **literal** symbol,
   so the census can see them. A sweep for `resolve` / `ns-resolve` /
   `requiring-resolve` against a dynamically constructed symbol found no such
   site, which is the one shape a literal census would miss.
4. The removal is itself the macro-time instrument: the JVM suite compiles
   `component_test.clj` and macroexpands `reg-view` through
   `re-frame.core/expand-reg-view`. A surviving macro-time consumer would fail
   to compile. It is green.

The docstring's "any macro … or otherwise can call them directly" line went
with the helper: it advertised a general macro-extension contract this
namespace neither specifies nor tests. It now names the one helper with a real
consumer and how that consumer reaches it.

## Gates

Exit codes captured to a file and read from the file, never through a pipe.

| Gate | Captured exit | Result |
| --- | --- | --- |
| `clojure -M:test` (reagent-slim, JVM) | 0 | 10 tests, 10 assertions, 0 failures |
| `compile-node-test.cjs node-test` + `--test=reagent2.ratom-cljs-test` | `COMPILE=0 RUN=0` | 24 tests, 66 assertions, 0 failures |
| `clojure -M:test -n re-frame.reg-view-test` (core) | 0 | 13 tests, 37 assertions, 0 failures |
| `clj-kondo --lint …/reagent-slim/src --cache false` | 2 (warnings) | 2 warnings, both pre-existing in `batching.cljs` |

**Controls that fired.**

- *The negative control the bead asks for.* Planting a fault in
  `classify-form-body`'s Form-2 branch took the JVM gate to exit 1 with four
  failures — including `fold-reg-view-form-2-expansion-tags-form-2`, which
  proves the fold test genuinely reaches reagent-slim's classifier through
  `requiring-resolve` rather than passing vacuously. The plant was scoped so
  the namespace still loaded and all 10 tests still ran, matching the clean
  run's count. Restored and verified by blob hash against the committed object,
  not by reading a diff.
- *clj-kondo baseline.* On unmodified `main` the same invocation reports three
  warnings including `ratom.cljs:146:17: warning: unused binding a`. On this
  branch it reports two: that one is gone and the deliberate
  `batching/installed?` namespace-load warning is untouched, not papered over.
- *The CLJS gate bit before it passed.* Its first run came back red on an
  assertion that existed only in this branch (CLJS `pr-str` emits a comma
  between map entries and the expected string omitted it). A run that had
  wandered into another checkout would have been green.

## Premises that did not hold

- **rf2-6r9j.29's line numbers are off by three.** The `defn` is at
  `ratom.cljs:146`, not 143; the call sites are at 237 and 462, not 234 and 459.
  The substance is unaffected.
- **rf2-6r9j.29 says clj-kondo "reports exactly" the one warning.** It reports
  three on unmodified `main` — the other two are in `batching.cljs` and are
  left alone.
- **rf2-6r9j.28's premise holds as stated**, with the count in a CI comment
  drifting: `.github/workflows/test.yml` describes
  `reagent2.impl.component-test` as "12 deftests" where `main` has 11 and this
  branch leaves 10. It is a YAML comment, not an assertion, and that file is
  hot-zone, so it is reported rather than edited.

## Not changed, reported instead

- `implementation/adapters/reagent-slim/IMPL-SPEC.md:324` describes
  `component.clj` as the "`defview` macro (S3-003 optional path)". No `defview`
  macro exists, and the namespace docstring says so explicitly. That file is
  held by an open PR, so it is untouched here.
- In `pr-atom`, `(pr-writer (binding [*ratom-context* nil] body) writer opts)`
  scopes the nil binding to evaluating `body` — an already-computed local — and
  pops it before `pr-writer` runs, so the guard covers no nested printing at
  all. That is unchanged by this diff and out of scope per the bead, which
  explicitly fences the binding, but it looks like it is not doing what its
  position implies.
