### PR TITLE
refactor(alias): canonical rf.* require aliases across examples (rf2-7sx1, rf2-lwx8)

### DIFF
--- a/examples/capabilities/machines/state_machine_walkthrough/core.cljc
+++ b/examples/capabilities/machines/state_machine_walkthrough/core.cljc
@@ -32,7 +32,7 @@
             ;; pre-baked replies our stubs below delegate to.
             [re-frame.http.test-support]
             ;; ...and those stubs find the canned fxs through the registrar.
-            [re-frame.registrar :as registrar]))
+            [re-frame.registrar :as rf.registrar]))
 
 ;; ============================================================================
 ;; THE TRANSITION TABLE — guide §A machine at a glance
@@ -163,7 +163,7 @@
          user/token. Defers the heavy lifting to the framework-shipped
          `:rf.http/managed-canned-success` — we just supply the payload."}
   (fn [frame-ctx args-map]
-    (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+    (let [stub (rf.registrar/handler :fx :rf.http/managed-canned-success)]
       (stub frame-ctx (assoc args-map :value {:user  {:id "test-user"}
                                               :token "test-token"})))))
 
@@ -172,7 +172,7 @@
          framework-shipped `:rf.http/managed-canned-failure` — we just supply
          the failure shape. This is the stub the lockout demo wires in."}
   (fn [frame-ctx args-map]
-    (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+    (let [stub (rf.registrar/handler :fx :rf.http/managed-canned-failure)]
       (stub frame-ctx (assoc args-map
                              :kind :rf.http/http-4xx
                              :tags {:message "bad creds" :status 401})))))

--- a/examples/capabilities/machines/state_machine_walkthrough/views.cljs
+++ b/examples/capabilities/machines/state_machine_walkthrough/views.cljs
@@ -12,7 +12,7 @@
   (three attempts total). For that to play out, every request has to fail, which
   is exactly why we wire in the canned-FAILURE stub here."
   (:require [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             [state-machine-walkthrough.core]))
 
 ;; ============================================================================
@@ -112,7 +112,7 @@
 ;; examples co-required into one page would both race to `create-root` onto the
 ;; shared `#app`, and exactly one would win. See examples/TESTING.md, "Convention:
 ;; defer DOM mount to `run`".
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 ;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
 ;; it after each hot reload — edited views re-render into the same root and frame.
@@ -137,7 +137,7 @@
   ;; which is a confusing afternoon you can skip by seeding up front.
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById "app"))]
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id              :rf/default
                       :doc             "State-machines walkthrough demo frame."
                       :fx-overrides    {:rf.http/managed :walkthrough.login/canned-failure}
@@ -148,5 +148,5 @@
 (defn run []
   ;; Tell re-frame2 which substrate to render through by handing init! the
   ;; Reagent adapter's spec map. One call, done.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))

--- a/examples/capabilities/resources/infinite_feed/core.cljs
+++ b/examples/capabilities/resources/infinite_feed/core.cljs
@@ -59,7 +59,7 @@
    exactly as they would over a live network. A small reply delay gives the
    load-more spinner a moment on screen before each page lands."
   (:require [re-frame.core :as rf]
-            [re-frame.registrar :as registrar]
+            [re-frame.registrar :as rf.registrar]
             ;; Managed HTTP — the built-in transport resources fetch over.
             ;; Loading it registers the `:rf.http/managed` fx that every page
             ;; fetch runs on. See docs/resources/glossary.md#managed-http.
@@ -78,7 +78,7 @@
             ;; declare its resources. On entry a route ensures page 0 of an
             ;; infinite feed — just the first page, not the whole pile.
             [re-frame.routing]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; ============================================================================
 ;; THE INFINITE RESOURCE — one growing feed, its pages held as the value
@@ -204,7 +204,7 @@
   (fn fx-managed-feed-demo [frame-ctx args-map]
     (let [cursor  (get-in args-map [:request :params :cursor])
           payload (demo-page-for-cursor cursor)
-          stub    (registrar/handler :fx :rf.http/managed-canned-success)]
+          stub    (rf.registrar/handler :fx :rf.http/managed-canned-success)]
       (stub frame-ctx (assoc args-map :after-ms demo-reply-delay-ms :value payload)))))
 
 ;; ============================================================================
@@ -355,7 +355,7 @@
 ;; frame carries no `:initial-events`.
 ;; See docs/core/glossary.md#frame-root.
 
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 (def app-frame :rf/default)
 
@@ -367,7 +367,7 @@
     ;; The provider creates the app frame (config and all) on first mount and
     ;; reuses it on hot reload. Route entry ensures page 0, so there's no need
     ;; for `:initial-events`.
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id           app-frame
                       :doc          "Infinite-feed demo frame."
                       :url-bound?   true
@@ -376,5 +376,5 @@
       el)))
 
 (defn run []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))

--- a/examples/capabilities/resources/linearlite/core.cljs
+++ b/examples/capabilities/resources/linearlite/core.cljs
@@ -65,7 +65,7 @@
    standalone."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.registrar :as registrar]
+            [re-frame.registrar :as rf.registrar]
             ;; Managed HTTP — the one transport every resource and mutation
             ;; lowers its read/write onto. Loading the ns registers the
             ;; `:rf.http/managed` fx. Guide:
@@ -83,7 +83,7 @@
             ;; `:resources` key — that's how the board route ensures the board on
             ;; entry.
             [re-frame.routing]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; ============================================================================
 ;; THE DOMAIN — issues + statuses
@@ -371,7 +371,7 @@
         ;; sees {:kind :rf.http/http-5xx :status 503 :message …} — an honest
         ;; 503 through the documented closed failure taxonomy, exactly what
         ;; this demo backend promises.
-        (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+        (let [stub (rf.registrar/handler :fx :rf.http/managed-canned-failure)]
           (rf/dispatch [:linearlite/set-fail-next-write false])
           (stub frame-ctx (assoc args-map
                                  :after-ms demo-reply-delay-ms
@@ -383,7 +383,7 @@
         (let [payload (if write?
                         (apply-write! method url body)
                         (strip-optimistic @demo-board))
-              stub    (registrar/handler :fx :rf.http/managed-canned-success)]
+              stub    (rf.registrar/handler :fx :rf.http/managed-canned-success)]
           (stub frame-ctx (assoc args-map :after-ms demo-reply-delay-ms :value payload)))))))
 
 ;; ============================================================================
@@ -615,7 +615,7 @@
 ;; metadata ensures it, kicked off by the first URL sync `:url-bound? true`
 ;; performs automatically when the frame is created.
 
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 (def app-frame :rf/default)
 
@@ -626,7 +626,7 @@
                      (js/document.getElementById "app"))]
     ;; Frame created and configured right here. First mount builds it under
     ;; `app-frame` and applies the config; hot reload reuses it.
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id           app-frame
                       :doc          "Linearlite optimistic-board demo frame."
                       :url-bound?   true
@@ -635,5 +635,5 @@
       el)))
 
 (defn run []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))

--- a/examples/capabilities/resources/resources/core.cljs
+++ b/examples/capabilities/resources/resources/core.cljs
@@ -45,7 +45,7 @@
    mutation invalidates reads by tag — lives in the
    [resources guide](../../../../docs/resources/concepts.md)."
   (:require [re-frame.core :as rf]
-            [re-frame.registrar :as registrar]
+            [re-frame.registrar :as rf.registrar]
             ;; Managed HTTP is the transport a resource fetch rides on.
             ;; Requiring it registers the `:rf.http/managed` effect that every
             ;; ensure ultimately runs onto. See the managed-HTTP glossary entry:
@@ -70,7 +70,7 @@
             ;; asking's other half — without this require that call throws
             ;; `:rf.error/machines-artefact-missing` at ns load.
             [re-frame.machines]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; ============================================================================
 ;; RESOURCES — named, cached server-state reads
@@ -164,7 +164,7 @@
    :platforms #{:client}}
   (fn fx-managed-resources-demo [frame-ctx args-map]
     (let [payload (demo-payload-for-url (-> args-map :request :url))
-          stub    (registrar/handler :fx :rf.http/managed-canned-success)]
+          stub    (rf.registrar/handler :fx :rf.http/managed-canned-success)]
       (stub frame-ctx (assoc args-map :after-ms demo-reply-delay-ms :value payload)))))
 
 ;; ============================================================================
@@ -536,7 +536,7 @@
 ;; automatically. See the frame glossary entry:
 ;; ../../../../docs/core/glossary.md#frame
 
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 ;; The id this app's frame is created under. Despite the name, `:rf/default`
 ;; carries no special privilege — it's just an ordinary id. The URL ownership
@@ -555,7 +555,7 @@
     ;; override is frame-wide, which is fine here precisely because this example
     ;; never makes a request we'd actually want to reach the network — a blanket
     ;; override is the right grain.
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id           app-frame
                       :doc          "Resources demo frame."
                       :url-bound?   true
@@ -564,5 +564,5 @@
       el)))
 
 (defn run []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))

--- a/examples/capabilities/routing/routing/core.cljs
+++ b/examples/capabilities/routing/routing/core.cljs
@@ -28,7 +28,7 @@
             ;; :rf.error/routing-artefact-missing — which is the runtime's
             ;; polite way of saying "you asked for routing but never packed it".
             [re-frame.routing]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; ============================================================================
 ;; ROUTES
@@ -164,7 +164,7 @@
 ;; the test harness loads several example namespaces side by side, and if each
 ;; eagerly grabbed `#app` they'd trample one another's `create-root`. Lazy
 ;; means whoever calls `run` wins the element, and only then.
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 ;; The id of the one frame this whole app runs under. `:rf/default` looks
 ;; special, but it isn't — it's an ordinary id with no secret privileges, and
@@ -197,7 +197,7 @@
     ;; every Back/Forward resolves whichever frame owns the URL at pop time
     ;; and updates its `:rf/route` slice. Idempotent, so hot reload never
     ;; stacks up duplicate listeners.
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id app-frame
                       :doc "Routing demo frame."
                       :url-bound? true
@@ -208,5 +208,5 @@
 (defn run []
   ;; Tell re-frame2 to render through Reagent. Every adapter namespace exports
   ;; an `adapter` var; hand it straight to `init!` and you're done.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))

--- a/examples/capabilities/ssr/resources_ssr/core.cljc
+++ b/examples/capabilities/ssr/resources_ssr/core.cljc
@@ -32,7 +32,7 @@
    This drives the real server path, not a stand-in. It blocks on the
    preloaded page resource before rendering (`await-resource-loaded!`,
    server entry point below) and ships only the allowed runtime-db
-   projection (`payload-policy/project-runtime-db`) under `:rf/runtime-db` —
+   projection (`rf.ssr.payload-policy/project-runtime-db`) under `:rf/runtime-db` —
    never the full cache. The `:rf/app-db` slice goes through the same
    fail-closed allowlist (`apply-policy`) the production Ring host uses. The
    static `index.html` next to this file carries a pre-baked payload so the
@@ -67,19 +67,19 @@
             [re-frame.resources]
             ;; SSR: render-to-string, the `:rf/hydrate` event, and the
             ;; per-request server effects.
-            [re-frame.ssr :as ssr]
+            [re-frame.ssr :as rf.ssr]
             ;; The payload assembly the production Ring host uses, so this
             ;; example builds the wire payload the same way the real thing does:
             ;; the fail-closed app-db allowlist (`apply-policy`) and the
             ;; runtime-db projection (`project-runtime-db`) that ships only the
             ;; allowed resource `:entries` under `:rf/runtime-db` (sensitive
             ;; data redacted; indexes rebuilt on install). Server-side only.
-            #?(:clj [re-frame.ssr.payload-policy :as payload-policy])
+            #?(:clj [re-frame.ssr.payload-policy :as rf.ssr.payload-policy])
             ;; The EDN-aware escaper for the payload `<script>` body. A server
             ;; string that happens to contain `</script>` would otherwise close
             ;; the envelope early — so we escape it. Server-side only.
-            #?(:clj [re-frame.ssr.html-helpers :as html])
-            #?(:cljs [re-frame.adapter.reagent :as reagent-adapter])))
+            #?(:clj [re-frame.ssr.html-helpers :as rf.ssr.html-helpers])
+            #?(:cljs [re-frame.adapter.reagent :as rf.adapter.reagent])))
 
 ;; ============================================================================
 ;; RESOURCE
@@ -188,7 +188,7 @@
 ;; DIRECT RESOURCE-PRELOAD POLL (route-free — no `reg-route` in this example)
 ;; ============================================================================
 ;;
-;; The framework's `ssr/drain-blocking-resources!` is ROUTE-blocking-keyed:
+;; The framework's `rf.ssr/drain-blocking-resources!` is ROUTE-blocking-keyed:
 ;; it drains only the resources a `reg-route` on-route-entry plan enqueued
 ;; for the CURRENT nav-token (`[:rf.runtime/routing :resource-blocking
 ;; <nav-token>]`, written by the routing artefact). This page has no route
@@ -255,8 +255,8 @@
 ;;      the render never catches the page mid-fetch with a `:loading`
 ;;      skeleton frozen into the HTML. See the DIRECT RESOURCE-PRELOAD POLL
 ;;      section above for why this page polls directly instead of calling
-;;      `ssr/drain-blocking-resources!`.
-;;   2. `payload-policy/project-runtime-db` boils the runtime-db down to just
+;;      `rf.ssr/drain-blocking-resources!`.
+;;   2. `rf.ssr.payload-policy/project-runtime-db` boils the runtime-db down to just
 ;;      what's safe to serialize: the durable `:rf.runtime/resources`
 ;;      `:entries`, with `:sensitive?` values redacted, `:large?` values
 ;;      omitted, and the reverse indexes dropped (the client rebuilds those
@@ -269,7 +269,7 @@
 #?(:clj
    (defn handle-request [request]
      (let [fid (keyword "rf.frame" (str (gensym "f")))
-           _   (ssr/set-request! fid request)
+           _   (rf.ssr/set-request! fid request)
            f   (rf/make-frame {:id fid :doc       "resources-ssr per-request frame"
                                :platform  :server
                                :initial-events [[:rf/server-init]]})]
@@ -314,17 +314,17 @@
                  ;; thing fail-closed won't let you get away with.
                  ;; See docs/ssr/concepts.md#payload--the-fail-closed-allowlist.
                  policy-opts   {:payload :rf.ssr.payload/whole-app-db}
-                 payload       (payload-policy/build-payload
+                 payload       (rf.ssr.payload-policy/build-payload
                                  f
-                                 (payload-policy/apply-policy final-db policy-opts)
+                                 (rf.ssr.payload-policy/apply-policy final-db policy-opts)
                                  render-hash
                                  (assoc policy-opts
-                                        :runtime-db (payload-policy/project-runtime-db
+                                        :runtime-db (rf.ssr.payload-policy/project-runtime-db
                                                       final-runtime)))
                  ;; Drop the payload's `:rf/frame-id`. `build-payload` stamps it
                  ;; with this per-request gensym frame (`f`), but the client
                  ;; hydrates a fixed app-frame (`:rf/default`, below). When a
-                 ;; `:rf/frame-id` *is* present, `ssr/hydrate!` checks it against
+                 ;; `:rf/frame-id` *is* present, `rf.ssr/hydrate!` checks it against
                  ;; the client's `:frame` and raises
                  ;; `:rf.error/hydration-frame-id-mismatch` if they disagree — so
                  ;; the frame-id is a sanity check, not a hydration target. Our
@@ -345,7 +345,7 @@
                    ;; that happens to contain `</script>` can't slam the
                    ;; envelope shut from the inside.
                    "<script id='__rf_payload' type='application/edn'>"
-                   (html/escape-edn-script-body (pr-str payload))
+                   (rf.ssr.html-helpers/escape-edn-script-body (pr-str payload))
                    "</script><script src='/main.js'></script>"
                    "</body></html>")}))
          (finally
@@ -355,7 +355,7 @@
 ;; CLIENT ENTRY POINT
 ;; ============================================================================
 ;;
-;; The browser's side of the handoff. `ssr/hydrate!` reads the payload,
+;; The browser's side of the handoff. `rf.ssr/hydrate!` reads the payload,
 ;; dispatch-syncs `[:rf/hydrate payload]` to install the resource projection
 ;; into the frame's `:rf.runtime/resources` slice, then verifies the render
 ;; hash to confirm client and server agree on what the page should look like.
@@ -364,10 +364,10 @@
 ;; for. A stale entry quietly refetches in the background, per its policy.
 ;; See docs/ssr/concepts.md#the-client-side-hydrate-then-verify.
 
-#?(:cljs (defonce app-root (reagent-adapter/client-root)))
+#?(:cljs (defonce app-root (rf.adapter.reagent/client-root)))
 
 ;; The client's one app-frame. The app names its hydration target out loud and
-;; threads the same id through two places: `ssr/hydrate!` (where the server
+;; threads the same id through two places: `rf.ssr/hydrate!` (where the server
 ;; state lands) and the root `frame-provider` (where in-tree dispatch/subscribe
 ;; go looking for their frame). One id, both ends — that's what makes them meet.
 ;; It has to be a `:client`-platform frame, or the `:rf.ssr/check-*`
@@ -386,20 +386,20 @@
 #?(:cljs
    (defn ^:dev/after-load render! []
      (when-let [el (and (exists? js/document) (js/document.getElementById "app"))]
-       (reagent-adapter/render! app-root
+       (rf.adapter.reagent/render! app-root
          [rf/frame-provider {:frame app-frame}
           [(rf/view :app/root)]]
          el))))
 
 #?(:cljs
    (defn run []
-     (rf/init! reagent-adapter/adapter)
+     (rf/init! rf.adapter.reagent/adapter)
      (rf/make-frame {:id app-frame :doc "resources-ssr client app-frame" :platform :client})
      ;; READ, HYDRATE, VERIFY against the app-frame. `hydrate!` seeds STATE only
      ;; — it never touches the DOM — and hands back the payload it applied, or
      ;; nil on a plain client load with no server render to adopt.
      (let [el      (and (exists? js/document) (js/document.getElementById "app"))
-           payload (ssr/hydrate! {:frame          app-frame
+           payload (rf.ssr/hydrate! {:frame          app-frame
                                   :render-tree-fn (fn [] ((rf/view :app/root)))})
            tree    [rf/frame-provider {:frame app-frame} [(rf/view :app/root)]]]
        (when el
@@ -410,4 +410,4 @@
          ;; adapter mounts a fresh root; a fresh entry serves from cache, a
          ;; stale or absent one refetches per its policy. Either way the root
          ;; is created exactly once, here, and `render!` above reuses it.
-         (reagent-adapter/render! app-root tree el {:hydrate? (some? payload)})))))
+         (rf.adapter.reagent/render! app-root tree el {:hydrate? (some? payload)})))))

--- a/examples/capabilities/ssr/ssr/core.cljc
+++ b/examples/capabilities/ssr/ssr/core.cljc
@@ -24,7 +24,7 @@
    - The hydration payload: the server's finished state, packed into the page
      for the client to adopt verbatim.
    - Hydration the app never has to write. The client boots through
-     `ssr/hydrate!`, which dispatches the reserved `:rf/hydrate` event;
+     `rf.ssr/hydrate!`, which dispatches the reserved `:rf/hydrate` event;
      re-frame2 owns the handler. `:rf/hydrate` *replaces* the client's
      frame-state rather than merging into it — on this question the server is
      the single source of truth.
@@ -65,7 +65,7 @@
             ;; The SSR machinery: the `:rf.server/*` server-only effects, the
             ;; framework-owned `:rf/hydrate` event, the default error
             ;; projector, and the render/hash hooks the calls below ride on.
-            [re-frame.ssr :as ssr]
+            [re-frame.ssr :as rf.ssr]
             ;; Server-side only: a `<script>`-body escaper that understands
             ;; EDN. `handle-request` drops the payload, `pr-str`'d, inside a
             ;; `<script type="application/edn">`. If some article body smuggled
@@ -73,13 +73,13 @@
             ;; early. The escaper rewrites `<` to its reader escape, but only
             ;; inside EDN string literals — so the payload still reads back
             ;; byte-for-byte on the client.
-            #?(:clj [re-frame.ssr.html-helpers :as html])
+            #?(:clj [re-frame.ssr.html-helpers :as rf.ssr.html-helpers])
             ;; Server-side only: the SSR artefact owns the hydration
             ;; pattern-protocol version as a compiled-in constant. The payload
             ;; sources `:rf/version` from it rather than pinning a literal, so a
             ;; future bump flows through without editing every producer.
-            #?(:clj [re-frame.ssr.payload-policy :as payload-policy])
-            #?(:cljs [re-frame.adapter.reagent :as reagent-adapter])
+            #?(:clj [re-frame.ssr.payload-policy :as rf.ssr.payload-policy])
+            #?(:cljs [re-frame.adapter.reagent :as rf.adapter.reagent])
             ;; The client mount step — the payload-vs-client-only React-root
             ;; branch — factored into a registration-free helper so the browser
             ;; DOM-adoption regression can execute the EXACT branch this recipe
@@ -187,7 +187,7 @@
 ;;
 ;; This example has no machines and doesn't hydrate a route, so its runtime-db
 ;; slice is empty here — but the shape is the same one a richer app fills in.
-;; The client `run` at the bottom drives all of this through `ssr/hydrate!`; the
+;; The client `run` at the bottom drives all of this through `rf.ssr/hydrate!`; the
 ;; CLIENT ENTRY POINT section picks up the thread.
 
 ;; ============================================================================
@@ -276,7 +276,7 @@
 #?(:clj
    (defn handle-request [request]
      (let [fid (keyword "rf.frame" (str (gensym "f")))
-           _   (ssr/set-request! fid request)
+           _   (rf.ssr/set-request! fid request)
            ;; Schema first, frame second — order matters. `make-frame` runs its
            ;; `:initial-events` pipeline run synchronously, and that run includes
            ;; the `:articles` commit `:rf/server-init` sets in motion. If the
@@ -316,7 +316,7 @@
                  ;; own fixed `app-frame` (defined below). The two frames have
                  ;; nothing to say to each other by name. A `:rf/frame-id` in
                  ;; the payload isn't a "hydrate into this" instruction — it's
-                 ;; evidence. `ssr/hydrate!` checks any id it finds against the
+                 ;; evidence. `rf.ssr/hydrate!` checks any id it finds against the
                  ;; `:frame` you explicitly pass, and raises
                  ;; `:rf.error/hydration-frame-id-mismatch` if they disagree.
                  ;; Leaving it out is the no-argument-to-have-here shape, which
@@ -324,7 +324,7 @@
                  ;; both use. A deployment that *does* want to carry one stamps
                  ;; a stable id both sides agree on ahead of time — never a
                  ;; per-request gensym.
-                 payload  {:rf/version     payload-policy/pattern-protocol-version  ;; the SSR-owned constant, not a literal
+                 payload  {:rf/version     rf.ssr.payload-policy/pattern-protocol-version  ;; the SSR-owned constant, not a literal
                            :rf/app-db      final-db        ;; app-db partition
                            :rf/runtime-db  final-runtime   ;; serializable runtime-db projection
                            :rf/render-hash render-hash}]
@@ -345,7 +345,7 @@
                    ;; inside EDN string literals, so the client's
                    ;; `cljs.reader/read-string` still reads it back unchanged.
                    "<script id='__rf_payload' type='application/edn'>"
-                   (html/escape-edn-script-body (pr-str payload))
+                   (rf.ssr.html-helpers/escape-edn-script-body (pr-str payload))
                    "</script>"
                    "<script src='/main.js'></script>"
                    "</body></html>")}))
@@ -360,7 +360,7 @@
 ;; CLIENT ENTRY POINT
 ;; ============================================================================
 ;;
-;; On the client, the whole boot is a single call: `ssr/hydrate!`, the mirror
+;; On the client, the whole boot is a single call: `rf.ssr/hydrate!`, the mirror
 ;; image of the server render. It rolls three steps into one, and the order is
 ;; the point:
 ;;   1. READ    — pull the embedded `__rf_payload` `<script>` by its pinned id.
@@ -395,10 +395,10 @@
 ;; the DOM — so if several example namespaces get required together, none of them
 ;; can race the others to slap a root onto the shared `#app`. One root per
 ;; container, reused across hot reloads.
-#?(:cljs (defonce app-root (reagent-adapter/client-root)))
+#?(:cljs (defonce app-root (rf.adapter.reagent/client-root)))
 
 ;; The client's app-frame id. The app names its frame out loud and threads the
-;; very same id through two places: `ssr/hydrate!` (where the server's state
+;; very same id through two places: `rf.ssr/hydrate!` (where the server's state
 ;; gets seeded) and the root `frame-provider` (where every `dispatch` and
 ;; `subscribe` in the tree goes looking for its frame). It has to be a
 ;; `:client`-platform frame, because the `:rf/hydrate` handler fires
@@ -420,7 +420,7 @@
      (when-let [el (and (exists? js/document) (js/document.getElementById "app"))]
        ;; Render inside the app-frame's `frame-provider`, so every `dispatch` and
        ;; `subscribe` down in the view tree resolves to the frame we hydrated.
-       (reagent-adapter/render! app-root
+       (rf.adapter.reagent/render! app-root
          [rf/frame-provider {:frame app-frame}
           [(rf/view :app/root)]]
          el))))
@@ -433,7 +433,7 @@
      ;; adapter and stops there. Creating a frame is the app's job, next line.
      ;; (Each adapter namespace exports an `adapter` var; you require it and
      ;; hand the spec map straight in.)
-     (rf/init! reagent-adapter/adapter)
+     (rf/init! rf.adapter.reagent/adapter)
      ;; Stand up the client app-frame before we hydrate anything into it.
      ;; Re-registering an existing frame is a no-op, so hot-reload just shrugs
      ;; and carries on. `:platform :client` is what lets the hydrate
@@ -455,7 +455,7 @@
      ;; verifies STATE only — it never touches the DOM — and returns the payload
      ;; it applied, or nil on a plain client load.
      (let [el      (and (exists? js/document) (js/document.getElementById "app"))
-           payload (ssr/hydrate! {:frame          app-frame
+           payload (rf.ssr/hydrate! {:frame          app-frame
                                   :render-tree-fn (fn [] ((rf/view :app/root)))})
            tree    [rf/frame-provider {:frame app-frame} [(rf/view :app/root)]]]
        (when el

--- a/examples/capabilities/ssr/ssr/mount.cljs
+++ b/examples/capabilities/ssr/ssr/mount.cljs
@@ -15,7 +15,7 @@
   assembly with the login + realworld examples already sharing the consolidated
   test bundle (`:rf.error/image-duplicate-id`). This namespace registers nothing,
   so a test loads only the mount logic and no example ids enter the bundle."
-  (:require [re-frame.adapter.reagent :as reagent-adapter]))
+  (:require [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 (defn mount!
   "Mount `tree` into the container `el` through the adapter's client-root
@@ -33,4 +33,4 @@
   Returns nil; does nothing when `el` is absent (no container to mount into)."
   [handle el tree payload]
   (when el
-    (reagent-adapter/render! handle tree el {:hydrate? (some? payload)})))
+    (rf.adapter.reagent/render! handle tree el {:hydrate? (some? payload)})))

--- a/examples/capabilities/ssr/ssr_streaming/core.cljc
+++ b/examples/capabilities/ssr/ssr_streaming/core.cljc
@@ -9,7 +9,7 @@
   shape as collected data; it does not simulate network timings.
 
   Six ideas earn their keep here:
-   - `ssr/boundary` — one component that says \"this region may arrive
+   - `rf.ssr/boundary` — one component that says \"this region may arrive
      late.\" That component IS the whole streaming API.
    - It is **cross-host**: the same form defers a region on the server and
      renders it in the browser, so the views are shared verbatim and there
@@ -33,8 +33,8 @@
   See the [SSR guide — Streaming](../../../../docs/ssr/concepts.md#streaming-rfsuspense-boundary)."
   (:require [re-frame.core :as rf]
             [re-frame.schemas]
-            [re-frame.ssr :as ssr]
-            #?(:cljs [re-frame.adapter.reagent :as reagent-adapter])))
+            [re-frame.ssr :as rf.ssr]
+            #?(:cljs [re-frame.adapter.reagent :as rf.adapter.reagent])))
 
 ;; ============================================================================
 ;; SCHEMA
@@ -117,7 +117,7 @@
   "One card's slot in the dashboard — and, since the boundary became a
   component, ONE program rather than two.
 
-  `ssr/boundary` wraps a region that's allowed to arrive late. On the
+  `rf.ssr/boundary` wraps a region that's allowed to arrive late. On the
   server the `:fallback` ships inline in the shell right now, and `body`
   renders separately and streams in as its own chunk once it resolves. In
   the browser the same form renders `body` — or, when this boundary is one
@@ -152,7 +152,7 @@
   trees reference views by **Var** (`card-view`, which `reg-view` defs for
   you) or by `(rf/view :id)` lookup."
   [boundary-id card-id body]
-  [ssr/boundary {:id boundary-id :fallback [card-skeleton card-id]}
+  [rf.ssr/boundary {:id boundary-id :fallback [card-skeleton card-id]}
    body])
 
 (rf/reg-view ^{:rf/id :dashboard/root} root-view []
@@ -205,7 +205,7 @@
                                :initial-events [[:rf/server-init]]})
            hiccup (rf/with-frame fid ((rf/view :dashboard/root)))
            {:keys [shell-html continuations]}
-           (rf/with-frame fid (ssr/streaming-render-shell hiccup))
+           (rf/with-frame fid (rf.ssr/streaming-render-shell hiccup))
            ;; Render the shell handed us one continuation per boundary —
            ;; the slow subtrees it deferred. Drain them in order, collecting
            ;; each resolved subtree's HTML plus its hydration delta. This is
@@ -215,13 +215,13 @@
            (mapv (fn [entry]
                    (let [{:keys [id html delta failed?]}
                          (rf/with-frame fid
-                           (ssr/streaming-render-continuation fid entry))]
+                           (rf.ssr/streaming-render-continuation fid entry))]
                      {:id    id
                       :template (if failed?
-                                  (ssr/streaming-failed-template id html)
-                                  (ssr/streaming-resolved-template id html))
+                                  (rf.ssr/streaming-failed-template id html)
+                                  (rf.ssr/streaming-resolved-template id html))
                       :delta-script (when (and (not failed?) (some? delta))
-                                      (ssr/streaming-hydrate-delta-script
+                                      (rf.ssr/streaming-hydrate-delta-script
                                         id (pr-str delta)))
                       :failed? failed?}))
                  continuations)
@@ -231,7 +231,7 @@
            ;; instead of every view inferring failure from missing state.
            failed-boundaries (into #{} (comp (filter :failed?) (map :id))
                                    resolved-chunks)
-           render-hash (rf/with-frame fid (ssr/render-tree-hash hiccup))
+           render-hash (rf/with-frame fid (rf.ssr/render-tree-hash hiccup))
            ;; The final payload: the canonical, whole app-db. This is the
            ;; load-bearing idea of the example. Those per-card deltas are a
            ;; speed bet — they exist only to paint each region early. This
@@ -246,7 +246,7 @@
            ;; apps usually pass an explicit allowlist of top-level keys
            ;; instead.
            final-payload (rf/with-frame fid
-                           (ssr/streaming-build-final-payload
+                           (rf.ssr/streaming-build-final-payload
                              fid render-hash
                              ;; No `:version` — the builder sources `:rf/version`
                              ;; from the SSR artefact's compiled-in
@@ -257,7 +257,7 @@
            ;; Strip the payload's `:rf/frame-id` before it goes over the
            ;; wire. The two sides don't share a frame id: the server renders
            ;; under this per-request gensym frame (`fid`), the client hydrates
-           ;; a fixed `app-frame` (below). When `ssr/hydrate!` sees a frame-id on the
+           ;; a fixed `app-frame` (below). When `rf.ssr/hydrate!` sees a frame-id on the
            ;; wire, it checks it against the client's explicit `:frame` and
            ;; fails closed if they differ — which a gensym always would. Send
            ;; no frame-id and the client's explicit target simply stands. (If
@@ -289,7 +289,7 @@
 ;;  2. The resolved cards stream in (Transfer-Encoding: chunked), each a
 ;;     `<template data-rf2-suspense-resolved=…>` plus a matching
 ;;     `<script data-rf2-suspense-hydrate=…>`. The client streaming runtime
-;;     (`ssr/streaming-install!`) does two things per chunk: it brings the
+;;     (`rf.ssr/streaming-install!`) does two things per chunk: it brings the
 ;;     inert fallback `<template>`s to life as `<rf-suspense>` mounts (now
 ;;     the skeletons paint), then swaps each mount's content for the resolved
 ;;     subtree in place and merges that subtree's delta into app-db. `run`
@@ -300,7 +300,7 @@
 ;;     processes any chunk still pending, consumes or quarantines the last
 ;;     deltas, unwraps every `<rf-suspense>` mount it created — leaving the
 ;;     DOM as the plain markup the author's tree describes — disconnects, and
-;;     calls `:on-ready`. Only then does `run` hydrate: `ssr/hydrate!`
+;;     calls `:on-ready`. Only then does `run` hydrate: `rf.ssr/hydrate!`
 ;;     dispatches `:rf/hydrate`, replacing the whole client frame-state in one
 ;;     step (app-db plus its serialisable runtime-db slice, which carries
 ;;     which boundaries failed), and `hydrate-root` adopts the painted DOM.
@@ -339,10 +339,10 @@
 ;; sibling example namespaces loaded alongside this one can't race each other
 ;; to `create-root` the shared `#app`. (Mount-isolation convention — see
 ;; examples/TESTING.md.)
-#?(:cljs (defonce app-root (reagent-adapter/client-root)))
+#?(:cljs (defonce app-root (rf.adapter.reagent/client-root)))
 
 ;; The client's app-frame id, carried explicitly. The same id flows into the
-;; streaming `install!`, into `ssr/hydrate!`, and into the root
+;; streaming `install!`, into `rf.ssr/hydrate!`, and into the root
 ;; `frame-provider` — one source of truth for which frame everything targets.
 ;; This example uses `:rf/default`. It has to be a `:client`-platform frame,
 ;; or the `:rf.ssr/check-*` compatibility checks that `:rf/hydrate` runs
@@ -367,7 +367,7 @@
      (when-let [el (and (exists? js/document) (js/document.getElementById "app"))]
        ;; Wrap the render in `frame-provider` so every `dispatch` and
        ;; `subscribe` inside the tree resolves to the frame we hydrated.
-       (reagent-adapter/render! app-root
+       (rf.adapter.reagent/render! app-root
          [rf/frame-provider {:frame app-frame}
           [(rf/view :dashboard/root)]]
          el))))
@@ -376,7 +376,7 @@
    (defn run []
      ;; `init!` installs the Reagent adapter and nothing more — it creates no
      ;; frame. The app stands up its own, explicitly, just below.
-     (rf/init! reagent-adapter/adapter)
+     (rf/init! rf.adapter.reagent/adapter)
      ;; Stand up the client app-frame BEFORE we install streaming or hydrate
      ;; into it — both need a frame to land in. `make-frame` is a no-op the
      ;; second time round, so hot-reload just works. `:platform :client` is
@@ -409,7 +409,7 @@
      ;; life, and mounting a fresh root in the meantime throws away the very
      ;; markup the server streamed. The readiness callback removes the race by
      ;; removing the guess.
-     (ssr/streaming-install!
+     (rf.ssr/streaming-install!
        {:frame    app-frame
         :on-ready (fn [_outcomes]
                     ;; Reconcile against the canonical payload first: read
@@ -425,7 +425,7 @@
                     ;; verification would warn every time. A real streaming
                     ;; server stamps the genuine hash and passes
                     ;; `:render-tree-fn` to switch mismatch detection on.)
-                    (let [payload (ssr/hydrate! {:frame app-frame})
+                    (let [payload (rf.ssr/hydrate! {:frame app-frame})
                           el      (and (exists? js/document)
                                        (js/document.getElementById "app"))
                           tree    [rf/frame-provider {:frame app-frame}
@@ -440,7 +440,7 @@
                         ;; to adopt — and the adapter mounts a fresh root.
                         ;; Either way the root is created exactly once, here,
                         ;; and the `^:dev/after-load` `render!` above reuses it.
-                        (reagent-adapter/render! app-root tree el
+                        (rf.adapter.reagent/render! app-root tree el
                                                  {:hydrate? (some? payload)}))))})))
 
 ;; The JVM headless test that walks the server stream end to end (shell →

--- a/examples/core/counter/core.cljs
+++ b/examples/core/counter/core.cljs
@@ -15,7 +15,7 @@
    On the menu: `reg-event`, `reg-sub`, and `reg-view` with its frame-bound
    `dispatch`/`subscribe`."
   (:require [re-frame.core    :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; -- Events / subs -----------------------------------------------------------
 ;;
@@ -78,7 +78,7 @@
 ;; are exactly the bug you don't want in your test harness. See
 ;; examples/TESTING.md, "mount-isolation".
 
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 ;; The frame's whole life story fits in one place: the `frame-root {:id
 ;; app-frame …}` in `mount!` below. First mount creates the frame and runs its
@@ -105,7 +105,7 @@
 (defn ^:dev/after-load mount! []
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById "app"))]
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id             app-frame
                       :initial-events [[:counter/initialise]]}
        [counter-app]]
@@ -117,5 +117,5 @@
   ;; ns and pass that var. One call, at startup, and you're done. Note it
   ;; installs the adapter for the whole process, not a frame — frames come
   ;; later, via the provider. See `docs/core/glossary.md#init`.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))

--- a/examples/core/flows/core.cljs
+++ b/examples/core/flows/core.cljs
@@ -38,7 +38,7 @@
             ;; re-frame.flows once wires up the flow API; leave it out and the
             ;; reg-flow calls below raise :rf.error/flows-artefact-missing.
             [re-frame.flows]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; ============================================================================
 ;; FLOWS
@@ -275,7 +275,7 @@
 ;; never at ns-load. Loading a namespace should touch no DOM, so that two
 ;; co-required example namespaces don't both race to slap `create-root` onto
 ;; the shared `#app`.
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 ;; `frame-root` (ENSURE, `{:id …}`) would normally be where
 ;; `:rf/default` gets created — but by the time it mounts below, `run` has
@@ -297,7 +297,7 @@
 (defn mount! []
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById "app"))]
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id app-frame}
        [cart-app]]
       el)))
@@ -325,7 +325,7 @@
   ;; here, Reagent. It has to come before any frame is constructed: a
   ;; frame's state container is substrate-specific, so `rf/make-frame` (next)
   ;; would raise :rf.error/no-adapter-installed without this first.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   ;; Create the frame explicitly, here, rather than leaving it to
   ;; `frame-root` in `mount!`. `reg-flow` (inside `install-flows!`) needs a
   ;; LIVE frame to register against, and the render tree — where

--- a/examples/core/login/core.cljs
+++ b/examples/core/login/core.cljs
@@ -30,7 +30,7 @@
             ;; hands us `model/frame-config` for the mount below. It names no
             ;; substrate — see model.cljc.
             [login.model :as model]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; ============================================================================
 ;; VIEWS  (Reagent — reg-view)
@@ -119,7 +119,7 @@
 ;; the DOM exactly zero times. Otherwise, the moment another example
 ;; co-requires this one, two `create-root` calls race for `#app` and you get
 ;; the kind of bug that only shows up on Tuesdays.
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 ;; `mount!` is browser setup: create the root lazily, then render the view tree
 ;; inside the frame-root. `^:dev/after-load` is shadow's cue to re-run it on
@@ -143,7 +143,7 @@
     ;; views' injected `dispatch`/`subscribe` (and the machine reads) know to
     ;; talk to `:rf/default`. Render a `reg-view` outside any frame scope and it
     ;; fails loud rather than guessing.
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root (merge {:id  :rf/default
                              :doc "Login demo frame."}
                             model/frame-config)
@@ -153,5 +153,5 @@
 (defn run []
   ;; Tell re-frame2 to render through Reagent. The adapter is just a spec
   ;; map; hand it straight to `init!`.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))

--- a/examples/core/login/model.cljc
+++ b/examples/core/login/model.cljc
@@ -73,7 +73,7 @@
   ;; switching itself on — and note the absence: no adapter, no view library.
   ;; This namespace is substrate-free by construction.
   (:require [re-frame.core :as rf]
-            [re-frame.registrar :as registrar]
+            [re-frame.registrar :as rf.registrar]
             ;; Malli directly — for the pre-submit form validator below
             ;; (`m/explain` + `me/humanize`), the same pure validator the form
             ;; recipe builds (docs/core/how-to/build-a-form.md, "Validation is a
@@ -274,7 +274,7 @@
           login? (= "/api/login" url)]
       (cond
         (and login? (= good-password (:password body)))
-        (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+        (let [stub (rf.registrar/handler :fx :rf.http/managed-canned-success)]
           (stub frame-ctx (assoc args-map
                                  :after-ms 50
                                  :value {:user  {:id    (random-uuid)
@@ -282,7 +282,7 @@
                                          :token "demo-token-123"})))
 
         login?
-        (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+        (let [stub (rf.registrar/handler :fx :rf.http/managed-canned-failure)]
           (stub frame-ctx (assoc args-map
                                  :after-ms 50
                                  :kind :rf.http/http-4xx
@@ -290,7 +290,7 @@
                                         :message "Invalid credentials."})))
 
         :else
-        (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+        (let [stub (rf.registrar/handler :fx :rf.http/managed-canned-success)]
           (stub frame-ctx (assoc args-map :after-ms 50 :value {})))))))
 
 ;; ============================================================================

--- a/examples/core/login/stories.cljs
+++ b/examples/core/login/stories.cljs
@@ -69,7 +69,7 @@
    Examples are test-free: these stories carry no `:script` / `:rf.assert/*`
    — they're a showcase, not a test surface."
   (:require [re-frame.core :as rf]
-            [re-frame.story :as story]
+            [re-frame.story :as rf.story]
             ;; Source the example's registrations (the machine, schemas,
             ;; demo fx, subs, views). The variant bodies below reference
             ;; its event-ids + the `root-view` view-id as plain keywords;
@@ -150,7 +150,7 @@
   ;; reg-tag — one project tag, marking which variant is the "hero" shot.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-tag :login/canonical
+  (rf.story/reg-tag :login/canonical
     {:doc "Marks the variant that ships as the example's canonical
           screenshot — the `:success` welcome-banner state."})
 
@@ -160,7 +160,7 @@
   ;; variant, so each variant only has to describe what makes it different.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-story :story.login
+  (rf.story/reg-story :story.login
     {:doc        "The login form — every reachable state of the
                  `:auth.login/flow` machine, as runnable variants."
      :component  :login.core/root-view
@@ -180,7 +180,7 @@
   ;; of the defaults — no defaults map is duplicated in Story, no `:db-seed`.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-fragment :fragment.login/form-base
+  (rf.story/reg-fragment :fragment.login/form-base
     {:doc   "Seeds the login-form slice to its standard form-recipe defaults
             via the example's own `:auth.login/initialise-form` (the single
             source of those defaults — the same event the live app runs at
@@ -201,7 +201,7 @@
   ;; `:initial` cascade into seeding the snapshot. Without that nudge the
   ;; `[:rf.runtime/machines :snapshots :auth.login/flow]` slot sits nil until
   ;; the first real event, and there'd be nothing to render.
-  (story/reg-variant :story.login/empty
+  (rf.story/reg-variant :story.login/empty
     {:compose    [:fragment.login/form-base]
      :doc        "Fresh form, nothing typed, no submit clicked — the
                  `:idle` entry state a user lands on. Email + password
@@ -216,7 +216,7 @@
   ;; `:auth.login/edit-password`), which write into the app-db slice. The
   ;; machine stays `:idle`, and the inputs show the seeded draft as their
   ;; `:value`. No shortcuts.
-  (story/reg-variant :story.login/filled
+  (rf.story/reg-variant :story.login/filled
     {:compose    [:fragment.login/form-base]
      :doc        "Both fields filled in, nothing submitted yet — the form
                  mid-edit. The draft was typed into the app-db login-form slice
@@ -237,14 +237,14 @@
   ;; `:success` / `:failure` ever fires, so the canvas is stuck in `:submitting`
   ;; (`:auth/busy`) — inputs disabled, button reading "Signing in…". A
   ;; freeze-frame of the in-flight moment.
-  (story/reg-variant :story.login/submitting
+  (rf.story/reg-variant :story.login/submitting
     {:compose    [:fragment.login/form-base]
      :doc        "First submit; the HTTP request is in flight. Inputs
                  are disabled and the button reads 'Signing in…'. The
                  fx-stub records the `:rf.http/managed` request and
                  resolves nothing, so the canvas locks in `:submitting`."
      :setup      [[:login.story/submit good-creds]]
-     :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
+     :decorators [[rf.story/force-fx-stub-id :rf.http/managed {}]]
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
@@ -254,7 +254,7 @@
   ;; slice, `:submit-attempted?` latches, and nothing is dispatched — so the
   ;; machine never leaves `:idle` and the form shows what's wrong under each
   ;; input.
-  (story/reg-variant :story.login/invalid-credentials
+  (rf.story/reg-variant :story.login/invalid-credentials
     {:compose    [:fragment.login/form-base]
      :doc        "A bad draft (bad email + too-short password) is caught by
                  `submit-form`'s pre-submit `Credentials` validation: field
@@ -273,7 +273,7 @@
   ;; outcome by hand is the standard Story move for pinning a precise terminal
   ;; state without being at the mercy of timing. The flow settles at
   ;; `:error-shown`, error message and all.
-  (story/reg-variant :story.login/auth-error
+  (rf.story/reg-variant :story.login/auth-error
     {:compose    [:fragment.login/form-base]
      :doc        "Server rejected the credentials. The form is re-enabled and
                  the error message surfaces under the submit button
@@ -291,7 +291,7 @@
   ;; the `:lock-account` request (a real `:rf.http/managed` call). There's no
   ;; shortcut to "three strikes already used", so this variant simply walks
   ;; the path: submit → failure, four times over, until the limit is spent.
-  (story/reg-variant :story.login/locked-out
+  (rf.story/reg-variant :story.login/locked-out
     {:compose    [:fragment.login/form-base]
      :doc        "Too many failed attempts — the `:under-retry-limit`
                  guard fails on the fourth failure and the flow reaches
@@ -311,7 +311,7 @@
                   [:auth.login/flow [:auth.login/submit]]
                   [:auth.login/flow [:auth.login/failure
                                      (failure-reply 423 "Account locked.")]]]
-     :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
+     :decorators [[rf.story/force-fx-stub-id :rf.http/managed {}]]
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
@@ -320,7 +320,7 @@
   ;; real `:rf.http/managed` fx → canned reply → `:auth.login/success` →
   ;; `:authed`. Open this one, hit Ctrl+Shift+C, and watch the full chain march
   ;; across Xray's Epoch / Trace / Side Effects panels.
-  (story/reg-variant :story.login/success
+  (rf.story/reg-variant :story.login/success
     {:compose    [:fragment.login/form-base]
      :doc        "Server accepted the credentials. The form is replaced
                  by the 'Welcome!' banner (`:authed`). The full
@@ -341,7 +341,7 @@
   ;; editing this workspace.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-workspace :Workspace.login/all-states
+  (rf.story/reg-workspace :Workspace.login/all-states
     {:doc      "Every login state, side by side in narrative order:
                empty → filled → submitting → invalid → auth-error →
                locked-out → success."
@@ -356,7 +356,7 @@
      :columns  3
      :tags     #{:docs}})
 
-  (story/reg-workspace :Workspace.login/auto-grid
+  (rf.story/reg-workspace :Workspace.login/auto-grid
     {:doc     "Auto-enumerated grid — pulls every variant off
               :story.login. New variants appear here without touching
               this workspace."

--- a/examples/core/login/stories_host.cljs
+++ b/examples/core/login/stories_host.cljs
@@ -43,7 +43,7 @@
    bundle-isolation gate fails the build if any Story or Xray sentinel sneaks
    into the plain `:examples/login` output."
   (:require [re-frame.core  :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             [day8.re-frame2-xray.config :as xray-config]
             ;; Pull in the example's registrations (machine / schemas / demo
             ;; fx / subs / views) and its Story artefacts. We get `login.core`
@@ -52,7 +52,7 @@
             [login.stories]
             ;; The shared Story-host helper, which owns the fiddly bits: the
             ;; live-app↔Story-shell hash router and the React-root handle.
-            [re-frame.testbed.story-host :as story-host]))
+            [re-frame.testbed.story-host :as rf.testbed.story-host]))
 
 ;; -- The live-app frame ----------------------------------------------------
 ;;
@@ -112,7 +112,7 @@
   ;; panel open — the page should land on the app or the shell first, and the
   ;; reader pops Xray with Ctrl+Shift+C when they want it.
   (xray-config/configure! {:rf.xray/auto-open? false})
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   ;; No `(story/install-canonical-vocabulary!)` call needed: the first
   ;; `reg-*` over in `login.stories` (loaded via the require above) installs
   ;; the canonical Story vocabulary for us.
@@ -124,4 +124,4 @@
   ;; request time, so the 'open in editor' chips land on the real file with
   ;; nothing to configure. We pass `live-app-root` (not the bare `login-app`)
   ;; so the `#/` surface arrives already wrapped in its frame.
-  (story-host/mount-with-hash-routing! live-app-root))
+  (rf.testbed.story-host/mount-with-hash-routing! live-app-root))

--- a/examples/core/managed_http_counter/core.cljs
+++ b/examples/core/managed_http_counter/core.cljs
@@ -47,12 +47,12 @@
             ;; The write seam (`record-in-flight!`) isn't on the public facade,
             ;; so we reach for the registry ns directly. It's the same atom the
             ;; live transport writes into and the live abort fx resolves.
-            [re-frame.http.registry :as http-registry]
+            [re-frame.http.registry :as rf.http.registry]
             ;; The verb helpers (rf.http/get / post / put / delete / patch /
             ;; head / options). Each builds the canonical
             ;; [:rf.http/managed args-map] vector so the call site stays a line.
             [re-frame.http :as rf.http]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; ============================================================================
 ;; APP-DB SHAPE
@@ -221,7 +221,7 @@
     ;; here and hand it to the deferred dispatch ourselves. See
     ;; docs/core/glossary.md#frame-identity-is-carried-not-found.
     (let [frame (:frame frame-ctx)]
-      (http-registry/record-in-flight!
+      (rf.http.registry/record-in-flight!
         request-id nil
         {:url      long-pending-url
          ;; The :abort-fn is the request's cancellation hook — the thing that
@@ -233,7 +233,7 @@
          ;; :http-counter/start-long. The live fx would deliver it via `:reply-to`,
          ;; so we mirror that: the canonical envelope is the appended last arg.
          :abort-fn (fn [reason]
-                     (http-registry/clear-in-flight! request-id)
+                     (rf.http.registry/clear-in-flight! request-id)
                      ;; The canonical abort reply uses `:status :cancelled`
                      ;; with `:cancelled? true`, carries the abort reason
                      ;; under the uniform reply contract's namespaced field
@@ -337,7 +337,7 @@
 ;; side effects, so that two example namespaces sharing a page can't race each
 ;; other to call `create-root` on the same `#app`.
 
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 ;; The app stands its frame up in exactly one place: the render root's
 ;; `frame-root {:id app-frame}`. On the first mount that provider creates
@@ -359,7 +359,7 @@
 (defn ^:dev/after-load mount! []
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById "app"))]
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id app-frame
                       :initial-events [[:http-counter/initialise]]}
        [counter-app]]
@@ -369,5 +369,5 @@
   ;; `init!` installs the Reagent adapter — and only the adapter. You hand it
   ;; the adapter spec map (every adapter ns exports one as `adapter`). It does
   ;; not create a frame; that's the frame-root's job, in `mount!`.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))

--- a/examples/core/notebook/core.cljs
+++ b/examples/core/notebook/core.cljs
@@ -36,7 +36,7 @@
   ;; same app runs on UIx. See docs/core/glossary.md#adapter.
   (:require [clojure.string     :as str]
             [re-frame.core      :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; ============================================================================
 ;; SEED DATA
@@ -374,7 +374,7 @@
 ;; container. Defer the mount and they stay out of each other's way. See
 ;; examples/TESTING.md (mount-isolation convention).
 
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 ;; re-frame2 won't conjure a frame for you — an app stands up its own. We
 ;; do it in exactly one place: the `frame-root {:id app-frame}` in
@@ -395,7 +395,7 @@
 (defn ^:dev/after-load mount! []
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById "app"))]
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id app-frame
                       :initial-events [[:notebook/initialise]]}
        [notebook]]
@@ -404,5 +404,5 @@
 (defn run []
   ;; One job each: `init!` tells the runtime to render through Reagent. It
   ;; does not make a frame — the `frame-root` in `mount!` does that.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))

--- a/examples/core/seven_guis/cells/core.cljs
+++ b/examples/core/seven_guis/cells/core.cljs
@@ -36,7 +36,7 @@
             ;; Pulled in for its side effect: loading it wires up the hooks that
             ;; make `rf/reg-app-schema` actually do something.
             [re-frame.schemas]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             [clojure.set]
             [clojure.string :as str]))
 
@@ -480,7 +480,7 @@
 ;; load time. Loading a namespace must not touch the DOM — otherwise several
 ;; example namespaces sharing this page would all race to call `create-root` on
 ;; the same `#app` element. Once is plenty.
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 ;; The frame's whole life happens in one place: the `frame-root` down in
 ;; `mount!`. First mount creates the frame, applies its config, and fires
@@ -503,7 +503,7 @@
 (defn ^:dev/after-load mount! []
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById "app"))]
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id app-frame
                       :initial-events [[:cells/initialise]]}
        [cells-grid]]
@@ -513,5 +513,5 @@
   ;; `init!` tells re-frame2 which reactive substrate to render through — here,
   ;; Reagent. Every adapter namespace exports an `adapter` var; you require the
   ;; namespace and hand that var straight in.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))

--- a/examples/core/seven_guis/circle_drawer/core.cljs
+++ b/examples/core/seven_guis/circle_drawer/core.cljs
@@ -25,7 +25,7 @@
             ;; Pulling in `re-frame.schemas` wires up the hooks that teach
             ;; `rf/reg-app-schema` how to do its job. Require it, then use it.
             [re-frame.schemas]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; ============================================================================
 ;; SCHEMA
@@ -301,7 +301,7 @@
 ;; — otherwise two example namespaces sharing one page would both lunge for the
 ;; same `#app` and race each other to `create-root`. See the mount-isolation
 ;; convention in examples/TESTING.md.
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 ;; The frame's whole life story happens in one place: the
 ;; `frame-root {:id app-frame …}` down in `mount!`. On the first mount it
@@ -324,7 +324,7 @@
 (defn ^:dev/after-load mount! []
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById "app"))]
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id app-frame
                       :initial-events [[:drawer/initialise]]}
        [drawer-view]]
@@ -332,5 +332,5 @@
 
 (defn run []
   ;; `init!` tells re-frame2 to render through Reagent. One adapter, one process.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))

--- a/examples/core/seven_guis/crud/core.cljs
+++ b/examples/core/seven_guis/crud/core.cljs
@@ -28,7 +28,7 @@
             ;; is what makes `rf/reg-app-schema` below mean anything. Guide:
             ;; docs/core/how-to/validate-with-schemas.md.
             [re-frame.schemas]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; ============================================================================
 ;; SCHEMA
@@ -230,7 +230,7 @@
 ;; example namespaces get required into one test page, and if each grabbed the
 ;; shared `#app` on load they'd trample each other. Deferring to `run` keeps them
 ;; out of each other's way. See examples/TESTING.md (Example mount-isolation).
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 ;; The frame's whole life happens in one place: the `frame-root {:id app-frame …}`
 ;; down in `mount!`. On the first mount it creates the frame, applies its config,
@@ -253,7 +253,7 @@
 (defn ^:dev/after-load mount! []
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById "app"))]
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id             app-frame
                       :initial-events [[:crud/initialise]]}
        [crud-view]]
@@ -262,5 +262,5 @@
 (defn run []
   ;; `init!` tells the runtime to render through Reagent — once, for the whole
   ;; process. It picks the substrate; it does not create a frame.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))

--- a/examples/core/seven_guis/flight_booker/core.cljs
+++ b/examples/core/seven_guis/flight_booker/core.cljs
@@ -25,7 +25,7 @@
             ;; Loading re-frame.schemas registers its late-bind hooks, which
             ;; is what makes rf/reg-app-schema resolve below.
             [re-frame.schemas]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; ============================================================================
 ;; SCHEMA
@@ -236,7 +236,7 @@
 ;; ns-load. Loading a namespace must do no DOM side effects, so that co-loaded
 ;; example namespaces don't race each other to `create-root` onto the shared
 ;; `#app`. See examples/TESTING.md, the Example mount-isolation convention.
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 ;; The whole frame lifecycle lives in one place: the `frame-root {:id
 ;; app-frame …}` at the render root below. On first mount it creates the app
@@ -255,7 +255,7 @@
 (defn ^:dev/after-load mount! []
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById "app"))]
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id app-frame
                       :initial-events [[:flight/initialise]]}
        [flight-booker]]
@@ -264,5 +264,5 @@
 (defn run []
   ;; `init!` installs the reactive adapter for the process. The adapter ns
   ;; exports an `adapter` var; pass it straight in.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))

--- a/examples/core/seven_guis/temperature/core.cljs
+++ b/examples/core/seven_guis/temperature/core.cljs
@@ -26,7 +26,7 @@
             ;; hooks that make `rf/reg-app-schema` resolve. No var from it is
             ;; used directly — it just has to be on the page.
             [re-frame.schemas]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; ============================================================================
 ;; SCHEMA
@@ -189,7 +189,7 @@
 ;; example namespaces required together would both grab for the shared `#app`
 ;; element and race to `create-root` on it — and a race in your test harness is
 ;; precisely the bug you don't want. See examples/TESTING.md, "mount-isolation".
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 ;; The frame's whole life story fits in one place: the `frame-root {:id
 ;; app-frame …}` in `mount!` below. First mount creates the frame and runs its
@@ -214,7 +214,7 @@
 (defn ^:dev/after-load mount! []
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById "app"))]
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id app-frame
                       :initial-events [[:temp/initialise]]}
        [temperature-converter]]
@@ -226,5 +226,5 @@
   ;; pass that var. One call, at startup. Note it installs the adapter, not a
   ;; frame — the frame comes later, via the provider in `mount!`.
   ;; See `docs/core/glossary.md#init`.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))

--- a/examples/core/seven_guis/timer/core.cljs
+++ b/examples/core/seven_guis/timer/core.cljs
@@ -26,7 +26,7 @@
             ;; Pulling this in registers the hooks that teach the frame how to
             ;; validate against a schema — that's what makes `rf/reg-app-schema` work.
             [re-frame.schemas]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 (def tick-ms
   "Wall-clock delay, in milliseconds, between one tick and the next. 100ms is
@@ -198,7 +198,7 @@
 ;; ns-load. Loading a namespace shouldn't touch the DOM — if it did, two example
 ;; namespaces loaded together would both race to `create-root` the shared `#app`
 ;; element, and exactly one of them would win. Lazy keeps that drama away.
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 ;; All the frame's lifecycle happens in one spot — the `frame-root` in
 ;; `mount!` below. On first mount it creates the frame, applies its config, and fires
@@ -219,7 +219,7 @@
 (defn ^:dev/after-load mount! []
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById "app"))]
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id app-frame
                       :initial-events [[:timer/initialise]]}
        [timer-view]]
@@ -228,5 +228,5 @@
 (defn run []
   ;; `init!` tells the runtime to render through the Reagent adapter. That's all
   ;; it does — it does *not* create a frame. The `frame-root` in `mount!` does that.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))

--- a/examples/core/todomvc/core.cljs
+++ b/examples/core/todomvc/core.cljs
@@ -5,15 +5,15 @@
   Everything else leans on this wiring. `init!` picks the reactive substrate
   (here, Reagent). The render root is a `frame-root {:id …}`: on first
   mount it creates the app frame, marks it `:url-bound?` so the frame owns the
-  address bar, and declares `:url-strategy routing/hash-url-strategy` so the router
+  address bar, and declares `:url-strategy rf.routing/hash-url-strategy` so the router
   speaks hash URLs (`#/active`) — because TodoMVC's URLs are hash-based. The
   frame is seeded once via `:initial-events`. In re-frame2 the URL is just an
   input and navigation is just an event; the router's hash strategy handles the
   `#` on both sides, so this app uses `route-link` / `rf.route/navigate` like
   every other example. See docs/core/frames.md."
   (:require [re-frame.core :as rf]
-            [re-frame.routing :as routing]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.routing :as rf.routing]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             [todomvc.events]
             [todomvc.subs]
             [todomvc.views :as views]))
@@ -37,18 +37,18 @@
 ;; the app frame and runs `:initial-events`; every reload after that reuses the
 ;; same frame and skips the seed, so your todos survive a code change.
 ;;
-;; `:url-strategy routing/hash-url-strategy` is the one line that makes this a hash
+;; `:url-strategy rf.routing/hash-url-strategy` is the one line that makes this a hash
 ;; app. It tells the router to encode `route-url` output as `#/active` at the
 ;; egress points (link hrefs, pushState) and decode `window.location.hash` back
 ;; to a path on the way in. `route-url` and `match-url` stay path-form; only the
 ;; browser address-bar shape changes.
 
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 (defn ^:dev/after-load mount! []
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById "app"))]
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       ;; The seed is just `[:todo/initialise]` — it folds the saved
       ;; todos (via the `:todo.storage/todos` coeffect in db.cljs)
       ;; into app-db. The initial URL sync happens automatically:
@@ -59,7 +59,7 @@
       [rf/frame-root {:id             app-frame
                       :doc            "TodoMVC demo frame."
                       :url-bound?     true
-                      :url-strategy   routing/hash-url-strategy
+                      :url-strategy   rf.routing/hash-url-strategy
                       :initial-events [[:todo/initialise]]}
        [views/root-view]]
       el)))
@@ -82,7 +82,7 @@
 ;; See docs/routing/concepts.md#the-browser-is-just-another-event-source.
 
 (defn- boot! []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))
 
 (defn run []          ; shadow :init-fn — runs once, at page load

--- a/examples/patterns/boot/core.cljs
+++ b/examples/patterns/boot/core.cljs
@@ -20,13 +20,13 @@
    (docs/resources/glossary.md#reply-map)."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            ;; `registrar/handler` looks up the framework's canonical
+            ;; `rf.registrar/handler` looks up the framework's canonical
             ;; canned-success fx handler so the demo stub can DELEGATE to it
             ;; (with an `:after-ms` delay) instead of hand-rolling the latency
             ;; plumbing.
-            [re-frame.registrar :as registrar]
+            [re-frame.registrar :as rf.registrar]
             ;; The adapter `rf/init!` needs.
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             ;; Managed HTTP ships in its own artefact; this require
             ;; registers `:rf.http/managed` and family. Without it, every
             ;; child loader's fetch would raise :rf.error/no-such-fx.
@@ -108,7 +108,7 @@
   (fn fx-managed-boot-demo [frame-ctx args-map]
     (let [url            (-> args-map :request :url)
           payload        (demo-payload-for-url url)
-          canned-success (registrar/handler :fx :rf.http/managed-canned-success)]
+          canned-success (rf.registrar/handler :fx :rf.http/managed-canned-success)]
       ;; Delegate to the framework canned-success handler. Passing `frame-ctx`
       ;; straight through preserves the `:frame` stamp and the originating
       ;; `:event`, so the deferred reply is addressed to the loader that
@@ -126,7 +126,7 @@
 ;; it there rather than at ns-load so several example namespaces can share one
 ;; browser-test bundle without two of them racing `create-root` onto the same
 ;; `#app` element.
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 ;; The app frame id. Every in-tree `dispatch`/`subscribe` resolves to this
 ;; frame, which the frame-root below stands up. An app always names its
@@ -147,7 +147,7 @@
     ;; - `:initial-events` fires `:boot/initialise` once on first mount to
     ;;   kick the boot off. A hot reload reuses the frame and leaves the boot
     ;;   alone, so you don't re-run it on every save.
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id             app-frame
                       :doc            "Boot example demo frame."
                       :fx-overrides   {:rf.http/managed :boot.demo/http-stub}
@@ -157,5 +157,5 @@
 
 (defn run []
   ;; Hand the adapter's spec map straight to `init!`.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))

--- a/examples/patterns/long_running_work/core.cljs
+++ b/examples/patterns/long_running_work/core.cljs
@@ -53,7 +53,7 @@
   ;; finally-clause that fires the `:cancel` cascade when the view
   ;; unmounts, riding on Reagent's own `reagent.core/with-let`.
   (:require [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             ;; Requiring re-frame.machines is what installs the machine
             ;; runtime: the :spawn-all init / spawn / destroy fx handlers
             ;; and the `:rf/machine` sub. worker.cljs and views.cljs pull
@@ -91,7 +91,7 @@
 ;; browser, and two co-loaded examples won't race to plant rival roots
 ;; on the shared `#app` element.
 
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 ;; The frame comes from the `frame-root {:id app-frame …}` at the
 ;; render root below. First mount creates the frame, applies its config,
@@ -108,7 +108,7 @@
 (defn ^:dev/after-load mount! []
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById "app"))]
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id app-frame
                       :initial-events [[:app/initialise]]}
        [views/root-view]]
@@ -117,5 +117,5 @@
 (defn run []
   ;; Install the Reagent adapter, then mount the provider that stands
   ;; the frame up (see above).
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))

--- a/examples/patterns/nine_states/core.cljs
+++ b/examples/patterns/nine_states/core.cljs
@@ -74,7 +74,7 @@
    codebase would spread it across schema / events / subs / views /
    machines files."
   (:require [re-frame.core :as rf]
-            [re-frame.registrar :as registrar]
+            [re-frame.registrar :as rf.registrar]
             ;; Schemas ship as their own artefact, day8/re-frame2-schemas.
             ;; Requiring this ns wires up the hooks the `rf/reg-app-schema`
             ;; call below leans on.
@@ -91,7 +91,7 @@
             ;; (`:rf.http/managed-canned-success` / `-failure`). Our little
             ;; per-app demo stub below just delegates to these.
             [re-frame.http.test-support]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; ============================================================================
 ;; CONSTANTS
@@ -218,14 +218,14 @@
     (let [url (-> args-map :request :url str)]
       (cond
         (= url "/api/todos/fail")
-        (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+        (let [stub (rf.registrar/handler :fx :rf.http/managed-canned-failure)]
           (stub frame-ctx (assoc args-map
                                  :kind :rf.http/transport
                                  :tags {:message "Network unreachable."})))
 
         :else
         (let [todo-count (or (-> args-map :request :query :n) 0)
-              stub (registrar/handler :fx :rf.http/managed-canned-success)]
+              stub (rf.registrar/handler :fx :rf.http/managed-canned-success)]
           (stub frame-ctx (assoc args-map :value (generate-todos todo-count))))))))
 
 ;; ============================================================================
@@ -818,7 +818,7 @@
 ;; has zero DOM side effects, and the namespaces coexist in one build
 ;; without a fuss.
 
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 ;; DOM setup lives in `mount!`, tagged `^:dev/after-load` so shadow-cljs re-runs
 ;; it after each hot reload — edited views re-render into the same root and frame.
@@ -838,7 +838,7 @@
   ;; attached to.
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById "app"))]
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id             :rf/default
                       :doc            "Nine-states demo frame."
                       :fx-overrides   {:rf.http/managed :nine-states.http/managed-demo}
@@ -849,5 +849,5 @@
 (defn run []
   ;; Tell the runtime which substrate to render through. Just the adapter —
   ;; no frame yet.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))

--- a/examples/patterns/nine_states/stories.cljs
+++ b/examples/patterns/nine_states/stories.cljs
@@ -82,7 +82,7 @@
    vocabulary installs itself on the first `reg-*` call, so there's no boot
    step to remember."
   (:require [re-frame.core :as rf]
-            [re-frame.story :as story]
+            [re-frame.story :as rf.story]
             ;; Pull in the example's own registrations — the machine, the
             ;; demo events / subs / views, the `:ui/render` selector. The
             ;; variant bodies below name its event-ids and `root-view` as
@@ -177,7 +177,7 @@
   ;; reg-tag — a project tag that flags the one variant we screenshot.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-tag :nine-states/canonical
+  (rf.story/reg-tag :nine-states/canonical
     {:doc "Marks the variant that ships as the example's canonical
           screenshot — the `:some` standard-list state. The face of the
           example, so to speak."})
@@ -188,7 +188,7 @@
   ;; variants only have to spell out their own per-state setup.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-story :story.nine-states
+  (rf.story/reg-story :story.nine-states
     {:doc        "The Nine States of UI — every canonical view-state of
                  the todos page, each driven through the `:ui/nine-states`
                  parallel machine."
@@ -196,7 +196,7 @@
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
-  (story/reg-story :story.nine-states-lifecycle
+  (rf.story/reg-story :story.nine-states-lifecycle
     {:doc        "The RemoteData fetch lifecycle as a stepped cascade —
                  load → loading → loaded / error. Kept apart from the
                  canonical nine so the async path (and its Xray Epoch /
@@ -215,7 +215,7 @@
   ;; -------------------------------------------------------------------------
 
   ;; State 1 — Nothing. Initialise the form slice and reset the machine.
-  (story/reg-variant :story.nine-states/nothing
+  (rf.story/reg-variant :story.nine-states/nothing
     {:doc        "State 1 — Nothing. Never fetched; the `:data` region
                  sits at `:nothing`. The blank-slate welcome screen with a
                  'Get started' nudge."
@@ -226,7 +226,7 @@
   ;; State 2 — Loading. `:fetch-started` parks the `:data` region at
   ;; `:loading`, and since no reply is ever sent it stays put — perfect for
   ;; a screenshot of a spinner that never resolves.
-  (story/reg-variant :story.nine-states/loading
+  (rf.story/reg-variant :story.nine-states/loading
     {:doc        "State 2 — Loading. A first fetch is in flight; the
                  `:data` region is parked at `:loading` (a `:fetch-started`
                  with no reply behind it). The spinner view."
@@ -236,7 +236,7 @@
      :substrates #{:reagent}})
 
   ;; State 3 — Empty. Load zero todos and the `:always`-cascade picks `:empty`.
-  (story/reg-variant :story.nine-states/empty
+  (rf.story/reg-variant :story.nine-states/empty
     {:doc        "State 3 — Empty. Fetched, but the result came back empty.
                  The `:always`-cascade reads a count of zero and picks
                  `:empty`."
@@ -246,7 +246,7 @@
      :substrates #{:reagent}})
 
   ;; State 4 — One. Exactly one todo, so the cascade picks `:one`.
-  (story/reg-variant :story.nine-states/one
+  (rf.story/reg-variant :story.nine-states/one
     {:doc        "State 4 — One. Exactly one todo; the focused
                  single-item layout (the `:one` cardinality bucket)."
      :setup      [[:nine-states.app/initialise]
@@ -255,7 +255,7 @@
      :substrates #{:reagent}})
 
   ;; State 5 — Some. A small, manageable list — and the canonical screenshot.
-  (story/reg-variant :story.nine-states/some
+  (rf.story/reg-variant :story.nine-states/some
     {:doc        "State 5 — Some. A small, manageable list, rendered
                  plainly (the `:some` cardinality bucket). This is the
                  example's canonical screenshot."
@@ -265,7 +265,7 @@
      :substrates #{:reagent}})
 
   ;; State 6 — Too Many. Push past the threshold and get search + truncation.
-  (story/reg-variant :story.nine-states/too-many
+  (rf.story/reg-variant :story.nine-states/too-many
     {:doc        "State 6 — Too Many. More items than the too-many
                  threshold (7), so the view switches to search +
                  truncation (the `:too-many` cardinality bucket)."
@@ -275,7 +275,7 @@
      :substrates #{:reagent}})
 
   ;; State 7 — Incorrect. Type a too-short title, submit → `:submit-invalid`.
-  (story/reg-variant :story.nine-states/incorrect
+  (rf.story/reg-variant :story.nine-states/incorrect
     {:doc        "State 7 — Incorrect. A too-short title trips the form
                  validator on submit; the `:form` region lands at
                  `:incorrect` (via `:submit-invalid`) and the inline
@@ -287,7 +287,7 @@
      :substrates #{:reagent}})
 
   ;; State 8 — Correct. Type a valid title, submit → `:submit-valid`.
-  (story/reg-variant :story.nine-states/correct
+  (rf.story/reg-variant :story.nine-states/correct
     {:doc        "State 8 — Correct. A valid title sails through the form
                  validator on submit; the `:form` region lands at
                  `:correct` (via `:submit-valid`) and the success
@@ -299,7 +299,7 @@
      :substrates #{:reagent}})
 
   ;; State 9 — Done. Load some items, then archive → `:mode` reaches `:done`.
-  (story/reg-variant :story.nine-states/done
+  (rf.story/reg-variant :story.nine-states/done
     {:doc        "State 9 — Done. Load a few todos, then archive: the
                  `:mode` region reaches its terminal, read-only `:done`
                  state and the form and controls all grey themselves out."
@@ -315,7 +315,7 @@
   ;; alongside :loading and :some.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-variant :story.nine-states-lifecycle/loading
+  (rf.story/reg-variant :story.nine-states-lifecycle/loading
     {:doc        "Lifecycle — the in-flight `:loading` step. Same as the
                  canonical Loading variant, shown here as the opening arm
                  of the fetch cascade."
@@ -324,7 +324,7 @@
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.nine-states-lifecycle/loaded
+  (rf.story/reg-variant :story.nine-states-lifecycle/loaded
     {:doc        "Lifecycle — the resolved `:some` step. The full
                  `:rf.http/managed` cascade runs in `:setup`, so pick this
                  variant and watch the fetch play out across Xray's Epoch /
@@ -334,7 +334,7 @@
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.nine-states-lifecycle/error
+  (rf.story/reg-variant :story.nine-states-lifecycle/error
     {:doc           "Lifecycle — the `:error` branch. This is the one
                     variant that wants its fetch to fail, so it stamps
                     `:fx-overrides {:rf.http/managed
@@ -362,7 +362,7 @@
   ;; is what you want for a stable README screenshot.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-workspace :Workspace.nine-states/all-states
+  (rf.story/reg-workspace :Workspace.nine-states/all-states
     {:doc      "Every canonical state, side by side in render order."
      :layout   :grid
      :variants [:story.nine-states/nothing
@@ -377,7 +377,7 @@
      :columns  3
      :tags     #{:docs}})
 
-  (story/reg-workspace :Workspace.nine-states/auto-grid
+  (rf.story/reg-workspace :Workspace.nine-states/auto-grid
     {:doc     "The set-it-and-forget-it grid — auto-pulls every variant off
               :story.nine-states, so new variants land here on their own."
      :layout  :variants-grid
@@ -385,7 +385,7 @@
      :columns 3
      :tags    #{:docs}})
 
-  (story/reg-workspace :Workspace.nine-states/lifecycle
+  (rf.story/reg-workspace :Workspace.nine-states/lifecycle
     {:doc      "The RemoteData fetch lifecycle as a left-to-right
               stepped row: loading → loaded → error."
      :layout   :grid

--- a/examples/patterns/nine_states/stories_host.cljs
+++ b/examples/patterns/nine_states/stories_host.cljs
@@ -46,7 +46,7 @@
    that the Story / Xray sentinels never show up in the plain
    `:examples/nine-states` build."
   (:require [re-frame.core  :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             [day8.re-frame2-xray.config :as xray-config]
             ;; Pull in the example's registrations (machine / schemas / demo
             ;; events / subs / the `:ui/render` selector / views) and the
@@ -57,7 +57,7 @@
             ;; The shared Story-host helper — it owns the
             ;; live-app↔Story-shell hash router and the React-root handle,
             ;; so we don't have to.
-            [re-frame.testbed.story-host :as story-host]))
+            [re-frame.testbed.story-host :as rf.testbed.story-host]))
 
 ;; -- The live-app frame ----------------------------------------------------
 ;;
@@ -108,7 +108,7 @@
   ;; panel open on load — the page should show the live app / shell first,
   ;; and the reader opens Xray with Ctrl+Shift+C when they're ready.
   (xray-config/configure! {:rf.xray/auto-open? false})
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   ;; No `(story/install-canonical-vocabulary!)` call needed — the first
   ;; `reg-*` over in `nine-states.stories` (loaded via the require above)
   ;; installs the canonical Story vocabulary for us.
@@ -121,4 +121,4 @@
   ;; source paths at request time. The live-app root is already frame-scoped
   ;; by `live-app-root` (the `frame-provider` wrapper), so the bare `#/`
   ;; surface mounts under the app frame.
-  (story-host/mount-with-hash-routing! live-app-root))
+  (rf.testbed.story-host/mount-with-hash-routing! live-app-root))

--- a/examples/patterns/websocket/core.cljs
+++ b/examples/patterns/websocket/core.cljs
@@ -59,7 +59,7 @@
    `re-frame.websocket-cljs-test`). The example tree is test-free, so
    `npm run test:adapter-smokes` does not build this example."
   (:require [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             [websocket.schema]
             [websocket.connection]
             [websocket.messages]
@@ -101,7 +101,7 @@
 ;; container. Building it in `run` keeps loading this namespace free of
 ;; DOM side effects.
 
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 ;; One place owns the frame: the `frame-root` at the render root.
 ;; `run` installs the adapter, then renders `[frame-root {:id ...}
@@ -121,12 +121,12 @@
 (defn ^:dev/after-load mount! []
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById "app"))]
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id app-frame
                       :initial-events [[:ws.app/initialise]]}
        [views/root-view]]
       el)))
 
 (defn run []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (mount!))

--- a/examples/real-apps/realworld_http/core.cljs
+++ b/examples/real-apps/realworld_http/core.cljs
@@ -51,7 +51,7 @@
             ;; `:rf/hydrate` handler and the SSR helpers ssr.cljc leans on
             ;; (`rf/render-tree-hash`).
             [re-frame.ssr]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             [realworld-shared.avatar :as avatar]
             [realworld-http.schema]
             ;; Requiring http registers the demo `:rf.http/managed` override fx
@@ -293,7 +293,7 @@
 ;; tests, with React grumbling "createRoot called twice" the whole way. The
 ;; name `app-root` (not `root`) keeps it distinct from the `root-view`
 ;; above.
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 ;; ============================================================================
 ;; HTTP REQUEST INTERCEPTOR
@@ -409,7 +409,7 @@
     ;; act on the moment `GET /user` lands (auth.cljs §THE COLD-BOOT DEEP-LINK
     ;; WINDOW has the full sequence; rf2-k85nd is the bug that taught us).
     ;; No explicit `:rf.route/handle-url-change` initial event is needed.
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id              :rf/default
                       :doc             "Realworld demo frame."
                       :url-bound?      true
@@ -425,7 +425,7 @@
   ;; Tell re-frame2 to render through Reagent. This is the one genuinely
   ;; frameworky step, and it has to come before any frame mounts; everything
   ;; below it is just this app wiring itself up.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   ;; Register the Bearer-auth interceptor (defined above) so it stamps the
   ;; `Authorization` header onto outbound managed requests. Order matters:
   ;; register it before the frame's `:initial-events` run, so it's already on

--- a/examples/real-apps/realworld_http/routing.cljs
+++ b/examples/real-apps/realworld_http/routing.cljs
@@ -22,10 +22,10 @@
             ;; Routing lives in its own artefact. Requiring it registers the
             ;; hooks and subs that make the `rf/reg-route` calls below resolve.
             ;; This one IS aliased — ROUTER WIRING below builds
-            ;; `url-strategy` off `routing/with-base-path` +
-            ;; `routing/history-url-strategy`. See the routing guide:
+            ;; `url-strategy` off `rf.routing/with-base-path` +
+            ;; `rf.routing/history-url-strategy`. See the routing guide:
             ;; ../../../docs/routing/index.md
-            [re-frame.routing :as routing]
+            [re-frame.routing :as rf.routing]
             ;; For `auth/restoring-session?` — the ONE definition of the
             ;; cold-boot window in which identity is not yet known, shared with
             ;; the `:auth/restoring-session?` sub so the denial handler below
@@ -251,5 +251,5 @@
 ;; base-path-aware popstate listener AND does the first-load URL→state sync
 ;; automatically, so this namespace needs no separate listener or install call.
 (def url-strategy
-  (routing/with-base-path routing/history-url-strategy "/realworld"))
+  (rf.routing/with-base-path rf.routing/history-url-strategy "/realworld"))
 

--- a/examples/real-apps/realworld_http/ssr.cljc
+++ b/examples/real-apps/realworld_http/ssr.cljc
@@ -16,7 +16,7 @@
             ;; compiled-in constant; the payload sources `:rf/version` from it
             ;; rather than pinning a literal, so a future bump reaches every
             ;; producer for free.
-            [re-frame.ssr.payload-policy :as payload-policy]
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]
             #?(:cljs [cljs.reader :as reader])))
 
 (def ssr-app-slice-keys
@@ -66,7 +66,7 @@
   (`{:rf.db/app … :rf.db/runtime …}`, e.g. `(rf/frame-state-value frame-id)`).
   This is what the server embeds and the client reads back."
   [{:rf.db/keys [app runtime]} render-tree]
-  {:rf/version     payload-policy/pattern-protocol-version  ;; the SSR-owned constant, not a literal
+  {:rf/version     rf.ssr.payload-policy/pattern-protocol-version  ;; the SSR-owned constant, not a literal
    :rf/app-db      (exportable-app-db app)
    :rf/runtime-db  (exportable-runtime-db runtime)
    :rf/render-hash (rf/render-tree-hash render-tree)})

--- a/examples/real-apps/realworld_resources/core.cljs
+++ b/examples/real-apps/realworld_resources/core.cljs
@@ -41,7 +41,7 @@
             ;; key; the auth machine needs machines.
             [re-frame.routing]
             [re-frame.machines]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             [realworld-shared.avatar :as avatar]
             [realworld-resources.schema]
             [realworld-resources.scope]
@@ -228,7 +228,7 @@
 ;; MOUNT  (CLJS reference; client-only)
 ;; ============================================================================
 
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 (def app-frame :rf/default)
 
@@ -313,7 +313,7 @@
     ;; went looking for it. The session token seeded by `:auth/initialise` is
     ;; already in app-db by then, so the bearer-auth interceptor decorates
     ;; those reads on the way out.
-    (reagent-adapter/render! app-root
+    (rf.adapter.reagent/render! app-root
       [rf/frame-root {:id              app-frame
                       :doc             "RealWorld-on-resources demo frame."
                       :url-bound?      true
@@ -338,7 +338,7 @@
     (install-conduit-debug! app-frame)))
 
 (defn run []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   ;; Register the bearer-auth interceptor at boot, before the frame's
   ;; `:initial-events` dispatch. Timing matters: session-restore fires an
   ;; authenticated `GET /user` the moment the JWT is hydrated, so the header has

--- a/examples/real-apps/realworld_resources/routing.cljs
+++ b/examples/real-apps/realworld_resources/routing.cljs
@@ -38,8 +38,8 @@
             ;; The routing runtime. Loading it triggers its hook + reg-sub
             ;; registrations; without it the reg-route calls have nothing to hook
             ;; into. Aliased so ROUTER WIRING below can build `url-strategy` off
-            ;; `routing/with-base-path` + `routing/history-url-strategy`.
-            [re-frame.routing :as routing]
+            ;; `rf.routing/with-base-path` + `rf.routing/history-url-strategy`.
+            [re-frame.routing :as rf.routing]
             ;; Loading resources is what makes `:resources` route-metadata
             ;; accepted — it's the late-bound routing extension.
             [re-frame.resources]
@@ -350,4 +350,4 @@
 ;; `/realworld-resources`. `strip-base-path` fails safe on `/`, so the strategy
 ;; also boots correctly when the build is served at the server root.
 (def url-strategy
-  (routing/with-base-path routing/history-url-strategy "/realworld-resources"))
+  (rf.routing/with-base-path rf.routing/history-url-strategy "/realworld-resources"))

--- a/examples/real-apps/realworld_shared/demo_backend.cljs
+++ b/examples/real-apps/realworld_shared/demo_backend.cljs
@@ -57,7 +57,7 @@
    The RealWorld spec lives at
    https://github.com/gothinkster/realworld/tree/main/api."
   (:require [clojure.string :as str]
-            [re-frame.registrar :as registrar]))
+            [re-frame.registrar :as rf.registrar]))
 
 (def reply-delay-ms
   "How long the demo backend waits before handing back each canned reply (via
@@ -572,10 +572,10 @@
   (let [[next-state reply] (transition @state-atom args-map)]
     (reset! state-atom next-state)
     (if-let [failure (:failure reply)]
-      (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+      (let [stub (rf.registrar/handler :fx :rf.http/managed-canned-failure)]
         (stub frame-ctx (assoc args-map
                                :after-ms reply-delay-ms
                                :kind     (:kind failure)
                                :tags     (:tags failure))))
-      (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+      (let [stub (rf.registrar/handler :fx :rf.http/managed-canned-success)]
         (stub frame-ctx (assoc args-map :after-ms reply-delay-ms :value (:ok reply)))))))

--- a/examples/substrates/hicasso/login/core.cljs
+++ b/examples/substrates/hicasso/login/core.cljs
@@ -11,17 +11,17 @@
    entire.
 
    What changes here is the notation, and it changes more than on the UIx side:
-   Hicasso interprets Hiccup at runtime, so a view is an `h/defview` boundary
-   whose body reads subscriptions with `h/sub` and states its handlers as DATA.
-   `{:on-change [:auth.login/edit-field :email ::h/value]}` IS the handler —
-   there is no callback to write, and `::h/value` substitutes the event
+   Hicasso interprets Hiccup at runtime, so a view is an `rf.hicasso/defview` boundary
+   whose body reads subscriptions with `rf.hicasso/sub` and states its handlers as DATA.
+   `{:on-change [:auth.login/edit-field :email ::rf.hicasso/value]}` IS the handler —
+   there is no callback to write, and `::rf.hicasso/value` substitutes the event
    target's value at dispatch time. Reagent reaches for `reg-view` and an
    injected `dispatch`; UIx reaches for `defui` plus the `use-subscribe` hook.
    The subscription vectors and the event ids do not change one character
    across the three.
 
-   Two handlers here are `h/event` callbacks rather than intent vectors,
-   and both for a stated reason — see them below. `h/event` is Hicasso's one
+   Two handlers here are `rf.hicasso/event` callbacks rather than intent vectors,
+   and both for a stated reason — see them below. `rf.hicasso/event` is Hicasso's one
    callback form: at an `on-*` position a returned vector is dispatched and any
    other return is ignored.
 
@@ -39,19 +39,19 @@
             ;; boot below. It names no substrate — the Hicasso code lives only
             ;; here.
             [login.model :as model]
-            [re-frame.hicasso :as h]
-            ;; The client half of an SSR route: `ssr/hydrate!` installs the
+            [re-frame.hicasso :as rf.hicasso]
+            ;; The client half of an SSR route: `rf.ssr/hydrate!` installs the
             ;; server's app-db from `__rf_payload` BEFORE the first client
             ;; render. On a client-only load it finds no payload and is a
             ;; no-op, which is what lets ONE `run` serve both pages.
-            [re-frame.ssr :as ssr]
+            [re-frame.ssr :as rf.ssr]
             ;; Hicasso is a VIEW layer, not a substrate: it owns Hiccup
             ;; interpretation and the render boundary, while the reactive
             ;; container app-db lives in comes from an adapter. Hicasso ships
             ;; its own, in this namespace, so the choice costs no extra
             ;; coordinate (docs/core/hicasso/00-installation.md §Hicasso needs a
             ;; substrate adapter).
-            [re-frame.hicasso.substrate :as substrate]))
+            [re-frame.hicasso.substrate :as rf.hicasso.substrate]))
 
 ;; ============================================================================
 ;; THE SSR COORDINATES  (shared by the client boot and the server bundle)
@@ -79,11 +79,11 @@
   :rf/default)
 
 ;; ============================================================================
-;; VIEWS  (Hicasso — h/defview + h/sub + intents)
+;; VIEWS  (Hicasso — rf.hicasso/defview + rf.hicasso/sub + intents)
 ;; ============================================================================
 ;;
-;; `h/defview` mints a real React function component whose head is a legal
-;; hiccup tag: `[login-form]`. Inside the body `h/sub` reads a subscription
+;; `rf.hicasso/defview` mints a real React function component whose head is a legal
+;; hiccup tag: `[login-form]`. Inside the body `rf.hicasso/sub` reads a subscription
 ;; from the frame this root scoped — no deref, no hook, and legal inside a
 ;; `let`, a `when` or an inlined helper, because the edge is recorded where the
 ;; read happens.
@@ -93,14 +93,14 @@
 ;; event. There is no view-local state anywhere in this file — the draft is
 ;; app-db, which is the whole reason there is nothing here to keep in step.
 
-(h/defview login-form
+(rf.hicasso/defview login-form
   "The login form: email + password + submit + error display."
   [_]
-  (let [draft     (h/sub [:auth.login/draft])
-        busy?     (h/sub [:rf.machine/has-tag? :auth.login/flow :auth/busy])
-        err       (h/sub [:auth.login/error])
-        email-err (h/sub [:auth.login/field-error :email])
-        pw-err    (h/sub [:auth.login/field-error :password])]
+  (let [draft     (rf.hicasso/sub [:auth.login/draft])
+        busy?     (rf.hicasso/sub [:rf.machine/has-tag? :auth.login/flow :auth/busy])
+        err       (rf.hicasso/sub [:auth.login/error])
+        email-err (rf.hicasso/sub [:auth.login/field-error :email])
+        pw-err    (rf.hicasso/sub [:auth.login/field-error :password])]
     [:form.login-form
      {:data-testid "login-form"
       ;; CALLBACK 1 of 2. `:on-submit` is the one position Hicasso prevents by
@@ -110,28 +110,28 @@
       ;; guard is written where a condition belongs: in a callback that
       ;; prevents unconditionally and returns an event only when there is one
       ;; to send.
-      :on-submit   (h/event [e]
+      :on-submit   (rf.hicasso/event [e]
                      (.preventDefault e)
                      (when-not busy?
                        [:auth.login/submit-form]))}
      ;; The email is NOT a secret, so it rides the plain positional
      ;; `:auth.login/edit-field` — and the whole handler is the intent vector.
-     ;; `::h/value` is substituted with the event target's current value at
+     ;; `::rf.hicasso/value` is substituted with the event target's current value at
      ;; dispatch time.
      [:input {:type        "email"
               :placeholder "Email"
               :disabled    busy?
               :data-testid "login-email"
               :value       (:email draft)
-              :on-change   [:auth.login/edit-field :email ::h/value]}]
+              :on-change   [:auth.login/edit-field :email ::rf.hicasso/value]}]
      (when email-err [:p.error {:data-testid "login-email-error"} email-err])
      ;; CALLBACK 2 of 2. The password's keystrokes ride a MAP payload —
      ;; `[:auth.login/edit-password {:value …}]` — because its registration
      ;; declares `:sensitive [[:value]]` and redaction is path-based, so a
      ;; positional secret would ship raw to every trace
-     ;; (docs/core/how-to/keep-secrets-out-of-traces.md). `::h/value`
+     ;; (docs/core/how-to/keep-secrets-out-of-traces.md). `::rf.hicasso/value`
      ;; substitutes at the intent's TOP LEVEL only, by design, so building that
-     ;; map is exactly the case `h/event` exists for. Flattening the secret
+     ;; map is exactly the case `rf.hicasso/event` exists for. Flattening the secret
      ;; into a positional intent to save four characters would break the
      ;; classification.
      [:input {:type        "password"
@@ -139,7 +139,7 @@
               :disabled    busy?
               :data-testid "login-password"
               :value       (:password draft)
-              :on-change   (h/event [e]
+              :on-change   (rf.hicasso/event [e]
                              [:auth.login/edit-password
                               {:value (.. e -target -value)}])}]
      (when pw-err [:p.error {:data-testid "login-password-error"} pw-err])
@@ -151,7 +151,7 @@
 
 ;; The dead end. `:locked-out` is tagged `:auth/locked` and has no way out, so
 ;; the form is replaced rather than left on screen taking input and ignoring it.
-(h/defview locked-panel
+(rf.hicasso/defview locked-panel
   "Locked-account panel shown when the login flow reaches :locked-out."
   [_]
   [:div.locked {:data-testid "locked-panel"}
@@ -160,11 +160,11 @@
 
 ;; The top-level switch: two tag reads, three faces. Views ask the machine a
 ;; QUESTION (`:rf.machine/has-tag?`) rather than matching exact state names.
-(h/defview login-banner
+(rf.hicasso/defview login-banner
   "Picks what to show by login state: welcome / locked panel / the form."
   [_]
-  (let [authed? (h/sub [:rf.machine/has-tag? :auth.login/flow :auth/authenticated])
-        locked? (h/sub [:rf.machine/has-tag? :auth.login/flow :auth/locked])]
+  (let [authed? (rf.hicasso/sub [:rf.machine/has-tag? :auth.login/flow :auth/authenticated])
+        locked? (rf.hicasso/sub [:rf.machine/has-tag? :auth.login/flow :auth/locked])]
     [:div.banner {:data-testid "login-banner"}
      (cond
        authed? [:span "Welcome!"]
@@ -200,13 +200,13 @@
   (fn sub-auth-login-server-notice [db _]
     (:auth.login/server-notice db)))
 
-(h/defview server-notice
+(rf.hicasso/defview server-notice
   "The deployment notice, when there is one."
   [_]
-  (when-some [notice (h/sub [:auth.login/server-notice])]
+  (when-some [notice (rf.hicasso/sub [:auth.login/server-notice])]
     [:p.server-notice {:data-testid "login-server-notice"} notice]))
 
-(h/defview root-view
+(rf.hicasso/defview root-view
   "The example's root boundary."
   [_]
   [:div.app
@@ -234,14 +234,14 @@
 ;;      form slice before the first paint — skip that and the inputs read `nil`
 ;;      for their `:value` and React quietly demotes them to uncontrolled.
 ;;
-;;      Why here rather than inside the mount? Because `h/mount!`'s config
+;;      Why here rather than inside the mount? Because `rf.hicasso/mount!`'s config
 ;;      carries exactly three keys — `:frame`, `:initial-events` and
 ;;      `:identifier-prefix` — and `:fx-overrides` is not among them. That is
 ;;      the root door's shape, not an omission, and the example bends to it
-;;      rather than the other way around: no shim is added to `h/mount!` for
+;;      rather than the other way around: no shim is added to `rf.hicasso/mount!` for
 ;;      this file's convenience.
 ;;
-;;   3. `h/mount!` associates the DOM node, the frame and one root view.
+;;   3. `rf.hicasso/mount!` associates the DOM node, the frame and one root view.
 ;;      Mounting ENSURES its frame: it creates the frame when absent and JOINS
 ;;      the live one otherwise. Step 2 already created `:rf/default`, so this
 ;;      joins it untouched — no re-seed, no config refresh — which is why
@@ -257,17 +257,17 @@
   !root
   (atom nil))
 
-;; Shadow's cue to re-run this after each reload. `h/render!` reconciles the new
+;; Shadow's cue to re-run this after each reload. `rf.hicasso/render!` reconciles the new
 ;; tree against the DOM already on the page, so edited views meet their own
-;; nodes and the frame beneath them is untouched. Calling `h/mount!` again would
+;; nodes and the frame beneath them is untouched. Calling `rf.hicasso/mount!` again would
 ;; `createRoot` a second time and throw away every node, subscription and scrap
 ;; of component state.
 (defn ^:dev/after-load re-render! []
   (when-some [root @!root]
-    (h/render! root [root-view])))
+    (rf.hicasso/render! root [root-view])))
 
 ;; ONE boot, two pages. A client-only load has no `__rf_payload` in the
-;; document, so `ssr/hydrate!` is a no-op and the root MOUNTS — exactly the
+;; document, so `rf.ssr/hydrate!` is a no-op and the root MOUNTS — exactly the
 ;; three lines above. A server-rendered load has one, so the payload is
 ;; installed first and the root ADOPTS the markup already on the page
 ;; instead of throwing it away.
@@ -276,24 +276,24 @@
 ;; one bundle serves both, so `npm run dev:example -- examples/login-hicasso`
 ;; keeps working unchanged and the SSR route needs no second build.
 ;;
-;; No `:render-tree-fn` is passed to `ssr/hydrate!`. The render-tree hash is
+;; No `:render-tree-fn` is passed to `rf.ssr/hydrate!`. The render-tree hash is
 ;; hiccup-tier-only, and this is an adoption-tier root: Hicasso's server
 ;; render ships no `:rf/render-hash` and there is nothing to compare
 ;; against. Adoption is verified by React itself — a divergence surfaces as
 ;; a recoverable error on this root's own stream.
 
 (defn run []
-  (rf/init! substrate/adapter)
+  (rf/init! rf.hicasso.substrate/adapter)
   (rf/make-frame (merge {:id  frame-id
                          :doc "Login (Hicasso) demo frame."}
                         model/frame-config))
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById app-element-id))]
-    (let [payload (ssr/read-server-payload)
+    (let [payload (rf.ssr/read-server-payload)
           config  {:frame             frame-id
                    :identifier-prefix identifier-prefix}]
       (if (some? payload)
-        (do (ssr/hydrate! {:frame frame-id :payload payload})
-            (reset! !root (h/hydrate! el config [root-view])))
-        (reset! !root (h/mount! el config [root-view])))))
+        (do (rf.ssr/hydrate! {:frame frame-id :payload payload})
+            (reset! !root (rf.hicasso/hydrate! el config [root-view])))
+        (reset! !root (rf.hicasso/mount! el config [root-view])))))
   nil)

--- a/examples/substrates/hicasso/login/host.clj
+++ b/examples/substrates/hicasso/login/host.clj
@@ -42,8 +42,8 @@
   over a real socket against the real sidecar launcher, by
   `re-frame.ssr.ring.login-host-crossing-test`
   (`implementation/ssr-ring/test/`, tagged `:crossing`)."
-  (:require [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.node :as node]
+  (:require [re-frame.ssr.ring :as rf.ssr.ring]
+            [re-frame.ssr.ring.node :as rf.ssr.ring.node]
             ;; The one render-state list, shared with `server.cljs`.
             [hicasso.login.policy :as policy]
             ;; The application, on the JVM: every `auth.login` schema, fx,
@@ -69,7 +69,7 @@
   default bind, and it accepts any absolute http(s) URL — a non-loopback
   sidecar is not refused. Render state can carry server-only values, so a
   remote one is the operator's network and transport to secure."
-  (or (System/getenv "LOGIN_HICASSO_SSR_NODE") node/default-endpoint))
+  (or (System/getenv "LOGIN_HICASSO_SSR_NODE") rf.ssr.ring.node/default-endpoint))
 
 (defn make-handler
   "Build the Ring handler against ONE sidecar. `handler` below is this
@@ -85,7 +85,7 @@
   frame exactly as the browser boot does and the two halves render the
   same page from the same events."
   [{:keys [endpoint build-id]}]
-  (ssr-ring/ssr-handler
+  (rf.ssr.ring/ssr-handler
     {:initial-events (:initial-events model/frame-config)
      ;; The demo HTTP stub, remapped for this frame exactly as the browser
      ;; mount remaps it. No request is issued during a server render, but
@@ -94,7 +94,7 @@
      ;; What the BROWSER may see: the form slice, and nothing else.
      :payload        [:auth]
      ;; No `:root-view` — only the default JVM-local renderer reads one.
-     :renderer       (node/renderer
+     :renderer       (rf.ssr.ring.node/renderer
                        {:endpoint     endpoint
                         :entry        policy/root-entry
                         :build-id     build-id

--- a/examples/substrates/hicasso/login/server.cljs
+++ b/examples/substrates/hicasso/login/server.cljs
@@ -49,9 +49,9 @@
   which the contract calls \"a sentence someone wrote\" and refuses along
   with every other value."
   (:require [re-frame.core :as rf]
-            [re-frame.hicasso.server :as server]
-            [re-frame.hicasso.substrate :as substrate]
-            [re-frame.ssr.render-state :as render-state]
+            [re-frame.hicasso.server :as rf.hicasso.server]
+            [re-frame.hicasso.substrate :as rf.hicasso.substrate]
+            [re-frame.ssr.render-state :as rf.ssr.render-state]
             ;; The views, the SSR coordinates and every `auth.login`
             ;; registration (the model rides in through this one require).
             [hicasso.login.core :as views]
@@ -94,7 +94,7 @@
 (defn- allowlist
   "The EDN text of each key in one slot of `policy/render-state-policy` —
   the spelling the protocol's key grammar admits (`:foo`, `:foo/bar`), and
-  the same spelling `render-state/serialize` puts on the wire."
+  the same spelling `rf.ssr.render-state/serialize` puts on the wire."
   [slot]
   (into-array (map pr-str (get policy/render-state-policy slot))))
 
@@ -110,7 +110,7 @@
   shared by every request in this isolate, which is the one thing a
   per-request renderer must not do."
   []
-  (rf/init! substrate/adapter)
+  (rf/init! rf.hicasso.substrate/adapter)
   js/undefined)
 
 (defn- render!
@@ -122,10 +122,10 @@
   reads them back under the bundled SAFE EDN reader, and `render-body`
   installs both partitions into a fresh per-request frame in one write."
   [^js call emit]
-  (let [partitions (render-state/deserialize
+  (let [partitions (rf.ssr.render-state/deserialize
                      {:rf/app-db     (js->clj (.-state call))
                       :rf/runtime-db (js->clj (.-runtime call))})]
-    (emit (server/render-body
+    (emit (rf.hicasso.server/render-body
             {:hiccup            [views/root-view]
              :render-state      partitions
              :identifier-prefix views/identifier-prefix

--- a/examples/substrates/reagent_slim/counter/core.cljs
+++ b/examples/substrates/reagent_slim/counter/core.cljs
@@ -23,7 +23,7 @@
   (:require [re-frame.core                      :as rf]
             ;; Monorepo-only spelling (see the ns docstring). Your app picks
             ;; slim by its deps coordinate, not by naming this namespace.
-            [re-frame.adapter.reagent-slim      :as reagent-slim-adapter]))
+            [re-frame.adapter.reagent-slim      :as rf.adapter.reagent-slim]))
 
 ;; -- Events / subs (the handler registry is app-global) ----------------------
 ;;
@@ -70,7 +70,7 @@
 ;; `create-root` on the shared `#app`. Same mount shape as
 ;; `examples/core/counter`.
 
-(defonce app-root (reagent-slim-adapter/client-root))
+(defonce app-root (rf.adapter.reagent-slim/client-root))
 
 ;; The app frame is born in exactly one place: the `frame-root {:id
 ;; app-frame …}` at the render root below. On first mount the provider
@@ -91,7 +91,7 @@
 (defn ^:dev/after-load mount! []
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById "app"))]
-    (reagent-slim-adapter/render! app-root
+    (rf.adapter.reagent-slim/render! app-root
       [rf/frame-root {:id app-frame
                       :initial-events [[:counter/initialise]]}
        [counter-app]]
@@ -117,7 +117,7 @@
   ([on-frame]
    ;; The slim adapter — this single line is the whole difference from
    ;; `examples/core/counter`. Same `rf/init!`, different adapter.
-   (rf/init! reagent-slim-adapter/adapter)
+   (rf/init! rf.adapter.reagent-slim/adapter)
    (when on-frame
      ;; Fixture-only seam. Run the hook in a throwaway frame (gone on exit)
      ;; so it never touches the app frame the provider creates below.

--- a/examples/substrates/uix/counter/core.cljs
+++ b/examples/substrates/uix/counter/core.cljs
@@ -22,7 +22,7 @@
   (:require [uix.core :refer [$ defui]]
             [uix.dom  :as uix-dom]
             [re-frame.core    :as rf]
-            [re-frame.adapter.uix :as uix-adapter]))
+            [re-frame.adapter.uix :as rf.adapter.uix]))
 
 ;; -- Events / subs -----------------------------------------------------------
 ;;
@@ -60,8 +60,8 @@
 ;; injection). See `docs/core/glossary.md#capture-frame`.
 
 (defui counter-buttons []
-  (let [count              (uix-adapter/use-subscribe [:counter/value])
-        {:keys [dispatch]} (uix-adapter/use-frame)]
+  (let [count              (rf.adapter.uix/use-subscribe [:counter/value])
+        {:keys [dispatch]} (rf.adapter.uix/use-frame)]
     ($ :div
        ($ :button {:on-click #(dispatch [:counter/dec])} "-")
        ($ :span {:style #js {:margin "0 1em"} :data-testid "counter-value"} count)
@@ -106,7 +106,7 @@
     (when-not @react-root
       (reset! react-root (uix-dom/create-root el)))
     (uix-dom/render-root
-      ($ uix-adapter/frame-root {:id app-frame
+      ($ rf.adapter.uix/frame-root {:id app-frame
                                      :initial-events [[:counter/initialise]]}
          ($ counter-app))
       @react-root)))
@@ -116,5 +116,5 @@
   ;; once, for the whole process. Every adapter ns exports an `adapter` var;
   ;; require the ns and hand that var over. Call it once at startup and
   ;; forget about it. See `docs/core/glossary.md#init`.
-  (rf/init! uix-adapter/adapter)
+  (rf/init! rf.adapter.uix/adapter)
   (mount!))

--- a/examples/substrates/uix/dashboard/core.cljs
+++ b/examples/substrates/uix/dashboard/core.cljs
@@ -29,7 +29,7 @@
   (:require [uix.core :refer [$ defui]]
             [uix.dom  :as uix-dom]
             [re-frame.core            :as rf]
-            [re-frame.adapter.uix     :as uix-adapter]))
+            [re-frame.adapter.uix     :as rf.adapter.uix]))
 
 ;; ============================================================================
 ;; SEED DATA
@@ -234,8 +234,8 @@
   ;; paint. Wrapping the row in a `role="group"` with an `aria-label` lets a
   ;; screen reader announce one labelled set of toggles instead of three
   ;; loose buttons.
-  (let [active-tags (uix-adapter/use-subscribe [:dashboard/active-tags])
-        {:keys [dispatch]} (uix-adapter/use-frame)]
+  (let [active-tags (rf.adapter.uix/use-subscribe [:dashboard/active-tags])
+        {:keys [dispatch]} (rf.adapter.uix/use-frame)]
     ($ :div.dash-chips {:role "group" :aria-label "Filter metrics by category"}
        (for [{:keys [id label]} all-tags]
          (let [selected? (contains? active-tags id)]
@@ -277,8 +277,8 @@
   ;;
   ;; As with the chips, `is-on` is paint only; `aria-checked` is the state
   ;; assistive tech reads.
-  (let [active-range-id    (uix-adapter/use-subscribe [:dashboard/range])
-        {:keys [dispatch]} (uix-adapter/use-frame)
+  (let [active-range-id    (rf.adapter.uix/use-subscribe [:dashboard/range])
+        {:keys [dispatch]} (rf.adapter.uix/use-frame)
         range-count        (count ranges)
         active-range-index (or (some (fn [[range-index {:keys [id]}]]
                                        (when (= active-range-id id) range-index))
@@ -318,8 +318,8 @@
          ranges))))
 
 (defui dashboard []
-  (let [visible-metrics (uix-adapter/use-subscribe [:dashboard/visible-metrics])
-        selected-range  (uix-adapter/use-subscribe [:dashboard/selected-range])]
+  (let [visible-metrics (rf.adapter.uix/use-subscribe [:dashboard/visible-metrics])
+        selected-range  (rf.adapter.uix/use-subscribe [:dashboard/selected-range])]
     ($ :div.dash-shell
        ($ :header.dash-shell-head
           ($ :div
@@ -366,7 +366,7 @@
     ;; `:initial-events` once to seed app-db. Save and hot-reload, and it
     ;; reuses the same frame untouched — no re-seeding, so your state sticks.
     (uix-dom/render-root
-      ($ uix-adapter/frame-root {:id app-frame
+      ($ rf.adapter.uix/frame-root {:id app-frame
                                      :initial-events [[:dashboard/initialise]]}
          ($ dashboard))
       @react-root)))
@@ -374,5 +374,5 @@
 (defn run []
   ;; `init!` installs the UIx adapter — this is how re-frame2 learns which
   ;; substrate to render through.
-  (rf/init! uix-adapter/adapter)
+  (rf/init! rf.adapter.uix/adapter)
   (mount!))

--- a/examples/substrates/uix/login/core.cljs
+++ b/examples/substrates/uix/login/core.cljs
@@ -28,7 +28,7 @@
             ;; machine, event, and sub, and hands us `model/frame-config` for the
             ;; mount below. It names no substrate — the UIx code lives only here.
             [login.model :as model]
-            [re-frame.adapter.uix :as uix-adapter]))
+            [re-frame.adapter.uix :as rf.adapter.uix]))
 
 ;; ============================================================================
 ;; VIEWS  (UIx — defui + use-subscribe)
@@ -49,13 +49,13 @@
 ;; secret). The draft lives in app-db, which is exactly why you won't find a
 ;; `uix/use-state` anywhere in here.
 (defui login-form []
-  (let [draft     (uix-adapter/use-subscribe [:auth.login/draft])
-        busy?     (uix-adapter/use-subscribe [:rf.machine/has-tag?
+  (let [draft     (rf.adapter.uix/use-subscribe [:auth.login/draft])
+        busy?     (rf.adapter.uix/use-subscribe [:rf.machine/has-tag?
                                               :auth.login/flow :auth/busy])
-        err       (uix-adapter/use-subscribe [:auth.login/error])
-        email-err (uix-adapter/use-subscribe [:auth.login/field-error :email])
-        pw-err    (uix-adapter/use-subscribe [:auth.login/field-error :password])
-        {:keys [dispatch]} (uix-adapter/use-frame)]
+        err       (rf.adapter.uix/use-subscribe [:auth.login/error])
+        email-err (rf.adapter.uix/use-subscribe [:auth.login/field-error :email])
+        pw-err    (rf.adapter.uix/use-subscribe [:auth.login/field-error :password])
+        {:keys [dispatch]} (rf.adapter.uix/use-frame)]
     ($ :form.login-form
        {:data-testid "login-form"
         :on-submit (fn [e]
@@ -90,9 +90,9 @@
      ($ :p "Too many failed attempts. Contact support to unlock.")))
 
 (defui login-banner []
-  (let [authed? (uix-adapter/use-subscribe [:rf.machine/has-tag?
+  (let [authed? (rf.adapter.uix/use-subscribe [:rf.machine/has-tag?
                                             :auth.login/flow :auth/authenticated])
-        locked? (uix-adapter/use-subscribe [:rf.machine/has-tag?
+        locked? (rf.adapter.uix/use-subscribe [:rf.machine/has-tag?
                                             :auth.login/flow :auth/locked])]
     ($ :div.banner {:data-testid "login-banner"}
        (cond
@@ -139,7 +139,7 @@
     ;; runtime-db the first time the flow runs
     ;; (see docs/machines/glossary.md#snapshot).
     (uix-dom/render-root
-      ($ uix-adapter/frame-root {:id  :rf/default
+      ($ rf.adapter.uix/frame-root {:id  :rf/default
                                      :doc "Login (UIx) demo frame."
                                      ;; `:&` spreads the substrate-free
                                      ;; `model/frame-config` (demo-stub
@@ -152,5 +152,5 @@
 (defn run []
   ;; Tell the runtime to render through UIx. (This installs the adapter; it does
   ;; not create a frame — the frame-root below does that.)
-  (rf/init! uix-adapter/adapter)
+  (rf/init! rf.adapter.uix/adapter)
   (mount!))

--- a/scripts/require-alias-baseline.edn
+++ b/scripts/require-alias-baseline.edn
@@ -21,7 +21,7 @@
   ".clj-kondo"                            0
   "bench"                                 701
   "docs"                                  0
-  "examples"                              65
+  "examples"                              0
   "implementation/adapters"               337
   "implementation/core"                   0
   "implementation/derivation-conformance" 0


### PR DESCRIPTION
Slice 3 of the require-alias dialect campaign (rf2-7sx1). The `examples`
surface goes to **zero** non-canonical require aliases, and its ratchet floor
comes down **65 -> 0 in the same commit** — the gate is two-sided, so a
partial cleanup that left the floor up would red just as surely as a
regression would.

## Counts

| | before | after |
|---|---|---|
| `examples` found / floor | 65 / 65 | **0 / 0** |
| repo-wide non-canonical | 5501 | **5436** |
| files scanned | 2773 | 2773 |
| re-frame require edges | 10771 | 10771 |

Files and edges are unchanged and the diff is **321 insertions / 321
deletions** with no line added or removed anywhere — what a pure rename
looks like. 17 aliases moved across 44 files: **65 libspecs, 254 use sites,
5 auto-resolved `::alias/kw` literals**.

## Baseline diff — exactly one row

```diff
-  "examples"                              65
+  "examples"                              0
```

`--write-baseline` did this and **held `:min-edges` at 9695** (the recompute
proposed 9693; lowering it would loosen the anti-blindness guard). That is
the monotonic writer behaving correctly — slice 1 saw it rise, slice 2 saw it
hold, and this is the hold case again.

## The three literal shapes, each hand-reviewed

Built on the checker's own `mask_source` rather than a line-oriented regex,
so strings and comments are classified at reader level.

| shape | count | disposition |
|---|---|---|
| `alias/sym` code use sites | 211 | renamed |
| `::alias/kw` auto-resolved | 1 (+4 in prose) | **renamed** — the reader resolves these |
| `:alias/key` plain keyword | 7 | **left alone** — data, not an alias |
| `"alias/…"` non-code | 96 | 47 renamed, 49 left |

The checker's own fix hint states the rule this follows: rename
"auto-resolved `::alias/key` keywords, which denote the aliased namespace —
but NOT literal `:alias/key` keywords, which are values whose first segment
merely collides with the alias." `ssr/core.cljc:388` says the same in its own
words: the app "gets the app's own `:ssr/` namespace, not `:rf/`".

Of the 96 non-code occurrences, **49 were left**: path separators
(`docs/ssr/concepts.md`), fully-qualified namespaces
(`re-frame.ssr.render-state/restore!`), and two substring near-misses that
the lookbehind caught — `:auth/locked` contains `h/`, and
`login-hicasso-server/server.js` contains `server/`. The other **47 are real
alias references in docstrings and comments naming vars in the same file**
(`h/defview`, `ssr/hydrate!`, `routing/with-base-path`), so they move with
the code they describe: examples are teaching surfaces, and a comment
contradicting the ns form two lines above it teaches the wrong spelling.

## Gates, each with its captured exit code

| gate | exit |
|---|---|
| `check_require_alias_dialect.py --verbose` (CI's exact invocation) | **0** |
| `check_require_alias_dialect.py --self-test` | **0** (79 passed, unmoved) |
| `npm run test:examples-compile` | **0** — 58 builds, all `0 warnings` |
| `examples/scripts/check-examples-assets.cjs` | **0** — 33 pages |

The compile gate's verdict is the **warning count against a zero baseline**,
not just the exit code: `shadow-cljs compile` exits 0 on warnings, and an
undeclared var from a missed use site surfaces as a warning. All 58 builds
read `0 warnings`.

**Planted fault:** one libspec reverted to `:as reagent-adapter` reddened the
ratchet at exit 1, naming the file, line and libspec, against a floor of 0
that exists only on this branch. Restore verified by git **blob** hash
against the committed object, not by reading a diff.

All gates re-run after the rebase onto `80356e56c2`; the numbers above are
from the final base.
