### PR TITLE
docs(hicasso): correct the entity-key scope, choose a list spelling, make ch16's diagnostics route startable

### DIFF
--- a/docs/core/hicasso/02-views-and-reads.md
+++ b/docs/core/hicasso/02-views-and-reads.md
@@ -91,8 +91,8 @@ inline helper because it was called with function syntax.
 
 Every member of a sequence of children needs a key. Put `:key` in that child's
 props map. Hicasso does not read Reagent-style `^{:key id}` metadata, and `for`
-does not invent a key. Missing keys produce React's own development warning;
-a key that is a map or other entity value produces
+does not invent a key. Missing keys produce React's own development warning; a
+map or other entity value at the `:key` of a view-boundary child produces
 `:rf.warning/hicasso-entity-key`, naming the child.
 
 This page owns the spelling. [Lists and collections](06-lists-and-collections.md)

--- a/docs/core/hicasso/06-lists-and-collections.md
+++ b/docs/core/hicasso/06-lists-and-collections.md
@@ -31,26 +31,77 @@ With domain ids, existing rows retain their identity and equal-props bail-outs
 can skip their bodies.
 
 !!! warning "Do not key by index or by the complete entity"
-    An index changes meaning after insertion or reorder. A complete entity
-    changes when the entity is edited; React also coerces non-primitive keys,
-    which can remount or collide. Hicasso reports
-    `:rf.warning/hicasso-entity-key` and identifies the child.
+    An index changes meaning after insertion or reorder.
+
+    A complete entity changes when the entity is edited. React coerces every
+    key to a string, so keying by the entity keys the child by its *content*:
+    edit the entity and the child silently remounts, losing focus, scroll
+    position, and any presence retention. That hazard applies to every
+    non-primitive key.
+
+    A foreign JS object is the sharper case, because every one of them coerces
+    to the same `[object Object]` — distinct children collapse onto one key and
+    React reconciles them as the same child. A ClojureScript collection coerces
+    to its own printed form, so it stays distinct per value; remounting, not
+    collision, is what bites there.
 
     Strings, numbers, keywords, UUIDs, and symbols are valid keys.
     Collections, JS objects, dates, booleans, and functions are not.
 
 Missing keys produce React's own warning in development; Hicasso adds nothing
-to it. The entity-key warning names the child head and the first offending
-index, and it fires per call site rather than relying on React's page-lifetime
-deduplication.
+to it.
 
-It also runs where React never looks: a sequence passed as a Hicasso view's
-children is flattened before reaching React, and the flattened elements already
-appear validated to it. The check disappears from production.
+Hicasso's own entity-key warning is narrower than the rule above, and it is
+worth knowing what it does and does not cover.
+`:rf.warning/hicasso-entity-key` fires for a member of a **sequence** whose head
+is a **view boundary** — an `h/defview` head, as in `[order-row {:key …}]` —
+and whose key is none of string, number, keyword, UUID, or symbol. It names the
+child head, the shape it found at `:key`, and the first offending index; the key
+value itself never reaches the console, so a cyclic or throwing value cannot
+break the diagnostic. It fires once per site rather than relying on React's
+page-lifetime deduplication, and it disappears from production.
+
+It does not fire for a native tag. `[:li {:key {:id id}} …]` inside a `for` is
+the same mistake and passes in silence, because Hicasso reads `:key` off a
+native tag without classifying it. Treat the rule above as the standard, not the
+warning as complete cover.
+
+The warning does, however, run where React never looks: a sequence passed as a
+Hicasso view's children is flattened before reaching React, and the flattened
+elements already appear validated to it.
 
 ??? info "For readers coming from Reagent"
     Hicasso does not read `^{:key id}` metadata. Use
     `[order-row {:key id :id id}]`.
+
+## Write the sequence in child position
+
+A `for` that produces a view's children has two spellings, and they put the same
+elements on the page:
+
+```clojure
+;; Prefer this: the sequence sits in child position.
+[:ul.orders
+ (for [id ids]
+   [order-row {:key id :id id}])]
+
+;; This splices the sequence away before Hicasso sees it.
+(into [:ul.orders]
+      (for [id ids]
+        [order-row {:key id :id id}]))
+```
+
+Prefer the first. A sequence in child position is spliced by Hicasso itself, and
+that splice is the only place the entity-key check runs: Hicasso walks the
+sequence's members and classifies each `:key` on the way past. `into` produces
+an ordinary vector of children before Hicasso is involved, so no sequence
+survives for it to walk and the check cannot run. The same applies to React's
+missing-key warning, because spliced children arrive as direct arguments, which
+React treats as already validated.
+
+So the two spellings render alike and diagnose differently. Reach for `into`
+when you are genuinely assembling one children vector out of several pieces —
+just know that the keyed members inside it are no longer inspected by anything.
 
 ## Choose where rows read
 

--- a/docs/core/hicasso/16-diagnostics.md
+++ b/docs/core/hicasso/16-diagnostics.md
@@ -9,9 +9,8 @@ is removed from production builds.
 
 ## Diagnose an interaction
 
-1. Load Xray through the development preload. [Xray's installation
-   chapter](../../xray/01-installation.md) carries the dependency coordinate,
-   the host element, and the preload namespace.
+1. Load Xray through the development preload. [The coordinate, the host
+   element, and the preload namespace](#load-xray) are below.
 2. Reproduce the click, keystroke, or update.
 3. Open Xray's **Hicasso** tab and select the view occurrence that ran.
 4. Read its cause, fan-out, and attribution.
@@ -26,6 +25,51 @@ what to change.
 
 An **epoch** is one event pipeline run, from dispatch through its state commit.
 Xray organises its evidence around epochs.
+
+### Load Xray
+
+Xray is a tool, not application code: the dependency belongs in a dev alias, and
+the preload belongs in the dev build, never in a release build.
+
+While re-frame2 is pre-alpha the dependency is a checkout-local one, resolved
+relative to your own `deps.edn`. It becomes an ordinary Maven coordinate once
+Xray is published.
+
+```clojure
+;; deps.edn
+{:aliases
+ {:dev
+  {:extra-deps
+   {day8/re-frame2-xray {:local/root "../re-frame2/tools/xray"}}}}}
+```
+
+The preload namespace is `day8.re-frame2-xray.preload`:
+
+```clojure
+;; shadow-cljs.edn
+{:builds
+ {:app
+  {:devtools
+   {:preloads [day8.re-frame2-xray.preload]}}}}
+```
+
+Xray renders into a host element your page reserves, marked
+`data-rf-xray-host`:
+
+```html
+<div class="app-shell">
+  <main id="app"></main>
+  <aside data-rf-xray-host></aside>
+</div>
+```
+
+That is the whole setup. The preload registers the collectors, installs the
+browser API, and opens Xray into the host once the substrate adapter is ready,
+so you do not call `init!` yourself. `Ctrl+Shift+C` hides and shows the panel.
+
+[Xray's installation chapter](../../xray/01-installation.md) is the reference
+for the rest: styling the host, choosing a different selector, jump-to-source
+editor configuration, popping out to a second window, and production posture.
 
 ## Why did this view run?
 
@@ -161,7 +205,7 @@ Examples from the guide:
 | `:rf.error/hicasso-intent-outside-boundary` | An event intent reached a position with no frame | Keep it under a view boundary; use `h/event` at a foreign callback edge |
 | `:rf.error/hicasso-host-unclaimed-callback` | `h/event` was passed to a host prop declared a ReactNode slot | Write markup there, or take the prop out of `:slots` |
 | `:rf.error/hicasso-revision-not-controlled` | `::h/revision` appeared on a non-controlled field | Control the text field or remove the revision |
-| `:rf.warning/hicasso-entity-key` | A sequence child's `:key` is a map, collection, date or other entity value React would coerce by content | Key on a stable primitive identifier |
+| `:rf.warning/hicasso-entity-key` | A boundary-headed sequence child's `:key` is a map, collection, date or other entity value React would coerce by content | Key on a stable primitive identifier |
 | `:rf.error/frame-destroyed` | An operation captured from a destroyed frame incarnation fired later | Drop the stale handle and capture from the current frame |
 
 Follow the named recovery before changing unrelated code.

--- a/docs/core/hicasso/cookbook.md
+++ b/docs/core/hicasso/cookbook.md
@@ -220,6 +220,88 @@ route entry, an explicit cancel and a successful save reply each need to say so:
 
 Chapter: [Forms](05-forms.md).
 
+## A reusable control the caller parameterises
+
+A pager, a tab strip, a sort header: one control, several screens, and each
+screen decides where its own selection lands. In Reagent that prop was a
+one-argument closure. Here it is an **intent prefix** — the caller passes the
+event vector short of its last argument, and the control appends the argument it
+owns.
+
+`forms/buffered-field` above is this contract already: `:on-commit` arrives as
+`[::events/title-committed id]` and is dispatched as
+`[::events/title-committed 7 "Buy oat milk"]`. Write your own controls the same
+way.
+
+```clojure
+(ns my.app.views
+  (:require [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [my.app.subs :as subs]))
+
+(h/defview pager
+  "Page numbers. `:on-select` is an intent PREFIX; this control appends the
+   page that was clicked."
+  [{:keys [page page-count on-select]}]
+  [:nav.pager {:aria-label "Pagination"}
+   (for [n (range 1 (inc page-count))]
+     [:button.page
+      {:key           n
+       :type          "button"
+       :aria-current  (when (= n page) "page")
+       :disabled      (= n page)
+       :on-click      (conj on-select n)}
+      n])])
+```
+
+Each caller supplies its own prefix, carrying whatever arguments it needs:
+
+```clojure
+(h/defview home-feed [_]
+  [pager {:page       (h/sub [::subs/home-page])
+          :page-count (h/sub [::subs/home-page-count])
+          :on-select  [:home/show-page]}])
+
+(h/defview profile-feed [{:keys [username]}]
+  [pager {:page       (h/sub [::subs/profile-page username])
+          :page-count (h/sub [::subs/profile-page-count username])
+          :on-select  [:profile/show-page username]}])
+```
+
+Clicking page 3 dispatches `[:home/show-page 3]` from one and
+`[:profile/show-page "alice" 3]` from the other. The control never learns which.
+
+**Append in the body when the argument is a render-time fact**, as above: the
+page number is known when the button is written, so `conj` there and the prop is
+an ordinary intent vector.
+
+**Append in the handler when the argument is only known when the event fires.**
+Pass the prefix through as an argument and let the handler finish it:
+
+```clojure
+(rf/reg-event :combo/committed
+  (fn [{:keys [db]} [_ id on-select]]
+    (let [active (get-in db [:ui :combo id :active])]
+      {:db (assoc-in db [:ui :combo id :open?] false)
+       :fx [[:dispatch (conj on-select active)]]})))
+```
+
+**When the argument is the DOM value**, no `conj` is needed at all — the
+substitution markers are the argument: `(conj on-search ::h/value)` dispatches
+the prefix with the field's value appended at dispatch time.
+
+**Why a prefix rather than a function prop.** A vector compares by value, so an
+unchanged `:on-select` is `=` to last render's and the child keeps its
+equal-props bail-out. A fresh `#(rf/dispatch [:home/show-page %])` is a new
+object on every parent render and defeats that bail-out permanently. It is also
+the wrong door: the browser invokes it after the rendering extent has gone, so
+its ambient `rf/dispatch` raises `:rf.error/no-frame-context`. Reach for
+`h/event` only when the callback's own arguments matter — geometry, a foreign
+SDK's payload — rather than for parameterisation, which this shape covers.
+
+Chapters: [Events as data](03-events-as-data.md), [Views and
+reads](02-views-and-reads.md).
+
 ## Fetch, show progress, and keep the last good answer
 
 A panel that paints `nil` while a request for new data is out blanks itself on


### PR DESCRIPTION
Four findings from the pre-pilot rehearsal, all in the published Hicasso guide.
Prose only — no framework surface was added or changed.

Beads: rf2-bx4t, rf2-t601, rf2-cngt, rf2-qi4v.

## rf2-bx4t — the entity-key warning: the premise did not hold, and the remedy is prose

The bead's title says the warning "is never raised at any tier — Hicasso `pr-str`s
the key, so the hazard does not arise". Checked at source, **both halves are wrong**,
and the warning is alive:

- `implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs` defines
  `warn-entity-key!`, emitting `:rf.warning/hicasso-entity-key`. It has direct test
  coverage in `implementation/hicasso/test/re_frame/hicasso/codec_cljs_test.cljs`.
- Hicasso does **not** `pr-str` the key. Every emission path does
  `(unchecked-set js-props "key" k)` — the value goes to React verbatim, and React's
  own `'' + config.key` does the coercion. For a ClojureScript map that reaches CLJS's
  `toString`, which is the printed form the pilot observed. For a **foreign JS object**
  the same coercion yields `[object Object]` for every one, and distinct children
  genuinely do collide — pinned by the test
  `a-foreign-object-key-collapses-distinct-children-onto-one-key`.

Why nothing fired for the pilot: `check-member-key!` gates on `(boundary-head? h)`.
The induced fault was `[:a.tag-pill {:key {:tag tag}} …]` — a native tag, not a marked
`h/defview` boundary — so the check correctly declined. `uuid` and `symbol` keys are
also deliberately classified safe, to avoid the false positive on `{:key (:id entity)}`.

So the warning is neither dead nor misfiring; the **guide overstated its scope**, and
correcting the guide is the smaller true thing. `implementation/hicasso/**` is untouched.

- **ch06** — the warning box now separates the two hazards: remount-on-edit applies to
  every non-primitive key, collision is the foreign-JS-object case, and a CLJS
  collection stays distinct per value. A following paragraph gives the check's real
  scope (boundary-headed sequence member, key not string/number/keyword/UUID/symbol)
  and names the native-tag case it does **not** cover, so the warning is not read as
  complete cover.
- **ch16** — the complaint-table row now says "A boundary-headed sequence child's `:key` …".
- **ch02** — the same one-clause overstatement, narrowed to a view-boundary child.

## rf2-cngt — chapter 06 now chooses a spelling

The two forms render alike but diagnose differently, and that is verifiable:
`as-element` routes a seq to `expand-seq`, which runs `check-member-key!` over every
member; a vector child goes to `vec->element`, where nothing walks members. `into`
splices the sequence away before Hicasso sees one, so the entity-key check cannot run
— and spliced children arrive as direct arguments, which React treats as already
validated. New section "Write the sequence in child position" prefers the sequence
form and says why, with one line on when `into` is still the right call.

## rf2-t601 — chapter 16's headline route is now startable from inside the guide

Step 1 delegated the dependency coordinate, host element and preload namespace to
`docs/xray/01-installation.md`, leaving the whole first half of the chapter
unreachable for a reader inside the Hicasso corpus. A new `### Load Xray` subsection
carries exactly those three facts (dev-alias coordinate, `data-rf-xray-host`,
`day8.re-frame2-xray.preload`) plus the one line that says the preload opens Xray
itself. Step 1 now links to it in-page. The installation chapter stays linked as the
reference for styling, selector overrides, jump-to-source, pop-out and production
posture — this is not an Xray install manual.

## rf2-qi4v — cookbook recipe for a caller-parameterised control

New recipe, "A reusable control the caller parameterises", placed after the
`buffered-field` recipe because that recipe already shows the contract from the
caller's side (`:on-commit` arriving as a prefix and dispatched with the draft
appended).

The idiom was verified as shipped framework contract rather than invented:
`forms/buffered-field` dispatches `(conj on-commit candidate)`, the error boundary
accepts a vector `:on-error` and dispatches `(conj on-error error)`, and ch13's combo
passes the prefix through to its handler. The recipe teaches both arms — `conj` in the
body when the argument is a render-time fact (pagination), `conj` in the handler when
it is only known at event time — plus the `::h/value` case, and why a vector prefix
keeps the equal-props bail-out that a fresh closure defeats.

## Gates

Run from the worker worktree; each exit code captured in the same shell as the run and
quoted from that capture.

| Gate | Exit |
| --- | --- |
| `python hicasso/scripts/check_guide_samples.py --self-test` | 0 ("the rule fires") |
| `python hicasso/scripts/check_guide_samples.py` | 0 — 74 verbs at 390 sites across 29 pages resolve |
| `python scripts/check_doc_slugs.py` | 0 |
| `python -m mkdocs build --strict` | 0 |

All four re-run on the final rebased base, after the rebase onto `origin/main`.

`check_readme_links.py` and `check_provenance_pins.py` are not this diff's gates —
no repo-root or beside-source markdown is touched, and `docs/design/hicasso/` is a
different tree from the published guide.

### Planted-fault controls

Each gate was proven to be reading this branch's tree, since none of these faults
exist anywhere else. Blob hashes were taken before each plant and re-checked after
restore; both files returned to their exact pre-plant blobs, and the match count was
read before every plant (1 each).

- `check_doc_slugs.py` — broke the new in-page anchor: **exit 1**, naming
  `16-diagnostics.md:13 -> #load-xray-planted-…`. This also confirms the new
  `#load-xray` anchor resolves, since the unplanted run is green.
- `check_guide_samples.py` — renamed an `h/sub` in the new recipe: **exit 1**,
  "names a verb the package does not define … at cookbook.md block 8".
- `mkdocs build --strict` — broke the cross-tree link in the new subsection:
  **exit 1**, "Aborted with 1 warnings in strict mode!".

### By hand (nothing gates prose, tables, rendering or nav)

- **Table column counts.** Chapter 16's complaint table is the only table touched.
  Counted every row explicitly: header, separator and all eight data rows are 3
  columns, the edited `:rf.warning/hicasso-entity-key` row included. No table was
  added; chapter 06's troubleshooting table is unmodified.
- **Anchors.** The one new in-page anchor is `(#load-xray)` at line 13 against
  `### Load Xray` at line 29, same file — checked by eye and by the slug gate in both
  directions. Every other link in the diff is pre-existing and unmoved.
- Heading levels: `### Load Xray` nests correctly under `## Diagnose an interaction`.

### Scope

`git diff origin/main...HEAD` touches four files, all inside the assigned fence:
`02-views-and-reads.md`, `06-lists-and-collections.md`, `16-diagnostics.md`,
`cookbook.md`. Read against the merge base for reverts: deletions are confined to the
passages this PR rewrites. No held page, hot-zone file or tracker path is touched.

Not Section 13 evidence: the rehearsal that found these ran on `:local/root` and
discharges no artefact gate.
