### PR TITLE
docs(bench): name the live prefetch fn, not the retired seam keyword (rf2-g8pf)

### DIFF
--- a/bench/hicasso/src/re_frame/bench/hicasso/front/route_link.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/front/route_link.cljs
@@ -124,7 +124,8 @@
 
   If HD-027 is deliberately reopened to admit prefetch, what replaces
   this is routing's full three-handler behaviour
-  (`:routing/prefetch-on-intent!` at `:on-mouse-enter` / `:on-focus` /
+  (`rf.routing.link/prefetch-on-intent!`, called directly at each
+  `prefetch-intent-keys` position — `:on-mouse-enter` / `:on-focus` /
   `:on-touch-start`). A passthrough is not the middle ground between the
   two."
   [{:keys [to] :as props}]


### PR DESCRIPTION
Closes rf2-g8pf.

## Part 1 — the fix (one comment, one file)

`bench/hicasso/src/re_frame/bench/hicasso/front/route_link.cljs`, in
`prefetch-declined!`'s docstring, named `:routing/prefetch-on-intent!` — a
late-bind seam keyword retired by PR #9165 that no longer resolves to anything.

Before:

```
  If HD-027 is deliberately reopened to admit prefetch, what replaces
  this is routing's full three-handler behaviour
  (`:routing/prefetch-on-intent!` at `:on-mouse-enter` / `:on-focus` /
  `:on-touch-start`). A passthrough is not the middle ground between the
  two."
```

After:

```
  If HD-027 is deliberately reopened to admit prefetch, what replaces
  this is routing's full three-handler behaviour
  (`rf.routing.link/prefetch-on-intent!`, called directly at each
  `prefetch-intent-keys` position — `:on-mouse-enter` / `:on-focus` /
  `:on-touch-start`). A passthrough is not the middle ground between the
  two."
```

The sentence is a CONDITIONAL FUTURE statement, and it stays one. The behaviour
it describes still exists; only the name was dead. The surrounding fail-open
argument is untouched.

### What I read to choose the new name

Nothing validates a comment's truth, so this was read by hand at tip:

- **This file is a view artefact's own route-link**, not `rf/route-link`. Its ns
  docstring: the href, payload and click decision come from "the substrate-neutral
  late-bound seams routing publishes for exactly this consumer class —
  `:routing/link-model` here at render, `:routing/activate-link!` in the lowered
  closure". So the mechanism it would *install* is whatever routing publishes for
  that consumer class.
- `implementation/routing/src/re_frame/routing/link.cljc:519` —
  `prefetch-on-intent!` is a public CLJS `defn`, and its docstring (rewritten by
  #9167) says it is "Kept as routing's one statement of the intent-dispatch law,
  **for a view artefact that needs it to call directly**." That is this consumer,
  by name.
- `link.cljc:191` `compose-intent-handler` and `link.cljc:203`
  `prefetch-intent-attrs` are both **`defn-` private** and CLJS-only, and are
  `rf/route-link`'s internal path. This file cannot reach them, so they are not
  what replaces the decline here.
- `link.cljc:25` `prefetch-intent-keys` is the closed class
  `[:on-mouse-enter :on-focus :on-touch-start]` — the same three positions the
  sentence already listed, now tied to their single source rather than restated.
- "called directly" is load-bearing: `implementation/routing/src/re_frame/routing.cljc:572`
  records that there is deliberately no late-bind seam for the prefetch trio, so a
  consumer reaches the law by direct call.

## Part 2 — the judgement: KEEP

`prefetch-on-intent!` is **not** a vestige. Recorded on the bead.

- **The consumer path is named and concrete, not speculative.** It is the one this
  very PR documents: a view artefact's own route-link that reopens HD-027. The
  bench front consumes routing through the published seams and declines
  `:prefetch` only for v0.
- **The alternative is closed to that consumer.** `prefetch-intent-attrs` /
  `compose-intent-handler` are private. Retire `prefetch-on-intent!` and the
  `link-model` seam consumer is left able to *validate and accept*
  `:prefetch :intent` (`link-model` calls `validate-prefetch!`) with no published
  way to honour it — precisely the fail-open shape both files exist to refuse.
- **The api-manifest evidence does not discriminate, and this refines the bead's
  premise.** `prefetch-on-intent!` is absent from `spec/api-manifest.edn` — but so
  is the string `prefetch` entirely (0 occurrences, against a control of 3
  `route-link` rows). `prefetch-payload` and `prefetch-intent-keys` are equally
  absent and are indisputably live, both called directly by `rf/route-link`. So
  manifest-absence is silent here, not evidence of vestige.
- **Stance.** Pre-alpha, no back-compat obligation, and we trust the programmer.
  An uncalled public helper with an honest docstring is not a defect, and #9167
  already made the docstring honest. Nothing is manufactured to close a bead.

### Census of the symbol at tip (count taken separately from the listing)

**4 occurrences across 3 source files** (7 across 4 including the `.beads` export,
which is not a source) — matching the bead's own count:

- `bench/hicasso/.../front/route_link.cljs:127` (this fix)
- `implementation/routing/src/re_frame/routing.cljc:574`
- `implementation/routing/src/re_frame/routing/link.cljc:519, :531`

Control for that low count: `activate-link!` reads **72 occurrences across 27
files** under the identical search, so the instrument bites.

## Reported, not touched

`implementation/routing/src/re_frame/routing.cljc:574` says `rf/route-link`
"reaches `rf.routing.link/prefetch-payload`, `prefetch-on-intent!` and
`prefetch-intent-keys` by direct call". That is true of `prefetch-payload` and
`prefetch-intent-keys`, but **`rf/route-link` does not call `prefetch-on-intent!`
at all** — `link.cljc:531` says so explicitly ("`rf/route-link` does NOT route
through here"). One residual clause #9167 did not reach, in a file outside this
PR's fence. Left for a ruling rather than fixed here.

`spec/009-Instrumentation.md`'s `:rf.error/route-link-bad-prefetch` row names
`ui/route-link`, a retired artefact — pre-existing, unrelated, hot zone. Not
touched.

## Gates

- `python scripts/check_require_alias_dialect.py --verbose` — **exit 0**.
  `2773 file(s), 10773 re-frame require edge(s), 5586 non-canonical, every surface
  at or under its floor.` Identical to trunk: **the ratchet did not move** in
  either direction. A comment-only edit inside an existing docstring changes no
  require edge.
- Routing suite not run: Part 2 is a keep, so no code changed. The diff is one
  comment hunk in `bench/`.

### Planted fault (provenance only)

The gate's counts came back byte-identical to trunk, which is exactly the
reassuring-constant failure mode, so provenance was proven rather than assumed.
After committing the real edit, an extra non-canonical require
(`[re-frame.core :as planted-fault-alias]`) was added to the same file: the gate
went **red, exit 1**, `bench: 702 violation(s), floor 701`, naming
`front/route_link.cljs:77  [re-frame.core :as planted-fault-alias]`. Restored and
verified by git **blob** hash against the committed object
(`15bd145e51de3e13afdb5e748ae46cca8ed23c02`, working == committed), then re-run
green at exit 0.

**This proves the gate reads this worktree's copy of this file, and nothing else.**
It proves nothing whatever about whether the prose I wrote is true — that rests on
the reading listed under Part 1.
