### PR TITLE
fix(migration): the reporter's census sees a re-frame2 app, and cannot report a confident zero (rf2-xoal, rf2-mckf)

### DIFF
--- a/migration/reagent-to-hicasso/codemod/README.md
+++ b/migration/reagent-to-hicasso/codemod/README.md
@@ -25,6 +25,16 @@ clojure -M:run --rewrite --write src/          # apply it
 clojure -M:run --report out.edn src/           # choose where the report goes
 ```
 
+**Every run writes one EDN report, a scan that changes no source included.**
+Without `--report` it goes to `reagent-to-hicasso-report.edn` beside the first
+path scanned — point the tool at `<repo>/src/` and it lands at `<repo>/` — and
+the run prints the absolute path it used. It used to be written to the process's
+working directory under that bare name, which, given that the first line above
+is a `cd` into this directory, meant *into this checkout*: a consumer running
+the documented command found the file in their `git status` for a repository
+they were treating as a read-only build input, with nothing having said it would
+be there (rf2-mckf).
+
 The exit code is `0` for any run that completed and `1` only when a file could
 not be read or written. A migration tool that fails a build because a
 consumer's code needs a human decision is a tool that gets run once.
@@ -38,9 +48,9 @@ the fixer reports zero entries — the corpus crosses into React nowhere — and
 a migrator reading that report sees eighty-eight files that are not mentioned.
 
 So the same run also produces a census, under `:census` in the report, whose
-population is the Reagent API call site: `r/atom`, `r/with-let`,
+population is the view-substrate API call site: `r/atom`, `r/with-let`,
 `r/create-class`, `r/as-element`, `r/cursor`, `r/reactify-component`, root
-mounting, and the rest of the roster in
+mounting, and the rest of the two rosters in
 `src/re_frame/migration/hicasso/census.clj`. On that same corpus it reports
 59 sites across 28 files, one of them the `with-let` whose teardown no
 mechanical edit can carry. Both are measurements of a corpus that keeps
@@ -50,7 +60,7 @@ landed.
 | Half | Population | Addressed at | Verdicts |
 |---|---|---|---|
 | fixer (`:entries`) | `[:>]`-family crossing sites | the site | rewrote / refused, in the classes below |
-| census (`:census`) | Reagent API call sites | the call | `:mechanical`, `:human-decision`, `:runtime-blocker` |
+| census (`:census`) | view-substrate API call sites | the call | `:mechanical`, `:human-decision`, `:runtime-blocker` |
 
 (4 columns; 2 body rows.)
 
@@ -102,6 +112,59 @@ returning a `fn` and nothing else marks it; a structural test for that would
 report every higher-order function in the corpus. The `r/atom` such a component
 closes over is on the roster, and the shape itself is left uncounted and said
 so. A confident wrong number is worse than a stated silence.
+
+## Two rosters, and a zero the tool cannot report confidently
+
+The census reads its population off a **namespace**, and for most of its life
+it knew one family of them. That made it score a real re-frame2 application at
+**zero** — not wrongly, but uselessly (rf2-xoal, found by a blinded pilot
+migrating a real application against the published guide). A re-frame2 app on
+the Reagent adapter renders *through* Reagent and never names it: views are
+declared with `reg-view`, reads are `@(subscribe […])`, and the substrate
+arrives as `re-frame.adapter.reagent`, which is not `reagent.core`. Not one
+`reagent.core` name anywhere. The zero was a true statement about a population
+that was not that application's migration surface — and an application on the
+Reagent adapter is the single most likely thing to be migrated to Hicasso.
+
+There are two rosters now, and the rule for both is **identity, not spelling: a
+namespace is classified when this project can vouch for what it is.**
+
+- **Reagent's API** — stock Reagent's four namespaces, plus the `reagent2.*`
+  four that the reagent-slim adapter ships. That is the same API authored a
+  second time in this repository, under names the how-to guide teaches
+  consumers to call, so one roster classifies both. Omitting it was the same
+  defect one adopter later.
+- **re-frame2's own substrate adapters** — everything under
+  `re-frame.adapter.`, matched as a **prefix rule anchored at the start of the
+  namespace**, because the adapter set is open and a list of today's adapters
+  goes stale into the same silent zero tomorrow. The roster of names on it is
+  the adapters' documented public surface in `docs/api/`.
+
+A namespace that merely *contains* one of these spellings is still not one and
+still binds nothing — re-frame-10x's vendored
+`day8.re-frame-10x.inlined-deps.reagent.v1v2v0.reagent.core` and a hypothetical
+`my.vendored.re-frame.adapter.reagent` alike. The two rosters are also kept
+**apart** rather than merged: `:files-with-reagent` is read to decide whether a
+Reagent *coordinate* can be dropped, which is a question about Reagent and not
+about the substrate.
+
+**And no roster is ever wide enough.** Whatever the census knows, some codebase
+renders through a surface it does not, and over that corpus every count comes
+back zero in precisely the voice of a clean bill of health. Widening postpones
+that; it cannot prevent it. So the tool is made unable to report the confident
+zero:
+
+- every scanned file is `:recognised?` or it is not, and the summary's file
+  counts **partition** the corpus (`files-scanned = files-recognised +
+  files-unrecognised`, and `files-recognised = files-clean + files carrying an
+  entry`) — the missing bucket was the very thing the zero was hiding;
+- `:recognition` is `:full`, `:partial`, `:none` or `:no-files`, and `:caveat`
+  is a sentence saying what that means for the numbers beside it — present
+  always, `:full` included, because a warning that appears only when something
+  is wrong is a warning nobody can tell from a missing key;
+- the verdict is **hoisted to the top of the report**, beside `:tool`, because
+  the reader who gets misled is the one who reads the first summary and stops;
+- the CLI's last line leads with it, for the same reason.
 
 ## The two laws
 
@@ -261,7 +324,7 @@ semantics directly, running the design's stated shape alongside to show the
 amendment is load-bearing. `shared_rule_test.clj` asserts that the slot rule
 this tool asks is the shared one and not a copy.
 
-`census_test.clj` gates the census on both ways a census fails — answering
+`census_test.clj` gates the census on the ways a census fails — answering
 nothing, and answering too much. The second control is not decoration: it caught
 two live over-reports while the namespace was being written. An `ns` DOCSTRING
 discussing `reagent.ratom/run!` in prose made five clean example files read as
@@ -280,6 +343,17 @@ write, and each is a place the advertised estimand was false — three counted,
 two missed. The controls that PRUNE come paired with controls that the pruning
 does not over-reach, since a walk that skips too much is the first failure
 mode arriving from the other side.
+
+A third failure mode joined them from rf2-xoal: answering nothing over a corpus
+the census never RECOGNISED, which wears the first one's face exactly — every
+count zero, nothing red. It is gated on the tool's inability to report that zero
+without saying which of the two it is, and the assertion comes with a control
+that has to fire: the same machinery over a corpus the census does have a
+population in reports `:full`, whose caveat says the zero would be a
+measurement. Beside it sit the roster controls, which are the same lesson in
+both families — a vendored `…reagent.v1v2v0.reagent.core` binds nothing, and
+neither does a `my.vendored.re-frame.adapter.reagent`, because the prefix rule
+is anchored at the start of the namespace and containment is not identity.
 
 ## One dependency, deliberately
 

--- a/migration/reagent-to-hicasso/codemod/deps.edn
+++ b/migration/reagent-to-hicasso/codemod/deps.edn
@@ -64,6 +64,16 @@
   ;; nothing to re-point here: pointing at the shipped door was already the
   ;; answer that outlives Freehand's retirement, and it outlives the harness's
   ;; relocation for free.
+  ;; THE DEPRECATION WARNING THIS PRINTS IS EXPECTED, AND A `:local/root` IS
+  ;; NOT THE FIX. `clojure` warns on every `:paths` entry outside the project
+  ;; ("Use of :paths external to the project has been deprecated"), which a
+  ;; migrator running the documented command sees and reasonably wonders about
+  ;; (rf2-mckf). The sanctioned spelling would be a `:local/root` on
+  ;; `implementation/hicasso`, and taking it would drag that artefact's own
+  ;; `:deps` — `day8/re-frame2` and `day8/re-frame2-ssr`, by `:local/root` in
+  ;; turn — onto the classpath of a tool whose whole design premise is that it
+  ;; runs on a bare JVM and never loads re-frame2. One pure `.cljc` file that
+  ;; requires `clojure.string` is the cheaper honesty.
   "../../../implementation/hicasso/src"]
 
  :deps {org.clojure/clojure       {:mvn/version "1.12.4"}

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/census.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/census.clj
@@ -22,13 +22,14 @@
   reactive cell is the single most common thing a Hicasso migration has to
   answer for, and it was invisible.
 
-  So the census walks the same files for the **Reagent API surface**, and
-  the two halves partition the question rather than the population:
+  So the census walks the same files for the **view-substrate API
+  surface**, and the two halves partition the question rather than the
+  population:
 
   | Half | Estimand | Addressed by |
   |---|---|---|
   | fixer (`:entries`) | `[:>]`-family crossing SITES | site line/col |
-  | census (`:census`) | Reagent API CALL SITES | call line/col |
+  | census (`:census`) | view-substrate API CALL SITES | call line/col |
 
   *(3 columns; 2 body rows.)*
 
@@ -42,6 +43,51 @@
   [[re-frame.migration.hicasso.rewrite/inert?]] prunes them. An advertised
   estimand a reader can construct a counterexample to in one line is worse
   than a vaguer one honestly stated.
+
+  ## Two rosters, because `reagent.core` is not the only way in
+
+  The census reads its population off a NAMESPACE, and for most of its
+  life it knew one family of them. That made it score a real re-frame2
+  application at ZERO — not wrongly, but uselessly. A re-frame2 app on the
+  Reagent adapter renders through Reagent and never names it: views are
+  declared with `reg-view`, reads are `@(subscribe […])`, and the
+  substrate arrives through `re-frame.adapter.reagent`, which is not
+  `reagent.core`. Not one `reagent.core` name anywhere. The report's zero
+  was a true statement about a population that was not that application's
+  migration surface, and the surrounding prose — *absence from the report
+  is meaningful* — invited exactly the wrong conclusion. It was found by a
+  blinded pilot migrating a real application, which is the only kind of
+  witness that finds this class of defect (rf2-xoal).
+
+  So there are two rosters, and the SECOND one is
+  [[substrate-surface]]: re-frame2's own `re-frame.adapter.*` adapters,
+  bound by a PREFIX RULE rather than a list, because the adapter set is
+  open and a list goes stale into the same silent zero one adapter later.
+  [[surface]] widened too, by the same principle in the other family:
+  the slim adapter's `reagent2.*` IS Reagent's API, authored a second time
+  in this repository.
+
+  **The rosters are kept apart rather than merged**, because
+  `:files-with-reagent` is read by the migration skill to decide whether a
+  Reagent COORDINATE can be dropped — a question about Reagent, not about
+  the substrate — and folding adapter files into that count would answer
+  it wrongly.
+
+  ## A tool that recognises nothing must not sound like one that found nothing
+
+  **No roster is ever wide enough**, and that is the deeper half of the
+  same defect: whatever this census knows, some codebase renders through a
+  surface it does not, and over that corpus every count comes back zero in
+  precisely the voice of a clean bill of health. Widening the roster
+  postpones that; it cannot prevent it.
+
+  So the tool is made unable to report the confident zero. Every scan
+  answers `:recognised?`, [[summarise]] carries `:recognition` and a
+  `:caveat` sentence, the file counts PARTITION the corpus so an
+  unrecognised file is a bucket rather than a gap, and
+  [[re-frame.migration.hicasso.report/build]] hoists the verdict to the
+  TOP of the artefact — because the reader who is going to be misled is
+  the one who reads the first summary and stops.
 
   ## The law this file exists to obey
 
@@ -136,6 +182,65 @@
     create-root               {:class :root-mount              :verdict :human-decision}
     hydrate-root              {:class :root-mount              :verdict :human-decision}})
 
+(def substrate-surface
+  "re-frame2's OWN substrate-adapter API — the SECOND roster, and the one
+  whose absence made this census score a real re-frame2 application at
+  zero.
+
+  ## Why a second roster and not a wider first one
+
+  The reported failure was a re-frame2 application on the Reagent adapter:
+  it renders through Reagent, and not one `reagent.core` name appears
+  anywhere in it. It reaches the substrate through
+  `re-frame.adapter.reagent`, which is not `reagent.core` — so the first
+  roster, which classifies by namespace, had no population in that
+  codebase and reported a confident zero over it.
+
+  The obvious repair — bolt `re-frame.adapter.reagent` onto
+  `reagent-namespaces` — is the wrong one twice over. It would make
+  `:files-with-reagent` (a documented half of this report, which the
+  migration skill reads to decide whether a Reagent COORDINATE can be
+  dropped) count files with no Reagent name in them; and it would leave
+  the roster an enumeration, so the next adapter along reproduces the same
+  silent zero. Two rosters, two counts, and a PREFIX RULE for this one:
+  see [[re-frame.migration.hicasso.rewrite/substrate-ns-prefix]].
+
+  ## What is on it
+
+  **The adapters' DOCUMENTED public surface**, which is `docs/api/`'s two
+  adapter pages, and nothing invented beside it. Three shapes are
+  deliberately absent and each absence is a decision:
+
+  * `adapter` — the substrate value passed to `rf/init!`. It is the single
+    most diagnostic line in a re-frame2 boot, and it is not a CALL: it
+    sits in argument position, where this walk (which reads call HEADS)
+    cannot see it. The file it lives in is still RECOGNISED, because its
+    `ns` form names the adapter, so nothing rides on catching it.
+  * `frame-provider` / `frame-root` — hiccup HEADS rather than calls, and
+    frame plumbing that survives the migration rather than migration work.
+  * `re-frame.adapter.test-react`'s `mount!` / `trigger-update!` — the
+    prefix rule binds that namespace, but the roster is the documented
+    consumer surface and the test adapter has no `docs/api/` page.
+
+  Nothing here is `:mechanical` either, for the same reason nothing in
+  [[surface]] is: no rewrite in this tool family reaches any of it.
+
+  **The two rosters must not share a NAME.** [[scan]] tries Reagent first,
+  so an overlap would silently classify a substrate call under a Reagent
+  class and a Reagent recovery sentence — a wrong answer wearing the right
+  shape, which is the one failure this file's whole design is against.
+  `census_test` asserts the intersection is empty rather than leaving it to
+  whoever adds the next row."
+  '{client-root         {:class :root-mount            :verdict :human-decision}
+    render!             {:class :root-mount            :verdict :human-decision}
+    unmount!            {:class :root-mount            :verdict :human-decision}
+    use-subscribe       {:class :substrate-read-hook   :verdict :human-decision}
+    use-frame           {:class :substrate-read-hook   :verdict :human-decision}
+    use-current-frame   {:class :substrate-read-hook   :verdict :human-decision}
+    wrap-view           {:class :substrate-view-seam   :verdict :human-decision}
+    set-hiccup-emitter! {:class :substrate-view-seam   :verdict :human-decision}
+    flush-views!        {:class :substrate-test-seam   :verdict :human-decision}})
+
 (def ^:private notes
   "One recovery sentence per class, in the migrator's vocabulary. The
   report's fourth property (§7.4) is that a refusal names the fix, and a
@@ -207,6 +312,26 @@
    (str "Root mounting. Hicasso mounts its own root; this call is boot ceremony and is replaced "
         "wholesale rather than edited.")
 
+   :substrate-read-hook
+   (str "A read through the substrate adapter's own hook tier - the UIx adapter's "
+        "`use-subscribe` / `use-frame` / `use-current-frame`. Hicasso reads with `h/sub` at the "
+        "point of use inside a declared view, so this is not a hook swap: the value stops "
+        "arriving through React's hook order and starts arriving through the view's own "
+        "reactive read, and a component whose hooks were conditional has to be re-shaped.")
+
+   :substrate-view-seam
+   (str "The substrate adapter's own view seam - `wrap-view`, or the hiccup emitter the adapter "
+        "was told to lower through. Hicasso owns both ends of that seam itself: views are "
+        "declared with `h/defview` and lowered by Hicasso's own compiler, so an explicit seam "
+        "call has no counterpart to be respelled into. Code-gen and library scaffolding that "
+        "minted these needs a Hicasso-side equivalent rather than an edit.")
+
+   :substrate-test-seam
+   (str "`flush-views!` wraps React's `act()` so a test can settle pending effects before "
+        "reading the DOM. It is a REAGENT/UIX-substrate seam, per Spec 008's per-adapter-require "
+        "rule, so it does not follow the views across: settle a Hicasso tree the way the "
+        "Hicasso testing chapter directs, and delete the adapter require the call came through.")
+
    :unresolved-reagent-require
    (str "This file's `ns` form NAMES a Reagent namespace, and the reader could not bind a "
         "single symbol to it. The usual cause is a namespace that SPELLS a Reagent name "
@@ -229,18 +354,18 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- roster-name
-  "The roster key this node's head spells, whether or not it resolves.
+  "The key `roster` holds for this node's head, whether or not it resolves.
 
   Usually the head's own name — `r/atom` and a bare `atom` both spell
   `atom`. The exception is a `:rename`d referral, where the file bound
   `reagent.core/atom` to some other spelling and the head is `ratom`; the
   roster key is then the ORIGINAL name, which is the only one the roster
   has a class and a recovery sentence for."
-  [nd ctx]
+  [nd ctx roster]
   (when-let [h (rw/head-symbol nd)]
     (let [k (or (when-not (namespace h) (get (:renamed ctx) h))
                 (symbol (name h)))]
-      (when (contains? surface k) k))))
+      (when (contains? roster k) k))))
 
 (defn- entry
   [{:keys [class verdict]} file line col form detail]
@@ -254,22 +379,45 @@
     detail (assoc :detail detail)))
 
 (defn scan
-  "Every Reagent API call site in one source string.
+  "Every rostered view-substrate API call site in one source string.
 
-  Returns `{:entries [...] :reagent? bool :unresolved? bool}`.
-  `:reagent?` is whether the file names a Reagent namespace at all, which
-  is what lets the summary distinguish *scanned and clean* from *scanned
-  and irrelevant* — the fixer's report already carries `:sites-left-alone`
-  for the same reason.
+  Returns `{:entries [...] :reagent? bool :substrate? bool :unresolved?
+  bool :recognised? bool}`.
+
+  **TWO ROSTERS, TWO CONTEXTS, ONE WALK.** [[surface]] is Reagent's API and
+  [[substrate-surface]] is re-frame2's own adapter API; the file's `ns`
+  form is read once per roster (`ns-context` takes the roster predicate)
+  and every node is offered to both. Reagent is tried first, and
+  [[roster-overlap]] is empty so the order decides nothing.
+
+  **The two recognition flags are asymmetric, deliberately.**
+
+  * `:reagent?` is whether the file NAMES a Reagent namespace at all, text
+    and all, even one nothing could be bound to. That is the right question
+    for Reagent because the FIXER rides on the same bindings: a name it
+    cannot bind means W4 and W5 are dead in this file, which is a hole
+    worth reporting (`:unresolved-reagent-require`).
+  * `:substrate?` is whether the `ns` form actually BINDS a
+    `re-frame.adapter.*` namespace. Nothing in the fixer rides on it, so a
+    spelling the reader cannot bind is not evidence of anything and gets no
+    class of its own. It also keeps the prefix rule honest from the other
+    end: `my.vendored.re-frame.adapter.reagent` binds nothing and so
+    counts for nothing.
+
+  `:recognised?` is their disjunction, and it is the flag that stops this
+  census reporting a confident zero over a corpus it never had a population
+  in — see [[summarise]].
 
   **CALL sites, so inert subtrees are pruned rather than walked.**
   The population is what the program runs, and a discard, a quote and a
   `(comment …)` body are none of it."
   [source file]
   (let [root        (p/parse-string-all source)
-        ctx         (rw/ns-context root)
+        rctx        (rw/ns-context root rw/reagent-namespace?)
+        sctx        (rw/ns-context root rw/substrate-namespace?)
         reagent?    (rw/names-reagent? root)
-        unresolved? (and reagent? (empty? (into (:aliases ctx) (:referred ctx))))
+        substrate?  (boolean (seq (into (:aliases sctx) (:referred sctx))))
+        unresolved? (and reagent? (empty? (into (:aliases rctx) (:referred rctx))))
         excerpt     (fn [loc] (let [s (z/string loc)]
                                 (if (> (count s) 200) (str (subs s 0 200) " …") s)))
         ns-node?    rw/ns-form?]
@@ -277,13 +425,18 @@
            entries  []
            ns-said? false]
       (if (or (nil? loc) (z/end? loc))
-        {:entries entries :reagent? reagent? :unresolved? unresolved?}
+        {:entries     entries
+         :reagent?    reagent?
+         :substrate?  substrate?
+         :unresolved? unresolved?
+         :recognised? (or reagent? substrate?)}
         (if (rw/inert? (z/node loc))
           (recur (rw/past-subtree loc) entries ns-said?)
           (let [nd         (z/node loc)
-                k          (roster-name nd ctx)
+                rk         (roster-name nd rctx surface)
+                sk         (roster-name nd sctx substrate-surface)
                 ns-here?   (and unresolved? (not ns-said?) (ns-node? nd))
-                [line col] (when (or k ns-here?) (z/position loc))]
+                [line col] (when (or rk sk ns-here?) (z/position loc))]
             (recur
              (z/next loc)
              (cond
@@ -297,12 +450,20 @@
                                      :verdict :runtime-blocker}
                                     file line col (excerpt loc) nil))
 
-               (nil? k) entries
-
                ;; Resolved: this really is Reagent's, through a symbol the
                ;; `ns` form binds.
-               (rw/reagent-call? nd k ctx)
-               (conj entries (entry (get surface k) file line col (excerpt loc) {:api (str k)}))
+               (and rk (rw/bound-call? nd rk rctx))
+               (conj entries (entry (get surface rk) file line col (excerpt loc)
+                                    {:api (str rk)}))
+
+               ;; Resolved against the SECOND roster: re-frame2's own
+               ;; substrate adapter, through a symbol the `ns` form binds.
+               ;; This is the arm the reported defect was missing — a
+               ;; re-frame2 application on the Reagent adapter has every one
+               ;; of its substrate calls here and none in the arm above.
+               (and sk (rw/bound-call? nd sk sctx))
+               (conj entries (entry (get substrate-surface sk) file line col (excerpt loc)
+                                    {:api (str sk)}))
 
                ;; Unresolvable, in a file we KNOW reaches for Reagent.
                ;; Reported, never skipped — the tool cannot tell whose symbol
@@ -315,11 +476,11 @@
                ;; `rdc/render` that IS the finding. Reporting both makes the
                ;; real one harder to see, which is the only thing a census
                ;; owes anybody.
-               (and unresolved? (namespace (rw/head-symbol nd)))
+               (and rk unresolved? (namespace (rw/head-symbol nd)))
                (conj entries (entry {:class   :unresolved-alias
                                      :verdict :runtime-blocker}
                                     file line col (excerpt loc)
-                                    {:api    (str k)
+                                    {:api    (str rk)
                                      :symbol (str (rw/head-symbol nd))}))
 
                :else entries)
@@ -334,30 +495,123 @@
   non-zero is a count nobody can tell from a bug."
   [:mechanical :human-decision :runtime-blocker])
 
+(defn recognition
+  "Did this census have a POPULATION in the corpus it was pointed at?
+
+  Four states, and the middle two are the whole reason this exists.
+
+  * `:full` — every scanned file names Reagent or a re-frame2 substrate
+    adapter. A zero here means the tool looked and found nothing.
+  * `:partial` — some files named one and some named neither.
+  * `:none` — files were scanned and NOT ONE named either. The tool had
+    nothing to count, and it says so rather than passing for a clean bill
+    of health.
+  * `:no-files` — nothing was scanned at all.
+
+  **This is the defect the roster widening only half closes.** A
+  classifier that recognises nothing answers `0` in exactly the voice of
+  one that recognised everything and found nothing wrong, and no roster is
+  ever wide enough to make that impossible — the next view surface along
+  reproduces it. So the tool is made unable to report the confident zero
+  instead: recognition is measured, named, and carried at the TOP of the
+  artefact as well as here."
+  [files-scanned files-recognised]
+  (cond (zero? files-scanned)              :no-files
+        (zero? files-recognised)           :none
+        (= files-scanned files-recognised) :full
+        :else                              :partial))
+
+(defn caveat
+  "The recognition verdict as a sentence a migrator can act on. Always
+  present, `:full` included — a warning that appears only when something
+  is wrong is a warning nobody can tell from a missing key, which is the
+  rule [[verdicts]] already states for the counts."
+  [{:keys [files-scanned files-recognised files-unrecognised files-with-substrate]}]
+  (case (recognition files-scanned files-recognised)
+    :no-files
+    (str "NO SOURCE FILE WAS SCANNED. Every count here is zero because there was nothing to "
+         "count — check the paths given to the tool.")
+
+    :none
+    (str "NOTHING WAS RECOGNISED. " files-scanned " file(s) were scanned and NOT ONE of them "
+         "names Reagent or a re-frame2 substrate adapter, so this census had no population in "
+         "this corpus at all. THIS ZERO IS NOT A CLEAN BILL OF HEALTH: it is the tool saying it "
+         "does not know what it is looking at. Check the paths you pointed it at first; then "
+         "read the migration chapter's translation table, because a codebase that renders "
+         "through some other view surface has migration work this tool cannot see.")
+
+    :partial
+    (str files-unrecognised " of " files-scanned " scanned file(s) name neither Reagent nor a "
+         "re-frame2 substrate adapter, and this census has NO POPULATION in them: their absence "
+         "from the entries below means they were not recognised, not that they are clean."
+         (when (pos? files-with-substrate)
+           (str " This corpus DOES name a re-frame2 substrate adapter, so it is a re-frame2 "
+                "application — the case where the distinction bites hardest. Its view files "
+                "declare views with `reg-view`, read with `@(subscribe …)` and dispatch with "
+                "`#(dispatch …)`, and NONE of that is Reagent API, so they are absent from this "
+                "census AND full of migration work. Port those shapes off the migration "
+                "chapter's translation table.")))
+
+    :full
+    (str "Every one of the " files-scanned " scanned file(s) names Reagent or a re-frame2 "
+         "substrate adapter, so this census had a population throughout. A zero below is a "
+         "measurement.")))
+
 (defn summarise
-  "The census half of the report artefact."
-  [{:keys [entries files-scanned files-with-reagent files-unresolved]}]
-  {:estimand "Reagent API call sites, addressed at the CALL. The fixer's `:entries` count `[:>]`-family crossing SITES; the two are different populations and neither is a denominator for the other."
-   :files-scanned      files-scanned
-   :files-with-reagent files-with-reagent
-   :files-unresolved   files-unresolved
-   :files-clean        (- files-with-reagent
-                          (count (into #{} (map :file) entries)))
-   :entries            (count entries)
-   :by-verdict         (into (sorted-map)
-                             (for [v verdicts]
-                               [v (count (filter #(= v (:verdict %)) entries))]))
-   :by-class           (into (sorted-map)
-                             (for [[k v] (group-by :class entries)] [k (count v)]))})
+  "The census half of the report artefact.
+
+  **The file counts PARTITION the corpus, which they did not before.** The
+  reported defect came with a bookkeeping tell beside it — 18 files
+  scanned, with `:files-with-reagent`, `:files-unresolved` and
+  `:files-clean` all zero, three sub-counts summing to 0 rather than 18 —
+  and the missing bucket was the very thing the zero was hiding: the files
+  the census had no population in. The arithmetic now closes twice over:
+
+      files-scanned    = files-recognised + files-unrecognised
+      files-recognised = files-clean      + (files carrying an entry)
+
+  `:files-with-reagent` and `:files-with-substrate` are overlapping DETAIL
+  views of the recognised half rather than a partition of it — one file
+  can name both — and `:files-unresolved` is a subset of the first.
+  `:files-with-reagent` keeps its exact meaning through the widening,
+  because the migration skill reads it to decide whether a Reagent
+  COORDINATE may be dropped, and that question is about Reagent rather
+  than about the substrate."
+  [{:keys [entries files-scanned files-with-reagent files-with-substrate
+           files-unresolved files-recognised]}]
+  (let [files-unrecognised (- files-scanned files-recognised)]
+    (array-map
+     :estimand "Rostered view-substrate API call sites, addressed at the CALL: Reagent's API (`reagent.*`, and the slim adapter's `reagent2.*`) and re-frame2's own substrate adapters (`re-frame.adapter.*`). The fixer's `:entries` count `[:>]`-family crossing SITES; the two are different populations and neither is a denominator for the other. Read `:recognition` before reading any zero here."
+     :files-scanned        files-scanned
+     :files-recognised     files-recognised
+     :files-unrecognised   files-unrecognised
+     :files-with-reagent   files-with-reagent
+     :files-with-substrate files-with-substrate
+     :files-unresolved     files-unresolved
+     :files-clean          (- files-recognised
+                              (count (into #{} (map :file) entries)))
+     :entries              (count entries)
+     :recognition          (recognition files-scanned files-recognised)
+     :caveat               (caveat {:files-scanned        files-scanned
+                                    :files-recognised     files-recognised
+                                    :files-unrecognised   files-unrecognised
+                                    :files-with-substrate files-with-substrate})
+     :by-verdict           (into (sorted-map)
+                                 (for [v verdicts]
+                                   [v (count (filter #(= v (:verdict %)) entries))]))
+     :by-class             (into (sorted-map)
+                                 (for [[k v] (group-by :class entries)] [k (count v)])))))
 
 (defn build
   "Assemble the census section from the per-file scans."
   [scans]
   (let [entries (vec (mapcat :entries scans))]
-    {:summary (summarise {:entries            entries
-                          :files-scanned      (count scans)
-                          :files-with-reagent (count (filter :reagent? scans))
-                          :files-unresolved   (count (filter :unresolved? scans))})
+    {:summary (summarise {:entries              entries
+                          :files-scanned        (count scans)
+                          :files-recognised     (count (filter :recognised? scans))
+                          :files-with-reagent   (count (filter :reagent? scans))
+                          :files-with-substrate (count (filter :substrate? scans))
+                          :files-unresolved     (count (filter :unresolved? scans))})
      :entries (vec (sort-by (juxt #(str (:file %)) #(or (:line %) 0) #(or (:col %) 0)
                                   #(str (:class %)))
                             entries))}))
@@ -377,10 +631,31 @@
   ([s file] (scan s (some-> file str))))
 
 (defn describe
-  "A one-line human summary, for the CLI tail."
+  "A one-line human summary, for the CLI tail.
+
+  **It leads with the recognition verdict, not with the count**, because
+  the count is the thing that misleads: `0 Reagent API call site(s)` is
+  the same sentence whether the tool searched a Reagent codebase and found
+  nothing or searched a codebase it could not classify at all. Whoever
+  reads only the last line of the run has to be told which."
   [{:keys [summary]}]
-  (str (:entries summary) " Reagent API call site(s) across "
-       (:files-with-reagent summary) " file(s) that name Reagent"
-       (when (pos? (:files-unresolved summary))
-         (str "; " (:files-unresolved summary) " file(s) UNRESOLVED"))
-       " — " (str/join ", " (for [[k v] (:by-verdict summary)] (str v " " (name k))))))
+  (let [{:keys [entries files-scanned files-recognised files-unrecognised
+                files-with-reagent files-with-substrate files-unresolved
+                by-verdict]} summary]
+    (case (recognition files-scanned files-recognised)
+      :no-files
+      "no source file scanned — nothing to census"
+
+      :none
+      (str "NOTHING RECOGNISED — " files-scanned " file(s) scanned, none of them naming Reagent "
+           "or a re-frame2 substrate adapter. This zero is NOT a clean bill of health; read "
+           ":census :summary :caveat.")
+
+      (str entries " view-substrate API call site(s) across " files-with-reagent
+           " file(s) that name Reagent and " files-with-substrate " that name a re-frame2 adapter"
+           (when (pos? files-unresolved)
+             (str "; " files-unresolved " file(s) UNRESOLVED"))
+           " — " (str/join ", " (for [[k v] by-verdict] (str v " " (name k))))
+           (when (pos? files-unrecognised)
+             (str "; " files-unrecognised " of " files-scanned
+                  " file(s) NOT RECOGNISED — read :census :summary :caveat"))))))

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/codemod.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/codemod.clj
@@ -50,7 +50,7 @@
   (and (rw/list-node? nd)
        (= 'def (rw/sexpr-safe (rw/element-at nd 0)))
        (symbol? (rw/sexpr-safe (rw/element-at nd 1)))
-       (some-> (rw/element-at nd 2) (rw/reagent-call? 'adapt-react-class ctx))))
+       (some-> (rw/element-at nd 2) (rw/bound-call? 'adapt-react-class ctx))))
 
 (defn- hiccup-head-symbol
   "The head of `[Foo …]` when it is a bare symbol — a call site of a
@@ -333,26 +333,56 @@
 ;; CLI
 ;; ---------------------------------------------------------------------------
 
+(def ^:private report-file-name "reagent-to-hicasso-report.edn")
+
+(defn- default-report-path
+  "Where the report goes when `--report` is not given: BESIDE the tree the
+  tool was pointed at, as an absolute path.
+
+  It used to be the bare name, which resolves against the process's
+  WORKING DIRECTORY — and the migration chapter's own first command is
+  `cd …/codemod` followed by `clojure -M:run path/to/your/src/`, so the
+  bare form wrote the report into this CHECKOUT, which a consumer has
+  every reason to be treating as a read-only build input. It turned up in
+  their `git status` and nothing had told them it would; a tool that
+  writes into somebody else's repository without saying so is a surprise
+  whatever it writes (rf2-mckf).
+
+  The parent of the first scanned path is where a migrator wants it: point
+  the tool at `<repo>/src/` and the report lands at `<repo>/`, beside the
+  tree it describes and inside the working copy they are about to change
+  anyway. A path with no parent falls back to the working directory.
+  Absolute either way, so the line the run prints cannot be ambiguous
+  about which directory it meant."
+  [paths]
+  (let [f      (io/file (str (first paths)))
+        parent (or (.getParentFile (.getAbsoluteFile f)) (io/file "."))]
+    (str (io/file parent report-file-name))))
+
 (def ^:private usage
   (str "usage: clojure -M:run [--rewrite] [--write] [--report PATH] PATH ...\n"
        "\n"
        "  (no flag)        scan: report only, touch nothing\n"
        "  --rewrite        dry run: show what would change\n"
        "  --rewrite --write  apply the fixer in place\n"
-       "  --report PATH    where the EDN report goes"
-       " (default: reagent-to-hicasso-report.edn)\n"))
+       "  --report PATH    where the EDN report goes\n"
+       "\n"
+       "EVERY run writes one EDN report, including a scan that changes no source.\n"
+       "Without --report it is written to " report-file-name " BESIDE the first\n"
+       "path scanned (`<repo>/src/` puts it at `<repo>/`), and the run prints the\n"
+       "absolute path it used.\n"))
 
 (defn -main
   [& args]
   (let [flags    (set (filter #(str/starts-with? % "--") args))
-        report-p (or (second (drop-while #(not= "--report" %) args))
-                     "reagent-to-hicasso-report.edn")
+        explicit (second (drop-while #(not= "--report" %) args))
         paths    (->> args
                       (remove #(str/starts-with? % "--"))
-                      (remove #(= % report-p)))]
+                      (remove #(= % explicit)))]
     (if (empty? paths)
       (do (print usage) (flush) (System/exit 2))
-      (let [rep (run paths {:rewrite? (contains? flags "--rewrite")
+      (let [report-p (or explicit (default-report-path paths))
+            rep (run paths {:rewrite? (contains? flags "--rewrite")
                             :write?   (contains? flags "--write")})]
         (report/print-lines (:entries rep))
         (census/print-lines (:entries (:census rep)))
@@ -360,7 +390,11 @@
         (println)
         (println (pr-str (:summary rep)))
         (println (census/describe (:census rep)))
-        (println (str "report: " report-p))
+        ;; ABSOLUTE, and it says it WROTE. The old line printed the bare
+        ;; relative name, which named the file without naming the directory
+        ;; — so the one thing a reader needed from it was the one thing it
+        ;; did not carry.
+        (println (str "wrote report: " (.getAbsolutePath (io/file report-p))))
         ;; Exit 0 for any run that COMPLETED. A migration tool that fails a
         ;; build because a consumer's code needs a human decision is a tool
         ;; that gets run once.

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/report.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/report.clj
@@ -145,10 +145,14 @@
   "Assemble the report artefact from the per-file results.
 
   `:census` is a SECOND SECTION, not more `:entries`. The fixer's entries
-  count `[:>]`-family crossing sites; the census counts Reagent API call
-  sites. Merging them would produce one number that answers neither
+  count `[:>]`-family crossing sites; the census counts view-substrate API
+  call sites. Merging them would produce one number that answers neither
   question, and the golden corpus — which asserts `:entries` — would stop
-  being a statement about the fixer."
+  being a statement about the fixer.
+
+  `:recognition` is the one thing lifted OUT of the census and repeated at
+  the top level, because it is the only key that can contradict the zeros
+  beside it."
   [{:keys [entries suggestions census files-scanned sites-total sites-left-alone
            files-changed dry-run?]}]
   (let [entries (sort-entries entries)
@@ -158,6 +162,14 @@
                       (into (sorted-map)))]
     {:tool    "reagent-to-hicasso/codemod (fixer)"
      :design  "docs/design/hicasso/studio/reagent-codemod-against-the-landed-escape.md"
+
+     ;; THE RECOGNITION VERDICT, HOISTED. It is the census's measurement and
+     ;; it is repeated here on purpose: a migrator who reads the top of this
+     ;; file and stops must not be able to take a zero for a clean bill of
+     ;; health. A tool that recognised nothing and a tool that found nothing
+     ;; print the same counts, and only this key separates them.
+     :recognition (select-keys (:summary census) [:recognition :caveat])
+
      :summary {:files-scanned     files-scanned
                :files-changed     files-changed
                :dry-run?          (boolean dry-run?)

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
@@ -338,7 +338,60 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private reagent-namespaces
-  '#{reagent.core reagent.dom reagent.dom.client reagent.ratom})
+  "Reagent's API, and the namespaces that ARE it.
+
+  **The rule is IDENTITY, not spelling: a namespace binds when this project
+  can vouch for what it is.** Two families qualify and nothing else does.
+
+  * Stock Reagent's four public namespaces.
+  * The `reagent2.*` four that `implementation/adapters/reagent-slim/`
+    ships. That is the SAME API authored a second time IN THIS REPOSITORY:
+    `reagent2.core` defines `atom`, `create-class`, `as-element`,
+    `current-component` and the rest of the census roster under those very
+    names, and `docs/core/how-to/use-uix-or-slim.md` teaches consumers to
+    call them so. One roster classifies both because there is one API.
+
+  Omitting the slim four was the reported defect one adopter later: an
+  application on the reagent-slim substrate writes `(r/atom 0)` through
+  `reagent2.core` and scored ZERO, with nothing on screen to say the tool
+  had not recognised it.
+
+  A namespace that merely SPELLS one of these is still not one and still
+  binds nothing — re-frame-10x's vendored
+  `day8.re-frame-10x.inlined-deps.reagent.v1v2v0.reagent.core` is the
+  standing example, and [[names-reagent?]] reports it rather than guessing.
+  Vouching is not spelling in either direction."
+  '#{reagent.core  reagent.dom    reagent.dom.client  reagent.ratom
+     reagent2.core reagent2.ratom reagent2.dom.client reagent2.dom.server})
+
+(defn reagent-namespace?
+  "Is this namespace symbol Reagent's API? Exact roster membership."
+  [sym]
+  (contains? reagent-namespaces sym))
+
+(def substrate-ns-prefix
+  "re-frame2's own substrate adapters live under one prefix, fixed by Spec
+  006's adapter inventory: `re-frame.adapter.reagent`,
+  `re-frame.adapter.uix`, `re-frame.adapter.test-react`, and the slim
+  adapter which PUBLISHES as `re-frame.adapter.reagent` so the jar is a
+  drop-in swap.
+
+  **A prefix RULE rather than an enumeration, and that is the point.** The
+  adapter set is open — Spec 006 fixes the naming, not the membership — so
+  a list of the ones shipping today would go stale into the same silent
+  zero the next adapter along, which is exactly how the reported defect
+  arrived."
+  "re-frame.adapter.")
+
+(defn substrate-namespace?
+  "Is this namespace symbol one of re-frame2's substrate adapters?
+
+  **ANCHORED AT THE START of the symbol**, which is the whole of what keeps
+  the prefix rule honest: `my.vendored.re-frame.adapter.reagent` CONTAINS
+  the prefix and is not an adapter, and a containment test would bind it
+  and classify somebody else's API under re-frame2's roster."
+  [sym]
+  (str/starts-with? (str sym) substrate-ns-prefix))
 
 (defn ns-form?
   "Is this node the file's `ns` form? Public because the census asks it of
@@ -429,7 +482,7 @@
   does not resolve a platform, and it has no business deciding which
   branch a consumer's build will take. Reading all of them is also the
   conservative direction for this tool specifically: the answer feeds
-  [[reagent-call?]], and a symbol bound to Reagent under ANY feature is a
+  [[bound-call?]], and a symbol bound to Reagent under ANY feature is a
   symbol whose call sites a migrator must see."
   [node]
   (let [values (->> (element-at node 1) elements (drop 1) (take-nth 2))]
@@ -459,7 +512,14 @@
        through-conditionals))
 
 (defn ns-context
-  "Read a file's `ns` form and answer which symbols name Reagent's API.
+  "Read a file's `ns` form and answer which symbols name a rostered API.
+
+  **Parameterised by the roster, one arity per question.** The 1-arity
+  answers for Reagent and is what the FIXER asks; the census asks it a
+  second time with [[substrate-namespace?]] to learn which symbols name
+  re-frame2's own substrate adapters. One reader, two rosters — a second
+  copy of the spec-by-spec reading below is a second place for the
+  reader-conditional bug to come back.
 
   Returns `{:aliases #{r reagent} :referred #{partial …}}`. Alias
   resolution is what makes W4 and W5 legal at all: the only non-fn `IFn`
@@ -507,36 +567,42 @@
     is dropped from `:referred` rather than left sitting in it. A
     `:rename` with no `:refer` binds nothing, which is the effect Clojure
     gives it."
-  [root-node]
-  (reduce
-   (fn [acc spec]
-     (let [spec (if (symbol? spec) [spec] spec)]
-       (if (and (sequential? spec) (contains? reagent-namespaces (first spec)))
-         ;; Pairwise rather than `(apply hash-map …)`: this reads source
-         ;; nobody in this repository wrote, and a lone trailing option
-         ;; must leave the tool answering less, never throwing.
-         (let [opts       (into {} (comp (partition-all 2) (filter #(= 2 (count %))) (map vec))
-                                (rest spec))
-               refer-all? (= :all (:refer opts))
-               referred   (when (sequential? (:refer opts))
-                            (filter symbol? (:refer opts)))
-               renamed    (when (and (or refer-all? referred) (map? (:rename opts)))
-                            (into {} (for [[from to] (:rename opts)
-                                           :when (and (symbol? from) (symbol? to))]
-                                       [to from])))]
-           (cond-> (update acc :aliases conj (first spec))
-             (symbol? (:as opts)) (update :aliases conj (:as opts))
-             referred             (update :referred into
-                                          (remove (set (vals renamed)) referred))
-             refer-all?           (assoc :refer-all? true)
-             (seq renamed)        (update :renamed merge renamed)))
-         acc)))
-   {:aliases #{} :referred #{} :refer-all? false :renamed {}}
-   (map sexpr-safe (some-> (ns-form-node root-node) require-specs))))
+  ([root-node] (ns-context root-node reagent-namespace?))
+  ([root-node ns-pred]
+   (reduce
+    (fn [acc spec]
+      (let [spec (if (symbol? spec) [spec] spec)]
+        (if (and (sequential? spec) (ns-pred (first spec)))
+          ;; Pairwise rather than `(apply hash-map …)`: this reads source
+          ;; nobody in this repository wrote, and a lone trailing option
+          ;; must leave the tool answering less, never throwing.
+          (let [opts       (into {} (comp (partition-all 2) (filter #(= 2 (count %))) (map vec))
+                                 (rest spec))
+                refer-all? (= :all (:refer opts))
+                referred   (when (sequential? (:refer opts))
+                             (filter symbol? (:refer opts)))
+                renamed    (when (and (or refer-all? referred) (map? (:rename opts)))
+                             (into {} (for [[from to] (:rename opts)
+                                            :when (and (symbol? from) (symbol? to))]
+                                        [to from])))]
+            (cond-> (update acc :aliases conj (first spec))
+              (symbol? (:as opts)) (update :aliases conj (:as opts))
+              referred             (update :referred into
+                                           (remove (set (vals renamed)) referred))
+              refer-all?           (assoc :refer-all? true)
+              (seq renamed)        (update :renamed merge renamed)))
+          acc)))
+    {:aliases #{} :referred #{} :refer-all? false :renamed {}}
+    (map sexpr-safe (some-> (ns-form-node root-node) require-specs)))))
 
-(defn reagent-call?
-  "Is `node` a literal call to Reagent's `sym`, through a symbol this
-  file's `ns` form actually binds?
+(defn bound-call?
+  "Is `node` a literal call to `sym`, through a symbol this file's `ns`
+  form actually binds to the roster `ctx` was read with?
+
+  Named for what it decides rather than for one caller's roster: the same
+  test answers for Reagent when handed a Reagent [[ns-context]] and for
+  re-frame2's substrate adapters when handed a substrate one. The roster
+  lives in the context, so there is nothing here to duplicate per roster.
 
   Three ways a bare head can be Reagent's, and only three: the `ns` form
   `:refer`red the name, it `:refer :all`ed the namespace, or it renamed
@@ -575,7 +641,7 @@
   [node sym ctx]
   (boolean
    (and (not (inert? node))
-        (or (reagent-call? node sym ctx)
+        (or (bound-call? node sym ctx)
             (and (n/inner? node)
                  (some #(subtree-has-reagent-call? % sym ctx)
                        (n/children node)))))))
@@ -602,7 +668,7 @@
       :> :raw
       :r> :r>
       :f> :f>
-      (when (reagent-call? (element-at node 0) 'adapt-react-class ctx) :adapt))))
+      (when (bound-call? (element-at node 0) 'adapt-react-class ctx) :adapt))))
 
 (defn- head-text
   "The component name for the report — the one thing in the system that
@@ -1016,7 +1082,7 @@
                             "`{:callbacks {… :render}}`, or a plain function."))))
 
          ;; ---- W4 (§4.4), amended by (A) ---------------------------------------
-         (reagent-call? v 'partial ctx)
+         (bound-call? v 'partial ctx)
          (if-let [{:keys [node captured]} (w4-plan v)]
            (-> (edit acc node)
                (add (entry :partial-wrapper :rewrote
@@ -1073,7 +1139,7 @@
                                   ;; W4 read this one and rewrote it; a tool that
                                   ;; reports its own rewrite as undecidable is
                                   ;; crying wolf.
-                                  (reagent-call? v 'partial ctx))))
+                                  (bound-call? v 'partial ctx))))
                     (mapv (fn [[k _ _]] (str/trim (n/string k)))))]
     (when (seq unread)
       (entry :computed-value :refused {:props unread}

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/census_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/census_test.clj
@@ -10,6 +10,13 @@
   this repository's own example corpus while this namespace was being
   written.
 
+  There is a **third** mode, and it is the one a blinded pilot found by
+  migrating a real application (rf2-xoal): answering nothing over a corpus
+  the census never RECOGNISED. That failure wears the first one's face
+  exactly — every count zero, nothing red — and no roster is wide enough
+  to rule it out, so it is gated from the other side, on the tool's
+  inability to report the zero without saying which of the two it is.
+
   * `ns` DOCSTRING prose mentioning `reagent.ratom/run!` made five clean
     example files read as five migration blockers. `names-reagent?` now
     reads the `ns` form's CLAUSES.
@@ -27,7 +34,8 @@
   example. A tool that started GUESSING that copy was `reagent.core`
   would be a worse tool than the blind one, so both directions are
   asserted."
-  (:require [clojure.string :as str]
+  (:require [clojure.set]
+            [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [re-frame.migration.hicasso.census :as census]
             [re-frame.migration.hicasso.codemod :as cm]))
@@ -247,10 +255,16 @@
                  "\n"
                  "(defn page []\n"
                  "  [:div (for [x @(rf/subscribe [:xs])] ^{:key x} [:span x])])\n")
-        {:keys [entries reagent? unresolved?]} (census/scan src "app/views.cljs")]
+        {:keys [entries reagent? unresolved? recognised?]} (census/scan src "app/views.cljs")]
     (is (= [] entries))
     (is (false? reagent?))
-    (is (false? unresolved?))))
+    (is (false? unresolved?))
+    (testing "and NOT recognised, which is a different fact from clean and is why
+              this deftest's name is only half the story. This is the shape of
+              every view file in the application that scored zero: legal,
+              unmentioned, and full of migration work the census has no
+              population for. `summarise` is where the two are told apart."
+      (is (false? recognised?)))))
 
 (deftest prose-about-reagent-is-not-a-finding
   (testing "the `ns` docstring is not a require. Five files in examples/ discuss
@@ -433,3 +447,191 @@
     (is (= 3 (:entries s)))
     (testing "ordering is file, then line, then column"
       (is (= (:entries built) (vec (sort-by (juxt :file :line :col) (:entries built))))))))
+
+;; ---------------------------------------------------------------------------
+;; The SECOND roster: re-frame2's own substrate adapters (rf2-xoal)
+;; ---------------------------------------------------------------------------
+
+(def ^:private rf2-native-boot
+  "A re-frame2 application's boot file, on the Reagent adapter.
+
+  This is the shape that scored ZERO. It renders through Reagent and never
+  names it: the substrate arrives as `re-frame.adapter.reagent`, and there
+  is no `reagent.core` name in the whole application."
+  (str "(ns app.core\n"
+       "  (:require [re-frame.core :as rf]\n"
+       "            [re-frame.adapter.reagent :as reagent-adapter]))\n"
+       "\n"
+       "(defonce app-root (reagent-adapter/client-root))\n"
+       "\n"
+       "(defn run []\n"
+       "  (rf/init! reagent-adapter/adapter)\n"
+       "  (reagent-adapter/render! app-root [root-view] el))\n"))
+
+(def ^:private rf2-native-view
+  "A re-frame2 view file. Every migration shape in it — the registration,
+  the read, the dispatch closure — is re-frame2's own, so the census has
+  no population here and must not pretend otherwise."
+  (str "(ns app.articles\n"
+       "  (:require [re-frame.core :as rf]))\n"
+       "\n"
+       "(rf/reg-view ::card [id]\n"
+       "  [:div {:on-click #(rf/dispatch [:open id])} @(rf/subscribe [:title id])])\n"))
+
+(deftest the-substrate-adapter-is-a-population
+  (testing "THE REPORTED DEFECT. `re-frame.adapter.reagent` is not `reagent.core`,
+            so a census that classified by the Reagent roster alone had nothing
+            to count in the file that actually mounts the application."
+    (let [{:keys [entries reagent? substrate? recognised?]}
+          (census/scan rf2-native-boot "app/core.cljs")]
+      (is (false? reagent?) "there is genuinely no Reagent name in this file")
+      (is (true? substrate?))
+      (is (true? recognised?))
+      (is (= [:root-mount :root-mount] (mapv :class entries)))
+      (is (= [5 9] (mapv :line entries)) "client-root, then render!")
+      (is (= [{:api "client-root"} {:api "render!"}] (mapv :detail entries)))
+      (testing "and each carries the recovery sentence for boot ceremony"
+        (is (str/includes? (:note (first entries)) "Hicasso mounts its own root")))))
+
+  (testing "`reagent-adapter/adapter` on the line between them is NOT counted:
+            it is a value in argument position, and this walk reads call heads.
+            The file is recognised through its `ns` form regardless, so nothing
+            rides on catching it — stated here so the silence is a decision."
+    (is (= 2 (count (:entries (census/scan rf2-native-boot "app/core.cljs")))))))
+
+(deftest every-substrate-class-has-a-recovery-sentence
+  (doseq [[api {:keys [verdict]}] census/substrate-surface]
+    (testing (str api)
+      (is (contains? (set census/verdicts) verdict))
+      (is (string? (:note (first (:entries (census/scan
+                                            (str "(ns a (:require [re-frame.adapter.uix :as ad]))\n"
+                                                 "(ad/" api " x)\n")
+                                            "a.cljs")))))
+          "a class the roster can produce but the notes cannot describe"))))
+
+(deftest the-two-rosters-do-not-overlap
+  (testing "`scan` tries Reagent first, so a shared name would classify a
+            substrate call under a Reagent class and a Reagent recovery
+            sentence — a wrong answer wearing the right shape."
+    (is (empty? (clojure.set/intersection (set (keys census/surface))
+                                          (set (keys census/substrate-surface)))))))
+
+(deftest the-prefix-rule-is-anchored-at-the-start
+  (testing "the substrate roster binds by PREFIX so the adapter set can grow,
+            and that is only safe anchored: a namespace that CONTAINS
+            `re-frame.adapter.` is not one, and a containment test would bind
+            somebody else's API under re-frame2's roster. This is the vendored
+            copy's lesson arriving in the second family."
+    (let [src (str "(ns app.p\n"
+                   "  (:require [my.vendored.re-frame.adapter.reagent :as ad]))\n"
+                   "\n"
+                   "(defn f [] (ad/render! nil nil nil))\n")
+          {:keys [entries substrate? recognised?]} (census/scan src "app/p.cljs")]
+      (is (= [] entries))
+      (is (false? substrate?))
+      (is (false? recognised?)))))
+
+;; ---------------------------------------------------------------------------
+;; The slim adapter's `reagent2.*` IS Reagent (rf2-xoal)
+;; ---------------------------------------------------------------------------
+
+(deftest the-slim-reagent-is-reagent
+  (testing "`implementation/adapters/reagent-slim/` ships Reagent's API a second
+            time under `reagent2.*`, and `docs/core/how-to/use-uix-or-slim.md`
+            teaches consumers to call it by the same names. An application on
+            the slim substrate scored ZERO for want of four roster entries —
+            the same defect the adapter surface had, one adopter later."
+    (let [src (str "(ns app.chart\n"
+                   "  (:require [reagent2.core :as r]))\n"
+                   "\n"
+                   "(def cache (r/atom {}))\n"
+                   "(defn chart [] (r/create-class {:reagent-render (fn [] [:div])}))\n"
+                   "(defn el [h] (r/as-element h))\n")
+          {:keys [entries reagent? unresolved?]} (census/scan src "app/chart.cljs")]
+      (is (true? reagent?))
+      (is (false? unresolved?) "bound, not merely named")
+      (is (= [:local-reactive-cell :lifecycle-class :as-element] (mapv :class entries)))))
+
+  (testing "and the slim ratom namespace binds too"
+    (let [src (str "(ns app.d\n"
+                   "  (:require [reagent2.ratom :as ratom]))\n"
+                   "\n"
+                   "(defn d [] (ratom/make-reaction #(inc 1)))\n")]
+      (is (= [:derived-cell] (classes src "app/d.cljs")))))
+
+  (testing "`reagent2` is not reached by SPELLING either: the roster is exact,
+            so a vendored copy of the slim one binds nothing"
+    (let [src (str "(ns app.p\n"
+                   "  (:require [vendor.inlined.reagent2.core :as r]))\n"
+                   "\n"
+                   "(defn f [] (r/atom 0))\n")]
+      (is (= [:unresolved-reagent-require :unresolved-alias] (classes src "app/p.cljs"))))))
+
+;; ---------------------------------------------------------------------------
+;; A zero the tool CANNOT report confidently (rf2-xoal)
+;; ---------------------------------------------------------------------------
+
+(deftest recognising-nothing-is-not-finding-nothing
+  (testing "the corpus that started this: every file a re-frame2 view file, so
+            the census has no population anywhere in it. Its zero used to be
+            indistinguishable from a clean bill of health, which is the
+            fail-open shape."
+    (let [s (:summary (census/build [(census/scan rf2-native-view "app/articles.cljs")
+                                     (census/scan rf2-native-view "app/profile.cljs")]))]
+      (is (= 0 (:entries s)))
+      (is (= :none (:recognition s)))
+      (is (= 2 (:files-scanned s)))
+      (is (= 0 (:files-recognised s)))
+      (is (= 2 (:files-unrecognised s)))
+      (is (str/includes? (:caveat s) "NOT A CLEAN BILL OF HEALTH"))
+      (testing "and the CLI tail says it too, because whoever reads only the last
+                line of the run is exactly who this misleads"
+        (is (str/includes? (census/describe {:summary s}) "NOTHING RECOGNISED")))))
+
+  (testing "THE CONTROL, and it has to fire or the assertion above means nothing:
+            the same machinery over a corpus the census DOES have a population
+            in reports `:full`, and its caveat says the zero would be a
+            measurement rather than a shrug."
+    (let [s (:summary (census/build [(census/scan form-2 "app/counter.cljs")]))]
+      (is (= :full (:recognition s)))
+      (is (= 1 (:entries s)))
+      (is (= 0 (:files-unrecognised s)))
+      (is (str/includes? (:caveat s) "a population throughout"))
+      (is (not (str/includes? (census/describe {:summary s}) "NOTHING RECOGNISED")))))
+
+  (testing "the mixed corpus — one adapter file, one view file — is `:partial`,
+            and its caveat is the one a re-frame2 migrator needs: the view files
+            are absent from this census AND full of migration work."
+    (let [s (:summary (census/build [(census/scan rf2-native-boot "app/core.cljs")
+                                     (census/scan rf2-native-view "app/articles.cljs")]))]
+      (is (= :partial (:recognition s)))
+      (is (= 2 (:entries s)) "the two mount calls, which used to be zero")
+      (is (= 1 (:files-with-substrate s)))
+      (is (= 0 (:files-with-reagent s))
+          "`:files-with-reagent` keeps its meaning: no Reagent name is in this app")
+      (is (str/includes? (:caveat s) "full of migration work"))))
+
+  (testing "an empty path set is its own verdict rather than a zero"
+    (let [s (:summary (census/build []))]
+      (is (= :no-files (:recognition s)))
+      (is (str/includes? (:caveat s) "NO SOURCE FILE WAS SCANNED")))))
+
+(deftest the-file-counts-partition-the-corpus
+  (testing "the reported defect came with a bookkeeping tell beside it: 18 files
+            scanned, and `files-with-reagent` + `files-unresolved` +
+            `files-clean` summing to 0. The buckets close now, and the one that
+            was missing is the one the zero was hiding."
+    (let [built (census/build [(census/scan form-2 "app/counter.cljs")
+                               (census/scan vendored-require "app/panel.cljs")
+                               (census/scan rf2-native-boot "app/core.cljs")
+                               (census/scan rf2-native-view "app/articles.cljs")])
+          s     (:summary built)
+          with-entries (count (into #{} (map :file) (:entries built)))]
+      (is (= (:files-scanned s) (+ (:files-recognised s) (:files-unrecognised s))))
+      (is (= (:files-recognised s) (+ (:files-clean s) with-entries)))
+      (is (= 4 (:files-scanned s)))
+      (is (= 3 (:files-recognised s)))
+      (is (= 1 (:files-unrecognised s)))
+      (is (= 2 (:files-with-reagent s)))
+      (is (= 1 (:files-with-substrate s)))
+      (is (= 0 (:files-clean s))))))


### PR DESCRIPTION
Closes rf2-xoal and rf2-mckf, both filed by blinded pilots in the `rf2-t4jpz`
PRE-PILOT rehearsal — agents given only the 29 published Hicasso pages and a
real application to migrate. Both premises were checked at source and **both
hold**; the first is reproduced below before and after.

## rf2-xoal — the census scored a real re-frame2 application at zero

Reproduced on `examples/real-apps/realworld_http/` (13 files) with the tool at
`origin/main`:

```
{:files-scanned 13, :sites-total 0, :entries 0, :by-class {}}
0 Reagent API call site(s) across 0 file(s) that name Reagent — 0 human-decision, 0 mechanical, 0 runtime-blocker
```

The report was not wrong. The census classifies by **namespace**, and a
re-frame2 application on the Reagent adapter renders *through* Reagent while
never naming it: views are declared with `reg-view`, reads are
`@(subscribe […])`, and the substrate arrives as `re-frame.adapter.reagent`,
which is not `reagent.core`. Not one `reagent.core` name appears in the
application. The zero was a true statement about a population that was not that
application's migration surface — and chapter 20's step 1 is *run the reporter*,
so the chapter's first step returned nothing for the case it most often meets.

### The classification rule, and the principle behind it

**Identity, not spelling: a namespace is classified when this project can vouch
for what it is.** Two rosters, kept apart rather than merged.

- **Reagent's API** (`rewrite/reagent-namespaces`) gains the reagent-slim
  adapter's `reagent2.core`, `reagent2.ratom`, `reagent2.dom.client`,
  `reagent2.dom.server`. That is the same API authored a second time *in this
  repository*, under the names `docs/core/how-to/use-uix-or-slim.md` teaches
  consumers to call (`reagent2.core/create-class` for a Form-3 view). One roster
  classifies both because there is one API. Omitting it was the reported defect
  arriving one adopter later: a slim-substrate app writes `(r/atom 0)` and
  scored zero too.
- **re-frame2's own substrate adapters** are a second roster
  (`census/substrate-surface`), bound by a **prefix rule anchored at the start
  of the namespace** — `re-frame.adapter.` — rather than a list, because the
  adapter set is open (Spec 006 fixes the naming, not the membership) and a list
  of today's adapters goes stale into the same silent zero tomorrow. The names on
  it are the adapters' **documented public surface** in `docs/api/`:
  `client-root`, `render!`, `unmount!` (`:root-mount`); `use-subscribe`,
  `use-frame`, `use-current-frame` (`:substrate-read-hook`); `wrap-view`,
  `set-hiccup-emitter!` (`:substrate-view-seam`); `flush-views!`
  (`:substrate-test-seam`). Three documented entries are deliberately absent and
  each absence is stated in the roster's docstring.

Containment is still not identity in either family, and both directions are
asserted: `day8.re-frame-10x.inlined-deps.reagent.v1v2v0.reagent.core` binds
nothing (unchanged), and neither does `my.vendored.re-frame.adapter.reagent` —
which is exactly why the prefix is anchored rather than searched for.

The rosters are **not merged** because `:files-with-reagent` is a documented
half of this report that the migration skill reads to decide whether a Reagent
*coordinate* may be dropped. That is a question about Reagent, and folding
adapter files into the count would answer it wrongly. It keeps its exact meaning
here: the RealWorld run still reports `:files-with-reagent 0`.

### The actual defect: a confident zero over an unclassified corpus

**No roster is ever wide enough.** Whatever the census knows, some codebase
renders through a surface it does not, and over that corpus every count comes
back zero in precisely the voice of a clean bill of health. Widening postpones
that; it cannot prevent it. So the tool is made unable to report the zero
without saying which of the two it is:

- every scanned file answers `:recognised?`, and the summary's file counts now
  **partition** the corpus — `files-scanned = files-recognised +
  files-unrecognised`, and `files-recognised = files-clean + files carrying an
  entry`. That also closes the bookkeeping tell the pilot spotted beside the
  original report (18 scanned, with `files-with-reagent`, `files-unresolved` and
  `files-clean` summing to 0, not 18): the missing bucket *was* the thing the
  zero was hiding.
- `:recognition` is `:full` / `:partial` / `:none` / `:no-files`, with a
  `:caveat` sentence beside it — present **always**, `:full` included, because a
  warning that appears only when something is wrong is a warning nobody can tell
  from a missing key. That is the rule the census already applied to its verdict
  counts.
- the verdict is **hoisted to the top of the artefact**, beside `:tool`, because
  the reader who gets misled is the one who reads the first summary and stops.
- the CLI's last line leads with it.

### The witness

Same corpus, same command, after:

```
…/realworld_http/core.cljs:296:19  root-mount  human-decision  client-root
…/realworld_http/core.cljs:412:5   root-mount  human-decision  render!

2 view-substrate API call site(s) across 0 file(s) that name Reagent and 1 that
name a re-frame2 adapter — 2 human-decision, 0 mechanical, 0 runtime-blocker;
12 of 13 file(s) NOT RECOGNISED — read :census :summary :caveat
```

`0 → 2` entries, both true findings with the existing `:root-mount` recovery
sentence ("Hicasso mounts its own root; this call is boot ceremony and is
replaced wholesale rather than edited"), and the twelve files the census still
has no population in are now *counted and named as such* instead of passing
silently. Their caveat is the sentence the pilot needed and did not get: this
corpus names a re-frame2 adapter, so its view files are absent from this census
**and full of migration work**.

`(rf/init! reagent-adapter/adapter)` on the line between the two is not counted:
`adapter` is a value in argument position and this walk reads call heads. The
file is recognised through its `ns` form regardless, so nothing rides on it —
recorded as a decision in the roster docstring rather than left as a gap.

**A green run over a corpus the tool cannot see is not evidence**, so two more
runs bound it. A single re-frame2 view file (`articles.cljs`) now reports
`NOTHING RECOGNISED — 1 file(s) scanned … This zero is NOT a clean bill of
health`. And a **control that fires**: `examples/patterns/long_running_work/`
exercises both rosters at once, going from **1** entry on `origin/main` (the
`with-let` alone) to **3** (that `with-let` plus `client-root` and `render!`),
with `2 of 4 file(s) NOT RECOGNISED` where the old run said nothing at all.

## rf2-mckf — the bare run wrote into the consumer's checkout

Reproduced: the default report path was the bare name
`reagent-to-hicasso-report.edn`, which resolves against the process's working
directory — and the chapter's first command is a `cd` into the tool's own
directory, so the documented invocation wrote the file **into the re-frame2
checkout** the migrator had been told to treat as a read-only build input. It
turned up in their `git status`, and the run's own last line printed the bare
relative name, which named the file without naming the directory.

It now defaults to **beside the first path scanned** — point the tool at
`<repo>/src/` and the report lands at `<repo>/`, next to the tree it describes
and inside the working copy the migrator is about to change anyway — and the run
prints `wrote report: <absolute path>`. Measured both ways: the old tool wrote
into its own directory; the new one wrote to `<fakerepo>/` and left the tool
directory clean.

The pilot also flagged the `:paths external to the project` deprecation warning
the tool prints. That one is **not** repaired, and the reason is now recorded in
`deps.edn` beside the entry: the sanctioned `:local/root` spelling would drag
`implementation/hicasso`'s own `:deps` (`day8/re-frame2` and
`day8/re-frame2-ssr`) onto the classpath of a tool whose whole design premise is
that it runs on a bare JVM and never loads re-frame2. One pure `.cljc` file is
the cheaper honesty.

## Output shape changed — chapter 20 needs sequencing

Chapter 20 is held by another worker and is **not touched here**. What changed:

| Where | Change |
|---|---|
| report, top level | new `:recognition {:recognition … :caveat …}`, between `:design` and `:summary` |
| `:census :summary` | new `:files-recognised`, `:files-unrecognised`, `:files-with-substrate`, `:recognition`, `:caveat` |
| `:census :summary :estimand` | now names both rosters |
| `:census :summary :files-clean` | denominator moved from `files-with-reagent` to `files-recognised` |
| census entry `:class` | new `:substrate-read-hook`, `:substrate-view-seam`, `:substrate-test-seam`; `:root-mount` now reachable from an adapter call |
| CLI tail | "N Reagent API call site(s) across N file(s) that name Reagent" → "N view-substrate API call site(s) … and N that name a re-frame2 adapter", plus the unrecognised suffix and a `NOTHING RECOGNISED` variant |
| CLI last line | `report: <relative>` → `wrote report: <absolute>` |

(2 columns; 7 body rows.)

**The fixer's `:entries` and the golden corpus are untouched** — every
`expected-report.edn` holds fixer entries only, and all twelve pass byte for
byte unchanged.

Prose outside this tool that describes the census in the old terms — chapter 20
§"The report's second half", `skills/reagent-migration/SKILL.md` and
`references/procedure.md` — is accurate about the Reagent half and now
understates the population. Both are outside this PR's fence; flagged for
sequencing rather than edited.

## Gates

Run from the tool directory, exit codes captured to files and read from the
files.

- `clojure -M:test` — **exit 0**, 61 tests / 529 assertions, 0 failures
  (was 54 / 466). Re-run on the final rebased base.
- `clj-kondo --lint src test` — **exit 3**, which is this tree's steady state
  (the fixture corpus is deliberately unlintable). The findings under `src/` and
  `census_test.clj` are **identical to `origin/main`'s**: the same six, line
  numbers shifted. No new lint.
- **Sabotage run**: with the prefix rule changed to `re-frame.PLANTED-FAULT.`
  (single-line anchor, match count read as 1 before running), the suite went
  **red at exit 1** — 22 failures / 1 error, naming
  `the-substrate-adapter-is-a-population`,
  `recognising-nothing-is-not-finding-nothing`,
  `every-substrate-class-has-a-recovery-sentence` and
  `the-file-counts-partition-the-corpus`. Those tests exist only on this branch,
  so the red is the proof the runner read this checkout. Restore verified by git
  blob hash against the pre-plant value, not by reading a diff.

`spec/` is unchanged, and nothing in `tools/xray/` or `tools/machines-viz/` is
touched — the reporter lives at `migration/reagent-to-hicasso/codemod/`, so the
Xray spec rule does not apply. No hot-zone file is touched.
