### PR TITLE
docs(routing): the prefetch trio is called directly, not published as a seam

### DIFF
--- a/implementation/routing/src/re_frame/routing/link.cljc
+++ b/implementation/routing/src/re_frame/routing/link.cljc
@@ -31,11 +31,12 @@
   drift from it silently — a view artefact's route-link would lack a trigger
   `rf/route-link` installs, with nothing failing to say so.
 
-  Routing's own `prefetch-intent-attrs` maps over it; a view artefact's
-  route-link reaches it as the `:routing/prefetch-intent-keys`
-  late-bound seam, the same way it already reaches `prefetch-payload` — so no
-  view substrate states the class for itself, and a position added here reaches
-  every link surface at once.
+  Routing's own `prefetch-intent-attrs` maps over it rather than writing the
+  positions out again, so a position added here reaches every anchor
+  `rf/route-link` renders without a second edit. There is deliberately no
+  late-bind seam publishing the class: `:routing/prefetch-intent-keys` was
+  retired for want of a reader (rf2-6r9j.15), and a view artefact that needs
+  the positions lands a real reader first.
 
   Order carries no meaning — the positions are independent, and each warms the
   same destination — but it is stable, so the attrs a render emits are too."
@@ -148,9 +149,9 @@
 (defn prefetch-payload
   "The `[:rf.route/prefetch {address}]` dispatch vector for a link whose props
   request `:prefetch :intent`, or nil when the link does not opt in. PURE, both
-  hosts — the routing calculation a view artefact's route-link
-  consumes through the `:routing/prefetch-payload` seam so it
-  reimplements none of the prefetch law. The address is selected through the ONE
+  hosts — the ONE prefetch calculation, called directly by `rf/route-link`
+  (through `prefetch-intent-attrs`), so no link surface reimplements the
+  prefetch law. The address is selected through the ONE
   shared extractor (`rf.routing.address/extract-address`), so it is byte-identical to the
   link's own destination (path `:params` + `:query`); `:fragment` is omitted — a
   prefetch is resource-only and a `#fragment` is never a resource input.
@@ -209,10 +210,10 @@
      handler targets its frame. Per Spec 012 §Route-plan prefetch."
      [props render-frame]
      (when-let [payload (prefetch-payload props)]
-       ;; Map over the published class rather than writing the positions out a
-       ;; second time (rf2-7g4qn): `prefetch-intent-keys` is the ONE enumeration
-       ;; this anchor and the `:routing/prefetch-intent-keys` seam both read, so
-       ;; a position added there reaches both of them together.
+       ;; Map over the class rather than writing the positions out a second
+       ;; time (rf2-7g4qn): `prefetch-intent-keys` is the ONE enumeration of the
+       ;; credible-intent positions, so a position added there reaches this
+       ;; anchor with no second edit here.
        (into {}
              (map (fn [k]
                     [k (compose-intent-handler (get props k) render-frame payload)]))
@@ -516,17 +517,24 @@
 
 #?(:cljs
    (defn prefetch-on-intent!
-     "The `:routing/prefetch-on-intent!` seam (CLJS only). Dispatch a prefetch
-     `payload` (the `[:rf.route/prefetch {address}]` vector from `prefetch-
-     payload`, or nil) on credible user intent — a view artefact's route-link
-     binds it to `:on-mouse-enter` / `:on-focus` /
-     `:on-touch-start`, so the anchor warms the destination the same way
-     `rf/route-link` does. Runs the caller-supplied intent handler FIRST
-     (compose, not replace), then dispatches to the render-time-captured
-     `render-frame` with `:source :router` (routing-substrate attribution,
-     retarget-safe by explicit `:frame`). A nil `payload` (the link did not opt
-     into `:prefetch :intent`) still runs the caller handler and dispatches
-     nothing — passive by construction. Mirrors `activate-link!` for the click."
+     "Dispatch a prefetch `payload` (the `[:rf.route/prefetch {address}]` vector
+     from `prefetch-payload`, or nil) at one credible-intent position — the
+     intent-position counterpart of `activate-link!` for the click. Runs the
+     caller-supplied intent handler FIRST (compose, not replace), then
+     dispatches to the render-time-captured `render-frame` with `:source
+     :router` (routing-substrate attribution, retarget-safe by explicit
+     `:frame`). A nil `payload` (the link did not opt into `:prefetch :intent`)
+     still runs the caller handler and dispatches nothing — passive by
+     construction.
+
+     NO in-repo caller at present. This was published as the
+     `:routing/prefetch-on-intent!` late-bind seam for a view artefact's own
+     route-link, and that publication was retired for want of a reader
+     (rf2-6r9j.15). `rf/route-link` does NOT route through here — its
+     `prefetch-intent-attrs` composes the same behaviour from
+     `compose-intent-handler` at every `prefetch-intent-keys` position. Kept as
+     routing's one statement of the intent-dispatch law, for a view artefact
+     that needs it to call directly."
      [e caller-handler render-frame payload]
      (when caller-handler (caller-handler e))
      (when payload

--- a/implementation/routing/test/re_frame/routing_prefetch_test.clj
+++ b/implementation/routing/test/re_frame/routing_prefetch_test.clj
@@ -4,9 +4,9 @@
 
   The always-on prefetch-address structural gate (`rf.routing.address/prefetch-address-
   error`) and the pure `[:rf.route/prefetch …]` payload synthesis
-  (`rf.routing.link/prefetch-payload`) the `rf/route-link` intent handlers + the substrate-
-  neutral `:routing/prefetch-payload` seam are built on. The event's warm-plan
-  behaviour (isolation, dedupe, reuse, planning failure) is proven end-to-end by
+  (`rf.routing.link/prefetch-payload`) the `rf/route-link` intent handlers are
+  built on. The event's warm-plan behaviour (isolation, dedupe, reuse, planning
+  failure) is proven end-to-end by
   the `ep-0037-r3-prefetch-*` conformance fixtures; the DOM intent arm (hover /
   focus / touch → dispatch) is proven by the CLJS route-link tests. Per Spec 012
   §Route-plan prefetch.


### PR DESCRIPTION
rf2-fhwd. PR #9165 (rf2-6r9j.15) removed the `:routing/prefetch-payload`, `:routing/prefetch-on-intent!` and `:routing/prefetch-intent-keys` late-bind publications and their three `late_bind/directory.cljc` rows, because nothing read them. The functions in `re-frame.routing.link` stayed — but prose there still described them as late-bind SEAMS a view artefact consumes, which is now false.

**Prose only.** No code, no signature, no behaviour change. The diff is docstrings and one comment.

## The six mentions of a retired key, and what each turned out to be

A repo-wide census on the keyword spellings (`:routing/prefetch-payload|:routing/prefetch-on-intent!|:routing/prefetch-intent-keys`) found six sites, controlled against `:routing/link-model` / `:routing/activate-link!`, which the same pattern shape finds 52 times. Four are the ones the bead names; two more it names outside `link.cljc`.

| Site | Verdict |
|---|---|
| `link.cljc` `prefetch-intent-keys` docstring | **stale claim** — fixed |
| `link.cljc` `prefetch-payload` docstring | **stale claim** — fixed |
| `link.cljc` `prefetch-intent-attrs` comment | **stale claim** — fixed |
| `link.cljc` `prefetch-on-intent!` docstring | **stale claim** — fixed, but not as the bead asked (below) |
| `routing_prefetch_test.clj` ns docstring | **stale claim** — fixed |
| `bench/hicasso/.../front/route_link.cljs:127` | **out of fence** — reported, not edited |

All four `link.cljc` sites described a LIVE mechanism in the present tense ("reaches it as the ... seam", "consumes through the ... seam", "the seam both read"). None was retirement bookkeeping. The two sentences that now name a retired key do so precisely to record that it *was* retired, which is the protected bookkeeping shape rather than a live claim.

## The one place this departs from the bead

The bead's scope says to rewrite each site to say "the function is called directly by `rf/route-link`". That is true of `prefetch-payload` and `prefetch-intent-keys`, and they now say so. It is **not** true of `prefetch-on-intent!`, and writing it would have planted a fresh false claim in place of the stale one.

`rf/route-link` does not call `prefetch-on-intent!`. `route-link-render` calls `prefetch-intent-attrs`, which composes the same behaviour itself from `compose-intent-handler` at every `prefetch-intent-keys` position. With the seam retired the function has **no in-repo caller at all** — the census finds it only at its own definition, in the retirement NOTE in `routing.cljc`, and in the out-of-fence bench comment. Its click sibling `activate-link!`, by contrast, has 46 references across 14 files. The docstring now states that plainly. Whether the function should itself be retired is a separate call, not made here.

## Code read for each sentence

Docstring truth has no gate, so each clause was checked against the code it sits on.

- `rf/route-link` reaches `prefetch-payload` and `prefetch-intent-keys` directly — `route-link-render` calls `prefetch-intent-attrs`, which calls `prefetch-payload` and maps over `prefetch-intent-keys`.
- `prefetch-on-intent!` has no caller — census above, with the `activate-link!` control.
- The retirement itself — the `routing.cljc` and `late_bind/directory.cljc` hunks of the merge commit, which remove three `set-fn!` publications and three directory rows and leave a NOTE in their place.

**Left alone as still correct**, having been read rather than assumed:

- `activate-link!`'s "Also PUBLISHED as the `:routing/activate-link!` late-bound seam" — still published in `routing.cljc`.
- The block comment above `link-model` describing "Two late-bound `:routing/*` hooks" and enumerating `link-model` + `activate-link!` — both still published, and two is now exactly right.
- `link-model`'s own `:routing/link-model` seam docstring — still published.
- `validate-prefetch!`'s caller list (`href-attrs`, `link-model`, `prefetch-payload`) — all three really do call it.
- The `link-model` rationale comment mentioning a view artefact's `prefetch-payload` call: borderline, but it reads as history explaining why validation was added there, names no retired key, and widening into it is not what this bead is for.

## No spec page carries the claim

`spec/` has no mention of any of the three retired keys. The one `spec/009-Instrumentation.md` hit on `prefetch-payload` is the `:rf.error/route-link-bad-prefetch` row listing `prefetch-payload` as a validation site, which is still accurate. (That row separately names `ui/route-link`, a retired artefact — pre-existing, unrelated to this bead, and hot-zone; flagged, not touched.)

## Gates

- `clojure -M:test` in `implementation/routing/` — **exit 0**, 553 tests / 3451 assertions, 0 failures, 0 errors. Re-run on the final rebased base and again on the exact final bytes.
- `python scripts/check_require_alias_dialect.py --verbose` — **exit 0**, `2773 file(s), 10773 re-frame require edge(s), 5586 non-canonical, every surface at or under its floor`. Unchanged in both directions; `implementation/routing`'s floor is 0 in `scripts/require-alias-baseline.edn` and this diff adds no require.
- Link gates do not reach these paths, and there is no gate for a docstring's truth — see the read above, which is the actual check.
