### PR TITLE
docs(ci): the spec-resource reader has one consumer, not a Freehand pair (rf2-6r9j.80)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2583,8 +2583,8 @@ jobs:
     name: JVM spec-resource (clojure -M:test)
     # The build-time reader for committed spec/ data
     # (day8/re-frame2-spec-resource) — the ONE resolver for shadow-cljs's
-    # recording classpath read, shared by the Freehand fixture loader and
-    # the api-manifest CLJS probe.
+    # recording classpath read, whose single consumer today is the
+    # api-manifest CLJS probe.
     #
     # Its suite is the deterministic control for the cold-load race that
     # reader exists to close: `requiring-resolve` resolves BEFORE it takes


### PR DESCRIPTION
Closes acceptance criterion 4 of rf2-6r9j.80 for the CI surface.

## The defect

`.github/workflows/test.yml`, in the `jvm-spec-resource` job header, described a
LIVE mechanism as shared with a consumer that no longer exists:

    the ONE resolver for shadow-cljs's
    recording classpath read, shared by the Freehand fixture loader and
    the api-manifest CLJS probe.

The Freehand fixture loader went with its tree under rf2-0yp7w. A maintainer
reading this goes looking for a second consumer that cannot be found. One line
changes; the sentence now names the single consumer that is actually there.

## Comments only — nothing CI executes moves

The whole diff is two lines inside a `#` comment block. No step, job key, `if:`,
`needs:`, `run:` or `name:` is touched. `git diff origin/main...HEAD` is one file,
2 insertions / 2 deletions, read hunk by hunk to confirm exactly that.

## One-toucher argument

`.github/scripts/report-changed-surfaces.sh` and
`implementation/scripts/_changed-surfaces.test.cjs` are a one-toucher pair for a
change that alters what the classifier OUTPUTS or what the test PINS about those
outputs. **This PR does not touch either file at all** — the triage below found
nothing to fix in the `.sh` — so the pair is not implicated in any direction, and
this is a stronger form of the one-file case argued in #8664 and #9151. The
mirror suite was run anyway to confirm it does not move: `_changed-surfaces.test.cjs`
passes unchanged.

## Triage: which `freehand` mentions are stale, and which are history

CLAUDE.md protects donor references that record their own retirement. Each hit was
read against one test: does the sentence describe a mechanism live NOW as though it
had a counterpart that is gone (fix), or does it record that something was retired
(leave)?

**`.github/workflows/test.yml` — 6 hits, 1 stale, 5 retirement bookkeeping.**

| line | verdict |
|---|---|
| 1305 | bookkeeping — "was a second escape held ahead of the catch-all **until** rf2-0yp7w.6 deleted that corpus" |
| 2447 | bookkeeping — past-tense "four artefacts **had** a lane", the dated why-it-exists rationale for the epoch job |
| 2586 | **STALE — fixed here.** Present tense, live mechanism, vanished counterpart |
| 2852 | bookkeeping — "the pin **used to live** under `implementation/freehand`", records the re-homing |
| 4064-4065 | bookkeeping — "**went with** the rf2-0yp7w Freehand retirement" |

**`.github/scripts/report-changed-surfaces.sh` — 13 hits, 0 stale, 13 retirement
bookkeeping. No change made.** Every one is past tense and names the retirement:
385 ("closed for"), 1288-1289 ("the **retired** ... case **used to** set. That case
**went with** its tree"), 1345 ("**until** that tree went under rf2-0yp7w"), 1395-1396
("**then-live** ... **went with** its tree"), 1475-1477 ("It **was** on ... which **left
with** the rf2-0yp7w retirement along with the second consumer and the `jvm-freehand`
lane this comment **used to name**"), 1623 ("the line rf2-drpa3.70 **drew**"), 1704
("it **retired** with the tree that read it"), 1738-1739 ("Two more **used to** sit
here ... **retired**"), 1863 ("the two freehand checker arms that **used to** sit above,
both **retired** with their tree").

Two of these (1475, 1739) were nominated as residue in the dispatch. On reading them
they are the opposite: both explicitly narrate the retirement, and 1475 is
self-describing ("the `jvm-freehand` lane this comment used to name"). Leaving them is
CLAUDE.md's rule, not an omission.

## Nothing validates a comment's truth — the check was by hand

No gate reads this prose. Each clause of the replacement was checked against source:

- **"the ONE resolver for shadow-cljs's recording classpath read"** —
  `implementation/spec-resource/src/re_frame/build/spec_resource.clj`: `recording-slurp`
  is the single `delay` resolving `shadow.resource/slurp-resource`, via
  `resolve-after-require`. Still true, unchanged.
- **"whose single consumer today is the api-manifest CLJS probe"** — a tracked search for
  `re-frame.build.spec-resource` returns exactly one `:require` in product source,
  `implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj:40`
  (the others are the artefact's own test suite and prose). The reader's own docstring
  now reads "A macro inlines a committed file — today the api-manifest sidecar" and
  "Every consumer is a ClojureScript macro", so the comment and the source agree.

The `spec-resource` arm of `report-changed-surfaces.sh` (:1479-1481) already said
"the api-manifest CLJS probe expands through it" in the singular — this workflow
comment was the last one out of step.

## Gates

Every exit code below was captured to a file on the same command line as the redirect
and read back from that file; none is a harness-reported number. All re-run on the
final base after the rebase onto `a10f5afb41`.

| gate | captured exit |
|---|---|
| `python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` | 0 (`YAML OK`) |
| `bash -n .github/scripts/report-changed-surfaces.sh` | 0 |
| `npm run test:scripts` (implementation) | 0 — 122 tests, 122 pass, 0 fail; includes `_changed-surfaces.test.cjs` ✔ |
| `python scripts/check_require_alias_dialect.py --verbose` | 0 — 2773 files, 10773 edges, 5640 non-canonical, every surface at or under its floor |

The alias-dialect figures are identical to the trunk's, as a comment edit requires.

**Planted structural fault.** YAML syntax is the only real risk in a comment edit, so
the parse gate was proved to read this branch's tree: re-indenting `name:` under
`jvm-spec-resource` by two spaces took the parse to exit 1, naming
`.github/workflows/test.yml` and the line where the block breaks. Restored and verified
by git blob hash (`76c9addaae`, matching the committed object) rather than by reading a
diff. The fault existed only here, so a run that had read another checkout would have
come back green — that is what the red discriminates. It proves nothing whatever about
whether the prose above is true; that was checked by hand, as set out.

## Search method

The target sentence breaks across two `#` lines mid-clause, so the census was run twice
— line-oriented and over whitespace-flattened text. Both instruments agree (6 hits in
`test.yml`, 13 in the `.sh`), and only the flattened one can see the phrase "shared by
the Freehand fixture loader and the api-manifest CLJS probe" as a unit. Every zero was
controlled against a string known present in the same file.

## Out of scope, still stale — reported, not touched

Two further criterion-4 sites describe the non-ClojureScript walk-up fallback that
#9106 removed. Both are outside this fence and neither is about the Freehand fixture
loader:

- `implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj:101-102`
  — "the reader's non-ClojureScript path locates the same file by walking up from the
  compile CWD"
- `implementation/shadow-cljs.edn:168` — "it owns the shadow-cljs recording read, the
  non-ClojureScript walk-up fallback, and ..."

`shadow-cljs.edn` is hot-zone. These need their own dispatch.