### PR TITLE
docs(hicasso): give chapter 15's L4 rung a driver, and make the cookbook preamble true (rf2-da3n, rf2-3s1t)

### DIFF
--- a/docs/core/hicasso/15-testing.md
+++ b/docs/core/hicasso/15-testing.md
@@ -536,6 +536,28 @@ browser engine:
 - hydration against real server bytes;
 - performance budgets.
 
+**The driver is Playwright.** Like L3's Testing Library it is an npm package
+rather than a classpath entry, and it is the only dependency on this page that
+also downloads a browser:
+
+```bash
+npm install --save-dev playwright@1.59.1
+npx playwright install chromium   # add firefox and webkit as you need them
+```
+
+One API exposes `chromium`, `firefox` and `webkit`, so a spec written once runs
+on all three. Pin the version rather than floating it: the browser that comes
+down is what decides what the check can see, and `1.59.1` is the pin this
+repository's own engine gates run at.
+
+Hicasso's L4 gate is the worked example, and there is less to it than you might
+expect — a build, a server, a browser and a script, with no runner framework and
+no config file.
+[`hicasso/testbed/spec.cjs`](../../../implementation/hicasso/testbed/spec.cjs)
+is a plain file of assertions, and
+[`serve-and-run-hicasso-controlled-testbed.cjs`](../../../implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs)
+compiles the testbed build, serves it, and runs that spec once per engine.
+
 Controlled-input composition is a canonical L4 case
 ([Controlled inputs](04-controlled-inputs.md)). Performance scripts and
 budgets belong to [Performance](19-performance.md).

--- a/docs/core/hicasso/cookbook.md
+++ b/docs/core/hicasso/cookbook.md
@@ -2,8 +2,10 @@
 
 Worked recipes, each one a whole thing you can copy into an application and then
 edit. Every recipe here is the shape a landed witness in
-`implementation/hicasso/test/re_frame/hicasso/examples/` already runs, reduced to
-the parts a reader needs.
+`implementation/hicasso/test/re_frame/hicasso/` already runs, reduced to the
+parts a reader needs. Most of those witnesses are the example applications under
+`examples/`; a few — the parameterised control, the server render — are contract
+tests sitting beside that directory rather than inside it.
 
 A recipe answers *how do I build this*. It is deliberately thin on *why it works
 that way*, because the chapters own that and repeating them here would give you


### PR DESCRIPTION
Two documentation corrections in the published Hicasso guide, both claims a reader could not act on. Both premises were re-checked at tip before rewriting; both held.

## rf2-da3n — the L4 rung named three engines and no instrument

`docs/core/hicasso/15-testing.md`'s L4 section said to "use Chromium, Firefox, and WebKit" and stopped: no driver, no coordinate, no install command, no invocation. Both blinded pilots of the pre-pilot rehearsal wrote their own Chrome DevTools Protocol driver rather than find one — hours spent on the instrument.

The repo does ship what they should have found. `playwright` is pinned at `1.59.1` in `implementation/package.json`'s `devDependencies`, and it drives every browser gate in the tree. More directly, `implementation/hicasso/testbed/spec.cjs` plus `implementation/scripts/serve-and-run-hicasso-controlled-testbed.cjs` is a working three-engine harness that runs one spec once per engine in Chromium, Firefox and WebKit — literally this rung in action.

The rung now names Playwright, gives the install and browser-download commands, states the pin and why pinning matters, and points at that harness as the worked example. Deliberately not a browser-automation tutorial: prose, one `bash` fence, two links.

Two judgement calls worth recording:

- **Not pointed at `page-check.cjs`.** It exists, at `docs/design/hicasso/product/pilots/page-check.cjs`, and it is the instrument the pilots package shipped. But `mkdocs.yml`'s `exclude_docs` hides `design/hicasso/` from the built site, and it is a pilot-workspace artefact rather than something a consumer lifts. The guide and the package are kept from diverging the way that matters instead — same driver, same `1.59.1` pin, same `npx playwright install chromium` step.
- **Links, not code spans.** `13-overlays-and-focus.md` already links into `implementation/` at this depth and the strict build is green on it, so the pattern is proven from this directory.

## rf2-3s1t — the cookbook preamble's "every" was false

The preamble claimed every recipe mirrors a witness under `test/re_frame/hicasso/examples/`. Confirmed false at tip, and **more broadly than the bead recorded**: two recipes break it, not one.

- *A reusable control the caller parameterises* — zero hits for `:on-commit`, `:on-select` or `:on-error` anywhere under `examples/`; the contract is witnessed in `forms_cljs_test.cljs` and `forms_dom_cljs_test.cljs`.
- *Render on the server, and adopt it on the client* — zero hits for `hydrate!`, `render-to-string` or `hicasso.server` under `examples/`; eleven witnesses exist, all at the test root.

Both zeros were control-verified: `:on-success` (same punctuation-led keyword shape) returns rows under `examples/`, and `h/mount!` / `h/sub` return 6 and 14 files against the same loop that read 0 for the SSR verbs.

**That finding decides the fix.** The bead offered (a) add a pagination witness under `examples/` or (b) widen the preamble. Option (a) does not work on the merits, independent of any fence: adding one pagination witness would leave "every" still false because of the SSR recipe. It is also a category error — `examples/` holds example *applications* (app/db/events/subs/views plus L0/L2/flow tests) while these are framework contract tests, so moving them would misfile them. Option (b) chosen.

The wording widens only the named root and keeps the guarantee the preamble actually makes — *every recipe is the shape a landed witness already runs* — fully intact, while still sending the reader to `examples/` first and naming the two exceptions. The reader loses no guarantee; they gain the exceptions by name.

## Gates

Each run foregrounded, redirected to a per-attempt log with the runner's own exit code captured on the same command line, and re-run after the rebase onto the final base.

| Gate | Exit |
| --- | --- |
| `python -m mkdocs build --strict` | 0 |
| `python scripts/check_doc_slugs.py` | 0 |
| `check_guide_samples.py --self-test` | 0 |
| `check_guide_samples.py` (live) | 0 — 74 verbs / 401 sites / 29 pages |
| `python scripts/check_require_alias_dialect.py --verbose` | 0 — 2773 files / 10773 edges / 5640 non-canonical, unmoved |

`docs/core/hicasso/` is not in `exclude_docs` and is in the nav, so the strict build does cover both pages.

### Planted fault

A broken anchor (`#no-such-heading-planted`) was planted inside the new L4 passage, after committing the real edits so the restore could not discard them.

- `check_doc_slugs.py` → **exit 1**, naming `docs/core/hicasso/15-testing.md:553 -> #no-such-heading-planted`.
- `mkdocs build --strict` on the same tree → **exit 0**, having *seen* it: `contains a link '#no-such-heading-planted', but there is no such anchor on this page` — logged at INFO, which `--strict` does not promote.

That is both halves: the gate read this branch's tree (the fault existed nowhere else, so a run against another checkout would have come back green), and the anchor/link split is demonstrated rather than asserted. Restored and verified by blob hash — `542f94e6a685c90c8d0219802e7088f9daa4ecbc` before the plant and after the restore, `9aa34a2ff38d5f255b81931d3e103bb5bc71daab` while planted, so the plant was not a silent no-op.

### Verified by hand, because nothing gates it

- **Tables.** No table was touched, and all four in `15-testing.md` were re-counted post-edit: the ladder 3 columns across 5 rows, the `hm` call table 2, troubleshooting 3, equality 3 — each separator row matching its header. `cookbook.md` has no tables.
- **Anchors.** The edits add no headings and no anchor-bearing links, so no anchor was created or invalidated.
- **Link targets.** Both new relative targets resolve on disk from the page's own directory, and a deliberately absent path was checked to confirm the test discriminates. In the built site both rewrite to `https://github.com/day8/re-frame2/blob/main/...`, identical in shape to the proven pre-existing link on `13-overlays-and-focus.md`.
- **Fences.** The cookbook edit is preamble prose, *not* inside a fence, so the link gates do read that passage. The new `bash` fence in chapter 15 is outside `check_guide_samples.py`'s Clojure-language set and names no `h/` verb, which is why the live count is unchanged at 74/401/29.

Closes rf2-da3n. Closes rf2-3s1t.
