### PR TITLE
docs(hicasso): chapter 20's scriptless shadow! contract, and the census's second roster (rf2-qwsw, rf2-onfy, rf2-o80n)

### DIFF
--- a/docs/core/hicasso/20-migration-from-reagent.md
+++ b/docs/core/hicasso/20-migration-from-reagent.md
@@ -384,8 +384,23 @@ a single happy click.
 Add a sabotage control before trusting the comparator: deliberately change a
 candidate prop and confirm the run turns red at the expected checkpoint.
 
-Omit `:script` for interactive development. Both mounts remain live and each
-committed render becomes a checkpoint as you use the screen manually.
+Omit `:script` for interactive development. Both mounts stay live and the call
+answers a handle rather than a verdict. **No checkpoint is taken
+automatically.** A reading per committed render is not built, because the
+runtime publishes no commit callback, so nothing is compared until you ask for
+it. Retain the handle, drive both mounts by hand, call `:checkpoint!` at each
+point you want compared, and `:stop!` when you are finished.
+
+```clojure
+(let [s (hm/shadow! {:reference [:> old-article-row {:id 7}]
+                     :candidate [new/article-row {:id 7}]})]
+  ;; drive the page by hand, then take a reading
+  ((:checkpoint! s))   ;; => {:status :green :checkpoints 1}
+  ((:stop! s)))
+```
+
+Each `:checkpoint!` call settles both mounts, compares them, and numbers the
+reading; `:stop!` takes both mounts down.
 
 Shadow comparison covers canonical DOM and intent streams. It does not prove
 focus, caret, IME, layout, or paint behaviour. Use the browser levels from

--- a/docs/core/hicasso/20-migration-from-reagent.md
+++ b/docs/core/hicasso/20-migration-from-reagent.md
@@ -9,8 +9,8 @@ it still uses re-frame v1 shapes, complete that migration first.
 Use three migration tools in this order:
 
 1. **Reporter** — classify every foreign React crossing, and census every
-   Reagent API call site, as mechanical rewrites, human decisions, and runtime
-   blockers.
+   rostered view-substrate API call site, as mechanical rewrites, human
+   decisions, and runtime blockers.
 2. **Shadow comparison** — run the Reagent original and Hicasso port side by
    side and compare canonical DOM and intent streams.
 3. **Codemod** — apply only source transformations whose behaviour is
@@ -30,6 +30,11 @@ cd re-frame2/migration/reagent-to-hicasso/codemod
 clojure -M:run path/to/your/src/
 clojure -M:run --report out.edn src/
 ```
+
+Every run writes one EDN report, a scan that changes no source included.
+Without `--report` it goes to `reagent-to-hicasso-report.edn` beside the first
+path scanned — point the tool at `<repo>/src/` and the report lands at
+`<repo>/` — and the run prints the absolute path it used.
 
 Reagent converted props crossing through `[:>]`. Among other behaviours, it
 camel-cased nested keys, converted keyword values to names, wrapped
@@ -72,11 +77,19 @@ because the corpus crosses into React nowhere. A migrator reading only that
 sees 88 files the report never mentions.
 
 So the same run also emits a **census**, under `:census`, whose population is
-the Reagent API **call site**: `r/atom`, `r/with-let`, `r/create-class`,
+the view-substrate API **call site**: `r/atom`, `r/with-let`, `r/create-class`,
 `r/as-element`, `r/cursor`, `r/reactify-component`, root mounting, and the rest
-of the roster. On that same corpus it reports **59 sites across 28 files**.
+of the two rosters. On that same corpus it reports **59 sites across 28 files**.
 Both figures are measurements of a corpus that keeps growing; these were taken
 at `e337a1d`.
+
+There are two rosters, because a re-frame2 application on the Reagent adapter
+calls no Reagent API of its own and a Reagent-only census scored it at zero.
+The first is Reagent's API — stock Reagent's namespaces, and the `reagent2.*`
+ones the reagent-slim adapter ships. The second is re-frame2's own substrate
+adapters: everything under `re-frame.adapter.`, matched as a prefix anchored at
+the start of the namespace, because the adapter set is open and a list of
+today's adapters goes stale into the same silent zero tomorrow.
 
 A **call site is source that runs**. `#_(r/atom 0)`, `'(r/atom 0)` and
 `(comment (r/atom 0))` parse into the same nodes a live call does, and the
@@ -86,14 +99,14 @@ pruned: a macro's template emits real call sites at every expansion.
 | Half | Population | Addressed at | Verdicts |
 | --- | --- | --- | --- |
 | fixer (`:entries`) | `[:>]`-family crossing sites | the site | rewrote, or refused in the classes above |
-| census (`:census`) | Reagent API call sites | the call | `:mechanical`, `:human-decision`, `:runtime-blocker` |
+| census (`:census`) | view-substrate API call sites | the call | `:mechanical`, `:human-decision`, `:runtime-blocker` |
 
 The two halves measure different things and neither is a denominator for the
-other. Every census class is a shape §2's translation table already teaches:
+other. Most census classes are a shape §2's translation tables already teach:
 
 | Verdict | Named classes | Meaning |
 | --- | --- | --- |
-| Human decision | `:with-let`, `:outward-bridge`, `:adapt-react-class`, `:react-create-element`, `:props-helper`, `:reagent-partial`, `:render-control`, `:root-mount` | A Hicasso translation exists, but which one depends on intent the source does not carry |
+| Human decision | `:with-let`, `:outward-bridge`, `:adapt-react-class`, `:react-create-element`, `:props-helper`, `:reagent-partial`, `:render-control`, `:root-mount`, `:substrate-read-hook`, `:substrate-view-seam`, `:substrate-test-seam` | A Hicasso translation exists, but which one depends on intent the source does not carry |
 | Runtime blocker | `:local-reactive-cell`, `:derived-cell`, `:lifecycle-class`, `:as-element`, `:component-introspection` | Hicasso has no equivalent tier, so the site raises or silently misrenders until someone chooses the shape |
 | Mechanical | none | The bucket is always emitted, at `:mechanical 0`. Every mechanical rewrite this tool family knows is a W-rule and every W-rule sits at a crossing, so the zero is a measurement rather than an omission |
 
@@ -136,9 +149,11 @@ it is the easier of the two ports: the reads and the dispatches are already
 data, and only the spellings move.
 
 §1's "absence from the report is meaningful" is a statement about the
-populations the report counts, both of which are Reagent's own API. Where your
-views are `reg-view` forms, a screen the report never mentions can still be a
-screen to port. Count your own `reg-view` forms and work the second table.
+populations the report counts. The census reads re-frame2's own
+`re-frame.adapter.` surface as well as Reagent's, but `rf/reg-view` is
+re-frame.core's and sits on neither roster, so a screen written entirely in
+`reg-view` forms can still go unmentioned. Count your own `reg-view` forms and
+work the second table.
 
 ### The half-migrated tree
 

--- a/skills/reagent-migration/SKILL.md
+++ b/skills/reagent-migration/SKILL.md
@@ -65,7 +65,7 @@ So rewriting views into Hicasso is a **separate, optional second step, and it is
 
 ## Start with the reporter — it is a real tool and it runs first
 
-Unlike the view rewrite, the **prop-dialect fixer and the Reagent API census are automated**, and they run before you touch anything:
+Unlike the view rewrite, the **prop-dialect fixer and the view-substrate API census are automated**, and they run before you touch anything:
 
 ```bash
 cd re-frame2/migration/reagent-to-hicasso/codemod
@@ -75,7 +75,7 @@ clojure -M:run path/to/consumer/src/          # scan: report only, touch nothing
 It reads source text on a bare JVM, loads no re-frame2, and writes a deterministic EDN report with two halves that answer different questions:
 
 - **The fixer** (`:entries`) — every `[:> …]`-family crossing into React. Reagent converted the prop dialect at those sites and Hicasso does not, so a crossing can keep rendering while sending different values. Six rewrite families (W1–W6) are decidable from source text; everything else is a named refusal with a recovery sentence.
-- **The census** (`:census`) — every Reagent API **call site**: `r/atom`, `r/with-let`, `r/create-class`, `r/cursor`, `r/as-element`, `r/reactify-component`, root mounting. This is the inventory that tells you how big the job actually is, and it is the half a `[:>]`-only report leaves invisible.
+- **The census** (`:census`) — every rostered view-substrate API **call site**, across two rosters: Reagent's API (`r/atom`, `r/with-let`, `r/create-class`, `r/cursor`, `r/as-element`, `r/reactify-component`, root mounting, and the `reagent2.*` namespaces the reagent-slim adapter ships), and re-frame2's own substrate adapters under `re-frame.adapter.`. The second roster exists because a re-frame2 application on the Reagent adapter calls no Reagent API of its own, and a Reagent-only census scored it at zero. This is the inventory that tells you how big the job actually is, and it is the half a `[:>]`-only report leaves invisible.
 
 Read the report first. It is exhaustive over what it touched or refused and carries a count of sites left alone, so *"not in the report"* is unambiguous. Its `h/defhost` sketches list the callback positions a site uses, and the usual case needs no `:callbacks` at all — Hicasso infers the contract from the spelling. The one thing to check against the library's own documentation is each `on*`-named prop: a render prop the vendor named `on*` (Fluent's `onRenderCell`, Ant's `onRow`) would infer `:event`, whose wrapper returns `nil` and blanks the UI, so that prop gets a `{:callbacks {… :render}}` override on the host.
 

--- a/skills/reagent-migration/references/procedure.md
+++ b/skills/reagent-migration/references/procedure.md
@@ -39,8 +39,11 @@ no re-frame2 loaded, no files touched.
 
 - **The census (`:census`)** tells you how big the job is — every `r/atom`,
   `r/with-let`, `r/create-class`, `r/cursor`, `r/as-element`,
-  `r/reactify-component` and root mount, classified `:human-decision` or
-  `:runtime-blocker`. Map each class onto a MIG rule and you have the D/R
+  `r/reactify-component` and root mount, plus re-frame2's own substrate
+  adapters under `re-frame.adapter.`, classified `:human-decision` or
+  `:runtime-blocker`. Two rosters, because a re-frame2 application on the
+  Reagent adapter calls no Reagent API of its own and a Reagent-only census
+  scored it at zero. Map each class onto a MIG rule and you have the D/R
   gating for the whole codebase before you open a file.
 - **The fixer (`:entries`)** covers only `[:> …]`-family crossings into React.
   A codebase that crosses into React nowhere gets **zero** entries — which is


### PR DESCRIPTION
Three chapter-20 corrections, all downstream of PRs #9131 and #9132 (both merged).

## rf2-qwsw — the scriptless `hm/shadow!` claim was false

The chapter said that omitting `:script` makes each committed render a
checkpoint. `hm/shadow!`'s own public docstring says the opposite, in bold: **a
checkpoint per committed render is NOT built**, because the runtime publishes
no commit callback. Scriptless `shadow!` answers
`{:status :live :reference … :candidate … :checkpoint! f :stop! f}` and the
caller decides when a reading is taken. The implementation comment beside the
scriptless branch repeats it.

As written, an interactive migrator could drive both mounts believing
comparisons were being recorded when none were — a correctness gap in the very
step #9131 set out to make executable.

Replaced with the real contract: retain the handle, drive both mounts, call
`:checkpoint!` at each comparison point, `:stop!` when finished. A short sample
shows the shape, because the handle's members are invoked *through* the map
(`((:checkpoint! s))`), which is easy to get wrong from prose alone.

## rf2-onfy — the census's prose surfaces still described one roster

#9132 widened the census from one roster to two. Three surfaces outside that
PR's fence still described the Reagent-only population, each understating what
the tool reports — which is the point of the widening, since a re-frame2
application on the Reagent adapter is invisible to a Reagent-only census:

- chapter 20 — the intro's tool list, the census section, and the
  `Half | Population | …` table row;
- `skills/reagent-migration/SKILL.md`;
- `skills/reagent-migration/references/procedure.md`.

Chapter 20 also gains the three new human-decision classes the census can now
emit (`:substrate-read-hook`, `:substrate-view-seam`, `:substrate-test-seam`),
and a sentence on where the bare form writes its report (beside the first path
scanned, absolute path printed — rf2-mckf).

Two things deliberately left alone, per the bead: `:files-with-reagent` keeps
its exact old meaning, because it answers whether a Reagent *coordinate* may be
dropped; and the census's `:mechanical 0` remains a finding rather than an
omission.

Two details corrected against the source rather than taken from the bead:

- **Only the substrate roster is a prefix rule.** Reagent's roster is exact
  membership of a set of eight namespaces, so the docs do not claim a
  `reagent.` prefix. `re-frame.adapter.` is the anchored prefix.
- The estimand string is written into the EDN report only; it is never printed
  to stdout, so no prose here claims the tool prints it.

## rf2-o80n — already fixed at tip; no change made

The bead asks for a `[rf/route-link …]` (head) → `(h/route-link …)` (call) row
in §2. **That row already exists**, added by #9131 itself, in §2's second table
(the re-frame2-on-the-Reagent-adapter table, which is where a framework surface
belongs rather than the Reagent-API table). The pilot that found the gap read at
a pin predating #9131's merge. Verified the spelling at source: `h/route-link`
is a plain function, and the API reference already says "Called, not written as
a head". Nothing to do.

## Verification

Gates run, each exit code captured from the runner itself:

| Gate | Exit |
| --- | --- |
| `python scripts/check_doc_slugs.py` | 0 |
| `python hicasso/scripts/check_guide_samples.py --self-test` | 0 |
| `python hicasso/scripts/check_guide_samples.py` | 0 |
| `python -m mkdocs build --strict` | 0 |

`check_guide_samples.py` reads inside Clojure fences and resolved 74 distinct
hicasso verbs at 384 sites across 29 pages, so the new sample is gated. All
gates were re-run after rebasing onto the current trunk.

**Planted-fault control.** `check_doc_slugs.py` prints nothing on success, so
its colour was proved rather than assumed: a broken anchor planted on a line
this PR edits turned it red (exit 1) naming that file, line and anchor. The
fault existed only in this branch's checkout, so a run reading any other tree
would have come back green. Restore confirmed by comparing the working file's
blob hash against the committed object — identical — rather than by reading a
diff.

**By hand, since nothing validates prose, tables or rendering.** Table column
counts checked against each header: the `Half | Population | Addressed at |
Verdicts` table is 4 columns including the edited census row; the
`Verdict | Named classes | Meaning` table is 3 columns including the edited
human-decision row; §2's two translation tables are 2 columns throughout, and
the route-link row matches. No headings were changed, so no in-page anchor
moved.
