### PR TITLE
test(react): retire the last React 18 act fallbacks below the React 19 floor (rf2-6r9j.35)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
@@ -125,20 +125,16 @@
     (.createElement js/document "div")))
 
 (defn- get-act
-  "Return React's act() if available, else nil. React 18 ships act in
-  react-dom/test-utils; React 19 promotes it to the React namespace
-  proper. Either is fine for our purposes — both are sync-or-async-
-  promise compatible with the same call shape. Used by Scenario 7
-  (concurrent re-render flush) and the ENSURE StrictMode / hot-reload scenarios
-  (act drives React's effect double-invoke deterministically — `flushSync`
-  does NOT run the StrictMode passive-effect cleanup/re-setup synchronously,
-  so the StrictMode reuse-no-reseed contract only surfaces under act)."
+  "Return React's act() if available, else nil. React 19 — the adapter
+  floor — hosts act on the React namespace proper. Absent only from
+  React's production bundle, which omits act by design. Used by
+  Scenario 7 (concurrent re-render flush) and the ENSURE StrictMode /
+  hot-reload scenarios (act drives React's effect double-invoke
+  deterministically — `flushSync` does NOT run the StrictMode
+  passive-effect cleanup/re-setup synchronously, so the StrictMode
+  reuse-no-reseed contract only surfaces under act)."
   []
-  (or (when (exists? (.-act React)) (.-act React))
-      (try
-        (let [test-utils (js/require "react-dom/test-utils")]
-          (.-act test-utils))
-        (catch :default _ nil))))
+  (when (exists? (.-act React)) (.-act React)))
 
 ;; ---- deferred-teardown await (rf2-vp3m9) ----------------------------------
 ;;
@@ -980,9 +976,10 @@
 ;; reflects a post-dispatch app-db change after act flushes pending
 ;; renders, and the resolution chain still lands on the wrapped frame.
 ;;
-;; React's `act()` is exposed via `react-dom/test-utils` (React 18)
-;; and on `react` directly (React 19). The harness uses whichever is
-;; available; if neither is reachable the test SKIPS and files a bead
+;; React's `act()` is exposed on `react` directly at the React-19
+;; adapter floor. The harness reads it there and nowhere else; if it is
+;; unreachable — React's production bundle omits `act` by design — the
+;; test SKIPS and files a bead
 ;; (per the bead's "no new test infrastructure" rule). `get-act` lives
 ;; in the helpers section above (shared with the frame-root StrictMode
 ;; scenarios, which also need act() to drive React's effect double-invoke).

--- a/implementation/adapters/reagent/test/re_frame/ssr_keyword_child_hydration_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/ssr_keyword_child_hydration_dom_cljs_test.cljs
@@ -72,9 +72,7 @@
        (some? (.-createElement js/document))))
 
 (defn- get-act []
-  (or (when (exists? (.-act React)) (.-act React))
-      (try (.-act (js/require "react-dom/test-utils"))
-           (catch :default _ nil))))
+  (when (exists? (.-act React)) (.-act React)))
 
 ;; ---------------------------------------------------------------------------
 ;; The harness

--- a/implementation/adapters/reagent/test/re_frame/ssr_reg_view_hydration_adoption_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/ssr_reg_view_hydration_adoption_dom_cljs_test.cljs
@@ -80,9 +80,7 @@
        (some? (.-createElement js/document))))
 
 (defn- get-act []
-  (or (when (exists? (.-act React)) (.-act React))
-      (try (.-act (js/require "react-dom/test-utils"))
-           (catch :default _ nil))))
+  (when (exists? (.-act React)) (.-act React)))
 
 ;; The values the CLIENT reg-view render stamps for `test-view-id` — read
 ;; off the SAME shared formatters the JVM emitter uses, so the GREEN server

--- a/implementation/ssr/test/re_frame/ssr/streaming_hydration_lifecycle_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/streaming_hydration_lifecycle_dom_cljs_test.cljs
@@ -263,9 +263,7 @@
   SYNCHRONOUSLY. Without it `hydrateRoot` returns before React has
   touched the DOM and every assertion races the scheduler."
   []
-  (or (when (exists? (.-act React)) (.-act React))
-      (try (.-act (js/require "react-dom/test-utils"))
-           (catch :default _ nil))))
+  (when (exists? (.-act React)) (.-act React)))
 
 (defn- hydrate-capturing!
   "Hydrate `container` against `tree` with REAL React and report

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
@@ -140,11 +140,7 @@
        (some? (.-createElement js/document))))
 
 (defn- get-act []
-  (or (when (exists? (.-act React)) (.-act React))
-      (try
-        (let [test-utils (js/require "react-dom/test-utils")]
-          (.-act test-utils))
-        (catch :default _ nil))))
+  (when (exists? (.-act React)) (.-act React)))
 
 (defn- enable-react-act-env! []
   (when (browser?)

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/export_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/export_dom_cljs_test.cljs
@@ -82,11 +82,7 @@
        (some? (.-createElement js/document))))
 
 (defn- get-act []
-  (or (when (exists? (.-act React)) (.-act React))
-      (try
-        (let [test-utils (js/require "react-dom/test-utils")]
-          (.-act test-utils))
-        (catch :default _ nil))))
+  (when (exists? (.-act React)) (.-act React)))
 
 (defn- enable-react-act-env! []
   (when (browser?)

--- a/tools/story/test/re_frame/story/sub_overrides_render_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/sub_overrides_render_dom_cljs_test.cljs
@@ -45,8 +45,7 @@
        (some? (.-createElement js/document))))
 
 (defn- get-act []
-  (or (when (exists? (.-act React)) (.-act React))
-      (try (.-act (js/require "react-dom/test-utils")) (catch :default _ nil))))
+  (when (exists? (.-act React)) (.-act React)))
 
 (defn- make-mount-node! []
   (let [node (js/document.createElement "div")]


### PR DESCRIPTION
Completes rf2-6r9j.35. The seven remaining DOM harnesses resolved `act()` by falling back to `(js/require "react-dom/test-utils")` when `React.act` was absent. Each `get-act` becomes the single React-19 lookup, matching the shape already landed for the spine, the shared React suite and the five UIx harnesses (PRs #9119, #9165).

## Why the fallback is dead

The floor was re-verified from the RESOLVED dependency, not repo prose: `implementation/package-lock.json` resolves react and react-dom at 19.2.0, `package.json` pins them, and `tools/template/src/day8/re_frame2_template/hooks.clj:191` pins generated consumers to the same, held in lockstep by `version_lockstep_test.clj`.

Probed against the installed lock at tip:

| build | `typeof React.act` | `test-utils.act(...)` |
|---|---|---|
| development | `function` | succeeds, but the `or` short-circuits before reaching it — unreachable |
| production (`NODE_ENV=production`) | `undefined` | **throws `TypeError: React.act is not a function`** |

So the branch was dead in development and actively harmful in production: it turned a clean nil-and-skip into a throw. The retained `(when (exists? (.-act React)) ...)` degrades to nil there, which is the documented safe behaviour.

## Acceptance criterion: repository-wide zero, reached

Measured as a fixed string, count taken separately from the listing, excluding the `.beads` export, and run **both** line-oriented and over whitespace-flattened text (the require can be written across two lines). Both instruments agreed at every step and no site was line-broken.

- `js/require "react-dom/test-utils"`: **7 occurrences / 7 files before → 0 / 0 after**.
- Control: the bare token `react-dom/test-utils` still finds **4 occurrences in 3 files**, so the zero is not a broken instrument.

## The four survivors are deliberate, not residue

All four are in `reagent-slim` (`IMPL-SPEC.md`, `src/reagent2/dom/client.cljs`, its test) and every one is prose stating that the pre-18.3 location is **below the floor and is not probed**, each citing rf2-6r9j.35. There is no `js/require` among them — reagent-slim was already completed by #9119. This matches commit `ad475a95b5`, which records the resolver as "React-19-floored by intent, no test-utils fallback". They are the record of this retirement; deleting them would delete the explanation.

## Gates

Every exit code captured in the same shell as the runner.

| gate | exit | result |
|---|---|---|
| `check_require_alias_dialect.py --verbose` (before) | 0 | 2773 files / 10771 edges / 5501 non-canonical |
| `check_require_alias_dialect.py --verbose` (after) | 0 | **unmoved** — identical figures |
| node-test compile (before) | 0 | 1892 files, **0 warnings** |
| node-test compile (after) | 0 | 1892 files, **0 warnings** |
| `node out/node-test.js` (before) | 0 | 11172 tests / 55747 assertions |
| `node out/node-test.js` (after) | 0 | 11172 tests / 55747 assertions |
| `shadow-cljs compile browser-test` | 0 | 5 `:infer-warning`s, all pre-existing in `hicasso/test/.../login_server_crossing_ssr_dom_cljs_test.cljs`, none in a touched file |
| `serve-and-run-browser-tests.cjs` | 0 | 783 tests / 4253 assertions, 0 failures |
| machines-viz node compile + run | 0 / 0 | 216 files 0 warnings; 845 tests / 3746 assertions |

The browser lane is the one that matters here — all seven files are `*_dom_cljs_test` and `:browser-test` (`:ns-regexp ".*-dom-cljs-test$"`, inheriting the top-level source paths) is what executes them. A node-only green would not have exercised the change.

## The deletion run backwards

Green before, green after, and the retained path proven load-bearing: replacing the surviving `(.-act React)` lookup in `chart_dom_cljs_test.cljs` with `(fn [thunk] (thunk))` turned the browser lane to **captured exit 1 — 42 failures, 50 errors**, carrying React's own "wrap-tests-with-act" warning. The red was bounded, not crash-shaped: still 783 tests (no namespace swallowed), 4215 vs 4253 assertions. The plant recompiled 3 files, so it was genuinely in the build's module graph. Restored and verified by git blob hash equality (`f860be30dbbe5275f0c57474c45e68485e9df9b8`).

## Xray spec

Spec unchanged because the machines-viz edits are confined to a private test-harness helper (`get-act`) and change no chart/export contract surface — no behaviour, no public API, no output.

`spec/api-manifest.edn` and `spec/api-manifest-metadata.edn` were read: they pin `flush-views!` by namespace/var/kind/tier/owner/status only, never docstring text, and `get-act` is private and unpinned. Nothing here touches `flush-views!` names, arities, nil return, `flush-render!`, root APIs or scheduler ordering.
