### PR TITLE
fix(lint): lower the flows and ssr require-alias floors to the tree (rf2-ril5)

### DIFF
--- a/scripts/require-alias-baseline.edn
+++ b/scripts/require-alias-baseline.edn
@@ -27,7 +27,7 @@
   "implementation/derivation-conformance" 19
   "implementation/epoch"                  196
   "implementation/event-conformance"      21
-  "implementation/flows"                  156
+  "implementation/flows"                  155
   "implementation/hicasso"                1017
   "implementation/http"                   272
   "implementation/machines"               0
@@ -38,7 +38,7 @@
   "implementation/scripts"                46
   "implementation/security"               45
   "implementation/spec-resource"          1
-  "implementation/ssr"                    402
+  "implementation/ssr"                    399
   "implementation/ssr-ring"               129
   "implementation/test-quiet"             5
   "migration"                             27


### PR DESCRIPTION
Trunk was red on the require-alias ratchet armed by #9135, and because that job is required and `lint.yml`'s `Lint required` aggregator consumes it, every open PR went red with it — including documentation-only ones.

The ratchet is two-sided by design. Its baseline was captured before two sweeps landed, so the *lower* side fired on `origin/main` itself:

```
implementation/flows: 155 violation(s), floor 156
implementation/ssr:   399 violation(s), floor 402
```

This lowers those two floors to what the tree carries. No source is touched.

### Why not a blind `--write-baseline`

`--write-baseline` rewrites the whole file from the current tree, so it can *raise* a row and silently bless a regression. It was run and diffed rather than accepted: it changes exactly these two rows plus `:min-edges` 9692 -> 9691. **No surface row would have risen.**

`:min-edges` is left at 9692. For that key lower is *looser*, not tighter — it is a blind-scanner floor checked as `total < min-edges` — and 10768 observed edges clear 9692 comfortably, so holding the higher value keeps more ground.

### No other row is slack

A `--report` census compares every row against a fresh scan. After this change every surface sits exactly at its floor: no row `under`, no row `OVER`. There was nothing else to tighten.

`implementation/http` is deliberately untouched at 272, which is correct at tip; rf2-ttss takes it to 0 after #9142 merges.

### Verification

- `python scripts/check_require_alias_dialect.py --self-test` -> exit 0 (40 passed)
- `python scripts/check_require_alias_dialect.py --verbose` -> exit 0, "every surface at or under its floor"
- Planted-fault control: a non-canonical `[re-frame.interop :as interop]` added to `implementation/flows/src/re_frame/flows/topo.cljc` took the gate to exit 1 naming `implementation/flows: 156 violation(s), floor 155` and the planted line itself — so the tightened floor still bites. Reverted, restore verified by blob hash.

Closes rf2-ril5.