### PR TITLE
refactor(alias): canonical rf.* aliases in skills, docs, testbeds, migration; drop two dead trace requires (rf2-lwx8, rf2-b38y)

### DIFF
--- a/docs/design/hicasso/product/pilots/baseline/linearlite/baseline_test.cljs
+++ b/docs/design/hicasso/product/pilots/baseline/linearlite/baseline_test.cljs
@@ -20,20 +20,20 @@
    needs no browser."
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.registrar :as registrar]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.fx :as rf.fx]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             ;; Production HTTP + resources surfaces, so the resource runtime,
             ;; the mutation runtime, managed-HTTP lowering and the routing
             ;; integration resolve; the actual fetch is overridden per test.
             [re-frame.http.managed]
             [re-frame.http.test-support]
             [re-frame.resources]
-            [re-frame.resources.route :as resources-route]
-            [re-frame.resources.state :as state]
+            [re-frame.resources.route :as rf.resources.route]
+            [re-frame.resources.state :as rf.resources.state]
             [re-frame.resources.test-support]
-            [re-frame.routing :as routing]
+            [re-frame.routing :as rf.routing]
             ;; The app's production source — registers the :linearlite/board
             ;; resource, the three optimistic mutations, routes, events, subs
             ;; and views at load.
@@ -51,11 +51,11 @@
 ;; `linearlite.core` require above ran them — and re-install them per test in
 ;; `init!`. What gets re-installed is the app's own registrations, not copies.
 (def ^:private resource-kind-snapshots
-  (select-keys @registrar/kind->id->metadata [:resource :mutation]))
+  (select-keys @rf.registrar/kind->id->metadata [:resource :mutation]))
 
 ;; Take those two kinds out of the live registry at load; `init!` puts them
 ;; back before each test, so every test starts from the same registrations.
-(swap! registrar/kind->id->metadata
+(swap! rf.registrar/kind->id->metadata
        (fn [reg]
          (reduce (fn [r [kind id->meta]]
                    (update r kind (fn [m] (apply dissoc m (keys id->meta)))))
@@ -77,21 +77,21 @@
    and the frame is made last."
   []
   (reset! last-managed-args nil)
-  ;; Re-install through `registrar/register!`, which writes the registry and
+  ;; Re-install through `rf.registrar/register!`, which writes the registry and
   ;; the source store in lockstep.
   (doseq [[kind id->meta] resource-kind-snapshots
           [id meta] id->meta]
-    (registrar/register! kind id meta))
-  (routing/reset-counters!)
-  (resources-route/install-routing-integration!)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
-  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
+    (rf.registrar/register! kind id meta))
+  (rf.routing/reset-counters!)
+  (rf.resources.route/install-routing-integration!)
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
   (rf/make-frame {:id :rf/default :url-bound? true
                   :doc "linearlite default app frame."}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter
      :init-fn init!}))
 
 ;; ============================================================================
@@ -104,9 +104,9 @@
   {:resource :linearlite/board :scope :rf.scope/global :params {}})
 
 (defn- board-key []
-  (state/scoped-resource-key :rf.scope/global :linearlite/board {}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global :linearlite/board {}))
 
-(defn- entry [] (get-in (runtime-db) (state/entry-path (board-key))))
+(defn- entry [] (get-in (runtime-db) (rf.resources.state/entry-path (board-key))))
 
 (defn- board-data
   "The passive board `:data` the view reads (the `:rf.resource/data` sub),
@@ -318,7 +318,7 @@
    asked for, and the arguments it built — and deliver nothing."
   []
   (doseq [fx-id canned-fx-ids]
-    (fx/reg-fx fx-id
+    (rf.fx/reg-fx fx-id
       {:doc "linearlite armed-demo-backend test parker (per-test; section 5)."}
       (fn [_ctx args]
         (swap! parked-replies conj {:fx-id    fx-id
@@ -332,7 +332,7 @@
    `request` is the lowered request map the app's own mutation produces."
   [request]
   (reset! parked-replies [])
-  ((registrar/handler :fx :linearlite.demo/http-stub)
+  ((rf.registrar/handler :fx :linearlite.demo/http-stub)
    {:frame :rf/default}
    {:request  request
     :decode   :json

--- a/docs/design/hicasso/product/pilots/baseline/realworld_http/baseline_test.cljs
+++ b/docs/design/hicasso/product/pilots/baseline/realworld_http/baseline_test.cljs
@@ -13,10 +13,10 @@
   (:require [clojure.string :as str]
             [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.http.test-support]
             ;; The app's production source. Requiring `realworld-http.core`
             ;; chains in every feature namespace, so the handlers, subs, views,
@@ -45,7 +45,7 @@
   (rf/reg-fx fx-id
     {:platforms #{:client :server}}
     (fn [frame-ctx args]
-      (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+      (let [stub (rf.registrar/handler :fx :rf.http/managed-canned-success)]
         (stub frame-ctx (assoc args :value value))))))
 
 (defn- reg-canned-success-by-url!
@@ -55,7 +55,7 @@
   (rf/reg-fx fx-id
     {:platforms #{:client :server}}
     (fn [frame-ctx args]
-      (let [stub   (registrar/handler :fx :rf.http/managed-canned-success)
+      (let [stub   (rf.registrar/handler :fx :rf.http/managed-canned-success)
             req    (:request args)
             method (or (:method req) :get)
             url    (:url req)
@@ -73,7 +73,7 @@
   (rf/reg-fx fx-id
     {:platforms #{:client :server}}
     (fn [frame-ctx args]
-      (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+      (let [stub (rf.registrar/handler :fx :rf.http/managed-canned-failure)]
         (stub frame-ctx (assoc args :kind kind :tags tags))))))
 
 ;; A generic success: every managed request resolves with an empty map. Tests
@@ -84,8 +84,8 @@
 ;; `:rf/default` scope: a frame's `:initial-events` then drain synchronously
 ;; at boot, and every dispatch in a test body names its frame explicitly.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       reagent-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
      :ambient-frame nil}))
 
 (defn- sub
@@ -111,7 +111,7 @@
                                     :author {:username "alice" :bio nil :image nil
                                              :following false}}]
                         :articlesCount 1})
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/canned-articles}})]
     (is (= :idle (:status (sub f [:articles/slice]))))
@@ -130,7 +130,7 @@
                        :rf.http/http-5xx
                        {:status 500
                         :body   "server error"})
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/canned-articles-failure}})]
     (rf/dispatch-sync [:articles/load] {:frame f})
@@ -144,7 +144,7 @@
                  :createdAt "x" :updatedAt "x" :favorited false :favoritesCount 0
                  :author {:username "bob" :bio nil :image nil :following true}}]
      :articlesCount 7})
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/feed-ok}})]
     (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -158,7 +158,7 @@
 
 (defn- feed-load-failure-test []
   (reg-canned-failure! :realworld.test/feed-fail :rf.http/http-5xx {:status 500 :body "boom"})
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/feed-fail}})]
     (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -167,7 +167,7 @@
         ":feed/load-failed surfaces a readable error on the feed slice")))
 
 (defn- tag-query-test []
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     ;; Applying a tag navigates to the `/tag/:tag` PATH route, so the active
@@ -203,7 +203,7 @@
     (is (str/includes? p "offset=20") "page 3 → offset 20")))
 
 (defn- pagination-nav-events-test []
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     ;; --- :home/show-page carries the active feed forward ---
@@ -286,7 +286,7 @@
                                   :favorited false
                                   :favoritesCount 0
                                   :author {:username "alice" :bio nil :image nil :following false}}})
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/canned-editor-save}})]
     (rf/dispatch-sync [:editor/initialise] {:frame f})
@@ -308,7 +308,7 @@
     (is (false? (sub f [:editor/dirty?])))))
 
 (defn- editor-can-leave-test []
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     (rf/dispatch-sync [:editor/initialise] {:frame f})
@@ -352,7 +352,7 @@
                    :createdAt "2026-05-01" :updatedAt "2026-05-01"
                    :favorited false :favoritesCount 0
                    :author {:username "alice" :bio nil :image nil :following false}}}))
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:app/initialise]]
                           :fx-overrides {:rf.http/managed :realworld.test/editor-edit}})]
       ;; /editor/:slug requires auth — sign in so the route's guard passes and
@@ -388,7 +388,7 @@
 (defn- editor-load-failure-test []
   (reg-canned-failure! :realworld.test/editor-load-fail
                        :rf.http/http-5xx {:status 500 :body "server error"})
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/editor-load-fail}})]
     (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -407,7 +407,7 @@
         {:article {:slug "doomed" :title "Doomed" :description "d" :body "b" :tagList []
                    :createdAt "x" :updatedAt "x" :favorited false :favoritesCount 0
                    :author {:username "alice" :bio nil :image nil :following false}}}))
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:app/initialise]]
                           :fx-overrides {:rf.http/managed :realworld.test/editor-delete}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -427,7 +427,7 @@
           "the :mode region resets to :create after a delete"))))
 
 (defn- editor-invalid-submit-test []
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     (rf/dispatch-sync [:editor/initialise] {:frame f})
@@ -456,7 +456,7 @@
     (rf/reg-fx :realworld.test/editor-in-flight
       {:platforms #{:client :server}}
       (fn [_frame-ctx args] (reset! in-flight args) nil))
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:app/initialise]]
                           :fx-overrides {:rf.http/managed :realworld.test/editor-in-flight}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -515,7 +515,7 @@
     (rf/reg-fx :realworld.test/editor-cross-slug
       {:platforms #{:client :server}}
       (fn [_frame-ctx args] (swap! lowered conj args) nil))
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:app/initialise]]
                           :fx-overrides {:rf.http/managed :realworld.test/editor-cross-slug}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -568,7 +568,7 @@
     (rf/reg-fx :realworld.test/editor-cross-slug-fail
       {:platforms #{:client :server}}
       (fn [_frame-ctx args] (swap! lowered conj args) nil))
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:app/initialise]]
                           :fx-overrides {:rf.http/managed :realworld.test/editor-cross-slug-fail}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -613,7 +613,7 @@
 ;; ============================================================================
 
 (defn- routing-tests []
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     (rf/dispatch-sync [:rf.route/navigate {:to :realworld.article/show :params {:slug "hello"}}] {:frame f})
@@ -645,7 +645,7 @@
   ;; replace-navigates to login. Entry denial is TERMINAL: it commits nothing
   ;; and creates NO pending value, so the return after sign-in is a FRESH
   ;; navigate, not a resume.
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     ;; Unauthenticated: navigating to a guarded route is denied and redirects
@@ -692,7 +692,7 @@
 ;; ============================================================================
 
 (defn- app-boot-test []
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed      :realworld.test/canned-success-empty
                                        :auth.session/persist :rf/no-op}})]

--- a/docs/tools/playground/sci/src/rf2_playground/sci.cljs
+++ b/docs/tools/playground/sci/src/rf2_playground/sci.cljs
@@ -65,24 +65,24 @@
   rather than the macro-less `reg-machine*` variant."
   (:require [sci.core :as sci]
             [re-frame.core :as rf]
-            [re-frame.router :as router]
-            [re-frame.subs :as subs]
+            [re-frame.router :as rf.router]
+            [re-frame.subs :as rf.subs]
             ;; The frame api constructor behind `capture-frame` and the
             ;; `reg-view` injection — an owned implementation seam, off the
             ;; facade (rf2-93sxp). Bound under its own SCI namespace below so
             ;; the `reg-view` shim can name it exactly as the real expansion
             ;; does, without copying an internal alias into `re-frame.core`.
-            [re-frame.capture-frame :as capture-frame]
+            [re-frame.capture-frame :as rf.capture-frame]
             ;; Consumed (not re-exposed to cells) for page-owned registration
             ;; ownership + clear-on-disposal — see `disposePage` (rf2-u4pqs).
-            [re-frame.registrar :as registrar]
+            [re-frame.registrar :as rf.registrar]
             [re-frame.views]
             [re-frame.machines]
             ;; flows artefact (Spec 007): required for its late-bind hooks so
             ;; `rf/reg-flow` (a copy-ns'd core fn-alias) is live in cells —
             ;; same pattern as re-frame.machines above (rf2 guide page 7).
             [re-frame.flows]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
             [reagent2.core :as r]
             [reagent2.ratom :as ratom]
             [reagent2.dom.client :as rdc]))
@@ -113,16 +113,16 @@
 ;; (and the whole point of these wrappers is to inject the default `:frame`,
 ;; not to author a real application call site).
 (defn- playground-dispatch
-  ([event]      (router/dispatch! event {:frame app-frame}))
-  ([event opts] (router/dispatch! event (merge {:frame app-frame} opts))))
+  ([event]      (rf.router/dispatch! event {:frame app-frame}))
+  ([event opts] (rf.router/dispatch! event (merge {:frame app-frame} opts))))
 
 (defn- playground-dispatch-sync
-  ([event]      (router/dispatch-sync! event {:frame app-frame}))
-  ([event opts] (router/dispatch-sync! event (merge {:frame app-frame} opts))))
+  ([event]      (rf.router/dispatch-sync! event {:frame app-frame}))
+  ([event opts] (rf.router/dispatch-sync! event (merge {:frame app-frame} opts))))
 
 (defn- playground-subscribe
-  ([query-v]      (subs/subscribe query-v {:frame app-frame}))
-  ([query-v opts] (subs/subscribe query-v (merge {:frame app-frame} opts))))
+  ([query-v]      (rf.subs/subscribe query-v {:frame app-frame}))
+  ([query-v opts] (rf.subs/subscribe query-v (merge {:frame app-frame} opts))))
 
 (def rf-ns (sci/create-ns 're-frame.core nil))
 
@@ -213,7 +213,7 @@
 ;; above, so the facade a cell sees stays the real one.
 (def capture-frame-ns (sci/create-ns 're-frame.capture-frame nil))
 (def re-frame-capture-frame-namespace
-  {'make-capture-frame (sci/copy-var capture-frame/make-capture-frame capture-frame-ns)})
+  {'make-capture-frame (sci/copy-var rf.capture-frame/make-capture-frame capture-frame-ns)})
 
 (def r-ns (sci/create-ns 'reagent2.core nil))
 (def reagent2-core-namespace (sci/copy-ns reagent2.core r-ns))
@@ -255,7 +255,7 @@
 
 (defn- ensure-adapter! []
   (when-not @adapter-inited?
-    (rf/init! reagent-slim-adapter/adapter)
+    (rf/init! rf.adapter.reagent-slim/adapter)
     (reset! adapter-inited? true)))
 
 ;; EP-0002 (carried-frame invariant): `rf/init!` installs the adapter but the
@@ -302,7 +302,7 @@
 (defn- capture-registration-baseline! []
   (when (nil? @baseline-registrations)
     (reset! baseline-registrations
-            (into {} (map (fn [k] [k (registrar/ids k)])) registrar/kinds))))
+            (into {} (map (fn [k] [k (rf.registrar/ids k)])) rf.registrar/kinds))))
 
 (defn- ensure-init! []
   (ensure-adapter!)
@@ -429,7 +429,7 @@
        reuses another cell's registration (the rf2-io9mdr isolation break this
        step closes). We clear exactly the page-owned set — `current − baseline`,
        where `baseline` is the framework/bundle-init snapshot captured at
-       `ensure-init!` — via `registrar/unregister!`, so a later page's dispatch/
+       `ensure-init!` — via `rf.registrar/unregister!`, so a later page's dispatch/
        subscribe through a cleared page-only id raises the ordinary
        `:rf.error/no-such-handler` / `:rf.error/no-such-sub` instead of hitting a
        leaked handler.
@@ -463,11 +463,11 @@
   ;;    guarded so one failure can't strand the rest. No-op before any cell ran
   ;;    (baseline nil ⇒ nothing page-owned yet).
   (when-let [baseline @baseline-registrations]
-    (doseq [kind registrar/kinds]
+    (doseq [kind rf.registrar/kinds]
       (let [baseline-ids (get baseline kind #{})]
-        (doseq [id (registrar/ids kind)]
+        (doseq [id (rf.registrar/ids kind)]
           (when-not (contains? baseline-ids id)
-            (try (registrar/unregister! kind id) (catch :default _ nil)))))))
+            (try (rf.registrar/unregister! kind id) (catch :default _ nil)))))))
   nil)
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/adapters/reagent/test/re_frame/render_key_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/render_key_cljs_test.cljs
@@ -20,7 +20,6 @@
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]
             [re-frame.views :as views])
   (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
 

--- a/implementation/adapters/reagent/test/re_frame/view_render_trigger_handler_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/view_render_trigger_handler_cljs_test.cljs
@@ -27,7 +27,6 @@
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]
             [re-frame.views])
   (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
 

--- a/migration/from-re-frame-v1/codemod/test-integration/re_frame/migration/reg_event_codemod_integration_test.clj
+++ b/migration/from-re-frame-v1/codemod/test-integration/re_frame/migration/reg_event_codemod_integration_test.clj
@@ -21,20 +21,20 @@
   self-contained (the codemod artefact itself never loads re-frame2)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.migration.reg-event-codemod :as cm])
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.migration.reg-event-codemod :as rf.migration.reg-event-codemod])
   (:import [java.io PushbackReader StringReader]))
 
 ;; ---- fixtures --------------------------------------------------------------
 
 (defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
   ;; re-registers the framework standards (incl. :rf.interceptor/path) after
   ;; the clear — idempotent by design.
-  (rf/init! plain-atom/adapter)
+  (rf/init! rf.substrate.plain-atom/adapter)
   (test-fn))
 
 (use-fixtures :each reset-runtime)
@@ -79,11 +79,11 @@
 
 (deftest rewritten-canonical-metadata-registers
   (testing "the codemod's emitted output for the canonical v1 form registers cleanly"
-    (let [{:keys [source findings]} (cm/rewrite-string canonical-v1)]
+    (let [{:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string canonical-v1)]
       (is (= :rewrite (:action (first findings))))
       (is (nil? (rf-error-id #(eval-source! source)))
           "emitted output must register without any :rf.error/* throw")
-      (is (some? (registrar/lookup :event :counter/inc))
+      (is (some? (rf.registrar/lookup :event :counter/inc))
           "the event handler actually registered"))))
 
 (deftest rewritten-positional-vector-registers
@@ -91,10 +91,10 @@
     (let [src (str "(rf/reg-event-db :counter/dec\n"
                    "  [(rf/path :counter)]\n"
                    "  (fn [db _] (update db :value dec)))")
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :rewrite (:action (first findings))))
       (is (nil? (rf-error-id #(eval-source! source))))
-      (is (some? (registrar/lookup :event :counter/dec))))))
+      (is (some? (rf.registrar/lookup :event :counter/dec))))))
 
 ;; ---- negative controls: the PRE-FIX outputs hard-fail registration --------
 ;;

--- a/migration/from-re-frame-v1/codemod/test/re_frame/migration/reg_event_codemod_test.clj
+++ b/migration/from-re-frame-v1/codemod/test/re_frame/migration/reg_event_codemod_test.clj
@@ -30,18 +30,18 @@
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
             [clojure.java.io :as io]
-            [re-frame.migration.reg-event-codemod :as cm]))
+            [re-frame.migration.reg-event-codemod :as rf.migration.reg-event-codemod]))
 
 ;; ---------------------------------------------------------------------------
 ;; helpers
 ;; ---------------------------------------------------------------------------
 
 (defn- only-finding [s]
-  (let [fs (cm/scan-string s)]
+  (let [fs (rf.migration.reg-event-codemod/scan-string s)]
     (is (= 1 (count fs)) (str "expected exactly one finding in: " s))
     (first fs)))
 
-(defn- rewrite [s] (:source (cm/rewrite-string s)))
+(defn- rewrite [s] (:source (rf.migration.reg-event-codemod/rewrite-string s)))
 
 ;; ---------------------------------------------------------------------------
 ;; reg-event-fx — pure rename
@@ -50,7 +50,7 @@
 (deftest fx-renamed
   (testing "reg-event-fx is renamed to reg-event, body untouched"
     (let [src "(rf/reg-event-fx :todo/add\n  (fn [{:keys [db]} [_ text]]\n    {:db (assoc-in db [:todos text] true)}))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= 1 (count findings)))
       (is (= :reg-event-fx (:form (first findings))))
       (is (= :rename (:action (first findings))))
@@ -74,7 +74,7 @@
 (deftest db-simple-update
   (testing "simple reg-event-db -> reg-event with {:db BODY} and {:keys [db]}"
     (let [src "(rf/reg-event-db :counter/inc\n  (fn [db _] (update db :count inc)))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :reg-event-db (:form (first findings))))
       (is (= :rewrite (:action (first findings))))
       (is (str/includes? source "rf/reg-event "))
@@ -87,7 +87,7 @@
 (deftest db-thread-body
   (testing "a (-> db ...) thread body wraps faithfully (last stage is a safe builder)"
     (let [src "(rf/reg-event-db :form/clear\n  (fn [db [_ k]]\n    (-> db\n        (assoc-in [:form k :value] \"\")\n        (assoc-in [:form k :error] nil))))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :rewrite (:action (first findings))) "->-thread ending in assoc-in is a safe, non-nil builder")
       (is (str/includes? source "{:keys [db]}"))
       (is (str/includes? source "{:db (-> db"))
@@ -124,7 +124,7 @@
 (deftest db-path-interceptor-normalized
   (testing "the canonical metadata path chain lowers to the standard factory ref"
     (let [src "(rf/reg-event-db :counter/inc\n  {:interceptors [(rf/path :counter)]}\n  (fn [db _] (update db :value inc)))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :rewrite (:action (first findings))))
       (is (str/includes? source "{:interceptors [[:rf.interceptor/path [:counter]]]}"))
       ;; no executable rf/path call survives (v2 makes it a throwing stub)
@@ -136,7 +136,7 @@
 (deftest db-positional-path-vector-normalized
   (testing "the historical positional chain becomes the one metadata-map form"
     (let [src "(rf/reg-event-db :counter/inc\n  [(rf/path :counter)]\n  (fn [db _] (update db :value inc)))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :rewrite (:action (first findings))))
       (is (str/includes? source "{:interceptors [[:rf.interceptor/path [:counter]]]}"))
       (is (not (str/includes? source "(rf/path")))
@@ -158,7 +158,7 @@
 (deftest db-metadata-plus-vector-merged
   (testing "the metadata-plus-vector shape merges into ONE metadata map, map entries first"
     (let [src "(rf/reg-event-db :x {:interceptors [(rf/path :a)]} [(rf/path :b)]\n  (fn [db _] (assoc db :k 1)))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :rewrite (:action (first findings))))
       (is (str/includes? source "{:interceptors [[:rf.interceptor/path [:a]] [:rf.interceptor/path [:b]]]}"))
       ;; exactly one :interceptors key survives — the positional vector is gone
@@ -184,7 +184,7 @@
 (deftest fx-with-path-chain-normalized
   (testing "reg-event-fx with a convertible chain is a :rewrite (not a bare :rename)"
     (let [src "(rf/reg-event-fx :x {:interceptors [(rf/path :a)]}\n  (fn [cofx _] {:db (:db cofx)}))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :rewrite (:action (first findings))))
       (is (str/includes? source "rf/reg-event "))
       (is (str/includes? source "{:interceptors [[:rf.interceptor/path [:a]]]}"))
@@ -194,7 +194,7 @@
 (deftest already-canonical-ref-chain-kept-verbatim
   (testing "a chain that is already refs-only is preserved byte-for-byte"
     (let [src "(rf/reg-event-db :x {:interceptors [:my/ic [:rf.interceptor/path [:cart]]]}\n  (fn [db _] (assoc db :k 1)))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :rewrite (:action (first findings))) "handler rewrite still applies")
       (is (str/includes? source "{:interceptors [:my/ic [:rf.interceptor/path [:cart]]]}")))))
 
@@ -209,7 +209,7 @@
 (deftest custom-inline-interceptor-flagged-db
   (testing "a custom interceptor var in the chain -> :flag :interceptors, unchanged"
     (let [src "(rf/reg-event-db :x {:interceptors [my-auth-interceptor]}\n  (fn [db _] (assoc db :k 1)))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :reg-event-db (:form (first findings))))
       (is (= :flag (:action (first findings))))
       (is (= :interceptors (:flag (first findings))))
@@ -219,7 +219,7 @@
 (deftest custom-inline-interceptor-flagged-fx
   (testing "a positional chain with a custom call (e.g. (rf/debug)) is NOT pure-renamed"
     (let [src "(rf/reg-event-fx :x [(rf/debug)]\n  (fn [c _] {:db (:db c)}))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :flag (:action (first findings))))
       (is (= :interceptors (:flag (first findings))))
       (is (= src source)))))
@@ -227,7 +227,7 @@
 (deftest path-dynamic-arg-flagged
   (testing "(rf/path p) with a non-literal arg has no derivable path vector -> flag"
     (let [src "(rf/reg-event-db :x {:interceptors [(rf/path p)]} (fn [db _] (assoc db :k 1)))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :flag (:action (first findings))))
       (is (= :interceptors (:flag (first findings))))
       (is (= src source)))))
@@ -235,7 +235,7 @@
 (deftest mixed-chain-with-one-unresolved-entry-flags-whole-site
   (testing "a chain mixing a convertible path with an underivable entry is NOT half-converted"
     (let [src "(rf/reg-event-db :x {:interceptors [(rf/path :a) my-ic]}\n  (fn [db _] (assoc db :k 1)))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :flag (:action (first findings))))
       (is (= :interceptors (:flag (first findings))))
       (is (= src source)))))
@@ -243,7 +243,7 @@
 (deftest db-nil-capable-with-convertible-chain-still-gates-on-d7
   (testing "a convertible chain does not bypass the D7 nil gate; source unchanged"
     (let [src "(rf/reg-event-db :x {:interceptors [(rf/path :a)]}\n  (fn [db _] (when true db)))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :flag (:action (first findings))))
       (is (= :nil-capable (:flag (first findings))))
       (is (= src source)))))
@@ -269,7 +269,7 @@
                    "(rf/reg-event-db :tenant/load\n"
                    "  {:interceptors [(app.interceptors/path :tenant)]}\n"
                    "  (fn [db _] (assoc db :loaded true)))\n")
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= 1 (count findings)))
       (is (= :flag (:action (first findings))))
       (is (= :interceptors (:flag (first findings))))
@@ -284,7 +284,7 @@
                    "            [app.interceptors :as icpt]))\n"
                    "(rf/reg-event-db :x {:interceptors [(icpt/path :tenant)]}\n"
                    "  (fn [db _] (assoc db :k 1)))\n")
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :flag (:action (first findings))))
       (is (= :interceptors (:flag (first findings))))
       (is (= src source)))))
@@ -292,7 +292,7 @@
 (deftest custom-dotted-path-flagged-in-ns-less-fragment
   (testing "even with no ns form, a DOTTED head namespace that is not re-frame.core flags"
     (let [src "(rf/reg-event-db :x {:interceptors [(app.interceptors/path :tenant)]} (fn [db _] (assoc db :k 1)))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :flag (:action (first findings))))
       (is (= :interceptors (:flag (first findings))))
       (is (= src source)))))
@@ -301,7 +301,7 @@
   (testing "an alias the ns form does not resolve is ambiguous -> conservative flag"
     (let [src (str "(ns app.events (:require [re-frame.core :as rf]))\n"
                    "(rf/reg-event-db :x {:interceptors [(xyz/path :a)]} (fn [db _] (assoc db :k 1)))\n")
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :flag (:action (first findings))))
       (is (= :interceptors (:flag (first findings))))
       (is (= src source)))))
@@ -310,7 +310,7 @@
   (testing "a bare `path` under an ns form that does NOT refer it is a local fn -> flag"
     (let [src (str "(ns app.events (:require [re-frame.core :as rf]))\n"
                    "(rf/reg-event-db :x {:interceptors [(path :a)]} (fn [db _] (assoc db :k 1)))\n")
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :flag (:action (first findings))))
       (is (= :interceptors (:flag (first findings))))
       (is (= src source)))))
@@ -321,7 +321,7 @@
                    "(rf/reg-event-db :counter/inc\n"
                    "  {:interceptors [(rf/path :counter)]}\n"
                    "  (fn [db _] (update db :value inc)))\n")
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :rewrite (:action (first findings))))
       (is (str/includes? source "{:interceptors [[:rf.interceptor/path [:counter]]]}"))
       (is (not (str/includes? source "(rf/path"))))))
@@ -334,7 +334,7 @@
                      "(reg-event-db :counter/inc\n"
                      "  {:interceptors [(path :counter)]}\n"
                      "  (fn [db _] (update db :value inc)))\n")
-            {:keys [source findings]} (cm/rewrite-string src)]
+            {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
         (is (= :rewrite (:action (first findings))) (str "require " req))
         (is (str/includes? source "{:interceptors [[:rf.interceptor/path [:counter]]]}"))))))
 
@@ -343,7 +343,7 @@
     (doseq [src [(str "(ns app.events (:require [re-frame.core]))\n"
                       "(re-frame.core/reg-event-db :x {:interceptors [(re-frame.core/path :a)]} (fn [db _] (assoc db :k 1)))\n")
                  "(re-frame.core/reg-event-db :x {:interceptors [(re-frame.core/path :a)]} (fn [db _] (assoc db :k 1)))"]]
-      (let [{:keys [source findings]} (cm/rewrite-string src)]
+      (let [{:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
         (is (= :rewrite (:action (first findings))))
         (is (str/includes? source "[:rf.interceptor/path [:a]]"))))))
 
@@ -357,11 +357,11 @@
           standard (str "(ns app.events (:require [re-frame.core :as rf]))\n"
                         "(rf/reg-event-db :counter/inc {:interceptors [(rf/path :counter)]}\n"
                         "  (fn [db _] (update db :value inc)))\n")]
-      (is (= custom (:source (cm/rewrite-string custom))) "custom site untouched")
+      (is (= custom (:source (rf.migration.reg-event-codemod/rewrite-string custom))) "custom site untouched")
       (let [once  (rewrite standard)
             twice (rewrite once)]
         (is (= once twice))
-        (is (empty? (cm/scan-string once)) "normalized ns-ful output rescans clean")))))
+        (is (empty? (rf.migration.reg-event-codemod/scan-string once)) "normalized ns-ful output rescans clean")))))
 
 ;; ---------------------------------------------------------------------------
 ;; path-head resolution — LEXICAL SHADOWING at the call site (rf2-8odvg reopen)
@@ -382,7 +382,7 @@
                    "  (reg-event-db :counter/inc\n"
                    "    {:interceptors [(path :tenant)]}\n"
                    "    (fn [db _] (update db :value inc))))\n")
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= 1 (count findings)))
       (is (= :flag (:action (first findings))))
       (is (= :interceptors (:flag (first findings))))
@@ -405,7 +405,7 @@
                      "  (reg-event-db :x\n"
                      "    {:interceptors [(path :tenant)]}\n"
                      "    (fn [db _] (assoc db :k 1)))" close "\n")
-            {:keys [source findings]} (cm/rewrite-string src)]
+            {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
         (is (= :flag (:action (first findings))) (str label " must flag"))
         (is (= :interceptors (:flag (first findings))) (str label " flag kind"))
         (is (= src source) (str label " left unchanged"))))))
@@ -434,7 +434,7 @@
                        "     {:interceptors [(path :tenant)]}\n"
                        "     (fn [db _] (update db :value inc))))\n"
                        " app.interceptors/path)\n"))
-            {:keys [source findings]} (cm/rewrite-string src)]
+            {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
         (is (= [:flag :interceptors]
                ((juxt :action :flag) (first findings)))
             (str label " must flag, not lower"))
@@ -458,7 +458,7 @@
                      "  (reg-event-db :x\n"
                      "    {:interceptors [(path :tenant)]}\n"
                      "    (fn [db _] (assoc db :k 1)))" close "\n")
-            {:keys [source findings]} (cm/rewrite-string src)]
+            {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
         (is (= [:flag :interceptors]
                ((juxt :action :flag) (first findings)))
             (str label " must flag"))
@@ -479,7 +479,7 @@
                      "  (reg-event-db :x\n"
                      "    {:interceptors [(path :counter)]}\n"
                      "    (fn [db _] (assoc db :k 1)))" close "\n")
-            {:keys [source findings]} (cm/rewrite-string src)]
+            {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
         (is (= :rewrite (:action (first findings))) (str label " must still rewrite"))
         (is (str/includes? source "[[:rf.interceptor/path [:counter]]]")
             (str label " must still lower the standard head"))))))
@@ -491,7 +491,7 @@
                    "  (rf/reg-event-db :counter/inc\n"
                    "    {:interceptors [(rf/path :counter)]}\n"
                    "    (fn [db _] (update db :value inc))))\n")
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :rewrite (:action (first findings))))
       (is (str/includes? source "{:interceptors [[:rf.interceptor/path [:counter]]]}")))))
 
@@ -518,7 +518,7 @@
                    "  (rf/reg-event-db :counter/inc\n"
                    "    {:interceptors [(rf/path :counter)]}\n"
                    "    (fn [db _] (update db :value inc))))\n")
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :rewrite (:action (first findings))))
       (is (str/includes? source "{:interceptors [[:rf.interceptor/path [:counter]]]}")))))
 
@@ -530,7 +530,7 @@
                    "(reg-event-db :counter/inc\n"
                    "  {:interceptors [(path :counter)]}\n"
                    "  (fn [db _] (update db :value inc)))\n")
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :rewrite (:action (first findings))))
       (is (str/includes? source "{:interceptors [[:rf.interceptor/path [:counter]]]}")))))
 
@@ -560,7 +560,7 @@
 (deftest reg-event-rescan-recovers-metadata-inline
   (testing "an already-renamed reg-event with a preserved (rf/path ...) chain is repaired"
     (let [src "(rf/reg-event :counter/inc\n  {:interceptors [(rf/path :counter)]}\n  (fn [{:keys [db]} _] {:db (update db :value inc)}))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= 1 (count findings)))
       (is (= :reg-event (:form (first findings))))
       (is (= :rewrite (:action (first findings))))
@@ -571,7 +571,7 @@
 (deftest reg-event-rescan-recovers-positional
   (testing "an already-renamed reg-event with a positional chain is repaired"
     (let [src "(rf/reg-event :x [(rf/path :a)] (fn [{:keys [db]} _] {:db db}))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :reg-event (:form (first findings))))
       (is (= :rewrite (:action (first findings))))
       (is (str/includes? source "{:interceptors [[:rf.interceptor/path [:a]]]}")))))
@@ -579,7 +579,7 @@
 (deftest reg-event-rescan-flags-custom-inline
   (testing "an already-renamed reg-event with an underivable inline entry is flagged"
     (let [src "(rf/reg-event :x {:interceptors [my-ic]} (fn [{:keys [db]} _] {:db db}))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :reg-event (:form (first findings))))
       (is (= :flag (:action (first findings))))
       (is (= :interceptors (:flag (first findings))))
@@ -591,7 +591,7 @@
                    "(rf/reg-event :b {:interceptors [:my/ic]} (fn [{:keys [db]} _] {:db db}))\n"
                    "(rf/reg-event :c {:interceptors [[:rf.interceptor/path [:x]]]} (fn [{:keys [db]} _] {:db db}))\n"
                    "(rf/reg-event :d {:doc \"plain metadata\"} (fn [{:keys [db]} _] {:db db}))\n")
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (empty? findings))
       (is (= src source)))))
 
@@ -601,7 +601,7 @@
           once  (rewrite src)
           twice (rewrite once)]
       (is (= once twice))
-      (is (empty? (cm/scan-string once)) "normalized output yields no findings"))))
+      (is (empty? (rf.migration.reg-event-codemod/scan-string once)) "normalized output yields no findings"))))
 
 ;; ---------------------------------------------------------------------------
 ;; reg-event-db — renamed (non-`db`) first param  (rf2-xhfxcs.15)
@@ -615,7 +615,7 @@
 (deftest db-renamed-param-path-interceptor
   (testing "the bead example: path chain lowered + first param `c` -> {c :db}, body untouched"
     (let [src "(reg-event-db :inc {:interceptors [(rf/path :counter)]}\n  (fn [c _] (update c :n inc)))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :reg-event-db (:form (first findings))))
       (is (= :rewrite (:action (first findings))) "renamed-db param is still a simple, faithful rewrite")
       (is (str/includes? source "(reg-event "))
@@ -658,7 +658,7 @@
     ;; references too. The faithful {c :db} rebind touches the BODY not at all, so
     ;; the inner shadowing is preserved exactly as written.
     (let [src "(rf/reg-event-db :shadow\n  (fn [c [_ k]]\n    (let [c (update c :depth inc)]\n      (assoc c :touched k))))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :rewrite (:action (first findings))))
       ;; param rebinds the slice under `c`
       (is (str/includes? source "(fn [{c :db} [_ k]]"))
@@ -713,7 +713,7 @@
 (deftest db-underscore-referenced-param-binds-back
   (testing "the bead/H repro: `_state` referenced in the body rebinds {_state :db}, body intact"
     (let [src "(reg-event-db :y (fn [_state ev] (assoc _state :x 1)))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :reg-event-db (:form (first findings))))
       (is (= :rewrite (:action (first findings))) "referenced `_`-param is still a faithful rewrite")
       (is (str/includes? source "(reg-event "))
@@ -760,7 +760,7 @@
     ;; inner let-binding. So the outer param is genuinely unused; {:keys [db]} is
     ;; correct, and the inner shadowing binding survives byte-for-byte.
     (let [src "(rf/reg-event-db :shadow\n  (fn [_state [_ k]]\n    (let [_state {:fresh k}]\n      (assoc _state :touched true))))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :rewrite (:action (first findings))))
       ;; outer param: no free reference -> canonical {:keys [db]}
       (is (str/includes? source "(fn [{:keys [db]} [_ k]]"))
@@ -806,7 +806,7 @@
 (deftest ctx-flagged-never-rewritten
   (testing "reg-event-ctx is flagged for manual review and left unchanged"
     (let [src "(rf/reg-event-ctx :advanced/thing\n  (fn [ctx] (assoc ctx :rf/skip-handler? true)))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :reg-event-ctx (:form (first findings))))
       (is (= :flag (:action (first findings))))
       (is (= :ctx (:flag (first findings))))
@@ -820,7 +820,7 @@
 (deftest nil-capable-when
   (testing "a (when ...) body can yield nil -> FLAG :nil-capable, source unchanged"
     (let [src "(rf/reg-event-db :maybe/set\n  (fn [db [_ v]] (when v (assoc db :v v))))"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :reg-event-db (:form (first findings))))
       (is (= :flag (:action (first findings))))
       (is (= :nil-capable (:flag (first findings))))
@@ -891,7 +891,7 @@
 (deftest complex-var-handler
   (testing "a var/symbol handler (not a literal fn) -> FLAG :complex, unchanged"
     (let [src "(rf/reg-event-db :x/y my-handler-fn)"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= :flag (:action (first findings))))
       (is (= :complex (:flag (first findings))))
       (is (= src source)))))
@@ -916,7 +916,7 @@
   (testing "detection works regardless of the namespace alias / fully-qualified ns"
     (doseq [head ["rf/reg-event-db" "re-frame.core/reg-event-db" "reg-event-db" "rf2/reg-event-db"]]
       (let [src (str "(" head " :id (fn [db _] (assoc db :x 1)))")
-            {:keys [source findings]} (cm/rewrite-string src)]
+            {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
         (is (= 1 (count findings)) (str "one finding for head " head))
         (is (= :rewrite (:action (first findings))))
         ;; the alias/ns is preserved on the renamed symbol
@@ -932,7 +932,7 @@
 (deftest non-registrar-code-untouched
   (testing "code with no retired registrar is returned byte-for-byte"
     (let [src "(ns my.app)\n\n(defn foo [x] (inc x))\n\n(rf/reg-sub :s (fn [db _] (:s db)))\n;; a comment\n(rf/reg-fx :my/fx (fn [_] nil))\n"
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (empty? findings))
       (is (= src source)))))
 
@@ -959,7 +959,7 @@
                    "(rf/reg-event-fx :b (fn [c e] {:db (:db c)}))\n"           ; rename
                    "(rf/reg-event-ctx :c (fn [ctx] ctx))\n"                    ; flag ctx
                    "(rf/reg-event-db :d (fn [db _] (when true db)))\n")        ; flag nil
-          {:keys [source findings]} (cm/rewrite-string src)]
+          {:keys [source findings]} (rf.migration.reg-event-codemod/rewrite-string src)]
       (is (= 4 (count findings)))
       (is (= [:rewrite :rename :flag :flag] (mapv :action findings)))
       (is (= [nil nil :ctx :nil-capable] (mapv :flag findings)))
@@ -976,16 +976,16 @@
     (let [tmp (java.io.File/createTempFile "regevent" ".cljc")]
       (try
         (spit tmp "(rf/reg-event-db :counter/inc (fn [db _] (update db :count inc)))\n")
-        (let [findings (cm/scan-file (.getPath tmp))]
+        (let [findings (rf.migration.reg-event-codemod/scan-file (.getPath tmp))]
           (is (= 1 (count findings)))
           (is (= (.getPath tmp) (str (:file (first findings))))))
         ;; dry run does NOT write
-        (let [{:keys [changed?]} (cm/rewrite-file! (.getPath tmp) {:write? false})
+        (let [{:keys [changed?]} (rf.migration.reg-event-codemod/rewrite-file! (.getPath tmp) {:write? false})
               after (slurp tmp)]
           (is changed?)
           (is (str/includes? after "reg-event-db") "dry run left the file unwritten"))
         ;; write does mutate the file
-        (let [{:keys [changed?]} (cm/rewrite-file! (.getPath tmp) {:write? true})
+        (let [{:keys [changed?]} (rf.migration.reg-event-codemod/rewrite-file! (.getPath tmp) {:write? true})
               after (slurp tmp)]
           (is changed?)
           (is (not (str/includes? after "reg-event-db")))
@@ -1001,7 +1001,7 @@
         (spit (io/file dir "a.cljs") "(rf/reg-event-db :a (fn [db _] (assoc db :x 1)))")
         (spit (io/file dir "b.clj")  "(rf/reg-event-fx :b (fn [c e] {:db (:db c)}))")
         (spit (io/file dir "c.txt")  "(rf/reg-event-db :ignored (fn [db _] db))") ; not a source ext
-        (let [findings (cm/scan-paths [(.getPath dir)])]
+        (let [findings (rf.migration.reg-event-codemod/scan-paths [(.getPath dir)])]
           (is (= 2 (count findings)) "only .cljs + .clj scanned, .txt ignored")
           (is (= #{:reg-event-db :reg-event-fx} (set (map :form findings)))))
         (finally

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/census.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/census.clj
@@ -151,7 +151,7 @@
   closes over is on the roster, and the shape it cannot name it does not
   count. A confident wrong number is worse than a stated silence."
   (:require [clojure.string :as str]
-            [re-frame.migration.hicasso.rewrite :as rw]
+            [re-frame.migration.hicasso.rewrite :as rf.migration.hicasso.rewrite]
             [rewrite-clj.node :as n]
             [rewrite-clj.parser :as p]
             [rewrite-clj.zip :as z]))
@@ -518,7 +518,7 @@
   roster key is then the ORIGINAL name, which is the only one the roster
   has a class and a recovery sentence for."
   [nd ctx roster]
-  (when-let [h (rw/head-symbol nd)]
+  (when-let [h (rf.migration.hicasso.rewrite/head-symbol nd)]
     (let [k (or (when-not (namespace h) (get (:renamed ctx) h))
                 (symbol (name h)))]
       (when (contains? roster k) k))))
@@ -569,14 +569,14 @@
   `(comment …)` body are none of it."
   [source file]
   (let [root        (p/parse-string-all source)
-        rctx        (rw/ns-context root rw/reagent-namespace?)
-        sctx        (rw/ns-context root rw/substrate-namespace?)
-        reagent?    (rw/names-reagent? root)
+        rctx        (rf.migration.hicasso.rewrite/ns-context root rf.migration.hicasso.rewrite/reagent-namespace?)
+        sctx        (rf.migration.hicasso.rewrite/ns-context root rf.migration.hicasso.rewrite/substrate-namespace?)
+        reagent?    (rf.migration.hicasso.rewrite/names-reagent? root)
         substrate?  (boolean (seq (into (:aliases sctx) (:referred sctx))))
         unresolved? (and reagent? (empty? (into (:aliases rctx) (:referred rctx))))
         excerpt     (fn [loc] (let [s (z/string loc)]
                                 (if (> (count s) 200) (str (subs s 0 200) " …") s)))
-        ns-node?    rw/ns-form?]
+        ns-node?    rf.migration.hicasso.rewrite/ns-form?]
     (loop [loc      (z/of-string source {:track-position? true})
            entries  []
            ns-said? false]
@@ -586,8 +586,8 @@
          :substrate?  substrate?
          :unresolved? unresolved?
          :recognised? (or reagent? substrate?)}
-        (if (rw/inert? (z/node loc))
-          (recur (rw/past-subtree loc) entries ns-said?)
+        (if (rf.migration.hicasso.rewrite/inert? (z/node loc))
+          (recur (rf.migration.hicasso.rewrite/past-subtree loc) entries ns-said?)
           (let [nd         (z/node loc)
                 rk         (roster-name nd rctx surface)
                 sk         (roster-name nd sctx substrate-surface)
@@ -608,7 +608,7 @@
 
                ;; Resolved: this really is Reagent's, through a symbol the
                ;; `ns` form binds.
-               (and rk (rw/bound-call? nd rk rctx))
+               (and rk (rf.migration.hicasso.rewrite/bound-call? nd rk rctx))
                (conj entries (entry (get surface rk) file line col (excerpt loc)
                                     {:api (str rk)}))
 
@@ -617,7 +617,7 @@
                ;; This is the arm the reported defect was missing — a
                ;; re-frame2 application on the Reagent adapter has every one
                ;; of its substrate calls here and none in the arm above.
-               (and sk (rw/bound-call? nd sk sctx))
+               (and sk (rf.migration.hicasso.rewrite/bound-call? nd sk sctx))
                (conj entries (entry (get substrate-surface sk) file line col (excerpt loc)
                                     {:api (str sk)}))
 
@@ -632,12 +632,12 @@
                ;; `rdc/render` that IS the finding. Reporting both makes the
                ;; real one harder to see, which is the only thing a census
                ;; owes anybody.
-               (and rk unresolved? (namespace (rw/head-symbol nd)))
+               (and rk unresolved? (namespace (rf.migration.hicasso.rewrite/head-symbol nd)))
                (conj entries (entry {:class   :unresolved-alias
                                      :verdict :runtime-blocker}
                                     file line col (excerpt loc)
                                     {:api    (str rk)
-                                     :symbol (str (rw/head-symbol nd))}))
+                                     :symbol (str (rf.migration.hicasso.rewrite/head-symbol nd))}))
 
                :else entries)
              (or ns-said? ns-here?))))))))

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/codemod.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/codemod.clj
@@ -32,9 +32,9 @@
   one level down."
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
-            [re-frame.migration.hicasso.census :as census]
-            [re-frame.migration.hicasso.report :as report]
-            [re-frame.migration.hicasso.rewrite :as rw]
+            [re-frame.migration.hicasso.census :as rf.migration.hicasso.census]
+            [re-frame.migration.hicasso.report :as rf.migration.hicasso.report]
+            [re-frame.migration.hicasso.rewrite :as rf.migration.hicasso.rewrite]
             [rewrite-clj.node :as n]
             [rewrite-clj.parser :as p]
             [rewrite-clj.zip :as z])
@@ -47,19 +47,19 @@
 (defn- adapt-def?
   "Is this node `(def Foo (r/adapt-react-class X))`?"
   [nd ctx]
-  (and (rw/list-node? nd)
-       (= 'def (rw/sexpr-safe (rw/element-at nd 0)))
-       (symbol? (rw/sexpr-safe (rw/element-at nd 1)))
-       (some-> (rw/element-at nd 2) (rw/bound-call? 'adapt-react-class ctx))))
+  (and (rf.migration.hicasso.rewrite/list-node? nd)
+       (= 'def (rf.migration.hicasso.rewrite/sexpr-safe (rf.migration.hicasso.rewrite/element-at nd 0)))
+       (symbol? (rf.migration.hicasso.rewrite/sexpr-safe (rf.migration.hicasso.rewrite/element-at nd 1)))
+       (some-> (rf.migration.hicasso.rewrite/element-at nd 2) (rf.migration.hicasso.rewrite/bound-call? 'adapt-react-class ctx))))
 
 (defn- hiccup-head-symbol
   "The head of `[Foo …]` when it is a bare symbol — a call site of a
   `def`ed adapted class, if that symbol names one."
   [nd]
   (when (= :vector (n/tag nd))
-    (let [h (rw/element-at nd 0)]
+    (let [h (rf.migration.hicasso.rewrite/element-at nd 0)]
       (when (and h (= :token (n/tag h)))
-        (let [s (rw/sexpr-safe h)] (when (symbol? s) s))))))
+        (let [s (rf.migration.hicasso.rewrite/sexpr-safe h)] (when (symbol? s) s))))))
 
 (defn- adapt-def-entry
   "`(def Foo (r/adapt-react-class X))` cannot be rewritten by a fixer:
@@ -99,7 +99,7 @@
   (loop [ks [], l loc]
     (let [p (z/up l)]
       (if (and p (= :meta (z/tag p)))
-        (recur (if-let [k (rw/meta-key-node (z/node p))] (conj ks k) ks) p)
+        (recur (if-let [k (rf.migration.hicasso.rewrite/meta-key-node (z/node p))] (conj ks k) ks) p)
         ks))))
 
 (defn analyse
@@ -126,23 +126,23 @@
        :suggestions suggests
        :sites      sites
        :left-alone quiet}
-      (if (rw/inert? (z/node loc))
-        (recur (rw/past-subtree loc) entries suggests defs calls sites quiet)
+      (if (rf.migration.hicasso.rewrite/inert? (z/node loc))
+        (recur (rf.migration.hicasso.rewrite/past-subtree loc) entries suggests defs calls sites quiet)
         (let [nd         (z/node loc)
               [line col] (z/position loc)
               form       (fn [] (let [s (z/string loc)]
                                   (if (> (count s) 200) (str (subs s 0 200) " …") s)))
-              kind       (rw/site-kind nd ctx)
+              kind       (rf.migration.hicasso.rewrite/site-kind nd ctx)
               calls      (if-let [s (hiccup-head-symbol nd)]
                            (update calls s (fnil conj []) line)
                            calls)
               defs       (if (adapt-def? nd ctx)
-                           (conj defs {:sym  (rw/sexpr-safe (rw/element-at nd 1))
+                           (conj defs {:sym  (rf.migration.hicasso.rewrite/sexpr-safe (rf.migration.hicasso.rewrite/element-at nd 1))
                                        :line line :col col :form (form) :file file})
                            defs)]
           (if-not kind
             (recur (z/next loc) entries suggests defs calls sites quiet)
-            (let [plan (rw/plan-site nd (assoc ctx :meta-keys (meta-keys-above loc)))
+            (let [plan (rf.migration.hicasso.rewrite/plan-site nd (assoc ctx :meta-keys (meta-keys-above loc)))
                   es   (mapv #(assoc % :file file :line line :col col
                                      :form (form) :head (:head plan))
                              (:entries plan))]
@@ -179,16 +179,16 @@
   produces."
   [nd ctx]
   (cond
-    (rw/inert? nd) nd
+    (rf.migration.hicasso.rewrite/inert? nd) nd
 
-    (rw/meta-node? nd)
-    (let [[metas inner] (rw/unwrap-metas nd)
-          plan   (rw/plan-site inner (assoc ctx :meta-keys (rw/meta-key-nodes metas)))
+    (rf.migration.hicasso.rewrite/meta-node? nd)
+    (let [[metas inner] (rf.migration.hicasso.rewrite/unwrap-metas nd)
+          plan   (rf.migration.hicasso.rewrite/plan-site inner (assoc ctx :meta-keys (rf.migration.hicasso.rewrite/meta-key-nodes metas)))
           inner' ((:edit plan) (rw-children inner ctx))]
-      (rw/rebuild-meta-chain nd inner' (boolean (:w1? plan))))
+      (rf.migration.hicasso.rewrite/rebuild-meta-chain nd inner' (boolean (:w1? plan))))
 
-    (rw/site-kind nd ctx)
-    (let [plan (rw/plan-site nd (assoc ctx :meta-keys []))]
+    (rf.migration.hicasso.rewrite/site-kind nd ctx)
+    (let [plan (rf.migration.hicasso.rewrite/plan-site nd (assoc ctx :meta-keys []))]
       ((:edit plan) (rw-children nd ctx)))
 
     :else (rw-children nd ctx)))
@@ -245,7 +245,7 @@
   node, which is `:cljc-site`)."
   [source file]
   (let [root (p/parse-string-all source)]
-    (assoc (rw/ns-context root)
+    (assoc (rf.migration.hicasso.rewrite/ns-context root)
            :file  (some-> file str)
            :cljc? (boolean (some-> file str (str/ends-with? ".cljc"))))))
 
@@ -290,7 +290,7 @@
             changed? (and rewrite? (not= orig (:source r)))]
         (when (and write? changed?) (spit f (:source r)))
         (assoc r :path path :changed? (boolean changed?)
-               :census (census/scan orig path)))
+               :census (rf.migration.hicasso.census/scan orig path)))
       (catch Exception e
         {:path path :changed? false :sites 0 :left-alone 0 :suggestions []
          ;; A file the reader cannot read is one refusal, not two: the
@@ -308,10 +308,10 @@
   [paths {:keys [rewrite? write?] :as opts}]
   (let [files   (expand-paths paths)
         results (mapv #(run-file % opts) files)]
-    (report/build
+    (rf.migration.hicasso.report/build
      {:entries          (vec (mapcat :entries results))
       :suggestions      (vec (mapcat :suggestions results))
-      :census           (census/build (mapv :census results))
+      :census           (rf.migration.hicasso.census/build (mapv :census results))
       :files-scanned    (count files)
       :files-changed    (count (filter :changed? results))
       :dry-run?         (and rewrite? (not write?))
@@ -384,12 +384,12 @@
       (let [report-p (or explicit (default-report-path paths))
             rep (run paths {:rewrite? (contains? flags "--rewrite")
                             :write?   (contains? flags "--write")})]
-        (report/print-lines (:entries rep))
-        (census/print-lines (:entries (:census rep)))
-        (report/write! rep report-p)
+        (rf.migration.hicasso.report/print-lines (:entries rep))
+        (rf.migration.hicasso.census/print-lines (:entries (:census rep)))
+        (rf.migration.hicasso.report/write! rep report-p)
         (println)
         (println (pr-str (:summary rep)))
-        (println (census/describe (:census rep)))
+        (println (rf.migration.hicasso.census/describe (:census rep)))
         ;; ABSOLUTE, and it says it WROTE. The old line printed the bare
         ;; relative name, which named the file without naming the directory
         ;; — so the one thing a reader needed from it was the one thing it

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/dest.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/dest.clj
@@ -45,17 +45,17 @@
   and asserts the two rosters equal rather than leaving this one to the
   convention (rf2-vi11)."
   (:require [clojure.string :as str]
-            [re-frame.hicasso.impl.slot :as slot]))
+            [re-frame.hicasso.impl.slot :as rf.hicasso.impl.slot]))
 
 (def canonical-slot
   "**The one slot resolver**, and it is the codec's own. The React prop
   slot a hiccup attribute key emits into.
 
   `front.codec/canonical-slot` is `cached-prop-name`, which is a cache
-  over `slot/prop-name`; a cache changes when a lookup is computed and
+  over `rf.hicasso.impl.slot/prop-name`; a cache changes when a lookup is computed and
   nothing about what it answers, so this alias and the codec's are the
   same function of the same key."
-  slot/prop-name)
+  rf.hicasso.impl.slot/prop-name)
 
 (def key-slot
   "`raw-element` lifts `(:key props)` — the LITERAL keyword, read off the
@@ -80,7 +80,7 @@
 (defn html-attr-slot?
   "Is `slot` one of the HTML-attribute positions? MIRRORS
   `front.codec/html-attr-slot?`, prefix families included —
-  `slot/prop-name` leaves `aria-*` and `data-*` uncamelCased, so the slot
+  `rf.hicasso.impl.slot/prop-name` leaves `aria-*` and `data-*` uncamelCased, so the slot
   still carries the prefix to test."
   [slot]
   (boolean

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/donor.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/donor.clj
@@ -18,7 +18,7 @@
   rule with the same three seeded renames and the same `aria`/`data`
   exemption. They part company in exactly two cells:
 
-  | cell | Reagent's `cached-prop-name` | our `slot/prop-name` |
+  | cell | Reagent's `cached-prop-name` | our `rf.hicasso.impl.slot/prop-name` |
   |---|---|---|
   | a STRING key | verbatim — the cache is only consulted for `named?` keys, so `\"class\"` stays `\"class\"` | the three renames apply to every spelling, so `\"class\"` is `\"className\"` |
   | a `--custom-property` | mangled: `--brand-color` → `BrandColor` | preserved verbatim |
@@ -32,7 +32,7 @@
   directions. There is one camel rule in this repository and this
   namespace calls it."
   (:require [clojure.string :as str]
-            [re-frame.hicasso.impl.slot :as slot]))
+            [re-frame.hicasso.impl.slot :as rf.hicasso.impl.slot]))
 
 (defn css-var-name?
   "Is `n` a CSS custom property? Reagent's `dash-to-prop-name` splits
@@ -72,7 +72,7 @@
         ;; The cache is keyed on `(name k)`, so a namespaced spelling
         ;; lands on the same slot as its bare twin — `:x/class` is
         ;; `className`. Re-keywording `n` reproduces that.
-        (slot/prop-name (keyword n))))
+        (rf.hicasso.impl.slot/prop-name (keyword n))))
 
     :else nil))
 

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/report.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/report.clj
@@ -31,7 +31,7 @@
   (:require [clojure.java.io :as io]
             [clojure.pprint :as pp]
             [clojure.string :as str]
-            [re-frame.migration.hicasso.dest :as dest]))
+            [re-frame.migration.hicasso.dest :as rf.migration.hicasso.dest]))
 
 (def ^:private class-order
   "Report ordering within one site. Blockers first, then the refusals that
@@ -104,11 +104,11 @@
     (if (and seg (re-matches simple-name seg)) seg "your-host")))
 
 (defn- contract-roster
-  "`\":event or :render\"` — generated from [[dest/callback-contracts]]
+  "`\":event or :render\"` — generated from [[rf.migration.hicasso.dest/callback-contracts]]
   rather than transcribed beside it, so the sentence the report prints and
   the roster the door enforces cannot drift apart in prose."
   []
-  (let [ss (mapv pr-str dest/callback-contracts)]
+  (let [ss (mapv pr-str rf.migration.hicasso.dest/callback-contracts)]
     (str (str/join ", " (pop ss)) " or " (peek ss))))
 
 (defn- defhost-sketch

--- a/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
+++ b/migration/reagent-to-hicasso/codemod/src/re_frame/migration/hicasso/rewrite.clj
@@ -38,8 +38,8 @@
   **(B)** W2 refuses normalized-key collisions — [[injective-keys]].
   **(C)** The key slot gets a dedicated report entry — [[w3-entry]]."
   (:require [clojure.string :as str]
-            [re-frame.migration.hicasso.dest :as dest]
-            [re-frame.migration.hicasso.donor :as donor]
+            [re-frame.migration.hicasso.dest :as rf.migration.hicasso.dest]
+            [re-frame.migration.hicasso.donor :as rf.migration.hicasso.donor]
             [rewrite-clj.node :as n]
             [rewrite-clj.parser :as p]
             [rewrite-clj.zip :as z]))
@@ -759,14 +759,14 @@
   Returns `nil` when injective, else a sorted vector of the colliding
   source keys' texts, grouped by the normalized name they collapse onto.
 
-  CSS custom properties are excluded from the check because [[donor/key-name]]
+  CSS custom properties are excluded from the check because [[rf.migration.hicasso.donor/key-name]]
   answers `nil` for them: they are refused individually and never
   respelled, so they cannot be half of a minted duplicate."
   [map-node]
   (let [named (->> (pairs map-node)
                    (keep (fn [[k _ _]]
                            (let [kv (sexpr-safe k)
-                                 dn (donor/key-name kv)]
+                                 dn (rf.migration.hicasso.donor/key-name kv)]
                              (when dn [dn (str/trim (n/string k))])))))
         clashes (->> (group-by first named)
                      (filter (fn [[_ v]] (> (count v) 1)))
@@ -783,8 +783,8 @@
   reproduces the donor's emitted name."
   [key-node]
   (let [kv (sexpr-safe key-node)
-        dn (donor/key-name kv)]
-    (when (and dn (not= dn (dest/nested-key-name kv)))
+        dn (rf.migration.hicasso.donor/key-name kv)]
+    (when (and dn (not= dn (rf.migration.hicasso.dest/nested-key-name kv)))
       (cond
         (keyword? kv) (n/token-node (keyword dn))
         (symbol? kv)  (n/token-node (symbol dn))
@@ -824,7 +824,7 @@
                  kpath (conj path (str/trim (n/string k)))
                  ;; the key
                  acc   (cond
-                         (and (or (keyword? kv) (symbol? kv)) (donor/css-var-name? (name kv)))
+                         (and (or (keyword? kv) (symbol? kv)) (rf.migration.hicasso.donor/css-var-name? (name kv)))
                          (update acc :entries conj
                                  (entry :css-var-repair :refused
                                         {:path kpath}
@@ -1055,8 +1055,8 @@
    (fn [acc [k v i]]
      (let [kv    (sexpr-safe k)
            ktext (str/trim (n/string k))
-           slot  (when (or (keyword? kv) (symbol? kv) (string? kv)) (dest/canonical-slot kv))
-           event? (dest/event-prop? kv)
+           slot  (when (or (keyword? kv) (symbol? kv) (string? kv)) (rf.migration.hicasso.dest/canonical-slot kv))
+           event? (rf.migration.hicasso.dest/event-prop? kv)
            vi    (inc i)
            add   (fn [a e] (update a :entries conj e))
            edit  (fn [a new-v]
@@ -1072,7 +1072,7 @@
                               "which you meant.")))
 
          ;; ---- §5.3 `:dangerous-html` -----------------------------------------
-         (dest/dangerous-html-key? kv)
+         (rf.migration.hicasso.dest/dangerous-html-key? kv)
          (add acc (entry :dangerous-html :refused {:prop ktext}
                          (str "MIGRATION BLOCKER. Reagent's `convert-props` DELETED this prop "
                               "unless its value was an `UnsafeHTML` instance, so under Reagent it "
@@ -1083,7 +1083,7 @@
          ;; ---- §5.2 `:named-ref` ----------------------------------------------
          ;; A bare symbol at `:ref` is a CALLBACK ref and is fine; only a
          ;; keyword or quoted symbol made the donor produce a string ref.
-         (and (= dest/ref-slot slot) (literal-named-value v))
+         (and (= rf.migration.hicasso.dest/ref-slot slot) (literal-named-value v))
          (add acc (entry :named-ref :refused {:prop ktext :value (str/trim (n/string v))}
                          (str "Reagent's `(name …)` here produced a STRING REF, which React 19 "
                               "removed and now throws on — so preserving Reagent would restore a "
@@ -1143,11 +1143,11 @@
              ;; it would only grow the diff (§4.6).
              native? acc
              ;; both runtimes `name` here — a fixpoint, and skipping keeps the diff small
-             (dest/html-attr-slot? slot) acc
+             (rf.migration.hicasso.dest/html-attr-slot? slot) acc
              ;; the class slot: `class-names` names it on the Hicasso side, in every spelling
-             (= dest/class-slot slot) acc
+             (= rf.migration.hicasso.dest/class-slot slot) acc
              ;; (C) — ratified exclusion, now with its own report entry
-             (= dest/key-slot slot) (add acc (w3-entry :key-slot vv ktext))
+             (= rf.migration.hicasso.dest/key-slot slot) (add acc (w3-entry :key-slot vv ktext))
              :else
              (-> (edit acc (n/string-node (name vv)))
                  (add (w3-entry (if (namespace vv) :namespaced :plain) vv ktext)))))
@@ -1197,7 +1197,7 @@
   (when props-node
     (let [ps (pairs props-node)
           ev (->> ps (keep (fn [[k _ _]] (let [kv (sexpr-safe k)]
-                                           (when (dest/event-prop? kv) (str/trim (n/string k))))))
+                                           (when (rf.migration.hicasso.dest/event-prop? kv) (str/trim (n/string k))))))
                   sort vec)
           fns (->> ps (keep (fn [[k v _]] (when (fn-literal? v) (str/trim (n/string k)))))
                    sort vec)]
@@ -1232,7 +1232,7 @@
             ;; would go live at a native destination.
             carrier?  (and props
                            (some (fn [[k v _]]
-                                   (and (dest/event-prop? (sexpr-safe k))
+                                   (and (rf.migration.hicasso.dest/event-prop? (sexpr-safe k))
                                         (or (vector-node? v) (map-node? v))))
                                  (pairs props)))
             w6-cand?  (and (= :raw kind) plain-tag?)

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/amendment_a_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/amendment_a_test.clj
@@ -22,7 +22,7 @@
   diverges here, so the amendment is load-bearing rather than defensive."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
-            [re-frame.migration.hicasso.rewrite :as rw]
+            [re-frame.migration.hicasso.rewrite :as rf.migration.hicasso.rewrite]
             [rewrite-clj.node :as n]
             [rewrite-clj.parser :as p]))
 
@@ -50,14 +50,14 @@
 (defn- emitted
   "Run W4 over a literal `(r/partial …)` call; return `[wrapper text]`."
   [src]
-  (let [node (:node (rw/w4-plan (p/parse-string src)))]
+  (let [node (:node (rf.migration.hicasso.rewrite/w4-plan (p/parse-string src)))]
     [(eval-here (n/sexpr node)) (n/string node)]))
 
 (defn- naive
   "The design's stated rewrite, `(fn [& args] (apply f a … args))`, built
   from the same call — the shape amendment (A) replaced."
   [src]
-  (let [els  (rw/elements (p/parse-string src))
+  (let [els  (rf.migration.hicasso.rewrite/elements (p/parse-string src))
         body (str/join " " (map n/string (rest els)))]
     (eval-here (read-string (str "(fn [& args] (apply " body " args))")))))
 
@@ -180,7 +180,7 @@
   "W4's output for `src`, evaluated inside an outer `let` binding `outer`.
   Returns `[wrapper text]`."
   [outer src]
-  (let [node (:node (rw/w4-plan (p/parse-string src)))]
+  (let [node (:node (rf.migration.hicasso.rewrite/w4-plan (p/parse-string src)))]
     [(eval-here (list 'let outer (n/sexpr node))) (n/string node)]))
 
 (defn- source-symbols
@@ -194,7 +194,7 @@
   "The names W4 minted for `src`: the `let`'s binding names, plus the
   wrapper's rest parameter."
   [src]
-  (let [[_ binds body] (n/sexpr (:node (rw/w4-plan (p/parse-string src))))]
+  (let [[_ binds body] (n/sexpr (:node (rf.migration.hicasso.rewrite/w4-plan (p/parse-string src))))]
     (set (concat (take-nth 2 binds) (remove #{'&} (second body))))))
 
 (defn- collisions

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/census_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/census_test.clj
@@ -37,11 +37,11 @@
   (:require [clojure.set]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
-            [re-frame.migration.hicasso.census :as census]
-            [re-frame.migration.hicasso.codemod :as cm]
+            [re-frame.migration.hicasso.census :as rf.migration.hicasso.census]
+            [re-frame.migration.hicasso.codemod :as rf.migration.hicasso.codemod]
             [re-frame.migration.hicasso.rewrite :as rf.migration.hicasso.rewrite]))
 
-(defn- classes [src file] (mapv :class (:entries (census/scan src file))))
+(defn- classes [src file] (mapv :class (:entries (rf.migration.hicasso.census/scan src file))))
 
 ;; ---------------------------------------------------------------------------
 ;; It can answer NON-EMPTY, on exactly the source the fixer answers empty on
@@ -60,12 +60,12 @@
 (deftest the-fixer-is-silent-here
   (testing "the crossing population is genuinely empty in this file — the census is
             not being compared against a fixer that simply failed"
-    (let [r (cm/scan-string form-2 "app/counter.cljs")]
+    (let [r (rf.migration.hicasso.codemod/scan-string form-2 "app/counter.cljs")]
       (is (= [] (:entries r)))
       (is (= 0 (:sites r))))))
 
 (deftest the-census-answers-non-empty
-  (let [{:keys [entries reagent? unresolved?]} (census/scan form-2 "app/counter.cljs")]
+  (let [{:keys [entries reagent? unresolved?]} (rf.migration.hicasso.census/scan form-2 "app/counter.cljs")]
     (is (true? reagent?))
     (is (false? unresolved?))
     (is (= [:local-reactive-cell] (mapv :class entries)))
@@ -77,10 +77,10 @@
       (is (str/includes? (:note (first entries)) "NO view-local state tier")))))
 
 (deftest every-roster-class-has-a-recovery-sentence
-  (doseq [[api {:keys [class verdict]}] census/surface]
+  (doseq [[api {:keys [class verdict]}] rf.migration.hicasso.census/surface]
     (testing (str api)
-      (is (contains? (set census/verdicts) verdict))
-      (is (string? (:note (first (:entries (census/scan
+      (is (contains? (set rf.migration.hicasso.census/verdicts) verdict))
+      (is (string? (:note (first (:entries (rf.migration.hicasso.census/scan
                                             (str "(ns a (:require [reagent.core :as r]))\n"
                                                  "(r/" api " x)\n")
                                             "a.cljs")))))
@@ -122,7 +122,7 @@
        "(defn panel [] (r/atom {}))\n"))
 
 (deftest an-unbindable-require-is-reported
-  (let [{:keys [entries unresolved?]} (census/scan vendored-require "app/panel.cljs")]
+  (let [{:keys [entries unresolved?]} (rf.migration.hicasso.census/scan vendored-require "app/panel.cljs")]
     (is (true? unresolved?))
     (is (= [:unresolved-reagent-require :unresolved-alias] (mapv :class entries)))
     (testing "the require is reported at the `ns` form, where the fix goes"
@@ -135,7 +135,7 @@
 (deftest the-unqualified-core-call-beside-it-is-not-reported
   (testing "`(atom nil)` on line 4 is `clojure.core`'s. An alias is what could not
             be bound, so a call with no alias is not evidence of it."
-    (is (not-any? #(= 4 (:line %)) (:entries (census/scan vendored-require "app/panel.cljs"))))))
+    (is (not-any? #(= 4 (:line %)) (:entries (rf.migration.hicasso.census/scan vendored-require "app/panel.cljs"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; A require behind a reader conditional RESOLVES (rf2-m4hm)
@@ -146,7 +146,7 @@
             form, which throws on a reader-conditional node, so EVERY alias
             came back empty and the file's real findings were reported only as
             `:unresolved-alias`"
-    (let [{:keys [entries reagent? unresolved?]} (census/scan conditional-require "app/ssr.cljc")]
+    (let [{:keys [entries reagent? unresolved?]} (rf.migration.hicasso.census/scan conditional-require "app/ssr.cljc")]
       (is (true? reagent?))
       (is (false? unresolved?) "resolved, not merely reported")
       (is (= [:root-mount] (mapv :class entries))
@@ -189,7 +189,7 @@
                    "\n"
                    "(defn v [] (r/atom 1))\n"
                    "(defn m [] (rdc/render nil nil))\n")
-          {:keys [entries unresolved?]} (census/scan src "app/mixed.cljc")]
+          {:keys [entries unresolved?]} (rf.migration.hicasso.census/scan src "app/mixed.cljc")]
       (is (false? unresolved?))
       (is (= [:local-reactive-cell :root-mount] (mapv :class entries))
           "BOTH requires' call sites are named, not just the ordinary one")
@@ -203,7 +203,7 @@
                    "  (:require #?(:cljs [clojure.string :as str])))\n"
                    "\n"
                    "(defn v [] (str/atom 1))\n")
-          {:keys [entries reagent? unresolved?]} (census/scan src "app/util.cljc")]
+          {:keys [entries reagent? unresolved?]} (rf.migration.hicasso.census/scan src "app/util.cljc")]
       (is (false? reagent?))
       (is (false? unresolved?))
       (is (= [] entries)))))
@@ -225,7 +225,7 @@
                    "   [reagent.core :as r]))\n"
                    "\n"
                    "(def graph-ref-map (r/atom {}))\n")
-          {:keys [entries reagent? unresolved?]} (census/scan src "app/graph.cljs")]
+          {:keys [entries reagent? unresolved?]} (rf.migration.hicasso.census/scan src "app/graph.cljs")]
       (is (true? reagent?))
       (is (false? unresolved?) "resolved, not merely reported")
       (is (= [:local-reactive-cell] (mapv :class entries)))
@@ -256,7 +256,7 @@
                  "\n"
                  "(defn page []\n"
                  "  [:div (for [x @(rf/subscribe [:xs])] ^{:key x} [:span x])])\n")
-        {:keys [entries reagent? unresolved? recognised?]} (census/scan src "app/views.cljs")]
+        {:keys [entries reagent? unresolved? recognised?]} (rf.migration.hicasso.census/scan src "app/views.cljs")]
     (is (= [] entries))
     (is (false? reagent?))
     (is (false? unresolved?))
@@ -276,7 +276,7 @@
                    "  (:require [clojure.string :as str]))\n"
                    "\n"
                    "(defn page [] [:div (str/upper-case \"x\")])\n")
-          {:keys [entries reagent?]} (census/scan src "app/editor.cljs")]
+          {:keys [entries reagent?]} (rf.migration.hicasso.census/scan src "app/editor.cljs")]
       (is (= [] entries))
       (is (false? reagent?)))))
 
@@ -293,7 +293,7 @@
                    "    [:div]\n"
                    "    (finally (dispatch [:cancel]))))\n")]
       (is (= [:with-let] (classes src "app/bench.cljs")))
-      (is (= 7 (:line (first (:entries (census/scan src "app/bench.cljs")))))))))
+      (is (= 7 (:line (first (:entries (rf.migration.hicasso.census/scan src "app/bench.cljs")))))))))
 
 (deftest a-core-name-is-not-reagents-without-a-binding
   (testing "half the roster shares a name with `clojure.core`. Only a bound alias,
@@ -397,7 +397,7 @@
                    "\n"
                    "(def a (ratom 0))\n"
                    "(def b (atom 0))\n")
-          {:keys [entries]} (census/scan src "app/p.clj")]
+          {:keys [entries]} (rf.migration.hicasso.census/scan src "app/p.clj")]
       (is (= [:local-reactive-cell] (mapv :class entries)))
       (is (= [4] (mapv :line entries)) "the renamed call, not the core one")
       (testing "and it is reported under the ROSTER name, which is the only one
@@ -411,7 +411,7 @@
                    "\n"
                    "(def a (ratom 0))\n"
                    "(def b (atom 0))\n")]
-      (is (= [4] (mapv :line (:entries (census/scan src "app/p.clj")))))))
+      (is (= [4] (mapv :line (:entries (rf.migration.hicasso.census/scan src "app/p.clj")))))))
 
   (testing "a `:rename` with no `:refer` binds nothing, which is the effect
             Clojure gives it"
@@ -426,19 +426,19 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-second-scan-reports-identically
-  (is (= (census/scan form-2 "app/counter.cljs")
-         (census/scan form-2 "app/counter.cljs")))
-  (is (= (census/scan conditional-require "app/ssr.cljc")
-         (census/scan conditional-require "app/ssr.cljc")))
-  (is (= (census/scan vendored-require "app/panel.cljs")
-         (census/scan vendored-require "app/panel.cljs"))))
+  (is (= (rf.migration.hicasso.census/scan form-2 "app/counter.cljs")
+         (rf.migration.hicasso.census/scan form-2 "app/counter.cljs")))
+  (is (= (rf.migration.hicasso.census/scan conditional-require "app/ssr.cljc")
+         (rf.migration.hicasso.census/scan conditional-require "app/ssr.cljc")))
+  (is (= (rf.migration.hicasso.census/scan vendored-require "app/panel.cljs")
+         (rf.migration.hicasso.census/scan vendored-require "app/panel.cljs"))))
 
 (deftest the-summary-names-every-bucket-including-the-empty-ones
-  (let [built (census/build [(census/scan form-2 "app/counter.cljs")
-                             (census/scan vendored-require "app/panel.cljs")
-                             (census/scan "(ns a)\n(defn f [] [:div])\n" "app/plain.cljs")])
+  (let [built (rf.migration.hicasso.census/build [(rf.migration.hicasso.census/scan form-2 "app/counter.cljs")
+                             (rf.migration.hicasso.census/scan vendored-require "app/panel.cljs")
+                             (rf.migration.hicasso.census/scan "(ns a)\n(defn f [] [:div])\n" "app/plain.cljs")])
         s     (:summary built)]
-    (is (= (set census/verdicts) (set (keys (:by-verdict s))))
+    (is (= (set rf.migration.hicasso.census/verdicts) (set (keys (:by-verdict s))))
         "an absent key is a count nobody can tell from a bug")
     (is (= 0 (get-in s [:by-verdict :mechanical]))
         "nothing outside a crossing is mechanical, and the census says so with a zero")
@@ -484,7 +484,7 @@
             so a census that classified by the Reagent roster alone had nothing
             to count in the file that actually mounts the application."
     (let [{:keys [entries reagent? substrate? recognised?]}
-          (census/scan rf2-native-boot "app/core.cljs")]
+          (rf.migration.hicasso.census/scan rf2-native-boot "app/core.cljs")]
       (is (false? reagent?) "there is genuinely no Reagent name in this file")
       (is (true? substrate?))
       (is (true? recognised?))
@@ -498,13 +498,13 @@
             it is a value in argument position, and this walk reads call heads.
             The file is recognised through its `ns` form regardless, so nothing
             rides on catching it — stated here so the silence is a decision."
-    (is (= 2 (count (:entries (census/scan rf2-native-boot "app/core.cljs")))))))
+    (is (= 2 (count (:entries (rf.migration.hicasso.census/scan rf2-native-boot "app/core.cljs")))))))
 
 (deftest every-substrate-class-has-a-recovery-sentence
-  (doseq [[api {:keys [verdict]}] census/substrate-surface]
+  (doseq [[api {:keys [verdict]}] rf.migration.hicasso.census/substrate-surface]
     (testing (str api)
-      (is (contains? (set census/verdicts) verdict))
-      (is (string? (:note (first (:entries (census/scan
+      (is (contains? (set rf.migration.hicasso.census/verdicts) verdict))
+      (is (string? (:note (first (:entries (rf.migration.hicasso.census/scan
                                             (str "(ns a (:require [re-frame.adapter.uix :as ad]))\n"
                                                  "(ad/" api " x)\n")
                                             "a.cljs")))))
@@ -520,8 +520,8 @@
             (rf2-xoal). An UNINTENDED overlap still reds here — only the
             deliberate one is allowed through."
     (is (= '#{flush-views!}
-           (clojure.set/intersection (set (keys census/surface))
-                                     (set (keys census/substrate-surface))))))
+           (clojure.set/intersection (set (keys rf.migration.hicasso.census/surface))
+                                     (set (keys rf.migration.hicasso.census/substrate-surface))))))
 
   (testing "through `reagent2.dom.client` the shared name is Reagent's — and the
             file counts as one that NAMES Reagent, which is the flag the migration
@@ -530,7 +530,7 @@
                    "  (:require [reagent2.dom.client :as rdc]))\n"
                    "\n"
                    "(defn settle [] (rdc/flush-views!))\n")
-          {:keys [entries reagent? substrate?]} (census/scan src "app/t.cljs")]
+          {:keys [entries reagent? substrate?]} (rf.migration.hicasso.census/scan src "app/t.cljs")]
       (is (true? reagent?))
       (is (false? substrate?))
       (is (= [:substrate-test-seam] (mapv :class entries)))))
@@ -542,7 +542,7 @@
                    "  (:require [re-frame.adapter.uix :as ad]))\n"
                    "\n"
                    "(defn settle [] (ad/flush-views!))\n")
-          {:keys [entries reagent? substrate?]} (census/scan src "app/t.cljs")]
+          {:keys [entries reagent? substrate?]} (rf.migration.hicasso.census/scan src "app/t.cljs")]
       (is (false? reagent?))
       (is (true? substrate?))
       (is (= [:substrate-test-seam] (mapv :class entries))))))
@@ -557,7 +557,7 @@
                    "  (:require [my.vendored.re-frame.adapter.reagent :as ad]))\n"
                    "\n"
                    "(defn f [] (ad/render! nil nil nil))\n")
-          {:keys [entries substrate? recognised?]} (census/scan src "app/p.cljs")]
+          {:keys [entries substrate? recognised?]} (rf.migration.hicasso.census/scan src "app/p.cljs")]
       (is (= [] entries))
       (is (false? substrate?))
       (is (false? recognised?)))))
@@ -578,7 +578,7 @@
                    "(def cache (r/atom {}))\n"
                    "(defn chart [] (r/create-class {:reagent-render (fn [] [:div])}))\n"
                    "(defn el [h] (r/as-element h))\n")
-          {:keys [entries reagent? unresolved?]} (census/scan src "app/chart.cljs")]
+          {:keys [entries reagent? unresolved?]} (rf.migration.hicasso.census/scan src "app/chart.cljs")]
       (is (true? reagent?))
       (is (false? unresolved?) "bound, not merely named")
       (is (= [:local-reactive-cell :lifecycle-class :as-element] (mapv :class entries)))))
@@ -610,7 +610,7 @@
   **This table is the ratchet, and the assertion below that it is
   COMPLETE is the half that matters.** Recognition is decided per FILE and
   entries are found per NAME, so widening the namespace set without
-  widening `census/surface` converts an honest *I did not recognise this
+  widening `rf.migration.hicasso.census/surface` converts an honest *I did not recognise this
   file* into `:recognition :full` with `entries 0` — a confident zero, and
   a strictly worse answer than the one it replaced. PR #9132 did exactly
   that: it added the `reagent2.*` four and left `reagent2.dom.server`'s
@@ -646,7 +646,7 @@
   "Scan a one-call file that requires `ns*` as `x`, and return the census
   summary over it."
   [ns* call]
-  (:summary (census/build [(census/scan (str "(ns app.probe\n"
+  (:summary (rf.migration.hicasso.census/build [(rf.migration.hicasso.census/scan (str "(ns app.probe\n"
                                              "  (:require [" ns* " :as x]))\n"
                                              "\n"
                                              "(defn f [] " call ")\n")
@@ -693,7 +693,7 @@
                    "\n"
                    "(defn page-html []\n"
                    "  (rds/render-to-static-markup [:div \"hello\"]))\n")
-          s   (:summary (census/build [(census/scan src "app/ssr.cljs")]))]
+          s   (:summary (rf.migration.hicasso.census/build [(rf.migration.hicasso.census/scan src "app/ssr.cljs")]))]
       (is (= 1 (:files-recognised s)))
       (is (= :full (:recognition s)))
       (is (= 1 (:entries s))         "was 0")
@@ -714,14 +714,14 @@
                    "  (:require [reagent.core :as r]))\n"
                    "\n"
                    "(defn v [] [:div \"no rostered call in this file\"])\n")
-          s   (:summary (census/build [(census/scan src "app/v.cljs")]))]
+          s   (:summary (rf.migration.hicasso.census/build [(rf.migration.hicasso.census/scan src "app/v.cljs")]))]
       (is (= :full (:recognition s)))
       (is (= 0 (:entries s)))
       (is (str/includes? (:caveat s) "fixed roster"))
       (is (str/includes? (:caveat s) "not that these files hold no migration work"))
       (testing "and the CLI tail — the last line of the run, read by whoever reads
                 nothing else — marks the zero rather than printing it bare"
-        (is (str/includes? (census/describe {:summary s}) "ZERO ENTRIES"))))))
+        (is (str/includes? (rf.migration.hicasso.census/describe {:summary s}) "ZERO ENTRIES"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; A zero the tool CANNOT report confidently (rf2-xoal)
@@ -732,8 +732,8 @@
             the census has no population anywhere in it. Its zero used to be
             indistinguishable from a clean bill of health, which is the
             fail-open shape."
-    (let [s (:summary (census/build [(census/scan rf2-native-view "app/articles.cljs")
-                                     (census/scan rf2-native-view "app/profile.cljs")]))]
+    (let [s (:summary (rf.migration.hicasso.census/build [(rf.migration.hicasso.census/scan rf2-native-view "app/articles.cljs")
+                                     (rf.migration.hicasso.census/scan rf2-native-view "app/profile.cljs")]))]
       (is (= 0 (:entries s)))
       (is (= :none (:recognition s)))
       (is (= 2 (:files-scanned s)))
@@ -742,24 +742,24 @@
       (is (str/includes? (:caveat s) "NOT A CLEAN BILL OF HEALTH"))
       (testing "and the CLI tail says it too, because whoever reads only the last
                 line of the run is exactly who this misleads"
-        (is (str/includes? (census/describe {:summary s}) "NOTHING RECOGNISED")))))
+        (is (str/includes? (rf.migration.hicasso.census/describe {:summary s}) "NOTHING RECOGNISED")))))
 
   (testing "THE CONTROL, and it has to fire or the assertion above means nothing:
             the same machinery over a corpus the census DOES have a population
             in reports `:full`, and its caveat says the zero would be a
             measurement rather than a shrug."
-    (let [s (:summary (census/build [(census/scan form-2 "app/counter.cljs")]))]
+    (let [s (:summary (rf.migration.hicasso.census/build [(rf.migration.hicasso.census/scan form-2 "app/counter.cljs")]))]
       (is (= :full (:recognition s)))
       (is (= 1 (:entries s)))
       (is (= 0 (:files-unrecognised s)))
       (is (str/includes? (:caveat s) "a population throughout"))
-      (is (not (str/includes? (census/describe {:summary s}) "NOTHING RECOGNISED")))))
+      (is (not (str/includes? (rf.migration.hicasso.census/describe {:summary s}) "NOTHING RECOGNISED")))))
 
   (testing "the mixed corpus — one adapter file, one view file — is `:partial`,
             and its caveat is the one a re-frame2 migrator needs: the view files
             are absent from this census AND full of migration work."
-    (let [s (:summary (census/build [(census/scan rf2-native-boot "app/core.cljs")
-                                     (census/scan rf2-native-view "app/articles.cljs")]))]
+    (let [s (:summary (rf.migration.hicasso.census/build [(rf.migration.hicasso.census/scan rf2-native-boot "app/core.cljs")
+                                     (rf.migration.hicasso.census/scan rf2-native-view "app/articles.cljs")]))]
       (is (= :partial (:recognition s)))
       (is (= 2 (:entries s)) "the two mount calls, which used to be zero")
       (is (= 1 (:files-with-substrate s)))
@@ -768,7 +768,7 @@
       (is (str/includes? (:caveat s) "full of migration work"))))
 
   (testing "an empty path set is its own verdict rather than a zero"
-    (let [s (:summary (census/build []))]
+    (let [s (:summary (rf.migration.hicasso.census/build []))]
       (is (= :no-files (:recognition s)))
       (is (str/includes? (:caveat s) "NO SOURCE FILE WAS SCANNED")))))
 
@@ -777,10 +777,10 @@
             scanned, and `files-with-reagent` + `files-unresolved` +
             `files-clean` summing to 0. The buckets close now, and the one that
             was missing is the one the zero was hiding."
-    (let [built (census/build [(census/scan form-2 "app/counter.cljs")
-                               (census/scan vendored-require "app/panel.cljs")
-                               (census/scan rf2-native-boot "app/core.cljs")
-                               (census/scan rf2-native-view "app/articles.cljs")])
+    (let [built (rf.migration.hicasso.census/build [(rf.migration.hicasso.census/scan form-2 "app/counter.cljs")
+                               (rf.migration.hicasso.census/scan vendored-require "app/panel.cljs")
+                               (rf.migration.hicasso.census/scan rf2-native-boot "app/core.cljs")
+                               (rf.migration.hicasso.census/scan rf2-native-view "app/articles.cljs")])
           s     (:summary built)
           with-entries (count (into #{} (map :file) (:entries built)))]
       (is (= (:files-scanned s) (+ (:files-recognised s) (:files-unrecognised s))))

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/corpus_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/corpus_test.clj
@@ -41,7 +41,7 @@
             [clojure.string :as str]
             [clojure.pprint :as pp]
             [clojure.test :refer [deftest is testing]]
-            [re-frame.migration.hicasso.codemod :as cm]))
+            [re-frame.migration.hicasso.codemod :as rf.migration.hicasso.codemod]))
 
 (def ^:private corpus-root (io/file "test" "corpus"))
 
@@ -93,7 +93,7 @@
           rep-f    (io/file dir "expected-report.edn")
           src      (slurp in-f)
           path     (str "src/app/" (.getName ^java.io.File in-f))
-          result   (cm/rewrite-string src path)
+          result   (rf.migration.hicasso.codemod/rewrite-string src path)
           entries  (report-shape (:entries result))]
 
       (when regen?
@@ -111,11 +111,11 @@
             (str name* ": the fixer SAID something other than expected-report.edn")))
 
       (testing (str name* " — idempotence (§4.7): a second run is a no-op")
-        (let [again (cm/rewrite-string (:source result) path)]
+        (let [again (rf.migration.hicasso.codemod/rewrite-string (:source result) path)]
           (is (= (:source result) (:source again))
               (str name* ": running the fixer on its own output changed it, so some "
                    "output is still inside its own rewrite's input language"))))
 
       (testing (str name* " — determinism")
-        (is (= entries (report-shape (:entries (cm/rewrite-string src path))))
+        (is (= entries (report-shape (:entries (rf.migration.hicasso.codemod/rewrite-string src path))))
             (str name* ": two analyses of one input disagreed"))))))

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/inert_source_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/inert_source_test.clj
@@ -40,7 +40,7 @@
   migrator a hand-port of a form that never runs. Pinned from
   [[an-inert-reagent-call-is-not-a-refusal-reason]] down."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.migration.hicasso.codemod :as cm]))
+            [re-frame.migration.hicasso.codemod :as rf.migration.hicasso.codemod]))
 
 (def ^:private hdr
   "(ns app.p\n  (:require [reagent.core :as r]))\n")
@@ -48,17 +48,17 @@
 (defn- classes
   "The report's entry classes for one source string."
   [body]
-  (mapv :class (:entries (cm/scan-string (str hdr body) "app/p.cljs"))))
+  (mapv :class (:entries (rf.migration.hicasso.codemod/scan-string (str hdr body) "app/p.cljs"))))
 
 (defn- sites
   "How many crossing sites the walk counted."
   [body]
-  (:sites (cm/scan-string (str hdr body) "app/p.cljs")))
+  (:sites (rf.migration.hicasso.codemod/scan-string (str hdr body) "app/p.cljs")))
 
 (defn- rewritten
   "The fixer's output for one source string."
   [body]
-  (:source (cm/rewrite-string (str hdr body) "app/p.cljs")))
+  (:source (rf.migration.hicasso.codemod/rewrite-string (str hdr body) "app/p.cljs")))
 
 ;; ---------------------------------------------------------------------------
 ;; Pass 1 — the report
@@ -182,7 +182,7 @@
   (testing "and the same for the CALL sites such an entry lists: a
             `[Foo …]` inside a comment is not a call site, so it must not
             appear in the line list the report tells a migrator to visit"
-    (let [entry (first (:entries (cm/scan-string
+    (let [entry (first (:entries (rf.migration.hicasso.codemod/scan-string
                                   (str hdr
                                        "(def Foo (r/adapt-react-class X))\n"
                                        "(comment [Foo {:a 1}])\n"

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/newlines_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/newlines_test.clj
@@ -18,7 +18,7 @@
   and they run identically on every platform including the Linux CI lane."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
-            [re-frame.migration.hicasso.codemod :as cm]))
+            [re-frame.migration.hicasso.codemod :as rf.migration.hicasso.codemod]))
 
 ;; ---------------------------------------------------------------------------
 ;; The rig
@@ -46,7 +46,7 @@
         all  (count (re-seq #"\n" s))]
     [crlf (- all crlf)]))
 
-(defn- rewritten [src] (:source (cm/rewrite-string src "src/app/endings.cljs")))
+(defn- rewritten [src] (:source (rf.migration.hicasso.codemod/rewrite-string src "src/app/endings.cljs")))
 
 ;; ---------------------------------------------------------------------------
 ;; The rewrite fires — otherwise every assertion below is vacuous
@@ -133,7 +133,7 @@
   (testing "a one-liner has no convention to preserve, and the fixer must
             not invent one"
     (let [src "[:> Btn {:variant :primary}]"
-          out (:source (cm/rewrite-string src "src/app/one.cljs"))]
+          out (:source (rf.migration.hicasso.codemod/rewrite-string src "src/app/one.cljs"))]
       (is (= "[:> Btn {:variant \"primary\"}]" out))
       (is (= [0 0] (endings out))))))
 

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/shared_rule_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/shared_rule_test.clj
@@ -30,7 +30,7 @@
 
   ## The donor's two deltas
 
-  Reagent's `cached-prop-name` and our `slot/prop-name` are one rule apart
+  Reagent's `cached-prop-name` and our `rf.hicasso.impl.slot/prop-name` are one rule apart
   from two cells. Each row below cites the executed donor witness that
   pins it — `codemod-contract-donor-*` in
   `implementation/adapters/reagent/test/re_frame/reagent_codemod_contract_donor_cljs_test.cljs`
@@ -39,10 +39,10 @@
             [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
-            [re-frame.hicasso.impl.slot :as slot]
-            [re-frame.migration.hicasso.dest :as dest]
-            [re-frame.migration.hicasso.donor :as donor]
-            [re-frame.migration.hicasso.rewrite :as rw]
+            [re-frame.hicasso.impl.slot :as rf.hicasso.impl.slot]
+            [re-frame.migration.hicasso.dest :as rf.migration.hicasso.dest]
+            [re-frame.migration.hicasso.donor :as rf.migration.hicasso.donor]
+            [re-frame.migration.hicasso.rewrite :as rf.migration.hicasso.rewrite]
             [rewrite-clj.parser :as p]))
 
 ;; ---------------------------------------------------------------------------
@@ -50,9 +50,9 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-slot-rule-is-the-shared-one
-  (testing "the tool's slot resolver IS `slot/prop-name`, by identity —
+  (testing "the tool's slot resolver IS `rf.hicasso.impl.slot/prop-name`, by identity —
             not a transcription of it"
-    (is (identical? dest/canonical-slot slot/prop-name)))
+    (is (identical? rf.migration.hicasso.dest/canonical-slot rf.hicasso.impl.slot/prop-name)))
 
   (testing "and it is loaded from the SHARED `.cljc` IN THE SHIPPED
             PACKAGE, not from a copy inside this artefact and not from
@@ -123,9 +123,9 @@
             calls conventions; this one is a mirror with an alarm on it."
     (let [door (door-contracts)]
       (is (set? door) "the door's `callback-contracts` set was not found in its source")
-      (is (= door (set dest/callback-contracts))
+      (is (= door (set rf.migration.hicasso.dest/callback-contracts))
           (str "the door accepts " (pr-str door) " and this tool prints "
-               (pr-str dest/callback-contracts)))))
+               (pr-str rf.migration.hicasso.dest/callback-contracts)))))
 
   (testing "`:fn` — the keyword the sketch used to print at every
             position — is not among them, which is the whole of the bug"
@@ -138,47 +138,47 @@
 (deftest the-donor-key-rule
   (testing "kebab→camel, which is `dash-to-prop-name`
             (donor witness: codemod-contract-donor-w2-nested-map-keys)"
-    (is (= "pageSize"  (donor/key-name :page-size)))
-    (is (= "firstName" (donor/key-name :first-name)))
-    (is (= "otherKey"  (donor/key-name :other-key))))
+    (is (= "pageSize"  (rf.migration.hicasso.donor/key-name :page-size)))
+    (is (= "firstName" (rf.migration.hicasso.donor/key-name :first-name)))
+    (is (= "otherKey"  (rf.migration.hicasso.donor/key-name :other-key))))
 
   (testing "the three seeded renames, which hold for every spelling of the
             same attribute because the cache is keyed on `(name k)`"
-    (is (= "className" (donor/key-name :class)))
-    (is (= "htmlFor"   (donor/key-name :for)))
-    (is (= "charSet"   (donor/key-name :charset)))
-    (is (= "className" (donor/key-name :x/class))))
+    (is (= "className" (rf.migration.hicasso.donor/key-name :class)))
+    (is (= "htmlFor"   (rf.migration.hicasso.donor/key-name :for)))
+    (is (= "charSet"   (rf.migration.hicasso.donor/key-name :charset)))
+    (is (= "className" (rf.migration.hicasso.donor/key-name :x/class))))
 
   (testing "`aria` and `data` are exempt"
-    (is (= "aria-label" (donor/key-name :aria-label)))
-    (is (= "data-kind"  (donor/key-name :data-kind))))
+    (is (= "aria-label" (rf.migration.hicasso.donor/key-name :aria-label)))
+    (is (= "data-kind"  (rf.migration.hicasso.donor/key-name :data-kind))))
 
   (testing "symbols take the same arm — `named?` is keyword-or-symbol"
-    (is (= "pageSize" (donor/key-name 'page-size))))
+    (is (= "pageSize" (rf.migration.hicasso.donor/key-name 'page-size))))
 
   (testing "DELTA 1 — a STRING key is verbatim under the donor, seeded
             renames included, where our own rule applies them to every
             spelling. This is the cell that makes a transcription of
             `prop-name` wrong for W2's purposes."
-    (is (= "first-name" (donor/key-name "first-name")))
-    (is (= "class"      (donor/key-name "class")))
-    (is (= "className"  (slot/prop-name "class"))
+    (is (= "first-name" (rf.migration.hicasso.donor/key-name "first-name")))
+    (is (= "class"      (rf.migration.hicasso.donor/key-name "class")))
+    (is (= "className"  (rf.hicasso.impl.slot/prop-name "class"))
         "the shared rule's answer for the same key, for contrast"))
 
   (testing "DELTA 2 — a CSS custom property is DETECTED and refused, never
             reproduced. Reagent mangled `--brand-color` into `BrandColor`,
             a style key nothing reads; preserving that would mean writing
             a key that never worked."
-    (is (donor/css-var-name? "--brand-color"))
-    (is (nil? (donor/key-name :--brand-color)))
-    (is (= "--brand-color" (slot/prop-name :--brand-color))
+    (is (rf.migration.hicasso.donor/css-var-name? "--brand-color"))
+    (is (nil? (rf.migration.hicasso.donor/key-name :--brand-color)))
+    (is (= "--brand-color" (rf.hicasso.impl.slot/prop-name :--brand-color))
         "our rule preserves it, and React routes it through `setProperty`"))
 
   (testing "everywhere else the two rules agree, which is why `key-name`
             delegates rather than transcribes"
     (doseq [k [:page-size :first-name :other-key :class :for :charset
                :aria-label :data-kind :onClick :on-click]]
-      (is (= (slot/prop-name k) (donor/key-name k))
+      (is (= (rf.hicasso.impl.slot/prop-name k) (rf.migration.hicasso.donor/key-name k))
           (str "the two rules should agree at " k)))))
 
 ;; ---------------------------------------------------------------------------
@@ -187,38 +187,38 @@
 
 (deftest the-destination-vocabulary
   (testing "`html-attr-slot?` mirrors the codec's, prefix families included"
-    (is (every? dest/html-attr-slot? ["className" "id" "role" "data-kind" "aria-label"]))
-    (is (not-any? dest/html-attr-slot? ["variant" "theme" "key" "ref" "onClick"])))
+    (is (every? rf.migration.hicasso.dest/html-attr-slot? ["className" "id" "role" "data-kind" "aria-label"]))
+    (is (not-any? rf.migration.hicasso.dest/html-attr-slot? ["variant" "theme" "key" "ref" "onClick"])))
 
   (testing "`event-prop?` mirrors `intent/event-prop?`, INCLUDING its type
             gate — a prop key spelled `on-click` as a SYMBOL is not an
             event position, so the tool must not refuse there"
-    (is (dest/event-prop? :on-click))
-    (is (dest/event-prop? :onClick))
-    (is (dest/event-prop? "on-click"))
-    (is (not (dest/event-prop? 'on-click)) "symbols answer false")
-    (is (not (dest/event-prop? :once)) "`on` followed by a lowercase letter is not `on-`")
-    (is (not (dest/event-prop? :online))))
+    (is (rf.migration.hicasso.dest/event-prop? :on-click))
+    (is (rf.migration.hicasso.dest/event-prop? :onClick))
+    (is (rf.migration.hicasso.dest/event-prop? "on-click"))
+    (is (not (rf.migration.hicasso.dest/event-prop? 'on-click)) "symbols answer false")
+    (is (not (rf.migration.hicasso.dest/event-prop? :once)) "`on` followed by a lowercase letter is not `on-`")
+    (is (not (rf.migration.hicasso.dest/event-prop? :online))))
 
   (testing "a nested map key's destination name is `clj->js`'s answer,
             which is what W2 has to make agree with the donor"
-    (is (= "page-size" (dest/nested-key-name :page-size)))
-    (is (= "x/page-size" (dest/nested-key-name 'x/page-size)))
-    (is (= "first-name" (dest/nested-key-name "first-name"))))
+    (is (= "page-size" (rf.migration.hicasso.dest/nested-key-name :page-size)))
+    (is (= "x/page-size" (rf.migration.hicasso.dest/nested-key-name 'x/page-size)))
+    (is (= "first-name" (rf.migration.hicasso.dest/nested-key-name "first-name"))))
 
   (testing "`dangerouslySetInnerHTML` is recognised in any spelling,
             because the kebab one never reached React's exact name under
             either runtime and the migrator needs telling regardless"
-    (is (dest/dangerous-html-key? :dangerouslySetInnerHTML))
-    (is (dest/dangerous-html-key? :dangerously-set-inner-html))
-    (is (dest/dangerous-html-key? "dangerouslySetInnerHTML"))
-    (is (not (dest/dangerous-html-key? :dangerous)))))
+    (is (rf.migration.hicasso.dest/dangerous-html-key? :dangerouslySetInnerHTML))
+    (is (rf.migration.hicasso.dest/dangerous-html-key? :dangerously-set-inner-html))
+    (is (rf.migration.hicasso.dest/dangerous-html-key? "dangerouslySetInnerHTML"))
+    (is (not (rf.migration.hicasso.dest/dangerous-html-key? :dangerous)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Amendment (B), at the unit
 ;; ---------------------------------------------------------------------------
 
-(defn- collisions [src] (rw/injective-keys (p/parse-string src)))
+(defn- collisions [src] (rf.migration.hicasso.rewrite/injective-keys (p/parse-string src)))
 
 (deftest amendment-b-injectivity
   (testing "an ordinary camel-case collision"

--- a/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/sketch_test.clj
+++ b/migration/reagent-to-hicasso/codemod/test/re_frame/migration/hicasso/sketch_test.clj
@@ -27,7 +27,7 @@
 
   1. the sketch READS — one form, no reader error;
   2. it is `(h/defhost <name> <component> …)` with a name `def` will take;
-  3. every contract it names is in [[dest/callback-contracts]], which
+  3. every contract it names is in [[rf.migration.hicasso.dest/callback-contracts]], which
      `shared-rule-test` holds equal to the door's own roster;
   4. and — the assertion that is not vacuous — FILLING the scaffold
      yields a `:callbacks` map of exactly this site's positions, each
@@ -38,9 +38,9 @@
             [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
-            [re-frame.migration.hicasso.codemod :as cm]
-            [re-frame.migration.hicasso.dest :as dest]
-            [re-frame.migration.hicasso.report :as report]))
+            [re-frame.migration.hicasso.codemod :as rf.migration.hicasso.codemod]
+            [re-frame.migration.hicasso.dest :as rf.migration.hicasso.dest]
+            [re-frame.migration.hicasso.report :as rf.migration.hicasso.report]))
 
 ;; ---------------------------------------------------------------------------
 ;; The corpus, through the REAL report builder
@@ -56,12 +56,12 @@
 
 (defn- corpus-report
   "The artefact the CLI writes, over the whole corpus at once — so this
-  suite exercises `report/build` rather than a private helper, and sees
+  suite exercises `rf.migration.hicasso.report/build` rather than a private helper, and sees
   the sketches exactly as a migrator does."
   []
-  (let [results (mapv #(cm/scan-string (slurp %) (str "src/app/" (.getName ^java.io.File %)))
+  (let [results (mapv #(rf.migration.hicasso.codemod/scan-string (slurp %) (str "src/app/" (.getName ^java.io.File %)))
                       (corpus-inputs))]
-    (report/build {:entries          (vec (mapcat :entries results))
+    (rf.migration.hicasso.report/build {:entries          (vec (mapcat :entries results))
                    :suggestions      (vec (mapcat :suggestions results))
                    :files-scanned    (count results)
                    :files-changed    0
@@ -70,7 +70,7 @@
 
 (defn- components [] (get-in (corpus-report) [:suggestions :components]))
 
-(def ^:private contracts (set dest/callback-contracts))
+(def ^:private contracts (set rf.migration.hicasso.dest/callback-contracts))
 
 ;; ---------------------------------------------------------------------------
 ;; The pin is only worth something if it has something to read
@@ -122,12 +122,12 @@
             (is (contains? contracts contract)
                 (str "the sketch declares " (pr-str slot) " as " (pr-str contract)
                      ", which the door refuses; the contracts are "
-                     (str/join ", " (map pr-str dest/callback-contracts))))))
+                     (str/join ", " (map pr-str rf.migration.hicasso.dest/callback-contracts))))))
 
         (testing "declares no structural slot — `key` and `ref` are
                   refused at mint in every spelling"
           (doseq [slot (keys (:callbacks opts))]
-            (is (not (contains? #{"key" "ref"} (dest/canonical-slot slot)))
+            (is (not (contains? #{"key" "ref"} (rf.migration.hicasso.dest/canonical-slot slot)))
                 (str "the sketch declares the structural slot " (pr-str slot)))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -148,7 +148,7 @@
 
 (deftest filling-the-scaffold-mints
   (doseq [{:keys [head defhost event-slots fn-slots]} (components)
-          contract dest/callback-contracts]
+          contract rf.migration.hicasso.dest/callback-contracts]
     (testing (str "the sketch for " head " filled with " contract)
       (let [slots (mapv edn/read-string (distinct (concat event-slots fn-slots)))
             opts  (nth (read-one (fill defhost contract)) 3)]

--- a/scripts/require-alias-baseline.edn
+++ b/scripts/require-alias-baseline.edn
@@ -20,9 +20,9 @@
  {
   ".clj-kondo"                            0
   "bench"                                 701
-  "docs"                                  16
+  "docs"                                  0
   "examples"                              65
-  "implementation/adapters"               339
+  "implementation/adapters"               337
   "implementation/core"                   0
   "implementation/derivation-conformance" 0
   "implementation/epoch"                  196
@@ -41,8 +41,8 @@
   "implementation/ssr"                    399
   "implementation/ssr-ring"               129
   "implementation/test-quiet"             5
-  "migration"                             27
-  "skills"                                15
-  "testbeds"                              25
+  "migration"                             0
+  "skills"                                0
+  "testbeds"                              0
   "tools"                                 2294
  }}

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -67,9 +67,9 @@
             ;; (production-DCE split). re-frame2-pair is dev-tier — loading the
             ;; tooling sibling here is bundle-isolation-safe (the
             ;; preload is dev-only).
-            [re-frame.subs.tooling :as subs-tooling]
-            [re-frame.schemas :as schemas]
-            [re-frame.machines :as machines]
+            [re-frame.subs.tooling :as rf.subs.tooling]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.machines :as rf.machines]
             ;; register-listener! / trace-buffer (and the rest of
             ;; the listener + ring-buffer surface) live in
             ;; re-frame.trace.tooling, not re-frame.trace. CLJS deliberately
@@ -77,7 +77,7 @@
             ;; bundles DCE the tooling sibling wholesale; this preload is
             ;; dev-only, so requiring the tooling ns directly here is
             ;; bundle-isolation-safe.
-            [re-frame.trace.tooling :as trace-tooling]
+            [re-frame.trace.tooling :as rf.trace.tooling]
             ;; `flush-render!` (the SYNCHRONOUS render-commit contract fn,
             ;; Spec 006 §`flush-render!`) lives in
             ;; re-frame.substrate.adapter, not re-frame.core. It resolves
@@ -90,14 +90,14 @@
             ;; `:rf.view/unmounted` traces land in (and re-fan back to the
             ;; causing) epoch before we re-read it. Dev-tier preload, so the
             ;; direct require is bundle-isolation-safe.
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.interop :as interop]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.interop :as rf.interop]
             ;; `parse-source-coord` (the canonical inverse of
             ;; `format-source-coord`) is the source-coord contract owner's
             ;; parser for the `data-rf2-source-coord` DOM attribute. The pair
             ;; preload routes through this one canonical impl in core.
             ;; Dev-tier preload, so the direct require is bundle-isolation-safe.
-            [re-frame.source-coords :as source-coords]
+            [re-frame.source-coords :as rf.source-coords]
             ;; `re-frame.fx/*effect-sink*` (rf2-j538f7.39) is the framework's
             ;; dry-run EFFECT SINK — an internal, in-process dev-tool seam.
             ;; `dispatch-dry-run` binds it around a `dispatch-sync` so the
@@ -105,7 +105,7 @@
             ;; effect executor (`do-fx`), structurally unable to run any fx
             ;; body — no registrar enumeration. Dev-tier preload, so the direct
             ;; require into a non-facade core ns is bundle-isolation-safe.
-            [re-frame.fx :as fx]
+            [re-frame.fx :as rf.fx]
             [clojure.data :as data]
             [clojure.string :as str]
             ;; cljs.reader is load-bearing for the eval-cljs typed result
@@ -596,7 +596,7 @@
    Map of `path → schema`. (re-frame.schemas/app-schemas frame-id)"
   ([] (schemas (current-frame)))
   ([frame-id]
-   (schemas/app-schemas frame-id)))
+   (rf.schemas/app-schemas frame-id)))
 
 ;; ---------------------------------------------------------------------------
 ;; Registrar introspection
@@ -974,7 +974,7 @@
    subscription in the operating frame. CLJS-only; nil on JVM."
   ([] (sub-cache (current-frame)))
   ([frame-id]
-   (subs-tooling/sub-cache-snapshot frame-id)))
+   (rf.subs.tooling/sub-cache-snapshot frame-id)))
 
 (defn sub-cache-info
   "List the LIVE reactive subscriptions materialised in a frame's
@@ -982,7 +982,7 @@
    currently active?\".
 
    Reads the SAME source `snapshot`'s `:sub-cache` slice reads
-   (`subs-tooling/sub-cache-snapshot`, via the `sub-cache` fn above), so
+   (`rf.subs.tooling/sub-cache-snapshot`, via the `sub-cache` fn above), so
    the two never disagree. This is the live reactive cache: an entry
    appears the moment a view subscribes and DISAPPEARS when the last
    consumer disposes the reaction — so a disposed sub no longer shows
@@ -1025,7 +1025,7 @@
          frame-id (current-frame frame)]
      (if (nil? frame-id)
        (ambiguous-frame-error :sub-cache-info)
-       (let [cache (or (subs-tooling/sub-cache-snapshot frame-id) {})
+       (let [cache (or (rf.subs.tooling/sub-cache-snapshot frame-id) {})
              qvs   (sort-by pr-str (keys cache))]
          {:ok?   true
           :frame frame-id
@@ -1139,13 +1139,13 @@
 (defn machines-list
   "(rf.machines/machines) — all registered machine ids."
   []
-  (vec (machines/machines)))
+  (vec (rf.machines/machines)))
 
 (defn machine-describe
   "(rf.machines/machine-meta id) — registered spec map for one machine, or
    `{:ok? false :reason :not-a-machine}`."
   [machine-id]
-  (or (machines/machine-meta machine-id)
+  (or (rf.machines/machine-meta machine-id)
       {:ok? false :reason :not-a-machine :id machine-id}))
 
 (defn machine-state
@@ -1419,7 +1419,7 @@
    re-registration replaces the same listener id, and
    `last-trace-event-id` keeps working through it."
   []
-  (trace-tooling/register-listener! :re-frame2-pair on-trace-event))
+  (rf.trace.tooling/register-listener! :re-frame2-pair on-trace-event))
 
 (defn last-trace-event-id
   "Last trace event id observed by the skill's listener. Useful as a
@@ -1479,7 +1479,7 @@
         ;; so the tree walk reads them off the bundle slot rather
         ;; than re-deriving from raw trace events.
         bundles    (into []
-                         (mapcat #(trace-tooling/trace-buffer %))
+                         (mapcat #(rf.trace.tooling/trace-buffer %))
                          (rf/frame-ids))
         by-parent  (group-by :parent-dispatch-id bundles)
         node       (fn node [did]
@@ -1561,7 +1561,7 @@
 ;;                          framework's redact-fn before we read it)
 ;;
 ;; Production builds elide the entire epoch-record path under
-;; `interop/debug-enabled? false`; cascade-summary inherits that —
+;; `rf.interop/debug-enabled? false`; cascade-summary inherits that —
 ;; the projection is dev-only by construction. The :elision /
 ;; :sensitive-paths machinery upstream of us already ran by the time
 ;; we read :db-before / :db-after, so we never see raw sensitive values.
@@ -1830,7 +1830,7 @@
           :frame frame-id
           :hint (str "epoch-history is empty after dispatch. Either depth "
                      "is 0 (disabled), the frame is destroyed, or "
-                     "interop/debug-enabled? is false (production build).")}
+                     "rf.interop/debug-enabled? is false (production build).")}
 
          :else
          {:ok? false
@@ -2090,7 +2090,7 @@
          ;; Bind the sink for the whole synchronous dispatch-sync extent: the
          ;; drain, its fx walk, any machine exit-cascade / resource-release
          ;; walk all funnel through `do-fx`, which records-and-skips.
-         (binding [fx/*effect-sink* sink]
+         (binding [rf.fx/*effect-sink* sink]
            (rf/dispatch-sync event-v dispatch-opts))
          (let [after-id (some-> (rf/epoch-history frame-id) peek :epoch-id)]
            (cond
@@ -2101,7 +2101,7 @@
               :frame   frame-id
               :hint    (str "epoch-history empty after dry-run dispatch. "
                             "Either depth is 0 (disabled), the frame is "
-                            "destroyed, or interop/debug-enabled? is false "
+                            "destroyed, or rf.interop/debug-enabled? is false "
                             "(production build).")}
 
              (= before-id after-id)
@@ -2280,7 +2280,7 @@
           :epoch-id epoch-id
           :frame    frame-id
           :hint     (str "rf/replay-epoch! returned false — the epoch surface is elided "
-                         "(interop/debug-enabled? false) or day8/re-frame2-epoch is not loaded.")}
+                         "(rf.interop/debug-enabled? false) or day8/re-frame2-epoch is not loaded.")}
 
          (and (map? result) (:ok? result))
          (let [attached (attach-cascade (assoc result :replayed? true)
@@ -2366,7 +2366,7 @@
    the `?`-placeholder degradation, and the Tool-Pair opacity caveat
    (downstream callers MUST NOT depend on the parsed shape's stability
    across re-frame2 versions)."
-  source-coords/parse-source-coord)
+  rf.source-coords/parse-source-coord)
 
 (def ^:private parse-view-id
   "Parse re-frame2's `data-rf-view` attribute into the registry id keyword
@@ -2379,7 +2379,7 @@
    for the value format (Spec 006 §View tagging contract §Attribute value
    format) and the Tool-Pair opacity caveat (downstream callers MUST NOT depend
    on the parsed shape's stability across re-frame2 versions)."
-  source-coords/parse-view-id)
+  rf.source-coords/parse-view-id)
 
 (defn- parse-rc-src
   "Parse re-com's `data-rc-src` attribute into {:file :line :column}.
@@ -2871,7 +2871,7 @@
           ;; that the view consumes. Sorted by pr-str for stable output.
           subs-read  (when frame-id
                        (try
-                         (->> (or (subs-tooling/sub-cache-snapshot frame-id) {})
+                         (->> (or (rf.subs.tooling/sub-cache-snapshot frame-id) {})
                               keys
                               (sort-by pr-str)
                               vec)
@@ -3297,7 +3297,7 @@
         schedule (fn [f]
                    (if raf?
                      (js/requestAnimationFrame f)
-                     (interop/next-tick f)))]
+                     (rf.interop/next-tick f)))]
     (letfn [(step [_]
               (when (recording-sampler-tick! rid)
                 (let [h (schedule step)]
@@ -3564,7 +3564,7 @@
 ;;     immediately, misses them.
 ;;
 ;;   - The `:await-render` path flushes via
-;;     `interop/after-render` — the rAF-scheduled, post-commit /
+;;     `rf.interop/after-render` — the rAF-scheduled, post-commit /
 ;;     pre-paint hook. It is ASYNC (returns a Promise the server awaits
 ;;     through the mailbox), and on a backgrounded / unfocused tab the
 ;;     underlying React lane commit is rAF-throttled, so it can stall.
@@ -3574,7 +3574,7 @@
 ;;     substrates, `reagent.core/flush` for the ratom family. NOT
 ;;     rAF-scheduled, so it commits even headless / backgrounded and is
 ;;     fully SYNCHRONOUS — no Promise, no mailbox. ZERO substrate
-;;     hardcoding: `adapter/flush-render!` resolves the INSTALLED adapter
+;;     hardcoding: `rf.substrate.adapter/flush-render!` resolves the INSTALLED adapter
 ;;     and routes to its native impl (re-frame2 knows its own registered
 ;;     adapter).
 ;;
@@ -3610,7 +3610,7 @@
    Steps:
      1. `dispatch-sync` — run the cascade; the epoch records its db-diff,
         effects, sub-runs (`dispatch-and-collect` shape).
-     2. `(adapter/flush-render!)` — SYNCHRONOUSLY commit the installed
+     2. `(rf.substrate.adapter/flush-render!)` — SYNCHRONOUSLY commit the installed
         substrate's pending renders + unmounts (React `flushSync` /
         `reagent.core/flush`, resolved from the live adapter — no
         substrate name appears here). Their `:rf.view/render` /
@@ -3650,7 +3650,7 @@
        (let [;; Flush the INSTALLED adapter's pending renders synchronously.
              ;; Zero-arity form flushes already-pending work — the cascade
              ;; in step 1 invalidated the views; this commits them now.
-             _        (adapter/flush-render!)
+             _        (rf.substrate.adapter/flush-render!)
              ;; Re-read AFTER the flush: the post-settle render/unmount
              ;; back-fill (re-fanned to listeners) has updated the record.
              epoch    (epoch-by-id (:epoch-id result) (:frame result))]
@@ -3700,7 +3700,7 @@
   [frame-id slice]
   (case slice
     :app-db     (rf/app-db-value frame-id)
-    :sub-cache  (subs-tooling/sub-cache-snapshot frame-id)
+    :sub-cache  (rf.subs.tooling/sub-cache-snapshot frame-id)
     ;; The global machine-id list is registrar-level (not per-frame).
     ;; Per Spec 005 each frame holds its own machine
     ;; snapshots at [:rf.runtime/machines :snapshots machine-id] in the
@@ -3709,7 +3709,7 @@
     ;; `rf/app-db-value` — rf2-t3lftq API-shrink #3 retired the dedicated
     ;; `rf/runtime-db-value` reader), so the per-frame
     ;; slice returns {:ids [...] :state {machine-id snapshot}}.
-    :machines   (let [ids (vec (machines/machines))
+    :machines   (let [ids (vec (rf.machines/machines))
                       state (or (get-in (:rf.db/runtime (rf/frame-state-value frame-id))
                                         [:rf.runtime/machines :snapshots])
                                 {})]
@@ -3720,7 +3720,7 @@
     ;; read shape (Tool-Pair
     ;; §Reading the per-frame trace ring + Tool-Pair §`watch-epochs` /
     ;; `trace-window` consumer shape).
-    :traces     (vec (trace-tooling/trace-buffer frame-id))
+    :traces     (vec (rf.trace.tooling/trace-buffer frame-id))
     nil))
 
 (defn- snapshot-frame
@@ -3791,7 +3791,7 @@
   "Probe `re-frame.interop/debug-enabled?`. False in production builds;
    trace and epoch surfaces elide entirely when this is false."
   []
-  (boolean interop/debug-enabled?))
+  (boolean rf.interop/debug-enabled?))
 
 (defn health
   "One-call summary of the runtime's view of the world. Used by
@@ -3998,4 +3998,4 @@
                                   (map (fn [fid] [fid (pure/top-keys (rf/app-db-value fid))]))
                                   app-fids)
        :registry            registry
-       :machines            (machines/machines)})))
+       :machines            (rf.machines/machines)})))

--- a/skills/re-frame2-pair/tests/fixture/src/counter/core.cljs
+++ b/skills/re-frame2-pair/tests/fixture/src/counter/core.cljs
@@ -15,7 +15,7 @@
  on it (Tool-Pair §Source-mapping, Spec 006 §Source-coord annotation)."
  (:require [re-frame.core :as rf]
  [re-frame.views]
- [re-frame.adapter.reagent :as reagent-adapter])
+ [re-frame.adapter.reagent :as rf.adapter.reagent])
  (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; -- Events / subs ------------------------------------------------------------
@@ -65,7 +65,7 @@
 ;; The adapter owns the React root. `client-root` allocates an inert handle —
 ;; no DOM work at namespace load — and the first `render!` through it creates
 ;; the root every later render reuses.
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 (defn ^:export run []
  ;; Source-coord DOM annotation is automatic in debug builds (mandatory per
@@ -79,10 +79,10 @@
  ;; `frame-provider`'s {:frame …} SCOPE-only shape (the frame already exists
  ;; from make-frame) so the reg-view-injected dispatch/subscribe resolve to it.
  ;; re-frame2-pair attaches over nREPL and operates this frame.
- (rf/init! reagent-adapter/adapter)
+ (rf/init! rf.adapter.reagent/adapter)
  (rf/make-frame {:id :rf/default})
  (rf/with-frame :rf/default
   (rf/dispatch-sync [:counter/initialise]))
- (reagent-adapter/render! app-root
+ (rf.adapter.reagent/render! app-root
   [rf/frame-provider {:frame :rf/default} [counter-app]]
   (js/document.getElementById "app")))

--- a/skills/re-frame2-pair/tests/runtime/dry_run_sink_pin_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/dry_run_sink_pin_test.clj
@@ -61,9 +61,12 @@
     (is (some? form) "dispatch-dry-run must be defined")
     (is (mentions-sym? form 'binding)
         "dispatch-dry-run must establish a dynamic binding around dispatch-sync")
-    (is (mentions-sym? form 'fx/*effect-sink*)
-        (str "dispatch-dry-run must bind re-frame.fx/*effect-sink* (the "
-             "universal effect-executor sink) — the structural no-effect guarantee"))
+    (is (mentions-sym? form 'rf.fx/*effect-sink*)
+        (str "dispatch-dry-run must bind re-frame.fx/*effect-sink* — spelled "
+             "`rf.fx/*effect-sink*` at the use site, since the preload requires "
+             "`[re-frame.fx :as rf.fx]` under the canonical require-alias "
+             "dialect (rf2-7sx1) — the universal effect-executor sink, and the "
+             "structural no-effect guarantee"))
     (is (mentions-sym? form 'rf/dispatch-sync)
         "dispatch-dry-run must run the cascade via dispatch-sync inside the sink")))
 

--- a/skills/re-frame2/evals/fixtures/existing-project/test/shop/cart_test.cljc
+++ b/skills/re-frame2/evals/fixtures/existing-project/test/shop/cart_test.cljc
@@ -1,18 +1,18 @@
 (ns shop.cart-test
   (:require [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as ts]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
             [shop.cart]
             #?(:clj  [clojure.test :refer [deftest is use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is use-fixtures]])))
 
 (use-fixtures :each
-  (ts/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (deftest add-item-appends-to-the-cart
   (rf/dispatch-sync [:cart/add-item {:sku "A1" :price 10}])
   (rf/dispatch-sync [:cart/add-item {:sku "B2" :price 5}])
-  (ts/assert-path-equals [:cart/items]
+  (rf.test-support/assert-path-equals [:cart/items]
                          [{:sku "A1" :price 10} {:sku "B2" :price 5}]))
 
 (deftest items-sub-reads-the-cart

--- a/skills/reagent-migration/tests/fixture/test/reagent_migration/mig23_cold_start_test.cljs
+++ b/skills/reagent-migration/tests/fixture/test/reagent_migration/mig23_cold_start_test.cljs
@@ -15,11 +15,11 @@
   `:rf.error/adapter-disposed` instead, a different lifecycle state):
 
     1. NEGATIVE (never-initialized): the recipe's two entry points —
-       `server/render` (the server half) and `rf/make-frame` (the client
+       `rf.hicasso.server/render` (the server half) and `rf/make-frame` (the client
        half's first call) — each raise `:rf.error/no-adapter-installed`
        before any render/hydration work; no `:document` is produced.
-    2. POSITIVE server control: ONE `(rf/init! ssr/adapter)` at process
-       boot, then TWO `server/render` requests both answer a `:document`
+    2. POSITIVE server control: ONE `(rf/init! rf.ssr/adapter)` at process
+       boot, then TWO `rf.hicasso.server/render` requests both answer a `:document`
        and a payload, with no second adapter install attempted
        (`rf/current-adapter-spec` identity is unchanged across both) —
        initialization is boot work, not request work.
@@ -37,12 +37,12 @@
       npm install && npm run test:cold-start"
   (:require [cljs.test :refer [deftest testing is]]
             [re-frame.core :as rf]
-            [re-frame.ssr :as ssr]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.server :as server]))
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.server :as rf.hicasso.server]))
 
-(h/defview page
+(rf.hicasso/defview page
   "Minimal deterministic root — no clock, no randomness, no browser
   global, so the server render is byte-stable."
   [_props]
@@ -70,21 +70,21 @@
     (is (nil? (rf/current-adapter))
         "cold start: no adapter is installed and none is defaulted")
     (is (= :rf.error/no-adapter-installed
-           (rf-error-id #(server/render render-opts)))
-        "the server half without rf/init!: server/render reaches rf/make-frame and throws; no :document is returned")
+           (rf-error-id #(rf.hicasso.server/render render-opts)))
+        "the server half without rf/init!: rf.hicasso.server/render reaches rf/make-frame and throws; no :document is returned")
     (is (= :rf.error/no-adapter-installed
            (rf-error-id #(rf/make-frame {:id :app/main :platform :client})))
-        "the client half without rf/init!: its first rf/make-frame throws the same error, so ssr/hydrate!/h/hydrate! never run")
+        "the client half without rf/init!: its first rf/make-frame throws the same error, so rf.ssr/hydrate! / rf.hicasso/hydrate! never run")
     (is (nil? (rf/current-adapter))
         "the failed calls did not install anything either — render never auto-installs"))
 
-  (testing "POSITIVE server control — one (rf/init! ssr/adapter) at process boot, then requests just work"
-    (rf/init! ssr/adapter)
+  (testing "POSITIVE server control — one (rf/init! rf.ssr/adapter) at process boot, then requests just work"
+    (rf/init! rf.ssr/adapter)
     (is (= :rf.adapter/ssr (rf/current-adapter))
         "the corrected server half installs the headless server-side adapter once")
     (let [spec-before (rf/current-adapter-spec)
-          r1          (server/render render-opts)
-          r2          (server/render render-opts)]
+          r1          (rf.hicasso.server/render render-opts)
+          r2          (rf.hicasso.server/render render-opts)]
       (is (string? (:document r1))
           "first request: the existing render call now returns a document")
       (is (map? (:payload r1))
@@ -96,13 +96,13 @@
 
   (testing "POSITIVE client-shaped control — the migrating app's existing Reagent adapter advances the same frame entry point"
     (rf/destroy-adapter!)
-    (rf/init! reagent-adapter/adapter)
+    (rf/init! rf.adapter.reagent/adapter)
     (is (= :rf.adapter/reagent (rf/current-adapter))
         "the client keeps its existing Reagent adapter — no silent adapter switch")
     (rf/make-frame {:id :app/main :platform :client})
     (is (contains? (rf/frame-ids) :app/main)
         "the exact rf/make-frame call the cold client died at now advances")
     (let [spec (rf/current-adapter-spec)]
-      (rf/init! reagent-adapter/adapter)
+      (rf/init! rf.adapter.reagent/adapter)
       (is (identical? spec (rf/current-adapter-spec))
           "a reload-path rf/init! re-run is a no-op — the hydration/HMR path never reinstalls"))))

--- a/testbeds/deep_machine/core.cljs
+++ b/testbeds/deep_machine/core.cljs
@@ -36,7 +36,7 @@
             [re-frame.core :as rf]
             [re-frame.machines]
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             ;; rf2-e8330v (xxo3zz F3) — this feature-gate testbed drives the
             ;; Xray Machine Inspector chart-render path via the test-only
             ;; epoch-history / focus-epoch-id seeding events. Production
@@ -389,7 +389,7 @@
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn ^:export run []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   ;; rf2-e8330v — install the Xray test-only override seam so the
   ;; feature-gate scenario's synthetic-epoch injection (via
   ;; `:rf.xray/set-epoch-history-for-test` + `:rf.xray/set-focus-epoch-

--- a/testbeds/deliberate_throw/core.cljs
+++ b/testbeds/deliberate_throw/core.cljs
@@ -18,9 +18,9 @@
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.flows]                            ;; load-time hook for reg-flow
-            [re-frame.machines :as machines]                          ;; load-time hook for make-machine-handler
+            [re-frame.machines :as rf.machines]                          ;; load-time hook for make-machine-handler
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent :as rf.adapter.reagent])
   (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 ;; ----------------------------------------------------------------------------
@@ -131,7 +131,7 @@
 ;; fire on the failed cascade.
 
 (rf/reg-event ::throw-in-machine
-  (machines/make-machine-handler
+  (rf.machines/make-machine-handler
     {:initial :idle
      :actions {:throw
                (fn [_]
@@ -183,7 +183,7 @@
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn ^:export run []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
   ;; absence — `:rf/default` is this testbed's app frame, registered
   ;; explicitly here (init! installs only the adapter, no frame).

--- a/testbeds/drain_depth_trigger/core.cljs
+++ b/testbeds/drain_depth_trigger/core.cljs
@@ -46,7 +46,7 @@
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent :as rf.adapter.reagent])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ----------------------------------------------------------------------------
@@ -199,7 +199,7 @@
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn ^:export run []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   ;; Register the default frame with the low ceiling BEFORE init —
   ;; the Start click only needs the runtime's drain to fire the halt;
   ;; per [spec/002 §Surgical update] re-registering only changes the

--- a/testbeds/http_toggle/core.cljs
+++ b/testbeds/http_toggle/core.cljs
@@ -27,8 +27,8 @@
   (:require [cljs.reader :as edn]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            [re-frame.registrar :as registrar]
-            [re-frame.trace :as trace]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.trace :as rf.trace]
             ;; Managed-HTTP ships in day8/re-frame2-http. Requiring at
             ;; app boot triggers its load-time fx registrations
             ;; (`:rf.http/managed` / `:rf.http/managed-abort`); without it,
@@ -42,7 +42,7 @@
             [re-frame.http.test-support]
             [re-frame.http :as rf.http]
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent :as rf.adapter.reagent])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ----------------------------------------------------------------------------
@@ -85,12 +85,12 @@
 ;;
 ;; The framework-shipped `:rf.http/managed-canned-failure` synthesises a
 ;; failure reply via the same late-bind dispatch path the live transport
-;; uses, but it does NOT call `trace/emit-error!`. The live failure path
+;; uses, but it does NOT call `rf.trace/emit-error!`. The live failure path
 ;; (`re-frame.http.transport/finalise-failure!`) emits a single
 ;; `:rf.http/<kind>` error-trace event before dispatching the reply; the
 ;; canned stub skips it. The testbed README documents an ordered
 ;; `:rf.http/<kind>` stream per click — so this per-testbed wrapper fx
-;; replays the live path's `trace/emit-error!` before delegating to the
+;; replays the live path's `rf.trace/emit-error!` before delegating to the
 ;; canned stub. Consumers (Xray, Story, cross-cutting specs) can now
 ;; assert on the `:operation :rf.http/<kind>` trace directly rather than
 ;; falling back to the `:rf.fx/handled` proxy.
@@ -110,13 +110,13 @@
       ;; :kind, tags carry the category-specific slots plus :request-id,
       ;; :url, and :recovery (canned failures are :no-recovery — they
       ;; classify identically to a terminal live failure).
-      (trace/emit-error! kind
+      (rf.trace/emit-error! kind
                          (assoc tags
                                 :kind       kind
                                 :request-id (:request-id args-map)
                                 :url        url
                                 :recovery   :no-recovery))
-      ((registrar/handler :fx :rf.http/managed-canned-failure)
+      ((rf.registrar/handler :fx :rf.http/managed-canned-failure)
        frame-ctx args-map))))
 
 (rf/reg-event ::go
@@ -239,7 +239,7 @@
                §Testing for the canonical stub seam."
    :platforms #{:client}}
   (fn fx-deferred-abortable [frame-ctx args-map]
-    (let [stub (registrar/handler :fx :http-toggle/canned-failure-with-trace)]
+    (let [stub (rf.registrar/handler :fx :http-toggle/canned-failure-with-trace)]
       ;; Demo-only artificial latency. The :request-id in args-map
       ;; would normally bind the abort handle in the in-flight
       ;; registry; for the testbed stub, the Cancel button fires the
@@ -322,7 +322,7 @@
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn ^:export run []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
   ;; absence — `:rf/default` is this testbed's app frame, registered
   ;; explicitly here (init! installs only the adapter). The boot dispatch

--- a/testbeds/large_dispatcher/core.cljs
+++ b/testbeds/large_dispatcher/core.cljs
@@ -43,9 +43,9 @@
             ;; Public reader for the per-frame elision registry (EP-0025):
             ;; `re-frame.elision/declarations` returns the `:large` `:app-db`
             ;; declarations the commit-plane effects recorded.
-            [re-frame.elision :as elision]
+            [re-frame.elision :as rf.elision]
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent :as rf.adapter.reagent])
   (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 ;; ----------------------------------------------------------------------------
@@ -194,7 +194,7 @@
 ;; through app-db. (A debug-introspection convenience; the load-bearing assert
 ;; is the wire-marker on the trace.)
 (rf/reg-sub :elision-decls
-  (fn [db _] (elision/declarations :rf/default)))
+  (fn [db _] (rf.elision/declarations :rf/default)))
 
 (reg-view buttons []
   (let [auto-len       @(subscribe [:auto-len])
@@ -265,7 +265,7 @@
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn ^:export run []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
   ;; absence — register `:rf/default` as the app frame, scope the boot
   ;; dispatch, and wrap the render in a frame-provider.

--- a/testbeds/long_flow_w_failure/core.cljs
+++ b/testbeds/long_flow_w_failure/core.cljs
@@ -64,7 +64,7 @@
             [re-frame.core :as rf]
             [re-frame.flows]
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent :as rf.adapter.reagent])
   (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 ;; ----------------------------------------------------------------------------
@@ -385,7 +385,7 @@
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn ^:export run []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
   ;; absence — `:rf/default` is this testbed's app frame, registered
   ;; explicitly here (init! installs only the adapter). The boot dispatch

--- a/testbeds/multi_frame/core.cljs
+++ b/testbeds/multi_frame/core.cljs
@@ -34,7 +34,7 @@
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent :as rf.adapter.reagent])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ----------------------------------------------------------------------------
@@ -203,7 +203,7 @@
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn ^:export run []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   ;; Register the three frames before any dispatch. `:initial-events`
   ;; seeds each frame's app-db via the corresponding init handler;
   ;; the framework dispatches each frame's setup events synchronously

--- a/testbeds/non_trivial_app_db/core.cljs
+++ b/testbeds/non_trivial_app_db/core.cljs
@@ -32,7 +32,7 @@
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent :as rf.adapter.reagent])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ----------------------------------------------------------------------------
@@ -280,7 +280,7 @@
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn ^:export run []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
   ;; absence — `:rf/default` is this testbed's app frame, registered
   ;; explicitly here (init! installs only the adapter). The boot dispatch

--- a/testbeds/schema_violation/core.cljs
+++ b/testbeds/schema_violation/core.cljs
@@ -33,7 +33,7 @@
             ;; would expose counters but no recovery traces.
             [re-frame.schemas.malli]
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent :as rf.adapter.reagent])
   (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 ;; ----------------------------------------------------------------------------
@@ -224,6 +224,6 @@
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn ^:export run []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (rf/dispatch-sync [::initialise])
   (rdc/render react-root [root]))

--- a/testbeds/ssr_basic/core.cljs
+++ b/testbeds/ssr_basic/core.cljs
@@ -51,13 +51,13 @@
             ;; SSR hydration metadata is durable runtime-db state, so the
             ;; :hydrated? discriminator is a runtime-db sub (reg-runtime-sub
             ;; lives on the re-frame.subs surface).
-            [re-frame.subs :as subs]
+            [re-frame.subs :as rf.subs]
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.ssr :as ssr]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.ssr :as rf.ssr]
             ;; rf2-qwm0a — listener surface lives in
             ;; `re-frame.trace.tooling` (production-DCE split).
-            [re-frame.trace.tooling :as trace-tooling]
+            [re-frame.trace.tooling :as rf.trace.tooling]
             [cljs.reader])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
@@ -91,7 +91,7 @@
   ;; HOT PATH — wire the trace bus to a window-side mirror so a
   ;; Playwright assertion can inspect the hydration trace stream
   ;; without poking at internal cljs vars.
-  (trace-tooling/register-listener! ::ssr-basic-listener
+  (rf.trace.tooling/register-listener! ::ssr-basic-listener
     (fn [ev]
       (let [op (:operation ev)]
         (when (and op
@@ -120,7 +120,7 @@
 ;; handler stashes it at [:rf.runtime/ssr :hydration] in the runtime-db
 ;; partition (NOT app-db). So :hydrated? is a runtime-db sub reading the
 ;; canonical source.
-(subs/reg-runtime-sub :hydrated?
+(rf.subs/reg-runtime-sub :hydrated?
   (fn [rt _] (boolean (get-in rt [:rf.runtime/ssr :hydration]))))
 
 ;; ----------------------------------------------------------------------------
@@ -205,7 +205,7 @@
     (update :rf/app-db assoc :server-response (:rf/response payload))))
 
 (defn ^:export run []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (install-trace-listener!)
   ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
   ;; absence — register `:rf/default` as the client app frame and scope the
@@ -233,4 +233,4 @@
     ;; subs evaluate against the post-hydrate app-db.
     (when payload
       (let [tree ((rf/view :ssr-basic.core/root))]
-        (ssr/verify-hydration! :rf/default tree)))))
+        (rf.ssr/verify-hydration! :rf/default tree)))))

--- a/testbeds/ssr_hydration_mismatch/core.cljs
+++ b/testbeds/ssr_hydration_mismatch/core.cljs
@@ -36,13 +36,13 @@
             ;; SSR hydration metadata is durable runtime-db state, so the
             ;; :hydrated? discriminator is a runtime-db sub (reg-runtime-sub
             ;; lives on the re-frame.subs surface).
-            [re-frame.subs :as subs]
+            [re-frame.subs :as rf.subs]
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.ssr :as ssr]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.ssr :as rf.ssr]
             ;; rf2-qwm0a — listener surface lives in
             ;; `re-frame.trace.tooling` (production-DCE split).
-            [re-frame.trace.tooling :as trace-tooling]
+            [re-frame.trace.tooling :as rf.trace.tooling]
             [cljs.reader])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
@@ -78,7 +78,7 @@
       (:recovery ev)       (assoc :recovery (str (:recovery ev))))))
 
 (defn install-trace-listener! []
-  (trace-tooling/register-listener! ::ssr-hydration-mismatch-listener
+  (rf.trace.tooling/register-listener! ::ssr-hydration-mismatch-listener
     (fn [ev]
       (let [op (:operation ev)]
         (when (and op
@@ -109,7 +109,7 @@
 ;; handler stashes it at [:rf.runtime/ssr :hydration] in the runtime-db
 ;; partition (NOT app-db). So :hydrated? is a runtime-db sub reading the
 ;; canonical source.
-(subs/reg-runtime-sub :hydrated?
+(rf.subs/reg-runtime-sub :hydrated?
   (fn [rt _] (boolean (get-in rt [:rf.runtime/ssr :hydration]))))
 
 ;; ----------------------------------------------------------------------------
@@ -178,7 +178,7 @@
     (cljs.reader/read-string (.-textContent el))))
 
 (defn ^:export run []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (install-trace-listener!)
   ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
   ;; absence — register `:rf/default` as the client app frame and scope the
@@ -204,4 +204,4 @@
     ;; client frame scope.
     (rf/with-frame :rf/default
       (let [tree ((rf/view :ssr-hydration-mismatch.core/root))]
-        (ssr/verify-hydration! :rf/default tree)))))
+        (rf.ssr/verify-hydration! :rf/default tree)))))

--- a/testbeds/ssr_multi_frame/core.cljs
+++ b/testbeds/ssr_multi_frame/core.cljs
@@ -43,10 +43,10 @@
             ;; SSR hydration metadata is durable runtime-db state, so the
             ;; per-frame :hydration readout is a runtime-db sub
             ;; (reg-runtime-sub lives on the re-frame.subs surface).
-            [re-frame.subs :as subs]
+            [re-frame.subs :as rf.subs]
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.ssr :as ssr]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.ssr :as rf.ssr]
             [cljs.reader])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
@@ -85,7 +85,7 @@
 ;; runtime-db partition (NOT app-db). So :hydration is a runtime-db sub; the
 ;; frame-explicit `{:frame f}` reads in `hydration-summary` resolve it against
 ;; each named frame's runtime-db.
-(subs/reg-runtime-sub :hydration
+(rf.subs/reg-runtime-sub :hydration
   (fn [rt _] (get-in rt [:rf.runtime/ssr :hydration])))
 
 ;; ----------------------------------------------------------------------------
@@ -187,7 +187,7 @@
     (cljs.reader/read-string (.-textContent el))))
 
 (defn ^:export run []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
 
   ;; Register the three frames with their initialisers. Each has its
   ;; own :initial-events, but :rf/hydrate (dispatched below) will REPLACE

--- a/testbeds/tenant_switcher/core.cljs
+++ b/testbeds/tenant_switcher/core.cljs
@@ -55,7 +55,7 @@
             ;; and `:fx-overrides` is the designed per-frame stub seam.
             [re-frame.http.managed]
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent :as rf.adapter.reagent])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ----------------------------------------------------------------------------
@@ -302,7 +302,7 @@
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn ^:export run []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from absence.
   ;; `:rf/default` is this testbed's frame, registered explicitly; the
   ;; boot dispatch runs under it and the render is wrapped in a


### PR DESCRIPTION
Slice 2 of the rf2-7sx1 require-alias campaign. Five surfaces reach their new floors **in this commit**, because the ratchet is two-sided and fires from below as readily as from above.

| surface | before | after |
|---|---|---|
| `docs` | 16 | **0** |
| `migration` | 27 | **0** |
| `skills` | 15 | **0** |
| `testbeds` | 25 | **0** |
| `implementation/adapters` | 339 | **337** (rf2-b38y) |

Repo-wide non-canonical **5586 -> 5501** (-85). Files 2773 unchanged; edges 10773 -> 10771, the two removed requires.

## What changed

83 libspecs renamed to the canonical `rf.<tail>` spelling per `spec/Conventions.md` §Require-alias dialect, with **344 alias-position use sites** and **28 docstring/comment references** moved with them. rf2-b38y removes two dead `[re-frame.trace :as trace]` requires from the reagent adapter tests; both files already require `re-frame.core`, which requires `re-frame.trace` itself, so those took an alias and not a dependency.

The rewrite was driven by the checker's own `--verbose` census and its own reader-level `mask_source`, so strings and comments were never rewritten blind — every non-code hit was reviewed by hand.

## Findings worth reading

**No fenced doc sample needed editing, and no markdown was touched at all.** The checker's corpus is git-tracked `.clj`/`.cljs`/`.cljc` only, so every counted violation on these surfaces lives in real source. The prose/fenced-example sites listed in rf2-lwx8's description are outside the ratchet's reach and stay with that bead.

**One non-code hit was deliberately left alone.** `skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs:3935` reads `discover-app + snapshot top-keys + list-handlers + list-subscriptions + machines/routes` — that slash is English, the same idiom used in `skills/README.md`, `skills/re-frame2-xray/`, `docs/skills/re-frame2-xray.md` and `spec/Spec-Schemas.md`. Renaming it would have fabricated a `rf.machines/routes` var that does not exist.

**Three literal shapes, each controlled against a fixture sharing its shape:** `:alias/key` **0**, `::alias/kw` **0**, `"alias/..."` **6 real**. A line-oriented string census first read 10; four were false positives where an alias call sits *between* two adjacent string literals, and it simultaneously missed multi-line docstrings. The reader-level mask settled it.

**`sci.cljs`'s SCI-exposed API is provably unchanged** — every `sci/create-ns` / `sci/copy-ns` argument is a quoted fully-qualified symbol, not an alias.

## Gates, each with its captured exit code

| gate | exit | result |
|---|---|---|
| `check_require_alias_dialect.py --self-test` | 0 | 79 passed, unmoved |
| `check_require_alias_dialect.py --verbose` | 0 | clean, all surfaces at/under floor |
| `migration/reagent-to-hicasso/codemod` `-M:test` | 0 | 64 tests / 621 assertions |
| `migration/from-re-frame-v1/codemod` `-M:test` | 0 | 82 tests / 310 assertions |
| `migration/from-re-frame-v1/codemod` `-M:integration` | 0 | 6 tests / 10 assertions |
| `clj-kondo --lint testbeds --lint implementation/adapters/reagent` | 0 | errors 0, warnings **84 -> 82** |
| CLJS `node-test` compile | 0 | 1892 files, **0 warnings** |
| CLJS `node out/node-test.js` | 0 | 11171 tests / 55746 assertions |
| `check_skill_package_refs.py` | 0 | clean |

The clj-kondo warning delta is an independent confirmation that the two `trace` requires were dead: the only two warnings that disappear are `namespace re-frame.trace is required but never used`, one per file, and **no new warning appears from any of the 83 renames**.

`--write-baseline` was used and its diff is **exactly five rows**, no other row touched. `:min-edges` **held at 9695** (the recompute proposed 9693); the writer refuses to lower it, because lowering the anti-blindness guard loosens the gate.

## Planted faults

* Reverting one libspec in `testbeds/multi_frame/core.cljs` red the ratchet (exit 1) against a floor of **0 that exists only on this branch** — trunk's floor is 25, so a run that had strayed into another checkout would have come back green.
* With that fault in place, `--write-baseline` **refused the whole write** (exit 1) and left the baseline byte-identical, confirming the monotonic writer at source.
* Breaking one use site in `shared_rule_test.clj` red the codemod suite (exit 1) at `165:25 — No such namespace: slot`; on trunk `slot` is a live alias there, so that red is branch-discriminating too.

Both restores were verified by git blob hash, not by reading a diff.

## Notes for review

`mkdocs build --strict` and `check_doc_slugs.py` are **not** cited here: this diff contains no markdown, and neither gate reads inside a fence in any case. `check_provenance_pins.py` is markdown-and-commit-SHA only, so it is not this diff's gate either.

`docs/tools/playground/sci/src/rf2_playground/sci.cljs` is in the roster of `scripts/playground-sci-input-digest.mjs`, so this arms CI's `tools-playground` job (build + headless smoke). That job was **not** run locally; clj-kondo resolves the file with 0 errors and the SCI namespace map is untouched.

rf2-b38y's note records the CLJS lane at 11174 tests / 55752 assertions. It now reads 11171 / 55746 — **trunk drift, not this change**: running the identical lane with and without the two-file change on one base gives the same 11171 / 55746 both times.