### PR TITLE
test(tools): rewrite the retired tools-root aggregate rationale (rf2-6ka0, rf2-fpeig)

### DIFF
--- a/tools/story-mcp/test/re_frame/story_mcp/rendered_hiccup_retirement_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/rendered_hiccup_retirement_test.clj
@@ -74,10 +74,11 @@
   (config/set-allow-sensitive-reads! false)
   (schemas/clear-schemas-by-frame!)
   (recorder/clear!)
-  ;; story-mcp's own artefact carries no epoch dep; under the tools-root
-  ;; aggregate a Story namespace installs the capture hooks process-wide and
-  ;; the `:narrative` projection then balloons the payload past the token cap.
-  ;; Reproduce the artefact's epoch-free posture either way.
+  ;; story-mcp's own artefact carries no epoch dep, so this suite never loads
+  ;; `re-frame.epoch`. PIN that posture rather than inherit it: `re-frame.epoch`
+  ;; installs its capture hooks PROCESS-WIDE at ns-load, so any JVM that puts
+  ;; epoch on this suite's classpath would switch the `:narrative` projection
+  ;; to a full per-event tape and balloon the payload past the token cap.
   (rf/configure! {:epoch-history {:depth 0}})
   (story/reg-story :story.cart
     {:doc "A cart." :component :app.ui/cart :tags #{:dev :test} :args {}})

--- a/tools/story-mcp/test/re_frame/story_mcp/run_result_roundtrip_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/run_result_roundtrip_test.clj
@@ -70,8 +70,8 @@
   (try
     (t)
     (finally
-      ;; Restore the shipped epoch-ring default so a story namespace running
-      ;; after this one in the aggregate sees the normal depth-50 posture.
+      ;; Restore the shipped epoch-ring default so any namespace running after
+      ;; this one in the same JVM sees the normal depth-50 posture.
       (rf/configure! {:epoch-history {:depth 50}}))))
 
 (use-fixtures :each reset-story)

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -163,8 +163,8 @@
   (try
     (t)
     (finally
-      ;; Restore the shipped epoch-ring default so a story namespace running
-      ;; after this one in the aggregate sees the normal depth-50 posture.
+      ;; Restore the shipped epoch-ring default so any namespace running after
+      ;; this one in the same JVM sees the normal depth-50 posture.
       (rf/configure! {:epoch-history {:depth 50}}))))
 
 (use-fixtures :each reset-story-and-config)
@@ -390,12 +390,14 @@
 
 (defn- artefact-root
   "Resolve the `tools/story-mcp/` artefact root on disk, cwd-independently.
-  The per-tool `:test` alias runs from `tools/story-mcp` (a cwd-relative
-  `(io/file …)` works), but the tools-root aggregate (`tools/deps.edn :test`)
-  runs from `tools/`, where a cwd-relative `spec/API.md` /
-  `../../skills/…` would miss. The repo-tree files `spec/API.md` and the
-  consuming skill leaf are NOT on the classpath (story-mcp ships only `src`
-  + `test`), so we anchor off a known classpath SOURCE resource
+  Every shipped invocation runs from `tools/story-mcp` (`clojure -M:test`,
+  typed by hand or driven by `scripts/test-jvm-tools.sh`, which cds into the
+  artefact), so cwd-relative `spec/API.md` / `../../skills/…` paths would
+  happen to work there — but keying the walk to cwd makes them wrong from any
+  other working directory (a REPL or editor rooted at the repo root). The
+  repo-tree files `spec/API.md` and the consuming skill leaf are NOT on the
+  classpath (story-mcp ships only `src` + `test`), so we anchor off a known
+  classpath SOURCE resource
   (`re_frame/story_mcp/protocol.cljc` under the `src` `:paths` root) and walk
   its parent chain up to the artefact root. Falls back to the JVM cwd if the
   resource is absent (e.g. a jar). Mirrors the xray guard tests' src-root

--- a/tools/story-mcp/test/re_frame/story_mcp/wire_encodability_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/wire_encodability_test.clj
@@ -80,8 +80,10 @@
   (story/install-canonical-vocabulary!)
   ;; Every test here exercises the write surface; the gate is default-off.
   (config/set-allow-writes! true)
-  ;; Mirrors `tools-test`: keep the epoch ring out of the wire payload so a
-  ;; tools-root aggregate run doesn't balloon a result past the token cap.
+  ;; Mirrors `tools-test`: keep the epoch ring out of the wire payload so any
+  ;; JVM that puts `re-frame.epoch` on this suite's classpath — its capture
+  ;; hooks install process-wide at ns-load — can't balloon a result past the
+  ;; token cap.
   (rf/configure! {:epoch-history {:depth 0}})
   (t)
   (config/set-allow-writes! false))

--- a/tools/story/test/re_frame/story/meta_fixtures_test.cljc
+++ b/tools/story/test/re_frame/story/meta_fixtures_test.cljc
@@ -46,15 +46,18 @@
        "meta_fixtures_test.cljc")
 
      (defn- test-root
-       "Resolve `tools/story/test/` on disk, cwd-independently. The per-tool
-       `:test` alias runs from `tools/story` (a cwd-relative `(io/file
-       \"test\")` works), but the tools-root aggregate (`tools/deps.edn
-       :test`, rf2-f2tkbt) runs from `tools/`, where a bare `test` would miss.
-       `test` is a classpath `:extra-paths` root, so this meta-check's own
-       source file is a classpath resource on the JVM regardless of cwd; its
-       parent chain up to the `test`-root anchors the walk. Falls back to the
-       cwd-relative path if the resource is absent. Mirrors the xray guard
-       tests' src-root pattern."
+       "Resolve `tools/story/test/` on disk, cwd-independently. Every shipped
+       invocation runs from `tools/story` (`clojure -M:test`, typed by hand or
+       driven by `scripts/test-jvm-tools.sh`, which cds into the artefact), so
+       a cwd-relative `(io/file \"test\")` would happen to work there — but
+       keying the walk to cwd makes it wrong from any other working directory
+       (a REPL or editor rooted at the repo root). `test` is a classpath
+       `:extra-paths` root, so this meta-check's own source file is a
+       classpath resource on the JVM regardless of cwd; its parent chain up to
+       the `test`-root anchors the walk. Falls back to the cwd-relative path
+       if the resource is absent; the companion `(is (seq files) …)` assertion
+       below turns a mis-resolved root into a loud failure rather than a
+       vacuous pass. Mirrors the xray guard tests' src-root pattern."
        []
        (let [marker (io/resource "re_frame/story/meta_fixtures_test.cljc")]
          (if (and marker (= "file" (.getProtocol marker)))
@@ -66,8 +69,9 @@
        "Walk `test/` and return every `.cljc` file as a `java.io.File`,
        excluding this meta-check (which quotes the forbidden form in its
        own docs/message). The root is resolved via `test-root` so the walk is
-       cwd-independent (per-tool `clojure -M:test` AND the tools-root
-       aggregate), mirroring `story-substrate-isolation-test`."
+       cwd-independent rather than tied to the artefact directory the shipped
+       `clojure -M:test` happens to run from, mirroring
+       `story-substrate-isolation-test`."
        []
        (let [root (test-root)]
          (when (.isDirectory root)

--- a/tools/story/test/re_frame/story_substrate_isolation_test.clj
+++ b/tools/story/test/re_frame/story_substrate_isolation_test.clj
@@ -28,14 +28,18 @@
 ;; ----- helpers ------------------------------------------------------------
 
 (defn- src-root
-  "Resolve `tools/story/src/` on disk, cwd-independently. The per-tool
-  `:test` alias runs from `tools/story` (a cwd-relative `(io/file \"src\")`
-  works), but the tools-root aggregate (`tools/deps.edn :test`, rf2-f2tkbt)
-  runs from `tools/`, where a bare `src` would miss. `src` is a classpath
-  `:paths` root, so a known story source (`re_frame/story.cljc`) is a
-  classpath resource on the JVM regardless of cwd; its `src`-relative parent
-  chain is the src-root. Falls back to the cwd-relative path if the resource
-  is absent (e.g. a jar). Mirrors the xray guard tests' `src-root`."
+  "Resolve `tools/story/src/` on disk, cwd-independently. Every shipped
+  invocation runs from `tools/story` (`clojure -M:test`, typed by hand or
+  driven by `scripts/test-jvm-tools.sh`, which cds into the artefact), so a
+  cwd-relative `(io/file \"src\")` would happen to work there — but keying
+  the walk to cwd makes it wrong from any other working directory (a REPL or
+  editor rooted at the repo root). `src` is a classpath `:paths` root, so a
+  known story source (`re_frame/story.cljc`) is a classpath resource on the
+  JVM regardless of cwd; its `src`-relative parent chain is the src-root.
+  Falls back to the cwd-relative path if the resource is absent (e.g. a jar);
+  the companion `(is (seq files) …)` assertion below turns a mis-resolved
+  root into a loud failure rather than a vacuous pass. Mirrors the xray guard
+  tests' `src-root`."
   []
   (let [marker (io/resource "re_frame/story.cljc")]
     (if (and marker (= "file" (.getProtocol marker)))
@@ -46,7 +50,8 @@
 (defn- src-files
   "Walk tools/story/src/ and return every .cljc / .cljs / .clj file as
   a `java.io.File`, resolving the src root via `src-root` so the walk is
-  cwd-independent (per-tool `clojure -M:test` AND the tools-root aggregate)."
+  cwd-independent rather than tied to the artefact directory the shipped
+  `clojure -M:test` happens to run from."
   []
   (let [root (src-root)]
     (when (.isDirectory root)

--- a/tools/xray/test/day8/re_frame2_xray/frame_singleton_guard_test.clj
+++ b/tools/xray/test/day8/re_frame2_xray/frame_singleton_guard_test.clj
@@ -127,13 +127,18 @@
 
 (defn- src-root []
   ;; Resolve `src/day8/re_frame2_xray` on disk so the guard reads the
-  ;; on-disk source text. The per-tool `:test` alias runs from
-  ;; `tools/xray` (cwd-relative `src` works), but the tools-root
-  ;; aggregate (`tools/deps.edn :test`, rf2-f2tkbt) runs from `tools/`,
-  ;; where a bare `(io/file "src" …)` would miss. `src` is a classpath
-  ;; `:paths` root, so a known `.cljs` source is a classpath resource on
-  ;; the JVM regardless of cwd; its parent dir is the src-root. Fall back
-  ;; to the cwd-relative path if the resource is absent (e.g. a jar).
+  ;; on-disk source text. Every shipped invocation runs from `tools/xray`
+  ;; (`clojure -M:test`, typed by hand or driven by
+  ;; `scripts/test-jvm-tools.sh`, which cds into the artefact), so a
+  ;; cwd-relative `(io/file "src" …)` would happen to work there — but
+  ;; keying the walk to cwd makes this guard fail OPEN anywhere else, and
+  ;; silently: from any other working directory (a REPL or editor rooted at
+  ;; the repo root) the path resolves to a non-directory, the walk yields no
+  ;; files, and every `(is (empty? …))` below passes having scanned nothing.
+  ;; `src` is a classpath `:paths` root, so a known `.cljs` source is a
+  ;; classpath resource on the JVM regardless of cwd; its parent dir is the
+  ;; src-root. Fall back to the cwd-relative path if the resource is absent
+  ;; (e.g. a jar).
   (let [marker (io/resource "day8/re_frame2_xray/defaults.cljs")]
     (if (and marker (= "file" (.getProtocol marker)))
       (.getParentFile (io/file (.toURI marker)))

--- a/tools/xray/test/day8/re_frame2_xray/panels/click_to_source_consolidation_test.clj
+++ b/tools/xray/test/day8/re_frame2_xray/panels/click_to_source_consolidation_test.clj
@@ -48,13 +48,18 @@
 
 (defn- src-root []
   ;; Resolve `src/day8/re_frame2_xray` on disk so the guard reads the
-  ;; on-disk source text. The per-tool `:test` alias runs from
-  ;; `tools/xray` (cwd-relative `src` works), but the tools-root
-  ;; aggregate (`tools/deps.edn :test`, rf2-f2tkbt) runs from `tools/`,
-  ;; where a bare `(io/file "src" …)` would miss. `src` is a classpath
-  ;; `:paths` root, so a known `.cljs` source is a classpath resource on
-  ;; the JVM regardless of cwd; its parent dir is the src-root. Fall back
-  ;; to the cwd-relative path if the resource is absent (e.g. a jar).
+  ;; on-disk source text. Every shipped invocation runs from `tools/xray`
+  ;; (`clojure -M:test`, typed by hand or driven by
+  ;; `scripts/test-jvm-tools.sh`, which cds into the artefact), so a
+  ;; cwd-relative `(io/file "src" …)` would happen to work there — but
+  ;; keying the walk to cwd makes this guard fail OPEN anywhere else, and
+  ;; silently: from any other working directory (a REPL or editor rooted at
+  ;; the repo root) the path resolves to a non-directory, the walk yields no
+  ;; files, and the `(is (empty? offenders))` below passes having scanned
+  ;; nothing. `src` is a classpath `:paths` root, so a known `.cljs` source
+  ;; is a classpath resource on the JVM regardless of cwd; its parent dir is
+  ;; the src-root. Fall back to the cwd-relative path if the resource is
+  ;; absent (e.g. a jar).
   (let [marker (io/resource "day8/re_frame2_xray/defaults.cljs")]
     (if (and marker (= "file" (.getProtocol marker)))
       (.getParentFile (io/file (.toURI marker)))


### PR DESCRIPTION
Two beads. One of them needed code; the other did not, and the evidence for that is below.

## rf2-6ka0 — the audit remainder

PR #9093 retired `tools/shadow-cljs.edn` and `tools/deps.edn`'s aggregate `:test` alias. The four references the bead's DESCRIPTION named had already landed (a repo-wide fixed-string search for `tools-root-coordinator` returns exactly one tracked hit, the tracker export's own copy of the bead text). The live instruction is the AUDIT #9108 note, and this PR is that remainder.

Active test comments still explained their setup by contrasting a standalone per-artefact run with "the tools-root aggregate (`cd tools && clojure -M:test`)". The aggregate is gone, so the contrast had one side and pointed maintainers at an invocation that can no longer happen.

**The code is unchanged throughout — comments and docstrings only.** No fixture line deleted, no executable form touched: every added line in the diff is either a `;;` comment or docstring prose.

Each rewrite justifies the call it sits above without invoking the retired run:

- **epoch-ring sites** now cite the real mechanism — `re-frame.epoch` installs its capture hooks process-wide at ns-load, so any JVM that puts epoch on the suite's classpath switches the `:narrative` projection and balloons the payload past the token cap. This mirrors the wording already settled in this tree by the earlier pass (`run_result_roundtrip_test.clj:49`, `tools_test.clj:97`).
- **cwd-independence sites** now cite what anchoring off a classpath resource actually buys. It is not a second working directory CI uses: `scripts/test-jvm-tools.sh` does `cd "$repo_root/$tool" && clojure -M:test`, so *every* shipped invocation runs from the artefact directory. What the anchoring buys is independence from cwd itself.

The two families are not equivalent and the comments now say which is which: the two xray guards assert only `(is (empty? ...))` and would pass having scanned nothing from a wrong root, whereas the two story guards carry a companion `(is (seq files) ...)` assertion and fail loudly instead.

Also drops the `rf2-f2tkbt` citation from the four comments carrying it: that id resolves to no issue in the tracker.

### Census

The audit named ten sites. Run both ways, because these are multi-line comment blocks and neither instrument is a superset of the other:

- line-oriented (`git grep -F`): 11 hits of `tools-root` across 8 files
- flattened (whitespace-collapsed, CR-stripped): confirmed the line-broken sites a line-oriented probe cannot see — the exact phrase `tools-root aggregate` reads 5 line-oriented and 6 flattened

**Acted on 11 sites, one more than the audit's ten.** The extra is `run_result_roundtrip_test.clj:73-74` ("a story namespace running after this one in the aggregate"), which names the retired aggregate without the `tools-root` token, so both censuses missed it and a broader net caught it.

One line-oriented hit was excluded as a false positive: `implementation/core/test/re_frame/no_rf_default_floor_lint_test.clj`'s `repo-tools-root` is a var naming the `tools/` directory, unrelated to the retired aggregate.

Out of scope per the bead and untouched: `tools/README.md`, `tools/deps.edn`, the split runbook, the changed-surfaces ledger.

After the change, `tools-root`, `tools-root aggregate`, `tools/deps.edn :test` and `cd tools && clojure` all read 0 across `tools/` on both instruments.

## rf2-fpeig — already on the trunk; no change in this PR

The bead was reopened on a salvage note reporting that commit `7759d8be25` "is not on the trunk", measured with `git cherry origin/main worker/retro-b`. **That measurement is correct and the inference drawn from it is not.**

Every hunk of that commit is already on `origin/main`, verbatim, landed by commit `0093c1858c` — same author date, same commit message, same stat (3 files, +14/-3), and an ancestor of `origin/main`:

- `skills/re-frame2-pair-retro/README.md:29` — the `tests/duplicate_search_test.clj` bullet
- `skills/re-frame2-pair-retro/spec/design.md:32` — the L2 pin sentence; `:96-97` — the section 5 tree entry
- `skills/README.md:427-429` — the Test-fixture discipline roster entry with its clause (b) justification

`git cherry` reported `+` because it compares patch-ids, and the rebase that merged the PR changed the patch. Diffing the two patches, they are byte-identical except the blob index line and **two context lines** listing `re-frame2-pair/tests` subdirectories: the stranded branch's base had `e2e/` and `shim/`, the trunk's did not. Differing context changes the patch-id (`a347d798...` vs `68e71052...`), so a patch-id instrument reports "not upstream" for work that is upstream.

Cherry-picking it confirmed this from the other side: the only conflict was the `skills/README.md` Layout sentence, where the trunk names **four** skills including `reagent-migration/` while the stranded hunk names three. Landing that hunk would have silently reverted the reagent-migration sentence. Resolving to the trunk's superset left the working tree byte-identical to HEAD — nothing to commit — so the cherry-pick was aborted.

The bead's acceptance criteria are satisfied at tip (the roster's "three" became "four" because `reagent-migration` landed in between).

The salvage note's six-file, +22/-11 stat is the union of both branch commits. `SKILL.md`, `evals/evals.json` and `references/known-frictions.md` belong to the already-landed sibling `85d7cc403f` (rf2-wz1qa), not to the stranded commit.

## Gates

Per-artefact JVM suites, which is the invocation the rewritten comments describe. Re-run on the final rebased base; exit codes captured from the runner itself, not reported by the harness.

| Gate | Exit | Result |
|---|---|---|
| `cd tools/xray && clojure -M:test` | 0 | 1273 tests, 6106 assertions, 0 failures |
| `cd tools/story && clojure -M:test` | 0 | 1889 tests, 6959 assertions, 0 failures |
| `cd tools/story-mcp && clojure -M:test` | 0 | 282 tests, 1527 assertions, 0 failures |
| `python scripts/check_doc_slugs.py` | 0 | clean |

`check_doc_slugs.py` is the link gate for `skills/**`: `skills` is in its `DEFAULT_ROOTS`, and `check_readme_links.py` explicitly excludes those roots.

**Sabotage controls.** These gates print no root, so a planted fault is the only proof they read this worktree:

- a one-line assertion fault in `tools_test.clj` (a file this PR edits) took story-mcp to **exit 1**, naming the planted token at both sites it matched, with the run holding at exactly 282 tests / 1527 assertions — same as the clean run, so the plant did not truncate a namespace. Restored; blob hash back to `9a13fcde...`, zero residue.
- a broken link planted in `skills/re-frame2-pair-retro/README.md` took `check_doc_slugs.py` to **exit 1** naming the target at file and line. Restored; blob hash back to `e93b1e88...`, zero residue.

**By hand, since nothing validates prose, tables or nav.** `skills/README.md`'s two tables are column-consistent: 3 columns by 12 rows (lines 150-161) and 5 columns by 11 rows (lines 194-204), no mismatches. The Test-fixture discipline roster is a bulleted list rather than a table; it reads "4 skills qualify today" and lists exactly four. Heading anchors are covered by `check_doc_slugs.py`, whose control above proves it bites.

Diffed against the merge base rather than the tip: every deleted line is one of the obsolete aggregate comment lines this PR intentionally rewrites. No sibling work reverted.
