### PR TITLE
docs(hicasso): the bridge needs a frame, not a Hicasso root; hot reload rebuilds the DOM (rf2-x97h, rf2-d4n8, rf2-lz0u)

### DIFF
--- a/docs/core/hicasso/00-installation.md
+++ b/docs/core/hicasso/00-installation.md
@@ -394,6 +394,16 @@ The `^:dev/after-load` hook calls `h/render!` with the redefined view. The root,
 frame, app-db, and subscriptions survive, so changing the view does not reset
 the counter or leak registrations.
 
+**The DOM does not survive with them.** A reload re-evaluates the namespace, so
+every `h/defview` in it is a new component type, and `h/as-component`'s `def`
+mints a new one too. A changed type is a remount rather than an update by
+React's own rule, so the re-render rebuilds those nodes instead of updating
+them. State held in app-db comes back untouched; state the DOM itself owns does
+not, and focus and the caret are the two you notice — edit a form's markup while
+typing in that form and the draft survives in app-db while the cursor leaves the
+field. Nothing is wrong when that happens, and it is not a reason to reach for
+`defonce` on a view.
+
 Boot and re-render are two functions rather than one because shadow calls
 `:init-fn` **once**, when the module loads, and not again after a reload — a
 build whose only entry point is `:init-fn` logs `reloading code but no

--- a/docs/core/hicasso/09-interop.md
+++ b/docs/core/hicasso/09-interop.md
@@ -289,7 +289,7 @@ render.
 ## Render a Hicasso view from native React
 
 `h/as-component` converts a Hicasso view head into a real React component for
-UIx, raw React, JavaScript, or TypeScript parents:
+Reagent, UIx, raw React, JavaScript, or TypeScript parents:
 
 ```clojure
 (def article-card*
@@ -299,8 +299,23 @@ UIx, raw React, JavaScript, or TypeScript parents:
 React props return to the Hicasso view as a normal props map with canonical
 names (`articleId` becomes `:article-id`) and identity-preserved values. The
 view retains its memoization, subscription reads, key identity, teardown, and
-frame from React context. Rendering it outside a Hicasso root raises
-`:rf.error/no-frame-context`.
+frame from React context. Rendering it outside every frame raises
+`:rf.error/no-frame-context` — every frame, not every Hicasso root. `h/mount!`,
+`rf/frame-provider` and `rf/frame-root` all write the same frame context, so a
+bridged view inside a Reagent or UIx tree resolves that tree's frame and needs
+no root of its own.
+
+**A Reagent parent converts the props before that decode.** Identity is
+preserved across the decode, which is the second half of the crossing; the
+first half belongs to the parent. Props on this route travel through React, so
+a Reagent parent converts them exactly as it does for any other `[:>]`
+crossing: a keyword becomes its name, a map becomes a camel-cased JavaScript
+object, any other collection is deeply `clj->js`'d, and strings, numbers,
+booleans, `nil` and functions cross unchanged. Prop *names* survive the round
+trip — `:article-id` is camel-cased on the way out and read back as
+`:article-id` — but values do not. Cross an id and read the rest with `h/sub`
+and the conversion never arises: [Views shared across the
+boundary](20-migration-from-reagent.md#views-shared-across-the-boundary).
 
 Use `h/as-element` for one subtree returned through a callback. Use
 `h/as-component` when a native parent will mount, key, and re-render the view

--- a/docs/core/hicasso/api-reference.md
+++ b/docs/core/hicasso/api-reference.md
@@ -120,7 +120,7 @@ many roots as it likes, and no call here reaches a root the caller did not name.
 | --- | --- | --- |
 | `h/mount!` | `(h/mount! container config view)` | Ensures a frame, associates it with a DOM container and one root view, and answers the handle the other three take. |
 | `h/hydrate!` | `(h/hydrate! container config view)` | Adopts the container's existing server-rendered DOM instead of replacing it. Returns the same handle shape, and returns **before** adoption has finished. |
-| `h/render!` | `(h/render! handle view)` | Re-renders a mounted root in place, synchronously, and answers its handle. The hot-reload door: React reconciles the new tree against the one on the page. |
+| `h/render!` | `(h/render! handle view)` | Re-renders a mounted root in place, synchronously, and answers its handle. It renders into the same root rather than opening a second one, so React reconciles the new tree against the one on the page. The hot-reload door — though on a reload that reconcile still rebuilds the DOM, because a reloaded namespace redefines every view and a changed component type is a remount: [Hot reload](00-installation.md#hot-reload). |
 | `h/unmount!` | `(h/unmount! handle)` | Takes this root down and touches nothing else — no sibling root's state, and not the container, which React empties and leaves in the document. Idempotent. |
 
 `h/mount!`'s `config` carries three keys:


### PR DESCRIPTION
Three findings from the pre-pilot rehearsal, all settled by reading the implementation rather than by taking the beads' claims on trust. All three claims still held at tip — none had been fixed by a sibling.

## rf2-x97h — `h/as-component` needs a frame, not a Hicasso root

`09-interop.md` said the bridge refuses "outside a Hicasso root". Read plainly that excludes `rf/frame-root`, so a reader migrating from Reagent concludes the bridge will not work in the tree they actually have. It does work.

Settled at source. The component `as-component` returns does not read a context itself; the boundary shell one fiber lower does, and it reads `re-frame.adapter.context/frame-context` — a single `defonce`'d `createContext`. `h/mount!`'s provider, `rf/frame-provider` and `rf/frame-root` all write that same object (the Reagent adapter aliases it rather than minting its own, with a source comment saying why). `resolve-frame!` refuses only when that context holds nil or the no-provider sentinel. So the requirement is *any* frame from *any* React-shaped adapter.

There is a committed test driving exactly this: `foreign_root_bridge_dom_cljs_test.cljs` has a `:crossed/reagent-as-component` route — a Reagent root, `rf/frame-provider` above, the `as-component` bridge inside, no Hicasso root anywhere — and asserts a write repaints through it.

`api-reference.md`'s wording was the true one, and four other pages already agreed with it. `09-interop.md` was the sole outlier; it now says "outside every frame" and names the three doors.

## rf2-d4n8 — what a Reagent parent does to props at the crossing

The section named "UIx, raw React, JavaScript, or TypeScript parents" and not Reagent — the one parent a migration from Reagent guarantees you have. Its "identity-preserved values" is true of the decode and silent about the half before it.

Both halves verified at source. Hicasso's `outward-props` is shallow, by identity, own properties only, with names decoded by `prop-key`. Reagent 2.0.1's `convert-prop-value` (read out of the declared jar, not from memory) converts on the way in: a keyword becomes its `name`, a CLJS map becomes a camel-cased JS object with values recursively converted, any other collection goes through `clj->js` deeply, and anything `js-val?` — strings, numbers, booleans, `nil`, functions — crosses unchanged. Names round-trip via `dash-to-prop-name` and back through `prop-key`; values do not.

Chapter 20 already works this through under "Views shared across the boundary". Rather than duplicate it, `09-interop.md` now carries the mechanism in one paragraph and points there, so a reader who never opens chapter 20 still meets it.

## rf2-lz0u — the hot-reload contradiction

`api-reference.md` called `h/render!` the hot-reload door and said React reconciles the new tree against the one on the page. The pilot measured every DOM node replaced, `<main>` included, with focus and caret lost.

Both are right, and the sentence was misleading precisely about the case it named. `render!` calls `.render` on the *same* React root inside `flushSync` — a genuine reconcile, and the distinction it was drawing is against `createRoot`ing a second time. But a hot reload re-evaluates the namespace, `mint-view!` allocates a new component and memo wrapper per evaluation, and `as-component` mints a fresh component per call. A changed component type is a remount by React's own rule, so the reconcile runs and concludes "replace everything". State survives because none of it lived in React.

`api-reference.md` now keeps the true general statement and says what a reload does to it. Chapter 00 promised the state half and was silent on the DOM half, so a reader met the lost caret with nothing in the corpus predicting it; it now carries both halves.

Scope note: the bead's suggested wording listed scroll position among the losses, but the pilot's own measurement recorded scroll surviving (299 before and after). The page says focus and caret, which is what was measured.

This is documentation only. No runtime change is proposed here.

## Gates

Run from the worker worktree, exit codes captured on the same command line as the redirect and quoted from that capture:

- `python scripts/check_doc_slugs.py` — exit 0
- `python hicasso/scripts/check_guide_samples.py --self-test` — exit 0 ("the rule fires")
- `python hicasso/scripts/check_guide_samples.py` — exit 0 (74 verbs at 401 sites across 29 pages)
- `python -m mkdocs build --strict` — exit 0

All four re-run after the rebase onto the current base; the sample-site count moved 393 to 401 across that rebase, so the re-run measured a genuinely different tree.

Each gate was proved to be reading this worktree by a planted fault, since the fault exists only here and a run that had wandered elsewhere would have come back green:

- broken anchor planted at the line edited in `09-interop.md` — slug gate exit 1, naming `09-interop.md:318`
- broken link target planted at the line edited in `api-reference.md` — strict build exit 1, naming the target
- bogus `h/` verb planted in a fence in `09-interop.md` — samples gate exit 1, naming it at blocks 1 and 3

Each file was restored afterwards and the restore verified by git blob hash against the committed object, not by reading a diff.

Worth recording, because it is the reason both link gates are run rather than one: with the broken anchor in place, `mkdocs build --strict` **exited 0** while naming the anchor on stdout. MkDocs grades a missing anchor at INFO and `--strict` promotes WARNING but not INFO, so `check_doc_slugs.py` is the only anchor gate for these pages. Measured here, in both directions.

## By-hand verification

Nothing validates prose, tables, rendering or nav, so:

- **Anchors.** Two links added: `20-migration-from-reagent.md#views-shared-across-the-boundary` and `00-installation.md#hot-reload`. Both targets confirmed to be unique headings, so neither takes a MkDocs `_N` or GitHub `-N` suffix. The chapter 20 target was re-confirmed after the rebase, since that page changed on main in the interval.
- **Table columns.** All 21 tables across the three touched pages checked, 0 mismatches, including the Roots table whose `h/render!` row was rewritten (3 columns, 6 rows). The checker was exercised against a deliberately planted 4-column row and flagged it at the right line, so the zero is a real check rather than a vacuous one. The rewritten cell contains no pipe inside a code span.
- **Agreement with chapter 20.** Re-read after the rebase; the new `09-interop.md` paragraph states the same mechanism in the same terms and does not contradict it.

## Not fixed here, outside the fence

`implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs` carries the same wrong wording in `as-component`'s own docstring — "outside every **Hicasso root** the shell refuses" — which is the likely origin of the guide sentence. It is the only place in the package that says it that way; `native.cljc` says "outside every frame" twice, and `resolve-frame!`'s docstring and raise message are both frame-scoped. Implementation was read-only for this task, so it is left alone and filed separately.
