### PR TITLE
refactor(http): implementation/http speaks the canonical rf.* alias dialect (rf2-r79e)

### DIFF
--- a/implementation/http/src/re_frame/http/decode.cljc
+++ b/implementation/http/src/re_frame/http/decode.cljc
@@ -29,10 +29,10 @@
   (`http-transport/handle-response!`) classifies as
   `:rf.http/decode-failure :schema-validation-failure? true`."
   (:require [clojure.string  :as str]
-            [re-frame.error   :as error]
-            [re-frame.interop :as interop]
-            [re-frame.trace   :as trace]
-            [re-frame.http.json :as http-json]))
+            [re-frame.error   :as rf.error]
+            [re-frame.interop :as rf.interop]
+            [re-frame.trace   :as rf.trace]
+            [re-frame.http.json :as rf.http.json]))
 
 (defn content-type-of
   "Per Spec 014 §Request envelope — HTTP header names are case-insensitive.
@@ -194,9 +194,9 @@
   ;; to nil and validation is skipped — unchecked data flows to
   ;; `:accept`. Emit a `:rf.warning/http-malli-absent` so the dropped
   ;; validation is observable rather than silent.
-  (when (and interop/debug-enabled?
+  (when (and rf.interop/debug-enabled?
              (compare-and-set! malli-absent-warned? false true))
-    (trace/emit! :warning :rf.warning/http-malli-absent
+    (rf.trace/emit! :warning :rf.warning/http-malli-absent
                  {:reason (str "a `:decode` schema was supplied but malli.core is "
                                "not on the classpath; schema validation is SKIPPED "
                                "and the parsed value flows to `:accept` unchecked. "
@@ -226,7 +226,7 @@
       (warn-malli-absent! schema))
     (when validate
       (when-not (validate schema decoded)
-        (error/throw-error!
+        (rf.error/throw-error!
           :rf.error/http-schema-validation-failed 'rf.http/decode-response-body
           "the decoded response body failed Malli schema validation; the caller classifies this as :rf.http/decode-failure"
           {:extra {:schema schema
@@ -270,7 +270,7 @@
       ;; `empty-2xx-json-body?`.
       (if (empty-2xx-json-body? body-text)
         nil
-        (http-json/json-parse body-text parse-opts))
+        (rf.http.json/json-parse body-text parse-opts))
 
       (= :text resolved)
       body-text
@@ -315,7 +315,7 @@
       ;; the diagnostic names the actual problem. A nil/absent Content-
       ;; Type stays JSON-eligible (many JSON APIs omit the header).
       (if-not (json-content-type? content-type)
-        (error/throw-error!
+        (rf.error/throw-error!
           :rf.error/http-schema-non-json-content-type 'rf.http/decode-response-body
           (str "a Malli `:decode` schema was supplied but the response "
                "declared a non-JSON Content-Type (" content-type "); the "
@@ -333,5 +333,5 @@
         ;; host-symmetric outcome, not a per-host parse divergence.
         (let [parsed (if (empty-2xx-json-body? body-text)
                        nil
-                       (http-json/json-parse body-text parse-opts))]
+                       (rf.http.json/json-parse body-text parse-opts))]
           (malli-decode resolved parsed))))))

--- a/implementation/http/src/re_frame/http/encoding.cljc
+++ b/implementation/http/src/re_frame/http/encoding.cljc
@@ -23,9 +23,9 @@
   Per Spec 014 §Body encoding, §`:accept`, §Failure categories,
   §Reply addressing, §Retry and backoff."
   (:require [clojure.string  :as str]
-            [re-frame.error :as error]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.http.json :as http-json])
+            [re-frame.error :as rf.error]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.http.json :as rf.http.json])
   #?(:clj (:import [java.net URLEncoder])))
 
 ;; ---- query string + URL helpers -------------------------------------------
@@ -135,7 +135,7 @@
     [nil nil]
 
     (= request-content-type :json)
-    [(http-json/json-stringify body) "application/json"]
+    [(rf.http.json/json-stringify body) "application/json"]
 
     (= request-content-type :form)
     [(params->query body) "application/x-www-form-urlencoded"]
@@ -148,7 +148,7 @@
 
     ;; No explicit content-type — heuristics for clj colls (default to JSON).
     (or (map? body) (sequential? body) (set? body))
-    [(http-json/json-stringify body) "application/json"]
+    [(rf.http.json/json-stringify body) "application/json"]
 
     :else
     ;; pass-through (Blob / FormData / ArrayBuffer / pre-encoded string)
@@ -255,7 +255,7 @@
   as usual."
   [args frame]
   (when-let [ev (build-reply-event args)]
-    (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+    (when-let [dispatch! (rf.late-bind/get-fn :router/dispatch!)]
       (dispatch! ev (cond-> {:source :http}
                       frame                  (assoc :frame frame)
                       (:completed-at args)   (assoc :rf.cofx
@@ -298,7 +298,7 @@
       ;; addressing types the reply target as "event vector or nil". Reject it
       ;; at the dispatch site rather than swallow the misuse.
       supplied?
-      (error/throw-error!
+      (rf.error/throw-error!
         :rf.error/http-bad-reply-target :rf.http/managed
         "`:reply-to` / `:on-success` / `:on-failure` must be an event vector or nil per Spec 014 §Reply addressing; a non-vector non-nil value cannot be dispatched as an event"
         {:extra {:value value}})

--- a/implementation/http/src/re_frame/http/handlers.cljc
+++ b/implementation/http/src/re_frame/http/handlers.cljc
@@ -19,15 +19,15 @@
                               registry and fires it; the abort closure owns
                               transport cancellation and registry cleanup."
   (:require [clojure.string]
-            [re-frame.error          :as error]
-            [re-frame.frame          :as frame]
-            [re-frame.http.encoding  :as encoding]
-            [re-frame.http.middleware :as middleware]
-            [re-frame.http.privacy   :as privacy]
-            [re-frame.http.registry  :as registry]
-            [re-frame.http.reply     :as http-reply]
-            [re-frame.http.transport :as transport]
-            [re-frame.http.transport-jvm :as transport-jvm]))
+            [re-frame.error          :as rf.error]
+            [re-frame.frame          :as rf.frame]
+            [re-frame.http.encoding  :as rf.http.encoding]
+            [re-frame.http.middleware :as rf.http.middleware]
+            [re-frame.http.privacy   :as rf.http.privacy]
+            [re-frame.http.registry  :as rf.http.registry]
+            [re-frame.http.reply     :as rf.http.reply]
+            [re-frame.http.transport :as rf.http.transport]
+            [re-frame.http.transport-jvm :as rf.http.transport-jvm]))
 
 ;; ---- closed-set `:retry :on` validation ----------------------------------
 ;;
@@ -79,7 +79,7 @@
         (when (some? on)
           ;; SHAPE: `:on` must be a set when present and non-nil.
           (when-not (set? on)
-            (throw (error/thrown-ex-info
+            (throw (rf.error/thrown-ex-info
                      :rf.error/http-bad-retry-on :rf.http/managed
                      "`:retry :on` must be a SET of retryable-category keywords per Spec 014 §Closed-set `:retry :on` validation; a non-set value (keyword, vector, list, string, …) is rejected because the transport membership gate `(contains? on-set kind)` tests index membership over a sequential collection and would silently disable retry. Use `#{:rf.http/transport :rf.http/http-5xx :rf.http/timeout}`, `#{}` for no-retry, or omit `:on`"
                      {:extra {:bad-shape     on
@@ -88,7 +88,7 @@
           ;; MEMBERSHIP: every member must be a retryable category.
           (let [bad-members (into #{} (remove retryable-categories) on)]
             (when (seq bad-members)
-              (throw (error/thrown-ex-info
+              (throw (rf.error/thrown-ex-info
                        :rf.error/http-bad-retry-on :rf.http/managed
                        "`:retry :on` must be drawn exclusively from the closed retryable set #{:rf.http/transport :rf.http/cors :rf.http/timeout :rf.http/http-4xx :rf.http/http-5xx}; `:rf.http/aborted`, `:rf.http/decode-failure`, and `:rf.http/accept-failure` are non-retryable by construction"
                        {:extra {:bad-members   bad-members
@@ -116,7 +116,7 @@
   [request]
   (let [url (:url request)]
     (when-not (and (string? url) (not (clojure.string/blank? url)))
-      (throw (error/thrown-ex-info
+      (throw (rf.error/thrown-ex-info
                :rf.error/http-bad-request :rf.http/managed
                "`:request :url` is required and must be a non-blank string per Spec 014 §Request envelope; a missing / nil / blank url cannot be dispatched"
                {:extra {:url url}})))))
@@ -157,7 +157,7 @@
      belt-and-braces for any non-args-map descriptor path."
   [args-map]
   (when-not (some #(contains? args-map %) [:reply-to :on-success :on-failure])
-    (throw (error/thrown-ex-info
+    (throw (rf.error/thrown-ex-info
              :rf.error/http-no-reply-target :rf.http/managed
              "`:rf.http/managed` must address its reply — supply `:reply-to` (one target for both success and failure; the app branches on the canonical envelope's `:status`), or `:on-success` / `:on-failure` (an explicit `nil` silences a branch). The co-located default (reply merged under `:rf/reply` back to the originating event) was retired pre-alpha. Per Spec 014 §Reply addressing"
              {:extra {:args-keys (vec (keys args-map))}})))
@@ -165,7 +165,7 @@
     (when (contains? args-map k)
       (let [v (get args-map k)]
         (when-not (valid-reply-target? v)
-          (throw (error/thrown-ex-info
+          (throw (rf.error/thrown-ex-info
                    :rf.error/http-bad-reply-target :rf.http/managed
                    "`:reply-to` / `:on-success` / `:on-failure` must be an event vector or nil per Spec 014 §Reply addressing; a non-vector non-nil value (a bare keyword, map, string, …) cannot be dispatched as an event. Validated at dispatch time, before the request is issued"
                    {:extra {:key k :value v}})))))))
@@ -204,7 +204,7 @@
         ;; frame as `:frame` (the HELD stamp used for reply-to-origin
         ;; addressing). A nil stamp is an invariant failure
         ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
-        frame        (frame/require-frame-stamp!
+        frame        (rf.frame/require-frame-stamp!
                        (:frame frame-ctx) :rf.http/managed
                        {:where 'rf.http/managed :event-id (first origin-event)})
         ;; rf2-wvkn — when the originating event-id is a spawned actor's
@@ -217,14 +217,14 @@
         ;; itself; ordinary event handlers' dispatches — and every request
         ;; when the machines artefact is absent — yield nil and are not
         ;; tracked.
-        actor-id     (registry/resolve-owning-actor-id frame origin-event)
+        actor-id     (rf.http.registry/resolve-owning-actor-id frame origin-event)
         ;; rf2-bma05 — compute the effective :sensitive? flag once and
         ;; thread it through the attempt-and-retry loop. Two sources
         ;; (OR-reduced): per-call args and per-request (handler-meta
         ;; :sensitive? was removed per rf2-hjs2d). The flag rides every
         ;; :rf.http/* trace event emitted within the cascade so
         ;; consumers honour the privacy contract per Spec 009 §Privacy.
-        sensitive?   (privacy/request-sensitive? args-map)
+        sensitive?   (rf.http.privacy/request-sensitive? args-map)
         ;; rf2-wu1n5 — keyword-interning DoS guard. The reserved
         ;; `:rf.http/max-decoded-keys` arg overrides the JSON reader's
         ;; default cap on unique decoded object keys. Absent → reader
@@ -311,14 +311,14 @@
   (let [;; EP-0002 carried invariant — the fx context carries the cascade
         ;; envelope frame as `:frame`; a nil stamp is an invariant failure
         ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
-        frame-id     (frame/require-frame-stamp!
+        frame-id     (rf.frame/require-frame-stamp!
                        (:frame frame-ctx) :rf.http/managed
                        {:where 'rf.http/managed
                         :event-id (first (:event frame-ctx))})
         ;; rf2-622e3 — resolve once, thread the result through
         ;; frame-ctx's :event slot so normalise-args reads it
         ;; directly instead of re-running the OR-chain.
-        origin-event (encoding/resolve-origin-event frame-ctx args-map)
+        origin-event (rf.http.encoding/resolve-origin-event frame-ctx args-map)
         frame-ctx'   (assoc frame-ctx :event origin-event)
         ;; rf2-1jcpm — resolve :sensitive? at handler entry so the
         ;; middleware-failure trace path (URL leak via
@@ -330,13 +330,13 @@
         ;; CLJS-only-key warning and `normalise-args` run. The chain
         ;; itself recomputes per-interceptor for its own failure-path
         ;; trace (see `run-chain*` / `run-interceptor-chain!`).
-        sensitive?   (privacy/request-sensitive? args-map)
+        sensitive?   (rf.http.privacy/request-sensitive? args-map)
         ctx0         {:request    (:request args-map)
                       :args       args-map
                       :frame      frame-id
                       :event      origin-event
                       :sensitive? sensitive?}
-        ctx          (middleware/run-interceptor-chain! frame-id ctx0)
+        ctx          (rf.http.middleware/run-interceptor-chain! frame-id ctx0)
         ;; rf2-93bck — validate the required `:url` AFTER the `:before`
         ;; chain produces the final `:request` (a `:before` may legitimately
         ;; SET the url). Throws `:rf.error/http-bad-request` on a missing /
@@ -360,14 +360,14 @@
         ;; Recomputing here closes both: the warning fires on the request
         ;; the transport will actually issue, redacted by the effective
         ;; sensitivity.
-        sensitive?'  (privacy/request-sensitive? args-map')
+        sensitive?'  (rf.http.privacy/request-sensitive? args-map')
         ;; rf2-hp772l — `check-cljs-only-keys!` is JVM per-row degradation
         ;; tracing (a no-op on CLJS), owned by the JVM platform adapter.
         ;; No frame is threaded: HTTP carrier redaction is process-global
         ;; (resolved from the :rf.http/managed `:carriers` registration,
         ;; EP-0025), so the warning path never depends on the emitting
         ;; frame.
-        _            (transport-jvm/check-cljs-only-keys! args-map' sensitive?')
+        _            (rf.http.transport-jvm/check-cljs-only-keys! args-map' sensitive?')
         ;; rf2-uheqq — carry the post-:before middleware-ctx forward so
         ;; the response-side `:after` chain sees the EXACT same ctx its
         ;; sibling `:before`s ended with. Per Spec 014 §Middleware: a
@@ -387,7 +387,7 @@
         ;; attempt has one work id (EP-0007 / Managed-Effects §Work-id
         ;; correlation §184). An anonymous request (nil request-id) never
         ;; supersedes and stays at issuance 1.
-        issuance     (registry/next-issuance! request-id)
+        issuance     (rf.http.registry/next-issuance! request-id)
         normalised   (assoc normalised0 :issuance issuance)]
     ;; rf2-azcmd3 — supersession emits the SUPERSEDED attempt's canonical
     ;; `:status :stale` / `:rf.reply/work-status :suppressed` reply-envelope trace
@@ -400,14 +400,14 @@
     ;; ADDS the canonical stale reply-envelope row the old `:rf.http/aborted`
     ;; trace alone did not record.
     (when request-id
-      (when-let [superseded (registry/supersede! request-id)]
-        (transport/emit-superseded-stale-trace!
+      (when-let [superseded (rf.http.registry/supersede! request-id)]
+        (rf.http.transport/emit-superseded-stale-trace!
           superseded
-          (http-reply/work-id {:request-id   request-id
+          (rf.http.reply/work-id {:request-id   request-id
                                :origin-event origin-event
                                :issuance     issuance
                                :attempt      1}))))
-    (transport/run-attempt! normalised)
+    (rf.http.transport/run-attempt! normalised)
     nil))
 
 (defn managed-abort-handler
@@ -424,5 +424,5 @@
   teardown reaches through the `:http/abort-in-flight!` late-bind hook),
   so the fx and the teardown hook fire identical abort semantics."
   [_frame-ctx request-id]
-  (registry/abort-in-flight! request-id :user)
+  (rf.http.registry/abort-in-flight! request-id :user)
   nil)

--- a/implementation/http/src/re_frame/http/json.cljc
+++ b/implementation/http/src/re_frame/http/json.cljc
@@ -34,7 +34,7 @@
   Overflow throws `:rf.error/id :rf.error/malformed-json` with
   `:cause :too-many-keys` — the `:rf.http/managed` cascade classifies
   this as `:rf.http/decode-failure`."
-  (:require [re-frame.error :as error]
+  (:require [re-frame.error :as rf.error]
             #?(:clj [cheshire.core :as cheshire])))
 
 ;; Reflection warnings catch unhinted calls in the Cheshire/HashSet JVM path.
@@ -64,7 +64,7 @@
   Carries `:rf.error/id :rf.error/malformed-json` + `:cause :too-many-keys`
   + the configured `:limit`."
   [max-keys]
-  (error/thrown-ex-info
+  (rf.error/thrown-ex-info
     :rf.error/malformed-json
     'rf.http/json-parse
     (str "JSON payload exceeded the per-call unique-key cap (" max-keys ") — a keyword-interning DoS guard")

--- a/implementation/http/src/re_frame/http/machine_wrapper.cljc
+++ b/implementation/http/src/re_frame/http/machine_wrapper.cljc
@@ -39,7 +39,7 @@
   registrations and the `with-managed-request-stubs*` helper that
   composes against them. This production-loaded namespace carries only the
   machine wrapper."
-  (:require [re-frame.late-bind :as late-bind]))
+  (:require [re-frame.late-bind :as rf.late-bind]))
 
 ;; ---- machine-shape wrapper spec -------------------------------------------
 
@@ -142,6 +142,6 @@
   machine-id on success, or nil if the machines artefact is not on the
   classpath (in which case the existing fx-only surface is unaffected)."
   []
-  (when-let [reg-machine* (late-bind/get-fn :machines/reg-machine)]
+  (when-let [reg-machine* (rf.late-bind/get-fn :machines/reg-machine)]
     (reg-machine* :rf.http/managed (http-managed-machine-spec))
     :rf.http/managed))

--- a/implementation/http/src/re_frame/http/managed.cljc
+++ b/implementation/http/src/re_frame/http/managed.cljc
@@ -120,14 +120,14 @@
   AND performs the artefact's load-time side-effects: the
   `:rf.http/*` fx registrations and the `late-bind/set-fn!` hook
   publications that `re-frame.core` reaches through."
-  (:require [re-frame.fx                   :as fx]
-            [re-frame.http.handlers        :as handlers]
-            [re-frame.http.machine-wrapper :as machine-wrapper]
-            [re-frame.http.middleware      :as middleware]
-            [re-frame.http.privacy         :as privacy]
-            [re-frame.http.privacy-headers :as privacy-headers]
-            [re-frame.http.registry        :as registry]
-            [re-frame.late-bind            :as late-bind]))
+  (:require [re-frame.fx                   :as rf.fx]
+            [re-frame.http.handlers        :as rf.http.handlers]
+            [re-frame.http.machine-wrapper :as rf.http.machine-wrapper]
+            [re-frame.http.middleware      :as rf.http.middleware]
+            [re-frame.http.privacy         :as rf.http.privacy]
+            [re-frame.http.privacy-headers :as rf.http.privacy-headers]
+            [re-frame.http.registry        :as rf.http.registry]
+            [re-frame.late-bind            :as rf.late-bind]))
 
 ;; ---- public-surface re-exports --------------------------------------------
 ;;
@@ -143,21 +143,21 @@
 ;; via `record-in-flight!`); the raw `in-flight` / `actor-in-flight` atoms
 ;; are not re-exported because direct mutation would bypass the two-index
 ;; cleanup invariant.
-(def clear-all-in-flight!        registry/clear-all-in-flight!)
-(def in-flight-snapshot          registry/in-flight-snapshot)
-(def actor-in-flight-snapshot    registry/actor-in-flight-snapshot)
-(def seed-in-flight-for-test!    registry/seed-in-flight-for-test!)
-(def abort-on-actor-destroy      registry/abort-on-actor-destroy)
+(def clear-all-in-flight!        rf.http.registry/clear-all-in-flight!)
+(def in-flight-snapshot          rf.http.registry/in-flight-snapshot)
+(def actor-in-flight-snapshot    rf.http.registry/actor-in-flight-snapshot)
+(def seed-in-flight-for-test!    rf.http.registry/seed-in-flight-for-test!)
+(def abort-on-actor-destroy      rf.http.registry/abort-on-actor-destroy)
 
 ;; The per-frame interceptor chain is
 ;; internal storage; tests observe it through the immutable
 ;; `interceptors-snapshot` helper rather than deref'ing the `interceptors`
 ;; atom. Registration and clearing
 ;; route through `reg-http-interceptor` / `clear-http-interceptor`.
-(def reg-http-interceptor        middleware/reg-http-interceptor)
-(def clear-http-interceptor      middleware/clear-http-interceptor)
-(def clear-all-http-interceptors! middleware/clear-all-http-interceptors!)
-(def interceptors-snapshot       middleware/interceptors-snapshot)
+(def reg-http-interceptor        rf.http.middleware/reg-http-interceptor)
+(def clear-http-interceptor      rf.http.middleware/clear-http-interceptor)
+(def clear-all-http-interceptors! rf.http.middleware/clear-all-http-interceptors!)
+(def interceptors-snapshot       rf.http.middleware/interceptors-snapshot)
 
 ;; Privacy surface — Spec 014 §Privacy. Header denylist lives
 ;; in `re-frame.http.privacy-headers`; the orchestrating composers
@@ -167,7 +167,7 @@
 ;; :query-params [..]}` block (the transient-payload case — see the
 ;; ## HTTP carriers section in the ns docstring). The immutable built-in
 ;; default denylist is re-exported for tests.
-(def default-header-denylist    privacy-headers/default-header-denylist)
+(def default-header-denylist    rf.http.privacy-headers/default-header-denylist)
 
 ;; The `:rf.http/managed` fx handler body — re-exported so an app can
 ;; RE-REGISTER `:rf.http/managed` to declare its `:carriers` block without
@@ -180,7 +180,7 @@
 ;; `re-frame.http.privacy/managed-carriers` reads the registration's
 ;; `:carriers` block and unions the (lower-cased) names onto the immutable
 ;; built-in carrier denylists at trace-emit time.
-(def managed-handler            handlers/managed-handler)
+(def managed-handler            rf.http.handlers/managed-handler)
 
 ;; ---- registration ---------------------------------------------------------
 ;;
@@ -192,13 +192,13 @@
 ;; anchor. The two canned-stub fxs register from
 ;; `re-frame.http.test-support`.
 
-(fx/reg-fx :rf.http/managed
+(rf.fx/reg-fx :rf.http/managed
            {:doc "Spec 014 — managed HTTP request."}
-           handlers/managed-handler)
+           rf.http.handlers/managed-handler)
 
-(fx/reg-fx :rf.http/managed-abort
+(rf.fx/reg-fx :rf.http/managed-abort
            {:doc "Spec 014 — abort an in-flight :rf.http/managed by request-id."}
-           handlers/managed-abort-handler)
+           rf.http.handlers/managed-abort-handler)
 
 ;; ---- middleware fx wrappers -----------------------------------------------
 ;;
@@ -223,7 +223,7 @@
 ;; alternative to the fn-call shape for codebases that prefer to drive
 ;; bootstrap through the dispatch surface.
 
-(fx/reg-fx :rf.fx/reg-http-interceptor
+(rf.fx/reg-fx :rf.fx/reg-http-interceptor
            {:doc "Spec 014 §Middleware — register an
                   HTTP interceptor as an fx. Args is a map carrying
                   `:id` (kw), at least one of `:before` / `:after`,
@@ -240,11 +240,11 @@
                   synthesised `:rf/default` (a frameless cascade would have
                   failed at dispatch already)."}
            (fn [{ctx-frame :frame} {:keys [id] :as args}]
-             (middleware/reg-http-interceptor
+             (rf.http.middleware/reg-http-interceptor
                id (-> (dissoc args :id)
                       (update :frame #(or % ctx-frame))))))
 
-(fx/reg-fx :rf.fx/clear-http-interceptor
+(rf.fx/reg-fx :rf.fx/clear-http-interceptor
            {:doc "Spec 014 §Middleware — clear a request-side
                   interceptor by id as an fx. Args is the map
                   `{:frame <id> :id <kw>}` (NOT positional, matching the
@@ -263,7 +263,7 @@
                   frame-first seam so it never repairs to a synthesised
                   `:rf/default`."}
            (fn [{ctx-frame :frame} {:keys [frame id]}]
-             (middleware/clear-http-interceptor* (or frame ctx-frame) id)))
+             (rf.http.middleware/clear-http-interceptor* (or frame ctx-frame) id)))
 
 ;; The canned effects and stub helpers are registered only when
 ;; `re-frame.http.test-support` is explicitly required. The namespace boundary,
@@ -281,27 +281,27 @@
 ;; effects share one require gate. Raw install/uninstall helpers publish no
 ;; hook and are called directly from that namespace.
 
-(late-bind/set-fn! :http/abort-in-flight!                 registry/abort-in-flight!)
-(late-bind/set-fn! :http/abort-on-actor-destroy           abort-on-actor-destroy)
+(rf.late-bind/set-fn! :http/abort-in-flight!                 rf.http.registry/abort-in-flight!)
+(rf.late-bind/set-fn! :http/abort-on-actor-destroy           abort-on-actor-destroy)
 ;; Epoch restore aborts pre-restore host work after installing the epoch. The
 ;; abort suppresses app replies and records stale-suppression facts. This remains
 ;; late-bound so the epoch artefact does not acquire an HTTP dependency.
-(late-bind/set-fn! :http/abort-in-flight-for-frame!       registry/abort-in-flight-for-frame!)
+(rf.late-bind/set-fn! :http/abort-in-flight-for-frame!       rf.http.registry/abort-in-flight-for-frame!)
 ;; Frame destroy aborts the destroyed frame's still-in-flight PLAIN managed HTTP
 ;; (rf2-j538f7.8). Called from core `frame/destroy-frame!` AFTER machine +
 ;; resource teardown, suppressing app replies (`:reason :frame-destroyed`) so no
 ;; late completion routes into the dead frame. Late-bound so core does not
 ;; acquire an HTTP dependency; the frame-teardown counterpart of the restore hook.
-(late-bind/set-fn! :http/on-frame-destroyed!              registry/abort-in-flight-on-frame-destroyed!)
-(late-bind/set-fn! :http/clear-all-http-interceptors!     clear-all-http-interceptors!)
-(late-bind/set-fn! :http/clear-all-in-flight!             clear-all-in-flight!)
-(late-bind/set-fn! :http/clear-http-interceptor           clear-http-interceptor)
-(late-bind/set-fn! :http/reg-http-interceptor             reg-http-interceptor)
-(late-bind/set-fn! :http/register-managed-machine!        machine-wrapper/register-managed-machine!)
+(rf.late-bind/set-fn! :http/on-frame-destroyed!              rf.http.registry/abort-in-flight-on-frame-destroyed!)
+(rf.late-bind/set-fn! :http/clear-all-http-interceptors!     clear-all-http-interceptors!)
+(rf.late-bind/set-fn! :http/clear-all-in-flight!             clear-all-in-flight!)
+(rf.late-bind/set-fn! :http/clear-http-interceptor           clear-http-interceptor)
+(rf.late-bind/set-fn! :http/reg-http-interceptor             reg-http-interceptor)
+(rf.late-bind/set-fn! :http/register-managed-machine!        rf.http.machine-wrapper/register-managed-machine!)
 ;; rf2-32ffq1 — the core classification projector consults this to redact a
 ;; `:rf.http/managed` entry's args at the generic fx-arg-bearing trace slots
 ;; (the `:rf.event/fx` aggregate + `:rf.fx/handled`-shaped slots), honouring
 ;; the DYNAMIC per-call `:sensitive?` flag + carrier denylists that a static
 ;; registration `:sensitive` path cannot express.
-(late-bind/set-fn! :http/project-managed-fx-args          privacy/project-managed-fx-args)
-(machine-wrapper/register-managed-machine!)
+(rf.late-bind/set-fn! :http/project-managed-fx-args          rf.http.privacy/project-managed-fx-args)
+(rf.http.machine-wrapper/register-managed-machine!)

--- a/implementation/http/src/re_frame/http/middleware.cljc
+++ b/implementation/http/src/re_frame/http/middleware.cljc
@@ -65,13 +65,13 @@
   `re-frame.flows.registry`'s private `flows` atom + the
   `flows-snapshot` accessor). Frame-scoped: an interceptor registered
   against frame A does not fire for a request dispatched from frame B."
-  (:require [re-frame.error        :as error]
-            [re-frame.frame        :as frame]
-            [re-frame.http.encoding :as encoding]
-            [re-frame.http.privacy :as privacy]
-            [re-frame.interop      :as interop]
-            [re-frame.source-coords :as source-coords]
-            [re-frame.trace        :as trace]))
+  (:require [re-frame.error        :as rf.error]
+            [re-frame.frame        :as rf.frame]
+            [re-frame.http.encoding :as rf.http.encoding]
+            [re-frame.http.privacy :as rf.http.privacy]
+            [re-frame.interop      :as rf.interop]
+            [re-frame.source-coords :as rf.source-coords]
+            [re-frame.trace        :as rf.trace]))
 
 (defonce
   ^{:doc "frame-id → vector of `:rf/http-interceptor-meta` slots — each a map
@@ -160,7 +160,7 @@
   Returns the registered `id`."
   [id interceptor-map]
   (when-not (valid-args? id interceptor-map)
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/http-bad-interceptor 'rf/reg-http-interceptor
       "expected (reg-http-interceptor id interceptor-map): id keyword; interceptor-map a map carrying at least one of :before / :after (each a fn), optional :frame keyword, optional :rf/registration-metadata"
       {:extra {:received {:id id :interceptor-map interceptor-map}}}))
@@ -175,13 +175,13 @@
                       ;; `:rf.error/no-frame-context` rather than installing
                       ;; the interceptor against a synthesised `:rf/default`
                       ;; chain (per Spec 002 §Frame target resolution).
-                      (frame/require-current-frame!
+                      (rf.frame/require-current-frame!
                         :reg-http-interceptor
                         {:where 'rf/reg-http-interceptor :event-id id}))
         before    (:before interceptor-map)
         after     (:after  interceptor-map)
         user-meta (dissoc interceptor-map :frame :before :after)
-        slot      (cond-> (source-coords/merge-coords user-meta)
+        slot      (cond-> (rf.source-coords/merge-coords user-meta)
                     true   (assoc :id    id
                                   :frame frame-id)
                     before (assoc :before before)
@@ -195,8 +195,8 @@
                (if idx
                  (assoc chain idx slot)
                  (conj chain slot)))))
-    (when interop/debug-enabled?
-      (trace/emit! :info :rf.http.interceptor/registered
+    (when rf.interop/debug-enabled?
+      (rf.trace/emit! :info :rf.http.interceptor/registered
                    {:frame frame-id
                     :id    id}))
     id))
@@ -216,14 +216,14 @@
   Both public arities also funnel through it once they have resolved a frame.
   Returns `id`."
   [frame id]
-  (let [frame-id (frame/frame-target->id frame)
+  (let [frame-id (rf.frame/frame-target->id frame)
         existed? (some? (some (fn [v] (when (= (:id v) id) v))
                               (get @interceptors frame-id)))]
     (swap! interceptors update frame-id
            (fn [chain]
              (vec (remove (fn [v] (= (:id v) id)) chain))))
-    (when (and existed? interop/debug-enabled?)
-      (trace/emit! :info :rf.http.interceptor/cleared
+    (when (and existed? rf.interop/debug-enabled?)
+      (rf.trace/emit! :info :rf.http.interceptor/cleared
                    {:frame frame-id
                     :id    id}))
     id))
@@ -240,7 +240,7 @@
        (= #{:frame} (set (keys opts)))
        (let [target (:frame opts)]
          (or (keyword? target)
-             (frame/frame-value? target)))))
+             (rf.frame/frame-value? target)))))
 
 (defn clear-http-interceptor
   "Unregister an HTTP interceptor by id from a frame's chain.
@@ -274,7 +274,7 @@
   seam instead. No-arg form is not supported — explicit ids only."
   ([id]
    (clear-http-interceptor*
-     (frame/require-current-frame!
+     (rf.frame/require-current-frame!
        :clear-http-interceptor
        {:where 'rf/clear-http-interceptor :event-id id})
      id))
@@ -286,7 +286,7 @@
    ;; scalar second arg is not a valid opts map. The explicit target names the
    ;; frame; the opts form never falls back to the ambient scope.
    (when-not (valid-clear-opts? opts)
-     (error/throw-error!
+     (rf.error/throw-error!
        :rf.error/http-bad-interceptor 'rf/clear-http-interceptor
        "expected (clear-http-interceptor id {:frame target}): the two-arity opts map must be exactly {:frame target} with a present, non-nil frame target (a frame-id keyword or a live frame value). Two-scalar frame-first (frame id) is not a public shape."
        {:extra {:received {:id id :opts opts}}}))
@@ -344,7 +344,7 @@
                 ;; wrapper carries :interceptor-id so a chain failure is
                 ;; locatable via ex-data; the :id key here is kept for
                 ;; programmatic consumers.
-                (error/throw-error!
+                (rf.error/throw-error!
                   :rf.error/http-interceptor-bad-return 'rf/reg-http-interceptor
                   (str "HTTP interceptor `" id "` " slot-noun ". A `:before` / "
                        ":after` HTTP interceptor (Spec 014 §Middleware) must "
@@ -363,14 +363,14 @@
                                 "handler so it does not throw (Spec 014 "
                                 "§Middleware)."
                                 (when cause (str " Cause: " cause)))
-                    data   (error/thrown-ex-info
+                    data   (rf.error/thrown-ex-info
                              :rf.error/http-interceptor-failed where reason
                              {:extra (cond-> {:frame          frame-id
                                               :interceptor-id id
                                               :url            (url-of acc)
                                               :cause          cause}
                                        phase (assoc :phase phase))})]
-                (when interop/debug-enabled?
+                (when rf.interop/debug-enabled?
                   ;; rf2-1jcpm — route through the privacy composer so a
                   ;; denylisted query param (`?api_key=…`) is scrubbed
                   ;; and `:sensitive?` is stamped on the trace event when
@@ -385,8 +385,8 @@
                   ;; followed by a later `:before` that threw emitted this
                   ;; diagnostic with the stale non-sensitive flag, leaking
                   ;; non-denylisted query values for a now-sensitive request.
-                  (trace/emit-error! :rf.error/http-interceptor-failed
-                                     (privacy/prepare-emit-failure
+                  (rf.trace/emit-error! :rf.error/http-interceptor-failed
+                                     (rf.http.privacy/prepare-emit-failure
                                        (ex-data data)
                                        (sensitive-of acc))))
                 (throw data))))
@@ -503,7 +503,7 @@
   (let [final-payload (if middleware-ctx
                         (run-after-chain! frame middleware-ctx reply-payload)
                         reply-payload)]
-    (encoding/dispatch-reply-via-late-bind!
+    (rf.http.encoding/dispatch-reply-via-late-bind!
       {:origin-event  origin-event
        :explicit-on   explicit-on
        :reply-payload final-payload

--- a/implementation/http/src/re_frame/http/privacy.cljc
+++ b/implementation/http/src/re_frame/http/privacy.cljc
@@ -75,15 +75,15 @@
   moot, and no walker runs against the denylists without the trace
   surface."
   (:require [clojure.string :as str]
-            [re-frame.error :as error]
-            [re-frame.http.privacy-headers :as headers]
-            [re-frame.http.url :as url]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]))
+            [re-frame.error :as rf.error]
+            [re-frame.http.privacy-headers :as rf.http.privacy-headers]
+            [re-frame.http.url :as rf.http.url]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.registrar :as rf.registrar]))
 
 ;; The URL leaf owns the public HTTP alias so privacy composers can share the
 ;; core sentinel without creating a leaf-to-parent cycle.
-(def ^:private redacted-sentinel url/redacted-sentinel)
+(def ^:private redacted-sentinel rf.http.url/redacted-sentinel)
 
 ;; ---- managed-HTTP carrier resolution --------------------------------------
 ;;
@@ -115,7 +115,7 @@
 
 (defn- carrier-error
   [reason extras]
-  (error/thrown-ex-info
+  (rf.error/thrown-ex-info
     :rf.error/bad-classification
     'rf/reg-fx
     reason
@@ -218,7 +218,7 @@
   `:rf.http/managed` with a `:carriers` block — the common case, so a
   defaults-only emit allocates nothing. Pure (modulo the registry read)."
   []
-  (let [carriers (:carriers (registrar/handler-meta :fx :rf.http/managed))]
+  (let [carriers (:carriers (rf.registrar/handler-meta :fx :rf.http/managed))]
     (when (some? carriers)
       (validate-carriers! carriers)
       (let [header-carriers        (lower-set (:headers carriers))
@@ -269,14 +269,14 @@
   (let [[payload-after-top-level-url top-level-url-redacted?]
         (if (string? (:url payload))
           (let [[redacted-url url-redacted?]
-                (url/redact-url-query-string
+                (rf.http.url/redact-url-query-string
                   (:url payload) sensitive? query-param-policy)]
             [(assoc payload :url redacted-url) url-redacted?])
           [payload false])
         [redacted-payload nested-url-redacted?]
         (if (string? (get-in payload-after-top-level-url [:request :url]))
           (let [[redacted-url url-redacted?]
-                (url/redact-url-query-string
+                (rf.http.url/redact-url-query-string
                   (get-in payload-after-top-level-url [:request :url])
                   sensitive?
                   query-param-policy)]
@@ -298,7 +298,7 @@
          tags' (cond-> tags
                  ;; Always-on header redaction (built-in defaults plus extensions).
                  (map? (:headers tags))
-                 (update :headers headers/redact-headers (:headers carriers))
+                 (update :headers rf.http.privacy-headers/redact-headers (:headers carriers))
 
                  ;; Sensitive-request redaction — body becomes the sentinel.
                  (and sensitive? (contains? tags :body))
@@ -338,7 +338,7 @@
      (let [[failure url-hit?] (redact-url-in failure sensitive? (:query-params carriers))
            failure' (cond-> failure
                       (map? (:headers failure))
-                      (update :headers headers/redact-headers (:headers carriers))
+                      (update :headers rf.http.privacy-headers/redact-headers (:headers carriers))
 
                       (and sensitive? (contains? failure :body))
                       (assoc :body redacted-sentinel)
@@ -404,7 +404,7 @@
   [reply]
   (if (map? (get-in reply [:meta :headers]))
     (update-in reply [:meta :headers]
-               headers/redact-headers (:headers (managed-carriers)))
+               rf.http.privacy-headers/redact-headers (:headers (managed-carriers)))
     reply))
 
 (defn stamp-sensitive
@@ -475,7 +475,7 @@
     args
     (let [sensitive?   (request-sensitive? args)
           carriers     (managed-carriers)
-          redact-event (or (late-bind/get-fn :classification/redact-event-by-registration)
+          redact-event (or (rf.late-bind/get-fn :classification/redact-event-by-registration)
                            identity)
           redact-addr  (fn [v] (if (vector? v) (redact-event v) v))]
       (cond-> args

--- a/implementation/http/src/re_frame/http/privacy_body.cljc
+++ b/implementation/http/src/re_frame/http/privacy_body.cljc
@@ -77,9 +77,9 @@
   Like the rest of the HTTP privacy machinery, the classification runs only
   at trace-emit / capture sites that gate on `interop/debug-enabled?`; in
   production builds the trace surface elides entirely and no body walk runs."
-  (:require [re-frame.late-bind :as late-bind]
-            [re-frame.error :as error]
-            [re-frame.classification :as classification]))
+  (:require [re-frame.late-bind :as rf.late-bind]
+            [re-frame.error :as rf.error]
+            [re-frame.classification :as rf.classification]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -186,8 +186,8 @@
   is unknown, and reporting it as empty would ride the marked slot verbatim."
   [hook schema]
   (if (declares-marks? schema)
-    (let [extract (or (late-bind/get-fn-cached hook)
-                      (error/throw-error!
+    (let [extract (or (rf.late-bind/get-fn-cached hook)
+                      (rf.error/throw-error!
                         :rf.error/schemas-artefact-missing
                         'rf.http/classify-response-body
                         (str "the request's `:decode` schema declares a `:sensitive?` / "
@@ -289,5 +289,5 @@
   [decoded decode]
   (let [{:keys [sensitive large]} (decode-schema-marks decode)]
     (if (or (seq sensitive) (seq large))
-      (classification/redact-with-paths decoded (keys sensitive) (keys large))
+      (rf.classification/redact-with-paths decoded (keys sensitive) (keys large))
       decoded)))

--- a/implementation/http/src/re_frame/http/privacy_headers.cljc
+++ b/implementation/http/src/re_frame/http/privacy_headers.cljc
@@ -35,11 +35,11 @@
   `trace/emit!`). In production builds the trace surface elides
   entirely; this namespace's walker never runs."
   (:require [clojure.string :as str]
-            [re-frame.http.url :as url]))
+            [re-frame.http.url :as rf.http.url]))
 
 ;; Keep the sentinel in the dependency-leaf URL namespace so every HTTP
 ;; redactor can share it without creating a privacy dependency cycle.
-(def ^:private redacted-sentinel url/redacted-sentinel)
+(def ^:private redacted-sentinel rf.http.url/redacted-sentinel)
 
 (def default-header-denylist
   "Canonical always-sensitive HTTP header names, lower-cased. These are

--- a/implementation/http/src/re_frame/http/registry.cljc
+++ b/implementation/http/src/re_frame/http/registry.cljc
@@ -25,11 +25,11 @@
   shape wrapper) because the operation is atomic state — it walks
   both atoms and mutates them under one `swap!` per slot. Keeping it
   next to the atoms makes the invariant local."
-  (:require [re-frame.http.privacy :as privacy]
-            [re-frame.http.reply   :as http-reply]
-            [re-frame.interop      :as interop]
-            [re-frame.late-bind    :as late-bind]
-            [re-frame.trace        :as trace]))
+  (:require [re-frame.http.privacy :as rf.http.privacy]
+            [re-frame.http.reply   :as rf.http.reply]
+            [re-frame.interop      :as rf.interop]
+            [re-frame.late-bind    :as rf.late-bind]
+            [re-frame.trace        :as rf.trace]))
 
 ;; ---- in-flight request registry -------------------------------------------
 
@@ -413,12 +413,12 @@
       ;; Atomically clear the slot first so a re-entry sees no handles.
       (swap! actor-in-flight dissoc actor-id)
       (doseq [handle handles]
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           ;; rf2-bma05 — the handle carries the originating request's
           ;; effective :sensitive? flag; stamp the trace event so off-box
           ;; consumers honour the privacy contract on actor-destroy aborts.
-          (trace/emit! :info :rf.http/aborted-on-actor-destroy
-                       (privacy/prepare-emit-tags
+          (rf.trace/emit! :info :rf.http/aborted-on-actor-destroy
+                       (rf.http.privacy/prepare-emit-tags
                          {:request-id (:request-id handle)
                           :actor-id   actor-id
                           :url        (:url handle)}
@@ -464,18 +464,18 @@
   suppresses the carried id against a nil current. Gated on `debug-enabled?`
   like the other `:rf.http/*` trace rows."
   [handle recovery]
-  (when interop/debug-enabled?
+  (when rf.interop/debug-enabled?
     (let [stale-ctx {:request-id   (:request-id handle)
                      :origin-event (:origin-event handle)
                      :issuance     (:issuance handle)
                      :attempt      (:attempt handle)
                      :frame        (:frame handle)}
-          {:keys [reply trace]} (http-reply/suppress stale-ctx nil)
-          summary (http-reply/trace-reply
+          {:keys [reply trace]} (rf.http.reply/suppress stale-ctx nil)
+          summary (rf.http.reply/trace-reply
                     reply
                     (cond-> {:sensitive? (true? (:sensitive? handle))}
                       (:frame handle) (assoc :frame (:frame handle))))]
-      (trace/emit! :info :rf.http/stale-suppressed
+      (rf.trace/emit! :info :rf.http/stale-suppressed
                    (cond-> {:rf.reply/status       (:status summary)
                             :rf.reply/work-status  (:rf.reply/work-status summary)
                             :rf.reply/stale-reason (:rf.reply/stale-reason summary)
@@ -607,5 +607,5 @@
   (let [event-id (when (vector? origin-event) (first origin-event))]
     (when (and event-id
                (not= event-id :rf.http/managed))
-      (when-let [owning-actor-id (late-bind/get-fn :machines/owning-actor-id)]
+      (when-let [owning-actor-id (rf.late-bind/get-fn :machines/owning-actor-id)]
         (owning-actor-id frame-id event-id)))))

--- a/implementation/http/src/re_frame/http/reply.cljc
+++ b/implementation/http/src/re_frame/http/reply.cljc
@@ -52,7 +52,7 @@
   `re-frame.reply/trace-summary` (which calls `re-frame.elision/
   elide-wire-value`) — never a family-private elider (Managed-Effects
   §Tracing)."
-  (:require [re-frame.reply :as reply]))
+  (:require [re-frame.reply :as rf.reply]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -266,7 +266,7 @@
   issuance counter bumped (`work-id` embeds the per-request-id issuance)."
   [ctx current-work-id]
   (let [carried-wid (work-id ctx)]
-    (reply/suppress nil
+    (rf.reply/suppress nil
                     {:work/id carried-wid}
                     {:work/id current-work-id}
                     (cond-> {:rf.reply/work-id      carried-wid
@@ -339,7 +339,7 @@
   unknown)."
   [ctx]
   (let [carried-wid (work-id ctx)]
-    (reply/suppress nil
+    (rf.reply/suppress nil
                     {:work/id carried-wid}
                     nil
                     (cond-> {:rf.reply/work-id      carried-wid
@@ -392,6 +392,6 @@
                      `:sensitive?` / `:large?` app-db policy as usual."
   ([reply] (trace-reply reply nil))
   ([reply {:keys [sensitive?] :as opts}]
-   (reply/trace-summary reply
+   (rf.reply/trace-summary reply
                         (cond-> (dissoc opts :sensitive?)
                           sensitive? (assoc :rf.privacy/force-redact-wire? true)))))

--- a/implementation/http/src/re_frame/http/test_support.cljc
+++ b/implementation/http/src/re_frame/http/test_support.cljc
@@ -16,16 +16,16 @@
     (:require [re-frame.http.managed]
               [re-frame.http.test-support]))
   ```"
-  (:require [re-frame.events               :as events]
-            [re-frame.frame                :as frame]
-            [re-frame.fx                   :as fx]
-            [re-frame.http.encoding        :as encoding]
-            [re-frame.http.handlers        :as handlers]
-            [re-frame.http.middleware      :as middleware]
-            [re-frame.http.privacy         :as privacy]
-            [re-frame.late-bind            :as late-bind]
-            [re-frame.registrar            :as registrar]
-            [re-frame.router               :as router]))
+  (:require [re-frame.events               :as rf.events]
+            [re-frame.frame                :as rf.frame]
+            [re-frame.fx                   :as rf.fx]
+            [re-frame.http.encoding        :as rf.http.encoding]
+            [re-frame.http.handlers        :as rf.http.handlers]
+            [re-frame.http.middleware      :as rf.http.middleware]
+            [re-frame.http.privacy         :as rf.http.privacy]
+            [re-frame.late-bind            :as rf.late-bind]
+            [re-frame.registrar            :as rf.registrar]
+            [re-frame.router               :as rf.router]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -86,17 +86,17 @@
         ;; cascade, so the fx context carries the envelope frame as
         ;; `:frame`; a nil stamp is an invariant failure
         ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
-        frame-id     (frame/require-frame-stamp!
+        frame-id     (rf.frame/require-frame-stamp!
                        (:frame frame-ctx) :rf.http/managed-canned
                        {:where 'rf.http/run-request-chain})
-        origin-event (encoding/resolve-origin-event frame-ctx args-map)
-        sensitive?   (privacy/request-sensitive? args-map)
+        origin-event (rf.http.encoding/resolve-origin-event frame-ctx args-map)
+        sensitive?   (rf.http.privacy/request-sensitive? args-map)
         ctx0         {:request    (:request args-map)
                       :args       args-map
                       :frame      frame-id
                       :event      origin-event
                       :sensitive? sensitive?}]
-    (middleware/run-interceptor-chain! frame-id ctx0)))
+    (rf.http.middleware/run-interceptor-chain! frame-id ctx0)))
 
 (defn- dispatch-canned-reply!
   "rf2-r5m22 — the canned-stub reply tail, mirroring
@@ -128,7 +128,7 @@
   a `:middleware-ctx` (produced by `run-request-chain`), so the `:after`
   chain always runs here."
   [{:keys [origin-event explicit-on reply-payload kind frame middleware-ctx]}]
-  (middleware/run-after-then-dispatch!
+  (rf.http.middleware/run-after-then-dispatch!
     {:frame          frame
      :middleware-ctx middleware-ctx
      :origin-event   origin-event
@@ -152,11 +152,11 @@
   (let [;; EP-0002 carried invariant — fx-context `:frame` is the cascade
         ;; envelope stamp; a nil stamp is an invariant failure, never a
         ;; synthesised `:rf/default`.
-        frame-id     (frame/require-frame-stamp!
+        frame-id     (rf.frame/require-frame-stamp!
                        (:frame frame-ctx) :rf.http/managed-canned-success
                        {:where 'rf.http/emit-canned-success!})
         value        (get args-map :value {:stubbed true})
-        origin-event (encoding/resolve-origin-event frame-ctx args-map)
+        origin-event (rf.http.encoding/resolve-origin-event frame-ctx args-map)
         ;; rf2-ibksxg — the canned stub delivers a MINIMAL canonical reply
         ;; (`:status :ok` + `:value`), the shape a handler actually branches
         ;; on. A stub has no real request lifecycle, so the identity facts the
@@ -197,13 +197,13 @@
   (let [;; EP-0002 carried invariant — fx-context `:frame` is the cascade
         ;; envelope stamp; a nil stamp is an invariant failure, never a
         ;; synthesised `:rf/default`.
-        frame-id     (frame/require-frame-stamp!
+        frame-id     (rf.frame/require-frame-stamp!
                        (:frame frame-ctx) :rf.http/managed-canned-failure
                        {:where 'rf.http/emit-canned-failure!})
         kind         (or (:kind args-map) :rf.http/transport)
         tags         (or (:tags args-map) {})
         failure      (assoc tags :kind kind)
-        origin-event (encoding/resolve-origin-event frame-ctx args-map)
+        origin-event (rf.http.encoding/resolve-origin-event frame-ctx args-map)
         ;; rf2-ibksxg — deliver a MINIMAL canonical reply: the classified
         ;; `:rf.http/*` failure map rides verbatim under `:error`, and an
         ;; `:rf.http/aborted` kind maps to `:status :cancelled` (mirroring the
@@ -290,7 +290,7 @@
 
 (def ^:private deliver-canned-reply-id :rf.http/deliver-canned-reply)
 
-(events/reg-event deliver-canned-reply-id
+(rf.events/reg-event deliver-canned-reply-id
   {:doc "Framework-private (rf2-j1mo4). Delivers a canned HTTP reply, optionally
          after an `:after-ms` delay. Dispatched by the `:rf.http/managed-canned-*`
          fxs when their args-map carries a positive `:after-ms`; self-recurses
@@ -330,9 +330,9 @@
       (if (and after-ms (pos? after-ms))
         ;; Deferred path — pin the origin, then hand off to the deliverer
         ;; event which schedules the `:dispatch-later`.
-        (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+        (when-let [dispatch! (rf.late-bind/get-fn :router/dispatch!)]
           (let [pinned (assoc args-map :rf.http/origin-event
-                              (encoding/resolve-origin-event frame-ctx args-map))]
+                              (rf.http.encoding/resolve-origin-event frame-ctx args-map))]
             (dispatch! [deliver-canned-reply-id fx-id pinned]
                        (cond-> {} (:frame frame-ctx) (assoc :frame (:frame frame-ctx))))))
         ;; Immediate path. On the deferred re-entry the ambient `:event`
@@ -356,7 +356,7 @@
 ;; `:after-ms` delay around those same bodies without changing their
 ;; contract.
 
-(fx/reg-fx :rf.http/managed-canned-success
+(rf.fx/reg-fx :rf.http/managed-canned-success
            {:doc "Spec 014 — synthesised success reply (test stub).
                   Registration gated on explicit `re-frame.http.test-support`
                   require per rf2-cdmle. Optional `:after-ms` (rf2-j1mo4)
@@ -364,7 +364,7 @@
            (with-after-ms :rf.http/managed-canned-success
                           canned-success-handler))
 
-(fx/reg-fx :rf.http/managed-canned-failure
+(rf.fx/reg-fx :rf.http/managed-canned-failure
            {:doc "Spec 014 — synthesised failure reply (test stub).
                   Registration gated on explicit `re-frame.http.test-support`
                   require per rf2-cdmle. Optional `:after-ms` (rf2-j1mo4)
@@ -408,7 +408,7 @@
   ;; that blanks the url now throws here instead of receiving a synthetic
   ;; stubbed reply.
   (let [middleware-ctx (run-request-chain frame-ctx args-map)
-        _              (handlers/validate-url! (:request middleware-ctx))
+        _              (rf.http.handlers/validate-url! (:request middleware-ctx))
         ;; Match against the POST-`:before` request — the url the managed
         ;; pipeline would actually send.
         req            (:request middleware-ctx)
@@ -490,8 +490,8 @@
 
   Per Spec 014 §Testing — the framework ships canonical stub fxs."
   [stubs]
-  (swap! stub-fx-handler-stack conj (registrar/handler :fx stub-fx-id))
-  (fx/reg-fx stub-fx-id
+  (swap! stub-fx-handler-stack conj (rf.registrar/handler :fx stub-fx-id))
+  (rf.fx/reg-fx stub-fx-id
              {:doc "with-managed-request-stubs synthesised stub"}
              (fn [frame-ctx args-map]
                (stub-handler stubs frame-ctx args-map)))
@@ -510,10 +510,10 @@
   []
   (let [[prior] (peek-and-pop! stub-fx-handler-stack)]
     (if prior
-      (fx/reg-fx stub-fx-id
+      (rf.fx/reg-fx stub-fx-id
                  {:doc "with-managed-request-stubs synthesised stub"}
                  prior)
-      (fx/clear-fx stub-fx-id)))
+      (rf.fx/clear-fx stub-fx-id)))
   nil)
 
 ;; rf2-bxc8kf — the scoped wrapper's override target is registered at
@@ -574,7 +574,7 @@
 ;; current scope's route map from `*scope-stubs*` and delegates to the shared
 ;; `stub-handler` (which runs the `:before` chain, keys the match off the
 ;; post-`:before` url, and emits through the `:after` chain).
-(fx/reg-fx scope-stub-fx-id
+(rf.fx/reg-fx scope-stub-fx-id
            {:doc "with-managed-request-stubs (scoped) synthesised stub — reads the
                   current scope's route map from `*scope-stubs*` (rf2-bxc8kf).
                   Registered at load time so a pre-created SEALED frame can
@@ -623,7 +623,7 @@
   ;; per-scope registration to tear down (rf2-bxc8kf). The `*scope-stubs*`
   ;; binding SHADOWS an enclosing scope's route map for nesting.
   (binding [*scope-stubs*             stubs
-            router/*fx-overrides*     (merge router/*fx-overrides*
+            rf.router/*fx-overrides*     (merge rf.router/*fx-overrides*
                                              {:rf.http/managed scope-stub-fx-id})]
     (thunk)))
 
@@ -654,4 +654,4 @@
 ;; pair is NOT a `re-frame.core` façade export (rf2-ntwwyt), so it publishes no
 ;; late-bind hook — tests call these two defns directly from this namespace.
 
-(late-bind/set-fn! :http/with-managed-request-stubs*      with-managed-request-stubs*)
+(rf.late-bind/set-fn! :http/with-managed-request-stubs*      with-managed-request-stubs*)

--- a/implementation/http/src/re_frame/http/transport.cljc
+++ b/implementation/http/src/re_frame/http/transport.cljc
@@ -25,18 +25,18 @@
   backoff `maybe-retry!` decides between retry, immediate-final-failure,
   and successful completion based on the failing attempt's failure
   category and the request's `:retry` config."
-  (:require [re-frame.error             :as error]
-            [re-frame.http.decode       :as decode]
-            [re-frame.http.encoding     :as encoding]
-            [re-frame.http.middleware   :as middleware]
-            [re-frame.http.privacy      :as privacy]
-            [re-frame.http.privacy-body :as privacy-body]
-            [re-frame.http.registry     :as registry]
-            [re-frame.http.reply        :as http-reply]
-            [re-frame.http.transport-cljs :as transport-cljs]
-            [re-frame.http.transport-jvm  :as transport-jvm]
-            [re-frame.interop           :as interop]
-            [re-frame.trace             :as trace])
+  (:require [re-frame.error             :as rf.error]
+            [re-frame.http.decode       :as rf.http.decode]
+            [re-frame.http.encoding     :as rf.http.encoding]
+            [re-frame.http.middleware   :as rf.http.middleware]
+            [re-frame.http.privacy      :as rf.http.privacy]
+            [re-frame.http.privacy-body :as rf.http.privacy-body]
+            [re-frame.http.registry     :as rf.http.registry]
+            [re-frame.http.reply        :as rf.http.reply]
+            [re-frame.http.transport-cljs :as rf.http.transport-cljs]
+            [re-frame.http.transport-jvm  :as rf.http.transport-jvm]
+            [re-frame.interop           :as rf.interop]
+            [re-frame.trace             :as rf.trace])
   #?(:clj (:import [java.util.concurrent CompletableFuture])))
 
 ;; ---- shared attempt-and-retry loop ----------------------------------------
@@ -119,7 +119,7 @@
   a completed request's listener. Phase-to-phase ownership transfer detaches
   the prior listener inside `bind-external-abort!` itself, not here."
   [ctx]
-  #?(:cljs (transport-cljs/detach-external-abort! (:external-abort ctx)))
+  #?(:cljs (rf.http.transport-cljs/detach-external-abort! (:external-abort ctx)))
   nil)
 
 (defn- emit-reply-tail-error!
@@ -150,15 +150,15 @@
   URL redacts under the per-call `:sensitive?` flag / query-param denylist)
   matching the sibling `:rf.http/*` error rows."
   [ctx e]
-  (when interop/debug-enabled?
+  (when rf.interop/debug-enabled?
     (let [reply-error-id (:rf.error/id (ex-data e))]
-      (trace/emit-error!
+      (rf.trace/emit-error!
         :rf.error/http-reply-tail-failed
-        (privacy/prepare-emit-tags
+        (rf.http.privacy/prepare-emit-tags
           {:url            (:url ctx)
            :kind           (:kind ctx)
            :reply-error-id reply-error-id
-           :cause          (error/ex-message-safe e)
+           :cause          (rf.error/ex-message-safe e)
            :recovery       :no-recovery
            :reason         (str "A managed-HTTP reply tail threw AFTER the "
                                 "transport completed"
@@ -215,7 +215,7 @@
     ;; `:after` chain is skipped when no middleware-ctx is present
     ;; (synthetic / test-path callers).
     (try
-      (middleware/run-after-then-dispatch!
+      (rf.http.middleware/run-after-then-dispatch!
         {:frame          frame
          :middleware-ctx middleware-ctx
          :origin-event   origin-event
@@ -272,7 +272,7 @@
    :issuance     (:issuance ctx)
    :attempt      (:attempt ctx)
    :frame        (:frame ctx)
-   :completed-at (interop/epoch-now-ms)})
+   :completed-at (rf.interop/epoch-now-ms)})
 
 (defn- self-identify
   "Stamp the four self-identifying fields (`:request
@@ -287,7 +287,7 @@
   `:retry` policy, plus `:url` / `:request-id` / `:origin-event` / `:issuance`
   / `:attempt`). Applies uniformly to ALL eight failure categories."
   [failure ctx]
-  (http-reply/self-identify-failure
+  (rf.http.reply/self-identify-failure
     failure
     {:method       (:method (:request ctx))
      :url          (:url ctx)
@@ -330,11 +330,11 @@
   request that no longer wants its reply is correct-by-design silence,
   not a swallowed error."
   [failure url sensitive?]
-  (when (and interop/debug-enabled?
+  (when (and rf.interop/debug-enabled?
              (not= :rf.http/aborted (:kind failure))
              (compare-and-set! failure-swallowed-warned? false true))
-    (trace/emit! :warning :rf.warning/failure-swallowed
-                 (privacy/prepare-emit-tags
+    (rf.trace/emit! :warning :rf.warning/failure-swallowed
+                 (rf.http.privacy/prepare-emit-tags
                    {:url     url
                     :failure failure
                     :reason  (str "an HTTP request failed with `:kind "
@@ -378,7 +378,7 @@
   `:completed-at`) ride verbatim. Gated on `debug-enabled?` like the other
   `:rf.http/*` trace rows."
   [ctx reply]
-  (when interop/debug-enabled?
+  (when rf.interop/debug-enabled?
     ;; The success reply's decoded body is classified through its schema
     ;; before it reaches the trace stream. It is a registration-
     ;; owned transient payload classified per-slot via `:sensitive?` props on
@@ -395,8 +395,8 @@
     ;; through the shared marks walker.
     (let [reply' (if (and (= :ok (:status reply))
                           (contains? reply :value)
-                          (privacy-body/schema-decode? (:decode ctx)))
-                   (update reply :value privacy-body/classify-decoded (:decode ctx))
+                          (rf.http.privacy-body/schema-decode? (:decode ctx)))
+                   (update reply :value rf.http.privacy-body/classify-decoded (:decode ctx))
                    reply)
           ;; rf2-lddbk — the success reply's `:meta` carries the response
           ;; wire facts (status / status-text / normalized headers). The
@@ -407,7 +407,7 @@
           ;; summary walk, matching the failure-map `:headers` posture.
           ;; Per-call `:sensitive?` then force-redacts the whole `:meta`
           ;; wire slot via `trace-reply` below, as for every wire slot.
-          reply' (privacy/redact-response-meta reply')]
+          reply' (rf.http.privacy/redact-response-meta reply')]
       ;; Thread the CARRIED frame into the elider opts (EP-0002 — wire-egress
       ;; frame resolves from the carried stamp; HTTP completions fire from the
       ;; transport callback, OUTSIDE any `with-frame` scope, so without an
@@ -425,12 +425,12 @@
       ;; `:rf.http/off-box-body`; the off-box trace-events projector
       ;; (`re-frame.epoch.tool-pair`) consults it and omits / classifies the
       ;; body slot. Only the success status carries a body slot to gate.
-      (trace/emit! :info :rf.http/replied
-                   (cond-> (http-reply/trace-reply reply' (cond-> {:sensitive? (true? (:sensitive? ctx))}
+      (rf.trace/emit! :info :rf.http/replied
+                   (cond-> (rf.http.reply/trace-reply reply' (cond-> {:sensitive? (true? (:sensitive? ctx))}
                                                             (:frame ctx) (assoc :frame (:frame ctx))))
                      (= :ok (:status reply))
                      (assoc :rf.http/off-box-body
-                            (privacy-body/off-box-body-disposition (:decode ctx))))))))
+                            (rf.http.privacy-body/off-box-body-disposition (:decode ctx))))))))
 
 (defn emit-superseded-stale-trace!
   "Emit the canonical `:status :stale` /
@@ -458,18 +458,18 @@
   it as a uniform stale-suppression row. Gated on `debug-enabled?` like the
   other `:rf.http/*` trace rows."
   [superseded-handle current-work-id]
-  (when interop/debug-enabled?
+  (when rf.interop/debug-enabled?
     (let [stale-ctx {:request-id   (:request-id superseded-handle)
                      :origin-event (:origin-event superseded-handle)
                      :issuance     (:issuance superseded-handle)
                      :attempt      (:attempt superseded-handle)
                      :frame        (:frame superseded-handle)}
-          {:keys [reply trace]} (http-reply/suppress stale-ctx current-work-id)
-          summary (http-reply/trace-reply
+          {:keys [reply trace]} (rf.http.reply/suppress stale-ctx current-work-id)
+          summary (rf.http.reply/trace-reply
                     reply
                     (cond-> {:sensitive? (true? (:sensitive? superseded-handle))}
                       (:frame superseded-handle) (assoc :frame (:frame superseded-handle))))]
-      (trace/emit! :info :rf.http/stale-suppressed
+      (rf.trace/emit! :info :rf.http/stale-suppressed
                    (cond-> {:rf.reply/status       (:status summary)
                             :rf.reply/work-status   (:rf.reply/work-status summary)
                             :rf.reply/stale-reason  (:rf.reply/stale-reason summary)
@@ -501,7 +501,7 @@
   [ctx failure]
   (when (on-failure-silenced? ctx)
     (warn-failure-swallowed! failure (:url ctx) (:sensitive? ctx)))
-  (let [reply (http-reply/failure-reply (reply-ctx ctx) failure)]
+  (let [reply (rf.http.reply/failure-reply (reply-ctx ctx) failure)]
     (emit-reply-trace! ctx reply)
     (dispatch-reply! (assoc ctx
                             :kind          :failure
@@ -522,7 +522,7 @@
   `handle-response!`'s 2xx branch) rides the canonical reply under `:meta`
   so both the `:after` chain and the app reply target can read it."
   [ctx value]
-  (let [reply (http-reply/success-reply (reply-ctx ctx) value (:response-meta ctx))]
+  (let [reply (rf.http.reply/success-reply (reply-ctx ctx) value (:response-meta ctx))]
     (emit-reply-trace! ctx reply)
     (dispatch-reply! (assoc ctx
                             :kind          :success
@@ -546,13 +546,13 @@
   `re-frame.elision/elide-wire-value` walker. Gated on `debug-enabled?` like
   the other `:rf.http/*` trace rows."
   [ctx]
-  (when interop/debug-enabled?
-    (let [{:keys [reply trace]} (http-reply/actor-destroy-suppress ctx)
-          summary (http-reply/trace-reply
+  (when rf.interop/debug-enabled?
+    (let [{:keys [reply trace]} (rf.http.reply/actor-destroy-suppress ctx)
+          summary (rf.http.reply/trace-reply
                     reply
                     (cond-> {:sensitive? (true? (:sensitive? ctx))}
                       (:frame ctx) (assoc :frame (:frame ctx))))]
-      (trace/emit! :info :rf.http/stale-suppressed
+      (rf.trace/emit! :info :rf.http/stale-suppressed
                    (cond-> {:rf.reply/status       (:status summary)
                             :rf.reply/work-status   (:rf.reply/work-status summary)
                             :rf.reply/stale-reason  (:rf.reply/stale-reason summary)
@@ -615,14 +615,14 @@
                                 :reason   reason
                                 :actor-id (:actor-id ctx)}
                                ctx)]
-    (when interop/debug-enabled?
+    (when rf.interop/debug-enabled?
       (let [sensitive? (true? (:sensitive? ctx))
-            redacted   (privacy/prepare-emit-failure
+            redacted   (rf.http.privacy/prepare-emit-failure
                          (assoc failure
                                 :url      (:url ctx)
                                 :recovery :no-recovery)
                          sensitive?)]
-        (trace/emit-error! :rf.http/aborted redacted)))
+        (rf.trace/emit-error! :rf.http/aborted redacted)))
     ;; An abort is terminal for this request-id (this is the
     ;; direct abort-fn choke: user / actor-destroy / supersede / epoch-restore
     ;; all land here). Evict the issuance counter so an unbounded distinct-id
@@ -630,7 +630,7 @@
     ;; supersede has ALREADY bumped the counter past this (superseded) attempt's
     ;; issuance, so the evict skips and the live successor keeps the id; only a
     ;; genuinely-quiescent id is dropped.
-    (registry/evict-issuance-on-completion! (:request-id ctx) (:issuance ctx))
+    (rf.http.registry/evict-issuance-on-completion! (:request-id ctx) (:issuance ctx))
     ;; rf2-3fc89f.9 — terminal for this request: detach the external
     ;; `:abort-signal` listener so a shared / parent controller retains no
     ;; completed-request listener. Fires for every abort reason (this is the
@@ -650,7 +650,7 @@
       ;; delivery as a canonical `:status :stale` / `:rf.reply/work-status :suppressed`
       ;; outcome (Managed-Effects §Cancellation). The app target MUST NOT run.
       (and (= :actor-destroyed reason)
-           (http-reply/actor-destroy-target-obsolete?
+           (rf.http.reply/actor-destroy-target-obsolete?
              (reply-target-id ctx) (:actor-id ctx)))
       (emit-actor-destroy-stale-trace! (reply-ctx ctx))
 
@@ -724,13 +724,13 @@
   reply names which request failed."
   [ctx failure]
   (let [failure (self-identify failure ctx)]
-  (when interop/debug-enabled?
+  (when rf.interop/debug-enabled?
     ;; Redact response-side payload slots (body, body-text,
     ;; decoded, detail) and the headers denylist before the trace surface
     ;; sees them; stamp :sensitive? when applicable. The CLJS and JVM
     ;; transports share the same contract.
     (let [sensitive? (true? (:sensitive? ctx))
-          redacted   (privacy/prepare-emit-failure
+          redacted   (rf.http.privacy/prepare-emit-failure
                        (assoc failure
                               :request-id (:request-id ctx)
                               :url        (:url ctx)
@@ -761,12 +761,12 @@
           redacted   (cond-> redacted
                        (contains? failure :decoded)
                        (assoc :rf.http/off-box-body
-                              (privacy-body/off-box-body-disposition (:decode ctx)))
+                              (rf.http.privacy-body/off-box-body-disposition (:decode ctx)))
 
                        (or (contains? failure :body)
                            (contains? failure :body-text))
                        (assoc :rf.http/off-box-body :omit))]
-      (trace/emit-error! (:kind failure) redacted)))
+      (rf.trace/emit-error! (:kind failure) redacted)))
   (cond
     ;; rf2-lxd3 / rf2-u5kmf8 — supersede / epoch-restore reasons suppress the
     ;; reply outright; the canonical stale trace for those is emitted at
@@ -791,7 +791,7 @@
     ;; snapshot (`aborted-failure`), falling back to the ctx's actor-id.
     (and (= :rf.http/aborted (:kind failure))
          (= :actor-destroyed (:reason failure))
-         (http-reply/actor-destroy-target-obsolete?
+         (rf.http.reply/actor-destroy-target-obsolete?
            (reply-target-id ctx) (:actor-id failure)))
     (emit-actor-destroy-stale-trace! (reply-ctx ctx))
 
@@ -815,10 +815,10 @@
   (if-let [abort-state (aborted-snapshot ctx)]
     (finalise-failure! ctx (aborted-failure ctx abort-state))
     (when-not (already-replied? ctx)
-      (registry/clear-in-flight! (:request-id ctx) (:handle ctx))
+      (rf.http.registry/clear-in-flight! (:request-id ctx) (:handle ctx))
       ;; rf2-k47b3d — terminal completion: evict this id's issuance counter
       ;; (conditional-atomic; skips when a live re-issue has bumped past it).
-      (registry/evict-issuance-on-completion! (:request-id ctx) (:issuance ctx))
+      (rf.http.registry/evict-issuance-on-completion! (:request-id ctx) (:issuance ctx))
       ;; rf2-3fc89f.9 — terminal: detach the external abort-signal listener
       ;; (covers the success, accept-failure, and sample-(2) abort branches
       ;; below; idempotent with the abort-path detach in `dispatch-aborted!`).
@@ -861,7 +861,7 @@
           (emit-and-dispatch-failure!
             ctx {:kind       :rf.http/accept-failure
                  :detail     (:failure accepted)
-                 :decoded    (privacy-body/classify-decoded (:decoded ctx) (:decode ctx))
+                 :decoded    (rf.http.privacy-body/classify-decoded (:decoded ctx) (:decode ctx))
                  :request-id (:request-id ctx)}))))))
 
 (defn- finalise-failure!
@@ -907,12 +907,12 @@
                                (not= :rf.http/aborted (:kind failure)))
                         (aborted-failure ctx abort-state)
                         failure)]
-      (registry/clear-in-flight! (:request-id ctx) (:handle ctx))
+      (rf.http.registry/clear-in-flight! (:request-id ctx) (:handle ctx))
       ;; rf2-k47b3d — terminal completion: evict this id's issuance counter
       ;; (conditional-atomic; skips when a live re-issue has bumped past it, so
       ;; a superseded-then-reclassified attempt does not drop the successor's
       ;; live counter).
-      (registry/evict-issuance-on-completion! (:request-id ctx) (:issuance ctx))
+      (rf.http.registry/evict-issuance-on-completion! (:request-id ctx) (:issuance ctx))
       ;; rf2-3fc89f.9 — terminal: detach the external abort-signal listener
       ;; (natural terminal failure + the abort-precedence reclassification;
       ;; idempotent with the abort-path detach in `dispatch-aborted!`).
@@ -948,8 +948,8 @@
   the off-box trace-events projector omits the nested `[:failure :body]`
   slot off-box."
   [ctx failure next-backoff-ms recovery]
-  (trace/emit! :info :rf.http/retry-attempt
-               (cond-> (privacy/prepare-emit-tags
+  (rf.trace/emit! :info :rf.http/retry-attempt
+               (cond-> (rf.http.privacy/prepare-emit-tags
                          {:request-id      (:request-id ctx)
                           :url             (:url ctx)
                           :attempt         (:attempt ctx)
@@ -1058,7 +1058,7 @@
                      ;; fire that loses here bails without retrying.
                      (when (compare-and-set! fired? false true)
                        (when-let [t @timer-cell]
-                         (interop/clear-timeout! t))
+                         (rf.interop/clear-timeout! t))
                        ;; rf2-meq28 — drop the backoff handle from both
                        ;; indexes via the 2-arg `clear-in-flight!`, passing
                        ;; the stamped handle (through `@handle-cell`) so the
@@ -1067,7 +1067,7 @@
                        ;; This mirrors the rf2-lz7se fix at the live-fetch
                        ;; abort-fn in `run-attempt!` and the by-identity
                        ;; clear the timer-fires path below already uses.
-                       (registry/clear-in-flight! request-id @handle-cell)
+                       (rf.http.registry/clear-in-flight! request-id @handle-cell)
                        ;; rf2-6nczv9 — dispatch guarded by the SHARED once-only
                        ;; reply guard so a prior-phase abort-fn (the just-
                        ;; completed live-fetch handle, resolvable during the
@@ -1079,7 +1079,7 @@
                        ;; as before.
                        (when (compare-and-set! finalised? false true)
                          (dispatch-aborted! ctx reason))))
-        handle     (registry/record-in-flight!
+        handle     (rf.http.registry/record-in-flight!
                      request-id actor-id
                      {:abort-fn   abort-fn
                       :url        (:url ctx)
@@ -1129,7 +1129,7 @@
         ;; index and only drops the prior handle from the actor index (rf2-wvkn
         ;; — no stale accumulation across retries).
         _          (when prev-handle
-                     (registry/clear-in-flight! request-id prev-handle))
+                     (rf.http.registry/clear-in-flight! request-id prev-handle))
         ;; rf2-3fc89f.9 — ownership transfer: rebind the external
         ;; `:abort-signal` from the just-completed live-fetch handle onto THIS
         ;; sleeping-backoff handle's canonical abort-fn, so a signal that fires
@@ -1140,7 +1140,7 @@
         ;; backoff abort-fn synchronously (winning `fired?`); the trailing
         ;; re-check below then disarms the armed timer.
         #?@(:cljs
-            [_     (transport-cljs/bind-external-abort!
+            [_     (rf.http.transport-cljs/bind-external-abort!
                      (:external-abort ctx)
                      (fn [] ((:abort-fn handle) :user)))])
         ;; rf2-6nczv9 — test-only interleaving seam: an abort injected HERE
@@ -1151,7 +1151,7 @@
         ;; instant the timer is armed. The callback wins/loses the same
         ;; `fired?` CAS: on a win it clears its own handle and proceeds;
         ;; on a loss (a cancel beat it) it does nothing.
-        timer      (interop/set-timeout!
+        timer      (rf.interop/set-timeout!
                      (fn []
                        (when (compare-and-set! fired? false true)
                          ;; rf2-6nczv9 — CONTINUOUS HANDOFF into attempt N+1.
@@ -1195,7 +1195,7 @@
       ;; read `timer-cell` as nil and skipped `clear-timeout!`; re-check and
       ;; disarm the now-known timer so the scheduler carries no doomed task.
       @fired?
-      (interop/clear-timeout! timer)
+      (rf.interop/clear-timeout! timer)
 
       ;; rf2-6nczv9 — the SHARED abort cell is flipped but this backoff's own
       ;; abort-fn never ran: an abort resolved the PRIOR live-fetch handle
@@ -1207,8 +1207,8 @@
       (and (some? @aborted?)
            (compare-and-set! fired? false true))
       (do
-        (interop/clear-timeout! timer)
-        (registry/clear-in-flight! request-id handle)))
+        (rf.interop/clear-timeout! timer)
+        (rf.http.registry/clear-in-flight! request-id handle)))
     nil))
 
 (defn- maybe-retry!
@@ -1251,7 +1251,7 @@
                          (not= :rf.http/aborted kind)
                          (not aborted?))]
     (if can-retry?
-      (let [delay-ms (encoding/compute-backoff-ms (or backoff {}) attempt)]
+      (let [delay-ms (rf.http.encoding/compute-backoff-ms (or backoff {}) attempt)]
         ;; rf2-fyt5i — HONEST timing: the intermediate `:recovery :retried`
         ;; disposition is deliberately NOT emitted here. This point only
         ;; DECIDES a retry is eligible and arms the backoff; the request can
@@ -1309,7 +1309,7 @@
         ;;       (e.g. attempt 1 retries a 5xx, attempt 2 hits a non-retryable
         ;;       decode failure under `:max-attempts 3`).
         ;; A non-retried, non-eligible terminal failure emits nothing.
-        (when (and interop/debug-enabled?
+        (when (and rf.interop/debug-enabled?
                    (some? max-attempts)
                    (> max-attempts 1)
                    (or (> attempt 1)
@@ -1371,7 +1371,7 @@
       (let [decode-result
             (try
               {:decoded
-               (decode/decode-response-body
+               (rf.http.decode/decode-response-body
                  {:body-text        body-text
                   ;; rf2-5zj6t — the CLJS transport reads a native
                   ;; Blob / ArrayBuffer / FormData for binary decode
@@ -1458,9 +1458,9 @@
                 ;; request was not declared per-call `:sensitive?`. A
                 ;; non-schema `:decode` is a no-op here (the per-call flag /
                 ;; off-box disposition govern an unschematized body).
-                decoded' (privacy-body/classify-decoded decoded decode)
+                decoded' (rf.http.privacy-body/classify-decoded decoded decode)
                 outcome (try
-                          {:accepted (encoding/run-accept accept decoded)}
+                          {:accepted (rf.http.encoding/run-accept accept decoded)}
                           (catch #?(:clj Throwable :cljs :default) e
                             {:accept-error e}))]
             (cond
@@ -1474,7 +1474,7 @@
                  :decoded    decoded'
                  :request-id request-id})
 
-              (encoding/valid-accept-return? (:accepted outcome))
+              (rf.http.encoding/valid-accept-return? (:accepted outcome))
               (finalise-success! ctx' (:accepted outcome))
 
               :else
@@ -1533,9 +1533,9 @@
   [request]
   (try
     (let [body          (let [b (:body request)] (if (fn? b) (b) b))
-          [enc-body ct] (encoding/encode-body body (:request-content-type request))
+          [enc-body ct] (rf.http.encoding/encode-body body (:request-content-type request))
           headers       (cond-> (or (:headers request) {})
-                          (and ct (nil? (decode/content-type-of (:headers request))))
+                          (and ct (nil? (rf.http.decode/content-type-of (:headers request))))
                           (assoc "Content-Type" ct))]
       {:ok {:enc-body enc-body :headers headers}})
     (catch #?(:clj Throwable :cljs :default) e
@@ -1572,7 +1572,7 @@
         ctx      (dissoc ctx :rf.http/retry-handoff)
         {:keys [request timeout-ms request-id actor-id abort-signal]} ctx
         method   (or (:method request) :get)
-        url      (encoding/merge-params (:url request) (:params request))
+        url      (rf.http.encoding/merge-params (:url request) (:params request))
         ;; rf2-065xo — body realization + encoding are DEFERRED past handle
         ;; registration and run inside `prepare-body!` as a managed
         ;; request-preparation PHASE (see below). Realizing a `:body` thunk
@@ -1596,7 +1596,7 @@
         ;; JVM treats `:abort-signal` as a degraded no-op (a one-line trace via
         ;; `check-cljs-only-keys!`), so no binding is made there.
         external-abort #?(:cljs (or (:external-abort ctx)
-                                    (transport-cljs/make-external-abort abort-signal))
+                                    (rf.http.transport-cljs/make-external-abort abort-signal))
                           :clj  nil)
         ctx-no-handle (cond-> (assoc ctx :url url)
                         external-abort (assoc :external-abort external-abort))
@@ -1698,7 +1698,7 @@
         ;; Register the abort handle. The handle ref is stamped into ctx
         ;; so finalise-* can clear it from both indexes without needing
         ;; the request-id, including anonymous actor-owned requests.
-        handle   (registry/record-in-flight!
+        handle   (rf.http.registry/record-in-flight!
                    request-id actor-id
                    {:abort-fn (fn [reason]
                                 ;; Flip `:aborted?` before the
@@ -1792,7 +1792,7 @@
                                   ;; the vector) while closing the gap for
                                   ;; any future trigger that does not
                                   ;; pre-clear.
-                                  (registry/clear-in-flight! request-id @handle-holder)
+                                  (rf.http.registry/clear-in-flight! request-id @handle-holder)
                                   ;; The abort closure dispatches a synthesised reply directly
                                   ;; (no finalise-failure! re-entry). The
                                   ;; shared `dispatch-aborted!` reuses the
@@ -1845,7 +1845,7 @@
         ;; removes the predecessor from the actor index (no stale accumulation
         ;; across retries, rf2-wvkn). No-op on the first attempt (no handoff).
         _        (when-let [prev (:prev-handle handoff)]
-                   (registry/clear-in-flight! request-id prev))
+                   (rf.http.registry/clear-in-flight! request-id prev))
         ;; rf2-3fc89f.9 — bind the external `:abort-signal` to THIS live-fetch
         ;; handle's canonical abort-fn (`:reason :user`), detaching the prior
         ;; phase's listener (ownership transfer). An ALREADY-aborted signal
@@ -1857,7 +1857,7 @@
         ;; cancellation, Spec 014 §Abort precedence). Must run AFTER
         ;; `handle-holder` is published (the abort-fn reads `@handle-holder`).
         #?@(:cljs
-            [_   (transport-cljs/bind-external-abort!
+            [_   (rf.http.transport-cljs/bind-external-abort!
                    external-abort
                    (fn [] ((:abort-fn handle) :user)))])
         ctx'     (assoc ctx-no-handle :handle handle)]
@@ -1875,7 +1875,7 @@
     ;; (On the first attempt / steady-state retry the cell is nil and this is a
     ;; single volatile read.)
     (when (some? @aborted?)
-      (registry/clear-in-flight! request-id handle)
+      (rf.http.registry/clear-in-flight! request-id handle)
       (when (compare-and-set! finalised? false true)
         (dispatch-aborted! ctx-no-handle (:reason @aborted?))))
     ;; rf2-6nczv9 / rf2-fyt5i — HONEST `:retried` (retry handoff only): the
@@ -1888,7 +1888,7 @@
     (when (and (some? handoff)
                (not (some? @aborted?))
                (not @finalised?)
-               interop/debug-enabled?)
+               rf.interop/debug-enabled?)
       (emit-retry-attempt! (:emit-ctx handoff) (:failure handoff) (:delay-ms handoff) :retried))
     ;; rf2-3fc89f.9 — short-circuit when an already-aborted external signal
     ;; won the CAS synchronously during the bind above: the request is already
@@ -1939,7 +1939,7 @@
         (interleave! :issue/before-send ctx')
         #?(:cljs
            (when (compare-and-set! issue-phase nil :issued)
-           (-> (transport-cljs/cljs-fetch
+           (-> (rf.http.transport-cljs/cljs-fetch
                            {:method              method
                             :url                 url
                             :headers             headers
@@ -1985,7 +1985,7 @@
                ;; natural-completion sink without a bespoke "did we abort?"
                ;; check here.
                (.catch (fn [err]
-                         (maybe-retry! ctx' (transport-cljs/classify-cljs-error err url))))))
+                         (maybe-retry! ctx' (rf.http.transport-cljs/classify-cljs-error err url))))))
            :clj
            ;; Monotonic start mark for the per-host timeout
            ;; `:elapsed-ms`. `System/nanoTime` is the JDK's monotonic clock
@@ -2012,7 +2012,7 @@
                (when-let [^CompletableFuture cf
                           (locking issue-lock
                             (when (compare-and-set! issue-phase nil :issued)
-                              (let [cf (transport-jvm/jvm-fetch
+                              (let [cf (rf.http.transport-jvm/jvm-fetch
                                          {:method     method
                                           :url        url
                                           :headers    headers
@@ -2058,7 +2058,7 @@
                                 (reify java.util.function.BiConsumer
                                   (accept [_ result throwable]
                                     (if throwable
-                                      (maybe-retry! ctx' (transport-jvm/classify-jvm-error throwable timeout-ms (elapsed-ms)))
+                                      (maybe-retry! ctx' (rf.http.transport-jvm/classify-jvm-error throwable timeout-ms (elapsed-ms)))
                                       (handle-response! ctx' result))))))
                (catch Throwable t
-                 (maybe-retry! ctx' (transport-jvm/classify-jvm-error t timeout-ms (elapsed-ms)))))))))))))
+                 (maybe-retry! ctx' (rf.http.transport-jvm/classify-jvm-error t timeout-ms (elapsed-ms)))))))))))))

--- a/implementation/http/src/re_frame/http/transport_cljs.cljc
+++ b/implementation/http/src/re_frame/http/transport_cljs.cljc
@@ -18,12 +18,12 @@
   `:cljs` reader branch). Keeping the conditionals local to the adapter is
   this boundary keeps CLJS interop out of the shared loop."
   (:require [clojure.string         :as str]
-            [re-frame.error         :as error]
-            [re-frame.http.decode   :as decode]
-            [re-frame.http.encoding :as encoding]
-            [re-frame.http.privacy  :as privacy]
-            [re-frame.interop       :as interop]
-            [re-frame.trace         :as trace]))
+            [re-frame.error         :as rf.error]
+            [re-frame.http.decode   :as rf.http.decode]
+            [re-frame.http.encoding :as rf.http.encoding]
+            [re-frame.http.privacy  :as rf.http.privacy]
+            [re-frame.interop       :as rf.interop]
+            [re-frame.trace         :as rf.trace]))
 
 ;; ---- platform transport: CLJS Fetch ---------------------------------------
 
@@ -130,13 +130,13 @@
                           ;; request-prep failures to stay on the managed path,
                           ;; not escape as fx errors.
                           (let [h (js/Headers.)]
-                            (doseq [[k v] (encoding/normalize-header-pairs headers)]
+                            (doseq [[k v] (rf.http.encoding/normalize-header-pairs headers)]
                               (try
                                 (.append h k v)
                                 (catch :default e
-                                  (when interop/debug-enabled?
-                                    (trace/emit! :warning :rf.warning/http-header-invalid
-                                                 (privacy/prepare-emit-tags
+                                  (when rf.interop/debug-enabled?
+                                    (rf.trace/emit! :warning :rf.warning/http-header-invalid
+                                                 (rf.http.privacy/prepare-emit-tags
                                                    {:url    url
                                                     :header k
                                                     :cause  (or (some-> ^js e .-message)
@@ -205,7 +205,7 @@
                    ;; only on 2xx, so a non-OK response always
                    ;; takes the text path regardless of `:decode`.
                    binary-read-mode (when ok?
-                                      (decode/binary-read-kind decode headers))]
+                                      (rf.http.decode/binary-read-kind decode headers))]
                (case binary-read-mode
                  :blob
                  (-> (.blob resp)
@@ -248,7 +248,7 @@
                                       (fn []
                                         (try (.abort internal-controller "timeout")
                                              (catch :default _ nil))
-                                        (reject (error/thrown-ex-info
+                                        (reject (rf.error/thrown-ex-info
                                                   :rf.error/http-timeout
                                                   ':rf.http/managed
                                                   (str "the request exceeded its " timeout-ms "ms timeout and was aborted")

--- a/implementation/http/src/re_frame/http/transport_jvm.cljc
+++ b/implementation/http/src/re_frame/http/transport_jvm.cljc
@@ -25,11 +25,11 @@
   effectively empty save the `check-cljs-only-keys!` no-op. Keeping the
   conditionals local to the adapter keeps JDK interop out of the shared loop."
   (:require [clojure.string         :as str]
-            [re-frame.http.decode   :as decode]
-            [re-frame.http.encoding :as encoding]
-            [re-frame.http.privacy  :as privacy]
-            [re-frame.interop       :as interop]
-            [re-frame.trace         :as trace])
+            [re-frame.http.decode   :as rf.http.decode]
+            [re-frame.http.encoding :as rf.http.encoding]
+            [re-frame.http.privacy  :as rf.http.privacy]
+            [re-frame.interop       :as rf.interop]
+            [re-frame.trace         :as rf.trace])
   #?(:clj (:import [java.net URI]
                    [java.net.http HttpClient HttpClient$Redirect
                                   HttpRequest
@@ -166,7 +166,7 @@
        ;; "no timeout" so the JDK request carries no per-request deadline.
        (when (and timeout-ms (pos? timeout-ms))
          (.timeout b (Duration/ofMillis (long timeout-ms))))
-       (doseq [[k v] (encoding/normalize-header-pairs headers)]
+       (doseq [[k v] (rf.http.encoding/normalize-header-pairs headers)]
          ;; Surface JDK HttpClient header-validation throws
          ;; via a `:rf.warning/http-header-invalid` trace rather than
          ;; silently dropping. Stray `\r`/`\n` / control chars / empty
@@ -189,9 +189,9 @@
           ;; stamped when the request is sensitive.
          (try (.header b k v)
               (catch Throwable t
-                (when interop/debug-enabled?
-                  (trace/emit! :warning :rf.warning/http-header-invalid
-                               (privacy/prepare-emit-tags
+                (when rf.interop/debug-enabled?
+                  (rf.trace/emit! :warning :rf.warning/http-header-invalid
+                               (rf.http.privacy/prepare-emit-tags
                                  {:url     url
                                   :header  k
                                   :cause   (.getMessage t)}
@@ -246,7 +246,7 @@
      decodes identically to the prior `ofString` behaviour. An unknown /
      unparseable charset falls back to UTF-8."
      ^Charset [headers]
-     (or (when-let [ct (decode/content-type-of headers)]
+     (or (when-let [ct (rf.http.decode/content-type-of headers)]
            (let [m (re-find #"(?i)charset=\s*\"?([^\";\s]+)" (str ct))]
              (when-let [cs (second m)]
                (try (Charset/forName cs)
@@ -295,7 +295,7 @@
                              headers  (jvm-headers->map (.headers r))
                              ^bytes raw (.body r)
                              binary?  (and ok?
-                                           (some? (decode/binary-read-kind decode headers)))
+                                           (some? (rf.http.decode/binary-read-kind decode headers)))
                              base     {:ok?         ok?
                                        :status      status
                                        :status-text ""
@@ -367,14 +367,14 @@
 
 #?(:clj
    (defn- emit-cljs-only-skipped! [k url sensitive?]
-     (when interop/debug-enabled?
+     (when rf.interop/debug-enabled?
        ;; Route through the privacy composer so a denylisted
        ;; query param in the URL is scrubbed and `:sensitive?` is stamped
        ;; on the warning event when the request is
        ;; sensitive. The frame supplies general trace attribution and elision;
        ;; HTTP carrier names come from the effect registration.
-       (trace/emit! :warning :rf.http/cljs-only-key-ignored-on-jvm
-                    (privacy/prepare-emit-tags
+       (rf.trace/emit! :warning :rf.http/cljs-only-key-ignored-on-jvm
+                    (rf.http.privacy/prepare-emit-tags
                       {:key k :url url}
                       (true? sensitive?))))))
 
@@ -409,10 +409,10 @@
        ;; only flag an EXPLICIT binary `:decode` here: `:auto` resolves to
        ;; `:blob` from the response Content-Type, which isn't known at
        ;; dispatch time. Per Spec 014 §JVM degradation table.
-       (when (and interop/debug-enabled?
+       (when (and rf.interop/debug-enabled?
                   (contains? #{:blob :array-buffer :form-data} decode))
-         (trace/emit! :warning :rf.http/binary-decode-degraded-on-jvm
-                      (privacy/prepare-emit-tags
+         (rf.trace/emit! :warning :rf.http/binary-decode-degraded-on-jvm
+                      (rf.http.privacy/prepare-emit-tags
                         {:decode decode :url url}
                         (true? sensitive?)))))))
 

--- a/implementation/http/src/re_frame/http/url.cljc
+++ b/implementation/http/src/re_frame/http/url.cljc
@@ -45,7 +45,7 @@
   on `interop/debug-enabled?` at their call sites (same gate as
   `trace/emit!`); no walker runs without the trace surface."
   (:require [clojure.string :as str]
-            [re-frame.privacy :as privacy])
+            [re-frame.privacy :as rf.privacy])
   #?(:clj (:import [java.net URLDecoder])))
 
 ;; ---- redaction sentinel ---------------------------------------------------
@@ -69,7 +69,7 @@
   core. This is the HTTP-side public anchor; `http-privacy`
   and `http-privacy-headers` both refer to it privately, so
   the keyword cannot drift across the http privacy cluster."
-  privacy/redacted-sentinel)
+  rf.privacy/redacted-sentinel)
 
 ;; ---- query-param denylist -------------------------------------------------
 

--- a/implementation/http/test/re_frame/flows_http_integration_test.clj
+++ b/implementation/http/test/re_frame/flows_http_integration_test.clj
@@ -57,8 +57,8 @@
             ;; flows artefact loaded (the canonical fixture's flows reset is
             ;; late-bound and no-ops when the artefact is absent).
             [re-frame.flows]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.http.registry :as http-registry]
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.registry :as rf.http.registry]
             ;; rf2-cdmle — required only to keep the test-support
             ;; canned-stub fx ids registered (mirrors http-managed-test's
             ;; require closure). This file does NOT use the stubs; the
@@ -66,16 +66,16 @@
             ;; in-flight registry with a recording abort-fn (mirrors
             ;; routing_http_composed_corners_test.clj's pattern).
             [re-frame.http.test-support]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace]))
 
 ;; ---- per-test reset / trace recorder -------------------------------------
 
 (def ^:dynamic ^:private *captured* nil)
 
 (def ^:private reset-runtime-fixture
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- reset-runtime [test-fn]
   ;; Canonical runtime reset (registrar snapshot/restore + frames / flows /
@@ -87,13 +87,13 @@
     (fn []
       (let [captured (atom [])]
         (binding [*captured* captured]
-          (trace/register-listener!
+          (rf.trace/register-listener!
             ::flows-http-recorder
             (fn [ev] (swap! captured conj ev)))
           (try
             (test-fn)
             (finally
-              (trace/unregister-listener! ::flows-http-recorder))))))))
+              (rf.trace/unregister-listener! ::flows-http-recorder))))))))
 
 (use-fixtures :each reset-runtime)
 
@@ -117,7 +117,7 @@
   `abort-fn` is the recording closure the test uses to observe whether
   `:rf.http/managed-abort` fired."
   [request-id abort-fn]
-  (http-registry/seed-in-flight-for-test!
+  (rf.http.registry/seed-in-flight-for-test!
     {:request-id request-id
      :actor-id   nil
      :url        (str "/api/" (name request-id))
@@ -305,7 +305,7 @@
              and a flow throw aborts the event BEFORE install (atomicity
              contract rule a; split-brain prevention: no transport abort
              on a request whose app-db state still says it's pending)")
-        (is (contains? (http-managed/in-flight-snapshot) :load-articles)
+        (is (contains? (rf.http.managed/in-flight-snapshot) :load-articles)
             "the side-channel in-flight registry STILL holds the request
              — finalise-failure! never ran because the abort-fn was never
              called")

--- a/implementation/http/test/re_frame/http_abort_body_prep_race_test.clj
+++ b/implementation/http/test/re_frame/http_abort_body_prep_race_test.clj
@@ -44,22 +44,22 @@
   timing sleeps."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.http.registry :as registry]
-            [re-frame.http.transport :as transport]
-            [re-frame.http.transport-jvm :as transport-jvm]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support])
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.registry :as rf.http.registry]
+            [re-frame.http.transport :as rf.http.transport]
+            [re-frame.http.transport-jvm :as rf.http.transport-jvm]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support])
   (:import [java.lang Thread$State]
            [java.util.concurrent CompletableFuture]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- await-condition!
   ([pred] (await-condition! pred 5000))
   ([pred timeout-ms]
-   (test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
+   (rf.test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
                                   :label "http-abort-body-prep-race condition"})
    true))
 
@@ -102,7 +102,7 @@
           thunk-entered (promise)
           release       (promise)
           replies       (atom [])]
-      (with-redefs [transport-jvm/jvm-fetch (fn [_]
+      (with-redefs [rf.http.transport-jvm/jvm-fetch (fn [_]
                                               (swap! fetch-calls inc)
                                               (CompletableFuture.))]
         (register-recorder-and-issue!
@@ -120,14 +120,14 @@
           (try
             (is (true? (deref thunk-entered 5000 false))
                 "the body thunk entered — preparation is in progress")
-            (is (contains? (registry/in-flight-snapshot) :prep-race)
+            (is (contains? (rf.http.registry/in-flight-snapshot) :prep-race)
                 "the handle was registered before preparation began")
             ;; The abort resolves the live handle and COMPLETES (registry
             ;; cleared synchronously by the abort closure) while the thunk
             ;; is still held.
-            (is (true? (registry/abort-in-flight! :prep-race :user))
+            (is (true? (rf.http.registry/abort-in-flight! :prep-race :user))
                 "the abort resolved the in-flight handle before release")
-            (is (empty? (registry/in-flight-snapshot))
+            (is (empty? (rf.http.registry/in-flight-snapshot))
                 "the registry is cleared before the body thunk is released")
             (is (zero? @fetch-calls)
                 "no transport call while preparation is held")
@@ -146,9 +146,9 @@
                   "the single reply is the canonical cancellation")
               (is (= :rf.http/aborted (get-in reply [:error :kind])))
               (is (= :user (get-in reply [:error :reason]))))
-            (is (empty? (registry/in-flight-snapshot))
+            (is (empty? (rf.http.registry/in-flight-snapshot))
                 "the request-id registry stays clean")
-            (is (empty? (registry/actor-in-flight-snapshot))
+            (is (empty? (rf.http.registry/actor-in-flight-snapshot))
                 "the actor registry stays clean")
             (finally
               (deliver release true)
@@ -162,7 +162,7 @@
           thunk-entered (promise)
           release       (promise)
           replies       (atom [])]
-      (with-redefs [transport-jvm/jvm-fetch
+      (with-redefs [rf.http.transport-jvm/jvm-fetch
                     (fn [_]
                       (swap! fetch-calls inc)
                       (CompletableFuture/completedFuture
@@ -192,7 +192,7 @@
             (is (= 1 (count @replies)))
             (is (= :ok (:status (first @replies)))
                 "the request completed normally through the stubbed transport")
-            (is (empty? (registry/in-flight-snapshot)))
+            (is (empty? (rf.http.registry/in-flight-snapshot)))
             (finally
               (deliver release true)
               (deref worker 5000 nil))))))))
@@ -204,7 +204,7 @@
     (let [fetch-calls  (atom 0)
           abort-result (atom ::not-fired)
           replies      (atom [])]
-      (with-redefs [transport-jvm/jvm-fetch (fn [_]
+      (with-redefs [rf.http.transport-jvm/jvm-fetch (fn [_]
                                               (swap! fetch-calls inc)
                                               (CompletableFuture.))]
         (register-recorder-and-issue!
@@ -216,7 +216,7 @@
            ;; alone stands between the delivered cancellation and the send.
            :body   (fn []
                      (reset! abort-result
-                             (registry/abort-in-flight! :prep-reentrant :user))
+                             (rf.http.registry/abort-in-flight! :prep-reentrant :user))
                      "reentrant-body")})
         (rf/dispatch-sync [:issue])
         (is (true? @abort-result)
@@ -228,7 +228,7 @@
         (let [reply (first @replies)]
           (is (= :cancelled (:status reply)))
           (is (= :rf.http/aborted (get-in reply [:error :kind]))))
-        (is (empty? (registry/in-flight-snapshot)))))))
+        (is (empty? (rf.http.registry/in-flight-snapshot)))))))
 
 ;; ---- (4) handoff control: issuance wins, the future is cancellable ---------
 
@@ -237,7 +237,7 @@
     (let [fetch-calls (atom 0)
           returned-cf (atom nil)
           replies     (atom [])]
-      (with-redefs [transport-jvm/jvm-fetch (fn [_]
+      (with-redefs [rf.http.transport-jvm/jvm-fetch (fn [_]
                                               (swap! fetch-calls inc)
                                               (let [cf (CompletableFuture.)]
                                                 (reset! returned-cf cf)
@@ -250,7 +250,7 @@
         (rf/dispatch-sync [:issue])
         (is (= 1 @fetch-calls) "issuance won — the transport was entered once")
         (is (some? @returned-cf) "the transport future exists")
-        (is (true? (registry/abort-in-flight! :issued-then-abort :user))
+        (is (true? (rf.http.registry/abort-in-flight! :issued-then-abort :user))
             "the abort resolved the in-flight handle")
         (is (.isCancelled ^CompletableFuture @returned-cf)
             "the abort cancelled the PUBLISHED future — the work actually stops")
@@ -260,7 +260,7 @@
         (let [reply (first @replies)]
           (is (= :cancelled (:status reply)))
           (is (= :rf.http/aborted (get-in reply [:error :kind]))))
-        (is (empty? (registry/in-flight-snapshot)))))))
+        (is (empty? (rf.http.registry/in-flight-snapshot)))))))
 
 ;; ---- (5) the issuance boundary: a completed abort issues nothing -----------
 
@@ -279,7 +279,7 @@
           abort-result (atom ::not-fired)
           replies      (atom [])]
       (try
-        (with-redefs [transport-jvm/jvm-fetch (fn [_]
+        (with-redefs [rf.http.transport-jvm/jvm-fetch (fn [_]
                                                 (swap! fetch-calls inc)
                                                 (let [cf (CompletableFuture.)]
                                                   (reset! returned-cf cf)
@@ -291,13 +291,13 @@
           ;; from the host call. The abort runs to completion here — registry
           ;; cleared, canonical cancelled reply dispatched — so no request may
           ;; follow it.
-          (transport/set-test-interleave-hook!
+          (rf.http.transport/set-test-interleave-hook!
             (fn [point ctx]
               (when (and (= point :issue/before-send)
                          (= :issuance-boundary (:request-id ctx))
                          (= ::not-fired @abort-result))
                 (reset! abort-result
-                        (registry/abort-in-flight! :issuance-boundary :user)))))
+                        (rf.http.registry/abort-in-flight! :issuance-boundary :user)))))
           (rf/dispatch-sync [:issue])
           (is (true? @abort-result)
               "the injected abort resolved the live handle at the issuance boundary")
@@ -311,10 +311,10 @@
             (is (= :cancelled (:status reply)))
             (is (= :rf.http/aborted (get-in reply [:error :kind])))
             (is (= :user (get-in reply [:error :reason]))))
-          (is (empty? (registry/in-flight-snapshot)))
-          (is (empty? (registry/actor-in-flight-snapshot))))
+          (is (empty? (rf.http.registry/in-flight-snapshot)))
+          (is (empty? (rf.http.registry/actor-in-flight-snapshot))))
         (finally
-          (transport/set-test-interleave-hook! nil))))))
+          (rf.http.transport/set-test-interleave-hook! nil))))))
 
 ;; ---- (6) the opposite ordering: the abort waits, then cancels --------------
 
@@ -328,7 +328,7 @@
           registry-in-region (atom ::not-sampled)
           replies-in-region  (atom ::not-sampled)
           replies            (atom [])]
-      (with-redefs [transport-jvm/jvm-fetch
+      (with-redefs [rf.http.transport-jvm/jvm-fetch
                     (fn [_]
                       ;; This stub runs INSIDE the issuance region, standing
                       ;; in for `HttpClient.sendAsync`. A competing abort
@@ -341,7 +341,7 @@
                                  ^Runnable
                                  (fn []
                                    (reset! abort-result
-                                           (registry/abort-in-flight! :handshake :user)))
+                                           (rf.http.registry/abort-in-flight! :handshake :user)))
                                  "rf2-rsv2n-aborter")]
                         (reset! returned-cf cf)
                         (reset! aborter t)
@@ -350,7 +350,7 @@
                         ;; Sampled while the abort is parked on the monitor:
                         ;; it has NOT completed, so the app has not been told
                         ;; the request was cancelled.
-                        (reset! registry-in-region (registry/in-flight-snapshot))
+                        (reset! registry-in-region (rf.http.registry/in-flight-snapshot))
                         (reset! replies-in-region @replies)
                         cf))]
         (register-recorder-and-issue!
@@ -376,5 +376,5 @@
         (let [reply (first @replies)]
           (is (= :cancelled (:status reply)))
           (is (= :rf.http/aborted (get-in reply [:error :kind]))))
-        (is (empty? (registry/in-flight-snapshot)))
-        (is (empty? (registry/actor-in-flight-snapshot)))))))
+        (is (empty? (rf.http.registry/in-flight-snapshot)))
+        (is (empty? (rf.http.registry/actor-in-flight-snapshot)))))))

--- a/implementation/http/test/re_frame/http_abort_config_validation_test.clj
+++ b/implementation/http/test/re_frame/http_abort_config_validation_test.clj
@@ -36,11 +36,11 @@
   single-outcome."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.http.handlers :as handlers]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace])
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.http.handlers :as rf.http.handlers]
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace])
   (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
            [java.net InetSocketAddress]
            [java.util.concurrent CountDownLatch TimeUnit]))
@@ -48,7 +48,7 @@
 ;; ---- per-test reset --------------------------------------------------------
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 
@@ -56,7 +56,7 @@
   "Invoke `:rf.http/managed` via the public handler with the given full
   args-map. Returns nil on success / no-throw, or the ex-info on a throw."
   [args-map]
-  (try (handlers/managed-handler {:frame :rf/default :event [:no-op]}
+  (try (rf.http.handlers/managed-handler {:frame :rf/default :event [:no-op]}
                                  args-map)
        nil
        (catch clojure.lang.ExceptionInfo e e)))
@@ -166,7 +166,7 @@
           (fn [_ _] {:fx [[:rf.http/managed-abort :dual]]}))
 
         (rf/dispatch-sync [:issue])
-        (await-condition! #(seq (http-managed/in-flight-snapshot)) 2000)
+        (await-condition! #(seq (rf.http.managed/in-flight-snapshot)) 2000)
         ;; Fire the user abort while the request is in-flight (server blocked).
         (rf/dispatch-sync [:do/abort])
         (await-condition! #(seq @replies))
@@ -184,7 +184,7 @@
               "the user-abort source determines :reason :user"))
         (is (= 1 (count @replies))
             "AT MOST ONE terminal outcome — the once-only :finalised? CAS")
-        (is (empty? (http-managed/in-flight-snapshot))
+        (is (empty? (rf.http.managed/in-flight-snapshot))
             "in-flight registry is clean after the single aborted reply")
         (finally
           (.countDown release)
@@ -210,7 +210,7 @@
           stale-traces (atom [])
           cb-id        ::q8vbna-stale]
       (try
-        (trace/register-listener! cb-id
+        (rf.trace/register-listener! cb-id
           (fn [ev]
             (when (= :rf.http/stale-suppressed (:operation ev))
               (swap! stale-traces conj ev))))
@@ -236,7 +236,7 @@
         (rf/reg-event :search/fresh-ok    (fn [_ _] (reset! fresh-ok?    true) {}))
 
         (rf/dispatch-sync [:search/prior])
-        (await-condition! #(seq (http-managed/in-flight-snapshot)) 2000)
+        (await-condition! #(seq (rf.http.managed/in-flight-snapshot)) 2000)
         ;; Supersede with the same :request-id BEFORE the server answers.
         (rf/dispatch-sync [:search/fresh])
         ;; Release the server so the fresh request can complete.
@@ -260,6 +260,6 @@
           (is (= :rf.http/request-id-superseded (:rf.reply/stale-reason tags))
               ":stale-reason names the supersession"))
         (finally
-          (trace/unregister-listener! cb-id)
+          (rf.trace/unregister-listener! cb-id)
           (.countDown release)
           (stop-server! srv))))))

--- a/implementation/http/test/re_frame/http_abort_precedence_test.clj
+++ b/implementation/http/test/re_frame/http_abort_precedence_test.clj
@@ -36,12 +36,12 @@
    3. abort-via-actor-destroy-wins-over-decode-failure"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.http.registry :as http-registry]
-            [re-frame.http.transport :as http-transport]
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.registry :as rf.http.registry]
+            [re-frame.http.transport :as rf.http.transport]
             [re-frame.machines]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support])
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support])
   (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
            [java.net InetSocketAddress]
            [java.util.concurrent CountDownLatch TimeUnit]))
@@ -49,7 +49,7 @@
 ;; ---- per-test reset --------------------------------------------------------
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- helpers --------------------------------------------------------------
 
@@ -166,7 +166,7 @@
         ;; the request handle right now.
         (is (.await decoder-entered 5 TimeUnit/SECONDS)
             "decoder entered — response landed, decode in progress, abort window open")
-        (is (= 1 (count (http-managed/in-flight-snapshot))))
+        (is (= 1 (count (rf.http.managed/in-flight-snapshot))))
         ;; Fire the abort BEFORE letting the decoder throw. Both the
         ;; abort-fn AND the about-to-fire finalise-failure! race for the
         ;; once-only :finalised? CAS — but the abort-fn flips :aborted?
@@ -184,7 +184,7 @@
               "user-initiated abort surfaces :reason :user"))
         (is (= 1 (count @replies))
             "exactly one reply — the once-only CAS still pins single-dispatch")
-        (is (empty? (http-managed/in-flight-snapshot))
+        (is (empty? (rf.http.managed/in-flight-snapshot))
             "in-flight registry is clean after the aborted reply")
         (finally
           (stop-server! srv))))))
@@ -249,8 +249,8 @@
         ;; error is possible) before we fire the abort. This replaces the
         ;; flaky reliance on the abort fx out-racing an async connection-
         ;; refused resolution.
-        (await-condition! #(seq (http-managed/in-flight-snapshot)))
-        (is (= 1 (count (http-managed/in-flight-snapshot)))
+        (await-condition! #(seq (rf.http.managed/in-flight-snapshot)))
+        (is (= 1 (count (rf.http.managed/in-flight-snapshot)))
             "request is in-flight against the stalled server — abort window open, no transport error possible")
         (rf/dispatch-sync [:do/abort])
         (await-condition! #(seq @replies))
@@ -263,7 +263,7 @@
               "user-initiated abort surfaces :reason :user"))
         (is (= 1 (count @replies))
             "exactly one reply — abort precedence does not double-dispatch")
-        (is (empty? (http-managed/in-flight-snapshot))
+        (is (empty? (rf.http.managed/in-flight-snapshot))
             "in-flight registry is clean after the aborted reply")
         (finally
           (.countDown release)
@@ -272,7 +272,7 @@
 ;; The finalise-failure! private is reached the same way (6c) reaches
 ;; schedule-backoff-handle! — a #'-deref of the private var.
 (def ^:private finalise-failure!*
-  @#'http-transport/finalise-failure!)
+  @#'rf.http.transport/finalise-failure!)
 
 (deftest transport-classification-loses-to-recorded-abort-precedence-seam
   (testing "rf2-12r1dn — finalise-failure! driven with a :rf.http/transport failure on a handle whose :aborted? is ALREADY flipped reclassifies the reply to :rf.http/aborted; this pins the exact precedence the flaky same-dispatch-vs-async-transport race was probing, with no cross-thread timing"
@@ -285,7 +285,7 @@
       ;; intent BEFORE the transport's whenComplete reaches finalise-failure!.
       (let [finalised? (atom false)
             aborted?   (atom {:reason :user :actor-id nil})
-            handle     (http-registry/record-in-flight!
+            handle     (rf.http.registry/record-in-flight!
                          :race nil
                          {:abort-fn   (fn [_] nil)
                           :url        "http://127.0.0.1:1/"
@@ -315,7 +315,7 @@
               "the abort snapshot's :reason rides the reclassified reply"))
         (is (= 1 (count @replies))
             "exactly one reply — the once-only :finalised? CAS still pins single-dispatch")
-        (is (empty? (http-managed/in-flight-snapshot))
+        (is (empty? (rf.http.managed/in-flight-snapshot))
             "finalise-failure! cleared the in-flight registry")))))
 
 ;; ---- (3) abort-via-actor-destroy wins over decode-failure -----------------
@@ -369,7 +369,7 @@
         ;; progress, child is in-flight under actor-in-flight.
         (is (.await decoder-entered 5 TimeUnit/SECONDS)
             "decoder entered while request was in flight under spawned actor")
-        (is (= 1 (count (http-managed/actor-in-flight-snapshot))))
+        (is (= 1 (count (rf.http.managed/actor-in-flight-snapshot))))
         ;; Destroy the actor — abort-on-actor-destroy walks the
         ;; actor-in-flight index and fires :abort-fn with
         ;; :reason :actor-destroyed.
@@ -387,7 +387,7 @@
           (is (= :actor-destroyed (get-in reply [:error :reason]))
               ":reason discriminates the actor-destroy source from a user abort"))
         (is (= 1 (count @replies)))
-        (is (empty? (http-managed/actor-in-flight-snapshot))
+        (is (empty? (rf.http.managed/actor-in-flight-snapshot))
             "actor-in-flight index is clean after the actor-destroy cascade")
         (finally
           (stop-server! srv))))))

--- a/implementation/http/test/re_frame/http_abort_retry_race_test.clj
+++ b/implementation/http/test/re_frame/http_abort_retry_race_test.clj
@@ -57,19 +57,19 @@
       a completing OLD attempt does NOT evict a same-id SUCCESSOR's handle."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.http.registry :as registry]
-            [re-frame.http.transport :as transport]
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.registry :as rf.http.registry]
+            [re-frame.http.transport :as rf.http.transport]
             [re-frame.machines]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace])
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace])
   (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
            [java.net InetSocketAddress]
            [java.util.concurrent.atomic AtomicInteger]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- hit-counting always-500 server ---------------------------------------
 
@@ -109,7 +109,7 @@
 (defn- await-condition!
   ([pred] (await-condition! pred 5000))
   ([pred timeout-ms]
-   (test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
+   (rf.test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
                                   :label "http-abort-retry-race condition"})
    true))
 
@@ -144,7 +144,7 @@
         listener-id ::retry-timeline-honesty
         fired?      (atom false)]
     (try
-      (trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
+      (rf.trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
       (rf/reg-event :reply/recorder
         (fn [_ [_ payload]] (swap! replies conj payload) {}))
       (rf/reg-event :issue
@@ -158,13 +158,13 @@
                   :on-success [:reply/recorder]}]]}))
       ;; The seam: fire the abort exactly once, when the retry lifecycle
       ;; reaches `inject-point`, resolving the still-registered prior handle.
-      (transport/set-test-interleave-hook!
+      (rf.http.transport/set-test-interleave-hook!
         (fn [point ctx]
           (when (and (= point inject-point)
                      (= :race (:request-id ctx))
                      (compare-and-set! fired? false true))
             ;; Same seam the `:rf.http/managed-abort` fx routes through.
-            (registry/abort-in-flight! (:request-id ctx) :user))))
+            (rf.http.registry/abort-in-flight! (:request-id ctx) :user))))
       (rf/dispatch-sync [:issue])
       ;; The abort's reply must arrive.
       (await-condition! #(seq @replies))
@@ -182,9 +182,9 @@
         (is (= :rf.http/aborted (get-in reply [:error :kind]))
             "the single reply is the canonical :rf.http/aborted")
         (is (= :user (get-in reply [:error :reason]))))
-      (is (empty? (registry/in-flight-snapshot))
+      (is (empty? (rf.http.registry/in-flight-snapshot))
           "the request-id registry is clean after the cancelled transition")
-      (is (empty? (registry/actor-in-flight-snapshot))
+      (is (empty? (rf.http.registry/actor-in-flight-snapshot))
           "the actor registry is clean")
       ;; rf2-fyt5i — the honesty assertion (red before the fix): a retry that
       ;; NEVER started must not surface a `:retried` disposition. The abort
@@ -200,8 +200,8 @@
                                          :next-backoff-ms (get-in ev [:tags :next-backoff-ms])})
                                retried)))))
       (finally
-        (trace/unregister-listener! listener-id)
-        (transport/set-test-interleave-hook! nil)
+        (rf.trace/unregister-listener! listener-id)
+        (rf.http.transport/set-test-interleave-hook! nil)
         (stop-server! srv)))))
 
 ;; ---- (1) abort in maybe-retry!'s transitional window -----------------------
@@ -226,35 +226,35 @@
 
 (deftest clear-in-flight-2arg-is-identity-conditional
   (testing "rf2-ous9e5 — clear-in-flight! (2-arg) does NOT evict a same-id successor's live handle; a completing OLD attempt clearing by its own handle leaves the successor in place"
-    (registry/clear-all-in-flight!)
-    (let [h-a (registry/seed-in-flight-for-test! :R nil {:abort-fn (fn [_] nil) :url "a"})
-          h-b (registry/seed-in-flight-for-test! :R nil {:abort-fn (fn [_] nil) :url "b"})]
+    (rf.http.registry/clear-all-in-flight!)
+    (let [h-a (rf.http.registry/seed-in-flight-for-test! :R nil {:abort-fn (fn [_] nil) :url "a"})
+          h-b (rf.http.registry/seed-in-flight-for-test! :R nil {:abort-fn (fn [_] nil) :url "b"})]
       ;; H_B (the successor) took over the request-id slot.
-      (is (identical? h-b (get (registry/in-flight-snapshot) :R))
+      (is (identical? h-b (get (rf.http.registry/in-flight-snapshot) :R))
           "the successor H_B is the live occupant under :R")
       ;; The OLD attempt (H_A) completes and clears BY ITS OWN handle.
-      (registry/clear-in-flight! :R h-a)
-      (is (identical? h-b (get (registry/in-flight-snapshot) :R))
+      (rf.http.registry/clear-in-flight! :R h-a)
+      (is (identical? h-b (get (rf.http.registry/in-flight-snapshot) :R))
           "the successor H_B SURVIVES — a stale completion must not evict it (the pre-fix unconditional dissoc did)")
       ;; Single-request cleanup is unchanged: clearing by the LIVE handle removes it.
-      (registry/clear-in-flight! :R h-b)
-      (is (not (contains? (registry/in-flight-snapshot) :R))
+      (rf.http.registry/clear-in-flight! :R h-b)
+      (is (not (contains? (rf.http.registry/in-flight-snapshot) :R))
           "clearing by the live handle removes the slot exactly as before"))
-    (registry/clear-all-in-flight!)))
+    (rf.http.registry/clear-all-in-flight!)))
 
 ;; ---- (4) actor-index identity clear survives a successor -------------------
 
 (deftest clear-in-flight-2arg-preserves-successor-actor-index
   (testing "rf2-ous9e5 — an OLD attempt's identity-conditional clear does not evict a same-id successor even when actor-indexed (mirrors remove-from-actor-index!)"
-    (registry/clear-all-in-flight!)
-    (let [h-a (registry/seed-in-flight-for-test! :R :actor {:abort-fn (fn [_] nil) :url "a"})
-          h-b (registry/seed-in-flight-for-test! :R :actor {:abort-fn (fn [_] nil) :url "b"})]
-      (is (identical? h-b (get (registry/in-flight-snapshot) :R)))
-      (registry/clear-in-flight! :R h-a)
-      (is (identical? h-b (get (registry/in-flight-snapshot) :R))
+    (rf.http.registry/clear-all-in-flight!)
+    (let [h-a (rf.http.registry/seed-in-flight-for-test! :R :actor {:abort-fn (fn [_] nil) :url "a"})
+          h-b (rf.http.registry/seed-in-flight-for-test! :R :actor {:abort-fn (fn [_] nil) :url "b"})]
+      (is (identical? h-b (get (rf.http.registry/in-flight-snapshot) :R)))
+      (rf.http.registry/clear-in-flight! :R h-a)
+      (is (identical? h-b (get (rf.http.registry/in-flight-snapshot) :R))
           "successor survives in the request-id index")
       ;; H_A is removed from the actor vector (by identity); H_B remains.
-      (let [v (get (registry/actor-in-flight-snapshot) :actor)]
+      (let [v (get (rf.http.registry/actor-in-flight-snapshot) :actor)]
         (is (some #(identical? % h-b) v) "H_B still actor-indexed")
         (is (not (some #(identical? % h-a) v)) "H_A dropped from the actor index by identity")))
-    (registry/clear-all-in-flight!)))
+    (rf.http.registry/clear-all-in-flight!)))

--- a/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
@@ -35,13 +35,13 @@
        is recognized from the durable `:rf/machine-type` snapshot marker"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.http.registry :as http-registry]
-            [re-frame.http.transport :as http-transport]
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.registry :as rf.http.registry]
+            [re-frame.http.transport :as rf.http.transport]
             [re-frame.machines]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace])
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace])
   (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
            [java.net InetSocketAddress]
            [java.util.concurrent CountDownLatch TimeUnit]))
@@ -49,7 +49,7 @@
 ;; ---- per-test reset --------------------------------------------------------
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- in-process latch server ----------------------------------------------
 
@@ -87,7 +87,7 @@
   per-file arity (`pred`, optional `timeout-ms`)."
   ([pred] (await-condition! pred 5000))
   ([pred timeout-ms]
-   (test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
+   (rf.test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
                                   :label "http-actor-destroy condition"})
    true))
 
@@ -106,7 +106,7 @@
           replies (atom [])
           traces  (atom [])]
       (try
-        (trace/register-listener! ::wvkn-1 (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! ::wvkn-1 (fn [ev] (swap! traces conj ev)))
         (rf/reg-event :reply/recorder
           (fn [_ [_ payload]]
             (swap! replies conj payload)
@@ -137,10 +137,10 @@
                       :on    {:cancel :idle}}}})
         (rf/dispatch-sync [:sup/flow [:start]])
         ;; Confirm the request is in-flight against the spawned child.
-        (await-condition! #(seq (http-managed/actor-in-flight-snapshot)))
-        (is (= 1 (count (http-managed/actor-in-flight-snapshot)))
+        (await-condition! #(seq (rf.http.managed/actor-in-flight-snapshot)))
+        (is (= 1 (count (rf.http.managed/actor-in-flight-snapshot)))
             "in-flight registry has one actor entry while the child request is pending")
-        (is (contains? (http-managed/actor-in-flight-snapshot) :worker/proc#1)
+        (is (contains? (rf.http.managed/actor-in-flight-snapshot) :worker/proc#1)
             "actor index keys on the spawned child's deterministic id")
         ;; Parent destroys the child by transitioning out.
         (rf/dispatch-sync [:sup/flow [:cancel]])
@@ -160,11 +160,11 @@
                 "trace tags carry the destroyed spawned-actor id")
             (is (= [:worker/proc :slow] (:request-id tags))
                 "trace tags carry the user-supplied :request-id")))
-        (is (empty? (http-managed/actor-in-flight-snapshot))
+        (is (empty? (rf.http.managed/actor-in-flight-snapshot))
             "actor index is empty after the abort")
         (.countDown latch)
         (finally
-          (trace/unregister-listener! ::wvkn-1)
+          (rf.trace/unregister-listener! ::wvkn-1)
           (stop-server! srv))))))
 
 ;; ---- (2) multiple in-flight requests from one actor → all abort ----------
@@ -176,7 +176,7 @@
           replies (atom [])
           traces  (atom [])]
       (try
-        (trace/register-listener! ::wvkn-2 (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! ::wvkn-2 (fn [ev] (swap! traces conj ev)))
         (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
         (rf/reg-machine :worker/multi
@@ -210,7 +210,7 @@
         (rf/dispatch-sync [:sup/multi [:start]])
         ;; Wait for all three in-flight against the same actor.
         (await-condition!
-          #(let [snap (http-managed/actor-in-flight-snapshot)]
+          #(let [snap (rf.http.managed/actor-in-flight-snapshot)]
              (and (= 1 (count snap))
                   (= 3 (count (val (first snap)))))))
         ;; Destroy.
@@ -220,10 +220,10 @@
         (is (every? #(= :actor-destroyed (get-in % [:error :reason])) @replies))
         (is (= 3 (count (abort-traces @traces)))
             "three :rf.http/aborted-on-actor-destroy traces — one per cancelled request")
-        (is (empty? (http-managed/actor-in-flight-snapshot)))
+        (is (empty? (rf.http.managed/actor-in-flight-snapshot)))
         (.countDown latch)
         (finally
-          (trace/unregister-listener! ::wvkn-2)
+          (rf.trace/unregister-listener! ::wvkn-2)
           (stop-server! srv))))))
 
 ;; ---- (3) sibling actors are NOT affected ----------------------------------
@@ -278,20 +278,20 @@
                                :on    {:cancel :idle}}}})
         (rf/dispatch-sync [:sup/a [:start]])
         (rf/dispatch-sync [:sup/b [:start]])
-        (await-condition! #(= 2 (count (http-managed/actor-in-flight-snapshot))))
+        (await-condition! #(= 2 (count (rf.http.managed/actor-in-flight-snapshot))))
         ;; Destroy A only.
         (rf/dispatch-sync [:sup/a [:cancel]])
         (await-condition! #(seq @replies))
         (is (= 1 (count @replies))
             "exactly one reply — A's. B is still pending")
         (is (= :actor-destroyed (get-in (first @replies) [:error :reason])))
-        (is (= 1 (count (http-managed/actor-in-flight-snapshot)))
+        (is (= 1 (count (rf.http.managed/actor-in-flight-snapshot)))
             "B remains in the in-flight registry")
         ;; Now destroy B.
         (rf/dispatch-sync [:sup/b [:cancel]])
         (await-condition! #(= 2 (count @replies)))
         (is (every? #(= :actor-destroyed (get-in % [:error :reason])) @replies))
-        (is (empty? (http-managed/actor-in-flight-snapshot)))
+        (is (empty? (rf.http.managed/actor-in-flight-snapshot)))
         (.countDown latch-a)
         (.countDown latch-b)
         (finally
@@ -315,21 +315,21 @@
                       :decode     :json
                       :request-id :direct}]]})))
         (rf/dispatch-sync [:direct/load {}])
-        (await-condition! #(seq (http-managed/in-flight-snapshot)))
-        (is (empty? (http-managed/actor-in-flight-snapshot))
+        (await-condition! #(seq (rf.http.managed/in-flight-snapshot)))
+        (is (empty? (rf.http.managed/actor-in-flight-snapshot))
             "direct event-handler dispatch is not tracked under actor-in-flight")
-        (is (= 1 (count (http-managed/in-flight-snapshot)))
+        (is (= 1 (count (rf.http.managed/in-flight-snapshot)))
             "request-id index does record the request")
         ;; Calling abort-on-actor-destroy with any actor-id is a no-op
         ;; for this request — there's no actor binding.
-        (http-managed/abort-on-actor-destroy :random/non-existent-actor-id)
+        (rf.http.managed/abort-on-actor-destroy :random/non-existent-actor-id)
         ;; Timer-semantics sleep (rf2-fun38): proving the *absence* of any
         ;; reply — no observable signal to poll. The 50ms window confirms
         ;; no stray dispatch surfaces from the no-op abort path.
         (Thread/sleep 50)
         (is (empty? @replies)
             "abort-on-actor-destroy is structurally scoped — it does not touch direct-dispatch requests")
-        (is (= 1 (count (http-managed/in-flight-snapshot)))
+        (is (= 1 (count (rf.http.managed/in-flight-snapshot)))
             "request still in flight")
         ;; The orthogonal app-level abort still works — driven through
         ;; an event handler that emits the `:rf.http/managed-abort` fx.
@@ -378,7 +378,7 @@
                       :after  {5000 :timeout}}
             :timeout {}}})
         (rf/dispatch-sync [:sup/timed [:start]])
-        (await-condition! #(seq (http-managed/actor-in-flight-snapshot)))
+        (await-condition! #(seq (rf.http.managed/actor-in-flight-snapshot)))
         ;; Synthetically fire the :after timer with matching epoch (the
         ;; :working node's per-path epoch, 1 after entry) + decl-path. This
         ;; drives the parent's transition out of :working — the standard
@@ -391,7 +391,7 @@
         (is (= :cancelled (:status (first @replies))))
         (is (= :actor-destroyed (get-in (first @replies) [:error :reason]))
             ":after-driven destroy cascades to the same :reason :actor-destroyed")
-        (is (empty? (http-managed/actor-in-flight-snapshot)))
+        (is (empty? (rf.http.managed/actor-in-flight-snapshot)))
         (.countDown latch)
         (finally (stop-server! srv))))))
 
@@ -431,16 +431,16 @@
                       :on    {:cancel :idle}}}})
         (rf/dispatch-sync [:sup/anon [:start]])
         ;; The anonymous request lands ONLY in the actor index.
-        (await-condition! #(seq (http-managed/actor-in-flight-snapshot)))
-        (is (= 1 (count (http-managed/actor-in-flight-snapshot)))
+        (await-condition! #(seq (rf.http.managed/actor-in-flight-snapshot)))
+        (is (= 1 (count (rf.http.managed/actor-in-flight-snapshot)))
             "actor index holds the anonymous request under the spawned child's id")
-        (is (contains? (http-managed/actor-in-flight-snapshot) :worker/anon#1))
-        (is (empty? (http-managed/in-flight-snapshot))
+        (is (contains? (rf.http.managed/actor-in-flight-snapshot) :worker/anon#1))
+        (is (empty? (rf.http.managed/in-flight-snapshot))
             "anonymous request is NOT in the request-id index (request-id is nil)")
         ;; Sanity: the handle has no :request-id, confirming the abort-fn's
         ;; 1-arg clear-in-flight! would have no-op'd. The 2-arg form (the fix)
         ;; cleans by handle identity regardless.
-        (is (nil? (:request-id (first (val (first (http-managed/actor-in-flight-snapshot))))))
+        (is (nil? (:request-id (first (val (first (rf.http.managed/actor-in-flight-snapshot))))))
             "the in-flight handle carries no :request-id — the leak vector the 1-arg form left open")
         ;; Parent destroys the child → abort-on-actor-destroy fires each
         ;; handle's abort-fn, which now passes the handle to clear-in-flight!.
@@ -450,9 +450,9 @@
             "the anonymous request's abort surfaces as a :cancelled reply")
         (is (= :rf.http/aborted (get-in (first @replies) [:error :kind])))
         (is (= :actor-destroyed (get-in (first @replies) [:error :reason])))
-        (is (empty? (http-managed/actor-in-flight-snapshot))
+        (is (empty? (rf.http.managed/actor-in-flight-snapshot))
             "actor-in-flight index is empty after the abort — the abort-fn's handle-passing cleanup left no stale slot")
-        (is (empty? (http-managed/in-flight-snapshot))
+        (is (empty? (rf.http.managed/in-flight-snapshot))
             "request-id index remains empty")
         (.countDown latch)
         (finally (stop-server! srv))))))
@@ -462,46 +462,46 @@
 
 (deftest anonymous-handle-cleared-without-actor-slot-preclear
   (testing "clearing an anonymous (request-id-less) handle by identity empties the actor-in-flight slot even when the slot is NOT pre-cleared first — this is the defensive guarantee the abort-fn now relies on by passing its in-scope handle. The earlier 1-arg form resolved by request-id and no-op'd on nil, leaking the slot under any abort trigger that does not pre-clear (the actor-destroy eager dissoc was the only thing masking this)"
-    (http-managed/clear-all-in-flight!)
+    (rf.http.managed/clear-all-in-flight!)
     (let [actor-id :worker/anon#7
           ;; Anonymous: request-id nil, actor-id set. record-in-flight!
           ;; stamps :actor-id and pushes the handle into actor-in-flight
           ;; only (the request-id index is skipped on nil id).
-          handle   (http-registry/record-in-flight!
+          handle   (rf.http.registry/record-in-flight!
                      nil actor-id {:abort-fn (fn [_] nil) :url "http://x/anon"})]
-      (is (empty? (http-managed/in-flight-snapshot))
+      (is (empty? (rf.http.managed/in-flight-snapshot))
           "anonymous handle is absent from the request-id index")
-      (is (= [handle] (get (http-managed/actor-in-flight-snapshot) actor-id))
+      (is (= [handle] (get (rf.http.managed/actor-in-flight-snapshot) actor-id))
           "anonymous handle lives solely in the actor-in-flight index, identity-equal")
       ;; Clear via the 2-arg form WITHOUT touching the actor slot first —
       ;; this simulates a future abort trigger (e.g. a frame-level abort-all
       ;; or a timeout-driven abort) that does NOT pre-clear actor-in-flight.
       ;; The 2-arg form's identity-based remove-from-actor-index! empties it.
-      (http-registry/clear-in-flight! nil handle)
-      (is (empty? (http-managed/actor-in-flight-snapshot))
+      (rf.http.registry/clear-in-flight! nil handle)
+      (is (empty? (rf.http.managed/actor-in-flight-snapshot))
           "2-arg clear-in-flight! removed the anonymous handle from the actor index by identity")
       ;; Contrast: the 1-arg form is a full no-op on a nil request-id — it
       ;; cannot reach the actor index for an anonymous handle. Re-record and
       ;; prove the leak the fix closes.
-      (let [h2 (http-registry/record-in-flight!
+      (let [h2 (rf.http.registry/record-in-flight!
                  nil actor-id {:abort-fn (fn [_] nil) :url "http://x/anon2"})]
-        (http-registry/clear-in-flight! nil) ; 1-arg, nil id → no-op
-        (is (= [h2] (get (http-managed/actor-in-flight-snapshot) actor-id))
+        (rf.http.registry/clear-in-flight! nil) ; 1-arg, nil id → no-op
+        (is (= [h2] (get (rf.http.managed/actor-in-flight-snapshot) actor-id))
             "1-arg clear-in-flight! leaves the anonymous handle stranded — the latent leak the 2-arg fix eliminates")
         ;; Clean up via the correct form so the fixture leaves a clean registry.
-        (http-registry/clear-in-flight! nil h2)
-        (is (empty? (http-managed/actor-in-flight-snapshot)))))))
+        (rf.http.registry/clear-in-flight! nil h2)
+        (is (empty? (rf.http.managed/actor-in-flight-snapshot)))))))
 
 ;; ---- (6c) the SECOND abort-fn site — schedule-backoff-handle! (rf2-meq28) ---
 ;; ----      sibling of (6b): a backoff-window abort fired WITHOUT a -----------
 ;; ----      pre-clear must clean the anonymous handle's actor slot -----------
 
 (def ^:private schedule-backoff-handle!
-  @#'http-transport/schedule-backoff-handle!)
+  @#'rf.http.transport/schedule-backoff-handle!)
 
 (deftest backoff-abort-fn-cleans-anonymous-handle-without-actor-slot-preclear
   (testing "schedule-backoff-handle!'s abort-fn — the SECOND of two structurally-identical abort-fns — cleans an anonymous (request-id-less, issued-from-actor) backoff handle's actor-in-flight slot when fired by a trigger that does NOT pre-clear the slot first. This is the rf2-meq28 sibling of (6b): the abort-fn now passes its in-scope handle to the 2-arg clear-in-flight!, so the actor slot is removed by identity regardless of the nil request-id. The earlier 1-arg form no-op'd on the nil id and stranded the handle under any abort trigger that does not pre-clear (actor-destroy's eager dissoc was the only thing masking the leak)"
-    (http-managed/clear-all-in-flight!)
+    (rf.http.managed/clear-all-in-flight!)
     (let [actor-id :worker/anon-backoff#1
           ;; Anonymous request sitting in a backoff window: request-id nil,
           ;; actor-id set. A request issued from inside a spawned actor with
@@ -526,11 +526,11 @@
           ;; only for the timer callback's honest `:retried` emit; the 600000ms
           ;; timer never fires in this test (the abort-fn wins), so pass nil.
           _        (schedule-backoff-handle! ctx 600000 nil nil)
-          slot     (get (http-managed/actor-in-flight-snapshot) actor-id)
+          slot     (get (rf.http.managed/actor-in-flight-snapshot) actor-id)
           handle   (first slot)]
       (is (= 1 (count slot))
           "the anonymous backoff handle is registered solely in the actor-in-flight index")
-      (is (empty? (http-managed/in-flight-snapshot))
+      (is (empty? (rf.http.managed/in-flight-snapshot))
           "anonymous backoff handle is absent from the request-id index (request-id is nil)")
       (is (nil? (:request-id handle))
           "the registered backoff handle carries no :request-id — the leak vector the 1-arg form left open")
@@ -541,9 +541,9 @@
       ;; nil id and the handle stranded here; the 2-arg form (the fix) removes
       ;; it from the actor index by identity.
       ((:abort-fn handle) :actor-destroyed)
-      (is (empty? (http-managed/actor-in-flight-snapshot))
+      (is (empty? (rf.http.managed/actor-in-flight-snapshot))
           "the backoff abort-fn's handle-passing 2-arg clear-in-flight! removed the anonymous handle from the actor index — no stranded slot")
-      (is (empty? (http-managed/in-flight-snapshot))
+      (is (empty? (rf.http.managed/in-flight-snapshot))
           "request-id index remains empty"))))
 
 ;; ---- (7) IMPERATIVELY-spawned actor (rf2-n877mb) → managed HTTP aborts ----
@@ -567,7 +567,7 @@
           replies (atom [])
           traces  (atom [])]
       (try
-        (trace/register-listener! ::n877mb (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! ::n877mb (fn [ev] (swap! traces conj ev)))
         (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
         ;; Worker machine: on entry to :running its action fires an
@@ -617,10 +617,10 @@
               "imperative spawn installs NO :spawned registry slot — the step-1 registry read would have classified its request as unowned"))
         ;; The request is in-flight, indexed under the actor's id — proof that
         ;; the widened owning-actor-id classified the imperative actor as owner.
-        (await-condition! #(seq (http-managed/actor-in-flight-snapshot)))
-        (is (= 1 (count (http-managed/actor-in-flight-snapshot)))
+        (await-condition! #(seq (rf.http.managed/actor-in-flight-snapshot)))
+        (is (= 1 (count (rf.http.managed/actor-in-flight-snapshot)))
             "in-flight registry has one actor entry while the imperative actor's request is pending")
-        (is (contains? (http-managed/actor-in-flight-snapshot) :worker/imp#1)
+        (is (contains? (rf.http.managed/actor-in-flight-snapshot) :worker/imp#1)
             "actor index keys on the imperatively-spawned actor's id — the widening this test pins")
         ;; Imperatively destroy the actor mid-flight.
         (rf/dispatch-sync [:imp/destroy])
@@ -639,9 +639,9 @@
                 "trace tags carry the destroyed imperatively-spawned actor id")
             (is (= [:worker/imp :slow] (:request-id tags))
                 "trace tags carry the user-supplied :request-id")))
-        (is (empty? (http-managed/actor-in-flight-snapshot))
+        (is (empty? (rf.http.managed/actor-in-flight-snapshot))
             "actor index is empty after the imperative-destroy abort")
         (.countDown latch)
         (finally
-          (trace/unregister-listener! ::n877mb)
+          (rf.trace/unregister-listener! ::n877mb)
           (stop-server! srv))))))

--- a/implementation/http/test/re_frame/http_actor_destroy_stale_test.clj
+++ b/implementation/http/test/re_frame/http_actor_destroy_stale_test.clj
@@ -25,11 +25,11 @@
   snapshot teardown)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.http.managed :as http-managed]
+            [re-frame.http.managed :as rf.http.managed]
             [re-frame.machines]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace])
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace])
   (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
            [java.net InetSocketAddress]
            [java.util.concurrent CountDownLatch TimeUnit]))
@@ -37,7 +37,7 @@
 ;; ---- per-test reset (mirrors http_actor_destroy_cancellation_test.clj) ----
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- in-process latch server ----------------------------------------------
 
@@ -68,7 +68,7 @@
 (defn- await-condition!
   ([pred] (await-condition! pred 5000))
   ([pred timeout-ms]
-   (test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
+   (rf.test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
                                   :label "http-actor-destroy-stale condition"})
    true))
 
@@ -88,7 +88,7 @@
           dispatched (atom [])
           traces  (atom [])]
       (try
-        (trace/register-listener! ::yrrpe2-1
+        (rf.trace/register-listener! ::yrrpe2-1
           (fn [ev]
             (swap! traces conj ev)
             (when (= :rf.event/dispatched (:operation ev))
@@ -119,8 +119,8 @@
                                :start      [:start]}
                       :on    {:cancel :idle}}}})
         (rf/dispatch-sync [:sup/flow [:start]])
-        (await-condition! #(seq (http-managed/actor-in-flight-snapshot)))
-        (is (contains? (http-managed/actor-in-flight-snapshot) :worker/proc#1))
+        (await-condition! #(seq (rf.http.managed/actor-in-flight-snapshot)))
+        (is (contains? (rf.http.managed/actor-in-flight-snapshot) :worker/proc#1))
         ;; Snapshot how many times the actor's own event-id was dispatched
         ;; up to (and including) the spawn/start sequence — the suppressed
         ;; reply must add NO further dispatch to it.
@@ -144,11 +144,11 @@
         (Thread/sleep 150)
         (is (= self-dispatches-before (count (filter #{:worker/proc#1} @dispatched)))
             "the app reply target (addressing the destroyed actor) MUST NOT be dispatched post-destroy")
-        (is (empty? (http-managed/actor-in-flight-snapshot))
+        (is (empty? (rf.http.managed/actor-in-flight-snapshot))
             "actor index is empty after the suppressed abort")
         (.countDown latch))
         (finally
-          (trace/unregister-listener! ::yrrpe2-1)
+          (rf.trace/unregister-listener! ::yrrpe2-1)
           (stop-server! srv))))))
 
 ;; ---- (2) meaningful (ordinary-event) target stays a live :cancelled --------
@@ -161,7 +161,7 @@
           replies (atom [])
           traces  (atom [])]
       (try
-        (trace/register-listener! ::yrrpe2-2 (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! ::yrrpe2-2 (fn [ev] (swap! traces conj ev)))
         (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
         (rf/reg-machine :worker/proc
@@ -186,7 +186,7 @@
                                :start      [:start]}
                       :on    {:cancel :idle}}}})
         (rf/dispatch-sync [:sup/flow [:start]])
-        (await-condition! #(seq (http-managed/actor-in-flight-snapshot)))
+        (await-condition! #(seq (rf.http.managed/actor-in-flight-snapshot)))
         (rf/dispatch-sync [:sup/flow [:cancel]])
         (await-condition! #(seq @replies))
         (let [reply (first @replies)]
@@ -198,7 +198,7 @@
             "a meaningful target emits NO stale-suppression trace")
         (.countDown latch)
         (finally
-          (trace/unregister-listener! ::yrrpe2-2)
+          (rf.trace/unregister-listener! ::yrrpe2-2)
           (stop-server! srv))))))
 
 ;; ---- (3) rf2-4teurt — the abort-precedence RECLASSIFICATION path -----------
@@ -212,7 +212,7 @@
           dispatched (atom [])
           traces  (atom [])]
       (try
-        (trace/register-listener! ::teurt-3
+        (rf.trace/register-listener! ::teurt-3
           (fn [ev]
             (swap! traces conj ev)
             (when (= :rf.event/dispatched (:operation ev))
@@ -240,8 +240,8 @@
                                :start      [:start]}
                       :on    {:cancel :idle}}}})
         (rf/dispatch-sync [:sup/flow [:start]])
-        (await-condition! #(seq (http-managed/actor-in-flight-snapshot)))
-        (is (contains? (http-managed/actor-in-flight-snapshot) :worker/proc#1))
+        (await-condition! #(seq (rf.http.managed/actor-in-flight-snapshot)))
+        (is (contains? (rf.http.managed/actor-in-flight-snapshot) :worker/proc#1))
         (let [self-dispatches-before (count (filter #{:worker/proc#1} @dispatched))
               ;; Reach the LIVE in-flight handle and reproduce Path B
               ;; DETERMINISTICALLY: flip its abort-precedence cell EXACTLY as
@@ -252,7 +252,7 @@
               ;; finalise-* → emit-and-dispatch-failure! rather than through
               ;; dispatch-aborted!. This isolates the exact reclassification
               ;; path from the inherently-flaky real thread race.
-              handle (first (get (http-managed/actor-in-flight-snapshot) :worker/proc#1))]
+              handle (first (get (rf.http.managed/actor-in-flight-snapshot) :worker/proc#1))]
           (is (some? handle) "the actor-bound in-flight handle is reachable")
           (is (some? (:aborted? handle)) "the handle carries the abort-precedence cell")
           (reset! (:aborted? handle) {:reason :actor-destroyed :actor-id :worker/proc#1})
@@ -274,5 +274,5 @@
           (is (= self-dispatches-before (count (filter #{:worker/proc#1} @dispatched)))
               "the abort-precedence reclassification MUST NOT deliver a live :cancelled reply to the destroyed actor's self-addressed target"))
         (finally
-          (trace/unregister-listener! ::teurt-3)
+          (rf.trace/unregister-listener! ::teurt-3)
           (stop-server! srv))))))

--- a/implementation/http/test/re_frame/http_backoff_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_backoff_cancellation_test.clj
@@ -30,12 +30,12 @@
    4. GUARD: an uncancelled backoff still retries (no regression)"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.http.registry :as registry]
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.registry :as rf.http.registry]
             [re-frame.machines]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace])
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace])
   (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
            [java.net InetSocketAddress]
            [java.util.concurrent.atomic AtomicInteger]))
@@ -43,7 +43,7 @@
 ;; ---- per-test reset --------------------------------------------------------
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- hit-counting always-500 server ---------------------------------------
 
@@ -88,7 +88,7 @@
 (defn- await-condition!
   ([pred] (await-condition! pred 5000))
   ([pred timeout-ms]
-   (test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
+   (rf.test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
                                   :label "http-backoff-cancellation condition"})
    true))
 
@@ -142,7 +142,7 @@
         (rf/dispatch-sync [:issue])
         ;; Attempt #1 fails 500 → request sleeps in the backoff window.
         (await-backoff-sleeping! hits)
-        (is (contains? (registry/in-flight-snapshot) :race)
+        (is (contains? (rf.http.registry/in-flight-snapshot) :race)
             "the sleeping request is visible in the in-flight registry during backoff (the defect made it invisible here)")
         ;; Abort squarely inside the 2000ms window.
         (rf/dispatch-sync [:do/abort])
@@ -152,7 +152,7 @@
           (is (= :rf.http/aborted (get-in reply [:error :kind]))
               "abort during backoff dispatches the canonical :rf.http/aborted reply")
           (is (= :user (get-in reply [:error :reason]))))
-        (is (empty? (registry/in-flight-snapshot))
+        (is (empty? (rf.http.registry/in-flight-snapshot))
             "the registry is cleared the instant the backoff is cancelled")
         (assert-no-retry-fired! hits)
         (is (= 1 (count @replies))
@@ -193,7 +193,7 @@
         ;; Attempt #1 fails 500 → request sleeps in the backoff window,
         ;; registered under BOTH the request-id and actor-in-flight index.
         (await-backoff-sleeping! hits)
-        (is (= 1 (count (registry/actor-in-flight-snapshot)))
+        (is (= 1 (count (rf.http.registry/actor-in-flight-snapshot)))
             "the sleeping retry is indexed under its issuing actor during backoff (the defect emptied this slot)")
         ;; Destroy the actor squarely inside the backoff window.
         (rf/dispatch-sync [:sup/race [:cancel]])
@@ -203,9 +203,9 @@
           (is (= :rf.http/aborted (get-in reply [:error :kind])))
           (is (= :actor-destroyed (get-in reply [:error :reason]))
               "actor-destroy during backoff surfaces :reason :actor-destroyed"))
-        (is (empty? (registry/actor-in-flight-snapshot))
+        (is (empty? (rf.http.registry/actor-in-flight-snapshot))
             "the actor index is clean — no stale entry left for a destroyed actor")
-        (is (empty? (registry/in-flight-snapshot)))
+        (is (empty? (rf.http.registry/in-flight-snapshot)))
         (assert-no-retry-fired! hits)
         (is (= 1 (count @replies)))
         (finally
@@ -246,7 +246,7 @@
         (rf/dispatch-sync [:issue-old])
         ;; Old request's attempt #1 fails 500 → sleeps in the backoff window.
         (await-backoff-sleeping! hits)
-        (is (contains? (registry/in-flight-snapshot) :shared))
+        (is (contains? (rf.http.registry/in-flight-snapshot) :shared))
         ;; Supersede with a fresh same-id request, squarely inside the
         ;; old request's backoff window.
         (rf/dispatch-sync [:issue-new])
@@ -282,7 +282,7 @@
           traces  (atom [])
           lid     ::supersede-backoff-stale]
       (try
-        (trace/register-listener! lid (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! lid (fn [ev] (swap! traces conj ev)))
         (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
         (rf/reg-event :issue-old
@@ -313,11 +313,11 @@
         ;; sleeping handle now represents attempt #2 (issuance 1, attempt 2).
         (await-condition! #(>= (.get hits) 2))
         (Thread/sleep 150)
-        (is (contains? (registry/in-flight-snapshot) :shared)
+        (is (contains? (rf.http.registry/in-flight-snapshot) :shared)
             "the old request is still registered, sleeping in attempt #2's backoff window")
         ;; Supersede with a fresh same-id request squarely inside that window.
         (rf/dispatch-sync [:issue-new])
-        (test-support/poll-until
+        (rf.test-support/poll-until
           #(some (fn [ev] (= :rf.http/stale-suppressed (:operation ev))) @traces)
           {:timeout-ms 5000 :label "supersede-backoff-stale"})
         (let [stale (filter #(= :rf.http/stale-suppressed (:operation %)) @traces)]
@@ -349,7 +349,7 @@
         (is (every? #(not= :request-id-superseded (get-in % [:error :reason])) @replies)
             "no :request-id-superseded reply is dispatched to the user")
         (finally
-          (trace/unregister-listener! lid)
+          (rf.trace/unregister-listener! lid)
           (stop-server! srv)
           (stop-server! new-srv))))))
 
@@ -384,7 +384,7 @@
           (is (= :error (:status reply)))
           (is (= :rf.http/http-5xx (get-in reply [:error :kind]))
               "after the retry exhausts, the final reply carries the real failure category, not :rf.http/aborted"))
-        (is (empty? (registry/in-flight-snapshot))
+        (is (empty? (rf.http.registry/in-flight-snapshot))
             "the registry is clean after the retry exhausts")
         (is (= 1 (count @replies))
             "exactly one final reply across the retry sequence")

--- a/implementation/http/test/re_frame/http_body_prep_failure_test.clj
+++ b/implementation/http/test/re_frame/http_body_prep_failure_test.clj
@@ -28,14 +28,14 @@
   through the router on `dispatch-sync`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.http.registry :as registry]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]))
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.registry :as rf.http.registry]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- a throwing body thunk -------------------------------------------------
 
@@ -45,7 +45,7 @@
           traces      (atom [])
           listener-id ::body-thunk]
       (try
-        (trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
         (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
         (rf/reg-event :issue/throwing-thunk
@@ -74,10 +74,10 @@
               "the thrown message rides the failure for diagnostics"))
         (is (not-any? #(= :rf.error/fx-handler-exception (:operation %)) @traces)
             "NO generic :rf.error/fx-handler-exception escaped — the throw is caught in the prep phase")
-        (is (empty? (registry/in-flight-snapshot))
+        (is (empty? (rf.http.registry/in-flight-snapshot))
             "the in-flight registry is cleared — the failed-prep request is not pinned")
         (finally
-          (trace/unregister-listener! listener-id))))))
+          (rf.trace/unregister-listener! listener-id))))))
 
 ;; ---- a body that fails to encode -------------------------------------------
 
@@ -87,7 +87,7 @@
           traces      (atom [])
           listener-id ::encode-fail]
       (try
-        (trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
         (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
         (rf/reg-event :issue/unencodable
@@ -113,9 +113,9 @@
           (is (= :request-prep (get-in reply [:error :stage]))))
         (is (not-any? #(= :rf.error/fx-handler-exception (:operation %)) @traces)
             "NO generic :rf.error/fx-handler-exception escaped")
-        (is (empty? (registry/in-flight-snapshot)))
+        (is (empty? (rf.http.registry/in-flight-snapshot)))
         (finally
-          (trace/unregister-listener! listener-id))))))
+          (rf.trace/unregister-listener! listener-id))))))
 
 ;; ---- retry when configured -------------------------------------------------
 
@@ -125,7 +125,7 @@
           invocations (atom 0)
           listener-id ::retry-thunk]
       (try
-        (trace/register-listener! listener-id (fn [_] nil))
+        (rf.trace/register-listener! listener-id (fn [_] nil))
         (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
         (rf/reg-event :issue/retry-thunk
@@ -163,7 +163,7 @@
           (is (= :error (:status reply)))
           (is (= :rf.http/transport (get-in reply [:error :kind]))
               "the final reply carries the :rf.http/transport prep-failure category"))
-        (is (empty? (registry/in-flight-snapshot))
+        (is (empty? (rf.http.registry/in-flight-snapshot))
             "the registry is clean after the retry sequence exhausts")
         (finally
-          (trace/unregister-listener! listener-id))))))
+          (rf.trace/unregister-listener! listener-id))))))

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -10,29 +10,29 @@
   Also covers the CLJS-only `:rf.http/cors` classification branch."
   (:require [cljs.reader :as edn]
             [cljs.test :refer-macros [deftest is testing async]]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
+            [re-frame.frame :as rf.frame]
             [re-frame.http :as rf.http]
             ;; Drive the full `:rf.http/managed` pipeline (fx
             ;; registration + in-flight registry) for the backoff-window
             ;; cancellation test below.
-            [re-frame.http.managed :as http-managed]
-            [re-frame.http.registry :as registry]
-            [re-frame.http.transport-cljs :as transport-cljs]
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.registry :as rf.http.registry]
+            [re-frame.http.transport-cljs :as rf.http.transport-cljs]
             ;; Assert the redacted `:rf.warning/http-header-invalid`
             ;; trace fires (instead of an escaping `:rf.error/fx-handler-
             ;; exception`) when an invalid request header hits the managed
             ;; CLJS path. `re-frame.trace.tooling` owns the listener surface;
             ;; `re-frame.http.url` carries
             ;; the canonical HTTP redaction sentinel.
-            [re-frame.http.url :as http-url]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.http.url :as rf.http.url]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 ;; Fetch transport and classification are named adapter seams.
 (def ^:private classify-cljs-error
-  transport-cljs/classify-cljs-error)
+  rf.http.transport-cljs/classify-cljs-error)
 
 ;; Tolerance band for measured `:elapsed-ms` wall-clock
 ;; assertions below. `js/setTimeout(…, limit)` is NOT a hard floor: under
@@ -46,7 +46,7 @@
 ;; Fetch Response body may be
 ;; consumed only once, so the reader is chosen up front).
 (def ^:private cljs-fetch
-  transport-cljs/cljs-fetch)
+  rf.http.transport-cljs/cljs-fetch)
 
 ;; `cross-origin?` (the load-bearing half of the CORS
 ;; classification) reads `js/globalThis.location.origin`, which is ABSENT
@@ -514,10 +514,10 @@
   [f on-events]
   (let [seen   (atom [])
         cb-key (keyword (str "http-cljs-invalid-header-" (gensym)))]
-    (trace-tooling/register-listener! cb-key (fn [ev] (swap! seen conj ev)))
+    (rf.trace.tooling/register-listener! cb-key (fn [ev] (swap! seen conj ev)))
     (-> (f)
         (.then (fn [result] (on-events seen result)))
-        (.finally (fn [] (trace-tooling/unregister-listener! cb-key))))))
+        (.finally (fn [] (rf.trace.tooling/unregister-listener! cb-key))))))
 
 (deftest cljs-fetch-invalid-header-name-surfaces-managed-warning-not-escape
   (testing "rf2-f5pguu — an EMPTY header name (which `Headers.append`
@@ -648,7 +648,7 @@
                         "denylisted query-param value MUST be scrubbed in the trace URL")
                     (is (true? (:sensitive? w))
                         ":sensitive? stamped at top level — a denylisted param name is a signal")
-                    (is (= http-url/redacted-sentinel :rf/redacted)
+                    (is (= rf.http.url/redacted-sentinel :rf/redacted)
                         "sanity: the redaction sentinel is the reserved keyword")))))
             ;; Handler upstream of the single trailing `done` (rf2-qpns).
             (.catch (fn [e]
@@ -811,14 +811,14 @@
   the end-to-end acceptance: the slow-loris no longer pins an in-flight
   handle indefinitely."
     (async done
-      (rf/init! reagent-adapter/adapter)
+      (rf/init! rf.adapter.reagent/adapter)
       ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
       ;; and the managed-HTTP fxs require a carried frame stamp. Register
       ;; `:rf/default` explicitly; each dispatch below carries `{:frame
       ;; :rf/default}` (the override) so the sync dispatch AND the async
       ;; abort continuation both target it without an ambient scope.
-      (frame/ensure-default-frame!)
-      (http-managed/clear-all-in-flight!)
+      (rf.frame/ensure-default-frame!)
+      (rf.http.managed/clear-all-in-flight!)
       (let [replies    (atom [])
             read-fired (atom false)
             resp       (fake-response-stalled-body
@@ -838,7 +838,7 @@
                     :on-failure [:reply/recorder]
                     :on-success [:reply/recorder]}]]}))
         (rf/dispatch-sync [:issue/slow-body] {:frame :rf/default})
-        (-> (test-support/poll-until
+        (-> (rf.test-support/poll-until
               #(seq @replies)
               {:timeout-ms 2000 :label "cljs stalled-body timeout reply"})
             (.then (fn [_]
@@ -848,7 +848,7 @@
                        (is (= :error (:status reply)))
                        (is (= :rf.http/timeout (get-in reply [:error :kind]))
                            "a stalled body read finalises as the canonical :rf.http/timeout failure"))
-                     (is (empty? (registry/in-flight-snapshot))
+                     (is (empty? (rf.http.registry/in-flight-snapshot))
                          "the in-flight registry is cleared — the slow-loris handle is not pinned")))
             (.catch (fn [e]
                       (is false (str "rf2-4zldh — unexpected: " e))
@@ -889,14 +889,14 @@
       ;; pure-transport tests, so cljs.test forbids a wrap-style
       ;; `use-fixtures` reset here (it would tear down before the async
       ;; body completes). Install the adapter + clear the registry inline.
-      (rf/init! reagent-adapter/adapter)
+      (rf/init! rf.adapter.reagent/adapter)
       ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
       ;; and the managed-HTTP fxs require a carried frame stamp. Register
       ;; `:rf/default` explicitly; each dispatch below carries `{:frame
       ;; :rf/default}` (the override) so the sync dispatch AND the async
       ;; abort continuation both target it without an ambient scope.
-      (frame/ensure-default-frame!)
-      (http-managed/clear-all-in-flight!)
+      (rf.frame/ensure-default-frame!)
+      (rf.http.managed/clear-all-in-flight!)
       (let [fetch-count (atom 0)
             replies     (atom [])
             restore     (with-counting-500-fetch fetch-count)
@@ -927,8 +927,8 @@
         ;; the backoff handle does not) — gating on this ensures we abort
         ;; the BACKOFF state, not a still-in-flight attempt #1. The defect
         ;; emptied the registry entirely during this window.
-        (-> (test-support/poll-until
-              #(let [handle (get (registry/in-flight-snapshot) :race)]
+        (-> (rf.test-support/poll-until
+              #(let [handle (get (rf.http.registry/in-flight-snapshot) :race)]
                  (and (= 1 @fetch-count)
                       (some? handle)
                       (nil? (:finalised? handle))))
@@ -936,12 +936,12 @@
             (.then (fn [_]
                      ;; Abort squarely inside the backoff window.
                      (rf/dispatch-sync [:do/abort] {:frame :rf/default})
-                     (is (empty? (registry/in-flight-snapshot))
+                     (is (empty? (rf.http.registry/in-flight-snapshot))
                          "the registry is cleared the instant the backoff is cancelled")
                      ;; The aborted reply dispatches through the async router;
                      ;; poll for it (it lands well before the backoff would
                      ;; have elapsed).
-                     (test-support/poll-until
+                     (rf.test-support/poll-until
                        #(seq @replies)
                        {:timeout-ms 2000 :label "cljs abort reply"})))
             (.then (fn [_]
@@ -983,10 +983,10 @@
             the backoff window cancels the pending retry (no second fetch) and
             SUPPRESSES the reply (nothing delivered into the destroyed frame)"
     (async done
-      (rf/init! reagent-adapter/adapter)
-      (frame/ensure-default-frame!)
+      (rf/init! rf.adapter.reagent/adapter)
+      (rf.frame/ensure-default-frame!)
       (rf/make-frame {:id :frame/req :doc "the frame that owns the in-flight request"})
-      (http-managed/clear-all-in-flight!)
+      (rf.http.managed/clear-all-in-flight!)
       (let [fetch-count (atom 0)
             replies     (atom [])
             restore     (with-counting-500-fetch fetch-count)
@@ -1009,18 +1009,18 @@
         ;; Poll until attempt #1 has fetched, failed 5xx, and the request is
         ;; sleeping in the backoff window (the backoff handle lacks `:finalised?`,
         ;; distinguishing it from a still-in-flight attempt).
-        (-> (test-support/poll-until
-              #(let [handle (get (registry/in-flight-snapshot) :destroy/race)]
+        (-> (rf.test-support/poll-until
+              #(let [handle (get (rf.http.registry/in-flight-snapshot) :destroy/race)]
                  (and (= 1 @fetch-count)
                       (some? handle)
                       (nil? (:finalised? handle))))
               {:timeout-ms 2000 :label "cljs backoff sleeping (destroy)"})
             (.then (fn [_]
-                     (is (= :frame/req (:frame (registry/lookup-in-flight :destroy/race)))
+                     (is (= :frame/req (:frame (rf.http.registry/lookup-in-flight :destroy/race)))
                          "precondition: the backoff handle carries its owning frame")
                      ;; Destroy the owning frame via the REAL recipe.
                      (rf/destroy-frame! :frame/req)
-                     (is (empty? (registry/in-flight-snapshot))
+                     (is (empty? (rf.http.registry/in-flight-snapshot))
                          "the registry cleared the instant the frame was destroyed")
                      ;; Wait past the original backoff deadline: the retry must
                      ;; never fetch again (timer cancelled) and no reply may land.
@@ -1066,14 +1066,14 @@
 (deftest cljs-throwing-body-thunk-delivers-managed-transport-failure
   (testing "rf2-065xo — a `:body` thunk that throws delivers ONE :on-failure reply with :rf.http/transport (NOT :rf.error/fx-handler-exception) and clears the registry"
     (async done
-      (rf/init! reagent-adapter/adapter)
+      (rf/init! rf.adapter.reagent/adapter)
       ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
       ;; and the managed-HTTP fxs require a carried frame stamp. Register
       ;; `:rf/default` explicitly; each dispatch below carries `{:frame
       ;; :rf/default}` (the override) so the sync dispatch AND the async
       ;; abort continuation both target it without an ambient scope.
-      (frame/ensure-default-frame!)
-      (http-managed/clear-all-in-flight!)
+      (rf.frame/ensure-default-frame!)
+      (rf.http.managed/clear-all-in-flight!)
       (let [replies (atom [])
             restore (with-failing-fetch)]
         (rf/reg-event :reply/recorder
@@ -1088,7 +1088,7 @@
                     :on-failure [:reply/recorder]
                     :on-success [:reply/recorder]}]]}))
         (rf/dispatch-sync [:issue/throwing-thunk] {:frame :rf/default})
-        (-> (test-support/poll-until
+        (-> (rf.test-support/poll-until
               #(seq @replies)
               {:timeout-ms 2000 :label "cljs body-thunk prep failure reply"})
             (.then (fn [_]
@@ -1100,7 +1100,7 @@
                            "a throwing body thunk surfaces as the managed :rf.http/transport category")
                        (is (= :request-prep (get-in reply [:error :stage]))
                            "the :stage discriminator marks this as a request-preparation failure"))
-                     (is (empty? (registry/in-flight-snapshot))
+                     (is (empty? (rf.http.registry/in-flight-snapshot))
                          "the in-flight registry is cleared — the failed-prep request is not pinned")))
             (.catch (fn [e]
                       (is false (str "rf2-065xo — unexpected: " e))
@@ -1110,14 +1110,14 @@
 (deftest cljs-unencodable-body-delivers-managed-transport-failure
   (testing "rf2-065xo — a non-serialisable body (circular ref → JSON.stringify throws) delivers ONE :on-failure reply with :rf.http/transport"
     (async done
-      (rf/init! reagent-adapter/adapter)
+      (rf/init! rf.adapter.reagent/adapter)
       ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
       ;; and the managed-HTTP fxs require a carried frame stamp. Register
       ;; `:rf/default` explicitly; each dispatch below carries `{:frame
       ;; :rf/default}` (the override) so the sync dispatch AND the async
       ;; abort continuation both target it without an ambient scope.
-      (frame/ensure-default-frame!)
-      (http-managed/clear-all-in-flight!)
+      (rf.frame/ensure-default-frame!)
+      (rf.http.managed/clear-all-in-flight!)
       (let [replies   (atom [])
             restore   (with-failing-fetch)
             ;; A circular JS object — `js/JSON.stringify` throws a TypeError
@@ -1138,7 +1138,7 @@
                     :on-failure [:reply/recorder]
                     :on-success [:reply/recorder]}]]}))
         (rf/dispatch-sync [:issue/unencodable] {:frame :rf/default})
-        (-> (test-support/poll-until
+        (-> (rf.test-support/poll-until
               #(seq @replies)
               {:timeout-ms 2000 :label "cljs encode prep failure reply"})
             (.then (fn [_]
@@ -1147,7 +1147,7 @@
                        (is (= :rf.http/transport (get-in reply [:error :kind]))
                            "an encode failure surfaces as the managed :rf.http/transport category")
                        (is (= :request-prep (get-in reply [:error :stage]))))
-                     (is (empty? (registry/in-flight-snapshot)))))
+                     (is (empty? (rf.http.registry/in-flight-snapshot)))))
             (.catch (fn [e]
                       (is false (str "rf2-065xo — unexpected: " e))
                       nil))
@@ -1156,14 +1156,14 @@
 (deftest cljs-throwing-body-thunk-retries-when-configured
   (testing "rf2-065xo — with `:retry {:on #{:rf.http/transport} …}` a throwing body thunk RETRIES (re-invoking the thunk per attempt) then finally fails :rf.http/transport"
     (async done
-      (rf/init! reagent-adapter/adapter)
+      (rf/init! rf.adapter.reagent/adapter)
       ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
       ;; and the managed-HTTP fxs require a carried frame stamp. Register
       ;; `:rf/default` explicitly; each dispatch below carries `{:frame
       ;; :rf/default}` (the override) so the sync dispatch AND the async
       ;; abort continuation both target it without an ambient scope.
-      (frame/ensure-default-frame!)
-      (http-managed/clear-all-in-flight!)
+      (rf.frame/ensure-default-frame!)
+      (rf.http.managed/clear-all-in-flight!)
       (let [replies     (atom [])
             invocations (atom 0)
             restore     (with-failing-fetch)]
@@ -1184,7 +1184,7 @@
                     :on-failure [:reply/recorder]
                     :on-success [:reply/recorder]}]]}))
         (rf/dispatch-sync [:issue/retry-thunk] {:frame :rf/default})
-        (-> (test-support/poll-until
+        (-> (rf.test-support/poll-until
               #(seq @replies)
               {:timeout-ms 4000 :label "cljs prep-failure retry exhaustion reply"})
             (.then (fn [_]
@@ -1195,7 +1195,7 @@
                      (let [reply (first @replies)]
                        (is (= :rf.http/transport (get-in reply [:error :kind]))
                            "the final reply carries the :rf.http/transport prep-failure category"))
-                     (is (empty? (registry/in-flight-snapshot)))))
+                     (is (empty? (rf.http.registry/in-flight-snapshot)))))
             (.catch (fn [e]
                       (is false (str "rf2-065xo — unexpected: " e))
                       nil))
@@ -1246,10 +1246,10 @@
   (testing "rf2-3fc89f.9 — `bind-external-abort!` attaches exactly ONE listener
   on a non-aborted signal; firing the signal invokes the bound `cancel!`."
     (let [{:keys [signal listener-count fire!]} (fake-abort-signal)
-          binding (transport-cljs/make-external-abort signal)
+          binding (rf.http.transport-cljs/make-external-abort signal)
           fired   (atom [])]
       (is (some? binding) "a binding is created for a non-nil signal")
-      (transport-cljs/bind-external-abort! binding (fn [] (swap! fired conj :phase-1)))
+      (rf.http.transport-cljs/bind-external-abort! binding (fn [] (swap! fired conj :phase-1)))
       (is (= 1 (listener-count)) "exactly one listener attached")
       (is (empty? @fired) "cancel! not yet called — signal has not aborted")
       (fire!)
@@ -1260,12 +1260,12 @@
   prior phase's listener (never a second concurrent listener) and routes the
   signal to the NEW phase handle's cancel!."
     (let [{:keys [signal listener-count fire!]} (fake-abort-signal)
-          binding (transport-cljs/make-external-abort signal)
+          binding (rf.http.transport-cljs/make-external-abort signal)
           fired   (atom [])]
-      (transport-cljs/bind-external-abort! binding (fn [] (swap! fired conj :live-fetch)))
+      (rf.http.transport-cljs/bind-external-abort! binding (fn [] (swap! fired conj :live-fetch)))
       (is (= 1 (listener-count)))
       ;; ownership transfer live-fetch → backoff
-      (transport-cljs/bind-external-abort! binding (fn [] (swap! fired conj :backoff)))
+      (rf.http.transport-cljs/bind-external-abort! binding (fn [] (swap! fired conj :backoff)))
       (is (= 1 (listener-count)) "still exactly one listener — the old one was detached")
       (fire!)
       (is (= [:backoff] @fired)
@@ -1275,31 +1275,31 @@
   (testing "rf2-3fc89f.9 — `detach-external-abort!` removes the listener and is
   idempotent (a shared/parent signal retains no listener after terminal)."
     (let [{:keys [signal listener-count]} (fake-abort-signal)
-          binding (transport-cljs/make-external-abort signal)]
-      (transport-cljs/bind-external-abort! binding (fn [] nil))
+          binding (rf.http.transport-cljs/make-external-abort signal)]
+      (rf.http.transport-cljs/bind-external-abort! binding (fn [] nil))
       (is (= 1 (listener-count)))
-      (transport-cljs/detach-external-abort! binding)
+      (rf.http.transport-cljs/detach-external-abort! binding)
       (is (= 0 (listener-count)) "listener detached")
-      (transport-cljs/detach-external-abort! binding)
+      (rf.http.transport-cljs/detach-external-abort! binding)
       (is (= 0 (listener-count)) "detach is idempotent — no throw, still zero"))))
 
 (deftest external-abort-already-aborted-fires-synchronously-attaches-nothing
   (testing "rf2-3fc89f.9 — binding an ALREADY-aborted signal fires cancel!
   synchronously and attaches NO listener (the caller then short-circuits)."
     (let [{:keys [signal listener-count pre-abort!]} (fake-abort-signal)
-          binding (transport-cljs/make-external-abort signal)
+          binding (rf.http.transport-cljs/make-external-abort signal)
           fired   (atom [])]
       (pre-abort!)
-      (transport-cljs/bind-external-abort! binding (fn [] (swap! fired conj :sync)))
+      (rf.http.transport-cljs/bind-external-abort! binding (fn [] (swap! fired conj :sync)))
       (is (= [:sync] @fired) "cancel! fired synchronously for an already-aborted signal")
       (is (= 0 (listener-count)) "no listener attached — nothing to leak"))))
 
 (deftest external-abort-nil-signal-is-a-noop
   (testing "rf2-3fc89f.9 — a nil `:abort-signal` yields a nil binding; bind /
   detach are no-ops (the common no-external-signal request path)."
-    (is (nil? (transport-cljs/make-external-abort nil)))
-    (is (nil? (transport-cljs/bind-external-abort! nil (fn [] (is false "must not fire")))))
-    (is (nil? (transport-cljs/detach-external-abort! nil)))))
+    (is (nil? (rf.http.transport-cljs/make-external-abort nil)))
+    (is (nil? (rf.http.transport-cljs/bind-external-abort! nil (fn [] (is false "must not fire")))))
+    (is (nil? (rf.http.transport-cljs/detach-external-abort! nil)))))
 
 ;; ---- (b) end-to-end: fetch stub whose body promise the test controls -------
 
@@ -1337,9 +1337,9 @@
   in-flight success to exactly one `:rf.http/aborted :reason :user` reply; no
   success/decode/status/accept outcome lands (pre-fix the settled success won)."
     (async done
-      (rf/init! reagent-adapter/adapter)
-      (frame/ensure-default-frame!)
-      (http-managed/clear-all-in-flight!)
+      (rf/init! rf.adapter.reagent/adapter)
+      (rf.frame/ensure-default-frame!)
+      (rf.http.managed/clear-all-in-flight!)
       (let [replies    (atom [])
             read-fired (atom false)
             {:keys [restore resolve-body!]} (with-controlled-body-fetch read-fired)
@@ -1355,7 +1355,7 @@
                     :on-failure [:reply/recorder]
                     :on-success [:reply/recorder]}]]}))
         (rf/dispatch-sync [:issue/ext] {:frame :rf/default})
-        (-> (test-support/poll-until
+        (-> (rf.test-support/poll-until
               #(when @read-fired true)
               {:timeout-ms 2000 :label "cljs body reader reached"})
             (.then (fn [_]
@@ -1363,7 +1363,7 @@
                      ;; synchronously in the same turn — before handle-response!.
                      (resolve-body! "{\"ok\":true}")
                      (.abort controller)
-                     (test-support/poll-until
+                     (rf.test-support/poll-until
                        #(seq @replies)
                        {:timeout-ms 2000 :label "cljs external-abort cancel reply"})))
             ;; Drain remaining microtasks so a wrongly-dispatched success would surface.
@@ -1376,7 +1376,7 @@
                        (is (= :rf.http/aborted (get-in reply [:error :kind]))
                            "the external signal flips the same precedence cell → :rf.http/aborted")
                        (is (= :user (get-in reply [:error :reason]))))
-                     (is (empty? (registry/in-flight-snapshot))
+                     (is (empty? (rf.http.registry/in-flight-snapshot))
                          "the live-fetch handle is cleared")))
             (.catch (fn [e] (is false (str "rf2-3fc89f.9 — unexpected: " e)) nil))
             (.then (fn [_] (restore) (done))))))))
@@ -1387,9 +1387,9 @@
   (timer cleared, registry emptied, one :rf.http/aborted :reason :user reply);
   attempt N+1 is never issued and the per-attempt body thunk is not re-invoked."
     (async done
-      (rf/init! reagent-adapter/adapter)
-      (frame/ensure-default-frame!)
-      (http-managed/clear-all-in-flight!)
+      (rf/init! rf.adapter.reagent/adapter)
+      (rf.frame/ensure-default-frame!)
+      (rf.http.managed/clear-all-in-flight!)
       (let [fetch-count (atom 0)
             thunk-calls (atom 0)
             replies     (atom [])
@@ -1418,8 +1418,8 @@
                     :on-failure [:reply/recorder]
                     :on-success [:reply/recorder]}]]}))
         (rf/dispatch-sync [:issue] {:frame :rf/default})
-        (-> (test-support/poll-until
-              #(let [handle (get (registry/in-flight-snapshot) :race)]
+        (-> (rf.test-support/poll-until
+              #(let [handle (get (rf.http.registry/in-flight-snapshot) :race)]
                  (and (= 1 @fetch-count)
                       (some? handle)
                       ;; backoff handle is distinguishable by the ABSENCE of the
@@ -1430,9 +1430,9 @@
                      (is (= 1 @thunk-calls) "attempt 1 invoked the body thunk exactly once")
                      ;; External signal fires squarely inside the backoff window.
                      (.abort controller)
-                     (is (empty? (registry/in-flight-snapshot))
+                     (is (empty? (rf.http.registry/in-flight-snapshot))
                          "the registry is cleared the instant the external signal cancels the backoff")
-                     (test-support/poll-until
+                     (rf.test-support/poll-until
                        #(seq @replies)
                        {:timeout-ms 2000 :label "cljs external abort reply"})))
             (.then (fn [_]
@@ -1462,9 +1462,9 @@
   ALREADY aborted before attempt setup dispatches one :rf.http/aborted
   :reason :user reply WITHOUT running the body thunk or issuing any fetch."
     (async done
-      (rf/init! reagent-adapter/adapter)
-      (frame/ensure-default-frame!)
-      (http-managed/clear-all-in-flight!)
+      (rf/init! rf.adapter.reagent/adapter)
+      (rf.frame/ensure-default-frame!)
+      (rf.http.managed/clear-all-in-flight!)
       (let [replies     (atom [])
             thunk-calls (atom 0)
             controller  (js/AbortController.)
@@ -1484,7 +1484,7 @@
                     :on-failure [:reply/recorder]
                     :on-success [:reply/recorder]}]]}))
         (rf/dispatch-sync [:issue/pre-aborted] {:frame :rf/default})
-        (-> (test-support/poll-until
+        (-> (rf.test-support/poll-until
               #(seq @replies)
               {:timeout-ms 2000 :label "cljs pre-aborted reply"})
             (.then (fn [_] (next-macrotask)))
@@ -1496,7 +1496,7 @@
                        (is (= :user (get-in reply [:error :reason]))))
                      (is (= 0 @thunk-calls)
                          "the body thunk was NEVER invoked — attempt setup short-circuited")
-                     (is (empty? (registry/in-flight-snapshot)))))
+                     (is (empty? (rf.http.registry/in-flight-snapshot)))))
             (.catch (fn [e] (is false (str "rf2-3fc89f.9 — unexpected: " e)) nil))
             (.then (fn [_] (restore) (done))))))))
 
@@ -1505,9 +1505,9 @@
   suppression stays authoritative: the superseded request delivers NO app reply
   even though its external signal ALSO fires afterwards (once-only CAS)."
     (async done
-      (rf/init! reagent-adapter/adapter)
-      (frame/ensure-default-frame!)
-      (http-managed/clear-all-in-flight!)
+      (rf/init! rf.adapter.reagent/adapter)
+      (rf.frame/ensure-default-frame!)
+      (rf.http.managed/clear-all-in-flight!)
       (let [replies-1  (atom [])
             read-fired (atom false)
             {:keys [restore]} (with-controlled-body-fetch read-fired)
@@ -1530,7 +1530,7 @@
                     :on-failure [:reply/recorder-2]
                     :on-success [:reply/recorder-2]}]]}))
         (rf/dispatch-sync [:issue/one] {:frame :rf/default})
-        (-> (test-support/poll-until
+        (-> (rf.test-support/poll-until
               #(when @read-fired true)
               {:timeout-ms 2000 :label "cljs request-1 in flight"})
             (.then (fn [_]
@@ -1554,9 +1554,9 @@
   the one canonical handle; the once-only CAS yields exactly one :cancelled
   outcome regardless of which fires first."
     (async done
-      (rf/init! reagent-adapter/adapter)
-      (frame/ensure-default-frame!)
-      (http-managed/clear-all-in-flight!)
+      (rf/init! rf.adapter.reagent/adapter)
+      (rf.frame/ensure-default-frame!)
+      (rf.http.managed/clear-all-in-flight!)
       (let [replies    (atom [])
             read-fired (atom false)
             {:keys [restore]} (with-controlled-body-fetch read-fired)
@@ -1573,7 +1573,7 @@
         (rf/reg-event :do/managed-abort
           (fn [_ _] {:fx [[:rf.http/managed-abort :both]]}))
         (rf/dispatch-sync [:issue] {:frame :rf/default})
-        (-> (test-support/poll-until
+        (-> (rf.test-support/poll-until
               #(when @read-fired true)
               {:timeout-ms 2000 :label "cljs both-sources in flight"})
             (.then (fn [_]
@@ -1581,7 +1581,7 @@
                      ;; handle whose once-only CAS is already spent → no-op.
                      (.abort controller)
                      (rf/dispatch-sync [:do/managed-abort] {:frame :rf/default})
-                     (test-support/poll-until
+                     (rf.test-support/poll-until
                        #(seq @replies)
                        {:timeout-ms 2000 :label "cljs single cancel reply"})))
             (.then (fn [_] (next-macrotask)))
@@ -1590,7 +1590,7 @@
                          "exactly one terminal outcome despite two cancellation sources")
                      (is (= :cancelled (:status (first @replies))))
                      (is (= :user (get-in (first @replies) [:error :reason])))
-                     (is (empty? (registry/in-flight-snapshot)))))
+                     (is (empty? (rf.http.registry/in-flight-snapshot)))))
             (.catch (fn [e] (is false (str "rf2-3fc89f.9 — unexpected: " e)) nil))
             (.then (fn [_] (restore) (done))))))))
 
@@ -1599,9 +1599,9 @@
   terminal failure that share ONE signal, no completed-attempt listeners
   accumulate: the binding detaches on every terminal path."
     (async done
-      (rf/init! reagent-adapter/adapter)
-      (frame/ensure-default-frame!)
-      (http-managed/clear-all-in-flight!)
+      (rf/init! rf.adapter.reagent/adapter)
+      (rf.frame/ensure-default-frame!)
+      (rf.http.managed/clear-all-in-flight!)
       (let [{:keys [signal listener-count]} (fake-abort-signal)
             replies (atom [])
             orig    (.-fetch js/globalThis)]
@@ -1620,7 +1620,7 @@
                 (js/Promise.resolve (fake-response {:status 200 :content-type "application/json"
                                                     :text-val "{\"ok\":true}"}))))
         (rf/dispatch-sync [:issue "/ok"] {:frame :rf/default})
-        (-> (test-support/poll-until
+        (-> (rf.test-support/poll-until
               #(seq @replies) {:timeout-ms 2000 :label "cljs shared-signal success reply"})
             (.then (fn [_]
                      (is (= :ok (:status (first @replies))))
@@ -1633,7 +1633,7 @@
                              (js/Promise.resolve (fake-response {:status 500 :content-type "application/json"
                                                                  :text-val "boom"}))))
                      (rf/dispatch-sync [:issue "/fail"] {:frame :rf/default})
-                     (test-support/poll-until
+                     (rf.test-support/poll-until
                        #(seq @replies) {:timeout-ms 2000 :label "cljs shared-signal failure reply"})))
             (.then (fn [_]
                      (is (= :error (:status (first @replies))))
@@ -1661,9 +1661,9 @@
   (testing "rf2-lddbk -- a successful managed request delivers the actual
             response status/status-text/normalized headers at [:meta ...]"
     (async done
-      (rf/init! reagent-adapter/adapter)
-      (frame/ensure-default-frame!)
-      (http-managed/clear-all-in-flight!)
+      (rf/init! rf.adapter.reagent/adapter)
+      (rf.frame/ensure-default-frame!)
+      (rf.http.managed/clear-all-in-flight!)
       (let [replies (atom [])
             orig    (.-fetch js/globalThis)
             resp    #js {:ok         true
@@ -1688,7 +1688,7 @@
         (set! (.-fetch js/globalThis)
               (fn [_url _init] (js/Promise.resolve resp)))
         (rf/dispatch-sync [:issue-meta] {:frame :rf/default})
-        (-> (test-support/poll-until
+        (-> (rf.test-support/poll-until
               #(seq @replies) {:timeout-ms 2000 :label "cljs success meta reply"})
             (.then (fn [_]
                      (let [reply (first @replies)]

--- a/implementation/http/test/re_frame/http_decode_test.clj
+++ b/implementation/http/test/re_frame/http_decode_test.clj
@@ -12,13 +12,13 @@
   / `malli.transform/json-transformer` succeeds at runtime — the
   schema branch exercises the real Malli decode + coerce + validate."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.http.decode :as decode]
-            [re-frame.trace :as trace]))
+            [re-frame.http.decode :as rf.http.decode]
+            [re-frame.trace :as rf.trace]))
 
 ;; `decode-response-body` is public; `malli-decode` is private — reach it
 ;; via #' so we can pin the lowest-level decode+validate behaviour without
 ;; widening the public surface.
-(def ^:private malli-decode @#'decode/malli-decode)
+(def ^:private malli-decode @#'rf.http.decode/malli-decode)
 
 ;; Sanity-pin: Malli really is resolvable on this test classpath. If a
 ;; future deps change drops the schemas test-dep, every schema test below
@@ -108,7 +108,7 @@
             yields a number for id (no coercion needed) and a string for
             status which the json-transformer coerces to a keyword."
     (is (= {:title "hello" :id 42 :status :active}
-           (decode/decode-response-body
+           (rf.http.decode/decode-response-body
              {:body-text "{\"title\":\"hello\",\"id\":42,\"status\":\"active\"}"
               :headers   {"content-type" "application/json"}
               :decode    [:map [:title :string] [:id :int] [:status :keyword]]}))
@@ -123,7 +123,7 @@
     (let [ex (is (thrown-with-msg?
                    clojure.lang.ExceptionInfo
                    #":rf.error/http-schema-validation-failed"
-                   (decode/decode-response-body
+                   (rf.http.decode/decode-response-body
                      {:body-text "{\"id\":\"not-an-int\"}"
                       :headers   {"content-type" "application/json"}
                       :decode    [:map [:id :int]]})))]
@@ -148,7 +148,7 @@
     (let [ex (is (thrown-with-msg?
                    clojure.lang.ExceptionInfo
                    #":rf.error/malformed-json"
-                   (decode/decode-response-body
+                   (rf.http.decode/decode-response-body
                      ;; three unique object keys, cap of 2 — the JSON
                      ;; reader throws :too-many-keys before any Malli work.
                      {:body-text "{\"a\":1,\"b\":2,\"c\":3}"
@@ -192,7 +192,7 @@
             (a Cheshire/Jackson `JsonParseException`, not an ex-info) so
             the caller classifies the response as :rf.http/decode-failure,
             NOT a successful string decode"
-    (let [thrown (try (decode/decode-response-body
+    (let [thrown (try (rf.http.decode/decode-response-body
                          {:body-text "tru" ; truncated `true` — invalid token
                           :headers   {"content-type" "application/json"}
                           :decode    :string})
@@ -211,7 +211,7 @@
             a plain decode failure (an unparseable body), NOT get
             misclassified as :schema-validation-failure? true (which would
             wrongly imply a well-formed-but-wrong-shaped payload)"
-    (let [thrown (try (decode/decode-response-body
+    (let [thrown (try (rf.http.decode/decode-response-body
                          {:body-text "{\"id\":nul}" ; misspelt `null`
                           :headers   {"content-type" "application/json"}
                           :decode    [:map [:id :int]]})
@@ -230,7 +230,7 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf.error/malformed-json"
-          (decode/decode-response-body
+          (rf.http.decode/decode-response-body
             {:body-text "{\"a\":1,\"b\":2,\"c\":3}"
              :headers   {"content-type" "application/json"}
              :decode    :json
@@ -256,7 +256,7 @@
                 "application/vnd.github+json"
                 "application/vnd.api+json; charset=utf-8"]]
       (is (= {:title "hello" :id 42}
-             (decode/decode-response-body
+             (rf.http.decode/decode-response-body
                {:body-text "{\"title\":\"hello\",\"id\":42}"
                 :headers   {"content-type" ct}
                 :decode    [:map [:title :string] [:id :int]]}))
@@ -271,7 +271,7 @@
       (is (thrown-with-msg?
             clojure.lang.ExceptionInfo
             #":rf.error/http-schema-non-json-content-type"
-            (decode/decode-response-body
+            (rf.http.decode/decode-response-body
               {:body-text "{\"title\":\"hello\"}"
                :headers   {"content-type" ct}
                :decode    [:map [:title :string]]}))
@@ -285,7 +285,7 @@
                 "application/ld+json"
                 "application/vnd.github+json; charset=utf-8"]]
       (is (= {:ok true}
-             (decode/decode-response-body
+             (rf.http.decode/decode-response-body
                {:body-text        "{\"ok\":true}"
                 :headers          {"content-type" ct}
                 :decode           :auto}))
@@ -294,7 +294,7 @@
 (deftest json-media-type-predicate-edge-cases
   (testing "rf2-houkno — the JSON media-type predicate accepts json subtype
             + +json suffix (parameter-stripped) and rejects genuine non-JSON"
-    (let [json-media-type? @#'decode/json-media-type?]
+    (let [json-media-type? @#'rf.http.decode/json-media-type?]
       (is (true?  (json-media-type? "application/json")))
       (is (true?  (json-media-type? "application/json; charset=utf-8")))
       (is (true?  (json-media-type? "APPLICATION/JSON")))
@@ -315,10 +315,10 @@
   (let [captured (atom [])
         cb-id    ::http-decode-test-cap]
     (try
-      (trace/register-listener! cb-id (fn [ev] (swap! captured conj ev)))
+      (rf.trace/register-listener! cb-id (fn [ev] (swap! captured conj ev)))
       (body-fn captured)
       (finally
-        (trace/unregister-listener! cb-id)))))
+        (rf.trace/unregister-listener! cb-id)))))
 
 ;; ---- Malli-absent degradation warning (rf2-ee38b.7 / rf2-ynjts.9) ---------
 ;;
@@ -343,10 +343,10 @@
 ;; the latch, and assert the documented degradation behaviour directly. This
 ;; is deterministic and host-agnostic.
 
-(def ^:private malli-decode-fn      @#'decode/malli-decode-fn)
-(def ^:private malli-transformer-fn @#'decode/malli-transformer-fn)
-(def ^:private malli-validate-fn    @#'decode/malli-validate-fn)
-(def ^:private malli-absent-warned? @#'decode/malli-absent-warned?)
+(def ^:private malli-decode-fn      @#'rf.http.decode/malli-decode-fn)
+(def ^:private malli-transformer-fn @#'rf.http.decode/malli-transformer-fn)
+(def ^:private malli-validate-fn    @#'rf.http.decode/malli-validate-fn)
+(def ^:private malli-absent-warned? @#'rf.http.decode/malli-absent-warned?)
 
 (defn- with-malli-absent
   "Run `body-fn` with the three Malli resolve delays rebound to the
@@ -358,9 +358,9 @@
   (let [prior-latch @malli-absent-warned?]
     (try
       (reset! malli-absent-warned? false)
-      (with-redefs [decode/malli-decode-fn      (delay nil)
-                    decode/malli-transformer-fn (delay nil)
-                    decode/malli-validate-fn    (delay nil)]
+      (with-redefs [rf.http.decode/malli-decode-fn      (delay nil)
+                    rf.http.decode/malli-transformer-fn (delay nil)
+                    rf.http.decode/malli-validate-fn    (delay nil)]
         (body-fn))
       (finally
         (reset! malli-absent-warned? prior-latch)))))

--- a/implementation/http/test/re_frame/http_empty_body_parity_cljs_test.cljc
+++ b/implementation/http/test/re_frame/http_empty_body_parity_cljs_test.cljc
@@ -29,7 +29,7 @@
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing]]
       :cljs [cljs.test :refer-macros [deftest is testing]])
-   [re-frame.http.decode :as decode]))
+   [re-frame.http.decode :as rf.http.decode]))
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-upexd.1 — empty / whitespace-only 2xx JSON body → nil on BOTH hosts
@@ -44,7 +44,7 @@
             empty/blank case before the host JSON reader is reached, so
             the value is nil identically — `run-accept`'s default then
             yields `{:ok nil}` → reply `{:status :ok :value nil …}`."
-    (is (nil? (decode/decode-response-body
+    (is (nil? (rf.http.decode/decode-response-body
                 {:body-text        ""
                  :headers          {"content-type" "application/json"}
                  :decode           :json}))
@@ -57,7 +57,7 @@
             it is the same empty-success-envelope outcome as `\"\"` — both
             classify as nil, not decode-failure."
     (doseq [s ["   " "\n" "\t" "  \n\t  "]]
-      (is (nil? (decode/decode-response-body
+      (is (nil? (rf.http.decode/decode-response-body
                   {:body-text        s
                    :headers          {"content-type" "application/json"}
                    :decode           :json}))
@@ -68,7 +68,7 @@
             and `:auto` resolves to :json via the `application/json`
             Content-Type (the exact repro from the bead: a 200 with an
             empty body and a JSON content-type). nil on both hosts."
-    (is (nil? (decode/decode-response-body
+    (is (nil? (rf.http.decode/decode-response-body
                 {:body-text        ""
                  :headers          {"content-type" "application/json; charset=utf-8"}
                  :decode           :auto}))
@@ -79,7 +79,7 @@
             JSON body still parses normally on both hosts (no regression
             to the happy path)."
     (is (= {:ok true}
-           (decode/decode-response-body
+           (rf.http.decode/decode-response-body
              {:body-text        "{\"ok\":true}"
               :headers          {"content-type" "application/json"}
               :decode           :json}))
@@ -95,7 +95,7 @@
             decode is a pass-through and nil flows straight out. Either way
             the value is nil cross-host, which is the parity contract under
             test.)"
-    (is (nil? (decode/decode-response-body
+    (is (nil? (rf.http.decode/decode-response-body
                 {:body-text        ""
                  :headers          {"content-type" "application/json"}
                  :decode           [:maybe [:map [:id :int]]]}))
@@ -122,7 +122,7 @@
             JSON-only (it wires Malli's json-transformer)."
     (is (= :rf.error/http-schema-non-json-content-type
            (thrown-id
-             #(decode/decode-response-body
+             #(rf.http.decode/decode-response-body
                 {:body-text        "{:a 1}"            ;; valid EDN, NOT JSON
                  :headers          {"content-type" "application/edn"}
                  :decode           [:map [:a :int]]})))
@@ -133,7 +133,7 @@
             non-JSON MIME and is rejected up-front on both hosts."
     (is (= :rf.error/http-schema-non-json-content-type
            (thrown-id
-             #(decode/decode-response-body
+             #(rf.http.decode/decode-response-body
                 {:body-text        "hello"
                  :headers          {"content-type" "text/plain"}
                  :decode           [:map [:a :int]]})))
@@ -148,7 +148,7 @@
             whether Malli is on the host's test classpath.)"
     (is (not= :rf.error/http-schema-non-json-content-type
               (thrown-id
-                #(decode/decode-response-body
+                #(rf.http.decode/decode-response-body
                    {:body-text        "{\"a\":1}"
                     :headers          {}                 ;; no content-type
                     :decode           [:map [:a :int]]})))
@@ -160,7 +160,7 @@
             non-JSON rejection does not fire."
     (is (not= :rf.error/http-schema-non-json-content-type
               (thrown-id
-                #(decode/decode-response-body
+                #(rf.http.decode/decode-response-body
                    {:body-text        "{\"a\":1}"
                     :headers          {"content-type" "application/json"}
                     :decode           [:map [:a :int]]})))

--- a/implementation/http/test/re_frame/http_encoding_test.clj
+++ b/implementation/http/test/re_frame/http_encoding_test.clj
@@ -22,8 +22,8 @@
      floor of zero (never negative)"
   (:require [clojure.string]
             [clojure.test :refer [deftest is testing]]
-            [re-frame.http.encoding :as encoding]
-            [re-frame.http.json :as http-json]))
+            [re-frame.http.encoding :as rf.http.encoding]
+            [re-frame.http.json :as rf.http.json]))
 
 ;; ---- attempt → delay (deterministic, jitter off) -------------------------
 
@@ -31,21 +31,21 @@
   (testing "rf2-9dro2 — default config (base-ms 250, factor 2,
             max-ms 5000) produces the documented exponential curve:
             250, 500, 1000, 2000, 4000, then clamped to 5000."
-    (is (= 250  (encoding/compute-backoff-ms {} 1))
+    (is (= 250  (rf.http.encoding/compute-backoff-ms {} 1))
         "attempt 1 = base-ms × factor^0 = 250 × 1 = 250")
-    (is (= 500  (encoding/compute-backoff-ms {} 2))
+    (is (= 500  (rf.http.encoding/compute-backoff-ms {} 2))
         "attempt 2 = 250 × 2 = 500")
-    (is (= 1000 (encoding/compute-backoff-ms {} 3))
+    (is (= 1000 (rf.http.encoding/compute-backoff-ms {} 3))
         "attempt 3 = 250 × 4 = 1000")
-    (is (= 2000 (encoding/compute-backoff-ms {} 4))
+    (is (= 2000 (rf.http.encoding/compute-backoff-ms {} 4))
         "attempt 4 = 250 × 8 = 2000")
-    (is (= 4000 (encoding/compute-backoff-ms {} 5))
+    (is (= 4000 (rf.http.encoding/compute-backoff-ms {} 5))
         "attempt 5 = 250 × 16 = 4000")
-    (is (= 5000 (encoding/compute-backoff-ms {} 6))
+    (is (= 5000 (rf.http.encoding/compute-backoff-ms {} 6))
         "attempt 6 = 250 × 32 = 8000, clamped to max-ms 5000")
-    (is (= 5000 (encoding/compute-backoff-ms {} 10))
+    (is (= 5000 (rf.http.encoding/compute-backoff-ms {} 10))
         "attempt 10 = 250 × 512 = 128000, clamped to max-ms 5000")
-    (is (= 5000 (encoding/compute-backoff-ms {} 20))
+    (is (= 5000 (rf.http.encoding/compute-backoff-ms {} 20))
         "attempt 20 = very large, clamped to max-ms 5000")))
 
 (deftest default-backoff-is-the-single-source-of-truth
@@ -53,25 +53,25 @@
             defaults Spec 014 §Retry and backoff documents (base-ms 250,
             factor 2, max-ms 5000), and `compute-backoff-ms` draws its `:or`
             defaults from it so the two can't drift"
-    (is (= {:base-ms 250 :factor 2 :max-ms 5000} encoding/default-backoff)
+    (is (= {:base-ms 250 :factor 2 :max-ms 5000} rf.http.encoding/default-backoff)
         "the named def matches the spec-documented defaults")
     ;; An empty config must produce exactly the curve the named defaults imply.
-    (is (= 250 (encoding/compute-backoff-ms {} 1)))
-    (is (= 500 (encoding/compute-backoff-ms {} 2)))
-    (is (= (:max-ms encoding/default-backoff)
-           (encoding/compute-backoff-ms {} 20))
+    (is (= 250 (rf.http.encoding/compute-backoff-ms {} 1)))
+    (is (= 500 (rf.http.encoding/compute-backoff-ms {} 2)))
+    (is (= (:max-ms rf.http.encoding/default-backoff)
+           (rf.http.encoding/compute-backoff-ms {} 20))
         "deep-attempt delay clamps to default-backoff's :max-ms")))
 
 (deftest compute-backoff-ms-custom-base-and-factor
   (testing "rf2-9dro2 — caller-supplied :base-ms and :factor override
             the defaults"
-    (is (= 100 (encoding/compute-backoff-ms {:base-ms 100 :factor 3} 1))
+    (is (= 100 (rf.http.encoding/compute-backoff-ms {:base-ms 100 :factor 3} 1))
         "attempt 1 with base=100, factor=3 → 100 × 3^0 = 100")
-    (is (= 300 (encoding/compute-backoff-ms {:base-ms 100 :factor 3} 2))
+    (is (= 300 (rf.http.encoding/compute-backoff-ms {:base-ms 100 :factor 3} 2))
         "attempt 2 with base=100, factor=3 → 100 × 3 = 300")
-    (is (= 900 (encoding/compute-backoff-ms {:base-ms 100 :factor 3} 3))
+    (is (= 900 (rf.http.encoding/compute-backoff-ms {:base-ms 100 :factor 3} 3))
         "attempt 3 with base=100, factor=3 → 100 × 9 = 900")
-    (is (= 2700 (encoding/compute-backoff-ms {:base-ms 100 :factor 3} 4))
+    (is (= 2700 (rf.http.encoding/compute-backoff-ms {:base-ms 100 :factor 3} 4))
         "attempt 4 with base=100, factor=3 → 100 × 27 = 2700")))
 
 (deftest compute-backoff-ms-linear-when-factor-is-one
@@ -79,10 +79,10 @@
             every attempt waits :base-ms. Spec 014 §Retry config
             allows :factor 1 as the linear escape hatch."
     (let [cfg {:base-ms 500 :factor 1 :max-ms 10000}]
-      (is (= 500 (encoding/compute-backoff-ms cfg 1)))
-      (is (= 500 (encoding/compute-backoff-ms cfg 2)))
-      (is (= 500 (encoding/compute-backoff-ms cfg 5)))
-      (is (= 500 (encoding/compute-backoff-ms cfg 100))
+      (is (= 500 (rf.http.encoding/compute-backoff-ms cfg 1)))
+      (is (= 500 (rf.http.encoding/compute-backoff-ms cfg 2)))
+      (is (= 500 (rf.http.encoding/compute-backoff-ms cfg 5)))
+      (is (= 500 (rf.http.encoding/compute-backoff-ms cfg 100))
           "factor=1 produces a constant base-ms delay regardless of
            attempt number — never grows, never clamps"))))
 
@@ -91,30 +91,30 @@
             delay; once raw exceeds :max-ms the result is exactly
             :max-ms (not bigger, not jittered)"
     (let [cfg {:base-ms 1000 :factor 2 :max-ms 3000}]
-      (is (= 1000 (encoding/compute-backoff-ms cfg 1)))
-      (is (= 2000 (encoding/compute-backoff-ms cfg 2)))
-      (is (= 3000 (encoding/compute-backoff-ms cfg 3))
+      (is (= 1000 (rf.http.encoding/compute-backoff-ms cfg 1)))
+      (is (= 2000 (rf.http.encoding/compute-backoff-ms cfg 2)))
+      (is (= 3000 (rf.http.encoding/compute-backoff-ms cfg 3))
           "raw 4000 clamped to max 3000")
-      (is (= 3000 (encoding/compute-backoff-ms cfg 4))
+      (is (= 3000 (rf.http.encoding/compute-backoff-ms cfg 4))
           "raw 8000 clamped to max 3000")
-      (is (= 3000 (encoding/compute-backoff-ms cfg 50))
+      (is (= 3000 (rf.http.encoding/compute-backoff-ms cfg 50))
           "raw 1000 × 2^49 clamped to max 3000"))))
 
 (deftest compute-backoff-ms-handles-low-attempt-numbers
   (testing "rf2-9dro2 — attempt 0 / negative is guarded by `(max 0
             (dec attempt))` in the exponent so it does not produce a
             negative exponent / fractional delay"
-    (is (= 250 (encoding/compute-backoff-ms {} 0))
+    (is (= 250 (rf.http.encoding/compute-backoff-ms {} 0))
         "attempt 0 → exponent (max 0 -1) = 0 → 250 × 1 = 250
          (same as attempt 1; the floor is documented in the source)")
-    (is (= 250 (encoding/compute-backoff-ms {} -5))
+    (is (= 250 (rf.http.encoding/compute-backoff-ms {} -5))
         "negative attempt → same floor at 250")))
 
 (deftest compute-backoff-ms-returns-long-integer
   (testing "rf2-9dro2 — the return type is `long` (the source coerces
             via `(long jittered)`), suitable for direct use as a
             timeout argument"
-    (let [result (encoding/compute-backoff-ms {} 3)]
+    (let [result (rf.http.encoding/compute-backoff-ms {} 3)]
       (is (integer? result))
       (is (instance? Long result)))))
 
@@ -136,7 +136,7 @@
           capped  4000.0
           low     (* capped 0.75)
           high    (* capped 1.25)
-          samples (repeatedly 200 #(encoding/compute-backoff-ms cfg attempt))]
+          samples (repeatedly 200 #(rf.http.encoding/compute-backoff-ms cfg attempt))]
       (doseq [s samples]
         (is (and (<= low s) (<= s high))
             (str "jittered sample " s " sits in ±25% window ["
@@ -154,7 +154,7 @@
             could go negative, the floor protects the caller from a
             negative timeout"
     (let [cfg     {:base-ms 100 :factor 1 :max-ms 100 :jitter true}
-          samples (repeatedly 200 #(encoding/compute-backoff-ms cfg 1))]
+          samples (repeatedly 200 #(rf.http.encoding/compute-backoff-ms cfg 1))]
       (doseq [s samples]
         (is (<= 0 s)
             (str "jittered sample " s " is non-negative (floor at 0)"))))))
@@ -167,7 +167,7 @@
     (let [cfg     {:base-ms 1000 :factor 2 :max-ms 2000 :jitter true}
           ;; attempt 10 — raw = 1000 × 512 = 512000, clamped to 2000.
           ;; Jittered samples should sit in [1500, 2500] (±25% of 2000).
-          samples (repeatedly 200 #(encoding/compute-backoff-ms cfg 10))]
+          samples (repeatedly 200 #(rf.http.encoding/compute-backoff-ms cfg 10))]
       (doseq [s samples]
         (is (and (<= 1500 s) (<= s 2500))
             (str "post-clamp jittered sample " s " sits in ±25% window
@@ -189,7 +189,7 @@
 
 (deftest build-reply-event-explicit-nil-is-silenced
   (testing "explicit :on-success nil silences the reply"
-    (is (nil? (encoding/build-reply-event
+    (is (nil? (rf.http.encoding/build-reply-event
                 {:origin-event  [:items/load {:page 1}]
                  :explicit-on   {:supplied? true :value nil}
                  :reply-payload reply-payload})))))
@@ -197,13 +197,13 @@
 (deftest build-reply-event-explicit-vector-appends-payload
   (testing "explicit event vector gets the reply payload appended as last arg"
     (is (= [:items/loaded reply-payload]
-           (encoding/build-reply-event
+           (rf.http.encoding/build-reply-event
              {:origin-event  [:items/load {:page 1}]
               :explicit-on   {:supplied? true :value [:items/loaded]}
               :reply-payload reply-payload})))
     (testing "extra args on the supplied vector are preserved before the payload"
       (is (= [:items/loaded 7 reply-payload]
-             (encoding/build-reply-event
+             (rf.http.encoding/build-reply-event
                {:origin-event  [:items/load]
                 :explicit-on   {:supplied? true :value [:items/loaded 7]}
                 :reply-payload reply-payload}))))))
@@ -215,11 +215,11 @@
             pre-alpha. A wholly-unaddressed request fails loud upstream at
             validate-reply-target!; an unsupplied branch reaching here is
             the partial-addressing silence case."
-    (is (nil? (encoding/build-reply-event
+    (is (nil? (rf.http.encoding/build-reply-event
                 {:origin-event  [:items/load {:page 1}]
                  :explicit-on   {:supplied? false :value nil}
                  :reply-payload reply-payload})))
-    (is (nil? (encoding/build-reply-event
+    (is (nil? (rf.http.encoding/build-reply-event
                 {:origin-event  [:items/load]
                  :explicit-on   {:supplied? false :value nil}
                  :reply-payload reply-payload})))))
@@ -233,7 +233,7 @@
     (let [ex (is (thrown-with-msg?
                    clojure.lang.ExceptionInfo
                    #":rf.error/http-bad-reply-target"
-                   (encoding/build-reply-event
+                   (rf.http.encoding/build-reply-event
                      {:origin-event  [:items/load {:page 1}]
                       :explicit-on   {:supplied? true :value :items/loaded}
                       :reply-payload reply-payload})))]
@@ -244,13 +244,13 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf.error/http-bad-reply-target"
-          (encoding/build-reply-event
+          (rf.http.encoding/build-reply-event
             {:origin-event  [:items/load]
              :explicit-on   {:supplied? true :value {:dispatch :items/loaded}}
              :reply-payload reply-payload})))
     (testing "the malformed value is NOT silently re-routed to the originator"
       (is (not= [:items/load {:page 1 :rf/reply reply-payload}]
-                (try (encoding/build-reply-event
+                (try (rf.http.encoding/build-reply-event
                        {:origin-event  [:items/load {:page 1}]
                         :explicit-on   {:supplied? true :value :items/loaded}
                         :reply-payload reply-payload})
@@ -272,64 +272,64 @@
 (deftest url-encode-escapes-reserved-characters
   (testing "rf2-ohwgm — url-encode percent-escapes reserved query
             characters so a value never breaks out of its key=value slot"
-    (is (= "hello%20world" (encoding/url-encode "hello world"))
+    (is (= "hello%20world" (rf.http.encoding/url-encode "hello world"))
         "JVM maps the URLEncoder `+` to `%20` (space) per the source")
-    (is (= "a%26b" (encoding/url-encode "a&b"))
+    (is (= "a%26b" (rf.http.encoding/url-encode "a&b"))
         "ampersand escaped so it can't be read as a param separator")
-    (is (= "a%3Db" (encoding/url-encode "a=b"))
+    (is (= "a%3Db" (rf.http.encoding/url-encode "a=b"))
         "equals escaped so it can't be read as a key/value delimiter")
-    (is (= "a%2Bb" (encoding/url-encode "a+b"))
+    (is (= "a%2Bb" (rf.http.encoding/url-encode "a+b"))
         "literal plus escaped to %2B (not collapsed with the space encoding)"))
   (testing "non-string args are coerced via (str ...) before encoding"
-    (is (= "42" (encoding/url-encode 42)))
-    (is (= "true" (encoding/url-encode true)))))
+    (is (= "42" (rf.http.encoding/url-encode 42)))
+    (is (= "true" (rf.http.encoding/url-encode true)))))
 
 ;; ---- params->query — keyword keys, escaping, joining ----------------------
 
 (deftest params->query-encodes-keyword-keys-and-escapes-values
   (testing "rf2-ohwgm — params->query renders keyword keys via `name`,
             escapes values, and joins pairs with `&` (no leading `?`)"
-    (is (= "page=2" (encoding/params->query {:page 2}))
+    (is (= "page=2" (rf.http.encoding/params->query {:page 2}))
         "keyword key → name; numeric value coerced via url-encode")
-    (is (= "q=a%20b" (encoding/params->query {:q "a b"}))
+    (is (= "q=a%20b" (rf.http.encoding/params->query {:q "a b"}))
         "value with a space is percent-escaped")
-    (is (= "q=a%26b" (encoding/params->query {:q "a&b"}))
+    (is (= "q=a%26b" (rf.http.encoding/params->query {:q "a&b"}))
         "value with an ampersand is escaped so it can't forge a new param"))
   (testing "string keys pass through, keyword keys lose their colon"
-    (is (= "limit=10" (encoding/params->query {"limit" 10}))))
+    (is (= "limit=10" (rf.http.encoding/params->query {"limit" 10}))))
   (testing "an empty params map renders an empty string"
-    (is (= "" (encoding/params->query {})))))
+    (is (= "" (rf.http.encoding/params->query {})))))
 
 (deftest params->query-multi-valued-uses-repeat-key
   (testing "rf2-mag59 — a sequential value (vector / seq / list) encodes
             as one repeated k=v pair per element (repeat-key idiom),
             NOT a single (str coll) blob"
     (is (= "tag=a&tag=b"
-           (encoding/params->query {:tag ["a" "b"]}))
+           (rf.http.encoding/params->query {:tag ["a" "b"]}))
         "a vector value repeats the key per element — not tag=%5B%22a%22...")
     (is (= "id=1&id=2&id=3"
-           (encoding/params->query {:id [1 2 3]}))
+           (rf.http.encoding/params->query {:id [1 2 3]}))
         "numeric elements coerce via url-encode like scalar values")
     (is (= "id=1&id=2"
-           (encoding/params->query {:id (list 1 2)}))
+           (rf.http.encoding/params->query {:id (list 1 2)}))
         "a list (seq) value is treated the same as a vector")
     (is (= "q=a%20b&q=c%26d"
-           (encoding/params->query {:q ["a b" "c&d"]}))
+           (rf.http.encoding/params->query {:q ["a b" "c&d"]}))
         "each element is independently percent-escaped"))
   (testing "an empty sequential value contributes no pair"
-    (is (= "" (encoding/params->query {:tag []}))
+    (is (= "" (rf.http.encoding/params->query {:tag []}))
         "an empty vector value emits nothing")
     (is (= "page=2"
-           (encoding/params->query {:page 2 :tag []}))
+           (rf.http.encoding/params->query {:page 2 :tag []}))
         "an empty seq value drops out, scalar siblings still encode"))
   (testing "a single-element sequential still uses the key once"
     (is (= "tag=only"
-           (encoding/params->query {:tag ["only"]}))))
+           (rf.http.encoding/params->query {:tag ["only"]}))))
   (testing "a set value (also sequential? false) is NOT repeat-keyed — only
             ordered seqs are; a set falls through to scalar (str ...)"
     ;; sets are unordered so repeat-key has no stable shape; treat as scalar.
     (is (clojure.string/starts-with?
-          (encoding/params->query {:tag #{"a"}})
+          (rf.http.encoding/params->query {:tag #{"a"}})
           "tag=")
         "a set value encodes via the scalar path (no defined repeat order)")))
 
@@ -340,14 +340,14 @@
             when the URL has none, and `&` when the URL already carries a
             `?` (http_encoding.cljc:60-67)"
     (is (= "/items?page=2"
-           (encoding/merge-params "/items" {:page 2}))
+           (rf.http.encoding/merge-params "/items" {:page 2}))
         "no existing `?` → join with `?`")
     (is (= "/items?sort=asc&page=2"
-           (encoding/merge-params "/items?sort=asc" {:page 2}))
+           (rf.http.encoding/merge-params "/items?sort=asc" {:page 2}))
         "existing `?` → join with `&`"))
   (testing "no params (empty or nil) returns the URL unchanged"
-    (is (= "/items" (encoding/merge-params "/items" {})))
-    (is (= "/items" (encoding/merge-params "/items" nil)))))
+    (is (= "/items" (rf.http.encoding/merge-params "/items" {})))
+    (is (= "/items" (rf.http.encoding/merge-params "/items" nil)))))
 
 (deftest merge-params-splices-before-fragment
   (testing "rf2-rznrz — params are spliced BEFORE a `#fragment`, never after.
@@ -355,16 +355,16 @@
             the fragment to nobody, so appending the query AFTER the `#` (the
             prior `(str url sep qs)` shape) silently drops the params."
     (is (= "/items?page=2#frag"
-           (encoding/merge-params "/items#frag" {:page 2}))
+           (rf.http.encoding/merge-params "/items#frag" {:page 2}))
         "no existing `?` → the query is inserted with `?` BEFORE `#frag`,
          and the fragment is reattached verbatim AFTER the query")
     (is (= "/items?sort=asc&page=2#frag"
-           (encoding/merge-params "/items?sort=asc#frag" {:page 2}))
+           (rf.http.encoding/merge-params "/items?sort=asc#frag" {:page 2}))
         "existing `?` in the pre-fragment part → join with `&`, fragment
          stays at the very end")
     (testing "the broken `#frag?page=2` shape is NOT produced"
       (is (not= "/items#frag?page=2"
-                (encoding/merge-params "/items#frag" {:page 2}))
+                (rf.http.encoding/merge-params "/items#frag" {:page 2}))
           "params MUST NOT land after the `#` where they'd be dropped on the wire"))))
 
 (deftest merge-params-no-encoded-pairs-leaves-url-unchanged
@@ -373,17 +373,17 @@
             returned UNCHANGED — no dangling `?` / `&`. The decision keys off
             the ENCODED query string, not `(seq params)`."
     (is (= "/items"
-           (encoding/merge-params "/items" {:tag []}))
+           (rf.http.encoding/merge-params "/items" {:tag []}))
         "an all-empty-sequential params map yields no pairs → no dangling `?`")
     (is (= "/items?sort=asc"
-           (encoding/merge-params "/items?sort=asc" {:tag []}))
+           (rf.http.encoding/merge-params "/items?sort=asc" {:tag []}))
         "an existing query is preserved with no dangling `&`")
     (is (= "/items#frag"
-           (encoding/merge-params "/items#frag" {:tag []}))
+           (rf.http.encoding/merge-params "/items#frag" {:tag []}))
         "a fragment-only URL with no encodable params is returned verbatim")
     (testing "a mix of empty + non-empty still encodes the non-empty pairs"
       (is (= "/items?page=2#frag"
-             (encoding/merge-params "/items#frag" {:tag [] :page 2}))
+             (rf.http.encoding/merge-params "/items#frag" {:tag [] :page 2}))
           "the empty-sequential drops out; the scalar sibling still splices
            before the fragment"))))
 
@@ -397,22 +397,22 @@
 (deftest encode-body-nil-body-emits-no-content-type
   (testing "rf2-ohwgm — a nil body encodes to [nil nil] (no body, no
             Content-Type header)"
-    (is (= [nil nil] (encoding/encode-body nil :json))
+    (is (= [nil nil] (rf.http.encoding/encode-body nil :json))
         "nil body short-circuits regardless of the requested content-type")
-    (is (= [nil nil] (encoding/encode-body nil nil)))))
+    (is (= [nil nil] (rf.http.encoding/encode-body nil nil)))))
 
 (deftest encode-body-json-request-content-type
   (testing "rf2-ohwgm — :request-content-type :json JSON-stringifies the
             body and returns application/json"
-    (let [[body ct] (encoding/encode-body {:a 1 :b "two"} :json)]
+    (let [[body ct] (rf.http.encoding/encode-body {:a 1 :b "two"} :json)]
       (is (= "application/json" ct))
-      (is (= {:a 1 :b "two"} (http-json/json-parse body))
+      (is (= {:a 1 :b "two"} (rf.http.json/json-parse body))
           "the body round-trips through json-parse (stable across key order)"))))
 
 (deftest encode-body-form-request-content-type
   (testing "rf2-ohwgm — :request-content-type :form URL-encodes the map as
             a form body and returns application/x-www-form-urlencoded"
-    (let [[body ct] (encoding/encode-body {:q "a b" :page 2} :form)]
+    (let [[body ct] (rf.http.encoding/encode-body {:q "a b" :page 2} :form)]
       (is (= "application/x-www-form-urlencoded" ct))
       ;; form body is `params->query` of the map — assert each escaped pair
       ;; is present (map iteration order is not guaranteed).
@@ -423,27 +423,27 @@
 (deftest encode-body-text-request-content-type
   (testing "rf2-ohwgm — :request-content-type :text stringifies the body
             and returns text/plain"
-    (is (= ["hello" "text/plain"] (encoding/encode-body "hello" :text)))
-    (is (= ["42" "text/plain"] (encoding/encode-body 42 :text))
+    (is (= ["hello" "text/plain"] (rf.http.encoding/encode-body "hello" :text)))
+    (is (= ["42" "text/plain"] (rf.http.encoding/encode-body 42 :text))
         "non-string body coerced via (str ...)")))
 
 (deftest encode-body-explicit-mime-string-request-content-type
   (testing "rf2-ohwgm — an explicit MIME-string :request-content-type
             stringifies the body and returns that exact MIME unchanged"
     (is (= ["<x/>" "application/xml"]
-           (encoding/encode-body "<x/>" "application/xml")))))
+           (rf.http.encoding/encode-body "<x/>" "application/xml")))))
 
 (deftest encode-body-coll-heuristic-defaults-to-json
   (testing "rf2-ohwgm — with no explicit :request-content-type, a raw
             Clojure coll (map / sequential / set) is JSON-encoded and
             tagged application/json (the heuristic at http_encoding.cljc:97)"
-    (let [[mbody mct] (encoding/encode-body {:a 1} nil)]
+    (let [[mbody mct] (rf.http.encoding/encode-body {:a 1} nil)]
       (is (= "application/json" mct))
-      (is (= {:a 1} (http-json/json-parse mbody))))
-    (let [[vbody vct] (encoding/encode-body [1 2 3] nil)]
+      (is (= {:a 1} (rf.http.json/json-parse mbody))))
+    (let [[vbody vct] (rf.http.encoding/encode-body [1 2 3] nil)]
       (is (= "application/json" vct))
-      (is (= [1 2 3] (http-json/json-parse vbody))))
-    (let [[_ sct] (encoding/encode-body #{1 2 3} nil)]
+      (is (= [1 2 3] (rf.http.json/json-parse vbody))))
+    (let [[_ sct] (rf.http.encoding/encode-body #{1 2 3} nil)]
       (is (= "application/json" sct)
           "a set also trips the coll heuristic"))))
 
@@ -452,7 +452,7 @@
             pre-encoded string / opaque value) passes through unchanged
             with a nil content-type (the caller sets no header)"
     (is (= ["already-encoded" nil]
-           (encoding/encode-body "already-encoded" nil))
+           (rf.http.encoding/encode-body "already-encoded" nil))
         "a bare string is pass-through: body kept, content-type nil")))
 
 ;; ---- run-accept — Spec 014 §`:accept` default normalisation (G2) ----------
@@ -473,9 +473,9 @@
             unconditionally as {:ok decoded} (run-accept only ever runs
             against an already-classified 2xx response)"
     (is (= {:ok {:title "hello"}}
-           (encoding/run-accept nil {:title "hello"})))
+           (rf.http.encoding/run-accept nil {:title "hello"})))
     (is (= {:ok nil}
-           (encoding/run-accept nil nil))
+           (rf.http.encoding/run-accept nil nil))
         "a nil decoded body still wraps as {:ok nil}")))
 
 (deftest run-accept-default-never-produces-http-status-rf2-xmp74u
@@ -494,7 +494,7 @@
                      [1 2 3]
                      "raw text"
                      42]]
-      (let [result (encoding/run-accept nil decoded)]
+      (let [result (rf.http.encoding/run-accept nil decoded)]
         (is (contains? result :ok)
             (str "default accept yields {:ok ...} for " (pr-str decoded)))
         (is (not (contains? result :failure))
@@ -511,9 +511,9 @@
                      {:ok (:data decoded)}
                      {:failure {:kind :domain :reason :invalid}}))]
       (is (= {:ok 42}
-             (encoding/run-accept accept {:valid? true :data 42})))
+             (rf.http.encoding/run-accept accept {:valid? true :data 42})))
       (is (= {:failure {:kind :domain :reason :invalid}}
-             (encoding/run-accept accept {:valid? false}))
+             (rf.http.encoding/run-accept accept {:valid? false}))
           "the user :accept can fail a 2xx response (domain-level rejection)"))))
 
 ;; ---- valid-accept-return? — Spec 014 §`:accept` shape validation ----------
@@ -521,30 +521,30 @@
 (deftest valid-accept-return-recognises-ok-and-failure
   (testing "rf2-rznrz — a map carrying EXACTLY one of :ok / :failure is the
             recognised accept-return shape"
-    (is (encoding/valid-accept-return? {:ok 42}))
-    (is (encoding/valid-accept-return? {:ok nil})
+    (is (rf.http.encoding/valid-accept-return? {:ok 42}))
+    (is (rf.http.encoding/valid-accept-return? {:ok nil})
         "{:ok nil} is valid — the key presence is what matters, not the value")
-    (is (encoding/valid-accept-return? {:failure {:kind :domain}}))
-    (is (encoding/valid-accept-return? {:ok 1 :extra :ignored})
+    (is (rf.http.encoding/valid-accept-return? {:failure {:kind :domain}}))
+    (is (rf.http.encoding/valid-accept-return? {:ok 1 :extra :ignored})
         "extra keys alongside the single recognised key are tolerated")))
 
 (deftest valid-accept-return-rejects-malformed-shapes
   (testing "rf2-rznrz — nil, non-maps, and maps without exactly one of
             :ok/:failure are MALFORMED (these previously stranded the
             request with no reply)"
-    (is (not (encoding/valid-accept-return? nil))
+    (is (not (rf.http.encoding/valid-accept-return? nil))
         "nil return is malformed")
-    (is (not (encoding/valid-accept-return? {}))
+    (is (not (rf.http.encoding/valid-accept-return? {}))
         "an empty map carries neither key")
-    (is (not (encoding/valid-accept-return? {:status :good}))
+    (is (not (rf.http.encoding/valid-accept-return? {:status :good}))
         "a map without :ok/:failure is malformed")
-    (is (not (encoding/valid-accept-return? {:ok 1 :failure {}}))
+    (is (not (rf.http.encoding/valid-accept-return? {:ok 1 :failure {}}))
         "a map carrying BOTH keys is ambiguous → rejected")
-    (is (not (encoding/valid-accept-return? :ok))
+    (is (not (rf.http.encoding/valid-accept-return? :ok))
         "a bare keyword is not a map")
-    (is (not (encoding/valid-accept-return? [:ok 1]))
+    (is (not (rf.http.encoding/valid-accept-return? [:ok 1]))
         "a vector is not a map")
-    (is (not (encoding/valid-accept-return? "ok"))
+    (is (not (rf.http.encoding/valid-accept-return? "ok"))
         "a string is not a map")))
 
 ;; ---- normalize-header-pairs — Spec 014 §Request envelope (multi-valued) ---
@@ -553,9 +553,9 @@
   (testing "rf2-rznrz — a scalar header value yields exactly one [name value]
             wire pair, stringified"
     (is (= [["Accept" "application/json"]]
-           (encoding/normalize-header-pairs {"Accept" "application/json"})))
+           (rf.http.encoding/normalize-header-pairs {"Accept" "application/json"})))
     (is (= [["X-Count" "42"]]
-           (encoding/normalize-header-pairs {"X-Count" 42}))
+           (rf.http.encoding/normalize-header-pairs {"X-Count" 42}))
         "a non-string scalar value is stringified per element")))
 
 (deftest normalize-header-pairs-vector-yields-pair-per-element
@@ -563,16 +563,16 @@
             element (the HTTP multi-valued idiom = repeat the name), NOT a
             single pair carrying the vector"
     (is (= [["Accept" "text/html"] ["Accept" "application/json"]]
-           (encoding/normalize-header-pairs {"Accept" ["text/html" "application/json"]}))
+           (rf.http.encoding/normalize-header-pairs {"Accept" ["text/html" "application/json"]}))
         "each element gets its own [name value] pair, in order")
     (is (= [["X-Tag" "1"] ["X-Tag" "2"] ["X-Tag" "3"]]
-           (encoding/normalize-header-pairs {"X-Tag" [1 2 3]}))
+           (rf.http.encoding/normalize-header-pairs {"X-Tag" [1 2 3]}))
         "numeric elements are stringified per element")
     (is (= [["X-Tag" "a"] ["X-Tag" "b"]]
-           (encoding/normalize-header-pairs {"X-Tag" (list "a" "b")}))
+           (rf.http.encoding/normalize-header-pairs {"X-Tag" (list "a" "b")}))
         "a seq value is treated like a vector"))
   (testing "an empty sequential value contributes NO pair (header absent)"
-    (is (= [] (encoding/normalize-header-pairs {"X-Empty" []})))
+    (is (= [] (rf.http.encoding/normalize-header-pairs {"X-Empty" []})))
     (is (= [["Accept" "application/json"]]
-           (encoding/normalize-header-pairs {"X-Empty" [] "Accept" "application/json"}))
+           (rf.http.encoding/normalize-header-pairs {"X-Empty" [] "Accept" "application/json"}))
         "the empty-sequential drops out; scalar siblings still emit")))

--- a/implementation/http/test/re_frame/http_frame_destroy_abort_test.clj
+++ b/implementation/http/test/re_frame/http_frame_destroy_abort_test.clj
@@ -26,18 +26,18 @@
   delivers nothing."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.http.registry :as http-registry]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace])
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.registry :as rf.http.registry]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace])
   (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
            [java.net InetSocketAddress]
            [java.util.concurrent CountDownLatch TimeUnit]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- start-blocking-server!
   [^CountDownLatch latch status content-type body]
@@ -66,7 +66,7 @@
 (defn- await-condition!
   ([pred] (await-condition! pred 5000))
   ([pred timeout-ms]
-   (test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
+   (rf.test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
                                   :label "http-frame-destroy condition"})
    true))
 
@@ -75,9 +75,9 @@
 (deftest hook-published
   (testing "rf2-j538f7.8 — the :http/on-frame-destroyed! hook is published and
             resolves to the frame-destroy abort walker"
-    (is (some? (late-bind/get-fn :http/on-frame-destroyed!)))
-    (is (= http-registry/abort-in-flight-on-frame-destroyed!
-           (late-bind/get-fn :http/on-frame-destroyed!)))))
+    (is (some? (rf.late-bind/get-fn :http/on-frame-destroyed!)))
+    (is (= rf.http.registry/abort-in-flight-on-frame-destroyed!
+           (rf.late-bind/get-fn :http/on-frame-destroyed!)))))
 
 ;; ---- registry-level: frame-scoped abort + reason (crit 1) -----------------
 
@@ -85,40 +85,40 @@
   (testing "rf2-j538f7.8 — abort-in-flight-on-frame-destroyed! fires each of the
             destroyed frame's handles exactly once with :reason :frame-destroyed
             and leaves a SIBLING frame's request byte-for-byte live"
-    (http-managed/clear-all-in-flight!)
+    (rf.http.managed/clear-all-in-flight!)
     (let [seen (atom [])
           ;; production abort-fns clear their own slot via the finalise cascade;
           ;; model that here so the sibling-survival + idempotence checks below
           ;; observe the real post-abort index shape.
           mk   (fn [frame-id request-id]
-                 (http-registry/seed-in-flight-for-test!
+                 (rf.http.registry/seed-in-flight-for-test!
                    request-id nil
                    {:abort-fn   (fn [reason]
                                   (swap! seen conj [frame-id reason])
-                                  (http-registry/clear-in-flight! request-id))
+                                  (rf.http.registry/clear-in-flight! request-id))
                     :request-id request-id
                     :url        "http://x/y"
                     :frame      frame-id}))]
       (mk :frame/a :req-a1)
       (mk :frame/a :req-a2)
       (mk :frame/b :req-b)
-      (http-registry/abort-in-flight-on-frame-destroyed! :frame/a)
+      (rf.http.registry/abort-in-flight-on-frame-destroyed! :frame/a)
       (is (= #{[:frame/a :frame-destroyed]} (set @seen))
           "only frame A's handles fired, each with :reason :frame-destroyed")
       (is (= 2 (count @seen)) "both of frame A's requests were aborted, once each")
-      (is (nil? (http-registry/lookup-in-flight :req-a1))
+      (is (nil? (rf.http.registry/lookup-in-flight :req-a1))
           "frame A's first request cleared from the index")
-      (is (nil? (http-registry/lookup-in-flight :req-a2))
+      (is (nil? (rf.http.registry/lookup-in-flight :req-a2))
           "frame A's second request cleared from the index")
-      (is (= :frame/b (:frame (http-registry/lookup-in-flight :req-b)))
+      (is (= :frame/b (:frame (rf.http.registry/lookup-in-flight :req-b)))
           "the SIBLING frame's request remains live and untouched")
-      (http-managed/clear-all-in-flight!))))
+      (rf.http.managed/clear-all-in-flight!))))
 
 (deftest frame-destroy-noop-on-frame-with-no-requests
   (testing "rf2-j538f7.8 — a frame with no in-flight managed HTTP is a clean no-op"
-    (http-managed/clear-all-in-flight!)
-    (is (nil? (http-registry/abort-in-flight-on-frame-destroyed! :frame/none)))
-    (is (nil? (http-registry/abort-in-flight-on-frame-destroyed! nil)))))
+    (rf.http.managed/clear-all-in-flight!)
+    (is (nil? (rf.http.registry/abort-in-flight-on-frame-destroyed! :frame/none)))
+    (is (nil? (rf.http.registry/abort-in-flight-on-frame-destroyed! nil)))))
 
 ;; ---- ordering / idempotence: no duplicate abort on a cleared handle (crit 4)
 
@@ -126,12 +126,12 @@
   (testing "rf2-j538f7.8 — when an earlier teardown (actor-destroy / resource
             teardown) already cleared a frame's HTTP slot, the later generic
             frame-destroy sweep produces NO duplicate abort or stale trace"
-    (http-managed/clear-all-in-flight!)
+    (rf.http.managed/clear-all-in-flight!)
     (let [aborts (atom [])
           traces (atom [])]
       (try
-        (trace/register-listener! ::idem (fn [ev] (swap! traces conj ev)))
-        (http-registry/seed-in-flight-for-test!
+        (rf.trace/register-listener! ::idem (fn [ev] (swap! traces conj ev)))
+        (rf.http.registry/seed-in-flight-for-test!
           :req/gone nil
           {:abort-fn   (fn [reason] (swap! aborts conj reason))
            :request-id :req/gone
@@ -139,16 +139,16 @@
            :frame      :frame/a})
         ;; A more-specific teardown wins first and clears the slot WITHOUT the
         ;; generic sweep's involvement.
-        (http-registry/clear-in-flight! :req/gone)
+        (rf.http.registry/clear-in-flight! :req/gone)
         ;; The generic HTTP frame-destroy sweep then runs — and finds nothing.
-        (http-registry/abort-in-flight-on-frame-destroyed! :frame/a)
+        (rf.http.registry/abort-in-flight-on-frame-destroyed! :frame/a)
         (is (empty? @aborts)
             "the already-cleared handle is NOT aborted a second time")
         (is (empty? (filter #(= :rf.http/stale-suppressed (:operation %)) @traces))
             "no duplicate stale-suppressed trace for the already-cleared handle")
         (finally
-          (trace/unregister-listener! ::idem)
-          (http-managed/clear-all-in-flight!))))))
+          (rf.trace/unregister-listener! ::idem)
+          (rf.http.managed/clear-all-in-flight!))))))
 
 ;; ---- end-to-end: destroy-frame! aborts a genuinely in-flight request -------
 ;; (crit 2 — the adversarial regression: FAILS before the destroy-frame! wiring)
@@ -165,7 +165,7 @@
           replies (atom [])
           traces  (atom [])]
       (try
-        (trace/register-listener! ::j538f7 (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! ::j538f7 (fn [ev] (swap! traces conj ev)))
         (rf/make-frame {:id :frame/req :doc "the frame that owns the in-flight request"})
         (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
@@ -182,10 +182,10 @@
                     :on-success [:reply/recorder]
                     :on-failure [:reply/recorder]}]]}))
         (rf/dispatch-sync [:load] {:frame :frame/req})
-        (await-condition! #(seq (http-managed/in-flight-snapshot)))
-        (is (= 1 (count (http-managed/in-flight-snapshot)))
+        (await-condition! #(seq (rf.http.managed/in-flight-snapshot)))
+        (is (= 1 (count (rf.http.managed/in-flight-snapshot)))
             "precondition: the request is in flight")
-        (is (= :frame/req (:frame (http-registry/lookup-in-flight :destroy/req)))
+        (is (= :frame/req (:frame (rf.http.registry/lookup-in-flight :destroy/req)))
             "precondition: the in-flight handle carries its originating frame")
         ;; Destroy the owning frame via the REAL recipe — this is the wiring
         ;; under test (before the fix, destroy-frame! left the slot in flight).
@@ -193,8 +193,8 @@
         ;; The abort cascade clears the registry slot — and it clears while the
         ;; server is STILL BLOCKED, so the clear is the abort, not a natural
         ;; completion.
-        (await-condition! #(empty? (http-managed/in-flight-snapshot)))
-        (is (empty? (http-managed/in-flight-snapshot))
+        (await-condition! #(empty? (rf.http.managed/in-flight-snapshot)))
+        (is (empty? (rf.http.managed/in-flight-snapshot))
             "the in-flight slot cleared promptly on frame destroy")
         ;; Release the server so any late completion would arrive.
         (.countDown latch)
@@ -219,5 +219,5 @@
             (is (= :frame/req (:frame tags))
                 "the trace names the destroyed frame")))
         (finally
-          (trace/unregister-listener! ::j538f7)
+          (rf.trace/unregister-listener! ::j538f7)
           (stop-server! srv))))))

--- a/implementation/http/test/re_frame/http_helpers_integration_test.clj
+++ b/implementation/http/test/re_frame/http_helpers_integration_test.clj
@@ -10,18 +10,18 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.http :as rf.http]
-            [re-frame.http.managed :as http-managed]
+            [re-frame.http.managed :as rf.http.managed]
             ;; rf2-cdmle — canned-stub fxs gate on explicit test-support
             ;; require. This file uses :fx-overrides {:rf.http/managed
             ;; :rf.http/managed-canned-success/failure} below.
             [re-frame.http.test-support]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---- per-test reset (mirrors http-managed-test) ---------------------------
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- helpers --------------------------------------------------------------
 
@@ -34,7 +34,7 @@
   `db`-closing-arity shape that read sites here expect."
   ([pred] (await-reply! pred 5000))
   ([pred timeout-ms]
-   (test-support/poll-until
+   (rf.test-support/poll-until
      #(let [db (rf/app-db-value :rf/default)] (when (pred db) db))
      {:timeout-ms timeout-ms :label "http-helpers reply"})))
 

--- a/implementation/http/test/re_frame/http_interceptors_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_interceptors_cljs_test.cljs
@@ -19,10 +19,10 @@
   interceptor surface."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.http.middleware :as http-mw]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.middleware :as rf.http.middleware]))
 
 ;; EP-0002 (rf2-nn0jqa): the no-`:frame` `reg-http-interceptor` /
 ;; `clear-http-interceptor` calls below resolve the frame through the
@@ -33,22 +33,22 @@
 ;; frame explicitly (the per-frame-scope case) still override it.
 (use-fixtures :each
   (fn [t]
-    (http-managed/clear-all-http-interceptors!)
-    (frame/ensure-default-frame!)
-    (binding [frame/*current-frame* :rf/default]
+    (rf.http.managed/clear-all-http-interceptors!)
+    (rf.frame/ensure-default-frame!)
+    (binding [rf.frame/*current-frame* :rf/default]
       (t))
-    (http-managed/clear-all-http-interceptors!)))
+    (rf.http.managed/clear-all-http-interceptors!)))
 
 ;; ---- 1. round-trip register / clear ---------------------------------------
 
 (deftest register-and-clear-round-trip
   (testing "reg-http-interceptor adds a slot; clear removes it"
     (rf/reg-http-interceptor :a {:before (fn [ctx] ctx)})
-    (let [chain (http-managed/interceptors-snapshot :rf/default)]
+    (let [chain (rf.http.managed/interceptors-snapshot :rf/default)]
       (is (= 1 (count chain)))
       (is (= :a (:id (first chain)))))
     (rf/clear-http-interceptor :a)
-    (let [chain (http-managed/interceptors-snapshot :rf/default)]
+    (let [chain (rf.http.managed/interceptors-snapshot :rf/default)]
       (is (zero? (count chain))))))
 
 ;; ---- 1a. rf2-vl5xsp — single-arity clear FAILS CLOSED under no scope ------
@@ -64,7 +64,7 @@
   (testing "rf2-vl5xsp — single-arity `rf/clear-http-interceptor` under NO
             ambient frame raises :rf.error/no-frame-context; it does NOT
             synthesise a :rf/default target."
-    (binding [frame/*current-frame* nil]
+    (binding [rf.frame/*current-frame* nil]
       (let [thrown (try (rf/clear-http-interceptor :some-id)
                         nil
                         (catch :default e e))]
@@ -94,7 +94,7 @@
   (testing "rf2-9ynwvx — a bare reg under no ambient scope raises
             :rf.error/no-frame-context and installs nothing; a
             (with-frame f …) reg installs on f's chain (the RealWorld fix)"
-    (binding [frame/*current-frame* nil]
+    (binding [rf.frame/*current-frame* nil]
       ;; (a) reproduce the example bug: bare reg with no scope fails closed.
       (let [thrown (try (rf/reg-http-interceptor :realworld/bearer-auth
                           {:before (fn [c] c)})
@@ -103,14 +103,14 @@
         (is (some? thrown) "bare reg under no ambient scope must throw")
         (is (= :rf.error/no-frame-context (:rf.error/id (ex-data thrown)))
             "the throw is the always-on :rf.error/no-frame-context — nothing installed")
-        (is (empty? (http-managed/interceptors-snapshot :realworld/app))
+        (is (empty? (rf.http.managed/interceptors-snapshot :realworld/app))
             "no slot landed on the app-frame chain"))
       ;; (b) the fix: with-frame supplies the frame context, so the reg lands
       ;; on :realworld/app's chain even though it was never `make-frame`d.
       (rf/with-frame :realworld/app
         (rf/reg-http-interceptor :realworld/bearer-auth {:before (fn [c] c)}))
       (is (= [:realworld/bearer-auth]
-             (mapv :id (http-managed/interceptors-snapshot :realworld/app)))
+             (mapv :id (rf.http.managed/interceptors-snapshot :realworld/app)))
           "with-frame scoped the reg onto the app frame's chain (the example fix)"))))
 
 ;; ---- 2. registration order is preserved -----------------------------------
@@ -120,7 +120,7 @@
     (rf/reg-http-interceptor :first  {:before (fn [c] c)})
     (rf/reg-http-interceptor :second {:before (fn [c] c)})
     (rf/reg-http-interceptor :third  {:before (fn [c] c)})
-    (let [chain (http-managed/interceptors-snapshot :rf/default)]
+    (let [chain (rf.http.managed/interceptors-snapshot :rf/default)]
       (is (= [:first :second :third] (mapv :id chain))))))
 
 ;; ---- 3. re-register replaces in place -------------------------------------
@@ -130,7 +130,7 @@
     (rf/reg-http-interceptor :a {:before (fn [c] (assoc c ::v 1))})
     (rf/reg-http-interceptor :b {:before (fn [c] c)})
     (rf/reg-http-interceptor :a {:before (fn [c] (assoc c ::v 2))})
-    (let [chain (http-managed/interceptors-snapshot :rf/default)]
+    (let [chain (rf.http.managed/interceptors-snapshot :rf/default)]
       (is (= [:a :b] (mapv :id chain)))
       (is (= {::v 2} ((:before (first chain)) {}))
           ":a's :before fn is the v2 fn (replacement)"))))
@@ -141,12 +141,12 @@
   (testing "interceptors registered on different frames do not collide"
     (rf/reg-http-interceptor :on-default {:frame :rf/default :before (fn [c] c)})
     (rf/reg-http-interceptor :on-other   {:frame :other      :before (fn [c] c)})
-    (is (= [:on-default] (mapv :id (http-managed/interceptors-snapshot :rf/default))))
-    (is (= [:on-other]   (mapv :id (http-managed/interceptors-snapshot :other))))
+    (is (= [:on-default] (mapv :id (rf.http.managed/interceptors-snapshot :rf/default))))
+    (is (= [:on-other]   (mapv :id (rf.http.managed/interceptors-snapshot :other))))
     ;; clear-http-interceptor on :rf/default doesn't touch :other
     (rf/clear-http-interceptor :on-default)
-    (is (zero? (count (http-managed/interceptors-snapshot :rf/default))))
-    (is (= [:on-other] (mapv :id (http-managed/interceptors-snapshot :other))))))
+    (is (zero? (count (rf.http.managed/interceptors-snapshot :rf/default))))
+    (is (= [:on-other] (mapv :id (rf.http.managed/interceptors-snapshot :other))))))
 
 ;; ---- 4a. rf2-f28bno / rf2-s32bf — the public {:frame} opts form ------------
 ;;
@@ -164,22 +164,22 @@
     ;; The ambient scope is :rf/default (fixture). Register on the OTHER frame.
     (rf/reg-http-interceptor :fa/on-other {:frame :fa/other :before (fn [c] c)})
     (rf/reg-http-interceptor :fa/on-default {:before (fn [c] c)})
-    (is (= [:fa/on-other]   (mapv :id (http-managed/interceptors-snapshot :fa/other))))
-    (is (= [:fa/on-default] (mapv :id (http-managed/interceptors-snapshot :rf/default))))
+    (is (= [:fa/on-other]   (mapv :id (rf.http.managed/interceptors-snapshot :fa/other))))
+    (is (= [:fa/on-default] (mapv :id (rf.http.managed/interceptors-snapshot :rf/default))))
     ;; (1) PUBLIC opts form clears the NAMED frame from the :rf/default scope —
     ;; this is exactly the natural guess `(clear id {:frame f})` from the reg
     ;; shape that used to SILENTLY NO-OP under the old frame-first arity. It now
     ;; binds :fa/other correctly.
     (rf/clear-http-interceptor :fa/on-other {:frame :fa/other})
-    (is (zero? (count (http-managed/interceptors-snapshot :fa/other)))
+    (is (zero? (count (rf.http.managed/interceptors-snapshot :fa/other)))
         "opts {:frame :fa/other} cleared the named frame's slot (misbind closed)")
-    (is (= [:fa/on-default] (mapv :id (http-managed/interceptors-snapshot :rf/default)))
+    (is (= [:fa/on-default] (mapv :id (rf.http.managed/interceptors-snapshot :rf/default)))
         "the :rf/default chain is untouched by the explicit-frame clear")
     ;; (2) INTERNAL frame-first seam still clears a named frame's slot.
     (rf/reg-http-interceptor :fa/again {:frame :fa/other :before (fn [c] c)})
-    (is (= [:fa/again] (mapv :id (http-managed/interceptors-snapshot :fa/other))))
-    (http-mw/clear-http-interceptor* :fa/other :fa/again)   ;; private seam: (frame id)
-    (is (zero? (count (http-managed/interceptors-snapshot :fa/other)))
+    (is (= [:fa/again] (mapv :id (rf.http.managed/interceptors-snapshot :fa/other))))
+    (rf.http.middleware/clear-http-interceptor* :fa/other :fa/again)   ;; private seam: (frame id)
+    (is (zero? (count (rf.http.managed/interceptors-snapshot :fa/other)))
         "internal frame-first seam (clear-http-interceptor*) cleared the slot")))
 
 ;; ---- 4b. rf2-s32bf — the public opts form is EXACT + FAIL-CLOSED -----------
@@ -198,7 +198,7 @@
       ;; ambient scope is :rf/default (fixture) — seed a slot there.
       (rf/reg-http-interceptor :s32bf/ambient {:before (fn [c] c)})
       (is (= [:s32bf/ambient]
-             (mapv :id (http-managed/interceptors-snapshot :rf/default))))
+             (mapv :id (rf.http.managed/interceptors-snapshot :rf/default))))
       (is (threw-bad? #(rf/clear-http-interceptor :s32bf/ambient {}))
           "empty opts map (no :frame) fails closed")
       (is (threw-bad? #(rf/clear-http-interceptor :s32bf/ambient {:frame nil}))
@@ -214,10 +214,10 @@
       (is (threw-bad? #(rf/clear-http-interceptor :s32bf/ambient :some-frame))
           "old two-scalar frame-first is not a public shape — fails closed")
       (is (= [:s32bf/ambient]
-             (mapv :id (http-managed/interceptors-snapshot :rf/default)))
+             (mapv :id (rf.http.managed/interceptors-snapshot :rf/default)))
           "no malformed clear touched the ambient :rf/default interceptor")
       (rf/clear-http-interceptor :s32bf/ambient {:frame :rf/default})
-      (is (zero? (count (http-managed/interceptors-snapshot :rf/default)))
+      (is (zero? (count (rf.http.managed/interceptors-snapshot :rf/default)))
           "the exact {:frame target} form clears the named frame"))))
 
 ;; ---- 5. invalid shape raises ----------------------------------------------
@@ -261,7 +261,7 @@
     (let [after-fn (fn [_ctx resp] resp)]
       (rf/reg-http-interceptor :uheqq/with-after {:after after-fn})
       (let [slot (first (filter #(= :uheqq/with-after (:id %))
-                                (http-managed/interceptors-snapshot :rf/default)))]
+                                (rf.http.managed/interceptors-snapshot :rf/default)))]
         (is (some? slot) "slot is in the chain")
         (is (= after-fn (:after slot))
             ":after fn stored verbatim on the slot")
@@ -272,6 +272,6 @@
 
 (deftest late-bind-hooks-published
   (testing ":http/reg-http-interceptor and :http/clear-http-interceptor land in the late-bind registry"
-    (is (some? (late-bind/get-fn :http/reg-http-interceptor)))
-    (is (some? (late-bind/get-fn :http/clear-http-interceptor)))
-    (is (some? (late-bind/get-fn :http/clear-all-http-interceptors!)))))
+    (is (some? (rf.late-bind/get-fn :http/reg-http-interceptor)))
+    (is (some? (rf.late-bind/get-fn :http/clear-http-interceptor)))
+    (is (some? (rf.late-bind/get-fn :http/clear-all-http-interceptors!)))))

--- a/implementation/http/test/re_frame/http_interceptors_test.clj
+++ b/implementation/http/test/re_frame/http_interceptors_test.clj
@@ -23,13 +23,13 @@
   transformation the interceptor produced."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.http.middleware :as http-mw]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace])
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.middleware :as rf.http.middleware]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace])
   (:import [com.sun.net.httpserver HttpServer HttpHandler HttpExchange]
            [java.net InetSocketAddress]))
 
@@ -45,7 +45,7 @@
 ;; locally. The canonical post-dispose reset now also clears the per-frame
 ;; HTTP interceptor chain (rf2-q14tde), so no explicit clear-all is needed.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- in-process server harness --------------------------------------------
 
@@ -77,7 +77,7 @@
   the per-file `(pred db)` arity that read sites here expect."
   ([pred] (await-reply! pred 5000))
   ([pred timeout-ms]
-   (test-support/poll-until
+   (rf.test-support/poll-until
      #(let [db (rf/app-db-value :rf/default)] (when (pred db) db))
      {:timeout-ms timeout-ms :label "http-interceptors reply"})))
 
@@ -139,7 +139,7 @@
       (try
         ;; (a) reproduce the example bug: bare reg under NO ambient scope
         ;; fails closed and installs nothing.
-        (binding [frame/*current-frame* nil]
+        (binding [rf.frame/*current-frame* nil]
           (let [thrown (try (rf/reg-http-interceptor :realworld/bearer-auth
                               {:before identity})
                             nil
@@ -148,7 +148,7 @@
                 "a bare reg-http-interceptor under no frame scope must throw")
             (is (= :rf.error/no-frame-context (:rf.error/id (ex-data thrown)))
                 "the throw is the always-on :rf.error/no-frame-context")
-            (is (empty? (http-managed/interceptors-snapshot :rf/default))
+            (is (empty? (rf.http.managed/interceptors-snapshot :rf/default))
                 "nothing was installed on the :rf/default chain"))
           ;; (b) the fix: with-frame supplies the frame context, so the reg
           ;; installs on :rf/default even under no ambient scope.
@@ -158,7 +158,7 @@
                          (assoc-in ctx [:request :headers "Authorization"]
                                    "Token stub.demo.jwt"))})))
         (is (= [:realworld/bearer-auth]
-               (mapv :id (http-managed/interceptors-snapshot :rf/default)))
+               (mapv :id (rf.http.managed/interceptors-snapshot :rf/default)))
             "with-frame scoped the reg onto the app frame's chain (the fix)")
         ;; (c) an authenticated request from that frame carries the header the
         ;; interceptor stamped — proving the fix actually decorates the wire.
@@ -272,7 +272,7 @@
         ;; Header values are NOT a valid readiness signal here — the
         ;; :other-frame request is expected to carry a nil header, which is
         ;; indistinguishable from "request has not yet landed" (rf2-fun38).
-        (test-support/poll-until
+        (rf.test-support/poll-until
           #(and @hit-default @hit-other)
           {:timeout-ms 5000 :label "both server hits landed"})
         (is (= "default-only" @seen-on-default)
@@ -294,7 +294,7 @@
               (swap! server-hits inc)
               (write-response! ex 200 "application/json" "{}")))]
       (try
-        (trace/register-listener! listener-id
+        (rf.trace/register-listener! listener-id
                                   (fn [ev] (swap! traces conj ev)))
         (rf/reg-http-interceptor :boom
           {:before (fn [_ctx]
@@ -316,7 +316,7 @@
         ;; Wait for the interceptor-failure trace to land (rf2-fun38) —
         ;; the trace event IS the observable signal. server-hits is then
         ;; asserted as zero (proven absence within the trace-fired window).
-        (test-support/poll-until
+        (rf.test-support/poll-until
           #(some (fn [t] (= :rf.error/http-interceptor-failed (:operation t)))
                  @traces)
           {:label ":rf.error/http-interceptor-failed surfaced"})
@@ -326,7 +326,7 @@
                   @traces)
             ":rf.error/http-interceptor-failed appears on the trace stream")
         (finally
-          (trace/unregister-listener! listener-id)
+          (rf.trace/unregister-listener! listener-id)
           (stop-server! srv))))))
 
 ;; ---- 4a. rf2-1jcpm — interceptor-failure URL redaction --------------------
@@ -340,7 +340,7 @@
     (let [traces      (atom [])
           listener-id (gensym "interceptor-redact-")]
       (try
-        (trace/register-listener! listener-id
+        (rf.trace/register-listener! listener-id
                                   (fn [ev] (swap! traces conj ev)))
         (rf/reg-http-interceptor :boom
           {:before (fn [_ctx]
@@ -354,7 +354,7 @@
                     :on-failure nil}]]}))
         (rf/dispatch-sync [:load])
         ;; Wait for the redacted-trace event to land (rf2-fun38).
-        (test-support/poll-until
+        (rf.test-support/poll-until
           #(some (fn [t] (= :rf.error/http-interceptor-failed (:operation t)))
                  @traces)
           {:label ":rf.error/http-interceptor-failed surfaced (redacted variant)"})
@@ -369,7 +369,7 @@
             (is (true? (:sensitive? w))
                 ":sensitive? stamped on the trace (denylist hit = signal)")))
         (finally
-          (trace/unregister-listener! listener-id))))))
+          (rf.trace/unregister-listener! listener-id))))))
 
 ;; ---- 5. clear-http-interceptor unregisters cleanly ------------------------
 
@@ -424,7 +424,7 @@
             it does NOT synthesise a :rf/default target. The facade must
             delegate frame resolution to the impl's require-current-frame!,
             never inject :rf/default from absence."
-    (binding [frame/*current-frame* nil]
+    (binding [rf.frame/*current-frame* nil]
       (let [thrown (try (rf/clear-http-interceptor :some-id)
                         nil
                         (catch clojure.lang.ExceptionInfo e e))]
@@ -454,22 +454,22 @@
     ;; sibling `per-frame-scope` CLJS test registers on `:other` the same way).
     (rf/reg-http-interceptor :fa/on-other   {:frame :fa/other :before (fn [c] c)})
     (rf/reg-http-interceptor :fa/on-default {:before (fn [c] c)})
-    (is (= [:fa/on-other]   (mapv :id (http-managed/interceptors-snapshot :fa/other))))
-    (is (= [:fa/on-default] (mapv :id (http-managed/interceptors-snapshot :rf/default))))
+    (is (= [:fa/on-other]   (mapv :id (rf.http.managed/interceptors-snapshot :fa/other))))
+    (is (= [:fa/on-default] (mapv :id (rf.http.managed/interceptors-snapshot :rf/default))))
     ;; (1) PUBLIC opts form clears the NAMED frame from the :rf/default scope —
     ;; the natural `(clear id {:frame f})` guess from the reg shape that USED to
     ;; silently no-op under the old public frame-first arity. It now binds
     ;; :fa/other correctly.
     (rf/clear-http-interceptor :fa/on-other {:frame :fa/other})
-    (is (zero? (count (http-managed/interceptors-snapshot :fa/other)))
+    (is (zero? (count (rf.http.managed/interceptors-snapshot :fa/other)))
         "opts {:frame :fa/other} cleared the named frame's slot (misbind closed)")
-    (is (= [:fa/on-default] (mapv :id (http-managed/interceptors-snapshot :rf/default)))
+    (is (= [:fa/on-default] (mapv :id (rf.http.managed/interceptors-snapshot :rf/default)))
         "the :rf/default chain is untouched by the explicit-frame clear")
     ;; (2) INTERNAL frame-first seam still clears a named frame's slot.
     (rf/reg-http-interceptor :fa/again {:frame :fa/other :before (fn [c] c)})
-    (is (= [:fa/again] (mapv :id (http-managed/interceptors-snapshot :fa/other))))
-    (http-mw/clear-http-interceptor* :fa/other :fa/again)   ;; private seam: (frame id)
-    (is (zero? (count (http-managed/interceptors-snapshot :fa/other)))
+    (is (= [:fa/again] (mapv :id (rf.http.managed/interceptors-snapshot :fa/other))))
+    (rf.http.middleware/clear-http-interceptor* :fa/other :fa/again)   ;; private seam: (frame id)
+    (is (zero? (count (rf.http.managed/interceptors-snapshot :fa/other)))
         "internal frame-first seam (clear-http-interceptor*) cleared the slot")))
 
 ;; ---- 5c. rf2-s32bf — the public opts form is EXACT + FAIL-CLOSED ----------
@@ -496,7 +496,7 @@
       ;; ambient scope is :rf/default (fixture) — seed a slot there.
       (rf/reg-http-interceptor :s32bf/ambient {:before (fn [c] c)})
       (is (= [:s32bf/ambient]
-             (mapv :id (http-managed/interceptors-snapshot :rf/default))))
+             (mapv :id (rf.http.managed/interceptors-snapshot :rf/default))))
       ;; every malformed 2-arg form fails closed
       (is (threw-bad? #(rf/clear-http-interceptor :s32bf/ambient {}))
           "empty opts map (no :frame) fails closed")
@@ -514,11 +514,11 @@
           "old two-scalar frame-first is not a public shape — fails closed")
       ;; NO rejected call touched the ambient chain
       (is (= [:s32bf/ambient]
-             (mapv :id (http-managed/interceptors-snapshot :rf/default)))
+             (mapv :id (rf.http.managed/interceptors-snapshot :rf/default)))
           "no malformed clear touched the ambient :rf/default interceptor")
       ;; the exact opts form still clears the ambient frame
       (rf/clear-http-interceptor :s32bf/ambient {:frame :rf/default})
-      (is (zero? (count (http-managed/interceptors-snapshot :rf/default)))
+      (is (zero? (count (rf.http.managed/interceptors-snapshot :rf/default)))
           "the exact {:frame target} form clears the named frame"))))
 
 ;; ---- 6. re-registering an id replaces in place ---------------------------
@@ -543,7 +543,7 @@
                     :on-success nil}]]}))
         (rf/dispatch-sync [:load])
         ;; Wait for both :before fns to fire (rf2-fun38).
-        (test-support/poll-until
+        (rf.test-support/poll-until
           #(= 2 (count @order))
           {:label "both interceptors in chain fired"})
         (is (= [:a-v2 :b] @order)
@@ -586,7 +586,7 @@
 
         ;; Confirm the chain order in the registry directly so the test
         ;; pins the slot ordering before the dispatch ever runs.
-        (let [chain (http-managed/interceptors-snapshot :rf/default)]
+        (let [chain (rf.http.managed/interceptors-snapshot :rf/default)]
           (is (= [:b :c :a] (mapv :id chain))
               "after clear-then-reg, :a moved to the end (was first; now last)"))
 
@@ -598,7 +598,7 @@
                     :on-success nil}]]}))
         (rf/dispatch-sync [:kg5nw/load])
         ;; Wait for all three :before fns to fire (rf2-fun38).
-        (test-support/poll-until
+        (rf.test-support/poll-until
           #(= 3 (count @order))
           {:label "all post-clear-then-reg interceptors fired"})
         (is (= [:b :c :a-fresh] @order)
@@ -613,17 +613,17 @@
     ;; Register in order :a, :b.
     (rf/reg-http-interceptor :a {:before identity})
     (rf/reg-http-interceptor :b {:before identity})
-    (is (= [:a :b] (mapv :id (http-managed/interceptors-snapshot :rf/default))))
+    (is (= [:a :b] (mapv :id (rf.http.managed/interceptors-snapshot :rf/default))))
 
     ;; Bare re-reg of :a — replaces in place; order unchanged.
     (rf/reg-http-interceptor :a {:before (fn [c] c)})
-    (is (= [:a :b] (mapv :id (http-managed/interceptors-snapshot :rf/default)))
+    (is (= [:a :b] (mapv :id (rf.http.managed/interceptors-snapshot :rf/default)))
         "bare re-reg preserves position (Spec 014 §Chain order, replace-in-place)")
 
     ;; Clear-then-reg of :a — appends to end; order changes.
     (rf/clear-http-interceptor :a)
     (rf/reg-http-interceptor :a {:before (fn [c] c)})
-    (is (= [:b :a] (mapv :id (http-managed/interceptors-snapshot :rf/default)))
+    (is (= [:b :a] (mapv :id (rf.http.managed/interceptors-snapshot :rf/default)))
         "clear-then-reg lands at the end (rf2-kg5nw contract)")))
 
 ;; ---- 7. invalid interceptor shape raises ---------------------------------
@@ -700,7 +700,7 @@
           {:before (fn [ctx] (assoc-in ctx [:request :headers "X-C"] "3"))})
 
         ;; Confirm the per-frame chain has all three before the bulk-clear.
-        (let [chain (http-managed/interceptors-snapshot :rf/default)]
+        (let [chain (rf.http.managed/interceptors-snapshot :rf/default)]
           (is (= 3 (count chain)))
           (is (= #{:hdr-a :hdr-b :hdr-c}
                  (set (map :id chain)))
@@ -724,10 +724,10 @@
 
         ;; Bulk clear.
         (reset! seen-headers [])
-        (http-managed/clear-all-http-interceptors!)
+        (rf.http.managed/clear-all-http-interceptors!)
 
         ;; Atom is now empty.
-        (is (= {} (http-managed/interceptors-snapshot))
+        (is (= {} (rf.http.managed/interceptors-snapshot))
             "the per-frame chain atom is now empty across every frame")
 
         ;; Second dispatch — none of the cleared interceptors fire.
@@ -748,29 +748,29 @@
     (rf/reg-sub :test.lfvi/sub (fn [_ _] :stub))
     (rf/reg-fx :test.lfvi/fx (fn [_ _] nil))
 
-    (is (seq (http-managed/interceptors-snapshot))
+    (is (seq (rf.http.managed/interceptors-snapshot))
         "pre-clear: interceptor atom has entries")
 
-    (http-managed/clear-all-http-interceptors!)
+    (rf.http.managed/clear-all-http-interceptors!)
 
-    (is (= {} (http-managed/interceptors-snapshot))
+    (is (= {} (rf.http.managed/interceptors-snapshot))
         ":http interceptor atom is empty")
-    (is (some? (registrar/lookup :event :test.lfvi/ev))
+    (is (some? (rf.registrar/lookup :event :test.lfvi/ev))
         ":event kind is untouched by the bulk-clear")
-    (is (some? (registrar/lookup :sub :test.lfvi/sub))
+    (is (some? (rf.registrar/lookup :sub :test.lfvi/sub))
         ":sub kind is untouched")
-    (is (some? (registrar/lookup :fx :test.lfvi/fx))
+    (is (some? (rf.registrar/lookup :fx :test.lfvi/fx))
         ":fx kind is untouched")))
 
 (deftest clear-all-http-interceptors-is-idempotent
   (testing "calling clear-all-http-interceptors! on an empty registry is a no-op"
-    (is (= {} (http-managed/interceptors-snapshot))
+    (is (= {} (rf.http.managed/interceptors-snapshot))
         "starting clean (per fixture)")
-    (is (nil? (http-managed/clear-all-http-interceptors!))
+    (is (nil? (rf.http.managed/clear-all-http-interceptors!))
         "first call returns nil")
-    (is (nil? (http-managed/clear-all-http-interceptors!))
+    (is (nil? (rf.http.managed/clear-all-http-interceptors!))
         "second call on the already-empty registry is also nil")
-    (is (= {} (http-managed/interceptors-snapshot))
+    (is (= {} (rf.http.managed/interceptors-snapshot))
         "atom stays empty")))
 
 ;; ---- rf2-rznrz — sensitivity recomputed from the POST-:before request -----
@@ -792,7 +792,7 @@
     (let [traces      (atom [])
           listener-id (gensym "rznrz-mark-sensitive-")]
       (try
-        (trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
         ;; First :before marks the request sensitive.
         (rf/reg-http-interceptor :mark-sensitive
           {:before (fn [ctx] (assoc-in ctx [:request :sensitive?] true))})
@@ -809,7 +809,7 @@
                     :on-success nil
                     :on-failure nil}]]}))
         (rf/dispatch-sync [:rznrz/load])
-        (test-support/poll-until
+        (rf.test-support/poll-until
           #(some (fn [t] (= :rf.error/http-interceptor-failed (:operation t))) @traces)
           {:label ":rf.error/http-interceptor-failed surfaced (sensitivity recompute)"})
         (let [w    (first (filter #(= :rf.error/http-interceptor-failed (:operation %)) @traces))
@@ -828,7 +828,7 @@
           (is (true? (:sensitive? w))
               ":sensitive? stamped because the effective request is sensitive"))
         (finally
-          (trace/unregister-listener! listener-id))))))
+          (rf.trace/unregister-listener! listener-id))))))
 
 ;; ---- rf2-rznrz — CLJS-only-key check runs on the POST-:before request -----
 ;;
@@ -850,7 +850,7 @@
             (fn [^HttpExchange ex]
               (write-response! ex 200 "application/json" "{\"ok\":true}")))]
       (try
-        (trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
         ;; The request as DISPATCHED carries no CLJS-only key; the :before
         ;; adds :credentials into the request map.
         (rf/reg-http-interceptor :add-credentials
@@ -872,7 +872,7 @@
                warning — proving check-cljs-only-keys! ran on the post-chain
                request, not the original (key-free) args"))
         (finally
-          (trace/unregister-listener! listener-id)
+          (rf.trace/unregister-listener! listener-id)
           (stop-server! srv))))))
 
 ;; ---- rf2-oyd1b — direct unit tests for the fx wrappers --------------------
@@ -896,12 +896,12 @@
                 :doc    "fixture interceptor"
                 :tags   #{:auth}}]]}))
 
-    (is (empty? (http-managed/interceptors-snapshot :rf/default))
+    (is (empty? (rf.http.managed/interceptors-snapshot :rf/default))
         "pre-dispatch: no interceptors on :rf/default")
 
     (rf/dispatch-sync [:oyd1b/register])
 
-    (let [chain (http-managed/interceptors-snapshot :rf/default)
+    (let [chain (rf.http.managed/interceptors-snapshot :rf/default)
           slot  (first (filter #(= :oyd1b/auth (:id %)) chain))]
       (is (= 1 (count chain))
           "the fx wrapper actually mutates the atom (not just a return-value smoke)")
@@ -921,17 +921,17 @@
 
     (rf/dispatch-sync [:oyd1b/register-on-named])
 
-    (is (empty? (http-managed/interceptors-snapshot :rf/default))
+    (is (empty? (rf.http.managed/interceptors-snapshot :rf/default))
         ":rf/default is not touched by an :rf/api registration")
-    (let [chain (http-managed/interceptors-snapshot :rf/api)]
+    (let [chain (rf.http.managed/interceptors-snapshot :rf/api)]
       (is (= 1 (count chain)))
       (is (= :oyd1b/named (:id (first chain)))))))
 
 (deftest clear-http-interceptor-fx-mutates-the-atom-rf2-oyd1b
   (testing "rf2-oyd1b — [:rf.fx/clear-http-interceptor {:id ...}] removes
             the slot from :rf/default (the implicit frame)."
-    (http-managed/reg-http-interceptor :oyd1b/to-clear {:before identity})
-    (is (= 1 (count (http-managed/interceptors-snapshot :rf/default)))
+    (rf.http.managed/reg-http-interceptor :oyd1b/to-clear {:before identity})
+    (is (= 1 (count (rf.http.managed/interceptors-snapshot :rf/default)))
         "pre-clear: the slot is present")
 
     (rf/reg-event :oyd1b/clear
@@ -939,13 +939,13 @@
         {:fx [[:rf.fx/clear-http-interceptor {:id :oyd1b/to-clear}]]}))
     (rf/dispatch-sync [:oyd1b/clear])
 
-    (is (empty? (http-managed/interceptors-snapshot :rf/default))
+    (is (empty? (rf.http.managed/interceptors-snapshot :rf/default))
         "the slot is gone after the fx")))
 
 (deftest clear-http-interceptor-fx-honours-explicit-frame-rf2-oyd1b
   (testing "rf2-oyd1b — explicit :frame on the clear fx scopes the removal"
-    (http-managed/reg-http-interceptor :oyd1b/scoped {:frame :rf/api :before identity})
-    (http-managed/reg-http-interceptor :oyd1b/default-survivor {:before identity})
+    (rf.http.managed/reg-http-interceptor :oyd1b/scoped {:frame :rf/api :before identity})
+    (rf.http.managed/reg-http-interceptor :oyd1b/default-survivor {:before identity})
 
     (rf/reg-event :oyd1b/clear-on-named
       (fn [_ _]
@@ -953,21 +953,21 @@
                {:frame :rf/api :id :oyd1b/scoped}]]}))
     (rf/dispatch-sync [:oyd1b/clear-on-named])
 
-    (is (empty? (http-managed/interceptors-snapshot :rf/api))
+    (is (empty? (rf.http.managed/interceptors-snapshot :rf/api))
         ":rf/api lost its slot")
-    (is (= 1 (count (http-managed/interceptors-snapshot :rf/default)))
+    (is (= 1 (count (rf.http.managed/interceptors-snapshot :rf/default)))
         ":rf/default is unaffected — the clear was scoped to :rf/api")))
 
 (deftest clear-http-interceptor-fx-defaults-frame-to-rf-default-rf2-oyd1b
   (testing "rf2-oyd1b — when :frame is nil/absent the fx routes to :rf/default
             (matching the fn-form behaviour)."
-    (http-managed/reg-http-interceptor :oyd1b/dflt {:before identity})
+    (rf.http.managed/reg-http-interceptor :oyd1b/dflt {:before identity})
     (rf/reg-event :oyd1b/clear-no-frame
       (fn [_ _]
         ;; No :frame key — must default to :rf/default.
         {:fx [[:rf.fx/clear-http-interceptor {:id :oyd1b/dflt}]]}))
     (rf/dispatch-sync [:oyd1b/clear-no-frame])
-    (is (empty? (http-managed/interceptors-snapshot :rf/default)))))
+    (is (empty? (rf.http.managed/interceptors-snapshot :rf/default)))))
 
 (deftest reg-http-interceptor-fx-rejects-invalid-args-rf2-oyd1b
   (testing "rf2-oyd1b + rf2-uheqq — invalid args (missing :id, missing both
@@ -979,7 +979,7 @@
     (let [errors (atom [])
           cb-id  ::oyd1b-bad-args]
       (try
-        (trace/register-listener!
+        (rf.trace/register-listener!
           cb-id
           (fn [ev]
             (when (= :error (:op-type ev))
@@ -991,7 +991,7 @@
             {:fx [[:rf.fx/reg-http-interceptor {:before identity}]]}))
         (try (rf/dispatch-sync [:oyd1b/bad-no-id])
              (catch Throwable _ nil))
-        (is (empty? (http-managed/interceptors-snapshot :rf/default))
+        (is (empty? (rf.http.managed/interceptors-snapshot :rf/default))
             "missing :id → no interceptor registered")
 
         ;; missing both :before AND :after (a no-op interceptor is rejected
@@ -1001,7 +1001,7 @@
             {:fx [[:rf.fx/reg-http-interceptor {:id :x}]]}))
         (try (rf/dispatch-sync [:oyd1b/bad-no-fns])
              (catch Throwable _ nil))
-        (is (empty? (http-managed/interceptors-snapshot :rf/default))
+        (is (empty? (rf.http.managed/interceptors-snapshot :rf/default))
             "missing both :before and :after → no interceptor registered")
 
         ;; non-keyword :id
@@ -1011,11 +1011,11 @@
                    {:id "not-a-keyword" :before identity}]]}))
         (try (rf/dispatch-sync [:oyd1b/bad-string-id])
              (catch Throwable _ nil))
-        (is (empty? (http-managed/interceptors-snapshot :rf/default))
+        (is (empty? (rf.http.managed/interceptors-snapshot :rf/default))
             "non-keyword :id → no interceptor registered")
 
         (finally
-          (trace/unregister-listener! cb-id))))))
+          (rf.trace/unregister-listener! cb-id))))))
 
 (deftest reg-and-clear-http-interceptor-fxs-roundtrip-rf2-oyd1b
   (testing "rf2-oyd1b — register-then-clear via fxs round-trips cleanly,
@@ -1027,7 +1027,7 @@
               [:rf.fx/clear-http-interceptor
                {:id :oyd1b/rt}]]}))
     (rf/dispatch-sync [:oyd1b/round-trip])
-    (is (empty? (http-managed/interceptors-snapshot :rf/default))
+    (is (empty? (rf.http.managed/interceptors-snapshot :rf/default))
         "register followed by clear in the same event leaves the chain empty")))
 
 ;; ===========================================================================

--- a/implementation/http/test/re_frame/http_json_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_json_cljs_test.cljs
@@ -29,7 +29,7 @@
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.http.json :as http-json]))
+            [re-frame.http.json :as rf.http.json]))
 
 (deftest cljs-json-parse-malformed-throws
   (testing "rf2-mih7n — malformed JSON inputs throw under
@@ -41,7 +41,7 @@
                "tru"                 ; truncated literal
                "{\"a\":nul}"         ; misspelt null
                "{\"x\":\"\\u\"}"]]   ; truncated unicode escape
-      (let [thrown (try (http-json/json-parse s) ::no-throw
+      (let [thrown (try (rf.http.json/json-parse s) ::no-throw
                         (catch :default e e))]
         (is (not= ::no-throw thrown)
             (str "expected a parse exception for " (pr-str s)
@@ -55,7 +55,7 @@
             CLJS branch by adding an empty-string short-circuit —
             doing so would mask a transport-layer programmer error
             that the current decode-failure path surfaces."
-    (let [thrown (try (http-json/json-parse "") ::no-throw
+    (let [thrown (try (rf.http.json/json-parse "") ::no-throw
                       (catch :default e e))]
       (is (not= ::no-throw thrown)
           (str "empty-string input must throw on CLJS — got "
@@ -70,16 +70,16 @@
             directly: nil coerced to nil, but a keyword/number/map/vector
             THREW where the JVM returned nil — the host asymmetry this
             bead closed."
-    (is (nil? (http-json/json-parse nil))
+    (is (nil? (rf.http.json/json-parse nil))
         "nil input → nil (string? guard short-circuits, cross-host)")
-    (is (nil? (http-json/json-parse :keyword))
+    (is (nil? (rf.http.json/json-parse :keyword))
         "keyword input → nil (was a throw before rf2-x1uhu)")
-    (is (nil? (http-json/json-parse 42))
+    (is (nil? (rf.http.json/json-parse 42))
         "number input → nil (was a throw before rf2-x1uhu)")
-    (is (nil? (http-json/json-parse {:already :clojure}))
+    (is (nil? (rf.http.json/json-parse {:already :clojure}))
         "map input → nil — caller passed an already-parsed value by
          mistake (was a throw before rf2-x1uhu)")
-    (is (nil? (http-json/json-parse [1 2 3]))
+    (is (nil? (rf.http.json/json-parse [1 2 3]))
         "vector input → nil (was a throw before rf2-x1uhu)")))
 
 (deftest cljs-json-stringify-happy-path
@@ -87,7 +87,7 @@
             `js/JSON.stringify` and produces standard JSON output
             (no edn-isms, no host-specific encoding quirks)."
     (is (= "{\"a\":1,\"b\":\"hello\"}"
-           (http-json/json-stringify {:a 1 :b "hello"})))
-    (is (= "[1,2,3]" (http-json/json-stringify [1 2 3])))
-    (is (= "true" (http-json/json-stringify true)))
-    (is (= "null" (http-json/json-stringify nil)))))
+           (rf.http.json/json-stringify {:a 1 :b "hello"})))
+    (is (= "[1,2,3]" (rf.http.json/json-stringify [1 2 3])))
+    (is (= "true" (rf.http.json/json-stringify true)))
+    (is (= "null" (rf.http.json/json-stringify nil)))))

--- a/implementation/http/test/re_frame/http_json_test.clj
+++ b/implementation/http/test/re_frame/http_json_test.clj
@@ -17,7 +17,7 @@
                  are moot — Cheshire is RFC-8259-conforming and bulletproof
                  around `\\uXXXX` escapes by construction."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.http.json :as http-json]))
+            [re-frame.http.json :as rf.http.json]))
 
 ;; ---- rf2-wu1n5 — keyword-interning cap -----------------------------------
 
@@ -34,13 +34,13 @@
   (testing "rf2-wu1n5 — Cheshire branch caps unique-key cardinality"
     (let [s (big-json 50)]
       ;; Under the cap → success.
-      (is (map? (http-json/json-parse s {:max-decoded-keys 100}))
+      (is (map? (rf.http.json/json-parse s {:max-decoded-keys 100}))
           "50 keys under cap=100 should succeed")
       ;; At the cap exactly → success (50 unique strings ≤ 50).
-      (is (map? (http-json/json-parse s {:max-decoded-keys 50}))
+      (is (map? (rf.http.json/json-parse s {:max-decoded-keys 50}))
           "50 keys at cap=50 should succeed")
       ;; Over the cap → throws tagged ex-info.
-      (let [thrown (try (http-json/json-parse s {:max-decoded-keys 10}) ::no-throw
+      (let [thrown (try (rf.http.json/json-parse s {:max-decoded-keys 10}) ::no-throw
                         (catch clojure.lang.ExceptionInfo e e))
             data   (when (instance? clojure.lang.ExceptionInfo thrown)
                      (ex-data thrown))]
@@ -56,11 +56,11 @@
   (testing "rf2-wu1n5 — default cap (`default-max-decoded-keys`) fires
   when no opts supplied."
     ;; Sanity: the documented constant is what we say it is.
-    (is (= 10000 http-json/default-max-decoded-keys))
+    (is (= 10000 rf.http.json/default-max-decoded-keys))
     ;; A payload one-over the documented default trips the cap when no
     ;; per-call override is supplied.
-    (let [s (big-json (inc http-json/default-max-decoded-keys))
-          thrown (try (http-json/json-parse s) ::no-throw
+    (let [s (big-json (inc rf.http.json/default-max-decoded-keys))
+          thrown (try (rf.http.json/json-parse s) ::no-throw
                       (catch clojure.lang.ExceptionInfo e e))
           data   (when (instance? clojure.lang.ExceptionInfo thrown)
                    (ex-data thrown))]
@@ -68,14 +68,14 @@
           "10001-key payload with no opts must trip the default cap")
       (is (= :rf.error/malformed-json (:rf.error/id data)))
       (is (= :too-many-keys (:cause data)))
-      (is (= http-json/default-max-decoded-keys (:limit data))))))
+      (is (= rf.http.json/default-max-decoded-keys (:limit data))))))
 
 (deftest cap-counts-unique-not-total
   (testing "rf2-wu1n5 — repeated keys don't multiply the count"
     ;; 1000 entries but only 5 unique key strings: {\"a\":1,\"a\":2,...}
     (let [pairs (clojure.string/join "," (repeat 200 "\"a\":1,\"b\":2,\"c\":3,\"d\":4,\"e\":5"))
           s     (str "{" pairs "}")]
-      (is (map? (http-json/json-parse s {:max-decoded-keys 10}))
+      (is (map? (rf.http.json/json-parse s {:max-decoded-keys 10}))
           "5 unique keys under cap=10 should succeed even with 1000 entries"))))
 
 ;; ---- rf2-dgsu1 — Cheshire is mandatory; malformed JSON propagates --------
@@ -85,9 +85,9 @@
   `\\uXXXX` escapes correctly. The previous hand-rolled fallback's
   `\\uXXXX` bounds-checking (rf2-263km) is moot — Cheshire is
   RFC-8259-conforming."
-    (is (= "A"   (http-json/json-parse "\"\\u0041\"")))
-    (is (= "AB"  (http-json/json-parse "\"\\u0041\\u0042\"")))
-    (is (= "café" (http-json/json-parse "\"caf\\u00e9\"")))))
+    (is (= "A"   (rf.http.json/json-parse "\"\\u0041\"")))
+    (is (= "AB"  (rf.http.json/json-parse "\"\\u0041\\u0042\"")))
+    (is (= "café" (rf.http.json/json-parse "\"caf\\u00e9\"")))))
 
 (deftest cheshire-rejects-malformed-input-cleanly
   (testing "rf2-dgsu1 — malformed JSON (truncated escape, unterminated
@@ -110,7 +110,7 @@
                "{\"x\":\"\\uZZ"   ; invalid unicode hex
                "tru"               ; truncated `true`
                "{\"x\":nul}"]]      ; misspelt null
-      (let [thrown (try (http-json/json-parse s) ::no-throw
+      (let [thrown (try (rf.http.json/json-parse s) ::no-throw
                         (catch Exception e e))]
         (is (instance? Exception thrown)
             (str "expected a parse exception for " (pr-str s)
@@ -124,10 +124,10 @@
     ;; Cheshire emits standard JSON: keys quoted, strings double-quoted,
     ;; no edn-isms.
     (is (= "{\"a\":1,\"b\":\"hello\"}"
-           (http-json/json-stringify {:a 1 :b "hello"})))
-    (is (= "[1,2,3]" (http-json/json-stringify [1 2 3])))
-    (is (= "true" (http-json/json-stringify true)))
-    (is (= "null" (http-json/json-stringify nil)))))
+           (rf.http.json/json-stringify {:a 1 :b "hello"})))
+    (is (= "[1,2,3]" (rf.http.json/json-stringify [1 2 3])))
+    (is (= "true" (rf.http.json/json-stringify true)))
+    (is (= "null" (rf.http.json/json-stringify nil)))))
 
 ;; ---- rf2-mih7n — non-string / empty input coverage -----------------------
 ;;
@@ -155,18 +155,18 @@
   (string? s) ...)` guard protects the managed-HTTP decode pipeline
   from a programmer error in transport — a malformed input throws
   through to `:rf.http/decode-failure`, a missing input is benign nil."
-    (is (nil? (http-json/json-parse nil))
+    (is (nil? (rf.http.json/json-parse nil))
         "nil input → nil (string? guard short-circuits)")
-    (is (nil? (http-json/json-parse ""))
+    (is (nil? (rf.http.json/json-parse ""))
         "empty string → nil (Cheshire's end-of-stream → nil)")
-    (is (nil? (http-json/json-parse :keyword))
+    (is (nil? (rf.http.json/json-parse :keyword))
         "keyword input → nil (string? guard short-circuits)")
-    (is (nil? (http-json/json-parse 42))
+    (is (nil? (rf.http.json/json-parse 42))
         "number input → nil (string? guard short-circuits)")
-    (is (nil? (http-json/json-parse {:already :clojure}))
+    (is (nil? (rf.http.json/json-parse {:already :clojure}))
         "map input → nil (string? guard short-circuits — caller
          passed an already-parsed value by mistake)")
-    (is (nil? (http-json/json-parse [1 2 3]))
+    (is (nil? (rf.http.json/json-parse [1 2 3]))
         "vector input → nil (same)")))
 
 (deftest jvm-json-parse-whitespace-only-returns-nil
@@ -174,6 +174,6 @@
   are not valid JSON documents per RFC 8259, but Cheshire/Jackson
   surfaces them as end-of-stream → nil (same as the empty-string
   case). Pin the contract."
-    (is (nil? (http-json/json-parse "   ")))
-    (is (nil? (http-json/json-parse "\n")))
-    (is (nil? (http-json/json-parse "\t")))))
+    (is (nil? (rf.http.json/json-parse "   ")))
+    (is (nil? (rf.http.json/json-parse "\n")))
+    (is (nil? (rf.http.json/json-parse "\t")))))

--- a/implementation/http/test/re_frame/http_jvm_binary_decode_test.clj
+++ b/implementation/http/test/re_frame/http_jvm_binary_decode_test.clj
@@ -25,17 +25,17 @@
   the pre-fix code (which UTF-8-decoded the bytes / left elapsed-ms nil)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.http.transport-jvm :as transport-jvm]
-            [re-frame.test-support :as test-support])
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.transport-jvm :as rf.http.transport-jvm]
+            [re-frame.test-support :as rf.test-support])
   (:import [com.sun.net.httpserver HttpServer HttpHandler HttpExchange]
            [java.net InetSocketAddress]))
 
 ;; ---- per-test reset --------------------------------------------------------
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- a tiny in-process HTTP server (raw-bytes capable) --------------------
 
@@ -57,7 +57,7 @@
     (.write os body)))
 
 (defn- await-reply! [pred]
-  (test-support/poll-until
+  (rf.test-support/poll-until
     #(let [db (rf/app-db-value :rf/default)] (when (pred db) db))
     {:timeout-ms 5000 :label "http binary reply"}))
 
@@ -142,7 +142,7 @@
 
 (deftest charset-of-resolves-declared-charset
   (testing "rf2-a3wxe — charset-of parses the Content-Type charset param"
-    (let [charset-of @#'transport-jvm/charset-of]
+    (let [charset-of @#'rf.http.transport-jvm/charset-of]
       (is (= "ISO-8859-1"
              (.name ^java.nio.charset.Charset
                     (charset-of {"content-type" "text/plain; charset=ISO-8859-1"}))))
@@ -152,7 +152,7 @@
 
 (deftest charset-of-defaults-to-utf8
   (testing "rf2-a3wxe — absent / unparseable charset falls back to UTF-8"
-    (let [charset-of @#'transport-jvm/charset-of]
+    (let [charset-of @#'rf.http.transport-jvm/charset-of]
       (is (= "UTF-8" (.name ^java.nio.charset.Charset (charset-of {}))))
       (is (= "UTF-8" (.name ^java.nio.charset.Charset
                             (charset-of {"content-type" "application/json"}))))
@@ -165,7 +165,7 @@
 (deftest classify-jvm-error-stamps-elapsed-ms-on-timeout
   (testing "rf2-a3wxe — classify-jvm-error's 3-arity stamps the measured
             :elapsed-ms onto a timeout failure (was nil pre-fix)"
-    (let [classify transport-jvm/classify-jvm-error
+    (let [classify rf.http.transport-jvm/classify-jvm-error
           timeout  (java.net.http.HttpTimeoutException. "request timed out")
           failure  (classify timeout 30000 1234)]
       (is (= :rf.http/timeout (:kind failure)))
@@ -176,7 +176,7 @@
   (testing "rf2-w59es5 — the single 3-arity carries a nil :elapsed-ms when no
             start mark was measured (the synthetic-caller case); :limit-ms
             still rides whatever was threaded"
-    (let [classify transport-jvm/classify-jvm-error
+    (let [classify rf.http.transport-jvm/classify-jvm-error
           timeout  (java.net.http.HttpTimeoutException. "request timed out")]
       (is (nil? (:elapsed-ms (classify timeout 30000 nil))))
       (is (nil? (:elapsed-ms (classify timeout nil nil)))))))

--- a/implementation/http/test/re_frame/http_jvm_headers_shape_test.clj
+++ b/implementation/http/test/re_frame/http_jvm_headers_shape_test.clj
@@ -29,7 +29,7 @@
   rf2-hp772l — `jvm-headers->map` is JVM-platform-transport internal and
   now lives in the per-platform adapter ns `re-frame.http.transport-jvm`."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.http.transport-jvm :as http-transport-jvm])
+            [re-frame.http.transport-jvm :as rf.http.transport-jvm])
   (:import [java.net.http HttpHeaders]
            [java.util Map]
            [java.util.function BiPredicate]))
@@ -53,7 +53,7 @@
                      (test [_ _ _] true))]
     (HttpHeaders/of ^Map java-map ^BiPredicate accept-all)))
 
-(def ^:private jvm-headers->map @#'http-transport-jvm/jvm-headers->map)
+(def ^:private jvm-headers->map @#'rf.http.transport-jvm/jvm-headers->map)
 
 ;; ---- single-valued path stays string ---------------------------------------
 

--- a/implementation/http/test/re_frame/http_jvm_relative_url_test.clj
+++ b/implementation/http/test/re_frame/http_jvm_relative_url_test.clj
@@ -31,15 +31,15 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.http.transport-jvm :as transport-jvm]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.transport-jvm :as rf.http.transport-jvm]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---- per-test reset --------------------------------------------------------
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 
@@ -49,7 +49,7 @@
   `await-reply!` (rf2-fun38's `poll-until` idiom)."
   ([pred] (await-reply! pred 5000))
   ([pred timeout-ms]
-   (test-support/poll-until
+   (rf.test-support/poll-until
      #(let [db (rf/app-db-value :rf/default)] (when (pred db) db))
      {:timeout-ms timeout-ms :label "jvm relative-url reply"})))
 
@@ -59,7 +59,7 @@
   (testing "rf2-4y04lq — a relative :url throws an ex-info naming the url
             and the absolute-url requirement, NOT the JDK's opaque
             \"URI with undefined scheme\" message"
-    (let [ex (try (transport-jvm/jvm-build-request
+    (let [ex (try (rf.http.transport-jvm/jvm-build-request
                     {:method :get :url "/api/items"})
                   nil
                   (catch clojure.lang.ExceptionInfo e e))]
@@ -75,7 +75,7 @@
   (testing "rf2-4y04lq — a protocol-relative url (`//host/path`, no scheme)
             is ALSO relative per `URI/isAbsolute` and is rejected the same
             way as a path-only relative url"
-    (let [ex (try (transport-jvm/jvm-build-request
+    (let [ex (try (rf.http.transport-jvm/jvm-build-request
                     {:method :get :url "//example.invalid/api/items"})
                   nil
                   (catch clojure.lang.ExceptionInfo e e))]
@@ -85,7 +85,7 @@
 (deftest absolute-url-does-not-throw
   (testing "rf2-4y04lq (complement) — an absolute :url builds normally,
             unaffected by the new guard"
-    (let [req (transport-jvm/jvm-build-request
+    (let [req (rf.http.transport-jvm/jvm-build-request
                 {:method :get :url "https://example.invalid/api/items"})]
       (is (some? req)))))
 

--- a/implementation/http/test/re_frame/http_managed_machine_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_managed_machine_cljs_test.cljs
@@ -16,7 +16,7 @@
   plus the back-channel to the parent."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             ;; re-frame.machines and re-frame.http.managed cross-publish their
             ;; registration hooks through `re-frame.late-bind` (machines
             ;; publishes `:machines/reg-machine`; http-managed publishes
@@ -24,22 +24,22 @@
             ;; whichever loads second triggers the wrapper registration
             ;; (rf2-ijm7). Listing both here makes the dependency closure
             ;; explicit so the bundle includes both producers.
-            [re-frame.machines :as machines]
-            [re-frame.http.managed :as http-managed]
+            [re-frame.machines :as rf.machines]
+            [re-frame.http.managed :as rf.http.managed]
             ;; rf2-lwmgw — the stub macros / install fn live in
             ;; `re-frame.http.test-support` (alongside the canned-stub fx
             ;; registrations). This test calls `install-managed-request-stubs!`
             ;; directly, so it requires that ns.
-            [re-frame.http.test-support :as http-test-support]
-            [re-frame.registrar :as registrar]
-            [re-frame.test-support :as test-support]))
+            [re-frame.http.test-support :as rf.http.test-support]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter
      :init-fn (fn []
-                (machines/reset-timers!)
-                (http-managed/clear-all-in-flight!))}))
+                (rf.machines/reset-timers!)
+                (rf.http.managed/clear-all-in-flight!))}))
 
 (defn- snapshot [machine-id]
   (get-in (:rf.db/runtime (rf/frame-state-value :rf/default)) [:rf.runtime/machines :snapshots machine-id]))
@@ -48,7 +48,7 @@
 
 (deftest wrapper-is-registered-when-machines-is-present
   (testing "loading both re-frame.machines and re-frame.http.managed registers `:rf.http/managed` as a machine"
-    (let [meta (registrar/lookup :event :rf.http/managed)]
+    (let [meta (rf.registrar/lookup :event :rf.http/managed)]
       (is (some? meta) ":rf.http/managed is registered as an :event")
       (is (true? (:rf/machine? meta))
           ":rf/machine? metadata flag is set — it's an actual machine, not a vanilla event")
@@ -67,7 +67,7 @@
   (testing "parent :spawn {:machine-id :rf.http/managed ...} spawns the wrapper actor and stamps :rf/parent-id / :rf/self-id / :rf/invoke-id into the wrapper's :data (rf2-ijm7)"
     ;; Install a stub that NEVER replies — gives us a stable
     ;; :requesting snapshot to inspect without racing against Fetch.
-    (http-test-support/install-managed-request-stubs! {})
+    (rf.http.test-support/install-managed-request-stubs! {})
     (try
       (rf/reg-machine :cljs/auth2
         {:initial :idle
@@ -104,7 +104,7 @@
           (is (= {:url "/api/me" :method :get} (:request wrapper-data))
               "the user's :request is preserved verbatim under :data")))
       (finally
-        (http-test-support/uninstall-managed-request-stubs!)))))
+        (rf.http.test-support/uninstall-managed-request-stubs!)))))
 
 ;; ---- (2b) nested :request-content-type survives the wrapper pass-through -
 
@@ -115,7 +115,7 @@
     ;; `(:request-content-type request)`), so the Args-carrier example
     ;; MUST nest it under `:request`, not at the top level of `:data`.
     ;; This proves the corrected example shape threads through.
-    (http-test-support/install-managed-request-stubs! {})  ;; no-reply stub: stable :requesting snapshot
+    (rf.http.test-support/install-managed-request-stubs! {})  ;; no-reply stub: stable :requesting snapshot
     (try
       (rf/reg-machine :cljs/poster
         {:initial :idle
@@ -141,13 +141,13 @@
         (is (not (contains? wrapper-data :request-content-type))
             ":request-content-type is NOT promoted to the top level of :data"))
       (finally
-        (http-test-support/uninstall-managed-request-stubs!)))))
+        (rf.http.test-support/uninstall-managed-request-stubs!)))))
 
 ;; ---- (3) parent state-exit destroys wrapper child + clears registry ----
 
 (deftest parent-exit-destroys-wrapper-child
   (testing "transition out of the :spawn-bearing state destroys the wrapper actor — registry slot cleared, snapshot gone (rf2-ijm7 + rf2-wvkn destroy cascade)"
-    (http-test-support/install-managed-request-stubs! {})  ;; no-match stub: synthesises a failure (which we will not observe)
+    (rf.http.test-support/install-managed-request-stubs! {})  ;; no-match stub: synthesises a failure (which we will not observe)
     (try
       (rf/reg-machine :cljs/cancellable
         {:initial :idle
@@ -175,4 +175,4 @@
         (is (nil? (get-in db [:rf.runtime/machines :snapshots :rf.http/managed#1]))
             "wrapper actor's snapshot is gone after the parent's cancel"))
       (finally
-        (http-test-support/uninstall-managed-request-stubs!)))))
+        (rf.http.test-support/uninstall-managed-request-stubs!)))))

--- a/implementation/http/test/re_frame/http_managed_machine_test.clj
+++ b/implementation/http/test/re_frame/http_managed_machine_test.clj
@@ -29,11 +29,11 @@
   uses the same wrapper registration via Fetch."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.http.managed :as http-managed]
+            [re-frame.http.managed :as rf.http.managed]
             [re-frame.machines]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace])
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace])
   (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
            [java.net InetSocketAddress]
            [java.util.concurrent CountDownLatch TimeUnit]))
@@ -41,7 +41,7 @@
 ;; ---- per-test reset --------------------------------------------------------
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- helpers --------------------------------------------------------------
 
@@ -99,7 +99,7 @@
   per-file arity (`pred`, optional `timeout-ms`)."
   ([pred] (await-condition! pred 5000))
   ([pred timeout-ms]
-   (test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
+   (rf.test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
                                   :label "http-managed-machine condition"})
    true))
 
@@ -195,7 +195,7 @@
           {:keys [port]} srv
           traces (atom [])]
       (try
-        (trace/register-listener! ::ijm7-3 (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! ::ijm7-3 (fn [ev] (swap! traces conj ev)))
         (rf/reg-machine :app/cancel
           {:initial :idle
            :states
@@ -214,8 +214,8 @@
         (rf/dispatch-sync [:app/cancel [:login]])
         ;; Wait until the wrapper's underlying fx has recorded the
         ;; request in-flight against the wrapper actor's id.
-        (await-condition! #(seq (http-managed/actor-in-flight-snapshot)))
-        (let [snap (http-managed/actor-in-flight-snapshot)]
+        (await-condition! #(seq (rf.http.managed/actor-in-flight-snapshot)))
+        (let [snap (rf.http.managed/actor-in-flight-snapshot)]
           (is (= 1 (count snap)))
           (is (contains? snap :rf.http/managed#1)
               "in-flight indexed by the spawned wrapper actor's id"))
@@ -223,7 +223,7 @@
         ;; is destroyed, and the abort cascade fires.
         (rf/dispatch-sync [:app/cancel [:cancel]])
         (is (= :idle (:state (snapshot :app/cancel))))
-        (is (empty? (http-managed/actor-in-flight-snapshot))
+        (is (empty? (rf.http.managed/actor-in-flight-snapshot))
             "in-flight registry cleared after parent's cancel")
         (let [abort-traces (filter #(= :rf.http/aborted-on-actor-destroy
                                        (:operation %))
@@ -235,7 +235,7 @@
                 "trace identifies the destroyed wrapper actor")))
         (.countDown latch)
         (finally
-          (trace/unregister-listener! ::ijm7-3)
+          (rf.trace/unregister-listener! ::ijm7-3)
           (stop-server! srv))))))
 
 ;; ---- (4) composes with :after — whichever fires first wins ----------------
@@ -247,7 +247,7 @@
           {:keys [port]} srv
           traces (atom [])]
       (try
-        (trace/register-listener! ::ijm7-4 (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! ::ijm7-4 (fn [ev] (swap! traces conj ev)))
         (rf/reg-machine :app/after-test
           {:initial :idle
            :states
@@ -271,8 +271,8 @@
             :authenticated {}
             :timed-out     {}}})
         (rf/dispatch-sync [:app/after-test [:login]])
-        (await-condition! #(seq (http-managed/actor-in-flight-snapshot)))
-        (is (contains? (http-managed/actor-in-flight-snapshot)
+        (await-condition! #(seq (rf.http.managed/actor-in-flight-snapshot)))
+        (is (contains? (rf.http.managed/actor-in-flight-snapshot)
                        :rf.http/managed#1))
         ;; Simulate the :after firing by dispatching the synthetic
         ;; timer-elapsed event directly (the after_test.clj pattern —
@@ -285,7 +285,7 @@
                              [:rf.machine.timer/after-elapsed 30000 epoch [:authenticating]]]))
         (is (= :timed-out (:state (snapshot :app/after-test)))
             ":after firing exited :authenticating to :timed-out")
-        (is (empty? (http-managed/actor-in-flight-snapshot))
+        (is (empty? (rf.http.managed/actor-in-flight-snapshot))
             "the cancellation cascade aborted the in-flight HTTP")
         (let [abort-traces (filter #(= :rf.http/aborted-on-actor-destroy
                                        (:operation %))
@@ -294,7 +294,7 @@
               "wall-clock timeout cancelled the wrapper child + fired the rf2-wvkn trace"))
         (.countDown latch)
         (finally
-          (trace/unregister-listener! ::ijm7-4)
+          (rf.trace/unregister-listener! ::ijm7-4)
           (stop-server! srv))))))
 
 ;; ---- (5) sibling fx-form continues to work alongside the machine wrapper -
@@ -318,7 +318,7 @@
                       :decode  :json}]]})))
         (rf/dispatch-sync [:legacy/load {}])
         ;; rf2-fun38: deterministic gate via canonical poll-until.
-        (test-support/poll-until
+        (rf.test-support/poll-until
           #(some? (:result (rf/app-db-value :rf/default)))
           {:timeout-ms 5000 :label "fx-form reply landed on :rf/default"})
         (is (= {:ok true} (:result (rf/app-db-value :rf/default)))

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -11,21 +11,21 @@
   (:require [clojure.string]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.http.json :as http-json]
-            [re-frame.registrar :as registrar]
-            [re-frame.http.decode :as http-decode]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.http.registry :as registry]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.fx :as rf.fx]
+            [re-frame.http.json :as rf.http.json]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.http.decode :as rf.http.decode]
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.registry :as rf.http.registry]
+            [re-frame.late-bind :as rf.late-bind]
             ;; This suite uses
             ;; `:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}`
             ;; throughout, so it opts in by requiring the test-support ns.
             ;; Requiring test support registers both canned effect ids.
             [re-frame.http.test-support]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace])
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace])
   (:import [com.sun.net.httpserver HttpServer HttpHandler HttpExchange]
            [java.net InetSocketAddress]
            [java.util.concurrent CountDownLatch TimeUnit]))
@@ -41,7 +41,7 @@
 ;; `re-frame.http.middleware`), so a leaked `:before` / `:after` would
 ;; otherwise mutate every subsequent test's reply payload.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- a tiny in-process HTTP server ----------------------------------------
 ;;
@@ -85,7 +85,7 @@
   `db`-closing-arity shape that read sites here expect."
   ([pred] (await-reply! pred 5000))
   ([pred timeout-ms]
-   (test-support/poll-until
+   (rf.test-support/poll-until
      #(let [db (rf/app-db-value :rf/default)] (when (pred db) db))
      {:timeout-ms timeout-ms :label "http-managed reply"})))
 
@@ -115,7 +115,7 @@
             :reply-to / :on-success / :on-failure throws
             :rf.error/http-no-reply-target at fx-call time (the co-located
             default was retired pre-alpha)"
-    (let [ex (try (http-managed/managed-handler
+    (let [ex (try (rf.http.managed/managed-handler
                     {:frame :rf/default :event [:no-op]}
                     {:request {:method :get :url "/x"}})
                   nil
@@ -125,7 +125,7 @@
       (is (= :rf.http/managed (:where (ex-data ex)))))
     ;; Supplying ANY one of the three satisfies the guard (an explicit nil counts).
     (doseq [k [:reply-to :on-success :on-failure]]
-      (let [ex (try (http-managed/managed-handler
+      (let [ex (try (rf.http.managed/managed-handler
                       {:frame :rf/default :event [:no-op]}
                       {:request {:method :get :url "http://127.0.0.1:1/x"} k nil})
                     nil
@@ -255,7 +255,7 @@
     (let [traces      (atom [])
           listener-id ::j1mo4-after-ms]
       (try
-        (trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
         (canned-success-reply-event {:value {:n 3} :after-ms 30})
         ;; The reply must NOT be present synchronously — the dispatch-sync
         ;; drain only schedules the :dispatch-later; nothing has delivered yet.
@@ -279,7 +279,7 @@
                     later)
               "the deferred dispatch is the framework canned-reply deliverer"))
         (finally
-          (trace/unregister-listener! listener-id))))))
+          (rf.trace/unregister-listener! listener-id))))))
 
 (deftest after-ms-positive-on-failure-defers
   (testing ":after-ms N also defers the canned-FAILURE reply by a
@@ -571,7 +571,7 @@
               ;; (NOT in the :on set, so non-retryable).
               (write-response! ex 200 "application/json" "{\"ok\":true}")))]
       (try
-        (trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
         (rf/reg-event :upexd3/load
           (fn [{:keys [db]} [_ msg reply]]
             (if reply
@@ -597,7 +597,7 @@
                      (count retry-traces) " — "
                      (pr-str (mapv #(get-in % [:tags :failure :kind]) retry-traces))))))
         (finally
-          (trace/unregister-listener! listener-id)
+          (rf.trace/unregister-listener! listener-id)
           (stop-server! srv))))))
 
 (deftest jvm-retry-eligible-exhaustion-still-emits-retry-attempts
@@ -625,7 +625,7 @@
             (fn [^HttpExchange ex]
               (write-response! ex 500 "application/json" "{\"err\":true}")))]
       (try
-        (trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
         (rf/reg-event :upexd3b/load
           (fn [{:keys [db]} [_ msg reply]]
             (if reply
@@ -669,7 +669,7 @@
                      "phantom `:retried`; saw "
                      (pr-str (mapv :recovery terminal))))))
         (finally
-          (trace/unregister-listener! listener-id)
+          (rf.trace/unregister-listener! listener-id)
           (stop-server! srv))))))
 
 ;; ---- 5d. Content-Type lookup is case-insensitive (rf2-6hbo8) -------------
@@ -697,28 +697,28 @@
 (deftest content-type-of-case-insensitive
   (testing "lowercase key"
     (is (= "application/json"
-           (http-decode/content-type-of {"content-type" "application/json"}))))
+           (rf.http.decode/content-type-of {"content-type" "application/json"}))))
   (testing "canonical Title-Case key"
     (is (= "application/json"
-           (http-decode/content-type-of {"Content-Type" "application/json"}))))
+           (rf.http.decode/content-type-of {"Content-Type" "application/json"}))))
   (testing "all-caps key (the original bug — CONTENT-TYPE)"
     (is (= "application/json"
-           (http-decode/content-type-of {"CONTENT-TYPE" "application/json"}))))
+           (rf.http.decode/content-type-of {"CONTENT-TYPE" "application/json"}))))
   (testing "mixed casing"
     (is (= "application/json"
-           (http-decode/content-type-of {"Content-type" "application/json"})))
+           (rf.http.decode/content-type-of {"Content-type" "application/json"})))
     (is (= "text/plain"
-           (http-decode/content-type-of {"cOnTeNt-TyPe" "text/plain"}))))
+           (rf.http.decode/content-type-of {"cOnTeNt-TyPe" "text/plain"}))))
   (testing "keyword key (some middlewares use keywords)"
     (is (= "application/json"
-           (http-decode/content-type-of {:content-type "application/json"})))
+           (rf.http.decode/content-type-of {:content-type "application/json"})))
     (is (= "application/json"
-           (http-decode/content-type-of {:Content-Type "application/json"}))))
+           (rf.http.decode/content-type-of {:Content-Type "application/json"}))))
   (testing "absent / unrelated headers"
-    (is (nil? (http-decode/content-type-of {})))
-    (is (nil? (http-decode/content-type-of {"X-Foo" "bar"})))
-    (is (nil? (http-decode/content-type-of nil)))
-    (is (nil? (http-decode/content-type-of "not-a-map")))))
+    (is (nil? (rf.http.decode/content-type-of {})))
+    (is (nil? (rf.http.decode/content-type-of {"X-Foo" "bar"})))
+    (is (nil? (rf.http.decode/content-type-of nil)))
+    (is (nil? (rf.http.decode/content-type-of "not-a-map")))))
 
 (deftest decode-response-body-resolves-content-type-case-insensitively
   (testing "JSON decode under :auto fires when Content-Type has non-canonical casing"
@@ -729,7 +729,7 @@
     ;; header regardless of casing and JSON decodes correctly.
     (doseq [ct-key ["CONTENT-TYPE" "Content-type" "content-type" "Content-Type" "cOnTeNt-TyPe"]]
       (testing (str "casing: " ct-key)
-        (let [decoded (http-decode/decode-response-body
+        (let [decoded (rf.http.decode/decode-response-body
                         {:body-text        "{\"ok\":true}"
                          :headers          {ct-key "application/json"}
                          :decode           :auto})]
@@ -758,24 +758,24 @@
 
 (deftest binary-read-kind-resolves-binary-decode-modes
   (testing "explicit binary modes resolve to themselves"
-    (is (= :blob         (http-decode/binary-read-kind :blob {})))
-    (is (= :array-buffer (http-decode/binary-read-kind :array-buffer {})))
-    (is (= :form-data    (http-decode/binary-read-kind :form-data {}))))
+    (is (= :blob         (rf.http.decode/binary-read-kind :blob {})))
+    (is (= :array-buffer (rf.http.decode/binary-read-kind :array-buffer {})))
+    (is (= :form-data    (rf.http.decode/binary-read-kind :form-data {}))))
   (testing "text-based / structured modes resolve to nil (read .text)"
-    (is (nil? (http-decode/binary-read-kind :json {})))
-    (is (nil? (http-decode/binary-read-kind :text {})))
-    (is (nil? (http-decode/binary-read-kind (fn [_ _] :decoded) {})))
-    (is (nil? (http-decode/binary-read-kind [:map] {}))
+    (is (nil? (rf.http.decode/binary-read-kind :json {})))
+    (is (nil? (rf.http.decode/binary-read-kind :text {})))
+    (is (nil? (rf.http.decode/binary-read-kind (fn [_ _] :decoded) {})))
+    (is (nil? (rf.http.decode/binary-read-kind [:map] {}))
         "a Malli schema is a text (JSON-parse) mode, not binary"))
   (testing ":auto sniffs the Content-Type — binary type → :blob (rf2-5zj6t)"
-    (is (= :blob (http-decode/binary-read-kind :auto {"content-type" "image/png"}))
+    (is (= :blob (rf.http.decode/binary-read-kind :auto {"content-type" "image/png"}))
         ":auto over a binary Content-Type reads as a Blob, not lossy text")
-    (is (= :blob (http-decode/binary-read-kind nil {"content-type" "application/octet-stream"}))
+    (is (= :blob (rf.http.decode/binary-read-kind nil {"content-type" "application/octet-stream"}))
         "omitted :decode (== :auto) over a binary Content-Type also reads binary"))
   (testing ":auto sniffs the Content-Type — text/JSON → nil (read .text)"
-    (is (nil? (http-decode/binary-read-kind :auto {"content-type" "application/json"})))
-    (is (nil? (http-decode/binary-read-kind :auto {"content-type" "text/plain"})))
-    (is (nil? (http-decode/binary-read-kind nil  {"content-type" "text/html"})))))
+    (is (nil? (rf.http.decode/binary-read-kind :auto {"content-type" "application/json"})))
+    (is (nil? (rf.http.decode/binary-read-kind :auto {"content-type" "text/plain"})))
+    (is (nil? (rf.http.decode/binary-read-kind nil  {"content-type" "text/html"})))))
 
 (deftest decode-response-body-returns-native-binary-for-binary-modes
   (testing "binary decode modes return the pre-read :body-binary verbatim"
@@ -786,7 +786,7 @@
       (doseq [mode [:blob :array-buffer :form-data]]
         (testing (str "mode: " mode)
           (is (identical? native
-                          (http-decode/decode-response-body
+                          (rf.http.decode/decode-response-body
                             {:body-text   "lossy-utf8-text"
                              :body-binary native
                              :headers     {}
@@ -795,7 +795,7 @@
   (testing "binary mode with no :body-binary (e.g. JVM transport) falls back to body-text"
     (doseq [mode [:blob :array-buffer :form-data]]
       (is (= "raw-payload"
-             (http-decode/decode-response-body
+             (rf.http.decode/decode-response-body
                {:body-text        "raw-payload"
                 :headers          {}
                 :decode           mode}))
@@ -896,7 +896,7 @@
           traces       (atom [])
           listener-id  ::kdwnq-trace]
       (try
-        (trace/register-listener! listener-id
+        (rf.trace/register-listener! listener-id
                                   (fn [ev] (swap! traces conj ev)))
         ;; If a reply ever dispatches the test will catch it (silently
         ;; ignored handler) — but the load-bearing assertion is that no
@@ -927,7 +927,7 @@
               (str "no :rf.error/* trace fired for the abort no-op; saw: "
                    (mapv :operation errors))))
         (finally
-          (trace/unregister-listener! listener-id))))))
+          (rf.trace/unregister-listener! listener-id))))))
 
 ;; ---- 9. abort by request-id -----------------------------------------------
 
@@ -955,8 +955,8 @@
         ;; Poll until the request is actually registered as in-flight —
         ;; aborting before the executor has stamped the handle is a no-op
         ;; (rf2-fun38 — replaces fixed Thread/sleep 50).
-        (test-support/poll-until
-          #(contains? (http-managed/in-flight-snapshot) :slow)
+        (rf.test-support/poll-until
+          #(contains? (rf.http.managed/in-flight-snapshot) :slow)
           {:label ":slow registered as in-flight before abort"})
         (rf/dispatch-sync [:slow/abort])
         (let [db (await-reply! #(some? (:reply %)) 5000)]
@@ -1023,8 +1023,8 @@
         (rf/dispatch-sync [:on7sj/load])
         ;; Poll until the request is registered in-flight before aborting
         ;; (rf2-fun38 — replaces fixed Thread/sleep 50).
-        (test-support/poll-until
-          #(contains? (http-managed/in-flight-snapshot) :on7sj/req)
+        (rf.test-support/poll-until
+          #(contains? (rf.http.managed/in-flight-snapshot) :on7sj/req)
           {:label ":on7sj/req registered as in-flight before abort"})
         ;; Abort while server is still blocked. The synthesised
         ;; :rf.http/aborted reply should fire immediately.
@@ -1198,7 +1198,7 @@
     (let [real-fx-invoked? (atom false)]
       ;; Shadow the production fx slot with a sentinel. Reaching THIS proves
       ;; the override was absent (the pre-fix bug). The stub path bypasses it.
-      (fx/reg-fx :rf.http/managed
+      (rf.fx/reg-fx :rf.http/managed
                  (fn [_frame-ctx _args] (reset! real-fx-invoked? true) nil))
       (rf/reg-event :rzqan/load
         (fn [{:keys [db]} [_ msg reply]]
@@ -1326,13 +1326,13 @@
     ;; Install the stub fx directly so the throw is observable (a throw
     ;; inside dispatch-sync's fx phase is swallowed into the error sink).
     (let [recorded (atom [])
-          original (late-bind/get-fn :router/dispatch!)]
-      (late-bind/set-fn! :router/dispatch!
+          original (rf.late-bind/get-fn :router/dispatch!)]
+      (rf.late-bind/set-fn! :router/dispatch!
                          (fn [ev opts] (swap! recorded conj [ev opts])))
       (try
         (re-frame.http.test-support/install-managed-request-stubs!
           {[:get "/x"] {:reply {:ok {:stubbed true}}}})
-        (let [stub-fx (registrar/handler :fx :rf.http/managed-test-stub)
+        (let [stub-fx (rf.registrar/handler :fx :rf.http/managed-test-stub)
               ex      (try (stub-fx {:frame :rf/default :event [:azrcs/erase]}
                                     {:request {:method :get :url "/x"}})
                            nil
@@ -1344,7 +1344,7 @@
               "NO synthetic reply was dispatched — the invalid request is rejected, not masked"))
         (finally
           (re-frame.http.test-support/uninstall-managed-request-stubs!)
-          (late-bind/set-fn! :router/dispatch! original))))))
+          (rf.late-bind/set-fn! :router/dispatch! original))))))
 
 ;; ---- 11a-vn8qjv. scoped stubs compose under nesting -----------------------
 ;;
@@ -1419,7 +1419,7 @@
   `await-reply!` but keyed to a `with-new-frame` frame VALUE rather than
   `:rf/default`, so a SEALED-generation frame's reply is observable."
   [f pred]
-  (test-support/poll-until
+  (rf.test-support/poll-until
     #(let [db (rf/app-db-value f)] (when (pred db) db))
     {:timeout-ms 2000 :label "sealed-frame http-managed reply"}))
 
@@ -1431,7 +1431,7 @@
       ;; Shadow the production fx slot with a sentinel — reaching it proves the
       ;; override was absent (the pre-fix sealed-frame bug). Registered BEFORE
       ;; make-frame so it is in the sealed generation either way.
-      (fx/reg-fx :rf.http/managed
+      (rf.fx/reg-fx :rf.http/managed
                  (fn [_frame-ctx _args] (reset! real-fx-invoked? true) nil))
       (rf/reg-event :bxc8kf/load
         (fn [{:keys [db]} [_ msg reply]]
@@ -1519,28 +1519,28 @@
   (testing "rf2-vn8qjv — nested install/uninstall on the stable id restores the
             outer handler; balanced top-level pair leaks no test fx"
     (let [stub-id :rf.http/managed-test-stub]
-      (is (nil? (registrar/handler :fx stub-id))
+      (is (nil? (rf.registrar/handler :fx stub-id))
           "no stub fx registered before install")
       (re-frame.http.test-support/install-managed-request-stubs!
         {[:get "/outer"] {:reply {:ok {:from :outer}}}})
-      (let [outer-handler (registrar/handler :fx stub-id)]
+      (let [outer-handler (rf.registrar/handler :fx stub-id)]
         (is (some? outer-handler) "outer install registered the stub fx")
         ;; Nested install replaces the handler in place.
         (re-frame.http.test-support/install-managed-request-stubs!
           {[:get "/inner"] {:reply {:ok {:from :inner}}}})
-        (is (not (identical? outer-handler (registrar/handler :fx stub-id)))
+        (is (not (identical? outer-handler (rf.registrar/handler :fx stub-id)))
             "inner install replaced the handler")
         ;; Inner uninstall RESTORES the outer handler (stack discipline).
         (re-frame.http.test-support/uninstall-managed-request-stubs!)
-        (is (identical? outer-handler (registrar/handler :fx stub-id))
+        (is (identical? outer-handler (rf.registrar/handler :fx stub-id))
             "inner uninstall restored the outer install's handler")
         ;; Outer uninstall clears (no prior on the stack).
         (re-frame.http.test-support/uninstall-managed-request-stubs!)
-        (is (nil? (registrar/handler :fx stub-id))
+        (is (nil? (rf.registrar/handler :fx stub-id))
             "balanced top-level install/uninstall leaves no leaked test fx")
         ;; Idempotent: an extra uninstall is a safe no-op.
         (re-frame.http.test-support/uninstall-managed-request-stubs!)
-        (is (nil? (registrar/handler :fx stub-id))
+        (is (nil? (rf.registrar/handler :fx stub-id))
             "extra uninstall is an idempotent no-op")))))
 
 ;; ---- 11b. canned-stub fxs gated on explicit test-support require (rf2-cdmle)
@@ -1579,13 +1579,13 @@
             be vacuous if this side did not actually register the stubs."
     ;; The fixture has just reloaded http-test-support, so the canned
     ;; stubs are present. The production-eligible fxs are present too.
-    (is (some? (registrar/lookup :fx :rf.http/managed))
+    (is (some? (rf.registrar/lookup :fx :rf.http/managed))
         ":rf.http/managed is dev+prod — always registered by re-frame.http.managed")
-    (is (some? (registrar/lookup :fx :rf.http/managed-abort))
+    (is (some? (rf.registrar/lookup :fx :rf.http/managed-abort))
         ":rf.http/managed-abort is dev+prod — always registered by re-frame.http.managed")
-    (is (some? (registrar/lookup :fx :rf.http/managed-canned-success))
+    (is (some? (rf.registrar/lookup :fx :rf.http/managed-canned-success))
         ":rf.http/managed-canned-success registered when re-frame.http.test-support is required")
-    (is (some? (registrar/lookup :fx :rf.http/managed-canned-failure))
+    (is (some? (rf.registrar/lookup :fx :rf.http/managed-canned-failure))
         ":rf.http/managed-canned-failure registered when re-frame.http.test-support is required")))
 
 ;; ---- 12. decode reflection metadata ---------------------------------------
@@ -1620,7 +1620,7 @@
   `:rf.error/poll-until-timeout` on timeout. Thin alias over
   `test-support/poll-until` (rf2-fun38)."
   [pred timeout-ms]
-  (test-support/poll-until pred {:timeout-ms timeout-ms
+  (rf.test-support/poll-until pred {:timeout-ms timeout-ms
                                  :label "http-managed condition"})
   :done)
 
@@ -1671,13 +1671,13 @@
 
         ;; Wait for both requests to be in-flight under the same actor.
         (await-condition!
-          #(let [snap (http-managed/actor-in-flight-snapshot)]
+          #(let [snap (rf.http.managed/actor-in-flight-snapshot)]
              (and (= 1 (count snap))
                   (= 2 (count (val (first snap))))))
           5000)
 
         ;; ---- actor-in-flight-snapshot shape ----
-        (let [actor-snap (http-managed/actor-in-flight-snapshot)]
+        (let [actor-snap (rf.http.managed/actor-in-flight-snapshot)]
           (is (map? actor-snap)
               "actor-in-flight-snapshot returns a map")
           (is (= 1 (count actor-snap))
@@ -1705,7 +1705,7 @@
                   ":request-id stamped on the handle matches the user-supplied id"))))
 
         ;; ---- in-flight-snapshot shape (request-id-keyed) ----
-        (let [req-snap (http-managed/in-flight-snapshot)]
+        (let [req-snap (rf.http.managed/in-flight-snapshot)]
           (is (map? req-snap)
               "in-flight-snapshot returns a map")
           (is (= 2 (count req-snap))
@@ -1799,7 +1799,7 @@
         (rf/dispatch-sync [:search/run "stale"])
         ;; Let the first request reach in-flight.
         (await-condition!
-          #(seq (http-managed/in-flight-snapshot))
+          #(seq (rf.http.managed/in-flight-snapshot))
           2000)
         ;; Fire the superseding request — same :request-id.
         (rf/dispatch-sync [:search/run-superseding])
@@ -1831,7 +1831,7 @@
               (.await latch 5 TimeUnit/SECONDS)
               (write-response! ex 200 "application/json" "{\"ok\":true}")))]
       (try
-        (trace/register-listener! cb-id
+        (rf.trace/register-listener! cb-id
                                   (fn [ev]
                                     (when (= :rf.http/aborted (:operation ev))
                                       (swap! events conj ev))))
@@ -1855,7 +1855,7 @@
 
         (rf/dispatch-sync [:search/run])
         (await-condition!
-          #(seq (http-managed/in-flight-snapshot))
+          #(seq (rf.http.managed/in-flight-snapshot))
           2000)
         (rf/dispatch-sync [:search/run-superseding])
         (await-condition! #(seq @events) 2000)
@@ -1871,7 +1871,7 @@
 
         (.countDown latch)
         (finally
-          (trace/unregister-listener! cb-id)
+          (rf.trace/unregister-listener! cb-id)
           (stop-server! srv))))))
 
 (deftest jvm-non-superseded-abort-still-fires-reply
@@ -1904,7 +1904,7 @@
 
         (rf/dispatch-sync [:slow/load])
         (await-condition!
-          #(seq (http-managed/in-flight-snapshot))
+          #(seq (rf.http.managed/in-flight-snapshot))
           2000)
         ;; User-initiated abort — the abort fn passes `:user` as the reason.
         (rf/dispatch-sync [:slow/abort])
@@ -2172,7 +2172,7 @@
         (await-reply! #(some? (:reply %)) 5000)
         (is (= "application/json" @seen-ct)
             ":request-content-type :json sets the Content-Type header")
-        (is (= {:name "widget"} (http-json/json-parse @seen-body))
+        (is (= {:name "widget"} (rf.http.json/json-parse @seen-body))
             "the body is JSON-encoded and round-trips at the server")
         (finally (stop-server! srv))))))
 
@@ -2426,17 +2426,17 @@
     (let [traces      (atom [])
           listener-id (gensym "xmp74u-stub-sensitive-")
           recorded    (atom [])
-          original    (late-bind/get-fn :router/dispatch!)]
-      (late-bind/set-fn! :router/dispatch!
+          original    (rf.late-bind/get-fn :router/dispatch!)]
+      (rf.late-bind/set-fn! :router/dispatch!
                          (fn [ev opts] (swap! recorded conj [ev opts])))
       (try
-        (trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
         ;; A :before that throws AFTER the chain starts.
         (rf/reg-http-interceptor :xmp74u/boom
           {:before (fn [_ctx] (throw (ex-info "kaboom" {})))})
         (re-frame.http.test-support/install-managed-request-stubs!
           {[:get "https://api.example.invalid/v1"] {:reply {:ok {:stubbed true}}}})
-        (let [stub-fx (registrar/handler :fx :rf.http/managed-test-stub)
+        (let [stub-fx (rf.registrar/handler :fx :rf.http/managed-test-stub)
               ;; TOP-LEVEL :sensitive? true (NOT [:request :sensitive?]).
               ;; customer_email is NOT in the query-param denylist, so it
               ;; only redacts when the request is effectively sensitive.
@@ -2467,8 +2467,8 @@
               ":sensitive? stamped on the stub-path failure trace, matching production"))
         (finally
           (re-frame.http.test-support/uninstall-managed-request-stubs!)
-          (trace/unregister-listener! listener-id)
-          (late-bind/set-fn! :router/dispatch! original))))))
+          (rf.trace/unregister-listener! listener-id)
+          (rf.late-bind/set-fn! :router/dispatch! original))))))
 
 (deftest stub-request-chain-failure-non-sensitive-leaves-query-value-rf2-xmp74u
   (testing "rf2-xmp74u (complement) — WITHOUT :sensitive?, the same throwing
@@ -2478,16 +2478,16 @@
     (let [traces      (atom [])
           listener-id (gensym "xmp74u-stub-nonsensitive-")
           recorded    (atom [])
-          original    (late-bind/get-fn :router/dispatch!)]
-      (late-bind/set-fn! :router/dispatch!
+          original    (rf.late-bind/get-fn :router/dispatch!)]
+      (rf.late-bind/set-fn! :router/dispatch!
                          (fn [ev opts] (swap! recorded conj [ev opts])))
       (try
-        (trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
         (rf/reg-http-interceptor :xmp74u/boom2
           {:before (fn [_ctx] (throw (ex-info "kaboom" {})))})
         (re-frame.http.test-support/install-managed-request-stubs!
           {[:get "https://api.example.invalid/v1"] {:reply {:ok {:stubbed true}}}})
-        (let [stub-fx (registrar/handler :fx :rf.http/managed-test-stub)
+        (let [stub-fx (rf.registrar/handler :fx :rf.http/managed-test-stub)
               _ex     (try
                         (stub-fx {:frame :rf/default :event [:xmp74u/load2]}
                                  {:request {:method :get
@@ -2505,8 +2505,8 @@
               ":sensitive? not stamped for a non-sensitive request"))
         (finally
           (re-frame.http.test-support/uninstall-managed-request-stubs!)
-          (trace/unregister-listener! listener-id)
-          (late-bind/set-fn! :router/dispatch! original))))))
+          (rf.trace/unregister-listener! listener-id)
+          (rf.late-bind/set-fn! :router/dispatch! original))))))
 
 ;; ---- rf2-k47b3d — issuance-counter eviction bounds the map -----------------
 
@@ -2516,21 +2516,21 @@
   distinct-id space (e.g. `[:fetch-doc uuid]` over an unbounded id space) does
   NOT accumulate one permanent `issuance-counters` entry per id ever requested
   on a long-running JVM (the leak the monotonic-forever design carried)."
-    (registry/reset-issuance-counters-for-test!)
-    (is (zero? (registry/issuance-counter-count)))
+    (rf.http.registry/reset-issuance-counters-for-test!)
+    (is (zero? (rf.http.registry/issuance-counter-count)))
     ;; Adversarial: 500 DISTINCT single-issuance request-ids, each issued once
     ;; then completed. Pre-fix the map would end holding 500 entries; the
     ;; conditional-atomic evict on completion keeps it at zero.
     (doseq [i (range 500)]
       (let [rid      [:fetch-doc i]
-            issuance (registry/next-issuance! rid)]
+            issuance (rf.http.registry/next-issuance! rid)]
         (is (= 1 issuance) "a fresh distinct id starts at issuance 1")
-        (is (= 1 (registry/issuance-counter-count))
+        (is (= 1 (rf.http.registry/issuance-counter-count))
             "exactly one live counter while the request is in flight")
-        (registry/evict-issuance-on-completion! rid issuance)
-        (is (zero? (registry/issuance-counter-count))
+        (rf.http.registry/evict-issuance-on-completion! rid issuance)
+        (is (zero? (rf.http.registry/issuance-counter-count))
             "the counter is evicted the moment the request completes")))
-    (is (zero? (registry/issuance-counter-count))
+    (is (zero? (rf.http.registry/issuance-counter-count))
         "the map stays bounded across 500 distinct single-issuance request-ids")))
 
 (deftest issuance-counter-eviction-preserves-live-successor
@@ -2539,26 +2539,26 @@
   rf2-azcmd3 anti-collision invariant: a SUPERSEDED attempt's terminal eviction
   MUST NOT drop the live successor's counter, because `next-issuance!` already
   bumped it past the superseded attempt's issuance BEFORE the supersede."
-    (registry/reset-issuance-counters-for-test!)
+    (rf.http.registry/reset-issuance-counters-for-test!)
     (let [rid [:search-box :q]
-          n1  (registry/next-issuance! rid)   ; attempt A: issuance 1
-          n2  (registry/next-issuance! rid)]  ; supersede → attempt B: issuance 2
+          n1  (rf.http.registry/next-issuance! rid)   ; attempt A: issuance 1
+          n2  (rf.http.registry/next-issuance! rid)]  ; supersede → attempt B: issuance 2
       (is (= 1 n1))
       (is (= 2 n2) "the superseding attempt gets a distinct, higher issuance")
       ;; Attempt A (the SUPERSEDED one) terminates. Its evict keys on issuance 1,
       ;; but the counter is already at 2 → the atomic compare-and-drop SKIPS.
-      (registry/evict-issuance-on-completion! rid n1)
-      (is (= 1 (registry/issuance-counter-count))
+      (rf.http.registry/evict-issuance-on-completion! rid n1)
+      (is (= 1 (rf.http.registry/issuance-counter-count))
           "the superseded attempt's eviction does NOT drop the live counter")
-      (is (= 3 (registry/next-issuance! rid))
+      (is (= 3 (rf.http.registry/next-issuance! rid))
           "the counter survived at 2, so the next issuance is 3 — no work-id collision")
       ;; The final live attempt terminates with the counter at its own issuance.
-      (registry/evict-issuance-on-completion! rid 3)
-      (is (zero? (registry/issuance-counter-count))
+      (rf.http.registry/evict-issuance-on-completion! rid 3)
+      (is (zero? (rf.http.registry/issuance-counter-count))
           "the id's final attempt evicts cleanly, bounding the map")))
   ;; A nil request-id never had a counter (anonymous requests stay at issuance 1
   ;; without touching the map) — eviction is a no-op.
-  (registry/reset-issuance-counters-for-test!)
-  (registry/evict-issuance-on-completion! nil 1)
-  (is (zero? (registry/issuance-counter-count))
+  (rf.http.registry/reset-issuance-counters-for-test!)
+  (rf.http.registry/evict-issuance-on-completion! nil 1)
+  (is (zero? (rf.http.registry/issuance-counter-count))
       "evicting a nil request-id is a no-op"))

--- a/implementation/http/test/re_frame/http_privacy_body_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_body_test.clj
@@ -24,9 +24,9 @@
   The schemas artefact is a test-only dep here, so requiring it binds the
   shared walker hooks (`:schemas/extract-sensitive-paths-from-schema` etc.)."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.http.privacy-body :as body]
+            [re-frame.http.privacy-body :as rf.http.privacy-body]
             ;; §7 unbinds the walker hooks to pin the fail-loud path.
-            [re-frame.late-bind :as late-bind]
+            [re-frame.late-bind :as rf.late-bind]
             ;; load-bearing: binds the shared schema walker hooks.
             [re-frame.schemas]))
 
@@ -38,20 +38,20 @@
 
 (deftest schema-decode?-distinguishes-schemas-from-modes-and-fns
   (testing "a Malli-schema :decode is a schema"
-    (is (body/schema-decode? [:map [:token :string]]))
-    (is (body/schema-decode? [:map [:a :int]])))
+    (is (rf.http.privacy-body/schema-decode? [:map [:token :string]]))
+    (is (rf.http.privacy-body/schema-decode? [:map [:a :int]])))
   (testing "keyword decode modes are NOT schemas"
-    (is (not (body/schema-decode? :auto)))
-    (is (not (body/schema-decode? :json)))
-    (is (not (body/schema-decode? :text)))
-    (is (not (body/schema-decode? :blob)))
-    (is (not (body/schema-decode? :array-buffer)))
-    (is (not (body/schema-decode? :form-data))))
+    (is (not (rf.http.privacy-body/schema-decode? :auto)))
+    (is (not (rf.http.privacy-body/schema-decode? :json)))
+    (is (not (rf.http.privacy-body/schema-decode? :text)))
+    (is (not (rf.http.privacy-body/schema-decode? :blob)))
+    (is (not (rf.http.privacy-body/schema-decode? :array-buffer)))
+    (is (not (rf.http.privacy-body/schema-decode? :form-data))))
   (testing "a custom decoder fn is NOT a schema"
-    (is (not (body/schema-decode? (fn [_text _headers] {}))))
-    (is (not (body/schema-decode? identity))))
+    (is (not (rf.http.privacy-body/schema-decode? (fn [_text _headers] {}))))
+    (is (not (rf.http.privacy-body/schema-decode? identity))))
   (testing "nil :decode (= :auto) is NOT a schema"
-    (is (not (body/schema-decode? nil)))))
+    (is (not (rf.http.privacy-body/schema-decode? nil)))))
 
 ;; ---- 2. per-slot marks → classify-decoded ---------------------------------
 
@@ -62,7 +62,7 @@
                    [:token {:sensitive? true} :string]
                    [:user-id :int]]
           decoded {:token "bearer-secret" :user-id 42}
-          out     (body/classify-decoded decoded schema)]
+          out     (rf.http.privacy-body/classify-decoded decoded schema)]
       (is (= :rf/redacted (:token out)))
       (is (= 42 (:user-id out)) "non-sensitive sibling rides verbatim"))))
 
@@ -73,7 +73,7 @@
                    [:profile [:map [:name :string]]]]
           decoded {:auth {:refresh-token "rt-secret"}
                    :profile {:name "Ada"}}
-          out     (body/classify-decoded decoded schema)]
+          out     (rf.http.privacy-body/classify-decoded decoded schema)]
       (is (= :rf/redacted (get-in out [:auth :refresh-token])))
       (is (= "Ada" (get-in out [:profile :name]))))))
 
@@ -81,16 +81,16 @@
   (testing "a schema with no :sensitive? marks leaves the body unchanged"
     (let [schema  [:map [:a :int] [:b :string]]
           decoded {:a 1 :b "x"}]
-      (is (= decoded (body/classify-decoded decoded schema))))))
+      (is (= decoded (rf.http.privacy-body/classify-decoded decoded schema))))))
 
 (deftest classify-decoded-non-schema-is-noop
   (testing "a keyword / fn / nil :decode is a no-op (body governed by the
             per-call flag / off-box disposition, not per-slot marks)"
     (let [decoded {:token "secret"}]
-      (is (= decoded (body/classify-decoded decoded :json)))
-      (is (= decoded (body/classify-decoded decoded :auto)))
-      (is (= decoded (body/classify-decoded decoded nil)))
-      (is (= decoded (body/classify-decoded decoded (fn [_ _] {})))))))
+      (is (= decoded (rf.http.privacy-body/classify-decoded decoded :json)))
+      (is (= decoded (rf.http.privacy-body/classify-decoded decoded :auto)))
+      (is (= decoded (rf.http.privacy-body/classify-decoded decoded nil)))
+      (is (= decoded (rf.http.privacy-body/classify-decoded decoded (fn [_ _] {})))))))
 
 ;; ---- 3. whole-body root prop ----------------------------------------------
 
@@ -99,24 +99,24 @@
             WHOLE body sensitive (the opaque-token-response case)"
     (let [schema  [:string {:sensitive? true}]
           decoded "opaque-token-value"]
-      (is (= :rf/redacted (body/classify-decoded decoded schema))))))
+      (is (= :rf/redacted (rf.http.privacy-body/classify-decoded decoded schema))))))
 
 ;; ---- 4. off-box disposition (fail-closed) ---------------------------------
 
 (deftest off-box-disposition-classifies-schema-bodies
   (testing "a schema-:decode body is :classify off-box"
-    (is (= :classify (body/off-box-body-disposition [:map [:a :int]])))
-    (is (= :classify (body/off-box-body-disposition [:string {:sensitive? true}])))))
+    (is (= :classify (rf.http.privacy-body/off-box-body-disposition [:map [:a :int]])))
+    (is (= :classify (rf.http.privacy-body/off-box-body-disposition [:string {:sensitive? true}])))))
 
 (deftest off-box-disposition-omits-unschematized-bodies
   (testing "an UNSCHEMATIZED body (keyword mode / custom fn / nil) is :omit
             off-box — whole-sensitive, fail-closed (EP-0015 issue 5)"
-    (is (= :omit (body/off-box-body-disposition :auto)))
-    (is (= :omit (body/off-box-body-disposition :json)))
-    (is (= :omit (body/off-box-body-disposition :text)))
-    (is (= :omit (body/off-box-body-disposition :blob)))
-    (is (= :omit (body/off-box-body-disposition nil)))
-    (is (= :omit (body/off-box-body-disposition (fn [_ _] {}))))))
+    (is (= :omit (rf.http.privacy-body/off-box-body-disposition :auto)))
+    (is (= :omit (rf.http.privacy-body/off-box-body-disposition :json)))
+    (is (= :omit (rf.http.privacy-body/off-box-body-disposition :text)))
+    (is (= :omit (rf.http.privacy-body/off-box-body-disposition :blob)))
+    (is (= :omit (rf.http.privacy-body/off-box-body-disposition nil)))
+    (is (= :omit (rf.http.privacy-body/off-box-body-disposition (fn [_ _] {}))))))
 
 (deftest off-box-disposition-omits-opaque-registry-ref
   (testing "an OPAQUE keyword registry-ref :decode is :omit off-box — the
@@ -127,8 +127,8 @@
     ;; A bare keyword that is NOT a known decode mode is taken by
     ;; `schema-decode?` as a registry ref — but the walker can only
     ;; introspect the VECTOR form. Off-box it must fail closed.
-    (is (= :omit (body/off-box-body-disposition :my-app/token-schema)))
-    (is (= :omit (body/off-box-body-disposition :user/profile)))))
+    (is (= :omit (rf.http.privacy-body/off-box-body-disposition :my-app/token-schema)))
+    (is (= :omit (rf.http.privacy-body/off-box-body-disposition :user/profile)))))
 
 (deftest off-box-disposition-omits-opaque-compiled-schema
   (testing "an OPAQUE non-vector schema value (a compiled m/schema object /
@@ -136,7 +136,7 @@
             the walker cannot introspect it, so fail-closed (rf2-y1pgdl)"
     ;; A map (or any non-vector, non-keyword decode value the walker treats
     ;; as an opaque leaf returning {}) must NOT ride :classify off-box.
-    (is (= :omit (body/off-box-body-disposition {:opaque :compiled-schema-stand-in})))))
+    (is (= :omit (rf.http.privacy-body/off-box-body-disposition {:opaque :compiled-schema-stand-in})))))
 
 ;; ---- 5. per-slot :large? elision (rf2-jhyccs) -----------------------------
 
@@ -148,7 +148,7 @@
                    [:blob {:large? true} :string]
                    [:user-id :int]]
           decoded {:blob (apply str (repeat 100 "x")) :user-id 42}
-          out     (body/classify-decoded decoded schema)]
+          out     (rf.http.privacy-body/classify-decoded decoded schema)]
       (is (contains? (:blob out) :rf.size/large-elided)
           "large body slot elided to the size marker")
       (is (= 42 (:user-id out)) "non-large sibling rides verbatim"))))
@@ -158,7 +158,7 @@
             WHOLE body to the size marker"
     (let [schema  [:string {:large? true}]
           decoded (apply str (repeat 200 "y"))
-          out     (body/classify-decoded decoded schema)]
+          out     (rf.http.privacy-body/classify-decoded decoded schema)]
       (is (contains? out :rf.size/large-elided)))))
 
 (deftest classify-decoded-sensitive-wins-over-large
@@ -167,7 +167,7 @@
     (let [schema  [:map
                    [:secret {:sensitive? true :large? true} :string]]
           decoded {:secret (apply str (repeat 100 "z"))}
-          out     (body/classify-decoded decoded schema)]
+          out     (rf.http.privacy-body/classify-decoded decoded schema)]
       (is (= :rf/redacted (:secret out))
           "sensitive wins — the slot is redacted, not a large marker"))))
 
@@ -190,14 +190,14 @@
   [f]
   (let [hook-keys [:schemas/extract-sensitive-paths-from-schema
                    :schemas/extract-large-paths-from-schema]
-        saved     (select-keys @late-bind/hooks hook-keys)
-        refresh!  #(doseq [k hook-keys] (late-bind/invalidate-cache! k))]
+        saved     (select-keys @rf.late-bind/hooks hook-keys)
+        refresh!  #(doseq [k hook-keys] (rf.late-bind/invalidate-cache! k))]
     (try
-      (swap! late-bind/hooks #(apply dissoc % hook-keys))
+      (swap! rf.late-bind/hooks #(apply dissoc % hook-keys))
       (refresh!)
       (f)
       (finally
-        (swap! late-bind/hooks merge saved)
+        (swap! rf.late-bind/hooks merge saved)
         (refresh!)))))
 
 (deftest unbound-walker-throws-for-a-mark-declaring-schema
@@ -207,7 +207,7 @@
     (with-walker-unbound
       (fn []
         (let [thrown (is (thrown? clojure.lang.ExceptionInfo
-                                  (body/classify-decoded
+                                  (rf.http.privacy-body/classify-decoded
                                     {:token "bearer-secret"}
                                     [:map [:token {:sensitive? true} :string]])))]
           (is (= :rf.error/schemas-artefact-missing (:rf.error/id (ex-data thrown)))
@@ -223,7 +223,7 @@
     (with-walker-unbound
       (fn []
         (is (thrown? clojure.lang.ExceptionInfo
-                     (body/classify-decoded
+                     (rf.http.privacy-body/classify-decoded
                        {:blob "huge"}
                        [:map [:blob {:large? true} :string]])))))))
 
@@ -233,10 +233,10 @@
     (with-walker-unbound
       (fn []
         (is (= {:id 1 :title "t"}
-               (body/classify-decoded {:id 1 :title "t"}
+               (rf.http.privacy-body/classify-decoded {:id 1 :title "t"}
                                       [:map [:id :int] [:title :string]])))
         (is (= {:sensitive {} :large {}}
-               (body/decode-schema-marks [:map [:id :int]])))))))
+               (rf.http.privacy-body/decode-schema-marks [:map [:id :int]])))))))
 
 (deftest unbound-walker-is-silent-for-a-field-merely-named-sensitive
   (testing "the probe reads PROPS, not field names — a schema with a field
@@ -244,7 +244,7 @@
     (with-walker-unbound
       (fn []
         (is (= {:sensitive? true}
-               (body/classify-decoded {:sensitive? true}
+               (rf.http.privacy-body/classify-decoded {:sensitive? true}
                                       [:map [:sensitive? :boolean]])))))))
 
 (deftest unbound-walker-is-silent-for-an-opaque-schema
@@ -253,13 +253,13 @@
             unbound hook is not an error"
     (with-walker-unbound
       (fn []
-        (is (= {:a 1} (body/classify-decoded {:a 1} :user/profile)))
-        (is (= {:a 1} (body/classify-decoded {:a 1} {:opaque :compiled})))))))
+        (is (= {:a 1} (rf.http.privacy-body/classify-decoded {:a 1} :user/profile)))
+        (is (= {:a 1} (rf.http.privacy-body/classify-decoded {:a 1} {:opaque :compiled})))))))
 
 (deftest bound-walker-still-classifies-the-mark-declaring-schema
   (testing "control for the four above — with the walker BOUND the same
             mark-declaring schema classifies rather than throwing, so the
             throw is about the unbound hook and not about the schema"
     (is (= {:token :rf/redacted}
-           (body/classify-decoded {:token "bearer-secret"}
+           (rf.http.privacy-body/classify-decoded {:token "bearer-secret"}
                                   [:map [:token {:sensitive? true} :string]])))))

--- a/implementation/http/test/re_frame/http_privacy_integration_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_integration_test.clj
@@ -16,14 +16,14 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.http.managed :as http-managed]
+            [re-frame.fx :as rf.fx]
+            [re-frame.http.managed :as rf.http.managed]
             ;; load-bearing: binds the shared schema walker hooks the
             ;; `:decode`-schema redaction/elision path late-binds (rf2-zvbm9).
             [re-frame.schemas]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace])
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace])
   (:import [com.sun.net.httpserver HttpServer HttpHandler HttpExchange]
            [java.net InetSocketAddress]))
 
@@ -35,7 +35,7 @@
 ;; them between tests (it also clears trace listeners, so no explicit
 ;; clear-listeners! is needed).
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- a tiny in-process HTTP server ----------------------------------------
 
@@ -61,7 +61,7 @@
   "Thin alias over `test-support/poll-until` (rf2-fun38) — preserves
   the per-file arity (`pred`, `timeout-ms`)."
   [pred timeout-ms]
-  (test-support/poll-until pred {:timeout-ms timeout-ms
+  (rf.test-support/poll-until pred {:timeout-ms timeout-ms
                                  :label "http-privacy wait-for"}))
 
 (defn- find-header
@@ -96,7 +96,7 @@
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
 
         (rf/reg-event :api/fetch
@@ -132,7 +132,7 @@
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
 
         (rf/reg-event :api/fetch
@@ -170,7 +170,7 @@
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
 
         (rf/reg-event :api/fetch
@@ -202,9 +202,9 @@
             extends header redaction to app-defined names"
     ;; EP-0025 — re-register :rf.http/managed with the app's :carriers block;
     ;; the redactor unions it onto the immutable defaults at trace egress.
-    (fx/reg-fx :rf.http/managed
+    (rf.fx/reg-fx :rf.http/managed
       {:carriers {:headers ["X-Honeycomb-Team"]}}
-      http-managed/managed-handler)
+      rf.http.managed/managed-handler)
     (let [srv (start-server!
                 (fn [^HttpExchange ex]
                   (-> ex .getResponseHeaders (.set "X-Honeycomb-Team" "hc-token"))
@@ -212,7 +212,7 @@
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
 
         (rf/reg-event :api/fetch
@@ -247,7 +247,7 @@
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
 
         (rf/reg-event :api/fetch
@@ -288,7 +288,7 @@
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
 
         (rf/reg-event :auth/login
@@ -322,16 +322,16 @@
   (testing "a :rf.http/managed :carriers {:query-params [..]} carrier
             (EP-0025) extends URL redaction to app-defined params"
     ;; EP-0025 — re-register :rf.http/managed with the app's query-param carrier.
-    (fx/reg-fx :rf.http/managed
+    (rf.fx/reg-fx :rf.http/managed
       {:carriers {:query-params ["shop_token"]}}
-      http-managed/managed-handler)
+      rf.http.managed/managed-handler)
     (let [srv (start-server!
                 (fn [^HttpExchange ex]
                   (write-response! ex 500 "text/plain" "boom")))
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
 
         (rf/reg-event :api/fetch
@@ -370,7 +370,7 @@
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
         ;; The :decode schema is the owner's declaration: [:token] is
         ;; sensitive, [:user-id] is not. No per-call :sensitive? flag.
@@ -409,7 +409,7 @@
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
         (rf/reg-event :auth/refresh
           (fn [_ _]
@@ -443,7 +443,7 @@
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
         (rf/reg-event :api/big
           (fn [_ _]
@@ -484,7 +484,7 @@
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
         ;; No :decode ⇒ :auto ⇒ unschematized ⇒ off-box :omit.
         (rf/reg-event :api/opaque
@@ -520,7 +520,7 @@
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
         (rf/reg-event :api/login
           (fn [_ _]
@@ -580,7 +580,7 @@
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
         ;; NO per-call :sensitive? flag — the disposition-5 fix must fire anyway.
         (rf/reg-event :api/fetch
@@ -616,7 +616,7 @@
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
         (rf/reg-event :api/fetch
           (fn [_ _]
@@ -651,7 +651,7 @@
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
         ;; :json decode of a non-JSON body throws → :rf.http/decode-failure.
         (rf/reg-event :api/fetch
@@ -702,7 +702,7 @@
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
         (rf/reg-event :api/login
           (fn [_ _]
@@ -759,7 +759,7 @@
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
         (rf/reg-event :api/login
           (fn [_ _]
@@ -827,7 +827,7 @@
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
         (rf/reg-event :api/meta-load
           (fn [{:keys [db]} [_ msg reply]]
@@ -862,9 +862,9 @@
             redacted at [:tags :meta :headers] on the :rf.http/replied trace
             (union onto the immutable defaults), while the delivered reply
             keeps it raw"
-    (fx/reg-fx :rf.http/managed
+    (rf.fx/reg-fx :rf.http/managed
       {:carriers {:headers ["X-Honeycomb-Team"]}}
-      http-managed/managed-handler)
+      rf.http.managed/managed-handler)
     (let [srv (start-server!
                 (fn [^HttpExchange ex]
                   (-> ex .getResponseHeaders (.set "X-Honeycomb-Team" "hc-token"))
@@ -872,7 +872,7 @@
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
         (rf/reg-event :api/carrier-load
           (fn [{:keys [db]} [_ msg reply]]
@@ -905,7 +905,7 @@
           port (:port srv)
           captured (atom [])]
       (try
-        (trace/register-listener! :test/capture
+        (rf.trace/register-listener! :test/capture
                                   (fn [ev] (swap! captured conj ev)))
         (rf/reg-event :api/sensitive-load
           (fn [{:keys [db]} [_ msg reply]]

--- a/implementation/http/test/re_frame/http_privacy_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_test.clj
@@ -20,14 +20,14 @@
   `re-frame.http-privacy-integration-test`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.http.privacy :as privacy]
-            [re-frame.http.privacy-headers :as headers]
-            [re-frame.http.url :as url]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]
-            [re-frame.test-support :as test-support]))
+            [re-frame.fx :as rf.fx]
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.privacy :as rf.http.privacy]
+            [re-frame.http.privacy-headers :as rf.http.privacy-headers]
+            [re-frame.http.url :as rf.http.url]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; The privacy suite is pure-fn (no dispatch), but registers events / fx
 ;; directly and asserts against a DELIBERATELY clean event + fx registry
@@ -37,47 +37,47 @@
 ;; per-test registrations back on the way out. No adapter is installed — the
 ;; suite needs no app-db / frame.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:clear-kinds [:event :fx]}))
+  (rf.test-support/make-reset-runtime-fixture {:clear-kinds [:event :fx]}))
 
 ;; ---- 1. header denylist ---------------------------------------------------
 
 (deftest default-header-denylist-covers-canonical-set
   (testing "the default denylist contains the canonical bearer / auth surface"
-    (is (contains? headers/default-header-denylist "authorization"))
-    (is (contains? headers/default-header-denylist "cookie"))
-    (is (contains? headers/default-header-denylist "set-cookie"))
-    (is (contains? headers/default-header-denylist "x-api-key"))
-    (is (contains? headers/default-header-denylist "x-auth-token"))
-    (is (contains? headers/default-header-denylist "x-csrf-token"))
-    (is (contains? headers/default-header-denylist "proxy-authorization"))))
+    (is (contains? rf.http.privacy-headers/default-header-denylist "authorization"))
+    (is (contains? rf.http.privacy-headers/default-header-denylist "cookie"))
+    (is (contains? rf.http.privacy-headers/default-header-denylist "set-cookie"))
+    (is (contains? rf.http.privacy-headers/default-header-denylist "x-api-key"))
+    (is (contains? rf.http.privacy-headers/default-header-denylist "x-auth-token"))
+    (is (contains? rf.http.privacy-headers/default-header-denylist "x-csrf-token"))
+    (is (contains? rf.http.privacy-headers/default-header-denylist "proxy-authorization"))))
 
 (deftest sensitive-header-is-case-insensitive
   (testing "header-name match ignores case"
-    (is (headers/sensitive-header? "Authorization"))
-    (is (headers/sensitive-header? "AUTHORIZATION"))
-    (is (headers/sensitive-header? "authorization"))
-    (is (headers/sensitive-header? "Cookie"))
-    (is (headers/sensitive-header? "X-API-Key"))))
+    (is (rf.http.privacy-headers/sensitive-header? "Authorization"))
+    (is (rf.http.privacy-headers/sensitive-header? "AUTHORIZATION"))
+    (is (rf.http.privacy-headers/sensitive-header? "authorization"))
+    (is (rf.http.privacy-headers/sensitive-header? "Cookie"))
+    (is (rf.http.privacy-headers/sensitive-header? "X-API-Key"))))
 
 (deftest non-sensitive-headers-pass
   (testing "ordinary headers are not in the denylist"
-    (is (not (headers/sensitive-header? "Content-Type")))
-    (is (not (headers/sensitive-header? "Accept")))
-    (is (not (headers/sensitive-header? "User-Agent")))
-    (is (not (headers/sensitive-header? "X-Request-Id")))))
+    (is (not (rf.http.privacy-headers/sensitive-header? "Content-Type")))
+    (is (not (rf.http.privacy-headers/sensitive-header? "Accept")))
+    (is (not (rf.http.privacy-headers/sensitive-header? "User-Agent")))
+    (is (not (rf.http.privacy-headers/sensitive-header? "X-Request-Id")))))
 
 (deftest carrier-extras-extend-header-denylist
   (testing "app-declared header carriers compose with defaults"
     (let [extras #{"x-honeycomb-team"}]
-      (is (headers/sensitive-header? "X-Honeycomb-Team" extras))
-      (is (headers/sensitive-header? "x-honeycomb-team" extras))
+      (is (rf.http.privacy-headers/sensitive-header? "X-Honeycomb-Team" extras))
+      (is (rf.http.privacy-headers/sensitive-header? "x-honeycomb-team" extras))
       ;; defaults still apply with extras present
-      (is (headers/sensitive-header? "Authorization" extras))
+      (is (rf.http.privacy-headers/sensitive-header? "Authorization" extras))
       ;; absent extras → only the built-in defaults apply
-      (is (not (headers/sensitive-header? "X-Honeycomb-Team")))
-      (is (not (headers/sensitive-header? "X-Honeycomb-Team" nil)))
+      (is (not (rf.http.privacy-headers/sensitive-header? "X-Honeycomb-Team")))
+      (is (not (rf.http.privacy-headers/sensitive-header? "X-Honeycomb-Team" nil)))
       ;; defaults are immutable — they apply regardless of extras
-      (is (headers/sensitive-header? "Authorization")))))
+      (is (rf.http.privacy-headers/sensitive-header? "Authorization")))))
 
 (deftest carrier-cannot-remove-a-built-in-header-default
   (testing "EP-0025 — the built-in header denylist is IMMUTABLE: an app's
@@ -94,16 +94,16 @@
           extras-unrelated          #{"x-honeycomb-team"}
           extras-empty              #{}]
       (doseq [extras [extras-redeclaring-default extras-unrelated extras-empty nil]]
-        (is (headers/sensitive-header? "Authorization" extras)
+        (is (rf.http.privacy-headers/sensitive-header? "Authorization" extras)
             "the built-in Authorization default survives every carrier extras shape")
-        (is (headers/sensitive-header? "Cookie" extras)
+        (is (rf.http.privacy-headers/sensitive-header? "Cookie" extras)
             "the built-in Cookie default survives every carrier extras shape")
-        (is (headers/sensitive-header? "Set-Cookie" extras)
+        (is (rf.http.privacy-headers/sensitive-header? "Set-Cookie" extras)
             "the built-in Set-Cookie default survives every carrier extras shape"))
       ;; redact-headers (the egress chokepoint) honours the same immutability:
       ;; a built-in default value is scrubbed even when the app supplies
       ;; unrelated extras.
-      (let [r (headers/redact-headers
+      (let [r (rf.http.privacy-headers/redact-headers
                 {"Authorization" "Bearer abc" "X-Honeycomb-Team" "team-1" "Accept" "json"}
                 extras-unrelated)]
         (is (= :rf/redacted (get r "Authorization")) "built-in default still redacted")
@@ -112,9 +112,9 @@
 
 (deftest sensitive-header-tolerates-non-string
   (testing "nil / non-string is not sensitive"
-    (is (not (headers/sensitive-header? nil)))
-    (is (not (headers/sensitive-header? :keyword)))
-    (is (not (headers/sensitive-header? 42)))))
+    (is (not (rf.http.privacy-headers/sensitive-header? nil)))
+    (is (not (rf.http.privacy-headers/sensitive-header? :keyword)))
+    (is (not (rf.http.privacy-headers/sensitive-header? 42)))))
 
 ;; ---- 2. redact-headers ----------------------------------------------------
 
@@ -124,22 +124,22 @@
              "Content-Type"  "application/json"
              "Cookie"        "session=secret"
              "X-Request-Id"  "req-42"}
-          r (headers/redact-headers m)]
+          r (rf.http.privacy-headers/redact-headers m)]
       (is (= :rf/redacted (get r "Authorization")))
       (is (= :rf/redacted (get r "Cookie")))
       (is (= "application/json" (get r "Content-Type")))
       (is (= "req-42" (get r "X-Request-Id"))))))
 
 (deftest redact-headers-handles-empty-and-nil
-  (is (nil? (headers/redact-headers nil)))
-  (is (= {} (headers/redact-headers {}))))
+  (is (nil? (rf.http.privacy-headers/redact-headers nil)))
+  (is (= {} (rf.http.privacy-headers/redact-headers {}))))
 
 (deftest redact-headers-handles-mixed-case-keys
   (testing "header-name match ignores case on the map key"
     (let [m {"AUTHORIZATION" "Bearer xyz"
              "set-cookie"    "id=1"
              "Set-cookie"    "id=2"}
-          r (headers/redact-headers m)]
+          r (rf.http.privacy-headers/redact-headers m)]
       (is (= :rf/redacted (get r "AUTHORIZATION")))
       (is (= :rf/redacted (get r "set-cookie")))
       (is (= :rf/redacted (get r "Set-cookie"))))))
@@ -155,7 +155,7 @@
     (let [m {"Authorization" ["Bearer one" "Bearer two"]
              "Cookie"        ["a=1" "b=2"]
              "X-Multi"       ["keep-1" "keep-2"]}
-          r (headers/redact-headers m)]
+          r (rf.http.privacy-headers/redact-headers m)]
       (is (= :rf/redacted (get r "Authorization"))
           "the entire vector value is replaced by the sentinel — no element leaks")
       (is (= :rf/redacted (get r "Cookie")))
@@ -166,17 +166,17 @@
 
 (deftest request-sensitive-per-call-true
   (testing "per-call :sensitive? on the args map opts in"
-    (is (true? (privacy/request-sensitive? {:sensitive? true :request {:url "/x"}})))))
+    (is (true? (rf.http.privacy/request-sensitive? {:sensitive? true :request {:url "/x"}})))))
 
 (deftest request-sensitive-per-request-true
   (testing "per-request :sensitive? on the :request map opts in"
-    (is (true? (privacy/request-sensitive? {:request {:url "/x" :sensitive? true}})))))
+    (is (true? (rf.http.privacy/request-sensitive? {:request {:url "/x" :sensitive? true}})))))
 
 (deftest request-sensitive-default-false
   (testing "no per-call flag = not sensitive; sensitivity is a per-call
             decision and the fn has no other input to read"
-    (is (false? (privacy/request-sensitive? {:request {:url "/x"}})))
-    (is (false? (privacy/request-sensitive? {})))))
+    (is (false? (rf.http.privacy/request-sensitive? {:request {:url "/x"}})))
+    (is (false? (rf.http.privacy/request-sensitive? {})))))
 
 ;; ---- 4. redact-request-tags ----------------------------------------------
 
@@ -185,46 +185,46 @@
     (let [tags  {:url "/x"
                  :headers {"Authorization" "Bearer t"
                            "Content-Type"  "application/json"}}
-          r     (privacy/redact-request-tags tags false)]
+          r     (rf.http.privacy/redact-request-tags tags false)]
       (is (= :rf/redacted (get-in r [:headers "Authorization"])))
       (is (= "application/json" (get-in r [:headers "Content-Type"]))))))
 
 (deftest redact-request-tags-redacts-body-when-sensitive
   (testing "body redacted when sensitive? is true"
     (let [tags {:url "/x" :body "{user: ada}"}
-          r    (privacy/redact-request-tags tags true)]
+          r    (rf.http.privacy/redact-request-tags tags true)]
       (is (= :rf/redacted (:body r))))
     (testing "body preserved when sensitive? is false"
       (let [tags {:url "/x" :body "regular payload"}
-            r    (privacy/redact-request-tags tags false)]
+            r    (rf.http.privacy/redact-request-tags tags false)]
         (is (= "regular payload" (:body r)))))))
 
 (deftest redact-request-tags-redacts-params-when-sensitive
   (testing "query-string params redacted when sensitive? is true"
     (let [tags {:url "/x" :params {:token "abc123"}}
-          r    (privacy/redact-request-tags tags true)]
+          r    (rf.http.privacy/redact-request-tags tags true)]
       (is (= :rf/redacted (:params r))))))
 
 ;; ---- 5. redact-failure ---------------------------------------------------
 
 (deftest redact-failure-redacts-response-body-when-sensitive
   (let [f {:kind :rf.http/http-4xx :status 401 :body "{password: shhh}"}
-        r (privacy/redact-failure f true)]
+        r (rf.http.privacy/redact-failure f true)]
     (is (= :rf/redacted (:body r)))))
 
 (deftest redact-failure-redacts-decode-failure-body-text
   (let [f {:kind :rf.http/decode-failure :body-text "raw secret"}
-        r (privacy/redact-failure f true)]
+        r (rf.http.privacy/redact-failure f true)]
     (is (= :rf/redacted (:body-text r)))))
 
 (deftest redact-failure-redacts-accept-failure-detail
   (let [f {:kind :rf.http/accept-failure :detail {:user-id 1 :pii "..."}}
-        r (privacy/redact-failure f true)]
+        r (rf.http.privacy/redact-failure f true)]
     (is (= :rf/redacted (:detail r)))))
 
 (deftest redact-failure-preserves-when-not-sensitive
   (let [f {:kind :rf.http/http-4xx :status 401 :body "{password: shhh}"}
-        r (privacy/redact-failure f false)]
+        r (rf.http.privacy/redact-failure f false)]
     (is (= "{password: shhh}" (:body r)))))
 
 (deftest redact-failure-always-redacts-headers
@@ -233,12 +233,12 @@
              :status 401
              :headers {"Set-Cookie" "id=secret"
                        "Content-Type" "text/plain"}}
-          r (privacy/redact-failure f false)]
+          r (rf.http.privacy/redact-failure f false)]
       (is (= :rf/redacted (get-in r [:headers "Set-Cookie"])))
       (is (= "text/plain" (get-in r [:headers "Content-Type"]))))))
 
 (deftest redact-failure-tolerates-nil
-  (is (nil? (privacy/redact-failure nil true))))
+  (is (nil? (rf.http.privacy/redact-failure nil true))))
 
 ;; rf2-eusm1 — an interceptor-failure trace carries the interceptor's
 ;; thrown message at :cause; it is author-controlled free text and can
@@ -249,7 +249,7 @@
     (let [f {:kind :rf.error/http-interceptor-failed
              :interceptor-id :auth/check
              :cause "token validation failed for Bearer sk-live-abc123"}
-          r (privacy/redact-failure f true)]
+          r (rf.http.privacy/redact-failure f true)]
       (is (= :rf/redacted (:cause r))
           "the interceptor's thrown message must not ride the trace surface verbatim"))))
 
@@ -258,7 +258,7 @@
     (let [f {:kind :rf.error/http-interceptor-failed
              :interceptor-id :auth/check
              :cause "interceptor :auth/check :before threw"}
-          r (privacy/redact-failure f false)]
+          r (rf.http.privacy/redact-failure f false)]
       (is (= "interceptor :auth/check :before threw" (:cause r))))))
 
 (deftest redact-failure-preserves-keyword-cause-discriminator
@@ -266,7 +266,7 @@
             security-relevant signal, NOT secret payload — preserved even
             when sensitive"
     (let [f {:kind :rf.http/decode-failure :cause :too-many-keys :body-text "raw"}
-          r (privacy/redact-failure f true)]
+          r (rf.http.privacy/redact-failure f true)]
       (is (= :too-many-keys (:cause r))
           "the keyword discriminator must survive — it is the signal, not the secret")
       (is (= :rf/redacted (:body-text r))
@@ -276,11 +276,11 @@
 
 (deftest stamp-sensitive-adds-flag-when-true
   (is (= {:foo 1 :sensitive? true}
-         (privacy/stamp-sensitive {:foo 1} true))))
+         (rf.http.privacy/stamp-sensitive {:foo 1} true))))
 
 (deftest stamp-sensitive-omits-when-false
   (is (= {:foo 1}
-         (privacy/stamp-sensitive {:foo 1} false))))
+         (rf.http.privacy/stamp-sensitive {:foo 1} false))))
 
 ;; ---- 7. prepare-emit-tags / prepare-emit-failure -------------------------
 
@@ -291,14 +291,14 @@
                 :headers {"Authorization" "Bearer t"}
                 :failure {:kind :rf.http/http-5xx
                           :body "secret"}}
-          r    (privacy/prepare-emit-tags tags true)]
+          r    (rf.http.privacy/prepare-emit-tags tags true)]
       (is (= :rf/redacted (get-in r [:headers "Authorization"])))
       (is (= :rf/redacted (get-in r [:failure :body])))
       (is (true? (:sensitive? r))))))
 
 (deftest prepare-emit-tags-omits-flag-when-not-sensitive
   (let [tags {:request-id :r/x :url "/x"}
-        r    (privacy/prepare-emit-tags tags false)]
+        r    (rf.http.privacy/prepare-emit-tags tags false)]
     (is (not (contains? r :sensitive?)))))
 
 (deftest prepare-emit-failure-composes-correctly
@@ -306,7 +306,7 @@
                  :status 500
                  :body "internal user data"
                  :headers {"Set-Cookie" "id=42"}}
-        r       (privacy/prepare-emit-failure failure true)]
+        r       (rf.http.privacy/prepare-emit-failure failure true)]
     (is (= :rf/redacted (:body r)))
     (is (= :rf/redacted (get-in r [:headers "Set-Cookie"])))
     (is (true? (:sensitive? r)))))
@@ -329,7 +329,7 @@
                              :body    {:password "hunter2" :email "a@b.c"}}
                 :sensitive? true
                 :decode     :json}
-          r    (privacy/project-managed-fx-args args)]
+          r    (rf.http.privacy/project-managed-fx-args args)]
       (is (= :rf/redacted (get-in r [:request :body]))
           "the whole body redacts on a sensitive request")
       (is (= :rf/redacted (get-in r [:request :headers "Authorization"]))
@@ -343,14 +343,14 @@
 
 (deftest project-managed-fx-args-respects-in-request-flag
   (testing "the per-request `[:request :sensitive?]` sugar redacts too"
-    (let [r (privacy/project-managed-fx-args
+    (let [r (rf.http.privacy/project-managed-fx-args
               {:request {:url "/login" :body {:pw "raw"} :sensitive? true}})]
       (is (= :rf/redacted (get-in r [:request :body]))))))
 
 (deftest project-managed-fx-args-not-sensitive-is-fail-open
   (testing "an unflagged request's body rides raw (per-call :sensitive? is the
             signal) while the denylisted header still redacts"
-    (let [r (privacy/project-managed-fx-args
+    (let [r (rf.http.privacy/project-managed-fx-args
               {:request {:url     "/user"
                          :headers {"Cookie" "id=42"}
                          :body    {:note "plain"}}})]
@@ -359,62 +359,62 @@
 
 (deftest project-managed-fx-args-tolerates-non-map
   (testing "a non-map args value passes through untouched"
-    (is (= :not-a-map (privacy/project-managed-fx-args :not-a-map)))
-    (is (nil? (privacy/project-managed-fx-args nil)))))
+    (is (= :not-a-map (rf.http.privacy/project-managed-fx-args :not-a-map)))
+    (is (nil? (rf.http.privacy/project-managed-fx-args nil)))))
 
 (deftest project-managed-fx-args-hook-is-published
   (testing "re-frame.http.managed publishes the hook core's fx-args walk
             consults (load-time anchor)"
-    (is (fn? (late-bind/get-fn :http/project-managed-fx-args)))))
+    (is (fn? (rf.late-bind/get-fn :http/project-managed-fx-args)))))
 
 ;; ---- 8. query-param denylist (rf2-2p8wr) ----------------------------------
 
 (deftest default-query-param-denylist-covers-canonical-set
   (testing "the default denylist contains the canonical query-string-auth surface"
-    (is (contains? url/default-query-param-denylist "api_key"))
-    (is (contains? url/default-query-param-denylist "access_token"))
-    (is (contains? url/default-query-param-denylist "token"))
-    (is (contains? url/default-query-param-denylist "auth"))
-    (is (contains? url/default-query-param-denylist "key"))
-    (is (contains? url/default-query-param-denylist "secret"))
-    (is (contains? url/default-query-param-denylist "password"))
-    (is (contains? url/default-query-param-denylist "signature"))
-    (is (contains? url/default-query-param-denylist "session"))))
+    (is (contains? rf.http.url/default-query-param-denylist "api_key"))
+    (is (contains? rf.http.url/default-query-param-denylist "access_token"))
+    (is (contains? rf.http.url/default-query-param-denylist "token"))
+    (is (contains? rf.http.url/default-query-param-denylist "auth"))
+    (is (contains? rf.http.url/default-query-param-denylist "key"))
+    (is (contains? rf.http.url/default-query-param-denylist "secret"))
+    (is (contains? rf.http.url/default-query-param-denylist "password"))
+    (is (contains? rf.http.url/default-query-param-denylist "signature"))
+    (is (contains? rf.http.url/default-query-param-denylist "session"))))
 
 (deftest sensitive-query-param-is-case-insensitive
   (testing "param-name match ignores case"
-    (is (url/sensitive-query-param? "api_key"))
-    (is (url/sensitive-query-param? "API_KEY"))
-    (is (url/sensitive-query-param? "Api_Key"))
-    (is (url/sensitive-query-param? "access_token"))
-    (is (url/sensitive-query-param? "ACCESS_TOKEN"))))
+    (is (rf.http.url/sensitive-query-param? "api_key"))
+    (is (rf.http.url/sensitive-query-param? "API_KEY"))
+    (is (rf.http.url/sensitive-query-param? "Api_Key"))
+    (is (rf.http.url/sensitive-query-param? "access_token"))
+    (is (rf.http.url/sensitive-query-param? "ACCESS_TOKEN"))))
 
 (deftest non-sensitive-query-params-pass
   (testing "ordinary query params are not in the denylist"
-    (is (not (url/sensitive-query-param? "page")))
-    (is (not (url/sensitive-query-param? "limit")))
-    (is (not (url/sensitive-query-param? "q")))
-    (is (not (url/sensitive-query-param? "id")))
-    (is (not (url/sensitive-query-param? "user_id")))))
+    (is (not (rf.http.url/sensitive-query-param? "page")))
+    (is (not (rf.http.url/sensitive-query-param? "limit")))
+    (is (not (rf.http.url/sensitive-query-param? "q")))
+    (is (not (rf.http.url/sensitive-query-param? "id")))
+    (is (not (rf.http.url/sensitive-query-param? "user_id")))))
 
 (deftest carrier-extras-extend-query-param-denylist
   (testing "app-declared query-param carriers (EP-0025) compose with defaults"
     (let [extras #{"shop_token"}]
-      (is (url/sensitive-query-param? "shop_token" extras))
-      (is (url/sensitive-query-param? "SHOP_TOKEN" extras))
+      (is (rf.http.url/sensitive-query-param? "shop_token" extras))
+      (is (rf.http.url/sensitive-query-param? "SHOP_TOKEN" extras))
       ;; defaults still apply with extras present
-      (is (url/sensitive-query-param? "api_key" extras))
+      (is (rf.http.url/sensitive-query-param? "api_key" extras))
       ;; absent extras → only the built-in defaults apply
-      (is (not (url/sensitive-query-param? "shop_token")))
-      (is (not (url/sensitive-query-param? "shop_token" nil)))
+      (is (not (rf.http.url/sensitive-query-param? "shop_token")))
+      (is (not (rf.http.url/sensitive-query-param? "shop_token" nil)))
       ;; defaults are immutable — they apply regardless of extras
-      (is (url/sensitive-query-param? "api_key")))))
+      (is (rf.http.url/sensitive-query-param? "api_key")))))
 
 (deftest sensitive-query-param-tolerates-non-string
   (testing "nil / non-string is not sensitive"
-    (is (not (url/sensitive-query-param? nil)))
-    (is (not (url/sensitive-query-param? :keyword)))
-    (is (not (url/sensitive-query-param? 42)))))
+    (is (not (rf.http.url/sensitive-query-param? nil)))
+    (is (not (rf.http.url/sensitive-query-param? :keyword)))
+    (is (not (rf.http.url/sensitive-query-param? 42)))))
 
 ;; rf2-4wqxq8 — query-param policy MAP {:include :except}: an app can SUBTRACT a
 ;; built-in default (relaxing its OWN dev-trace friction over a harmless
@@ -425,38 +425,38 @@
   (testing "rf2-4wqxq8 — :except removes a built-in default for this app"
     (let [policy {:except #{"token"}}]
       ;; the excepted default is no longer sensitive
-      (is (not (url/sensitive-query-param? "token" policy)))
-      (is (not (url/sensitive-query-param? "TOKEN" policy)))
+      (is (not (rf.http.url/sensitive-query-param? "token" policy)))
+      (is (not (rf.http.url/sensitive-query-param? "TOKEN" policy)))
       ;; other defaults still apply
-      (is (url/sensitive-query-param? "api_key" policy))
-      (is (url/sensitive-query-param? "signature" policy))
+      (is (rf.http.url/sensitive-query-param? "api_key" policy))
+      (is (rf.http.url/sensitive-query-param? "signature" policy))
       ;; without the policy the default still redacts (subtraction is app-local)
-      (is (url/sensitive-query-param? "token")))))
+      (is (rf.http.url/sensitive-query-param? "token")))))
 
 (deftest query-param-policy-include-and-except-compose
   (testing "rf2-4wqxq8 — :include extends defaults; :except subtracts; both compose"
     (let [policy {:include #{"shop_token"} :except #{"token"}}]
-      (is (url/sensitive-query-param? "shop_token" policy)) ; included extension
-      (is (not (url/sensitive-query-param? "token" policy))) ; excepted default
-      (is (url/sensitive-query-param? "api_key" policy))     ; untouched default
-      (is (not (url/sensitive-query-param? "page" policy)))))) ; never sensitive
+      (is (rf.http.url/sensitive-query-param? "shop_token" policy)) ; included extension
+      (is (not (rf.http.url/sensitive-query-param? "token" policy))) ; excepted default
+      (is (rf.http.url/sensitive-query-param? "api_key" policy))     ; untouched default
+      (is (not (rf.http.url/sensitive-query-param? "page" policy)))))) ; never sensitive
 
 (deftest query-param-policy-include-wins-over-except
   (testing "rf2-4wqxq8 — a name in BOTH :include and :except stays sensitive"
     (let [policy {:include #{"token"} :except #{"token"}}]
-      (is (url/sensitive-query-param? "token" policy)
+      (is (rf.http.url/sensitive-query-param? "token" policy)
           "declaring a name sensitive is never undone by also excepting it"))))
 
 (deftest query-param-policy-empty-map-is-defaults-only
   (testing "rf2-4wqxq8 — an empty policy map behaves like defaults-only"
-    (is (url/sensitive-query-param? "api_key" {}))
-    (is (not (url/sensitive-query-param? "page" {})))))
+    (is (rf.http.url/sensitive-query-param? "api_key" {}))
+    (is (not (rf.http.url/sensitive-query-param? "page" {})))))
 
 (deftest redact-url-policy-except-leaves-default-param-visible
   (testing "rf2-4wqxq8 — end-to-end: :except keeps a default param's value
             visible in the app's own dev trace"
     (let [policy {:except #{"token"}}
-          [url any?] (url/redact-url-query-string
+          [url any?] (rf.http.url/redact-url-query-string
                        "https://api.example.com/list?token=abc&api_key=SECRET&page=2"
                        false policy)]
       ;; token is excepted → visible; api_key still a default → redacted
@@ -464,7 +464,7 @@
       (is (true? any?)))
     (testing "a sensitive? request still redacts EVERY param regardless of :except"
       (let [policy {:except #{"token"}}
-            [url _] (url/redact-url-query-string
+            [url _] (rf.http.url/redact-url-query-string
                       "https://api.example.com/list?token=abc&page=2"
                       true policy)]
         (is (= "https://api.example.com/list?token=:rf/redacted&page=:rf/redacted" url))))))
@@ -473,7 +473,7 @@
 
 (deftest redact-url-denylist-replaces-sensitive-values
   (testing "denylisted query-param values become :rf/redacted; non-denylisted preserved"
-    (let [[url any?] (url/redact-url-query-string
+    (let [[url any?] (rf.http.url/redact-url-query-string
                        "https://api.example.com/users?api_key=SECRET&page=2"
                        false)]
       (is (= "https://api.example.com/users?api_key=:rf/redacted&page=2" url))
@@ -481,7 +481,7 @@
 
 (deftest redact-url-sensitive-true-redacts-everything
   (testing "when sensitive? true, ALL params are redacted (broader rule)"
-    (let [[url any?] (url/redact-url-query-string
+    (let [[url any?] (rf.http.url/redact-url-query-string
                        "https://api.example.com/users?user_id=42&page=2&sort=asc"
                        true)]
       (is (= "https://api.example.com/users?user_id=:rf/redacted&page=:rf/redacted&sort=:rf/redacted"
@@ -490,39 +490,39 @@
 
 (deftest redact-url-no-query-string-unchanged
   (testing "URL with no query string returns unchanged"
-    (let [[url any?] (url/redact-url-query-string
+    (let [[url any?] (rf.http.url/redact-url-query-string
                        "https://api.example.com/users/42" false)]
       (is (= "https://api.example.com/users/42" url))
       (is (false? any?)))))
 
 (deftest redact-url-no-denylist-hit-unchanged
   (testing "URL with no denylisted params returns unchanged when not sensitive"
-    (let [[url any?] (url/redact-url-query-string
+    (let [[url any?] (rf.http.url/redact-url-query-string
                        "https://api.example.com/users?page=2&limit=10" false)]
       (is (= "https://api.example.com/users?page=2&limit=10" url))
       (is (false? any?)))))
 
 (deftest redact-url-preserves-fragment
   (testing "fragment is preserved verbatim after the redacted query string"
-    (let [[url _] (url/redact-url-query-string
+    (let [[url _] (rf.http.url/redact-url-query-string
                     "https://api.example.com/x?token=abc&page=2#section-3" false)]
       (is (= "https://api.example.com/x?token=:rf/redacted&page=2#section-3" url)))))
 
 (deftest redact-url-empty-value-redacted
   (testing "param with empty value still has the value slot replaced"
-    (let [[url _] (url/redact-url-query-string
+    (let [[url _] (rf.http.url/redact-url-query-string
                     "https://api.example.com/x?token=&page=2" false)]
       (is (= "https://api.example.com/x?token=:rf/redacted&page=2" url)))))
 
 (deftest redact-url-handles-url-encoded-values
   (testing "URL-encoded special chars in values are replaced wholesale, not parsed"
-    (let [[url _] (url/redact-url-query-string
+    (let [[url _] (rf.http.url/redact-url-query-string
                     "https://api.example.com/x?api_key=a%20b%26c&page=2" false)]
       (is (= "https://api.example.com/x?api_key=:rf/redacted&page=2" url)))))
 
 (deftest redact-url-multiple-denylist-hits
   (testing "all denylisted params in a URL are redacted"
-    (let [[url any?] (url/redact-url-query-string
+    (let [[url any?] (rf.http.url/redact-url-query-string
                        "https://api.example.com/x?api_key=A&token=B&page=2&secret=C" false)]
       (is (= "https://api.example.com/x?api_key=:rf/redacted&token=:rf/redacted&page=2&secret=:rf/redacted"
              url))
@@ -531,21 +531,21 @@
 (deftest redact-url-carrier-extras-denylist
   (testing "app-declared query-param carriers (EP-0025) apply on URL redaction"
     (let [extras #{"shop_token"}
-          [url _] (url/redact-url-query-string
+          [url _] (rf.http.url/redact-url-query-string
                     "https://api.example.com/x?shop_token=abc&page=2" false extras)]
       (is (= "https://api.example.com/x?shop_token=:rf/redacted&page=2" url)))
     ;; absent extras → only the built-in defaults redact
-    (let [[url _] (url/redact-url-query-string
+    (let [[url _] (rf.http.url/redact-url-query-string
                     "https://api.example.com/x?shop_token=abc&page=2" false)]
       (is (= "https://api.example.com/x?shop_token=abc&page=2" url)))))
 
 (deftest redact-url-tolerates-non-string
-  (is (= [nil false] (url/redact-url-query-string nil false)))
-  (is (= [42 false] (url/redact-url-query-string 42 false))))
+  (is (= [nil false] (rf.http.url/redact-url-query-string nil false)))
+  (is (= [42 false] (rf.http.url/redact-url-query-string 42 false))))
 
 (deftest redact-url-handles-malformed-pair
   (testing "param without `=` is not crashed on"
-    (let [[url _] (url/redact-url-query-string
+    (let [[url _] (rf.http.url/redact-url-query-string
                     "https://api.example.com/x?orphan&api_key=SECRET" false)]
       ;; The orphan is not in the denylist and is preserved; api_key is redacted.
       (is (= "https://api.example.com/x?orphan&api_key=:rf/redacted" url)))))
@@ -559,28 +559,28 @@
 
 (deftest redact-url-fragment-only-no-query
   (testing "URL with a fragment but no query string is returned unchanged"
-    (let [[url any?] (url/redact-url-query-string
+    (let [[url any?] (rf.http.url/redact-url-query-string
                        "https://api.example.com/x#section-3" false)]
       (is (= "https://api.example.com/x#section-3" url))
       (is (false? any?)))))
 
 (deftest redact-url-empty-query-string
   (testing "URL with `?` but no params is returned unchanged"
-    (let [[url any?] (url/redact-url-query-string
+    (let [[url any?] (rf.http.url/redact-url-query-string
                        "https://api.example.com/x?" false)]
       (is (= "https://api.example.com/x?" url))
       (is (false? any?)))))
 
 (deftest redact-url-denylisted-param-with-fragment
   (testing "denylisted param value redacted; fragment preserved verbatim"
-    (let [[url any?] (url/redact-url-query-string
+    (let [[url any?] (rf.http.url/redact-url-query-string
                        "https://api.example.com/x?api_key=SECRET#section-3" false)]
       (is (= "https://api.example.com/x?api_key=:rf/redacted#section-3" url))
       (is (true? any?)))))
 
 (deftest redact-url-empty-value-denylisted-param
   (testing "denylisted param with empty value still has value slot replaced"
-    (let [[url any?] (url/redact-url-query-string
+    (let [[url any?] (rf.http.url/redact-url-query-string
                        "https://api.example.com/x?api_key=&page=2" false)]
       (is (= "https://api.example.com/x?api_key=:rf/redacted&page=2" url))
       (is (true? any?)
@@ -588,7 +588,7 @@
 
 (deftest redact-url-sensitive-true-preserves-fragment
   (testing "sensitive? true redacts ALL params and still preserves the fragment"
-    (let [[url _] (url/redact-url-query-string
+    (let [[url _] (rf.http.url/redact-url-query-string
                     "https://api.example.com/x?user_id=42&page=2#section-3" true)]
       (is (= "https://api.example.com/x?user_id=:rf/redacted&page=:rf/redacted#section-3" url)))))
 
@@ -597,7 +597,7 @@
     ;; The fragment is verbatim everything after the first `#` — even if it
     ;; contains `=` or `&` that would look like query syntax. The splitter
     ;; uses index-of `#`, not regex; this asserts the round-trip is clean.
-    (let [[url _] (url/redact-url-query-string
+    (let [[url _] (rf.http.url/redact-url-query-string
                     "https://api.example.com/x?token=abc#k=v&also=x" false)]
       (is (= "https://api.example.com/x?token=:rf/redacted#k=v&also=x" url)))))
 
@@ -611,21 +611,21 @@
 (deftest redact-url-wrapper-returns-string
   (testing "redact-url returns only the redacted URL string (not the [url flag] tuple)"
     (is (= "https://api.example.com/x?api_key=:rf/redacted&page=2"
-           (url/redact-url
+           (rf.http.url/redact-url
              "https://api.example.com/x?api_key=SECRET&page=2" false))
         "denylist hit — value redacted")
     (is (= "https://api.example.com/x?page=2"
-           (url/redact-url
+           (rf.http.url/redact-url
              "https://api.example.com/x?page=2" false))
         "no denylist hit — unchanged")
     (is (= "https://api.example.com/x?user_id=:rf/redacted&page=:rf/redacted"
-           (url/redact-url
+           (rf.http.url/redact-url
              "https://api.example.com/x?user_id=42&page=2" true))
         "sensitive? true — all params redacted")
-    (is (nil? (url/redact-url nil false))
+    (is (nil? (rf.http.url/redact-url nil false))
         "nil input passes through")
     (is (= "https://api.example.com/x#frag"
-           (url/redact-url "https://api.example.com/x#frag" false))
+           (rf.http.url/redact-url "https://api.example.com/x#frag" false))
         "fragment-only URL passes through")))
 
 ;; ---- 10. redact-request-tags integrates URL redaction --------------------
@@ -633,13 +633,13 @@
 (deftest redact-request-tags-redacts-url-denylist-always
   (testing "URL with denylisted query param is redacted regardless of :sensitive?"
     (let [tags {:url "https://api.example.com/x?api_key=SECRET&page=2"}
-          r    (privacy/redact-request-tags tags false)]
+          r    (rf.http.privacy/redact-request-tags tags false)]
       (is (= "https://api.example.com/x?api_key=:rf/redacted&page=2" (:url r))))))
 
 (deftest redact-request-tags-redacts-all-params-when-sensitive
   (testing "URL gets ALL params redacted when sensitive? is true"
     (let [tags {:url "https://api.example.com/x?user_id=42&page=2"}
-          r    (privacy/redact-request-tags tags true)]
+          r    (rf.http.privacy/redact-request-tags tags true)]
       (is (= "https://api.example.com/x?user_id=:rf/redacted&page=:rf/redacted" (:url r))))))
 
 ;; ---- 11. redact-failure integrates URL redaction -------------------------
@@ -649,7 +649,7 @@
     (let [f {:kind :rf.http/http-5xx
              :status 500
              :url "https://api.example.com/x?token=abc&page=2"}
-          r (privacy/redact-failure f false)]
+          r (rf.http.privacy/redact-failure f false)]
       (is (= "https://api.example.com/x?token=:rf/redacted&page=2" (:url r))))))
 
 (deftest redact-failure-redacts-all-url-params-when-sensitive
@@ -657,7 +657,7 @@
     (let [f {:kind :rf.http/http-5xx
              :status 500
              :url "https://api.example.com/x?user_id=42&page=2"}
-          r (privacy/redact-failure f true)]
+          r (rf.http.privacy/redact-failure f true)]
       (is (= "https://api.example.com/x?user_id=:rf/redacted&page=:rf/redacted" (:url r))))))
 
 ;; ---- 12. prepare-emit-* stamps :sensitive? on denylist-only hit ----------
@@ -665,7 +665,7 @@
 (deftest prepare-emit-tags-stamps-sensitive-on-denylist-hit
   (testing "denylisted query-param alone (no per-call :sensitive?) stamps :sensitive?"
     (let [tags {:url "https://api.example.com/x?api_key=SECRET&page=2"}
-          r    (privacy/prepare-emit-tags tags false)]
+          r    (rf.http.privacy/prepare-emit-tags tags false)]
       (is (= "https://api.example.com/x?api_key=:rf/redacted&page=2" (:url r)))
       (is (true? (:sensitive? r))
           "denylist hit alone is signal — :sensitive? stamped"))))
@@ -675,7 +675,7 @@
     (let [tags {:url "/x"
                 :failure {:kind :rf.http/http-5xx
                           :url "https://api.example.com/x?token=abc&page=2"}}
-          r    (privacy/prepare-emit-tags tags false)]
+          r    (rf.http.privacy/prepare-emit-tags tags false)]
       (is (= "https://api.example.com/x?token=:rf/redacted&page=2"
              (get-in r [:failure :url])))
       (is (true? (:sensitive? r))))))
@@ -683,7 +683,7 @@
 (deftest prepare-emit-tags-no-stamp-when-no-denylist-and-not-sensitive
   (testing "URL with no denylisted params and no per-call :sensitive? does NOT stamp"
     (let [tags {:url "https://api.example.com/x?page=2&limit=10"}
-          r    (privacy/prepare-emit-tags tags false)]
+          r    (rf.http.privacy/prepare-emit-tags tags false)]
       (is (= "https://api.example.com/x?page=2&limit=10" (:url r)))
       (is (not (contains? r :sensitive?))))))
 
@@ -692,7 +692,7 @@
     (let [f {:kind :rf.http/http-5xx
              :status 500
              :url "https://api.example.com/x?api_key=SECRET&page=2"}
-          r (privacy/prepare-emit-failure f false)]
+          r (rf.http.privacy/prepare-emit-failure f false)]
       (is (= "https://api.example.com/x?api_key=:rf/redacted&page=2" (:url r)))
       (is (true? (:sensitive? r))))))
 
@@ -701,7 +701,7 @@
     (let [f {:kind :rf.http/http-5xx
              :status 500
              :url "https://api.example.com/x?page=2"}
-          r (privacy/prepare-emit-failure f false)]
+          r (rf.http.privacy/prepare-emit-failure f false)]
       (is (not (contains? r :sensitive?))))))
 
 (deftest prepare-emit-failure-handler-sensitive-redacts-all-url-params
@@ -709,7 +709,7 @@
     (let [f {:kind :rf.http/http-5xx
              :status 500
              :url "https://api.example.com/x?user_id=42&page=2"}
-          r (privacy/prepare-emit-failure f true)]
+          r (rf.http.privacy/prepare-emit-failure f true)]
       (is (= "https://api.example.com/x?user_id=:rf/redacted&page=:rf/redacted" (:url r)))
       (is (true? (:sensitive? r))))))
 
@@ -724,7 +724,7 @@
                    :interceptor-id :auth/check
                    :url            "https://api.example.com/login"
                    :cause          "validation failed: token sk-live-abc123 rejected"}
-          r       (privacy/prepare-emit-failure failure true)]
+          r       (rf.http.privacy/prepare-emit-failure failure true)]
       (is (= :rf/redacted (:cause r))
           "the interceptor's thrown message rides redacted, not verbatim")
       (is (true? (:sensitive? r)))
@@ -746,22 +746,22 @@
   shape). `registrar/clear-all!` in the reset fixture clears the framework's
   own registration, so each carrier test installs the carriers it needs."
   [carriers]
-  (fx/reg-fx :rf.http/managed {:carriers carriers} http-managed/managed-handler))
+  (rf.fx/reg-fx :rf.http/managed {:carriers carriers} rf.http.managed/managed-handler))
 
 (deftest managed-carriers-resolves-registration-carriers
   (testing "managed-carriers reads the :rf.http/managed :carriers block"
     (reg-managed-carriers! {:headers      ["X-Honeycomb-Team"]
                             :query-params ["shop_token"]})
-    (let [carriers (privacy/managed-carriers)]
+    (let [carriers (rf.http.privacy/managed-carriers)]
       ;; names lower-cased for the case-insensitive wire match.
       (is (= #{"x-honeycomb-team"} (:headers carriers)))
       (is (= #{"shop_token"} (:query-params carriers))))
     (testing "a registration with no :carriers block resolves to nil"
-      (fx/reg-fx :rf.http/managed {} http-managed/managed-handler)
-      (is (nil? (privacy/managed-carriers))))
+      (rf.fx/reg-fx :rf.http/managed {} rf.http.managed/managed-handler)
+      (is (nil? (rf.http.privacy/managed-carriers))))
     (testing "an unregistered :rf.http/managed resolves to nil"
-      (registrar/clear-all!)
-      (is (nil? (privacy/managed-carriers))))))
+      (rf.registrar/clear-all!)
+      (is (nil? (rf.http.privacy/managed-carriers))))))
 
 (deftest prepare-emit-tags-honours-managed-header-carrier
   (testing "a managed-HTTP header carrier redacts on a non-sensitive request"
@@ -770,7 +770,7 @@
                 :headers {"X-Honeycomb-Team" "hc-secret"
                           "Authorization"    "Bearer abc"
                           "Content-Type"     "application/json"}}
-          out  (privacy/prepare-emit-tags tags false)]
+          out  (rf.http.privacy/prepare-emit-tags tags false)]
       (is (= :rf/redacted (get-in out [:headers "X-Honeycomb-Team"]))
           "app-declared carrier redacted")
       (is (= :rf/redacted (get-in out [:headers "Authorization"]))
@@ -778,10 +778,10 @@
       (is (= "application/json" (get-in out [:headers "Content-Type"]))
           "ordinary header preserved"))
     (testing "without a :carriers block, only the built-in defaults redact"
-      (fx/reg-fx :rf.http/managed {} http-managed/managed-handler)
+      (rf.fx/reg-fx :rf.http/managed {} rf.http.managed/managed-handler)
       (let [tags {:headers {"X-Honeycomb-Team" "hc-secret"
                             "Authorization"    "Bearer abc"}}
-            out  (privacy/prepare-emit-tags tags false)]
+            out  (rf.http.privacy/prepare-emit-tags tags false)]
         (is (= "hc-secret" (get-in out [:headers "X-Honeycomb-Team"]))
             "no carrier block → app carrier not consulted")
         (is (= :rf/redacted (get-in out [:headers "Authorization"]))
@@ -791,14 +791,14 @@
   (testing "a managed-HTTP query-param carrier redacts the URL value + stamps sensitive"
     (reg-managed-carriers! {:query-params ["shop_token"]})
     (let [tags {:url "https://api.example.com/x?shop_token=abc&page=2"}
-          out  (privacy/prepare-emit-tags tags false)]
+          out  (rf.http.privacy/prepare-emit-tags tags false)]
       (is (= "https://api.example.com/x?shop_token=:rf/redacted&page=2" (:url out)))
       (is (true? (:sensitive? out))
           "a carrier query-param hit stamps :sensitive? (the name is the signal)"))
     (testing "without a :carriers block the same param rides unredacted (built-in only)"
-      (fx/reg-fx :rf.http/managed {} http-managed/managed-handler)
+      (rf.fx/reg-fx :rf.http/managed {} rf.http.managed/managed-handler)
       (let [tags {:url "https://api.example.com/x?shop_token=abc&page=2"}
-            out  (privacy/prepare-emit-tags tags false)]
+            out  (rf.http.privacy/prepare-emit-tags tags false)]
         (is (= "https://api.example.com/x?shop_token=abc&page=2" (:url out)))))))
 
 ;; rf2-4wqxq8 — :query-params {:include :except} policy map (carried verbatim
@@ -809,29 +809,29 @@
             to a {:include #{..} :except #{..}} policy (sub-sets lower-cased)"
     (reg-managed-carriers! {:query-params {:include ["Shop_Token"]
                                            :except  ["Token" "Sig"]}})
-    (let [carriers (privacy/managed-carriers)
+    (let [carriers (rf.http.privacy/managed-carriers)
           qp       (:query-params carriers)]
       (is (= #{"shop_token"} (:include qp)))
       (is (= #{"token" "sig"} (:except qp))))
     (testing "the legacy vector form still resolves to a plain set"
       (reg-managed-carriers! {:query-params ["shop_token"]})
-      (is (= #{"shop_token"} (:query-params (privacy/managed-carriers)))))
+      (is (= #{"shop_token"} (:query-params (rf.http.privacy/managed-carriers)))))
     (testing "a policy map of all-empty vectors resolves :query-params to nil"
       (reg-managed-carriers! {:query-params {:include [] :except []}})
-      (is (nil? (:query-params (privacy/managed-carriers)))))))
+      (is (nil? (:query-params (rf.http.privacy/managed-carriers)))))))
 
 (deftest prepare-emit-tags-honours-managed-query-param-except
   (testing "rf2-4wqxq8 — a managed-HTTP :except keeps a built-in default param
             VISIBLE in the app's own dev trace (subtraction is app-local)"
     (reg-managed-carriers! {:query-params {:except ["token"]}})
     (let [tags {:url "https://api.example.com/x?token=abc&api_key=SECRET&page=2"}
-          out  (privacy/prepare-emit-tags tags false)]
+          out  (rf.http.privacy/prepare-emit-tags tags false)]
       (is (= "https://api.example.com/x?token=abc&api_key=:rf/redacted&page=2" (:url out))
           "excepted default visible; non-excepted default still redacted"))
     (testing "without a :carriers block the default param redacts as usual"
-      (fx/reg-fx :rf.http/managed {} http-managed/managed-handler)
+      (rf.fx/reg-fx :rf.http/managed {} rf.http.managed/managed-handler)
       (let [tags {:url "https://api.example.com/x?token=abc&page=2"}
-            out  (privacy/prepare-emit-tags tags false)]
+            out  (rf.http.privacy/prepare-emit-tags tags false)]
         (is (= "https://api.example.com/x?token=:rf/redacted&page=2" (:url out)))))))
 
 ;; ---- managed-HTTP carrier shape validation (fail-loud) -------------------
@@ -839,24 +839,24 @@
 (deftest managed-carriers-fail-loud-on-malformed-block
   (testing "a non-string carrier name fails loud (:rf.error/bad-classification)"
     (reg-managed-carriers! {:headers [:X-Honeycomb-Team]}) ;; keyword, not string
-    (let [data (try (privacy/managed-carriers) nil
+    (let [data (try (rf.http.privacy/managed-carriers) nil
                     (catch clojure.lang.ExceptionInfo e (ex-data e)))]
       (is (= :rf.error/bad-classification (:rf.error/id data)))
       (is (= [:carriers :headers] (:bad-key data)))
       (is (= :X-Honeycomb-Team (:bad-carrier data)))))
   (testing "an unknown :carriers key fails loud"
     (reg-managed-carriers! {:cookies ["x"]})
-    (let [data (try (privacy/managed-carriers) nil
+    (let [data (try (rf.http.privacy/managed-carriers) nil
                     (catch clojure.lang.ExceptionInfo e (ex-data e)))]
       (is (= :rf.error/bad-classification (:rf.error/id data)))
       (is (= [:carriers :cookies] (:bad-key data)))))
   (testing "the header denylist stays vector-only (no policy-map form)"
     (reg-managed-carriers! {:headers {:include ["X-Foo"]}})
-    (let [data (try (privacy/managed-carriers) nil
+    (let [data (try (rf.http.privacy/managed-carriers) nil
                     (catch clojure.lang.ExceptionInfo e (ex-data e)))]
       (is (= [:carriers :headers] (:bad-key data)))))
   (testing "an unknown key inside the :query-params policy map fails loud"
     (reg-managed-carriers! {:query-params {:include ["x"] :bogus ["y"]}})
-    (let [data (try (privacy/managed-carriers) nil
+    (let [data (try (rf.http.privacy/managed-carriers) nil
                     (catch clojure.lang.ExceptionInfo e (ex-data e)))]
       (is (= [:carriers :query-params :bogus] (:bad-key data))))))

--- a/implementation/http/test/re_frame/http_reply_lowering_cljs_test.cljc
+++ b/implementation/http/test/re_frame/http_reply_lowering_cljs_test.cljc
@@ -11,8 +11,8 @@
   Canonical contract: `spec/Managed-Effects.md` §The uniform reply
   envelope; EP-0011; rf2-ibksxg (one canonical async-reply envelope)."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.http.reply :as http-reply]
-            [re-frame.reply :as reply]))
+            [re-frame.http.reply :as rf.http.reply]
+            [re-frame.reply :as rf.reply]))
 
 (def ^:private ctx
   {:request-id   :article/by-id
@@ -23,29 +23,29 @@
 
 (deftest work-id-head
   (testing "HTTP work-id head [:rf.work/http logical-id issuance attempt]"
-    (is (= [:rf.work/http :article/by-id 1 1] (http-reply/work-id ctx)))
+    (is (= [:rf.work/http :article/by-id 1 1] (rf.http.reply/work-id ctx)))
     (is (= [:rf.work/http :article/load 1 1]
-           (http-reply/work-id (dissoc ctx :request-id)))
+           (rf.http.reply/work-id (dissoc ctx :request-id)))
         "logical-id falls back to origin event-id")
     (is (= [:rf.work/http :article/by-id 1 2]
-           (http-reply/work-id (assoc ctx :attempt 2)))
+           (rf.http.reply/work-id (assoc ctx :attempt 2)))
         "attempt slot discriminates retries within one issuance")
     (testing "issuance slot discriminates re-issuances across supersessions (rf2-azcmd3)"
       (is (= [:rf.work/http :article/by-id 2 1]
-             (http-reply/work-id (assoc ctx :issuance 2))))
-      (is (not= (http-reply/work-id ctx)
-                (http-reply/work-id (assoc ctx :issuance 2)))))))
+             (rf.http.reply/work-id (assoc ctx :issuance 2))))
+      (is (not= (rf.http.reply/work-id ctx)
+                (rf.http.reply/work-id (assoc ctx :issuance 2)))))))
 
 (deftest suppress-builds-canonical-stale-reply
   (testing "rf2-azcmd3 — http-reply/suppress produces a :status :stale / :rf.reply/work-status :suppressed reply with carried/current work-id correlation, joined to :work/id"
     (let [{:keys [deliver? reply trace]}
-          (http-reply/suppress ctx [:rf.work/http :article/by-id 2 1])]
+          (rf.http.reply/suppress ctx [:rf.work/http :article/by-id 2 1])]
       (is (false? deliver?) "a superseded attempt's app target MUST NOT run")
       (is (= :suppressed (:rf.reply/work-status reply)))
       (is (= :stale (:status reply)))
       (is (= :rf.http/request-id-superseded (:rf.reply/stale-reason reply)))
       (is (not (contains? reply :value)) "a stale reply MUST NOT carry :value")
-      (is (reply/valid-reply? reply) (str (reply/validate-reply reply)))
+      (is (rf.reply/valid-reply? reply) (str (rf.reply/validate-reply reply)))
       ;; carried = the superseded attempt's work-id (issuance 1);
       ;; current = the superseding attempt's work-id (issuance 2); =-distinct.
       (is (= [:rf.work/http :article/by-id 1 1] (:work/id (:rf.reply/carried trace))))
@@ -55,31 +55,31 @@
 (deftest actor-destroy-obsolete-target-suppression
   (testing "rf2-yrrpe2 — actor-destroy obsolete-target predicate + canonical stale suppression (host-symmetric pure core)"
     (testing "the obsolete-target predicate: target == actor-id → obsolete; ordinary target → meaningful"
-      (is (true?  (http-reply/actor-destroy-target-obsolete? :worker/proc#1 :worker/proc#1)))
-      (is (false? (http-reply/actor-destroy-target-obsolete? :reply/recorder :worker/proc#1)))
-      (is (false? (http-reply/actor-destroy-target-obsolete? :worker/proc#1 nil)))
-      (is (false? (http-reply/actor-destroy-target-obsolete? nil :worker/proc#1))))
+      (is (true?  (rf.http.reply/actor-destroy-target-obsolete? :worker/proc#1 :worker/proc#1)))
+      (is (false? (rf.http.reply/actor-destroy-target-obsolete? :reply/recorder :worker/proc#1)))
+      (is (false? (rf.http.reply/actor-destroy-target-obsolete? :worker/proc#1 nil)))
+      (is (false? (rf.http.reply/actor-destroy-target-obsolete? nil :worker/proc#1))))
     (testing "actor-destroy-suppress produces a canonical :status :stale / :rf.reply/work-status :suppressed reply with carried work-id, no current successor"
       (let [actor-ctx {:request-id   [:worker/proc#1 :slow]
                        :origin-event [:worker/proc#1 [:rf.http/failed]]
                        :issuance     1
                        :attempt      1
                        :frame        :app/main}
-            {:keys [deliver? reply trace]} (http-reply/actor-destroy-suppress actor-ctx)]
+            {:keys [deliver? reply trace]} (rf.http.reply/actor-destroy-suppress actor-ctx)]
         (is (false? deliver?) "the obsolete actor-bound app target MUST NOT run")
         (is (= :suppressed (:rf.reply/work-status reply)))
         (is (= :stale (:status reply)))
         (is (= :rf.http/actor-destroyed-target-obsolete (:rf.reply/stale-reason reply)))
         (is (not (contains? reply :value)) "a stale reply MUST NOT carry :value")
-        (is (reply/valid-reply? reply) (str (reply/validate-reply reply)))
+        (is (rf.reply/valid-reply? reply) (str (rf.reply/validate-reply reply)))
         (is (= [:rf.work/http [:worker/proc#1 :slow] 1 1] (:work/id (:rf.reply/carried trace))))
         (is (nil? (:rf.reply/current trace))
             "no live successor — the actor that owned the target is gone")))))
 
 (deftest canonical-replies-validate
   (testing ":status :ok success"
-    (let [r (http-reply/success-reply ctx {:title "Welcome"})]
-      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+    (let [r (rf.http.reply/success-reply ctx {:title "Welcome"})]
+      (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r)))
       (is (= :ok (:status r)))
       (is (= :completed (:rf.reply/work-status r)))
       (is (= :http (:rf.reply/work-kind r)))
@@ -87,18 +87,18 @@
       (is (not (contains? r :request-id))
           ":request-id is correlation metadata, not a second stale key")))
   (testing ":status :error failure"
-    (let [r (http-reply/failure-reply ctx {:kind :rf.http/http-5xx :status 503})]
-      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+    (let [r (rf.http.reply/failure-reply ctx {:kind :rf.http/http-5xx :status 503})]
+      (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r)))
       (is (= :error (:status r)))
       (is (= :failed (:rf.reply/work-status r)))))
   (testing "timeout → :status :error + :rf.reply/work-status :timed-out (not a top-level status)"
-    (let [r (http-reply/failure-reply ctx {:kind :rf.http/timeout :limit-ms 30000 :elapsed-ms 30012})]
-      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+    (let [r (rf.http.reply/failure-reply ctx {:kind :rf.http/timeout :limit-ms 30000 :elapsed-ms 30012})]
+      (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r)))
       (is (= :error (:status r)))
       (is (= :timed-out (:rf.reply/work-status r)))))
   (testing "abort → :status :cancelled with :rf.http/aborted :error"
-    (let [r (http-reply/failure-reply ctx {:kind :rf.http/aborted :reason :user})]
-      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+    (let [r (rf.http.reply/failure-reply ctx {:kind :rf.http/aborted :reason :user})]
+      (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r)))
       (is (= :cancelled (:status r)))
       (is (= :cancelled (:rf.reply/work-status r)))
       (is (true? (:cancelled? r)))
@@ -119,7 +119,7 @@
                   :issuance     1
                   :attempt      3
                   :max-attempts 3}
-          f      (http-reply/self-identify-failure
+          f      (rf.http.reply/self-identify-failure
                    {:kind :rf.http/timeout :elapsed-ms 8000 :limit-ms 8000}
                    id-ctx)]
       (is (= {:method :get :url "/api/articles/42"} (:request f)))
@@ -131,7 +131,7 @@
         (is (= :rf.http/timeout (:kind f)))
         (is (= 8000 (:elapsed-ms f)))))
     (testing ":max-attempts is omitted when no retry policy was configured"
-      (let [f (http-reply/self-identify-failure
+      (let [f (rf.http.reply/self-identify-failure
                 {:kind :rf.http/transport :message "boom"}
                 {:method :post :url "/x" :request-id nil
                  :origin-event [:e] :attempt 1})]
@@ -142,8 +142,8 @@
 
 (deftest trace-summary-elides-wire-slots
   (testing "the canonical trace summary keeps identity facts verbatim"
-    (let [r       (http-reply/success-reply ctx {:secret "x"})
-          summary (http-reply/trace-reply r {:sensitive? true})]
+    (let [r       (rf.http.reply/success-reply ctx {:secret "x"})
+          summary (rf.http.reply/trace-reply r {:sensitive? true})]
       (is (= :ok (:status summary)))
       (is (= [:rf.work/http :article/by-id 1 1] (:rf.reply/work-id summary)))
       (is (= :http (:rf.reply/work-kind summary)))

--- a/implementation/http/test/re_frame/http_reply_lowering_test.clj
+++ b/implementation/http/test/re_frame/http_reply_lowering_test.clj
@@ -28,15 +28,15 @@
   envelope; EP-0011; rf2-ibksxg (one canonical async-reply envelope)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.http.registry :as registry]
-            [re-frame.http.reply :as http-reply]
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.registry :as rf.http.registry]
+            [re-frame.http.reply :as rf.http.reply]
             [re-frame.http.test-support]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.reply :as reply]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace])
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.reply :as rf.reply]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace])
   (:import [com.sun.net.httpserver HttpServer HttpHandler HttpExchange]
            [java.net InetSocketAddress]))
 
@@ -49,7 +49,7 @@
 ;; need `:rf/time-ms` present for a reply handler declaring
 ;; `:rf.cofx/requires [:rf/time-ms]`.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- real-transport server harness ---------------------------------------
 
@@ -74,7 +74,7 @@
 (defn- await-reply!
   ([pred] (await-reply! pred 5000))
   ([pred timeout-ms]
-   (test-support/poll-until
+   (rf.test-support/poll-until
      #(let [db (rf/app-db-value :rf/default)] (when (pred db) db))
      {:timeout-ms timeout-ms :label "http-reply-lowering"})))
 
@@ -120,26 +120,26 @@
 
 (deftest work-id-head
   (testing "HTTP work-id head is [:rf.work/http logical-id issuance attempt]"
-    (is (= [:rf.work/http :article/by-id 1 1] (http-reply/work-id base-ctx)))
+    (is (= [:rf.work/http :article/by-id 1 1] (rf.http.reply/work-id base-ctx)))
     (testing "logical-id falls back to the origin event-id when :request-id is absent"
       (is (= [:rf.work/http :article/load 1 1]
-             (http-reply/work-id (dissoc base-ctx :request-id)))))
+             (rf.http.reply/work-id (dissoc base-ctx :request-id)))))
     (testing "the attempt slot discriminates transport retries within one issuance"
       (is (= [:rf.work/http :article/by-id 1 3]
-             (http-reply/work-id (assoc base-ctx :attempt 3)))))
+             (rf.http.reply/work-id (assoc base-ctx :attempt 3)))))
     (testing "the issuance slot discriminates re-issuances across supersessions (rf2-azcmd3)"
       ;; A superseded attempt (issuance 1) and its superseder (issuance 2) both
       ;; reset their retry :attempt to 1, but the issuance keeps their work
       ;; ids =-distinct — the EP-0011 one-attempt-one-work-id rule.
       (is (= [:rf.work/http :article/by-id 2 1]
-             (http-reply/work-id (assoc base-ctx :issuance 2))))
-      (is (not= (http-reply/work-id base-ctx)
-                (http-reply/work-id (assoc base-ctx :issuance 2)))))))
+             (rf.http.reply/work-id (assoc base-ctx :issuance 2))))
+      (is (not= (rf.http.reply/work-id base-ctx)
+                (rf.http.reply/work-id (assoc base-ctx :issuance 2)))))))
 
 (deftest success-reply-is-canonical
   (testing "a success completion builds a schema-valid :status :ok reply"
-    (let [r (http-reply/success-reply base-ctx {:title "Welcome"})]
-      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+    (let [r (rf.http.reply/success-reply base-ctx {:title "Welcome"})]
+      (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r)))
       (is (= :ok (:status r)))
       (is (= {:title "Welcome"} (:value r)))
       (is (= :completed (:rf.reply/work-status r)))
@@ -163,8 +163,8 @@
                                ;; vector-of-verbatim-lines shape rides
                                ;; UNCHANGED (no second representation)
                                "set-cookie"            ["a=1; Path=/" "b=2; Path=/"]}}
-          r     (http-reply/success-reply base-ctx {:title "Welcome"} meta*)]
-      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+          r     (rf.http.reply/success-reply base-ctx {:title "Welcome"} meta*)]
+      (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r)))
       (is (= :ok (:status r)) "the envelope status stays :ok — :meta adds facts, never re-levels them")
       (is (= {:title "Welcome"} (:value r)) ":value remains the decoded-and-accepted payload")
       (is (= meta* (:meta r)) "the response wire facts ride verbatim under :meta")
@@ -172,14 +172,14 @@
           "a multi-valued header keeps the ONE normalized vector shape")))
   (testing "rf2-lddbk — absent metadata is OMITTED, never fabricated (the
             2-arity and a nil 3rd arg both leave :meta off the reply)"
-    (is (not (contains? (http-reply/success-reply base-ctx {:v 1}) :meta)))
-    (is (not (contains? (http-reply/success-reply base-ctx {:v 1} nil) :meta)))))
+    (is (not (contains? (rf.http.reply/success-reply base-ctx {:v 1}) :meta)))
+    (is (not (contains? (rf.http.reply/success-reply base-ctx {:v 1} nil) :meta)))))
 
 (deftest failure-reply-maps-to-error
   (testing "a transport failure builds a schema-valid :status :error reply"
-    (let [r (http-reply/failure-reply
+    (let [r (rf.http.reply/failure-reply
               base-ctx {:kind :rf.http/http-5xx :status 503 :body "down"})]
-      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+      (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r)))
       (is (= :error (:status r)))
       (is (= :failed (:rf.reply/work-status r)))
       (is (= :rf.http/http-5xx (get-in r [:error :kind])))
@@ -187,9 +187,9 @@
 
 (deftest timeout-maps-to-error-plus-timed-out-work-status
   (testing "timeout is :status :error + :rf.reply/work-status :timed-out (NOT a top-level status)"
-    (let [r (http-reply/failure-reply
+    (let [r (rf.http.reply/failure-reply
               base-ctx {:kind :rf.http/timeout :limit-ms 30000 :elapsed-ms 30012})]
-      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+      (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r)))
       (is (= :error (:status r)) "timeout is NOT a top-level :status")
       (is (= :timed-out (:rf.reply/work-status r)))
       (is (= :rf.http/timeout (get-in r [:error :kind]))))))
@@ -197,15 +197,15 @@
 (deftest abort-maps-to-cancelled
   (testing "an abort is :status :cancelled with an :rf.http/aborted :error"
     (let [failure {:kind :rf.http/aborted :reason :user :request-id :article/by-id}
-          r       (http-reply/failure-reply base-ctx failure)]
-      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+          r       (rf.http.reply/failure-reply base-ctx failure)]
+      (is (rf.reply/valid-reply? r) (str (rf.reply/validate-reply r)))
       (is (= :cancelled (:status r)))
       (is (= :cancelled (:rf.reply/work-status r)))
       (is (true? (:cancelled? r)))
       (is (= :user (:rf.reply/cancel-reason r)))
       (is (= :rf.http/aborted (get-in r [:error :kind])))))
   (testing "an aborted failure routed through failure-reply also lowers to :cancelled"
-    (let [r (http-reply/failure-reply
+    (let [r (rf.http.reply/failure-reply
               base-ctx {:kind :rf.http/aborted :reason :actor-destroyed})]
       (is (= :cancelled (:status r)))
       (is (= :actor-destroyed (:rf.reply/cancel-reason r))))))
@@ -223,36 +223,36 @@
 
 (deftest http-target-lowers-through-shared-complete
   (testing "the HTTP reply (canonical envelope appended to the target event) IS re-frame.reply/complete :delivery :append — the shared-target lowering path, not a family-private append"
-    (let [reply  (http-reply/success-reply base-ctx {:title "Welcome"})
+    (let [reply  (rf.http.reply/success-reply base-ctx {:title "Welcome"})
           target [:article/load {:id 42}]]
       ;; `complete` appends the canonical reply as the final arg — exactly the
       ;; shape `build-reply-event` produces for an explicit reply target.
       (is (= [:article/load {:id 42} reply]
-             (reply/complete target reply)))
-      (is (= :ok (get-in (reply/complete target reply) [2 :status])))
+             (rf.reply/complete target reply)))
+      (is (= :ok (get-in (rf.reply/complete target reply) [2 :status])))
       (testing "a failure reply lowers the same way through the shared append"
-        (let [fr (http-reply/failure-reply base-ctx {:kind :rf.http/http-5xx :status 503 :body "down"})]
-          (is (= [:svc/failed fr] (reply/complete [:svc/failed] fr)))
-          (is (= :rf.http/http-5xx (get-in (reply/complete [:svc/failed] fr) [1 :error :kind]))))))))
+        (let [fr (rf.http.reply/failure-reply base-ctx {:kind :rf.http/http-5xx :status 503 :body "down"})]
+          (is (= [:svc/failed fr] (rf.reply/complete [:svc/failed] fr)))
+          (is (= :rf.http/http-5xx (get-in (rf.reply/complete [:svc/failed] fr) [1 :error :kind]))))))))
 
 (deftest http-target-satisfies-functor-law
   (testing "rf2-9u1tvq — the EP-0011 reply-mapping functor law holds over HTTP's reply target: complete(map-completed-event(f,t),reply) == f(complete(t,reply)); identity + composition"
-    (let [payload (http-reply/success-reply base-ctx {:title "Welcome"})
+    (let [payload (rf.http.reply/success-reply base-ctx {:title "Welcome"})
           target  [:article/load {:id 42}]
           ;; relocate the completed reply into a wrapper event (the Cmd.map role)
           wrap    (fn [ev] [:wrap ev])
           tag     (fn [ev] (conj ev :tag))]
       (testing "the law: complete(map-completed-event(f, target), reply) == f(complete(target, reply))"
-        (is (= (reply/complete (reply/map-completed-event wrap target) payload)
-               (wrap (reply/complete target payload)))))
+        (is (= (rf.reply/complete (rf.reply/map-completed-event wrap target) payload)
+               (wrap (rf.reply/complete target payload)))))
       (testing "identity: map-completed-event(identity, target) completes to the plain completion"
-        (is (= (reply/complete (reply/map-completed-event identity target) payload)
-               (reply/complete target payload))))
+        (is (= (rf.reply/complete (rf.reply/map-completed-event identity target) payload)
+               (rf.reply/complete target payload))))
       (testing "composition: map-completed-event(comp f g) == map-completed-event f ∘ map-completed-event g"
-        (is (= (reply/complete (reply/map-completed-event (comp wrap tag) target) payload)
-               (reply/complete (reply/map-completed-event wrap (reply/map-completed-event tag target)) payload))))
+        (is (= (rf.reply/complete (rf.reply/map-completed-event (comp wrap tag) target) payload)
+               (rf.reply/complete (rf.reply/map-completed-event wrap (rf.reply/map-completed-event tag target)) payload))))
       (testing "mapping changes ONLY the completed event — the canonical reply facts (work-id / status) are untouched by map-completed-event"
-        (let [reply (http-reply/success-reply base-ctx {:title "Welcome"})]
+        (let [reply (rf.http.reply/success-reply base-ctx {:title "Welcome"})]
           ;; work-id / status are not stored on the target, so mapping cannot
           ;; touch them — the law is structural.
           (is (= [:rf.work/http :article/by-id 1 1] (:rf.reply/work-id reply)))
@@ -345,7 +345,7 @@
         (rf/dispatch-sync [:meta/load {}])
         (let [db    (await-reply! #(some? (:reply %)))
               reply (:reply db)]
-          (is (reply/valid-reply? reply) (str (reply/validate-reply reply)))
+          (is (rf.reply/valid-reply? reply) (str (rf.reply/validate-reply reply)))
           (is (= "hello" (get-in reply [:value :title]))
               ":value remains the decoded-and-accepted payload")
           (is (= 200 (get-in reply [:meta :status]))
@@ -499,7 +499,7 @@
           traces  (atom [])
           lid     ::replied-trace]
       (try
-        (trace/register-listener! lid (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! lid (fn [ev] (swap! traces conj ev)))
         (rf/reg-event :t/load
           (fn [{:keys [db]} [_ msg reply]]
             (if reply
@@ -521,7 +521,7 @@
             ;; :request-id is correlation metadata, not a second stale key
             (is (= {:request-id :t/load} (:correlation tags)))))
         (finally
-          (trace/unregister-listener! lid)
+          (rf.trace/unregister-listener! lid)
           (stop-server! srv))))))
 
 ;; ===========================================================================
@@ -572,7 +572,7 @@
     ;; same :request-id supersedes #1. Per Spec 014 §`:request-id` (internal)
     ;; the superseded request's reply is trace-only — its app target MUST NOT
     ;; fire. #2 completes normally and IS delivered.
-    (registry/reset-issuance-counters-for-test!)
+    (rf.http.registry/reset-issuance-counters-for-test!)
     (let [release (java.util.concurrent.CountDownLatch. 1)
           replied (java.util.concurrent.CountDownLatch. 1)
           srv     (start-held-server! release)
@@ -602,9 +602,9 @@
         ;; Device (2) — read while BOTH exchanges are still held, so this is an
         ;; ordering fact, not a sampled one: #1 has already been cleared out of
         ;; the `:search` slot and issuance 2 owns it.
-        (let [live (registry/lookup-in-flight :search)]
+        (let [live (rf.http.registry/lookup-in-flight :search)]
           (is (some? live) "the superseding request #2 is the live in-flight request")
-          (is (= [:rf.work/http :search 2 1] (http-reply/work-id live))
+          (is (= [:rf.work/http :search 2 1] (rf.http.reply/work-id live))
               "the surviving in-flight request is issuance 2; issuance 1 was superseded out of the slot during the second dispatch-sync"))
         ;; Release both exchanges, then wait on the reply handler's own latch.
         (.countDown release)
@@ -631,7 +631,7 @@
 
 (deftest supersede-distinct-work-ids-and-canonical-stale-trace
   (testing "rf2-azcmd3 — superseded + superseding attempts have DISTINCT :work/id, and the superseded one records a canonical :status :stale / :rf.reply/work-status :suppressed reply-envelope trace with carried/current correlation; only the new app reply fires"
-    (registry/reset-issuance-counters-for-test!)
+    (rf.http.registry/reset-issuance-counters-for-test!)
     (let [release (java.util.concurrent.CountDownLatch. 1)
           replied (java.util.concurrent.CountDownLatch. 1)
           srv     (start-held-server! release)
@@ -639,7 +639,7 @@
           traces  (atom [])
           lid     ::supersede-stale]
       (try
-        (trace/register-listener! lid (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! lid (fn [ev] (swap! traces conj ev)))
         (rf/reg-event :search/replied
           (fn [{:keys [db]} [_ payload]]
             (swap! replies conj payload)
@@ -700,9 +700,9 @@
         ;; Device (2) — read while BOTH exchanges are still held: the supersede
         ;; already cleared issuance 1 out of the `:search` slot and issuance 2
         ;; owns it, so #1's suppression is settled BEFORE anything is released.
-        (let [live (registry/lookup-in-flight :search)]
+        (let [live (rf.http.registry/lookup-in-flight :search)]
           (is (some? live) "the superseding request #2 is the live in-flight request")
-          (is (= [:rf.work/http :search 2 1] (http-reply/work-id live))
+          (is (= [:rf.work/http :search 2 1] (rf.http.reply/work-id live))
               "the surviving in-flight request is issuance 2; issuance 1 was superseded out of the slot during the second dispatch-sync"))
         ;; The surviving request's APP REPLY is the one genuinely async step
         ;; (transport reply → reply lowering → app dispatch), and it publishes
@@ -732,7 +732,7 @@
             "the delivered reply belongs to the SUPERSEDING issuance (2), not the superseded issuance 1")
         (finally
           (.countDown release)
-          (trace/unregister-listener! lid)
+          (rf.trace/unregister-listener! lid)
           (stop-server! srv))))))
 
 ;; ===========================================================================
@@ -745,13 +745,13 @@
 
 (deftest actor-destroy-target-obsolete-predicate
   (testing "rf2-yrrpe2 — a reply target naming the destroyed actor itself is obsolete; an ordinary target is meaningful"
-    (is (true?  (http-reply/actor-destroy-target-obsolete? :worker/proc#1 :worker/proc#1))
+    (is (true?  (rf.http.reply/actor-destroy-target-obsolete? :worker/proc#1 :worker/proc#1))
         "target == actor-id (machine-shape wrapper's [self-id ...]) → obsolete")
-    (is (false? (http-reply/actor-destroy-target-obsolete? :reply/recorder :worker/proc#1))
+    (is (false? (rf.http.reply/actor-destroy-target-obsolete? :reply/recorder :worker/proc#1))
         "target is an ordinary event (≠ actor-id) → still meaningful")
-    (is (false? (http-reply/actor-destroy-target-obsolete? :worker/proc#1 nil))
+    (is (false? (rf.http.reply/actor-destroy-target-obsolete? :worker/proc#1 nil))
         "no actor binding → never obsolete")
-    (is (false? (http-reply/actor-destroy-target-obsolete? nil :worker/proc#1))
+    (is (false? (rf.http.reply/actor-destroy-target-obsolete? nil :worker/proc#1))
         "no resolvable target → not classified obsolete")))
 
 (deftest actor-destroy-suppress-is-canonical-stale
@@ -761,10 +761,10 @@
                :issuance     1
                :attempt      1
                :frame        :app/main}
-          {:keys [deliver? reply trace] :as out} (http-reply/actor-destroy-suppress ctx)]
+          {:keys [deliver? reply trace] :as out} (rf.http.reply/actor-destroy-suppress ctx)]
       (is (false? deliver?) "the obsolete actor-bound app target MUST NOT run")
       (is (= :suppressed (:rf.reply/work-status out)))
-      (is (reply/valid-reply? reply) (str (reply/validate-reply reply)))
+      (is (rf.reply/valid-reply? reply) (str (rf.reply/validate-reply reply)))
       (is (= :stale (:status reply)))
       (is (true? (:stale? reply)))
       (is (= :rf.http/actor-destroyed-target-obsolete (:rf.reply/stale-reason reply)))
@@ -807,15 +807,15 @@
           ;; missing-cofx enqueue fill — whose value coincides with
           ;; :completed-at to the millisecond and so cannot discriminate.
           reply-dispatch-opts (atom nil)
-          real-dispatch! (late-bind/get-fn :router/dispatch!)
+          real-dispatch! (rf.late-bind/get-fn :router/dispatch!)
           lid    ::cofx-time]
       (try
-        (late-bind/set-fn! :router/dispatch!
+        (rf.late-bind/set-fn! :router/dispatch!
           (fn [ev opts]
             (when (= :svc/replied (first ev))
               (reset! reply-dispatch-opts opts))
             (real-dispatch! ev opts)))
-        (trace/register-listener! lid (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! lid (fn [ev] (swap! traces conj ev)))
         (rf/reg-event :svc/call
           (fn [_ _]
             {:fx [[:rf.http/managed
@@ -857,8 +857,8 @@
             (is (not (contains? c :rf.world/inputs))
                 "the retired :rf.world/inputs nested envelope is GONE (flat rename)")))
         (finally
-          (late-bind/set-fn! :router/dispatch! real-dispatch!)
-          (trace/unregister-listener! lid)
+          (rf.late-bind/set-fn! :router/dispatch! real-dispatch!)
+          (rf.trace/unregister-listener! lid)
           (stop-server! srv))))))
 
 (deftest http-reply-undeclared-handler-does-not-see-implicit-time

--- a/implementation/http/test/re_frame/http_reply_tail_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_reply_tail_cljs_test.cljs
@@ -18,12 +18,12 @@
   Fetch pipeline), mirroring the `with-counting-500-fetch` idiom in
   `re-frame.http-cljs-test`."
   (:require [cljs.test :refer-macros [deftest is testing async]]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace]))
 
 (defn- fake-200-json-response
   "A minimal Fetch `Response` stand-in that 200s a JSON body."
@@ -45,10 +45,10 @@
             even under a :retry {:on #{:rf.http/transport}} policy that the
             pre-fix leak would have triggered."
     (async done
-      (rf/init! reagent-adapter/adapter)
-      (frame/ensure-default-frame!)
-      (http-managed/clear-all-in-flight!)
-      (http-managed/clear-all-http-interceptors!)
+      (rf/init! rf.adapter.reagent/adapter)
+      (rf.frame/ensure-default-frame!)
+      (rf.http.managed/clear-all-in-flight!)
+      (rf.http.managed/clear-all-http-interceptors!)
       (let [fetch-count (atom 0)
             replies     (atom [])
             traces      (atom [])
@@ -57,9 +57,9 @@
             resp        (fake-200-json-response)
             restore     (fn []
                           (set! (.-fetch js/globalThis) orig)
-                          (trace/unregister-listener! cb-id)
-                          (http-managed/clear-all-http-interceptors!))]
-        (trace/register-listener! cb-id (fn [ev] (swap! traces conj ev)))
+                          (rf.trace/unregister-listener! cb-id)
+                          (rf.http.managed/clear-all-http-interceptors!))]
+        (rf.trace/register-listener! cb-id (fn [ev] (swap! traces conj ev)))
         (set! (.-fetch js/globalThis)
               (fn [_url _init] (swap! fetch-count inc) (js/Promise.resolve resp)))
         ;; EP-0002: reg-http-interceptor is context-required frame-local.
@@ -82,7 +82,7 @@
                     :on-success [:reply/recorder]
                     :on-failure [:reply/recorder]}]]}))
         (rf/dispatch-sync [:issue] {:frame :rf/default})
-        (-> (test-support/poll-until
+        (-> (rf.test-support/poll-until
               #(seq (reply-tail-failures traces))
               {:timeout-ms 3000 :label "cljs :rf.error/http-reply-tail-failed surfaced"})
             (.then (fn [_]

--- a/implementation/http/test/re_frame/http_reply_tail_test.clj
+++ b/implementation/http/test/re_frame/http_reply_tail_test.clj
@@ -25,19 +25,19 @@
   reply-tail throw does NOT re-send an already-completed request."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.http.handlers :as handlers]
+            [re-frame.http.handlers :as rf.http.handlers]
             ;; Requiring the managed artefact publishes the `:rf.http/managed`
             ;; fx + the `reg-http-interceptor` late-bind hooks the tests drive.
-            [re-frame.http.managed :as http-managed]
-            [re-frame.test-support :as test-support]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace])
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace :as rf.trace])
   (:import [com.sun.net.httpserver HttpServer HttpHandler HttpExchange]
            [java.net InetSocketAddress]
            [java.util.concurrent.atomic AtomicInteger]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- in-process server harness (hit-counting) ------------------------------
 
@@ -66,10 +66,10 @@
   (let [captured (atom [])
         cb-id    (gensym "reply-tail-cap-")]
     (try
-      (trace/register-listener! cb-id (fn [ev] (swap! captured conj ev)))
+      (rf.trace/register-listener! cb-id (fn [ev] (swap! captured conj ev)))
       (body-fn captured)
       (finally
-        (trace/unregister-listener! cb-id)))))
+        (rf.trace/unregister-listener! cb-id)))))
 
 (defn- ops [captured op]
   (filter #(= op (:operation %)) @captured))
@@ -78,7 +78,7 @@
 ;; rf2-bvw9ut — dispatch-time reply-target SHAPE validation
 ;; ===========================================================================
 
-(def ^:private validate-reply-target! @#'handlers/validate-reply-target!)
+(def ^:private validate-reply-target! @#'rf.http.handlers/validate-reply-target!)
 
 (deftest bvw9ut-shape-validated-at-dispatch-time-unit
   (testing "rf2-bvw9ut — validate-reply-target! rejects a non-vector non-nil
@@ -184,7 +184,7 @@
             ;; The observable post-fix signal: the reply-tail failure surfaces
             ;; (rather than vanishing into the whenComplete future). Poll for it
             ;; — a regression that reclassified/retried would never emit it.
-            (test-support/poll-until
+            (rf.test-support/poll-until
               #(seq (ops captured :rf.error/http-reply-tail-failed))
               {:timeout-ms 5000 :label ":rf.error/http-reply-tail-failed surfaced"})
             ;; EXACTLY ONE wire hit — no re-send of the already-completed 2xx.

--- a/implementation/http/test/re_frame/http_restore_quiesce_test.clj
+++ b/implementation/http/test/re_frame/http_restore_quiesce_test.clj
@@ -23,18 +23,18 @@
   to prove the late completion delivers nothing to the app target."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.http.registry :as http-registry]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace])
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.registry :as rf.http.registry]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace])
   (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
            [java.net InetSocketAddress]
            [java.util.concurrent CountDownLatch TimeUnit]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- start-blocking-server!
   [^CountDownLatch latch status content-type body]
@@ -63,7 +63,7 @@
 (defn- await-condition!
   ([pred] (await-condition! pred 5000))
   ([pred timeout-ms]
-   (test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
+   (rf.test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
                                   :label "http-restore-quiesce condition"})
    true))
 
@@ -71,19 +71,19 @@
 
 (deftest hook-published
   (testing "rf2-u5kmf8 — the :http/abort-in-flight-for-frame! hook is published"
-    (is (some? (late-bind/get-fn :http/abort-in-flight-for-frame!)))
-    (is (= http-registry/abort-in-flight-for-frame!
-           (late-bind/get-fn :http/abort-in-flight-for-frame!)))))
+    (is (some? (rf.late-bind/get-fn :http/abort-in-flight-for-frame!)))
+    (is (= rf.http.registry/abort-in-flight-for-frame!
+           (rf.late-bind/get-fn :http/abort-in-flight-for-frame!)))))
 
 ;; ---- registry-level: frame-scoped abort + reason ---------------------------
 
 (deftest abort-in-flight-for-frame-aborts-only-the-frames-requests
   (testing "rf2-u5kmf8 — abort-in-flight-for-frame! fires each matching handle's
             abort-fn with :reason :epoch-restored and leaves other frames alone"
-    (http-managed/clear-all-in-flight!)
+    (rf.http.managed/clear-all-in-flight!)
     (let [seen (atom [])
           mk   (fn [frame-id request-id]
-                 (http-registry/seed-in-flight-for-test!
+                 (rf.http.registry/seed-in-flight-for-test!
                    request-id nil
                    {:abort-fn (fn [reason] (swap! seen conj [frame-id reason]))
                     :url      "http://x/y"
@@ -91,19 +91,19 @@
       (mk :frame/restored :req-a)
       (mk :frame/restored :req-b)
       (mk :frame/other    :req-c)
-      (http-registry/abort-in-flight-for-frame! :frame/restored)
+      (rf.http.registry/abort-in-flight-for-frame! :frame/restored)
       (is (= #{[:frame/restored :epoch-restored]}
              (set (map (fn [[f r]] [f r]) @seen)))
           "only the restored frame's handles fired, each with :reason :epoch-restored")
       (is (= 2 (count @seen)) "both of the restored frame's requests were aborted")
       (is (not-any? #(= :frame/other (first %)) @seen)
           "the unrelated frame's request was NOT aborted")
-      (http-managed/clear-all-in-flight!))))
+      (rf.http.managed/clear-all-in-flight!))))
 
 (deftest abort-in-flight-for-frame-noop-on-frame-with-no-requests
   (testing "rf2-u5kmf8 — a frame with no in-flight managed HTTP is a clean no-op"
-    (http-managed/clear-all-in-flight!)
-    (is (nil? (http-registry/abort-in-flight-for-frame! :frame/none)))))
+    (rf.http.managed/clear-all-in-flight!)
+    (is (nil? (rf.http.registry/abort-in-flight-for-frame! :frame/none)))))
 
 ;; ---- end-to-end: suppression of a genuinely in-flight request --------------
 
@@ -117,7 +117,7 @@
           replies (atom [])
           traces  (atom [])]
       (try
-        (trace/register-listener! ::u5kmf8 (fn [ev] (swap! traces conj ev)))
+        (rf.trace/register-listener! ::u5kmf8 (fn [ev] (swap! traces conj ev)))
         (rf/reg-event :reply/recorder
           (fn [_ [_ payload]] (swap! replies conj payload) {}))
         ;; an ordinary event handler (no spawned actor) issues a managed
@@ -133,15 +133,15 @@
                     :on-success [:reply/recorder]
                     :on-failure [:reply/recorder]}]]}))
         (rf/dispatch-sync [:load])
-        (await-condition! #(seq (http-managed/in-flight-snapshot)))
-        (is (= 1 (count (http-managed/in-flight-snapshot)))
+        (await-condition! #(seq (rf.http.managed/in-flight-snapshot)))
+        (is (= 1 (count (rf.http.managed/in-flight-snapshot)))
             "precondition: the request is in flight")
-        (is (= :rf/default (:frame (http-registry/lookup-in-flight :restore/req)))
+        (is (= :rf/default (:frame (rf.http.registry/lookup-in-flight :restore/req)))
             "precondition: the in-flight handle carries its originating frame")
         ;; The restore boundary fires the published hook for the restored frame.
-        ((late-bind/get-fn :http/abort-in-flight-for-frame!) :rf/default)
+        ((rf.late-bind/get-fn :http/abort-in-flight-for-frame!) :rf/default)
         ;; The abort cascade clears the registry slot.
-        (await-condition! #(empty? (http-managed/in-flight-snapshot)))
+        (await-condition! #(empty? (rf.http.managed/in-flight-snapshot)))
         ;; Release the server so the late completion (if any) would arrive.
         (.countDown latch)
         ;; Timer-semantics window (rf2-fun38): prove the ABSENCE of any reply
@@ -160,5 +160,5 @@
             (is (= :rf/default (:frame tags))
                 "the trace names the restored frame")))
         (finally
-          (trace/unregister-listener! ::u5kmf8)
+          (rf.trace/unregister-listener! ::u5kmf8)
           (stop-server! srv))))))

--- a/implementation/http/test/re_frame/http_retry_on_validation_test.clj
+++ b/implementation/http/test/re_frame/http_retry_on_validation_test.clj
@@ -17,15 +17,15 @@
   absent `:on`, and an empty `:on` set, all pass through cleanly."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.http.handlers :as handlers]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.test-support :as test-support]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.http.handlers :as rf.http.handlers]
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---- per-test reset --------------------------------------------------------
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- closed-set assertion --------------------------------------------------
 
@@ -37,7 +37,7 @@
              :rf.http/timeout
              :rf.http/http-4xx
              :rf.http/http-5xx}
-           handlers/retryable-categories))))
+           rf.http.handlers/retryable-categories))))
 
 ;; ---- helpers ---------------------------------------------------------------
 
@@ -47,7 +47,7 @@
   [retry]
   (let [args {:request {:method :get :url "http://localhost/x"}
               :retry   retry}]
-    (try (handlers/managed-handler {:frame :rf/default :event [:no-op]} args)
+    (try (rf.http.handlers/managed-handler {:frame :rf/default :event [:no-op]} args)
          nil
          (catch clojure.lang.ExceptionInfo e e))))
 
@@ -58,7 +58,7 @@
          (and (= :rf.error/http-bad-retry-on (:rf.error/id data))
               (= :rf.http/managed         (:where data))
               (= :no-recovery             (:recovery data))
-              (= handlers/retryable-categories (:retryable-set data))
+              (= rf.http.handlers/retryable-categories (:retryable-set data))
               (= bad-members               (:bad-members data))
               (string?                     (:reason data))))))
 
@@ -169,7 +169,7 @@
     validation. The `run-attempt!` that follows attempts the network
     request synchronously on JVM; we don't care about the eventual
     failure here, only that the validator did NOT throw."
-    (doseq [k handlers/retryable-categories]
+    (doseq [k rf.http.handlers/retryable-categories]
       (let [ex (call-managed! {:on #{k} :max-attempts 1})]
         (is (not (and (some? ex)
                       (= :rf.error/http-bad-retry-on (:rf.error/id (ex-data ex)))))
@@ -178,7 +178,7 @@
 (deftest full-closed-set-passes-through
   (testing "rf2-apwkm — the entire closed set as `:on` passes."
     (let [ex (call-managed!
-               {:on  handlers/retryable-categories
+               {:on  rf.http.handlers/retryable-categories
                 :max-attempts 1})]
       (is (not (and (some? ex)
                     (= :rf.error/http-bad-retry-on (:rf.error/id (ex-data ex)))))))))
@@ -187,7 +187,7 @@
   (testing "rf2-apwkm — no `:retry` key at all: the validator is a
     no-op. Most calls don't configure retry."
     (let [args {:request {:method :get :url "http://localhost/x"}}
-          ex   (try (handlers/managed-handler {:frame :rf/default :event [:no-op]} args)
+          ex   (try (rf.http.handlers/managed-handler {:frame :rf/default :event [:no-op]} args)
                     nil
                     (catch clojure.lang.ExceptionInfo e e))]
       (is (not (and (some? ex)

--- a/implementation/http/test/re_frame/http_set_cookie_parity_cljs_test.cljc
+++ b/implementation/http/test/re_frame/http_set_cookie_parity_cljs_test.cljc
@@ -27,9 +27,9 @@
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing]]
       :cljs [cljs.test :refer-macros [deftest is testing]])
-   [re-frame.http.reply :as http-reply]
-   #?(:clj  [re-frame.http.transport-jvm :as transport-jvm]
-      :cljs [re-frame.http.transport-cljs :as transport-cljs]))
+   [re-frame.http.reply :as rf.http.reply]
+   #?(:clj  [re-frame.http.transport-jvm :as rf.http.transport-jvm]
+      :cljs [re-frame.http.transport-cljs :as rf.http.transport-cljs]))
   #?(:clj (:import [java.net.http HttpHeaders]
                    [java.util Map]
                    [java.util.function BiPredicate])))
@@ -42,10 +42,10 @@
 ;; ---------------------------------------------------------------------------
 
 #?(:clj
-   (def ^:private flatten-headers @#'transport-jvm/jvm-headers->map))
+   (def ^:private flatten-headers @#'rf.http.transport-jvm/jvm-headers->map))
 
 #?(:cljs
-   (def ^:private flatten-headers @#'transport-cljs/fetch-headers->map))
+   (def ^:private flatten-headers @#'rf.http.transport-cljs/fetch-headers->map))
 
 #?(:clj
    (defn- decode-headers
@@ -126,7 +126,7 @@
           headers (decode-headers {"Set-Cookie"             cookies
                                    "Content-Type"           ["application/json"]
                                    "X-RateLimit-Remaining"  ["37"]})
-          reply   (http-reply/success-reply
+          reply   (rf.http.reply/success-reply
                     {:request-id :parity/req :origin-event [:parity/load]
                      :attempt 1 :frame :app/main :completed-at 1}
                     {:ok true}

--- a/implementation/http/test/re_frame/http_source_coords_test.clj
+++ b/implementation/http/test/re_frame/http_source_coords_test.clj
@@ -21,9 +21,9 @@
      keys win over framework auto-capture)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; EP-0002 (rf2-5q7um6): reg-http-interceptor is context-required frame-local —
 ;; an ambient call under no scope raises :rf.error/no-frame-context. The
@@ -32,12 +32,12 @@
 ;; case passes {:frame :rf/api} explicitly. The post-dispose reset now clears
 ;; the per-frame HTTP interceptor chain too (rf2-q14tde).
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- slot-for
   "Locate the stored slot for `id` on `frame-id` in (http-managed/interceptors-snapshot)."
   [frame-id id]
-  (->> (http-managed/interceptors-snapshot frame-id)
+  (->> (rf.http.managed/interceptors-snapshot frame-id)
        (filter #(= id (:id %)))
        first))
 

--- a/implementation/http/test/re_frame/http_swallowed_failure_test.clj
+++ b/implementation/http/test/re_frame/http_swallowed_failure_test.clj
@@ -14,13 +14,13 @@
   `:router/dispatch!`), so calling the failure-dispatch helper with a
   synthetic ctx fires the swallow-detection path without needing a runtime."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.http.transport :as transport]
-            [re-frame.trace :as trace]))
+            [re-frame.http.transport :as rf.http.transport]
+            [re-frame.trace :as rf.trace]))
 
 ;; Private surface reached via #' (same discipline as http_decode_test.clj).
-(def ^:private dispatch-failure!         @#'transport/dispatch-failure!)
-(def ^:private on-failure-silenced?      @#'transport/on-failure-silenced?)
-(def ^:private failure-swallowed-warned? @#'transport/failure-swallowed-warned?)
+(def ^:private dispatch-failure!         @#'rf.http.transport/dispatch-failure!)
+(def ^:private on-failure-silenced?      @#'rf.http.transport/on-failure-silenced?)
+(def ^:private failure-swallowed-warned? @#'rf.http.transport/failure-swallowed-warned?)
 
 (defn- reset-latch [t]
   ;; The one-shot latch is a `defonce` that persists across deftests in the
@@ -34,10 +34,10 @@
   (let [captured (atom [])
         cb-id    ::http-swallowed-failure-cap]
     (try
-      (trace/register-listener! cb-id (fn [ev] (swap! captured conj ev)))
+      (rf.trace/register-listener! cb-id (fn [ev] (swap! captured conj ev)))
       (body-fn captured)
       (finally
-        (trace/unregister-listener! cb-id)))))
+        (rf.trace/unregister-listener! cb-id)))))
 
 (defn- swallowed-warnings [captured]
   (filter #(= :rf.warning/failure-swallowed (:operation %)) @captured))

--- a/implementation/http/test/re_frame/http_synthetic_4xx_test.clj
+++ b/implementation/http/test/re_frame/http_synthetic_4xx_test.clj
@@ -31,11 +31,11 @@
    - Spec 014 §Retry and backoff / §Request envelope (`:redirect`)"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.http.registry :as registry]
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.registry :as rf.http.registry]
             [re-frame.machines]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support])
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support])
   (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
            [java.net InetSocketAddress]
            [java.util.concurrent.atomic AtomicInteger]))
@@ -43,7 +43,7 @@
 ;; ---- per-test reset (mirrors http_backoff_cancellation_test) ---------------
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- hit-counting always-302 server ----------------------------------------
 
@@ -84,7 +84,7 @@
 (defn- await-condition!
   ([pred] (await-condition! pred 5000))
   ([pred timeout-ms]
-   (test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
+   (rf.test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
                                   :label "http-synthetic-4xx condition"})
    true))
 
@@ -132,7 +132,7 @@
               "the RAW 3xx status rides on the failure map")
           (is (= redirect-body (get-in reply [:error :body]))
               "the RAW 302 body-text rides at :body (decode never runs on a non-2xx)"))
-        (is (empty? (registry/in-flight-snapshot))
+        (is (empty? (rf.http.registry/in-flight-snapshot))
             "the registry is clean after the synthetic-4xx exhausts its retries")
         (finally
           (stop-server! srv))))))
@@ -171,6 +171,6 @@
         (is (= 1 (.get hits))
             "the synthetic-4xx is NOT in the 5xx retry set → exactly one attempt, no retry")
         (is (= 1 (count @replies)))
-        (is (empty? (registry/in-flight-snapshot)))
+        (is (empty? (rf.http.registry/in-flight-snapshot)))
         (finally
           (stop-server! srv))))))

--- a/implementation/http/test/re_frame/http_test_support_absent_test.clj
+++ b/implementation/http/test/re_frame/http_test_support_absent_test.clj
@@ -48,8 +48,8 @@
   closure, the canned stubs ARE registered AND the hooks publish\" —
   lives in `re-frame.http-test-support-test`."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]))
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.registrar :as rf.registrar]))
 
 (deftest canned-stub-fxs-absent-without-test-support-require
   (testing "rf2-cdmle — with re-frame.http.test-support ABSENT from the
@@ -59,7 +59,7 @@
             re-frame.http.managed, which IS in the require closure via
             the reload below)."
     ;; Start from a known-clean registrar.
-    (registrar/clear-all!)
+    (rf.registrar/clear-all!)
     ;; Reload re-frame.http.managed so its load-time fx registrations
     ;; fire. This file does NOT require `re-frame.http.test-support`,
     ;; so the canned-stub fx ids are not registered as a side effect of
@@ -69,9 +69,9 @@
     ;; floor: a regression that broke re-frame.http.managed itself
     ;; (rather than merely re-introducing the canned-stub gate) would
     ;; show up as both these and the canned ones absent.
-    (is (some? (registrar/lookup :fx :rf.http/managed))
+    (is (some? (rf.registrar/lookup :fx :rf.http/managed))
         ":rf.http/managed is dev+prod — registered by re-frame.http.managed at load")
-    (is (some? (registrar/lookup :fx :rf.http/managed-abort))
+    (is (some? (rf.registrar/lookup :fx :rf.http/managed-abort))
         ":rf.http/managed-abort is dev+prod — registered by re-frame.http.managed at load")
     ;; The load-bearing assertion: canned-stub fx ids MUST NOT be
     ;; registered when re-frame.http.test-support has not been required.
@@ -79,9 +79,9 @@
     ;; {:rf.http/managed :rf.http/managed-canned-success}` would fail
     ;; with the framework's no-such-fx error, which is the intended
     ;; production posture per rf2-zk08x's audit decision.
-    (is (nil? (registrar/lookup :fx :rf.http/managed-canned-success))
+    (is (nil? (rf.registrar/lookup :fx :rf.http/managed-canned-success))
         ":rf.http/managed-canned-success MUST NOT register without re-frame.http.test-support require")
-    (is (nil? (registrar/lookup :fx :rf.http/managed-canned-failure))
+    (is (nil? (rf.registrar/lookup :fx :rf.http/managed-canned-failure))
         ":rf.http/managed-canned-failure MUST NOT register without re-frame.http.test-support require")))
 
 (deftest stub-family-hooks-absent-without-test-support-require
@@ -97,8 +97,8 @@
     ;; explicitly so this assertion is hermetic against test ordering.
     ;; (registrar/clear-all! does not touch the late-bind table — it's a
     ;; separate atom.)
-    (late-bind/set-fn! :http/with-managed-request-stubs*      nil)
-    (registrar/clear-all!)
+    (rf.late-bind/set-fn! :http/with-managed-request-stubs*      nil)
+    (rf.registrar/clear-all!)
     (require 're-frame.http.managed :reload)
-    (is (nil? (late-bind/get-fn :http/with-managed-request-stubs*))
+    (is (nil? (rf.late-bind/get-fn :http/with-managed-request-stubs*))
         ":http/with-managed-request-stubs* MUST NOT publish from re-frame.http.managed (rf2-lwmgw)")))

--- a/implementation/http/test/re_frame/http_test_support_test.clj
+++ b/implementation/http/test/re_frame/http_test_support_test.clj
@@ -34,23 +34,23 @@
   app-db) is exercised by `re-frame.http-managed-test` and the
   corresponding CLJS smoke under `implementation/adapters/*`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]
-            [re-frame.http.test-support :as http-test-support]))
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.http.test-support :as rf.http.test-support]))
 
 ;; Ensure each test starts from a known registrar — clear, then reload
 ;; the test-support ns so its load-time registration fires.
 (use-fixtures :each
   (fn [t]
-    (registrar/clear-all!)
+    (rf.registrar/clear-all!)
     (require 're-frame.http.test-support :reload)
     (t)))
 
 (deftest canned-stub-fxs-register-on-test-support-load
   (testing "loading re-frame.http.test-support registers both canned-stub fx ids"
-    (is (some? (registrar/lookup :fx :rf.http/managed-canned-success))
+    (is (some? (rf.registrar/lookup :fx :rf.http/managed-canned-success))
         ":rf.http/managed-canned-success registered")
-    (is (some? (registrar/lookup :fx :rf.http/managed-canned-failure))
+    (is (some? (rf.registrar/lookup :fx :rf.http/managed-canned-failure))
         ":rf.http/managed-canned-failure registered")))
 
 (deftest canned-stub-fxs-delegate-to-canned-handlers
@@ -72,13 +72,13 @@
           ;; null it. Nulling `:router/dispatch!` is global state that
           ;; would silently break every subsequent test's `:dispatch`
           ;; cascade (it is published once at router load, not per-test).
-          original   (late-bind/get-fn :router/dispatch!)]
-      (late-bind/set-fn! :router/dispatch!
+          original   (rf.late-bind/get-fn :router/dispatch!)]
+      (rf.late-bind/set-fn! :router/dispatch!
                          (fn [ev opts] (swap! dispatched conj [ev opts])))
       (try
         ;; Immediate path — no :after-ms. The wrapper must delegate to the
         ;; canned handler body, which calls dispatch-reply-via-late-bind!.
-        ((registrar/handler :fx :rf.http/managed-canned-success)
+        ((rf.registrar/handler :fx :rf.http/managed-canned-success)
          {:frame :rf/default :event [:t/load]}
          {:value {:ok true} :reply-to [:t/load]})
         (is (= 1 (count @dispatched))
@@ -86,7 +86,7 @@
         (is (= :ok (-> @dispatched first first (nth 1) :status))
             "the synthesised reply is the canned handler's success envelope (appended last arg)")
         (finally
-          (late-bind/set-fn! :router/dispatch! original))))))
+          (rf.late-bind/set-fn! :router/dispatch! original))))))
 
 (deftest stub-family-late-bind-hooks-publish-on-test-support-load
   (testing "rf2-lwmgw — loading re-frame.http.test-support publishes the
@@ -97,6 +97,6 @@
             install/uninstall pair is no longer a re-frame.core façade export
             (rf2-ntwwyt) and carries no late-bind hook — it is reached directly
             via this namespace."
-    (is (identical? http-test-support/with-managed-request-stubs*
-                    (late-bind/get-fn :http/with-managed-request-stubs*))
+    (is (identical? rf.http.test-support/with-managed-request-stubs*
+                    (rf.late-bind/get-fn :http/with-managed-request-stubs*))
         ":http/with-managed-request-stubs* → http-test-support/with-managed-request-stubs*")))

--- a/implementation/http/test/re_frame/http_trace_emit_elision_prod_test.cljs
+++ b/implementation/http/test/re_frame/http_trace_emit_elision_prod_test.cljs
@@ -34,25 +34,25 @@
   `http-managed` tests)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             ;; Require every gated emit-site host ns so the reachability
             ;; graph includes their compiled bodies — DCE only proves the
             ;; gated branches dead from a reachable module.
-            [re-frame.http.managed :as http-managed]
-            [re-frame.http.registry :as http-registry]
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.registry :as rf.http.registry]
             [re-frame.http.transport]
             [re-frame.http.decode]
             ;; Listener mutation belongs to the tooling namespace.
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter
      :init-fn (fn []
                 ;; Defonce'd indexes need to be clean between tests so a
                 ;; leaked handle from one test doesn't influence another.
-                (http-managed/clear-all-in-flight!))}))
+                (rf.http.managed/clear-all-in-flight!))}))
 
 ;; ---- helpers --------------------------------------------------------------
 
@@ -63,14 +63,14 @@
   [body-fn]
   (let [seen   (atom [])
         cb-key (keyword (str "elision-prod-" (gensym)))]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       cb-key
       (fn [ev] (swap! seen conj ev)))
     (try
       (body-fn)
       @seen
       (finally
-        (trace-tooling/unregister-listener! cb-key)))))
+        (rf.trace.tooling/unregister-listener! cb-key)))))
 
 ;; ---- :rf.http/aborted-on-actor-destroy elides under prod ----------------
 
@@ -86,11 +86,11 @@
           handle      {:abort-fn    (fn [_reason] (swap! aborts-seen inc))
                        :url         "https://prod-elision.example/test"
                        :sensitive?  false}
-          _           (http-registry/record-in-flight!
+          _           (rf.http.registry/record-in-flight!
                         :prod-elision/req-id actor-id handle)
           seen        (listener-fixture
                         (fn []
-                          (http-managed/abort-on-actor-destroy actor-id)))]
+                          (rf.http.managed/abort-on-actor-destroy actor-id)))]
       (is (= 1 @aborts-seen)
           ":abort-fn ran exactly once — host side-effect not elided")
       (is (empty? seen)
@@ -105,7 +105,7 @@
             the idempotency contract under prod-mode."
     (let [seen (listener-fixture
                  (fn []
-                   (http-managed/abort-on-actor-destroy
+                   (rf.http.managed/abort-on-actor-destroy
                      :prod-elision/never-spawned)))]
       (is (empty? seen)
           "no trace events for the idempotent no-handle path under prod"))))

--- a/implementation/http/test/re_frame/http_transport_security_test.clj
+++ b/implementation/http/test/re_frame/http_transport_security_test.clj
@@ -5,8 +5,8 @@
             [re-frame.http.handlers]
             [re-frame.http.transport]
             [re-frame.http.transport-jvm]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.trace :as trace])
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.trace :as rf.trace])
   (:import [java.net.http HttpClient HttpClient$Redirect HttpRequest]
            [java.time Duration]
            [java.util Optional]))
@@ -20,10 +20,10 @@
   (let [captured (atom [])
         cb-id    ::transport-security-cap]
     (try
-      (trace/register-listener! cb-id (fn [ev] (swap! captured conj ev)))
+      (rf.trace/register-listener! cb-id (fn [ev] (swap! captured conj ev)))
       (body-fn captured)
       (finally
-        (trace/unregister-listener! cb-id)))))
+        (rf.trace/unregister-listener! cb-id)))))
 
 ;; ---- header validation surfaces a trace ----------------------------------
 
@@ -402,10 +402,10 @@
   events, restoring the original in finally. Returns the body-fn's value."
   [body-fn]
   (let [dispatched (atom [])
-        original   (late-bind/get-fn :router/dispatch!)]
-    (late-bind/set-fn! :router/dispatch! (fn [ev opts] (swap! dispatched conj [ev opts])))
+        original   (rf.late-bind/get-fn :router/dispatch!)]
+    (rf.late-bind/set-fn! :router/dispatch! (fn [ev opts] (swap! dispatched conj [ev opts])))
     (try (body-fn dispatched)
-         (finally (late-bind/set-fn! :router/dispatch! original)))))
+         (finally (rf.late-bind/set-fn! :router/dispatch! original)))))
 
 (deftest emit-and-dispatch-failure-emits-and-dispatches-non-supersede
   (testing "rf2-sixs3 — for a NON-supersede failure the helper both emits

--- a/implementation/http/test/re_frame/http_url_percent_encoded_redaction_cljs_test.cljc
+++ b/implementation/http/test/re_frame/http_url_percent_encoded_redaction_cljs_test.cljc
@@ -16,7 +16,7 @@
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing]]
       :cljs [cljs.test :refer-macros [deftest is testing]])
-   [re-frame.http.url :as url]))
+   [re-frame.http.url :as rf.http.url]))
 
 ;; App-specific carrier policy is passed explicitly to this leaf API, so no
 ;; registration or process cleanup is needed here.
@@ -28,53 +28,53 @@
 (deftest encoded-default-denylist-name-matches
   (testing "rf2-065xo — a percent-encoded DEFAULT-denylist name matches via the decoded form"
     ;; api%5Fkey decodes to api_key; %61ccess_token decodes to access_token.
-    (is (url/sensitive-query-param-name? "api%5Fkey"))
-    (is (url/sensitive-query-param-name? "%61ccess_token"))
+    (is (rf.http.url/sensitive-query-param-name? "api%5Fkey"))
+    (is (rf.http.url/sensitive-query-param-name? "%61ccess_token"))
     ;; case-insensitive on the decoded form too (%41PI%5FKEY → API_KEY).
-    (is (url/sensitive-query-param-name? "%41PI%5FKEY"))
+    (is (rf.http.url/sensitive-query-param-name? "%41PI%5FKEY"))
     ;; raw match path unchanged — plain names still match.
-    (is (url/sensitive-query-param-name? "api_key"))
-    (is (url/sensitive-query-param-name? "access_token"))))
+    (is (rf.http.url/sensitive-query-param-name? "api_key"))
+    (is (rf.http.url/sensitive-query-param-name? "access_token"))))
 
 (deftest encoded-frame-extra-denylist-name-matches
   (testing "a registration-declared carrier name matches when percent-encoded"
     (let [extras #{"shop_token"}]
       ;; shop%5Ftoken decodes to shop_token.
-      (is (url/sensitive-query-param-name? "shop%5Ftoken" extras))
-      (is (url/sensitive-query-param-name? "shop_token" extras))
+      (is (rf.http.url/sensitive-query-param-name? "shop%5Ftoken" extras))
+      (is (rf.http.url/sensitive-query-param-name? "shop_token" extras))
       ;; Without extensions the app carrier no longer matches.
-      (is (not (url/sensitive-query-param-name? "shop%5Ftoken"))
+      (is (not (rf.http.url/sensitive-query-param-name? "shop%5Ftoken"))
           "without extensions the app carrier does not match")
       ;; defaults are immutable — they match regardless of frame-extras.
-      (is (url/sensitive-query-param-name? "api%5Fkey")))))
+      (is (rf.http.url/sensitive-query-param-name? "api%5Fkey")))))
 
 (deftest non-sensitive-encoded-name-does-not-match
   (testing "rf2-065xo — an encoded NON-denylisted name stays non-sensitive"
     ;; page%5Fnum decodes to page_num — not denylisted.
-    (is (not (url/sensitive-query-param-name? "page%5Fnum")))
-    (is (not (url/sensitive-query-param-name? "user%5Fid")))))
+    (is (not (rf.http.url/sensitive-query-param-name? "page%5Fnum")))
+    (is (not (rf.http.url/sensitive-query-param-name? "user%5Fid")))))
 
 (deftest malformed-escape-falls-back-to-raw-never-throws
   (testing "rf2-065xo — a malformed percent-escape decodes to nil; matching falls back to the raw name and never throws"
     ;; Truncated / invalid escapes — must not throw on either host.
-    (is (false? (url/sensitive-query-param-name? "api%5")))
-    (is (false? (url/sensitive-query-param-name? "%zz")))
-    (is (false? (url/sensitive-query-param-name? "page%")))
+    (is (false? (rf.http.url/sensitive-query-param-name? "api%5")))
+    (is (false? (rf.http.url/sensitive-query-param-name? "%zz")))
+    (is (false? (rf.http.url/sensitive-query-param-name? "page%")))
     ;; A denylisted RAW name carrying a trailing malformed escape STILL
     ;; matches via the raw path (the decode bails to nil; raw is consulted
     ;; first and matches the plain segment only if it IS the denylisted
     ;; name). Here `token` is denylisted raw; `token%` is not the raw name
     ;; nor a valid decode, so it correctly does not match — proving no
     ;; crash and a sane fallback.
-    (is (false? (url/sensitive-query-param-name? "token%")))
+    (is (false? (rf.http.url/sensitive-query-param-name? "token%")))
     ;; But a valid-raw denylisted name is unaffected by the decode attempt.
-    (is (true? (url/sensitive-query-param-name? "token")))))
+    (is (true? (rf.http.url/sensitive-query-param-name? "token")))))
 
 (deftest sensitive-query-param-name-tolerates-non-string
   (testing "rf2-065xo — nil / non-string is not sensitive and never throws"
-    (is (false? (url/sensitive-query-param-name? nil)))
-    (is (false? (url/sensitive-query-param-name? :keyword)))
-    (is (false? (url/sensitive-query-param-name? 42)))))
+    (is (false? (rf.http.url/sensitive-query-param-name? nil)))
+    (is (false? (rf.http.url/sensitive-query-param-name? :keyword)))
+    (is (false? (rf.http.url/sensitive-query-param-name? 42)))))
 
 ;; ---------------------------------------------------------------------------
 ;; redact-url-query-string — end-to-end: encoded name's VALUE is redacted
@@ -82,7 +82,7 @@
 
 (deftest redact-url-encoded-default-name-value-redacted
   (testing "rf2-065xo — a percent-encoded default-denylist param has its VALUE redacted; the raw name spelling is preserved"
-    (let [[redacted any?] (url/redact-url-query-string
+    (let [[redacted any?] (rf.http.url/redact-url-query-string
                             "https://api.example.com/x?api%5Fkey=SECRET&page=2"
                             false)]
       (is (= "https://api.example.com/x?api%5Fkey=:rf/redacted&page=2" redacted)
@@ -92,7 +92,7 @@
 
 (deftest redact-url-encoded-name-leading-escape-value-redacted
   (testing "rf2-065xo — %61ccess_token (= access_token) value is redacted"
-    (let [[redacted any?] (url/redact-url-query-string
+    (let [[redacted any?] (rf.http.url/redact-url-query-string
                             "https://api.example.com/x?%61ccess_token=SECRET&q=hi"
                             false)]
       (is (= "https://api.example.com/x?%61ccess_token=:rf/redacted&q=hi" redacted))
@@ -101,7 +101,7 @@
 (deftest redact-url-encoded-frame-extra-name-value-redacted
   (testing "a registration-declared carrier name, percent-encoded, has its value redacted"
     (let [extras #{"shop_token"}
-          [redacted any?] (url/redact-url-query-string
+          [redacted any?] (rf.http.url/redact-url-query-string
                             "https://api.example.com/x?shop%5Ftoken=SECRET&page=2"
                             false extras)]
       (is (= "https://api.example.com/x?shop%5Ftoken=:rf/redacted&page=2" redacted))
@@ -109,7 +109,7 @@
 
 (deftest redact-url-malformed-escape-does-not-throw-and-passes-through
   (testing "rf2-065xo — a malformed percent-escape in a non-denylisted name does not throw and is preserved unchanged"
-    (let [[redacted any?] (url/redact-url-query-string
+    (let [[redacted any?] (rf.http.url/redact-url-query-string
                             "https://api.example.com/x?weird%5=v&page=2"
                             false)]
       (is (= "https://api.example.com/x?weird%5=v&page=2" redacted)
@@ -118,7 +118,7 @@
 
 (deftest redact-url-malformed-escape-on-other-param-still-redacts-real-denylist-hit
   (testing "rf2-065xo — a malformed escape elsewhere in the URL does not stop a real (encoded) denylisted name from being redacted"
-    (let [[redacted any?] (url/redact-url-query-string
+    (let [[redacted any?] (rf.http.url/redact-url-query-string
                             "https://api.example.com/x?weird%5=v&api%5Fkey=SECRET"
                             false)]
       (is (= "https://api.example.com/x?weird%5=v&api%5Fkey=:rf/redacted" redacted))

--- a/implementation/http/test/re_frame/http_url_validation_test.clj
+++ b/implementation/http/test/re_frame/http_url_validation_test.clj
@@ -19,15 +19,15 @@
   had weaker guarding than the optional ones."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.http.handlers :as handlers]
-            [re-frame.http.managed :as http-managed]
-            [re-frame.test-support :as test-support]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.http.handlers :as rf.http.handlers]
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---- per-test reset --------------------------------------------------------
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 
@@ -38,7 +38,7 @@
   Supplies a `:reply-to` so the request satisfies the mandatory reply
   addressing (rf2-et4c1s) and this suite isolates the `:url` guard."
   [request]
-  (try (handlers/managed-handler {:frame :rf/default :event [:no-op]}
+  (try (rf.http.handlers/managed-handler {:frame :rf/default :event [:no-op]}
                                  {:request request :reply-to [:no-op]})
        nil
        (catch clojure.lang.ExceptionInfo e e)))

--- a/implementation/http/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/http/test/re_frame/late_bind_missing_test.clj
@@ -28,7 +28,7 @@
   throw contract, so it is not exercised here."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.core :as rf]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.late-bind :as rf.late-bind]
             ;; Loading http-managed registers its production late-bind
             ;; hooks (middleware, registry). The stub-family hooks
             ;; publish from `re-frame.http.test-support` per rf2-lwmgw.
@@ -42,12 +42,12 @@
   "Run `f` with the named late-bind hook set to nil. Restores the
   original value after `f` returns or throws."
   [hook-key f]
-  (let [original (late-bind/get-fn hook-key)]
+  (let [original (rf.late-bind/get-fn hook-key)]
     (try
-      (late-bind/set-fn! hook-key nil)
+      (rf.late-bind/set-fn! hook-key nil)
       (f)
       (finally
-        (late-bind/set-fn! hook-key original)))))
+        (rf.late-bind/set-fn! hook-key original)))))
 
 ;; The raw install/uninstall pair is no longer a `re-frame.core` façade
 ;; export (rf2-ntwwyt) — it carries no late-bind hook and no missing-artefact

--- a/implementation/http/test/re_frame/routing_http_composed_corners_test.clj
+++ b/implementation/http/test/re_frame/routing_http_composed_corners_test.clj
@@ -26,12 +26,12 @@
       precedence."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.http.managed :as http-managed]
+            [re-frame.fx :as rf.fx]
+            [re-frame.http.managed :as rf.http.managed]
             [re-frame.http.test-support]
             [re-frame.routing]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---- fixture --------------------------------------------------------------
 
@@ -42,7 +42,7 @@
 ;; "nav-2" stable across tests). It also clears trace listeners and, per
 ;; rf2-q14tde, the per-frame HTTP interceptor chain.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- helpers --------------------------------------------------------------
 
@@ -154,7 +154,7 @@
                   {:params    [:map [:id :string]]
                    :can-leave :editor/blocked?} "/editor/:id")
     (rf/reg-route :route/home {} "/")
-    (fx/reg-fx :rf.nav/push-url
+    (rf.fx/reg-fx :rf.nav/push-url
                {:platforms #{:server :client}}
                (fn [_ _] nil))
 
@@ -201,11 +201,11 @@
     ;; both-index invariants) without requiring an unsettled real network
     ;; or a brittle stub (rf2-hp772l — was a raw `swap!` of the in-flight
     ;; atom).
-    (http-managed/seed-in-flight-for-test!
+    (rf.http.managed/seed-in-flight-for-test!
       {:request-id :editor.save/draft
        :url        "/api/editor/draft"
        :abort-fn   (fn [_] nil)})
-    (is (contains? (http-managed/in-flight-snapshot) :editor.save/draft)
+    (is (contains? (rf.http.managed/in-flight-snapshot) :editor.save/draft)
         "precondition: in-flight registry holds the active-route request")
 
     ;; User requests navigation to /home — leave guard blocks; pending-nav populates.
@@ -230,7 +230,7 @@
       ;; cancel of the navigation does not abort requests issued by the
       ;; route the user is staying on. Cleanup is the user's
       ;; responsibility (or the request's natural completion / abort).
-      (is (contains? (http-managed/in-flight-snapshot) :editor.save/draft)
+      (is (contains? (rf.http.managed/in-flight-snapshot) :editor.save/draft)
           "post-cancel: in-flight registry still holds the active-route's request — cancel does NOT abort active-route HTTP")
 
       ;; Slice still reflects the active route (no nav happened).
@@ -260,7 +260,7 @@
     ;; Use a sibling route that's an actual valid URL (not /home which
     ;; would be :route/root). /sibling has its own route entry.
     (rf/reg-route :route/sibling {} "/sibling")
-    (fx/reg-fx :rf.nav/push-url
+    (rf.fx/reg-fx :rf.nav/push-url
                {:platforms #{:server :client}}
                (fn [_ url] nil))
 
@@ -278,7 +278,7 @@
       ;; via :rf.route/transitioned dispatched from :rf.route/url-requested.
       (let [pushed (atom [])]
         (rf/clear-fx :rf.nav/push-url)
-        (fx/reg-fx :rf.nav/push-url
+        (rf.fx/reg-fx :rf.nav/push-url
                    {:platforms #{:server :client}}
                    (fn [_ url] (swap! pushed conj url)))
 
@@ -342,7 +342,7 @@
     (let [[recorded unreg] (record! ::stale-cycle)
           pushed           (atom [])]
       (try
-        (fx/reg-fx :rf.nav/push-url
+        (rf.fx/reg-fx :rf.nav/push-url
                    {:platforms #{:server :client}}
                    (fn [_ url] (swap! pushed conj url)))
 

--- a/scripts/require-alias-baseline.edn
+++ b/scripts/require-alias-baseline.edn
@@ -29,7 +29,7 @@
   "implementation/event-conformance"      21
   "implementation/flows"                  155
   "implementation/hicasso"                1017
-  "implementation/http"                   272
+  "implementation/http"                   0
   "implementation/machines"               0
   "implementation/reply-conformance"      13
   "implementation/resources"              0


### PR DESCRIPTION
`implementation/http` was believed migrated and was not. `rf2-j5or`'s notes assert that "core, routing, http and (with this PR) machines are clean"; three of those four are. The repo-wide ratchet built yesterday (rf2-ydpr, PR #9135) measured http at **272 non-canonical require edges across its 65 tracked Clojure files** (307 edges total) — in `src/` as well as `test/`. This is the fifth artefact sweep, matching core + routing (#9103), machines (#9114) and resources (#9129).

The rule is `spec/Conventions.md` §Require-alias dialect: `re-frame.core` keeps the bare root alias `rf`, every other `re-frame.<tail>` takes the **full dotted** `rf.<tail>` (so `re-frame.http.transport` takes `rf.http.transport`, not a shorter variant), and the bare leaf form is reserved for application namespaces.

## The census reconciles to 272 exactly, on two independent instruments

The bead's 272 is not taken on trust and not re-run through the same tool twice. A second scanner was written from scratch for this sweep — balanced-bracket libspec discovery over reader-masked text, its own `:as` / `:as-alias` extraction, its own derived exemption predicate — and both agree, before and after:

| | files | edges | non-canonical | unparseable |
|---|---|---|---|---|
| ratchet, before | 65 | 307 | **272** | 0 |
| independent scanner, before | 65 | 307 | **272** | 0 |
| ratchet, after | 65 | 307 | **0** | 0 |
| independent scanner, after | 65 | 307 | **0** | 0 |

**No discrepancy to explain, and no dedup adjustment either.** The machines sweep read 841 textual edges against its bead's 835, reconciled as 2 host-conditional exemption edges plus `.cljc` reader-arm duplication. Http needs neither: edges deduplicated per `(file, namespace, alias)` equal raw edges (307 = 307), so no `.cljc` binds one alias to one namespace twice across reader arms.

## What moved, and what deliberately did not

272 libspec `:as` sites, plus the **1401** qualified use sites that move with them:

* **1384** plain symbol references (`(rf.trace/emit! ...)`, `(rf.http.json/json-parse ...)`).
* **17** `@#'alias/y` **var-quotes**. These resolve through the alias and so move. They are the one shape a naive "preceded by a symbol character means skip" rule gets wrong, because the apostrophe is both a reader macro and a legal symbol-body character; the rewriter fails closed on any apostrophe-prefixed form whose preceding character is not `#` rather than guessing.

Not moved, each separated **by construction** rather than by a word boundary:

* **7** literal single-colon `:alias/key` keywords whose first segment collides with a live alias — `:router/dispatch!` in `http/test_support.cljc`, `:frame/req` in `http_cljs_test.cljs`. This is the trap that silently rewrote 42 late-bind keys on the machines sweep's first pass.
* **85** `:rf.error/*` reserved keywords, matched while searching for the `error` alias.
* **51** `http-test-support/` sites found while searching for the shorter `test-support/` alias (longest-alias-first ordering plus a preceding-character guard).
* **11** fully-qualified `re-frame.http.*/` references, including three surviving `@#'re-frame.http.handlers/...` var-quotes.

### The control that proves no keyword id moved

The multiset of **every literal single-colon `:ns/name` keyword across the artefact is IDENTICAL before and after — 387 distinct keywords, 2398 occurrences, zero entries changed.** The instrument was exercised against an input it should flag rather than trusted for returning nothing: rewriting one `:router/dispatch!` to `:rf.router/dispatch!` in a scratch plant produced exactly the shape the machines sweep's control caught (`rf.router/dispatch!` 0 to 1, `router/dispatch!` 20 to 19), and the bytes restored identically afterwards.

## Host-conditional exemptions: ZERO in http

The derived predicate — one alias bound to 2+ distinct namespaces within one file, never a path allowlist — finds **no exemption anywhere in the 65 files**. Http joins core at zero; machines has 1 file, routing 8, resources 12 files / 24 edges.

## The splicing reader-conditional shape does NOT appear in http

The sixth shape found live in core during the ratchet's build — `[re-frame.trace :as rf.trace #?@(:cljs [:include-macros true])]`, a reader conditional splicing *options* into the libspec, 26 sites there — has **no instance in http**: zero libspec vectors contain a reader conditional at all. Neither does the prefix-list form. The scanner reports these rather than stepping over them, so the zero is a measurement, not an omission.

## `::alias/key` has no subject here either

There is **not one auto-resolved `::x/y` keyword anywhere in `implementation/http`**, so the `scripts/check_keyword_catalogue_drift.py` CHECK B gap — its extractor cannot tell `::rf.x/y` from `:rf.x/y` and would demand a false reservation row in the one-toucher `spec/Conventions.md` — has nothing to fire on. Run live: findings identical before and after, exit 0 both, and its `--self-test` exit 0. **`spec/Conventions.md` was not edited and needed no edit.**

## Source-scanning gates: none needed widening, and that is MEASURED, not reasoned

Several gates read http source as text. Each was run, and two were proven live against a planted fault, because a gate that forbids a shape **fails open** on a spelling it cannot see.

* **`scripts/check_ambient_durable_reads.py`** names `implementation/http/src/re_frame/http/reply.cljc` in its durable-write scan surface. Its clock read-form was widened for the resources sweep to accept an optional `rf.` prefix, and that widening covers http: a planted `:completed-at (rf.interop/now-ms)` at `reply.cljc:166` returns **exit 1** naming the file, line and read form. Restored, blob hash `72612fd5be681ab27f3167148121463021fe99d6`. Live gate and `--self-test` both exit 0.
* **`late_bind_drift_test`** scans `implementation/**/src`, and http *has* subjects there (16 `late-bind/set-fn!` sites in `http/managed.cljc`). Its pattern already carries the optional `rf.` prefix, and it is not blind to the migrated spelling: a planted `:http/abort-in-flightZZZ!` returns **exit 1** with two failures naming the key. Restored, blob hash `3734733339e050421fe574fddfa33773fbbc0e51`.
* **`warn_once_clear_governance_test`** scans the same tree; its `chain-fn!` pattern carries the same optional prefix, and http src has no warn-once subject.
* **`scope_ensure_authority_test`** pins `http/middleware.cljc` on prose patterns naming the SCOPE/ENSURE boundary pair, which are alias-insensitive.
* **`tools/mcp-conformance/wire-vocab`** reads three http src files but reader-parses them and asserts on keyword map keys — 94 tests / 1031 assertions, exit 0.

## The ratchet baseline row

**PR #9135 has not merged** (verified by payload — `git log origin/main --grep=rf2-ydpr` is empty and neither `scripts/check_require_alias_dialect.py` nor `scripts/require-alias-baseline.edn` exists on `main`), so `scripts/` is untouched here: it belongs to `worker/ratchet-a`. When #9135 lands, its baseline row must become:

```
  "implementation/http"                   0
```

down from 272, and the file's `:min-edges` total is unaffected (307 http edges remain; only their aliases changed). Until then the ratchet's own "surface now BELOW its floor" report is the mechanism that will surface it.

## Alignment

Continuation lines inside multi-line call forms are left unshifted, matching what the machines and routing sweeps landed (`rf.trace/emit!` call sites on `main` today read the same way). Consistency with the four sibling sweeps beats a 1384-site whitespace diff.

## Concurrency

`worker/dispatchlater-a` (PR #9134) holds http *source semantics* for rf2-2xzc. Its file list is `examples/real-apps/realworld_http/schema.cljs` and `implementation/core/test/re_frame/example_realworld_boot_seed_cljs_test.cljs` — **zero overlap** with the 63 files here, all of which are under `implementation/http/`. No commit touching `implementation/http` landed on `main` between this branch's base and its rebase target, so nothing here reverts a sibling's work.

## Byte-level verification

Every one of the 67 tracked files under `implementation/http` was counted before and after: **CRLF 26307, LF 26307, bare CR 0, non-ASCII bytes 8148, UTF-8 decode failures 0 — with zero per-file delta on any of those four.** No line-ending flip and no cp1252 damage. `git diff --check` clean.

## Gates — every number captured to a file and read back, never through a pipe

Re-run on the **final rebased base**, not only on the pre-rebase tree:

| gate | result | exit |
|---|---|---|
| `implementation/http` JVM (`clojure -M:test`) | 506 tests / 3882 assertions, 0 failures, 0 errors | **0** |
| `npm run test:cljs` — compile step | 1890 files, 0 warnings | **0** |
| `npm run test:cljs` — run step | 11165 tests / 55711 assertions, 0 failures, 0 errors | **0** |
| clj-kondo `--lint implementation/http` | 34 warnings, 0 errors | **0** |
| clj-kondo vs pristine pre-sweep tree | 34 warnings both sides, **zero delta** once columns and alias text are normalised | **0** |
| require-alias ratchet, `--scan-path implementation/http` | 65 files, 307 edges, **0 non-canonical**, 0 unparseable | **0** |
| `check_ambient_durable_reads.py` (live + `--self-test`) | findings identical to pre-sweep | **0** / **0** |
| `check_keyword_catalogue_drift.py` (live + `--self-test`) | findings identical to pre-sweep | **0** / **0** |
| core `late-bind-drift` + `warn-once-clear-governance` + `scope-ensure-authority` | 12 tests / 736 assertions, 0 failures | **0** |
| `tools/mcp-conformance/wire-vocab` | 94 tests / 1031 assertions, 0 failures | **0** |

The http JVM gate was proven live before its green was believed: a planted `rf.errorZZZ/throw-error!` returned **exit 1** naming `re_frame/http/decode.cljc:229:9`, and restoring returned blob hash `f82510a72b84c63bde05ac826145b6f42ccfdf51`. The fault existed only in this worktree, so a run that had wandered into a sibling checkout would have come back green.

`npm ci` was run from the lockfile into this worktree's own `implementation/node_modules` rather than linking to a shared tree, because the CLJS gate runs an installer and an installer writes *through* a link.

## Not done, deliberately

No `scripts/` edit (`worker/ratchet-a`'s lane), no `spec/` edit, no `.github/workflows/` edit, no `implementation/` tree outside `http/`, no `tools/`, `skills/` or `examples/` source. This sweep changes require aliases and the use sites that move with them — nothing else.

Closes rf2-r79e.
