### PR TITLE
fix(pair-mcp): `clojure -M:test` no longer returns a fail-open 0 (rf2-7r9w)

### DIFF
--- a/tools/re-frame2-pair-mcp/deps.edn
+++ b/tools/re-frame2-pair-mcp/deps.edn
@@ -1,6 +1,6 @@
 ;; shadow-cljs resolves this npm artefact's CLJS classpath from deps.edn.
-;; `npm test` is the canonical test command; `:test` exposes the same
-;; node-test build to Clojure CLI and editor tooling.
+;; `npm test` is the canonical -- and only -- test command here; see the
+;; :aliases comment for why `clojure -M:test` deliberately refuses.
 {:paths ["src" "test"]
  :deps  {org.clojure/clojure       {:mvn/version "1.12.0"}
          org.clojure/clojurescript {:mvn/version "1.12.145"}
@@ -24,5 +24,35 @@
          day8/re-frame2-test-quiet {:local/root "../../implementation/test-quiet"}}
 
  :aliases
- {:test {:extra-paths ["test"]
-         :main-opts   ["-m" "shadow.cljs.devtools.cli" "compile" "server-test"]}}}
+ ;; `npm test` is the ONLY verdict for this artefact: it compiles the
+ ;; `:server-test` build AND runs `node out/server-test.js`, and the npm
+ ;; script's exit status is Node's. Every test here is CLJS on that build
+ ;; (`shadow-cljs.edn`); there is no JVM suite and so no JVM lane.
+ ;;
+ ;; rf2-7r9w -- this alias used to run
+ ;; `["-m" "shadow.cljs.devtools.cli" "compile" "server-test"]`, and that
+ ;; FAILED OPEN. The `:server-test` build sets `:autorun true`, so the
+ ;; compile runs the suite and prints its failures -- then exits 0 anyway,
+ ;; because the COMPILE succeeded, which is the whole of what a compile
+ ;; exit code claims. Measured on this tree when the fix landed -- same
+ ;; directory, same build, one compile: `shadow-cljs compile server-test`
+ ;; printed `Ran 1120 tests containing 4068 assertions. 2 failures, 0
+ ;; errors.` and exited 0, while `node out/server-test.js` over that same
+ ;; build printed the identical tally and exited 1. Those two failures
+ ;; were LOCAL to the measuring machine -- a live nREPL server that the
+ ;; deliberately no-port harness discovered -- and not a red in this repo;
+ ;; the cause is beside the point, because the two runs disagree on
+ ;; nothing except the exit code. Every other
+ ;; artefact's `:test` alias IS a verdict, so this one read as one and
+ ;; handed back a clean pass over real failures.
+ ;;
+ ;; Deleting the alias is NOT the fix, and that was measured too:
+ ;; `clojure -M:test` against an ABSENT alias drops into a REPL and exits
+ ;; 0 on EOF -- silent, no test output, a false green in a script just the
+ ;; same. So `:test` stays and fails CLOSED, naming the command that is a
+ ;; verdict. (`:extra-paths ["test"]` is gone as redundant: top-level
+ ;; `:paths` already carries `test`, and shadow-cljs reads `:deps true`,
+ ;; which applies no aliases at all.)
+ {:test {:main-opts
+         ["-e"
+          "(binding [*out* *err*] (println \"tools/re-frame2-pair-mcp has no JVM test lane. `shadow-cljs compile server-test` is NOT a verdict: its :autorun prints failures and the compile still exits 0 (rf2-7r9w). Run `npm test` -- it also runs `node out/server-test.js`, and THAT exit code is the verdict.\")) (System/exit 2)"]}}}

--- a/tools/re-frame2-pair-mcp/test/README.md
+++ b/tools/re-frame2-pair-mcp/test/README.md
@@ -31,6 +31,22 @@ build (`shadow-cljs.edn`) and Node runs `out/server-test.js`. Every
 `*_test.cljs` namespace under `test/re_frame2_pair_mcp/` is picked up
 by the `:ns-regexp "-test$"` rule.
 
+**Only the Node run is a verdict (rf2-7r9w).** The `:server-test` build
+sets `:autorun true`, so `shadow-cljs compile server-test` runs the suite
+and prints its failures -- and then exits 0 anyway, because the COMPILE
+succeeded, which is the whole of what a compile exit code claims.
+Measured: the compile printed `Ran 1120 tests containing 4068
+assertions. 2 failures, 0 errors.` and exited 0, while
+`node out/server-test.js` over that same build printed the identical
+tally and exited 1. (Those two failures were local to the measuring
+machine -- a live nREPL server that this suite's deliberately no-port
+harness discovered -- not a red in this repo. The cause is beside the
+point: the two runs disagree on nothing but the exit code.) So read the exit
+code of `npm test` (which chains both and ends on Node) or of
+`node out/server-test.js` -- never of the compile alone. `clojure -M:test`
+in this directory now refuses and says so; before rf2-7r9w it ran the bare
+compile and handed back that fail-open 0.
+
 What this layer covers:
 
 - Per-tool body — `<tool>_test.cljs` (one per registered tool):


### PR DESCRIPTION
Closes rf2-7r9w. Also carries the investigation for rf2-vbw2, which needed no code change (see below).

## rf2-7r9w — the census, and the one consumer that read a compile exit as a verdict

`shadow-cljs compile server-test` exits 0 even when its `:autorun` reports test FAILURES. The bead's first instruction was to establish whether anything actually reads that exit code as a test result before changing anything.

**Census** (two instruments plus a control that discriminates; `.beads/` excluded):

1. Line-oriented `git grep -F` for `compile server-test`, `server-test`, `out/server-test.js`, `-M:test`.
2. A whitespace-flattened scan of all 4808 tracked files in Python, which sees references broken across lines that `git grep` cannot.

Control: the phrase "compiles the :server-test build", which is line-wrapped in `tools/re-frame2-pair-mcp/test/README.md`. The line-oriented instrument returns **exit 1 (no match)** on that file; the flattened instrument finds it. So the flattened pass is strictly stronger and the control fires.

**Result — every consumer of the `:server-test` build, and what each reads:**

| Consumer | Command | Reads the compile exit as a verdict? |
|---|---|---|
| `tools/re-frame2-pair-mcp/package.json:19` | `shadow-cljs compile server-test && node out/server-test.js` | **No** — `&&` chains, the script's status is Node's |
| `.github/workflows/test.yml` `node-test-tools-re-frame2-pair-mcp` | `npm test` | **No** — via the above |
| `implementation/scripts/test-mcp-conformance.cjs` gate row | `{exe: 'npm', args: ['test'], cwd: PAIR_MCP}` | **No** — via the above |
| `.github/workflows/test.yml` conformance job, `expensive-tests.yml` | `npx shadow-cljs compile server` | **No** — the `:server` bundle, a build step, not a suite |
| **`tools/re-frame2-pair-mcp/deps.edn` `:test` alias** | `-m shadow.cljs.devtools.cli compile server-test`, **no node run** | **YES** |

No CI job and no repo script read it as a verdict; `tools/re-frame2-pair-mcp` is on neither JVM roster in `scripts/test-jvm-tools.sh`. The one real consumer is the artefact's own `:test` alias — a per-artefact `deps.edn`, and the file this PR changes. Every other artefact's `:test` alias IS a verdict, so this one read as one by shape while silently not being one.

**The fail-open, reproduced with captured exit codes on one unmodified build:**

```
npx shadow-cljs compile server-test   Ran 1120 tests containing 4068 assertions.  2 failures, 0 errors.   exit 0
node out/server-test.js               Ran 1120 tests containing 4068 assertions.  2 failures, 0 errors.   exit 1
npm test                              (chains both, ends on Node)                                          exit 1
```

Identical tally, opposite exit codes. Those two failures were **local to the measuring machine** — a live nREPL server that this suite's deliberately no-port harness discovered — and are **not a red in this repo**; the cause is beside the point, since the two runs disagree on nothing but the exit code.

**The fix, and why it is not a deletion.** Deleting the alias was measured to be *worse*: `clojure -M:test` against an **absent** alias drops into a REPL and exits **0** on EOF — silent, no test output, a false green in a script just the same. So `:test` stays and fails **closed**:

```
$ clojure -M:test          # in tools/re-frame2-pair-mcp
tools/re-frame2-pair-mcp has no JVM test lane. `shadow-cljs compile server-test` is NOT a
verdict: its :autorun prints failures and the compile still exits 0 (rf2-7r9w). Run `npm test`
-- it also runs `node out/server-test.js`, and THAT exit code is the verdict.
$ echo $?
2
```

Per the bead, no attempt is made to have shadow-cljs fail the compile on autorun failures: the compile genuinely succeeded, and that is the whole of what a compile exit code claims. `:extra-paths ["test"]` goes as redundant — top-level `:paths` already carries `test`, and `shadow-cljs.edn` reads `:deps true`, which applies no aliases at all. The trap is also recorded in `tools/re-frame2-pair-mcp/test/README.md`, where a reader meets the compile/run split.

**Out of fence, reported not touched:** `skills/re-frame2-pair/docs/TESTING.md` lines 5 and 188 name the suite as "`shadow-cljs compile server-test`", which is exactly the half that is not a verdict. Worth a follow-up in a skills-fenced tick.

## rf2-vbw2 — premise does not hold, no change

The `:rf.warning/schema-validator-unavailable` diagnostic advises "Require `re-frame.schemas.malli` at app boot". Established by three JVM probes which population reaches it:

| Probe | Route | Facade | `reg-app-schema` outcome | Warnings |
|---|---|---|---|---|
| A2 | `rf/reg-app-schema` (public) | loaded | completed | **0** — suppressed |
| B | `rf/reg-app-schema` (public) | not loaded | **threw** `:rf.error/schemas-artefact-missing` | **0** — never reached |
| C | `re-frame.schemas.storage/reg-app-schema` (internal ns) | bypassed | completed | **1** — fires |

The diagnostic is unreachable through the supported public API **in both directions**. With the facade, `re-frame.schemas` requires `re-frame.schemas.malli`, which publishes `:schemas/malli-validate` in every build, so the gate is false. Without the facade, `:schemas/reg-app-schema` is declared `:on-absent :throw` and `re-frame.schemas` is its only publisher, so the call throws before reaching the warn site.

That refutes the bead's premise *and* its own named refutation: the expected readers ("people who have not required the facade") get a throw, not a warning. The actual readers are a caller reaching past the facade into the internal `storage` ns — for whom the advice **works** — or a half-installed substitute-validator port, for whom the string's second clause (`set-schema-validator!`) is already the right steer. The advice is correct as written for everyone who can reach it.

Two further reasons not to reword: `spec/009-Instrumentation.md` pins the reason's content (hot-zone, one-toucher, not this worker's), and the JVM suite asserts `re-frame.schemas.malli` appears in it. Full evidence is on the bead, which is left open for disposition.

## Gates

Run from this worktree, each redirected to its own log with the runner's own exit code captured to a file and read back:

| Gate | Exit |
|---|---|
| `clojure -M:test` in `tools/re-frame2-pair-mcp` (the fix's acceptance test) | 2 (was 0) |
| `npm test` in `tools/re-frame2-pair-mcp` (canonical path still a verdict) | 1 |
| `scripts/check_readme_links.py --ci` | 0 |
| `scripts/check_test_lane_bijection.py` | 0 (1551 files, 44 lanes) |
| `scripts/check_jvm_lane_rosters.py` | 0 (31 rostered artefacts) |
| `scripts/check_readme_inventories.py` | 0 |
| `scripts/check-no-hardcoded-paths.sh` | 0 |

All re-run on the final rebased base. `check_readme_links.py --ci` prints nothing on success, so it was verified by a **planted fault**: a broken link inserted into `tools/re-frame2-pair-mcp/test/README.md` took it to **exit 1** naming that file, line and target; the restore was verified by git blob hash returning to `99ded455…` before the green run. `mkdocs build --strict` and `check_doc_slugs.py` are **not** the gates here — `tools/re-frame2-pair-mcp/test/README.md` is a README beside source, outside `docs_dir` and outside the slug gate's roots; `check_readme_links.py --ci` is its surface.

Both changed files are CRLF and were edited byte-exactly in Python, with the bare-LF count and non-ASCII byte count asserted unchanged (deps.edn 3, README 340) after each edit.
