### PR TITLE
docs(method): the history walk names .Issue-nested fields and treats an absent key as empty (rf2-tg6o)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -823,9 +823,13 @@ correction is invisible to it and an edited description can be the newest field 
 bead. Use `bd history <id>`, which lists real mutation times newest-first, and
 `bd comments <id> --json` for comment `created_at`. THE PLAIN LISTING TELLS YOU A NEWER
 MUTATION EXISTS, NOT WHAT IT SAYS — it names no changed field, so for the change itself
-use `bd history <id> --json`, which carries a full snapshot per commit. WALK ADJACENT
-PAIRS NEWEST-FIRST UNTIL THE FIRST CHANGE TO A TEXT-BEARING FIELD (description, notes,
-acceptance, design): the history holds duplicate checkpoint snapshots and status-only
+use `bd history <id> --json`, which carries a full snapshot per commit. EACH ENTRY
+NESTS THE ITEM'S FIELDS UNDER `.Issue`; the top level carries only commit metadata, so
+a walk keyed at the top level matches nothing in every snapshot and reports “no change”
+without erroring. WALK ADJACENT PAIRS NEWEST-FIRST UNTIL THE FIRST CHANGE TO A
+TEXT-BEARING FIELD (`.Issue.description`, `.Issue.notes`, `.Issue.acceptance_criteria`
+— the update flag is spelled `--acceptance` but the field is not — and
+`.Issue.design`): the history holds duplicate checkpoint snapshots and status-only
 mutations, so the newest pair alone can truthfully say nothing changed while a live
 instruction change sits behind it. AND A WALK THAT ENDS WITHOUT FINDING ONE HAS FOUND
 NOTHING, NOT “NO CHANGE” — say which of the two you have. Histories accumulate
@@ -834,6 +838,23 @@ machine-written no-ops, so a walk bounded anywhere short of the item’s beginni
 signature whose remedy is to re-close. On a long history, search the text for the marker
 you expect rather than walking to it. If the bead has children, re-enumerate them too: a
 ruling is sometimes recorded as a NEW CHILD BEAD rather than as a note.
+
+AND THE SNAPSHOT OMITS EMPTY FIELDS, so a key's ABSENCE means “empty on this item”, NOT
+“not tracked”. The key set is per-item and reflects exactly what that item populates, so
+there is no schema to read off one item's snapshot — do not derive one. Treat absent and
+null as the same thing, and never read “no change” off a field the item never populated:
+null hashes constant across every adjacent pair, so an empty field reports a clean walk
+in the very same words as a genuinely unchanged one, and the two are indistinguishable
+in the output. That makes the walk INTERMITTENTLY wrong rather than reliably wrong — the
+identical expression works perfectly on an item that DOES populate the field — which is
+why it survives casual use. `notes` is the field that matters most here, because
+rulings, sequencing fences and audit reopenings are appended there.
+
+SO CONTROL THE WALK AGAINST A FIELD YOU KNOW VARIES ON THE ITEM IN FRONT OF YOU before
+you believe any “no change”; a control on a different item proves nothing about this
+one. That control is the only reason this paragraph is right: a field list asserted from
+a single item's key set was refuted only when somebody ran the same walk on a second
+item, where the field it called untracked was populated and had changed seven times.
 
 TIMESTAMP ORDER DOES NOT ESTABLISH CURRENCY, so a perfect walk can still hand you
 superseded text: the newest note by mutation time can be a faithful re-derivation of a


### PR DESCRIPTION
The common preamble in `dispatch-prompt-template.md` travels verbatim into every worker dispatch, and its history-walk paragraph told workers to key the walk on `(description, notes, acceptance, design)` at the top level of `bd history --json`. Two things were wrong, and both fail **open** — they report "no text-bearing change" without erroring, which is the exact false clean the paragraph exists to prevent, reached by following the paragraph.

## What was actually measured

The item's original diagnosis — "notes and design are not in this build's history schema" — is **refuted**, and the mayor appended a correction to the bead saying so mid-task. The real mechanism is different and nastier.

`bd history --json` **omits empty fields**. The key set is per-item and reflects exactly which fields that item populates, so one item's snapshot is not a schema. Both `notes` and `design` are genuinely tracked:

| measurement | result |
| --- | --- |
| `design` populated across the export | 4 of 1685 beads |
| `bd history` on a bead that populates it | `design` present in 771 of 771 snapshots, alongside `assignee`, `close_reason`, `closed_at` |

So `design` stays in the enumeration. Only the **spelling** and the **nesting** were wrong.

## The control, run on the bead in front of me

Walking rf2-tg6o, adjacent-pair change points:

| key | change points | meaning |
| --- | --- | --- |
| `.Issue.notes` | 1 | field known to vary — the control fires |
| `.Issue.description` | 0 | a **true** no-change |
| `.Issue.acceptance_criteria` | 0 | never populated — a **false** clean |
| `.Issue.design` | 0 | never populated — a **false** clean |
| `.notes` (top level, no `.Issue`) | 0 | the nesting trap, while `.Issue.notes` reads 1 |

The true no-change and the two false cleans are **indistinguishable in the output**. That is why the walk is *intermittently* wrong rather than reliably wrong: the identical expression works perfectly on an item that does populate the field.

## The change

Confined to the preamble's history-walk paragraph:

1. Fields named as `.Issue`-nested, with `acceptance` corrected to `acceptance_criteria` (noting the update flag really is spelled `--acceptance`, which is where the error came from).
2. A new paragraph stating the consequence plainly: an absent key means "empty on this item", not "not tracked"; treat absent and null alike; never read "no change" off a field the item never populated.
3. The control instruction strengthened to name **the item in front of you** — a control on a different item proves nothing about this one.

No paragraph that was not wrong has been rewritten, and no field list is presented as a schema.

## Travel-verbatim block ranges (new)

| block | was | now |
| --- | --- | --- |
| worktree-boundary (fenced 739/795) | 740–794 | **740–794** (unchanged) |
| common preamble (fenced 804/885) | 805–863 | **805–884** |
| gate mechanics (heading-to-heading) | 920–1139 | **941–1160** |

Fence count across the file is 4 (two balanced pairs); no heading was introduced inside a block and no text crossed a boundary.

## Quality gates

| gate | exit | notes |
| --- | --- | --- |
| `python scripts/check_doc_slugs.py` | **0** | re-run post-rebase |
| `python -m mkdocs build --strict` | **0** | log names `the-mayor-method/dispatch-prompt-template.md` among built files |
| `python scripts/check_require_alias_dialect.py --verbose` | **0** | "every surface at or under its floor" — unmoved; no code touched |

`mkdocs.yml`'s `exclude_docs` was read at source: it lists `tools/playground/`, the two codemod trees, and `design/{freehand,hicasso,retirement}/`. `the-mayor-method/` is **not** excluded, so the strict build does cover this path.

### Planted-fault check, and a correction to a premise

The slug gate prints no root, so discrimination was proved by planting a broken anchor inside the preamble fence. It went **red (exit 1)** naming `dispatch-prompt-template.md:853` — confirming the gate read this worktree, since the fault existed nowhere else. Restored and verified by git **blob** hash `47455d342b21c248c56645c1ab5ed8ce5c36a1f2`, matching the committed object, with zero residue.

But the mechanism is not anchor validation. Swapping the bogus anchor for a **valid** one (`loops.md#after-each-merge`) was rejected **identically**, exit 1. The rule in this tree is `rf2-mmyc`: *any* markdown link inside a fence is an error regardless of target validity, because a fenced block here is pasteable verbatim text. So fence-internal links are indeed reported in this tree — but as link-presence, never as a validated anchor. Practical consequence: no markdown link may be added inside these blocks, and no gate would catch a bad anchor there if one could exist.

### Not changed

`loops.md`, `bootstrap.md` and `README.md` were checked for the same wrong field list, line-oriented and again over whitespace-flattened text (the phrase is hard-wrapped, so a line-oriented search alone would miss a wrapped copy); the flat scan's control needle hit 646 files, and the target needle was confirmed findable both ways in the pre-edit file. `loops.md` references the walk at lines 466–474 but carries **no field list** — it links to `dispatch-prompt-template.md#common-preamble` and delegates the mechanics, so this fix reaches the mayor's own reading path automatically. Nothing else in the repository carried the enumeration.
