### PR TITLE
retire React 18 act fallbacks and the orphaned prefetch hook trio; witness shadow!'s foreign reference (rf2-6r9j.35, rf2-6r9j.15, rf2-g1a8)

### DIFF
--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -174,8 +174,8 @@
   "Flush pending UIx renders synchronously. Wraps React's act() —
   intended for test code only. Calls (act f); with no arg, calls (act
   (fn [] nil)) to flush pending effects. Returns nil. Resolves React's
-  act() across React 18 (in `react-dom/test-utils`) and React 19 (on
-  the React namespace directly).
+  act() from the React namespace directly (React 19 is the adapter
+  floor); a production React bundle omits act, where this is a no-op.
   It publishes a render phase, so do not call it from inside a
   `dispatch-sync` handler (rf2-0c23j)."
   (:flush-views! spine-fns))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_boot_order_source_coord_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_boot_order_source_coord_dom_cljs_test.cljs
@@ -100,11 +100,7 @@
        (some? (.-createElement js/document))))
 
 (defn- get-act []
-  (or (when (exists? (.-act React)) (.-act React))
-      (try
-        (let [test-utils (js/require "react-dom/test-utils")]
-          (.-act test-utils))
-        (catch :default _ nil))))
+  (when (exists? (.-act React)) (.-act React)))
 
 (defn- with-browser-act
   "Skip under :node-test (no DOM) and when act() is unreachable; otherwise opt

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_frame_root_ensure_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_frame_root_ensure_dom_cljs_test.cljs
@@ -71,11 +71,7 @@
        (some? (.-createElement js/document))))
 
 (defn- get-act []
-  (or (when (exists? (.-act React)) (.-act React))
-      (try
-        (let [test-utils (js/require "react-dom/test-utils")]
-          (.-act test-utils))
-        (catch :default _ nil))))
+  (when (exists? (.-act React)) (.-act React)))
 
 ;; ---- ENSURE `:id` + `:initial-events` + `:url-bound?` through `$` ----------
 

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_reg_view_direct_mount_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_reg_view_direct_mount_dom_cljs_test.cljs
@@ -77,11 +77,7 @@
        (some? (.-createElement js/document))))
 
 (defn- get-act []
-  (or (when (exists? (.-act React)) (.-act React))
-      (try
-        (let [test-utils (js/require "react-dom/test-utils")]
-          (.-act test-utils))
-        (catch :default _ nil))))
+  (when (exists? (.-act React)) (.-act React)))
 
 (defn- with-browser-act
   "Skip under :node-test (no DOM) and when act() is unreachable; otherwise

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_current_frame_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_current_frame_dom_cljs_test.cljs
@@ -53,11 +53,7 @@
        (some? (.-createElement js/document))))
 
 (defn- get-act []
-  (or (when (exists? (.-act React)) (.-act React))
-      (try
-        (let [test-utils (js/require "react-dom/test-utils")]
-          (.-act test-utils))
-        (catch :default _ nil))))
+  (when (exists? (.-act React)) (.-act React)))
 
 (defn- mount-and-render!
   "Mount `element` under a fresh root inside `act`, then unmount. Returns nil."

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -656,11 +656,7 @@
        (some? (.-createElement js/document))))
 
 (defn- get-act []
-  (or (when (exists? (.-act React)) (.-act React))
-      (try
-        (let [test-utils (js/require "react-dom/test-utils")]
-          (.-act test-utils))
-        (catch :default _ nil))))
+  (when (exists? (.-act React)) (.-act React)))
 
 (deftest frame-provider-trailing-children-propagate-frame
   (testing "UIx — ($ frame-provider {:frame :f} c1 c2) trailing children propagate :frame + render (rf2-7kii2)"

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -534,18 +534,6 @@
     :producer-ns 're-frame.routing
     :design-bead "rf2-vxgfnd.95.5"
     :description "CLJS-only route-link activation op `(fn [event on-click render-frame payload native?])` consumed by every non-Reagent route-link view (Hicasso's `h/route-link`): THE router-attributed click decision — run the caller `:on-click` first, defer to the browser on `defaultPrevented` / native? / a non-plain-left (modifier or auxiliary-button) click, else `.preventDefault` + `router/dispatch!` the payload to the captured render frame with `:source :router`. Keeps the modifier/native/veto click law inside routing so a view artefact reimplements NONE of it (footgun-ownership). Unbound on the JVM (SSR emits a handler-free anchor) and when routing is absent."}
-   {:key         :routing/prefetch-payload
-    :producer-ns 're-frame.routing
-    :design-bead "rf2-kqxe6.7"
-    :description "PURE substrate-neutral prefetch-payload seam `(fn [props]) -> [:rf.route/prefetch {address}] | nil` published on BOTH hosts (EP-0037 R3 §Resource-only intent prefetch). Synthesises the address-only `:rf.route/prefetch` dispatch vector for a route-link whose props request `:prefetch :intent` (nil when the link does not opt in), selecting the address through the ONE shared extractor so it is byte-identical to the link's own destination. Consumed by every non-Reagent route-link view (Hicasso's `h/route-link`) so it reimplements none of the prefetch law — the warm-mode-intent sibling of `:routing/link-model`. Unbound when routing is absent. Per Spec 012 §Route-plan prefetch."}
-   {:key         :routing/prefetch-on-intent!
-    :producer-ns 're-frame.routing
-    :design-bead "rf2-kqxe6.7"
-    :description "CLJS-only prefetch intent-dispatch op `(fn [event caller-handler render-frame payload])` consumed by every non-Reagent route-link view (Hicasso's `h/route-link`): warms the destination on credible user intent — run the caller-supplied intent handler first (compose, not replace), then `router/dispatch!` the `:rf.route/prefetch` payload to the captured render frame with `:source :router` (a nil payload dispatches nothing — passive by construction). The hover/focus/touch sibling of `:routing/activate-link!`; keeps the intent-dispatch law inside routing so a view artefact reimplements none of it. Unbound on the JVM (SSR emits no intent handlers) and when routing is absent. Per Spec 012 §Route-plan prefetch."}
-   {:key         :routing/prefetch-intent-keys
-    :producer-ns 're-frame.routing
-    :design-bead "rf2-7g4qn"
-    :description "The CLOSED class of DOM positions a `:prefetch :intent` route-link warms from — pointer hover, focus, touch-start (Spec 012 §Route-plan prefetch) — published on BOTH hosts as a thunk `(fn []) -> [<keyword> ...]` over `re-frame.routing.link/prefetch-intent-keys`. DATA rather than an op: the class is routing's law, and a view artefact that wrote its own copy would drift silently — a route-link view lacking a trigger `rf/route-link` installs, with nothing failing to say so. Consumed by Hicasso's `h/route-link` both to normalise the caller's value at each owned position and to strip those positions off the passthrough attrs, which is why it is needed on the JVM too (the SSR shell installs no handler but must still not emit a routing control key as an HTML attribute). The class sibling of `:routing/prefetch-payload` / `:routing/prefetch-on-intent!`. Unbound when routing is absent → the consuming view has already failed loud at `:routing/prefetch-payload`."}
    {:key         :routing/preflight-frame-config!
     :producer-ns 're-frame.routing
     :design-bead "rf2-ktmto9"

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -22,8 +22,8 @@
       `dom-element?`, `inject-source-coord-attr`, `warn-non-dom-root!`,
       `clear-warned-non-dom-roots!`, `wrap-view`) parameterised on the
       substrate-name string for the warning text.
-    * `flush-views!` with a correct `react-dom/test-utils` fallback
-      (subsumes rf2-jk7hr).
+    * `flush-views!` resolving `act` from the React namespace (React 19
+      is the adapter floor; subsumes rf2-jk7hr).
     * A factory `make-react-spine` that produces the per-substrate
       hook-based surfaces (`use-current-frame`, `use-subscribe`,
       `frame-provider`, `register-context-provider`) given the
@@ -1715,22 +1715,18 @@
 ;; ---- render flush for tests ----------------------------------------------
 ;;
 ;; `flush-views!` wraps React's `act()` so test code can drive a
-;; subscribe → re-render cycle synchronously. React 18 ships `act` in
-;; `react-dom/test-utils`; React 19 promotes it onto the React namespace
-;; proper. Probe both — without the fallback, users on React 18.x get a
-;; silent no-op (subsumes rf2-jk7hr).
+;; subscribe → re-render cycle synchronously. React 19 — the adapter floor —
+;; hosts `act` on the React namespace proper, so that is the one supported
+;; source (subsumes rf2-jk7hr). The lookup stays a PROBE rather than a
+;; direct call because React's PRODUCTION bundle omits `act` by design:
+;; the nil branch is documented safe degradation, not a compatibility path.
 
 (defn- resolve-act-fn
-  "Return React's act() if available, else nil. React 19 hosts act on
-  the React namespace directly; React 18 hosts it on react-dom/test-utils.
-  Mirrors the Reagent test harness's act-fn in
-  `adapters/reagent/test/re_frame/frame_provider_context_cljs_test.cljs`."
+  "Return React's act() if available, else nil. React 19 — the adapter
+  floor — hosts act on the React namespace directly. Absent only from
+  React's production bundle, which omits act by design."
   []
-  (or (when (exists? (.-act React)) (.-act React))
-      (try
-        (let [tu (js/require "react-dom/test-utils")]
-          (.-act tu))
-        (catch :default _ nil))))
+  (when (exists? (.-act React)) (.-act React)))
 
 (defn flush-views!
   "Flush pending substrate renders synchronously. Wraps React's act() —

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -2803,15 +2803,11 @@
     (.createElement js/document "div")))
 
 (defn- get-act
-  "Return React's act() if available, else nil. React 18 ships act in
-  react-dom/test-utils; React 19 promotes it to the React namespace
-  proper."
+  "Return React's act() if available, else nil. React 19 — the adapter
+  floor — hosts act on the React namespace proper. Absent only from
+  React's production bundle, which omits act by design."
   []
-  (or (when (exists? (.-act React)) (.-act React))
-      (try
-        (let [test-utils (js/require "react-dom/test-utils")]
-          (.-act test-utils))
-        (catch :default _ nil))))
+  (when (exists? (.-act React)) (.-act React)))
 
 (defn- enable-react-act-env!
   "React's act() helper warns / behaves as a no-op unless the runner

--- a/implementation/hicasso/src/re_frame/hicasso/impl/route_link.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/route_link.cljs
@@ -54,12 +54,14 @@
     it, so it is not a door marker. **(Declined:** Replicant's routing posture of a GLOBAL
     body-level click interceptor — ambient behaviour no vector carries is
     exactly what the in-band school exists to avoid.**)**
-  - **Not wired in v0: the `:prefetch :intent` trio.** Routing publishes
-    it; the census counts no prefetch site, and the opt-in is sugar over
-    an event a Hicasso author can already spell (`:on-mouse-enter
-    [:rf.route/prefetch {…}]`). `:prefetch` is one of the keys the link
-    owns (`control-keys`), so it never reaches the anchor as an
-    attribute; routing's link model is what reads it.
+  - **Not wired in v0: the `:prefetch :intent` trio.** The census counts
+    no prefetch site, and the opt-in is sugar over an event a Hicasso
+    author can already spell (`:on-mouse-enter [:rf.route/prefetch
+    {…}]`). Routing publishes no late-bind seam for it either — the trio
+    was retired as orphaned in rf2-6r9j.15, since nothing read it — so
+    `rf/route-link` reaches the prefetch law by direct call. `:prefetch`
+    is still one of the keys the link owns (`control-keys`), so it never
+    reaches the anchor as a stray attribute.
 
   ## Composition with `::h/prevent`
 
@@ -95,7 +97,7 @@
   `:target` / `:download` pair the link model reads for its `:native?`
   verdict.
 
-  `:prefetch` is owned too: it is routing's link-model key, not an HTML
+  `:prefetch` is owned too: it is a routing props key, not an HTML
   attribute, and Hicasso wires none of the prefetch handlers in v0, so it
   is kept off the anchor rather than emitted as a stray attribute."
   [:to :params :query :fragment :on-click :prefetch])

--- a/implementation/hicasso/test_kit/test/re_frame/hicasso/shadow_dom_cljs_test.cljs
+++ b/implementation/hicasso/test_kit/test/re_frame/hicasso/shadow_dom_cljs_test.cljs
@@ -70,7 +70,11 @@
             [re-frame.hicasso.impl.collector :as collector]
             [re-frame.hicasso.test :as ht]
             [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.test-support :as test-support]))
+            [re-frame.test-support :as test-support]
+            ;; The ONE second view library this namespace names, and only so
+            ;; that [[foreign-title-row]] is a genuinely foreign element type.
+            ;; `hm/shadow!` itself still requires none — that is its design.
+            [reagent.core :as r]))
 
 ;; ---------------------------------------------------------------------------
 ;; The application under comparison
@@ -524,6 +528,55 @@
             (is (= [:hicasso.shadow/noted ::alien-a] (:reference difference)))
             (is (= [:hicasso.shadow/noted ::alien-b] (:candidate difference)))))
         (finally ((:stop! s)))))))
+
+;; ---------------------------------------------------------------------------
+;; The route the door is FOR: a foreign original as the reference
+;; ---------------------------------------------------------------------------
+;;
+;; Every row above is `h/defview` on BOTH sides, which is the one shape a
+;; migration never has. `hm/shadow!`'s documented route crosses the ORIGINAL in
+;; through the runtime's own `[:> C props]` door, and nothing here executed
+;; that route — which is how the `:article-id` defect in the door's own
+;; docstring example survived to be found by reading rather than by a red
+;; (rf2-rx99, split out as rf2-g1a8).
+;;
+;; One row, and no sabotage twin: the drift classes are already twinned above,
+;; and what is new here is the ROUTE, not a claim about the comparator.
+
+(defn- reagent-title-row
+  "A Reagent original — no Hicasso, no `h/sub`, no knowledge of the frame.
+  It renders from the ONE prop it is crossed with, which is what the
+  original half of a just-ported screen actually looks like."
+  [{:keys [title]}]
+  [:div.row [:h3.title title]])
+
+(def ^:private foreign-title-row
+  "Reactified ONCE at top level, exactly as the door's own example says to:
+  a component allocated per render is a new element type, and it would
+  remount the subtree under it on every pass."
+  (r/reactify-component reagent-title-row))
+
+(h/defview hicasso-title-row
+  "The port of [[reagent-title-row]] — same markup, same single-word prop."
+  [{:keys [title]}]
+  [:div.row [:h3.title title]])
+
+(deftest a-foreign-reference-crosses-in-and-compares-green
+  (if-not (browser?)
+    (skip! "a crossed foreign original needs a real React DOM")
+    (is (= {:status :green :checkpoints 1}
+           (hm/shadow! {:reference      [:> foreign-title-row {:title "Original title"}]
+                        :candidate      [hicasso-title-row {:title "Original title"}]
+                        :initial-events seed
+                        :script         []}))
+        (str "the reference is a REACTIFIED REAGENT component reached through "
+             "`[:> C props]` while the candidate is an `h/defview`, so a green "
+             "is the whole crossing working: the foreign element type mounted, "
+             "the single-word `:title` crossed unchanged (the rename the "
+             "docstring warns about only bites a hyphenated key), and "
+             "canonical DOM called the two sides identical. It cannot be "
+             "vacuous — the candidate always renders the title, so a reference "
+             "that rendered nothing would be `:only-in-candidate` and red"))))
 
 ;; ---------------------------------------------------------------------------
 ;; The closed rosters — refused before anything is mounted, so these rows

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -569,19 +569,10 @@
 (rf.late-bind/set-fn! :routing/link-model rf.routing.link/link-model)
 #?(:cljs (rf.late-bind/set-fn! :routing/activate-link! rf.routing.link/activate-link!))
 
-;; EP-0037 R3 — the substrate-neutral prefetch seam a view artefact's own
-;; route-link consumes so it wires `:prefetch
-;; :intent` through routing's law without reimplementing it. `prefetch-payload`
-;; is PURE and published on BOTH hosts (a descriptor computes the payload at
-;; render, JVM shell included, though only the CLJS anchor binds the intent
-;; handlers); `prefetch-on-intent!` is the CLJS-only intent-dispatch op (SSR has
-;; no DOM intent to intercept). Per Spec 012 §Route-plan prefetch.
-(rf.late-bind/set-fn! :routing/prefetch-payload rf.routing.link/prefetch-payload)
-#?(:cljs (rf.late-bind/set-fn! :routing/prefetch-on-intent! rf.routing.link/prefetch-on-intent!))
-;; The closed intent-position class itself (rf2-7g4qn) — DATA, not an op, so the
-;; hook is a thunk over `rf.routing.link/prefetch-intent-keys`. Published on BOTH hosts
-;; because a descriptor strips the positions it owns on the JVM too (the SSR
-;; shell must not emit a routing control key as an attribute), and a descriptor
-;; that wrote its own copy of the class would silently drift from the one
-;; `rf/route-link` installs.
-(rf.late-bind/set-fn! :routing/prefetch-intent-keys (constantly rf.routing.link/prefetch-intent-keys))
+;; NOTE — there is deliberately no late-bind seam for `:prefetch :intent`
+;; (rf2-6r9j.15). `rf/route-link` reaches `rf.routing.link/prefetch-payload`,
+;; `prefetch-on-intent!` and `prefetch-intent-keys` by direct call, and no view
+;; artefact consumes them through the hook table, so publishing them only
+;; promised reachability that did not exist. Per Spec 012 §Route-plan prefetch
+;; the law still lives in `re-frame.routing.link`; a view artefact that needs
+;; it should land a real reader first and publish only the keys it reads.


### PR DESCRIPTION
Three bounded changes under `implementation/`, none overlapping.

## rf2-6r9j.35 — React 18 `act` fallbacks below the React 19 floor (PARTIAL, bead stays open)

The floor was re-measured from the resolved dependency, not from prose:
`package-lock.json` resolves react and react-dom at 19.2.0, `package.json`
pins the same, and the template pins generated consumers to 19.2.0 in lockstep.
So the `react-dom/test-utils` probe is dead on every supported build — in a
React 19 development build `React.act` is a function and the fallback is
unreachable, and in production `act` is absent while the deprecated forwarding
wrapper throws rather than rescuing anything.

Removed the probe from the shared spine resolver, the shared React-adapter
suite's `get-act`, and the five UIx DOM harnesses; dropped the React-18 promise
from the UIx `flush-views!` docstring and the spine ns-docstring bullet.
`flush-views!` keeps both arities, its nil return and its no-op-when-`act`-is-
absent behaviour. The lookup deliberately stays a **probe** rather than a direct
call, because React's production bundle omits `act` by design — the nil branch
is documented safe degradation, not a compatibility path.

**The repository-wide zero the bead asks for is NOT reached, so the bead stays
open.** The census went 14 sites -> 7. The 7 remaining are all outside this
change's surface: three stock-Reagent harnesses, one SSR harness, two
machines-viz, one Story.

`spec/api-manifest.edn` and `spec/api-manifest-metadata.edn` were read first:
they pin `flush-views!` by name/kind/tier/owner/status only, never docstring
text, and nothing removed here is manifest-pinned (`resolve-act-fn` and
`get-act` are private).

## rf2-6r9j.15 — the orphaned route-link prefetch hook trio

`:routing/prefetch-payload`, `:routing/prefetch-on-intent!` and
`:routing/prefetch-intent-keys` had no reader anywhere — no `get-fn`, no
`require-fn!`, no wrapper. Their original view-artefact consumer was retired,
and Hicasso's shipped `route-link` reads only `:routing/link-model` and
`:routing/activate-link!`. Verified with a control: `:routing/link-model` has
real `require-fn!` / `get-fn` readers, the trio has none.

Removed the three publications and their three directory rows **together**, so
the late-bind drift test stays satisfied in both directions, and corrected the
Hicasso route-link contract, which claimed routing published a trio it no longer
does. The underlying `re-frame.routing.link` functions and `rf/route-link`'s
`:prefetch :intent` behaviour are untouched — `rf/route-link` calls them
directly, so this removes no user-visible behaviour. `:prefetch` remains one of
`control-keys`, so it still never reaches the anchor as a stray attribute.

Three docstrings in `re-frame.routing.link` still describe these functions as
late-bind "seams". They are outside this change's surface; a follow-up covers
them.

## rf2-g1a8 — a witness for `shadow!`'s foreign `:reference`

Every row in the shadow comparison suite was `h/defview` on **both** sides,
which is the one shape a migration never has. The door's documented route
crosses the original in through `[:> C props]`, and nothing executed it — which
is how the `:article-id` defect in the door's own docstring example survived to
be found by reading rather than by a red.

Added one row whose reference is a reactified Reagent component hoisted to a
top-level def and whose candidate is an equivalent `h/defview`, crossed with a
single-word prop. No sabotage twin: the drift classes are already twinned in
that file, and what is new here is the route, not a claim about the comparator.

## Gates

All run on the final rebased base, exit codes captured in the same shell as the
runner and quoted from the captured file (never from a pipeline):

| Gate | Captured exit | Result |
|---|---|---|
| `check_require_alias_dialect.py --verbose` | 0 | 2773 files / 10773 edges / 5640 non-canonical — **unmoved from trunk** |
| `clojure -M:test -n re-frame.late-bind-drift-test` (core, JVM) | 0 | 8 tests / 683 assertions |
| `clojure -M:test` (routing, JVM) | 0 | 553 tests / 3451 assertions |
| `compile-node-test.cjs node-test` | 0 | 1892 files, 0 warnings |
| `node out/node-test.js` | 0 | 11175 tests / 55753 assertions |
| `shadow-cljs compile browser-test` | 0 | 1024 files, 5 warnings (all pre-existing, none in touched files) |
| `serve-and-run-browser-tests.cjs` | 0 | 783 tests / 4253 assertions |

### The deletions run backwards

Each plant was made from a committed tree and restored via `git checkout HEAD --`,
with the restore verified by comparing the git **blob** hash against the
pre-plant value.

1. **rf2-6r9j.15** — re-added one publication *without* its directory row. Drift
   test went to captured exit 1 with exactly one failure naming
   `:routing/prefetch-payload`, at identical 8 tests / 683 assertions. Proves the
   gate reads this tree and that publication and row were removed as a matched pair.
2. **rf2-g1a8** — changed the new row's candidate `h3` -> `h4`. Browser lane went
   to captured exit 1 with exactly one failure naming
   `a-foreign-reference-crosses-in-and-compares-green`, reporting
   `{:kind :dom :reason :tag :reference "h3" :candidate "h4"}`. The `:reference "h3"`
   is positive proof the reactified Reagent component genuinely mounted and
   rendered, so the unplanted green is not vacuous.
3. **rf2-6r9j.35** — made `resolve-act-fn` return nil unconditionally. Browser lane
   went to captured exit 1, erroring in the shared React suite's poll loop. This
   was a crash-shaped red rather than a bounded one, so it establishes that the
   retained `React.act` path is load-bearing and exercised, but not a precise count.

The `react-dom/test-utils` census was measured as a fixed string with a control
that bites, and run **twice** — line-oriented and over whitespace-flattened text —
because the require can be written across two lines. Both instruments agreed at
every step: 14 sites before, 7 after, no line-broken sites.

### Verified by hand

`mkdocs build --strict` is not nominated: this diff touches no path under
`docs/`, `spec/` or `migration/`. Docstring and comment prose was re-read by eye;
the markdown table above was checked for column count.
