### PR TITLE
fix(examples,reagent-slim): three isolated defects (rf2-do50, rf2-sefb, rf2-3hqm)

### DIFF
--- a/examples/capabilities/routing/routing/index.html
+++ b/examples/capabilities/routing/routing/index.html
@@ -2,6 +2,16 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <!-- This example ships a two-segment route ("/articles/:id"), and a page's
+       relative URLs resolve against the DOCUMENT url — which, under the default
+       history strategy, is the route. Without this, deep-linking or refreshing
+       on /articles/intro would resolve every asset below against /articles/,
+       so the page would load with no stylesheet, no favicon and no main.js.
+       One <base> fixes all of them; see the Hicasso routing guide, "A route
+       deeper than one segment moves what relative URLs resolve against".
+       Under a sub-path deployment this becomes <base href="/my-app/">, with
+       rf.routing/with-base-path on the frame's :url-strategy so the two agree. -->
+  <base href="/">
   <title>re-frame2 example: routing</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#1A1814">

--- a/examples/real-apps/realworld_http/index.html
+++ b/examples/real-apps/realworld_http/index.html
@@ -2,6 +2,15 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <!-- Conduit routes three segments deep ("/profile/:username/favorites"), and
+       a page's relative URLs resolve against the DOCUMENT url — which, under
+       the default history strategy, is the route. Without this, deep-linking or
+       refreshing on /profile/bob/favorites would resolve every asset below
+       against /profile/bob/, so the page would load with no stylesheet, no
+       favicon and no main.js. One <base> fixes all of them; see the Hicasso
+       routing guide, "A route deeper than one segment moves what relative URLs
+       resolve against". -->
+  <base href="/">
   <title>re-frame2 example: realworld (Conduit)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#1A1814">

--- a/examples/real-apps/realworld_shared/markdown.cljs
+++ b/examples/real-apps/realworld_shared/markdown.cljs
@@ -134,12 +134,37 @@
                  (apply str))]
     [:span raw]))
 
+;; ---------------------------------------------------------------------------
+;; Tight-list children (React key hygiene)
+;; ---------------------------------------------------------------------------
+
+(defn- plain->fragment
+  "Render a `:plain` node as a hiccup FRAGMENT rather than a bare seq.
+
+   markdown-it marks the paragraph inside a tight list item `hidden`, which
+   nextjournal maps to the `:plain` node type. Its default renderer returns
+   `(seq ...)`, and `:list-item` is `(partial into-markup [:li])`, which
+   conj's that single value in — so an ordinary `- item` bullet carrying any
+   inline markup emits `[:li (\"Full CommonMark via \" [:code \"…\"])]`. That
+   inner seq reaches React as an ARRAY child, and every element in an array
+   needs a key, so React warns: \"Each child in a list should have a unique
+   `key` prop. Check the render method of `li`.\"
+
+   A fragment carries exactly the same children in the same order, but
+   positionally — React sees ordinary siblings, not a list, and no key is
+   required. Keys would be the wrong remedy here anyway: these children are
+   prose runs with no stable identity to key on (rf2-sefb)."
+  [ctx {:keys [content]}]
+  (into [:<>] (map (partial md.transform/->hiccup ctx)) content))
+
 (def ^:private hiccup-renderers
   "The default nextjournal renderers, plus explicit inert handlers for raw
-   HTML node types so attacker HTML degrades to escaped text (never markup)."
+   HTML node types so attacker HTML degrades to escaped text (never markup),
+   and a `:plain` renderer that emits a fragment instead of a bare seq."
   (assoc md.transform/default-hiccup-renderers
          :html-inline raw-html->text
-         :html-block  raw-html->text))
+         :html-block  raw-html->text
+         :plain       plain->fragment))
 
 ;; ---------------------------------------------------------------------------
 ;; Public entry point

--- a/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
@@ -151,8 +151,21 @@
   ;; print). The "private" tag is a CLJS-packaging artefact, not an
   ;; API contract — silence kondo's private-call check at the one
   ;; call site rather than blanket-excluding the linter.
+  ;; The nil `*ratom-context*` must wrap the `pr-writer` CALL, not `body`:
+  ;; `body` is an already-computed local, so binding around it pops before
+  ;; any printing happens. The derefs worth guarding are the ones `pr-writer`
+  ;; makes as it recurses — a nested ratom's own `-pr-writer` derefs it — and
+  ;; capturing those would subscribe whatever is currently tracking to a
+  ;; value it merely printed (rf2-3hqm).
+  ;;
+  ;; The receiver's own deref stays visible: both call sites build
+  ;; `{:val (-deref a)}` before entering here, and that is deliberate. A
+  ;; Reaction's `-deref` branches on `*ratom-context*`, so reading it under a
+  ;; nil context would additionally force a `flush!` and an on-demand
+  ;; recompute — a behaviour change well beyond suppressing capture.
   #_:clj-kondo/ignore
-  (pr-writer (binding [*ratom-context* nil] body) writer opts)
+  (binding [*ratom-context* nil]
+    (pr-writer body writer opts))
   (-write writer "]"))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/adapters/reagent-slim/test/reagent2/ratom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/ratom_cljs_test.cljs
@@ -482,3 +482,41 @@
   (testing "the Reaction's value is printed recursively too"
     (is (= "#object[reagent2.ratom.Reaction {:val [:p 1]}]"
            (pr-str (ratom/make-reaction (fn [] [:p 1])))))))
+
+;; ---------------------------------------------------------------------------
+;; pr-atom's *ratom-context* guard (rf2-3hqm)
+;;
+;; Printing must not make the printer depend on what it printed. A ratom's
+;; own deref happens at the `-pr-writer` call site, building `{:val ...}`
+;; before `pr-atom` is entered — that one is deliberately left visible, since
+;; a Reaction's `-deref` branches on `*ratom-context*` and reading it under a
+;; nil context would force a `flush!` and an on-demand recompute.
+;;
+;; What `pr-atom`'s guard is for is the derefs that happen DURING the print:
+;; `pr-writer` recurses into the value, and a nested ratom's `-pr-writer`
+;; derefs it. Those must not be captured.
+;; ---------------------------------------------------------------------------
+
+(deftest pr-atom-does-not-capture-nested-derefs
+  (testing "printing a ratom-in-a-ratom captures the outer, never the inner"
+    (let [inner (ratom/atom 7)
+          outer (ratom/atom {:inner inner})
+          r     (ratom/make-reaction (fn [] (pr-str outer)) :auto-run true)]
+      @r
+      (let [watched (set (.-watching r))]
+        (is (contains? watched outer)
+            "the printed ratom itself is deref'd at the call site")
+        (is (not (contains? watched inner))
+            "the nested ratom is deref'd inside pr-writer, under the guard"))))
+
+  (testing "so changing the nested ratom does not re-run the printer"
+    (let [inner (ratom/atom 7)
+          outer (ratom/atom {:inner inner})
+          runs  (volatile! 0)
+          r     (ratom/make-reaction (fn [] (vswap! runs inc) (pr-str outer))
+                                     :auto-run true)]
+      @r
+      (is (= 1 @runs))
+      (reset! inner 8)
+      (is (= 1 @runs)
+          "a spurious dependency on the nested ratom would recompute here"))))


### PR DESCRIPTION
Three small, independent fixes on three isolated surfaces. Two of the three
beads' stated premises turned out to be wrong in ways that changed the fix, so
each section says what was measured rather than what was assumed.

## rf2-do50 — relative asset hrefs under a route deeper than one segment

**The bead asks whether this example's routes actually go deeper than one
segment. They do:** `routing/core.cljs` registers `"/articles/:id"`. So this is
a live defect, not a latent one.

Measured with `new URL(href, base)` over the shipped route shapes, the same
instrument rf2-g1gt used: **16 of 28 route x asset combinations resolve wrong,
and 0 of 28 once a `<base href="/">` is in place.** The bead (and chapter 07's
prose) frame the symptom as a lost stylesheet, but `main.js` is relative too and
resolves the same way — so a deep link or refresh does not merely render
unstyled, **the application never boots**.

```
/articles/intro          ->  /articles/_shared/css/style.css , /articles/main.js
/profile/bob/favorites   ->  /profile/bob/main.js
```

**The census the bead asks for.** Two instruments (a `grep -rn` over
`--include=index.html` and an independent attribute-parsing pass that classifies
absolute vs relative) agree: **all 31 example `index.html` files carry relative
asset refs; none uses absolute paths.** So "prefer whichever the repo's other
examples already use" has a null answer — there is no existing absolute-path
example to follow. Cross-referencing against the route table each example ships
(`reg-route` path literals, max depth per file) leaves **four** examples where
the defect is live today:

| example | max route depth | in this PR |
|---|---|---|
| `capabilities/routing/routing` | 2 (`/articles/:id`) | fixed |
| `real-apps/realworld_http` | 3 (`/profile/:username/favorites`) | fixed |
| `capabilities/resources/resources` | 2 (`/articles/:slug`) | **not fixed — outside this PR's scope** |
| `real-apps/realworld_resources` | 3 (`/profile/:username/favorites`) | **not fixed — outside this PR's scope** |

The other 27 ship one-segment routes or none, and are correct today but fragile
if extended. `capabilities/ssr/resources_ssr` mentions `reg-route` only in prose
— it is route-free, and is not a case.

**Why `<base href="/">` rather than absolute paths.** Chapter 07 documents both
remedies. Absolute paths would break the static asset gate:
`check-examples-assets.cjs`'s `resolveRef` special-cases a `_shared/`-prefixed
ref and resolves it against the examples root, so `/_shared/css/style.css` falls
through to `path.resolve(pageDir, "/...")` and misses on disk. `<base>` leaves
every href untouched, fixes all four refs on the page at once including
`main.js`, and is one line. `stageShared` copies `_shared` next to `index.html`
and `main.js` into a single served root, so `/` is the correct base.

## rf2-sefb — the duplicate-key warning is not in the tag list

**The bead's leading hypothesis does not hold.** Every tag list in the app
already carries `^{:key tag}` (`articles.cljs:443`, `comments.cljs:830`), and so
does every other seq-producing child site in `realworld_http` — 7 of 7, swept
file by file. No key is missing anywhere in those 13 files.

The bead also says the defect is "entirely inside
`examples/real-apps/realworld_http/`". It is not: the unkeyed seq is produced by
the shared markdown renderer, and there is no call-site fix.

**Mechanism, each link verified at source:**

1. markdown-it marks the paragraph inside a *tight* list item `hidden` — measured
   directly against the demo article body: all three bullets return
   `paragraph_open hidden=true`.
2. `nextjournal/markdown/impl.cljs:70-73` maps a hidden paragraph to the
   `:plain` node type.
3. `transform.cljc:79-80` — `:plain`'s default renderer returns a bare
   `(seq (mapv ...))`.
4. `transform.cljc:111` — `:list-item` is `(partial into-markup [:li])`, which
   conj's that single seq in.

So an ordinary bullet carrying inline markup emits
`[:li ("Full CommonMark via " [:code "nextjournal/markdown"])]`. React sees an
**array** child and asks for a key on each element of it — which is exactly why
the warning names *the render method of `li`* rather than any component in this
repository.

Rendering `:plain` as a fragment carries the same children in the same order but
positionally, so React sees ordinary siblings rather than a list. **Keys would be
the wrong remedy here**: these children are prose runs with no stable identity to
key on. The fix is one renderer override alongside the two this file already
installs, and it fixes both RealWorld apps, which share the namespace.

**Evidence limits, stated plainly:** a React key warning is emitted only by a dev
build at runtime, so no static gate in this repo observes it, and I did not drive
a browser. What is measured above is the mechanism end to end; what is *not*
measured is the warning disappearing in a live dev build.

## rf2-3hqm — the guard was real, and mispositioned

**Established before moving anything, as the bead requires.** The binding wrapped
`body`, an already-computed local, so it popped before `pr-writer` ran. But it is
not vestigial: `pr-writer` recurses into the value, and a **nested** ratom's own
`-pr-writer` derefs it, and `-deref` calls `notify-deref-watcher!`. The suite
already pinned a nested-ratom print, so the path was live and untested for
capture.

**Demonstrated rather than argued.** A new test prints a ratom-inside-a-ratom
inside a live reactive context. Before the fix it failed on both assertions —
the nested ratom was present in the reaction's watching set, and the printer
re-ran (2 rather than 1) when that nested ratom changed. After moving the binding
to wrap the `pr-writer` call, both pass, with the suite's test and assertion
totals unchanged (11174 / 55752) so nothing was skipped.

**What deliberately did not change.** The receiver's own deref stays at the call
site, where both `-pr-writer` methods build `{:val (-deref a)}`. A `Reaction`'s
`-deref` branches on `*ratom-context*`: under a nil context it additionally calls
`flush!` and takes an on-demand recompute path. Guarding that deref would drain
the reaction queue from inside `pr-str` — a behaviour change well beyond
suppressing capture, and precisely the "wrong move at a reactive-substrate seam"
the bead warns against. Both the rationale and the residual are recorded in the
source comment.

For the record, PR #9127 did not introduce this: it only dropped `pr-atom`'s
unused receiver argument, and its message correctly states the binding and the
deref points were untouched. The shape dates from the file's first commit.

## Gates

Each command's own exit code, captured on the same line as the redirect and
quoted here.

| gate | exit |
|---|---|
| `node scripts/compile-node-test.cjs node-test out/node-test.js` | 0 |
| `node out/node-test.js` (11174 tests, 55752 assertions, 0 failures, 0 errors) | 0 |
| `node scripts/check-examples-compile.cjs` (58 builds, zero warnings) | 0 |
| `node examples/scripts/check-examples-assets.cjs` (33 pages) | 0 |
| `python scripts/check_require_alias_dialect.py --verbose` | 0 |

All re-run on the final rebased base, not a pre-rebase tree.

**The alias ratchet did not move** — "every surface at or under its floor". Its
totals shift between the two runs (5912 -> 5640 non-canonical) purely because
rf2-r79e / rf2-ttss landed `implementation/http`'s dialect rewrite in between;
this branch touches no require form anywhere.

**Planted-fault control.** The asset gate prints no root, so its worktree was
proven by a planted fault rather than a printed path: `style.css` ->
`style-PLANTED.css` in `routing/index.html` turned it red (exit 1) naming
`_shared/css/style-PLANTED.css`. The fault existed only in this branch, so a run
reading a sibling checkout would have come back green. Restore verified by
comparing the file's git blob hash against its pre-plant value, not by reading a
diff.

`test:reagent-slim:bundle-isolation` was judged **not required**: the change
repositions an existing `binding` form inside an existing function and adds no
require, no namespace and no new symbol, so the slim bundle's dependency graph is
unchanged.

**Not covered by any gate, per repo convention:** examples are test-free
(rf2-8cevm), so no `*.spec.cjs` was added under `examples/`; the two `index.html`
edits and the `<base>` behaviour are verified by the `new URL()` measurement
above and by the asset gate, not by a browser.
