### PR TITLE
refactor(tests): canonical rf.* require aliases in four conformance surfaces (rf2-7sx1)

### DIFF
--- a/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
+++ b/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
@@ -20,34 +20,34 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.set :as set]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.frame :as frame]
-            [re-frame.derivation.graph :as graph]
-            [re-frame.schemas :as schemas]
-            [re-frame.flows :as flows]
+            [re-frame.fx :as rf.fx]
+            [re-frame.frame :as rf.frame]
+            [re-frame.derivation.graph :as rf.derivation.graph]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.flows :as rf.flows]
             ;; The graph-wide egress projection lives in core so conformance
             ;; can test the same implementation used by tool consumers without
             ;; introducing a dependency on `tools/`.
-            [re-frame.derivation.egress :as egress]
-            [re-frame.privacy :as privacy]
-            [re-frame.elision :as elision]
+            [re-frame.derivation.egress :as rf.derivation.egress]
+            [re-frame.privacy :as rf.privacy]
+            [re-frame.elision :as rf.elision]
             ;; Load-bearing requires: each facade installs its framework
             ;; registrations before the graph contributors are exercised.
             [re-frame.routing]
-            [re-frame.routing.tooling :as routing-tooling]
+            [re-frame.routing.tooling :as rf.routing.tooling]
             [re-frame.resources]
-            [re-frame.resources.tooling :as resources-tooling]
-            [re-frame.resources.state :as resources-state]
-            [re-frame.resources.work-ledger :as work-ledger]
-            [re-frame.machines.tooling :as machines-tooling]
-            [re-frame.machines.paths :as machine-paths]
+            [re-frame.resources.tooling :as rf.resources.tooling]
+            [re-frame.resources.state :as rf.resources.state]
+            [re-frame.resources.work-ledger :as rf.resources.work-ledger]
+            [re-frame.machines.tooling :as rf.machines.tooling]
+            [re-frame.machines.paths :as rf.machines.paths]
             ;; The CLJS lifecycle arm drives the cache through the internal
             ;; subscribe/unsubscribe operations.
-            [re-frame.subs :as subs]
-            [re-frame.subs.tooling :as subs-tooling]
-            [re-frame.flows.tooling :as flows-tooling]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.subs :as rf.subs]
+            [re-frame.subs.tooling :as rf.subs.tooling]
+            [re-frame.flows.tooling :as rf.flows.tooling]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---------------------------------------------------------------------------
 ;; Closed vocabularies from `spec/Derivations.md` and `spec/Spec-Schemas.md`.
@@ -89,17 +89,17 @@
 ;; plain-atom substrate into later React-backed suites. `:init-fn` reloads the
 ;; optional family registrations after the baseline has been restored.
 (defn- refresh-families! []
-  (flows/reset-flows!)
-  (flows/reset-last-inputs!)
-  (schemas/clear-schemas-by-frame!)
+  (rf.flows/reset-flows!)
+  (rf.flows/reset-last-inputs!)
+  (rf.schemas/clear-schemas-by-frame!)
   #?(:clj (do (require 're-frame.routing :reload)
               (require 're-frame.resources :reload)
               (require 're-frame.machines :reload)))
-  (frame/ensure-default-frame!))
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      :init-fn refresh-families!}))
 
 ;; ---------------------------------------------------------------------------
@@ -108,22 +108,22 @@
 ;; ---------------------------------------------------------------------------
 
 (def all-contributors
-  {:subs      {:static-fn  subs-tooling/sub-algebra-view
-               :live-fn    subs-tooling/sub-cache-algebra-view
+  {:subs      {:static-fn  rf.subs.tooling/sub-algebra-view
+               :live-fn    rf.subs.tooling/sub-cache-algebra-view
                :live-shape :map}
-   :flows     {:static-fn  flows-tooling/flow-algebra-view
-               :live-fn    flows-tooling/flow-algebra-view
+   :flows     {:static-fn  rf.flows.tooling/flow-algebra-view
+               :live-fn    rf.flows.tooling/flow-algebra-view
                :live-shape :map}
-   :resources {:static-fn  resources-tooling/resource-algebra-view
-               :live-fn    resources-tooling/resource-cache-algebra-view
+   :resources {:static-fn  rf.resources.tooling/resource-algebra-view
+               :live-fn    rf.resources.tooling/resource-cache-algebra-view
                :live-shape :map}
-   :routes    {:static-fn  routing-tooling/route-algebra-view
-               :live-fn    routing-tooling/route-slice-algebra-view
+   :routes    {:static-fn  rf.routing.tooling/route-algebra-view
+               :live-fn    rf.routing.tooling/route-slice-algebra-view
                :live-shape :node}
-   :machines  {:static-fn         machines-tooling/machine-algebra-view
-               :live-fn           machines-tooling/machine-instance-algebra-view
+   :machines  {:static-fn         rf.machines.tooling/machine-algebra-view
+               :live-fn           rf.machines.tooling/machine-instance-algebra-view
                :live-shape        :map
-               :selector-targets  machines-tooling/machine-selector-targets}})
+               :selector-targets  rf.machines.tooling/machine-selector-targets}})
 
 ;; ---------------------------------------------------------------------------
 ;; The subscription and flow share one whole-value function and differ only in
@@ -203,7 +203,7 @@
 
 (deftest a-every-source-form-lowers-to-a-node-of-the-right-superkind
   (register-one-of-each!)
-  (let [nodes (:nodes (graph/derivation-graph all-contributors))]
+  (let [nodes (:nodes (rf.derivation.graph/derivation-graph all-contributors))]
     (testing "all five families lowered into the assembled graph"
       (is (= #{:subs :flows :resources :routes :machines}
              (->> nodes vals (map :rf/family) set))
@@ -264,7 +264,7 @@
 
 (deftest b-storage-evaluation-lifecycle-classified-per-family
   (register-one-of-each!)
-  (let [nodes (:nodes (graph/derivation-graph all-contributors))
+  (let [nodes (:nodes (rf.derivation.graph/derivation-graph all-contributors))
         sub   (node-by-family nodes :subs      :cart/total)
         flow  (node-by-family nodes :flows     :cart/materialized-total)
         res   (node-by-family nodes :resources :article/by-slug)
@@ -305,7 +305,7 @@
 
 (deftest b-every-classification-is-in-its-closed-vocabulary
   (register-one-of-each!)
-  (let [nodes (:nodes (graph/derivation-graph all-contributors))]
+  (let [nodes (:nodes (rf.derivation.graph/derivation-graph all-contributors))]
     (testing "every classification is in its closed set"
       (doseq [[node-id node] nodes]
         ;; Storage is one local class; authority is checked separately.
@@ -327,7 +327,7 @@
 (deftest b-external-authority-names-its-local-storage-separately
   ;; Authority names the source of truth; storage still names the local home.
   (register-one-of-each!)
-  (let [nodes (:nodes (graph/derivation-graph all-contributors))
+  (let [nodes (:nodes (rf.derivation.graph/derivation-graph all-contributors))
         res   (node-by-family nodes :resources :article/by-slug)]
     (is (= :remote     (get-in res [:authority :kind])))
     (is (= :runtime-db (:storage res))
@@ -342,7 +342,7 @@
 
 (deftest c-static-edges-span-input-param-selector
   (register-one-of-each!)
-  (let [edges (:edges (graph/derivation-graph all-contributors))
+  (let [edges (:edges (rf.derivation.graph/derivation-graph all-contributors))
         roles (->> edges (map :role) set)]
     (testing "an :input edge follows the static `:<-` chain (cart/items → cart/total)"
       (is (some #(= % {:from [:sub :cart/items] :to [:sub :cart/total] :role :input})
@@ -368,7 +368,7 @@
   ;; input-fn, so a parametric sub reports the :parametric marker and
   ;; contributes no static :input edge. Its realized edges are live-only.
   (register-one-of-each!)
-  (let [g    (graph/derivation-graph all-contributors)
+  (let [g    (rf.derivation.graph/derivation-graph all-contributors)
         node (get (:nodes g) [:sub :article/page])]
     (is (some? node) "the parametric sub node is present")
     (is (= :parametric (:inputs node)) "its declared inputs are the :parametric marker")
@@ -389,7 +389,7 @@
                     :params-schema [:map [:page :int]]}
                    (fn [{:keys [page]} _ctx]
                      {:request {:method :get :url "/api/feed" :params {:page page}}}))
-  (let [nodes (:nodes (graph/derivation-graph all-contributors))
+  (let [nodes (:nodes (rf.derivation.graph/derivation-graph all-contributors))
         res   (node-by-family nodes :resources :tenant/feed)]
     (is (some? res) "the {:from-db} resource composed into the umbrella cross-family graph")
     (testing "the named-resolver reference remains a static scope input"
@@ -409,7 +409,7 @@
   ;; matched route id, its params, and the route owner (nav-token), facts
   ;; that exist only after a navigation commits to runtime-db.
   (register-one-of-each!)
-  (let [g0 (graph/live-derivation-graph :rf/default all-contributors)]
+  (let [g0 (rf.derivation.graph/live-derivation-graph :rf/default all-contributors)]
     (testing "the live graph always carries the :mode :live + :frame shape"
       (is (= :live (:mode g0)))
       (is (= :rf/default (:frame g0)))
@@ -417,7 +417,7 @@
       (is (vector? (:edges g0)))))
   ;; Drive a navigation so the route slice is materialized in runtime-db.
   (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "welcome"}}])
-  (let [g     (graph/live-derivation-graph :rf/default all-contributors)
+  (let [g     (rf.derivation.graph/live-derivation-graph :rf/default all-contributors)
         slice (get (:nodes g) :rf/route)]
     ;; Assert setup explicitly so the remaining checks cannot pass vacuously.
     (testing "the navigation materialized the live route slice"
@@ -517,7 +517,7 @@
                    :storage :runtime-db :evaluation :on-route :lifecycle :frame})}})
 
 (deftest cplus-live-graph-realizes-non-route-nodes-and-edges
-  (let [g     (graph/live-derivation-graph :rf/default (live-composition-contributors))
+  (let [g     (rf.derivation.graph/live-derivation-graph :rf/default (live-composition-contributors))
         nodes (:nodes g)
         edges (:edges g)]
     (testing "realized sub nodes are wrapped by their concrete query vector
@@ -654,7 +654,7 @@
    {:from [:sub :a] :to [:sub :c] :role :input}])
 
 (deftest cplusplus-edge-order-is-canonical-across-registration-permutations
-  (let [baseline (graph/derivation-graph (permutation-contributors [:a :b :c] [:r1 :r2] true))]
+  (let [baseline (rf.derivation.graph/derivation-graph (permutation-contributors [:a :b :c] [:r1 :r2] true))]
     (testing "the de-duplicated edge SET is the four expected edges (the
               duplicated `[:sub [:a]]` input on `:b` collapsed to ONE edge —
               distinct runs BEFORE canonicalization)"
@@ -683,7 +683,7 @@
       (doseq [sub-order   (permutations-of [:a :b :c])
               route-order (permutations-of [:r1 :r2])
               slug-first? [true false]]
-        (let [g (graph/derivation-graph
+        (let [g (rf.derivation.graph/derivation-graph
                   (permutation-contributors sub-order route-order slug-first?))]
           (is (= permutation-expected-edges (:edges g))
               (str "edges must equal the canonical order for sub-order "
@@ -698,7 +698,7 @@
       (doseq [slug-first? [true false]]
         (let [serials (for [sub-order   (permutations-of [:a :b :c])
                             route-order (permutations-of [:r1 :r2])]
-                        (pr-str (:edges (graph/derivation-graph
+                        (pr-str (:edges (rf.derivation.graph/derivation-graph
                                           (permutation-contributors sub-order route-order slug-first?)))))]
           (is (= 1 (count (distinct serials)))
               (str "all permutations must serialize `:edges` identically (slug-first? "
@@ -718,7 +718,7 @@
   ;; Seed the flow input. The flow runs :after-event (same-commit
   ;; materialization), so after this dispatch the output path is settled.
   (rf/dispatch-sync [::seed-cart cart-items])
-  (let [app-db        (frame/frame-app-db-value :rf/default)
+  (let [app-db        (rf.frame/frame-app-db-value :rf/default)
         materialized  (get-in app-db [:cart :total])
         whole-value   (sum-cart (get-in app-db [:cart :items]))]
     (is (= whole-value materialized)
@@ -736,7 +736,7 @@
   ;; `:derive` tokens are distinct objects through the registrar. The graph
   ;; treats those executable tokens as opaque.
   (register-one-of-each!)
-  (let [nodes (:nodes (graph/derivation-graph all-contributors))
+  (let [nodes (:nodes (rf.derivation.graph/derivation-graph all-contributors))
         sub   (node-by-family nodes :subs  :cart/total)
         flow  (node-by-family nodes :flows :cart/materialized-total)]
     (testing "both carry an opaque :derive whole-value token (never serialized)"
@@ -765,7 +765,7 @@
   ;; The optional delta law applies only when an executable delta protocol is
   ;; present. The current implementation remains whole-value only.
   (register-one-of-each!)
-  (let [nodes (:nodes (graph/derivation-graph all-contributors))]
+  (let [nodes (:nodes (rf.derivation.graph/derivation-graph all-contributors))]
     (doseq [[node-id node] nodes]
       (is (not (contains? node :step-delta))
           (str node-id " carries a :step-delta — slice-1 ships no delta protocol")))))
@@ -788,7 +788,7 @@
   (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "welcome"}}]
                     {:frame :checkout/frame})
   (rf/dispatch-sync [:upload/main [:upload/start]] {:frame :checkout/frame})
-  (let [g-before (graph/live-derivation-graph :checkout/frame all-contributors)
+  (let [g-before (rf.derivation.graph/live-derivation-graph :checkout/frame all-contributors)
         nodes    (:nodes g-before)]
     ;; Assert setup before teardown so absence afterwards cannot pass vacuously.
     (testing "the setup dispatches materialized both frame-owned nodes"
@@ -800,8 +800,8 @@
       (let [slice (get nodes :rf/route)]
         (is (= :frame (:lifecycle slice)))
         (is (= [:route :route/article (:nav-token slice)] (:owner slice)))))
-    (frame/destroy-frame! :checkout/frame)
-    (let [g-after (graph/live-derivation-graph :checkout/frame all-contributors)]
+    (rf.frame/destroy-frame! :checkout/frame)
+    (let [g-after (rf.derivation.graph/live-derivation-graph :checkout/frame all-contributors)]
       (testing "destroy-frame! releases every frame-owned graph node"
         (is (= :live (:mode g-after)) "the live graph shape survives a destroyed frame")
         (is (= {} (:nodes g-after))
@@ -818,7 +818,7 @@
   (register-one-of-each!)
   (rf/reg-route :route/about {} "/about")
   (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "welcome"}}])
-  (let [g-a   (graph/live-derivation-graph :rf/default all-contributors)
+  (let [g-a   (rf.derivation.graph/live-derivation-graph :rf/default all-contributors)
         slice (get (:nodes g-a) :rf/route)]
     (testing "the first navigation materialized the route-A slice"
       (is (some? slice)
@@ -830,7 +830,7 @@
         (is (= [:route :route/article nav-token-a] owner-a)))
       ;; Supersede: a second navigation commits a new slice.
       (rf/dispatch-sync [:rf.route/navigate {:to :route/about}])
-      (let [g-b      (graph/live-derivation-graph :rf/default all-contributors)
+      (let [g-b      (rf.derivation.graph/live-derivation-graph :rf/default all-contributors)
             slice-b  (get (:nodes g-b) :rf/route)]
         (testing "the superseding navigation materialized the route-B slice"
           (is (some? slice-b)
@@ -880,8 +880,8 @@
   ;; the GENUINE live nav-token owner minted by the real navigation, and the
   ;; RELEASE is driven entirely by the real supersession hook — never by editing
   ;; the post-state.
-  (fx/reg-fx :rf.http/managed       (fn [_ctx _args] nil))
-  (fx/reg-fx :rf.http/managed-abort (fn [_ctx _args] nil))
+  (rf.fx/reg-fx :rf.http/managed       (fn [_ctx _args] nil))
+  (rf.fx/reg-fx :rf.http/managed-abort (fn [_ctx _args] nil))
   (rf/reg-resource :article/by-slug
                    {:scope         :rf.scope/global
                     :params-schema [:map [:slug :string]]}
@@ -896,40 +896,40 @@
   (rf/reg-route :route/about {} "/about")
   ;; --- Navigate to route A: the real navigation mints the route owner. ---
   (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:slug "welcome"}}])
-  (let [owner-a    (:owner (routing-tooling/route-slice-algebra-view :rf/default))
+  (let [owner-a    (:owner (rf.routing.tooling/route-slice-algebra-view :rf/default))
         scope      :rf.scope/global
         params     {:slug "welcome"}
-        scoped-key (resources-state/scoped-resource-key scope :article/by-slug params)
-        k-id       (resources-state/key-id scoped-key)
-        work-id    (work-ledger/resource-work-id scoped-key 1)
-        entry      (-> (resources-state/empty-entry :article/by-slug scoped-key)
-                       (resources-state/attach-owner owner-a)
+        scoped-key (rf.resources.state/scoped-resource-key scope :article/by-slug params)
+        k-id       (rf.resources.state/key-id scoped-key)
+        work-id    (rf.resources.work-ledger/resource-work-id scoped-key 1)
+        entry      (-> (rf.resources.state/empty-entry :article/by-slug scoped-key)
+                       (rf.resources.state/attach-owner owner-a)
                        (assoc :status :fetching :current-work work-id))]
-    (is (= [:route :route/article (:nav-token (routing-tooling/route-slice-algebra-view :rf/default))]
+    (is (= [:route :route/article (:nav-token (rf.routing.tooling/route-slice-algebra-view :rf/default))]
            owner-a)
         "the real navigation minted the route-A owner [:route route-A nav-token]")
     ;; Materialize the route-owned cache row with the canonical constructors
     ;; (resource entry + its reverse owner-index member + the in-flight work
     ;; record) — the shape a real route-owned fetch produces. This is test setup,
     ;; NOT the release under grade.
-    (frame/swap-runtime-db!
+    (rf.frame/swap-runtime-db!
       :rf/default
       (fn [rdb]
         (-> (or rdb {})
-            (assoc-in (resources-state/entry-path scoped-key) entry)
-            (assoc-in (conj (resources-state/owner-index-path) owner-a) #{k-id})
-            (work-ledger/put-record
+            (assoc-in (rf.resources.state/entry-path scoped-key) entry)
+            (assoc-in (conj (rf.resources.state/owner-index-path) owner-a) #{k-id})
+            (rf.resources.work-ledger/put-record
               work-id
-              (work-ledger/work-record {:work-id      work-id
+              (rf.resources.work-ledger/work-record {:work-id      work-id
                                         :frame-id     :rf/default
                                         :resource/key scoped-key
                                         :generation   1
                                         :transport    :rf.http/managed
                                         :owner        owner-a
                                         :cause        :test/materialize})))))
-    (let [entry-a       (get-in (frame/frame-runtime-db-value :rf/default)
-                                (resources-state/entry-path scoped-key))
-          g-a           (graph/live-derivation-graph :rf/default all-contributors)
+    (let [entry-a       (get-in (rf.frame/frame-runtime-db-value :rf/default)
+                                (rf.resources.state/entry-path scoped-key))
+          g-a           (rf.derivation.graph/live-derivation-graph :rf/default all-contributors)
           res-a         (->> (:nodes g-a)
                              (filter (fn [[_ n]] (= :resources (:rf/family n))))
                              first)
@@ -963,9 +963,9 @@
       ;; `:rf.resource/release-owner {:owner owner-A}`, which drops owner A from
       ;; the entry + owner-index + work record — the genuine release path.
       (rf/dispatch-sync [:rf.route/navigate {:to :route/about}])
-      (let [entry-b        (get-in (frame/frame-runtime-db-value :rf/default)
-                                   (resources-state/entry-path scoped-key))
-            g-b            (graph/live-derivation-graph :rf/default all-contributors)
+      (let [entry-b        (get-in (rf.frame/frame-runtime-db-value :rf/default)
+                                   (rf.resources.state/entry-path scoped-key))
+            g-b            (rf.derivation.graph/live-derivation-graph :rf/default all-contributors)
             slice-b        (get (:nodes g-b) :rf/route)
             owner-b        (:owner slice-b)
             res-owner-sets (->> (:nodes g-b) vals
@@ -1012,22 +1012,22 @@
   ;; Materialize the live singleton snapshot.
   (rf/dispatch-sync [:job/runner [:job/finish-noop]]) ;; no-op event: stays :running, installs snapshot
   ;; Prove the instance exists before driving its release boundary.
-  (let [g-before    (graph/live-derivation-graph :rf/default all-contributors)
+  (let [g-before    (rf.derivation.graph/live-derivation-graph :rf/default all-contributors)
         node-before (get (:nodes g-before) [:machine :job/runner])
-        rt-before   (frame/frame-runtime-db-value :rf/default)]
+        rt-before   (rf.frame/frame-runtime-db-value :rf/default)]
     (testing "the machine instance materialized a live snapshot before destroy"
       (is (some? node-before)
           "the no-op dispatch must materialize the [:machine :job/runner] live snapshot node — absence is a failure")
-      (is (some? (get-in rt-before (machine-paths/snapshot-path :job/runner)))
+      (is (some? (get-in rt-before (rf.machines.paths/snapshot-path :job/runner)))
           "the machine-owned snapshot must be live before the final event")))
   (rf/dispatch-sync [:job/runner [:job/finish]])      ;; → :done (:final?) → auto-destroy
-  (let [g-after (graph/live-derivation-graph :rf/default all-contributors)
+  (let [g-after (rf.derivation.graph/live-derivation-graph :rf/default all-contributors)
         node    (get (:nodes g-after) [:machine :job/runner])
-        rt      (frame/frame-runtime-db-value :rf/default)]
+        rt      (rf.frame/frame-runtime-db-value :rf/default)]
     (testing "the machine instance node is released from the live graph on destroy"
       (is (nil? node)
           "the :machine-instance-owned snapshot node is gone after final-state auto-destroy")
-      (is (nil? (get-in rt (machine-paths/snapshot-path :job/runner)))
+      (is (nil? (get-in rt (rf.machines.paths/snapshot-path :job/runner)))
           "the machine-owned snapshot is released from runtime-db (machine destroy releases its owners)"))))
 
 #?(:cljs
@@ -1044,12 +1044,12 @@
                  (fn [[items] [_ sku]] (some #(when (= sku (:sku %)) (:qty %)) items)))
      (rf/dispatch-sync [::seed-cart cart-items])
      (let [q [:cart/item-qty "b"]
-           r (subs/subscribe q {:frame :rf/default})]
+           r (rf.subs/subscribe q {:frame :rf/default})]
        (is (= 3 @r)
            "sanity: the parametric sub computes its whole value from the realized input")
        ;; Live cache entries use the concrete query vector in their node id.
        ;; Assert presence before disposal to avoid a vacuous release check.
-       (let [g-before (graph/live-derivation-graph :rf/default all-contributors)
+       (let [g-before (rf.derivation.graph/live-derivation-graph :rf/default all-contributors)
              node     (get (:nodes g-before) [:sub q])]
          (testing "the live subscribe materialized the cache-entry node"
            (is (some? node)
@@ -1060,12 +1060,12 @@
            (is (= 1 (:ref-count node))
                "one live reader keeps the cache entry alive — the :ref-count lifecycle evidence")))
        ;; The sole reader drops the ref-count to zero and triggers eviction.
-       (subs/unsubscribe :rf/default q)
-       (let [g-after (graph/live-derivation-graph :rf/default all-contributors)]
+       (rf.subs/unsubscribe :rf/default q)
+       (let [g-after (rf.derivation.graph/live-derivation-graph :rf/default all-contributors)]
          (testing "subscription disposal releases the cache-entry node from the live graph"
            (is (nil? (get (:nodes g-after) [:sub q]))
                 "the :subscription-cache-entry node left the live graph at ref-count zero")
-           (is (not (contains? (set (keys @(:sub-cache (frame/frame :rf/default)))) q))
+           (is (not (contains? (set (keys @(:sub-cache (rf.frame/frame :rf/default)))) q))
                "and the underlying :sub-cache entry is evicted — the release the node absence reflects"))))))
 
 ;; ===========================================================================
@@ -1081,7 +1081,7 @@
   ;; First, pin the algebra classification the read is exercising: the sub is
   ;; the canonical :on-demand node; the resource selectors are the
   ;; read-fact surface of an :on-demand-readable process.
-  (let [nodes (:nodes (graph/derivation-graph all-contributors))
+  (let [nodes (:nodes (rf.derivation.graph/derivation-graph all-contributors))
         sub   (node-by-family nodes :subs      :cart/items)
         res   (node-by-family nodes :resources :article/by-slug)]
     (is (= :on-demand (:evaluation sub))
@@ -1089,8 +1089,8 @@
     (is (contains? (set (:selectors res)) :rf/resource)
         "the resource exposes the :rf/resource read selector"))
   ;; Snapshot both durable partitions, read the on-demand nodes, re-snapshot.
-  (let [app-before (frame/frame-app-db-value :rf/default)
-        rt-before  (frame/frame-runtime-db-value :rf/default)
+  (let [app-before (rf.frame/frame-app-db-value :rf/default)
+        rt-before  (rf.frame/frame-runtime-db-value :rf/default)
         ;; Read the ordinary subscription. The value is deliberately
         ;; discarded — it may be nil (no cart seeded); the point is that the
         ;; read RAN, between the two durable-state snapshots.
@@ -1100,8 +1100,8 @@
         ;; cache entry / work-ledger record.
         sel-val    @(rf/subscribe [:rf/resource
                                    {:resource :article/by-slug :params {:slug "welcome"}}])
-        app-after  (frame/frame-app-db-value :rf/default)
-        rt-after   (frame/frame-runtime-db-value :rf/default)]
+        app-after  (rf.frame/frame-app-db-value :rf/default)
+        rt-after   (rf.frame/frame-runtime-db-value :rf/default)]
     (testing "the reads return values (the reads actually happened)"
       ;; The subscription read above is unasserted by design (see its comment);
       ;; the selector read carries the observable claim.
@@ -1120,7 +1120,7 @@
 ;; (g) TOOL REDACTION — off-box graph egress.
 ;;
 ;; The composer assembles an internal graph; it does not apply a graph-wide
-;; wire policy. `egress/project-graph` owns that boundary: it walks value
+;; wire policy. `rf.derivation.egress/project-graph` owns that boundary: it walks value
 ;; summaries under the named frame's elision policy and remaps every
 ;; identity-bearing resource position consistently so edges still connect.
 ;;
@@ -1221,8 +1221,8 @@
   ;; non-sensitive resource id remains visible, all identity positions use the
   ;; same stable opaque scoped key, and edges still connect.
   (rf/make-frame {:id egress-frame :doc "off-box egress conformance frame"})
-  (let [raw      (graph/live-derivation-graph egress-frame (egress-live-contributors))
-        redacted (egress/project-graph raw egress-frame)]
+  (let [raw      (rf.derivation.graph/live-derivation-graph egress-frame (egress-live-contributors))
+        redacted (rf.derivation.egress/project-graph raw egress-frame)]
 
     (testing "the raw fixture exposes the sensitive identity to the projection"
       (is (contains? (:nodes raw) [:resource egress-scoped-key])
@@ -1323,8 +1323,8 @@
   "Install the `[:cart :items]` sensitive classification on `egress-frame`
   through the same runtime-db effect the commit plane uses."
   []
-  (frame/swap-runtime-db! egress-frame
-    (fn [rt] (elision/apply-classification-effects rt {:sensitive [[:cart :items]]}))))
+  (rf.frame/swap-runtime-db! egress-frame
+    (fn [rt] (rf.elision/apply-classification-effects rt {:sensitive [[:cart :items]]}))))
 
 (deftest g-graph-egress-for-unknown-frame-fails-closed
   ;; An unreachable frame has no usable value policy, so value-bearing fields
@@ -1332,31 +1332,31 @@
   (rf/make-frame {:id egress-frame})
   (classify-egress-frame-sensitive!)
   (let [contributors (egress-sensitive-value-contributors)
-        raw (graph/live-derivation-graph egress-frame contributors)]
+        raw (rf.derivation.graph/live-derivation-graph egress-frame contributors)]
     (testing "the raw graph carries the secret in value and identity positions"
       (is (contains-secret? raw)))
     (testing "egress under an unknown frame fails closed"
-      (let [redacted (egress/project-graph raw :app/does-not-exist)
+      (let [redacted (rf.derivation.egress/project-graph raw :app/does-not-exist)
             sub      (get-in redacted [:nodes [:sub [:cart/items]]])]
-        (is (= privacy/redacted-sentinel (:value sub))
+        (is (= rf.privacy/redacted-sentinel (:value sub))
             "the whole value-bearing field is redacted under no reachable policy")
         (is (not (contains-secret? redacted))
             "no raw secret survives — value-path fail-closed + frame-independent
              identity projection cover both leak channels")))
     (testing "a nil frame does not borrow an ambient frame's policy"
       (rf/with-frame :rf/default
-        (is (some? (frame/resolve-current-frame))
+        (is (some? (rf.frame/resolve-current-frame))
             "an ambient frame is bound, making policy borrowing observable")
-        (let [redacted (egress/project-graph raw nil)
+        (let [redacted (rf.derivation.egress/project-graph raw nil)
               sub      (get-in redacted [:nodes [:sub [:cart/items]]])]
-          (is (= privacy/redacted-sentinel (:value sub))
+          (is (= rf.privacy/redacted-sentinel (:value sub))
               "nil frame redacts rather than using the ambient frame")
           (is (not (contains-secret? redacted))
               "no raw secret survives a nil-frame egress under an ambient binding"))))
     (testing "egress under the known frame applies its classified value path"
-      (let [redacted (egress/project-graph raw egress-frame)
+      (let [redacted (rf.derivation.egress/project-graph raw egress-frame)
             sub      (get-in redacted [:nodes [:sub [:cart/items]]])]
-        (is (= privacy/redacted-sentinel (get-in sub [:value :cart :items]))
+        (is (= rf.privacy/redacted-sentinel (get-in sub [:value :cart :items]))
             "the classified [:cart :items] leaf is redacted")
         (is (= :derivation (:kind sub)) "the sub node is still present + classified")
         (is (not (contains-secret? redacted)))))))
@@ -1382,18 +1382,18 @@
   ;; registry is what makes the leak observable.
   (rf/make-frame {:id :re-frame.derivation.egress/no-egress-frame})
   (try
-    (let [raw (graph/live-derivation-graph egress-frame
+    (let [raw (rf.derivation.graph/live-derivation-graph egress-frame
                                            (egress-sensitive-value-contributors))]
       (is (contains-secret? raw)
           "the raw graph carries the secret in value and identity positions")
       ;; An ambient frame is bound as well, so a pass here cannot be an
       ;; accident of there being nothing to borrow.
       (rf/with-frame :rf/default
-        (is (some? (frame/resolve-current-frame))
+        (is (some? (rf.frame/resolve-current-frame))
             "an ambient frame is bound, making policy borrowing observable")
-        (let [redacted (egress/project-graph raw nil)
+        (let [redacted (rf.derivation.egress/project-graph raw nil)
               sub      (get-in redacted [:nodes [:sub [:cart/items]]])]
-          (is (= privacy/redacted-sentinel (:value sub))
+          (is (= rf.privacy/redacted-sentinel (:value sub))
               "a nil governing frame must redact the whole value-bearing field
                even with a live frame registered under the dead-frame
                sentinel's former keyword id")
@@ -1409,9 +1409,9 @@
   ;; catches fresh handles in any identity-bearing position, including realized
   ;; inputs that would not be detected by node-key checks alone.
   (rf/make-frame {:id egress-frame})
-  (let [raw   (graph/live-derivation-graph egress-frame (egress-live-contributors))
-        once  (egress/project-graph raw egress-frame)
-        twice (egress/project-graph once egress-frame)
+  (let [raw   (rf.derivation.graph/live-derivation-graph egress-frame (egress-live-contributors))
+        once  (rf.derivation.egress/project-graph raw egress-frame)
+        twice (rf.derivation.egress/project-graph once egress-frame)
         node1 (-> once :nodes vals first)
         node2 (-> twice :nodes vals first)]
     (is (not (contains-secret? twice)) "still no secret after double projection")
@@ -1445,7 +1445,7 @@
 ;; ===========================================================================
 ;; (g+) RESOURCE-CONTRIBUTOR EGRESS THROUGH THE COMPOSER.
 ;;
-;; The synthetic g arms isolate `egress/project-graph`. This arm instead uses
+;; The synthetic g arms isolate `rf.derivation.egress/project-graph`. This arm instead uses
 ;; the actual resource contributor, which applies resource classification and
 ;; scoped-key projection before the composer receives its nodes. The cache row
 ;; is a direct fixture because this artefact intentionally has no HTTP
@@ -1471,32 +1471,32 @@
   (rf/reg-route :route/secure-article {} "/secure")
   (rf/dispatch-sync [:rf.route/navigate {:to :route/secure-article}]
                     {:frame real-egress-frame})
-  (let [nav-token   (:nav-token (get (:nodes (graph/live-derivation-graph real-egress-frame all-contributors))
+  (let [nav-token   (:nav-token (get (:nodes (rf.derivation.graph/live-derivation-graph real-egress-frame all-contributors))
                                      :rf/route))
         owner       [:route :route/secure-article nav-token]
         scope       :rf.scope/global
         params      {:auth-token secret-token}
-        scoped-key  (resources-state/scoped-resource-key scope :secret/tenant-article params)
-        work-id     (work-ledger/resource-work-id scoped-key 1)
-        entry       (assoc (resources-state/empty-entry :secret/tenant-article scoped-key)
+        scoped-key  (rf.resources.state/scoped-resource-key scope :secret/tenant-article params)
+        work-id     (rf.resources.work-ledger/resource-work-id scoped-key 1)
+        entry       (assoc (rf.resources.state/empty-entry :secret/tenant-article scoped-key)
                            :status :fetching :active-owners #{owner} :current-work work-id)]
     (is (some? nav-token) "the navigation minted a nav-token")
     ;; Materialize with the resource and work-ledger constructors. This is test
     ;; setup, not the resource request/write path under test.
-    (frame/swap-runtime-db!
+    (rf.frame/swap-runtime-db!
       real-egress-frame
       (fn [rdb]
-        (-> (assoc-in (or rdb {}) (resources-state/entry-path scoped-key) entry)
-            (work-ledger/put-record
+        (-> (assoc-in (or rdb {}) (rf.resources.state/entry-path scoped-key) entry)
+            (rf.resources.work-ledger/put-record
               work-id
-              (work-ledger/work-record {:work-id      work-id
+              (rf.resources.work-ledger/work-record {:work-id      work-id
                                         :frame-id     real-egress-frame
                                         :resource/key scoped-key
                                         :generation   1
                                         :transport    :rf.http/managed
                                         :owner        owner
                                         :cause        :test/materialize}))))))
-  (let [g              (graph/live-derivation-graph real-egress-frame all-contributors)
+  (let [g              (rf.derivation.graph/live-derivation-graph real-egress-frame all-contributors)
         resource-entry (->> (:nodes g)
                              (filter (fn [[_ n]] (= :resources (:rf/family n))))
                              first)]

--- a/implementation/event-conformance/test/re_frame/event_frame_isolation_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_frame_isolation_conformance_cljs_test.cljc
@@ -19,29 +19,29 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core           :as rf]
-            [re-frame.events         :as events]
-            [re-frame.frame          :as frame]
-            [re-frame.image          :as image]
-            [re-frame.registrar      :as registrar]
-            [re-frame.live-frame     :as lf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support   :as test-support]))
+            [re-frame.events         :as rf.events]
+            [re-frame.frame          :as rf.frame]
+            [re-frame.image          :as rf.image]
+            [re-frame.registrar      :as rf.registrar]
+            [re-frame.live-frame     :as rf.live-frame]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support   :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter       plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture {:adapter       rf.substrate.plain-atom/adapter
                                             :ambient-frame nil}))
 
 ;; Image resolution stores the registration descriptor plus its selection keys.
 (defn- event-desc
   [provenance-ns id handler-fn]
-  (merge (events/event-handler-meta handler-fn)
+  (merge (rf.events/event-handler-meta handler-fn)
          {:rf.provenance/ns provenance-ns
           :kind             :event
           :id               id}))
 
 ;; A framework-authority variant of `event-desc`: stamps the reserved
 ;; `:rf/framework-authority? true` registration-meta key (EP-0001 —
-;; `events/framework-authority?`) onto the image descriptor. Because `lookup`
+;; `rf.events/framework-authority?`) onto the image descriptor. Because `lookup`
 ;; resolves the descriptor verbatim through the frame's generation and the
 ;; router feeds it in as `handler-meta`, the resolved handler carries legitimate
 ;; write-authority over the reserved `:rf.db/runtime` partition — so an
@@ -67,18 +67,18 @@
           [(event-desc "examples.counter" :boot/init
              (fn [{:keys [db]} _] {:db (assoc db :booted-by :counter)}))]
           todo-image
-          (image/image {:id :examples/todo
+          (rf.image/image {:id :examples/todo
                         :select-ns {:include ["examples.todo"]}})
           counter-image
-          (image/image {:id :examples/counter
+          (rf.image/image {:id :examples/counter
                         :select-ns {:include ["examples.counter"]}})
           todo-frame
-          (lf/make-frame {:id :todo/main :images [todo-image]}
+          (rf.live-frame/make-frame {:id :todo/main :images [todo-image]}
                          todo-registrations)
           counter-frame
-          (lf/make-frame {:id :counter/main :images [counter-image]}
+          (rf.live-frame/make-frame {:id :counter/main :images [counter-image]}
                          counter-registrations)]
-      (is (some? (registrar/lookup :event :boot/init))
+      (is (some? (rf.registrar/lookup :event :boot/init))
           "the same-id global sentinel is genuinely armed on the default registrar
            (so the `not= :global` rows below are not vacuous)")
       (rf/dispatch-sync [:boot/init] {:frame :todo/main})
@@ -99,12 +99,12 @@
         (is (= {:booted-by :counter} (rf/app-db-value :counter/main))
             "the counter frame's app-db holds ONLY the counter handler's write"))
       (testing "the generation binding did NOT leak past either cascade"
-        (is (nil? registrar/*generation*)
+        (is (nil? rf.registrar/*generation*)
             "after the dispatches, no generation is bound (the seam unwound)"))
       (testing "the two frames carry genuinely different resolved generations for
                 the same id (no shared generation)"
-        (is (not= (lf/frame-generation todo-frame)
-                  (lf/frame-generation counter-frame))
+        (is (not= (rf.live-frame/frame-generation todo-frame)
+                  (rf.live-frame/frame-generation counter-frame))
             "the two image-loaded frames resolve the SAME id through DIFFERENT generations")))))
 
 (deftest two-image-frames-same-id-isolate-the-runtime-db-partition
@@ -154,61 +154,61 @@
                {:rf.db/runtime
                 (assoc runtime-db :rf.runtime/conf-writer :sibling)}))]
           todo-image
-          (image/image {:id :conf.rt/todo
+          (rf.image/image {:id :conf.rt/todo
                         :select-ns {:include ["conf.rt.todo"]}})
           counter-image
-          (image/image {:id :conf.rt/counter
+          (rf.image/image {:id :conf.rt/counter
                         :select-ns {:include ["conf.rt.counter"]}})
           sibling-image
-          (image/image {:id :conf.rt/sibling
+          (rf.image/image {:id :conf.rt/sibling
                         :select-ns {:include ["conf.rt.sibling"]}})
-          _ (lf/make-frame {:id :conf.rt/todo :images [todo-image]}
+          _ (rf.live-frame/make-frame {:id :conf.rt/todo :images [todo-image]}
                            todo-registrations)
-          _ (lf/make-frame {:id :conf.rt/counter :images [counter-image]}
+          _ (rf.live-frame/make-frame {:id :conf.rt/counter :images [counter-image]}
                            counter-registrations)
-          _ (lf/make-frame {:id :conf.rt/sibling :images [sibling-image]}
+          _ (rf.live-frame/make-frame {:id :conf.rt/sibling :images [sibling-image]}
                            sibling-registrations)]
       ;; Seed each frame's runtime-db partition with a UNIQUE marker (the
       ;; framework-authority runtime-db write surface — Spec 002 §Write
       ;; authority). The seed is what each handler reads back as its
       ;; `:rf.db/runtime` coeffect.
-      (frame/replace-runtime-db! :conf.rt/todo    {:rf.runtime/conf-seed :todo-seed})
-      (frame/replace-runtime-db! :conf.rt/counter {:rf.runtime/conf-seed :counter-seed})
-      (frame/replace-runtime-db! :conf.rt/sibling {:rf.runtime/conf-seed :sibling-seed})
+      (rf.frame/replace-runtime-db! :conf.rt/todo    {:rf.runtime/conf-seed :todo-seed})
+      (rf.frame/replace-runtime-db! :conf.rt/counter {:rf.runtime/conf-seed :counter-seed})
+      (rf.frame/replace-runtime-db! :conf.rt/sibling {:rf.runtime/conf-seed :sibling-seed})
       ;; Dispatch ONCE to each explicit target — the sibling is left alone.
       (rf/dispatch-sync [:boot/rt-init] {:frame :conf.rt/todo})
       (rf/dispatch-sync [:boot/rt-init] {:frame :conf.rt/counter})
       (testing "the same-id GLOBAL runtime sentinel is genuinely armed (not a
                 vacuous `not= :global`)"
-        (is (some? (registrar/lookup :event :boot/rt-init))
+        (is (some? (rf.registrar/lookup :event :boot/rt-init))
             "the same-id global runtime handler is live on the default registrar"))
       (testing "each handler read ITS OWN frame's runtime-db seed as the
                 `:rf.db/runtime` coeffect — not a sibling's or the default's"
-        (is (= :todo-seed (:rf.runtime/conf-observed (frame/frame-runtime-db-value :conf.rt/todo)))
+        (is (= :todo-seed (:rf.runtime/conf-observed (rf.frame/frame-runtime-db-value :conf.rt/todo)))
             "the todo handler observed the TODO frame's runtime-db seed")
-        (is (= :counter-seed (:rf.runtime/conf-observed (frame/frame-runtime-db-value :conf.rt/counter)))
+        (is (= :counter-seed (:rf.runtime/conf-observed (rf.frame/frame-runtime-db-value :conf.rt/counter)))
             "the counter handler observed the COUNTER frame's runtime-db seed"))
       (testing "each runtime-db effect committed ONLY to its own frame — exact
                 per-frame runtime-db, no cross-frame commit bleed"
         (is (= {:rf.runtime/conf-seed     :todo-seed
                 :rf.runtime/conf-observed :todo-seed
                 :rf.runtime/conf-writer   :todo}
-               (frame/frame-runtime-db-value :conf.rt/todo))
+               (rf.frame/frame-runtime-db-value :conf.rt/todo))
             "the todo frame's runtime-db is EXACTLY the todo handler's write over the todo seed")
         (is (= {:rf.runtime/conf-seed     :counter-seed
                 :rf.runtime/conf-observed :counter-seed
                 :rf.runtime/conf-writer   :counter}
-               (frame/frame-runtime-db-value :conf.rt/counter))
+               (rf.frame/frame-runtime-db-value :conf.rt/counter))
             "the counter frame's runtime-db is EXACTLY the counter handler's write over the counter seed"))
       (testing "neither frame fell back to the same-id GLOBAL runtime handler"
-        (is (not= :global (:rf.runtime/conf-writer (frame/frame-runtime-db-value :conf.rt/todo)))
+        (is (not= :global (:rf.runtime/conf-writer (rf.frame/frame-runtime-db-value :conf.rt/todo)))
             "the todo frame did NOT resolve the global runtime handler")
-        (is (not= :global (:rf.runtime/conf-writer (frame/frame-runtime-db-value :conf.rt/counter)))
+        (is (not= :global (:rf.runtime/conf-writer (rf.frame/frame-runtime-db-value :conf.rt/counter)))
             "the counter frame did NOT resolve the global runtime handler"))
       (testing "the un-dispatched SIBLING frame's runtime-db is UNCHANGED — no
                 todo / counter / global runtime write leaked into it"
         (is (= {:rf.runtime/conf-seed :sibling-seed}
-               (frame/frame-runtime-db-value :conf.rt/sibling))
+               (rf.frame/frame-runtime-db-value :conf.rt/sibling))
             "the sibling frame's runtime-db is EXACTLY its seed (untouched)"))
       (testing "the runtime-only event left the app-db partition untouched —
                 the two partitions commit independently (EP-0001)"
@@ -217,7 +217,7 @@
         (is (= {} (rf/app-db-value :conf.rt/counter))
             "the counter frame's app-db partition saw no write from the runtime-only event"))
       (testing "the generation binding did NOT leak past either cascade"
-        (is (nil? registrar/*generation*)
+        (is (nil? rf.registrar/*generation*)
             "after the dispatches, no generation is bound (the resolution seam unwound)")))))
 
 (deftest child-dispatch-stays-in-the-frames-image-and-commits-only-that-frame
@@ -237,13 +237,13 @@
                        (fn [{:keys [db]} _] {:db (assoc db :inc :sibling)}))
            (event-desc "examples.todo" :counter/step
                        (fn [{:keys [db]} _] {:db (assoc db :step :sibling)}))]
-          target-image (image/image {:id :examples/counter
+          target-image (rf.image/image {:id :examples/counter
                                      :select-ns {:include ["examples.counter"]}})
-          sibling-image (image/image {:id :examples/todo
+          sibling-image (rf.image/image {:id :examples/todo
                                       :select-ns {:include ["examples.todo"]}})
-          _ (lf/make-frame {:id :counter/main :images [target-image]}
+          _ (rf.live-frame/make-frame {:id :counter/main :images [target-image]}
                            target-registrations)
-          _ (lf/make-frame {:id :sibling/main :images [sibling-image]}
+          _ (rf.live-frame/make-frame {:id :sibling/main :images [sibling-image]}
                            sibling-registrations)]
       (rf/dispatch-sync [:counter/inc] {:frame :counter/main})
       (let [target-db (rf/app-db-value :counter/main)]

--- a/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_model_conformance_cljs_test.cljc
@@ -20,20 +20,20 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
-            [re-frame.cofx :as cofx]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.event-emit :as event-emit]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.cofx :as rf.cofx]
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.event-emit :as rf.event-emit]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 (defn- clear-observation-state! []
-  (error-emit/clear-error-listeners!)
-  (event-emit/clear-event-listeners!))
+  (rf.error-emit/clear-error-listeners!)
+  (rf.event-emit/clear-event-listeners!))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter})
   (fn [test-fn]
     (clear-observation-state!)
     (test-fn)
@@ -353,16 +353,16 @@
 (deftest supplied-recordable-value-failing-schema-is-cofx-value-invalid-in-production
   (testing "recordable-coeffect schemas are enforced at the durable boundary"
     ;; Exercise the schema hook without taking a dependency on the schemas artefact.
-    (let [previous-validator (late-bind/get-fn :schemas/validate-with-registered-fn)
-          previous-explainer (late-bind/get-fn :schemas/explain-with-registered-fn)]
+    (let [previous-validator (rf.late-bind/get-fn :schemas/validate-with-registered-fn)
+          previous-explainer (rf.late-bind/get-fn :schemas/explain-with-registered-fn)]
       (try
-        (late-bind/set-fn! :schemas/validate-with-registered-fn
+        (rf.late-bind/set-fn! :schemas/validate-with-registered-fn
           (fn [schema value]
             ;; schema shape `[:enum a b …]` → membership check.
             (and (vector? schema)
                  (= :enum (first schema))
                  (contains? (set (rest schema)) value))))
-        (late-bind/set-fn! :schemas/explain-with-registered-fn
+        (rf.late-bind/set-fn! :schemas/explain-with-registered-fn
           (fn [schema value] {:schema schema :value value :failed true}))
         (let [delivered-fact (atom ::unset)]
           (rf/reg-cofx :evt-conf/graded-fact
@@ -387,13 +387,13 @@
         (finally
           ;; Restore the prior hooks (nil = no validator) so no leak.
           (if previous-validator
-            (late-bind/set-fn! :schemas/validate-with-registered-fn previous-validator)
-            (swap! late-bind/hooks dissoc :schemas/validate-with-registered-fn))
+            (rf.late-bind/set-fn! :schemas/validate-with-registered-fn previous-validator)
+            (swap! rf.late-bind/hooks dissoc :schemas/validate-with-registered-fn))
           (if previous-explainer
-            (late-bind/set-fn! :schemas/explain-with-registered-fn previous-explainer)
-            (swap! late-bind/hooks dissoc :schemas/explain-with-registered-fn))
-          (late-bind/invalidate-cache! :schemas/validate-with-registered-fn)
-          (late-bind/invalidate-cache! :schemas/explain-with-registered-fn))))))
+            (rf.late-bind/set-fn! :schemas/explain-with-registered-fn previous-explainer)
+            (swap! rf.late-bind/hooks dissoc :schemas/explain-with-registered-fn))
+          (rf.late-bind/invalidate-cache! :schemas/validate-with-registered-fn)
+          (rf.late-bind/invalidate-cache! :schemas/explain-with-registered-fn))))))
 
 (deftest reg-event-declared-rf-time-ms-is-delivered-flat-from-the-token
   (testing "a declared :rf/time-ms fact is delivered flat from the causal token"
@@ -484,9 +484,9 @@
            "there is NO public re-frame.core/inject-cofx var — the facade surface is removed"))
     ;; Leg 2 — the surviving private thrower is the always-on hard error.
     (is (= :rf.error/inject-cofx-removed
-           (thrown-error-id #(cofx/inject-cofx :evt-conf/anything)))
+           (thrown-error-id #(rf.cofx/inject-cofx :evt-conf/anything)))
         "the surviving inject-cofx thrower raises :rf.error/inject-cofx-removed")
-    (let [reason (thrown-error-reason #(cofx/inject-cofx :evt-conf/anything))]
+    (let [reason (thrown-error-reason #(rf.cofx/inject-cofx :evt-conf/anything))]
       (is (string? reason)
           "the removal stub raises an ex-info carrying a :reason string")
       (is (re-find #":rf.cofx/requires" reason)
@@ -801,11 +801,11 @@
     (thrown-error-id #(rf/reg-event-db  :evt-conf/db-noreg  (fn [_ _] nil)))
     (thrown-error-id #(rf/reg-event-fx  :evt-conf/fx-noreg  (fn [_ _] nil)))
     (thrown-error-id #(rf/reg-event-ctx :evt-conf/ctx-noreg (fn [_ _] nil)))
-    (is (nil? (registrar/lookup :event :evt-conf/db-noreg))
+    (is (nil? (rf.registrar/lookup :event :evt-conf/db-noreg))
         "reg-event-db registered nothing")
-    (is (nil? (registrar/lookup :event :evt-conf/fx-noreg))
+    (is (nil? (rf.registrar/lookup :event :evt-conf/fx-noreg))
         "reg-event-fx registered nothing")
-    (is (nil? (registrar/lookup :event :evt-conf/ctx-noreg))
+    (is (nil? (rf.registrar/lookup :event :evt-conf/ctx-noreg))
         "reg-event-ctx registered nothing")
     (rf/dispatch-sync [:evt-conf/live])
     (is (= [:reg-event] @(rf/subscribe [:evt-conf/tally]))

--- a/implementation/event-conformance/test/re_frame/event_reply_envelope_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_reply_envelope_conformance_cljs_test.cljc
@@ -36,16 +36,16 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
-            [re-frame.events :as events]
-            [re-frame.image :as image]
-            [re-frame.live-frame :as lf]
-            [re-frame.registrar :as registrar]
-            [re-frame.reply :as reply]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.events :as rf.events]
+            [re-frame.image :as rf.image]
+            [re-frame.live-frame :as rf.live-frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.reply :as rf.reply]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (def ^:private completed-at-ms 1781078400456)
 
@@ -66,7 +66,7 @@
 ;; handler resolution (the write is `:global`, not `:image`).
 (defn- event-desc
   [provenance-ns id handler-fn]
-  (merge (events/event-handler-meta handler-fn)
+  (merge (rf.events/event-handler-meta handler-fn)
          {:rf.provenance/ns provenance-ns
           :kind             :event
           :id               id}))
@@ -82,13 +82,13 @@
 ;; lowering (and never app-delivers a stale reply); this invents no production API.
 (defn- observe-stale-reply!
   [{stale-reply :reply} reply-target dispatch-options]
-  (rf/dispatch-sync (reply/complete reply-target stale-reply) dispatch-options))
+  (rf/dispatch-sync (rf.reply/complete reply-target stale-reply) dispatch-options))
 
 (deftest reply-completion-is-an-ordinary-reg-event-dispatch
   (testing "a completed reply target is an ordinary event with the reply last"
-    (is (reply/valid-reply? canonical-reply)
+    (is (rf.reply/valid-reply? canonical-reply)
         (str "the fixture reply must be a canonical uniform envelope: "
-             (reply/validate-reply canonical-reply)))
+             (rf.reply/validate-reply canonical-reply)))
     (let [seen-event      (atom ::unset)
           seen-coeffects  (atom ::unset)
           reply-target    [:article/loaded {:id 42}]]
@@ -102,7 +102,7 @@
                         :title
                         (get-in delivered-reply [:value :article :title]))})))
 
-      (let [completed-event (reply/complete reply-target canonical-reply)]
+      (let [completed-event (rf.reply/complete reply-target canonical-reply)]
         (is (= [:article/loaded {:id 42} canonical-reply] completed-event)
             "complete appends the reply map as the FINAL event argument")
         (rf/dispatch-sync completed-event))
@@ -127,9 +127,9 @@
             (is (= :rf/default (:rf.frame/id delivered-reply)) ":rf.frame/id preserved")
             (is (= completed-at-ms (:completed-at delivered-reply))
                 ":completed-at (EP-0017) preserved")
-            (is (contains? reply/statuses (:status delivered-reply))
+            (is (contains? rf.reply/statuses (:status delivered-reply))
                 ":status is in the ONE closed status vocabulary")
-            (is (contains? reply/work-statuses (:rf.reply/work-status delivered-reply))
+            (is (contains? rf.reply/work-statuses (:rf.reply/work-status delivered-reply))
                 ":rf.reply/work-status is in the ONE closed work-status vocabulary"))))
 
       (testing "the reply event got ORDINARY event-model semantics — a coeffects
@@ -153,7 +153,7 @@
     ;; explicit one) runs THIS handler and stamps `:global`.
     (rf/reg-event :article/loaded
       (fn [{:keys [db]} _] {:db (assoc db :delivered-by :global)}))
-    (is (some? (registrar/lookup :event :article/loaded))
+    (is (some? (rf.registrar/lookup :event :article/loaded))
         "the same-id global sentinel is genuinely armed on the default registrar")
     (let [seen-event         (atom ::unset)
           handler-call-count (atom 0)
@@ -165,9 +165,9 @@
                (reset! seen-event event)
                {:db (assoc db :delivered-by :image)}))]
           event-image
-          (image/image {:id :evt.reply/stale-img
+          (rf.image/image {:id :evt.reply/stale-img
                         :select-ns {:include ["evt.reply.stale"]}})
-          _ (lf/make-frame {:id :evt.reply/frame :images [event-image]}
+          _ (rf.live-frame/make-frame {:id :evt.reply/frame :images [event-image]}
                            image-registrations)
           ;; A PLAIN app-shaped target — nothing capability-bearing rides it.
           reply-target [:article/loaded {:id 42}]
@@ -178,7 +178,7 @@
           {:work/id [:rf.work/resource [:rf.scope/global :r {}] 5]
            :generation 5}
           suppression-outcome
-          (reply/suppress reply-target carried-correlation current-correlation
+          (rf.reply/suppress reply-target carried-correlation current-correlation
             {:rf.reply/work-id (:work/id carried-correlation)
                      :work/kind        :resource
                      :rf.frame/id      :evt.reply/frame})]
@@ -187,9 +187,9 @@
                 is a deliberate observer self-dispatch"
         (is (false? (:deliver? suppression-outcome))
             "the suppress boundary never authorises app delivery of a stale reply")
-        (is (reply/valid-reply? (:reply suppression-outcome))
+        (is (rf.reply/valid-reply? (:reply suppression-outcome))
             (str "the suppressed reply must be a canonical stale envelope: "
-                 (reply/validate-reply (:reply suppression-outcome))))
+                 (rf.reply/validate-reply (:reply suppression-outcome))))
         (is (zero? @handler-call-count) "nothing has been dispatched yet"))
       (testing "TOOTH — authorised observation: the observer self-dispatches the
                 stale reply on its OWN authority (explicit complete + dispatch)"
@@ -210,7 +210,7 @@
               "a :rf.reply/stale-reason rides")
           (is (not (contains? delivered-reply :value))
               "a stale reply carries NO :value — it mutates no app state")
-          (is (contains? reply/statuses (:status delivered-reply))
+          (is (contains? rf.reply/statuses (:status delivered-reply))
               ":stale is in the ONE closed status vocabulary")))
       (testing "the observer's dispatch was routed to the EXPLICIT frame via ITS
                 OWN image — not the ambient default frame, nor the default registrar"
@@ -220,5 +220,5 @@
             "resolution did NOT fall through to the same-id default-registrar sentinel")
         (is (nil? (:delivered-by (rf/app-db-value :rf/default)))
             "targeting did NOT fall through to the ambient default frame")
-        (is (nil? registrar/*generation*)
+        (is (nil? rf.registrar/*generation*)
             "the image generation binding unwound after the dispatch")))))

--- a/implementation/reply-conformance/test/re_frame/reply_egress_projection_conformance_cljs_test.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_egress_projection_conformance_cljs_test.cljc
@@ -34,16 +34,16 @@
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.frame :as frame]
-            [re-frame.privacy :as privacy]
-            [re-frame.reply :as reply]
-            [re-frame.reply-conformance-fixtures :as fixtures]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.elision :as rf.elision]
+            [re-frame.frame :as rf.frame]
+            [re-frame.privacy :as rf.privacy]
+            [re-frame.reply :as rf.reply]
+            [re-frame.reply-conformance-fixtures :as rf.reply-conformance-fixtures]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---------------------------------------------------------------------------
 ;; The frame's elision registry classifies paths within each reply wire slot.
@@ -67,8 +67,8 @@
 (defn- mk-frame! []
   (rf/make-frame {:id frame-id})
   ;; Seed the same runtime registry that classification effects update.
-  (frame/swap-runtime-db! frame-id
-    (fn [rt] (elision/apply-classification-effects rt
+  (rf.frame/swap-runtime-db! frame-id
+    (fn [rt] (rf.elision/apply-classification-effects rt
                {:sensitive [[:token] [:secret-big]]
                 :large     [[:blob] [:secret-big]]}))))
 
@@ -82,7 +82,7 @@
 (def ^:private work-id
   [:rf.work/resource [:rf.scope/global :article/by-id {:id 42}] 1])
 
-(def ^:private completed-at-ms fixtures/completion-time-ms)
+(def ^:private completed-at-ms rf.reply-conformance-fixtures/completion-time-ms)
 
 (defn- ok-reply []
   ;; A complete canonical envelope keeps the projection assertions realistic.
@@ -106,7 +106,7 @@
    :rf.reply/work-status :failed
    :rf.frame/id frame-id})
 
-(defn- redacted? [value] (= privacy/redacted-sentinel value))
+(defn- redacted? [value] (= rf.privacy/redacted-sentinel value))
 (defn- large-marker? [value] (and (map? value) (contains? value :rf.size/large-elided)))
 
 ;; ---------------------------------------------------------------------------
@@ -156,7 +156,7 @@
     (let [reply   (assoc (ok-reply)
                          :correlation {:token "corr-SECRET"}
                          :meta        {:blob big-string})
-          summary (reply/trace-summary reply {:frame frame-id})]
+          summary (rf.reply/trace-summary reply {:frame frame-id})]
       (testing "the sensitive reply-value leaf is redacted"
         (is (redacted? (get-in summary [:value :token]))
             ":value sensitive leaf redacted"))
@@ -199,7 +199,7 @@
 (deftest trace-summary-projects-the-error-failure-payload
   (testing "the :error payload is projected like the :value payload"
     (mk-frame!)
-    (let [summary (reply/trace-summary (error-reply) {:frame frame-id})]
+    (let [summary (rf.reply/trace-summary (error-reply) {:frame frame-id})]
       (is (redacted? (get-in summary [:error :token]))
           "a sensitive leaf inside the :error response body is redacted")
       (is (large-marker? (get-in summary [:error :blob]))
@@ -225,7 +225,7 @@
 (deftest sensitive-wins-over-large-at-a-both-marked-reply-slot
   (testing "a both-marked reply value redacts rather than large-elides"
     (mk-frame!)
-    (let [summary (reply/trace-summary (ok-reply) {:frame frame-id})]
+    (let [summary (rf.reply/trace-summary (ok-reply) {:frame frame-id})]
       (is (redacted? (get-in summary [:value :secret-big]))
           "the both-marked leaf is REDACTED, not large-elided")
       (is (not (large-marker? (get-in summary [:value :secret-big])))
@@ -240,11 +240,11 @@
   (testing "an explicit live frame applies policy and an unresolved frame fails closed"
     (mk-frame!)
     ;; A live explicit frame applies its classification policy.
-    (let [known (reply/trace-summary (ok-reply) {:frame frame-id})]
+    (let [known (rf.reply/trace-summary (ok-reply) {:frame frame-id})]
       (is (redacted? (get-in known [:value :token]))
           "a KNOWN :frame opt applies its sensitive policy"))
     ;; A never-registered frame cannot supply policy, so the whole slot redacts.
-    (let [unresolved (reply/trace-summary (ok-reply) {:frame :reply-egress/ghost})]
+    (let [unresolved (rf.reply/trace-summary (ok-reply) {:frame :reply-egress/ghost})]
       (is (redacted? (:value unresolved))
           "an UNRESOLVED :frame opt fails closed — the whole :value slot redacts")
       (is (not (embeds-raw-token? unresolved))
@@ -258,10 +258,10 @@
 (deftest carried-frame-stamp-auto-resolves-into-the-egress-policy
   (mk-frame!)
   ;; Remove ambient scope so the carried stamp is the only frame source.
-  (binding [frame/*current-frame* nil]
+  (binding [rf.frame/*current-frame* nil]
     (testing "a live carried frame supplies the wire-slot policy"
       (let [reply   (ok-reply)
-            summary (reply/trace-summary reply nil)]
+            summary (rf.reply/trace-summary reply nil)]
         (is (= frame-id (:rf.frame/id reply))
             "precondition: reply carries the live frame stamp")
         (is (redacted? (get-in summary [:value :token]))
@@ -278,14 +278,14 @@
             ":rf.reply/work-id still rides verbatim")))
     (testing "an unresolved carried frame fails closed"
       (let [reply   (assoc (ok-reply) :rf.frame/id :reply-egress/ghost)
-            summary (reply/trace-summary reply nil)]
+            summary (rf.reply/trace-summary reply nil)]
         (is (redacted? (:value summary))
             "an unresolved carried stamp still fails closed under nil opts")
         (is (= :reply-egress/ghost (:rf.frame/id summary))
             "the carried (unresolved) :rf.frame/id rides verbatim as identity")))
     (testing "an explicit frame takes precedence over the carried stamp"
       (let [reply   (ok-reply)
-            summary (reply/trace-summary reply {:frame :reply-egress/ghost})]
+            summary (rf.reply/trace-summary reply {:frame :reply-egress/ghost})]
         (is (redacted? (:value summary))
             "the explicit unresolved frame wins and fails closed")))))
 
@@ -345,22 +345,22 @@
 
 (deftest a-mapped-reply-target-has-a-data-only-durable-representation
   (testing "durable-target strips a mapped target's ephemeral accumulator"
-    (let [relayed (reply/map-completed-event (fn [event] [:parent/relay event])
+    (let [relayed (rf.reply/map-completed-event (fn [event] [:parent/relay event])
                                     [:article/loaded {:id 42}])]
-      (is (false? (reply/data-only-target? relayed))
+      (is (false? (rf.reply/data-only-target? relayed))
           "a mapped target is not data-only while it carries ::post")
-      (let [durable (reply/durable-target relayed)]
-        (is (true? (reply/data-only-target? durable))
+      (let [durable (rf.reply/durable-target relayed)]
+        (is (true? (rf.reply/data-only-target? durable))
             "the durable projection strips the accumulator")))))
 
 (deftest a-completed-reply-event-can-be-summarized-for-egress
   (testing "a completed event is raw in memory and its reply can be summarized for egress"
     (mk-frame!)
     (let [target    [:article/loaded {:id 42}]
-          completed (reply/complete target (ok-reply))
+          completed (rf.reply/complete target (ok-reply))
           ;; Completion appends the raw reply; trace-summary creates the egress view.
           delivered (peek completed)
-          summary   (reply/trace-summary delivered {:frame frame-id})]
+          summary   (rf.reply/trace-summary delivered {:frame frame-id})]
       (is (= [:article/loaded {:id 42} (ok-reply)] completed)
           "the completed event carries the raw reply as its final arg in-memory")
       (is (redacted? (get-in summary [:value :token]))
@@ -390,7 +390,7 @@
       (is (embeds-raw-blob? reply)
           "the sentinel predicate finds the raw blob in the pre-projection reply")
       ;; The direct walker provides the expected projection result.
-      (let [direct (elision/elide-wire-value (:value reply) {:frame frame-id})]
+      (let [direct (rf.elision/elide-wire-value (:value reply) {:frame frame-id})]
         (is (redacted? (get-in direct [:token]))
             "the shared walker redacts the token")))))
 
@@ -414,7 +414,7 @@
           "the sentinel predicate FINDS the raw blob the leaking marker embeds")))
   (testing "a LEGITIMATE large-elided marker carries no raw value, so the
             sentinel predicate does not false-positive on it"
-    (let [clean (elision/->marker big-string [:blob] {})]
+    (let [clean (rf.elision/->marker big-string [:blob] {})]
       (is (large-marker? clean) "a real marker is still a marker")
       (is (not (embeds-raw-blob? clean))
           "the real marker carries only a byte-count / type / handle — no raw blob"))))

--- a/implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc
@@ -38,12 +38,12 @@
             ;; the JVM arm uses clojure.core/read-string.
             #?(:cljs [cljs.reader])
             [clojure.string :as string]
-            [re-frame.reply :as reply]
-            [re-frame.reply-conformance-fixtures :as fixtures]
-            [re-frame.http.reply :as http-reply]
-            [re-frame.resources.reply :as rreply]
-            [re-frame.machines.reply :as m-reply]
-            [re-frame.routing.reply :as route-reply]))
+            [re-frame.reply :as rf.reply]
+            [re-frame.reply-conformance-fixtures :as rf.reply-conformance-fixtures]
+            [re-frame.http.reply :as rf.http.reply]
+            [re-frame.resources.reply :as rf.resources.reply]
+            [re-frame.machines.reply :as rf.machines.reply]
+            [re-frame.routing.reply :as rf.routing.reply]))
 
 ;; ---------------------------------------------------------------------------
 ;; Work ids are portable data, so both readers must reconstruct an equal value.
@@ -59,7 +59,7 @@
 
 ;; This tier checks only reply-map `:completed-at` propagation. Router and
 ;; family lowering suites own live dispatch-envelope `:rf.cofx` coverage.
-(def ^:private completion-time-ms fixtures/completion-time-ms)
+(def ^:private completion-time-ms rf.reply-conformance-fixtures/completion-time-ms)
 
 (def ^:private http-ctx
   {:request-id   :article/by-id
@@ -115,10 +115,10 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- machine-stale-reply []
-  (m-reply/stale-spawn-reply (assoc machine-ctx :current-generation nil)))
+  (rf.machines.reply/stale-spawn-reply (assoc machine-ctx :current-generation nil)))
 
 (defn- after-stale-reply []
-  (m-reply/after-stale-reply
+  (rf.machines.reply/after-stale-reply
     {:actor-id        :a/multi
      :state           :loading
      :delay           30000
@@ -129,7 +129,7 @@
 
 ;; The paired timer builders exercise presence and omission of `:completed-at`.
 (defn- after-fired-reply []
-  (m-reply/after-fired-reply
+  (rf.machines.reply/after-fired-reply
     {:actor-id   :a/multi
      :state      :loading
      :delay      30000
@@ -138,7 +138,7 @@
      :frame      :app/main}))
 
 (defn- after-fired-reply-with-time []
-  (m-reply/after-fired-reply
+  (rf.machines.reply/after-fired-reply
     {:actor-id     :a/multi
      :state        :loading
      :delay        30000
@@ -157,10 +157,10 @@
    :completed-at completion-time-ms})
 
 (defn- route-live-reply []
-  (route-reply/live-reply route-ctx {:title "Welcome"}))
+  (rf.routing.reply/live-reply route-ctx {:title "Welcome"}))
 
 (defn- route-success-no-time []
-  (route-reply/live-reply (dissoc route-ctx :completed-at) {:title "Welcome"}))
+  (rf.routing.reply/live-reply (dissoc route-ctx :completed-at) {:title "Welcome"}))
 
 ;; ---------------------------------------------------------------------------
 ;; Companion builders omit the completion time so the matrix can distinguish
@@ -168,18 +168,18 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- http-success-no-time []
-  (http-reply/success-reply (dissoc http-ctx :completed-at) {:title "Welcome"}))
+  (rf.http.reply/success-reply (dissoc http-ctx :completed-at) {:title "Welcome"}))
 
 (defn- resource-success-no-time []
-  (rreply/success-reply resource-vp {:title "Welcome"}
-                        {:work-kind rreply/work-kind-resource}))
+  (rf.resources.reply/success-reply resource-vp {:title "Welcome"}
+                        {:work-kind rf.resources.reply/work-kind-resource}))
 
 (defn- mutation-success-no-time []
-  (rreply/success-reply mutation-vp {:slug "w" :title "Welcome"}
-                        {:work-kind rreply/work-kind-mutation}))
+  (rf.resources.reply/success-reply mutation-vp {:slug "w" :title "Welcome"}
+                        {:work-kind rf.resources.reply/work-kind-mutation}))
 
 (defn- machine-success-no-time []
-  (m-reply/success-reply (dissoc machine-ctx :completed-at) {:user-id "u-42"}))
+  (rf.machines.reply/success-reply (dissoc machine-ctx :completed-at) {:user-id "u-42"}))
 
 ;; ---------------------------------------------------------------------------
 ;; HTTP, resource, mutation, and route delegate stale classification to a
@@ -192,7 +192,7 @@
 
 (defn- http-stale-out []
   ;; The current work id names the superseding HTTP attempt.
-  (http-reply/suppress http-ctx [:rf.work/http :article/by-id 2 1]))
+  (rf.http.reply/suppress http-ctx [:rf.work/http :article/by-id 2 1]))
 
 ;; The stale-suppression outcomes are parameterized by an optional `extra-more`
 ;; (resource / mutation) or `ctx-more` (route) map so the non-success stale
@@ -202,7 +202,7 @@
 (defn- resource-stale-out
   ([] (resource-stale-out nil))
   ([extra-more]
-   (rreply/stale-reply
+   (rf.resources.reply/stale-reply
      {:carried {:work/id [:rf.work/resource [:rf.scope/global :r {}] 4] :generation 4}
       :current {:work/id [:rf.work/resource [:rf.scope/global :r {}] 5] :generation 5}
       :extra   (merge {:rf.reply/work-id      [:rf.work/resource [:rf.scope/global :r {}] 4]
@@ -214,7 +214,7 @@
 (defn- mutation-stale-out
   ([] (mutation-stale-out nil))
   ([extra-more]
-   (rreply/stale-reply
+   (rf.resources.reply/stale-reply
      {:carried {:work/id [:rf.work/resource [:rf.mutation :form/save-1] 2] :generation 2}
       :current {:work/id [:rf.work/resource [:rf.mutation :form/save-1] 3] :generation 3}
       :extra   (merge {:rf.reply/work-id      [:rf.work/resource [:rf.mutation :form/save-1] 2]
@@ -226,7 +226,7 @@
 (defn- route-stale-out
   ([] (route-stale-out nil))
   ([ctx-more]
-   (route-reply/suppress (merge {:route-id  :route/article
+   (rf.routing.reply/suppress (merge {:route-id  :route/article
                                  :nav-token "nav-1"
                                  :loader-id :article/loaded
                                  :frame     :app/main}
@@ -243,7 +243,7 @@
 ;; omission.
 ;;
 ;; Terminals EXCLUDED from the gate (see `time-pair-exclusions`): HTTP stale
-;; (`http-reply/suppress` hard-codes its stale `:extra` — no completion-time
+;; (`rf.http.reply/suppress` hard-codes its stale `:extra` — no completion-time
 ;; slot), machine cancel (`cancelled-actor-reply`) and timer cancel
 ;; (`cancelled-timer-reply`) take no `:completed-at` parameter — an
 ;; actor-destroy / timer-cancel terminal is a correlation row, not a causal
@@ -252,35 +252,35 @@
 ;; ---------------------------------------------------------------------------
 
 ;; HTTP failure/abort lower through `base-reply`, which threads `:completed-at`.
-(defn- http-error-with-time  [] (http-reply/failure-reply http-ctx a-failure))
-(defn- http-error-no-time    [] (http-reply/failure-reply (dissoc http-ctx :completed-at) a-failure))
-(defn- http-cancel-with-time [] (http-reply/failure-reply http-ctx an-abort))
-(defn- http-cancel-no-time   [] (http-reply/failure-reply (dissoc http-ctx :completed-at) an-abort))
+(defn- http-error-with-time  [] (rf.http.reply/failure-reply http-ctx a-failure))
+(defn- http-error-no-time    [] (rf.http.reply/failure-reply (dissoc http-ctx :completed-at) a-failure))
+(defn- http-cancel-with-time [] (rf.http.reply/failure-reply http-ctx an-abort))
+(defn- http-cancel-no-time   [] (rf.http.reply/failure-reply (dissoc http-ctx :completed-at) an-abort))
 
 ;; Resource/mutation failure/abort thread `:completed-at` from the opts map —
 ;; the causal fact closed bug rf2-rl27r2 / PR #4473 repaired (pinned only
 ;; family-locally before; this closes the umbrella gap Finding 1 names).
 (defn- resource-error-with-time []
-  (rreply/failure-reply resource-vp a-failure
-                        {:work-kind rreply/work-kind-resource :completed-at completion-time-ms}))
+  (rf.resources.reply/failure-reply resource-vp a-failure
+                        {:work-kind rf.resources.reply/work-kind-resource :completed-at completion-time-ms}))
 (defn- resource-error-no-time []
-  (rreply/failure-reply resource-vp a-failure {:work-kind rreply/work-kind-resource}))
+  (rf.resources.reply/failure-reply resource-vp a-failure {:work-kind rf.resources.reply/work-kind-resource}))
 (defn- resource-cancel-with-time []
-  (rreply/failure-reply resource-vp an-abort
-                        {:work-kind rreply/work-kind-resource :completed-at completion-time-ms}))
+  (rf.resources.reply/failure-reply resource-vp an-abort
+                        {:work-kind rf.resources.reply/work-kind-resource :completed-at completion-time-ms}))
 (defn- resource-cancel-no-time []
-  (rreply/failure-reply resource-vp an-abort {:work-kind rreply/work-kind-resource}))
+  (rf.resources.reply/failure-reply resource-vp an-abort {:work-kind rf.resources.reply/work-kind-resource}))
 
 (defn- mutation-error-with-time []
-  (rreply/failure-reply mutation-vp a-failure
-                        {:work-kind rreply/work-kind-mutation :completed-at completion-time-ms}))
+  (rf.resources.reply/failure-reply mutation-vp a-failure
+                        {:work-kind rf.resources.reply/work-kind-mutation :completed-at completion-time-ms}))
 (defn- mutation-error-no-time []
-  (rreply/failure-reply mutation-vp a-failure {:work-kind rreply/work-kind-mutation}))
+  (rf.resources.reply/failure-reply mutation-vp a-failure {:work-kind rf.resources.reply/work-kind-mutation}))
 (defn- mutation-cancel-with-time []
-  (rreply/failure-reply mutation-vp an-abort
-                        {:work-kind rreply/work-kind-mutation :completed-at completion-time-ms}))
+  (rf.resources.reply/failure-reply mutation-vp an-abort
+                        {:work-kind rf.resources.reply/work-kind-mutation :completed-at completion-time-ms}))
 (defn- mutation-cancel-no-time []
-  (rreply/failure-reply mutation-vp an-abort {:work-kind rreply/work-kind-mutation}))
+  (rf.resources.reply/failure-reply mutation-vp an-abort {:work-kind rf.resources.reply/work-kind-mutation}))
 
 ;; Resource/mutation stale thread `:completed-at` via the suppress `:extra`.
 (defn- resource-stale-with-time [] (:reply (resource-stale-out {:completed-at completion-time-ms})))
@@ -290,18 +290,18 @@
 
 ;; Machine spawn-error threads `:completed-at` through `base-reply`; `machine-ctx`
 ;; already carries one, so the with-time builder reuses it directly.
-(defn- machine-error-with-time [] (m-reply/error-reply machine-ctx {:reason :bad-creds}))
-(defn- machine-error-no-time   [] (m-reply/error-reply (dissoc machine-ctx :completed-at) {:reason :bad-creds}))
+(defn- machine-error-with-time [] (rf.machines.reply/error-reply machine-ctx {:reason :bad-creds}))
+(defn- machine-error-no-time   [] (rf.machines.reply/error-reply (dissoc machine-ctx :completed-at) {:reason :bad-creds}))
 
 ;; Machine spawn-stale threads `:completed-at` when the ctx supplies one
 ;; (`machine-stale-reply` already carries it; this is its no-time companion).
 (defn- machine-stale-no-time []
-  (m-reply/stale-spawn-reply (assoc (dissoc machine-ctx :completed-at) :current-generation nil)))
+  (rf.machines.reply/stale-spawn-reply (assoc (dissoc machine-ctx :completed-at) :current-generation nil)))
 
 ;; Timer `:after`-stale threads `:completed-at` when the firing dispatch
 ;; supplied it (`after-stale-reply` above is its no-time companion).
 (defn- after-stale-reply-with-time []
-  (m-reply/after-stale-reply
+  (rf.machines.reply/after-stale-reply
     {:actor-id        :a/multi
      :state           :loading
      :delay           30000
@@ -318,10 +318,10 @@
 (def ^:private families
   [{:family          :http
     :work-head       :rf.work/http
-    :success         #(http-reply/success-reply http-ctx {:title "Welcome"})
+    :success         #(rf.http.reply/success-reply http-ctx {:title "Welcome"})
     :success-no-time http-success-no-time
-    :error           #(http-reply/failure-reply http-ctx a-failure)
-    :cancel          #(http-reply/failure-reply http-ctx an-abort)
+    :error           #(rf.http.reply/failure-reply http-ctx a-failure)
+    :cancel          #(rf.http.reply/failure-reply http-ctx an-abort)
     ;; Non-success completion-time pairs (HTTP stale excluded — `suppress`
     ;; hard-codes its `:extra` with work-id facts only).
     :error-with-time  http-error-with-time
@@ -334,14 +334,14 @@
 
    {:family          :resource
     :work-head       :rf.work/resource
-    :success         #(rreply/success-reply resource-vp {:title "Welcome"}
-                                            {:work-kind rreply/work-kind-resource
+    :success         #(rf.resources.reply/success-reply resource-vp {:title "Welcome"}
+                                            {:work-kind rf.resources.reply/work-kind-resource
                                              :completed-at completion-time-ms})
     :success-no-time resource-success-no-time
-    :error           #(rreply/failure-reply resource-vp a-failure
-                                            {:work-kind rreply/work-kind-resource})
-    :cancel          #(rreply/failure-reply resource-vp an-abort
-                                            {:work-kind rreply/work-kind-resource})
+    :error           #(rf.resources.reply/failure-reply resource-vp a-failure
+                                            {:work-kind rf.resources.reply/work-kind-resource})
+    :cancel          #(rf.resources.reply/failure-reply resource-vp an-abort
+                                            {:work-kind rf.resources.reply/work-kind-resource})
     :error-with-time  resource-error-with-time
     :error-no-time    resource-error-no-time
     :cancel-with-time resource-cancel-with-time
@@ -353,14 +353,14 @@
 
    {:family          :mutation
     :work-head       :rf.work/resource ;; mutation reuses the resource head with a [:rf.mutation …] key
-    :success         #(rreply/success-reply mutation-vp {:slug "w" :title "Welcome"}
-                                            {:work-kind rreply/work-kind-mutation
+    :success         #(rf.resources.reply/success-reply mutation-vp {:slug "w" :title "Welcome"}
+                                            {:work-kind rf.resources.reply/work-kind-mutation
                                              :completed-at completion-time-ms})
     :success-no-time mutation-success-no-time
-    :error           #(rreply/failure-reply mutation-vp a-failure
-                                            {:work-kind rreply/work-kind-mutation})
-    :cancel          #(rreply/failure-reply mutation-vp an-abort
-                                            {:work-kind rreply/work-kind-mutation})
+    :error           #(rf.resources.reply/failure-reply mutation-vp a-failure
+                                            {:work-kind rf.resources.reply/work-kind-mutation})
+    :cancel          #(rf.resources.reply/failure-reply mutation-vp an-abort
+                                            {:work-kind rf.resources.reply/work-kind-mutation})
     :error-with-time  mutation-error-with-time
     :error-no-time    mutation-error-no-time
     :cancel-with-time mutation-cancel-with-time
@@ -372,11 +372,11 @@
 
    {:family          :machine
     :work-head       :rf.work/machine
-    :success         #(m-reply/success-reply machine-ctx {:user-id "u-42"})
+    :success         #(rf.machines.reply/success-reply machine-ctx {:user-id "u-42"})
     :success-no-time machine-success-no-time
-    :error           #(m-reply/error-reply machine-ctx {:reason :bad-creds})
+    :error           #(rf.machines.reply/error-reply machine-ctx {:reason :bad-creds})
     ;; Destroying an actor closes its work attempt with cancellation data.
-    :cancel          #(m-reply/cancelled-actor-reply
+    :cancel          #(rf.machines.reply/cancelled-actor-reply
                         (assoc machine-ctx :reason :explicit))
     ;; Spawn-error + spawn-stale carry completion time; actor-destroy cancel
     ;; does not (see `time-pair-exclusions`).
@@ -395,7 +395,7 @@
     :success-no-time after-fired-reply
     :error           nil
     ;; State exit closes an outstanding timer with cancellation data.
-    :cancel          #(m-reply/cancelled-timer-reply
+    :cancel          #(rf.machines.reply/cancelled-timer-reply
                         {:actor-id  :a/multi
                          :state     :loading
                          :delay     30000
@@ -448,10 +448,10 @@
   each builder is fed an input context that DOES carry a completion time, so the
   companion test proves the builder omits `:completed-at` regardless."
   [[:http    :stale  #(:reply (http-stale-out))
-    "http-reply/suppress hard-codes its stale :extra map (work-id facts only)"]
-   [:machine :cancel #(m-reply/cancelled-actor-reply (assoc machine-ctx :reason :explicit))
+    "rf.http.reply/suppress hard-codes its stale :extra map (work-id facts only)"]
+   [:machine :cancel #(rf.machines.reply/cancelled-actor-reply (assoc machine-ctx :reason :explicit))
     "cancelled-actor-reply takes no :completed-at parameter"]
-   [:timer   :cancel #(m-reply/cancelled-timer-reply
+   [:timer   :cancel #(rf.machines.reply/cancelled-timer-reply
                         {:actor-id     :a/multi
                          :state        :loading
                          :delay        30000
@@ -571,21 +571,21 @@
           :when builder
           :let [reply (builder)]]
     (testing (str family " / " situation)
-      (is (reply/valid-reply? reply)
+      (is (rf.reply/valid-reply? reply)
           (str family " " situation " reply MUST validate against the shared "
-               "re-frame.reply/validate-reply: " (reply/validate-reply reply)))
+               "re-frame.reply/validate-reply: " (rf.reply/validate-reply reply)))
       (testing ":status is in the closed status vocabulary"
-        (is (contains? reply/statuses (:status reply))
+        (is (contains? rf.reply/statuses (:status reply))
             (str family " " situation " :status " (:status reply)
-                 " is not in the closed " reply/statuses)))
+                 " is not in the closed " rf.reply/statuses)))
       (testing ":rf.reply/work-status is in the closed work-status vocabulary"
         (when (contains? reply :rf.reply/work-status)
-          (is (contains? reply/work-statuses (:rf.reply/work-status reply))
+          (is (contains? rf.reply/work-statuses (:rf.reply/work-status reply))
               (str family " " situation " :rf.reply/work-status " (:rf.reply/work-status reply)
-                   " is not in the closed " reply/work-statuses))))
+                   " is not in the closed " rf.reply/work-statuses))))
       (testing "the reply contains no host handles"
         (is (not-any? #(= :rf.reply/host-handle (:rf.reply/problem %))
-                      (reply/validate-reply reply))
+                      (rf.reply/validate-reply reply))
             (str family " " situation " reply carries a host handle"))))))
 
 ;; ---------------------------------------------------------------------------
@@ -675,7 +675,7 @@
   ;; their work ids share the actor-prefixed logical id.
   (let [fired  (:rf.reply/work-id (after-fired-reply))
         stale  (:rf.reply/work-id (after-stale-reply))
-        cancel (:rf.reply/work-id (m-reply/cancelled-timer-reply
+        cancel (:rf.reply/work-id (rf.machines.reply/cancelled-timer-reply
                            {:actor-id  :a/multi
                             :state     :loading
                             :delay     30000
@@ -761,9 +761,9 @@
                  "sentinel would let a reducer derive a bogus durable "
                  "timestamp). Got " (pr-str (:completed-at reply))))
         ;; Omitting the optional fact must not invalidate the envelope.
-        (is (reply/valid-reply? reply)
+        (is (rf.reply/valid-reply? reply)
             (str family " no-time success reply still validates: "
-                 (reply/validate-reply reply)))
+                 (rf.reply/validate-reply reply)))
         (is (= :ok (:status reply))
             (str family " no-time success is still :status :ok"))))))
 
@@ -866,12 +866,12 @@
                  "would let a reducer derive a bogus durable timestamp). Got "
                  (pr-str (:completed-at no-reply)))))
       (testing (str family " / " situation " → both replies still validate")
-        (is (reply/valid-reply? with-reply)
+        (is (rf.reply/valid-reply? with-reply)
             (str family " " situation " with-time reply must validate: "
-                 (reply/validate-reply with-reply)))
-        (is (reply/valid-reply? no-reply)
+                 (rf.reply/validate-reply with-reply)))
+        (is (rf.reply/valid-reply? no-reply)
             (str family " " situation " no-time reply must validate: "
-                 (reply/validate-reply no-reply)))))))
+                 (rf.reply/validate-reply no-reply)))))))
 
 (deftest excluded-terminals-omit-completion-time-even-when-supplied
   (testing "a terminal whose builder does not accept a causal completion time
@@ -885,9 +885,9 @@
                reason ") — its reply MUST NOT carry :completed-at even when the "
                "input context supplies one; got " (pr-str (:completed-at reply))))
       ;; The excluded terminal is still a canonical, valid reply.
-      (is (reply/valid-reply? reply)
+      (is (rf.reply/valid-reply? reply)
           (str family " " situation " excluded terminal still validates: "
-               (reply/validate-reply reply))))))
+               (rf.reply/validate-reply reply))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Error shape: :status :error, a terminal failure work status, and a
@@ -911,11 +911,11 @@
 
 (deftest http-timeout-is-error-plus-timed-out-work-status
   (testing "timeout is an error reply with :timed-out work status"
-    (let [reply (http-reply/failure-reply http-ctx {:kind :rf.http/timeout :limit-ms 30000 :elapsed-ms 30012})]
-      (is (reply/valid-reply? reply) (str (reply/validate-reply reply)))
+    (let [reply (rf.http.reply/failure-reply http-ctx {:kind :rf.http/timeout :limit-ms 30000 :elapsed-ms 30012})]
+      (is (rf.reply/valid-reply? reply) (str (rf.reply/validate-reply reply)))
       (is (= :error (:status reply)) "timeout is NOT a top-level :status")
       (is (= :timed-out (:rf.reply/work-status reply)))
-      (is (contains? reply/work-statuses (:rf.reply/work-status reply))
+      (is (contains? rf.reply/work-statuses (:rf.reply/work-status reply))
           ":timed-out is in the closed work-status vocabulary"))))
 
 ;; ---------------------------------------------------------------------------
@@ -953,8 +953,8 @@
           :when stale
           :let [reply (stale)]]
     (testing (str family " stale → canonical :stale / :suppressed")
-      (is (reply/valid-reply? reply)
-          (str family " stale reply must validate: " (reply/validate-reply reply)))
+      (is (rf.reply/valid-reply? reply)
+          (str family " stale reply must validate: " (rf.reply/validate-reply reply)))
       (is (= :stale (:status reply))
           (str family " stale :status must be :stale (NOT a bespoke shape), got "
                (:status reply)))
@@ -1050,8 +1050,8 @@
       ;; The reply remains a valid :ok envelope because completion time is optional.
       (is (= :ok (:status bad))
           (str family " control reply is still :status :ok"))
-      (is (reply/valid-reply? bad)
-          (str family " control reply still validates: " (reply/validate-reply bad)))
+      (is (rf.reply/valid-reply? bad)
+          (str family " control reply still validates: " (rf.reply/validate-reply bad)))
       ;; The teeth: the propagation predicate the primary asserts TRUE must go
       ;; FALSE on the dropped fact. Gutting the predicate reddens this control.
       (is (not (completion-time-propagated? bad completion-time-ms))
@@ -1076,8 +1076,8 @@
     (doseq [{:keys [family situation with-builder]} time-paired-rows
             :let [bad (drop-completion-time (with-builder))]]
       ;; Completion time is optional, so the reply is otherwise still valid.
-      (is (reply/valid-reply? bad)
-          (str family " " situation " control still validates: " (reply/validate-reply bad)))
+      (is (rf.reply/valid-reply? bad)
+          (str family " " situation " control still validates: " (rf.reply/validate-reply bad)))
       ;; The teeth: the SHARED propagation predicate must go FALSE on the drop.
       (is (not (completion-time-propagated? bad completion-time-ms))
           (str family " " situation " control DROPPED :completed-at, yet the "

--- a/implementation/spec-resource/test/re_frame/build/spec_resource_test.clj
+++ b/implementation/spec-resource/test/re_frame/build/spec_resource_test.clj
@@ -35,7 +35,7 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.build.spec-resource :as spec-resource]))
+            [re-frame.build.spec-resource :as rf.build.spec-resource]))
 
 (def ^:private cold-load-iterations
   "Iterations per shape. Each one generates and cold-loads a fresh
@@ -206,7 +206,7 @@
             finished loading"
     (dotimes [_ cold-load-iterations]
       (let [{:keys [probe-var-symbol during-load observer-result loader-result]}
-            (observe-resolver-during-load spec-resource/resolve-after-require)]
+            (observe-resolver-during-load rf.build.spec-resource/resolve-after-require)]
         (is (= ::blocked during-load)
             (str probe-var-symbol
                  ": the observer must WAIT on the require lock rather than "
@@ -223,5 +223,5 @@
                                     (doto (promise) (deliver :go)))
           fixture-ns-symbol (write-blocked-fixture-namespace! release-gate-name)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"is not defined after loading"
-            (spec-resource/resolve-after-require
+            (rf.build.spec-resource/resolve-after-require
              (symbol (name fixture-ns-symbol) "absent")))))))

--- a/scripts/require-alias-baseline.edn
+++ b/scripts/require-alias-baseline.edn
@@ -14,7 +14,7 @@
 ;; observes. It is not a style rule: it is what stops the checker
 ;; reporting a confident zero over a corpus it has stopped being able
 ;; to read.
-{:min-edges 9692
+{:min-edges 9695
 
  :surfaces
  {
@@ -24,20 +24,20 @@
   "examples"                              65
   "implementation/adapters"               339
   "implementation/core"                   0
-  "implementation/derivation-conformance" 19
+  "implementation/derivation-conformance" 0
   "implementation/epoch"                  196
-  "implementation/event-conformance"      21
+  "implementation/event-conformance"      0
   "implementation/flows"                  155
   "implementation/hicasso"                1017
   "implementation/http"                   0
   "implementation/machines"               0
-  "implementation/reply-conformance"      13
+  "implementation/reply-conformance"      0
   "implementation/resources"              0
   "implementation/routing"                0
   "implementation/schemas"                112
   "implementation/scripts"                46
   "implementation/security"               45
-  "implementation/spec-resource"          1
+  "implementation/spec-resource"          0
   "implementation/ssr"                    399
   "implementation/ssr-ring"               129
   "implementation/test-quiet"             5


### PR DESCRIPTION
First cleanup slice of the require-alias campaign (rf2-7sx1) since PR #9154 made
the baseline writer monotonic. **rf2-7sx1 stays open** — it is the campaign roster,
not this slice; twenty-plus surfaces remain.

## What changed

Four surfaces driven to **zero** non-canonical re-frame require aliases, each with
its baseline floor lowered **in the same commit**, because the ratchet is two-sided:
a surface *below* its floor reds the gate exactly as one above it does.

| surface | before | after | floor |
|---|---|---|---|
| `implementation/spec-resource` | 1 | 0 | 1 → 0 |
| `implementation/reply-conformance` | 13 | 0 | 13 → 0 |
| `implementation/derivation-conformance` | 19 | 0 | 19 → 0 |
| `implementation/event-conformance` | 21 | 0 | 21 → 0 |

**Repo-wide non-canonical: 5640 → 5586** (−54). File and edge totals unchanged at
2773 / 10773 — this is a pure rename, and the diff is 339 insertions / 339
deletions with no line added or removed anywhere.

54 libspecs and 288 use sites moved to the canonical `rf.<dotted-tail>` dialect
fixed by `spec/Conventions.md` §Require-alias dialect (`re-frame.core` keeps the
bare root alias `rf`; every other `re-frame.<tail>` takes the full dotted tail).
The mapping came from the checker's own `--verbose` output, never a hand-built
table, so the rename cannot disagree with the gate. No namespace was restructured
and no `ns` form reordered beyond what the rename required.

`docs` (16) was deliberately left alone — different tree, its own slice.

## `:min-edges` 9692 → 9695

`:min-edges` is the anti-blindness guard, not an allowance: it is checked
`total < min_edges -> fail`, so a **rise tightens** the gate. `int(10773 * 0.9)`
= 9695, and the bump tracks the trunk's edge count growing since the file was last
written (10769 → 10773) — it is not an effect of this change, whose edge count is
10773 before and after. Produced by `--write-baseline`, whose refusal of any
proposed floor *increase* is what made running it safe here.

## The three literal shapes

A rename that hits a keyword or a string rather than an alias is the silent failure
mode, so each shape was counted separately, and each pattern controlled against a
fixture **sharing its shape** (plus a negative control) so a zero is a check that
passed rather than a wrong pattern:

- `:alias/key` single-colon literals (must NOT move): **0**
- `::alias/kw` auto-resolved keywords (MUST move with the libspec): **0**
- `"alias/…"` strings (must NOT move): **1**

The one string is a `time-pair-exclusions` reason field naming `http-reply/suppress`.
It is only ever checked non-empty and interpolated into a failure message — never
compared — so it was updated **by hand, deliberately**, to match the comment 200
lines above it that the rename had already made accurate. Every other string body
is untouched. A residue sweep for surviving old aliases (control: positive 1,
dotted-prefix 0, alnum-prefix 0) reads **0**.

## Gates

Each captured with its own redirect and `echo $?` on one command line; the number
quoted is the captured one.

| gate | exit |
|---|---|
| `check_require_alias_dialect.py --verbose` (CI's invocation) | **0** — clean, every surface at or under floor |
| `check_require_alias_dialect.py --self-test` | **0** — 79 passed, 0 failed (unmoved) |
| `spec-resource` `clojure -M:test` | **0** — 3 tests / 126 assertions |
| `reply-conformance` `clojure -M:test` | **0** — 30 tests / 556 assertions |
| `derivation-conformance` `clojure -M:test` | **0** — 23 tests / 526 assertions |
| `event-conformance` `clojure -M:test` | **0** — 44 tests / 186 assertions |
| `npm run test:cljs` (compile + node-test) | **0** — 1892 files, 0 warnings; 11174 tests / 55752 assertions |

The CLJS run is load-bearing rather than belt-and-braces: `derivation_algebra_…cljc`
carries a `#?(:cljs …)`-only deftest using renamed aliases that no JVM lane reads.
All 54 renamed libspecs sit outside reader conditionals, so the JVM lanes resolved
every one.

## Sabotage

Two planted faults, each restored and the restore verified by comparing the git
**blob** hash against the pre-plant object:

- Reverted one libspec to `[re-frame.fx :as fx]` → ratchet **exit 1**, naming the
  file, line and alias, against a floor of 0 that exists only on this branch.
- Typo'd the `spec-resource` alias → its JVM suite **exit 1** at
  `spec_resource_test.clj:209`.

Both faults exist only in this worktree, so a run that had wandered into a sibling
checkout would have come back green. The `shadow-cljs` log independently names this
worktree's own `shadow-cljs.edn`.

Gates were re-run on the final rebased base; the only trunk commit since the branch
point is a beads checkpoint touching no code.
