### PR TITLE
fix(realworld): the example boots under its own app-db schemas (rf2-2xzc)

### DIFF
--- a/examples/real-apps/realworld_http/schema.cljs
+++ b/examples/real-apps/realworld_http/schema.cljs
@@ -190,29 +190,53 @@
 ;; absent — they're runtime-db, not app-db, and get validated through each
 ;; machine's own `[:schemas :data]` (the *Data schemas above) instead.
 ;;
+;; WHY EVERY SLICE WEARS A `:maybe` — THE BOOT WINDOW. Validation is not scoped
+;; to the paths the committing event touched: at every `:db` commit the runtime
+;; walks EVERY registered path with `get-in` over the whole candidate app-db and
+;; rejects the entire transaction if any one of them fails (Spec 010 §Per-step
+;; recovery row 4 — the candidate is discarded, and `:fx` does not walk either).
+;; A path nothing has written yet reads `nil`, and `nil` is not a `[:map …]`.
+;; app-db starts empty and each slice is seeded by its OWN feature's
+;; `:*/initialise`, fanned out from `:app/initialise` (core.cljs) — separate
+;; events, so separate commits. Register these bare and the very first seed is
+;; rejected by the eighteen siblings that have not been seeded yet; the same
+;; thing happens to every later seed, so app-db never leaves `{}` and the app
+;; renders empty everywhere. Silently, and only in a development build, since a
+;; production build elides the validator and installs every candidate. The
+;; `:maybe` buys exactly the window before a slice's seed lands — once it has,
+;; the schema is doing its full job. `examples/patterns/boot/schema.cljs` wears
+;; its `:maybe`s for the same reason.
+;;
 ;; One wrinkle: `reg-app-schemas` is frame-local, so it needs a frame in
 ;; context — call it bare at ns-load and you'd get :rf.error/no-frame-context.
 ;; `with-frame` names the target, `:rf/default`, so these register against that
 ;; frame at load time, ready for the frame-provider in core.cljs to pick up
 ;; when it creates `:rf/default`.
-(with-frame :rf/default
- (rf/reg-app-schemas
-  {[:auth]                          AuthSlice
-   [:articles]                      RequestSlice
-   [:articles :data]                [:vector ws/Article]
-   [:article]                       RequestSlice
+
+(def app-db-schemas
+  "This app's app-db schema registry as a `{path -> schema}` VALUE, so the same
+   set can be registered against a frame other than `:rf/default` — registration
+   is frame-local, and a harness driving its own frame gets no schemas at all
+   unless it asks for these by name."
+  {[:auth]                          [:maybe AuthSlice]
+   [:articles]                      [:maybe RequestSlice]
+   [:articles :data]                [:maybe [:vector ws/Article]]
+   [:article]                       [:maybe RequestSlice]
    [:article :data]                 [:maybe ws/Article]
-   [:profile]                       RequestSlice
+   [:profile]                       [:maybe RequestSlice]
    [:profile :data]                 [:maybe ws/Profile]
-   [:profile.articles]              RequestSlice
-   [:profile.articles :data]        [:vector ws/Article]
-   [:profile.favorites]             RequestSlice
-   [:profile.favorites :data]       [:vector ws/Article]
-   [:comments]                      RequestSlice
-   [:comments :data]                [:vector ws/Comment]
-   [:feed]                          RequestSlice
-   [:feed :data]                    [:vector ws/Article]
-   [:comment-form]                  FormSlice
-   [:auth :login-form]              FormSlice
-   [:auth :register-form]           FormSlice
-   [:editor]                        EditorSlice}))
+   [:profile.articles]              [:maybe RequestSlice]
+   [:profile.articles :data]        [:maybe [:vector ws/Article]]
+   [:profile.favorites]             [:maybe RequestSlice]
+   [:profile.favorites :data]       [:maybe [:vector ws/Article]]
+   [:comments]                      [:maybe RequestSlice]
+   [:comments :data]                [:maybe [:vector ws/Comment]]
+   [:feed]                          [:maybe RequestSlice]
+   [:feed :data]                    [:maybe [:vector ws/Article]]
+   [:comment-form]                  [:maybe FormSlice]
+   [:auth :login-form]              [:maybe FormSlice]
+   [:auth :register-form]           [:maybe FormSlice]
+   [:editor]                        [:maybe EditorSlice]})
+
+(with-frame :rf/default
+  (rf/reg-app-schemas app-db-schemas))

--- a/implementation/core/test/re_frame/example_realworld_boot_seed_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_realworld_boot_seed_cljs_test.cljs
@@ -1,0 +1,173 @@
+(ns re-frame.example-realworld-boot-seed-cljs-test
+  "rf2-2xzc — THE BOOT WINDOW: an app whose slices are seeded by SEPARATE events
+   must still boot under its own app-db schema registry.
+
+   THE DEFECT. The RealWorld (Conduit) managed-HTTP example rendered every
+   screen empty in a DEVELOPMENT build — the Global Feed showed \"No articles
+   are here... yet.\", article detail \"No article loaded.\", profile \"No profile
+   loaded.\", sign-in stayed anonymous — while the SAME bundle in a RELEASE build
+   rendered all four correctly. Nothing complained: no page error, no console
+   error, no failed request.
+
+   THE MECHANISM. `examples/real-apps/realworld_http/schema.cljs` registers
+   nineteen app-db path schemas against `:rf/default` at ns-load. app-db starts
+   `{}`, and each slice is seeded by its OWN feature's `:*/initialise`, fanned
+   out from `:app/initialise` — so each seed is a SEPARATE commit. The candidate
+   validator walks EVERY registered path over the WHOLE candidate app-db at
+   EVERY `:db` commit (`(get-in db path)`, Spec 010 §Per-step recovery row 4) —
+   there is no exemption for a path nothing has written yet, and an unwritten
+   path reads `nil`. So the FIRST seed was rejected by the eighteen siblings
+   still absent; every later seed was rejected the same way; and app-db never
+   left `{}`. Because a rejected candidate also does NOT walk `:fx`, the
+   `[:rf.http/managed …]` effect never fired either — which is why the symptom
+   presented as \"the demo backend's replies never settle\" when in fact no
+   request was ever issued.
+
+   WHY DEV ONLY. `re-frame.schemas.validate/validate-app-schema!` puts its whole
+   body inside `(if interop/debug-enabled? … true)`, so a production build
+   returns `true` without walking anything and every candidate installs. Dev and
+   release therefore disagree about whether this app can boot at all.
+
+   WHY THE POPULAR-TAGS SIDEBAR STILL POPULATED. The tags lifecycle lives
+   ENTIRELY in the `:realworld/tags` state machine, whose snapshot is runtime-db
+   and is validated by the machine-data boundary against the machine's own
+   `[:schemas :data]` — a different partition, a different validator, and one
+   whose `:data` the machine spec seeds itself. `:tags/load` / `:tags/loaded`
+   return only `:fx`, never `:db`, so the app-db validator never ran for them.
+   The one panel on the page that never touches app-db was the one that worked.
+
+   WHY NOTHING IN THE SUITE SAW IT. `reg-app-schemas` is FRAME-LOCAL, and the
+   example registers against `:rf/default`. Every existing test drives the
+   example in an anonymous frame, which carries no app-db schemas at all — so
+   the registry that breaks the real app is inert in the harness. This ns closes
+   that gap by registering the example's OWN registry against the frame under
+   test.
+
+   Feature nses only, never `realworld-http.core` — requiring core would pull
+   `routing.cljs` and register routes into the shared node-test registrar (the
+   same rule the sibling password-classification ns states). `:app/initialise`
+   lives in core, so the boot fan-out it performs is spelled out below."
+  (:require [cljs.test :refer-macros [deftest testing is use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.schemas]
+            [re-frame.machines]
+            [re-frame.http.managed]
+            [re-frame.http.test-support]
+            ;; managed-HTTP app FEATURE nses (no core -> no routes)
+            [realworld-http.http]
+            [realworld-http.schema :as app-schema]
+            [realworld-http.auth]
+            [realworld-http.articles]
+            [realworld-http.comments]
+            [realworld-http.article-editor]
+            [realworld-http.profile]
+            [realworld-http.favorites]
+            [realworld-http.tags])
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; The example's own boot fan-out, spelled out.
+;;
+;; `:app/initialise` (core.cljs) dispatches these; `:auth/initialise` runs ahead
+;; of it as its own `:initial-events` step, because it consumes the recordable
+;; `:auth.session/token` coeffect. The ORDER is the app's, and it matters: it is
+;; `:auth/initialise` that creates `[:auth]` in the AuthSlice shape, before the
+;; two form initialisers write inside it.
+;; ---------------------------------------------------------------------------
+
+(defn- boot!
+  "Drive the example's boot sequence into frame `f`, one dispatch per event
+  exactly as the app does — so each `:db`-bearing initialiser is its own
+  commit, which is the whole point of the regression."
+  [f]
+  (rf/dispatch-sync [:auth/initialise] {:frame   f
+                                        :rf.cofx {:auth.session/token nil}})
+  (doseq [ev [[:articles/initialise]
+              [:article/initialise]
+              [:comments/initialise]
+              [:comment-form/initialise]
+              [:editor/initialise]
+              [:profile/initialise]
+              [:feed/initialise]
+              [:tags/initialise]
+              [:auth.login-form/initialise]
+              [:auth.register-form/initialise]]]
+    (rf/dispatch-sync ev {:frame f})))
+
+(deftest realworld-boots-under-its-own-app-db-schemas
+  (testing "every slice the example seeds is present after boot, with the
+            example's OWN app-db schema registry installed on the frame"
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {})]
+      ;; The registry the real app installs on `:rf/default`. Registering it
+      ;; here is what makes this frame behave like the running application
+      ;; rather than like every previous harness frame.
+      (rf/reg-app-schemas app-schema/app-db-schemas {:frame f})
+      (boot! f)
+      (let [db (rf/app-db-value f)]
+        (is (seq db)
+            "app-db is not empty — the first seed was not rejected by its
+             not-yet-seeded siblings (the rf2-2xzc rollback loop)")
+        (doseq [k [:auth :articles :article :comments :comment-form
+                   :profile :profile.articles :profile.favorites :feed :editor]]
+          (is (contains? db k)
+              (str "app-db carries the " k " slice after boot")))
+        (is (contains? (get db :auth) :login-form)
+            "app-db carries the login-form slice after boot")
+        (is (contains? (get db :auth) :register-form)
+            "app-db carries the register-form slice after boot")
+        (is (= :idle (get-in db [:articles :status]))
+            "the articles slice really is the seeded idle shape")))))
+
+(deftest a-load-after-boot-commits-its-db
+  (testing ":articles/load commits its :db — the half a rejected candidate
+            loses along with its :fx, which is why no request was ever issued"
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {})]
+      (rf/reg-app-schemas app-schema/app-db-schemas {:frame f})
+      (boot! f)
+      (rf/dispatch-sync [:articles/load] {:frame f})
+      (is (= :loading (get-in (rf/app-db-value f) [:articles :status]))
+          "the in-flight status committed (a rejected candidate would leave
+           :idle, and would never have walked :fx to issue the request)"))))
+
+;; ---------------------------------------------------------------------------
+;; The framework contract underneath the regression, pinned on its own.
+;;
+;; DEV-ONLY BEHAVIOUR. `validate-app-schema!` is gated on
+;; `re-frame.interop/debug-enabled?`, so under `:advanced` + `goog.DEBUG=false`
+;; the candidate installs instead and neither assertion below would hold. The
+;; node-test build is a development build — which is the build a developer
+;; meets, and the build in which the example was dead.
+;; ---------------------------------------------------------------------------
+
+(def ^:private Slot [:map [:n :int]])
+
+(rf/reg-event :test.boot-window/seed-a
+  (fn [{:keys [db]} _] {:db (assoc db :slot-a {:n 1})}))
+
+(deftest a-sibling-unseeded-path-rejects-the-whole-candidate
+  (testing "an unwritten registered path reads nil and rejects a commit that
+            never touched it — the mechanism behind rf2-2xzc"
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {})]
+      (rf/reg-app-schemas {[:slot-a] Slot
+                           [:slot-b] Slot}
+                          {:frame f})
+      (rf/dispatch-sync [:test.boot-window/seed-a] {:frame f})
+      (is (nil? (get (rf/app-db-value f) :slot-a))
+          "the :slot-a write was REJECTED because :slot-b, which this event
+           never touched, is still absent (and validation IS live here — a
+           soft-passing validator would have let the write land)")))
+  (testing "the same write lands once the unseeded sibling tolerates absence"
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {})]
+      (rf/reg-app-schemas {[:slot-a] Slot
+                           [:slot-b] [:maybe Slot]}
+                          {:frame f})
+      (rf/dispatch-sync [:test.boot-window/seed-a] {:frame f})
+      (is (= {:n 1} (get (rf/app-db-value f) :slot-a))
+          "with :maybe on the not-yet-seeded sibling the candidate installs"))))


### PR DESCRIPTION
## rf2-2xzc — the RealWorld example was dead in every development build

**The bead's title is not the bug and `:dispatch-later` is not involved.** `:dispatch-later` is healthy; so is the demo backend, the canned-reply path and managed HTTP. No request was ever issued.

### The mechanism

`examples/real-apps/realworld_http/schema.cljs` registered nineteen app-db path schemas against `:rf/default` at ns-load. app-db starts `{}`, and each slice is seeded by its own feature's `:*/initialise`, fanned out from `:app/initialise` — separate events, therefore separate commits.

The candidate validator walks **every** registered path over the **whole** candidate app-db at **every** `:db` commit (`(get-in db path)`, Spec 010 §Per-step recovery row 4). There is no exemption for a path nothing has written yet, and an unwritten path reads `nil`, which is not a `[:map …]`. So the first seed was rejected by the eighteen siblings still absent; every later seed was rejected the same way; app-db never left `{}`.

A rejected candidate also does **not** walk `:fx`. That is the whole reason the symptom read as "the demo backend's replies do not settle": `:articles/load`'s `[:rf.http/managed …]` never fired, so no request was made and no `:dispatch-later` was ever armed.

**Dev only** because `re-frame.schemas.validate/validate-app-schema!` wraps its whole body in `(if interop/debug-enabled? … true)` — a release build returns `true` without walking anything and every candidate installs.

**Why the Popular Tags sidebar populated on the same page.** The tags lifecycle lives entirely in the `:realworld/tags` state machine, whose snapshot is runtime-db and is validated by the machine-data boundary against the machine's own `[:schemas :data]` — different partition, different validator, and one whose `:data` the machine spec seeds itself. `:tags/load` and `:tags/loaded` return only `:fx`, never `:db`, so the app-db validator never ran for them. The one panel on the page that never touches app-db was the one that worked.

**Why nothing in the suite saw it.** `reg-app-schemas` is frame-local and the example registers against `:rf/default`; every existing test drives the example in an anonymous frame, where that registry is simply absent. LinearLite — the pilot's control, which rendered fine — registers no app-db schemas at all.

### The change

Two files.

- `examples/real-apps/realworld_http/schema.cljs` — every registration now wears `:maybe` for the boot window, the way `examples/patterns/boot/schema.cljs` already does and with the same stated rationale written out. The registry also becomes a named value, `app-db-schemas`, so a harness can install the app's real registry on its own frame.
- `implementation/core/test/re_frame/example_realworld_boot_seed_cljs_test.cljs` — new. Drives the example's own boot fan-out on a frame carrying the example's own registry, and separately pins the framework semantics underneath (an unwritten sibling path rejects a commit that never touched it; a `:maybe` sibling lets it land). Examples stay test-free, so it lives in the framework tree beside the existing `example_realworld_password_classification_cljs_test`.

No framework behaviour is changed. `implementation/schemas` and the spec are untouched.

### Evidence

Headless Chrome against a real `shadow-cljs compile :examples/realworld` dev bundle, served over HTTP:

| | `#app` | feed | app-db |
|---|---|---|---|
| dev, before | 2350 | `No articles are here... yet.` | `{}` |
| dev, after | 13236 | 10 article cards + pagination | seeded |
| release, after | 9130 | 10 article cards + pagination | seeded |

Article detail, sign-in and the post-login home all render in the dev build after the change; sign-in authenticates. Zero page errors either side — the failure was always silent.

Same instrument each side, via an `:events` listener on the identical dispatch:

- before — `{:event [:articles/load] :outcome :rolled-back}`, one event, and a `:trace` listener carrying **17** `:rf.error/schema-validation-failure` records with `:rollback? true`, no `:rf.fx/handled` at all
- after — `{:event [:articles/load] :outcome :ok}`, six events including both `:rf.http/deliver-canned-reply` hops through `:dispatch-later` and `:articles/loaded` with ten articles

Gates, exit codes captured to files and read back:

- `npx shadow-cljs compile node-test` → **0**
- `node out/node-test.js --test=` the new ns plus the five existing realworld namespaces → **0**, `Ran 90 tests containing 899 assertions. 0 failures, 0 errors.` Re-run on the final rebased base.
- `clj-kondo` on both changed files → **0**, 0 errors 0 warnings
- release build `npx shadow-cljs release :examples/realworld` → **0**

The witness bites: with the pre-fix registrations planted back (17 sites reverted, the rest of the file and the test untouched) the new ns is **exit 1, 15 of 17 assertions failing**, `app-db` `{}`. The two that still pass are the two pinning the framework semantics, which the example fix does not move. Restore verified by blob hash, identical before and after the plant.

No markdown changed, so no documentation gate is nominated.

### Filed separately, not fixed here

- `examples/real-apps/realworld_resources` has the **same** defect — measured, not inferred: dev build, app-db `{}`, zero cards. Outside this fence.
- `:rf.error/schema-validation-failure` reaches only the dev-only `:trace` stream, never the always-on `:errors` stream. A listener registered on `:errors` saw nothing while `:trace` carried all 17; the control on the same frame — an unregistered event id — did reach `:errors`. That silence is what made an app-wide rollback loop invisible.
- A React duplicate-`key` warning on the article-card tag list, visible only once cards render.
