### PR TITLE
refactor(resources): canonical dotted rf.* require aliases (rf2-6r9j.209)

### DIFF
--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -43,34 +43,34 @@
 
   Loading this namespace registers the complete resource and mutation event,
   subscription, effect, and integration surface."
-  (:require [re-frame.cofx :as cofx]
-            [re-frame.error :as error]
-            [re-frame.events :as events]
-            [re-frame.frame :as frame]
-            [re-frame.fx :as fx]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.resources.classification :as classification]
-            [re-frame.resources.events :as resource-events]
-            [re-frame.resources.mutation-events :as mutation-events]
-            [re-frame.resources.mutation-registry :as mutation-registry]
-            [re-frame.resources.mutation-runtime :as mstate]
-            [re-frame.resources.mutation-subs :as mutation-subs]
-            [re-frame.resources.registry :as registry]
-            [re-frame.resources.revalidate-listeners :as revalidate-listeners]
-            [re-frame.resources.route :as route]
-            [re-frame.resources.scope-registry :as scope-registry]
-            [re-frame.resources.ssr :as ssr]
-            [re-frame.resources.state :as state]
-            [re-frame.resources.subs :as resource-subs]
-            [re-frame.resources.timers :as timers]
+  (:require [re-frame.cofx :as rf.cofx]
+            [re-frame.error :as rf.error]
+            [re-frame.events :as rf.events]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fx :as rf.fx]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.resources.classification :as rf.resources.classification]
+            [re-frame.resources.events :as rf.resources.events]
+            [re-frame.resources.mutation-events :as rf.resources.mutation-events]
+            [re-frame.resources.mutation-registry :as rf.resources.mutation-registry]
+            [re-frame.resources.mutation-runtime :as rf.resources.mutation-runtime]
+            [re-frame.resources.mutation-subs :as rf.resources.mutation-subs]
+            [re-frame.resources.registry :as rf.resources.registry]
+            [re-frame.resources.revalidate-listeners :as rf.resources.revalidate-listeners]
+            [re-frame.resources.route :as rf.resources.route]
+            [re-frame.resources.scope-registry :as rf.resources.scope-registry]
+            [re-frame.resources.ssr :as rf.resources.ssr]
+            [re-frame.resources.state :as rf.resources.state]
+            [re-frame.resources.subs :as rf.resources.subs]
+            [re-frame.resources.timers :as rf.resources.timers]
             ;; The OFF-BOX trace-row egress projector for
             ;; the resource/mutation trace family's scoped-key slots. A
             ;; production-reachable ns (NOT the bundle-isolated tooling sibling)
             ;; so the `:resources/project-resource-trace-egress` hook below is
             ;; published on BOTH runtimes whenever resources is loaded — the
             ;; epoch tool-pair consults it on every off-box record projection.
-            [re-frame.resources.trace-egress :as trace-egress]
-            [re-frame.resources.work-ledger :as work-ledger]
+            [re-frame.resources.trace-egress :as rf.resources.trace-egress]
+            [re-frame.resources.work-ledger :as rf.resources.work-ledger]
             ;; JVM-only require of the resources tooling sibling that backs the
             ;; `resource-algebra-view`
             ;; / `resource-cache-algebra-view` aliases at the foot of this ns.
@@ -79,7 +79,7 @@
             ;; body wholesale — the facade never reaches it. JVM has no bundle
             ;; to protect; the alias gives JVM tools / conformance fixtures the
             ;; ergonomic `re-frame.resources/<name>` shape.
-            #?@(:clj [[re-frame.resources.tooling :as resources-tooling]])))
+            #?@(:clj [[re-frame.resources.tooling :as rf.resources.tooling]])))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -88,10 +88,10 @@
 ;; `re-frame.resources/<name>` so consumers (the `re-frame.core` late-bind
 ;; bridge, conformance, tests, examples) see one surface.
 
-(def reg-resource    registry/reg-resource)
-(def clear-resource  registry/clear-resource)
-(def resource-meta   registry/resource-meta)
-(def resource-ids    registry/resource-ids)
+(def reg-resource    rf.resources.registry/reg-resource)
+(def clear-resource  rf.resources.registry/clear-resource)
+(def resource-meta   rf.resources.registry/resource-meta)
+(def resource-ids    rf.resources.registry/resource-ids)
 
 ;; Derivation/process algebra views of
 ;; registered resources (`resource-algebra-view`, static) and of a frame's
@@ -107,17 +107,17 @@
 ;; `re-frame.core` facade export.
 #?(:clj
    (do
-     (def resource-algebra-view       resources-tooling/resource-algebra-view)
-     (def resource-cache-algebra-view resources-tooling/resource-cache-algebra-view)))
+     (def resource-algebra-view       rf.resources.tooling/resource-algebra-view)
+     (def resource-cache-algebra-view rf.resources.tooling/resource-cache-algebra-view)))
 
 ;; Mutations (Spec 016 §Mutations). `reg-mutation` registers a causal-write
 ;; mutation; `:rf.mutation/execute` runs it over the SAME managed-HTTP
 ;; transport the resources use, with success-time resource invalidation /
 ;; patch / populate; `clear-mutation` is the registration-lifecycle removal.
-(def reg-mutation    mutation-registry/reg-mutation)
-(def clear-mutation  mutation-registry/clear-mutation)
-(def mutation-meta   mutation-registry/mutation-meta)
-(def mutation-ids    mutation-registry/mutation-ids)
+(def reg-mutation    rf.resources.mutation-registry/reg-mutation)
+(def clear-mutation  rf.resources.mutation-registry/clear-mutation)
+(def mutation-meta   rf.resources.mutation-registry/mutation-meta)
+(def mutation-ids    rf.resources.mutation-registry/mutation-ids)
 
 ;; Named resource-scope resolvers (Spec 016 §Named resource-scope resolvers).
 ;; `reg-resource-scope`
@@ -131,11 +131,11 @@
 ;; `:rf.resource/scope-resolved` evidence is emitted only at the CAUSAL
 ;; resolution boundaries (`{:from-db ...}` scope, route entry, mutation
 ;; settle), per Spec 016 §Named resource-scope resolvers.
-(def reg-resource-scope     scope-registry/reg-resource-scope)
-(def clear-resource-scope   scope-registry/clear-resource-scope)
-(def resolve-resource-scope scope-registry/resolve-resource-scope)
-(def scope-resolver-meta    scope-registry/scope-resolver-meta)
-(def scope-resolver-ids     scope-registry/scope-resolver-ids)
+(def reg-resource-scope     rf.resources.scope-registry/reg-resource-scope)
+(def clear-resource-scope   rf.resources.scope-registry/clear-resource-scope)
+(def resolve-resource-scope rf.resources.scope-registry/resolve-resource-scope)
+(def scope-resolver-meta    rf.resources.scope-registry/scope-resolver-meta)
+(def scope-resolver-ids     rf.resources.scope-registry/scope-resolver-ids)
 
 ;; Focus / reconnect revalidation host-listener install (Spec 016
 ;; §Stale and GC scheduling). An app calls `install-revalidation-listeners!` for each
@@ -144,8 +144,8 @@
 ;; `:rf.resource/network-reconnected` at that frame and are cancelled on
 ;; frame destroy via the single `:resources/on-frame-destroyed!` hook.
 ;; These are CLJS-only host listeners; the JVM arm is a no-op.
-(def install-revalidation-listeners! revalidate-listeners/install-revalidation-listeners!)
-(def remove-revalidation-listeners!  revalidate-listeners/remove-revalidation-listeners!)
+(def install-revalidation-listeners! rf.resources.revalidate-listeners/install-revalidation-listeners!)
+(def remove-revalidation-listeners!  rf.resources.revalidate-listeners/remove-revalidation-listeners!)
 
 (defn resources
   "Return resource introspection for a frame target (Spec 016
@@ -157,7 +157,7 @@
 
   The `:entries` map is keyed on the CEDN-1 byte `key-id` STRING (the SAME
   key the internal runtime storage, the SSR wire, and the reverse indexes
-  use — `state/entries-path`, `state/key-id`); each entry carries its
+  use — `rf.resources.state/entries-path`, `rf.resources.state/key-id`); each entry carries its
   kind-preserving public scoped-resource-key VECTOR
   `[canonical-scope resource-id canonical-params]` under `:resource/key`.
   Callers that need to destructure
@@ -178,8 +178,8 @@
   ([{:keys [frame]}]
    {:resource-ids (resource-ids)
     :entries      (if frame
-                    (let [entries (get-in (frame/frame-runtime-db-value frame)
-                                          (state/entries-path))]
+                    (let [entries (get-in (rf.frame/frame-runtime-db-value frame)
+                                          (rf.resources.state/entries-path))]
                       ;; Preserve the byte-keyed map: re-keying on scoped-key
                       ;; vectors can collapse CEDN-distinct sequential params
                       ;; that compare equal under Clojure `=`.
@@ -205,7 +205,7 @@
   lookup returns `nil` only for a genuinely absent entry."
   [{:keys [frame] :as opts}]
   (when (nil? frame)
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/no-frame-context
       'rf/resource-state
       (str "resource-state requires an explicit :frame "
@@ -221,10 +221,10 @@
         ;; against the frame's app-db value (the same db the
         ;; reactive sub resolves against), so `resource-state` and a live
         ;; `[:rf/resource …]` sub resolve the SAME scoped key.
-        scoped-key (resource-subs/resolve-scoped-key
-                     opts (frame/frame-app-db-value frame))
-        runtime-db (frame/frame-runtime-db-value frame)]
-    (get-in runtime-db (state/entry-path scoped-key))))
+        scoped-key (rf.resources.subs/resolve-scoped-key
+                     opts (rf.frame/frame-app-db-value frame))
+        runtime-db (rf.frame/frame-runtime-db-value frame)]
+    (get-in runtime-db (rf.resources.state/entry-path scoped-key))))
 
 (defn mutations
   "Return mutation introspection for a frame target (Spec 016 §Mutations /
@@ -241,8 +241,8 @@
   ([{:keys [frame]}]
    {:mutation-ids (mutation-ids)
     :instances    (if frame
-                    (or (get-in (frame/frame-runtime-db-value frame)
-                                (mstate/instances-path)) {})
+                    (or (get-in (rf.frame/frame-runtime-db-value frame)
+                                (rf.resources.mutation-runtime/instances-path)) {})
                     {})}))
 
 (defn mutation-state
@@ -263,7 +263,7 @@
   explicit frame lookup returns `nil` only for a genuinely absent instance."
   [{:keys [instance frame] :as opts}]
   (when (nil? frame)
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/no-frame-context
       'rf/mutation-state
       (str "mutation-state requires an explicit :frame "
@@ -274,8 +274,8 @@
            ":frame <frame-id>}. Per Spec 016 §Mutations.")
       {:recovery :pass-frame
        :extra    {:opts (dissoc opts :frame)}}))
-  (let [runtime-db (frame/frame-runtime-db-value frame)]
-    (get-in runtime-db (mstate/instance-path instance))))
+  (let [runtime-db (rf.frame/frame-runtime-db-value frame)]
+    (get-in runtime-db (rf.resources.mutation-runtime/instance-path instance))))
 
 ;; A resource / mutation state read is a subscription VECTOR —
 ;; `(subscribe [:rf/resource
@@ -295,7 +295,7 @@
 ;; ownership diagnostic treats these as in-bounds. Applied uniformly so a
 ;; new resource handler that touches the slice inherits authority by
 ;; sitting in this façade. (Mirrors routing's framework-authority-meta.)
-(def ^:private framework-authority-meta state/framework-authority-meta)
+(def ^:private framework-authority-meta rf.resources.state/framework-authority-meta)
 
 ;; :rf.resource/generation-allocation cofx + :rf.resource/commit-generation
 ;; fx — Spec 016 §Restore and replay part 1 + 002 §Durable join keys are
@@ -313,12 +313,12 @@
 ;; recorded `:generation` flat and write only it durably; the fx advances the
 ;; host high-water with `max`. Registered in the façade so a `:reload`
 ;; re-wires them.
-(cofx/reg-cofx :rf.resource/generation-allocation
-               state/generation-allocation-cofx-meta
-               state/generation-allocation-cofx)
-(fx/reg-fx :rf.resource/commit-generation
-           state/commit-generation-meta
-           state/commit-generation-handler)
+(rf.cofx/reg-cofx :rf.resource/generation-allocation
+               rf.resources.state/generation-allocation-cofx-meta
+               rf.resources.state/generation-allocation-cofx)
+(rf.fx/reg-fx :rf.resource/commit-generation
+           rf.resources.state/commit-generation-meta
+           rf.resources.state/commit-generation-handler)
 
 ;; Work-ledger host-handle side-table write fx. The work-handle
 ;; side table is host-side transient state (NOT runtime-db), so its writes
@@ -327,12 +327,12 @@
 ;; lower and :rf.resource/clear-work-handle when an attempt is superseded /
 ;; settled. Per Spec 016 §Frame work ledger. Registered in the façade so a
 ;; `:reload` re-wires them.
-(fx/reg-fx :rf.resource/record-work-handle
-           work-ledger/record-work-handle-meta
-           work-ledger/record-work-handle-handler)
-(fx/reg-fx :rf.resource/clear-work-handle
-           work-ledger/clear-work-handle-meta
-           work-ledger/clear-work-handle-handler)
+(rf.fx/reg-fx :rf.resource/record-work-handle
+           rf.resources.work-ledger/record-work-handle-meta
+           rf.resources.work-ledger/record-work-handle-handler)
+(rf.fx/reg-fx :rf.resource/clear-work-handle
+           rf.resources.work-ledger/clear-work-handle-meta
+           rf.resources.work-ledger/clear-work-handle-handler)
 
 ;; Stale / GC timer side-table write fx. The stale / GC timer
 ;; handles are host-side transient state (NOT runtime-db), so their writes
@@ -345,19 +345,19 @@
 ;; point + lazy client revalidation, never wall-clock background timers). Per
 ;; Spec 016 §Stale and GC scheduling. Registered in the façade so a `:reload`
 ;; re-wires them.
-(fx/reg-fx :rf.resource/schedule-timers
-           timers/schedule-timers-meta
-           timers/schedule-timers-handler)
-(fx/reg-fx :rf.resource/cancel-timers
-           timers/cancel-timers-meta
-           timers/cancel-timers-handler)
+(rf.fx/reg-fx :rf.resource/schedule-timers
+           rf.resources.timers/schedule-timers-meta
+           rf.resources.timers/schedule-timers-handler)
+(rf.fx/reg-fx :rf.resource/cancel-timers
+           rf.resources.timers/cancel-timers-meta
+           rf.resources.timers/cancel-timers-handler)
 ;; The poll-only cancel fx. `:rf.resource/release-owner`
 ;; emits it for each entry that became owner-free (polling stops the instant
 ;; the last owner releases — a poll never pins an owner-free entry; the stale
 ;; / GC timers stay armed because an owner-free entry still GCs).
-(fx/reg-fx :rf.resource/cancel-poll-timers
-           timers/cancel-poll-timers-meta
-           timers/cancel-poll-timers-handler)
+(rf.fx/reg-fx :rf.resource/cancel-poll-timers
+           rf.resources.timers/cancel-poll-timers-meta
+           rf.resources.timers/cancel-poll-timers-handler)
 
 ;; A time-consuming resource / mutation handler DECLARES the
 ;; framework-stamped causal-time fact `:rf/time-ms` via `:rf.cofx/requires`
@@ -396,30 +396,30 @@
 
 ;; Public resource events (map payloads). Per Spec 016 §Events.
 ;; Every entry-mutating handler is wrapped with
-;; `resource-events/with-classification-lowering` so its durable `:rf.db/runtime`
+;; `rf.resources.events/with-classification-lowering` so its durable `:rf.db/runtime`
 ;; transition LOWERS each live entry's projection-relative `:sensitive` /
 ;; `:large` classification into the per-frame elision registry under `:source
 ;; :resource` (the routing/machines lowering peer),
 ;; instead of re-deriving it only at the family-private projectors. The
 ;; reconciliation is idempotent + self-dropping, so the registry's resource-
 ;; sourced set stays in step with `:entries` no matter which handler ran.
-(events/reg-event :rf.resource/ensure
+(rf.events/reg-event :rf.resource/ensure
                      generation-meta
-                     (resource-events/with-classification-lowering
-                       resource-events/ensure-handler))
-(events/reg-event :rf.resource/refetch
+                     (rf.resources.events/with-classification-lowering
+                       rf.resources.events/ensure-handler))
+(rf.events/reg-event :rf.resource/refetch
                      generation-meta
-                     (resource-events/with-classification-lowering
-                       resource-events/refetch-handler))
+                     (rf.resources.events/with-classification-lowering
+                       rf.resources.events/refetch-handler))
 ;; `:rf.resource/load-more` extends an infinite feed by one page.
 ;; It mints a generation (the same host-side monotone allocator, for stale
 ;; suppression — the work-id derives from it) and records the work-ledger
 ;; `:started-at` from the causal `:rf/time-ms`, so it declares the recordable
 ;; generation-allocation cofx + the time cofx exactly like ensure / refetch.
-(events/reg-event :rf.resource/load-more
+(rf.events/reg-event :rf.resource/load-more
                      generation-meta
-                     (resource-events/with-classification-lowering
-                       resource-events/load-more-handler))
+                     (rf.resources.events/with-classification-lowering
+                       rf.resources.events/load-more-handler))
 ;; `:rf.resource.internal/refetch-page` re-fetches
 ;; ONE page of a multi-page refetch sweep (`:refetch-all-pages?` /
 ;; `:refetch-window`). Chained by `page-succeeded-handler` one leg at a time; it
@@ -427,52 +427,52 @@
 ;; suppression) and records the work `:started-at` from the causal `:rf/time-ms`,
 ;; so it declares the recordable generation-allocation + time cofx exactly like
 ;; load-more. User code MUST NOT dispatch it.
-(events/reg-event :rf.resource.internal/refetch-page
+(rf.events/reg-event :rf.resource.internal/refetch-page
                      generation-meta
-                     (resource-events/with-classification-lowering
-                       resource-events/refetch-page-handler))
+                     (rf.resources.events/with-classification-lowering
+                       rf.resources.events/refetch-page-handler))
 ;; `invalidate-tags` writes the durable `:invalidated-at`
 ;; fact from the event's causal `:rf/time-ms`, so it declares the time cofx.
-(events/reg-event :rf.resource/invalidate-tags
+(rf.events/reg-event :rf.resource/invalidate-tags
                      time-meta
-                     (resource-events/with-classification-lowering
-                       resource-events/invalidate-tags-handler))
-(events/reg-event :rf.resource/release-owner
+                     (rf.resources.events/with-classification-lowering
+                       rf.resources.events/invalidate-tags-handler))
+(rf.events/reg-event :rf.resource/release-owner
                      framework-authority-meta
-                     (resource-events/with-classification-lowering
-                       resource-events/release-owner-handler))
+                     (rf.resources.events/with-classification-lowering
+                       rf.resources.events/release-owner-handler))
 ;; EP-0037 R2 — the attach-before-release primitive for a KEPT branch-plan
 ;; identity: attach the next route-plan owner onto a shared ancestor read
 ;; WITHOUT a fetch (the partial-revalidation law), dispatched ahead of the
 ;; prior owner's release. See resources.route/route-resource-plan.
-(events/reg-event :rf.resource/adopt-owner
+(rf.events/reg-event :rf.resource/adopt-owner
                      framework-authority-meta
-                     (resource-events/with-classification-lowering
-                       resource-events/adopt-route-owner-handler))
+                     (rf.resources.events/with-classification-lowering
+                       rf.resources.events/adopt-route-owner-handler))
 ;; rf2-y8jjk — the release-side twin of `adopt-owner`: release an owner from a
 ;; SUBSET of the identities it holds. Dispatched by the route planner on a
 ;; same-token REPLAN (`:rf.route/replan-resources`) for exactly the identities
 ;; the new plan dropped, ordered AFTER the attach fx; clears no route slot (the
 ;; replan commit owns them). A framework primitive, not an app verb. See
 ;; resources.route/route-resource-plan (plan mode `:replan`).
-(events/reg-event :rf.resource/release-owner-identities
+(rf.events/reg-event :rf.resource/release-owner-identities
                      framework-authority-meta
-                     (resource-events/with-classification-lowering
-                       resource-events/release-owner-identities-handler))
+                     (rf.resources.events/with-classification-lowering
+                       rf.resources.events/release-owner-identities-handler))
 ;; rf2-x76af2.14 — clear-scope / remove settle in-flight work rows terminal
 ;; `:cancelled`, and a cancellation is a COMPLETION: its terminal outcome carries
 ;; the event's causal `:completed-at` (from the declared-flat `:rf/time-ms`),
 ;; symmetric with every reply-driven cancellation (rf2-rl27r2). Declare
 ;; `time-meta` (framework-authority + the `:rf/time-ms` cofx) so the causal time
 ;; is delivered flat and the handler can stamp it onto the cancelled work row.
-(events/reg-event :rf.resource/clear-scope
+(rf.events/reg-event :rf.resource/clear-scope
                      time-meta
-                     (resource-events/with-classification-lowering
-                       resource-events/clear-scope-handler))
-(events/reg-event :rf.resource/remove
+                     (rf.resources.events/with-classification-lowering
+                       rf.resources.events/clear-scope-handler))
+(rf.events/reg-event :rf.resource/remove
                      time-meta
-                     (resource-events/with-classification-lowering
-                       resource-events/remove-handler))
+                     (rf.resources.events/with-classification-lowering
+                       rf.resources.events/remove-handler))
 
 ;; Focus / reconnect revalidation events (Spec 016 §Stale and GC scheduling).
 ;; The host focus / online listeners
@@ -488,12 +488,12 @@
 ;; active-stale SELECTION against the token's causal `:rf/time-ms`, so they
 ;; declare the time cofx (the scan writes nothing durable itself, but a
 ;; replayed signal must SELECT the same set the recorded time dictated).
-(events/reg-event :rf.resource/window-focused
+(rf.events/reg-event :rf.resource/window-focused
                      time-meta
-                     resource-events/window-focused-handler)
-(events/reg-event :rf.resource/network-reconnected
+                     rf.resources.events/window-focused-handler)
+(rf.events/reg-event :rf.resource/network-reconnected
                      time-meta
-                     resource-events/network-reconnected-handler)
+                     rf.resources.events/network-reconnected-handler)
 
 ;; Framework-internal reply handlers. Per Spec 016 §Events / §Transport.
 ;; User code MUST NOT dispatch these.
@@ -504,14 +504,14 @@
 ;; carry it, symmetrically with success + mutation); stale-fired → a
 ;; replay-stable freshness re-check. Each declares the time cofx so the fact
 ;; is delivered flat.
-(events/reg-event :rf.resource.internal/succeeded
+(rf.events/reg-event :rf.resource.internal/succeeded
                      time-meta
-                     (resource-events/with-classification-lowering
-                       resource-events/succeeded-handler))
-(events/reg-event :rf.resource.internal/failed
+                     (rf.resources.events/with-classification-lowering
+                       rf.resources.events/succeeded-handler))
+(rf.events/reg-event :rf.resource.internal/failed
                      time-meta
-                     (resource-events/with-classification-lowering
-                       resource-events/failed-handler))
+                     (rf.resources.events/with-classification-lowering
+                       rf.resources.events/failed-handler))
 ;; The infinite-feed PAGE reply handlers are DISTINCT from the
 ;; scalar succeeded / failed replies: a page success APPENDS / replaces-in-place
 ;; one page (`entry-replace-page`); a page failure is the THIRD error channel
@@ -519,37 +519,37 @@
 ;; same `live-entry-for-reply` verification + stale suppression and consume the
 ;; reply token's causal `:rf/time-ms` (→ `:loaded-at` / `:completed-at`), so
 ;; each declares the time cofx. User code MUST NOT dispatch them.
-(events/reg-event :rf.resource.internal/page-succeeded
+(rf.events/reg-event :rf.resource.internal/page-succeeded
                      time-meta
-                     (resource-events/with-classification-lowering
-                       resource-events/page-succeeded-handler))
-(events/reg-event :rf.resource.internal/page-failed
+                     (rf.resources.events/with-classification-lowering
+                       rf.resources.events/page-succeeded-handler))
+(rf.events/reg-event :rf.resource.internal/page-failed
                      time-meta
-                     (resource-events/with-classification-lowering
-                       resource-events/page-failed-handler))
-(events/reg-event :rf.resource.internal/stale-fired
+                     (rf.resources.events/with-classification-lowering
+                       rf.resources.events/page-failed-handler))
+(rf.events/reg-event :rf.resource.internal/stale-fired
                      time-meta
-                     (resource-events/with-classification-lowering
-                       resource-events/stale-fired-handler))
-(events/reg-event :rf.resource.internal/gc-fired
+                     (rf.resources.events/with-classification-lowering
+                       rf.resources.events/stale-fired-handler))
+(rf.events/reg-event :rf.resource.internal/gc-fired
                      framework-authority-meta
-                     (resource-events/with-classification-lowering
-                       resource-events/gc-fired-handler))
+                     (rf.resources.events/with-classification-lowering
+                       rf.resources.events/gc-fired-handler))
 ;; An active-owner `:poll` timer fired. The handler
 ;; re-checks the live entry (present? owned? not hidden? not in-flight?) and
 ;; unconditionally refetches (cause `:poll`, never an owner) when polling
 ;; should continue, re-arming the next interval. The host `:poll` timer
 ;; dispatches this; user code MUST NOT dispatch it directly.
-(events/reg-event :rf.resource.internal/poll-fired
+(rf.events/reg-event :rf.resource.internal/poll-fired
                      framework-authority-meta
-                     (resource-events/with-classification-lowering
-                       resource-events/poll-fired-handler))
-(events/reg-event :rf.resource.internal/stale-suppressed
+                     (rf.resources.events/with-classification-lowering
+                       rf.resources.events/poll-fired-handler))
+(rf.events/reg-event :rf.resource.internal/stale-suppressed
                      framework-authority-meta
-                     resource-events/stale-suppressed-handler)
+                     rf.resources.events/stale-suppressed-handler)
 
 ;; Passive resource subs. Per Spec 016 §Subscriptions.
-(resource-subs/register-subs!)
+(rf.resources.subs/register-subs!)
 
 ;; Mutations (Spec 016 §Mutations). The causal-write counterpart of the resource
 ;; events: `:rf.mutation/execute` mints an instance + work-ledger record and
@@ -568,7 +568,7 @@
 ;; The ENTRY-mutating mutation handlers (`execute` optimistic apply / seed;
 ;; `succeeded` `:patches` / `:populates` / `:removes`; `failed` conflict-aware
 ;; rollback restore / remove / invalidate) are wrapped in
-;; `resource-events/with-classification-lowering` exactly like the resource
+;; `rf.resources.events/with-classification-lowering` exactly like the resource
 ;; reply/lifecycle handlers — a `:populates` can CREATE a brand-new registered-
 ;; resource entry the elision registry never lowered a declaration for, so
 ;; without the reconcile the per-frame registry drifts out of step with
@@ -587,11 +587,11 @@
 ;; self-dropping reconcile removes the cleared instance's lowered declaration).
 (defn- with-mutation-classification-lowering
   "Wrap a mutation event handler `f` so the `:rf.db/runtime` value of its returned
-  effects map is reconciled through `classification/reconcile-mutation-registry`
-  (resolver = `mutation-registry/mutation-meta`) — lowering each live mutation
+  effects map is reconciled through `rf.resources.classification/reconcile-mutation-registry`
+  (resolver = `rf.resources.mutation-registry/mutation-meta`) — lowering each live mutation
   instance's projection-relative classification into the per-frame elision
   registry under `:source :mutation`. Composes with the resource-entry
-  `resource-events/with-classification-lowering` (each reconcile touches only its
+  `rf.resources.events/with-classification-lowering` (each reconcile touches only its
   own registry owner, so order is immaterial). A returned map with no
   `:rf.db/runtime` key rides unchanged."
   [f]
@@ -599,34 +599,34 @@
     (let [effects (apply f args)]
       (if (and (map? effects) (contains? effects :rf.db/runtime))
         (update effects :rf.db/runtime
-                classification/reconcile-mutation-registry mutation-registry/mutation-meta)
+                rf.resources.classification/reconcile-mutation-registry rf.resources.mutation-registry/mutation-meta)
         effects))))
-(events/reg-event :rf.mutation/execute
+(rf.events/reg-event :rf.mutation/execute
                      generation-meta
-                     (resource-events/with-classification-lowering
+                     (rf.resources.events/with-classification-lowering
                        (with-mutation-classification-lowering
-                         mutation-events/execute-handler)))
-(events/reg-event :rf.mutation/clear
+                         rf.resources.mutation-events/execute-handler)))
+(rf.events/reg-event :rf.mutation/clear
                      framework-authority-meta
                      (with-mutation-classification-lowering
-                       mutation-events/clear-handler))
+                       rf.resources.mutation-events/clear-handler))
 ;; The mutation reply handlers consume the reply token's
 ;; causal `:rf/time-ms` for the canonical reply's `:completed-at` → the durable
 ;; instance `:settled-at` + any patch / populate `:loaded-at`, so they declare
 ;; the time cofx (success + failure both, symmetric).
-(events/reg-event :rf.mutation.internal/succeeded
+(rf.events/reg-event :rf.mutation.internal/succeeded
                      time-meta
-                     (resource-events/with-classification-lowering
+                     (rf.resources.events/with-classification-lowering
                        (with-mutation-classification-lowering
-                         mutation-events/succeeded-handler)))
-(events/reg-event :rf.mutation.internal/failed
+                         rf.resources.mutation-events/succeeded-handler)))
+(rf.events/reg-event :rf.mutation.internal/failed
                      time-meta
-                     (resource-events/with-classification-lowering
+                     (rf.resources.events/with-classification-lowering
                        (with-mutation-classification-lowering
-                         mutation-events/failed-handler)))
+                         rf.resources.mutation-events/failed-handler)))
 
 ;; Passive mutation subs. Per Spec 016 §Mutations.
-(mutation-subs/register-subs!)
+(rf.resources.mutation-subs/register-subs!)
 
 ;; rf2-3ej3xu — the dispatched-event trace projection for
 ;; `[:rf.mutation/execute …]`. The execute payload's classification lives on
@@ -636,19 +636,19 @@
 ;; projection chokepoint (`re-frame.classification/redact-event-by-registration`)
 ;; defers to this resources-owned hook — the event peer of
 ;; `:http/project-managed-fx-args`. Published from the facade (not the
-;; classification ns) because the resolver is `mutation-registry/mutation-meta`
+;; classification ns) because the resolver is `rf.resources.mutation-registry/mutation-meta`
 ;; and the registry requires the classification ns (a back-require would cycle).
-(late-bind/set-fn! :resources/project-execute-event-args
+(rf.late-bind/set-fn! :resources/project-execute-event-args
                    (fn project-execute-event-args-hook [args]
-                     (classification/project-execute-event-args
-                       args mutation-registry/mutation-meta)))
+                     (rf.resources.classification/project-execute-event-args
+                       args rf.resources.mutation-registry/mutation-meta)))
 
 ;; LATE-BOUND cross-feature integrations (Spec 016 §Route integration /
 ;; §SSR and hydration). Wired here so they re-install on a `:reload`. Each
 ;; publishes a late-bind hook the host artefact (routing / ssr) CONSULTS;
 ;; both are no-op-effect on an app that never loads the host artefact.
-(route/install-routing-integration!)
-(ssr/install-ssr-integration!)
+(rf.resources.route/install-routing-integration!)
+(rf.resources.ssr/install-ssr-integration!)
 
 ;; Release the destroyed frame's host-side TRANSIENT
 ;; resource caches — the work-ledger host handles (AbortControllers,
@@ -657,7 +657,7 @@
 ;; generation high-water mark (`re-frame.resources.state/generation-cache`).
 ;; None is runtime-db state — all live in module-level atoms (host-derived,
 ;; ephemeral, off the epoch / SSR egress wire; the generation host-side so an
-;; epoch restore cannot rewind + recycle a generation). `frame/destroy-frame!`
+;; epoch restore cannot rewind + recycle a generation). `rf.frame/destroy-frame!`
 ;; invokes this SINGLE hook by key (no static dep on resources — the artefact
 ;; is optional; ONE teardown path, not three). The durable serializable work
 ;; records + cache entries ride the frame value and are released atomically
@@ -672,13 +672,13 @@
   The `:resources/on-frame-destroyed!` teardown body — one composed hook, no
   second teardown path."
   [frame-id]
-  (work-ledger/on-frame-destroyed! frame-id)
-  (timers/on-frame-destroyed! frame-id)
-  (revalidate-listeners/on-frame-destroyed! frame-id)
-  (state/release-frame! frame-id)
+  (rf.resources.work-ledger/on-frame-destroyed! frame-id)
+  (rf.resources.timers/on-frame-destroyed! frame-id)
+  (rf.resources.revalidate-listeners/on-frame-destroyed! frame-id)
+  (rf.resources.state/release-frame! frame-id)
   nil)
 
-(late-bind/set-fn! :resources/on-frame-destroyed! release-resources-host-caches!)
+(rf.late-bind/set-fn! :resources/on-frame-destroyed! release-resources-host-caches!)
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;; `re-frame.core` MUST NOT `:require [re-frame.resources]` — the artefact
@@ -696,7 +696,7 @@
 ;; it from its own ns-load. The shared CLJS make-reset-runtime-fixture
 ;; reset-hooks table consults it by key and no-ops when test-support is
 ;; absent.
-(late-bind/set-fns!
+(rf.late-bind/set-fns!
   {:resources/reg-resource   reg-resource
    :resources/clear-resource clear-resource
    :resources/resource-meta  resource-meta
@@ -731,7 +731,7 @@
    ;; resolver-owned values once copied into trace tags). Published so the
    ;; epoch artefact reaches it without a static :require on resources.
    :resources/project-scope-resolved-egress
-   scope-registry/project-scope-resolved-egress
+   rf.resources.scope-registry/project-scope-resolved-egress
    ;; Family-level OFF-BOX trace egress projector for
    ;; the rest of the resource/mutation trace family — projects the scoped-key
    ;; slots (`:resource/key` / `:resource/keys` / `:matched` / `:removed` /
@@ -744,7 +744,7 @@
    ;; scoped keys once copied into trace tags). Published so the epoch artefact
    ;; reaches it without a static :require on resources.
    :resources/project-resource-trace-egress
-   trace-egress/project-resource-trace-egress
+   rf.resources.trace-egress/project-resource-trace-egress
    ;; The same owner classification, reached by SLOT rather than by op
    ;; (rf2-1kiuj). An `ensure` lowers into effects that address the work BY its
    ;; scoped key, so the family's keys ride `:rf.fx/args` / `:rf.event/fx` on
@@ -753,4 +753,4 @@
    ;; tool-pair applies this to EVERY row (it no-ops on a row carrying neither
    ;; slot), so no row predicate has to be kept in step with the emit sites.
    :resources/project-fx-args-egress
-   trace-egress/project-fx-args-egress})
+   rf.resources.trace-egress/project-fx-args-egress})

--- a/implementation/resources/src/re_frame/resources/classification.cljc
+++ b/implementation/resources/src/re_frame/resources/classification.cljc
@@ -57,13 +57,13 @@
   This is an internal seam used by SSR, tooling, trace egress, and event-time
   registry reconciliation. The public surface is the projection-relative
   declaration on `reg-resource` / `reg-mutation`."
-  (:require [re-frame.late-bind :as late-bind]
-            [re-frame.classification :as classification]
-            [re-frame.elision :as elision]
-            [re-frame.path :as path]
-            [re-frame.projection :as projection]
-            [re-frame.resources.mutation-runtime :as mutation-runtime]
-            [re-frame.resources.state :as state]))
+  (:require [re-frame.late-bind :as rf.late-bind]
+            [re-frame.classification :as rf.classification]
+            [re-frame.elision :as rf.elision]
+            [re-frame.path :as rf.path]
+            [re-frame.projection :as rf.projection]
+            [re-frame.resources.mutation-runtime :as rf.resources.mutation-runtime]
+            [re-frame.resources.state :as rf.resources.state]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -164,7 +164,7 @@
               (str "each path in the `" k "` classification declaration must be a "
                    "path vector; got " (pr-str p))
               :else
-              (try (path/normalize-concrete p) nil
+              (try (rf.path/normalize-concrete p) nil
                    (catch #?(:clj Throwable :cljs :default) e
                      (str "an invalid path in the `" k "` classification "
                           "declaration: " (or (ex-message e) (str e)))))))
@@ -196,7 +196,7 @@
   [spec k]
   (reduce
     (fn [acc p]
-      (let [p (vec (path/normalize-concrete p))]
+      (let [p (vec (rf.path/normalize-concrete p))]
         (case (first p)
           :data   (update acc :data conj (subvec p 1))
           :params (update acc :params conj (subvec p 1))
@@ -301,7 +301,7 @@
   (let [sens  (carrier-decl-paths spec :sensitive :value)
         large (carrier-decl-paths spec :large :value)]
     (if (or (seq sens) (seq large))
-      (classification/redact-with-paths reply sens large {:index-free? true})
+      (rf.classification/redact-with-paths reply sens large {:index-free? true})
       reply)))
 
 (defn project-execute-event-args
@@ -335,9 +335,9 @@
           sens  (when spec (carrier-decl-paths spec :sensitive nil))
           large (when spec (carrier-decl-paths spec :large nil))
           args  (if (or (seq sens) (seq large))
-                  (classification/redact-with-paths args sens large)
+                  (rf.classification/redact-with-paths args sens large)
                   args)
-          redact-event (late-bind/get-fn :classification/redact-event-by-registration)
+          redact-event (rf.late-bind/get-fn :classification/redact-event-by-registration)
           reply-to     (:reply-to args)]
       (if (and redact-event (vector? reply-to))
         (let [rt' (redact-event reply-to)]
@@ -408,8 +408,8 @@
                 (some (fn [p]
                         (and (>= (count p) n) (= prefix (subvec (vec p) 0 n))))
                       (keys decls)))]
-    (boolean (or (under (elision/sensitive-declarations frame-id))
-                 (under (elision/declarations frame-id))))))
+    (boolean (or (under (rf.elision/sensitive-declarations frame-id))
+                 (under (rf.elision/declarations frame-id))))))
 
 (defn project-entry-data
   "Project a resource entry's serialized DATA value for egress across
@@ -441,9 +441,9 @@
   entry's CEDN-1 byte key-id. Pure w.r.t. the value (reads the live frame's
   registry)."
   [data key-id frame-id boundary-profile]
-  (let [data-prefix (conj (state/entry-path-by-id key-id) :data)]
+  (let [data-prefix (conj (rf.resources.state/entry-path-by-id key-id) :data)]
     (if (and frame-id (registry-classifies-under? frame-id data-prefix))
-      (projection/project-egress
+      (rf.projection/project-egress
         data
         {:frame             frame-id
          :path              data-prefix
@@ -476,9 +476,9 @@
   would break the cache-key-identity round-trip). Frame-SCOPED: a nil /
   unresolvable `frame-id` rides the component VERBATIM. Pure w.r.t. the value."
   [component index key-id frame-id boundary-profile]
-  (let [prefix (conj (state/entry-path-by-id key-id) :resource/key index)]
+  (let [prefix (conj (rf.resources.state/entry-path-by-id key-id) :resource/key index)]
     (if (and frame-id (registry-classifies-under? frame-id prefix))
-      (projection/project-egress
+      (rf.projection/project-egress
         component
         {:frame             frame-id
          :path              prefix
@@ -596,7 +596,7 @@
   walker hooks are unbound. Pure (modulo the memoised walker)."
   [schema]
   (let [extract (fn [hook]
-                  (if-let [f (and schema (late-bind/get-fn-cached hook))]
+                  (if-let [f (and schema (rf.late-bind/get-fn-cached hook))]
                     (or (f schema []) {})
                     {}))]
     {:sensitive (extract :schemas/extract-sensitive-paths-from-schema)
@@ -626,13 +626,13 @@
   hook)."
   [params error spec]
   (let [schema     (:params-schema spec)
-        redact-fn  (late-bind/get-fn-cached :schemas/redact-validation-tags)
+        redact-fn  (rf.late-bind/get-fn-cached :schemas/redact-validation-tags)
         {:keys [sensitive large]} (validation-failure-params-marks schema)
         ;; The failing params slot is the validator's own failure product — redact
         ;; the schema's `:sensitive?` / `:large?` slots per-slot (the surviving
         ;; schema-prop route), keeping the non-sensitive failing field diagnostic.
         params'    (if (or (seq sensitive) (seq large))
-                     (classification/redact-with-paths params (keys sensitive) (keys large))
+                     (rf.classification/redact-with-paths params (keys sensitive) (keys large))
                      params)
         ;; The explainer output carries the failing params verbatim; treat it as
         ;; the `:explain` value-bearing slot the shared seam scrubs whole-payload.
@@ -691,7 +691,7 @@
   "The ABSOLUTE runtime-db prefix for an entry's `:data` value, keyed on the
   byte `key-id` — `[:rf.runtime/resources :entries <key-id> :data]`."
   [key-id]
-  (conj (state/entry-path-by-id key-id) :data))
+  (conj (rf.resources.state/entry-path-by-id key-id) :data))
 
 (defn- entry-key-prefix
   "The ABSOLUTE runtime-db prefix for an entry's scoped-key `:resource/key`
@@ -699,7 +699,7 @@
   scoped key is `[scope resource-id params]`, so a `:params`-rooted declared
   path re-roots under index 2, a `:scope`-rooted one under index 0."
   [key-id]
-  (conj (state/entry-path-by-id key-id) :resource/key))
+  (conj (rf.resources.state/entry-path-by-id key-id) :resource/key))
 
 (defn- instance-declaration-paths
   "The ABSOLUTE `{:sensitive [paths] :large [paths]}` runtime-db paths a single
@@ -731,7 +731,7 @@
   "The multi-owner elision-registry owner identity a resource / mutation
   instance lowering claims under. All current entries share this owner; the
   reconcile rebuilds the full resource-owned claim set from the live entries
-  each commit (self-dropping), so `elision/replace-owner-claims` drops evicted
+  each commit (self-dropping), so `rf.elision/replace-owner-claims` drops evicted
   entries' claims and installs current ones in one step."
   {:source resource-source})
 
@@ -771,7 +771,7 @@
   no key."
   [runtime-db spec-of]
   (let [base    (or runtime-db {})
-        entries (get-in base (state/entries-path))
+        entries (get-in base (rf.resources.state/entries-path))
         reg     (get base elision-registry-key)
         ;; gather every current entry's absolute declaration paths
         {:keys [sensitive large]}
@@ -788,8 +788,8 @@
           {:sensitive [] :large []}
           (or entries {}))
         new-reg (-> (or reg {})
-                    (elision/replace-owner-claims :sensitive-declarations resource-owner sensitive)
-                    (elision/replace-owner-claims :declarations resource-owner large))]
+                    (rf.elision/replace-owner-claims :sensitive-declarations resource-owner sensitive)
+                    (rf.elision/replace-owner-claims :declarations resource-owner large))]
     (cond
       (seq new-reg)
       (assoc base elision-registry-key new-reg)
@@ -835,7 +835,7 @@
   [key-id spec]
   (let [s            (split-projection-paths spec :sensitive)
         l            (split-projection-paths spec :large)
-        inst-prefix  (conj (mutation-runtime/instances-path) key-id)
+        inst-prefix  (conj (rf.resources.mutation-runtime/instances-path) key-id)
         result-pre   (conj inst-prefix :result)
         params-pre   (conj inst-prefix :params)
         scope-pre    (conj inst-prefix :scope)
@@ -893,7 +893,7 @@
   drop verbatim; the never-classified case emits no key."
   [runtime-db spec-of]
   (let [base      (or runtime-db {})
-        instances (get-in base (mutation-runtime/instances-path))
+        instances (get-in base (rf.resources.mutation-runtime/instances-path))
         reg       (get base elision-registry-key)
         {:keys [sensitive large]}
         (reduce-kv
@@ -909,8 +909,8 @@
           {:sensitive [] :large []}
           (or instances {}))
         new-reg   (-> (or reg {})
-                      (elision/replace-owner-claims :sensitive-declarations mutation-owner sensitive)
-                      (elision/replace-owner-claims :declarations mutation-owner large))]
+                      (rf.elision/replace-owner-claims :sensitive-declarations mutation-owner sensitive)
+                      (rf.elision/replace-owner-claims :declarations mutation-owner large))]
     (cond
       (seq new-reg)
       (assoc base elision-registry-key new-reg)

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -22,7 +22,7 @@
   managed-async family produces (EP-0011 §Resource Reply And Work Ledger).
 
   Every handler carries framework-write authority
-  (`state/framework-authority-meta`) so a returned `:rf.db/runtime`
+  (`rf.resources.state/framework-authority-meta`) so a returned `:rf.db/runtime`
   effect is in-bounds (Spec 016 §Write authority); the registrations live
   in the `re-frame.resources` façade so a `(require … :reload)` on a
   fresh registrar re-wires them.
@@ -44,17 +44,17 @@
   scheduling / timers are the invalidation+GC slice. The HTTP request
   execution is the managed-HTTP slice (rf2-p19360); this slice LOWERS into
   managed HTTP (`transport.http/lower`) after the transport seam's
-  registration-time guard (`transport/assert-managed-transport!`).
+  registration-time guard (`rf.resources.transport/assert-managed-transport!`).
 
   ## Work-ledger substrate (rf2-afpdkn)
 
   Each load-causing attempt now also writes a SERIALIZABLE work record at
   `[:rf.runtime/work-ledger <work-id-id>]` — keyed on the CEDN-1 byte
-  `work-ledger/work-id-id` (NOT the work-id vector; rf2-9e0tyq), via
-  `work-ledger/record-path` (the entry points at it via
+  `rf.resources.work-ledger/work-id-id` (NOT the work-id vector; rf2-9e0tyq), via
+  `rf.resources.work-ledger/record-path` (the entry points at it via
   `:current-work`; the record carries status / owners / causes / deadline /
   outcome — NO host handles). Host abort handles live in a side table keyed
-  by `[frame-id work-id]` (`work-ledger/handle-table`), recorded via the
+  by `[frame-id work-id]` (`rf.resources.work-ledger/handle-table`), recorded via the
   `:rf.resource/record-work-handle` fx and dropped on terminate / frame
   destroy. ABORT IS OPPORTUNISTIC (best-effort `:rf.http/managed-abort` on
   supersession / owner-loss / scope-clear); STALE SUPPRESSION by work-id +
@@ -62,19 +62,19 @@
   `live-entry-for-reply`). Terminal rows are pruned on the linked entry's
   next successful transition, retaining a bounded per-key tail for Xray."
   (:require [clojure.set :as set]
-            [re-frame.error :as error]
-            [re-frame.reply :as reply]
-            [re-frame.resources.classification :as classification]
-            [re-frame.resources.registry :as registry]
-            [re-frame.resources.reply :as rreply]
-            [re-frame.resources.reply-handlers :as reply-handlers]
-            [re-frame.resources.route :as route]
-            [re-frame.resources.scope-registry :as scope-registry]
-            [re-frame.resources.state :as state]
-            [re-frame.resources.transport :as transport]
-            [re-frame.resources.transport.http :as transport-http]
-            [re-frame.resources.work-ledger :as work-ledger]
-            [re-frame.trace :as trace]))
+            [re-frame.error :as rf.error]
+            [re-frame.reply :as rf.reply]
+            [re-frame.resources.classification :as rf.resources.classification]
+            [re-frame.resources.registry :as rf.resources.registry]
+            [re-frame.resources.reply :as rf.resources.reply]
+            [re-frame.resources.reply-handlers :as rf.resources.reply-handlers]
+            [re-frame.resources.route :as rf.resources.route]
+            [re-frame.resources.scope-registry :as rf.resources.scope-registry]
+            [re-frame.resources.state :as rf.resources.state]
+            [re-frame.resources.transport :as rf.resources.transport]
+            [re-frame.resources.transport.http :as rf.resources.transport.http]
+            [re-frame.resources.work-ledger :as rf.resources.work-ledger]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -83,7 +83,7 @@
 ;; Every resource handler that writes / evicts `:entries` returns a durable
 ;; `{:rf.db/runtime rdb'}` effect. `with-classification-lowering` wraps such a
 ;; handler so its returned runtime-db is reconciled through
-;; `classification/reconcile-registry` (passing `registry/resource-meta` as the
+;; `rf.resources.classification/reconcile-registry` (passing `rf.resources.registry/resource-meta` as the
 ;; `spec-of` resolver) BEFORE it is committed — lowering each current entry's
 ;; projection-relative `:sensitive` / `:large` declarations into the per-frame
 ;; elision registry under `:source :resource`, and self-dropping an evicted
@@ -97,8 +97,8 @@
 
 (defn with-classification-lowering
   "Wrap a resource event handler `f` so the `:rf.db/runtime` value of its
-  returned effects map is reconciled through `classification/reconcile-registry`
-  (resolver = `registry/resource-meta`) — lowering each live entry's
+  returned effects map is reconciled through `rf.resources.classification/reconcile-registry`
+  (resolver = `rf.resources.registry/resource-meta`) — lowering each live entry's
   projection-relative classification into the per-frame elision registry under
   `:source :resource` (rf2-v8x9n8). A returned map with no `:rf.db/runtime` key
   rides unchanged. Variadic in the handler arity (coeffects + payload + any
@@ -107,7 +107,7 @@
   (fn [& args]
     (let [effects (apply f args)]
       (if (and (map? effects) (contains? effects :rf.db/runtime))
-        (update effects :rf.db/runtime classification/reconcile-registry registry/resource-meta)
+        (update effects :rf.db/runtime rf.resources.classification/reconcile-registry rf.resources.registry/resource-meta)
         effects))))
 
 ;; ---- shared timestamp helpers ---------------------------------------------
@@ -226,7 +226,7 @@
 ;; Where the mutation target rides the TRANSPORT PAYLOAD (a mutation mints a
 ;; fresh instance and never joins), a read JOINS in flight — N ensures share one
 ;; work record and one transport request — so the targets accumulate on the
-;; DURABLE work record's `:reply-targets` (via `work-ledger/add-reply-target`),
+;; DURABLE work record's `:reply-targets` (via `rf.resources.work-ledger/add-reply-target`),
 ;; and the ONE accepted terminal reply fans out to each recorded target exactly
 ;; once. A fresh-skip cache hit has no work record, so it dispatches immediately
 ;; (see the `ensure-load` fresh-skip branch, `:cache-hit? true`).
@@ -266,7 +266,7 @@
   (when-let [targets (seq (:reply-targets record))]
     (let [enriched (read-continuation-reply reply {:resource-key resource-key
                                                    :cache-hit? false})]
-      (into [] (keep (fn [t] (when-let [ev (reply/complete t enriched)]
+      (into [] (keep (fn [t] (when-let [ev (rf.reply/complete t enriched)]
                                [:dispatch ev])))
             targets))))
 
@@ -274,7 +274,7 @@
   "The canonical `:reply-to` `:value` for an INFINITE-feed read completion
   (rf2-c64uiz): the MERGED / flattened item list — the headline
   `:rf.resource/items` read — computed from the feed `entry`'s accumulated
-  pages via `state/merge-pages->items`. BOTH the fresh-skip cache-hit path and
+  pages via `rf.resources.state/merge-pages->items`. BOTH the fresh-skip cache-hit path and
   the async page-0 settle deliver THIS shape, so a `:reply-to` continuation
   reads ONE stable `:value` regardless of how the read settled — never the raw
   page vector (the cache-hit `(:data entry)`) vs a single decoded page (the
@@ -286,10 +286,10 @@
   `:rf.resource/items` sub raises for a misconfigured feed. Per Spec 016 §Read
   completion continuations. Pure."
   [entry where]
-  (let [spec (registry/resource-meta (:resource/id entry))]
-    (state/merge-pages->items
+  (let [spec (rf.resources.registry/resource-meta (:resource/id entry))]
+    (rf.resources.state/merge-pages->items
       (:data entry)
-      (state/resolve-page->items (:page->items spec))
+      (rf.resources.state/resolve-page->items (:page->items spec))
       (:resource/id entry)
       where)))
 
@@ -308,7 +308,7 @@
   delivers nothing) nor when the read carried no `:reply-to`. Returns nil."
   [frame-id resource-key work-id status targets cache-hit?]
   (when (seq targets)
-    (trace/emit! :rf.event :rf.resource/replied
+    (rf.trace/emit! :rf.event :rf.resource/replied
                  {:rf.frame/id frame-id :resource/key resource-key
                   :work/id work-id :status status
                   :targets (vec targets) :cache-hit? (boolean cache-hit?)})))
@@ -331,12 +331,12 @@
 
   `force-new?` false (ensure) ALSO short-circuits a FRESH-SKIP: an
   `ensure` of an already-`:loaded` entry that is still fresh-by-policy
-  (`state/entry-stale?` false against the token's causal declared-flat
+  (`rf.resources.state/entry-stale?` false against the token's causal declared-flat
   `:rf/time-ms`)
   neither dedupes (no
   in-flight work to join) nor starts a fetch — it serves the cached value,
   attaches the supplied owner, emits `:rf.resource/cache-hit`, and
-  re-projects route readiness (`route/reconcile-readiness`), which resolves
+  re-projects route readiness (`rf.resources.route/reconcile-readiness`), which resolves
   the requirement immediately for a route-owned blocking resource. Per Spec 016
   §Lifecycle is an FSM (a `:loaded` entry transitions to `:fetching` ONLY
   on `stale/refetch`; a fresh `ensure` has no transition) / §Restore and
@@ -351,7 +351,7 @@
     time-ms :rf/time-ms, app-db :db}
    {:keys [resource owner cause keep-previous? reply-to] :as payload} {:keys [force-new? where]}]
   (let [runtime-db (or rt {})
-        spec       (registry/require-resource-spec! resource where)
+        spec       (rf.resources.registry/require-resource-spec! resource where)
         ;; EP-0016 D1 extension (rf2-p1yri7) — the OPTIONAL call-site
         ;; `:reply-to` read-completion continuation. It rides the durable work
         ;; record (a read JOINS in flight, so N ensures share one record; the
@@ -364,30 +364,30 @@
         ;; stranding a non-serializable value on the durable row) at completion.
         ;; A nil target stays nil (no continuation). Mirrors the mutation
         ;; execute handler's reply-to hardening (rf2-6kdcs9).
-        reply-to'  (when (some? reply-to) (reply/durable-target reply-to))
+        reply-to'  (when (some? reply-to) (rf.reply/durable-target reply-to))
         ;; EP-0016 D3 slice 3: a `{:from-db …}` payload-scope OR spec-policy
         ;; resolves against the handler's app-db coeffect (`app-db`, the
         ;; causal world input) at use time — fail-closed on nil. Concrete
         ;; scopes resolve as before.
-        scope      (registry/resolve-scope-for-event
+        scope      (rf.resources.registry/resolve-scope-for-event
                      resource spec {:payload-scope (:scope payload) :db app-db} where)
         ;; rf2-hgy5kf — thread `:params` PRESENCE (absent vs explicit nil) to
         ;; the validation boundary; an absent slot becomes `{}` there, an
         ;; explicit `{:params nil}` reaches the schema unchanged.
-        cparams    (registry/validate+canonicalize-params
-                     resource spec (state/params-present? payload) where)
+        cparams    (rf.resources.registry/validate+canonicalize-params
+                     resource spec (rf.resources.state/params-present? payload) where)
         ;; rf2-rplgkw: scope (resolve-scope-for-event → canonicalize-scope) +
         ;; cparams (validate+canonicalize-params) are ALREADY canonical.
-        scoped-key (state/scoped-resource-key* scope resource cparams)
+        scoped-key (rf.resources.state/scoped-resource-key* scope resource cparams)
         ;; EP-0021 R1: an infinite feed is the SAME durable entry whose `:data`
         ;; is the ordered page vector — seed `empty-infinite-entry` (the page
         ;; facts) on a first load, NOT the scalar `empty-entry`. A registered
         ;; non-infinite resource seeds the scalar entry unchanged.
-        infinite?  (registry/infinite-resource? spec)
-        entry      (or (get-in runtime-db (state/entry-path scoped-key))
+        infinite?  (rf.resources.registry/infinite-resource? spec)
+        entry      (or (get-in runtime-db (rf.resources.state/entry-path scoped-key))
                        (if infinite?
-                         (state/empty-infinite-entry resource scoped-key)
-                         (state/empty-entry resource scoped-key)))
+                         (rf.resources.state/empty-infinite-entry resource scoped-key)
+                         (rf.resources.state/empty-entry resource scoped-key)))
         prior-work (:current-work entry)
         in-flight? (some? prior-work)
         ;; JOINABLE work (rf2-v4ygg5): an `ensure` may DEDUPE onto the prior
@@ -406,10 +406,10 @@
         ;; `entry-abort-settled` clears `:current-work` on the way through.)
         ;; A non-joinable prior pointer falls through to a fresh load (a new
         ;; generation), which is the correct re-ensure.
-        ;; `work-ledger/live-work?` is the ONE definition of that liveness
+        ;; `rf.resources.work-ledger/live-work?` is the ONE definition of that liveness
         ;; question, shared with `load-more`'s page dedupe and the route
         ;; planner's retained-identity adoption test (rf2-kqxe6.6).
-        joinable?  (work-ledger/live-work? runtime-db prior-work)
+        joinable?  (rf.resources.work-ledger/live-work? runtime-db prior-work)
         ;; FRESH-SKIP gate (Spec 016 §Lifecycle is an FSM / §Restore and
         ;; replay): an `ensure` (never a `refetch`) of an already-`:loaded`
         ;; entry that is NOT in flight and is still fresh-by-policy serves
@@ -436,7 +436,7 @@
         fresh-skip? (and (not force-new?)
                          (not in-flight?)
                          (= :loaded (:status entry))
-                         (not (state/entry-stale? entry time-ms)))
+                         (not (rf.resources.state/entry-stale? entry time-ms)))
         ;; a NEW owner lands on the entry when an owner is supplied and
         ;; was not already in the active-owner set. `:rf.resource/owner-attached`
         ;; marks that liveness change distinctly from work — symmetric with the
@@ -449,16 +449,16 @@
         ;; HTTP — the only built-in transport; the transport seam
         ;; defaults identically). The work record + side-table handle +
         ;; opportunistic-abort fx all key off the concrete transport id.
-        transport-id (or (:transport spec) transport/default-transport)
+        transport-id (or (:transport spec) rf.resources.transport/default-transport)
         ;; `:keep-previous?` (Spec 016 §Paginated and previous data): when a
         ;; new page/filter key FIRST-loads (no usable data of its own), record
         ;; a PROJECTION POINTER to the prior loaded sibling key so the sub
         ;; layer can show old data while the new key loads — WITHOUT inserting
         ;; that data into this entry or borrowing its tags. Only on a genuine
         ;; first load (an entry that already has data needs no placeholder).
-        prev-key   (when (and keep-previous? (not (state/has-data? entry)))
-                     (state/prior-loaded-sibling-key
-                       (get-in runtime-db (state/entries-path)) scoped-key))]
+        prev-key   (when (and keep-previous? (not (rf.resources.state/has-data? entry)))
+                     (rf.resources.state/prior-loaded-sibling-key
+                       (get-in runtime-db (rf.resources.state/entries-path)) scoped-key))]
     (cond
       ;; ----- fresh-skip: serve the cached value (ensure only) -------------
       ;; A fresh `:loaded` entry needs no work — attach the owner,
@@ -470,25 +470,25 @@
       ;; needed (the entry has its own fresh data); arms no timers; supersedes
       ;; nothing.
       fresh-skip?
-      ;; rf2-cxwuhl — attach the owner via `state/attach-owner`, which bumps the
+      ;; rf2-cxwuhl — attach the owner via `rf.resources.state/attach-owner`, which bumps the
       ;; entry's `:revision` when a NEW owner lands (an owner attach is an
       ;; authoritative durable write a later optimistic rollback could clobber —
       ;; a blind `restore-before` would otherwise DROP a mid-flight-attached
       ;; owner, causing premature GC). A re-attach of a present owner / a nil
       ;; owner is a no-op (no bump), matching `owner-newly-attached?`.
-      (let [hit  (state/attach-owner entry owner)
+      (let [hit  (rf.resources.state/attach-owner entry owner)
             rdb' (-> runtime-db
-                     (assoc-in (state/entry-path scoped-key) hit)
+                     (assoc-in (rf.resources.state/entry-path scoped-key) hit)
                      (cond->
-                       owner (update-in (state/owner-index-path)
-                                        update owner (fnil conj #{}) (state/key-id scoped-key)))
+                       owner (update-in (rf.resources.state/owner-index-path)
+                                        update owner (fnil conj #{}) (rf.resources.state/key-id scoped-key)))
                      ;; route readiness: a route-owned blocking resource that
                      ;; is already fresh MUST resolve its nav-token blocking
                      ;; requirement NOW — no fetch will ever land a reply, so
                      ;; without this re-projection the route hangs forever
                      ;; (Spec 016 §Route integration). A no-op for a
                      ;; non-route-owned / non-blocking resource.
-                     (route/reconcile-readiness))
+                     (rf.resources.route/reconcile-readiness))
             ;; rf2-k9u4h3 — a fresh-skip that attaches a NEW owner to a
             ;; previously OWNER-FREE entry must (re)arm polling. The original
             ;; load may have settled while owner-free (`succeeded-handler` arms
@@ -509,13 +509,13 @@
             ;; but its timers are already live, so it re-arms nothing here.
             was-owner-free? (empty? (:active-owners entry))
             arm-timers?    (and owner-newly-attached? was-owner-free?)
-            spec           (registry/resource-meta (:resource/id entry))
+            spec           (rf.resources.registry/resource-meta (:resource/id entry))
             poll-delay-ms  (when (and arm-timers? (seq (:active-owners hit)))
-                             (state/positive-or-nil (:poll-interval-ms spec)))
+                             (rf.resources.state/positive-or-nil (:poll-interval-ms spec)))
             stale-delay-ms (when arm-timers?
-                             (state/positive-or-nil (:stale-after-ms spec)))
+                             (rf.resources.state/positive-or-nil (:stale-after-ms spec)))
             gc-delay-ms    (when arm-timers?
-                             (state/positive-or-nil (:gc-after-ms spec)))
+                             (rf.resources.state/positive-or-nil (:gc-after-ms spec)))
             ;; EP-0016 D1 extension (rf2-p1yri7) — a fresh-skip cache hit has NO
             ;; work record (no fetch, no new generation), so a call-site
             ;; `:reply-to` continuation dispatches IMMEDIATELY: build the
@@ -538,29 +538,29 @@
             ;; continuation).
             hit-reply  (when reply-to'
                          (read-continuation-reply
-                           (rreply/success-reply
-                             {:work/id      (work-ledger/resource-work-id
+                           (rf.resources.reply/success-reply
+                             {:work/id      (rf.resources.work-ledger/resource-work-id
                                               scoped-key (:generation entry))
                               :resource/key scoped-key
                               :scope        scope
                               :generation   (:generation entry)
                               :rf.frame/id  frame-id}
-                             (if (state/infinite-entry? entry)
+                             (if (rf.resources.state/infinite-entry? entry)
                                (infinite-reply-value entry reply-to-where)
                                (:data entry))
-                             {:work-kind    rreply/work-kind-resource
+                             {:work-kind    rf.resources.reply/work-kind-resource
                               :completed-at time-ms})
                            {:resource-key scoped-key :cache-hit? true}))
             hit-cont-fx (when hit-reply
-                          (when-let [ev (reply/complete reply-to' hit-reply)]
+                          (when-let [ev (rf.reply/complete reply-to' hit-reply)]
                             [:dispatch ev]))]
-        (trace/emit! :rf.event :rf.resource/cache-hit
+        (rf.trace/emit! :rf.event :rf.resource/cache-hit
                      {:rf.frame/id frame-id :resource/key scoped-key
                       :generation (:generation entry) :owner owner :cause cause})
         ;; the cache-hit attached a new owner — record that distinct
         ;; liveness change (symmetric with the dedupe / fresh-load paths).
         (when owner-newly-attached?
-          (trace/emit! :rf.event :rf.resource/owner-attached
+          (rf.trace/emit! :rf.event :rf.resource/owner-attached
                        {:rf.frame/id frame-id :resource/key scoped-key
                         :generation (:generation entry) :owner owner :cause cause
                         :work/id nil :joined-in-flight? false}))
@@ -583,7 +583,7 @@
                              :timers       {:stale stale-delay-ms
                                             :gc    gc-delay-ms
                                             :poll  poll-delay-ms}
-                             :server?      (state/server-frame? frame-id)}]])
+                             :server?      (rf.resources.state/server-frame? frame-id)}]])
               fx        (cond-> (vec timers-fx)
                           hit-cont-fx (conj hit-cont-fx))]
           (cond-> {:rf.db/runtime rdb'}
@@ -599,34 +599,34 @@
       ;; load below, so a route supersession + immediate re-ensure never joins
       ;; dead work.
       (and joinable? (not force-new?))
-      ;; rf2-cxwuhl — attach via `state/attach-owner` (bumps `:revision` on a new
+      ;; rf2-cxwuhl — attach via `rf.resources.state/attach-owner` (bumps `:revision` on a new
       ;; owner) so a dedupe-join that lands an owner mid optimistic-flight is
       ;; visible to the settle conflict check (else a blind rollback would drop
       ;; the joined owner). No-op bump for a re-attach / nil owner.
-      (let [joined (state/attach-owner entry owner)
+      (let [joined (rf.resources.state/attach-owner entry owner)
             rdb'   (-> runtime-db
-                       (assoc-in (state/entry-path scoped-key) joined)
-                       (work-ledger/update-record
-                         prior-work work-ledger/join-owner+cause owner cause)
+                       (assoc-in (rf.resources.state/entry-path scoped-key) joined)
+                       (rf.resources.work-ledger/update-record
+                         prior-work rf.resources.work-ledger/join-owner+cause owner cause)
                        ;; EP-0016 D1 extension (rf2-p1yri7) — a joining ensure
                        ;; appends its call-site `:reply-to` to the SHARED work
                        ;; record's `:reply-targets` (deduped), so the one
                        ;; accepted terminal reply fans out to every joined
                        ;; target exactly once. No-op when the join carried none.
                        (cond->
-                         reply-to' (work-ledger/update-record
-                                     prior-work work-ledger/add-reply-target reply-to'))
+                         reply-to' (rf.resources.work-ledger/update-record
+                                     prior-work rf.resources.work-ledger/add-reply-target reply-to'))
                        (cond->
-                         owner (update-in (state/owner-index-path)
-                                          update owner (fnil conj #{}) (state/key-id scoped-key))))]
-        (trace/emit! :rf.event :rf.resource/deduped
+                         owner (update-in (rf.resources.state/owner-index-path)
+                                          update owner (fnil conj #{}) (rf.resources.state/key-id scoped-key))))]
+        (rf.trace/emit! :rf.event :rf.resource/deduped
                      {:rf.frame/id frame-id :resource/key scoped-key
                       :generation (:generation entry) :owner owner :cause cause
                       :work/id prior-work})
         ;; the ensure joined the in-flight work (no new generation) but ALSO
         ;; attached a new owner — record that distinct liveness change.
         (when owner-newly-attached?
-          (trace/emit! :rf.event :rf.resource/owner-attached
+          (rf.trace/emit! :rf.event :rf.resource/owner-attached
                        {:rf.frame/id frame-id :resource/key scoped-key
                         :generation (:generation entry) :owner owner :cause cause
                         :work/id prior-work :joined-in-flight? true}))
@@ -641,7 +641,7 @@
       ;; identical `:work/id`, which derives from it) — a recorded managed
       ;; reply keeps its current-vs-stale verdict on replay.
       (let [generation (:generation gen-allocation)
-            work-id    (work-ledger/resource-work-id scoped-key generation)
+            work-id    (rf.resources.work-ledger/resource-work-id scoped-key generation)
             ;; rf2-sxyrzk — the transport correlation token is the
             ;; frame-QUALIFIED request-id, NOT the bare work-id. The
             ;; managed-HTTP in-flight registry keys by request-id
@@ -650,7 +650,7 @@
             ;; resource at the same generation would collide on a bare work-id
             ;; and supersede/abort each other's in-flight request. Qualifying
             ;; with the frame id isolates them.
-            request-id (work-ledger/managed-request-id frame-id work-id)
+            request-id (rf.resources.work-ledger/managed-request-id frame-id work-id)
             ;; EP-0010 §Resources, Mutations, And Work-Ledger Timestamps: the
             ;; durable work-ledger `:started-at` is the TRIGGERING TOKEN'S
             ;; `:time-ms` (the causal world input the router stamped once at
@@ -679,7 +679,7 @@
             ;; already-loaded feed never reaches this `:else` fresh-load branch
             ;; (fresh-skip / dedupe handle it).
             refetch-policy (when infinite? (:refetch spec))
-            entry'     (cond-> (state/entry-start-load
+            entry'     (cond-> (rf.resources.state/entry-start-load
                                  entry {:generation generation :work-id work-id
                                         :request-id request-id :owner owner})
                          ;; `:keep-previous?` projection pointer (a pointer
@@ -690,13 +690,13 @@
                          ;; default = no cursor, no sweep). An ensure (not
                          ;; force-new) arms nothing.
                          (and infinite? force-new?)
-                         (state/entry-begin-refetch-sweep refetch-policy))
+                         (rf.resources.state/entry-begin-refetch-sweep refetch-policy))
             ;; EP-0021 R8 — the page context for THIS fetch. A first ensure /
             ;; a refetch's replacement fetch a page-0 (`page-param-for-spec` —
             ;; the framework `nil` default, overridable via `:initial-page-param`
             ;; — at index 0). A non-infinite resource passes a nil ctx (R8 — the
             ;; reserved ctx is empty for a non-infinite request, unchanged).
-            page-param (when infinite? (state/page-param-for-spec spec))
+            page-param (when infinite? (rf.resources.state/page-param-for-spec spec))
             page-index 0
             req-ctx    (when infinite? (page-request-ctx page-param page-index))
             ;; a forced refetch over an in-flight prior attempt SUPERSEDES it:
@@ -705,7 +705,7 @@
             ;; protects the late reply by work-id + generation). Per Spec 016
             ;; §Race (refetch may force a new generation).
             superseding? (and in-flight? force-new?)
-            record     (work-ledger/work-record
+            record     (rf.resources.work-ledger/work-record
                          {:work-id      work-id
                           :frame-id     frame-id
                           :resource/key scoped-key
@@ -731,16 +731,16 @@
                           ;; Omitted when the read carried none.
                           :reply-targets (when reply-to' [reply-to'])})
             rdb'       (-> runtime-db
-                           (assoc-in (state/entry-path scoped-key) entry')
+                           (assoc-in (rf.resources.state/entry-path scoped-key) entry')
                            (cond->
                              superseding?
-                             (work-ledger/update-record
-                               prior-work work-ledger/mark-terminal
+                             (rf.resources.work-ledger/update-record
+                               prior-work rf.resources.work-ledger/mark-terminal
                                :suppressed {:reason :superseded :by work-id}))
-                           (work-ledger/put-record work-id record)
+                           (rf.resources.work-ledger/put-record work-id record)
                            (cond->
-                             owner (update-in (state/owner-index-path)
-                                              update owner (fnil conj #{}) (state/key-id scoped-key))))
+                             owner (update-in (rf.resources.state/owner-index-path)
+                                              update owner (fnil conj #{}) (rf.resources.state/key-id scoped-key))))
             ;; lower into the resource's transport (the existing seam). The
             ;; runtime owns reply addressing: the internal reply payloads
             ;; stamp the qualified :rf.frame/id + :work/id + :resource/key +
@@ -767,11 +767,11 @@
             ;; rf2-rrcfwk — guard the declared transport (registration-time
             ;; misconfig throw), then lower directly into the only
             ;; built-in transport. The one-arm dispatch indirection
-            ;; (`transport/lower-ensure`) is folded into this guarded call;
+            ;; (`rf.resources.transport/lower-ensure`) is folded into this guarded call;
             ;; a real dispatch table returns only when a second transport
             ;; lands (the guard becomes the dispatch).
-            lower-fx   (do (transport/assert-managed-transport! transport-id where)
-                           (transport-http/lower
+            lower-fx   (do (rf.resources.transport/assert-managed-transport! transport-id where)
+                           (rf.resources.transport.http/lower
                              (merge
                                {:http-args    http-args
                                 :request-id   request-id
@@ -787,13 +787,13 @@
             ;; registered); a bare work-id misses it. nil when not superseding or
             ;; the transport has no abort capability (then no abort fx is added).
             superseding-abort-fx (when superseding?
-                                   (work-ledger/abort-fx transport-id frame-id prior-work))]
-        (trace/emit! :rf.event :rf.resource/work-started
+                                   (rf.resources.work-ledger/abort-fx transport-id frame-id prior-work))]
+        (rf.trace/emit! :rf.event :rf.resource/work-started
                      {:rf.frame/id frame-id :resource/key scoped-key
                       :generation generation :work/id work-id
                       :status :running :owner owner :cause cause
                       :superseded (when superseding? prior-work)})
-        (trace/emit! :rf.event :rf.resource/fetch-started
+        (rf.trace/emit! :rf.event :rf.resource/fetch-started
                      {:rf.frame/id frame-id :resource/key scoped-key
                       :generation generation :work/id work-id
                       :status (:status entry') :owner owner :cause cause})
@@ -801,7 +801,7 @@
         ;; liveness change distinctly from the work it kicked off (symmetric
         ;; with `:rf.resource/owner-released`).
         (when owner-newly-attached?
-          (trace/emit! :rf.event :rf.resource/owner-attached
+          (rf.trace/emit! :rf.event :rf.resource/owner-attached
                        {:rf.frame/id frame-id :resource/key scoped-key
                         :generation generation :owner owner :cause cause
                         :work/id work-id :joined-in-flight? false}))
@@ -874,12 +874,12 @@
     time-ms :rf/time-ms, app-db :db}
    {:keys [resource cause] supplied-owner :owner :as payload} {:keys [where]}]
   (let [runtime-db (or rt {})
-        spec       (registry/require-resource-spec! resource where)
-        scope      (registry/resolve-scope-for-event
+        spec       (rf.resources.registry/require-resource-spec! resource where)
+        scope      (rf.resources.registry/resolve-scope-for-event
                      resource spec {:payload-scope (:scope payload) :db app-db} where)
-        cparams    (registry/validate+canonicalize-params
-                     resource spec (state/params-present? payload) where)
-        scoped-key (state/scoped-resource-key* scope resource cparams)
+        cparams    (rf.resources.registry/validate+canonicalize-params
+                     resource spec (rf.resources.state/params-present? payload) where)
+        scoped-key (rf.resources.state/scoped-resource-key* scope resource cparams)
         ;; EP-0021 / rf2-bi8vg1 — `:rf.resource/load-more` is OWNERLESS by
         ;; contract: the feed's liveness is the ROUTE owner's (the route that
         ;; ensured page 0), and a load-more is a user-caused page extension
@@ -898,17 +898,17 @@
         ;; user's data keeps loading. Bright-line rule (1a — reject ANY owner,
         ;; not a conflict predicate): a load-more NEVER takes an owner.
         owner      nil
-        entry      (get-in runtime-db (state/entry-path scoped-key))
+        entry      (get-in runtime-db (rf.resources.state/entry-path scoped-key))
         prior-work (:current-work entry)
         ;; a page fetch (or any fetch) is genuinely in flight when the linked
         ;; work record is LIVE (`:queued` / `:running`) — the same `joinable?`
         ;; liveness the `ensure` dedupe uses (rf2-v4ygg5). A doomed
         ;; (`:abort-requested`) / terminal pointer is NOT in flight.
-        in-flight? (work-ledger/live-work? runtime-db prior-work)
+        in-flight? (rf.resources.work-ledger/live-work? runtime-db prior-work)
         pages      (:data entry)
-        next-param (state/next-param-for (:next-page-param spec) pages)
-        terminal?  (state/terminal? next-param)
-        page-index (state/page-count entry)]
+        next-param (rf.resources.state/next-param-for (:next-page-param spec) pages)
+        terminal?  (rf.resources.state/terminal? next-param)
+        page-index (rf.resources.state/page-count entry)]
     ;; rf2-bi8vg1 — surface the dropped owner ONCE, at the point of the mistake,
     ;; for EVERY branch (issue / skip / dedupe / no-feed): the owner is ignored
     ;; the same way regardless of whether this load-more fetches a page or
@@ -917,7 +917,7 @@
     ;; `:owner-index`, or any in-flight work record on any path. Per Conventions
     ;; §No silent swallow (`:rf.warning/*` when the cascade continues safely).
     (when (some? supplied-owner)
-      (trace/emit! :warning :rf.warning/resource-load-more-owner-ignored
+      (rf.trace/emit! :warning :rf.warning/resource-load-more-owner-ignored
                    {:rf.frame/id  frame-id
                     :resource     resource
                     :resource/key scoped-key
@@ -940,9 +940,9 @@
       ;; no accumulated tail has no param to derive (`next-param-for` returns
       ;; nil on an empty/absent page vector, so this also covers a not-yet-
       ;; loaded feed). Fail-quiet (a trace), never a spurious request.
-      (or (nil? entry) (not (state/infinite-entry? entry)) (empty? pages))
+      (or (nil? entry) (not (rf.resources.state/infinite-entry? entry)) (empty? pages))
       (do
-        (trace/emit! :rf.event :rf.resource/load-more-skipped
+        (rf.trace/emit! :rf.event :rf.resource/load-more-skipped
                      {:rf.frame/id frame-id :resource/key scoped-key
                       :reason :no-feed :owner owner :cause cause})
         {:rf.db/runtime runtime-db})
@@ -950,7 +950,7 @@
       ;; ----- terminal: no more pages — no-op (R2) -------------------------
       terminal?
       (do
-        (trace/emit! :rf.event :rf.resource/load-more-skipped
+        (rf.trace/emit! :rf.event :rf.resource/load-more-skipped
                      {:rf.frame/id frame-id :resource/key scoped-key
                       :reason :no-next-page :page-count page-index
                       :owner owner :cause cause})
@@ -962,9 +962,9 @@
       ;; cause are folded onto the live work record so the in-flight page is
       ;; attributed to the new caller too.
       in-flight?
-      (let [rdb' (work-ledger/update-record
-                   runtime-db prior-work work-ledger/join-owner+cause owner cause)]
-        (trace/emit! :rf.event :rf.resource/load-more-skipped
+      (let [rdb' (rf.resources.work-ledger/update-record
+                   runtime-db prior-work rf.resources.work-ledger/join-owner+cause owner cause)]
+        (rf.trace/emit! :rf.event :rf.resource/load-more-skipped
                      {:rf.frame/id frame-id :resource/key scoped-key
                       :reason :in-flight :work/id prior-work
                       :page-count page-index :owner owner :cause cause})
@@ -973,21 +973,21 @@
       ;; ----- issue the next page fetch (fresh generation, APPEND) ---------
       :else
       (let [generation (:generation gen-allocation)
-            work-id    (work-ledger/resource-work-id scoped-key generation)
-            request-id (work-ledger/managed-request-id frame-id work-id)
+            work-id    (rf.resources.work-ledger/resource-work-id scoped-key generation)
+            request-id (rf.resources.work-ledger/managed-request-id frame-id work-id)
             started-at time-ms
             deadline   (when-let [ms (:timeout-ms spec)] (+ started-at ms))
-            transport-id (or (:transport spec) transport/default-transport)
+            transport-id (or (:transport spec) rf.resources.transport/default-transport)
             ;; transition the FEED to its in-flight status. The feed has data,
             ;; so `entry-start-load` chooses `:fetching` (the refresh-class
             ;; transition — pages stay visible, no skeleton); it bumps the
             ;; generation/attempt, records `:current-work` + `:request-id`, and
             ;; attaches the owner. The page vector is UNTOUCHED (a load-more
             ;; never collapses the feed). Per Spec 016 §Causal event — load-more.
-            entry'     (state/entry-start-load
+            entry'     (rf.resources.state/entry-start-load
                          entry {:generation generation :work-id work-id
                                 :request-id request-id :owner owner})
-            record     (work-ledger/work-record
+            record     (rf.resources.work-ledger/work-record
                          {:work-id      work-id
                           :frame-id     frame-id
                           :resource/key scoped-key
@@ -1008,18 +1008,18 @@
             owner-newly-attached? (and (some? owner)
                                        (not (contains? (:active-owners entry) owner)))
             rdb'       (-> runtime-db
-                           (assoc-in (state/entry-path scoped-key) entry')
-                           (work-ledger/put-record work-id record)
+                           (assoc-in (rf.resources.state/entry-path scoped-key) entry')
+                           (rf.resources.work-ledger/put-record work-id record)
                            (cond->
-                             owner (update-in (state/owner-index-path)
-                                              update owner (fnil conj #{}) (state/key-id scoped-key))))
+                             owner (update-in (rf.resources.state/owner-index-path)
+                                              update owner (fnil conj #{}) (rf.resources.state/key-id scoped-key))))
             ;; R8 — the reserved page ctx for THIS (next) page: the derived
             ;; param at index `page-count` (an append).
             req-ctx    (page-request-ctx next-param page-index)
             http-args  (let [req-fn (:request spec)]
                          (req-fn cparams req-ctx))
-            lower-fx   (do (transport/assert-managed-transport! transport-id where)
-                           (transport-http/lower
+            lower-fx   (do (rf.resources.transport/assert-managed-transport! transport-id where)
+                           (rf.resources.transport.http/lower
                              {:http-args    http-args
                               :request-id   request-id
                               :work-id      work-id
@@ -1036,21 +1036,21 @@
                               :reply-payload (infinite-page-reply-payload
                                                scoped-key scope generation
                                                work-id next-param page-index)}))]
-        (trace/emit! :rf.event :rf.resource/load-more
+        (rf.trace/emit! :rf.event :rf.resource/load-more
                      {:rf.frame/id frame-id :resource/key scoped-key
                       :generation generation :work/id work-id
                       :page-param next-param :page-index page-index
                       :page-count page-index :owner owner :cause cause})
-        (trace/emit! :rf.event :rf.resource/work-started
+        (rf.trace/emit! :rf.event :rf.resource/work-started
                      {:rf.frame/id frame-id :resource/key scoped-key
                       :generation generation :work/id work-id
                       :status :running :owner owner :cause cause})
-        (trace/emit! :rf.event :rf.resource/fetch-started
+        (rf.trace/emit! :rf.event :rf.resource/fetch-started
                      {:rf.frame/id frame-id :resource/key scoped-key
                       :generation generation :work/id work-id
                       :status (:status entry') :owner owner :cause cause})
         (when owner-newly-attached?
-          (trace/emit! :rf.event :rf.resource/owner-attached
+          (rf.trace/emit! :rf.event :rf.resource/owner-attached
                        {:rf.frame/id frame-id :resource/key scoped-key
                         :generation generation :owner owner :cause cause
                         :work/id work-id :joined-in-flight? false}))
@@ -1115,18 +1115,18 @@
    {:keys [resource owner cause] page-param :rf.resource/page-param
     page-index :rf.resource/page-index :as payload} {:keys [where]}]
   (let [runtime-db (or rt {})
-        spec       (registry/require-resource-spec! resource where)
-        scope      (registry/resolve-scope-for-event
+        spec       (rf.resources.registry/require-resource-spec! resource where)
+        scope      (rf.resources.registry/resolve-scope-for-event
                      resource spec {:payload-scope (:scope payload) :db app-db} where)
-        cparams    (registry/validate+canonicalize-params
-                     resource spec (state/params-present? payload) where)
-        scoped-key (state/scoped-resource-key* scope resource cparams)
-        entry      (get-in runtime-db (state/entry-path scoped-key))]
+        cparams    (rf.resources.registry/validate+canonicalize-params
+                     resource spec (rf.resources.state/params-present? payload) where)
+        scoped-key (rf.resources.state/scoped-resource-key* scope resource cparams)
+        entry      (get-in runtime-db (rf.resources.state/entry-path scoped-key))]
     (cond
       ;; ----- the feed vanished / is no longer infinite — no-op -------------
-      (or (nil? entry) (not (state/infinite-entry? entry)))
+      (or (nil? entry) (not (rf.resources.state/infinite-entry? entry)))
       (do
-        (trace/emit! :rf.event :rf.resource/load-more-skipped
+        (rf.trace/emit! :rf.event :rf.resource/load-more-skipped
                      {:rf.frame/id frame-id :resource/key scoped-key
                       :reason :no-feed :owner owner :cause cause})
         {:rf.db/runtime runtime-db})
@@ -1134,29 +1134,29 @@
       ;; ----- the page index is past the (current) accumulation — no-op -----
       ;; A sweep leg only refreshes a page the feed still has; a feed that
       ;; shrank under the sweep (a clear / re-load) drops the stale leg.
-      (>= page-index (state/page-count entry))
+      (>= page-index (rf.resources.state/page-count entry))
       (do
-        (trace/emit! :rf.event :rf.resource/load-more-skipped
+        (rf.trace/emit! :rf.event :rf.resource/load-more-skipped
                      {:rf.frame/id frame-id :resource/key scoped-key
-                      :reason :no-next-page :page-count (state/page-count entry)
+                      :reason :no-next-page :page-count (rf.resources.state/page-count entry)
                       :owner owner :cause cause})
         {:rf.db/runtime runtime-db})
 
       ;; ----- issue the replacement fetch for THIS page (fresh generation) --
       :else
       (let [generation (:generation gen-allocation)
-            work-id    (work-ledger/resource-work-id scoped-key generation)
-            request-id (work-ledger/managed-request-id frame-id work-id)
+            work-id    (rf.resources.work-ledger/resource-work-id scoped-key generation)
+            request-id (rf.resources.work-ledger/managed-request-id frame-id work-id)
             started-at time-ms
             deadline   (when-let [ms (:timeout-ms spec)] (+ started-at ms))
-            transport-id (or (:transport spec) transport/default-transport)
+            transport-id (or (:transport spec) rf.resources.transport/default-transport)
             ;; the feed has data, so `entry-start-load` chooses `:fetching`
             ;; (refresh-class — pages stay visible). The page vector is
             ;; UNTOUCHED (a sweep leg replaces in place on its reply).
-            entry'     (state/entry-start-load
+            entry'     (rf.resources.state/entry-start-load
                          entry {:generation generation :work-id work-id
                                 :request-id request-id :owner owner})
-            record     (work-ledger/work-record
+            record     (rf.resources.work-ledger/work-record
                          {:work-id      work-id
                           :frame-id     frame-id
                           :resource/key scoped-key
@@ -1170,16 +1170,16 @@
                           ;; replacement, not a load-more append).
                           :page-index   page-index})
             rdb'       (-> runtime-db
-                           (assoc-in (state/entry-path scoped-key) entry')
-                           (work-ledger/put-record work-id record)
+                           (assoc-in (rf.resources.state/entry-path scoped-key) entry')
+                           (rf.resources.work-ledger/put-record work-id record)
                            (cond->
-                             owner (update-in (state/owner-index-path)
-                                              update owner (fnil conj #{}) (state/key-id scoped-key))))
+                             owner (update-in (rf.resources.state/owner-index-path)
+                                              update owner (fnil conj #{}) (rf.resources.state/key-id scoped-key))))
             req-ctx    (page-request-ctx page-param page-index)
             http-args  (let [req-fn (:request spec)]
                          (req-fn cparams req-ctx))
-            lower-fx   (do (transport/assert-managed-transport! transport-id where)
-                           (transport-http/lower
+            lower-fx   (do (rf.resources.transport/assert-managed-transport! transport-id where)
+                           (rf.resources.transport.http/lower
                              {:http-args    http-args
                               :request-id   request-id
                               :work-id      work-id
@@ -1193,11 +1193,11 @@
                               :reply-payload (infinite-page-reply-payload
                                                scoped-key scope generation
                                                work-id page-param page-index)}))]
-        (trace/emit! :rf.event :rf.resource/work-started
+        (rf.trace/emit! :rf.event :rf.resource/work-started
                      {:rf.frame/id frame-id :resource/key scoped-key
                       :generation generation :work/id work-id
                       :status :running :owner owner :cause cause})
-        (trace/emit! :rf.event :rf.resource/fetch-started
+        (rf.trace/emit! :rf.event :rf.resource/fetch-started
                      {:rf.frame/id frame-id :resource/key scoped-key
                       :generation generation :work/id work-id
                       :status (:status entry') :owner owner :cause cause})
@@ -1232,7 +1232,7 @@
 ;;   - ACTIVE OWNERS decide WHICH entries are worth refetching — only an entry
 ;;     with a live owner (`:active-owners` non-empty) is scanned (an inactive
 ;;     entry is GC fodder, not a revalidation target);
-;;   - DURABLE stale/fresh timestamps decide WHETHER — `state/entry-stale?`
+;;   - DURABLE stale/fresh timestamps decide WHETHER — `rf.resources.state/entry-stale?`
 ;;     (the single shared freshness derivation the subs / SSR / stale-timer
 ;;     re-check all use) against the focus/reconnect token's causal declared-flat
 ;;     `:rf/time-ms` (rf2-95b0lc / rf2-601ife — not an ambient host-clock read at
@@ -1280,7 +1280,7 @@
 (defn- entry-revalidation-in-flight?
   "True iff `entry` already has a LIVE refetch in flight — work that will
   produce a usable reply. Such an entry needs no new revalidation refetch: one
-  is already running. Liveness is `work-ledger/live-work?`, the ONE definition
+  is already running. Liveness is `rf.resources.work-ledger/live-work?`, the ONE definition
   of that question (rf2-kqxe6.6) — a `:current-work` POINTER alone is not proof
   of work, since the linked record may be terminal (a settled attempt whose
   entry write has not yet cleared the pointer) or `:abort-requested` (a doomed,
@@ -1290,13 +1290,13 @@
   generation. Per Spec 016 §Race / §Deferred slices (rf2-wankrd: coalesce focus
   + visibility revalidation for in-flight stale entries)."
   [runtime-db entry]
-  (work-ledger/live-work? runtime-db (:current-work entry)))
+  (rf.resources.work-ledger/live-work? runtime-db (:current-work entry)))
 
 (defn- active-stale-scan
   "Pure scan: given the frame's `runtime-db` value and the live `clock-ms`,
   return the vector of `{:resource/key :scope :resource :params}` for every
   cache entry that is active (has at least one `:active-owner` — a live owner
-  worth refetching), stale-by-policy (`state/entry-stale?` against the
+  worth refetching), stale-by-policy (`rf.resources.state/entry-stale?` against the
   durable timestamps), AND not already mid-revalidation (no LIVE in-flight
   refetch — `entry-revalidation-in-flight?`). Fresh entries, owner-free
   entries, and entries with a live refetch already running are excluded.
@@ -1315,11 +1315,11 @@
   selection — it never mutates; the caller turns the selection into
   background `:rf.resource/refetch` dispatches."
   [runtime-db clock-ms]
-  (let [entries (get-in runtime-db (state/entries-path))]
+  (let [entries (get-in runtime-db (rf.resources.state/entries-path))]
     (into []
           (keep (fn [[_k-id entry]]
                   (when (and (seq (:active-owners entry))
-                             (state/entry-stale? entry clock-ms)
+                             (rf.resources.state/entry-stale? entry clock-ms)
                              (not (entry-revalidation-in-flight? runtime-db entry)))
                     ;; rf2-9e0tyq — read the scoped-key VECTOR from the entry's
                     ;; `:resource/key` (the map key is now the opaque byte id).
@@ -1369,9 +1369,9 @@
     ;; ONE scan summary (a tab-return / reconnect can touch many entries — keep
     ;; the trace readable). The per-entry refetch decisions ride the ordinary
     ;; `:rf.resource/work-started` / `fetch-started` traces each refetch emits.
-    (trace/emit! :rf.event :rf.resource/revalidate-scan
+    (rf.trace/emit! :rf.event :rf.resource/revalidate-scan
                  {:rf.frame/id frame-id :signal signal :cause cause
-                  :scanned    (count (get-in runtime-db (state/entries-path)))
+                  :scanned    (count (get-in runtime-db (rf.resources.state/entries-path)))
                   :refetched  (count eligible)
                   :keys       (mapv :resource/key eligible)})
     {:fx refetches}))
@@ -1459,12 +1459,12 @@
   [{rt :rf.db/runtime, frame-id :rf.frame/id}
    [_event-id {resource-key :resource/key :keys [hidden?]}]]
   (let [runtime-db (or rt {})
-        entry      (get-in runtime-db (state/entry-path resource-key))
+        entry      (get-in runtime-db (rf.resources.state/entry-path resource-key))
         owned?     (seq (:active-owners entry))
         in-flight? (and entry (entry-revalidation-in-flight? runtime-db entry))
         ;; the resource's declared interval — the re-arm delay (cancel-then-arm)
-        interval   (state/positive-or-nil
-                     (:poll-interval-ms (registry/resource-meta (:resource/id entry))))
+        interval   (rf.resources.state/positive-or-nil
+                     (:poll-interval-ms (rf.resources.registry/resource-meta (:resource/id entry))))
         decision   (cond
                      (nil? entry)     :no-entry
                      (not owned?)     :no-owner
@@ -1479,7 +1479,7 @@
         ;; rather than cancelling them (rf2-3fc89f.10).
         re-arm?    (and interval (contains? #{:paused-hidden :coalesced :polled} decision))
         refetch?   (= :polled decision)]
-    (trace/emit! :rf.event :rf.resource/poll-fired
+    (rf.trace/emit! :rf.event :rf.resource/poll-fired
                  {:rf.frame/id frame-id :resource/key resource-key
                   :decision decision :rearmed? (boolean re-arm?)})
     (cond-> {:rf.db/runtime runtime-db}
@@ -1500,7 +1500,7 @@
                  {:frame-id     frame-id
                   :resource/key resource-key
                   :timers       {:poll interval}
-                  :server?      (state/server-frame? frame-id)}]))))))
+                  :server?      (rf.resources.state/server-frame? frame-id)}]))))))
 
 ;; ---- invalidate-tags — exact tag invalidation -----------------------------
 
@@ -1562,7 +1562,7 @@
   references): a CONCRETE scope value OR a `{:from-db <resolver-id>}`
   named-resolver reference, resolved against this handler's app-db coeffect at
   event-execution time — SYMMETRIC with `ensure` / `clear-scope`
-  (`scope-registry/resolve-scope-input`). A reference that resolves NIL is
+  (`rf.resources.scope-registry/resolve-scope-input`). A reference that resolves NIL is
   FAIL-CLOSED with `:rf.error/resource-scope-unresolved-reference` (invalidate
   is scope-requiring like ensure — NOT clear-scope's warn/no-op); an
   unregistered resolver id throws `:rf.error/resource-scope-not-registered`
@@ -1605,7 +1605,7 @@
   a silent `(= nil entry-scope)` match that quietly invalidates nothing (or,
   worse, only the entries that happen to live in a nil scope). Cross-scope is
   the ONLY scope-agnostic path; it must be requested explicitly. The concrete
-  `:scope` is routed through the shared `state/canonicalize-scope` validation
+  `:scope` is routed through the shared `rf.resources.state/canonicalize-scope` validation
   path (rf2-hosnba) so a reserved-namespace typo (`:rf.scope/glabal`) or a
   host / non-EDN scope value fails closed through the SAME single path every
   other scope-bearing operation uses.
@@ -1637,7 +1637,7 @@
         ;; {:from-db …} scope only to discard it). Per Spec 016 §The cross-scope
         ;; lattice.
         _          (when (and cross-scope? (some? scope))
-                     (error/throw-error!
+                     (rf.error/throw-error!
                        :rf.error/resource-cross-scope-scope-conflict
                        'rf.resource/invalidate-tags
                        (str "a :cross-scope? true :rf.resource/invalidate-tags "
@@ -1656,7 +1656,7 @@
         ;; set). Cross-scope is the only scope-agnostic path and must be
         ;; opted into explicitly. Per Spec 016 §Invalidation.
         _          (when (and (not cross-scope?) (nil? scope))
-                     (error/throw-error!
+                     (rf.error/throw-error!
                        :rf.error/resource-invalidate-scope-required
                        'rf.resource/invalidate-tags
                        (str "a scoped :rf.resource/invalidate-tags MUST "
@@ -1677,7 +1677,7 @@
         ;; unaudited sweep. (The mutation engine always stamps
         ;; :cause [:mutation id instance]; this guards the direct public entry.)
         _          (when (and cross-scope? (nil? cause))
-                     (error/throw-error!
+                     (rf.error/throw-error!
                        :rf.error/resource-cross-scope-cause-required
                        'rf.resource/invalidate-tags
                        (str "a :cross-scope? true :rf.resource/invalidate-tags "
@@ -1698,7 +1698,7 @@
         ;; app-db coeffect at event-execution time, EXACTLY like ensure /
         ;; clear-scope (Spec 016 §Resolver references — the single use-time
         ;; rule). `resolve-scope-input` routes a concrete scope through the
-        ;; SHARED `state/canonicalize-scope` validation path ONCE (rejects
+        ;; SHARED `rf.resources.state/canonicalize-scope` validation path ONCE (rejects
         ;; reserved-namespace typos + host / non-EDN values + the wrapped
         ;; [:rf.scope/global] singleton — rf2-hosnba, rf2-lzv9xc, rf2-bwwk6l)
         ;; and resolves a reference (result already canonical; it also emits the
@@ -1706,9 +1706,9 @@
         ;; id throws :rf.error/resource-scope-not-registered here, before any
         ;; mutation. No resource-id (a tag invalidation spans resources); nil
         ;; when scope-agnostic cross-scope OR a reference resolved nil.
-        from-db?   (scope-registry/from-db-reference? scope)
+        from-db?   (rf.resources.scope-registry/from-db-reference? scope)
         cscope     (when (some? scope)
-                     (scope-registry/resolve-scope-input
+                     (rf.resources.scope-registry/resolve-scope-input
                        scope app-db 'rf.resource/invalidate-tags nil))
         ;; nil-resolution at a scope-REQUIRING site is FAIL-CLOSED like ensure
         ;; (NOT clear-scope's warn/no-op — invalidate is scope-requiring, so it
@@ -1719,7 +1719,7 @@
         ;; global / fall through / silently no-op. Per Spec 016 §Resolver
         ;; references.
         _          (when (and from-db? (nil? cscope))
-                     (error/throw-error!
+                     (rf.error/throw-error!
                        :rf.error/resource-scope-unresolved-reference
                        'rf.resource/invalidate-tags
                        (str "a :rf.resource/invalidate-tags {:from-db …} :scope "
@@ -1740,7 +1740,7 @@
         ;; slug]}`, not the scalar set `#{:article slug}` (which would silently
         ;; match nothing). A tag-set (`#{[:article slug]}` / `[[:article slug]]`)
         ;; lowers unchanged.
-        tag-set    (state/normalize-tag-set tags)
+        tag-set    (rf.resources.state/normalize-tag-set tags)
         ;; EP-0010 §Resources, Mutations, And Work-Ledger Timestamps: the
         ;; durable `:invalidated-at` written by an invalidation event is that
         ;; EVENT'S `:time-ms` (the causal world input the router stamped once
@@ -1748,7 +1748,7 @@
         ;; reducer. Replay-stable: re-running the same invalidation token
         ;; rewrites the SAME `:invalidated-at`.
         invalidated-at time-ms
-        entries    (get-in runtime-db (state/entries-path))
+        entries    (get-in runtime-db (rf.resources.state/entries-path))
         ;; EP-0016 Rider 1 — keys this same mutation just POPULATED
         ;; authoritatively are EXEMPT from this pass (kept fresh, never
         ;; re-staled / refetched). The set is canonicalized at the producer
@@ -1762,7 +1762,7 @@
         ;; is keyed on the byte `key-id` (so `assoc-in (entry-path …)` and the
         ;; trace's `:resource/key` use the right form: byte for the db write,
         ;; vector for the trace/refetch).
-        exempt     (into #{} (map state/key-id) exempt-keys)
+        exempt     (into #{} (map rf.resources.state/key-id) exempt-keys)
         ;; the SHARED pure match (rf2-fi6tda.2): exactly the set the
         ;; mutation-settlement reply pre-computes for `:affected-keys`. Keyed
         ;; on the byte key-id; `:matched` are scoped-key VECTORS.
@@ -1774,15 +1774,15 @@
         ;; on the byte key-id — write straight to the entries-path slot.
         ;; EP-0019 / byl7bk: marking an entry stale is an authoritative durable
         ;; write a later optimistic rollback could clobber (it moves the entry's
-        ;; freshness), so `state/entry-invalidate` bumps the per-entry :revision
+        ;; freshness), so `rf.resources.state/entry-invalidate` bumps the per-entry :revision
         ;; write identity in the SAME swap — biasing to over-bump (a false
         ;; conflict costs one refetch; a missed one is silent corruption). The
         ;; SHARED durable stale mark the EP-0019 restore-dangle conflict-rollback
         ;; also uses (one home, identical `:stale?` derivation).
         rdb'       (reduce
                      (fn [db k-id]
-                       (update-in db (state/entry-path-by-id k-id)
-                                  state/entry-invalidate invalidated-at))
+                       (update-in db (rf.resources.state/entry-path-by-id k-id)
+                                  rf.resources.state/entry-invalidate invalidated-at))
                      runtime-db matched-ids)
         ;; per-entry decision: active-owner entries refetch (Spec 016
         ;; §Invalidation 3); ownerless entries are left stale / GC-eligible
@@ -1806,7 +1806,7 @@
                                                  :cause [:invalidate {:tags tags}]}]]))))
                          decisions)]
     ;; ONE decision summary (broad-tag storms stay readable) ...
-    (trace/emit! :rf.event :rf.resource/invalidated
+    (rf.trace/emit! :rf.event :rf.resource/invalidated
                  {:rf.frame/id frame-id :scope cscope :tags tags :cause cause
                   :cross-scope? (boolean cross-scope?)
                   :matched (mapv :resource/key decisions)
@@ -1822,7 +1822,7 @@
     ;; decision per matched key — Spec 016 §Invalidation 5 / the Xray
     ;; invalidation graph)
     (doseq [{:keys [active? decision tags] resource-key :resource/key :as _d} decisions]
-      (trace/emit! :rf.event :rf.resource/refetch-decision
+      (rf.trace/emit! :rf.event :rf.resource/refetch-decision
                    {:rf.frame/id frame-id :resource/key resource-key
                     :scope (first resource-key) :active? active?
                     :decision decision :tags tags :cause cause}))
@@ -1834,7 +1834,7 @@
 (defn- release-owner-from-identities
   "The per-identity CORE of an owner release, over an EXPLICIT set of byte
   `key-id`s (rf2-y8jjk): drop `owner` from each named entry's `:active-owners`
-  (via `state/detach-owner`, which bumps the entry's `:revision` when the owner
+  (via `rf.resources.state/detach-owner`, which bumps the entry's `:revision` when the owner
   was actually present — rf2-cxwuhl) and from the owner-index (the owner's
   index row is dropped outright once it holds nothing); drop the owner from
   each named entry's in-flight work record, marking `:abort-requested` and
@@ -1862,12 +1862,12 @@
         ;; that nil back would mint an empty entry slot.
         rdb1  (-> (reduce
                     (fn [db k-id]
-                      (let [path (state/entry-path-by-id k-id)]
+                      (let [path (rf.resources.state/entry-path-by-id k-id)]
                         (if-let [e (get-in db path)]
-                          (assoc-in db path (state/detach-owner e owner))
+                          (assoc-in db path (rf.resources.state/detach-owner e owner))
                           db)))
                     runtime-db k-ids)
-                  (update-in (state/owner-index-path)
+                  (update-in (rf.resources.state/owner-index-path)
                              (fn [index]
                                (let [remaining (reduce disj (get index owner #{}) k-ids)]
                                  (if (empty? remaining)
@@ -1880,14 +1880,14 @@
         (reduce
           (fn [acc k-id]
             (let [db   (:rdb acc)
-                  e    (get-in db (state/entry-path-by-id k-id))
+                  e    (get-in db (rf.resources.state/entry-path-by-id k-id))
                   wid  (:current-work e)
-                  rec  (when wid (work-ledger/get-record db wid))]
+                  rec  (when wid (rf.resources.work-ledger/get-record db wid))]
               (if (and wid rec)
-                (let [rec' (work-ledger/release-owner-from-record rec owner)
+                (let [rec' (rf.resources.work-ledger/release-owner-from-record rec owner)
                       orphaned? (empty? (:owners rec'))
-                      rec'' (if orphaned? (work-ledger/mark-abort-requested rec') rec')]
-                  {:rdb (work-ledger/put-record db wid rec'')
+                      rec'' (if orphaned? (rf.resources.work-ledger/mark-abort-requested rec') rec')]
+                  {:rdb (rf.resources.work-ledger/put-record db wid rec'')
                    :aborts (cond-> (:aborts acc)
                              orphaned? (conj [wid (:transport rec'')]))})
                 acc)))
@@ -1902,7 +1902,7 @@
         now-owner-free
         (into []
               (keep (fn [k-id]
-                      (let [e (get-in rdb2 (state/entry-path-by-id k-id))]
+                      (let [e (get-in rdb2 (rf.resources.state/entry-path-by-id k-id))]
                         (when (and e (empty? (:active-owners e)))
                           (:resource/key e)))))
               k-ids)
@@ -1923,16 +1923,16 @@
         released
         (into []
               (keep (fn [k-id]
-                      (:resource/key (get-in runtime-db (state/entry-path-by-id k-id)))))
+                      (:resource/key (get-in runtime-db (rf.resources.state/entry-path-by-id k-id)))))
               k-ids)]
-    (trace/emit! :rf.event :rf.resource/owner-released
+    (rf.trace/emit! :rf.event :rf.resource/owner-released
                  {:rf.frame/id frame-id :owner owner :released released
                   :aborted (mapv first aborts)})
     {:rf.db/runtime rdb2
      ;; rf2-sxyrzk — abort by the frame-QUALIFIED request-id (the registered
      ;; token); a bare work-id would miss the orphaned in-flight request.
      :fx (cond-> (into [] (keep (fn [[wid transport]]
-                                  (work-ledger/abort-fx transport frame-id wid)))
+                                  (rf.resources.work-ledger/abort-fx transport frame-id wid)))
                        aborts)
            (seq now-owner-free)
            (conj [:rf.resource/cancel-poll-timers
@@ -1956,7 +1956,7 @@
   adds the route-owner slot clears."
   [{rt :rf.db/runtime, frame-id :rf.frame/id} [_event-id {:keys [owner]}]]
   (let [runtime-db (or rt {})
-        owned      (get-in runtime-db (conj (state/owner-index-path) owner))
+        owned      (get-in runtime-db (conj (rf.resources.state/owner-index-path) owner))
         ;; rf2-l2gofj: releasing a ROUTE owner ([:route route-id nav-token])
         ;; happens on every route leave / supersession (route-resource-plan
         ;; dispatches it) — and on a committed FAILED replan of the token that
@@ -1971,8 +1971,8 @@
                      ;; with the blocking slot — a superseded plan's identity
                      ;; set must not accumulate once its owner is gone.
                      (-> runtime-db
-                         (route/clear-blocking-slot (nth owner 2))
-                         (route/clear-plan-slot (nth owner 2)))
+                         (rf.resources.route/clear-blocking-slot (nth owner 2))
+                         (rf.resources.route/clear-plan-slot (nth owner 2)))
                      runtime-db)]
     (release-owner-from-identities rdb0 frame-id owner (or owned #{}))))
 
@@ -2000,7 +2000,7 @@
   the owner does not currently hold (not an owner-index member) is a no-op."
   [{rt :rf.db/runtime, frame-id :rf.frame/id} [_event-id {:keys [owner identities]}]]
   (let [runtime-db (or rt {})
-        owned      (get-in runtime-db (conj (state/owner-index-path) owner))
+        owned      (get-in runtime-db (conj (rf.resources.state/owner-index-path) owner))
         k-ids      (into #{} (filter (or owned #{})) (keys identities))]
     (release-owner-from-identities runtime-db frame-id owner k-ids)))
 
@@ -2019,7 +2019,7 @@
   join the owner to any in-flight `:current-work` record, so the prior owner's
   later release does NOT orphan-and-abort work the next plan still needs (the
   no-abort-shared-work law); (3) reconcile route readiness from the entry's
-  ACTUAL state through the ONE projector (`route/reconcile-readiness`) — the
+  ACTUAL state through the ONE projector (`rf.resources.route/reconcile-readiness`) — the
   adopt path has NO private has-data/error/else readiness branch. A kept
   blocking identity that already has usable data resolves NOW (no reply will
   ever land to resolve it), a failed first load projects route `:error`, one
@@ -2031,7 +2031,7 @@
   request.
 
   rf2-kqxe6.6 — the planner only ever adopts a GENUINELY REUSABLE identity
-  (`route/adoptable?`: own usable data, or genuinely live work). A retained
+  (`rf.resources.route/adoptable?`: own usable data, or genuinely live work). A retained
   identity that has been cleared / removed / GC'd, or that cannot progress,
   takes the ordinary `ensure` path instead, because this event issues no
   request and so could never drain the blocking slot the same commit wrote. A
@@ -2045,25 +2045,25 @@
   [{rt :rf.db/runtime, frame-id :rf.frame/id}
    [_event-id {:keys [resource scope params owner cause]}]]
   (let [runtime-db (or rt {})
-        scoped-key (state/scoped-resource-key* scope resource params)
-        entry      (get-in runtime-db (state/entry-path scoped-key))]
+        scoped-key (rf.resources.state/scoped-resource-key* scope resource params)
+        entry      (get-in runtime-db (rf.resources.state/entry-path scoped-key))]
     (if (nil? entry)
       {:rf.db/runtime runtime-db}
       (let [newly? (and (some? owner)
                         (not (contains? (:active-owners entry) owner)))
-            hit    (state/attach-owner entry owner)
+            hit    (rf.resources.state/attach-owner entry owner)
             wid    (:current-work hit)
             rdb0   (-> runtime-db
-                       (assoc-in (state/entry-path scoped-key) hit)
+                       (assoc-in (rf.resources.state/entry-path scoped-key) hit)
                        (cond->
-                         owner (update-in (state/owner-index-path)
-                                          update owner (fnil conj #{}) (state/key-id scoped-key)))
+                         owner (update-in (rf.resources.state/owner-index-path)
+                                          update owner (fnil conj #{}) (rf.resources.state/key-id scoped-key)))
                        (cond->
-                         (and owner wid) (work-ledger/update-record
-                                           wid work-ledger/join-owner+cause owner cause)))
-            rdb    (route/reconcile-readiness rdb0)]
+                         (and owner wid) (rf.resources.work-ledger/update-record
+                                           wid rf.resources.work-ledger/join-owner+cause owner cause)))
+            rdb    (rf.resources.route/reconcile-readiness rdb0)]
         (when newly?
-          (trace/emit! :rf.event :rf.resource/owner-attached
+          (rf.trace/emit! :rf.event :rf.resource/owner-attached
                        {:rf.frame/id frame-id :resource/key scoped-key
                         :owner owner :adopted? true}))
         {:rf.db/runtime rdb}))))
@@ -2073,7 +2073,7 @@
 (defn- clear-scope-handler*
   "The clear-scope body once `cscope` is the resolved CANONICAL concrete scope
   (a literal scope canonicalized, or a `{:from-db …}` reference resolved against
-  app-db — both flow through `scope-registry/resolve-scope-input` at the caller,
+  app-db — both flow through `rf.resources.scope-registry/resolve-scope-input` at the caller,
   rf2-oo8cv7, so the concrete-scope validation happens ONCE). Removes the
   in-scope entries, settles their in-flight work rows `:cancelled`, recomputes
   indexes, and emits the explaining trace + fx.
@@ -2084,7 +2084,7 @@
   (rf2-rl27r2), so epoch / tooling correlation of a logout / tenant-switch
   cancellation is intact."
   [runtime-db frame-id cscope cause time-ms]
-  (let [entries    (get-in runtime-db (state/entries-path))
+  (let [entries    (get-in runtime-db (rf.resources.state/entries-path))
         ;; rf2-9e0tyq — `entries` is keyed on the byte `key-id`; the scope to
         ;; match against lives in each entry's `:resource/key` vector
         ;; (`(first (:resource/key entry))`), not the map key. `in-scope` is
@@ -2103,27 +2103,27 @@
                                  (let [e (get entries k-id)
                                        wid (:current-work e)]
                                    (when wid
-                                     [wid (:transport (work-ledger/get-record runtime-db wid))]))))
+                                     [wid (:transport (rf.resources.work-ledger/get-record runtime-db wid))]))))
                          in-scope-ids)
         ;; remove the entries, settle their in-flight work rows :cancelled,
         ;; then reconcile the indexes for the removed keys. rf2-2c2mkh — only
         ;; the in-scope keys' index members change, so reconcile that bounded
         ;; set incrementally rather than full-rebuilding from all entries.
         rdb'       (-> runtime-db
-                       (update-in (state/entries-path)
+                       (update-in (rf.resources.state/entries-path)
                                   (fn [es] (reduce dissoc es in-scope-ids)))
                        (as-> db (reduce (fn [d [wid _]]
-                                          (work-ledger/update-record
-                                            d wid work-ledger/mark-terminal
+                                          (rf.resources.work-ledger/update-record
+                                            d wid rf.resources.work-ledger/mark-terminal
                                             ;; rf2-x76af2.14 — carry the causal
                                             ;; `:completed-at` onto the cancelled
                                             ;; work row (a cancellation completes).
                                             :cancelled {:reason :clear-scope
                                                         :completed-at time-ms}))
                                         db in-flight))
-                       (update state/resources-key state/reindex-keys
+                       (update rf.resources.state/resources-key rf.resources.state/reindex-keys
                                entries in-scope-ids))]
-    (trace/emit! :rf.event :rf.resource/removed
+    (rf.trace/emit! :rf.event :rf.resource/removed
                  {:rf.frame/id frame-id :scope cscope :cause cause
                   :removed (vec in-scope) :reason :clear-scope
                   :aborted (mapv first in-flight) :completed-at time-ms})
@@ -2135,7 +2135,7 @@
      ;; correctness boundary; the abort + timer-cancel are the optimisation.
      ;; rf2-sxyrzk — abort by the frame-QUALIFIED request-id (the registered
      ;; token); the bare work-id would miss the in-scope in-flight requests.
-     :fx (cond-> (into [] (keep (fn [[wid transport]] (work-ledger/abort-fx transport frame-id wid)))
+     :fx (cond-> (into [] (keep (fn [[wid transport]] (rf.resources.work-ledger/abort-fx transport frame-id wid)))
                        in-flight)
            (seq in-scope)
            (conj [:rf.resource/cancel-timers
@@ -2152,7 +2152,7 @@
   abort is the optimisation. Payload: `{:scope :cause}`.
 
   The concrete `:scope` is routed through the shared
-  `state/canonicalize-scope` validation path (rf2-hosnba, rf2-lzv9xc) so a
+  `rf.resources.state/canonicalize-scope` validation path (rf2-hosnba, rf2-lzv9xc) so a
   reserved-namespace typo (`:rf.scope/glabal`) or a host / non-EDN scope
   value fails closed through the SAME single path every other scope-bearing
   operation uses — a typo can never silently clear the WRONG scope (a
@@ -2168,22 +2168,22 @@
   no-op (it INTENDED to derive the tenant / user / leak-boundary scope to wipe
   and could not; clearing nothing — or matching the literal reference map,
   which keys nothing — would be the silent no-op the spec prohibits). The
-  resolved concrete scope is then routed through `state/canonicalize-scope`
+  resolved concrete scope is then routed through `rf.resources.state/canonicalize-scope`
   exactly as a literal scope is. Per Spec 016 §clear-scope is causal."
   [{rt :rf.db/runtime, frame-id :rf.frame/id, app-db :db, time-ms :rf/time-ms}
    [_event-id {:keys [scope cause]}]]
   (let [runtime-db (or rt {})
         ;; EP-0016 D3 / rf2-mfnc5i / rf2-oo8cv7: resolve the public ScopeInput
         ;; ONCE through the shared symmetric arm — a concrete scope canonicalizes
-        ;; through `state/canonicalize-scope`, a `{:from-db …}` reference resolves
+        ;; through `rf.resources.state/canonicalize-scope`, a `{:from-db …}` reference resolves
         ;; against the handler's app-db coeffect at use time (result already
         ;; canonical). nil ONLY when a reference resolved nil — the clear-scope
         ;; warn/no-op fail-closed below (the DELIBERATE destructive-teardown
         ;; exception; NOT the ensure/invalidate throw). Never canonicalized as a
         ;; literal reference map (which keys nothing → the silent no-op Spec 016
         ;; prohibits).
-        from-db?   (scope-registry/from-db-reference? scope)
-        cscope     (scope-registry/resolve-scope-input
+        from-db?   (rf.resources.scope-registry/from-db-reference? scope)
+        cscope     (rf.resources.scope-registry/resolve-scope-input
                      scope app-db 'rf.resource/clear-scope nil)]
     (if (and from-db? (nil? cscope))
       ;; FAIL-CLOSED: a {:from-db …} reference resolved nil at a clear-scope
@@ -2193,7 +2193,7 @@
       ;; permission to clear global or silently no-op. Per Spec 016 §clear-scope
       ;; is causal (EP-0016 issue-7 tripwire).
       (do
-        (trace/emit! :warning :rf.warning/resource-clear-scope-unresolved
+        (rf.trace/emit! :warning :rf.warning/resource-clear-scope-unresolved
                      {:rf.frame/id frame-id
                       :scope       scope
                       :from-db     (:from-db scope)
@@ -2227,37 +2227,37 @@
   [{rt :rf.db/runtime, frame-id :rf.frame/id, app-db :db, time-ms :rf/time-ms}
    [_event-id {:keys [resource] :as payload}]]
   (let [runtime-db (or rt {})
-        spec       (registry/require-resource-spec! resource 'rf.resource/remove)
+        spec       (rf.resources.registry/require-resource-spec! resource 'rf.resource/remove)
         ;; EP-0016 D3 slice 3: resolve a `{:from-db …}` scope against app-db.
-        scope      (registry/resolve-scope-for-event
+        scope      (rf.resources.registry/resolve-scope-for-event
                      resource spec {:payload-scope (:scope payload) :db app-db} 'rf.resource/remove)
         ;; rf2-hgy5kf — thread `:params` presence (absent vs explicit nil) to
         ;; the validation boundary so removal keys on the SAME identity an
         ;; explicit-nil-params ensure produced.
-        cparams    (registry/validate+canonicalize-params
-                     resource spec (state/params-present? payload) 'rf.resource/remove)
+        cparams    (rf.resources.registry/validate+canonicalize-params
+                     resource spec (rf.resources.state/params-present? payload) 'rf.resource/remove)
         ;; rf2-rplgkw: scope (resolve-scope-for-event → canonicalize-scope) +
         ;; cparams (validate+canonicalize-params) are ALREADY canonical.
-        scoped-key (state/scoped-resource-key* scope resource cparams)
-        entry      (get-in runtime-db (state/entry-path scoped-key))
+        scoped-key (rf.resources.state/scoped-resource-key* scope resource cparams)
+        entry      (get-in runtime-db (rf.resources.state/entry-path scoped-key))
         wid        (:current-work entry)
-        transport  (when wid (:transport (work-ledger/get-record runtime-db wid)))
+        transport  (when wid (:transport (rf.resources.work-ledger/get-record runtime-db wid)))
         ;; rf2-2c2mkh — removing ONE entry touches ONE key's index members;
         ;; reconcile incrementally rather than full-rebuilding both indexes.
-        old-entries (get-in runtime-db (state/entries-path))
+        old-entries (get-in runtime-db (rf.resources.state/entries-path))
         rdb'       (-> runtime-db
                        ;; rf2-9e0tyq — dissoc by the byte key-id (a dissoc by
                        ;; the scoped-key vector would no-op and leak the entry).
-                       (update-in (state/entries-path) dissoc (state/key-id scoped-key))
-                       (cond-> wid (work-ledger/update-record
-                                     wid work-ledger/mark-terminal
+                       (update-in (rf.resources.state/entries-path) dissoc (rf.resources.state/key-id scoped-key))
+                       (cond-> wid (rf.resources.work-ledger/update-record
+                                     wid rf.resources.work-ledger/mark-terminal
                                      ;; rf2-x76af2.14 — carry the causal
                                      ;; `:completed-at` onto the cancelled work
                                      ;; row (a cancellation completes).
                                      :cancelled {:reason :remove :completed-at time-ms}))
-                       (update state/resources-key state/reindex-keys
-                               old-entries [(state/key-id scoped-key)]))]
-    (trace/emit! :rf.event :rf.resource/removed
+                       (update rf.resources.state/resources-key rf.resources.state/reindex-keys
+                               old-entries [(rf.resources.state/key-id scoped-key)]))]
+    (rf.trace/emit! :rf.event :rf.resource/removed
                  {:rf.frame/id frame-id :resource/key scoped-key :reason :remove
                   :aborted (when wid [wid]) :completed-at time-ms})
     {:rf.db/runtime rdb'
@@ -2266,7 +2266,7 @@
      ;; its advisory stale / GC timers (the entry's durable facts are gone).
      ;; rf2-sxyrzk — abort by the frame-QUALIFIED request-id (the registered
      ;; token); a bare work-id would miss the removed instance's in-flight request.
-     :fx (conj (if-let [fx (and wid (work-ledger/abort-fx transport frame-id wid))] [fx] [])
+     :fx (conj (if-let [fx (and wid (rf.resources.work-ledger/abort-fx transport frame-id wid))] [fx] [])
                [:rf.resource/cancel-timers
                 {:frame-id frame-id :resource/keys [scoped-key]}])}))
 
@@ -2288,7 +2288,7 @@
   cache entry at the reply's `:resource/key`. Used by the shared
   `reply-handlers` verifier + current-generation reader."
   [{resource-key :resource/key}]
-  (state/entry-path resource-key))
+  (rf.resources.state/entry-path resource-key))
 
 (defn- resource-correlation
   "The resource family's stale-reply diagnostic correlation keys (beyond the
@@ -2301,33 +2301,33 @@
 
 (def ^:private resource-stale-knobs
   "The resource family's stale-suppress knobs for
-  `reply-handlers/stale-suppress-reply`: `:work-kind`, `:stale-reason`, and
+  `rf.resources.reply-handlers/stale-suppress-reply`: `:work-kind`, `:stale-reason`, and
   the `:correlation-fn`."
-  {:work-kind      rreply/work-kind-resource
+  {:work-kind      rf.resources.reply/work-kind-resource
    :stale-reason   :rf.resource/superseded
    :correlation-fn resource-correlation})
 
 (defn- stale-suppress-reply
   "Build the canonical `:status :stale` reply outcome for a superseded /
   vanished RESOURCE reply through the SHARED `reply-handlers` substrate (which
-  lowers through `rreply/stale-reply`), so the resource family lowers its stale
+  lowers through `rf.resources.reply/stale-reply`), so the resource family lowers its stale
   outcome exactly as the mutation family + every other managed-async family
   does (Managed-Effects §Stale suppression). `extra` threads diagnostic facts
   (e.g. `:outcome`) onto the stale reply."
   [runtime-db _resource-key payload extra]
-  (reply-handlers/stale-suppress-reply
+  (rf.resources.reply-handlers/stale-suppress-reply
     runtime-db entry-path-for-reply payload resource-stale-knobs extra))
 
 (defn- emit-resource-stale-suppressed!
   "Emit the `:rf.resource/stale-suppressed` trace for a suppressed late
-  resource reply via the SHARED `reply-handlers/emit-stale-suppressed!`,
+  resource reply via the SHARED `rf.resources.reply-handlers/emit-stale-suppressed!`,
   carrying the resource bespoke facts (`:resource/key` / `:generation` /
   `:outcome`) PLUS the canonical reply-envelope vocabulary ADDITIVELY
   (Managed-Effects §Tracing / EP-0011 / rf2-waawic). The work identity rides
   ONLY as `:rf.reply/work-id` (one name per fact — rf2-o6c2jr dropped the bare
   `:work/id` duplicate the additive vocabulary already carries)."
   [frame-id resource-key _work-id generation outcome stale]
-  (reply-handlers/emit-stale-suppressed!
+  (rf.resources.reply-handlers/emit-stale-suppressed!
     :rf.resource/stale-suppressed
     {:rf.frame/id frame-id :resource/key resource-key
      :generation generation :outcome outcome}
@@ -2335,13 +2335,13 @@
 
 (defn- live-entry-for-reply
   "Look the live entry up for an internal reply via the SHARED
-  `reply-handlers/live-slot-for-reply` (frame + work-id + generation
+  `rf.resources.reply-handlers/live-slot-for-reply` (frame + work-id + generation
   verification against the resource entry at the reply's `:resource/key`).
   Returns the entry on a match, nil on a cross-frame / stale / superseded /
   vanished reply (which MUST be suppressed — Spec 016 §Cancellation is
   opportunistic; stale suppression is mandatory)."
   [runtime-db receiving-frame-id payload]
-  (reply-handlers/live-slot-for-reply
+  (rf.resources.reply-handlers/live-slot-for-reply
     runtime-db receiving-frame-id entry-path-for-reply payload))
 
 ;; ---- transport reply payload extraction → canonical reply map --------------
@@ -2386,7 +2386,7 @@
 (defn succeeded-handler
   "`:rf.resource.internal/succeeded` — a transport read succeeded. Re-lifts
   the transport's PUBLIC reply into the canonical reply map
-  (`rreply/success-reply`, `:status :ok` carrying `:value` — Managed-Effects
+  (`rf.resources.reply/success-reply`, `:status :ok` carrying `:value` — Managed-Effects
   §The uniform reply envelope), verifies frame + `:work/id` + generation
   against the live entry, and on match installs `(:value reply)` as the
   durable entry `:data` (`:loaded`), preserving the old `:data` value when
@@ -2401,12 +2401,12 @@
   Event shape: `[_ <verification-payload> <http-result>]` — the managed-HTTP
   transport appends the canonical `{:status :ok :value <decoded-data> …}` as the last arg
   (Spec 014 §Reply addressing); the decoded data is read from there
-  (`rreply/transport-success-value` with the `:data` durable-layer fallback)
+  (`rf.resources.reply/transport-success-value` with the `:data` durable-layer fallback)
   and re-lifted into the canonical `:value`."
   [{rt :rf.db/runtime, frame-id :rf.frame/id, time-ms :rf/time-ms}
    [_event-id {work-id :work/id resource-key :resource/key :keys [generation] :as payload} http-result]]
   (let [runtime-db (or rt {})
-        value      (rreply/transport-success-value payload http-result :data)
+        value      (rf.resources.reply/transport-success-value payload http-result :data)
         ;; EP-0010 §Managed Effects And Reply Tokens / §Resources, Mutations,
         ;; And Work-Ledger Timestamps + EP-0017 declared-only delivery
         ;; (rf2-601ife): the reply is a CAUSAL TOKEN. The host completion time
@@ -2422,8 +2422,8 @@
         ;; (Managed-Effects §The uniform reply envelope). The internal
         ;; resource reply target receives it DIRECTLY (no public `{:kind …}`
         ;; reshape). The decoded result is `:value` (EP-0007 / kh9jz6).
-        reply      (rreply/success-reply payload value
-                                         {:work-kind rreply/work-kind-resource
+        reply      (rf.resources.reply/success-reply payload value
+                                         {:work-kind rf.resources.reply/work-kind-resource
                                           :completed-at completed-at})
         entry      (live-entry-for-reply runtime-db frame-id payload)
         ;; EP-0016 D1 extension (rf2-p1yri7) — the accepted-reply fan-out to any
@@ -2431,16 +2431,16 @@
         ;; the ORIGINAL runtime-db, before the row is marked terminal / pruned).
         ;; Used ONLY on the live (accepted) branch below; the nil-entry stale
         ;; branch delivers nothing (mandatory stale suppression).
-        record     (work-ledger/get-record runtime-db work-id)
+        record     (rf.resources.work-ledger/get-record runtime-db work-id)
         cont-fxs   (read-reply-continuation-fxs record reply resource-key)]
     (if (nil? entry)
       ;; STALE SUPPRESSION (mandatory): a superseded / vanished reply never
       ;; mutates a newer entry. Per Managed-Effects §Stale suppression the
       ;; completion is recorded `:status :stale` / `:rf.reply/work-status :suppressed`
       ;; through the SHARED `re-frame.reply` substrate (via
-      ;; `rreply/stale-reply`), exactly as every other managed-async family
+      ;; `rf.resources.reply/stale-reply`), exactly as every other managed-async family
       ;; lowers its stale outcome — the canonical reply built above
-      ;; (`rreply/success-reply`) is the SUCCESS reply for the live path; the
+      ;; (`rf.resources.reply/success-reply`) is the SUCCESS reply for the live path; the
       ;; nil-entry path produces the canonical STALE reply instead. The app
       ;; reply target MUST NOT run (no live entry to settle), the
       ;; (already-superseded) work row settles terminal `:suppressed`, and the
@@ -2450,11 +2450,11 @@
                                         {:outcome :success})]
         (emit-resource-stale-suppressed!
           frame-id resource-key work-id generation :success stale)
-        (work-ledger/clear-handle! frame-id work-id)
-        {:rf.db/runtime (work-ledger/update-record
-                          runtime-db work-id work-ledger/mark-terminal
+        (rf.resources.work-ledger/clear-handle! frame-id work-id)
+        {:rf.db/runtime (rf.resources.work-ledger/update-record
+                          runtime-db work-id rf.resources.work-ledger/mark-terminal
                           :suppressed {:reason :stale-reply :outcome :success})})
-      (let [spec      (registry/resource-meta (:resource/id entry))
+      (let [spec      (rf.resources.registry/resource-meta (:resource/id entry))
             ;; the durable entry stores the canonical reply's `:value` under
             ;; `:data` (the entry layer's spelling of the same fact — the
             ;; reply-map spelling is `:value`, kh9jz6 / EP-0007).
@@ -2465,7 +2465,7 @@
             ;; `:stale-at` is computed from it + the resource's
             ;; `:stale-after-ms` policy — never an ambient clock read here.
             loaded-at (:completed-at reply)
-            stale-at  (state/stale-at-for spec loaded-at)
+            stale-at  (rf.resources.state/stale-at-for spec loaded-at)
             ;; arm the advisory stale / GC timers from the resource's policy
             ;; (Spec 016 §Stale and GC scheduling). The DELAYS are relative
             ;; from now (the durable absolute :stale-at / :loaded-at remain the
@@ -2473,13 +2473,13 @@
             ;; an advisory nudge). A resource declaring no :stale-after-ms /
             ;; :gc-after-ms arms neither. nil when this resource arms no timers
             ;; (no schedule-timers fx emitted).
-            stale-delay-ms (state/positive-or-nil (:stale-after-ms spec))
-            gc-delay-ms    (state/positive-or-nil (:gc-after-ms spec))
+            stale-delay-ms (rf.resources.state/positive-or-nil (:stale-after-ms spec))
+            gc-delay-ms    (rf.resources.state/positive-or-nil (:gc-after-ms spec))
             tags-fn   (:tags spec)
             ;; tags are produced from the params + decoded data; the canonical
             ;; params are the third element of the scoped key
             tags      (when tags-fn (set (tags-fn (nth resource-key 2) data)))
-            entry'    (state/entry-succeeded
+            entry'    (rf.resources.state/entry-succeeded
                         entry {:data data :loaded-at loaded-at
                                :stale-at stale-at :tags tags})
             ;; EP-0020 §Polling: arm the active-owner POLL timer from the
@@ -2491,7 +2491,7 @@
             ;; tick. A resource declaring no `:poll-interval-ms` (or one whose
             ;; entry is owner-free at settle) arms no poll timer.
             poll-delay-ms (when (seq (:active-owners entry'))
-                            (state/positive-or-nil (:poll-interval-ms spec)))
+                            (rf.resources.state/positive-or-nil (:poll-interval-ms spec)))
             ;; on a successful load the tag index for this key is REPLACED
             ;; with the new tags (old tags removed). This settle touches ONE
             ;; entry, so reconcile only that key's index members incrementally
@@ -2499,26 +2499,26 @@
             ;; row settles :completed; terminal rows for this key are then
             ;; PRUNED (bounded per-key tail kept for Xray) — Spec 016 §Ledger
             ;; row retention. The host handle is cleared (the attempt settled).
-            old-entries (get-in runtime-db (state/entries-path))
+            old-entries (get-in runtime-db (rf.resources.state/entries-path))
             rdb'      (-> runtime-db
-                          (assoc-in (state/entry-path resource-key) entry')
-                          (work-ledger/update-record
-                            work-id work-ledger/mark-terminal
+                          (assoc-in (rf.resources.state/entry-path resource-key) entry')
+                          (rf.resources.work-ledger/update-record
+                            work-id rf.resources.work-ledger/mark-terminal
                             :completed {:loaded-at loaded-at})
-                          (work-ledger/prune-terminal-for-key resource-key)
-                          (update state/resources-key state/reindex-keys
-                                  old-entries [(state/key-id resource-key)])
+                          (rf.resources.work-ledger/prune-terminal-for-key resource-key)
+                          (update rf.resources.state/resources-key rf.resources.state/reindex-keys
+                                  old-entries [(rf.resources.state/key-id resource-key)])
                           ;; route blocking: a route-owned blocking resource
                           ;; settling drops it from the nav-token blocking
                           ;; slot + lands the route transition when the slot
                           ;; empties (Spec 016 §Route integration). No-op for
                           ;; a non-route-owned / non-blocking resource.
-                          (route/reconcile-readiness))]
-        (work-ledger/clear-handle! frame-id work-id)
-        (trace/emit! :rf.event :rf.resource/work-completed
+                          (rf.resources.route/reconcile-readiness))]
+        (rf.resources.work-ledger/clear-handle! frame-id work-id)
+        (rf.trace/emit! :rf.event :rf.resource/work-completed
                      {:rf.frame/id frame-id :resource/key resource-key
                       :work/id work-id :generation generation :status :completed})
-        (trace/emit! :rf.event :rf.resource/succeeded
+        (rf.trace/emit! :rf.event :rf.resource/succeeded
                      {:rf.frame/id frame-id :resource/key resource-key
                       :work/id work-id :generation generation
                       :status-before (:status entry) :status-after :loaded})
@@ -2550,7 +2550,7 @@
                              :timers       {:stale stale-delay-ms
                                             :gc    gc-delay-ms
                                             :poll  poll-delay-ms}
-                             :server?      (state/server-frame? frame-id)}]])
+                             :server?      (rf.resources.state/server-frame? frame-id)}]])
               fx        (into (vec timers-fx) cont-fxs)]
           (cond-> {:rf.db/runtime rdb'}
             (seq fx) (assoc :fx fx)))))))
@@ -2569,7 +2569,7 @@
 
   Either way `:current-work` is cleared (the attempt settled) and no error
   facts are written. Per Spec 016 §Cancellation is opportunistic / §Status
-  semantics. (Distinct from `state/entry-failed`, which records the failure
+  semantics. (Distinct from `rf.resources.state/entry-failed`, which records the failure
   envelope; an abort is the no-error settlement.)
 
   Bumps the per-entry `:revision` UNCONDITIONALLY (EP-0019 / byl7bk / rf2-mx0w2o):
@@ -2578,10 +2578,10 @@
   clobber. A snapshot taken while the attempt was in-flight is now a STALE
   `:before`; without the bump the settle-time conflict check would miss this
   move and a rollback could RESURRECT the cancelled in-flight `:current-work`
-  pointer. Symmetric with `state/entry-failed` / `entry-succeeded`."
+  pointer. Symmetric with `rf.resources.state/entry-failed` / `entry-succeeded`."
   [entry]
-  (state/bump-revision
-    (if (state/has-data? entry)
+  (rf.resources.state/bump-revision
+    (if (rf.resources.state/has-data? entry)
       (assoc entry :status :loaded :current-work nil)
       (assoc entry :status :idle  :current-work nil))))
 
@@ -2608,15 +2608,15 @@
   Event shape: `[_ <verification-payload> <http-result>]` — the managed-HTTP
   transport appends the canonical `{:status :error :error <:rf.http/* envelope> …}` as the
   last arg (Spec 014 §Reply addressing); the failure envelope is read from
-  there (`rreply/transport-failure-envelope`) and re-lifted into the canonical
-  reply map (`rreply/failure-reply` — `:status :error` with the envelope under
+  there (`rf.resources.reply/transport-failure-envelope`) and re-lifted into the canonical
+  reply map (`rf.resources.reply/failure-reply` — `:status :error` with the envelope under
   `:error`, or `:status :cancelled` for an `:rf.http/aborted` envelope; per
   Managed-Effects §Status taxonomy / EP-0011 §Resource Reply And Work
   Ledger)."
   [{rt :rf.db/runtime, frame-id :rf.frame/id, time-ms :rf/time-ms}
    [_event-id {work-id :work/id resource-key :resource/key :keys [generation] :as payload} http-result]]
   (let [runtime-db (or rt {})
-        error      (rreply/transport-failure-envelope payload http-result)
+        error      (rf.resources.reply/transport-failure-envelope payload http-result)
         ;; EP-0017 declared-only delivery + EP-0010 §Managed Effects And Reply
         ;; Tokens (rf2-rl27r2): a FAILED / CANCELLED completion is still a
         ;; managed-async completion with a reply token, so its causal completion
@@ -2630,12 +2630,12 @@
         ;; the ONE canonical reply map (Managed-Effects §The uniform reply
         ;; envelope) — `:status :error` (or `:cancelled` for an abort), now
         ;; carrying `:completed-at` (rf2-rl27r2). The internal reply target
-        ;; receives it directly. The abort classification is `rreply/failure-
+        ;; receives it directly. The abort classification is `rf.resources.reply/failure-
         ;; reply`'s (`re-frame.resources.reply/abort-failure?` — the family's
         ;; ONE classifier); the canonical reply's `:status` then drives the
         ;; branch below.
-        reply      (rreply/failure-reply payload error
-                                         {:work-kind rreply/work-kind-resource
+        reply      (rf.resources.reply/failure-reply payload error
+                                         {:work-kind rf.resources.reply/work-kind-resource
                                           :completed-at completed-at})
         aborted?   (= :cancelled (:status reply))
         entry      (live-entry-for-reply runtime-db frame-id payload)
@@ -2644,7 +2644,7 @@
         ;; accepted terminal FAILURE (`:status :error`) OR terminal cancellation
         ;; (accepted `:status :cancelled`) both continue; only the nil-entry
         ;; stale branch delivers nothing. Read off the ORIGINAL runtime-db.
-        record     (work-ledger/get-record runtime-db work-id)
+        record     (rf.resources.work-ledger/get-record runtime-db work-id)
         cont-fxs   (read-reply-continuation-fxs record reply resource-key)]
     (cond
       ;; STALE SUPPRESSION (mandatory): a superseded / vanished reply (failure
@@ -2665,9 +2665,9 @@
         (emit-resource-stale-suppressed!
           frame-id resource-key work-id generation
           (if aborted? :aborted :failure) stale)
-        (work-ledger/clear-handle! frame-id work-id)
-        {:rf.db/runtime (work-ledger/update-record
-                          runtime-db work-id work-ledger/mark-terminal
+        (rf.resources.work-ledger/clear-handle! frame-id work-id)
+        {:rf.db/runtime (rf.resources.work-ledger/update-record
+                          runtime-db work-id rf.resources.work-ledger/mark-terminal
                           :suppressed
                           ;; rf2-rl27r2: the terminal outcome summary records
                           ;; the causal completion time (the reply token's
@@ -2689,16 +2689,16 @@
             ;; so `entry-abort-settled` settles it to a non-error stable
             ;; `:idle` (never `:loaded`, which only a REFRESH abort reaches).
             first-load-abort? (= :idle (:status entry'))
-            spec      (registry/resource-meta (:resource/id entry'))
+            spec      (rf.resources.registry/resource-meta (:resource/id entry'))
             rdb'   (-> runtime-db
-                       (assoc-in (state/entry-path resource-key) entry')
-                       (work-ledger/update-record
-                         work-id work-ledger/mark-terminal
+                       (assoc-in (rf.resources.state/entry-path resource-key) entry')
+                       (rf.resources.work-ledger/update-record
+                         work-id rf.resources.work-ledger/mark-terminal
                          ;; rf2-rl27r2: a cancellation is a completion — its
                          ;; terminal outcome carries the reply token's causal
                          ;; `:completed-at`.
                          :cancelled {:reason :aborted :completed-at completed-at})
-                       (route/reconcile-readiness))
+                       (rf.resources.route/reconcile-readiness))
             ;; rf2-kz5op1 — a FIRST-LOAD abort settle MUST arm the GC timer
             ;; (and the stale timer, if declared), mirroring rf2-ar9pcx's
             ;; :error-settle fix. GC timers are otherwise armed only on a
@@ -2718,11 +2718,11 @@
             ;; already enforce). Per Spec 016 §Stale and GC scheduling /
             ;; §Cancellation is opportunistic.
             stale-delay-ms (when first-load-abort?
-                             (state/positive-or-nil (:stale-after-ms spec)))
+                             (rf.resources.state/positive-or-nil (:stale-after-ms spec)))
             gc-delay-ms    (when first-load-abort?
-                             (state/positive-or-nil (:gc-after-ms spec)))]
-        (work-ledger/clear-handle! frame-id work-id)
-        (trace/emit! :rf.event :rf.resource/work-abort-requested
+                             (rf.resources.state/positive-or-nil (:gc-after-ms spec)))]
+        (rf.resources.work-ledger/clear-handle! frame-id work-id)
+        (rf.trace/emit! :rf.event :rf.resource/work-abort-requested
                      {:rf.frame/id frame-id :resource/key resource-key
                       :work/id work-id :generation generation
                       :status-before (:status entry) :status-after (:status entry')})
@@ -2742,24 +2742,24 @@
                              :timers       {:stale stale-delay-ms
                                             :gc    gc-delay-ms
                                             :poll  nil}
-                             :server?      (state/server-frame? frame-id)}]])
+                             :server?      (rf.resources.state/server-frame? frame-id)}]])
               fx        (into (vec timers-fx) cont-fxs)]
           (cond-> {:rf.db/runtime rdb'}
             (seq fx) (assoc :fx fx))))
 
       :else
-      (let [entry' (state/entry-failed entry {:error error})
+      (let [entry' (rf.resources.state/entry-failed entry {:error error})
             first-load-error? (= :error (:status entry'))
             op     (if first-load-error?
                      :rf.resource/failed :rf.resource/refresh-failed)
-            spec   (registry/resource-meta (:resource/id entry'))
+            spec   (rf.resources.registry/resource-meta (:resource/id entry'))
             ;; the work row settles :failed (terminal) with the error
             ;; envelope as its outcome summary (Xray gets the summary). The
             ;; host handle is cleared (the attempt settled).
             rdb'   (-> runtime-db
-                       (assoc-in (state/entry-path resource-key) entry')
-                       (work-ledger/update-record
-                         work-id work-ledger/mark-terminal
+                       (assoc-in (rf.resources.state/entry-path resource-key) entry')
+                       (rf.resources.work-ledger/update-record
+                         work-id rf.resources.work-ledger/mark-terminal
                          ;; rf2-rl27r2: the failed terminal outcome carries the
                          ;; reply token's causal `:completed-at` alongside the
                          ;; error envelope (the summary represents the completion).
@@ -2771,7 +2771,7 @@
                        ;; resolves the requirement. The projector reads the
                        ;; entry's facts, not a settle signal.
                        ;; (Spec 016 §Route integration.)
-                       (route/reconcile-readiness))
+                       (rf.resources.route/reconcile-readiness))
             ;; rf2-ar9pcx — a FIRST-LOAD `:error` settle MUST arm the GC timer
             ;; (and the stale timer, if declared). GC timers are otherwise armed
             ;; only on a SUCCESSFUL settle (`succeeded-handler`); a first load
@@ -2787,14 +2787,14 @@
             ;; success and `entry-failed` makes no freshness change; re-arming
             ;; would double-arm. Per Spec 016 §Stale and GC scheduling.
             stale-delay-ms (when first-load-error?
-                             (state/positive-or-nil (:stale-after-ms spec)))
+                             (rf.resources.state/positive-or-nil (:stale-after-ms spec)))
             gc-delay-ms    (when first-load-error?
-                             (state/positive-or-nil (:gc-after-ms spec)))]
-        (work-ledger/clear-handle! frame-id work-id)
-        (trace/emit! :rf.event :rf.resource/work-completed
+                             (rf.resources.state/positive-or-nil (:gc-after-ms spec)))]
+        (rf.resources.work-ledger/clear-handle! frame-id work-id)
+        (rf.trace/emit! :rf.event :rf.resource/work-completed
                      {:rf.frame/id frame-id :resource/key resource-key
                       :work/id work-id :generation generation :status :failed})
-        (trace/emit! :rf.event op
+        (rf.trace/emit! :rf.event op
                      {:rf.frame/id frame-id :resource/key resource-key
                       :work/id work-id :generation generation
                       :status-before (:status entry) :status-after (:status entry')})
@@ -2823,7 +2823,7 @@
                              :timers       {:stale stale-delay-ms
                                             :gc    gc-delay-ms
                                             :poll  nil}
-                             :server?      (state/server-frame? frame-id)}]])
+                             :server?      (rf.resources.state/server-frame? frame-id)}]])
               fx        (into (vec timers-fx) cont-fxs)]
           (cond-> {:rf.db/runtime rdb'}
             (seq fx) (assoc :fx fx)))))))
@@ -2867,10 +2867,10 @@
                page-param :rf.resource/page-param
                page-index :rf.resource/page-index :as payload} http-result]]
   (let [runtime-db   (or rt {})
-        page         (rreply/transport-success-value payload http-result :data)
+        page         (rf.resources.reply/transport-success-value payload http-result :data)
         completed-at time-ms
-        reply        (rreply/success-reply payload page
-                                           {:work-kind rreply/work-kind-resource
+        reply        (rf.resources.reply/success-reply payload page
+                                           {:work-kind rf.resources.reply/work-kind-resource
                                             :completed-at completed-at})
         entry        (live-entry-for-reply runtime-db frame-id payload)
         ;; EP-0016 D1 extension (rf2-p1yri7) — an `:rf.resource/ensure` /
@@ -2882,7 +2882,7 @@
         ;; rf2-c64uiz — an infinite `:reply-to` `:value` is the MERGED items
         ;; list over the post-settle feed (the same shape the fresh-skip
         ;; cache-hit path delivers), NOT this single decoded `page`.
-        record       (work-ledger/get-record runtime-db work-id)]
+        record       (rf.resources.work-ledger/get-record runtime-db work-id)]
     (if (nil? entry)
       ;; STALE SUPPRESSION (mandatory) — a superseded / vanished / cross-frame
       ;; page reply never appends to a newer feed. Recorded `:status :stale` /
@@ -2892,17 +2892,17 @@
                                         {:outcome :page-success})]
         (emit-resource-stale-suppressed!
           frame-id resource-key work-id generation :page-success stale)
-        (work-ledger/clear-handle! frame-id work-id)
-        {:rf.db/runtime (work-ledger/update-record
-                          runtime-db work-id work-ledger/mark-terminal
+        (rf.resources.work-ledger/clear-handle! frame-id work-id)
+        {:rf.db/runtime (rf.resources.work-ledger/update-record
+                          runtime-db work-id rf.resources.work-ledger/mark-terminal
                           :suppressed {:reason :stale-reply :outcome :page-success})})
-      (let [spec      (registry/resource-meta (:resource/id entry))
+      (let [spec      (rf.resources.registry/resource-meta (:resource/id entry))
             decoded   (:value reply)
             loaded-at (:completed-at reply)
-            stale-at  (state/stale-at-for spec loaded-at)
-            stale-delay-ms (state/positive-or-nil (:stale-after-ms spec))
-            gc-delay-ms    (state/positive-or-nil (:gc-after-ms spec))
-            replaced  (state/entry-replace-page
+            stale-at  (rf.resources.state/stale-at-for spec loaded-at)
+            stale-delay-ms (rf.resources.state/positive-or-nil (:stale-after-ms spec))
+            gc-delay-ms    (rf.resources.state/positive-or-nil (:gc-after-ms spec))
+            replaced  (rf.resources.state/entry-replace-page
                         entry {:page decoded :page-param page-param
                                :page-index page-index
                                :next-page-param-fn (:next-page-param spec)
@@ -2913,9 +2913,9 @@
             ;; off the `:refetch-sweep` cursor and re-fetch it (one in-flight
             ;; leg at a time, "in sequence"). `entry-replace-page` preserves the
             ;; cursor, so it rides through to here.
-            sweep-leg (state/next-refetch-sweep-leg replaced)
+            sweep-leg (rf.resources.state/next-refetch-sweep-leg replaced)
             entry'    (if sweep-leg
-                        (state/entry-advance-refetch-sweep replaced)
+                        (rf.resources.state/entry-advance-refetch-sweep replaced)
                         replaced)
             ;; rf2-c64uiz — the accepted `:reply-to` continuation carries the
             ;; MERGED items list over the POST-settle feed (`entry'`), the SAME
@@ -2931,17 +2931,17 @@
                           (assoc reply :value (infinite-reply-value entry' reply-to-where))
                           resource-key))
             poll-delay-ms (when (seq (:active-owners entry'))
-                            (state/positive-or-nil (:poll-interval-ms spec)))
+                            (rf.resources.state/positive-or-nil (:poll-interval-ms spec)))
             rdb'      (-> runtime-db
-                          (assoc-in (state/entry-path resource-key) entry')
-                          (work-ledger/update-record
-                            work-id work-ledger/mark-terminal
+                          (assoc-in (rf.resources.state/entry-path resource-key) entry')
+                          (rf.resources.work-ledger/update-record
+                            work-id rf.resources.work-ledger/mark-terminal
                             :completed {:loaded-at loaded-at :page-index page-index})
-                          (work-ledger/prune-terminal-for-key resource-key)
+                          (rf.resources.work-ledger/prune-terminal-for-key resource-key)
                           ;; route readiness: a route-owned blocking infinite
                           ;; feed blocks on page 0 — the accumulated page makes
                           ;; the requirement data-ready.
-                          (route/reconcile-readiness))
+                          (rf.resources.route/reconcile-readiness))
             ;; the chained sweep leg is a self-dispatched internal event so it
             ;; re-enters the router and mints its own replay-stable generation
             ;; (the generation-allocation cofx) — the framework's follow-up-fetch
@@ -2955,16 +2955,16 @@
                                        :cause    [:rf.resource/refetch-sweep leg-index]
                                        :rf.resource/page-param leg-param
                                        :rf.resource/page-index leg-index}]]))]
-        (work-ledger/clear-handle! frame-id work-id)
-        (trace/emit! :rf.event :rf.resource/work-completed
+        (rf.resources.work-ledger/clear-handle! frame-id work-id)
+        (rf.trace/emit! :rf.event :rf.resource/work-completed
                      {:rf.frame/id frame-id :resource/key resource-key
                       :work/id work-id :generation generation :status :completed})
-        (trace/emit! :rf.event :rf.resource/page-appended
+        (rf.trace/emit! :rf.event :rf.resource/page-appended
                      {:rf.frame/id frame-id :resource/key resource-key
                       :work/id work-id :generation generation
-                      :page-index page-index :page-count (state/page-count entry')
+                      :page-index page-index :page-count (rf.resources.state/page-count entry')
                       :next-page-param (:next-page-param entry')
-                      :terminal? (state/terminal? (:next-page-param entry'))})
+                      :terminal? (rf.resources.state/terminal? (:next-page-param entry'))})
         (emit-resource-replied!
           frame-id resource-key work-id (:status reply) (:reply-targets record) false)
         (let [timers-fx (when (or stale-delay-ms gc-delay-ms poll-delay-ms)
@@ -2977,7 +2977,7 @@
                             :timers       {:stale stale-delay-ms
                                            :gc    gc-delay-ms
                                            :poll  poll-delay-ms}
-                            :server?      (state/server-frame? frame-id)}])
+                            :server?      (rf.resources.state/server-frame? frame-id)}])
               fx        (cond-> []
                           timers-fx (conj timers-fx)
                           sweep-fx  (conj sweep-fx))
@@ -3038,10 +3038,10 @@
    [_event-id {work-id :work/id resource-key :resource/key :keys [generation]
                page-index :rf.resource/page-index :as payload} http-result]]
   (let [runtime-db   (or rt {})
-        error        (rreply/transport-failure-envelope payload http-result)
+        error        (rf.resources.reply/transport-failure-envelope payload http-result)
         completed-at time-ms
-        reply        (rreply/failure-reply payload error
-                                           {:work-kind rreply/work-kind-resource
+        reply        (rf.resources.reply/failure-reply payload error
+                                           {:work-kind rf.resources.reply/work-kind-resource
                                             :completed-at completed-at})
         aborted?     (= :cancelled (:status reply))
         entry        (live-entry-for-reply runtime-db frame-id payload)
@@ -3051,12 +3051,12 @@
         ;; load — it keeps `:page-error` + `:loaded` (data to keep).
         first-load?  (and (some? entry)
                           (= 0 page-index)
-                          (zero? (state/page-count entry)))
+                          (zero? (rf.resources.state/page-count entry)))
         ;; EP-0016 D1 extension (rf2-p1yri7) — a page-0 ensure/refetch reply-to
         ;; settles here on failure/abort; a load-more (page N>0) carries no
         ;; `:reply-to` (its record has none, so the fan-out is a no-op). Read off
         ;; the ORIGINAL runtime-db; only the live branches fan out.
-        record       (work-ledger/get-record runtime-db work-id)
+        record       (rf.resources.work-ledger/get-record runtime-db work-id)
         cont-fxs     (read-reply-continuation-fxs record reply resource-key)]
     (cond
       ;; STALE SUPPRESSION (mandatory) — stale wins over the natural status
@@ -3067,9 +3067,9 @@
         (emit-resource-stale-suppressed!
           frame-id resource-key work-id generation
           (if aborted? :aborted :page-failure) stale)
-        (work-ledger/clear-handle! frame-id work-id)
-        {:rf.db/runtime (work-ledger/update-record
-                          runtime-db work-id work-ledger/mark-terminal
+        (rf.resources.work-ledger/clear-handle! frame-id work-id)
+        {:rf.db/runtime (rf.resources.work-ledger/update-record
+                          runtime-db work-id rf.resources.work-ledger/mark-terminal
                           :suppressed {:reason :stale-reply
                                        :outcome (if aborted? :aborted :page-failure)
                                        :completed-at completed-at})})
@@ -3092,19 +3092,19 @@
       ;; settle).
       (and aborted? first-load?)
       (let [entry' (-> (assoc entry :status :idle :current-work nil)
-                       state/clear-refetch-sweep
-                       state/bump-revision)
-            spec   (registry/resource-meta (:resource/id entry'))
+                       rf.resources.state/clear-refetch-sweep
+                       rf.resources.state/bump-revision)
+            spec   (rf.resources.registry/resource-meta (:resource/id entry'))
             rdb'   (-> runtime-db
-                       (assoc-in (state/entry-path resource-key) entry')
-                       (work-ledger/update-record
-                         work-id work-ledger/mark-terminal
+                       (assoc-in (rf.resources.state/entry-path resource-key) entry')
+                       (rf.resources.work-ledger/update-record
+                         work-id rf.resources.work-ledger/mark-terminal
                          :cancelled {:reason :aborted :completed-at completed-at})
-                       (route/reconcile-readiness))
-            stale-delay-ms (state/positive-or-nil (:stale-after-ms spec))
-            gc-delay-ms    (state/positive-or-nil (:gc-after-ms spec))]
-        (work-ledger/clear-handle! frame-id work-id)
-        (trace/emit! :rf.event :rf.resource/work-abort-requested
+                       (rf.resources.route/reconcile-readiness))
+            stale-delay-ms (rf.resources.state/positive-or-nil (:stale-after-ms spec))
+            gc-delay-ms    (rf.resources.state/positive-or-nil (:gc-after-ms spec))]
+        (rf.resources.work-ledger/clear-handle! frame-id work-id)
+        (rf.trace/emit! :rf.event :rf.resource/work-abort-requested
                      {:rf.frame/id frame-id :resource/key resource-key
                       :work/id work-id :generation generation
                       :status-before (:status entry) :status-after (:status entry')})
@@ -3121,7 +3121,7 @@
                              :timers       {:stale stale-delay-ms
                                             :gc    gc-delay-ms
                                             :poll  nil}
-                             :server?      (state/server-frame? frame-id)}]])
+                             :server?      (rf.resources.state/server-frame? frame-id)}]])
               fx        (into (vec timers-fx) cont-fxs)]
           (cond-> {:rf.db/runtime rdb'}
             (seq fx) (assoc :fx fx))))
@@ -3143,16 +3143,16 @@
       ;; could clobber — symmetric with the scalar abort (`entry-abort-settled`)
       ;; and the page failure (`entry-page-failed`).
       (let [entry' (-> (assoc entry :status :loaded :current-work nil)
-                       state/clear-refetch-sweep
-                       state/bump-revision)
+                       rf.resources.state/clear-refetch-sweep
+                       rf.resources.state/bump-revision)
             rdb'   (-> runtime-db
-                       (assoc-in (state/entry-path resource-key) entry')
-                       (work-ledger/update-record
-                         work-id work-ledger/mark-terminal
+                       (assoc-in (rf.resources.state/entry-path resource-key) entry')
+                       (rf.resources.work-ledger/update-record
+                         work-id rf.resources.work-ledger/mark-terminal
                          :cancelled {:reason :aborted :completed-at completed-at})
-                       (route/reconcile-readiness))]
-        (work-ledger/clear-handle! frame-id work-id)
-        (trace/emit! :rf.event :rf.resource/work-abort-requested
+                       (rf.resources.route/reconcile-readiness))]
+        (rf.resources.work-ledger/clear-handle! frame-id work-id)
+        (rf.trace/emit! :rf.event :rf.resource/work-abort-requested
                      {:rf.frame/id frame-id :resource/key resource-key
                       :work/id work-id :generation generation
                       :status-before (:status entry) :status-after (:status entry')})
@@ -3171,14 +3171,14 @@
       ;; Trace the first-load `:rf.resource/failed` op (not
       ;; `:rf.resource/page-failed`) so the channel and the trace agree.
       first-load?
-      (let [entry' (state/entry-failed entry {:error error})
-            spec   (registry/resource-meta (:resource/id entry'))
+      (let [entry' (rf.resources.state/entry-failed entry {:error error})
+            spec   (rf.resources.registry/resource-meta (:resource/id entry'))
             rdb'   (-> runtime-db
-                       (assoc-in (state/entry-path resource-key) entry')
-                       (work-ledger/update-record
-                         work-id work-ledger/mark-terminal
+                       (assoc-in (rf.resources.state/entry-path resource-key) entry')
+                       (rf.resources.work-ledger/update-record
+                         work-id rf.resources.work-ledger/mark-terminal
                          :failed {:error error :completed-at completed-at})
-                       (route/reconcile-readiness))
+                       (rf.resources.route/reconcile-readiness))
             ;; rf2-s54uzc — mirrors rf2-ar9pcx's scalar first-load `:error`
             ;; arming (`failed-handler`'s `:else` branch): a first-load
             ;; infinite-feed failure settles `:error` with `:current-work nil`
@@ -3186,13 +3186,13 @@
             ;; timer the same way — otherwise an owner-free errored empty feed
             ;; is never reaped (the same unbounded per-frame cache leak this
             ;; handler's abort twin, above, is also fixed against).
-            stale-delay-ms (state/positive-or-nil (:stale-after-ms spec))
-            gc-delay-ms    (state/positive-or-nil (:gc-after-ms spec))]
-        (work-ledger/clear-handle! frame-id work-id)
-        (trace/emit! :rf.event :rf.resource/work-completed
+            stale-delay-ms (rf.resources.state/positive-or-nil (:stale-after-ms spec))
+            gc-delay-ms    (rf.resources.state/positive-or-nil (:gc-after-ms spec))]
+        (rf.resources.work-ledger/clear-handle! frame-id work-id)
+        (rf.trace/emit! :rf.event :rf.resource/work-completed
                      {:rf.frame/id frame-id :resource/key resource-key
                       :work/id work-id :generation generation :status :failed})
-        (trace/emit! :rf.event :rf.resource/failed
+        (rf.trace/emit! :rf.event :rf.resource/failed
                      {:rf.frame/id frame-id :resource/key resource-key
                       :work/id work-id :generation generation
                       :status-before (:status entry) :status-after (:status entry')
@@ -3210,7 +3210,7 @@
                              :timers       {:stale stale-delay-ms
                                             :gc    gc-delay-ms
                                             :poll  nil}
-                             :server?      (state/server-frame? frame-id)}]])
+                             :server?      (rf.resources.state/server-frame? frame-id)}]])
               fx        (into (vec timers-fx) cont-fxs)]
           (cond-> {:rf.db/runtime rdb'}
             (seq fx) (assoc :fx fx))))
@@ -3226,19 +3226,19 @@
       ;; a failed leg STOPS any in-progress refetch sweep (clear the cursor —
       ;; don't chain past a failure; rf2-byl7bk.3.3). The kept-feed +
       ;; :page-error channel is unchanged.
-      (let [entry' (-> (state/entry-page-failed entry {:error error})
-                       state/clear-refetch-sweep)
+      (let [entry' (-> (rf.resources.state/entry-page-failed entry {:error error})
+                       rf.resources.state/clear-refetch-sweep)
             rdb'   (-> runtime-db
-                       (assoc-in (state/entry-path resource-key) entry')
-                       (work-ledger/update-record
-                         work-id work-ledger/mark-terminal
+                       (assoc-in (rf.resources.state/entry-path resource-key) entry')
+                       (rf.resources.work-ledger/update-record
+                         work-id rf.resources.work-ledger/mark-terminal
                          :failed {:error error :completed-at completed-at})
-                       (route/reconcile-readiness))]
-        (work-ledger/clear-handle! frame-id work-id)
-        (trace/emit! :rf.event :rf.resource/work-completed
+                       (rf.resources.route/reconcile-readiness))]
+        (rf.resources.work-ledger/clear-handle! frame-id work-id)
+        (rf.trace/emit! :rf.event :rf.resource/work-completed
                      {:rf.frame/id frame-id :resource/key resource-key
                       :work/id work-id :generation generation :status :failed})
-        (trace/emit! :rf.event :rf.resource/page-failed
+        (rf.trace/emit! :rf.event :rf.resource/page-failed
                      {:rf.frame/id frame-id :resource/key resource-key
                       :work/id work-id :generation generation
                       :status-before (:status entry) :status-after (:status entry')
@@ -3278,12 +3278,12 @@
   [{rt :rf.db/runtime, frame-id :rf.frame/id, time-ms :rf/time-ms}
    [_event-id {resource-key :resource/key}]]
   (let [runtime-db (or rt {})
-        entry      (get-in runtime-db (state/entry-path resource-key))
+        entry      (get-in runtime-db (rf.resources.state/entry-path resource-key))
         ;; re-derive staleness from the DURABLE :stale-at (the timer is
         ;; advisory — never trust "the timer fired on time"). An entry
         ;; re-loaded since the timer armed has a future :stale-at and is not
         ;; yet stale, so the re-check naturally no-ops. Shared derivation
-        ;; (`state/entry-stale?`) so it never drifts from the subs / SSR view.
+        ;; (`rf.resources.state/entry-stale?`) so it never drifts from the subs / SSR view.
         ;;
         ;; EP-0010 §Resources / §The World-Input Rule (rf2-95b0lc) + EP-0017
         ;; declared-only delivery (rf2-601ife): a TIMER-FIRE event's freshness
@@ -3294,8 +3294,8 @@
         ;; `:stale?` sub), but the recorded `:decision` must be replay-stable: a
         ;; replayed `:stale-fired` under a later live clock must classify the
         ;; entry the same way the recorded `:rf/time-ms` did.
-        stale?     (state/entry-stale? entry time-ms)]
-    (trace/emit! :rf.event :rf.resource/stale-fired
+        stale?     (rf.resources.state/entry-stale? entry time-ms)]
+    (rf.trace/emit! :rf.event :rf.resource/stale-fired
                  {:rf.frame/id frame-id :resource/key resource-key
                   :decision (cond (nil? entry) :no-entry
                                   stale?       :now-stale
@@ -3348,18 +3348,18 @@
   [{rt :rf.db/runtime, frame-id :rf.frame/id}
    [_event-id {resource-key :resource/key}]]
   (let [runtime-db (or rt {})
-        entry      (get-in runtime-db (state/entry-path resource-key))]
+        entry      (get-in runtime-db (rf.resources.state/entry-path resource-key))]
     (if (and entry (empty? (:active-owners entry)) (nil? (:current-work entry)))
       ;; rf2-9e0tyq — `:entries` is keyed on the byte `key-id`; dissoc by it
       ;; (a dissoc by the scoped-key VECTOR would be a no-op and the GC removal
       ;; would silently leak the entry). rf2-2c2mkh — GC removes ONE entry, so
       ;; reconcile only that key's index members incrementally.
-      (let [old-entries (get-in runtime-db (state/entries-path))
+      (let [old-entries (get-in runtime-db (rf.resources.state/entries-path))
             rdb' (-> runtime-db
-                     (update-in (state/entries-path) dissoc (state/key-id resource-key))
-                     (update state/resources-key state/reindex-keys
-                             old-entries [(state/key-id resource-key)]))]
-        (trace/emit! :rf.event :rf.resource/gc-fired
+                     (update-in (rf.resources.state/entries-path) dissoc (rf.resources.state/key-id resource-key))
+                     (update rf.resources.state/resources-key rf.resources.state/reindex-keys
+                             old-entries [(rf.resources.state/key-id resource-key)]))]
+        (rf.trace/emit! :rf.event :rf.resource/gc-fired
                      {:rf.frame/id frame-id :resource/key resource-key})
         {:rf.db/runtime rdb'
          ;; the entry is gone — cancel its (now orphaned) stale / GC timer
@@ -3377,8 +3377,8 @@
             ;; resource's own :gc-after-ms (positive-guarded — a resource with
             ;; no GC policy never armed one, so it never reaches this branch).
             gc-delay (when (not= :no-entry reason)
-                       (state/positive-or-nil (:gc-after-ms (registry/resource-meta (:resource/id entry)))))]
-        (trace/emit! :rf.event :rf.resource/gc-skipped
+                       (rf.resources.state/positive-or-nil (:gc-after-ms (rf.resources.registry/resource-meta (:resource/id entry)))))]
+        (rf.trace/emit! :rf.event :rf.resource/gc-skipped
                      {:rf.frame/id frame-id :resource/key resource-key
                       :reason reason
                       :rescheduled? (some? gc-delay)})
@@ -3391,7 +3391,7 @@
                         ;; / poll timers are PRESERVED (absent from `:timers`),
                         ;; not cancelled (rf2-3fc89f.10)
                         :timers       {:gc gc-delay}
-                        :server?      (state/server-frame? frame-id)}]]))))))
+                        :server?      (rf.resources.state/server-frame? frame-id)}]]))))))
 
 (defn stale-suppressed-handler
   "`:rf.resource.internal/stale-suppressed` — a late reply carrying a

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -39,7 +39,7 @@
     mutation registration; `clear-mutation` owns that separate lifecycle.
 
   Every handler carries framework-write authority
-  (`state/framework-authority-meta`) so a returned `:rf.db/runtime` effect
+  (`rf.resources.state/framework-authority-meta`) so a returned `:rf.db/runtime` effect
   is in-bounds; the registrations live in the `re-frame.resources` façade.
 
   ## Stale suppression (the correctness boundary, as for resources)
@@ -59,21 +59,21 @@
   follow `:on-conflict` (`:invalidate` by default, or explicit `:force`) and may
   refetch authoritative data."
   (:require [clojure.set :as set]
-            [re-frame.interop :as interop]
-            [re-frame.reply :as reply]
-            [re-frame.resources.classification :as rclass]
-            [re-frame.resources.events :as events]
-            [re-frame.resources.mutation-registry :as mreg]
-            [re-frame.resources.mutation-runtime :as mstate]
-            [re-frame.resources.registry :as registry]
-            [re-frame.resources.reply :as rreply]
-            [re-frame.resources.reply-handlers :as reply-handlers]
-            [re-frame.resources.scope-registry :as scope-registry]
-            [re-frame.resources.state :as state]
-            [re-frame.resources.transport :as transport]
-            [re-frame.resources.transport.http :as transport-http]
-            [re-frame.resources.work-ledger :as work-ledger]
-            [re-frame.trace :as trace]))
+            [re-frame.interop :as rf.interop]
+            [re-frame.reply :as rf.reply]
+            [re-frame.resources.classification :as rf.resources.classification]
+            [re-frame.resources.events :as rf.resources.events]
+            [re-frame.resources.mutation-registry :as rf.resources.mutation-registry]
+            [re-frame.resources.mutation-runtime :as rf.resources.mutation-runtime]
+            [re-frame.resources.registry :as rf.resources.registry]
+            [re-frame.resources.reply :as rf.resources.reply]
+            [re-frame.resources.reply-handlers :as rf.resources.reply-handlers]
+            [re-frame.resources.scope-registry :as rf.resources.scope-registry]
+            [re-frame.resources.state :as rf.resources.state]
+            [re-frame.resources.transport :as rf.resources.transport]
+            [re-frame.resources.transport.http :as rf.resources.transport.http]
+            [re-frame.resources.work-ledger :as rf.resources.work-ledger]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -99,10 +99,10 @@
   the resource spec's `:stale-after-ms` / `:gc-after-ms` policy, or nil when
   the resource declares neither (so no `:rf.resource/schedule-timers` fx is
   emitted for that key). Mirrors the read path's
-  `state/positive-or-nil`-guarded delay derivation."
+  `rf.resources.state/positive-or-nil`-guarded delay derivation."
   [resource-spec]
-  (let [stale-delay-ms (state/positive-or-nil (:stale-after-ms resource-spec))
-        gc-delay-ms    (state/positive-or-nil (:gc-after-ms resource-spec))]
+  (let [stale-delay-ms (rf.resources.state/positive-or-nil (:stale-after-ms resource-spec))
+        gc-delay-ms    (rf.resources.state/positive-or-nil (:gc-after-ms resource-spec))]
     (when (or stale-delay-ms gc-delay-ms)
       {:stale-delay-ms stale-delay-ms :gc-delay-ms gc-delay-ms})))
 
@@ -129,11 +129,11 @@
 ;; a `{:from-db …}` named-resolver reference resolved against the settle-time
 ;; app-db (the single use-time rule). This mirrors the invalidation-descriptor
 ;; scope resolution (`resolve-descriptor-scope` below); both share the same
-;; `:rf.scope/same` marker, the same `state/canonicalize-scope` path, and the
+;; `:rf.scope/same` marker, the same `rf.resources.state/canonicalize-scope` path, and the
 ;; same fail-closed nil-resolution discipline.
 
 (defn- resolve-exact-target-scope
-  "Resolve a map-form exact target's DECLARED `:scope` (via `mstate/target-scope`,
+  "Resolve a map-form exact target's DECLARED `:scope` (via `rf.resources.mutation-runtime/target-scope`,
   defaulting `:rf.scope/same`) to a concrete cache scope at settle time, against
   the mutation's resolved scope `mut-scope` and the handler's app-db `db`.
   Returns `[:resolved <concrete-scope>]` or `[:nil-resolved <from-db-id>]` (a
@@ -142,18 +142,18 @@
   concept (an exact target writes ONE key, so there is no scope-agnostic form).
   Per Spec 016 §Map-form exact resource targets / §Resolver references."
   [target mut-scope db where]
-  (let [scope (mstate/target-scope target)]
+  (let [scope (rf.resources.mutation-runtime/target-scope target)]
     (cond
-      (= scope mstate/same-scope-marker)
+      (= scope rf.resources.mutation-runtime/same-scope-marker)
       [:resolved mut-scope]
 
-      (scope-registry/from-db-reference? scope)
-      (if-let [s (scope-registry/resolve-from-db-reference scope db where)]
-        [:resolved (state/canonicalize-scope s where nil)]
+      (rf.resources.scope-registry/from-db-reference? scope)
+      (if-let [s (rf.resources.scope-registry/resolve-from-db-reference scope db where)]
+        [:resolved (rf.resources.state/canonicalize-scope s where nil)]
         [:nil-resolved (:from-db scope)])
 
       :else
-      [:resolved (state/canonicalize-scope scope where nil)])))
+      [:resolved (rf.resources.state/canonicalize-scope scope where nil)])))
 
 ;; ---- the success-time patch / populate / invalidate composition -----------
 
@@ -182,21 +182,21 @@
           ;; (never a wrong-scope write); a RECOVERABLE bad target is
           ;; dropped-and-warned (the valid siblings still land); cache-identity
           ;; CORRUPTION still throws the whole arm.
-          (mstate/validate-target-map!
+          (rf.resources.mutation-runtime/validate-target-map!
             (patches-fn params result)
             #(resolve-exact-target-scope % mut-scope db where)
-            registry/resource-meta :patches where :skip-recoverable))]
+            rf.resources.registry/resource-meta :patches where :skip-recoverable))]
     (if (seq patches)
       (reduce-kv
         (fn [[db' ks policies nils sk] scoped-key patch-fn]
-          (let [entry (get-in db' (state/entry-path scoped-key))]
-            (if (and entry (state/has-data? entry))
-              (let [rspec    (registry/resource-meta (:resource/id entry))
-                    stale-at (state/stale-at-for rspec clock-ms)
-                    entry'   (mstate/patch-entry entry patch-fn result
+          (let [entry (get-in db' (rf.resources.state/entry-path scoped-key))]
+            (if (and entry (rf.resources.state/has-data? entry))
+              (let [rspec    (rf.resources.registry/resource-meta (:resource/id entry))
+                    stale-at (rf.resources.state/stale-at-for rspec clock-ms)
+                    entry'   (rf.resources.mutation-runtime/patch-entry entry patch-fn result
                                                  {:clock-ms clock-ms :stale-at stale-at})
                     delays   (timer-delays rspec)]
-                [(assoc-in db' (state/entry-path scoped-key) entry')
+                [(assoc-in db' (rf.resources.state/entry-path scoped-key) entry')
                  (conj ks scoped-key)
                  (cond-> policies delays (assoc scoped-key delays))
                  nils sk])
@@ -223,24 +223,24 @@
   [runtime-db populates-fn params result clock-ms mut-scope db where]
   (let [[populates nil-ids skipped]
         (when populates-fn
-          (mstate/validate-target-map!
+          (rf.resources.mutation-runtime/validate-target-map!
             (populates-fn params result)
             #(resolve-exact-target-scope % mut-scope db where)
-            registry/resource-meta :populates where :skip-recoverable))]
+            rf.resources.registry/resource-meta :populates where :skip-recoverable))]
     (if (seq populates)
       (reduce-kv
         (fn [[db' ks policies nils sk] scoped-key value]
           (let [[_scope resource-id rparams] scoped-key
-                rspec    (registry/resource-meta resource-id)
-                stale-at (state/stale-at-for rspec clock-ms)
+                rspec    (rf.resources.registry/resource-meta resource-id)
+                stale-at (rf.resources.state/stale-at-for rspec clock-ms)
                 tags-fn  (:tags rspec)
                 tags     (when tags-fn (set (tags-fn rparams value)))
-                entry    (get-in db' (state/entry-path scoped-key))
-                entry'   (mstate/populate-entry entry resource-id value
+                entry    (get-in db' (rf.resources.state/entry-path scoped-key))
+                entry'   (rf.resources.mutation-runtime/populate-entry entry resource-id value
                                                 {:clock-ms clock-ms :stale-at stale-at :tags tags
                                                  :scoped-key scoped-key})
                 delays   (timer-delays rspec)]
-            [(assoc-in db' (state/entry-path scoped-key) entry')
+            [(assoc-in db' (rf.resources.state/entry-path scoped-key) entry')
              (conj ks scoped-key)
              (cond-> policies delays (assoc scoped-key delays))
              nils sk]))
@@ -278,26 +278,26 @@
                     ;; consumes (it threads VALUES — a remove carries none).
                     (cond
                       (nil? raw)                 nil
-                      (mstate/target-map? raw)   {raw ::remove}
+                      (rf.resources.mutation-runtime/target-map? raw)   {raw ::remove}
                       :else                      (into {} (map (fn [t] [t ::remove])) raw))))
         [resolved nil-ids skipped]
         (when (seq targets)
-          (mstate/validate-target-map!
+          (rf.resources.mutation-runtime/validate-target-map!
             targets
             #(resolve-exact-target-scope % mut-scope db where)
-            registry/resource-meta :removes where :skip-recoverable))]
+            rf.resources.registry/resource-meta :removes where :skip-recoverable))]
     (if (seq resolved)
       (reduce-kv
         (fn [[db' ks work nils sk] scoped-key _placeholder]
-          (let [k-id  (state/key-id scoped-key)
-                entry (get-in db' (state/entry-path scoped-key))]
+          (let [k-id  (rf.resources.state/key-id scoped-key)
+                entry (get-in db' (rf.resources.state/entry-path scoped-key))]
             (if entry
               (let [wid       (:current-work entry)
-                    transport (when wid (:transport (work-ledger/get-record db' wid)))]
+                    transport (when wid (:transport (rf.resources.work-ledger/get-record db' wid)))]
                 [(-> db'
-                     (update-in (state/entries-path) dissoc k-id)
-                     (cond-> wid (work-ledger/update-record
-                                   wid work-ledger/mark-terminal
+                     (update-in (rf.resources.state/entries-path) dissoc k-id)
+                     (cond-> wid (rf.resources.work-ledger/update-record
+                                   wid rf.resources.work-ledger/mark-terminal
                                    :cancelled {:reason :mutation-remove})))
                  (conj ks scoped-key)
                  (cond-> work wid (conj [wid transport]))
@@ -312,12 +312,12 @@
 ;; An `:optimistic` / `:optimistic-tags` plan applies a FORWARD patch to the
 ;; resource cache BEFORE the request settles (phase 1.5 of the mutation phase
 ;; order). For each touched entry the runtime SNAPSHOTS the truthful inverse
-;; (`mstate/snapshot-entry` — the whole entry by reference, or the `:absent`
+;; (`rf.resources.mutation-runtime/snapshot-entry` — the whole entry by reference, or the `:absent`
 ;; sentinel) + its `:revision` at apply time, applies the forward patch
-;; (`mstate/apply-optimistic-patch`, which bumps the entry's `:revision`), and
+;; (`rf.resources.mutation-runtime/apply-optimistic-patch`, which bumps the entry's `:revision`), and
 ;; records the inverse on the instance row's `:patch-summary` `:rollback` slot.
 ;; The SETTLE slice (next) consumes that recorded inverse +
-;; `mstate/optimistic-conflict?` (the recorded POST-apply `:applied-revision`)
+;; `rf.resources.mutation-runtime/optimistic-conflict?` (the recorded POST-apply `:applied-revision`)
 ;; to commit / rollback / reconcile.
 ;;
 ;; `:optimistic` is the EXACT-target twin of `:patches` (the same map-form
@@ -357,19 +357,19 @@
   [optimistic-fn params mut-scope db where]
   (if-not optimistic-fn
     [nil []]
-    (mstate/validate-target-map!
+    (rf.resources.mutation-runtime/validate-target-map!
       (optimistic-fn params)
       #(resolve-exact-target-scope % mut-scope db where)
-      registry/resource-meta :optimistic where)))
+      rf.resources.registry/resource-meta :optimistic where)))
 
 (defn- warn-optimistic-tag-descriptor-skipped!
   "DEV-ONLY: emit `:rf.warning/optimistic-tags-descriptor-skipped` for a
   malformed `:optimistic-tags` descriptor that was warn-and-skipped (rf2-o5ca8k).
-  Behind `interop/debug-enabled?` so Closure DCE elides it in production, riding
-  the same `trace/emit!` gate as the other write-side dev tripwires. Returns nil."
+  Behind `rf.interop/debug-enabled?` so Closure DCE elides it in production, riding
+  the same `rf.trace/emit!` gate as the other write-side dev tripwires. Returns nil."
   [{:keys [frame-id mutation]} reason detail]
-  (when interop/debug-enabled?
-    (trace/emit! :warning :rf.warning/optimistic-tags-descriptor-skipped
+  (when rf.interop/debug-enabled?
+    (rf.trace/emit! :warning :rf.warning/optimistic-tags-descriptor-skipped
                  (merge {:rf.frame/id frame-id
                          :mutation    mutation
                          :recovery    :fix-descriptor
@@ -433,8 +433,8 @@
 
                 :else
                 (let [{:keys [scope tags patch]} descriptor]
-                  {:scope (if (contains? descriptor :scope) scope mstate/same-scope-marker)
-                   :tags  (state/normalize-tag-set tags)
+                  {:scope (if (contains? descriptor :scope) scope rf.resources.mutation-runtime/same-scope-marker)
+                   :tags  (rf.resources.state/normalize-tag-set tags)
                    :patch patch})))]
     (cond
       (or (nil? raw) (and (coll? raw) (empty? raw))) []
@@ -456,7 +456,7 @@
   descriptor: resolve its OWN scope (`resolve-descriptor-scope` — `:rf.scope/same`
   / concrete / `{:from-db …}`, FAIL-CLOSED on nil), then match every cache entry
   carrying the descriptor's tags IN that scope (the SHARED
-  `events/match-invalidation-keys` — the same matcher the invalidation engine
+  `rf.resources.events/match-invalidation-keys` — the same matcher the invalidation engine
   uses, EP-0014 one tag index). Each matched entry's scoped key maps to the
   descriptor's `:patch` fn. A later descriptor matching the same key wins
   (last-write). Cross-scope optimistic patching is NOT offered (the optimistic
@@ -473,7 +473,7 @@
           ;; cross-scope is unreachable (a descriptor has no :cross-scope? here)
           :cross-scope  [m nils]
           :resolved
-          (let [{:keys [matched]} (events/match-invalidation-keys
+          (let [{:keys [matched]} (rf.resources.events/match-invalidation-keys
                                     entries scope-or-id false (set tags) #{})]
             [(reduce (fn [m' sk] (assoc m' sk patch)) m matched) nils]))))
     [{} []]
@@ -486,16 +486,16 @@
   [patch-fn before-entry]
   (cond
     (nil? patch-fn)                               :remove
-    (= before-entry mstate/absent-snapshot)       :seed
+    (= before-entry rf.resources.mutation-runtime/absent-snapshot)       :seed
     :else                                         :patch))
 
 (defn- apply-optimistic
   "Apply the resolved optimistic target map `{scoped-key patch-fn-or-nil}` to the
   cache `runtime-db` at execute time (phase 1.5, EP-0019 Decisions 1/2). For each
-  key: SNAPSHOT the entry before (`mstate/snapshot-entry` — the truthful inverse),
-  record `{:resource/key :revision :before :forward}` (`mstate/record-optimistic-
+  key: SNAPSHOT the entry before (`rf.resources.mutation-runtime/snapshot-entry` — the truthful inverse),
+  record `{:resource/key :revision :before :forward}` (`rf.resources.mutation-runtime/record-optimistic-
   entry`), then either DISSOC the entry (a nil patch-fn = optimistic remove) or
-  apply the forward patch + bump revision (`mstate/apply-optimistic-patch`). A
+  apply the forward patch + bump revision (`rf.resources.mutation-runtime/apply-optimistic-patch`). A
   remove of an absent key records the `:absent` inverse and no-ops the cache.
   Returns `[runtime-db' affected-keys inverse-vec]` — `inverse-vec` is the
   recorded `:rollback` slot the instance row carries (in apply order). Indexes are
@@ -503,16 +503,16 @@
   [runtime-db target-map clock-ms]
   (reduce-kv
     (fn [[db' ks inverses] scoped-key patch-fn]
-      (let [entry  (get-in db' (state/entry-path scoped-key))
-            before (mstate/snapshot-entry entry)
+      (let [entry  (get-in db' (rf.resources.state/entry-path scoped-key))
+            before (rf.resources.mutation-runtime/snapshot-entry entry)
             fwd    (forward-summary patch-fn before)
-            inverse (mstate/record-optimistic-entry scoped-key before fwd)
+            inverse (rf.resources.mutation-runtime/record-optimistic-entry scoped-key before fwd)
             db''   (if (nil? patch-fn)
                      ;; optimistic REMOVE — dissoc by the byte key-id
-                     (update-in db' (state/entries-path) dissoc (state/key-id scoped-key))
+                     (update-in db' (rf.resources.state/entries-path) dissoc (rf.resources.state/key-id scoped-key))
                      (let [[_scope resource-id _p] scoped-key
-                           rspec    (registry/resource-meta resource-id)
-                           stale-at (state/stale-at-for rspec clock-ms)
+                           rspec    (rf.resources.registry/resource-meta resource-id)
+                           stale-at (rf.resources.state/stale-at-for rspec clock-ms)
                            tags-fn  (:tags rspec)
                            ;; a freshly-seeded entry needs its resource's tags
                            ;; (so a later invalidation can reach it). An existing
@@ -520,11 +520,11 @@
                            ;; the base entry's tags).
                            [_s _r rparams] scoped-key
                            tags     (when tags-fn (set (tags-fn rparams nil)))
-                           entry'   (mstate/apply-optimistic-patch
+                           entry'   (rf.resources.mutation-runtime/apply-optimistic-patch
                                       entry patch-fn resource-id
                                       {:clock-ms clock-ms :stale-at stale-at
                                        :tags tags :scoped-key scoped-key})]
-                       (assoc-in db' (state/entry-path scoped-key) entry')))]
+                       (assoc-in db' (rf.resources.state/entry-path scoped-key) entry')))]
         [db'' (conj ks scoped-key) (conj inverses inverse)]))
     [runtime-db #{} []]
     target-map))
@@ -532,7 +532,7 @@
 ;; ---- the settle protocol (phase 4) — commit / rollback / reconcile --------
 ;;
 ;; The SETTLE slice (EP-0019 Decision 3) consumes the recorded inverse on the
-;; instance row's `:patch-summary` `:rollback` slot + `mstate/optimistic-conflict?`
+;; instance row's `:patch-summary` `:rollback` slot + `rf.resources.mutation-runtime/optimistic-conflict?`
 ;; (the recorded POST-apply `:applied-revision`) to deterministically dispose
 ;; each optimistic apply when its mutation reply settles:
 ;;
@@ -554,10 +554,10 @@
 ;; These pieces compute the rolled-back runtime-db + the per-key dispositions
 ;; (for the trace + the `:reconciliation-refetches` evidence) + the
 ;; per-conflicted-key exact recovery-refetch fx; the pure decision lives in
-;; `mstate/rollback-entry-disposition` / `mstate/restore-before`.
+;; `rf.resources.mutation-runtime/rollback-entry-disposition` / `rf.resources.mutation-runtime/restore-before`.
 
 (defn- recorded-rollback
-  "The recorded optimistic inverse vector (`mstate/record-optimistic-entry`
+  "The recorded optimistic inverse vector (`rf.resources.mutation-runtime/record-optimistic-entry`
   shapes) the phase-1.5 apply wrote on the live instance's `:patch-summary`
   `:rollback` slot, or nil when this mutation ran no optimistic apply. Read off
   the live instance row (NOT the reply) — the inverse is durable instance state."
@@ -572,13 +572,13 @@
   (`:tags` is OPTIONAL registration metadata and an exact-target optimistic
   write needs none, so tag metadata must not gate rollback recovery —
   rf2-wcdj4). The caller has already marked the surviving entry durably stale
-  in the settle pass (`state/entry-invalidate`); this arms the ordinary exact
+  in the settle pass (`rf.resources.state/entry-invalidate`); this arms the ordinary exact
   refetch ONLY when the entry has ACTIVE OWNERS (a live owner needs fresh data
   now — Spec 016 §Invalidation 3/4). Returns nil when the (moved) entry has
   since vanished or is owner-free — an owner-free entry stays durably stale
   for its next ensure. `scoped-key` is `[scope resource-id params]`."
   [runtime-db scoped-key cause]
-  (let [entry (get-in runtime-db (state/entry-path scoped-key))
+  (let [entry (get-in runtime-db (rf.resources.state/entry-path scoped-key))
         [scope resource-id params] scoped-key]
     (when (and entry (seq (:active-owners entry)))
       [:dispatch [:rf.resource/refetch
@@ -588,9 +588,9 @@
 (defn- settle-optimistic-rollback
   "ROLL BACK the recorded optimistic apply on a FAILED / cancelled / dangled
   mutation reply (EP-0019 Decision 3). For each recorded inverse, decide the
-  conflict-aware disposition (`mstate/rollback-entry-disposition` against the
+  conflict-aware disposition (`rf.resources.mutation-runtime/rollback-entry-disposition` against the
   CURRENT entry + the resolved `on-conflict` policy), then either RESTORE the
-  recorded `:before` verbatim (`mstate/restore-before` — an unmoved revision, or
+  recorded `:before` verbatim (`rf.resources.mutation-runtime/restore-before` — an unmoved revision, or
   `:force`) or keep the moved entry's current owner/work facts, mark it durably
   STALE at its EXACT carried `:resource/key`, and arm the ordinary exact
   refetch when it has active owners — an owner-free entry stays durably stale
@@ -614,8 +614,8 @@
   caller emits `:rf.mutation/optimistic-rolled-back`)."
   [inverse runtime-db on-conflict cause clock-ms]
   (let [dispositions (mapv (fn [{scoped-key :resource/key :as recorded}]
-                             (mstate/rollback-entry-disposition
-                               (get-in runtime-db (state/entry-path scoped-key))
+                             (rf.resources.mutation-runtime/rollback-entry-disposition
+                               (get-in runtime-db (rf.resources.state/entry-path scoped-key))
                                recorded on-conflict))
                            inverse)
         restored?    #(= :restore (:disposition %))
@@ -625,13 +625,13 @@
         ;; moved entry's current owner/work facts, only staling it), so
         ;; reconcile that bounded key set incrementally rather than
         ;; full-rebuilding from all entries.
-        old-entries  (get-in runtime-db (state/entries-path))
-        changed-ids  (mapv (fn [{scoped-key :resource/key}] (state/key-id scoped-key))
+        old-entries  (get-in runtime-db (rf.resources.state/entries-path))
+        changed-ids  (mapv (fn [{scoped-key :resource/key}] (rf.resources.state/key-id scoped-key))
                            inverse)
         ;; apply each disposition to the cache: a :restore restores the recorded
         ;; :before verbatim; an :invalidate KEEPS the moved entry's current
         ;; owner/work facts and marks it durably STALE at its EXACT carried
-        ;; :resource/key (`state/entry-invalidate` — the same in-place exact-key
+        ;; :resource/key (`rf.resources.state/entry-invalidate` — the same in-place exact-key
         ;; staling the EP-0019 restore-dangle reconciler uses), never
         ;; rediscovered through the entry's tags (`:tags` is optional and must
         ;; not gate rollback recovery — rf2-wcdj4). A vanished entry no-ops —
@@ -642,14 +642,14 @@
         [rdb' staled-ks]
                      (reduce (fn [[rdb staled] {scoped-key :resource/key :as disp}]
                                (case (:disposition disp)
-                                 :restore    [(mstate/restore-before rdb disp) staled]
-                                 :invalidate (if (get-in rdb (state/entry-path scoped-key))
-                                               [(update-in rdb (state/entry-path scoped-key)
-                                                           state/entry-invalidate clock-ms)
+                                 :restore    [(rf.resources.mutation-runtime/restore-before rdb disp) staled]
+                                 :invalidate (if (get-in rdb (rf.resources.state/entry-path scoped-key))
+                                               [(update-in rdb (rf.resources.state/entry-path scoped-key)
+                                                           rf.resources.state/entry-invalidate clock-ms)
                                                 (conj staled scoped-key)]
                                                [rdb staled])))
                              [runtime-db []] dispositions)
-        rdb''        (update rdb' state/resources-key state/reindex-keys
+        rdb''        (update rdb' rf.resources.state/resources-key rf.resources.state/reindex-keys
                              old-entries changed-ids)
         ;; one ordinary EXACT refetch per :invalidate (conflicted, non-:force)
         ;; key WITH ACTIVE OWNERS, computed against the ROLLED-BACK runtime-db
@@ -690,7 +690,7 @@
 ;;
 ;; The mutation `:invalidates` arm now lowers TWO public forms — the bare
 ;; tag-set shorthand AND the per-target descriptor form — into ONE canonical
-;; descriptor vector (the pure `mstate/normalize-invalidation-descriptors`),
+;; descriptor vector (the pure `rf.resources.mutation-runtime/normalize-invalidation-descriptors`),
 ;; then resolves each descriptor's OWN scope and dispatches the SINGLE scoped
 ;; invalidation engine (`:rf.resource/invalidate-tags`) once per descriptor.
 ;; The runtime does not re-implement the invalidation — it causes it, once per
@@ -708,18 +708,18 @@
 
     - `:rf.scope/same` (the default) -> the mutation's resolved scope;
     - `:rf.scope/global` / a concrete value -> routed through the SHARED
-      `state/canonicalize-scope` (typo / host / global-spelling guarantees);
+      `rf.resources.state/canonicalize-scope` (typo / host / global-spelling guarantees);
     - `{:from-db <id>}` -> resolved against `db` at use time, nil fail-closed;
     - a `:cross-scope? true` descriptor -> `[:cross-scope]` (scope-agnostic by
       construction; its `:scope`, if any, is advisory only)."
   [{:keys [scope cross-scope?]} mut-scope db where]
   (cond
     cross-scope?                                [:cross-scope]
-    (= scope mstate/same-scope-marker)          [:resolved mut-scope]
-    (scope-registry/from-db-reference? scope)   (if-let [s (scope-registry/resolve-from-db-reference scope db where)]
-                                                  [:resolved (state/canonicalize-scope s where nil)]
+    (= scope rf.resources.mutation-runtime/same-scope-marker)          [:resolved mut-scope]
+    (rf.resources.scope-registry/from-db-reference? scope)   (if-let [s (rf.resources.scope-registry/resolve-from-db-reference scope db where)]
+                                                  [:resolved (rf.resources.state/canonicalize-scope s where nil)]
                                                   [:nil-resolved (:from-db scope)])
-    :else                                       [:resolved (state/canonicalize-scope scope where nil)]))
+    :else                                       [:resolved (rf.resources.state/canonicalize-scope scope where nil)]))
 
 (defn- invalidation-plan
   "Resolve the mutation's `:invalidates` result into the per-descriptor
@@ -748,7 +748,7 @@
   settlement op rather than a new trace op). Per EP-0003 §Mutations / EP-0016 D2."
   [invalidates-fn params result mut-scope db where]
   (when invalidates-fn
-    (let [descriptors (mstate/normalize-invalidation-descriptors
+    (let [descriptors (rf.resources.mutation-runtime/normalize-invalidation-descriptors
                         (invalidates-fn params result) where)]
       (reduce
         (fn [plan {:keys [tags refetch-populated?] :as descriptor}]
@@ -806,7 +806,7 @@
   "The per-descriptor scoped-key evidence the SETTLEMENT path needs from an
   invalidation `plan`, computed against the settle-time cache `entries` (read
   from `runtime-db`) — the SAME match the dispatched `:rf.resource/invalidate-
-  tags` passes will see — via the SHARED pure `events/match-invalidation-keys`
+  tags` passes will see — via the SHARED pure `rf.resources.events/match-invalidation-keys`
   (so the reply, the trace, and the engine never disagree). Returns
   `{:invalidated-keys <vec> :populate-exempt <vec> :per-descriptor [<vec> …]}`:
 
@@ -830,8 +830,8 @@
   (matched by byte `key-id`). Per Spec 016 §Trace evidence for invalidation /
   §Populate is an authoritative load."
   [plan populated-ks runtime-db]
-  (let [populated-ids (into #{} (map state/key-id) populated-ks)
-        entries       (get-in runtime-db (state/entries-path))
+  (let [populated-ids (into #{} (map rf.resources.state/key-id) populated-ks)
+        entries       (get-in runtime-db (rf.resources.state/entries-path))
         sk-by-id      (into {} (map (fn [[k-id e]] [k-id (:resource/key e)])) entries)
         id->sk        (fn [ids] (into [] (keep sk-by-id) ids))
         ;; per dispatch: the keys it will stale (exempt set = the populated keys
@@ -842,12 +842,12 @@
                 (let [tag-set (set tags)
                       exempt  (if refetch-populated? #{} populated-ids)
                       ;; what this descriptor actually stales (exempt removed)
-                      {stale :matched-ids} (events/match-invalidation-keys
+                      {stale :matched-ids} (rf.resources.events/match-invalidation-keys
                                              entries scope cross-scope? tag-set exempt)
                       ;; the populated keys it SPARED (matched with no exempt set)
                       spared  (if refetch-populated?
                                 #{}
-                                (let [{m :matched-ids} (events/match-invalidation-keys
+                                (let [{m :matched-ids} (rf.resources.events/match-invalidation-keys
                                                          entries scope cross-scope? tag-set #{})]
                                   (set/intersection (set m) populated-ids)))]
                   {:stale stale :exempt spared}))
@@ -856,7 +856,7 @@
         exempt-ids (into #{} (mapcat :exempt) per-descriptor)]
     {:invalidated-keys (id->sk stale-ids)
      ;; report by the scoped-key VECTOR, preserving each populated key's spelling
-     :populate-exempt  (into [] (filter (fn [sk] (contains? exempt-ids (state/key-id sk)))) populated-ks)
+     :populate-exempt  (into [] (filter (fn [sk] (contains? exempt-ids (rf.resources.state/key-id sk)))) populated-ks)
      :per-descriptor   (mapv (comp id->sk :exempt) per-descriptor)}))
 
 (defn- plan-trace
@@ -899,7 +899,7 @@
 ;; This is the WRITE-SIDE complement of the read-side `:rf.warning/resource-sub-
 ;; scope-mismatch` (`subs.cljc`): the SAME silent-miss footgun, observed at the
 ;; mutation-settlement boundary. The runtime tripwire reuses the SHARED
-;; `events/match-invalidation-keys` `:other-scope-hit?` signal — a descriptor
+;; `rf.resources.events/match-invalidation-keys` `:other-scope-hit?` signal — a descriptor
 ;; that matched ZERO keys in its resolved scope WHILE the same tags DO match an
 ;; entry in a DIFFERENT scope is a likely scope mismatch (the precise case;
 ;; a tag that simply has no cache entry anywhere does NOT warn — it is a true
@@ -967,19 +967,19 @@
   recoverable tripwire (the asymmetry-fix is not a silent swallow). Cache-identity
   CORRUPTION never reaches here (it throws in the runtime classifier).
 
-  DEV-ONLY: the whole body is behind `interop/debug-enabled?` so Closure DCE
-  elides it in production, and the emit rides `trace/emit!` (same gate). One-shot
+  DEV-ONLY: the whole body is behind `rf.interop/debug-enabled?` so Closure DCE
+  elides it in production, and the emit rides `rf.trace/emit!` (same gate). One-shot
   idempotent per distinct `[mutation-id arm reason resource-id target]` so a
   mutation re-executed repeatedly warns once per genuine bad target. `skipped` is
   the egress-safe `[{:reason :target :resource} …]` vector
   `validate-target-map!`'s `:skip-recoverable` policy returns. Returns nil."
   [skipped {:keys [frame-id mutation-id instance-id arm]}]
-  (when (and interop/debug-enabled? (seq skipped))
+  (when (and rf.interop/debug-enabled? (seq skipped))
     (doseq [{:keys [reason target resource]} skipped]
       (let [dedupe-key [mutation-id arm reason resource target]]
         (when-not (contains? @warned-mutation-target-skipped dedupe-key)
           (swap! warned-mutation-target-skipped conj dedupe-key)
-          (trace/emit! :warning :rf.warning/mutation-target-skipped
+          (rf.trace/emit! :warning :rf.warning/mutation-target-skipped
                        {:rf.frame/id frame-id
                         :mutation    mutation-id
                         :instance    instance-id
@@ -1018,27 +1018,27 @@
   tripwire for the mutation-scope footgun (Spec 016 §Mutation scope is two
   distinct scopes — Scope-match guidance).
 
-  DEV-ONLY: the whole body is behind `interop/debug-enabled?` so Closure DCE
+  DEV-ONLY: the whole body is behind `rf.interop/debug-enabled?` so Closure DCE
   elides it in production (`:advanced` + `goog.DEBUG=false`), and the emit rides
-  `trace/emit!` (same gate). One-shot idempotent per distinct
+  `rf.trace/emit!` (same gate). One-shot idempotent per distinct
   `[mutation-id descriptor-scope other-scope sorted-tags]` so a mutation
   re-executed repeatedly warns once per genuine mismatch.
 
   A `:cross-scope? true` descriptor (the AUDITED deliberate escape) is never
   flagged — it ignores the scope filter by construction, so a 'no match in this
   scope' is impossible / intentional for it. Reuses the SHARED pure
-  `events/match-invalidation-keys` (against the settle-time `entries`), so the
+  `rf.resources.events/match-invalidation-keys` (against the settle-time `entries`), so the
   diagnostic, the dispatched `:rf.resource/invalidate-tags`, and the settlement
   trace never disagree on the match set. Returns nil."
   [plan {:keys [frame-id mutation-id instance-id mut-scope entries]}]
-  (when (and interop/debug-enabled? plan)
+  (when (and rf.interop/debug-enabled? plan)
     (doseq [{:keys [scope cross-scope? tags]} (:dispatches plan)]
       ;; a cross-scope sweep cannot mis-scope; only a scoped descriptor that
       ;; matched nothing-here-but-something-elsewhere is the footgun.
       (when (and (not cross-scope?) (seq tags))
         (let [tag-set (set tags)
               {:keys [matched other-scope-hit?]}
-              (events/match-invalidation-keys entries scope cross-scope? tag-set #{})]
+              (rf.resources.events/match-invalidation-keys entries scope cross-scope? tag-set #{})]
           (when (and (empty? matched) other-scope-hit?)
             (let [other-scope (some (fn [[_k-id entry]]
                                       (let [[s] (:resource/key entry)]
@@ -1049,7 +1049,7 @@
                   dedupe-key  [mutation-id scope other-scope (vec (sort-by pr-str tag-set))]]
               (when-not (contains? @warned-mutation-scope-mismatch dedupe-key)
                 (swap! warned-mutation-scope-mismatch conj dedupe-key)
-                (trace/emit! :warning :rf.warning/mutation-scope-mismatch
+                (rf.trace/emit! :warning :rf.warning/mutation-scope-mismatch
                              {:rf.frame/id        frame-id
                               :mutation           mutation-id
                               :instance           instance-id
@@ -1141,7 +1141,7 @@
   Spec 016 §Phase order) rather than landing while the effect vector is still
   being built."
   [reply-to reply]
-  (when-let [completed (reply/complete reply-to reply)]
+  (when-let [completed (rf.reply/complete reply-to reply)]
     [:dispatch completed]))
 
 (defn- emit-replied!
@@ -1155,7 +1155,7 @@
   when the call site supplied no `:reply-to` (cont-fx is nil)."
   [cont-fx {:keys [frame-id mutation-id instance-id work-id status reply-to]}]
   (when cont-fx
-    (trace/emit! :rf.event :rf.mutation/replied
+    (rf.trace/emit! :rf.event :rf.mutation/replied
                  {:rf.frame/id frame-id :mutation mutation-id :instance instance-id
                   :work/id work-id :status status :target reply-to
                   :cause [:mutation mutation-id instance-id]})))
@@ -1173,8 +1173,8 @@
   references): a CONCRETE scope value OR a `{:from-db <resolver-id>}`
   named-resolver reference, resolved against this handler's app-db coeffect
   at event-execution time — SYMMETRIC with ensure / clear-scope /
-  invalidate-tags (`scope-registry/resolve-scope-input`, via
-  `mreg/resolve-scope`). A supplied reference that resolves NIL is
+  invalidate-tags (`rf.resources.scope-registry/resolve-scope-input`, via
+  `rf.resources.mutation-registry/resolve-scope`). A supplied reference that resolves NIL is
   FAIL-CLOSED with `:rf.error/resource-scope-unresolved-reference` (execute
   is scope-requiring for a supplied reference — never a fall-through to the
   global default); an unregistered resolver id throws
@@ -1209,12 +1209,12 @@
    [_event-id {:keys [mutation instance scope cause reply-to] :as payload}]]
   (let [where      'rf.mutation/execute
         runtime-db (or rt {})
-        spec       (mreg/require-mutation-spec! mutation where)
+        spec       (rf.resources.mutation-registry/require-mutation-spec! mutation where)
         ;; rf2-hgy5kf — thread `:params` presence (absent vs explicit nil) to
         ;; the validation boundary: an absent slot defaults to `{}` there, an
         ;; explicit `{:params nil}` reaches `:params-schema` unchanged.
-        cparams    (mreg/validate+canonicalize-params
-                     mutation spec (state/params-present? payload) where)
+        cparams    (rf.resources.mutation-registry/validate+canonicalize-params
+                     mutation spec (rf.resources.state/params-present? payload) where)
         ;; rf2-l11670 — the payload / spec :scope is a public ScopeInput: a
         ;; concrete scope OR a `{:from-db <id>}` named-resolver reference,
         ;; resolved against THIS handler's app-db coeffect at event-execution
@@ -1227,13 +1227,13 @@
         ;; invalidation plans, continuation reply) sees only the RESOLVED
         ;; concrete scope. An ABSENT :scope keeps the documented fail-open
         ;; :rf.scope/global default.
-        cscope     (mreg/resolve-scope mutation spec scope app-db)
+        cscope     (rf.resources.mutation-registry/resolve-scope mutation spec scope app-db)
         ;; rf2-e8wj5t — reject a non-serializable caller-supplied instance id
         ;; BEFORE any runtime-db / work-ledger write or HTTP lowering (the
         ;; instance id is durable + trace-visible + epoch-restore-safe). A nil
         ;; instance falls through to the generated id (serializable by
         ;; construction).
-        _          (mstate/validate-instance-id! instance where)
+        _          (rf.resources.mutation-runtime/validate-instance-id! instance where)
         ;; rf2-6kdcs9 — the call-site `:reply-to` continuation (EP-0016 D1) is
         ;; a TRANSPORT-PAYLOAD-only app target (NOT a durable ledger row fact),
         ;; but it MUST still be data-only: it rides the internal reply payload
@@ -1245,7 +1245,7 @@
         ;; mis-delivering (or stranding a non-serializable value on the wire)
         ;; at completion. A nil target stays nil (no continuation). The
         ;; data-only-validated target rides the `:reply-payload` below.
-        reply-to'  (when (some? reply-to) (reply/durable-target reply-to))
+        reply-to'  (when (some? reply-to) (rf.reply/durable-target reply-to))
         ;; rf2-abyycr — the generation is the RECORDED allocation value (the
         ;; generator-backed `:rf.resource/generation-allocation` cofx minted
         ;; it at processing-start and the runtime recorded it on the token),
@@ -1260,7 +1260,7 @@
         ;; re-execute under the same instance id mints a NEW work-id (stale
         ;; suppression keys on it). The scoped "key" for a mutation is the
         ;; instance id (no cache identity — a write is not cached by params).
-        work-id    (work-ledger/resource-work-id [:rf.mutation instance-id] generation)
+        work-id    (rf.resources.work-ledger/resource-work-id [:rf.mutation instance-id] generation)
         ;; rf2-sxyrzk — the transport correlation token is the frame-QUALIFIED
         ;; request-id, NOT the bare work-id. The managed-HTTP in-flight registry
         ;; keys by request-id PROCESS-GLOBALLY and supersedes by equal
@@ -1268,7 +1268,7 @@
         ;; frames executing the same mutation instance at the same generation
         ;; would collide on a bare work-id and abort/supersede each other's
         ;; in-flight write. Qualifying with the frame id isolates them.
-        request-id (work-ledger/managed-request-id frame-id work-id)
+        request-id (rf.resources.work-ledger/managed-request-id frame-id work-id)
         ;; EP-0010 §Resources, Mutations, And Work-Ledger Timestamps + EP-0017
         ;; declared-only delivery (rf2-601ife): `:rf.mutation/execute` writes the
         ;; durable instance + work-ledger `:started-at` from the TRIGGERING
@@ -1277,7 +1277,7 @@
         ;; ambient clock read in the reducer. Replay-stable: the same execute
         ;; token mints the same `:started-at`.
         started-at time-ms
-        transport-id (or (:transport spec) transport/default-transport)
+        transport-id (or (:transport spec) rf.resources.transport/default-transport)
         ;; the mutation's :request returns the Spec 014 managed-HTTP args
         ;; (the causal write); the runtime owns reply addressing.
         http-args  ((:request spec) cparams nil)
@@ -1294,11 +1294,11 @@
         ;; (Rider 1 is a success-path concept).
         before-fxs  (when before-plan
                       (plan->fx before-plan [:mutation mutation instance-id] #{}))
-        instance'  (mstate/empty-instance
+        instance'  (rf.resources.mutation-runtime/empty-instance
                      mutation instance-id
                      {:scope cscope :params cparams :cause cause
                       :generation generation :work-id work-id :started-at started-at})
-        record     (-> (work-ledger/work-record
+        record     (-> (rf.resources.work-ledger/work-record
                          {:work-id      work-id
                           :frame-id     frame-id
                           :resource/key [:rf.mutation instance-id]
@@ -1313,10 +1313,10 @@
         ;; Guard the declared transport (registration-time misconfig throw),
         ;; then lower directly into the only built-in
         ;; transport. The one-arm dispatch indirection
-        ;; (`transport/lower-ensure`) is folded into this guarded call.
+        ;; (`rf.resources.transport/lower-ensure`) is folded into this guarded call.
         lower-fx   (do
-                     (transport/assert-managed-transport! transport-id where)
-                     (transport-http/lower
+                     (rf.resources.transport/assert-managed-transport! transport-id where)
+                     (rf.resources.transport.http/lower
                      {:http-args    http-args
                       :request-id   request-id
                       ;; the reply addresses the MUTATION internal replies,
@@ -1350,8 +1350,8 @@
                       :generation   generation
                       :where        where}))
         rdb0       (-> runtime-db
-                       (assoc-in (mstate/instance-path instance-id) instance')
-                       (work-ledger/put-record work-id record))
+                       (assoc-in (rf.resources.mutation-runtime/instance-path instance-id) instance')
+                       (rf.resources.work-ledger/put-record work-id record))
         ;; EP-0019 PHASE 1.5 — the FORWARD optimistic apply, BEFORE the request
         ;; lowers. Per-call opt-out (Q4): `{:optimistic? false}` forces the
         ;; pessimistic path for one call (the registration plan is otherwise
@@ -1366,7 +1366,7 @@
         opt-out?    (and (contains? payload :optimistic?) (false? (:optimistic? payload)))
         has-opt?    (and (not opt-out?)
                          (or (:optimistic spec) (:optimistic-tags spec)))
-        opt-entries (when has-opt? (get-in rdb0 (state/entries-path)))
+        opt-entries (when has-opt? (get-in rdb0 (rf.resources.state/entries-path)))
         [exact-tm exact-nils]
         (when has-opt?
           (optimistic-exact-targets (:optimistic spec) cparams cscope app-db where))
@@ -1399,7 +1399,7 @@
         ;; ALL targets dropped — the evidence must survive).
         rdb'       (if opt-applied?
                      (-> rdb1
-                         (assoc-in (conj (mstate/instance-path instance-id) :patch-summary)
+                         (assoc-in (conj (rf.resources.mutation-runtime/instance-path instance-id) :patch-summary)
                                    {:snapshot-id       snapshot-id
                                     :rollback          opt-inverse
                                     :optimistic-keys   (vec opt-ks)
@@ -1411,11 +1411,11 @@
                          ;; members change, so reconcile that bounded set
                          ;; incrementally (against the pre-apply `opt-entries`)
                          ;; rather than full-rebuilding from all entries.
-                         (update state/resources-key state/reindex-keys
-                                 opt-entries (mapv state/key-id opt-ks)))
+                         (update rf.resources.state/resources-key rf.resources.state/reindex-keys
+                                 opt-entries (mapv rf.resources.state/key-id opt-ks)))
                      rdb1)]
     (when opt-applied?
-      (trace/emit! :rf.event :rf.mutation/optimistic-applied
+      (rf.trace/emit! :rf.event :rf.mutation/optimistic-applied
                    {:rf.frame/id frame-id :mutation mutation :instance instance-id
                     :work/id work-id :generation generation :scope cscope
                     :snapshot-id snapshot-id
@@ -1428,7 +1428,7 @@
                     :tag-matched-keys (vec (keys tag-tm))
                     :target-unresolved (vec opt-nil-ids)
                     :cause [:mutation mutation instance-id]}))
-    (trace/emit! :rf.event :rf.mutation/started
+    (rf.trace/emit! :rf.event :rf.mutation/started
                  (cond-> {:rf.frame/id frame-id :mutation mutation :instance instance-id
                           :work/id work-id :generation generation :scope cscope
                           :cause cause :invalidate-timing invalidate-timing}
@@ -1443,7 +1443,7 @@
     ;; execute-time runtime-db entries (the cache state before the write).
     (maybe-warn-scope-mismatch!
       before-plan {:frame-id frame-id :mutation-id mutation :instance-id instance-id
-                   :mut-scope cscope :entries (get-in runtime-db (state/entries-path))})
+                   :mut-scope cscope :entries (get-in runtime-db (rf.resources.state/entries-path))})
     {:rf.db/runtime rdb'
      ;; rf2-agrjvk — `:before-request` invalidation must precede the request
      ;; being lowered to transport. fx run in order, so the invalidation
@@ -1476,7 +1476,7 @@
   row terminal `:cancelled`."
   [{rt :rf.db/runtime, frame-id :rf.frame/id} [_event-id {:keys [instance mutation]}]]
   (let [runtime-db (or rt {})
-        instances  (get-in runtime-db (mstate/instances-path))
+        instances  (get-in runtime-db (rf.resources.mutation-runtime/instances-path))
         ;; rf2-8iciw8 — the `:rf.runtime/mutations` map is keyed on the CEDN-1
         ;; byte `key-id`; the storage targets (`dissoc` / `get`) MUST be those
         ;; byte key-ids, never the raw caller-supplied instance id (which is
@@ -1484,7 +1484,7 @@
         ;; `:instance` is matched by its OWN byte key-id so a `[:row 7]` clear
         ;; does NOT also gate a CEDN-distinct `'(:row 7)` row.
         target-kids (cond
-                      (some? instance) (let [k (mstate/instance-key-id instance)]
+                      (some? instance) (let [k (rf.resources.mutation-runtime/instance-key-id instance)]
                                          (when (contains? instances k) [k]))
                       (some? mutation) (keep (fn [[kid inst]]
                                                (when (= mutation (:mutation/id inst)) kid))
@@ -1497,27 +1497,27 @@
                                  (let [inst (get instances kid)
                                        wid  (:current-work inst)]
                                    (when wid
-                                     [wid (:transport (work-ledger/get-record runtime-db wid))]))))
+                                     [wid (:transport (rf.resources.work-ledger/get-record runtime-db wid))]))))
                          target-kids)
         rdb'       (-> runtime-db
-                       (update-in (mstate/instances-path)
+                       (update-in (rf.resources.mutation-runtime/instances-path)
                                   (fn [m] (reduce dissoc m target-kids)))
                        (as-> db (reduce (fn [d [wid _]]
-                                          (work-ledger/update-record
-                                            d wid work-ledger/mark-terminal
+                                          (rf.resources.work-ledger/update-record
+                                            d wid rf.resources.work-ledger/mark-terminal
                                             :cancelled {:reason :mutation-clear}))
                                         db in-flight)))
         ;; surface the kind-preserving `:instance/id` values in the trace (the
         ;; byte key-ids are an opaque storage detail), read off the rows BEFORE
         ;; they were dissoc'd.
         cleared-ids (mapv #(:instance/id (get instances %)) target-kids)]
-    (trace/emit! :rf.event :rf.mutation/cleared
+    (rf.trace/emit! :rf.event :rf.mutation/cleared
                  {:rf.frame/id frame-id :cleared cleared-ids
                   :aborted (mapv first in-flight)})
     {:rf.db/runtime rdb'
      ;; rf2-sxyrzk — abort by the frame-QUALIFIED request-id (the token the
      ;; lower registered); the bare work-id would miss the in-flight request.
-     :fx (into [] (keep (fn [[wid transport]] (work-ledger/abort-fx transport frame-id wid)))
+     :fx (into [] (keep (fn [[wid transport]] (rf.resources.work-ledger/abort-fx transport frame-id wid)))
                in-flight)}))
 
 ;; ---- framework-internal reply handlers ------------------------------------
@@ -1538,7 +1538,7 @@
   mutation instance at the reply's `:instance-id`. Used by the shared
   `reply-handlers` verifier + current-generation reader."
   [{:keys [instance-id]}]
-  (mstate/instance-path instance-id))
+  (rf.resources.mutation-runtime/instance-path instance-id))
 
 (defn- mutation-correlation
   "The mutation family's stale-reply diagnostic correlation keys (beyond the
@@ -1552,45 +1552,45 @@
 
 (def ^:private mutation-stale-knobs
   "The mutation family's stale-suppress knobs for
-  `reply-handlers/stale-suppress-reply`: `:work-kind`, `:stale-reason`, and
+  `rf.resources.reply-handlers/stale-suppress-reply`: `:work-kind`, `:stale-reason`, and
   the `:correlation-fn`."
-  {:work-kind      rreply/work-kind-mutation
+  {:work-kind      rf.resources.reply/work-kind-mutation
    :stale-reason   :rf.mutation/superseded
    :correlation-fn mutation-correlation})
 
 (defn- live-instance-for-reply
   "Look the live mutation instance up for an internal reply via the SHARED
-  `reply-handlers/live-slot-for-reply` (frame + work-id + generation
+  `rf.resources.reply-handlers/live-slot-for-reply` (frame + work-id + generation
   verification against the mutation instance at the reply's `:instance-id`).
   Returns the instance on a match, nil on a cross-frame / stale / superseded /
   cleared reply (which MUST be suppressed). Mirrors the resource
   `live-entry-for-reply` (the shared substrate is identical; only the slot
   path-fn differs)."
   [runtime-db receiving-frame-id payload]
-  (reply-handlers/live-slot-for-reply
+  (rf.resources.reply-handlers/live-slot-for-reply
     runtime-db receiving-frame-id instance-path-for-reply payload))
 
 (defn- stale-suppress-reply
   "Build the canonical `:status :stale` reply outcome for a superseded /
   cleared MUTATION reply through the SHARED `reply-handlers` substrate (which
-  lowers through `rreply/stale-reply`), so the mutation family lowers its stale
+  lowers through `rf.resources.reply/stale-reply`), so the mutation family lowers its stale
   outcome exactly as the resource family + every other managed-async family
   does (Managed-Effects §Stale suppression). `extra` threads diagnostic facts
   (e.g. `:outcome`) onto the stale reply."
   [runtime-db payload extra]
-  (reply-handlers/stale-suppress-reply
+  (rf.resources.reply-handlers/stale-suppress-reply
     runtime-db instance-path-for-reply payload mutation-stale-knobs extra))
 
 (defn- emit-mutation-stale-suppressed!
   "Emit the `:rf.mutation/stale-suppressed` trace for a suppressed late
-  mutation reply via the SHARED `reply-handlers/emit-stale-suppressed!`,
+  mutation reply via the SHARED `rf.resources.reply-handlers/emit-stale-suppressed!`,
   carrying the mutation bespoke facts (`:instance` / `:generation` /
   `:outcome`) PLUS the canonical reply-envelope vocabulary ADDITIVELY
   (Managed-Effects §Tracing / EP-0011 / rf2-waawic). The work identity rides
   ONLY as `:rf.reply/work-id` (one name per fact — rf2-o6c2jr dropped the bare
   `:work/id` duplicate the additive vocabulary already carries)."
   [frame-id instance-id _work-id generation outcome stale]
-  (reply-handlers/emit-stale-suppressed!
+  (rf.resources.reply-handlers/emit-stale-suppressed!
     :rf.mutation/stale-suppressed
     {:rf.frame/id frame-id :instance instance-id
      :generation generation :outcome outcome}
@@ -1633,7 +1633,7 @@
   A stale / superseded / cleared reply is SUPPRESSED. Per EP-0003
   §Mutations; EP-0011 §Mutation Reply.
 
-  The reply is re-lifted into the canonical reply map (`rreply/success-reply`
+  The reply is re-lifted into the canonical reply map (`rf.resources.reply/success-reply`
   with `:work/kind :mutation`); the decoded result rides as `:value` (the
   reply-map spelling) and is stored under the instance's durable `:result`
   (the instance-layer spelling — kh9jz6 / EP-0007).
@@ -1656,8 +1656,8 @@
         ;; the ONE canonical reply map (Managed-Effects §The uniform reply
         ;; envelope), `:work/kind :mutation`. The internal mutation reply
         ;; target receives it directly; the decoded result is `:value`.
-        reply      (rreply/success-reply payload (rreply/transport-success-value payload http-result :result)
-                                         {:work-kind rreply/work-kind-mutation
+        reply      (rf.resources.reply/success-reply payload (rf.resources.reply/transport-success-value payload http-result :result)
+                                         {:work-kind rf.resources.reply/work-kind-mutation
                                           :completed-at completed-at})
         result     (:value reply)
         inst       (live-instance-for-reply runtime-db frame-id payload)]
@@ -1673,11 +1673,11 @@
       (let [stale (stale-suppress-reply runtime-db payload {:outcome :success})]
         (emit-mutation-stale-suppressed!
           frame-id instance-id work-id generation :success stale)
-        (work-ledger/clear-handle! frame-id work-id)
-        {:rf.db/runtime (work-ledger/update-record
-                          runtime-db work-id work-ledger/mark-terminal
+        (rf.resources.work-ledger/clear-handle! frame-id work-id)
+        {:rf.db/runtime (rf.resources.work-ledger/update-record
+                          runtime-db work-id rf.resources.work-ledger/mark-terminal
                           :suppressed {:reason :stale-reply :outcome :success})})
-      (let [spec        (mreg/mutation-meta mutation-id)
+      (let [spec        (rf.resources.mutation-registry/mutation-meta mutation-id)
             params      (:params inst)
             timing      (or (:invalidate-timing spec) :after-success)
             ;; EP-0010: the terminal mutation reply writes `:settled-at` from
@@ -1804,7 +1804,7 @@
                                    :rollback    (:rollback opt-summary)
                                    :committed   committed-keys
                                    :reconciliation-refetches reconciliation-refetches))
-            inst'       (mstate/instance-succeeded
+            inst'       (rf.resources.mutation-runtime/instance-succeeded
                           inst {:result result :settled-at clock-ms
                                 :affected-keys affected :patch-summary patch-summary})
             ;; rf2-2c2mkh — the cache consequences (apply-patches /
@@ -1815,15 +1815,15 @@
             ;; rides a separate dispatched `:rf.resource/invalidate-tags`, which
             ;; marks entries stale without touching `:tags` / `:active-owners`,
             ;; so it never perturbs the indexes.)
-            old-entries (get-in runtime-db (state/entries-path))
+            old-entries (get-in runtime-db (rf.resources.state/entries-path))
             rdb'        (-> rdb3
-                            (assoc-in (mstate/instance-path instance-id) inst')
-                            (work-ledger/update-record
-                              work-id work-ledger/mark-terminal
+                            (assoc-in (rf.resources.mutation-runtime/instance-path instance-id) inst')
+                            (rf.resources.work-ledger/update-record
+                              work-id rf.resources.work-ledger/mark-terminal
                               :completed {:settled-at clock-ms})
-                            (update state/resources-key state/reindex-keys
+                            (update rf.resources.state/resources-key rf.resources.state/reindex-keys
                                     old-entries
-                                    (mapv state/key-id authoritative-keys)))
+                                    (mapv rf.resources.state/key-id authoritative-keys)))
             ;; arm the advisory stale / GC timers (host-side side table) for
             ;; every patched / populated key carrying a policy — one
             ;; `:rf.resource/schedule-timers` fx per key, mirroring the
@@ -1834,7 +1834,7 @@
             ;; populated ownerless entry would carry a durable :stale-at /
             ;; :gc-after-ms policy but NO armed reaper. Per Spec 016 §Stale
             ;; and GC scheduling.
-            server?     (state/server-frame? frame-id)
+            server?     (rf.resources.state/server-frame? frame-id)
             timer-fx    (mapv (fn [[scoped-key {:keys [stale-delay-ms gc-delay-ms]}]]
                                 [:rf.resource/schedule-timers
                                  {:frame-id     frame-id
@@ -1869,7 +1869,7 @@
                           ;; and dispatches into app workflow. The durable
                           ;; instance keeps the raw value (the success-path
                           ;; `:invalidates` / `:patches` above already read it).
-                          (rclass/redact-continuation-reply
+                          (rf.resources.classification/redact-continuation-reply
                             (continuation-reply
                               reply {:mutation-id mutation-id :params params
                                      :instance-id instance-id :scope scope
@@ -1883,13 +1883,13 @@
             ;; mirroring `:rf.resource/remove`. Stale suppression by work-id +
             ;; generation remains the correctness boundary.
             remove-abort-fx (into [] (keep (fn [[wid transport]]
-                                             (work-ledger/abort-fx transport frame-id wid)))
+                                             (rf.resources.work-ledger/abort-fx transport frame-id wid)))
                                   removed-work)
             remove-timer-fx (when (seq removed-ks)
                               [[:rf.resource/cancel-timers
                                 {:frame-id frame-id :resource/keys (vec removed-ks)}]])]
-        (work-ledger/clear-handle! frame-id work-id)
-        (trace/emit! :rf.event :rf.mutation/succeeded
+        (rf.resources.work-ledger/clear-handle! frame-id work-id)
+        (rf.trace/emit! :rf.event :rf.mutation/succeeded
                      (cond-> {:rf.frame/id frame-id :instance instance-id :mutation mutation-id
                               :work/id work-id :generation generation
                               :affected-keys affected :patch-summary patch-summary}
@@ -1912,7 +1912,7 @@
         ;; refetches). The recorded inverse was DISCARDED (the commit superseded
         ;; it — no rollback on success).
         (when opt-applied?
-          (trace/emit! :rf.event :rf.mutation/optimistic-reconciled
+          (rf.trace/emit! :rf.event :rf.mutation/optimistic-reconciled
                        {:rf.frame/id frame-id :instance instance-id :mutation mutation-id
                         :work/id work-id :generation generation
                         :snapshot-id (:snapshot-id opt-summary)
@@ -1929,7 +1929,7 @@
         ;; entries the dispatched invalidate-tags will themselves see).
         (maybe-warn-scope-mismatch!
           inv-plan {:frame-id frame-id :mutation-id mutation-id :instance-id instance-id
-                    :mut-scope scope :entries (get-in rdb3 (state/entries-path))})
+                    :mut-scope scope :entries (get-in rdb3 (rf.resources.state/entries-path))})
         ;; DEV-ONLY drop-and-warn tripwire (rf2-1vpbld) — for each RECOVERABLE
         ;; post-write `:patches` / `:populates` / `:removes` target the relaxed
         ;; settle policy DROPPED (unregistered resource / non-map / non-keyword
@@ -1965,7 +1965,7 @@
   EP-0011 §Mutation Reply.
 
   The failure is re-lifted into the canonical reply map
-  (`rreply/failure-reply` with `:rf.reply/work-kind :mutation` — `:status :error`
+  (`rf.resources.reply/failure-reply` with `:rf.reply/work-kind :mutation` — `:status :error`
   carrying the `:rf.http/*` envelope under `:error`, or `:status :cancelled`
   for an abort). The `:error` envelope (the same closed shape the instance
   `:error` stores) is read back from the canonical reply.
@@ -1987,8 +1987,8 @@
         ;; the ONE canonical reply map (Managed-Effects §The uniform reply
         ;; envelope), `:work/kind :mutation`. `:error` carries the closed
         ;; `:rf.http/*` envelope the instance `:error` also stores.
-        reply      (rreply/failure-reply payload (rreply/transport-failure-envelope payload http-result)
-                                         {:work-kind rreply/work-kind-mutation
+        reply      (rf.resources.reply/failure-reply payload (rf.resources.reply/transport-failure-envelope payload http-result)
+                                         {:work-kind rf.resources.reply/work-kind-mutation
                                           :completed-at completed-at})
         error      (:error reply)
         ;; rf2-qsn30x (EP-0011 §Status taxonomy / §Work-status mapping): an
@@ -2015,11 +2015,11 @@
       (let [stale (stale-suppress-reply runtime-db payload {:outcome :failure})]
         (emit-mutation-stale-suppressed!
           frame-id instance-id work-id generation :failure stale)
-        (work-ledger/clear-handle! frame-id work-id)
-        {:rf.db/runtime (work-ledger/update-record
-                          runtime-db work-id work-ledger/mark-terminal
+        (rf.resources.work-ledger/clear-handle! frame-id work-id)
+        {:rf.db/runtime (rf.resources.work-ledger/update-record
+                          runtime-db work-id rf.resources.work-ledger/mark-terminal
                           :suppressed {:reason :stale-reply :outcome :failure})})
-      (let [spec     (mreg/mutation-meta mutation-id)
+      (let [spec     (rf.resources.mutation-registry/mutation-meta mutation-id)
             params   (:params inst)
             timing   (or (:invalidate-timing spec) :after-success)
             ;; EP-0010: the terminal failure reply writes `:settled-at` from
@@ -2042,7 +2042,7 @@
             ;; failure-time invalidation so that pass reads the ROLLED-BACK cache.
             ;; A purely-pessimistic mutation (no recorded inverse) skips this.
             rollback-inverse (recorded-rollback inst)
-            on-conflict      (mstate/on-conflict-policy spec)
+            on-conflict      (rf.resources.mutation-runtime/on-conflict-policy spec)
             rolled  (when rollback-inverse
                       (settle-optimistic-rollback rollback-inverse runtime-db on-conflict
                                                   cause clock-ms))
@@ -2091,12 +2091,12 @@
                                     :rollback                 (rollback-trace-dispositions
                                                                 (:dispositions rolled) on-conflict)
                                     :reconciliation-refetches refetched-ks))
-            inst'    (cond-> (mstate/instance-failed
+            inst'    (cond-> (rf.resources.mutation-runtime/instance-failed
                                inst {:error error :settled-at clock-ms
                                      :affected-keys affected})
                        rolled-summary (assoc :patch-summary rolled-summary))
             rdb'     (-> settle-db
-                         (assoc-in (mstate/instance-path instance-id) inst')
+                         (assoc-in (rf.resources.mutation-runtime/instance-path instance-id) inst')
                          ;; rf2-qsn30x: the ledger row settles `:cancelled` for
                          ;; an accepted abort (the reply lowered it to
                          ;; `:status :cancelled`), else `:failed`. The outcome
@@ -2105,8 +2105,8 @@
                          ;; an abort is not a user-visible failure) so the
                          ;; ledger status and the canonical reply `:rf.reply/work-status`
                          ;; agree (Managed-Effects §Status taxonomy).
-                         (work-ledger/update-record
-                           work-id work-ledger/mark-terminal
+                         (rf.resources.work-ledger/update-record
+                           work-id rf.resources.work-ledger/mark-terminal
                            (:rf.reply/work-status reply)
                            (if aborted?
                              {:reason :aborted :completed-at completed-at}
@@ -2129,19 +2129,19 @@
                        ;; scope subpaths on the failure continuation echo too
                        ;; (an accepted `:error` / `:cancelled` reply dispatches
                        ;; `:reply-to`). Derived from the mutation spec.
-                       (rclass/redact-continuation-reply
+                       (rf.resources.classification/redact-continuation-reply
                          (continuation-reply
                            reply {:mutation-id mutation-id :params params
                                   :instance-id instance-id :scope scope
                                   :affected-keys affected})
                          spec))]
-        (work-ledger/clear-handle! frame-id work-id)
+        (rf.resources.work-ledger/clear-handle! frame-id work-id)
         ;; EP-0019 — the optimistic rollback trace (phase 4, error/cancel).
         ;; Carries the snapshot id, per-key restored-vs-conflict disposition (the
         ;; `:on-conflict` rule applied on a conflict), and the refetched keys.
         ;; Emitted only when this mutation ran an optimistic apply.
         (when rolled
-          (trace/emit! :rf.event :rf.mutation/optimistic-rolled-back
+          (rf.trace/emit! :rf.event :rf.mutation/optimistic-rolled-back
                        {:rf.frame/id frame-id :instance instance-id :mutation mutation-id
                         :work/id work-id :generation generation
                         :snapshot-id (-> inst :patch-summary :snapshot-id)
@@ -2156,7 +2156,7 @@
           ;; concurrent authoritative write — the deliberate single-writer
           ;; escape, but a tooling warning so an unexpected clobber is loud.
           (when (and (= :force on-conflict) (seq (:conflicted-keys rolled)))
-            (trace/emit! :warning :rf.warning/optimistic-force-clobber
+            (rf.trace/emit! :warning :rf.warning/optimistic-force-clobber
                          {:rf.frame/id frame-id :instance instance-id :mutation mutation-id
                           :forced-keys (vec (:conflicted-keys rolled))
                           :recovery :review-on-conflict
@@ -2171,7 +2171,7 @@
                                        "written concurrently, use the :invalidate default "
                                        "(refetch the authoritative value on conflict). Per "
                                        "Spec 016 §Optimistic settle / EP-0019 Decision 3.")})))
-        (trace/emit! :rf.event :rf.mutation/failed
+        (rf.trace/emit! :rf.event :rf.mutation/failed
                      (cond-> {:rf.frame/id frame-id :instance instance-id :mutation mutation-id
                               :work/id work-id :generation generation :error error
                               :affected-keys affected
@@ -2188,7 +2188,7 @@
         ;; the ROLLED-BACK settle-time entries the dispatched invalidate-tags see.
         (maybe-warn-scope-mismatch!
           inv-plan {:frame-id frame-id :mutation-id mutation-id :instance-id instance-id
-                    :mut-scope scope :entries (get-in settle-db (state/entries-path))})
+                    :mut-scope scope :entries (get-in settle-db (rf.resources.state/entries-path))})
         ;; PHASE 6 evidence — emitted AFTER `:rf.mutation/failed` so the
         ;; `:rf.mutation/replied` row truthfully follows settlement in the phase
         ;; order (rf2-ru73k6 F2). No-op when no `:reply-to` continued.

--- a/implementation/resources/src/re_frame/resources/mutation_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_registry.cljc
@@ -17,13 +17,13 @@
   family. Both delegate params validation and canonicalization to
   `re-frame.resources.params`; mutation scope normalization uses the shared
   concrete-scope boundary in `re-frame.resources.state`."
-  (:require [re-frame.error :as error]
-            [re-frame.registrar :as registrar]
-            [re-frame.resources.classification :as classification]
-            [re-frame.resources.mutation-runtime :as mstate]
-            [re-frame.resources.params :as params]
-            [re-frame.resources.scope-registry :as scope-registry]
-            [re-frame.source-coords :as source-coords]))
+  (:require [re-frame.error :as rf.error]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.resources.classification :as rf.resources.classification]
+            [re-frame.resources.mutation-runtime :as rf.resources.mutation-runtime]
+            [re-frame.resources.params :as rf.resources.params]
+            [re-frame.resources.scope-registry :as rf.resources.scope-registry]
+            [re-frame.source-coords :as rf.source-coords]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -49,7 +49,7 @@
   "Build the canonical thrown-error shape (Spec 009 §The thrown-error
   shape) for a `reg-mutation` validation failure."
   [error-id where reason extra]
-  (error/thrown-ex-info
+  (rf.error/thrown-ex-info
     error-id
     where
     reason
@@ -151,13 +151,13 @@
   ;; would then NOT clobber a concurrent write as the author expected). Reject
   ;; it loudly at the authoring boundary. Per Spec 016 §Optimistic settle.
   (let [oc (:on-conflict spec)]
-    (when (and (some? oc) (not (contains? mstate/on-conflict-policies oc)))
+    (when (and (some? oc) (not (contains? rf.resources.mutation-runtime/on-conflict-policies oc)))
       (throw (registration-error
                :rf.error/mutation-bad-spec
                'rf/reg-mutation
                (str "mutation " mutation-id " declares an :on-conflict of "
                     (pr-str oc) " outside the closed enum "
-                    (pr-str (sort mstate/on-conflict-policies)) ". A typo "
+                    (pr-str (sort rf.resources.mutation-runtime/on-conflict-policies)) ". A typo "
                     "(e.g. :invlaidate, or a mistyped :force) would register "
                     "cleanly and then silently fall back to the default "
                     ":invalidate rollback rule at settle time, masking the "
@@ -165,13 +165,13 @@
                     "EP-0019 Decision 3.")
                {:mutation-id mutation-id
                 :on-conflict oc
-                :valid       mstate/on-conflict-policies}))))
+                :valid       rf.resources.mutation-runtime/on-conflict-policies}))))
   ;; EP-0025 §subsystems (rf2-h3d8tf): reject a malformed projection-relative
   ;; `:sensitive` / `:large` data-classification declaration fail-loud at the
   ;; registration boundary — the same shape contract + posture as the resource
   ;; + machine declarations (a mutation's work-row `:params` carry the same
   ;; privacy class as a resource's, Spec 016 clause 4).
-  (when-let [{:keys [axis reason]} (classification/classification-declaration-defect spec)]
+  (when-let [{:keys [axis reason]} (rf.resources.classification/classification-declaration-defect spec)]
     (throw (registration-error
              :rf.error/mutation-bad-spec
              'rf/reg-mutation
@@ -286,10 +286,10 @@
              {:mutation-id mutation-id :value (:request metadata)})))
   (let [mutation-spec (assoc metadata :request request-fn)]
     (validate-mutation-spec! mutation-id mutation-spec)
-    (registrar/register!
+    (rf.registrar/register!
       mutation-kind
       mutation-id
-      (source-coords/merge-coords
+      (rf.source-coords/merge-coords
         (merge {:doc (:doc mutation-spec)}
                {:rf/mutation mutation-spec
                 :handler-fn  (:request mutation-spec)})))
@@ -309,7 +309,7 @@
 
   No-op (returns `mutation-id`) when the id is not registered."
   [mutation-id]
-  (registrar/unregister! mutation-kind mutation-id)
+  (rf.registrar/unregister! mutation-kind mutation-id)
   mutation-id)
 
 ;; ---- registry-side introspection -----------------------------------------
@@ -322,14 +322,14 @@
   mutation is registered under that id. The introspection counterpart of
   `resource-meta`. Per EP-0003 §Mutations / Xray."
   [mutation-id]
-  (:rf/mutation (registrar/lookup mutation-kind mutation-id)))
+  (:rf/mutation (rf.registrar/lookup mutation-kind mutation-id)))
 
 (defn mutation-ids
   "Return a vector of every registered mutation id. The registry-side half
   of the mutation introspection (the runtime-side per-frame instance table
   lives in the subs / accessors). Per EP-0003 §Mutations / Xray."
   []
-  (vec (registrar/ids mutation-kind)))
+  (vec (rf.registrar/ids mutation-kind)))
 
 (defn require-mutation-spec!
   "Look the mutation spec up by `mutation-id`, throwing
@@ -380,7 +380,7 @@
   invalid-param REDACTION (the shared classification seam), and canonicalization
   are owned once there, so the two registrars can never drift again."
   [mutation-id spec params where]
-  (params/validate+canonicalize
+  (rf.resources.params/validate+canonicalize
     mutation-id spec params where
     (fn [redacted-params redacted-error]
       (registration-error
@@ -411,7 +411,7 @@
   §Resolver references): a CONCRETE scope value OR a `{:from-db
   <resolver-id>}` named-resolver reference, resolved against `db` (the
   execute handler's app-db coeffect) at event-execution time through the
-  single symmetric resolution arm (`scope-registry/resolve-scope-input`) —
+  single symmetric resolution arm (`rf.resources.scope-registry/resolve-scope-input`) —
   `:rf.mutation/execute` is its third consumer, alongside the direct
   invalidate-tags / clear-scope events (rf2-oo8cv7). A reference is NEVER
   canonicalized literally (a literal `{:from-db …}` map keys nothing, so
@@ -443,11 +443,11 @@
   nil-resolving supplied one)."
   [mutation-id spec payload-scope db]
   (let [scope    (or payload-scope (:scope spec) :rf.scope/global)
-        from-db? (scope-registry/from-db-reference? scope)
-        resolved (scope-registry/resolve-scope-input
+        from-db? (rf.resources.scope-registry/from-db-reference? scope)
+        resolved (rf.resources.scope-registry/resolve-scope-input
                    scope db 'rf.mutation/execute mutation-id)]
     (when (and from-db? (nil? resolved))
-      (error/throw-error!
+      (rf.error/throw-error!
         :rf.error/resource-scope-unresolved-reference
         'rf.mutation/execute
         (str "a :rf.mutation/execute {:from-db …} :scope referenced named "

--- a/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
@@ -33,8 +33,8 @@
   shape, and the PURE patch / populate transition over resource entries
   (the mutation success handler applies them); the swaps over these
   paths live in `re-frame.resources.mutation-events`."
-  (:require [re-frame.error :as error]
-            [re-frame.resources.state :as state]))
+  (:require [re-frame.error :as rf.error]
+            [re-frame.resources.state :as rf.resources.state]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -55,7 +55,7 @@
 (defn instance-key-id
   "The CEDN-1 BYTE-IDENTITY map-key for a mutation INSTANCE id — its
   `canonical-bytes` string (rf2-8iciw8). The SAME canonical identity the
-  resource cache key uses (`state/key-id`), applied to the instance id.
+  resource cache key uses (`rf.resources.state/key-id`), applied to the instance id.
 
   WHY (the EP-0012 `=`-collapse fix, mirrored for mutations): a caller MAY
   supply a sequential / collection instance id (a row-keyed form addresses its
@@ -71,13 +71,13 @@
   instances — without re-erasing the kind (the kind-preserving instance id is
   stored alongside on the instance as `:instance/id`). The bytes string is
   plain serializable EDN, so it rides the epoch / restore / trace wire with no
-  custom handler — exactly the resource cache (`state/key-id`) discipline.
+  custom handler — exactly the resource cache (`rf.resources.state/key-id`) discipline.
 
   Total on a `validate-instance-id!`-conforming id (`serializable-edn?` →
   `canonical-bytes` is total on canonical EDN). Per EP-0003 §Mutations /
   Conventions §Canonical EDN identity."
   [instance-id]
-  (state/key-id instance-id))
+  (rf.resources.state/key-id instance-id))
 
 (defn instances-path
   "Runtime-db-relative path to the mutation-instances map
@@ -267,7 +267,7 @@
   `patch-fn` is `(fn [old-data mutation-result] -> new-data)` — the mutation
   author transforms the cached read from the write's result."
   [entry patch-fn mutation-result {:keys [clock-ms stale-at]}]
-  (if (state/has-data? entry)
+  (if (rf.resources.state/has-data? entry)
     (let [old      (:data entry)
           patched  (patch-fn old mutation-result)
           ;; structural sharing — keep the old value when nothing changed
@@ -285,7 +285,7 @@
           ;; bumps the per-entry :revision write identity UNCONDITIONALLY —
           ;; even on the `=`-shared structural-sharing branch. The no-usable-
           ;; data no-op branch below makes no write and does not bump.
-          state/bump-revision))
+          rf.resources.state/bump-revision))
     entry))
 
 (defn populate-entry
@@ -305,7 +305,7 @@
   entry, and every entry must carry its own scoped-key vector now that
   `:entries` is keyed on the byte `key-id`); an existing entry keeps its own."
   [entry resource-id populate-value {:keys [clock-ms stale-at tags scoped-key]}]
-  (let [base   (or entry (state/empty-entry resource-id scoped-key))
+  (let [base   (or entry (rf.resources.state/empty-entry resource-id scoped-key))
         old    (:data base)
         shared (if (and (some? old) (= old populate-value)) old populate-value)]
     (-> base
@@ -324,7 +324,7 @@
         ;; seeds / re-stamps :loaded-at / :stale-at / :tags), so it bumps the
         ;; per-entry :revision write identity UNCONDITIONALLY — including the
         ;; `=`-shared branch and a freshly-seeded entry (base revision 0 -> 1).
-        state/bump-revision)))
+        rf.resources.state/bump-revision)))
 
 ;; ---- optimistic apply (phase 1.5) — snapshot inverse (EP-0019 D1/D2) -------
 ;;
@@ -378,7 +378,7 @@
   seeded entry's tags (so a later invalidation can reach it). Per EP-0019
   Decision 1 / §Optimistic mutations."
   [entry patch-fn resource-id {:keys [clock-ms stale-at tags scoped-key]}]
-  (let [base   (or entry (state/empty-entry resource-id scoped-key))
+  (let [base   (or entry (rf.resources.state/empty-entry resource-id scoped-key))
         old    (:data base)
         new    (patch-fn old)
         shared (if (and (some? old) (= old new)) old new)]
@@ -401,7 +401,7 @@
         ;; write — it bumps the per-entry `:revision` write identity, so the
         ;; recorded inverse's `:revision` (observed BEFORE this bump) lets the
         ;; settle-time conflict check detect a competing write.
-        state/bump-revision)))
+        rf.resources.state/bump-revision)))
 
 (def applied-removed-revision
   "The `:applied-revision` sentinel for an optimistic REMOVE (the apply dissoc'd
@@ -431,7 +431,7 @@
   explicitly (the apply already computed it). Per EP-0019 Decision 2 / §Optimistic
   settle."
   ([scoped-key before-entry forward]
-   (let [observed (state/entry-revision
+   (let [observed (rf.resources.state/entry-revision
                     (when (not= before-entry absent-snapshot) before-entry))
          applied  (if (= forward :remove) applied-removed-revision (inc observed))]
      (record-optimistic-entry scoped-key before-entry forward observed applied)))
@@ -507,7 +507,7 @@
   [current-entry applied-revision]
   (if (= applied-revision applied-removed-revision)
     (some? current-entry)
-    (not= (state/entry-revision current-entry) applied-revision)))
+    (not= (rf.resources.state/entry-revision current-entry) applied-revision)))
 
 (defn rollback-entry-disposition
   "PURE: decide ONE recorded inverse entry's rollback disposition at settle time
@@ -551,8 +551,8 @@
   tags). Per EP-0019 Decision 3 (restore the exact entry that existed)."
   [runtime-db {scoped-key :resource/key :keys [before]}]
   (if (= before absent-snapshot)
-    (update-in runtime-db (state/entries-path) dissoc (state/key-id scoped-key))
-    (assoc-in runtime-db (state/entry-path scoped-key) before)))
+    (update-in runtime-db (rf.resources.state/entries-path) dissoc (rf.resources.state/key-id scoped-key))
+    (assoc-in runtime-db (rf.resources.state/entry-path scoped-key) before)))
 
 (defn dangle-rollback-optimistic
   "PURE: roll back a restored PENDING optimistic mutation INSTANCE's recorded
@@ -566,7 +566,7 @@
   single pure pass over `runtime-db`, NOT as a second post-restore dispatched
   event — a dispatched `:invalidate` could RACE a fresh load the restored
   timeline issues. So a CONFLICT (the entry's `:revision` moved) marks the entry
-  durably STALE in place (`state/entry-invalidate` — `:invalidated-at` set, the
+  durably STALE in place (`rf.resources.state/entry-invalidate` — `:invalidated-at` set, the
   read path refetches on the next live-owner ensure) rather than dispatching an
   invalidation; an UNMOVED revision restores the recorded `:before` verbatim
   (`restore-before`). `:on-conflict :force` restores the (stale) inverse even on
@@ -588,14 +588,14 @@
                    (fn [rdb {scoped-key :resource/key :as recorded}]
                      (let [{:keys [disposition]}
                            (rollback-entry-disposition
-                             (get-in rdb (state/entry-path scoped-key)) recorded on-conflict)]
+                             (get-in rdb (rf.resources.state/entry-path scoped-key)) recorded on-conflict)]
                        (case disposition
                          :restore    (restore-before rdb recorded)
                          ;; CONFLICT + :invalidate — mark the moved entry stale
                          ;; durably IN THE PASS (no dispatch; the read path
                          ;; recovers on the next ensure — the Q3 no-race rule).
-                         :invalidate (update-in rdb (state/entry-path scoped-key)
-                                                state/entry-invalidate settled-at))))
+                         :invalidate (update-in rdb (rf.resources.state/entry-path scoped-key)
+                                                rf.resources.state/entry-invalidate settled-at))))
                    runtime-db inverse)]
         [rdb' (mapv :resource/key inverse)]))))
 
@@ -605,8 +605,8 @@
 ;; Mutation runtime state is durable and trace-visible, so the identities it
 ;; writes — the mutation INSTANCE id and the patch / populate TARGET scoped
 ;; keys — must follow the SAME serializable-EDN discipline the resource cache
-;; key and the resource params already enforce (`state/serializable-edn?` /
-;; `state/reject-non-edn!`). These predicates / validators are PURE so they
+;; key and the resource params already enforce (`rf.resources.state/serializable-edn?` /
+;; `rf.resources.state/reject-non-edn!`). These predicates / validators are PURE so they
 ;; sit in the runtime layer (this namespace, the home of the instance shape +
 ;; the controlled patch / populate transition); the impure handler boundary
 ;; (`mutation-events`) CALLS them before any runtime-db / work-ledger write or
@@ -657,7 +657,7 @@
   for an invalid mutation patch / populate TARGET scoped key. `arm`
   (`:patches` | `:populates`) names the offending mutation-spec arm."
   [where arm reason target extra]
-  (error/thrown-ex-info
+  (rf.error/thrown-ex-info
     :rf.error/mutation-invalid-target
     where
     reason
@@ -755,14 +755,14 @@
                       "silently write the cache under a wrong scope. Per "
                       "Conventions §Reserved namespaces.")
                  target {:scope scope})))
-      (when-not (state/serializable-edn? scope)
+      (when-not (rf.resources.state/serializable-edn? scope)
         (throw (target-key-error
                  where arm
                  (str "a mutation " (name arm) " target's scope is not "
                       "serializable EDN — host / opaque values are rejected at "
                       "the cache-key boundary. Per Spec 016 §Resource identity.")
                  target {:scope (pr-str scope)})))
-      (when-not (state/serializable-edn? params)
+      (when-not (rf.resources.state/serializable-edn? params)
         (throw (target-key-error
                  where arm
                  (str "a mutation " (name arm) " target's params are not "
@@ -779,7 +779,7 @@
         [:skip :unregistered-resource (target-summary target)]
 
         :else
-        [:apply (state/scoped-resource-key scope resource params)]))))
+        [:apply (rf.resources.state/scoped-resource-key scope resource params)]))))
 
 (defn validate-target-key!
   "Fail-closed validation of a SINGLE mutation patch / populate TARGET, BEFORE
@@ -809,7 +809,7 @@
     enum — `:rf.scope/glabal`), which would silently write under a wrong
     scope;
   - a non-EDN / host scope or params (the cache key MUST be serializable EDN —
-    the same boundary `state/reject-non-edn!` enforces for resource params).
+    the same boundary `rf.resources.state/reject-non-edn!` enforces for resource params).
 
   `registered-resource?` is `(fn [resource-id] -> truthy)` — the injected
   registry-lookup predicate (so this PURE validator carries no registry
@@ -951,7 +951,7 @@
   "Build the canonical thrown-error shape (Spec 009 §The thrown-error shape)
   for a non-serializable mutation INSTANCE id."
   [instance-id where]
-  (error/thrown-ex-info
+  (rf.error/thrown-ex-info
     :rf.error/mutation-non-serializable-instance-id
     where
     (str "a mutation instance id must be serializable EDN "
@@ -980,7 +980,7 @@
   conforms; throws `:rf.error/mutation-non-serializable-instance-id`
   otherwise. Per EP-0003 §Mutations."
   [instance-id where]
-  (when (and (some? instance-id) (not (state/serializable-edn? instance-id)))
+  (when (and (some? instance-id) (not (rf.resources.state/serializable-edn? instance-id)))
     (throw (instance-id-error instance-id where)))
   instance-id)
 
@@ -1018,7 +1018,7 @@
   CLOSED at settle time (before any invalidation dispatch), never a silent
   no-op — an author who returns garbage from `:invalidates` learns loudly."
   [where reason raw extra]
-  (error/thrown-ex-info
+  (rf.error/thrown-ex-info
     :rf.error/mutation-invalid-invalidation
     where
     reason
@@ -1033,7 +1033,7 @@
   :refetch-populated? bool}`, validating fail-closed. `:scope` defaults to
   `:rf.scope/same` (Spec 016 §Scoped invalidation descriptors). `:tags` must
   be a non-nil collection of tags; the boolean flags default false. `:tags`
-  is lowered through the shared `state/normalize-tag-set` (the SAME
+  is lowered through the shared `rf.resources.state/normalize-tag-set` (the SAME
   normalizer the bare tag-set shorthand and the direct
   `:rf.resource/invalidate-tags` `:tags` use), so a LONE vector tag written
   directly (`{:tags [:article slug]}`) is the ONE tag `#{[:article slug]}`,
@@ -1062,7 +1062,7 @@
                     "descriptors.")
                raw {:descriptor (pr-str descriptor) :tags (pr-str tags)})))
     {:scope              (if (contains? descriptor :scope) scope same-scope-marker)
-     :tags               (state/normalize-tag-set tags)
+     :tags               (rf.resources.state/normalize-tag-set tags)
      :cross-scope?       (boolean cross-scope?)
      :refetch-populated? (boolean refetch-populated?)}))
 
@@ -1083,7 +1083,7 @@
   nothing). The disambiguation: a MAP is a single descriptor; a sequential /
   set collection whose first element is a MAP is a descriptor vector; any
   other non-empty collection is the bare tag-set (its elements are tags). The
-  bare tag-set is lowered through `state/normalize-tag-set`, so a LONE vector
+  bare tag-set is lowered through `rf.resources.state/normalize-tag-set`, so a LONE vector
   tag written directly (`[:article slug]` — a vector whose head is a scalar
   marker, not a collection) is the ONE tag `#{[:article slug]}`, NOT a scalar
   set of its elements `#{:article slug}` (which would silently match nothing —
@@ -1107,7 +1107,7 @@
     (mapv #(normalize-one-descriptor % raw where) raw)
 
     ;; the bare tag-set shorthand: a collection of TAGS at :rf.scope/same.
-    ;; rf2-ru73k6 F1 — `state/normalize-tag-set` treats a LONE vector tag
+    ;; rf2-ru73k6 F1 — `rf.resources.state/normalize-tag-set` treats a LONE vector tag
     ;; (`[:article slug]`) as the ONE tag `#{[:article slug]}` rather than
     ;; silently splitting it into `#{:article slug}` (a scalar set that matches
     ;; nothing); a tag-set (`#{[:article slug]}` / `[[:article slug]]`) lowers
@@ -1115,7 +1115,7 @@
     ;; `:tags` uses, so a lone vector tag has one meaning across the cache.
     (coll? raw)
     [{:scope              same-scope-marker
-      :tags               (state/normalize-tag-set raw)
+      :tags               (rf.resources.state/normalize-tag-set raw)
       :cross-scope?       false
       :refetch-populated? false}]
 

--- a/implementation/resources/src/re_frame/resources/mutation_subs.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_subs.cljc
@@ -29,8 +29,8 @@
   installs `(:value reply)` under the entry's `:data`). They are kept
   distinct deliberately — the instance sub answers \"what is the durable
   state of this write?\", not \"what did the continuation carry?\"."
-  (:require [re-frame.resources.mutation-runtime :as mstate]
-            [re-frame.subs :as subs]))
+  (:require [re-frame.resources.mutation-runtime :as rf.resources.mutation-runtime]
+            [re-frame.subs :as rf.subs]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -38,7 +38,7 @@
   "Look up the durable mutation instance for a sub payload by its
   `:instance` id, or nil when no instance exists."
   [runtime-db [_id {:keys [instance]}]]
-  (get-in runtime-db (mstate/instance-path instance)))
+  (get-in runtime-db (rf.resources.mutation-runtime/instance-path instance)))
 
 (defn optimistic?-for
   "PURE DERIVED: is this mutation instance showing a LIVE optimistic value — an
@@ -81,7 +81,7 @@
        :pending?      (= :pending (:status i))
        :success?      (= :success (:status i))
        :error?        (= :error (:status i))
-       :settled?      (mstate/terminal? (:status i))
+       :settled?      (rf.resources.mutation-runtime/terminal? (:status i))
        :optimistic?   (optimistic?-for i)})))
 
 (defn status-sub-fn
@@ -115,19 +115,19 @@
   `re-frame.resources` façade so a `(require … :reload)` on a fresh
   registrar re-wires them. Per Spec 016 §Mutations."
   []
-  (subs/reg-runtime-sub :rf/mutation
+  (rf.subs/reg-runtime-sub :rf/mutation
     {:doc "Passive read of a mutation instance's full view-model `{:status :result :error :affected-keys :pending? :success? :error? :settled? :optimistic?}`, keyed by :instance id. The `:optimistic?` flag is true while a live optimistic apply is showing and not yet settled. Per Spec 016 §Mutations."}
     state-sub-fn)
-  (subs/reg-runtime-sub :rf.mutation/status
+  (rf.subs/reg-runtime-sub :rf.mutation/status
     {:doc "Passive read of a mutation instance's :status keyword (:idle / :pending / :success / :error). Per Spec 016 §Mutations."}
     status-sub-fn)
-  (subs/reg-runtime-sub :rf.mutation/pending?
+  (rf.subs/reg-runtime-sub :rf.mutation/pending?
     {:doc "Passive read: true iff a mutation instance's write is in flight. Per Spec 016 §Mutations."}
     pending?-sub-fn)
-  (subs/reg-runtime-sub :rf.mutation/result
+  (rf.subs/reg-runtime-sub :rf.mutation/result
     {:doc "Passive read of a mutation instance's decoded success result (or nil). Per Spec 016 §Mutations."}
     result-sub-fn)
-  (subs/reg-runtime-sub :rf.mutation/error
+  (rf.subs/reg-runtime-sub :rf.mutation/error
     {:doc "Passive read of a mutation instance's failure envelope (or nil). Per Spec 016 §Mutations."}
     error-sub-fn)
   nil)

--- a/implementation/resources/src/re_frame/resources/params.cljc
+++ b/implementation/resources/src/re_frame/resources/params.cljc
@@ -18,14 +18,14 @@
   Hosting the pipeline here introduces no require cycle; `mutation-registry`
   does not depend on `registry`.
 
-  PRIVACY: the `classification/redact-invalid-params-error` step is a privacy
+  PRIVACY: the `rf.resources.classification/redact-invalid-params-error` step is a privacy
   boundary: a `:sensitive?` params slot must never ride raw on the thrown error
   payload or downstream logs when validation fails on a non-sensitive sibling;
   a `:large?` slot is elided. Projection happens before the family error is
   built."
-  (:require [re-frame.late-bind :as late-bind]
-            [re-frame.resources.classification :as classification]
-            [re-frame.resources.state :as state]))
+  (:require [re-frame.late-bind :as rf.late-bind]
+            [re-frame.resources.classification :as rf.resources.classification]
+            [re-frame.resources.state :as rf.resources.state]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -33,23 +33,23 @@
   "The shared validate+canonicalize params pipeline used by both registrars.
   Applies, in order:
 
-    1. the documented omitted-`:params` default (`state/default-omitted-params`)
-       — an ABSENT slot (`state/missing-params`) becomes `{}`; a PRESENT value
+    1. the documented omitted-`:params` default (`rf.resources.state/default-omitted-params`)
+       — an ABSENT slot (`rf.resources.state/missing-params`) becomes `{}`; a PRESENT value
        (INCLUDING an explicit `nil`) passes through unchanged so the
        `:params-schema`, not a blanket `(or params {})`, decides whether nil
        conforms (nil vs missing is schema-defined — Spec 016 §Resource
        identity and Conventions §Canonical EDN identity);
     2. host / opaque value rejection at the cache-key boundary
-       (`state/reject-non-edn!`, throwing `:rf.error/resource-non-edn-params`);
+       (`rf.resources.state/reject-non-edn!`, throwing `:rf.error/resource-non-edn-params`);
     3. schema conformance against the family `:params-schema` via the pluggable
        late-bound Malli validator (`:schemas/validate-with-registered-fn`) — a
        no-op when no validator is registered; NO static `schemas` dependency;
     4. on a conformance failure, REDACT the failing params + explainer output
-       through the shared `classification/redact-invalid-params-error` privacy
+       through the shared `rf.resources.classification/redact-invalid-params-error` privacy
        seam (a `:sensitive?` slot never rides raw on the error payload; a
        `:large?` slot elides), then throw the FAMILY error the
        `build-invalid-error` callback shapes from the ALREADY-redacted values;
-    5. return the canonical params (`state/canonicalize`).
+    5. return the canonical params (`rf.resources.state/canonicalize`).
 
   `id` is the resource / mutation id (named in the non-EDN boundary error).
   `spec` carries the `:params-schema` + its per-slot classification marks.
@@ -63,15 +63,15 @@
   + redacted explainer error, and its return value is thrown — so each family
   keeps its exact thrown-error shape."
   [id spec params where build-invalid-error]
-  (let [params (state/default-omitted-params params)
+  (let [params (rf.resources.state/default-omitted-params params)
         schema (:params-schema spec)]
     ;; host / opaque values are rejected at the cache-key boundary
-    (state/reject-non-edn! params where :params id)
+    (rf.resources.state/reject-non-edn! params where :params id)
     ;; schema conformance (pluggable; no-op when no validator is registered)
     (when schema
-      (let [validate (late-bind/get-fn-cached :schemas/validate-with-registered-fn)]
+      (let [validate (rf.late-bind/get-fn-cached :schemas/validate-with-registered-fn)]
         (when (and validate (not (validate schema params)))
-          (let [explain  (late-bind/get-fn-cached :schemas/explain-with-registered-fn)
+          (let [explain  (rf.late-bind/get-fn-cached :schemas/explain-with-registered-fn)
                  ;; Thrown error data and downstream egress must not leak a
                  ;; `:sensitive?` params slot (nor ride a `:large?`
                 ;; slot raw). Route `:params` + the explainer `:error` through the
@@ -79,7 +79,7 @@
                 ;; owner surface SSR key egress uses + the shared schemas redaction
                 ;; seam), so the owner's `:params-schema` marks govern the error
                 ;; payload as they govern wire egress.
-                redacted (classification/redact-invalid-params-error
+                redacted (rf.resources.classification/redact-invalid-params-error
                            params (when explain (explain schema params)) spec)]
             (throw (build-invalid-error (:params redacted) (:error redacted)))))))
-    (state/canonicalize params)))
+    (rf.resources.state/canonicalize params)))

--- a/implementation/resources/src/re_frame/resources/registry.cljc
+++ b/implementation/resources/src/re_frame/resources/registry.cljc
@@ -24,17 +24,17 @@
   data-lifecycle events (`:rf.resource/remove` / `:rf.resource/release-owner`
   / `:rf.resource/clear-scope`) remain the in-cascade, scope/instance-grained
   disposal surfaces."
-  (:require [re-frame.error :as error]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.resources.classification :as classification]
-            [re-frame.resources.params :as params]
-            [re-frame.resources.scope-registry :as scope-registry]
-            [re-frame.resources.state :as state]
-            [re-frame.resources.timers :as timers]
-            [re-frame.resources.work-ledger :as work-ledger]
-            [re-frame.source-coords :as source-coords]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.error :as rf.error]
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.resources.classification :as rf.resources.classification]
+            [re-frame.resources.params :as rf.resources.params]
+            [re-frame.resources.scope-registry :as rf.resources.scope-registry]
+            [re-frame.resources.state :as rf.resources.state]
+            [re-frame.resources.timers :as rf.resources.timers]
+            [re-frame.resources.work-ledger :as rf.resources.work-ledger]
+            [re-frame.source-coords :as rf.source-coords]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -66,11 +66,11 @@
   `:rf.scope/*` namespace — i.e. a candidate for the closed scope-policy
   enum. A non-keyword (a `[:rf.scope/session …]` tuple, a map, a string)
   is NOT in the bare-keyword reserved slot. Reuses the shared
-  `state/reserved-scope-ns` constant (one source of truth for the reserved
+  `rf.resources.state/reserved-scope-ns` constant (one source of truth for the reserved
   namespace across the policy gate here and the concrete-scope gate in
   `state`)."
   [scope]
-  (and (keyword? scope) (= state/reserved-scope-ns (namespace scope))))
+  (and (keyword? scope) (= rf.resources.state/reserved-scope-ns (namespace scope))))
 
 (defn- valid-scope-policy?
   "A scope policy is one of the reserved enum keywords
@@ -102,7 +102,7 @@
          (= scope from-caller-scope-policy) true
          ;; a `{:from-db <id>}` named-resolver reference — a derived-scope
          ;; policy resolved at use time, NOT a literal map scope.
-         (scope-registry/from-db-reference? scope) true
+         (rf.resources.scope-registry/from-db-reference? scope) true
          ;; a bare `:rf.scope/*` keyword outside the enum is a typo —
          ;; reject (fail closed), do NOT accept as a literal scope.
          (reserved-scope-namespace? scope)  false
@@ -117,7 +117,7 @@
   "Build the canonical thrown-error shape (Spec 009 §The thrown-error
   shape) for a `reg-resource` validation failure."
   [error-id where reason extra]
-  (error/thrown-ex-info
+  (rf.error/thrown-ex-info
     error-id
     where
     reason
@@ -135,7 +135,7 @@
 ;; (`{:rf.resource/page-param p :rf.resource/page-index i}`); a non-infinite
 ;; `:request` still receives a nil/empty ctx (NO new 3-arity). The
 ;; `:rf.error/infinite-missing-page-accessor` error is RUNTIME-detected at the
-;; first non-vector page in the subs merge site (state/merge-pages->items), not
+;; first non-vector page in the subs merge site (rf.resources.state/merge-pages->items), not
 ;; here — at registration
 ;; we have no page to inspect; here we shape-validate `:page->items` (a keyword
 ;; or fn) when present.
@@ -337,7 +337,7 @@
              {:resource-id resource-id})))
   ;; `:poll-interval-ms` is OPTIONAL (Spec 016 §Polling). When present it MUST
   ;; be a number of milliseconds — a non-positive / absent value means NO
-  ;; polling (the disarm rule `timers/schedule!` applies to a non-positive
+  ;; polling (the disarm rule `rf.resources.timers/schedule!` applies to a non-positive
   ;; delay), parallel to `:stale-after-ms` (infinite-by-default, Spec 016
   ;; §Freshness clock contract). Absent `:gc-after-ms` normalizes to a finite
   ;; default; any other non-positive/non-`:never` value is a loud registration
@@ -372,7 +372,7 @@
   ;; is value-independent + standing (it redacts whatever later occupies the
   ;; projection-relative slot on every instance), so a shape fault is caught
   ;; at definition, not silently dropped.
-  (when-let [{:keys [axis reason]} (classification/classification-declaration-defect spec)]
+  (when-let [{:keys [axis reason]} (rf.resources.classification/classification-declaration-defect spec)]
     (throw (registration-error
              :rf.error/resource-bad-spec
              'rf/reg-resource
@@ -507,11 +507,11 @@
                           (assoc :gc-after-ms
                                  (normalize-gc-after-ms resource-id metadata)))]
   (validate-resource-spec! resource-id resource-spec)
-  (let [previous (registrar/lookup resource-kind resource-id)]
-    (registrar/register!
+  (let [previous (rf.registrar/lookup resource-kind resource-id)]
+    (rf.registrar/register!
       resource-kind
       resource-id
-      (source-coords/merge-coords
+      (rf.source-coords/merge-coords
         (merge {:doc (:doc resource-spec)}
                {:rf/resource resource-spec
                 :handler-fn  (:request resource-spec)})))
@@ -520,12 +520,12 @@
     ;; tab / lifecycle timeline) see one row per fresh resource — the
     ;; registration anchor of the `:rf.resource/*` trace family (Spec 016
     ;; §Xray and AI tooling). Re-registration rides the cross-kind
-    ;; `:rf.registry/handler-replaced` trace (emitted by `registrar/register!`
+    ;; `:rf.registry/handler-replaced` trace (emitted by `rf.registrar/register!`
     ;; per Spec 001 §Hot-reload trace surface); not re-emitted here. Mirrors
     ;; the `:rf.route/registered` / `:rf.flow/registered` symmetry. The row is
     ;; frame-agnostic (registration is a load-time act, not a per-frame event).
     (when (nil? previous)
-      (trace/emit! :rf.event :rf.resource/registered
+      (rf.trace/emit! :rf.event :rf.resource/registered
                    {:resource-id      resource-id
                     :scope-policy     (:scope resource-spec)
                     :transport        (:transport resource-spec)
@@ -541,18 +541,18 @@
   reads each entry's stored `:resource/key` vector (NOT the map key), and the
   returned keys are the kind-preserving VECTORS the timer-cancel / abort / trace
   consumers name resources by. The disposal `dissoc` maps these through
-  `state/key-id` to address the byte-keyed `:entries` slots."
+  `rf.resources.state/key-id` to address the byte-keyed `:entries` slots."
   [runtime-db resource-id]
   (into []
         (comp (map val)
               (filter (fn [entry] (= resource-id (second (:resource/key entry)))))
               (map :resource/key))
-        (get-in runtime-db (state/entries-path))))
+        (get-in runtime-db (rf.resources.state/entries-path))))
 
 (defn- dispose-resource-runtime!
   "Dispose every live runtime entry for `resource-id` in ONE frame (Spec 016
   §clear-resource MUST-dispose, rf2-m9h5iq). Atomically (through
-  `frame/swap-runtime-db!`, the framework-authority out-of-cascade runtime-db
+  `rf.frame/swap-runtime-db!`, the framework-authority out-of-cascade runtime-db
   write surface routing / machine spawn use): removes the resource's
   `:entries`, marks each in-flight work record terminal `:suppressed` (so a
   late reply's `live-entry-for-reply` existence check finds nothing to write
@@ -564,31 +564,31 @@
   (`:reason :clear-resource`) for the frame when anything was disposed.
   Returns the disposed scoped keys (possibly empty)."
   [frame-id resource-id]
-  (let [runtime-db (or (frame/frame-runtime-db-value frame-id) {})
+  (let [runtime-db (or (rf.frame/frame-runtime-db-value frame-id) {})
         keys'      (entry-keys-for-resource runtime-db resource-id)]
     (when (seq keys')
       (let [in-flight (into []
                             (keep (fn [k]
-                                    (let [e   (get-in runtime-db (state/entry-path k))
+                                    (let [e   (get-in runtime-db (rf.resources.state/entry-path k))
                                           wid (:current-work e)]
                                       (when wid
-                                        [wid (:transport (work-ledger/get-record runtime-db wid))]))))
+                                        [wid (:transport (rf.resources.work-ledger/get-record runtime-db wid))]))))
                             keys')]
         ;; durable disposal — atomic on the frame's runtime-db partition
-        (frame/swap-runtime-db!
+        (rf.frame/swap-runtime-db!
           frame-id
           (fn [rdb]
             (-> (or rdb {})
                 ;; rf2-9e0tyq — `keys'` are scoped-key VECTORS; the byte-keyed
                 ;; `:entries` map is dissoc'd by their `key-id`s.
-                (update-in (state/entries-path)
-                           (fn [es] (reduce dissoc es (map state/key-id keys'))))
+                (update-in (rf.resources.state/entries-path)
+                           (fn [es] (reduce dissoc es (map rf.resources.state/key-id keys'))))
                 (as-> db (reduce (fn [d [wid _]]
-                                   (work-ledger/update-record
-                                     d wid work-ledger/mark-terminal
+                                   (rf.resources.work-ledger/update-record
+                                     d wid rf.resources.work-ledger/mark-terminal
                                      :suppressed {:reason :clear-resource}))
                                  db in-flight))
-                (update state/resources-key state/recompute-indexes))))
+                (update rf.resources.state/resources-key rf.resources.state/recompute-indexes))))
         ;; host-side disposal — release advisory timers + opportunistically
         ;; abort each in-flight attempt. Correctness rests on the removed
         ;; entry (a late reply's existence check finds nothing), NOT on the
@@ -597,10 +597,10 @@
         ;; frame-destroy teardown uses (Spec 016 §Cancellation is
         ;; opportunistic).
         (doseq [k keys']
-          (timers/cancel-for-key! frame-id k))
+          (rf.resources.timers/cancel-for-key! frame-id k))
         (doseq [[wid _transport] in-flight]
-          (work-ledger/opportunistic-abort! frame-id wid))
-        (trace/emit! :rf.event :rf.resource/removed
+          (rf.resources.work-ledger/opportunistic-abort! frame-id wid))
+        (rf.trace/emit! :rf.event :rf.resource/removed
                      {:rf.frame/id frame-id :resource-id resource-id
                       :reason :clear-resource :removed (vec keys')
                       :aborted (mapv first in-flight)})))
@@ -628,8 +628,8 @@
   No-op (returns `resource-id`) when the id is not registered and no frame
   holds a live entry for it."
   [resource-id]
-  (registrar/unregister! resource-kind resource-id)
-  (doseq [frame-id (frame/frame-ids)]
+  (rf.registrar/unregister! resource-kind resource-id)
+  (doseq [frame-id (rf.frame/frame-ids)]
     (dispose-resource-runtime! frame-id resource-id))
   resource-id)
 
@@ -642,7 +642,7 @@
   `resource-id`, or nil if no resource is registered under that id. Per Spec
   016 §Introspection."
   [resource-id]
-  (:rf/resource (registrar/lookup resource-kind resource-id)))
+  (:rf/resource (rf.registrar/lookup resource-kind resource-id)))
 
 (defn resource-ids
   "Return a vector of every registered resource id. The registry-side
@@ -650,7 +650,7 @@
   the runtime). Per Spec 016 §Xray and AI tooling (the static
   resource registry)."
   []
-  (vec (registrar/ids resource-kind)))
+  (vec (rf.registrar/ids resource-kind)))
 
 (defn require-resource-spec!
   "Look the resource spec up by `resource-id`, throwing
@@ -673,14 +673,14 @@
   "Validate `params` against the resource's REQUIRED `:params-schema`
   (pluggable late-bound Malli validator, exactly as routing validates route
   params — `:schemas/validate-with-registered-fn`; no static schemas dep),
-  reject non-EDN / host values loudly (`state/reject-non-edn!`), then return
-  the canonical params (`state/canonicalize`). Throws
+  reject non-EDN / host values loudly (`rf.resources.state/reject-non-edn!`), then return
+  the canonical params (`rf.resources.state/canonicalize`). Throws
   `:rf.error/resource-invalid-params` on a schema-conformance failure.
   Per Spec 016 §Resource identity / §Canonicalization rule.
 
   `nil` vs missing is schema-defined (rf2-hgy5kf): a caller threads
-  `state/missing-params` for an ABSENT `:params` slot (the documented
-  omitted-default lowers it to `{}` via `state/default-omitted-params`), while
+  `rf.resources.state/missing-params` for an ABSENT `:params` slot (the documented
+  omitted-default lowers it to `{}` via `rf.resources.state/default-omitted-params`), while
   a PRESENT explicit `nil` is passed THROUGH to `:params-schema` validation +
   canonicalization unchanged — the schema (not a blanket `(or params {})`)
   decides whether nil conforms. This keeps the validation boundary from
@@ -695,7 +695,7 @@
   validation, invalid-param REDACTION, and canonicalization are owned once in
   that leaf (so the mutation registrar's identical pipeline can never drift)."
   [resource-id spec params where]
-  (params/validate+canonicalize
+  (rf.resources.params/validate+canonicalize
     resource-id spec params where
     (fn [redacted-params redacted-error]
       (registration-error
@@ -719,7 +719,7 @@
 
 (defn- canonical-scope!
   "Route a CONCRETE resolved scope through the single shared concrete-scope
-  validation path (`state/canonicalize-scope`, rf2-lzv9xc): reject a
+  validation path (`rf.resources.state/canonicalize-scope`, rf2-lzv9xc): reject a
   reserved-namespace typo fail-closed (rf2-pd7akw), reject a host / opaque
   value, reject the global scope wrapped as the singleton `[:rf.scope/global]`
   in favour of the canonical bare `:rf.scope/global` (rf2-bwwk6l), then
@@ -729,7 +729,7 @@
   route-resolver / fn-of-nothing / pure-data policy is caught at the concrete
   boundary, not silently accepted as a literal scope."
   [resource-id scope where]
-  (state/canonicalize-scope scope where resource-id))
+  (rf.resources.state/canonicalize-scope scope where resource-id))
 
 (defn- require-resolved-reference!
   "A `{:from-db <id>}` reference at a scope-REQUIRING event/route site
@@ -741,7 +741,7 @@
   `:rf.error/resource-scope-unresolved-reference` naming the resolver id;
   returns the resolved concrete scope otherwise."
   [resource-id reference db where]
-  (or (scope-registry/resolve-from-db-reference reference db where)
+  (or (rf.resources.scope-registry/resolve-from-db-reference reference db where)
       (throw (registration-error
                :rf.error/resource-scope-unresolved-reference
                where
@@ -788,19 +788,19 @@
       ;; 1. payload scope (highest precedence) — a {:from-db …} reference
       ;; resolves at use time + fails closed on nil; a concrete scope is
       ;; canonicalized as before.
-      (scope-registry/from-db-reference? payload-scope)
+      (rf.resources.scope-registry/from-db-reference? payload-scope)
       (canonical-scope! resource-id (resolve-ref payload-scope) where)
       (some? payload-scope) (canonical-scope! resource-id payload-scope where)
       ;; 2. route-resource resolver result (threaded in by the route slice).
       ;; The route slice already resolves a {:from-db …} route-resource
       ;; `:scope` to a concrete value before threading it here, so route-scope
       ;; is concrete; resolve defensively if a reference still arrives.
-      (scope-registry/from-db-reference? route-scope)
+      (rf.resources.scope-registry/from-db-reference? route-scope)
       (canonical-scope! resource-id (resolve-ref route-scope) where)
       (some? route-scope)   (canonical-scope! resource-id route-scope where)
       ;; 3a. a {:from-db …} spec policy — the declared derived-scope policy,
       ;; resolved against db at use time, fail-closed on nil.
-      (scope-registry/from-db-reference? policy)
+      (rf.resources.scope-registry/from-db-reference? policy)
       (canonical-scope! resource-id (resolve-ref policy) where)
       ;; 3b. explicit global claim — the resource's declared policy
       (= policy global-scope-policy) global-scope-policy
@@ -838,7 +838,7 @@
   ;; `:rf.resource/scope-resolved` observability state. The causal write-side
   ;; resolution (event ensure / route / mutation settle) keeps its traced
   ;; evidence via `resolve-from-db-reference`.
-  (or (scope-registry/resolve-from-db-reference-pure reference db where)
+  (or (rf.resources.scope-registry/resolve-from-db-reference-pure reference db where)
       (throw (registration-error
                :rf.error/resource-sub-unresolved-scope
                where
@@ -887,7 +887,7 @@
     (cond
       ;; 1. payload scope — a {:from-db …} reference resolves against the
       ;; frame db at use time + fails closed on nil (sub-side).
-      (scope-registry/from-db-reference? payload-scope)
+      (rf.resources.scope-registry/from-db-reference? payload-scope)
       (canonical-scope! resource-id
                         (sub-unresolved-reference! resource-id payload-scope db where)
                         where)
@@ -895,7 +895,7 @@
       ;; 2a. a {:from-db …} spec policy — the declared derived-scope policy,
       ;; resolved against the frame db at use time (rf2-616xa6: the sub
       ;; re-keys reactively when the resolver's app-db inputs change).
-      (scope-registry/from-db-reference? policy)
+      (rf.resources.scope-registry/from-db-reference? policy)
       (canonical-scope! resource-id
                         (sub-unresolved-reference! resource-id policy db where)
                         where)

--- a/implementation/resources/src/re_frame/resources/reply.cljc
+++ b/implementation/resources/src/re_frame/resources/reply.cljc
@@ -97,7 +97,7 @@
   still route through the shared `re-frame.reply/suppress` and spell
   `:cancelled` identically — uniform where it matters; the obsolescence
   DETERMINATION is correctly surface-specific."
-  (:require [re-frame.reply :as reply]))
+  (:require [re-frame.reply :as rf.reply]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -282,7 +282,7 @@
   `extra` threads `:rf.reply/work-id` / `:rf.reply/work-kind` / `:rf.frame/id` /
   `:completed-at` / `:rf.reply/stale-reason` onto the stale reply."
   [{:keys [carried current extra]}]
-  (reply/suppress nil carried current extra))
+  (rf.reply/suppress nil carried current extra))
 
 ;; ---------------------------------------------------------------------------
 ;; Trace summary (Managed-Effects §Tracing). A data-only summary of the
@@ -301,4 +301,4 @@
   `:rf.reply/work-kind`, `:rf.reply/work-status`, `:rf.frame/id`, `:completed-at`) ride
   verbatim. `opts` is forwarded to the elider (e.g. `:frame`)."
   ([reply] (trace-reply reply nil))
-  ([reply opts] (reply/trace-summary reply opts)))
+  ([reply opts] (rf.reply/trace-summary reply opts)))

--- a/implementation/resources/src/re_frame/resources/reply_handlers.cljc
+++ b/implementation/resources/src/re_frame/resources/reply_handlers.cljc
@@ -25,7 +25,7 @@
     by `live-for-reply?` (the verifier reads `:current-work` + `:generation`
     off the slot) and by `current-generation` (the `:current` half of the
     carried-vs-current stale gate reads the slot's live `:generation`).
-  - **`work-kind`** — `rreply/work-kind-resource` | `rreply/work-kind-mutation`
+  - **`work-kind`** — `rf.resources.reply/work-kind-resource` | `rf.resources.reply/work-kind-mutation`
     (Managed-Effects §Work-id correlation).
   - **`stale-reason`** — `:rf.resource/superseded` | `:rf.mutation/superseded`
     (the family's `:rf.reply/stale-reason` on the suppressed reply).
@@ -53,8 +53,8 @@
   no stamped frame (a direct-dispatch test payload) skips the frame check (nil
   never collides with a concrete frame id) and is verified by work-id +
   generation alone."
-  (:require [re-frame.resources.reply :as rreply]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.resources.reply :as rf.resources.reply]
+            [re-frame.trace :as rf.trace]))
 
 ;; ---------------------------------------------------------------------------
 ;; (1) Live-slot verifier (Spec 016 §Transport — stale suppression).
@@ -120,7 +120,7 @@
 (defn stale-suppress-reply
   "Build the canonical `:status :stale` reply outcome for a superseded /
   vanished reply through the SHARED `re-frame.reply` substrate (via
-  `rreply/stale-reply`), so the family lowers its stale outcome exactly as
+  `rf.resources.reply/stale-reply`), so the family lowers its stale outcome exactly as
   every other managed-async family does (Managed-Effects §Stale suppression).
   The carried correlation is the reply token's `:work/id` + `:generation`; the
   current correlation is the live slot's `:generation` (nil when the slot is
@@ -136,7 +136,7 @@
   The three family knobs:
   - `path-fn` reads the live slot's `:current` generation (see
     `current-generation`);
-  - `work-kind` is `rreply/work-kind-resource` | `rreply/work-kind-mutation`;
+  - `work-kind` is `rf.resources.reply/work-kind-resource` | `rf.resources.reply/work-kind-mutation`;
   - `stale-reason` is the family's `:rf.reply/stale-reason`.
   `correlation-fn` is `(payload) → extra-correlation` (the family's diagnostic
   correlation keys merged ONTO the carried/current `:generation` pair —
@@ -146,7 +146,7 @@
   [runtime-db path-fn {work-id :work/id :as payload} {:keys [work-kind stale-reason correlation-fn]} extra]
   (let [carried-generation      (:generation payload)
         current-slot-generation (current-generation runtime-db path-fn payload)]
-    (rreply/stale-reply
+    (rf.resources.reply/stale-reply
       {:carried {:work/id work-id :generation carried-generation}
        :current {:generation current-slot-generation}
        :extra   (merge {:rf.reply/work-id      work-id
@@ -173,14 +173,14 @@
   additive shape the machine `:rf.machine/done` and HTTP / probe stale paths
   ride (Managed-Effects §Tracing / EP-0011). `stale` is the
   `stale-suppress-reply` outcome; its trace summary routes wire slots through
-  the shared elider via `rreply/trace-reply`.
+  the shared elider via `rf.resources.reply/trace-reply`.
 
   `bespoke-facts` is the family's leading per-trace map (its caller-side
   spelling of `:rf.frame/id` + the durable key + `:generation` / `:outcome`);
   the additive `:rf.reply/*` facts are MERGED on top."
   [trace-id bespoke-facts stale]
-  (let [trace-summary (rreply/trace-reply (:reply stale))]
-    (trace/emit! :rf.event trace-id
+  (let [trace-summary (rf.resources.reply/trace-reply (:reply stale))]
+    (rf.trace/emit! :rf.event trace-id
                  (merge bespoke-facts
                         {;; reply-envelope vocabulary (Managed-Effects §9) — the
                          ;; canonical :status :stale reply produced via the

--- a/implementation/resources/src/re_frame/resources/revalidate_listeners.cljc
+++ b/implementation/resources/src/re_frame/resources/revalidate_listeners.cljc
@@ -53,7 +53,7 @@
   Idempotent: re-installing for a frame replaces (does not stack) its
   listeners — hot-reload safe (the same teardown-then-reinstall shape
   `re-frame.routing.history/reconcile-url-listener!` uses)."
-  (:require [re-frame.late-bind :as late-bind]))
+  (:require [re-frame.late-bind :as rf.late-bind]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -106,7 +106,7 @@
   caller is the CLJS focus/online listener, so the JVM never reaches it (it
   installs no listeners)."
   [frame-id event-id]
-  (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+  (when-let [dispatch! (rf.late-bind/get-fn :router/dispatch!)]
     (dispatch! [event-id] {:frame frame-id :source :revalidate})))
 
 #?(:cljs

--- a/implementation/resources/src/re_frame/resources/route.cljc
+++ b/implementation/resources/src/re_frame/resources/route.cljc
@@ -54,13 +54,13 @@
   token's slot is dropped wholesale on owner release.
 
   Per Spec 016 §Route integration."
-  (:require [re-frame.error :as error]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.resources.registry :as registry]
-            [re-frame.resources.scope-registry :as scope-registry]
-            [re-frame.resources.state :as state]
-            [re-frame.resources.work-ledger :as work-ledger]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.error :as rf.error]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.resources.registry :as rf.resources.registry]
+            [re-frame.resources.scope-registry :as rf.resources.scope-registry]
+            [re-frame.resources.state :as rf.resources.state]
+            [re-frame.resources.work-ledger :as rf.resources.work-ledger]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -227,7 +227,7 @@
   `entry` (nil when the entry is absent). The four outcomes are the Spec 016
   facts the Spec 012 readiness table is written in:
 
-    `:ready`   — the identity has its OWN usable data (`state/has-data?`), so
+    `:ready`   — the identity has its OWN usable data (`rf.resources.state/has-data?`), so
                  the requirement is met. `:keep-previous?` PREVIOUS data is a
                  projection POINTER (`:previous-key`) and never this entry's
                  `:data`, so previous data can NOT complete a newly-keyed
@@ -252,7 +252,7 @@
   [entry]
   (cond
     (nil? entry)                            :pending
-    (state/has-data? entry)                 :ready
+    (rf.resources.state/has-data? entry)                 :ready
     (= :error (:status entry))              :failed
     (contains? #{:loading :fetching} (:status entry)) :pending
     (zero? (:attempt entry 0))              :pending
@@ -300,7 +300,7 @@
 
     - it has its OWN usable data (`:ready`) — the partial-revalidation law
       applies and navigation must not revalidate it; or
-    - GENUINELY LIVE work will settle it (`work-ledger/live-work?`) — adopting
+    - GENUINELY LIVE work will settle it (`rf.resources.work-ledger/live-work?`) — adopting
       joins that work, and attach-before-release keeps it from being aborted.
 
   Everything else takes the ordinary ensure/readiness path: an ABSENT entry
@@ -317,7 +317,7 @@
   [runtime-db entry]
   (case (requirement-state entry)
     :ready   true
-    :pending (work-ledger/live-work? runtime-db (:current-work entry))
+    :pending (rf.resources.work-ledger/live-work? runtime-db (:current-work entry))
     false))
 
 (defn- route-blocking-error
@@ -399,7 +399,7 @@
          blocking   (get-in runtime-db (blocking-path nav-token))]
      (if (empty? blocking)
        runtime-db
-       (let [entry-of    (fn [k-id] (get-in runtime-db (state/entry-path-by-id k-id)))
+       (let [entry-of    (fn [k-id] (get-in runtime-db (rf.resources.state/entry-path-by-id k-id)))
              outstanding (into {} (remove (comp requirement-met? entry-of key)) blocking)
              ;; deterministic first failure: the outstanding slot promises no
              ;; order, so the pick is ordered by the canonical CEDN-1 byte
@@ -425,7 +425,7 @@
                ;; rf2-u5aj91: the route slice carries the structured :error AND
                ;; the trace/error stream sees `:rf.error/resource-route-blocking`
                ;; (tags conform to ResourceRouteBlockingTags).
-               (trace/emit-error! :rf.error/resource-route-blocking
+               (rf.trace/emit-error! :rf.error/resource-route-blocking
                                   (dissoc err :rf.error/id :operation)))
              (-> db'
                  (assoc-in (conj slice-path :transition) transition)
@@ -444,8 +444,8 @@
 
 (defn- planning-error
   "Build the canonical route-resource PLANNING ex-info via the central
-  `error/thrown-ex-info` builder (Spec 009 §The thrown-error shape) — the
-  same shape its intra-artefact sibling `registry/registration-error`
+  `rf.error/thrown-ex-info` builder (Spec 009 §The thrown-error shape) — the
+  same shape its intra-artefact sibling `rf.resources.registry/registration-error`
   follows. The fail-closed boundary `route-resource-plan` catches the throw
   and surfaces it on the route slice + Xray (never a silent cache miss).
 
@@ -458,7 +458,7 @@
   `:fix-route-integration`). Per Spec 016 §Route integration (a failed
   params / scope resolution is a planning error, NOT a silent fallback)."
   [reason extra]
-  (error/thrown-ex-info
+  (rf.error/thrown-ex-info
     :rf.error/resource-route-plan
     'rf/route-resource-plan
     reason
@@ -527,8 +527,8 @@
   [{scope-fn :scope :keys [resource]} route ctx app-db]
   (cond
     ;; a {:from-db …} reference — db-derived route-resource scope (slice 3)
-    (scope-registry/from-db-reference? scope-fn)
-    (let [resolved-scope (scope-registry/resolve-from-db-reference
+    (rf.resources.scope-registry/from-db-reference? scope-fn)
+    (let [resolved-scope (rf.resources.scope-registry/resolve-from-db-reference
                            scope-fn (or app-db {}) 'rf.resource/route-entry)]
       (if (nil? resolved-scope)
         (throw (planning-error
@@ -716,17 +716,17 @@
               (if-not (when-passes? entry route ctx)
                 [occurrences next-sequence]
                 (let [resource-id (:resource entry)
-                      spec        (registry/require-resource-spec!
+                      spec        (rf.resources.registry/require-resource-spec!
                                     resource-id 'rf.resource/route-entry)
                       raw-params  (resolve-entry-params entry route)
                       route-scope (resolve-entry-scope entry route ctx app-db)
-                      scope       (registry/resolve-scope-for-event
+                      scope       (rf.resources.registry/resolve-scope-for-event
                                     resource-id spec {:route-scope route-scope :db app-db}
                                     'rf.resource/route-entry)
-                      canonical-params (registry/validate+canonicalize-params
+                      canonical-params (rf.resources.registry/validate+canonicalize-params
                                          resource-id spec raw-params
                                          'rf.resource/route-entry)
-                      scoped-key       (state/scoped-resource-key*
+                      scoped-key       (rf.resources.state/scoped-resource-key*
                                          scope resource-id canonical-params)]
                   [(conj occurrences
                          {:occ-id         [contributor-id (:id entry) next-sequence]
@@ -745,7 +745,7 @@
                           ;; this (vector-vs-list params), so grouping on
                           ;; the scoped key itself collapses a supported
                           ;; pair before any ensure is dispatched.
-                          :key-id         (state/key-id scoped-key)
+                          :key-id         (rf.resources.state/key-id scoped-key)
                           :blocking?      (boolean (:blocking? entry))
                           :keep-previous? (boolean (:keep-previous? entry))})
                    (inc next-sequence)]))
@@ -1112,7 +1112,7 @@
         (cond
           branch-error
           (let [err (stamp (branch-plan-error route-id nav-token branch-error))]
-            (trace/emit-error! :rf.error/resource-route-plan err)
+            (rf.trace/emit-error! :rf.error/resource-route-plan err)
             {:plan-error err})
           :else
           (try
@@ -1120,7 +1120,7 @@
                   collapse-result (collapse-and-order occurrences)]
               (if-let [cyclic (:cycle collapse-result)]
                 (let [err (stamp (collapse-cycle-error route-id nav-token cyclic))]
-                  (trace/emit-error! :rf.error/resource-route-plan err)
+                  (rf.trace/emit-error! :rf.error/resource-route-plan err)
                   {:plan-error err})
                 collapse-result))
             (catch #?(:clj Throwable :cljs :default) ex
@@ -1129,7 +1129,7 @@
               ;; names the resource when the ex carries it.
               (let [err (stamp (plan-error route-id nav-token
                                            (:resource-id (ex-data ex)) ex))]
-                (trace/emit-error! :rf.error/resource-route-plan err)
+                (rf.trace/emit-error! :rf.error/resource-route-plan err)
                 {:plan-error err}))))
         ;; EP-0037 R2 plan diff: partition the dedup'd identities into
         ;; added (ensure with the next owner + freshness) vs kept (adopt the
@@ -1153,12 +1153,12 @@
         ;; rf2-dlkou (merged-PR audit of #7228) — the identity carriers are keyed
         ;; by the CEDN-1 BYTE key-id, NOT by Clojure `=`.
         ;;
-        ;; Resource identity is `state/key-id`, which is collection-KIND
+        ;; Resource identity is `rf.resources.state/key-id`, which is collection-KIND
         ;; sensitive (rf2-wgutc2): `{:p [1 2]}` and `{:p '(1 2)}` are two
-        ;; entries under two `state/entry-path`s, and yet the two scoped keys
+        ;; entries under two `rf.resources.state/entry-path`s, and yet the two scoped keys
         ;; are `=` to Clojure and hash alike. A raw `set` of scoped keys
         ;; therefore COLLAPSES a supported pair before anything downstream can
-        ;; canonicalize it — the row's `sort-by state/key-id` runs after the
+        ;; canonicalize it — the row's `sort-by rf.resources.state/key-id` runs after the
         ;; loss, not before it. What that cost: a navigation whose prior plan
         ;; held `{:p '(1 2)}` and whose next plan holds `{:p [1 2]}` reported
         ;; `:removed 0` and an EMPTY `:removed-identities`, because the prior
@@ -1179,9 +1179,9 @@
         ;; call may hand any collection of scoped keys, which does.
         prev-by-id (if (map? prev-identities)
                      prev-identities
-                     (into {} (map (juxt state/key-id identity)) prev-identities))
+                     (into {} (map (juxt rf.resources.state/key-id identity)) prev-identities))
         next-by-id (into {} (map (juxt :key-id :scoped-key)) ordered)
-        entry-of  (fn [k-id] (get-in runtime-db (state/entry-path-by-id k-id)))
+        entry-of  (fn [k-id] (get-in runtime-db (rf.resources.state/entry-path-by-id k-id)))
         adopted?  (fn [{:keys [key-id]}]
                     (and (contains? prev-by-id key-id)
                          (adoptable? runtime-db (entry-of key-id))))
@@ -1316,7 +1316,7 @@
                                   {:owner [:route prev-id prev-nav-token]}]]])
         added-count        (count ensured-identities)
         removed-count      (count removed-identities)]
-    (trace/emit! :rf.event :rf.resource/route-plan
+    (rf.trace/emit! :rf.event :rf.resource/route-plan
                  (cond-> {:route-id           route-id
                           :nav-token          nav-token
                           :branch             (mapv :route-id branch)
@@ -1513,7 +1513,7 @@
         (cond
           branch-error
           (let [err (warm-err (branch-plan-error route-id nil branch-error))]
-            (trace/emit-error! :rf.error/resource-route-plan err)
+            (rf.trace/emit-error! :rf.error/resource-route-plan err)
             {:plan-error err})
           :else
           (try
@@ -1521,13 +1521,13 @@
                   collapse-result (collapse-and-order occurrences)]
               (if-let [cyclic (:cycle collapse-result)]
                 (let [err (warm-err (collapse-cycle-error route-id nil cyclic))]
-                  (trace/emit-error! :rf.error/resource-route-plan err)
+                  (rf.trace/emit-error! :rf.error/resource-route-plan err)
                   {:plan-error err})
                 collapse-result))
             (catch #?(:clj Throwable :cljs :default) ex
               (let [err (warm-err (plan-error route-id nil
                                               (:resource-id (ex-data ex)) ex))]
-                (trace/emit-error! :rf.error/resource-route-plan err)
+                (rf.trace/emit-error! :rf.error/resource-route-plan err)
                 {:plan-error err}))))
         ;; WARM: ownerless ensure per unique identity — no owner, no blocking,
         ;; no keep-previous?. `:blocking?` on a contributor is inert here.
@@ -1536,7 +1536,7 @@
                                    {:resource resource :scope scope
                                     :params   cparams  :cause  cause}]])
                      ordered)]
-    (trace/emit! :rf.event :rf.resource/route-plan
+    (rf.trace/emit! :rf.event :rf.resource/route-plan
                  (cond-> {:route-id   route-id
                           :plan-cause :prefetch
                           :branch     (mapv :route-id branch)
@@ -1575,9 +1575,9 @@
   §Route-plan prefetch — warm-mode + §Route-plan replan — same-token
   reconciliation."
   []
-  (late-bind/set-fn! :routing/extra-route-keys
+  (rf.late-bind/set-fn! :routing/extra-route-keys
                      (fn extra-route-keys-thunk [] extra-route-keys))
-  (late-bind/set-fn! :routing/on-route-entry    on-route-entry-fx)
-  (late-bind/set-fn! :routing/on-route-prefetch on-route-prefetch-fx)
-  (late-bind/set-fn! :routing/on-route-replan   on-route-replan-fx)
+  (rf.late-bind/set-fn! :routing/on-route-entry    on-route-entry-fx)
+  (rf.late-bind/set-fn! :routing/on-route-prefetch on-route-prefetch-fx)
+  (rf.late-bind/set-fn! :routing/on-route-replan   on-route-replan-fx)
   nil)

--- a/implementation/resources/src/re_frame/resources/scope_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/scope_registry.cljc
@@ -102,12 +102,12 @@
   the handler's coeffect db (the pre-transition causal input) and pass it to
   `:rf.resource/clear-scope` concretely. Per Spec 016 §`clear-scope` resolves
   the concrete scope from the coeffect db (EP-0016 issue 7)."
-  (:require [re-frame.error :as error]
-            [re-frame.path :as path]
-            [re-frame.registrar :as registrar]
-            [re-frame.resources.state :as state]
-            [re-frame.source-coords :as source-coords]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.error :as rf.error]
+            [re-frame.path :as rf.path]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.resources.state :as rf.resources.state]
+            [re-frame.source-coords :as rf.source-coords]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -150,7 +150,7 @@
   "Build the canonical thrown-error shape (Spec 009 §The thrown-error
   shape) for a `reg-resource-scope` validation failure."
   [error-id where reason extra]
-  (error/thrown-ex-info
+  (rf.error/thrown-ex-info
     error-id
     where
     reason
@@ -224,7 +224,7 @@
       ;; a host/opaque or template segment in a `:db` path fails closed here.
       :else
       (try
-        [:db (path/normalize-concrete raw-path)]
+        [:db (rf.path/normalize-concrete raw-path)]
         (catch #?(:clj Exception :cljs :default) e
           (throw (registration-error
                    :rf.error/invalid-resource-scope-spec
@@ -381,16 +381,16 @@
   ([scope-id resolve-fn] (reg-resource-scope scope-id {} resolve-fn))
   ([scope-id metadata resolve-fn]
   (let [spec     (canonical-spec scope-id metadata resolve-fn)
-        previous (registrar/lookup scope-kind scope-id)]
-    (registrar/register!
+        previous (rf.registrar/lookup scope-kind scope-id)]
+    (rf.registrar/register!
       scope-kind
       scope-id
-      (source-coords/merge-coords
+      (rf.source-coords/merge-coords
         (merge {:doc (:doc spec)}
                {:rf/resource-scope spec
                 :handler-fn        (:resolve spec)})))
     (when (nil? previous)
-      (trace/emit! :rf.event :rf.resource/registered
+      (rf.trace/emit! :rf.event :rf.resource/registered
                    {:resource-id scope-id
                     :kind        :resource-scope
                     :inputs      (vec (keys (:inputs spec)))
@@ -406,7 +406,7 @@
   `scope-id`) when the id is not registered. Per Spec 016 §Named
   resource-scope resolvers."
   [scope-id]
-  (registrar/unregister! scope-kind scope-id)
+  (rf.registrar/unregister! scope-kind scope-id)
   scope-id)
 
 ;; ---- registry-side introspection -----------------------------------------
@@ -417,14 +417,14 @@
   registered. The introspection counterpart of `resource-meta` /
   `mutation-meta`. Per Spec 016 §Named resource-scope resolvers."
   [scope-id]
-  (:rf/resource-scope (registrar/lookup scope-kind scope-id)))
+  (:rf/resource-scope (rf.registrar/lookup scope-kind scope-id)))
 
 (defn scope-resolver-ids
   "Return a vector of every registered resource-scope resolver id. Per
   Spec 016 §Named resource-scope resolvers (the static resolver registry —
   enumerable by tooling)."
   []
-  (vec (registrar/ids scope-kind)))
+  (vec (rf.registrar/ids scope-kind)))
 
 (defn require-scope-resolver!
   "Look the resolver spec up by `scope-id`, throwing
@@ -453,7 +453,7 @@
   [inputs db]
   (reduce-kv
     (fn [acc input-name [_source rf-path]]
-      (assoc acc input-name (path/get db rf-path)))
+      (assoc acc input-name (rf.path/get db rf-path)))
     {} (or inputs {})))
 
 ;; ---- off-box trace egress projection of scope-resolution rows (rf2-84l82t) -
@@ -504,14 +504,14 @@
   "PURE core of resolver evaluation: given the ALREADY-EVALUATED resolver
   `in-vals`, call `:resolve` with `(in-vals nil)` (the `ctx` arg is reserved,
   literal nil in this slice), then route a non-nil result through the SHARED
-  concrete-scope canonicalization path (`state/canonicalize-scope`). A nil
+  concrete-scope canonicalization path (`rf.resources.state/canonicalize-scope`). A nil
   result passes through as nil (the fail-closed unresolved condition). Shared
   by `resolve-scope*-pure` and the traced `resolve-scope*` wrapper so a single
   causal resolution evaluates its declared `:inputs` exactly ONCE."
   [scope-id spec in-vals where]
   (let [raw ((:resolve spec) in-vals nil)]
     (when (some? raw)
-      (state/canonicalize-scope raw where scope-id))))
+      (rf.resources.state/canonicalize-scope raw where scope-id))))
 
 (defn resolve-scope*-pure
   "PURE: resolve resolver `spec` against `db`, returning a canonical scope
@@ -519,7 +519,7 @@
   Evaluates the declared `:inputs` off `db`, calls `:resolve` with
   `(inputs nil)` (the `ctx` arg is reserved, literal nil in this slice), then
   routes a non-nil result through the SHARED concrete-scope canonicalization
-  path (`state/canonicalize-scope` — rejects a misspelled `:rf.scope/*`
+  path (`rf.resources.state/canonicalize-scope` — rejects a misspelled `:rf.scope/*`
   keyword fail-closed, rejects a host/opaque value, rejects the global scope
   wrapped as the singleton `[:rf.scope/global]` in favour of the canonical
   bare keyword). A nil result passes through as nil (the fail-closed
@@ -560,7 +560,7 @@
   (let [inputs   (:inputs spec)
         in-vals  (eval-inputs inputs db)
         resolved (resolve-scope-from-inputs scope-id spec in-vals where)]
-    (trace/emit! :rf.event :rf.resource/scope-resolved
+    (rf.trace/emit! :rf.event :rf.resource/scope-resolved
                  {:resource-id   scope-id
                   :kind          :resource-scope
                   :inputs        (vec (keys inputs))
@@ -662,7 +662,7 @@
   the single use-time resolution rule, uniform across every site.
 
     - concrete arm — the literal scope is routed through the shared
-      `state/canonicalize-scope` validation path ONCE (reserved-typo /
+      `rf.resources.state/canonicalize-scope` validation path ONCE (reserved-typo /
       wrapped-global / host-value fail-closed);
     - reference arm — `resolve-from-db-reference` resolves against `db` at use
       time AND emits the causal `:rf.resource/scope-resolved` evidence; its
@@ -683,4 +683,4 @@
   [scope db where resource-id]
   (if (from-db-reference? scope)
     (resolve-from-db-reference scope db where)
-    (state/canonicalize-scope scope where resource-id)))
+    (rf.resources.state/canonicalize-scope scope where resource-id)))

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -62,22 +62,22 @@
   recomputable-from-`:entries` (rebuilt on install, never trusted from the
   snapshot — Spec 016 §Restore and replay part 5) and need not ride. Per
   Spec 016 §Runtime-subsystem graduation clause 4."
-  (:require [re-frame.elision :as elision]
-            [re-frame.error :as error]
-            [re-frame.frame :as frame]
-            [re-frame.identity :as identity]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.privacy :as privacy]
-            [re-frame.resources.classification :as classification]
-            [re-frame.resources.mutation-registry :as mutation-registry]
-            [re-frame.resources.mutation-runtime :as mutation-runtime]
-            [re-frame.resources.registry :as registry]
-            [re-frame.resources.route :as route]
-            [re-frame.resources.state :as state]
-            [re-frame.resources.timers :as timers]
-            [re-frame.resources.work-ledger :as work-ledger]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.elision :as rf.elision]
+            [re-frame.error :as rf.error]
+            [re-frame.frame :as rf.frame]
+            [re-frame.identity :as rf.identity]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.privacy :as rf.privacy]
+            [re-frame.resources.classification :as rf.resources.classification]
+            [re-frame.resources.mutation-registry :as rf.resources.mutation-registry]
+            [re-frame.resources.mutation-runtime :as rf.resources.mutation-runtime]
+            [re-frame.resources.registry :as rf.resources.registry]
+            [re-frame.resources.route :as rf.resources.route]
+            [re-frame.resources.state :as rf.resources.state]
+            [re-frame.resources.timers :as rf.resources.timers]
+            [re-frame.resources.work-ledger :as rf.resources.work-ledger]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -97,12 +97,12 @@
 ;; absolute timestamps against to surface skew — is the core
 ;; `re-frame.interop/epoch-now-ms` (rf2-366u0g — `System/currentTimeMillis`
 ;; on the JVM, `js/Date.now` on CLJS), the canonical EP-0010 §Time wall-clock
-;; surface — NOT the perf clock `interop/now-ms` (`performance.now()` on CLJS,
+;; surface — NOT the perf clock `rf.interop/now-ms` (`performance.now()` on CLJS,
 ;; origin-relative, ~1e4), which is incomparable with `js/Date`-based freshness
 ;; checks. These resources are durable freshness / skew readers, so the wall
 ;; clock is correct.
 ;;
-;; `interop/epoch-now-ms` is PUBLIC (rf2-wshzsp test seam preserved): the
+;; `rf.interop/epoch-now-ms` is PUBLIC (rf2-wshzsp test seam preserved): the
 ;; restore-reconcile suite `with-redefs`-stubs it to a sentinel and ADVERSARIALLY
 ;; pins that restore reads it ONLY for the clock-skew DIAGNOSTIC — never to
 ;; freshen a DURABLE restored entry / instance timestamp (EP-0010
@@ -114,7 +114,7 @@
 ;; Freshness is computed from the entry's DURABLE absolute timestamps
 ;; (`:stale-at` / `:invalidated-at`) against a supplied clock — never from
 ;; trusting a timer fired on time (Spec 016 §Stale and GC scheduling). SSR
-;; reads the CANONICAL `state/entry-stale?` (which explicitly owns the
+;; reads the CANONICAL `rf.resources.state/entry-stale?` (which explicitly owns the
 ;; staleness derivation for the subs projection, the SSR projection, AND the
 ;; stale-timer re-check) so the server projection metadata and the client
 ;; refetch decision agree with the subs layer — there is no SSR-private copy
@@ -135,7 +135,7 @@
 ;;   - the canonical FINE-GRAINED surface is the projection-relative
 ;;     `:sensitive` / `:large` PATH declarations on the resource spec (EP-0025).
 ;;     They are LOWERED per instance into the per-frame elision registry
-;;     (`classification/reconcile-registry`, `:source :resource`) at the entry's
+;;     (`rf.resources.classification/reconcile-registry`, `:source :resource`) at the entry's
 ;;     absolute runtime-db path, and the SSR egress READS that registry back —
 ;;     `project-entry-data` for `:data`, and `project-entry-scope` /
 ;;     `project-entry-params` for the scoped key's two classification-bearing
@@ -149,7 +149,7 @@
 ;; onto the wire — every visitor of every SSR page would otherwise receive
 ;; it. The whole-entry coarse claim drives redact / omit; a `:serialize`
 ;; entry's data slice still rides through the registry-driven
-;; `classification/project-entry-data` (over the SHARED `rf/elide-wire-value`
+;; `rf.resources.classification/project-entry-data` (over the SHARED `rf/elide-wire-value`
 ;; walker) under the SSR boundary profile, so the resource's OWN lowered
 ;; projection-relative `:sensitive` / `:large` path declarations redact / elide
 ;; their slots, and any path the FRAME ALSO classifies composes as
@@ -159,7 +159,7 @@
 ;; family-private elider.
 
 ;; The per-entry disposition (`:serialize` / `:redact` / `:omit`) is computed
-;; inside `project-entry` (`classification/whole-entry-disposition` over the
+;; inside `project-entry` (`rf.resources.classification/whole-entry-disposition` over the
 ;; resource OWNER's coarse root-prop `:sensitive?` / `:large?` claim — EP-0015
 ;; §6 / issue 11). EP-0025 (rf2-71dr8t) removed the named-scope-resolver
 ;; derived-sensitivity inheritance arm (no sensitivity propagation). Sensitive
@@ -314,7 +314,7 @@
 
 (defn- shape-token
   "The CONTENT-FREE payload of a `{:rf/redacted …}` token: `value`'s shape,
-  through `error/diag-value-summary`'s closed vocabulary — a `:type` tag drawn
+  through `rf.error/diag-value-summary`'s closed vocabulary — a `:type` tag drawn
   from a fixed set, plus a `:count` for a counted collection or string.
 
   Every slot is a member of a closed vocabulary or an integer, so no expression
@@ -332,13 +332,13 @@
   reaches neither `toString` nor `pr-str`, so an app payload carrying a host
   object cannot destroy the redaction being performed on it."
   [value]
-  (error/diag-value-summary value))
+  (rf.error/diag-value-summary value))
 
 (defn- canonical-digest-token
   "The CONTENT-ADDRESSED payload of a `{:rf/redacted …}` token: `fnv-1a-32` over
   `value`'s CEDN-1 canonical bytes.
 
-  `identity/canonical-bytes` is the repo's identity authority and is what makes
+  `rf.identity/canonical-bytes` is the repo's identity authority and is what makes
   this a fixed function of the CANONICAL value rather than of one spelling of
   it: `(array-map :a 1 :b 2)` and `(array-map :b 2 :a 1)` are `=`, have equal
   canonical bytes, and now produce one token — on both hosts. `pr-str`, which
@@ -354,7 +354,7 @@
   redaction that throws is not a redaction."
   [value]
   (try
-    (fnv-1a-32 (identity/canonical-bytes value))
+    (fnv-1a-32 (rf.identity/canonical-bytes value))
     (catch #?(:clj Throwable :cljs :default) _t
       (shape-token value))))
 
@@ -418,10 +418,10 @@
 ;; ---- is a wire key one the live client can DERIVE? (rf2-rjq9d) ------------
 ;;
 ;; The client never receives a key; it RE-DERIVES one, from its live scope and
-;; params, and reads `(state/entry-path scoped-key)` (`route/route-resource-
+;; params, and reads `(rf.resources.state/entry-path scoped-key)` (`rf.resources.route/route-resource-
 ;; plan`, `events/ensure-handler`). So a wire key is only useful to it if that
 ;; re-derivation can reproduce it. A per-slot `:scope` / `:params` declaration
-;; breaks exactly that: `classification/project-entry-key-component` substitutes
+;; breaks exactly that: `rf.resources.classification/project-entry-key-component` substitutes
 ;; the CONSTANT `:rf/redacted` / `:rf.size/large-elided` sentinel into the
 ;; declared slot, and no live value re-derives to a constant.
 ;;
@@ -483,8 +483,8 @@
 
 (defn- carries-projection-substitution?
   "Deep-scan `v` for ANY projection substitution that makes a wire key
-  underivable by the live client — `privacy/redacted-sentinel` (`:rf/redacted`)
-  or an `:rf.size/large-elided` marker map (`elision/marker?`) from a per-slot
+  underivable by the live client — `rf.privacy/redacted-sentinel` (`:rf/redacted`)
+  or an `:rf.size/large-elided` marker map (`rf.elision/marker?`) from a per-slot
   declaration, or a whole-component coarse `{:rf/redacted <digest>}` token.
 
   The scan is deep because a per-slot declaration names a SLOT INSIDE a
@@ -501,8 +501,8 @@
   Pure."
   [v]
   (cond
-    (= v privacy/redacted-sentinel) true
-    (elision/marker? v)             true
+    (= v rf.privacy/redacted-sentinel) true
+    (rf.elision/marker? v)             true
     (coarse-redaction-token? v)     true
     (map? v)                        (boolean (some carries-projection-substitution? (vals v)))
     (coll? v)                       (boolean (some carries-projection-substitution? v))
@@ -533,8 +533,8 @@
     - `:serialize` — the key rides VERBATIM (scope + params unchanged). A
       per-slot `:params` / `:scope` projection-relative declaration on a
       `:serialize` resource is the REGISTRY-DRIVEN concern of the SSR
-      `project-entry` path (`classification/project-entry-params` at index 2,
-      rf2-d3pku1; `classification/project-entry-scope` at index 0, rf2-5e2ye):
+      `project-entry` path (`rf.resources.classification/project-entry-params` at index 2,
+      rf2-d3pku1; `rf.resources.classification/project-entry-scope` at index 0, rf2-5e2ye):
       it has the entry's `key-id` + the live SSR frame, so it walks each
       component through `project-egress` seeded at that component's own lowered
       registry path. The trace / tool egress callers do NOT get their per-slot
@@ -558,7 +558,7 @@
 
   The wire key keeps the `[scope resource-id params]` SHAPE so the client's
   index recompute + refetch plan parse it unchanged (resource-id at position
-  1). `spec` is the resource owner spec (`registry/resource-meta`) — retained
+  1). `spec` is the resource owner spec (`rf.resources.registry/resource-meta`) — retained
   for caller signature stability (the disposition already encodes the coarse
   claim it carried). PURE."
   [scoped-key disposition _spec]
@@ -573,8 +573,8 @@
   disposition+project-key pipeline. Returns
   `[projected-key disposition spec]`:
 
-    1. `spec`        ← `registry/resource-meta` of `scoped-key`'s resource-id;
-    2. `disposition` ← `classification/whole-entry-disposition spec`
+    1. `spec`        ← `rf.resources.registry/resource-meta` of `scoped-key`'s resource-id;
+    2. `disposition` ← `rf.resources.classification/whole-entry-disposition spec`
        (the coarse owner `:sensitive?` / `:large?` root-prop claim; scope
        resolver inputs never propagate classification to the output);
     3. projected key ← `project-scoped-key scoped-key disposition spec`
@@ -582,8 +582,8 @@
        `{:rf/redacted <digest>}` tokens; `:serialize` rides VERBATIM — the
        resource-id always survives. A `:serialize` key's per-slot `:params` /
        `:scope` projection-relative declarations are the registry-driven concern
-       of the SSR `project-entry` caller — `classification/project-entry-scope`
-       at index 0 and `classification/project-entry-params` at index 2 — which
+       of the SSR `project-entry` caller — `rf.resources.classification/project-entry-scope`
+       at index 0 and `rf.resources.classification/project-entry-params` at index 2 — which
        has the entry's `key-id` + the live frame).
 
   The single home for the pipeline the SSR durable-egress projection
@@ -595,7 +595,7 @@
   never drift between egress boundaries. Pure.
 
   It lives HERE (not in `classification`) because the pipeline needs both
-  `project-scoped-key` (this ns) AND `registry/resource-meta` — and
+  `project-scoped-key` (this ns) AND `rf.resources.registry/resource-meta` — and
   `re-frame.resources.registry` already requires `classification`, so hosting
   it in `classification` would introduce a require cycle. `ssr` already
   requires both `classification` and `registry`, and the trace / tool egress
@@ -603,8 +603,8 @@
   signature stability; whole-entry disposition is frame-independent."
   [scoped-key _frame-id]
   (let [resource-id (second scoped-key)
-        spec        (registry/resource-meta resource-id)
-        disposition (classification/whole-entry-disposition spec)]
+        spec        (rf.resources.registry/resource-meta resource-id)
+        disposition (rf.resources.classification/whole-entry-disposition spec)]
     [(project-scoped-key scoped-key disposition spec) disposition spec]))
 
 (defn- project-entry
@@ -652,7 +652,7 @@
   [frame-id clock-ms entry]
   (let [scoped-key  (:resource/key entry)
         resource-id (second scoped-key)
-        key-id      (state/key-id scoped-key)
+        key-id      (rf.resources.state/key-id scoped-key)
         ;; The shared disposition+project-key pipeline (rf2-366u0g) resolves the
         ;; owner spec ONCE, computes the whole-entry disposition, and projects
         ;; the scoped key in one call:
@@ -667,7 +667,7 @@
         ;;     `:serialize` key rides verbatim and its per-slot scope + params
         ;;     are registry-projected below.
         [projected-key disposition _spec] (disposition+project-key scoped-key frame-id)
-        stale?      (state/entry-stale? entry clock-ms)
+        stale?      (rf.resources.state/entry-stale? entry clock-ms)
         ;; A `:serialize` key's BOTH classification-bearing components are
         ;; REGISTRY-PROJECTED — the SCOPE at index 0 (rf2-5e2ye) and the PARAMS
         ;; at index 2 (rf2-d3pku1). `reconcile-registry` lowers a `:scope`-rooted
@@ -683,21 +683,21 @@
         ;; DEPENDS on it — see `key-projected?` immediately below.
         projected-key (if (= :serialize disposition)
                         (let [[scope rid params] projected-key]
-                          [(classification/project-entry-scope
+                          [(rf.resources.classification/project-entry-scope
                              scope key-id frame-id
                              :rf.egress/ssr-hydration)
                            rid
-                           (classification/project-entry-params
+                           (rf.resources.classification/project-entry-params
                              params key-id frame-id
                              :rf.egress/ssr-hydration)])
                         projected-key)
         ;; rf2-rjq9d — DID a per-slot declaration actually change this entry's
-        ;; identity? `state/key-id` is `canonical-bytes` over the WHOLE key
+        ;; identity? `rf.resources.state/key-id` is `canonical-bytes` over the WHOLE key
         ;; vector, so projecting EITHER component re-keys the entry, and
         ;; `project-resources-runtime-db` installs the wire entry under the
         ;; key-id of THIS projected key. The live client, however, derives the
         ;; ORDINARY scoped key from live scope + params and reads
-        ;; `(state/entry-path scoped-key)` — the RAW key-id (`route/route-
+        ;; `(rf.resources.state/entry-path scoped-key)` — the RAW key-id (`rf.resources.route/route-
         ;; resource-plan`'s readiness read, `events/ensure-handler`). It
         ;; therefore CANNOT address a re-keyed entry, and issues a load.
         ;;
@@ -707,7 +707,7 @@
         ;; clear — the exact leak rf2-5e2ye closed. Nor is it fixable by having
         ;; the client re-derive the PROJECTED key-id and adopt the entry under
         ;; it: the per-slot substitution is the CONSTANT `:rf/redacted` /
-        ;; `:rf.size/large-elided` sentinel (`classification/project-entry-key-
+        ;; `:rf.size/large-elided` sentinel (`rf.resources.classification/project-entry-key-
         ;; component`), NOT the classification-chosen `{:rf/redacted …}` token
         ;; the coarse arm uses, so the mapping is MANY-TO-ONE precisely on the
         ;; slots that carry principal identity. Two tenants' keys project to one
@@ -731,7 +731,7 @@
         ;; reason (see `unaddressable-wire-key?`: neither token payload buys
         ;; the coarse arm an adoption path).
         ;; Comparing key-ids is exact, so nothing here sniffs a shape.
-        key-derivable? (= (state/key-id projected-key) key-id)
+        key-derivable? (= (rf.resources.state/key-id projected-key) key-id)
         ;; the `:serialize`-specific NAME for that answer, which drives the
         ;; `:key-projected` disposition and the data decision below. It is
         ;; narrower than `key-derivable?` on purpose: a coarse entry is already
@@ -770,7 +770,7 @@
                       ;; per-slot `:data` declarations were lowered into the
                       ;; per-frame elision registry at the entry's absolute
                       ;; `:data` path (`reconcile-registry`), and
-                      ;; `classification/project-entry-data` walks the bare `:data`
+                      ;; `rf.resources.classification/project-entry-data` walks the bare `:data`
                       ;; through `project-egress` SEEDED at that absolute offset
                       ;; (`[:rf.runtime/resources :entries <key-id> :data]`) so the
                       ;; lowered `:source :resource` decls — UNIONED with any frame
@@ -789,7 +789,7 @@
                       ;; branch.
                       :serialize
                       (assoc entry :data
-                             (classification/project-entry-data
+                             (rf.resources.classification/project-entry-data
                                (:data entry) key-id frame-id
                                :rf.egress/ssr-hydration))
                       ;; sensitive: replace data with the redaction sentinel.
@@ -809,7 +809,7 @@
                       ;; `:withheld?` does, from an exact key-id comparison.
                       :redact
                       (-> entry
-                          (assoc :data privacy/redacted-sentinel)
+                          (assoc :data rf.privacy/redacted-sentinel)
                           (dissoc :refresh-error))
                       ;; large: drop the data key entirely (metadata only).
                       :omit
@@ -830,7 +830,7 @@
         ;; depends on whether it fired); `projected-key` here is already final.
         ;;
         ;; Projecting either component CHANGES the entry's `key-id`, because
-        ;; `state/key-id` is `canonical-bytes` over the WHOLE key vector.
+        ;; `rf.resources.state/key-id` is `canonical-bytes` over the WHOLE key vector.
         ;; `project-resources-runtime-db` re-keys each wire entry on the `key-id`
         ;; of THIS projected `:resource/key`, so the wire map key and the entry's
         ;; own copy are one value by construction, and the client's
@@ -942,7 +942,7 @@
 
   ## The re-key, and what it costs the entry (rf2-5e2ye, rf2-rjq9d)
 
-  `state/key-id` is `canonical-bytes` over the WHOLE `[scope resource-id params]`
+  `rf.resources.state/key-id` is `canonical-bytes` over the WHOLE `[scope resource-id params]`
   vector, so projecting EITHER component changes it. The wire map is therefore
   keyed on the key-id of each entry's PROJECTED `:resource/key` — the wire map
   key and the entry's own copy are ONE value by construction, and the client
@@ -990,7 +990,7 @@
 
   Unlike the trace / tool key projection (`trace-egress/redact-key-declarations`,
   rf2-dl7bz), which is dev-only — every caller sits behind
-  `interop/debug-enabled?` or bundle isolation — this projection is PRODUCTION.
+  `rf.interop/debug-enabled?` or bundle isolation — this projection is PRODUCTION.
   It is the body behind `:ssr/extend-runtime-db-projection`, called from
   `re-frame.ssr.payload-policy/project-runtime-db` on every SSR render, and its
   output ships in the `:rf/hydration-payload` to every visitor of every page.
@@ -1001,12 +1001,12 @@
    ;; site already inside the frame's own `with-frame` (ambient == the target) —
    ;; e.g. a direct unit-test caller. The security-critical SSR consumer passes
    ;; the explicit target (rf2-f02diw).
-   (project-resources-runtime-db runtime-db (frame/resolve-current-frame)))
+   (project-resources-runtime-db runtime-db (rf.frame/resolve-current-frame)))
   ([runtime-db frame-id]
-   (let [resources (get runtime-db state/resources-key)
+   (let [resources (get runtime-db rf.resources.state/resources-key)
          entries   (:entries resources)]
      (if (seq entries)
-       (let [clock-ms (interop/epoch-now-ms)
+       (let [clock-ms (rf.interop/epoch-now-ms)
              ;; rf2-9e0tyq — the projected wire entries are RE-KEYED on the byte
              ;; `key-id` of each entry's PROJECTED `:resource/key` (the wire
              ;; entry's own `:resource/key`, set by `project-entry`), so the
@@ -1026,9 +1026,9 @@
                               (map (fn [[_k-id entry]] (project-entry frame-id clock-ms entry)))
                               (remove (fn [[_wire-entry meta']] (:withheld? meta')))
                               (map (fn [[wire-entry _meta]]
-                                     [(state/key-id (:resource/key wire-entry)) wire-entry])))
+                                     [(rf.resources.state/key-id (:resource/key wire-entry)) wire-entry])))
                             entries)]
-         {state/resources-key {:entries wired}})
+         {rf.resources.state/resources-key {:entries wired}})
        {}))))
 
 ;; ---- server blocking drain (Spec 016 §SSR and hydration steps 3-4) --------
@@ -1135,10 +1135,10 @@
             entries' (reduce
                        (fn [es [k-id k]]
                          (let [entry (or (get es k-id)
-                                         (state/empty-entry (second k) k))]
-                           (assoc es k-id (state/entry-failed entry {:error error}))))
+                                         (rf.resources.state/empty-entry (second k) k))]
+                           (assoc es k-id (rf.resources.state/entry-failed entry {:error error}))))
                        entries unsettled)]
-        (trace/emit-error! :rf.error/resource-ssr-blocking-timeout
+        (rf.trace/emit-error! :rf.error/resource-ssr-blocking-timeout
                            {:rf.error/id :rf.error/resource-ssr-blocking-timeout
                             :where       're-frame.resources.ssr/settle-blocking-timeout
                             :frame       frame-id
@@ -1172,7 +1172,7 @@
 ;; itself uses (resources never statically depends on routing). The route
 ;; slice's READINESS, by contrast, is not a literal but a projection, and it
 ;; has exactly one implementation: hydration + restore call
-;; `route/reconcile-readiness` rather than re-deriving it here.
+;; `rf.resources.route/reconcile-readiness` rather than re-deriving it here.
 
 (def ^:private routing-key
   "The routing-runtime subtree key (`:rf.runtime/routing`). Mirrors the
@@ -1276,16 +1276,16 @@
   record). The drain reads the LIVE frame each tick (`frame-runtime-db-value`)
   so a reply that lands mid-pump is observed."
   [frame-id {:keys [pump! deadline-ms clock-fn tick-ms]}]
-  (let [clock-fn (or clock-fn interop/epoch-now-ms)
-        rdb0     (frame/frame-runtime-db-value frame-id)
+  (let [clock-fn (or clock-fn rf.interop/epoch-now-ms)
+        rdb0     (rf.frame/frame-runtime-db-value frame-id)
         blocking (current-blocking-keys rdb0)]
     (if (empty? blocking)
       {:settled? true :timed-out [] :route-blocking-failure nil}
       (let [start    (clock-fn)
             deadline (+ start deadline-ms)]
         (loop []
-          (let [rdb     (frame/frame-runtime-db-value frame-id)
-                entries (get-in rdb [state/resources-key :entries])]
+          (let [rdb     (rf.frame/frame-runtime-db-value frame-id)
+                entries (get-in rdb [rf.resources.state/resources-key :entries])]
             (cond
               ;; every blocking entry settled within budget — render sees the
               ;; settled state, runtime-db untouched.
@@ -1298,11 +1298,11 @@
               (>= (clock-fn) deadline)
               (let [{:keys [entries route-blocking-failure]}
                     (settle-blocking-timeout entries blocking deadline-ms frame-id)]
-                (frame/swap-runtime-db! frame-id assoc-in
-                                        [state/resources-key :entries] entries)
+                (rf.frame/swap-runtime-db! frame-id assoc-in
+                                        [rf.resources.state/resources-key :entries] entries)
                 {:settled?              false
                  :timed-out             (vec (vals (unsettled-blocking-keys
-                                                     (get-in rdb [state/resources-key :entries])
+                                                     (get-in rdb [rf.resources.state/resources-key :entries])
                                                      blocking)))
                  :route-blocking-failure route-blocking-failure})
 
@@ -1504,7 +1504,7 @@
        Wiring the COMPUTE into the reconcile means the per-entry decision is
        never lost on the `:rf/hydrate` install path;
     5. RECONCILE the hydrated route readiness through the one projector
-       (`route/reconcile-readiness`) — the payload's cached `:transition` /
+       (`rf.resources.route/reconcile-readiness`) — the payload's cached `:transition` /
        `:error` is not independent authority, and hydration MUST NOT preserve
        a `:loading` / `:error` the reconciled resource facts contradict (Spec
        012 §Route readiness is a resource projection). A payload with no
@@ -1517,11 +1517,11 @@
   emit self-gates on debug)."
   ([runtime-db] (hydrate-runtime-db runtime-db nil))
   ([runtime-db frame-id]
-   (let [resources (get runtime-db state/resources-key)
+   (let [resources (get runtime-db rf.resources.state/resources-key)
          entries   (:entries resources)]
      (if-not (seq entries)
        runtime-db
-       (let [clock-ms (interop/epoch-now-ms)
+       (let [clock-ms (rf.interop/epoch-now-ms)
              ;; reconcile each entry: orphan SSR owners + clear current-work +
              ;; settle a non-terminal entry to last-stable (rf2-bg6qah).
              ;; Hydration passes nil live-nav-token — there is no client
@@ -1593,10 +1593,10 @@
                           entries)
              entries'  (:entries reconciled)
              ;; recompute the reverse indexes from the reconciled entries
-             subtree'  (state/recompute-indexes
+             subtree'  (rf.resources.state/recompute-indexes
                          (assoc resources :entries entries'))
-             rdb'      (assoc runtime-db state/resources-key subtree')]
-         (trace/emit! :rf.event :rf.resource/hydrated
+             rdb'      (assoc runtime-db rf.resources.state/resources-key subtree')]
+         (rf.trace/emit! :rf.event :rf.resource/hydrated
                       {:rf.frame/id    frame-id
                        :installed      (count entries')
                        :orphaned-owners (vec (:orphaned reconciled))
@@ -1615,7 +1615,7 @@
                        ;; nothing the payload did not already contain.
                        :unaddressable  (vec (:unaddressable reconciled))})
          (doseq [[sk skew] (:skews reconciled)]
-           (trace/emit! :warning :rf.resource/hydrate-clock-skew
+           (rf.trace/emit! :warning :rf.resource/hydrate-clock-skew
                         {:rf.frame/id  frame-id
                          :resource/key sk
                          :skew-ms      skew
@@ -1640,7 +1640,7 @@
          ;; readiness no live work can ever move. No routing slice / no live
          ;; nav-token / no blocking slot is a structural no-op. Per Spec 012
          ;; §Route readiness is a resource projection.
-         (route/reconcile-readiness rdb'))))))
+         (rf.resources.route/reconcile-readiness rdb'))))))
 
 ;; ---- epoch-restore reconcile (Spec 016 §Restore and replay parts 2/4/5) ---
 ;;
@@ -1681,7 +1681,7 @@
 ;;      pre-restore in-flight reply that lands post-restore is suppressed by the
 ;;      ordinary work-id + generation check (the entry no longer points at it and
 ;;      its row is terminal). The generation allocator is host-side + monotonic
-;;      (part 1, `state/generation-cache`), so the dangling `:work/id` can never
+;;      (part 1, `rf.resources.state/generation-cache`), so the dangling `:work/id` can never
 ;;      re-match a live entry — collision is structurally impossible.
 ;;
 ;; Whether a settled entry then re-fetches is a freshness decision (part 3) — it
@@ -1704,7 +1704,7 @@
   [entry]
   (if (contains? #{:loading :fetching} (:status entry))
     (let [next (cond
-                 (state/has-data? entry) :loaded
+                 (rf.resources.state/has-data? entry) :loaded
                  (some? (:error entry))  :error
                  :else                   :idle)]
       (assoc entry :status next))
@@ -1726,10 +1726,10 @@
   handles are dropped by the resources frame-destroy / restore teardown, not
   here (this only moves the durable serializable row forward)."
   [runtime-db]
-  (let [ledger (get runtime-db state/work-ledger-key)
+  (let [ledger (get runtime-db rf.resources.state/work-ledger-key)
         non-terminal (into []
                            (comp (filter (fn [[_ r]]
-                                           (contains? work-ledger/non-terminal-statuses
+                                           (contains? rf.resources.work-ledger/non-terminal-statuses
                                                       (:status r))))
                                  (map key))
                            ledger)]
@@ -1740,8 +1740,8 @@
       ;; `update-record-by-id` (NOT `update-record`, which re-transforms a
       ;; work-id VECTOR to its byte id and would double-hash).
       [(reduce (fn [rdb work-id-id]
-                 (work-ledger/update-record-by-id rdb work-id-id
-                                                   work-ledger/mark-terminal
+                 (rf.resources.work-ledger/update-record-by-id rdb work-id-id
+                                                   rf.resources.work-ledger/mark-terminal
                                                    :suppressed
                                                    {:reason :dangling
                                                     :recovery :restore-reconcile}))
@@ -1763,7 +1763,7 @@
 
   Each restored pending/idle instance is TERMINALLY SETTLED to `:error` with
   the `:dangling-on-restore` envelope and its `:current-work` is CLEARED
-  (`mutation-runtime/instance-dangled`). Clearing `:current-work` makes the
+  (`rf.resources.mutation-runtime/instance-dangled`). Clearing `:current-work` makes the
   ordinary work-id + generation gate suppress the late reply (the
   `(= work-id (:current-work inst))` check fails); the generation allocator is
   host-side + monotonic (part 1), so the dangling work-id can never re-match a
@@ -1774,7 +1774,7 @@
   EP-0019 Q3 GUARD — a dangled OPTIMISTIC write also ROLLS BACK its recorded
   apply (the entry shows the optimistic value with no in-flight write to confirm
   it — an accepted-error-shaped terminal). The rollback runs INSIDE this same
-  pure pass (`mutation-runtime/dangle-rollback-optimistic`), NOT as a second
+  pure pass (`rf.resources.mutation-runtime/dangle-rollback-optimistic`), NOT as a second
   post-restore dispatched event that could RACE a fresh load: an UNMOVED
   `:revision` restores the recorded `:before` verbatim; a CONFLICT (the entry's
   revision moved) marks the entry durably STALE in place (the read path refetches
@@ -1790,13 +1790,13 @@
   handles are cleared separately — the mutation's work-ledger row is dangled by
   `dangle-non-terminal-work!`, work-kind `:mutation`)."
   [runtime-db settled-at]
-  (let [instances (get-in runtime-db (mutation-runtime/instances-path))
+  (let [instances (get-in runtime-db (rf.resources.mutation-runtime/instances-path))
         ;; rf2-8iciw8 — `:rf.runtime/mutations` is keyed on the CEDN-1 byte
         ;; `key-id`; iterate the map's OWN keys (already byte key-ids) and
         ;; operate on the direct `[mutations-key <key-id>]` path. Do NOT re-feed
         ;; a byte key-id through `instance-path` (that would re-encode it).
         pending   (into []
-                        (comp (filter (fn [[_ inst]] (mutation-runtime/pending? inst)))
+                        (comp (filter (fn [[_ inst]] (rf.resources.mutation-runtime/pending? inst)))
                               (map key))
                         instances)]
     (if (empty? pending)
@@ -1804,7 +1804,7 @@
       (let [[rdb' rolled-keys dangled-ids]
             (reduce
               (fn [[rdb rk dids] key-id]
-                (let [inst-path (conj (mutation-runtime/instances-path) key-id)
+                (let [inst-path (conj (rf.resources.mutation-runtime/instances-path) key-id)
                       inst (get-in rdb inst-path)
                       ;; EP-0019 Q3 — roll back the recorded optimistic apply
                       ;; (conflict-aware, INSIDE the pass) BEFORE settling the
@@ -1812,11 +1812,11 @@
                       ;; restored `:before`, or a durable-stale entry the read path
                       ;; refetches), never a dangling optimistic value with no
                       ;; in-flight write to confirm it.
-                      spec (mutation-registry/mutation-meta (:mutation/id inst))
-                      [rdb2 keys2] (mutation-runtime/dangle-rollback-optimistic
+                      spec (rf.resources.mutation-registry/mutation-meta (:mutation/id inst))
+                      [rdb2 keys2] (rf.resources.mutation-runtime/dangle-rollback-optimistic
                                      rdb inst spec settled-at)]
                   [(update-in rdb2 inst-path
-                              mutation-runtime/instance-dangled settled-at)
+                              rf.resources.mutation-runtime/instance-dangled settled-at)
                    (into rk keys2)
                    ;; surface the kind-preserving `:instance/id` in the returned
                    ;; dangled-id list (the byte key-id is opaque storage detail).
@@ -1833,19 +1833,19 @@
   cleared so a stale timer / abandoned in-flight handle cannot fire against the
   restored state:
 
-    - **stale / GC timer handles** (`timers/release-frame!`) — cancelled +
+    - **stale / GC timer handles** (`rf.resources.timers/release-frame!`) — cancelled +
       dropped for the frame; stale/GC scheduling re-arms LAZILY from the
       restored entries' durable timestamps the next time the runtime touches
       each entry (the timer is advisory, re-checked against durable facts), so
       restore arms NO eager timer;
-    - **work-ledger host handles** (`work-ledger/release-frame!`) — the
+    - **work-ledger host handles** (`rf.resources.work-ledger/release-frame!`) — the
       AbortController / transport-promise slots for the frame's in-flight
       attempts; best-effort aborted on the way out (the work is dangling per
       part 2 — its durable row was already settled `:suppressed`).
 
   DELIBERATELY does NOT touch (Spec 016 part 5 / the bead's explicit fence):
 
-    - the host-side GENERATION high-water mark (`state/generation-cache`) — it
+    - the host-side GENERATION high-water mark (`rf.resources.state/generation-cache`) — it
       is monotonic + must NOT rewind (part 1), or a pre-restore reply's
       generation could re-match a post-restore entry; resetting it here would
       reintroduce the exact anti-recycling hazard restore exists to prevent;
@@ -1860,8 +1860,8 @@
   (mutates the module-level `timer-table` / `handle-table`); idempotent;
   returns nil. No-op for a frame with no armed transients."
   [frame-id]
-  (timers/release-frame! frame-id)
-  (work-ledger/release-frame! frame-id)
+  (rf.resources.timers/release-frame! frame-id)
+  (rf.resources.work-ledger/release-frame! frame-id)
   nil)
 
 ;; ---- deferred restore trace intents (rf2-obi8rr) --------------------------
@@ -1882,7 +1882,7 @@
 ;; directly (the 1-/2-arity, the pure unit-test path) the reconcile still emits
 ;; inline — there is no install to gate against. The host-side-transient clear is
 ;; NOT deferred: it is idempotent and the only failure path is an already-
-;; destroyed frame whose transients `frame/destroy-frame!` already released.
+;; destroyed frame whose transients `rf.frame/destroy-frame!` already released.
 
 (def ^:private deferred-trace-intents-key
   "Metadata key carrying the deferred restore-reconcile trace intents on the
@@ -1893,13 +1893,13 @@
 
 (defn- emit-trace-intent!
   "Emit one deferred restore trace intent `{:level :op :tags}` through the
-  matching `trace` emitter. `:error` routes through `trace/emit-error!` (the
+  matching `trace` emitter. `:error` routes through `rf.trace/emit-error!` (the
   structured-error channel); every other level (`:rf.epoch` / `:warning` / …)
-  routes through `trace/emit!`. Per rf2-obi8rr."
+  routes through `rf.trace/emit!`. Per rf2-obi8rr."
   [{:keys [level op tags]}]
   (if (= :error level)
-    (trace/emit-error! op tags)
-    (trace/emit! level op tags))
+    (rf.trace/emit-error! op tags)
+    (rf.trace/emit! level op tags))
   nil)
 
 (defn commit-restore-reconcile-traces!
@@ -1927,7 +1927,7 @@
    (let [still-owned? (fn []
                         (or (nil? frame-id)
                             (nil? owner-token)
-                            (frame/frame-incarnation-live? frame-id owner-token)))]
+                            (rf.frame/frame-incarnation-live? frame-id owner-token)))]
      (doseq [intent (-> reconciled-runtime-db meta (get deferred-trace-intents-key))
              :while (still-owned?)]
        (emit-trace-intent! intent)))
@@ -1968,7 +1968,7 @@
        `:generation`, not the resource entry's, so the resource-side dangle
        alone does NOT suppress it);
     3c. RECONCILE the restored route readiness through the one projector
-       (`route/reconcile-readiness`, run LAST so it projects over the settled
+       (`rf.resources.route/reconcile-readiness`, run LAST so it projects over the settled
        entries + dangled work). A snapshot captured mid-load restores a route
        `:loading` whose in-flight work step 3 has just dangled — nothing would
        ever move it again — so restore recomputes `:transition` / `:error`
@@ -2004,7 +2004,7 @@
     atomic install, so a callback that churns incarnation A to a same-id
     successor B mid-reconcile could otherwise make it release B's live host
     handles. When present, the clear fires ONLY while that exact incarnation is
-    still live (`frame/frame-incarnation-live?`); once it is lost the clear is
+    still live (`rf.frame/frame-incarnation-live?`); once it is lost the clear is
     skipped — B is untouched, and A's transients were already released by
     `destroy-frame!`. nil (the pure-unit 1-/2-arity) has no incarnation to fence
     and clears unconditionally, as before.
@@ -2012,7 +2012,7 @@
     epoch's `:committed-at` (the committing token's `:rf.cofx`
     `:rf/time-ms`, replay-stable per EP-0010 §Time). It is the source of the
     DURABLE `:settled-at` stamped on a PENDING mutation instance dangled on
-    restore — NOT the live install clock (`interop/epoch-now-ms`). Per EP-0010 §Restore/Replay
+    restore — NOT the live install clock (`rf.interop/epoch-now-ms`). Per EP-0010 §Restore/Replay
     a durable frame-state field MUST come from a causal input, never an ambient
     world read at install. nil on the pure-unit 1-/2-arity (no token / no real
     restore epoch), where it falls back to the live clock — those paths install
@@ -2025,10 +2025,10 @@
   ([runtime-db] (reconcile-on-restore runtime-db nil nil))
   ([runtime-db frame-id] (reconcile-on-restore runtime-db frame-id nil))
   ([runtime-db frame-id {:keys [defer-traces? restore-time-ms owner-token]}]
-   (let [resources (get runtime-db state/resources-key)
+   (let [resources (get runtime-db rf.resources.state/resources-key)
          entries   (:entries resources)
-         ledger    (get runtime-db state/work-ledger-key)
-         mutations (get-in runtime-db (mutation-runtime/instances-path))
+         ledger    (get runtime-db rf.resources.state/work-ledger-key)
+         mutations (get-in runtime-db (rf.resources.mutation-runtime/instances-path))
          ;; the nav-token the restored routing slice currently considers live
          ;; — restore installs both partitions wholesale, so routing :current
          ;; is present in this same runtime-db (nil when the app carries no
@@ -2037,7 +2037,7 @@
          live-nav-token (get-in runtime-db routing-current-nav-token-path)]
      (if-not (or (seq entries) (seq ledger) (seq mutations))
        runtime-db
-       (let [clock-ms (interop/epoch-now-ms)
+       (let [clock-ms (rf.interop/epoch-now-ms)
              ;; reconcile each entry: orphan SSR owners + STALE-NAV route
              ;; owners (part 4) + clear current-work (part 2) + settle a
              ;; mid-flight status to last-stable (restore-specific — the wire
@@ -2065,10 +2065,10 @@
                           {:entries {} :orphaned [] :skews []}
                           entries)
              entries'  (:entries reconciled)
-             subtree'  (state/recompute-indexes
+             subtree'  (rf.resources.state/recompute-indexes
                          (assoc resources :entries entries'))
              rdb'      (cond-> runtime-db
-                         (seq entries) (assoc state/resources-key subtree'))
+                         (seq entries) (assoc rf.resources.state/resources-key subtree'))
              ;; settle the dangling non-terminal work-ledger rows (restore-specific)
              [rdb'' dangled] (dangle-non-terminal-work! rdb')
              ;; settle the dangling PENDING mutation instances + clear their
@@ -2082,7 +2082,7 @@
              ;; come from the restore's CAUSAL time (`restore-time-ms` — the
              ;; restored epoch's `:committed-at`, itself the committing token's
              ;; `:rf.cofx` `:rf/time-ms`), NOT the ambient `clock-ms`
-             ;; (`interop/epoch-now-ms`) read above. Sourcing it from the live install clock
+             ;; (`rf.interop/epoch-now-ms`) read above. Sourcing it from the live install clock
              ;; would make the durable stamp non-replayable (the exact shape the
              ;; EP's restore clause warns against: a durable write fed by an
              ;; ambient read at install). `clock-ms` legitimately feeds ONLY the
@@ -2101,7 +2101,7 @@
              [rdb-dangled dangled-mutations rolled-mutation-keys]
              (dangle-pending-mutations! rdb'' settled-at)
              rdb''' (if (seq rolled-mutation-keys)
-                      (update rdb-dangled state/resources-key state/recompute-indexes)
+                      (update rdb-dangled rf.resources.state/resources-key rf.resources.state/recompute-indexes)
                       rdb-dangled)
              ;; rf2-obi8rr — compute the restore-reconcile trace rows as INTENTS
              ;; (plain `{:level :op :tags}` data). They are emitted inline below
@@ -2215,7 +2215,7 @@
          ;; unconditionally, as before.
          (when (and frame-id
                     (or (nil? owner-token)
-                        (frame/frame-incarnation-live? frame-id owner-token)))
+                        (rf.frame/frame-incarnation-live? frame-id owner-token)))
            (clear-host-transients-on-restore! frame-id))
          ;; rf2-kqxe6.17 — reconcile the restored ROUTE readiness through the
          ;; ONE projector, LAST (after the entry settles + the work/mutation
@@ -2229,7 +2229,7 @@
          ;; and must announce nothing an aborted install would not have done
          ;; (rf2-obi8rr). Per Spec 012 §Route readiness is a resource
          ;; projection.
-         (let [rdb-final (route/reconcile-readiness
+         (let [rdb-final (rf.resources.route/reconcile-readiness
                            rdb''' {:emit-error? (not defer-traces?)})]
            (if defer-traces?
              ;; rf2-obi8rr — ride the intents back as metadata; the epoch
@@ -2254,7 +2254,7 @@
 ;;
 ;; A REDACTED entry rides
 ;; the wire with its `:data` REPLACED by the redaction sentinel
-;; (`privacy/redacted-sentinel` = `:rf/redacted`) — it is METADATA ONLY, NOT
+;; (`rf.privacy/redacted-sentinel` = `:rf/redacted`) — it is METADATA ONLY, NOT
 ;; usable data. A naive `(some? (:data entry))` would see the sentinel as
 ;; present and misclassify a redacted entry as fresh-with-data → NEVER
 ;; refetch, leaving the client rendering the `:rf/redacted` sentinel as if it
@@ -2263,14 +2263,14 @@
 
 (defn hydrated-data-usable?
   "True iff a HYDRATED `entry` carries USABLE last-known-good `:data` — i.e.
-  `:data` is NOT the redaction sentinel (`privacy/redacted-sentinel`) AND the
-  durable `state/has-data?` predicate reports usable data. A `:sensitive?`
+  `:data` is NOT the redaction sentinel (`rf.privacy/redacted-sentinel`) AND the
+  durable `rf.resources.state/has-data?` predicate reports usable data. A `:sensitive?`
   resource projects its data as the sentinel (`project-entry` `:redact`), so on
   the wire the entry's `:data` is `:rf/redacted` — metadata only, never usable.
   An `:large?` resource OMITS the `:data` key entirely (nil — also not usable).
 
   This DELEGATES the 'is there usable last-known-good data?' question to
-  `state/has-data?` so the two never drift: crucially, an INFINITE feed's
+  `rf.resources.state/has-data?` so the two never drift: crucially, an INFINITE feed's
   `:data` is the ordered PAGE VECTOR (seeded `[]`), and an EMPTY page vector is
   NO usable data (EP-0021 R1) — a naive `(some? :data)` would treat `[]` as
   present and strand an empty hydrated feed fresh-forever (rf2-x76af2.11). The
@@ -2280,8 +2280,8 @@
   Spec 016 §SSR and hydration (redacted entries hydrate as metadata only)."
   [entry]
   (let [d (:data entry)]
-    (and (not= privacy/redacted-sentinel d)
-         (state/has-data? entry))))
+    (and (not= rf.privacy/redacted-sentinel d)
+         (rf.resources.state/has-data? entry))))
 
 (defn entry-needs-refetch?
   "Decide whether a hydrated `entry` needs a client refetch against
@@ -2305,7 +2305,7 @@
   (let [usable? (hydrated-data-usable? entry)]
     (cond
       (not usable?)                true            ;; metadata-only / redacted / error
-      (state/entry-stale? entry clock-ms) true           ;; stale-while-revalidate
+      (rf.resources.state/entry-stale? entry clock-ms) true           ;; stale-while-revalidate
       :else                         false)))       ;; fresh + usable data → no dup-fetch
 
 (defn hydrate-refetch-plan
@@ -2345,10 +2345,10 @@
 
   `frame-id` (3-arity) is the explicit hydration target the trace rows are
   tagged with; the 1-/2-arity overloads omit it (a frame-agnostic decision)."
-  ([runtime-db] (hydrate-refetch-plan runtime-db (interop/epoch-now-ms) nil))
+  ([runtime-db] (hydrate-refetch-plan runtime-db (rf.interop/epoch-now-ms) nil))
   ([runtime-db clock-ms] (hydrate-refetch-plan runtime-db clock-ms nil))
   ([runtime-db clock-ms frame-id]
-   (let [entries (get-in runtime-db [state/resources-key :entries])
+   (let [entries (get-in runtime-db [rf.resources.state/resources-key :entries])
          ;; rf2-9e0tyq — `entries` is keyed on the opaque byte `key-id`; the
          ;; plan names each entry by its stored `:resource/key` VECTOR (the
          ;; route slice re-resolves params from the live route under that key)
@@ -2377,19 +2377,19 @@
                                                  ;; Xray / the route slice can tell a
                                                  ;; sensitive-redaction refetch from a
                                                  ;; large-omission one (rf2-fopuj9).
-                                                 (= privacy/redacted-sentinel (:data entry)) :metadata-only
+                                                 (= rf.privacy/redacted-sentinel (:data entry)) :metadata-only
                                                  ;; no usable last-known-good data — a nil
                                                  ;; scalar (omitted `:large?`) OR an EMPTY
                                                  ;; infinite page vector `[]` (EP-0021 R1;
-                                                 ;; rf2-x76af2.11). `state/has-data?` is the
+                                                 ;; rf2-x76af2.11). `rf.resources.state/has-data?` is the
                                                  ;; single home for the infinite-empty branch,
                                                  ;; reached only after the sentinel is ruled out.
-                                                 (not (state/has-data? entry))       :no-data
-                                                 (state/entry-stale? entry clock-ms) :stale
+                                                 (not (rf.resources.state/has-data? entry))       :no-data
+                                                 (rf.resources.state/entry-stale? entry clock-ms) :stale
                                                  :else                         :metadata-only)})))
                        entries)]
      (doseq [{:keys [resource-id reason] resource-key :resource/key} plan]
-       (trace/emit! :rf.event :rf.resource/hydrate-refetch
+       (rf.trace/emit! :rf.event :rf.resource/hydrate-refetch
                     {:rf.frame/id  frame-id
                      :resource/key resource-key
                      :resource-id  resource-id
@@ -2434,7 +2434,7 @@
   runtime-db). Published from the `re-frame.resources` façade so a `:reload`
   re-wires them."
   []
-  (late-bind/set-fns!
+  (rf.late-bind/set-fns!
     {:ssr/extend-runtime-db-projection project-resources-runtime-db
      :resources/drain-blocking-ssr!    drain-blocking-resources!
      :resources/hydrate-runtime-db     hydrate-runtime-db
@@ -2458,5 +2458,5 @@
   fallback). NEVER crosses scopes (the reconcile only touches the entries
   the server projected under their own scoped keys)."
   [frame-id]
-  (let [rdb (frame/swap-runtime-db! frame-id hydrate-runtime-db frame-id)]
-    (hydrate-refetch-plan (or rdb {}) (interop/epoch-now-ms) frame-id)))
+  (let [rdb (rf.frame/swap-runtime-db! frame-id hydrate-runtime-db frame-id)]
+    (hydrate-refetch-plan (or rdb {}) (rf.interop/epoch-now-ms) frame-id)))

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -15,9 +15,9 @@
   `:rf.runtime/work-ledger`. Both are reserved runtime-db keys (per
   [Conventions §Reserved runtime-db keys]) — allocated lazily, per-frame
   isolated, never an app-db location."
-  (:require [re-frame.error :as error]
-            [re-frame.frame :as frame]
-            [re-frame.identity :as identity]))
+  (:require [re-frame.error :as rf.error]
+            [re-frame.frame :as rf.frame]
+            [re-frame.identity :as rf.identity]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -64,7 +64,7 @@
   scope + params, and `canonical-bytes` is total on canonical EDN). Per Spec
   016 §Resource identity / Conventions §Canonical EDN identity."
   [scoped-key]
-  (identity/canonical-bytes scoped-key))
+  (rf.identity/canonical-bytes scoped-key))
 
 (defn entries-path
   "Runtime-db-relative path to the cache entries map `{<key-id> <entry>}` —
@@ -254,7 +254,7 @@
 ;; via the shared `re-frame.identity` algebra (Conventions §Canonical EDN
 ;; identity). There is no resource-local identity dialect — a thin wrapper
 ;; preserves the public resource error categories but delegates the actual
-;; canonicalization / domain validation to `identity/canonical` (rf2-wgutc2,
+;; canonicalization / domain validation to `rf.identity/canonical` (rf2-wgutc2,
 ;; EP-0012 correctness review item 1).
 ;;
 ;; Delegating to the shared algebra means resource identities get exactly
@@ -268,7 +268,7 @@
 ;;   - map-key ordering is the one shared CEDN-1 byte order, with no
 ;;     bespoke second ordering definition.
 ;;
-;; `identity/canonical` also fails closed on DUPLICATE canonical map keys
+;; `rf.identity/canonical` also fails closed on DUPLICATE canonical map keys
 ;; (two distinct host keys whose CEDN-1 bytes collide), so a colliding cache
 ;; key can never silently collapse two identity-distinct param maps.
 
@@ -333,7 +333,7 @@
   identity). Per Spec 016 §Resource identity (\"Host values … are rejected\")."
   [x]
   (try
-    (identity/canonical-bytes x)
+    (rf.identity/canonical-bytes x)
     true
     (catch #?(:clj Throwable :cljs :default) _
       false)))
@@ -353,7 +353,7 @@
   carrying DUPLICATE canonical keys. Callers route the value through
   `reject-non-edn!` first to surface the public resource error category."
   [x]
-  (identity/canonical x))
+  (rf.identity/canonical x))
 
 (defn- throw-non-edn!
   "Throw the public `:rf.error/resource-non-edn-params` cache-key-boundary
@@ -362,7 +362,7 @@
   (validate-only) and `canonicalize-or-rethrow` (validate+canonicalize in one
   walk) so the two surfaces can never drift. Never returns normally."
   [value where kind resource-id]
-  (error/throw-error!
+  (rf.error/throw-error!
     :rf.error/resource-non-edn-params
     where
     (str "resource " resource-id " " (name kind)
@@ -393,7 +393,7 @@
 
   Preserves the public resource error category (`:rf.error/resource-non-edn-
   params`) while delegating the domain decision to the shared CEDN-1 rule
-  (`serializable-edn?` → `identity/canonical-bytes`).
+  (`serializable-edn?` → `rf.identity/canonical-bytes`).
 
   Validate-ONLY: a caller that then needs the canonical value should call
   `canonicalize-or-rethrow` instead, which validates AND canonicalizes in a
@@ -494,7 +494,7 @@
   [scope where resource-id]
   (when (and (vector? scope)
              (contains? reserved-concrete-scopes (first scope)))
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/resource-invalid-scope
       where
       (str "resource " resource-id " was reached with a "
@@ -520,7 +520,7 @@
   unchanged when it conforms."
   [scope where resource-id]
   (when (reserved-scope-typo? scope)
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/resource-invalid-scope
       where
       (str "resource " resource-id " was reached with a "
@@ -764,7 +764,7 @@
   wall-clock background timer. Per Spec 016 §Stale and GC scheduling (no
   wall-clock background timers under SSR)."
   [frame-id]
-  (= :server (:platform (frame/frame-meta frame-id))))
+  (= :server (:platform (rf.frame/frame-meta frame-id))))
 
 ;; ---- per-entry revision (EP-0019 §Decision 2 / byl7bk Open Issue 5) --------
 ;;
@@ -1372,7 +1372,7 @@
               (some? resolved-accessor) (resolved-accessor page)
               ;; loud over guessing (R3): a non-vector page + no accessor
               :else
-              (error/throw-error!
+              (rf.error/throw-error!
                 :rf.error/infinite-missing-page-accessor
                 where
                 (str "infinite resource " resource-id " accumulated a non-vector "
@@ -1633,7 +1633,7 @@ Spec 016 §Restore and replay + 002 §Durable join keys are recordable."})
 (defn generation-allocation-cofx
   "Value-returning GENERATOR for the `:rf.resource/generation-allocation`
   recordable cofx (EP-0017 §5). Reads the in-flight cascade's frame
-  (`frame/*current-frame*`, bound by the router during processing) and the
+  (`rf.frame/*current-frame*`, bound by the router during processing) and the
   frame's host-side generation high-water snapshot, and returns the next
   monotone allocation `{:generation N :counter N}` (N = `(inc snapshot)`).
 
@@ -1648,7 +1648,7 @@ Spec 016 §Restore and replay + 002 §Durable join keys are recordable."})
   (`:rf.cofx {:rf.resource/generation-allocation {:generation N :counter N}}`)
   or re-register the generator (the visible seam)."
   []
-  (let [n (next-generation (generation-snapshot frame/*current-frame*))]
+  (let [n (next-generation (generation-snapshot rf.frame/*current-frame*))]
     {:generation n :counter n}))
 
 (def commit-generation-meta
@@ -1673,7 +1673,7 @@ replay."})
   frame as `:frame`; a nil stamp is an invariant failure
   (`:rf.error/no-frame-context`), never a synthesised default."
   [{:keys [frame]} {:keys [value]}]
-  (let [frame-id (frame/require-frame-stamp!
+  (let [frame-id (rf.frame/require-frame-stamp!
                    frame :rf.resource/commit-generation
                    {:where 'rf.resource/commit-generation-handler})]
     (when (number? value)

--- a/implementation/resources/src/re_frame/resources/subs.cljc
+++ b/implementation/resources/src/re_frame/resources/subs.cljc
@@ -17,7 +17,7 @@
   (`reg-runtime-sub`) — the durable cache lives at
   `[:rf.runtime/resources :entries <key-id>]` in runtime-db, keyed by the
   CEDN-1 byte-identity `key-id` (the scoped key is carried inside each
-  entry under `:resource/key`); the sub resolves it via `(state/entry-path k)`.
+  entry under `:resource/key`); the sub resolves it via `(rf.resources.state/entry-path k)`.
   The derived booleans (`:stale?` / `:loading?` / `:fetching?` /
   `:has-data?`) are PUBLIC DERIVED SUB VALUES computed here from the
   durable entry facts, NOT stored on the entry (Spec 016 §Status
@@ -48,12 +48,12 @@
   route/event that ensures under the new scope attaches the new owner, and
   route leave / `clear-scope` releases the old — the sub is a passive
   reader throughout (Spec 016 §Views stay passive)."
-  (:require [re-frame.interop :as interop]
-            [re-frame.resources.registry :as registry]
-            [re-frame.resources.state :as state]
-            [re-frame.resources.work-ledger :as work-ledger]
-            [re-frame.subs :as subs]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.interop :as rf.interop]
+            [re-frame.resources.registry :as rf.resources.registry]
+            [re-frame.resources.state :as rf.resources.state]
+            [re-frame.resources.work-ledger :as rf.resources.work-ledger]
+            [re-frame.subs :as rf.subs]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -104,19 +104,19 @@
   supplies the frame `db` explicitly (rf2-bwwk6l): a caller that resolves no
   `{:from-db …}` scope passes `{}`."
   [{:keys [resource] :as payload} db]
-  (let [spec    (registry/require-resource-spec! resource 'rf.resource/subscribe)
-        scope   (registry/resolve-scope-for-sub
+  (let [spec    (rf.resources.registry/require-resource-spec! resource 'rf.resource/subscribe)
+        scope   (rf.resources.registry/resolve-scope-for-sub
                   resource spec (:scope payload) 'rf.resource/subscribe db)
         ;; rf2-hgy5kf — thread `:params` presence (absent vs explicit nil) so
         ;; the sub re-keys to the SAME identity the ensure produced (an absent
         ;; slot defaults to `{}` at the boundary; explicit nil reaches the
         ;; schema unchanged).
-        cparams (registry/validate+canonicalize-params
-                  resource spec (state/params-present? payload) 'rf.resource/subscribe)]
+        cparams (rf.resources.registry/validate+canonicalize-params
+                  resource spec (rf.resources.state/params-present? payload) 'rf.resource/subscribe)]
     ;; rf2-rplgkw: scope + cparams are ALREADY canonical (resolve-scope-for-sub
     ;; → canonicalize-scope; validate+canonicalize-params), so use the trusted
     ;; constructor — a resource sub re-runs this on every frame-state change.
-    (state/scoped-resource-key* scope resource cparams)))
+    (rf.resources.state/scoped-resource-key* scope resource cparams)))
 
 ;; ---- dev-mode scope-mismatch warning (Spec 016 §Subscription-side scope
 ;; ---- resolution — likely-mismatch dev warning) ----------------------------
@@ -145,8 +145,8 @@
 ;; does NOT fire: there is no "right" entry being missed, only an un-ensured
 ;; resource, which the empty `:idle` projection already documents.)
 ;;
-;; DEV-ONLY + production-elided: gated by `interop/debug-enabled?` and
-;; emitted through `trace/emit!` (which is itself behind the same gate), so
+;; DEV-ONLY + production-elided: gated by `rf.interop/debug-enabled?` and
+;; emitted through `rf.trace/emit!` (which is itself behind the same gate), so
 ;; Closure DCE strips the whole path at `:advanced` + `goog.DEBUG=false`,
 ;; exactly like the rest of the framework's dev warnings (e.g.
 ;; `:rf.warning/large-value-unschema'd`). One-shot idempotent per distinct
@@ -221,9 +221,9 @@
   the fail-closed scope rules cannot catch (the sub DID resolve a scope; it
   resolved the WRONG one).
 
-  DEV-ONLY: the whole body is behind `interop/debug-enabled?` so Closure DCE
+  DEV-ONLY: the whole body is behind `rf.interop/debug-enabled?` so Closure DCE
   elides it in production (`:advanced` + `goog.DEBUG=false`), and the emit
-  rides `trace/emit!` (same gate). One-shot idempotent per distinct
+  rides `rf.trace/emit!` (same gate). One-shot idempotent per distinct
   `[resource-id sub-scope active-scope]` so a reactive re-run warns once.
 
   Only `:rf.scope/from-caller` resources are checked: every other policy
@@ -231,9 +231,9 @@
   SAME concrete scope sub-side and ensure-side, so a sub cannot land on a
   different key than the ensure did. Returns nil."
   [runtime-db payload sub-key sub-entry]
-  (when interop/debug-enabled?
+  (when rf.interop/debug-enabled?
     (let [resource-id (:resource payload)
-          spec        (registry/resource-meta resource-id)]
+          spec        (rf.resources.registry/resource-meta resource-id)]
       ;; only the from-caller footgun — see docstring
       (when (and (= :rf.scope/from-caller (:scope spec))
                  ;; the subscribed entry has no active owner (or no entry) …
@@ -241,7 +241,7 @@
         ;; rf2-tluunj — pass the whole resources subtree so the mismatch scan
         ;; can use the `:owner-index` (visit only active entries) rather than
         ;; scanning the entire `:entries` map on every reactive sub recompute.
-        (let [resources-subtree (get runtime-db state/resources-key)
+        (let [resources-subtree (get runtime-db rf.resources.state/resources-key)
               [sub-scope]   sub-key
               active-scope  (active-mismatch-scope resources-subtree sub-key)]
           ;; … while a DIFFERENT scope for the same resource IS active.
@@ -249,7 +249,7 @@
             (let [dedupe-key [resource-id sub-scope active-scope]]
               (when-not (contains? @warned-scope-mismatch dedupe-key)
                 (swap! warned-scope-mismatch conj dedupe-key)
-                (trace/emit! :warning :rf.warning/resource-sub-scope-mismatch
+                (rf.trace/emit! :warning :rf.warning/resource-sub-scope-mismatch
                              {:resource-id  resource-id
                               :sub-scope    sub-scope
                               :active-scope active-scope
@@ -282,7 +282,7 @@
   snapshot the `:frame-state` sub body receives."
   [runtime-db app-db payload]
   (let [k (resolve-scoped-key payload app-db)
-        e (get-in runtime-db (state/entry-path k))]
+        e (get-in runtime-db (rf.resources.state/entry-path k))]
     (maybe-warn-scope-mismatch! runtime-db payload k e)
     e))
 
@@ -292,7 +292,7 @@
 ;; core WALL-clock `re-frame.interop/epoch-now-ms` (rf2-366u0g —
 ;; `System/currentTimeMillis` on the JVM, `js/Date.now` on CLJS), the
 ;; canonical EP-0010 §Time wall-clock surface. NOT the perf clock
-;; `interop/now-ms` (`performance.now()`
+;; `rf.interop/now-ms` (`performance.now()`
 ;; on CLJS, origin-relative), which is incomparable with the `js/Date`-based
 ;; `:stale-at` timestamps. Freshness is computed from durable timestamps, not
 ;; from trusting a timer fired on time (Spec 016 §Stale and GC scheduling).
@@ -303,12 +303,12 @@
   (`:stale-at` set and `now >= :stale-at`). Freshness is ORTHOGONAL to load
   status — a `:loaded` entry may be stale; a `:fetching` entry may be
   refreshing stale data. Per Spec 016 §Status semantics. A computed value,
-  never a stored fact. Delegates to the single shared `state/entry-stale?`
+  never a stored fact. Delegates to the single shared `rf.resources.state/entry-stale?`
   derivation (the same one the SSR projection + the stale-timer re-check
   use) so freshness never drifts between readers; the live clock is the
-  canonical wall-clock `interop/epoch-now-ms`."
+  canonical wall-clock `rf.interop/epoch-now-ms`."
   [entry]
-  (state/entry-stale? entry (interop/epoch-now-ms)))
+  (rf.resources.state/entry-stale? entry (rf.interop/epoch-now-ms)))
 
 ;; ---- the projections (public derived sub values) -------------------------
 
@@ -323,7 +323,7 @@
   [runtime-db e]
   (let [prev-key (:previous-key e)]
     (if (and prev-key (nil? (:data e)))
-      (let [prev-entry (get-in runtime-db (state/entry-path prev-key))]
+      (let [prev-entry (get-in runtime-db (rf.resources.state/entry-path prev-key))]
         {:previous?     true
          :previous-key  prev-key
          :previous-data (:data prev-entry)})
@@ -357,13 +357,13 @@
          :loading?      (= :loading (:status e))
          :fetching?     (= :fetching (:status e))
          :stale?        (stale? e)
-         ;; `:has-data?` via the shared `state/has-data?` derivation, NOT the
+         ;; `:has-data?` via the shared `rf.resources.state/has-data?` derivation, NOT the
          ;; scalar `(some? :data)`: an infinite feed's `:data` is the page
          ;; VECTOR seeded EMPTY (`[]`), which `some?` would wrongly read as
-         ;; usable data (rf2-3fynns). `state/has-data?` branches on the
+         ;; usable data (rf2-3fynns). `rf.resources.state/has-data?` branches on the
          ;; feed shape (`(seq data)`), so the scalar `:state` sub and
          ;; `:infinite-state` never disagree.
-         :has-data?     (state/has-data? e)}
+         :has-data?     (rf.resources.state/has-data? e)}
         ;; `:keep-previous?` projection — previous-key data shown while this
         ;; key first-loads, WITHOUT polluting this entry's cache / tags.
         (previous-projection rt e)))))
@@ -413,13 +413,13 @@
 
 (defn has-data?-sub-fn
   "Project `:rf.resource/has-data?` — usable data present. Per Spec 016
-  §Status semantics. Routed through the shared `state/has-data?` derivation
+  §Status semantics. Routed through the shared `rf.resources.state/has-data?` derivation
   (NOT the scalar `(some? :data)`): an infinite feed's `:data` is the page
   VECTOR seeded EMPTY (`[]`), which `some?` would wrongly read as usable data
-  (rf2-3fynns). `state/has-data?` branches on the feed shape (`(seq data)`),
+  (rf2-3fynns). `rf.resources.state/has-data?` branches on the feed shape (`(seq data)`),
   so this scalar sub and `:rf.resource/infinite-state` never disagree."
   [frame-state [_id payload]]
-  (state/has-data? (entry-for (runtime-of frame-state) (app-of frame-state) payload)))
+  (rf.resources.state/has-data? (entry-for (runtime-of frame-state) (app-of frame-state) payload)))
 
 (defn previous-data-sub-fn
   "Project `:rf.resource/previous-data` — the prior key's data projected
@@ -432,7 +432,7 @@
   (let [rt (runtime-of frame-state)
         e  (entry-for rt (app-of frame-state) payload)]
     (when (and (:previous-key e) (nil? (:data e)))
-      (:data (get-in rt (state/entry-path (:previous-key e)))))))
+      (:data (get-in rt (rf.resources.state/entry-path (:previous-key e)))))))
 
 ;; ---- the infinite-feed projection family (EP-0021 R3) ---------------------
 ;;
@@ -463,7 +463,7 @@
   missing-accessor merge, below)."
   [runtime-db app-db payload]
   (let [e (entry-for runtime-db app-db payload)]
-    (when (state/infinite-entry? e) e)))
+    (when (rf.resources.state/infinite-entry? e) e)))
 
 ;; Framework-owned merge memo (R3). A bounded per-feed cache keyed on the
 ;; feed's byte `key-id` → `{:pages <page-vector> :items <merged-vector>}`. The
@@ -505,7 +505,7 @@
   "The framework-owned, MEMOISED merged item list for an infinite-feed
   `entry` (R3) — the headline `:rf.resource/items` read. Resolves the
   resource's `:page->items` accessor and flattens the entry's `:data` page
-  vector via `state/merge-pages->items` (vector pages flatten by identity; a
+  vector via `rf.resources.state/merge-pages->items` (vector pages flatten by identity; a
   non-vector page REQUIRES the accessor or raises
   `:rf.error/infinite-missing-page-accessor`). Memoised on the page-vector
   IDENTITY keyed by the feed's `key-id`: a re-run whose page vector is
@@ -515,13 +515,13 @@
   (let [pages (:data entry)]
     (if (empty? pages)
       []
-      (let [k-id   (state/key-id (:resource/key entry))
+      (let [k-id   (rf.resources.state/key-id (:resource/key entry))
             cached (get @items-merge-memo k-id)]
         (if (and cached (identical? (:pages cached) pages))
           (:items cached)
-          (let [spec     (registry/resource-meta (:resource/id entry))
-                accessor (state/resolve-page->items (:page->items spec))
-                merged   (state/merge-pages->items
+          (let [spec     (rf.resources.registry/resource-meta (:resource/id entry))
+                accessor (rf.resources.state/resolve-page->items (:page->items spec))
+                merged   (rf.resources.state/merge-pages->items
                            pages accessor (:resource/id entry) where)]
             (swap! items-merge-memo assoc k-id {:pages pages :items merged})
             merged))))))
@@ -549,7 +549,7 @@
   no feed). Per Spec 016 §Subscription contract."
   [frame-state [_id payload]]
   (let [e (feed-entry-for (runtime-of frame-state) (app-of frame-state) payload)]
-    (state/page-count e)))
+    (rf.resources.state/page-count e)))
 
 (defn has-next-page?-sub-fn
   "Project `:rf.resource/has-next-page?` — `(some? :next-page-param)`, the
@@ -557,7 +557,7 @@
   Spec 016 §Subscription contract."
   [frame-state [_id payload]]
   (let [e (feed-entry-for (runtime-of frame-state) (app-of frame-state) payload)]
-    (and (some? e) (not (state/terminal? (:next-page-param e))))))
+    (and (some? e) (not (rf.resources.state/terminal? (:next-page-param e))))))
 
 (defn has-prev-page?-sub-fn
   "Project `:rf.resource/has-prev-page?` — `(some? :prev-page-param)`, the
@@ -565,7 +565,7 @@
   when no feed. Per Spec 016 §Subscription contract."
   [frame-state [_id payload]]
   (let [e (feed-entry-for (runtime-of frame-state) (app-of frame-state) payload)]
-    (and (some? e) (not (state/terminal? (:prev-page-param e))))))
+    (and (some? e) (not (rf.resources.state/terminal? (:prev-page-param e))))))
 
 (defn page-error-sub-fn
   "Project `:rf.resource/page-error` — the last load-more failure envelope
@@ -582,7 +582,7 @@
   in-flight work record's `:page-index` — a load-more APPENDS at a POSITIVE
   index (the tail), a page-0 fetch / refetch fetches index 0. The sub joins
   the entry's `:current-work` pointer to its live work-ledger row and reads the
-  recorded page index. Liveness is `work-ledger/live-work?`, the ONE definition
+  recorded page index. Liveness is `rf.resources.work-ledger/live-work?`, the ONE definition
   of that question (rf2-kqxe6.6); the row is re-read here only for its
   `:page-index`. false when the feed is not fetching, has no live work, or the
   live work is a page-0 fetch / whole-feed refresh. Per Spec 016 §Causal event
@@ -592,10 +592,10 @@
     (when (and (some? entry) (= :fetching (:status entry)))
       (let [work-id (:current-work entry)]
         ;; the work is genuinely LIVE (not terminal / doomed) …
-        (and (work-ledger/live-work? runtime-db work-id)
+        (and (rf.resources.work-ledger/live-work? runtime-db work-id)
              ;; … and it is a load-more APPEND (a positive page index), not a
              ;; page-0 fetch / whole-feed refresh (index 0 / absent).
-             (let [pi (:page-index (work-ledger/get-record runtime-db work-id))]
+             (let [pi (:page-index (rf.resources.work-ledger/get-record runtime-db work-id))]
                (and (integer? pi) (pos? pi))))))))
 
 (defn fetching-next?-sub-fn
@@ -630,9 +630,9 @@
         {:status         (:status e)
          :items          (merged-items e 'rf.resource/infinite-state)
          :pages          (vec (:data e))
-         :page-count     (state/page-count e)
-         :has-next-page? (not (state/terminal? (:next-page-param e)))
-         :has-prev-page? (not (state/terminal? (:prev-page-param e)))
+         :page-count     (rf.resources.state/page-count e)
+         :has-next-page? (not (rf.resources.state/terminal? (:next-page-param e)))
+         :has-prev-page? (not (rf.resources.state/terminal? (:prev-page-param e)))
          :loading?       (= :loading (:status e))
          ;; `:fetching?` is a WHOLE-FEED refresh; `:fetching-next?` is a
          ;; load-more — both ride `:fetching` (no 6th FSM state, R2), so split
@@ -642,10 +642,10 @@
          :stale?         (stale? e)
          ;; an infinite feed's `:data` is the page VECTOR (`[]` when empty), so
          ;; `:has-data?` is "≥ 1 accumulated page" — delegated to the shared
-         ;; `state/has-data?` (which knows the infinite-feed shape: `(seq data)`,
+         ;; `rf.resources.state/has-data?` (which knows the infinite-feed shape: `(seq data)`,
          ;; never the scalar `(some? data)` that an empty `[]` would satisfy), so
          ;; the sub and the restore/FSM readers never drift.
-         :has-data?      (state/has-data? e)
+         :has-data?      (rf.resources.state/has-data? e)
          :error          (:error e)
          :refresh-error  (:refresh-error e)
          :page-error     (:page-error e)}))))
@@ -665,62 +665,62 @@
   runtime-db cache writes. Output `=` memoisation keeps the sub quiet when
   neither the resolved scoped key nor the read entry changed."
   []
-  (subs/reg-frame-state-sub :rf/resource
+  (rf.subs/reg-frame-state-sub :rf/resource
     {:doc "Passive read of a resource instance's full view-model `{:status :data :error :refresh-error :loading? :fetching? :stale? :has-data?}`. Resolves scope per Spec 016 §Subscription-side scope resolution (incl. `{:from-db <id>}` named-resolver references against app-db); raises :rf.error/resource-sub-unresolved-scope rather than reading global / returning a silent :idle. Per Spec 016 §Subscriptions."}
     state-sub-fn)
-  (subs/reg-frame-state-sub :rf.resource/data
+  (rf.subs/reg-frame-state-sub :rf.resource/data
     {:doc "Passive read of a resource instance's last-known-good :data (or nil). Per Spec 016 §Subscriptions."}
     data-sub-fn)
-  (subs/reg-frame-state-sub :rf.resource/status
+  (rf.subs/reg-frame-state-sub :rf.resource/status
     {:doc "Passive read of a resource instance's :status keyword (:idle / :loading / :fetching / :loaded / :error). Per Spec 016 §Subscriptions."}
     status-sub-fn)
-  (subs/reg-frame-state-sub :rf.resource/loading?
+  (rf.subs/reg-frame-state-sub :rf.resource/loading?
     {:doc "Passive read: true iff a resource instance is on its first load with no usable data. Per Spec 016 §Status semantics."}
     loading?-sub-fn)
-  (subs/reg-frame-state-sub :rf.resource/fetching?
+  (rf.subs/reg-frame-state-sub :rf.resource/fetching?
     {:doc "Passive read: true iff a resource instance is refreshing while prior data stays visible. Per Spec 016 §Status semantics."}
     fetching?-sub-fn)
-  (subs/reg-frame-state-sub :rf.resource/stale?
+  (rf.subs/reg-frame-state-sub :rf.resource/stale?
     {:doc "Passive read: true iff a resource instance is stale (freshness is orthogonal to load status). Per Spec 016 §Status semantics."}
     stale?-sub-fn)
-  (subs/reg-frame-state-sub :rf.resource/error
+  (rf.subs/reg-frame-state-sub :rf.resource/error
     {:doc "Passive read of a resource instance's first-load error envelope (or nil). Per Spec 016 §Status semantics."}
     error-sub-fn)
-  (subs/reg-frame-state-sub :rf.resource/refresh-error
+  (rf.subs/reg-frame-state-sub :rf.resource/refresh-error
     {:doc "Passive read of a resource instance's background-refresh error envelope (or nil); the prior :data is kept. Per Spec 016 §Status semantics."}
     refresh-error-sub-fn)
-  (subs/reg-frame-state-sub :rf.resource/has-data?
+  (rf.subs/reg-frame-state-sub :rf.resource/has-data?
     {:doc "Passive read: true iff a resource instance currently has usable :data. Per Spec 016 §Status semantics."}
     has-data?-sub-fn)
-  (subs/reg-frame-state-sub :rf.resource/previous-data
+  (rf.subs/reg-frame-state-sub :rf.resource/previous-data
     {:doc "Passive read of the prior key's data, projected while a new page/filter resource first-loads under :keep-previous? (not inserted into the new entry). Per Spec 016 §Paginated and previous data."}
     previous-data-sub-fn)
   ;; ---- the infinite-feed projection family (EP-0021 R3) -----------------
   ;; `:rf.resource/items` / `:pages` / `:infinite-state` are the framework-
   ;; owned MEMOISED merge subs (R3 — NOT ordinary app subs over :pages); the
   ;; page-metadata subs round out the load-more UI state.
-  (subs/reg-frame-state-sub :rf.resource/items
+  (rf.subs/reg-frame-state-sub :rf.resource/items
     {:doc "Passive read of an infinite feed's MERGED / flattened item list (the headline read) — DERIVED + framework-owned-memoised by concatenating each accumulated page's items (R3). A vector page flattens by identity; a non-vector / enveloped page REQUIRES a :page->items accessor (else :rf.error/infinite-missing-page-accessor). [] for a non-feed / empty feed. Per Spec 016 §Subscription contract (R3)."}
     items-sub-fn)
-  (subs/reg-frame-state-sub :rf.resource/pages
+  (rf.subs/reg-frame-state-sub :rf.resource/pages
     {:doc "Passive read of an infinite feed's raw ordered page vector (the TanStack `pages` analogue) — for views that need page boundaries. [] for a non-feed. Per Spec 016 §Subscription contract (R3)."}
     pages-sub-fn)
-  (subs/reg-frame-state-sub :rf.resource/page-count
+  (rf.subs/reg-frame-state-sub :rf.resource/page-count
     {:doc "Passive read of an infinite feed's accumulated page count (0 when no feed). Per Spec 016 §Subscription contract."}
     page-count-sub-fn)
-  (subs/reg-frame-state-sub :rf.resource/has-next-page?
+  (rf.subs/reg-frame-state-sub :rf.resource/has-next-page?
     {:doc "Passive read: true iff an infinite feed has a next page ((some? :next-page-param) — nil is the single terminal). false for a non-feed / terminal feed. Per Spec 016 §Subscription contract."}
     has-next-page?-sub-fn)
-  (subs/reg-frame-state-sub :rf.resource/has-prev-page?
+  (rf.subs/reg-frame-state-sub :rf.resource/has-prev-page?
     {:doc "Passive read: true iff an infinite feed has a prev page ((some? :prev-page-param) — the bidirectional mirror; the prepend event is deferred, R7). false for a non-feed. Per Spec 016 §Subscription contract."}
     has-prev-page?-sub-fn)
-  (subs/reg-frame-state-sub :rf.resource/fetching-next?
+  (rf.subs/reg-frame-state-sub :rf.resource/fetching-next?
     {:doc "Passive read: true iff a LOAD-MORE is in flight on an infinite feed (R2) — distinct from :fetching? (a whole-feed refresh). Derived from the in-flight work record's page index (a load-more appends at a positive index). Per Spec 016 §Subscription contract / §Causal event — load-more."}
     fetching-next?-sub-fn)
-  (subs/reg-frame-state-sub :rf.resource/page-error
+  (rf.subs/reg-frame-state-sub :rf.resource/page-error
     {:doc "Passive read of an infinite feed's last LOAD-MORE failure envelope (the third error channel; distinct from :error first-load and :refresh-error whole-feed), or nil. Per Spec 016 §Subscription contract / §Causal event — load-more."}
     page-error-sub-fn)
-  (subs/reg-frame-state-sub :rf.resource/infinite-state
+  (rf.subs/reg-frame-state-sub :rf.resource/infinite-state
     {:doc "Passive read of an infinite feed's combined view-model `{:status :items :pages :page-count :has-next-page? :has-prev-page? :loading? :fetching? :fetching-next? :stale? :has-data? :error :refresh-error :page-error}` — the feed analogue of :rf/resource, with the framework-owned-memoised merged :items (R3). Empty-feed shape when no infinite entry. Per Spec 016 §Subscription contract (R3)."}
     infinite-state-sub-fn)
   nil)

--- a/implementation/resources/src/re_frame/resources/test_support.cljc
+++ b/implementation/resources/src/re_frame/resources/test_support.cljc
@@ -26,17 +26,17 @@
   rides on the managed-HTTP canned-stub fixtures (`re-frame.http-test-
   support`), reached through the same managed-HTTP transport the runtime
   uses."
-  (:require [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]
-            [re-frame.resources.mutation-events :as mutation-events]
-            [re-frame.resources.mutation-registry :as mutation-registry]
-            [re-frame.resources.registry :as registry]
-            [re-frame.resources.revalidate-listeners :as revalidate-listeners]
-            [re-frame.resources.scope-registry :as scope-registry]
-            [re-frame.resources.state :as state]
-            [re-frame.resources.subs :as subs]
-            [re-frame.resources.timers :as timers]
-            [re-frame.resources.work-ledger :as work-ledger]))
+  (:require [re-frame.late-bind :as rf.late-bind]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.resources.mutation-events :as rf.resources.mutation-events]
+            [re-frame.resources.mutation-registry :as rf.resources.mutation-registry]
+            [re-frame.resources.registry :as rf.resources.registry]
+            [re-frame.resources.revalidate-listeners :as rf.resources.revalidate-listeners]
+            [re-frame.resources.scope-registry :as rf.resources.scope-registry]
+            [re-frame.resources.state :as rf.resources.state]
+            [re-frame.resources.subs :as rf.resources.subs]
+            [re-frame.resources.timers :as rf.resources.timers]
+            [re-frame.resources.work-ledger :as rf.resources.work-ledger]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -49,46 +49,46 @@
   production façade carries no test-fixture surface). Per
   Spec 016 (test isolation)."
   []
-  (registrar/clear-kind! registry/resource-kind)
+  (rf.registrar/clear-kind! rf.resources.registry/resource-kind)
   ;; Clear the mutation registrar kind too; the mutation
   ;; registry is the causal-write counterpart of the resource registry.
-  (registrar/clear-kind! mutation-registry/mutation-kind)
+  (rf.registrar/clear-kind! rf.resources.mutation-registry/mutation-kind)
   ;; Also clear the named resource-scope resolver registry. Pure resolvers hold
   ;; no per-frame
   ;; runtime state, so clearing the registrar kind is the whole reset.
-  (registrar/clear-kind! scope-registry/scope-kind)
-  (state/reset-cache!)
+  (rf.registrar/clear-kind! rf.resources.scope-registry/scope-kind)
+  (rf.resources.state/reset-cache!)
   ;; Drop the host-side work-ledger handles too; they are
   ;; host-side transient state not cleared by the runtime / frames reset.
-  (work-ledger/reset-cache!)
+  (rf.resources.work-ledger/reset-cache!)
   ;; Cancel and drop host-side stale / GC timer handles; likewise
   ;; host-side transient state; cancels any armed timers so a leftover timer
   ;; cannot fire into a later test's frame.
-  (timers/reset-cache!)
+  (rf.resources.timers/reset-cache!)
   ;; Remove host-side focus/reconnect revalidation listeners;
   ;; likewise host-side transient state; detaches any installed window
   ;; listeners so a leftover listener cannot dispatch into a later test's frame.
-  (revalidate-listeners/reset-cache!)
+  (rf.resources.revalidate-listeners/reset-cache!)
   ;; Clear the host-side scope-mismatch dev-warning dedupe set;
   ;; host-side transient dev state; clearing it lets each test observe the
   ;; one-shot warning freshly without a prior test's emission masking it.
-  (subs/reset-scope-mismatch-warnings!)
+  (rf.resources.subs/reset-scope-mismatch-warnings!)
   ;; Clear the framework-owned `:rf.resource/items` merge memo;
   ;; host-side transient derivation cache (the infinite-feed merged-list
   ;; projection), not runtime-db; cleared so a prior test's feed merge cannot
   ;; be served for a later test's `=`-equal page vector.
-  (subs/reset-merge-memo!)
+  (rf.resources.subs/reset-merge-memo!)
   ;; and the host-side WRITE-side scope-mismatch dev-warning dedupe set
   ;; (rf2-byl7bk.4) — the mutation-settlement complement of the sub-side
   ;; warning; likewise host-side transient dev state, cleared so each test
   ;; observes the one-shot `:rf.warning/mutation-scope-mismatch` freshly.
-  (mutation-events/reset-mutation-scope-mismatch-warnings!)
+  (rf.resources.mutation-events/reset-mutation-scope-mismatch-warnings!)
   ;; and the host-side settle-time SKIPPED-TARGET dev-warning dedupe set
   ;; (rf2-1vpbld) — the dedicated drop-and-warn tripwire for recoverable
   ;; post-write `:patches` / `:populates` / `:removes` targets; likewise
   ;; host-side transient dev state, cleared so each test observes the one-shot
   ;; `:rf.warning/mutation-target-skipped` freshly.
-  (mutation-events/reset-mutation-target-skipped-warnings!)
+  (rf.resources.mutation-events/reset-mutation-target-skipped-warnings!)
   nil)
 
 ;; Publish the reset hook from this test-support ns-load — the shared CLJS
@@ -96,4 +96,4 @@
 ;; `:resources/reset-resources!` by key and no-ops when this namespace is
 ;; absent (production builds never load it). Mirrors the
 ;; re-frame.routing.test-support / re-frame.http.test-support posture.
-(late-bind/set-fn! :resources/reset-resources! reset-resources!)
+(rf.late-bind/set-fn! :resources/reset-resources! reset-resources!)

--- a/implementation/resources/src/re_frame/resources/timers.cljc
+++ b/implementation/resources/src/re_frame/resources/timers.cljc
@@ -65,11 +65,11 @@
   `:server` and a JVM client-mode unit test must still arm timers. A re-load
   reschedules (cancel-then-arm) so a single live timer per `[key kind]`
   survives."
-  (:require [re-frame.identity :as identity]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.managed-timer :as managed-timer]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.identity :as rf.identity]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.managed-timer :as rf.managed-timer]
+            [re-frame.trace :as rf.trace]))
 
 ;; Forward declaration: the poll thunk reads host document visibility (CLJS).
 #?(:cljs (declare document-hidden?))
@@ -176,7 +176,7 @@
   recheck event still carries the kind-preserving scoped-key VECTOR; only the
   host side-table key is byte-reduced."
   [frame-id resource-key kind]
-  [frame-id (identity/canonical-bytes resource-key) kind])
+  [frame-id (rf.identity/canonical-bytes resource-key) kind])
 
 (defn cancel!
   "Cancel + drop the host timer for `[frame-id resource-key kind]` (a no-op
@@ -205,7 +205,7 @@
                                              m)))
             claimed    (get old k)]
         (when (and (= token (:token claimed)) (:handle claimed))
-          (interop/cancel-scheduled! (:handle claimed))))))
+          (rf.interop/cancel-scheduled! (:handle claimed))))))
   nil)
 
 (defn cancel-for-key!
@@ -256,7 +256,7 @@
   `poll-fired-handler` makes its default-pause-when-hidden decision from its
   recordable event payload, never an ambient host read at the cascade site."
   [frame-id resource-key kind]
-  (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+  (when-let [dispatch! (rf.late-bind/get-fn :router/dispatch!)]
     (let [event-id (condp = kind
                      stale-kind stale-fired-event
                      gc-kind    gc-fired-event
@@ -298,7 +298,7 @@
   ;; rf2-j538f7.2): reserve the slot BEFORE arming the host clock, then publish
   ;; the handle only if this attempt still owns the slot, so a cleanup racing the
   ;; arm can never be outrun by a late-returning handle.
-  (when (managed-timer/positive-delay? delay-ms)
+  (when (rf.managed-timer/positive-delay? delay-ms)
     (let [k     (timer-key frame-id resource-key kind)
           token (next-attempt-token)]
       ;; PHASE 1 — reserve an arming sentinel (`:handle nil`) so a concurrent
@@ -307,7 +307,7 @@
       (let [handle
             ;; Shared positive-delay-guarded arm (rf2-7x2lky) — a no-op guard
             ;; pass-through here (already known positive).
-            (managed-timer/arm!
+            (rf.managed-timer/arm!
               (fn []
                 ;; ATOMICALLY claim THIS fire's slot — dispatch AUTHORITY +
                 ;; self-reap in one swap (mirrors core `:dispatch-later`). If a
@@ -332,13 +332,13 @@
                                              (assoc m k {:token token :handle handle})
                                              m)))]
         (if (= token (:token (get old k)))
-          (do (trace/emit! :rf.event (scheduled-trace-id kind)
+          (do (rf.trace/emit! :rf.event (scheduled-trace-id kind)
                            {:rf.frame/id frame-id :resource/key resource-key
                             :delay-ms delay-ms})
               handle)
           ;; a cleanup / synchronous self-fire claimed the sentinel while we
           ;; armed — cancel the orphan handle, publish nothing, emit no trace.
-          (do (interop/cancel-scheduled! handle)
+          (do (rf.interop/cancel-scheduled! handle)
               nil))))))
 
 (defn release-frame!
@@ -363,7 +363,7 @@
                                (fn [m] (into {} (remove (fn [[[fid _ _] _]] (= fid frame-id))) m)))]
     (doseq [[[fid _rkey _kind] slot] old
             :when (and (= fid frame-id) (:handle slot))]
-      (interop/cancel-scheduled! (:handle slot))))
+      (rf.interop/cancel-scheduled! (:handle slot))))
   nil)
 
 (defn reset-cache!
@@ -378,7 +378,7 @@
   (let [[old _new] (reset-vals! timer-table {})]
     (doseq [[_ slot] old
             :when (:handle slot)]
-      (interop/cancel-scheduled! (:handle slot))))
+      (rf.interop/cancel-scheduled! (:handle slot))))
   nil)
 
 ;; ---- the host-side scheduling fx (mirrors :rf.resource/commit-generation) -

--- a/implementation/resources/src/re_frame/resources/tooling.cljc
+++ b/implementation/resources/src/re_frame/resources/tooling.cljc
@@ -28,28 +28,28 @@
   The STATIC view reads the `:resource` registry through the existing
   `resource-meta` / `resource-ids` introspection seams; the LIVE view reads
   the per-frame `:rf.runtime/resources` entries + `:rf.runtime/work-ledger`
-  records through the existing `frame/frame-runtime-db-value` read seam (the
+  records through the existing `rf.frame/frame-runtime-db-value` read seam (the
   same seam `re-frame.resources/resources` + the SSR drain read).
 
   Per [Derivations.md](../../../../../../spec/Derivations.md) §Resources
   expose process nodes and the projected Malli
   shapes in [Spec-Schemas §`:rf/derivation-node`](../../../../../../spec/Spec-Schemas.md)."
-  (:require [re-frame.derivation.node :as node]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.resources.registry :as registry]
-            [re-frame.resources.scope-registry :as scope-registry]
-            [re-frame.resources.ssr :as ssr]
-            [re-frame.resources.state :as state]
+  (:require [re-frame.derivation.node :as rf.derivation.node]
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.resources.registry :as rf.resources.registry]
+            [re-frame.resources.scope-registry :as rf.resources.scope-registry]
+            [re-frame.resources.ssr :as rf.resources.ssr]
+            [re-frame.resources.state :as rf.resources.state]
             ;; rf2-dl7bz — the per-slot arm of the key projection lives in the
             ;; production-reachable trace-egress ns (beside the reply's), and
             ;; this TOOL boundary opts into the same helper so the two off-box
             ;; boundaries cannot answer differently. The edge points from the
             ;; bundle-isolated sibling INTO a production-reachable ns, which is
             ;; the safe direction: nothing here is pulled toward a bundle.
-            [re-frame.resources.trace-egress :as trace-egress]
-            [re-frame.resources.transport :as transport]
-            [re-frame.resources.work-ledger :as work-ledger]))
+            [re-frame.resources.trace-egress :as rf.resources.trace-egress]
+            [re-frame.resources.transport :as rf.resources.transport]
+            [re-frame.resources.work-ledger :as rf.resources.work-ledger]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -168,7 +168,7 @@
   transport (a recomputable PROJECTION of the Spec 016 registration fact —
   never a second authoritative home). `transport-id` is the spec's
   `:transport`, defaulting to the only built-in transport
-  (`transport/default-transport`, `:rf.http/managed`)."
+  (`rf.resources.transport/default-transport`, `:rf.http/managed`)."
   [transport-id]
   {:kind      :remote
    :system    :server
@@ -195,7 +195,7 @@
   (let [scope (:scope spec)]
     [[:param :rf.params]
      [:scope (cond
-               (scope-registry/from-db-reference? scope) scope        ;; {:from-db <id>} — static reference
+               (rf.resources.scope-registry/from-db-reference? scope) scope        ;; {:from-db <id>} — static reference
                (fn? scope)                                :rf.scope/resolver
                :else                                      scope)]]))
 
@@ -205,16 +205,16 @@
   reference rather than an inline function, the static graph reports the
   RESOLVER ID and its DECLARED INPUTS even while the params stay generic —
   because the resolver's inputs are declared, not executed. Read READ-ONLY
-  through `scope-registry/scope-resolver-meta` (the resolver inputs as
+  through `rf.resources.scope-registry/scope-resolver-meta` (the resolver inputs as
   `[:db <rf-path>]` descriptors). Returns the `:scope-resolver` map, or nil
   when the scope is not a `{:from-db …}` reference (or the resolver is not
   registered — a registration-time forward reference; the static graph then
   carries the reference id alone, no inputs)."
   [spec]
   (let [scope (:scope spec)]
-    (when (scope-registry/from-db-reference? scope)
+    (when (rf.resources.scope-registry/from-db-reference? scope)
       (let [scope-id (:from-db scope)
-            rmeta    (scope-registry/scope-resolver-meta scope-id)]
+            rmeta    (rf.resources.scope-registry/scope-resolver-meta scope-id)]
         (cond-> {:id scope-id}
           (some? rmeta)
           ;; the resolver's declared inputs are static facts — each stored
@@ -235,7 +235,7 @@
   fn is the resource's whole-value process driver, surfaced under `:derive`
   as an opaque token (never serialized)."
   [node spec slot]
-  (cond-> (node/attach-source node slot)
+  (cond-> (rf.derivation.node/attach-source node slot)
     (contains? spec :data-schema) (assoc :schema (:data-schema spec))
     (some? (:doc spec))           (assoc :doc (:doc spec))
     (contains? spec :request)     (assoc :derive (:request spec))))
@@ -257,9 +257,9 @@
   `:scope-resolver` named-resolver enrichment, and source coords / schema /
   doc / opaque `:derive` request token."
   [resource-id spec slot]
-  (let [transport-id (or (:transport spec) transport/default-transport)
+  (let [transport-id (or (:transport spec) rf.resources.transport/default-transport)
         resolver     (scope-resolver-enrichment spec)]
-    (-> (node/node-base resource-id [:runtime [state/resources-key :entries]]
+    (-> (rf.derivation.node/node-base resource-id [:runtime [rf.resources.state/resources-key :entries]]
                         {:kind          resource-superkind
                          :storage       resource-storage
                          :evaluation    resource-evaluation
@@ -341,14 +341,14 @@
   ([]
    (reduce
      (fn [acc resource-id]
-       (let [slot (registrar/lookup registry/resource-kind resource-id)
+       (let [slot (rf.registrar/lookup rf.resources.registry/resource-kind resource-id)
              spec (:rf/resource slot)]
          (cond-> acc
            (some? spec) (assoc resource-id (static-node-for resource-id spec slot)))))
      {}
-     (registry/resource-ids)))
+     (rf.resources.registry/resource-ids)))
   ([resource-id]
-   (let [slot (registrar/lookup registry/resource-kind resource-id)
+   (let [slot (rf.registrar/lookup rf.resources.registry/resource-kind resource-id)
          spec (:rf/resource slot)]
      (when (some? spec)
        (static-node-for resource-id spec slot)))))
@@ -376,18 +376,18 @@
 ;;
 ;; The projection reuses the SAME resource OWNER classification the SSR /
 ;; durable-egress path uses — never a tooling-private elider — through the
-;; shared `ssr/disposition+project-key` pipeline (rf2-366u0g):
+;; shared `rf.resources.ssr/disposition+project-key` pipeline (rf2-366u0g):
 ;;   - `classification/whole-entry-disposition` (inside the shared helper)
 ;;     resolves the coarse `:sensitive?` / `:large?` root-prop claim. EP-0025
 ;;     (rf2-71dr8t) removed the named-scope-resolver derived-sensitivity
 ;;     inheritance arm (no sensitivity propagation);
-;;   - `ssr/project-scoped-key` (inside the shared helper) then projects the
+;;   - `rf.resources.ssr/project-scoped-key` (inside the shared helper) then projects the
 ;;     scoped key per that disposition — `:redact` / `:omit` replace scope +
 ;;     params with opaque content-addressed `{:rf/redacted <digest>}` tokens
 ;;     (distinct values stay distinct, so graph connectivity by projected key
 ;;     is preserved), while `:serialize` rides verbatim (non-sensitive identity
 ;;     is preserved);
-;;   - `trace-egress/redact-key-declarations` (rf2-dl7bz) then applies the
+;;   - `rf.resources.trace-egress/redact-key-declarations` (rf2-dl7bz) then applies the
 ;;     resource's per-slot `:params` / `:scope` PROJECTION-RELATIVE declarations
 ;;     to a `:serialize` key — the arm the coarse disposition above is blind to,
 ;;     since a spec declaring only paths makes no root-prop claim and classifies
@@ -408,9 +408,9 @@
   tokens; `:serialize` substitutes the owner's per-slot `:params` / `:scope`
   PROJECTION-RELATIVE declarations (a no-op when the spec declares none) — the
   resource-id always survives. Pure. Delegates to the shared
-  `ssr/disposition+project-key` pipeline (rf2-366u0g — the SAME owner
+  `rf.resources.ssr/disposition+project-key` pipeline (rf2-366u0g — the SAME owner
   classification + key projection the SSR durable-egress + off-box trace-egress
-  paths use), then to `trace-egress/redact-key-declarations` for the per-slot
+  paths use), then to `rf.resources.trace-egress/redact-key-declarations` for the per-slot
   arm that pipeline defers (rf2-dl7bz), which is the SAME helper the off-box
   trace projector applies — one declaration, one answer at both boundaries.
 
@@ -420,8 +420,8 @@
   not durable egress policy). The projection-relative declaration on the spec is
   the single durable classification surface."
   [scoped-key frame-id]
-  (let [[projected-key disposition spec] (ssr/disposition+project-key scoped-key frame-id)]
-    [(trace-egress/redact-key-declarations projected-key disposition spec) disposition]))
+  (let [[projected-key disposition spec] (rf.resources.ssr/disposition+project-key scoped-key frame-id)]
+    [(rf.resources.trace-egress/redact-key-declarations projected-key disposition spec) disposition]))
 
 (defn- project-work-id
   "Project the scoped key embedded in a resource work-id
@@ -438,7 +438,7 @@
   for tool egress (rf2-0t0l3w) so neither leaks the raw scope/params. Returns
   the node `acc` with both slots assoc'd."
   [acc runtime-db work-id frame-id]
-  (let [record  (work-ledger/get-record runtime-db work-id)
+  (let [record  (rf.resources.work-ledger/get-record runtime-db work-id)
         wid'    (project-work-id work-id frame-id)
         summary (select-keys record
                              [:work/id :work/kind :status
@@ -480,7 +480,7 @@
              :refinement    resource-refined-kind
              :source-form   {:kind :reg-resource :id resource-id}
              :inputs        [[:scope proj-scope] [:param proj-params]]
-             :output        [:runtime (state/entry-path proj-key)]
+             :output        [:runtime (rf.resources.state/entry-path proj-key)]
              :storage       resource-storage
              :authority     (:authority static-node)
              :evaluation    resource-evaluation
@@ -517,7 +517,7 @@
   `[cache-scope resource-id canonical-params]` — its canonical fact identity
   when concrete (Derivations §Fact identity). Pure data over the frame's
   `:rf.runtime/resources` `:entries` + `:rf.runtime/work-ledger` records,
-  read READ-ONLY through `frame/frame-runtime-db-value` (the same read seam
+  read READ-ONLY through `rf.frame/frame-runtime-db-value` (the same read seam
   `re-frame.resources/resources` + the SSR drain use) — never touching the
   runtime write-path.
 
@@ -553,8 +553,8 @@
   the cache entries + work records are serializable EDN runtime-db facts (no
   host handles ride them; those live in the side table)."
   [frame-id]
-  (let [runtime-db (frame/frame-runtime-db-value frame-id)
-        entries    (get-in runtime-db (state/entries-path))]
+  (let [runtime-db (rf.frame/frame-runtime-db-value frame-id)
+        entries    (get-in runtime-db (rf.resources.state/entries-path))]
     (reduce-kv
       ;; rf2-9e0tyq / rf2-ka2nkx — `:entries` is keyed on the opaque byte
       ;; `key-id`; the live node's `:id` / inputs use the entry's own
@@ -577,7 +577,7 @@
           ;; so its byte key-id is unchanged; a `:redact` / `:omit` resource's
           ;; opaque content-addressed tokens stay distinct per distinct value,
           ;; so two CEDN-distinct entries never collapse onto one map key.
-          (assoc acc (state/key-id (:id node)) node)))
+          (assoc acc (rf.resources.state/key-id (:id node)) node)))
       {}
       (or entries {}))))
 

--- a/implementation/resources/src/re_frame/resources/trace_egress.cljc
+++ b/implementation/resources/src/re_frame/resources/trace_egress.cljc
@@ -96,11 +96,11 @@
   carrier — substituted by `redact-key-declarations`, so a `:params` / `:scope`
   declaration reaches every carrier of the value it names rather than only the
   ones somebody has looked at."
-  (:require [re-frame.classification :as core-classification]
-            [re-frame.resources.classification :as classification]
-            [re-frame.resources.registry :as registry]
-            [re-frame.resources.reply :as resources-reply]
-            [re-frame.resources.ssr :as ssr]))
+  (:require [re-frame.classification :as rf.classification]
+            [re-frame.resources.classification :as rf.resources.classification]
+            [re-frame.resources.registry :as rf.resources.registry]
+            [re-frame.resources.reply :as rf.resources.reply]
+            [re-frame.resources.ssr :as rf.resources.ssr]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -119,17 +119,17 @@
   neither axis names dropped — so `nil` means the spec declares nothing the KEY
   carries and the key must ride VERBATIM.
 
-  Built from the already-public `classification/spec-declaration-marks`, whose
+  Built from the already-public `rf.resources.classification/spec-declaration-marks`, whose
   `:params` bucket IS the scoped-key bucket: a `:params`-rooted declaration
   arrives with its head stripped and names the params component, a
   `:scope`-rooted one arrives WITH its `[:scope …]` head and names the scope
   component. That is the same reading
-  `classification/instance-declaration-paths` lowers into the per-frame elision
+  `rf.resources.classification/instance-declaration-paths` lowers into the per-frame elision
   registry (`[… :resource/key 2 …]` for params, `[… :resource/key 0 …]` for
   scope), which is what makes this agree with the durable side by construction
   rather than by coincidence. Pure / value-independent."
   [spec]
-  (let [declaration-marks (:params (classification/spec-declaration-marks spec))
+  (let [declaration-marks (:params (rf.resources.classification/spec-declaration-marks spec))
         paths-by-component
         (fn [classification-axis]
           (reduce (fn [component-paths declaration-path]
@@ -156,12 +156,12 @@
   the owner's per-slot `:params` / `:scope` projection-relative declarations,
   substituted inside the key `[scope resource-id params]` at the trace / tool
   egress boundary. Takes the key ALREADY projected by
-  `ssr/disposition+project-key`, that call's `disposition`, and the owner
+  `rf.resources.ssr/disposition+project-key`, that call's `disposition`, and the owner
   `spec` it resolved; returns the key.
 
   ## Why the coarse projection is not the whole answer
 
-  `ssr/project-scoped-key` projects the key by the COARSE
+  `rf.resources.ssr/project-scoped-key` projects the key by the COARSE
   `whole-entry-disposition` — the owner's root `:sensitive?` / `:large?` prop.
   A spec that declares `{:sensitive [[:params :account-id]]}` and no coarse prop
   classifies `:serialize`, so that read says nothing and the declared params
@@ -170,12 +170,12 @@
   work-id, and inside every fx carrier the key reaches — while the SAME bytes
   in the durable entry redact, because `reconcile-registry` lowered the
   declaration to `[… :resource/key 2 …]` and the SSR wire key walks it
-  (`classification/project-entry-params`). One value, two carriers, one rule
+  (`rf.resources.classification/project-entry-params`). One value, two carriers, one rule
   applied: the rf2-irwsq shape the sibling `redact-reply-declarations`
   (rf2-ko5lm) closed for the reply's copy of those same params, one slot over
   on the same carrier.
 
-  ## Why HERE and not in `ssr/project-scoped-key`
+  ## Why HERE and not in `rf.resources.ssr/project-scoped-key`
 
   `project-scoped-key`'s `:serialize` deferral is DELIBERATE and stays intact:
   the SSR durable path has a REGISTRY-driven counterpart with the entry's
@@ -183,7 +183,7 @@
   `project-egress` seeded at the lowered registry offset. The trace / tool
   boundary has neither, so it derives the same declaration from the SPEC — the
   frameless derivation the family already uses beside this fn for the reply
-  (`classification/redact-continuation-reply` over `carrier-decl-paths`). The
+  (`rf.resources.classification/redact-continuation-reply` over `carrier-decl-paths`). The
   two answers are byte-identical by construction, because both re-root the same
   `spec-declaration-marks` bucket onto the same two key components and both walk
   INDEX-FREE. SSR is not a caller that never asked for this — it is not a caller
@@ -216,7 +216,7 @@
     scoped-key
     (if-let [declarations (key-slot-declarations spec)]
       (reduce-kv (fn [projected-key component-index {:keys [sensitive large]}]
-                   (update projected-key component-index core-classification/redact-with-paths
+                   (update projected-key component-index rf.classification/redact-with-paths
                             sensitive large {:index-free? true}))
                  scoped-key
                  declarations)
@@ -250,11 +250,11 @@
     (and (redacted-token? (nth scoped-key 0)) (redacted-token? (nth scoped-key 2)))
     [scoped-key true nil nil]
 
-    (nil? (registry/resource-meta (second scoped-key)))
-    [(ssr/project-scoped-key scoped-key :redact nil) true :redact nil]
+    (nil? (rf.resources.registry/resource-meta (second scoped-key)))
+    [(rf.resources.ssr/project-scoped-key scoped-key :redact nil) true :redact nil]
 
     :else
-    (let [[projected-key disposition spec] (ssr/disposition+project-key scoped-key frame-id)]
+    (let [[projected-key disposition spec] (rf.resources.ssr/disposition+project-key scoped-key frame-id)]
       [projected-key (not= :serialize disposition) disposition spec])))
 
 (defn- project-trace-scoped-key
@@ -627,7 +627,7 @@
   [v]
   (and (scoped-key-frame? v)
        (or (map? (nth v 2))
-           (some? (registry/resource-meta (nth v 1))))))
+           (some? (rf.resources.registry/resource-meta (nth v 1))))))
 
 (defn- project-unknown-slot-value
   "SHAPE-DRIVEN fail-closed projection of ONE tag value under a slot the
@@ -678,7 +678,7 @@
   (cond
     (redacted-token? value)   [value true]
     (scoped-key-shape? value) (project-trace-scoped-key value frame-id)
-    (map? value)              [(ssr/redact-value value) true]
+    (map? value)              [(rf.resources.ssr/redact-value value) true]
 
     (coll? value)
     (let [sensitive-found? (volatile! false)
@@ -780,9 +780,9 @@
   merely happens to carry a `:resource/key` beside a `:value` / `:params` is
   NOT a reply, and the family does not speak for those two words anywhere
   else. A mutation reply stamps `:mutation` and is deliberately not matched —
-  its payload is redacted at source (`classification/redact-continuation-reply`)."
+  its payload is redacted at source (`rf.resources.classification/redact-continuation-reply`)."
   [m]
-  (= resources-reply/work-kind-resource (:rf.reply/work-kind m)))
+  (= rf.resources.reply/work-kind-resource (:rf.reply/work-kind m)))
 
 (def ^:private family-reply-kinds
   "The resource FAMILY's two canonical reply `:rf.reply/work-kind`s — a read
@@ -795,8 +795,8 @@
   HTTP stamps `:http` on its own canonical reply (`re-frame.http.reply`), and an
   HTTP reply riding these same carriers is the HTTP family's data to classify.
   The resources projector speaks only for what the resources runtime planted."
-  #{resources-reply/work-kind-resource
-    resources-reply/work-kind-mutation})
+  #{rf.resources.reply/work-kind-resource
+    rf.resources.reply/work-kind-mutation})
 
 (defn- family-reply?
   "Whether MAP `m` is a canonical reply of the resource FAMILY — a read
@@ -805,7 +805,7 @@
 
   The widening exists because the two halves diverge on the OWNER'S data and
   agree on the TRANSPORT ENVELOPE. `:value` / `:params` are the owner's, and the
-  mutation redacts its own at the source (`classification/redact-continuation-
+  mutation redacts its own at the source (`rf.resources.classification/redact-continuation-
   reply`), so `resource-reply?` deliberately excludes `:mutation` there.
   `:error` is the transport's `:rf.http/*` failure envelope — no projection of
   owner data, so no source-side redaction reaches it on EITHER half — and both
@@ -816,7 +816,7 @@
 
 (defn- redact-reply-declarations
   "The READ-CONTINUATION analogue of the mutation's source-side
-  `classification/redact-continuation-reply` (rf2-ko5lm) — literally that
+  `rf.resources.classification/redact-continuation-reply` (rf2-ko5lm) — literally that
   function, reached at the egress projector instead of at the source.
 
   `row-owner-redacts?` above reads the COARSE root-prop claim
@@ -883,14 +883,14 @@
   owner's key rode there verbatim. That copy is closed by
   `redact-key-declarations` above, which is this fn's shape re-rooted onto the
   key's two components instead of the reply's sibling slots —
-  `ssr/project-scoped-key`'s documented `:serialize` deferral left intact,
+  `rf.resources.ssr/project-scoped-key`'s documented `:serialize` deferral left intact,
   because the per-slot arm belongs at the boundary that has no registry to read
   rather than inside the projection the SSR durable path shares."
   [reply]
   (let [rid  (second (:resource/key reply))
-        spec (when (keyword? rid) (registry/resource-meta rid))]
+        spec (when (keyword? rid) (rf.resources.registry/resource-meta rid))]
     (if spec
-      (classification/redact-continuation-reply reply spec)
+      (rf.resources.classification/redact-continuation-reply reply spec)
       reply)))
 
 (defn- carrier-family-value?
@@ -933,7 +933,7 @@
   exists to keep reachable was not reached (merged-PR audit #7013)."
   [v named?]
   (and (scoped-key-frame? v)
-       (or named? (some? (registry/resource-meta (nth v 1))))))
+       (or named? (some? (rf.resources.registry/resource-meta (nth v 1))))))
 
 (def ^:private fx-carrier-slot
   "Trace tag slots owned by the FX family that the resource family's scoped keys
@@ -1096,7 +1096,7 @@
   false and this arm does not fire on it — deliberately. The mutation half is
   closed one layer EARLIER, at the
   source: both settle sites wrap the reply in
-  `classification/redact-continuation-reply`, which redacts the mutation's own
+  `rf.resources.classification/redact-continuation-reply`, which redacts the mutation's own
   projection-relative `:sensitive` / `:large` declarations before the reply ever
   reaches a carrier (rf2-825mzj). A coarse `:sensitive?` ROOT prop is not part
   of `reg-mutation`'s declaration surface and is inert at every mutation egress
@@ -1116,7 +1116,7 @@
   verbatim — while the same bytes in the durable entry redact, because the
   declaration was lowered into the frame's elision registry and the epoch walk
   reads it. `redact-reply-declarations` closes that half by applying the
-  mutation's own `classification/redact-continuation-reply` over the read
+  mutation's own `rf.resources.classification/redact-continuation-reply` over the read
   owner's spec, and the two arms compose by grain rather than overlap: coarse
   claim ⇒ the whole `:value` / `:params` tokenize; declaration only ⇒ the
   declared paths substitute in place and their undeclared siblings ride;
@@ -1283,7 +1283,7 @@
                          true
                          (if (redacted-token? map-value)
                            map-value
-                           (ssr/redact-value map-value)))
+                           (rf.resources.ssr/redact-value map-value)))
 
                        ;; the owner's own reply data — tokenized
                        ;; content-FREE (rf2-hzcv8) iff THIS reply's owner redacts, so a
@@ -1296,7 +1296,7 @@
                          true
                          (if (redacted-token? map-value)
                            map-value
-                           (ssr/redact-value map-value)))
+                           (rf.resources.ssr/redact-value map-value)))
 
                        ;; every other entry takes the walk, NAMED iff the family
                        ;; reserved the key it sits under.
@@ -1413,7 +1413,7 @@
                       (assoc projected-tags tag-name tag-value))
                   (if cursor-redacts?
                     (do (record-sensitive! true)
-                        (assoc projected-tags tag-name (ssr/redact-value tag-value)))
+                        (assoc projected-tags tag-name (rf.resources.ssr/redact-value tag-value)))
                     (assoc projected-tags tag-name tag-value)))
 
                 ;; HTTP failure envelope (`:error` / `:page-error`): the raw
@@ -1430,7 +1430,7 @@
                   (do (record-sensitive! true)
                       (assoc projected-tags tag-name tag-value))
                   (do (record-sensitive! true)
-                      (assoc projected-tags tag-name (ssr/redact-value tag-value))))
+                      (assoc projected-tags tag-name (rf.resources.ssr/redact-value tag-value))))
 
                 ;; An already-projected token rides as-is and still marks the row
                 ;; sensitive — guarded BEFORE `sibling-owned-slot` so a
@@ -1498,7 +1498,7 @@
   `:restored-keys` / `:conflicted-keys` / `:refetched-keys`), and the
   optimistic-rollback `:dispositions` (per-key maps) is projected through the
   resource OWNER classification (`whole-entry-disposition` +
-  `ssr/project-scoped-key`).
+  `rf.resources.ssr/project-scoped-key`).
 
   A `:sensitive?` / `:large?` owner's scope + params
   tokenize to classification-chosen `{:rf/redacted <digest>}` (distinct

--- a/implementation/resources/src/re_frame/resources/transport.cljc
+++ b/implementation/resources/src/re_frame/resources/transport.cljc
@@ -19,7 +19,7 @@
   guards the declared transport at the call site and lowers into
   `transport.http/lower`. A dispatch table is warranted only when a second
   transport exists."
-  (:require [re-frame.error :as error]))
+  (:require [re-frame.error :as rf.error]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -51,7 +51,7 @@
   suppression is the correctness boundary)."
   [transport where]
   (when-not (= transport managed-http-transport)
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/resource-unknown-transport (or where 're-frame.resources.transport/assert-managed-transport!)
       (str "unknown resource transport " transport
            " — the only built-in transport is "

--- a/implementation/resources/src/re_frame/resources/transport/http.cljc
+++ b/implementation/resources/src/re_frame/resources/transport/http.cljc
@@ -31,8 +31,8 @@
   The lowering ships here: `lower` mints the request-id and stamps the
   work-ledger correlation (`:work/id` / `:resource/key` / `:scope` /
   `:rf.frame/id` / `:generation`) into the reply addressing."
-  (:require [re-frame.error :as error]
-            [re-frame.late-bind :as late-bind]))
+  (:require [re-frame.error :as rf.error]
+            [re-frame.late-bind :as rf.late-bind]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -72,7 +72,7 @@
   [http-args resource-key where]
   (let [offending-keys (filter #(contains? http-args %) reserved-reply-keys)]
     (when (seq offending-keys)
-      (error/throw-error!
+      (rf.error/throw-error!
         :rf.error/resource-reserved-request-key where
         (str "a resource :request supplied the "
              "runtime-owned reply-addressing key(s) "
@@ -162,8 +162,8 @@
   ;; the always-published feature probe (consult ≠ static require). This
   ;; fails closed with a clear artefact-missing error when an HTTP-backed
   ;; read is issued without the HTTP artefact on the classpath.
-  (when-not (late-bind/get-fn :http/abort-on-actor-destroy)
-    (error/throw-error!
+  (when-not (rf.late-bind/get-fn :http/abort-on-actor-destroy)
+    (rf.error/throw-error!
       :rf.error/http-artefact-missing 're-frame.resources.transport.http/lower
       (str "an HTTP-backed resource read requires "
            "day8/re-frame2-http on the classpath; "

--- a/implementation/resources/src/re_frame/resources/work_ledger.cljc
+++ b/implementation/resources/src/re_frame/resources/work_ledger.cljc
@@ -82,9 +82,9 @@
   trace). The two continuations are kept distinct: the ledger owns the
   framework-internal reified continuation; the call-site target is the app's
   transport-payload continuation."
-  (:require [re-frame.late-bind :as late-bind]
-            [re-frame.reply :as reply]
-            [re-frame.resources.state :as state]))
+  (:require [re-frame.late-bind :as rf.late-bind]
+            [re-frame.reply :as rf.reply]
+            [re-frame.resources.state :as rf.resources.state]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -129,7 +129,7 @@
   (`[:rf.work/resource <scoped-key> <generation>]`) — its `canonical-bytes`
   string (rf2-9e0tyq). The work-ledger runtime-db map is keyed on THIS string,
   NOT the work-id vector, for the SAME reason `:entries` is keyed on
-  `state/key-id`: the work-id embeds the scoped-key, so two work-ids that
+  `rf.resources.state/key-id`: the work-id embeds the scoped-key, so two work-ids that
   differ only by a list-vs-vector params spelling are `=`-equal (Clojure
   `(= [1 2 3] '(1 2 3))`) and would collide in the ledger map even though
   their CEDN-1 byte identities differ. Keying on the bytes string makes the
@@ -138,12 +138,12 @@
   `:current-work`, and on the wire. Total on a work-id over a canonical
   scoped-key. Per Spec 016 §Frame work ledger.
 
-  This IS `state/key-id` (both are `canonical-bytes` of an
+  This IS `rf.resources.state/key-id` (both are `canonical-bytes` of an
   already-canonical EDN identity — rf2-366u0g): the work-id-as-map-key
   byte-identity rule is the SAME rule the scoped-key-as-map-key follows, so
   the ledger surface re-binds the one canonical wrapper under its own name
   rather than re-typing the `canonical-bytes` call."
-  state/key-id)
+  rf.resources.state/key-id)
 
 (defn managed-request-id
   "Build the frame-QUALIFIED managed-HTTP transport correlation token
@@ -184,7 +184,7 @@
   Spec 016 §Ledger row retention and identity. The canonical set lives in
   `re-frame.resources.state/terminal-work-statuses` (rf2-366u0g); re-bound
   under the ledger surface's own name so a ledger consumer reads one home."
-  state/terminal-work-statuses)
+  rf.resources.state/terminal-work-statuses)
 
 (defn terminal?
   "True iff `status` is a terminal work-ledger status (the attempt has
@@ -310,7 +310,7 @@
   ;; The success leg is canonical: the failure leg
   ;; (`:rf.resource.internal/failed`) shares the SAME verification payload, so
   ;; one durable target represents the reified continuation.
-  (reply/durable-target
+  (rf.reply/durable-target
     {:event [:rf.resource.internal/succeeded
              {:work/id      (:work/id record)
               :resource/key (:resource/key record)
@@ -382,7 +382,7 @@
   016 §Frame work ledger / [Runtime-Subsystems] clause 4. Reuses the same
   serializable-EDN walker the cache-key boundary uses."
   [record]
-  (state/serializable-edn? record))
+  (rf.resources.state/serializable-edn? record))
 
 ;; ---- runtime-db record bookkeeping (Spec 016 §Cache home) -----------------
 ;;
@@ -432,7 +432,7 @@
   (let [ledger (:rf.runtime/work-ledger runtime-db)
         idx    (reduce-kv
                  (fn [acc wid-id record]
-                   (let [rk-id (state/key-id (:resource/key record))]
+                   (let [rk-id (rf.resources.state/key-id (:resource/key record))]
                      (update acc rk-id (fnil conj #{}) wid-id)))
                  {}
                  ledger)]
@@ -464,7 +464,7 @@
   [runtime-db work-id record]
   (-> runtime-db
       (assoc-in (record-path work-id) record)
-      (index-add (state/key-id (:resource/key record)) (work-id-id work-id))))
+      (index-add (rf.resources.state/key-id (:resource/key record)) (work-id-id work-id))))
 
 (defn get-record
   "Read the work record under `work-id` from `runtime-db`, or nil."
@@ -547,7 +547,7 @@
          ;; rf2-9e0tyq — match by CEDN-1 byte identity, not `=` over the
          ;; `:resource/key` vector (which would `=`-collapse a list- and a
          ;; vector-params key and prune both resources' rows).
-         rk-id  (state/key-id resource-key)
+         rk-id  (rf.resources.state/key-id resource-key)
          ;; rf2-wyan7e — visit ONLY this key's rows (via the inverse index)
          ;; instead of scanning the WHOLE ledger per settle (O(rows-for-key)
          ;; rather than O(all-work)). The index members ARE this key's row ids.
@@ -581,7 +581,7 @@
 ;; The non-serializable cancellation / timer handles keyed by `[frame-id
 ;; work-id]`. A module-level transient host cache — NOT runtime-db, NOT
 ;; serialized, off the epoch / SSR egress wire. Mirrors the host-side
-;; generation allocator (`state/generation-cache`) and routing's
+;; generation allocator (`rf.resources.state/generation-cache`) and routing's
 ;; nav-counters / scroll caches (rf2-oosjmh / rf2-1hncp2). Cleared on frame
 ;; destroy (Spec 016 [Runtime-Subsystems] clause 5: transient host handles
 ;; dropped).
@@ -670,7 +670,7 @@
                    (when (and (= (:transport handle) managed-abort-fx-transport)
                               (:request-id handle))
                      (try
-                       (when-let [abort! (late-bind/get-fn :http/abort-in-flight!)]
+                       (when-let [abort! (rf.late-bind/get-fn :http/abort-in-flight!)]
                          (boolean (abort! (:request-id handle) :resource-superseded)))
                        (catch #?(:clj Throwable :cljs :default) _ false))))]
     (or direct? managed?)))
@@ -853,7 +853,7 @@ attempt is superseded / settled so a stale handle does not leak. Per Spec 016
 ;; `:resources/on-frame-destroyed!` late-bind hook the façade publishes (the
 ;; same shape as routing's `:routing/on-frame-destroyed!`). Frame destroy
 ;; ALSO drops the host-side generation high-water mark
-;; (`state/release-frame!`), composed into the same hook body in the façade.
+;; (`rf.resources.state/release-frame!`), composed into the same hook body in the façade.
 
 (defn release-frame!
   "Release a destroyed frame's TRANSIENT work-ledger host handles: drop
@@ -896,7 +896,7 @@ attempt is superseded / settled so a stale handle does not leak. Per Spec 016
   host handles. `destroy-frame!` invokes it by key with the destroyed
   `frame-id`. Releases the frame's transient work-ledger host handles
   (`release-frame!`). The façade composes this with
-  `state/release-frame!` (the generation high-water mark) so both
+  `rf.resources.state/release-frame!` (the generation high-water mark) so both
   host-side transient caches drop on one hook. Per Spec 016
   [Runtime-Subsystems] clause 5."
   [frame-id]

--- a/implementation/resources/test/re_frame/ep0037_r6_integrated_proof_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/ep0037_r6_integrated_proof_cljs_test.cljc
@@ -61,21 +61,21 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
-   [re-frame.registrar :as registrar]
+   [re-frame.fx :as rf.fx]
+   [re-frame.registrar :as rf.registrar]
    ;; load-bearing side-effecting requires: register the routing + resources
    ;; events / subs and resources' late-bound `:routing/*` integration hooks.
    [re-frame.resources]
-   [re-frame.resources.route :as res-route]
-   [re-frame.resources.ssr :as res-ssr]
-   [re-frame.resources.state :as state]
+   [re-frame.resources.route :as rf.resources.route]
+   [re-frame.resources.ssr :as rf.resources.ssr]
+   [re-frame.resources.state :as rf.resources.state]
    [re-frame.resources.test-support]
-   [re-frame.routing :as routing]
-   [re-frame.routing.link :as link]
+   [re-frame.routing :as rf.routing]
+   [re-frame.routing.link :as rf.routing.link]
    [re-frame.schemas]
    [re-frame.http.managed]
-   [re-frame.ssr :as ssr]
-   [re-frame.test-support :as core-test-support]
+   [re-frame.ssr :as rf.ssr]
+   [re-frame.test-support :as rf.test-support]
    #?(:clj  [re-frame.substrate.plain-atom :as substrate]
       :cljs [re-frame.adapter.reagent :as substrate])))
 
@@ -89,11 +89,11 @@
   exercise app's own frames are built by `boot-app!` in each test body, AFTER
   its registrations — see the ns docstring."
   []
-  (routing/reset-counters!)
-  (res-route/install-routing-integration!))
+  (rf.routing/reset-counters!)
+  (rf.resources.route/install-routing-integration!))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     {:adapter substrate/adapter
      :init-fn init!}))
 
@@ -255,14 +255,14 @@
   (reset! replaced [])
   (reset! scrolled [])
   (reset! page-views [])
-  (fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
-  (fx/reg-fx :rf.nav/push-url    {:platforms #{:server :client}}
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf.fx/reg-fx :rf.nav/push-url    {:platforms #{:server :client}}
              (fn [_ url] (swap! pushed conj url) nil))
-  (fx/reg-fx :rf.nav/replace-url {:platforms #{:server :client}}
+  (rf.fx/reg-fx :rf.nav/replace-url {:platforms #{:server :client}}
              (fn [_ url] (swap! replaced conj url) nil))
-  (fx/reg-fx :rf.nav/scroll         {:platforms #{:server :client}}
+  (rf.fx/reg-fx :rf.nav/scroll         {:platforms #{:server :client}}
              (fn [_ arg] (swap! scrolled conj arg) nil))
-  (fx/reg-fx :rf.nav/capture-scroll {:platforms #{:server :client}} (fn [_ _] nil)))
+  (rf.fx/reg-fx :rf.nav/capture-scroll {:platforms #{:server :client}} (fn [_ _] nil)))
 
 (defn- register-app!
   "Load the exercise app: its resources, routes, subs, events and the requested
@@ -336,8 +336,8 @@
   (rf/with-frame frame-id
     {:route  @(rf/subscribe [:rf/route])
      :chain  @(rf/subscribe [:rf.route/chain])
-     :anchor #?(:clj  (routing/route-link-render-ssr (article-link-props slug) "Read it")
-                :cljs (routing/route-link-render     (article-link-props slug) "Read it"))}))
+     :anchor #?(:clj  (rf.routing/route-link-render-ssr (article-link-props slug) "Read it")
+                :cljs (rf.routing/route-link-render     (article-link-props slug) "Read it"))}))
 
 ;; ===========================================================================
 ;; helpers over the app's observable state
@@ -345,17 +345,17 @@
 
 (defn- rdb     [frame-id] (:rf.db/runtime (rf/frame-state-value frame-id)))
 (defn- slice   [frame-id] (get-in (rdb frame-id) [:rf.runtime/routing :current]))
-(defn- entries [frame-id] (get-in (rdb frame-id) (state/entries-path)))
-(defn- entry   [frame-id k] (get-in (rdb frame-id) (state/entry-path k)))
+(defn- entries [frame-id] (get-in (rdb frame-id) (rf.resources.state/entries-path)))
+(defn- entry   [frame-id k] (get-in (rdb frame-id) (rf.resources.state/entry-path k)))
 (defn- pending [frame-id] (get-in (rdb frame-id) [:rf.runtime/routing :pending-navigation]))
 
-(def ^:private viewer-key   (state/scoped-resource-key* :rf.scope/global :conduit/viewer {}))
-(def ^:private feed-key     (state/scoped-resource-key* :rf.scope/global :conduit/feed {:page 1}))
-(def ^:private settings-key (state/scoped-resource-key* :rf.scope/global :conduit/settings {}))
+(def ^:private viewer-key   (rf.resources.state/scoped-resource-key* :rf.scope/global :conduit/viewer {}))
+(def ^:private feed-key     (rf.resources.state/scoped-resource-key* :rf.scope/global :conduit/feed {:page 1}))
+(def ^:private settings-key (rf.resources.state/scoped-resource-key* :rf.scope/global :conduit/settings {}))
 (defn- article-key [slug]
-  (state/scoped-resource-key* :rf.scope/global :conduit/article {:slug slug}))
+  (rf.resources.state/scoped-resource-key* :rf.scope/global :conduit/article {:slug slug}))
 (defn- profile-key [handle tab]
-  (state/scoped-resource-key* :rf.scope/global :conduit/profile {:handle handle :tab tab}))
+  (rf.resources.state/scoped-resource-key* :rf.scope/global :conduit/profile {:handle handle :tab tab}))
 
 (defn- route-owners
   "The `[:route …]` owners currently attached to an entry."
@@ -459,7 +459,7 @@
         (rf/dispatch-sync [:rf.route/navigate {:to :conduit/feed}] {:frame app})
         (is (= gen-before (:generation (entry app viewer-key)))
             "the shell read was KEPT — same generation, no revalidation")
-        (is (state/has-data? (entry app viewer-key))
+        (is (rf.resources.state/has-data? (entry app viewer-key))
             "…and keeps its data across the sibling move")
         (is (some? (entry app feed-key))
             "the newly added leaf identity was ensured")
@@ -486,7 +486,7 @@
   [f]
   (let [s (slice f)]
     {:target     (select-keys s [:route-id :params :query :fragment])
-     :url        (routing/route-url (-> (select-keys s [:params :query :fragment])
+     :url        (rf.routing/route-url (-> (select-keys s [:params :query :fragment])
                                         (assoc :to (:route-id s))))
      :chain      (rf/with-frame f @(rf/subscribe [:rf.route/chain]))
      :identities (identity-set f)}))
@@ -616,7 +616,7 @@
         (is (= "preview-link" (:class attrs)) "ordinary DOM props pass through"))
 
       (is (= [:rf.route/prefetch {:to :conduit/article :params {:slug slug}}]
-             (link/prefetch-payload props))
+             (rf.routing.link/prefetch-payload props))
           "the link's intent payload is the address ONLY — no policy, no fragment")
       #?(:cljs (is (fn? (:on-mouse-enter attrs))
                    "the real anchor carries the composed intent handler; that
@@ -628,7 +628,7 @@
       ;; the behavioural arm dispatches that exact payload synchronously — same
       ;; event, same frame, observable in one turn on both hosts.
       (let [traces (capture-traces
-                     #(rf/dispatch-sync (link/prefetch-payload props) {:frame app}))]
+                     #(rf/dispatch-sync (rf.routing.link/prefetch-payload props) {:frame app}))]
         (testing "warm mode ran the FULL effective branch plan, ownerlessly"
           (is (some? (entry app viewer-key)) "the shell requirement is in the warm plan")
           (is (some? (entry app akey))       "…and so is the leaf requirement")
@@ -676,7 +676,7 @@
             click arriving as a fresh `:attempt 1` on a second identity. It failed
             SILENTLY: no error, no warning, a passive prefetch indistinguishable
             from a working one without measuring — exactly the failure mode
-            `link/validate-prefetch!` argues for failing loud about."
+            `rf.routing.link/validate-prefetch!` argues for failing loud about."
     (let [app    (boot-app!)
           handle "ada"
           pkey   (profile-key handle :authored)
@@ -686,18 +686,18 @@
           ;; `:on-mouse-enter` handler dispatches, and `link-model`'s `:payload`
           ;; is what the click handler dispatches. Hand-rolling either half would
           ;; be a different test — the claim is about one link.
-          model  (link/link-model props app)]
+          model  (rf.routing.link/link-model props app)]
       (testing "the anchor the app renders warms and activates the same
                 destination"
         (is (= (str "/profile/" handle) (:href model))
             "the href omits the key already at its declared default")
         (is (= [:rf.route/prefetch {:to :conduit/profile :params {:handle handle}}]
-               (link/prefetch-payload props))
+               (rf.routing.link/prefetch-payload props))
             "the payload is the address only — the defaults are resolved by the
              prefetch handler, through the same seam the activation uses"))
 
       ;; hover
-      (rf/dispatch-sync (link/prefetch-payload props) {:frame app})
+      (rf/dispatch-sync (rf.routing.link/prefetch-payload props) {:frame app})
       (let [warmed (profile-identities app)]
         (is (= 1 (count warmed)) "hover warmed exactly one profile identity")
         (is (= [pkey] warmed)
@@ -752,7 +752,7 @@
              milestones (atom [])
              props      (article-link-props slug (fn [_e] (swap! milestones conj :caller)))
              attrs      (second (rf/with-frame app
-                                  (routing/route-link-render props "Read it")))]
+                                  (rf.routing/route-link-render props "Read it")))]
          (is (fn? (:on-mouse-enter attrs)))
          ;; render scope has unwound by the time a real pointer arrives, and a
          ;; DIFFERENT frame is ambient — exactly the rf2-o3nam4 hazard.
@@ -794,7 +794,7 @@
     (let [app (boot-app! {:auth-arm :client})]
       (is (some? app) "the app frame sealed cleanly after the app registration")
       (is (= 1 (count (filter #(= :rf.route/entry-denied %)
-                              (keys (registrar/registrations :event)))))
+                              (keys (rf.registrar/registrations :event)))))
           "one :event registration for the id — the app's replaced the default")
       (is (some? (seal-frame! {:frame-id :conduit/second-frame}))
           "…and a second frame sealed later assembles too"))))
@@ -869,7 +869,7 @@
             arm stamps the default 403 and commits nothing"
     (let [srv (boot-app! {:auth-arm :none :frame-id :conduit/server :preset :ssr-server})]
       (rf/dispatch-sync [:rf.route/handle-url-change "/settings"] {:frame srv})
-      (is (= 403 (:status (ssr/get-response srv))))
+      (is (= 403 (:status (rf.ssr/get-response srv))))
       (is (nil? (slice srv)) "no route committed for the denied target")
       (is (nil? (entry srv settings-key))
           "and no resource or hydration data for it was produced"))))
@@ -879,7 +879,7 @@
             :rf.server/redirect, whose redirect precedence replaces the floor"
     (let [srv (boot-app! {:auth-arm :server :frame-id :conduit/server :preset :ssr-server})]
       (rf/dispatch-sync [:rf.route/handle-url-change "/settings"] {:frame srv})
-      (let [resp (ssr/get-response srv)]
+      (let [resp (rf.ssr/get-response srv)]
         (is (= "/login" (get-in resp [:redirect :location])))
         (is (= 302 (:status resp)) "the app redirect superseded the default 403")))))
 
@@ -899,13 +899,13 @@
       (is (= :idle (:transition (slice srv)))
           "…and renders once every blocking requirement of the plan has data")
 
-      (let [projected (res-ssr/project-resources-runtime-db (rdb srv) srv)
-            hydrated  (res-ssr/hydrate-runtime-db projected)
-            plan      (res-ssr/hydrate-refetch-plan hydrated)
+      (let [projected (rf.resources.ssr/project-resources-runtime-db (rdb srv) srv)
+            hydrated  (rf.resources.ssr/hydrate-runtime-db projected)
+            plan      (rf.resources.ssr/hydrate-refetch-plan hydrated)
             planned   (into #{} (map :resource/key) plan)]
         (testing "both branch reads crossed the wire"
-          (is (some? (get-in hydrated [state/resources-key :entries (state/key-id viewer-key)])))
-          (is (some? (get-in hydrated [state/resources-key :entries (state/key-id akey)]))))
+          (is (some? (get-in hydrated [rf.resources.state/resources-key :entries (rf.resources.state/key-id viewer-key)])))
+          (is (some? (get-in hydrated [rf.resources.state/resources-key :entries (rf.resources.state/key-id akey)]))))
         (testing "and neither is refetched on the client — hydration REUSE"
           (is (not (contains? planned viewer-key))
               "the shell read was fresh with data; no double-fetch")
@@ -972,7 +972,7 @@
     (rf/dispatch-sync [:rf.route/navigate {:to :conduit/broken}] {:frame app})
     (testing "the failed target COMMITS, so the error is addressable"
       (is (= :conduit/broken (:route-id (slice app))))
-      (is (= "/broken" (routing/route-url {:to (:route-id (slice app))}))
+      (is (= "/broken" (rf.routing/route-url {:to (:route-id (slice app))}))
           "the committed facts still derive the destination URL"))
     (testing "readiness projects :error with the structured planning error"
       (is (= :error (:transition (slice app))))

--- a/implementation/resources/test/re_frame/readiness_projector_conformance_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/readiness_projector_conformance_cljs_test.cljc
@@ -44,30 +44,30 @@
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing]]
       :cljs [cljs.test :refer-macros [deftest is testing]])
-   [re-frame.resources.route :as res-route]
-   [re-frame.resources.state :as state]
-   [re-frame.routing.readiness :as readiness]))
+   [re-frame.resources.route :as rf.resources.route]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.routing.readiness :as rf.routing.readiness]))
 
 ;; ---- fixtures for the two vocabularies ------------------------------------
 
 (def ^:private req-a
-  (state/scoped-resource-key* :rf.scope/global :article/by-slug {:slug "a"}))
+  (rf.resources.state/scoped-resource-key* :rf.scope/global :article/by-slug {:slug "a"}))
 
 (def ^:private req-b
-  (state/scoped-resource-key* :rf.scope/global :article/by-slug {:slug "b"}))
+  (rf.resources.state/scoped-resource-key* :rf.scope/global :article/by-slug {:slug "b"}))
 
 (defn- blocking-map
   "The byte-keyed blocking carrier `{<key-id> <scoped-key>}` both slots hold
   (rf2-btdl1)."
   [& ks]
-  (into {} (map (juxt state/key-id identity)) ks))
+  (into {} (map (juxt rf.resources.state/key-id identity)) ks))
 
 (def ^:private plan-error
   {:rf.error/id :rf.error/resource-route-plan
    :reason      "params failed their schema"})
 
 ;; Durable cache entries, one per `requirement-state` outcome. The classifier
-;; (`res-route/requirement-state`) is the authority for what each shape means;
+;; (`rf.resources.route/requirement-state`) is the authority for what each shape means;
 ;; `requirement-states-are-what-this-table-thinks-they-are` below re-derives
 ;; that rather than trusting these names.
 (def ^:private entry-ready   {:resource/id :article/by-slug :status :loaded  :data {:x 1} :attempt 1})
@@ -87,7 +87,7 @@
                                             :transition transition
                                             :error      error}}
            :rf.runtime/resources {:entries (into {}
-                                                 (map (fn [[k e]] [(state/key-id k) e]))
+                                                 (map (fn [[k e]] [(rf.resources.state/key-id k) e]))
                                                  entries-by-key)}}
     entries-by-key
     (assoc-in [:rf.runtime/routing :resource-blocking nav-token]
@@ -172,7 +172,7 @@
 (defn- routing-projection
   "Run the commit-time half on a row and return `[transition error?]`."
   [{:keys [plan]}]
-  (let [{:keys [transition error]} (readiness/project-at-commit plan)]
+  (let [{:keys [transition error]} (rf.routing.readiness/project-at-commit plan)]
     [transition (some? error)]))
 
 (defn- resources-projection
@@ -181,7 +181,7 @@
   edge-triggered and pinned separately in `resources-route-cljs-test`."
   [{:keys [committed entries]}]
   (let [[transition error] committed
-        rdb  (res-route/reconcile-readiness
+        rdb  (rf.resources.route/reconcile-readiness
                (runtime-db-with "nav-1" transition error entries)
                {:emit-error? false})
         cur  (get-in rdb [:rf.runtime/routing :current])]
@@ -206,7 +206,7 @@
   ;; from the classifier so a change to `requirement-state` cannot quietly turn
   ;; a row into a test of something else — the guard above would stay green
   ;; while pinning the wrong classes.
-  (is (= :ready   (res-route/requirement-state entry-ready)))
-  (is (= :pending (res-route/requirement-state entry-pending)))
-  (is (= :failed  (res-route/requirement-state entry-failed)))
-  (is (= :inert   (res-route/requirement-state entry-inert))))
+  (is (= :ready   (rf.resources.route/requirement-state entry-ready)))
+  (is (= :pending (rf.resources.route/requirement-state entry-pending)))
+  (is (= :failed  (rf.resources.route/requirement-state entry-failed)))
+  (is (= :inert   (rf.resources.route/requirement-state entry-inert))))

--- a/implementation/resources/test/re_frame/replay_determinism_e2e_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/replay_determinism_e2e_cljs_test.cljc
@@ -62,7 +62,7 @@
 
   The SAME log is replayed TWICE. Run A uses ambient clock/RNG sentinel A;
   run B uses a WILDLY different ambient clock/RNG sentinel B (we redef BOTH
-  `interop/now-ms` and `interop/epoch-now-ms`, and the host `rand` /
+  `rf.interop/now-ms` and `rf.interop/epoch-now-ms`, and the host `rand` /
   `random-uuid` generators). Each run starts from a FRESH runtime + reset
   host-transient caches (generation allocator, resource/timer caches) so the
   only difference between the two runs is the ambient clock/RNG — exactly the
@@ -84,20 +84,20 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
-   [re-frame.interop :as interop]
+   [re-frame.fx :as rf.fx]
+   [re-frame.interop :as rf.interop]
    ;; load-bearing side-effecting requires: register the :rf.resource/*
    ;; events + subs + the generation cofx/fx the ensure/invalidate drive.
    [re-frame.resources]
-   [re-frame.resources.state :as state]
+   [re-frame.resources.state :as rf.resources.state]
    [re-frame.resources.test-support]
    ;; production HTTP fx surface (so the transport feature probe resolves);
    ;; the actual fetch is overridden by the capturing reply stub below.
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport (replays the real reply-append shape) ------------
 ;;
@@ -112,13 +112,13 @@
 
 (defn- capturing-transport-fixture [f]
   (reset! last-managed-args nil)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
   capturing-transport-fixture)
 
 (def ^:private frame-id :rf/default)
@@ -264,8 +264,8 @@
     ;; fold (the tokens supply every durable fact). A regression that re-read
     ;; ANY ambient surface in a durable write stamps a sentinel and diverges
     ;; from run B.
-    (let [run-a (with-redefs [interop/now-ms       (constantly 111)
-                              interop/epoch-now-ms (constantly 111)
+    (let [run-a (with-redefs [rf.interop/now-ms       (constantly 111)
+                              rf.interop/epoch-now-ms (constantly 111)
                               rand        (fn ([] 0.111) ([n] (* n 0.111)))
                               random-uuid (constantly
                                             #uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")]
@@ -274,16 +274,16 @@
       ;; runtime, frames, schemas, AND host-transient caches (generation
       ;; allocator, resource/timer caches) are clean — the ONLY difference
       ;; between the two runs is the ambient clock/RNG.
-      ((core-test-support/make-reset-runtime-fixture
-         #?(:clj  {:adapter plain-atom/adapter}
-            :cljs {:adapter reagent-adapter/adapter}))
+      ((rf.test-support/make-reset-runtime-fixture
+         #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+            :cljs {:adapter rf.adapter.reagent/adapter}))
        (fn []
          (reset! last-managed-args nil)
-         (fx/reg-fx :rf.http/managed
+         (rf.fx/reg-fx :rf.http/managed
                     (fn [_ctx args] (reset! last-managed-args args) nil))
          ;; RUN B — a WILDLY different ambient clock + RNG sentinel.
-         (let [run-b (with-redefs [interop/now-ms       (constantly 9999999999999)
-                                   interop/epoch-now-ms (constantly 9999999999999)
+         (let [run-b (with-redefs [rf.interop/now-ms       (constantly 9999999999999)
+                                   rf.interop/epoch-now-ms (constantly 9999999999999)
                                    rand        (fn ([] 0.999) ([n] (* n 0.999)))
                                    random-uuid (constantly
                                                  #uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")]
@@ -303,9 +303,9 @@
            (let [app   (:rf.db/app run-b)
                  todo  (get-in app [:todos todo-id])
                  rt    (:rf.db/runtime run-b)
-                 scoped-key (state/scoped-resource-key
+                 scoped-key (rf.resources.state/scoped-resource-key
                               :rf.scope/global :repl/article {:slug "w"})
-                 entry (get-in rt (state/entry-path scoped-key))]
+                 entry (get-in rt (rf.resources.state/entry-path scoped-key))]
              ;; (1) app-db entity — token uuid/random/time-ms, NOT ambient.
              (is (= todo-id (:todo/id todo))
                  "the durable entity id is the token uuid, not the ambient
@@ -333,6 +333,6 @@
              ;; the freshness DECISION itself is replay-stable: against ANY
              ;; clock the entry is stale (it was explicitly invalidated), a
              ;; durable fact, not an ambient-clock-dependent computation.
-             (is (true? (state/entry-stale? entry (:reply-time log)))
+             (is (true? (rf.resources.state/entry-stale? entry (:reply-time log)))
                  "the entry is stale (explicitly invalidated) — a durable,
                   token-sourced decision, identical across both runs"))))))))

--- a/implementation/resources/test/re_frame/resource_algebra_view_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resource_algebra_view_cljs_test.cljc
@@ -31,26 +31,26 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.elision :as elision]
-   [re-frame.frame :as frame]
+   [re-frame.elision :as rf.elision]
+   [re-frame.frame :as rf.frame]
    ;; load-bearing side-effecting require: the façade registers the
    ;; :rf.resource/* events + subs + the :resource registrar kind.
    [re-frame.resources]
-   [re-frame.resources.registry :as registry]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.tooling :as resources-tooling]
-   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.resources.registry :as rf.resources.registry]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.tooling :as rf.resources.tooling]
+   [re-frame.resources.work-ledger :as rf.resources.work-ledger]
    ;; production HTTP fx surface (so the transport feature probe resolves).
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter})))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter})))
 
 ;; ---- helpers --------------------------------------------------------------
 
@@ -98,10 +98,10 @@
 
 (deftest empty-registry-returns-empty-map
   (testing "(resource-algebra-view) returns {} (not nil) when none registered"
-    (is (= {} (resources-tooling/resource-algebra-view)))
-    (is (map? (resources-tooling/resource-algebra-view))))
+    (is (= {} (rf.resources.tooling/resource-algebra-view)))
+    (is (map? (rf.resources.tooling/resource-algebra-view))))
   (testing "(resource-algebra-view id) returns nil for an unregistered id"
-    (is (nil? (resources-tooling/resource-algebra-view :nope/missing)))))
+    (is (nil? (rf.resources.tooling/resource-algebra-view :nope/missing)))))
 
 ;; ---- a registered resource exposes its process node ----------------------
 
@@ -110,14 +110,14 @@
     (rf/reg-resource :article/by-slug (article-spec {:data-schema :app/article
                                                      :doc "an article by slug"})
                      article-spec-request)
-    (let [node (resources-tooling/resource-algebra-view :article/by-slug)]
+    (let [node (rf.resources.tooling/resource-algebra-view :article/by-slug)]
       (is (some? node) "the resource is present in the static view")
       (is (has-fixed-classifications? node)
           "resource carries the fixed process / runtime-db / multi-trigger / resource-key / materialized classifications")
       (is (= :article/by-slug (:id node)))
       (is (= {:kind :reg-resource :id :article/by-slug} (:source-form node)))
       (testing "output materializes the cache entries into runtime-db"
-        (is (= [:runtime [state/resources-key :entries]] (:output node))))
+        (is (= [:runtime [rf.resources.state/resources-key :entries]] (:output node))))
       (testing "the remote authority axis names the external system + transport"
         (is (= {:kind :remote :system :server :transport :rf.http/managed}
                (:authority node)))
@@ -147,10 +147,10 @@
   (testing "(resource-algebra-view) lowers every registered resource"
     (rf/reg-resource :a/x (article-spec) article-spec-request)
     (rf/reg-resource :b/y (article-spec) article-spec-request)
-    (let [view (resources-tooling/resource-algebra-view)]
+    (let [view (rf.resources.tooling/resource-algebra-view)]
       (is (= #{:a/x :b/y} (set (keys view))))
       (is (every? has-fixed-classifications? (vals view)))
-      (is (= (resources-tooling/resource-algebra-view :a/x) (:a/x view))
+      (is (= (rf.resources.tooling/resource-algebra-view :a/x) (:a/x view))
           "the one-arity form equals that id's entry in the all-resources map"))))
 
 ;; ---- the don't-execute rule on scope -------------------------------------
@@ -163,7 +163,7 @@
                      (article-spec {:scope (fn [_route _ctx]
                                              (throw (ex-info "must not run in static view" {})))})
                      article-spec-request)
-    (let [node (resources-tooling/resource-algebra-view :fn/scoped)]
+    (let [node (rf.resources.tooling/resource-algebra-view :fn/scoped)]
       (is (= [[:param :rf.params] [:scope :rf.scope/resolver]] (:inputs node))
           "the fn scope lowers to the opaque resolver marker — the fn is never executed")
       (is (not (contains? node :scope-resolver))
@@ -183,7 +183,7 @@
     (rf/reg-resource :tenant/article
                      (article-spec {:scope {:from-db :session/current-tenant}})
                      article-spec-request)
-    (let [node (resources-tooling/resource-algebra-view :tenant/article)]
+    (let [node (rf.resources.tooling/resource-algebra-view :tenant/article)]
       (is (= [[:param :rf.params] [:scope {:from-db :session/current-tenant}]]
              (:inputs node))
           "the {:from-db <id>} reference is reported verbatim — a static fact")
@@ -195,31 +195,31 @@
 
 (deftest live-cache-view-empty-when-no-entries
   (testing "(resource-cache-algebra-view frame) is {} for a frame with no entries"
-    (is (= {} (resources-tooling/resource-cache-algebra-view :rf/default)))))
+    (is (= {} (rf.resources.tooling/resource-cache-algebra-view :rf/default)))))
 
 (defn- install-live-entry!
   "Write a live cache entry (and, when in flight, a linked work-ledger
   record) DIRECTLY into the frame's runtime-db — a test fixture, NOT the
   resource write-path under test. Returns the scoped key."
   [frame-id resource-id scope params {:keys [status owner in-flight?]}]
-  (let [scoped-key (state/scoped-resource-key scope resource-id params)
-        work-id    (when in-flight? (work-ledger/resource-work-id scoped-key 1))
+  (let [scoped-key (rf.resources.state/scoped-resource-key scope resource-id params)
+        work-id    (when in-flight? (rf.resources.work-ledger/resource-work-id scoped-key 1))
         ;; rf2-9e0tyq — the runtime stamps each entry's `:resource/key`; the
         ;; live algebra view reads it for the node `:id` / `:inputs` (the
         ;; `:entries` map is keyed on the opaque byte `key-id`).
-        entry      (cond-> (assoc (state/empty-entry resource-id scoped-key)
+        entry      (cond-> (assoc (rf.resources.state/empty-entry resource-id scoped-key)
                                   :status        (or status :loaded)
                                   :data          {:slug (:slug params)}
                                   :active-owners (if owner #{owner} #{}))
                      in-flight? (assoc :current-work work-id :status :fetching))]
-    (frame/swap-runtime-db!
+    (rf.frame/swap-runtime-db!
       frame-id
       (fn [rdb]
-        (cond-> (assoc-in (or rdb {}) (state/entry-path scoped-key) entry)
+        (cond-> (assoc-in (or rdb {}) (rf.resources.state/entry-path scoped-key) entry)
           in-flight?
-          (work-ledger/put-record
+          (rf.resources.work-ledger/put-record
             work-id
-            (work-ledger/work-record {:work-id      work-id
+            (rf.resources.work-ledger/work-record {:work-id      work-id
                                       :frame-id     frame-id
                                       :resource/key scoped-key
                                       :generation   1
@@ -235,8 +235,8 @@
           params     {:slug "welcome"}
           scoped-key (install-live-entry! :rf/default :article/by-slug scope params
                                           {:status :loaded :owner [:route :route/article 17]})
-          view       (resources-tooling/resource-cache-algebra-view :rf/default)
-          node       (get view (state/key-id scoped-key))]
+          view       (rf.resources.tooling/resource-cache-algebra-view :rf/default)
+          node       (get view (rf.resources.state/key-id scoped-key))]
       (is (some? node) "the live entry node is reachable by its byte key-id")
       (is (has-live-fixed-classifications? node)
           "the live node keeps the fixed process classifications (lifecycle is the map form)")
@@ -244,7 +244,7 @@
       (testing "the realized scope + param edges"
         (is (= [[:scope scope] [:param params]] (:inputs node))))
       (testing "the concrete entry output address"
-        (is (= [:runtime (state/entry-path scoped-key)] (:output node))))
+        (is (= [:runtime (rf.resources.state/entry-path scoped-key)] (:output node))))
       (testing "the live lifecycle map carries the active owners"
         (is (= {:kind :scoped-resource-key :owners #{[:route :route/article 17]}}
                (:lifecycle node))))
@@ -264,9 +264,9 @@
           params     {:slug "loading"}
           scoped-key (install-live-entry! :rf/default :article/by-slug scope params
                                           {:owner [:route :route/article 9] :in-flight? true})
-          node       (get (resources-tooling/resource-cache-algebra-view :rf/default)
-                          (state/key-id scoped-key))
-          work-id    (work-ledger/resource-work-id scoped-key 1)]
+          node       (get (rf.resources.tooling/resource-cache-algebra-view :rf/default)
+                          (rf.resources.state/key-id scoped-key))
+          work-id    (rf.resources.work-ledger/resource-work-id scoped-key 1)]
       (is (= :fetching (:status node)))
       (testing "the work-ledger link carries the work id + a serializable record summary"
         (is (= work-id (get-in node [:work-ledger :work/id])))
@@ -290,16 +290,16 @@
                                       {:status :loaded :owner [:app :v 1]})
           kl     (install-live-entry! :rf/default :article/by-slug scope pl
                                       {:status :loaded :owner [:app :l 1]})
-          view   (resources-tooling/resource-cache-algebra-view :rf/default)]
+          view   (rf.resources.tooling/resource-cache-algebra-view :rf/default)]
       (is (= kv kl) "the scoped-key VECTORS are Clojure-= (the collapse routed around)")
-      (is (not= (state/key-id kv) (state/key-id kl))
+      (is (not= (rf.resources.state/key-id kv) (rf.resources.state/key-id kl))
           "their byte key-ids differ (v[…] vs l(…))")
       (is (= 2 (count view)) "TWO distinct nodes — no =-collapse onto one map key")
-      (is (= #{(state/key-id kv) (state/key-id kl)} (set (keys view)))
+      (is (= #{(rf.resources.state/key-id kv) (rf.resources.state/key-id kl)} (set (keys view)))
           "the view is keyed on the byte key-ids of BOTH entries")
       (testing "each node keeps its kind-preserving scoped-key on :id"
-        (let [nv (get view (state/key-id kv))
-              nl (get view (state/key-id kl))]
+        (let [nv (get view (rf.resources.state/key-id kv))
+              nl (get view (rf.resources.state/key-id kl))]
           (is (= kv (:id nv)) "vector node keeps its vector key")
           (is (= kl (:id nl)) "list node keeps its list key")
           (is (vector? (-> nv :id (nth 2) :xs)) "vector-params node preserves vector kind")
@@ -344,7 +344,7 @@
           params     {:auth-token secret}
           scoped-key (install-live-entry! :rf/default :secret/article scope params
                                           {:owner [:route :route/article 17] :in-flight? true})
-          view       (resources-tooling/resource-cache-algebra-view :rf/default)
+          view       (rf.resources.tooling/resource-cache-algebra-view :rf/default)
           node       (first (vals view))]
       (is (= 1 (count view)) "exactly one live node")
       (is (some? node))
@@ -367,8 +367,8 @@
           params {:slug "welcome"}
           scoped-key (install-live-entry! :rf/default :plain/article scope params
                                           {:status :loaded :owner [:app :p 1]})
-          view   (resources-tooling/resource-cache-algebra-view :rf/default)
-          node   (get view (state/key-id scoped-key))]
+          view   (rf.resources.tooling/resource-cache-algebra-view :rf/default)
+          node   (get view (rf.resources.state/key-id scoped-key))]
       (is (some? node))
       (is (= [[:scope scope] [:param params]] (:inputs node))
           "non-sensitive scope + params ride verbatim")
@@ -383,8 +383,8 @@
     ;; FRAME classification: the resolver's :db input path is sensitive
     ;; (commit-plane effect path, :source :effect).
     (rf/make-frame {:id :sens/frame :doc "frame with a sensitive tenant-id"})
-    (frame/swap-runtime-db! :sens/frame
-      (fn [rt] (elision/apply-classification-effects rt {:sensitive [[:session :tenant-id]]})))
+    (rf.frame/swap-runtime-db! :sens/frame
+      (fn [rt] (rf.elision/apply-classification-effects rt {:sensitive [[:session :tenant-id]]})))
     ;; resolver reading the frame-sensitive path — NO propagation now.
     (rf/reg-resource-scope :session/tenant
                            {:inputs {:tenant-id [:db [:session :tenant-id]]}}
@@ -399,7 +399,7 @@
           params {:slug "x"}]
       (install-live-entry! :sens/frame :derived/article scope params
                            {:status :loaded :owner [:app :d 1]})
-      (let [view (resources-tooling/resource-cache-algebra-view :sens/frame)]
+      (let [view (rf.resources.tooling/resource-cache-algebra-view :sens/frame)]
         (is (= 1 (count view)) "one node")
         (testing "the derived scope is NOT auto-redacted (no inheritance)"
           (is (contains-secret? view)
@@ -418,7 +418,7 @@
             params {:slug "y"}]
         (install-live-entry! :sens/frame2 :derived/secret-article scope params
                              {:status :loaded :owner [:app :s 1]})
-        (let [view (resources-tooling/resource-cache-algebra-view :sens/frame2)]
+        (let [view (rf.resources.tooling/resource-cache-algebra-view :sens/frame2)]
           (is (= 1 (count view)) "one node in the fresh frame")
           (testing "the owner-:sensitive? key redacts the secret"
             (is (not (contains-secret? view))
@@ -430,9 +430,9 @@
   (testing "(clear-resource id) removes the resource from the static view"
     (rf/reg-resource :a/x (article-spec) article-spec-request)
     (rf/reg-resource :b/y (article-spec) article-spec-request)
-    (is (contains? (resources-tooling/resource-algebra-view) :a/x))
+    (is (contains? (rf.resources.tooling/resource-algebra-view) :a/x))
     (rf/clear-resource :a/x)
-    (let [view (resources-tooling/resource-algebra-view)]
+    (let [view (rf.resources.tooling/resource-algebra-view)]
       (is (not (contains? view :a/x)))
       (is (contains? view :b/y)))))
 
@@ -440,6 +440,6 @@
    (deftest jvm-alias-mirrors-the-tooling-fn
      (testing "the JVM re-frame.resources/resource-algebra-view alias is the tooling fn"
        (rf/reg-resource :article/by-slug (article-spec) article-spec-request)
-       (is (= (resources-tooling/resource-algebra-view)
+       (is (= (rf.resources.tooling/resource-algebra-view)
               (re-frame.resources/resource-algebra-view))
            "the JVM convenience alias projects identically to the tooling sibling"))))

--- a/implementation/resources/test/re_frame/resource_generation_recordable_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resource_generation_recordable_cljs_test.cljc
@@ -48,20 +48,20 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting requires: register the :rf.resource/*
    ;; events + subs + the generation-allocation cofx / commit-generation fx.
    [re-frame.resources]
-   [re-frame.resources.state :as state]
+   [re-frame.resources.state :as rf.resources.state]
    [re-frame.resources.test-support]
    ;; production HTTP fx surface (so the transport feature probe resolves);
    ;; the actual fetch is overridden by the capturing reply stub below.
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.trace.tooling :as trace-tooling]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport (replays the real reply-append shape) ------------
 
@@ -69,13 +69,13 @@
 
 (defn- capturing-transport-fixture [f]
   (reset! last-managed-args nil)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
   capturing-transport-fixture)
 
 (def ^:private frame-id :rf/default)
@@ -89,7 +89,7 @@
       {:request {:method :get :url (str "/api/articles/" slug)}})))
 
 (def ^:private scoped-key
-  (delay (state/scoped-resource-key :rf.scope/global :gen/article {:slug "w"})))
+  (delay (rf.resources.state/scoped-resource-key :rf.scope/global :gen/article {:slug "w"})))
 
 (defn- ensure!
   "Dispatch the ensure for `:gen/article`, optionally SUPPLYING a recorded
@@ -118,7 +118,7 @@
                      {:frame frame-id :rf.cofx {:rf/time-ms 1781078400250}})))
 
 (defn- live-entry []
-  (get-in (:rf.db/runtime (rf/frame-state-value frame-id)) (state/entry-path @scoped-key)))
+  (get-in (:rf.db/runtime (rf/frame-state-value frame-id)) (rf.resources.state/entry-path @scoped-key)))
 
 (defn- with-fresh-runtime
   "Run `body` (a zero-arg thunk) inside a FRESH runtime — re-runs the `:each`
@@ -130,12 +130,12 @@
   dispatch (no installed frame ⇒ nil entries). Mirrors the in-test reset of
   `replay_determinism_e2e_cljs_test`. Returns `body`'s value."
   [body]
-  ((core-test-support/make-reset-runtime-fixture
-     #?(:clj  {:adapter plain-atom/adapter}
-        :cljs {:adapter reagent-adapter/adapter}))
+  ((rf.test-support/make-reset-runtime-fixture
+     #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+        :cljs {:adapter rf.adapter.reagent/adapter}))
    (fn []
      (reset! last-managed-args nil)
-     (fx/reg-fx :rf.http/managed
+     (rf.fx/reg-fx :rf.http/managed
                 (fn [_ctx args] (reset! last-managed-args args) nil))
      (body))))
 
@@ -149,13 +149,13 @@
     ;; ===== 1. RECORD — fresh allocator; ensure mints generation 1 ==========
     (register-resource!)
     (let [generated (atom [])]
-      (trace-tooling/register-listener!
+      (rf.trace.tooling/register-listener!
         ::gen-rec
         (fn [ev] (when (= :rf.cofx/generated (:operation ev))
                    (swap! generated conj ev))))
       (try
         (ensure!)                                  ;; generator runs (:live)
-        (finally (trace-tooling/unregister-listener! ::gen-rec)))
+        (finally (rf.trace.tooling/unregister-listener! ::gen-rec)))
 
       ;; The runtime recorded the allocation on the token (the dev-only
       ;; `:rf.cofx/generated` op carries the produced value). Fresh allocator
@@ -203,7 +203,7 @@
             ;; the replay process's host allocator already minted 10
             ;; generations (a different frame's work, a longer-lived process)
             ;; — restore / replay cannot rewind it.
-            (state/commit-generation! frame-id 10)
+            (rf.resources.state/commit-generation! frame-id 10)
             ;; replay the ensure SUPPLYING the recorded allocation: the handler
             ;; reads generation 1 (the recorded value), NOT (inc 10) = 11.
             (ensure! recorded-allocation)
@@ -223,7 +223,7 @@
         (with-fresh-runtime
           (fn []
             (register-resource!)
-            (state/commit-generation! frame-id 10)
+            (rf.resources.state/commit-generation! frame-id 10)
             ;; replay the ensure WITHOUT the recorded allocation — the
             ;; generator re-mints from the live high-water (the old ambient
             ;; behaviour): generation 11.
@@ -258,7 +258,7 @@
       (fn [{:keys [slug]} _] {:request {:method :post
                                         :url (str "/api/save/" slug)}}))
     (let [generated (atom [])]
-      (trace-tooling/register-listener!
+      (rf.trace.tooling/register-listener!
         ::mgen-rec
         (fn [ev] (when (and (= :rf.cofx/generated (:operation ev))
                             (= :rf.resource/generation-allocation
@@ -268,7 +268,7 @@
         (rf/dispatch-sync [:rf.mutation/execute
                            {:mutation :gen/save :params {:slug "w"}}]
                           {:frame frame-id :rf.cofx {:rf/time-ms 1781078400100}})
-        (finally (trace-tooling/unregister-listener! ::mgen-rec)))
+        (finally (rf.trace.tooling/unregister-listener! ::mgen-rec)))
       (is (= {:generation 1 :counter 1} (:rf.cofx/value (:tags (first @generated))))
           "the mutation writer recorded the generation allocation on its token
            via the same `:rf.resource/generation-allocation` cofx (one root,

--- a/implementation/resources/test/re_frame/resources_cache_key_identity_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_cache_key_identity_cljs_test.cljc
@@ -3,7 +3,7 @@
 
   The full fix for the resource cache-key `=`-collapse: the `:entries` map,
   the reverse indexes, and the work-ledger map are keyed on the CEDN-1 byte
-  `key-id` (`state/key-id` / `work-ledger/work-id-id`) rather than the scoped
+  `key-id` (`rf.resources.state/key-id` / `rf.resources.work-ledger/work-id-id`) rather than the scoped
   resource key VECTOR under Clojure `=`. The vector is the kind-preserving
   identity (`rf2-wgutc2`) carried as each entry's `:resource/key`, embedded in
   the work-id, on the SSR wire, and in trace payloads.
@@ -32,31 +32,31 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    #?(:cljs [cljs.reader])
-   [re-frame.identity :as identity]
-   [re-frame.resources.ssr :as ssr]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.identity :as rf.identity]
+   [re-frame.resources.ssr :as rf.resources.ssr]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.work-ledger :as rf.resources.work-ledger]
    ;; the façade publishes the SSR projection / reconcile hooks + registrar.
    [re-frame.resources]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter})))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter})))
 
 ;; ---- the two adversarial keys: same scope+rid, list-vs-vector params -------
 
-(def ^:private kv (state/scoped-resource-key :rf.scope/global :r/x {:xs [1 2 3]}))
-(def ^:private kl (state/scoped-resource-key :rf.scope/global :r/x {:xs '(1 2 3)}))
+(def ^:private kv (rf.resources.state/scoped-resource-key :rf.scope/global :r/x {:xs [1 2 3]}))
+(def ^:private kl (rf.resources.state/scoped-resource-key :rf.scope/global :r/x {:xs '(1 2 3)}))
 
 (defn- loaded-entry
   "A loaded durable entry stamped with its scoped-key `sk` (the runtime
   stamps `:resource/key` on every entry now)."
   [sk data tags]
-  (-> (state/empty-entry :r/x sk)
+  (-> (rf.resources.state/empty-entry :r/x sk)
       (merge {:status :loaded :data data :loaded-at 1000 :stale-at 9.0e15
               :generation 1 :tags tags})))
 
@@ -67,7 +67,7 @@
   would itself throw `Duplicate key` because `kv` and `kl` are Clojure-`=`,
   which is the very collapse this fix routes around)."
   [pairs]
-  (into {} (map (fn [[sk e]] [(state/key-id sk) e])) pairs))
+  (into {} (map (fn [[sk e]] [(rf.resources.state/key-id sk) e])) pairs))
 
 ;; ===========================================================================
 ;; Carrier 1 — the :entries map key
@@ -77,15 +77,15 @@
   (testing "list- and vector-params keys are `=` as VECTORS but their byte
             key-ids differ, so the :entries map holds TWO entries"
     (is (= kv kl) "the vectors are Clojure-= (the collapse the fix routes around)")
-    (is (not= (state/key-id kv) (state/key-id kl))
+    (is (not= (rf.resources.state/key-id kv) (rf.resources.state/key-id kl))
         "the byte key-ids differ (v[…] vs l(…))")
     (let [es (byte-keyed-entries [[kv (loaded-entry kv {:v 1} #{:t})]
                                    [kl (loaded-entry kl {:l 1} #{:t})]])]
       (is (= 2 (count es)) "two distinct entries — no =-collapse")
-      (is (= {:v 1} (:data (get es (state/key-id kv)))) "vector entry intact")
-      (is (= {:l 1} (:data (get es (state/key-id kl)))) "list entry intact")
-      (is (= kv (:resource/key (get es (state/key-id kv)))) "vector entry keeps its vector key")
-      (is (seq? (-> (get es (state/key-id kl)) :resource/key (nth 2) :xs))
+      (is (= {:v 1} (:data (get es (rf.resources.state/key-id kv)))) "vector entry intact")
+      (is (= {:l 1} (:data (get es (rf.resources.state/key-id kl)))) "list entry intact")
+      (is (= kv (:resource/key (get es (rf.resources.state/key-id kv)))) "vector entry keeps its vector key")
+      (is (seq? (-> (get es (rf.resources.state/key-id kl)) :resource/key (nth 2) :xs))
           "the list entry's :resource/key PRESERVES the list kind (not coerced to a vector)"))))
 
 ;; ===========================================================================
@@ -94,21 +94,21 @@
 
 (deftest carrier-2-work-ledger-keys-distinctly
   (testing "the embedded work-id keys the work-ledger map on its own byte id"
-    (let [wv (work-ledger/resource-work-id kv 1)
-          wl (work-ledger/resource-work-id kl 1)]
+    (let [wv (rf.resources.work-ledger/resource-work-id kv 1)
+          wl (rf.resources.work-ledger/resource-work-id kl 1)]
       (is (= wv wl) "the work-id VECTORS are = (they embed the key vector)")
-      (is (not= (work-ledger/work-id-id wv) (work-ledger/work-id-id wl))
+      (is (not= (rf.resources.work-ledger/work-id-id wv) (rf.resources.work-ledger/work-id-id wl))
           "their byte work-id-ids differ")
-      (let [recv (work-ledger/work-record {:work-id wv :frame-id :f :resource/key kv
+      (let [recv (rf.resources.work-ledger/work-record {:work-id wv :frame-id :f :resource/key kv
                                            :generation 1 :transport :rf.http/managed})
-            recl (work-ledger/work-record {:work-id wl :frame-id :f :resource/key kl
+            recl (rf.resources.work-ledger/work-record {:work-id wl :frame-id :f :resource/key kl
                                            :generation 1 :transport :rf.http/managed})
-            rdb  (-> {} (work-ledger/put-record wv recv) (work-ledger/put-record wl recl))]
+            rdb  (-> {} (rf.resources.work-ledger/put-record wv recv) (rf.resources.work-ledger/put-record wl recl))]
         (is (= 2 (count (:rf.runtime/work-ledger rdb))) "two distinct ledger rows")
-        (is (= wv (:work/id (work-ledger/get-record rdb wv))) "vector work record reads back")
-        (is (= wl (:work/id (work-ledger/get-record rdb wl))) "list work record reads back")
-        (is (= kv (:resource/key (work-ledger/get-record rdb wv))))
-        (is (= kl (:resource/key (work-ledger/get-record rdb wl))))))))
+        (is (= wv (:work/id (rf.resources.work-ledger/get-record rdb wv))) "vector work record reads back")
+        (is (= wl (:work/id (rf.resources.work-ledger/get-record rdb wl))) "list work record reads back")
+        (is (= kv (:resource/key (rf.resources.work-ledger/get-record rdb wv))))
+        (is (= kl (:resource/key (rf.resources.work-ledger/get-record rdb wl))))))))
 
 ;; ===========================================================================
 ;; Carrier 3 — the SSR hydration wire (project → install → hydrate recompute)
@@ -121,10 +121,10 @@
             string — no transit handler needed; a deftype key would break here)"
     (let [es   (byte-keyed-entries [[kv (loaded-entry kv {:v 1} #{:t})]
                                      [kl (loaded-entry kl {:l 1} #{:t})]])
-          rdb  {state/resources-key {:entries es :tag-index {} :owner-index {}}}
+          rdb  {rf.resources.state/resources-key {:entries es :tag-index {} :owner-index {}}}
           ;; SERVER projection (the :ssr/extend-runtime-db-projection body)
-          proj (ssr/project-resources-runtime-db rdb)
-          wired (get-in proj [state/resources-key :entries])]
+          proj (rf.resources.ssr/project-resources-runtime-db rdb)
+          wired (get-in proj [rf.resources.state/resources-key :entries])]
       (is (= 2 (count wired)) "two distinct wire entries projected")
       ;; the wire keys are plain strings (transit/JSON-safe — the load-bearing
       ;; property a deftype key would have violated).
@@ -135,16 +135,16 @@
                              :cljs (cljs.reader/read-string (pr-str wired)))]
         (is (= wired round-tripped) "the projected wire entries survive an EDN round-trip"))
       ;; CLIENT hydration reinstalls + recomputes indexes over the two entries.
-      (let [installed {state/resources-key {:entries wired}}
-            out (ssr/hydrate-runtime-db installed :app/main)
-            out-es (get-in out [state/resources-key :entries])
-            tag-members (get-in out [state/resources-key :tag-index :t])]
+      (let [installed {rf.resources.state/resources-key {:entries wired}}
+            out (rf.resources.ssr/hydrate-runtime-db installed :app/main)
+            out-es (get-in out [rf.resources.state/resources-key :entries])
+            tag-members (get-in out [rf.resources.state/resources-key :tag-index :t])]
         (is (= 2 (count out-es)) "hydration installs TWO distinct entries (no collapse)")
-        (is (= #{(state/key-id kv) (state/key-id kl)} (set (keys out-es)))
+        (is (= #{(rf.resources.state/key-id kv) (rf.resources.state/key-id kl)} (set (keys out-es)))
             "both byte key-ids present after hydration")
         (is (= 2 (count tag-members))
             "the recomputed tag-index has TWO distinct members for the shared tag")
-        (is (= #{(state/key-id kv) (state/key-id kl)} tag-members)
+        (is (= #{(rf.resources.state/key-id kv) (rf.resources.state/key-id kl)} tag-members)
             "the tag-index members are the byte key-ids of both entries")))))
 
 ;; ===========================================================================
@@ -157,13 +157,13 @@
             recomputed two-member shared tag index (restore never collapses)"
     (let [es  (byte-keyed-entries [[kv (loaded-entry kv {:v 1} #{:t})]
                                     [kl (loaded-entry kl {:l 1} #{:t})]])
-          rdb {state/resources-key {:entries es :tag-index {} :owner-index {}}
-               state/work-ledger-key {}}
-          out (ssr/reconcile-on-restore rdb)
-          out-es (get-in out [state/resources-key :entries])]
+          rdb {rf.resources.state/resources-key {:entries es :tag-index {} :owner-index {}}
+               rf.resources.state/work-ledger-key {}}
+          out (rf.resources.ssr/reconcile-on-restore rdb)
+          out-es (get-in out [rf.resources.state/resources-key :entries])]
       (is (= 2 (count out-es)) "two distinct entries survive restore reconcile")
-      (is (= #{(state/key-id kv) (state/key-id kl)}
-             (get-in out [state/resources-key :tag-index :t]))
+      (is (= #{(rf.resources.state/key-id kv) (rf.resources.state/key-id kl)}
+             (get-in out [rf.resources.state/resources-key :tag-index :t]))
           "the recomputed tag-index keeps both byte key-ids for the shared tag"))))
 
 ;; ===========================================================================
@@ -179,13 +179,13 @@
     (is (vector? (:xs (nth kv 2))) "the vector-params scoped key keeps its vector kind")
     ;; and the two are byte-distinct identities — a trace consumer can tell them
     ;; apart (the authoritative CEDN-1 identity, not Clojure =).
-    (is (not (identity/identical-identity? kv kl))
+    (is (not (rf.identity/identical-identity? kv kl))
         "the two trace-carried keys are byte-distinct CEDN-1 identities")))
 
 ;; The real-ensure path (the runtime stamping `:resource/key` on a freshly
 ;; minted entry, keyed under the byte `key-id`) is exercised by the broader
 ;; `resources-runtime-cljs-test` suite (its `entry` helper reads via
-;; `state/entry-path`, which byte-keys) — this focused file pins the cache-key
+;; `rf.resources.state/entry-path`, which byte-keys) — this focused file pins the cache-key
 ;; byte-identity round-trip through the four serialization carriers.
 
 ;; ===========================================================================
@@ -204,9 +204,9 @@
 ;; instant still dedupe to one identity.
 
 (def ^:private instant-text "2026-06-10T00:00:00.000Z")
-(def ^:private ki (state/scoped-resource-key
+(def ^:private ki (rf.resources.state/scoped-resource-key
                     :rf.scope/global :r/x {:at #inst "2026-06-10T00:00:00.000-00:00"}))
-(def ^:private ks (state/scoped-resource-key
+(def ^:private ks (rf.resources.state/scoped-resource-key
                     :rf.scope/global :r/x {:at instant-text}))
 
 (deftest instant-vs-string-params-distinct-identity
@@ -217,32 +217,32 @@
         "the string param stays a plain string"))
   (testing "instant- and string-params keys are DISTINCT scoped keys AND byte key-ids"
     (is (not= ki ks) "the scoped-key vectors differ (tagged tuple vs string param)")
-    (is (not= (state/key-id ki) (state/key-id ks))
+    (is (not= (rf.resources.state/key-id ki) (rf.resources.state/key-id ks))
         "the byte key-ids differ (t:<text> vs s:\"<text>\")")
-    (is (not (identity/identical-identity? ki ks))
+    (is (not (rf.identity/identical-identity? ki ks))
         "the two keys are byte-distinct CEDN-1 identities"))
   (testing "the two params key an :entries map DISTINCTLY end-to-end (no alias)"
     (let [es (byte-keyed-entries [[ki (loaded-entry ki {:from :instant} #{:t})]
                                    [ks (loaded-entry ks {:from :string} #{:t})]])]
       (is (= 2 (count es))
           "two distinct entries — the instant param no longer aliases the string param")
-      (is (= {:from :instant} (:data (get es (state/key-id ki)))))
-      (is (= {:from :string}  (:data (get es (state/key-id ks)))))))
+      (is (= {:from :instant} (:data (get es (rf.resources.state/key-id ki)))))
+      (is (= {:from :string}  (:data (get es (rf.resources.state/key-id ks)))))))
   (testing "the work-ledger work-id is likewise distinct for instant vs string params"
-    (let [wi (work-ledger/resource-work-id ki 1)
-          ws (work-ledger/resource-work-id ks 1)]
-      (is (not= (work-ledger/work-id-id wi) (work-ledger/work-id-id ws))
+    (let [wi (rf.resources.work-ledger/resource-work-id ki 1)
+          ws (rf.resources.work-ledger/resource-work-id ks 1)]
+      (is (not= (rf.resources.work-ledger/work-id-id wi) (rf.resources.work-ledger/work-id-id ws))
           "distinct byte work-id-ids end-to-end")))
   (testing "two SPELLINGS of ONE instant dedupe to the SAME scoped key + byte key-id"
     ;; a host Date and its #inst EDN literal for one moment (both read as the
     ;; host instant on each host) canonicalize to the SAME tagged tuple.
-    (let [ka (state/scoped-resource-key
+    (let [ka (rf.resources.state/scoped-resource-key
                :rf.scope/global :r/x {:at #?(:clj  (java.util.Date. 1781049600000)
                                              :cljs (js/Date. 1781049600000))})
-          kb (state/scoped-resource-key
+          kb (rf.resources.state/scoped-resource-key
                :rf.scope/global :r/x {:at #inst "2026-06-10T00:00:00.000-00:00"})]
       (is (= ka kb) "the two instant spellings collapse to one scoped key")
-      (is (= (state/key-id ka) (state/key-id kb))
+      (is (= (rf.resources.state/key-id ka) (rf.resources.state/key-id kb))
           "one instant → one byte key-id (dedupe holds)"))))
 
 ;; ===========================================================================
@@ -266,7 +266,7 @@
 (deftest scoped-key-vs-resource-id-not-confused
   (testing "the durable entry carries the registered :resource/id (a bare
             keyword) AND the scoped :resource/key (a tuple) under DISTINCT keys"
-    (let [entry (state/empty-entry :r/x kv)]
+    (let [entry (rf.resources.state/empty-entry :r/x kv)]
       ;; the registered id is a bare keyword, NOT the tuple
       (is (= :r/x (:resource/id entry)) ":resource/id is the registered keyword id")
       (is (keyword? (:resource/id entry)) "the registered id is a keyword, never a tuple")
@@ -281,8 +281,8 @@
       (is (= (:resource/id entry) (second (:resource/key entry)))
           "the scoped key's 2nd element is the registered id (the embedded fact)"))
     (testing "the work record names the SAME two distinct facts the SAME way"
-      (let [rec (work-ledger/work-record
-                  {:work-id (work-ledger/resource-work-id kv 1)
+      (let [rec (rf.resources.work-ledger/work-record
+                  {:work-id (rf.resources.work-ledger/resource-work-id kv 1)
                    :frame-id :f :resource/key kv :generation 1
                    :transport :rf.http/managed})]
         ;; the durable scoped-key field on the work record is :resource/key (the
@@ -296,7 +296,7 @@
             "the registered id reads out of the scoped key, not a separate row field"))))
   (testing "the durable scoped-key field is the canonical :resource/key spelling,
             never the retired unqualified :resource-key"
-    (let [entry (state/empty-entry :r/x kv)]
+    (let [entry (rf.resources.state/empty-entry :r/x kv)]
       (is (contains? entry :resource/key) "the canonical :resource/key field is present")
       (is (not (contains? entry :resource-key))
           "the retired :resource-key spelling never appears on a data shape"))))

--- a/implementation/resources/test/re_frame/resources_classification_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_classification_cljs_test.cljc
@@ -30,26 +30,26 @@
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [clojure.string :as str]
    [re-frame.core :as rf]
-   [re-frame.elision :as elision]
-   [re-frame.frame :as frame]
-   [re-frame.privacy :as privacy]
+   [re-frame.elision :as rf.elision]
+   [re-frame.frame :as rf.frame]
+   [re-frame.privacy :as rf.privacy]
    ;; the unit under test + the SSR projection that consumes it.
-   [re-frame.resources.classification :as classification]
-   [re-frame.resources.registry :as registry]
-   [re-frame.resources.ssr :as ssr]
-   [re-frame.resources.state :as state]
+   [re-frame.resources.classification :as rf.resources.classification]
+   [re-frame.resources.registry :as rf.resources.registry]
+   [re-frame.resources.ssr :as rf.resources.ssr]
+   [re-frame.resources.state :as rf.resources.state]
    ;; load-bearing side-effecting requires: the façade registers the
    ;; :resource registrar kind; schemas binds the shared walker hooks.
    [re-frame.resources]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter})))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter})))
 
 ;; ---- helpers --------------------------------------------------------------
 
@@ -68,16 +68,16 @@
 (defn- entry
   [{:keys [resource-id status data loaded-at stale-at]
     :or   {status :loaded loaded-at 1000 stale-at 9.0e15}}]
-  (merge (state/empty-entry resource-id)
+  (merge (rf.resources.state/empty-entry resource-id)
          {:status status :data data :loaded-at loaded-at :stale-at stale-at}))
 
 ;; rf2-9e0tyq — the runtime keys `:entries` on the byte `key-id` and stamps
 ;; each entry's `:resource/key`; this helper re-keys the natural
 ;; `{scoped-key-vector entry}` form callers write into the runtime's shape.
 (defn- runtime-db-with [entries]
-  {state/resources-key {:entries (into {}
+  {rf.resources.state/resources-key {:entries (into {}
                                        (map (fn [[sk e]]
-                                              [(state/key-id sk) (assoc e :resource/key sk)]))
+                                              [(rf.resources.state/key-id sk) (assoc e :resource/key sk)]))
                                        entries)
                         :tag-index {} :owner-index {}}})
 
@@ -93,17 +93,17 @@
   first lowered the resource classification into the frame's registry (the live
   durable home of `[:rf.runtime/elision]`). Returns the projection map."
   [frame-id runtime-db]
-  (let [lowered (classification/reconcile-registry runtime-db registry/resource-meta)]
+  (let [lowered (rf.resources.classification/reconcile-registry runtime-db rf.resources.registry/resource-meta)]
     (when-let [reg (get lowered :rf.runtime/elision)]
-      (elision/swap-elision-slot! frame-id (constantly reg)))
+      (rf.elision/swap-elision-slot! frame-id (constantly reg)))
     (rf/with-frame frame-id
-      (ssr/project-resources-runtime-db lowered))))
+      (rf.resources.ssr/project-resources-runtime-db lowered))))
 
 ;; The projection map is byte-keyed; the projected SCOPED KEY (verbatim or
 ;; redacted) rides as the wire entry's `:resource/key`. Return it as the
 ;; first element so the privacy/distinctness assertions inspect it.
 (defn- only-wire-entry [proj]
-  (let [we (val (first (get-in proj [state/resources-key :entries])))]
+  (let [we (val (first (get-in proj [rf.resources.state/resources-key :entries])))]
     [(:resource/key we) we]))
 
 (defn- only-projection-metadata
@@ -115,8 +115,8 @@
   client derives, and its row does not ride. What the projection DECIDED is
   unchanged and fully reported: `:disposition`, `:projected-key`, `:withheld?`."
   [runtime-db]
-  (first (ssr/projection-metadata
-           nil 5000 (get-in runtime-db [state/resources-key :entries]))))
+  (first (rf.resources.ssr/projection-metadata
+           nil 5000 (get-in runtime-db [rf.resources.state/resources-key :entries]))))
 
 (defn- ssr-projected-key
   "The key the SSR projection PRODUCED for the single entry in `runtime-db`.
@@ -128,13 +128,13 @@
   this suite asserts — the params surface is projected exactly as the data
   surface is — is read off the carrier that survives."
   [frame-id runtime-db]
-  (let [lowered (classification/reconcile-registry runtime-db registry/resource-meta)]
+  (let [lowered (rf.resources.classification/reconcile-registry runtime-db rf.resources.registry/resource-meta)]
     (when-let [reg (get lowered :rf.runtime/elision)]
-      (elision/swap-elision-slot! frame-id (constantly reg)))
+      (rf.elision/swap-elision-slot! frame-id (constantly reg)))
     (rf/with-frame frame-id
       (first (map :projected-key
-                  (ssr/projection-metadata
-                    frame-id 5000 (get-in lowered (state/entries-path))))))))
+                  (rf.resources.ssr/projection-metadata
+                    frame-id 5000 (get-in lowered (rf.resources.state/entries-path))))))))
 
 ;; ===========================================================================
 ;; 1. whole-entry-disposition — the coarse root-prop owner classification
@@ -143,13 +143,13 @@
 (deftest whole-entry-disposition-reads-coarse-root-prop
   (testing "EP-0015 issue 11: the coarse whole-entry :sensitive? / :large?
             claims are the degenerate ROOT-PROP classification unit"
-    (is (= :serialize (classification/whole-entry-disposition {})))
-    (is (= :serialize (classification/whole-entry-disposition nil))
+    (is (= :serialize (rf.resources.classification/whole-entry-disposition {})))
+    (is (= :serialize (rf.resources.classification/whole-entry-disposition nil))
         "an unregistered / nil spec carries no coarse claim → serialize")
-    (is (= :redact (classification/whole-entry-disposition {:sensitive? true})))
-    (is (= :omit   (classification/whole-entry-disposition {:large? true})))
+    (is (= :redact (rf.resources.classification/whole-entry-disposition {:sensitive? true})))
+    (is (= :omit   (rf.resources.classification/whole-entry-disposition {:large? true})))
     (testing "sensitive wins over large (the conservative shape)"
-      (is (= :redact (classification/whole-entry-disposition
+      (is (= :redact (rf.resources.classification/whole-entry-disposition
                        {:sensitive? true :large? true}))))))
 
 ;; ===========================================================================
@@ -165,7 +165,7 @@
             to data; a :scope-rooted path rides params)"
     (let [spec {:sensitive [[:data :ssn] [:params :account-id] [:bare-data] [:scope :tenant]]
                 :large     [[:data :avatar-bytes] [:params :cursor]]}
-          {:keys [data params]} (classification/spec-declaration-marks spec)]
+          {:keys [data params]} (rf.resources.classification/spec-declaration-marks spec)]
       (is (contains? (:sensitive data) [:ssn]) ":data-rooted sensitive → data projection (head stripped)")
       (is (contains? (:sensitive data) [:bare-data]) "bare-rooted sensitive → data projection (shorthand)")
       (is (contains? (:large data) [:avatar-bytes]) ":data-rooted large → data projection")
@@ -181,7 +181,7 @@
     (let [spec {:sensitive [[:data :ssn]]
                 :data-schema   [:map [:token {:sensitive? true} :string] [:title :string]]
                 :params-schema [:map [:account-id {:sensitive? true} :string] [:slug :string]]}
-          {:keys [data]} (classification/spec-declaration-marks spec)]
+          {:keys [data]} (rf.resources.classification/spec-declaration-marks spec)]
       (is (contains? (:sensitive data) [:ssn]) "projection-relative sensitive :data path is present")
       (is (not (contains? (:sensitive data) [:token])) "schema-prop sensitive slot is NOT present (no union)"))))
 
@@ -212,7 +212,7 @@
             frame-independent authority (matches machines / routing
             fail-open-frameless)"
     (is (= {:title "X" :token "tok"}
-           (classification/project-entry-data
+           (rf.resources.classification/project-entry-data
              {:title "X" :token "tok"} "k-1" nil :rf.egress/ssr-hydration)))))
 
 (deftest project-entry-data-redacts-registry-lowered-sensitive-slot
@@ -222,14 +222,14 @@
             project-entry-data walks the bare :data through project-egress seeded
             at that offset and redacts the declared :ssn slot; a sibling rides"
     (rf/make-frame {:id :reg/frame})
-    (let [k       (state/scoped-resource-key :rf.scope/global :acct/profile {:slug "x"})
-          k-id    (state/key-id k)
+    (let [k       (rf.resources.state/scoped-resource-key :rf.scope/global :acct/profile {:slug "x"})
+          k-id    (rf.resources.state/key-id k)
           rdb     (runtime-db-with {k (entry {:resource-id :acct/profile
                                               :data {:ssn "123-45-6789" :name "Alice"}})})
-          lowered (classification/reconcile-registry rdb registry/resource-meta)]
-      (elision/swap-elision-slot! :reg/frame (constantly (get lowered :rf.runtime/elision)))
-      (let [data      (get-in lowered [state/resources-key :entries k-id :data])
-            projected (classification/project-entry-data
+          lowered (rf.resources.classification/reconcile-registry rdb rf.resources.registry/resource-meta)]
+      (rf.elision/swap-elision-slot! :reg/frame (constantly (get lowered :rf.runtime/elision)))
+      (let [data      (get-in lowered [rf.resources.state/resources-key :entries k-id :data])
+            projected (rf.resources.classification/project-entry-data
                         data k-id :reg/frame :rf.egress/off-box-tool)]
         (is (= :rf/redacted (:ssn projected))
             "the registry-lowered :data :ssn slot is redacted")
@@ -243,14 +243,14 @@
             ELIDES its slot to the :rf.size/large-elided marker at egress"
     (rf/make-frame {:id :reg/large})
     (let [big     (apply str (repeat 500 "x"))
-          k       (state/scoped-resource-key :rf.scope/global :report/card {:slug "r"})
-          k-id    (state/key-id k)
+          k       (rf.resources.state/scoped-resource-key :rf.scope/global :report/card {:slug "r"})
+          k-id    (rf.resources.state/key-id k)
           rdb     (runtime-db-with {k (entry {:resource-id :report/card
                                               :data {:blob big :title "public"}})})
-          lowered (classification/reconcile-registry rdb registry/resource-meta)]
-      (elision/swap-elision-slot! :reg/large (constantly (get lowered :rf.runtime/elision)))
-      (let [data      (get-in lowered [state/resources-key :entries k-id :data])
-            projected (classification/project-entry-data
+          lowered (rf.resources.classification/reconcile-registry rdb rf.resources.registry/resource-meta)]
+      (rf.elision/swap-elision-slot! :reg/large (constantly (get lowered :rf.runtime/elision)))
+      (let [data      (get-in lowered [rf.resources.state/resources-key :entries k-id :data])
+            projected (rf.resources.classification/project-entry-data
                         data k-id :reg/large :rf.egress/off-box-tool)]
         (is (contains? (:blob projected) :rf.size/large-elided)
             "the registry-lowered :data :blob slot is elided to the size marker")
@@ -265,16 +265,16 @@
             through project-egress seeded at the lowered :resource/key params
             offset and redacts the declared :account-id slot"
     (rf/make-frame {:id :reg/params})
-    (let [k       (state/scoped-resource-key :rf.scope/global :report/by-account
+    (let [k       (rf.resources.state/scoped-resource-key :rf.scope/global :report/by-account
                                              {:account-id "acct-secret-42" :slug "q3"})
-          k-id    (state/key-id k)
+          k-id    (rf.resources.state/key-id k)
           rdb     (runtime-db-with {k (entry {:resource-id :report/by-account :data {:total 99}})})
-          lowered (classification/reconcile-registry rdb registry/resource-meta)]
-      (elision/swap-elision-slot! :reg/params (constantly (get lowered :rf.runtime/elision)))
+          lowered (rf.resources.classification/reconcile-registry rdb rf.resources.registry/resource-meta)]
+      (rf.elision/swap-elision-slot! :reg/params (constantly (get lowered :rf.runtime/elision)))
       (let [params    (nth k 2)
-            projected (classification/project-entry-params
+            projected (rf.resources.classification/project-entry-params
                         params k-id :reg/params :rf.egress/ssr-hydration)]
-        (is (= privacy/redacted-sentinel (:account-id projected))
+        (is (= rf.privacy/redacted-sentinel (:account-id projected))
             "the registry-lowered :params :account-id slot is redacted")
         (is (= "q3" (:slug projected)) "the unmarked params sibling rides verbatim")
         (is (not (str/includes? (pr-str projected) "acct-secret-42")))))))
@@ -289,15 +289,15 @@
             rf2-4bjep settles what that costs the ROW: the projection re-keys
             both components, so no live client can address the entry and it does
             not ride. The claim is absence of the ROW, not of its data"
-    (let [k    (state/scoped-resource-key :rf.scope/global :secret/thing {:slug "s"})
+    (let [k    (rf.resources.state/scoped-resource-key :rf.scope/global :secret/thing {:slug "s"})
           e    (entry {:resource-id :secret/thing :data {:ssn "123-45-6789"}})
           rdb  (runtime-db-with {k e})
-          proj (ssr/project-resources-runtime-db rdb)
+          proj (rf.resources.ssr/project-resources-runtime-db rdb)
           m    (only-projection-metadata rdb)]
-      (is (= :redact (classification/whole-entry-disposition
+      (is (= :redact (rf.resources.classification/whole-entry-disposition
                        (rf/resource-meta :secret/thing)))
           "premise: the coarse claim still classifies :redact")
-      (is (empty? (get-in proj [state/resources-key :entries]))
+      (is (empty? (get-in proj [rf.resources.state/resources-key :entries]))
           (str "the row does not ride: " (pr-str proj)))
       (is (not (str/includes? (pr-str proj) "123-45-6789"))
           "so the sensitive data cannot ride")
@@ -309,15 +309,15 @@
   (reg! :big/thing {:large? true})
   (testing "the same for the coarse :large? root-prop claim: it still classifies
             :omit, and its row is withheld for the same identity reason"
-    (let [k    (state/scoped-resource-key :rf.scope/global :big/thing {:slug "b"})
+    (let [k    (rf.resources.state/scoped-resource-key :rf.scope/global :big/thing {:slug "b"})
           e    (entry {:resource-id :big/thing :data (vec (range 10000))})
           rdb  (runtime-db-with {k e})
-          proj (ssr/project-resources-runtime-db rdb)
+          proj (rf.resources.ssr/project-resources-runtime-db rdb)
           m    (only-projection-metadata rdb)]
-      (is (= :omit (classification/whole-entry-disposition
+      (is (= :omit (rf.resources.classification/whole-entry-disposition
                      (rf/resource-meta :big/thing)))
           "premise: the coarse claim still classifies :omit")
-      (is (empty? (get-in proj [state/resources-key :entries]))
+      (is (empty? (get-in proj [rf.resources.state/resources-key :entries]))
           "the row does not ride, so the large payload cannot")
       (is (= :omitted (:disposition m)))
       (is (true? (:withheld? m))))))
@@ -333,17 +333,17 @@
     ;; the commit-plane effect at the entry's absolute :data path (the frame may
     ;; additionally classify a subsystem absolute path — Spec 015 L149).
     (rf/make-frame {:id :rcfg/ssr})
-    (let [k    (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "x"})
-          k-id (state/key-id k)
+    (let [k    (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "x"})
+          k-id (rf.resources.state/key-id k)
           e    (entry {:resource-id :article/by-slug
                        :data {:secret "tok-xyz" :title "hello"}})]
-      (frame/swap-runtime-db! :rcfg/ssr
-        (fn [rt] (elision/apply-classification-effects
+      (rf.frame/swap-runtime-db! :rcfg/ssr
+        (fn [rt] (rf.elision/apply-classification-effects
                    rt {:sensitive [[:rf.runtime/resources :entries k-id :data :secret]]})))
       (let [proj (rf/with-frame :rcfg/ssr
-                   (ssr/project-resources-runtime-db (runtime-db-with {k e})))
+                   (rf.resources.ssr/project-resources-runtime-db (runtime-db-with {k e})))
             [_ we] (only-wire-entry proj)]
-        (is (= privacy/redacted-sentinel (:secret (:data we)))
+        (is (= rf.privacy/redacted-sentinel (:secret (:data we)))
             "the frame-classified :secret slot is redacted on the serialized entry")
         (is (= "hello" (:title (:data we)))
             "the unclassified sibling rides verbatim")
@@ -357,14 +357,14 @@
             redacts that slot on SSR projection — the registry-driven egress
             read fires (the standard model)"
     (rf/make-frame {:id :rcfg/owner-data})
-    (let [k   (state/scoped-resource-key :rf.scope/global :profile/card {:slug "x"})
+    (let [k   (rf.resources.state/scoped-resource-key :rf.scope/global :profile/card {:slug "x"})
           e   (entry {:resource-id :profile/card
                       :data {:pan "4111-1111-1111-1111" :name "Alice"}})
           [_ we] (only-wire-entry (ssr-project :rcfg/owner-data (runtime-db-with {k e})))]
-      (is (= :serialize (classification/whole-entry-disposition
+      (is (= :serialize (rf.resources.classification/whole-entry-disposition
                           (rf/resource-meta :profile/card)))
           "no coarse claim → :serialize (the per-slot mark is the fine-grained surface)")
-      (is (= privacy/redacted-sentinel (get-in we [:data :pan]))
+      (is (= rf.privacy/redacted-sentinel (get-in we [:data :pan]))
           "the owner-declared :pan slot is redacted on the serialized entry")
       (is (= "Alice" (get-in we [:data :name])) "the unmarked sibling rides verbatim")
       (is (not (str/includes? (pr-str we) "4111-1111-1111-1111"))
@@ -377,7 +377,7 @@
             projection (the registry-driven owner surface fires)"
     (rf/make-frame {:id :rcfg/owner-large})
     (let [big (apply str (repeat 1000 "q"))
-          k   (state/scoped-resource-key :rf.scope/global :report/blob {:slug "r"})
+          k   (rf.resources.state/scoped-resource-key :rf.scope/global :report/blob {:slug "r"})
           e   (entry {:resource-id :report/blob :data {:blob big :name "ok"}})
           [_ we] (only-wire-entry (ssr-project :rcfg/owner-large (runtime-db-with {k e})))]
       (is (contains? (:blob (:data we)) :rf.size/large-elided)
@@ -397,20 +397,20 @@
             slot RAW in the projected wire KEY — the params surface is co-equal
             with the data surface (Spec 016 clause 4)"
     (rf/make-frame {:id :rcfg/owner-params})
-    (let [k   (state/scoped-resource-key :rf.scope/global :report/by-account
+    (let [k   (rf.resources.state/scoped-resource-key :rf.scope/global :report/by-account
                                          {:account-id "acct-secret-42" :slug "q3"})
           e   (entry {:resource-id :report/by-account :data {:total 99}})
           rdb (runtime-db-with {k e})
           wk  (ssr-projected-key :rcfg/owner-params rdb)]
-      (is (= :serialize (classification/whole-entry-disposition
+      (is (= :serialize (rf.resources.classification/whole-entry-disposition
                           (rf/resource-meta :report/by-account)))
           "no coarse claim → :serialize (the per-slot params mark is the surface)")
       (is (= :report/by-account (nth wk 1)) "resource-id preserved (position 1)")
-      (is (= privacy/redacted-sentinel (get-in wk [2 :account-id]))
+      (is (= rf.privacy/redacted-sentinel (get-in wk [2 :account-id]))
           "the owner-declared :account-id params slot is redacted in the wire key")
       (is (= "q3" (get-in wk [2 :slug])) "the unmarked params sibling rides verbatim")
       (is (empty? (get-in (ssr-project :rcfg/owner-params rdb)
-                          [state/resources-key :entries]))
+                          [rf.resources.state/resources-key :entries]))
           ;; rf2-rjq9d — redacting a params slot re-keys the entry (identity is
           ;; the canonical bytes of the WHOLE key), and the live client derives
           ;; the RAW key, so a shipped row would be unaddressable. Shipping it
@@ -438,7 +438,7 @@
   "Build a `:loaded` infinite-feed entry for `resource-id` carrying `pages` (a
   vector of decoded page values) as its durable `:data` page vector."
   [resource-id pages]
-  (merge (state/empty-infinite-entry resource-id)
+  (merge (rf.resources.state/empty-infinite-entry resource-id)
          {:status      :loaded
           :data        (vec pages)
           :page-params (vec (repeat (count pages) nil))
@@ -454,21 +454,21 @@
             EVERY page during SSR projection (the index-free decl matches every
             indexed page path)"
     (rf/make-frame {:id :rcfg/infinite})
-    (let [k    (state/scoped-resource-key :rf.scope/global :feed/timeline {:slug "t"})
+    (let [k    (rf.resources.state/scoped-resource-key :rf.scope/global :feed/timeline {:slug "t"})
           e    (infinite-entry-with-pages
                  :feed/timeline
                  [{:author-email "alice@example.com" :body "hello"}
                   {:author-email "bob@example.com" :body "world"}])
           [_ we] (only-wire-entry (ssr-project :rcfg/infinite (runtime-db-with {k e})))
           pages  (:data we)]
-      (is (= :serialize (classification/whole-entry-disposition
+      (is (= :serialize (rf.resources.classification/whole-entry-disposition
                           (rf/resource-meta :feed/timeline)))
           "no coarse claim → :serialize")
       (is (vector? pages) "the page-vector shape is preserved on the wire")
       (is (= 2 (count pages)) "every accumulated page rides")
-      (is (= privacy/redacted-sentinel (get-in pages [0 :author-email]))
+      (is (= rf.privacy/redacted-sentinel (get-in pages [0 :author-email]))
           "page-0's sensitive field is redacted on the wire")
-      (is (= privacy/redacted-sentinel (get-in pages [1 :author-email]))
+      (is (= rf.privacy/redacted-sentinel (get-in pages [1 :author-email]))
           "page-1's sensitive field is redacted on the wire")
       (is (= "hello" (get-in pages [0 :body])) "page-0's unmarked field rides verbatim")
       (is (= "world" (get-in pages [1 :body])) "page-1's unmarked field rides verbatim")
@@ -486,15 +486,15 @@
   (testing "Spec 016 §SSR: only the durable :rf.runtime/resources :entries
             slice rides — never the indexes, never all of runtime-db
             (allowlist-shaped, preserved under the reconciliation)"
-    (let [k   (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "x"})
+    (let [k   (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "x"})
           e   (entry {:resource-id :article/by-slug :data {:title "X"}})
           rdb (assoc (runtime-db-with {k e})
                      :rf.runtime/machines {:snapshots {}}
                      :rf.runtime/routing  {:current {:route :x}})
-          proj (ssr/project-resources-runtime-db rdb)]
-      (is (= #{state/resources-key} (set (keys proj)))
+          proj (rf.resources.ssr/project-resources-runtime-db rdb)]
+      (is (= #{rf.resources.state/resources-key} (set (keys proj)))
           "only the resources subsystem key is projected")
-      (is (= #{:entries} (set (keys (get proj state/resources-key))))
+      (is (= #{:entries} (set (keys (get proj rf.resources.state/resources-key))))
           "only :entries rides — indexes are recomputable-from-entries"))))
 
 (deftest ssr-redacted-entry-installs-no-row-so-nothing-can-mistake-it-for-data
@@ -506,17 +506,17 @@
             nothing it cannot address. `entry-needs-refetch?`'s sentinel
             handling is unchanged and pinned by
             `refetch-plan-classifies-redacted-vs-omitted-vs-stale-vs-fresh`"
-    (let [k    (state/scoped-resource-key :rf.scope/global :secret/thing {:slug "s"})
+    (let [k    (rf.resources.state/scoped-resource-key :rf.scope/global :secret/thing {:slug "s"})
           e    (entry {:resource-id :secret/thing :data {:ssn "x"}})
           rdb  (runtime-db-with {k e})
-          proj (ssr/project-resources-runtime-db rdb)
+          proj (rf.resources.ssr/project-resources-runtime-db rdb)
           m    (only-projection-metadata rdb)]
-      (is (empty? (get-in proj [state/resources-key :entries]))
+      (is (empty? (get-in proj [rf.resources.state/resources-key :entries]))
           "nothing rides")
-      (is (empty? (get-in (ssr/hydrate-runtime-db proj nil)
-                          [state/resources-key :entries]))
+      (is (empty? (get-in (rf.resources.ssr/hydrate-runtime-db proj nil)
+                          [rf.resources.state/resources-key :entries]))
           "so the client installs no row for it")
-      (is (empty? (ssr/hydrate-refetch-plan proj 5000))
+      (is (empty? (rf.resources.ssr/hydrate-refetch-plan proj 5000))
           "and the plan names nothing")
       (is (true? (:refetch-on-client? m))
           "while the server's own metadata still says the client must fetch it
@@ -529,7 +529,7 @@
             the reconciliation). rf2-4bjep — read off `projection-metadata`,
             since the row itself no longer rides at all"
     (let [scope [:rf.scope/session {:user "alice@example.com"}]
-          k    (state/scoped-resource-key scope :secret/thing {:account-id "secret-42"})
+          k    (rf.resources.state/scoped-resource-key scope :secret/thing {:account-id "secret-42"})
           e    (entry {:resource-id :secret/thing :data {:ssn "x"}})
           rdb  (runtime-db-with {k e})
           wk   (:projected-key (only-projection-metadata rdb))]
@@ -539,7 +539,7 @@
       (let [s (pr-str wk)]
         (is (not (str/includes? s "alice@example.com")) "no raw user in the key")
         (is (not (str/includes? s "secret-42")) "no raw param in the key"))
-      (let [s (pr-str (ssr/project-resources-runtime-db rdb))]
+      (let [s (pr-str (rf.resources.ssr/project-resources-runtime-db rdb))]
         (is (not (str/includes? s "alice@example.com")))
         (is (not (str/includes? s "secret-42")))
         (is (not (str/includes? s "rf/redacted"))

--- a/implementation/resources/test/re_frame/resources_classification_lowering_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_classification_lowering_cljs_test.cljc
@@ -18,21 +18,21 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.elision :as elision]
-   [re-frame.frame :as frame]
-   [re-frame.resources.classification :as classification]
-   [re-frame.resources.registry :as registry]
-   [re-frame.resources.state :as state]
+   [re-frame.elision :as rf.elision]
+   [re-frame.frame :as rf.frame]
+   [re-frame.resources.classification :as rf.resources.classification]
+   [re-frame.resources.registry :as rf.resources.registry]
+   [re-frame.resources.state :as rf.resources.state]
    [re-frame.resources]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter})))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter})))
 
 ;; ---- helpers --------------------------------------------------------------
 
@@ -45,9 +45,9 @@
     (rf/reg-resource id spec (fn [_ _] {:request {:method :get :url "/x"}}))))
 
 (defn- runtime-db-with [entries]
-  {state/resources-key {:entries (into {}
+  {rf.resources.state/resources-key {:entries (into {}
                                        (map (fn [[sk e]]
-                                              [(state/key-id sk) (assoc (state/empty-entry (second sk) sk)
+                                              [(rf.resources.state/key-id sk) (assoc (rf.resources.state/empty-entry (second sk) sk)
                                                                         :status :loaded
                                                                         :resource/key sk
                                                                         :data (:data e))]))
@@ -72,11 +72,11 @@
             into the per-frame elision registry under :source :resource, rooted
             at the entry's absolute runtime-db path (a generic registry reader
             now SEES them)"
-    (let [k       (state/scoped-resource-key :rf.scope/global :profile/card
+    (let [k       (rf.resources.state/scoped-resource-key :rf.scope/global :profile/card
                                              {:account-id "a-1" :slug "x"})
-          k-id    (state/key-id k)
+          k-id    (rf.resources.state/key-id k)
           rdb     (runtime-db-with {k {:data {:ssn "x" :avatar-bytes "y"}}})
-          out     (classification/reconcile-registry rdb registry/resource-meta)
+          out     (rf.resources.classification/reconcile-registry rdb rf.resources.registry/resource-meta)
           sens    (sensitive-decls out)
           large   (large-decls out)
           data-pre  [:rf.runtime/resources :entries k-id :data]
@@ -95,23 +95,23 @@
   (reg! :profile/card2 {:sensitive [[:data :ssn]]})
   (testing "re-running reconcile-registry over its own output is a no-op (the
             full resource-sourced set is rebuilt from :entries deterministically)"
-    (let [k    (state/scoped-resource-key :rf.scope/global :profile/card2 {:slug "x"})
+    (let [k    (rf.resources.state/scoped-resource-key :rf.scope/global :profile/card2 {:slug "x"})
           rdb  (runtime-db-with {k {:data {:ssn "x"}}})
-          once (classification/reconcile-registry rdb registry/resource-meta)
-          twice (classification/reconcile-registry once registry/resource-meta)]
+          once (rf.resources.classification/reconcile-registry rdb rf.resources.registry/resource-meta)
+          twice (rf.resources.classification/reconcile-registry once rf.resources.registry/resource-meta)]
       (is (= once twice) "reconciliation is idempotent"))))
 
 (deftest reconcile-self-drops-evicted-entry
   (reg! :profile/card3 {:sensitive [[:data :ssn]]})
   (testing "an evicted entry's :source :resource declarations vanish on the next
             reconcile (the per-instance teardown — no separate drop hook)"
-    (let [k     (state/scoped-resource-key :rf.scope/global :profile/card3 {:slug "x"})
+    (let [k     (rf.resources.state/scoped-resource-key :rf.scope/global :profile/card3 {:slug "x"})
           rdb   (runtime-db-with {k {:data {:ssn "x"}}})
-          live  (classification/reconcile-registry rdb registry/resource-meta)
+          live  (rf.resources.classification/reconcile-registry rdb rf.resources.registry/resource-meta)
           ;; evict: drop the entry, keep the carried registry, reconcile again.
           evicted (-> live
-                      (assoc-in [state/resources-key :entries] {})
-                      (classification/reconcile-registry registry/resource-meta))]
+                      (assoc-in [rf.resources.state/resources-key :entries] {})
+                      (rf.resources.classification/reconcile-registry rf.resources.registry/resource-meta))]
       (is (seq (sensitive-decls live)) "the live entry lowered a declaration")
       (is (empty? (get-in evicted [:rf.runtime/elision :sensitive-declarations]))
           "the evicted entry's declaration is dropped"))))
@@ -120,11 +120,11 @@
   (reg! :profile/card4 {:sensitive [[:data :ssn]]})
   (testing "a non-resource-sourced registry entry (e.g. :source :effect) on a
             different path rides untouched through reconciliation"
-    (let [k   (state/scoped-resource-key :rf.scope/global :profile/card4 {:slug "x"})
+    (let [k   (rf.resources.state/scoped-resource-key :rf.scope/global :profile/card4 {:slug "x"})
           rdb (-> (runtime-db-with {k {:data {:ssn "x"}}})
                   (assoc-in [:rf.runtime/elision :sensitive-declarations [:app :token]]
                             #{{:source :effect}}))
-          out (classification/reconcile-registry rdb registry/resource-meta)]
+          out (rf.resources.classification/reconcile-registry rdb rf.resources.registry/resource-meta)]
       (is (= #{{:source :effect}} (get (sensitive-decls out) [:app :token]))
           "the :source :effect entry survives reconciliation"))))
 
@@ -132,9 +132,9 @@
   (reg! :plain/card {})   ;; declares no classification
   (testing "a resource that declares no classification lowers nothing — no
             stray registry sub-tree"
-    (let [k   (state/scoped-resource-key :rf.scope/global :plain/card {:slug "x"})
+    (let [k   (rf.resources.state/scoped-resource-key :rf.scope/global :plain/card {:slug "x"})
           rdb (runtime-db-with {k {:data {:title "t"}}})
-          out (classification/reconcile-registry rdb registry/resource-meta)]
+          out (rf.resources.classification/reconcile-registry rdb rf.resources.registry/resource-meta)]
       (is (not (contains? out :rf.runtime/elision))
           "no :rf.runtime/elision key when nothing classifies"))))
 
@@ -150,15 +150,15 @@
             redacts the resource's declared :data :ssn path — proving the
             classification is IN the registry, not only at the family projector"
     (rf/make-frame {:id :reg/frame})
-    (let [k     (state/scoped-resource-key :rf.scope/global :acct/profile {:slug "x"})
-          k-id  (state/key-id k)
+    (let [k     (rf.resources.state/scoped-resource-key :rf.scope/global :acct/profile {:slug "x"})
+          k-id  (rf.resources.state/key-id k)
           rdb   (runtime-db-with {k {:data {:ssn "123-45-6789" :name "Alice"}}})
           ;; lower the resource classification into the frame's registry…
-          lowered (classification/reconcile-registry rdb registry/resource-meta)]
-      (frame/swap-runtime-db! :reg/frame (constantly lowered))
+          lowered (rf.resources.classification/reconcile-registry rdb rf.resources.registry/resource-meta)]
+      (rf.frame/swap-runtime-db! :reg/frame (constantly lowered))
       ;; …then a GENERIC registry reader (elide-wire-value over the frame's
       ;; registry) redacts the declared :data :ssn path of the entry value.
-      (let [entry-data (get-in lowered [state/resources-key :entries k-id :data])
+      (let [entry-data (get-in lowered [rf.resources.state/resources-key :entries k-id :data])
             projected  (rf/elide-wire-value
                          entry-data
                          {:frame :reg/frame
@@ -170,7 +170,7 @@
             "the undeclared sibling rides verbatim")
         (testing "the registry carries the declaration under :source :resource"
           (is (= #{{:source :resource}}
-                 (get (elision/sensitive-declarations :reg/frame)
+                 (get (rf.elision/sensitive-declarations :reg/frame)
                       [:rf.runtime/resources :entries k-id :data :ssn]))))))))
 
 ;; ===========================================================================
@@ -184,8 +184,8 @@
             on the SAME absolute entry path UNION through reconcile, and each
             removes INDEPENDENTLY: eviction drops the resource claim while the
             effect survives; removing the effect owner leaves the resource claim."
-    (let [k       (state/scoped-resource-key :rf.scope/global :acct/card {:slug "x"})
-          k-id    (state/key-id k)
+    (let [k       (rf.resources.state/scoped-resource-key :rf.scope/global :acct/card {:slug "x"})
+          k-id    (rf.resources.state/key-id k)
           abs-ssn [:rf.runtime/resources :entries k-id :data :ssn]
           ;; base runtime-db: the entry exists AND an app effect ALREADY
           ;; classifies the same absolute path (Spec 015 L149).
@@ -193,20 +193,20 @@
                       (assoc-in [:rf.runtime/elision :sensitive-declarations abs-ssn]
                                 #{{:source :effect}}))
           ;; reconcile LOWERS the resource claim → UNION with the effect claim
-          unioned (classification/reconcile-registry base registry/resource-meta)
+          unioned (rf.resources.classification/reconcile-registry base rf.resources.registry/resource-meta)
           owners  (get-in unioned [:rf.runtime/elision :sensitive-declarations abs-ssn])]
       (is (contains? owners {:source :effect})  "the effect claim is retained")
       (is (contains? owners {:source :resource}) "the resource claim UNIONS in")
       ;; EVICT the entry → reconcile drops ONLY the resource owner; effect survives
       (let [evicted  (-> unioned
-                         (assoc-in [state/resources-key :entries] {})
-                         (classification/reconcile-registry registry/resource-meta))
+                         (assoc-in [rf.resources.state/resources-key :entries] {})
+                         (rf.resources.classification/reconcile-registry rf.resources.registry/resource-meta))
             e-owners (get-in evicted [:rf.runtime/elision :sensitive-declarations abs-ssn])]
         (is (= #{{:source :effect}} e-owners)
             "eviction drops the resource claim; the effect claim SURVIVES (no fail-open)"))
       ;; conversely, removing the effect owner leaves the resource claim standing
       (let [reg-only       (get unioned :rf.runtime/elision)
-            without-effect (elision/remove-owner reg-only :sensitive-declarations {:source :effect})
+            without-effect (rf.elision/remove-owner reg-only :sensitive-declarations {:source :effect})
             r-owners       (get-in without-effect [:sensitive-declarations abs-ssn])]
         (is (= #{{:source :resource}} r-owners)
             "removing the effect owner leaves the resource claim standing")))))

--- a/implementation/resources/test/re_frame/resources_derived_scope_sensitivity_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_derived_scope_sensitivity_cljs_test.cljc
@@ -28,20 +28,20 @@
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [clojure.string :as str]
    [re-frame.core :as rf]
-   [re-frame.elision :as elision]
-   [re-frame.frame :as frame]
-   [re-frame.registrar :as registrar]
-   [re-frame.resources.classification :as classification]
-   [re-frame.resources.scope-registry :as scope-registry]
-   [re-frame.resources.ssr :as ssr]
-   [re-frame.resources.state :as state]
+   [re-frame.elision :as rf.elision]
+   [re-frame.frame :as rf.frame]
+   [re-frame.registrar :as rf.registrar]
+   [re-frame.resources.classification :as rf.resources.classification]
+   [re-frame.resources.scope-registry :as rf.resources.scope-registry]
+   [re-frame.resources.ssr :as rf.resources.ssr]
+   [re-frame.resources.state :as rf.resources.state]
    ;; load-bearing side-effecting requires: register the :resource +
    ;; :resource-scope registrar kinds + the schemas walker hooks.
    [re-frame.resources]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- fixture --------------------------------------------------------------
 
@@ -53,13 +53,13 @@
   `:scope` is the `{:from-db …}` reference but NOT itself declared sensitive.
   EP-0025: the frame's sensitive declaration does NOT propagate to the resource."
   []
-  (registrar/clear-kind! :resource-scope)
-  (registrar/clear-kind! :resource)
+  (rf.registrar/clear-kind! :resource-scope)
+  (rf.registrar/clear-kind! :resource)
   ;; FRAME classification: the viewer-identity path is sensitive (commit-plane
   ;; effect path, :source :effect).
   (rf/make-frame {:id frame-id})
-  (frame/swap-runtime-db! frame-id
-    (fn [rt] (elision/apply-classification-effects rt {:sensitive [[:auth :user :username]]})))
+  (rf.frame/swap-runtime-db! frame-id
+    (fn [rt] (rf.elision/apply-classification-effects rt {:sensitive [[:auth :user :username]]})))
   ;; resolver reading the sensitive viewer-identity path — NO propagation now.
   (rf/reg-resource-scope :t/session
     {:inputs {:username [:db [:auth :user :username]]}}
@@ -73,34 +73,34 @@
       {:request {:method :get :url "/feed" :params {:page page}}})))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter :init-fn init!}
-       :cljs {:adapter reagent-adapter/adapter :init-fn init!})))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter :init-fn init!}
+       :cljs {:adapter rf.adapter.reagent/adapter :init-fn init!})))
 
 ;; ---- helpers --------------------------------------------------------------
 
 (defn- entry
   [resource-id data]
-  (merge (state/empty-entry resource-id)
+  (merge (rf.resources.state/empty-entry resource-id)
          {:status :loaded :data data :loaded-at 1000 :stale-at 9.0e15}))
 
 ;; rf2-9e0tyq — re-key into the runtime's byte-`key-id` :entries shape, stamping
 ;; each entry's `:resource/key`.
 (defn- runtime-db-with [entries]
-  {state/resources-key {:entries (into {}
+  {rf.resources.state/resources-key {:entries (into {}
                                        (map (fn [[sk e]]
-                                              [(state/key-id sk) (assoc e :resource/key sk)]))
+                                              [(rf.resources.state/key-id sk) (assoc e :resource/key sk)]))
                                        entries)
                         :tag-index {} :owner-index {}}})
 
 ;; the projected SCOPED KEY rides as the wire entry's `:resource/key` (the map
 ;; key is the opaque byte id); return it as the first element.
 (defn- only-wire [proj]
-  (let [we (val (first (get-in proj [state/resources-key :entries])))]
+  (let [we (val (first (get-in proj [rf.resources.state/resources-key :entries])))]
     [(:resource/key we) we]))
 
 (defn- session-key [u page]
-  (state/scoped-resource-key [:rf.scope/session {:username u}] :t/feed {:page page}))
+  (rf.resources.state/scoped-resource-key [:rf.scope/session {:username u}] :t/feed {:page page}))
 
 ;; ===========================================================================
 ;; 1. :rf.egress/output-sensitivity is SILENTLY IGNORED, not validated.
@@ -120,7 +120,7 @@
              (fn [{:keys [username]} _] (when username [:rf.scope/session {:username username}]))))
         "a resolver with :rf.egress/output-sensitivity registers cleanly")
     (testing "the key is not stored on the canonical spec"
-      (is (nil? (:output-sensitivity (scope-registry/scope-resolver-meta :t/with-claim)))))
+      (is (nil? (:output-sensitivity (rf.resources.scope-registry/scope-resolver-meta :t/with-claim)))))
     (testing "even a previously-invalid enum value is ignored (no fail-closed throw)"
       (is (= :t/garbage-claim
              (rf/reg-resource-scope :t/garbage-claim
@@ -137,7 +137,7 @@
             does NOT inherit sensitive — its disposition is its OWN coarse claim
             (:serialize, since :t/feed declares neither :sensitive? nor :large?)"
     (let [spec (rf/resource-meta :t/feed)]
-      (is (= :serialize (classification/whole-entry-disposition spec))
+      (is (= :serialize (rf.resources.classification/whole-entry-disposition spec))
           "no propagation — the resource serializes despite the sensitive input"))))
 
 (deftest disposition-owner-declared-still-redacts
@@ -149,7 +149,7 @@
        :params-schema [:map [:page :int]]}
       (fn [_ _] {:request {:method :get :url "/secret"}}))
     (let [spec (rf/resource-meta :t/secret-feed)]
-      (is (= :redact (classification/whole-entry-disposition spec))
+      (is (= :redact (rf.resources.classification/whole-entry-disposition spec))
           "the owner :sensitive? claim redacts (frame-blind)")))
   (testing "an owner :large? claim omits (frame-blind)"
     (rf/reg-resource :t/big-feed
@@ -158,7 +158,7 @@
        :params-schema [:map [:page :int]]}
       (fn [_ _] {:request {:method :get :url "/big"}}))
     (let [spec (rf/resource-meta :t/big-feed)]
-      (is (= :omit (classification/whole-entry-disposition spec))))))
+      (is (= :omit (rf.resources.classification/whole-entry-disposition spec))))))
 
 ;; ===========================================================================
 ;; 4. SSR projection END-TO-END — a resource that reads a sensitive input but
@@ -173,7 +173,7 @@
     (let [k   (session-key "jake" 1)
           e   (entry :t/feed {:articles [:a :b]})
           proj (rf/with-frame frame-id
-                 (ssr/project-resources-runtime-db (runtime-db-with {k e})))
+                 (rf.resources.ssr/project-resources-runtime-db (runtime-db-with {k e})))
           [wk we] (only-wire proj)]
       (is (= {:articles [:a :b]} (:data we))
           "the non-classified entry's data rides verbatim (no inheritance)")
@@ -190,19 +190,19 @@
        :sensitive?    true
        :params-schema [:map [:page :int]]}
       (fn [_ _] {:request {:method :get :url "/secret"}}))
-    (let [k    (state/scoped-resource-key [:rf.scope/session {:username "jake"}] :t/secret-feed {:page 1})
+    (let [k    (rf.resources.state/scoped-resource-key [:rf.scope/session {:username "jake"}] :t/secret-feed {:page 1})
           e    (entry :t/secret-feed {:articles [:a :b]})
           rdb  (runtime-db-with {k e})
-          proj (rf/with-frame frame-id (ssr/project-resources-runtime-db rdb))
+          proj (rf/with-frame frame-id (rf.resources.ssr/project-resources-runtime-db rdb))
           m    (rf/with-frame frame-id
-                 (first (ssr/projection-metadata
+                 (first (rf.resources.ssr/projection-metadata
                           frame-id 5000
-                          (get-in rdb [state/resources-key :entries]))))
+                          (get-in rdb [rf.resources.state/resources-key :entries]))))
           wk   (:projected-key m)]
       (is (= :redacted (:disposition m))
           "the owner-:sensitive? entry is classified by its own coarse claim")
       (is (true? (:withheld? m)))
-      (is (empty? (get-in proj [state/resources-key :entries]))
+      (is (empty? (get-in proj [rf.resources.state/resources-key :entries]))
           (str "and its row does not ride at all: " (pr-str proj)))
       (is (= :t/secret-feed (nth wk 1)) "the resource-id rides at position 1")
       (is (contains? (nth wk 0) :rf/redacted) "the scope is tokenized in the key")

--- a/implementation/resources/test/re_frame/resources_from_db_scope_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_from_db_scope_cljs_test.cljc
@@ -30,25 +30,25 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting requires: register the resources + routing
    ;; events / subs and resources' late-bound :routing/* integration hooks.
    [re-frame.resources]
-   [re-frame.resources.events :as events]
-   [re-frame.resources.mutation-events :as mutation-events]
-   [re-frame.resources.mutation-runtime :as mstate]
-   [re-frame.resources.registry :as registry]
-   [re-frame.resources.route :as route]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.subs :as r-subs]
-   [re-frame.resources.scope-registry :as scope-registry]
+   [re-frame.resources.events :as rf.resources.events]
+   [re-frame.resources.mutation-events :as rf.resources.mutation-events]
+   [re-frame.resources.mutation-runtime :as rf.resources.mutation-runtime]
+   [re-frame.resources.registry :as rf.resources.registry]
+   [re-frame.resources.route :as rf.resources.route]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.subs :as rf.resources.subs]
+   [re-frame.resources.scope-registry :as rf.resources.scope-registry]
    [re-frame.resources.test-support]
-   [re-frame.routing :as routing]
+   [re-frame.routing :as rf.routing]
    [re-frame.schemas]
    [re-frame.http.managed]
-   [re-frame.registrar :as registrar]
-   [re-frame.trace.tooling :as trace-tooling]
-   [re-frame.test-support :as core-test-support]
+   [re-frame.registrar :as rf.registrar]
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   [re-frame.test-support :as rf.test-support]
    #?(:clj  [re-frame.substrate.plain-atom :as substrate]
       :cljs [re-frame.adapter.reagent :as substrate])))
 
@@ -63,11 +63,11 @@
   []
   (rf/make-frame {:id :rf/default :url-bound? true
                   :doc "from-db scope suite default app frame."})
-  (routing/reset-counters!)
-  (route/install-routing-integration!)
-  (registrar/clear-kind! :resource-scope)
-  (fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
-  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
+  (rf.routing/reset-counters!)
+  (rf.resources.route/install-routing-integration!)
+  (rf.registrar/clear-kind! :resource-scope)
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf.fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
   ;; the named db-derived viewer-session resolver (EP-0016 D3 canonical form)
   (rf/reg-resource-scope :t/session
     {:inputs {:username [:db [:auth :user :username]]}}
@@ -85,7 +85,7 @@
   (rf/reg-event :t/logout (fn [{:keys [db]} _] {:db (update db :auth dissoc :user)})))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     {:adapter substrate/adapter
      :init-fn init!}))
 
@@ -97,14 +97,14 @@
 ;; scoped-key vectors. Semantics unchanged.
 (defn- entries []
   (into {} (map (fn [[_k-id e]] [(:resource/key e) e]))
-        (get-in (runtime-db) (state/entries-path))))
-(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
+        (get-in (runtime-db) (rf.resources.state/entries-path))))
+(defn- entry [scoped-key] (get-in (runtime-db) (rf.resources.state/entry-path scoped-key)))
 (defn- slice [] (get-in (runtime-db) [:rf.runtime/routing :current]))
 
 (defn- session-key
   "The scoped feed key for username `u`, page `page`."
   [u page]
-  (state/scoped-resource-key [:rf.scope/session {:username u}] :t/feed {:page page}))
+  (rf.resources.state/scoped-resource-key [:rf.scope/session {:username u}] :t/feed {:page page}))
 
 (defn- settle-loaded!
   "Drive the just-ensured entry at `scoped-key` to :loaded by dispatching
@@ -143,7 +143,7 @@
     (rf/dispatch-sync [:rf.resource/ensure {:resource :t/notes :params {}
                                             :scope {:from-db :t/session}
                                             :owner [:app :n 1]}])
-    (is (some? (entry (state/scoped-resource-key
+    (is (some? (entry (rf.resources.state/scoped-resource-key
                         [:rf.scope/session {:username "abel"}] :t/notes {}))))))
 
 (deftest event-ensure-from-db-nil-fails-closed
@@ -155,7 +155,7 @@
     (let [spec (rf/resource-meta :t/feed)]
       (is (thrown-with-msg?
             #?(:clj Throwable :cljs js/Error) #"resource-scope-unresolved-reference"
-            (registry/resolve-scope-for-event
+            (rf.resources.registry/resolve-scope-for-event
               :t/feed spec {:db {}} 'test)))))
   (testing "dispatched through the event the failure is caught by the runtime
             error path — NO entry is created under any scope (fail-closed)"
@@ -231,7 +231,7 @@
     ;; no logged-in user — the {:from-db} spec policy resolves nil against `{}`
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-sub-unresolved-scope"
-          (r-subs/resolve-scoped-key {:resource :t/feed :params {:page 1}} {})))))
+          (rf.resources.subs/resolve-scoped-key {:resource :t/feed :params {:page 1}} {})))))
 
 ;; ===========================================================================
 ;; 4. rf2-616xa6 — mid-session input change RE-KEYS the live sub
@@ -279,12 +279,12 @@
   [body-fn]
   (let [seen (atom [])
         k    ::clear-scope-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev]
           (when (= :rf.warning/resource-clear-scope-unresolved (:operation ev))
             (swap! seen conj ev))))
     (try (body-fn)
-         (finally (trace-tooling/unregister-listener! k)))
+         (finally (rf.trace.tooling/unregister-listener! k)))
     @seen))
 
 (deftest clear-scope-from-db-resolves-and-clears-the-resolved-scope
@@ -342,9 +342,9 @@
   [body-fn]
   (let [seen (atom [])
         k    ::scope-resolved-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (= :rf.resource/scope-resolved (:operation ev)) (swap! seen conj ev))))
-    (try (body-fn) (finally (trace-tooling/unregister-listener! k)))
+    (try (body-fn) (finally (rf.trace.tooling/unregister-listener! k)))
     @seen))
 
 (deftest scope-resolved-trace-emitted-on-event-ensure-with-full-shape
@@ -427,7 +427,7 @@
     (let [rows (record-scope-resolved!
                  (fn []
                    (is (= (session-key "jake" 1)
-                          (r-subs/resolve-scoped-key {:resource :t/feed :params {:page 1}}
+                          (rf.resources.subs/resolve-scoped-key {:resource :t/feed :params {:page 1}}
                                                      {:auth {:user {:username "jake"}}})))))]
       (is (zero? (count (filter #(= :t/session (:resource-id (:tags %))) rows)))
           (str "expected no scope-resolved rows from sub resolution; got "
@@ -465,7 +465,7 @@
                 :whole-db?    false
                 :scope        [:rf.scope/session {:username "jake"}]
                 :resolved-nil? false}
-          proj (scope-registry/project-scope-resolved-egress tags)]
+          proj (rf.resources.scope-registry/project-scope-resolved-egress tags)]
       (is (= :rf/redacted (:input-values proj)) "raw db reads redacted")
       (is (= :rf/redacted (:scope proj)) "derived identity tuple redacted")
       (is (true? (:sensitive? proj)) "row stamped sensitive for the egress gate")
@@ -500,7 +500,7 @@
                 :input-values {:locale "en"}
                 :scope        [:rf.scope/locale {:locale "en"}]
                 :resolved-nil? false}
-          proj (scope-registry/project-scope-resolved-egress tags)]
+          proj (rf.resources.scope-registry/project-scope-resolved-egress tags)]
       (is (= :rf/redacted (:input-values proj)) "resolved input-values redacted")
       (is (= :rf/redacted (:scope proj)) "derived scope redacted")
       (is (:sensitive? proj) "the row is stamped sensitive")
@@ -572,7 +572,7 @@
   (settle-loaded! (session-key "jake" 1) {:for "jake"})
   ;; keep the owner ACTIVE (no release) so the match arms a refetch
   (testing "the active-owner refetch carries the resolved concrete scope"
-    (let [{:keys [fx]} (events/invalidate-tags-handler
+    (let [{:keys [fx]} (rf.resources.events/invalidate-tags-handler
                          {:rf.db/runtime (runtime-db) :rf.frame/id :rf/default
                           :db {:auth {:user {:username "jake"}}} :rf/time-ms 1}
                          [:rf.resource/invalidate-tags
@@ -597,7 +597,7 @@
             handler throw as :rf.error/handler-exception)"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-scope-unresolved-reference"
-          (events/invalidate-tags-handler
+          (rf.resources.events/invalidate-tags-handler
             {:rf.db/runtime {} :rf.frame/id :rf/default :db {} :rf/time-ms 1}
             [:rf.resource/invalidate-tags
              {:scope {:from-db :t/session} :tags #{[:feed]}}]))))
@@ -606,7 +606,7 @@
     (let [rows (record-scope-resolved!
                  (fn []
                    (try
-                     (events/invalidate-tags-handler
+                     (rf.resources.events/invalidate-tags-handler
                        {:rf.db/runtime {} :rf.frame/id :rf/default :db {} :rf/time-ms 1}
                        [:rf.resource/invalidate-tags
                         {:scope {:from-db :t/session} :tags #{[:feed]}}])
@@ -634,7 +634,7 @@
             :rf.error/resource-scope-not-registered before any mutation"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-scope-not-registered"
-          (events/invalidate-tags-handler
+          (rf.resources.events/invalidate-tags-handler
             {:rf.db/runtime {} :rf.frame/id :rf/default
              :db {:auth {:user {:username "jake"}}} :rf/time-ms 1}
             [:rf.resource/invalidate-tags
@@ -656,7 +656,7 @@
 (defn- minstance
   "The durable mutation instance row for `instance-id` (byte-key addressed)."
   [instance-id]
-  (get-in (runtime-db) (mstate/instance-path instance-id)))
+  (get-in (runtime-db) (rf.resources.mutation-runtime/instance-path instance-id)))
 
 (defn- reg-save-mutation!
   "Register the `:t/save` test mutation with `extra` merged into its metadata
@@ -706,7 +706,7 @@
      :params-schema [:map]
      :tags          (fn [_p _v] #{[:gfact]})}
     (fn [_p _ctx] {:request {:method :get :url "/gnotes"}}))
-  (let [gkey (state/scoped-resource-key :rf.scope/global :t/gnotes {})]
+  (let [gkey (rf.resources.state/scoped-resource-key :rf.scope/global :t/gnotes {})]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :t/gnotes :params {}
                                             :owner [:app :g 1]}])
     (settle-loaded! gkey {:g 1})
@@ -736,7 +736,7 @@
             error path)"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-scope-unresolved-reference"
-          (mutation-events/execute-handler
+          (rf.resources.mutation-events/execute-handler
             {:rf.db/runtime {} :rf.frame/id :rf/default :db {} :rf/time-ms 1
              :rf.resource/generation-allocation {:generation 1 :counter 1}}
             [:rf.mutation/execute {:mutation :t/save :params {}
@@ -747,7 +747,7 @@
     (let [rows (record-scope-resolved!
                  (fn []
                    (try
-                     (mutation-events/execute-handler
+                     (rf.resources.mutation-events/execute-handler
                        {:rf.db/runtime {} :rf.frame/id :rf/default :db {}
                         :rf/time-ms 1
                         :rf.resource/generation-allocation {:generation 1 :counter 1}}
@@ -775,7 +775,7 @@
             :rf.error/resource-scope-not-registered before any mutation start"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-scope-not-registered"
-          (mutation-events/execute-handler
+          (rf.resources.mutation-events/execute-handler
             {:rf.db/runtime {} :rf.frame/id :rf/default
              :db {:auth {:user {:username "jake"}}} :rf/time-ms 1
              :rf.resource/generation-allocation {:generation 1 :counter 1}}

--- a/implementation/resources/test/re_frame/resources_http_completed_at_clock_cljs_test.cljs
+++ b/implementation/resources/test/re_frame/resources_http_completed_at_clock_cljs_test.cljs
@@ -26,9 +26,9 @@
   `entry-stale?` returns true the instant the load completes."
   (:require
    [cljs.test :refer-macros [deftest is testing async]]
-   [re-frame.adapter.reagent :as reagent-adapter]
+   [re-frame.adapter.reagent :as rf.adapter.reagent]
    [re-frame.core :as rf]
-   [re-frame.frame :as frame]
+   [re-frame.frame :as rf.frame]
    ;; production HTTP transport: registers the REAL `:rf.http/managed` fx
    ;; (we deliberately do NOT override it — the genuine `reply-ctx` clock
    ;; read is the unit under test).
@@ -36,9 +36,9 @@
    ;; load-bearing side-effecting require: registers the :rf.resource/*
    ;; events + subs the ensure below drives.
    [re-frame.resources]
-   [re-frame.resources.state :as state]
+   [re-frame.resources.state :as rf.resources.state]
    [re-frame.schemas]
-   [re-frame.test-support :as test-support]))
+   [re-frame.test-support :as rf.test-support]))
 
 (def ^:private stale-after-ms 60000)
 
@@ -73,18 +73,18 @@
             on CLJS), so :stale-at was ~perf-clock + window — far below
             `js/Date.now()` — and the entry read STALE the instant it loaded."
     (async done
-      (rf/init! reagent-adapter/adapter)
+      (rf/init! rf.adapter.reagent/adapter)
       ;; EP-0002 (rf2-nn0jqa): `init!` does not synthesise a `:rf/default`
       ;; frame, and the managed-HTTP fxs require a carried frame stamp. Register
       ;; `:rf/default` explicitly; the dispatch below carries `{:frame
       ;; :rf/default}` so the sync dispatch AND the async reply continuation
       ;; both target it.
-      (frame/ensure-default-frame!)
-      (let [scoped-key (state/scoped-resource-key
+      (rf.frame/ensure-default-frame!)
+      (let [scoped-key (rf.resources.state/scoped-resource-key
                          :rf.scope/global :clk/article {:slug "w"})
             orig       (.-fetch js/globalThis)
             entry      #(get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
-                                (state/entry-path scoped-key))]
+                                (rf.resources.state/entry-path scoped-key))]
         (rf/reg-resource :clk/article (article-spec) article-spec-request)
         (set! (.-fetch js/globalThis)
               (fn [_url _init] (js/Promise.resolve (json-200 "{\"title\":\"Welcome\"}"))))
@@ -94,7 +94,7 @@
                           {:frame :rf/default})
         (is (= :loading (:status (entry)))
             "the ensure lowered to the real transport and is in flight")
-        (-> (test-support/poll-until
+        (-> (rf.test-support/poll-until
               #(= :loaded (:status (entry)))
               {:timeout-ms 2000 :label "rf2-2elcw3 live load settles :loaded"})
             (.then
@@ -109,7 +109,7 @@
                   ;; against `js/Date.now` (the freshness readers' clock).
                   ;; A just-loaded entry MUST NOT be stale. A perf-clock
                   ;; :stale-at (≪ js/Date.now()) would wrongly read as stale.
-                  (is (false? (state/entry-stale? e now-epoch))
+                  (is (false? (rf.resources.state/entry-stale? e now-epoch))
                       "a just-loaded resource is NOT stale against js/Date.now")
                   ;; :loaded-at must be a wall-clock epoch value (within a
                   ;; few seconds of `js/Date.now()`), not a small perf-clock

--- a/implementation/resources/test/re_frame/resources_infinite_initial_page_param_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_initial_page_param_cljs_test.cljc
@@ -3,7 +3,7 @@
   (EP-0021 R8, Spec 016 §Causal event — load-more — the page-0 cursor, the
   TanStack `initialPageParam` analogue).
 
-  The pure boundary (`state/page-param-for-spec`) is already pinned in
+  The pure boundary (`rf.resources.state/page-param-for-spec`) is already pinned in
   `resources_infinite_state_cljs_test` (`page-0-param-default`). This slice
   closes the RUNTIME gap: that a non-nil `:initial-page-param` actually RIDES
   into the page-0 request and is recorded as page-0's `:page-params` entry. A
@@ -12,7 +12,7 @@
   uses the framework `nil` default.
 
   In `ensure-load` (events.cljc) the page-0 param is
-  `(state/page-param-for-spec spec)` and the reserved request ctx is
+  `(rf.resources.state/page-param-for-spec spec)` and the reserved request ctx is
   `(page-request-ctx page-param 0)`, which the resource's `:request` fn reads
   via `{:rf.resource/keys [page-param page-index]}`. The capturing transport
   below REPLAYS the live managed-HTTP reply shape (Spec 014 §Reply addressing)
@@ -21,17 +21,17 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    [re-frame.resources]
-   [re-frame.resources.state :as state]
+   [re-frame.resources.state :as rf.resources.state]
    [re-frame.resources.test-support]
    ;; production HTTP fx surface (so the transport feature probe resolves);
    ;; the fetch itself is overridden by the capturing reply stub below.
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport that REPLAYS the real reply-append shape ----------
 
@@ -40,13 +40,13 @@
 (defn- capturing-transport-fixture
   [f]
   (reset! last-managed-args nil)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
   capturing-transport-fixture)
 
 ;; ---- helpers --------------------------------------------------------------
@@ -54,7 +54,7 @@
 (defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
 
 (defn- entry [scoped-key]
-  (get-in (runtime-db) (state/entry-path scoped-key)))
+  (get-in (runtime-db) (rf.resources.state/entry-path scoped-key)))
 
 (defn- reply-success!
   "Dispatch the captured `:on-success` reply with the transport's success
@@ -87,7 +87,7 @@
                          page-param (assoc :cursor page-param))}}))
 
 (defn- feed-key [resource]
-  (state/scoped-resource-key :rf.scope/global resource {:filter :recent}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global resource {:filter :recent}))
 
 (defn- ensure! [resource]
   (rf/dispatch-sync [:rf.resource/ensure

--- a/implementation/resources/test/re_frame/resources_infinite_load_more_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_load_more_cljs_test.cljc
@@ -33,19 +33,19 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    [re-frame.resources]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.work-ledger :as rf.resources.work-ledger]
    [re-frame.resources.test-support]
    ;; production HTTP fx surface (so the transport feature probe resolves);
    ;; the fetch itself is overridden by the capturing reply stub below.
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   [re-frame.trace.tooling :as trace-tooling]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport that REPLAYS the real reply-append shape ----------
 
@@ -61,14 +61,14 @@
   [f]
   (reset! last-managed-args nil)
   (reset! scheduled-timers [])
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
-  (fx/reg-fx :rf.resource/schedule-timers (fn [_ctx args] (swap! scheduled-timers conj args) nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.resource/schedule-timers (fn [_ctx args] (swap! scheduled-timers conj args) nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
   capturing-transport-fixture)
 
 ;; ---- helpers --------------------------------------------------------------
@@ -80,7 +80,7 @@
 (defn- entry
   ([scoped-key] (entry :rf/default scoped-key))
   ([frame-id scoped-key]
-   (get-in (runtime-db frame-id) (state/entry-path scoped-key))))
+   (get-in (runtime-db frame-id) (rf.resources.state/entry-path scoped-key))))
 
 (defn- reply-success!
   "Dispatch the captured `:on-success` reply with the transport's success
@@ -138,7 +138,7 @@
                          page-param (assoc :cursor page-param))}}))
 
 (defn- feed-key [resource]
-  (state/scoped-resource-key :rf.scope/global resource {:filter :recent}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global resource {:filter :recent}))
 
 (defn- ensure! [resource]
   (rf/dispatch-sync [:rf.resource/ensure
@@ -183,7 +183,7 @@
     (rf/reg-resource :inf1/feed (feed-spec) feed-spec-request)
     (ensure! :inf1/feed)
     (let [e (entry (feed-key :inf1/feed))]
-      (is (state/infinite-entry? e) "seeded an infinite entry (R1)")
+      (is (rf.resources.state/infinite-entry? e) "seeded an infinite entry (R1)")
       (is (= :loading (:status e)) "first load (no data) is :loading")
       (is (= [] (:data e)) "page vector still empty (page-0 in flight)"))
     (testing "the request received the page-0 ctx {:page-param nil :page-index 0}"
@@ -202,7 +202,7 @@
       (is (= [(page [:a :b] "c1")] (:data e)) "page-0 accumulated")
       (is (= [nil] (:page-params e)) "page-0 param is nil")
       (is (= "c1" (:next-page-param e)) "cursor advanced from the page")
-      (is (= 1 (state/page-count e))))))
+      (is (= 1 (rf.resources.state/page-count e))))))
 
 ;; ===========================================================================
 ;; 2. load-more appends + advances the cursor (the headline behaviour)
@@ -215,7 +215,7 @@
       (load-more! :lm/feed)
       (let [e (entry k)]
         (is (= :fetching (:status e)) "feed has data → refresh-class :fetching")
-        (is (= 1 (state/page-count e)) "page vector unchanged while in flight (pages stay visible)"))
+        (is (= 1 (rf.resources.state/page-count e)) "page vector unchanged while in flight (pages stay visible)"))
       (testing "the load-more request carried the derived next param + index 1"
         (let [req-params (get-in @last-managed-args [:request :params])]
           (is (= 1 (:page-index req-params)))
@@ -226,7 +226,7 @@
         (is (= [(page [:a] "c1") (page [:b] "c2")] (:data e)) "appended in order")
         (is (= [nil "c1"] (:page-params e)) "param per page, page-0 = nil")
         (is (= "c2" (:next-page-param e)) "cursor advanced to page-1's next")
-        (is (= 2 (state/page-count e)))))))
+        (is (= 2 (rf.resources.state/page-count e)))))))
 
 (deftest load-more-multiple-pages-accumulate
   (testing "successive load-more accumulate the feed in order"
@@ -234,7 +234,7 @@
       (load-more! :lm3/feed) (reply-success! (page [:b] "c2"))
       (load-more! :lm3/feed) (reply-success! (page [:c] "c3"))
       (let [e (entry k)]
-        (is (= 3 (state/page-count e)))
+        (is (= 3 (rf.resources.state/page-count e)))
         (is (= [(page [:a] "c1") (page [:b] "c2") (page [:c] "c3")] (:data e)))
         (is (= [nil "c1" "c2"] (:page-params e)))
         (is (= "c3" (:next-page-param e)))))))
@@ -260,7 +260,7 @@
       (is (nil? @last-managed-args) "no request issued on a terminal load-more")
       (let [e (entry k)]
         (is (= :loaded (:status e)) "feed unchanged (still :loaded)")
-        (is (= 1 (state/page-count e)) "no page appended")
+        (is (= 1 (rf.resources.state/page-count e)) "no page appended")
         (is (nil? (:current-work e)) "no work record created")))))
 
 (deftest load-more-no-feed-is-noop
@@ -295,7 +295,7 @@
         ;; the single in-flight page settles ONCE → exactly one append
         (reply-success! args1 (page [:b] "c2"))
         (let [e3 (entry k)]
-          (is (= 2 (state/page-count e3)) "exactly one page appended despite two load-mores")
+          (is (= 2 (rf.resources.state/page-count e3)) "exactly one page appended despite two load-mores")
           (is (= [(page [:a] "c1") (page [:b] "c2")] (:data e3))))))))
 
 ;; ===========================================================================
@@ -324,7 +324,7 @@
                 "the stale page was NOT appended")
             (is (= gen2 (:generation e)) "entry generation unchanged by the stale reply"))
           (testing "the suppressed work row settles terminal :suppressed"
-            (let [rec (work-ledger/get-record (runtime-db) wid1)]
+            (let [rec (rf.resources.work-ledger/get-record (runtime-db) wid1)]
               (is (= :suppressed (:status rec))))))))))
 
 ;; ===========================================================================
@@ -340,7 +340,7 @@
       (reply-failure! envelope)
       (let [e (entry k)]
         (is (= :loaded (:status e)) "feed returns to :loaded (NOT :error)")
-        (is (= 1 (state/page-count e)) "accumulated pages kept")
+        (is (= 1 (rf.resources.state/page-count e)) "accumulated pages kept")
         (is (= [(page [:a] "c1")] (:data e)) "page vector untouched")
         (is (= "c1" (:next-page-param e)) "cursor untouched — retry is possible")
         (is (= envelope (:page-error e)) ":page-error recorded (third channel)")
@@ -359,7 +359,7 @@
       (reply-success! (page [:b] "c2"))
       (let [e (entry k)]
         (is (nil? (:page-error e)) "the next success cleared the page-error")
-        (is (= 2 (state/page-count e)) "the retried page appended")))))
+        (is (= 2 (rf.resources.state/page-count e)) "the retried page appended")))))
 
 ;; ===========================================================================
 ;; 6b. per-page VALIDATION rides the request :decode (rf2-x76af2.12) — the
@@ -432,7 +432,7 @@
             "no usable pages — the first-load :error clears :data (mirrors the scalar path)")
         (is (nil? (:current-work e)) "no in-flight work after the settle")
         (is (nil? (:page-error e)) "NOT the load-more :page-error channel"))
-      (is (= :failed (:status (work-ledger/get-record (runtime-db) wid)))
+      (is (= :failed (:status (rf.resources.work-ledger/get-record (runtime-db) wid)))
           "the work row settles terminal :failed"))))
 
 (deftest load-more-decode-failure-keeps-pages-records-page-error
@@ -443,13 +443,13 @@
     (ensure! :decn/feed)
     (reply-success! (page [:a] "c1"))          ;; page 0 validates + appends
     (let [k (feed-key :decn/feed)]
-      (is (= 1 (state/page-count (entry k))) "page 0 accumulated")
+      (is (= 1 (rf.resources.state/page-count (entry k))) "page 0 accumulated")
       (load-more! :decn/feed)
       (let [wid (:current-work (entry k))]
         (reply-failure! (decode-failure "{\"items\":[1]}"))
         (let [e (entry k)]
           (is (= :loaded (:status e)) "feed returns to :loaded (NOT :error)")
-          (is (= 1 (state/page-count e)) "the prior page is preserved")
+          (is (= 1 (rf.resources.state/page-count e)) "the prior page is preserved")
           (is (= [(page [:a] "c1")] (:data e)) "page vector untouched")
           (is (= "c1" (:next-page-param e)) "cursor untouched — retry is possible")
           (is (= :rf.http/decode-failure (:kind (:page-error e)))
@@ -459,7 +459,7 @@
           (is (nil? (:error e)) "NOT the first-load :error channel")
           (is (nil? (:refresh-error e)) "NOT the refresh :refresh-error channel")
           (is (nil? (:current-work e)) ":current-work cleared"))
-        (is (= :failed (:status (work-ledger/get-record (runtime-db) wid)))
+        (is (= :failed (:status (rf.resources.work-ledger/get-record (runtime-db) wid)))
             "the work row settles terminal :failed")))))
 
 ;; ===========================================================================
@@ -479,13 +479,13 @@
             the accumulated pages visible (does NOT collapse to page 0) and
             replaces page-0 in place on success"
     (let [k (accumulate-3! :rw/feed {})]
-      (is (= 3 (state/page-count (entry k))) "3 pages accumulated")
+      (is (= 3 (rf.resources.state/page-count (entry k))) "3 pages accumulated")
       (rf/dispatch-sync [:rf.resource/refetch
                          {:resource :rw/feed :scope :rf.scope/global
                           :params {:filter :recent} :cause [:test :refresh]}])
       (let [e (entry k)]
         (is (= :fetching (:status e)) "refetch is refresh-class (data kept)")
-        (is (= 3 (state/page-count e)) "WINDOW PRESERVED — feed NOT collapsed to page 0"))
+        (is (= 3 (rf.resources.state/page-count e)) "WINDOW PRESERVED — feed NOT collapsed to page 0"))
       (testing "the replacement fetches page-0 (index 0, nil cursor)"
         (let [req-params (get-in @last-managed-args [:request :params])]
           (is (= 0 (:page-index req-params)))
@@ -493,7 +493,7 @@
       (reply-success! (page [:a*] "c1"))
       (let [e (entry k)]
         (is (= :loaded (:status e)))
-        (is (= 3 (state/page-count e)) "still 3 pages after the replacement succeeds")
+        (is (= 3 (rf.resources.state/page-count e)) "still 3 pages after the replacement succeeds")
         (is (= (page [:a*] "c1") (nth (:data e) 0)) "page-0 replaced in place")
         (is (= (page [:b] "c2") (nth (:data e) 1)) "tail preserved")
         (is (= (page [:c] "c3") (nth (:data e) 2)) "tail preserved")))))
@@ -509,13 +509,13 @@
                          {:resource :ra/feed :scope :rf.scope/global
                           :params {:filter :recent} :cause [:test :refresh-all]}])
       (testing "the issue-time fetch is page 0; the feed is NOT truncated"
-        (is (= 3 (state/page-count (entry k))) "WINDOW PRESERVED — feed not collapsed")
+        (is (= 3 (rf.resources.state/page-count (entry k))) "WINDOW PRESERVED — feed not collapsed")
         (is (= 0 (:rf.resource/page-index (second (:on-success @last-managed-args))))
             "the first fetch is page 0 (index 0)"))
       ;; page-0 reply replaces in place, then CHAINS the page-1 leg.
       (reply-success! (page [:a*] "c1"))
       (let [e (entry k)]
-        (is (= 3 (state/page-count e)) "still 3 pages after page-0 replacement")
+        (is (= 3 (rf.resources.state/page-count e)) "still 3 pages after page-0 replacement")
         (is (= (page [:a*] "c1") (nth (:data e) 0)) "page-0 replaced in place"))
       (testing "the sweep CHAINED a page-1 fetch (the next leg, in sequence)"
         (is (= 1 (:rf.resource/page-index (second (:on-success @last-managed-args))))
@@ -525,7 +525,7 @@
       ;; page-1 reply replaces in place, then chains page-2.
       (reply-success! (page [:b*] "c2"))
       (let [e (entry k)]
-        (is (= 3 (state/page-count e)))
+        (is (= 3 (rf.resources.state/page-count e)))
         (is (= (page [:b*] "c2") (nth (:data e) 1)) "page-1 replaced in place"))
       (testing "the sweep CHAINED a page-2 fetch (the final leg)"
         (is (= 2 (:rf.resource/page-index (second (:on-success @last-managed-args))))
@@ -533,7 +533,7 @@
       ;; page-2 reply replaces in place — the sweep is now exhausted.
       (reply-success! (page [:c*] "c3"))
       (let [e (entry k)]
-        (is (= 3 (state/page-count e)) "all 3 pages refreshed; length preserved")
+        (is (= 3 (rf.resources.state/page-count e)) "all 3 pages refreshed; length preserved")
         (is (= [(page [:a*] "c1") (page [:b*] "c2") (page [:c*] "c3")] (:data e))
             "every page replaced in place, in order")
         (is (not (contains? e :refetch-sweep)) "the sweep cursor is cleared when exhausted")
@@ -547,14 +547,14 @@
       (rf/dispatch-sync [:rf.resource/refetch
                          {:resource :rwn/feed :scope :rf.scope/global
                           :params {:filter :recent} :cause [:test :window]}])
-      (is (= 3 (state/page-count (entry k))) "feed NOT truncated — full window preserved")
+      (is (= 3 (rf.resources.state/page-count (entry k))) "feed NOT truncated — full window preserved")
       (is (= 0 (:rf.resource/page-index (second (:on-success @last-managed-args)))) "page 0 first")
       (reply-success! (page [:a*] "c1"))
       (testing "the sweep chained the page-1 leg (the bounded window)"
         (is (= 1 (:rf.resource/page-index (second (:on-success @last-managed-args)))) "then page 1"))
       (reply-success! (page [:b*] "c2"))
       (let [e (entry k)]
-        (is (= 3 (state/page-count e)) "feed length preserved (page 2 kept untouched)")
+        (is (= 3 (rf.resources.state/page-count e)) "feed length preserved (page 2 kept untouched)")
         (is (= (page [:a*] "c1") (nth (:data e) 0)) "page 0 refreshed")
         (is (= (page [:b*] "c2") (nth (:data e) 1)) "page 1 refreshed")
         (is (= (page [:c] "c3") (nth (:data e) 2)) "page 2 left UNTOUCHED (outside the window)")
@@ -573,7 +573,7 @@
       (reply-failure! {:kind :rf.http/server :status 503})
       (let [e (entry k)]
         (is (= :loaded (:status e)) "feed stays :loaded (pages kept)")
-        (is (= 3 (state/page-count e)) "all pages preserved")
+        (is (= 3 (rf.resources.state/page-count e)) "all pages preserved")
         (is (some? (:page-error e)) ":page-error recorded for the failed sweep leg")
         (is (not (contains? e :refetch-sweep)) "the sweep cursor is cleared — chain stopped")))))
 
@@ -590,7 +590,7 @@
       (ensure! :fs/feed)
       (is (nil? @last-managed-args) "fresh loaded feed served from cache, no refetch")
       (is (= gen0 (:generation (entry k))) "no new generation")
-      (is (= 1 (state/page-count (entry k))) "feed untouched"))))
+      (is (= 1 (rf.resources.state/page-count (entry k))) "feed untouched"))))
 
 ;; ===========================================================================
 ;; 8b. rf2-s54uzc — page-0 abort/failure uses FIRST-LOAD cleanup, not the
@@ -624,7 +624,7 @@
         (is (= [] (:data e)) "no pages accumulated")
         (is (nil? (:current-work e)) "no in-flight work after the abort settle")
         (is (nil? (:error e)) "an abort is not an :error settle"))
-      (is (= :cancelled (:status (work-ledger/get-record (runtime-db) wid)))
+      (is (= :cancelled (:status (rf.resources.work-ledger/get-record (runtime-db) wid)))
           "the work row settles terminal :cancelled"))))
 
 (deftest page-0-abort-does-not-fresh-skip-future-ensure
@@ -700,7 +700,7 @@
       (reply-aborted!)
       (let [e (entry k)]
         (is (= :loaded (:status e)) "load-more abort keeps :loaded")
-        (is (= 1 (state/page-count e)) "page-0 kept")
+        (is (= 1 (rf.resources.state/page-count e)) "page-0 kept")
         (is (nil? (:page-error e)) "an abort is not a page-error"))
       (is (empty? (filter #(= k (:resource/key %)) @scheduled-timers))
           "no timer re-armed by the load-more abort (already armed on the
@@ -740,14 +740,14 @@
   [body-fn]
   (let [seen (atom [])
         k    ::resource-trace-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev]
           (when (and (keyword? (:operation ev))
                      (contains? #{"rf.resource" "rf.warning"}
                                 (namespace (:operation ev))))
             (swap! seen conj ev))))
     (try (body-fn)
-         (finally (trace-tooling/unregister-listener! k)))
+         (finally (rf.trace.tooling/unregister-listener! k)))
     @seen))
 
 (defn- owner-ignored-warnings
@@ -759,13 +759,13 @@
 (defn- owner-index-keys
   "The set of OWNERS currently in the derived :owner-index."
   []
-  (-> (runtime-db) (get-in (state/owner-index-path)) keys set))
+  (-> (runtime-db) (get-in (rf.resources.state/owner-index-path)) keys set))
 
 (defn- owners-for-key
   "Owners in the :owner-index whose set contains this feed's key-id."
   [scoped-key]
-  (let [kid (state/key-id scoped-key)]
-    (->> (get-in (runtime-db) (state/owner-index-path))
+  (let [kid (rf.resources.state/key-id scoped-key)]
+    (->> (get-in (runtime-db) (rf.resources.state/owner-index-path))
          (filter (fn [[_owner key-ids]] (contains? key-ids kid)))
          (map key)
          set)))
@@ -802,7 +802,7 @@
       (let [e (entry k)]
         (testing "the page APPENDED despite the ignored owner (warn-and-PROCEED)"
           (is (= :loaded (:status e)))
-          (is (= 2 (state/page-count e)) "exactly the load-more page appended")
+          (is (= 2 (rf.resources.state/page-count e)) "exactly the load-more page appended")
           (is (= [(page [:a] "c1") (page [:b] "c2")] (:data e)) "appended in order")
           (is (= "c2" (:next-page-param e)) "cursor advanced from the appended page"))))))
 
@@ -836,7 +836,7 @@
             ":owner-index lists only the original owner against this feed's key"))
       (testing "the work record carries NO owner (the in-flight page is ownerless)"
         (let [e' (entry k)
-              rec (work-ledger/get-record (runtime-db) (:current-work e'))]
+              rec (rf.resources.work-ledger/get-record (runtime-db) (:current-work e'))]
           (is (some? rec) "a work record exists for the in-flight load-more page")
           (is (empty? (:owners rec))
               "the work record's :owners is empty — the ignored owner never joined it")))
@@ -844,7 +844,7 @@
         (reply-success! (page [:b] "c2"))
         (let [e' (entry k)]
           (is (= :loaded (:status e')) "feed settled :loaded")
-          (is (= 2 (state/page-count e')) "the page still appended (warn-and-PROCEED)")
+          (is (= 2 (rf.resources.state/page-count e')) "the page still appended (warn-and-PROCEED)")
           (is (= #{[:test :w]} (:active-owners e'))
               "still exactly one owner after settle — no durable leak to release"))))))
 
@@ -855,7 +855,7 @@
     (let [k (load-page-0! :mc/feed (page [:a] "c1"))]
       (record-resource-traces!
         #(load-more-with-owner! :mc/feed [:wrong :owner]))
-      (let [rec (work-ledger/get-record (runtime-db) (:current-work (entry k)))]
+      (let [rec (rf.resources.work-ledger/get-record (runtime-db) (:current-work (entry k)))]
         (is (= [[:user :feed/load-more]] (:causes rec))
             "the load-more's :cause is recorded on the work record (owner dropped, cause kept)")))))
 
@@ -873,6 +873,6 @@
           "no :rf.warning/resource-load-more-owner-ignored for an ownerless load-more")
       (reply-success! (page [:b] "c2"))
       (let [e (entry k)]
-        (is (= 2 (state/page-count e)) "the ownerless load-more appended normally")
+        (is (= 2 (rf.resources.state/page-count e)) "the ownerless load-more appended normally")
         (is (= #{[:test :w]} (:active-owners e))
             "still exactly the route/ensure owner — load-more added no owner")))))

--- a/implementation/resources/test/re_frame/resources_infinite_registration_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_registration_cljs_test.cljc
@@ -16,8 +16,8 @@
   merged-list SUBS (wave 4) are out of scope here."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
-            [re-frame.registrar :as registrar]
-            [re-frame.resources.registry :as registry]))
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.resources.registry :as rf.resources.registry]))
 
 (defn- base-infinite-spec
   "A minimal VALID `:infinite` resource METADATA map — the ordinary REQUIRED
@@ -39,20 +39,20 @@
                :params (cond-> {} page-param (assoc :cursor page-param))}}))
 
 (use-fixtures :each
-  {:before (fn [] (registrar/clear-kind! :resource))
-   :after  (fn [] (registrar/clear-kind! :resource))})
+  {:before (fn [] (rf.registrar/clear-kind! :resource))
+   :after  (fn [] (rf.registrar/clear-kind! :resource))})
 
 (deftest valid-infinite-spec-registers
   (testing "a well-formed :infinite spec registers + reads back"
-    (is (= :feed/timeline (registry/reg-resource :feed/timeline (base-infinite-spec) base-infinite-request)))
-    (let [meta (registry/resource-meta :feed/timeline)]
+    (is (= :feed/timeline (rf.resources.registry/reg-resource :feed/timeline (base-infinite-spec) base-infinite-request)))
+    (let [meta (rf.resources.registry/resource-meta :feed/timeline)]
       (is (true? (:infinite meta)))
       (is (fn? (:next-page-param meta))))))
 
 (deftest valid-infinite-spec-with-all-optionals-registers
   (testing "the full optional infinite slice (R3/R6/R7) registers"
     (is (= :feed/full
-           (registry/reg-resource
+           (rf.resources.registry/reg-resource
              :feed/full
              (assoc (base-infinite-spec)
                     :prev-page-param   (fn [first-page _all] (get-in first-page [:page-info :prev-cursor]))
@@ -64,18 +64,18 @@
   (testing ":infinite true with NO :next-page-param => infinite-missing-next-page-param (R8 gate)"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"infinite-missing-next-page-param"
-          (registry/reg-resource :feed/no-next
+          (rf.resources.registry/reg-resource :feed/no-next
                                  (dissoc (base-infinite-spec) :next-page-param) base-infinite-request))))
   (testing ":next-page-param present but NOT a fn => same gate"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"infinite-missing-next-page-param"
-          (registry/reg-resource :feed/bad-next
+          (rf.resources.registry/reg-resource :feed/bad-next
                                  (assoc (base-infinite-spec) :next-page-param :not-a-fn) base-infinite-request)))))
 
 (deftest non-infinite-resource-untouched
   (testing "an ordinary (non-:infinite) resource needs no :next-page-param"
     (is (= :res/plain
-           (registry/reg-resource
+           (rf.resources.registry/reg-resource
              :res/plain
              {:scope :rf.scope/global
               :params-schema [:map [:slug :string]]}
@@ -84,7 +84,7 @@
     ;; The :infinite slice is GATED on :infinite true; a stray :next-page-param
     ;; on a non-infinite resource is not validated as the infinite slice.
     (is (= :res/plain2
-           (registry/reg-resource
+           (rf.resources.registry/reg-resource
              :res/plain2
              {:scope :rf.scope/global
               :params-schema [:map]
@@ -95,71 +95,71 @@
   (testing ":infinite false is a meaningless typo => resource-bad-spec"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-bad-spec"
-          (registry/reg-resource :feed/false-flag
+          (rf.resources.registry/reg-resource :feed/false-flag
                                  (assoc (base-infinite-spec) :infinite false) base-infinite-request))))
   (testing ":infinite \"true\" (string) is not the literal selector => resource-bad-spec"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-bad-spec"
-          (registry/reg-resource :feed/string-flag
+          (rf.resources.registry/reg-resource :feed/string-flag
                                  (assoc (base-infinite-spec) :infinite "true") base-infinite-request)))))
 
 (deftest prev-page-param-shape-validated
   (testing "a non-fn :prev-page-param => resource-bad-spec"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-bad-spec"
-          (registry/reg-resource :feed/bad-prev
+          (rf.resources.registry/reg-resource :feed/bad-prev
                                  (assoc (base-infinite-spec) :prev-page-param :not-a-fn) base-infinite-request))))
   (testing "a fn :prev-page-param is accepted"
     (is (= :feed/good-prev
-           (registry/reg-resource :feed/good-prev
+           (rf.resources.registry/reg-resource :feed/good-prev
                                   (assoc (base-infinite-spec)
                                          :prev-page-param (fn [_first _all] nil)) base-infinite-request)))))
 
 (deftest page-accessor-shape-validated
   (testing "a keyword :page->items is accepted"
     (is (= :feed/kw-acc
-           (registry/reg-resource :feed/kw-acc
+           (rf.resources.registry/reg-resource :feed/kw-acc
                                   (assoc (base-infinite-spec) :page->items :items) base-infinite-request))))
   (testing "a fn :page->items is accepted"
     (is (= :feed/fn-acc
-           (registry/reg-resource :feed/fn-acc
+           (rf.resources.registry/reg-resource :feed/fn-acc
                                   (assoc (base-infinite-spec) :page->items (fn [p] (:items p))) base-infinite-request))))
   (testing "a :page->items that is neither keyword nor fn => resource-bad-spec"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-bad-spec"
-          (registry/reg-resource :feed/bad-acc
+          (rf.resources.registry/reg-resource :feed/bad-acc
                                  (assoc (base-infinite-spec) :page->items 99) base-infinite-request)))))
 
 (deftest refetch-policy-shape-validated
   (testing "a well-formed :refetch policy registers"
     (is (= :feed/rf-ok
-           (registry/reg-resource :feed/rf-ok
+           (rf.resources.registry/reg-resource :feed/rf-ok
                                   (assoc (base-infinite-spec)
                                          :refetch {:refetch-all-pages? true :refetch-window 5}) base-infinite-request)))
     (is (= :feed/rf-empty
-           (registry/reg-resource :feed/rf-empty
+           (rf.resources.registry/reg-resource :feed/rf-empty
                                   (assoc (base-infinite-spec) :refetch {}) base-infinite-request))))
   (testing "a non-map :refetch => resource-bad-spec"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-bad-spec"
-          (registry/reg-resource :feed/rf-nonmap
+          (rf.resources.registry/reg-resource :feed/rf-nonmap
                                  (assoc (base-infinite-spec) :refetch true) base-infinite-request))))
   (testing "a non-boolean :refetch-all-pages? => resource-bad-spec"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-bad-spec"
-          (registry/reg-resource :feed/rf-badbool
+          (rf.resources.registry/reg-resource :feed/rf-badbool
                                  (assoc (base-infinite-spec) :refetch {:refetch-all-pages? :yes}) base-infinite-request))))
   (testing "a non-integer :refetch-window => resource-bad-spec"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-bad-spec"
-          (registry/reg-resource :feed/rf-badwin
+          (rf.resources.registry/reg-resource :feed/rf-badwin
                                  (assoc (base-infinite-spec) :refetch {:refetch-window 1.5}) base-infinite-request)))))
 
 (deftest infinite-resource-predicate
   (testing "infinite-resource? recognises the :infinite true marker"
-    (is (true? (registry/infinite-resource? (base-infinite-spec))))
-    (is (false? (registry/infinite-resource? {:infinite false})))
-    (is (false? (registry/infinite-resource? {})))))
+    (is (true? (rf.resources.registry/infinite-resource? (base-infinite-spec))))
+    (is (false? (rf.resources.registry/infinite-resource? {:infinite false})))
+    (is (false? (rf.resources.registry/infinite-resource? {})))))
 
 ;; ===========================================================================
 ;; rf2-x76af2.12 — `:page-data-schema` is a RETIRED key: HARD-REJECTED, never
@@ -181,16 +181,16 @@
             (resource-bad-spec) — the retired key is never silently stored"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-bad-spec"
-          (registry/reg-resource :feed/retired
+          (rf.resources.registry/reg-resource :feed/retired
                                  (assoc (base-infinite-spec)
                                         :page-data-schema :app/timeline-page)
                                  base-infinite-request))))
   (testing "the reject fails BEFORE storage — no registrar entry is written"
-    (is (nil? (registry/resource-meta :feed/retired))
+    (is (nil? (rf.resources.registry/resource-meta :feed/retired))
         "a rejected registration leaves nothing behind (pre-storage gate)"))
   (testing "the error carries the retired key + names BOTH replacements"
     (let [ex   (capture-ex
-                 #(registry/reg-resource :feed/retired2
+                 #(rf.resources.registry/reg-resource :feed/retired2
                                          (assoc (base-infinite-spec)
                                                 :page-data-schema :app/timeline-page)
                                          base-infinite-request))
@@ -209,9 +209,9 @@
             too — it is rejected WHEREVER it appears"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-bad-spec"
-          (registry/reg-resource :res/retired-plain
+          (rf.resources.registry/reg-resource :res/retired-plain
                                  {:scope :rf.scope/global
                                   :params-schema [:map [:slug :string]]
                                   :page-data-schema :app/whatever}
                                  (fn [_ _] {:request {:method :get :url "/x"}}))))
-    (is (nil? (registry/resource-meta :res/retired-plain)))))
+    (is (nil? (rf.resources.registry/resource-meta :res/retired-plain)))))

--- a/implementation/resources/test/re_frame/resources_infinite_ssr_restore_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_ssr_restore_cljs_test.cljc
@@ -35,25 +35,25 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.frame :as frame]
+   [re-frame.frame :as rf.frame]
    ;; load-bearing side-effecting requires: the façade publishes the SSR
    ;; projection + reconcile hooks + registers the resource registrar kind; the
    ;; subs ns publishes the framework-owned merged-items projection + the
    ;; :rf.resource/* read family the acceptance reads through.
    [re-frame.resources]
-   [re-frame.resources.ssr :as ssr]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.subs :as rsubs]
-   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.resources.ssr :as rf.resources.ssr]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.subs :as rf.resources.subs]
+   [re-frame.resources.work-ledger :as rf.resources.work-ledger]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter})))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter})))
 
 ;; ---- the feed spec + cursor fns -------------------------------------------
 
@@ -93,7 +93,7 @@
 
 (def ^:private fkey
   ;; canonical global-scope key for :feed/timeline {:filter :recent}
-  (state/scoped-resource-key :rf.scope/global :feed/timeline {:filter :recent}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global :feed/timeline {:filter :recent}))
 
 ;; The three accumulated pages (N=3, non-terminal — a 4th page exists, "c3"),
 ;; built by replaying the pure append transition the wave-3 reply path drives.
@@ -107,16 +107,16 @@
   prev-mirror are exactly what the runtime would have produced), stamped under
   `fkey`. :loaded, fresh (far-future stale-at)."
   []
-  (-> (state/empty-infinite-entry :feed/timeline fkey)
-      (state/entry-append-page {:page p0 :page-param nil
+  (-> (rf.resources.state/empty-infinite-entry :feed/timeline fkey)
+      (rf.resources.state/entry-append-page {:page p0 :page-param nil
                                 :next-page-param-fn next-cursor
                                 :prev-page-param-fn prev-cursor
                                 :loaded-at 1000 :stale-at 9.0e15})
-      (state/entry-append-page {:page p1 :page-param "c1"
+      (rf.resources.state/entry-append-page {:page p1 :page-param "c1"
                                 :next-page-param-fn next-cursor
                                 :prev-page-param-fn prev-cursor
                                 :loaded-at 1100 :stale-at 9.0e15})
-      (state/entry-append-page {:page p2 :page-param "c2"
+      (rf.resources.state/entry-append-page {:page p2 :page-param "c2"
                                 :next-page-param-fn next-cursor
                                 :prev-page-param-fn prev-cursor
                                 :loaded-at 1200 :stale-at 9.0e15})))
@@ -125,10 +125,10 @@
 ;; a load-more APPENDS at a positive page index (3, past the accumulated tail),
 ;; which is the durable evidence `:rf.resource/fetching-next?` reads.
 (def ^:private load-more-gen 7)
-(def ^:private load-more-wid (work-ledger/resource-work-id fkey load-more-gen))
+(def ^:private load-more-wid (rf.resources.work-ledger/resource-work-id fkey load-more-gen))
 
 (defn- load-more-row [frame-id status]
-  (-> (work-ledger/work-record
+  (-> (rf.resources.work-ledger/work-record
         {:work-id load-more-wid :frame-id frame-id :resource/key fkey
          :generation load-more-gen :transport :rf.http/managed
          :started-at 1300 :page-index 3})
@@ -145,9 +145,9 @@
   (let [e (assoc (loaded-feed-entry)
                  :status :fetching
                  :current-work load-more-wid)]
-    {state/resources-key   {:entries   {(state/key-id fkey) (assoc e :resource/key fkey)}
+    {rf.resources.state/resources-key   {:entries   {(rf.resources.state/key-id fkey) (assoc e :resource/key fkey)}
                             :tag-index {} :owner-index {}}
-     state/work-ledger-key {(work-ledger/work-id-id load-more-wid)
+     rf.resources.state/work-ledger-key {(rf.resources.work-ledger/work-id-id load-more-wid)
                             (load-more-row frame-id :running)}}))
 
 ;; ---- shared expectations ---------------------------------------------------
@@ -163,7 +163,7 @@
   framework-owned `merged-items` projection (resolves the registered spec's
   `:page->items`, raises loudly on a missing accessor). The headline R3 read."
   [entry]
-  (#'rsubs/merged-items entry 'rf.resource/items))
+  (#'rf.resources.subs/merged-items entry 'rf.resource/items))
 
 ;; ===========================================================================
 ;; (a) SERVER PROJECTION — the page vector + infinite facts + merged :items
@@ -175,13 +175,13 @@
   (testing "PRE: the assembled live entry is a 3-page :loaded feed in ONE
             :rf.runtime/resources entry slot, with a load-more in flight"
     (let [rdb (feed-with-load-more-in-flight :app/main)
-          e   (get-in rdb [state/resources-key :entries (state/key-id fkey)])]
-      (is (state/infinite-entry? e) "it is an infinite entry (the :infinite? marker)")
+          e   (get-in rdb [rf.resources.state/resources-key :entries (rf.resources.state/key-id fkey)])]
+      (is (rf.resources.state/infinite-entry? e) "it is an infinite entry (the :infinite? marker)")
       (is (= expected-pages (:data e)) "the ordered page vector")
       (is (= expected-params (:page-params e)) "one page-param per page (page-0 = nil)")
       (is (= expected-cursor (:next-page-param e)) "the cursor is the 4th page's param")
       (is (= expected-prev (:prev-page-param e)) "no prev mirror (page-0 declared none)")
-      (is (= 3 (state/page-count e)))
+      (is (= 3 (rf.resources.state/page-count e)))
       (is (= :fetching (:status e)) "the load-more left the feed :fetching")
       (is (= load-more-wid (:current-work e)) "the entry points at the in-flight load-more work")
       (is (= expected-items (merged-items* e)) "the headline merged :items, live"))))
@@ -193,12 +193,12 @@
             infinite feed is just a :serialize entry whose :data is a vector
             (R1; rides the existing project-resources-runtime-db, no new code)"
     (let [rdb  (feed-with-load-more-in-flight :app/main)
-          proj (ssr/project-resources-runtime-db rdb)]
-      (is (= #{state/resources-key} (set (keys proj)))
+          proj (rf.resources.ssr/project-resources-runtime-db rdb)]
+      (is (= #{rf.resources.state/resources-key} (set (keys proj)))
           "ONLY the resources subsystem is projected (the feed adds no subsystem)")
-      (is (= #{:entries} (set (keys (get proj state/resources-key))))
+      (is (= #{:entries} (set (keys (get proj rf.resources.state/resources-key))))
           "only :entries rides — indexes recompute, work-ledger never rides")
-      (let [es (get-in proj [state/resources-key :entries])
+      (let [es (get-in proj [rf.resources.state/resources-key :entries])
             we (val (first es))]
         (is (= 1 (count es)) "the whole feed is ONE entry slot (R1 — no per-page slot)")
         (is (true? (:infinite? we)) ":infinite? marker rides")
@@ -216,11 +216,11 @@
             do NOT ride the wire (they reference a host attempt that does not
             survive the round-trip) — same rule as a scalar entry"
     (let [rdb  (feed-with-load-more-in-flight :app/main)
-          proj (ssr/project-resources-runtime-db rdb)
-          we   (val (first (get-in proj [state/resources-key :entries])))]
+          proj (rf.resources.ssr/project-resources-runtime-db rdb)
+          we   (val (first (get-in proj [rf.resources.state/resources-key :entries])))]
       (is (not (contains? we :current-work))
           "the load-more :current-work pointer is stripped on the wire")
-      (is (not (contains? proj state/work-ledger-key))
+      (is (not (contains? proj rf.resources.state/work-ledger-key))
           "the :rf.runtime/work-ledger subtree (the in-flight page-3 row) never rides"))))
 
 (deftest projected-entry-merges-items-identically-server-side
@@ -230,9 +230,9 @@
             vector + the registered :page->items accessor are all that the merge
             needs, and both survive the projection)"
     (let [rdb       (feed-with-load-more-in-flight :app/main)
-          live      (get-in rdb [state/resources-key :entries (state/key-id fkey)])
-          proj      (ssr/project-resources-runtime-db rdb)
-          projected (val (first (get-in proj [state/resources-key :entries])))]
+          live      (get-in rdb [rf.resources.state/resources-key :entries (rf.resources.state/key-id fkey)])
+          proj      (rf.resources.ssr/project-resources-runtime-db rdb)
+          projected (val (first (get-in proj [rf.resources.state/resources-key :entries])))]
       (is (= expected-items (merged-items* live)) "live merge")
       (is (= expected-items (merged-items* projected))
           "the projected entry merges to the SAME flat ordered :items list — no page loss")
@@ -252,17 +252,17 @@
             terminal? + page-params + prev-mirror INTACT (order preserved, no
             page loss) — the durable feed rides the EXISTING restore reconcile"
     (let [snapshot (feed-with-load-more-in-flight :app/main)
-          out      (ssr/reconcile-on-restore snapshot :app/main)
-          e        (get-in out [state/resources-key :entries (state/key-id fkey)])]
-      (is (state/infinite-entry? e) "the restored entry is still the infinite feed")
+          out      (rf.resources.ssr/reconcile-on-restore snapshot :app/main)
+          e        (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id fkey)])]
+      (is (rf.resources.state/infinite-entry? e) "the restored entry is still the infinite feed")
       (is (= expected-pages (:data e))
           "the ordered page vector rehydrates intact — order preserved, no page loss")
       (is (= expected-params (:page-params e)) ":page-params rehydrate intact")
       (is (= expected-cursor (:next-page-param e)) "the cursor (:next-page-param) rehydrates intact")
-      (is (false? (state/terminal? (:next-page-param e)))
+      (is (false? (rf.resources.state/terminal? (:next-page-param e)))
           "terminal? is FALSE — a 4th page exists (cursor \"c3\"), as before restore")
       (is (= expected-prev (:prev-page-param e)) "the prev mirror rehydrates intact")
-      (is (= 3 (state/page-count e)) "all 3 pages survived (no page loss)")
+      (is (= 3 (rf.resources.state/page-count e)) "all 3 pages survived (no page loss)")
       (is (= expected-items (merged-items* e))
           "the merged :items rehydrates to the SAME flat ordered list"))))
 
@@ -274,9 +274,9 @@
             dangles the non-terminal page-3 work-ledger row (it must not dangle
             as a live attempt against the restored feed)"
     (let [snapshot (feed-with-load-more-in-flight :app/main)
-          out      (ssr/reconcile-on-restore snapshot :app/main)
-          e        (get-in out [state/resources-key :entries (state/key-id fkey)])
-          row      (get-in out [state/work-ledger-key (work-ledger/work-id-id load-more-wid)])]
+          out      (rf.resources.ssr/reconcile-on-restore snapshot :app/main)
+          e        (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id fkey)])
+          row      (get-in out [rf.resources.state/work-ledger-key (rf.resources.work-ledger/work-id-id load-more-wid)])]
       (is (= :loaded (:status e))
           ":fetching-with-data settles to :loaded (keep last-known-good) — never stranded :fetching")
       (is (nil? (:current-work e)) "the vanished load-more pointer is cleared")
@@ -286,9 +286,9 @@
       (is (= expected-cursor (:next-page-param e)) "the cursor is untouched by the settle")
       (testing "the non-terminal page-3 work-ledger row is dangled (suppressed)"
         (is (= :suppressed (:status row)) "the in-flight load-more row settled terminal :suppressed")
-        (is (work-ledger/terminal? (:status row)) "it is now terminal")
+        (is (rf.resources.work-ledger/terminal? (:status row)) "it is now terminal")
         (is (= :dangling (get-in row [:outcome :reason])) "marked dangling")
-        (is (not (contains? work-ledger/non-terminal-statuses (:status row)))
+        (is (not (contains? rf.resources.work-ledger/non-terminal-statuses (:status row)))
             "NO non-terminal load-more row survives the restore")))))
 
 (deftest restore-fetching-next?-resolves-false-no-phantom-load-more
@@ -302,9 +302,9 @@
           snapshot (feed-with-load-more-in-flight fid)
           ;; reconcile + install the snapshot as the live frame's runtime-db,
           ;; exactly as epoch perform-restore! does.
-          reconciled (ssr/reconcile-on-restore snapshot fid)]
+          reconciled (rf.resources.ssr/reconcile-on-restore snapshot fid)]
       (rf/make-frame {:id fid :doc "restore infinite fetching-next? frame"})
-      (frame/replace-runtime-db! fid reconciled)
+      (rf.frame/replace-runtime-db! fid reconciled)
       (let [q {:resource :feed/timeline :scope :rf.scope/global :params {:filter :recent}}]
         (testing "the durable feed reads through the live subs intact post-restore"
           (is (= expected-items @(rf/subscribe [:rf.resource/items q] {:frame fid}))
@@ -324,30 +324,30 @@
             (is (= :loaded (:status vm)) "the feed settled :loaded")
             (is (= expected-items (:items vm)) "the accumulated pages stay visible (no skeleton)")
             (is (true? (:has-data? vm))))))
-      (frame/destroy-frame! fid))))
+      (rf.frame/destroy-frame! fid))))
 
 (deftest restore-with-terminal-feed-rehydrates-terminal-intact
   (reg-feed!)
   (testing "a TERMINAL feed (last page's next-cursor nil) rehydrates with
             terminal? TRUE — the single-terminal rule rides restore (no spurious
             has-next-page? on a feed that already reached the end)"
-    (let [terminal-entry (-> (state/empty-infinite-entry :feed/timeline fkey)
-                             (state/entry-append-page {:page p0 :page-param nil
+    (let [terminal-entry (-> (rf.resources.state/empty-infinite-entry :feed/timeline fkey)
+                             (rf.resources.state/entry-append-page {:page p0 :page-param nil
                                                        :next-page-param-fn next-cursor
                                                        :prev-page-param-fn prev-cursor
                                                        :loaded-at 1000 :stale-at 9.0e15})
                              ;; a terminal final page (next-cursor nil)
-                             (state/entry-append-page {:page (page [:z] nil) :page-param "c1"
+                             (rf.resources.state/entry-append-page {:page (page [:z] nil) :page-param "c1"
                                                        :next-page-param-fn next-cursor
                                                        :prev-page-param-fn prev-cursor
                                                        :loaded-at 1100 :stale-at 9.0e15}))
-          snapshot {state/resources-key {:entries   {(state/key-id fkey) (assoc terminal-entry :resource/key fkey)}
+          snapshot {rf.resources.state/resources-key {:entries   {(rf.resources.state/key-id fkey) (assoc terminal-entry :resource/key fkey)}
                                          :tag-index {} :owner-index {}}}
-          out (ssr/reconcile-on-restore snapshot :app/main)
-          e   (get-in out [state/resources-key :entries (state/key-id fkey)])]
-      (is (= 2 (state/page-count e)) "both pages (including the terminal one) survived")
+          out (rf.resources.ssr/reconcile-on-restore snapshot :app/main)
+          e   (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id fkey)])]
+      (is (= 2 (rf.resources.state/page-count e)) "both pages (including the terminal one) survived")
       (is (nil? (:next-page-param e)) "the terminal cursor (nil) rehydrates")
-      (is (true? (state/terminal? (:next-page-param e))) "terminal? rehydrates TRUE")
+      (is (true? (rf.resources.state/terminal? (:next-page-param e))) "terminal? rehydrates TRUE")
       (is (= [:a :b :z] (merged-items* e)) "the merged :items spans both pages, in order"))))
 
 (deftest restore-with-page-error-rehydrates-third-error-channel
@@ -356,11 +356,11 @@
             error channel) rehydrates that channel intact through restore, kept
             distinct from :error / :refresh-error"
     (let [failed (-> (loaded-feed-entry)
-                     (state/entry-page-failed {:error {:kind :rf.http/server :status 503}}))
-          snapshot {state/resources-key {:entries   {(state/key-id fkey) (assoc failed :resource/key fkey)}
+                     (rf.resources.state/entry-page-failed {:error {:kind :rf.http/server :status 503}}))
+          snapshot {rf.resources.state/resources-key {:entries   {(rf.resources.state/key-id fkey) (assoc failed :resource/key fkey)}
                                          :tag-index {} :owner-index {}}}
-          out (ssr/reconcile-on-restore snapshot :app/main)
-          e   (get-in out [state/resources-key :entries (state/key-id fkey)])]
+          out (rf.resources.ssr/reconcile-on-restore snapshot :app/main)
+          e   (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id fkey)])]
       (is (= {:kind :rf.http/server :status 503} (:page-error e))
           "the :page-error (third channel) rehydrates intact")
       (is (nil? (:error e)) "NOT the first-load :error channel")
@@ -381,9 +381,9 @@
             settles to :loaded (last-known-good) and is NOT refetched (the SSR
             no-double-fetch win), since the accumulated data is fresh"
     (let [rdb       (feed-with-load-more-in-flight :app/main)
-          projected (ssr/project-resources-runtime-db rdb)
-          out       (ssr/hydrate-runtime-db projected :app/main)
-          e         (get-in out [state/resources-key :entries (state/key-id fkey)])]
+          projected (rf.resources.ssr/project-resources-runtime-db rdb)
+          out       (rf.resources.ssr/hydrate-runtime-db projected :app/main)
+          e         (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id fkey)])]
       (is (= expected-pages (:data e)) "the page vector survived project→hydrate intact")
       (is (= expected-cursor (:next-page-param e)) "the cursor survived the round-trip")
       (is (= expected-items (merged-items* e)) "the merged :items survived the round-trip")
@@ -391,7 +391,7 @@
           "the dangling :fetching load-more settled to :loaded on hydrate (last-known-good)")
       (is (nil? (:current-work e)) "the stripped :current-work stays cleared")
       (testing "the fresh-with-data feed is NOT in the client refetch plan (no double-fetch)"
-        (let [plan (->> (ssr/hydrate-refetch-plan out 5000)
+        (let [plan (->> (rf.resources.ssr/hydrate-refetch-plan out 5000)
                         (into {} (map (juxt :resource/key identity))))]
           (is (not (contains? plan fkey))
               "a fresh accumulated feed is not refetched on the client — the SSR win"))))))

--- a/implementation/resources/test/re_frame/resources_infinite_state_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_state_cljs_test.cljc
@@ -31,7 +31,7 @@
   The load-more EVENT (wave 3) + subs (wave 4) are out of scope."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer-macros [deftest is testing]])
-            [re-frame.resources.state :as state]))
+            [re-frame.resources.state :as rf.resources.state]))
 
 (def ^:private next-cursor
   "A :next-page-param fn: read the next cursor off the last page's envelope;
@@ -50,16 +50,16 @@
 
 (deftest empty-infinite-entry-shape
   (testing "an empty infinite entry carries the infinite facts (R1)"
-    (let [e (state/empty-infinite-entry :feed/timeline [:rf.scope/global :feed/timeline {:filter :recent}])]
+    (let [e (rf.resources.state/empty-infinite-entry :feed/timeline [:rf.scope/global :feed/timeline {:filter :recent}])]
       (is (true? (:infinite? e)))
-      (is (state/infinite-entry? e))
+      (is (rf.resources.state/infinite-entry? e))
       (is (= [] (:data e))            "page vector seeded empty (not nil)")
       (is (= [] (:page-params e)))
       (is (nil? (:next-page-param e)))
       (is (nil? (:prev-page-param e)))
       (is (nil? (:page-error e)))
       (is (= :idle (:status e)))
-      (is (= 0 (state/page-count e)))
+      (is (= 0 (rf.resources.state/page-count e)))
       (testing "it is still an ordinary resource entry (R1 — no new kind)"
         (is (= :feed/timeline (:resource/id e)))
         (is (= [:rf.scope/global :feed/timeline {:filter :recent}] (:resource/key e)))
@@ -68,43 +68,43 @@
 
 (deftest ordinary-entry-not-infinite
   (testing "an ordinary entry is not an infinite feed"
-    (is (false? (state/infinite-entry? (state/empty-entry :res/plain))))))
+    (is (false? (rf.resources.state/infinite-entry? (rf.resources.state/empty-entry :res/plain))))))
 
 ;; ---- next-param-for / prev-param-for / terminal ----------------------------
 
 (deftest next-param-derivation
   (testing "next-param-for derives the next cursor from the last page"
-    (is (= "c1" (state/next-param-for next-cursor [(page [:a] "c1")])))
-    (is (= "c2" (state/next-param-for next-cursor [(page [:a] "c1") (page [:b] "c2")]))
+    (is (= "c1" (rf.resources.state/next-param-for next-cursor [(page [:a] "c1")])))
+    (is (= "c2" (rf.resources.state/next-param-for next-cursor [(page [:a] "c1") (page [:b] "c2")]))
         "derives from the LAST page, not the first"))
   (testing "nil last-page next-cursor is the SINGLE terminal"
-    (is (nil? (state/next-param-for next-cursor [(page [:a] nil)]))))
+    (is (nil? (rf.resources.state/next-param-for next-cursor [(page [:a] nil)]))))
   (testing "an empty page vector yields nil (no last page to derive from)"
-    (is (nil? (state/next-param-for next-cursor []))))
+    (is (nil? (rf.resources.state/next-param-for next-cursor []))))
   (testing "no :next-page-param fn yields nil"
-    (is (nil? (state/next-param-for nil [(page [:a] "c1")])))))
+    (is (nil? (rf.resources.state/next-param-for nil [(page [:a] "c1")])))))
 
 (deftest prev-param-derivation-mirror
   (testing "prev-param-for derives from the FIRST page (R7 mirror)"
     (let [pages [{:items [:a] :page-info {:prev-cursor "p0"}}
                  {:items [:b] :page-info {:prev-cursor "p1"}}]]
-      (is (= "p0" (state/prev-param-for prev-cursor pages))
+      (is (= "p0" (rf.resources.state/prev-param-for prev-cursor pages))
           "the prev cursor comes from the head, not the tail")))
   (testing "no :prev-page-param fn yields nil (mirror not declared)"
-    (is (nil? (state/prev-param-for nil [(page [:a] "c1")])))))
+    (is (nil? (rf.resources.state/prev-param-for nil [(page [:a] "c1")])))))
 
 (deftest terminal-rule
   (testing "terminal? is the nil-next-param rule (R8 single terminal)"
-    (is (true? (state/terminal? nil)))
-    (is (false? (state/terminal? "c1")))
-    (is (false? (state/terminal? 0)) "0 is a legit cursor, not terminal")))
+    (is (true? (rf.resources.state/terminal? nil)))
+    (is (false? (rf.resources.state/terminal? "c1")))
+    (is (false? (rf.resources.state/terminal? 0)) "0 is a legit cursor, not terminal")))
 
 ;; ---- entry-append-page -----------------------------------------------------
 
 (deftest append-first-page
   (testing "appending page-0 to an empty feed accumulates + advances the cursor"
-    (let [e0 (state/empty-infinite-entry :feed/timeline)
-          e1 (state/entry-append-page
+    (let [e0 (rf.resources.state/empty-infinite-entry :feed/timeline)
+          e1 (rf.resources.state/entry-append-page
                e0 {:page (page [:a :b] "c1")
                    :page-param nil           ;; page-0 param is nil (initial)
                    :next-page-param-fn next-cursor
@@ -115,44 +115,44 @@
       (is (= :loaded (:status e1)))
       (is (= 1000 (:loaded-at e1)))
       (is (= 61000 (:stale-at e1)))
-      (is (= 1 (state/page-count e1)))
+      (is (= 1 (rf.resources.state/page-count e1)))
       (is (> (:revision e1) (:revision e0)) "authoritative write bumps revision (EP-0019)"))))
 
 (deftest append-multiple-pages-accumulates
   (testing "successive appends grow the feed in order + re-derive the cursor"
-    (let [e (-> (state/empty-infinite-entry :feed/timeline)
-                (state/entry-append-page {:page (page [:a] "c1") :page-param nil
+    (let [e (-> (rf.resources.state/empty-infinite-entry :feed/timeline)
+                (rf.resources.state/entry-append-page {:page (page [:a] "c1") :page-param nil
                                           :next-page-param-fn next-cursor
                                           :loaded-at 1000 :stale-at 2000})
-                (state/entry-append-page {:page (page [:b] "c2") :page-param "c1"
+                (rf.resources.state/entry-append-page {:page (page [:b] "c2") :page-param "c1"
                                           :next-page-param-fn next-cursor
                                           :loaded-at 1100 :stale-at 2100})
-                (state/entry-append-page {:page (page [:c] "c3") :page-param "c2"
+                (rf.resources.state/entry-append-page {:page (page [:c] "c3") :page-param "c2"
                                           :next-page-param-fn next-cursor
                                           :loaded-at 1200 :stale-at 2200}))]
       (is (= [(page [:a] "c1") (page [:b] "c2") (page [:c] "c3")] (:data e)))
       (is (= [nil "c1" "c2"] (:page-params e)) "one param per page, page-0 = nil")
       (is (= "c3" (:next-page-param e)))
-      (is (= 3 (state/page-count e)))
+      (is (= 3 (rf.resources.state/page-count e)))
       (is (= 1200 (:loaded-at e)) "loaded-at re-stamped each append"))))
 
 (deftest append-terminal-page
   (testing "a page whose next-cursor is nil sets :next-page-param nil (terminal)"
-    (let [e (-> (state/empty-infinite-entry :feed/timeline)
-                (state/entry-append-page {:page (page [:a] "c1") :page-param nil
+    (let [e (-> (rf.resources.state/empty-infinite-entry :feed/timeline)
+                (rf.resources.state/entry-append-page {:page (page [:a] "c1") :page-param nil
                                           :next-page-param-fn next-cursor
                                           :loaded-at 1 :stale-at 2})
-                (state/entry-append-page {:page (page [:b] nil) :page-param "c1"
+                (rf.resources.state/entry-append-page {:page (page [:b] nil) :page-param "c1"
                                           :next-page-param-fn next-cursor
                                           :loaded-at 3 :stale-at 4}))]
       (is (nil? (:next-page-param e)) "terminal — no more pages")
-      (is (state/terminal? (:next-page-param e)))
-      (is (= 2 (state/page-count e)) "the terminal page IS accumulated"))))
+      (is (rf.resources.state/terminal? (:next-page-param e)))
+      (is (= 2 (rf.resources.state/page-count e)) "the terminal page IS accumulated"))))
 
 (deftest append-recomputes-prev-mirror
   (testing "append re-derives :prev-page-param from the head when a fn is supplied"
-    (let [e (state/entry-append-page
-              (state/empty-infinite-entry :feed/timeline)
+    (let [e (rf.resources.state/entry-append-page
+              (rf.resources.state/empty-infinite-entry :feed/timeline)
               {:page {:items [:a] :page-info {:prev-cursor "p0"}}
                :page-param nil
                :next-page-param-fn (fn [_ _] nil)
@@ -162,22 +162,22 @@
 
 (deftest append-clears-page-error
   (testing "a successful append clears a prior :page-error (load-more recovery)"
-    (let [failed (-> (state/empty-infinite-entry :feed/timeline)
-                     (state/entry-append-page {:page (page [:a] "c1") :page-param nil
+    (let [failed (-> (rf.resources.state/empty-infinite-entry :feed/timeline)
+                     (rf.resources.state/entry-append-page {:page (page [:a] "c1") :page-param nil
                                                :next-page-param-fn next-cursor
                                                :loaded-at 1 :stale-at 2})
-                     (state/entry-page-failed {:error {:kind :rf.http/server :status 503}}))
-          recovered (state/entry-append-page failed
+                     (rf.resources.state/entry-page-failed {:error {:kind :rf.http/server :status 503}}))
+          recovered (rf.resources.state/entry-append-page failed
                                               {:page (page [:b] "c2") :page-param "c1"
                                                :next-page-param-fn next-cursor
                                                :loaded-at 3 :stale-at 4})]
       (is (some? (:page-error failed)) "the failure recorded a page-error")
       (is (nil? (:page-error recovered)) "the next success cleared it")
-      (is (= 2 (state/page-count recovered))))))
+      (is (= 2 (rf.resources.state/page-count recovered))))))
 
 (deftest append-nil-entry-noop
   (testing "appending to a nil entry returns nil unchanged (no feed to append to)"
-    (is (nil? (state/entry-append-page nil {:page (page [:a] "c1")
+    (is (nil? (rf.resources.state/entry-append-page nil {:page (page [:a] "c1")
                                             :next-page-param-fn next-cursor
                                             :loaded-at 1 :stale-at 2})))))
 
@@ -185,17 +185,17 @@
 
 (deftest page-failure-keeps-feed
   (testing "a load-more failure keeps ALL pages + records :page-error (third channel)"
-    (let [loaded (-> (state/empty-infinite-entry :feed/timeline)
-                     (state/entry-append-page {:page (page [:a] "c1") :page-param nil
+    (let [loaded (-> (rf.resources.state/empty-infinite-entry :feed/timeline)
+                     (rf.resources.state/entry-append-page {:page (page [:a] "c1") :page-param nil
                                                :next-page-param-fn next-cursor
                                                :loaded-at 1 :stale-at 2})
-                     (state/entry-append-page {:page (page [:b] "c2") :page-param "c1"
+                     (rf.resources.state/entry-append-page {:page (page [:b] "c2") :page-param "c1"
                                                :next-page-param-fn next-cursor
                                                :loaded-at 3 :stale-at 4}))
           envelope {:kind :rf.http/server :status 503}
-          failed (state/entry-page-failed loaded {:error envelope})]
+          failed (rf.resources.state/entry-page-failed loaded {:error envelope})]
       (is (= :loaded (:status failed)) "feed returns to :loaded, NOT :error")
-      (is (= 2 (state/page-count failed)) "all accumulated pages kept")
+      (is (= 2 (rf.resources.state/page-count failed)) "all accumulated pages kept")
       (is (= (:data loaded) (:data failed)) "page vector untouched")
       (is (= "c2" (:next-page-param failed)) "cursor untouched")
       (is (= envelope (:page-error failed)) ":page-error recorded")
@@ -205,32 +205,32 @@
 
 (deftest page-failed-nil-entry-noop
   (testing "page-failed on a nil entry returns nil unchanged"
-    (is (nil? (state/entry-page-failed nil {:error {:kind :rf.http/server}})))))
+    (is (nil? (rf.resources.state/entry-page-failed nil {:error {:kind :rf.http/server}})))))
 
 ;; ---- resolve-page->items (R3 accessor) -------------------------------------
 
 (deftest page-accessor-resolution
   (testing "a keyword accessor lifts to its get fn"
-    (let [acc (state/resolve-page->items :items)]
+    (let [acc (rf.resources.state/resolve-page->items :items)]
       (is (fn? acc))
       (is (= [:a :b] (acc {:items [:a :b]})))))
   (testing "a fn accessor passes through"
     (let [f (fn [p] (:rows p))
-          acc (state/resolve-page->items f)]
+          acc (rf.resources.state/resolve-page->items f)]
       (is (= [:x] (acc {:rows [:x]})))))
   (testing "nil accessor resolves to nil (caller applies vector-identity / raises at merge)"
-    (is (nil? (state/resolve-page->items nil))))
+    (is (nil? (rf.resources.state/resolve-page->items nil))))
   (testing "a non-keyword / non-fn accessor resolves to nil"
-    (is (nil? (state/resolve-page->items 99)))))
+    (is (nil? (rf.resources.state/resolve-page->items 99)))))
 
 ;; ---- page-param-for-spec (page-0 cursor) -----------------------------------
 
 (deftest page-0-param-default
   (testing "page-0 param defaults to nil (TanStack initialPageParam analogue)"
-    (is (nil? (state/page-param-for-spec {})))
-    (is (nil? (state/page-param-for-spec {:initial-page-param nil}))))
+    (is (nil? (rf.resources.state/page-param-for-spec {})))
+    (is (nil? (rf.resources.state/page-param-for-spec {:initial-page-param nil}))))
   (testing "an :initial-page-param override is honoured"
-    (is (= "p0" (state/page-param-for-spec {:initial-page-param "p0"})))))
+    (is (= "p0" (rf.resources.state/page-param-for-spec {:initial-page-param "p0"})))))
 
 ;; ---- entry-replace-page (R6 window-preserving in-place replace) ------------
 ;;
@@ -245,14 +245,14 @@
   param per page ([nil c1 c2]). Built via the same pure appends the event
   layer drives, so the structural-sharing assertions ride a realistic shape."
   []
-  (-> (state/empty-infinite-entry :feed/timeline)
-      (state/entry-append-page {:page (page [:a] "c1") :page-param nil
+  (-> (rf.resources.state/empty-infinite-entry :feed/timeline)
+      (rf.resources.state/entry-append-page {:page (page [:a] "c1") :page-param nil
                                 :next-page-param-fn next-cursor
                                 :loaded-at 1000 :stale-at 2000})
-      (state/entry-append-page {:page (page [:b] "c2") :page-param "c1"
+      (rf.resources.state/entry-append-page {:page (page [:b] "c2") :page-param "c1"
                                 :next-page-param-fn next-cursor
                                 :loaded-at 1100 :stale-at 2100})
-      (state/entry-append-page {:page (page [:c] "c3") :page-param "c2"
+      (rf.resources.state/entry-append-page {:page (page [:c] "c3") :page-param "c2"
                                 :next-page-param-fn next-cursor
                                 :loaded-at 1200 :stale-at 2200})))
 
@@ -260,11 +260,11 @@
   (testing "replacing page-0 of a 3-page feed refreshes index 0 in place +
             keeps the accumulated tail (window-preserving R6 settle)"
     (let [e0 (accumulated-3)
-          e1 (state/entry-replace-page
+          e1 (rf.resources.state/entry-replace-page
                e0 {:page (page [:a*] "c1") :page-param nil :page-index 0
                    :next-page-param-fn next-cursor
                    :loaded-at 9000 :stale-at 9999})]
-      (is (= 3 (state/page-count e1)) "feed NOT grown — replace, not append")
+      (is (= 3 (rf.resources.state/page-count e1)) "feed NOT grown — replace, not append")
       (is (= (page [:a*] "c1") (nth (:data e1) 0)) "page-0 replaced with the fresh value")
       (is (= (page [:b] "c2") (nth (:data e1) 1)) "tail page-1 preserved")
       (is (= (page [:c] "c3") (nth (:data e1) 2)) "tail page-2 preserved")
@@ -285,7 +285,7 @@
           fresh    (page [:a] "c1")]
       (is (= old-page fresh) "the fresh page is value-equal to the old page-0")
       (is (not (identical? old-page fresh)) "but it is a distinct object (a fresh decode)")
-      (let [e1 (state/entry-replace-page
+      (let [e1 (rf.resources.state/entry-replace-page
                  e0 {:page fresh :page-param nil :page-index 0
                      :next-page-param-fn next-cursor
                      :loaded-at 9000 :stale-at 9999})]
@@ -298,7 +298,7 @@
   (testing "a DIFFERENT page-0 value is taken as-is (no spurious sharing)"
     (let [e0    (accumulated-3)
           fresh (page [:a*] "c1")
-          e1    (state/entry-replace-page
+          e1    (rf.resources.state/entry-replace-page
                   e0 {:page fresh :page-param nil :page-index 0
                       :next-page-param-fn next-cursor
                       :loaded-at 9000 :stale-at 9999})]
@@ -309,18 +309,18 @@
   (testing "replacing the LAST page re-derives :next-page-param from the new tail"
     (let [e0 (accumulated-3)
           ;; replace the terminal page-2 with one whose next-cursor differs
-          e1 (state/entry-replace-page
+          e1 (rf.resources.state/entry-replace-page
                e0 {:page (page [:c*] "c3*") :page-param "c2" :page-index 2
                    :next-page-param-fn next-cursor
                    :loaded-at 9000 :stale-at 9999})]
       (is (= "c3*" (:next-page-param e1)) "cursor recomputed from the replaced last page")
-      (is (= 3 (state/page-count e1))))))
+      (is (= 3 (rf.resources.state/page-count e1))))))
 
 (deftest replace-page-clears-error-channels
   (testing "an in-place replace clears :page-error / :refresh-error (a fresh authoritative write)"
     (let [e0     (-> (accumulated-3)
-                     (state/entry-page-failed {:error {:kind :rf.http/server :status 503}}))
-          e1     (state/entry-replace-page
+                     (rf.resources.state/entry-page-failed {:error {:kind :rf.http/server :status 503}}))
+          e1     (rf.resources.state/entry-replace-page
                    e0 {:page (page [:a*] "c1") :page-param nil :page-index 0
                        :next-page-param-fn next-cursor
                        :loaded-at 9000 :stale-at 9999})]
@@ -332,31 +332,31 @@
 (deftest replace-page-past-tail-delegates-to-append
   (testing "a replace at page-index >= page-count is an APPEND (replacement past the
             tail — e.g. a window-preserving refetch of a feed emptied to page 0)"
-    (let [e0 (-> (state/empty-infinite-entry :feed/timeline)
-                 (state/entry-append-page {:page (page [:a] "c1") :page-param nil
+    (let [e0 (-> (rf.resources.state/empty-infinite-entry :feed/timeline)
+                 (rf.resources.state/entry-append-page {:page (page [:a] "c1") :page-param nil
                                            :next-page-param-fn next-cursor
                                            :loaded-at 1 :stale-at 2}))
           ;; page-index 1 == page-count (1) → delegates to entry-append-page
-          e1 (state/entry-replace-page
+          e1 (rf.resources.state/entry-replace-page
                e0 {:page (page [:b] "c2") :page-param "c1" :page-index 1
                    :next-page-param-fn next-cursor
                    :loaded-at 3 :stale-at 4})]
-      (is (= 2 (state/page-count e1)) "the page was APPENDED (feed grew), not replaced")
+      (is (= 2 (rf.resources.state/page-count e1)) "the page was APPENDED (feed grew), not replaced")
       (is (= [(page [:a] "c1") (page [:b] "c2")] (:data e1)))
       (is (= [nil "c1"] (:page-params e1)) "params appended in step")
       (is (= "c2" (:next-page-param e1)) "cursor advanced from the appended tail")))
   (testing "a replace into an EMPTY feed at index 0 appends page-0"
-    (let [e0 (state/empty-infinite-entry :feed/timeline)
-          e1 (state/entry-replace-page
+    (let [e0 (rf.resources.state/empty-infinite-entry :feed/timeline)
+          e1 (rf.resources.state/entry-replace-page
                e0 {:page (page [:a] "c1") :page-param nil :page-index 0
                    :next-page-param-fn next-cursor
                    :loaded-at 1 :stale-at 2})]
-      (is (= 1 (state/page-count e1)) "index 0 == count 0 → append page-0")
+      (is (= 1 (rf.resources.state/page-count e1)) "index 0 == count 0 → append page-0")
       (is (= [(page [:a] "c1")] (:data e1))))))
 
 (deftest replace-page-nil-entry-noop
   (testing "replace on a nil entry returns nil unchanged (no feed to replace into)"
-    (is (nil? (state/entry-replace-page nil {:page (page [:a] "c1") :page-index 0
+    (is (nil? (rf.resources.state/entry-replace-page nil {:page (page [:a] "c1") :page-index 0
                                              :next-page-param-fn next-cursor
                                              :loaded-at 1 :stale-at 2})))))
 
@@ -371,50 +371,50 @@
 
 (deftest refetch-window-count-empty-feed
   (testing "an empty feed (page-count 0) refreshes 0 pages — nothing to refresh"
-    (is (= 0 (state/refetch-window-count nil 0)))
-    (is (= 0 (state/refetch-window-count {:refetch-all-pages? true} 0)))
-    (is (= 0 (state/refetch-window-count {:refetch-window 5} 0))
+    (is (= 0 (rf.resources.state/refetch-window-count nil 0)))
+    (is (= 0 (rf.resources.state/refetch-window-count {:refetch-all-pages? true} 0)))
+    (is (= 0 (rf.resources.state/refetch-window-count {:refetch-window 5} 0))
         "window over an empty feed is still 0 (zero-page short-circuits first)")))
 
 (deftest refetch-window-count-default-refreshes-page-0-only
   (testing "the ruled DEFAULT (no policy / empty policy) refreshes PAGE 0 only —
             the window-preserving default (replace page 0 in place, keep tail)"
-    (is (= 1 (state/refetch-window-count nil 3)))
-    (is (= 1 (state/refetch-window-count {} 3)))
-    (is (= 1 (state/refetch-window-count {} 1)))))
+    (is (= 1 (rf.resources.state/refetch-window-count nil 3)))
+    (is (= 1 (rf.resources.state/refetch-window-count {} 3)))
+    (is (= 1 (rf.resources.state/refetch-window-count {} 1)))))
 
 (deftest refetch-window-count-all-pages-opt-in
   (testing ":refetch-all-pages? true refreshes EVERY accumulated page (TanStack parity)"
-    (is (= 3 (state/refetch-window-count {:refetch-all-pages? true} 3))
+    (is (= 3 (rf.resources.state/refetch-window-count {:refetch-all-pages? true} 3))
         "all 3 pages refreshed (not collapsed to page 0)")
-    (is (= 1 (state/refetch-window-count {:refetch-all-pages? true} 1)))
+    (is (= 1 (rf.resources.state/refetch-window-count {:refetch-all-pages? true} 1)))
     (testing "all-pages? wins over a co-present :refetch-window (cond order)"
-      (is (= 3 (state/refetch-window-count {:refetch-all-pages? true :refetch-window 2} 3))))))
+      (is (= 3 (rf.resources.state/refetch-window-count {:refetch-all-pages? true :refetch-window 2} 3))))))
 
 (deftest refetch-window-count-window-clamps
   (testing ":refetch-window n refreshes the first n pages"
-    (is (= 2 (state/refetch-window-count {:refetch-window 2} 3)) "in-range window verbatim"))
+    (is (= 2 (rf.resources.state/refetch-window-count {:refetch-window 2} 3)) "in-range window verbatim"))
   (testing "CLAMP HIGH — a window beyond the page count never invents pages"
-    (is (= 3 (state/refetch-window-count {:refetch-window 5} 3))
+    (is (= 3 (rf.resources.state/refetch-window-count {:refetch-window 5} 3))
         "window > page-count clamps DOWN to page-count")
-    (is (= 3 (state/refetch-window-count {:refetch-window 3} 3)) "window == page-count is exact"))
+    (is (= 3 (rf.resources.state/refetch-window-count {:refetch-window 3} 3)) "window == page-count is exact"))
   (testing "CLAMP LOW — a refetch always refreshes at least page 0"
-    (is (= 1 (state/refetch-window-count {:refetch-window 1} 3)) "window 1 refreshes exactly page 0")
-    (is (= 1 (state/refetch-window-count {:refetch-window 0} 3)) "window 0 clamps UP to 1")
-    (is (= 1 (state/refetch-window-count {:refetch-window -4} 3)) "a negative window clamps UP to 1")))
+    (is (= 1 (rf.resources.state/refetch-window-count {:refetch-window 1} 3)) "window 1 refreshes exactly page 0")
+    (is (= 1 (rf.resources.state/refetch-window-count {:refetch-window 0} 3)) "window 0 clamps UP to 1")
+    (is (= 1 (rf.resources.state/refetch-window-count {:refetch-window -4} 3)) "a negative window clamps UP to 1")))
 
 ;; ---- refetch-sweep-tail (R6 — the ordered pages beyond 0 to re-fetch) ------
 
 (deftest refetch-sweep-tail-default-is-empty
   (testing "the window-preserving DEFAULT starts NO sweep — page 0 is the
             issue-time replacement; there is no tail to chain"
-    (is (= [] (state/refetch-sweep-tail (accumulated-3) nil)))
-    (is (= [] (state/refetch-sweep-tail (accumulated-3) {})))))
+    (is (= [] (rf.resources.state/refetch-sweep-tail (accumulated-3) nil)))
+    (is (= [] (rf.resources.state/refetch-sweep-tail (accumulated-3) {})))))
 
 (deftest refetch-sweep-tail-all-pages
   (testing ":refetch-all-pages? sweeps pages 1..N-1 in order (page 0 is issue-time),
             each pair carrying that page's durable :page-param"
-    (let [tail (state/refetch-sweep-tail (accumulated-3) {:refetch-all-pages? true})]
+    (let [tail (rf.resources.state/refetch-sweep-tail (accumulated-3) {:refetch-all-pages? true})]
       ;; accumulated-3 :page-params == [nil "c1" "c2"]
       (is (= [["c1" 1] ["c2" 2]] tail)
           "pages 1 and 2, each with its original param + index, in order"))))
@@ -422,15 +422,15 @@
 (deftest refetch-sweep-tail-window
   (testing ":refetch-window 2 sweeps only page 1 (the bounded leading window
             minus the issue-time page 0)"
-    (is (= [["c1" 1]] (state/refetch-sweep-tail (accumulated-3) {:refetch-window 2})))
+    (is (= [["c1" 1]] (rf.resources.state/refetch-sweep-tail (accumulated-3) {:refetch-window 2})))
     (testing ":refetch-window 1 is page-0-only ⇒ empty tail (no sweep)"
-      (is (= [] (state/refetch-sweep-tail (accumulated-3) {:refetch-window 1}))))))
+      (is (= [] (rf.resources.state/refetch-sweep-tail (accumulated-3) {:refetch-window 1}))))))
 
 (deftest refetch-sweep-tail-guard-arms
   (testing "a nil / non-infinite / empty-feed entry yields an empty tail"
-    (is (= [] (state/refetch-sweep-tail nil {:refetch-all-pages? true})))
-    (is (= [] (state/refetch-sweep-tail (state/empty-entry :res/plain) {:refetch-all-pages? true})))
-    (is (= [] (state/refetch-sweep-tail (state/empty-infinite-entry :feed/timeline)
+    (is (= [] (rf.resources.state/refetch-sweep-tail nil {:refetch-all-pages? true})))
+    (is (= [] (rf.resources.state/refetch-sweep-tail (rf.resources.state/empty-entry :res/plain) {:refetch-all-pages? true})))
+    (is (= [] (rf.resources.state/refetch-sweep-tail (rf.resources.state/empty-infinite-entry :feed/timeline)
                                         {:refetch-all-pages? true})))))
 
 ;; ---- entry-begin / advance / clear refetch sweep (R6 cursor) ---------------
@@ -439,36 +439,36 @@
   (testing "the window-preserving DEFAULT arms NO sweep cursor (returns the entry
             unchanged — a plain refetch refreshes page 0 only)"
     (let [e0 (accumulated-3)]
-      (is (identical? e0 (state/entry-begin-refetch-sweep e0 nil)))
-      (is (identical? e0 (state/entry-begin-refetch-sweep e0 {})))
-      (is (not (contains? (state/entry-begin-refetch-sweep e0 nil) :refetch-sweep))))))
+      (is (identical? e0 (rf.resources.state/entry-begin-refetch-sweep e0 nil)))
+      (is (identical? e0 (rf.resources.state/entry-begin-refetch-sweep e0 {})))
+      (is (not (contains? (rf.resources.state/entry-begin-refetch-sweep e0 nil) :refetch-sweep))))))
 
 (deftest entry-begin-refetch-sweep-opt-in-arms-cursor
   (testing ":refetch-all-pages? arms the cursor with pages 1..N-1 (issue-time
             page 0 excluded) WITHOUT touching :data / :status / :revision"
     (let [e0 (accumulated-3)
-          e1 (state/entry-begin-refetch-sweep e0 {:refetch-all-pages? true})]
+          e1 (rf.resources.state/entry-begin-refetch-sweep e0 {:refetch-all-pages? true})]
       (is (= [["c1" 1] ["c2" 2]] (:refetch-sweep e1)) "cursor armed with the sweep tail")
-      (is (= 3 (state/page-count e1)) ":data UNTOUCHED — never truncated")
+      (is (= 3 (rf.resources.state/page-count e1)) ":data UNTOUCHED — never truncated")
       (is (= (:data e0) (:data e1)))
       (is (= (:status e0) (:status e1)))
       (is (= (:revision e0) (:revision e1)) "revision NOT bumped by arming the cursor")))
   (testing ":refetch-window 2 arms a cursor with only page 1"
-    (let [e1 (state/entry-begin-refetch-sweep (accumulated-3) {:refetch-window 2})]
+    (let [e1 (rf.resources.state/entry-begin-refetch-sweep (accumulated-3) {:refetch-window 2})]
       (is (= [["c1" 1]] (:refetch-sweep e1))))))
 
 (deftest entry-advance-and-clear-refetch-sweep
   (testing "advance pops the head leg; clearing the last leg removes the key"
-    (let [e0 (state/entry-begin-refetch-sweep (accumulated-3) {:refetch-all-pages? true})]
-      (is (= ["c1" 1] (state/next-refetch-sweep-leg e0)) "head leg is page 1")
-      (let [e1 (state/entry-advance-refetch-sweep e0)]
+    (let [e0 (rf.resources.state/entry-begin-refetch-sweep (accumulated-3) {:refetch-all-pages? true})]
+      (is (= ["c1" 1] (rf.resources.state/next-refetch-sweep-leg e0)) "head leg is page 1")
+      (let [e1 (rf.resources.state/entry-advance-refetch-sweep e0)]
         (is (= [["c2" 2]] (:refetch-sweep e1)) "page 1 popped, page 2 remains")
-        (is (= ["c2" 2] (state/next-refetch-sweep-leg e1)))
-        (let [e2 (state/entry-advance-refetch-sweep e1)]
+        (is (= ["c2" 2] (rf.resources.state/next-refetch-sweep-leg e1)))
+        (let [e2 (rf.resources.state/entry-advance-refetch-sweep e1)]
           (is (not (contains? e2 :refetch-sweep)) "last leg popped ⇒ cursor removed")
-          (is (nil? (state/next-refetch-sweep-leg e2)) "no next leg on an exhausted sweep")))))
+          (is (nil? (rf.resources.state/next-refetch-sweep-leg e2)) "no next leg on an exhausted sweep")))))
   (testing "clear-refetch-sweep drops an in-progress cursor (a failed/aborted leg stops it)"
-    (let [e0 (state/entry-begin-refetch-sweep (accumulated-3) {:refetch-all-pages? true})]
-      (is (not (contains? (state/clear-refetch-sweep e0) :refetch-sweep)))))
+    (let [e0 (rf.resources.state/entry-begin-refetch-sweep (accumulated-3) {:refetch-all-pages? true})]
+      (is (not (contains? (rf.resources.state/clear-refetch-sweep e0) :refetch-sweep)))))
   (testing "next-refetch-sweep-leg on an unarmed entry is nil"
-    (is (nil? (state/next-refetch-sweep-leg (accumulated-3))))))
+    (is (nil? (rf.resources.state/next-refetch-sweep-leg (accumulated-3))))))

--- a/implementation/resources/test/re_frame/resources_infinite_subs_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_subs_cljs_test.cljc
@@ -22,16 +22,16 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    [re-frame.resources]
-   [re-frame.resources.state :as state]
+   [re-frame.resources.state :as rf.resources.state]
    [re-frame.resources.subs]
    [re-frame.resources.test-support]
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport (replays the real reply-append shape) ------------
 
@@ -39,19 +39,19 @@
 
 (defn- capturing-transport-fixture [f]
   (reset! last-managed-args nil)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
   capturing-transport-fixture)
 
 ;; ---- helpers --------------------------------------------------------------
 
 (defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
-(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
+(defn- entry [scoped-key] (get-in (runtime-db) (rf.resources.state/entry-path scoped-key)))
 
 (defn- reply-success!
   ([data] (reply-success! @last-managed-args data))
@@ -97,7 +97,7 @@
                          page-param (assoc :cursor page-param))}}))
 
 (defn- feed-key [resource]
-  (state/scoped-resource-key :rf.scope/global resource {:filter :recent}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global resource {:filter :recent}))
 
 (defn- q [resource]
   {:resource resource :scope :rf.scope/global :params {:filter :recent}})
@@ -153,7 +153,7 @@
 ;;   test would WRONGLY read an empty/never-loaded feed as `:has-data? true`
 ;;   (and `:rf/resource` would return the self-contradictory
 ;;   `{:status :loading … :has-data? true}`). Both scalar subs must route
-;;   through the shared `state/has-data?` derivation (the same one
+;;   through the shared `rf.resources.state/has-data?` derivation (the same one
 ;;   `:rf.resource/infinite-state` uses), so the two PUBLIC sub families agree.
 ;; ===========================================================================
 
@@ -167,7 +167,7 @@
       (is (= :loading (:status e)) "first load, no usable data ⇒ :loading"))
     (testing "the scalar :rf.resource/has-data? reads FALSE (empty page vector)"
       (is (false? @(rf/subscribe [:rf.resource/has-data? (q :is1b/feed)]))
-          "an empty page vector is NO usable data — must match state/has-data?"))
+          "an empty page vector is NO usable data — must match rf.resources.state/has-data?"))
     (testing "the scalar :rf/resource's :has-data? agrees (and isn't self-contradictory)"
       (let [vm @(rf/subscribe [:rf/resource (q :is1b/feed)])]
         (is (= :loading (:status vm)) "still first-loading")
@@ -347,7 +347,7 @@
   (testing "a non-vector page with NO :page->items raises at the merge site
             (R3, loud over guessing — the runtime-detected error wave-2
             deferred to the merge layer). Asserted at the MERGE layer
-            (`state/merge-pages->items` / the framework-owned `merged-items`
+            (`rf.resources.state/merge-pages->items` / the framework-owned `merged-items`
             projection) — a sub-body throw is otherwise routed to the runtime
             error path, the same level the sub-unresolved-scope test asserts at."
     ;; valid registration (no :page->items declared); the page is enveloped, so
@@ -359,13 +359,13 @@
     (reply-success! (page [:a :b] "c1"))         ;; an enveloped (map) page
     (let [e (entry (feed-key :iserr/feed))]
       (testing "the entry accumulated the enveloped page fine (merge is read-side)"
-        (is (= 1 (state/page-count e))))
+        (is (= 1 (rf.resources.state/page-count e))))
       (testing "the pure merge raises :rf.error/infinite-missing-page-accessor"
         (is (thrown-with-msg?
               #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
               #"infinite-missing-page-accessor"
-              (state/merge-pages->items
-                (:data e) (state/resolve-page->items nil)
+              (rf.resources.state/merge-pages->items
+                (:data e) (rf.resources.state/resolve-page->items nil)
                 :iserr/feed 'rf.resource/items))))
       (testing "the framework-owned merged-items projection raises too"
         (is (thrown-with-msg?
@@ -374,8 +374,8 @@
               (#'re-frame.resources.subs/merged-items e 'rf.resource/items))))
       (testing "the error carries the canonical :rf.error/id discriminator"
         (is (= :rf.error/infinite-missing-page-accessor
-               (try (state/merge-pages->items
-                      (:data e) (state/resolve-page->items nil)
+               (try (rf.resources.state/merge-pages->items
+                      (:data e) (rf.resources.state/resolve-page->items nil)
                       :iserr/feed 'rf.resource/items)
                     nil
                     (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) ex
@@ -390,8 +390,8 @@
             (a re-run with an identical page vector returns the cached merge)"
     (load-page-0! :is8/feed (page [:a :b] "c1"))
     (let [e      (entry (feed-key :is8/feed))
-          first  (state/merge-pages->items
-                   (:data e) (state/resolve-page->items :items)
+          first  (rf.resources.state/merge-pages->items
+                   (:data e) (rf.resources.state/resolve-page->items :items)
                    :is8/feed 'rf.resource/items)
           ;; via the memoised entry path
           m1     (#'re-frame.resources.subs/merged-items e 'rf.resource/items)

--- a/implementation/resources/test/re_frame/resources_invalid_params_redaction_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalid_params_redaction_cljs_test.cljc
@@ -25,22 +25,22 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [clojure.string :as str]
-   [re-frame.privacy :as privacy]
-   [re-frame.resources.registry :as registry]
-   [re-frame.resources.mutation-registry :as mreg]
+   [re-frame.privacy :as rf.privacy]
+   [re-frame.resources.registry :as rf.resources.registry]
+   [re-frame.resources.mutation-registry :as rf.resources.mutation-registry]
    ;; load-bearing side-effecting requires: the façade registers the
    ;; :resource / :mutation registrar kinds; schemas binds the Malli
    ;; validator + explainer + the shared walker / redaction hooks.
    [re-frame.resources]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter})))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter})))
 
 ;; A params schema with a CONFORMING sensitive sibling (`:token`) and a FAILING
 ;; non-sensitive field (`:age` declared `:int`, supplied a string). The failure
@@ -78,7 +78,7 @@
             `:error`"
     (let [spec {:params-schema sensitive-params-schema}
           data (ex->data
-                 #(registry/validate+canonicalize-params
+                 #(rf.resources.registry/validate+canonicalize-params
                     :report/by-account spec bad-params 'rf/ensure))]
       (is (some? data) "the failure throws ex-info")
       (is (= :rf.error/resource-invalid-params (:rf.error/id data))
@@ -86,7 +86,7 @@
       ;; the structural slots stay so the failure stays locatable
       (is (= :report/by-account (:resource-id data)) "resource-id preserved")
       ;; the sensitive param slot is redacted in :params
-      (is (= privacy/redacted-sentinel (get-in data [:params :token]))
+      (is (= rf.privacy/redacted-sentinel (get-in data [:params :token]))
           "the `:sensitive?` :token param slot is redacted in :params")
       (is (= "not-an-int" (get-in data [:params :age]))
           "the non-sensitive failing field rides verbatim (it must, to be diagnostic)")
@@ -100,7 +100,7 @@
     (let [big  (apply str (repeat 500 "x"))
           spec {:params-schema large-params-schema}
           data (ex->data
-                 #(registry/validate+canonicalize-params
+                 #(rf.resources.registry/validate+canonicalize-params
                     :feed/by-cursor spec {:blob big :age "bad"} 'rf/ensure))]
       (is (= :rf.error/resource-invalid-params (:rf.error/id data)))
       (is (contains? (get-in data [:params :blob]) :rf.size/large-elided)
@@ -115,7 +115,7 @@
             so the failure stays diagnostic)"
     (let [spec {:params-schema [:map [:age :int]]}
           data (ex->data
-                 #(registry/validate+canonicalize-params
+                 #(rf.resources.registry/validate+canonicalize-params
                     :plain/r spec {:age "nope"} 'rf/ensure))]
       (is (= :rf.error/resource-invalid-params (:rf.error/id data)))
       (is (= {:age "nope"} (:params data))
@@ -132,13 +132,13 @@
             leak a conforming `:sensitive?` sibling param in the thrown ex-data"
     (let [spec {:params-schema sensitive-params-schema}
           data (ex->data
-                 #(mreg/validate+canonicalize-params
+                 #(rf.resources.mutation-registry/validate+canonicalize-params
                     :acct/update spec bad-params 'rf.mutation/execute))]
       (is (some? data) "the failure throws ex-info")
       (is (= :rf.error/mutation-invalid-params (:rf.error/id data))
           "the canonical mutation invalid-params error id is preserved")
       (is (= :acct/update (:mutation-id data)) "mutation-id preserved")
-      (is (= privacy/redacted-sentinel (get-in data [:params :token]))
+      (is (= rf.privacy/redacted-sentinel (get-in data [:params :token]))
           "the `:sensitive?` :token param slot is redacted in :params")
       (is (= "not-an-int" (get-in data [:params :age]))
           "the non-sensitive failing field rides verbatim")
@@ -150,7 +150,7 @@
             (canonicalization preserved for ordinary invalid params)"
     (let [spec {:params-schema [:map [:age :int]]}
           data (ex->data
-                 #(mreg/validate+canonicalize-params
+                 #(rf.resources.mutation-registry/validate+canonicalize-params
                     :plain/m spec {:age "nope"} 'rf.mutation/execute))]
       (is (= :rf.error/mutation-invalid-params (:rf.error/id data)))
       (is (= {:age "nope"} (:params data))

--- a/implementation/resources/test/re_frame/resources_invalidation_descriptors_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalidation_descriptors_cljs_test.cljc
@@ -36,28 +36,28 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting requires: register the :rf.resource/* +
    ;; :rf.mutation/* events + subs + the generation cofx/fx.
    [re-frame.resources]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.mutation-runtime :as mstate]
-   [re-frame.registrar :as registrar]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.mutation-runtime :as rf.resources.mutation-runtime]
+   [re-frame.registrar :as rf.registrar]
    [re-frame.resources.test-support]
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   [re-frame.error-emit :as error-emit]
-   [re-frame.trace.tooling :as trace-tooling]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   [re-frame.error-emit :as rf.error-emit]
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport ---------------------------------------------------
 
 (def ^:private last-managed-args (atom nil))
 
 (defn- init! []
-  (registrar/clear-kind! :resource-scope)
+  (rf.registrar/clear-kind! :resource-scope)
   ;; the named db-derived viewer-session resolver (EP-0016 D3 canonical form)
   (rf/reg-resource-scope :t/session
     {:inputs {:username [:db [:auth :user :username]]}}
@@ -69,28 +69,28 @@
 
 (defn- capturing-transport-fixture [f]
   (reset! last-managed-args nil)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
-  (fx/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter :init-fn init!}
-       :cljs {:adapter reagent-adapter/adapter :init-fn init!}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter :init-fn init!}
+       :cljs {:adapter rf.adapter.reagent/adapter :init-fn init!}))
   capturing-transport-fixture)
 
 ;; ---- helpers ---------------------------------------------------------------
 
 (defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
-(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
-(defn- entries [] (get-in (runtime-db) (state/entries-path)))
+(defn- entry [scoped-key] (get-in (runtime-db) (rf.resources.state/entry-path scoped-key)))
+(defn- entries [] (get-in (runtime-db) (rf.resources.state/entries-path)))
 
 (defn- reply-success!
   ([args result] (rf/dispatch-sync (conj (:on-success args) {:status :ok :value result})))
   ([args result opts] (rf/dispatch-sync (conj (:on-success args) {:status :ok :value result}) opts)))
 
-(def ^:private global-key (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"}))
-(defn- session-feed-key [u] (state/scoped-resource-key [:rf.scope/session {:username u}] :r/feed {}))
+(def ^:private global-key (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"}))
+(defn- session-feed-key [u] (rf.resources.state/scoped-resource-key [:rf.scope/session {:username u}] :r/feed {}))
 
 (defn- reg-article-resource! []
   (rf/reg-resource :r/article
@@ -132,9 +132,9 @@
   [body-fn]
   (let [seen (atom [])
         k    ::inv-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (= :rf.resource/invalidated (:operation ev)) (swap! seen conj ev))))
-    (try (body-fn) (finally (trace-tooling/unregister-listener! k)))
+    (try (body-fn) (finally (rf.trace.tooling/unregister-listener! k)))
     @seen))
 
 ;; ===========================================================================
@@ -357,12 +357,12 @@
     (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}}))
   (let [seen (atom [])
         k    ::succeeded-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (= :rf.mutation/succeeded (:operation ev)) (swap! seen conj ev))))
     (try
       (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :n1}])
       (reply-success! @last-managed-args {:title "new"})
-      (finally (trace-tooling/unregister-listener! k)))
+      (finally (rf.trace.tooling/unregister-listener! k)))
     (testing "the nil-resolving {:from-db} descriptor is recorded as fail-closed
               :unresolved evidence on the settlement trace's :invalidation facet"
       (is (= 1 (count @seen)))
@@ -389,12 +389,12 @@
     (fn [{:keys [slug]} _] {:request {:method :post :url (str "/a/" slug "/fav")}}))
   (let [seen (atom [])
         k    ::succeeded-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (= :rf.mutation/succeeded (:operation ev)) (swap! seen conj ev))))
     (try
       (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/favorite :params {:slug "w"} :instance :t1}])
       (reply-success! @last-managed-args {:favorited true})
-      (finally (trace-tooling/unregister-listener! k)))
+      (finally (rf.trace.tooling/unregister-listener! k)))
     (testing "the :invalidation facet records both resolved descriptor scopes"
       (let [inv (:invalidation (:tags (first @seen)))]
         (is (= 2 (:descriptor-count inv)))
@@ -421,8 +421,8 @@
   [body-fn]
   (let [seen (atom [])
         k    ::err-recorder]
-    (error-emit/register-error-listener! k (fn [rec] (swap! seen conj rec)))
-    (try (body-fn) (finally (error-emit/unregister-error-listener! k)))
+    (rf.error-emit/register-error-listener! k (fn [rec] (swap! seen conj rec)))
+    (try (body-fn) (finally (rf.error-emit/unregister-error-listener! k)))
     @seen))
 
 (defn- error-id-of
@@ -437,7 +437,7 @@
 (deftest descriptor-typo-concrete-scope-fails-closed-at-settle
   ;; A mutation :invalidates DESCRIPTOR carrying a typo'd CONCRETE reserved
   ;; scope (:rf.scope/glabal) is resolved at settle time through
-  ;; resolve-descriptor-scope -> state/canonicalize-scope — the SAME
+  ;; resolve-descriptor-scope -> rf.resources.state/canonicalize-scope — the SAME
   ;; typo-rejecting path. It fails closed LOUD (no silent wrong-scope blast).
   (reg-article-resource!)
   (rf/reg-mutation :m/save
@@ -492,8 +492,8 @@
   ;; most one; only the scope-agnostic fan-out reaches BOTH.
   (let [sa {:user "amy"}
         sb {:user "bo"}
-        ka (state/scoped-resource-key sa :rx/article {:slug "w"})
-        kb (state/scoped-resource-key sb :rx/article {:slug "w"})]
+        ka (rf.resources.state/scoped-resource-key sa :rx/article {:slug "w"})
+        kb (rf.resources.state/scoped-resource-key sb :rx/article {:slug "w"})]
     (ownerless-stale-load! {:resource :rx/article :scope sa :params {:slug "w"} :owner [:v :a]})
     (ownerless-stale-load! {:resource :rx/article :scope sb :params {:slug "w"} :owner [:v :b]})
     (rf/reg-mutation :m/purge
@@ -507,12 +507,12 @@
       (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}}))
     (let [seen (atom [])
           k    ::succeeded-recorder]
-      (trace-tooling/register-listener!
+      (rf.trace.tooling/register-listener!
         k (fn [ev] (when (= :rf.mutation/succeeded (:operation ev)) (swap! seen conj ev))))
       (try
         (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/purge :params {:slug "w"} :instance :x1}])
         (reply-success! @last-managed-args {:purged true})
-        (finally (trace-tooling/unregister-listener! k)))
+        (finally (rf.trace.tooling/unregister-listener! k)))
       (testing "the scope-agnostic fan-out reached the same tag in BOTH scopes
                 (a scoped descriptor would have reached at most one)"
         (is (some? (:invalidated-at (entry ka))) "amy's session entry marked stale")
@@ -559,18 +559,18 @@
 
 (deftest normalize-lowers-the-public-forms
   (testing "a bare tag-set lowers to ONE :rf.scope/same descriptor"
-    (let [[d & more] (mstate/normalize-invalidation-descriptors
+    (let [[d & more] (rf.resources.mutation-runtime/normalize-invalidation-descriptors
                        #{[:article "w"] [:article-list]} 'test)]
       (is (nil? more))
       (is (= :rf.scope/same (:scope d)))
       (is (= #{[:article "w"] [:article-list]} (:tags d)))))
   (testing "a single descriptor map lowers to a one-element vector"
-    (let [ds (mstate/normalize-invalidation-descriptors
+    (let [ds (rf.resources.mutation-runtime/normalize-invalidation-descriptors
                {:scope :rf.scope/global :tags #{[:x]}} 'test)]
       (is (= 1 (count ds)))
       (is (= :rf.scope/global (:scope (first ds))))))
   (testing "a vector of descriptors lowers each, defaulting omitted :scope to :rf.scope/same"
-    (let [ds (mstate/normalize-invalidation-descriptors
+    (let [ds (rf.resources.mutation-runtime/normalize-invalidation-descriptors
                [{:scope :rf.scope/global :tags #{[:a]}}
                 {:tags #{[:b]} :cross-scope? true}] 'test)]
       (is (= 2 (count ds)))
@@ -578,18 +578,18 @@
       (is (= :rf.scope/same (:scope (second ds))))
       (is (true? (:cross-scope? (second ds))))))
   (testing "a nil / empty result lowers to an empty vector (invalidates nothing)"
-    (is (= [] (mstate/normalize-invalidation-descriptors nil 'test)))
-    (is (= [] (mstate/normalize-invalidation-descriptors #{} 'test)))))
+    (is (= [] (rf.resources.mutation-runtime/normalize-invalidation-descriptors nil 'test)))
+    (is (= [] (rf.resources.mutation-runtime/normalize-invalidation-descriptors #{} 'test)))))
 
 (deftest normalize-fails-closed-on-malformed
   (testing "a non-collection scalar result is a loud fail-closed error"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-invalid-invalidation"
-          (mstate/normalize-invalidation-descriptors :nonsense 'test))))
+          (rf.resources.mutation-runtime/normalize-invalidation-descriptors :nonsense 'test))))
   (testing "a descriptor missing :tags is a loud fail-closed error"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-invalid-invalidation"
-          (mstate/normalize-invalidation-descriptors {:scope :rf.scope/global} 'test)))))
+          (rf.resources.mutation-runtime/normalize-invalidation-descriptors {:scope :rf.scope/global} 'test)))))
 
 ;; ===========================================================================
 ;; rf2-ru73k6 F1 — a LONE vector tag is ONE tag, not a scalar tag-set
@@ -598,22 +598,22 @@
 (deftest lone-vector-tag-normalizes-to-one-tag
   ;; A naive `(set raw)` on a lone vector tag `[:article "w"]` would split it
   ;; into the scalar set `#{:article "w"}` — a tag-set that names nothing and
-  ;; silently matches nothing. The shared `state/normalize-tag-set` (and the
+  ;; silently matches nothing. The shared `rf.resources.state/normalize-tag-set` (and the
   ;; mutation `:invalidates` bare shorthand that uses it) MUST treat a lone
   ;; vector tag as the ONE tag `#{[:article "w"]}`.
   (testing "the shared normalizer wraps a lone vector tag as one tag"
-    (is (= #{[:article "w"]} (state/normalize-tag-set [:article "w"])))
-    (is (= #{[:article-list]} (state/normalize-tag-set [:article-list]))
+    (is (= #{[:article "w"]} (rf.resources.state/normalize-tag-set [:article "w"])))
+    (is (= #{[:article-list]} (rf.resources.state/normalize-tag-set [:article-list]))
         "a single-element marker tag is still one tag, not #{:article-list}"))
   (testing "an existing tag-SET form lowers UNCHANGED (no regression)"
-    (is (= #{[:article "w"]} (state/normalize-tag-set #{[:article "w"]})))
-    (is (= #{[:article "w"]} (state/normalize-tag-set [[:article "w"]]))
+    (is (= #{[:article "w"]} (rf.resources.state/normalize-tag-set #{[:article "w"]})))
+    (is (= #{[:article "w"]} (rf.resources.state/normalize-tag-set [[:article "w"]]))
         "a vector wrapping one tag is the set of that tag")
     (is (= #{[:article "w"] [:article-list]}
-           (state/normalize-tag-set #{[:article "w"] [:article-list]}))))
+           (rf.resources.state/normalize-tag-set #{[:article "w"] [:article-list]}))))
   (testing "the mutation :invalidates bare shorthand lowers a lone vector tag
             to one :rf.scope/same descriptor carrying the one tag"
-    (let [[d & more] (mstate/normalize-invalidation-descriptors [:article "w"] 'test)]
+    (let [[d & more] (rf.resources.mutation-runtime/normalize-invalidation-descriptors [:article "w"] 'test)]
       (is (nil? more))
       (is (= :rf.scope/same (:scope d)))
       (is (= #{[:article "w"]} (:tags d))
@@ -648,7 +648,7 @@
 (deftest lone-vector-tag-direct-invalidate-tags-event-matches
   ;; The SAME tag semantics on the DIRECT :rf.resource/invalidate-tags event:
   ;; a lone vector `:tags [:article "w"]` invalidates the [:article "w"] entry
-  ;; (events.cljc routes through the same shared state/normalize-tag-set).
+  ;; (events.cljc routes through the same shared rf.resources.state/normalize-tag-set).
   (reg-article-resource!)
   (rf/dispatch-sync [:rf.resource/ensure {:resource :r/article :scope :rf.scope/global
                                           :params {:slug "w"} :owner [:v :a]}])
@@ -674,16 +674,16 @@
   ;; (the per-target DESCRIPTOR MAP arm) still lowered `:tags` through a naive
   ;; `(set tags)` — a lone vector tag `{:tags [:article "w"]}` split into the
   ;; scalar set `#{:article "w"}`, silently matching nothing. It must route
-  ;; through the SAME `state/normalize-tag-set` normalizer.
+  ;; through the SAME `rf.resources.state/normalize-tag-set` normalizer.
   (testing "a single descriptor map with a lone vector :tags normalizes to one tag"
-    (let [[d & more] (mstate/normalize-invalidation-descriptors
+    (let [[d & more] (rf.resources.mutation-runtime/normalize-invalidation-descriptors
                        {:tags [:article "w"]} 'test)]
       (is (nil? more))
       (is (= :rf.scope/same (:scope d)))
       (is (= #{[:article "w"]} (:tags d))
           "the lone tag is the single tag, NOT #{:article \"w\"}")))
   (testing "a vector of descriptor maps also normalizes each lone vector :tags"
-    (let [[d1 d2] (mstate/normalize-invalidation-descriptors
+    (let [[d1 d2] (rf.resources.mutation-runtime/normalize-invalidation-descriptors
                     [{:scope :rf.scope/global :tags [:article "w"]}
                      {:tags [:article-list]}] 'test)]
       (is (= #{[:article "w"]} (:tags d1)))
@@ -763,7 +763,7 @@
     (testing "exactly one invalidation pass row"
       (is (= 1 (count invs))))
     (testing ":matched names the global list key (NOT the exempt detail key)"
-      (let [list-key (state/scoped-resource-key :rf.scope/global :r/article-list {})]
+      (let [list-key (rf.resources.state/scoped-resource-key :rf.scope/global :r/article-list {})]
         (is (= [list-key] (:matched row)) "the populate-exempt detail is excluded from :matched")))
     (testing ":refetched / :left-stale reflect the active-owner decision"
       (is (= 1 (:refetched row)) "the active-owner list refetched")

--- a/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
@@ -33,24 +33,24 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
-   [re-frame.frame :as frame]
+   [re-frame.fx :as rf.fx]
+   [re-frame.frame :as rf.frame]
    ;; load-bearing side-effecting require: the façade registers the
    ;; :rf.resource/* events + the timer / work-ledger side-table fx + the
    ;; internal re-check events these tests dispatch through.
    [re-frame.resources]
-   [re-frame.resources.events :as events]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.timers :as timers]
-   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.resources.events :as rf.resources.events]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.timers :as rf.resources.timers]
+   [re-frame.resources.work-ledger :as rf.resources.work-ledger]
    [re-frame.resources.test-support]
    ;; production HTTP fx surface (so the transport feature probe resolves);
    ;; the actual fetch + abort are overridden by capturing no-ops below.
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport + abort + timer-schedule (deterministic) ---------
 
@@ -68,22 +68,22 @@
   `:resources/reset-resources!` post-dispose hook already clears the state /
   work-ledger / timer host caches before this fixture runs, so no per-suite
   reset is repeated here. (The timer-PRIMITIVE tests below keep their own
-  `timers/reset-cache!` calls — those are direct primitive assertions that
+  `rf.resources.timers/reset-cache!` calls — those are direct primitive assertions that
   reset just before arming a real timer, not fixture-level cache hygiene.)"
   [f]
   (reset! aborts [])
   (reset! scheduled-timers [])
-  (fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
-  (fx/reg-fx :rf.http/managed-abort (fn [_ctx work-id] (swap! aborts conj work-id) nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf.fx/reg-fx :rf.http/managed-abort (fn [_ctx work-id] (swap! aborts conj work-id) nil))
   ;; capture the schedule-timers arming (the real fx arms host timers; here we
   ;; record the args so the test stays deterministic — no wall clock)
-  (fx/reg-fx :rf.resource/schedule-timers (fn [_ctx args] (swap! scheduled-timers conj args) nil))
+  (rf.fx/reg-fx :rf.resource/schedule-timers (fn [_ctx args] (swap! scheduled-timers conj args) nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
   capturing-fixture)
 
 ;; ---- helpers --------------------------------------------------------------
@@ -95,7 +95,7 @@
 (defn- entry
   ([scoped-key] (entry :rf/default scoped-key))
   ([frame-id scoped-key]
-   (get-in (runtime-db frame-id) (state/entry-path scoped-key))))
+   (get-in (runtime-db frame-id) (rf.resources.state/entry-path scoped-key))))
 
 (defn- article-spec
   ([] (article-spec {}))
@@ -158,8 +158,8 @@
 (deftest invalidate-tags-is-scoped-by-default
   (rf/reg-resource :iv/article (article-spec) article-spec-request)
   (let [sa {:user "a"} sb {:user "b"}
-        ka (state/scoped-resource-key sa :iv/article {:slug "w"})
-        kb (state/scoped-resource-key sb :iv/article {:slug "w"})]
+        ka (rf.resources.state/scoped-resource-key sa :iv/article {:slug "w"})
+        kb (rf.resources.state/scoped-resource-key sb :iv/article {:slug "w"})]
     (ensure! :iv/article sa "w" [:app :a 1])
     (succeed! ka {:title "A"})
     (ensure! :iv/article sb "w" [:app :b 1])
@@ -179,8 +179,8 @@
 (deftest invalidate-tags-cross-scope-opt-in
   (rf/reg-resource :ivx/article (article-spec) article-spec-request)
   (let [sa {:user "a"} sb {:user "b"}
-        ka (state/scoped-resource-key sa :ivx/article {:slug "w"})
-        kb (state/scoped-resource-key sb :ivx/article {:slug "w"})]
+        ka (rf.resources.state/scoped-resource-key sa :ivx/article {:slug "w"})
+        kb (rf.resources.state/scoped-resource-key sb :ivx/article {:slug "w"})]
     (ensure! :ivx/article sa "w" [:app :a 1])
     (succeed! ka {:title "A"})
     (ensure! :ivx/article sb "w" [:app :b 1])
@@ -209,7 +209,7 @@
             (fail-closed, before any invalidation)"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-cross-scope-scope-conflict"
-          (events/invalidate-tags-handler
+          (rf.resources.events/invalidate-tags-handler
             {:rf.db/runtime {} :rf.frame/id :rf/default}
             [:rf.resource/invalidate-tags
              {:scope {:user "a"} :tags #{[:article "w"]} :cross-scope? true
@@ -223,7 +223,7 @@
   ;; rewrites the SAME :invalidated-at (replay-stable, not the live clock).
   (rf/reg-resource :ivt/article (article-spec) article-spec-request)
   (let [sa {:user "a"}
-        ka (state/scoped-resource-key sa :ivt/article {:slug "w"})
+        ka (rf.resources.state/scoped-resource-key sa :ivt/article {:slug "w"})
         t1 1781078400123
         t2 1781078999999]
     (ensure! :ivt/article sa "w" [:app :a 1])
@@ -265,14 +265,14 @@
             nil-scope match that invalidates nothing or the wrong set)"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-invalidate-scope-required"
-          (events/invalidate-tags-handler
+          (rf.resources.events/invalidate-tags-handler
             (invalidate-cofx {})
             [:rf.resource/invalidate-tags {:tags #{[:article "w"]}}]))))
   (testing "an explicitly nil :scope (not merely absent) is ALSO rejected
             — fail-closed is about the absence of a concrete scope"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-invalidate-scope-required"
-          (events/invalidate-tags-handler
+          (rf.resources.events/invalidate-tags-handler
             (invalidate-cofx {})
             [:rf.resource/invalidate-tags {:scope nil :tags #{[:article "w"]}}])))))
 
@@ -284,8 +284,8 @@
   ;; :cause even when it carries no :scope (scope-agnostic ≠ cause-free).
   (rf/reg-resource :ivxn/article (article-spec) article-spec-request)
   (let [sa {:user "a"} sb {:user "b"}
-        ka (state/scoped-resource-key sa :ivxn/article {:slug "w"})
-        kb (state/scoped-resource-key sb :ivxn/article {:slug "w"})]
+        ka (rf.resources.state/scoped-resource-key sa :ivxn/article {:slug "w"})
+        kb (rf.resources.state/scoped-resource-key sb :ivxn/article {:slug "w"})]
     (ensure! :ivxn/article sa "w" [:app :a 1])
     (succeed! ka {:title "A"})
     (ensure! :ivxn/article sb "w" [:app :b 1])
@@ -311,7 +311,7 @@
             MUST carry the privacy-relevant :cause evidence."
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-cross-scope-cause-required"
-          (events/invalidate-tags-handler
+          (rf.resources.events/invalidate-tags-handler
             (invalidate-cofx {})
             [:rf.resource/invalidate-tags
              {:tags #{[:article "w"]} :cross-scope? true}]))))
@@ -320,7 +320,7 @@
             carries NO :scope, rf2-oo8cv7 closed union)"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-cross-scope-cause-required"
-          (events/invalidate-tags-handler
+          (rf.resources.events/invalidate-tags-handler
             (invalidate-cofx {})
             [:rf.resource/invalidate-tags
              {:tags #{[:article "w"]}
@@ -328,7 +328,7 @@
   (testing "cross-scope WITH a :cause is accepted (the audited escape clears
             the gate) — no throw"
     (is (map?
-          (events/invalidate-tags-handler
+          (rf.resources.events/invalidate-tags-handler
             (invalidate-cofx {})
             [:rf.resource/invalidate-tags
              {:tags #{[:article "w"]} :cross-scope? true
@@ -339,11 +339,11 @@
 (deftest invalidate-tags-rejects-reserved-scope-typo
   (testing "rf2-hosnba / rf2-lzv9xc — a reserved-namespace scope typo
             (:rf.scope/glabal) reaching invalidate-tags fails closed through
-            the shared state/canonicalize-scope path (never a silent wrong
+            the shared rf.resources.state/canonicalize-scope path (never a silent wrong
             cache scope), surfaced as :rf.error/resource-invalid-scope"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
-          (events/invalidate-tags-handler
+          (rf.resources.events/invalidate-tags-handler
             (invalidate-cofx {})
             [:rf.resource/invalidate-tags
              {:scope :rf.scope/glabal :tags #{[:article "w"]}}])))))
@@ -354,7 +354,7 @@
             (:rf.error/resource-non-edn-params)"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-non-edn-params"
-          (events/invalidate-tags-handler
+          (rf.resources.events/invalidate-tags-handler
             (invalidate-cofx {})
             [:rf.resource/invalidate-tags
              {:scope {:cb (fn [])} :tags #{[:article "w"]}}])))))
@@ -368,27 +368,27 @@
             fail-closed at the shared scope-validation boundary"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
-          (events/invalidate-tags-handler
+          (rf.resources.events/invalidate-tags-handler
             (invalidate-cofx {})
             [:rf.resource/invalidate-tags
              {:scope [:rf.scope/global] :tags #{[:article "w"]}}])))))
 
 (deftest clear-scope-rejects-reserved-scope-typo
   (testing "rf2-hosnba / rf2-lzv9xc — clear-scope routes its scope through
-            the shared state/canonicalize-scope path; a reserved-namespace
+            the shared rf.resources.state/canonicalize-scope path; a reserved-namespace
             typo (:rf.scope/glabal) fails closed (a typo can never silently
             clear the WRONG scope — a cross-tenant data wipe)"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
-          (events/clear-scope-handler
+          (rf.resources.events/clear-scope-handler
             (invalidate-cofx {})
             [:rf.resource/clear-scope {:scope :rf.scope/glabal :cause :logout}])))))
 
 (deftest invalidate-tags-refetches-active-leaves-inactive-stale
   (rf/reg-resource :ivr/article (article-spec) article-spec-request)
   (let [scope {:user "u"}
-        kact  (state/scoped-resource-key scope :ivr/article {:slug "active"})
-        kin   (state/scoped-resource-key scope :ivr/article {:slug "inactive"})]
+        kact  (rf.resources.state/scoped-resource-key scope :ivr/article {:slug "active"})
+        kin   (rf.resources.state/scoped-resource-key scope :ivr/article {:slug "inactive"})]
     ;; active-owner entry
     (ensure! :ivr/article scope "active" [:route :r 1])
     (succeed! kact {:title "Active"})
@@ -413,13 +413,13 @@
                                           #{[:article slug] [:rev (:rev data)]})})
                    article-spec-request)
   (let [scope {:user "u"}
-        k     (state/scoped-resource-key scope :tagrep/article {:slug "w"})]
+        k     (rf.resources.state/scoped-resource-key scope :tagrep/article {:slug "w"})]
     (ensure! :tagrep/article scope "w" [:app :t 1])
     (succeed! k {:rev 1})
     (testing "first load produces version-1 tags"
       (is (= #{[:article "w"] [:rev 1]} (:tags (entry k))))
       ;; rf2-9e0tyq — tag-index members are the byte key-id.
-      (is (= #{(state/key-id k)} (get-in (runtime-db) (conj (state/tag-index-path) [:rev 1])))))
+      (is (= #{(rf.resources.state/key-id k)} (get-in (runtime-db) (conj (rf.resources.state/tag-index-path) [:rev 1])))))
     ;; refetch → data now rev 2 → tags REPLACED
     (rf/dispatch-sync [:rf.resource/refetch {:resource :tagrep/article :scope scope
                                              :params {:slug "w"}}])
@@ -429,9 +429,9 @@
               removed (stale list/detail relationships stop receiving
               invalidations)"
       (is (= #{[:article "w"] [:rev 2]} (:tags (entry k))) "entry tags replaced")
-      (is (= #{(state/key-id k)} (get-in (runtime-db) (conj (state/tag-index-path) [:rev 2])))
+      (is (= #{(rf.resources.state/key-id k)} (get-in (runtime-db) (conj (rf.resources.state/tag-index-path) [:rev 2])))
           "new tag indexed")
-      (is (nil? (get-in (runtime-db) (conj (state/tag-index-path) [:rev 1])))
+      (is (nil? (get-in (runtime-db) (conj (rf.resources.state/tag-index-path) [:rev 1])))
           "OLD tag removed from the index (not accumulated)"))))
 
 ;; ===========================================================================
@@ -441,7 +441,7 @@
 (deftest release-owner-does-not-abort-shared-in-flight
   (rf/reg-resource :sh/article (article-spec) article-spec-request)
   (let [scope {:user "u"}
-        k     (state/scoped-resource-key scope :sh/article {:slug "w"})]
+        k     (rf.resources.state/scoped-resource-key scope :sh/article {:slug "w"})]
     ;; two owners ensure the SAME in-flight key (dedupe joins)
     (ensure! :sh/article scope "w" [:route :r 1])
     (ensure! :sh/article scope "w" [:app :x 1])
@@ -453,7 +453,7 @@
                 request does NOT abort it (a remaining owner still needs it)"
         (is (= #{[:app :x 1]} (:active-owners (entry k))) "one owner dropped")
         (is (= [] @aborts) "no abort emitted (work still owned)")
-        (is (= #{[:app :x 1]} (:owners (work-ledger/get-record (runtime-db) wid)))
+        (is (= #{[:app :x 1]} (:owners (rf.resources.work-ledger/get-record (runtime-db) wid)))
             "work record owners updated"))
       (testing "releasing the LAST owner orphans the in-flight attempt →
                 opportunistic abort (best-effort; stale suppression is the
@@ -464,10 +464,10 @@
         ;; (`managed-request-id`), NOT the bare work-id (the managed-HTTP
         ;; registry keys by request-id process-globally; a bare work-id would
         ;; collide across frames).
-        (is (= [(work-ledger/managed-request-id :rf/default wid)] @aborts)
+        (is (= [(rf.resources.work-ledger/managed-request-id :rf/default wid)] @aborts)
             "orphaned in-flight attempt aborted (by qualified request-id)")
         (is (= :abort-requested
-               (:status (work-ledger/get-record (runtime-db) wid)))
+               (:status (rf.resources.work-ledger/get-record (runtime-db) wid)))
             "work row moved to :abort-requested")))))
 
 ;; ---- rf2-v4ygg5: abort-requested / terminal work is NON-joinable ----------
@@ -480,16 +480,16 @@
 (deftest re-ensure-after-owner-release-does-not-join-abort-requested
   (rf/reg-resource :nj/article (article-spec) article-spec-request)
   (let [scope {:user "u"}
-        k     (state/scoped-resource-key scope :nj/article {:slug "w"})]
+        k     (rf.resources.state/scoped-resource-key scope :nj/article {:slug "w"})]
     ;; load attempt in flight, single owner
     (ensure! :nj/article scope "w" [:route :r 1])
     (let [wid1 (:current-work (entry k))
           gen1 (:generation (entry k))]
-      (is (= :running (:status (work-ledger/get-record (runtime-db) wid1))))
+      (is (= :running (:status (rf.resources.work-ledger/get-record (runtime-db) wid1))))
       ;; the LAST owner releases → the work record is marked :abort-requested
       ;; (opportunistic abort issued) but the entry still POINTS at wid1.
       (rf/dispatch-sync [:rf.resource/release-owner {:owner [:route :r 1]}])
-      (is (= :abort-requested (:status (work-ledger/get-record (runtime-db) wid1)))
+      (is (= :abort-requested (:status (rf.resources.work-ledger/get-record (runtime-db) wid1)))
           "released-last-owner work is abort-requested")
       (is (= wid1 (:current-work (entry k)))
           "entry still points at the abort-requested work (stale pointer)")
@@ -499,7 +499,7 @@
         (let [e (entry k)]
           (is (= (inc gen1) (:generation e)) "fresh generation (no dedupe onto dead work)")
           (is (not= wid1 (:current-work e)) "a new work id, not the abort-requested one")
-          (is (= :running (:status (work-ledger/get-record (runtime-db) (:current-work e))))
+          (is (= :running (:status (rf.resources.work-ledger/get-record (runtime-db) (:current-work e))))
               "the new attempt is live")
           (is (contains? (:active-owners e) [:route :r 2])
               "the new owner is attached to the fresh attempt"))))))
@@ -507,7 +507,7 @@
 (deftest re-ensure-after-abort-settle-does-not-join-terminal
   (rf/reg-resource :njt/article (article-spec) article-spec-request)
   (let [scope {:user "u"}
-        k     (state/scoped-resource-key scope :njt/article {:slug "w"})]
+        k     (rf.resources.state/scoped-resource-key scope :njt/article {:slug "w"})]
     (ensure! :njt/article scope "w" [:app :a 1])
     (let [wid1 (:current-work (entry k))
           gen1 (:generation (entry k))]
@@ -515,7 +515,7 @@
       ;; failure seam) settles the entry to a non-error `:idle` and marks the
       ;; work row TERMINAL :cancelled.
       (abort! k)
-      (is (= :cancelled (:status (work-ledger/get-record (runtime-db) wid1)))
+      (is (= :cancelled (:status (rf.resources.work-ledger/get-record (runtime-db) wid1)))
           "the aborted work row is terminal :cancelled")
       (testing "rf2-v4ygg5 — a subsequent ensure does NOT join the terminal
                 work; it starts a fresh generation"
@@ -531,7 +531,7 @@
 (deftest clear-scope-suppresses-late-reply
   (rf/reg-resource :clr/article (article-spec) article-spec-request)
   (let [scope {:user "u"}
-        k     (state/scoped-resource-key scope :clr/article {:slug "w"})]
+        k     (rf.resources.state/scoped-resource-key scope :clr/article {:slug "w"})]
     (ensure! :clr/article scope "w" [:app :c 1])
     (let [stale-wid (:current-work (entry k))]
       (rf/dispatch-sync [:rf.resource/clear-scope {:scope scope :cause :logout}])
@@ -561,7 +561,7 @@
 (deftest succeeded-arms-stale-and-gc-timers
   (rf/reg-resource :tm/article (article-spec {:stale-after-ms 60000 :gc-after-ms 300000}) article-spec-request)
   (let [scope {:user "u"}
-        k     (state/scoped-resource-key scope :tm/article {:slug "w"})]
+        k     (rf.resources.state/scoped-resource-key scope :tm/article {:slug "w"})]
     (reset! scheduled-timers [])
     (ensure! :tm/article scope "w" [:app :tm 1])
     (succeed! k {:title "W"})
@@ -583,7 +583,7 @@
   ;; time-stale) — so the settle's :timers :stale delay stays nil.
   (rf/reg-resource :np/article (article-spec) article-spec-request) ;; no :stale-after-ms / :gc-after-ms
   (let [scope {:user "u"}
-        k     (state/scoped-resource-key scope :np/article {:slug "w"})]
+        k     (rf.resources.state/scoped-resource-key scope :np/article {:slug "w"})]
     (reset! scheduled-timers [])
     (ensure! :np/article scope "w" [:app :np 1])
     (succeed! k {:title "W"})
@@ -602,7 +602,7 @@
   ;; lingers indefinitely, by declared intent rather than by omission).
   (rf/reg-resource :npn/article (article-spec {:gc-after-ms :never}) article-spec-request)
   (let [scope {:user "u"}
-        k     (state/scoped-resource-key scope :npn/article {:slug "w"})]
+        k     (rf.resources.state/scoped-resource-key scope :npn/article {:slug "w"})]
     (reset! scheduled-timers [])
     (ensure! :npn/article scope "w" [:app :npn 1])
     (succeed! k {:title "W"})
@@ -612,43 +612,43 @@
 (deftest timer-side-table-is-host-side-not-frame-state
   (testing "Spec 016 §Stale and GC scheduling — timers live in a host SIDE
             TABLE keyed by [frame-id resource-key kind], NOT in frame-state"
-    (timers/reset-cache!)
+    (rf.resources.timers/reset-cache!)
     ;; rf2-9e0tyq — the side-table key's resource-key element is the CEDN-1
     ;; byte `key-id` (so a list- and a vector-params resource never share a
     ;; timer slot). The dispatched recheck event still carries the vector.
     (let [k    [:rf.scope/global :t/x {:id 1}]
-          k-id (state/key-id k)]
+          k-id (rf.resources.state/key-id k)]
       ;; arm a real (long) timer so it does not fire during the test
-      (timers/schedule! :rf/default k timers/gc-kind 1000000)
-      (is (contains? @timers/timer-table [:rf/default k-id timers/gc-kind])
+      (rf.resources.timers/schedule! :rf/default k rf.resources.timers/gc-kind 1000000)
+      (is (contains? @rf.resources.timers/timer-table [:rf/default k-id rf.resources.timers/gc-kind])
           "the timer handle lives in the module-level side table")
       ;; the durable runtime-db carries NO timer handle
       (is (not (contains? (runtime-db) :rf.runtime/resources-timers))
           "no timer state leaked into runtime-db")
-      (timers/cancel! :rf/default k timers/gc-kind)
-      (is (not (contains? @timers/timer-table [:rf/default k-id timers/gc-kind]))
+      (rf.resources.timers/cancel! :rf/default k rf.resources.timers/gc-kind)
+      (is (not (contains? @rf.resources.timers/timer-table [:rf/default k-id rf.resources.timers/gc-kind]))
           "cancel! drops the handle"))))
 
 (deftest timer-reschedule-cancels-prior
   (testing "Spec 016 — a re-load reschedules (cancel-then-arm), not accumulate"
-    (timers/reset-cache!)
+    (rf.resources.timers/reset-cache!)
     (let [k    [:rf.scope/global :t/y {:id 1}]
-          k-id (state/key-id k)]
-      (timers/schedule! :rf/default k timers/stale-kind 1000000)
-      (let [h1 (get @timers/timer-table [:rf/default k-id timers/stale-kind])]
-        (timers/schedule! :rf/default k timers/stale-kind 1000000)
-        (let [h2 (get @timers/timer-table [:rf/default k-id timers/stale-kind])]
+          k-id (rf.resources.state/key-id k)]
+      (rf.resources.timers/schedule! :rf/default k rf.resources.timers/stale-kind 1000000)
+      (let [h1 (get @rf.resources.timers/timer-table [:rf/default k-id rf.resources.timers/stale-kind])]
+        (rf.resources.timers/schedule! :rf/default k rf.resources.timers/stale-kind 1000000)
+        (let [h2 (get @rf.resources.timers/timer-table [:rf/default k-id rf.resources.timers/stale-kind])]
           (is (not= h1 h2) "a fresh handle replaced the prior one")
           (is (= 1 (count (filter (fn [[[_ rk kind] _]]
-                                    (and (= rk k-id) (= kind timers/stale-kind)))
-                                  @timers/timer-table)))
+                                    (and (= rk k-id) (= kind rf.resources.timers/stale-kind)))
+                                  @rf.resources.timers/timer-table)))
               "exactly one live stale timer per [key kind]")))
-      (timers/cancel-for-key! :rf/default k))))
+      (rf.resources.timers/cancel-for-key! :rf/default k))))
 
 (deftest gc-fired-rechecks-before-removing
   (rf/reg-resource :gc/article (article-spec {:gc-after-ms 1000}) article-spec-request)
   (let [scope {:user "u"}
-        k     (state/scoped-resource-key scope :gc/article {:slug "w"})]
+        k     (rf.resources.state/scoped-resource-key scope :gc/article {:slug "w"})]
     ;; load + release owner → owner-free + idle → GC-eligible
     (ensure! :gc/article scope "w" [:app :gc 1])
     (succeed! k {:title "W"})
@@ -667,7 +667,7 @@
   ;; collects it.
   (rf/reg-resource :gce/article (article-spec {:gc-after-ms 5000}) article-spec-request)
   (let [scope {:user "u"}
-        k     (state/scoped-resource-key scope :gce/article {:slug "w"})]
+        k     (rf.resources.state/scoped-resource-key scope :gce/article {:slug "w"})]
     (reset! scheduled-timers [])
     (ensure! :gce/article scope "w" [:app :gce 1])
     (fail! k :transient-500)   ;; first load fails → :error (no usable data)
@@ -701,7 +701,7 @@
   ;; GC re-check collects it.
   (rf/reg-resource :gca/article (article-spec {:gc-after-ms 5000}) article-spec-request)
   (let [scope {:user "u"}
-        k     (state/scoped-resource-key scope :gca/article {:slug "w"})]
+        k     (rf.resources.state/scoped-resource-key scope :gca/article {:slug "w"})]
     (reset! scheduled-timers [])
     (ensure! :gca/article scope "w" [:app :gca 1])
     (abort! k)   ;; first-load aborted → :idle (no usable data)
@@ -732,7 +732,7 @@
   ;; double-arm) — mirrors `background-refresh-failure-does-not-rearm-gc`.
   (rf/reg-resource :gcra/article (article-spec {:gc-after-ms 5000}) article-spec-request)
   (let [scope {:user "u"}
-        k     (state/scoped-resource-key scope :gcra/article {:slug "w"})]
+        k     (rf.resources.state/scoped-resource-key scope :gcra/article {:slug "w"})]
     (ensure! :gcra/article scope "w" [:route :r 1])
     (succeed! k {:title "W"})        ;; first load succeeds → :loaded, GC armed
     ;; a background refetch that is then aborted (entry keeps data, returns to
@@ -757,7 +757,7 @@
   ;; change, so the refresh-failure settle re-arms NOTHING (no double-arm).
   (rf/reg-resource :gcb/article (article-spec {:gc-after-ms 5000}) article-spec-request)
   (let [scope {:user "u"}
-        k     (state/scoped-resource-key scope :gcb/article {:slug "w"})]
+        k     (rf.resources.state/scoped-resource-key scope :gcb/article {:slug "w"})]
     (ensure! :gcb/article scope "w" [:route :r 1])
     (succeed! k {:title "W"})        ;; first load succeeds → :loaded, GC armed
     ;; a background refetch that fails (entry keeps data, returns to :loaded)
@@ -778,7 +778,7 @@
 (deftest gc-fired-skips-when-owner-reattached
   (rf/reg-resource :gck/article (article-spec {:gc-after-ms 1000}) article-spec-request)
   (let [scope {:user "u"}
-        k     (state/scoped-resource-key scope :gck/article {:slug "w"})]
+        k     (rf.resources.state/scoped-resource-key scope :gck/article {:slug "w"})]
     (ensure! :gck/article scope "w" [:app :gck 1])
     (succeed! k {:title "W"})
     (testing "Spec 016 §Stale and GC scheduling — a fired GC timer RE-CHECKS
@@ -791,7 +791,7 @@
 (deftest gc-fired-skips-when-in-flight
   (rf/reg-resource :gcf/article (article-spec {:gc-after-ms 1000}) article-spec-request)
   (let [scope {:user "u"}
-        k     (state/scoped-resource-key scope :gcf/article {:slug "w"})]
+        k     (rf.resources.state/scoped-resource-key scope :gcf/article {:slug "w"})]
     ;; ensure without ever succeeding → in flight (owner released, still
     ;; :current-work)
     (ensure! :gcf/article scope "w" [:app :gcf 1])
@@ -808,7 +808,7 @@
 (deftest gc-skip-while-owned-reschedules-and-collects-after-release
   (rf/reg-resource :gcr/article (article-spec {:gc-after-ms 1000}) article-spec-request)
   (let [scope {:user "u"}
-        k     (state/scoped-resource-key scope :gcr/article {:slug "w"})]
+        k     (rf.resources.state/scoped-resource-key scope :gcr/article {:slug "w"})]
     (ensure! :gcr/article scope "w" [:app :gcr 1])
     (succeed! k {:title "W"})
     (reset! scheduled-timers [])
@@ -832,7 +832,7 @@
 (deftest gc-skip-while-in-flight-reschedules-and-collects-after-settle
   (rf/reg-resource :gci/article (article-spec {:gc-after-ms 1000}) article-spec-request)
   (let [scope {:user "u"}
-        k     (state/scoped-resource-key scope :gci/article {:slug "w"})]
+        k     (rf.resources.state/scoped-resource-key scope :gci/article {:slug "w"})]
     ;; in flight + owner-free (owner released while loading)
     (ensure! :gci/article scope "w" [:app :gci 1])
     (rf/dispatch-sync [:rf.resource/release-owner {:owner [:app :gci 1]}])
@@ -863,7 +863,7 @@
 
 (deftest gc-skip-no-entry-does-not-reschedule
   (rf/reg-resource :gcn/article (article-spec {:gc-after-ms 1000}) article-spec-request)
-  (let [k (state/scoped-resource-key {:user "u"} :gcn/article {:slug "gone"})]
+  (let [k (rf.resources.state/scoped-resource-key {:user "u"} :gcn/article {:slug "gone"})]
     (reset! scheduled-timers [])
     (testing "rf2-07693y — a GC timer firing for an entry that no longer exists
               (removed / cleared) does NOT reschedule (nothing to collect)"
@@ -874,7 +874,7 @@
 (deftest stale-fired-rechecks-durable-fact-no-write
   (rf/reg-resource :sf/article (article-spec {:stale-after-ms 60000}) article-spec-request)
   (let [scope {:user "u"}
-        k     (state/scoped-resource-key scope :sf/article {:slug "w"})]
+        k     (rf.resources.state/scoped-resource-key scope :sf/article {:slug "w"})]
     (ensure! :sf/article scope "w" [:app :sf 1])
     (succeed! k {:title "W"})
     (let [before (entry k)]
@@ -888,19 +888,19 @@
 (deftest frame-destroy-cancels-resource-timers
   (rf/reg-resource :fd/article (article-spec {:stale-after-ms 60000 :gc-after-ms 300000}) article-spec-request)
   (let [fa :fd/frame-a
-        k  (state/scoped-resource-key {:user "u"} :fd/article {:slug "w"})]
+        k  (rf.resources.state/scoped-resource-key {:user "u"} :fd/article {:slug "w"})]
     (rf/make-frame {:id fa :doc "frame-destroy timer frame"})
     ;; arm two long timers in frame A directly via the side-table primitive
-    (timers/schedule! fa k timers/stale-kind 1000000)
-    (timers/schedule! fa k timers/gc-kind 1000000)
-    (is (= 2 (count (filter (fn [[[fid _ _] _]] (= fid fa)) @timers/timer-table)))
+    (rf.resources.timers/schedule! fa k rf.resources.timers/stale-kind 1000000)
+    (rf.resources.timers/schedule! fa k rf.resources.timers/gc-kind 1000000)
+    (is (= 2 (count (filter (fn [[[fid _ _] _]] (= fid fa)) @rf.resources.timers/timer-table)))
         "two timers armed for frame A")
     (testing "Spec 016 §Stale and GC scheduling — frame destroy cancels ALL
               of the frame's resource timers (composed into the single
               :resources/on-frame-destroyed! teardown hook, not a second
               teardown path)"
-      (frame/destroy-frame! fa)
-      (is (= 0 (count (filter (fn [[[fid _ _] _]] (= fid fa)) @timers/timer-table)))
+      (rf.frame/destroy-frame! fa)
+      (is (= 0 (count (filter (fn [[[fid _ _] _]] (= fid fa)) @rf.resources.timers/timer-table)))
           "frame A's timers cancelled + dropped on destroy"))))
 
 ;; ===========================================================================
@@ -910,17 +910,17 @@
 (deftest remove-cancels-instance-timers
   (rf/reg-resource :rmt/article (article-spec {:gc-after-ms 1000}) article-spec-request)
   (let [scope {:user "u"}
-        k     (state/scoped-resource-key scope :rmt/article {:slug "w"})]
+        k     (rf.resources.state/scoped-resource-key scope :rmt/article {:slug "w"})]
     (ensure! :rmt/article scope "w" [:app :rmt 1])
     (succeed! k {:title "W"})
     ;; arm a real long timer so remove has something to cancel. rf2-9e0tyq —
     ;; the timer side-table key's resource-key element is the byte key-id.
-    (timers/schedule! :rf/default k timers/gc-kind 1000000)
-    (is (contains? @timers/timer-table [:rf/default (state/key-id k) timers/gc-kind]))
+    (rf.resources.timers/schedule! :rf/default k rf.resources.timers/gc-kind 1000000)
+    (is (contains? @rf.resources.timers/timer-table [:rf/default (rf.resources.state/key-id k) rf.resources.timers/gc-kind]))
     (testing "Spec 016 §Events / §Stale and GC scheduling — :rf.resource/remove
               evicts the instance AND cancels its advisory timers"
       (rf/dispatch-sync [:rf.resource/remove {:resource :rmt/article :scope scope
                                               :params {:slug "w"}}])
       (is (nil? (entry k)) "instance removed")
-      (is (not (contains? @timers/timer-table [:rf/default (state/key-id k) timers/gc-kind]))
+      (is (not (contains? @rf.resources.timers/timer-table [:rf/default (rf.resources.state/key-id k) rf.resources.timers/gc-kind]))
           "its GC timer cancelled"))))

--- a/implementation/resources/test/re_frame/resources_lifecycle_trace_ops_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_lifecycle_trace_ops_cljs_test.cljc
@@ -29,21 +29,21 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting require: the façade registers the
    ;; :rf.resource/* events + subs + the generation cofx/fx these tests
    ;; dispatch.
    [re-frame.resources]
-   [re-frame.resources.ssr :as ssr]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.resources.ssr :as rf.resources.ssr]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.work-ledger :as rf.resources.work-ledger]
    [re-frame.resources.test-support]
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   [re-frame.trace.tooling :as trace-tooling]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport + trace recorder ---------------------------------
 
@@ -54,13 +54,13 @@
   :loading entry write + lower-fx are deterministic and no real fetch fires."
   [f]
   (reset! last-managed-args nil)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
   capturing-transport-fixture)
 
 (defn- record-resource-traces!
@@ -70,13 +70,13 @@
   [body-fn]
   (let [seen (atom [])
         k    ::resource-trace-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev]
           (when (and (keyword? (:operation ev))
                      (= "rf.resource" (namespace (:operation ev))))
             (swap! seen conj ev))))
     (try (body-fn)
-         (finally (trace-tooling/unregister-listener! k)))
+         (finally (rf.trace.tooling/unregister-listener! k)))
     @seen))
 
 (defn- ops
@@ -102,7 +102,7 @@
     {:request {:method :get :url (str "/api/articles/" slug)}}))
 
 (defn- entry [scoped-key]
-  (get-in (:rf.db/runtime (rf/frame-state-value :rf/default)) (state/entry-path scoped-key)))
+  (get-in (:rf.db/runtime (rf/frame-state-value :rf/default)) (rf.resources.state/entry-path scoped-key)))
 
 ;; ===========================================================================
 ;; 1. :rf.resource/registered — first-time-only, frame-agnostic
@@ -143,7 +143,7 @@
   (rf/reg-resource :oa/article (article-spec) article-spec-request)
   (testing "an ensure that fresh-loads AND attaches a NEW owner emits
             :rf.resource/owner-attached (:joined-in-flight? false)"
-    (let [scoped-key (state/scoped-resource-key :rf.scope/global :oa/article {:slug "w"})
+    (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :oa/article {:slug "w"})
           traces (record-resource-traces!
                    #(rf/dispatch-sync
                       [:rf.resource/ensure {:resource :oa/article :scope :rf.scope/global
@@ -213,11 +213,11 @@
         k-meta  [:rf.scope/global :h/meta  {:slug "m"}]]
     ;; rf2-9e0tyq — `:entries` is keyed on the byte `key-id`; each entry carries
     ;; its own `:resource/key` (the refetch plan reads it for :resource-id).
-    {state/resources-key
+    {rf.resources.state/resources-key
      {:entries
-      {(state/key-id k-fresh) {:resource/key k-fresh :status :loaded :data {:x 1} :loaded-at (- clock 10) :stale-at (+ clock 10000)}
-       (state/key-id k-stale) {:resource/key k-stale :status :loaded :data {:y 2} :loaded-at (- clock 20000) :stale-at (- clock 1)}
-       (state/key-id k-meta)  {:resource/key k-meta  :status :loaded :data nil    :loaded-at (- clock 10) :stale-at (+ clock 10000)}}}}))
+      {(rf.resources.state/key-id k-fresh) {:resource/key k-fresh :status :loaded :data {:x 1} :loaded-at (- clock 10) :stale-at (+ clock 10000)}
+       (rf.resources.state/key-id k-stale) {:resource/key k-stale :status :loaded :data {:y 2} :loaded-at (- clock 20000) :stale-at (- clock 1)}
+       (rf.resources.state/key-id k-meta)  {:resource/key k-meta  :status :loaded :data nil    :loaded-at (- clock 10) :stale-at (+ clock 10000)}}}}))
 
 (deftest hydrate-refetch-emits-per-plan-entry
   (testing "hydrate-refetch-plan emits one :rf.resource/hydrate-refetch per
@@ -226,7 +226,7 @@
     (let [clock  5000
           rdb    (hydrated-runtime-db clock)
           traces (record-resource-traces!
-                   #(ssr/hydrate-refetch-plan rdb clock :rf/default))
+                   #(rf.resources.ssr/hydrate-refetch-plan rdb clock :rf/default))
           evs    (by-op traces :rf.resource/hydrate-refetch)
           reasons (into {} (map (juxt #(get-in % [:tags :resource-id])
                                       #(get-in % [:tags :reason]))) evs)]
@@ -246,7 +246,7 @@
   (testing "a stale/superseded reply emits :rf.resource/stale-suppressed and
             NEVER :rf.resource/work-suppressed (folded into stale-suppressed —
             there is exactly one suppression op)"
-    (let [scoped-key (state/scoped-resource-key :rf.scope/global :sp/article {:slug "w"})]
+    (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :sp/article {:slug "w"})]
       (rf/dispatch-sync
         [:rf.resource/ensure {:resource :sp/article :scope :rf.scope/global
                               :params {:slug "w"} :owner [:app :sp 1]}])
@@ -285,7 +285,7 @@
             the shared substrate, with the carried-vs-current generation pair
             on the production :rf.resource/stale-suppressed trace; the app
             target does NOT run (no entry write) and the ledger is :suppressed"
-    (let [scoped-key (state/scoped-resource-key :rf.scope/global :rev/article {:slug "w"})]
+    (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :rev/article {:slug "w"})]
       (rf/dispatch-sync
         [:rf.resource/ensure {:resource :rev/article :scope :rf.scope/global
                               :params {:slug "w"} :owner [:app :rev 1]}])
@@ -332,7 +332,7 @@
           (is (= 2 (:generation e)) "the stale reply did not touch the newer entry")
           (is (not= {:stale "data"} (:data e)) "stale data was NOT written"))
         ;; (3) the ledger row settles terminal :suppressed.
-        (is (= :suppressed (:status (work-ledger/get-record
+        (is (= :suppressed (:status (rf.resources.work-ledger/get-record
                                       (:rf.db/runtime (rf/frame-state-value :rf/default)) wid1)))
             "the work row settled terminal :suppressed")))))
 
@@ -344,7 +344,7 @@
             cached value: it emits :rf.resource/cache-hit and starts NO new
             load (Spec 016 §Lifecycle is an FSM / §Restore — fresh-skip,
             rf2-hsa0sv)"
-    (let [scoped-key (state/scoped-resource-key :rf.scope/global :ch/article {:slug "w"})]
+    (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :ch/article {:slug "w"})]
       ;; load it once, then settle to :loaded (fresh: stale-after 60s)
       (rf/dispatch-sync
         [:rf.resource/ensure {:resource :ch/article :scope :rf.scope/global
@@ -389,7 +389,7 @@
   (testing "a STALE :loaded entry STILL refetches on the next ensure —
             fresh-skip must NOT swallow a stale refresh (negative case,
             rf2-hsa0sv)"
-    (let [scoped-key (state/scoped-resource-key :rf.scope/global :ch/stale {:slug "w"})]
+    (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :ch/stale {:slug "w"})]
       (rf/dispatch-sync
         [:rf.resource/ensure {:resource :ch/stale :scope :rf.scope/global
                               :params {:slug "w"} :owner [:app :st 1]}])

--- a/implementation/resources/test/re_frame/resources_machine_owner_release_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_machine_owner_release_cljs_test.cljc
@@ -37,19 +37,19 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting requires: the resources façade registers the
    ;; :rf.resource/* events; machines wires the machine grammar + the
    ;; :rf.machine/start / :rf.machine/destroy fxs (and the release-on-destroy
    ;; dispatch under test).
    [re-frame.resources]
-   [re-frame.resources.state :as state]
+   [re-frame.resources.state :as rf.resources.state]
    [re-frame.resources.test-support]
    [re-frame.machines]
-   [re-frame.machines.paths :as machine-paths]
+   [re-frame.machines.paths :as rf.machines.paths]
    [re-frame.schemas]
    [re-frame.http.managed]
-   [re-frame.test-support :as core-test-support]
+   [re-frame.test-support :as rf.test-support]
    #?@(:clj  [[re-frame.substrate.plain-atom :as substrate]]
        :cljs [[re-frame.adapter.reagent :as substrate]])))
 
@@ -65,10 +65,10 @@
 (defn- capturing-fixture
   [f]
   (reset! cancelled-poll [])
-  (fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
-  (fx/reg-fx :rf.http/managed-abort (fn [_ctx _wid] nil))
-  (fx/reg-fx :rf.resource/schedule-timers (fn [_ctx _args] nil))
-  (fx/reg-fx :rf.resource/cancel-poll-timers
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf.fx/reg-fx :rf.http/managed-abort (fn [_ctx _wid] nil))
+  (rf.fx/reg-fx :rf.resource/schedule-timers (fn [_ctx _args] nil))
+  (rf.fx/reg-fx :rf.resource/cancel-poll-timers
              (fn [_ctx args] (swap! cancelled-poll conj args) nil))
   ;; A poll-enabled, actively-owned resource. The machine actor ensures it on
   ;; entry under its `[:machine actor-id]` owner; on actor destroy the owner
@@ -85,7 +85,7 @@
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     {:adapter substrate/adapter})
   capturing-fixture)
 
@@ -98,20 +98,20 @@
 
 (defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
 (defn- slug-key [slug]
-  (state/scoped-resource-key scope :art/by-slug {:slug slug}))
-(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
+  (rf.resources.state/scoped-resource-key scope :art/by-slug {:slug slug}))
+(defn- entry [scoped-key] (get-in (runtime-db) (rf.resources.state/entry-path scoped-key)))
 (defn- machine-snapshot [id]
-  (get-in (runtime-db) (machine-paths/snapshot-path id)))
+  (get-in (runtime-db) (rf.machines.paths/snapshot-path id)))
 (defn- owner-index []
   ;; :entries is keyed on the opaque byte key-id; map the owner-index members
   ;; back to scoped-key vectors for readable assertions (mirrors the
   ;; scoped-owner-lifecycle suite's owner-index helper).
   (let [rdb    (runtime-db)
-        es     (get-in rdb (state/entries-path))
+        es     (get-in rdb (rf.resources.state/entries-path))
         id->sk (into {} (map (fn [[k-id e]] [k-id (:resource/key e)])) es)]
     (into {} (map (fn [[owner members]]
                     [owner (into #{} (map #(get id->sk % %)) members)]))
-          (get-in rdb (state/owner-index-path)))))
+          (get-in rdb (rf.resources.state/owner-index-path)))))
 (defn- succeed! [scoped-key data]
   (let [e (entry scoped-key)]
     (rf/dispatch-sync [:rf.resource.internal/succeeded

--- a/implementation/resources/test/re_frame/resources_managed_http_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_managed_http_cljs_test.cljc
@@ -32,15 +32,15 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
-   [re-frame.frame :as frame]
+   [re-frame.fx :as rf.fx]
+   [re-frame.frame :as rf.frame]
    ;; load-bearing side-effecting requires: register the :rf.resource/*
    ;; events + subs + the generation cofx/fx these tests dispatch.
    [re-frame.resources]
-   [re-frame.resources.registry :as registry]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.transport.http :as http]
-   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.resources.registry :as rf.resources.registry]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.transport.http :as rf.resources.transport.http]
+   [re-frame.resources.work-ledger :as rf.resources.work-ledger]
    [re-frame.resources.test-support]
    ;; production HTTP fx surface (so the transport feature probe resolves);
    ;; the actual fetch is overridden by the capturing reply stub below.
@@ -48,11 +48,11 @@
    ;; managed-HTTP in-flight registry (NOT a captured no-op abort), so the
    ;; abort-by-request-id seam (`:http/abort-in-flight!`) runs end-to-end.
    [re-frame.http.managed]
-   [re-frame.http.registry :as http-registry]
+   [re-frame.http.registry :as rf.http.registry]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport that REPLAYS the real reply-append shape ----------
 ;;
@@ -79,15 +79,15 @@
   (reset! last-managed-args nil)
   ;; rf2-rak684 — the in-flight registry is module-level host state; clear any
   ;; entry a prior test seeded so the teardown-abort regressions start clean.
-  (http-registry/clear-all-in-flight!)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.http.registry/clear-all-in-flight!)
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
   (f)
-  (http-registry/clear-all-in-flight!))
+  (rf.http.registry/clear-all-in-flight!))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
   capturing-transport-fixture)
 
 ;; ---- helpers --------------------------------------------------------------
@@ -99,7 +99,7 @@
 (defn- entry
   ([scoped-key] (entry :rf/default scoped-key))
   ([frame-id scoped-key]
-   (get-in (runtime-db frame-id) (state/entry-path scoped-key))))
+   (get-in (runtime-db frame-id) (rf.resources.state/entry-path scoped-key))))
 
 (defn- reply-success!
   "Dispatch the captured `:on-success` reply with the transport's success
@@ -136,7 +136,7 @@
     (doseq [reserved [:request-id :on-success :on-failure]]
       (is (thrown-with-msg?
             #?(:clj Throwable :cljs js/Error) #"resource-reserved-request-key"
-            (http/build-managed-args
+            (rf.resources.transport.http/build-managed-args
               {:http-args    {:request {:url "/x"} reserved :sneaky}
                :request-id   [:rf.work/resource [:rf.scope/global :r {}] 1]
                :work-id      [:rf.work/resource [:rf.scope/global :r {}] 1]
@@ -182,7 +182,7 @@
                       :accept  identity
                       :retry   {:on #{:rf.http/http-5xx}
                                 :max-attempts 3}}))
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :lo/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :lo/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :lo/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:app :lo 1]}])
@@ -215,7 +215,7 @@
 
 (deftest success-reply-reads-decoded-value-from-transport-result
   (rf/reg-resource :sv/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :sv/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :sv/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :sv/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:app :sv 1]}])
@@ -231,7 +231,7 @@
 
 (deftest failure-reply-reads-envelope-from-transport-result
   (rf/reg-resource :fe/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :fe/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :fe/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :fe/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:app :fe 1]}])
@@ -245,7 +245,7 @@
 
 (deftest background-refresh-failure-keeps-data-via-transport-shape
   (rf/reg-resource :bg/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :bg/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :bg/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :bg/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:app :bg 1]}])
@@ -271,7 +271,7 @@
 
 (deftest stale-transport-reply-suppressed
   (rf/reg-resource :sp/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :sp/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :sp/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :sp/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:app :sp 1]}])
@@ -311,7 +311,7 @@
 
 (deftest first-load-abort-settles-non-error-not-failure
   (rf/reg-resource :ab1/article (article-spec) article-spec-request)
-  (let [k (state/scoped-resource-key :rf.scope/global :ab1/article {:slug "w"})]
+  (let [k (rf.resources.state/scoped-resource-key :rf.scope/global :ab1/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :ab1/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:app :ab1 1]}])
@@ -329,13 +329,13 @@
           (is (nil? (:data e)) "no data (the load was cancelled)")
           (is (nil? (:current-work e)) "current-work cleared")))
       (testing "the work row settles terminal :cancelled (not :failed)"
-        (let [rec (work-ledger/get-record (runtime-db) wid)]
+        (let [rec (rf.resources.work-ledger/get-record (runtime-db) wid)]
           (is (= :cancelled (:status rec)) "work row :cancelled")
           (is (= :aborted (:reason (:outcome rec)))))))))
 
 (deftest refresh-abort-preserves-prior-loaded-data
   (rf/reg-resource :ab2/article (article-spec) article-spec-request)
-  (let [k (state/scoped-resource-key :rf.scope/global :ab2/article {:slug "w"})]
+  (let [k (rf.resources.state/scoped-resource-key :rf.scope/global :ab2/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :ab2/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:app :ab2 1]}])
@@ -348,7 +348,7 @@
           ;; the revision the in-flight refetch sits at (load START does not bump
           ;; :revision; entry-start-load). An optimistic snapshot taken here would
           ;; record this revision (rf2-mx0w2o).
-          rev-before (state/entry-revision (entry k))]
+          rev-before (rf.resources.state/entry-revision (entry k))]
       (testing "rf2-z70ujl — a background-REFRESH abort returns to :loaded,
                 PRESERVES prior :data, and records NO :refresh-error (a
                 cancelled refresh leaves the last-known-good value intact)"
@@ -364,14 +364,14 @@
                 a later optimistic rollback whose snapshot sat at the in-flight
                 revision DETECTS the conflict instead of resurrecting the stale
                 in-flight :current-work pointer"
-        (is (= (inc rev-before) (state/entry-revision (entry k)))
+        (is (= (inc rev-before) (rf.resources.state/entry-revision (entry k)))
             "the abort settle moved the per-entry write identity"))
       (testing "the work row settles terminal :cancelled"
-        (is (= :cancelled (:status (work-ledger/get-record (runtime-db) wid))))))))
+        (is (= :cancelled (:status (rf.resources.work-ledger/get-record (runtime-db) wid))))))))
 
 (deftest stale-abort-reply-cannot-mutate-newer-entry
   (rf/reg-resource :ab3/article (article-spec) article-spec-request)
-  (let [k (state/scoped-resource-key :rf.scope/global :ab3/article {:slug "w"})]
+  (let [k (rf.resources.state/scoped-resource-key :rf.scope/global :ab3/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :ab3/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:app :ab3 1]}])
@@ -396,7 +396,7 @@
                   :cancelled (a stale abort cannot be an accepted cancellation
                   — there is no live target to cancel; the :aborted outcome is
                   kept as a diagnostic)"
-          (let [rec (work-ledger/get-record (runtime-db) gen1-wid)]
+          (let [rec (rf.resources.work-ledger/get-record (runtime-db) gen1-wid)]
             (is (= :suppressed (:status rec)))
             (is (= :aborted (:outcome (:outcome rec)))
                 "the abort nature is retained as a diagnostic outcome")))))))
@@ -406,7 +406,7 @@
   ;; released emits a best-effort abort; when that abort reply lands it must
   ;; NOT surface as a resource error (rf2-z70ujl acceptance).
   (rf/reg-resource :ab4/article (article-spec) article-spec-request)
-  (let [k (state/scoped-resource-key :rf.scope/global :ab4/article {:slug "w"})]
+  (let [k (rf.resources.state/scoped-resource-key :rf.scope/global :ab4/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :ab4/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:app :ab4 1]}])
@@ -449,13 +449,13 @@
               compare it)"
       (let [vp (nth (:on-success @last-managed-args) 1)]
         (is (= fa (:rf.frame/id vp)) "payload carries the issuing frame stamp")))
-    (frame/destroy-frame! fa)))
+    (rf.frame/destroy-frame! fa)))
 
 (deftest cross-frame-reply-rejected-without-mutating-receiving-frame
   (rf/reg-resource :xf/article (article-spec) article-spec-request)
   (let [fa :xf/frame-a
         fb :xf/frame-b
-        k  (state/scoped-resource-key :rf.scope/global :xf/article {:slug "w"})]
+        k  (rf.resources.state/scoped-resource-key :rf.scope/global :xf/article {:slug "w"})]
     (rf/make-frame {:id fa :doc "xframe A"})
     (rf/make-frame {:id fb :doc "xframe B"})
     ;; both frames issue the SAME resource at the SAME generation (gen 1) —
@@ -483,8 +483,8 @@
         (is (= {:title "A-data"} (:data (entry fa k))) "frame A settled by its own reply")
         (is (= :loaded (:status (entry fa k))))
         (is (= :loading (:status (entry fb k))) "frame B still independently in flight")))
-    (frame/destroy-frame! fa)
-    (frame/destroy-frame! fb)))
+    (rf.frame/destroy-frame! fa)
+    (rf.frame/destroy-frame! fb)))
 
 ;; ===========================================================================
 ;; 5. ensure dedupe / join while in flight (attach owner, no new generation)
@@ -492,7 +492,7 @@
 
 (deftest ensure-while-in-flight-joins-and-dedupes
   (rf/reg-resource :dj/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :dj/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :dj/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :dj/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:route :r 1]}])
@@ -521,19 +521,19 @@
 ;;
 ;;    The in-cascade lifecycle events (:rf.resource/remove, clear-scope,
 ;;    refetch supersession, owner-release) abort the underlying managed-HTTP
-;;    request by emitting :rf.http/managed-abort via `work-ledger/abort-fx`
+;;    request by emitting :rf.http/managed-abort via `rf.resources.work-ledger/abort-fx`
 ;;    (covered by the suites above + the work-ledger suite). The OUT-of-cascade
 ;;    lifecycle paths run no cascade:
 ;;
-;;      - `clear-resource`  (registry/dispose-resource-runtime! →
-;;                           work-ledger/opportunistic-abort!)
+;;      - `clear-resource`  (rf.resources.registry/dispose-resource-runtime! →
+;;                           rf.resources.work-ledger/opportunistic-abort!)
 ;;      - frame destroy     (resources/release-resources-host-caches! →
-;;                           work-ledger/release-frame! → abort-slot!)
+;;                           rf.resources.work-ledger/release-frame! → abort-slot!)
 ;;
 ;;    Before rf2-rak684 these only fired the side-table `:abort-fn` (nil for
 ;;    managed HTTP, whose AbortController is host-owned), so they dropped the
 ;;    Resources-side work handle while leaving the underlying managed request
-;;    ALIVE. The fix routes them through `work-ledger/abort-handle!`, which —
+;;    ALIVE. The fix routes them through `rf.resources.work-ledger/abort-handle!`, which —
 ;;    for a managed-HTTP slot — fires the abort-by-request-id seam
 ;;    (`re-frame.http.registry/abort-in-flight!`) through the published
 ;;    `:http/abort-in-flight!` late-bind hook, by the SAME frame-qualified
@@ -552,11 +552,11 @@
   abort reason into `recorder` so the test can assert WHICH reason fired and
   that exactly one abort happened. Returns the recorder atom."
   [request-id recorder]
-  (http-registry/record-in-flight!
+  (rf.http.registry/record-in-flight!
     request-id nil
     {:abort-fn (fn [reason]
                  (swap! recorder conj [request-id reason])
-                 (http-registry/clear-in-flight! request-id))})
+                 (rf.http.registry/clear-in-flight! request-id))})
   recorder)
 
 (deftest clear-resource-aborts-managed-http-in-flight
@@ -566,28 +566,28 @@
   ;; slot. The abort fires by the frame-qualified request-id and the HTTP
   ;; in-flight registry entry is gone afterwards.
   (rf/reg-resource :crab/article (article-spec) article-spec-request)
-  (let [k (state/scoped-resource-key :rf.scope/global :crab/article {:slug "w"})]
+  (let [k (rf.resources.state/scoped-resource-key :rf.scope/global :crab/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :crab/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:app :crab 1]}])
     (let [wid        (:current-work (entry k))
-          request-id (work-ledger/managed-request-id :rf/default wid)
+          request-id (rf.resources.work-ledger/managed-request-id :rf/default wid)
           aborted    (seed-in-flight! request-id (atom []))]
       (testing "the managed-HTTP request is in flight + the work-handle slot
                 records the frame-qualified request-id (no live :abort-fn —
                 the transport owns the AbortController)"
-        (is (some? (http-registry/lookup-in-flight request-id)) "request in flight")
-        (let [handle (work-ledger/get-handle :rf/default wid)]
+        (is (some? (rf.http.registry/lookup-in-flight request-id)) "request in flight")
+        (let [handle (rf.resources.work-ledger/get-handle :rf/default wid)]
           (is (= :rf.http/managed (:transport handle)))
           (is (= request-id (:request-id handle)))
           (is (nil? (:abort-fn handle)) "managed-HTTP slot carries NO direct abort-fn")))
-      (registry/clear-resource :crab/article)
+      (rf.resources.registry/clear-resource :crab/article)
       (testing "rf2-rak684 — clear-resource aborts the underlying managed-HTTP
                 request by [:rf.req frame-id work-id] (not just the side-table slot)"
         (is (= [[request-id :resource-superseded]] @aborted)
             "exactly one abort fired, by the frame-qualified request-id")
-        (is (nil? (http-registry/lookup-in-flight request-id))
+        (is (nil? (rf.http.registry/lookup-in-flight request-id))
             "no live HTTP in-flight entry remains")
-        (is (nil? (work-ledger/get-handle :rf/default wid))
+        (is (nil? (rf.resources.work-ledger/get-handle :rf/default wid))
             "the work-handle side-table slot is dropped")))))
 
 (deftest frame-destroy-aborts-managed-http-in-flight
@@ -597,34 +597,34 @@
   ;; outlive the frame and could satisfy a future same-id frame's reply gate.
   (rf/reg-resource :fdab/article (article-spec) article-spec-request)
   (let [fa :fdab/frame-a
-        k  (state/scoped-resource-key :rf.scope/global :fdab/article {:slug "w"})]
+        k  (rf.resources.state/scoped-resource-key :rf.scope/global :fdab/article {:slug "w"})]
     (rf/make-frame {:id fa :doc "teardown-abort frame"})
     (rf/dispatch-sync [:rf.resource/ensure {:resource :fdab/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:app :fdab 1]}]
                       {:frame fa})
     (let [wid        (:current-work (entry fa k))
-          request-id (work-ledger/managed-request-id fa wid)
+          request-id (rf.resources.work-ledger/managed-request-id fa wid)
           aborted    (seed-in-flight! request-id (atom []))]
       (testing "before destroy: request in flight, handle + generation high-water present"
-        (is (some? (http-registry/lookup-in-flight request-id)) "request in flight")
-        (is (some? (work-ledger/get-handle fa wid)) "work-handle slot present")
-        (is (pos? (state/generation-snapshot fa)) "generation high-water present"))
-      (frame/destroy-frame! fa)
+        (is (some? (rf.http.registry/lookup-in-flight request-id)) "request in flight")
+        (is (some? (rf.resources.work-ledger/get-handle fa wid)) "work-handle slot present")
+        (is (pos? (rf.resources.state/generation-snapshot fa)) "generation high-water present"))
+      (rf.frame/destroy-frame! fa)
       (testing "rf2-rak684 — frame destroy aborts the underlying managed-HTTP
                 request by [:rf.req frame-id work-id] and leaves no live in-flight entry"
         (is (= [[request-id :resource-superseded]] @aborted)
             "exactly one abort fired, by the frame-qualified request-id")
-        (is (nil? (http-registry/lookup-in-flight request-id))
+        (is (nil? (rf.http.registry/lookup-in-flight request-id))
             "no live HTTP in-flight entry survives frame destroy")
-        (is (nil? (work-ledger/get-handle fa wid)) "host handle dropped")
-        (is (zero? (state/generation-snapshot fa)) "generation high-water dropped")))))
+        (is (nil? (rf.resources.work-ledger/get-handle fa wid)) "host handle dropped")
+        (is (zero? (rf.resources.state/generation-snapshot fa)) "generation high-water dropped")))))
 
 (deftest same-frame-id-reuse-old-reply-cannot-mutate-new-frame
   ;; rf2-rak684 — the structural-safety case the teardown abort protects, and
   ;; WHY the abort (not stale suppression) is load-bearing here.
   ;;
   ;; Same-id frame re-registration is supported, and frame destroy DROPS the
-  ;; destroyed frame's generation high-water (state/release-frame!), so a
+  ;; destroyed frame's generation high-water (rf.resources.state/release-frame!), so a
   ;; re-registered frame mints generation 1 AGAIN for the same scoped key. The
   ;; work-id `[:rf.work/resource <scoped-key> <generation>]` embeds ONLY the
   ;; scoped key + generation (it is frame-LOCAL), so the OLD incarnation's
@@ -642,7 +642,7 @@
   ;; assert that reply does NOT mutate the re-registered frame's fresh entry.
   (rf/reg-resource :rab/article (article-spec) article-spec-request)
   (let [fr :rab/reused
-        k  (state/scoped-resource-key :rf.scope/global :rab/article {:slug "w"})]
+        k  (rf.resources.state/scoped-resource-key :rf.scope/global :rab/article {:slug "w"})]
     ;; ---- first incarnation: start a load; capture the reply addressing ----
     (rf/make-frame {:id fr :doc "reuse frame — first incarnation"})
     (rf/dispatch-sync [:rf.resource/ensure {:resource :rab/article :scope :rf.scope/global
@@ -650,25 +650,25 @@
                       {:frame fr})
     (let [old-payload    (nth (:on-success @last-managed-args) 1)
           old-wid        (:current-work (entry fr k))
-          old-request-id (work-ledger/managed-request-id fr old-wid)
+          old-request-id (rf.resources.work-ledger/managed-request-id fr old-wid)
           ;; seed the REAL in-flight registry with an abort-fn that, like the
           ;; live transport's cancel path, clears the registry when fired (the
           ;; production abort-fn closure reaches finalise-failure! →
           ;; clear-in-flight!). `delivered` records that the abort fired.
           delivered      (atom [])
-          _              (http-registry/record-in-flight!
+          _              (rf.http.registry/record-in-flight!
                            old-request-id nil
                            {:abort-fn (fn [reason]
                                         (swap! delivered conj [old-request-id reason])
-                                        (http-registry/clear-in-flight! old-request-id))})]
+                                        (rf.http.registry/clear-in-flight! old-request-id))})]
       (is (= 1 (:generation (entry fr k))) "first incarnation on generation 1")
-      (is (some? (http-registry/lookup-in-flight old-request-id)) "old request in flight")
+      (is (some? (rf.http.registry/lookup-in-flight old-request-id)) "old request in flight")
       ;; ---- destroy + re-register the SAME frame id ----
-      (frame/destroy-frame! fr)
+      (rf.frame/destroy-frame! fr)
       (testing "rf2-rak684 — destroy aborts the surviving managed request"
         (is (= [[old-request-id :resource-superseded]] @delivered)
             "the old request was aborted on destroy")
-        (is (nil? (http-registry/lookup-in-flight old-request-id))
+        (is (nil? (rf.http.registry/lookup-in-flight old-request-id))
             "no surviving in-flight request to deliver a late success"))
       (reset! last-managed-args nil)
       (rf/make-frame {:id fr :doc "reuse frame — second incarnation"})
@@ -695,10 +695,10 @@
                   from the registry, so NO surviving request can deliver a late
                   success into the re-registered frame (the only structural
                   protection, since the gate can't tell the replies apart)"
-          (is (nil? (http-registry/lookup-in-flight old-request-id))
+          (is (nil? (rf.http.registry/lookup-in-flight old-request-id))
               "the colliding old request cannot deliver any reply"))
         (testing "the NEW incarnation's OWN reply settles it normally"
           (reply-into-frame! fr new-payload {:title "FRESH"})
           (is (= {:title "FRESH"} (:data (entry fr k))) "new reply settles the new entry")
           (is (= :loaded (:status (entry fr k)))))))
-    (frame/destroy-frame! fr)))
+    (rf.frame/destroy-frame! fr)))

--- a/implementation/resources/test/re_frame/resources_mutation_classification_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_classification_cljs_test.cljc
@@ -22,24 +22,24 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [clojure.string :as str]
-   [re-frame.classification :as core-classification]
+   [re-frame.classification :as rf.classification]
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
-   [re-frame.elision :as elision]
-   [re-frame.late-bind :as late-bind]
-   [re-frame.privacy :as privacy]
-   [re-frame.resources.classification :as classification]
-   [re-frame.resources.mutation-registry :as mreg]
-   [re-frame.resources.mutation-runtime :as mstate]
+   [re-frame.fx :as rf.fx]
+   [re-frame.elision :as rf.elision]
+   [re-frame.late-bind :as rf.late-bind]
+   [re-frame.privacy :as rf.privacy]
+   [re-frame.resources.classification :as rf.resources.classification]
+   [re-frame.resources.mutation-registry :as rf.resources.mutation-registry]
+   [re-frame.resources.mutation-runtime :as rf.resources.mutation-runtime]
    ;; load-bearing side-effecting requires: register the :rf.mutation/* events +
    ;; subs + the generation cofx/fx + bind the shared walker hooks.
    [re-frame.resources]
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   [re-frame.trace.tooling :as trace-tooling]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport (records the lowered request args) ----------------
 
@@ -47,14 +47,14 @@
 
 (defn- capturing-transport-fixture [f]
   (reset! last-managed-args nil)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
-  (fx/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
   capturing-transport-fixture)
 
 ;; A UNIQUE sentinel so a leak anywhere in the projected surface is unambiguous.
@@ -78,7 +78,7 @@
 ;; A runtime-db carrying ONE mutation instance under its byte key-id, mirroring
 ;; the durable `:rf.runtime/mutations` shape the runtime mints.
 (defn- runtime-db-with-instance [instance-id inst]
-  {mstate/mutations-key {(mstate/instance-key-id instance-id) inst}})
+  {rf.resources.mutation-runtime/mutations-key {(rf.resources.mutation-runtime/instance-key-id instance-id) inst}})
 
 ;; ===========================================================================
 ;; 1. reconcile-mutation-registry — lowers a live instance's owner declaration
@@ -90,10 +90,10 @@
   (testing "a live mutation instance's owner :params-rooted :sensitive
             declaration is LOWERED into the elision registry under
             :source :mutation, rooted at the instance's absolute runtime-db path"
-    (let [k-id (mstate/instance-key-id :i1)
+    (let [k-id (rf.resources.mutation-runtime/instance-key-id :i1)
           rdb  (runtime-db-with-instance
-                 :i1 (mstate/empty-instance :m/secret :i1 {:params {:slug "w" :password PW}}))
-          out  (classification/reconcile-mutation-registry rdb mreg/mutation-meta)
+                 :i1 (rf.resources.mutation-runtime/empty-instance :m/secret :i1 {:params {:slug "w" :password PW}}))
+          out  (rf.resources.classification/reconcile-mutation-registry rdb rf.resources.mutation-registry/mutation-meta)
           sens (get-in out [:rf.runtime/elision :sensitive-declarations])]
       (is (= #{{:source :mutation}}
              (get sens [:rf.runtime/mutations k-id :params :password]))
@@ -103,9 +103,9 @@
   (reg-secret-mutation!)
   (testing "re-running the mutation reconcile over its own output is a no-op"
     (let [rdb   (runtime-db-with-instance
-                  :i1 (mstate/empty-instance :m/secret :i1 {:params {:slug "w" :password PW}}))
-          once  (classification/reconcile-mutation-registry rdb mreg/mutation-meta)
-          twice (classification/reconcile-mutation-registry once mreg/mutation-meta)]
+                  :i1 (rf.resources.mutation-runtime/empty-instance :m/secret :i1 {:params {:slug "w" :password PW}}))
+          once  (rf.resources.classification/reconcile-mutation-registry rdb rf.resources.mutation-registry/mutation-meta)
+          twice (rf.resources.classification/reconcile-mutation-registry once rf.resources.mutation-registry/mutation-meta)]
       (is (= once twice) "mutation reconciliation is idempotent"))))
 
 (deftest reconcile-mutation-self-drops-cleared-instance
@@ -113,12 +113,12 @@
   (testing "a cleared instance's :source :mutation declaration vanishes on the
             next reconcile (the per-instance teardown — no separate drop hook)"
     (let [rdb   (runtime-db-with-instance
-                  :i1 (mstate/empty-instance :m/secret :i1 {:params {:slug "w" :password PW}}))
-          live  (classification/reconcile-mutation-registry rdb mreg/mutation-meta)
+                  :i1 (rf.resources.mutation-runtime/empty-instance :m/secret :i1 {:params {:slug "w" :password PW}}))
+          live  (rf.resources.classification/reconcile-mutation-registry rdb rf.resources.mutation-registry/mutation-meta)
           ;; drop the instance, keep the carried registry, reconcile again.
           cleared (-> live
-                      (assoc mstate/mutations-key {})
-                      (classification/reconcile-mutation-registry mreg/mutation-meta))]
+                      (assoc rf.resources.mutation-runtime/mutations-key {})
+                      (rf.resources.classification/reconcile-mutation-registry rf.resources.mutation-registry/mutation-meta))]
       (is (seq (get-in live [:rf.runtime/elision :sensitive-declarations]))
           "the live instance lowered a declaration")
       (is (empty? (get-in cleared [:rf.runtime/elision :sensitive-declarations]))
@@ -129,10 +129,10 @@
   (testing "a non-mutation-sourced registry entry (:source :resource / :effect)
             rides untouched through the mutation reconcile (multi-owner union)"
     (let [rdb (-> (runtime-db-with-instance
-                    :i1 (mstate/empty-instance :m/secret :i1 {:params {:slug "w" :password PW}}))
+                    :i1 (rf.resources.mutation-runtime/empty-instance :m/secret :i1 {:params {:slug "w" :password PW}}))
                   (assoc-in [:rf.runtime/elision :sensitive-declarations [:app :token]]
                             #{{:source :effect}}))
-          out (classification/reconcile-mutation-registry rdb mreg/mutation-meta)]
+          out (rf.resources.classification/reconcile-mutation-registry rdb rf.resources.mutation-registry/mutation-meta)]
       (is (= #{{:source :effect}}
              (get-in out [:rf.runtime/elision :sensitive-declarations [:app :token]]))
           "the :source :effect entry survives the mutation reconcile"))))
@@ -143,8 +143,8 @@
     (fn [_ _] {:request {:method :get :url "/x"}}))
   (testing "a mutation that declares no classification lowers nothing"
     (let [rdb (runtime-db-with-instance
-                :i1 (mstate/empty-instance :m/plain :i1 {:params {:slug "w"}}))
-          out (classification/reconcile-mutation-registry rdb mreg/mutation-meta)]
+                :i1 (rf.resources.mutation-runtime/empty-instance :m/plain :i1 {:params {:slug "w"}}))
+          out (rf.resources.classification/reconcile-mutation-registry rdb rf.resources.mutation-registry/mutation-meta)]
       (is (not (contains? out :rf.runtime/elision))
           "no :rf.runtime/elision key when nothing classifies"))))
 
@@ -158,8 +158,8 @@
             reply map; the non-sensitive sibling rides verbatim"
     (let [reply {:status :ok :value {:ok true}
                  :params {:slug "w" :password PW} :scope :rf.scope/global}
-          out   (classification/redact-continuation-reply reply (mreg/mutation-meta :m/secret))]
-      (is (= privacy/redacted-sentinel (get-in out [:params :password]))
+          out   (rf.resources.classification/redact-continuation-reply reply (rf.resources.mutation-registry/mutation-meta :m/secret))]
+      (is (= rf.privacy/redacted-sentinel (get-in out [:params :password]))
           "the sensitive param is redacted on the reply")
       (is (= "w" (get-in out [:params :slug])) "the non-sensitive param rides verbatim")
       (is (= {:ok true} (:value out)) "the result value rides verbatim")
@@ -171,7 +171,7 @@
     (fn [_ _] {:request {:method :get :url "/x"}}))
   (testing "a mutation that declares no classification rides the reply UNCHANGED"
     (let [reply {:status :ok :params {:slug "w" :password PW}}]
-      (is (= reply (classification/redact-continuation-reply reply (mreg/mutation-meta :m/plain)))
+      (is (= reply (rf.resources.classification/redact-continuation-reply reply (rf.resources.mutation-registry/mutation-meta :m/plain)))
           "no declaration → the reply is unchanged"))))
 
 ;; ===========================================================================
@@ -183,7 +183,7 @@
   (let [replied (atom nil)
         traces  (atom [])]
     (rf/reg-event :m/replied (fn [_ [_ reply]] (reset! replied reply) {}))
-    (trace-tooling/register-listener! ::rec (fn [ev] (swap! traces conj ev)))
+    (rf.trace.tooling/register-listener! ::rec (fn [ev] (swap! traces conj ev)))
     (rf/dispatch-sync [:rf.mutation/execute
                        {:mutation :m/secret
                         :params   {:slug "w" :password PW}
@@ -194,31 +194,31 @@
       (is (= PW (get-in @last-managed-args [:request :body :password]))))
     ;; reply success to settle the instance + fire the continuation.
     (rf/dispatch-sync (conj (:on-success @last-managed-args) {:status :ok :value {:ok true}}))
-    (trace-tooling/unregister-listener! ::rec)
+    (rf.trace.tooling/unregister-listener! ::rec)
 
     (let [rdb  (runtime-db)
-          k-id (mstate/instance-key-id :i1)
-          inst (get-in rdb (mstate/instance-path :i1))]
+          k-id (rf.resources.mutation-runtime/instance-key-id :i1)
+          inst (get-in rdb (rf.resources.mutation-runtime/instance-path :i1))]
       (testing "the durable instance keeps the RAW params (success-path fns read them)"
         (is (= PW (get-in inst [:params :password]))
             "the durable instance :password is NOT destroyed"))
       (testing "the owner declaration is LOWERED into the frame elision registry"
         (is (= #{{:source :mutation}}
-               (get (elision/sensitive-declarations :rf/default)
+               (get (rf.elision/sensitive-declarations :rf/default)
                     [:rf.runtime/mutations k-id :params :password]))
             "the instance :params :password decl is in the per-frame registry"))
       (testing "the off-box egress walk over the instance REDACTS :password"
         (let [proj (rf/elide-wire-value inst {:frame :rf/default
                                               :path [:rf.runtime/mutations k-id]
                                               :rf.egress/profile :rf.egress/off-box-tool})]
-          (is (= privacy/redacted-sentinel (get-in proj [:params :password]))
+          (is (= rf.privacy/redacted-sentinel (get-in proj [:params :password]))
               "the instance :password is redacted at egress")
           (is (= "w" (get-in proj [:params :slug])) "the non-sensitive :slug rides verbatim")
           (is (not (str/includes? (pr-str proj) PW))
               "no raw sentinel rides anywhere on the projected instance"))))
 
     (testing "the continuation reply redacts :password but keeps the result + slug"
-      (is (= privacy/redacted-sentinel (get-in @replied [:params :password]))
+      (is (= rf.privacy/redacted-sentinel (get-in @replied [:params :password]))
           "the continuation reply :password is redacted")
       (is (= "w" (get-in @replied [:params :slug])) "the reply :slug rides verbatim")
       (is (= {:ok true} (:value @replied)) "the reply :value (result) rides verbatim")
@@ -243,7 +243,7 @@
                     (filter #(and (vector? %) (= :rf.mutation/execute (first %)))))]
         (is (seq vs) "the execute dispatched-event trace surfaced")
         (doseq [v vs]
-          (is (= privacy/redacted-sentinel (get-in v [1 :params :password]))
+          (is (= rf.privacy/redacted-sentinel (get-in v [1 :params :password]))
               "the owner-declared :params :password redacts at :rf.event/v")
           (is (= "w" (get-in v [1 :params :slug]))
               "the non-sensitive :slug rides verbatim at :rf.event/v"))))
@@ -259,7 +259,7 @@
                           :reply-to [:m/replied]}])
       (rf/dispatch-sync (conj (:on-failure @last-managed-args)
                               {:status :error :error {:status 422 :body "nope"}}))
-      (is (= privacy/redacted-sentinel (get-in @replied [:params :password]))
+      (is (= rf.privacy/redacted-sentinel (get-in @replied [:params :password]))
           "the failure continuation reply :password is redacted")
       (is (= "w" (get-in @replied [:params :slug])) "the failure reply :slug rides verbatim")
       (is (not (str/includes? (pr-str @replied) PW))
@@ -267,8 +267,8 @@
 
     (testing "clear DROPS the lowered instance declaration (self-dropping)"
       (rf/dispatch-sync [:rf.mutation/clear {:instance :i1}])
-      (is (empty? (get (elision/sensitive-declarations :rf/default)
-                       [:rf.runtime/mutations (mstate/instance-key-id :i1) :params :password]))
+      (is (empty? (get (rf.elision/sensitive-declarations :rf/default)
+                       [:rf.runtime/mutations (rf.resources.mutation-runtime/instance-key-id :i1) :params :password]))
           "the cleared instance's declaration is gone from the registry"))))
 
 ;; ===========================================================================
@@ -285,8 +285,8 @@
   (testing "the owner-declared :params :password redacts on the execute args;
             the non-sensitive sibling and the structural :mutation id ride"
     (let [args {:mutation :m/secret :params {:slug "w" :password PW} :instance :i9}
-          out  (classification/project-execute-event-args args mreg/mutation-meta)]
-      (is (= privacy/redacted-sentinel (get-in out [:params :password]))
+          out  (rf.resources.classification/project-execute-event-args args rf.resources.mutation-registry/mutation-meta)]
+      (is (= rf.privacy/redacted-sentinel (get-in out [:params :password]))
           "the sensitive param is redacted on the execute payload")
       (is (= "w" (get-in out [:params :slug])) "the non-sensitive param rides verbatim")
       (is (= :m/secret (:mutation out)) "the owner id survives (attribution)")
@@ -301,11 +301,11 @@
   (testing "a :scope-rooted decl redacts the execute payload's sibling :scope
             slot (Spec 016 clause 4 — params, scopes, and data carry the same
             classification)"
-    (let [out (classification/project-execute-event-args
+    (let [out (rf.resources.classification/project-execute-event-args
                 {:mutation :m/scoped :params {:slug "w"}
                  :scope    {:tenant PW :region "r"}}
-                mreg/mutation-meta)]
-      (is (= privacy/redacted-sentinel (get-in out [:scope :tenant]))
+                rf.resources.mutation-registry/mutation-meta)]
+      (is (= rf.privacy/redacted-sentinel (get-in out [:scope :tenant]))
           "the :scope-rooted decl bites the payload's :scope")
       (is (= "r" (get-in out [:scope :region])) "the non-sensitive scope field rides"))))
 
@@ -319,18 +319,18 @@
             the execute payload rides UNCHANGED (reference-preserved, no
             phantom slot)"
     (let [args {:mutation :m/data-classified :params {:slug "w"}}]
-      (is (identical? args (classification/project-execute-event-args
-                             args mreg/mutation-meta))))))
+      (is (identical? args (rf.resources.classification/project-execute-event-args
+                             args rf.resources.mutation-registry/mutation-meta))))))
 
 (deftest project-execute-event-args-fail-open
   (testing "an unregistered :mutation id / a non-map payload rides UNCHANGED
             (the EP-0025 fail-open — no registration to read a declaration off)"
     (rf/clear-mutation :m/ghost)
     (let [args {:mutation :m/ghost :params {:password PW}}]
-      (is (identical? args (classification/project-execute-event-args
-                             args mreg/mutation-meta))))
-    (is (= :not-a-map (classification/project-execute-event-args
-                        :not-a-map mreg/mutation-meta)))))
+      (is (identical? args (rf.resources.classification/project-execute-event-args
+                             args rf.resources.mutation-registry/mutation-meta))))
+    (is (= :not-a-map (rf.resources.classification/project-execute-event-args
+                        :not-a-map rf.resources.mutation-registry/mutation-meta)))))
 
 (deftest project-execute-event-args-reply-to-rides-target-classification
   (reg-secret-mutation!)
@@ -340,12 +340,12 @@
   (testing "a payload-carrying :reply-to address rides the TARGET event
             registration's own classification — the same composition the
             managed-HTTP :on-success / :on-failure addresses get"
-    (let [out (classification/project-execute-event-args
+    (let [out (rf.resources.classification/project-execute-event-args
                 {:mutation :m/secret
                  :params   {:slug "w" :password PW}
                  :reply-to [:m/reply-target {:cb-secret PW :tag "t"}]}
-                mreg/mutation-meta)]
-      (is (= privacy/redacted-sentinel (get-in out [:reply-to 1 :cb-secret]))
+                rf.resources.mutation-registry/mutation-meta)]
+      (is (= rf.privacy/redacted-sentinel (get-in out [:reply-to 1 :cb-secret]))
           "the reply-to target's declared path redacts")
       (is (= "t" (get-in out [:reply-to 1 :tag])) "the non-secret tag rides")
       (is (not (str/includes? (pr-str out) PW)) "no raw sentinel anywhere"))))
@@ -353,17 +353,17 @@
 (deftest execute-event-args-hook-is-published
   (testing "re-frame.resources publishes the hook the core event-vector
             chokepoint consults (load-time anchor)"
-    (is (fn? (late-bind/get-fn :resources/project-execute-event-args)))))
+    (is (fn? (rf.late-bind/get-fn :resources/project-execute-event-args)))))
 
 (deftest core-event-chokepoint-projects-execute-payload
   (reg-secret-mutation!)
   (testing "re-frame.classification/redact-event-by-registration (the single
             event-vector chokepoint — also the ALWAYS-ON :rf.observe/* egress
             redactor) consults the resources hook for [:rf.mutation/execute …]"
-    (let [v (core-classification/redact-event-by-registration
+    (let [v (rf.classification/redact-event-by-registration
               [:rf.mutation/execute {:mutation :m/secret
                                      :params   {:slug "w" :password PW}}])]
-      (is (= privacy/redacted-sentinel (get-in v [1 :params :password]))
+      (is (= rf.privacy/redacted-sentinel (get-in v [1 :params :password]))
           "the owner-declared param redacts through the core chokepoint")
       (is (= "w" (get-in v [1 :params :slug])) "the non-sensitive param rides")
       (is (= :rf.mutation/execute (first v)) "the event id survives"))))
@@ -375,20 +375,20 @@
             the same chokepoint (deterministic projector teeth on hand-built
             trace shapes, mirroring fx_aggregate_classification)"
     (let [payload {:mutation :m/secret :params {:slug "w" :password PW}}
-          disp    (core-classification/project-trace-event
+          disp    (rf.classification/project-trace-event
                     {:operation :rf.event/dispatched
                      :tags {:frame       :rf/default
                             :rf.event/v [:rf.mutation/execute payload]}})
-          agg     (core-classification/project-trace-event
+          agg     (rf.classification/project-trace-event
                     {:operation :rf.fx/do-fx
                      :tags {:frame        :rf/default
                             :rf.event/fx [[:dispatch [:rf.mutation/execute payload]]]}})]
-      (is (= privacy/redacted-sentinel
+      (is (= rf.privacy/redacted-sentinel
              (get-in disp [:tags :rf.event/v 1 :params :password]))
           ":rf.event/v redacts the owner-declared param")
       (is (= "w" (get-in disp [:tags :rf.event/v 1 :params :slug]))
           ":rf.event/v keeps the non-sensitive sibling")
-      (is (= privacy/redacted-sentinel
+      (is (= rf.privacy/redacted-sentinel
              (get-in agg [:tags :rf.event/fx 0 1 1 :params :password]))
           "the nested :dispatch fx entry inherits the same projection")
       (is (not (str/includes? (pr-str [disp agg]) PW))

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -32,35 +32,35 @@
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [clojure.string :as str]
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
-   [re-frame.elision :as elision]
-   [re-frame.privacy :as privacy]
-   [re-frame.reply :as reply]
+   [re-frame.fx :as rf.fx]
+   [re-frame.elision :as rf.elision]
+   [re-frame.privacy :as rf.privacy]
+   [re-frame.reply :as rf.reply]
    ;; rf2-x76af2.13 — the mutation classification-lowering regression reads the
    ;; per-frame elision registry the succeeded-handler lowers into, then projects
    ;; the populated entry's data through the registry-driven egress projector.
-   [re-frame.resources.classification :as classification]
+   [re-frame.resources.classification :as rf.resources.classification]
    ;; load-bearing side-effecting requires: register the :rf.resource/* +
    ;; :rf.mutation/* events + subs + the generation cofx/fx.
    [re-frame.resources]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.mutation-runtime :as mstate]
-   [re-frame.resources.mutation-events :as mevents]
-   [re-frame.resources.mutation-registry :as mreg]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.mutation-runtime :as rf.resources.mutation-runtime]
+   [re-frame.resources.mutation-events :as rf.resources.mutation-events]
+   [re-frame.resources.mutation-registry :as rf.resources.mutation-registry]
    ;; work-ledger: used by the cross-frame request-id correlation assertions
    ;; (rf2-sxyrzk). The per-suite `(timers/reset-cache!)` was dropped with the
    ;; rf2-784223 fixture consolidation (shared reset hook clears timer caches),
    ;; so the `timers` alias is no longer required here.
-   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.resources.work-ledger :as rf.resources.work-ledger]
    [re-frame.resources.test-support]
    ;; production HTTP fx surface (so the transport feature probe resolves);
    ;; the actual fetch is overridden by the capturing reply stub below.
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   [re-frame.trace.tooling :as trace-tooling]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport that REPLAYS the real reply-append shape ----------
 
@@ -75,18 +75,18 @@
   [f]
   (reset! last-managed-args nil)
   (reset! scheduled-timers [])
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
   ;; capture the host-side stale / GC timer arming so the success handler's
   ;; emission is asserted deterministically WITHOUT a real wall-clock timer
   ;; firing (the timer-table primitive is tested directly in the
   ;; invalidation/GC suite).
-  (fx/reg-fx :rf.resource/schedule-timers (fn [_ctx args] (swap! scheduled-timers conj args) nil))
+  (rf.fx/reg-fx :rf.resource/schedule-timers (fn [_ctx args] (swap! scheduled-timers conj args) nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
   capturing-transport-fixture)
 
 ;; ---- helpers --------------------------------------------------------------
@@ -98,12 +98,12 @@
 (defn- instance
   ([instance-id] (instance :rf/default instance-id))
   ([frame-id instance-id]
-   (get-in (runtime-db frame-id) (mstate/instance-path instance-id))))
+   (get-in (runtime-db frame-id) (rf.resources.mutation-runtime/instance-path instance-id))))
 
 (defn- entry
   ([scoped-key] (entry :rf/default scoped-key))
   ([frame-id scoped-key]
-   (get-in (runtime-db frame-id) (state/entry-path scoped-key))))
+   (get-in (runtime-db frame-id) (rf.resources.state/entry-path scoped-key))))
 
 (defn- mutation-record
   "The serializable work-ledger record for a mutation INSTANCE's current
@@ -134,7 +134,7 @@
   "The map-form exact target (EP-0016 Rider 2 — the only public input form for
   `:populates` / `:patches`) for the `:r/article {:slug \"w\"}` global key the
   patch/populate tests use. Its canonical STORAGE key is
-  `(state/scoped-resource-key :rf.scope/global :r/article {:slug \"w\"})`, the
+  `(rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug \"w\"})`, the
   `rkey` the entry-lookup assertions read."
   ([] (art-target "w"))
   ([slug] {:resource :r/article :params {:slug slug} :scope :rf.scope/global}))
@@ -145,13 +145,13 @@
   [body-fn]
   (let [seen (atom [])
         k    ::mutation-trace-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev]
           (when (and (keyword? (:operation ev))
                      (= "rf.mutation" (namespace (:operation ev))))
             (swap! seen conj ev))))
     (try (body-fn)
-         (finally (trace-tooling/unregister-listener! k)))
+         (finally (rf.trace.tooling/unregister-listener! k)))
     @seen))
 
 (defn- record-target-skipped-warnings!
@@ -160,11 +160,11 @@
   [body-fn]
   (let [seen (atom [])
         k    ::target-skipped-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (= :rf.warning/mutation-target-skipped (:operation ev))
                    (swap! seen conj ev))))
     (try (body-fn)
-         (finally (trace-tooling/unregister-listener! k)))
+         (finally (rf.trace.tooling/unregister-listener! k)))
     @seen))
 
 (defn- record-error-records!
@@ -262,7 +262,7 @@
           (rf/reg-mutation :m/non-kw
                            (save-article-spec {:invalidate-timing "after-success"}) save-article-request))))
   (testing "every value in the closed enum registers cleanly"
-    (doseq [timing mreg/invalidate-timings]
+    (doseq [timing rf.resources.mutation-registry/invalidate-timings]
       (rf/reg-mutation :m/ok (save-article-spec {:invalidate-timing timing}) save-article-request)
       (is (= timing (:invalidate-timing (rf/mutation-meta :m/ok)))
           (str "valid timing " timing " registered"))
@@ -279,7 +279,7 @@
   ;; caught the regression it was named for, and a reader who met the symptom
   ;; in an app (no instance, no request, `:idle` afterwards — byte-identical to
   ;; "nobody asked") had no gate telling them the runtime HAD refused. The
-  ;; refusal is real: `mreg/require-mutation-spec!` runs as the FIRST statement
+  ;; refusal is real: `rf.resources.mutation-registry/require-mutation-spec!` runs as the FIRST statement
   ;; of `execute-handler`, so the id lookup fails before any instance row,
   ;; work-ledger row, optimistic patch or transport lowering exists.
   ;;
@@ -450,7 +450,7 @@
                    (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}}))
   (rf/reg-mutation :m/save (save-article-spec) save-article-request)
   ;; load + own the article resource so the invalidation refetches it
-  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :r/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:view :article]}])
@@ -483,7 +483,7 @@
                     :params-schema [:map [:slug :string]]
                     :tags (fn [{:keys [slug]} _] #{[:article slug]})}
                    (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}}))
-  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
     (rf/reg-mutation :m/patch
                      {:params-schema [:map [:slug :string]]
                       :patches (fn [_params result]
@@ -518,7 +518,7 @@
                     :tags (fn [{:keys [slug]} _] #{[:article slug]})
                     :stale-after-ms 60000}
                    (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}}))
-  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})
         completed-at 1781078400456]
     (rf/reg-mutation :m/save
                      {:params-schema [:map [:slug :string]]
@@ -556,7 +556,7 @@
                     :params-schema [:map [:slug :string]]
                     :tags (fn [{:keys [slug]} _] #{[:article slug]})}
                    (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}}))
-  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
     (rf/reg-mutation :m/save
                      {:params-schema [:map [:slug :string]]
                       :populates (fn [_params result] {(art-target) result})}
@@ -601,8 +601,8 @@
   ;; path: no wrapped resource event ever ran for this key).
   (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save-profile :params {:slug "w"} :instance :sp1}])
   (reply-success! @last-managed-args {:ssn "123-45-6789" :name "Alice"})
-  (let [rkey (state/scoped-resource-key :rf.scope/global :acct/profile {:slug "w"})
-        k-id (state/key-id rkey)
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :acct/profile {:slug "w"})
+        k-id (rf.resources.state/key-id rkey)
         e    (entry rkey)]
     (testing "the populate seeded the entry — raw data lives in the durable cache
               (redaction is an egress concern, not a durable one)"
@@ -612,14 +612,14 @@
               :data :ssn declaration into the frame registry (under :source
               :resource), WITHOUT the test reconciling"
       (is (= #{{:source :resource}}
-             (get (elision/sensitive-declarations :rf/default)
+             (get (rf.elision/sensitive-declarations :rf/default)
                   [:rf.runtime/resources :entries k-id :data :ssn]))
           "the mutation handler kept the elision registry in step with :entries"))
     (testing "rf2-x76af2.13 — SSR project-entry-data redacts the field via the
               registry the handler lowered (the drift is closed)"
-      (let [projected (classification/project-entry-data
+      (let [projected (rf.resources.classification/project-entry-data
                         (:data e) k-id :rf/default :rf.egress/ssr-hydration)]
-        (is (= privacy/redacted-sentinel (:ssn projected))
+        (is (= rf.privacy/redacted-sentinel (:ssn projected))
             "the populated entry's :ssn is redacted at egress")
         (is (= "Alice" (:name projected)) "the undeclared sibling rides verbatim")
         (is (not (str/includes? (pr-str projected) "123-45-6789"))
@@ -638,7 +638,7 @@
                     :stale-after-ms 60000
                     :gc-after-ms    300000}
                    (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}}))
-  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
     (rf/reg-mutation :m/save
                      {:params-schema [:map [:slug :string]]
                       :populates (fn [_params result] {(art-target) result})}
@@ -675,7 +675,7 @@
                     :stale-after-ms 60000
                     :gc-after-ms    300000}
                    (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}}))
-  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
     (rf/reg-mutation :m/patch
                      {:params-schema [:map [:slug :string]]
                       :patches (fn [_params result]
@@ -705,7 +705,7 @@
                     :params-schema [:map [:slug :string]]
                     :tags (fn [{:keys [slug]} _] #{[:article slug]})}
                    (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}}))
-  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
     (rf/reg-mutation :m/save
                      {:params-schema [:map [:slug :string]]
                       :populates (fn [_params result] {(art-target) result})}
@@ -741,7 +741,7 @@
                     :params-schema [:map [:slug :string]]
                     :tags (fn [{:keys [slug]} _] #{[:article slug]})}
                    (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}}))
-  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
     (rf/reg-mutation :m/save (save-article-spec {:invalidate-timing :after-failure}) save-article-request)
     ;; ensure WITHOUT an owner so the invalidation leaves the matched entry
     ;; stale (an ownerless entry is left stale / GC-eligible, NOT refetched —
@@ -768,7 +768,7 @@
                     :params-schema [:map [:slug :string]]
                     :tags (fn [{:keys [slug]} _] #{[:article slug]})}
                    (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}}))
-  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
     (rf/reg-mutation :m/save (save-article-spec {:invalidate-timing :before-request}) save-article-request)
     ;; ownerless ensure — the invalidation leaves the entry stale (observable
     ;; via :invalidated-at) rather than refetching it.
@@ -861,7 +861,7 @@
 (deftest cross-frame-mutation-reply-rejected-without-mutating-receiving-frame
   (rf/reg-mutation :m/save (save-article-spec) save-article-request)
   (let [all-args (atom [])]
-    (fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! all-args conj args) nil))
+    (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! all-args conj args) nil))
     (let [fa :xfm/frame-a
           fb :xfm/frame-b]
       (rf/make-frame {:id fa :doc "frame A"})
@@ -960,7 +960,7 @@
             cache-key boundary (mutation reuses the resource EDN discipline)"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-non-edn-params"
-          (mreg/validate+canonicalize-params
+          (rf.resources.mutation-registry/validate+canonicalize-params
             :m/save (rf/mutation-meta :m/save) {:slug "w" :cb (fn [])}
             'test)))))
 
@@ -996,7 +996,7 @@
   (testing "an unregistered resource id is rejected"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
-          (mstate/validate-target-key!
+          (rf.resources.mutation-runtime/validate-target-key!
             {:resource :r/never-registered :params {:slug "w"}}
             :rf.scope/global (fn [_] false) 'test :patches)))))
 
@@ -1006,21 +1006,21 @@
   (testing "a tuple (the internal storage form) is NOT a public input"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
-          (mstate/validate-target-key!
+          (rf.resources.mutation-runtime/validate-target-key!
             [:rf.scope/global :r/article {:slug "w"}] :rf.scope/global
             (constantly true) 'test :populates))))
   (testing "a non-map target is rejected"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
-          (mstate/validate-target-key! :r/article :rf.scope/global (constantly true) 'test :patches))))
+          (rf.resources.mutation-runtime/validate-target-key! :r/article :rf.scope/global (constantly true) 'test :patches))))
   (testing "a map missing :resource is rejected"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
-          (mstate/validate-target-key! {:params {}} :rf.scope/global (constantly true) 'test :patches))))
+          (rf.resources.mutation-runtime/validate-target-key! {:params {}} :rf.scope/global (constantly true) 'test :patches))))
   (testing "a non-keyword :resource is rejected"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
-          (mstate/validate-target-key! {:resource "article" :params {}} :rf.scope/global
+          (rf.resources.mutation-runtime/validate-target-key! {:resource "article" :params {}} :rf.scope/global
                                        (constantly true) 'test :patches)))))
 
 (deftest validate-target-key-rejects-reserved-scope-typo
@@ -1031,12 +1031,12 @@
   (testing ":rf.scope/glabal (a typo) is rejected"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
-          (mstate/validate-target-key!
+          (rf.resources.mutation-runtime/validate-target-key!
             {:resource :r/article :params {:slug "w"}} :rf.scope/glabal
             (constantly true) 'test :patches))))
   (testing "the closed reserved policy :rf.scope/global is a legitimate literal scope"
     (is (= [:rf.scope/global :r/article {:slug "w"}]
-           (mstate/validate-target-key!
+           (rf.resources.mutation-runtime/validate-target-key!
              {:resource :r/article :params {:slug "w"}} :rf.scope/global
              (constantly true) 'test :patches)))))
 
@@ -1047,13 +1047,13 @@
   (testing "non-EDN params rejected"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
-          (mstate/validate-target-key!
+          (rf.resources.mutation-runtime/validate-target-key!
             {:resource :r/article :params {:slug "w" :cb (fn [])}} :rf.scope/global
             (constantly true) 'test :patches))))
   (testing "non-EDN scope rejected"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
-          (mstate/validate-target-key!
+          (rf.resources.mutation-runtime/validate-target-key!
             {:resource :r/article :params {:slug "w"}} (fn [])
             (constantly true) 'test :patches)))))
 
@@ -1074,7 +1074,7 @@
     (testing "a single bad target (typo scope) rejects the whole map (default :strict)"
       (is (thrown-with-msg?
             #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
-            (mstate/validate-target-map!
+            (rf.resources.mutation-runtime/validate-target-map!
               {{:resource :r/article :params {:slug "w"} :scope :rf.scope/global} :ok
                {:resource :r/article :params {:slug "x"} :scope :rf.scope/glabal} :bad}
               resolve-scope (constantly true) :patches 'test))))
@@ -1083,24 +1083,24 @@
       ;; unregistered resource (rf2-1vpbld — only the POST-WRITE settle path relaxes).
       (is (thrown-with-msg?
             #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
-            (mstate/validate-target-map!
+            (rf.resources.mutation-runtime/validate-target-map!
               {{:resource :r/article :params {:slug "w"} :scope :rf.scope/global} :ok
                {:resource :r/nope :params {:slug "x"} :scope :rf.scope/global} :bad}
               resolve-scope #(= % :r/article) :patches 'test))))
     (testing "an all-valid map is re-keyed by the canonical STORAGE key (and no nils)"
       (is (= [{[:rf.scope/global :r/article {:slug "w"}] :v} []]
-             (mstate/validate-target-map!
+             (rf.resources.mutation-runtime/validate-target-map!
                {{:resource :r/article :params {:slug "w"} :scope :rf.scope/global} :v}
                resolve-scope (constantly true) :populates 'test))))
     (testing "a {:from-db …} target that resolves nil is FAIL-CLOSED — dropped,
               its resolver id recorded as nil-resolved (never an implicit global)"
       (is (= [{} [:nope]]
-             (mstate/validate-target-map!
+             (rf.resources.mutation-runtime/validate-target-map!
                {{:resource :r/article :params {:slug "w"} :scope {:from-db :nope}} :v}
                resolve-scope (constantly true) :populates 'test))))
     (testing "an empty / nil map returns [nil []] (no-op arm)"
-      (is (= [nil []] (mstate/validate-target-map! {} resolve-scope (constantly true) :patches 'test)))
-      (is (= [nil []] (mstate/validate-target-map! nil resolve-scope (constantly true) :patches 'test))))))
+      (is (= [nil []] (rf.resources.mutation-runtime/validate-target-map! {} resolve-scope (constantly true) :patches 'test)))
+      (is (= [nil []] (rf.resources.mutation-runtime/validate-target-map! nil resolve-scope (constantly true) :patches 'test))))))
 
 (deftest validate-target-map-skip-recoverable-policy
   ;; rf2-1vpbld — the POST-WRITE settle policy (:skip-recoverable): a RECOVERABLE
@@ -1116,7 +1116,7 @@
                           :else                        [:resolved scope]))]
     (testing "an unregistered sibling is SKIPPED while the valid sibling LANDS"
       (let [[canonical nils skipped]
-            (mstate/validate-target-map!
+            (rf.resources.mutation-runtime/validate-target-map!
               {{:resource :r/article :params {:slug "w"} :scope :rf.scope/global} :ok
                {:resource :r/nope :params {:slug "x"} :scope :rf.scope/global} :bad}
               resolve-scope #(= % :r/article) :patches 'test :skip-recoverable)]
@@ -1128,7 +1128,7 @@
         (is (= :r/nope (:resource (first skipped))) "the recoverable resource id is recorded")))
     (testing "a non-keyword :resource sibling is SKIPPED while the valid one LANDS"
       (let [[canonical _nils skipped]
-            (mstate/validate-target-map!
+            (rf.resources.mutation-runtime/validate-target-map!
               {{:resource :r/article :params {:slug "w"} :scope :rf.scope/global} :ok
                {:resource "article" :params {:slug "x"} :scope :rf.scope/global} :bad}
               resolve-scope (constantly true) :populates 'test :skip-recoverable)]
@@ -1137,24 +1137,24 @@
     (testing "CACHE-IDENTITY CORRUPTION (reserved-scope typo) STILL THROWS even under :skip-recoverable"
       (is (thrown-with-msg?
             #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
-            (mstate/validate-target-map!
+            (rf.resources.mutation-runtime/validate-target-map!
               {{:resource :r/article :params {:slug "w"} :scope :rf.scope/global} :ok
                {:resource :r/article :params {:slug "x"} :scope :rf.scope/glabal} :bad}
               resolve-scope (constantly true) :patches 'test :skip-recoverable))))
     (testing "CACHE-IDENTITY CORRUPTION (non-EDN params) STILL THROWS"
       (is (thrown-with-msg?
             #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
-            (mstate/validate-target-map!
+            (rf.resources.mutation-runtime/validate-target-map!
               {{:resource :r/article :params {:slug "w" :cb (fn [])} :scope :rf.scope/global} :bad}
               resolve-scope (constantly true) :patches 'test :skip-recoverable))))
     (testing "a {:from-db …} nil-resolve is STILL fail-closed-dropped (separate from skip)"
       (is (= [{} [:nope] []]
-             (mstate/validate-target-map!
+             (rf.resources.mutation-runtime/validate-target-map!
                {{:resource :r/article :params {:slug "w"} :scope {:from-db :nope}} :v}
                resolve-scope (constantly true) :populates 'test :skip-recoverable))))
     (testing "an empty / nil map returns the 3-tuple empty shape [nil [] []]"
-      (is (= [nil [] []] (mstate/validate-target-map! {} resolve-scope (constantly true) :patches 'test :skip-recoverable)))
-      (is (= [nil [] []] (mstate/validate-target-map! nil resolve-scope (constantly true) :patches 'test :skip-recoverable))))))
+      (is (= [nil [] []] (rf.resources.mutation-runtime/validate-target-map! {} resolve-scope (constantly true) :patches 'test :skip-recoverable)))
+      (is (= [nil [] []] (rf.resources.mutation-runtime/validate-target-map! nil resolve-scope (constantly true) :patches 'test :skip-recoverable))))))
 
 (deftest classify-target-key-corruption-vs-recoverable
   ;; rf2-1vpbld — the pure classifier: recoverable cases return [:skip …]
@@ -1162,27 +1162,27 @@
   (testing "an unregistered resource classifies :skip :unregistered-resource"
     (is (= [:skip :unregistered-resource {:target (pr-str {:resource :r/nope :params {:slug "w"}})
                                           :resource :r/nope}]
-           (mstate/classify-target-key
+           (rf.resources.mutation-runtime/classify-target-key
              {:resource :r/nope :params {:slug "w"}} :rf.scope/global (constantly false) 'test :patches))))
   (testing "a non-map target classifies :skip :non-map-target"
     (is (= :non-map-target
-           (second (mstate/classify-target-key :r/article :rf.scope/global (constantly true) 'test :patches)))))
+           (second (rf.resources.mutation-runtime/classify-target-key :r/article :rf.scope/global (constantly true) 'test :patches)))))
   (testing "a non-keyword :resource classifies :skip :non-keyword-resource"
     (is (= :non-keyword-resource
-           (second (mstate/classify-target-key {:resource "article" :params {}} :rf.scope/global (constantly true) 'test :patches)))))
+           (second (rf.resources.mutation-runtime/classify-target-key {:resource "article" :params {}} :rf.scope/global (constantly true) 'test :patches)))))
   (testing "a valid target classifies :apply <canonical key>"
     (is (= [:apply [:rf.scope/global :r/article {:slug "w"}]]
-           (mstate/classify-target-key
+           (rf.resources.mutation-runtime/classify-target-key
              {:resource :r/article :params {:slug "w"}} :rf.scope/global (constantly true) 'test :patches))))
   (testing "a reserved-scope typo THROWS (corruption) — never classified :skip"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
-          (mstate/classify-target-key
+          (rf.resources.mutation-runtime/classify-target-key
             {:resource :r/article :params {:slug "w"}} :rf.scope/glabal (constantly true) 'test :patches))))
   (testing "corruption (non-EDN scope) wins even when the resource is also unregistered"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
-          (mstate/classify-target-key
+          (rf.resources.mutation-runtime/classify-target-key
             {:resource :r/nope :params {:slug "w"}} (fn []) (constantly false) 'test :patches)))))
 
 (deftest recoverable-patch-target-skipped-while-valid-sibling-lands
@@ -1194,7 +1194,7 @@
   ;; whole committed mutation (the asymmetry-fix: a patch on a missing entry
   ;; already no-ops; an unregistered target now does too, with a loud warning).
   (rf/reg-resource :r/article (article-resource-spec) article-resource-request)
-  (let [good-key (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})
+  (let [good-key (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})
         bad-key  [:rf.scope/global :r/never-registered {:slug "w"}]]
     (rf/reg-mutation :m/save
                      {:params-schema [:map [:slug :string]]
@@ -1245,7 +1245,7 @@
   ;; wrong-identity write. The event loop catches the throw, so we observe the
   ;; fail-closed EFFECT: the valid sibling in the same arm did NOT land.
   (rf/reg-resource :r/article (article-resource-spec) article-resource-request)
-  (let [good-key (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+  (let [good-key (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
     (rf/reg-mutation :m/save
                      {:params-schema [:map [:slug :string]]
                       ;; the SECOND target carries a bare reserved-scope typo
@@ -1270,7 +1270,7 @@
   ;; SKIPPED-AND-WARNED while the valid sibling SEEDS the cache and the instance
   ;; SETTLES.
   (rf/reg-resource :r/article (article-resource-spec) article-resource-request)
-  (let [good-key (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+  (let [good-key (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
     (rf/reg-mutation :m/create
                      {:params-schema [:map [:slug :string]]
                       :populates (fn [_p r] {{:resource :r/article :params {:slug "w"} :scope :rf.scope/global} r
@@ -1293,7 +1293,7 @@
   ;; SKIPPED-AND-WARNED while the valid sibling DROPS its entry and the instance
   ;; SETTLES.
   (rf/reg-resource :r/article (article-resource-spec) article-resource-request)
-  (let [good-key (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+  (let [good-key (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :r/article :scope :rf.scope/global :params {:slug "w"}}])
     (reply-success! @last-managed-args {:title "doomed"})
@@ -1322,7 +1322,7 @@
   ;; serializable target patches normally (validation is transparent on valid
   ;; input, and canonicalizes the key so an alternate spelling still lands).
   (rf/reg-resource :r/article (article-resource-spec) article-resource-request)
-  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
     (rf/reg-mutation :m/patch
                      {:params-schema [:map [:slug :string]]
                       ;; target params spelled in a different key order — must
@@ -1354,7 +1354,7 @@
   (rf/reg-mutation :m/save (save-article-spec {:invalidate-timing :before-request}) save-article-request)
   (let [cofx   {:rf.db/runtime {} :rf.frame/id :rf/default
                 :rf.resource/generation-allocation {:generation 1 :counter 1}}
-        out    (mevents/execute-handler
+        out    (rf.resources.mutation-events/execute-handler
                  cofx [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :ord1}])
         fx     (:fx out)
         fx-ids (mapv first fx)
@@ -1378,7 +1378,7 @@
   (rf/reg-mutation :m/save (save-article-spec) save-article-request) ;; default :after-success
   (let [cofx {:rf.db/runtime {} :rf.frame/id :rf/default
               :rf.resource/generation-allocation {:generation 1 :counter 1}}
-        out  (mevents/execute-handler
+        out  (rf.resources.mutation-events/execute-handler
                cofx [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :ord2}])
         fx-ids (mapv first (:fx out))]
     (testing "no before-request invalidation dispatch is emitted on the default timing"
@@ -1412,17 +1412,17 @@
   ;; rf2-e8wj5t — valid scalar / vector instance ids pass (they ARE
   ;; epoch / restore-safe serializable EDN).
   (testing "scalar ids pass"
-    (is (= :form/save-1 (mstate/validate-instance-id! :form/save-1 'test)))
-    (is (= "inst-7" (mstate/validate-instance-id! "inst-7" 'test)))
-    (is (= 42 (mstate/validate-instance-id! 42 'test))))
+    (is (= :form/save-1 (rf.resources.mutation-runtime/validate-instance-id! :form/save-1 'test)))
+    (is (= "inst-7" (rf.resources.mutation-runtime/validate-instance-id! "inst-7" 'test)))
+    (is (= 42 (rf.resources.mutation-runtime/validate-instance-id! 42 'test))))
   (testing "a vector id (e.g. a row-keyed form instance) passes"
-    (is (= [:row 7] (mstate/validate-instance-id! [:row 7] 'test))))
+    (is (= [:row 7] (rf.resources.mutation-runtime/validate-instance-id! [:row 7] 'test))))
   (testing "nil passes (the events layer then mints a generated id)"
-    (is (nil? (mstate/validate-instance-id! nil 'test))))
+    (is (nil? (rf.resources.mutation-runtime/validate-instance-id! nil 'test))))
   (testing "a host value is rejected"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-non-serializable-instance-id"
-          (mstate/validate-instance-id! (fn []) 'test)))))
+          (rf.resources.mutation-runtime/validate-instance-id! (fn []) 'test)))))
 
 (deftest execute-with-valid-vector-instance-id
   ;; rf2-e8wj5t — a vector instance id (a common row-keyed form shape) is
@@ -1444,11 +1444,11 @@
   ;; clear would gate the wrong one).
   (rf/reg-mutation :m/save (save-article-spec) save-article-request)
   (let [all-args (atom [])]
-    (fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! all-args conj args) nil))
+    (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! all-args conj args) nil))
     (let [iv [:row 7]
           il '(:row 7)]
       (is (= iv il) "the two instance ids are Clojure-= (the collapse routed around)")
-      (is (not= (mstate/instance-key-id iv) (mstate/instance-key-id il))
+      (is (not= (rf.resources.mutation-runtime/instance-key-id iv) (rf.resources.mutation-runtime/instance-key-id il))
           "their byte key-ids differ (v[…] vs l(…)) — distinct storage rows")
       (rf/dispatch-sync [:rf.mutation/execute
                          {:mutation :m/save :params {:slug "v"} :instance iv}])
@@ -1483,7 +1483,7 @@
   ;; identity, so clearing `[:row 7]` does NOT also clear / gate `'(:row 7)`.
   (rf/reg-mutation :m/save (save-article-spec) save-article-request)
   (let [all-args (atom [])]
-    (fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! all-args conj args) nil))
+    (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! all-args conj args) nil))
     (let [iv [:row 7]
           il '(:row 7)]
       (rf/dispatch-sync [:rf.mutation/execute
@@ -1509,7 +1509,7 @@
 (deftest cross-frame-mutation-request-id-does-not-collide
   (rf/reg-mutation :m/save (save-article-spec) save-article-request)
   (let [all-args (atom [])]
-    (fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! all-args conj args) nil))
+    (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! all-args conj args) nil))
     (let [fa :xm/frame-a
           fb :xm/frame-b]
       (rf/make-frame {:id fa :doc "frame A"})
@@ -1531,17 +1531,17 @@
         (testing "Spec 016 §Transport — the lowered transport :request-id is
                   the frame-QUALIFIED token, DISTINCT per frame"
           (is (= 2 (count req-ids)))
-          (is (contains? (set req-ids) (work-ledger/managed-request-id fa wid-a)))
-          (is (contains? (set req-ids) (work-ledger/managed-request-id fb wid-b)))
+          (is (contains? (set req-ids) (rf.resources.work-ledger/managed-request-id fa wid-a)))
+          (is (contains? (set req-ids) (rf.resources.work-ledger/managed-request-id fb wid-b)))
           (is (apply distinct? req-ids) "the two frames' request-ids differ")
           (is (not= (set req-ids) #{wid-a})
               "the request-id is NOT the bare work-id (which would collide)"))
         (testing "each frame holds an independent live work record keyed by
                   its own [frame-id work-id]"
-          (is (= :running (:status (work-ledger/get-record (runtime-db fa) wid-a))))
-          (is (= :running (:status (work-ledger/get-record (runtime-db fb) wid-b))))
-          (is (some? (work-ledger/get-handle fa wid-a)))
-          (is (some? (work-ledger/get-handle fb wid-b))))
+          (is (= :running (:status (rf.resources.work-ledger/get-record (runtime-db fa) wid-a))))
+          (is (= :running (:status (rf.resources.work-ledger/get-record (runtime-db fb) wid-b))))
+          (is (some? (rf.resources.work-ledger/get-handle fa wid-a)))
+          (is (some? (rf.resources.work-ledger/get-handle fb wid-b))))
         (testing "frame A's reply settles ONLY frame A's instance — frame B's
                   write stays independently in flight (no stranded instance)"
           ;; the reply event the live transport appends, dispatched into frame A
@@ -1578,7 +1578,7 @@
   ;; affected keys, work id, frame id, completion time, and cause.
   (reg-capture-continuation!)
   (rf/reg-resource :r/article (article-resource-spec) article-resource-request)
-  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})
         completed-at 1781078400777]
     (rf/reg-mutation :m/save
                      {:params-schema [:map [:slug :string]]
@@ -1618,7 +1618,7 @@
                     :params-schema [:map [:slug :string]]
                     :tags (fn [{:keys [slug]} _] #{[:article slug] [:article-list]})}
                    (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}}))
-  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
     (rf/reg-mutation :m/save (save-article-spec) save-article-request)
     ;; own + load the list-tagged article so the invalidation refetches it
     (rf/dispatch-sync [:rf.resource/ensure
@@ -1664,20 +1664,20 @@
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #"event-vector|Invalid"
-          (reply/durable-target {:event :not-a-vector})))
+          (rf.reply/durable-target {:event :not-a-vector})))
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #"event-vector|Invalid"
-          (reply/durable-target {}))))
+          (rf.reply/durable-target {}))))
   (testing "a host handle smuggled into a public slot (a fn in :suppress) is rejected"
     (try
-      (reply/durable-target {:event [:test/save-replied] :suppress {:cb (fn [] 1)}})
+      (rf.reply/durable-target {:event [:test/save-replied] :suppress {:cb (fn [] 1)}})
       (is false "expected durable-target to reject a host-handle target")
       (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
         (is (= :rf.reply/non-data-target (:rf.error/kind (ex-data e)))))))
   (testing "a WELL-FORMED data-only call-site target survives durable projection"
     (is (= {:event [:test/save-replied] :delivery :append}
-           (reply/durable-target [:test/save-replied])))))
+           (rf.reply/durable-target [:test/save-replied])))))
 
 (deftest execute-rejects-malformed-reply-to-fails-closed
   ;; rf2-6kdcs9 — the dispatch-path fail-closed EFFECT: a malformed call-site
@@ -1708,7 +1708,7 @@
                       :params-schema [:map [:slug :string]]
                       :tags (fn [{:keys [slug]} _] #{[:article slug]})}
                      (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}}))
-    (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+    (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
       (rf/reg-mutation :m/save
                        {:params-schema [:map [:slug :string]]
                         :populates (fn [_params result] {(art-target) result})}
@@ -1942,7 +1942,7 @@
                     :params-schema [:map [:slug :string]]
                     :tags (fn [{:keys [slug]} _] #{[:article slug]})}
                    (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}}))
-  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
     (rf/reg-mutation :m/save (save-article-spec {:invalidate-timing :after-failure}) save-article-request)
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :r/article :scope :rf.scope/global :params {:slug "w"}}])
@@ -1971,7 +1971,7 @@
 (deftest invalidation-only-success-includes-stale-keys-in-affected-keys
   (reg-capture-continuation!)
   (rf/reg-resource :r/article (article-resource-spec) article-resource-request)
-  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
     ;; an ownerless loaded article entry the mutation will INVALIDATE (no
     ;; populate / patch — invalidation is the ONLY cache consequence).
     (rf/dispatch-sync [:rf.resource/ensure
@@ -2002,7 +2002,7 @@
 (deftest after-failure-invalidation-includes-stale-keys-in-affected-keys
   (reg-capture-continuation!)
   (rf/reg-resource :r/article (article-resource-spec) article-resource-request)
-  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :r/article :scope :rf.scope/global :params {:slug "w"} :owner [:v :a]}])
     (reply-success! @last-managed-args {:title "x"})
@@ -2032,7 +2032,7 @@
   ;; cached entry (mirroring :rf.resource/remove) and reports the removed key.
   (reg-capture-continuation!)
   (rf/reg-resource :r/article (article-resource-spec) article-resource-request)
-  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
     ;; seed a loaded entry the delete mutation will remove
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :r/article :scope :rf.scope/global :params {:slug "w"}}])
@@ -2060,7 +2060,7 @@
   ;; the :removes fn may return a SINGLE map-form target (sugar) — not only a
   ;; collection. A remove of a key with no entry is a harmless no-op.
   (rf/reg-resource :r/article (article-resource-spec) article-resource-request)
-  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :r/article :scope :rf.scope/global :params {:slug "w"}}])
     (reply-success! @last-managed-args {:title "x"})

--- a/implementation/resources/test/re_frame/resources_mutation_scope_mismatch_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_scope_mismatch_cljs_test.cljc
@@ -35,26 +35,26 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting requires: register the :rf.resource/* +
    ;; :rf.mutation/* events + subs + the generation cofx/fx.
    [re-frame.resources]
-   [re-frame.resources.state :as state]
-   [re-frame.registrar :as registrar]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.registrar :as rf.registrar]
    [re-frame.resources.test-support]
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   [re-frame.trace.tooling :as trace-tooling]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport ---------------------------------------------------
 
 (def ^:private last-managed-args (atom nil))
 
 (defn- init! []
-  (registrar/clear-kind! :resource-scope)
+  (rf.registrar/clear-kind! :resource-scope)
   ;; a named db-derived viewer-session resolver (EP-0016 D3 canonical form)
   (rf/reg-resource-scope :t/session
     {:inputs {:username [:db [:auth :user :username]]}}
@@ -64,25 +64,25 @@
 
 (defn- capturing-transport-fixture [f]
   (reset! last-managed-args nil)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
-  (fx/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter :init-fn init!}
-       :cljs {:adapter reagent-adapter/adapter :init-fn init!}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter :init-fn init!}
+       :cljs {:adapter rf.adapter.reagent/adapter :init-fn init!}))
   capturing-transport-fixture)
 
 ;; ---- helpers ---------------------------------------------------------------
 
 (defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
-(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
+(defn- entry [scoped-key] (get-in (runtime-db) (rf.resources.state/entry-path scoped-key)))
 
 (defn- reply-success! [args result]
   (rf/dispatch-sync (conj (:on-success args) {:status :ok :value result})))
 
-(defn- session-feed-key [u] (state/scoped-resource-key [:rf.scope/session {:username u}] :r/feed {}))
+(defn- session-feed-key [u] (rf.resources.state/scoped-resource-key [:rf.scope/session {:username u}] :r/feed {}))
 
 (defn- reg-feed-resource!
   "A SESSION-scoped resource (`{:from-db :t/session}`) producing the `[:feed]`
@@ -120,10 +120,10 @@
   [body-fn]
   (let [seen (atom [])
         k    ::warn-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (= :rf.warning/mutation-scope-mismatch (:operation ev))
                    (swap! seen conj ev))))
-    (try (body-fn) (finally (trace-tooling/unregister-listener! k)))
+    (try (body-fn) (finally (rf.trace.tooling/unregister-listener! k)))
     @seen))
 
 ;; ===========================================================================
@@ -294,7 +294,7 @@
                                                               :params {:slug "w"} :instance :s1}])
                      (reply-success! @last-managed-args {:favorited true})))]
     (testing "both targets HIT their own-scope entries"
-      (is (some? (:invalidated-at (entry (state/scoped-resource-key
+      (is (some? (:invalidated-at (entry (rf.resources.state/scoped-resource-key
                                            :rf.scope/global :r/article {:slug "w"})))))
       (is (some? (:invalidated-at (entry (session-feed-key "jake"))))))
     (testing "no scope-mismatch warning — the safe pattern matched every scope"

--- a/implementation/resources/test/re_frame/resources_optimistic_apply_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_optimistic_apply_cljs_test.cljc
@@ -38,27 +38,27 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting requires: register the :rf.resource/* +
    ;; :rf.mutation/* events + subs + the generation cofx/fx.
    [re-frame.resources]
-   [re-frame.resources.mutation-registry :as mreg]
-   [re-frame.resources.state :as state]
-   [re-frame.registrar :as registrar]
+   [re-frame.resources.mutation-registry :as rf.resources.mutation-registry]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.registrar :as rf.registrar]
    [re-frame.resources.test-support]
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   [re-frame.trace.tooling :as trace-tooling]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport ---------------------------------------------------
 
 (def ^:private last-managed-args (atom nil))
 
 (defn- init! []
-  (registrar/clear-kind! :resource-scope)
+  (rf.registrar/clear-kind! :resource-scope)
   (rf/reg-resource-scope :t/session
     {:inputs {:username [:db [:auth :user :username]]}}
     (fn [{:keys [username]} _ctx]
@@ -68,33 +68,33 @@
 
 (defn- capturing-transport-fixture [f]
   (reset! last-managed-args nil)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
-  (fx/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter :init-fn init!}
-       :cljs {:adapter reagent-adapter/adapter :init-fn init!}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter :init-fn init!}
+       :cljs {:adapter rf.adapter.reagent/adapter :init-fn init!}))
   capturing-transport-fixture)
 
 ;; ---- helpers ---------------------------------------------------------------
 
 (defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
-(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
+(defn- entry [scoped-key] (get-in (runtime-db) (rf.resources.state/entry-path scoped-key)))
 ;; rf2-8iciw8 — `:rf.runtime/mutations` is keyed on the instance id's CEDN-1
-;; byte `key-id` (`state/key-id`), not the raw id; resolve through it.
-(defn- instance [instance-id] (get-in (runtime-db) [:rf.runtime/mutations (state/key-id instance-id)]))
+;; byte `key-id` (`rf.resources.state/key-id`), not the raw id; resolve through it.
+(defn- instance [instance-id] (get-in (runtime-db) [:rf.runtime/mutations (rf.resources.state/key-id instance-id)]))
 (defn- patch-summary [instance-id] (:patch-summary (instance instance-id)))
 
 (defn- reply-success! [args result]
   (rf/dispatch-sync (conj (:on-success args) {:status :ok :value result})))
 
 (def ^:private article-key
-  (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"}))
 
 (defn- session-feed-key [u]
-  (state/scoped-resource-key [:rf.scope/session {:username u}] :r/feed {}))
+  (rf.resources.state/scoped-resource-key [:rf.scope/session {:username u}] :r/feed {}))
 
 (defn- reg-article-resource! []
   (rf/reg-resource :r/article
@@ -114,9 +114,9 @@
   [body-fn]
   (let [seen (atom [])
         k    ::applied-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (= :rf.mutation/optimistic-applied (:operation ev)) (swap! seen conj ev))))
-    (try (body-fn) (finally (trace-tooling/unregister-listener! k)))
+    (try (body-fn) (finally (rf.trace.tooling/unregister-listener! k)))
     (:tags (last @seen))))
 
 ;; ===========================================================================
@@ -245,7 +245,7 @@
                           :tags  #{[:article slug]}
                           :patch (fn [d] (assoc d :touched true))}])}
     (fn [{:keys [slug]} _] {:request {:method :post :url "/fav"}}))
-  (let [list-key (state/scoped-resource-key :rf.scope/global :r/article-list {})]
+  (let [list-key (rf.resources.state/scoped-resource-key :rf.scope/global :r/article-list {})]
     (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/favorite-everywhere
                                              :params {:slug "w"} :instance :fe1}])
     (testing "BOTH tag-matched entries were optimistically patched"
@@ -279,7 +279,7 @@
   (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/touch-feed :params {} :instance :tf1}])
   (testing "no session entry was written (fail-closed drop, never an implicit global)"
     (is (nil? (entry (session-feed-key "jake"))))
-    (is (nil? (entry (state/scoped-resource-key :rf.scope/global :r/feed {})))))
+    (is (nil? (entry (rf.resources.state/scoped-resource-key :rf.scope/global :r/feed {})))))
   (testing "the dropped target is recorded as :target-unresolved; no inverse"
     (let [ps (patch-summary :tf1)]
       (is (= [:t/session] (:target-unresolved ps)))
@@ -329,7 +329,7 @@
       (is (some? ex) "registration threw")
       (is (= :rf.error/mutation-optimistic-before-request
              (:rf.error/id (ex-data ex))))
-      (is (nil? (mreg/mutation-meta :m/bad)) "the bad mutation was NOT registered")))
+      (is (nil? (rf.resources.mutation-registry/mutation-meta :m/bad)) "the bad mutation was NOT registered")))
   (testing ":optimistic-tags + :before-request also throws"
     (let [ex (try
                (rf/reg-mutation :m/bad2

--- a/implementation/resources/test/re_frame/resources_optimistic_settle_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_optimistic_settle_cljs_test.cljc
@@ -30,28 +30,28 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting requires: register the :rf.resource/* +
    ;; :rf.mutation/* events + subs + the generation cofx/fx.
    [re-frame.resources]
-   [re-frame.resources.mutation-runtime :as mstate]
-   [re-frame.resources.ssr :as ssr]
-   [re-frame.resources.state :as state]
-   [re-frame.registrar :as registrar]
+   [re-frame.resources.mutation-runtime :as rf.resources.mutation-runtime]
+   [re-frame.resources.ssr :as rf.resources.ssr]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.registrar :as rf.registrar]
    [re-frame.resources.test-support]
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   [re-frame.trace.tooling :as trace-tooling]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport ---------------------------------------------------
 
 (def ^:private last-managed-args (atom nil))
 
 (defn- init! []
-  (registrar/clear-kind! :resource-scope)
+  (rf.registrar/clear-kind! :resource-scope)
   (rf/reg-resource-scope :t/session
     {:inputs {:username [:db [:auth :user :username]]}}
     (fn [{:keys [username]} _ctx]
@@ -61,23 +61,23 @@
 
 (defn- capturing-transport-fixture [f]
   (reset! last-managed-args nil)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
-  (fx/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter :init-fn init!}
-       :cljs {:adapter reagent-adapter/adapter :init-fn init!}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter :init-fn init!}
+       :cljs {:adapter rf.adapter.reagent/adapter :init-fn init!}))
   capturing-transport-fixture)
 
 ;; ---- helpers ---------------------------------------------------------------
 
 (defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
-(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
+(defn- entry [scoped-key] (get-in (runtime-db) (rf.resources.state/entry-path scoped-key)))
 ;; rf2-8iciw8 — `:rf.runtime/mutations` is keyed on the instance id's CEDN-1
-;; byte `key-id` (`state/key-id`), not the raw id; resolve through it.
-(defn- instance [instance-id] (get-in (runtime-db) [:rf.runtime/mutations (state/key-id instance-id)]))
+;; byte `key-id` (`rf.resources.state/key-id`), not the raw id; resolve through it.
+(defn- instance [instance-id] (get-in (runtime-db) [:rf.runtime/mutations (rf.resources.state/key-id instance-id)]))
 (defn- patch-summary [instance-id] (:patch-summary (instance instance-id)))
 
 (defn- reply-success! [args result]
@@ -87,7 +87,7 @@
   (rf/dispatch-sync (conj (:on-failure args) {:status :error :error failure})))
 
 (def ^:private article-key
-  (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"}))
 
 (defn- reg-article-resource! []
   (rf/reg-resource :r/article
@@ -119,9 +119,9 @@
   [op body-fn]
   (let [seen (atom [])
         k    ::recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (= op (:operation ev)) (swap! seen conj ev))))
-    (try (body-fn) (finally (trace-tooling/unregister-listener! k)))
+    (try (body-fn) (finally (rf.trace.tooling/unregister-listener! k)))
     (:tags (last @seen))))
 
 (defn- traces-of
@@ -131,10 +131,10 @@
   (let [op-set (set ops)
         seen   (atom {})
         k      ::multi]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (op-set (:operation ev))
                    (swap! seen assoc (:operation ev) (:tags ev)))))
-    (try (body-fn) (finally (trace-tooling/unregister-listener! k)))
+    (try (body-fn) (finally (rf.trace.tooling/unregister-listener! k)))
     @seen))
 
 (defn- competing-authoritative-write!
@@ -256,7 +256,7 @@
   ;; exact key, never rediscovered through the entry's optional tags). Capture
   ;; the recovery request the refetch lowers into managed HTTP.
   (let [muta @last-managed-args]
-    (fx/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
+    (rf.fx/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
     (reset! last-managed-args nil)
     (let [rb (trace-of :rf.mutation/optimistic-rolled-back
                #(reply-failure! muta {:kind :rf.http/http-5xx :status 500}))]
@@ -323,7 +323,7 @@
   "A restored cache entry carrying the OPTIMISTIC value (the heart already
   flipped, no in-flight write to confirm it), at `:revision` `rev`."
   [rev fav count]
-  (merge (state/empty-entry :r/article article-key)
+  (merge (rf.resources.state/empty-entry :r/article article-key)
          {:status :loaded :data {:article {:favorited fav :favoritesCount count}}
           :loaded-at 1000 :stale-at 9.0e15 :revision rev
           :tags #{[:article "w"] [:article-list]}}))
@@ -332,7 +332,7 @@
   "A restored :pending mutation instance whose `:patch-summary` `:rollback`
   records the snapshot-inverse the dangle must replay."
   [rollback]
-  (-> (mstate/empty-instance :m/favorite :f1
+  (-> (rf.resources.mutation-runtime/empty-instance :m/favorite :f1
         {:scope :rf.scope/global :params {:slug "w"} :generation 3
          :work-id [:rf.work/resource [:rf.mutation :f1 3] 3] :started-at 1000})
       (assoc :patch-summary {:snapshot-id [:rf.mutation/snapshot :f1 3]
@@ -343,46 +343,46 @@
   ;; the mutation must be registered so the dangle can read its :on-conflict.
   (rf/reg-mutation :m/favorite favorite-plan favorite-plan-request)        ;; defaults :invalidate
   (testing "NO CONFLICT — the recorded :before is restored INSIDE the reconcile pass"
-    (let [before (merge (state/empty-entry :r/article article-key)
+    (let [before (merge (rf.resources.state/empty-entry :r/article article-key)
                         {:status :loaded :data {:article {:favorited false :favoritesCount 9}}
                          :loaded-at 1000 :stale-at 9.0e15 :revision 5
                          :tags #{[:article "w"] [:article-list]}})
           ;; the apply left the entry at `before.revision + 1` (= 6); the cache
           ;; shows the optimistic value at that applied revision (no competing
           ;; write since the apply) → no conflict.
-          rdb {state/resources-key {:entries {(state/key-id article-key)
+          rdb {rf.resources.state/resources-key {:entries {(rf.resources.state/key-id article-key)
                                               (optimistic-entry 6 true 10)}
                                     :tag-index {} :owner-index {}}
-               mstate/mutations-key
-               {(mstate/instance-key-id :f1)
+               rf.resources.mutation-runtime/mutations-key
+               {(rf.resources.mutation-runtime/instance-key-id :f1)
                 (pending-optimistic-instance
-                  [(mstate/record-optimistic-entry article-key before :patch)])}}
-          out (ssr/reconcile-on-restore rdb :app/main {:restore-time-ms 7777})
-          e   (get-in out [state/resources-key :entries (state/key-id article-key)])]
+                  [(rf.resources.mutation-runtime/record-optimistic-entry article-key before :patch)])}}
+          out (rf.resources.ssr/reconcile-on-restore rdb :app/main {:restore-time-ms 7777})
+          e   (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id article-key)])]
       (testing "the optimistic value was ROLLED BACK to the recorded :before"
         (is (= 9 (get-in e [:data :article :favoritesCount])) "count reverted")
         (is (= false (get-in e [:data :article :favorited])) "heart un-flipped"))
       (testing "the instance is terminally dangled (the same pass)"
-        (is (= :error (get-in out [mstate/mutations-key (mstate/instance-key-id :f1) :status])))
-        (is (= :dangling-on-restore (:reason (get-in out [mstate/mutations-key (mstate/instance-key-id :f1) :error]))))
-        (is (nil? (get-in out [mstate/mutations-key (mstate/instance-key-id :f1) :current-work]))))))
+        (is (= :error (get-in out [rf.resources.mutation-runtime/mutations-key (rf.resources.mutation-runtime/instance-key-id :f1) :status])))
+        (is (= :dangling-on-restore (:reason (get-in out [rf.resources.mutation-runtime/mutations-key (rf.resources.mutation-runtime/instance-key-id :f1) :error]))))
+        (is (nil? (get-in out [rf.resources.mutation-runtime/mutations-key (rf.resources.mutation-runtime/instance-key-id :f1) :current-work]))))))
   (testing "CONFLICT — a moved revision marks the entry durably STALE in the pass
             (NOT a racing dispatch), the read path refetches on next ensure"
-    (let [before (merge (state/empty-entry :r/article article-key)
+    (let [before (merge (rf.resources.state/empty-entry :r/article article-key)
                         {:status :loaded :data {:article {:favorited false :favoritesCount 9}}
                          :loaded-at 1000 :stale-at 9.0e15 :revision 5
                          :tags #{[:article "w"] [:article-list]}})
           ;; the cache entry's revision (8) MOVED past the recorded one (5) — a
           ;; competing authoritative write landed before the snapshot was taken.
-          rdb {state/resources-key {:entries {(state/key-id article-key)
+          rdb {rf.resources.state/resources-key {:entries {(rf.resources.state/key-id article-key)
                                               (optimistic-entry 8 false 100)}
                                     :tag-index {} :owner-index {}}
-               mstate/mutations-key
-               {(mstate/instance-key-id :f1)
+               rf.resources.mutation-runtime/mutations-key
+               {(rf.resources.mutation-runtime/instance-key-id :f1)
                 (pending-optimistic-instance
-                  [(mstate/record-optimistic-entry article-key before :patch)])}}
-          out (ssr/reconcile-on-restore rdb :app/main {:restore-time-ms 7777})
-          e   (get-in out [state/resources-key :entries (state/key-id article-key)])]
+                  [(rf.resources.mutation-runtime/record-optimistic-entry article-key before :patch)])}}
+          out (rf.resources.ssr/reconcile-on-restore rdb :app/main {:restore-time-ms 7777})
+          e   (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id article-key)])]
       (testing "the conflicted entry is NOT restored — the newer truth (100) is kept"
         (is (= 100 (get-in e [:data :article :favoritesCount]))
             "the stale inverse (9) did NOT clobber the moved entry (100)"))
@@ -390,7 +390,7 @@
         (is (= 7777 (:invalidated-at e))
             ":invalidated-at stamped from the restore causal time, in the reconcile pass"))
       (testing "the instance is still terminally dangled"
-        (is (= :error (get-in out [mstate/mutations-key (mstate/instance-key-id :f1) :status])))))))
+        (is (= :error (get-in out [rf.resources.mutation-runtime/mutations-key (rf.resources.mutation-runtime/instance-key-id :f1) :status])))))))
 
 ;; ===========================================================================
 ;; 6. OWNER-CHANGE ROLLBACK (rf2-cxwuhl) — an owner attach / release that lands
@@ -408,9 +408,9 @@
 (defn- stub-lifecycle-fx! []
   ;; no-op the host-timer / refetch fx the rollback + release + GC paths emit,
   ;; so the pure durable-state assertions run without wall-clock side effects.
-  (fx/reg-fx :rf.resource/schedule-timers   (fn [_ _] nil))
-  (fx/reg-fx :rf.resource/cancel-timers     (fn [_ _] nil))
-  (fx/reg-fx :rf.resource/cancel-poll-timers (fn [_ _] nil))
+  (rf.fx/reg-fx :rf.resource/schedule-timers   (fn [_ _] nil))
+  (rf.fx/reg-fx :rf.resource/cancel-timers     (fn [_ _] nil))
+  (rf.fx/reg-fx :rf.resource/cancel-poll-timers (fn [_ _] nil))
   (rf/reg-fx :rf.resource/refetch           (fn [_ _] nil)))
 
 (deftest release-mid-flight-does-not-resurrect-the-owner-on-rollback
@@ -444,7 +444,7 @@
           "the pre-release snapshot's owner set did NOT clobber the current one")
       (is (empty? owners) "the entry is still owner-free after the rollback")))
   (testing "the derived owner-index carries no phantom membership for the departed owner"
-    (is (nil? (get-in (runtime-db) (conj (state/owner-index-path) route-owner)))
+    (is (nil? (get-in (runtime-db) (conj (rf.resources.state/owner-index-path) route-owner)))
         "reindex did not re-add a phantom owner from a resurrected :active-owners"))
   (testing "the now-owner-free, idle entry is GC-eligible and gc-fired COLLECTS it"
     (let [e (entry article-key)]
@@ -483,10 +483,10 @@
           "the mid-flight attach survived (was dropped by the blind restore before the fix)")
       (is (contains? owners [:v :first]) "the original owner is intact too")))
   (testing "the owner-index still routes both owners to the entry"
-    (is (contains? (get-in (runtime-db) (conj (state/owner-index-path) [:v :second]))
-                   (state/key-id article-key)))
-    (is (contains? (get-in (runtime-db) (conj (state/owner-index-path) [:v :first]))
-                   (state/key-id article-key)))))
+    (is (contains? (get-in (runtime-db) (conj (rf.resources.state/owner-index-path) [:v :second]))
+                   (rf.resources.state/key-id article-key)))
+    (is (contains? (get-in (runtime-db) (conj (rf.resources.state/owner-index-path) [:v :first]))
+                   (rf.resources.state/key-id article-key)))))
 
 ;; ===========================================================================
 ;; 7. EXACT-KEY CONFLICT RECOVERY (rf2-wcdj4) — rollback recovery is keyed by
@@ -500,7 +500,7 @@
 ;; ===========================================================================
 
 (def ^:private profile-key
-  (state/scoped-resource-key :rf.scope/global :r/profile {}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global :r/profile {}))
 
 (def ^:private profile-q
   {:resource :r/profile :scope :rf.scope/global :params {}})
@@ -531,7 +531,7 @@
   "Drive the rf2-wcdj4 reproduction through PUBLIC surfaces only: load server
   value A under owner [:v :a], execute the exact-target optimistic save (A→B),
   move the entry's :revision mid-flight via a SECOND owner attach (a fresh-skip
-  cache-hit ensure — state/attach-owner advances :revision, rf2-cxwuhl), then
+  cache-hit ensure — rf.resources.state/attach-owner advances :revision, rf2-cxwuhl), then
   deliver the accepted mutation failure. Returns the rolled-back trace tags;
   `@last-managed-args` afterwards holds the recovery request (or nil)."
   []
@@ -610,7 +610,7 @@
     (reg-save-profile-mutation!)
     (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save-profile :params {} :instance :s1
                                              :reply-to [:t/save-settled]}])
-    ;; the sole owner leaves mid-flight — state/detach-owner advances :revision
+    ;; the sole owner leaves mid-flight — rf.resources.state/detach-owner advances :revision
     ;; (rf2-cxwuhl), so the settle sees a conflict on an OWNER-FREE entry.
     (rf/dispatch-sync [:rf.resource/release-owner {:owner [:v :a]}])
     (is (empty? (:active-owners (entry profile-key)))

--- a/implementation/resources/test/re_frame/resources_optimistic_validation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_optimistic_validation_cljs_test.cljc
@@ -31,27 +31,27 @@
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [clojure.string :as str]
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting requires: register the :rf.resource/* +
    ;; :rf.mutation/* events + subs + the generation cofx/fx.
    [re-frame.resources]
-   [re-frame.resources.mutation-registry :as mreg]
-   [re-frame.resources.state :as state]
-   [re-frame.registrar :as registrar]
+   [re-frame.resources.mutation-registry :as rf.resources.mutation-registry]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.registrar :as rf.registrar]
    [re-frame.resources.test-support]
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   [re-frame.trace.tooling :as trace-tooling]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport ---------------------------------------------------
 
 (def ^:private last-managed-args (atom nil))
 
 (defn- init! []
-  (registrar/clear-kind! :resource-scope)
+  (rf.registrar/clear-kind! :resource-scope)
   (rf/reg-resource-scope :t/session
     {:inputs {:username [:db [:auth :user :username]]}}
     (fn [{:keys [username]} _ctx]
@@ -61,23 +61,23 @@
 
 (defn- capturing-transport-fixture [f]
   (reset! last-managed-args nil)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
-  (fx/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter :init-fn init!}
-       :cljs {:adapter reagent-adapter/adapter :init-fn init!}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter :init-fn init!}
+       :cljs {:adapter rf.adapter.reagent/adapter :init-fn init!}))
   capturing-transport-fixture)
 
 ;; ---- helpers ---------------------------------------------------------------
 
 (defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
-(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
+(defn- entry [scoped-key] (get-in (runtime-db) (rf.resources.state/entry-path scoped-key)))
 ;; rf2-8iciw8 — `:rf.runtime/mutations` is keyed on the instance id's CEDN-1
-;; byte `key-id` (`state/key-id`), not the raw id; resolve through it.
-(defn- instance [instance-id] (get-in (runtime-db) [:rf.runtime/mutations (state/key-id instance-id)]))
+;; byte `key-id` (`rf.resources.state/key-id`), not the raw id; resolve through it.
+(defn- instance [instance-id] (get-in (runtime-db) [:rf.runtime/mutations (rf.resources.state/key-id instance-id)]))
 (defn- patch-summary [instance-id] (:patch-summary (instance instance-id)))
 
 (defn- reply-success! [args result]
@@ -87,7 +87,7 @@
   (rf/dispatch-sync (conj (:on-failure args) {:status :error :error failure})))
 
 (def ^:private article-key
-  (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"}))
 
 (defn- reg-article-resource! []
   (rf/reg-resource :r/article
@@ -122,9 +122,9 @@
   [op body-fn]
   (let [seen (atom [])
         k    ::recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (= op (:operation ev)) (swap! seen conj ev))))
-    (try (body-fn) (finally (trace-tooling/unregister-listener! k)))
+    (try (body-fn) (finally (rf.trace.tooling/unregister-listener! k)))
     (:tags (last @seen))))
 
 (defn- traces-of
@@ -133,10 +133,10 @@
   (let [op-set (set ops)
         seen   (atom {})
         k      ::multi]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (op-set (:operation ev))
                    (swap! seen assoc (:operation ev) (:tags ev)))))
-    (try (body-fn) (finally (trace-tooling/unregister-listener! k)))
+    (try (body-fn) (finally (rf.trace.tooling/unregister-listener! k)))
     @seen))
 
 (defn- competing-authoritative-write!
@@ -419,7 +419,7 @@
      :params-schema [:map]
      :tags (fn [_p _] #{[:feed-w]})}
     (fn [_p _] {:request {:method :get :url "/feed"}}))
-  (let [feed-key (state/scoped-resource-key :rf.scope/global :r/feed {})]
+  (let [feed-key (rf.resources.state/scoped-resource-key :rf.scope/global :r/feed {})]
     (own-loaded! {:resource :r/article :scope :rf.scope/global :params {:slug "w"} :owner [:v :d]}
                  {:article {:favorited false}})
     (own-loaded! {:resource :r/feed :scope :rf.scope/global :params {} :owner [:v :f]}
@@ -494,7 +494,7 @@
   ;; NO :t/login — the {:from-db :t/session} resolver returns nil.
   (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/touch-feed :params {} :instance :tf1}])
   (testing "no entry was written (fail-closed drop, never an implicit global)"
-    (is (nil? (entry (state/scoped-resource-key :rf.scope/global :r/feed {})))))
+    (is (nil? (entry (rf.resources.state/scoped-resource-key :rf.scope/global :r/feed {})))))
   (testing "the dropped target is recorded as :target-unresolved; no inverse"
     (is (= [:t/session] (:target-unresolved (patch-summary :tf1))))
     (is (empty? (:rollback (patch-summary :tf1))))))
@@ -516,7 +516,7 @@
                (catch #?(:clj Exception :cljs :default) e e))]
       (is (some? ex))
       (is (= :rf.error/mutation-optimistic-before-request (:rf.error/id (ex-data ex))))
-      (is (nil? (mreg/mutation-meta :m/bad)) "the bad mutation was NOT registered")))
+      (is (nil? (rf.resources.mutation-registry/mutation-meta :m/bad)) "the bad mutation was NOT registered")))
   (testing ":optimistic-tags + :before-request also throws"
     (let [ex (try
                (rf/reg-mutation :m/bad2
@@ -696,7 +696,7 @@
      :params-schema [:map]
      :tags (fn [_p _] #{[:feed-w]})}
     (fn [_p _] {:request {:method :get :url "/feed"}}))
-  (let [feed-key (state/scoped-resource-key :rf.scope/global :r/feed {})]
+  (let [feed-key (rf.resources.state/scoped-resource-key :rf.scope/global :r/feed {})]
     (own-loaded! {:resource :r/article :scope :rf.scope/global :params {:slug "w"} :owner [:v :d]}
                  {:article {:favorited false}})
     (own-loaded! {:resource :r/feed :scope :rf.scope/global :params {} :owner [:v :f]}

--- a/implementation/resources/test/re_frame/resources_polling_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_polling_cljs_test.cljc
@@ -38,23 +38,23 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
-   [re-frame.identity :as identity]
+   [re-frame.fx :as rf.fx]
+   [re-frame.identity :as rf.identity]
    ;; load-bearing side-effecting require: the façade registers the
    ;; :rf.resource/* events (incl. the internal poll-fired event + the timer /
    ;; cancel-poll-timers fx + the internal replies these tests dispatch).
    [re-frame.resources]
-   [re-frame.resources.state :as state]
+   [re-frame.resources.state :as rf.resources.state]
    [re-frame.resources.test-support]
-   [re-frame.resources.timers :as timers]
-   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.resources.timers :as rf.resources.timers]
+   [re-frame.resources.work-ledger :as rf.resources.work-ledger]
    ;; production HTTP fx surface (so the transport feature probe resolves);
    ;; the actual fetch + abort are overridden by capturing no-ops below.
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport + abort + timer-schedule (deterministic) ---------
 ;;
@@ -79,16 +79,16 @@
   (reset! aborts [])
   (reset! scheduled-timers [])
   (reset! cancelled-poll [])
-  (fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
-  (fx/reg-fx :rf.http/managed-abort (fn [_ctx work-id] (swap! aborts conj work-id) nil))
-  (fx/reg-fx :rf.resource/schedule-timers (fn [_ctx args] (swap! scheduled-timers conj args) nil))
-  (fx/reg-fx :rf.resource/cancel-poll-timers (fn [_ctx args] (swap! cancelled-poll conj args) nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf.fx/reg-fx :rf.http/managed-abort (fn [_ctx work-id] (swap! aborts conj work-id) nil))
+  (rf.fx/reg-fx :rf.resource/schedule-timers (fn [_ctx args] (swap! scheduled-timers conj args) nil))
+  (rf.fx/reg-fx :rf.resource/cancel-poll-timers (fn [_ctx args] (swap! cancelled-poll conj args) nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
   capturing-fixture)
 
 ;; ---- helpers --------------------------------------------------------------
@@ -100,7 +100,7 @@
 (defn- entry
   ([scoped-key] (entry :rf/default scoped-key))
   ([frame-id scoped-key]
-   (get-in (runtime-db frame-id) (state/entry-path scoped-key))))
+   (get-in (runtime-db frame-id) (rf.resources.state/entry-path scoped-key))))
 
 (defn- article-spec
   ([] (article-spec {}))
@@ -161,7 +161,7 @@
 (deftest poll-enabled-active-owner-arms-poll-timer-on-settle
   (rf/reg-resource :pl/poll (article-spec {:poll-interval-ms 5000}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :pl/poll {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :pl/poll {:slug "w"})]
     (ensure! :pl/poll scope "w" [:route :r 1])
     (succeed! k {:title "W"})
     (testing "Spec 016 §Polling — a poll-enabled, actively-owned entry arms a
@@ -173,7 +173,7 @@
 (deftest no-poll-policy-arms-no-poll-timer
   (rf/reg-resource :pl/nopoll (article-spec {:stale-after-ms 1000}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :pl/nopoll {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :pl/nopoll {:slug "w"})]
     (ensure! :pl/nopoll scope "w" [:route :r 1])
     (succeed! k {:title "W"})
     (testing "Spec 016 §Polling — a resource with no :poll-interval-ms arms no
@@ -189,7 +189,7 @@
   ;; the reply landed), no poll timer arms.
   (rf/reg-resource :pl/of (article-spec {:poll-interval-ms 5000 :gc-after-ms 9000}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :pl/of {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :pl/of {:slug "w"})]
     (ensure! :pl/of scope "w" [:app :x 1])
     ;; release the owner BEFORE the reply lands → settles owner-free
     (rf/dispatch-sync [:rf.resource/release-owner {:owner [:app :x 1]}])
@@ -211,7 +211,7 @@
   ;; mirroring the success-path arming.
   (rf/reg-resource :fs/poll (article-spec {:poll-interval-ms 5000}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :fs/poll {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :fs/poll {:slug "w"})]
     (ensure! :fs/poll scope "w" [:app :x 1])
     ;; release the owner BEFORE the reply lands → settles owner-free (no poll)
     (rf/dispatch-sync [:rf.resource/release-owner {:owner [:app :x 1]}])
@@ -239,7 +239,7 @@
   ;; fresh-skip re-arms nothing (the success-path settle armed it).
   (rf/reg-resource :fa/poll (article-spec {:poll-interval-ms 5000}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :fa/poll {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :fa/poll {:slug "w"})]
     (ensure! :fa/poll scope "w" [:route :r 1])
     (succeed! k {:title "W"})   ;; active-owner settle → poll already armed
     (reset! scheduled-timers [])
@@ -264,7 +264,7 @@
   ;; :stale?.
   (rf/reg-resource :pt/poll (article-spec {:poll-interval-ms 5000}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :pt/poll {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :pt/poll {:slug "w"})]
     (ensure! :pt/poll scope "w" [:route :r 1])
     (succeed! k {:title "W"})
     (let [gen-before (:generation (entry k))]
@@ -285,14 +285,14 @@
 (deftest poll-tick-records-poll-cause-never-owner
   (rf/reg-resource :pc/poll (article-spec {:poll-interval-ms 5000}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :pc/poll {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :pc/poll {:slug "w"})]
     (ensure! :pc/poll scope "w" [:route :r 1])
     (succeed! k {:title "W"})
     (poll-fired! k)
     (testing "Spec 016 §Active owners and causes — a poll refetch records the
               :poll CAUSE on the work record but attaches NO new owner"
       (let [e   (entry k)
-            rec (work-ledger/get-record (runtime-db) (:current-work e))]
+            rec (rf.resources.work-ledger/get-record (runtime-db) (:current-work e))]
         (is (= #{[:route :r 1]} (:active-owners e)) "owner set unchanged — poll added no owner")
         (is (some #{:poll} (:causes rec)) "the :poll cause is recorded on the refetch")))))
 
@@ -303,7 +303,7 @@
 (deftest last-owner-release-cancels-poll-timer
   (rf/reg-resource :or/poll (article-spec {:poll-interval-ms 5000 :gc-after-ms 9000}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :or/poll {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :or/poll {:slug "w"})]
     (ensure! :or/poll scope "w" [:app :x 1])
     (succeed! k {:title "W"})
     (reset! cancelled-poll [])
@@ -321,7 +321,7 @@
   ;; close), the tick refetches nothing and does not re-arm.
   (rf/reg-resource :os/poll (article-spec {:poll-interval-ms 5000}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :os/poll {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :os/poll {:slug "w"})]
     (ensure! :os/poll scope "w" [:app :x 1])
     (succeed! k {:title "W"})
     (rf/dispatch-sync [:rf.resource/release-owner {:owner [:app :x 1]}])
@@ -341,7 +341,7 @@
 (deftest hidden-tab-pauses-tick-but-rearms
   (rf/reg-resource :hd/poll (article-spec {:poll-interval-ms 5000}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :hd/poll {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :hd/poll {:slug "w"})]
     (ensure! :hd/poll scope "w" [:route :r 1])
     (succeed! k {:title "W"})
     (reset! scheduled-timers [])
@@ -357,7 +357,7 @@
 (deftest visible-tick-after-hidden-resumes-refetch
   (rf/reg-resource :hr/poll (article-spec {:poll-interval-ms 5000}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :hr/poll {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :hr/poll {:slug "w"})]
     (ensure! :hr/poll scope "w" [:route :r 1])
     (succeed! k {:title "W"})
     (poll-fired! k true)  ;; hidden — paused
@@ -375,7 +375,7 @@
   ;; (no second generation, no overlap) but RE-ARMS.
   (rf/reg-resource :if/poll (article-spec {:poll-interval-ms 5000}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :if/poll {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :if/poll {:slug "w"})]
     (ensure! :if/poll scope "w" [:route :r 1])
     (succeed! k {:title "W"})
     (reset! aborts [])
@@ -406,7 +406,7 @@
   ;; work first sets :current-work, the other becomes a no-op.
   (rf/reg-resource :fp/poll (article-spec {:poll-interval-ms 5000 :stale-after-ms 0}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :fp/poll {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :fp/poll {:slug "w"})]
     (ensure! :fp/poll scope "w" [:route :r 1])
     (succeed! k {:title "W"})
     (let [gen-before (:generation (entry k))]
@@ -427,7 +427,7 @@
 (deftest late-poll-reply-is-suppressed
   (rf/reg-resource :lp/poll (article-spec {:poll-interval-ms 5000}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :lp/poll {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :lp/poll {:slug "w"})]
     (ensure! :lp/poll scope "w" [:route :r 1])
     (succeed! k {:title "W"})
     (let [gen-before (:generation (entry k))]
@@ -438,7 +438,7 @@
                 is suppressed (never overwrites the post-poll entry)"
         (rf/dispatch-sync [:rf.resource.internal/succeeded
                            {:resource/key k
-                            :work/id (work-ledger/resource-work-id k gen-before)
+                            :work/id (rf.resources.work-ledger/resource-work-id k gen-before)
                             :generation gen-before :data {:title "Zombie"}}])
         (is (not= {:title "Zombie"} (:data (entry k)))
             "the pre-poll-generation reply was suppressed")))))
@@ -449,18 +449,18 @@
 
 (deftest reload-reschedules-poll-cancel-then-arm
   ;; A poll tick that settles reschedules the poll (cancel-then-arm). The
-  ;; schedule-timers fx is cancel-then-arm by construction (timers/schedule!),
+  ;; schedule-timers fx is cancel-then-arm by construction (rf.resources.timers/schedule!),
   ;; so a re-load emits a fresh schedule rather than stacking timers.
   (rf/reg-resource :rs/poll (article-spec {:poll-interval-ms 5000}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :rs/poll {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :rs/poll {:slug "w"})]
     (ensure! :rs/poll scope "w" [:route :r 1])
     (succeed! k {:title "W"})
     (poll-fired! k)               ;; tick → refetch in flight
     (reset! scheduled-timers [])
     (succeed! k {:title "W2"})    ;; the poll refetch settles → reschedules
     (testing "Spec 016 §Polling — a settle reschedules the poll (cancel-then-arm
-              via timers/schedule!), it does not stack a second poll timer"
+              via rf.resources.timers/schedule!), it does not stack a second poll timer"
       (is (= {:title "W2"} (:data (entry k))) "new data landed")
       (let [args (last-schedule-for k)]
         (is (= 5000 (get-in args [:timers :poll])) "poll re-armed on the new settle")))))
@@ -472,7 +472,7 @@
 (deftest background-poll-failure-keeps-prior-data-and-keeps-polling
   (rf/reg-resource :bf/poll (article-spec {:poll-interval-ms 5000}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :bf/poll {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :bf/poll {:slug "w"})]
     (ensure! :bf/poll scope "w" [:route :r 1])
     (succeed! k {:title "W"})
     (poll-fired! k)            ;; tick → refetch in flight
@@ -499,10 +499,10 @@
     (let [fired (atom 0)]
       ;; arm a real poll timer via the substrate (long delay — we cancel before
       ;; it fires; we only assert the side-table slot is dropped)
-      (timers/schedule! :pk/frame [:s :pk/r {}] timers/poll-kind 60000)
-      (is (contains? @timers/timer-table [:pk/frame (identity/canonical-bytes [:s :pk/r {}]) timers/poll-kind])
+      (rf.resources.timers/schedule! :pk/frame [:s :pk/r {}] rf.resources.timers/poll-kind 60000)
+      (is (contains? @rf.resources.timers/timer-table [:pk/frame (rf.identity/canonical-bytes [:s :pk/r {}]) rf.resources.timers/poll-kind])
           "poll timer armed in the side table")
-      (timers/cancel-for-key! :pk/frame [:s :pk/r {}])
-      (is (not (contains? @timers/timer-table [:pk/frame (identity/canonical-bytes [:s :pk/r {}]) timers/poll-kind]))
+      (rf.resources.timers/cancel-for-key! :pk/frame [:s :pk/r {}])
+      (is (not (contains? @rf.resources.timers/timer-table [:pk/frame (rf.identity/canonical-bytes [:s :pk/r {}]) rf.resources.timers/poll-kind]))
           "cancel-for-key! dropped the :poll slot")
       @fired)))

--- a/implementation/resources/test/re_frame/resources_populate_exact_target_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_populate_exact_target_cljs_test.cljc
@@ -47,26 +47,26 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting requires: register the :rf.resource/* +
    ;; :rf.mutation/* events + subs + the generation cofx/fx.
    [re-frame.resources]
-   [re-frame.resources.state :as state]
-   [re-frame.registrar :as registrar]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.registrar :as rf.registrar]
    [re-frame.resources.test-support]
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   [re-frame.trace.tooling :as trace-tooling]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport ---------------------------------------------------
 
 (def ^:private last-managed-args (atom nil))
 
 (defn- init! []
-  (registrar/clear-kind! :resource-scope)
+  (rf.registrar/clear-kind! :resource-scope)
   ;; the named db-derived viewer-session resolver (EP-0016 D3 canonical form)
   (rf/reg-resource-scope :t/session
     {:inputs {:username [:db [:auth :user :username]]}}
@@ -76,33 +76,33 @@
 
 (defn- capturing-transport-fixture [f]
   (reset! last-managed-args nil)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
-  (fx/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter :init-fn init!}
-       :cljs {:adapter reagent-adapter/adapter :init-fn init!}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter :init-fn init!}
+       :cljs {:adapter rf.adapter.reagent/adapter :init-fn init!}))
   capturing-transport-fixture)
 
 ;; ---- helpers ---------------------------------------------------------------
 
 (defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
-(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
+(defn- entry [scoped-key] (get-in (runtime-db) (rf.resources.state/entry-path scoped-key)))
 ;; rf2-8iciw8 — `:rf.runtime/mutations` is keyed on the instance id's CEDN-1
-;; byte `key-id` (`state/key-id`), not the raw id; resolve through it.
+;; byte `key-id` (`rf.resources.state/key-id`), not the raw id; resolve through it.
 (defn- instance [instance-id]
-  (get-in (runtime-db) [:rf.runtime/mutations (state/key-id instance-id)]))
+  (get-in (runtime-db) [:rf.runtime/mutations (rf.resources.state/key-id instance-id)]))
 
 (defn- reply-success! [args result]
   (rf/dispatch-sync (conj (:on-success args) {:status :ok :value result})))
 
 (def ^:private global-article-key
-  (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global :r/article {:slug "w"}))
 
 (defn- session-feed-key [u]
-  (state/scoped-resource-key [:rf.scope/session {:username u}] :r/feed {}))
+  (rf.resources.state/scoped-resource-key [:rf.scope/session {:username u}] :r/feed {}))
 
 (defn- reg-article-resource! []
   (rf/reg-resource :r/article
@@ -132,9 +132,9 @@
   [body-fn]
   (let [seen (atom [])
         k    ::succeeded-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (= :rf.mutation/succeeded (:operation ev)) (swap! seen conj ev))))
-    (try (body-fn) (finally (trace-tooling/unregister-listener! k)))
+    (try (body-fn) (finally (rf.trace.tooling/unregister-listener! k)))
     (:tags (last @seen))))
 
 ;; ===========================================================================
@@ -224,7 +224,7 @@
      ;; just-populated detail key, since the article resource carries it).
      :invalidates (fn [_p _r] #{[:article-list]})}
     (fn [{:keys [slug]} _] {:request {:method :post :url (str "/a/" slug "/fav")}}))
-  (let [list-key (state/scoped-resource-key :rf.scope/global :r/article-list {})
+  (let [list-key (rf.resources.state/scoped-resource-key :rf.scope/global :r/article-list {})
         trace    (succeeded-trace
                    #(do (rf/dispatch-sync [:rf.mutation/execute
                                            {:mutation :m/favorite :params {:slug "w"} :instance :f1}])
@@ -440,7 +440,7 @@
                      (reply-success! @last-managed-args {:articles [:x]})))]
     (testing "FAIL-CLOSED — NO session feed key was seeded under any scope"
       (is (nil? (entry (session-feed-key "jake"))))
-      (is (nil? (entry (state/scoped-resource-key :rf.scope/global :r/feed {})))
+      (is (nil? (entry (rf.resources.state/scoped-resource-key :rf.scope/global :r/feed {})))
           "and never under an implicit global"))
     (testing "the dropped target's resolver id is recorded as :target-unresolved"
       (is (= [:t/session] (:target-unresolved (:patch-summary trace)))))))

--- a/implementation/resources/test/re_frame/resources_reply_correlation_egress_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_reply_correlation_egress_cljs_test.cljc
@@ -8,7 +8,7 @@
   `resources.reply/base-reply` puts the resolved scope in TWO places on every
   reply it builds: free at the top level, and again inside the `:correlation`
   map it stamps beside it. The carrier projector
-  (`trace-egress/project-embedded-keys`) reaches a free `:scope` through
+  (`rf.resources.trace-egress/project-embedded-keys`) reaches a free `:scope` through
   `carrier-family-payload?` — a map is provably the runtime's when its
   IMMEDIATE entries wear the family's reserved vocabulary (a `resource`-
   namespaced key, or a `[:rf.work/resource …]` work-id value). Both halves of
@@ -76,15 +76,15 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting requires: register the :rf.resource/* /
    ;; :rf.mutation/* events this suite dispatches.
    [re-frame.resources]
    [re-frame.resources.test-support]
-   [re-frame.resources.trace-egress :as trace-egress]
+   [re-frame.resources.trace-egress :as rf.resources.trace-egress]
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
+   [re-frame.test-support :as rf.test-support]
    #?(:clj  [re-frame.substrate.plain-atom :as substrate]
       :cljs [re-frame.adapter.reagent :as substrate])))
 
@@ -116,7 +116,7 @@
     (fn [_p _ctx] {:request {:method :get :url "/a"}})))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     {:adapter substrate/adapter
      :init-fn init!}))
 
@@ -172,7 +172,7 @@
   does — through the late-bound `:resources/project-fx-args-egress` hook's
   body, against the row's own `:rf.frame/id` falling back to the record's."
   [rows]
-  (mapv #(update % :tags trace-egress/project-fx-args-egress
+  (mapv #(update % :tags rf.resources.trace-egress/project-fx-args-egress
                  (or (:rf.frame/id (:tags %)) frame-id))
         rows))
 
@@ -199,7 +199,7 @@
   own carriers are covered by rf2-425mm's arm."
   [{:keys [status] :as outcome}]
   (let [captured (atom nil)]
-    (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
+    (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
     (rf/reg-event :app/save-replied (fn [_ _ev] {}))
     (rf/dispatch-sync [:rf.mutation/execute
                        {:mutation :m/save :params {:slug "a-slug"}
@@ -218,7 +218,7 @@
   the agreement counterpart, not a second acceptance arm."
   []
   (let [captured (atom nil)]
-    (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
+    (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
     (rf/reg-event :app/read-loaded (fn [_ _ev] {}))
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :r/article :params {:slug "a-slug"}
@@ -355,7 +355,7 @@
             well as after, which is what makes it a control rather than a
             second acceptance arm"
     (let [captured (atom nil)]
-      (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
+      (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
       (rf/reg-event :app/save-replied (fn [_ _ev] {}))
       (rf/dispatch-sync [:rf.mutation/execute
                          {:mutation :m/save :params {:slug "a-slug"}
@@ -386,8 +386,8 @@
                    :correlation        {:scope [:rf.scope/session {:username secret}]
                                         :generation 3}}
           tags    {:rf.fx/args {:on-success [:app/done foreign]}}]
-      (is (= tags (trace-egress/project-fx-args-egress tags frame-id))
+      (is (= tags (rf.resources.trace-egress/project-fx-args-egress tags frame-id))
           "byte-identical — the resources projector speaks only for what the
            resources runtime planted")
-      (is (nil? (:sensitive? (trace-egress/project-fx-args-egress tags frame-id)))
+      (is (nil? (:sensitive? (rf.resources.trace-egress/project-fx-args-egress tags frame-id)))
           "and does not stamp the row"))))

--- a/implementation/resources/test/re_frame/resources_reply_lowering_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_reply_lowering_cljs_test.cljc
@@ -16,8 +16,8 @@
   Canonical contract: `spec/Managed-Effects.md` §The uniform reply
   envelope; EP-0011 §Resource Reply And Work Ledger / §Mutation Reply."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.reply :as reply]
-            [re-frame.resources.reply :as rreply]))
+            [re-frame.reply :as rf.reply]
+            [re-frame.resources.reply :as rf.resources.reply]))
 
 (def ^:private resource-vp
   "A resource verification payload — what resource lowering stamps into the
@@ -42,9 +42,9 @@
 (deftest resource-success-reply-is-canonical
   (testing "a resource :ok reply carries the decoded result under :value
             (EP-0007: :value everywhere, never :data on the reply map)"
-    (let [r (rreply/success-reply resource-vp {:title "Welcome"}
-                                  {:work-kind rreply/work-kind-resource :completed-at 1781078400456})]
-      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+    (let [r (rf.resources.reply/success-reply resource-vp {:title "Welcome"}
+                                  {:work-kind rf.resources.reply/work-kind-resource :completed-at 1781078400456})]
+      (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r)))
       (is (= :ok (:status r)))
       (is (= :completed (:rf.reply/work-status r)))
       (is (= :resource (:rf.reply/work-kind r)))
@@ -64,10 +64,10 @@
             the causal :completed-at (rf2-rl27r2 — a failed completion is still
             a managed-async completion with a reply token, so its causal
             completion time rides the reply, symmetric with success)"
-    (let [r (rreply/failure-reply resource-vp {:kind :rf.http/http-5xx :status 503}
-                                  {:work-kind rreply/work-kind-resource
+    (let [r (rf.resources.reply/failure-reply resource-vp {:kind :rf.http/http-5xx :status 503}
+                                  {:work-kind rf.resources.reply/work-kind-resource
                                    :completed-at 1781078400456})]
-      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+      (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r)))
       (is (= :error (:status r)))
       (is (= :failed (:rf.reply/work-status r)))
       (is (= :resource (:rf.reply/work-kind r)))
@@ -77,10 +77,10 @@
       (is (nil? (:value r)))))
   (testing "an :rf.http/aborted envelope lowers to :status :cancelled, not
             :error, and carries the causal :completed-at (rf2-rl27r2)"
-    (let [r (rreply/failure-reply resource-vp {:kind :rf.http/aborted :reason :actor-destroyed}
-                                  {:work-kind rreply/work-kind-resource
+    (let [r (rf.resources.reply/failure-reply resource-vp {:kind :rf.http/aborted :reason :actor-destroyed}
+                                  {:work-kind rf.resources.reply/work-kind-resource
                                    :completed-at 1781078400456})]
-      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+      (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r)))
       (is (= :cancelled (:status r)))
       (is (= :cancelled (:rf.reply/work-status r)))
       (is (true? (:cancelled? r)))
@@ -92,9 +92,9 @@
 (deftest mutation-success-reply-is-canonical
   (testing "a mutation :ok reply carries :work/kind :mutation and the result
             under :value (the instance layer stores it as :result — kh9jz6)"
-    (let [r (rreply/success-reply mutation-vp {:slug "w" :title "Welcome"}
-                                  {:work-kind rreply/work-kind-mutation :completed-at 1781078400456})]
-      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+    (let [r (rf.resources.reply/success-reply mutation-vp {:slug "w" :title "Welcome"}
+                                  {:work-kind rf.resources.reply/work-kind-mutation :completed-at 1781078400456})]
+      (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r)))
       (is (= :ok (:status r)))
       (is (= :mutation (:rf.reply/work-kind r)))
       (is (= {:slug "w" :title "Welcome"} (:value r)))
@@ -111,7 +111,7 @@
   (testing "a superseded completion produces :status :stale and DOES NOT deliver"
     (let [carried {:work/id [:rf.work/resource [:rf.scope/global :r {}] 4] :generation 4}
           current {:work/id [:rf.work/resource [:rf.scope/global :r {}] 5] :generation 5}
-          out     (rreply/stale-reply
+          out     (rf.resources.reply/stale-reply
                     {:carried carried :current current
                      :extra   {:rf.reply/work-id (:work/id carried)
                                :work/kind :resource
@@ -124,7 +124,7 @@
         (is (true? (:stale? r)))
         (is (= :resource/generation-mismatch (:rf.reply/stale-reason r)))
         (is (not (contains? r :value)) "a stale reply carries no value (no app mutation)")
-        (is (reply/valid-reply? r) (str (reply/validate-reply r))))
+        (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r))))
       (testing "the suppression trace carries the carried + current correlation"
         (is (= carried (get-in out [:trace :rf.reply/carried])))
         (is (= current (get-in out [:trace :rf.reply/current])))))))

--- a/implementation/resources/test/re_frame/resources_reply_to_reads_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_reply_to_reads_cljs_test.cljc
@@ -37,21 +37,21 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting requires: register the :rf.resource/* events +
    ;; subs + the generation cofx/fx these tests dispatch.
    [re-frame.resources]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.work-ledger :as rf.resources.work-ledger]
    [re-frame.resources.test-support]
    ;; production HTTP fx surface (so the transport feature probe resolves); the
    ;; actual fetch is overridden by the capturing reply stub below.
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   [re-frame.trace.tooling :as trace-tooling]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport + continuation-recording fixture ------------------
 
@@ -61,10 +61,10 @@
 (defn- capturing-fixture [f]
   (reset! last-managed-args nil)
   (reset! replied [])
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
   ;; capture host-side timer arming so the fresh-skip / success handlers'
   ;; emission does not fire a real wall-clock timer.
-  (fx/reg-fx :rf.resource/schedule-timers (fn [_ctx _args] nil))
+  (rf.fx/reg-fx :rf.resource/schedule-timers (fn [_ctx _args] nil))
   ;; the continuation target — an ordinary app event recording the FULL event
   ;; vector (so static-arg preservation + the appended reply are both
   ;; observable). Every test's `:reply-to` names it (distinguished by a static
@@ -73,15 +73,15 @@
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
   capturing-fixture)
 
 ;; ---- helpers --------------------------------------------------------------
 
 (defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
-(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
+(defn- entry [scoped-key] (get-in (runtime-db) (rf.resources.state/entry-path scoped-key)))
 
 (defn- reply-success!
   ([args data] (rf/dispatch-sync (conj (:on-success args) {:status :ok :value data})))
@@ -138,7 +138,7 @@
                          page-param (assoc :cursor page-param))}}))
 
 (defn- feed-key [resource]
-  (state/scoped-resource-key :rf.scope/global resource {:filter :recent}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global resource {:filter :recent}))
 
 (defn- ensure-feed!
   ([resource owner] (ensure-feed! resource owner nil))
@@ -159,11 +159,11 @@
   [body-fn]
   (let [seen (atom [])
         k    ::replied-trace-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (= :rf.resource/replied (:operation ev))
                    (swap! seen conj ev))))
     (try (body-fn)
-         (finally (trace-tooling/unregister-listener! k)))
+         (finally (rf.trace.tooling/unregister-listener! k)))
     @seen))
 
 ;; ===========================================================================
@@ -172,7 +172,7 @@
 
 (deftest reply-to-fires-on-accepted-fetch-and-carries-read-facts
   (rf/reg-resource :rr/article (article-spec) article-request)
-  (let [rkey (state/scoped-resource-key :rf.scope/global :rr/article {:slug "w"})
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :rr/article {:slug "w"})
         completed-at 1781078400777]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :rr/article :scope :rf.scope/global
@@ -205,7 +205,7 @@
 
 (deftest reply-to-cache-hit-dispatches-immediately
   (rf/reg-resource :rr/article (article-spec) article-request)
-  (let [rkey (state/scoped-resource-key :rf.scope/global :rr/article {:slug "w"})]
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :rr/article {:slug "w"})]
     ;; first: load + settle so the entry is fresh :loaded (no :stale-after-ms →
     ;; never time-stale → a later ensure is a fresh-skip cache hit).
     (rf/dispatch-sync [:rf.resource/ensure
@@ -236,7 +236,7 @@
 
 (deftest reply-to-join-in-flight-fans-out-exactly-once
   (rf/reg-resource :rr/article (article-spec) article-request)
-  (let [rkey (state/scoped-resource-key :rf.scope/global :rr/article {:slug "w"})]
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :rr/article {:slug "w"})]
     ;; first ensure kicks off the load (owner A, target tagged :a)
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :rr/article :scope :rf.scope/global
@@ -253,7 +253,7 @@
       (testing "the second ensure joined (no new transport request)"
         (is (= args @last-managed-args) "still the same in-flight args"))
       (testing "both targets recorded on the ONE shared work record"
-        (let [rec (work-ledger/get-record (runtime-db) wid)]
+        (let [rec (rf.resources.work-ledger/get-record (runtime-db) wid)]
           (is (= 2 (count (:reply-targets rec))))))
       ;; ONE success reply settles the shared work
       (reply-success! args {:title "Shared"})
@@ -272,7 +272,7 @@
 
 (deftest reply-to-stale-superseded-never-delivered
   (rf/reg-resource :rr/article (article-spec) article-request)
-  (let [rkey (state/scoped-resource-key :rf.scope/global :rr/article {:slug "w"})]
+  (let [rkey (rf.resources.state/scoped-resource-key :rf.scope/global :rr/article {:slug "w"})]
     ;; gen-1 ensure carries a :reply-to
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :rr/article :scope :rf.scope/global

--- a/implementation/resources/test/re_frame/resources_request_decoration_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_request_decoration_cljs_test.cljc
@@ -42,7 +42,7 @@
   The decoration seam IS the production `:rf.http/managed` per-frame
   interceptor chain (`re-frame.http.middleware`). To exercise it without a
   live fetch we override `:rf.http/managed` with a stub that runs the REAL
-  request-side chain (`http-test-support/run-request-chain`) — so the
+  request-side chain (`rf.http.test-support/run-request-chain`) — so the
   registered interceptors genuinely fire on the request the resource /
   mutation runtime lowered — captures the post-`:before` decorated request,
   and exposes the runtime-owned reply addressing so the test can replay the
@@ -53,26 +53,26 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting requires: register the :rf.resource/* +
    ;; :rf.mutation/* events + subs + the generation cofx/fx.
    [re-frame.resources]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.mutation-runtime :as mstate]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.mutation-runtime :as rf.resources.mutation-runtime]
    [re-frame.resources.test-support]
    ;; production HTTP fx + interceptor surface — loading it publishes the
    ;; transport feature probe (`:http/abort-on-actor-destroy`) the resource
    ;; lowering consults AND registers the per-frame interceptor chain.
-   [re-frame.http.managed :as http-managed]
+   [re-frame.http.managed :as rf.http.managed]
    ;; the request-side chain walker `run-request-chain` is HTTP test
    ;; scaffolding (rf2-w59es5) — it lives in http-test-support alongside the
    ;; canned-stub fxs, not the production machine-wrapper.
-   [re-frame.http.test-support :as http-test-support]
+   [re-frame.http.test-support :as rf.http.test-support]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   [re-frame.trace.tooling :as trace-tooling]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- a transport stub that runs the REAL :before chain --------------------
 ;;
@@ -96,29 +96,29 @@
   ;; the per-frame HTTP-interceptor chain is a `defonce` atom NOT cleared by
   ;; the shared resource reset hook — drop it so each test starts with an
   ;; empty chain (otherwise a prior test's interceptor leaks forward).
-  (http-managed/clear-all-http-interceptors!)
-  (fx/reg-fx :rf.http/managed
+  (rf.http.managed/clear-all-http-interceptors!)
+  (rf.fx/reg-fx :rf.http/managed
              (fn [frame-ctx args]
-               (let [ctx (http-test-support/run-request-chain frame-ctx args)]
+               (let [ctx (rf.http.test-support/run-request-chain frame-ctx args)]
                  (reset! last-decorated
                          {:request    (:request ctx)
                           :on-success (:on-success args)
                           :on-failure (:on-failure args)}))
                nil))
-  (fx/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
+  (rf.fx/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
   decorating-transport-fixture)
 
 ;; ---- helpers --------------------------------------------------------------
 
 (defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
-(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
-(defn- instance [instance-id] (get-in (runtime-db) (mstate/instance-path instance-id)))
+(defn- entry [scoped-key] (get-in (runtime-db) (rf.resources.state/entry-path scoped-key)))
+(defn- instance [instance-id] (get-in (runtime-db) (rf.resources.mutation-runtime/instance-path instance-id)))
 
 (defn- reply-success! [addr-key data]
   (rf/dispatch-sync (conj (get @last-decorated addr-key) {:status :ok :value data})))
@@ -170,7 +170,7 @@
   (seed-token! "abc123")
   (reg-auth-interceptor!)
   (rf/reg-resource :rd/article (article-spec) article-spec-request)
-  (let [k (state/scoped-resource-key :rf.scope/global :rd/article {:slug "w"})]
+  (let [k (rf.resources.state/scoped-resource-key :rf.scope/global :rd/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :rd/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:app :rd 1]}])
@@ -244,7 +244,7 @@
   (seed-token! "tok")
   (reg-auth-interceptor!)
   (rf/reg-resource :sp/article (article-spec) article-spec-request)
-  (let [k (state/scoped-resource-key :rf.scope/global :sp/article {:slug "w"})]
+  (let [k (rf.resources.state/scoped-resource-key :rf.scope/global :sp/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :sp/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:app :sp 1]}])
@@ -322,9 +322,9 @@
               (contains? #{"rf.resource" "rf.resource.internal"
                            "rf.mutation" "rf.mutation.internal"}
                          ns*))))]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (resource-or-mutation-op? (:operation ev)) (swap! seen conj ev))))
-    (try (body-fn) (finally (trace-tooling/unregister-listener! k)))
+    (try (body-fn) (finally (rf.trace.tooling/unregister-listener! k)))
     @seen))
 
 (deftest decorated-bearer-token-does-not-leak-into-trace-rows

--- a/implementation/resources/test/re_frame/resources_restore_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_restore_cljs_test.cljc
@@ -27,7 +27,7 @@
       stable status;
     - the generation allocator is monotonic across restore (a post-restore
       allocation strictly exceeds any pre-restore generation — the host-side
-      allocator part 1, exercised here against `state/generation-cache`);
+      allocator part 1, exercised here against `rf.resources.state/generation-cache`);
     - a pre-restore in-flight reply that lands after restore is suppressed by
       the work-id + generation check (the dangled terminal row + cleared
       `:current-work` are what make the suppression structural);
@@ -41,26 +41,26 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.frame :as frame]
-   [re-frame.interop :as interop]
-   [re-frame.late-bind :as late-bind]
+   [re-frame.frame :as rf.frame]
+   [re-frame.interop :as rf.interop]
+   [re-frame.late-bind :as rf.late-bind]
    ;; load-bearing side-effecting require: the façade publishes the restore
    ;; reconcile hook + registers the resource registrar kind.
    [re-frame.resources]
-   [re-frame.resources.mutation-runtime :as mstate]
-   [re-frame.resources.ssr :as ssr]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.timers :as timers]
-   [re-frame.resources.work-ledger :as work-ledger]
-   [re-frame.test-support :as core-test-support]
-   [re-frame.trace.tooling :as trace-tooling]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.resources.mutation-runtime :as rf.resources.mutation-runtime]
+   [re-frame.resources.ssr :as rf.resources.ssr]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.timers :as rf.resources.timers]
+   [re-frame.resources.work-ledger :as rf.resources.work-ledger]
+   [re-frame.test-support :as rf.test-support]
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter})))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter})))
 
 ;; ---- helpers --------------------------------------------------------------
 
@@ -69,7 +69,7 @@
   [{:keys [resource-id status data error loaded-at stale-at invalidated-at
            generation current-work tags owners refresh-error]
     :or   {status :loaded generation 1 tags #{} owners #{}}}]
-  (merge (state/empty-entry resource-id)
+  (merge (rf.resources.state/empty-entry resource-id)
          {:status         status
           :data           data
           :error          error
@@ -90,14 +90,14 @@
   `{work-id-vector record}` to the byte `work-id-id` shape."
   ([entries] (runtime-db-with entries nil))
   ([entries ledger]
-   (cond-> {state/resources-key
+   (cond-> {rf.resources.state/resources-key
             {:entries (into {}
                             (map (fn [[sk e]]
-                                   [(state/key-id sk) (assoc e :resource/key sk)]))
+                                   [(rf.resources.state/key-id sk) (assoc e :resource/key sk)]))
                             entries)
              :tag-index {} :owner-index {}}}
-     ledger (assoc state/work-ledger-key
-                   (into {} (map (fn [[wid r]] [(work-ledger/work-id-id wid) r])) ledger)))))
+     ledger (assoc rf.resources.state/work-ledger-key
+                   (into {} (map (fn [[wid r]] [(rf.resources.work-ledger/work-id-id wid) r])) ledger)))))
 
 (defn- with-live-nav-token
   "Install a restored routing slice naming `nav-token` as live
@@ -108,7 +108,7 @@
   (assoc-in runtime-db [:rf.runtime/routing :current :nav-token] nav-token))
 
 (def ^:private gkey
-  (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "x"}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "x"}))
 
 ;; ===========================================================================
 ;; 1. Settle mid-flight entries to last stable (Spec 016 §Restore part 2)
@@ -118,8 +118,8 @@
   (testing "a restored :loading entry that never loaded (no data, no error) settles to :idle"
     (let [e   (entry {:resource-id :article/by-slug :status :loading :data nil
                       :current-work [:rf.work/resource gkey 3]})
-          out (ssr/reconcile-on-restore (runtime-db-with {gkey e}) :app/main)
-          se  (get-in out [state/resources-key :entries (state/key-id gkey)])]
+          out (rf.resources.ssr/reconcile-on-restore (runtime-db-with {gkey e}) :app/main)
+          se  (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id gkey)])]
       (is (= :idle (:status se)) "loading-with-no-data → :idle, never stranded :loading")
       (is (nil? (:current-work se)) "the vanished current-work pointer is cleared"))))
 
@@ -129,8 +129,8 @@
     (let [e   (entry {:resource-id :article/by-slug :status :fetching
                       :data {:title "kept"} :loaded-at 1000 :stale-at 9.0e15
                       :current-work [:rf.work/resource gkey 4]})
-          out (ssr/reconcile-on-restore (runtime-db-with {gkey e}) :app/main)
-          se  (get-in out [state/resources-key :entries (state/key-id gkey)])]
+          out (rf.resources.ssr/reconcile-on-restore (runtime-db-with {gkey e}) :app/main)
+          se  (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id gkey)])]
       (is (= :loaded (:status se)) "fetching-with-data → :loaded (keep last-known-good)")
       (is (= {:title "kept"} (:data se)) "the last-known-good data is preserved")
       (is (nil? (:current-work se)) "the vanished current-work pointer is cleared"))))
@@ -141,8 +141,8 @@
     (let [err {:kind :rf.http/http-5xx}
           e   (entry {:resource-id :article/by-slug :status :loading :data nil
                       :error err :current-work [:rf.work/resource gkey 5]})
-          out (ssr/reconcile-on-restore (runtime-db-with {gkey e}) :app/main)
-          se  (get-in out [state/resources-key :entries (state/key-id gkey)])]
+          out (rf.resources.ssr/reconcile-on-restore (runtime-db-with {gkey e}) :app/main)
+          se  (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id gkey)])]
       (is (= :error (:status se)) "loading-with-error-and-no-data → :error")
       (is (= err (:error se)) "the first-load error envelope is retained")
       (is (nil? (:current-work se))))))
@@ -154,28 +154,28 @@
                          :loaded-at 1000 :stale-at 9.0e15})
           errd   (entry {:resource-id :b :status :error :error {:kind :x}})
           idle   (entry {:resource-id :c :status :idle})
-          ka (state/scoped-resource-key :rf.scope/global :a {})
-          kb (state/scoped-resource-key :rf.scope/global :b {})
-          kc (state/scoped-resource-key :rf.scope/global :c {})
-          out (ssr/reconcile-on-restore (runtime-db-with {ka loaded kb errd kc idle}) :app/main)
-          es  (get-in out [state/resources-key :entries])]
+          ka (rf.resources.state/scoped-resource-key :rf.scope/global :a {})
+          kb (rf.resources.state/scoped-resource-key :rf.scope/global :b {})
+          kc (rf.resources.state/scoped-resource-key :rf.scope/global :c {})
+          out (rf.resources.ssr/reconcile-on-restore (runtime-db-with {ka loaded kb errd kc idle}) :app/main)
+          es  (get-in out [rf.resources.state/resources-key :entries])]
       ;; rf2-9e0tyq — entries are keyed on the byte key-id.
-      (is (= :loaded (:status (es (state/key-id ka)))))
-      (is (= :error  (:status (es (state/key-id kb)))))
-      (is (= :idle   (:status (es (state/key-id kc))))))))
+      (is (= :loaded (:status (es (rf.resources.state/key-id ka)))))
+      (is (= :error  (:status (es (rf.resources.state/key-id kb)))))
+      (is (= :idle   (:status (es (rf.resources.state/key-id kc))))))))
 
 (deftest settle-entry-to-last-stable-is-pure
   (testing "settle-entry-to-last-stable: the three in-flight resolutions + pass-through"
-    (is (= :idle   (:status (ssr/settle-entry-to-last-stable
+    (is (= :idle   (:status (rf.resources.ssr/settle-entry-to-last-stable
                               (entry {:resource-id :a :status :loading :data nil})))))
-    (is (= :loaded (:status (ssr/settle-entry-to-last-stable
+    (is (= :loaded (:status (rf.resources.ssr/settle-entry-to-last-stable
                               (entry {:resource-id :a :status :fetching :data {:x 1}})))))
-    (is (= :loaded (:status (ssr/settle-entry-to-last-stable
+    (is (= :loaded (:status (rf.resources.ssr/settle-entry-to-last-stable
                               (entry {:resource-id :a :status :loading :data {:x 1}})))))
-    (is (= :error  (:status (ssr/settle-entry-to-last-stable
+    (is (= :error  (:status (rf.resources.ssr/settle-entry-to-last-stable
                               (entry {:resource-id :a :status :loading :data nil
                                       :error {:kind :x}})))))
-    (is (= :loaded (:status (ssr/settle-entry-to-last-stable
+    (is (= :loaded (:status (rf.resources.ssr/settle-entry-to-last-stable
                               (entry {:resource-id :a :status :loaded :data {:x 1}})))))))
 
 (deftest restore-does-not-re-read-the-live-clock-for-durable-entry-timestamps
@@ -185,12 +185,12 @@
   ;; not re-read the live clock during install." The structural restore tests
   ;; prove the durable timestamps SURVIVE (they are passed through, not
   ;; recomputed); this one PROVES it adversarially — it stubs the ONLY live-clock
-  ;; read in the reconcile (`interop/epoch-now-ms`) to a sentinel NOTHING durable
+  ;; read in the reconcile (`rf.interop/epoch-now-ms`) to a sentinel NOTHING durable
   ;; should ever stamp, then asserts every restored entry's :loaded-at /
   ;; :stale-at / :invalidated-at is the SNAPSHOT's value, untouched by the
   ;; sentinel. A regression that freshened any durable timestamp from the live
   ;; install clock would stamp the sentinel and fail loudly here.
-  (testing "the live install clock (interop/epoch-now-ms) does NOT freshen any durable restored
+  (testing "the live install clock (rf.interop/epoch-now-ms) does NOT freshen any durable restored
             entry timestamp — they ride through equal to the snapshot's"
     (let [sentinel    9999999999999  ; the install-clock value nothing durable may stamp
           ;; one of each freshness shape: a loaded entry with a future stale-at,
@@ -200,14 +200,14 @@
                               :loaded-at 1000 :stale-at 2000})
           invalidated (entry {:resource-id :b :status :loaded :data {:y 2}
                               :loaded-at 1000 :stale-at 8000 :invalidated-at 1500})
-          ka (state/scoped-resource-key :rf.scope/global :a {})
-          kb (state/scoped-resource-key :rf.scope/global :b {})]
-      (with-redefs [interop/epoch-now-ms (constantly sentinel)]
-        (let [out (ssr/reconcile-on-restore (runtime-db-with {ka loaded kb invalidated}) :app/main)
-              es  (get-in out [state/resources-key :entries])
+          ka (rf.resources.state/scoped-resource-key :rf.scope/global :a {})
+          kb (rf.resources.state/scoped-resource-key :rf.scope/global :b {})]
+      (with-redefs [rf.interop/epoch-now-ms (constantly sentinel)]
+        (let [out (rf.resources.ssr/reconcile-on-restore (runtime-db-with {ka loaded kb invalidated}) :app/main)
+              es  (get-in out [rf.resources.state/resources-key :entries])
               ;; rf2-9e0tyq — entries are keyed on the byte key-id.
-              ea (es (state/key-id ka))
-              eb (es (state/key-id kb))]
+              ea (es (rf.resources.state/key-id ka))
+              eb (es (rf.resources.state/key-id kb))]
           (is (= 1000 (:loaded-at ea)) ":loaded-at is the snapshot's, NOT the install clock")
           (is (= 2000 (:stale-at  ea)) ":stale-at is the snapshot's, NOT the install clock")
           (is (= 1000 (:loaded-at eb)) ":loaded-at (invalidated entry) is the snapshot's")
@@ -223,7 +223,7 @@
 
 (defn- work-row
   [work-id status]
-  (-> (work-ledger/work-record
+  (-> (rf.resources.work-ledger/work-record
         {:work-id work-id :frame-id :app/main :resource/key gkey
          :generation (nth work-id 2) :transport :rf.http/managed
          :started-at 1000})
@@ -241,14 +241,14 @@
           rdb (runtime-db-with {gkey (entry {:resource-id :article/by-slug
                                              :status :loading :data nil})}
                                ledger)
-          out (ssr/reconcile-on-restore rdb :app/main)
-          out-ledger (get out state/work-ledger-key)]
+          out (rf.resources.ssr/reconcile-on-restore rdb :app/main)
+          out-ledger (get out rf.resources.state/work-ledger-key)]
       (doseq [wid [w-running w-queued w-abort]]
         ;; rf2-9e0tyq — the ledger is keyed on the byte work-id-id.
-        (let [row (get out-ledger (work-ledger/work-id-id wid))]
+        (let [row (get out-ledger (rf.resources.work-ledger/work-id-id wid))]
           (is (= :suppressed (:status row))
               (str wid " settled to terminal :suppressed"))
-          (is (work-ledger/terminal? (:status row))
+          (is (rf.resources.work-ledger/terminal? (:status row))
               (str wid " is now terminal"))
           (is (= :dangling (get-in row [:outcome :reason]))
               (str wid " outcome marks it dangling")))))))
@@ -256,14 +256,14 @@
 (deftest terminal-rows-ride-through-unchanged
   (testing "already-terminal work-ledger rows are not re-touched by restore"
     (let [w-done [:rf.work/resource gkey 2]
-          row    (work-ledger/mark-terminal (work-row w-done :completed)
+          row    (rf.resources.work-ledger/mark-terminal (work-row w-done :completed)
                                             :completed {:ok true})
           rdb (runtime-db-with {gkey (entry {:resource-id :article/by-slug
                                              :status :loaded :data {:x 1}
                                              :loaded-at 1 :stale-at 9.0e15})}
                                {w-done row})
-          out (ssr/reconcile-on-restore rdb :app/main)]
-      (is (= row (get-in out [state/work-ledger-key (work-ledger/work-id-id w-done)]))
+          out (rf.resources.ssr/reconcile-on-restore rdb :app/main)]
+      (is (= row (get-in out [rf.resources.state/work-ledger-key (rf.resources.work-ledger/work-id-id w-done)]))
           "a completed row is unchanged"))))
 
 (deftest dangle-non-terminal-work-returns-dangled-ids
@@ -272,12 +272,12 @@
     (let [w1 [:rf.work/resource gkey 3]
           w2 [:rf.work/resource gkey 2]
           ledger {w1 (work-row w1 :running)
-                  w2 (work-ledger/mark-terminal (work-row w2 :completed) :completed {})}
-          [rdb' dangled] (ssr/dangle-non-terminal-work!
-                          {state/work-ledger-key ledger})]
+                  w2 (rf.resources.work-ledger/mark-terminal (work-row w2 :completed) :completed {})}
+          [rdb' dangled] (rf.resources.ssr/dangle-non-terminal-work!
+                          {rf.resources.state/work-ledger-key ledger})]
       (is (= [w1] dangled) "only the non-terminal row is dangled")
-      (is (= :suppressed (get-in rdb' [state/work-ledger-key w1 :status])))
-      (is (= :completed (get-in rdb' [state/work-ledger-key w2 :status]))))))
+      (is (= :suppressed (get-in rdb' [rf.resources.state/work-ledger-key w1 :status])))
+      (is (= :completed (get-in rdb' [rf.resources.state/work-ledger-key w2 :status]))))))
 
 ;; ===========================================================================
 ;; 2b. Dangle PENDING mutation instances on restore (rf2-o3d1uf, part 2)
@@ -296,7 +296,7 @@
   overrides (defaults to a :pending instance pointing at work-id)."
   [{:keys [mutation-id instance-id status generation work-id scope params]
     :or   {mutation-id :comment/add status :pending generation 3}}]
-  (-> (mstate/empty-instance mutation-id instance-id
+  (-> (rf.resources.mutation-runtime/empty-instance mutation-id instance-id
         {:scope scope :params params :generation generation
          :work-id work-id :started-at 1000})
       (assoc :status status)))
@@ -307,21 +307,21 @@
   own kind-preserving `:instance/id`. Takes `{<instance-id> <instance>}` pairs
   (instance ids as the LOGICAL key) and rekeys to the byte storage key."
   [m]
-  (into {} (map (fn [[iid inst]] [(mstate/instance-key-id iid) inst])) m))
+  (into {} (map (fn [[iid inst]] [(rf.resources.mutation-runtime/instance-key-id iid) inst])) m))
 
 (deftest instance-dangled-settles-pending-and-clears-current-work
   (testing "instance-dangled: a :pending instance settles terminal :error with
             the :dangling-on-restore envelope and CLEARS :current-work"
     (let [inst (mutation-instance {:instance-id :inst-1
                                    :work-id [:rf.work/resource [:rf.mutation :inst-1 3] 3]})
-          out  (mstate/instance-dangled inst 9999)]
+          out  (rf.resources.mutation-runtime/instance-dangled inst 9999)]
       (is (= :error (:status out)) "pending → terminal :error")
       (is (= :dangling-on-restore (:reason (:error out))))
       (is (nil? (:current-work out)) ":current-work cleared (the suppression gate)")
-      (is (mstate/terminal? (:status out)) "the instance is now terminal")))
+      (is (rf.resources.mutation-runtime/terminal? (:status out)) "the instance is now terminal")))
   (testing "a TERMINAL instance rides through unchanged"
     (let [done (mutation-instance {:instance-id :inst-2 :status :success})]
-      (is (= done (mstate/instance-dangled done 9999))))))
+      (is (= done (rf.resources.mutation-runtime/instance-dangled done 9999))))))
 
 (deftest dangle-pending-mutations-settles-and-returns-ids
   (testing "dangle-pending-mutations! settles every pending instance + clears
@@ -329,25 +329,25 @@
     (let [pending (mutation-instance {:instance-id :inst-p
                                       :work-id [:rf.work/resource [:rf.mutation :inst-p 3] 3]})
           settled (mutation-instance {:instance-id :inst-s :status :success})
-          rdb {mstate/mutations-key (mutations-map {:inst-p pending :inst-s settled})}
-          [rdb' dangled] (ssr/dangle-pending-mutations! rdb 9999)]
+          rdb {rf.resources.mutation-runtime/mutations-key (mutations-map {:inst-p pending :inst-s settled})}
+          [rdb' dangled] (rf.resources.ssr/dangle-pending-mutations! rdb 9999)]
       (is (= [:inst-p] dangled) "only the pending instance is dangled (kind-preserving :instance/id)")
-      (is (= :error (get-in rdb' [mstate/mutations-key (mstate/instance-key-id :inst-p) :status])))
-      (is (nil? (get-in rdb' [mstate/mutations-key (mstate/instance-key-id :inst-p) :current-work])))
-      (is (= :success (get-in rdb' [mstate/mutations-key (mstate/instance-key-id :inst-s) :status]))
+      (is (= :error (get-in rdb' [rf.resources.mutation-runtime/mutations-key (rf.resources.mutation-runtime/instance-key-id :inst-p) :status])))
+      (is (nil? (get-in rdb' [rf.resources.mutation-runtime/mutations-key (rf.resources.mutation-runtime/instance-key-id :inst-p) :current-work])))
+      (is (= :success (get-in rdb' [rf.resources.mutation-runtime/mutations-key (rf.resources.mutation-runtime/instance-key-id :inst-s) :status]))
           "the terminal instance is untouched")))
   (testing "no mutation instances → no-op"
     ;; EP-0019 Q3 — the return is now `[rdb dangled rolled-back-keys]`.
-    (is (= [{} [] []] (ssr/dangle-pending-mutations! {} 9999)))))
+    (is (= [{} [] []] (rf.resources.ssr/dangle-pending-mutations! {} 9999)))))
 
 (deftest reconcile-on-restore-dangles-pending-mutation-instances
   (testing "reconcile-on-restore reconciles the :rf.runtime/mutations slice too"
     (let [pending (mutation-instance {:instance-id :inst-1
                                       :work-id [:rf.work/resource [:rf.mutation :inst-1 3] 3]})
-          rdb {mstate/mutations-key (mutations-map {:inst-1 pending})}
-          out (ssr/reconcile-on-restore rdb :app/main)]
-      (is (= :error (get-in out [mstate/mutations-key (mstate/instance-key-id :inst-1) :status])))
-      (is (nil? (get-in out [mstate/mutations-key (mstate/instance-key-id :inst-1) :current-work]))))))
+          rdb {rf.resources.mutation-runtime/mutations-key (mutations-map {:inst-1 pending})}
+          out (rf.resources.ssr/reconcile-on-restore rdb :app/main)]
+      (is (= :error (get-in out [rf.resources.mutation-runtime/mutations-key (rf.resources.mutation-runtime/instance-key-id :inst-1) :status])))
+      (is (nil? (get-in out [rf.resources.mutation-runtime/mutations-key (rf.resources.mutation-runtime/instance-key-id :inst-1) :current-work]))))))
 
 (deftest dangled-instance-settled-at-is-the-restore-causal-time-not-the-live-clock
   ;; rf2-wshzsp (the option-1 CORRECTNESS fix) — a dangled-on-restore mutation
@@ -363,10 +363,10 @@
           live-sentinel 9999999999999  ; the (wrong) ambient install clock
           pending (mutation-instance {:instance-id :inst-1
                                       :work-id [:rf.work/resource [:rf.mutation :inst-1 3] 3]})
-          rdb {mstate/mutations-key (mutations-map {:inst-1 pending})}]
-      (with-redefs [interop/epoch-now-ms (constantly live-sentinel)]
-        (let [out (ssr/reconcile-on-restore rdb :app/main {:restore-time-ms restore-time})
-              inst (get-in out [mstate/mutations-key (mstate/instance-key-id :inst-1)])]
+          rdb {rf.resources.mutation-runtime/mutations-key (mutations-map {:inst-1 pending})}]
+      (with-redefs [rf.interop/epoch-now-ms (constantly live-sentinel)]
+        (let [out (rf.resources.ssr/reconcile-on-restore rdb :app/main {:restore-time-ms restore-time})
+              inst (get-in out [rf.resources.mutation-runtime/mutations-key (rf.resources.mutation-runtime/instance-key-id :inst-1)])]
           (is (= :error (:status inst)) "the pending instance is terminally dangled")
           (is (= restore-time (:settled-at inst))
               ":settled-at is the causal :restore-time-ms — replay-stable")
@@ -377,10 +377,10 @@
     (let [live-sentinel 9999999999999
           pending (mutation-instance {:instance-id :inst-1
                                       :work-id [:rf.work/resource [:rf.mutation :inst-1 3] 3]})
-          rdb {mstate/mutations-key (mutations-map {:inst-1 pending})}]
-      (with-redefs [interop/epoch-now-ms (constantly live-sentinel)]
-        (let [out (ssr/reconcile-on-restore rdb :app/main)]
-          (is (= live-sentinel (get-in out [mstate/mutations-key (mstate/instance-key-id :inst-1) :settled-at]))
+          rdb {rf.resources.mutation-runtime/mutations-key (mutations-map {:inst-1 pending})}]
+      (with-redefs [rf.interop/epoch-now-ms (constantly live-sentinel)]
+        (let [out (rf.resources.ssr/reconcile-on-restore rdb :app/main)]
+          (is (= live-sentinel (get-in out [rf.resources.mutation-runtime/mutations-key (rf.resources.mutation-runtime/instance-key-id :inst-1) :settled-at]))
               "no causal time supplied → the unit path falls back to the live clock"))))))
 
 (deftest dangling-mutation-without-restore-time-warns-loudly
@@ -393,18 +393,18 @@
   ;; is loud, not a quiet footgun (no-silent-swallow).
   (let [pending (mutation-instance {:instance-id :inst-1
                                     :work-id [:rf.work/resource [:rf.mutation :inst-1 3] 3]})
-        rdb {mstate/mutations-key (mutations-map {:inst-1 pending})}
+        rdb {rf.resources.mutation-runtime/mutations-key (mutations-map {:inst-1 pending})}
         recorder (fn []
                    (let [seen (atom [])
                          k    ::live-clock-warn-recorder]
-                     (trace-tooling/register-listener!
+                     (rf.trace.tooling/register-listener!
                        k (fn [ev] (when (= :rf.resource/restore-settled-at-from-live-clock
                                            (:operation ev))
                                     (swap! seen conj ev))))
-                     [seen (fn [] (trace-tooling/unregister-listener! k))]))]
+                     [seen (fn [] (rf.trace.tooling/unregister-listener! k))]))]
     (testing "dangling a pending mutation with NO :restore-time-ms warns loudly"
       (let [[seen unregister!] (recorder)]
-        (try (ssr/reconcile-on-restore rdb :app/main)
+        (try (rf.resources.ssr/reconcile-on-restore rdb :app/main)
              (finally (unregister!)))
         (is (= 1 (count @seen))
             "exactly one restore-settled-at-from-live-clock warning fired")
@@ -413,14 +413,14 @@
     (testing "supplying a causal :restore-time-ms suppresses the warning (the
               durable stamp folds the causal token — replay-stable)"
       (let [[seen unregister!] (recorder)]
-        (try (ssr/reconcile-on-restore rdb :app/main {:restore-time-ms 1781078400777})
+        (try (rf.resources.ssr/reconcile-on-restore rdb :app/main {:restore-time-ms 1781078400777})
              (finally (unregister!)))
         (is (empty? @seen)
             "no live-clock warning when the causal restore time is threaded")))
     (testing "no warning when NO pending mutations are dangled (nothing durable
               was stamped from the live clock)"
       (let [[seen unregister!] (recorder)]
-        (try (ssr/reconcile-on-restore {mstate/mutations-key {}} :app/main)
+        (try (rf.resources.ssr/reconcile-on-restore {rf.resources.mutation-runtime/mutations-key {}} :app/main)
              (finally (unregister!)))
         (is (empty? @seen)
             "an empty restore stamps no durable :settled-at, so no warning")))))
@@ -440,7 +440,7 @@
                             :data {:title "post-restore"} :loaded-at 1 :stale-at 9.0e15
                             :generation 9})
           instance-id [:rf.mutation/instance :article/edit 3]
-          work-id   (work-ledger/resource-work-id [:rf.mutation instance-id] 3)
+          work-id   (rf.resources.work-ledger/resource-work-id [:rf.mutation instance-id] 3)
           ;; the captured snapshot: a PENDING mutation instance pointing at work-id
           pending   (mutation-instance {:mutation-id :article/edit
                                         :instance-id instance-id
@@ -448,21 +448,21 @@
                                         :scope :rf.scope/global :params {:slug "x"}})
           ;; the runtime-db that restore is about to install (reconciled first)
           snapshot  (-> (runtime-db-with {gkey loaded})
-                        (assoc mstate/mutations-key (mutations-map {instance-id pending}))
-                        (assoc-in (work-ledger/record-path work-id)
-                                  (-> (work-ledger/work-record
+                        (assoc rf.resources.mutation-runtime/mutations-key (mutations-map {instance-id pending}))
+                        (assoc-in (rf.resources.work-ledger/record-path work-id)
+                                  (-> (rf.resources.work-ledger/work-record
                                         {:work-id work-id :frame-id fid
                                          :resource/key [:rf.mutation instance-id]
                                          :generation 3 :transport :rf.http/managed
                                          :started-at 1000})
                                       (assoc :work/kind :mutation))))
-          reconciled (ssr/reconcile-on-restore snapshot fid)]
+          reconciled (rf.resources.ssr/reconcile-on-restore snapshot fid)]
       (rf/make-frame {:id fid :doc "restore mutation suppression frame"})
       ;; install the reconciled snapshot as the live frame-state
-      (frame/replace-runtime-db! fid reconciled)
+      (rf.frame/replace-runtime-db! fid reconciled)
       (testing "post-reconcile the pending instance is terminal + current-work cleared"
-        (is (= :error (get-in reconciled [mstate/mutations-key (mstate/instance-key-id instance-id) :status])))
-        (is (nil? (get-in reconciled [mstate/mutations-key (mstate/instance-key-id instance-id) :current-work]))))
+        (is (= :error (get-in reconciled [rf.resources.mutation-runtime/mutations-key (rf.resources.mutation-runtime/instance-key-id instance-id) :status])))
+        (is (nil? (get-in reconciled [rf.resources.mutation-runtime/mutations-key (rf.resources.mutation-runtime/instance-key-id instance-id) :current-work]))))
       ;; NOW the late pre-restore mutation SUCCESS reply lands (carrying the
       ;; pre-restore work-id + generation that the snapshot instance held).
       (rf/dispatch-sync
@@ -471,13 +471,13 @@
           :work/id work-id :generation 3 :scope :rf.scope/global}
          {:status :ok :value {:title "STALE pre-restore write"}}]
         {:frame fid})
-      (let [post (frame/frame-runtime-db-value fid)
-            e    (get-in post [state/resources-key :entries (state/key-id gkey)])]
+      (let [post (rf.frame/frame-runtime-db-value fid)
+            e    (get-in post [rf.resources.state/resources-key :entries (rf.resources.state/key-id gkey)])]
         (is (= {:title "post-restore"} (:data e))
             "the resource entry is UNCHANGED — the stale reply did not patch/populate it")
-        (is (= :error (get-in post [mstate/mutations-key (mstate/instance-key-id instance-id) :status]))
+        (is (= :error (get-in post [rf.resources.mutation-runtime/mutations-key (rf.resources.mutation-runtime/instance-key-id instance-id) :status]))
             "the dangled instance stays terminal :error — the stale reply did not revive it"))
-      (frame/destroy-frame! fid))))
+      (rf.frame/destroy-frame! fid))))
 
 ;; ===========================================================================
 ;; 3. Owner reconciliation: orphan SSR, keep route (Spec 016 §Restore part 4)
@@ -495,16 +495,16 @@
           ;; the restored routing slice considers nav-1 live — the route owner
           ;; names the same nav-token, so it revives (Spec 016 §Restore part 4).
           rdb (with-live-nav-token (runtime-db-with {gkey e}) "nav-1")
-          out (ssr/reconcile-on-restore rdb :app/main)
-          owners (get-in out [state/resources-key :entries (state/key-id gkey) :active-owners])]
+          out (rf.resources.ssr/reconcile-on-restore rdb :app/main)
+          owners (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id gkey) :active-owners])]
       (is (not (contains? owners [:ssr "req-9" "nav-1"])) "SSR owner orphaned")
       (is (contains? owners [:route :route/article "nav-1"])
           "live-nav route owner survives (its nav-token is the one routing names live)")
       (is (contains? owners [:machine :checkout/flow "inst-1"]) "machine owner survives")
-      (is (not (contains? (get-in out [state/resources-key :owner-index])
+      (is (not (contains? (get-in out [rf.resources.state/resources-key :owner-index])
                           [:ssr "req-9" "nav-1"]))
           "the orphaned SSR owner is absent from the recomputed owner-index")
-      (is (contains? (get-in out [state/resources-key :owner-index])
+      (is (contains? (get-in out [rf.resources.state/resources-key :owner-index])
                      [:route :route/article "nav-1"])
           "the live-nav route owner IS in the recomputed owner-index"))))
 
@@ -520,17 +520,17 @@
           ;; the restored routing slice considers nav-NEW live; nav-OLD is the
           ;; navigation the timeline has already left.
           rdb (with-live-nav-token (runtime-db-with {gkey e}) "nav-NEW")
-          out (ssr/reconcile-on-restore rdb :app/main)
-          owners (get-in out [state/resources-key :entries (state/key-id gkey) :active-owners])]
+          out (rf.resources.ssr/reconcile-on-restore rdb :app/main)
+          owners (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id gkey) :active-owners])]
       (is (not (contains? owners stale))
           "the stale-nav route owner (nav-OLD ≠ live nav-NEW) is orphaned")
       (is (contains? owners live)
           "the live-nav route owner (nav-NEW = live) survives")
       (is (contains? owners [:machine :checkout/flow "inst-1"])
           "the machine owner is untouched")
-      (is (not (contains? (get-in out [state/resources-key :owner-index]) stale))
+      (is (not (contains? (get-in out [rf.resources.state/resources-key :owner-index]) stale))
           "the orphaned stale-nav route owner is absent from the recomputed owner-index")
-      (is (contains? (get-in out [state/resources-key :owner-index]) live)
+      (is (contains? (get-in out [rf.resources.state/resources-key :owner-index]) live)
           "the surviving live-nav route owner is present in the owner-index"))))
 
 ;; rf2-64bdnk — on RESTORE, a missing/nil live nav-token means NO route owner
@@ -558,14 +558,14 @@
                                     route-owner
                                     [:machine :checkout/flow "inst-1"]
                                     [:app :dashboard 7]}})
-              out (ssr/reconcile-on-restore (rdb-fn (runtime-db-with {gkey e})) :app/main)
-              owners (get-in out [state/resources-key :entries (state/key-id gkey) :active-owners])]
+              out (rf.resources.ssr/reconcile-on-restore (rdb-fn (runtime-db-with {gkey e})) :app/main)
+              owners (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id gkey) :active-owners])]
           (is (not (contains? owners route-owner))
               "the route owner is ORPHANED (no live nav-token names it live)")
           (is (not (contains? owners [:ssr "req-9" "nav-1"])) "SSR owner orphaned")
           (is (contains? owners [:machine :checkout/flow "inst-1"]) "machine owner survives")
           (is (contains? owners [:app :dashboard 7]) "app owner survives")
-          (is (not (contains? (get-in out [state/resources-key :owner-index]) route-owner))
+          (is (not (contains? (get-in out [rf.resources.state/resources-key :owner-index]) route-owner))
               "the orphaned route owner is absent from the recomputed owner-index"))))))
 
 (deftest restore-no-live-token-emits-owner-release-trace
@@ -576,12 +576,12 @@
                       :loaded-at 1 :stale-at 9.0e15 :owners #{route-owner}})
           seen (atom [])
           k    ::owner-release-recorder]
-      (trace-tooling/register-listener!
+      (rf.trace.tooling/register-listener!
         k (fn [ev] (when (= :rf.resource/owner-released (:operation ev))
                      (swap! seen conj ev))))
       (try
-        (ssr/reconcile-on-restore (runtime-db-with {gkey e}) :app/main)
-        (finally (trace-tooling/unregister-listener! k)))
+        (rf.resources.ssr/reconcile-on-restore (runtime-db-with {gkey e}) :app/main)
+        (finally (rf.trace.tooling/unregister-listener! k)))
       (is (some #(= route-owner (:owner (:tags %))) @seen)
           "an owner-released row names the orphaned route owner")
       (is (some #(= :stale-nav-orphan (:reason (:tags %))) @seen)
@@ -607,11 +607,11 @@
   []
   (let [seen (atom [])
         k    ::restore-trace-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (contains? #{:rf.resource/restored :rf.resource/owner-released}
                                   (:operation ev))
                    (swap! seen conj ev))))
-    [seen (fn [] (trace-tooling/unregister-listener! k))]))
+    [seen (fn [] (rf.trace.tooling/unregister-listener! k))]))
 
 (deftest defer-traces-does-not-emit-inline
   (testing "rf2-obi8rr — reconcile-on-restore with :defer-traces? true emits NO
@@ -622,14 +622,14 @@
                       :loaded-at 1 :stale-at 9.0e15 :owners #{stale}})
           rdb (with-live-nav-token (runtime-db-with {gkey e}) "nav-NEW")
           [seen unregister!] (restore-trace-recorder)
-          out (try (ssr/reconcile-on-restore rdb :app/main {:defer-traces? true})
+          out (try (rf.resources.ssr/reconcile-on-restore rdb :app/main {:defer-traces? true})
                    (finally (unregister!)))]
       (is (empty? @seen)
           "no restore/owner-released trace fired inline under :defer-traces? true")
       (is (seq (-> out meta (get :re-frame.resources.ssr/deferred-trace-intents)))
           "the trace intents ride back as metadata on the reconciled runtime-db")
       ;; the reconcile work still happened (the stale owner was orphaned)
-      (is (not (contains? (get-in out [state/resources-key :entries (state/key-id gkey) :active-owners]) stale))
+      (is (not (contains? (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id gkey) :active-owners]) stale))
           "the stale-nav owner is still reconciled (only the TRACE is deferred)"))))
 
 (deftest commit-restore-reconcile-traces-emits-deferred-rows
@@ -640,9 +640,9 @@
           e   (entry {:resource-id :article/by-slug :status :loaded :data {:x 1}
                       :loaded-at 1 :stale-at 9.0e15 :owners #{stale}})
           rdb (with-live-nav-token (runtime-db-with {gkey e}) "nav-NEW")
-          out (ssr/reconcile-on-restore rdb :app/main {:defer-traces? true})
+          out (rf.resources.ssr/reconcile-on-restore rdb :app/main {:defer-traces? true})
           [seen unregister!] (restore-trace-recorder)]
-      (try (ssr/commit-restore-reconcile-traces! out)
+      (try (rf.resources.ssr/commit-restore-reconcile-traces! out)
            (finally (unregister!)))
       (is (some #(= :rf.resource/restored (:operation %)) @seen)
           "the deferred :rf.resource/restored summary row is emitted on commit")
@@ -656,8 +656,8 @@
     (let [[seen unregister!] (restore-trace-recorder)]
       (try
         ;; a plain runtime-db (no deferred-intents metadata) → nothing emitted
-        (ssr/commit-restore-reconcile-traces! (runtime-db-with {}))
-        (ssr/commit-restore-reconcile-traces! nil)
+        (rf.resources.ssr/commit-restore-reconcile-traces! (runtime-db-with {}))
+        (rf.resources.ssr/commit-restore-reconcile-traces! nil)
         (finally (unregister!)))
       (is (empty? @seen) "no intents → no trace rows"))))
 
@@ -667,16 +667,16 @@
     (let [e   (entry {:resource-id :article/by-slug :status :loaded :data {:x 1}
                       :loaded-at 1 :stale-at 9.0e15})
           [seen unregister!] (restore-trace-recorder)]
-      (try (ssr/reconcile-on-restore (runtime-db-with {gkey e}) :app/main)
+      (try (rf.resources.ssr/reconcile-on-restore (runtime-db-with {gkey e}) :app/main)
            (finally (unregister!)))
       (is (some #(= :rf.resource/restored (:operation %)) @seen)
           "the inline path emits the :rf.resource/restored summary immediately"))))
 
 (deftest commit-hook-published
   (testing "rf2-obi8rr — the :resources/commit-restore-reconcile! hook is published"
-    (is (some? (late-bind/get-fn :resources/commit-restore-reconcile!)))
-    (is (= ssr/commit-restore-reconcile-traces!
-           (late-bind/get-fn :resources/commit-restore-reconcile!)))))
+    (is (some? (rf.late-bind/get-fn :resources/commit-restore-reconcile!)))
+    (is (= rf.resources.ssr/commit-restore-reconcile-traces!
+           (rf.late-bind/get-fn :resources/commit-restore-reconcile!)))))
 
 (deftest hydration-parity-route-owners-ride-through-without-routing
   (testing "rf2-64bdnk parity — HYDRATION (the no-comparison-yet case) still
@@ -686,8 +686,8 @@
           e   (entry {:resource-id :article/by-slug :status :loaded :data {:x 1}
                       :loaded-at 1 :stale-at 9.0e15
                       :owners #{[:ssr "req-9" "nav-1"] route-owner}})
-          out (ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)
-          owners (get-in out [state/resources-key :entries (state/key-id gkey) :active-owners])]
+          out (rf.resources.ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)
+          owners (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id gkey) :active-owners])]
       (is (not (contains? owners [:ssr "req-9" "nav-1"]))
           "SSR owner still orphans on hydration")
       (is (contains? owners route-owner)
@@ -711,15 +711,15 @@
           ;; stamped), then overwrite the indexes with deliberately-wrong
           ;; snapshot values to prove they are discarded + recomputed.
           rdb (-> (runtime-db-with {gkey e})
-                  (assoc-in [state/resources-key :tag-index]   {[:bogus] #{:nope}})
-                  (assoc-in [state/resources-key :owner-index] {[:bogus] #{:nope}})
+                  (assoc-in [rf.resources.state/resources-key :tag-index]   {[:bogus] #{:nope}})
+                  (assoc-in [rf.resources.state/resources-key :owner-index] {[:bogus] #{:nope}})
                   (with-live-nav-token "nav-1"))
-          out (ssr/reconcile-on-restore rdb :app/main)
-          sub (get out state/resources-key)]
+          out (rf.resources.ssr/reconcile-on-restore rdb :app/main)
+          sub (get out rf.resources.state/resources-key)]
       ;; rf2-9e0tyq — index MEMBERS are the byte key-id, not the scoped-key vector.
-      (is (= {[:article "x"] #{(state/key-id gkey)}} (:tag-index sub))
+      (is (= {[:article "x"] #{(rf.resources.state/key-id gkey)}} (:tag-index sub))
           "tag-index recomputed from the entry's :tags; bogus snapshot index discarded")
-      (is (= {[:route :route/article "nav-1"] #{(state/key-id gkey)}} (:owner-index sub))
+      (is (= {[:route :route/article "nav-1"] #{(rf.resources.state/key-id gkey)}} (:owner-index sub))
           "owner-index recomputed from the entry's owners; bogus snapshot index discarded"))))
 
 ;; ===========================================================================
@@ -736,12 +736,12 @@
 (defn- frame-timer-keys
   "The timer-table keys (`[frame-id resource-key kind]`) armed for `frame-id`."
   [frame-id]
-  (filter (fn [[fid _ _]] (= fid frame-id)) (keys @timers/timer-table)))
+  (filter (fn [[fid _ _]] (= fid frame-id)) (keys @rf.resources.timers/timer-table)))
 
 (defn- work-handle-keys
   "The work-ledger handle-table keys (`[frame-id work-id]`) for `frame-id`."
   [frame-id]
-  (filter (fn [[fid _]] (= fid frame-id)) (keys @work-ledger/handle-table)))
+  (filter (fn [[fid _]] (= fid frame-id)) (keys @rf.resources.work-ledger/handle-table)))
 
 (deftest clear-host-transients-on-restore-clears-timers-and-handles
   (testing "rf2-nd1r9q — restore clears the frame's armed stale/GC timer handles
@@ -751,33 +751,33 @@
           wid  [:rf.work/resource gkey 4]]
       ;; arm a stale timer (long delay so it never fires during the test) and a
       ;; work-ledger host handle for the frame.
-      (timers/schedule! fid rkey timers/stale-kind 600000)
-      (work-ledger/put-handle! fid wid {:transport :rf.http/managed :request-id wid})
+      (rf.resources.timers/schedule! fid rkey rf.resources.timers/stale-kind 600000)
+      (rf.resources.work-ledger/put-handle! fid wid {:transport :rf.http/managed :request-id wid})
       (is (seq (frame-timer-keys fid)) "a stale timer is armed for the frame")
       (is (seq (work-handle-keys fid)) "a work handle is recorded for the frame")
       ;; restore the frame's snapshot (a mid-flight fetching entry)
       (let [e (entry {:resource-id :article/by-slug :status :fetching :data {:x 1}
                       :loaded-at 1 :stale-at 9.0e15 :current-work wid})]
-        (ssr/reconcile-on-restore (runtime-db-with {gkey e}) fid))
+        (rf.resources.ssr/reconcile-on-restore (runtime-db-with {gkey e}) fid))
       (is (empty? (frame-timer-keys fid))
           "the frame's stale/GC timer handles are GONE after restore")
       (is (empty? (work-handle-keys fid))
           "the frame's work-ledger host handles are GONE after restore")
       ;; cleanup any stray timers (none expected)
-      (timers/cancel-for-key! fid rkey))))
+      (rf.resources.timers/cancel-for-key! fid rkey))))
 
 (deftest restore-host-clear-preserves-generation-high-water
   (testing "rf2-nd1r9q — clearing host transients on restore does NOT rewind the
             generation high-water mark (part 1 — it must stay monotonic)"
     (let [fid :restore/gen-preserve]
-      (state/commit-generation! fid 11)
-      (timers/schedule! fid gkey timers/stale-kind 600000)
+      (rf.resources.state/commit-generation! fid 11)
+      (rf.resources.timers/schedule! fid gkey rf.resources.timers/stale-kind 600000)
       (let [e (entry {:resource-id :article/by-slug :status :fetching :data {:x 1}
                       :loaded-at 1 :stale-at 9.0e15 :current-work [:rf.work/resource gkey 5]})]
-        (ssr/reconcile-on-restore (runtime-db-with {gkey e}) fid))
-      (is (= 11 (state/generation-snapshot fid))
+        (rf.resources.ssr/reconcile-on-restore (runtime-db-with {gkey e}) fid))
+      (is (= 11 (rf.resources.state/generation-snapshot fid))
           "the host-side generation high-water mark is UNTOUCHED by the host-transient clear")
-      (timers/cancel-for-key! fid gkey))))
+      (rf.resources.timers/cancel-for-key! fid gkey))))
 
 (deftest restore-host-clear-triggers-no-eager-refetch
   (testing "rf2-nd1r9q — restore clears transients but arms NO eager refetch /
@@ -785,7 +785,7 @@
     (let [fid :restore/no-eager
           e   (entry {:resource-id :article/by-slug :status :loaded
                       :data {:x 1} :loaded-at 1 :stale-at 2})] ;; stale
-      (ssr/reconcile-on-restore (runtime-db-with {gkey e}) fid)
+      (rf.resources.ssr/reconcile-on-restore (runtime-db-with {gkey e}) fid)
       (is (empty? (frame-timer-keys fid))
           "no stale/GC timer is armed by restore (lazy re-arm on next ensure)")
       (is (empty? (work-handle-keys fid))
@@ -794,7 +794,7 @@
 (deftest clear-host-transients-on-restore-is-pure-subset
   (testing "rf2-nd1r9q — clear-host-transients-on-restore! clears timers + work
             handles but is a no-op on an unarmed frame (idempotent)"
-    (is (nil? (ssr/clear-host-transients-on-restore! :restore/unarmed)))))
+    (is (nil? (rf.resources.ssr/clear-host-transients-on-restore! :restore/unarmed)))))
 
 (deftest reconcile-host-transient-clear-fenced-to-exact-incarnation
   (testing "rf2-qfrh4 seam 2 — the pre-write host-transient clear fires only when
@@ -809,12 +809,12 @@
           rkey gkey
           wid  [:rf.work/resource gkey 7]
           arm! (fn []
-                 (timers/schedule! fid rkey timers/stale-kind 600000)
-                 (work-ledger/put-handle! fid wid {:transport :rf.http/managed :request-id wid}))
+                 (rf.resources.timers/schedule! fid rkey rf.resources.timers/stale-kind 600000)
+                 (rf.resources.work-ledger/put-handle! fid wid {:transport :rf.http/managed :request-id wid}))
           e    (entry {:resource-id :article/by-slug :status :fetching :data {:x 1}
                        :loaded-at 1 :stale-at 9.0e15 :current-work wid})]
       (rf/make-frame {:id fid})
-      (let [live-token  (frame/frame-incarnation-token fid)
+      (let [live-token  (rf.frame/frame-incarnation-token fid)
             ;; a unique reference that never names fid's live incarnation — an
             ;; incarnation token is a `:drain-lock` atom, so a fresh atom stands
             ;; in for a destroyed / successor incarnation's token (cross-host:
@@ -824,26 +824,26 @@
         (arm!)
         (is (seq (frame-timer-keys fid)) "armed a stale timer for the frame")
         (is (seq (work-handle-keys fid)) "recorded a work handle for the frame")
-        (ssr/reconcile-on-restore (runtime-db-with {gkey e}) fid {:owner-token stale-token})
+        (rf.resources.ssr/reconcile-on-restore (runtime-db-with {gkey e}) fid {:owner-token stale-token})
         (is (seq (frame-timer-keys fid))
             "a stale incarnation token SKIPS the timer clear (successor's handle spared)")
         (is (seq (work-handle-keys fid))
             "a stale incarnation token SKIPS the work-handle clear")
         ;; LIVE token — clears as before.
-        (ssr/reconcile-on-restore (runtime-db-with {gkey e}) fid {:owner-token live-token})
+        (rf.resources.ssr/reconcile-on-restore (runtime-db-with {gkey e}) fid {:owner-token live-token})
         (is (empty? (frame-timer-keys fid)) "the live incarnation token clears the timer")
         (is (empty? (work-handle-keys fid)) "the live incarnation token clears the work handle")
         ;; nil token (pure-unit path) — clears unconditionally, as before.
         (arm!)
-        (ssr/reconcile-on-restore (runtime-db-with {gkey e}) fid {:owner-token nil})
+        (rf.resources.ssr/reconcile-on-restore (runtime-db-with {gkey e}) fid {:owner-token nil})
         (is (empty? (frame-timer-keys fid)) "nil token clears the timer unconditionally")
         (is (empty? (work-handle-keys fid)) "nil token clears the work handle unconditionally")
-        (timers/cancel-for-key! fid rkey)))))
+        (rf.resources.timers/cancel-for-key! fid rkey)))))
 
 ;; ---- rf2-sdeae — the clear itself is a CALLBACK-BEARING fan-out ------------
 ;;
 ;; The seam-2 fence above answers "may this clear run at all?" ONCE, before the
-;; fan-out. But the fan-out is not callback-free: `work-ledger/release-frame!`
+;; fan-out. But the fan-out is not callback-free: `rf.resources.work-ledger/release-frame!`
 ;; best-effort ABORTS each slot on the way out, and an abort callback is app /
 ;; transport code that can churn incarnation A to a same-id successor B and let
 ;; B record a handle in the SAME `[frame-id work-id]` slot. Read-abort-dissoc
@@ -854,7 +854,7 @@
 ;; FIRST (one `swap-vals!`, no callback window before it), then abort the
 ;; DETACHED handle values. Callbacks then act on detached attempt identities and
 ;; can neither be re-read nor dissociated by A's tail. This is the discipline
-;; `timers/release-frame!` already uses for the sibling timer table.
+;; `rf.resources.timers/release-frame!` already uses for the sibling timer table.
 
 (deftest work-ledger-release-frame-detaches-before-abort-callbacks
   (testing "rf2-sdeae — an abort callback that seats a same-id successor B in the
@@ -868,18 +868,18 @@
       ;; A's slot carries an abort callback that — synchronously, at the exact
       ;; seam between the table read and the dissoc — seats successor B's handle
       ;; in the very slot key A is about to drop.
-      (work-ledger/put-handle! fid wid
+      (rf.resources.work-ledger/put-handle! fid wid
         {:transport :rf.http/direct
          :owner     :A
          :abort-fn  (fn [reason]
                       (swap! aborted conj reason)
-                      (work-ledger/put-handle! fid wid b-handle))})
-      (work-ledger/release-frame! fid)
+                      (rf.resources.work-ledger/put-handle! fid wid b-handle))})
+      (rf.resources.work-ledger/release-frame! fid)
       (is (= [:resource-superseded] @aborted)
           "A's abort callback fired exactly once")
-      (is (identical? b-handle (work-ledger/get-handle fid wid))
+      (is (identical? b-handle (rf.resources.work-ledger/get-handle fid wid))
           "successor B's re-seated handle survives byte-for-byte (not dissoc'd by A's tail)")
-      (work-ledger/clear-handle! fid wid))))
+      (rf.resources.work-ledger/clear-handle! fid wid))))
 
 (deftest work-ledger-release-frame-abort-callback-reentrancy
   (testing "rf2-sdeae adversarial (nested fan-out) — an abort callback that
@@ -891,22 +891,22 @@
           wid-2    [:rf.work/resource gkey 22]
           b-handle {:transport :rf.http/managed :owner :B}
           aborted  (atom [])]
-      (work-ledger/put-handle! fid wid-1
+      (rf.resources.work-ledger/put-handle! fid wid-1
         {:owner :A :abort-fn (fn [_]
                                (swap! aborted conj :a1)
                                ;; nested fan-out over the same frame
-                               (work-ledger/release-frame! fid)
+                               (rf.resources.work-ledger/release-frame! fid)
                                ;; …then B seats a handle in a slot the OUTER
                                ;; pass still holds detached.
-                               (work-ledger/put-handle! fid wid-2 b-handle))})
-      (work-ledger/put-handle! fid wid-2
+                               (rf.resources.work-ledger/put-handle! fid wid-2 b-handle))})
+      (rf.resources.work-ledger/put-handle! fid wid-2
         {:owner :A :abort-fn (fn [_] (swap! aborted conj :a2))})
-      (work-ledger/release-frame! fid)
+      (rf.resources.work-ledger/release-frame! fid)
       (is (= 1 (count (filter #{:a1} @aborted))) "A's slot 1 aborted exactly once")
       (is (= 1 (count (filter #{:a2} @aborted))) "A's slot 2 aborted exactly once")
-      (is (identical? b-handle (work-ledger/get-handle fid wid-2))
+      (is (identical? b-handle (rf.resources.work-ledger/get-handle fid wid-2))
           "the successor handle seated during the nested fan-out survives")
-      (work-ledger/clear-handle! fid wid-2))))
+      (rf.resources.work-ledger/clear-handle! fid wid-2))))
 
 (deftest work-ledger-abort-callback-may-drop-its-own-slot
   (testing "rf2-sdeae adversarial (callback drops its own listener mid-cleanup) —
@@ -916,14 +916,14 @@
     (let [fid      :restore/self-drop
           wid      [:rf.work/resource gkey 31]
           b-handle {:transport :rf.http/managed :owner :B}]
-      (work-ledger/put-handle! fid wid
+      (rf.resources.work-ledger/put-handle! fid wid
         {:owner :A :abort-fn (fn [_]
-                               (work-ledger/clear-handle! fid wid)
-                               (work-ledger/put-handle! fid wid b-handle))})
-      (work-ledger/release-frame! fid)
-      (is (identical? b-handle (work-ledger/get-handle fid wid))
+                               (rf.resources.work-ledger/clear-handle! fid wid)
+                               (rf.resources.work-ledger/put-handle! fid wid b-handle))})
+      (rf.resources.work-ledger/release-frame! fid)
+      (is (identical? b-handle (rf.resources.work-ledger/get-handle fid wid))
           "the successor handle the callback seated after self-clearing survives")
-      (work-ledger/clear-handle! fid wid))))
+      (rf.resources.work-ledger/clear-handle! fid wid))))
 
 (deftest opportunistic-abort-detaches-before-abort-callback
   (testing "rf2-sdeae — the single-slot public abort has the same seam: the abort
@@ -932,13 +932,13 @@
     (let [fid      :restore/one-slot
           wid      [:rf.work/resource gkey 41]
           b-handle {:transport :rf.http/managed :owner :B}]
-      (work-ledger/put-handle! fid wid
-        {:owner :A :abort-fn (fn [_] (work-ledger/put-handle! fid wid b-handle))})
-      (is (true? (work-ledger/opportunistic-abort! fid wid))
+      (rf.resources.work-ledger/put-handle! fid wid
+        {:owner :A :abort-fn (fn [_] (rf.resources.work-ledger/put-handle! fid wid b-handle))})
+      (is (true? (rf.resources.work-ledger/opportunistic-abort! fid wid))
           "an abort capability was found and fired")
-      (is (identical? b-handle (work-ledger/get-handle fid wid))
+      (is (identical? b-handle (rf.resources.work-ledger/get-handle fid wid))
           "successor B's re-seated handle survives the returning clear")
-      (work-ledger/clear-handle! fid wid))))
+      (rf.resources.work-ledger/clear-handle! fid wid))))
 
 ;; ---- rf2-sdeae — the deferred trace commit is a callback fan-out too -------
 
@@ -954,15 +954,15 @@
                         :loaded-at 1 :stale-at 9.0e15 :owners #{stale}})
           rdb   (with-live-nav-token (runtime-db-with {gkey e}) "nav-NEW")]
       (rf/make-frame {:id fid})
-      (let [token (frame/frame-incarnation-token fid)
-            out   (ssr/reconcile-on-restore rdb fid {:defer-traces? true :owner-token token})
+      (let [token (rf.frame/frame-incarnation-token fid)
+            out   (rf.resources.ssr/reconcile-on-restore rdb fid {:defer-traces? true :owner-token token})
             intents (-> out meta (get :re-frame.resources.ssr/deferred-trace-intents))
             [seen unregister!] (restore-trace-recorder)
             churned? (atom false)]
         (is (< 1 (count intents))
             "the reconcile deferred MORE than one intent (a genuine fan-out)")
         ;; the FIRST emitted intent's listener destroys A and seats successor B
-        (trace-tooling/register-listener! ::sdeae-churn
+        (rf.trace.tooling/register-listener! ::sdeae-churn
           (fn [ev]
             (when (and (not @churned?)
                        (contains? #{:rf.resource/restored :rf.resource/owner-released}
@@ -971,9 +971,9 @@
               (rf/destroy-frame! fid)
               (rf/make-frame {:id fid}))))
         (try
-          (ssr/commit-restore-reconcile-traces! out fid {:owner-token token})
+          (rf.resources.ssr/commit-restore-reconcile-traces! out fid {:owner-token token})
           (finally
-            (trace-tooling/unregister-listener! ::sdeae-churn)
+            (rf.trace.tooling/unregister-listener! ::sdeae-churn)
             (unregister!)))
         (is (true? @churned?) "the first intent's listener churned A to B")
         (is (= 1 (count @seen))
@@ -986,22 +986,22 @@
           stale [:route :route/article "nav-OLD"]
           e     (entry {:resource-id :article/by-slug :status :loaded :data {:x 1}
                         :loaded-at 1 :stale-at 9.0e15 :owners #{stale}})
-          mk    (fn [] (ssr/reconcile-on-restore
+          mk    (fn [] (rf.resources.ssr/reconcile-on-restore
                          (with-live-nav-token (runtime-db-with {gkey e}) "nav-NEW")
                          fid {:defer-traces? true}))]
       (rf/make-frame {:id fid})
-      (let [token (frame/frame-incarnation-token fid)
+      (let [token (rf.frame/frame-incarnation-token fid)
             n     (count (-> (mk) meta (get :re-frame.resources.ssr/deferred-trace-intents)))]
         (let [[seen unregister!] (restore-trace-recorder)]
-          (try (ssr/commit-restore-reconcile-traces! (mk))
+          (try (rf.resources.ssr/commit-restore-reconcile-traces! (mk))
                (finally (unregister!)))
           (is (= n (count @seen)) "the 1-arity commits every intent unconditionally"))
         (let [[seen unregister!] (restore-trace-recorder)]
-          (try (ssr/commit-restore-reconcile-traces! (mk) fid {:owner-token token})
+          (try (rf.resources.ssr/commit-restore-reconcile-traces! (mk) fid {:owner-token token})
                (finally (unregister!)))
           (is (= n (count @seen)) "a LIVE incarnation commits every intent"))
         (let [[seen unregister!] (restore-trace-recorder)]
-          (try (ssr/commit-restore-reconcile-traces! (mk) fid {:owner-token nil})
+          (try (rf.resources.ssr/commit-restore-reconcile-traces! (mk) fid {:owner-token nil})
                (finally (unregister!)))
           (is (= n (count @seen)) "a nil token commits every intent, as before"))))))
 
@@ -1014,7 +1014,7 @@
             cannot rewind it, so a post-restore allocation strictly exceeds any
             pre-restore generation (anti-recycling, part 1)"
     ;; Pre-restore: the live timeline minted up to generation 7.
-    (state/commit-generation! :app/main 7)
+    (rf.resources.state/commit-generation! :app/main 7)
     ;; The captured snapshot is from an earlier epoch where generation was 3.
     ;; reconcile-on-restore touches ONLY durable frame-state — never the host
     ;; allocator — so the high-water mark stays at 7.
@@ -1022,13 +1022,13 @@
                                  :data {:x 1} :loaded-at 1 :stale-at 9.0e15
                                  :generation 3
                                  :current-work [:rf.work/resource gkey 3]})]
-      (ssr/reconcile-on-restore (runtime-db-with {gkey snapshot-entry}) :app/main)
-      (is (= 7 (state/generation-snapshot :app/main))
+      (rf.resources.ssr/reconcile-on-restore (runtime-db-with {gkey snapshot-entry}) :app/main)
+      (is (= 7 (rf.resources.state/generation-snapshot :app/main))
           "restore did not rewind the host-side allocator")
       ;; the next allocation strictly exceeds the pre-restore generation 7 AND
       ;; the restored snapshot's generation 3 → a pre-restore reply carrying
       ;; generation 3 can never match a freshly-minted live entry.
-      (is (= 8 (state/next-generation (state/generation-snapshot :app/main)))
+      (is (= 8 (rf.resources.state/next-generation (rf.resources.state/generation-snapshot :app/main)))
           "the next minted generation strictly exceeds every pre-restore generation"))))
 
 ;; ===========================================================================
@@ -1040,40 +1040,40 @@
             freshness is a later live-owner decision (part 3)"
     (let [stale (entry {:resource-id :article/by-slug :status :loaded
                         :data {:x 1} :loaded-at 1 :stale-at 2})  ;; stale
-          out (ssr/reconcile-on-restore (runtime-db-with {gkey stale}) :app/main)]
+          out (rf.resources.ssr/reconcile-on-restore (runtime-db-with {gkey stale}) :app/main)]
       ;; the reconcile returns a runtime-db, never an fx vector / dispatch plan
       (is (map? out))
-      (is (contains? out state/resources-key))
-      (is (= {:x 1} (get-in out [state/resources-key :entries (state/key-id gkey) :data]))
+      (is (contains? out rf.resources.state/resources-key))
+      (is (= {:x 1} (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id gkey) :data]))
           "the stale entry keeps its data; restore double-fetches nothing"))))
 
 (deftest restore-noop-without-resources
   (testing "a runtime-db with no resource entries AND no work-ledger rows is
             returned unchanged (a resource-free restore)"
     (let [rdb {:rf.runtime/machines {:snapshots {}}}]
-      (is (= rdb (ssr/reconcile-on-restore rdb :app/main))))))
+      (is (= rdb (rf.resources.ssr/reconcile-on-restore rdb :app/main))))))
 
 (deftest restore-never-crosses-scopes
   (testing "entries under different scopes stay isolated through the restore reconcile"
-    (let [ka (state/scoped-resource-key [:rf.scope/session {:user "a"}] :article/by-slug {:slug "x"})
-          kb (state/scoped-resource-key [:rf.scope/session {:user "b"}] :article/by-slug {:slug "x"})
+    (let [ka (rf.resources.state/scoped-resource-key [:rf.scope/session {:user "a"}] :article/by-slug {:slug "x"})
+          kb (rf.resources.state/scoped-resource-key [:rf.scope/session {:user "b"}] :article/by-slug {:slug "x"})
           ea (entry {:resource-id :article/by-slug :status :fetching :data {:owner "a"}
                      :loaded-at 1 :stale-at 9.0e15 :tags #{[:article "x"]}
                      :current-work [:rf.work/resource ka 2]})
           eb (entry {:resource-id :article/by-slug :status :loaded :data {:owner "b"}
                      :loaded-at 1 :stale-at 9.0e15 :tags #{[:article "x"]}})
-          out (ssr/reconcile-on-restore (runtime-db-with {ka ea kb eb}) :app/main)
-          es  (get-in out [state/resources-key :entries])]
+          out (rf.resources.ssr/reconcile-on-restore (runtime-db-with {ka ea kb eb}) :app/main)
+          es  (get-in out [rf.resources.state/resources-key :entries])]
       ;; rf2-9e0tyq — entries + tag-index members are keyed on the byte key-id.
-      (is (= {:owner "a"} (:data (es (state/key-id ka)))) "scope-a data stays under scope-a's key")
-      (is (= :loaded (:status (es (state/key-id ka)))) "scope-a fetching → loaded (kept data)")
-      (is (= {:owner "b"} (:data (es (state/key-id kb)))) "scope-b data stays under scope-b's key")
-      (is (= #{(state/key-id ka) (state/key-id kb)}
-             (get-in out [state/resources-key :tag-index [:article "x"]]))
+      (is (= {:owner "a"} (:data (es (rf.resources.state/key-id ka)))) "scope-a data stays under scope-a's key")
+      (is (= :loaded (:status (es (rf.resources.state/key-id ka)))) "scope-a fetching → loaded (kept data)")
+      (is (= {:owner "b"} (:data (es (rf.resources.state/key-id kb)))) "scope-b data stays under scope-b's key")
+      (is (= #{(rf.resources.state/key-id ka) (rf.resources.state/key-id kb)}
+             (get-in out [rf.resources.state/resources-key :tag-index [:article "x"]]))
           "the shared tag maps to both scoped keys, never collapsed"))))
 
 (deftest reconcile-on-restore-hook-published
   (testing "the :resources/reconcile-on-restore hook is published by the façade"
-    (is (some? (late-bind/get-fn :resources/reconcile-on-restore)))
-    (is (= ssr/reconcile-on-restore
-           (late-bind/get-fn :resources/reconcile-on-restore)))))
+    (is (some? (rf.late-bind/get-fn :resources/reconcile-on-restore)))
+    (is (= rf.resources.ssr/reconcile-on-restore
+           (rf.late-bind/get-fn :resources/reconcile-on-restore)))))

--- a/implementation/resources/test/re_frame/resources_revalidation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_revalidation_cljs_test.cljc
@@ -9,7 +9,7 @@
     1. ACTIVE-STALE SCAN — `:rf.resource/window-focused` /
        `:rf.resource/network-reconnected` scan the frame's cache entries and
        refetch ONLY those that are BOTH active (a live `:active-owner`)
-       AND stale-by-policy (`state/entry-stale?` against the durable
+       AND stale-by-policy (`rf.resources.state/entry-stale?` against the durable
        timestamps); fresh entries and owner-free entries are LEFT ALONE;
     2. CAUSE, NEVER OWNER — a focus/reconnect-triggered refetch carries cause
        `:focus` / `:reconnect` and attaches NO owner (it never creates
@@ -28,25 +28,25 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
-   [re-frame.frame :as frame]
-   [re-frame.late-bind :as late-bind]
+   [re-frame.fx :as rf.fx]
+   [re-frame.frame :as rf.frame]
+   [re-frame.late-bind :as rf.late-bind]
    ;; load-bearing side-effecting require: the façade registers the
    ;; :rf.resource/* events (incl. the focus/reconnect events this test
    ;; dispatches) + the timer / work-ledger side-table fx + the internal
    ;; replies these tests dispatch through.
    [re-frame.resources]
-   [re-frame.resources.revalidate-listeners :as revalidate-listeners]
-   [re-frame.resources.state :as state]
+   [re-frame.resources.revalidate-listeners :as rf.resources.revalidate-listeners]
+   [re-frame.resources.state :as rf.resources.state]
    [re-frame.resources.test-support]
-   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.resources.work-ledger :as rf.resources.work-ledger]
    ;; production HTTP fx surface (so the transport feature probe resolves);
    ;; the actual fetch + abort are overridden by capturing no-ops below.
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport + abort + timer-schedule (deterministic) ---------
 
@@ -68,15 +68,15 @@
   [f]
   (reset! aborts [])
   (reset! scheduled-timers [])
-  (fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
-  (fx/reg-fx :rf.http/managed-abort (fn [_ctx work-id] (swap! aborts conj work-id) nil))
-  (fx/reg-fx :rf.resource/schedule-timers (fn [_ctx args] (swap! scheduled-timers conj args) nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf.fx/reg-fx :rf.http/managed-abort (fn [_ctx work-id] (swap! aborts conj work-id) nil))
+  (rf.fx/reg-fx :rf.resource/schedule-timers (fn [_ctx args] (swap! scheduled-timers conj args) nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
   capturing-fixture)
 
 ;; ---- helpers --------------------------------------------------------------
@@ -88,7 +88,7 @@
 (defn- entry
   ([scoped-key] (entry :rf/default scoped-key))
   ([frame-id scoped-key]
-   (get-in (runtime-db frame-id) (state/entry-path scoped-key))))
+   (get-in (runtime-db frame-id) (rf.resources.state/entry-path scoped-key))))
 
 (defn- article-spec
   ([] (article-spec {}))
@@ -129,9 +129,9 @@
   (rf/reg-resource :rv/sw   (article-spec {:stale-after-ms 0}) article-spec-request) ;; goes stale at once
   (rf/reg-resource :rv/fresh (article-spec) article-spec-request)                    ;; never stale
   (let [scope    {:user "u"}
-        k-as     (state/scoped-resource-key scope :rv/sw    {:slug "active-stale"})
-        k-af     (state/scoped-resource-key scope :rv/fresh {:slug "active-fresh"})
-        k-is     (state/scoped-resource-key scope :rv/sw    {:slug "inactive-stale"})]
+        k-as     (rf.resources.state/scoped-resource-key scope :rv/sw    {:slug "active-stale"})
+        k-af     (rf.resources.state/scoped-resource-key scope :rv/fresh {:slug "active-fresh"})
+        k-is     (rf.resources.state/scoped-resource-key scope :rv/sw    {:slug "inactive-stale"})]
     ;; active + stale
     (ensure! :rv/sw scope "active-stale" [:route :r 1])
     (succeed! k-as {:title "AS"})
@@ -156,7 +156,7 @@
 (deftest network-reconnected-refetches-active-stale
   (rf/reg-resource :rc/sw (article-spec {:stale-after-ms 0}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :rc/sw {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :rc/sw {:slug "w"})]
     (ensure! :rc/sw scope "w" [:route :r 1])
     (succeed! k {:title "W"})
     (testing "Spec 016 §Deferred slices — network reconnect refetches the
@@ -172,7 +172,7 @@
 (deftest focus-refetch-is-cause-not-owner
   (rf/reg-resource :ca/sw (article-spec {:stale-after-ms 0}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :ca/sw {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :ca/sw {:slug "w"})]
     (ensure! :ca/sw scope "w" [:route :r 1])
     (succeed! k {:title "W"})
     (rf/dispatch-sync [:rf.resource/window-focused])
@@ -180,7 +180,7 @@
               records the :focus CAUSE on the live work record but attaches NO
               new owner (it never creates liveness)"
       (let [e   (entry k)
-            rec (work-ledger/get-record (runtime-db) (:current-work e))]
+            rec (rf.resources.work-ledger/get-record (runtime-db) (:current-work e))]
         (is (= #{[:route :r 1]} (:active-owners e))
             "owner set unchanged — focus added no owner")
         (is (some #{:focus} (:causes rec))
@@ -193,7 +193,7 @@
 (deftest focus-refetch-bumps-generation-and-suppresses-stale-reply
   (rf/reg-resource :gn/sw (article-spec {:stale-after-ms 0}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :gn/sw {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :gn/sw {:slug "w"})]
     (ensure! :gn/sw scope "w" [:route :r 1])
     (succeed! k {:title "W"})
     (let [gen-before (:generation (entry k))
@@ -209,7 +209,7 @@
                   suppressed (never overwrites the post-focus entry)"
           (rf/dispatch-sync [:rf.resource.internal/succeeded
                              {:resource/key k
-                              :work/id (work-ledger/resource-work-id k gen-before)
+                              :work/id (rf.resources.work-ledger/resource-work-id k gen-before)
                               :generation gen-before :data {:title "Zombie"}}])
           (is (not= {:title "Zombie"} (:data (entry k)))
               "the pre-focus-generation reply was suppressed"))))))
@@ -219,7 +219,7 @@
             harmless no-op (no refetch, no error)"
     (rf/dispatch-sync [:rf.resource/window-focused])
     (rf/dispatch-sync [:rf.resource/network-reconnected])
-    (is (nil? (get-in (runtime-db) (state/entries-path)))
+    (is (nil? (get-in (runtime-db) (rf.resources.state/entries-path)))
         "no entries materialised by an empty-frame scan")))
 
 ;; ===========================================================================
@@ -237,7 +237,7 @@
   ;; force a SECOND new generation, superseding + aborting the first (churn).
   (rf/reg-resource :co/sw (article-spec {:stale-after-ms 0}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :co/sw {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :co/sw {:slug "w"})]
     (ensure! :co/sw scope "w" [:route :r 1])
     (succeed! k {:title "W"})
     (let [gen-before (:generation (entry k))]
@@ -264,7 +264,7 @@
   ;; work item and no abort churn.
   (rf/reg-resource :cv/sw (article-spec {:stale-after-ms 0}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :cv/sw {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :cv/sw {:slug "w"})]
     (ensure! :cv/sw scope "w" [:route :r 1])
     (succeed! k {:title "W"})
     (let [gen-before (:generation (entry k))]
@@ -274,7 +274,7 @@
       (rf/dispatch-sync [:rf.resource/window-focused]) ;; window focus
       (rf/dispatch-sync [:rf.resource/window-focused]) ;; document visibilitychange→visible
       (let [e   (entry k)
-            rec (work-ledger/get-record (runtime-db) (:current-work e))]
+            rec (rf.resources.work-ledger/get-record (runtime-db) (:current-work e))]
         (is (= (inc gen-before) (:generation e))
             "focus+visibility together bumped exactly ONE generation")
         (is (= :fetching (:status e)) "one in-flight refetch")
@@ -287,7 +287,7 @@
   ;; focus signal MUST start a fresh refetch.
   (rf/reg-resource :cf/sw (article-spec {:stale-after-ms 0}) article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :cf/sw {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :cf/sw {:slug "w"})]
     (ensure! :cf/sw scope "w" [:route :r 1])
     (succeed! k {:title "W"})
     (rf/dispatch-sync [:rf.resource/window-focused]) ;; refetch in flight
@@ -312,17 +312,17 @@
             entries (fresh active, stale inactive, and fresh inactive excluded)"
     (let [now    1000
           scope  {:user "u"}
-          mk     (fn [slug] (state/scoped-resource-key scope :sc/x {:slug slug}))
+          mk     (fn [slug] (rf.resources.state/scoped-resource-key scope :sc/x {:slug slug}))
           ;; active + stale (stale-at in the past)
-          e-as   (assoc (state/empty-entry :sc/x)
+          e-as   (assoc (rf.resources.state/empty-entry :sc/x)
                         :status :loaded :data {:v 1}
                         :active-owners #{[:route :r 1]} :stale-at 500)
           ;; active + fresh (stale-at in the future)
-          e-af   (assoc (state/empty-entry :sc/x)
+          e-af   (assoc (rf.resources.state/empty-entry :sc/x)
                         :status :loaded :data {:v 1}
                         :active-owners #{[:route :r 1]} :stale-at 5000)
           ;; inactive + stale (no owner)
-          e-is   (assoc (state/empty-entry :sc/x)
+          e-is   (assoc (rf.resources.state/empty-entry :sc/x)
                         :status :loaded :data {:v 1}
                         :active-owners #{} :stale-at 500)
           rdb    {:rf.runtime/resources
@@ -331,11 +331,11 @@
           ;; by reading the public events ns var via the dispatched event would
           ;; need a frame — instead assert through the handler-level behaviour
           ;; in the integration tests above. Here we assert the selection
-          ;; predicate directly via state/entry-stale? + active-owner gate.
+          ;; predicate directly via rf.resources.state/entry-stale? + active-owner gate.
           eligible (into #{}
                          (keep (fn [[kk e]]
                                  (when (and (seq (:active-owners e))
-                                            (state/entry-stale? e now))
+                                            (rf.resources.state/entry-stale? e now))
                                    kk)))
                          (:entries (:rf.runtime/resources rdb)))]
       (is (= #{(mk "as")} eligible)
@@ -351,22 +351,22 @@
     ;; install the per-frame listener side-table slot directly (the host
     ;; addEventListener arm is CLJS/DOM-only; the side-table bookkeeping is the
     ;; platform-neutral part frame-destroy must clear)
-    (swap! revalidate-listeners/listener-table assoc fa {:focus :h :visibility :h :online :h})
-    (is (contains? @revalidate-listeners/listener-table fa)
+    (swap! rf.resources.revalidate-listeners/listener-table assoc fa {:focus :h :visibility :h :online :h})
+    (is (contains? @rf.resources.revalidate-listeners/listener-table fa)
         "listener slot recorded for frame A")
     (testing "Spec 016 [Runtime-Subsystems] clause 5 — frame destroy drops the
               frame's focus/reconnect listeners via the single
               :resources/on-frame-destroyed! teardown hook (composed, not a
               second path)"
-      (frame/destroy-frame! fa)
-      (is (not (contains? @revalidate-listeners/listener-table fa))
+      (rf.frame/destroy-frame! fa)
+      (is (not (contains? @rf.resources.revalidate-listeners/listener-table fa))
           "frame A's listener slot dropped on destroy"))))
 
 (deftest remove-revalidation-listeners-is-idempotent
   (testing "Spec 016 — remove for a frame with no installed listeners is a
             harmless no-op (idempotent + JVM-safe)"
-    (revalidate-listeners/remove-revalidation-listeners! :rv/no-such-frame)
-    (is (not (contains? @revalidate-listeners/listener-table :rv/no-such-frame)))))
+    (rf.resources.revalidate-listeners/remove-revalidation-listeners! :rv/no-such-frame)
+    (is (not (contains? @rf.resources.revalidate-listeners/listener-table :rv/no-such-frame)))))
 
 ;; ===========================================================================
 ;; 6. Host event-target wiring (rf2-pxe0c7) — CLJS/DOM-stub only
@@ -430,10 +430,10 @@
              ;; capture dispatches via the late-bind router hook the listener
              ;; rides (so we observe the EXACT event the host wiring produces)
              (let [dispatched (atom [])
-                   prior      (late-bind/get-fn :router/dispatch!)]
-               (late-bind/set-fn! :router/dispatch! (fn [ev opts] (swap! dispatched conj [ev opts])))
+                   prior      (rf.late-bind/get-fn :router/dispatch!)]
+               (rf.late-bind/set-fn! :router/dispatch! (fn [ev opts] (swap! dispatched conj [ev opts])))
                (try
-                 (revalidate-listeners/install-revalidation-listeners! :rv/dom)
+                 (rf.resources.revalidate-listeners/install-revalidation-listeners! :rv/dom)
                  (testing "rf2-pxe0c7 — visibilitychange is attached to DOCUMENT, not window"
                    (is (seq (get-in @state [:document :listeners "visibilitychange"]))
                        "document carries the visibilitychange listener")
@@ -457,7 +457,7 @@
                    (.dispatchEvent (:document-obj @state) #js {:type "visibilitychange"})
                    (is (empty? @dispatched) "hidden visibilitychange dispatched nothing"))
                  (testing "rf2-pxe0c7 — remove detaches the visibilitychange listener from document"
-                   (revalidate-listeners/remove-revalidation-listeners! :rv/dom)
+                   (rf.resources.revalidate-listeners/remove-revalidation-listeners! :rv/dom)
                    (is (empty? (get-in @state [:document :listeners "visibilitychange"]))
                        "document visibilitychange listener detached on remove")
                    (is (empty? (get-in @state [:window :listeners "focus"]))
@@ -469,8 +469,8 @@
                    (is (empty? @dispatched) "detached listener fires nothing"))
                  (finally
                    (if prior
-                     (late-bind/set-fn! :router/dispatch! prior)
-                     (late-bind/set-fn! :router/dispatch! nil)))))
+                     (rf.late-bind/set-fn! :router/dispatch! prior)
+                     (rf.late-bind/set-fn! :router/dispatch! nil)))))
              (finally
                (uninstall-dom-stub!))))))))
 
@@ -482,15 +482,15 @@
            (try
              (let [fa :rv/dom-destroy]
                (rf/make-frame {:id fa :doc "DOM-stub frame-destroy detach frame"})
-               (revalidate-listeners/install-revalidation-listeners! fa)
+               (rf.resources.revalidate-listeners/install-revalidation-listeners! fa)
                (is (seq (get-in @state [:document :listeners "visibilitychange"]))
                    "document visibilitychange attached for the frame")
                (testing "rf2-pxe0c7 — frame destroy detaches the document
                          visibilitychange listener via the single teardown hook"
-                 (frame/destroy-frame! fa)
+                 (rf.frame/destroy-frame! fa)
                  (is (empty? (get-in @state [:document :listeners "visibilitychange"]))
                      "document visibilitychange detached on frame destroy")
-                 (is (not (contains? @revalidate-listeners/listener-table fa))
+                 (is (not (contains? @rf.resources.revalidate-listeners/listener-table fa))
                      "side-table slot dropped on frame destroy")))
              (finally
                (uninstall-dom-stub!))))))))

--- a/implementation/resources/test/re_frame/resources_revision_substrate_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_revision_substrate_cljs_test.cljc
@@ -28,21 +28,21 @@
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing]]
       :cljs [cljs.test :refer-macros [deftest is testing]])
-   [re-frame.resources.state :as state]
-   [re-frame.resources.mutation-runtime :as mut-rt]))
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.mutation-runtime :as rf.resources.mutation-runtime]))
 
 ;; ---- shape: base value, distinct from :generation -------------------------
 
 (deftest empty-entry-carries-revision-zero
   (testing "the base empty entry carries :revision 0, alongside :generation 0"
-    (let [e (state/empty-entry :conduit/article)]
+    (let [e (rf.resources.state/empty-entry :conduit/article)]
       (is (= 0 (:revision e)) ":revision base value is 0")
       (is (= 0 (:generation e)) ":generation base value is 0")
       (is (contains? e :revision)
           ":revision is a present durable entry fact, not absent")))
   (testing "the 2-arity (with scoped-key) also carries :revision 0"
-    (let [sk (state/scoped-resource-key :rf.scope/global :conduit/article {:slug "a"})
-          e  (state/empty-entry :conduit/article sk)]
+    (let [sk (rf.resources.state/scoped-resource-key :rf.scope/global :conduit/article {:slug "a"})
+          e  (rf.resources.state/empty-entry :conduit/article sk)]
       (is (= 0 (:revision e)))
       (is (= sk (:resource/key e))))))
 
@@ -50,8 +50,8 @@
   (testing ":revision and :generation are independent facts; entry-start-load
             bumps :generation (load START) but NOT :revision — so an in-flight
             refetch never false-conflicts"
-    (let [e0 (state/empty-entry :conduit/article)
-          e1 (state/entry-start-load
+    (let [e0 (rf.resources.state/empty-entry :conduit/article)
+          e1 (rf.resources.state/entry-start-load
                e0 {:generation 7 :work-id [:w 1] :request-id "r1" :owner :o})]
       (is (= 7 (:generation e1)) ":generation moves to the allocated value at load start")
       (is (= 0 (:revision e1))
@@ -64,15 +64,15 @@
   (testing "a load success bumps :revision; and a freshness-only settle
             (re-stamping :loaded-at / :stale-at while :data is `=`-shared) STILL
             bumps :revision — the byl7bk ruling's load-bearing case"
-    (let [loaded (-> (state/empty-entry :conduit/article)
-                     (state/entry-succeeded {:data {:n 1} :loaded-at 100
+    (let [loaded (-> (rf.resources.state/empty-entry :conduit/article)
+                     (rf.resources.state/entry-succeeded {:data {:n 1} :loaded-at 100
                                              :stale-at 200 :tags #{[:a]}}))]
       (is (= 1 (:revision loaded)) "first load success bumps 0 -> 1")
       (is (= 100 (:loaded-at loaded)))
       ;; a refetch returning EQUAL data: structural sharing keeps the old :data
       ;; identity, but :loaded-at / :stale-at are re-stamped — an authoritative
       ;; freshness settle a rollback could clobber.
-      (let [resettled (state/entry-succeeded
+      (let [resettled (rf.resources.state/entry-succeeded
                         loaded {:data {:n 1} :loaded-at 999 :stale-at 1200
                                 :tags #{[:a]}})]
         (is (identical? (:data loaded) (:data resettled))
@@ -85,13 +85,13 @@
 
 (deftest patch-entry-bumps-revision-even-on-equal-data
   (testing "a controlled patch bumps :revision, including the `=`-shared branch"
-    (let [base   (-> (state/empty-entry :conduit/article)
-                     (state/entry-succeeded {:data {:count 0} :loaded-at 10
+    (let [base   (-> (rf.resources.state/empty-entry :conduit/article)
+                     (rf.resources.state/entry-succeeded {:data {:count 0} :loaded-at 10
                                              :stale-at 20 :tags #{}}))
           rev0   (:revision base)
           ;; identity patch (returns `=` data) — structural-shared but a
           ;; re-stamp of :loaded-at / :stale-at, an authoritative durable write.
-          patched (mut-rt/patch-entry base (fn [d _r] d) :ignored-result
+          patched (rf.resources.mutation-runtime/patch-entry base (fn [d _r] d) :ignored-result
                                       {:clock-ms 50 :stale-at 60})]
       (is (= (inc rev0) (:revision patched))
           "patch bumps :revision even when the patch-fn returns `=` data")
@@ -99,8 +99,8 @@
           "structural sharing still holds for `=` patched data")
       (is (= 50 (:loaded-at patched)) "freshness IS re-stamped")))
   (testing "a patch of an entry with NO usable data is a no-op — no bump"
-    (let [empty   (state/empty-entry :conduit/article)
-          patched (mut-rt/patch-entry empty (fn [d _r] {:x 1}) :r
+    (let [empty   (rf.resources.state/empty-entry :conduit/article)
+          patched (rf.resources.mutation-runtime/patch-entry empty (fn [d _r] {:x 1}) :r
                                       {:clock-ms 1 :stale-at 2})]
       (is (= empty patched) "no-data patch returns the entry unchanged")
       (is (= 0 (:revision patched)) "the no-op path makes no write and no bump"))))
@@ -108,15 +108,15 @@
 (deftest populate-entry-bumps-revision
   (testing "populate-of-fresh seeds :revision 1 (base 0 -> bump); populate-over-
             existing bumps including the `=`-shared branch"
-    (let [sk    (state/scoped-resource-key :rf.scope/global :conduit/article {})
-          fresh (mut-rt/populate-entry nil :conduit/article {:v 1}
+    (let [sk    (rf.resources.state/scoped-resource-key :rf.scope/global :conduit/article {})
+          fresh (rf.resources.mutation-runtime/populate-entry nil :conduit/article {:v 1}
                                        {:clock-ms 5 :stale-at 9 :tags #{[:t]}
                                         :scoped-key sk})]
       (is (= 1 (:revision fresh)) "a freshly-seeded populate bumps 0 -> 1")
       (is (= {:v 1} (:data fresh)))
       ;; populate over the existing entry with EQUAL value — structural-shared,
       ;; but re-stamps freshness: an authoritative write.
-      (let [re (mut-rt/populate-entry fresh :conduit/article {:v 1}
+      (let [re (rf.resources.mutation-runtime/populate-entry fresh :conduit/article {:v 1}
                                       {:clock-ms 77 :stale-at 88 :tags #{[:t]}})]
         (is (identical? (:data fresh) (:data re))
             "equal populate value keeps the SAME :data identity")
@@ -129,18 +129,18 @@
 (deftest bump-revision-helper-is-total-and-monotone
   (testing "bump-revision increments, treats absent/nil :revision as 0, and
             leaves a nil entry unchanged"
-    (is (= 1 (:revision (state/bump-revision {:revision 0}))))
-    (is (= 6 (:revision (state/bump-revision {:revision 5}))))
-    (is (= 1 (:revision (state/bump-revision {})))
+    (is (= 1 (:revision (rf.resources.state/bump-revision {:revision 0}))))
+    (is (= 6 (:revision (rf.resources.state/bump-revision {:revision 5}))))
+    (is (= 1 (:revision (rf.resources.state/bump-revision {})))
         "absent :revision is treated as 0 (a pre-EP-0019 entry)")
-    (is (= 1 (:revision (state/bump-revision {:revision nil})))
+    (is (= 1 (:revision (rf.resources.state/bump-revision {:revision nil})))
         "nil :revision is treated as 0")
-    (is (nil? (state/bump-revision nil))
+    (is (nil? (rf.resources.state/bump-revision nil))
         "a nil entry has nothing to bump — returned unchanged"))
   (testing "entry-revision reads the fact, defaulting to 0"
-    (is (= 0 (state/entry-revision nil)))
-    (is (= 0 (state/entry-revision {})))
-    (is (= 3 (state/entry-revision {:revision 3})))))
+    (is (= 0 (rf.resources.state/entry-revision nil)))
+    (is (= 0 (rf.resources.state/entry-revision {})))
+    (is (= 3 (rf.resources.state/entry-revision {:revision 3})))))
 
 ;; ---- failure / cancel SETTLE bumps :revision (rf2-mx0w2o) ------------------
 ;;
@@ -160,17 +160,17 @@
             returns to :loaded, records :refresh-error, clears :current-work —
             and BUMPS :revision (rf2-mx0w2o): the settle is an authoritative
             durable write a later optimistic rollback could clobber"
-    (let [loaded   (-> (state/empty-entry :conduit/article)
-                       (state/entry-succeeded {:data {:n 1} :loaded-at 1
+    (let [loaded   (-> (rf.resources.state/empty-entry :conduit/article)
+                       (rf.resources.state/entry-succeeded {:data {:n 1} :loaded-at 1
                                                :stale-at 2 :tags #{}}))
           ;; a background refetch starts — :fetching, :current-work set; the
           ;; revision is UNMOVED at load start (entry-start-load) — this is the
           ;; revision a snapshot taken here would record.
-          fetching (state/entry-start-load
+          fetching (rf.resources.state/entry-start-load
                      loaded {:generation 5 :work-id [:w 1] :request-id "r" :owner :o})
-          rec-rev  (state/entry-revision fetching)
+          rec-rev  (rf.resources.state/entry-revision fetching)
           ;; the in-flight refetch FAILS — background failure settle.
-          settled  (state/entry-failed fetching {:error {:kind :rf.http/http-5xx}})]
+          settled  (rf.resources.state/entry-failed fetching {:error {:kind :rf.http/http-5xx}})]
       (is (= :fetching (:status fetching)) "the refetch is in flight")
       (is (= [:w 1] (:current-work fetching)) "with a :current-work pointer")
       (is (= rec-rev (:revision fetching))
@@ -183,44 +183,44 @@
         (is (= (inc rec-rev) (:revision settled))
             "the failure settle moved the write identity past the snapshot's"))
       (testing "so the optimistic-rollback conflict check now DETECTS the move"
-        (is (true? (mut-rt/optimistic-conflict? settled rec-rev))
+        (is (true? (rf.resources.mutation-runtime/optimistic-conflict? settled rec-rev))
             "a snapshot recorded at the in-flight revision sees the settle as a
              conflict — the rollback will NOT resurrect the stale :before")))))
 
 (deftest entry-failed-bumps-revision-on-a-first-load-failure
   (testing "a FIRST-load failure (no usable data) settles :error and BUMPS
             :revision (rf2-mx0w2o)"
-    (let [loading  (-> (state/empty-entry :conduit/article)
-                       (state/entry-start-load
+    (let [loading  (-> (rf.resources.state/empty-entry :conduit/article)
+                       (rf.resources.state/entry-start-load
                          {:generation 3 :work-id [:w 2] :request-id "r" :owner :o}))
-          rec-rev  (state/entry-revision loading)
-          settled  (state/entry-failed loading {:error {:kind :rf.http/http-4xx}})]
+          rec-rev  (rf.resources.state/entry-revision loading)
+          settled  (rf.resources.state/entry-failed loading {:error {:kind :rf.http/http-4xx}})]
       (is (= :loading (:status loading)) "first load — no usable data yet")
       (is (= :error (:status settled)) "first-load failure → :error")
       (is (nil? (:data settled)))
       (is (nil? (:current-work settled)))
       (is (= (inc rec-rev) (:revision settled))
           ":revision moved on the first-load failure settle")
-      (is (true? (mut-rt/optimistic-conflict? settled rec-rev))
+      (is (true? (rf.resources.mutation-runtime/optimistic-conflict? settled rec-rev))
           "the conflict check sees the settle"))))
 
 (deftest entry-page-failed-bumps-revision-on-a-load-more-failure
   (testing "a load-more (page N>0) failure keeps the feed, records :page-error,
             clears :current-work — and BUMPS :revision (rf2-mx0w2o)"
-    (let [feed     (-> (state/empty-infinite-entry :conduit/feed)
-                       (state/entry-append-page {:page [:a :b] :page-param nil
+    (let [feed     (-> (rf.resources.state/empty-infinite-entry :conduit/feed)
+                       (rf.resources.state/entry-append-page {:page [:a :b] :page-param nil
                                                  :loaded-at 1 :stale-at 2}))
           ;; a load-more starts (page 1 fetch) — :fetching, :current-work set.
-          fetching (state/entry-start-load
+          fetching (rf.resources.state/entry-start-load
                      feed {:generation 4 :work-id [:w 3] :request-id "r" :owner :o})
-          rec-rev  (state/entry-revision fetching)
-          settled  (state/entry-page-failed fetching {:error {:kind :rf.http/timeout}})]
+          rec-rev  (rf.resources.state/entry-revision fetching)
+          settled  (rf.resources.state/entry-page-failed fetching {:error {:kind :rf.http/timeout}})]
       (is (= [[:a :b]] (:data settled)) "the accumulated feed is KEPT")
       (is (= {:kind :rf.http/timeout} (:page-error settled)) ":page-error recorded")
       (is (nil? (:current-work settled)) ":current-work cleared")
       (is (= (inc rec-rev) (:revision settled))
           "the page-failure settle moved :revision (the rf2-mx0w2o fix)")
-      (is (true? (mut-rt/optimistic-conflict? settled rec-rev))
+      (is (true? (rf.resources.mutation-runtime/optimistic-conflict? settled rec-rev))
           "the conflict check sees the load-more failure settle"))))
 
 (deftest optimistic-rollback-does-not-resurrect-a-settled-in-flight-snapshot
@@ -231,28 +231,28 @@
             conflict and :invalidate — NOT :restore the stale in-flight :before
             (which would RESURRECT the in-flight :current-work pointer over the
             settled-failure state)."
-    (let [sk       (state/scoped-resource-key :rf.scope/global :conduit/article {:slug "w"})
-          loaded   (-> (state/empty-entry :conduit/article sk)
-                       (state/entry-succeeded {:data {:n 1} :loaded-at 1
+    (let [sk       (rf.resources.state/scoped-resource-key :rf.scope/global :conduit/article {:slug "w"})
+          loaded   (-> (rf.resources.state/empty-entry :conduit/article sk)
+                       (rf.resources.state/entry-succeeded {:data {:n 1} :loaded-at 1
                                                :stale-at 2 :tags #{}}))
           ;; an in-flight background refetch — :fetching, :current-work set.
-          fetching (state/entry-start-load
+          fetching (rf.resources.state/entry-start-load
                      loaded {:generation 9 :work-id [:w 7] :request-id "r" :owner :o})
           ;; the OPTIMISTIC APPLY (phase 1.5): snapshot the in-flight entry as
           ;; `:before`, then apply the forward patch — which bumps :revision and
           ;; PRESERVES :current-work (apply-optimistic-patch never clears it). The
           ;; recorded `:applied-revision` is the revision the apply LEFT it at.
-          observed (state/entry-revision fetching)
-          applied  (mut-rt/apply-optimistic-patch
+          observed (rf.resources.state/entry-revision fetching)
+          applied  (rf.resources.mutation-runtime/apply-optimistic-patch
                      fetching (fn [d] (assoc d :n 99)) :conduit/article
                      {:clock-ms 5 :stale-at 9 :scoped-key sk})
-          recorded (mut-rt/record-optimistic-entry
-                     sk fetching :patch observed (state/entry-revision applied))
+          recorded (rf.resources.mutation-runtime/record-optimistic-entry
+                     sk fetching :patch observed (rf.resources.state/entry-revision applied))
           ;; the in-flight refetch is STILL live after the apply (its
           ;; :current-work survived) → its failure reply settles the entry.
-          settled  (state/entry-failed applied {:error {:kind :rf.http/http-5xx}})
+          settled  (rf.resources.state/entry-failed applied {:error {:kind :rf.http/http-5xx}})
           ;; the mutation then fails → settle-time rollback for this recorded key.
-          disp     (mut-rt/rollback-entry-disposition settled recorded :invalidate)]
+          disp     (rf.resources.mutation-runtime/rollback-entry-disposition settled recorded :invalidate)]
       (testing "the recorded snapshot captured the IN-FLIGHT state (the danger)"
         (is (= :fetching (:status (:before recorded))))
         (is (= [:w 7] (:current-work (:before recorded)))
@@ -265,7 +265,7 @@
       (testing "the failure settle moved the entry's revision PAST the apply
                 baseline (the rf2-mx0w2o fix)"
         (is (= (inc (:applied-revision recorded)) (:revision settled)))
-        (is (true? (mut-rt/optimistic-conflict? settled (:applied-revision recorded)))
+        (is (true? (rf.resources.mutation-runtime/optimistic-conflict? settled (:applied-revision recorded)))
             "the settle is detected as a competing write since the apply"))
       (testing "so the rollback INVALIDATES — it does NOT restore the stale
                 in-flight :before (no resurrection of :current-work)"
@@ -280,51 +280,51 @@
   (testing "the apply's OWN bump is NOT a conflict: the baseline is the
             POST-apply :applied-revision, so an entry still standing where the
             apply left it is conflict-free"
-    (let [sk       (state/scoped-resource-key :rf.scope/global :conduit/article {:slug "a"})
-          loaded   (-> (state/empty-entry :conduit/article sk)
-                       (state/entry-succeeded {:data {:n 1} :loaded-at 1
+    (let [sk       (rf.resources.state/scoped-resource-key :rf.scope/global :conduit/article {:slug "a"})
+          loaded   (-> (rf.resources.state/empty-entry :conduit/article sk)
+                       (rf.resources.state/entry-succeeded {:data {:n 1} :loaded-at 1
                                                :stale-at 2 :tags #{}}))
-          observed (state/entry-revision loaded)
-          applied  (mut-rt/apply-optimistic-patch
+          observed (rf.resources.state/entry-revision loaded)
+          applied  (rf.resources.mutation-runtime/apply-optimistic-patch
                      loaded (fn [d] (assoc d :n 99)) :conduit/article
                      {:clock-ms 5 :stale-at 9 :scoped-key sk})
-          recorded (mut-rt/record-optimistic-entry
-                     sk loaded :patch observed (state/entry-revision applied))]
+          recorded (rf.resources.mutation-runtime/record-optimistic-entry
+                     sk loaded :patch observed (rf.resources.state/entry-revision applied))]
       (is (= (inc observed) (:applied-revision recorded))
           "the apply left the entry one bump past what it observed")
-      (is (false? (mut-rt/optimistic-conflict? applied (:applied-revision recorded)))
+      (is (false? (rf.resources.mutation-runtime/optimistic-conflict? applied (:applied-revision recorded)))
           "the apply's own numeric bump is expected — NOT a conflict")))
   (testing "CONFLICT when a competing authoritative write moves the entry BEYOND
             the applied baseline between the apply and the settle"
-    (let [loaded   (-> (state/empty-entry :conduit/article)
-                       (state/entry-succeeded {:data {:n 1} :loaded-at 1
+    (let [loaded   (-> (rf.resources.state/empty-entry :conduit/article)
+                       (rf.resources.state/entry-succeeded {:data {:n 1} :loaded-at 1
                                                :stale-at 2 :tags #{}}))
-          applied-revision (state/entry-revision loaded)
+          applied-revision (rf.resources.state/entry-revision loaded)
           ;; a competing write lands (a refetch returning equal data — still an
           ;; authoritative freshness settle that bumps :revision):
-          competed (state/entry-succeeded
+          competed (rf.resources.state/entry-succeeded
                      loaded {:data {:n 1} :loaded-at 500 :stale-at 600 :tags #{}})]
-      (is (= (inc applied-revision) (state/entry-revision competed)))
-      (is (true? (mut-rt/optimistic-conflict? competed applied-revision))
+      (is (= (inc applied-revision) (rf.resources.state/entry-revision competed)))
+      (is (true? (rf.resources.mutation-runtime/optimistic-conflict? competed applied-revision))
           "the moved revision is detected as a conflict — the recorded inverse
            is now a stale `before` the settle must NOT blindly restore")))
   (testing "the REMOVE branch (`applied-removed-revision` sentinel): a
             still-absent entry is UNMOVED, a re-created one is a conflict"
     (let [removed-baseline (:applied-revision
-                             (mut-rt/record-optimistic-entry
-                               (state/scoped-resource-key
+                             (rf.resources.mutation-runtime/record-optimistic-entry
+                               (rf.resources.state/scoped-resource-key
                                  :rf.scope/global :conduit/article {:slug "r"})
-                               mut-rt/absent-snapshot :remove))]
-      (is (false? (mut-rt/optimistic-conflict? nil removed-baseline))
+                               rf.resources.mutation-runtime/absent-snapshot :remove))]
+      (is (false? (rf.resources.mutation-runtime/optimistic-conflict? nil removed-baseline))
           "absent-after-remove — the remove stands, no conflict")
-      (is (true? (mut-rt/optimistic-conflict?
-                   (state/empty-entry :conduit/article) removed-baseline))
+      (is (true? (rf.resources.mutation-runtime/optimistic-conflict?
+                   (rf.resources.state/empty-entry :conduit/article) removed-baseline))
           "re-created-after-remove — a competing write seeded the removed key")))
   (testing "the comparison is canonical-identity over the monotone counter, not
             a value diff: an absent entry reads as revision 0"
-    (is (false? (mut-rt/optimistic-conflict? nil 0))
+    (is (false? (rf.resources.mutation-runtime/optimistic-conflict? nil 0))
         "absent entry ~ 0 vs applied 0 — no conflict")
-    (is (true? (mut-rt/optimistic-conflict? {:revision 1} 0))
+    (is (true? (rf.resources.mutation-runtime/optimistic-conflict? {:revision 1} 0))
         "current 1 vs applied 0 — conflict")))
 
 ;; ---- owner-liveness writes: the NO-OP GATE (rf2-k49jec / rf2-cxwuhl) --------
@@ -350,52 +350,52 @@
 (deftest attach-owner-bumps-revision-only-when-a-new-owner-lands
   (testing "attaching a NEW owner adds it to :active-owners AND bumps :revision
             (an authoritative durable write a rollback could clobber)"
-    (let [e0 (state/empty-entry :conduit/article)]
+    (let [e0 (rf.resources.state/empty-entry :conduit/article)]
       (is (= 0 (:revision e0)))
-      (let [e1 (state/attach-owner e0 :owner/a)]
+      (let [e1 (rf.resources.state/attach-owner e0 :owner/a)]
         (is (contains? (:active-owners e1) :owner/a) "the new owner is in the set")
         (is (= 1 (:revision e1)) "a new owner bumps :revision 0 -> 1")
         (testing "attaching a SECOND distinct owner also lands + bumps"
-          (let [e2 (state/attach-owner e1 :owner/b)]
+          (let [e2 (rf.resources.state/attach-owner e1 :owner/b)]
             (is (= #{:owner/a :owner/b} (:active-owners e2)) "set gains the 2nd owner")
             (is (= 2 (:revision e2)) "the 2nd distinct owner bumps 1 -> 2"))))))
   (testing "RE-ATTACHING an already-present owner is a NO-OP — the set is
             unchanged and :revision is UNMOVED (the load-bearing gate: no
             phantom conflict on every unrelated re-ensure)"
-    (let [e1 (state/attach-owner (state/empty-entry :conduit/article) :owner/a)
-          e2 (state/attach-owner e1 :owner/a)]
+    (let [e1 (rf.resources.state/attach-owner (rf.resources.state/empty-entry :conduit/article) :owner/a)
+          e2 (rf.resources.state/attach-owner e1 :owner/a)]
       (is (= (:active-owners e1) (:active-owners e2)) ":active-owners unchanged")
       (is (= 1 (:revision e2))
           ":revision is NOT bumped by a re-attach of a present owner")
       (is (identical? (:active-owners e1) (:active-owners e2))
           "the re-attach returns the SAME set identity — genuinely no write")))
   (testing "a nil owner is a no-op — no write, no bump (the (some? owner) gate)"
-    (let [e1 (state/attach-owner (state/empty-entry :conduit/article) :owner/a)
-          e2 (state/attach-owner e1 nil)]
+    (let [e1 (rf.resources.state/attach-owner (rf.resources.state/empty-entry :conduit/article) :owner/a)
+          e2 (rf.resources.state/attach-owner e1 nil)]
       (is (= e1 e2) "nil owner returns the entry unchanged")
       (is (= 1 (:revision e2)) ":revision is UNMOVED by a nil-owner attach"))))
 
 (deftest detach-owner-bumps-revision-only-when-the-owner-was-present
   (testing "detaching a PRESENT owner drops it from :active-owners AND bumps
             :revision (release is an authoritative durable write)"
-    (let [e1 (state/attach-owner (state/empty-entry :conduit/article) :owner/a)
-          e2 (state/detach-owner e1 :owner/a)]
+    (let [e1 (rf.resources.state/attach-owner (rf.resources.state/empty-entry :conduit/article) :owner/a)
+          e2 (rf.resources.state/detach-owner e1 :owner/a)]
       (is (not (contains? (:active-owners e2) :owner/a)) "the owner is gone")
       (is (= 2 (:revision e2)) "the release bumps :revision 1 -> 2")))
   (testing "detaching an ABSENT owner is a NO-OP — the set is unchanged and
             :revision is UNMOVED (the release-side gate)"
-    (let [e1 (state/attach-owner (state/empty-entry :conduit/article) :owner/a)
-          e2 (state/detach-owner e1 :owner/absent)]
+    (let [e1 (rf.resources.state/attach-owner (rf.resources.state/empty-entry :conduit/article) :owner/a)
+          e2 (rf.resources.state/detach-owner e1 :owner/absent)]
       (is (= (:active-owners e1) (:active-owners e2)) ":active-owners unchanged")
       (is (= 1 (:revision e2))
           ":revision is NOT bumped by a release of an owner that was never present")))
   (testing "detaching from an entry with NO :active-owners key is a no-op"
-    (let [e0 (state/empty-entry :conduit/article)]
+    (let [e0 (rf.resources.state/empty-entry :conduit/article)]
       (is (not (contains? (:active-owners e0) :owner/a)) "no owner set yet")
-      (let [e1 (state/detach-owner e0 :owner/a)]
+      (let [e1 (rf.resources.state/detach-owner e0 :owner/a)]
         (is (= 0 (:revision e1)) "the release of an absent owner makes no write, no bump"))))
   (testing "a nil entry is returned unchanged (the (and entry …) gate)"
-    (is (nil? (state/detach-owner nil :owner/a))
+    (is (nil? (rf.resources.state/detach-owner nil :owner/a))
         "detach-owner of nil returns nil")))
 
 (deftest owner-gate-drives-the-optimistic-conflict-check-correctly
@@ -403,35 +403,35 @@
             :revision UNMOVED, so a snapshot recorded before it sees NO conflict
             at settle — no PHANTOM optimistic-rollback conflict / spurious
             invalidate on an unrelated re-ensure"
-    (let [attached (state/attach-owner (state/empty-entry :conduit/article) :owner/a)
-          recorded (state/entry-revision attached)      ;; snapshot the apply revision
-          re-ens   (state/attach-owner attached :owner/a)]   ;; a re-ensure re-attaches
-      (is (= recorded (state/entry-revision re-ens))
+    (let [attached (rf.resources.state/attach-owner (rf.resources.state/empty-entry :conduit/article) :owner/a)
+          recorded (rf.resources.state/entry-revision attached)      ;; snapshot the apply revision
+          re-ens   (rf.resources.state/attach-owner attached :owner/a)]   ;; a re-ensure re-attaches
+      (is (= recorded (rf.resources.state/entry-revision re-ens))
           "the no-op re-attach did not move the write identity")
-      (is (false? (mut-rt/optimistic-conflict? re-ens recorded))
+      (is (false? (rf.resources.mutation-runtime/optimistic-conflict? re-ens recorded))
           "so the settle conflict check sees NO conflict — the gate prevents the
            phantom conflict that an unconditional bump would manufacture")))
   (testing "conversely a GENUINE mid-flight owner change DOES bump, so it is
             visible to the conflict check (the gate does not suppress real
             writes — the departed/arrived owner is protected)"
-    (let [attached (state/attach-owner (state/empty-entry :conduit/article) :owner/a)
-          recorded (state/entry-revision attached)
+    (let [attached (rf.resources.state/attach-owner (rf.resources.state/empty-entry :conduit/article) :owner/a)
+          recorded (rf.resources.state/entry-revision attached)
           ;; a real mid-flight change: a NEW owner arrives while the mutation
           ;; is in flight — an authoritative write a rollback would clobber.
-          changed  (state/attach-owner attached :owner/b)]
-      (is (= (inc recorded) (state/entry-revision changed))
+          changed  (rf.resources.state/attach-owner attached :owner/b)]
+      (is (= (inc recorded) (rf.resources.state/entry-revision changed))
           "the genuine new-owner attach bumped past the snapshot")
-      (is (true? (mut-rt/optimistic-conflict? changed recorded))
+      (is (true? (rf.resources.mutation-runtime/optimistic-conflict? changed recorded))
           "so the settle detects the conflict and :invalidates rather than
            blindly restoring the stale :before (which would DROP the new owner)"))
     (testing "and the RELEASE side is symmetric — a present-owner release bumps
               and is detected"
-      (let [with-two (-> (state/empty-entry :conduit/article)
-                         (state/attach-owner :owner/a)
-                         (state/attach-owner :owner/b))
-            recorded (state/entry-revision with-two)
-            released (state/detach-owner with-two :owner/a)]
-        (is (= (inc recorded) (state/entry-revision released))
+      (let [with-two (-> (rf.resources.state/empty-entry :conduit/article)
+                         (rf.resources.state/attach-owner :owner/a)
+                         (rf.resources.state/attach-owner :owner/b))
+            recorded (rf.resources.state/entry-revision with-two)
+            released (rf.resources.state/detach-owner with-two :owner/a)]
+        (is (= (inc recorded) (rf.resources.state/entry-revision released))
             "the present-owner release bumped past the snapshot")
-        (is (true? (mut-rt/optimistic-conflict? released recorded))
+        (is (true? (rf.resources.mutation-runtime/optimistic-conflict? released recorded))
             "so a rollback will NOT resurrect the departed owner")))))

--- a/implementation/resources/test/re_frame/resources_route_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_route_cljs_test.cljc
@@ -32,22 +32,22 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
-   [re-frame.error :as error]
-   [re-frame.interop :as interop]
+   [re-frame.fx :as rf.fx]
+   [re-frame.error :as rf.error]
+   [re-frame.interop :as rf.interop]
    ;; load-bearing side-effecting requires: register the routing + resources
    ;; events / subs and resources' late-bound :routing/* integration hooks.
    [re-frame.resources]
-   [re-frame.resources.route :as route]
-   [re-frame.resources.ssr :as res-ssr]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.resources.route :as rf.resources.route]
+   [re-frame.resources.ssr :as rf.resources.ssr]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.work-ledger :as rf.resources.work-ledger]
    [re-frame.resources.test-support]
-   [re-frame.routing :as routing]
+   [re-frame.routing :as rf.routing]
    [re-frame.schemas]
    [re-frame.http.managed]
-   [re-frame.test-support :as core-test-support]
-   [re-frame.trace.tooling :as trace-tooling]
+   [re-frame.test-support :as rf.test-support]
+   [re-frame.trace.tooling :as rf.trace.tooling]
    #?(:clj  [re-frame.substrate.plain-atom :as substrate]
       :cljs [re-frame.adapter.reagent :as substrate])))
 
@@ -63,19 +63,19 @@
   rf2-784223: the resources host-side caches (state / work-ledger / timers /
   revalidate-listeners) are cleared by the shared `make-reset-runtime-
   fixture`'s `:resources/reset-resources!` post-dispose hook, which runs
-  BEFORE this `:init-fn` — so no `state/reset-cache!` is repeated here. The
+  BEFORE this `:init-fn` — so no `rf.resources.state/reset-cache!` is repeated here. The
   routing counter reset + late-bound integration re-publication stay (they
   are routing-suite setup, not resource cache hygiene)."
   []
   (rf/make-frame {:id :rf/default :url-bound? true
                   :doc "Route-resource suite default app frame."})
-  (routing/reset-counters!)
-  (route/install-routing-integration!)
-  (fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
-  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil)))
+  (rf.routing/reset-counters!)
+  (rf.resources.route/install-routing-integration!)
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf.fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil)))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     {:adapter substrate/adapter
      :init-fn init!}))
 
@@ -85,26 +85,26 @@
   (get-in (:rf.db/runtime (rf/frame-state-value :rf/default)) [:rf.runtime/routing :current]))
 
 (defn- entry [scoped-key]
-  (get-in (:rf.db/runtime (rf/frame-state-value :rf/default)) (state/entry-path scoped-key)))
+  (get-in (:rf.db/runtime (rf/frame-state-value :rf/default)) (rf.resources.state/entry-path scoped-key)))
 
 (defn- entries []
-  (get-in (:rf.db/runtime (rf/frame-state-value :rf/default)) (state/entries-path)))
+  (get-in (:rf.db/runtime (rf/frame-state-value :rf/default)) (rf.resources.state/entries-path)))
 
 (defn- blocking-slot
   "The live blocking slot for `nav-token`, projected to the SET of its scoped
   keys. The slot itself is the byte-keyed `{<key-id> <scoped-key>}` carrier
   (rf2-btdl1); these assertions ask a membership question that the projection
   answers, and the byte-exactness of the carrier is pinned directly off
-  `route/blocking-path` by `r2-a-plan-holding-both-byte-distinct-twins-*`."
+  `rf.resources.route/blocking-path` by `r2-a-plan-holding-both-byte-distinct-twins-*`."
   [nav-token]
   (set (vals (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
-                     (route/blocking-path nav-token)))))
+                     (rf.resources.route/blocking-path nav-token)))))
 
 (defn- blocking-map
   "The byte-keyed blocking / plan-identity carrier `{<key-id> <scoped-key>}`
   over `ks` — the shape both routing slots hold (rf2-btdl1)."
   [& ks]
-  (into {} (map (juxt state/key-id identity)) ks))
+  (into {} (map (juxt rf.resources.state/key-id identity)) ks))
 
 (defn- article-spec [overrides]
   (merge {:scope         :rf.scope/global
@@ -141,9 +141,9 @@
   [body-fn]
   (let [seen (atom [])
         k    ::route-error-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (= :error (:op-type ev)) (swap! seen conj ev))))
-    (try (body-fn) (finally (trace-tooling/unregister-listener! k)))
+    (try (body-fn) (finally (rf.trace.tooling/unregister-listener! k)))
     @seen))
 
 (defn- errors-of [traces op]
@@ -157,9 +157,9 @@
   [op body-fn]
   (let [seen (atom [])
         k    ::route-op-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (= op (:operation ev)) (swap! seen conj ev))))
-    (try (body-fn) (finally (trace-tooling/unregister-listener! k)))
+    (try (body-fn) (finally (rf.trace.tooling/unregister-listener! k)))
     @seen))
 
 ;; ===========================================================================
@@ -188,7 +188,7 @@
                               :params   (fn [route] {:slug (get-in route [:params :slug])})}]} "/articles/:slug")
   (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "intro"}}])
   (let [nav-token  (:nav-token (slice))
-        scoped-key (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})
+        scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})
         e          (entry scoped-key)]
     (testing "route entry ensured the resource (a :loading entry exists)"
       (is (some? e) "the route :resources entry was ensured on entry")
@@ -210,7 +210,7 @@
                               :blocking? true}]} "/articles/:slug")
   (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "intro"}}])
   (let [nav-token  (:nav-token (slice))
-        scoped-key (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
+        scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
     (testing "a blocking resource keeps the route transition :loading"
       (is (= :loading (:transition (slice)))
           "transition stays :loading while the blocking resource is pending")
@@ -234,7 +234,7 @@
   (testing "a non-blocking resource fetches in the background; the route is :idle"
     (is (= :idle (:transition (slice)))
         "no blocking resource → transition is :idle immediately")
-    (let [scoped-key (state/scoped-resource-key :rf.scope/global :comments/list {:slug "intro"})]
+    (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :comments/list {:slug "intro"})]
       (is (= :loading (:status (entry scoped-key)))
           "the non-blocking resource is still ensured (background fetch)"))))
 
@@ -251,7 +251,7 @@
                               :params    (fn [route] {:slug (get-in route [:params :slug])})
                               :blocking? true}]} "/articles/:slug")
   (rf/reg-route :route/home {} "/")
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
     ;; first entry: blocking resource fetches, then settles :loaded (fresh)
     (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "intro"}}])
     (settle-success! scoped-key {:title "Intro"})
@@ -285,7 +285,7 @@
                               :params    (fn [route] {:slug (get-in route [:params :slug])})
                               :blocking? true}]} "/articles/:slug")
   (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "intro"}}])
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
     (settle-failure! scoped-key {:status 503 :message "upstream down"})
     (testing "a blocking first-load failure flips the route transition to :error"
       (is (= :error (:transition (slice))))
@@ -306,7 +306,7 @@
   (rf/reg-route :route/home {} "/")
   (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "intro"}}])
   (let [token-1    (:nav-token (slice))
-        scoped-key (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
+        scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
     (is (contains? (:active-owners (entry scoped-key)) [:route :route/article token-1]))
     (rf/dispatch-sync [:rf.route/navigate {:to :route/home}])
     (testing "leaving the route releases its nav-token owner from the entry"
@@ -322,7 +322,7 @@
 ;; hang waiting on a reply the aborted work will never send).
 
 (defn- work-record-for [scoped-key]
-  (work-ledger/get-record (:rf.db/runtime (rf/frame-state-value :rf/default)) (:current-work (entry scoped-key))))
+  (rf.resources.work-ledger/get-record (:rf.db/runtime (rf/frame-state-value :rf/default)) (:current-work (entry scoped-key))))
 
 (deftest route-resupersede-same-key-does-not-join-abort-requested-non-blocking
   (rf/reg-resource :article/by-slug (article-spec {}) article-spec-request)
@@ -331,7 +331,7 @@
                  :resources [{:resource :article/by-slug
                               :params   (fn [route] {:slug (get-in route [:params :slug])})}]} "/articles/:slug")
   (rf/reg-route :route/home {} "/")
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
     ;; enter route A: the resource is in flight under token-1's route owner
     (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "intro"}}])
     (let [token-1 (:nav-token (slice))
@@ -341,7 +341,7 @@
       ;; leave (route B = home): releases token-1's route owner → wid1 becomes
       ;; :abort-requested; the entry still points at wid1.
       (rf/dispatch-sync [:rf.route/navigate {:to :route/home}])
-      (is (= :abort-requested (:status (work-ledger/get-record (:rf.db/runtime (rf/frame-state-value :rf/default)) wid1)))
+      (is (= :abort-requested (:status (rf.resources.work-ledger/get-record (:rf.db/runtime (rf/frame-state-value :rf/default)) wid1)))
           "the superseded route's in-flight work is abort-requested")
       ;; re-enter the SAME route + same slug → re-ensure the same scoped key
       (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "intro"}}])
@@ -362,11 +362,11 @@
                               :params    (fn [route] {:slug (get-in route [:params :slug])})
                               :blocking? true}]} "/articles/:slug")
   (rf/reg-route :route/home {} "/")
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
     (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "intro"}}])
     (let [wid1 (:current-work (entry scoped-key))]
       (rf/dispatch-sync [:rf.route/navigate {:to :route/home}])
-      (is (= :abort-requested (:status (work-ledger/get-record (:rf.db/runtime (rf/frame-state-value :rf/default)) wid1))))
+      (is (= :abort-requested (:status (rf.resources.work-ledger/get-record (:rf.db/runtime (rf/frame-state-value :rf/default)) wid1))))
       ;; re-enter the blocking route on the SAME key
       (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "intro"}}])
       (let [token-2 (:nav-token (slice))]
@@ -465,11 +465,11 @@
                               :params         (fn [route] {:page (get-in route [:query :page])})
                               :keep-previous? true}]} "/list")
   (rf/dispatch-sync [:rf.route/navigate {:to :route/list :query {:page 1}}])
-  (let [k1 (state/scoped-resource-key :rf.scope/global :articles/list {:page 1})]
+  (let [k1 (rf.resources.state/scoped-resource-key :rf.scope/global :articles/list {:page 1})]
     (settle-success! k1 [{:id 1 :title "Old page"}]))
   (rf/dispatch-sync [:rf.route/navigate {:to :route/list :query {:page 2}}])
-  (let [k1   (state/scoped-resource-key :rf.scope/global :articles/list {:page 1})
-        k2   (state/scoped-resource-key :rf.scope/global :articles/list {:page 2})
+  (let [k1   (rf.resources.state/scoped-resource-key :rf.scope/global :articles/list {:page 1})
+        k2   (rf.resources.state/scoped-resource-key :rf.scope/global :articles/list {:page 2})
         view @(rf/subscribe [:rf/resource {:resource :articles/list
                                                  :scope   :rf.scope/global
                                                  :params  {:page 2}}])]
@@ -498,7 +498,7 @@
                               :params    (fn [route] {:slug (get-in route [:params :slug])})
                               :blocking? true}]} "/articles/:slug")
   (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "intro"}}])
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})
         nav-token  (:nav-token (slice))
         traces     (record-error-traces!
                      #(settle-failure! scoped-key {:status 503 :message "upstream down"}))
@@ -539,7 +539,7 @@
   (rf/reg-route :route/home {} "/")
   (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "intro"}}])
   (let [token-1    (:nav-token (slice))
-        scoped-key (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
+        scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
     (testing "the blocking slot is populated on entry (resource never settles)"
       (is (contains? (blocking-slot token-1) scoped-key)))
     ;; leave WITHOUT the blocking resource ever settling
@@ -572,7 +572,7 @@
         (is (empty? (blocking-slot token-2))
             "the live token has no blocking requirements of its own")
         (is (identical? (:rf.db/runtime (rf/frame-state-value :rf/default))
-                        (route/reconcile-readiness
+                        (rf.resources.route/reconcile-readiness
                           (:rf.db/runtime (rf/frame-state-value :rf/default))))
             "re-projecting is a structural no-op for the live token")))))
 
@@ -584,7 +584,7 @@
   ;; The ctx seam is REAL: a :scope resolver reads (:current-session-scope ctx)
   ;; and the resolved scope is used as the cache scope (not a global fallback).
   (rf/reg-resource :secret/doc (article-spec {:scope :rf.scope/from-caller}) article-spec-request)
-  (let [plan (route/route-resource-plan
+  (let [plan (rf.resources.route/route-resource-plan
                {:id :route/secret :params {:slug "x"}
                 :resources [{:resource :secret/doc
                              :params   (fn [route] {:slug (get-in route [:params :slug])})
@@ -605,17 +605,17 @@
   (rf/reg-resource :secret/doc (article-spec {:scope :rf.scope/from-caller}) article-spec-request)
   (testing "route-resource-plan throws on a nil ctx"
     (is (thrown? #?(:clj Throwable :cljs :default)
-                 (route/route-resource-plan
+                 (rf.resources.route/route-resource-plan
                    {:id :route/secret :resources []}
                    nil
                    {:nav-token 1}))))
-  ;; rf2-9g3qzi: the thrown planning-error routes through error/thrown-ex-info,
+  ;; rf2-9g3qzi: the thrown planning-error routes through rf.error/thrown-ex-info,
   ;; so its message LEADS with a human sentence and TRAILS with the
   ;; [:rf.error/resource-route-plan] greppability token, and the ex-data carries
   ;; the canonical :where / :recovery slots (the conformant shape its sibling
   ;; registry/registration-error already follows).
   (testing "the thrown planning-error carries the canonical thrown-error shape"
-    (let [thrown (try (route/route-resource-plan
+    (let [thrown (try (rf.resources.route/route-resource-plan
                         {:id :route/secret :resources []} nil {:nav-token 1})
                       nil
                       (catch #?(:clj clojure.lang.ExceptionInfo
@@ -624,9 +624,9 @@
           msg    (ex-message thrown)]
       (is (some? thrown))
       (is (= :rf.error/resource-route-plan (:rf.error/id data)))
-      (is (error/message-has-id-token? msg)
+      (is (rf.error/message-has-id-token? msg)
           "message carries the trailing [:rf.error/resource-route-plan] token (rule 4)")
-      (is (not (error/keyword-only-message? msg))
+      (is (not (rf.error/keyword-only-message? msg))
           "message is a human sentence, not a bare keyword (rule 1)")
       (is (= 'rf/route-resource-plan (:where data))
           ":where names the planning boundary helper")
@@ -640,7 +640,7 @@
   ;; mint an unreleasable owner — fail closed.
   (testing "route-resource-plan throws on a missing nav-token"
     (is (thrown? #?(:clj Throwable :cljs :default)
-                 (route/route-resource-plan
+                 (rf.resources.route/route-resource-plan
                    {:id :route/x :resources []}
                    {}
                    {:nav-token nil})))))
@@ -778,7 +778,7 @@
                  :route-meta {:resources [{:resource :shell/viewer :params (fn [_] {:slug "v"}) :blocking? true}]}}
                 {:route-id   :route/account.settings
                  :route-meta {:resources [{:resource :leaf/settings :params (fn [_] {:slug "s"}) :blocking? true}]}}]
-        plan (route/route-resource-plan
+        plan (rf.resources.route/route-resource-plan
                {:id :route/account.settings :params {} :query {}}
                {}
                {:nav-token 1 :branch branch})
@@ -800,18 +800,18 @@
                 {:route-id   :route/profile.favorites
                  :route-meta {:resources [(assoc banner :blocking? false)     ;; redundant copy
                                           {:resource :leaf/list :params (fn [_] {:slug "f"})}]}}]
-        plan (route/route-resource-plan
+        plan (rf.resources.route/route-resource-plan
                {:id :route/profile.favorites :params {} :query {}}
                {}
                {:nav-token 1 :branch branch})
         ensures (of-event (plan-dispatches plan) :rf.resource/ensure)
-        banner-key (state/scoped-resource-key* :rf.scope/global :shell/banner {:slug "u"})]
+        banner-key (rf.resources.state/scoped-resource-key* :rf.scope/global :shell/banner {:slug "u"})]
     (testing "the duplicated banner dedupes to one ensure at the parent position"
       (is (nil? (:plan-error plan)))
       (is (= [:shell/banner :leaf/list] (mapv #(:resource (second %)) ensures))
           "banner deduped + fixed earliest; leaf list follows"))
     (testing "blocking? is OR across contributors — the parent marked it blocking"
-      (is (contains? (:blocking plan) (state/key-id banner-key))))
+      (is (contains? (:blocking plan) (rf.resources.state/key-id banner-key))))
     (testing "the redundant child declaration surfaces as an advisory"
       (is (= 1 (count (:advisories plan))))
       (let [adv (first (:advisories plan))]
@@ -829,7 +829,7 @@
                  :route-meta {:resources [{:resource :cyc/shared :id :a :params (fn [_] {:slug "k"})}
                                           {:resource :cyc/mid    :id :b :params (fn [_] {:slug "m"}) :after #{:a}}
                                           {:resource :cyc/shared :id :c :params (fn [_] {:slug "k"}) :after #{:b}}]}}]
-        plan (route/route-resource-plan {:id :route/cyc :params {} :query {}} {}
+        plan (rf.resources.route/route-resource-plan {:id :route/cyc :params {} :query {}} {}
                                         {:nav-token 1 :branch branch})]
     (testing "the collapse-created cycle is a planning error"
       (is (some? (:plan-error plan)))
@@ -853,18 +853,18 @@
   (let [parent-meta {:resources [{:resource :sh/v :params (fn [_] {:slug "v"}) :blocking? true}]}
         branch1 [{:route-id :route/p   :route-meta parent-meta}
                  {:route-id :route/p.a :route-meta {:resources [{:resource :lf/a :params (fn [_] {:slug "a"})}]}}]
-        plan1 (route/route-resource-plan {:id :route/p.a :params {} :query {}} {}
+        plan1 (rf.resources.route/route-resource-plan {:id :route/p.a :params {} :query {}} {}
                                          {:nav-token 1 :branch branch1})
         ids1  (:identities plan1)
-        shared-key (state/scoped-resource-key* :rf.scope/global :sh/v {:slug "v"})
+        shared-key (rf.resources.state/scoped-resource-key* :rf.scope/global :sh/v {:slug "v"})
         ;; plan1's shared identity has since LOADED — the reusable kept case.
         rdb   {:rf.runtime/resources
-               {:entries {(state/key-id shared-key)
+               {:entries {(rf.resources.state/key-id shared-key)
                           {:resource/id :sh/v :resource/key shared-key
                            :status :loaded :data {:n 1} :attempt 1}}}}
         branch2 [{:route-id :route/p   :route-meta parent-meta}
                  {:route-id :route/p.b :route-meta {:resources [{:resource :lf/b :params (fn [_] {:slug "b"})}]}}]
-        plan2 (route/route-resource-plan {:id :route/p.b :params {} :query {}} {}
+        plan2 (rf.resources.route/route-resource-plan {:id :route/p.b :params {} :query {}} {}
                                          {:nav-token 2 :prev-id :route/p.a :prev-nav-token 1
                                           :prev-identities ids1 :branch branch2
                                           :runtime-db rdb})
@@ -892,31 +892,31 @@
   (rf/reg-resource :lf/a (article-spec {}) article-spec-request)
   (rf/reg-resource :lf/b (article-spec {}) article-spec-request)
   (let [parent-meta {:resources [{:resource :sh/v :params (fn [_] {:slug "v"}) :blocking? true}]}
-        shared-key  (state/scoped-resource-key* :rf.scope/global :sh/v {:slug "v"})
-        a-key       (state/scoped-resource-key* :rf.scope/global :lf/a {:slug "a"})
-        b-key       (state/scoped-resource-key* :rf.scope/global :lf/b {:slug "b"})
+        shared-key  (rf.resources.state/scoped-resource-key* :rf.scope/global :sh/v {:slug "v"})
+        a-key       (rf.resources.state/scoped-resource-key* :rf.scope/global :lf/a {:slug "a"})
+        b-key       (rf.resources.state/scoped-resource-key* :rf.scope/global :lf/b {:slug "b"})
         branch1 [{:route-id :route/p   :route-meta parent-meta}
                  {:route-id :route/p.a :route-meta {:resources [{:resource :lf/a :params (fn [_] {:slug "a"})}]}}]
         branch2 [{:route-id :route/p   :route-meta parent-meta}
                  {:route-id :route/p.b :route-meta {:resources [{:resource :lf/b :params (fn [_] {:slug "b"})}]}}]
-        plan1 (route/route-resource-plan {:id :route/p.a :params {} :query {}} {}
+        plan1 (rf.resources.route/route-resource-plan {:id :route/p.a :params {} :query {}} {}
                                          {:nav-token 1 :branch branch1})
         ;; plan1's shared identity has since LOADED — the reusable kept case.
         rdb   {:rf.runtime/resources
-               {:entries {(state/key-id shared-key)
+               {:entries {(rf.resources.state/key-id shared-key)
                           {:resource/id :sh/v :resource/key shared-key
                            :status :loaded :data {:n 1} :attempt 1}}}}
         traces (record-op-traces!
                  :rf.resource/route-plan
-                 (fn [] (route/route-resource-plan
+                 (fn [] (rf.resources.route/route-resource-plan
                           {:id :route/p.b :params {} :query {}} {}
                           {:nav-token 2 :prev-id :route/p.a :prev-nav-token 1
                            :prev-identities (:identities plan1) :branch branch2
                            :runtime-db rdb})))]
-    ;; rf2-o5dbf — `trace/emit!` sits behind `interop/debug-enabled?`, so the
+    ;; rf2-o5dbf — `trace/emit!` sits behind `rf.interop/debug-enabled?`, so the
     ;; row exists only in the dev posture. Under `-Dre-frame.debug=false` there
     ;; is no row to read and the plan-diff assertions are vacuous by design.
-    (when interop/debug-enabled?
+    (when rf.interop/debug-enabled?
       (let [tags (:tags (first traces))]
         (is (some? tags) "the activation emits one :rf.resource/route-plan row")
         (testing "the counts are unchanged — the compact headline still reads
@@ -965,7 +965,7 @@
   (rf/reg-resource :rm/b (article-spec {}) article-spec-request)
   (rf/reg-resource :rm/c (article-spec {}) article-spec-request)
   (rf/reg-resource :rm/n (article-spec {}) article-spec-request)
-  (let [key-of      (fn [id slug] (state/scoped-resource-key* :rf.scope/global id {:slug slug}))
+  (let [key-of      (fn [id slug] (rf.resources.state/scoped-resource-key* :rf.scope/global id {:slug slug}))
         v-key       (key-of :rm/v "v")
         a-key       (key-of :rm/a "a")
         b-key       (key-of :rm/b "b")
@@ -977,13 +977,13 @@
         ;; the shared ancestor has LOADED, so it is genuinely adoptable (the
         ;; kept case) — leaving a / b / c as the three this plan drops.
         rdb         {:rf.runtime/resources
-                     {:entries {(state/key-id v-key)
+                     {:entries {(rf.resources.state/key-id v-key)
                                 {:resource/id :rm/v :resource/key v-key
                                  :status :loaded :data {:n 1} :attempt 1}}}}
         tags-for    (fn [prev-identities]
                       (:tags (first (record-op-traces!
                                       :rf.resource/route-plan
-                                      (fn [] (route/route-resource-plan
+                                      (fn [] (rf.resources.route/route-resource-plan
                                                {:id :route/q.n :params {} :query {}} {}
                                                {:nav-token       2
                                                 :prev-id         :route/q.a
@@ -998,10 +998,10 @@
         backward    (tags-for [c-key b-key a-key v-key])
         as-set      (tags-for #{v-key a-key b-key c-key})
         duplicated  (tags-for [a-key a-key v-key b-key b-key c-key c-key])]
-    ;; rf2-o5dbf — `trace/emit!` sits behind `interop/debug-enabled?`, so the
+    ;; rf2-o5dbf — `trace/emit!` sits behind `rf.interop/debug-enabled?`, so the
     ;; row exists only in the dev posture. Under `-Dre-frame.debug=false` there
     ;; is no row to read and these assertions are vacuous by design.
-    (when interop/debug-enabled?
+    (when rf.interop/debug-enabled?
       (testing "three prior identities are dropped, and the row names all three
                 however the caller supplied them"
         (doseq [[label tags] [["a vector"                        forward]
@@ -1037,9 +1037,9 @@
   ;; rf2-dlkou (merged-PR audit of #7228) — the identity partition is keyed on
   ;; the CEDN-1 BYTE key-id, not on Clojure `=`.
   ;;
-  ;; Resource identity is `state/key-id`, and it is collection-KIND sensitive
+  ;; Resource identity is `rf.resources.state/key-id`, and it is collection-KIND sensitive
   ;; (rf2-wgutc2): `{:slug "s" :tags ["a"]}` and `{:slug "s" :tags '("a")}` live
-  ;; at two `state/entry-path`s, and yet the two scoped keys are `=` to Clojure
+  ;; at two `rf.resources.state/entry-path`s, and yet the two scoped keys are `=` to Clojure
   ;; AND hash alike. Every `=`-keyed carrier therefore collapses the pair, and
   ;; the row's canonical `key-id` ordering runs AFTER the loss rather than
   ;; before it — so sorting could not save it.
@@ -1054,14 +1054,14 @@
   ;;
   ;; The pair is `=` under `clojure.core/=`, so an assertion written with `=`
   ;; would pass on the WRONG key. Every claim below is therefore made on
-  ;; `state/key-id` of the emitted value.
+  ;; `rf.resources.state/key-id` of the emitted value.
   (rf/reg-resource :bx/v (article-spec {}) article-spec-request)
   (rf/reg-resource :bx/n (article-spec {}) article-spec-request)
   (rf/reg-resource :bx/p (article-spec {}) article-spec-request)
-  (let [vec-key     (state/scoped-resource-key* :rf.scope/global :bx/p {:slug "p" :tags ["a"]})
-        list-key    (state/scoped-resource-key* :rf.scope/global :bx/p {:slug "p" :tags '("a")})
-        v-key       (state/scoped-resource-key* :rf.scope/global :bx/v {:slug "v"})
-        n-key       (state/scoped-resource-key* :rf.scope/global :bx/n {:slug "n"})
+  (let [vec-key     (rf.resources.state/scoped-resource-key* :rf.scope/global :bx/p {:slug "p" :tags ["a"]})
+        list-key    (rf.resources.state/scoped-resource-key* :rf.scope/global :bx/p {:slug "p" :tags '("a")})
+        v-key       (rf.resources.state/scoped-resource-key* :rf.scope/global :bx/v {:slug "v"})
+        n-key       (rf.resources.state/scoped-resource-key* :rf.scope/global :bx/n {:slug "n"})
         parent-meta {:resources [{:resource :bx/v :params (fn [_] {:slug "v"}) :blocking? true}]}
         leaf-with-p {:resources [{:resource :bx/n :params (fn [_] {:slug "n"})}
                                  {:resource :bx/p :params (fn [_] {:slug "p" :tags ["a"]})}]}
@@ -1072,7 +1072,7 @@
                      {:route-id :route/b.n :route-meta leaf-with-p}]
         branch-p    [{:route-id :route/b :route-meta parent-meta}
                      {:route-id :route/b.n :route-meta leaf-sans-p}]
-        loaded      (fn [k rid] [(state/key-id k)
+        loaded      (fn [k rid] [(rf.resources.state/key-id k)
                                  {:resource/id rid :resource/key k
                                   :status :loaded :data {:n 1} :attempt 1}])
         ;; the shared ancestor is LOADED, so it is genuinely adoptable.
@@ -1084,7 +1084,7 @@
         tags-for    (fn [branch runtime-db prev-identities]
                       (:tags (first (record-op-traces!
                                       :rf.resource/route-plan
-                                      (fn [] (route/route-resource-plan
+                                      (fn [] (rf.resources.route/route-resource-plan
                                                {:id :route/b.n :params {} :query {}} {}
                                                {:nav-token       2
                                                 :prev-id         :route/b.a
@@ -1092,7 +1092,7 @@
                                                 :prev-identities prev-identities
                                                 :branch          branch
                                                 :runtime-db      runtime-db}))))))
-        ids         (fn [ks] (mapv state/key-id ks))]
+        ids         (fn [ks] (mapv rf.resources.state/key-id ks))]
     (testing "premise: the two params shapes are ONE value to Clojure and TWO
               identities to the cache"
       (is (= vec-key list-key)
@@ -1101,12 +1101,12 @@
       (is (= 1 (count (set [vec-key list-key])))
           "…and neither can a set: the collapse is in the carrier, not in a
            comparison this code could have written differently")
-      (is (not= (state/key-id vec-key) (state/key-id list-key))
+      (is (not= (rf.resources.state/key-id vec-key) (rf.resources.state/key-id list-key))
           "premise: while the CEDN-1 byte identities differ (rf2-wgutc2)")
-      (is (not= (state/entry-path vec-key) (state/entry-path list-key))
+      (is (not= (rf.resources.state/entry-path vec-key) (rf.resources.state/entry-path list-key))
           "premise: so the cache holds two entries, and dropping one IS a
            removal"))
-    (when interop/debug-enabled?
+    (when rf.interop/debug-enabled?
       (testing "the prior plan's LIST-bearing identity is reported REMOVED when
                 the next plan holds only its VECTOR-bearing twin"
         (let [tags (tags-for branch+p rdb [v-key list-key])]
@@ -1160,7 +1160,7 @@
   ;;
   ;; Two sibling routes declare the SAME resource under the SAME scope, with
   ;; params that differ only in the KIND of one collection: `{:tags ["a"]}` vs
-  ;; `{:tags '("a")}`. Those are two cache entries at two `state/entry-path`s
+  ;; `{:tags '("a")}`. Those are two cache entries at two `rf.resources.state/entry-path`s
   ;; and one value to Clojure `=`. Navigating between them therefore removes one
   ;; identity and ensures the other — and the row said `:removed 0`.
   ;;
@@ -1174,8 +1174,8 @@
   (rf/reg-route :route/tw-list
                 {:resources [{:resource :tw/feed :params (fn [_] {:slug "f" :tags '("a")})}]}
                 "/tw/list")
-  (let [vec-key  (state/scoped-resource-key* :rf.scope/global :tw/feed {:slug "f" :tags ["a"]})
-        list-key (state/scoped-resource-key* :rf.scope/global :tw/feed {:slug "f" :tags '("a")})]
+  (let [vec-key  (rf.resources.state/scoped-resource-key* :rf.scope/global :tw/feed {:slug "f" :tags ["a"]})
+        list-key (rf.resources.state/scoped-resource-key* :rf.scope/global :tw/feed {:slug "f" :tags '("a")})]
     (rf/dispatch-sync [:rf.route/navigate {:to :route/tw-list}])
     (settle-success! list-key [{:id 1}])
     (testing "premise: the first navigation created the LIST-bearing entry, and
@@ -1193,16 +1193,16 @@
             "a second entry now exists at the VECTOR-bearing byte path — the
              navigation really did dispatch an ensure rather than adopt across
              the pair"))
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (testing "…and the row reports the removal it performed"
           (is (= 1 (:removed tags))
               "the LIST-bearing identity left the plan — the row read
                `:removed 0` before this repair, because the prior identity
                tested as still-present against an `=`-keyed set")
-          (is (= [(state/key-id list-key)] (mapv state/key-id (:removed-identities tags)))
+          (is (= [(rf.resources.state/key-id list-key)] (mapv rf.resources.state/key-id (:removed-identities tags)))
               "…and it is named, asserted on the byte identity because `=`
                would have accepted the vector-bearing key here")
-          (is (= [(state/key-id vec-key)] (mapv state/key-id (:ensured-identities tags)))
+          (is (= [(rf.resources.state/key-id vec-key)] (mapv rf.resources.state/key-id (:ensured-identities tags)))
               "while the twin is ENSURED")
           (is (empty? (:kept-identities tags))
               "and nothing was kept — the two are not one identity"))))))
@@ -1220,7 +1220,7 @@
   ;; :resource-plan]` / `:resource-blocking` slots were SETS, which cannot hold
   ;; both members however carefully the planner counted.
   ;;
-  ;; Every claim below is asserted on `state/key-id`, never on `=`: the two
+  ;; Every claim below is asserted on `rf.resources.state/key-id`, never on `=`: the two
   ;; scoped keys are `=` and hash alike, so an `=`-written assertion would pass
   ;; on the WRONG key and prove nothing.
   (rf/reg-resource :tw2/feed (article-spec {}) article-spec-request)
@@ -1234,15 +1234,15 @@
                               :params    (fn [_] {:slug "f" :tags (list "a")})
                               :blocking? true}]}
                 "/tw2/both")
-  (let [vec-key  (state/scoped-resource-key* :rf.scope/global :tw2/feed {:slug "f" :tags ["a"]})
-        list-key (state/scoped-resource-key* :rf.scope/global :tw2/feed {:slug "f" :tags (list "a")})
-        ids      (fn [ks] (vec (sort (mapv state/key-id ks))))
+  (let [vec-key  (rf.resources.state/scoped-resource-key* :rf.scope/global :tw2/feed {:slug "f" :tags ["a"]})
+        list-key (rf.resources.state/scoped-resource-key* :rf.scope/global :tw2/feed {:slug "f" :tags (list "a")})
+        ids      (fn [ks] (vec (sort (mapv rf.resources.state/key-id ks))))
         rdb      (fn [] (:rf.db/runtime (rf/frame-state-value :rf/default)))]
     (testing "premise: ONE value to Clojure, TWO identities to the cache"
       (is (= vec-key list-key))
       (is (= 1 (count (set [vec-key list-key]))))
-      (is (not= (state/key-id vec-key) (state/key-id list-key)))
-      (is (not= (state/entry-path vec-key) (state/entry-path list-key))))
+      (is (not= (rf.resources.state/key-id vec-key) (rf.resources.state/key-id list-key)))
+      (is (not= (rf.resources.state/entry-path vec-key) (rf.resources.state/entry-path list-key))))
     (let [tags      (:tags (first (record-op-traces!
                                     :rf.resource/route-plan
                                     (fn [] (rf/dispatch-sync
@@ -1250,15 +1250,15 @@
           token     (:nav-token (slice))
           ;; the blocking carrier AS COMMITTED — the SSR drain reads exactly
           ;; this and pumps until every member settles.
-          blocking0 (get-in (rdb) (route/blocking-path token))]
+          blocking0 (get-in (rdb) (rf.resources.route/blocking-path token))]
       (testing "TWO dedup-reqs, TWO ensures — the second identity is really fetched"
         (is (some? (entry vec-key)) "the vector-bearing identity was ensured")
         (is (some? (entry list-key)) "…and so was its list-bearing twin")
-        (is (= 2 (count (select-keys (entries) [(state/key-id vec-key)
-                                                (state/key-id list-key)])))
+        (is (= 2 (count (select-keys (entries) [(rf.resources.state/key-id vec-key)
+                                                (rf.resources.state/key-id list-key)])))
             "two cache entries at two byte paths — a collapsed plan leaves one"))
       (testing "the handoff slot carries BOTH identities, byte-keyed"
-        (is (= (blocking-map vec-key list-key) (get-in (rdb) (route/plan-path token)))
+        (is (= (blocking-map vec-key list-key) (get-in (rdb) (rf.resources.route/plan-path token)))
             "[:rf.runtime/routing :resource-plan <token>] is {key-id scoped-key}
              and holds the pair — a set held exactly one of them"))
       (testing "…and so does the blocking slot: two independent wait points"
@@ -1266,26 +1266,26 @@
         (is (= :loading (:transition (slice)))
             "both blocking first loads are outstanding"))
       (testing "the SSR drain sees both, and only both, as unsettled"
-        (is (false? (res-ssr/blocking-settled? (entries) blocking0)))
+        (is (false? (rf.resources.ssr/blocking-settled? (entries) blocking0)))
         (is (= (ids [vec-key list-key])
-               (ids (vals (res-ssr/unsettled-blocking-keys (entries) blocking0))))))
+               (ids (vals (rf.resources.ssr/unsettled-blocking-keys (entries) blocking0))))))
       (testing "each twin settles INDEPENDENTLY — one settle prunes one wait point"
         (settle-success! vec-key [{:id 1}])
-        (is (= (blocking-map list-key) (get-in (rdb) (route/blocking-path token)))
+        (is (= (blocking-map list-key) (get-in (rdb) (rf.resources.route/blocking-path token)))
             "only the LIST-bearing requirement is still outstanding; an
              `=`-keyed prune could not have told the two apart")
         (is (= :loading (:transition (slice)))
             "the route is still :loading — the twin has not settled")
-        (is (false? (res-ssr/blocking-settled? (entries) blocking0))
+        (is (false? (rf.resources.ssr/blocking-settled? (entries) blocking0))
             "the SSR drain agrees: one member of the pair is still in flight")
         (is (= (ids [list-key])
-               (ids (vals (res-ssr/unsettled-blocking-keys (entries) blocking0))))))
+               (ids (vals (rf.resources.ssr/unsettled-blocking-keys (entries) blocking0))))))
       (testing "…and when the twin settles too the route lands and the drain ends"
         (settle-success! list-key [{:id 2}])
-        (is (empty? (get-in (rdb) (route/blocking-path token))))
+        (is (empty? (get-in (rdb) (rf.resources.route/blocking-path token))))
         (is (= :idle (:transition (slice))))
-        (is (true? (res-ssr/blocking-settled? (entries) blocking0))))
-      (when interop/debug-enabled?
+        (is (true? (rf.resources.ssr/blocking-settled? (entries) blocking0))))
+      (when rf.interop/debug-enabled?
         (testing "the plan row reports two ensures over two identities"
           (is (= 2 (:ensured tags)) "two real ensures, not one deduped ensure")
           (is (= 0 (:kept tags)))
@@ -1311,9 +1311,9 @@
                 {:resources [{:resource :tw3/feed
                               :params (fn [_] {:slug "g" :tags ["a"]})}]}
                 "/tw3/vec")
-  (let [vec-key  (state/scoped-resource-key* :rf.scope/global :tw3/feed {:slug "g" :tags ["a"]})
-        list-key (state/scoped-resource-key* :rf.scope/global :tw3/feed {:slug "g" :tags (list "a")})
-        ids      (fn [ks] (mapv state/key-id ks))
+  (let [vec-key  (rf.resources.state/scoped-resource-key* :rf.scope/global :tw3/feed {:slug "g" :tags ["a"]})
+        list-key (rf.resources.state/scoped-resource-key* :rf.scope/global :tw3/feed {:slug "g" :tags (list "a")})
+        ids      (fn [ks] (mapv rf.resources.state/key-id ks))
         rdb      (fn [] (:rf.db/runtime (rf/frame-state-value :rf/default)))]
     (rf/dispatch-sync [:rf.route/navigate {:to :route/tw3-both}])
     ;; both twins LOAD, so the retained one is genuinely adoptable at commit.
@@ -1321,15 +1321,15 @@
     (settle-success! list-key [{:id 2}])
     (testing "premise: the first plan owns BOTH byte identities"
       (is (= (blocking-map vec-key list-key)
-             (get-in (rdb) (route/plan-path (:nav-token (slice)))))))
+             (get-in (rdb) (rf.resources.route/plan-path (:nav-token (slice)))))))
     (let [tags  (:tags (first (record-op-traces!
                                 :rf.resource/route-plan
                                 (fn [] (rf/dispatch-sync
                                          [:rf.route/navigate {:to :route/tw3-vec}])))))
           token (:nav-token (slice))]
       (testing "the NEXT handoff carries exactly the surviving identity"
-        (is (= (blocking-map vec-key) (get-in (rdb) (route/plan-path token)))))
-      (when interop/debug-enabled?
+        (is (= (blocking-map vec-key) (get-in (rdb) (rf.resources.route/plan-path token)))))
+      (when rf.interop/debug-enabled?
         (testing "one KEPT, one REMOVED, nothing ensured — and the row names which"
           (is (= 1 (:kept tags)) "the vector-bearing twin was adopted, not re-fetched")
           (is (= 0 (:ensured tags)))
@@ -1354,9 +1354,9 @@
   (rf/reg-resource :po/mid (article-spec {}) article-spec-request)
   (rf/reg-resource :po/zulu (article-spec {}) article-spec-request)
   (rf/reg-resource :po/alpha (article-spec {}) article-spec-request)
-  (let [mid-key   (state/scoped-resource-key* :rf.scope/global :po/mid {:slug "m"})
-        zulu-key  (state/scoped-resource-key* :rf.scope/global :po/zulu {:slug "z"})
-        alpha-key (state/scoped-resource-key* :rf.scope/global :po/alpha {:slug "a"})
+  (let [mid-key   (rf.resources.state/scoped-resource-key* :rf.scope/global :po/mid {:slug "m"})
+        zulu-key  (rf.resources.state/scoped-resource-key* :rf.scope/global :po/zulu {:slug "z"})
+        alpha-key (rf.resources.state/scoped-resource-key* :rf.scope/global :po/alpha {:slug "a"})
         branch    [{:route-id :route/p
                     :route-meta {:resources [{:resource :po/mid :params (fn [_] {:slug "m"})}]}}
                    {:route-id :route/p.leaf
@@ -1364,10 +1364,10 @@
                                              {:resource :po/alpha :params (fn [_] {:slug "a"})}]}}]
         tags      (:tags (first (record-op-traces!
                                   :rf.resource/route-plan
-                                  (fn [] (route/route-resource-plan
+                                  (fn [] (rf.resources.route/route-resource-plan
                                            {:id :route/p.leaf :params {} :query {}} {}
                                            {:nav-token 2 :branch branch :runtime-db {}})))))]
-    (when interop/debug-enabled?
+    (when rf.interop/debug-enabled?
       (testing "the vectors carry PLAN order, which is neither declaration-name
                 order nor the canonical byte order the removal vector uses"
         (is (= [mid-key zulu-key alpha-key] (:identities tags))
@@ -1376,7 +1376,7 @@
         (is (= (:identities tags) (:ensured-identities tags))
             "nothing is adoptable here, so the ensured vector is the whole plan
              in the same order")
-        (is (not= (sort-by state/key-id (:identities tags)) (:identities tags))
+        (is (not= (sort-by rf.resources.state/key-id (:identities tags)) (:identities tags))
             "and plan order is DISTINGUISHABLE from key-id order on this
              branch — otherwise the assertion above could not tell them apart")
         (is (not= (vec (sort-by (comp name second) (:identities tags))) (:identities tags))
@@ -1387,7 +1387,7 @@
   ;; A :parent naming an unregistered route aborts the plan (a committed failed
   ;; activation): empty next ownership, no partial ensure/adopt, prior owner
   ;; released.
-  (let [plan (route/route-resource-plan
+  (let [plan (rf.resources.route/route-resource-plan
                {:id :route/leaf :params {} :query {}} {}
                {:nav-token 2 :prev-id :route/prev :prev-nav-token 1
                 :prev-identities #{[:rf.scope/global :old/res {}]}
@@ -1416,8 +1416,8 @@
                  :resources [{:resource :acct/settings :params (fn [_] {:slug "s"}) :blocking? true}]}
                 "/account/settings")
   (rf/dispatch-sync [:rf.route/navigate {:to :route/account.settings}])
-  (let [viewer-key   (state/scoped-resource-key* :rf.scope/global :acct/viewer {:slug "v"})
-        settings-key (state/scoped-resource-key* :rf.scope/global :acct/settings {:slug "s"})]
+  (let [viewer-key   (rf.resources.state/scoped-resource-key* :rf.scope/global :acct/viewer {:slug "v"})
+        settings-key (rf.resources.state/scoped-resource-key* :rf.scope/global :acct/settings {:slug "s"})]
     (testing "activating the child composes the ancestor resource too"
       (is (some? (entry viewer-key)) "the parent shell resource is ensured on child activation")
       (is (some? (entry settings-key)) "the leaf resource is ensured"))))
@@ -1441,8 +1441,8 @@
                 {:parent    :route/prof
                  :resources [{:resource :prof/tab-two :params (fn [_] {:slug "two"})}]}
                 "/prof/two")
-  (let [banner-key (state/scoped-resource-key* :rf.scope/global :prof/banner {:slug "b"})
-        tab1-key   (state/scoped-resource-key* :rf.scope/global :prof/tab-one {:slug "one"})]
+  (let [banner-key (rf.resources.state/scoped-resource-key* :rf.scope/global :prof/banner {:slug "b"})
+        tab1-key   (rf.resources.state/scoped-resource-key* :rf.scope/global :prof/tab-one {:slug "one"})]
     (rf/dispatch-sync [:rf.route/navigate {:to :route/prof.one}])
     (settle-success! banner-key {:name "Ada"})
     (settle-success! tab1-key [{:id 1}])
@@ -1450,7 +1450,7 @@
       (rf/dispatch-sync [:rf.route/navigate {:to :route/prof.two}])
       (testing "the kept banner is not refetched by the sibling navigation"
         (is (= gen-before (:generation (entry banner-key))) "generation unchanged — no revalidation")
-        (is (state/has-data? (entry banner-key)) "banner keeps its loaded data"))
+        (is (rf.resources.state/has-data? (entry banner-key)) "banner keeps its loaded data"))
       (testing "the removed tab route owner is released"
         (let [t1 (entry tab1-key)]
           (is (or (nil? t1)
@@ -1474,32 +1474,32 @@
 
 (deftest requirement-state-reads-spec-016-facts-not-a-settle-signal
   (testing "an absent entry is pending — its ensure has not been applied yet"
-    (is (= :pending (route/requirement-state nil))))
+    (is (= :pending (rf.resources.route/requirement-state nil))))
   (testing "own usable data is :ready"
-    (is (= :ready (route/requirement-state {:status :loaded :data {:a 1}}))))
+    (is (= :ready (rf.resources.route/requirement-state {:status :loaded :data {:a 1}}))))
   (testing "a BACKGROUND-refresh failure keeps its data and stays :ready"
     ;; `entry-failed` returns a :fetching-with-data entry to :loaded and records
     ;; :refresh-error — it must NOT read as a failed first load, so it never
     ;; makes the route :error.
-    (is (= :ready (route/requirement-state
+    (is (= :ready (rf.resources.route/requirement-state
                     {:status        :loaded :data {:a 1}
                      :refresh-error {:kind :rf.http/server :status 503}}))))
   (testing "a FIRST-load failure (no usable data, :error) is :failed"
-    (is (= :failed (route/requirement-state
+    (is (= :failed (rf.resources.route/requirement-state
                      {:status :error :data nil :attempt 1
                       :error  {:kind :rf.http/server :status 503}}))))
   (testing "work in flight is :pending"
-    (is (= :pending (route/requirement-state {:status :loading :data nil :attempt 1})))
-    (is (= :pending (route/requirement-state {:status :fetching :data nil :attempt 1}))))
+    (is (= :pending (rf.resources.route/requirement-state {:status :loading :data nil :attempt 1})))
+    (is (= :pending (rf.resources.route/requirement-state {:status :fetching :data nil :attempt 1}))))
   (testing "an enqueued but never-attempted entry is :pending (its load is coming)"
-    (is (= :pending (route/requirement-state {:status :idle :data nil :attempt 0}))))
+    (is (= :pending (rf.resources.route/requirement-state {:status :idle :data nil :attempt 0}))))
   (testing "settled with no data and nothing left to settle it is :inert"
     ;; an ABORTED first load — it neither completes nor fails the route.
-    (is (= :inert (route/requirement-state {:status :idle :data nil :attempt 1}))))
+    (is (= :inert (rf.resources.route/requirement-state {:status :idle :data nil :attempt 1}))))
   (testing "previous-data can never complete a newly-keyed first load"
     ;; `:previous-key` is a projection POINTER; the new key's own `:data` is
     ;; still nil, so the requirement is a pending FIRST load.
-    (is (= :pending (route/requirement-state
+    (is (= :pending (rf.resources.route/requirement-state
                       {:status       :loading :data nil :attempt 1
                        :previous-key [:rf.scope/global :article/by-slug {:slug "a"}]})))))
 
@@ -1515,29 +1515,29 @@
                                               :transition transition
                                               :error      nil}
                           :resource-blocking {nav-token (apply blocking-map (keys entries-by-key))}}
-   :rf.runtime/resources {:entries (into {} (map (fn [[k e]] [(state/key-id k) e]))
+   :rf.runtime/resources {:entries (into {} (map (fn [[k e]] [(rf.resources.state/key-id k) e]))
                                          entries-by-key)}})
 
-(def ^:private req-a (state/scoped-resource-key* :rf.scope/global :article/by-slug {:slug "a"}))
-(def ^:private req-b (state/scoped-resource-key* :rf.scope/global :article/by-slug {:slug "b"}))
+(def ^:private req-a (rf.resources.state/scoped-resource-key* :rf.scope/global :article/by-slug {:slug "a"}))
+(def ^:private req-b (rf.resources.state/scoped-resource-key* :rf.scope/global :article/by-slug {:slug "b"}))
 
 (deftest reconcile-readiness-projects-the-spec-012-table
   (testing "all requirements ready → :idle, and the slot is pruned empty"
-    (let [rdb (route/reconcile-readiness
+    (let [rdb (rf.resources.route/reconcile-readiness
                 (runtime-db-with "nav-1" :loading {req-a {:status :loaded :data {:x 1}}}))]
       (is (= :idle (get-in rdb [:rf.runtime/routing :current :transition])))
       (is (nil? (get-in rdb [:rf.runtime/routing :current :error])))
-      (is (empty? (get-in rdb (route/blocking-path "nav-1")))
+      (is (empty? (get-in rdb (rf.resources.route/blocking-path "nav-1")))
           "a resolved requirement is pruned, so a later invalidation cannot re-block")))
   (testing "one still pending → :loading"
-    (let [rdb (route/reconcile-readiness
+    (let [rdb (rf.resources.route/reconcile-readiness
                 (runtime-db-with "nav-1" :idle {req-a {:status :loaded :data {:x 1}}
                                                 req-b {:status :loading :data nil :attempt 1}}))]
       (is (= :loading (get-in rdb [:rf.runtime/routing :current :transition])))
-      (is (= (blocking-map req-b) (get-in rdb (route/blocking-path "nav-1")))
+      (is (= (blocking-map req-b) (get-in rdb (rf.resources.route/blocking-path "nav-1")))
           "only the outstanding requirement remains")))
   (testing "a failed blocking first load → :error carrying the structured error"
-    (let [rdb (route/reconcile-readiness
+    (let [rdb (rf.resources.route/reconcile-readiness
                 (runtime-db-with "nav-1" :loading
                                  {req-a {:resource/id :article/by-slug
                                          :status      :error :data nil :attempt 1
@@ -1546,10 +1546,10 @@
       (is (= :error (get-in rdb [:rf.runtime/routing :current :transition])))
       (is (= :rf.error/resource-route-blocking (:rf.error/id err)))
       (is (= :article/by-slug (:resource-id err)))
-      (is (= (blocking-map req-a) (get-in rdb (route/blocking-path "nav-1")))
+      (is (= (blocking-map req-a) (get-in rdb (rf.resources.route/blocking-path "nav-1")))
           "the failed requirement is NOT pruned — a later successful load re-projects :idle")))
   (testing "an ABORTED first load un-blocks rather than erroring the route"
-    (let [rdb (route/reconcile-readiness
+    (let [rdb (rf.resources.route/reconcile-readiness
                 (runtime-db-with "nav-1" :loading {req-a {:status :idle :data nil :attempt 1}}))]
       (is (= :idle (get-in rdb [:rf.runtime/routing :current :transition]))
           "settled-but-empty with nothing left to settle it neither completes nor fails")
@@ -1561,7 +1561,7 @@
                {:current {:nav-token  "nav-1"
                           :transition :error
                           :error      {:rf.error/id :rf.error/resource-route-plan}}}}]
-      (is (identical? rdb (route/reconcile-readiness rdb))))))
+      (is (identical? rdb (rf.resources.route/reconcile-readiness rdb))))))
 
 ;; ---- the error trace is EDGE-triggered (rf2-kqxe6.17) ----------------------
 
@@ -1585,21 +1585,21 @@
   ;; transition to report. The trace is gated on the transition EDGE, not on
   ;; value-inequality with the slice.
   (testing "a second failure while ALREADY :error re-picks silently — one trace"
-    (let [[early late] (sort-by state/key-id [req-a req-b])
+    (let [[early late] (sort-by rf.resources.state/key-id [req-a req-b])
           final  (volatile! nil)
           traces (record-error-traces!
                    (fn []
                      ;; settle 1 — the canonically LATER requirement fails first,
                      ;; taking the route from :loading INTO :error.
-                     (let [rdb1 (route/reconcile-readiness
+                     (let [rdb1 (rf.resources.route/reconcile-readiness
                                   (runtime-db-with "nav-1" :loading
                                                    {early pending-req
                                                     late  (failed-req 503)}))]
                        ;; settle 2 — the canonically EARLIER one fails too. It
                        ;; becomes the deterministic first failure.
                        (vreset! final
-                                (route/reconcile-readiness
-                                  (assoc-in rdb1 (state/entry-path early)
+                                (rf.resources.route/reconcile-readiness
+                                  (assoc-in rdb1 (rf.resources.state/entry-path early)
                                             (failed-req 500)))))))
           rdb2   @final]
       (is (= :error (get-in rdb2 [:rf.runtime/routing :current :transition])))
@@ -1607,7 +1607,7 @@
           (str "the slice reports the CURRENT deterministic first failure — "
                ":error is a pure function of the live outstanding set, NOT a "
                "latched first observation that could go stale on refetch"))
-      (is (= (blocking-map early late) (get-in rdb2 (route/blocking-path "nav-1")))
+      (is (= (blocking-map early late) (get-in rdb2 (rf.resources.route/blocking-path "nav-1")))
           "neither failed requirement is pruned")
       (is (= 1 (count (blocking-error-traces traces)))
           "ONE trace per transition INTO :error, not one per settle")))
@@ -1616,23 +1616,23 @@
     ;; again. That is a real second transition into :error and must be reported.
     (let [traces (record-error-traces!
                    (fn []
-                     (let [rdb1 (route/reconcile-readiness
+                     (let [rdb1 (rf.resources.route/reconcile-readiness
                                   (runtime-db-with "nav-1" :loading
                                                    {req-a (failed-req 503)}))
                            ;; the retry lands: :error → :idle (and the now-ready
                            ;; requirement is pruned from the slot)
-                           rdb2 (route/reconcile-readiness
-                                  (assoc-in rdb1 (state/entry-path req-a)
+                           rdb2 (rf.resources.route/reconcile-readiness
+                                  (assoc-in rdb1 (rf.resources.state/entry-path req-a)
                                             {:resource/id :article/by-slug
                                              :status :loaded :data {:x 1}}))]
                        (is (= :idle (get-in rdb2 [:rf.runtime/routing :current :transition]))
                            "a successful load re-projects :idle — no stale error survives")
                        ;; a fresh activation re-blocks on the same identity, which
                        ;; fails again
-                       (route/reconcile-readiness
+                       (rf.resources.route/reconcile-readiness
                          (-> rdb2
-                             (assoc-in (route/blocking-path "nav-1") (blocking-map req-a))
-                             (assoc-in (state/entry-path req-a) (failed-req 500)))))))]
+                             (assoc-in (rf.resources.route/blocking-path "nav-1") (blocking-map req-a))
+                             (assoc-in (rf.resources.state/entry-path req-a) (failed-req 500)))))))]
       (is (= 2 (count (blocking-error-traces traces)))
           "two distinct transitions INTO :error are two traces"))))
 
@@ -1649,11 +1649,11 @@
                  :resources [{:resource  :article/by-slug
                               :params    (fn [route] {:slug (get-in route [:params :slug])})
                               :blocking? true}]} "/articles/:slug")
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
     ;; warm the identity OUTSIDE any navigation (an ownerless preload)
     (rf/dispatch-sync [:rf.resource/ensure {:resource :article/by-slug :params {:slug "intro"}}])
     (settle-success! scoped-key {:title "Intro"})
-    (is (state/has-data? (entry scoped-key)) "precondition: the identity is warm")
+    (is (rf.resources.state/has-data? (entry scoped-key)) "precondition: the identity is warm")
     (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "intro"}}])
     (let [nav-token (:nav-token (slice))]
       (testing "the already-fresh blocking requirement is recorded nowhere"
@@ -1674,7 +1674,7 @@
                               :blocking? true}]} "/articles/:slug")
   (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "cold"}}])
   (let [nav-token  (:nav-token (slice))
-        scoped-key (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "cold"})]
+        scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "cold"})]
     (is (= #{scoped-key} (blocking-slot nav-token)))
     (is (= :loading (:transition (slice))))))
 
@@ -1688,7 +1688,7 @@
                               :params    (fn [route] {:slug (get-in route [:params :slug])})
                               :blocking? true}]} "/articles/:slug")
   (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "intro"}}])
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
     (settle-success! scoped-key {:title "Intro"})
     (is (= :idle (:transition (slice))) "precondition: the blocking first load landed")
     ;; a REFRESH over the loaded entry, which then fails
@@ -1714,8 +1714,8 @@
                               :params         (fn [route] {:slug (get-in route [:params :slug])})
                               :blocking?      true
                               :keep-previous? true}]} "/articles/:slug")
-  (let [key-a (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "a"})
-        key-b (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "b"})]
+  (let [key-a (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "a"})
+        key-b (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "b"})]
     (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "a"}}])
     (settle-success! key-a {:title "A"})
     (is (= :idle (:transition (slice))) "precondition: slug a landed")
@@ -1725,7 +1725,7 @@
         (is (= key-a (:previous-key b)) "the projection pointer is set")
         (is (nil? (:data b)) "previous data is NEVER inserted into the new entry"))
       (testing "the route stays :loading — previous pixels are not a completed load"
-        (is (= :pending (route/requirement-state b)))
+        (is (= :pending (rf.resources.route/requirement-state b)))
         (is (= :loading (:transition (slice))))
         (is (contains? (blocking-slot (:nav-token (slice))) key-b))))))
 
@@ -1733,7 +1733,7 @@
 
 (deftest restore-recomputes-a-readiness-the-restored-resources-contradict
   (testing "a snapshot's :loading whose requirement restored WITH data lands :idle"
-    (let [rdb (res-ssr/reconcile-on-restore
+    (let [rdb (rf.resources.ssr/reconcile-on-restore
                 (runtime-db-with "nav-1" :loading
                                  {req-a {:resource/id  :article/by-slug
                                          :resource/key req-a
@@ -1744,16 +1744,16 @@
     ;; The in-flight attempt did not survive the restore (its work row is
     ;; dangled and the entry settles to last-stable :idle), so a preserved
     ;; :loading would hang the route forever.
-    (let [rdb (res-ssr/reconcile-on-restore
+    (let [rdb (rf.resources.ssr/reconcile-on-restore
                 (runtime-db-with "nav-1" :loading
                                  {req-a {:resource/id  :article/by-slug
                                          :resource/key req-a
                                          :status       :loading :data nil :attempt 1
                                          :current-work "work-1"}}))]
       (is (= :idle (get-in rdb [:rf.runtime/routing :current :transition])))
-      (is (empty? (get-in rdb (route/blocking-path "nav-1"))))))
+      (is (empty? (get-in rdb (rf.resources.route/blocking-path "nav-1"))))))
   (testing "a restored FAILED blocking requirement projects the route :error"
-    (let [rdb (res-ssr/reconcile-on-restore
+    (let [rdb (rf.resources.ssr/reconcile-on-restore
                 (runtime-db-with "nav-1" :loading
                                  {req-a {:resource/id  :article/by-slug
                                          :resource/key req-a
@@ -1765,14 +1765,14 @@
 
 (deftest hydration-recomputes-a-readiness-the-hydrated-resources-contradict
   (rf/reg-resource :article/by-slug (article-spec {}) article-spec-request)
-  (let [rdb (res-ssr/hydrate-runtime-db
+  (let [rdb (rf.resources.ssr/hydrate-runtime-db
               (runtime-db-with "nav-1" :loading
                                {req-a {:resource/id  :article/by-slug
                                        :resource/key req-a
                                        :status       :loaded :data {:x 1} :attempt 1}}))]
     (is (= :idle (get-in rdb [:rf.runtime/routing :current :transition]))
         "hydration must not preserve a :loading the hydrated entries contradict")
-    (is (empty? (get-in rdb (route/blocking-path "nav-1"))))))
+    (is (empty? (get-in rdb (rf.resources.route/blocking-path "nav-1"))))))
 
 ;; ===========================================================================
 ;; 16. rf2-kqxe6.6 — EP-0037 R2 follow-through
@@ -1799,7 +1799,7 @@
   "A `:rf.runtime/work-ledger` map carrying `work-id` at `status`, keyed the way
   the runtime keys it (the CEDN-1 byte identity, not the work-id itself)."
   [work-id status]
-  {(work-ledger/work-id-id work-id) {:work/id work-id :status status}})
+  {(rf.resources.work-ledger/work-id-id work-id) {:work/id work-id :status status}})
 
 (deftest adoptable-splits-reusable-from-unusable-retained-identities
   ;; Derived from the ONE projector's `requirement-state` classification — this
@@ -1811,27 +1811,27 @@
         dead-work {:rf.runtime/work-ledger (ledger-with "w-dead" :cancelled)}
         doomed    {:rf.runtime/work-ledger (ledger-with "w-doom" :abort-requested)}]
     (testing "own usable data is reusable — adopt, never revalidate"
-      (is (route/adoptable? {} {:status :loaded :data {:a 1} :attempt 1})))
+      (is (rf.resources.route/adoptable? {} {:status :loaded :data {:a 1} :attempt 1})))
     (testing "genuinely live work is reusable — its own settle will drain the slot"
-      (is (route/adoptable? live-work {:status :loading :data nil :attempt 1
+      (is (rf.resources.route/adoptable? live-work {:status :loading :data nil :attempt 1
                                        :current-work "w-live"})))
     (testing "an ABSENT entry is not adoptable — adopt-owner would be a no-op"
-      (is (not (route/adoptable? {} nil))))
+      (is (not (rf.resources.route/adoptable? {} nil))))
     (testing "an enqueued but never-attempted entry is not adoptable — no work exists"
-      (is (not (route/adoptable? {} {:status :idle :data nil :attempt 0}))))
+      (is (not (rf.resources.route/adoptable? {} {:status :idle :data nil :attempt 0}))))
     (testing "settled with no data and nothing left to settle it is not adoptable"
-      (is (not (route/adoptable? {} {:status :idle :data nil :attempt 1}))))
+      (is (not (rf.resources.route/adoptable? {} {:status :idle :data nil :attempt 1}))))
     (testing "a failed first load is not adoptable — there is nothing to reuse"
-      (is (not (route/adoptable? {} {:status :error :data nil :attempt 1
+      (is (not (rf.resources.route/adoptable? {} {:status :error :data nil :attempt 1
                                      :error {:kind :rf.http/server}}))))
     (testing "an in-flight-LOOKING entry whose work is dead is not adoptable"
       ;; `:current-work` alone is not proof of work — the LINKED RECORD'S status
       ;; is (the same liveness `ensure`'s dedupe gate reads).
-      (is (not (route/adoptable? dead-work {:status :loading :data nil :attempt 1
+      (is (not (rf.resources.route/adoptable? dead-work {:status :loading :data nil :attempt 1
                                             :current-work "w-dead"})))
-      (is (not (route/adoptable? doomed {:status :loading :data nil :attempt 1
+      (is (not (rf.resources.route/adoptable? doomed {:status :loading :data nil :attempt 1
                                          :current-work "w-doom"})))
-      (is (not (route/adoptable? {} {:status :loading :data nil :attempt 1
+      (is (not (rf.resources.route/adoptable? {} {:status :loading :data nil :attempt 1
                                      :current-work "w-pruned"}))
           "a pointer with no record at all is dead work too"))))
 
@@ -1842,7 +1842,7 @@
   work ledger) — the AT-COMMIT facts routing threads into the plan hook."
   ([entries-by-key] (rdb-with-entries entries-by-key nil))
   ([entries-by-key ledger]
-   (cond-> {:rf.runtime/resources {:entries (into {} (map (fn [[k e]] [(state/key-id k) e]))
+   (cond-> {:rf.runtime/resources {:entries (into {} (map (fn [[k e]] [(rf.resources.state/key-id k) e]))
                                                   entries-by-key)}}
      ledger (assoc :rf.runtime/work-ledger ledger))))
 
@@ -1852,9 +1852,9 @@
   (let [parent-meta {:resources [{:resource :sh/v :params (fn [_] {:slug "v"}) :blocking? true}]}
         branch      [{:route-id :route/p   :route-meta parent-meta}
                      {:route-id :route/p.b :route-meta {:resources [{:resource :lf/b :params (fn [_] {:slug "b"})}]}}]
-        shared-key  (state/scoped-resource-key* :rf.scope/global :sh/v {:slug "v"})
+        shared-key  (rf.resources.state/scoped-resource-key* :rf.scope/global :sh/v {:slug "v"})
         plan-for    (fn [runtime-db]
-                      (route/route-resource-plan
+                      (rf.resources.route/route-resource-plan
                         {:id :route/p.b :params {} :query {}} {}
                         {:nav-token 2 :prev-id :route/p.a :prev-nav-token 1
                          :prev-identities #{shared-key} :branch branch
@@ -1865,7 +1865,7 @@
             ds   (plan-dispatches plan)]
         (is (= [:sh/v] (mapv #(:resource (second %)) (of-event ds :rf.resource/adopt-owner))))
         (is (= [:lf/b] (mapv #(:resource (second %)) (of-event ds :rf.resource/ensure))))
-        (is (not (contains? (:blocking plan) (state/key-id shared-key)))
+        (is (not (contains? (:blocking plan) (rf.resources.state/key-id shared-key)))
             "already has usable data — nothing left to wait for")))
     (testing "an IN-FLIGHT retained identity is adopted — its own settle drains the slot"
       (let [plan (plan-for (rdb-with-entries
@@ -1874,7 +1874,7 @@
                              (ledger-with "w-1" :running)))
             ds   (plan-dispatches plan)]
         (is (= [:sh/v] (mapv #(:resource (second %)) (of-event ds :rf.resource/adopt-owner))))
-        (is (contains? (:blocking plan) (state/key-id shared-key)) "still outstanding")))
+        (is (contains? (:blocking plan) (rf.resources.state/key-id shared-key)) "still outstanding")))
     (testing "a MISSING retained identity takes the ordinary ensure path"
       ;; The bead's repro: prior-plan membership alone dispatched adopt-owner,
       ;; which is a NO-OP on an absent entry — the committed blocking slot then
@@ -1883,7 +1883,7 @@
             ds   (plan-dispatches plan)]
         (is (empty? (of-event ds :rf.resource/adopt-owner)))
         (is (= [:sh/v :lf/b] (mapv #(:resource (second %)) (of-event ds :rf.resource/ensure))))
-        (is (contains? (:blocking plan) (state/key-id shared-key))
+        (is (contains? (:blocking plan) (rf.resources.state/key-id shared-key))
             "recorded blocking — and an ensure now exists to drain it")))
     (testing "an UNUSABLE retained identity (settled, no data, no work) is ensured"
       (let [plan (plan-for (rdb-with-entries {shared-key {:resource/id :sh/v :status :idle
@@ -1891,7 +1891,7 @@
             ds   (plan-dispatches plan)]
         (is (empty? (of-event ds :rf.resource/adopt-owner)))
         (is (= [:sh/v :lf/b] (mapv #(:resource (second %)) (of-event ds :rf.resource/ensure))))
-        (is (contains? (:blocking plan) (state/key-id shared-key))
+        (is (contains? (:blocking plan) (rf.resources.state/key-id shared-key))
             "a blocking requirement with no usable data at commit must hold the route")))
     (testing "a retained identity whose work is DEAD is ensured, not adopted"
       (let [plan (plan-for (rdb-with-entries
@@ -1950,8 +1950,8 @@
   ;; route stayed :loading with no entry, no work and no reply that could ever
   ;; drain it.
   (reg-shell-branch!)
-  (let [banner-key (state/scoped-resource-key* :rf.scope/global :prof/banner {:slug "b"})
-        tab1-key   (state/scoped-resource-key* :rf.scope/global :prof/tab-one {:slug "one"})]
+  (let [banner-key (rf.resources.state/scoped-resource-key* :rf.scope/global :prof/banner {:slug "b"})
+        tab1-key   (rf.resources.state/scoped-resource-key* :rf.scope/global :prof/tab-one {:slug "one"})]
     (rf/dispatch-sync [:rf.route/navigate {:to :route/prof.one}])
     (settle-success! banner-key {:name "Ada"})
     (settle-success! tab1-key [{:id 1}])
@@ -1972,7 +1972,7 @@
         (settle-success! banner-key {:name "Ada"})
         (is (= :idle (:transition (slice))))
         (is (empty? (blocking-slot nav-token)))
-        (is (state/has-data? (entry banner-key)))))))
+        (is (rf.resources.state/has-data? (entry banner-key)))))))
 
 (deftest r2-sibling-nav-recovers-a-retained-identity-that-cannot-progress
   ;; LIVENESS. Same branch, but the retained banner EXISTS and is unusable: its
@@ -1980,16 +1980,16 @@
   ;; work. Adopting it attaches an owner to a dead entry and issues no fetch —
   ;; the blocking requirement is silently never satisfied.
   (reg-shell-branch!)
-  (let [banner-key (state/scoped-resource-key* :rf.scope/global :prof/banner {:slug "b"})
-        tab1-key   (state/scoped-resource-key* :rf.scope/global :prof/tab-one {:slug "one"})]
+  (let [banner-key (rf.resources.state/scoped-resource-key* :rf.scope/global :prof/banner {:slug "b"})
+        tab1-key   (rf.resources.state/scoped-resource-key* :rf.scope/global :prof/tab-one {:slug "one"})]
     (rf/dispatch-sync [:rf.route/navigate {:to :route/prof.one}])
     (settle-success! tab1-key [{:id 1}])
     (abort-current-work! banner-key)
     (let [aborted (entry banner-key)]
       (is (= :idle (:status aborted)) "precondition: settled with no data")
       (is (nil? (:current-work aborted)) "precondition: no work left")
-      (is (not (state/has-data? aborted)))
-      (is (= :inert (route/requirement-state aborted))))
+      (is (not (rf.resources.state/has-data? aborted)))
+      (is (= :inert (rf.resources.route/requirement-state aborted))))
 
     (rf/dispatch-sync [:rf.route/navigate {:to :route/prof.two}])
     (let [nav-token (:nav-token (slice))
@@ -2004,14 +2004,14 @@
         (is (= :loading (:transition (slice))))
         (settle-success! banner-key {:name "Ada"})
         (is (= :idle (:transition (slice))))
-        (is (state/has-data? (entry banner-key)))))))
+        (is (rf.resources.state/has-data? (entry banner-key)))))))
 
 (deftest r2-adoption-of-in-flight-work-neither-revalidates-nor-aborts
   ;; The counterweight to the two liveness regressions: a genuinely reusable
   ;; retained identity is still adopted WITHOUT revalidation, and releasing the
   ;; prior owner cannot abort work the next plan still needs.
   (reg-shell-branch!)
-  (let [banner-key (state/scoped-resource-key* :rf.scope/global :prof/banner {:slug "b"})]
+  (let [banner-key (rf.resources.state/scoped-resource-key* :rf.scope/global :prof/banner {:slug "b"})]
     (rf/dispatch-sync [:rf.route/navigate {:to :route/prof.one}])
     (let [before (entry banner-key)
           work   (:current-work before)]
@@ -2022,7 +2022,7 @@
           (is (= (:generation before) (:generation after)) "no new generation")
           (is (= work (:current-work after)) "the same work record — no refetch"))
         (testing "releasing the prior owner did not abort the shared work"
-          (is (not (work-ledger/terminal? (:status (work-ledger/get-record
+          (is (not (rf.resources.work-ledger/terminal? (:status (rf.resources.work-ledger/get-record
                                                      (:rf.db/runtime (rf/frame-state-value :rf/default))
                                                      work))))))
         (testing "the adopted work's own settle lands the route"
@@ -2049,7 +2049,7 @@
   [branch]
   (let [plan   (atom nil)
         traces (record-error-traces!
-                 (fn [] (reset! plan (route/route-resource-plan
+                 (fn [] (reset! plan (rf.resources.route/route-resource-plan
                                        {:id :route/leaf :params {} :query {}} {}
                                        {:nav-token 1 :branch branch}))))]
     [@plan traces]))
@@ -2141,7 +2141,7 @@
   ;; rides its planning error (with :plan-cause :prefetch and no nav-token).
   (rf/reg-resource :audit/ancestor (article-spec {}) article-spec-request)
   (rf/reg-resource :audit/leaf (article-spec {}) article-spec-request)
-  (let [plan (route/route-resource-warm-plan
+  (let [plan (rf.resources.route/route-resource-warm-plan
                {:id :route/leaf :params {} :query {}}
                {:branch (ancestor-branch {:resource :audit/ancestor :id :anc
                                           :params (fn [_] nil)})})

--- a/implementation/resources/test/re_frame/resources_route_infinite_blocking_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_route_infinite_blocking_cljs_test.cljc
@@ -53,17 +53,17 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting requires: register the routing + resources
    ;; events / subs and resources' late-bound :routing/* integration hooks.
    [re-frame.resources]
-   [re-frame.resources.route :as route]
-   [re-frame.resources.state :as state]
+   [re-frame.resources.route :as rf.resources.route]
+   [re-frame.resources.state :as rf.resources.state]
    [re-frame.resources.test-support]
-   [re-frame.routing :as routing]
+   [re-frame.routing :as rf.routing]
    [re-frame.schemas]
    [re-frame.http.managed]
-   [re-frame.test-support :as core-test-support]
+   [re-frame.test-support :as rf.test-support]
    #?(:clj  [re-frame.substrate.plain-atom :as substrate]
       :cljs [re-frame.adapter.reagent :as substrate])))
 
@@ -83,13 +83,13 @@
   (reset! last-managed-args nil)
   (rf/make-frame {:id :rf/default :url-bound? true
                   :doc "Route-infinite-blocking suite default app frame."})
-  (routing/reset-counters!)
-  (route/install-routing-integration!)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
-  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil)))
+  (rf.routing/reset-counters!)
+  (rf.resources.route/install-routing-integration!)
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil)))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     {:adapter substrate/adapter
      :init-fn init!}))
 
@@ -99,7 +99,7 @@
   (get-in (:rf.db/runtime (rf/frame-state-value :rf/default)) [:rf.runtime/routing :current]))
 
 (defn- entry [scoped-key]
-  (get-in (:rf.db/runtime (rf/frame-state-value :rf/default)) (state/entry-path scoped-key)))
+  (get-in (:rf.db/runtime (rf/frame-state-value :rf/default)) (rf.resources.state/entry-path scoped-key)))
 
 (defn- blocking-slot
   "The live blocking slot for `nav-token`, projected to the SET of its scoped
@@ -108,7 +108,7 @@
   answers."
   [nav-token]
   (set (vals (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
-                     (route/blocking-path nav-token)))))
+                     (rf.resources.route/blocking-path nav-token)))))
 
 (def ^:private next-cursor
   (fn [last-page _all-pages] (get-in last-page [:page-info :next-cursor])))
@@ -137,7 +137,7 @@
                          page-param (assoc :cursor page-param))}}))
 
 (defn- feed-key [slug]
-  (state/scoped-resource-key :rf.scope/global :feed/articles {:slug slug}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global :feed/articles {:slug slug}))
 
 (defn- reply-page-success!
   "Dispatch the captured page reply's `:on-success` with the transport's
@@ -185,7 +185,7 @@
       (is (contains? (blocking-slot nav-token) k)
           "the blocking infinite feed's scoped key is tracked under the nav-token")
       (let [e (entry k)]
-        (is (state/infinite-entry? e) "ensured an INFINITE entry (page-0 fetch, not a scalar)")
+        (is (rf.resources.state/infinite-entry? e) "ensured an INFINITE entry (page-0 fetch, not a scalar)")
         (is (= :loading (:status e)) "first load (no data) is :loading")
         (is (= [] (:data e)) "page vector empty (page-0 in flight)"))
       (testing "the route owner is on the infinite feed entry"
@@ -195,7 +195,7 @@
       (reply-page-success! (page [:a :b] "c1"))
       (let [e (entry k)]
         (is (= :loaded (:status e)) "feed settled :loaded")
-        (is (= 1 (state/page-count e)) "page 0 accumulated through the append path")
+        (is (= 1 (rf.resources.state/page-count e)) "page 0 accumulated through the append path")
         (is (= [(page [:a :b] "c1")] (:data e)) "page-0 data appended"))
       (is (= :idle (:transition (slice)))
           "the blocking infinite route drained to :idle on the page-0 reply")
@@ -235,7 +235,7 @@
         (is (nil? (:page-error e)) "NOT the load-more :page-error channel (page 0 is not a load-more)")
         (is (nil? (:refresh-error e)) "NOT the whole-feed :refresh-error channel")
         (is (nil? (:data e)) "first-load failure clears data (no usable data)")
-        (is (= 0 (state/page-count e)) "no page accumulated — page 0 never landed")))
+        (is (= 0 (rf.resources.state/page-count e)) "no page accumulated — page 0 never landed")))
     (testing "the BLOCKING ROUTE flips to :error (parity with a scalar blocking resource)"
       (is (= :error (:transition (slice)))
           "the blocking infinite route flips to :error on the page-0 first-load failure")
@@ -271,9 +271,9 @@
                               :params    (fn [route] {:slug (get-in route [:params :slug])})
                               :blocking? true}]} "/articles/:slug")
   (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "intro"}}])
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})
         e          (entry scoped-key)]
-    (is (not (state/infinite-entry? e)) "the contrast resource is SCALAR, not infinite")
+    (is (not (rf.resources.state/infinite-entry? e)) "the contrast resource is SCALAR, not infinite")
     ;; settle the scalar via the SCALAR failed handler (its live reply shape)
     (rf/dispatch-sync (conj (:on-failure @last-managed-args)
                             {:status :error :error {:status 503 :message "upstream down"}}))
@@ -304,7 +304,7 @@
     ;; drains to :idle, then the feed has one accumulated page.
     (reply-page-success! (page [:a :b] "c1"))
     (is (= :idle (:transition (slice))) "route drained on page-0 success")
-    (is (= 1 (state/page-count (entry k))) "page 0 accumulated")
+    (is (= 1 (rf.resources.state/page-count (entry k))) "page 0 accumulated")
     ;; now a load-more (page 1) is dispatched and FAILS.
     (rf/dispatch-sync [:rf.resource/load-more {:resource :feed/articles
                                                :scope    :rf.scope/global
@@ -318,7 +318,7 @@
         (is (= :loaded (:status e)) "load-more failure leaves the feed :loaded (data kept)")
         (is (= failure (:page-error e)) ":page-error records the load-more failure envelope")
         (is (nil? (:error e)) "NOT the first-load :error channel")
-        (is (= 1 (state/page-count e)) "the accumulated page-0 is KEPT (no data lost)")
+        (is (= 1 (rf.resources.state/page-count e)) "the accumulated page-0 is KEPT (no data lost)")
         (is (= [(page [:a :b] "c1")] (:data e)) "page-0 data still present")))
     (testing "the route is undisturbed by the load-more failure (already :idle)"
       (is (= :idle (:transition (slice)))

--- a/implementation/resources/test/re_frame/resources_route_plan_recovery_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_route_plan_recovery_cljs_test.cljc
@@ -51,17 +51,17 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting requires: register the resources + routing
    ;; events / subs and resources' late-bound :routing/* integration hooks.
    [re-frame.resources]
-   [re-frame.resources.route :as route]
+   [re-frame.resources.route :as rf.resources.route]
    [re-frame.resources.test-support]
-   [re-frame.routing :as routing]
+   [re-frame.routing :as rf.routing]
    [re-frame.schemas]
    [re-frame.http.managed]
-   [re-frame.registrar :as registrar]
-   [re-frame.test-support :as core-test-support]
+   [re-frame.registrar :as rf.registrar]
+   [re-frame.test-support :as rf.test-support]
    ;; The node-runtime window/history/location stub — CLJS only; the two
    ;; construction-time tests set `location.pathname` through it so the URL
    ;; under test is OWNED by this suite rather than by whichever co-loaded
@@ -90,19 +90,19 @@
   fixture's own `:rf/default` is NOT `:url-bound?`, so nothing syncs a URL
   until a test asks for it."
   []
-  (routing/reset-counters!)
-  (route/install-routing-integration!)
-  (registrar/clear-kind! :resource-scope)
+  (rf.routing/reset-counters!)
+  (rf.resources.route/install-routing-integration!)
+  (rf.registrar/clear-kind! :resource-scope)
   (reset! requests [])
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! requests conj args) nil))
-  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! requests conj args) nil))
+  (rf.fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
   (rf/reg-route :ma8r/board
     {:resources [{:resource :ma8r/board-data :blocking? true}]}
     board-path))
 
 (use-fixtures :each
   #?@(:cljs [with-window-stub-fixture])
-  (core-test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     {:adapter substrate/adapter
      :init-fn init!}))
 
@@ -150,7 +150,7 @@
   (let [tok (token)]
     (testing "registering the resource afterwards does not, by itself, re-plan"
       (reg-board-resource!)
-      (is (some? (registrar/lookup :resource :ma8r/board-data))
+      (is (some? (rf.registrar/lookup :resource :ma8r/board-data))
           "control: the resource IS registered and visible now")
       (rf/dispatch-sync [:rf.route/navigate {:to :ma8r/board}])
       (is (= tok (token))

--- a/implementation/resources/test/re_frame/resources_route_prefetch_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_route_prefetch_cljs_test.cljc
@@ -21,18 +21,18 @@
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    ;; load-bearing side-effecting requires: register the resources runtime + the
    ;; late-bound :routing/* integration hooks.
-   [re-frame.resources :as resources]
-   [re-frame.resources.route :as route]))
+   [re-frame.resources :as rf.resources]
+   [re-frame.resources.route :as rf.resources.route]))
 
 (def ^:private res-id :prefetch/warm-res)
 
 (defn- with-resource [f]
-  (resources/reg-resource
+  (rf.resources/reg-resource
     res-id
     {:scope :rf.scope/global :params-schema [:map]}
     (fn [_params _ctx] {:request {:method :get :url "/api/warm"}}))
   (try (f)
-       (finally (resources/clear-resource res-id))))
+       (finally (rf.resources/clear-resource res-id))))
 
 (use-fixtures :each with-resource)
 
@@ -42,7 +42,7 @@
 
 (deftest warm-plan-ensures-are-ownerless-cause-only-and-blocking-inert
   (let [{:keys [fx warmed plan-error]}
-        (route/on-route-prefetch-fx
+        (rf.resources.route/on-route-prefetch-fx
           {:route-id     :route/article
            :params       {}
            :query        {}
@@ -72,7 +72,7 @@
 
 (deftest warm-plan-branch-error-is-a-prefetch-planning-failure
   (let [{:keys [fx warmed plan-error]}
-        (route/route-resource-warm-plan
+        (rf.resources.route/route-resource-warm-plan
           {:id :route/child}
           {:app-db       {}
            :branch       [{:route-id :route/child :route-meta nil}]
@@ -90,7 +90,7 @@
 
 (deftest warm-plan-is-a-noop-when-no-branch-contributor-declares-resources
   (testing "a resource-free branch warms nothing (nil hook result — no work)"
-    (is (nil? (route/on-route-prefetch-fx
+    (is (nil? (rf.resources.route/on-route-prefetch-fx
                 {:route-id     :route/plain
                  :params       {}
                  :query        {}

--- a/implementation/resources/test/re_frame/resources_route_replan_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_route_replan_cljs_test.cljc
@@ -38,20 +38,20 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting requires: register the resources + routing
    ;; events / subs and resources' late-bound :routing/* integration hooks.
    [re-frame.resources]
-   [re-frame.resources.route :as route]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.resources.route :as rf.resources.route]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.work-ledger :as rf.resources.work-ledger]
    [re-frame.resources.test-support]
-   [re-frame.routing :as routing]
+   [re-frame.routing :as rf.routing]
    [re-frame.schemas]
    [re-frame.http.managed]
-   [re-frame.registrar :as registrar]
-   [re-frame.trace.tooling :as trace-tooling]
-   [re-frame.test-support :as core-test-support]
+   [re-frame.registrar :as rf.registrar]
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   [re-frame.test-support :as rf.test-support]
    #?(:clj  [re-frame.substrate.plain-atom :as substrate]
       :cljs [re-frame.adapter.reagent :as substrate])))
 
@@ -76,13 +76,13 @@
   []
   (rf/make-frame {:id :rf/default :url-bound? true
                   :doc "replan suite default app frame."})
-  (routing/reset-counters!)
-  (route/install-routing-integration!)
-  (registrar/clear-kind! :resource-scope)
+  (rf.routing/reset-counters!)
+  (rf.resources.route/install-routing-integration!)
+  (rf.registrar/clear-kind! :resource-scope)
   (reset! requests [])
   (reset! extra-admitted? false)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! requests conj args) nil))
-  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! requests conj args) nil))
+  (rf.fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
   (rf/reg-resource-scope :t/viewer
     {:inputs {:username [:db [:auth :user :username]]}}
     (fn [{:keys [username]} _ctx]
@@ -120,15 +120,15 @@
   (rf/reg-event :t/logout (fn [{:keys [db]} _]     {:db (update db :auth dissoc :user)})))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     {:adapter substrate/adapter
      :init-fn init!}))
 
 ;; ---- helpers --------------------------------------------------------------
 
 (defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
-(defn- entry [k] (get-in (runtime-db) (state/entry-path k)))
-(defn- entries [] (get-in (runtime-db) (state/entries-path)))
+(defn- entry [k] (get-in (runtime-db) (rf.resources.state/entry-path k)))
+(defn- entries [] (get-in (runtime-db) (rf.resources.state/entries-path)))
 (defn- slice [] (get-in (runtime-db) [:rf.runtime/routing :current]))
 (defn- token [] (:nav-token (slice)))
 (defn- route-owner [] [:route (:route-id (slice)) (token)])
@@ -136,22 +136,22 @@
 (defn- blocking-slot [] (get-in (runtime-db) [:rf.runtime/routing :resource-blocking (token)]))
 (defn- has-plan-slot? [] (contains? (get-in (runtime-db) [:rf.runtime/routing :resource-plan]) (token)))
 (defn- has-blocking-slot? [] (contains? (get-in (runtime-db) [:rf.runtime/routing :resource-blocking]) (token)))
-(defn- owner-index [owner] (get-in (runtime-db) (conj (state/owner-index-path) owner)))
+(defn- owner-index [owner] (get-in (runtime-db) (conj (rf.resources.state/owner-index-path) owner)))
 
 (defn- by-id
   "The byte-keyed `{<key-id> <scoped-key>}` carrier the slots hold."
   [& ks]
-  (into {} (map (juxt state/key-id identity)) ks))
+  (into {} (map (juxt rf.resources.state/key-id identity)) ks))
 
 (defn- viewer [u] [:rf.scope/viewer {:username u}])
-(defn- shell-key [u] (state/scoped-resource-key (viewer u) :t/shell {}))
-(defn- docs-key [u page] (state/scoped-resource-key (viewer u) :t/docs {:page page}))
-(def ^:private global-key (state/scoped-resource-key :rf.scope/global :t/global {}))
-(def ^:private extra-key  (state/scoped-resource-key :rf.scope/global :t/extra {}))
+(defn- shell-key [u] (rf.resources.state/scoped-resource-key (viewer u) :t/shell {}))
+(defn- docs-key [u page] (rf.resources.state/scoped-resource-key (viewer u) :t/docs {:page page}))
+(def ^:private global-key (rf.resources.state/scoped-resource-key :rf.scope/global :t/global {}))
+(def ^:private extra-key  (rf.resources.state/scoped-resource-key :rf.scope/global :t/extra {}))
 
 (defn- owned? [k] (contains? (:active-owners (entry k)) (route-owner)))
-(defn- work-record [k] (work-ledger/get-record (runtime-db) (:current-work (entry k))))
-(defn- live? [k] (work-ledger/live-work? (runtime-db) (:current-work (entry k))))
+(defn- work-record [k] (rf.resources.work-ledger/get-record (runtime-db) (:current-work (entry k))))
+(defn- live? [k] (rf.resources.work-ledger/live-work? (runtime-db) (:current-work (entry k))))
 (defn- request-count [] (count @requests))
 
 (defn- settle-loaded!
@@ -174,10 +174,10 @@
   [ops body-fn]
   (let [seen (atom [])
         k    ::replan-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (contains? ops (:operation ev)) (swap! seen conj ev))))
     (try (body-fn)
-         (finally (trace-tooling/unregister-listener! k)))
+         (finally (rf.trace.tooling/unregister-listener! k)))
     @seen))
 
 (defn- op [traces operation]
@@ -366,7 +366,7 @@
       (replan! [:flag-on])
       (is (owned? extra-key))
       (is (= [[:flag-on]] (:causes (work-record extra-key))))
-      (is (= (assoc base (state/key-id extra-key) extra-key) (plan-slot)))
+      (is (= (assoc base (rf.resources.state/key-id extra-key) extra-key) (plan-slot)))
       (is (= tok (token))))
     (testing "LEAVING: a same-owner SUBSET release names ONLY the dropped identity"
       (reset! extra-admitted? false)
@@ -451,16 +451,16 @@
     (rf/dispatch-sync [:rf.resource/ensure {:resource :t/global :params {} :owner B :cause [:b1]}])
     (is (= #{A B} (:active-owners (entry k1))))
     (is (= #{A} (:active-owners (entry k2))))
-    (is (= #{(state/key-id k1) (state/key-id k2)} (owner-index A)))
+    (is (= #{(rf.resources.state/key-id k1) (rf.resources.state/key-id k2)} (owner-index A)))
     (testing "only the NAMED identity, only THIS owner, and no abort while another owner remains"
       (let [traces (record-traces! #{:rf.resource/owner-released}
                      #(rf/dispatch-sync [:rf.resource/release-owner-identities
                                          {:owner A :identities (by-id k1)}]))]
         (is (= #{B} (:active-owners (entry k1))) "A released from k1; B survives")
         (is (= #{A} (:active-owners (entry k2))) "A still owns k2 — it was not named")
-        (is (work-ledger/live-work? (runtime-db) (:current-work (entry k1)))
+        (is (rf.resources.work-ledger/live-work? (runtime-db) (:current-work (entry k1)))
             "k1's in-flight work is NOT aborted — B still needs it")
-        (is (= #{(state/key-id k2)} (owner-index A)) "the owner-index drops only k1")
+        (is (= #{(rf.resources.state/key-id k2)} (owner-index A)) "the owner-index drops only k1")
         (let [tags (:tags (op traces :rf.resource/owner-released))]
           (is (= A (:owner tags)))
           (is (= [k1] (:released tags)))
@@ -468,13 +468,13 @@
     (testing "an identity the owner does not hold is a no-op"
       (rf/dispatch-sync [:rf.resource/release-owner-identities {:owner A :identities (by-id k1)}])
       (is (= #{B} (:active-owners (entry k1))))
-      (is (= #{(state/key-id k2)} (owner-index A))))
+      (is (= #{(rf.resources.state/key-id k2)} (owner-index A))))
     (testing "releasing the LAST owner from an in-flight identity aborts it and drops the index row"
       (let [traces (record-traces! #{:rf.resource/owner-released}
                      #(rf/dispatch-sync [:rf.resource/release-owner-identities
                                          {:owner A :identities (by-id k2)}]))]
         (is (empty? (:active-owners (entry k2))))
-        (is (not (work-ledger/live-work? (runtime-db) (:current-work (entry k2))))
+        (is (not (rf.resources.work-ledger/live-work? (runtime-db) (:current-work (entry k2))))
             "orphaned → abort-requested")
         (is (nil? (owner-index A)) "A's index row is gone once it holds nothing")
         (is (= [(:current-work (entry k2))] (:aborted (:tags (op traces :rf.resource/owner-released)))))))
@@ -482,4 +482,4 @@
       (rf/dispatch-sync [:rf.resource/release-owner {:owner B}])
       (is (empty? (:active-owners (entry k1))))
       (is (nil? (owner-index B)))
-      (is (not (work-ledger/live-work? (runtime-db) (:current-work (entry k1))))))))
+      (is (not (rf.resources.work-ledger/live-work? (runtime-db) (:current-work (entry k1))))))))

--- a/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
@@ -33,31 +33,31 @@
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [clojure.string :as str]
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
-   [re-frame.frame :as frame]
-   [re-frame.identity :as identity]
-   [re-frame.late-bind :as late-bind]
-   [re-frame.registrar :as registrar]
+   [re-frame.fx :as rf.fx]
+   [re-frame.frame :as rf.frame]
+   [re-frame.identity :as rf.identity]
+   [re-frame.late-bind :as rf.late-bind]
+   [re-frame.registrar :as rf.registrar]
    ;; load-bearing side-effecting require: the façade registers the
    ;; :rf.resource/* events + subs + the generation cofx/fx these tests
    ;; dispatch / subscribe to.
    [re-frame.resources]
-   [re-frame.resources.registry :as registry]
-   [re-frame.resources.mutation-registry :as mreg]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.subs :as subs]
-   [re-frame.resources.test-support :as resources-test-support]
-   [re-frame.resources.timers :as timers]
-   [re-frame.resources.work-ledger :as work-ledger]
-   [re-frame.resources.revalidate-listeners :as revalidate-listeners]
+   [re-frame.resources.registry :as rf.resources.registry]
+   [re-frame.resources.mutation-registry :as rf.resources.mutation-registry]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.subs :as rf.resources.subs]
+   [re-frame.resources.test-support :as rf.resources.test-support]
+   [re-frame.resources.timers :as rf.resources.timers]
+   [re-frame.resources.work-ledger :as rf.resources.work-ledger]
+   [re-frame.resources.revalidate-listeners :as rf.resources.revalidate-listeners]
    ;; production HTTP fx surface (so the transport feature probe resolves);
    ;; the actual fetch is overridden by the capturing no-op below.
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   [re-frame.trace.tooling :as trace-tooling]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport (decouples entry-state tests from HTTP) ----------
 
@@ -76,13 +76,13 @@
   ;; test body, so no per-suite generation-cache reset is needed here.
   ;; fx handlers are BINARY `(fn [ctx args] …)` (Spec 002 §binary
   ;; fx-handler signature) — capture the args (second arg).
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
   capturing-transport-fixture)
 
 ;; ---- helpers --------------------------------------------------------------
@@ -96,7 +96,7 @@
   :rf/default)."
   ([scoped-key] (entry :rf/default scoped-key))
   ([frame-id scoped-key]
-   (get-in (runtime-db frame-id) (state/entry-path scoped-key))))
+   (get-in (runtime-db frame-id) (rf.resources.state/entry-path scoped-key))))
 
 (defn- article-spec
   "A minimal valid resource spec (global scope, a slug param)."
@@ -143,22 +143,22 @@
 (deftest canonicalization-is-key-order-independent
   (testing "scoped key is identical regardless of map key order (Spec 016
             §Canonicalization rule)"
-    (let [k1 (state/scoped-resource-key {:tenant "acme" :user "u-42"}
+    (let [k1 (rf.resources.state/scoped-resource-key {:tenant "acme" :user "u-42"}
                                         :article/by-slug {:slug "x" :rev 1})
-          k2 (state/scoped-resource-key {:user "u-42" :tenant "acme"}
+          k2 (rf.resources.state/scoped-resource-key {:user "u-42" :tenant "acme"}
                                         :article/by-slug {:rev 1 :slug "x"})]
       (is (= k1 k2) "two spellings of the same scope + params collapse to one key")))
   (testing "nested maps recurse; sets / vectors keep value semantics"
-    (is (= (state/canonicalize {:a {:c 3 :b 2} :z #{2 1}})
-           (state/canonicalize {:z #{1 2} :a {:b 2 :c 3}})))))
+    (is (= (rf.resources.state/canonicalize {:a {:c 3 :b 2} :z #{2 1}})
+           (rf.resources.state/canonicalize {:z #{1 2} :a {:b 2 :c 3}})))))
 
 (deftest host-values-rejected-at-the-cache-key-boundary
   (testing "a host / opaque param value is rejected loudly (Spec 016
             §Resource identity)"
-    (is (false? (state/serializable-edn? {:f (fn [])})))
+    (is (false? (rf.resources.state/serializable-edn? {:f (fn [])})))
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-non-edn-params"
-          (state/reject-non-edn! {:f (fn [])} 'test :params :r/x)))))
+          (rf.resources.state/reject-non-edn! {:f (fn [])} 'test :params :r/x)))))
 
 ;; rf2-rplgkw — the redundant scope/params re-canonicalization on the resource
 ;; sub re-key hot path is collapsed: a trusted `scoped-resource-key*` for
@@ -170,43 +170,43 @@
   (testing "scoped-resource-key* (no re-canonicalize) yields the SAME key as
             the defensive scoped-resource-key when handed ALREADY-canonical
             scope + params — the dedup is behaviour-preserving"
-    (let [cscope  (state/canonicalize {:tenant "acme" :user "u-42"})
-          cparams (state/canonicalize {:slug "x" :rev 1})
-          trusted (state/scoped-resource-key* cscope :article/by-slug cparams)
-          defens  (state/scoped-resource-key cscope :article/by-slug cparams)]
+    (let [cscope  (rf.resources.state/canonicalize {:tenant "acme" :user "u-42"})
+          cparams (rf.resources.state/canonicalize {:slug "x" :rev 1})
+          trusted (rf.resources.state/scoped-resource-key* cscope :article/by-slug cparams)
+          defens  (rf.resources.state/scoped-resource-key cscope :article/by-slug cparams)]
       (is (= defens trusted) "same key vector")
-      (is (= (state/key-id defens) (state/key-id trusted)) "same byte key-id")))
+      (is (= (rf.resources.state/key-id defens) (rf.resources.state/key-id trusted)) "same byte key-id")))
   (testing "the defensive constructor still canonicalizes RAW (key-order-
             varying) input to the same identity scoped-resource-key* produces
             from the canonical value — so RAW direct/test/mutation callers keep
             working"
-    (let [raw-a (state/scoped-resource-key {:user "u-42" :tenant "acme"}
+    (let [raw-a (rf.resources.state/scoped-resource-key {:user "u-42" :tenant "acme"}
                                            :article/by-slug {:rev 1 :slug "x"})
-          raw-b (state/scoped-resource-key {:tenant "acme" :user "u-42"}
+          raw-b (rf.resources.state/scoped-resource-key {:tenant "acme" :user "u-42"}
                                            :article/by-slug {:slug "x" :rev 1})]
       (is (= raw-a raw-b) "key-order spellings collapse via the defensive path")
-      (is (= raw-a (state/scoped-resource-key*
-                     (state/canonicalize {:tenant "acme" :user "u-42"})
+      (is (= raw-a (rf.resources.state/scoped-resource-key*
+                     (rf.resources.state/canonicalize {:tenant "acme" :user "u-42"})
                      :article/by-slug
-                     (state/canonicalize {:rev 1 :slug "x"})))
+                     (rf.resources.state/canonicalize {:rev 1 :slug "x"})))
           "the trusted path on the canonical value matches the defensive path"))))
 
 (deftest canonicalize-or-rethrow-folds-validate-and-canonicalize
   (testing "on conforming input it returns the SAME value as canonicalize"
-    (is (= (state/canonicalize {:b 2 :a 1})
-           (state/canonicalize-or-rethrow {:a 1 :b 2} 'test :scope :r/x))
+    (is (= (rf.resources.state/canonicalize {:b 2 :a 1})
+           (rf.resources.state/canonicalize-or-rethrow {:a 1 :b 2} 'test :scope :r/x))
         "canonical result is identical to the two-step (reject + canonicalize)")
     (is (= :rf.scope/global
-           (state/canonicalize-or-rethrow :rf.scope/global 'test :scope :r/x))
+           (rf.resources.state/canonicalize-or-rethrow :rf.scope/global 'test :scope :r/x))
         "the bare global scope keyword canonicalizes to itself"))
   (testing "a host / opaque value re-throws the SAME public
             :rf.error/resource-non-edn-params category reject-non-edn! threw"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-non-edn-params"
-          (state/canonicalize-or-rethrow {:f (fn [])} 'test :scope :r/x)))
+          (rf.resources.state/canonicalize-or-rethrow {:f (fn [])} 'test :scope :r/x)))
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-non-edn-params"
-          (state/canonicalize-or-rethrow {:ratio 1.5} 'test :params :r/x)))))
+          (rf.resources.state/canonicalize-or-rethrow {:ratio 1.5} 'test :params :r/x)))))
 
 ;; rf2-wgutc2 (EP-0012 correctness review item 1): resource params + scopes
 ;; use the SHARED CEDN-1 identity rule (`re-frame.identity/canonical`), not a
@@ -220,26 +220,26 @@
   (testing "non-portable NUMBERS are rejected at the cache-key boundary
             (CEDN-1 admits only portable safe-range integers)"
     ;; floats / doubles
-    (is (false? (state/serializable-edn? {:ratio 1.5}))
+    (is (false? (rf.resources.state/serializable-edn? {:ratio 1.5}))
         "a float param is not a portable CEDN-1 identity")
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-non-edn-params"
-          (state/reject-non-edn! {:ratio 1.5} 'test :params :r/x))
+          (rf.resources.state/reject-non-edn! {:ratio 1.5} 'test :params :r/x))
         "a float param is rejected loudly")
     ;; out-of-safe-range integer (> 2^53 - 1) — diverges across hosts, so
     ;; CEDN-1 fails it closed.
-    (is (false? (state/serializable-edn? {:n 9007199254740993}))
+    (is (false? (rf.resources.state/serializable-edn? {:n 9007199254740993}))
         "an integer beyond the ECMAScript safe range is rejected")
     #?(:clj
        ;; ratios + bigdecimals only exist on the JVM
        (do
-         (is (false? (state/serializable-edn? {:r 1/3}))
+         (is (false? (rf.resources.state/serializable-edn? {:r 1/3}))
              "a ratio param is rejected")
-         (is (false? (state/serializable-edn? {:d 1.5M}))
+         (is (false? (rf.resources.state/serializable-edn? {:d 1.5M}))
              "a bigdecimal param is rejected"))))
   (testing "a plain safe-range integer param is STILL accepted (the common case)"
-    (is (true? (state/serializable-edn? {:rev 1 :page 42})))
-    (is (= {:rev 1 :page 42} (state/canonicalize {:page 42 :rev 1}))))
+    (is (true? (rf.resources.state/serializable-edn? {:rev 1 :page 42})))
+    (is (= {:rev 1 :page 42} (rf.resources.state/canonicalize {:page 42 :rev 1}))))
   (testing "list vs vector are DISTINCT EDN facts — never collapsed
             (Conventions §Sequences and sets)"
     ;; The prior resource-local canonicalize ACTIVELY COERCED lists to vectors
@@ -251,25 +251,25 @@
     ;; (`(= [1 2 3] '(1 2 3))` is true), so the distinction is at the
     ;; AUTHORITATIVE CEDN-1 identity level (EP-0012 disposition 5: the canonical
     ;; EDN value IS the identity, and equality-as-identity is CEDN-1 byte
-    ;; equality, `identity/identical-identity?`) — the vector encodes `v[…]`
+    ;; equality, `rf.identity/identical-identity?`) — the vector encodes `v[…]`
     ;; and the list encodes `l(…)`, distinct token streams.
-    (is (not (identity/identical-identity?
-               (state/canonicalize {:xs [1 2 3]})
-               (state/canonicalize {:xs '(1 2 3)})))
+    (is (not (rf.identity/identical-identity?
+               (rf.resources.state/canonicalize {:xs [1 2 3]})
+               (rf.resources.state/canonicalize {:xs '(1 2 3)})))
         "a vector value and a list value canonicalize to DISTINCT CEDN-1 identities")
-    (is (not (identity/identical-identity?
-               (state/scoped-resource-key :rf.scope/global :r/x {:xs [1 2 3]})
-               (state/scoped-resource-key :rf.scope/global :r/x {:xs '(1 2 3)})))
+    (is (not (rf.identity/identical-identity?
+               (rf.resources.state/scoped-resource-key :rf.scope/global :r/x {:xs [1 2 3]})
+               (rf.resources.state/scoped-resource-key :rf.scope/global :r/x {:xs '(1 2 3)})))
         "the scoped keys are distinct identities — list and vector params are
          not the same cache fact")
-    (is (vector? (:xs (state/canonicalize {:xs [1 2 3]})))
+    (is (vector? (:xs (rf.resources.state/canonicalize {:xs [1 2 3]})))
         "a vector value stays a vector")
-    (is (seq? (:xs (state/canonicalize {:xs '(1 2 3)})))
+    (is (seq? (:xs (rf.resources.state/canonicalize {:xs '(1 2 3)})))
         "a list value stays a list (not coerced to a vector — the prior
          resource-local canonicalizer's silent collapse is gone)"))
   (testing "key-order independence is preserved through the shared rule"
-    (is (= (state/canonicalize {:a 1 :b 2})
-           (state/canonicalize {:b 2 :a 1})))))
+    (is (= (rf.resources.state/canonicalize {:a 1 :b 2})
+           (rf.resources.state/canonicalize {:b 2 :a 1})))))
 
 ;; ===========================================================================
 ;; rf2-du585y — resource :params present-nil vs missing boundary
@@ -296,17 +296,17 @@
             identity from the absent-key case (EP-0012 §Missing vs present nil)"
     (let [spec (accepts-nil-spec)
           ;; explicit present-nil value vs the key absent entirely
-          present-nil (registry/validate+canonicalize-params :r/x spec {:x nil} 'test)
-          absent      (registry/validate+canonicalize-params :r/x spec {} 'test)]
+          present-nil (rf.resources.registry/validate+canonicalize-params :r/x spec {:x nil} 'test)
+          absent      (rf.resources.registry/validate+canonicalize-params :r/x spec {} 'test)]
       (is (= {:x nil} present-nil)
           "the present-nil param survives validation/canonicalization — not dropped to {}")
       (is (= {} absent) "the absent-key case canonicalizes to the empty map")
-      (is (not (identity/identical-identity? present-nil absent))
+      (is (not (rf.identity/identical-identity? present-nil absent))
           "present-nil and absent are DISTINCT canonical identities")
       ;; and therefore distinct cache keys
-      (is (not (identity/identical-identity?
-                 (state/scoped-resource-key :rf.scope/global :r/x present-nil)
-                 (state/scoped-resource-key :rf.scope/global :r/x absent)))
+      (is (not (rf.identity/identical-identity?
+                 (rf.resources.state/scoped-resource-key :rf.scope/global :r/x present-nil)
+                 (rf.resources.state/scoped-resource-key :rf.scope/global :r/x absent)))
           "the scoped resource keys differ — present-nil is its own cache fact"))))
 
 ;; rf2-hgy5kf (EP-0012) — the WHOLE-slot case the prior `(or params {})` at the
@@ -314,20 +314,20 @@
 ;; explicitly `nil` (`{:params nil}`) vs `:params` ABSENT (`{}`). Spec 016:70 +
 ;; EP-0012:1316 say present-nil and absent are DISTINCT unless explicitly
 ;; elided; the schema (not a blanket boundary default) decides whether the
-;; whole-slot nil conforms. `state/params-present?` threads the presence, and
-;; `state/default-omitted-params` applies the omitted-→`{}` policy ONLY to an
+;; whole-slot nil conforms. `rf.resources.state/params-present?` threads the presence, and
+;; `rf.resources.state/default-omitted-params` applies the omitted-→`{}` policy ONLY to an
 ;; absent slot — an explicit whole-slot nil reaches the schema unchanged.
 
 (deftest resource-explicit-nil-params-slot-distinct-from-omitted
   (testing "the presence helper distinguishes an explicit nil :params slot from
             an absent one (the distinction the old (or params {}) destroyed)"
-    (is (= nil (state/params-present? {:params nil}))
+    (is (= nil (rf.resources.state/params-present? {:params nil}))
         "a PRESENT explicit nil slot threads nil")
-    (is (= state/missing-params (state/params-present? {}))
+    (is (= rf.resources.state/missing-params (rf.resources.state/params-present? {}))
         "an ABSENT slot threads the missing sentinel")
-    (is (= {} (state/default-omitted-params (state/params-present? {})))
+    (is (= {} (rf.resources.state/default-omitted-params (rf.resources.state/params-present? {})))
         "an absent slot defaults to {} at the boundary")
-    (is (= nil (state/default-omitted-params (state/params-present? {:params nil})))
+    (is (= nil (rf.resources.state/default-omitted-params (rf.resources.state/params-present? {:params nil})))
         "an explicit nil slot passes THROUGH the default unchanged (not {})"))
   (testing "under a schema that ACCEPTS a nil params value ([:maybe :map]), an
             explicit whole-slot nil is preserved to the cache key and is a
@@ -335,18 +335,18 @@
     (let [spec {:scope         :rf.scope/global
                 :params-schema [:maybe :map]   ;; the whole params value may be nil
                 :request       (fn [_ _ctx] {:request {:method :get :url "/x"}})}
-          explicit-nil (registry/validate+canonicalize-params
-                         :r/x spec (state/params-present? {:params nil}) 'test)
-          omitted      (registry/validate+canonicalize-params
-                         :r/x spec (state/params-present? {}) 'test)]
+          explicit-nil (rf.resources.registry/validate+canonicalize-params
+                         :r/x spec (rf.resources.state/params-present? {:params nil}) 'test)
+          omitted      (rf.resources.registry/validate+canonicalize-params
+                         :r/x spec (rf.resources.state/params-present? {}) 'test)]
       (is (nil? explicit-nil)
           "explicit whole-slot nil survives validation — NOT coerced to {}")
       (is (= {} omitted) "the omitted slot defaults to {}")
-      (is (not (identity/identical-identity? explicit-nil omitted))
+      (is (not (rf.identity/identical-identity? explicit-nil omitted))
           "explicit-nil and omitted are DISTINCT canonical identities")
-      (is (not (identity/identical-identity?
-                 (state/scoped-resource-key :rf.scope/global :r/x explicit-nil)
-                 (state/scoped-resource-key :rf.scope/global :r/x omitted)))
+      (is (not (rf.identity/identical-identity?
+                 (rf.resources.state/scoped-resource-key :rf.scope/global :r/x explicit-nil)
+                 (rf.resources.state/scoped-resource-key :rf.scope/global :r/x omitted)))
           "the scoped resource keys differ — explicit-nil params is its own fact"))))
 
 (deftest resource-explicit-nil-params-slot-rejected-when-schema-rejects-nil
@@ -357,8 +357,8 @@
     (let [spec {:scope         :rf.scope/global
                 :params-schema [:map [:slug :string]]   ;; requires a map, rejects nil
                 :request       (fn [_ _] {:request {:method :get :url "/x"}})}
-          ex   (try (registry/validate+canonicalize-params
-                      :r/x spec (state/params-present? {:params nil}) 'test)
+          ex   (try (rf.resources.registry/validate+canonicalize-params
+                      :r/x spec (rf.resources.state/params-present? {:params nil}) 'test)
                     nil
                     (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) e e))]
       (is (some? ex)
@@ -375,8 +375,8 @@
     (let [spec {:scope         :rf.scope/global
                 :params-schema [:map [:slug :string]]
                 :request       (fn [_ _] {:request {:method :post :url "/x"}})}
-          ex   (try (mreg/validate+canonicalize-params
-                      :m/x spec (state/params-present? {:params nil}) 'test)
+          ex   (try (rf.resources.mutation-registry/validate+canonicalize-params
+                      :m/x spec (rf.resources.state/params-present? {:params nil}) 'test)
                     nil
                     (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) e e))]
       (is (some? ex) "an explicit nil mutation params slot against [:map] throws")
@@ -386,8 +386,8 @@
     (testing "an OMITTED mutation params slot still defaults to {} (API policy)"
       (let [spec {:scope :rf.scope/global :params-schema [:map]
                   :request (fn [_ _] {:request {:method :post :url "/x"}})}]
-        (is (= {} (mreg/validate+canonicalize-params
-                    :m/x spec (state/params-present? {}) 'test)))))))
+        (is (= {} (rf.resources.mutation-registry/validate+canonicalize-params
+                    :m/x spec (rf.resources.state/params-present? {}) 'test)))))))
 
 (deftest resource-present-nil-rejected-when-schema-rejects-nil
   (testing "under a schema that REJECTS nil ([:map [:x :string]]), an explicit
@@ -396,7 +396,7 @@
     (let [spec {:scope         :rf.scope/global
                 :params-schema [:map [:x :string]]   ;; :x is required + non-nil
                 :request       (fn [_ _] {:request {:method :get :url "/x"}})}
-          ex   (try (registry/validate+canonicalize-params :r/x spec {:x nil} 'test)
+          ex   (try (rf.resources.registry/validate+canonicalize-params :r/x spec {:x nil} 'test)
                     nil
                     (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) e e))]
       (is (some? ex) "a nil value against a non-nil schema throws")
@@ -415,7 +415,7 @@
 ;; (a list value stays a list, distinct from a vector — rf2-wgutc2), but it is
 ;; NO LONGER used directly as a Clojure map key. The `:entries` map, the
 ;; reverse indexes, and the work-ledger map are keyed on the CEDN-1 byte
-;; `key-id` (`state/key-id` / `work-ledger/work-id-id`), so the map-key
+;; `key-id` (`rf.resources.state/key-id` / `rf.resources.work-ledger/work-id-id`), so the map-key
 ;; comparison is EXACTLY the CEDN-1 byte identity. Clojure `=` collapses
 ;; `(= [1 2 3] '(1 2 3))` to TRUE, but two distinct `canonical-bytes` strings
 ;; never collapse — so a list-params key and a vector-params key get DISTINCT
@@ -425,9 +425,9 @@
 ;; CEDN-1 kind distinction rf2-wgutc2 introduced — the test above).
 (deftest list-vs-vector-params-get-distinct-entries-rf2-9e0tyq
   (testing "list-vs-vector params keys carry DISTINCT CEDN-1 identities..."
-    (let [kv (state/scoped-resource-key :rf.scope/global :r/x {:xs [1 2 3]})
-          kl (state/scoped-resource-key :rf.scope/global :r/x {:xs '(1 2 3)})]
-      (is (not (identity/identical-identity? kv kl))
+    (let [kv (rf.resources.state/scoped-resource-key :rf.scope/global :r/x {:xs [1 2 3]})
+          kl (rf.resources.state/scoped-resource-key :rf.scope/global :r/x {:xs '(1 2 3)})]
+      (is (not (rf.identity/identical-identity? kv kl))
           "the authoritative identities differ (v[...] vs l(...))")
       ;; Clojure `=` still treats the VECTORS as equal — but the cache no longer
       ;; keys on the vector; it keys on the byte `key-id`, which is DISTINCT.
@@ -435,34 +435,34 @@
           "Clojure value = treats the vector- and list-params VECTORS as equal …")
       (testing "...and now resolve to DISTINCT :entries entries (the byte key-id
                 comparison is exactly the CEDN-1 identity — the fix)"
-        (is (not= (state/key-id kv) (state/key-id kl))
+        (is (not= (rf.resources.state/key-id kv) (rf.resources.state/key-id kl))
             "their byte key-ids differ (v[…] vs l(…)) — the map-key identity")
         (is (= 2 (count (-> {}
-                            (assoc (state/key-id kv) :v)
-                            (assoc (state/key-id kl) :l))))
+                            (assoc (rf.resources.state/key-id kv) :v)
+                            (assoc (rf.resources.state/key-id kl) :l))))
             "both keys map to TWO distinct entries — the =-collapse is closed")
         (is (= :v (get (-> {}
-                           (assoc (state/key-id kv) :v)
-                           (assoc (state/key-id kl) :l))
-                       (state/key-id kv)))
+                           (assoc (rf.resources.state/key-id kv) :v)
+                           (assoc (rf.resources.state/key-id kl) :l))
+                       (rf.resources.state/key-id kv)))
             "the vector-params entry is NOT overwritten by the list-params write"))
       ;; carrier 2 — the embedded work-id is keyed on its OWN byte id too, so
       ;; the two work-ledger slots stay distinct (stale suppression keys on the
       ;; entry's :current-work + the entry lookup, both byte-disambiguated).
       (testing "...and the embedded work-id keys on its own byte id (carrier 2)"
-        (let [wv (work-ledger/resource-work-id kv 1)
-              wl (work-ledger/resource-work-id kl 1)]
+        (let [wv (rf.resources.work-ledger/resource-work-id kv 1)
+              wl (rf.resources.work-ledger/resource-work-id kl 1)]
           (is (= wv wl) "the work-id VECTORS are still `=` (they embed the key vector) …")
-          (is (not= (work-ledger/work-id-id wv) (work-ledger/work-id-id wl))
+          (is (not= (rf.resources.work-ledger/work-id-id wv) (rf.resources.work-ledger/work-id-id wl))
               "…but their byte work-id-ids differ — distinct ledger slots")
           (is (= 2 (count (-> {}
-                              (assoc (work-ledger/work-id-id wv) :v)
-                              (assoc (work-ledger/work-id-id wl) :l))))
+                              (assoc (rf.resources.work-ledger/work-id-id wv) :v)
+                              (assoc (rf.resources.work-ledger/work-id-id wl) :l))))
               "both work-ids map to TWO distinct work-ledger slots")))))
   ;; The other CEDN-distinct params kinds were already `=`-distinct and stay
   ;; keyed correctly (the fix never regresses them).
   (testing "every other CEDN-distinct params kind also keys distinctly"
-    (let [k (fn [params] (state/key-id (state/scoped-resource-key :rf.scope/global :r/x params)))]
+    (let [k (fn [params] (rf.resources.state/key-id (rf.resources.state/scoped-resource-key :rf.scope/global :r/x params)))]
       (is (= 3 (count (-> {} (assoc (k {:v "1"}) :s) (assoc (k {:v 1}) :i) (assoc (k {:v :a}) :k))))
           "string / integer / keyword params keep distinct cache entries")
       (is (= 2 (count (-> {} (assoc (k {:v #{1 2}}) :set) (assoc (k {:v [1 2]}) :vec))))
@@ -480,20 +480,20 @@
             (Spec 016 §Scope resolution — no global fallthrough)"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-scope-required-from-caller"
-          (registry/resolve-scope-for-event
-            :sr/from-caller (registry/resource-meta :sr/from-caller)
+          (rf.resources.registry/resolve-scope-for-event
+            :sr/from-caller (rf.resources.registry/resource-meta :sr/from-caller)
             {:payload-scope nil} 'test))))
   (testing "from-caller WITH a payload scope resolves to that scope"
     (is (= {:user "u-1"}
-           (registry/resolve-scope-for-event
-             :sr/from-caller (registry/resource-meta :sr/from-caller)
+           (rf.resources.registry/resolve-scope-for-event
+             :sr/from-caller (rf.resources.registry/resource-meta :sr/from-caller)
              {:payload-scope {:user "u-1"}} 'test))))
   (testing "an explicit :rf.scope/global policy resolves to global (its
             declared policy, not a fallthrough)"
     (rf/reg-resource :sr/global (article-spec) article-spec-request)
     (is (= :rf.scope/global
-           (registry/resolve-scope-for-event
-             :sr/global (registry/resource-meta :sr/global) {} 'test)))))
+           (rf.resources.registry/resolve-scope-for-event
+             :sr/global (rf.resources.registry/resource-meta :sr/global) {} 'test)))))
 
 (deftest sub-side-scope-fail-closed
   (rf/reg-resource :ss/from-caller (article-spec {:scope :rf.scope/from-caller}) article-spec-request)
@@ -502,13 +502,13 @@
             read / :idle) — Spec 016 §Subscription-side scope resolution"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-sub-unresolved-scope"
-          (subs/resolve-scoped-key {:resource :ss/from-caller :params {:slug "x"}} {})))))
+          (rf.resources.subs/resolve-scoped-key {:resource :ss/from-caller :params {:slug "x"}} {})))))
 
 ;; ===========================================================================
 ;; 2b. The registration guard on the READ path (rf2-w67y)
 ;; ===========================================================================
 ;;
-;; `registry/require-resource-spec!` is the read-path twin of the mutation
+;; `rf.resources.registry/require-resource-spec!` is the read-path twin of the mutation
 ;; registrar's `require-mutation-spec!`. It is the loud, fail-closed boundary
 ;; behind SIX public surfaces — the four `:rf.resource/*` event handlers
 ;; (`ensure` / `refetch` / `remove`, plus the `:rf.resource/*` internal
@@ -533,7 +533,7 @@
   ;; rather than a half-built one, exactly as the mutation twin refuses
   ;; before minting its instance.
   (testing "Spec 016 §Public API — an unregistered resource id REFUSES"
-    (let [scoped-key (state/scoped-resource-key :rf.scope/global :r/nope {:slug "w"})
+    (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :r/nope {:slug "w"})
           recs (record-error-records!
                  #(rf/dispatch-sync [:rf.resource/ensure
                                      {:resource :r/nope :scope :rf.scope/global
@@ -578,7 +578,7 @@
                    (fn [{:keys [slug]} _ctx]
                      {:request {:method :post :url (str "/api/articles/" slug)}}))
   (testing "a MUTATION id passed as :resource refuses like any unknown id"
-    (let [scoped-key (state/scoped-resource-key :rf.scope/global :m/save {:slug "w"})
+    (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :m/save {:slug "w"})
           recs (record-error-records!
                  #(rf/dispatch-sync [:rf.resource/ensure
                                      {:resource :m/save :scope :rf.scope/global
@@ -600,7 +600,7 @@
   ;; over-eager guard shows up here as a spurious record on an otherwise
   ;; working read, which no other assertion in this suite would notice.
   (rf/reg-resource :r/ok (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :r/ok {:slug "w"})
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :r/ok {:slug "w"})
         recs (record-error-records!
                #(rf/dispatch-sync [:rf.resource/ensure
                                    {:resource :r/ok :scope :rf.scope/global
@@ -616,13 +616,13 @@
 (deftest status-transition-fn-is-pure
   (testing "Spec 016 §Lifecycle is an FSM — a pure transition fn over the
             five states"
-    (is (= :loading  (state/next-status :idle    :start-load false)))
-    (is (= :fetching (state/next-status :loaded  :start-load true)))
-    (is (= :loaded   (state/next-status :loading :success   false)))
-    (is (= :error    (state/next-status :loading :failure   false)))
+    (is (= :loading  (rf.resources.state/next-status :idle    :start-load false)))
+    (is (= :fetching (rf.resources.state/next-status :loaded  :start-load true)))
+    (is (= :loaded   (rf.resources.state/next-status :loading :success   false)))
+    (is (= :error    (rf.resources.state/next-status :loading :failure   false)))
     ;; background-refresh failure returns to :loaded (data kept)
-    (is (= :loaded   (state/next-status :fetching :failure  true)))
-    (is (= :loading  (state/next-status :error    :start-load false)))))
+    (is (= :loaded   (rf.resources.state/next-status :fetching :failure  true)))
+    (is (= :loading  (rf.resources.state/next-status :error    :start-load false)))))
 
 ;; ===========================================================================
 ;; 4. ensure → :loading → succeeded → :loaded  +  structural sharing
@@ -630,7 +630,7 @@
 
 (deftest ensure-then-success-loaded
   (rf/reg-resource :a/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :a/article {:slug "welcome"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :a/article {:slug "welcome"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :a/article :scope :rf.scope/global
                         :params {:slug "welcome"} :owner [:app :test 1]}])
@@ -667,7 +667,7 @@
 
 (deftest structural-sharing-preserves-identical-data
   (rf/reg-resource :ss/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :ss/article {:slug "w"})
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :ss/article {:slug "w"})
         data1      {:title "Welcome" :body [1 2 3]}]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :ss/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:app :ss 1]}])
@@ -693,7 +693,7 @@
 
 (deftest refresh-failure-keeps-data
   (rf/reg-resource :rf2/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :rf2/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :rf2/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :rf2/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:app :rf2 1]}])
     (let [wid1 (:current-work (entry scoped-key))]
@@ -719,7 +719,7 @@
 
 (deftest first-load-failure-error
   (rf/reg-resource :fl/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :fl/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :fl/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :fl/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:app :fl 1]}])
     (let [wid (:current-work (entry scoped-key))]
@@ -738,7 +738,7 @@
 
 (deftest stale-reply-is-suppressed
   (rf/reg-resource :st/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :st/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :st/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :st/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:app :st 1]}])
     (let [wid1 (:current-work (entry scoped-key))]
@@ -763,7 +763,7 @@
 
 (deftest ensure-dedupes-in-flight
   (rf/reg-resource :dd/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :dd/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :dd/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :dd/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:route :r 1]}])
     (let [gen1 (:generation (entry scoped-key))]
@@ -784,7 +784,7 @@
   (rf/reg-resource :iso/article (article-spec) article-spec-request)
   (let [fa :iso/frame-a
         fb :iso/frame-b
-        scoped-key (state/scoped-resource-key :rf.scope/global :iso/article {:slug "w"})]
+        scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :iso/article {:slug "w"})]
     (rf/make-frame {:id fa :doc "isolation frame A"})
     (rf/make-frame {:id fb :doc "isolation frame B"})
     (testing "Spec 016 — resources are per-frame isolated; a resource
@@ -800,8 +800,8 @@
                           {:frame fa}))
       (is (= {:title "A"} (:data (entry fa scoped-key))) "frame A has the entry")
       (is (nil? (entry fb scoped-key)) "frame B has NO entry (isolated)"))
-    (frame/destroy-frame! fa)
-    (frame/destroy-frame! fb)))
+    (rf.frame/destroy-frame! fa)
+    (rf.frame/destroy-frame! fb)))
 
 ;; ===========================================================================
 ;; 9. Passive subscriptions (none fetch)
@@ -809,7 +809,7 @@
 
 (deftest passive-subs-project-the-entry
   (rf/reg-resource :sub/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :sub/article {:slug "w"})
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :sub/article {:slug "w"})
         q          {:resource :sub/article :scope :rf.scope/global :params {:slug "w"}}]
     (testing "before any load the state projection is the idle empty-state
               (a sub NEVER fetches — Spec 016 §Subscriptions)"
@@ -833,7 +833,7 @@
 
 (deftest stale-sub-derives-from-facts
   (rf/reg-resource :stl/article (article-spec {:stale-after-ms 60000}) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :stl/article {:slug "w"})
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :stl/article {:slug "w"})
         q          {:resource :stl/article :scope :rf.scope/global :params {:slug "w"}}]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :stl/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:app :st 1]}])
@@ -863,7 +863,7 @@
   ;; the reply handler. Scripting the reply dispatch's :rf.cofx pins
   ;; both; the same reply token rewrites the same durable timestamps.
   (rf/reg-resource :lra/article (article-spec {:stale-after-ms 60000}) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :lra/article {:slug "w"})
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :lra/article {:slug "w"})
         completed-at 1781078400456]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :lra/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:app :lr 1]}])
@@ -892,7 +892,7 @@
 ;; pins against.
 (deftest fresh-skip-decision-reads-causal-time-ms-not-ambient-clock
   (rf/reg-resource :fsd/article (article-spec {:stale-after-ms 60000}) article-spec-request)
-  (let [scoped-key  (state/scoped-resource-key :rf.scope/global :fsd/article {:slug "w"})
+  (let [scoped-key  (rf.resources.state/scoped-resource-key :rf.scope/global :fsd/article {:slug "w"})
         t0          1000000          ;; a SMALL scripted epoch-ms (a "recorded
         ;; run" basis far below the live host clock). The entry loads at t0 and
         ;; is fresh until t0 + 60000.
@@ -948,7 +948,7 @@
 
 (deftest release-owner-drops-the-owner
   (rf/reg-resource :ro/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :ro/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :ro/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :ro/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:app :ro 1]}])
     (is (contains? (:active-owners (entry scoped-key)) [:app :ro 1]))
@@ -956,14 +956,14 @@
     (testing "Spec 016 §Active owners — release drops the owner from the
               entry + the owner-index"
       (is (not (contains? (:active-owners (entry scoped-key)) [:app :ro 1])))
-      (is (nil? (get-in (runtime-db) (conj (state/owner-index-path) [:app :ro 1])))))))
+      (is (nil? (get-in (runtime-db) (conj (rf.resources.state/owner-index-path) [:app :ro 1])))))))
 
 (deftest clear-scope-removes-scoped-entries
   (rf/reg-resource :cs/article (article-spec {:scope :rf.scope/from-caller}) article-spec-request)
   (let [scope-a {:user "a"}
         scope-b {:user "b"}
-        ka (state/scoped-resource-key scope-a :cs/article {:slug "w"})
-        kb (state/scoped-resource-key scope-b :cs/article {:slug "w"})]
+        ka (rf.resources.state/scoped-resource-key scope-a :cs/article {:slug "w"})
+        kb (rf.resources.state/scoped-resource-key scope-b :cs/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :cs/article :scope scope-a
                                             :params {:slug "w"} :owner [:app :a 1]}])
     (rf/dispatch-sync [:rf.resource/ensure {:resource :cs/article :scope scope-b
@@ -978,7 +978,7 @@
 
 (deftest invalidate-tags-marks-stale-and-refetches-active
   (rf/reg-resource :it/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :it/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :it/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :it/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:route :r 1]}])
     (let [wid (:current-work (entry scoped-key))]
@@ -998,7 +998,7 @@
 
 (deftest remove-evicts-the-entry
   (rf/reg-resource :rm/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :rm/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :rm/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :rm/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:app :rm 1]}])
     (is (some? (entry scoped-key)))
@@ -1018,7 +1018,7 @@
           k2 [:rf.scope/global :r/b {:id 2}]
           subtree {:entries {k1 {:tags #{:t1 :shared} :active-owners #{[:app 1]}}
                              k2 {:tags #{:t2 :shared} :active-owners #{[:app 1]}}}}
-          rebuilt (state/recompute-indexes subtree)]
+          rebuilt (rf.resources.state/recompute-indexes subtree)]
       (is (= #{k1 k2} (get-in rebuilt [:tag-index :shared])))
       (is (= #{k1}    (get-in rebuilt [:tag-index :t1])))
       (is (= #{k1 k2} (get-in rebuilt [:owner-index [:app 1]]))))))
@@ -1042,10 +1042,10 @@
           ;; entries transition (subtree carries the OLD indexes built by a
           ;; prior full rebuild — the realistic pre-mutation shape).
           check (fn [old-entries new-entries touched]
-                  (let [old-subtree (state/recompute-indexes {:entries old-entries})
+                  (let [old-subtree (rf.resources.state/recompute-indexes {:entries old-entries})
                         new-subtree (assoc old-subtree :entries new-entries)
-                        incremental (state/reindex-keys new-subtree old-entries touched)
-                        full        (state/recompute-indexes new-subtree)]
+                        incremental (rf.resources.state/reindex-keys new-subtree old-entries touched)
+                        full        (rf.resources.state/recompute-indexes new-subtree)]
                     (is (= (:tag-index full)   (:tag-index incremental))
                         (str "tag-index drift on touched " (vec touched)))
                     (is (= (:owner-index full) (:owner-index incremental))
@@ -1102,7 +1102,7 @@
              entries {}
              ;; the incrementally maintained subtree (indexes derived from the
              ;; SAME entries via reindex-keys after each step).
-             subtree (state/recompute-indexes {:entries {}})]
+             subtree (rf.resources.state/recompute-indexes {:entries {}})]
         (if (= step 600)
           (is true "600 randomised mutations stayed in lock-step with the rebuild")
           (let [k        (nth key-ids (nextint (count key-ids)))
@@ -1111,9 +1111,9 @@
                               (dissoc entries k)
                               (assoc entries k {:tags          (rand-set tags)
                                                 :active-owners (rand-set owners)}))
-                incremental (state/reindex-keys (assoc subtree :entries new-entries)
+                incremental (rf.resources.state/reindex-keys (assoc subtree :entries new-entries)
                                                 entries [k])
-                full        (state/recompute-indexes {:entries new-entries})]
+                full        (rf.resources.state/recompute-indexes {:entries new-entries})]
             (is (= (:tag-index full) (:tag-index incremental))
                 (str "tag-index drift at step " step " key " k))
             (is (= (:owner-index full) (:owner-index incremental))
@@ -1130,8 +1130,8 @@
 
 (deftest resource-kind-registered
   (testing "the :resource registrar kind is valid (skeleton invariant held)"
-    (is (registrar/valid-kind? :resource))
-    (is (not (registrar/valid-kind? :query)))))
+    (is (rf.registrar/valid-kind? :resource))
+    (is (not (rf.registrar/valid-kind? :query)))))
 
 ;; ===========================================================================
 ;; 13. Concrete-scope typo rejection at resolution boundaries (rf2-pd7akw)
@@ -1139,35 +1139,35 @@
 
 (deftest reserved-scope-typo-rejected-at-concrete-boundaries
   (rf/reg-resource :tp/article (article-spec {:scope :rf.scope/from-caller}) article-spec-request)
-  (let [spec (registry/resource-meta :tp/article)]
+  (let [spec (rf.resources.registry/resource-meta :tp/article)]
     (testing "rf2-pd7akw — a misspelled reserved :rf.scope/* keyword on an
               EVENT payload is rejected fail-closed (never a silent wrong
               cache scope)"
       (is (thrown-with-msg?
             #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
-            (registry/resolve-scope-for-event
+            (rf.resources.registry/resolve-scope-for-event
               :tp/article spec {:payload-scope :rf.scope/glabal} 'test))))
     (testing "rf2-pd7akw — a misspelled reserved :rf.scope/* keyword on a
               SUBSCRIPTION payload is rejected fail-closed too"
       (is (thrown-with-msg?
             #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
-            (registry/resolve-scope-for-sub
+            (rf.resources.registry/resolve-scope-for-sub
               :tp/article spec :rf.scope/sesssion 'test {}))))
     (testing "rf2-pd7akw — :rf.scope/from-caller reaching a CONCRETE boundary
               as a payload value (not a policy) is a typo-class rejection"
       (is (thrown-with-msg?
             #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
-            (registry/resolve-scope-for-event
+            (rf.resources.registry/resolve-scope-for-event
               :tp/article spec {:payload-scope :rf.scope/from-caller} 'test))))
     (testing "an APP-namespaced keyword scope is a legitimate literal scope
               (only the framework-reserved namespace is fail-closed)"
       (is (= :my.app/tenant
-             (registry/resolve-scope-for-event
+             (rf.resources.registry/resolve-scope-for-event
                :tp/article spec {:payload-scope :my.app/tenant} 'test))))
     (testing "a vector-tuple scope [:rf.scope/session {…}] is a value, not a
               bare-keyword typo — accepted"
       (is (= [:rf.scope/session {:tenant "acme"}]
-             (registry/resolve-scope-for-event
+             (rf.resources.registry/resolve-scope-for-event
                :tp/article spec {:payload-scope [:rf.scope/session {:tenant "acme"}]}
                'test))))))
 
@@ -1180,20 +1180,20 @@
 (deftest singleton-vector-global-rejected-fail-closed
   (testing "rf2-bwwk6l — the bare :rf.scope/global is the canonical concrete
             global scope and canonicalizes unchanged"
-    (is (= :rf.scope/global (state/canonicalize-scope :rf.scope/global 'test :r/x))))
+    (is (= :rf.scope/global (rf.resources.state/canonicalize-scope :rf.scope/global 'test :r/x))))
   (testing "rf2-bwwk6l — the singleton-vector [:rf.scope/global] spelling is
             NO LONGER accepted as a global alias; it fails closed at the shared
             canonicalize boundary, naming the canonical bare spelling"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
-          (state/canonicalize-scope [:rf.scope/global] 'test :r/x))))
+          (rf.resources.state/canonicalize-scope [:rf.scope/global] 'test :r/x))))
   (testing "rf2-bwwk6l — a sub payload carrying the wrapped [:rf.scope/global]
             spelling fails closed too (never a silent read of the bare global
             entry)"
     (rf/reg-resource :gv/article (article-spec) article-spec-request)
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
-          (subs/resolve-scoped-key {:resource :gv/article
+          (rf.resources.subs/resolve-scoped-key {:resource :gv/article
                                     :scope [:rf.scope/global]
                                     :params {:slug "w"}}
                                    {})))))
@@ -1204,8 +1204,8 @@
 
 (deftest clear-resource-disposes-runtime-state
   (rf/reg-resource :cr/article (article-spec) article-spec-request)
-  (let [loaded-key  (state/scoped-resource-key :rf.scope/global :cr/article {:slug "loaded"})
-        inflight-key (state/scoped-resource-key :rf.scope/global :cr/article {:slug "inflight"})]
+  (let [loaded-key  (rf.resources.state/scoped-resource-key :rf.scope/global :cr/article {:slug "loaded"})
+        inflight-key (rf.resources.state/scoped-resource-key :rf.scope/global :cr/article {:slug "inflight"})]
     ;; one LOADED entry (with tags + an active owner → indexed)
     (rf/dispatch-sync [:rf.resource/ensure {:resource :cr/article :scope :rf.scope/global
                                             :params {:slug "loaded"} :owner [:app :cr 1]}])
@@ -1218,34 +1218,34 @@
                                             :params {:slug "inflight"} :owner [:app :cr 2]}])
     (is (= :loaded (:status (entry loaded-key))))
     (is (some? (:current-work (entry inflight-key))) "in-flight entry has live work")
-    (is (seq (get-in (runtime-db) (state/tag-index-path))) "tag index populated")
-    (is (seq (get-in (runtime-db) (state/owner-index-path))) "owner index populated")
+    (is (seq (get-in (runtime-db) (rf.resources.state/tag-index-path))) "tag index populated")
+    (is (seq (get-in (runtime-db) (rf.resources.state/owner-index-path))) "owner index populated")
     (let [inflight-wid (:current-work (entry inflight-key))]
       ;; CLEAR the resource (registration-lifecycle + runtime disposal)
-      (registry/clear-resource :cr/article)
+      (rf.resources.registry/clear-resource :cr/article)
       (testing "rf2-m9h5iq — clear-resource removes the registrar entry"
-        (is (nil? (registry/resource-meta :cr/article))))
+        (is (nil? (rf.resources.registry/resource-meta :cr/article))))
       (testing "rf2-m9h5iq — every live entry for the id is removed from
                 :rf.runtime/resources :entries"
         (is (nil? (entry loaded-key)))
         (is (nil? (entry inflight-key))))
       (testing "rf2-m9h5iq — reverse indexes are recomputed/pruned"
-        (is (empty? (get-in (runtime-db) (state/tag-index-path))))
-        (is (empty? (get-in (runtime-db) (state/owner-index-path)))))
+        (is (empty? (get-in (runtime-db) (rf.resources.state/tag-index-path))))
+        (is (empty? (get-in (runtime-db) (rf.resources.state/owner-index-path)))))
       (testing "rf2-m9h5iq — the in-flight work record is settled terminal
                 (:suppressed) so the ledger row is not left in-flight"
         ;; Read through the byte-keyed work-ledger API (rf2-hgy5kf): the row is
-        ;; addressed by `work-ledger/work-id-id`, NOT the stale vector key. The
+        ;; addressed by `rf.resources.work-ledger/work-id-id`, NOT the stale vector key. The
         ;; assertion is NON-vacuous — a present post-clear row MUST be terminal
         ;; (`:suppressed`), and a present-but-NON-terminal row FAILS the test
         ;; (the exact drift EP-0012 closes; the old `(when rec …)` made it pass
         ;; silently when the byte-keyed row was read through a dead address).
-        (let [rec (work-ledger/get-record (runtime-db) inflight-wid)]
+        (let [rec (rf.resources.work-ledger/get-record (runtime-db) inflight-wid)]
           (is (some? rec)
               "the post-clear work record MUST be readable through the byte-keyed
                address — a nil here means the contract is asserted against a dead
                address, the exact vacuity EP-0012 closes")
-          (is (work-ledger/terminal? (:status rec))
+          (is (rf.resources.work-ledger/terminal? (:status rec))
               "a present post-clear work record must be terminal, never in-flight")
           (is (= :suppressed (:status rec)))))
       (testing "rf2-m9h5iq — a LATE reply for a cleared in-flight entry cannot
@@ -1265,19 +1265,19 @@
             :rf.scope/* typo is rejected through the same path resources use"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
-          (mreg/resolve-scope :m/x {} :rf.scope/glabal {}))))
+          (rf.resources.mutation-registry/resolve-scope :m/x {} :rf.scope/glabal {}))))
   (testing "rf2-lzv9xc — a host / opaque mutation scope value is rejected"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-non-edn-params"
-          (mreg/resolve-scope :m/x {} {:fn (fn [])} {}))))
+          (rf.resources.mutation-registry/resolve-scope :m/x {} {:fn (fn [])} {}))))
   (testing "rf2-lzv9xc — the default global scope still resolves to the bare
             :rf.scope/global"
-    (is (= :rf.scope/global (mreg/resolve-scope :m/x {} nil {}))))
+    (is (= :rf.scope/global (rf.resources.mutation-registry/resolve-scope :m/x {} nil {}))))
   (testing "rf2-bwwk6l — the wrapped [:rf.scope/global] singleton is rejected
             fail-closed (no back-compat alias); supply the bare keyword"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
-          (mreg/resolve-scope :m/x {} [:rf.scope/global] {})))))
+          (rf.resources.mutation-registry/resolve-scope :m/x {} [:rf.scope/global] {})))))
 
 ;; ===========================================================================
 ;; 17. resource-state fails closed without an explicit frame (rf2-c8lgy3)
@@ -1298,7 +1298,7 @@
                 {:resource :rs/article :scope :rf.scope/global
                  :params {:slug "absent"} :frame :rf/default}))))
   (testing "rf2-c8lgy3 — a valid explicit frame returns the entry when present"
-    (let [k (state/scoped-resource-key :rf.scope/global :rs/article {:slug "w"})]
+    (let [k (rf.resources.state/scoped-resource-key :rf.scope/global :rs/article {:slug "w"})]
       (rf/dispatch-sync [:rf.resource/ensure {:resource :rs/article :scope :rf.scope/global
                                               :params {:slug "w"} :owner [:app 1]}])
       (let [wid (:current-work (entry k))]
@@ -1325,8 +1325,8 @@
             `=`-colliding scoped-key vector (the original rf2-jtlq7l approach)
             collapsed a list-params and a vector-params entry onto one map key"
     (rf/reg-resource :intro/article (article-spec) article-spec-request)
-    (let [k1 (state/scoped-resource-key :rf.scope/global :intro/article {:slug "one"})
-          k2 (state/scoped-resource-key :rf.scope/global :intro/article {:slug "two"})]
+    (let [k1 (rf.resources.state/scoped-resource-key :rf.scope/global :intro/article {:slug "one"})
+          k2 (rf.resources.state/scoped-resource-key :rf.scope/global :intro/article {:slug "two"})]
       ;; Install two entries with DISTINCT scoped keys (distinct byte key-ids).
       (rf/dispatch-sync [:rf.resource/ensure {:resource :intro/article :scope :rf.scope/global
                                               :params {:slug "one"} :owner [:app :intro 1]}])
@@ -1336,11 +1336,11 @@
         (testing "the static registry still lists the registered id"
           (is (contains? (set resource-ids) :intro/article)))
         (testing "entry keys are the CEDN-1 byte key-id STRINGS (collapse-proof)"
-          (is (= #{(state/key-id k1) (state/key-id k2)} (set (keys entries)))
+          (is (= #{(rf.resources.state/key-id k1) (rf.resources.state/key-id k2)} (set (keys entries)))
               "the public accessor keys by the byte key-id, matching internal storage")
           (is (every? string? (keys entries))
               "every entry key is the byte key-id string")
-          (is (contains? entries (state/key-id k1))
+          (is (contains? entries (rf.resources.state/key-id k1))
               "the byte key-id IS the public entry key"))
         (testing "each entry carries its kind-preserving :resource/key VECTOR for
                   destructure + scope/resource filtering (the rf2-jtlq7l goal,
@@ -1363,8 +1363,8 @@
               "every entry filters cleanly by scope + resource-id"))
         (testing "the entry value is carried through unchanged (byte-keyed
                   in internal storage too)"
-          (is (= :intro/article (-> entries (get (state/key-id k1)) :resource/key second)))
-          (let [raw (get-in (:rf.db/runtime (rf/frame-state-value :rf/default)) (state/entries-path))]
+          (is (= :intro/article (-> entries (get (rf.resources.state/key-id k1)) :resource/key second)))
+          (let [raw (get-in (:rf.db/runtime (rf/frame-state-value :rf/default)) (rf.resources.state/entries-path))]
             (is (every? string? (keys raw))
                 "internal runtime storage remains byte-keyed (string key-ids)")))))))
 
@@ -1375,29 +1375,29 @@
             list params). The former vector-rekey `assoc`'d one entry OVER the
             other (the `=`-collapse), reporting ONE entry for TWO live ones"
     (rf/reg-resource :intro/article (article-spec) article-spec-request)
-    (let [kv (state/scoped-resource-key :rf.scope/global :intro/article {:xs [1 2 3]})
-          kl (state/scoped-resource-key :rf.scope/global :intro/article {:xs '(1 2 3)})
-          ev (assoc (state/empty-entry :intro/article kv) :status :loaded :data {:v 1})
-          el (assoc (state/empty-entry :intro/article kl) :status :loaded :data {:l 1})]
+    (let [kv (rf.resources.state/scoped-resource-key :rf.scope/global :intro/article {:xs [1 2 3]})
+          kl (rf.resources.state/scoped-resource-key :rf.scope/global :intro/article {:xs '(1 2 3)})
+          ev (assoc (rf.resources.state/empty-entry :intro/article kv) :status :loaded :data {:v 1})
+          el (assoc (rf.resources.state/empty-entry :intro/article kl) :status :loaded :data {:l 1})]
       (is (= kv kl) "the scoped-key VECTORS are Clojure-= (the collapse routed around)")
-      (is (not= (state/key-id kv) (state/key-id kl)) "their byte key-ids differ")
+      (is (not= (rf.resources.state/key-id kv) (rf.resources.state/key-id kl)) "their byte key-ids differ")
       ;; write both entries the runtime way (byte-keyed paths) — a `{kv .. kl ..}`
       ;; literal would itself throw `Duplicate key` (kv and kl are Clojure-=).
-      (frame/swap-runtime-db! :rf/default
+      (rf.frame/swap-runtime-db! :rf/default
         (fn [rdb] (-> (or rdb {})
-                      (assoc-in (state/entry-path kv) ev)
-                      (assoc-in (state/entry-path kl) el))))
+                      (assoc-in (rf.resources.state/entry-path kv) ev)
+                      (assoc-in (rf.resources.state/entry-path kl) el))))
       (let [{:keys [entries]} (re-frame.resources/resources {:frame :rf/default})]
         (is (= 2 (count entries))
             "TWO distinct returned entries — no =-collapse onto one map key")
-        (is (= #{(state/key-id kv) (state/key-id kl)} (set (keys entries)))
+        (is (= #{(rf.resources.state/key-id kv) (rf.resources.state/key-id kl)} (set (keys entries)))
             "keyed on the byte key-ids of BOTH entries")
-        (is (= {:v 1} (:data (get entries (state/key-id kv)))) "vector entry intact")
-        (is (= {:l 1} (:data (get entries (state/key-id kl)))) "list entry NOT overwritten")
+        (is (= {:v 1} (:data (get entries (rf.resources.state/key-id kv)))) "vector entry intact")
+        (is (= {:l 1} (:data (get entries (rf.resources.state/key-id kl)))) "list entry NOT overwritten")
         (testing "each entry carries its kind-preserving :resource/key"
-          (is (vector? (-> (get entries (state/key-id kv)) :resource/key (nth 2) :xs))
+          (is (vector? (-> (get entries (rf.resources.state/key-id kv)) :resource/key (nth 2) :xs))
               "vector-params entry preserves vector kind on :resource/key")
-          (is (seq? (-> (get entries (state/key-id kl)) :resource/key (nth 2) :xs))
+          (is (seq? (-> (get entries (rf.resources.state/key-id kl)) :resource/key (nth 2) :xs))
               "list-params entry preserves list kind on :resource/key"))))))
 
 (deftest resources-introspection-without-frame-returns-empty-entries
@@ -1415,17 +1415,17 @@
 (deftest param-canonicalization-total-over-mixed-keys
   (testing "rf2-ptz7z8 — a params map mixing keyword and string keys
             canonicalizes deterministically (no raw ClassCastException)"
-    (let [c1 (state/canonicalize {:b 1 "a" 2 :a 3 "z" 4})
-          c2 (state/canonicalize {"z" 4 :a 3 "a" 2 :b 1})]
+    (let [c1 (rf.resources.state/canonicalize {:b 1 "a" 2 :a 3 "z" 4})
+          c2 (rf.resources.state/canonicalize {"z" 4 :a 3 "a" 2 :b 1})]
       (is (= c1 c2) "key-order-independent over mixed key types")
       (is (= {:b 1 "a" 2 :a 3 "z" 4} c1) "values preserved")))
   (testing "rf2-ptz7z8 — mixed nil / number / boolean / keyword / string keys
             all order deterministically"
     (let [m {nil 0 1 :one true :t :kw :k "s" :str}]
-      (is (= (state/canonicalize m) (state/canonicalize (into {} (shuffle (seq m))))))))
+      (is (= (rf.resources.state/canonicalize m) (rf.resources.state/canonicalize (into {} (shuffle (seq m))))))))
   (testing "rf2-ptz7z8 — a scoped key built from mixed-key params is stable"
-    (is (= (state/scoped-resource-key :rf.scope/global :r/x {:a 1 "b" 2})
-           (state/scoped-resource-key :rf.scope/global :r/x {"b" 2 :a 1})))))
+    (is (= (rf.resources.state/scoped-resource-key :rf.scope/global :r/x {:a 1 "b" 2})
+           (rf.resources.state/scoped-resource-key :rf.scope/global :r/x {"b" 2 :a 1})))))
 
 ;; ===========================================================================
 ;; 19. Shared reset contract (rf2-784223) — `make-reset-runtime-fixture` plus
@@ -1441,10 +1441,10 @@
   ;; thunk clears the whole surface, so the redundant per-suite resets were
   ;; safe to remove.
   (testing "the late-bind reset hook IS published (the fixture's mechanism)"
-    (is (some? (late-bind/get-fn :resources/reset-resources!))
+    (is (some? (rf.late-bind/get-fn :resources/reset-resources!))
         ":resources/reset-resources! hook published at test-support ns-load")
-    (is (identical? resources-test-support/reset-resources!
-                    (late-bind/get-fn :resources/reset-resources!))
+    (is (identical? rf.resources.test-support/reset-resources!
+                    (rf.late-bind/get-fn :resources/reset-resources!))
         "the published hook IS test-support/reset-resources!"))
   ;; Seed every surface the reset must clear.
   (rf/reg-resource :rst/article (article-spec) article-spec-request)
@@ -1452,36 +1452,36 @@
                    {:params-schema [:map [:slug :string]]}
                    (fn [{:keys [slug]} _ctx]
                      {:request {:method :post :url (str "/api/articles/" slug)}}))
-  (state/commit-generation! :rf/default 7)
-  (let [k       (state/scoped-resource-key :rf.scope/global :rst/article {:slug "w"})
-        work-id (work-ledger/resource-work-id k 1)]
-    (work-ledger/put-handle! :rf/default work-id {:abort-fn (fn [] nil)})
-    (timers/schedule! :rf/default k timers/gc-kind 1000000)
-    (swap! revalidate-listeners/listener-table assoc :rf/default
+  (rf.resources.state/commit-generation! :rf/default 7)
+  (let [k       (rf.resources.state/scoped-resource-key :rf.scope/global :rst/article {:slug "w"})
+        work-id (rf.resources.work-ledger/resource-work-id k 1)]
+    (rf.resources.work-ledger/put-handle! :rf/default work-id {:abort-fn (fn [] nil)})
+    (rf.resources.timers/schedule! :rf/default k rf.resources.timers/gc-kind 1000000)
+    (swap! rf.resources.revalidate-listeners/listener-table assoc :rf/default
            {:focus :h :visibility :h :online :h})
     ;; precondition: everything is populated
-    (is (contains? (registrar/registrations registry/resource-kind) :rst/article))
-    (is (contains? (registrar/registrations mreg/mutation-kind) :rst/save))
-    (is (= 7 (state/generation-snapshot :rf/default)))
-    (is (some? (work-ledger/get-handle :rf/default work-id)))
+    (is (contains? (rf.registrar/registrations rf.resources.registry/resource-kind) :rst/article))
+    (is (contains? (rf.registrar/registrations rf.resources.mutation-registry/mutation-kind) :rst/save))
+    (is (= 7 (rf.resources.state/generation-snapshot :rf/default)))
+    (is (some? (rf.resources.work-ledger/get-handle :rf/default work-id)))
     ;; rf2-9e0tyq — the timer side-table key's resource-key element is the byte key-id.
-    (is (contains? @timers/timer-table [:rf/default (state/key-id k) timers/gc-kind]))
-    (is (contains? @revalidate-listeners/listener-table :rf/default))
+    (is (contains? @rf.resources.timers/timer-table [:rf/default (rf.resources.state/key-id k) rf.resources.timers/gc-kind]))
+    (is (contains? @rf.resources.revalidate-listeners/listener-table :rf/default))
     (testing "rf2-784223 — `reset-resources!` clears the resource + mutation
               registrars AND the generation / work-ledger-handle / timer /
               revalidate-listener host side tables in ONE call"
-      (resources-test-support/reset-resources!)
-      (is (empty? (registrar/registrations registry/resource-kind))
+      (rf.resources.test-support/reset-resources!)
+      (is (empty? (rf.registrar/registrations rf.resources.registry/resource-kind))
           "resource registrar cleared")
-      (is (empty? (registrar/registrations mreg/mutation-kind))
+      (is (empty? (rf.registrar/registrations rf.resources.mutation-registry/mutation-kind))
           "mutation registrar cleared")
-      (is (= 0 (state/generation-snapshot :rf/default))
+      (is (= 0 (rf.resources.state/generation-snapshot :rf/default))
           "generation high-water cache cleared")
-      (is (nil? (work-ledger/get-handle :rf/default work-id))
+      (is (nil? (rf.resources.work-ledger/get-handle :rf/default work-id))
           "work-ledger host handle table cleared")
-      (is (not (contains? @timers/timer-table [:rf/default (state/key-id k) timers/gc-kind]))
+      (is (not (contains? @rf.resources.timers/timer-table [:rf/default (rf.resources.state/key-id k) rf.resources.timers/gc-kind]))
           "stale/GC timer table cleared (timer cancelled)")
-      (is (not (contains? @revalidate-listeners/listener-table :rf/default))
+      (is (not (contains? @rf.resources.revalidate-listeners/listener-table :rf/default))
           "revalidation-listener side table cleared"))))
 
 ;; ===========================================================================
@@ -1500,19 +1500,19 @@
   [body-fn]
   (let [seen (atom [])
         k    ::scope-mismatch-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev]
           (when (= :rf.warning/resource-sub-scope-mismatch (:operation ev))
             (swap! seen conj ev))))
     (try (body-fn)
-         (finally (trace-tooling/unregister-listener! k)))
+         (finally (rf.trace.tooling/unregister-listener! k)))
     @seen))
 
 (defn- load-under!
   "Ensure + settle a `:sm/article` resource under `scope` with an active
   owner so its entry is :loaded and ACTIVE (≥1 active owner)."
   [scope owner]
-  (let [k (state/scoped-resource-key scope :sm/article {:slug "w"})]
+  (let [k (rf.resources.state/scoped-resource-key scope :sm/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :sm/article :scope scope
                                             :params {:slug "w"} :owner owner}])
     (let [wid (:current-work (entry k))]
@@ -1531,7 +1531,7 @@
     (load-under! {:user "a"} [:route :r 1])
     (let [warns (record-scope-mismatch-warnings!
                   (fn []
-                    (subs/state-sub-fn (runtime-db)
+                    (rf.resources.subs/state-sub-fn (runtime-db)
                                        [:rf/resource
                                         {:resource :sm/article :scope {:user "b"}
                                          :params {:slug "w"}}])))]
@@ -1546,14 +1546,14 @@
     (let [warns (record-scope-mismatch-warnings!
                   (fn []
                     (dotimes [_ 5]
-                      (subs/state-sub-fn (runtime-db)
+                      (rf.resources.subs/state-sub-fn (runtime-db)
                                          [:rf/resource
                                           {:resource :sm/article :scope {:user "b"}
                                            :params {:slug "w"}}]))))]
       (is (zero? (count warns)) "already-warned mismatch is not re-emitted")))
   (testing "rf2-rsmiru — the sub STILL reads the documented :idle empty-state
             projection (fail-closed is preserved; the warning is advisory)"
-    (is (= :idle (:status (subs/state-sub-fn (runtime-db)
+    (is (= :idle (:status (rf.resources.subs/state-sub-fn (runtime-db)
                                              [:rf/resource
                                               {:resource :sm/article :scope {:user "b"}
                                                :params {:slug "w"}}]))))))
@@ -1565,7 +1565,7 @@
     (load-under! {:user "a"} [:route :r 1])
     (let [warns (record-scope-mismatch-warnings!
                   (fn []
-                    (subs/state-sub-fn (runtime-db)
+                    (rf.resources.subs/state-sub-fn (runtime-db)
                                        [:rf/resource
                                         {:resource :sm/article :scope {:user "a"}
                                          :params {:slug "w"}}])))]
@@ -1579,7 +1579,7 @@
                     ;; a sub under a never-ensured scope C: no DIFFERENT scope
                     ;; is active, so this is an un-ensured resource (the empty
                     ;; :idle projection), not a likely mismatch.
-                    (subs/state-sub-fn (runtime-db)
+                    (rf.resources.subs/state-sub-fn (runtime-db)
                                        [:rf/resource
                                         {:resource :sm/article :scope {:user "c"}
                                          :params {:slug "w"}}])))]
@@ -1591,7 +1591,7 @@
             (global resolves the SAME scope sub-side and ensure-side, so a sub
             cannot land on a different key than the ensure did)"
     (rf/reg-resource :smg/article (article-spec) article-spec-request) ; :rf.scope/global
-    (let [k (state/scoped-resource-key :rf.scope/global :smg/article {:slug "w"})]
+    (let [k (rf.resources.state/scoped-resource-key :rf.scope/global :smg/article {:slug "w"})]
       (rf/dispatch-sync [:rf.resource/ensure {:resource :smg/article :scope :rf.scope/global
                                               :params {:slug "w"} :owner [:route :g 1]}])
       (let [wid (:current-work (entry k))]
@@ -1599,7 +1599,7 @@
                            {:resource/key k :work/id wid :generation 1 :data {:title "W"}}])))
     (let [warns (record-scope-mismatch-warnings!
                   (fn []
-                    (subs/state-sub-fn (runtime-db)
+                    (rf.resources.subs/state-sub-fn (runtime-db)
                                        [:rf/resource
                                         {:resource :smg/article :scope :rf.scope/global
                                          :params {:slug "w"}}])))]

--- a/implementation/resources/test/re_frame/resources_scope_leak_boundary_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_scope_leak_boundary_cljs_test.cljc
@@ -48,19 +48,19 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting requires: register the :rf.resource/* events
    ;; + subs and the named-resolver scope plumbing.
    [re-frame.resources]
    [re-frame.resources.registry]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.subs :as r-subs]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.subs :as rf.resources.subs]
    [re-frame.resources.test-support]
    [re-frame.schemas]
    [re-frame.http.managed]
-   [re-frame.registrar :as registrar]
-   [re-frame.trace.tooling :as trace-tooling]
-   [re-frame.test-support :as core-test-support]
+   [re-frame.registrar :as rf.registrar]
+   [re-frame.trace.tooling :as rf.trace.tooling]
+   [re-frame.test-support :as rf.test-support]
    #?(:clj  [re-frame.substrate.plain-atom :as substrate]
       :cljs [re-frame.adapter.reagent :as substrate])))
 
@@ -75,8 +75,8 @@
   []
   (rf/make-frame {:id :rf/default :url-bound? true
                   :doc "scope-leak-boundary suite default app frame."})
-  (registrar/clear-kind! :resource-scope)
-  (fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf.registrar/clear-kind! :resource-scope)
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
   (rf/reg-resource-scope :t/tenant
     {:inputs {:tenant [:db [:viewer :tenant-id]]}}
     (fn [{:keys [tenant]} _ctx]
@@ -91,7 +91,7 @@
   (rf/reg-event :t/logout (fn [{:keys [db]} _] {:db (update db :viewer dissoc :tenant-id)})))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     {:adapter substrate/adapter
      :init-fn init!}))
 
@@ -103,13 +103,13 @@
 ;; assertions speak scoped-key vectors. Semantics unchanged.
 (defn- entries []
   (into {} (map (fn [[_k-id e]] [(:resource/key e) e]))
-        (get-in (runtime-db) (state/entries-path))))
-(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
+        (get-in (runtime-db) (rf.resources.state/entries-path))))
+(defn- entry [scoped-key] (get-in (runtime-db) (rf.resources.state/entry-path scoped-key)))
 
 (defn- tenant-key
   "The scoped feed key for tenant `t`, page `page`."
   [t page]
-  (state/scoped-resource-key [:rf.scope/tenant {:tenant-id t}] :t/feed {:page page}))
+  (rf.resources.state/scoped-resource-key [:rf.scope/tenant {:tenant-id t}] :t/feed {:page page}))
 
 (defn- ensure-feed!
   "Ensure + load the tenant-scoped feed for tenant `t`, page `page`, under
@@ -231,7 +231,7 @@
                      {:resource :t/notes :params {}
                       :scope [:rf.scope/tenant {:tenant-id "acme"}]
                       :owner [:app :n 1]}])
-  (let [ka (state/scoped-resource-key [:rf.scope/tenant {:tenant-id "acme"}] :t/notes {})
+  (let [ka (rf.resources.state/scoped-resource-key [:rf.scope/tenant {:tenant-id "acme"}] :t/notes {})
         e  (entry ka)]
     (rf/dispatch-sync [:rf.resource.internal/succeeded
                        {:resource/key ka :work/id (:current-work e)
@@ -244,15 +244,15 @@
           k    ::mismatch-recorder
           wrong-q {:resource :t/notes :params {}
                    :scope [:rf.scope/tenant {:tenant-id "globex"}]}]
-      (r-subs/reset-scope-mismatch-warnings!)
-      (trace-tooling/register-listener!
+      (rf.resources.subs/reset-scope-mismatch-warnings!)
+      (rf.trace.tooling/register-listener!
         k (fn [ev] (when (= :rf.warning/resource-sub-scope-mismatch (:operation ev))
                      (swap! seen conj ev))))
       (try
         (let [st (rf/subscribe [:rf/resource wrong-q])]
           (is (= :idle (:status @st)) "wrong-scope read is idle (fail-closed)")
           (is (nil? (:data @st)) "never acme's notes"))
-        (finally (trace-tooling/unregister-listener! k)))
+        (finally (rf.trace.tooling/unregister-listener! k)))
       ;; the dev build fires the mismatch warning; production elides it. We
       ;; assert it fired when present, and that the read was fail-closed
       ;; regardless (the security property does not depend on the warning).
@@ -274,7 +274,7 @@
             silent shared read"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-sub-unresolved-scope"
-          (r-subs/resolve-scoped-key {:resource :t/feed :params {:page 1}} {})))))
+          (rf.resources.subs/resolve-scoped-key {:resource :t/feed :params {:page 1}} {})))))
 
 ;; ===========================================================================
 ;; 3. MIXED-scope invalidation — a scoped invalidation reaches EXACTLY the

--- a/implementation/resources/test/re_frame/resources_scope_mismatch_elision_prod_test.cljs
+++ b/implementation/resources/test/re_frame/resources_scope_mismatch_elision_prod_test.cljs
@@ -24,21 +24,21 @@
   runtime test). This mirrors `re-frame.http-trace-emit-elision-prod-test`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.fx :as rf.fx]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             ;; load-bearing side-effecting require: the façade registers the
             ;; :rf.resource/* events + subs + the generation cofx/fx. Forces
             ;; the gated `maybe-warn-scope-mismatch!` body into the bundle so
             ;; DCE proves the branch dead from a reachable module.
             [re-frame.resources]
-            [re-frame.resources.state :as state]
-            [re-frame.resources.subs :as subs]
+            [re-frame.resources.state :as rf.resources.state]
+            [re-frame.resources.subs :as rf.resources.subs]
             [re-frame.resources.test-support]
             [re-frame.http.managed]
-            [re-frame.schemas :as schemas]
+            [re-frame.schemas :as rf.schemas]
             ;; rf2-qwm0a — listener surface lives in `re-frame.trace.tooling`.
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 (def ^:private last-managed-args (atom nil))
 
@@ -52,15 +52,15 @@
   restore the schema-fn bundle so the suite leaves no cross-test residue."
   [f]
   (reset! last-managed-args nil)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
-  (let [snapshot (schemas/snapshot-schema-fns)]
-    (schemas/set-schema-validator! nil)
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (let [snapshot (rf.schemas/snapshot-schema-fns)]
+    (rf.schemas/set-schema-validator! nil)
     (try (f)
-         (finally (schemas/restore-schema-fns! snapshot)))))
+         (finally (rf.schemas/restore-schema-fns! snapshot)))))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter})
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter})
   capturing-transport-fixture)
 
 ;; ---- helpers --------------------------------------------------------------
@@ -68,7 +68,7 @@
 (defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
 
 (defn- entry [scoped-key]
-  (get-in (runtime-db) (state/entry-path scoped-key)))
+  (get-in (runtime-db) (rf.resources.state/entry-path scoped-key)))
 
 (defn- article-spec [overrides]
   (merge {:scope         :rf.scope/from-caller
@@ -87,12 +87,12 @@
   [body-fn]
   (let [seen   (atom [])
         cb-key (keyword (str "scope-mismatch-elision-prod-" (gensym)))]
-    (trace-tooling/register-listener! cb-key (fn [ev] (swap! seen conj ev)))
+    (rf.trace.tooling/register-listener! cb-key (fn [ev] (swap! seen conj ev)))
     (try
       (body-fn)
       @seen
       (finally
-        (trace-tooling/unregister-listener! cb-key)))))
+        (rf.trace.tooling/unregister-listener! cb-key)))))
 
 ;; ---- the prod-elision contract --------------------------------------------
 
@@ -105,7 +105,7 @@
             still returns its documented :idle projection (fail-closed kept)."
     (rf/reg-resource :sme/article (article-spec {:scope :rf.scope/from-caller}) article-spec-request)
     ;; ensure + settle scope A active (the real owner) …
-    (let [ka (state/scoped-resource-key {:user "a"} :sme/article {:slug "w"})]
+    (let [ka (rf.resources.state/scoped-resource-key {:user "a"} :sme/article {:slug "w"})]
       (rf/dispatch-sync [:rf.resource/ensure {:resource :sme/article :scope {:user "a"}
                                               :params {:slug "w"} :owner [:route :r 1]}])
       (let [wid (:current-work (entry ka))]
@@ -115,7 +115,7 @@
     ;; … then subscribe under scope B (the mismatch the dev warning targets)
     (let [seen (listener-fixture
                  (fn []
-                   (subs/state-sub-fn (runtime-db)
+                   (rf.resources.subs/state-sub-fn (runtime-db)
                                       [:rf/resource
                                        {:resource :sme/article :scope {:user "b"}
                                         :params {:slug "w"}}])))]
@@ -125,7 +125,7 @@
            — the maybe-warn-scope-mismatch! body elided")
       (is (empty? seen)
           "no trace events at all from the sub read under prod")
-      (is (= :idle (:status (subs/state-sub-fn (runtime-db)
+      (is (= :idle (:status (rf.resources.subs/state-sub-fn (runtime-db)
                                                [:rf/resource
                                                 {:resource :sme/article :scope {:user "b"}
                                                  :params {:slug "w"}}])))

--- a/implementation/resources/test/re_frame/resources_scope_registry_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_scope_registry_cljs_test.cljc
@@ -26,15 +26,15 @@
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
-   [re-frame.registrar :as registrar]
-   [re-frame.resources :as resources]
-   [re-frame.resources.scope-registry :as scope]))
+   [re-frame.registrar :as rf.registrar]
+   [re-frame.resources :as rf.resources]
+   [re-frame.resources.scope-registry :as rf.resources.scope-registry]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
 (use-fixtures :each
-  {:before (fn [] (registrar/clear-kind! :resource-scope))
-   :after  (fn [] (registrar/clear-kind! :resource-scope))})
+  {:before (fn [] (rf.registrar/clear-kind! :resource-scope))
+   :after  (fn [] (rf.registrar/clear-kind! :resource-scope))})
 
 ;; rf2-bqstzr — the canonical declared-inputs resolver split into the 3-slot
 ;; grammar's metadata middle slot (`session-meta`: `:doc` + `:inputs`) and the
@@ -57,23 +57,23 @@
 
 (deftest resource-scope-kind-in-closed-set
   (testing ":resource-scope is a valid registrar kind"
-    (is (registrar/valid-kind? :resource-scope))
-    (is (contains? registrar/kinds :resource-scope))))
+    (is (rf.registrar/valid-kind? :resource-scope))
+    (is (contains? rf.registrar/kinds :resource-scope))))
 
 (deftest reg-resource-scope-registers-and-introspects
   (testing "reg-resource-scope writes a :resource-scope registrar entry"
-    (is (= :realworld/session (resources/reg-resource-scope :realworld/session session-meta session-resolve)))
-    (is (contains? (registrar/registrations :resource-scope) :realworld/session))
-    (is (= [:realworld/session] (resources/scope-resolver-ids))))
+    (is (= :realworld/session (rf.resources/reg-resource-scope :realworld/session session-meta session-resolve)))
+    (is (contains? (rf.registrar/registrations :resource-scope) :realworld/session))
+    (is (= [:realworld/session] (rf.resources/scope-resolver-ids))))
   (testing "scope-resolver-meta reads the canonical spec back"
-    (let [m (resources/scope-resolver-meta :realworld/session)]
+    (let [m (rf.resources/scope-resolver-meta :realworld/session)]
       (is (fn? (:resolve m)))
       (is (= {:username [:db [:auth :user :username]]} (:inputs m)))
       (is (false? (:whole-db? m)))))
   (testing "clear-resource-scope removes the registration"
-    (resources/clear-resource-scope :realworld/session)
-    (is (nil? (resources/scope-resolver-meta :realworld/session)))
-    (is (not (contains? (registrar/registrations :resource-scope) :realworld/session)))))
+    (rf.resources/clear-resource-scope :realworld/session)
+    (is (nil? (rf.resources/scope-resolver-meta :realworld/session)))
+    (is (not (contains? (rf.registrar/registrations :resource-scope) :realworld/session)))))
 
 ;; ===========================================================================
 ;; 2. Fail-closed validation at the authoring boundary
@@ -86,40 +86,40 @@
   (testing "a non-fn value slot throws invalid-resource-scope-spec"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"invalid-resource-scope-spec"
-          (resources/reg-resource-scope :s/no-resolve
+          (rf.resources/reg-resource-scope :s/no-resolve
                                         {:inputs {:x [:db [:x]]}}
                                         "not a fn"))))
   (testing "a non-map non-fn value slot throws (2-arg sugar, value not a fn)"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"invalid-resource-scope-spec"
-          (resources/reg-resource-scope :s/bad "not a resolver"))))
+          (rf.resources/reg-resource-scope :s/bad "not a resolver"))))
   (testing "a non-map metadata slot throws"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"invalid-resource-scope-spec"
-          (resources/reg-resource-scope :s/bad-meta "not a map" (fn [_ _] nil)))))
+          (rf.resources/reg-resource-scope :s/bad-meta "not a map" (fn [_ _] nil)))))
   (testing "a :resolve left inside the metadata map is rejected as mislocated"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"invalid-resource-scope-spec"
-          (resources/reg-resource-scope :s/mislocated
+          (rf.resources/reg-resource-scope :s/mislocated
                                         {:inputs {:x [:db [:x]]}
                                          :resolve (fn [_ _] nil)}
                                         (fn [_ _] nil)))))
   (testing "a non-map :inputs throws"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"invalid-resource-scope-spec"
-          (resources/reg-resource-scope :s/bad-inputs
+          (rf.resources/reg-resource-scope :s/bad-inputs
                                         {:inputs [:not :a :map]}
                                         (fn [_ _] nil)))))
   (testing "a malformed input descriptor (not a 2-vector) throws"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"invalid-resource-scope-spec"
-          (resources/reg-resource-scope :s/bad-desc
+          (rf.resources/reg-resource-scope :s/bad-desc
                                         {:inputs {:x [:db]}}
                                         (fn [_ _] nil)))))
   (testing "an unknown source head throws"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"invalid-resource-scope-spec"
-          (resources/reg-resource-scope :s/bad-src
+          (rf.resources/reg-resource-scope :s/bad-src
                                         {:inputs {:x [:cookie [:x]]}}
                                         (fn [_ _] nil))))))
 
@@ -131,7 +131,7 @@
   (testing "[:runtime path] is rejected with the reserved-source error"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-scope-source-reserved"
-          (resources/reg-resource-scope :s/tenant
+          (rf.resources/reg-resource-scope :s/tenant
                                         {:inputs {:tenant [:runtime [:rf.runtime/routing :current :params :tenant]]}}
                                         (fn [{:keys [tenant]} _]
                                           (when tenant [:rf.scope/tenant {:tenant tenant}])))))))
@@ -145,40 +145,40 @@
     (let [inputs {:username [:db [:auth :user :username]]
                   :locale   [:db [:i18n :locale]]}
           db     {:auth {:user {:username "jake"}} :i18n {:locale :en}}]
-      (is (= {:username "jake" :locale :en} (scope/eval-inputs inputs db)))))
+      (is (= {:username "jake" :locale :en} (rf.resources.scope-registry/eval-inputs inputs db)))))
   (testing "a missing path resolves to nil (rf.path get, no throw)"
-    (is (= {:username nil} (scope/eval-inputs {:username [:db [:auth :user :username]]} {})))))
+    (is (= {:username nil} (rf.resources.scope-registry/eval-inputs {:username [:db [:auth :user :username]]} {})))))
 
 ;; ===========================================================================
 ;; 4. The resolve-resource-scope resolver helper (fail-closed nil)
 ;; ===========================================================================
 
 (deftest resolve-resource-scope-against-supplied-db
-  (resources/reg-resource-scope :realworld/session session-meta session-resolve)
+  (rf.resources/reg-resource-scope :realworld/session session-meta session-resolve)
   (testing "resolves the concrete scope from a supplied db value (canonicalized)"
     (is (= [:rf.scope/session {:username "jake"}]
-           (resources/resolve-resource-scope {:auth {:user {:username "jake"}}}
+           (rf.resources/resolve-resource-scope {:auth {:user {:username "jake"}}}
                                              :realworld/session))))
   (testing "a resolver returning nil FAILS CLOSED — nil, never an implicit global"
-    (is (nil? (resources/resolve-resource-scope {} :realworld/session)))))
+    (is (nil? (rf.resources/resolve-resource-scope {} :realworld/session)))))
 
 (deftest resolve-resource-scope-unregistered-is-loud
   (testing "resolve-resource-scope on an unregistered id throws fail-closed"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-scope-not-registered"
-          (resources/resolve-resource-scope {} :s/nope)))))
+          (rf.resources/resolve-resource-scope {} :s/nope)))))
 
 (deftest resolved-scope-routes-through-canonicalization
   ;; A resolver that returns a :rf.scope/* TYPO must be rejected fail-closed
   ;; (the shared concrete-scope canonicalization path) — it can never become
   ;; a silent wrong cache scope.
-  (resources/reg-resource-scope :s/typo
+  (rf.resources/reg-resource-scope :s/typo
                                 {:inputs {}}
                                 (fn [_ _] :rf.scope/glabal))
   (testing "a resolved :rf.scope/* typo is rejected at canonicalization"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
-          (resources/resolve-resource-scope {} :s/typo)))))
+          (rf.resources/resolve-resource-scope {} :s/typo)))))
 
 ;; ===========================================================================
 ;; 5. Whole-db function sugar (explicit-cost)
@@ -186,44 +186,44 @@
 
 (deftest whole-db-fn-sugar-lowers-to-explicit-whole-db-input
   (testing "a bare (fn [db ctx] …) registers and is marked :whole-db? true"
-    (resources/reg-resource-scope :s/sugar
+    (rf.resources/reg-resource-scope :s/sugar
                                   (fn [db _ctx]
                                     (when-let [u (get-in db [:auth :user :username])]
                                       [:rf.scope/session {:username u}])))
-    (let [m (resources/scope-resolver-meta :s/sugar)]
+    (let [m (rf.resources/scope-resolver-meta :s/sugar)]
       (is (true? (:whole-db? m)))
       ;; the synthetic explicit whole-db input — the root [:db []] path, so
       ;; tooling sees the cost on both axes (EP-0015 disposition 8)
       (is (= {:db [:db []]} (:inputs m)))))
   (testing "the sugar resolves against the whole db at use time"
     (is (= [:rf.scope/session {:username "jake"}]
-           (resources/resolve-resource-scope {:auth {:user {:username "jake"}}}
+           (rf.resources/resolve-resource-scope {:auth {:user {:username "jake"}}}
                                              :s/sugar)))
-    (is (nil? (resources/resolve-resource-scope {} :s/sugar)))))
+    (is (nil? (rf.resources/resolve-resource-scope {} :s/sugar)))))
 
 ;; ===========================================================================
 ;; 6. {:from-db id} reference resolution (use-time, nil fail-closed)
 ;; ===========================================================================
 
 (deftest from-db-reference-resolution
-  (resources/reg-resource-scope :realworld/session session-meta session-resolve)
+  (rf.resources/reg-resource-scope :realworld/session session-meta session-resolve)
   (testing "from-db-reference? recognises only {:from-db …} maps"
-    (is (scope/from-db-reference? {:from-db :realworld/session}))
-    (is (not (scope/from-db-reference? :rf.scope/global)))
-    (is (not (scope/from-db-reference? [:rf.scope/session {:username "jake"}])))
-    (is (not (scope/from-db-reference? {:tenant "acme"}))))
+    (is (rf.resources.scope-registry/from-db-reference? {:from-db :realworld/session}))
+    (is (not (rf.resources.scope-registry/from-db-reference? :rf.scope/global)))
+    (is (not (rf.resources.scope-registry/from-db-reference? [:rf.scope/session {:username "jake"}])))
+    (is (not (rf.resources.scope-registry/from-db-reference? {:tenant "acme"}))))
   (testing "a reference resolves at USE TIME against the supplied db"
     (is (= [:rf.scope/session {:username "jake"}]
-           (scope/resolve-from-db-reference {:from-db :realworld/session}
+           (rf.resources.scope-registry/resolve-from-db-reference {:from-db :realworld/session}
                                             {:auth {:user {:username "jake"}}}
                                             'test))))
   (testing "a reference resolving nil FAILS CLOSED (nil — the caller interprets)"
-    (is (nil? (scope/resolve-from-db-reference {:from-db :realworld/session}
+    (is (nil? (rf.resources.scope-registry/resolve-from-db-reference {:from-db :realworld/session}
                                                {} 'test))))
   (testing "a reference to an unregistered resolver is loud"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-scope-not-registered"
-          (scope/resolve-from-db-reference {:from-db :s/nope} {} 'test)))))
+          (rf.resources.scope-registry/resolve-from-db-reference {:from-db :s/nope} {} 'test)))))
 
 ;; ===========================================================================
 ;; 7. No :rf.egress/output-sensitivity claim (EP-0025, rf2-71dr8t) — the
@@ -235,24 +235,24 @@
 (deftest output-sensitivity-claim-silently-ignored
   (testing "a resolver carries no :output-sensitivity on its canonical spec
             (the propagation enum is gone — EP-0025)"
-    (resources/reg-resource-scope :s/default session-meta session-resolve)
-    (is (nil? (:output-sensitivity (resources/scope-resolver-meta :s/default)))))
+    (rf.resources/reg-resource-scope :s/default session-meta session-resolve)
+    (is (nil? (:output-sensitivity (rf.resources/scope-resolver-meta :s/default)))))
   (testing "a present :rf.egress/output-sensitivity key is silently ignored, not
             stored, and registration does NOT throw (Spec 015 §No propagation:
             the key is gone and silently ignored if present)"
     (doseq [claim [:rf.egress/inherit :rf.egress/sensitive :rf.egress/public]]
       (is (= :s/claim
-             (resources/reg-resource-scope :s/claim
+             (rf.resources/reg-resource-scope :s/claim
                                            (assoc session-meta :rf.egress/output-sensitivity claim)
                                            session-resolve)))
-      (is (nil? (:output-sensitivity (resources/scope-resolver-meta :s/claim))))))
+      (is (nil? (:output-sensitivity (rf.resources/scope-resolver-meta :s/claim))))))
   (testing "the whole-db fn sugar carries no :output-sensitivity"
-    (resources/reg-resource-scope :s/sugar-claim (fn [_db _ctx] nil))
-    (is (nil? (:output-sensitivity (resources/scope-resolver-meta :s/sugar-claim)))))
+    (rf.resources/reg-resource-scope :s/sugar-claim (fn [_db _ctx] nil))
+    (is (nil? (:output-sensitivity (rf.resources/scope-resolver-meta :s/sugar-claim)))))
   (testing "a value that was a fail-closed enum typo is now silently ignored —
             no :rf.error/invalid-resource-scope-spec throw"
     (is (= :s/was-typo-claim
-           (resources/reg-resource-scope :s/was-typo-claim
+           (rf.resources/reg-resource-scope :s/was-typo-claim
                                          (assoc session-meta :rf.egress/output-sensitivity :rf.egress/publik)
                                          session-resolve)))))
 
@@ -267,28 +267,28 @@
   ;; reg-route.
   (testing "the 3-arg form stores :inputs from the metadata slot and the value
             fn as :resolve"
-    (resources/reg-resource-scope :s/three-slot
+    (rf.resources/reg-resource-scope :s/three-slot
                                   {:doc "3-slot." :inputs {:username [:db [:auth :user :username]]}}
                                   session-resolve)
-    (let [m (resources/scope-resolver-meta :s/three-slot)]
+    (let [m (rf.resources/scope-resolver-meta :s/three-slot)]
       (is (= {:username [:db [:auth :user :username]]} (:inputs m)))
       (is (identical? session-resolve (:resolve m)))
       (is (false? (:whole-db? m)))))
   (testing "the resolver first arg is the resolved inputs map"
     (is (= [:rf.scope/session {:username "jake"}]
-           (resources/resolve-resource-scope {:auth {:user {:username "jake"}}}
+           (rf.resources/resolve-resource-scope {:auth {:user {:username "jake"}}}
                                              :s/three-slot))))
   (testing "the 2-arg sugar (no metadata) selects the whole-db form"
-    (resources/reg-resource-scope :s/two-slot
+    (rf.resources/reg-resource-scope :s/two-slot
                                   (fn [db _ctx]
                                     (when-let [u (get-in db [:auth :user :username])]
                                       [:rf.scope/session {:username u}])))
-    (is (true? (:whole-db? (resources/scope-resolver-meta :s/two-slot))))
+    (is (true? (:whole-db? (rf.resources/scope-resolver-meta :s/two-slot))))
     (is (= [:rf.scope/session {:username "jake"}]
-           (resources/resolve-resource-scope {:auth {:user {:username "jake"}}}
+           (rf.resources/resolve-resource-scope {:auth {:user {:username "jake"}}}
                                              :s/two-slot))))
   (testing ":doc-only metadata (no :inputs) still selects the whole-db form"
-    (resources/reg-resource-scope :s/doc-only
+    (rf.resources/reg-resource-scope :s/doc-only
                                   {:doc "Whole-db, documented."}
                                   (fn [db _ctx] (get-in db [:tenant])))
-    (is (true? (:whole-db? (resources/scope-resolver-meta :s/doc-only))))))
+    (is (true? (:whole-db? (rf.resources/scope-resolver-meta :s/doc-only))))))

--- a/implementation/resources/test/re_frame/resources_scoped_owner_lifecycle_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_scoped_owner_lifecycle_cljs_test.cljc
@@ -33,17 +33,17 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting requires: register the :rf.resource/* events
    ;; (ensure / release-owner / gc-fired) + the named-resolver scope plumbing.
    [re-frame.resources]
    [re-frame.resources.registry]
-   [re-frame.resources.state :as state]
+   [re-frame.resources.state :as rf.resources.state]
    [re-frame.resources.test-support]
    [re-frame.schemas]
    [re-frame.http.managed]
-   [re-frame.registrar :as registrar]
-   [re-frame.test-support :as core-test-support]
+   [re-frame.registrar :as rf.registrar]
+   [re-frame.test-support :as rf.test-support]
    #?(:clj  [re-frame.substrate.plain-atom :as substrate]
       :cljs [re-frame.adapter.reagent :as substrate])))
 
@@ -58,8 +58,8 @@
   []
   (rf/make-frame {:id :rf/default :url-bound? true
                   :doc "scoped-owner-lifecycle suite default app frame."})
-  (registrar/clear-kind! :resource-scope)
-  (fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf.registrar/clear-kind! :resource-scope)
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
   (rf/reg-resource-scope :t/tenant
     {:inputs {:tenant [:db [:viewer :tenant-id]]}}
     (fn [{:keys [tenant]} _ctx]
@@ -75,7 +75,7 @@
     (fn [{:keys [db]} [_ tenant]] {:db (assoc-in db [:viewer :tenant-id] tenant)})))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     {:adapter substrate/adapter
      :init-fn init!}))
 
@@ -89,20 +89,20 @@
 ;; semantics (which keys/owners map where) are unchanged.
 (defn- entries []
   (into {} (map (fn [[_k-id e]] [(:resource/key e) e]))
-        (get-in (runtime-db) (state/entries-path))))
-(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
+        (get-in (runtime-db) (rf.resources.state/entries-path))))
+(defn- entry [scoped-key] (get-in (runtime-db) (rf.resources.state/entry-path scoped-key)))
 (defn- owner-index []
   (let [rdb (runtime-db)
-        es  (get-in rdb (state/entries-path))
+        es  (get-in rdb (rf.resources.state/entries-path))
         id->sk (into {} (map (fn [[k-id e]] [k-id (:resource/key e)])) es)]
     (into {} (map (fn [[owner members]]
                     [owner (into #{} (map #(get id->sk % %)) members)]))
-          (get-in rdb (state/owner-index-path)))))
+          (get-in rdb (rf.resources.state/owner-index-path)))))
 
 (defn- tenant-key
   "The scoped feed key for tenant `t`, page `page`."
   [t page]
-  (state/scoped-resource-key [:rf.scope/tenant {:tenant-id t}] :t/feed {:page page}))
+  (rf.resources.state/scoped-resource-key [:rf.scope/tenant {:tenant-id t}] :t/feed {:page page}))
 
 (defn- ensure-feed!
   "Ensure the tenant-scoped feed for tenant `t` under owner `owner`. Uses an

--- a/implementation/resources/test/re_frame/resources_skeleton_cljs_test.cljs
+++ b/implementation/resources/test/re_frame/resources_skeleton_cljs_test.cljs
@@ -24,16 +24,16 @@
   GC, invalidation, hydration) is exercised by the sibling runtime tests
   (`resources_runtime_cljs_test`, `resources_work_ledger_cljs_test`, …)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.features :as features]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]
-            [re-frame.resources :as resources]
+            [re-frame.features :as rf.features]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.resources :as rf.resources]
             ;; The route + ssr siblings carry the late-bound integration
             ;; publication; the façade transitively loads them, but require
             ;; them explicitly so a hostile load-order can't hide a miss.
-            [re-frame.resources.route :as route]
-            [re-frame.resources.registry :as registry]
-            [re-frame.routing.registry :as routing-registry]))
+            [re-frame.resources.route :as rf.resources.route]
+            [re-frame.resources.registry :as rf.resources.registry]
+            [re-frame.routing.registry :as rf.routing.registry]))
 
 (defn- valid-spec
   "A minimal, valid resource METADATA map — the REQUIRED metadata keys (Spec
@@ -50,27 +50,27 @@
     {:request {:method :get :url "/api/x"}}))
 
 (use-fixtures :each
-  {:before (fn [] (registrar/clear-kind! :resource))
-   :after  (fn [] (registrar/clear-kind! :resource))})
+  {:before (fn [] (rf.registrar/clear-kind! :resource))
+   :after  (fn [] (rf.registrar/clear-kind! :resource))})
 
 (deftest artefact-loads
   (testing "the resources façade ns loaded (the require is the smoke)"
-    (is (fn? resources/reg-resource))
-    (is (fn? resources/clear-resource))
-    (is (fn? resources/resource-meta))
-    (is (fn? resources/resources))))
+    (is (fn? rf.resources/reg-resource))
+    (is (fn? rf.resources/clear-resource))
+    (is (fn? rf.resources/resource-meta))
+    (is (fn? rf.resources/resources))))
 
 (deftest reg-resource-registers-under-resource-kind
   (testing "reg-resource writes a :resource-kind registrar entry"
-    (resources/reg-resource :test/article (valid-spec) valid-request)
-    (is (contains? (registrar/registrations :resource) :test/article))
-    (is (= :test/article (first (resources/resource-ids))))
+    (rf.resources/reg-resource :test/article (valid-spec) valid-request)
+    (is (contains? (rf.registrar/registrations :resource) :test/article))
+    (is (= :test/article (first (rf.resources/resource-ids))))
     (testing "resource-meta reads the spec back"
-      (is (= "test resource" (:doc (resources/resource-meta :test/article))))
-      (is (= :rf.scope/global (:scope (resources/resource-meta :test/article)))))
+      (is (= "test resource" (:doc (rf.resources/resource-meta :test/article))))
+      (is (= :rf.scope/global (:scope (rf.resources/resource-meta :test/article)))))
     (testing "clear-resource removes the entry"
-      (resources/clear-resource :test/article)
-      (is (not (contains? (registrar/registrations :resource) :test/article))))))
+      (rf.resources/clear-resource :test/article)
+      (is (not (contains? (rf.registrar/registrations :resource) :test/article))))))
 
 (deftest gc-after-ms-normalizes-at-registration
   ;; rf2-bbpu11 (Option A) — `:gc-after-ms` is normalized AT REGISTRATION so
@@ -79,28 +79,28 @@
   ;; opt-out, the caller's own positive number, or a loud registration error.
   ;; Never today's silent "any non-number becomes nil".
   (testing "absent :gc-after-ms normalizes to the finite framework default (300000ms)"
-    (resources/reg-resource :test/gc-absent (valid-spec) valid-request)
-    (is (= 300000 (:gc-after-ms (resources/resource-meta :test/gc-absent))))
-    (is (= 300000 registry/default-gc-after-ms)))
+    (rf.resources/reg-resource :test/gc-absent (valid-spec) valid-request)
+    (is (= 300000 (:gc-after-ms (rf.resources/resource-meta :test/gc-absent))))
+    (is (= 300000 rf.resources.registry/default-gc-after-ms)))
   (testing ":gc-after-ms :never is stored verbatim — the explicit, auditable
             opt-out for intentional unowned-entry pinning, distinct from an
             accidental nil"
-    (resources/reg-resource :test/gc-never
+    (rf.resources/reg-resource :test/gc-never
                              (assoc (valid-spec) :gc-after-ms :never)
                              valid-request)
-    (is (= :never (:gc-after-ms (resources/resource-meta :test/gc-never)))))
+    (is (= :never (:gc-after-ms (rf.resources/resource-meta :test/gc-never)))))
   (testing "a positive :gc-after-ms is stored unchanged"
-    (resources/reg-resource :test/gc-positive
+    (rf.resources/reg-resource :test/gc-positive
                              (assoc (valid-spec) :gc-after-ms 45000)
                              valid-request)
-    (is (= 45000 (:gc-after-ms (resources/resource-meta :test/gc-positive)))))
+    (is (= 45000 (:gc-after-ms (rf.resources/resource-meta :test/gc-positive)))))
   (testing "a bad :gc-after-ms (zero, negative, a string, an explicit nil, or
             any keyword other than :never) throws :rf.error/resource-bad-spec
             rather than silently disarming GC"
     (doseq [bad [0 -1 "5min" :neverr nil]]
       (is (thrown-with-msg?
             js/Error #"resource-bad-spec"
-            (resources/reg-resource :test/gc-bad
+            (rf.resources/reg-resource :test/gc-bad
                                     (assoc (valid-spec) :gc-after-ms bad)
                                     valid-request))
           (str "bad :gc-after-ms value " (pr-str bad) " must throw")))))
@@ -109,20 +109,20 @@
   (testing "reg-resource with no :scope throws :rf.error/resource-missing-scope-policy"
     (is (thrown-with-msg?
           js/Error #"resource-missing-scope-policy"
-          (resources/reg-resource :test/no-scope
+          (rf.resources/reg-resource :test/no-scope
                                   (dissoc (valid-spec) :scope)
                                   valid-request))))
   (testing "reg-resource with no :params-schema throws"
     (is (thrown-with-msg?
           js/Error #"resource-bad-spec"
-          (resources/reg-resource :test/no-params
+          (rf.resources/reg-resource :test/no-params
                                   (dissoc (valid-spec) :params-schema)
                                   valid-request))))
   (testing "reg-resource with :request inside the metadata map throws (it is the
             THIRD slot, rf2-wvh95f F1)"
     (is (thrown-with-msg?
           js/Error #"resource-bad-spec"
-          (resources/reg-resource :test/no-request
+          (rf.resources/reg-resource :test/no-request
                                   (assoc (valid-spec) :request valid-request)
                                   valid-request)))))
 
@@ -133,7 +133,7 @@
   ;; IllegalArgumentException ("Key must be integer") from the `:request`
   ;; `assoc`. Mirrors reg-route's `reg-route-rejects-non-map-metadata`.
   (testing "a vector metadata is rejected with the canonical error id"
-    (let [ex (try (resources/reg-resource :test/bad-vec [] valid-request)
+    (let [ex (try (rf.resources/reg-resource :test/bad-vec [] valid-request)
                   nil
                   (catch :default e e))]
       (is (some? ex) "a non-map metadata must throw, not silently mis-register")
@@ -144,11 +144,11 @@
   (testing "a string metadata is rejected with the canonical error id"
     (is (thrown-with-msg?
           js/Error #"resource-bad-spec"
-          (resources/reg-resource :test/bad-str "nope" valid-request))))
+          (rf.resources/reg-resource :test/bad-str "nope" valid-request))))
   (testing "a nil metadata is rejected with the canonical error id"
     (is (thrown-with-msg?
           js/Error #"resource-bad-spec"
-          (resources/reg-resource :test/bad-nil nil valid-request)))))
+          (rf.resources/reg-resource :test/bad-nil nil valid-request)))))
 
 (deftest reserved-scope-namespace-typo-rejected-fail-closed
   ;; rf2-y7lcqy — a bare keyword in the framework-reserved :rf.scope/*
@@ -159,67 +159,67 @@
   (testing "a :rf.scope/* typo throws :rf.error/resource-missing-scope-policy"
     (is (thrown-with-msg?
           js/Error #"resource-missing-scope-policy"
-          (resources/reg-resource :test/typo
+          (rf.resources/reg-resource :test/typo
                                   (assoc (valid-spec) :scope :rf.scope/glabal) valid-request)))
     (is (thrown-with-msg?
           js/Error #"resource-missing-scope-policy"
-          (resources/reg-resource :test/typo2
+          (rf.resources/reg-resource :test/typo2
                                   (assoc (valid-spec) :scope :rf.scope/sesssion) valid-request))))
   ;; The closed enum members stay valid.
   (testing ":rf.scope/global and :rf.scope/from-caller remain valid"
     (is (= :test/global
-           (resources/reg-resource :test/global
+           (rf.resources/reg-resource :test/global
                                    (assoc (valid-spec) :scope :rf.scope/global) valid-request)))
     (is (= :test/from-caller
-           (resources/reg-resource :test/from-caller
+           (rf.resources/reg-resource :test/from-caller
                                    (assoc (valid-spec) :scope :rf.scope/from-caller) valid-request))))
   ;; An app-namespaced keyword is a legitimate literal scope — NOT in the
   ;; reserved :rf.scope/* namespace, so it is accepted unchanged.
   (testing "an app-namespaced keyword scope is accepted as a literal scope"
     (is (= :test/app-ns
-           (resources/reg-resource :test/app-ns
+           (rf.resources/reg-resource :test/app-ns
                                    (assoc (valid-spec) :scope :my.app/whatever) valid-request))))
   ;; Data-value scopes (the legitimate data-value-resolver feature) stay
   ;; valid: a [:rf.scope/session {…}] tuple is a value, not a bare keyword,
   ;; and a map / string scope is likewise a literal data value.
   (testing "data-value scopes (tuple / map / string) remain valid"
     (is (= :test/tuple
-           (resources/reg-resource :test/tuple
+           (rf.resources/reg-resource :test/tuple
                                    (assoc (valid-spec)
                                           :scope [:rf.scope/session {:user-id "u-1"}])
                                    valid-request)))
     (is (= :test/map
-           (resources/reg-resource :test/map
+           (rf.resources/reg-resource :test/map
                                    (assoc (valid-spec) :scope {:tenant-id "acme"}) valid-request)))
     (is (= :test/string
-           (resources/reg-resource :test/string
+           (rf.resources/reg-resource :test/string
                                    (assoc (valid-spec) :scope "tenant-acme") valid-request))))
   ;; A fn resolver is valid.
   (testing "a fn resolver scope is accepted"
     (is (= :test/fn
-           (resources/reg-resource :test/fn
+           (rf.resources/reg-resource :test/fn
                                    (assoc (valid-spec) :scope (fn [] :rf.scope/global)) valid-request)))))
 
 (deftest resource-kind-in-closed-set
   (testing ":resource is a valid registrar kind"
-    (is (registrar/valid-kind? :resource))
-    (is (contains? registrar/kinds :resource)))
+    (is (rf.registrar/valid-kind? :resource))
+    (is (contains? rf.registrar/kinds :resource)))
   (testing ":query is NOT a registrar kind (deliberate — Spec 016)"
-    (is (not (registrar/valid-kind? :query)))
-    (is (not (contains? registrar/kinds :query)))))
+    (is (not (rf.registrar/valid-kind? :query)))
+    (is (not (contains? rf.registrar/kinds :query)))))
 
 (deftest feature-probe-published
   (testing "the :resources feature is loaded? (the probe key is published)"
-    (is (some? (late-bind/get-fn :resources/reg-resource)))
-    (is (true? (features/feature-loaded? :resources)))
-    (is (= "day8/re-frame2-resources" (:maven (:resources (features/features)))))))
+    (is (some? (rf.late-bind/get-fn :resources/reg-resource)))
+    (is (true? (rf.features/feature-loaded? :resources)))
+    (is (= "day8/re-frame2-resources" (:maven (:resources (rf.features/features)))))))
 
 (deftest public-api-hooks-published
   (testing "every public-API late-bind hook resolves"
     (doseq [k [:resources/reg-resource :resources/clear-resource
                :resources/resource-meta :resources/resource-state
                :resources/resources]]
-      (is (some? (late-bind/get-fn k)) (str k " should be published")))))
+      (is (some? (rf.late-bind/get-fn k)) (str k " should be published")))))
 
 (deftest resource-subs-registered
   (testing "the passive :rf.resource/* sub family is registered"
@@ -228,7 +228,7 @@
                     :rf.resource/stale? :rf.resource/error
                     :rf.resource/refresh-error :rf.resource/has-data?
                     :rf.resource/previous-data]]
-      (is (some? (registrar/lookup :sub sub-id))
+      (is (some? (rf.registrar/lookup :sub sub-id))
           (str sub-id " sub should be registered")))))
 
 (def ^:private resource-event-family
@@ -260,7 +260,7 @@
   (testing "the CURRENT :rf.resource/* event family is registered AND every
             member carries framework-write authority (rf2-l1a0s7)"
     (doseq [event-id resource-event-family]
-      (let [handler (registrar/lookup :event event-id)]
+      (let [handler (rf.registrar/lookup :event event-id)]
         (is (some? handler)
             (str event-id " event should be registered"))
         (is (true? (:rf/framework-authority? handler))
@@ -268,16 +268,16 @@
 
 (deftest late-bound-routing-accepts-resources-key
   (testing "the :routing/extra-route-keys hook publishes #{:resources}"
-    (is (= #{:resources} ((late-bind/get-fn :routing/extra-route-keys)))))
+    (is (= #{:resources} ((rf.late-bind/get-fn :routing/extra-route-keys)))))
   (testing "routing's accepted-key extension lets a route carry :resources"
     ;; routing.registry/reg-route validates bare metadata keys; with the
     ;; resources extension loaded, :resources is accepted (it would
     ;; otherwise throw :rf.error/route-bad-metadata).
-    (registrar/clear-kind! :route)
+    (rf.registrar/clear-kind! :route)
     (is (= :test/route
-           (routing-registry/reg-route
+           (rf.routing.registry/reg-route
              :test/route
              {:params    [:map [:slug :string]]
               :resources [{:resource :test/article
                            :params   (fn [route] {:slug (get-in route [:params :slug])})}]} "/x/:slug")))
-    (registrar/clear-kind! :route)))
+    (rf.registrar/clear-kind! :route)))

--- a/implementation/resources/test/re_frame/resources_ssr_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_ssr_cljs_test.cljc
@@ -34,16 +34,16 @@
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [clojure.string :as str]
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
-   [re-frame.frame :as frame]
-   [re-frame.late-bind :as late-bind]
-   [re-frame.privacy :as privacy]
+   [re-frame.fx :as rf.fx]
+   [re-frame.frame :as rf.frame]
+   [re-frame.late-bind :as rf.late-bind]
+   [re-frame.privacy :as rf.privacy]
    ;; load-bearing side-effecting requires: the façade publishes the SSR
    ;; projection + reconcile hooks + registers the resource registrar kind.
    [re-frame.resources]
-   [re-frame.resources.ssr :as ssr]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.resources.ssr :as rf.resources.ssr]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.work-ledger :as rf.resources.work-ledger]
    ;; production HTTP fx surface (so the transport feature probe resolves on the
    ;; real-path integration drain test); the fetch + abort are overridden by
    ;; capturing no-ops in `capturing-transport-fixture` so no real request fires.
@@ -51,11 +51,11 @@
    ;; SSR artefact — the :rf/hydrate handler that consults the reconcile hook.
    [re-frame.ssr]
    ;; the consumer of :ssr/extend-runtime-db-projection (project-runtime-db).
-   [re-frame.ssr.payload-policy :as payload-policy]
+   [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport (decouples the real-path drain test from HTTP) ----
 ;;
@@ -76,14 +76,14 @@
   real fetch / abort fires. Composed INSIDE the reset-runtime fixture."
   [f]
   (reset! aborts [])
-  (fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
-  (fx/reg-fx :rf.http/managed-abort (fn [_ctx request-id] (swap! aborts conj request-id) nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf.fx/reg-fx :rf.http/managed-abort (fn [_ctx request-id] (swap! aborts conj request-id) nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
   capturing-transport-fixture)
 
 ;; ---- helpers --------------------------------------------------------------
@@ -107,7 +107,7 @@
   [{:keys [resource-id status data loaded-at stale-at invalidated-at
            generation current-work tags owners refresh-error]
     :or   {status :loaded generation 1 tags #{} owners #{}}}]
-  (merge (state/empty-entry resource-id)
+  (merge (rf.resources.state/empty-entry resource-id)
          {:status         status
           :data           data
           :loaded-at      loaded-at
@@ -127,9 +127,9 @@
   `{key-id (assoc entry :resource/key scoped-key)}` shape — the call sites
   stay written in the natural scoped-key-vector form."
   [entries]
-  {state/resources-key {:entries (into {}
+  {rf.resources.state/resources-key {:entries (into {}
                                        (map (fn [[sk e]]
-                                              [(state/key-id sk) (assoc e :resource/key sk)]))
+                                              [(rf.resources.state/key-id sk) (assoc e :resource/key sk)]))
                                        entries)
                         :tag-index {} :owner-index {}}})
 
@@ -143,18 +143,18 @@
   "Build a byte-keyed `:entries` map from `{scoped-key-vector entry}`,
   stamping each entry's `:resource/key` (mirrors `runtime-db-with`)."
   [m]
-  (into {} (map (fn [[sk e]] [(state/key-id sk) (assoc e :resource/key sk)])) m))
-(defn- entry-by [entries sk] (get entries (state/key-id sk)))
+  (into {} (map (fn [[sk e]] [(rf.resources.state/key-id sk) (assoc e :resource/key sk)])) m))
+(defn- entry-by [entries sk] (get entries (rf.resources.state/key-id sk)))
 
 (defn- blocking-map
   "The byte-keyed blocking carrier `{<key-id> <scoped-key>}` the route slice
   writes and the drain consumes (rf2-btdl1)."
   [& ks]
-  (into {} (map (juxt state/key-id identity)) ks))
+  (into {} (map (juxt rf.resources.state/key-id identity)) ks))
 
 (def ^:private gkey
   ;; canonical global-scope key for :article/by-slug {:slug "x"}
-  (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "x"}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "x"}))
 
 ;; ===========================================================================
 ;; 1. SERVER projection
@@ -169,17 +169,17 @@
           rdb (assoc (runtime-db-with {gkey e})
                      :rf.runtime/machines {:snapshots {}}
                      :rf.runtime/routing  {:current {:route :x}})
-          proj (ssr/project-resources-runtime-db rdb)]
-      (is (= #{state/resources-key} (set (keys proj)))
+          proj (rf.resources.ssr/project-resources-runtime-db rdb)]
+      (is (= #{rf.resources.state/resources-key} (set (keys proj)))
           "only the :rf.runtime/resources subsystem key is projected")
-      (is (= #{:entries} (set (keys (get proj state/resources-key))))
+      (is (= #{:entries} (set (keys (get proj rf.resources.state/resources-key))))
           "only :entries rides — indexes are recomputable-from-entries")
-      (is (contains? (get-in proj [state/resources-key :entries]) (state/key-id gkey))))))
+      (is (contains? (get-in proj [rf.resources.state/resources-key :entries]) (rf.resources.state/key-id gkey))))))
 
 (deftest projection-empty-when-no-entries
   (testing "no resource entries → empty projection (the hook contributes nothing)"
-    (is (= {} (ssr/project-resources-runtime-db {})))
-    (is (= {} (ssr/project-resources-runtime-db (runtime-db-with {}))))))
+    (is (= {} (rf.resources.ssr/project-resources-runtime-db {})))
+    (is (= {} (rf.resources.ssr/project-resources-runtime-db (runtime-db-with {}))))))
 
 (defn- only-wire-entry
   "The single projected wire entry as `[projected-scoped-key wire-entry]` from
@@ -190,7 +190,7 @@
   about that projected scoped key, so this returns it as the first element
   (the byte map-key is exercised separately by the byte-keying tests)."
   [proj]
-  (let [we (val (first (get-in proj [state/resources-key :entries])))]
+  (let [we (val (first (get-in proj [rf.resources.state/resources-key :entries])))]
     [(:resource/key we) we]))
 
 (defn- only-projection-metadata
@@ -206,8 +206,8 @@
   the SSR and trace-egress derivations of one answer comparable (rf2-5e2ye,
   rf2-dl7bz) now that the wire entry is no longer a carrier."
   [runtime-db]
-  (first (ssr/projection-metadata
-           nil 5000 (get-in runtime-db [state/resources-key :entries]))))
+  (first (rf.resources.ssr/projection-metadata
+           nil 5000 (get-in runtime-db [rf.resources.state/resources-key :entries]))))
 
 (deftest sensitive-resource-row-is-withheld-not-shipped-redacted
   (reg! :secret/thing {:sensitive? true})
@@ -216,15 +216,15 @@
             it, and an emptied row would be an ownerless duplicate nothing
             collects. The projection decision stays fully observable on the
             metadata"
-    (let [k   (state/scoped-resource-key :rf.scope/global :secret/thing {:slug "s"})
+    (let [k   (rf.resources.state/scoped-resource-key :rf.scope/global :secret/thing {:slug "s"})
           e   (entry {:resource-id :secret/thing :data {:ssn "123-45-6789"}
                       :loaded-at 1000 :stale-at 9.0e15
                       :refresh-error {:kind :rf.http/http-5xx}})
           rdb (runtime-db-with {k e})
-          proj (ssr/project-resources-runtime-db rdb)
+          proj (rf.resources.ssr/project-resources-runtime-db rdb)
           m    (only-projection-metadata rdb)
           wk   (:projected-key m)]
-      (is (empty? (get-in proj [state/resources-key :entries]))
+      (is (empty? (get-in proj [rf.resources.state/resources-key :entries]))
           (str "no row rides — stated as absence of the ROW, not of its data: "
                (pr-str proj)))
       (is (not (str/includes? (pr-str proj) "123-45-6789"))
@@ -247,14 +247,14 @@
   (testing "rf2-4bjep — the same for a `:large?` resource. The two coarse arms
             differ in what they do to the data and not at all in what they do to
             the key, so withholding reaches both"
-    (let [k   (state/scoped-resource-key :rf.scope/global :big/thing {:slug "b"})
+    (let [k   (rf.resources.state/scoped-resource-key :rf.scope/global :big/thing {:slug "b"})
           e   (entry {:resource-id :big/thing :data (vec (range 10000))
                       :loaded-at 1000 :stale-at 9.0e15})
           rdb (runtime-db-with {k e})
-          proj (ssr/project-resources-runtime-db rdb)
+          proj (rf.resources.ssr/project-resources-runtime-db rdb)
           m    (only-projection-metadata rdb)
           wk   (:projected-key m)]
-      (is (empty? (get-in proj [state/resources-key :entries]))
+      (is (empty? (get-in proj [rf.resources.state/resources-key :entries]))
           (str "no row rides, so the large payload cannot: " (pr-str proj)))
       (is (= :omitted (:disposition m)))
       (is (true? (:withheld? m)))
@@ -278,15 +278,15 @@
           big   (entry {:resource-id :big/thing :data [1 2 3]
                         :loaded-at 1000 :stale-at 9.0e15})
           k-fresh gkey
-          k-stale (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "y"})
-          k-sens  (state/scoped-resource-key :rf.scope/global :secret/thing {:slug "s"})
-          k-big   (state/scoped-resource-key :rf.scope/global :big/thing {:slug "b"})
+          k-stale (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "y"})
+          k-sens  (rf.resources.state/scoped-resource-key :rf.scope/global :secret/thing {:slug "s"})
+          k-big   (rf.resources.state/scoped-resource-key :rf.scope/global :big/thing {:slug "b"})
           ;; rf2-9e0tyq — `projection-metadata` reads each entry's own
           ;; `:resource/key` (the `:entries` map is byte-keyed), so stamp it
           ;; (mirrors the runtime's byte-keyed `:entries` shape). The returned
           ;; metadata `:resource/key` is the scoped-key VECTOR, so the
           ;; `(metas k-…)` vector lookups below stay unchanged.
-          metas   (->> (ssr/projection-metadata
+          metas   (->> (rf.resources.ssr/projection-metadata
                          nil 5000
                          (entries* {k-fresh fresh k-stale stale k-sens sens k-big big}))
                        (into {} (map (juxt :resource/key identity))))]
@@ -323,9 +323,9 @@
   (reg! :article/by-slug)
   (testing "a non-sensitive, non-large resource's key rides VERBATIM (scope +
             params are wire-safe, same class as its data)"
-    (let [k    (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "x"})
+    (let [k    (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "x"})
           e    (entry {:resource-id :article/by-slug :data {:t "x"} :loaded-at 1000 :stale-at 9.0e15})
-          [wk _] (only-wire-entry (ssr/project-resources-runtime-db (runtime-db-with {k e})))]
+          [wk _] (only-wire-entry (rf.resources.ssr/project-resources-runtime-db (runtime-db-with {k e})))]
       (is (= k wk) "the serialized key is unchanged on the wire"))))
 
 (deftest sensitive-resource-key-scope-and-params-are-redacted
@@ -333,7 +333,7 @@
   (testing "a :sensitive? resource's scope (user/tenant markers) + params are
             redacted in the projected key — neither rides raw"
     (let [scope [:rf.scope/session {:user "alice@example.com" :tenant "acme"}]
-          k    (state/scoped-resource-key scope :secret/thing {:account-id "secret-42"})
+          k    (rf.resources.state/scoped-resource-key scope :secret/thing {:account-id "secret-42"})
           e    (entry {:resource-id :secret/thing :data {:ssn "x"} :loaded-at 1000 :stale-at 9.0e15})
           rdb  (runtime-db-with {k e})
           wk   (:projected-key (only-projection-metadata rdb))]
@@ -349,7 +349,7 @@
       ;; all. rf2-4bjep: a 32-bit digest of a low-entropy identity is
       ;; enumerable, so the TOKEN was itself a small egress of what the coarse
       ;; claim asked to hide, and withholding removes its last carrier.
-      (let [s (pr-str (ssr/project-resources-runtime-db rdb))]
+      (let [s (pr-str (rf.resources.ssr/project-resources-runtime-db rdb))]
         (is (not (str/includes? s "alice@example.com")))
         (is (not (str/includes? s "acme")))
         (is (not (str/includes? s "secret-42")))
@@ -363,13 +363,13 @@
             content-derived token over a low-entropy identity is recoverable by
             enumeration, so the trade is settled the other way: joins lose,
             because the token they were bought with was the leak"
-    (let [k1 (state/scoped-resource-key :rf.scope/global :secret/thing {:slug "alpha"})
-          k2 (state/scoped-resource-key :rf.scope/global :secret/thing {:slug "beta"})
+    (let [k1 (rf.resources.state/scoped-resource-key :rf.scope/global :secret/thing {:slug "alpha"})
+          k2 (rf.resources.state/scoped-resource-key :rf.scope/global :secret/thing {:slug "beta"})
           e1 (entry {:resource-id :secret/thing :data {:s 1} :loaded-at 1000 :stale-at 9.0e15})
           e2 (entry {:resource-id :secret/thing :data {:s 2} :loaded-at 1000 :stale-at 9.0e15})
           rdb  (runtime-db-with {k1 e1 k2 e2})
-          metas (ssr/projection-metadata
-                  nil 5000 (get-in rdb [state/resources-key :entries]))
+          metas (rf.resources.ssr/projection-metadata
+                  nil 5000 (get-in rdb [rf.resources.state/resources-key :entries]))
           wks   (set (map :projected-key metas))]
       (is (= 2 (count metas)) "premise: the metadata still accounts for both entries")
       (is (= 1 (count wks))
@@ -385,13 +385,13 @@
             withheld — the withholding matches the token by its :rf/redacted
             KEY, never by its payload, so no two entries can collide onto one
             surviving wire row (PR #7391 preserved)"
-    (let [k1 (state/scoped-resource-key :rf.scope/global :secret/thing {:slug "alpha"})
-          k2 (state/scoped-resource-key :rf.scope/global :secret/thing {:slug "beta"})
+    (let [k1 (rf.resources.state/scoped-resource-key :rf.scope/global :secret/thing {:slug "alpha"})
+          k2 (rf.resources.state/scoped-resource-key :rf.scope/global :secret/thing {:slug "beta"})
           e1 (entry {:resource-id :secret/thing :data {:s 1} :loaded-at 1000 :stale-at 9.0e15})
           e2 (entry {:resource-id :secret/thing :data {:s 2} :loaded-at 1000 :stale-at 9.0e15})
           rdb (runtime-db-with {k1 e1 k2 e2})]
-      (is (empty? (get-in (ssr/project-resources-runtime-db rdb)
-                          [state/resources-key :entries]))
+      (is (empty? (get-in (rf.resources.ssr/project-resources-runtime-db rdb)
+                          [rf.resources.state/resources-key :entries]))
           "neither row rides"))))
 
 (deftest large-keys-stay-distinct-no-collision
@@ -400,38 +400,38 @@
             so a content-derived token is permitted there and is KEPT. Two
             distinct large entries still project to distinct keys, which is what
             makes this a real classification split rather than a blanket removal"
-    (let [k1 (state/scoped-resource-key :rf.scope/global :bulky/thing {:slug "alpha"})
-          k2 (state/scoped-resource-key :rf.scope/global :bulky/thing {:slug "beta"})
+    (let [k1 (rf.resources.state/scoped-resource-key :rf.scope/global :bulky/thing {:slug "alpha"})
+          k2 (rf.resources.state/scoped-resource-key :rf.scope/global :bulky/thing {:slug "beta"})
           e1 (entry {:resource-id :bulky/thing :data {:s 1} :loaded-at 1000 :stale-at 9.0e15})
           e2 (entry {:resource-id :bulky/thing :data {:s 2} :loaded-at 1000 :stale-at 9.0e15})
           rdb   (runtime-db-with {k1 e1 k2 e2})
-          metas (ssr/projection-metadata
-                  nil 5000 (get-in rdb [state/resources-key :entries]))
+          metas (rf.resources.ssr/projection-metadata
+                  nil 5000 (get-in rdb [rf.resources.state/resources-key :entries]))
           wks   (set (map :projected-key metas))]
       (is (= 2 (count metas)) "premise: the metadata accounts for both entries")
       (is (= 2 (count wks)) "two distinct projected keys (no collision)")
-      (is (= 2 (count (set (map (comp state/key-id :projected-key) metas))))
+      (is (= 2 (count (set (map (comp rf.resources.state/key-id :projected-key) metas))))
           "…and two distinct BYTE identities, which is the form a collapse would take"))))
 
 (deftest project-scoped-key-is-pure
   (testing "project-scoped-key: :serialize rides verbatim; :redact/:omit both
             redact scope+params and preserve the resource-id"
-    (let [k1 (state/scoped-resource-key :rf.scope/global :r {:a 1})
-          k2 (state/scoped-resource-key :rf.scope/global :r {:a 2})]
+    (let [k1 (rf.resources.state/scoped-resource-key :rf.scope/global :r {:a 1})
+          k2 (rf.resources.state/scoped-resource-key :rf.scope/global :r {:a 2})]
       ;; nil spec → no :params-schema marks → :serialize rides params verbatim.
-      (is (= k1 (ssr/project-scoped-key k1 :serialize nil)))
-      (let [r1 (ssr/project-scoped-key k1 :redact nil)
-            r2 (ssr/project-scoped-key k2 :redact nil)]
+      (is (= k1 (rf.resources.ssr/project-scoped-key k1 :serialize nil)))
+      (let [r1 (rf.resources.ssr/project-scoped-key k1 :redact nil)
+            r2 (rf.resources.ssr/project-scoped-key k2 :redact nil)]
         (is (= :r (nth r1 1)) "resource-id preserved")
         (is (contains? (nth r1 2) :rf/redacted))
         (is (= r1 r2)
             "rf2-hzcv8 — SENSITIVE keys no longer stay distinct: the token that
              kept them apart was the enumerable one")
-        (is (= r1 (ssr/project-scoped-key k1 :redact nil)) "deterministic"))
-      (let [o1 (ssr/project-scoped-key k1 :omit nil)
-            o2 (ssr/project-scoped-key k2 :omit nil)]
+        (is (= r1 (rf.resources.ssr/project-scoped-key k1 :redact nil)) "deterministic"))
+      (let [o1 (rf.resources.ssr/project-scoped-key k1 :omit nil)
+            o2 (rf.resources.ssr/project-scoped-key k2 :omit nil)]
         (is (not= o1 o2) ":omit (large) keeps distinctness — a size claim permits a digest")
-        (is (not= (ssr/project-scoped-key k1 :redact nil) o1)
+        (is (not= (rf.resources.ssr/project-scoped-key k1 :redact nil) o1)
             ":redact and :omit no longer project identically — the payload is
              chosen by classification (rf2-hzcv8)")))))
 
@@ -477,63 +477,63 @@
             every slot is a closed-vocabulary tag or an integer. There is no
             candidate space to enumerate against it: every 6-character string
             produces the same token"
-    (is (= {:rf/redacted {:type :string :count 6}} (ssr/redact-value "tenant")))
-    (is (= (ssr/redact-value "tenant") (ssr/redact-value "abc123"))
+    (is (= {:rf/redacted {:type :string :count 6}} (rf.resources.ssr/redact-value "tenant")))
+    (is (= (rf.resources.ssr/redact-value "tenant") (rf.resources.ssr/redact-value "abc123"))
         "two distinct 6-char secrets are INDISTINGUISHABLE — that is the property")
-    (is (= {:rf/redacted {:type :map :count 1}} (ssr/redact-value {:tenant-id cafe-str})))
-    (is (= {:rf/redacted {:type :number}} (ssr/redact-value 42)))
-    (is (= {:rf/redacted nil} (ssr/redact-value nil))
+    (is (= {:rf/redacted {:type :map :count 1}} (rf.resources.ssr/redact-value {:tenant-id cafe-str})))
+    (is (= {:rf/redacted {:type :number}} (rf.resources.ssr/redact-value 42)))
+    (is (= {:rf/redacted nil} (rf.resources.ssr/redact-value nil))
         "nil / empty still projects to the stable no-content token")
-    (is (= {:rf/redacted nil} (ssr/redact-value {}))))
+    (is (= {:rf/redacted nil} (rf.resources.ssr/redact-value {}))))
 
   (testing "the 1-arity is the SAFE one, so a caller that cannot name a
             disposition cannot accidentally mint an enumerable token"
-    (is (= (ssr/redact-value "tenant") (ssr/redact-value "tenant" :redact))))
+    (is (= (rf.resources.ssr/redact-value "tenant") (rf.resources.ssr/redact-value "tenant" :redact))))
 
   (testing "and it is TOTAL — an app payload carrying a value outside CEDN-1 is
             summarised, not thrown at. A redaction that explodes is not a
             redaction"
-    (is (= {:rf/redacted {:type :map :count 1}} (ssr/redact-value {:f (fn [_])})))
-    (is (= {:rf/redacted {:type :number}} (ssr/redact-value 1.5)))))
+    (is (= {:rf/redacted {:type :map :count 1}} (rf.resources.ssr/redact-value {:f (fn [_])})))
+    (is (= {:rf/redacted {:type :number}} (rf.resources.ssr/redact-value 1.5)))))
 
 (deftest large-redaction-digest-is-byte-identical-across-clj-and-cljs
   (testing "rf2-4bjep / rf2-hzcv8 — the `:omit` (large) digest is a fixed
             function of the value's CANONICAL BYTES on EVERY host. The expected
             digests are literals checked by both runs of this `.cljc`, which is
             the only shape of assertion that can catch one host drifting"
-    (is (= {:rf/redacted "d6a56084"} (ssr/redact-value "tenant" :omit))
+    (is (= {:rf/redacted "d6a56084"} (rf.resources.ssr/redact-value "tenant" :omit))
         "ASCII: the case the two fnv branches disagreed on even though their
          bytes were identical — the double multiply lost the low bits")
-    (is (= {:rf/redacted "475d8714"} (ssr/redact-value "" :omit))
+    (is (= {:rf/redacted "475d8714"} (rf.resources.ssr/redact-value "" :omit))
         "the empty string still hashes (it is not the nil/empty-COLLECTION case)")
-    (is (= {:rf/redacted "3fb1602a"} (ssr/redact-value cafe-str :omit))
+    (is (= {:rf/redacted "3fb1602a"} (rf.resources.ssr/redact-value cafe-str :omit))
         "non-ASCII: one code point, two UTF-8 bytes, one UTF-16 code unit")
-    (is (= {:rf/redacted "c4ef233c"} (ssr/redact-value emoji-str :omit))
+    (is (= {:rf/redacted "c4ef233c"} (rf.resources.ssr/redact-value emoji-str :omit))
         "a SURROGATE PAIR: one code point, four UTF-8 bytes, TWO UTF-16 code
          units — the case a per-code-unit walk cannot get right")
-    (is (= {:rf/redacted "cd777c20"} (ssr/redact-value {:tenant-id cafe-str} :omit))
+    (is (= {:rf/redacted "cd777c20"} (rf.resources.ssr/redact-value {:tenant-id cafe-str} :omit))
         "and the same through a whole scope map, which is how it is really used")
-    (is (= {:rf/redacted nil} (ssr/redact-value nil :omit)))))
+    (is (= {:rf/redacted nil} (rf.resources.ssr/redact-value nil :omit)))))
 
 (deftest large-redaction-digest-is-a-function-of-the-canonical-value
   (testing "rf2-hzcv8's concrete witness — `(array-map :a 1 :b 2)` and
             `(array-map :b 2 :a 1)` are `=`, have equal canonical bytes, and
             emitted 943e4859 / 08a47259 under `pr-str`. Hashing
             identity/canonical-bytes makes them ONE token, on both hosts"
-    (is (= (ssr/redact-value (array-map :a 1 :b 2) :omit)
-           (ssr/redact-value (array-map :b 2 :a 1) :omit)))
-    (is (= {:rf/redacted "64f7985e"} (ssr/redact-value (array-map :a 1 :b 2) :omit))
+    (is (= (rf.resources.ssr/redact-value (array-map :a 1 :b 2) :omit)
+           (rf.resources.ssr/redact-value (array-map :b 2 :a 1) :omit)))
+    (is (= {:rf/redacted "64f7985e"} (rf.resources.ssr/redact-value (array-map :a 1 :b 2) :omit))
         "pinned as a literal so a host that reorders differently reds here"))
 
   (testing "SET construction order likewise — canonical bytes sort set elements"
-    (is (= (ssr/redact-value #{:a :b :c} :omit)
-           (ssr/redact-value (into #{} [:c :b :a]) :omit))))
+    (is (= (rf.resources.ssr/redact-value #{:a :b :c} :omit)
+           (rf.resources.ssr/redact-value (into #{} [:c :b :a]) :omit))))
 
   (testing "and a value OUTSIDE CEDN-1 falls back to the content-free shape
             rather than throwing — `canonical-bytes` is partial, and an off-box
             egress projector is handed whatever the app owns"
-    (is (= {:rf/redacted {:type :map :count 1}} (ssr/redact-value {:f (fn [_])} :omit)))
-    (is (= {:rf/redacted {:type :number}} (ssr/redact-value 1.5 :omit)))))
+    (is (= {:rf/redacted {:type :map :count 1}} (rf.resources.ssr/redact-value {:f (fn [_])} :omit)))
+    (is (= {:rf/redacted {:type :number}} (rf.resources.ssr/redact-value 1.5 :omit)))))
 
 (deftest the-large-redaction-digest-has-the-shape-it-documents
   (testing "rf2-4bjep — 8 lower-case hex characters, always. The CLJS branch's
@@ -542,7 +542,7 @@
             a spread wide enough to hit the negative half rather than over one
             lucky value"
     (let [digests (into []
-                        (map (fn [i] (:rf/redacted (ssr/redact-value {:n i :s (str "id-" i)} :omit))))
+                        (map (fn [i] (:rf/redacted (rf.resources.ssr/redact-value {:n i :s (str "id-" i)} :omit))))
                         (range 256))]
       (is (every? (fn [d] (and (string? d)
                                (= 8 (count d))
@@ -560,9 +560,9 @@
 ;; 2. SERVER blocking drain + timeout
 ;; ===========================================================================
 
-(def ^:private ka (state/scoped-resource-key :rf.scope/global :a {:slug "a"}))
-(def ^:private kb (state/scoped-resource-key :rf.scope/global :b {:slug "b"}))
-(def ^:private kc (state/scoped-resource-key :rf.scope/global :c {:slug "c"}))
+(def ^:private ka (rf.resources.state/scoped-resource-key :rf.scope/global :a {:slug "a"}))
+(def ^:private kb (rf.resources.state/scoped-resource-key :rf.scope/global :b {:slug "b"}))
+(def ^:private kc (rf.resources.state/scoped-resource-key :rf.scope/global :c {:slug "c"}))
 
 (deftest blocking-settled-predicate
   (testing "blocking-settled? is true iff every blocking entry has settled"
@@ -570,13 +570,13 @@
           errored (entry {:resource-id :b :status :error})
           loading (entry {:resource-id :c :status :loading})
           es      (entries* {ka loaded kb errored kc loading})]
-      (is (true?  (ssr/blocking-settled? es (blocking-map ka kb)))
+      (is (true?  (rf.resources.ssr/blocking-settled? es (blocking-map ka kb)))
           ":loaded and :error are settled")
-      (is (false? (ssr/blocking-settled? es (blocking-map ka kc)))
+      (is (false? (rf.resources.ssr/blocking-settled? es (blocking-map ka kc)))
           ":loading is NOT settled")
-      (is (false? (ssr/blocking-settled? es (blocking-map ka [:rf.scope/global :missing {}])))
+      (is (false? (rf.resources.ssr/blocking-settled? es (blocking-map ka [:rf.scope/global :missing {}])))
           "an absent (never-enqueued) blocking key is not settled")
-      (is (true?  (ssr/blocking-settled? es {}))
+      (is (true?  (rf.resources.ssr/blocking-settled? es {}))
           "no blocking resources → trivially settled (never blocks render)"))))
 
 (deftest blocking-timeout-settles-first-load-failure
@@ -586,7 +586,7 @@
           loaded  (entry {:resource-id :b :status :loaded :data {:x 1}})
           es      (entries* {ka loading kb loaded})
           {:keys [entries route-blocking-failure]}
-          (ssr/settle-blocking-timeout es (blocking-map ka kb) 250 :app/main)]
+          (rf.resources.ssr/settle-blocking-timeout es (blocking-map ka kb) 250 :app/main)]
       (testing "the unsettled blocking entry settles to a first-load :error"
         (let [se (entry-by entries ka)]
           (is (= :error (:status se)))
@@ -604,15 +604,15 @@
   (testing "no unsettled blocking entries → no failure record, entries unchanged"
     (let [es (entries* {ka (entry {:resource-id :a :status :loaded :data {:x 1}})})
           {:keys [entries route-blocking-failure]}
-          (ssr/settle-blocking-timeout es (blocking-map ka) 250 :app/main)]
+          (rf.resources.ssr/settle-blocking-timeout es (blocking-map ka) 250 :app/main)]
       (is (= es entries))
       (is (nil? route-blocking-failure)))))
 
 (deftest blocking-timeout-settles-absent-blocking-key
   (testing "an absent blocking key (enqueued but never wrote an entry) settles to :error"
-    (let [kmiss (state/scoped-resource-key :rf.scope/global :missing {})
+    (let [kmiss (rf.resources.state/scoped-resource-key :rf.scope/global :missing {})
           {:keys [entries route-blocking-failure]}
-          (ssr/settle-blocking-timeout {} (blocking-map kmiss) 100 :app/main)]
+          (rf.resources.ssr/settle-blocking-timeout {} (blocking-map kmiss) 100 :app/main)]
       ;; rf2-9e0tyq — the settled entry is keyed on the byte key-id.
       (is (= :error (:status (entry-by entries kmiss))))
       (is (= #{kmiss} (set (:timed-out route-blocking-failure)))))))
@@ -635,7 +635,7 @@
   drain loop reads/writes."
   [frame-id runtime-db]
   (rf/make-frame {:id frame-id :doc "ssr blocking-drain test frame" :platform :server})
-  (frame/replace-runtime-db! frame-id runtime-db)
+  (rf.frame/replace-runtime-db! frame-id runtime-db)
   frame-id)
 
 (defn- with-blocking-slot
@@ -656,23 +656,23 @@
                   ;; a superseded nav-token's stale slot must NOT leak in
                   (assoc-in [:rf.runtime/routing :resource-blocking "nav-OLD"]
                             (blocking-map kc)))]
-      (is (= (blocking-map ka kb) (ssr/current-blocking-keys rdb))))
+      (is (= (blocking-map ka kb) (rf.resources.ssr/current-blocking-keys rdb))))
     (testing "no routing slice / no current nav-token → empty (never blocks)"
-      (is (= {} (ssr/current-blocking-keys (runtime-db-with {}))))
-      (is (= {} (ssr/current-blocking-keys {}))))))
+      (is (= {} (rf.resources.ssr/current-blocking-keys (runtime-db-with {}))))
+      (is (= {} (rf.resources.ssr/current-blocking-keys {}))))))
 
 (deftest drain-noop-when-no-blocking-resources
   (testing "a route with no blocking resources returns :settled? immediately, no pump"
     (let [pumped (atom 0)
           fid    (seed-frame-runtime-db! :ssr/drain-none
                                          (runtime-db-with {ka (entry {:resource-id :a :status :loaded :data {:x 1}})}))
-          res    (ssr/drain-blocking-resources!
+          res    (rf.resources.ssr/drain-blocking-resources!
                    fid {:pump! (fn [_] (swap! pumped inc)) :deadline-ms 1000})]
       (is (true? (:settled? res)))
       (is (= [] (:timed-out res)))
       (is (nil? (:route-blocking-failure res)))
       (is (zero? @pumped) "no blocking set → the loop never pumps")
-      (frame/destroy-frame! fid))))
+      (rf.frame/destroy-frame! fid))))
 
 (deftest drain-settles-when-blocking-entries-already-settled
   (testing "blocking entries already settled → :settled? true, runtime-db untouched, no timeout"
@@ -680,13 +680,13 @@
                                     kb (entry {:resource-id :b :status :error})})
                   (with-blocking-slot "nav-1" [ka kb]))
           fid (seed-frame-runtime-db! :ssr/drain-settled rdb)
-          res (ssr/drain-blocking-resources! fid {:pump! (fn [_] nil) :deadline-ms 1000})]
+          res (rf.resources.ssr/drain-blocking-resources! fid {:pump! (fn [_] nil) :deadline-ms 1000})]
       (is (true? (:settled? res)))
       (is (nil? (:route-blocking-failure res)))
-      (is (= :loaded (get-in (frame/frame-runtime-db-value fid)
-                             [state/resources-key :entries (state/key-id ka) :status]))
+      (is (= :loaded (get-in (rf.frame/frame-runtime-db-value fid)
+                             [rf.resources.state/resources-key :entries (rf.resources.state/key-id ka) :status]))
           "the settled entry is untouched")
-      (frame/destroy-frame! fid))))
+      (rf.frame/destroy-frame! fid))))
 
 (deftest drain-pumps-until-a-blocking-reply-lands
   (testing "the loop pumps until an in-flight blocking entry settles; the pump
@@ -699,16 +699,16 @@
           ticks (atom 0)
           pump! (fn [_]
                   (when (= 2 (swap! ticks inc))
-                    (frame/swap-runtime-db!
-                      fid assoc-in [state/resources-key :entries (state/key-id ka)]
+                    (rf.frame/swap-runtime-db!
+                      fid assoc-in [rf.resources.state/resources-key :entries (rf.resources.state/key-id ka)]
                       (assoc (entry {:resource-id :a :status :loaded :data {:x 1}})
                              :resource/key ka))))
-          res   (ssr/drain-blocking-resources! fid {:pump! pump! :deadline-ms 60000})]
+          res   (rf.resources.ssr/drain-blocking-resources! fid {:pump! pump! :deadline-ms 60000})]
       (is (true? (:settled? res)) "the loop settled once the reply landed")
       (is (nil? (:route-blocking-failure res)) "no timeout — it settled in time")
-      (is (= {:x 1} (get-in (frame/frame-runtime-db-value fid)
-                            [state/resources-key :entries (state/key-id ka) :data])))
-      (frame/destroy-frame! fid))))
+      (is (= {:x 1} (get-in (rf.frame/frame-runtime-db-value fid)
+                            [rf.resources.state/resources-key :entries (rf.resources.state/key-id ka) :data])))
+      (rf.frame/destroy-frame! fid))))
 
 (deftest drain-times-out-a-never-settling-blocking-resource
   (testing "ADVERSARIAL: a never-settling blocking resource is settled to a
@@ -723,12 +723,12 @@
           ;; a no-op (the resource never settles).
           clk (atom 0)
           clock-fn (fn [] (let [v @clk] (swap! clk + 100) v))]
-      (let [res (ssr/drain-blocking-resources!
+      (let [res (rf.resources.ssr/drain-blocking-resources!
                   fid {:pump! (fn [_] nil) :deadline-ms 50 :clock-fn clock-fn})]
         (is (false? (:settled? res)) "the loop reported a timeout, not a settle")
         (is (= [ka] (:timed-out res)))
-        (let [se (get-in (frame/frame-runtime-db-value fid)
-                         [state/resources-key :entries (state/key-id ka)])]
+        (let [se (get-in (rf.frame/frame-runtime-db-value fid)
+                         [rf.resources.state/resources-key :entries (rf.resources.state/key-id ka)])]
           (is (= :error (:status se))
               "the never-settling blocking entry is SETTLED to :error, not left :loading")
           (is (= :rf.http/timeout (:kind (:error se))))
@@ -736,7 +736,7 @@
         (is (= :rf.error/resource-ssr-blocking-timeout
                (:rf.error/id (:route-blocking-failure res)))
             "a route-blocking-failure record is produced for the renderer / route slice"))
-      (frame/destroy-frame! fid))))
+      (rf.frame/destroy-frame! fid))))
 
 (deftest drain-times-out-with-nil-pump-sync-stub
   (testing "a nil :pump! (a synchronous stub) still respects the deadline — a
@@ -746,18 +746,18 @@
           fid (seed-frame-runtime-db! :ssr/drain-nilpump rdb)
           clk (atom 0)
           clock-fn (fn [] (let [v @clk] (swap! clk + 100) v))
-          res (ssr/drain-blocking-resources!
+          res (rf.resources.ssr/drain-blocking-resources!
                 fid {:pump! nil :deadline-ms 50 :clock-fn clock-fn})]
       (is (false? (:settled? res)))
-      (is (= :error (get-in (frame/frame-runtime-db-value fid)
-                            [state/resources-key :entries (state/key-id ka) :status])))
-      (frame/destroy-frame! fid))))
+      (is (= :error (get-in (rf.frame/frame-runtime-db-value fid)
+                            [rf.resources.state/resources-key :entries (rf.resources.state/key-id ka) :status])))
+      (rf.frame/destroy-frame! fid))))
 
 (deftest drain-hook-published
   (testing "the :resources/drain-blocking-ssr! late-bind hook is published by the façade"
-    (is (some? (late-bind/get-fn :resources/drain-blocking-ssr!)))
-    (is (= ssr/drain-blocking-resources!
-           (late-bind/get-fn :resources/drain-blocking-ssr!)))))
+    (is (some? (rf.late-bind/get-fn :resources/drain-blocking-ssr!)))
+    (is (= rf.resources.ssr/drain-blocking-resources!
+           (rf.late-bind/get-fn :resources/drain-blocking-ssr!)))))
 
 ;; ===========================================================================
 ;; 2c. SSR blocking drain ↔ WORK-LEDGER TERMINAL completion (rf2-jnrotz,
@@ -789,7 +789,7 @@
 (defn- ledger-row
   "The work-ledger record for `work-id` in `frame-id`'s live runtime-db, or nil."
   [frame-id work-id]
-  (work-ledger/get-record (frame/frame-runtime-db-value frame-id) work-id))
+  (rf.resources.work-ledger/get-record (rf.frame/frame-runtime-db-value frame-id) work-id))
 
 (deftest drain-releases-only-when-work-ledger-row-terminal-real-path
   (reg! :article/by-slug)
@@ -807,19 +807,19 @@
                           :params {:slug "x"} :owner [:ssr "req-1" "nav-1"]
                           :cause [:route-entry :route/article "nav-1"]}]
                         {:frame fid})
-      (let [wid (get-in (frame/frame-runtime-db-value fid) (conj (state/entry-path gkey) :current-work))]
+      (let [wid (get-in (rf.frame/frame-runtime-db-value fid) (conj (rf.resources.state/entry-path gkey) :current-work))]
         (testing "the real ensure path armed the joined work facts before the drain"
           (is (some? wid) "the entry points at a current work id")
           (is (= :running (:status (ledger-row fid wid)))
               "the work-ledger row is NON-terminal (:running) while in flight")
-          (is (some? (work-ledger/get-handle fid wid))
+          (is (some? (rf.resources.work-ledger/get-handle fid wid))
               "a host handle exists for the in-flight attempt")
-          (is (= :loading (get-in (frame/frame-runtime-db-value fid)
-                                  (conj (state/entry-path gkey) :status)))
+          (is (= :loading (get-in (rf.frame/frame-runtime-db-value fid)
+                                  (conj (rf.resources.state/entry-path gkey) :status)))
               "the entry is :loading (not yet settled)"))
         ;; publish the nav-token blocking slot the drain reads (mirrors what the
         ;; route slice writes on entry).
-        (frame/swap-runtime-db! fid with-blocking-slot "nav-1" [gkey])
+        (rf.frame/swap-runtime-db! fid with-blocking-slot "nav-1" [gkey])
         ;; the pump fires the REAL reply on the 2nd tick — settling the entry
         ;; :loaded AND the ledger row terminal :completed + clearing the handle
         ;; through `succeeded-handler`, exactly as a real transport reply would.
@@ -831,29 +831,29 @@
                            {:resource/key gkey :work/id wid :generation 1
                             :rf.frame/id fid :data {:title "X"}}]
                           {:frame fid})))
-              res   (ssr/drain-blocking-resources! fid {:pump! pump! :deadline-ms 60000})]
+              res   (rf.resources.ssr/drain-blocking-resources! fid {:pump! pump! :deadline-ms 60000})]
           (testing "the drain releases (the blocking entry settled in time)"
             (is (true? (:settled? res)))
             (is (nil? (:route-blocking-failure res)) "no timeout — settled in time"))
           (testing "the JOIN: when the drain released, the entry is :loaded AND
                     the work-ledger row is TERMINAL (the EP-0011 §SSR contract)"
-            (is (= :loaded (get-in (frame/frame-runtime-db-value fid)
-                                   (conj (state/entry-path gkey) :status)))
+            (is (= :loaded (get-in (rf.frame/frame-runtime-db-value fid)
+                                   (conj (rf.resources.state/entry-path gkey) :status)))
                 "the blocking entry settled :loaded")
             (let [row (ledger-row fid wid)]
               ;; the row is terminal (:completed) — or pruned to nil if the
               ;; bounded per-key tail dropped it; either way it is NOT live /
               ;; non-terminal. The load-bearing assertion is that NO non-terminal
               ;; row for the work survives once the drain releases.
-              (is (or (nil? row) (work-ledger/terminal? (:status row)))
+              (is (or (nil? row) (rf.resources.work-ledger/terminal? (:status row)))
                   "the associated work-ledger row is terminal (or pruned), never non-terminal"))
-            (is (not (contains? work-ledger/non-terminal-statuses
+            (is (not (contains? rf.resources.work-ledger/non-terminal-statuses
                                 (:status (ledger-row fid wid))))
                 "no NON-terminal ledger row survives the released drain"))
           (testing "the host handle is cleared (no live host work behind a
                     released SSR render)"
-            (is (nil? (work-ledger/get-handle fid wid)))))
-        (frame/destroy-frame! fid)))))
+            (is (nil? (rf.resources.work-ledger/get-handle fid wid)))))
+        (rf.frame/destroy-frame! fid)))))
 
 (deftest drain-blocks-while-work-ledger-row-non-terminal-real-path
   (reg! :article/by-slug)
@@ -868,15 +868,15 @@
                          {:resource :article/by-slug :scope :rf.scope/global
                           :params {:slug "x"} :owner [:ssr "req-2" "nav-2"]}]
                         {:frame fid})
-      (frame/swap-runtime-db! fid with-blocking-slot "nav-2" [gkey])
-      (let [wid (get-in (frame/frame-runtime-db-value fid) (conj (state/entry-path gkey) :current-work))
+      (rf.frame/swap-runtime-db! fid with-blocking-slot "nav-2" [gkey])
+      (let [wid (get-in (rf.frame/frame-runtime-db-value fid) (conj (rf.resources.state/entry-path gkey) :current-work))
             ;; deterministic clock that jumps past the deadline; pump! is a no-op
             ;; (the real reply never lands → the ledger row stays :running).
             clk (atom 0)
             clock-fn (fn [] (let [v @clk] (swap! clk + 100) v))]
         (is (= :running (:status (ledger-row fid wid)))
             "the row is NON-terminal at drain entry")
-        (let [res (ssr/drain-blocking-resources!
+        (let [res (rf.resources.ssr/drain-blocking-resources!
                     fid {:pump! (fn [_] nil) :deadline-ms 50 :clock-fn clock-fn})]
           (testing "the drain did NOT release early — it reported a timeout"
             (is (false? (:settled? res)))
@@ -885,9 +885,9 @@
                    (:rf.error/id (:route-blocking-failure res)))))
           (testing "the never-settling blocking entry is settled to a structured
                     first-load :error in the frame (not left hung :loading)"
-            (is (= :error (get-in (frame/frame-runtime-db-value fid)
-                                  (conj (state/entry-path gkey) :status)))))))
-      (frame/destroy-frame! fid))))
+            (is (= :error (get-in (rf.frame/frame-runtime-db-value fid)
+                                  (conj (rf.resources.state/entry-path gkey) :status)))))))
+      (rf.frame/destroy-frame! fid))))
 
 (deftest hydration-projection-ships-no-work-ledger-rows
   (reg! :article/by-slug)
@@ -903,17 +903,17 @@
                          {:resource :article/by-slug :scope :rf.scope/global
                           :params {:slug "x"} :owner [:ssr "req-3" "nav-3"]}]
                         {:frame fid})
-      (let [rdb (frame/frame-runtime-db-value fid)]
-        (is (seq (get rdb state/work-ledger-key))
+      (let [rdb (rf.frame/frame-runtime-db-value fid)]
+        (is (seq (get rdb rf.resources.state/work-ledger-key))
             "the live runtime-db carries a work-ledger row before projection")
-        (let [proj (payload-policy/project-runtime-db rdb)]
-          (is (contains? proj state/resources-key)
+        (let [proj (rf.ssr.payload-policy/project-runtime-db rdb)]
+          (is (contains? proj rf.resources.state/resources-key)
               "the resource :entries slice rides the wire")
-          (is (not (contains? proj state/work-ledger-key))
+          (is (not (contains? proj rf.resources.state/work-ledger-key))
               "the :rf.runtime/work-ledger subtree does NOT ride the hydration wire")
-          (is (= #{:entries} (set (keys (get proj state/resources-key))))
+          (is (= #{:entries} (set (keys (get proj rf.resources.state/resources-key))))
               "only :entries rides — no indexes, no work rows")))
-      (frame/destroy-frame! fid))))
+      (rf.frame/destroy-frame! fid))))
 
 ;; ===========================================================================
 ;; 3. CLIENT hydration reconcile
@@ -926,11 +926,11 @@
                       :tags #{[:article "x"]}
                       :owners #{[:route :route/article "nav-1"]}})
           ;; arrive with deliberately-WRONG (stale) indexes — they must be discarded
-          rdb {state/resources-key {:entries   {gkey e}
+          rdb {rf.resources.state/resources-key {:entries   {gkey e}
                                     :tag-index {[:bogus] #{:nope}}
                                     :owner-index {[:bogus] #{:nope}}}}
-          out (ssr/hydrate-runtime-db rdb :app/main)
-          sub (get out state/resources-key)]
+          out (rf.resources.ssr/hydrate-runtime-db rdb :app/main)
+          sub (get out rf.resources.state/resources-key)]
       (is (= {[:article "x"] #{gkey}} (:tag-index sub))
           "tag-index recomputed from the entry's :tags, the bogus wire index discarded")
       (is (= {[:route :route/article "nav-1"] #{gkey}} (:owner-index sub))
@@ -942,13 +942,13 @@
                       :loaded-at 1000 :stale-at 9.0e15
                       :owners #{[:ssr "req-7" "nav-1"]
                                 [:route :route/article "nav-1"]}})
-          out (ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)
-          owners (get-in out [state/resources-key :entries (state/key-id gkey) :active-owners])]
+          out (rf.resources.ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)
+          owners (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id gkey) :active-owners])]
       (is (not (contains? owners [:ssr "req-7" "nav-1"]))
           "the SSR owner is dropped as an orphan")
       (is (contains? owners [:route :route/article "nav-1"])
           "the route owner survives (its liveness is reconciled by routing)")
-      (is (not (contains? (get-in out [state/resources-key :owner-index])
+      (is (not (contains? (get-in out [rf.resources.state/resources-key :owner-index])
                           [:ssr "req-7" "nav-1"]))
           "the orphaned SSR owner is absent from the recomputed owner-index"))))
 
@@ -957,21 +957,21 @@
     (let [e   (entry {:resource-id :article/by-slug :data {:t "x"}
                       :loaded-at 1000 :stale-at 9.0e15
                       :current-work [:rf.work/resource gkey 1]})
-          out (ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)]
-      (is (nil? (get-in out [state/resources-key :entries (state/key-id gkey) :current-work]))))))
+          out (rf.resources.ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)]
+      (is (nil? (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id gkey) :current-work]))))))
 
 (deftest hydrate-preserves-entry-data
   (testing "hydrated entries are PRESERVED (data + status survive the reconcile)"
     (let [e   (entry {:resource-id :article/by-slug :data {:t "kept"}
                       :loaded-at 1000 :stale-at 9.0e15})
-          out (ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)]
-      (is (= {:t "kept"} (get-in out [state/resources-key :entries (state/key-id gkey) :data])))
-      (is (= :loaded (get-in out [state/resources-key :entries (state/key-id gkey) :status]))))))
+          out (rf.resources.ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)]
+      (is (= {:t "kept"} (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id gkey) :data])))
+      (is (= :loaded (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id gkey) :status]))))))
 
 (deftest hydrate-noop-without-resources
   (testing "a runtime-db with no resource entries is returned unchanged (SSR app without resources)"
     (let [rdb {:rf.runtime/machines {:snapshots {}}}]
-      (is (= rdb (ssr/hydrate-runtime-db rdb :app/main))))))
+      (is (= rdb (rf.resources.ssr/hydrate-runtime-db rdb :app/main))))))
 
 ;; ===========================================================================
 ;; 3b. Hydrated NON-TERMINAL entries settle to last-stable (rf2-bg6qah)
@@ -991,10 +991,10 @@
   (testing "rf2-bg6qah — a hydrated :loading entry with NO data settles to :idle
             (never stranded :loading), and the refetch plan then refetches it"
     (let [e   (entry {:resource-id :article/by-slug :status :loading :data nil})
-          out (ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)
-          se  (get-in out [state/resources-key :entries (state/key-id gkey)])]
+          out (rf.resources.ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)
+          se  (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id gkey)])]
       (is (= :idle (:status se)) "loading-with-no-data → :idle, never a dangling :loading")
-      (let [plan (->> (ssr/hydrate-refetch-plan out 5000)
+      (let [plan (->> (rf.resources.ssr/hydrate-refetch-plan out 5000)
                       (into {} (map (juxt :resource/key identity))))]
         (is (contains? plan gkey) "the settled :idle entry (no data) is refetched")
         (is (= :no-data (:reason (plan gkey))))))))
@@ -1005,11 +1005,11 @@
             case the bead calls out)"
     (let [e   (entry {:resource-id :article/by-slug :status :fetching
                       :data {:t "fresh"} :loaded-at 1000 :stale-at 9.0e15})
-          out (ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)
-          se  (get-in out [state/resources-key :entries (state/key-id gkey)])]
+          out (rf.resources.ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)
+          se  (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id gkey)])]
       (is (= :loaded (:status se)) "fetching-with-fresh-data → :loaded (keep last-known-good)")
       (is (= {:t "fresh"} (:data se)) "the data is preserved")
-      (let [plan (->> (ssr/hydrate-refetch-plan out 5000)
+      (let [plan (->> (rf.resources.ssr/hydrate-refetch-plan out 5000)
                       (into {} (map (juxt :resource/key identity))))]
         (is (not (contains? plan gkey))
             "the settled fresh-with-data entry is NOT refetched (no double-fetch — the SSR win)")))))
@@ -1019,11 +1019,11 @@
             :loaded (keep last-known-good) and background-refetches"
     (let [e   (entry {:resource-id :article/by-slug :status :fetching
                       :data {:t "stale"} :loaded-at 1000 :stale-at 1500})  ;; stale vs 5000
-          out (ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)
-          se  (get-in out [state/resources-key :entries (state/key-id gkey)])]
+          out (rf.resources.ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)
+          se  (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id gkey)])]
       (is (= :loaded (:status se)) "fetching-with-stale-data → :loaded")
       (is (= {:t "stale"} (:data se)) "the stale last-known-good data is preserved")
-      (let [plan (->> (ssr/hydrate-refetch-plan out 5000)
+      (let [plan (->> (rf.resources.ssr/hydrate-refetch-plan out 5000)
                       (into {} (map (juxt :resource/key identity))))]
         (is (= :stale (:reason (plan gkey)))
             "the settled stale entry background-refetches (stale-while-revalidate)")))))
@@ -1033,11 +1033,11 @@
             (already stable) and is NOT refetched"
     (let [e   (entry {:resource-id :article/by-slug :status :loaded
                       :data {:t "kept"} :loaded-at 1000 :stale-at 9.0e15})
-          out (ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)
-          se  (get-in out [state/resources-key :entries (state/key-id gkey)])]
+          out (rf.resources.ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)
+          se  (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id gkey)])]
       (is (= :loaded (:status se)) "a :loaded entry stays :loaded")
       (is (= {:t "kept"} (:data se)))
-      (let [plan (->> (ssr/hydrate-refetch-plan out 5000)
+      (let [plan (->> (rf.resources.ssr/hydrate-refetch-plan out 5000)
                       (into {} (map (juxt :resource/key identity))))]
         (is (not (contains? plan gkey)) "fresh-loaded → no refetch (no double-fetch)")))))
 
@@ -1050,15 +1050,15 @@
     (let [e    (entry {:resource-id :article/by-slug :status :fetching
                        :data {:t "x"} :loaded-at 1000 :stale-at 9.0e15
                        :current-work [:rf.work/resource gkey 7]})
-          proj (ssr/project-resources-runtime-db (runtime-db-with {gkey e}))
+          proj (rf.resources.ssr/project-resources-runtime-db (runtime-db-with {gkey e}))
           [wk we] (only-wire-entry proj)]
       (is (= :fetching (:status we)) "the projection keeps the entry's :fetching status on the wire")
       (is (not (contains? we :current-work)) "the projection strips :current-work on the wire")
       ;; rf2-9e0tyq — install the REAL projected (byte-keyed) map; look the
       ;; settled entry up by the byte `key-id` of the projected scoped key.
       (let [installed proj
-            out (ssr/hydrate-runtime-db installed :app/main)
-            se  (get-in out [state/resources-key :entries (state/key-id wk)])]
+            out (rf.resources.ssr/hydrate-runtime-db installed :app/main)
+            se  (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id wk)])]
         (is (= :loaded (:status se))
             "hydration settles the dangling :fetching entry to :loaded — not installed verbatim")
         (is (nil? (:current-work se)) "current-work stays cleared")))))
@@ -1068,12 +1068,12 @@
     ;; window = stale-at - loaded-at = 1000; stale-at 100000 is far beyond
     ;; (clock 2000 + window 1000) = 3000 → implausible (server clock ran ahead).
     (let [e (entry {:resource-id :a :data {:x 1} :loaded-at 99000 :stale-at 100000})]
-      (is (= (- 100000 2000) (ssr/clock-skew-ms e 2000))))
+      (is (= (- 100000 2000) (rf.resources.ssr/clock-skew-ms e 2000))))
     (testing "a plausible stale-at returns nil (no skew)"
       (let [e (entry {:resource-id :a :data {:x 1} :loaded-at 1000 :stale-at 2000})]
-        (is (nil? (ssr/clock-skew-ms e 1500)))))
+        (is (nil? (rf.resources.ssr/clock-skew-ms e 1500)))))
     (testing "no :stale-at → nil (cannot assess)"
-      (is (nil? (ssr/clock-skew-ms (entry {:resource-id :a :data {:x 1}}) 1500))))))
+      (is (nil? (rf.resources.ssr/clock-skew-ms (entry {:resource-id :a :data {:x 1}}) 1500))))))
 
 ;; ===========================================================================
 ;; 4. NO double-fetch — refetch plan
@@ -1085,7 +1085,7 @@
           stale (entry {:resource-id :b :data {:x 2} :loaded-at 1000 :stale-at 1500})
           meta  (entry {:resource-id :c :data nil :status :loaded})  ;; redacted/omitted: no data
           rdb   (runtime-db-with {ka fresh kb stale kc meta})
-          plan  (->> (ssr/hydrate-refetch-plan rdb 5000)
+          plan  (->> (rf.resources.ssr/hydrate-refetch-plan rdb 5000)
                      (into {} (map (juxt :resource/key identity))))]
       (is (not (contains? plan ka)) "fresh-with-data is NOT refetched (the SSR win)")
       (is (= :stale   (:reason (plan kb))))
@@ -1093,12 +1093,12 @@
 
 (deftest entry-needs-refetch-predicate
   (testing "entry-needs-refetch? is false ONLY for fresh-with-data"
-    (is (false? (ssr/entry-needs-refetch?
+    (is (false? (rf.resources.ssr/entry-needs-refetch?
                   (entry {:resource-id :a :data {:x 1} :loaded-at 1 :stale-at 9.0e15}) 100)))
-    (is (true?  (ssr/entry-needs-refetch?
+    (is (true?  (rf.resources.ssr/entry-needs-refetch?
                   (entry {:resource-id :a :data {:x 1} :loaded-at 1 :stale-at 50}) 100))
         "stale-with-data → refetch")
-    (is (true?  (ssr/entry-needs-refetch?
+    (is (true?  (rf.resources.ssr/entry-needs-refetch?
                   (entry {:resource-id :a :data nil}) 100))
         "no-data (metadata-only) → refetch")))
 
@@ -1113,28 +1113,28 @@
 ;; `hydrated-data-usable?` used `(some? :data)`, so `[]` read as fresh-with-data
 ;; → EXCLUDED from the refetch plan → the feed rendered permanently empty with no
 ;; error and no recovery (a terminal no-op `load-more`). The fix delegates the
-;; usable-data question to `state/has-data?` (whose infinite branch is
+;; usable-data question to `rf.resources.state/has-data?` (whose infinite branch is
 ;; `(seq data)`), so an empty page vector is correctly refetched on hydration.
 
 (def ^:private fkey
   ;; a global-scope INFINITE feed key
-  (state/scoped-resource-key :rf.scope/global :feed/timeline {}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global :feed/timeline {}))
 
 (defn- infinite-entry* [m]
   (assoc (entry m) :infinite? true))
 
 (deftest empty-infinite-feed-is-not-usable-data
-  (testing "rf2-x76af2.11 — hydrated-data-usable? mirrors state/has-data?'s
+  (testing "rf2-x76af2.11 — hydrated-data-usable? mirrors rf.resources.state/has-data?'s
             infinite empty-page-vector branch (an empty feed is NOT usable)"
-    (is (false? (ssr/hydrated-data-usable?
+    (is (false? (rf.resources.ssr/hydrated-data-usable?
                   (infinite-entry* {:resource-id :feed/timeline :data [] :status :idle})))
         "empty infinite :data [] is NOT usable last-known-good data")
-    (is (true? (ssr/hydrated-data-usable?
+    (is (true? (rf.resources.ssr/hydrated-data-usable?
                  (infinite-entry* {:resource-id :feed/timeline :data [{:items [1]}]
                                    :status :loaded :loaded-at 1000 :stale-at 9.0e15})))
         "an infinite feed with at least one accumulated page IS usable")
-    (is (false? (ssr/hydrated-data-usable?
-                  (infinite-entry* {:resource-id :feed/timeline :data privacy/redacted-sentinel
+    (is (false? (rf.resources.ssr/hydrated-data-usable?
+                  (infinite-entry* {:resource-id :feed/timeline :data rf.privacy/redacted-sentinel
                                     :status :loaded})))
         "a redacted infinite entry is still metadata-only (sentinel ruled out before has-data?)")))
 
@@ -1145,9 +1145,9 @@
             stranded rendering permanently empty"
     (let [empty-feed (infinite-entry* {:resource-id :feed/timeline :status :idle
                                        :data [] :stale-at nil})]
-      (is (true? (ssr/entry-needs-refetch? empty-feed 5000))
+      (is (true? (rf.resources.ssr/entry-needs-refetch? empty-feed 5000))
           "an empty infinite feed needs a client refetch — never fresh-forever")
-      (let [plan (->> (ssr/hydrate-refetch-plan (runtime-db-with {fkey empty-feed}) 5000)
+      (let [plan (->> (rf.resources.ssr/hydrate-refetch-plan (runtime-db-with {fkey empty-feed}) 5000)
                       (into {} (map (juxt :resource/key identity))))]
         (is (contains? plan fkey) "the empty infinite feed IS in the refetch plan")
         (is (= :no-data (:reason (plan fkey)))
@@ -1159,8 +1159,8 @@
             WITH a page stays ABSENT from the plan (the SSR win, no double-fetch)"
     (let [loaded-feed (infinite-entry* {:resource-id :feed/timeline :status :loaded
                                         :data [{:items [1 2 3]}] :loaded-at 1000 :stale-at 9.0e15})]
-      (is (false? (ssr/entry-needs-refetch? loaded-feed 5000)))
-      (let [plan (->> (ssr/hydrate-refetch-plan (runtime-db-with {fkey loaded-feed}) 5000)
+      (is (false? (rf.resources.ssr/entry-needs-refetch? loaded-feed 5000)))
+      (let [plan (->> (rf.resources.ssr/hydrate-refetch-plan (runtime-db-with {fkey loaded-feed}) 5000)
                       (into {} (map (juxt :resource/key identity))))]
         (is (not (contains? plan fkey))
             "a fresh infinite feed WITH a page is NOT double-fetched")))))
@@ -1171,11 +1171,11 @@
             refetches it :no-data (the actual stranded-fresh-forever path)"
     (let [e   (infinite-entry* {:resource-id :feed/timeline :status :loading
                                 :data [] :stale-at nil})
-          out (ssr/hydrate-runtime-db (runtime-db-with {fkey e}) :app/main)
-          se  (get-in out [state/resources-key :entries (state/key-id fkey)])]
+          out (rf.resources.ssr/hydrate-runtime-db (runtime-db-with {fkey e}) :app/main)
+          se  (get-in out [rf.resources.state/resources-key :entries (rf.resources.state/key-id fkey)])]
       (is (= :idle (:status se)) "empty infinite :loading → :idle (never dangling :loading)")
       (is (= [] (:data se)) "the empty page vector is preserved")
-      (let [plan (->> (ssr/hydrate-refetch-plan out 5000)
+      (let [plan (->> (rf.resources.ssr/hydrate-refetch-plan out 5000)
                       (into {} (map (juxt :resource/key identity))))]
         (is (contains? plan fkey) "the settled empty infinite feed IS refetched")
         (is (= :no-data (:reason (plan fkey))))))))
@@ -1191,11 +1191,11 @@
 
 (deftest redacted-sentinel-is-not-usable-data
   (testing "hydrated-data-usable? excludes the redaction sentinel"
-    (is (true?  (ssr/hydrated-data-usable? (entry {:resource-id :a :data {:x 1}})))
+    (is (true?  (rf.resources.ssr/hydrated-data-usable? (entry {:resource-id :a :data {:x 1}})))
         "real data is usable")
-    (is (false? (ssr/hydrated-data-usable? (entry {:resource-id :a :data privacy/redacted-sentinel})))
+    (is (false? (rf.resources.ssr/hydrated-data-usable? (entry {:resource-id :a :data rf.privacy/redacted-sentinel})))
         "the :rf/redacted sentinel is NOT usable (metadata-only)")
-    (is (false? (ssr/hydrated-data-usable? (entry {:resource-id :a :data nil})))
+    (is (false? (rf.resources.ssr/hydrated-data-usable? (entry {:resource-id :a :data nil})))
         "omitted (nil) is NOT usable")))
 
 (deftest redacted-fresh-entry-still-refetches
@@ -1203,24 +1203,24 @@
             redaction sentinel still needs a refetch — the sentinel must NOT be
             mistaken for usable fresh data (rf2-fopuj9)"
     (let [redacted-fresh (entry {:resource-id :secret/thing
-                                 :data privacy/redacted-sentinel
+                                 :data rf.privacy/redacted-sentinel
                                  :loaded-at 1000 :stale-at 9.0e15 :status :loaded})]
-      (is (true? (ssr/entry-needs-refetch? redacted-fresh 5000))
+      (is (true? (rf.resources.ssr/entry-needs-refetch? redacted-fresh 5000))
           "a fresh redacted entry refetches (the sentinel is metadata-only, not fresh data)"))))
 
 (deftest refetch-plan-classifies-redacted-vs-omitted-vs-stale-vs-fresh
   (testing "the four hydration dispositions classify correctly (rf2-fopuj9 acceptance)"
     (let [fresh    (entry {:resource-id :a :data {:x 1} :loaded-at 1000 :stale-at 9.0e15})
           stale    (entry {:resource-id :b :data {:x 2} :loaded-at 1000 :stale-at 1500})
-          redacted (entry {:resource-id :c :data privacy/redacted-sentinel
+          redacted (entry {:resource-id :c :data rf.privacy/redacted-sentinel
                            :loaded-at 1000 :stale-at 9.0e15 :status :loaded})  ;; sensitive → sentinel
           omitted  (entry {:resource-id :d :data nil :status :loaded})          ;; large → no data key
-          plan     (->> (ssr/hydrate-refetch-plan (runtime-db-with {ka fresh kb stale kc redacted
-                                                                    (state/scoped-resource-key
+          plan     (->> (rf.resources.ssr/hydrate-refetch-plan (runtime-db-with {ka fresh kb stale kc redacted
+                                                                    (rf.resources.state/scoped-resource-key
                                                                       :rf.scope/global :d {}) omitted})
                                                   5000)
                         (into {} (map (juxt :resource/key identity))))
-          kd       (state/scoped-resource-key :rf.scope/global :d {})]
+          kd       (rf.resources.state/scoped-resource-key :rf.scope/global :d {})]
       (is (not (contains? plan ka)) "FRESH serialized → absent from the plan (no double-fetch)")
       (is (= :stale         (:reason (plan kb))) "STALE serialized → background refetch")
       (is (= :metadata-only (:reason (plan kc)))
@@ -1238,15 +1238,15 @@
             halves go away together: the row does not ride, so there is nothing
             to misclassify and nothing to plan, and the client issues the one
             load it derives from the raw key"
-    (let [k    (state/scoped-resource-key :rf.scope/global :secret/thing {:slug "s"})
+    (let [k    (rf.resources.state/scoped-resource-key :rf.scope/global :secret/thing {:slug "s"})
           ;; a FRESH sensitive entry on the server (stale-at far ahead)
           e    (entry {:resource-id :secret/thing :data {:ssn "123-45-6789"}
                        :loaded-at 1000 :stale-at 9.0e15})
           rdb  (runtime-db-with {k e})
-          proj (ssr/project-resources-runtime-db rdb)
+          proj (rf.resources.ssr/project-resources-runtime-db rdb)
           m    (only-projection-metadata rdb)
           wk   (:projected-key m)]
-      (is (empty? (get-in proj [state/resources-key :entries]))
+      (is (empty? (get-in proj [rf.resources.state/resources-key :entries]))
           (str "the row does not ride: " (pr-str proj)))
       (is (not= {:slug "s"} (nth wk 2)) "the sensitive params do not ride raw (rf2-otms75)")
       (is (= :secret/thing (nth wk 1)) "the resource-id is preserved for refetch identity")
@@ -1254,9 +1254,9 @@
           "and the server's own metadata still says the client must fetch it —
            the fact rf2-fopuj9 was about is reported, not lost")
       ;; CLIENT hydration over what actually ships.
-      (let [out  (ssr/hydrate-runtime-db proj nil)
-            plan (ssr/hydrate-refetch-plan proj 5000)]
-        (is (empty? (get-in out [state/resources-key :entries]))
+      (let [out  (rf.resources.ssr/hydrate-runtime-db proj nil)
+            plan (rf.resources.ssr/hydrate-refetch-plan proj 5000)]
+        (is (empty? (get-in out [rf.resources.state/resources-key :entries]))
             "the client's cache holds no row for it — so the sentinel can never
              be rendered as if it were the real value")
         (is (empty? plan)
@@ -1271,10 +1271,10 @@
             planner has quietly stopped distinguishing a sentinel from data. A
             sentinel-bearing entry under an ADDRESSABLE key (a restore snapshot,
             a host-assembled slice) is still `:metadata-only`, never fresh"
-    (let [k (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "s"})
-          e (entry {:resource-id :article/by-slug :data privacy/redacted-sentinel
+    (let [k (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "s"})
+          e (entry {:resource-id :article/by-slug :data rf.privacy/redacted-sentinel
                     :loaded-at 1000 :stale-at 9.0e15 :status :loaded})
-          plan (ssr/hydrate-refetch-plan (runtime-db-with {k e}) 5000)]
+          plan (rf.resources.ssr/hydrate-refetch-plan (runtime-db-with {k e}) 5000)]
       (is (= 1 (count plan)) "premise: the addressable row IS planned")
       (is (= :metadata-only (:reason (first plan)))
           "the sentinel is metadata-only, not fresh usable data")
@@ -1287,25 +1287,25 @@
 
 (deftest hydration-never-crosses-scopes
   (testing "entries under different scopes stay isolated; indexes key on each entry's own scoped key"
-    (let [ka (state/scoped-resource-key [:rf.scope/session {:user "a"}] :article/by-slug {:slug "x"})
-          kb (state/scoped-resource-key [:rf.scope/session {:user "b"}] :article/by-slug {:slug "x"})
+    (let [ka (rf.resources.state/scoped-resource-key [:rf.scope/session {:user "a"}] :article/by-slug {:slug "x"})
+          kb (rf.resources.state/scoped-resource-key [:rf.scope/session {:user "b"}] :article/by-slug {:slug "x"})
           ea (entry {:resource-id :article/by-slug :data {:owner "a"}
                      :loaded-at 1000 :stale-at 9.0e15 :tags #{[:article "x"]}
                      :owners #{[:route :r "nav-a"]}})
           eb (entry {:resource-id :article/by-slug :data {:owner "b"}
                      :loaded-at 1000 :stale-at 9.0e15 :tags #{[:article "x"]}
                      :owners #{[:route :r "nav-b"]}})
-          out (ssr/hydrate-runtime-db (runtime-db-with {ka ea kb eb}) :app/main)
-          es  (get-in out [state/resources-key :entries])]
-      (is (= {:owner "a"} (:data (es (state/key-id ka)))) "scope-a data stays under scope-a's key")
-      (is (= {:owner "b"} (:data (es (state/key-id kb)))) "scope-b data stays under scope-b's key")
+          out (rf.resources.ssr/hydrate-runtime-db (runtime-db-with {ka ea kb eb}) :app/main)
+          es  (get-in out [rf.resources.state/resources-key :entries])]
+      (is (= {:owner "a"} (:data (es (rf.resources.state/key-id ka)))) "scope-a data stays under scope-a's key")
+      (is (= {:owner "b"} (:data (es (rf.resources.state/key-id kb)))) "scope-b data stays under scope-b's key")
       (testing "the shared tag [:article \"x\"] maps to BOTH scoped keys, never collapsed"
         ;; rf2-9e0tyq — index members are the byte key-id.
-        (is (= #{(state/key-id ka) (state/key-id kb)}
-               (get-in out [state/resources-key :tag-index [:article "x"]]))))
+        (is (= #{(rf.resources.state/key-id ka) (rf.resources.state/key-id kb)}
+               (get-in out [rf.resources.state/resources-key :tag-index [:article "x"]]))))
       (testing "each scope's owner indexes only its own key"
-        (is (= #{(state/key-id ka)} (get-in out [state/resources-key :owner-index [:route :r "nav-a"]])))
-        (is (= #{(state/key-id kb)} (get-in out [state/resources-key :owner-index [:route :r "nav-b"]])))))))
+        (is (= #{(rf.resources.state/key-id ka)} (get-in out [rf.resources.state/resources-key :owner-index [:route :r "nav-a"]])))
+        (is (= #{(rf.resources.state/key-id kb)} (get-in out [rf.resources.state/resources-key :owner-index [:route :r "nav-b"]])))))))
 
 ;; ===========================================================================
 ;; 6. End-to-end through the :rf/hydrate reconcile hook
@@ -1313,12 +1313,12 @@
 
 (deftest hooks-are-published
   (testing "both SSR late-bind hooks are published by the façade"
-    (is (some? (late-bind/get-fn :ssr/extend-runtime-db-projection)))
-    (is (some? (late-bind/get-fn :resources/hydrate-runtime-db)))
-    (is (= ssr/project-resources-runtime-db
-           (late-bind/get-fn :ssr/extend-runtime-db-projection)))
-    (is (= ssr/hydrate-runtime-db
-           (late-bind/get-fn :resources/hydrate-runtime-db)))))
+    (is (some? (rf.late-bind/get-fn :ssr/extend-runtime-db-projection)))
+    (is (some? (rf.late-bind/get-fn :resources/hydrate-runtime-db)))
+    (is (= rf.resources.ssr/project-resources-runtime-db
+           (rf.late-bind/get-fn :ssr/extend-runtime-db-projection)))
+    (is (= rf.resources.ssr/hydrate-runtime-db
+           (rf.late-bind/get-fn :resources/hydrate-runtime-db)))))
 
 (deftest project-runtime-db-merges-resource-slice
   (reg! :article/by-slug)
@@ -1327,9 +1327,9 @@
                       :loaded-at 1000 :stale-at 9.0e15})
           rdb (runtime-db-with {gkey e})
           ;; the SSR payload-policy is the consumer of :ssr/extend-runtime-db-projection
-          proj (payload-policy/project-runtime-db rdb)]
-      (is (contains? proj state/resources-key))
-      (is (contains? (get-in proj [state/resources-key :entries]) (state/key-id gkey))))))
+          proj (rf.ssr.payload-policy/project-runtime-db rdb)]
+      (is (contains? proj rf.resources.state/resources-key))
+      (is (contains? (get-in proj [rf.resources.state/resources-key :entries]) (rf.resources.state/key-id gkey))))))
 
 (deftest hydrate-event-reconciles-resource-slice
   (reg! :article/by-slug)
@@ -1345,13 +1345,13 @@
                    :rf/runtime-db (runtime-db-with {gkey e})}]
       (rf/dispatch-sync [:rf/hydrate payload])
       (let [rdb (:rf.db/runtime (rf/frame-state-value :rf/default))
-            installed (get-in rdb [state/resources-key :entries (state/key-id gkey)])]
+            installed (get-in rdb [rf.resources.state/resources-key :entries (rf.resources.state/key-id gkey)])]
         (is (= {:t "x"} (:data installed)) "entry data preserved through hydrate")
         (is (nil? (:current-work installed)) "transient current-work cleared")
         (is (not (contains? (:active-owners installed) [:ssr "req-1" "nav-1"]))
             "SSR owner orphaned during the :rf/hydrate reconcile")
         (is (contains? (:active-owners installed) [:route :route/article "nav-1"])
             "route owner survives")
-        (is (= {[:article "x"] #{(state/key-id gkey)}}
-               (get-in rdb [state/resources-key :tag-index]))
+        (is (= {[:article "x"] #{(rf.resources.state/key-id gkey)}}
+               (get-in rdb [rf.resources.state/resources-key :tag-index]))
             "tag-index recomputed from entries during the :rf/hydrate reconcile (byte key-id member)")))))

--- a/implementation/resources/test/re_frame/resources_ssr_projected_key_refetch_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_ssr_projected_key_refetch_cljs_test.cljc
@@ -13,7 +13,7 @@
   `project-resources-runtime-db` installs the wire entry under the projected
   one. The live client never derives that identity: `route/route-resource-plan`
   and `events/ensure-handler` build the ordinary scoped key from live scope +
-  params and read `(state/entry-path scoped-key)`, i.e. the RAW key-id. So the
+  params and read `(rf.resources.state/entry-path scoped-key)`, i.e. the RAW key-id. So the
   hydrated entry is unreachable and the client loads.
 
   Three answers were given to one question and they did not agree. The server
@@ -98,19 +98,19 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
-   [re-frame.frame :as frame]
+   [re-frame.fx :as rf.fx]
+   [re-frame.frame :as rf.frame]
    ;; load-bearing side-effecting require: the façade registers the
    ;; :rf.resource/* events + subs and the :resource registrar kind.
    [re-frame.resources]
-   [re-frame.resources.classification :as classification]
-   [re-frame.resources.registry :as registry]
-   [re-frame.resources.ssr :as ssr]
-   [re-frame.resources.state :as state]
+   [re-frame.resources.classification :as rf.resources.classification]
+   [re-frame.resources.registry :as rf.resources.registry]
+   [re-frame.resources.ssr :as rf.resources.ssr]
+   [re-frame.resources.state :as rf.resources.state]
    ;; production HTTP fx surface (so the transport feature probe resolves).
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
+   [re-frame.test-support :as rf.test-support]
    #?@(:clj  [[re-frame.substrate.plain-atom :as substrate]]
        :cljs [[re-frame.adapter.reagent :as substrate]])))
 
@@ -147,7 +147,7 @@
   (reset! requests 0)
   (rf/make-frame {:id :rf/default :url-bound? true
                   :doc "SSR projected-key refetch suite frame."})
-  (fx/reg-fx :rf.http/managed (fn [_ctx _args] (swap! requests inc)))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx _args] (swap! requests inc)))
   (rf/reg-event ::seed (fn [{:keys [db]} _] {:db (assoc db :tenant tenant-secret)}))
   (rf/dispatch-sync [::seed])
   (rf/reg-resource-scope :t/tenant
@@ -184,7 +184,7 @@
     (fn [_p _ctx] {:request {:method :get :url "/bulky"}})))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     {:adapter substrate/adapter
      :init-fn init!}))
 
@@ -195,16 +195,16 @@
   ([tenant] [:rf.scope/session {:tenant-id tenant :region "au"}]))
 
 (def ^:private params-key
-  (delay (state/scoped-resource-key
+  (delay (rf.resources.state/scoped-resource-key
            :rf.scope/global :params/report
            {:account-id account-secret :page 3})))
 
 (defn- scoped-key-for
   ([] (scoped-key-for tenant-secret))
-  ([tenant] (state/scoped-resource-key (tenant-scope tenant) :scoped/report {:page 3})))
+  ([tenant] (rf.resources.state/scoped-resource-key (tenant-scope tenant) :scoped/report {:page 3})))
 
 (defn- global-key [resource-id]
-  (state/scoped-resource-key :rf.scope/global resource-id {:page 3}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global resource-id {:page 3}))
 
 (defn- install-entry!
   "Write a `:loaded` entry for `scoped-key` AND reconcile the per-frame elision
@@ -215,17 +215,17 @@
   millis `hydrate-resources!` uses)."
   ([scoped-key] (install-entry! scoped-key false))
   ([scoped-key stale?]
-   (frame/swap-runtime-db!
+   (rf.frame/swap-runtime-db!
      :rf/default
      (fn [rdb]
        (-> (or rdb {})
-           (assoc-in (state/entry-path scoped-key)
-                     (cond-> (assoc (state/empty-entry (second scoped-key) scoped-key)
+           (assoc-in (rf.resources.state/entry-path scoped-key)
+                     (cond-> (assoc (rf.resources.state/empty-entry (second scoped-key) scoped-key)
                                     :status    :loaded
                                     :data      {:total 1}
                                     :loaded-at 1000)
                        stale? (assoc :stale-at 2000)))
-           (classification/reconcile-registry registry/resource-meta))))
+           (rf.resources.classification/reconcile-registry rf.resources.registry/resource-meta))))
    scoped-key))
 
 (defn- install-all! []
@@ -236,13 +236,13 @@
   (install-entry! (global-key :sealed/report))
   (install-entry! (global-key :bulky/report)))
 
-(defn- runtime-db [] (frame/frame-runtime-db-value :rf/default))
+(defn- runtime-db [] (rf.frame/frame-runtime-db-value :rf/default))
 
 (defn- wire-slice []
-  (ssr/project-resources-runtime-db (runtime-db) :rf/default))
+  (rf.resources.ssr/project-resources-runtime-db (runtime-db) :rf/default))
 
 (defn- wire-entries []
-  (get-in (wire-slice) [state/resources-key :entries]))
+  (get-in (wire-slice) [rf.resources.state/resources-key :entries]))
 
 (defn- wire-rows
   "Every wire entry whose key names `resource-id` (a SEQ, because §4 asks how
@@ -260,9 +260,9 @@
   []
   (into {}
         (map (fn [m] [(second (:resource/key m)) m]))
-        (ssr/projection-metadata
+        (rf.resources.ssr/projection-metadata
           :rf/default 5000
-          (get-in (runtime-db) (state/entries-path)))))
+          (get-in (runtime-db) (rf.resources.state/entries-path)))))
 
 (defn- boot-client!
   "Simulate the client boot: replace the durable resource subtree with EXACTLY
@@ -271,16 +271,16 @@
   registry) is what the client's own `reg-resource` calls give it."
   []
   (let [slice (wire-slice)]
-    (frame/swap-runtime-db!
+    (rf.frame/swap-runtime-db!
       :rf/default
-      (fn [rdb] (assoc (or rdb {}) state/resources-key (get slice state/resources-key))))
-    (ssr/hydrate-resources! :rf/default)))
+      (fn [rdb] (assoc (or rdb {}) rf.resources.state/resources-key (get slice rf.resources.state/resources-key))))
+    (rf.resources.ssr/hydrate-resources! :rf/default)))
 
 (defn- live-entry
   "The read `route-resource-plan` and `ensure-handler` both perform: derive the
-  ordinary scoped key from live scope + params, then `(state/entry-path k)`."
+  ordinary scoped key from live scope + params, then `(rf.resources.state/entry-path k)`."
   [scoped-key]
-  (get-in (runtime-db) (state/entry-path scoped-key)))
+  (get-in (runtime-db) (rf.resources.state/entry-path scoped-key)))
 
 (defn- plan-by-resource [plan]
   (into {} (map (fn [p] [(:resource-id p) p])) plan))
@@ -289,7 +289,7 @@
   (str/includes? (pr-str v) secret))
 
 (defn- durable-entries []
-  (get-in (runtime-db) (state/entries-path)))
+  (get-in (runtime-db) (rf.resources.state/entries-path)))
 
 (defn- rows-for
   "Every DURABLE row naming `resource-id`, as `[key-id entry]` pairs."
@@ -301,7 +301,7 @@
   entry under. Derived through the production projector rather than restated, so
   this suite pins the coarse arm's PRESENCE without pinning its digest."
   [resource-id]
-  (state/key-id (ssr/project-scoped-key (global-key resource-id) :redact nil)))
+  (rf.resources.state/key-id (rf.resources.ssr/project-scoped-key (global-key resource-id) :redact nil)))
 
 ;; ---- a payload from BEFORE the withholding (the version-skew forgery) ------
 ;;
@@ -347,8 +347,8 @@
   FRESHNESS and the plan omits it whether or not the addressability filter
   exists."
   [wire-key data]
-  [(state/key-id wire-key)
-   (cond-> (assoc (state/empty-entry (second wire-key) wire-key)
+  [(rf.resources.state/key-id wire-key)
+   (cond-> (assoc (rf.resources.state/empty-entry (second wire-key) wire-key)
                   :status :loaded :loaded-at 1000)
      (some? data) (assoc :data data))])
 
@@ -356,7 +356,7 @@
   "Today's wire slice PLUS the four rows an earlier render would have included,
   in the shape `data` selects (see `legacy-row`)."
   [data]
-  (update-in (wire-slice) [state/resources-key :entries]
+  (update-in (wire-slice) [rf.resources.state/resources-key :entries]
              (fn [entries]
                (into entries [(legacy-row legacy-params-wire-key data)
                               (legacy-row legacy-scope-wire-key data)
@@ -379,7 +379,7 @@
     (install-all!)
     (let [wired (wire-entries)
           m     (:params/report (metadata-by-resource))]
-      (is (not (contains? wired (state/key-id @params-key)))
+      (is (not (contains? wired (rf.resources.state/key-id @params-key)))
           "premise: the raw key-id is NOT a wire map key — the entry re-keyed")
       (is (empty? (wire-rows :params/report))
           (str "…and NO row rides under the projected key either — an emptied "
@@ -402,7 +402,7 @@
     (install-all!)
     (let [wired (wire-entries)
           m     (:scoped/report (metadata-by-resource))]
-      (is (not (contains? wired (state/key-id (scoped-key-for))))
+      (is (not (contains? wired (rf.resources.state/key-id (scoped-key-for))))
           "premise: the raw key-id is NOT a wire map key")
       (is (empty? (wire-rows :scoped/report))
           (str "…and no row rides under the projected key either: "
@@ -415,8 +415,8 @@
             as an exact set. Six durable entries, two wire rows: withholding one
             row too many fails here just as loudly as withholding none"
     (install-all!)
-    (is (= #{(state/key-id (global-key :plain/report))
-             (state/key-id (global-key :stale/report))}
+    (is (= #{(rf.resources.state/key-id (global-key :plain/report))
+             (rf.resources.state/key-id (global-key :stale/report))}
            (set (keys (wire-entries))))
         (str "the wire carries exactly the rows a live client can address — "
              (pr-str (mapv (comp :resource/key second) (wire-entries)))))
@@ -436,7 +436,7 @@
     (let [wired (wire-entries)
           e     (wire-entry-for :plain/report)
           m     (:plain/report (metadata-by-resource))]
-      (is (contains? wired (state/key-id (global-key :plain/report)))
+      (is (contains? wired (rf.resources.state/key-id (global-key :plain/report)))
           "its key-id is unchanged — nothing re-keyed it")
       (is (= {:total 1} (:data e)) "so its data rides, as it always has")
       (is (= :serialized (:disposition m)))
@@ -467,7 +467,7 @@
       (is (= (global-key :sealed/report) (:resource/key (:sealed/report m)))
           "the metadata names the RAW key — it is a diagnostic over the
            server's own entries, not a wire identity")
-      (is (= (ssr/project-scoped-key (global-key :sealed/report) :redact nil)
+      (is (= (rf.resources.ssr/project-scoped-key (global-key :sealed/report) :redact nil)
              (:projected-key (:sealed/report m)))
           "…while :projected-key preserves the observation point the wire row
            used to carry, so the SSR and trace-egress derivations of one answer
@@ -479,15 +479,15 @@
             of dispositions. Stated over the whole cache, it is what stops a
             future re-keying projection shipping a ghost by default"
     (install-all!)
-    (doseq [m (ssr/projection-metadata
+    (doseq [m (rf.resources.ssr/projection-metadata
                 :rf/default 5000
-                (get-in (runtime-db) (state/entries-path)))]
+                (get-in (runtime-db) (rf.resources.state/entries-path)))]
       (is (= (:withheld? m)
-             (not= (state/key-id (:resource/key m))
-                   (state/key-id (:projected-key m))))
+             (not= (rf.resources.state/key-id (:resource/key m))
+                   (rf.resources.state/key-id (:projected-key m))))
           (str "withheld? iff the projection re-keyed it — " (pr-str m)))
       (is (= (not (:withheld? m))
-             (contains? (wire-entries) (state/key-id (:projected-key m))))
+             (contains? (wire-entries) (rf.resources.state/key-id (:projected-key m))))
           (str "…and the wire agrees, row for row — " (pr-str m))))))
 
 (deftest the-declared-slot-still-does-not-ride
@@ -572,16 +572,16 @@
     ;; #7354 actually shipped and the plan actually named. A data-carrying row
     ;; would be excluded on freshness instead, and this test would pass with the
     ;; addressability filter deleted.
-    (let [forged (get (slice-with-legacy-rows nil) state/resources-key)
+    (let [forged (get (slice-with-legacy-rows nil) rf.resources.state/resources-key)
           row-of (fn [rid] (some (fn [[_ e]] (when (= rid (second (:resource/key e))) e))
                                  (:entries forged)))
-          plan   (ssr/hydrate-refetch-plan {state/resources-key forged} 5000)
+          plan   (rf.resources.ssr/hydrate-refetch-plan {rf.resources.state/resources-key forged} 5000)
           by-id  (plan-by-resource plan)]
       (doseq [rid [:params/report :sealed/report :bulky/report]]
         (let [row (row-of rid)]
           (is (some? row)
               (str "premise: the forged slice carries an unaddressable row for " rid))
-          (is (true? (ssr/entry-needs-refetch? row 5000))
+          (is (true? (rf.resources.ssr/entry-needs-refetch? row 5000))
               (str "premise: and one the planner WOULD name — every other reason "
                    "to omit it is absent, so only addressability can be doing "
                    "the work for " rid))
@@ -622,7 +622,7 @@
     (is (= 1 @requests) "exactly one request — not zero, and not two")
     (is (some? (live-entry @params-key))
         "the entry now exists under the identity the client derives")
-    (is (= [(state/key-id @params-key)] (mapv first (rows-for :params/report)))
+    (is (= [(rf.resources.state/key-id @params-key)] (mapv first (rows-for :params/report)))
         (str "…and it is the ONLY row for this resource: no unreachable "
              "duplicate persists beside it — "
              (pr-str (mapv (comp :resource/key second) (rows-for :params/report)))))))
@@ -641,7 +641,7 @@
     (is (some? (live-entry (scoped-key-for)))
         "the resolved session scope lands on the raw key, as the client
          derives it")
-    (is (= [(state/key-id (scoped-key-for))] (mapv first (rows-for :scoped/report)))
+    (is (= [(rf.resources.state/key-id (scoped-key-for))] (mapv first (rows-for :scoped/report)))
         (str "…and it is the only row for this resource — "
              (pr-str (mapv (comp :resource/key second) (rows-for :scoped/report)))))))
 
@@ -663,12 +663,12 @@
                        {:resource :sealed/report :params {:page 3}}])
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :bulky/report :params {:page 3}}])
-    (is (= #{(state/key-id @params-key)
-             (state/key-id (scoped-key-for))
-             (state/key-id (global-key :plain/report))
-             (state/key-id (global-key :stale/report))
-             (state/key-id (global-key :sealed/report))
-             (state/key-id (global-key :bulky/report))}
+    (is (= #{(rf.resources.state/key-id @params-key)
+             (rf.resources.state/key-id (scoped-key-for))
+             (rf.resources.state/key-id (global-key :plain/report))
+             (rf.resources.state/key-id (global-key :stale/report))
+             (rf.resources.state/key-id (global-key :sealed/report))
+             (rf.resources.state/key-id (global-key :bulky/report))}
            (set (keys (durable-entries))))
         (str "the client's cache holds exactly the addressable rows — every "
              "coarse entry sits under the key the client DERIVES, and neither "
@@ -743,17 +743,17 @@
             derivation reproduces, exactly as `recompute-indexes` refuses to
             trust the wire's indexes"
     (install-all!)
-    (let [forged (get (slice-with-legacy-rows {:total 1}) state/resources-key)]
+    (let [forged (get (slice-with-legacy-rows {:total 1}) rf.resources.state/resources-key)]
       (is (= 6 (count (:entries forged)))
           "premise: the forged payload carries the four withheld rows too")
       (is (some (fn [[_ e]] (some? (:data e)))
                 (filterv (fn [[_ e]] (= :params/report (second (:resource/key e))))
                          (:entries forged)))
           "premise: and the pre-fix row carries its DATA")
-      (frame/swap-runtime-db!
+      (rf.frame/swap-runtime-db!
         :rf/default
-        (fn [rdb] (assoc (or rdb {}) state/resources-key forged)))
-      (ssr/hydrate-resources! :rf/default)
+        (fn [rdb] (assoc (or rdb {}) rf.resources.state/resources-key forged)))
+      (rf.resources.ssr/hydrate-resources! :rf/default)
       (is (empty? (rows-for :params/report))
           (str "the unaddressable row is gone after hydrate — "
                (pr-str (mapv (comp :resource/key second) (rows-for :params/report)))))
@@ -777,17 +777,17 @@
             behaves identically to one hydrating a withheld payload — one
             intentional load, and nothing left over"
     (install-all!)
-    (let [forged (get (slice-with-legacy-rows {:total 1}) state/resources-key)]
-      (frame/swap-runtime-db!
+    (let [forged (get (slice-with-legacy-rows {:total 1}) rf.resources.state/resources-key)]
+      (rf.frame/swap-runtime-db!
         :rf/default
-        (fn [rdb] (assoc (or rdb {}) state/resources-key forged)))
-      (ssr/hydrate-resources! :rf/default)
+        (fn [rdb] (assoc (or rdb {}) rf.resources.state/resources-key forged)))
+      (rf.resources.ssr/hydrate-resources! :rf/default)
       (reset! requests 0)
       (rf/dispatch-sync [:rf.resource/ensure
                          {:resource :params/report
                           :params   {:account-id account-secret :page 3}}])
       (is (= 1 @requests) "exactly one request")
-      (is (= [(state/key-id @params-key)] (mapv first (rows-for :params/report)))
+      (is (= [(rf.resources.state/key-id @params-key)] (mapv first (rows-for :params/report)))
           "and one row"))))
 
 ;; ===========================================================================
@@ -812,7 +812,7 @@
     (is (= 1 @requests) "exactly one request — not zero, and not two")
     (is (some? (live-entry (global-key :sealed/report)))
         "the entry now exists under the identity the client derives")
-    (is (= [(state/key-id (global-key :sealed/report))]
+    (is (= [(rf.resources.state/key-id (global-key :sealed/report))]
            (mapv first (rows-for :sealed/report)))
         (str "…and it is the ONLY row for this resource: no unreachable "
              "duplicate persists beside it — "
@@ -829,7 +829,7 @@
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :bulky/report :params {:page 3}}])
     (is (= 1 @requests))
-    (is (= [(state/key-id (global-key :bulky/report))]
+    (is (= [(rf.resources.state/key-id (global-key :bulky/report))]
            (mapv first (rows-for :bulky/report)))
         (str "the only row for this resource — "
              (pr-str (mapv (comp :resource/key second) (rows-for :bulky/report)))))))

--- a/implementation/resources/test/re_frame/resources_ssr_wire_key_scope_declaration_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_ssr_wire_key_scope_declaration_cljs_test.cljc
@@ -4,12 +4,12 @@
 
   ## The asymmetry this suite closes
 
-  `classification/instance-declaration-paths` has always lowered a
+  `rf.resources.classification/instance-declaration-paths` has always lowered a
   `:scope`-rooted declaration to the entry's ABSOLUTE `[… :resource/key 0 …]`
   path exactly as it lowers a `:params`-rooted one to `[… :resource/key 2 …]`,
   so the epoch / registry walk over the runtime-db honoured BOTH, and since
-  rf2-dl7bz `trace-egress/redact-key-declarations` honours both on every trace
-  and every tool key. But `ssr/project-entry` projected ONLY index 2. So a
+  rf2-dl7bz `rf.resources.trace-egress/redact-key-declarations` honours both on every trace
+  and every tool key. But `rf.resources.ssr/project-entry` projected ONLY index 2. So a
   resource declaring
 
     (rf/reg-resource :tenant/report
@@ -33,7 +33,7 @@
 
   ## The re-key is the mechanism, not a hazard — §2 pins it
 
-  `state/key-id` is `canonical-bytes` over the WHOLE `[scope resource-id
+  `rf.resources.state/key-id` is `canonical-bytes` over the WHOLE `[scope resource-id
   params]` vector, so projecting EITHER component necessarily changes it. That
   is not a new consequence of this change: `project-resources-runtime-db` re-keys
   each wire entry on the key-id of its own PROJECTED `:resource/key`, the coarse
@@ -61,22 +61,22 @@
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [clojure.string :as str]
    [re-frame.core :as rf]
-   [re-frame.frame :as frame]
+   [re-frame.frame :as rf.frame]
    ;; load-bearing side-effecting require: the façade registers the
    ;; :rf.resource/* events + subs + the :resource registrar kind, and
    ;; publishes the trace-egress hooks the epoch tool-pair consults.
    [re-frame.resources]
-   [re-frame.resources.classification :as classification]
-   [re-frame.resources.registry :as registry]
-   [re-frame.resources.ssr :as ssr]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.trace-egress :as trace-egress]
+   [re-frame.resources.classification :as rf.resources.classification]
+   [re-frame.resources.registry :as rf.resources.registry]
+   [re-frame.resources.ssr :as rf.resources.ssr]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.trace-egress :as rf.resources.trace-egress]
    ;; production HTTP fx surface (so the transport feature probe resolves).
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (def ^:private tenant-secret "tenant-SECRET-99")
 (def ^:private account-secret "acct-SECRET-4417")
@@ -118,8 +118,8 @@
     (fn [_p _ctx] {:request {:method :get :url "/sealed"}})))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    {:adapter #?(:clj plain-atom/adapter :cljs reagent-adapter/adapter)
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter #?(:clj rf.substrate.plain-atom/adapter :cljs rf.adapter.reagent/adapter)
      :init-fn init!}))
 
 ;; ---- helpers --------------------------------------------------------------
@@ -142,7 +142,7 @@
   `:scope`-rooted declaration has to reach THROUGH."
   ([resource-id] (key-for resource-id {:page 3}))
   ([resource-id params]
-   (state/scoped-resource-key (session-scope) resource-id params)))
+   (rf.resources.state/scoped-resource-key (session-scope) resource-id params)))
 
 (defn- global-key-for
   "The same undeclared owner under `:rf.scope/global` — an ADDRESSABLE key that
@@ -156,7 +156,7 @@
   verbatim, tenant id and all, which is exactly what
   `an-undeclared-owners-key-rides-byte-identical` asserts about it."
   [resource-id]
-  (state/scoped-resource-key :rf.scope/global resource-id {:page 3}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global resource-id {:page 3}))
 
 (defn- install-entry!
   "Write a durable `:loaded` entry for `scoped-key` into the frame's runtime-db
@@ -165,15 +165,15 @@
   commit folds into one atomic transition. Returns the key."
   [frame-id scoped-key]
   (let [resource-id (second scoped-key)]
-    (frame/swap-runtime-db!
+    (rf.frame/swap-runtime-db!
       frame-id
       (fn [rdb]
         (-> (or rdb {})
-            (assoc-in (state/entry-path scoped-key)
-                      (assoc (state/empty-entry resource-id scoped-key)
+            (assoc-in (rf.resources.state/entry-path scoped-key)
+                      (assoc (rf.resources.state/empty-entry resource-id scoped-key)
                              :status :loaded
                              :data   {:total 1}))
-            (classification/reconcile-registry registry/resource-meta)))))
+            (rf.resources.classification/reconcile-registry rf.resources.registry/resource-meta)))))
   scoped-key)
 
 (defn- wire-entries
@@ -181,9 +181,9 @@
   `:rf/runtime-db` slice — keyed on the byte key-id of each entry's PROJECTED
   `:resource/key`."
   [frame-id]
-  (get-in (ssr/project-resources-runtime-db
-            (frame/frame-runtime-db-value frame-id) frame-id)
-          [state/resources-key :entries]))
+  (get-in (rf.resources.ssr/project-resources-runtime-db
+            (rf.frame/frame-runtime-db-value frame-id) frame-id)
+          [rf.resources.state/resources-key :entries]))
 
 (defn- wire-entry-for
   "The single wire entry whose key names `resource-id`."
@@ -209,9 +209,9 @@
   pins directly against the map key."
   [frame-id resource-id]
   (some (fn [m] (when (= resource-id (second (:resource/key m))) (:projected-key m)))
-        (ssr/projection-metadata
+        (rf.resources.ssr/projection-metadata
           frame-id 5000
-          (get-in (frame/frame-runtime-db-value frame-id) (state/entries-path)))))
+          (get-in (rf.frame/frame-runtime-db-value frame-id) (rf.resources.state/entries-path)))))
 
 (defn- leaks?
   "Whether `secret` survives ANYWHERE in `v` — the plaintext test."
@@ -253,17 +253,17 @@
     ;; `global-key-for` for why neither `:sealed/report` nor the session-scoped
     ;; `:plain/report` can serve.
     (install-entry! :rf/default (global-key-for :plain/report))
-    (let [slice (ssr/project-resources-runtime-db
-                  (frame/frame-runtime-db-value :rf/default) :rf/default)
+    (let [slice (rf.resources.ssr/project-resources-runtime-db
+                  (rf.frame/frame-runtime-db-value :rf/default) :rf/default)
           w     (wire-key :rf/default :tenant/report)]
-      (is (seq (get-in slice [state/resources-key :entries]))
+      (is (seq (get-in slice [rf.resources.state/resources-key :entries]))
           "premise: the slice is not empty — every re-keyed row is withheld
            (rf2-rjq9d, rf2-4bjep), so this claim would otherwise be satisfied
            by a slice with nothing in it at all")
       (is (not (leaks? tenant-secret slice))
           (str "the tenant id survived somewhere in the wire slice: "
                (pr-str slice)))
-      (is (not (leaks? tenant-secret [w (state/key-id w)]))
+      (is (not (leaks? tenant-secret [w (rf.resources.state/key-id w)]))
           (str "…nor in the projected key or its key-id, which is where it
                 would ride if the row were sent — " (pr-str w))))))
 
@@ -285,7 +285,7 @@
 ;; ===========================================================================
 ;; 2. THE RE-KEYING INTERACTION — the bead's Q1, pinned rather than argued.
 ;;
-;;    `state/key-id` is `canonical-bytes` over the WHOLE key vector, so
+;;    `rf.resources.state/key-id` is `canonical-bytes` over the WHOLE key vector, so
 ;;    projecting index 0 CHANGES it. The invariant that has to hold is not
 ;;    "the key-id is stable" — it is "the wire MAP key and the wire ENTRY's own
 ;;    :resource/key are ONE value". `project-resources-runtime-db` maintains
@@ -308,7 +308,7 @@
          declaration and the coarse one are withheld (rf2-rjq9d, rf2-4bjep), so
          a `doseq` over the wire is not a `doseq` over nothing")
     (doseq [[k-id e] (wire-entries :rf/default)]
-      (is (= k-id (state/key-id (:resource/key e)))
+      (is (= k-id (rf.resources.state/key-id (:resource/key e)))
           (str "wire map key must equal key-id of the entry's own projected "
                ":resource/key — entry " (pr-str (:resource/key e)))))))
 
@@ -321,11 +321,11 @@
           plain-k  (install-entry! :rf/default (key-for :plain/report))
           sealed-k (install-entry! :rf/default (key-for :sealed/report))
           wired    (wire-entries :rf/default)]
-      (is (not (contains? wired (state/key-id scope-k)))
+      (is (not (contains? wired (rf.resources.state/key-id scope-k)))
           "a declared SCOPE re-keys the entry — the raw key-id is gone")
-      (is (not (contains? wired (state/key-id sealed-k)))
+      (is (not (contains? wired (rf.resources.state/key-id sealed-k)))
           "…as the coarse whole-component digests always have")
-      (is (contains? wired (state/key-id plain-k))
+      (is (contains? wired (rf.resources.state/key-id plain-k))
           "…while an UNDECLARED key keeps its byte identity exactly"))))
 
 ;; ===========================================================================
@@ -349,7 +349,7 @@
       (is (= (pr-str k) (pr-str w)) "…byte-for-byte, not merely `=`")
       (is (seq? (get-in w [0 1 :roles]))
           "…the list is still a LIST — no walker reconstruction happened")
-      (is (= (state/key-id k) (state/key-id w)) "…so its key-id is unchanged")
+      (is (= (rf.resources.state/key-id k) (rf.resources.state/key-id w)) "…so its key-id is unchanged")
       (is (leaks? tenant-secret w)
           "and its scope rides VERBATIM — nothing here scrubs by shape"))))
 
@@ -372,12 +372,12 @@
             An owner that declares nothing under :scope must leave it exactly
             as it found it"
     (let [k (install-entry! :rf/default
-                            (state/scoped-resource-key
+                            (rf.resources.state/scoped-resource-key
                               :rf.scope/global :plain/report {:page 3}))
           w (wire-key :rf/default :plain/report)]
       (is (= :rf.scope/global (nth w 0)))
       (is (= k w))
-      (is (= (state/key-id k) (state/key-id w))))))
+      (is (= (rf.resources.state/key-id k) (rf.resources.state/key-id w))))))
 
 (deftest a-key-declaration-does-not-promote-the-entry-to-a-coarse-claim
   (testing "rf2-dl7bz's second finding, on this surface: a declaration naming
@@ -414,10 +414,10 @@
         "…while the undeclared sibling still rides, so this is withholding and
          not an empty projection")
     (let [m (some (fn [m] (when (= :tenant/report (second (:resource/key m))) m))
-                  (ssr/projection-metadata
+                  (rf.resources.ssr/projection-metadata
                     :rf/default 5000
-                    (get-in (frame/frame-runtime-db-value :rf/default)
-                            (state/entries-path))))]
+                    (get-in (rf.frame/frame-runtime-db-value :rf/default)
+                            (rf.resources.state/entries-path))))]
       (is (= :key-projected (:disposition m))
           "the server-side metadata still announces what the server knew")
       (is (true? (:refetch-on-client? m))
@@ -442,9 +442,9 @@
     ;; owner is installed to prove it contributes NOTHING here.
     (install-entry! :rf/default (key-for :sealed/report))
     (let [wired    (wire-entries :rf/default)
-          subtree  (state/recompute-indexes {:entries wired})
+          subtree  (rf.resources.state/recompute-indexes {:entries wired})
           members  (into #{} cat (vals (:owner-index subtree)))]
-      (is (not (contains? wired (state/key-id (key-for :sealed/report))))
+      (is (not (contains? wired (rf.resources.state/key-id (key-for :sealed/report))))
           "premise: the coarse row IS re-keyed — its raw key-id is not a map key")
       (is (= 2 (count wired))
           (str "premise: exactly the two undeclared rows ride — the coarse row "
@@ -457,7 +457,7 @@
         (is (contains? wired m)
             (str "index member " (pr-str m) " must resolve to an installed entry")))
       (doseq [[k-id e] (:entries subtree)]
-        (is (= k-id (state/key-id (:resource/key e)))
+        (is (= k-id (rf.resources.state/key-id (:resource/key e)))
             "…and the round-tripped entry still agrees with its own key")))))
 
 ;; ===========================================================================
@@ -474,7 +474,7 @@
     (let [k     (install-entry! :rf/default (key-for :tenant/report))
           wire  (wire-key :rf/default :tenant/report)
           trace (:resource/key
-                  (trace-egress/project-resource-trace-egress
+                  (rf.resources.trace-egress/project-resource-trace-egress
                     {:rf.frame/id :rf/default :resource/key k} :rf/default))]
       (is (= (pr-str (nth wire 0)) (pr-str (nth trace 0)))
           (str "the SSR wire key's SCOPE component must be BYTE-equal to the "
@@ -488,7 +488,7 @@
                                          {:account-id account-secret :page 3}))
           wire  (wire-key :rf/default :both/report)
           trace (:resource/key
-                  (trace-egress/project-resource-trace-egress
+                  (rf.resources.trace-egress/project-resource-trace-egress
                     {:rf.frame/id :rf/default :resource/key k} :rf/default))]
       (is (= (pr-str wire) (pr-str trace))
           (str "wire " (pr-str wire) " vs trace " (pr-str trace))))))
@@ -513,7 +513,7 @@
       (is (contains? (nth w 2) :rf/redacted) "…and so is the whole params")
       (is (= :sealed/report (nth w 1)) "the resource-id survives")
       (is (not (leaks? tenant-secret w)))
-      (is (= w (ssr/project-scoped-key k :redact nil))
+      (is (= w (rf.resources.ssr/project-scoped-key k :redact nil))
           "byte-for-byte what `project-scoped-key` alone produces"))))
 
 (deftest a-coarse-owners-row-is-withheld-like-any-other-re-keyed-one
@@ -525,7 +525,7 @@
     (install-entry! :rf/default (global-key-for :plain/report))
     (let [wired (wire-entries :rf/default)
           w     (wire-key :rf/default :sealed/report)]
-      (is (not (contains? wired (state/key-id w)))
+      (is (not (contains? wired (rf.resources.state/key-id w)))
           (str "no row rides under the coarse PROJECTED key either — the claim "
                "is absence of the ROW, not of its data: " (pr-str wired)))
       (is (nil? (wire-entry-for :rf/default :sealed/report)))
@@ -551,11 +551,11 @@
             :params one. This test reds if anyone moves the arm into the
             shared projection"
     (let [k    (key-for :tenant/report)
-          spec (registry/resource-meta :tenant/report)]
-      (is (= k (ssr/project-scoped-key k :serialize spec))
+          spec (rf.resources.registry/resource-meta :tenant/report)]
+      (is (= k (rf.resources.ssr/project-scoped-key k :serialize spec))
           "`:serialize` still rides VERBATIM through `project-scoped-key`")
-      (is (= (ssr/project-scoped-key k :serialize spec)
-             (ssr/project-scoped-key k :serialize nil))
+      (is (= (rf.resources.ssr/project-scoped-key k :serialize spec)
+             (rf.resources.ssr/project-scoped-key k :serialize nil))
           "…and it still ignores the spec argument, exactly as documented"))))
 
 ;; ===========================================================================
@@ -566,20 +566,20 @@
 (deftest project-entry-scope-is-frame-scoped-and-declaration-gated
   (testing "the two guards `project-entry-params` carries, on the scope arm"
     (let [k      (install-entry! :rf/default (key-for :tenant/report))
-          key-id (state/key-id k)
+          key-id (rf.resources.state/key-id k)
           scope  (nth k 0)]
       (is (= :rf/redacted
-             (get-in (classification/project-entry-scope
+             (get-in (rf.resources.classification/project-entry-scope
                        scope key-id :rf/default :rf.egress/ssr-hydration)
                      [1 :tenant-id]))
           "under a live frame with the declaration lowered, the slot redacts")
-      (is (= scope (classification/project-entry-scope
+      (is (= scope (rf.resources.classification/project-entry-scope
                      scope key-id nil :rf.egress/ssr-hydration))
           "a nil frame rides the scope VERBATIM — the registry is frame-scoped")
       (let [plain-k (install-entry! :rf/default (key-for :plain/report))]
         (is (= (nth plain-k 0)
-               (classification/project-entry-scope
-                 (nth plain-k 0) (state/key-id plain-k)
+               (rf.resources.classification/project-entry-scope
+                 (nth plain-k 0) (rf.resources.state/key-id plain-k)
                  :rf/default :rf.egress/ssr-hydration))
             "an UNDECLARED offset rides the scope VERBATIM — no walk, no
              list↔vector collapse, byte identity preserved")))))

--- a/implementation/resources/test/re_frame/resources_time_ms_cofx_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_time_ms_cofx_cljs_test.cljc
@@ -30,19 +30,19 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting require: the façade registers the
    ;; :rf.resource/* + :rf.mutation/* events with the meta under test.
    [re-frame.resources]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.work-ledger :as rf.resources.work-ledger]
    ;; production HTTP fx surface (the transport feature probe); the actual
    ;; fetch is overridden by the capturing no-op below.
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (def ^:private last-managed-args (atom nil))
 
@@ -51,18 +51,18 @@
   refetch / execute land deterministically without a live fetch."
   [f]
   (reset! last-managed-args nil)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
   capturing-transport-fixture)
 
 (defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
-(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
-(defn- record [wid] (work-ledger/get-record (runtime-db) wid))
+(defn- entry [scoped-key] (get-in (runtime-db) (rf.resources.state/entry-path scoped-key)))
+(defn- record [wid] (rf.resources.work-ledger/get-record (runtime-db) wid))
 
 (defn- article-spec []
   {:scope          :rf.scope/global
@@ -129,7 +129,7 @@
             :loaded-at — scripting the reply token's :rf.cofx :rf/time-ms
             lands it flat and the durable write picks it up"
     (rf/reg-resource :tm/article (article-spec) article-spec-request)
-    (let [scoped-key   (state/scoped-resource-key :rf.scope/global :tm/article {:slug "w"})
+    (let [scoped-key   (rf.resources.state/scoped-resource-key :rf.scope/global :tm/article {:slug "w"})
           completed-at 1781078400456]
       (rf/dispatch-sync [:rf.resource/ensure {:resource :tm/article :scope :rf.scope/global
                                               :params {:slug "w"} :owner [:app :tm 1]}])
@@ -147,7 +147,7 @@
   (testing "rf2-601ife: the ensure handler reads the DELIVERED FLAT
             `:rf/time-ms` for the durable work-ledger :started-at"
     (rf/reg-resource :tm/started (article-spec) article-spec-request)
-    (let [scoped-key (state/scoped-resource-key :rf.scope/global :tm/started {:slug "w"})
+    (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :tm/started {:slug "w"})
           started-at 1781000000000]
       (rf/dispatch-sync [:rf.resource/ensure {:resource :tm/started :scope :rf.scope/global
                                               :params {:slug "w"} :owner [:app :tm 2]}]
@@ -164,7 +164,7 @@
             behaviour, not the fact under test), so the durable :invalidated-at
             persists and pins the causal time."
     (rf/reg-resource :tm/inv (article-spec) article-spec-request)
-    (let [scoped-key     (state/scoped-resource-key :rf.scope/global :tm/inv {:slug "w"})
+    (let [scoped-key     (rf.resources.state/scoped-resource-key :rf.scope/global :tm/inv {:slug "w"})
           loaded-at      1781000000000
           invalidated-at 1781000099999]
       (rf/dispatch-sync [:rf.resource/ensure {:resource :tm/inv :scope :rf.scope/global
@@ -192,7 +192,7 @@
             :failed carrying the reply token's causal :completed-at (delivered
             flat) alongside the error envelope — symmetric with success"
     (rf/reg-resource :fail/article (article-spec) article-spec-request)
-    (let [scoped-key   (state/scoped-resource-key :rf.scope/global :fail/article {:slug "w"})
+    (let [scoped-key   (rf.resources.state/scoped-resource-key :rf.scope/global :fail/article {:slug "w"})
           completed-at 1781111111111]
       (rf/dispatch-sync [:rf.resource/ensure {:resource :fail/article :scope :rf.scope/global
                                               :params {:slug "w"} :owner [:app :fail 1]}])
@@ -212,7 +212,7 @@
             reply) settles the work row terminal :cancelled carrying the
             reply token's causal :completed-at"
     (rf/reg-resource :ab2/article (article-spec) article-spec-request)
-    (let [scoped-key   (state/scoped-resource-key :rf.scope/global :ab2/article {:slug "w"})
+    (let [scoped-key   (rf.resources.state/scoped-resource-key :rf.scope/global :ab2/article {:slug "w"})
           completed-at 1781222222222]
       (rf/dispatch-sync [:rf.resource/ensure {:resource :ab2/article :scope :rf.scope/global
                                               :params {:slug "w"} :owner [:app :ab2 1]}])
@@ -230,7 +230,7 @@
   (testing "rf2-rl27r2: a SUPPRESSED (superseded) failure reply records the
             causal :completed-at in its terminal :suppressed outcome too"
     (rf/reg-resource :sf/article (article-spec) article-spec-request)
-    (let [scoped-key   (state/scoped-resource-key :rf.scope/global :sf/article {:slug "w"})
+    (let [scoped-key   (rf.resources.state/scoped-resource-key :rf.scope/global :sf/article {:slug "w"})
           completed-at 1781444444444]
       (rf/dispatch-sync [:rf.resource/ensure {:resource :sf/article :scope :rf.scope/global
                                               :params {:slug "w"} :owner [:app :sf 1]}])

--- a/implementation/resources/test/re_frame/resources_timer_arm_publish_race_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_timer_arm_publish_race_cljs_test.cljc
@@ -29,21 +29,21 @@
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
-   [re-frame.identity :as identity]
-   [re-frame.interop :as interop]
+   [re-frame.identity :as rf.identity]
+   [re-frame.interop :as rf.interop]
    ;; load-bearing side-effecting require: the façade registers the resources
    ;; events + the test-support reset hook that clears timer-table.
    [re-frame.resources]
    [re-frame.resources.test-support]
-   [re-frame.resources.timers :as timers]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.resources.timers :as rf.resources.timers]
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter})))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter})))
 
 (defn- fresh-handle
   "A process-unique opaque host handle, distinguishable by `identical?`."
@@ -52,9 +52,9 @@
 
 (def ^:private frame :race/f)
 (defn- rkey [tag] [:rf.scope/global tag {:id 1}])
-(defn- tkey [rk kind] [frame (identity/canonical-bytes rk) kind])
-(defn- slot [rk kind] (get @timers/timer-table (tkey rk kind)))
-(defn- armed? [rk kind] (contains? @timers/timer-table (tkey rk kind)))
+(defn- tkey [rk kind] [frame (rf.identity/canonical-bytes rk) kind])
+(defn- slot [rk kind] (get @rf.resources.timers/timer-table (tkey rk kind)))
+(defn- armed? [rk kind] (contains? @rf.resources.timers/timer-table (tkey rk kind)))
 
 ;; ===========================================================================
 ;; RACE 1 — arm-after-cleanup
@@ -62,23 +62,23 @@
 
 (deftest arm-after-cleanup-leaves-no-slot-and-cancels-orphan-handle
   (doseq [[label cleanup!]
-          [["release-frame!"  (fn [rk] (timers/release-frame! frame))]
-           ["cancel-for-key!" (fn [rk] (timers/cancel-for-key! frame rk))]
-           ["reset-cache!"    (fn [_]  (timers/reset-cache!))]]]
+          [["release-frame!"  (fn [rk] (rf.resources.timers/release-frame! frame))]
+           ["cancel-for-key!" (fn [rk] (rf.resources.timers/cancel-for-key! frame rk))]
+           ["reset-cache!"    (fn [_]  (rf.resources.timers/reset-cache!))]]]
     (testing (str "cleanup owner: " label)
-      (timers/reset-cache!)
+      (rf.resources.timers/reset-cache!)
       (let [rk           (rkey :race/arm)
-            kind         timers/stale-kind
+            kind         rf.resources.timers/stale-kind
             cancelled    (atom [])
             armed-handle (fresh-handle)]
-        (with-redefs [interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)
-                      interop/schedule-after!
+        (with-redefs [rf.interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)
+                      rf.interop/schedule-after!
                       (fn [_thunk _ms]
                         ;; the slot is reserved (sentinel) but not yet
                         ;; published: a cleanup wins here.
                         (cleanup! rk)
                         armed-handle)]
-          (timers/schedule! frame rk kind 60000))
+          (rf.resources.timers/schedule! frame rk kind 60000))
         (is (not (armed? rk kind))
             "no slot survives — the late arm did not publish onto a cleaned frame")
         (is (some #(identical? armed-handle %) @cancelled)
@@ -93,29 +93,29 @@
   ;; handle is released — publish a successor B at the same reused key (the
   ;; deterministic stand-in for a concurrent re-arm landing between A's read and
   ;; its removal). A's cancellation must claim ONLY A and leave B tracked.
-  (timers/reset-cache!)
+  (rf.resources.timers/reset-cache!)
   (let [rk        (rkey :succ)
-        kind      timers/gc-kind
+        kind      rf.resources.timers/gc-kind
         hA        (fresh-handle)
         hB        (fresh-handle)
         b-slot    {:token ::successor-token :handle hB}
         cancelled (atom [])]
-    (with-redefs [interop/schedule-after! (fn [_thunk _ms] hA)]
-      (timers/schedule! frame rk kind 60000))
+    (with-redefs [rf.interop/schedule-after! (fn [_thunk _ms] hA)]
+      (rf.resources.timers/schedule! frame rk kind 60000))
     (let [k (tkey rk kind)]
       (is (identical? hA (:handle (slot rk kind))) "precondition: A armed with hA")
-      (with-redefs [interop/cancel-scheduled!
+      (with-redefs [rf.interop/cancel-scheduled!
                     (fn [h]
                       (swap! cancelled conj h)
                       ;; B lands at the same key while A's handle is released —
                       ;; the concurrent re-arm publishing a successor.
                       (when (identical? h hA)
-                        (swap! timers/timer-table assoc k b-slot))
+                        (swap! rf.resources.timers/timer-table assoc k b-slot))
                       nil)]
-        (timers/cancel! frame rk kind))
-      (is (= b-slot (get @timers/timer-table k))
+        (rf.resources.timers/cancel! frame rk kind))
+      (is (= b-slot (get @rf.resources.timers/timer-table k))
           "successor B SURVIVES A's cancellation — the old cancel did not erase it")
-      (is (identical? hB (:handle (get @timers/timer-table k))) "B's host handle is intact")
+      (is (identical? hB (:handle (get @rf.resources.timers/timer-table k))) "B's host handle is intact")
       (is (some #(identical? hA %) @cancelled) "A's own handle was cancelled")
       (is (not (some #(identical? hB %) @cancelled))
           "B's handle was NOT cancelled by A's cancellation"))))
@@ -126,14 +126,14 @@
 ;; ===========================================================================
 
 (deftest stale-poll-loser-thunk-cannot-reap-or-refetch-the-winner
-  (timers/reset-cache!)
+  (rf.resources.timers/reset-cache!)
   (let [rk     (rkey :poll)
-        kind   timers/poll-kind
+        kind   rf.resources.timers/poll-kind
         thunks (atom [])]
-    (with-redefs [interop/schedule-after! (fn [thunk _ms] (swap! thunks conj thunk) (fresh-handle))
-                  interop/cancel-scheduled! (fn [_h] nil)]
-      (timers/schedule! frame rk kind 60000)   ;; attempt-1 → thunk-1
-      (timers/schedule! frame rk kind 60000)   ;; attempt-2 (cancel-then-arm) → thunk-2
+    (with-redefs [rf.interop/schedule-after! (fn [thunk _ms] (swap! thunks conj thunk) (fresh-handle))
+                  rf.interop/cancel-scheduled! (fn [_h] nil)]
+      (rf.resources.timers/schedule! frame rk kind 60000)   ;; attempt-1 → thunk-1
+      (rf.resources.timers/schedule! frame rk kind 60000)   ;; attempt-2 (cancel-then-arm) → thunk-2
       (is (= 2 (count @thunks)) "captured both arm thunks")
       (is (armed? rk kind) "exactly one poll slot armed")
       (let [thunk-1 (first @thunks)
@@ -155,18 +155,18 @@
 ;; ===========================================================================
 
 (deftest synchronous-fire-during-arm-strands-no-spent-handle
-  (timers/reset-cache!)
+  (rf.resources.timers/reset-cache!)
   (let [rk        (rkey :sync)
-        kind      timers/stale-kind
+        kind      rf.resources.timers/stale-kind
         cancelled (atom [])]
-    (with-redefs [interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)
-                  interop/schedule-after! (fn [thunk _ms]
+    (with-redefs [rf.interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)
+                  rf.interop/schedule-after! (fn [thunk _ms]
                                             (let [h (fresh-handle)]
                                               ;; the host fires synchronously
                                               ;; BEFORE returning the handle
                                               (thunk)
                                               h))]
-      (timers/schedule! frame rk kind 60000))
+      (rf.resources.timers/schedule! frame rk kind 60000))
     (is (not (armed? rk kind))
         "the synchronous fire closed its sentinel — no spent handle was published")
     (is (seq @cancelled)

--- a/implementation/resources/test/re_frame/resources_timer_rearm_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_timer_rearm_cljs_test.cljc
@@ -26,19 +26,19 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
+   [re-frame.fx :as rf.fx]
    ;; load-bearing side-effecting require: the façade registers the
    ;; :rf.resource/* events (incl. the internal poll-fired / gc-fired events +
    ;; the timer fxs) and the test-support reset hook that clears timer-table.
    [re-frame.resources]
-   [re-frame.resources.state :as state]
+   [re-frame.resources.state :as rf.resources.state]
    [re-frame.resources.test-support]
-   [re-frame.resources.timers :as timers]
+   [re-frame.resources.timers :as rf.resources.timers]
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport (deterministic) ----------------------------------
 ;;
@@ -51,14 +51,14 @@
 (def ^:private long-ms 1000000)
 
 (defn- capturing-fixture [f]
-  (fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
-  (fx/reg-fx :rf.http/managed-abort (fn [_ctx _work-id] nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf.fx/reg-fx :rf.http/managed-abort (fn [_ctx _work-id] nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
   capturing-fixture)
 
 ;; ---- helpers --------------------------------------------------------------
@@ -66,11 +66,11 @@
 (def ^:private frame-id :rf/default)
 
 (defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value frame-id)))
-(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
+(defn- entry [scoped-key] (get-in (runtime-db) (rf.resources.state/entry-path scoped-key)))
 
-(defn- tkey [scoped-key kind] [frame-id (state/key-id scoped-key) kind])
-(defn- timer-handle [scoped-key kind] (get @timers/timer-table (tkey scoped-key kind)))
-(defn- armed? [scoped-key kind] (contains? @timers/timer-table (tkey scoped-key kind)))
+(defn- tkey [scoped-key kind] [frame-id (rf.resources.state/key-id scoped-key) kind])
+(defn- timer-handle [scoped-key kind] (get @rf.resources.timers/timer-table (tkey scoped-key kind)))
+(defn- armed? [scoped-key kind] (contains? @rf.resources.timers/timer-table (tkey scoped-key kind)))
 
 (defn- article-spec [overrides]
   (merge {:scope         :rf.scope/from-caller
@@ -104,65 +104,65 @@
 ;; ===========================================================================
 
 (defn- reconcile! [scoped-key timers-map]
-  (timers/schedule-timers-handler
+  (rf.resources.timers/schedule-timers-handler
     nil {:frame-id frame-id :resource/key scoped-key :timers timers-map :server? false}))
 
 (deftest poll-only-rearm-preserves-sibling-stale-and-gc
-  (timers/reset-cache!)
+  (rf.resources.timers/reset-cache!)
   (let [k [:rf.scope/global :tr/combo {:id 1}]]
     ;; a full-settlement reconcile arms all three kinds
-    (reconcile! k {timers/stale-kind long-ms timers/gc-kind long-ms timers/poll-kind long-ms})
-    (is (armed? k timers/stale-kind) "stale armed")
-    (is (armed? k timers/gc-kind) "gc armed")
-    (is (armed? k timers/poll-kind) "poll armed")
-    (let [stale-h (timer-handle k timers/stale-kind)
-          gc-h    (timer-handle k timers/gc-kind)
-          poll-h  (timer-handle k timers/poll-kind)]
+    (reconcile! k {rf.resources.timers/stale-kind long-ms rf.resources.timers/gc-kind long-ms rf.resources.timers/poll-kind long-ms})
+    (is (armed? k rf.resources.timers/stale-kind) "stale armed")
+    (is (armed? k rf.resources.timers/gc-kind) "gc armed")
+    (is (armed? k rf.resources.timers/poll-kind) "poll armed")
+    (let [stale-h (timer-handle k rf.resources.timers/stale-kind)
+          gc-h    (timer-handle k rf.resources.timers/gc-kind)
+          poll-h  (timer-handle k rf.resources.timers/poll-kind)]
       ;; a POLL-ONLY partial re-arm names ONLY :poll
-      (reconcile! k {timers/poll-kind long-ms})
+      (reconcile! k {rf.resources.timers/poll-kind long-ms})
       (testing "rf2-3fc89f.10 — a poll-only re-arm PRESERVES the sibling stale
                 + GC handles (they are not named, so untouched)"
-        (is (= stale-h (timer-handle k timers/stale-kind)) "stale handle unchanged")
-        (is (= gc-h (timer-handle k timers/gc-kind)) "gc handle unchanged"))
+        (is (= stale-h (timer-handle k rf.resources.timers/stale-kind)) "stale handle unchanged")
+        (is (= gc-h (timer-handle k rf.resources.timers/gc-kind)) "gc handle unchanged"))
       (testing "the named :poll kind IS replaced (cancel-then-arm)"
-        (is (armed? k timers/poll-kind) "poll still armed")
-        (is (not= poll-h (timer-handle k timers/poll-kind)) "poll handle replaced")))
-    (timers/cancel-for-key! frame-id k)))
+        (is (armed? k rf.resources.timers/poll-kind) "poll still armed")
+        (is (not= poll-h (timer-handle k rf.resources.timers/poll-kind)) "poll handle replaced")))
+    (rf.resources.timers/cancel-for-key! frame-id k)))
 
 (deftest gc-only-rearm-preserves-sibling-stale-and-poll
-  (timers/reset-cache!)
+  (rf.resources.timers/reset-cache!)
   (let [k [:rf.scope/global :tr/combo2 {:id 1}]]
-    (reconcile! k {timers/stale-kind long-ms timers/gc-kind long-ms timers/poll-kind long-ms})
-    (let [stale-h (timer-handle k timers/stale-kind)
-          gc-h    (timer-handle k timers/gc-kind)
-          poll-h  (timer-handle k timers/poll-kind)]
+    (reconcile! k {rf.resources.timers/stale-kind long-ms rf.resources.timers/gc-kind long-ms rf.resources.timers/poll-kind long-ms})
+    (let [stale-h (timer-handle k rf.resources.timers/stale-kind)
+          gc-h    (timer-handle k rf.resources.timers/gc-kind)
+          poll-h  (timer-handle k rf.resources.timers/poll-kind)]
       ;; a GC-ONLY partial re-arm names ONLY :gc
-      (reconcile! k {timers/gc-kind long-ms})
+      (reconcile! k {rf.resources.timers/gc-kind long-ms})
       (testing "rf2-3fc89f.10 — a GC-only re-arm PRESERVES the sibling stale +
                 poll handles"
-        (is (= stale-h (timer-handle k timers/stale-kind)) "stale handle unchanged")
-        (is (= poll-h (timer-handle k timers/poll-kind)) "poll handle unchanged"))
+        (is (= stale-h (timer-handle k rf.resources.timers/stale-kind)) "stale handle unchanged")
+        (is (= poll-h (timer-handle k rf.resources.timers/poll-kind)) "poll handle unchanged"))
       (testing "the named :gc kind IS replaced (cancel-then-arm)"
-        (is (armed? k timers/gc-kind) "gc still armed")
-        (is (not= gc-h (timer-handle k timers/gc-kind)) "gc handle replaced")))
-    (timers/cancel-for-key! frame-id k)))
+        (is (armed? k rf.resources.timers/gc-kind) "gc still armed")
+        (is (not= gc-h (timer-handle k rf.resources.timers/gc-kind)) "gc handle replaced")))
+    (rf.resources.timers/cancel-for-key! frame-id k)))
 
 (deftest full-reconcile-cancels-a-kind-whose-policy-was-removed
   ;; A full settlement names ALL declared kinds; a kind carrying a nil delay
   ;; (its policy was dropped by a hot reload) is CANCELLED, not preserved.
-  (timers/reset-cache!)
+  (rf.resources.timers/reset-cache!)
   (let [k [:rf.scope/global :tr/hotreload {:id 1}]]
-    (reconcile! k {timers/stale-kind long-ms timers/gc-kind long-ms timers/poll-kind long-ms})
-    (is (armed? k timers/poll-kind) "poll armed before reload")
+    (reconcile! k {rf.resources.timers/stale-kind long-ms rf.resources.timers/gc-kind long-ms rf.resources.timers/poll-kind long-ms})
+    (is (armed? k rf.resources.timers/poll-kind) "poll armed before reload")
     ;; a later settle where the resource no longer declares a poll policy:
     ;; poll is NAMED with a nil delay ⇒ explicit cancel; stale/gc re-armed.
-    (reconcile! k {timers/stale-kind long-ms timers/gc-kind long-ms timers/poll-kind nil})
+    (reconcile! k {rf.resources.timers/stale-kind long-ms rf.resources.timers/gc-kind long-ms rf.resources.timers/poll-kind nil})
     (testing "rf2-3fc89f.10 — a NAMED nil-delay kind is CANCELLED (a removed
               policy leaves no lingering timer); the still-declared kinds stay"
-      (is (not (armed? k timers/poll-kind)) "poll cancelled (policy removed)")
-      (is (armed? k timers/stale-kind) "stale still armed")
-      (is (armed? k timers/gc-kind) "gc still armed"))
-    (timers/cancel-for-key! frame-id k)))
+      (is (not (armed? k rf.resources.timers/poll-kind)) "poll cancelled (policy removed)")
+      (is (armed? k rf.resources.timers/stale-kind) "stale still armed")
+      (is (armed? k rf.resources.timers/gc-kind) "gc still armed"))
+    (rf.resources.timers/cancel-for-key! frame-id k)))
 
 ;; ===========================================================================
 ;; EVENT LEVEL — a poll tick preserves the GC reaper; a GC skip keeps polling
@@ -176,18 +176,18 @@
   (rf/reg-resource :tre/pg (article-spec {:poll-interval-ms long-ms :gc-after-ms long-ms})
                    article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :tre/pg {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :tre/pg {:slug "w"})]
     (ensure! :tre/pg scope "w" [:route :r 1])
     (succeed! k {:title "W"})
-    (is (armed? k timers/gc-kind) "GC timer armed on settle")
-    (is (armed? k timers/poll-kind) "poll timer armed on settle")
-    (let [gc-h (timer-handle k timers/gc-kind)]
+    (is (armed? k rf.resources.timers/gc-kind) "GC timer armed on settle")
+    (is (armed? k rf.resources.timers/poll-kind) "poll timer armed on settle")
+    (let [gc-h (timer-handle k rf.resources.timers/gc-kind)]
       (poll-fired! k) ;; poll tick → background refetch + poll-only re-arm
       (testing "rf2-3fc89f.10 — the GC timer is PRESERVED across a poll tick"
-        (is (armed? k timers/gc-kind) "GC timer still armed after the poll tick")
-        (is (= gc-h (timer-handle k timers/gc-kind)) "GC handle unchanged (not re-armed)"))
+        (is (armed? k rf.resources.timers/gc-kind) "GC timer still armed after the poll tick")
+        (is (= gc-h (timer-handle k rf.resources.timers/gc-kind)) "GC handle unchanged (not re-armed)"))
       (testing "the poll timer IS re-armed (cancel-then-arm)"
-        (is (armed? k timers/poll-kind) "poll timer re-armed")))))
+        (is (armed? k rf.resources.timers/poll-kind) "poll timer re-armed")))))
 
 (deftest gc-skip-while-owned-preserves-the-poll-timer
   ;; A GC timer that fires while the entry is still OWNED skips collection and
@@ -197,19 +197,19 @@
   (rf/reg-resource :tre/gp (article-spec {:poll-interval-ms long-ms :gc-after-ms long-ms})
                    article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :tre/gp {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :tre/gp {:slug "w"})]
     (ensure! :tre/gp scope "w" [:route :r 1])
     (succeed! k {:title "W"})
-    (is (armed? k timers/poll-kind) "poll timer armed on settle")
-    (is (armed? k timers/gc-kind) "GC timer armed on settle")
-    (let [poll-h (timer-handle k timers/poll-kind)]
+    (is (armed? k rf.resources.timers/poll-kind) "poll timer armed on settle")
+    (is (armed? k rf.resources.timers/gc-kind) "GC timer armed on settle")
+    (let [poll-h (timer-handle k rf.resources.timers/poll-kind)]
       (gc-fired! k) ;; entry still owned → GC skip → gc-only re-arm
       (is (some? (entry k)) "entry not collected (still owned)")
       (testing "rf2-3fc89f.10 — the poll timer is PRESERVED across a GC skip"
-        (is (armed? k timers/poll-kind) "poll timer still armed after the GC skip")
-        (is (= poll-h (timer-handle k timers/poll-kind)) "poll handle unchanged"))
+        (is (armed? k rf.resources.timers/poll-kind) "poll timer still armed after the GC skip")
+        (is (= poll-h (timer-handle k rf.resources.timers/poll-kind)) "poll handle unchanged"))
       (testing "the GC timer IS re-armed (cancel-then-arm)"
-        (is (armed? k timers/gc-kind) "GC timer re-armed")))))
+        (is (armed? k rf.resources.timers/gc-kind) "GC timer re-armed")))))
 
 (deftest poll-tick-then-release-still-collects-the-entry
   ;; The end-to-end consequence the bug broke: on a combined poll+GC resource,
@@ -218,13 +218,13 @@
   (rf/reg-resource :tre/pgc (article-spec {:poll-interval-ms long-ms :gc-after-ms long-ms})
                    article-spec-request)
   (let [scope {:user "u"}
-        k (state/scoped-resource-key scope :tre/pgc {:slug "w"})]
+        k (rf.resources.state/scoped-resource-key scope :tre/pgc {:slug "w"})]
     (ensure! :tre/pgc scope "w" [:app :x 1])
     (succeed! k {:title "W"})
     (poll-fired! k)                 ;; poll tick (background refetch in flight)
     ;; settle the poll refetch so the entry is idle again (owner-free-able)
     (succeed! k {:title "W2"})
-    (is (armed? k timers/gc-kind) "GC timer survived the poll tick + resettle")
+    (is (armed? k rf.resources.timers/gc-kind) "GC timer survived the poll tick + resettle")
     (rf/dispatch-sync [:rf.resource/release-owner {:owner [:app :x 1]}])
     (is (empty? (:active-owners (entry k))) "entry owner-free after release")
     (gc-fired! k)                   ;; owner-free + idle → collected

--- a/implementation/resources/test/re_frame/resources_trace_egress_enumerable_token_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_trace_egress_enumerable_token_cljs_test.cljc
@@ -57,13 +57,13 @@
    ;; load-bearing side-effecting require: the façade registers the
    ;; :rf.resource/* events + subs and publishes the trace-egress hooks.
    [re-frame.resources]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.trace-egress :as trace-egress]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.trace-egress :as rf.resources.trace-egress]
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; Two secrets of the SAME shape. That is the whole design of this fixture: a
 ;; content-free token must map them to ONE value (nothing survives to tell them
@@ -92,8 +92,8 @@
     (fn [_p _ctx] {:request {:method :get :url "/plain"}})))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    {:adapter #?(:clj plain-atom/adapter :cljs reagent-adapter/adapter)
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter #?(:clj rf.substrate.plain-atom/adapter :cljs rf.adapter.reagent/adapter)
      :init-fn init!}))
 
 ;; ---- helpers --------------------------------------------------------------
@@ -101,10 +101,10 @@
 (defn- project-row
   "Project `tags` for OFF-BOX egress exactly as the epoch tool-pair does."
   [tags]
-  (trace-egress/project-resource-trace-egress tags (:rf.frame/id tags)))
+  (rf.resources.trace-egress/project-resource-trace-egress tags (:rf.frame/id tags)))
 
 (defn- key-for [resource-id tenant]
-  (state/scoped-resource-key :rf.scope/global resource-id {:tenant tenant}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global resource-id {:tenant tenant}))
 
 (defn- leaks? [secret v]
   (str/includes? (pr-str v) secret))
@@ -230,9 +230,9 @@
 
   (testing "and that digest is a function of the CANONICAL value, so a map
             spelling difference cannot change it (the rf2-hzcv8 witness)"
-    (let [k1 (state/scoped-resource-key :rf.scope/global :bulky/feed
+    (let [k1 (rf.resources.state/scoped-resource-key :rf.scope/global :bulky/feed
                                         (array-map :tenant tenant-a :page 2))
-          k2 (state/scoped-resource-key :rf.scope/global :bulky/feed
+          k2 (rf.resources.state/scoped-resource-key :rf.scope/global :bulky/feed
                                         (array-map :page 2 :tenant tenant-a))]
       (is (= (params-token k1) (params-token k2))
           "equal canonical values with different construction order produce ONE

--- a/implementation/resources/test/re_frame/resources_trace_key_declarations_egress_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_trace_key_declarations_egress_cljs_test.cljc
@@ -11,20 +11,20 @@
 
   and NO coarse `:sensitive?` root prop classifies `:serialize`. The trace /
   tool key projection read only that coarse disposition
-  (`ssr/project-scoped-key`), so the declared `:account-id` rode RAW inside
+  (`rf.resources.ssr/project-scoped-key`), so the declared `:account-id` rode RAW inside
   `:resource/key` on every `:rf.resource/*` / `:rf.mutation/*` row, inside every
   scoped-keys vector slot, inside every `[:rf.work/resource <key> <gen>]`
   work-id, and inside every fx carrier (`:rf.fx/args` / `:rf.event/fx`) the key
   reaches — off-box, epoch, MCP. Meanwhile the SAME bytes in the durable entry
   redact, because `reconcile-registry` lowered the declaration to
   `[… :resource/key 2 :account-id]` and the SSR wire key walks it
-  (`classification/project-entry-params`). One value, two carriers, one rule
+  (`rf.resources.classification/project-entry-params`). One value, two carriers, one rule
   applied: the rf2-irwsq shape.
 
   The artefact ALREADY DOCUMENTED the closed behaviour before it existed —
   `tooling.cljc` claimed `:serialize` \"applies the resource's per-slot
   `:params` projection-relative declarations\" and \"projects per-slot
-  `:params-schema` marks\", and `ssr/project-scoped-key` took a `spec` argument
+  `:params-schema` marks\", and `rf.resources.ssr/project-scoped-key` took a `spec` argument
   it named `_spec`. §1 below is the standing statement that the prose is now
   true of the code, and §5 is the standing statement that it was made true
   WITHOUT widening `project-scoped-key`, whose `:serialize` deferral is
@@ -61,24 +61,24 @@
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [clojure.string :as str]
    [re-frame.core :as rf]
-   [re-frame.frame :as frame]
+   [re-frame.frame :as rf.frame]
    ;; load-bearing side-effecting require: the façade registers the
    ;; :rf.resource/* events + subs + the :resource registrar kind, and
    ;; publishes the trace-egress hooks the epoch tool-pair consults.
    [re-frame.resources]
-   [re-frame.resources.classification :as classification]
-   [re-frame.resources.registry :as registry]
-   [re-frame.resources.ssr :as ssr]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.tooling :as resources-tooling]
-   [re-frame.resources.trace-egress :as trace-egress]
-   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.resources.classification :as rf.resources.classification]
+   [re-frame.resources.registry :as rf.resources.registry]
+   [re-frame.resources.ssr :as rf.resources.ssr]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.tooling :as rf.resources.tooling]
+   [re-frame.resources.trace-egress :as rf.resources.trace-egress]
+   [re-frame.resources.work-ledger :as rf.resources.work-ledger]
    ;; production HTTP fx surface (so the transport feature probe resolves).
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 (def ^:private account-secret "acct-SECRET-4417")
 (def ^:private tenant-secret "tenant-SECRET-99")
@@ -124,8 +124,8 @@
     (fn [_p _ctx] {:request {:method :get :url "/sealed"}})))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    {:adapter #?(:clj plain-atom/adapter :cljs reagent-adapter/adapter)
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter #?(:clj rf.substrate.plain-atom/adapter :cljs rf.adapter.reagent/adapter)
      :init-fn init!}))
 
 ;; ---- helpers --------------------------------------------------------------
@@ -133,10 +133,10 @@
 (def ^:private declared-params {:account-id account-secret :page 3})
 
 (defn- key-for [resource-id]
-  (state/scoped-resource-key :rf.scope/global resource-id declared-params))
+  (rf.resources.state/scoped-resource-key :rf.scope/global resource-id declared-params))
 
 (defn- tenant-key []
-  (state/scoped-resource-key [:rf.scope/session {:tenant-id tenant-secret :region "au"}]
+  (rf.resources.state/scoped-resource-key [:rf.scope/session {:tenant-id tenant-secret :region "au"}]
                              :tenant/report
                              {:avatar avatar-blob :page 3}))
 
@@ -145,7 +145,7 @@
   through the late-bound `:resources/project-resource-trace-egress` hook's body,
   against the row's own `:rf.frame/id`."
   [tags]
-  (trace-egress/project-resource-trace-egress tags (:rf.frame/id tags)))
+  (rf.resources.trace-egress/project-resource-trace-egress tags (:rf.frame/id tags)))
 
 (defn- projected-key
   "The single `:resource/key` slot of a one-key row, projected off-box."
@@ -164,15 +164,15 @@
   steps a real resource commit folds into one transition. Returns the key."
   [frame-id scoped-key]
   (let [resource-id (second scoped-key)]
-    (frame/swap-runtime-db!
+    (rf.frame/swap-runtime-db!
       frame-id
       (fn [rdb]
         (-> (or rdb {})
-            (assoc-in (state/entry-path scoped-key)
-                      (assoc (state/empty-entry resource-id scoped-key)
+            (assoc-in (rf.resources.state/entry-path scoped-key)
+                      (assoc (rf.resources.state/empty-entry resource-id scoped-key)
                              :status :loaded
                              :data   {:total 1}))
-            (classification/reconcile-registry registry/resource-meta)))))
+            (rf.resources.classification/reconcile-registry rf.resources.registry/resource-meta)))))
   scoped-key)
 
 (defn- ssr-wire-key
@@ -184,15 +184,15 @@
   row, because a `:serialize` entry re-keyed by its own per-slot declaration is
   WITHHELD from the wire (rf2-rjq9d — an unaddressable row hydrates as an
   ownerless duplicate nothing can reach or collect). The projection itself is
-  untouched: `classification/project-entry-params` still runs and still produces
+  untouched: `rf.resources.classification/project-entry-params` still runs and still produces
   this key, so the agreement asserted below is the same agreement, read off the
   carrier that survives."
   [frame-id scoped-key]
-  (let [rdb (frame/frame-runtime-db-value frame-id)]
+  (let [rdb (rf.frame/frame-runtime-db-value frame-id)]
     (some (fn [m]
             (when (= (second (:resource/key m)) (second scoped-key))
               (:projected-key m)))
-          (ssr/projection-metadata frame-id 5000 (get-in rdb (state/entries-path))))))
+          (rf.resources.ssr/projection-metadata frame-id 5000 (get-in rdb (rf.resources.state/entries-path))))))
 
 ;; ===========================================================================
 ;; 1. THE LEAK. A `:serialize` owner's declared params slot must not ride raw
@@ -226,7 +226,7 @@
             slot, inside a work-id, and inside the fx carriers a foreign row
             stamps"
     (let [k       (key-for :account/summary)
-          work-id (work-ledger/resource-work-id k 1)
+          work-id (rf.resources.work-ledger/resource-work-id k 1)
           rows    {:rf.frame/id :rf/default
                    :matched     [k]
                    :work/id     work-id
@@ -248,7 +248,7 @@
             tags {:rf.frame/id :rf/default
                   :rf.fx/args  {:request-id [:rf.req :rf/default
                                              [:rf.work/resource k 1]]}}
-            out  (trace-egress/project-fx-args-egress tags :rf/default)]
+            out  (rf.resources.trace-egress/project-fx-args-egress tags :rf/default)]
         (is (not (leaks? account-secret out))
             (str "an ensure's fx carrier must honour the declaration — got "
                  (pr-str out)))
@@ -264,7 +264,7 @@
     (let [k  (key-for :plain/summary)
           pk (projected-key k)]
       (is (= k pk) "a plain owner's key is unchanged")
-      (is (= (state/key-id k) (state/key-id pk))
+      (is (= (rf.resources.state/key-id k) (rf.resources.state/key-id pk))
           "…byte-identical, so the cache-key-identity round-trip is intact")
       (is (leaks? account-secret pk)
           "an undeclared param is app data and stays readable to a tool"))))
@@ -273,7 +273,7 @@
   (testing "rf2-wgutc2 — the walker reconstructs collections, so an UNNECESSARY
             walk would collapse a list-valued param to a vector and change the
             key's bytes. The declaration-existence gate is what stops it"
-    (let [k  (state/scoped-resource-key :rf.scope/global :plain/summary
+    (let [k  (rf.resources.state/scoped-resource-key :rf.scope/global :plain/summary
                                         {:account-id "a" :page 3 :ids '(1 2 3)})
           pk (projected-key k)]
       (is (= (pr-str k) (pr-str pk))
@@ -331,7 +331,7 @@
     (let [k     (key-for :account/summary)
           reply (read-reply k {:ok true})
           tags  {:rf.frame/id :rf/default :rf.fx/args reply}
-          out   (:rf.fx/args (trace-egress/project-fx-args-egress tags :rf/default))]
+          out   (:rf.fx/args (rf.resources.trace-egress/project-fx-args-egress tags :rf/default))]
       (is (= :rf/redacted (:account-id (:params out)))
           "the reply's own :params copy still redacts through its declaration")
       (is (= 3 (:page (:params out)))
@@ -376,7 +376,7 @@
 
 (deftest trace-key-agrees-with-the-ssr-durable-wire-key
   (testing "rf2-dl7bz Q1 — the spec-derived per-slot projection is BYTE-EQUAL
-            to the registry-driven `classification/project-entry-params` the SSR
+            to the registry-driven `rf.resources.classification/project-entry-params` the SSR
             durable path runs. Two derivations, one answer"
     (let [k        (install-entry! :rf/default (key-for :account/summary))
           wire     (ssr-wire-key :rf/default k)
@@ -402,16 +402,16 @@
 
 (deftest project-scoped-key-still-defers-on-serialize
   (testing "rf2-dl7bz ruling — the per-slot arm lives at the trace / tool
-            boundary, NOT inside `ssr/project-scoped-key`, whose `:serialize`
+            boundary, NOT inside `rf.resources.ssr/project-scoped-key`, whose `:serialize`
             deferral is deliberate (the SSR durable path resolves the same
             declaration from the per-frame elision registry). This test reds if
             anyone moves the arm into the shared projection"
     (let [k    (key-for :account/summary)
-          spec (registry/resource-meta :account/summary)]
-      (is (= k (ssr/project-scoped-key k :serialize spec))
+          spec (rf.resources.registry/resource-meta :account/summary)]
+      (is (= k (rf.resources.ssr/project-scoped-key k :serialize spec))
           "`:serialize` still rides VERBATIM through `project-scoped-key`")
-      (is (= (ssr/project-scoped-key k :serialize spec)
-             (ssr/project-scoped-key k :serialize nil))
+      (is (= (rf.resources.ssr/project-scoped-key k :serialize spec)
+             (rf.resources.ssr/project-scoped-key k :serialize nil))
           "…and it still ignores the spec argument, exactly as documented"))))
 
 ;; ===========================================================================
@@ -431,12 +431,12 @@
           "…and so is the whole scope component")
       (is (= :sealed/summary (nth pk 1)) "the resource-id survives")
       (is (true? (:sensitive? tags)))
-      (is (= pk (ssr/project-scoped-key k :redact nil))
+      (is (= pk (rf.resources.ssr/project-scoped-key k :redact nil))
           "byte-for-byte what `project-scoped-key` alone produced before"))))
 
 (deftest unregistered-owner-still-fails-closed
   (testing "the nil-spec fail-closed arm is untouched by the declaration arm"
-    (let [k    (state/scoped-resource-key :rf.scope/global :never/registered
+    (let [k    (rf.resources.state/scoped-resource-key :rf.scope/global :never/registered
                                           {:account-id account-secret})
           tags (project-row {:rf.frame/id :rf/default :resource/key k})]
       (is (not (leaks? account-secret (:resource/key tags))))
@@ -455,7 +455,7 @@
             Before this, `project-key-for-egress`'s docstring claimed `:serialize`
             projected per-slot marks and the code did nothing"
     (let [k    (install-entry! :rf/default (key-for :account/summary))
-          view (resources-tooling/resource-cache-algebra-view :rf/default)
+          view (rf.resources.tooling/resource-cache-algebra-view :rf/default)
           node (first (vals view))]
       (is (some? node) "the live entry projects to a node")
       (is (not (leaks? account-secret node))
@@ -466,6 +466,6 @@
       (is (= 3 (get-in (:id node) [2 :page]))
           "…and the undeclared sibling still rides, so joins survive")
       (testing "the DURABLE cache key is untouched — this is an egress-only projection"
-        (let [rdb (frame/frame-runtime-db-value :rf/default)]
-          (is (= k (:resource/key (get-in rdb (state/entry-path k))))
+        (let [rdb (rf.frame/frame-runtime-db-value :rf/default)]
+          (is (= k (:resource/key (get-in rdb (rf.resources.state/entry-path k))))
               "the entry still stores the raw scoped key"))))))

--- a/implementation/resources/test/re_frame/resources_trace_keyid_egress_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_trace_keyid_egress_cljs_test.cljc
@@ -3,7 +3,7 @@
 
   ## The leak this suite pins
 
-  A `state/key-id` is `re-frame.identity/canonical-bytes` of the scoped key —
+  A `rf.resources.state/key-id` is `re-frame.identity/canonical-bytes` of the scoped key —
   CEDN-1, a **reversible plaintext encoding, not a digest**. `encode-string`
   emits `(str \"s:\" (pr-str s))`, so the key-id for
   `[:rf.scope/global :secret/article {:auth-token \"topsecret-PII\"}]` is
@@ -68,20 +68,20 @@
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [clojure.string :as str]
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
-   [re-frame.identity :as identity]
+   [re-frame.fx :as rf.fx]
+   [re-frame.identity :as rf.identity]
    ;; load-bearing side-effecting require: registers the :rf.resource/* events
    ;; + subs this suite dispatches.
    [re-frame.resources]
-   [re-frame.resources.ssr :as r-ssr]
-   [re-frame.resources.state :as state]
+   [re-frame.resources.ssr :as rf.resources.ssr]
+   [re-frame.resources.state :as rf.resources.state]
    [re-frame.resources.test-support]
-   [re-frame.resources.trace-egress :as trace-egress]
+   [re-frame.resources.trace-egress :as rf.resources.trace-egress]
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.interop :as interop]
-   [re-frame.test-support :as core-test-support]
-   [re-frame.trace.tooling :as trace-tooling]
+   [re-frame.interop :as rf.interop]
+   [re-frame.test-support :as rf.test-support]
+   [re-frame.trace.tooling :as rf.trace.tooling]
    #?(:clj  [re-frame.substrate.plain-atom :as substrate]
       :cljs [re-frame.adapter.reagent :as substrate])))
 
@@ -96,7 +96,7 @@
   []
   (rf/make-frame {:id :rf/default :url-bound? true
                   :doc "key-id trace-egress suite default app frame."})
-  (fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
   (rf/reg-resource :secret/article
     {:scope         :rf.scope/global
      :sensitive?    true
@@ -116,17 +116,17 @@
     (fn [_p _ctx] {:request {:method :get :url "/seq"}})))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     {:adapter substrate/adapter
      :init-fn init!}))
 
 ;; ---- helpers --------------------------------------------------------------
 
 (def ^:private secret-key
-  (state/scoped-resource-key :rf.scope/global :secret/article {:auth-token secret}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global :secret/article {:auth-token secret}))
 
 (def ^:private plain-key
-  (state/scoped-resource-key :rf.scope/global :plain/article {:slug "public-post"}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global :plain/article {:slug "public-post"}))
 
 (defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
 
@@ -152,10 +152,10 @@
   [op body-fn]
   (let [seen (atom [])
         k    ::keyid-egress-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (= op (:operation ev)) (swap! seen conj ev))))
     (try (body-fn)
-         (finally (trace-tooling/unregister-listener! k)))
+         (finally (rf.trace.tooling/unregister-listener! k)))
     @seen))
 
 (defn- project
@@ -163,7 +163,7 @@
   through the late-bound `:resources/project-resource-trace-egress` hook's
   body, against the row's own `:rf.frame/id`."
   [tags]
-  (trace-egress/project-resource-trace-egress tags (:rf.frame/id tags)))
+  (rf.resources.trace-egress/project-resource-trace-egress tags (:rf.frame/id tags)))
 
 (defn- release-owner-row
   "Drive the PUBLIC path: `ensure` the sensitive resource AND the plain
@@ -199,15 +199,15 @@
 ;; ===========================================================================
 
 (deftest key-id-is-reversible-plaintext-not-a-digest
-  (testing "rf2-5o52l — `state/key-id` is `identity/canonical-bytes`, CEDN-1: a
+  (testing "rf2-5o52l — `rf.resources.state/key-id` is `rf.identity/canonical-bytes`, CEDN-1: a
             REVERSIBLE PLAINTEXT encoding. The key-id for a scoped key whose
             params carry a secret CONTAINS that secret verbatim, wrapped in the
             `s:\"…\"` string token `encode-string` emits. This is why a key-id
             may never be copied into a trace tag: nothing downstream can undo
             it, and the off-box projector correctly sees only a string"
-    (let [k-id (state/key-id secret-key)]
+    (let [k-id (rf.resources.state/key-id secret-key)]
       (is (string? k-id) "a key-id is a plain string — a scalar to any shape walk")
-      (is (= k-id (identity/canonical-bytes secret-key))
+      (is (= k-id (rf.identity/canonical-bytes secret-key))
           "key-id IS canonical-bytes — no hashing step exists")
       (is (str/includes? k-id secret)
           "the raw secret survives verbatim inside the key-id")
@@ -345,9 +345,9 @@
   `reconcile-entry-owners` drops an `[:ssr …]` owner always and, on restore with
   no live nav-token, every `[:route …]` owner."
   [owner]
-  (let [now (interop/epoch-now-ms)]
+  (let [now (rf.interop/epoch-now-ms)]
     (-> (runtime-db)
-        (assoc-in (state/entry-path secret-key)
+        (assoc-in (rf.resources.state/entry-path secret-key)
                   {:resource/key   secret-key
                    :status         :loaded
                    :data           {:body "server-rendered"}
@@ -369,7 +369,7 @@
     (let [ssr-owner [:ssr "req-1" "nav-1"]
           rows      (capture-op!
                       :rf.resource/hydrate-clock-skew
-                      (fn [] (r-ssr/hydrate-runtime-db (skewed-runtime-db ssr-owner)
+                      (fn [] (rf.resources.ssr/hydrate-runtime-db (skewed-runtime-db ssr-owner)
                                                        :rf/default)))
           tags      (:tags (first rows))]
       (is (= 1 (count rows)) "one skew row for the one skewed entry")
@@ -386,7 +386,7 @@
       (let [ssr-owner [:ssr "req-1" "nav-1"]
             rows      (capture-op!
                         :rf.resource/hydrated
-                        (fn [] (r-ssr/hydrate-runtime-db (skewed-runtime-db ssr-owner)
+                        (fn [] (rf.resources.ssr/hydrate-runtime-db (skewed-runtime-db ssr-owner)
                                                          :rf/default)))
             tags      (:tags (first rows))]
         (is (= [[secret-key ssr-owner]] (:orphaned-owners tags))
@@ -407,7 +407,7 @@
       (testing "the :warning clock-skew row"
         (let [tags (:tags (first (capture-op!
                                    :rf.resource/restore-clock-skew
-                                   #(r-ssr/reconcile-on-restore rdb :rf/default))))]
+                                   #(rf.resources.ssr/reconcile-on-restore rdb :rf/default))))]
           (is (= secret-key (:resource/key tags)) "scoped key, not key-id")
           (is (redacted-token? (nth (:resource/key (project tags)) 2))
               "params tokenized off-box")
@@ -416,7 +416,7 @@
                 route orphan"
         (let [tags (:tags (first (capture-op!
                                    :rf.resource/owner-released
-                                   #(r-ssr/reconcile-on-restore rdb :rf/default))))]
+                                   #(rf.resources.ssr/reconcile-on-restore rdb :rf/default))))]
           (is (= secret-key (:resource/key tags)) "scoped key, not key-id")
           (is (= route-owner (:owner tags)) "names the orphaned route owner")
           (is (redacted-token? (nth (:resource/key (project tags)) 2))
@@ -426,7 +426,7 @@
       (testing "the :rf.resource/restored summary's :orphaned-owners"
         (let [tags (:tags (first (capture-op!
                                    :rf.resource/restored
-                                   #(r-ssr/reconcile-on-restore rdb :rf/default))))]
+                                   #(rf.resources.ssr/reconcile-on-restore rdb :rf/default))))]
           (is (= [[secret-key route-owner]] (:orphaned-owners tags))
               "the orphaned route owner is paired with its entry's scoped key")
           (is (not (leaks-secret? (project tags))) "no plaintext off-box")
@@ -459,14 +459,14 @@
   "A scoped key for `:secret/seq` whose secret-bearing params carry `xs` — the
   collection whose KIND decides identity."
   [xs]
-  (state/scoped-resource-key :rf.scope/global seq-resource-id {:xs xs}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global seq-resource-id {:xs xs}))
 
 (defn- kind-colliding-runtime-db
   "A runtime-db holding TWO skewed `:sensitive?` entries whose scoped keys are
   Clojure-`=` and whose key-ids are not: one with VECTOR params, one with LIST
   params. Both owned by an `[:ssr …]` owner, so both also orphan."
   []
-  (let [now (interop/epoch-now-ms)
+  (let [now (rf.interop/epoch-now-ms)
         ent (fn [sk] {:resource/key   sk
                       :status         :loaded
                       :data           {:body "server-rendered"}
@@ -477,8 +477,8 @@
                       :stale-at       (+ now 200000)
                       :stale-after-ms 100000})]
     (-> (runtime-db)
-        (assoc-in (state/entry-path (seq-key [secret])) (ent (seq-key [secret])))
-        (assoc-in (state/entry-path (seq-key (list secret)))
+        (assoc-in (rf.resources.state/entry-path (seq-key [secret])) (ent (seq-key [secret])))
+        (assoc-in (rf.resources.state/entry-path (seq-key (list secret)))
                   (ent (seq-key (list secret)))))))
 
 (deftest reconcile-skew-accumulators-keep-kind-distinct-entries-distinct
@@ -492,15 +492,15 @@
                 idea of equality"
         (is (= vk lk)
             "the two scoped keys are `=` — a map keyed on them holds ONE entry")
-        (is (not= (state/key-id vk) (state/key-id lk))
+        (is (not= (rf.resources.state/key-id vk) (rf.resources.state/key-id lk))
             "while their CEDN key-ids differ — they are two distinct resources")
-        (is (= 2 (count (:entries (get rdb state/resources-key))))
+        (is (= 2 (count (:entries (get rdb rf.resources.state/resources-key))))
             "and the runtime-db really holds both"))
 
       (doseq [[label reconcile! skew-op summary-op]
-              [["hydrate" #(r-ssr/hydrate-runtime-db % :rf/default)
+              [["hydrate" #(rf.resources.ssr/hydrate-runtime-db % :rf/default)
                 :rf.resource/hydrate-clock-skew :rf.resource/hydrated]
-               ["restore" #(r-ssr/reconcile-on-restore % :rf/default)
+               ["restore" #(rf.resources.ssr/reconcile-on-restore % :rf/default)
                 :rf.resource/restore-clock-skew :rf.resource/restored]]]
         (testing label
           (is (= 2 (count (capture-op! skew-op #(reconcile! rdb))))

--- a/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
@@ -27,23 +27,23 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.fx :as fx]
-   [re-frame.frame :as frame]
-   [re-frame.reply :as reply]
+   [re-frame.fx :as rf.fx]
+   [re-frame.frame :as rf.frame]
+   [re-frame.reply :as rf.reply]
    ;; load-bearing side-effecting require: the façade registers the
    ;; :rf.resource/* events + the work-ledger side-table fx these tests
    ;; dispatch through.
    [re-frame.resources]
-   [re-frame.resources.state :as state]
-   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.resources.state :as rf.resources.state]
+   [re-frame.resources.work-ledger :as rf.resources.work-ledger]
    [re-frame.resources.test-support]
    ;; production HTTP fx surface (so the transport feature probe resolves);
    ;; the actual fetch + abort are overridden by capturing no-ops below.
    [re-frame.http.managed]
    [re-frame.schemas]
-   [re-frame.test-support :as core-test-support]
-   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+   [re-frame.test-support :as rf.test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as rf.adapter.reagent]])))
 
 ;; ---- capturing transport + abort (decouples ledger tests from HTTP) -------
 
@@ -62,20 +62,20 @@
   [f]
   (reset! last-managed-args nil)
   (reset! aborts [])
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
   ;; rf2-sxyrzk — managed-abort args is the frame-QUALIFIED transport
   ;; request-id (`[:rf.req <frame-id> <work-id>]`, `managed-request-id`), NOT
   ;; the bare work-id. The managed-HTTP in-flight registry keys by request-id
   ;; PROCESS-GLOBALLY (Spec 014), so the abort must carry the same qualified
   ;; token the lower registered or it would miss the request (or, across
   ;; frames, resolve a sibling frame's colliding request).
-  (fx/reg-fx :rf.http/managed-abort (fn [_ctx request-id] (swap! aborts conj request-id) nil))
+  (rf.fx/reg-fx :rf.http/managed-abort (fn [_ctx request-id] (swap! aborts conj request-id) nil))
   (f))
 
 (use-fixtures :each
-  (core-test-support/make-reset-runtime-fixture
-    #?(:clj  {:adapter plain-atom/adapter}
-       :cljs {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter rf.substrate.plain-atom/adapter}
+       :cljs {:adapter rf.adapter.reagent/adapter}))
   capturing-transport-fixture)
 
 ;; ---- helpers --------------------------------------------------------------
@@ -87,13 +87,13 @@
 (defn- entry
   ([scoped-key] (entry :rf/default scoped-key))
   ([frame-id scoped-key]
-   (get-in (runtime-db frame-id) (state/entry-path scoped-key))))
+   (get-in (runtime-db frame-id) (rf.resources.state/entry-path scoped-key))))
 
 (defn- record
   "The serializable work record under a work-id in a frame."
   ([work-id] (record :rf/default work-id))
   ([frame-id work-id]
-   (work-ledger/get-record (runtime-db frame-id) work-id)))
+   (rf.resources.work-ledger/get-record (runtime-db frame-id) work-id)))
 
 (defn- ledger
   ([] (ledger :rf/default))
@@ -105,7 +105,7 @@
   for a `work-id` issued in `frame-id` (default `:rf/default`). The abort
   carries this, NOT the bare work-id, so it matches the registered token."
   ([work-id] (req :rf/default work-id))
-  ([frame-id work-id] (work-ledger/managed-request-id frame-id work-id)))
+  ([frame-id work-id] (rf.resources.work-ledger/managed-request-id frame-id work-id)))
 
 (defn- article-spec
   ([] (article-spec {}))
@@ -125,7 +125,7 @@
 
 (deftest ensure-writes-work-record
   (rf/reg-resource :wl/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :wl/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :wl/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :wl/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:route :r 1]
@@ -150,37 +150,37 @@
         (is (number? (:started-at r))))
       (testing "the work record carries NO host handles (serializable EDN
                 for SSR / Xray)"
-        (is (work-ledger/serializable-record? r))
+        (is (rf.resources.work-ledger/serializable-record? r))
         (is (not (contains? r :abort-controller)))
         (is (not (contains? r :promise)))
         (is (not (contains? r :abort-fn)))))))
 
 (deftest work-record-byte-keyed-address-is-canonical
   ;; rf2-hgy5kf (EP-0012) — the work record lives at ONE address: the
-  ;; byte-keyed `work-ledger/record-path` (`[:rf.runtime/work-ledger
+  ;; byte-keyed `rf.resources.work-ledger/record-path` (`[:rf.runtime/work-ledger
   ;; (work-id-id work-id)]`). The stale `[work-ledger-key work-id]` VECTOR
-  ;; address (the removed `state/work-record-path` shape) holds NOTHING — a
+  ;; address (the removed `rf.resources.state/work-record-path` shape) holds NOTHING — a
   ;; test reading through it would silently miss the live row, making any
   ;; `(when rec …)` assertion vacuous. This pins the one home so the drift
   ;; cannot reappear.
   (rf/reg-resource :wlbk/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :wlbk/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :wlbk/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :wlbk/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:route :r 1]}])
     (let [wid (:current-work (entry scoped-key))
           rdb (runtime-db)]
       (testing "the byte-keyed work-ledger API reads the live row"
-        (is (some? (work-ledger/get-record rdb wid)))
-        (is (= :running (:status (work-ledger/get-record rdb wid)))))
+        (is (some? (rf.resources.work-ledger/get-record rdb wid)))
+        (is (= :running (:status (rf.resources.work-ledger/get-record rdb wid)))))
       (testing "the row is stored under the CEDN-1 byte work-id-id, NOT the
                 work-id vector"
-        (is (contains? (:rf.runtime/work-ledger rdb) (work-ledger/work-id-id wid)))
+        (is (contains? (:rf.runtime/work-ledger rdb) (rf.resources.work-ledger/work-id-id wid)))
         (is (not (contains? (:rf.runtime/work-ledger rdb) wid)))
-        (is (string? (work-ledger/work-id-id wid))))
+        (is (string? (rf.resources.work-ledger/work-id-id wid))))
       (testing "the removed stale [work-ledger-key work-id] vector address
                 holds nothing (the dead shape EP-0012 eliminates)"
-        (is (nil? (get-in rdb [state/work-ledger-key wid])))))))
+        (is (nil? (get-in rdb [rf.resources.state/work-ledger-key wid])))))))
 
 (deftest work-record-started-at-deadline-at-from-token-time-ms
   ;; rf2-uuzj88 / EP-0010 §Resources, Mutations, And Work-Ledger Timestamps:
@@ -190,7 +190,7 @@
   ;; clock read in the reducer. Scripting the dispatch's `:rf.cofx`
   ;; pins both; the same token mints the same row (replay-stable).
   (rf/reg-resource :wlt/article (article-spec {:timeout-ms 5000}) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :wlt/article {:slug "w"})
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :wlt/article {:slug "w"})
         t1 1781078400123]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :wlt/article :scope :rf.scope/global
@@ -204,7 +204,7 @@
   ;; a resource declaring NO timeout policy has a nil :deadline-at, and its
   ;; :started-at still tracks the token (replay-stable, no ambient read).
   (rf/reg-resource :wlnt/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :wlnt/article {:slug "w"})
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :wlnt/article {:slug "w"})
         t2 1781079000000]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :wlnt/article :scope :rf.scope/global
@@ -222,20 +222,20 @@
 
 (deftest host-handle-in-side-table-not-runtime-db
   (rf/reg-resource :hh/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :hh/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :hh/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :hh/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:app :hh 1]}])
     (let [wid (:current-work (entry scoped-key))]
       (testing "a host-side side-table slot exists for [frame-id work-id]
                 (host-side, NOT runtime-db — Spec 016 §Frame work ledger)"
-        (is (some? (work-ledger/get-handle :rf/default wid)))
-        (is (= :rf.http/managed (:transport (work-ledger/get-handle :rf/default wid)))))
+        (is (some? (rf.resources.work-ledger/get-handle :rf/default wid)))
+        (is (= :rf.http/managed (:transport (rf.resources.work-ledger/get-handle :rf/default wid)))))
       (testing "the side table is NOT inside runtime-db (no host handles ride
                 the durable wire)"
         (is (nil? (get-in (runtime-db) [:rf.runtime/work-ledger :handles])))
         ;; the record in runtime-db is host-handle-free
-        (is (work-ledger/serializable-record? (record wid)))))))
+        (is (rf.resources.work-ledger/serializable-record? (record wid)))))))
 
 ;; ===========================================================================
 ;; 3. succeeded settles the record :completed + prunes terminal rows
@@ -243,7 +243,7 @@
 
 (deftest succeeded-completes-and-prunes-record
   (rf/reg-resource :sc/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :sc/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :sc/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :sc/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:app :sc 1]}])
     (let [wid (:current-work (entry scoped-key))]
@@ -257,11 +257,11 @@
         (is (or (nil? (record wid))
                 (= :completed (:status (record wid))))))
       (testing "the host handle for the settled attempt is cleared"
-        (is (nil? (work-ledger/get-handle :rf/default wid)))))))
+        (is (nil? (rf.resources.work-ledger/get-handle :rf/default wid)))))))
 
 (deftest succeeded-prunes-old-terminal-rows-beyond-tail
   (rf/reg-resource :pr/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :pr/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :pr/article {:slug "w"})]
     ;; run several attempts so terminal rows accumulate, then assert the
     ;; ledger is bounded (default tail = 3 terminal rows per key)
     (dotimes [_ 6]
@@ -276,8 +276,8 @@
               bounded (a small per-key tail), not unbounded growth"
       (let [terminal-rows (->> (vals (ledger))
                                (filter (fn [r] (and (= scoped-key (:resource/key r))
-                                                    (work-ledger/terminal? (:status r))))))]
-        (is (<= (count terminal-rows) work-ledger/default-terminal-tail)
+                                                    (rf.resources.work-ledger/terminal? (:status r))))))]
+        (is (<= (count terminal-rows) rf.resources.work-ledger/default-terminal-tail)
             "terminal rows for the key are pruned to the bounded tail")))))
 
 ;; ===========================================================================
@@ -286,7 +286,7 @@
 
 (deftest failed-settles-record-terminal
   (rf/reg-resource :fa/article (article-spec) article-spec-request)
-  (let [scoped-key   (state/scoped-resource-key :rf.scope/global :fa/article {:slug "w"})
+  (let [scoped-key   (rf.resources.state/scoped-resource-key :rf.scope/global :fa/article {:slug "w"})
         completed-at  1781649764112]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :fa/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:app :fa 1]}])
@@ -308,11 +308,11 @@
                 :completed-at completed-at}
                (:outcome (record wid)))))
       (testing "the host handle is cleared"
-        (is (nil? (work-ledger/get-handle :rf/default wid)))))))
+        (is (nil? (rf.resources.work-ledger/get-handle :rf/default wid)))))))
 
 (deftest aborted-settles-record-cancelled
   (rf/reg-resource :ab/article (article-spec) article-spec-request)
-  (let [scoped-key   (state/scoped-resource-key :rf.scope/global :ab/article {:slug "w"})
+  (let [scoped-key   (rf.resources.state/scoped-resource-key :rf.scope/global :ab/article {:slug "w"})
         completed-at  1781649764112]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :ab/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:app :ab 1]}])
@@ -331,7 +331,7 @@
         (is (= :cancelled (:status (record wid))))
         (is (= {:reason :aborted :completed-at completed-at}
                (:outcome (record wid))))
-        (is (nil? (work-ledger/get-handle :rf/default wid)))))))
+        (is (nil? (rf.resources.work-ledger/get-handle :rf/default wid)))))))
 
 (deftest stale-aborted-reply-suppressed-not-cancelled
   ;; rf2-iu0z8t (EP-0011): an ABORT reply must honour the SAME
@@ -341,7 +341,7 @@
   ;; :cancelled. Stale validation wins over the natural cancellation status
   ;; (Managed-Effects §Stale suppression).
   (rf/reg-resource :sa/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :sa/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :sa/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :sa/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:app :sa 1]}])
     (let [wid1 (:current-work (entry scoped-key))]
@@ -371,7 +371,7 @@
   (rf/reg-resource :cfa/article (article-spec) article-spec-request)
   (let [fa :cfa/frame-a
         fb :cfa/frame-b
-        scoped-key (state/scoped-resource-key :rf.scope/global :cfa/article {:slug "w"})]
+        scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :cfa/article {:slug "w"})]
     (rf/make-frame {:id fa :doc "frame A"})
     (rf/make-frame {:id fb :doc "frame B"})
     (rf/dispatch-sync [:rf.resource/ensure {:resource :cfa/article :scope :rf.scope/global
@@ -403,7 +403,7 @@
 
 (deftest stale-reply-suppressed-and-row-terminal
   (rf/reg-resource :ss/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :ss/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :ss/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :ss/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:app :ss 1]}])
     (let [wid1 (:current-work (entry scoped-key))]
@@ -431,7 +431,7 @@
 
 (deftest dedupe-joins-existing-record
   (rf/reg-resource :dd/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :dd/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :dd/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :dd/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:route :r 1]
                                             :cause [:route-entry :r 1]}])
@@ -453,7 +453,7 @@
 
 (deftest release-owner-aborts-only-when-orphaned
   (rf/reg-resource :ro/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :ro/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :ro/article {:slug "w"})]
     ;; two owners on one in-flight attempt (ensure dedupes)
     (rf/dispatch-sync [:rf.resource/ensure {:resource :ro/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:route :r 1]}])
@@ -479,7 +479,7 @@
 (deftest clear-scope-cancels-in-flight-rows
   (rf/reg-resource :cs/article (article-spec {:scope :rf.scope/from-caller}) article-spec-request)
   (let [scope-a {:user "a"}
-        ka (state/scoped-resource-key scope-a :cs/article {:slug "w"})]
+        ka (rf.resources.state/scoped-resource-key scope-a :cs/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :cs/article :scope scope-a
                                             :params {:slug "w"} :owner [:app :a 1]}])
     (let [wid (:current-work (entry ka))]
@@ -492,7 +492,7 @@
 
 (deftest remove-cancels-in-flight-row
   (rf/reg-resource :rm/article (article-spec) article-spec-request)
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :rm/article {:slug "w"})]
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :rm/article {:slug "w"})]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :rm/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:app :rm 1]}])
     (let [wid (:current-work (entry scoped-key))]
@@ -513,7 +513,7 @@
   ;; switch cancellations.
   (rf/reg-resource :cst/article (article-spec {:scope :rf.scope/from-caller}) article-spec-request)
   (let [scope-a      {:user "a"}
-        ka           (state/scoped-resource-key scope-a :cst/article {:slug "w"})
+        ka           (rf.resources.state/scoped-resource-key scope-a :cst/article {:slug "w"})
         completed-at 1781649764222]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :cst/article :scope scope-a
                                             :params {:slug "w"} :owner [:app :a 1]}])
@@ -529,7 +529,7 @@
   ;; rf2-x76af2.14 — remove has the identical gap clear-scope had: its terminal
   ;; :cancelled row now carries the event's causal :completed-at.
   (rf/reg-resource :rmt/article (article-spec) article-spec-request)
-  (let [scoped-key   (state/scoped-resource-key :rf.scope/global :rmt/article {:slug "w"})
+  (let [scoped-key   (rf.resources.state/scoped-resource-key :rf.scope/global :rmt/article {:slug "w"})
         completed-at 1781649764333]
     (rf/dispatch-sync [:rf.resource/ensure {:resource :rmt/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:app :rm 1]}])
@@ -549,7 +549,7 @@
 (deftest frame-destroy-clears-side-tables
   (rf/reg-resource :fd/article (article-spec) article-spec-request)
   (let [fa :fd/frame-a
-        scoped-key (state/scoped-resource-key :rf.scope/global :fd/article {:slug "w"})]
+        scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :fd/article {:slug "w"})]
     (rf/make-frame {:id fa :doc "teardown frame"})
     (rf/dispatch-sync [:rf.resource/ensure {:resource :fd/article :scope :rf.scope/global
                                             :params {:slug "w"} :owner [:app :fd 1]}]
@@ -557,14 +557,14 @@
     (let [wid (:current-work (entry fa scoped-key))]
       (testing "before destroy the host handle + generation high-water exist
                 for the frame"
-        (is (some? (work-ledger/get-handle fa wid)))
-        (is (pos? (state/generation-snapshot fa))))
-      (frame/destroy-frame! fa)
+        (is (some? (rf.resources.work-ledger/get-handle fa wid)))
+        (is (pos? (rf.resources.state/generation-snapshot fa))))
+      (rf.frame/destroy-frame! fa)
       (testing "Spec 016 [Runtime-Subsystems] clause 5 — frame destroy drops
                 the TRANSIENT host handles + generation high-water for the
                 frame (durable records ride the dropped frame value)"
-        (is (nil? (work-ledger/get-handle fa wid)) "host handle cleared")
-        (is (zero? (state/generation-snapshot fa)) "generation high-water dropped")))))
+        (is (nil? (rf.resources.work-ledger/get-handle fa wid)) "host handle cleared")
+        (is (zero? (rf.resources.state/generation-snapshot fa)) "generation high-water dropped")))))
 
 ;; ===========================================================================
 ;; 10. work-id embeds the generation (one identity per record)
@@ -574,11 +574,11 @@
   (testing "Spec 016 §Ledger row retention and identity — the work id embeds
             the generation; ONE identity per record (no separate :stale-key)"
     (let [scoped-key [:rf.scope/global :r/x {:id 1}]
-          wid (work-ledger/resource-work-id scoped-key 4)]
+          wid (rf.resources.work-ledger/resource-work-id scoped-key 4)]
       (is (= [:rf.work/resource scoped-key 4] wid))
       ;; a constructed record has exactly :work/id as its identity — no
       ;; :stale-key synonym
-      (let [r (work-ledger/work-record {:work-id wid :frame-id :f :resource/key scoped-key
+      (let [r (rf.resources.work-ledger/work-record {:work-id wid :frame-id :f :resource/key scoped-key
                                         :generation 4 :transport :rf.http/managed
                                         :started-at 1})]
         (is (= wid (:work/id r)))
@@ -597,12 +597,12 @@
             (work-id / resource-key / generation / work-frame) — not a stored
             copy that could drift from the stale-suppression identity"
     (let [scoped-key [:rf.scope/global :r/x {:id 1}]
-          wid        (work-ledger/resource-work-id scoped-key 4)
-          r          (work-ledger/work-record {:work-id wid :frame-id :app/main
+          wid        (rf.resources.work-ledger/resource-work-id scoped-key 4)
+          r          (rf.resources.work-ledger/work-record {:work-id wid :frame-id :app/main
                                                :resource/key scoped-key
                                                :generation 4 :transport :rf.http/managed
                                                :started-at 1})
-          target     (work-ledger/durable-reply-to r)]
+          target     (rf.resources.work-ledger/durable-reply-to r)]
       (testing "the continuation addresses the framework-internal reply handler
                 carrying the verification payload the handler gates on"
         (is (= [:rf.resource.internal/succeeded
@@ -615,8 +615,8 @@
       (testing "the reconstructed durable continuation is DATA-ONLY (no
                 ephemeral ::post, no host handle) and EDN-
                 serializable — it can ride the durable row / SSR / epoch wire"
-        (is (true? (reply/data-only-target? target)))
-        (is (work-ledger/serializable-record? target)))
+        (is (true? (rf.reply/data-only-target? target)))
+        (is (rf.resources.work-ledger/serializable-record? target)))
       (testing "the durable continuation carries ONLY the suppression identity
                 — no scope (correlation metadata, not a suppression key) and no
                 :stale-key synonym (one name per fact)"
@@ -629,13 +629,13 @@
     ;; A record whose :resource/key carried a host handle (a fn) must never
     ;; produce a durable continuation — durable-target rejects it before the
     ;; bogus target could ride a row / transport / trace.
-    (let [bad (work-ledger/work-record {:work-id [:rf.work/resource [(fn [] 1)] 4]
+    (let [bad (rf.resources.work-ledger/work-record {:work-id [:rf.work/resource [(fn [] 1)] 4]
                                         :frame-id :app/main
                                         :resource/key [(fn [] 1)]
                                         :generation 4 :transport :rf.http/managed
                                         :started-at 1})]
       (try
-        (work-ledger/durable-reply-to bad)
+        (rf.resources.work-ledger/durable-reply-to bad)
         (is false "expected durable-reply-to to reject a host-handle row fact")
         (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
           (is (= :rf.reply/non-data-target (:rf.error/kind (ex-data e)))))))))
@@ -653,10 +653,10 @@
   ;; capture every lowered managed-HTTP args map (not just the last) so we can
   ;; inspect BOTH frames' request-ids.
   (let [all-args (atom [])]
-    (fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! all-args conj args) nil))
+    (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! all-args conj args) nil))
     (let [fa :xf/frame-a
           fb :xf/frame-b
-          scoped-key (state/scoped-resource-key :rf.scope/global :xf/article {:slug "w"})]
+          scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :xf/article {:slug "w"})]
       (rf/make-frame {:id fa :doc "frame A"})
       (rf/make-frame {:id fb :doc "frame B"})
       ;; both frames ensure the SAME global-scope resource — same scoped key.
@@ -679,8 +679,8 @@
                   process-global managed-HTTP registry cannot supersede one
                   frame's in-flight request with the other's"
           (is (= 2 (count req-ids)) "both frames lowered a managed request")
-          (is (contains? (set req-ids) (work-ledger/managed-request-id fa wid-a)))
-          (is (contains? (set req-ids) (work-ledger/managed-request-id fb wid-b)))
+          (is (contains? (set req-ids) (rf.resources.work-ledger/managed-request-id fa wid-a)))
+          (is (contains? (set req-ids) (rf.resources.work-ledger/managed-request-id fb wid-b)))
           (is (apply distinct? req-ids) "the two frames' request-ids differ")
           (is (not= (set req-ids) #{wid-a})
               "the request-id is NOT the bare work-id (which would collide)"))
@@ -690,8 +690,8 @@
           (is (= :running (:status (record fb wid-b))))
           (is (= fa (:work/frame (record fa wid-a))))
           (is (= fb (:work/frame (record fb wid-b))))
-          (is (some? (work-ledger/get-handle fa wid-a)))
-          (is (some? (work-ledger/get-handle fb wid-b))))
+          (is (some? (rf.resources.work-ledger/get-handle fa wid-a)))
+          (is (some? (rf.resources.work-ledger/get-handle fb wid-b))))
         (testing "frame A settling does NOT disturb frame B (independent
                   settlement — no stranded pending entry)"
           (rf/dispatch-sync [:rf.resource.internal/succeeded
@@ -720,11 +720,11 @@
   must reproduce exactly (modulo the inverse-index sidecar key)."
   [runtime-db resource-key keep-tail]
   (let [ledger (:rf.runtime/work-ledger runtime-db)
-        rk-id  (state/key-id resource-key)
+        rk-id  (rf.resources.state/key-id resource-key)
         terminal-for-key
         (->> ledger
-             (filter (fn [[_ r]] (and (= rk-id (state/key-id (:resource/key r)))
-                                      (work-ledger/terminal? (:status r)))))
+             (filter (fn [[_ r]] (and (= rk-id (rf.resources.state/key-id (:resource/key r)))
+                                      (rf.resources.work-ledger/terminal? (:status r)))))
              (sort-by (fn [[_ r]] (or (:started-at r) 0)) >))
         drop-ids (->> terminal-for-key (drop keep-tail) (map key))]
     (if (seq drop-ids)
@@ -746,15 +746,15 @@
   maintain the inverse index via `put-record` (so the index is live, the
   realistic in-session shape)."
   [records]
-  (reduce (fn [rdb r] (work-ledger/put-record rdb (:work/id r) r))
+  (reduce (fn [rdb r] (rf.resources.work-ledger/put-record rdb (:work/id r) r))
           {}
           records))
 
 (deftest prune-terminal-for-key-matches-full-scan-reference
   (testing "rf2-wyan7e — the index-driven prune drops EXACTLY the rows the
             prior full-scan prune dropped, across mixed keys / statuses / tails"
-    (let [ka (state/scoped-resource-key :rf.scope/global :wl/a {:id 1})
-          kb (state/scoped-resource-key :rf.scope/global :wl/b {:id 2})
+    (let [ka (rf.resources.state/scoped-resource-key :rf.scope/global :wl/a {:id 1})
+          kb (rf.resources.state/scoped-resource-key :rf.scope/global :wl/b {:id 2})
           ;; ka: 5 terminal (varied started-at) + 1 running; kb: 2 terminal
           records [(record-for ka 1 :completed 100)
                    (record-for ka 2 :failed    300)
@@ -766,7 +766,7 @@
                    (record-for kb 2 :failed    70)]
           rdb (build-ledger records)]
       (doseq [keep-tail [0 1 3 10]]
-        (let [new-rdb (work-ledger/prune-terminal-for-key rdb ka keep-tail)
+        (let [new-rdb (rf.resources.work-ledger/prune-terminal-for-key rdb ka keep-tail)
               ref-rdb (reference-prune-full-scan rdb ka keep-tail)]
           (is (= (:rf.runtime/work-ledger ref-rdb)
                  (:rf.runtime/work-ledger new-rdb))
@@ -774,14 +774,14 @@
                    keep-tail))
           (testing "the running (non-terminal) row + the other key's rows are
                     NEVER pruned"
-            (is (some? (get-in new-rdb (work-ledger/record-path
+            (is (some? (get-in new-rdb (rf.resources.work-ledger/record-path
                                          [:rf.work/resource ka 6]))))
-            (is (some? (get-in new-rdb (work-ledger/record-path
+            (is (some? (get-in new-rdb (rf.resources.work-ledger/record-path
                                          [:rf.work/resource kb 1]))))
-            (is (some? (get-in new-rdb (work-ledger/record-path
+            (is (some? (get-in new-rdb (rf.resources.work-ledger/record-path
                                          [:rf.work/resource kb 2])))))
           (testing "the inverse index stays == a full rebuild from the ledger"
-            (is (= (-> new-rdb work-ledger/recompute-ledger-index
+            (is (= (-> new-rdb rf.resources.work-ledger/recompute-ledger-index
                        :rf.runtime/work-ledger-by-key)
                    (:rf.runtime/work-ledger-by-key new-rdb))
                 "inverse index drift vs full rebuild")))))))
@@ -790,25 +790,25 @@
   (testing "rf2-wyan7e — a ledger installed wholesale (hydration / restore /
             replace-frame-state!) carries NO inverse index; the first prune
             rebuilds it from ground truth and still matches the full scan"
-    (let [ka (state/scoped-resource-key :rf.scope/global :wl/h {:id 1})
+    (let [ka (rf.resources.state/scoped-resource-key :rf.scope/global :wl/h {:id 1})
           ;; install the ledger DIRECTLY (no put-record), so no index sidecar
           records [(record-for ka 1 :completed 100)
                    (record-for ka 2 :completed 200)
                    (record-for ka 3 :failed    300)
                    (record-for ka 4 :running   400)]
           installed (reduce (fn [rdb r]
-                              (assoc-in rdb (work-ledger/record-path (:work/id r)) r))
+                              (assoc-in rdb (rf.resources.work-ledger/record-path (:work/id r)) r))
                             {} records)]
       (is (not (contains? installed :rf.runtime/work-ledger-by-key))
           "precondition: installed ledger has no inverse index")
-      (let [new-rdb (work-ledger/prune-terminal-for-key installed ka 1)
+      (let [new-rdb (rf.resources.work-ledger/prune-terminal-for-key installed ka 1)
             ref-rdb (reference-prune-full-scan installed ka 1)]
         (is (= (:rf.runtime/work-ledger ref-rdb)
                (:rf.runtime/work-ledger new-rdb))
             "self-healed prune matches the full-scan reference")
         (is (contains? new-rdb :rf.runtime/work-ledger-by-key)
             "the inverse index was rebuilt")
-        (is (= (-> new-rdb work-ledger/recompute-ledger-index
+        (is (= (-> new-rdb rf.resources.work-ledger/recompute-ledger-index
                    :rf.runtime/work-ledger-by-key)
                (:rf.runtime/work-ledger-by-key new-rdb))
             "rebuilt index == full rebuild")))))
@@ -822,10 +822,10 @@
                     (let [x (-> (* @seed 1103515245) (+ 12345) (bit-and 0x7fffffff))]
                       (reset! seed x)
                       (mod x n)))
-          keys'   (mapv #(state/scoped-resource-key :rf.scope/global :wl/r {:id %})
+          keys'   (mapv #(rf.resources.state/scoped-resource-key :rf.scope/global :wl/r {:id %})
                         (range 5))
           ;; seed the index live so put/prune keep it in step from step 0
-          start   (work-ledger/recompute-ledger-index {:rf.runtime/work-ledger {}})]
+          start   (rf.resources.work-ledger/recompute-ledger-index {:rf.runtime/work-ledger {}})]
       (loop [step 0, rdb start, gen 0]
         (if (= step 500)
           (is true "500 randomised ledger ops stayed in lock-step with the rebuild")
@@ -838,10 +838,10 @@
                                              (nth [:running :completed :failed :cancelled]
                                                   (nextint 4))
                                              (nextint 1000))]
-                           (work-ledger/put-record rdb [:rf.work/resource k g] r))
+                           (rf.resources.work-ledger/put-record rdb [:rf.work/resource k g] r))
                        ;; prune one terminal tail for the key
-                       1 (work-ledger/prune-terminal-for-key rdb k (nextint 3)))
-                full (-> rdb' work-ledger/recompute-ledger-index
+                       1 (rf.resources.work-ledger/prune-terminal-for-key rdb k (nextint 3)))
+                full (-> rdb' rf.resources.work-ledger/recompute-ledger-index
                          :rf.runtime/work-ledger-by-key)]
             (is (= full (:rf.runtime/work-ledger-by-key rdb'))
                 (str "inverse-index drift at step " step " op " op))

--- a/scripts/_test_fixtures/check_ambient_durable_reads/positive/dotted_alias_now_ms_into_loaded_at.cljc
+++ b/scripts/_test_fixtures/check_ambient_durable_reads/positive/dotted_alias_now_ms_into_loaded_at.cljc
@@ -1,0 +1,14 @@
+(ns fixtures.dotted-alias-now-ms-into-loaded-at
+  "POSITIVE fixture: the SAME anti-pattern as `now_ms_into_loaded_at.cljc`,
+  written in the canonical dotted require-alias dialect
+  (spec/Conventions.md §Require-alias dialect) that migrated artefacts use.
+  A pattern that knew only the bare leaf `interop/` read this as clean and
+  waved the durable write through — fail-open, since this gate forbids a
+  shape rather than requiring one. Must FLAG (1 finding)."
+  (:require [re-frame.interop :as rf.interop]))
+
+(defn install-loaded-entry
+  [entry value]
+  (assoc entry
+         :value     value
+         :loaded-at (rf.interop/now-ms)))   ;; FLAGGED: ambient clock into durable field

--- a/scripts/check_ambient_durable_reads.py
+++ b/scripts/check_ambient_durable_reads.py
@@ -8,8 +8,9 @@ read ambiently at the durable write site. The accepted spec's
 to ship a STATIC LINT that flags direct ambient reads in code paths that can
 write durable frame-state:
 
-  - clock:   `interop/now-ms`, `interop/epoch-now-ms`, `js/Date.now`,
-             `(.now js/Date)`;
+  - clock:   `interop/now-ms`, `interop/epoch-now-ms` (and their canonical
+             dotted spellings `rf.interop/now-ms` / `rf.interop/epoch-now-ms`),
+             `js/Date.now`, `(.now js/Date)`;
   - random:  `rand`, `rand-int`, `rand-nth`, `random-uuid`,
              `js/crypto.getRandomValues`;
   - browser: `js/location`, `navigator`, `localStorage`, `sessionStorage`,
@@ -240,7 +241,8 @@ _DURABLE_ID_KEYS = (
 # EP-0010 §Validation enumerates. `\b` boundaries keep `now-ms` from matching
 # `now-ms-foo` and `rand` from matching `random` / `rand-something`.
 #
-#   clock:  (interop/now-ms) (interop/epoch-now-ms) (js/Date.now) (.now js/Date)
+#   clock:  (interop/now-ms) (interop/epoch-now-ms) (rf.interop/now-ms)
+#           (rf.interop/epoch-now-ms) (js/Date.now) (.now js/Date)
 #   random: (rand) (rand-int ...) (rand-nth ...) (random-uuid)
 #           js/crypto.getRandomValues  (.getRandomValues js/crypto)
 #   browser: js/location  js/navigator  navigator.  js/localStorage
@@ -274,7 +276,14 @@ _DURABLE_ID_KEYS = (
 # whose result IS the host fact, so there is no threading it can mistake.
 _AMBIENT_READ_FORMS: tuple[tuple[str, str], ...] = (
     # clock
-    ("now-ms",       r"\(\s*(?:interop/)?(?:epoch-)?now-ms\b[^)]*\)"),
+    # BOTH alias spellings of `re-frame.interop`, and the bare symbol. An
+    # artefact migrated to the spec/Conventions.md §Require-alias dialect calls
+    # the clock `(rf.interop/now-ms)`, and a pattern that knew only the bare
+    # leaf `interop/` went BLIND on it — fail-open, since this gate forbids a
+    # shape. Measured on implementation/resources (rf2-6r9j.209): a planted
+    # `:restored-at (rf.interop/epoch-now-ms)` in resources/ssr.cljc scored 0
+    # findings while the identical `(interop/epoch-now-ms)` scored 1.
+    ("now-ms",       r"\(\s*(?:(?:rf\.)?interop/)?(?:epoch-)?now-ms\b[^)]*\)"),
     ("js/Date.now",  r"\(\s*js/Date\.now\b[^)]*\)"),
     (".now js/Date", r"\(\s*\.now\s+js/Date\b[^)]*\)"),
     # random
@@ -759,6 +768,11 @@ _UNEXERCISABLE_READ_FORMS: dict[str, str] = {
 # planting N witnesses on N lines is asserted by NAME, not by the number N.
 _POSITIVE_WITNESSES: dict[str, frozenset[str]] = {
     "positive/now_ms_into_loaded_at.cljc":
+        frozenset({"loaded-at<-now-ms"}),
+    # The same plant in the canonical dotted alias dialect. Its own fixture,
+    # not a second line in the one above, so the bare-leaf and dotted spellings
+    # can each die alone and be named when they do (rf2-6r9j.209).
+    "positive/dotted_alias_now_ms_into_loaded_at.cljc":
         frozenset({"loaded-at<-now-ms"}),
     "positive/date_now_into_started_at.cljc":
         frozenset({"started-at<-.now js/Date"}),


### PR DESCRIPTION
`implementation/resources` migrated as a whole to the `spec/Conventions.md`
§Require-alias dialect: `re-frame.core` keeps the bare root alias `rf`, every
other `re-frame.<tail>` takes the dotted `rf.<tail>`, and the bare leaf form is
left to application namespaces. Resources was the last unmigrated artefact of
the four — core and routing landed in #9103, machines in #9114 — and this
follows those to the letter, full dotted tail and all
(`re-frame.resources.work-ledger` → `rf.resources.work-ledger`).

## Census, and how it reconciles against the bead

589 noncanonical require edges across all 83 code files, plus the 4127 qualified
use sites that move with them: 3812 plain symbols, 1 var-quote, 281
backtick-delimited code references in docstrings and comments, and 33
unbackticked prose code references classified by hand.

The bead says 617 edges across 83 files (166 production-source + 451 test). The
test half reproduces **exactly**: 451 = 427 migratable + the 24 host-conditional
exemption edges below. The production half reads 162, four short, and the four
are accounted for rather than waved away — `da058d8ed1` ("drop eight dead
imports", rf2-6r9j.62) landed after the bead's census and removed exactly four
noncanonical re-frame edges from `src`: `[re-frame.frame :as frame]` from
`events.cljc`, `mutation_events.cljc` and `subs.cljc`, and
`[re-frame.resources.state :as state]` from `mutation_registry.cljc`. 166 − 4 =
162, and 617 − 4 = 613.

Cross-checked independently with clj-kondo's `namespace-usages` analysis:
deduplicated by `(file, namespace, alias)` it yields **the same 613 edges across
the same 83 files** — set-identical to the textual balanced-bracket scan, zero
edges in either direction. Post-sweep the same scan reads 0 migratable edges.

## Host-conditional aliases: exempt, and found by a derived predicate

Twelve test files bind one alias `substrate` to two namespaces across reader
arms:

```clojure
#?(:clj  [re-frame.substrate.plain-atom :as substrate]
   :cljs [re-frame.adapter.reagent      :as substrate])
```

The shared name **is** the point — a per-arm dotted tail would give each single
use site two names. These 24 edges stay bare. The check that found them is
derived (an alias bound to 2+ distinct namespaces within one file), not a path
list, so it cannot rot. Machines had one such file; routing had eight; resources
has twelve.

## No keyword id moved — the control, not the claim

The multiset of every literal single-colon `:ns/name` keyword across the
artefact is **identical before and after**: 7636 occurrences, 884 distinct, zero
entries changed. That covers the 210 sites whose first segment collides with a
live alias — `:route/article`, `:routing/*`, `:ssr/extend-runtime-db-projection`,
`:http/abort-in-flight!`, `:classification/redact-event-by-registration` — which
are literal keyword values, not alias references.

`::alias/key` auto-resolved keywords **must** move where they exist; resources
has none at all (0 such forms artefact-wide, against machines' 7), which is also
why the third gate below did not fire.

Fully-qualified `re-frame.x/y`, quoted `'re-frame.x/y`, repo-relative paths
(`docs/routing/testing.md`) and prose noun/noun slashes (`privacy/size`,
`has-data/error/else`, `route/SSR`, `routing/resources`) were separated from
alias references and left alone — 29 such prose sites skipped, each classified.

## A gate went blind, and is fixed here

`scripts/check_ambient_durable_reads.py`'s clock read-form accepted an optional
bare-leaf `interop/` prefix. `resources/ssr.cljc` sits in that gate's scan
surface and carries six live clock reads, so after the rename the gate could no
longer see them — and it forbids a shape, so a spelling it cannot see is an
offender it waves through.

Measured in both directions before touching it: a planted
`:restored-at (rf.interop/epoch-now-ms)` in `ssr.cljc` scored **0** findings,
while the identical `:restored-at (interop/epoch-now-ms)` scored **1**, naming
`ssr.cljc:1009`. The pattern now accepts both spellings, and the dotted plant
scores 1 at the same line. It ships with its own positive fixture rather than a
second line in the existing one, so the two spellings can each die alone and be
named when they do; the roster entry keeps its name `now-ms`, so the self-test's
read-form coverage assertion is unchanged.

The other four source-scanning consumers of `implementation/resources` were
checked and need nothing, verified by RUNNING them rather than by reading them:

- `implementation/epoch/.../epoch_egress_resource_trace_test.clj` reader-parses
  the `ns` form and builds an alias→namespace map, so it is alias-insensitive by
  construction;
- the three `tools/mcp-conformance/wire-vocab` gates pin **keyword** literals and
  file paths over comment-and-string-stripped text;
- `implementation/scripts/api-manifest/gen.clj` reads namespace names and public
  vars, none of which move.

`scripts/check_keyword_catalogue_drift.py` CHECK B — the gate the machines sweep
met — did **not** fire, because the sweep produces no `::rf.*` form. Proven live
against this tree all the same: a planted `::rf.resources.state/probe-sentinel`
returns exit 1 naming the file, and restoring returns the file's original blob.

## Gates

| gate | result |
|---|---|
| `implementation/resources` JVM (`clojure -M:test`) | 828 tests / 7475 assertions, exit 0 |
| `implementation/epoch` JVM | 552 tests / 7237 assertions, exit 0 |
| `npm run test:cljs` (split into compile + run) | compile 1889 files, 0 warnings, exit 0; 11165 tests / 55735 assertions, exit 0 |
| `tools/mcp-conformance/wire-vocab` JVM | 94 tests / 1031 assertions, exit 0 |
| `check_ambient_durable_reads.py` and `--self-test` | exit 0 / exit 0 (21 fixtures) |
| `check_keyword_catalogue_drift.py` | exit 0 |
| `clj-kondo --fail-level error --lint implementation/resources` | exit 0, 22 warnings |
| `git diff --check` | exit 0 |

clj-kondo was compared against a pristine `origin/main` export of the same tree:
**22 findings both sides**, and the sole delta is a column shift on one
pre-existing warning (`resources_revision_substrate_cljs_test.cljc:103`, col 50 →
73) caused by the longer alias on that line. Zero semantic delta.

The resources JVM gate was proven live on this checkout before its green was
believed: a planted `rf.resources.stateX/entry-path-by-id` returned exit 1
naming `classification.cljc:694:9`, and restoring returned blob
`70516dd2ea16ef4b59c727ffc9d3ecebd51cc0b1`.

All 83 files stay pure-CRLF and valid UTF-8, verified by counting bytes rather
than reading a diff: 83/83 CRLF, 0 mixed, 0 lone CR, 0 decode failures.

## Not done here, deliberately

- **The syntax-aware CI ratchet** in the bead's acceptance criteria. It belongs
  in `scripts/` + `.github/workflows/` as ONE repo-wide instrument and is carried
  on rf2-ydpr with its full design.
- **Prose references to a framework namespace by its bare tail, in files that
  never bound that alias** — `transport.http/lower` in `transport.cljc`,
  `classification/whole-entry-disposition` in `tooling.cljc`, and ~180 more.
  These were never aliases in their own files, so they sit outside the
  require-alias contract; the machines sweep left the same class
  (`cofx_attach.cljc` still reads `timeout/desugar-timeouts`). Reported rather
  than swept, so the two sweeps stay consistent.
