### PR TITLE
refactor(machines): drop three vestiges from the machines namespaces (rf2-6r9j.2, rf2-6r9j.5, rf2-6r9j.6)

### DIFF
--- a/implementation/machines/src/re_frame/machines/cofx_attach.cljc
+++ b/implementation/machines/src/re_frame/machines/cofx_attach.cljc
@@ -343,13 +343,13 @@
   (rf.machines.grammar/node-at states (vec path)))
 
 (defn- resolve-target-path
-  "Resolve a candidate `:target` (declared at `decl-path`) to an absolute
-  path within `states`, or nil. A keyword is a sibling (direct child of the
+  "Normalise a candidate `:target` (declared at `decl-path`) to an absolute
+  path coordinate, or nil. A keyword is a sibling (direct child of the
   declaring state's PARENT compound); a vector is absolute; `:same-state` is
   the declaring state; nil / internal contributes the declaring state itself
   (the `:always` on the unchanged state still runs). Mirrors the runtime
   target resolution closely enough for the static closure."
-  [states decl-path target]
+  [decl-path target]
   (cond
     (or (nil? target) (= :same-state target)) (vec decl-path)
     (keyword? target) (conj (vec (drop-last decl-path)) target)
@@ -406,7 +406,7 @@
         (doseq [e (always-entries node)]
           (doseq [d (entry-diet by-entry :guards  (:guard e))]  (conj! diet d))
           (doseq [d (entry-diet by-entry :actions (:action e))] (conj! diet d))
-          (when-let [tgt (resolve-target-path states prefix (:target e))]
+          (when-let [tgt (resolve-target-path prefix (:target e))]
             (conj! targets tgt)))))
     (persistent! targets)))
 
@@ -521,7 +521,7 @@
             (doseq [cand (candidate-maps (:on-done node))]
               (add! (entry-diet by-entry :guards  (:guard cand)))
               (add! (entry-diet by-entry :actions (:action cand)))
-              (when-let [tgt (resolve-target-path states done-path (:target cand))]
+              (when-let [tgt (resolve-target-path done-path (:target cand))]
                 (add-always! tgt)))))))))
 
 (defn- after-diet-for-event
@@ -563,7 +563,7 @@
             (doseq [cand (candidate-maps (get-in node [:after delay-key]))]
               (add! (entry-diet by-entry :guards  (:guard cand)))
               (add! (entry-diet by-entry :actions (:action cand)))
-              (when-let [tgt (resolve-target-path states decl-path (:target cand))]
+              (when-let [tgt (resolve-target-path decl-path (:target cand))]
                 (add-always! tgt)))))))))
 
 (defn- ensure-set-in-scope
@@ -636,7 +636,7 @@
           ;; entered descending the target's `:initial` chain, since entering a
           ;; compound target cascades into its initial leaf. The active-state
           ;; `:exit` diet is added once below (it is candidate-independent).
-          (when-let [tgt (resolve-target-path states prefix (:target cand))]
+          (when-let [tgt (resolve-target-path prefix (:target cand))]
             (add-lifecycle! states (initial-descent-path states tgt) :entry)
             ;; (b) :always closure reachable from this candidate's target.
             (add! (always-diet-for-state by-entry states tgt))))))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -804,7 +804,7 @@
   tags lack `:frame`). The caller threads `frame-id` (resolved from
   `(:rf/frame machine)` at the interceptor's entry) so the per-survivor
   cancellation traces reach the cascade's `:trace-events` slot."
-  [frame-id parent-id invoke-id spec join-state'' child-id child-extra
+  [frame-id parent-id invoke-id join-state'' child-id child-extra
    {:keys [resolved? resolution-event join-event-kw]}]
   (let [destroy-fx
         (when resolved?
@@ -1214,7 +1214,7 @@
       (emit-child-fold-terminal! frame-id parent-id invoke-id join-state''
                                  child-id work-generation kind child-extra
                                  completed-at))
-    (let [fx (build-resolution-fx frame-id parent-id invoke-id spec join-state''
+    (let [fx (build-resolution-fx frame-id parent-id invoke-id join-state''
                                   child-id child-extra resolution)]
       {:rf.db/runtime (assoc-in runtime-db (rf.machines.paths/spawned-path parent-id invoke-id) join-state'')
        :fx fx})))

--- a/implementation/machines/src/re_frame/machines/tooling.cljc
+++ b/implementation/machines/src/re_frame/machines/tooling.cljc
@@ -390,10 +390,9 @@
                    ;; else the actor-id itself for a singleton). An inline
                    ;; `:definition` spawn has no registered type — key its
                    ;; source-form by the actor-id.
-                   source-id    (cond
-                                  (keyword? machine-type) machine-type
-                                  spawned?                actor-id
-                                  :else                   actor-id)]
+                   source-id    (if (keyword? machine-type)
+                                  machine-type
+                                  actor-id)]
                (if spec
                  (assoc acc actor-id
                         (-> (node-for actor-id source-id spec


### PR DESCRIPTION
Three small, behaviour-neutral vestige removals in `implementation/machines/`, one per bead. Every measurement below was re-run on this branch's tip rather than quoted from the beads.

## rf2-6r9j.2 — `resolve-target-path`'s unread `states` parameter

`cofx_attach.cljc`'s private `resolve-target-path` took `[states decl-path target]` but derived its result from `decl-path` and `target` alone. The parameter has been unused since the helper was introduced in `9895cbd53d0`. Dropped it, dropped the four in-namespace call sites' redundant argument, and reworded the docstring so it describes coordinate normalisation instead of implying a read of the state tree.

The surrounding `states` reads are untouched — `add-lifecycle!`, `initial-descent-path` and `always-diet-for-state` still take it, and the sibling helper directly above still wraps `grammar/node-at` over it.

## rf2-6r9j.5 — `build-resolution-fx`'s retired `spec` argument

`lifecycle_fx/join.cljc`'s private `build-resolution-fx` still declared `spec`, residue from `4842757f6c`, which removed the `(:cancel-on-decision? spec)` read and made survivor cancellation unconditional. The body never referenced it. Dropped the parameter and its sole call's argument; cancellation, completed-child reap, trace emission and parent resolution-event ordering are unchanged.

## rf2-6r9j.6 — two `cond` arms that cannot differ

`machine-instance-algebra-view`'s `source-id` had three arms, of which `spawned?` and `:else` both yielded `actor-id`. Collapsed to `(if (keyword? machine-type) machine-type actor-id)`. `spawned?` is deliberately kept: it still selects spawned-vs-singleton spec resolution and is still emitted as the node's `:spawned?` field. The comment above the expression already documented that both non-keyword cases intentionally share identity, so it needed no change.

## Verification

Instrument readings taken on this branch, before and after:

| instrument | before | after |
|---|---|---|
| `clj-kondo --lint src` (from `implementation/machines`) | exit 2, 37 warnings, incl. `cofx_attach.cljc:352:4 unused binding states` and `join.cljc:807:33 unused binding spec` | exit 2, 35 warnings, **0 unused bindings** |
| `clojure -M:splint machines/src/.../tooling.cljc` | exit 1, `tooling.cljc:395:35 [lint/identical-branches]` | **exit 0**, 0 style warnings |

The only other difference between the two clj-kondo runs is a pre-existing unrelated warning shifting line 493 → 492, from the one line this change removes. No new warning is introduced.

Gates, all run to completion in the foreground with the runner's own exit code captured and quoted:

- `clojure -M:test` from `implementation/machines` — **exit 0**, 1241 tests / 4495 assertions, 0 failures, 0 errors.
- `npm run test:cljs` from `implementation` — **exit 0**, 11173 tests / 55748 assertions, 0 failures, 0 errors, 0 compile warnings. This compiles the whole CLJS tree, which is what rules out a missed call site.
- `python scripts/check_require_alias_dialect.py --verbose` — **exit 0**, every surface at or under its floor. `implementation/machines`' floor is 0 and this diff contains no `:require` lines at all; the non-canonical total is 5912 before and after, so the count did not move.

Both suites were re-run after rebasing onto the current `main`, not only before it.

Neither gate prints a root path unprompted, so each was controlled with a planted fault and restored by content hash:

- A logic fault in `resolve-target-path` (`drop-last` → `identity`) took the machines JVM suite to **exit 1 with 14 failures** naming the cofx ensure-set path, over an identical 1241 tests / 4495 assertions — so no namespace collapsed and the failures were the planted ones.
- An arity fault (restoring a three-argument call against the two-argument definition) took the CLJS compile to **exit 1**, reporting `Wrong number of args (3) passed to re-frame.machines.cofx-attach/resolve-target-path` and naming this branch's own checkout path — confirming both that the gate reads this working tree and that it catches exactly the class of error these deletions could have introduced.

Both files were restored and confirmed byte-identical to the committed blob afterwards.

Call-site censuses were run twice, line-oriented and again over the file with line endings stripped and whitespace collapsed, because a Clojure call can wrap across lines — and `build-resolution-fx`'s sole call does. Both readings agree: `resolve-target-path` has one definition and four calls, all in its own namespace; `build-resolution-fx` has one definition, one call and one comment mention. Note that `resolve-target-path` is also the name of three unrelated private helpers under `tools/machines-viz/` (chart, mermaid, scxml); those are separate namespaces with their own arities and are not callers of this one.

Nothing here changes an externally observable surface, so no spec document is affected.