### PR TITLE
docs(hicasso): booting and routing a real app (rf2-v0qc, rf2-q312, rf2-ktit, rf2-g1gt)

### DIFF
--- a/docs/core/hicasso/00-installation.md
+++ b/docs/core/hicasso/00-installation.md
@@ -174,9 +174,33 @@ substrates — see [Use UIx or reagent-slim](../how-to/use-uix-or-slim.md) for t
 shipped alternatives and their coordinates. A Reagent or UIx adapter under a
 Hicasso tree keeps working exactly as it did, and is what you want when the page
 also renders that substrate's own components: every React-shaped adapter writes
-the same frame context, so the two subtrees resolve one frame. What it costs is
-a second dependency whose notation you never write, which is why Hicasso's own
-is the default here.
+the same frame context, so a Hicasso subtree and that substrate's own subtree
+resolve one frame. What it costs is a second dependency whose notation you never
+write, which is why Hicasso's own is the default here.
+
+**One frame, but not one markup dialect.** That shared context is what a
+*component* crossing reads; it is not permission to interleave the two notations.
+A Reagent view is not a legal Hiccup head, so `[reagent-footer]` written inside a
+Hicasso body raises `:rf.error/hicasso-bad-head` at the first paint — and because
+a Reagent view is an anonymous meta-carrying function, the refusal can name the
+enclosing view but not the offender. The two directions are not symmetric:
+
+- **Hicasso inside a foreign parent has a named door.** `h/as-component` mints a
+  real React component from a Hicasso head, and `h/as-element` converts one
+  subtree; a Reagent, UIx, React or plain-JavaScript parent then mounts either
+  under the frame it is already in. See [Render a Hicasso view from native
+  React](09-interop.md#render-a-hicasso-view-from-native-react).
+- **Reagent inside a Hicasso tree has no Hicasso door.** `[:>]` and `h/defhost`
+  take real React components, which a Reagent view is not. Lifting it with
+  `reagent.core/reactify-component` and crossing at the [raw
+  escape](09-interop.md#raw--escape) does work, but that is Reagent's own bridge
+  plus a general escape rather than something this package offers, and it puts
+  two renderers in one tree.
+
+So the practical boundary between the two layers is a **root**, not a tag. Mix or
+migrate a screen at a time, and where one page must genuinely show both, give
+each layer its own root naming the same `:frame` — see [More than one
+root](#more-than-one-root).
 
 An adapter buys plumbing, not notation: you write Hicasso views either way and
 never call the adapter yourself. The headless plain-atom adapter is not a
@@ -282,6 +306,45 @@ reached independently by fixtures, reload hooks, and `finally` blocks. The
 unmount releases the root's subscriptions as their reference counts reach
 zero and makes the DOM node available for another root.
 
+**A bare mount catches nothing.** Every Hicasso refusal is a throw, and React
+unmounts a root whose tree throws with no error boundary above it — the whole
+page, not the offending region, with the error only in the console. Put
+`h/error-boundary` around the regions a user can carry on without, which for
+most applications means a route's main content rather than the root itself;
+[Errors](17-errors.md#place-boundaries-at-useful-recovery-regions) is the whole
+rule and [Routing and navigation](07-routing-and-navigation.md#move-focus-after-a-page-change)
+shows it in a routed root.
+
+### A frame that needs more than a seed
+
+Those three keys are the whole of what `h/mount!` reads, and the list is closed:
+any other key in `config` is ignored, silently and without complaint. A frame
+that needs an `rf/make-frame` option — `:url-bound? true` for an application that
+owns the browser URL, `:fx-overrides` for a stubbed backend, `:images`,
+`:platform` — is therefore **created first, and the mount joins it**:
+
+```clojure
+(defn ^:export init []
+  (rf/init! substrate/adapter)
+  (rf/make-frame {:id             :app/main
+                  :url-bound?     true
+                  :initial-events [[:app/initialise]]})
+  (reset! !root
+          (h/mount! (js/document.getElementById "app")
+                    {:frame :app/main}
+                    [app-root]))
+  nil)
+```
+
+Mounting ensures rather than creates, so the mount finds the frame already live
+and joins it untouched. That is the same join a second root takes, and it carries
+the same consequence: **seed from `rf/make-frame` in this shape, not from the
+mount**, because `:initial-events` handed to a mount that joins never run.
+
+[Routing and navigation](07-routing-and-navigation.md#boot-a-routed-application)
+walks the routed case, which is the common one — a frame owns the browser URL
+only by carrying `:url-bound? true`, and nothing supplies it by default.
+
 ## More than one root
 
 A page can mount several Hicasso roots. The frame id determines whether those
@@ -364,5 +427,7 @@ production; there is no production-only view mode.
 | The first paint is empty and then fills in | Initial state was dispatched after mounting | Put the seed events in `:initial-events` so they finish before the first paint |
 | A second `h/mount!` fails on the same DOM node | A live root already owns the node | Keep the handle with `defonce`; unmount that root before mounting another |
 | A joining root's `:initial-events` never run | The named frame already exists; joining does not replay setup | Seed only from the mount that creates the frame |
+| A key added to `h/mount!`'s `config` has no effect and raises nothing | The config is closed at `:frame`, `:initial-events` and `:identifier-prefix`; every other key is ignored | Put frame options on `rf/make-frame` and let the mount join ([above](#a-frame-that-needs-more-than-a-seed)) |
+| One refused head blanks the whole page | A Hicasso refusal is a throw, and React unmounts a root that throws with no boundary above it | Wrap independently recoverable regions with `h/error-boundary` ([Errors](17-errors.md)) |
 | A changed initialisation handler has no effect after hot reload | The live frame kept its existing app-db | Reload, recreate the frame, or dispatch an explicit reset event |
 | A view body runs twice when first mounted in development | React StrictMode probes bodies twice | Expected. Keep view bodies pure and safe to re-run |

--- a/docs/core/hicasso/07-routing-and-navigation.md
+++ b/docs/core/hicasso/07-routing-and-navigation.md
@@ -32,6 +32,63 @@ beyond it:
   (:require [re-frame.hicasso :as h]))
 ```
 
+## Boot a routed application
+
+Routing costs a dependency and a frame option, and a mount line says neither out
+loud: `h/mount!`'s config carries no routing key at all.
+
+```clojure
+;; deps.edn — beside the Hicasso coordinate
+{:deps {day8/re-frame2-hicasso {:local/root "../re-frame2/implementation/hicasso"}
+        day8/re-frame2-routing {:local/root "../re-frame2/implementation/routing"}}}
+```
+
+```clojure
+(ns app.core
+  (:require [re-frame.core :as rf]
+            [re-frame.routing]                  ;; loads the routing artefact
+            [re-frame.hicasso.substrate :as substrate]
+            [re-frame.hicasso :as h]
+            [app.routes]                        ;; the reg-route table above
+            [app.views :as views]))
+
+(defonce !root (atom nil))
+
+(defn ^:export init []
+  (rf/init! substrate/adapter)
+  (rf/make-frame {:id             :app/main
+                  :url-bound?     true          ;; this frame owns the browser URL
+                  :initial-events [[:app/initialise]]})
+  (reset! !root
+          (h/mount! (js/document.getElementById "app")
+                    {:frame :app/main}
+                    [views/app-root]))
+  nil)
+```
+
+Three things in that shape are load-bearing:
+
+- **`re-frame.routing` is a separate coordinate, and Hicasso does not bring it
+  in.** Require it before anything renders a route link, or `h/route-link` raises
+  `:rf.error/routing-artefact-missing`.
+- **A frame owns the browser URL only by carrying `:url-bound? true`.** There is
+  no default and nothing infers it; the declaration *is* the wiring, and creating
+  the frame installs the URL listener and syncs the current URL into the route
+  slice in one step. Without it `route-link` still renders and navigation still
+  updates that frame's own route state — the address bar simply never moves, and
+  a refresh loses the page.
+- **The frame is made before the mount, because the mount cannot carry
+  `:url-bound?`.** `h/mount!`'s config is closed at `:frame`, `:initial-events`
+  and `:identifier-prefix`, and any other key is ignored without complaint. The
+  mount then joins the live frame, so the seed belongs to `rf/make-frame` — see
+  [A frame that needs more than a
+  seed](00-installation.md#a-frame-that-needs-more-than-a-seed).
+
+Exactly one frame may carry `:url-bound? true`. A second raises
+`:rf.error/duplicate-url-binding` and the first claimant keeps the URL. Frames
+without it — story variants, devcards, per-test fixtures — route independently
+and never touch the address bar.
+
 ## Render an application route link
 
 Call `h/route-link` as a plain helper. Name a registered route and its params
@@ -208,15 +265,28 @@ focusable, and focus it after commit:
      [:main {:key       route
              :tab-index -1
              :ref       focus-page}
-      (case route
-        :app/home    [home-page]
-        :app/article [article-page]
-        [not-found-page])]]))
+      [h/error-boundary
+       {:fallback [:p.oops "This page could not be shown."]}
+       (case route
+         :app/home    [home-page]
+         :app/article [article-page]
+         [not-found-page])]]]))
 ```
 
 The key remounts `<main>` when page identity changes, causing the ref to run.
 `:tab-index -1` allows programmatic focus without adding the region to normal
 tab order. `preventScroll` lets the router's scroll policy remain authoritative.
+
+The boundary sits inside `<main>` on purpose. Every Hicasso refusal is a throw,
+and React unmounts a root whose tree throws with nothing above it to catch, so a
+single refused head anywhere in a page takes the whole application to a blank
+screen with the error only in the console. Catching at the page keeps the
+navigation usable, which is the region rule
+[Errors](17-errors.md#place-boundaries-at-useful-recovery-regions) states and the
+reason not to wrap the root instead — that would turn every failure into a
+whole-page fallback and remove `site-nav` along with the broken content. It needs
+no `:reset-key`: the `:key` above already remounts `<main>` on a route change, so
+navigating away is the retry.
 
 Query-only or fragment-only changes keep the same route id and therefore do
 not move focus. If article 7 and article 9 count as separate pages, include the
@@ -308,6 +378,23 @@ and activation pipeline as route links:
 - The server runs the same routing pipeline for the request URL. Hydration
   adopts that result rather than navigating again.
 
+!!! warning "A route deeper than one segment moves what relative URLs resolve against"
+
+    A page's relative URLs resolve against the *document* URL, and under the
+    default history strategy the document URL **is** the route. So a host page
+    carrying `href="css/style.css"` is correct while every route is `/`, and
+    silently wrong the moment somebody deep-links or refreshes on
+    `/articles/intro`, where it resolves to `/articles/css/style.css` and 404s.
+    Nothing in the application fails: the script tag is usually absolute already,
+    so the app boots, routes and behaves — with no stylesheet and no favicon.
+
+    Give every asset in the host page an absolute path, as [chapter 00's
+    `index.html`](00-installation.md#add-the-dependencies) does for
+    `/js/main.js`, or add one `<base href="/">` to `<head>`. Under a sub-path
+    deployment that becomes `<base href="/my-app/">`, with
+    `rf.routing/with-base-path` wrapped around the frame's `:url-strategy` so
+    the two agree.
+
 ??? info "For readers coming from React Router"
     `route-link` is a plain function returning an anchor, not a component with
     private router context. A blocked transition is app state, not a blocker
@@ -319,6 +406,8 @@ and activation pipeline as route links:
 | --- | --- | --- |
 | Rendering a route link raises `:rf.error/routing-artefact-missing` | The core routing artefact was not required before rendering | Require `re-frame.routing` during boot |
 | An in-app link performs a full page load | A hand-written anchor bypassed route interception | Use `route-link` or the documented document-level routing listener |
+| Links change the page but the address bar never moves, and a refresh loses the route | No frame carries `:url-bound? true`, so nothing owns the browser URL | Declare it on the frame — [Boot a routed application](#boot-a-routed-application) |
+| The page loads and behaves but is unstyled after a deep link or a refresh | Relative asset paths in the host page resolve against the current route | Make host-page asset paths absolute, or add `<base href="/">` |
 | `route-link` rejects a bare `:on-click` vector | The click would produce two semantic events | Use `[::h/prevent [:app/event]]`, `h/event`, or a plain function according to the intended veto |
 | A link carrying `:prefetch` warms nothing | `route-link` installs none of routing's prefetch handlers | Dispatch `[:rf.route/prefetch address]` from `:on-mouse-enter` |
 | Every attempt to leave is rejected and the guard is named | `:rf.error/can-leave-non-boolean` | Return strict `true` or `false` from the guard subscription |

--- a/docs/core/hicasso/api-reference.md
+++ b/docs/core/hicasso/api-reference.md
@@ -131,6 +131,12 @@ many roots as it likes, and no call here reaches a root the caller did not name.
 | `:initial-events` | an ordered vector of ordinary event vectors, dispatched synchronously **when this mount creates the frame**, draining before the call returns. Core's own `:initial-events`, reaching `rf/make-frame` untouched |
 | `:identifier-prefix` | React's `identifierPrefix`, handed to `createRoot` untouched. No default, no coercion, no validation |
 
+The list is closed, and any other key is ignored without complaint. A frame that
+needs an `rf/make-frame` option — `:url-bound?` for an application that owns the
+browser URL, `:fx-overrides`, `:images`, `:platform` — is created before the
+mount, which then joins it: [A frame that needs more than a
+seed](00-installation.md#a-frame-that-needs-more-than-a-seed).
+
 `h/hydrate!`'s `config` carries `:frame` and `:identifier-prefix`, and no
 `:initial-events`. The next section is why.
 


### PR DESCRIPTION
Four adoption-failure points filed by the blinded pilots in the `rf2-t4jpz`
rehearsal, all sitting between "Hicasso is installed" and "a routed application
is on the page". Three chapters, prose and samples only.

## rf2-v0qc — `h/mount!`'s config is closed, and a routed app has no documented boot

**Premise holds, and it reaches further than the bead says.** Established at
source, not inferred: `re-frame.hicasso/mount!` hands `config` whole to
`impl.mount/root!`, which reads exactly `:initial-events` and
`:identifier-prefix`; `ensure-frame!` then builds `{:id frame-kw}` plus the seed
and calls `rf/make-frame` with that. So the three-key list is accurate, **and
every other key is dropped in silence** — no error, no warning. That is the half
worth writing down, because `:url-bound? true` in a mount config is the first
thing a reader tries.

`rf/frame-root` is the contrast: `frame_boundary/frame-root-opts` `dissoc`s two
substrate carriers and passes *every other key* to `make-frame`. The Reagent
spelling really did carry these options and the Hicasso spelling does not.

The reach: per Spec 012 §Multi-frame routing a frame owns the browser URL **only**
by carrying `:url-bound? true` — "there is no `:rf/default`-owns-by-default
floor", and with no owner the outbound `:rf.nav/push-url` no-ops and the popstate
listener skips. `:url-bound?` appears **nowhere** in the 29-page corpus. Chapter
07 therefore taught deep links, Back and Forward over a frame nothing had bound
to the address bar.

- Chapter 00 gains **A frame that needs more than a seed**: make the frame, let
  the mount join it, seed from `make-frame`.
- Chapter 07 gains **Boot a routed application**: the second coordinate
  (`day8/re-frame2-routing` is its own artefact and Hicasso does not bring it
  in), the require, and `:url-bound? true`.
- `api-reference.md` says the list is closed and where the other options live.

## rf2-q312 — the inward bridge

**Premise half-refuted, and the correction is the useful part.** There is no
*Hicasso-owned* inward door, and a Reagent view in head position is
`:rf.error/hicasso-bad-head` (`impl/codec` HD-016; `impl/error/fail!` throws with
`:recovery :no-recovery`, so it is a throw and not a diagnostic). But a crossing
does exist: `r/reactify-component` plus the raw `[:>]` escape — which is what
this repository's own `hm/shadow!` reference mount and MIG-22 in the migration
skill both use, and what the chapter 20 that merged today already relies on for
its shadow-comparison `:reference`.

Outward is confirmed real and this change does not restate it: `h/as-component`
and `h/as-element`, with `foreign_root_bridge_dom_cljs_test` driving five
mounting routes including a Reagent parent through both doors.

Chapter 00's "the two subtrees resolve one frame" now says which crossing it is
about. The frame context genuinely is shared — `impl.mount/provider` writes
`re-frame.adapter.context/frame-context` and `impl.collector/resolve-frame!`
reads it — but that is what a *component* crossing reads, not permission to
interleave markup. The practical boundary is a root.

## rf2-ktit — no error boundary in the boot recipes

**Premise holds; the bead's remedy does not, and the page it collides with is
chapter 17.** Every Hicasso refusal is a throw, and React unmounts an uncaught
root, so a refused head does blank the page. But 17 §*Place boundaries at useful
recovery regions* argues **against** a root boundary in as many words — "a single
boundary around the root turns every failure into a whole-page fallback and may
remove navigation along with the broken content" — and names the region it wants
instead: "a route's main content while the surrounding shell remains usable".

That region is chapter 07's routed root, which did not have one. The boundary is
placed inside `<main>`, below `site-nav`, exactly where 17 asks. It needs no
`:reset-key`: the `:key route` already on `<main>` remounts the subtree on a
route change, which the chapter's own prose already says. Chapter 00 gets the
one-line pointer the bead asked for.

## rf2-g1gt — relative asset paths under a nested route

**Premise holds.** Browser behaviour, not Hicasso: relative URLs resolve against
the document URL, and under the default history strategy the document URL is the
route. Verified rather than asserted, with `new URL()` over four cases —
`_shared/css/style.css` on `/` gives `/_shared/css/style.css`, and on
`/issues/srv-1` gives `/issues/_shared/css/style.css`. The failure is silent
because the script tag is usually absolute. An admonition in *Deep links, Back,
and Forward* names the mechanism and both fixes, and a troubleshooting row
catches the symptom.

## Gates

Captured exit codes, each redirected and echoed on one command line, quoted from
the file — all three re-run on the final post-rebase base.

| Gate | Exit | Note |
| --- | --- | --- |
| `implementation/hicasso/scripts/check_guide_samples.py` | `0` | 74 verbs at 388 sites across 29 pages. `--self-test` exit `0`. |
| `scripts/check_doc_slugs.py` | `0` | Silent. |
| `python -m mkdocs build --strict` | `0` | 0 WARNINGs; the pre-build hook staged `spec/` and `migration/`. |

Each gate was proved to be reading this branch by a planted fault, since none of
them prints a root:

- **Guide samples** — a phantom `h/phantom-verb-hicboot-a` in the new chapter 00
  sample: exit `1`, *"named at 00-installation.md block 12, defined nowhere in
  re-frame.hicasso"*. The block it names exists only in this branch. A clean run
  on the pre-edit files read 378 sites against 388 after, so the instrument moves
  in both directions.
- **Doc slugs** — a broken file target and a broken anchor on one planted line:
  exit `1`, both reported with file, line and target.
- **mkdocs strict** — the same planted line: exit `1`, *"Aborted with 1 warnings
  in strict mode"* on the file target, with the anchor graded INFO and therefore
  invisible to `--strict`, which is why the two gates are complementary here.

Every plant was made from a committed tree and restored with `git checkout HEAD
--`, verified by git blob hash rather than by diff: `00-installation.md` back to
`131d2ad990e2f6b64a10d92e570dd9014d15e61c` and `07-routing-and-navigation.md`
back to `943733af191fc03f757dd81e6b29aa6dd459ba2f`, both blob hashes, with
`git status` clean afterwards.

## Verified by hand, because nothing gates it

- **Table column counts** — every markdown table row in the three files parsed
  and compared against its header, backtick-aware. No mismatches.
- **Rendering** — the new admonition emits `class="admonition warning"` in the
  built site, and the two new headings emit exactly the ids the new cross-links
  use, `#boot-a-routed-application` and `#a-frame-that-needs-more-than-a-seed`.
- **No revert of a sibling's work** — `git diff origin/main...HEAD` read for
  deletions: three lines of the rewritten sentence and four lines of the
  re-indented `case` form, nothing else. Chapter 20 merged mid-flight and is
  untouched here; its shadow-comparison section and the new chapter 00 paragraph
  agree on the head-position refusal.

## Not fixed here, for the mayor

`examples/capabilities/routing/routing/index.html` carries
`href="_shared/css/style.css"` beside an `/articles/:id` route, so it is latently
the rf2-g1gt bug in the repository's own routing example. Left alone: examples
are outside this dispatch's fence.
