### PR TITLE
fix(examples,reagent-adapter): deep-route asset base + eight dead test imports (rf2-pxzf, rf2-6r9j.26)

### DIFF
--- a/examples/capabilities/resources/resources/index.html
+++ b/examples/capabilities/resources/resources/index.html
@@ -2,6 +2,17 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <!-- This example ships a two-segment route ("/articles/:slug"), and a page's
+       relative URLs resolve against the DOCUMENT url — which, under the default
+       history strategy, is the route. Without this, deep-linking or refreshing
+       on /articles/intro would resolve every asset below against /articles/, so
+       the page would lose its stylesheet and favicon — and, because main.js is
+       relative too, the app would never boot at all. One <base> fixes all of
+       them; see the Hicasso routing guide, "A route deeper than one segment
+       moves what relative URLs resolve against".
+       Under a sub-path deployment this becomes <base href="/my-app/">, with
+       rf.routing/with-base-path on the frame's :url-strategy so the two agree. -->
+  <base href="/">
   <title>re-frame2 example: resources</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#1A1814">

--- a/examples/real-apps/realworld_resources/index.html
+++ b/examples/real-apps/realworld_resources/index.html
@@ -2,6 +2,15 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <!-- Conduit routes three segments deep ("/profile/:username/favorites"), and
+       a page's relative URLs resolve against the DOCUMENT url — which, under
+       the default history strategy, is the route. Without this, deep-linking or
+       refreshing on /profile/bob/favorites would resolve every asset below
+       against /profile/bob/, so the page would lose its stylesheet and favicon —
+       and, because main.js is relative too, the app would never boot at all.
+       One <base> fixes all of them; see the Hicasso routing guide, "A route
+       deeper than one segment moves what relative URLs resolve against". -->
+  <base href="/">
   <title>re-frame2 example: realworld on resources (Conduit)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#1A1814">

--- a/implementation/adapters/reagent/test/re_frame/reg_view_devtools_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/reg_view_devtools_cljs_test.cljs
@@ -34,8 +34,7 @@
             [re-frame.core :as rf]
             [re-frame.performance :as performance]
             [re-frame.test-support :as test-support]
-            [re-frame.views])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [re-frame.views]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture

--- a/implementation/adapters/reagent/test/re_frame/source_coord_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/source_coord_dom_cljs_test.cljs
@@ -28,8 +28,7 @@
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
-            [re-frame.views])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [re-frame.views]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture

--- a/implementation/adapters/reagent/test/re_frame/source_coord_warn_once_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/source_coord_warn_once_cljs_test.cljs
@@ -27,8 +27,7 @@
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
-            [re-frame.views])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [re-frame.views]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture

--- a/implementation/adapters/reagent/test/re_frame/view_id_attr_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/view_id_attr_cljs_test.cljs
@@ -27,8 +27,7 @@
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
-            [re-frame.views])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [re-frame.views]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture

--- a/implementation/adapters/reagent/test/re_frame/view_render_trigger_handler_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/view_render_trigger_handler_cljs_test.cljs
@@ -29,8 +29,7 @@
             [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]
             [re-frame.views])
-  (:require-macros [re-frame.core :refer [reg-view]]
-                   [re-frame.test-support :refer [with-trace-recorder!]]))
+  (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture

--- a/implementation/adapters/reagent/test/re_frame/view_rendered_op_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/view_rendered_op_cljs_test.cljs
@@ -25,8 +25,7 @@
             [re-frame.frame :as frame]
             [re-frame.test-support :as test-support]
             [re-frame.epoch]) ;; load so :epoch/run-cause hook is bound
-  (:require-macros [re-frame.core :refer [reg-view]]
-                   [re-frame.test-support :refer [with-trace-recorder!]]))
+  (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture

--- a/implementation/adapters/reagent/test/re_frame/view_side_capture_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/view_side_capture_cljs_test.cljs
@@ -33,8 +33,7 @@
             [re-frame.test-support :as test-support]
             [re-frame.views :as views]
             [re-frame.epoch]) ;; load so :epoch/run-cause hook is bound
-  (:require-macros [re-frame.core :refer [reg-view]]
-                   [re-frame.test-support :refer [with-trace-recorder!]]))
+  (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture

--- a/implementation/adapters/reagent/test/re_frame/views_synthetic_event_frame_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/views_synthetic_event_frame_dom_cljs_test.cljs
@@ -43,7 +43,7 @@
   opts this file into the `:browser-test` build; `:node-test` still loads it
   (matches `cljs-test$`) and the DOM branch self-gates on `(browser?)`,
   exiting early under :node-test where `js/document` is absent."
-  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+  (:require [cljs.test :refer-macros [deftest is use-fixtures async]]
             [reagent.dom.client :as rdc]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]


### PR DESCRIPTION
Two bounded fixes. Both beads' premises were re-derived at source rather than taken on report; where a figure differed, mine is stated.

## rf2-pxzf — the last two deep-routed examples take a `<base href="/">`

The rf2-do50 census found four examples registering routes deeper than one segment while carrying relative asset hrefs. PR #9155 fixed two; these are the other two.

Census re-verified independently rather than assumed: eight files under `examples/` contain `reg-route`, and exactly four register a path deeper than one segment — `capabilities/routing/routing` and `real-apps/realworld_http` (both fixed by #9155), plus the two here. The `/api/...` and `/users/login` literals that a naive sweep also returns are request URLs inside `:request {:url ...}` maps, not routes; `capabilities/ssr/resources_ssr`'s four `reg-route` mentions are all comment prose, so it is route-free as the bead said.

**Measurement is mine and differs from the bead's, because the bead quotes rf2-do50's figure for the OTHER two examples.** Over these two pages' own route tables, with `new URL()` and concrete params: **24 of 64 route x asset combinations resolve wrong without a base, and 0 of 64 with one.** Per example: resources 4 of 16 (its one two-segment route, `/articles/:slug`), realworld_resources 20 of 48 (five routes of two or three segments among twelve).

**The symptom is that the app never boots, not that the page loses styling.** `main.js` is relative on both pages, so six distinct routes ask for it at the wrong path — `/articles/intro` here, and `/article/:slug`, `/editor/:slug`, `/profile/:username`, `/profile/:username/favorites` and `/tag/:tag` in Conduit. Chapter 07's warning describes the merely-unstyled case because it assumes a host page whose script tag is already absolute; these two are not that case.

`<base href="/">` is the second of the two remedies chapter 07 documents, and the one that leaves the asset gate alone. Absolute paths would break it: `check-examples-assets.cjs`'s `resolveRef` special-cases a `_shared/`-prefixed ref against the examples root, so a leading slash falls through to `path.resolve(pageDir, "/...")` and misses on disk — read at source before editing, and confirmed by the planted-fault run below, whose error line shows the `_shared/` resolution happening. `stageShared` copies `_shared` into the same `outDir` that holds `index.html` and `main.js`, so `/` is the correct base for the served stage.

Examples are test-free (rf2-8cevm) and nothing was added under `examples/`. Had a test been possible there, what it would pin is asset resolution under a deep document URL; that coverage belongs where it already is — this gate for the static contract, and the adapter smokes for live mounting.

## rf2-6r9j.26 — eight of ten dead imports removed, two held back

Re-counted at tip: **ten is right**, but only eight land here.

Removed: seven `:require-macros [re-frame.core :refer [reg-view]]` clauses and one `testing` refer. Each was established unused **in its own file, namespace included** — the seven reach the macro as `rf/reg-view` or the plain function `rf/reg-view*`, and `rf` is `[re-frame.core :as rf]` in all seven, checked per file rather than assumed. `core.cljc`'s self-`:require-macros` covers that: its own comment states `(:require [re-frame.core :as rf])` is the only import CLJS apps need.

The six sibling namespaces that DO call `reg-view` bare keep their refer (acceptance criterion 4). They are the control for the census: the same pattern reads 3, 2, 1, 1, 3 and 1 on those and 0 on all seven, so a zero here is a measurement rather than a silent miss. `views_synthetic_event_frame_dom` is one of the six — it loses only its `testing` refer and keeps the macro.

No namespace load is dropped: the seven already require `re-frame.core` in `:require`.

**The two `[re-frame.trace :as trace]` removals are deliberately NOT here.** Both are genuinely dead — but that census needed a second pass, because a `\btrace/` pattern also matches inside the KEYWORD `:rf.trace/trigger-handler` and read 15 false hits in one of the two files; restricted to alias position the count is 0 across the whole reagent test tree, while the same pattern still bites on reagent-slim's real `trace/register-listener!`. Removing them wins ground the ratchet has to be told about: `re-frame.trace`'s canonical alias is `rf.trace`, so `:as trace` is itself a counted violation, and dropping the pair takes `implementation/adapters` from 339 to 337 against a floor of 339 — `check_require_alias_dialect.py` fails from BELOW. Measured both ways: with the pair, exit 1 naming that surface; without it, exit 0 at figures identical to trunk. The floor must move in the SAME commit as the removal or the tree is red either way, so that pair is a separate change against a file this branch does not touch.

## Gates

Every exit code below is the runner's own, captured on the command line that ran it, on the final rebased base.

| Gate | Exit | Result |
| --- | --- | --- |
| `node examples/scripts/check-examples-assets.cjs` | 0 | 33 pages resolve; `_shared` intact |
| `node scripts/check-examples-compile.cjs` | 0 | 58 builds, zero warnings |
| `node scripts/compile-node-test.cjs node-test out/node-test.js` | 0 | 1892 files, 0 warnings |
| `node out/node-test.js` | 0 | 11174 tests / 55752 assertions, 0 failures, 0 errors |
| `python scripts/check_require_alias_dialect.py --verbose` | 0 | 2773 files / 10773 edges / 5640 non-canonical, every surface at or under floor |

**Planted faults, both restored and verified by blob hash.** A broken `_shared` stylesheet ref reddened the asset gate at exit 1, naming the planted ref. Replacing the `reg-view` refer in `auto_inject_form2_cljs_test.cljs` — a file that calls it bare three times — reddened the CLJS compile at exit 1 with `:undeclared-var .../reg-view` at the exact line, which is the control for the seven removals actually made.

**One gate needed three attempts, and the first two failures were not real.** `check-examples-compile` stopped twice at build 22 of 58 with exit -1 and, tellingly, no error block at all — where a genuine compile error prints file and line, as the planted fault did. The build compiles green in isolation; more decisively, restoring the changed files recompiles **0** namespaces in it, so those files are not in its graph and cannot be its cause. A run with the changes reverted to trunk passed 58/58, and a third run with the changes restored also passed 58/58.

Table column counts and the one cross-reference to `docs/core/hicasso/07-routing-and-navigation.md` were checked by hand: the cited heading exists, verified both line-oriented and with whitespace flattened.
