### PR TITLE
docs(schemas,pair): whole-registry validation, and npm test is the pair-MCP verdict

### DIFF
--- a/docs/core/how-to/validate-with-schemas.md
+++ b/docs/core/how-to/validate-with-schemas.md
@@ -156,6 +156,31 @@ These paths address *your* data only. The framework's [runtime-db partition next
     - **A path that reaches into runtime-db is a hard error.** App-db schemas validate the [app-db](../glossary.md#app-db) partition only. Register one whose first segment is a reserved `:rf.runtime/*` key (or the retired `:rf/runtime` root) and you get `:rf.error/app-schema-runtime-path` at registration — [runtime-db](../glossary.md#runtime-db) is framework-owned, with no public schema surface; the remedy is to drop the runtime path. (See [app-db's two partitions](../app-db.md) for why the boundary is structural.)
     - **A malformed schema value fails closed at first check.** Malli validates schema *forms* lazily, so a structurally-broken schema (a childless `[:vector]`, an unknown op) registers cleanly and then throws on the first candidate validation. The runtime isolates that per-entry: a distinct `:rf.error/malformed-schema` trace, the candidate rejected (it does *not* install unvalidated state), and the frame's sibling schemas keep validating — so one bad schema can't disable validation frame-wide.
 
+## Every registered path is checked on every commit
+
+One property of that registry decides whether your app boots at all, and it's the one most people assume backwards: **validation is not scoped to the paths the committing event touched.** After a handler returns `:db`, the runtime walks *every* path registered for the frame, `get-in`s the candidate app-db at each one, and rejects the **whole** transaction if any single path fails. A handler that writes only `[:auth]` is still checked against your `[:articles]` schema, and against every other schema the frame holds.
+
+That matters because `get-in` on a path nothing has written yet returns `nil` — and `nil` is a value like any other, checked like any other. A `[:map …]` over a slice that hasn't been seeded doesn't get skipped; it *fails*. So a schema registered before its slice exists rejects every commit until the seed lands.
+
+Where that bites is the shape most apps boot in, and it's a shape this guide has already taught you twice: a bulk `reg-app-schemas` at namespace load, and a boot event that fans out per-feature `:*/initialise` events to seed the slices. Put those together and the first seed to commit is validated against every sibling that hasn't run yet, fails on their `nil`s, and is rejected. And because a rejected transition doesn't walk `:fx` either, the very dispatch that would have fanned out the remaining seeds never fires them. Nothing can ever land, app-db never leaves `{}`, and each attempt reports a failure naming a path the handler never touched.
+
+Two ways out. **Seed before you register, or seed in one commit** — have the boot write put every schema'd slice in place in a single `:db`, so there's no window in which a registered path reads `nil`. **Or wear a `:maybe` for the boot window**, which is the honest move when a slice is legitimately empty until data arrives:
+
+```clojure
+(rf/with-frame :rf/default
+  (rf/reg-app-schemas
+   {[:config] [:maybe Config]     ;; nil until the config request returns
+    [:flags]  [:maybe Flags]
+    [:user]   [:maybe User]
+    [:routes] [:maybe Routes]}))
+```
+
+That's the [boot example](../../../examples/patterns/boot/schema.cljs)'s house style: each slot starts out nil — the boot machine fills it in later — so every registration wears a `:maybe` to stay valid through the loading phases. It costs you the guarantee that the slice is *populated*, which is exactly the right trade while it legitimately isn't.
+
+!!! warning "This one is broken in dev and fine in production"
+
+    Every other bug you meet runs the other way, which is what makes this one so disorienting to walk into. The candidate validator is **dev-only** — a release build elides it entirely, so nothing consults your app-db schemas there ([In production](#in-production-what-goes-what-stays) draws the whole line). An app with this defect therefore *works* when you build it for release, and is bricked at boot the moment you go back to a dev build. A dead dev app beside a healthy release build is the signature: read it as a schema registered ahead of its data, not as a broken release pipeline.
+
 ## Put a schema on the event too
 
 App-db schemas check writes *after* the fact. The complementary move is to refuse bad input *before* it ever reaches a handler — and that's what an event schema does. `reg-event` takes an optional metadata map between the id and the handler; the `:schema` key there describes the **event vector**, positionally, with `[:cat …]`:

--- a/skills/re-frame2-pair/docs/TESTING.md
+++ b/skills/re-frame2-pair/docs/TESTING.md
@@ -2,7 +2,7 @@
 
 Three surfaces need coverage at different fidelities.
 
-> **Scope (current surface).** The **MCP server** (`tools/re-frame2-pair-mcp/`) is the only skill-facing transport — and the one implementation of every operation. It carries its own test suite under that directory (`shadow-cljs compile server-test`), including the live end-to-end fixture gate (`test/live-e2e-fixture.cjs`). The surfaces below cover the skill's **runtime preload** + **structural docs** that live in this tree. (The retired bash/babashka transport — `scripts/ops.clj`, its shell wrappers, and the `tests/shim/` + `tests/e2e/` suites that drove it — has been removed; the connect/dispatch/trace/hot-reload coverage now drives the MCP server over stdio from `tools/re-frame2-pair-mcp/test/live-e2e-fixture.cjs`.)
+> **Scope (current surface).** The **MCP server** (`tools/re-frame2-pair-mcp/`) is the only skill-facing transport — and the one implementation of every operation. It carries its own test suite under that directory — run it with `npm test` — including the live end-to-end fixture gate (`test/live-e2e-fixture.cjs`). The surfaces below cover the skill's **runtime preload** + **structural docs** that live in this tree. (The retired bash/babashka transport — `scripts/ops.clj`, its shell wrappers, and the `tests/shim/` + `tests/e2e/` suites that drove it — has been removed; the connect/dispatch/trace/hot-reload coverage now drives the MCP server over stdio from `tools/re-frame2-pair-mcp/test/live-e2e-fixture.cjs`.)
 
 The fixture app at `tests/fixture/` backs the structural pure-core surface
 and the pair-mcp live-e2e gate — a minimal Reagent + shadow-cljs build that
@@ -185,7 +185,7 @@ re-deriving the prompts.
 
 | Surface | Runs on |
 |---|---|
-| MCP server suite (`tools/re-frame2-pair-mcp/`) | The skill-facing transport's own tests — `shadow-cljs compile server-test` + the descriptor-manifest drift gate. Run under the tool's directory, not this skill's `tests/`. |
+| MCP server suite (`tools/re-frame2-pair-mcp/`) | The skill-facing transport's own tests — `npm test` + the descriptor-manifest drift gate (`npm run check:descriptors`). Run under the tool's directory, not this skill's `tests/`. `npm test` chains `shadow-cljs compile server-test` to `node out/server-test.js`; the compile is only the build/autorun phase, and **the Node run supplies the verdict** — the compile exits 0 even when the autorun printed failures. See the tool's `test/README.md`. |
 | Runtime structural tests | PR CI when `skills/re-frame2-pair/**` changes; nightly/manual expensive workflow may also run them before release. |
 | End-to-end live fixture (`tools/re-frame2-pair-mcp/test/live-e2e-fixture.cjs`) | Runnable on demand (soft-skips without a live fixture). The mcp-conformance hermetic live suite runs the equivalent stdio coverage in CI by booting the fixture itself. |
 | Prompt regression | PR CI when `skills/re-frame2-pair/**` changes. |


### PR DESCRIPTION
Two prose corrections in different documents, same failure shape: a document that
silently misleads a competent reader. No framework surface changes.

## rf2-aaam — `docs/core/how-to/validate-with-schemas.md`

The how-to taught `reg-app-schema` / `reg-app-schemas` without ever stating the one
fact needed to use them safely: **validation is not scoped to the paths the committing
event touched.** Adds a section (`## Every registered path is checked on every commit`)
covering the mechanism, the two ways out, and the dev/release inversion.

Mechanism verified at source rather than taken from the brief:

- `implementation/schemas/src/re_frame/schemas/validate.cljc` — `validate-app-schema!`
  loops `storage/frame-schema-entries` for the frame and reads each registered path with
  `(get-in db registered-path)`. An unwritten path yields `nil`, validated like any other
  value.
- `spec/010-Schemas.md` §Per-step recovery row 4 — the candidate is validated before
  install and **never installed** on failure; and `:fx` does **not** walk for that
  dispatch. That last clause is why a boot that fans seeds out across per-feature
  `:*/initialise` events never fires them at all: the first seed is rejected by its
  not-yet-seeded siblings, the fan-out never runs, and app-db never leaves `{}`.
- Elision direction confirmed (`spec/010` §Production builds, and the `debug-enabled?`
  gate as the outermost form in `validate-app-schema!`): a release build elides the
  candidate validator, so an app with this defect works in release and is dead in dev.
  That inversion is stated plainly, since a reader will assume it the other way.

The `:maybe` remedy is cited from `examples/patterns/boot/schema.cljs`, which is where
the corpus already records it — in a code comment only. No example is edited.

## rf2-rx35 — `skills/re-frame2-pair/docs/TESTING.md`

Both live sites (lines 5 and 188) presented `shadow-cljs compile server-test` as the MCP
server test suite. That compile is a fail-open: `:autorun` prints failures and the compile
still exits 0. Both now name `npm test`; the compile is labelled as the build/autorun
phase only, with the Node run named as the verdict, pointing at the tool's
`test/README.md` rather than restating the incident.

Confirmed against `tools/re-frame2-pair-mcp/package.json`:
`"test": "shadow-cljs compile server-test && node out/server-test.js"` — it ends on Node,
whose exit code is the verdict. The tool's `test/README.md` states it directly: "Only the
Node run is a verdict."

A tracked-file census (line-oriented **and** whitespace-flattened, each with a control
that fired) found the defect confined to these two lines: no other file under `skills/`
mentions `server-test` at all. Remaining hits are the build-id definition, the tool's own
correct docs, and CI job *labels* whose run lines already invoke `npm test`.

## Gates

- `scripts/check_doc_slugs.py` — captured exit **0**. Covers both files (762 markdown
  files across 11 roots, including `docs` and `skills`); it is the only link gate covering
  the skill page.
- `python -m mkdocs build --strict` — captured exit **0**. Covers the how-to only;
  `skills/` is outside `docs_dir`, so this build says nothing about that page.

Both gates are silent on success, so each was proved by a planted fault, restored
afterwards and verified by git blob hash:

- Slug gate: broken anchors planted in *both* files → exit **1**, naming both
  (`docs/...:182` and `skills/...:5`). The faults existed only in this worktree, so a run
  reading another checkout would have come back green.
- Strict build: the new cross-tree `examples/` link broken into a form
  `mkdocs_hooks.py` does not rewrite → exit **1**, naming the file and the target. This
  also confirms the real link is genuinely validated rather than silently ignored.

`scripts/check_readme_links.py --ci` is **not** this diff's gate: both files sit under
`check_doc_slugs.py`'s roots, which that gate's rosters exclude.
`scripts/check_skill_description_budget.py` does not apply — no SKILL.md description is
touched.

## Checked by hand (no gate covers it)

- **Anchors.** `#in-production-what-goes-what-stays` resolves to the `## In production:
  what goes, what stays` heading; the page's opening paragraph already links the same
  anchor. The new `##` heading's slug is unique on the page.
- **Fenced content is ungated** — both link gates strip fences before reading. The new
  fenced example deliberately contains no links; verified none present.
- **Table columns.** The CI-gating table in the skill guide is 2 cells per row across all
  six rows, the edited row included, with no stray raw pipe.

Closes rf2-aaam. Closes rf2-rx35.
