### PR TITLE
docs(hicasso): chapter 15 states its own preconditions (rf2-w4yz, rf2-30hi, rf2-ib25, rf2-3q38)

### DIFF
--- a/docs/core/hicasso/15-testing.md
+++ b/docs/core/hicasso/15-testing.md
@@ -14,6 +14,11 @@ The test kit is split across two namespaces:
 - `re-frame.hicasso.test.mounted`, usually aliased `hm`, for real React and DOM
   tests.
 
+Each level has preconditions — a classpath entry, a subscription fixture, a
+document. A level whose preconditions are unmet rarely fails honestly: it
+passes for the wrong reason, or never runs at all. Each is stated below beside
+the level that needs it.
+
 ## Put the test kit on the classpath
 
 Where the kit comes from depends on how you resolve Hicasso, and the two routes
@@ -75,6 +80,66 @@ Testing Library is the one further thing L3 reaches for, and it is an npm packag
 rather than a classpath entry: `npm install --save-dev @testing-library/dom`, plus
 `@testing-library/user-event` if your tests drive real interactions.
 
+## Where L3's DOM comes from
+
+L0–L2 never touch a document, so any target runs them. L3 is different, and it
+is the one setup step the classpath does not cover: `hm/mount!` renders through
+`react-dom/client`, which needs a real `document` to mount into. Nothing on the
+classpath supplies one, and neither does Testing Library —
+`@testing-library/dom` *queries* a DOM, it does not create one. On a
+shadow-cljs `:node-test` build there is no `document` at all, so every `hm`
+name resolves, compiles, and then fails at run time.
+
+Two build shapes answer it, and they are not equivalent.
+
+**A `:browser-test` target** compiles the suite into a page and runs it in a
+real engine, so the document is a browser's. This is what Hicasso's own mounted
+suites use, and it is the recommendation: L3 exists to prove React and DOM
+facts, and a real engine is the only thing that knows them.
+
+**A DOM shim on `:node-test`** — `jsdom` or `happy-dom`, installed as globals
+before the suite loads — is cheaper, and enough for structural assertions. It
+is a reimplementation though, and what it is least reliable about is focus,
+selection and layout. Those are L4's subject, so a shim narrows what L3 can
+honestly claim rather than moving L4's work down a rung.
+
+Split the two lanes by namespace suffix, so the browser-free bulk of the suite
+never pays for a browser:
+
+```clojure
+;; shadow-cljs.edn -- :builds, beside the :deps entry above
+{:builds
+ {:node-test    {:target    :node-test
+                 :ns-regexp "-cljs-test$"
+                 :output-to "out/node-test.js"}
+
+  :browser-test {:target    :browser-test
+                 :ns-regexp "-dom-cljs-test$"
+                 :test-dir  "out/browser-test"}}}
+```
+
+Then name a mounted test's namespace `...-dom-cljs-test` and a browser-free one
+`...-cljs-test`.
+
+Those two regexes overlap: `-cljs-test$` also matches `-dom-cljs-test`, so a
+mounted file compiles on the Node lane as well unless you narrow it. Overlap is
+often what you want, because a cross-runtime file then gets asserted twice —
+but each mounted row has to say so rather than fail:
+
+```clojure
+(defn- browser? [] (exists? js/document))
+
+(deftest toggle-reaches-the-real-dom
+  (async done
+    (if-not (browser?)
+      (do (println "SKIP (no document): the toggle on a real checkbox")
+          (done))
+      (run-the-mounted-body done))))
+```
+
+A stated skip is a true report. A row that passes because it never ran is the
+failure this chapter is most concerned with.
+
 ## The testing ladder
 
 | Level | What it proves | Mechanism |
@@ -82,7 +147,7 @@ rather than a classpath entry: `npm install --save-dev @testing-library/dom`, pl
 | **L0** | Handler behaviour, subscription output, state transitions | Pure function calls |
 | **L1** | Intent values, prevent/navigate decisions, codecs, merge laws, macro expansion | Plain data and property tests |
 | **L2** | The semantic output of one hook-free view body | `ht/tree` with injected subscription fixtures |
-| **L3** | React lifecycle, hooks, context, refs, hosts, error boundaries, real DOM | Mounted facade with Testing Library and user-event |
+| **L3** | React lifecycle, hooks, context, refs, hosts, error boundaries, real DOM | Mounted facade with Testing Library and user-event, on a target that has a [DOM](#where-l3s-dom-comes-from) |
 | **L4** | IME, caret, focus traversal, layout, hydration, browser performance | Chromium, Firefox, and WebKit |
 
 These levels prove different kinds of equality. A passing semantic-tree test
@@ -242,10 +307,74 @@ Useful tree helpers include:
 - `ht/text` — collect its text;
 - `ht/intents` — collect event intents in the tree.
 
-A node's `:tag` identifies an element. `:view-id` identifies a child view call.
+A node's `:tag` identifies an element. `:view-id` identifies a child view call,
+and it is a **string** — the `"<ns>/<sym>"` name `ht/view-name` answers for
+that view, not the view value itself. Spell it from the var rather than typing
+the string, so a rename moves the test with the code:
+
+```clojure
+(ht/find tree #(= (ht/view-name views/todo-row) (:view-id %)))
+```
+
+It is the same name React DevTools shows for the boundary.
 
 The head may be the `defview` or its underlying body function. No React
 element is created, and nothing mounts or paints.
+
+### The intent stream carries more than your events
+
+`ht/intents` answers **every** event vector in the tree, and an application's
+own events are not always all of them. A tree holding an `h/route-link` also
+carries routing's click decision, and that decision embeds the frame it was
+minted under — which, under `ht/tree`, is a fresh probe keyword per call,
+numbered in the order the tests happened to run:
+
+```clojure
+[:re-frame.hicasso.impl.intent/navigate
+ {:frame   :re-frame.hicasso.test/probe-7
+  :payload [:rf.route/url-requested {:url "/profile/jane" ...}]
+  :native? false
+  :veto    nil}]
+```
+
+So the exact-equality assertion above is right for the todo row, whose tree has
+no link in it, and fragile for any tree that has one: adding a test *above* it
+renumbers the probe and reds it. Where a link is in play, assert what you
+actually meant — that your intent is offered:
+
+```clojure
+(is (contains? (set (ht/intents tree)) [:todo/toggle 7]))
+```
+
+or, when the order of your own events is the claim, filter to the heads you
+own before comparing:
+
+```clojure
+(is (= [[:todo/toggle 7] [:todo/destroy 7]]
+       (filterv #(= "todo" (namespace (first %))) (ht/intents tree))))
+```
+
+For the link itself, assert its `:href`. Routing synthesised it from `:to` and
+`:params`, which is the fact worth pinning, and it does not move.
+
+### The root is always a node
+
+`ht/tree` answers a node map, never `nil`. A body that returned one element
+roots in that element; a body that returned text, several forms, or **nothing
+at all** roots in a fragment, which is a map carrying the version and a
+`:children` vector. So a body whose whole return is `nil` — the usual shape
+being a `when` that did not fire — answers this, and `(nil? tree)` is false:
+
+```clojure
+{:rf.ui/tree-version 1 :children []}
+```
+
+Assert `(empty? (:children tree))`. Asserting the absence of the node you care
+about is stronger still, because it survives the body later gaining a wrapper:
+
+```clojure
+(is (nil? (ht/find tree #(= :nav (:tag %)))))
+```
 
 ### Subscription fixtures
 
@@ -294,7 +423,9 @@ Use the mounted facade when the claim depends on React, hooks, context, refs,
 error boundaries, hosts, or real DOM nodes.
 
 Each mount receives its own frame, app-db, queue, subscription cache, React
-root, and residue baseline.
+root, and residue baseline. It also needs a document: see
+[Where L3's DOM comes from](#where-l3s-dom-comes-from) for the build target
+that supplies one.
 
 | Call | Behaviour |
 | --- | --- |
@@ -465,6 +596,9 @@ props. The row's own test proves what a row renders.
 | `hm/assert-clean!` fails | A subscription, listener, task, or foreign callback survived unmount | Fix the leak; retained host callbacks are a common cause ([Interop](09-interop.md)) |
 | Data test passes but mounted test fails | React lifecycle, effect order, StrictMode, or commit timing changed the result | Treat the mounted result as authoritative for React behaviour |
 | Tree assertion sees `nil` | A `when` returned `nil`; it renders nothing but still appears in authored data | Assert that `nil`, or filter it before comparing |
+| `(nil? (ht/tree ...))` fails on a body that renders nothing | The root is always a node; a body returning `nil` roots in an empty fragment | Assert `(empty? (:children tree))` ([The root is always a node](#the-root-is-always-a-node)) |
+| Every `hm` name resolves but nothing mounts | The test lane has no `document` | Run L3 on a `:browser-test` target ([Where L3's DOM comes from](#where-l3s-dom-comes-from)) |
+| An `ht/intents` equality reds when an unrelated test is added | The tree holds a route link, whose navigate decision carries a per-call probe frame id | Compare by membership, or filter to the heads you own ([The intent stream carries more than your events](#the-intent-stream-carries-more-than-your-events)) |
 | A collection test remains green with an empty list | The assertion is vacuously true | Assert the count and add a sabotage twin |
 
 ## When not to test through a view

--- a/docs/core/hicasso/15-testing.md
+++ b/docs/core/hicasso/15-testing.md
@@ -88,7 +88,7 @@ is the one setup step the classpath does not cover: `hm/mount!` renders through
 classpath supplies one, and neither does Testing Library —
 `@testing-library/dom` *queries* a DOM, it does not create one. On a
 shadow-cljs `:node-test` build there is no `document` at all, so every `hm`
-name resolves, compiles, and then fails at run time.
+call compiles and then fails at run time.
 
 Two build shapes answer it, and they are not equivalent.
 
@@ -107,7 +107,7 @@ Split the two lanes by namespace suffix, so the browser-free bulk of the suite
 never pays for a browser:
 
 ```clojure
-;; shadow-cljs.edn -- :builds, beside the :deps entry above
+;; shadow-cljs.edn, continued: the :builds map
 {:builds
  {:node-test    {:target    :node-test
                  :ns-regexp "-cljs-test$"
@@ -597,7 +597,7 @@ props. The row's own test proves what a row renders.
 | Data test passes but mounted test fails | React lifecycle, effect order, StrictMode, or commit timing changed the result | Treat the mounted result as authoritative for React behaviour |
 | Tree assertion sees `nil` | A `when` returned `nil`; it renders nothing but still appears in authored data | Assert that `nil`, or filter it before comparing |
 | `(nil? (ht/tree ...))` fails on a body that renders nothing | The root is always a node; a body returning `nil` roots in an empty fragment | Assert `(empty? (:children tree))` ([The root is always a node](#the-root-is-always-a-node)) |
-| Every `hm` name resolves but nothing mounts | The test lane has no `document` | Run L3 on a `:browser-test` target ([Where L3's DOM comes from](#where-l3s-dom-comes-from)) |
+| Every `hm` call compiles but nothing mounts | The test lane has no `document` | Run L3 on a `:browser-test` target ([Where L3's DOM comes from](#where-l3s-dom-comes-from)) |
 | An `ht/intents` equality reds when an unrelated test is added | The tree holds a route link, whose navigate decision carries a per-call probe frame id | Compare by membership, or filter to the heads you own ([The intent stream carries more than your events](#the-intent-stream-carries-more-than-your-events)) |
 | A collection test remains green with an empty list | The assertion is vacuously true | Assert the count and add a sabotage twin |
 


### PR DESCRIPTION
Chapter 15 (`docs/core/hicasso/15-testing.md`) closes four gaps measured by the two
blinded pilots in the `rf2-t4jpz` pre-pilot rehearsal. All four premises held; each was
re-verified at source and three of them by running the kit's own witnesses.

They share one shape, and the chapter now names it in its opening: **a test-authoring page
that omits its own preconditions produces tests that pass for the wrong reason, or do not
run at all.**

### rf2-w4yz (P2) — where L3's DOM comes from

Both pilots hit this independently, in different applications. The chapter named the
classpath alias, the `:local/root` coordinate, the `shadow-cljs.edn` alias line and the npm
install, then stopped: `hm/mount!` renders through `react-dom/client` and needs a
`document`, which `:node-test` does not have and which `@testing-library/dom` does not
supply — it queries a DOM, it does not create one.

New section **Where L3's DOM comes from**, placed immediately after the Testing Library
line where both pilots looked. It names the two build shapes that answer it, recommends the
`:browser-test` target (what Hicasso's own mounted suites use — verified, see below),
shows the two-lane `shadow-cljs.edn` split by namespace suffix, and covers the regex
overlap that puts a mounted file on the Node lane as well, with the stated-skip idiom the
repo's own mounted suites use.

### rf2-30hi — `:view-id` is the `ht/view-name` string

`:view-id` is `(or (view-name head) "<unnamed boundary>")`, i.e. the `"<ns>/<sym>"` string,
not the view value. The chapter said only that it "identifies a child view call". It now
says the shape and shows `ht/find` spelling the name off the var.

### rf2-ib25 — a `nil` body roots in an empty fragment

`ht/tree` answers a node map, never `nil`: a body returning `nil` answers
`{:rf.ui/tree-version 1 :children []}`. The existing troubleshooting row was about a `nil`
*child*, which is a different symptom. New subsection **The root is always a node**, plus
its own troubleshooting row.

### rf2-3q38 — the whole-stream `ht/intents` comparison is positional

A tree holding an `h/route-link` also carries routing's click decision, and that decision
embeds the frame it was minted under. Under `ht/tree` that is a fresh probe keyword per
call (`:re-frame.hicasso.test/probe-N`, from a `defonce` counter), so an exact-equality
assertion over a stream containing a link reds when a test is added *above* it. New
subsection giving the membership and filtered-stream comparisons, and pointing at `:href`
for the link itself.

## What was verified by running

The kit's own committed witnesses pin all three behavioural claims. Compiled
`:node-test-hicasso` (exit 0, 527 files, 0 warnings) and ran:

| Namespace | What it pins | Result |
| --- | --- | --- |
| `re-frame.hicasso.test-kit-runtime-parity-cljs-test` | row *"a body that renders nothing roots in an EMPTY FRAGMENT"*: `:form nil` against `:tree {:rf.ui/tree-version 1 :children []}` | 29 tests / 130 assertions, exit 0 (run with the slice suite) |
| `re-frame.hicasso.test-kit-cljs-test` | `ht/view-name greeting` and the tree node's `:view-id` are the same string, in one namespace | 21 tests / 103 assertions, exit 0 |
| `re-frame.hicasso.route-link-cljs-test` | the `:on-click` is `[navigate-head {:frame … :payload …}]` and the `:href` is routing's own synthesis | 17 tests / 40 assertions, exit 0 |

`ht/tree-version` is `1`, so the literal in the sample is the real value.

## Gates

The chapter is under `docs/core/`, **not** `docs/design/`, so
`scripts/check_provenance_pins.py` does not apply and the strict build is not excluded.

| Gate | Exit | Proven to read this branch |
| --- | --- | --- |
| `python hicasso/scripts/check_guide_samples.py` | 0 — 74 verbs / 383 sites across 29 pages | yes — a planted `ht/no-such-verb` reddened it naming `15-testing.md block 12` |
| `python scripts/check_doc_slugs.py` | 0 | yes — a planted `#where-l3s-no-such-anchor` reddened it naming `15-testing.md:427` |
| `python -m mkdocs build --strict` | 0 | built 15-testing.md with no warning |
| `check_guide_samples.py --self-test` | 0 — "the rule fires" | control bites |

Both plants were reverted and the restore confirmed by git blob hash, not by reading a diff.

## Verified by hand, because no gate covers it

- **Link targets and anchors inside fenced blocks** — both link gates strip fences before
  reading. Checked mechanically: this page has **0** markdown links inside any fence, so
  there is nothing in that blind spot.
- **All four tables' column counts**, parsed and compared row by row: ladder 3 columns /
  7 rows, the L3 call table 2 / 10, troubleshooting 3 / 14 (three rows added), the equality
  table 3 / 8. No mismatched row in any table.
- **Every in-page anchor resolves to a real heading** — cross-checked against the heading
  list as well as the slug gate.
- **Prose, tables and rendering** are ungated entirely; read through in full.
- **Bytes**: the file is uniformly CRLF (647/647, zero bare LF), decodes as valid UTF-8, and
  its only non-ASCII characters are the em and en dashes the file already used.
