### PR TITLE
refactor(core): the late-bind directory alias joins the rf.* dialect (rf2-6r9j.161)

### DIFF
--- a/implementation/core/test/re_frame/late_bind_drift_test.clj
+++ b/implementation/core/test/re_frame/late_bind_drift_test.clj
@@ -33,7 +33,7 @@
          '[clojure.set :as set]
          '[clojure.string :as str]
          '[clojure.test :refer [deftest is testing]]
-         '[re-frame.late-bind.directory :as directory])
+         '[re-frame.late-bind.directory :as rf.late-bind.directory])
 
 (def ^:private repo-implementation-root
   "Absolute path to the `implementation/` directory at the repo root.
@@ -250,7 +250,7 @@
 
 (deftest every-directory-entry-has-required-fields
   (testing "Each entry in re-frame.late-bind.directory/hooks declares :key, :producer-ns, :description"
-    (doseq [entry directory/hooks]
+    (doseq [entry rf.late-bind.directory/hooks]
       (is (keyword? (:key entry))
           (str "entry must have a keyword :key — saw " (pr-str entry)))
       (is (or (symbol? (:producer-ns entry))
@@ -264,7 +264,7 @@
 
 (deftest directory-keys-are-unique
   (testing "No duplicate :key entries in the directory"
-    (let [ks   (map :key directory/hooks)
+    (let [ks   (map :key rf.late-bind.directory/hooks)
           dups (->> (frequencies ks)
                     (filter (fn [[_ n]] (> n 1)))
                     (map first))]
@@ -274,7 +274,7 @@
 (deftest every-published-key-has-a-directory-entry
   (testing "Every (late-bind/set-fn! :key ...) site in implementation/**/src is documented"
     (let [published (published-keys)
-          documented (directory/hook-keys)
+          documented (rf.late-bind.directory/hook-keys)
           orphans (sort (set/difference published documented))]
       (is (empty? orphans)
           (str "These keys are published via (late-bind/set-fn! ...) but missing from "
@@ -283,7 +283,7 @@
 
 (deftest every-directory-entry-has-a-real-producer
   (testing "Every directory entry's :producer-ns appears as a `(ns ...)` declaration in tree"
-    (let [stale (->> directory/hooks
+    (let [stale (->> rf.late-bind.directory/hooks
                      (remove (fn [e] (producer-publishes-key? (:producer-ns e))))
                      (map :key)
                      sort)]
@@ -307,7 +307,7 @@
     ;; not meaningful for them and they are intentionally out of scope here.
     (let [direct-by-ns (direct-set-fn-keys-by-ns)
           direct-keys  (reduce into #{} (vals direct-by-ns))
-          mismatched   (->> directory/hooks
+          mismatched   (->> rf.late-bind.directory/hooks
                             ;; only entries whose key is published via a direct set-fn!
                             (filter (fn [{:keys [key]}] (contains? direct-keys key)))
                             (remove
@@ -335,7 +335,7 @@
 (deftest every-directory-entry-is-actually-published
   (testing "Every directory entry's :key has at least one (late-bind/set-fn! :key ...) call site"
     (let [published (published-keys)
-          missing-publish (->> directory/hooks
+          missing-publish (->> rf.late-bind.directory/hooks
                                (map :key)
                                (remove published)
                                sort)]
@@ -386,7 +386,7 @@
     ;; anyway (rf2-0st1f). Extracting the roster block and comparing the exact field
     ;; set gives it teeth — add/remove/rename a roster field and this fails unless
     ;; `epoch-destroy-bundle-roster` above is updated in lockstep.
-    (let [desc         (:description (directory/entry :epoch/snapshot-frame-destroyed))
+    (let [desc         (:description (rf.late-bind.directory/entry :epoch/snapshot-frame-destroyed))
           roster-block (some-> (re-find destroy-bundle-roster-re desc) second)]
       (is (some? desc)
           ":epoch/snapshot-frame-destroyed must have a directory entry")
@@ -431,7 +431,7 @@
     ;; consults to learn whether a hook is production-live, so a row that
     ;; re-acquires the retired rationale re-seeds the defect class.
     (doseq [k reprojection-hook-keys]
-      (let [desc (:description (directory/entry k))]
+      (let [desc (:description (rf.late-bind.directory/entry k))]
         (is (some? desc) (str k " must have a directory entry"))
         (let [lowered (str/lower-case (or desc ""))
               stale   (filter #(str/includes? lowered %) retired-gate-phrases)]


### PR DESCRIPTION
Closes the core require-alias migration begun in PR #9103. One edge, one file.

## What the residue actually was

PR #9103 migrated core to `spec/Conventions.md` §Require-alias dialect and left
**exactly one** non-exempt bare framework alias behind. A balanced-bracket scan of
every `[re-frame… ]` libspec vector under `implementation/core/**` (349 tracked
`.clj`/`.cljs`/`.cljc` files, 1795 re-frame require edges) reads:

| tree | non-exempt noncanonical edges | files |
|---|---|---|
| pre-#9103 (`1db71eac77^`) | 1617 | 311 |
| post-#9103 (`origin/main`) | 1 | 1 |
| this branch | **0** | **0** |

#9103 itself touched 312 core files, +11168/-11155.

## Why #9103 missed it, precisely

The edge is not an `(ns … (:require …))` edge at all. It is a **runtime top-level
`(require '[re-frame.late-bind.directory :as directory])`** at
`late_bind_drift_test.clj:36`. clj-kondo's *namespace-usage* analysis — the
instrument that produced the bead's census — does not report a runtime `require`
form, which is why that census read **1616** where a textual balanced-bracket scan
of the same tree reads **1617**. The one-edge delta *is* this edge.

## What moved, and what deliberately did not

The libspec plus its **8 qualified use sites**. Nothing else:

- the **3 fully-qualified** `re-frame.late-bind.directory/hooks` references in the
  docstring and failure messages stay fully qualified;
- the `re_frame/late_bind/directory.cljc` classpath-resource paths stay paths;
- the prose sense of "directory", and the `every-directory-entry-*` deftest names,
  are untouched.

The file carries **zero** `::directory/`, `:directory/`, `#'directory/` and
`'directory/` forms, so none of those classes arose here.

## Controls

- **Literal-keyword multiset** over all of `implementation/core/**` — 3652 distinct
  literal single-colon `:ns/name` keywords, 22833 occurrences — is **identical**
  before and after, **0 entries changed**. (This is the control that caught 42
  silently-rewritten late-bind keys during the machines sweep.)
- **Host-conditional exemptions**: the derived predicate — an alias bound to 2+
  distinct namespaces within one file — finds **0** in core, across the 143 core
  `.cljc` files that carry both reader conditionals and re-frame requires. Core has
  no dual-binding shape. (Nothing is exempted by path list.)
- **Multi-line libspecs**: the balanced-bracket scan finds **39** libspec vectors in
  core that span lines, e.g. `[re-frame.trace :as rf.trace\n #?@(:cljs […])]`. A
  line-anchored regex would have missed every one — the silent miss that cost the
  machines sweep 116 use sites.
- **Census instrument exercised against inputs it should flag**: 339 noncanonical
  edges in `implementation/adapters/`, 112 in `implementation/schemas/`. A zero from
  this scanner is a measurement, not a misfire.

## Gates

| gate | captured exit | result |
|---|---|---|
| `clojure -M:test` (core JVM) | **0** | 2177 tests / 11158 assertions, 0 failures, 0 errors |
| `clojure -M:test -n re-frame.late-bind-drift-test` | **0** | **8** tests / 695 assertions — the file's 8 deftests, so it was discovered and did run |
| `scripts/check_keyword_catalogue_drift.py` | **0** | no drift |
| `clj-kondo --lint implementation/core` | 2 (warnings present) | 640 warnings / 0 errors — **identical to the same tree with this file reverted**, zero delta |
| `git diff --check` | **0** | clean |

The focused run matters on its own: a file whose `ns` form the reader cannot read is
*invisible* to `cognitect.test-runner` and the suite still exits 0 (the defect
`re-frame.test-quiet-discovery-integrity-test` exists to pin). Counting **8** is what
rules that out here.

**Both live gates were proven to bite, and to be reading this checkout:**

- A planted `rf.late-bind.directoryX/hooks` returned **exit 1 naming
  `rf.late-bind.directoryX`** — a token that exists only in this worktree, so a run
  that had wandered into a sibling checkout would have come back green. Restored;
  verified by blob hash `0c3b55026700f8569e0b998fc76a3d4a50c89ef7`.
- A planted `::rf.zzzprobe/planted` in `late_bind.cljc` returned the catalogue
  checker **exit 1 naming `:rf.zzzprobe/*`**. Restored; blob
  `a6afbfcf54067de601b2b438c770e0dfc5a8bac1`.

## Two gates deliberately not nominated, with the measurement

**`npm run test:cljs` cannot observe this change.** The `:node-test` build selects by
`:ns-regexp "cljs-test$"`; `re-frame.late-bind-drift-test` does not match it (control:
`re-frame.foo-cljs-test` does), the file is `.clj` rather than a CLJS source, and
nothing `:require`s the namespace. Running it would be a green over an unexercised
subject.

**`scripts/check_keyword_catalogue_drift.py` could not have fired on this diff
either way** — its scan surface excludes `test/` trees, and this sweep produced no
auto-resolved `::rf.*` keyword at all. So the `::rf.x/y` vs `:rf.x/y` ambiguity that
forced the machines sweep to spell a sentinel fully-qualified **does not arise here,
and `spec/Conventions.md` needs no row.** It was still exercised (above) rather than
trusted.

## Scope

One file under `implementation/core/test/`. No overlap with the open core-adjacent
PRs #9123 (event-conformance) or #9122 (adapters/derivation-conformance) — checked
against the paginated file lists of both; neither names a path under
`implementation/core/`.
