### PR TITLE
docs(skills): the description-budget gate's prose states the live contract (rf2-w9p2, rf2-bn5f)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -942,16 +942,22 @@ jobs:
         run: python scripts/check_doc_slugs.py --verbose
 
       # SKILL.md description-budget gate (rf2-w9p2; armed under rf2-bn5f). Guards
-      # the two limits the agent host actually enforces, both silent when breached:
-      # the 1,536-char `skillListingMaxDescChars` hard slice on a single
-      # description (it truncates mid-sentence, so the disqualifier a description
-      # ends on is the first thing lost), and the family's whole listing footprint
-      # against a pinned RATCHET rather than the absolute 8,000-char budget — past
-      # that budget the planner drops ENTIRE descriptions in ascending priority
-      # order, and nine skills averaging ~1,200 chars cannot fit in 8,000 however
-      # they are written, so failing at the absolute would red the repo with no
-      # in-repo remedy. The absolute comparison PRINTS on every run, green or red,
-      # so the overshoot is never lost behind a tick.
+      # the SKILL.md description limits: the portable 1,024 and the Claude 1,536.
+      # It hard-fails a description over the 1,024-char Agent Skills packaging cap
+      # — the portable contract skills/README.md advertises via `npx skills add` —
+      # and escalates that message when the description is ALSO past Claude Code's
+      # 1,536-char `skillListingMaxDescChars` hard slice, which cuts mid-word, so
+      # the disqualifier a description ends on is the first thing lost. Anything
+      # within 1,024 is within 1,536, so the slice is reported on every run rather
+      # than separately failed on. Separately, the family's whole listing
+      # footprint is hard-failed against a pinned RATCHET rather than the absolute
+      # 8,000-char budget — past that budget the planner drops ENTIRE descriptions
+      # in ascending priority order, and nine skills each carrying a routing
+      # contract cannot fit in 8,000 however they are written (bringing every
+      # description under 1,024 still left the family near 8,900), so failing at
+      # the absolute would red the repo with no in-repo remedy. The absolute
+      # comparison PRINTS on every run, green or red, so the overshoot is never
+      # lost behind a tick.
       #
       # WHY THIS JOB AND NOT THE ALWAYS-ON INVARIANT JOB, where every other
       # check_skill_*.py step lives: this checker is NOT pure stdlib. It reads

--- a/scripts/check_skill_description_budget.py
+++ b/scripts/check_skill_description_budget.py
@@ -595,9 +595,14 @@ def _is_ci() -> bool:
 def main(argv: Iterable[str]) -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "Guard the enforced SKILL.md description limits: the 1,536-char "
-            "per-description hard slice, and the family's listing footprint "
-            "against a pinned ratchet (rf2-w9p2)."
+            "Guard the SKILL.md description limits: the portable 1,024 and the "
+            "Claude 1,536. Hard-fails a description over the 1,024-char Agent "
+            "Skills packaging cap, and escalates that message when the "
+            "description is ALSO past Claude Code's 1,536-char hard slice "
+            "(skillListingMaxDescChars), which is otherwise only reported. "
+            "Separately hard-fails the family's listing footprint against a "
+            "pinned ratchet, not against the absolute listing budget, which is "
+            "printed on every run (rf2-w9p2)."
         ),
     )
     parser.add_argument("--verbose", "-v", action="store_true",

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -933,17 +933,25 @@ run "skill eval-docs match evals.json" "python scripts/check_skill_eval_docs.py 
   python "$spine_root/scripts/check_skill_eval_docs.py" --verbose --ci
 
 # SKILL.md description-budget gate (rf2-w9p2; armed under rf2-bn5f).  Guards the
-# two limits the agent host actually enforces, both silent when breached: the
-# 1,536-char hard slice on a single description (it truncates mid-sentence, so
-# the disqualifier a description ends on is the first thing lost), and the
-# family's whole listing footprint against a pinned ratchet -- past the
-# 8,000-char budget the planner drops ENTIRE descriptions, lowest priority
-# first.  The absolute comparison prints on every run, so the overshoot is never
-# lost behind a tick.  Paired with test.yml's steps of the same ids and moves
-# with them: check_fast_pr_gap.py derives its required set from that job and
-# reports a required checker with no local lane as unrun.  Pure-stdlib and
-# sub-second, so it sits in the always-on block rather than the docs tier -- the
-# footprint it ratchets can be moved by any SKILL.md edit.  Self-test first
+# SKILL.md description limits: the portable 1,024 and the Claude 1,536.  It
+# hard-fails a description over the 1,024-char Agent Skills packaging cap -- the
+# portable contract skills/README.md advertises via `npx skills add` -- and
+# escalates that message when the description is ALSO past Claude Code's
+# 1,536-char hard slice, which cuts mid-word, so the disqualifier a description
+# ends on is the first thing lost.  Anything within 1,024 is within 1,536, so
+# the slice is reported on every run rather than separately failed on.  The
+# family's whole listing footprint is hard-failed against a pinned RATCHET, not
+# against the absolute 8,000-char budget -- past that budget the planner drops
+# ENTIRE descriptions, lowest priority first, but nine skills each carrying a
+# routing contract cannot fit in 8,000 however they are written, so the absolute
+# is printed on every run instead of failed on and the overshoot is never lost
+# behind a tick.  Paired with test.yml's steps of the same ids and moves with
+# them: check_fast_pr_gap.py derives its required set from that job and reports
+# a required checker with no local lane as unrun.  Sub-second, and the footprint
+# it ratchets moves on any SKILL.md edit, so it sits in the always-on block
+# rather than the docs tier.  NOT pure stdlib: it reads SKILL.md front-matter
+# with PyYAML and exits 2 with an install message without it, which is why
+# test.yml runs it in a job that installs requirements.txt.  Self-test first
 # (proves both rules fire in both directions), then the live scan.
 run "SKILL.md description-budget self-test" "python scripts/check_skill_description_budget.py --self-test" \
   python "$spine_root/scripts/check_skill_description_budget.py" --self-test

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -947,12 +947,12 @@ run "skill eval-docs match evals.json" "python scripts/check_skill_eval_docs.py 
 # is printed on every run instead of failed on and the overshoot is never lost
 # behind a tick.  Paired with test.yml's steps of the same ids and moves with
 # them: check_fast_pr_gap.py derives its required set from that job and reports
-# a required checker with no local lane as unrun.  Sub-second, and the footprint
-# it ratchets moves on any SKILL.md edit, so it sits in the always-on block
-# rather than the docs tier.  NOT pure stdlib: it reads SKILL.md front-matter
-# with PyYAML and exits 2 with an install message without it, which is why
-# test.yml runs it in a job that installs requirements.txt.  Self-test first
-# (proves both rules fire in both directions), then the live scan.
+# a required checker with no local lane as unrun.  Cheap, and the footprint it
+# ratchets moves on any SKILL.md edit, so it sits in the always-on block rather
+# than the docs tier.  NOT pure stdlib: it reads SKILL.md front-matter with
+# PyYAML and exits 2 with an install message without it, which is why test.yml
+# runs it in a job that installs requirements.txt.  Self-test first (proves
+# both rules fire in both directions), then the live scan.
 run "SKILL.md description-budget self-test" "python scripts/check_skill_description_budget.py --self-test" \
   python "$spine_root/scripts/check_skill_description_budget.py" --self-test
 


### PR DESCRIPTION
Closes rf2-w9p2 and rf2-bn5f — the two halves of PR #9084's audit remainder. They are one PR because they must state **one** contract across three surfaces, and writing them separately is how they drifted apart in the first place.

No behaviour change: the checks, the limits, the ratchet and the step invocations are untouched. This is prose only.

## The defect is a self-contradicting file, not "stale help text"

`scripts/check_skill_description_budget.py` disagreed with itself. Its module docstring at line 2 already read *"Guard the SKILL.md description limits: the portable 1,024 and the Claude 1,536"* — correct. Twelve lines from the bottom, its `argparse` help still read:

> Guard the enforced SKILL.md description limits: the 1,536-char per-description hard slice, and the family's listing footprint against a pinned ratchet.

That is the contract from *before* the #9051 audit reopened rf2-cupfi. The half a user actually sees — `--help` — was the wrong half.

## The live contract, verified against the code rather than the beads

- **C1, hard fail, at 1,024.** `check()` fails on `entry.over_cap`, and `over_cap` is `resolved_len > PACKAGE_MAX_DESC_CHARS`, which is `1024` — the Agent Skills packaging ceiling. 1,536 is **not** a second failure condition: `sliced_by_runtime` only *escalates the message* of a failure C1 has already raised, adding the "being cut mid-word today" sentence.
- **C2, hard fail, against a pinned ratchet** (`FAMILY_FOOTPRINT_CEILING`), deliberately **not** against the absolute ~8,000-char listing budget, which is printed on every run instead.

So "the two limits the agent host actually enforces" was true of neither check: 1,024 is a packaging spec's ceiling rather than any host's, and the footprint ratchet is this repo's own number.

## What each of the three surfaces said, and which were stale

| Surface | Before | Verdict |
|---|---|---|
| `check_skill_description_budget.py` argparse help | "the enforced … limits: the 1,536-char per-description hard slice, and the family's listing footprint against a pinned ratchet" | **Stale** — rewritten |
| `.github/workflows/test.yml` comment | "the two limits the agent host actually enforces … the 1,536-char `skillListingMaxDescChars` hard slice on a single description" | **Stale** — rewritten |
| `scripts/test-fast-pr.sh` comment | "the two limits the agent host actually enforces … the 1,536-char hard slice on a single description" | **Stale** — rewritten |

The spine comment had *partly* moved already: it correctly described the 8,000-char listing budget and the "both rules fire in both directions" self-test. Those halves were always compatible with either contract, so they were not the defect; its opening sentence carried the same stale claim as the other two.

## Two further claims that were false rather than merely stale

Both surfaced while checking the sentences by hand, and both are corrected here:

1. **`test-fast-pr.sh` called the checker "Pure-stdlib".** It is not — it reads front-matter with PyYAML and exits 2 with an install message without it. `test.yml`'s own comment records this *from a measured CI run* ("both steps failed with `ERROR: PyYAML is required`"), so the two integration comments directly contradicted each other. Corrected in favour of the measured one.
2. **`test.yml` put the family at "nine skills averaging ~1,200 chars".** All nine are now under 1,024 and average **963**; the footprint is 8,860 against a pinned ceiling of 8,864. The sentence's argument (nine routing contracts cannot fit in 8,000) is sound and is kept — the arithmetic supporting it was not.

A "sub-second" timing claim was also dropped rather than restated: measured here, the live scan is 0.44–0.69s but the paired self-test lane is ~3.4s, so it was true of one lane and not the pair. The reason the gate is unconditional — any `SKILL.md` edit moves the footprint it ratchets — is already in the sentence and does not rot.

## Verification

**Nothing gates a comment.** A green run proves the script still works; it says nothing about whether the prose is true. The truth check was by hand, reading `check()`, `over_cap`, `sliced_by_runtime` and the two constants and confirming each sentence against them. The two comment edits are **ungated** and reviewed by reading only.

What the gates do cover:

| Gate | Exit |
|---|---|
| `check_skill_description_budget.py --self-test` | 0 (14/14) |
| `check_skill_description_budget.py --verbose --ci` | 0 (9 skills, footprint 8,860 ≤ 8,864) |
| `check_require_alias_dialect.py --verbose` | 0, unmoved |
| `check_fast_pr_gap.py --verbose` | 0, gap map clean |
| `check_retired_composition_vocab.py --verbose` | 0 |
| `test-fast-pr.sh` tiering self-test | 0 (44/44) |
| `_changed-surfaces.test.cjs` | 0 (346 assertions) |

The last three are there because a comment edit *can* bite in this repo: `check_retired_composition_vocab.py` treats `test-fast-pr.sh`'s comments as its prose corpus, and `_changed-surfaces.test.cjs` carries several unanchored assertions over raw `test.yml` job-block text. Both were run rather than assumed.

**Planted fault.** `PACKAGE_MAX_DESC_CHARS` was lowered 1024 → 1000 on the final rebased base: the gate went **exit 1**, naming `skills/re-frame2/SKILL.md` (1012 chars, 12 over) and `skills/reagent-migration/SKILL.md` (1011, 11 over), and correctly *withheld* the 1,536 escalation because neither is past that slice — which is positive evidence for the sentence this PR adds about escalation. Restored, and the restore verified by git blob-hash equality against the pre-plant object.

The full `test-fast-pr.sh` spine was not run. Editing a comment in the spine trips its own `spine self-change (every tier)` rule, which arms the ~15-minute MkDocs build plus the JVM and CLJS tiers for a prose diff that touches no CLJS, no docs page and no browser surface. The two description-budget lanes were run directly instead, with a planted-fault control, alongside every checker that reads either edited file.

`.github/workflows/test.yml` is hot-zone; the diff there is comment lines only, verified by filtering the diff for non-comment changes (empty) and by re-parsing the YAML to confirm both steps still sit in `verify-readme-links`.
