### PR TITLE
docs(hicasso): as-component needs a frame, not a Hicasso root; shadow!'s example crosses :id (rf2-ip7a, rf2-rx99)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso.cljc
@@ -521,15 +521,18 @@
 
      (def ^{:doc "`h/as-component` — **the outward bridge**.
   Answers a real React component for a hiccup head, so a React parent —
-  UIx or plain JavaScript — mounts a minted Hicasso
+  UIx, Reagent or plain JavaScript — mounts a minted Hicasso
   view under the frame it is already in:
 
       (def article-card* (h/as-component article-card))
 
   Declared once at top level, beside the view. The parent's props arrive
   as the view's ordinary props map (`articleId` → `:article-id`),
-  children at `:children`, values by identity; the frame comes from React
-  context, and no second root, state owner or props ABI appears anywhere.
+  children at `:children`, values as this shallow decode finds them — a
+  Reagent parent's `[:>]` converts first, so names round-trip across the
+  crossing and values do not. The frame comes from React context: ANY
+  frame, written by any React-shaped adapter, rather than a Hicasso
+  root — and no second root, state owner or props ABI appears anywhere.
   Sits HERE rather than on the native tier because a UIx or JavaScript
   parent must not have to require the native namespace — and therefore
   ship it — to cross inward.

--- a/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
@@ -1794,21 +1794,32 @@
 
 (defn as-component
   "Hand a hiccup head to React: a real React function component a React
-  parent (UIx or plain JavaScript) renders without a second root, a
-  second frame, or a sight of the internal `rfProps` ABI.
+  parent (UIx, Reagent or plain JavaScript) renders without a second
+  root, a second frame, or a sight of the internal `rfProps` ABI.
 
       (def article-card* (h/as-component article-card))
       ;; on the React side: <ArticleCard articleId={7} />
 
   The parent's props arrive as the view's ordinary props map (`prop-key`
-  on each slot, values by identity) and React's `children` at `:children`
-  as the vector a hiccup caller's would be (`outward-children`). The
-  element is built by `vec->element` from `[head props]`, so the view
-  keeps its memo wrapper, its reads, its teardown and its refusals; the
-  frame is the surrounding React context's, and outside every Hicasso
-  root the shell refuses with `:rf.error/no-frame-context`. Neither
-  `*frame*` nor `*dispatch*` is bound — this is not a boundary body, so
-  an intent vector in a `[:div]` handed through here stays the loud
+  on each slot) and React's `children` at `:children` as the vector a
+  hiccup caller's would be (`outward-children`). That decode is SHALLOW:
+  it reverses the camelCasing on each key and takes each value as it
+  finds it. Values therefore cross BY IDENTITY here, which is a fact
+  about this decode rather than a promise about what arrives — a Reagent
+  parent's `[:>]` runs its own `convert-prop-value` first, so a keyword
+  reaches the body as its name and a map as a camelCased object. Names
+  round-trip across a crossing; values do not.
+
+  The element is built by `vec->element` from `[head props]`, so the
+  view keeps its memo wrapper, its reads, its teardown and its refusals;
+  the frame is the surrounding React context's — the one
+  `re-frame.adapter.context/frame-context` that `h/mount!`,
+  `rf/frame-provider` and `rf/frame-root` all write — so what is
+  required is a frame from any React-shaped adapter, not a Hicasso root,
+  and outside every frame the shell refuses with
+  `:rf.error/no-frame-context`. Neither `*frame*` nor `*dispatch*` is
+  bound — this is not a boundary body, so an intent vector in a `[:div]`
+  handed through here stays the loud
   `:rf.error/hicasso-intent-outside-boundary`. Call it ONCE, at top
   level: it allocates a component, and a fresh one per render is a fresh
   element type that remounts the subtree, `React.memo`'s own law."

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
@@ -1904,9 +1904,14 @@
   same seeded frame, drives both with one script, and compares canonical
   DOM and the intent stream at every checkpoint.
 
+      ;; Once, at top level, for the same reason `h/as-component` is: a
+      ;; component allocated per render is a new element type and
+      ;; remounts the subtree.
+      (def old-article-row (r/reactify-component old/article-row))
+
       (hm/shadow!
-       {:reference      [:> (r/reactify-component old/article-row) {:article-id 7}]
-        :candidate      [new/article-row {:article-id 7}]
+       {:reference      [:> old-article-row {:id 7}]
+        :candidate      [new/article-row {:id 7}]
         :initial-events [[:demo/install-fixture]]
         :script         [{:click \"button.edit\"}
                          {:type  [\"input.title\" \"Better title\"]}
@@ -1944,6 +1949,15 @@
   own translation table already sends it through. Nothing here `:require`s
   a second view library, and the door works for all of them for that
   reason.
+
+  **Cross single-word props.** The crossing renames the KEY: Hicasso
+  camelCases it on the way out, and a reactified Reagent original reads
+  back the name React actually carried, so `:article-id` reaches the
+  reference as `:articleId` while the Hiccup candidate still sees
+  `:article-id`. Nothing decodes it back on that route. A prop both
+  sides spell the same way — and a seeded frame both sides read — keeps
+  the difference out of the SCRIPT, where it would be a divergence the
+  code under comparison did not cause.
 
   A crossing is also how a foreign original reaches the frame at all. A
   declared callback contract lowers an intent vector into a real function


### PR DESCRIPTION
Two docstrings in `implementation/hicasso/` that said something the code does not do. **Docstrings only — no behaviour changes.**

## rf2-ip7a — `as-component` refuses outside every FRAME, not every Hicasso root

`impl/codec.cljs`'s `as-component` docstring said the shell refuses *"outside every Hicasso root"*. The code refuses outside every **frame**.

Code read to settle it:

- `codec.cljs` `as-component` → `vec->element` → `boundary-element` → `element-type` (the `React.memo` wrapper) → the component `collector/mint-view!` built → `collector/shell`, which is the thing that reads the context: `(resolve-frame! (react/useContext adapter-context/frame-context) …)`.
- `collector/resolve-frame!` refuses on `(or (nil? frame-kw) (= adapter-context/no-provider-sentinel frame-kw))` and raises `:rf.error/no-frame-context`. There is no Hicasso-root check anywhere in it.
- `core/src/re_frame/adapter/context.cljs` — `frame-context` is one `defonce`'d `createContext`, defaulting to the no-provider sentinel.
- All three writers write that same object: `h/mount!` calls `createElement` on `(.-Provider adapter-context/frame-context)` directly (`impl/mount.cljs`); `rf/frame-provider` takes it by alias — `(def frame-context rf.adapter.context/frame-context)` in `views/provider.cljs`, whose own comment says it references it "rather than minting a new createContext call"; `rf/frame-root` writes through `context/provider-element` (`views/frame_boundary.cljs`).
- Already proven in-tree: `hicasso/test/re_frame/hicasso/foreign_root_bridge_dom_cljs_test.cljs` route `:crossed/reagent-as-component` mounts a `reagent.dom.client` root with `rf/frame-provider` above and the `as-component` bridge inside — **no Hicasso root** — and asserts a write re-runs the body and moves the readout.

The docstring now names the shared context and its three writers, and says the requirement is a frame from any React-shaped adapter. This matches its siblings: `native.cljc` says "outside every frame" twice, and `docs/core/hicasso/09-interop.md` was corrected to the same rule in #9149.

### Two further corrections the bead's audit note asked for, applied to BOTH `as-component` docstrings

`impl/codec.cljs` and the public facade in `hicasso.cljc` both (a) listed only UIx and plain JavaScript as supported parents and (b) claimed "values by identity" unqualified.

- **Reagent is a supported parent**, and the `foreign_root_bridge` test above is the witness.
- **"By identity" is a fact about Hicasso's shallow decode, not about what arrives.** `outward-props` reads `(prop-key s)` for the key and `(unchecked-get js-props s)` for the value, so it renames nothing inside a value — but a Reagent parent's `[:>]` has already run `reagent.impl.template/convert-prop-value`, which maps a keyword to its name, a CLJS map to a camelCased JS object with values recursively converted, and other collections through `clj->js`. So names round-trip across a crossing and values do not.

## rf2-rx99 — `hm/shadow!`'s example crossed a prop that does not survive the crossing

`test_kit/.../test/mounted.cljs`, `shadow!`'s headline example, crossed `{:article-id 7}` into a reactified Reagent original. Code read to settle it:

- **Out:** `raw-element` reduces the props with `codec/host-entry`, which computes the emitted slot via `slot/prop-name` — the camelCaser. `:article-id` → `"articleId"`. `raw-gate` hands that props object to the foreign component untouched. `host-prop-value`'s own docstring already says "The caller (`host-entry`) camelCases the top-level KEY".
- **In:** Reagent's `reactify-component` → `as-class`; a React parent's props carry no `.argv`, so `props-argv` falls back to `util/shallow-obj-to-map`, which is `(keyword k)` on the raw JS key. `"articleId"` → `:articleId`.
- **Nothing decodes it back on that route.** `codec/prop-key` does exactly that decode, but its only two call sites are its definition and `outward-props` — both inward.

So the reference saw `:articleId` while the candidate saw `:article-id`: a divergence the example itself introduces, in the door whose entire purpose is to attribute divergences to the code under comparison. Fixed per the bead's stated preference order — cross `:id`, hoist `reactify-component` to a top-level `def` (`as-component`'s own docstring states that law for the mirror-image case), and state the renaming rule in the section that explains the crossing. This aligns the docstring with `docs/core/hicasso/20-migration-from-reagent.md` §3, corrected to `:id` and a hoisted def in #9131.

## Census — is `codec.cljs` the only place saying it that way?

Yes, and the search needed doing twice. A **line-oriented** `git grep -F "outside every Hicasso root"` returns **zero** — a false zero, because in `codec.cljs` "Hicasso" ends one line and "root" begins the next; the shorter probe `"Hicasso root"` misses it for the same reason. A **whitespace-tolerant multiline** search (`outside\s+every\s+Hicasso\s+root`) finds exactly one site repo-wide, `codec.cljs:1808-1809`. Both phrases are now absent from `implementation/` by that same instrument, which found them before the edit.

The other repo hits for "Hicasso root" are all correct uses about actual Hicasso roots (`ssr/`, `ssr-ring/`, and one test comment about non-reactivity) and were left alone.

## Verification

**Nothing in this repo validates docstring prose.** The truth check was by hand, against the code named above.

Gates run, each with its exit code captured on the same command line (never piped), all on the final rebased base:

| Gate | Exit |
|---|---|
| `check_optional_module_reachability.py --self-test` | 0 |
| `check_optional_module_reachability.py` | 0 |
| `check_guide_samples.py --self-test` | 0 |
| `check_guide_samples.py` | 0 — 74 verbs at 401 sites across 29 pages resolve |
| `scripts/check_require_alias_dialect.py --verbose` | 0 — every surface at or under its floor; baseline untouched |
| `compile-node-test.cjs node-test` | 0 — 1892 files, 0 warnings |
| `node out/node-test.js` | 0 — **11173 tests, 55748 assertions, 0 failures, 0 errors** |

**Planted fault.** An unbalanced quote was inserted into the `as-component` docstring (single-line anchor, match count checked as exactly 1 before running). The compile went **red, exit 1**, naming `…/hicasso/src/re_frame/hicasso/impl/codec.cljs:1808:26` and quoting the planted line — so the gate read this worktree and the compiler observed the plant. Restored by `git checkout HEAD --` and verified by **blob** hash, back to `a20ea9321568defcdcd98f533a32cebc5ae3aca8`. The working tree was committed before the plant, so the restore could not discard the work under test.

## Follow-up not done here

`shadow!` still has **no in-repo witness for a foreign `:reference`** — every row in `test_kit/test/.../shadow_dom_cljs_test.cljs` uses `h/defview` on both sides, and `reactify-component` appears nowhere in that suite. That is a test addition rather than a docstring repair, so it is outside this dispatch's fence; filed separately as rf2-g1a8.
