### PR TITLE
refactor: remove three superseded vestiges (rf2-6r9j.44, rf2-6r9j.23, rf2-6r9j.249)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -2034,8 +2034,9 @@
 ;; the owner of the payload shape; registration-owned `:sensitive` payload
 ;; classification + centralized `project-egress` at egress boundaries
 ;; replace it. The `re-frame.privacy/redact-interceptor` fn (and the
-;; router's internal `redact-interceptor?` consumer) remain as internal
-;; plumbing, but the var is no longer published from this façade.
+;; router's internal `collect-redaction-paths` consumer, which matches
+;; `redact-interceptor-id` itself) remain as internal plumbing, but the
+;; var is no longer published from this façade.
 
 ;; ---- privacy / spec / trace / emit / elision (Spec 009, 010) -------------
 

--- a/implementation/core/src/re_frame/privacy.cljc
+++ b/implementation/core/src/re_frame/privacy.cljc
@@ -264,28 +264,9 @@
               scrubbed (redact-event base paths)]
           (assoc ctx :rf/redacted-event scrubbed))))))
 
-(defn- redact-interceptor?
-  [interceptor]
-  (and (map? interceptor)
-       (= redact-interceptor-id (:id interceptor))))
-
-(defn user-redaction-paths
-  "Walk an interceptor chain and return the concatenated `:paths` vectors
-  of every `redact-interceptor` interceptor it contains.
-
-  Read by the router at chain-assembly time so the pre-chain trace events
-  (`:run-start`, `emit-pipeline-trailers`'s `:run-end`) and the frame-
-  classification emit-event projection both honour user-declared payload
-  paths."
-  [interceptors]
-  (into []
-        (comp (filter redact-interceptor?)
-              (mapcat :paths))
-        interceptors))
-
 (defn collect-redaction-paths
-  "Single-pass fusion of
-  `schema-redaction-paths` + `user-redaction-paths` over the SAME
+  "Single-pass fusion of the schema-redaction walk and the
+  user-declared `redact-interceptor` `:paths` walk over the SAME
   resolved interceptor chain — read together by the router's
   `prepare-handler-ctx` on every dispatch.
 
@@ -295,8 +276,9 @@
     * the `redact-interceptor` `:paths` (user-declared payload paths).
 
   Returns `{:schema-paths <vec> :user-paths <vec>}`, behaviour-identical
-  to calling `schema-redaction-paths` and `user-redaction-paths`
-  separately. The schema-path overlap is only computed when the frame
+  to walking the chain twice — once for `schema-redaction-paths`, once
+  for the `redact-interceptor` `:paths`. The schema-path overlap is only
+  computed when the frame
   declares ≥1 sensitive app-db path (the dominant no-classification path
   skips the overlap `mapcat` entirely); the single chain walk
   collects `:path` slices unconditionally so the overlap, when needed,

--- a/implementation/core/test/re_frame/redact_interceptor_test.clj
+++ b/implementation/core/test/re_frame/redact_interceptor_test.clj
@@ -316,7 +316,7 @@
     ;; reference it twice with different `[id arg]` args. The factory returns a
     ;; `redact-interceptor` value whose `:id` is already `:rf/redact-interceptor`
     ;; (matching the registration id the resolver re-stamps), so the router's
-    ;; `redact-interceptor?` recognition (`:id = :rf/redact-interceptor`) and the
+    ;; `collect-redaction-paths` recognition (`:id = :rf/redact-interceptor`) and the
     ;; per-value `:paths` both survive resolution — the union is scrubbed.
     (rf/reg-interceptor :rf/redact-interceptor
       {:factory (fn [paths] (rf.privacy/redact-interceptor paths))})

--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -322,7 +322,7 @@
                 ;; hydrates into a working SPA. A post-render recovered-to-nil
                 ;; 5xx is caught inside `build-full-response`.
                 :else
-                (pipeline/build-full-response frame-id response opts)))
+                (pipeline/build-full-response frame-id opts)))
             (catch Throwable t
               ;; A failing caller hook falls back to the locked response.
               (lifecycle/safe-on-error on-error request t))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -592,7 +592,7 @@
   Body render, head, and hydration projection share one frame scope. This
   is required for registered lookups and frame-sensitive egress
   classification."
-  [frame-id resp
+  [frame-id
    {:keys [renderer emit-hash? version schema-digest payload
            html-shell content-type client-frame-id]
     :as   opts}]
@@ -776,9 +776,9 @@
   Content-Type negotiator, or a re-throw from the projector pipeline
   itself when no server frame is registered). Those use the fixed, no-detail
   transport fallback."
-  [frame-id resp opts]
+  [frame-id opts]
   (try
-    (build-full-response* frame-id resp opts)
+    (build-full-response* frame-id opts)
     (catch Throwable t
       ;; The projector stamps :status onto the response accumulator and
       ;; the projected (fail-closed, non-200) error body is materialised

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/resource_payload_projection_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/resource_payload_projection_test.clj
@@ -175,7 +175,7 @@
                         ;; whole-app-db so the test isolates the runtime-db
                         ;; resource projection, not the app-db allowlist.
                         :payload    :rf.ssr.payload/whole-app-db}
-              resp     (#'pipeline/build-full-response* fid {:status 200} opts)
+              resp     (#'pipeline/build-full-response* fid opts)
               body     (:body resp)
               payload  (payload-edn body)
               entries  (get-in payload [:rf/runtime-db
@@ -227,7 +227,7 @@
                         :emit-hash? true
                         :html-shell shell/default-html-shell
                         :payload    :rf.ssr.payload/whole-app-db}
-              resp     (#'pipeline/build-full-response* fid {:status 200} opts)
+              resp     (#'pipeline/build-full-response* fid opts)
               body     (:body resp)
               payload  (payload-edn body)
               entries  (get-in payload [:rf/runtime-db
@@ -303,7 +303,7 @@
                          :emit-hash? true
                          :html-shell shell/default-html-shell
                          :payload    :rf.ssr.payload/whole-app-db}
-                resp    (#'pipeline/build-full-response* fid {:status 200} opts)
+                resp    (#'pipeline/build-full-response* fid opts)
                 payload (payload-edn (:body resp))
                 we      (val (first (get-in payload [:rf/runtime-db
                                                      :rf.runtime/resources

--- a/tools/xray/src/day8/re_frame2_xray/panels/issues_ribbon_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/issues_ribbon_helpers.cljc
@@ -381,22 +381,6 @@
      :epoch-id   (:epoch-id epoch-record)
      :empty-kind empty-kind}))
 
-;; ---- issue-bearing epoch predicate --------------------------------------
-
-(defn epoch-has-issues?
-  "True iff `epoch-record`'s `:trace-events` carry at least one issue
-  (any severity). Pure data → bool; JVM-testable.
-
-  Written for the film-strip header's `:filter-fn` slot (spec/021 §8.5
-  stretch — 'next epoch with ⚠'). That header was removed unmounted by
-  rf2-6r9j.16: spine navigation is the L2 events list's, not any L4
-  panel's. The predicate survives as pure, test-covered algebra with no
-  current caller — wire it to a real surface or retire it, but do not
-  read it as evidence that a per-panel epoch filter exists."
-  [epoch-record]
-  (boolean
-    (some issue-event?
-          (or (:trace-events epoch-record) []))))
 
 ;; ---- focus-status resolver ----------------------------------------------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/l2_timeline.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/l2_timeline.cljc
@@ -271,9 +271,6 @@
 ;; into a small flag map and the renderer reads the flags — cheaper
 ;; than walking the slot per badge and more testable.
 
-(defn- str-of [x]
-  (when (some? x) (str x)))
-
 (defn- op-namespace
   "Return the namespace string of a keyword `:operation` value, or nil
   when the operation is not a keyword. Defence-in-depth — synthetic

--- a/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
@@ -150,17 +150,6 @@
    :padding          "4px 8px"
    :border-radius    "3px"})
 
-(defn- primary-button-style []
-  {:background       (:accent tokens)
-   :color            (:white tokens)
-   :border           "none"
-   :padding          "6px 14px"
-   :border-radius    "4px"
-   :cursor           "pointer"
-   :font-family      sans-stack
-   :font-size        (:body type-scale)
-   :font-weight      500})
-
 ;; ---- tab strip ----------------------------------------------------------
 
 (def ^:private tabs

--- a/tools/xray/test/day8/re_frame2_xray/panels/issues_ribbon_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/issues_ribbon_helpers_cljs_test.cljc
@@ -26,8 +26,7 @@
        (rf2-ad7zx.9 — pure rows per the Figma design).
     7. **resolve-focus-status / find-epoch-record** — focus + history
        resolver.
-    8. **epoch-has-issues?** — issue-bearing epoch predicate.
-    9. **format-time** — renders a stable HH:MM:SS.mmm string."
+    8. **format-time** — renders a stable HH:MM:SS.mmm string."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [day8.re-frame2-xray.panels.issues-ribbon-helpers :as h]
@@ -435,24 +434,6 @@
       (is (= 4 (:total feed)))
       (is (= 4 (:rendered feed)))
       (is (= #{1 2 3 4} (set (map :id (:issues feed))))))))
-
-;; ---- (9) issue-bearing epoch predicate -----------------------------
-
-(deftest epoch-has-issues?-empty-record
-  (is (false? (h/epoch-has-issues? nil)))
-  (is (false? (h/epoch-has-issues? {})))
-  (is (false? (h/epoch-has-issues? (epoch-record 1 [])))))
-
-(deftest epoch-has-issues?-only-non-issues
-  (is (false? (h/epoch-has-issues?
-                (epoch-record 1 [(non-issue-ev 1) (non-issue-ev 2)])))))
-
-(deftest epoch-has-issues?-with-issue
-  (is (true? (h/epoch-has-issues?
-               (epoch-record 1 [(non-issue-ev 1)
-                                (warning-ev 2 :rf.warning/recoverable)]))))
-  (is (true? (h/epoch-has-issues?
-               (epoch-record 1 [(error-ev 1 :rf.error/handler-exception)])))))
 
 ;; ---- (10) format-time ---------------------------------------------
 

--- a/tools/xray/testbeds/panel_gallery/fixtures.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures.cljs
@@ -251,23 +251,6 @@
   []
   (cascade-with-other 100 50))
 
-(defn long-handler-buffer
-  "A buffer of cascades whose `:run-end` rows carry a wide spread of
-  `:duration-ms` values so the panel's duration chrome is visible
-  across the cascade list."
-  []
-  (->> [{:dispatch-id 100 :event-vec [:counter/increment] :id-base 50  :duration 1}
-        {:dispatch-id 101 :event-vec [:cart/add-item :apple] :id-base 100 :duration 6}
-        {:dispatch-id 102 :event-vec [:report/render-table] :id-base 150 :duration 22}
-        {:dispatch-id 103 :event-vec [:dashboard/refresh] :id-base 200 :duration 87}
-        {:dispatch-id 104 :event-vec [:scenario/replay] :id-base 250 :duration 312}]
-       (mapcat (fn [{:keys [dispatch-id event-vec id-base duration]}]
-                 (-> (cascade-evs dispatch-id event-vec id-base)
-                     ;; Patch the run-end emit's :duration-ms so the
-                     ;; rendered duration reflects the variant's intent.
-                     (update 2 update :tags assoc :duration-ms duration))))
-       vec))
-
 ;; ---- specialised cascade builders --------------------------------------
 
 (defn exception-cascade-buffer


### PR DESCRIPTION
Three bounded removals of code a later landing superseded. Three trees, no overlap.

## rf2-6r9j.44 — ssr-ring: the pre-render `resp` argument

`build-full-response*` and `build-full-response` (`ssr/ring/pipeline.clj`) drop the `resp` parameter. The private fn never read it — the only bare `resp` in its body was the parameter binding — and the wrapper only forwarded it, its catch arm deriving the response from `project-render-throw->ring-response` instead. Commit `2a97334c07` replaced the read with the post-render flush and `555038b12f` strengthened it to `flush-response-result!`; the parameter and every call argument were left behind.

`ssr-handler` KEEPS its pre-render `response` binding: it is still consumed by the redirect branch (`ring.clj:308-309`) and the projected-5xx branch (`:317`). Only the argument at the happy-path call goes. The three focused tests stop passing a dummy `{:status 200}`.

The bead's line numbers had drifted (`build-full-response*` is at 588, not 569) because the `:renderer` seam landed in between; the dataflow claim itself held exactly.

## rf2-6r9j.23 — core: the redaction helper pair

`user-redaction-paths` and its now-exclusive private helper `redact-interceptor?` are removed from `re-frame.privacy`, superseded by the single-pass `collect-redaction-paths`, which does its own `(= redact-interceptor-id (:id interceptor))` match. Retained and verified still resolving: `schema-redaction-paths`, `redact-interceptor`, `redact-interceptor-id`, `collect-redaction-paths`.

**Public-facade classification — the facade export set does NOT change.** `re-frame.core` exports exactly one symbol from `re-frame.privacy`, `sensitive?`, and neither removed symbol was ever exported: `user-redaction-paths` appeared nowhere in `core.cljc`, and `redact-interceptor?` appeared only inside a comment. Neither is pinned in `spec/api-manifest.edn` or `spec/api-manifest-metadata.edn` (both read zero, against a control symbol that reads 2 and 3 hits respectively). So this is an internal-plumbing removal, not a public-surface change, and it needs no back-compat shim.

Two stale claims are corrected rather than left standing, per the bead's acceptance criteria. The EP-0015 §7 comment in `core.cljc` named `redact-interceptor?` as "the router's internal consumer" — it now names `collect-redaction-paths`. A comment in `redact_interceptor_test.clj` made the same claim and is corrected the same way; no test behaviour is touched.

## rf2-6r9j.249 — xray: four zero-consumer helpers

Re-counted at tip: **four**, as the bead states. `epoch-has-issues?` (`panels/issues_ribbon_helpers.cljc`, plus its three self-only deftests and its entry in the test ns's contents list), `long-handler-buffer` (`testbeds/panel_gallery/fixtures.cljs`), private `str-of` (`panels/l2_timeline.cljc`) and private `primary-button-style` (`settings/view.cljs`). `epoch-has-issues?`'s own docstring already recorded that it had no caller and invited either wiring or retirement; the bead rules retirement.

`issue-event?`, which `epoch-has-issues?` called, is public and heavily used elsewhere — it survives untouched. The test-file fixture builders the removed deftests used (`non-issue-ev`, `epoch-record`, `warning-ev`, `error-ev`, `advisory-ev`) all remain in use by other tests.

The test ns's contents list is renumbered only across the removed entry, to keep that list contiguous. The body's section headers already ran 1–14 with 6 missing and were independently out of step with that list before this change, so they are left alone rather than renumbered.

**tools/xray spec: unchanged, because none of the four symbols is named or contracted in `tools/xray/spec/*`.** Verified with two instruments (line-oriented and whitespace-flattened), both reading zero, against a control symbol (`issue-event?`) that reads 4 hits in that tree.

## How "zero consumer" was established

Per symbol, not per file, and with every zero controlled:

- Two independent instruments — `git grep` and a plain recursive `grep` — agreeing on every symbol.
- Bare-symbol regexes rather than call forms, since a Clojure call site wraps. A census for the SYMBOL then reading each hit is what caught that three of `str-of`'s four repo-wide hits were `pr-str-of-form` / `pr-str-of-rejection` — different tokens in unrelated namespaces.
- Namespace and arity checked, not just the symbol: `pipeline.clj` has two other functions with their own `resp` binding, and those are untouched.
- Every zero controlled against something the pattern should find, sharing the target's shape. This caught a real defect in the census itself: an early pattern excluded `/` on the left and so could not see namespace-qualified calls like `h/epoch-has-issues?`, reading zero where ten hits existed. The pattern was corrected and every census re-run.
- Fixture consumers specifically controlled: other fixtures in the same file read 25, 8 and 7 hits under the same pattern, so the instrument demonstrably finds cross-namespace fixture use.

## Gates

Every exit code below is the runner's own, captured on the same command line as the redirect, never read through a pipeline.

| Gate | Exit |
| --- | --- |
| `check_require_alias_dialect.py --verbose` | 0 |
| ssr-ring `clojure -M:test` | 0 — 231 tests / 1163 assertions |
| core `clojure -M:test` (JVM) | 0 — 2177 tests / 11155 assertions |
| core CLJS compile (`compile-node-test.cjs`) | 0 — 1892 files, 0 warnings |
| core CLJS run (`node out/node-test.js`) | 0 — 11171 tests / 55746 assertions |
| `scripts/test-jvm-tools.sh` (10 artefacts) | 0 — xray 1270 tests / 6100 assertions |
| shadow-cljs compile `testbeds/panel-gallery` | 0 — 710 files, 0 warnings |

**The alias ratchet did not move**: 2773 files / 10773 edges / 5640 non-canonical, identical before and after. It is two-sided and deleting code can red it from below, so it was read in both directions.

Re-run on the final base after rebasing: ratchet, ssr-ring, xray JVM, core JVM and the panel-gallery compile, all green again. The CLJS pair was not re-run because `implementation/` and `tools/` are byte-identical across the rebase — the six commits in the interval touched only `.beads/issues.jsonl`, `.github/workflows/test.yml` and two `.md` files — so that suite's entire input tree is unchanged.

## Sabotage checks

Each removal was verified by reintroducing a call and confirming it fails, which is what separates "nothing used it" from "the suite does not cover it":

- Reinstating the 3-arity call to `build-full-response*` → ssr-ring suite exit **1**, `ArityException: Wrong number of args (3) passed to build-full-response*`.
- Calling the removed `user-redaction-paths` → exit **1**, `No such var`. Calling the removed private `redact-interceptor?` → exit **1**, `Unable to resolve var`. A control in the same probe confirms all three retained symbols still resolve.
- Referencing `fixtures/long-handler-buffer` from `gallery_chrome.cljs` → the compile reports `Use of undeclared Var panel-gallery.fixtures/long-handler-buffer`, 1 warning against a 0-warning baseline. **Worth flagging: shadow-cljs grades this as a WARNING and still exits 0**, so for this gate the discriminating signal is the warning count, not the exit code.
- A deliberately non-canonical require alias → ratchet exit **1**, naming the planted line.
- A JVM probe confirms the retained `issue-event?` resolves while both removed xray symbols do not.

Every planted file was restored and verified by git blob hash, not by reading a diff.
