### PR TITLE
refactor(routing): remove four routing-surface vestiges (rf2-6r9j.1, .3, .4, .8)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -515,9 +515,6 @@
     :producer-ns 're-frame.routing
     :design-bead "rf2-3l7xxz"
     :description "Reset the process-global URL-ownership claim-order vector (re-frame.routing.nav-fx/url-claim-order) that records, in claim order, which frames carry :url-bound? true. url-owner-frame-id resolves the FIRST-CLAIMED still-live binding (the incumbent) so a later duplicate cannot steal the browser URL. Like the nav-counters it is process-global state a runtime/frames reset does not clear; the shared CLJS make-reset-runtime-fixture reset-hooks table fires this per test so a prior test's claim cannot leak (test isolation)."}
-   {:key         :routing/route-sub-fn
-    :producer-ns 're-frame.routing
-    :description "Subscription fn returning the currently-matched route."}
    {:key         :routing/route-sub-egress-path
     :producer-ns 're-frame.routing
     :design-bead "rf2-mtzv5m"

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -89,11 +89,13 @@
 ;; EP-0037 R0 — the shared RouteAddress extraction law
 ;; (`re-frame.routing.address`) and the one resolved-target / route-plan seam
 ;; (`re-frame.routing.resolve`) are INTERNAL routing seams the navigation
-;; doors consume; they are deliberately NOT re-exported here. A tool that
-;; needs the R0 plan diagnostic projection (`resolve/plan-projection`) requires
-;; the internal namespace directly, exactly as CLJS tools require
-;; `re-frame.routing.tooling` — routing adds no public `RoutePlan` constructor
-;; (Spec 012 §Resolved target and the plan diagnostic projection).
+;; doors consume; they are deliberately NOT re-exported here. The plan's
+;; observable projection is the `:rf.route/planned` trace
+;; (`resolve/plan-trace-tags`), which every door commit branch emits through;
+;; a tool reads it there rather than through a facade export, exactly as CLJS
+;; tools require `re-frame.routing.tooling` directly — routing adds no public
+;; `RoutePlan` constructor (Spec 012 §Resolved target and the plan diagnostic
+;; projection).
 
 ;; Scroll positions are host-side transient state, not runtime-db state.
 (def scroll-positions-cap       rf.routing.scroll/scroll-positions-cap)
@@ -486,7 +488,12 @@
 ;; cannot reach.
 (rf.late-bind/set-fn! :routing/reset-nav-counters! reset-nav-counters!)
 (rf.late-bind/set-fn! :routing/reset-url-claims!  reset-url-claims!)
-(rf.late-bind/set-fn! :routing/route-sub-fn       route-sub-fn)
+;; rf2-6r9j.8: no :routing/route-sub-fn hook. `route-sub-fn` is registered
+;; DIRECTLY as the `:rf/route` sub above, in this already-loaded facade, so
+;; core never needed to late-bind to it; the hook was mechanical residue of the
+;; artefact split (c435165251) that nothing ever read. The public
+;; `re-frame.routing/route-sub-fn` alias stays — it is a documented owned-
+;; namespace function.
 
 ;; Registration-time frame-config preflight (rf2-ktmto9): routing owns the
 ;; MEANING of `:url-strategy` (presence semantics + host-required legs), core

--- a/implementation/routing/src/re_frame/routing/address.cljc
+++ b/implementation/routing/src/re_frame/routing/address.cljc
@@ -95,19 +95,16 @@
   (set/union address-keys raw-url-keys policy-keys edit-keys))
 
 ;; ---- the closed `:rf/route-address` value ---------------------------------
-
-(def RouteAddress
-  "The closed `:rf/route-address` Malli schema DATA (Spec-Schemas
-  §`:rf/route-address`) — the caller-authored address of one registered named
-  destination. Held as data so the routing artefact carries the contract's
-  schema shape without a hot-path Malli-artefact dependency; `valid-address?`
-  is the pure structural check the extractor applies to the EXTRACTED
-  address."
-  [:map {:closed true}
-   [:to       :keyword]
-   [:params   {:optional true} :map]
-   [:query    {:optional true} :map]
-   [:fragment {:optional true} [:maybe :string]]])
+;;
+;; The NORMATIVE schema for this value is `:rf/route-address` in
+;; Spec-Schemas.md; routing does not carry a second copy of it. A Malli-form
+;; `RouteAddress` value used to sit here (rf2-6r9j.3). It was inert: routing
+;; never read it, the optional Schemas artefact never imported it, and
+;; `valid-address?` below — the pure structural check the extractor applies to
+;; the EXTRACTED address — derives nothing from it. Its only remaining effect
+;; was to present, in an internal namespace, a second spelling of the contract
+;; that could drift from both the normative schema and the live gate. Keep the
+;; structural gate and the spec text as the two authorities.
 
 (defn valid-address?
   "Pure structural predicate for the closed `:rf/route-address` shape

--- a/implementation/routing/src/re_frame/routing/resolve.cljc
+++ b/implementation/routing/src/re_frame/routing/resolve.cljc
@@ -27,14 +27,6 @@
       R0 diagnostic projection: the source address / raw-URL request, the
       cause, the resolved target, the parent-to-leaf branch, and the
       behaviour-preserving leaf resource plan.
-    - `plan-projection` — the R0 diagnostic projection of a plan (the minimum
-      needed to prove the shared spine), the pure on-demand view a tool
-      (Xray / trace tooling) reads. Later EP-0037 slices widen it (R2 adds
-      occurrence / dependency groups, the grouped order, and the identity
-      diff); R0 exposes only the source + cause, the resolved target, the
-      branch, and the leaf plan. This adds no public `RoutePlan` constructor
-      or promise-returning router object — its observable laws are public and
-      its projection is a pure derivation.
     - `plan-trace-tags` — the projection as `:rf.route/planned` TRACE tags, the
       ONE mapping both door commit branches emit through so the projection is
       reachable from an executed navigation without the trace becoming a
@@ -302,8 +294,9 @@
   resolved target — the ONE place the branch + leaf plan are derived.
 
   Plain data — this contract adds no public `RoutePlan` constructor or
-  promise-returning router object; its diagnostic projection is
-  `plan-projection`.
+  promise-returning router object; its observable projection is
+  `plan-trace-tags`, the `:rf.route/planned` trace both door commit branches
+  emit through.
 
   The parent-to-leaf `:branch` is the FAIL-LOUD walk
   (`rf.routing.events/resolve-branch`), resolved ONCE per navigation here:
@@ -330,29 +323,18 @@
              :leaf-plan           (leaf-plan-of route-id)}
       branch-error (assoc :branch-error branch-error))))
 
-;; ---- the diagnostic projection --------------------------------------------
-
-(def r0-projection-keys
-  "The keys the R0 plan diagnostic projection exposes (Spec 012 §Resolved
-  target and the plan diagnostic projection): the minimum needed to prove the
-  shared spine — the source address and cause, the resolved target, the
-  parent-to-leaf branch, and the behaviour-preserving leaf resource plan.
-  Later EP-0037 slices widen the projection (R2 adds occurrence / dependency
-  groups, contributor dedupe advisories, the grouped order, and the identity
-  diff)."
-  [:source :cause :target :branch :leaf-plan])
-
-(defn plan-projection
-  "The R0 diagnostic projection of a route `plan` — the pure, on-demand view a
-  tool (Xray / trace tooling) reads to prove the shared spine, exposing ONLY
-  `r0-projection-keys`. No slice is licence to build a second Xray graph or a
-  general-purpose public plan debugger (Spec 012 §Resolved target and the plan
-  diagnostic projection); this is a `select-keys` over the plan the doors
-  already build."
-  [plan]
-  (select-keys plan r0-projection-keys))
-
 ;; ---- the projection as trace tags -----------------------------------------
+;;
+;; An on-demand `plan-projection` helper and its `r0-projection-keys` list used
+;; to sit here (rf2-6r9j.4). Nothing read them: no runtime, Xray, trace tool,
+;; example or conformance path called the helper, and its only caller was the
+;; unit test that pinned it. `plan-trace-tags` below is the ONE projection an
+;; executed navigation actually exposes — deliberately bounded and redacted
+;; where the raw plan carries the carriers — so the helper was a second,
+;; unreachable spelling of "the plan projection" that future plan-field changes
+;; would have had to keep in step for no reader. Should a tool ever need an
+;; on-demand view, land the concrete consumer and a supported access boundary
+;; with it rather than re-planting a speculative internal helper.
 
 (defn- bound-keys
   "The KEY SET of a resolved `:params` / `:query` map, as a vector in the total

--- a/implementation/routing/src/re_frame/routing/tooling.cljc
+++ b/implementation/routing/src/re_frame/routing/tooling.cljc
@@ -17,8 +17,8 @@
       whole routing artefact is already bundle-isolated
       from production builds (the counter example never `:require`s
       `re-frame.routing`), so this sibling can never reach a no-routing
-      app's bundle; the explicit sentinel at the foot of this ns
-      is checked by the sentinel at the foot of this namespace.
+      app's bundle; the bundle-isolation gate noted at the foot of this ns
+      additionally proves no stray `:require` ever pulled the body in.
 
   READ-ONLY over the registry. Like slice-2's subs.tooling read the sub
   registrar and slice-3's flows.tooling read the flow registry, this ns
@@ -340,10 +340,24 @@
 
 ;; ---- bundle-isolation sentinel ------------------------------------------
 ;;
-;; `implementation/scripts/check-bundle-isolation.cjs` rejects the production
-;; counter bundle if this exact string appears. Keep the literal unique to this
-;; namespace and in lockstep with the checker; its presence means the tooling
-;; namespace reached a production bundle that should not load routing tools.
-
-(defonce ^:private bundle-isolation-sentinel
-  "rf.routing.tooling/sentinel:rf2-eiiifu-2026-06-12:do-not-rename")
+;; `implementation/scripts/check-bundle-isolation.cjs` proves this tooling
+;; sibling never reaches the production counter bundle. The literal it greps
+;; the EMITTED module for is `route-fact` — the `:refinement` every route
+;; algebra node this namespace builds carries (`node-for` and
+;; `route-slice-algebra-view` both stamp it), so a CLJS keyword's
+;; fully-qualified name is interned into the emitted JS as a string constant
+;; Closure does not rename.
+;;
+;; A `defonce ^:private bundle-isolation-sentinel` string used to sit here
+;; (rf2-eiiifu). It was inert: private, unconsumed, and therefore dropped by
+;; Closure `:advanced`, so the `do-not-rename` instruction it carried guarded
+;; nothing. `4e43784ec7` (2026-07-15) moved this roster entry onto the live
+;; node kind when these controls became emitted-module greps rather than
+;; source greps; the var was simply left behind, and rf2-6r9j.1 removed it.
+;; `re-frame.resources.tooling` (rf2-6r9j.54) and `re-frame.derivation.egress`
+;; (rf2-yk2d) record the identical trap and repair.
+;;
+;; The rule, and the reason a planted string is the WRONG instinct here: pick
+;; a literal a LIVE code path emits, and verify the count in the emitted
+;; module, never in the `.cljc`. The roster comment in check-bundle-
+;; isolation.cjs beside the `routing-tooling` entry is the full account.

--- a/implementation/routing/test/re_frame/routing_plan_seam_test.clj
+++ b/implementation/routing/test/re_frame/routing_plan_seam_test.clj
@@ -21,7 +21,7 @@
   The SEAM ITSELF is production-real and carries no posture guard. Every pure
   constructor test — `resolved-target`, the nil-query strip, the fragment
   collapse, `:query-defaults`, `route-plan`, the fail-loud `:branch` walk,
-  `leaf-plan-of`, `plan-projection`, `plan-trace-tags` and `url-resolution` —
+  `leaf-plan-of`, `plan-trace-tags` and `url-resolution` —
   runs in the ordinary `clojure -M:test` suite AND in
   `scripts/test-routing-prod-gate.sh` (the `-Dre-frame.debug=false` lane). So
   do the door-wiring tests at the foot: the link/commit agreement, the exact
@@ -367,20 +367,6 @@
           (is (= cause (:cause plan)))
           (is (= target (:target plan)))
           (is (= [:route/home] (:branch plan))))))))
-
-;; ---- the R0 diagnostic projection -----------------------------------------
-
-(deftest plan-projection-exposes-only-the-r0-keys
-  (rf.routing/reg-route :route/home {} "/")
-  (let [plan (rf.routing.resolve/route-plan
-               {:source {:url "/"} :cause :popstate
-                :target (rf.routing.resolve/resolved-target {:route-id :route/home :params {} :query {} :url "/"})})
-        proj (rf.routing.resolve/plan-projection plan)]
-    (testing "the projection is exactly the R0 keys — the minimum needed to prove the shared spine"
-      (is (= #{:source :cause :target :branch :leaf-plan} (set (keys proj))))
-      (is (= (set rf.routing.resolve/r0-projection-keys) (set (keys proj)))))
-    (testing "the projection is a pure view of the plan the doors already build"
-      (is (= (select-keys plan rf.routing.resolve/r0-projection-keys) proj)))))
 
 ;; ---- the projection as trace tags (mayor ruling on rf2-kqxe6.3) ------------
 ;;


### PR DESCRIPTION
Four unconsumed routing surfaces, each removed with a tombstone comment recording why re-planting it is the wrong instinct. Every bead's EVIDENCE section was re-run at this branch's tip before anything was deleted; all four premises still held.

## rf2-6r9j.1 — routing tooling's obsolete private bundle sentinel

`routing/tooling.cljc` defined a private `bundle-isolation-sentinel` whose comment claimed `check-bundle-isolation.cjs` greps that exact string. Read at source: the checker's `routing-tooling` arm asserts the live `route-fact` node kind, and has since `4e43784ec7`. A private, unconsumed var is dropped by Closure `:advanced`, so the `do-not-rename` instruction guarded nothing.

Follows the two identical repairs already in tree — `resources.tooling` (rf2-6r9j.54) and `derivation.egress` (rf2-yk2d) — and reuses their comment shape. The stale ns-header sentence (which had also become self-referential: "the explicit sentinel at the foot of this ns is checked by the sentinel at the foot of this namespace") is corrected.

## rf2-6r9j.3 — the inert internal `RouteAddress` constant

`routing/address.cljc` carried a Malli-form `RouteAddress` value routing never read: `valid-address?` is the hand-coded structural gate and derives nothing from the form, and the Schemas artefact never imported it. A repo-wide search finds the code symbol at that one definition only.

The normative `:rf/route-address` schema in `spec/Spec-Schemas.md` is **untouched** and remains the single contract authority; `valid-address?` accepts and rejects exactly the shape it did before.

## rf2-6r9j.4 — the unconsumed plan-projection helper

`routing/resolve.cljc`'s `plan-projection` and `r0-projection-keys` had one caller: the unit test pinning them. `plan-trace-tags` is the projection an executed navigation actually exposes — deliberately bounded and redacted where the raw plan carries the carriers — and Spec 009 names `:rf.route/planned/plan-trace-tags` as the observable projection. The helper, its key list and that single test go; the facade's internal-seam comment now points at the trace rather than the removed helper. `plan-trace-tags` and every door-wiring test are untouched.

## rf2-6r9j.8 — the unread `:routing/route-sub-fn` late-bind hook

The facade published `route-sub-fn` twice: directly as the `:rf/route` sub registration, and again into the late-bind hook table. Nothing read the hook — no `get-fn`, no `require-fn!`, no wrapper, no reset-hook roster. Both sides (the publication and the core directory row) go together so the bidirectional drift scan stays balanced.

The public `re-frame.routing/route-sub-fn` and its direct `:rf/route` registration are unchanged and stay documented in `docs/api/re-frame.routing.md`; `spec/api-manifest.edn` needed no edit.

## Gates

Run from this branch after rebasing onto the current `main`; every exit code below was captured with the runner's own status, not reported by a wrapper.

| gate | exit | result |
|---|---|---|
| `clojure -M:test` (`implementation/routing/`) | 0 | 553 tests, 3451 assertions, 0 failures |
| `clojure -M:test -n re-frame.late-bind-drift-test` (`implementation/core/`) | 0 | 8 tests, 692 assertions, 0 failures |
| `npm run test:cljs` | 0 | 11168 tests, 55728 assertions, 0 failures |
| `npm run test:bundle-isolation` | 0 | 40 internal sentinels absent, 40 emitted positive-control sentinels present |
| `python scripts/lint_kondo.py` (pinned 2026.04.15) | 0 | errors: 0 |

`test:bundle-isolation` was chosen over the cheaper `test:scripts` deliberately: only the release-building lane runs `check-bundle-isolation.cjs` itself and so proves the routing-tooling positive control is non-vacuous, which is rf2-6r9j.1's acceptance criterion 3. clj-kondo no longer reports `re-frame.routing.tooling/bundle-isolation-sentinel` as an unused private var.

Two gates were exercised against planted faults to prove they read this branch rather than a sibling checkout. Planting `[:route/PLANTED…]` in the plan-seam test turned the routing suite red at exactly that assertion with unchanged 553/3451 counts (so the plant crashed no namespace); restoring the directory row for `:routing/route-sub-fn` while leaving the publication removed turned the drift scan red naming that key, which also proves the both-sides-together requirement is genuinely gated. Both files were restored and verified byte-identical by blob hash.

## Note for the merge tick, not part of this change

`python scripts/check_require_alias_dialect.py --verbose` (the ratchet added by `a48586caf5`, ~40 minutes before this branch rebased) exits 1 on the current `main`: `implementation/flows` reads 155 violations against a floor of 156, and `implementation/ssr` 399 against 402 — both *below* their baseline, so the fix is to lower the floors. Neither surface is touched here; both are byte-identical to `origin/main` on this branch, and neither `implementation/routing` nor `implementation/core` is named in the failure. Its `--self-test` passes 40/40. Flagging rather than fixing, since the baseline is outside these beads' scope.