### PR TITLE
fix(migration): the census roster covers every namespace it recognises (rf2-xoal)

### DIFF
--- a/migration/reagent-to-hicasso/codemod/README.md
+++ b/migration/reagent-to-hicasso/codemod/README.md
@@ -43,19 +43,24 @@ consumer's code needs a human decision is a tool that gets run once.
 
 Everything below this section is about the fixer, whose population is the
 `[:>]`-family crossing. That population is not a Reagent codebase, and the
-difference is not small. Run over this repository's own 88-file example corpus
-the fixer reports zero entries — the corpus crosses into React nowhere — and
-a migrator reading that report sees eighty-eight files that are not mentioned.
+difference is not small. Run over this repository's own example corpus — 83
+files at `39a7a339a2` — the fixer reports zero entries, because the corpus
+crosses into React nowhere, and a migrator reading that report sees
+eighty-three files that are not mentioned.
 
 So the same run also produces a census, under `:census` in the report, whose
 population is the view-substrate API call site: `r/atom`, `r/with-let`,
 `r/create-class`, `r/as-element`, `r/cursor`, `r/reactify-component`, root
-mounting, and the rest of the two rosters in
-`src/re_frame/migration/hicasso/census.clj`. On that same corpus it reports
-59 sites across 28 files, one of them the `with-let` whose teardown no
+mounting, static-markup export, cell teardown, and the rest of the two rosters
+in `src/re_frame/migration/hicasso/census.clj`. On that corpus it reports
+75 sites across 33 files, one of them the `with-let` whose teardown no
 mechanical edit can carry. Both are measurements of a corpus that keeps
-growing, taken here at `e337a1d`; the corpus was 81 files when the census
-landed.
+growing, and of a roster that grows with it: the corpus was 81 files when the
+census landed and 83 at `39a7a339a2`, where these were taken. The site count
+moved 74 → 75 in the same commit as this sentence, and the extra one is worth
+naming — a file that had been counted RECOGNISED AND CLEAN turned out to be
+calling `render-to-static-markup`, which the roster had no row for. See *Two
+rosters*, below.
 
 | Half | Population | Addressed at | Verdicts |
 |---|---|---|---|
@@ -129,7 +134,7 @@ Reagent adapter is the single most likely thing to be migrated to Hicasso.
 There are two rosters now, and the rule for both is **identity, not spelling: a
 namespace is classified when this project can vouch for what it is.**
 
-- **Reagent's API** — stock Reagent's four namespaces, plus the `reagent2.*`
+- **Reagent's API** — stock Reagent's five namespaces, plus the `reagent2.*`
   four that the reagent-slim adapter ships. That is the same API authored a
   second time in this repository, under names the how-to guide teaches
   consumers to call, so one roster classifies both. Omitting it was the same
@@ -164,7 +169,41 @@ zero:
   is wrong is a warning nobody can tell from a missing key;
 - the verdict is **hoisted to the top of the report**, beside `:tool`, because
   the reader who gets misled is the one who reads the first summary and stops;
-- the CLI's last line leads with it, for the same reason.
+- the CLI's last line leads with it, for the same reason, and marks a zero
+  rather than printing it bare.
+
+### The zero came back through the widening itself
+
+Recognition is decided per **file**, off the `ns` form. Entries are found per
+**name**, off the roster. Widening the namespace family without widening the
+roster moves those two apart, and the gap between them is exactly a confident
+zero: the file is recognised, no rostered name matches, so it is counted
+`:files-clean` and `:recognition` reads `:full`. **A recognised-and-unrostered
+file is a strictly worse answer than an unrecognised one** — the unrecognised
+file is a bucket the caveat names out loud, and this one is a clean bill of
+health.
+
+That is not hypothetical. The change that added the `reagent2.*` four did not
+add `render-to-static-markup`, which is `reagent2.dom.server`'s only public
+function, and a one-line file calling it reported `files-recognised 1,
+files-clean 1, entries 0, :recognition :full` under the sentence *A zero below
+is a measurement*. Three things answer it, and they are different in kind:
+
+- the roster was reconciled against every recognised namespace's supported
+  public calls, which is where `render-to-string`, `unmount`, `flush-views!`,
+  `flush!`, `activate!`, `reactive?`, `dispose!` and the rest arrived from;
+- the coupling is now a **law with a ratchet**. `reagent-namespaces` says a
+  namespace joins it only together with the roster rows for the names it
+  publishes, and `census_test` holds one known public call per recognised
+  namespace and reds when a namespace is added without one. The same probe
+  covers the adapters shipping today, where `mount!` / `trigger-update!` were
+  the identical hole at a second address;
+- the `:full` caveat was **weakened to the claim it can support**. It said the
+  zero was a measurement; it says instead that recognition is about the files
+  while the count is bounded by a fixed roster. The substrate roster binds by
+  an open prefix, so a residual survives every list — an adapter recognised
+  the day it ships, before this roster has rows for it — and admitting that is
+  the only honest thing the `:full` sentence can do.
 
 ## The two laws
 
@@ -349,11 +388,19 @@ the census never RECOGNISED, which wears the first one's face exactly — every
 count zero, nothing red. It is gated on the tool's inability to report that zero
 without saying which of the two it is, and the assertion comes with a control
 that has to fire: the same machinery over a corpus the census does have a
-population in reports `:full`, whose caveat says the zero would be a
-measurement. Beside it sit the roster controls, which are the same lesson in
+population in reports `:full`, whose caveat says what recognition measured and
+what it did not. Beside it sit the roster controls, which are the same lesson in
 both families — a vendored `…reagent.v1v2v0.reagent.core` binds nothing, and
 neither does a `my.vendored.re-frame.adapter.reagent`, because the prefix rule
 is anchored at the start of the namespace and containment is not identity.
+
+The same bead's merged-PR audit added the **fourth**, and it is the third one
+inverted: answering nothing over a corpus the census DID recognise, because the
+namespace family was widened and the roster was not. It is gated by a table
+holding one known public call per recognised namespace, asserting for each that
+`:recognition :full` and zero entries cannot co-occur — and, more importantly,
+that the table is COMPLETE against `reagent-namespaces`, so a namespace added
+without a sample reds on the ratchet rather than on somebody's migration.
 
 ## One dependency, deliberately
 

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/census.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/census.clj
@@ -89,6 +89,32 @@
   TOP of the artefact — because the reader who is going to be misled is
   the one who reads the first summary and stops.
 
+  ## The confident zero came back through the widening itself
+
+  And it came back *because* of it. Recognition is decided per FILE, off
+  the `ns` form; the entries are found per NAME, off the roster. Widening
+  the namespace list without widening the roster moves those two apart,
+  and the gap between them is exactly a confident zero: the file is
+  RECOGNISED, no rostered name matches, so it is counted `:files-clean`
+  and `:recognition` reads `:full`. PR #9132 widened the first and not the
+  second, and a file whose single call was
+  `reagent2.dom.server/render-to-static-markup` — that namespace's ONLY
+  public function — reported `files-recognised 1, files-clean 1, entries
+  0, :recognition :full` under the sentence *A zero below is a
+  measurement*. The unrecognised file was always honest; it was the newly
+  recognised one that lied.
+
+  Three things answer it, and they are different in kind. The roster was
+  reconciled against every recognised namespace's supported public calls;
+  the coupling between the two lists is now a stated law with a test
+  ratchet on
+  [[re-frame.migration.hicasso.rewrite/reagent-namespaces]], so a
+  namespace cannot join the recognition set without a call the census can
+  find in it; and the `:full` wording was weakened to the claim it can
+  actually support — *this census had a population*, which is about the
+  files, rather than *a zero is a measurement*, which is about the roster
+  and was never true of it (rf2-xoal, merged-PR audit of #9132).
+
   ## The law this file exists to obey
 
   **What cannot be resolved is REPORTED, never skipped.** [[ns-context]]
@@ -147,7 +173,45 @@
   those all sit at a crossing. Outside a crossing, Reagent's API asks for a
   state-ownership or lifecycle decision that no source reader can make.
   [[summarise]] therefore emits `:mechanical 0` explicitly rather than
-  leaving the key absent, so an empty bucket reads as a measurement."
+  leaving the key absent, so an empty bucket reads as a measurement.
+
+  ## The roster covers every namespace the tool RECOGNISES, and that is a law
+
+  A row here is looked up by NAME, while
+  [[re-frame.migration.hicasso.rewrite/reagent-namespaces]] decides
+  per-FILE whether the file reaches for Reagent at all. The two must be
+  widened together or the tool starts recognising files it cannot count —
+  see the coupling law on that Var, which is where the reasoning lives.
+  In short: a recognised file with no rostered call in it is scored
+  `:files-clean`, and `:recognition :full` then presents its zero as a
+  measurement. `render-to-static-markup` is the row whose absence proved
+  it (rf2-xoal).
+
+  ## What was deliberately left off
+
+  The ask was every SUPPORTED, MIGRATION-RELEVANT public call, not every
+  Var in a vendored fork, so four kinds of public name are absent on
+  purpose:
+
+  * **Implementation namespaces.** `reagent2.impl.template`,
+    `reagent2.impl.batching`, `reagent2.impl.component` and
+    `reagent2.impl.diag` publish plenty and are not on the recognition
+    roster at all, so a call through one is an UNRECOGNISED file and the
+    caveat says so out loud — the honest answer for a surface nobody is
+    told to call.
+  * **Protocols and types as values.** `IReactiveAtom`, `IDisposable`,
+    `RAtom`, `Reaction` and the `->RAtom` factory are not names a migrator
+    writes in call position; the protocol's own METHODS (`dispose!`,
+    `add-on-dispose!`) are, and they are rostered.
+  * **Dynamic Vars and hooks.** `reagent2.ratom/rea-schedule` is a hook
+    the render scheduler installs, not consumer surface, and it is not
+    called.
+  * **Names no shipped namespace defines.** Nothing here is invented to
+    look thorough: every row is a public Var of a namespace on the
+    recognition roster (`run!`, `cursor`, `track` and `with-let` are stock
+    Reagent's; slim deliberately ships none of them, and one roster
+    covering both families is a superset by design rather than by
+    accident)."
   '{atom                      {:class :local-reactive-cell     :verdict :runtime-blocker}
     cursor                    {:class :derived-cell            :verdict :runtime-blocker}
     track                     {:class :derived-cell            :verdict :runtime-blocker}
@@ -155,6 +219,11 @@
     reaction                  {:class :derived-cell            :verdict :runtime-blocker}
     make-reaction             {:class :derived-cell            :verdict :runtime-blocker}
     run!                      {:class :derived-cell            :verdict :runtime-blocker}
+    activate!                 {:class :reactive-graph-control  :verdict :runtime-blocker}
+    flush!                    {:class :reactive-graph-control  :verdict :runtime-blocker}
+    reactive?                 {:class :reactive-graph-control  :verdict :runtime-blocker}
+    dispose!                  {:class :cell-disposal           :verdict :human-decision}
+    add-on-dispose!           {:class :cell-disposal           :verdict :human-decision}
     with-let                  {:class :with-let                :verdict :human-decision}
     create-class              {:class :lifecycle-class         :verdict :runtime-blocker}
     as-element                {:class :as-element              :verdict :runtime-blocker}
@@ -175,12 +244,17 @@
     force-update              {:class :render-control          :verdict :human-decision}
     force-update-all          {:class :render-control          :verdict :human-decision}
     flush                     {:class :render-control          :verdict :human-decision}
+    flush-render!             {:class :render-control          :verdict :human-decision}
     next-tick                 {:class :render-control          :verdict :human-decision}
     after-render              {:class :render-control          :verdict :human-decision}
+    flush-views!              {:class :substrate-test-seam     :verdict :human-decision}
     render                    {:class :root-mount              :verdict :human-decision}
+    unmount                   {:class :root-mount              :verdict :human-decision}
     unmount-component-at-node {:class :root-mount              :verdict :human-decision}
     create-root               {:class :root-mount              :verdict :human-decision}
-    hydrate-root              {:class :root-mount              :verdict :human-decision}})
+    hydrate-root              {:class :root-mount              :verdict :human-decision}
+    render-to-string          {:class :static-markup           :verdict :human-decision}
+    render-to-static-markup   {:class :static-markup           :verdict :human-decision}})
 
 (def substrate-surface
   "re-frame2's OWN substrate-adapter API — the SECOND roster, and the one
@@ -218,28 +292,73 @@
     `ns` form names the adapter, so nothing rides on catching it.
   * `frame-provider` / `frame-root` — hiccup HEADS rather than calls, and
     frame plumbing that survives the migration rather than migration work.
-  * `re-frame.adapter.test-react`'s `mount!` / `trigger-update!` — the
-    prefix rule binds that namespace, but the roster is the documented
-    consumer surface and the test adapter has no `docs/api/` page.
+  * The test adapter's INTROSPECTION tail — `lifecycle-log`,
+    `current-render-tree`, `mounted-components`, `mounted-children`,
+    `rendering?`. A test that calls one of them calls `mount!` first, so
+    the file is counted either way and rostering the tail would only
+    inflate the number a migrator has to read.
+
+  `re-frame.adapter.test-react`'s `mount!` and `trigger-update!` used to
+  be on that list, refused on the grounds that the test adapter has no
+  `docs/api/` page. **That was the same defect as rf2-xoal's, at a second
+  address**: the prefix rule RECOGNISES the namespace, so a test file
+  reaching for it and calling nothing else on the roster was
+  `:files-clean 1, entries 0, :recognition :full` — a confident zero. Two
+  rows close it, and they earn their place on the migration ask as well:
+  a headless test that mounts a tree and drives an update is exactly the
+  code a Hicasso migration has to re-point.
 
   Nothing here is `:mechanical` either, for the same reason nothing in
   [[surface]] is: no rewrite in this tool family reaches any of it.
 
-  **The two rosters must not share a NAME.** [[scan]] tries Reagent first,
-  so an overlap would silently classify a substrate call under a Reagent
-  class and a Reagent recovery sentence — a wrong answer wearing the right
-  shape, which is the one failure this file's whole design is against.
-  `census_test` asserts the intersection is empty rather than leaving it to
-  whoever adds the next row."
-  '{client-root         {:class :root-mount            :verdict :human-decision}
-    render!             {:class :root-mount            :verdict :human-decision}
-    unmount!            {:class :root-mount            :verdict :human-decision}
-    use-subscribe       {:class :substrate-read-hook   :verdict :human-decision}
-    use-frame           {:class :substrate-read-hook   :verdict :human-decision}
-    use-current-frame   {:class :substrate-read-hook   :verdict :human-decision}
-    wrap-view           {:class :substrate-view-seam   :verdict :human-decision}
-    set-hiccup-emitter! {:class :substrate-view-seam   :verdict :human-decision}
-    flush-views!        {:class :substrate-test-seam   :verdict :human-decision}})
+  ## The rosters MAY share a name, and one of them does
+
+  This file used to assert the two rosters were disjoint, on the reasoning
+  that [[scan]] tries Reagent first so an overlap would classify a
+  substrate call under a Reagent class. **That reasoning does not survive
+  reading [[re-frame.migration.hicasso.rewrite/bound-call?]]**, and the
+  assertion was retired when `reagent2.dom.client/flush-views!` had to be
+  rostered on the Reagent side too (rf2-xoal): the two arms are not
+  decided by name order, they are decided by two SEPARATE `ns` contexts,
+  and each arm fires only when this file's `ns` form binds that arm's
+  alias. `(rdc/flush-views!)` under `[reagent2.dom.client :as rdc]` fails
+  the substrate context's `bound-call?` and `(ad/flush-views!)` under
+  `[re-frame.adapter.uix :as ad]` fails the Reagent one, so the shared
+  name resolves correctly in both directions. The only construction that
+  could reach the wrong arm — the same bare symbol `:refer`red from both
+  families in one file — is a duplicate-refer conflict ClojureScript
+  refuses to compile.
+
+  The shared row is also the SAME SEAM at two addresses:
+  `re-frame.adapter.reagent-slim/flush-views!` is published from the
+  adapter's spine and `reagent2.dom.client/flush-views!` is the
+  promise-returning primitive beside it, so both carry
+  `:substrate-test-seam` and one recovery sentence answers for both.
+  `census_test/a-shared-roster-name-resolves-by-require` pins the
+  disambiguation, which is the property that actually matters, in place of
+  the emptiness assertion that pinned a proxy for it.
+
+  ## The residual, and why the `:full` wording had to weaken
+
+  `reagent-namespaces` is exact membership, so it can carry a ratchet
+  guaranteeing every recognised namespace has a rostered call. **This
+  roster cannot, and deliberately so**: it binds by an open PREFIX, which
+  is what stops the next adapter along reproducing the original silent
+  zero — but it also means an adapter this roster has no rows for is
+  recognised the day it ships. That residual is real, no list closes it,
+  and it is precisely what [[caveat]]'s `:full` sentence now admits to
+  instead of calling its zero a measurement."
+  '{client-root         {:class :root-mount               :verdict :human-decision}
+    render!             {:class :root-mount               :verdict :human-decision}
+    unmount!            {:class :root-mount               :verdict :human-decision}
+    use-subscribe       {:class :substrate-read-hook      :verdict :human-decision}
+    use-frame           {:class :substrate-read-hook      :verdict :human-decision}
+    use-current-frame   {:class :substrate-read-hook      :verdict :human-decision}
+    wrap-view           {:class :substrate-view-seam      :verdict :human-decision}
+    set-hiccup-emitter! {:class :substrate-view-seam      :verdict :human-decision}
+    flush-views!        {:class :substrate-test-seam      :verdict :human-decision}
+    mount!              {:class :substrate-test-harness   :verdict :human-decision}
+    trigger-update!     {:class :substrate-test-harness   :verdict :human-decision}})
 
 (def ^:private notes
   "One recovery sentence per class, in the migrator's vocabulary. The
@@ -308,9 +427,35 @@
         "exposes no equivalent lever; a migration that needed one is usually a migration with a "
         "read still living outside the frame.")
 
+   :reactive-graph-control
+   (str "This drives Reagent's reactive GRAPH directly — draining the pending-reaction queue "
+        "(`flush!`), forcing a Reaction onto the push path (`activate!`), or asking whether the "
+        "current stack is a reactive context (`reactive?`). re-frame2 owns that graph and settles "
+        "it on its own clock, and exposes no consumer-facing lever over it, so this does not port "
+        "as a respelling. Code that branched on `reactive?` has to be re-shaped rather than "
+        "translated: the question it was asking does not exist once every read is a subscription "
+        "at the point of use.")
+
+   :cell-disposal
+   (str "Teardown for a Reagent cell — `dispose!`, or a callback registered with "
+        "`add-on-dispose!`. re-frame2 disposes a subscription when its last reader goes away, "
+        "through the cache rather than at a call site, so an explicit disposal has no counterpart "
+        "to be respelled into. Decide what the callback was really FOR: releasing a host resource "
+        "belongs in a declared native host's release path, and cancelling in-flight work belongs "
+        "in an effect.")
+
    :root-mount
    (str "Root mounting. Hicasso mounts its own root; this call is boot ceremony and is replaced "
         "wholesale rather than edited.")
+
+   :static-markup
+   (str "Hiccup to an HTML STRING, outside the React lifecycle — `render-to-string` or "
+        "`render-to-static-markup`. Hicasso's counterpart is the SSR seam "
+        "(`day8/re-frame2-ssr`'s `re-frame.ssr/render-to-string`), which lowers a HICCASSO tree "
+        "rather than a Reagent one, so this is a re-point rather than an edit. An export that "
+        "only ever wanted static bytes — clipboard HTML, report HTML, email — ports "
+        "straightforwardly; anything whose output is later HYDRATED has to be re-read against "
+        "Spec 011, because the two paths do not agree about hydration attributes.")
 
    :substrate-read-hook
    (str "A read through the substrate adapter's own hook tier - the UIx adapter's "
@@ -330,7 +475,18 @@
    (str "`flush-views!` wraps React's `act()` so a test can settle pending effects before "
         "reading the DOM. It is a REAGENT/UIX-substrate seam, per Spec 008's per-adapter-require "
         "rule, so it does not follow the views across: settle a Hicasso tree the way the "
-        "Hicasso testing chapter directs, and delete the adapter require the call came through.")
+        "Hicasso testing chapter directs, and delete the require the call came through — which "
+        "is the substrate adapter for the re-exported spelling and `reagent2.dom.client` for the "
+        "promise-returning one.")
+
+   :substrate-test-harness
+   (str "`mount!` / `trigger-update!` — the headless test adapter's own harness, which mounts a "
+        "view tree with no browser and drives an update through it. It is test scaffolding "
+        "rather than application code, so it does not port: a Hicasso view is exercised the way "
+        "the Hicasso testing chapter directs, and this call is replaced wholesale along with the "
+        "adapter require it came through. Check what the test was ASSERTING before respelling "
+        "it — a harness that reached into the render tree is usually asserting something a "
+        "subscription-level test says more directly.")
 
    :unresolved-reagent-require
    (str "This file's `ns` form NAMES a Reagent namespace, and the reader could not bind a "
@@ -501,7 +657,19 @@
   Four states, and the middle two are the whole reason this exists.
 
   * `:full` — every scanned file names Reagent or a re-frame2 substrate
-    adapter. A zero here means the tool looked and found nothing.
+    adapter. **This is a statement about the FILES, and it is the only
+    thing it is.** It says the census had a population to look in; it does
+    NOT say the roster covers everything those files could call, and the
+    two are different claims that a zero collapses together. The wording
+    [[caveat]] emits was once the stronger one — *a zero below is a
+    measurement*, full stop — and a file whose one call was
+    `reagent2.dom.server/render-to-static-markup` earned it while the
+    roster had no such row (rf2-xoal). The recognised half is now
+    guaranteed at least one rostered call PER NAMESPACE by
+    `rewrite/reagent-namespaces`' coupling law and its test ratchet, which
+    is the strongest honest claim available: every namespace this tool
+    recognises, it can find something in. It is not a claim that the
+    roster is complete, and no roster ever is.
   * `:partial` — some files named one and some named neither.
   * `:none` — files were scanned and NOT ONE named either. The tool had
     nothing to count, and it says so rather than passing for a clean bill
@@ -554,8 +722,13 @@
 
     :full
     (str "Every one of the " files-scanned " scanned file(s) names Reagent or a re-frame2 "
-         "substrate adapter, so this census had a population throughout. A zero below is a "
-         "measurement.")))
+         "substrate adapter, so this census had a population throughout. THAT IS A STATEMENT "
+         "ABOUT THE FILES, NOT ABOUT THE ROSTER: recognition is decided per FILE, from its `ns` "
+         "form, while the entries below are found per NAME, against a fixed roster of "
+         (count surface) " Reagent names and " (count substrate-surface) " substrate names. A "
+         "zero below therefore means no rostered call was found — not that these files hold no "
+         "migration work. Read it as a measurement of the roster, and port the shapes it does "
+         "not name off the migration chapter's translation table.")))
 
 (defn summarise
   "The census half of the report artefact.
@@ -658,4 +831,11 @@
            " — " (str/join ", " (for [[k v] by-verdict] (str v " " (name k))))
            (when (pos? files-unrecognised)
              (str "; " files-unrecognised " of " files-scanned
-                  " file(s) NOT RECOGNISED — read :census :summary :caveat"))))))
+                  " file(s) NOT RECOGNISED — read :census :summary :caveat"))
+           ;; A ZERO ON THIS LINE IS THE ONE THAT MISLEADS, and until
+           ;; rf2-xoal's audit it was unmarked whenever recognition was
+           ;; `:full` — the reader who stops at the last line of the run
+           ;; got a bare `0` with nothing beside it. The count is bounded
+           ;; by the roster, and only the caveat says by how much.
+           (when (zero? entries)
+             " — ZERO ENTRIES: bounded by the ROSTER, not by the corpus; read :census :summary :caveat")))))

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/census.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/census.clj
@@ -451,7 +451,7 @@
    :static-markup
    (str "Hiccup to an HTML STRING, outside the React lifecycle — `render-to-string` or "
         "`render-to-static-markup`. Hicasso's counterpart is the SSR seam "
-        "(`day8/re-frame2-ssr`'s `re-frame.ssr/render-to-string`), which lowers a HICCASSO tree "
+        "(`day8/re-frame2-ssr`'s `re-frame.ssr/render-to-string`), which lowers a HICASSO tree "
         "rather than a Reagent one, so this is a re-point rather than an edit. An export that "
         "only ever wanted static bytes — clipboard HTML, report HTML, email — ports "
         "straightforwardly; anything whose output is later HYDRATED has to be re-read against "

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
@@ -337,13 +337,13 @@
 ;; Reagent alias resolution
 ;; ---------------------------------------------------------------------------
 
-(def ^:private reagent-namespaces
+(def reagent-namespaces
   "Reagent's API, and the namespaces that ARE it.
 
   **The rule is IDENTITY, not spelling: a namespace binds when this project
   can vouch for what it is.** Two families qualify and nothing else does.
 
-  * Stock Reagent's four public namespaces.
+  * Stock Reagent's five public namespaces.
   * The `reagent2.*` four that `implementation/adapters/reagent-slim/`
     ships. That is the SAME API authored a second time IN THIS REPOSITORY:
     `reagent2.core` defines `atom`, `create-class`, `as-element`,
@@ -356,12 +356,45 @@
   `reagent2.core` and scored ZERO, with nothing on screen to say the tool
   had not recognised it.
 
+  ## THE COUPLING LAW, and why it is written here rather than next door
+
+  **A namespace joins this set only together with the
+  [[re-frame.migration.hicasso.census/surface]] rows for the names it
+  publishes.** This set answers a per-FILE question — *is this file's `ns`
+  form reaching for Reagent* — and the census roster answers a per-NAME
+  one. Widening this set alone therefore does not widen what the tool can
+  find; it widens what the tool claims to UNDERSTAND, and those move in
+  opposite directions. A file that binds a namespace on this list and
+  calls a name the census roster has no row for is counted RECOGNISED and
+  scored zero, and `:recognition :full` then tells its reader the zero is
+  a measurement.
+
+  That is strictly worse than leaving the namespace off. An unrecognised
+  file is a bucket the caveat names out loud; a recognised-and-unrostered
+  one is a confident zero, which is the exact fail-open shape the census's
+  whole design is against. It is not hypothetical: PR #9132 added the
+  `reagent2.*` four to this set without adding
+  `render-to-static-markup` — `reagent2.dom.server`'s ONLY public fn — to
+  the roster, and a one-line file calling it reported `files-recognised 1,
+  files-clean 1, entries 0, :recognition :full` under the caveat *A zero
+  below is a measurement* (rf2-xoal, merged-PR audit of #9132).
+
+  `census_test/every-recognised-namespace-has-a-rostered-call` is the
+  ratchet: it holds one known public call per namespace on this list and
+  fails on any namespace added without one, so the next widening cannot
+  reach main half-done.
+
+  `reagent.dom.server` is here for that reason and no other — it was added
+  in the same change as its two roster rows, `render-to-string` and
+  `render-to-static-markup`, whose absence was the identical hole in the
+  stock family.
+
   A namespace that merely SPELLS one of these is still not one and still
   binds nothing — re-frame-10x's vendored
   `day8.re-frame-10x.inlined-deps.reagent.v1v2v0.reagent.core` is the
   standing example, and [[names-reagent?]] reports it rather than guessing.
   Vouching is not spelling in either direction."
-  '#{reagent.core  reagent.dom    reagent.dom.client  reagent.ratom
+  '#{reagent.core  reagent.dom    reagent.dom.client  reagent.ratom  reagent.dom.server
      reagent2.core reagent2.ratom reagent2.dom.client reagent2.dom.server})
 
 (defn reagent-namespace?

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/census_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/census_test.clj
@@ -38,7 +38,8 @@
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [re-frame.migration.hicasso.census :as census]
-            [re-frame.migration.hicasso.codemod :as cm]))
+            [re-frame.migration.hicasso.codemod :as cm]
+            [re-frame.migration.hicasso.rewrite :as rw]))
 
 (defn- classes [src file] (mapv :class (:entries (census/scan src file))))
 
@@ -509,12 +510,42 @@
                                             "a.cljs")))))
           "a class the roster can produce but the notes cannot describe"))))
 
-(deftest the-two-rosters-do-not-overlap
-  (testing "`scan` tries Reagent first, so a shared name would classify a
-            substrate call under a Reagent class and a Reagent recovery
-            sentence — a wrong answer wearing the right shape."
-    (is (empty? (clojure.set/intersection (set (keys census/surface))
-                                          (set (keys census/substrate-surface)))))))
+(deftest a-shared-roster-name-resolves-by-require
+  (testing "this used to assert the two rosters were DISJOINT, on the reasoning
+            that `scan` tries Reagent first so an overlap would classify a
+            substrate call under a Reagent class. `bound-call?` is what actually
+            decides, and it consults a SEPARATE `ns` context per roster, so the
+            require decides the arm and the name order decides nothing. The
+            emptiness assertion was pinning a proxy; this pins the property
+            (rf2-xoal). An UNINTENDED overlap still reds here — only the
+            deliberate one is allowed through."
+    (is (= '#{flush-views!}
+           (clojure.set/intersection (set (keys census/surface))
+                                     (set (keys census/substrate-surface))))))
+
+  (testing "through `reagent2.dom.client` the shared name is Reagent's — and the
+            file counts as one that NAMES Reagent, which is the flag the migration
+            skill reads to decide whether a Reagent coordinate may be dropped"
+    (let [src (str "(ns app.t\n"
+                   "  (:require [reagent2.dom.client :as rdc]))\n"
+                   "\n"
+                   "(defn settle [] (rdc/flush-views!))\n")
+          {:keys [entries reagent? substrate?]} (census/scan src "app/t.cljs")]
+      (is (true? reagent?))
+      (is (false? substrate?))
+      (is (= [:substrate-test-seam] (mapv :class entries)))))
+
+  (testing "and through an adapter it is the substrate's, with the two flags the
+            other way round — same class, because it is the same seam at two
+            addresses, and one recovery sentence answers for both"
+    (let [src (str "(ns app.t\n"
+                   "  (:require [re-frame.adapter.uix :as ad]))\n"
+                   "\n"
+                   "(defn settle [] (ad/flush-views!))\n")
+          {:keys [entries reagent? substrate?]} (census/scan src "app/t.cljs")]
+      (is (false? reagent?))
+      (is (true? substrate?))
+      (is (= [:substrate-test-seam] (mapv :class entries))))))
 
 (deftest the-prefix-rule-is-anchored-at-the-start
   (testing "the substrate roster binds by PREFIX so the adapter set can grow,
@@ -566,6 +597,131 @@
                    "\n"
                    "(defn f [] (r/atom 0))\n")]
       (is (= [:unresolved-reagent-require :unresolved-alias] (classes src "app/p.cljs"))))))
+
+;; ---------------------------------------------------------------------------
+;; RECOGNISED BUT UNCOUNTABLE — the confident zero that came back through the
+;; widening itself (rf2-xoal, merged-PR audit of #9132)
+;; ---------------------------------------------------------------------------
+
+(def ^:private recognised-namespace-calls
+  "One known PUBLIC call per namespace `rewrite/reagent-namespaces`
+  recognises, written as it would be called through the alias `x`.
+
+  **This table is the ratchet, and the assertion below that it is
+  COMPLETE is the half that matters.** Recognition is decided per FILE and
+  entries are found per NAME, so widening the namespace set without
+  widening `census/surface` converts an honest *I did not recognise this
+  file* into `:recognition :full` with `entries 0` — a confident zero, and
+  a strictly worse answer than the one it replaced. PR #9132 did exactly
+  that: it added the `reagent2.*` four and left `reagent2.dom.server`'s
+  only public function off the roster.
+
+  Every call here is a real public Var of the namespace it sits under, read
+  off `implementation/adapters/reagent-slim/src/` for the `reagent2` half
+  and Reagent's own published API for the stock half. A sample that named
+  something no namespace defines would pass this test while proving
+  nothing about the tool."
+  '{reagent.core        "(x/atom 0)"
+    reagent.dom         "(x/render [:div] el)"
+    reagent.dom.client  "(x/unmount root)"
+    reagent.ratom       "(x/reactive?)"
+    reagent.dom.server  "(x/render-to-string [:div])"
+    reagent2.core       "(x/as-element h)"
+    reagent2.ratom      "(x/activate! rx)"
+    reagent2.dom.client "(x/flush-views!)"
+    reagent2.dom.server "(x/render-to-static-markup [:div])"})
+
+(def ^:private substrate-namespace-calls
+  "The same probe for the adapters shipping today. There is no
+  completeness assertion to pair with it: `substrate-ns-prefix` binds an
+  OPEN set on purpose, so no list here could be exhaustive, and the
+  residual — an adapter recognised before this roster has rows for it — is
+  what `caveat`'s weakened `:full` sentence now admits to."
+  '{re-frame.adapter.reagent      "(x/render! root view opts)"
+    re-frame.adapter.reagent-slim "(x/client-root el)"
+    re-frame.adapter.uix          "(x/use-subscribe [:q])"
+    re-frame.adapter.test-react   "(x/mount! [:div])"})
+
+(defn- probe
+  "Scan a one-call file that requires `ns*` as `x`, and return the census
+  summary over it."
+  [ns* call]
+  (:summary (census/build [(census/scan (str "(ns app.probe\n"
+                                             "  (:require [" ns* " :as x]))\n"
+                                             "\n"
+                                             "(defn f [] " call ")\n")
+                                        "app/probe.cljs")])))
+
+(deftest every-recognised-namespace-has-a-rostered-call
+  (testing "the ratchet: a namespace cannot join `reagent-namespaces` without a
+            sample here, so the next widening cannot reach main half-done the way
+            #9132's did"
+    (is (= (set (keys recognised-namespace-calls)) rw/reagent-namespaces)
+        "a recognised namespace with no known-public-call sample, or a sample for
+         a namespace the tool does not recognise"))
+
+  (doseq [[ns* call] recognised-namespace-calls]
+    (testing (str ns* " " call)
+      (let [s (probe ns* call)]
+        (is (= :full (:recognition s))
+            "the probe file must be recognised, or it is testing the wrong thing")
+        (is (not (and (= :full (:recognition s)) (zero? (:entries s))))
+            (str "CONFIDENT ZERO: " ns* " is recognised, " call " is one of its public "
+                 "calls, and the census scored it :full with zero entries — which is the "
+                 "sentence `a zero below is a measurement` over a roster that has no row "
+                 "for it (rf2-xoal)"))
+        (is (= 0 (:files-clean s))
+            "a file whose only call is on the roster is not a clean file")
+        (is (= 1 (:files-recognised s))))))
+
+  (doseq [[ns* call] substrate-namespace-calls]
+    (testing (str ns* " " call)
+      (let [s (probe ns* call)]
+        (is (= :full (:recognition s)))
+        (is (not (and (= :full (:recognition s)) (zero? (:entries s))))
+            (str "CONFIDENT ZERO through the prefix rule: " ns* " " call))
+        (is (= 0 (:files-clean s)))))))
+
+(deftest the-audits-reproduction
+  (testing "the exact file the merged-PR audit of #9132 built, and the four numbers
+            it reported. `reagent2.dom.server` was added to the namespace roster and
+            `render-to-static-markup` — its ONLY public function — was not added to
+            the call roster, so the census recognised the file, found nothing in it,
+            counted it CLEAN, and told its reader the zero was a measurement."
+    (let [src (str "(ns app.ssr\n"
+                   "  (:require [reagent2.dom.server :as rds]))\n"
+                   "\n"
+                   "(defn page-html []\n"
+                   "  (rds/render-to-static-markup [:div \"hello\"]))\n")
+          s   (:summary (census/build [(census/scan src "app/ssr.cljs")]))]
+      (is (= 1 (:files-recognised s)))
+      (is (= :full (:recognition s)))
+      (is (= 1 (:entries s))         "was 0")
+      (is (= 0 (:files-clean s))     "was 1")
+      (is (= 1 (get-in s [:by-verdict :human-decision])))
+      (is (= {:static-markup 1} (:by-class s)))
+      (testing "and the sentence that made the zero confident is gone, replaced by one
+                that says what recognition actually measures"
+        (is (not (str/includes? (:caveat s) "A zero below is a measurement")))
+        (is (str/includes? (:caveat s) "NOT ABOUT THE ROSTER"))))))
+
+(deftest a-full-zero-still-says-the-roster-bounds-it
+  (testing "recognition can be `:full` and the count still zero — a recognised file
+            whose only call is a shape no roster names. That is legal and honest;
+            what it must not do is present the zero as a measurement of the corpus.
+            This is the residual no roster closes, so the WORDING is the gate."
+    (let [src (str "(ns app.v\n"
+                   "  (:require [reagent.core :as r]))\n"
+                   "\n"
+                   "(defn v [] [:div \"no rostered call in this file\"])\n")
+          s   (:summary (census/build [(census/scan src "app/v.cljs")]))]
+      (is (= :full (:recognition s)))
+      (is (= 0 (:entries s)))
+      (is (str/includes? (:caveat s) "fixed roster"))
+      (is (str/includes? (:caveat s) "not that these files hold no migration work"))
+      (testing "and the CLI tail — the last line of the run, read by whoever reads
+                nothing else — marks the zero rather than printing it bare"
+        (is (str/includes? (census/describe {:summary s}) "ZERO ENTRIES"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; A zero the tool CANNOT report confidently (rf2-xoal)

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/census_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/census_test.clj
@@ -39,7 +39,7 @@
             [clojure.test :refer [deftest is testing]]
             [re-frame.migration.hicasso.census :as census]
             [re-frame.migration.hicasso.codemod :as cm]
-            [re-frame.migration.hicasso.rewrite :as rw]))
+            [re-frame.migration.hicasso.rewrite :as rf.migration.hicasso.rewrite]))
 
 (defn- classes [src file] (mapv :class (:entries (census/scan src file))))
 
@@ -656,7 +656,7 @@
   (testing "the ratchet: a namespace cannot join `reagent-namespaces` without a
             sample here, so the next widening cannot reach main half-done the way
             #9132's did"
-    (is (= (set (keys recognised-namespace-calls)) rw/reagent-namespaces)
+    (is (= (set (keys recognised-namespace-calls)) rf.migration.hicasso.rewrite/reagent-namespaces)
         "a recognised namespace with no known-public-call sample, or a sample for
          a namespace the tool does not recognise"))
 


### PR DESCRIPTION
The merged-PR audit of #9132 said the closure was incomplete and the same confident zero was still reachable. **It reproduces.** A one-line file requiring `reagent2.dom.server` and calling `render-to-static-markup` — that namespace's only public function — reported:

```clojure
:files-scanned 1, :files-recognised 1, :files-clean 1, :entries 0,
:recognition :full,
:caveat "… so this census had a population throughout. A zero below is a measurement."
```

## Why

`rewrite/reagent-namespaces` decides per **file** whether the file reaches for Reagent. `census/surface` finds entries per **name**. #9132 widened the first with the reagent-slim adapter's `reagent2.*` four and did not widen the second, and the gap between the two lists is exactly a confident zero: the file is recognised, no rostered name matches, so it is counted `:files-clean` and `:recognition` reads `:full`.

A recognised-and-unrostered file is **strictly worse** than an unrecognised one. The unrecognised file is a bucket the caveat names out loud; this one is a clean bill of health. The unrecognised file was always honest — it was the newly recognised one that lied.

## What changed

**1. The roster is reconciled against every recognised namespace's supported public calls.** Ten new rows — `render-to-string`, `render-to-static-markup`, `unmount`, `flush-render!`, `flush-views!`, `flush!`, `activate!`, `reactive?`, `dispose!`, `add-on-dispose!` — and three new classes to carry them, each with a recovery sentence: `:static-markup`, `:reactive-graph-control`, `:cell-disposal`. `reagent.dom.server` joins the recognition set in the same change as its two rows, never before them. **No existing row's class moved.**

Deliberately left off, and said so in the docstring: the `reagent2.impl.*` namespaces (not on the recognition roster at all, so a call through one is an unrecognised file and the caveat says so); protocols and types as values (`IReactiveAtom`, `RAtom`, `->RAtom` — the protocol's *methods* are rostered); `rea-schedule`, a scheduler hook rather than consumer surface. Every row is a real public Var of a namespace on the recognition roster.

**2. The coupling is now a law with a ratchet.** `reagent-namespaces` states that a namespace joins it only together with the roster rows for the names it publishes, and `census_test` holds one known public call per recognised namespace with a **completeness assertion** against that set — so a namespace added without a sample reds here rather than on somebody's migration. The same probe covers the adapters shipping today, where `mount!` / `trigger-update!` were the identical hole at a second address: the prefix rule recognised `re-frame.adapter.test-react` while the roster had no row in it.

**3. The `:full` wording is weakened to the claim it can support.** It said the zero was a measurement. It now says recognition is a statement about the *files*, while the count is bounded by a fixed roster of N Reagent and M substrate names — because the substrate roster binds by an open prefix, so a residual survives every list. The CLI tail marks a zero rather than printing it bare.

**The disjoint-rosters assertion is retired for the property it was proxying.** It claimed a shared name would misclassify because `scan` tries Reagent first; `bound-call?` is what actually decides, and it consults a separate `ns` context per roster, so the require decides the arm and name order decides nothing. `flush-views!` is now on both — deliberately, as the only shared name, and the same seam at two addresses — and an unintended overlap still reds.

## Evidence

* Codemod suite `clojure -M:test`: **64 tests, 621 assertions, 0 failures**, exit 0.
* **The new tests fail against the pre-fix roster.** Renaming the `render-to-static-markup` roster key produced 6 failures naming exactly that: `the-audits-reproduction` on all four numbers, and `every-recognised-namespace-has-a-rostered-call` with `CONFIDENT ZERO: reagent2.dom.server is recognised …`. Restored and re-verified by blob hash; suite green again.
* `scripts/check_doc_slugs.py`: exit 0. Proved to cover this README by planting a broken link and anchor — it reds naming the file and line.
* `mkdocs build --strict`: exit 0 — but it does **not** cover this file. `mkdocs.yml`'s `exclude_docs` lists `migration/reagent-to-hicasso/codemod/`, and the same planted breakage left the strict build green and silent. `check_doc_slugs.py` is the gate here.
* **Goldens unmoved**, and that is expected rather than suspicious: the corpus pins the *fixer*'s entries via `rewrite-string`, and no corpus input names a newly rostered call or `reagent.dom.server`.
* On this repository's own example corpus the census moves **74 sites across 32 files → 75 across 33**, and the one that moved is the point: a file previously counted RECOGNISED AND CLEAN was calling `render-to-static-markup`.

## Prose this makes stale elsewhere — not edited, flagged for follow-up

PR #9139's chapter-20 and skill edits are **not on this tip**, so those pages are already stale by three classes before this change and by six after it. Specifically:

* `docs/core/hicasso/20-migration-from-reagent.md:96-97` — the verdict/class table names 13 classes; the census now emits 19. Line 92's "Every census class is a shape §2's translation table already teaches" becomes false: §2 teaches none of the ten new names. Lines 77-79 pin "59 sites across 28 files … taken at `e337a1d`" (75 across 33 here). Line 89's table row still says "Reagent API call sites".
* `skills/reagent-migration/references/catalog-mechanical.md:352-353` — names four recognised namespaces; the set was already eight and is now nine.
* `skills/reagent-migration/references/procedure.md:40-44` — "Map each class onto a MIG rule"; no MIG rule exists for the three new classes.
* `skills/reagent-migration/evals/evals.json` — eval 31 (line 199) pins the old CLI tail verbatim; evals 29/31 pin the old estimand. Eval 23's fixture is literally `(s/render-to-string [app])` through `reagent.dom.server`, which flips from unrecognised to a rostered `:static-markup` entry — its expectations say nothing about the census, so it does not fail.

`:files-with-reagent` keeps its exact meaning, and `:mechanical 0` stays a finding.
