### PR TITLE
fix(examples): realworld-resources app-db schemas tolerate absence (rf2-ghxt)

### DIFF
--- a/examples/real-apps/realworld_resources/schema.cljs
+++ b/examples/real-apps/realworld_resources/schema.cljs
@@ -91,16 +91,58 @@
 ;; SCHEMA REGISTRATION
 ;; ============================================================================
 ;;
-;; reg-app-schemas is frame-local, so a bare ns-load call with no frame context
-;; would fail. This app runs in `:rf/default` (the `frame-root {:id …}` form
-;; in core.cljs creates it at the render root), so we name that id here. Worth
-;; being precise about what this is: a frame-local registration scoped by id, not
-;; a frame creation or seed. It binds the id at ns-load; the frame itself doesn't
-;; exist until the provider first renders.
+;; WHY EVERY SLICE WEARS A `:maybe`. Validation is not scoped to the paths the
+;; committing event touched: at every `:db` commit the runtime walks EVERY
+;; registered path with `get-in` over the whole candidate app-db and rejects the
+;; entire transaction if any one of them fails (Spec 010 §Per-step recovery
+;; row 4 — the candidate is discarded, and `:fx` does not walk either). A path
+;; nothing has written yet reads `nil`, and `nil` is not a `[:map …]`.
+;;
+;; Two different reasons apply here, and it's worth keeping them apart:
+;;
+;;   THE BOOT WINDOW — `[:auth]`, `[:auth :login-form]`, `[:auth :register-form]`.
+;;   app-db starts `{}` and each of these is seeded by its OWN event:
+;;   `:auth/initialise` is its own `:initial-events` step (it consumes a
+;;   recordable token coeffect), and the two form drafts are separate dispatches
+;;   fanned out from `:app/initialise` (core.cljs). Separate events, separate
+;;   commits. Register these bare and the FIRST seed is rejected by the siblings
+;;   that have not been seeded yet, and so is every later one — app-db never
+;;   leaves `{}` and the app renders empty everywhere. The `:maybe` buys exactly
+;;   the window before a slice's seed lands; once it has, the schema is doing its
+;;   full job. `examples/patterns/boot/schema.cljs` wears its `:maybe`s for this
+;;   same reason.
+;;
+;;   ABSENT BY DESIGN — `[:settings-form]`. This one is not a boot-window case at
+;;   all: nothing seeds it at boot and nothing should. `:settings/load` seeds the
+;;   draft FROM the authenticated user on settings-route entry (settings.cljs),
+;;   and that route is auth-guarded — so for an anonymous visitor, and for a
+;;   signed-in one who never opens Settings, the path is legitimately nil for the
+;;   whole life of the app. Seeding it at boot would only manufacture an empty
+;;   draft from a user who isn't there yet, to be overwritten on entry. Its
+;;   `:maybe` is therefore permanent, not a window.
+;;
+;; Note this all bites in DEVELOPMENT ONLY: `validate-app-schema!` puts its whole
+;; body inside `(if interop/debug-enabled? … true)`, so a release build installs
+;; every candidate unchecked. Dev and release would otherwise disagree about
+;; whether this app can boot at all — and dev is the build every consumer
+;; develops against.
+;;
+;; One wrinkle: reg-app-schemas is frame-local, so a bare ns-load call with no
+;; frame context would fail. This app runs in `:rf/default` (the
+;; `frame-root {:id …}` form in core.cljs creates it at the render root), so we
+;; name that id here. Worth being precise about what this is: a frame-local
+;; registration scoped by id, not a frame creation or seed. It binds the id at
+;; ns-load; the frame itself doesn't exist until the provider first renders.
+
+(def app-db-schemas
+  "This app's app-db schema registry as a `{path -> schema}` VALUE, so the same
+   set can be registered against a frame other than `:rf/default` — registration
+   is frame-local, and a harness driving its own frame gets no schemas at all
+   unless it asks for these by name."
+  {[:auth]                 [:maybe AuthSlice]
+   [:auth :login-form]     [:maybe FormSlice]
+   [:auth :register-form]  [:maybe FormSlice]
+   [:settings-form]        [:maybe FormSlice]})
 
 (rf/with-frame :rf/default
-  (rf/reg-app-schemas
-    {[:auth]                 AuthSlice
-     [:auth :login-form]     FormSlice
-     [:auth :register-form]  FormSlice
-     [:settings-form]        FormSlice}))
+  (rf/reg-app-schemas app-db-schemas))

--- a/implementation/core/test/re_frame/example_realworld_resources_boot_seed_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_realworld_resources_boot_seed_cljs_test.cljs
@@ -101,18 +101,24 @@
 ;; co-loaded. cljs.test loads every test ns into ONE bundle, so both apps' rows
 ;; sit in the shared source store, and two provenance rows for one id fail
 ;; default-image assembly loud (`:rf.error/image-duplicate-id`) for every suite
-;; whose baseline is captured after the second app loads. Sequester the SIBLING
-;; app's tree here, at ns load and BEFORE the fixture below captures its
-;; baseline, so this suite's frames resolve the resources app's implementations.
-;; The realworld-http suites reinstate their own tree in their fixture init.
-(rf.test-support/sequester-app-namespaces! "realworld-http.")
-
+;; whose baseline is captured after the second app loads. So the sibling app's
+;; tree is sequestered below, per test, and the realworld-http suites reinstate
+;; their own tree in their fixture init.
+;;
+;; THE SEQUESTER CALL BELONGS IN `:init-fn`, NOT AT NS LOAD, and the difference
+;; is not cosmetic. `sequester-app-namespaces!` captures the prefix's rows ONCE
+;; and MEMOIZES them, scrubbing only that captured set on every later call. A
+;; call at THIS ns's load runs while the bundle is still loading — this ns sorts
+;; ahead of the two RealWorld integration suites, so `realworld-http.tags` (and
+;; the rest of the app beyond the few feature nses loaded ahead of us) is not
+;; there yet — and the incomplete capture is then the memo EVERY suite gets
+;; afterwards. Measured: an ns-load call here left `:home/show-global-feed`
+;; unsequestered and failed the sibling resources suite's own frame creation
+;; with `:rf.error/image-duplicate-id`. By `:init-fn` time every test ns has
+;; loaded, so the capture is complete whether it is ours or a sibling's.
 (use-fixtures :each
   (rf.test-support/make-reset-runtime-fixture
     {:adapter rf.adapter.reagent/adapter
-     ;; The merge-form source-store restore preserves slots this suite's baseline
-     ;; does not know about, so re-sequester per test as the sibling resources
-     ;; suite does.
      :init-fn (fn [] (rf.test-support/sequester-app-namespaces! "realworld-http."))}))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/core/test/re_frame/example_realworld_resources_boot_seed_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_realworld_resources_boot_seed_cljs_test.cljs
@@ -1,8 +1,8 @@
 (ns re-frame.example-realworld-resources-boot-seed-cljs-test
   "rf2-ghxt — THE BOOT WINDOW, RealWorld-on-resources: an app whose slices are
    seeded by SEPARATE events must still boot under its own app-db schema
-   registry, and a slice that is absent BY DESIGN must not veto every commit
-   the app will ever make.
+   registry, and a slice that is absent BY DESIGN must not veto every commit the
+   application will ever make.
 
    THE DEFECT. A development build of `:examples/realworld-resources` booted to
    nothing: `app-db` still `{}`, zero article cards, `#app` a bare shell. No page
@@ -18,31 +18,32 @@
    unwritten path reads `nil` — which is not a `[:map …]`. Registered bare, the
    four paths therefore veto each other:
 
-     [:auth]                seeded by `:auth/initialise` (its own `:initial-events`
-                            step — it consumes a recordable token coeffect)
+     [:auth]                 seeded by `:auth/initialise` — its own
+                             `:initial-events` step, since it consumes a
+                             recordable token coeffect
      [:auth :login-form]     seeded by `:auth.login-form/initialise`
      [:auth :register-form]  seeded by `:auth.register-form/initialise`
      [:settings-form]        NOT SEEDED AT BOOT AT ALL
 
    The first three are a boot WINDOW: each is its own dispatch (the two form
    initialisers are fanned out from `:app/initialise` in core.cljs), so each seed
-   is its own commit and each is rejected by the siblings still absent.
+   is its own commit, and each was rejected by the siblings still absent.
 
    The fourth is worse, and is why this example failed harder than its
    managed-HTTP twin (rf2-2xzc). `[:settings-form]` is seeded by `:settings/load`
    on settings-ROUTE ENTRY, behind an auth guard — so for an anonymous visitor,
    and for a signed-in one who never opens Settings, it reads `nil` for the whole
-   life of the app. Registered bare it rejects EVERY `:db` commit in the
+   life of the app. Registered bare it rejected EVERY `:db` commit in the
    application, permanently, not only during boot. And because a rejected
    candidate does not walk `:fx` either, nothing downstream of a `:db`-bearing
-   handler fires.
+   handler fired.
 
    THE FIX. Every entry wears a `:maybe`, and `schema.cljs` names the registry as
    the VALUE `app-db-schemas` so a harness can install it on its own frame. For
    the first three the `:maybe` buys exactly the window before that slice's seed
    lands; for `[:settings-form]` it is permanent, because absence there is the
-   design rather than a window (seeding it at boot would only manufacture an
-   empty draft from a user who is not signed in yet, to be overwritten on entry).
+   design rather than a window — seeding it at boot would only manufacture an
+   empty draft from a user who is not signed in yet, to be overwritten on entry.
 
    WHY DEV ONLY. `validate-app-schema!` puts its whole body inside
    `(if interop/debug-enabled? … true)`, so a production build returns `true`
@@ -67,16 +68,35 @@
    the bare one refuses — so a validator that had gone quiet fails the second
    test rather than silently passing the first.
 
-   Feature nses only, never `realworld-resources.core` — requiring core would
-   pull `routing.cljs` and register the app's routes (including the reserved
-   per-app `:rf.route/not-found`) into the shared node-test registrar.
-   `:app/initialise` and `:auth/classify-token` live in core, so the boot
-   fan-out they perform is spelled out in `boot!` below."
+   WHY THE SEEDS BELOW ARE LOCAL EVENTS RATHER THAN THE APP'S OWN. This ns
+   requires the example's `schema` ns and NOTHING else from the app, because
+   `reg-app-schemas` writes no registrar or source-store row — so this ns cannot
+   collide with anything. Requiring the app's EVENT nses would, and does:
+   cljs.test loads every test ns into one bundle, the two RealWorld apps
+   deliberately share id vocabulary (`:settings/load`, `:auth/initialise`,
+   `:auth.login-form/initialise`, … are registered by BOTH with different
+   implementations), and this ns sorts early. Measured on this tree: requiring
+   `realworld-resources.auth` / `.settings` here put a second provenance row for
+   those ids into the shared source store from this ns's load onward, and every
+   alphabetically-later suite's baseline then failed default-image assembly with
+   `:rf.error/image-duplicate-id` — dozens of unrelated tests, in nine
+   namespaces. Sequestering the sibling tree from here does not fix it either:
+   `sequester-app-namespaces!` captures a prefix's rows ONCE and memoizes them,
+   so a call this early captures an incomplete set and that becomes the memo the
+   later suites get (measured: `:home/show-global-feed` left unsequestered,
+   failing the sibling resources suite's own frame creation).
+
+   So the seeds below are local events that reproduce the app's own writes —
+   same paths, same slice shapes, one dispatch each. What is under test is the
+   REGISTRY, which is the artefact that was wrong and which is imported from the
+   example verbatim; the seeds are the boot fan-out's shape, and the shape is
+   what the registry has to tolerate. The app's own handlers, driven against a
+   hand-registered `[:auth]`, are covered by the example's integration suite in
+   the adapter tree."
   (:require [cljs.test :refer-macros [deftest testing is use-fixtures]]
-            [clojure.string :as str]
+            [malli.core :as m]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
-            [re-frame.registrar :as rf.registrar]
             [re-frame.adapter.reagent :as rf.adapter.reagent]
             [re-frame.test-support :as rf.test-support]
             [re-frame.schemas]
@@ -86,99 +106,79 @@
             ;; would boot just as happily as the shipped one. This is also the
             ;; canonical app-boot opt-in for Malli app-schema validation.
             [re-frame.schemas.malli]
-            [re-frame.machines]
-            ;; resources app FEATURE nses (no core -> no routes). `settings`
-            ;; chains in `auth`, which chains in `http` / `scope` / `schema`.
-            [realworld-resources.schema :as app-schema]
-            [realworld-resources.auth]
-            [realworld-resources.settings])
+            ;; The example's app-db schema registry, imported verbatim. This ns
+            ;; registers no events / subs / fx / resources — see the ns doc.
+            [realworld-resources.schema :as app-schema])
   (:require-macros [re-frame.core :refer [with-new-frame]]))
 
-;; rf2-h1vqa4 BUNDLE CO-LOAD HYGIENE. The two RealWorld apps deliberately share
-;; id vocabulary — both register `:auth/initialise`, `:auth.login-form/initialise`,
-;; `:auth.register-form/initialise` and `:settings/load` with DIFFERENT
-;; implementations — and they are built and run as separate bundles, never
-;; co-loaded. cljs.test loads every test ns into ONE bundle, so both apps' rows
-;; sit in the shared source store, and two provenance rows for one id fail
-;; default-image assembly loud (`:rf.error/image-duplicate-id`) for every suite
-;; whose baseline is captured after the second app loads. So the sibling app's
-;; tree is sequestered below, per test, and the realworld-http suites reinstate
-;; their own tree in their fixture init.
-;;
-;; THE SEQUESTER CALL BELONGS IN `:init-fn`, NOT AT NS LOAD, and the difference
-;; is not cosmetic. `sequester-app-namespaces!` captures the prefix's rows ONCE
-;; and MEMOIZES them, scrubbing only that captured set on every later call. A
-;; call at THIS ns's load runs while the bundle is still loading — this ns sorts
-;; ahead of the two RealWorld integration suites, so `realworld-http.tags` (and
-;; the rest of the app beyond the few feature nses loaded ahead of us) is not
-;; there yet — and the incomplete capture is then the memo EVERY suite gets
-;; afterwards. Measured: an ns-load call here left `:home/show-global-feed`
-;; unsequestered and failed the sibling resources suite's own frame creation
-;; with `:rf.error/image-duplicate-id`. By `:init-fn` time every test ns has
-;; loaded, so the capture is complete whether it is ours or a sibling's.
 (use-fixtures :each
   (rf.test-support/make-reset-runtime-fixture
-    {:adapter rf.adapter.reagent/adapter
-     :init-fn (fn [] (rf.test-support/sequester-app-namespaces! "realworld-http."))}))
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ---------------------------------------------------------------------------
-;; The example's own boot fan-out, spelled out.
+;; The example's boot fan-out, reproduced as three separate commits.
 ;;
-;; The real app runs `:auth/classify-token`, `:auth/initialise` and
-;; `:app/initialise` as `:initial-events` (core.cljs); `:app/initialise` then
-;; fans out to the two form initialisers as SEPARATE dispatches. The two events
-;; that live in core are not driveable from here (requiring core would register
-;; the app's routes into the shared bundle), so what is driven below is the
-;; three `:db`-bearing seeds, each its own dispatch — which is the whole point
-;; of the regression: separate events mean separate commits.
+;; Paths and slice shapes are the app's (auth.cljs `:auth/initialise`,
+;; `:auth.login-form/initialise`, `:auth.register-form/initialise`). The ids are
+;; local so this ns stays collision-free in the shared bundle. What matters is
+;; that each seed is its OWN event — separate events mean separate commits, and
+;; that is the whole of the regression.
 ;; ---------------------------------------------------------------------------
+
+(rf/reg-event :rf2-ghxt.boot/seed-auth
+  (fn [{:keys [db]} _]
+    {:db (assoc db :auth {:user nil :token nil})}))
+
+(rf/reg-event :rf2-ghxt.boot/seed-login-form
+  (fn [{:keys [db]} _]
+    {:db (assoc-in db [:auth :login-form]
+                   {:draft {:email "" :password ""} :touched #{}})}))
+
+(rf/reg-event :rf2-ghxt.boot/seed-register-form
+  (fn [{:keys [db]} _]
+    {:db (assoc-in db [:auth :register-form]
+                   {:draft {:username "" :email "" :password ""} :touched #{}})}))
+
+;; An ordinary post-boot edit — the shape of every `:*-form/edit-field` handler.
+(rf/reg-event :rf2-ghxt.boot/edit-login-email
+  (fn [{:keys [db]} [_ value]]
+    {:db (-> db
+             (assoc-in [:auth :login-form :draft :email] value)
+             (update-in [:auth :login-form :touched] (fnil conj #{}) :email))}))
+
+;; `:settings/load`'s write: seeded from the authenticated user, on route entry,
+;; behind the auth guard (settings.cljs). `:touched` is seeded alongside `:draft`
+;; because FormSlice requires both.
+(rf/reg-event :rf2-ghxt.boot/load-settings-form
+  (fn [{:keys [db]} [_ user]]
+    {:db (assoc-in db [:settings-form]
+                   {:draft   {:image    (or (:image user) "")
+                              :username (or (:username user) "")
+                              :bio      (or (:bio user) "")
+                              :email    (or (:email user) "")
+                              :password ""}
+                    :touched #{}})}))
 
 (defn- boot!
-  "Drive the example's boot seeds into frame `f`, one dispatch per event exactly
-  as the app does. The ORDER is the app's and it matters: `:auth/initialise`
-  creates `[:auth]` in the AuthSlice shape before the two form initialisers
-  write inside it."
+  "Drive the three boot seeds into frame `f`, one dispatch each, in the app's
+  order — `[:auth]` is created in the AuthSlice shape before the two form
+  initialisers write inside it."
   [f]
-  (rf/dispatch-sync [:auth/initialise]
-                    {:frame f :rf.cofx {:realworld-resources.session/token nil}})
-  (rf/dispatch-sync [:auth.login-form/initialise] {:frame f})
-  (rf/dispatch-sync [:auth.register-form/initialise] {:frame f}))
+  (rf/dispatch-sync [:rf2-ghxt.boot/seed-auth] {:frame f})
+  (rf/dispatch-sync [:rf2-ghxt.boot/seed-login-form] {:frame f})
+  (rf/dispatch-sync [:rf2-ghxt.boot/seed-register-form] {:frame f}))
 
 (def ^:private pre-fix-bare-registry
   "The four registrations EXACTLY as `schema.cljs` carried them before rf2-ghxt —
-  bare, no `:maybe`. Kept here as the negative control: the shipped registry has
-  to permit a boot this one refuses."
+  bare, no `:maybe`. Kept as the negative control: the shipped registry has to
+  permit a boot this one refuses."
   {[:auth]                app-schema/AuthSlice
    [:auth :login-form]    app-schema/FormSlice
    [:auth :register-form] app-schema/FormSlice
    [:settings-form]       app-schema/FormSlice})
 
 ;; ---------------------------------------------------------------------------
-;; Provenance guard.
-;;
-;; Every id this suite drives is registered by BOTH RealWorld apps. If the
-;; sequester above ever stopped biting, these dispatches would silently exercise
-;; the managed-HTTP app's handlers instead — which seed the same shaped slices,
-;; so the assertions below would still pass while testing the wrong application.
-;; That is a fail-OPEN, so it gets an assertion of its own rather than a comment.
-;; ---------------------------------------------------------------------------
-
-(deftest the-resources-app-owns-the-ids-this-suite-drives
-  (testing "the live handlers for the ids both RealWorld apps register resolve to
-            the RESOURCES app — otherwise every green below is about the wrong app"
-    (doseq [id [:auth/initialise
-                :auth.login-form/initialise
-                :auth.register-form/initialise
-                :auth/store-session
-                :settings/load]]
-      (let [provenance (some-> (rf.registrar/handler-meta :event id) :ns str)]
-        (is (and (string? provenance)
-                 (str/starts-with? provenance "realworld-resources."))
-            (str "the live " id " handler comes from the resources app, not the "
-                 "managed-HTTP twin (got " (pr-str provenance) ")"))))))
-
-;; ---------------------------------------------------------------------------
-;; The regression itself.
+;; The regression.
 ;; ---------------------------------------------------------------------------
 
 (deftest boot-under-the-shipped-registry
@@ -204,9 +204,9 @@
             "the login-form slice really is the seeded draft shape")))))
 
 (deftest boot-under-the-pre-fix-bare-registry
-  (testing "the bare registry this file used to carry REJECTS the very first seed
-            — the regression, and the proof that the validator is live here (a
-            soft-passing validator would let this boot too)"
+  (testing "the bare registry this example used to carry REJECTS the very first
+            seed — the regression, and the proof that the validator is live here
+            (a soft-passing validator would let this boot too)"
     (with-new-frame [f (rf.frame/make-anon-frame-record! {})]
       (rf/reg-app-schemas pre-fix-bare-registry {:frame f})
       (boot! f)
@@ -225,35 +225,34 @@
       (is (nil? (get (rf/app-db-value f) :settings-form))
           "nothing seeded [:settings-form] at boot, and nothing should have —
            :settings/load seeds it from the authenticated user on route entry")
-      ;; An ordinary post-boot edit. Pre-fix this was rejected forever, because
-      ;; [:settings-form] read nil at every commit for the whole life of the app.
-      (rf/dispatch-sync [:auth.login-form/edit-field :email "alice@example.com"]
+      ;; Pre-fix this commit was rejected forever, because [:settings-form] read
+      ;; nil at every commit for the whole life of the application.
+      (rf/dispatch-sync [:rf2-ghxt.boot/edit-login-email "alice@example.com"]
                         {:frame f})
-      (is (= "alice@example.com" (get-in (rf/app-db-value f) [:auth :login-form :draft :email]))
+      (is (= "alice@example.com"
+             (get-in (rf/app-db-value f) [:auth :login-form :draft :email]))
           "an ordinary post-boot :db commit lands"))))
 
-(deftest settings-load-seeds-a-slice-that-validates
-  (testing ":settings/load seeds [:settings-form] from the authenticated user on
-            route entry, and the seeded slice satisfies the FormSlice the shipped
-            registry wraps — the `:maybe` widens the schema, it does not retire it"
+(deftest the-settings-slice-still-validates-once-route-entry-seeds-it
+  (testing "the settings draft, seeded from the authenticated user on route
+            entry, commits under the shipped registry — the `:maybe` widens the
+            schema, it does not retire it"
     (with-new-frame [f (rf.frame/make-anon-frame-record! {})]
       (rf/reg-app-schemas app-schema/app-db-schemas {:frame f})
       (boot! f)
-      ;; The settings route is auth-guarded, so there is always a user by the
-      ;; time :settings/load runs. Establish one the way the app does.
-      (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
-                                              :username "alice"
-                                              :token "jwt-abc"
-                                              :bio nil :image nil}]
+      (rf/dispatch-sync [:rf2-ghxt.boot/load-settings-form
+                         {:username "alice" :email "alice@example.com"
+                          :bio nil :image nil}]
                         {:frame f})
-      (rf/dispatch-sync [:settings/load] {:frame f})
       (let [slice (get (rf/app-db-value f) :settings-form)]
         (is (some? slice)
             "the settings draft is seeded on route entry")
         (is (= "alice" (get-in slice [:draft :username]))
             "the draft is seeded FROM the authenticated user")
-        (is (contains? slice :touched)
-            "`:touched` is seeded alongside `:draft` — FormSlice requires both")))))
+        (is (true? (m/validate app-schema/FormSlice slice))
+            "and it satisfies the UNWRAPPED FormSlice — the `:maybe` only added
+             tolerance of absence; a present-but-malformed slice is still
+             rejected")))))
 
 ;; ---------------------------------------------------------------------------
 ;; The shape of the fix, pinned structurally.
@@ -262,10 +261,12 @@
 (deftest every-shipped-registration-tolerates-absence
   (testing "each entry in the example's registry is nilable — unwrap any one of
             them and the boot window (or, for [:settings-form], the whole life of
-            the app) reopens"
+            the application) reopens"
     (doseq [[path schema] app-schema/app-db-schemas]
       (is (and (vector? schema) (= :maybe (first schema)))
-          (str "the registration at " path " tolerates absence")))
+          (str "the registration at " path " tolerates absence"))
+      (is (true? (m/validate schema nil))
+          (str "the registration at " path " really does admit nil")))
     (is (= #{[:auth] [:auth :login-form] [:auth :register-form] [:settings-form]}
            (set (keys app-schema/app-db-schemas)))
         "the registry still covers exactly the four app-db paths this app owns")))

--- a/implementation/core/test/re_frame/example_realworld_resources_boot_seed_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_realworld_resources_boot_seed_cljs_test.cljs
@@ -1,0 +1,265 @@
+(ns re-frame.example-realworld-resources-boot-seed-cljs-test
+  "rf2-ghxt — THE BOOT WINDOW, RealWorld-on-resources: an app whose slices are
+   seeded by SEPARATE events must still boot under its own app-db schema
+   registry, and a slice that is absent BY DESIGN must not veto every commit
+   the app will ever make.
+
+   THE DEFECT. A development build of `:examples/realworld-resources` booted to
+   nothing: `app-db` still `{}`, zero article cards, `#app` a bare shell. No page
+   error, no console error, no failed request. The same bundle in a RELEASE build
+   rendered correctly.
+
+   THE MECHANISM. `examples/real-apps/realworld_resources/schema.cljs` registers
+   four app-db path schemas against `:rf/default` at ns-load. app-db starts `{}`,
+   and the candidate validator walks EVERY registered path over the WHOLE
+   candidate app-db at EVERY `:db` commit (`(get-in db registered-path)` in
+   `re-frame.schemas.validate/validate-app-schema!`, Spec 010 §Per-step recovery
+   row 4). There is no exemption for a path nothing has written yet, and an
+   unwritten path reads `nil` — which is not a `[:map …]`. Registered bare, the
+   four paths therefore veto each other:
+
+     [:auth]                seeded by `:auth/initialise` (its own `:initial-events`
+                            step — it consumes a recordable token coeffect)
+     [:auth :login-form]     seeded by `:auth.login-form/initialise`
+     [:auth :register-form]  seeded by `:auth.register-form/initialise`
+     [:settings-form]        NOT SEEDED AT BOOT AT ALL
+
+   The first three are a boot WINDOW: each is its own dispatch (the two form
+   initialisers are fanned out from `:app/initialise` in core.cljs), so each seed
+   is its own commit and each is rejected by the siblings still absent.
+
+   The fourth is worse, and is why this example failed harder than its
+   managed-HTTP twin (rf2-2xzc). `[:settings-form]` is seeded by `:settings/load`
+   on settings-ROUTE ENTRY, behind an auth guard — so for an anonymous visitor,
+   and for a signed-in one who never opens Settings, it reads `nil` for the whole
+   life of the app. Registered bare it rejects EVERY `:db` commit in the
+   application, permanently, not only during boot. And because a rejected
+   candidate does not walk `:fx` either, nothing downstream of a `:db`-bearing
+   handler fires.
+
+   THE FIX. Every entry wears a `:maybe`, and `schema.cljs` names the registry as
+   the VALUE `app-db-schemas` so a harness can install it on its own frame. For
+   the first three the `:maybe` buys exactly the window before that slice's seed
+   lands; for `[:settings-form]` it is permanent, because absence there is the
+   design rather than a window (seeding it at boot would only manufacture an
+   empty draft from a user who is not signed in yet, to be overwritten on entry).
+
+   WHY DEV ONLY. `validate-app-schema!` puts its whole body inside
+   `(if interop/debug-enabled? … true)`, so a production build returns `true`
+   without walking anything and every candidate installs. Dev and release
+   therefore disagreed about whether this app could boot at all — and dev is the
+   build every consumer develops against. The node-test build is a development
+   build.
+
+   WHY NOTHING IN THE SUITE SAW IT. `reg-app-schemas` is FRAME-LOCAL, and the
+   example registers against `:rf/default`. The example's existing integration
+   suite drives anonymous frames, which carry no app-db schemas at all, and
+   re-registers `[:auth]` against its own frame BY HAND for the one regression
+   that needs a live validator — so the registry that broke the real app was
+   inert in every harness. This ns closes that gap by installing the example's
+   OWN registry, by name, on the frame under test.
+
+   THE VALIDATOR IS LIVE HERE, and that is load-bearing: a soft-passing validator
+   would make every green below vacuous. `[[boot-under-the-shipped-registry]]` is
+   paired with `[[boot-under-the-pre-fix-bare-registry]]`, which installs the
+   bare four-entry map this file used to register and asserts the boot is
+   REJECTED. The pair is differential — the shipped registry has to permit what
+   the bare one refuses — so a validator that had gone quiet fails the second
+   test rather than silently passing the first.
+
+   Feature nses only, never `realworld-resources.core` — requiring core would
+   pull `routing.cljs` and register the app's routes (including the reserved
+   per-app `:rf.route/not-found`) into the shared node-test registrar.
+   `:app/initialise` and `:auth/classify-token` live in core, so the boot
+   fan-out they perform is spelled out in `boot!` below."
+  (:require [cljs.test :refer-macros [deftest testing is use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.schemas]
+            ;; Activate the default Malli validator (rf2-t0hq). The CLJS default
+            ;; validator SOFT-PASSES without this require, and a soft pass would
+            ;; make the whole regression below unobservable — the bare registry
+            ;; would boot just as happily as the shipped one. This is also the
+            ;; canonical app-boot opt-in for Malli app-schema validation.
+            [re-frame.schemas.malli]
+            [re-frame.machines]
+            ;; resources app FEATURE nses (no core -> no routes). `settings`
+            ;; chains in `auth`, which chains in `http` / `scope` / `schema`.
+            [realworld-resources.schema :as app-schema]
+            [realworld-resources.auth]
+            [realworld-resources.settings])
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
+
+;; rf2-h1vqa4 BUNDLE CO-LOAD HYGIENE. The two RealWorld apps deliberately share
+;; id vocabulary — both register `:auth/initialise`, `:auth.login-form/initialise`,
+;; `:auth.register-form/initialise` and `:settings/load` with DIFFERENT
+;; implementations — and they are built and run as separate bundles, never
+;; co-loaded. cljs.test loads every test ns into ONE bundle, so both apps' rows
+;; sit in the shared source store, and two provenance rows for one id fail
+;; default-image assembly loud (`:rf.error/image-duplicate-id`) for every suite
+;; whose baseline is captured after the second app loads. Sequester the SIBLING
+;; app's tree here, at ns load and BEFORE the fixture below captures its
+;; baseline, so this suite's frames resolve the resources app's implementations.
+;; The realworld-http suites reinstate their own tree in their fixture init.
+(rf.test-support/sequester-app-namespaces! "realworld-http.")
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter
+     ;; The merge-form source-store restore preserves slots this suite's baseline
+     ;; does not know about, so re-sequester per test as the sibling resources
+     ;; suite does.
+     :init-fn (fn [] (rf.test-support/sequester-app-namespaces! "realworld-http."))}))
+
+;; ---------------------------------------------------------------------------
+;; The example's own boot fan-out, spelled out.
+;;
+;; The real app runs `:auth/classify-token`, `:auth/initialise` and
+;; `:app/initialise` as `:initial-events` (core.cljs); `:app/initialise` then
+;; fans out to the two form initialisers as SEPARATE dispatches. The two events
+;; that live in core are not driveable from here (requiring core would register
+;; the app's routes into the shared bundle), so what is driven below is the
+;; three `:db`-bearing seeds, each its own dispatch — which is the whole point
+;; of the regression: separate events mean separate commits.
+;; ---------------------------------------------------------------------------
+
+(defn- boot!
+  "Drive the example's boot seeds into frame `f`, one dispatch per event exactly
+  as the app does. The ORDER is the app's and it matters: `:auth/initialise`
+  creates `[:auth]` in the AuthSlice shape before the two form initialisers
+  write inside it."
+  [f]
+  (rf/dispatch-sync [:auth/initialise]
+                    {:frame f :rf.cofx {:realworld-resources.session/token nil}})
+  (rf/dispatch-sync [:auth.login-form/initialise] {:frame f})
+  (rf/dispatch-sync [:auth.register-form/initialise] {:frame f}))
+
+(def ^:private pre-fix-bare-registry
+  "The four registrations EXACTLY as `schema.cljs` carried them before rf2-ghxt —
+  bare, no `:maybe`. Kept here as the negative control: the shipped registry has
+  to permit a boot this one refuses."
+  {[:auth]                app-schema/AuthSlice
+   [:auth :login-form]    app-schema/FormSlice
+   [:auth :register-form] app-schema/FormSlice
+   [:settings-form]       app-schema/FormSlice})
+
+;; ---------------------------------------------------------------------------
+;; Provenance guard.
+;;
+;; Every id this suite drives is registered by BOTH RealWorld apps. If the
+;; sequester above ever stopped biting, these dispatches would silently exercise
+;; the managed-HTTP app's handlers instead — which seed the same shaped slices,
+;; so the assertions below would still pass while testing the wrong application.
+;; That is a fail-OPEN, so it gets an assertion of its own rather than a comment.
+;; ---------------------------------------------------------------------------
+
+(deftest the-resources-app-owns-the-ids-this-suite-drives
+  (testing "the live handlers for the ids both RealWorld apps register resolve to
+            the RESOURCES app — otherwise every green below is about the wrong app"
+    (doseq [id [:auth/initialise
+                :auth.login-form/initialise
+                :auth.register-form/initialise
+                :auth/store-session
+                :settings/load]]
+      (let [provenance (some-> (rf.registrar/handler-meta :event id) :ns str)]
+        (is (and (string? provenance)
+                 (str/starts-with? provenance "realworld-resources."))
+            (str "the live " id " handler comes from the resources app, not the "
+                 "managed-HTTP twin (got " (pr-str provenance) ")"))))))
+
+;; ---------------------------------------------------------------------------
+;; The regression itself.
+;; ---------------------------------------------------------------------------
+
+(deftest boot-under-the-shipped-registry
+  (testing "every slice the example seeds at boot is present afterwards, with the
+            example's OWN app-db schema registry installed on the frame"
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {})]
+      ;; The registry the real app installs on `:rf/default`, by name. Installing
+      ;; it here is what makes this frame behave like the running application
+      ;; rather than like every previous harness frame.
+      (rf/reg-app-schemas app-schema/app-db-schemas {:frame f})
+      (boot! f)
+      (let [db (rf/app-db-value f)]
+        (is (seq db)
+            "app-db is not empty — the first seed was not rejected by its
+             not-yet-seeded siblings (the rf2-ghxt rollback loop)")
+        (is (contains? db :auth)
+            "app-db carries the auth slice after boot")
+        (is (contains? (get db :auth) :login-form)
+            "app-db carries the login-form draft after boot")
+        (is (contains? (get db :auth) :register-form)
+            "app-db carries the register-form draft after boot")
+        (is (= {:email "" :password ""} (get-in db [:auth :login-form :draft]))
+            "the login-form slice really is the seeded draft shape")))))
+
+(deftest boot-under-the-pre-fix-bare-registry
+  (testing "the bare registry this file used to carry REJECTS the very first seed
+            — the regression, and the proof that the validator is live here (a
+            soft-passing validator would let this boot too)"
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {})]
+      (rf/reg-app-schemas pre-fix-bare-registry {:frame f})
+      (boot! f)
+      (is (= {} (rf/app-db-value f))
+          "app-db never left {} — each seed was rolled back by the siblings still
+           absent, which is exactly what the dev build did on screen"))))
+
+(deftest a-commit-after-boot-still-lands-with-settings-form-never-seeded
+  (testing "[:settings-form] is absent by design until the settings route is
+            entered, and under the shipped registry that absence does not veto
+            later commits — the way in which this example failed harder than its
+            managed-HTTP twin"
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {})]
+      (rf/reg-app-schemas app-schema/app-db-schemas {:frame f})
+      (boot! f)
+      (is (nil? (get (rf/app-db-value f) :settings-form))
+          "nothing seeded [:settings-form] at boot, and nothing should have —
+           :settings/load seeds it from the authenticated user on route entry")
+      ;; An ordinary post-boot edit. Pre-fix this was rejected forever, because
+      ;; [:settings-form] read nil at every commit for the whole life of the app.
+      (rf/dispatch-sync [:auth.login-form/edit-field :email "alice@example.com"]
+                        {:frame f})
+      (is (= "alice@example.com" (get-in (rf/app-db-value f) [:auth :login-form :draft :email]))
+          "an ordinary post-boot :db commit lands"))))
+
+(deftest settings-load-seeds-a-slice-that-validates
+  (testing ":settings/load seeds [:settings-form] from the authenticated user on
+            route entry, and the seeded slice satisfies the FormSlice the shipped
+            registry wraps — the `:maybe` widens the schema, it does not retire it"
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {})]
+      (rf/reg-app-schemas app-schema/app-db-schemas {:frame f})
+      (boot! f)
+      ;; The settings route is auth-guarded, so there is always a user by the
+      ;; time :settings/load runs. Establish one the way the app does.
+      (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
+                                              :username "alice"
+                                              :token "jwt-abc"
+                                              :bio nil :image nil}]
+                        {:frame f})
+      (rf/dispatch-sync [:settings/load] {:frame f})
+      (let [slice (get (rf/app-db-value f) :settings-form)]
+        (is (some? slice)
+            "the settings draft is seeded on route entry")
+        (is (= "alice" (get-in slice [:draft :username]))
+            "the draft is seeded FROM the authenticated user")
+        (is (contains? slice :touched)
+            "`:touched` is seeded alongside `:draft` — FormSlice requires both")))))
+
+;; ---------------------------------------------------------------------------
+;; The shape of the fix, pinned structurally.
+;; ---------------------------------------------------------------------------
+
+(deftest every-shipped-registration-tolerates-absence
+  (testing "each entry in the example's registry is nilable — unwrap any one of
+            them and the boot window (or, for [:settings-form], the whole life of
+            the app) reopens"
+    (doseq [[path schema] app-schema/app-db-schemas]
+      (is (and (vector? schema) (= :maybe (first schema)))
+          (str "the registration at " path " tolerates absence")))
+    (is (= #{[:auth] [:auth :login-form] [:auth :register-form] [:settings-form]}
+           (set (keys app-schema/app-db-schemas)))
+        "the registry still covers exactly the four app-db paths this app owns")))


### PR DESCRIPTION
## rf2-ghxt — realworld-resources never left `{}` in a development build

A dev build of `:examples/realworld-resources` booted to nothing: `app-db` still
`{}`, zero article cards, `#app` a bare shell, and no page error, console error
or failed request to say so. The same bundle in a **release** build rendered
correctly.

### Mechanism (verified at source)

`examples/real-apps/realworld_resources/schema.cljs` registered four app-db path
schemas against `:rf/default` at ns-load, all bare. `app-db` starts `{}`, and
`re-frame.schemas.validate/validate-app-schema!` walks **every** registered path
with `(get-in db registered-path)` over the **whole** candidate app-db at **every**
`:db` commit (Spec 010 §Per-step recovery row 4). There is no exemption for a path
nothing has written yet, and an unwritten path reads `nil` — which is not a
`[:map …]`. So the four paths vetoed each other:

| path | seeded by |
| --- | --- |
| `[:auth]` | `:auth/initialise` — its own `:initial-events` step |
| `[:auth :login-form]` | `:auth.login-form/initialise` |
| `[:auth :register-form]` | `:auth.register-form/initialise` |
| `[:settings-form]` | **nothing, at boot** |

The first three are a boot **window**: each is its own dispatch (the two form
initialisers are fanned out from `:app/initialise`), so each seed is its own
commit and each was rejected by the siblings still absent.

The fourth is why this example failed harder than its managed-HTTP twin
(rf2-2xzc). `[:settings-form]` is seeded by `:settings/load` on settings-**route
entry**, behind an auth guard — so for an anonymous visitor, and for a signed-in
one who never opens Settings, it reads `nil` for the whole life of the app.
Registered bare it rejected **every** `:db` commit in the application,
permanently, not only during boot. And a rejected candidate does not walk `:fx`
either, so nothing downstream of a `:db`-bearing handler fired.

Dev only, because `validate-app-schema!` keeps its whole body inside
`(if interop/debug-enabled? … true)` — a release build installs every candidate
unchecked. Dev and release disagreed about whether this app could boot at all,
and dev is the build every consumer develops against.

### The fix

Every entry wears a `:maybe`, with the two **distinct** reasons written out at
the site rather than collapsed into one: a boot *window* for the three seeded
slices, and *permanent* absence-by-design for `[:settings-form]`. The registry is
named as the value `app-db-schemas` so a harness can install it on its own frame.

**`[:settings-form]` is deliberately NOT also seeded at boot.** `:settings/load`
seeds the draft *from the authenticated user* on route entry, which is what keeps
the form a pure Form-1 whose in-flight edits survive a re-render. A boot seed
would only manufacture an empty draft from a user who is not signed in yet, to be
overwritten on entry — so `:maybe` alone is the honest fix here, and the comment
says which of the two reasons each entry is wearing.

### The test

`implementation/core/test/re_frame/example_realworld_resources_boot_seed_cljs_test.cljs`
— the framework tree, because examples are test-free (rf2-8cevm).

It is **differential**, not merely positive: `boot-under-the-shipped-registry` is
paired with `boot-under-the-pre-fix-bare-registry`, which installs the bare
four-entry map this file used to carry and asserts the boot is *rejected*. A
validator that had gone quiet fails the second test rather than silently passing
the first — which matters, because the CLJS default validator soft-passes unless
`re-frame.schemas.malli` is loaded.

The ns requires the example's `schema` ns and **nothing else** from the app.
`reg-app-schemas` writes no registrar or source-store row, so it cannot collide;
requiring the app's *event* nses does, and did. Measured on this tree: the two
RealWorld apps deliberately share id vocabulary (`:settings/load`,
`:auth/initialise`, … are registered by both with different implementations), and
because this ns sorts early in the shared cljs.test bundle, requiring
`realworld-resources.auth` / `.settings` here put a second provenance row for
those ids into the shared source store from this ns's load onward — after which
every alphabetically-later suite's baseline failed default-image assembly with
`:rf.error/image-duplicate-id`, across nine namespaces. Sequestering the sibling
tree from here does not fix it either: `sequester-app-namespaces!` captures a
prefix's rows once and *memoizes* them, so a call this early becomes an
incomplete memo for the later suites (measured: `:home/show-global-feed` left
unsequestered, failing the sibling resources suite's own frame creation). Both
findings are recorded in the ns docstring, since the next person to add a
RealWorld-touching test in this tree will meet them.

The seeds are therefore local events reproducing the app's own writes — same
paths, same slice shapes, one dispatch each, which is the property under test.
The registry itself, the artefact that was wrong, is imported from the example
verbatim.

### Gates

`npm run test:cljs` from `implementation/` — it compiles the `node-test` build
(which carries `implementation/core/test/re_frame/**` and, via
`../examples/real-apps`, the example source) and runs it.

* On the final rebased base: **exit 0**, `Ran 11173 tests containing 55748
  assertions. 0 failures, 0 errors`, 0 compile warnings.
* **Planted-fault control**: unwrapping all four `:maybe`s — i.e. restoring the
  pre-fix registration exactly — and recompiling gives **exit 1**, 17 failures
  across 20 assertions, with `app-db` stuck at `{}` and the seeds rolled back:
  the on-screen symptom, reproduced. `boot-under-the-pre-fix-bare-registry` stays
  green throughout, as it should. The plant was restored and verified by git blob
  hash, not by reading a diff.

`npm run test:bundle-isolation` was **not** run, deliberately: this change adds
no `:require` anywhere, and the only compile it could affect is
`realworld-resources.schema`, which `test:cljs` compiles and exercises. A schema
map literal gaining a `:maybe` wrapper cannot move a namespace across a bundle
boundary.

The new `scripts/check_require_alias_dialect.py` ratchet passes on both changed
surfaces. It does report `implementation/flows` (155, floor 156) and
`implementation/ssr` (399, floor 402) as **below** their floors — stale floors
inherited from `origin/main`, in trees this branch does not touch and whose
content is byte-identical to `origin/main`. The remedy is `--write-baseline` on
`scripts/require-alias-baseline.edn`, which is outside this change's fence;
filed separately. The checker was exercised against a deliberately wrong alias in
the new file and named it by file and line, so its green here is a real read.
