### PR TITLE
Stale spec-resource comments + skill-package gate scan surface (rf2-8esm, rf2-pp72)

### DIFF
--- a/implementation/README.md
+++ b/implementation/README.md
@@ -215,8 +215,8 @@ implementation/
                              reader is a cold-load race that two independent resolvers lose
                              to each other.
     deps.edn                 No runtime deps, and none on shadow-cljs; build/test-time only.
-    src/re_frame/build/spec_resource.clj  Recording read + walk-up fallback + the
-                             require-before-resolve that makes the reader cold-load-safe.
+    src/re_frame/build/spec_resource.clj  Recording read + the require-before-resolve
+                             that makes the reader cold-load-safe.
     test/re_frame/build/           The deterministic race control: it holds the
                              interned-but-unbound window open and drives two independent
                              resolver sites into it.

--- a/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj
+++ b/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj
@@ -97,9 +97,11 @@
 ;; namespace docstring. The JVM lanes were never affected: the manifest
 ;; generator re-reads the sidecar on every `clojure -M -m
 ;; re-frame.api-manifest.gen --check`, so it has no cache to invalidate,
-;; and the reader's non-ClojureScript path locates the same file by
-;; walking up from the compile CWD rather than requiring `spec/` on that
-;; classpath.
+;; and it does not go through this reader at all — it locates the same
+;; file by walking up from its own deps.edn directory rather than
+;; requiring `spec/` on that classpath. The reader itself has a
+;; ClojureScript lane and no other: `slurp-resource` requires an `&env`
+;; carrying `:ns` and rejects anything else.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private sidecar-resource

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -165,13 +165,12 @@
                 ;; (day8/re-frame2-spec-resource). Both macros named under
                 ;; the `../spec` root below go through it, and it is on
                 ;; this classpath so they can: it owns the shadow-cljs
-                ;; recording read, the non-ClojureScript walk-up fallback,
-                ;; and — the reason it is ONE namespace rather than a
-                ;; helper copied into each consumer — the cold-load
-                ;; resolution of `shadow.resource/slurp-resource`, which
-                ;; two independent resolvers race however carefully each
-                ;; one guards itself. JVM-only source; nothing compilable
-                ;; into a bundle.
+                ;; recording read and — the reason it is ONE namespace
+                ;; rather than a helper copied into each consumer — the
+                ;; cold-load resolution of
+                ;; `shadow.resource/slurp-resource`, which two independent
+                ;; resolvers race however carefully each one guards itself.
+                ;; JVM-only source; nothing compilable into a bundle.
                 "spec-resource/src"
                 ;; `spec/` as a classpath ROOT — the one root under which
                 ;; every committed spec-side DATA file a build inlines is

--- a/scripts/check_skill_package_refs.py
+++ b/scripts/check_skill_package_refs.py
@@ -13,8 +13,16 @@ left to caveat.)
 The invariant this gate enforces — in-package link resolution (rf2-deo2zp):
 
     For every packaged skill, every INTRA-package relative link from a shipped
-    doc (SKILL.md / README.md / references/**.md) MUST resolve to a file the
-    package.json `files` allow-list ships.
+    doc MUST resolve to a file the package.json `files` allow-list ships.
+
+"Shipped doc" is DERIVED from that same allow-list rather than from a roster of
+directory names (rf2-pp72). The docs a packaged install can resolve links inside
+are exactly the markdown files the tarball contains, so `patterns/`,
+`decision-trees/` and a top-level `examples-map.md` are scanned on the day
+`files` starts shipping them — there is no second list to keep in step, which is
+what let the roster fall behind the allow-list in the first place. A doc `files`
+omits is not in the tarball at all, so its links cannot break a packaged install
+and it is correctly out of scope.
 
 "Intra-package" is decided by where a link RESOLVES, not by how it is spelled
 (rf2-kgw8z). A `../` from a nested doc usually lands back inside the package —
@@ -142,19 +150,21 @@ def _is_shipped(rel_target: str, allow: list[str]) -> bool:
     return False
 
 
-def _shipped_docs_with_links(skill_dir: Path) -> Iterable[Path]:
+def _shipped_docs_with_links(skill_dir: Path, allow: list[str]) -> Iterable[Path]:
     """Yield shipped markdown docs whose intra-package links we validate.
 
-    SKILL.md, README.md, and every references/**.md leaf — the docs that ship in
-    the package and that a packaged install resolves links inside.
+    Every markdown file the `files` allow-list ships — decided by the same
+    [[_is_shipped]] predicate the link TARGETS are checked against, so the two
+    halves of the invariant cannot drift apart (rf2-pp72).
+
+    This replaced a hardcoded SKILL.md / README.md / references/**.md roster
+    that had already fallen behind: `skills/re-frame2` ships `patterns/`,
+    `decision-trees/` and `examples-map.md`, and `skills/re-frame2-pair` ships
+    `docs/` and `STATUS.md`, none of which the roster named — so a link from
+    any of them to an unshipped path was invisible here.
     """
-    for name in ("SKILL.md", "README.md"):
-        p = skill_dir / name
-        if p.is_file():
-            yield p
-    refs = skill_dir / "references"
-    if refs.is_dir():
-        for md in sorted(refs.rglob("*.md")):
+    for md in sorted(skill_dir.rglob("*.md")):
+        if _is_shipped(md.relative_to(skill_dir).as_posix(), allow):
             yield md
 
 
@@ -164,7 +174,7 @@ def _broken_package_links(skill_dir: Path) -> list[str]:
     if allow is None:
         return []
     findings: list[str] = []
-    for doc in _shipped_docs_with_links(skill_dir):
+    for doc in _shipped_docs_with_links(skill_dir, allow):
         rel_doc = doc.relative_to(skill_dir)
         text = doc.read_text(encoding="utf-8", errors="replace")
         for line in text.splitlines():
@@ -267,6 +277,7 @@ def _make_skill(
     files: list[str] | None = None,  # package.json `files`; None -> ["SKILL.md"]
     skill_link: str | None = None,   # an intra-package link to embed in SKILL.md
     ref_link: str | None = None,     # a link to embed in references/lens.md
+    pattern_link: str | None = None, # a link to embed in patterns/example.md
     create_docs: bool = False,       # create docs/SETUP.md on disk
     monorepo_only: bool = False,     # mark the link's line monorepo-only
 ) -> None:
@@ -294,6 +305,13 @@ def _make_skill(
     if ref_link is not None:
         ref_body += f"See [design]({ref_link}){suffix}.\n"
     _write(d / "references" / "lens.md", ref_body)
+    # patterns/example.md is the rf2-pp72 shape: a doc the old hardcoded
+    # roster never scanned, shipped or not.
+    if pattern_link is not None:
+        _write(
+            d / "patterns" / "example.md",
+            f"# pattern\nSee [setup]({pattern_link}){suffix}.\n",
+        )
     _write(d / "README.md", "# readme\n")
 
 
@@ -392,6 +410,45 @@ def _run_self_tests(verbose: bool = False) -> int:
                 package=True,
                 files=["SKILL.md", "README.md", "references/", "docs/"],
                 ref_link="../docs/NEVER-CREATED.md",
+            ),
+            0,
+        ),
+        # rf2-pp72 — THE WIDENING CASE. A shipped `patterns/` doc links to a
+        # path `files` omits. Under the old hardcoded SKILL/README/references
+        # roster this doc was never opened, so the finding was invisible and
+        # this case returned 0. It is the negative fixture proving the scan
+        # surface is genuinely derived from the allow-list.        -> 1
+        (
+            "bad_patterns_doc_unshipped_link",
+            dict(
+                package=True,
+                files=["SKILL.md", "README.md", "patterns"],
+                pattern_link="../docs/SETUP.md",
+                create_docs=True,
+            ),
+            1,
+        ),
+        # the same shipped `patterns/` doc, but the target IS shipped   -> 0
+        (
+            "ok_patterns_doc_shipped_link",
+            dict(
+                package=True,
+                files=["SKILL.md", "README.md", "patterns", "docs"],
+                pattern_link="../docs/SETUP.md",
+                create_docs=True,
+            ),
+            0,
+        ),
+        # the derivation's OTHER half: `patterns/` is NOT in `files`, so the
+        # doc is absent from the tarball and its links cannot break a packaged
+        # install. Out of scope by construction rather than by omission. -> 0
+        (
+            "ok_unshipped_patterns_dir_is_not_scanned",
+            dict(
+                package=True,
+                files=["SKILL.md", "README.md"],
+                pattern_link="../docs/SETUP.md",
+                create_docs=True,
             ),
             0,
         ),


### PR DESCRIPTION
Two small, independent corrections.

## rf2-8esm — the prose stops crediting the reader with a removed fallback

`904a8e4668` ("the reader has one lane, so drop the other") removed
`slurp-resource`'s non-ClojureScript branch, along with the `classpath-root`
and `spec-file` helpers that walked up the tree to locate the committed file
outside a ClojureScript compile. Three comments still credited the reader with
that fallback.

**Nothing validates a comment's truth, so each surviving clause was checked by
hand against the code it describes.** What I read, clause by clause:

| Clause | Verdict | Code read |
| --- | --- | --- |
| "it owns the shadow-cljs recording read" | **kept — live** | `spec_resource.clj` `recording-slurp` (resolves `shadow.resource/slurp-resource`, cached in a `delay`) and its single call site at the end of `slurp-resource` |
| "the non-ClojureScript walk-up fallback" | **removed — dead** | `slurp-resource` now opens with a `when-not (:ns env)` that throws; the namespace docstring states the recorded edge "is the only lane this reader has". No `clojure.java.io` require remains |
| "the cold-load resolution of `shadow.resource/slurp-resource`, which two independent resolvers race" | **kept — live** | `resolve-after-require` (takes `clojure.lang.RT/REQUIRE_LOCK` before resolving) and the docstring section explaining why a per-consumer `delay` does not fix it — which is precisely the "ONE namespace rather than a helper copied into each consumer" justification |

Three sites corrected:

- **`implementation/shadow-cljs.edn`** — dropped the dead clause from the
  reader's `:source-paths` comment, keeping the two live ones.
- **`implementation/scripts/api-manifest/probe/.../cljs_publics.clj`** —
  attributed the walk-up to "the reader's non-ClojureScript path". The walk-up
  is real but it belongs to the **JVM generator**: `gen.clj` derives `repo-root`
  by walking up three levels from `user.dir` and reads the sidecar with
  `io/file`, never touching this reader. Reworded to say so, and to record that
  the reader has a ClojureScript lane and no other.
- **`implementation/README.md`** — the artefact map listed "walk-up fallback"
  among the file's contents.

**Census.** The bead recorded that its own repo-wide scan had been killed at the
command timeout and asked for the census to be redone. Done scoped per
directory, unpiped, with a per-directory exit code, on two axes because the
target wraps across lines: the exact hyphenated token `walk-up` (a single token,
so line breaks cannot hide it), and the rare `CWD` token (which catches the
`cljs_publics.clj` wording, which never says "walk-up" at all and which the
first axis therefore missed). Every zero was controlled against a search that
returns hits — `tools/` still reports its four unrelated `walk-up` uses after
the edits, so the instrument is known to bite. That second axis is what found
the third site; the bead and the brief between them named only two.

**One candidate deliberately left alone.** `implementation/shadow-cljs.edn:206`
("The JVM lanes ... do not carry this root: each walks up from the compile CWD
instead") is a claim about the lanes, not about the reader, and it still holds —
see `gen.clj`'s `repo-root`. Not a defect, not touched.

**Hot-zone discipline.** The `shadow-cljs.edn` diff is a single hunk in which
every added and removed line is a `;;` comment. No build id, `:dev-http` port,
`:output-dir` or other config is touched, and this was verified rather than
eyeballed: both files were parsed as EDN and the parsed values compared for
equality against `origin/main` (`CONFIG-EQUAL= true`, `BUILD-IDS-EQUAL= true`,
exit 0). The comparison was shown to bite in both of its halves — a planted
port change returned `CONFIG-EQUAL= false` / exit 1, and a planted unbalanced
brace returned an EDN parse error / exit 1. Both plants were reverted and the
restore verified by git blob hash rather than by reading a diff.

## rf2-pp72 — the gate's scan surface is derived, not hardcoded

`_shipped_docs_with_links` yielded a hardcoded SKILL.md / README.md /
`references/**.md` roster, while the invariant it serves is about the docs the
**tarball** contains. The roster had fallen behind the allow-lists.

**Re-measured at this tip: 22 of the 125 shipped link-carrying markdown files
sat outside the scan surface**, across two skills — `skills/re-frame2`'s
`patterns/` (14), `decision-trees/` (2) and `examples-map.md`, and
`skills/re-frame2-pair`'s `docs/` (4) and `STATUS.md`. The bead recorded 8 of
80; the gap is larger than filed, and includes a skill the bead did not name.

The fix removes the second list rather than extending it: the docs to scan are
now decided by the same `_is_shipped` predicate the link **targets** are checked
against, so the two halves of the invariant cannot drift apart again. This is a
pure widening — every packaged skill already allow-lists its own SKILL.md,
README.md and `references/`, so no currently-scanned doc leaves the surface
(checked per skill before making the change).

**The widening finds nothing new: the live gate stays green across all 9
packaged skills.** The latent hole is closed without touching the link
population, so rf2-nvbz's escaping-links question is untouched and remains
fenced.

**Proof the widening is real**, run both ways against the same tree: a probe
file planted under `skills/re-frame2/patterns/` linking an unshipped path is
**exit 0 under the pre-change checker** and **exit 1 under this one**, naming
the file and the omitted target. The probe was then deleted — `skills/` is not
this PR's to edit — and the permanent negative fixture is a self-test case.

Three self-test cases pin the behaviour: a shipped `patterns/` doc linking an
unshipped path (1 finding, and 0 under the old roster — the regression this
prevents), the same doc with a shipped target (0), and an **unshipped**
`patterns/` dir whose doc is correctly not scanned at all, since a doc absent
from the tarball cannot break a packaged install.

## Gates

Every exit code below was captured with the runner's own `$?` on the same
command line as the redirect, never through a pipe, and re-run after the rebase.

| Gate | Exit | Result |
| --- | --- | --- |
| EDN parse + config equality vs `origin/main` | 0 | `CONFIG-EQUAL= true`, `BUILD-IDS-EQUAL= true` |
| `check_skill_package_refs.py --self-test --verbose` | 0 | all 14 self-tests passed (11 pre-existing + 3 new) |
| `check_skill_package_refs.py --verbose` (live) | 0 | all 9 packaged skills resolve their in-package links |
| `check_require_alias_dialect.py --verbose` | 0 | 2773 files / 10773 edges / 5640 non-canonical — unmoved, as required |
| `check_readme_links.py --ci` | 0 | clean (`implementation/README.md` is this gate's surface, not `check_doc_slugs.py`'s) |

The `check_readme_links.py --ci` log is 0 bytes. That is by design, not a
swallowed run: `main` passes `verbose=args.verbose and not args.ci`. Confirmed
by exercising it against an input it should flag — a planted broken link in
`implementation/README.md` returned exit 1 naming file, line and missing target.
Restored and verified by blob hash.

`mkdocs build --strict` is **not** nominated: `implementation/` sits outside
`docs_dir`, so the strict build never sees `implementation/README.md`.
`check_doc_slugs.py` is not nominated either — its roots do not include
`implementation/`, where it exits 0 on a broken link.
