### PR TITLE
refactor(alias): canonical rf.* require aliases across bench (rf2-7sx1, rf2-lwx8)

### DIFF
--- a/bench/hicasso/src/re_frame/bench/hicasso/adoption_witness_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/adoption_witness_app.cljs
@@ -136,11 +136,11 @@
   refusal publishes no figure for it.
 
   Owner: rf2-2rtt6.80; phase 3 rf2-2rtt6.87."
-  (:require [re-frame.adapter.uix :as uixa]
-            [re-frame.bench.hicasso.lane :as lane]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.frame :as rf.frame]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
             [uix.core :as uix :refer-macros [defui $]]
             ["react-dom/server" :as rdom-server]))
 
@@ -193,7 +193,7 @@
   ;; purpose: that ordering, and not a timer, is what places the snapshot at
   ;; the first instant after the commit-owned subscribe.
   (let [f @target-frame
-        v (uixa/use-subscribe f query-v)]
+        v (rf.adapter.uix/use-subscribe f query-v)]
     (when-let [g @at-render] (g))
     (uix/use-effect
       (fn [] (when-let [g @at-commit] (g)) js/undefined)
@@ -273,7 +273,7 @@
   ([n read-integers?] (run-trial! n read-integers? false))
   ([n read-integers? hydrate?]
   (let [frame-id      (keyword "rf.adoptwit" (str "trial-" n))
-        container     (lane/fresh-container!)
+        container     (rf.bench.hicasso.lane/fresh-container!)
         t0            (volatile! nil)
         t1            (volatile! nil)
         render-tenant (volatile! nil)
@@ -284,11 +284,11 @@
     (rf/dispatch-sync [::seed] {:frame frame-id})
     (reset! builds 0)
     (reset! target-frame frame-id)
-    (let [cache (:sub-cache (frame/frame frame-id))
+    (let [cache (:sub-cache (rf.frame/frame frame-id))
           cold? (nil? (get @cache query-v))]
       (reset! at-render
               (fn []
-                (vreset! t0 (lane/now-ms))
+                (vreset! t0 (rf.bench.hicasso.lane/now-ms))
                 (when read-integers?
                   ;; The render's escrowed +1 is what keeps this entry
                   ;; tenanted, so the reaction read HERE is the render's.
@@ -296,7 +296,7 @@
       (reset! at-commit
               (fn []
                 (when (nil? @t1)
-                  (vreset! t1 (lane/now-ms))
+                  (vreset! t1 (rf.bench.hicasso.lane/now-ms))
                   (when read-integers?
                     (let [tenant (get-in @cache [query-v :reaction])]
                       (vreset! snap
@@ -314,7 +314,7 @@
       (when hydrate?
         ;; The page as it arrives, before any JavaScript has adopted it.
         (set! (.-innerHTML container) @server-markup))
-      (let [unmount (substrate-adapter/render ($ Boundary) container
+      (let [unmount (rf.substrate.adapter/render ($ Boundary) container
                                               (if hydrate? {:hydrate? true} {}))]
         (-> (js/Promise.race #js [committed (timeout-after commit-budget-ms :timeout)])
             ;; The SETTLED read happens one horizon-crossing later, and
@@ -339,7 +339,7 @@
                             (= outcome :timeout)
                             (assoc :dom-at-timeout (.-textContent container))
                             (not= outcome :timeout)
-                            (assoc :gap-ms (lane/round4 (- @t1 @t0)))
+                            (assoc :gap-ms (rf.bench.hicasso.lane/round4 (- @t1 @t0)))
 
                             (and (not= outcome :timeout) read-integers?)
                             (merge @snap)
@@ -382,10 +382,10 @@
 (defn- gap-summary [rows]
   (let [gaps (keep :gap-ms rows)]
     (merge {:trials (count rows) :committed (count gaps)}
-           (some-> (lane/summarise gaps)
-                   (update :min lane/round4)
-                   (update :max lane/round4)
-                   (update :p50 lane/round4)))))
+           (some-> (rf.bench.hicasso.lane/summarise gaps)
+                   (update :min rf.bench.hicasso.lane/round4)
+                   (update :max rf.bench.hicasso.lane/round4)
+                   (update :p50 rf.bench.hicasso.lane/round4)))))
 
 (defn- disqualifiers
   "Every reason `rows` cannot carry an adoption reading, in the order a reader
@@ -538,7 +538,7 @@
         (fn [rows]
           (let [summary (gap-summary rows)
                 bad     (disqualifiers rows ceiling-ms)]
-            (lane/record! :hydration {:horizon-ms horizon-ms
+            (rf.bench.hicasso.lane/record! :hydration {:horizon-ms horizon-ms
                                       :ceiling-ms ceiling-ms
                                       :summary    summary
                                       :rows       rows
@@ -568,7 +568,7 @@
                              (str "A MARGIN, NOT A CONTRACT: React documents no maximum "
                                   "render-to-subscribe interval. Re-run when the react / "
                                   "react-dom / playwright pins move.")]))))
-            (lane/done!))))))
+            (rf.bench.hicasso.lane/done!))))))
 
 (defn- adjudicate-adoption!
   "PHASE 2 — reached only from a qualifying phase-1 gap, and refusing again if
@@ -581,7 +581,7 @@
         (fn [rows]
           (let [summary (gap-summary rows)
                 bad     (disqualifiers rows ceiling-ms)]
-            (lane/record! :adoption {:horizon-ms horizon-ms
+            (rf.bench.hicasso.lane/record! :adoption {:horizon-ms horizon-ms
                                      :ceiling-ms ceiling-ms
                                      :summary    summary
                                      :rows       rows})
@@ -592,7 +592,7 @@
                             (into ["phase 1 qualified but an adoption mount did not, so its"
                                    "integers were discarded unread."]
                                   bad))
-                  (lane/done!)
+                  (rf.bench.hicasso.lane/done!)
                   (js/Promise.resolve nil))
               (let [faults (adoption-faults rows)]
                 (if (seq faults)
@@ -601,7 +601,7 @@
                                        "commit still did not adopt the render's build. On a qualifying"
                                        "page that is a MECHANISM regression, not a scheduling one."]
                                       faults))
-                      (lane/done!)
+                      (rf.bench.hicasso.lane/done!)
                       (js/Promise.resolve nil))
                   ;; Phase 2 held, so the hydration schedule is worth asking
                   ;; about — and phase 2's records are what its parity row is
@@ -614,7 +614,7 @@
   [rows horizon-ms ceiling-ms]
   (let [summary (gap-summary rows)
         bad     (disqualifiers rows ceiling-ms)]
-    (lane/record! :gap {:horizon-ms horizon-ms
+    (rf.bench.hicasso.lane/record! :gap {:horizon-ms horizon-ms
                         :ceiling-ms ceiling-ms
                         :summary    summary
                         :rows       rows})
@@ -626,29 +626,29 @@
                            "This is not a failure of the adoption; it is a refusal to"
                            "adjudicate it here."]
                           bad))
-          (lane/done!)
+          (rf.bench.hicasso.lane/done!)
           (js/Promise.resolve nil))
       (adjudicate-adoption! horizon-ms ceiling-ms))))
 
 (defn ^:export -main []
-  (rf/init! uixa/adapter)
+  (rf/init! rf.adapter.uix/adapter)
   ;; Every reading here is taken outside React's act queue, so the commit
   ;; measured is the commit a consumer's page performs.
-  (lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/leave-act-environment!)
   (let [{:keys [horizon-ms ceiling-ms error]} (params)]
     (if error
-      (do (lane/fail! error) (lane/done!))
+      (do (rf.bench.hicasso.lane/fail! error) (rf.bench.hicasso.lane/done!))
       (-> (js/Promise.resolve nil)
           (.then (fn [_] (register!) (render-server-markup!)))
           ;; WARM-UP: printed, never counted. The first mount on a fresh page
           ;; pays React's own lazy initialisation.
           (.then (fn [_] (run-trials! (trial-ids "w" warmup-trials) false)))
           (.then (fn [warm]
-                   (lane/record! :warmup {:rows warm})
+                   (rf.bench.hicasso.lane/record! :warmup {:rows warm})
                    (js/console.log (str ";; warm-up gaps (discarded): "
                                         (pr-str (mapv :gap-ms warm)) " ms"))
                    (run-trials! (trial-ids "g" gap-trials) false)))
           (.then (fn [rows] (adjudicate-gap! rows horizon-ms ceiling-ms)))
           (.catch (fn [e]
-                    (lane/fail! (or (some-> e .-message) (str e)))
-                    (lane/done!)))))))
+                    (rf.bench.hicasso.lane/fail! (or (some-> e .-message) (str e)))
+                    (rf.bench.hicasso.lane/done!)))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/amp_merge_arms_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/amp_merge_arms_cljs_test.cljs
@@ -47,8 +47,8 @@
   things that were never in danger of differing, and this file would
   pass while checking nothing."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.bench.hicasso.amp-merge-clock-app :as amp]
-            [re-frame.bench.hicasso.front.codec :as codec]))
+            [re-frame.bench.hicasso.amp-merge-clock-app :as rf.bench.hicasso.amp-merge-clock-app]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]))
 
 ;; ---------------------------------------------------------------------------
 ;; The witness's own inputs
@@ -120,7 +120,7 @@
   two, so a comparison between them is a comparison of the same
   quantity."
   [hiccup]
-  (codec/merge-caller (attrs-of hiccup)))
+  (rf.bench.hicasso.front.codec/merge-caller (attrs-of hiccup)))
 
 ;; ---------------------------------------------------------------------------
 ;; The cliff itself
@@ -151,7 +151,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest rung-1-prime-writes-expandeds-eight-keys-and-no-ninth
-  (let [lean (attrs-of (amp/field-lean draft errors id :description false
+  (let [lean (attrs-of (rf.bench.hicasso.amp-merge-clock-app/field-lean draft errors id :description false
                                        classless-remainder))]
     (testing "`field-lean` writes `:expanded`'s keys, in `:expanded`'s order"
       (is (= expanded-attr-keys (vec (keys lean)))))
@@ -162,11 +162,11 @@
       (is (not (contains? lean :class))
           "the passenger is absent, which is the whole of the repair"))
     (testing "and the codec meets that map by identity — there is no `:&` here"
-      (is (identical? lean (codec/merge-caller lean))))))
+      (is (identical? lean (rf.bench.hicasso.front.codec/merge-caller lean))))))
 
 (deftest the-lg-helper-differs-from-the-plain-one-by-the-TAG-alone
-  (let [plain (amp/field-lean    draft errors id :description false classless-remainder)
-        lg    (amp/field-lean-lg draft errors id :description false classless-remainder)]
+  (let [plain (rf.bench.hicasso.amp-merge-clock-app/field-lean    draft errors id :description false classless-remainder)
+        lg    (rf.bench.hicasso.amp-merge-clock-app/field-lean-lg draft errors id :description false classless-remainder)]
     (testing "same remainder in, same attribute map out"
       (is (= (attrs-of plain) (attrs-of lg)))
       (is (= (vec (keys (attrs-of plain))) (vec (keys (attrs-of lg))))
@@ -189,9 +189,9 @@
             ;; its helper takes them back out; `:no-dissoc-lean` passes
             ;; them as arguments. Both are handed the SAME remainder, so
             ;; the round trip is the only thing between them.
-            merged (presented (amp/field draft errors id
+            merged (presented (rf.bench.hicasso.amp-merge-clock-app/field draft errors id
                                          (merge {:k k :busy? false} remainder)))
-            lean   (presented (amp/field-no-dissoc draft errors id k false
+            lean   (presented (rf.bench.hicasso.amp-merge-clock-app/field-no-dissoc draft errors id k false
                                                    remainder))]
         (is (= merged lean) "the same attribute map")
         (is (= (vec (keys merged)) (vec (keys lean))) "in the same order")
@@ -206,7 +206,7 @@
 
 (deftest the-old-rungs-crossed-the-cliff
   (testing "rung (1): `field-explicit` writes `:class` whether or not there is one"
-    (let [old (attrs-of (amp/field-explicit draft errors id :description false
+    (let [old (attrs-of (rf.bench.hicasso.amp-merge-clock-app/field-explicit draft errors id :description false
                                             classless-remainder))]
       (is (contains? old :class))
       (is (nil? (:class old)) "the passenger, and its value is nil")
@@ -215,10 +215,10 @@
           "a hash map where `:expanded` and `field-lean` build an array map")))
 
   (testing "rung (3): the `:class nil` call site crosses where `:merged` does not"
-    (let [merged (presented (amp/field draft errors id
+    (let [merged (presented (rf.bench.hicasso.amp-merge-clock-app/field draft errors id
                                        (merge {:k :description :busy? false}
                                               classless-remainder)))
-          old    (presented (amp/field-no-dissoc draft errors id :description false
+          old    (presented (rf.bench.hicasso.amp-merge-clock-app/field-no-dissoc draft errors id :description false
                                                  classless-remainder+nil-class))]
       (is (= 8 (count merged)))
       (is (instance? PersistentArrayMap merged))

--- a/bench/hicasso/src/re_frame/bench/hicasso/amp_merge_clock_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/amp_merge_clock_app.cljs
@@ -214,7 +214,7 @@
 
   ## The control is adjudicated STRICTLY, and per round (rf2-egdaq)
 
-  `lane/control-verdict-strict` decides it: every round's `:ctl-2x` /
+  `rf.bench.hicasso.lane/control-verdict-strict` decides it: every round's `:ctl-2x` /
   `:expanded` ratio must sit inside ±25% of 2.00x, and one bad round
   refuses the run however good the others were. This instrument is
   entitled to that rule and the coarse-leg rows are not — the 2026-07-31
@@ -240,7 +240,7 @@
 
   ## What is published
 
-  `lane/ratio-between :merged :expanded` over the per-round
+  `rf.bench.hicasso.lane/ratio-between :merged :expanded` over the per-round
   floor-normalised ratios, with its range and its `:straddles-1?` flag —
   and beside it the same statistic for `:expanded-b`, which carries no
   effect by construction. A `:merged` range that straddles 1.0 means
@@ -265,10 +265,10 @@
   cannot be timed. Instrument: `lane.cljs`, ridden through `run.cjs` on
   the existing `:hicasso-bench` build id via `HICASSO_INIT_FN` — no
   `shadow-cljs.edn` edit."
-  (:require [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.lane :as lane]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]))
+            [re-frame.hicasso :as rf.hicasso]))
 
 (def frame-id ::amp-merge-clock)
 
@@ -302,7 +302,7 @@
 ;; Two reads per boundary, the same two in both arms. The ERROR TEXT is
 ;; per-boundary and lands in the DOM as text, which is what makes the
 ;; far-end read-back and the mutation gate able to see the page at all: a
-;; controlled input's `value` is a DOM PROPERTY, and `lane/canonical`
+;; controlled input's `value` is a DOM PROPERTY, and `rf.bench.hicasso.lane/canonical`
 ;; reads attributes.
 
 (rf/reg-sub :amp/draft  (fn [db [_ id]] (get-in db [:drafts id])))
@@ -331,8 +331,8 @@
 
 (defn expanded-body
   [{:keys [id]}]
-  (let [draft  (h/sub [:amp/draft id])
-        errors (h/sub [:amp/errors id])
+  (let [draft  (rf.hicasso/sub [:amp/draft id])
+        errors (rf.hicasso/sub [:amp/errors id])
         busy?  (:busy? draft)]
     [:fieldset
      [:fieldset.form-group
@@ -341,7 +341,7 @@
         :data-testid "editor-title"
         :value (:title draft) :disabled busy?
         :on-blur  [:amp/blur id :title]
-        :on-input [:amp/edit id :title ::h/value]}]
+        :on-input [:amp/edit id :title ::rf.hicasso/value]}]
       (when-some [e (:title errors)] [:div.error-messages e])]
      [:fieldset.form-group
       [:input.form-control
@@ -349,7 +349,7 @@
         :data-testid "editor-description"
         :value (:description draft) :disabled busy?
         :on-blur  [:amp/blur id :description]
-        :on-input [:amp/edit id :description ::h/value]}]
+        :on-input [:amp/edit id :description ::rf.hicasso/value]}]
       (when-some [e (:description errors)] [:div.error-messages e])]
      [:fieldset.form-group
       [:input.form-control
@@ -357,7 +357,7 @@
         :data-testid "editor-body"
         :value (:body draft) :disabled busy?
         :on-blur  [:amp/blur id :body]
-        :on-input [:amp/edit id :body ::h/value]}]
+        :on-input [:amp/edit id :body ::rf.hicasso/value]}]
       (when-some [e (:body errors)] [:div.error-messages e])]
      [:fieldset.form-group
       [:input.form-control
@@ -365,7 +365,7 @@
         :data-testid "editor-tags"
         :value (:tagList draft) :disabled busy?
         :on-blur  [:amp/blur id :tagList]
-        :on-input [:amp/edit id :tagList ::h/value]}]
+        :on-input [:amp/edit id :tagList ::rf.hicasso/value]}]
       (when-some [e (:tagList errors)] [:div.error-messages e])]]))
 
 ;; ---------------------------------------------------------------------------
@@ -397,13 +397,13 @@
                          :value    (get draft k)
                          :disabled busy?
                          :on-blur  [:amp/blur id k]
-                         :on-input [:amp/edit id k ::h/value]}]
+                         :on-input [:amp/edit id k ::rf.hicasso/value]}]
    (when-some [e (get errors k)] [:div.error-messages e])])
 
 (defn merged-body
   [{:keys [id]}]
-  (let [draft  (h/sub [:amp/draft id])
-        errors (h/sub [:amp/errors id])
+  (let [draft  (rf.hicasso/sub [:amp/draft id])
+        errors (rf.hicasso/sub [:amp/errors id])
         busy?  (:busy? draft)]
     [:fieldset
      (field draft errors id
@@ -464,7 +464,7 @@
                          :value       (get draft k)
                          :disabled    busy?
                          :on-blur     [:amp/blur id k]
-                         :on-input    [:amp/edit id k ::h/value]}]
+                         :on-input    [:amp/edit id k ::rf.hicasso/value]}]
    (when-some [e (get errors k)] [:div.error-messages e])])
 
 (defn field-no-dissoc
@@ -478,13 +478,13 @@
                          :value    (get draft k)
                          :disabled busy?
                          :on-blur  [:amp/blur id k]
-                         :on-input [:amp/edit id k ::h/value]}]
+                         :on-input [:amp/edit id k ::rf.hicasso/value]}]
    (when-some [e (get errors k)] [:div.error-messages e])])
 
 (defn explicit-body
   [{:keys [id]}]
-  (let [draft  (h/sub [:amp/draft id])
-        errors (h/sub [:amp/errors id])
+  (let [draft  (rf.hicasso/sub [:amp/draft id])
+        errors (rf.hicasso/sub [:amp/errors id])
         busy?  (:busy? draft)]
     [:fieldset
      (field-explicit draft errors id :title busy?
@@ -509,8 +509,8 @@
 
 (defn no-dissoc-body
   [{:keys [id]}]
-  (let [draft  (h/sub [:amp/draft id])
-        errors (h/sub [:amp/errors id])
+  (let [draft  (rf.hicasso/sub [:amp/draft id])
+        errors (rf.hicasso/sub [:amp/errors id])
         busy?  (:busy? draft)]
     [:fieldset
      (field-no-dissoc draft errors id :title busy?
@@ -569,7 +569,7 @@
                          :value       (get draft k)
                          :disabled    busy?
                          :on-blur     [:amp/blur id k]
-                         :on-input    [:amp/edit id k ::h/value]}]
+                         :on-input    [:amp/edit id k ::rf.hicasso/value]}]
    (when-some [e (get errors k)] [:div.error-messages e])])
 
 (defn field-lean-lg
@@ -592,13 +592,13 @@
                                          :value       (get draft k)
                                          :disabled    busy?
                                          :on-blur     [:amp/blur id k]
-                                         :on-input    [:amp/edit id k ::h/value]}]
+                                         :on-input    [:amp/edit id k ::rf.hicasso/value]}]
    (when-some [e (get errors k)] [:div.error-messages e])])
 
 (defn lean-body
   [{:keys [id]}]
-  (let [draft  (h/sub [:amp/draft id])
-        errors (h/sub [:amp/errors id])
+  (let [draft  (rf.hicasso/sub [:amp/draft id])
+        errors (rf.hicasso/sub [:amp/errors id])
         busy?  (:busy? draft)]
     [:fieldset
      (field-lean-lg draft errors id :title busy?
@@ -626,8 +626,8 @@
   the title, absent everywhere else. So the only thing this arm and
   `:merged` do differently is where `:k` and `:busy?` travel."
   [{:keys [id]}]
-  (let [draft  (h/sub [:amp/draft id])
-        errors (h/sub [:amp/errors id])
+  (let [draft  (rf.hicasso/sub [:amp/draft id])
+        errors (rf.hicasso/sub [:amp/errors id])
         busy?  (:busy? draft)]
     [:fieldset
      (field-no-dissoc draft errors id :title busy?
@@ -654,14 +654,14 @@
   [_]
   nil)
 
-(h/defview expanded-arm       [props] (expanded-body props))
-(h/defview expanded-arm-b     [props] (expanded-body props))
-(h/defview merged-arm         [props] (merged-body props))
-(h/defview explicit-arm       [props] (explicit-body props))
-(h/defview no-dissoc-arm      [props] (no-dissoc-body props))
-(h/defview lean-arm           [props] (lean-body props))
-(h/defview no-dissoc-lean-arm [props] (no-dissoc-lean-body props))
-(h/defview floor-arm          [props] (floor-body props))
+(rf.hicasso/defview expanded-arm       [props] (expanded-body props))
+(rf.hicasso/defview expanded-arm-b     [props] (expanded-body props))
+(rf.hicasso/defview merged-arm         [props] (merged-body props))
+(rf.hicasso/defview explicit-arm       [props] (explicit-body props))
+(rf.hicasso/defview no-dissoc-arm      [props] (no-dissoc-body props))
+(rf.hicasso/defview lean-arm           [props] (lean-body props))
+(rf.hicasso/defview no-dissoc-lean-arm [props] (no-dissoc-lean-body props))
+(rf.hicasso/defview floor-arm          [props] (floor-body props))
 
 ;; ---------------------------------------------------------------------------
 ;; The page — identical for every arm but the body
@@ -687,9 +687,9 @@
 
 (defn- mount-page
   [view]
-  (fn [container _props _n] (h/mount! container {:frame frame-id} (page view))))
+  (fn [container _props _n] (rf.hicasso/mount! container {:frame frame-id} (page view))))
 
-(defn- unmount-page [handle] (h/unmount! handle))
+(defn- unmount-page [handle] (rf.hicasso/unmount! handle))
 
 (def ^:private arms
   [{:id :floor :k 1 :elements floor-elements :parity-exempt? true
@@ -733,7 +733,7 @@
   claimed no term inside instrument resolution, its own included.
 
   ROUND TWO IS A WARM-UP ROUND, and that is the connection to `rf2-h904p`
-  on `direct_return_clock_app`. Replaying [[lane/rounds!]] against
+  on `direct_return_clock_app`. Replaying [[rf.bench.hicasso.lane/rounds!]] against
   `order-guard/slot-order` puts every arm's FIRST-THIRD phase stratum at
   rounds one and two — 3 to 15 prior executions of the arm — and its
   LAST-THIRD at rounds four and five, 32 to 44. The null degraded inside
@@ -747,7 +747,7 @@
   `run.cjs` names `fewer arms per round` as one of the three moves, and
   `rf2-z143r` taking the schedule from five arms to seven is the lead the
   bead was filed on. The schedule arithmetic answers it: replaying
-  [[lane/rounds!]] against `order-guard/slot-order` at n = 5, 7, 8 and 9
+  [[rf.bench.hicasso.lane/rounds!]] against `order-guard/slot-order` at n = 5, 7, 8 and 9
   on the sampling that failed, every arm still banks 30 samples per run,
   every arm's phase strata are still rounds 1-2 against rounds 4-5 at the
   same prior-execution counts, and the null's true predecessor
@@ -763,8 +763,8 @@
   10.26 10.26 10.33 10.28` and then `8.12` for ever, a +27% step falling
   after the SIXTH execution of the site. `{:warmup 8 :samples 12}` puts
   that step inside the warm-up, doubles each phase stratum to n = 20, and
-  is what every other harness riding [[lane/mount-batch!]] already runs.
-  That set is checkable and small — `(lane/mount-batch!` has five call
+  is what every other harness riding [[rf.bench.hicasso.lane/mount-batch!]] already runs.
+  That set is checkable and small — `(rf.bench.hicasso.lane/mount-batch!` has five call
   sites on this lane, this file, `direct_return_clock_app`,
   `coldmount_app`, `p0_converge_app` and `p0_reagent_app` — and the last
   three all sample at 8/12, so the two clocks were the lane's only
@@ -804,7 +804,7 @@
   probe that cannot pass manufactures a defect and hides real ones behind
   it."
   [arm container]
-  (and (= (:elements arm) (lane/element-count container))
+  (and (= (:elements arm) (rf.bench.hicasso.lane/element-count container))
        (or (= :floor (:id arm))
            (= (expected-far-end) (far-end container)))))
 
@@ -814,10 +814,10 @@
 
 (defn parity!
   "Mount every arm at once and compare the judged arms' canonical DOM.
-  Answers `lane/parity`'s verdict with the mounts already released."
+  Answers `rf.bench.hicasso.lane/parity`'s verdict with the mounts already released."
   []
-  (let [{:keys [mounts] :as p} (lane/parity arms nil)]
-    (doseq [m mounts] (lane/release! m))
+  (let [{:keys [mounts] :as p} (rf.bench.hicasso.lane/parity arms nil)]
+    (doseq [m mounts] (rf.bench.hicasso.lane/release! m))
     p))
 
 (defn parity-can-fail?
@@ -826,15 +826,15 @@
   to the run's own data afterwards, so nothing downstream is measured on
   the mutated page."
   []
-  (let [before (let [m (lane/mount-arm! (arm-named :expanded) nil)
-                     s (lane/canonical (:container m))]
-                 (lane/release! m)
+  (let [before (let [m (rf.bench.hicasso.lane/mount-arm! (arm-named :expanded) nil)
+                     s (rf.bench.hicasso.lane/canonical (:container m))]
+                 (rf.bench.hicasso.lane/release! m)
                  s)]
     (rf/with-frame frame-id
       (rf/dispatch-sync [:amp/seed (seed-db boundaries mutated-error)]))
-    (let [after (let [m (lane/mount-arm! (arm-named :merged) nil)
-                      s (lane/canonical (:container m))]
-                  (lane/release! m)
+    (let [after (let [m (rf.bench.hicasso.lane/mount-arm! (arm-named :merged) nil)
+                      s (rf.bench.hicasso.lane/canonical (:container m))]
+                  (rf.bench.hicasso.lane/release! m)
                   s)]
       (rf/with-frame frame-id
         (rf/dispatch-sync [:amp/seed (seed-db boundaries default-error)]))
@@ -846,12 +846,12 @@
 
 (defn- measure-one!
   [tally arm]
-  (let [{:keys [ms mounts]} (lane/mount-batch! arm nil (:k arm))]
+  (let [{:keys [ms mounts]} (rf.bench.hicasso.lane/mount-batch! arm nil (:k arm))]
     (doseq [m mounts]
       (let [ok? (verified? arm (:container m))]
         (swap! tally (fn [{:keys [of bad]}]
                        {:of (inc of) :bad (if ok? bad (inc bad))}))))
-    (doseq [m mounts] (lane/release! m))
+    (doseq [m mounts] (rf.bench.hicasso.lane/release! m))
     ms))
 
 (defn- fmt [x n] (.toFixed (double x) n))
@@ -887,9 +887,9 @@
   reader can check `{:min :max :p50}` against the printed `:per-round` and
   get an exact match instead of a near one."
   [p50s a b]
-  (let [vs (mapv (fn [r] (lane/round4 (/ (* 1e6 (- (get r a) (get r b))) amp-sites)))
+  (let [vs (mapv (fn [r] (rf.bench.hicasso.lane/round4 (/ (* 1e6 (- (get r a) (get r b))) amp-sites)))
                  p50s)]
-    (assoc (lane/summarise vs) :per-round vs)))
+    (assoc (rf.bench.hicasso.lane/summarise vs) :per-round vs)))
 
 (defn- ns-combine
   "Combine two or more [[ns-terms]] records with `f`, term by term and
@@ -907,9 +907,9 @@
   residual, which is a difference of two such sums."
   [f & terms]
   (let [vs (apply mapv
-                  (fn [& xs] (lane/round4 (apply f xs)))
+                  (fn [& xs] (rf.bench.hicasso.lane/round4 (apply f xs)))
                   (map :per-round terms))]
-    (assoc (lane/summarise vs) :per-round vs)))
+    (assoc (rf.bench.hicasso.lane/summarise vs) :per-round vs)))
 
 (defn- ladder-rung
   "One rung: the ratio of two arms over the floor-normalised per-round
@@ -920,7 +920,7 @@
   {:from      b
    :to        a
    :standing  standing
-   :ratio     (lane/ratio-between ratios a b)
+   :ratio     (rf.bench.hicasso.lane/ratio-between ratios a b)
    :ns-per-site (ns-terms p50s a b)})
 
 (defn- derived-ns
@@ -954,7 +954,7 @@
        "BEFORE the clock starts; the :ctl-2x arm's sample is the SAME operation "
        "performed TWICE inside one window, so its per-sample constants double "
        "with its work and its prediction is 2.00x by construction rather than by "
-       "model — adjudicated by lane/control-verdict-strict, which requires EVERY "
+       "model — adjudicated by rf.bench.hicasso.lane/control-verdict-strict, which requires EVERY "
        "round's ctl-2x/expanded ratio to sit inside ±"
        (.toFixed (* 100.0 control-slack) 0)
        "% of it rather than merely the range, and records the per-round values so "
@@ -985,9 +985,9 @@
 ;; ---------------------------------------------------------------------------
 
 (defn ^:export -main []
-  (rf/init! uix-adapter/adapter)
-  (lane/leave-act-environment!)
-  (lane/self-test!)
+  (rf/init! rf.adapter.uix/adapter)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/self-test!)
   (-> (js/Promise.resolve nil)
       (.then
         (fn [_]
@@ -1000,12 +1000,12 @@
           ;; known able to disagree.
           (let [p         (parity!)
                 can-fail? (parity-can-fail?)]
-            (lane/record! :amp-merge-clock-parity
+            (rf.bench.hicasso.lane/record! :amp-merge-clock-parity
                           {:agree?    (:agree? p)
                            :disagree  (:disagree p)
                            :counts    (:counts p)
                            :can-fail? can-fail?
-                           :bytes     (lane/utf8-bytes (or (:reference p) ""))})
+                           :bytes     (rf.bench.hicasso.lane/utf8-bytes (or (:reference p) ""))})
             (when-not (:agree? p)
               (throw (ex-info (str "FAIRNESS GATE: the arms do not build the same "
                                    "mounted page, so no ratio between them is about the "
@@ -1018,34 +1018,34 @@
                                    "that cannot answer false is not a gate, and the "
                                    "agreement above is worth nothing.")
                               {}))))
-          (lane/assert-teardown-clean! "the fairness gate")
-          (.then (lane/settle!) (fn [_] nil))))
+          (rf.bench.hicasso.lane/assert-teardown-clean! "the fairness gate")
+          (.then (rf.bench.hicasso.lane/settle!) (fn [_] nil))))
       (.then
         (fn [_]
-          (let [baseline (lane/residue frame-id)
-                tally    (lane/tally)
+          (let [baseline (rf.bench.hicasso.lane/residue frame-id)
+                tally    (rf.bench.hicasso.lane/tally)
                 {:keys [readings samples]}
-                (lane/rounds! arms sampling rounds (partial measure-one! tally))
-                norm     (mapv #(lane/normalise % :floor) readings)
+                (rf.bench.hicasso.lane/rounds! arms sampling rounds (partial measure-one! tally))
+                norm     (mapv #(rf.bench.hicasso.lane/normalise % :floor) readings)
                 ratios   (mapv :ratio norm)
-                summ     (lane/across-rounds ratios)
+                summ     (rf.bench.hicasso.lane/across-rounds ratios)
                 p50s     (mapv :p50 norm)
                 abs      (into {}
                                (map (fn [{:keys [id]}]
-                                      [id (lane/summarise (mapv #(get % id) p50s))]))
+                                      [id (rf.bench.hicasso.lane/summarise (mapv #(get % id) p50s))]))
                                arms)
-                effect   (lane/ratio-between ratios :merged :expanded)
-                null     (lane/ratio-between ratios :expanded-b :expanded)
+                effect   (rf.bench.hicasso.lane/ratio-between ratios :merged :expanded)
+                null     (rf.bench.hicasso.lane/ratio-between ratios :expanded-b :expanded)
                 eff-ns   (ns-terms p50s :merged :expanded)
                 null-ns  (ns-terms p50s :expanded-b :expanded)
-                gv       (lane/guard! samples "amp-merge clock arms (in-page ms)")
+                gv       (rf.bench.hicasso.lane/guard! samples "amp-merge clock arms (in-page ms)")
                 ;; THE POSITIVE CONTROL, per round and strictly (rf2-egdaq).
                 ;; `:ctl-2x` is `:expanded`'s own operation performed twice
                 ;; in one window, so 2.00x is arithmetic rather than a
                 ;; model, and dividing each round by ITS OWN `:expanded`
                 ;; leaves the floor and the round's drift out of it.
-                ctl-ratio (lane/ratio-between ratios :ctl-2x :expanded)
-                ctl      (lane/control-verdict-strict
+                ctl-ratio (rf.bench.hicasso.lane/ratio-between ratios :ctl-2x :expanded)
+                ctl      (rf.bench.hicasso.lane/control-verdict-strict
                            2.0 (:per-round ctl-ratio) control-slack)
                 ;; THE APPORTIONMENT (rf2-z143r). A chain, so the three
                 ;; rungs sum to `:whole` term by term and there is no
@@ -1090,19 +1090,19 @@
                                                                [:author :author-clean]
                                                                (ns-combine - author author-c))
                                                    :zero-by-construction? false)}
-                sum-check (mapv (fn [w r m t] (lane/round4 (- w (+ r m t))))
+                sum-check (mapv (fn [w r m t] (rf.bench.hicasso.lane/round4 (- w (+ r m t))))
                                 (:per-round (:ns-per-site whole))
                                 (:per-round (:ns-per-site wrapper))
                                 (:per-round (:ns-per-site merge-r))
                                 (:per-round (:ns-per-site trip)))
-                tv       (lane/tally-value tally)]
-            (lane/assert-teardown-clean! "the measured rounds")
-            (lane/record! :amp-merge-clock
+                tv       (rf.bench.hicasso.lane/tally-value tally)]
+            (rf.bench.hicasso.lane/assert-teardown-clean! "the measured rounds")
+            (rf.bench.hicasso.lane/record! :amp-merge-clock
                           {:benchmark   :hicasso.HD-023/amp-merge-clock
                            :bead        "rf2-pqyxz"
                            :discharges  "HD-023 'Cost, stated' — the clock cost named there as unmeasured"
                            :grade       :distributional
-                           :runtime     (lane/runtime-label)
+                           :runtime     (rf.bench.hicasso.lane/runtime-label)
                            :boundaries  boundaries
                            :amp-sites   amp-sites
                            :elements    {:floor floor-elements :page page-elements}
@@ -1195,10 +1195,10 @@
               (set! (.-HICASSO_GUARD_REFUSED js/window) true))
             (when-not (:ok? ctl)
               (set! (.-HICASSO_CONTROL_FAILED js/window) true))
-            (.then (lane/settle!)
+            (.then (rf.bench.hicasso.lane/settle!)
                    (fn [_]
-                     (lane/assert-residue! baseline frame-id "the measured rounds")
-                     (lane/done!))))))
+                     (rf.bench.hicasso.lane/assert-residue! baseline frame-id "the measured rounds")
+                     (rf.bench.hicasso.lane/done!))))))
       (.catch (fn [e]
-                (lane/fail! (or (some-> e .-message) (str e)))
-                (lane/done!)))))
+                (rf.bench.hicasso.lane/fail! (or (some-> e .-message) (str e)))
+                (rf.bench.hicasso.lane/done!)))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/ambient_refusal_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/ambient_refusal_cljs_test.cljs
@@ -13,7 +13,7 @@
   spelling threw. Silence or a throw, decided by a dependency choice
   made elsewhere.
 
-  Core now has a refusal tier (`frame/call-with-ambient-frame-refused`)
+  Core now has a refusal tier (`rf.frame/call-with-ambient-frame-refused`)
   and [[re-frame.bench.hicasso.front.intent/with-frame]] establishes it
   over every Hicasso render extent, so the answer is the same under every
   adapter: a loud `:rf.error/ambient-frame-refused` naming the collector.
@@ -29,7 +29,7 @@
   runs under that same publication. Remove the fence and the refusal
   rows go green-to-red as a pair with that control staying green.
 
-  A body run is reached through `rt/render-body` rather than a React
+  A body run is reached through `rf.bench.hicasso.arm1.runtime/render-body` rather than a React
   root on purpose: React routes a render-phase throw to `reportError`,
   where `cljs.test` cannot see it, and a row that cannot see its own
   exception is a row that cannot go red. The real-React half — the
@@ -45,28 +45,28 @@
   one, together with each legitimate carry spelling proved individually."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
-            [re-frame.adapter.context :as adapter-context]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.intent :as intent]
+            [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.intent :as rf.bench.hicasso.front.intent]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.live-frame :as live-frame]
-            [re-frame.test-support :as test-support]))
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.frame :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.live-frame :as rf.live-frame]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::rt122)
 
 (defn- make-frame! []
-  (live-frame/make-frame {:id frame-id})
-  (frame/replace-app-db! frame-id {:v 7})
+  (rf.live-frame/make-frame {:id frame-id})
+  (rf.frame/replace-app-db! frame-id {:v 7})
   (rf/reg-sub :rt122/v (fn [db _] (:v db)))
   (rf/reg-event :rt122/bump (fn [{:keys [db]} _] {:db (update db :v inc)}))
   frame-id)
@@ -80,7 +80,7 @@
   React root. Same save/restore shape the core adapter suite uses for its
   corrupted-context rows."
   [frame-kw thunk]
-  (let [^js ctx  adapter-context/frame-context
+  (let [^js ctx  rf.adapter.context/frame-context
         original (.-_currentValue ctx)]
     (set! (.-_currentValue ctx) frame-kw)
     (try (thunk)
@@ -98,10 +98,10 @@
   "The always-on error records `thunk` produced."
   [thunk]
   (let [records (volatile! [])]
-    (error-emit/register-error-listener! ::rt122 (fn [r] (vswap! records conj r)))
+    (rf.error-emit/register-error-listener! ::rt122 (fn [r] (vswap! records conj r)))
     (try (thunk)
          (catch :default _ nil)
-         (finally (error-emit/unregister-error-listener! ::rt122)))
+         (finally (rf.error-emit/unregister-error-listener! ::rt122)))
     @records))
 
 ;; ---------------------------------------------------------------------------
@@ -116,7 +116,7 @@
     (let [f (make-frame!)]
       (with-context-frame f
         (fn []
-          (is (= f (frame/resolve-current-frame))
+          (is (= f (rf.frame/resolve-current-frame))
               "tier 2 is genuinely answering here; if it were not, every
                refusal row below would be proving nothing")
           (is (= 7 @(rf/subscribe [:rt122/v]))
@@ -132,7 +132,7 @@
     (let [f (make-frame!)]
       (with-context-frame f
         (fn []
-          (let [data (outcome #(rt/render-body f (fn [_] @(rf/subscribe [:rt122/v]) [:li]) {}))]
+          (let [data (outcome #(rf.bench.hicasso.arm1.runtime/render-body f (fn [_] @(rf/subscribe [:rt122/v]) [:li]) {}))]
             (is (= :rf.error/ambient-frame-refused (:rf.error/id data))
                 (str "expected the refusal; got " (pr-str data)))
             (is (= :subscribe (:operation data)))
@@ -149,7 +149,7 @@
     (let [f (make-frame!)]
       (with-context-frame f
         (fn []
-          (let [data (outcome #(rt/render-body f (fn [_] (rf/dispatch [:rt122/bump]) [:li]) {}))]
+          (let [data (outcome #(rf.bench.hicasso.arm1.runtime/render-body f (fn [_] (rf/dispatch [:rt122/bump]) [:li]) {}))]
             (is (= :rf.error/ambient-frame-refused (:rf.error/id data))
                 (str "expected the refusal; got " (pr-str data)))
             (is (= :dispatch (:operation data)))
@@ -163,7 +163,7 @@
     (let [f (make-frame!)]
       (with-context-frame f
         (fn []
-          (let [data   (outcome #(rt/render-body f (fn [_] @(rf/subscribe [:rt122/v]) [:li]) {}))
+          (let [data   (outcome #(rf.bench.hicasso.arm1.runtime/render-body f (fn [_] @(rf/subscribe [:rt122/v]) [:li]) {}))
                 reason (:reason data)]
             (is (string? reason))
             (is (re-find #"collector" reason)
@@ -182,7 +182,7 @@
       (with-context-frame f
         (fn []
           (let [records (captured-errors
-                          #(rt/render-body f (fn [_] @(rf/subscribe [:rt122/v]) [:li]) {}))]
+                          #(rf.bench.hicasso.arm1.runtime/render-body f (fn [_] @(rf/subscribe [:rt122/v]) [:li]) {}))]
             (is (some (fn [r] (= :rf.error/ambient-frame-refused (:error r))) records)
                 (str "no always-on record for the refusal: " (pr-str records)))))))))
 
@@ -198,7 +198,7 @@
       (with-context-frame f
         (fn []
           (let [seen (volatile! ::unset)]
-            (rt/render-body f
+            (rf.bench.hicasso.arm1.runtime/render-body f
                             (fn [_]
                               (rf/with-frame f (vreset! seen @(rf/subscribe [:rt122/v])))
                               [:li])
@@ -216,7 +216,7 @@
       (with-context-frame f
         (fn []
           (let [seen (volatile! ::unset)]
-            (rt/render-body f
+            (rf.bench.hicasso.arm1.runtime/render-body f
                             (fn [_]
                               (vreset! seen @(rf/subscribe [:rt122/v] {:frame f}))
                               [:li])
@@ -230,7 +230,7 @@
       (with-context-frame f
         (fn []
           (let [seen (volatile! ::unset)]
-            (rt/render-body f (fn [_] (vreset! seen (rt/sub [:rt122/v])) [:li]) {})
+            (rf.bench.hicasso.arm1.runtime/render-body f (fn [_] (vreset! seen (rf.bench.hicasso.arm1.runtime/sub [:rt122/v])) [:li]) {})
             (is (= 7 @seen) "the read the author is supposed to write")))))))
 
 (deftest the-refusal-unwinds-with-the-body
@@ -245,12 +245,12 @@
       (with-context-frame f
         (fn []
           (let [deferred (volatile! nil)]
-            (rt/render-body f
+            (rf.bench.hicasso.arm1.runtime/render-body f
                             (fn [_]
                               (vreset! deferred (fn [] @(rf/subscribe [:rt122/v])))
                               [:li])
                             {})
-            (is (= f (frame/resolve-current-frame))
+            (is (= f (rf.frame/resolve-current-frame))
                 "the binding popped with the body run")
             (is (= 7 (@deferred))
                 "and the very same closure that would have refused inside
@@ -263,8 +263,8 @@
     (let [f (make-frame!)]
       (with-context-frame f
         (fn []
-          (rt/render-body f (fn [_] [:li]) {})
-          ((rt/frame-dispatch f) [:rt122/bump])
+          (rf.bench.hicasso.arm1.runtime/render-body f (fn [_] [:li]) {})
+          ((rf.bench.hicasso.arm1.runtime/frame-dispatch f) [:rt122/bump])
           (is (= 8 @(rf/subscribe [:rt122/v]))
               "the intent's dispatch landed and an ambient read outside the
                extent still resolves"))))))
@@ -286,14 +286,14 @@
   (testing "the ordinary path pays one nil-test and answers exactly what it
            answered before: tier 1 wins, then tier 2, then nil"
     (let [f (make-frame!)]
-      (is (nil? (frame/resolve-current-frame)) "no tier answers")
+      (is (nil? (rf.frame/resolve-current-frame)) "no tier answers")
       (with-context-frame f
-        (fn [] (is (= f (frame/resolve-current-frame)) "tier 2 answers")))
+        (fn [] (is (= f (rf.frame/resolve-current-frame)) "tier 2 answers")))
       (rf/with-frame f
-        (is (= f (frame/resolve-current-frame)) "tier 1 answers"))
+        (is (= f (rf.frame/resolve-current-frame)) "tier 1 answers"))
       (with-context-frame ::other
         (fn [] (rf/with-frame f
-                 (is (= f (frame/resolve-current-frame))
+                 (is (= f (rf.frame/resolve-current-frame))
                      "tier 1 still wins over tier 2")))))))
 
 ;; ---------------------------------------------------------------------------
@@ -331,7 +331,7 @@
   live, so it is the anchor rather than a second copy of the spelling."
   [f]
   (:rf.error/id
-    (outcome #(rt/render-body f (fn [_] @(rf/subscribe [:rt122/v]) [:li]) {}))))
+    (outcome #(rf.bench.hicasso.arm1.runtime/render-body f (fn [_] @(rf/subscribe [:rt122/v]) [:li]) {}))))
 
 (deftest a-carry-inside-a-body-is-admitted-while-a-read-refuses
   (testing "FLIPPED under rf2-t32wg, which admits the pure doors: this row
@@ -345,7 +345,7 @@
           held (volatile! nil)]
       (with-context-frame f
         (fn []
-          (let [data   (outcome #(rt/render-body f (fn [_] (vreset! held (rf/capture-frame)) [:li]) {}))
+          (let [data   (outcome #(rf.bench.hicasso.arm1.runtime/render-body f (fn [_] (vreset! held (rf/capture-frame)) [:li]) {}))
                 anchor (refusal-id f)]
             (is (some? anchor)
                 "precondition: an ambient READ still refuses here, so the
@@ -366,28 +366,28 @@
            differs between adapters — is not reached at all. Counted here
            rather than reasoned about"
     (let [f        (make-frame!)
-          original (late-bind/get-fn :adapter/current-frame)
+          original (rf.late-bind/get-fn :adapter/current-frame)
           calls    (volatile! 0)]
       (is (some? original)
           "precondition: an adapter has published the hook, so a zero below
            means 'not consulted' rather than 'nothing to consult'")
-      (late-bind/set-fn! :adapter/current-frame
+      (rf.late-bind/set-fn! :adapter/current-frame
                          (fn [] (vswap! calls inc) (original)))
       (try
         (with-context-frame f
           (fn []
             (vreset! calls 0)
-            (outcome #(rt/render-body f (fn [_] (rf/capture-frame) [:li]) {}))
+            (outcome #(rf.bench.hicasso.arm1.runtime/render-body f (fn [_] (rf/capture-frame) [:li]) {}))
             (is (zero? @calls)
                 "the refused carry never asked the adapter")
 
             (vreset! calls 0)
-            (is (= f (frame/resolve-current-frame))
+            (is (= f (rf.frame/resolve-current-frame))
                 "control: one call outside the body")
             (is (pos? @calls)
                 "and THAT read did ask it — so the zero above is the tier
                  being withdrawn, not a hook that is never called")))
-        (finally (late-bind/set-fn! :adapter/current-frame original))))))
+        (finally (rf.late-bind/set-fn! :adapter/current-frame original))))))
 
 (deftest the-prototypes-refusal-sentence-still-names-the-carry
   (testing "rf2-hnrww's first half, on the FROZEN prototype's own sentence.
@@ -400,7 +400,7 @@
     (let [f (make-frame!)]
       (with-context-frame f
         (fn []
-          (let [data   (outcome #(rt/render-body f (fn [_] @(rf/subscribe [:rt122/v]) [:li]) {}))
+          (let [data   (outcome #(rf.bench.hicasso.arm1.runtime/render-body f (fn [_] @(rf/subscribe [:rt122/v]) [:li]) {}))
                 reason (:reason data)]
             (is (string? reason))
             (is (re-find #"CARRYING" reason)
@@ -426,9 +426,9 @@
           held (volatile! nil)]
       (with-context-frame f
         (fn []
-          (rt/render-body f (fn [_] (vreset! held (rf/capture-frame f)) [:li]) {})))
+          (rf.bench.hicasso.arm1.runtime/render-body f (fn [_] (vreset! held (rf/capture-frame f)) [:li]) {})))
       (is (= f (:frame @held)))
-      (is (nil? frame/*ambient-frame-refusal*) "the extent has unwound")
+      (is (nil? rf.frame/*ambient-frame-refusal*) "the extent has unwound")
       ((:dispatch-sync @held) [:rt122/bump])
       (is (= 8 @(rf/subscribe [:rt122/v] {:frame f}))
           "the carried api dispatched into its own frame"))))
@@ -444,9 +444,9 @@
           held (volatile! nil)]
       (with-context-frame f
         (fn []
-          (rt/render-body f
+          (rf.bench.hicasso.arm1.runtime/render-body f
                           (fn [_]
-                            (vreset! held (rf/capture-frame (intent/hframe)))
+                            (vreset! held (rf/capture-frame (rf.bench.hicasso.front.intent/hframe)))
                             [:li])
                           {})))
       (is (= f (:frame @held)))
@@ -481,8 +481,8 @@
   "A SECOND live frame, so 'the carried stamp names a different frame' is a
   real frame rather than a keyword nobody registered."
   []
-  (live-frame/make-frame {:id other-frame-id})
-  (frame/replace-app-db! other-frame-id {:v 99})
+  (rf.live-frame/make-frame {:id other-frame-id})
+  (rf.frame/replace-app-db! other-frame-id {:v 99})
   other-frame-id)
 
 (deftest a-mismatched-carried-stamp-is-refused-inside-a-body
@@ -497,7 +497,7 @@
       (with-context-frame f
         (fn []
           (let [data   (rf/with-frame other
-                         (outcome #(rt/render-body f (fn [_] (rf/capture-frame) [:li]) {})))
+                         (outcome #(rf.bench.hicasso.arm1.runtime/render-body f (fn [_] (rf/capture-frame) [:li]) {})))
                 anchor (refusal-id f)]
             (is (some? anchor)
                 "precondition: an ambient read refuses here at all, so the
@@ -522,8 +522,8 @@
       (with-context-frame f
         (fn []
           (rf/with-frame other
-            (let [read     (outcome #(rt/render-body f (fn [_] @(rf/subscribe [:rt122/v]) [:li]) {}))
-                  dispatch (outcome #(rt/render-body f (fn [_] (rf/dispatch [:rt122/bump]) [:li]) {}))]
+            (let [read     (outcome #(rf.bench.hicasso.arm1.runtime/render-body f (fn [_] @(rf/subscribe [:rt122/v]) [:li]) {}))
+                  dispatch (outcome #(rf.bench.hicasso.arm1.runtime/render-body f (fn [_] (rf/dispatch [:rt122/bump]) [:li]) {}))]
               (is (= :subscribe (:operation read)))
               (is (= other (:carried-frame read))
                   (str "an ambient read under a mismatched scope refuses; got "
@@ -542,7 +542,7 @@
       (with-context-frame f
         (fn []
           (let [reason (:reason (rf/with-frame other
-                                  (outcome #(rt/render-body f (fn [_] (rf/capture-frame) [:li]) {}))))]
+                                  (outcome #(rf.bench.hicasso.arm1.runtime/render-body f (fn [_] (rf/capture-frame) [:li]) {}))))]
             (is (string? reason))
             (is (str/includes? reason (pr-str other)) "it names the carried stamp")
             (is (str/includes? reason (pr-str f)) "and the extent's own frame")
@@ -566,7 +566,7 @@
       (with-context-frame f
         (fn []
           (rf/with-frame f
-            (rt/render-body f (fn [_] (vreset! held (rf/capture-frame)) [:li]) {}))))
+            (rf.bench.hicasso.arm1.runtime/render-body f (fn [_] (vreset! held (rf/capture-frame)) [:li]) {}))))
       (is (= f (:frame @held))
           "the ambient carry still answers when the stamp IS the extent's frame")
       ((:dispatch-sync @held) [:rt122/bump])
@@ -589,6 +589,6 @@
       (with-context-frame f
         (fn []
           (rf/with-frame built
-            (rt/render-body f (fn [_] (vreset! held (rf/capture-frame)) [:li]) {}))))
+            (rf.bench.hicasso.arm1.runtime/render-body f (fn [_] (vreset! held (rf/capture-frame)) [:li]) {}))))
       (is (= f (:frame @held))
           "a stamp equal to the extent's frame is the extent's frame"))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/ambient_refusal_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/ambient_refusal_dom_cljs_test.cljs
@@ -30,14 +30,14 @@
   presence tray all render inside or around the refusing extent, and any
   one of them reaching for an ambient frame would take this suite down."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.live-frame :as live-frame]
-            [re-frame.test-support :as test-support]
+            [re-frame.frame :as rf.frame]
+            [re-frame.live-frame :as rf.live-frame]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview defhost]]))
 
@@ -45,17 +45,17 @@
 (rf/reg-event :rt122d/bump (fn [{:keys [db]} _] {:db (update db :v inc)}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::rt122-dom)
 
 (defn- frame! []
-  (lane/leave-act-environment!)
-  (live-frame/make-frame {:id frame-id})
-  (frame/replace-app-db! frame-id {:v 7})
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.live-frame/make-frame {:id frame-id})
+  (rf.frame/replace-app-db! frame-id {:v 7})
   frame-id)
 
 (defn- skip! [why]
@@ -83,7 +83,7 @@
   island's is the ambient one, in the one position where it stays legal."
   [_]
   [:div.page
-   [:output.collector (str (rt/sub [:rt122d/v]))]
+   [:output.collector (str (rf.bench.hicasso.arm1.runtime/sub [:rt122d/v]))]
    [island {}]])
 
 (defn- text-in [handle selector]
@@ -92,13 +92,13 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest an-adapter-island-under-a-hicasso-tree-still-resolves-ambiently
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! "the child-render ordering claim is React's, not the runtime's")
     (testing "a foreign component rendered from a Hicasso body reads its
              frame ambiently and renders the value — the binding unwound
              when the body returned, before React ever called the child"
       (let [f      (frame!)
-            handle (mount/root! (mount/fresh-container!) f [page])]
+            handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) f [page])]
         (try
           (is (= "7" (text-in handle ".collector"))
               "precondition: the boundary itself rendered through its collector")
@@ -106,25 +106,25 @@
               "and the ambient read inside the island resolved the same frame —
                a refusal leaking past the body would have thrown here instead")
           (testing "and it keeps following the frame when the state moves"
-            (mount/dispatch! handle [:rt122d/bump])
-            (mount/settle!)
+            (rf.bench.hicasso.arm1.mount/dispatch! handle [:rt122d/bump])
+            (rf.bench.hicasso.arm1.mount/settle!)
             (is (= "8" (text-in handle ".collector")))
             (is (= "8" (text-in handle ".island"))
                 "the island re-read ambiently on the boundary's re-render"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 (deftest mounting-the-page-at-all-is-the-shells-own-witness
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! "no DOM")
     (testing "the shell's `useContext`, the codec's root element and the
              boundary machinery all run inside or around the refusing
              extent; a page that mounts and paints is each of them proven
              not to have reached for an ambient frame"
       (let [f      (frame!)
-            handle (mount/root! (mount/fresh-container!) f [page])]
+            handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) f [page])]
         (try
           (is (some? (.querySelector (:container handle) ".page"))
               "the tree rendered")
-          (is (nil? frame/*ambient-frame-refusal*)
+          (is (nil? rf.frame/*ambient-frame-refusal*)
               "and the extent is not live outside a body run")
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/boundary.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/boundary.cljs
@@ -78,7 +78,7 @@
   Both are hiccup **data**, written in the parent boundary's body — and
   both are walked by the codec inside **this class's own React render**,
   one render later, after that body's dynamic extent has unwound. So
-  `intent/*dispatch*` was unbound at the moment the codec reached them,
+  `rf.bench.hicasso.front.intent/*dispatch*` was unbound at the moment the codec reached them,
   and before the binding below existed an intent at an event position on
   the fallback or on a native child raised
   `:rf.error/hicasso-intent-outside-boundary` at render, while an `h/event`
@@ -119,10 +119,10 @@
   browser calls outside React's own work loop — an intent handler that
   throws lands in the browser's error channel, not here. That is React's
   boundary, not this arm's, and the arm inherits it exactly."
-  (:require [re-frame.adapter.context :as adapter-context]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.codec :as codec]
-            [re-frame.bench.hicasso.front.intent :as intent]
+  (:require [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
+            [re-frame.bench.hicasso.front.intent :as rf.bench.hicasso.front.intent]
             ["react" :as react]))
 
 (defn- props-of
@@ -134,7 +134,7 @@
 (defn- frame-of
   "The frame this boundary is mounted under, read through `contextType`."
   [^js this]
-  (adapter-context/context-value->current-frame (.-context this)))
+  (rf.adapter.context/context-value->current-frame (.-context this)))
 
 (defn- report!
   "Fire `:on-error` for the failure React just caught. A vector is an
@@ -147,7 +147,7 @@
   (let [on-error (:on-error (props-of this))]
     (cond
       (vector? on-error) (when-some [frame-kw (frame-of this)]
-                           (rt/dispatch! frame-kw (conj on-error error)))
+                           (rf.bench.hicasso.arm1.runtime/dispatch! frame-kw (conj on-error error)))
       (fn? on-error)     (on-error error)
       :else              nil))
   nil)
@@ -176,7 +176,7 @@
     (set! (.-prototype ^js ctor) proto)
     (set! (.-constructor proto) ctor)
     (set! (.-displayName ^js ctor) "hicasso/boundary")
-    (set! (.-contextType ^js ctor) adapter-context/frame-context)
+    (set! (.-contextType ^js ctor) rf.adapter.context/frame-context)
     ;; React 19 requires the static marker for the boundary to catch at
     ;; all. It cannot reach the instance, so it only flips the render
     ;; marker; everything with a side effect is the commit's.
@@ -210,9 +210,9 @@
                 ;; binding is unconditional so the branch does not exist, and
                 ;; an intent written under a frameless boundary still lands on
                 ;; the existing loud error naming the intent.
-                (intent/with-frame frame-kw (when frame-kw (rt/frame-dispatch frame-kw))
+                (rf.bench.hicasso.front.intent/with-frame frame-kw (when frame-kw (rf.bench.hicasso.arm1.runtime/frame-dispatch frame-kw))
                   (fn []
                     (if (some? error)
-                      (codec/as-element (if (fn? fallback) (fallback error) fallback))
-                      (codec/as-element (into [:<>] children)))))))))
-    (codec/mark-boundary! ctor)))
+                      (rf.bench.hicasso.front.codec/as-element (if (fn? fallback) (fallback error) fallback))
+                      (rf.bench.hicasso.front.codec/as-element (into [:<>] children)))))))))
+    (rf.bench.hicasso.front.codec/mark-boundary! ctor)))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/boundary_crossing_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/boundary_crossing_cljs_test.cljs
@@ -43,7 +43,7 @@
 
   ## What closes it
 
-  `codec/realize-deep`, called once on `body-props` in
+  `rf.bench.hicasso.front.codec/realize-deep`, called once on `body-props` in
   `boundary-element`. It forces every lazy sequence reachable from the
   props map — including the `:children` vector, whose one-level flatten
   leaves a nested seq unrealised — and returns the map itself, by
@@ -69,22 +69,22 @@
   layer, so a subscription under it never notifies and every commit
   assertion below would pass by never firing."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.codec :as codec]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
-     :init-fn (fn [] (rt/reset-runtime!))}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
+     :init-fn (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::arm1-boundary-crossing)
 
 (defn- seeded! []
-  (rt/reset-runtime!)
-  (dogfood/make-frame! frame-id 3)
+  (rf.bench.hicasso.arm1.runtime/reset-runtime!)
+  (rf.bench.hicasso.front.dogfood/make-frame! frame-id 3)
   frame-id)
 
 (defn- key-of [query] [frame-id query])
@@ -102,17 +102,17 @@
 (defn- child-body [{:keys [rows]}]
   [:ul.child (for [r rows] [:li.cell (str r)])])
 
-(def ^:private child-view (rt/mint-view! "boundary-crossing/child" child-body))
+(def ^:private child-view (rf.bench.hicasso.arm1.runtime/mint-view! "boundary-crossing/child" child-body))
 
 (defn- parent-body [_]
-  [child-view {:rows (for [id (rt/sub [:dogfood/visible-ids])]
-                       (:title (rt/sub [:dogfood/todo id])))}])
+  [child-view {:rows (for [id (rf.bench.hicasso.arm1.runtime/sub [:dogfood/visible-ids])]
+                       (:title (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo id])))}])
 
 (defn- nested-child-body [{:keys [children]}]
   (into [:ul.nested] children))
 
 (def ^:private nested-child-view
-  (rt/mint-view! "boundary-crossing/nested-child" nested-child-body))
+  (rf.bench.hicasso.arm1.runtime/mint-view! "boundary-crossing/nested-child" nested-child-body))
 
 (defn- nested-parent-body
   "Carrier (b): the seqs are in the CHILDREN position, one level below the
@@ -121,9 +121,9 @@
   `for` on as an element, unrealised."
   [_]
   [nested-child-view
-   (for [chunk (partition-all 2 (rt/sub [:dogfood/visible-ids]))]
+   (for [chunk (partition-all 2 (rf.bench.hicasso.arm1.runtime/sub [:dogfood/visible-ids]))]
      (for [id chunk]
-       [:li.cell {:key id} (str (:title (rt/sub [:dogfood/todo id])))]))])
+       [:li.cell {:key id} (str (:title (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo id])))]))])
 
 (defn- crossing-props
   "The props map the codec built for the crossing — precisely what the
@@ -132,8 +132,8 @@
   (unchecked-get (.-props element) "rfProps"))
 
 (defn- render [body-fn props]
-  (let [element (rt/render-body frame-id body-fn props)]
-    {:element element :entry (rt/last-reads) :reads (rt/reads-of (rt/last-reads))}))
+  (let [element (rf.bench.hicasso.arm1.runtime/render-body frame-id body-fn props)]
+    {:element element :entry (rf.bench.hicasso.arm1.runtime/last-reads) :reads (rf.bench.hicasso.arm1.runtime/reads-of (rf.bench.hicasso.arm1.runtime/last-reads))}))
 
 (defn- mounted!
   "A boundary at the seam React occupies: render the body, commit its
@@ -141,7 +141,7 @@
   [body-fn props]
   (let [{:keys [element entry reads]} (render body-fn props)
         hits    (volatile! 0)
-        release (rt/commit-boundary! entry (fn [] (vswap! hits inc)))]
+        release (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn [] (vswap! hits inc)))]
     {:element element :entry entry :reads reads :hits hits :release! release}))
 
 (def ^:private row-keys
@@ -214,10 +214,10 @@
            props are the same object and its seq is already realised."
     (let [parent (mounted! parent-body {})
           child  (mounted! child-body (crossing-props (:element parent)))]
-      (is (= 4 (:edges (rt/stats)))
+      (is (= 4 (:edges (rf.bench.hicasso.arm1.runtime/stats)))
           "four edges, all of them the parent's: the ids query and one per row")
-      (rt/dispatch! frame-id [:dogfood/edit-draft 1 "crossed"])
-      (rt/dispatch! frame-id [:dogfood/commit 1])
+      (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/edit-draft 1 "crossed"])
+      (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/commit 1])
       (is (= 1 @(:hits parent))
           "the parent re-runs, so the seq is rebuilt and the child receives
            a new one")
@@ -233,8 +233,8 @@
         child  (mounted! child-body (crossing-props (:element parent)))]
     ((:release! child))
     ((:release! parent))
-    (rt/reset-runtime!)
-    (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0} (rt/residue)))))
+    (rf.bench.hicasso.arm1.runtime/reset-runtime!)
+    (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0} (rf.bench.hicasso.arm1.runtime/residue)))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3 — the walk itself: what it forces, and what it must not disturb
@@ -245,12 +245,12 @@
            nothing and the props map the child receives is the map the
            codec built — no copy, no fresh identity for React to see"
     (let [m {:rows (map inc (range 3)) :label "x"}]
-      (is (identical? m (codec/realize-deep m)))
-      (is (identical? (:rows m) (:rows (codec/realize-deep m))))))
+      (is (identical? m (rf.bench.hicasso.front.codec/realize-deep m)))
+      (is (identical? (:rows m) (:rows (rf.bench.hicasso.front.codec/realize-deep m))))))
   (testing "a scalar and a nil pass straight through"
-    (is (= 7 (codec/realize-deep 7)))
-    (is (nil? (codec/realize-deep nil)))
-    (is (= "s" (codec/realize-deep "s")))))
+    (is (= 7 (rf.bench.hicasso.front.codec/realize-deep 7)))
+    (is (nil? (rf.bench.hicasso.front.codec/realize-deep nil)))
+    (is (= "s" (rf.bench.hicasso.front.codec/realize-deep "s")))))
 
 (deftest realize-deep-forces-every-lazy-seq-it-can-reach
   (testing "the reach is the one `clj->js` already has at a native prop
@@ -263,7 +263,7 @@
                            ["a seq inside a set"    (fn [!n] {:v #{(map (fn [i] (vswap! !n inc) i) (range 3))}})]]]
       (let [!n (volatile! 0)
             v  (build !n)]
-        (codec/realize-deep v)
+        (rf.bench.hicasso.front.codec/realize-deep v)
         (is (= 3 @!n) label)))))
 
 (deftest realize-deep-walks-map-keys-without-disturbing-the-map
@@ -274,7 +274,7 @@
            the map hashed has moved"
     (let [composite [:composite 1]
           m         {composite :a :plain :b "s" :c 7 :d}
-          walked    (codec/realize-deep m)]
+          walked    (rf.bench.hicasso.front.codec/realize-deep m)]
       (is (identical? m walked))
       (is (= m walked))
       (is (= (keys m) (keys walked)))
@@ -287,7 +287,7 @@
   (testing "a map big enough to be a hash map rather than an array map is
            equally untouched"
     (let [m      (into {} (map (fn [i] [[:k i] i]) (range 32)))
-          walked (codec/realize-deep m)]
+          walked (rf.bench.hicasso.front.codec/realize-deep m)]
       (is (identical? m walked))
       (is (= 32 (count walked)))
       (is (= 17 (get walked [:k 17]))))))
@@ -304,7 +304,7 @@
           at-construction @!n]
       (is (zero? at-construction)
           "constructing the map neither hashed nor compared the key")
-      (codec/realize-deep m)
+      (rf.bench.hicasso.front.codec/realize-deep m)
       (is (= 3 @!n)
           "and the walk reaches it, inside the window of the body that
            wrote it"))))
@@ -320,16 +320,16 @@
   (testing "and the guard skips the KEY, never the entry: a keyword-keyed
            entry's value half is walked exactly as before"
     (is (thrown-with-msg? js/Error #"unforced `delay` reached a boundary's props"
-                          (codec/realize-deep {:k (delay 1)})))
+                          (rf.bench.hicasso.front.codec/realize-deep {:k (delay 1)})))
     (let [!n (volatile! 0)]
-      (codec/realize-deep {:k (map (fn [i] (vswap! !n inc) i) (range 3))})
+      (rf.bench.hicasso.front.codec/realize-deep {:k (map (fn [i] (vswap! !n inc) i) (range 3))})
       (is (= 3 @!n)))))
 
 (deftest realize-deep-does-not-walk-into-a-react-element-or-a-function
   (testing "a React element is an opaque JS object and a function is a
            value, not a structure; neither is a collection and neither is
            descended into"
-    (let [el (codec/as-element [:li "a"])
+    (let [el (rf.bench.hicasso.front.codec/as-element [:li "a"])
           f  (fn [] :never-called)]
-      (is (identical? el (codec/realize-deep el)))
-      (is (identical? f (codec/realize-deep f))))))
+      (is (identical? el (rf.bench.hicasso.front.codec/realize-deep el)))
+      (is (identical? f (rf.bench.hicasso.front.codec/realize-deep f))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/boundary_crossing_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/boundary_crossing_dom_cljs_test.cljs
@@ -32,19 +32,19 @@
   Runtime: `-dom-cljs-test`; under `:node-test` every claim degrades to a
   stated skip."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.test-support :as test-support])
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.test-support :as rf.test-support])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn (fn [] (rt/reset-runtime!))}))
+     :init-fn (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::arm1-boundary-crossing-dom)
 (def ^:private todo-count 6)
@@ -52,9 +52,9 @@
 (defn- skip! [why] (is true (str "a boundary-crossing claim needs a real React DOM — " why)))
 
 (defn- fresh! []
-  (lane/leave-act-environment!)
-  (dogfood/make-frame! frame-id todo-count)
-  (dogfood/reseed! frame-id todo-count)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.front.dogfood/make-frame! frame-id todo-count)
+  (rf.bench.hicasso.front.dogfood/reseed! frame-id todo-count)
   frame-id)
 
 (defn- cell-text [handle id]
@@ -67,10 +67,10 @@
 (defn- retitle!
   "Move one row's `:dogfood/todo` query, through the arm's own door."
   [id title]
-  (rt/dispatch! frame-id [:dogfood/edit-draft id title])
-  (mount/settle!)
-  (rt/dispatch! frame-id [:dogfood/commit id])
-  (mount/settle!)
+  (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/edit-draft id title])
+  (rf.bench.hicasso.arm1.mount/settle!)
+  (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/commit id])
+  (rf.bench.hicasso.arm1.mount/settle!)
   nil)
 
 ;; ---------------------------------------------------------------------------
@@ -91,21 +91,21 @@
   defers every row read into the seq it hands across the crossing."
   [_]
   [crossing-child
-   {:rows (for [id (rt/sub [:dogfood/visible-ids])]
-            [id (:title (rt/sub [:dogfood/todo id]))])}])
+   {:rows (for [id (rf.bench.hicasso.arm1.runtime/sub [:dogfood/visible-ids])]
+            [id (:title (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo id]))])}])
 
 (deftest a-read-deferred-across-a-boundarys-props-still-moves-the-dom
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [crossing-parent {}])]
+      (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [crossing-parent {}])]
         (try
           (is (= todo-count (cell-count handle)))
           (is (= "todo 2" (cell-text handle 2))
               "the first paint is right — which is exactly what the broken
                runtime also gives you, and why this row proves nothing alone")
-          (let [edges-at-mount (:edges (rt/stats))]
+          (let [edges-at-mount (:edges (rf.bench.hicasso.arm1.runtime/stats))]
             (retitle! 2 "crossed")
             (is (= "crossed" (cell-text handle 2))
                 "**the second half.** A write to a row query the PARENT
@@ -113,14 +113,14 @@
                  boundary that can rebuild the seq, and it did")
             (is (= "todo 1" (cell-text handle 1))
                 "while its neighbour is untouched")
-            (is (= edges-at-mount (:edges (rt/stats)))
+            (is (= edges-at-mount (:edges (rf.bench.hicasso.arm1.runtime/stats)))
                 "and the edges survived the re-render — the failure mode was
                  that the wrong reader re-rendered ONCE, read nothing the
                  second time, and left the row with no edge at all"))
           (testing "and it is not a one-shot correction: the value keeps moving"
             (retitle! 2 "crossed again")
             (is (= "crossed again" (cell-text handle 2))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Carrier (b) — a nested seq in the CHILDREN position
@@ -138,16 +138,16 @@
   outer spine and hands each inner seq on as an element."
   [_]
   [nested-child
-   (for [chunk (partition-all 2 (rt/sub [:dogfood/visible-ids]))]
+   (for [chunk (partition-all 2 (rf.bench.hicasso.arm1.runtime/sub [:dogfood/visible-ids]))]
      (for [id chunk]
-       [:li.cell {:key id :data-id id} (str (:title (rt/sub [:dogfood/todo id])))]))])
+       [:li.cell {:key id :data-id id} (str (:title (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo id])))]))])
 
 (deftest a-read-deferred-into-a-boundarys-nested-children-still-moves-the-dom
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [nested-parent {}])]
+      (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [nested-parent {}])]
         (try
           (is (= todo-count (cell-count handle)))
           (is (= "todo 4" (cell-text handle 4)) "the first paint is right")
@@ -157,4 +157,4 @@
                parent too, and its write reaches the DOM")
           (is (= "todo 3" (cell-text handle 3))
               "while its chunk-mate is untouched")
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/cell_table_laws_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/cell_table_laws_cljs_test.cljs
@@ -24,8 +24,8 @@
   their subject entirely rather than partially — and they are ported
   here, one `deftest` per law under its own number, discharged against
   the runtime's own doors rather than against a rebuilt value algebra:
-  [[rt/commit-boundary!]] (the seam React occupies), [[rt/dispatch!]]
-  (which drives `flush!`), [[rt/stats]] and [[rt/cell-readers]]. That
+  [[rf.bench.hicasso.arm1.runtime/commit-boundary!]] (the seam React occupies), [[rf.bench.hicasso.arm1.runtime/dispatch!]]
+  (which drives `flush!`), [[rf.bench.hicasso.arm1.runtime/stats]] and [[rf.bench.hicasso.arm1.runtime/cell-readers]]. That
   seam exists precisely so the commit path is provable without a browser,
   and driving the real thing is what makes these rows evidence rather
   than a restatement.
@@ -64,34 +64,34 @@
   here from `front/dogfood_cljs_test` — it drove the retired index's pure
   algebra directly, and the fused doors need a substrate that moves."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      ;; The map shape, because the residue claims are `async` — a reaper
      ;; horizon is not observable inside one synchronous test body.
      :async?  true
-     :init-fn (fn [] (rt/reset-runtime!) (rt/set-evidence-sink! nil))}))
+     :init-fn (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!) (rf.bench.hicasso.arm1.runtime/set-evidence-sink! nil))}))
 
 (def ^:private frame-id ::cell-table-laws)
 
 (defn- seeded!
   ([] (seeded! 3))
-  ([n] (rt/reset-runtime!) (dogfood/make-frame! frame-id n) frame-id))
+  ([n] (rf.bench.hicasso.arm1.runtime/reset-runtime!) (rf.bench.hicasso.front.dogfood/make-frame! frame-id n) frame-id))
 
 (defn- key-of [query] [frame-id query])
 
 (defn- render!
-  "One body run through the shell's own fence, exactly as `rt/shell` does
+  "One body run through the shell's own fence, exactly as `rf.bench.hicasso.arm1.runtime/shell` does
   — minus React, which contributes nothing to what is asserted. Answers
   the read-set entry."
   [body-fn]
-  (rt/render-body frame-id body-fn {})
-  (rt/last-reads))
+  (rf.bench.hicasso.arm1.runtime/render-body frame-id body-fn {})
+  (rf.bench.hicasso.arm1.runtime/last-reads))
 
 (defn- mount!
   "One boundary at the seam React occupies: render its body, commit its
@@ -104,8 +104,8 @@
   [body-fn]
   (let [entry (render! body-fn)
         hits  (volatile! 0)
-        stop  (rt/commit-boundary! entry (fn [] (vswap! hits inc)))
-        reg   (last (rt/cell-readers (first (rt/reads-of entry))))]
+        stop  (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn [] (vswap! hits inc)))
+        reg   (last (rf.bench.hicasso.arm1.runtime/cell-readers (first (rf.bench.hicasso.arm1.runtime/reads-of entry))))]
     {:entry entry :reg reg :hits hits :stop! stop}))
 
 (defn- stop-all! [& boundaries]
@@ -118,24 +118,24 @@
 
 (deftest law-1-a-committed-sub-dirties-its-own-reader-only
   (seeded! 3)
-  (let [row-1  (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 1]))
-                                (str (rt/sub [:dogfood/draft 1]))]))
-        row-2  (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 2]))]))
-        header (mount! (fn [_] [:span (str (rt/sub [:dogfood/remaining]))]))]
+  (let [row-1  (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1]))
+                                (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/draft 1]))]))
+        row-2  (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 2]))]))
+        header (mount! (fn [_] [:span (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))]))]
     (try
       ;; `edit-draft` moves the draft and nothing else — one dirty key,
       ;; which is what makes this law-1 rather than law-5.
-      (rt/dispatch! frame-id [:dogfood/edit-draft 1 "half-typed"])
+      (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/edit-draft 1 "half-typed"])
       (testing "the reader of the dirty sub re-runs"
         (is (= 1 @(:hits row-1))))
       (testing "and nobody else does — not the sibling row, not the header"
         (is (= 0 @(:hits row-2)))
         (is (= 0 @(:hits header))))
       (testing "the dirty key's reader list holds that boundary and no other"
-        (is (= [(:reg row-1)] (rt/cell-readers (key-of [:dogfood/draft 1])))))
+        (is (= [(:reg row-1)] (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:dogfood/draft 1])))))
       (testing "a boundary's second read is an independent edge, not a merge"
-        (is (= [(:reg row-1)] (rt/cell-readers (key-of [:dogfood/todo 1]))))
-        (is (= [(:reg row-2)] (rt/cell-readers (key-of [:dogfood/todo 2])))))
+        (is (= [(:reg row-1)] (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:dogfood/todo 1]))))
+        (is (= [(:reg row-2)] (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:dogfood/todo 2])))))
       (finally (stop-all! row-1 row-2 header)))))
 
 ;; ===========================================================================
@@ -144,26 +144,26 @@
 
 (deftest law-2-a-shared-sub-dirties-every-sharer
   (seeded! 3)
-  (let [a (mount! (fn [_] [:span (str (rt/sub [:dogfood/remaining]))]))
-        b (mount! (fn [_] [:span (str (rt/sub [:dogfood/remaining]))]))
-        c (mount! (fn [_] [:span (str (rt/sub [:dogfood/remaining]))
-                           (str (rt/sub [:dogfood/draft 0]))]))]
+  (let [a (mount! (fn [_] [:span (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))]))
+        b (mount! (fn [_] [:span (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))]))
+        c (mount! (fn [_] [:span (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))
+                           (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/draft 0]))]))]
     (try
       (testing "ONE cell for the shared key, holding all three readers —
                shared structure, not per-boundary fan-out, which is the
                claim the two-global-maps design used to carry and the
                fused table carries with one container fewer"
-        (is (= 3 (count (rt/cell-readers (key-of [:dogfood/remaining])))))
+        (is (= 3 (count (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:dogfood/remaining])))))
         (is (= #{(:reg a) (:reg b) (:reg c)}
-               (set (rt/cell-readers (key-of [:dogfood/remaining])))))
-        (is (= 2 (:cells (rt/stats))) "remaining, and c's own draft key"))
+               (set (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:dogfood/remaining])))))
+        (is (= 2 (:cells (rf.bench.hicasso.arm1.runtime/stats))) "remaining, and c's own draft key"))
       (testing "every reader of the shared key runs, and only them"
-        (rt/dispatch! frame-id [:dogfood/toggle 1])
+        (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 1])
         (is (= 1 @(:hits a)))
         (is (= 1 @(:hits b)))
         (is (= 1 @(:hits c))))
       (testing "a key one of them additionally reads dirties only that one"
-        (rt/dispatch! frame-id [:dogfood/edit-draft 0 "mine alone"])
+        (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/edit-draft 0 "mine alone"])
         (is (= 1 @(:hits a)))
         (is (= 1 @(:hits b)))
         (is (= 2 @(:hits c))))
@@ -176,31 +176,31 @@
 (deftest law-3-unmount-removes-every-edge-the-boundary-held
   (async done
     (seeded! 3)
-    (let [gone (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                                (str (rt/sub [:dogfood/draft 0]))]))
-          stay (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))]
-      (is (= 3 (:edges (rt/stats))) "two edges and one, before the departure")
+    (let [gone (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                                (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/draft 0]))]))
+          stay (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))]
+      (is (= 3 (:edges (rf.bench.hicasso.arm1.runtime/stats))) "two edges and one, before the departure")
       ((:stop! gone))
       (testing "the shared key keeps the survivor and loses the departed"
-        (is (= [(:reg stay)] (rt/cell-readers (key-of [:dogfood/todo 0])))))
+        (is (= [(:reg stay)] (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:dogfood/todo 0])))))
       (testing "the key only the departed read has no reader left"
-        (is (= [] (rt/cell-readers (key-of [:dogfood/draft 0])))))
+        (is (= [] (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:dogfood/draft 0])))))
       (testing "and the departure is final: a later write reaches the
                survivor and never the departed"
-        (rt/dispatch! frame-id [:dogfood/edit-draft 0 "after the exit"])
+        (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/edit-draft 0 "after the exit"])
         (is (= 0 @(:hits gone)))
         (is (= 0 @(:hits stay)))
-        (rt/dispatch! frame-id [:dogfood/toggle 0])
+        (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 0])
         (is (= 0 @(:hits gone)))
         (is (= 1 @(:hits stay))))
-      (is (= 1 (:edges (rt/stats))) "one membership survives, and it is the survivor's")
+      (is (= 1 (:edges (rf.bench.hicasso.arm1.runtime/stats))) "one membership survives, and it is the survivor's")
       ;; A cell whose readers all left is REAPED, which is the fused
       ;; counterpart of the old index dropping an emptied reader set
       ;; rather than retaining it — an index that kept empty sets grew
       ;; without bound across a long session, and a table that kept
       ;; readerless cells would too.
       (js/setTimeout (fn []
-                       (is (= 1 (:cells (rt/stats)))
+                       (is (= 1 (:cells (rf.bench.hicasso.arm1.runtime/stats)))
                            "the readerless key left the table entirely")
                        ((:stop! stay))
                        (done))
@@ -220,25 +220,25 @@
            registration; React's own sequence — the previous cleanup,
            then the new subscribe — performs the whole edge-set
            replacement. rf2-2rtt6.47, rf2-dabt3"
-    (let [wide (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                                (str (rt/sub [:dogfood/todo 1]))]))]
-      (is (= 2 (:edges (rt/stats))))
+    (let [wide (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                                (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1]))]))]
+      (is (= 2 (:edges (rf.bench.hicasso.arm1.runtime/stats))))
       ((:stop! wide))
-      (let [narrow (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))]
+      (let [narrow (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))]
         (testing "the edge the second run did not read is dropped"
-          (is (= #{(key-of [:dogfood/todo 0])} (rt/boundary-reads (:reg narrow))))
-          (is (= [] (rt/cell-readers (key-of [:dogfood/todo 1]))))
-          (rt/dispatch! frame-id [:dogfood/toggle 1])
+          (is (= #{(key-of [:dogfood/todo 0])} (rf.bench.hicasso.arm1.runtime/boundary-reads (:reg narrow))))
+          (is (= [] (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:dogfood/todo 1]))))
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 1])
           (is (= 0 @(:hits narrow))))
         (testing "the edge it did read survives untouched"
-          (rt/dispatch! frame-id [:dogfood/toggle 0])
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 0])
           (is (= 1 @(:hits narrow))))
         ((:stop! narrow)))
       (testing "and a third run that reads it again restores the edge"
-        (let [again (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                                     (str (rt/sub [:dogfood/todo 1]))]))]
-          (is (= 2 (:edges (rt/stats))))
-          (rt/dispatch! frame-id [:dogfood/toggle 1])
+        (let [again (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                                     (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1]))]))]
+          (is (= 2 (:edges (rf.bench.hicasso.arm1.runtime/stats))))
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 1])
           (is (= 1 @(:hits again)))
           ((:stop! again))))
       (testing "a re-run that reads nothing leaves the boundary holding no
@@ -246,10 +246,10 @@
                MEANS here, because the table has no registration record
                beside the memberships"
         (let [entry (render! (fn [_] [:li "static"]))
-              stop  (rt/commit-boundary! entry (fn []))]
-          (is (= #{} (rt/reads-of entry)))
-          (is (= 0 (:edges (rt/stats))))
-          (is (= 0 (:boundaries (rt/stats))))
+              stop  (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn []))]
+          (is (= #{} (rf.bench.hicasso.arm1.runtime/reads-of entry)))
+          (is (= 0 (:edges (rf.bench.hicasso.arm1.runtime/stats))))
+          (is (= 0 (:boundaries (rf.bench.hicasso.arm1.runtime/stats))))
           (stop))))))
 
 ;; ===========================================================================
@@ -258,30 +258,30 @@
 
 (deftest law-5-the-broad-dirty-set-is-the-union-of-the-readers
   (seeded! 3)
-  (let [r1  (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 1]))
-                             (str (rt/sub [:dogfood/remaining]))]))
-        r2  (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 2]))]))
-        hdr (mount! (fn [_] [:span (str (rt/sub [:dogfood/remaining]))]))]
+  (let [r1  (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1]))
+                             (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))]))
+        r2  (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 2]))]))
+        hdr (mount! (fn [_] [:span (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))]))]
     (try
       (testing "**the union does not double-count its overlap.** A toggle
                moves BOTH of r1's keys in one commit, and r1 is notified
                ONCE — the obligation a per-cell reader walk has to carry
                that a single reverse-edge map carried for free"
-        (rt/dispatch! frame-id [:dogfood/toggle 1])
+        (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 1])
         (is (= 1 @(:hits r1)))
         (is (= 1 @(:hits hdr)) "and the other reader of the shared key ran")
         (is (= 0 @(:hits r2)) "and the row that read neither did not"))
       (testing "a commit whose keys nobody shares is the plain union"
-        (rt/with-commit (fn []
-                          (rt/dispatch! frame-id [:dogfood/edit-draft 1 "a"])
-                          (rt/dispatch! frame-id [:dogfood/edit-draft 2 "b"])))
+        (rf.bench.hicasso.arm1.runtime/with-commit (fn []
+                          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/edit-draft 1 "a"])
+                          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/edit-draft 2 "b"])))
         (is (= 1 @(:hits r1)) "neither draft is read by anybody")
         (is (= 1 @(:hits hdr)))
         (is (= 0 @(:hits r2))))
       (testing "the empty commit dirties nothing"
-        (let [g (rt/generation)]
-          (rt/with-commit (fn []))
-          (is (= g (rt/generation)))
+        (let [g (rf.bench.hicasso.arm1.runtime/generation)]
+          (rf.bench.hicasso.arm1.runtime/with-commit (fn []))
+          (is (= g (rf.bench.hicasso.arm1.runtime/generation)))
           (is (= 1 @(:hits r1)))))
       (finally (stop-all! r1 r2 hdr)))))
 
@@ -291,25 +291,25 @@
 
 (deftest law-6-an-unknown-dirty-sub-yields-the-empty-set
   (seeded! 3)
-  (let [row-1 (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 1]))]))]
+  (let [row-1 (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1]))]))]
     (try
       (testing "a key nobody reads has no reader"
-        (is (= [] (rt/cell-readers (key-of [:dogfood/todo 2]))))
-        (is (= [] (rt/cell-readers (key-of [:dogfood/draft 1])))))
+        (is (= [] (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:dogfood/todo 2]))))
+        (is (= [] (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:dogfood/draft 1])))))
       (testing "a write that moves only unread keys notifies nobody"
-        (rt/dispatch! frame-id [:dogfood/edit-draft 2 "nobody reads this"])
+        (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/edit-draft 2 "nobody reads this"])
         (is (= 0 @(:hits row-1))))
       (testing "an unread key mixed into a read one adds no phantom"
-        (rt/with-commit (fn []
-                          (rt/dispatch! frame-id [:dogfood/toggle 1])
-                          (rt/dispatch! frame-id [:dogfood/edit-draft 2 "still nobody"])))
+        (rf.bench.hicasso.arm1.runtime/with-commit (fn []
+                          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 1])
+                          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/edit-draft 2 "still nobody"])))
         (is (= 1 @(:hits row-1))))
       (testing "and asking about an unread key does not intern it — the
                fused table has nowhere to intern one, which is stronger
                than the old index's `get` with a default"
-        (let [before (:cells (rt/stats))]
-          (is (= [] (rt/cell-readers (key-of [:no-such/query]))))
-          (is (= before (:cells (rt/stats))))))
+        (let [before (:cells (rf.bench.hicasso.arm1.runtime/stats))]
+          (is (= [] (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:no-such/query]))))
+          (is (= before (:cells (rf.bench.hicasso.arm1.runtime/stats))))))
       (testing "**the fused table's own version of an unknown key, and the
                one the retired index could not have.** A cell outlives its
                last reader by a reaper's grace, so between a cleanup and
@@ -317,9 +317,9 @@
                reader list. A write that dirties it must contribute
                nothing — the same claim law 6 makes about a key nobody
                ever read, now about a key nobody reads any more"
-        (let [tmp (mount! (fn [_] [:li (str (rt/sub [:dogfood/draft 1]))]))]
+        (let [tmp (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/draft 1]))]))]
           ((:stop! tmp))
-          (rt/dispatch! frame-id [:dogfood/edit-draft 1 "into the void"])
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/edit-draft 1 "into the void"])
           (is (= 0 @(:hits tmp)))
           (is (= 1 @(:hits row-1))
               "and the live boundary is not swept up by the readerless cell")))
@@ -338,32 +338,32 @@
            now taken through the fused doors against real notifications
            rather than against a value algebra"
     (seeded! 3)
-    (let [header (mount! (fn [_] [:span (str (rt/sub [:dogfood/remaining]))
-                                  (str (rt/sub [:dogfood/visible-ids]))]))
-          row-0  (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                                  (str (rt/sub [:dogfood/done? 0]))]))
-          row-1  (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 1]))
-                                  (str (rt/sub [:dogfood/done? 1]))]))]
+    (let [header (mount! (fn [_] [:span (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))
+                                  (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/visible-ids]))]))
+          row-0  (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                                  (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/done? 0]))]))
+          row-1  (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1]))
+                                  (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/done? 1]))]))]
       (try
         (testing "the narrow write dirties the one row and the header that counts it"
-          (rt/dispatch! frame-id [:dogfood/toggle 1])
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 1])
           (is (= 1 @(:hits row-1)))
           (is (= 1 @(:hits header)))
           (is (= 0 @(:hits row-0))))
         (testing "the broad write dirties every reader of the list"
-          (rt/dispatch! frame-id [:dogfood/set-filter :active])
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/set-filter :active])
           (is (= 2 @(:hits header)))
           (is (= 1 @(:hits row-1)))
           (is (= 0 @(:hits row-0))))
         (testing "a to-do nobody has mounted a row for dirties nothing"
-          (rt/dispatch! frame-id [:dogfood/edit-draft 2 "no row for this"])
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/edit-draft 2 "no row for this"])
           (is (= 2 @(:hits header)))
           (is (= 1 @(:hits row-1)))
           (is (= 0 @(:hits row-0))))
         (testing "unmounting a row takes its edges with it"
           ((:stop! row-1))
-          (is (= [] (rt/cell-readers (key-of [:dogfood/done? 1]))))
-          (rt/dispatch! frame-id [:dogfood/toggle 1])
+          (is (= [] (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:dogfood/done? 1]))))
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 1])
           (is (= 1 @(:hits row-1)) "no further notification for the departed")
           (is (= 3 @(:hits header)) "and the header still counts"))
         (finally (stop-all! header row-0))))))
@@ -374,13 +374,13 @@
 
 (deftest sub-key-identity-is-value-equality-over-query-and-args
   (seeded! 3)
-  (let [row (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 1]))]))]
+  (let [row (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1]))]))]
     (try
       (testing "same query-id, same args — one key, however it was constructed"
         (is (= [(:reg row)]
-               (rt/cell-readers [frame-id (vec [:dogfood/todo (+ 0 1)])]))))
+               (rf.bench.hicasso.arm1.runtime/cell-readers [frame-id (vec [:dogfood/todo (+ 0 1)])]))))
       (testing "same query-id, different args — different keys"
-        (is (= [] (rt/cell-readers (key-of [:dogfood/todo 2])))))
+        (is (= [] (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:dogfood/todo 2])))))
       (finally (stop-all! row)))))
 
 (deftest an-abandoned-render-writes-nothing-because-the-only-write-is-the-commits
@@ -395,22 +395,22 @@
            witness rather than a guard — and it is the stronger of the
            two, because a guard can be removed while a structure cannot
            acquire a write path by accident"
-    (let [before (rt/stats)]
-      (render! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                        (str (rt/sub [:dogfood/remaining]))]))
-      (let [after (rt/stats)]
+    (let [before (rf.bench.hicasso.arm1.runtime/stats)]
+      (render! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                        (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))]))
+      (let [after (rf.bench.hicasso.arm1.runtime/stats)]
         (is (= (:boundaries before) (:boundaries after)) "no boundary registered")
         (is (= (:edges before) (:edges after)) "no edge added")
         (is (= (:cells before) (:cells after)) "no cell built")))
     (testing "and a body run AFTER its boundary's cleanup adds nothing
              either, which is exactly what the old guard existed for"
-      (let [b (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))]
+      (let [b (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))]
         ((:stop! b))
-        (is (= 0 (:edges (rt/stats))))
-        (render! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                          (str (rt/sub [:dogfood/todo 1]))]))
-        (is (= 0 (:edges (rt/stats))))
-        (rt/dispatch! frame-id [:dogfood/toggle 0])
+        (is (= 0 (:edges (rf.bench.hicasso.arm1.runtime/stats))))
+        (render! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                          (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1]))]))
+        (is (= 0 (:edges (rf.bench.hicasso.arm1.runtime/stats))))
+        (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 0])
         (is (= 0 @(:hits b)))))))
 
 (deftest a-double-subscribe-and-its-two-cleanups-leave-zero-residue
@@ -423,26 +423,26 @@
              than one registration mounted twice, and what the old test
              actually protected — the second pass must not corrupt the
              first's edges, and neither must survive teardown — is this"
-      (let [entry (render! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
+      (let [entry (render! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))
             hits  (volatile! 0)
-            stop-1 (rt/commit-boundary! entry (fn [] (vswap! hits inc)))
-            stop-2 (rt/commit-boundary! entry (fn [] (vswap! hits inc)))]
-        (is (= 2 (count (rt/cell-readers (key-of [:dogfood/todo 0]))))
+            stop-1 (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn [] (vswap! hits inc)))
+            stop-2 (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn [] (vswap! hits inc)))]
+        (is (= 2 (count (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:dogfood/todo 0]))))
             "two registrations, one entry, one cell")
-        (is (= 2 (:boundaries (rt/stats))))
-        (rt/dispatch! frame-id [:dogfood/toggle 0])
+        (is (= 2 (:boundaries (rf.bench.hicasso.arm1.runtime/stats))))
+        (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 0])
         (is (= 2 @hits) "both are notified, once each")
         (stop-1)
-        (is (= 1 (count (rt/cell-readers (key-of [:dogfood/todo 0]))))
+        (is (= 1 (count (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:dogfood/todo 0]))))
             "the first cleanup removes ITS membership and not the other's")
         (stop-2)
-        (is (= [] (rt/cell-readers (key-of [:dogfood/todo 0]))))
+        (is (= [] (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:dogfood/todo 0]))))
         (is (= {:cells 1 :cell-refs 0 :boundaries 0 :edges 0 :entries 1}
-               (rt/residue))
+               (rf.bench.hicasso.arm1.runtime/residue))
             "no membership survives; the cell and the entry await the reaper")
         (js/setTimeout (fn []
                          (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                                (rt/residue))
+                                (rf.bench.hicasso.arm1.runtime/residue))
                              "and nothing survives the macrotask horizon")
                          (done))
                        8)))))
@@ -460,12 +460,12 @@
            anything now, and the sharing claim is one step shorter and
            one step stronger: the registration's read set IS the entry's,
            so the fused table stores no forward edge at all"
-    (let [b (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                             (str (rt/sub [:dogfood/remaining]))]))]
+    (let [b (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                             (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))]))]
       (try
-        (is (identical? (rt/reads-of (:entry b)) (rt/boundary-reads (:reg b))))
+        (is (identical? (rf.bench.hicasso.arm1.runtime/reads-of (:entry b)) (rf.bench.hicasso.arm1.runtime/boundary-reads (:reg b))))
         (is (= #{(key-of [:dogfood/todo 0]) (key-of [:dogfood/remaining])}
-               (rt/boundary-reads (:reg b))))
+               (rf.bench.hicasso.arm1.runtime/boundary-reads (:reg b))))
         (finally (stop-all! b))))))
 
 (deftest one-membership-is-both-the-edge-and-the-reference
@@ -481,13 +481,13 @@
              a second record has to make two numbers disagree"
       (let [steps (volatile! [])
             note! (fn [step]
-                    (let [s (rt/stats)]
+                    (let [s (rf.bench.hicasso.arm1.runtime/stats)]
                       (vswap! steps conj [step (:cell-refs s) (:edges s)])))]
         (note! :empty)
-        (let [a (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                                 (str (rt/sub [:dogfood/todo 1]))]))]
+        (let [a (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                                 (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1]))]))]
           (note! :one-boundary-two-reads)
-          (let [b (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))]
+          (let [b (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))]
             (note! :a-shared-key)
             ((:stop! a))
             (note! :the-wide-one-leaves)
@@ -503,7 +503,7 @@
                  every step, because they are one membership")
             (js/setTimeout (fn []
                              (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                                    (rt/residue)))
+                                    (rf.bench.hicasso.arm1.runtime/residue)))
                              (done))
                            8)))))))
 
@@ -519,17 +519,17 @@
            being redesigned (rf2-dabt3)"
     (let [seen (atom [])]
       (testing "with no sink attached the table does its work and says nothing"
-        (let [b (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))]
-          (rt/dispatch! frame-id [:dogfood/toggle 0])
+        (let [b (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))]
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 0])
           (is (= 1 @(:hits b)))
           (is (= [] @seen))
           ((:stop! b))))
       (testing "an attached sink sees the edge change and the commit"
         (seeded! 3)
-        (rt/set-evidence-sink! (fn [ev] (swap! seen conj ev)))
+        (rf.bench.hicasso.arm1.runtime/set-evidence-sink! (fn [ev] (swap! seen conj ev)))
         (try
-          (let [b (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))]
-            (rt/dispatch! frame-id [:dogfood/toggle 0])
+          (let [b (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))]
+            (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 0])
             (let [[edges commit] @seen]
               (is (= 2 (count @seen)))
               (is (= :edges-changed (:event edges)))
@@ -543,24 +543,24 @@
               (is (contains? (:dirty-subs commit) (key-of [:dogfood/todo 0])))
               (is (= #{(:reg b)} (:dirty-boundaries commit))))
             ((:stop! b)))
-          (finally (rt/set-evidence-sink! nil))))
+          (finally (rf.bench.hicasso.arm1.runtime/set-evidence-sink! nil))))
       (testing "a boundary that read nothing emits no edge change — the
                seam reports change, not traffic"
         (seeded! 3)
         (reset! seen [])
-        (rt/set-evidence-sink! (fn [ev] (swap! seen conj ev)))
+        (rf.bench.hicasso.arm1.runtime/set-evidence-sink! (fn [ev] (swap! seen conj ev)))
         (try
           (let [entry (render! (fn [_] [:li "static"]))
-                stop  (rt/commit-boundary! entry (fn []))]
+                stop  (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn []))]
             (is (= [] @seen))
             (stop))
-          (finally (rt/set-evidence-sink! nil))))
+          (finally (rf.bench.hicasso.arm1.runtime/set-evidence-sink! nil))))
       (testing "detaching restores silence"
         (seeded! 3)
         (reset! seen [])
-        (rt/set-evidence-sink! (fn [ev] (swap! seen conj ev)))
-        (rt/set-evidence-sink! nil)
-        (let [b (mount! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))]
-          (rt/dispatch! frame-id [:dogfood/toggle 0])
+        (rf.bench.hicasso.arm1.runtime/set-evidence-sink! (fn [ev] (swap! seen conj ev)))
+        (rf.bench.hicasso.arm1.runtime/set-evidence-sink! nil)
+        (let [b (mount! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))]
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 0])
           (is (= [] @seen))
           ((:stop! b)))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/cold_read_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/cold_read_cljs_test.cljs
@@ -27,24 +27,24 @@
   both drive their repairs THROUGH the cold path this file pins, and
   both stay green over it)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.frame :as frame]
-            [re-frame.live-frame :as live-frame]
-            [re-frame.subs :as subs]
-            [re-frame.test-support :as test-support]))
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.frame :as rf.frame]
+            [re-frame.live-frame :as rf.live-frame]
+            [re-frame.subs :as rf.subs]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (defn- make-frame! [id db]
-  (live-frame/make-frame {:id id})
-  (frame/replace-app-db! id db)
+  (rf.live-frame/make-frame {:id id})
+  (rf.frame/replace-app-db! id db)
   id)
 
 (def ^:private !runs
@@ -62,10 +62,10 @@
   captured records."
   [thunk]
   (let [records (volatile! [])]
-    (error-emit/register-error-listener! ::cold-read
+    (rf.error-emit/register-error-listener! ::cold-read
                                          (fn [r] (vswap! records conj r)))
     (try (thunk)
-         (finally (error-emit/unregister-error-listener! ::cold-read)))
+         (finally (rf.error-emit/unregister-error-listener! ::cold-read)))
     @records))
 
 ;; ---------------------------------------------------------------------------
@@ -80,9 +80,9 @@
           a (volatile! nil)
           b (volatile! nil)]
       (reg-counted! :coldread/once)
-      (rt/render-body f (fn [_]
-                          (vreset! a (rt/sub [:coldread/once]))
-                          (vreset! b (rt/sub [:coldread/once]))
+      (rf.bench.hicasso.arm1.runtime/render-body f (fn [_]
+                          (vreset! a (rf.bench.hicasso.arm1.runtime/sub [:coldread/once]))
+                          (vreset! b (rf.bench.hicasso.arm1.runtime/sub [:coldread/once]))
                           [:li])
                       {})
       (is (= 7 @a))
@@ -97,12 +97,12 @@
            THEN, never a stale snapshot"
     (let [f    (make-frame! ::fresh {:v 1})
           seen (volatile! nil)
-          body (fn [_] (vreset! seen (rt/sub [:coldread/fresh])) [:li])]
+          body (fn [_] (vreset! seen (rf.bench.hicasso.arm1.runtime/sub [:coldread/fresh])) [:li])]
       (reg-counted! :coldread/fresh)
-      (rt/render-body f body {})
+      (rf.bench.hicasso.arm1.runtime/render-body f body {})
       (is (= 1 @seen))
-      (frame/replace-app-db! f {:v 2})
-      (rt/render-body f body {})
+      (rf.frame/replace-app-db! f {:v 2})
+      (rf.bench.hicasso.arm1.runtime/render-body f body {})
       (is (= 2 @seen)
           "the second render minted a fresh snapshot and a fresh memo —
            a probe box surviving the run would answer 1 here")
@@ -114,14 +114,14 @@
            needs no cleanup because nothing happened"
     (let [f (make-frame! ::clean {:v 3})]
       (reg-counted! :coldread/clean)
-      (let [before (rt/stats)]
-        (rt/render-body f (fn [_] (rt/sub [:coldread/clean]) [:li]) {})
-        (let [after (rt/stats)]
+      (let [before (rf.bench.hicasso.arm1.runtime/stats)]
+        (rf.bench.hicasso.arm1.runtime/render-body f (fn [_] (rf.bench.hicasso.arm1.runtime/sub [:coldread/clean]) [:li]) {})
+        (let [after (rf.bench.hicasso.arm1.runtime/stats)]
           (is (= (:cells before) (:cells after)) "no cell built")
           (is (= (:cell-refs before) (:cell-refs after)) "no reference taken")
           (is (= (:boundaries before) (:boundaries after)) "no boundary registered")
           (is (= (:edges before) (:edges after)) "no edge added"))
-        (is (zero? (count @(:sub-cache (frame/frame f))))
+        (is (zero? (count @(:sub-cache (rf.frame/frame f))))
             "and the frame's sub-cache holds nothing — where the
              subscribe-once crossing paid an insert and an evict per read,
              the probe never touched it")))))
@@ -137,14 +137,14 @@
     (let [f (make-frame! ::reuse {:v 11})]
       (reg-counted! :coldread/reuse)
       ;; The outside holder — a tool, a test, another runtime. One build.
-      (let [held (subs/subscribe [:coldread/reuse] {:frame f})
+      (let [held (rf.subs/subscribe [:coldread/reuse] {:frame f})
             _    @held
             runs-after-hold @!runs
-            cache (:sub-cache (frame/frame f))
+            cache (:sub-cache (rf.frame/frame f))
             entry-before (get @cache [:coldread/reuse])
             seen (volatile! nil)]
         (is (= 1 runs-after-hold))
-        (rt/render-body f (fn [_] (vreset! seen (rt/sub [:coldread/reuse])) [:li]) {})
+        (rf.bench.hicasso.arm1.runtime/render-body f (fn [_] (vreset! seen (rf.bench.hicasso.arm1.runtime/sub [:coldread/reuse])) [:li]) {})
         (is (= 11 @seen) "the cold read answered the held reaction's value")
         (is (= 1 @!runs)
             "by deref alone: the probe's first rung reused the live
@@ -154,14 +154,14 @@
               "the same reaction, not a rebuild")
           (is (= (:ref-count entry-before) (:ref-count entry-after))
               "and the same ref-count — no acquire/release churn"))
-        (subs/unsubscribe f [:coldread/reuse])))))
+        (rf.subs/unsubscribe f [:coldread/reuse])))))
 
 ;; ---------------------------------------------------------------------------
 ;; The error contract the probe must keep
 ;; ---------------------------------------------------------------------------
 
 (deftest a-cold-unregistered-read-emits-no-such-sub-once-and-recovers-nil
-  (testing "the probe's memo is seeded with `subs/observation-opts-key`,
+  (testing "the probe's memo is seeded with `rf.subs/observation-opts-key`,
            so an unregistered cold read emits the always-on
            `:rf.error/no-such-sub` exactly as the reactive build does —
            and the memo dedupes, so two reads of the same unknown query
@@ -171,9 +171,9 @@
           records
           (capture-errors
             (fn []
-              (rt/render-body f (fn [_]
-                                  (vreset! seen (rt/sub [:coldread/nope]))
-                                  (rt/sub [:coldread/nope])
+              (rf.bench.hicasso.arm1.runtime/render-body f (fn [_]
+                                  (vreset! seen (rf.bench.hicasso.arm1.runtime/sub [:coldread/nope]))
+                                  (rf.bench.hicasso.arm1.runtime/sub [:coldread/nope])
                                   [:li])
                               {})))]
       (is (nil? @seen) "recovered to nil, the contract unchanged")
@@ -192,7 +192,7 @@
           seen (volatile! :unread)]
       ;; Registered AFTER the frame exists, read in the SAME tick.
       (reg-counted! :coldread/sametick)
-      (rt/render-body f (fn [_] (vreset! seen (rt/sub [:coldread/sametick])) [:li]) {})
+      (rf.bench.hicasso.arm1.runtime/render-body f (fn [_] (vreset! seen (rf.bench.hicasso.arm1.runtime/sub [:coldread/sametick])) [:li]) {})
       (is (= 5 @seen)
           "the very next cold read resolved the handler registered this
            tick — a probe that skipped the resolution seam's flush could

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/controlled_burst_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/controlled_burst_dom_cljs_test.cljs
@@ -92,23 +92,23 @@
   `:value` / `:on-input` cells, unchanged, so HD-020's ≤2-hook budget is
   untouched and `arm1_hook_ledger_dom_cljs_test` still gates it."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.grid :as grid]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.grid :as rf.bench.hicasso.arm1.grid]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
             [re-frame.core :as rf]
-            [re-frame.test-support :as test-support]))
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      ;; Same as the grid suite: the fixture's default leaves a dynamic-var
      ;; frame stamp in scope, and the carried-invariant chain resolves that
      ;; tier before React context.
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::burst-grid)
 
@@ -125,13 +125,13 @@
 ;; against the tag string — the UIx selector has nothing to select.
 
 (defn- fresh! []
-  (lane/leave-act-environment!)
-  (grid/make-frame! frame-id grid/cells)
-  (grid/reseed! frame-id grid/cells)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.arm1.grid/make-frame! frame-id rf.bench.hicasso.arm1.grid/cells)
+  (rf.bench.hicasso.arm1.grid/reseed! frame-id rf.bench.hicasso.arm1.grid/cells)
   frame-id)
 
 (defn- arm-mount! []
-  (mount/root! (mount/fresh-container!) frame-id [grid/grid {:n grid/cells}]))
+  (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [rf.bench.hicasso.arm1.grid/grid {:n rf.bench.hicasso.arm1.grid/cells}]))
 
 (defn- cell-input [handle i] (.querySelector (:container handle) (str "#c" i)))
 
@@ -152,8 +152,8 @@
   "The out-of-band setup door — OUT of the discrete-event path, so this
   is where `settle!` is legitimate. Never part of any burst."
   [i v]
-  (rt/dispatch! frame-id [:agrid/set i v])
-  (mount/settle!)
+  (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:agrid/set i v])
+  (rf.bench.hicasso.arm1.mount/settle!)
   nil)
 
 (defn- with-grid
@@ -163,7 +163,7 @@
   (fresh!)
   (let [handle (arm-mount!)]
     (try (f handle)
-         (finally (mount/release! handle)))))
+         (finally (rf.bench.hicasso.arm1.mount/release! handle)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The instrument
@@ -229,7 +229,7 @@
            event object itself — a burst row whose events silently carried
            the wrong signal would be a green gate over an unexercised door
            (the dead-isComposing lesson)"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM, and no InputEvent constructor")
       (do
         (let [e (burst-event "h")]
@@ -256,13 +256,13 @@
             (fn [handle]
               (let [n (cell-input handle 7)]
                 (.focus n)
-                (reset! grid/!body-runs 0)
+                (reset! rf.bench.hicasso.arm1.grid/!body-runs 0)
                 (let [[r] (burst! n 7 "x")]
                   (is (true? (:delivered r))
                       "dispatchEvent returned true — nothing cancelled it")
                   (is (= "x" (:model r)) "the event reached the model")
                   (is (= "x" (:value r)) "and the echo landed in the same turn")
-                  (is (= 1 @grid/!body-runs) "through exactly one body run"))))))))))
+                  (is (= 1 @rf.bench.hicasso.arm1.grid/!body-runs) "through exactly one body run"))))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — the plain burst: k keystrokes, k landings, in order
@@ -273,13 +273,13 @@
            every keystroke landing on its predecessor's outcome, so the
            final value is what the sequence implies and not merely what
            the last event carried"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
           (let [n (cell-input handle 7)]
             (.focus n)
-            (reset! grid/!body-runs 0)
+            (reset! rf.bench.hicasso.arm1.grid/!body-runs 0)
             (let [rs (burst! n 7 "hello")]
               (is (every? :delivered rs) "all five dispatches delivered")
               (is (= ["h" "he" "hel" "hell" "hello"] (mapv :value rs))
@@ -294,7 +294,7 @@
             (is (= "hello" (model-value 7)) "the model holds the sequence")
             (is (= "hello" (.-value n)) "so does the DOM")
             (is (= [5 5] (caret n)) "caret at 5")
-            (is (= 5 @grid/!body-runs)
+            (is (= 5 @rf.bench.hicasso.arm1.grid/!body-runs)
                 "and the body ran exactly k times — one per keystroke,
                  not one for the burst and not a hundred")))))))
 
@@ -303,18 +303,18 @@
            nothing between one dispatchEvent and the next mutate. The
            endpoint alone: if any keystroke had been dropped or deferred,
            the model could not spell the sequence"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
           (let [n (cell-input handle 7)]
             (.focus n)
-            (reset! grid/!body-runs 0)
+            (reset! rf.bench.hicasso.arm1.grid/!body-runs 0)
             (bare-burst! n "hello")
             (is (= "hello" (model-value 7)))
             (is (= "hello" (.-value n)))
             (is (= [5 5] (caret n)))
-            (is (= 5 @grid/!body-runs))))))))
+            (is (= 5 @rf.bench.hicasso.arm1.grid/!body-runs))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 — refusals interleaved: the next keystroke lands on the restored state
@@ -325,13 +325,13 @@
            accepted subset, each refusal's restore happens INSIDE its own
            event, and the next keystroke in the burst builds on the
            restored field rather than on the refused character"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
           (let [n (cell-input handle 11)]
             (.focus n)
-            (reset! grid/!body-runs 0)
+            (reset! rf.bench.hicasso.arm1.grid/!body-runs 0)
             (let [rs (burst! n 11 "1a2b3")]
               (is (= ["1" "1" "12" "12" "123"] (mapv :value rs))
                   "each refused character is off the screen on the line
@@ -344,7 +344,7 @@
                    next keystroke expects it"))
             (is (= "123" (model-value 11)) "the accepted subset, in order")
             (is (= "123" (.-value n)))
-            (is (= 3 @grid/!body-runs)
+            (is (= 3 @rf.bench.hicasso.arm1.grid/!body-runs)
                 "three accepted keystrokes, three body runs — a refusal
                  moves no model and re-renders nothing")))))))
 
@@ -354,7 +354,7 @@
            refusal landing on the acceptance's converge, all mid-string,
            where React alone would have dumped the caret at the end of
            the field on every one of them"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
@@ -362,7 +362,7 @@
             (set-model! 11 "12345")
             (.focus n)
             (.setSelectionRange n 2 2)
-            (reset! grid/!body-runs 0)
+            (reset! rf.bench.hicasso.arm1.grid/!body-runs 0)
             (let [rs (burst! n 11 "z9z")]
               (is (= ["12345" "129345" "129345"] (mapv :value rs))
                   "z refused, 9 accepted at the position the restore
@@ -373,7 +373,7 @@
                    the end by the refusal's restore, nor by the
                    acceptance's converge, nor by the second refusal's"))
             (is (= "129345" (model-value 11)))
-            (is (= 1 @grid/!body-runs) "one acceptance, one body run")))))))
+            (is (= 1 @rf.bench.hicasso.arm1.grid/!body-runs) "one acceptance, one body run")))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3 — normalising models: the caret arithmetic survives k successive
@@ -385,13 +385,13 @@
            by the model (h → H), so every keystroke costs a converge, and
            the burst is five successive restores each of which the next
            keystroke builds on"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
           (let [n (cell-input handle 13)]
             (.focus n)
-            (reset! grid/!body-runs 0)
+            (reset! rf.bench.hicasso.arm1.grid/!body-runs 0)
             (let [rs (burst! n 13 "hello")]
               (is (= ["H" "HE" "HEL" "HELL" "HELLO"] (mapv :value rs))
                   "each lowercase keystroke came back uppercased inside
@@ -402,7 +402,7 @@
                    through five rewrites"))
             (is (= "HELLO" (model-value 13)))
             (is (= "HELLO" (.-value n)))
-            (is (= 5 @grid/!body-runs) "five acceptances, five body runs")))))))
+            (is (= 5 @rf.bench.hicasso.arm1.grid/!body-runs) "five acceptances, five body runs")))))))
 
 (deftest a-grouping-burst-survives-length-changing-normalisation-mid-burst
   (testing "1,2,3,4,5 into the :group cell — the fourth keystroke changes
@@ -410,13 +410,13 @@
            every absolute offset in the field is wrong and only the
            offset-from-the-end arithmetic can carry the caret through the
            rest of the burst"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
           (let [n (cell-input handle 17)]
             (.focus n)
-            (reset! grid/!body-runs 0)
+            (reset! rf.bench.hicasso.arm1.grid/!body-runs 0)
             (let [rs (burst! n 17 "12345")]
               (is (= ["1" "12" "123" "1,234" "12,345"] (mapv :value rs))
                   "the grouping landed inside the fourth keystroke's own
@@ -429,7 +429,7 @@
             (is (= "12,345" (model-value 17)))
             (is (= "12,345" (.-value n)))
             (is (= [6 6] (caret n)))
-            (is (= 5 @grid/!body-runs))))))))
+            (is (= 5 @rf.bench.hicasso.arm1.grid/!body-runs))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4 — the ordering claim, where a broken door changes the STRING
@@ -441,7 +441,7 @@
            the WRONG PLACE: abdc instead of abcd. A final value equal to
            the last event's payload is not enough; it has to be what the
            SEQUENCE of keystrokes implies, position and all"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
@@ -449,7 +449,7 @@
             (set-model! 7 "ad")
             (.focus n)
             (.setSelectionRange n 1 1)
-            (reset! grid/!body-runs 0)
+            (reset! rf.bench.hicasso.arm1.grid/!body-runs 0)
             (let [rs (burst! n 7 "bc")]
               (is (= ["abd" "abcd"] (mapv :value rs))
                   "b landed at position 1; c landed AFTER b, because the
@@ -461,4 +461,4 @@
                  a caret thrown to the end between two keystrokes of one
                  burst")
             (is (= "abcd" (.-value n)))
-            (is (= 2 @grid/!body-runs))))))))
+            (is (= 2 @rf.bench.hicasso.arm1.grid/!body-runs))))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/controlled_grid_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/controlled_grid_dom_cljs_test.cljs
@@ -12,7 +12,7 @@
 
   Every synchronous assertion runs on the line after `dispatchEvent`
   returns. There is **no `act` anywhere in this file**, and no `flushSync`
-  inside a discrete-event path an assertion reads: `mount/settle!` appears
+  inside a discrete-event path an assertion reads: `rf.bench.hicasso.arm1.mount/settle!` appears
   only after an OUT-OF-BAND dispatch, which is the setup door and never
   the claim.
 
@@ -107,14 +107,14 @@
   Runtime: `-dom-cljs-test`; under `:node-test` every claim degrades to a
   stated skip."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.grid :as grid]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.controlled :as controlled]
-            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.grid :as rf.bench.hicasso.arm1.grid]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.controlled :as rf.bench.hicasso.front.controlled]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
             [re-frame.core :as rf]
-            [re-frame.test-support :as test-support]
+            [re-frame.test-support :as rf.test-support]
             [uix.core :refer [$ defui]]
             [uix.compiler.input]
             ;; Required so `:uix-reagent-input` can be SELECTED rather than
@@ -198,8 +198,8 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private runtime-fixture
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      ;; `:ambient-frame nil` is load-bearing: the fixture's default leaves
      ;; a dynamic-var frame stamp in scope and the carried-invariant chain
      ;; resolves that tier BEFORE React context, so the UIx comparator
@@ -207,7 +207,7 @@
      ;; provider's.
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (use-fixtures :each
   {:before (:before runtime-fixture)
@@ -230,15 +230,15 @@
   an id that already exists, and `reseed!` is the model's own door for
   returning a live frame to its seeded state."
   []
-  (lane/leave-act-environment!)
-  (grid/make-frame! frame-id grid/cells)
-  (grid/reseed! frame-id grid/cells)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.arm1.grid/make-frame! frame-id rf.bench.hicasso.arm1.grid/cells)
+  (rf.bench.hicasso.arm1.grid/reseed! frame-id rf.bench.hicasso.arm1.grid/cells)
   frame-id)
 
 (defn- arm-mount!
   "The arm's grid, on the arm's own root."
   []
-  (mount/root! (mount/fresh-container!) frame-id [grid/grid {:n grid/cells}]))
+  (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [rf.bench.hicasso.arm1.grid/grid {:n rf.bench.hicasso.arm1.grid/cells}]))
 
 (defn- cell-input [handle i] (.querySelector (:container handle) (str "#c" i)))
 
@@ -290,8 +290,8 @@
   async-normalisation door. OUT of the discrete-event path, so this is
   where `settle!` is legitimate."
   [i v]
-  (rt/dispatch! frame-id [:agrid/set i v])
-  (mount/settle!)
+  (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:agrid/set i v])
+  (rf.bench.hicasso.arm1.mount/settle!)
   nil)
 
 (defn- after-a-frame
@@ -311,7 +311,7 @@
    (fresh!)
    (let [handle (arm-mount!)]
      (try (f handle)
-          (finally (mount/release! handle) (restore-adapter-pin!))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle) (restore-adapter-pin!))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The UIx comparator — its own root, its own provider
@@ -323,18 +323,18 @@
 ;; keystroke — the ONLY variable is which library minted the element.
 
 (defui uix-cell [{:keys [i]}]
-  (let [v                        (uix-adapter/use-subscribe [:agrid/cell i])
-        {:keys [dispatch-sync]}  (uix-adapter/use-frame)]
+  (let [v                        (rf.adapter.uix/use-subscribe [:agrid/cell i])
+        {:keys [dispatch-sync]}  (rf.adapter.uix/use-frame)]
     ($ :input {:id        (str "u" i)
                :type      "text"
                :value     v
                :on-change (fn [e] (dispatch-sync [:agrid/edit i (.. e -target -value)]))})))
 
 (defn- uix-mount! [i]
-  (let [container (mount/fresh-container!)
+  (let [container (rf.bench.hicasso.arm1.mount/fresh-container!)
         root      (react-dom-client/createRoot container)]
     (react-dom/flushSync
-      (fn [] (.render root ($ uix-adapter/frame-provider {:frame frame-id}
+      (fn [] (.render root ($ rf.adapter.uix/frame-provider {:frame frame-id}
                               ($ uix-cell {:i i})))))
     {:root root :container container}))
 
@@ -382,7 +382,7 @@
 
 (deftest the-arms-input-is-reacts-own-whatever-the-selector-says
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       ;; THE PIN THAT WOULD CHANGE A UIx CELL. Both elements are minted in
       ;; the same turn, on the same frame, against the same model, with
@@ -396,7 +396,7 @@
               a     (cell-input arm 11)
               u     (.querySelector (:container ctrl) "#u11")]
           (set-model! 11 "12")
-          (mount/settle!)
+          (rf.bench.hicasso.arm1.mount/settle!)
           (.focus a)
           (.setSelectionRange a 2 2)
           (type-into! a "a")
@@ -424,7 +424,7 @@
                 (catch :default e
                   (is false (str "the deferred converge threw: " (ex-message e)))))
               (uix-release! ctrl)
-              (mount/release! arm)
+              (rf.bench.hicasso.arm1.mount/release! arm)
               (restore-adapter-pin!)
               (done))))))))
 
@@ -432,7 +432,7 @@
   (testing "the selector cannot reach `react/createElement \"input\"`, so
            the arm's cell is byte-identical under both pins — which is what
            licenses every row below to name React and mean it"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (let [reading (fn [impl]
                       (with-grid impl
@@ -456,11 +456,11 @@
   (testing "100 cells mounted; a real `input` event on one of them reaches
            app-db and comes back to the DOM before the event returns — no
            act, no flushSync, no yield"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
-          (is (= grid/cells (.-length (.querySelectorAll (:container handle) ".cell")))
+          (is (= rf.bench.hicasso.arm1.grid/cells (.-length (.querySelectorAll (:container handle) ".cell")))
               "the witness is at its stated size")
           (let [n (cell-input handle 7)]
             (.focus n)
@@ -472,16 +472,16 @@
 
 (deftest the-echo-is-one-body-run-not-one-hundred
   (testing "the per-keystroke budget: a keystroke in cell 7 re-runs cell 7"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
           (let [n (cell-input handle 7)]
             (.focus n)
-            (reset! grid/!body-runs 0)
+            (reset! rf.bench.hicasso.arm1.grid/!body-runs 0)
             (type-into! n "x")
-            (is (= 1 @grid/!body-runs)
-                (str "one boundary body ran, not " grid/cells))))))))
+            (is (= 1 @rf.bench.hicasso.arm1.grid/!body-runs)
+                (str "one boundary body ran, not " rf.bench.hicasso.arm1.grid/cells))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 — :mid-string-caret
@@ -490,7 +490,7 @@
 (deftest editing-mid-string-leaves-the-caret-where-the-typing-put-it
   (testing "the model agreed with the field, so React wrote nothing and the
            cursor stayed where the character went in"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
@@ -515,7 +515,7 @@
            Measured against the same keystroke on the shipped paths:
            React alone leaves [5 5], and UIx's port reaches [3 3] one
            animation frame later"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
@@ -537,7 +537,7 @@
            at the END of the field and that is where React's write leaves
            the caret anyway; it stays green for the better reason, which
            is that the offset is taken from the end"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
@@ -558,7 +558,7 @@
   (testing "a commit that moves a DIFFERENT cell's subscription writes
            nothing here, so nothing here moves — the index's narrowness
            read as a caret rather than as a re-render count"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
@@ -582,7 +582,7 @@
            to run at the end of. Restoring a RANGE is a second algorithm
            besides — two offsets rather than one — and rf2-n3dxw keeps it.
            Nothing here pretends otherwise"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
@@ -645,12 +645,12 @@
            `isComposing` is not on it, so a gate reading it off the
            synthetic event is dead on React and only the legacy keyCode
            half ever fires"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (do
         (fresh!)
         (reset! !probe [])
-        (let [handle (mount/root! (mount/fresh-container!) frame-id [compose-probe {}])]
+        (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [compose-probe {}])]
           (try
             (let [node (.querySelector (:container handle) ".probe")
                   e    (key-event {:key "Enter" :composing? true :key-code 229})]
@@ -670,12 +670,12 @@
                 (is (= 229 (:key-code seen))
                     "while the legacy signal survives the synthetic
                      interface, because keyCode IS on React's list")))
-            (finally (mount/release! handle))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! handle))))))))
 
 (deftest a-composing-enter-commits-nothing
   (testing "both signals, each on its own, through a real React keydown on
            a real cell"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
@@ -711,7 +711,7 @@
 (deftest a-refused-keystroke-moves-no-model-and-re-runs-no-boundary
   (testing "cell 11 takes digits only. The browser has already shown the
            letter; the model does not move, so NOTHING re-renders"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
@@ -719,10 +719,10 @@
             (set-model! 11 "12")
             (.focus n)
             (.setSelectionRange n 2 2)
-            (reset! grid/!body-runs 0)
+            (reset! rf.bench.hicasso.arm1.grid/!body-runs 0)
             (type-into! n "a")
             (is (= "12" (model-value 11)) "the model refused the letter")
-            (is (zero? @grid/!body-runs)
+            (is (zero? @rf.bench.hicasso.arm1.grid/!body-runs)
                 "and no boundary body ran at all — the value the model holds
                  did not change, so there was nothing for React to
                  re-render")))))))
@@ -733,7 +733,7 @@
            keystroke — so the write below cannot have come from a render.
            It is React's own controlled-state restore, and all of it lands
            before `dispatchEvent` returns"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
@@ -741,12 +741,12 @@
             (set-model! 11 "12")
             (.focus n)
             (.setSelectionRange n 2 2)
-            (reset! grid/!body-runs 0)
+            (reset! rf.bench.hicasso.arm1.grid/!body-runs 0)
             (type-into! n "a")
             (is (= "12" (.-value n))
                 "the refused character is off the screen, on the next line")
             (is (= "12" (model-value 11)) "and the field and the model agree")
-            (is (zero? @grid/!body-runs) "with nothing re-rendered to do it")
+            (is (zero? @rf.bench.hicasso.arm1.grid/!body-runs) "with nothing re-rendered to do it")
             (is (= [2 2] (caret n))
                 "caret at the position before the refused character —
                  because the edit was AT the end, which is where React's
@@ -761,7 +761,7 @@
            gets the caret right and arrives an animation frame late.
 
            Here both halves land before `dispatchEvent` returns"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
@@ -793,7 +793,7 @@
            the user just typed. `front/controlled_dom_cljs_test`
            reproduces that deletion; this row is what says it does not
            happen here"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
@@ -863,18 +863,18 @@
            MOVES when the rendered value moves. If React ever stopped
            writing it, this goes red by name instead of five caret rows
            going quietly wrong"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
           (let [n (cell-input handle 7)]
             (set-model! 7 "abcd")
-            (is (= "abcd" (controlled/last-rendered n))
+            (is (= "abcd" (rf.bench.hicasso.front.controlled/last-rendered n))
                 "the record is what the last render put on the element")
-            (is (= (.-value n) (controlled/last-rendered n))
+            (is (= (.-value n) (rf.bench.hicasso.front.controlled/last-rendered n))
                 "and the field agrees with it before anything is typed")
             (set-model! 7 "wxyz")
-            (is (= "wxyz" (controlled/last-rendered n))
+            (is (= "wxyz" (rf.bench.hicasso.front.controlled/last-rendered n))
                 "a re-render moves the record with it — which is exactly
                  what a closure minted by the PREVIOUS render cannot do")
             (testing "and typing does not disturb it, because the value
@@ -883,7 +883,7 @@
               (.focus n)
               (.setSelectionRange n 4 4)
               (set-native-value! n "wxyzQ")
-              (is (= "wxyz" (controlled/last-rendered n))
+              (is (= "wxyz" (rf.bench.hicasso.front.controlled/last-rendered n))
                   "still the value the element rendered, not the value
                    the field shows"))))))))
 
@@ -897,7 +897,7 @@
   `number` — and does it inside the converge's own `flushSync`, against
   a wrapper the `text` render minted."
   [{:keys [i]}]
-  (let [v (rt/sub [:agrid/cell i])]
+  (let [v (rf.bench.hicasso.arm1.runtime/sub [:agrid/cell i])]
     [:input.flip {:type     (if (= "" v) "text" "number")
                   :value    v
                   :on-input [:agrid/edit i :re-frame.hicasso/value]}]))
@@ -942,12 +942,12 @@
            Measured with the post-flush reading deleted: `InvalidStateError:
            Failed to execute 'setSelectionRange' on 'HTMLInputElement': The
            input element's type ('number') does not support selection.`"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (do
         (pin! :react)
         (fresh!)
-        (let [handle (mount/root! (mount/fresh-container!) frame-id
+        (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id
                                   [type-flipping-cell {:i 31}])]
           (try
             (let [before (.querySelector (:container handle) ".flip")]
@@ -984,7 +984,7 @@
                 (is (= "5" (.-value after))
                     "and the field still shows the keystroke that caused
                      the flip")
-                (is (= "" (controlled/last-rendered after))
+                (is (= "" (rf.bench.hicasso.front.controlled/last-rendered after))
                     "THE RECORD IS STALE HERE, and this is the second
                      reason to be inert rather than merely careful with
                      the caret: `setDefaultValue` skips a FOCUSED number
@@ -992,7 +992,7 @@
                      still holds what the TEXT render wrote. It is no
                      longer the value this element renders, so there is
                      nothing here the converge could correctly write")))
-            (finally (mount/release! handle) (restore-adapter-pin!))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! handle) (restore-adapter-pin!))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 6 — :async-normalisation
@@ -1004,7 +1004,7 @@
            Nothing about the arm's door is synchronous here, and it still
            lands"
     (async done
-      (if-not (mount/browser?)
+      (if-not (rf.bench.hicasso.arm1.mount/browser?)
         (do (skip! ":node-test has no DOM") (done))
         ;; NOT `with-grid`: its `finally` runs the moment the body returns,
         ;; and the body of an async test returns before its timer fires.
@@ -1020,14 +1020,14 @@
             (js/setTimeout
               (fn []
                 (try
-                  (set-model! 17 (grid/group-digits "1234"))
+                  (set-model! 17 (rf.bench.hicasso.arm1.grid/group-digits "1234"))
                   (is (= "1,234" (model-value 17)) "the late correction reached the model")
                   (is (= "1,234" (.-value n)) "and the field")
                   (is (= [5 5] (caret n))
                       "with the caret still after the last digit")
                   (catch :default e
                     (is false (str "the late correction threw: " (ex-message e)))))
-                (mount/release! handle)
+                (rf.bench.hicasso.arm1.mount/release! handle)
                 (restore-adapter-pin!)
                 (done))
               0)))))))
@@ -1096,7 +1096,7 @@
            dead-`isComposing` lesson applied to this file's own composing
            input. A row whose event silently carried `isComposing false`
            would be green over a carve-out that never engaged"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM, and no InputEvent constructor")
       (let [e (js/InputEvent. "input" #js {:bubbles     true
                                            :data        "し"
@@ -1118,7 +1118,7 @@
            by one reading of the native event, React's own restore because
            the value it compares against is the live draft — and the
            refusal arrives whole at `compositionend` instead"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
@@ -1176,7 +1176,7 @@
            `ime_run.cjs`'s measurement and not this row's. This row
            witnesses the CAUSE: the write is there on React, and it is not
            there on the arm"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (do
         (pin! :react)
@@ -1202,7 +1202,7 @@
            there was never a write to suppress, so the carve-out is
            invisible — the field tracks the draft and the model tracks it
            too, update by update"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
@@ -1224,7 +1224,7 @@
   (testing "the other half of the carve-out's behavioural claim: the model
            normalises every intermediate state as it always did, and the
            FIELD shows the composition until the exchange closes"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
@@ -1247,7 +1247,7 @@
            release cannot be that event's alone. Blur releases
            unconditionally, and the worst outcome available is the
            ordinary converge"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
@@ -1260,7 +1260,7 @@
             (.blur n)
             ;; OUT of the discrete-event claim: the row is that the release
             ;; happens at all, not that it happens in the blur's own turn.
-            (mount/settle!)
+            (rf.bench.hicasso.arm1.mount/settle!)
             (is (= "12" (.-value n))
                 "the field is the model's again with no compositionend
                  anywhere in the exchange")
@@ -1273,7 +1273,7 @@
            and a change event that is not composing releases before it
            converges, so the field cannot stay stuck on a draft the model
            never agreed to"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
         (fn [handle]
@@ -1296,7 +1296,7 @@
            no registry, no node property and no module-level record, so an
            element that goes away takes its shadow with it and the next
            mount reads the model"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (do
         (pin! :react)
@@ -1309,14 +1309,14 @@
               (composition-start! n)
               (compose-into! n "12し")
               (is (= "12し" (.-value n)) "a shadow is live when the tree goes"))
-            (finally (mount/release! first-handle)))
+            (finally (rf.bench.hicasso.arm1.mount/release! first-handle)))
           (let [second-handle (arm-mount!)]
             (try
               (is (= "12" (.-value (cell-input second-handle 11)))
                   "the remounted field is the model's, with nothing carried
                    over from the composition that never ended")
               (is (= "12" (model-value 11)))
-              (finally (mount/release! second-handle)
+              (finally (rf.bench.hicasso.arm1.mount/release! second-handle)
                        (restore-adapter-pin!)))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -1328,7 +1328,7 @@
 
            **The census is read after React's unmount and BEFORE the arm's
            teardown door**, and that ordering is the whole of it.
-           `mount/release!` calls `runtime/reset-runtime!`, which disposes
+           `rf.bench.hicasso.arm1.mount/release!` calls `runtime/reset-runtime!`, which disposes
            every cell — and with them every reader membership — by fiat, so
            a residue reading taken after it is all zeros whatever the
            teardown released —
@@ -1340,7 +1340,7 @@
            unmount returns; `:cells` and `:entries` are the reaper's, one
            macrotask later, and asserting them here would assert a
            schedule rather than a release."
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (do
         (pin! :react)
@@ -1350,7 +1350,7 @@
           (.focus n)
           (type-into! n "abc")
           (is (= "abc" (model-value 7)))
-          (is (= grid/cells (:boundaries (rt/stats)))
+          (is (= rf.bench.hicasso.arm1.grid/cells (:boundaries (rf.bench.hicasso.arm1.runtime/stats)))
               "a hundred cell registrations are really standing before the
                teardown. The enclosing `grid` is a `defview` too and its
                registration is standing beside them — but its body READS
@@ -1361,13 +1361,13 @@
                record of liveness (rf2-ixb92 removed the last one). An
                edgeless boundary retains its read-set entry and React's own
                hook cells, and nothing else of this arm's")
-          (is (= (inc grid/cells) (:entries (rt/stats)))
+          (is (= (inc rf.bench.hicasso.arm1.grid/cells) (:entries (rf.bench.hicasso.arm1.runtime/stats)))
               "…which is where it shows up: 101 read-set entries, the
                hundredth-and-first being the empty read sequence the grid
                resolved")
           (react-dom/flushSync (fn [] (.unmount (:root handle))))
-          (let [census (select-keys (rt/residue) [:cell-refs :boundaries :edges])]
-            (mount/release! (assoc handle :root nil))
+          (let [census (select-keys (rf.bench.hicasso.arm1.runtime/residue) [:cell-refs :boundaries :edges])]
+            (rf.bench.hicasso.arm1.mount/release! (assoc handle :root nil))
             (restore-adapter-pin!)
             (is (= {:cell-refs 0 :boundaries 0 :edges 0} census)
                 "zero leaked subscription ref-counts, zero boundaries and zero

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/deferred_read_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/deferred_read_cljs_test.cljs
@@ -38,7 +38,7 @@
 
   ## What this change does, and what it deliberately does not
 
-  `codec/realize-deep` — already the one walk at the crossing — refuses
+  `rf.bench.hicasso.front.codec/realize-deep` — already the one walk at the crossing — refuses
   an **unforced** `delay` it reaches, and refuses it *inside the render
   of the body that wrote it*, so the stack lands on the author's own call
   site. It does not force the delay: that would change the meaning of the
@@ -63,22 +63,22 @@
   `plain-atom` has no reactivity layer, so a subscription under it never
   notifies and every commit assertion would pass by never firing."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.codec :as codec]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
-     :init-fn (fn [] (rt/reset-runtime!))}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
+     :init-fn (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::arm1-deferred-read)
 
 (defn- seeded! []
-  (rt/reset-runtime!)
-  (dogfood/make-frame! frame-id 3)
+  (rf.bench.hicasso.arm1.runtime/reset-runtime!)
+  (rf.bench.hicasso.front.dogfood/make-frame! frame-id 3)
   frame-id)
 
 (defn- key-of [query] [frame-id query])
@@ -90,29 +90,29 @@
   (unchecked-get (.-props element) "rfProps"))
 
 (defn- render [body-fn props]
-  (let [element (rt/render-body frame-id body-fn props)]
-    {:element element :entry (rt/last-reads) :reads (rt/reads-of (rt/last-reads))}))
+  (let [element (rf.bench.hicasso.arm1.runtime/render-body frame-id body-fn props)]
+    {:element element :entry (rf.bench.hicasso.arm1.runtime/last-reads) :reads (rf.bench.hicasso.arm1.runtime/reads-of (rf.bench.hicasso.arm1.runtime/last-reads))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The bodies
 ;; ---------------------------------------------------------------------------
 
 (defn- child-derefs-body [{:keys [d]}] [:li.deref (str @d)])
-(def ^:private child-derefs (rt/mint-view! "deferred/child-derefs" child-derefs-body))
+(def ^:private child-derefs (rf.bench.hicasso.arm1.runtime/mint-view! "deferred/child-derefs" child-derefs-body))
 
 (defn- parent-delay-body
   "The crossing this file exists for: an explicit deferral written by one
   body and forced by another."
   [_]
-  [child-derefs {:d (delay (:title (rt/sub [:dogfood/todo 1])))}])
+  [child-derefs {:d (delay (:title (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1])))}])
 
 (defn- child-calls-body [{:keys [f]}] [:li.call (str (f))])
-(def ^:private child-calls (rt/mint-view! "deferred/child-calls" child-calls-body))
+(def ^:private child-calls (rf.bench.hicasso.arm1.runtime/mint-view! "deferred/child-calls" child-calls-body))
 
 (defn- parent-fn-body
   "The shape that is NOT in the class: the child re-runs it every render."
   [_]
-  [child-calls {:f (fn [] (:title (rt/sub [:dogfood/todo 1])))}])
+  [child-calls {:f (fn [] (:title (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1])))}])
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — the refusal, at the crossing, in the writing body's render
@@ -137,9 +137,9 @@
   (testing "a render that threw is an abandoned render, and an abandoned
            render mutates neither the index nor a reference — the
            refusal is a diagnostic, not a half-built boundary"
-    (let [before (rt/residue)]
+    (let [before (rf.bench.hicasso.arm1.runtime/residue)]
       (try (render parent-delay-body {}) (catch :default _ nil))
-      (is (= before (rt/residue))))))
+      (is (= before (rf.bench.hicasso.arm1.runtime/residue))))))
 
 (deftest the-refusal-reaches-wherever-the-walk-reaches
   (testing "the delay is refused at every position the crossing walk
@@ -153,7 +153,7 @@
                        ["inside a lazy seq"      {:d (map (fn [_] (delay 1)) (range 1))}]
                        ["inside a set"           {:d #{(delay 1)}}]]]
       (is (thrown-with-msg? js/Error #"unforced `delay` reached a boundary's props"
-                            (codec/realize-deep v))
+                            (rf.bench.hicasso.front.codec/realize-deep v))
           label))))
 
 ;; ---------------------------------------------------------------------------
@@ -168,10 +168,10 @@
   [:li.deref-key (str @(first (keys m)))])
 
 (def ^:private child-derefs-key
-  (rt/mint-view! "deferred/child-derefs-key" child-derefs-key-body))
+  (rf.bench.hicasso.arm1.runtime/mint-view! "deferred/child-derefs-key" child-derefs-key-body))
 
 (defn- parent-key-delay-body [_]
-  [child-derefs-key {:m {(delay (:title (rt/sub [:dogfood/todo 1]))) :marked}}])
+  [child-derefs-key {:m {(delay (:title (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1]))) :marked}}])
 
 (deftest a-delay-held-as-a-map-key-is-refused-exactly-as-a-value-is
   (testing "the invariant is about **reach** — every unforced `delay`
@@ -190,7 +190,7 @@
                        ["a key of a map inside a seq"     {:v (list {(delay 1) :marked})}]
                        ["a key of a map inside a set"     {:v #{{(delay 1) :marked}}}]]]
       (is (thrown-with-msg? js/Error #"unforced `delay` reached a boundary's props"
-                            (codec/realize-deep v))
+                            (rf.bench.hicasso.front.codec/realize-deep v))
           label))))
 
 (deftest a-key-held-delay-is-refused-before-the-child-can-cache-it
@@ -226,7 +226,7 @@
            respect but where the `delay` sits, and that is the finding: the
            position it occupies changes nothing about what it does to the
            edge, so the walk's **reach** was the whole of the defect."
-    (let [d      (delay (:title (rt/sub [:dogfood/todo 1])))
+    (let [d      (delay (:title (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1])))
           props  {:m {d :marked}}
           first' (render child-derefs-key-body props)
           again  (render child-derefs-key-body props)]
@@ -242,7 +242,7 @@
            property `realize-children`'s one-level flatten made necessary
            for seqs holds identically for a deferral"
     (is (thrown-with-msg? js/Error #"unforced `delay` reached a boundary's props"
-                          (render (fn [_] [child-derefs (delay (rt/sub [:dogfood/remaining]))]) {})))))
+                          (render (fn [_] [child-derefs (delay (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))]) {})))))
 
 (deftest a-delay-the-author-already-forced-crosses-untouched
   (seeded!)
@@ -251,7 +251,7 @@
            calling anything, and is harmless wherever it goes — so the
            refusal costs the legitimate spelling nothing"
     (let [parent (render (fn [_]
-                           (let [d (delay (:title (rt/sub [:dogfood/todo 1])))]
+                           (let [d (delay (:title (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1])))]
                              @d
                              [child-derefs {:d d}]))
                          {})
@@ -276,7 +276,7 @@
            mechanism the refusal exists to prevent, and it is asserted
            rather than described so that removing the refusal cannot
            quietly restore it."
-    (let [d      (delay (:title (rt/sub [:dogfood/todo 1])))
+    (let [d      (delay (:title (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1])))
           first' (render child-derefs-body {:d d})
           again  (render child-derefs-body {:d d})]
       (is (= #{(key-of [:dogfood/todo 1])} (:reads first'))
@@ -357,7 +357,7 @@
            than a discovery."
     (let [parent  (render (fn [_]
                             (reset! !parked
-                                    (map (fn [id] (:title (rt/sub [:dogfood/todo id]))) (range 3)))
+                                    (map (fn [id] (:title (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo id]))) (range 3)))
                             [:li])
                           {})
           reader  (render (fn [_] [:li (str (doall @!parked))]) {})]
@@ -370,7 +370,7 @@
           "and every row lands on whichever body happened to force it")))
   (testing "the same, one step nearer: the reference is at a boundary
            prop, so the codec SEES it and still may not open it"
-    (let [box    (atom (map (fn [id] (:title (rt/sub [:dogfood/todo id]))) (range 3)))
+    (let [box    (atom (map (fn [id] (:title (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo id]))) (range 3)))
           parent (render (fn [_] [child-derefs {:d box}]) {})
           props  (crossing-props (:element parent))
           child  (render (fn [{:keys [d]}] [:li (str (doall @d))]) props)]

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/disposed_cell_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/disposed_cell_cljs_test.cljs
@@ -36,16 +36,16 @@
   adapter: on an unwatchable host a subscription never notifies and the
   `notified` half of every row would pass by never firing."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.live-frame :as live-frame]
-            [re-frame.test-support :as test-support]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.live-frame :as rf.live-frame]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      ;; The rebuild rows resume on a later tick, and `cljs.test` refuses a
      ;; fn-form fixture for an `async` test — the fn-form's ambient scope is
      ;; a dynamic binding that would be unwound before the body resumes.
@@ -54,7 +54,7 @@
      ;; BEFORE React context, so a fixture-installed ambient frame would
      ;; answer reads for a frame this file never made.
      :ambient-frame nil
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 ;; This file's OWN queries and OWN frames: a re-registration is a global
 ;; act, and re-registering a query some other suite reads would be a test
@@ -63,15 +63,15 @@
 (def ^:private q-node [:disposedcell/node])
 
 (defn- make-frame! [id db]
-  (live-frame/make-frame {:id id})
-  (frame/replace-app-db! id db)
+  (rf.live-frame/make-frame {:id id})
+  (rf.frame/replace-app-db! id db)
   id)
 
 (defn- reader
   "A boundary whose whole body is one read, so the read set is one key
   and the snapshot arithmetic is one term."
   [q seen]
-  (fn [_] (let [v (rt/sub q)] (vreset! seen v) [:li (str v)])))
+  (fn [_] (let [v (rf.bench.hicasso.arm1.runtime/sub q)] (vreset! seen v) [:li (str v)])))
 
 (defn- settle!
   "Run the macrotask queue once. `invalidate-cell!`'s rebuild is deferred
@@ -101,26 +101,26 @@
     (async done
     (let [seen (volatile! nil)
           f    (make-frame! ::registry {:v 1})]
-      (rt/render-body f (reader q-reg seen) {})
-      (let [entry    (rt/last-reads)
+      (rf.bench.hicasso.arm1.runtime/render-body f (reader q-reg seen) {})
+      (let [entry    (rf.bench.hicasso.arm1.runtime/last-reads)
             hits     (volatile! 0)
-            release! (rt/commit-boundary! entry (fn [] (vswap! hits inc)))]
-        (is (= 1 (:cells (rt/stats)))
+            release! (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn [] (vswap! hits inc)))]
+        (is (= 1 (:cells (rf.bench.hicasso.arm1.runtime/stats)))
             "RETAINED: the commit acquired a cell, so the key's reaction is
              held for the life of this boundary — which is what makes the
              warm read a pure deref, and what exposes it to a disposal")
 
         (testing "the CONTROL — the watch is live before the re-registration"
-          (frame/replace-app-db! f {:v 2})
+          (rf.frame/replace-app-db! f {:v 2})
           (is (= 1 @hits) "a write notified the boundary")
-          (rt/render-body f (reader q-reg seen) {})
+          (rf.bench.hicasso.arm1.runtime/render-body f (reader q-reg seen) {})
           (is (= 2 @seen) "and the re-render read the new value"))
 
         ;; THE RE-REGISTRATION.
         (rf/reg-sub (first q-reg) (fn [db _] (* 10 (:v db))))
 
         (testing "the next render computes against the NEW registration"
-          (rt/render-body f (reader q-reg seen) {})
+          (rf.bench.hicasso.arm1.runtime/render-body f (reader q-reg seen) {})
           (is (= 20 @seen)
               "20, not 2: the cell's reaction was disposed by the sub-cache
                eviction, so the read falls through to `subscribe-once`,
@@ -131,12 +131,12 @@
             (testing "and the durable attachment is rebuilt, so later writes
                       notify again"
               (let [before @hits]
-                (frame/replace-app-db! f {:v 3})
+                (rf.frame/replace-app-db! f {:v 3})
                 (is (pos? (- @hits before))
                     "the boundary was notified — without the rebuild the cell
                      is deaf from the disposal onwards, because `-dispose`
                      cleared the watcher set this arm's `add-watch` was in")))
-            (rt/render-body f (reader q-reg seen) {})
+            (rf.bench.hicasso.arm1.runtime/render-body f (reader q-reg seen) {})
             (is (= 30 @seen) "and it reads the new handler over the new db")
             (release!)
             (done))))))))
@@ -151,22 +151,22 @@
             strictly worse: it looks alive."
     (rf/reg-sub (first q-reg) (fn [db _] (:v db)))
     (let [f (make-frame! ::registry-retired {:v 1})]
-      (rt/render-body f (reader q-reg (volatile! nil)) {})
-      (let [entry    (rt/last-reads)
-            release! (rt/commit-boundary! entry (fn []))
+      (rf.bench.hicasso.arm1.runtime/render-body f (reader q-reg (volatile! nil)) {})
+      (let [entry    (rf.bench.hicasso.arm1.runtime/last-reads)
+            release! (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn []))
             ;; Reach past the repair: hold the reaction the cell held, then
             ;; re-register. This is exactly the object the cell kept before
             ;; `invalidate-cell!` existed.
-            held     (rt/cell-reaction [f q-reg])]
+            held     (rf.bench.hicasso.arm1.runtime/cell-reaction [f q-reg])]
         (is (some? held) "precondition: the cell holds a reaction")
         (rf/reg-sub (first q-reg) (fn [db _] (* 10 (:v db))))
-        (frame/replace-app-db! f {:v 7})
+        (rf.frame/replace-app-db! f {:v 7})
         (is (= 7 @held)
             "the disposed container answers 7 — the RETIRED `(:v db)` over
              the new db — where the live registration answers 70. A term in
              `getSnapshot` would have scheduled a re-render that read
              exactly this")
-        (is (nil? (rt/cell-reaction [f q-reg]))
+        (is (nil? (rf.bench.hicasso.arm1.runtime/cell-reaction [f q-reg]))
             "which is why the cell drops the reference instead: the repair
              is to stop reading through it, not to re-read it")
         (release!)))))
@@ -188,30 +188,30 @@
     (async done
     (let [seen (volatile! nil)
           f    (make-frame! ::node {:v 1})]
-      (rt/render-body f (reader q-node seen) {})
-      (let [entry    (rt/last-reads)
+      (rf.bench.hicasso.arm1.runtime/render-body f (reader q-node seen) {})
+      (let [entry    (rf.bench.hicasso.arm1.runtime/last-reads)
             hits     (volatile! 0)
-            release! (rt/commit-boundary! entry (fn [] (vswap! hits inc)))
-            token-a  (frame/frame-incarnation-token f)
-            basis-a  (rt/commit-basis f)]
+            release! (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn [] (vswap! hits inc)))
+            token-a  (rf.frame/frame-incarnation-token f)
+            basis-a  (rf.bench.hicasso.arm1.runtime/commit-basis f)]
         (is (= 1 @seen) "incarnation A's value")
 
         ;; THE REINCARNATION.
-        (frame/destroy-frame! f)
+        (rf.frame/destroy-frame! f)
         (make-frame! f {:v 99})
 
         (testing "the precondition this axis exists for — the basis TIES"
-          (is (not (identical? token-a (frame/frame-incarnation-token f)))
+          (is (not (identical? token-a (rf.frame/frame-incarnation-token f)))
               "a distinct incarnation, and `frame-incarnation-token` is the
                public reader that says so")
-          (is (= basis-a (rt/commit-basis f))
+          (is (= basis-a (rf.bench.hicasso.arm1.runtime/commit-basis f))
               "and yet the basis is the number it was: the epoch restarted at
                0 and climbed back to exactly where it stood. A tie, not a
                near-miss — so no arithmetic over these two terms could have
                distinguished the incarnations"))
 
         (testing "the boundary reads the SUCCESSOR's app-db"
-          (rt/render-body f (reader q-node seen) {})
+          (rf.bench.hicasso.arm1.runtime/render-body f (reader q-node seen) {})
           (is (= 99 @seen)
               "99, not 1: the destroyed incarnation's reaction was disposed
                with its frame, so the read resolves against the frame that is
@@ -221,9 +221,9 @@
           (fn []
             (testing "and the rebuilt attachment tracks the successor"
               (let [before @hits]
-                (frame/replace-app-db! f {:v 100})
+                (rf.frame/replace-app-db! f {:v 100})
                 (is (pos? (- @hits before)) "a write on B notified the boundary"))
-              (rt/render-body f (reader q-node seen) {})
+              (rf.bench.hicasso.arm1.runtime/render-body f (reader q-node seen) {})
               (is (= 100 @seen)))
             (release!)
             (done))))))))
@@ -236,17 +236,17 @@
             the basis ties."
     (rf/reg-sub (first q-node) (fn [db _] (:v db)))
     (let [f (make-frame! ::node-pinned {:v 1})]
-      (rt/render-body f (reader q-node (volatile! nil)) {})
-      (let [entry    (rt/last-reads)
-            release! (rt/commit-boundary! entry (fn []))
-            held     (rt/cell-reaction [f q-node])]
+      (rf.bench.hicasso.arm1.runtime/render-body f (reader q-node (volatile! nil)) {})
+      (let [entry    (rf.bench.hicasso.arm1.runtime/last-reads)
+            release! (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn []))
+            held     (rf.bench.hicasso.arm1.runtime/cell-reaction [f q-node])]
         (is (some? held) "precondition: the cell holds a reaction")
-        (frame/destroy-frame! f)
+        (rf.frame/destroy-frame! f)
         (make-frame! f {:v 99})
         (is (= 1 @held)
             "the pinned container answers incarnation A's 1 where the live
              frame holds 99")
-        (is (nil? (rt/cell-reaction [f q-node]))
+        (is (nil? (rf.bench.hicasso.arm1.runtime/cell-reaction [f q-node]))
             "so the cell drops it")
         (release!)))))
 
@@ -260,12 +260,12 @@
             an event armed once per unique key. So the shell is unchanged,
             the snapshot arithmetic is unchanged, and `subscribe` still
             closes over the read set alone."
-    (is (= 2 (count rt/shell-hook-ledger))
+    (is (= 2 (count rf.bench.hicasso.arm1.runtime/shell-hook-ledger))
         "still two hooks — the disposal hook is not a React hook")
     (is (= [:use-context/frame :use-sync-external-store/subscription-epoch]
-           rt/shell-hook-ledger)
+           rf.bench.hicasso.arm1.runtime/shell-hook-ledger)
         "and the same two, in the same order")
-    (let [inv (rt/retained-inventory)]
+    (let [inv (rf.bench.hicasso.arm1.runtime/retained-inventory)]
       (is (= #{:use-ref :use-state :view-cell :candidate-ledger}
              (into #{} (map :token) (:absent inv)))
           "the enumerated absences are unchanged: no per-boundary object was
@@ -276,11 +276,11 @@
             risked on every boundary in the application"
     (rf/reg-sub (first q-reg) (fn [db _] (:v db)))
     (let [f     (make-frame! ::registry-clean {:v 1})
-          _     (rt/render-body f (reader q-reg (volatile! nil)) {})
-          entry (rt/last-reads)
-          at-render (rt/snapshot-of entry)
-          release!  (rt/commit-boundary! entry (fn []))]
-      (is (= at-render (rt/snapshot-of entry))
+          _     (rf.bench.hicasso.arm1.runtime/render-body f (reader q-reg (volatile! nil)) {})
+          entry (rf.bench.hicasso.arm1.runtime/last-reads)
+          at-render (rf.bench.hicasso.arm1.runtime/snapshot-of entry)
+          release!  (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn []))]
+      (is (= at-render (rf.bench.hicasso.arm1.runtime/snapshot-of entry))
           "acquisition still moves nothing: the cell is born at the same
            basis the staged term reported, and arming a disposal hook is not
            a term")

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/dogfood_collector.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/dogfood_collector.cljs
@@ -38,7 +38,7 @@
   Mounted by `arm1_dogfood_dom_cljs_test` — and mounting it is what
   started the six-week K7 clock (HD-014)."
   (:require [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
-            [re-frame.bench.hicasso.front.dogfood :as d])
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 (defview head [_]
@@ -50,10 +50,10 @@
 (defview new-item [_]
   [:form.new {:on-submit [:dogfood/create]}
    [:input.new-input {:type        "text"
-                      :value       (sub [:dogfood/draft d/new-draft-key])
-                      :on-input    [:dogfood/edit-draft d/new-draft-key :re-frame.hicasso/value]
+                      :value       (sub [:dogfood/draft rf.bench.hicasso.front.dogfood/new-draft-key])
+                      :on-input    [:dogfood/edit-draft rf.bench.hicasso.front.dogfood/new-draft-key :re-frame.hicasso/value]
                       :on-key-down {"Enter"  [:dogfood/create]
-                                    "Escape" [:dogfood/cancel d/new-draft-key]}}]
+                                    "Escape" [:dogfood/cancel rf.bench.hicasso.front.dogfood/new-draft-key]}}]
    [:button.add {:type "submit"} "Add"]])
 
 (defn- filter-button

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/dogfood_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/dogfood_dom_cljs_test.cljs
@@ -59,17 +59,17 @@
   Runtime: `-dom-cljs-test`; under `:node-test` every claim degrades to a
   stated skip."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.dogfood-collector :as collector]
-            [re-frame.bench.hicasso.arm1.dogfood-grouped :as grouped]
-            [re-frame.bench.hicasso.arm1.dogfood-script :as script]
-            [re-frame.bench.hicasso.arm1.dogfood-uix :as raw-uix]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
-            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.dogfood-collector :as rf.bench.hicasso.arm1.dogfood-collector]
+            [re-frame.bench.hicasso.arm1.dogfood-grouped :as rf.bench.hicasso.arm1.dogfood-grouped]
+            [re-frame.bench.hicasso.arm1.dogfood-script :as rf.bench.hicasso.arm1.dogfood-script]
+            [re-frame.bench.hicasso.arm1.dogfood-uix :as rf.bench.hicasso.arm1.dogfood-uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
             [re-frame.core :as rf]
-            [re-frame.test-support :as test-support]
+            [re-frame.test-support :as rf.test-support]
             [uix.compiler.input]
             [uix.core :refer [$ defui]]
             ["react-dom" :as react-dom]
@@ -127,8 +127,8 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private runtime-fixture
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      ;; `:ambient-frame nil` is load-bearing, not tidiness. The fixture's
      ;; default leaves a dynamic-var frame stamp in scope, and the
      ;; carried-invariant chain resolves that tier BEFORE React context —
@@ -142,7 +142,7 @@
      ;; and entry reapers are macrotasks, so the residue a React unmount
      ;; leaves is not readable inside one synchronous test body.
      :async?  true
-     :init-fn (fn [] (rt/reset-runtime!))}))
+     :init-fn (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (use-fixtures :each
   {:before (fn []
@@ -164,9 +164,9 @@
   for an id that already exists, and `reseed!` is the front half's own
   door for returning a live frame to its seeded state."
   []
-  (lane/leave-act-environment!)
-  (dogfood/make-frame! frame-id todo-count)
-  (dogfood/reseed! frame-id todo-count)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.front.dogfood/make-frame! frame-id todo-count)
+  (rf.bench.hicasso.front.dogfood/reseed! frame-id todo-count)
   frame-id)
 
 ;; ---------------------------------------------------------------------------
@@ -176,7 +176,7 @@
 (defn- hicasso-mount!
   "Either Hicasso rendering, on the arm's own root."
   [screen]
-  (mount/root! (mount/fresh-container!) frame-id [screen {}]))
+  (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [screen {}]))
 
 (defn- uix-mount!
   "The comparator, on its own React root and its own `frame-provider`.
@@ -184,9 +184,9 @@
   candidate's plumbing, or a plumbing bug would hide inside the parity
   gate it is supposed to expose."
   []
-  (let [container (mount/fresh-container!)
+  (let [container (rf.bench.hicasso.arm1.mount/fresh-container!)
         root      (react-dom-client/createRoot container)]
-    (react-dom/flushSync (fn [] (.render root (raw-uix/root frame-id))))
+    (react-dom/flushSync (fn [] (.render root (rf.bench.hicasso.arm1.dogfood-uix/root frame-id))))
     {:root root :container container :uix? true}))
 
 (defn- release-uix! [handle]
@@ -203,21 +203,21 @@
 ;; its own, so a failure names the plumbing rather than the rendering.
 
 (defui frame-probe [_props]
-  ($ :div.probe {:data-frame (str (uix-adapter/use-current-frame))
-                 :data-ambient (str (uix-adapter/use-subscribe [:dogfood/remaining]))
-                 :data-explicit (str (uix-adapter/use-subscribe frame-id [:dogfood/remaining]))}))
+  ($ :div.probe {:data-frame (str (rf.adapter.uix/use-current-frame))
+                 :data-ambient (str (rf.adapter.uix/use-subscribe [:dogfood/remaining]))
+                 :data-explicit (str (rf.adapter.uix/use-subscribe frame-id [:dogfood/remaining]))}))
 
 (deftest the-comparator-reads-the-frame-this-test-seeded
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (is (= todo-count (rf/with-frame frame-id (deref (rf/subscribe [:dogfood/remaining]))))
           "the frame itself is seeded")
-      (let [container (mount/fresh-container!)
+      (let [container (rf.bench.hicasso.arm1.mount/fresh-container!)
             root      (react-dom-client/createRoot container)]
         (react-dom/flushSync
-          (fn [] (.render root ($ uix-adapter/frame-provider {:frame frame-id}
+          (fn [] (.render root ($ rf.adapter.uix/frame-provider {:frame frame-id}
                                   ($ frame-probe)))))
         (let [probe (.querySelector container ".probe")]
           (is (= (str frame-id) (.getAttribute probe "data-frame"))
@@ -234,7 +234,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-three-renderings-build-the-same-page
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     ;; The comparator goes FIRST, on the freshest possible frame. If it
     ;; went last, a parity miss could be read either as a rendering
@@ -242,24 +242,24 @@
     ;; gate would not be able to tell a reader which.
     (let [_ (fresh!)
           c (uix-mount!)
-          c-dom (lane/canonical (:container c))
+          c-dom (rf.bench.hicasso.lane/canonical (:container c))
           _ (release-uix! c)
           _ (fresh!)
-          a (hicasso-mount! collector/screen)
-          a-dom (lane/canonical (:container a))
-          _ (mount/release! a)
+          a (hicasso-mount! rf.bench.hicasso.arm1.dogfood-collector/screen)
+          a-dom (rf.bench.hicasso.lane/canonical (:container a))
+          _ (rf.bench.hicasso.arm1.mount/release! a)
           _ (fresh!)
-          b (hicasso-mount! grouped/screen)
-          b-dom (lane/canonical (:container b))
-          _ (mount/release! b)]
+          b (hicasso-mount! rf.bench.hicasso.arm1.dogfood-grouped/screen)
+          b-dom (rf.bench.hicasso.lane/canonical (:container b))
+          _ (rf.bench.hicasso.arm1.mount/release! b)]
       (is (= a-dom b-dom) "collector and grouped build the same page")
       (is (= a-dom c-dom) "and so does raw UIx")
       (testing "the comparison can answer false, so it is not passing vacuously"
         (fresh!)
-        (let [d     (hicasso-mount! collector/screen)
-              _     (mount/dispatch! d [:dogfood/toggle 0])
-              moved (lane/canonical (:container d))]
-          (mount/release! d)
+        (let [d     (hicasso-mount! rf.bench.hicasso.arm1.dogfood-collector/screen)
+              _     (rf.bench.hicasso.arm1.mount/dispatch! d [:dogfood/toggle 0])
+              moved (rf.bench.hicasso.lane/canonical (:container d))]
+          (rf.bench.hicasso.arm1.mount/release! d)
           (is (not= a-dom moved))))
       (testing "and the page is the screen validation.md asked for — a list
                and a controlled field"
@@ -280,31 +280,31 @@
   "Every read is inside the lazy seq. Nothing outside it reads a row."
   [_]
   [:ul.lazy
-   (for [id (rt/sub [:dogfood/visible-ids])]
+   (for [id (rf.bench.hicasso.arm1.runtime/sub [:dogfood/visible-ids])]
      [:li.lazy-row {:key id :data-id id}
-      (str (:title (rt/sub [:dogfood/todo id])))])])
+      (str (:title (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo id])))])])
 
 (deftest reads-inside-a-lazy-for-update-the-dom-on-a-later-write
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [lazy-rows {}])]
+      (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [lazy-rows {}])]
         (try
           (let [cell (fn [id] (some-> (.querySelector (:container handle)
                                                       (str ".lazy-row[data-id=\"" id "\"]"))
                                       (.-textContent)))]
             (is (= todo-count (.-length (.querySelectorAll (:container handle) ".lazy-row"))))
             (is (= "todo 2" (cell 2)) "the first paint is right — which proves nothing on its own")
-            (rt/dispatch! frame-id [:dogfood/edit-draft 2 "ignored"])
-            (mount/settle!)
-            (rt/dispatch! frame-id [:dogfood/commit 2])
-            (mount/settle!)
+            (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/edit-draft 2 "ignored"])
+            (rf.bench.hicasso.arm1.mount/settle!)
+            (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/commit 2])
+            (rf.bench.hicasso.arm1.mount/settle!)
             (is (= "ignored" (cell 2))
                 "and a later write to a query the lazy seq produced reaches the
                  DOM — the half a first render cannot tell you")
             (is (= "todo 1" (cell 1)) "while its neighbour is untouched"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 1c — the same intents on the same interactions (rf2-2rtt6.67)
@@ -359,16 +359,16 @@
                            (fn [record]
                              (when (= frame-id (:frame record))
                                (swap! log conj (:event record)))))
-    (script/run-steps!
-      (script/interaction-steps handle)
+    (rf.bench.hicasso.arm1.dogfood-script/run-steps!
+      (rf.bench.hicasso.arm1.dogfood-script/interaction-steps handle)
       (fn []
-        (let [result {:intents @log :dom (lane/canonical (:container handle))}]
+        (let [result {:intents @log :dom (rf.bench.hicasso.lane/canonical (:container handle))}]
           (rf/unregister-listener! :events ::intent-parity)
           (release-fn handle)
           (k result))))))
 
 (deftest the-two-live-renderings-dispatch-the-same-intents-on-the-same-interactions
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     ;; The control first, on the freshest frame — same reasoning as the
     ;; DOM-parity gate above.
@@ -377,12 +377,12 @@
         uix-mount! release-uix!
         (fn [uix-run]
           (capture-run!
-            (fn [] (hicasso-mount! collector/screen)) mount/release!
+            (fn [] (hicasso-mount! rf.bench.hicasso.arm1.dogfood-collector/screen)) rf.bench.hicasso.arm1.mount/release!
             (fn [collector-run]
-              (is (= script/interaction-intents (:intents uix-run))
+              (is (= rf.bench.hicasso.arm1.dogfood-script/interaction-intents (:intents uix-run))
                   "raw UIx dispatches exactly the stated intents — and
                    nothing for the two composing keystrokes")
-              (is (= script/interaction-intents (:intents collector-run))
+              (is (= rf.bench.hicasso.arm1.dogfood-script/interaction-intents (:intents collector-run))
                   "and so does the collector, so the two renderings mean
                    the same page as well as building it")
               (is (= (:dom uix-run) (:dom collector-run))
@@ -404,50 +404,50 @@
           (.getAttribute "data-done")))
 
 (deftest a-toggle-moves-exactly-the-row-it-names
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
-    (doseq [[label screen] [["collector" collector/screen] ["grouped" grouped/screen]]]
+    (doseq [[label screen] [["collector" rf.bench.hicasso.arm1.dogfood-collector/screen] ["grouped" rf.bench.hicasso.arm1.dogfood-grouped/screen]]]
       (fresh!)
       (let [handle (hicasso-mount! screen)]
         (try
           (is (= "false" (row-done handle 1)) label)
-          (mount/dispatch! handle [:dogfood/toggle 1])
+          (rf.bench.hicasso.arm1.mount/dispatch! handle [:dogfood/toggle 1])
           (is (= "true" (row-done handle 1)) (str label ": the named row moved"))
           (is (= "false" (row-done handle 0)) (str label ": and its neighbour did not"))
           (is (= "false" (row-done handle 2)) (str label ": nor the one after"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 (deftest a-broad-write-rebuilds-the-list
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle (hicasso-mount! collector/screen)]
+      (let [handle (hicasso-mount! rf.bench.hicasso.arm1.dogfood-collector/screen)]
         (try
-          (mount/dispatch! handle [:dogfood/toggle 1])
+          (rf.bench.hicasso.arm1.mount/dispatch! handle [:dogfood/toggle 1])
           (is (= todo-count (.-length (.querySelectorAll (:container handle) ".row"))))
-          (mount/dispatch! handle [:dogfood/set-filter :done])
+          (rf.bench.hicasso.arm1.mount/dispatch! handle [:dogfood/set-filter :done])
           (is (= 1 (.-length (.querySelectorAll (:container handle) ".row")))
               "the filter is a broad write: the visible-ids subscription
                moved and the list rebuilt")
           (is (= "todo 1" (row-text handle 1)))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 (deftest keyed-rows-keep-their-identity-across-a-reorder
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle (hicasso-mount! collector/screen)]
+      (let [handle (hicasso-mount! rf.bench.hicasso.arm1.dogfood-collector/screen)]
         (try
           (let [node-before (.querySelector (:container handle) "[data-id=\"3\"]")]
-            (mount/dispatch! handle [:dogfood/move 3 0])
+            (rf.bench.hicasso.arm1.mount/dispatch! handle [:dogfood/move 3 0])
             (let [rows (array-seq (.querySelectorAll (:container handle) ".row"))]
               (is (= "3" (.getAttribute (first rows) "data-id"))
                   "the moved row is first")
               (is (identical? node-before (.querySelector (:container handle) "[data-id=\"3\"]"))
                   "and it is the SAME node — identity follows the key")))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3 — the controlled field, and what the collector's conditional read buys
@@ -456,55 +456,55 @@
 (defn- new-input [handle] (.querySelector (:container handle) ".new-input"))
 
 (deftest the-controlled-field-echoes-in-the-callers-turn
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle (hicasso-mount! collector/screen)]
+      (let [handle (hicasso-mount! rf.bench.hicasso.arm1.dogfood-collector/screen)]
         (try
           (let [input (new-input handle)]
             (is (= "" (.-value input)))
             ;; The intent's own path: dispatch through the arm's
             ;; synchronous door, exactly as the lowered `:on-input`
             ;; closure does, and read the DOM on the next line.
-            (rt/dispatch! frame-id [:dogfood/edit-draft dogfood/new-draft-key "milk"])
-            (mount/settle!)
+            (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/edit-draft rf.bench.hicasso.front.dogfood/new-draft-key "milk"])
+            (rf.bench.hicasso.arm1.mount/settle!)
             (is (= "milk" (.-value (new-input handle)))
                 "the echo landed without waiting for a later turn"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 (deftest the-submit-intent-creates-and-clears-the-draft
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle (hicasso-mount! collector/screen)]
+      (let [handle (hicasso-mount! rf.bench.hicasso.arm1.dogfood-collector/screen)]
         (try
-          (rt/dispatch! frame-id [:dogfood/edit-draft dogfood/new-draft-key "milk"])
-          (mount/settle!)
-          (rt/dispatch! frame-id [:dogfood/create])
-          (mount/settle!)
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/edit-draft rf.bench.hicasso.front.dogfood/new-draft-key "milk"])
+          (rf.bench.hicasso.arm1.mount/settle!)
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/create])
+          (rf.bench.hicasso.arm1.mount/settle!)
           (is (= (inc todo-count) (.-length (.querySelectorAll (:container handle) ".row"))))
           (is (= "milk" (row-text handle todo-count)))
           (is (= "" (.-value (new-input handle)))
               "and the draft cleared by explicit caller revision, never by
                value equality")
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 (deftest the-collectors-conditional-read-costs-fewer-edges-than-the-declaration
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [collector-edges (let [h (hicasso-mount! collector/screen)]
-                              (mount/dispatch! h [:dogfood/toggle 0])
-                              (mount/dispatch! h [:dogfood/toggle 1])
-                              (let [e (:edges (rt/stats))] (mount/release! h) e))
+      (let [collector-edges (let [h (hicasso-mount! rf.bench.hicasso.arm1.dogfood-collector/screen)]
+                              (rf.bench.hicasso.arm1.mount/dispatch! h [:dogfood/toggle 0])
+                              (rf.bench.hicasso.arm1.mount/dispatch! h [:dogfood/toggle 1])
+                              (let [e (:edges (rf.bench.hicasso.arm1.runtime/stats))] (rf.bench.hicasso.arm1.mount/release! h) e))
             _ (fresh!)
-            grouped-edges   (let [h (hicasso-mount! grouped/screen)]
-                              (mount/dispatch! h [:dogfood/toggle 0])
-                              (mount/dispatch! h [:dogfood/toggle 1])
-                              (let [e (:edges (rt/stats))] (mount/release! h) e))]
+            grouped-edges   (let [h (hicasso-mount! rf.bench.hicasso.arm1.dogfood-grouped/screen)]
+                              (rf.bench.hicasso.arm1.mount/dispatch! h [:dogfood/toggle 0])
+                              (rf.bench.hicasso.arm1.mount/dispatch! h [:dogfood/toggle 1])
+                              (let [e (:edges (rf.bench.hicasso.arm1.runtime/stats))] (rf.bench.hicasso.arm1.mount/release! h) e))]
         (is (< collector-edges grouped-edges)
             (str "two completed rows drop their draft edge under the collector "
                  "and keep it under the declaration (" collector-edges " vs "
@@ -517,7 +517,7 @@
 ;; ---------------------------------------------------------------------------
 ;;
 ;; The reading is taken between the root unmount and any reset, because
-;; `mount/release!` resets the runtime and a reading taken after that is a
+;; `rf.bench.hicasso.arm1.mount/release!` resets the runtime and a reading taken after that is a
 ;; reading of an emptied table — zero however badly teardown went. That
 ;; ordering is what made these two gates unable to fail (rf2-2rtt6.48),
 ;; and `the-residue-reading-can-answer-false` below is the demonstration
@@ -543,31 +543,31 @@
   [label screen done]
   (fresh!)
   (let [handle (hicasso-mount! screen)]
-    (mount/dispatch! handle [:dogfood/toggle 0])
-    (mount/dispatch! handle [:dogfood/set-filter :all])
-    (is (pos? (:cell-refs (rt/stats)))
+    (rf.bench.hicasso.arm1.mount/dispatch! handle [:dogfood/toggle 0])
+    (rf.bench.hicasso.arm1.mount/dispatch! handle [:dogfood/set-filter :all])
+    (is (pos? (:cell-refs (rf.bench.hicasso.arm1.runtime/stats)))
         (str label ": the mounted screen holds references, so the reading "
              "below is a reading of something"))
-    (mount/unmount! handle)
+    (rf.bench.hicasso.arm1.mount/unmount! handle)
     (js/setTimeout (fn []
-                     (is (= nothing-retained (rt/residue))
+                     (is (= nothing-retained (rf.bench.hicasso.arm1.runtime/residue))
                          (str label ": React's own cleanup released every edge, "
                               "reference and cached entry"))
-                     (rt/reset-runtime!)
+                     (rf.bench.hicasso.arm1.runtime/reset-runtime!)
                      (done))
                    reaper-horizon-ms)))
 
 (deftest the-collector-screen-leaves-no-residue
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (async done (assert-react-teardown-releases-everything!
-                  "collector" collector/screen done))))
+                  "collector" rf.bench.hicasso.arm1.dogfood-collector/screen done))))
 
 (deftest the-grouped-screen-leaves-no-residue
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (async done (assert-react-teardown-releases-everything!
-                  "grouped" grouped/screen done))))
+                  "grouped" rf.bench.hicasso.arm1.dogfood-grouped/screen done))))
 
 (deftest the-residue-reading-can-answer-false
   (testing "two roots, one unmounted: the reading the gates above take is
@@ -575,19 +575,19 @@
            what they acquired. This is the property the pre-repair gates
            lacked — `release!` resets the runtime, so it would report zero
            here too, with a whole screen still mounted"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (async done
         (fresh!)
-        (let [survivor (hicasso-mount! collector/screen)
-              doomed   (hicasso-mount! collector/screen)]
-          (mount/unmount! doomed)
+        (let [survivor (hicasso-mount! rf.bench.hicasso.arm1.dogfood-collector/screen)
+              doomed   (hicasso-mount! rf.bench.hicasso.arm1.dogfood-collector/screen)]
+          (rf.bench.hicasso.arm1.mount/unmount! doomed)
           (js/setTimeout (fn []
-                           (is (not= nothing-retained (rt/residue))
+                           (is (not= nothing-retained (rf.bench.hicasso.arm1.runtime/residue))
                                "a live screen is visible to the residue reading")
-                           (is (pos? (:cell-refs (rt/residue)))
+                           (is (pos? (:cell-refs (rf.bench.hicasso.arm1.runtime/residue)))
                                "and it is visible as held references, which is
                                 the quantity the gates assert to be zero")
-                           (mount/release! survivor)
+                           (rf.bench.hicasso.arm1.mount/release! survivor)
                            (done))
                          reaper-horizon-ms))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/dogfood_grouped.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/dogfood_grouped.cljs
@@ -36,7 +36,7 @@
   (`the-collectors-conditional-read-costs-fewer-edges-than-the-declaration`),
   and for no other reason."
   (:require [re-frame.bench.hicasso.arm1.runtime :refer [use-subs]]
-            [re-frame.bench.hicasso.front.dogfood :as d])
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 (defview head [_]
@@ -46,13 +46,13 @@
      [:span.remaining {:data-remaining remaining} (str remaining " left")]]))
 
 (defview new-item [_]
-  (let [{:keys [draft]} (use-subs {:draft [:dogfood/draft d/new-draft-key]})]
+  (let [{:keys [draft]} (use-subs {:draft [:dogfood/draft rf.bench.hicasso.front.dogfood/new-draft-key]})]
     [:form.new {:on-submit [:dogfood/create]}
      [:input.new-input {:type        "text"
                         :value       draft
-                        :on-input    [:dogfood/edit-draft d/new-draft-key :re-frame.hicasso/value]
+                        :on-input    [:dogfood/edit-draft rf.bench.hicasso.front.dogfood/new-draft-key :re-frame.hicasso/value]
                         :on-key-down {"Enter"  [:dogfood/create]
-                                      "Escape" [:dogfood/cancel d/new-draft-key]}}]
+                                      "Escape" [:dogfood/cancel rf.bench.hicasso.front.dogfood/new-draft-key]}}]
      [:button.add {:type "submit"} "Add"]]))
 
 (defn- filter-button

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/dogfood_script.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/dogfood_script.cljs
@@ -31,8 +31,8 @@
   Nothing here reads a subscription, mounts anything or asserts
   anything. The steps take a mount HANDLE (`{:container …}`) and the
   caller owns the mount, the capture and the assertions."
-  (:require [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]))
+  (:require [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]))
 
 ;; ---------------------------------------------------------------------------
 ;; The three ways a user touches a page
@@ -84,16 +84,16 @@
    [:dogfood/set-filter :done]
    [:dogfood/set-filter :active]
    [:dogfood/set-filter :all]
-   [:dogfood/edit-draft dogfood/new-draft-key "milk"]
-   [:dogfood/cancel dogfood/new-draft-key]
-   [:dogfood/edit-draft dogfood/new-draft-key "milk"]
+   [:dogfood/edit-draft rf.bench.hicasso.front.dogfood/new-draft-key "milk"]
+   [:dogfood/cancel rf.bench.hicasso.front.dogfood/new-draft-key]
+   [:dogfood/edit-draft rf.bench.hicasso.front.dogfood/new-draft-key "milk"]
    [:dogfood/create]
    [:dogfood/edit-draft 0 "x"]
    [:dogfood/cancel 0]
    [:dogfood/edit-draft 3 "renamed"]
    [:dogfood/commit 3]
    [:dogfood/remove 2]
-   [:dogfood/edit-draft dogfood/new-draft-key "bread"]
+   [:dogfood/edit-draft rf.bench.hicasso.front.dogfood/new-draft-key "bread"]
    [:dogfood/create]])
 
 (defn interaction-steps
@@ -153,4 +153,4 @@
   (if (empty? steps)
     (k)
     (do ((first steps))
-        (js/setTimeout (fn [] (mount/settle!) (run-steps! (rest steps) k)) 8))))
+        (js/setTimeout (fn [] (rf.bench.hicasso.arm1.mount/settle!) (run-steps! (rest steps) k)) 8))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/dogfood_uix.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/dogfood_uix.cljs
@@ -75,8 +75,8 @@
   retired grouped rendering rides too, and the DOM this file builds is
   asserted identical to the collector's — elements AND dispatched
   intents — by `arm1_dogfood_dom_cljs_test`."
-  (:require [re-frame.adapter.uix :as uixa]
-            [re-frame.bench.hicasso.front.dogfood :as d]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
             [uix.core :refer [$ defui]]))
 
 (defn- ime-gated
@@ -95,25 +95,25 @@
           (dispatch intent))))))
 
 (defui head [_props]
-  (let [remaining (uixa/use-subscribe [:dogfood/remaining])]
+  (let [remaining (rf.adapter.uix/use-subscribe [:dogfood/remaining])]
     ($ :header.head
        ($ :h1.title "todos")
        ($ :span.remaining {:data-remaining remaining} (str remaining " left")))))
 
 (defui new-item [_props]
-  (let [draft              (uixa/use-subscribe [:dogfood/draft d/new-draft-key])
-        {:keys [dispatch]} (uixa/use-frame)]
+  (let [draft              (rf.adapter.uix/use-subscribe [:dogfood/draft rf.bench.hicasso.front.dogfood/new-draft-key])
+        {:keys [dispatch]} (rf.adapter.uix/use-frame)]
     ($ :form.new {:on-submit (fn [e]
                                (.preventDefault e)
                                (dispatch [:dogfood/create]))}
        ($ :input.new-input
           {:type        "text"
            :value       draft
-           :on-change   #(dispatch [:dogfood/edit-draft d/new-draft-key
+           :on-change   #(dispatch [:dogfood/edit-draft rf.bench.hicasso.front.dogfood/new-draft-key
                                     (.. % -target -value)])
            :on-key-down (ime-gated dispatch
                                    {"Enter"  [:dogfood/create]
-                                    "Escape" [:dogfood/cancel d/new-draft-key]})})
+                                    "Escape" [:dogfood/cancel rf.bench.hicasso.front.dogfood/new-draft-key]})})
        ($ :button.add {:type "submit"} "Add"))))
 
 (defn- filter-button [id label current dispatch]
@@ -124,17 +124,17 @@
      label))
 
 (defui filters [_props]
-  (let [current            (uixa/use-subscribe [:dogfood/filter])
-        {:keys [dispatch]} (uixa/use-frame)]
+  (let [current            (rf.adapter.uix/use-subscribe [:dogfood/filter])
+        {:keys [dispatch]} (rf.adapter.uix/use-frame)]
     ($ :nav.filters
        (filter-button :all "All" current dispatch)
        (filter-button :active "Active" current dispatch)
        (filter-button :done "Done" current dispatch))))
 
 (defui row [{:keys [id]}]
-  (let [todo               (uixa/use-subscribe [:dogfood/todo id])
-        draft              (uixa/use-subscribe [:dogfood/draft id])
-        {:keys [dispatch]} (uixa/use-frame)]
+  (let [todo               (rf.adapter.uix/use-subscribe [:dogfood/todo id])
+        draft              (rf.adapter.uix/use-subscribe [:dogfood/draft id])
+        {:keys [dispatch]} (rf.adapter.uix/use-frame)]
     ($ :li.row {:data-id id :data-done (str (boolean (:done? todo)))}
        ($ :button.toggle {:type     "button"
                           :on-click #(dispatch [:dogfood/toggle id])}
@@ -153,7 +153,7 @@
           "x"))))
 
 (defui todo-list [_props]
-  (let [ids (uixa/use-subscribe [:dogfood/visible-ids])]
+  (let [ids (rf.adapter.uix/use-subscribe [:dogfood/visible-ids])]
     ($ :ul.list {:role "list"}
        (for [id ids]
          ($ row {:key id :id id})))))
@@ -170,5 +170,5 @@
   its own, so the canonical-DOM comparison against the collector
   rendering is unaffected."
   [frame-kw]
-  ($ uixa/frame-provider {:frame frame-kw}
+  ($ rf.adapter.uix/frame-provider {:frame frame-kw}
      ($ screen {})))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/first_registration_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/first_registration_cljs_test.cljs
@@ -65,16 +65,16 @@
   assertions are unchanged by the term, which is the cleanest available
   proof that the option taken is not the option declined."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.live-frame :as live-frame]
-            [re-frame.test-support :as test-support]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.live-frame :as rf.live-frame]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      ;; The rebuild rows resume on a later tick, and `cljs.test` refuses a
      ;; fn-form fixture for an `async` test — the fn-form's ambient scope is
      ;; a dynamic binding that would be unwound before the body resumes.
@@ -83,7 +83,7 @@
      ;; BEFORE React context, so a fixture-installed ambient frame would
      ;; answer reads for a frame this file never made.
      :ambient-frame nil
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 ;; This file's OWN queries. Every row here turns on a query being
 ;; UNREGISTERED when the boundary mounts, so these ids must be ones no
@@ -95,15 +95,15 @@
 (def ^:private q-live  [:firstreg/live])
 
 (defn- make-frame! [id db]
-  (live-frame/make-frame {:id id})
-  (frame/replace-app-db! id db)
+  (rf.live-frame/make-frame {:id id})
+  (rf.frame/replace-app-db! id db)
   id)
 
 (defn- reader
   "A boundary whose whole body is one read, so the read set is one key
   and the snapshot arithmetic is one term."
   [q seen]
-  (fn [_] (let [v (rt/sub q)] (vreset! seen v) [:li (str v)])))
+  (fn [_] (let [v (rf.bench.hicasso.arm1.runtime/sub q)] (vreset! seen v) [:li (str v)])))
 
 (defn- settle!
   "Run the macrotask queue once. The repair's rebuild is deferred — it
@@ -131,14 +131,14 @@
         ;; NO `reg-sub` yet. This is the boot-order / lazy-load shape: a
         ;; boundary mounts, reads a query whose module has not registered
         ;; its subs, and stays mounted while it does.
-        (rt/render-body f (reader q-first seen) {})
+        (rf.bench.hicasso.arm1.runtime/render-body f (reader q-first seen) {})
         (is (nil? @seen)
             "the recovery contract, unchanged: an unregistered read emits
              `:rf.error/no-such-sub` and derefs to nil")
-        (let [entry    (rt/last-reads)
+        (let [entry    (rf.bench.hicasso.arm1.runtime/last-reads)
               hits     (volatile! 0)
-              release! (rt/commit-boundary! entry (fn [] (vswap! hits inc)))]
-          (is (= 1 (:cells (rt/stats)))
+              release! (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn [] (vswap! hits inc)))]
+          (is (= 1 (:cells (rf.bench.hicasso.arm1.runtime/stats)))
               "and the COMMIT is what makes it a problem: the boundary now
                holds a cell for the key, so the read is a pure deref of
                whatever that cell caught — and what it caught is the
@@ -151,7 +151,7 @@
 
           (testing "the next render computes against the registration that
                     now exists"
-            (rt/render-body f (reader q-first seen) {})
+            (rf.bench.hicasso.arm1.runtime/render-body f (reader q-first seen) {})
             (is (= 1 @seen)
                 "1, not nil: the cell dropped the recovery, so the read falls
                  through to `subscribe-once`, which resolves the handler that
@@ -162,13 +162,13 @@
               (testing "and the durable attachment is built against it, so
                         later writes notify"
                 (let [before @hits]
-                  (frame/replace-app-db! f {:v 2})
+                  (rf.frame/replace-app-db! f {:v 2})
                   (is (pos? (- @hits before))
                       "the boundary was notified — without the repair the cell
                        is deaf for the life of the mount, because the watch it
                        installed is on a reaction the registration never
                        reaches")))
-              (rt/render-body f (reader q-first seen) {})
+              (rf.bench.hicasso.arm1.runtime/render-body f (reader q-first seen) {})
               (is (= 2 @seen) "and it reads the registered handler over the new db")
               (release!)
               (done))))))))
@@ -181,13 +181,13 @@
             cell that keeps it answers nil for as long as the boundary
             lives."
     (let [f (make-frame! ::held {:v 1})]
-      (rt/render-body f (reader q-held (volatile! nil)) {})
-      (let [entry    (rt/last-reads)
-            release! (rt/commit-boundary! entry (fn []))
+      (rf.bench.hicasso.arm1.runtime/render-body f (reader q-held (volatile! nil)) {})
+      (let [entry    (rf.bench.hicasso.arm1.runtime/last-reads)
+            release! (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn []))
             ;; Reach past the repair and hold the object the cell caught.
             ;; This is exactly what the cell kept before the first
             ;; registration was made an event.
-            held     (rt/cell-reaction [f q-held])]
+            held     (rf.bench.hicasso.arm1.runtime/cell-reaction [f q-held])]
         (is (some? held)
             "precondition: the commit acquired a reaction, and it is the
              substrate's uncached nil-recovery")
@@ -196,7 +196,7 @@
             "the held recovery answers nil where the live registration answers
              1 — and it will answer nil after every later write too, because
              it derives from nothing")
-        (is (nil? (rt/cell-reaction [f q-held]))
+        (is (nil? (rf.bench.hicasso.arm1.runtime/cell-reaction [f q-held]))
             "which is why the cell drops the reference instead: the repair is
              to stop reading through it, not to re-read it")
         (release!)))))
@@ -227,32 +227,32 @@
             zero is that distinction on the board."
     (let [seen (volatile! :unread)
           f    (make-frame! ::gap {:v 1})]
-      (rt/render-body f (reader q-gap seen) {})
+      (rf.bench.hicasso.arm1.runtime/render-body f (reader q-gap seen) {})
       (is (nil? @seen) "the body ran against no registration")
-      (let [entry     (rt/last-reads)
-            at-render (rt/snapshot-of entry)
-            epoch     (rt/registry-epoch)
+      (let [entry     (rf.bench.hicasso.arm1.runtime/last-reads)
+            at-render (rf.bench.hicasso.arm1.runtime/snapshot-of entry)
+            epoch     (rf.bench.hicasso.arm1.runtime/registry-epoch)
             hits      (volatile! 0)]
         ;; THE REGISTRATION, inside the gap: after the body returned and
         ;; before React's effect acquires the edge.
         (rf/reg-sub (first q-gap) (fn [db _] (:v db)))
-        (is (> (rt/registry-epoch) epoch)
+        (is (> (rf.bench.hicasso.arm1.runtime/registry-epoch) epoch)
             "precondition: the arm counted the registration — the term the
              rest of this row turns on actually moved")
-        (let [release! (rt/commit-boundary! entry (fn [] (vswap! hits inc)))]
-          (is (not= at-render (rt/snapshot-of entry))
+        (let [release! (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn [] (vswap! hits inc)))]
+          (is (not= at-render (rf.bench.hicasso.arm1.runtime/snapshot-of entry))
               "the snapshot MOVED across the commit, so React's
                post-`subscribe` re-check sees a tear and schedules the
                re-render the boundary needs to stop painting `nil`")
           (is (zero? @hits)
               "and it is the tear check that does it, not a notification —
                a `reg-sub` reaches `flush!` by no route")
-          (is (= 1 @(rt/cell-reaction [f q-gap]))
+          (is (= 1 @(rf.bench.hicasso.arm1.runtime/cell-reaction [f q-gap]))
               "and the cell the commit acquired holds the REAL handler, so
                the render React just scheduled reads the right value")
           (testing "which the re-render then does, at once rather than at
                     the next write"
-            (rt/render-body f (reader q-gap seen) {})
+            (rf.bench.hicasso.arm1.runtime/render-body f (reader q-gap seen) {})
             (is (= 1 @seen) "1, not nil: the delayed paint is gone"))
           (release!))))))
 
@@ -273,20 +273,20 @@
     (rf/reg-sub (first q-live) (fn [db _] (:v db)))
     (let [seen  (volatile! nil)
           f     (make-frame! ::unrelated {:v 1})
-          _     (rt/render-body f (reader q-live seen) {})
-          entry (rt/last-reads)
+          _     (rf.bench.hicasso.arm1.runtime/render-body f (reader q-live seen) {})
+          entry (rf.bench.hicasso.arm1.runtime/last-reads)
           hits  (volatile! 0)
-          release! (rt/commit-boundary! entry (fn [] (vswap! hits inc)))
-          before   (rt/snapshot-of entry)
-          held     (rt/cell-reaction [f q-live])]
+          release! (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn [] (vswap! hits inc)))
+          before   (rf.bench.hicasso.arm1.runtime/snapshot-of entry)
+          held     (rf.bench.hicasso.arm1.runtime/cell-reaction [f q-live])]
       (is (= 1 @seen) "the control: a registered key, read and committed")
       (is (some? held) "and holding its reaction")
       (rf/reg-sub :firstreg/nobody-reads-this (fn [db _] (:v db)))
-      (is (= before (rt/snapshot-of entry))
+      (is (= before (rf.bench.hicasso.arm1.runtime/snapshot-of entry))
           "the snapshot did not move: nothing about an unrelated first
            registration is in this key's contribution")
       (is (zero? @hits) "and nothing notified the boundary")
-      (is (identical? held (rt/cell-reaction [f q-live]))
+      (is (identical? held (rf.bench.hicasso.arm1.runtime/cell-reaction [f q-live]))
           "and the cell still holds the SAME reaction — an unrelated
            registration is not a reason to rebuild an attachment")
       (release!))))
@@ -296,12 +296,12 @@
             disposal half. The held-cell half is repaired by an event and
             the gap half by one term shared by every key, so neither buys
             a React hook and neither buys a per-boundary object."
-    (is (= 2 (count rt/shell-hook-ledger))
+    (is (= 2 (count rf.bench.hicasso.arm1.runtime/shell-hook-ledger))
         "still two hooks — a registrar hook is not a React hook")
     (is (= [:use-context/frame :use-sync-external-store/subscription-epoch]
-           rt/shell-hook-ledger)
+           rf.bench.hicasso.arm1.runtime/shell-hook-ledger)
         "and the same two, in the same order")
-    (let [inv (rt/retained-inventory)]
+    (let [inv (rf.bench.hicasso.arm1.runtime/retained-inventory)]
       (is (= #{:use-ref :use-state :view-cell :candidate-ledger}
              (into #{} (map :token) (:absent inv)))
           "the enumerated absences are unchanged: no per-boundary object was

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/frame_prop_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/frame_prop_dom_cljs_test.cljs
@@ -11,7 +11,7 @@
   ([[re-frame.bench.hicasso.front.codec/mark-frame-prop!]]).
 
   **This file is the CORRECTNESS half only.** The bead's heap ladder, its
-  mount/bulk clock and its studio row are measurement work on a quiet box
+  rf.bench.hicasso.arm1.mount/bulk clock and its studio row are measurement work on a quiet box
   and are not taken here (rf2-2rtt6.72). What is settled here is what a
   measurement is not allowed to be taken without:
 
@@ -44,26 +44,26 @@
   Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
   React DOM; under `:node-test` every claim degrades to a stated skip."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.hook-probe :as probe]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt :refer [sub]]
-            [re-frame.bench.hicasso.front.codec :as codec]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.hook-probe :as rf.bench.hicasso.arm1.hook-probe]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime :refer [sub]]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      ;; Same reason as the hook-ledger fixture: the default leaves a
      ;; dynamic-var frame stamp in scope, and a frame resolved from there
      ;; instead of from the prop would make an isolation miss look like a
      ;; rendering difference.
      :ambient-frame nil
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-a ::arm1-frame-prop-a)
 (def ^:private frame-b ::arm1-frame-prop-b)
@@ -95,7 +95,7 @@
 
 (def frame-prop-row
   "The challenger: the frame arrives as `rfFrame` on the element."
-  (rt/mint-frame-prop-view! "frame-prop-row" row-body))
+  (rf.bench.hicasso.arm1.runtime/mint-frame-prop-view! "frame-prop-row" row-body))
 
 ;; ---------------------------------------------------------------------------
 ;; The foreign component in the middle (claim 3)
@@ -109,7 +109,7 @@
   (react/createElement "div" #js {"className" "hatch"} (.-children props)))
 
 (def ^:private hatch
-  (codec/mint-host! "frame-prop-test/hatch" passthrough-component))
+  (rf.bench.hicasso.front.codec/mint-host! "frame-prop-test/hatch" passthrough-component))
 
 ;; ---------------------------------------------------------------------------
 ;; Fixture helpers
@@ -125,14 +125,14 @@
                  " rather than reading this as a pass.")))
 
 (defn- frames! []
-  (lane/leave-act-environment!)
-  (dogfood/make-frame! frame-a todos)
-  (dogfood/make-frame! frame-b todos)
-  (dogfood/reseed! frame-a todos)
-  (dogfood/reseed! frame-b todos))
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.front.dogfood/make-frame! frame-a todos)
+  (rf.bench.hicasso.front.dogfood/make-frame! frame-b todos)
+  (rf.bench.hicasso.front.dogfood/reseed! frame-a todos)
+  (rf.bench.hicasso.front.dogfood/reseed! frame-b todos))
 
 (defn- mount! [frame-kw hiccup]
-  (mount/root! (mount/fresh-container!) frame-kw hiccup))
+  (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-kw hiccup))
 
 (defn- text-of [handle]
   (.-textContent (:container handle)))
@@ -143,8 +143,8 @@
   root, page and frame so only the component varies."
   [hiccup]
   (let [handle (volatile! nil)
-        names  (probe/record! (fn [] (vreset! handle (mount! frame-a hiccup))))]
-    (mount/release! @handle)
+        names  (rf.bench.hicasso.arm1.hook-probe/record! (fn [] (vreset! handle (mount! frame-a hiccup))))]
+    (rf.bench.hicasso.arm1.mount/release! @handle)
     names))
 
 ;; ---------------------------------------------------------------------------
@@ -152,9 +152,9 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-frame-prop-shell-calls-one-hook-where-the-context-shell-calls-two
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
-    (if-not (probe/install!)
+    (if-not (rf.bench.hicasso.arm1.hook-probe/install!)
       (unwitnessed!)
       (testing "the same body, minted twice, counted by the same probe on
                the same page — the frame hook is the whole difference"
@@ -165,22 +165,22 @@
               (str "the incumbent's ledger, unchanged: " (pr-str ctx)))
           (is (= ["useSyncExternalStore"] prop)
               (str "and the frame-fed shell asks for one hook: " (pr-str prop)))
-          (is (= (count rt/shell-hook-ledger) (count ctx))
+          (is (= (count rf.bench.hicasso.arm1.runtime/shell-hook-ledger) (count ctx))
               "each declared ledger is the measured one")
-          (is (= (count rt/frame-prop-shell-hook-ledger) (count prop))
+          (is (= (count rf.bench.hicasso.arm1.runtime/frame-prop-shell-hook-ledger) (count prop))
               "for both variants")
           (is (= 1 (- (count ctx) (count prop)))
               "one slot of the ≤2 budget is freed, and it is exactly one"))))))
 
 (deftest the-freed-slot-does-not-come-back-with-the-read-count
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
-    (if-not (probe/install!)
+    (if-not (rf.bench.hicasso.arm1.hook-probe/install!)
       (unwitnessed!)
       (testing "1, 7 and 20 reads all cost ONE hook — the budget claim the
                ledger test makes at two, restated at one"
         (frames!)
-        (let [many (rt/mint-frame-prop-view!
+        (let [many (rf.bench.hicasso.arm1.runtime/mint-frame-prop-view!
                      "frame-prop-many"
                      (fn [{:keys [n]}]
                        [:ul.reads
@@ -196,7 +196,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest one-app-in-two-isolated-frames-and-no-read-crosses
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (testing "the same view mounted in two frames reads two app-dbs, and a
              write to one moves only one"
@@ -206,21 +206,21 @@
         (is (= "no" (text-of a)) "frame A starts undone")
         (is (= "no" (text-of b)) "frame B starts undone")
 
-        (mount/dispatch! a [:dogfood/toggle 0])
+        (rf.bench.hicasso.arm1.mount/dispatch! a [:dogfood/toggle 0])
         (is (= "yes" (text-of a)) "the write lands in the frame it was sent to")
         (is (= "no" (text-of b))
             "and NOTHING crosses — a prop-threaded frame isolates as
              completely as the context it replaces")
 
-        (mount/dispatch! b [:dogfood/toggle 0])
+        (rf.bench.hicasso.arm1.mount/dispatch! b [:dogfood/toggle 0])
         (is (= "yes" (text-of a)) "A is undisturbed by B's write")
         (is (= "yes" (text-of b)) "and B moves on its own")
 
-        (mount/release! a)
-        (mount/release! b)))))
+        (rf.bench.hicasso.arm1.mount/release! a)
+        (rf.bench.hicasso.arm1.mount/release! b)))))
 
 (deftest the-two-variants-isolate-identically
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (testing "the incumbent is put through the identical witness, so
              'isolation holds' is a comparison and not an assertion about
@@ -228,45 +228,45 @@
       (frames!)
       (let [a (mount! frame-a [context-row {:id 0}])
             b (mount! frame-b [context-row {:id 0}])]
-        (mount/dispatch! a [:dogfood/toggle 0])
+        (rf.bench.hicasso.arm1.mount/dispatch! a [:dogfood/toggle 0])
         (is (= "yes" (text-of a)))
         (is (= "no" (text-of b)))
-        (mount/release! a)
-        (mount/release! b)))))
+        (rf.bench.hicasso.arm1.mount/release! a)
+        (rf.bench.hicasso.arm1.mount/release! b)))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3. A foreign component in the middle
 ;; ---------------------------------------------------------------------------
 
 (deftest a-foreign-component-between-two-boundaries-preserves-the-frame
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (testing "the children handed to a foreign component were created by
              the Hicasso body ABOVE it, with the frame already in them, so
              `props.children` carries it through untouched"
       (frames!)
-      (let [outer (rt/mint-frame-prop-view!
+      (let [outer (rf.bench.hicasso.arm1.runtime/mint-frame-prop-view!
                     "frame-prop-outer"
                     (fn [_] [hatch {} [frame-prop-row {:id 0}]]))
             a     (mount! frame-a [outer {}])
             b     (mount! frame-b [outer {}])]
         (is (= "no" (text-of a)))
         (is (= "no" (text-of b)))
-        (mount/dispatch! a [:dogfood/toggle 0])
+        (rf.bench.hicasso.arm1.mount/dispatch! a [:dogfood/toggle 0])
         (is (= "yes" (text-of a))
             "the inner boundary resolved a frame at all — no crossing threw")
         (is (= "no" (text-of b))
             "and it resolved the RIGHT one, through a component that knows
              nothing about frames")
-        (mount/release! a)
-        (mount/release! b)))))
+        (rf.bench.hicasso.arm1.mount/release! a)
+        (rf.bench.hicasso.arm1.mount/release! b)))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4. The memo does not swallow a frame change (the mutation witness)
 ;; ---------------------------------------------------------------------------
 
 (deftest a-frame-change-with-unchanged-props-still-re-renders
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (testing "same root, same element, same props map, different frame.
              The props-equality bail-out would otherwise leave the body
@@ -277,24 +277,24 @@
       ;; Frame A's row is done; frame B's is not. Props are `{:id 0}` in
       ;; both renders, so `=` on `rfProps` is true and the comparator is
       ;; the only thing that can decide to re-render.
-      (rt/dispatch! frame-a [:dogfood/toggle 0])
+      (rf.bench.hicasso.arm1.runtime/dispatch! frame-a [:dogfood/toggle 0])
       (let [handle (mount! frame-a [frame-prop-row {:id 0}])]
         (is (= "yes" (text-of handle)) "mounted in A, reading A")
-        (mount/render! (assoc handle :frame frame-b) [frame-prop-row {:id 0}])
+        (rf.bench.hicasso.arm1.mount/render! (assoc handle :frame frame-b) [frame-prop-row {:id 0}])
         (is (= "no" (text-of handle))
             "re-rendered into B and reading B — the comparator saw the
              frame move even though the props did not")
-        (mount/release! handle)))))
+        (rf.bench.hicasso.arm1.mount/release! handle)))))
 
 (deftest the-incumbent-survives-the-same-frame-change
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (testing "for free, and by a different mechanism: React propagates a
              context change to its consumers ahead of the comparator"
       (frames!)
-      (rt/dispatch! frame-a [:dogfood/toggle 0])
+      (rf.bench.hicasso.arm1.runtime/dispatch! frame-a [:dogfood/toggle 0])
       (let [handle (mount! frame-a [context-row {:id 0}])]
         (is (= "yes" (text-of handle)))
-        (mount/render! (assoc handle :frame frame-b) [context-row {:id 0}])
+        (rf.bench.hicasso.arm1.mount/render! (assoc handle :frame frame-b) [context-row {:id 0}])
         (is (= "no" (text-of handle)))
-        (mount/release! handle)))))
+        (rf.bench.hicasso.arm1.mount/release! handle)))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/generation_fence_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/generation_fence_dom_cljs_test.cljs
@@ -39,18 +39,18 @@
   The fence's own algebra is proved without a browser in
   `arm1/runtime_cljs_test`."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
-            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
             [re-frame.core :as rf]
-            [re-frame.test-support :as test-support])
+            [re-frame.test-support :as rf.test-support])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      ;; `:ambient-frame nil` is load-bearing, not tidiness. The fixture's
      ;; default leaves a dynamic-var frame stamp in scope, and the
      ;; carried-invariant chain resolves that tier BEFORE React context —
@@ -64,7 +64,7 @@
      ;; entry reapers are macrotasks, so the residue a React unmount leaves
      ;; is not readable inside one synchronous test body.
      :async?  true
-     :init-fn (fn [] (rt/reset-runtime!))}))
+     :init-fn (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::arm1-fence)
 
@@ -84,10 +84,10 @@
   ;; separate the fence from ordinary invalidation. The read set is the
   ;; same on both runs, so the entry (and React's `subscribe`) is stable
   ;; across the re-run.
-  (let [_filter (rt/sub [:dogfood/filter])
-        before  (rt/sub [:dogfood/done? id])]
+  (let [_filter (rf.bench.hicasso.arm1.runtime/sub [:dogfood/filter])
+        before  (rf.bench.hicasso.arm1.runtime/sub [:dogfood/done? id])]
     (when-some [stage @!stage] (reset! !stage nil) (stage))
-    (let [after (rt/sub [:dogfood/done? id])]
+    (let [after (rf.bench.hicasso.arm1.runtime/sub [:dogfood/done? id])]
       (swap! !runs inc)
       [:li.row {:data-id id
                 :data-before (str before)
@@ -99,11 +99,11 @@
 (defn- mounted! []
   (reset! !runs 0)
   (reset! !stage nil)
-  (lane/leave-act-environment!)
-  (dogfood/make-frame! frame-id 3)
-  (dogfood/reseed! frame-id 3)
-  (let [container (mount/fresh-container!)]
-    (mount/root! container frame-id [staged-row {:id 0}])))
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.front.dogfood/make-frame! frame-id 3)
+  (rf.bench.hicasso.front.dogfood/reseed! frame-id 3)
+  (let [container (rf.bench.hicasso.arm1.mount/fresh-container!)]
+    (rf.bench.hicasso.arm1.mount/root! container frame-id [staged-row {:id 0}])))
 
 (defn- read-back [handle k]
   (some-> (.querySelector (:container handle) ".row") (.getAttribute k)))
@@ -113,7 +113,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-commit-staged-inside-a-body-never-publishes-a-straddled-read
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (let [handle (mounted!)]
       (try
@@ -121,8 +121,8 @@
         (let [runs-before @!runs]
           ;; Arm the stage, then make React re-render this boundary. The
           ;; body will write to the very subscription it is reading.
-          (reset! !stage (fn [] (rt/dispatch! frame-id [:dogfood/toggle 0])))
-          (mount/dispatch! handle [:dogfood/set-filter :done])
+          (reset! !stage (fn [] (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 0])))
+          (rf.bench.hicasso.arm1.mount/dispatch! handle [:dogfood/set-filter :done])
           (is (> @!runs runs-before) "the body ran"))
         (testing "the two reads of the winning run agree, so the DOM never
                  carries a value that was not simultaneously true"
@@ -130,14 +130,14 @@
         (testing "and the committed DOM is the POST-write value, not the
                  pre-write one the abandoned run started from"
           (is (= "true" (read-back handle "data-after"))))
-        (finally (mount/release! handle))))))
+        (finally (rf.bench.hicasso.arm1.mount/release! handle))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Case 2 — a commit lands between the body and React's commit (§6.1)
 ;; ---------------------------------------------------------------------------
 
 (deftest a-commit-landing-after-the-body-does-not-leave-the-dom-stale
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (let [handle (mounted!)]
       (try
@@ -149,13 +149,13 @@
         ;; window has closed — so what must catch it is the ordinary
         ;; invalidation path, and the claim is that between the two the DOM
         ;; is never left stale.
-        (mount/dispatch! handle [:dogfood/toggle 0])
-        (mount/settle!)
+        (rf.bench.hicasso.arm1.mount/dispatch! handle [:dogfood/toggle 0])
+        (rf.bench.hicasso.arm1.mount/settle!)
         (is (= "true" (read-back handle "data-after"))
             "the committed DOM caught up without a commit-phase re-read of
              every subscription")
         (is (= (read-back handle "data-before") (read-back handle "data-after")))
-        (finally (mount/release! handle))))))
+        (finally (rf.bench.hicasso.arm1.mount/release! handle))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Case 3 — a STAGED read moves in the render->commit gap (rf2-2rtt6.42)
@@ -179,7 +179,7 @@
 (defview staged-reader
   "Renders FIRST, and reads a key nothing else holds."
   [{:keys [id]}]
-  (let [v (rt/sub [:dogfood/done? id])]
+  (let [v (rf.bench.hicasso.arm1.runtime/sub [:dogfood/done? id])]
     [:li.row {:data-id id :data-after (str v) :data-before (str v)} (str v)]))
 
 (defview sibling-writer
@@ -189,33 +189,33 @@
   [{:keys [id]}]
   ;; A read of its own, so this is an ordinary boundary rather than a
   ;; contrivance with no edges.
-  (rt/sub [:dogfood/filter])
+  (rf.bench.hicasso.arm1.runtime/sub [:dogfood/filter])
   (when (zero? @!sibling-writes)
     (swap! !sibling-writes inc)
-    (rt/dispatch! frame-id [:dogfood/toggle id]))
+    (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle id]))
   [:li.writer])
 
 (deftest a-staged-read-that-moves-before-the-commit-is-corrected-in-the-dom
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (reset! !sibling-writes 0)
-      (lane/leave-act-environment!)
-      (dogfood/make-frame! frame-id 3)
-      (dogfood/reseed! frame-id 3)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id
+      (rf.bench.hicasso.lane/leave-act-environment!)
+      (rf.bench.hicasso.front.dogfood/make-frame! frame-id 3)
+      (rf.bench.hicasso.front.dogfood/reseed! frame-id 3)
+      (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id
                                 [:ul [staged-reader {:id 0}] [sibling-writer {:id 0}]])]
         (try
           (is (= 1 @!sibling-writes) "the sibling wrote, exactly once")
-          (mount/settle!)
-          (mount/settle!)
+          (rf.bench.hicasso.arm1.mount/settle!)
+          (rf.bench.hicasso.arm1.mount/settle!)
           (testing "the reader's key had no cell, no watch and no epoch when
                    it moved, so nothing was marked and the generation did
                    not move — and the DOM must still not be stale"
             (is (= "true" (read-back handle "data-after"))
                 "the boundary was corrected: React re-read the store after
                  `subscribe` and found a number that had moved"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Case 4 — a first REGISTRATION lands in the gap (rf2-2rtt6.50)
@@ -245,7 +245,7 @@
 (defview gap-reader
   "Renders FIRST, and reads a query NOTHING has registered."
   [_]
-  (let [v (rt/sub gap-q)]
+  (let [v (rf.bench.hicasso.arm1.runtime/sub gap-q)]
     [:li.row {:data-after (str v) :data-before (str v)} (str v)]))
 
 (defview gap-registrar
@@ -256,26 +256,26 @@
   [_]
   ;; A read of its own, so this is an ordinary boundary rather than a
   ;; contrivance with no edges.
-  (rt/sub [:dogfood/filter])
+  (rf.bench.hicasso.arm1.runtime/sub [:dogfood/filter])
   (when (zero? @!gap-registrations)
     (swap! !gap-registrations inc)
     (rf/reg-sub (first gap-q) (fn [_ _] :arrived)))
   [:li.writer])
 
 (deftest a-first-registration-landing-in-the-gap-is-corrected-in-the-dom
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (reset! !gap-registrations 0)
-      (lane/leave-act-environment!)
-      (dogfood/make-frame! frame-id 3)
-      (dogfood/reseed! frame-id 3)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id
+      (rf.bench.hicasso.lane/leave-act-environment!)
+      (rf.bench.hicasso.front.dogfood/make-frame! frame-id 3)
+      (rf.bench.hicasso.front.dogfood/reseed! frame-id 3)
+      (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id
                                 [:ul [gap-reader {}] [gap-registrar {}]])]
         (try
           (is (= 1 @!gap-registrations) "the sibling registered, exactly once")
-          (mount/settle!)
-          (mount/settle!)
+          (rf.bench.hicasso.arm1.mount/settle!)
+          (rf.bench.hicasso.arm1.mount/settle!)
           (testing "the reader's query had no handler when its body ran and no
                    cell when the registration landed, so `first-registration!`
                    reached nothing on its behalf and neither the generation nor
@@ -286,33 +286,33 @@
                  store after `subscribe`, found a number the registry term had
                  moved, and re-rendered through the cell the commit acquired
                  against the live registration"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Teardown — **React's** teardown, read while the runtime still holds it
 ;; ---------------------------------------------------------------------------
 ;;
-;; `mount/unmount!` rather than `mount/release!`, because `release!` resets
+;; `rf.bench.hicasso.arm1.mount/unmount!` rather than `rf.bench.hicasso.arm1.mount/release!`, because `release!` resets
 ;; the runtime and a reading taken after that reset answers zero whatever
 ;; teardown did — the ordering that made this gate unable to fail
 ;; (rf2-2rtt6.48). The macrotask wait is the cell and entry reapers'
 ;; deliberate grace period, not slack.
 
 (deftest the-fenced-boundary-leaves-no-residue
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (async done
       (let [handle (mounted!)]
-        (mount/dispatch! handle [:dogfood/toggle 0])
-        (is (pos? (:cell-refs (rt/stats)))
+        (rf.bench.hicasso.arm1.mount/dispatch! handle [:dogfood/toggle 0])
+        (is (pos? (:cell-refs (rf.bench.hicasso.arm1.runtime/stats)))
             "the mounted boundary holds references, so the reading below is
              a reading of something")
-        (mount/unmount! handle)
+        (rf.bench.hicasso.arm1.mount/unmount! handle)
         (js/setTimeout (fn []
                          (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                                (rt/residue))
+                                (rf.bench.hicasso.arm1.runtime/residue))
                              "React's own cleanup released every edge and every
                               subscription reference")
-                         (rt/reset-runtime!)
+                         (rf.bench.hicasso.arm1.runtime/reset-runtime!)
                          (done))
                        8)))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/hook_ledger_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/hook_ledger_dom_cljs_test.cljs
@@ -21,19 +21,19 @@
   Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
   React DOM; under `:node-test` every claim degrades to a stated skip."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.hook-probe :as probe]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.hook-probe :as rf.bench.hicasso.arm1.hook-probe]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.test-support :as rf.test-support]
             [uix.core :refer [$ defui]])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      ;; `:ambient-frame nil` is load-bearing, not tidiness. The fixture's
      ;; default leaves a dynamic-var frame stamp in scope, and the
      ;; carried-invariant chain resolves that tier BEFORE React context —
@@ -43,7 +43,7 @@
      ;; difference. Caught by the frame probe below, which is why the
      ;; probe stays.
      :ambient-frame nil
-     :init-fn (fn [] (rt/reset-runtime!))}))
+     :init-fn (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::arm1-hooks)
 
@@ -58,17 +58,17 @@
   [{:keys [n]}]
   [:ul.reads
    (for [i (range n)]
-     [:li.read {:key i} (str (rt/sub [:dogfood/todo i]))])])
+     [:li.read {:key i} (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo i]))])])
 
 (defui uix-one [{:keys [i]}]
-  ($ :li.read (str (uix-adapter/use-subscribe [:dogfood/todo i]))))
+  ($ :li.read (str (rf.adapter.uix/use-subscribe [:dogfood/todo i]))))
 
 (defui uix-three [{:keys [i]}]
   ;; Three reads, three hooks, spelled out — a loop is illegal here, and
   ;; that illegality is the finding rather than an inconvenience.
-  (let [a (uix-adapter/use-subscribe [:dogfood/todo i])
-        b (uix-adapter/use-subscribe [:dogfood/todo (inc i)])
-        c (uix-adapter/use-subscribe [:dogfood/todo (+ i 2)])]
+  (let [a (rf.adapter.uix/use-subscribe [:dogfood/todo i])
+        b (rf.adapter.uix/use-subscribe [:dogfood/todo (inc i)])
+        c (rf.adapter.uix/use-subscribe [:dogfood/todo (+ i 2)])]
     ($ :li.read (str a b c))))
 
 ;; ---------------------------------------------------------------------------
@@ -89,14 +89,14 @@
   are identical for every caller, so the only thing that varies between
   readings is the component."
   [hiccup]
-  (lane/leave-act-environment!)
-  (dogfood/make-frame! frame-id 32)
-  (dogfood/reseed! frame-id 32)
-  (let [container (mount/fresh-container!)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.front.dogfood/make-frame! frame-id 32)
+  (rf.bench.hicasso.front.dogfood/reseed! frame-id 32)
+  (let [container (rf.bench.hicasso.arm1.mount/fresh-container!)
         handle    (volatile! nil)
-        names     (probe/record!
-                    (fn [] (vreset! handle (mount/root! container frame-id hiccup))))]
-    (mount/release! @handle)
+        names     (rf.bench.hicasso.arm1.hook-probe/record!
+                    (fn [] (vreset! handle (rf.bench.hicasso.arm1.mount/root! container frame-id hiccup))))]
+    (rf.bench.hicasso.arm1.mount/release! @handle)
     names))
 
 (defn- hicasso-hooks
@@ -109,9 +109,9 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-shell-calls-exactly-two-hooks
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
-    (if-not (probe/install!)
+    (if-not (rf.bench.hicasso.arm1.hook-probe/install!)
       (unwitnessed!)
       (testing "one boundary, one read: the frame hook and the
                subscription/epoch hook, and nothing else"
@@ -119,13 +119,13 @@
           (is (= 2 (count names)) (str "hooks React was asked for: " (pr-str names)))
           (is (= ["useContext" "useSyncExternalStore"] names)
               "in the order shell-hook-ledger declares")
-          (is (= (count rt/shell-hook-ledger) (count names))
+          (is (= (count rf.bench.hicasso.arm1.runtime/shell-hook-ledger) (count names))
               "and the declared ledger is the measured one"))))))
 
 (deftest the-count-does-not-move-with-the-read-count
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
-    (if-not (probe/install!)
+    (if-not (rf.bench.hicasso.arm1.hook-probe/install!)
       (unwitnessed!)
       (testing "1, 7 and 20 reads — the first rung, the census archetype
                and the stress rung — all cost two hooks"
@@ -135,9 +135,9 @@
                 (str n " reads still cost two hooks: " (pr-str names)))))))))
 
 (deftest no-use-ref-and-no-use-state-in-the-shell
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
-    (if-not (probe/install!)
+    (if-not (rf.bench.hicasso.arm1.hook-probe/install!)
       (unwitnessed!)
       (let [names (set (hicasso-hooks 7))]
         (is (not (contains? names "useRef")) "HD-020(b) bans useRef in the shell")
@@ -147,16 +147,16 @@
         (is (not (contains? names "useCallback")))))))
 
 (deftest the-scalar-comparator-pays-per-read-and-is-measured-saying-so
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
-    (if-not (probe/install!)
+    (if-not (rf.bench.hicasso.arm1.hook-probe/install!)
       (unwitnessed!)
       (testing "the raw UIx spine's per-read hooks, counted by the same
                probe on the same page — a comparator read rather than
                recalled. No bar row is published from this: it is a hook
                count, not a clock or a heap figure."
-        (let [host-1 (rt/mint-view! "uix-host-1" (fn [_] ($ uix-one {:i 0})))
-              host-3 (rt/mint-view! "uix-host-3" (fn [_] ($ uix-three {:i 0})))
+        (let [host-1 (rf.bench.hicasso.arm1.runtime/mint-view! "uix-host-1" (fn [_] ($ uix-one {:i 0})))
+              host-3 (rf.bench.hicasso.arm1.runtime/mint-view! "uix-host-3" (fn [_] ($ uix-three {:i 0})))
               base   (count (hicasso-hooks 1))
               one    (count (mount-and-count [host-1 {}]))
               three  (count (mount-and-count [host-3 {}]))]

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
@@ -69,16 +69,16 @@
   React DOM; under `:node-test` every DOM claim degrades to a stated
   skip while the declaration/refusal rows run everywhere."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.hook-probe :as probe]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.hook-probe :as rf.bench.hicasso.arm1.hook-probe]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
             [re-frame.bench.hicasso.arm1.presence :refer [presence]]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.codec :as codec]
-            [re-frame.bench.hicasso.front.intent :as intent]
-            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
+            [re-frame.bench.hicasso.front.intent :as rf.bench.hicasso.front.intent]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
             [re-frame.core :as rf]
-            [re-frame.test-support :as test-support]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview defhost event]]))
 
@@ -110,18 +110,18 @@
   (fn [{:keys [db]} _] {:db (update db :closed inc)}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; the presence row waits on a real clock, and `cljs.test`
      ;; hard-errors on a fn-form fixture in a suite with an async test.
      :async?        true
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (defn- skip! [why] (is true (str "a host-hatch claim needs a real React DOM — " why)))
 
 (defn- fresh! []
-  (lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/leave-act-environment!)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [:hatch/seed]))
   frame-id)
@@ -268,11 +268,11 @@
 (defview screen
   [_]
   [:div.screen
-   [:output.picked-count (str (count (rt/sub [:hatch/picked-log])))]
-   [themed {:value (rt/sub [:hatch/theme])}
-    [picker {:label         (rt/sub [:hatch/label])
-             :draft         (rt/sub [:hatch/draft])
-             :value         (rt/sub [:hatch/city])
+   [:output.picked-count (str (count (rf.bench.hicasso.arm1.runtime/sub [:hatch/picked-log])))]
+   [themed {:value (rf.bench.hicasso.arm1.runtime/sub [:hatch/theme])}
+    [picker {:label         (rf.bench.hicasso.arm1.runtime/sub [:hatch/label])
+             :draft         (rf.bench.hicasso.arm1.runtime/sub [:hatch/draft])
+             :value         (rf.bench.hicasso.arm1.runtime/sub [:hatch/city])
              :on-pick       (event [city e] [:hatch/picked city (.-type e)])
              :on-close      [:re-frame.hicasso/prevent [:hatch/closed]]
              :on-draft      [:hatch/typed :re-frame.hicasso/value]
@@ -298,7 +298,7 @@
   "The minimal page the hook probe counts: one shell, one hosted widget,
   nothing else."
   [_]
-  [picker {:label (rt/sub [:hatch/label])}])
+  [picker {:label (rf.bench.hicasso.arm1.runtime/sub [:hatch/label])}])
 
 (defview render-prop-page
   "A declared `:render` slot, driven by the foreign component's own
@@ -306,7 +306,7 @@
   its tree — the position table's render row, met where it actually
   bites."
   [_]
-  [render-picker {:label         (rt/sub [:hatch/label])
+  [render-picker {:label         (rf.bench.hicasso.arm1.runtime/sub [:hatch/label])
                   :on-render-row (event [label] (str "rendered:" label))}])
 
 (defview tray
@@ -316,7 +316,7 @@
   `h/event` at `:on-pick` survives lowering and would fail at invocation."
   [_]
   [presence {:timeout-ms timeout-ms}
-   (for [w (rt/sub [:hatch/widgets])]
+   (for [w (rf.bench.hicasso.arm1.runtime/sub [:hatch/widgets])]
      [picker {:key      (:id w)
               :label    (:name w)
               :value    (:name w)
@@ -336,19 +336,19 @@
   value-equal props. The write moves the chrome only."
   [_]
   [:div
-   [:span.chrome (str (rt/sub [:hatch/label]))]
+   [:span.chrome (str (rf.bench.hicasso.arm1.runtime/sub [:hatch/label]))]
    [hosted-row {:label "fixed"}]])
 
 (defview memo-page
   [_]
   [:div
-   [:span.mlabel (str (rt/sub [:hatch/label]))]
+   [:span.mlabel (str (rf.bench.hicasso.arm1.runtime/sub [:hatch/label]))]
    [memo-picker {:label "fixed" :on-imperative stable-imperative}]])
 
 (defview memo-defeated-page
   [_]
   [:div
-   [:span.mlabel (str (rt/sub [:hatch/label]))]
+   [:span.mlabel (str (rf.bench.hicasso.arm1.runtime/sub [:hatch/label]))]
    [memo-picker {:label "fixed" :on-pick [:hatch/picked "static"]}]])
 
 ;; ---------------------------------------------------------------------------
@@ -360,7 +360,7 @@
 
 (defn- click! [handle sel]
   (.click (q handle sel))
-  (mount/settle!))
+  (rf.bench.hicasso.arm1.mount/settle!))
 
 (defn- settled!
   "Let the widget's own effect-driven state land. Its `set-phase` runs in
@@ -371,7 +371,7 @@
   presence's weak half, owned by the library instead)."
   []
   (js/Promise. (fn [resolve]
-                 (js/setTimeout (fn [] (mount/settle!) (resolve true)) 0))))
+                 (js/setTimeout (fn [] (rf.bench.hicasso.arm1.mount/settle!) (resolve true)) 0))))
 
 (defn- set-native-value!
   "Write `v` through `HTMLInputElement.prototype`'s OWN value setter,
@@ -385,19 +385,19 @@
   (let [node (q handle sel)]
     (set-native-value! node text)
     (.dispatchEvent node (js/Event. "input" #js {:bubbles true}))
-    (mount/settle!)))
+    (rf.bench.hicasso.arm1.mount/settle!)))
 
 (defn- teardown-census!
   "Unmount through the arm's own residue door, read the live-reference
   census, THEN release — the lifecycle suite's ordering, and for the
   same reason: a census taken after `release!` reads an emptied table
-  whatever teardown did. `mount/unmount!` rather than a raw flushSync,
+  whatever teardown did. `rf.bench.hicasso.arm1.mount/unmount!` rather than a raw flushSync,
   because it is the door a residue gate is designed to read through —
   and the seam the teardown mutation breaks."
   [handle]
-  (mount/unmount! handle)
-  (let [census (select-keys (rt/residue) [:cell-refs :boundaries :edges])]
-    (mount/release! (assoc handle :root nil))
+  (rf.bench.hicasso.arm1.mount/unmount! handle)
+  (let [census (select-keys (rf.bench.hicasso.arm1.runtime/residue) [:cell-refs :boundaries :edges])]
+    (rf.bench.hicasso.arm1.mount/release! (assoc handle :root nil))
     census))
 
 (def ^:private released {:cell-refs 0 :boundaries 0 :edges 0})
@@ -408,12 +408,12 @@
 
 (deftest the-declared-door-mounts-a-foreign-component-inside-a-hicasso-tree
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (instr!)
         (fresh!)
-        (let [handle (mount/root! (mount/fresh-container!) frame-id [screen {}])]
+        (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [screen {}])]
           (-> (settled!)
               (.then
                 (fn [_]
@@ -451,12 +451,12 @@
 
 (deftest two-namespaced-keywords-reach-two-providers-as-two-distinct-values
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (instr!)
         (fresh!)
-        (let [handle (mount/root! (mount/fresh-container!) frame-id
+        (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id
                                   [namespaced-theme-page {}])]
           (-> (settled!)
               (.then
@@ -481,7 +481,7 @@
                                 two subtrees differ there"
                         (is (not= (attr handle ".theme-a .widget" "data-theme")
                                   (attr handle ".theme-b .widget" "data-theme")))))
-                    (finally (mount/release! handle)))))
+                    (finally (rf.bench.hicasso.arm1.mount/release! handle)))))
               (.catch (fn [e] (is false (str e)) nil))
               (.then (fn [_] (done)))))))))
 
@@ -490,15 +490,15 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest callbacks-cross-out-and-react-owned-state-survives-hicasso-rerenders
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (instr!)
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [screen {}])
+      (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [screen {}])
             census (volatile! nil)]
         (try
-          (mount/settle!)
+          (rf.bench.hicasso.arm1.mount/settle!)
           (click! handle ".widget-pick")
           (click! handle ".widget-pick")
           (testing "declared :event + h/event: EVERY argument the foreign
@@ -513,7 +513,7 @@
           (testing "REACT-OWNED STATE SURVIVES: the boundary above re-renders
                     on a moved subscription, the new value crosses, and the
                     foreign useState keeps its count — same fiber, no remount"
-            (mount/dispatch! handle [:hatch/set :label "arrival"])
+            (rf.bench.hicasso.arm1.mount/dispatch! handle [:hatch/set :label "arrival"])
             (is (= "arrival" (.-textContent (q handle ".widget-label"))))
             (is (= "2" (attr handle ".widget" "data-clicks")))
             (is (= 1 (:mounts @!instr))
@@ -521,7 +521,7 @@
                  rather than remounted"))
           (testing "and a context value driven by a subscription moves through
                     the hosted provider"
-            (mount/dispatch! handle [:hatch/set :theme "sepia"])
+            (rf.bench.hicasso.arm1.mount/dispatch! handle [:hatch/set :theme "sepia"])
             (is (= "sepia" (attr handle ".widget" "data-theme")))
             (is (= "2" (attr handle ".widget" "data-clicks"))))
           (finally (vreset! census (teardown-census! handle))))
@@ -532,23 +532,23 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-prevented-intent-at-a-declared-position-prevents-then-dispatches
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (instr!)
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [screen {}])]
+      (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [screen {}])]
         (try
-          (mount/settle!)
+          (rf.bench.hicasso.arm1.mount/settle!)
           (let [ev      (js/MouseEvent. "click" #js {:bubbles true :cancelable true})
                 outcome (.dispatchEvent (q handle ".widget-close") ev)]
-            (mount/settle!)
+            (rf.bench.hicasso.arm1.mount/settle!)
             (is (false? outcome)
                 "dispatchEvent answers false exactly when preventDefault ran —
                  the ::h/prevent half fired on the real event")
             (is (true? (.-defaultPrevented ev)))
             (is (= 1 (:closed (db))) "and the wrapped intent dispatched"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 (deftest the-value-marker-materializes-when-the-foreign-invoker-hands-an-event
   (testing "the guide's open question — 'whether ::h/value works across a host
@@ -556,35 +556,35 @@
             foreign contract hands the DOM event first, as this widget's
             onChange does. A value-first invoker has no event to read a
             target from; h/event is that spelling (row 2 above proves it)."
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (do
         (instr!)
         (fresh!)
-        (let [handle (mount/root! (mount/fresh-container!) frame-id [screen {}])]
+        (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [screen {}])]
           (try
-            (mount/settle!)
+            (rf.bench.hicasso.arm1.mount/settle!)
             (type-into! handle ".widget-input" "west")
             (is (= "west" (:draft (db)))
                 "the marker read the event's target across the door")
             (is (= "west" (.-value (q handle ".widget-input")))
                 "and the model echoed back into the foreign input — the loop
                  is closed in both directions")
-            (finally (mount/release! handle))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! handle))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4 — :handler crosses by identity, runs imperatively, returns to the caller
 ;; ---------------------------------------------------------------------------
 
 (deftest a-declared-handler-crosses-by-identity-and-its-return-is-the-foreigners
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (instr!)
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [screen {}])]
+      (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [screen {}])]
         (try
-          (mount/settle!)
+          (rf.bench.hicasso.arm1.mount/settle!)
           (is (identical? stable-imperative (:received-imperative @!instr))
               ":handler is the FUNCTION ITSELF — the door rewrapped nothing,
                so a library memoising on handler identity is not defeated")
@@ -594,7 +594,7 @@
               "and the RETURN went back to the foreign caller — 'return
                ignored' is Hicasso's side of the contract, not the library's")
           (is (= [] (:picked (db))) "and nothing dispatched")
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 5 — the declaration's refusals (these rows run under :node-test too)
@@ -607,35 +607,35 @@
   (testing "nil component — the broken-import symptom — refuses at the
             declaration, where the author's stack is the declaration site"
     (is (= :rf.error/hicasso-host-no-component
-           (error-id #(codec/mint-host! "hatch/nil-host" nil {})))))
+           (error-id #(rf.bench.hicasso.front.codec/mint-host! "hatch/nil-host" nil {})))))
   (testing "a contract on a structural slot is refused in every spelling"
     (is (= :rf.error/hicasso-host-structural-callback
-           (error-id #(codec/mint-host! "hatch/reffy" widget
+           (error-id #(rf.bench.hicasso.front.codec/mint-host! "hatch/reffy" widget
                                         {:callbacks {:ref :event}}))))
     (is (= :rf.error/hicasso-host-structural-callback
-           (error-id #(codec/mint-host! "hatch/reffy" widget
+           (error-id #(rf.bench.hicasso.front.codec/mint-host! "hatch/reffy" widget
                                         {:callbacks {"ref" :handler}}))))
     (is (= :rf.error/hicasso-host-structural-callback
-           (error-id #(codec/mint-host! "hatch/keyed" widget
+           (error-id #(rf.bench.hicasso.front.codec/mint-host! "hatch/keyed" widget
                                         {:callbacks {:x/key :event}})))))
   (testing "an unknown contract is refused at mint, not at first render"
     (is (= :rf.error/hicasso-unknown-callback-contract
-           (error-id #(codec/mint-host! "hatch/typo" widget
+           (error-id #(rf.bench.hicasso.front.codec/mint-host! "hatch/typo" widget
                                         {:callbacks {:on-pick :evnt}})))))
   (testing "two spellings landing on one slot are one contradiction, refused"
     (is (= :rf.error/hicasso-host-callback-slot-collision
-           (error-id #(codec/mint-host! "hatch/twice" widget
+           (error-id #(rf.bench.hicasso.front.codec/mint-host! "hatch/twice" widget
                                         {:callbacks {:on-pick :event
                                                      :onPick  :handler}}))))))
 
 (deftest the-crossing-refuses-an-undeclared-event-spelled-intent
-  (let [h (codec/mint-host! "hatch/mini" widget {:callbacks {:on-pick :event}})]
+  (let [h (rf.bench.hicasso.front.codec/mint-host! "hatch/mini" widget {:callbacks {:on-pick :event}})]
     (testing "an intent vector at an event-spelled prop the declaration does
               not name refuses LOUDLY, naming the host and the position —
               never inference, and never an inert array shipped to the
               library"
       (try
-        (codec/as-element [h {:on-nope [:boom]}])
+        (rf.bench.hicasso.front.codec/as-element [h {:on-nope [:boom]}])
         (is false "should have thrown")
         (catch :default e
           (let [d (ex-data e)]
@@ -645,33 +645,33 @@
     (testing "an event-spelled KEY-MAP at an undeclared position is the same
               refusal"
       (is (= :rf.error/hicasso-host-undeclared-callback
-             (error-id #(codec/as-element [h {:on-key-down {"Enter" [:boom]}}])))))
+             (error-id #(rf.bench.hicasso.front.codec/as-element [h {:on-key-down {"Enter" [:boom]}}])))))
     (testing "a vector at the ref slot is HD-022's reservation, held at the
               host position too"
       (is (= :rf.error/hicasso-ref-vector-reserved
-             (error-id #(codec/as-element [h {:ref [:re-frame.hicasso/autosize {}]}])))))
+             (error-id #(rf.bench.hicasso.front.codec/as-element [h {:ref [:re-frame.hicasso/autosize {}]}])))))
     (testing "while a plain data vector at a non-event prop is ordinary data"
-      (is (some? (codec/as-element [h {:columns [1 2 3]}]))))))
+      (is (some? (rf.bench.hicasso.front.codec/as-element [h {:columns [1 2 3]}]))))))
 
 (deftest the-declaration-binds-by-canonical-slot-not-by-spelling
-  (let [h (codec/mint-host! "hatch/slot-bound" widget {:callbacks {:on-pick :event}})]
+  (let [h (rf.bench.hicasso.front.codec/mint-host! "hatch/slot-bound" widget {:callbacks {:on-pick :event}})]
     (testing "the camel spelling lands on the declared slot: the vector was
               LOWERED — outside a boundary that is the intent's own loud
               error — rather than crossing as data"
       (is (= :rf.error/hicasso-intent-outside-boundary
-             (error-id #(codec/as-element [h {:onPick [:hatch/picked "x"]}])))))
+             (error-id #(rf.bench.hicasso.front.codec/as-element [h {:onPick [:hatch/picked "x"]}])))))
     (testing "while an undeclared on* spelling never becomes an event position,
               however event-shaped its name"
       (is (= :rf.error/hicasso-host-undeclared-callback
-             (error-id #(codec/as-element [h {:onValueChange [:hatch/picked "x"]}])))))))
+             (error-id #(rf.bench.hicasso.front.codec/as-element [h {:onValueChange [:hatch/picked "x"]}])))))))
 
 (deftest host-props-convert-shallowly
   (testing "HD-011's default: the top-level key camelCases, the value crosses
             with no renaming inside it — a nested option map keeps the
             spelling the author wrote, and converting it is the author's
             explicit job when a library wants camelCase inside"
-    (let [h  (codec/mint-host! "hatch/shallow" widget {})
-          el (codec/as-element [h {:menu-items [{:day-of-week 1}]
+    (let [h  (rf.bench.hicasso.front.codec/mint-host! "hatch/shallow" widget {})
+          el (rf.bench.hicasso.front.codec/as-element [h {:menu-items [{:day-of-week 1}]
                                    :variant    :compact
                                    :theme      :theme/dark
                                    :class      :primary
@@ -734,24 +734,24 @@
   the render's dynamic extent has unwound."
   [head props]
   (let [!seen (atom [])
-        el    (intent/with-frame (fn [ev] (swap! !seen conj ev) nil)
-                (fn [] (codec/as-element [head props])))]
+        el    (rf.bench.hicasso.front.intent/with-frame (fn [ev] (swap! !seen conj ev) nil)
+                (fn [] (rf.bench.hicasso.front.codec/as-element [head props])))]
     [el !seen]))
 
 (deftest a-declared-render-slot-is-invoked-during-the-foreign-render
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (instr!)
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [render-prop-page {}])]
+      (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [render-prop-page {}])]
         (try
-          (mount/settle!)
+          (rf.bench.hicasso.arm1.mount/settle!)
           (is (= "rendered:due date" (.-textContent (q handle ".widget-render")))
               "the h/event ran inside the foreign component's own render and its
                return went into the library's tree — not to dispatch")
           (is (= [] (:picked (db))) "and nothing dispatched")
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 (deftest the-declaration-governs-every-carrier-at-its-position
   (testing ":event takes all four carriers, because dispatching is what that
@@ -916,7 +916,7 @@
             render position raises, because the position is the thing that
             selected it"
     (let [[el !seen] (crossed render-picker
-                             {:on-render-row (event [_] (intent/*dispatch* [:hatch/closed]) "never")})]
+                             {:on-render-row (event [_] (rf.bench.hicasso.front.intent/*dispatch* [:hatch/closed]) "never")})]
       (try
         ((prop el "onRenderRow") "x")
         (is false "should have thrown")
@@ -930,12 +930,12 @@
 
 (defn- crossed-in-frame
   "[[crossed]] with the boundary's FRAME KEYWORD bound as well — the
-  3-arity door, which is what a row body's `intent/*frame*` read (and a
+  3-arity door, which is what a row body's `rf.bench.hicasso.front.intent/*frame*` read (and a
   `route-link` in one) needs. Answers `[element !dispatched]`."
   [frame-kw head props]
   (let [!seen (atom [])
-        el    (intent/with-frame frame-kw (fn [ev] (swap! !seen conj ev) nil)
-                (fn [] (codec/as-element [head props])))]
+        el    (rf.bench.hicasso.front.intent/with-frame frame-kw (fn [ev] (swap! !seen conj ev) nil)
+                (fn [] (rf.bench.hicasso.front.codec/as-element [head props])))]
     [el !seen]))
 
 (deftest a-render-props-row-is-owned-by-the-boundary-that-supplied-the-callback
@@ -958,13 +958,13 @@
             ::supplier render-picker
             {:on-render-row
              (event [label]
-               (reset! !frame intent/*frame*)
-               (reset! !row (codec/as-element
+               (reset! !frame rf.bench.hicasso.front.intent/*frame*)
+               (reset! !row (rf.bench.hicasso.front.codec/as-element
                               [:li {:on-click [:hatch/picked label "row"]}]))
                ;; an event-position h/event, lowered in the same body
-               (codec/as-element
+               (rf.bench.hicasso.front.codec/as-element
                  [:button {:on-click (event [_] [:hatch/closed])}]))})
-          btn (intent/with-frame ::other (fn [ev] (swap! !other conj ev) nil)
+          btn (rf.bench.hicasso.front.intent/with-frame ::other (fn [ev] (swap! !other conj ev) nil)
                 (fn [] ((prop el "onRenderRow") "paris")))]
       (is (= ::supplier @!frame)
           "inside the invocation the ambient frame is the OWNER's, not the
@@ -973,7 +973,7 @@
       (is (= [] @!other))
 
       (testing "and then the browser's click, long after both extents unwound"
-        (is (nil? intent/*dispatch*))
+        (is (nil? rf.bench.hicasso.front.intent/*dispatch*))
         ((prop @!row "onClick") #js {})
         ((prop btn "onClick") #js {})
         (is (= [[:hatch/picked "paris" "row"] [:hatch/closed]] @!supplier)
@@ -1039,9 +1039,9 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-door-spends-one-hook-and-the-hosted-hooks-are-its-own
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
-    (if-not (probe/install!)
+    (if-not (rf.bench.hicasso.arm1.hook-probe/install!)
       (is false (str "React's internals slot was not found, so this claim is "
                      "UNWITNESSED on this build — fix the probe rather than "
                      "reading this as a pass"))
@@ -1049,9 +1049,9 @@
         (instr!)
         (fresh!)
         (let [handle (volatile! nil)
-              names  (probe/record!
+              names  (rf.bench.hicasso.arm1.hook-probe/record!
                        (fn [] (vreset! handle
-                                       (mount/root! (mount/fresh-container!)
+                                       (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!)
                                                     frame-id [host-page {}]))))]
           (try
             (is (= ["useContext" "useSyncExternalStore"] (vec (take 2 names)))
@@ -1071,11 +1071,11 @@
                 (str "exactly TWO on the whole page — the boundary's "
                      "subscription and the door's gate, and no third: "
                      (pr-str names)))
-            (is (= 2 (count rt/shell-hook-ledger))
+            (is (= 2 (count rf.bench.hicasso.arm1.runtime/shell-hook-ledger))
                 (str "and HD-020(b)'s ≤2 budget is untouched by the gate, "
                      "which is not a boundary: it holds no subscription and "
-                     "reads no frame. " (pr-str rt/shell-hook-ledger)))
-            (finally (mount/release! @handle))))))))
+                     "reads no frame. " (pr-str rf.bench.hicasso.arm1.runtime/shell-hook-ledger)))
+            (finally (rf.bench.hicasso.arm1.mount/release! @handle))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 7 — the host under presence: retention, override crossing, state survival
@@ -1083,19 +1083,19 @@
 
 (deftest react-owned-state-survives-a-presence-transition-around-the-host
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (instr!)
         (fresh!)
         (rf/with-frame frame-id
           (rf/dispatch-sync [:hatch/set :widgets [{:id 1 :name "one"}]]))
-        (let [handle (mount/root! (mount/fresh-container!) frame-id [tray {}])]
-          (mount/settle!)
+        (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [tray {}])]
+          (rf.bench.hicasso.arm1.mount/settle!)
           (click! handle ".widget-pick")
           (is (= "1" (attr handle ".widget" "data-clicks"))
               "the library's own state moved before the transition")
-          (mount/dispatch! handle [:hatch/set :widgets []])
+          (rf.bench.hicasso.arm1.mount/dispatch! handle [:hatch/set :widgets []])
           (is (some? (q handle ".widget"))
               "gone from the model, retained on screen — presence retains a
                host child by key exactly as it retains a native node")
@@ -1121,7 +1121,7 @@
                     would have refused before any click could happen"
             (click! handle ".widget-close")
             (is (= 1 (:closed (db)))))
-          (mount/dispatch! handle [:hatch/set :widgets [{:id 1 :name "one"}]])
+          (rf.bench.hicasso.arm1.mount/dispatch! handle [:hatch/set :widgets [{:id 1 :name "one"}]])
           (is (not (.contains (.-classList (q handle ".widget")) "widget--exit"))
               "re-entry cancelled the exit and took the override off")
           (is (= "2" (attr handle ".widget" "data-clicks"))
@@ -1131,16 +1131,16 @@
                remounted, so the library's own state was never reset")
           (is (= 1 (:mounts @!instr)))
           ;; and a real departure is a real unmount, on the clock
-          (mount/dispatch! handle [:hatch/set :widgets []])
+          (rf.bench.hicasso.arm1.mount/dispatch! handle [:hatch/set :widgets []])
           (js/setTimeout
             (fn []
-              (mount/settle!)
+              (rf.bench.hicasso.arm1.mount/settle!)
               (try
                 (is (nil? (q handle ".widget"))
                     "past :timeout-ms the retained host left")
                 (is (= (:mounts @!instr) (:cleanups @!instr))
                     "and its own effect cleanups ran — no foreign residue")
-                (finally (mount/release! handle) (done))))
+                (finally (rf.bench.hicasso.arm1.mount/release! handle) (done))))
             (* 4 timeout-ms)))))))
 
 ;; ---------------------------------------------------------------------------
@@ -1148,13 +1148,13 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest teardown-runs-the-hosted-cleanups-and-leaves-no-residue
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (instr!)
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [screen {}])]
-        (mount/settle!)
+      (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [screen {}])]
+        (rf.bench.hicasso.arm1.mount/settle!)
         (is (= 1 (:mounts @!instr)))
         (is (some? (:ref-node @!instr)))
         (is (zero? (:ref-cleanups @!instr)))
@@ -1182,12 +1182,12 @@
             repaired, extended to foreign components, which are exactly the
             ones whose render cost nobody controls."
     (async done
-      (if-not (mount/browser?)
+      (if-not (rf.bench.hicasso.arm1.mount/browser?)
         (do (skip! ":node-test has no DOM") (done))
         (do
           (instr!)
           (fresh!)
-          (let [handle (mount/root! (mount/fresh-container!) frame-id
+          (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id
                                     [chrome-page {}])]
             (-> (settled!)
                 (.then
@@ -1195,7 +1195,7 @@
                     (try
                       (let [before (:renders @!instr)]
                         (is (pos? before) "the host mounted")
-                        (mount/dispatch! handle [:hatch/set :label "chrome moved"])
+                        (rf.bench.hicasso.arm1.mount/dispatch! handle [:hatch/set :label "chrome moved"])
                         (is (= "chrome moved" (.-textContent (q handle ".chrome")))
                             "the page chrome really re-rendered")
                         (is (= before (:renders @!instr))
@@ -1204,18 +1204,18 @@
                              props, so the crossing was never re-run")
                         (is (= 1 (:mounts @!instr))
                             "nor was it remounted"))
-                      (finally (mount/release! handle)))))
+                      (finally (rf.bench.hicasso.arm1.mount/release! handle)))))
                 (.catch (fn [e] (is false (str e)) nil))
                 (.then (fn [_] (done))))))))))
 
 (deftest a-memoised-hosted-component-and-the-doors-honest-cost
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (instr!)
         (fresh!)
-        (let [handle (volatile! (mount/root! (mount/fresh-container!)
+        (let [handle (volatile! (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!)
                                              frame-id [memo-page {}]))]
           (-> (settled!)
               (.then
@@ -1224,20 +1224,20 @@
                             shallow-equal props: scalars cross as values and
                             a :handler crosses by identity"
                     (let [before (:renders @!instr)]
-                      (mount/dispatch! @handle [:hatch/set :label "moved"])
+                      (rf.bench.hicasso.arm1.mount/dispatch! @handle [:hatch/set :label "moved"])
                       (is (= "moved" (.-textContent (q @handle ".mlabel")))
                           "the parent boundary really re-rendered")
                       (is (= before (:renders @!instr))
                           "and React.memo held across it — the door mints a
                            fresh props OBJECT per render, but every value in
                            it was shallow-equal")))
-                  (mount/release! @handle)
+                  (rf.bench.hicasso.arm1.mount/release! @handle)
                   (instr!)
                   ;; same frame, re-seeded — a second make-frame mid-test
                   ;; would be a reincarnation, which is its own suite's
                   ;; subject
                   (rf/with-frame frame-id (rf/dispatch-sync [:hatch/seed]))
-                  (vreset! handle (mount/root! (mount/fresh-container!)
+                  (vreset! handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!)
                                                frame-id [memo-defeated-page {}]))
                   (settled!)))
               (.then
@@ -1253,9 +1253,9 @@
                               equal-props parent re-render before the door is
                               reached at all, which is the row below.)"
                       (let [before (:renders @!instr)]
-                        (mount/dispatch! @handle [:hatch/set :label "moved-again"])
+                        (rf.bench.hicasso.arm1.mount/dispatch! @handle [:hatch/set :label "moved-again"])
                         (is (= "moved-again" (.-textContent (q @handle ".mlabel"))))
                         (is (= (inc before) (:renders @!instr)))))
-                    (finally (mount/release! @handle)))))
+                    (finally (rf.bench.hicasso.arm1.mount/release! @handle)))))
               (.catch (fn [e] (is false (str e)) nil))
               (.then (fn [_] (done)))))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/hydrate_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/hydrate_cljs_test.cljs
@@ -26,32 +26,32 @@
   a measurement. Setting the horizon back to 0 turns this row red;
   raising it to 32 does not."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      ;; The horizon rows are `async` — a reap horizon is not observable
      ;; inside one synchronous test body.
      :async?  true
-     :init-fn (fn [] (rt/reset-runtime!) (rt/reset-body-runs!))}))
+     :init-fn (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!) (rf.bench.hicasso.arm1.runtime/reset-body-runs!))}))
 
 (def ^:private frame-id ::arm1-hydrate)
 
 (defn- seeded! []
-  (rt/reset-runtime!)
-  (rt/reset-body-runs!)
-  (dogfood/make-frame! frame-id 3)
+  (rf.bench.hicasso.arm1.runtime/reset-runtime!)
+  (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
+  (rf.bench.hicasso.front.dogfood/make-frame! frame-id 3)
   frame-id)
 
 (defn- one-body-run!
   "One boundary body through the shell's own fence, minus React."
   []
-  (rt/render-body frame-id (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]) {})
-  (rt/last-reads))
+  (rf.bench.hicasso.arm1.runtime/render-body frame-id (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]) {})
+  (rf.bench.hicasso.arm1.runtime/last-reads))
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — the reap horizon is past a bare `setTimeout 0`
@@ -76,15 +76,15 @@
       (let [entry (one-body-run!)]
         (is (some? entry) "the render minted an entry")
         (is (zero? (.-refs entry)) "unclaimed — no commit has run")
-        (is (= 1 (:entries (rt/stats))) "and it is in the cache")
+        (is (= 1 (:entries (rf.bench.hicasso.arm1.runtime/stats))) "and it is in the cache")
         (js/setTimeout
           (fn []
-            (is (= 1 (:entries (rt/stats)))
+            (is (= 1 (:entries (rf.bench.hicasso.arm1.runtime/stats)))
                 "one bare macrotask later it is STILL cached — a commit
                  arriving here would find the entry its render minted")
             (js/setTimeout
               (fn []
-                (is (zero? (:entries (rt/stats)))
+                (is (zero? (:entries (rf.bench.hicasso.arm1.runtime/stats)))
                     "and the horizon is bounded, not disabled: an entry
                      nothing claimed is still evicted")
                 (done))
@@ -98,15 +98,15 @@
              an entry a commit claimed is held by its `refs`, so no delay
              can drop it and correctness never depended on the race"
       (let [entry (one-body-run!)
-            stop  (rt/commit-boundary! entry (fn [] nil))]
+            stop  (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn [] nil))]
         (is (= 1 (.-refs entry)))
         (js/setTimeout
           (fn []
-            (is (= 1 (:entries (rt/stats))) "claimed, so past the horizon it stands")
+            (is (= 1 (:entries (rf.bench.hicasso.arm1.runtime/stats))) "claimed, so past the horizon it stands")
             (stop)
             (js/setTimeout
               (fn []
-                (is (zero? (:entries (rt/stats)))
+                (is (zero? (:entries (rf.bench.hicasso.arm1.runtime/stats)))
                     "and released, it is evicted on the ordinary edge")
                 (done))
               8))
@@ -123,14 +123,14 @@
            charter's one-mode law intact — and `reset-runtime!` shuts it,
            so a fixture that throws between `hydrateRoot` and the closer's
            effect cannot leave the page adopting for every row after it"
-    (is (false? (rt/adopting?)) "shut by default")
-    (rt/open-adoption-window!)
-    (is (true? (rt/adopting?)) "opened by the door")
-    (rt/close-adoption-window!)
-    (is (false? (rt/adopting?)) "shut by the closer")
-    (rt/open-adoption-window!)
-    (rt/reset-runtime!)
-    (is (false? (rt/adopting?)) "and shut by a runtime reset, whatever threw")))
+    (is (false? (rf.bench.hicasso.arm1.runtime/adopting?)) "shut by default")
+    (rf.bench.hicasso.arm1.runtime/open-adoption-window!)
+    (is (true? (rf.bench.hicasso.arm1.runtime/adopting?)) "opened by the door")
+    (rf.bench.hicasso.arm1.runtime/close-adoption-window!)
+    (is (false? (rf.bench.hicasso.arm1.runtime/adopting?)) "shut by the closer")
+    (rf.bench.hicasso.arm1.runtime/open-adoption-window!)
+    (rf.bench.hicasso.arm1.runtime/reset-runtime!)
+    (is (false? (rf.bench.hicasso.arm1.runtime/adopting?)) "and shut by a runtime reset, whatever threw")))
 
 ;; ---------------------------------------------------------------------------
 ;; 3 — the body-run counter (HD-028's rider)
@@ -145,19 +145,19 @@
            was asked for — which is the whole of HD-028's rider, because a
            `React.memo` bail-out has to read as an increment that did not
            happen"
-    (is (zero? (rt/body-runs)) "the fixture zeroed it")
+    (is (zero? (rf.bench.hicasso.arm1.runtime/body-runs)) "the fixture zeroed it")
     (one-body-run!)
-    (is (= 1 (rt/body-runs)))
+    (is (= 1 (rf.bench.hicasso.arm1.runtime/body-runs)))
     (one-body-run!)
     (one-body-run!)
-    (is (= 3 (rt/body-runs)) "one per body, counted")
-    (rt/reset-runtime!)
-    (is (= 3 (rt/body-runs))
+    (is (= 3 (rf.bench.hicasso.arm1.runtime/body-runs)) "one per body, counted")
+    (rf.bench.hicasso.arm1.runtime/reset-runtime!)
+    (is (= 3 (rf.bench.hicasso.arm1.runtime/body-runs))
         "and a teardown does NOT zero it — an instrument a teardown door
          resets is one a reading taken on the wrong side of the reset can
          pass with")
-    (rt/reset-body-runs!)
-    (is (zero? (rt/body-runs)) "only the explicit door zeroes it")))
+    (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
+    (is (zero? (rf.bench.hicasso.arm1.runtime/body-runs)) "only the explicit door zeroes it")))
 
 (deftest a-fenced-re-run-is-two-body-runs-because-two-bodies-ran
   (seeded!)
@@ -169,19 +169,19 @@
     ;; A mid-body write is only observable when the key is already held —
     ;; a key nothing holds has no watch to fire (`runtime_cljs_test`'s
     ;; own fence row states it).
-    (rt/render-body frame-id (fn [_] [:li (str (rt/sub [:dogfood/done? 0]))]) {})
-    (let [stop (rt/commit-boundary! (rt/last-reads) (fn [] nil))
+    (rf.bench.hicasso.arm1.runtime/render-body frame-id (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/done? 0]))]) {})
+    (let [stop (rf.bench.hicasso.arm1.runtime/commit-boundary! (rf.bench.hicasso.arm1.runtime/last-reads) (fn [] nil))
           runs (volatile! 0)]
-      (rt/reset-body-runs!)
-      (rt/render-body frame-id
+      (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
+      (rf.bench.hicasso.arm1.runtime/render-body frame-id
                       (fn [_]
                         (vswap! runs inc)
-                        (rt/sub [:dogfood/done? 0])
+                        (rf.bench.hicasso.arm1.runtime/sub [:dogfood/done? 0])
                         (when (= 1 @runs)
-                          (rt/dispatch! frame-id [:dogfood/toggle 0]))
-                        [:li (str (rt/sub [:dogfood/done? 0]))])
+                          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 0]))
+                        [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/done? 0]))])
                       {})
       (is (= 2 @runs) "the fence re-ran the body")
-      (is (= 2 (rt/body-runs))
+      (is (= 2 (rf.bench.hicasso.arm1.runtime/body-runs))
           "and the counter reads two, because two bodies ran")
       (stop))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/hydrate_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/hydrate_dom_cljs_test.cljs
@@ -49,7 +49,7 @@
   2. **`act` and `flushSync` are not the browser's schedule.** Adoption
      is React's own concurrent business, so `hydration-support/adopted!`
      waits on real timers for the closer's passive effect and never pulls
-     it forward. `mount/dispatch!` still flushes, but only in rows whose
+     it forward. `rf.bench.hicasso.arm1.mount/dispatch!` still flushes, but only in rows whose
      claim is about the model rather than about the turn.
 
   Both live in `arm1/hydration_support.cljs` — one copy, shared with the
@@ -60,17 +60,17 @@
   React DOM; under `:node-test` every DOM claim degrades to a stated
   skip."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.bench.hicasso.arm1.hydration-support
              :refer [adopted! open-console-capture! server-dom! server-node?
                      stamp-server-nodes!]]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
             [re-frame.bench.hicasso.arm1.presence :refer [presence]]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.controlled :as controlled]
-            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.controlled :as rf.bench.hicasso.front.controlled]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
             [re-frame.core :as rf]
-            [re-frame.test-support :as test-support])
+            [re-frame.test-support :as rf.test-support])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 (def ^:private frame-id ::arm1-hydrate-dom)
@@ -105,21 +105,21 @@
   (fn [{:keys [db]} [_ v]] {:db (assoc db :field v)}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (rt/reset-runtime!) (rt/reset-body-runs!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!) (rf.bench.hicasso.arm1.runtime/reset-body-runs!))}))
 
 (defn- skip! [why]
   (is true (str "a hydration claim needs a real React DOM — " why)))
 
 (defn- fresh! []
-  (lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/leave-act-environment!)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [:hyd/seed]))
-  (rt/reset-runtime!)
-  (rt/reset-body-runs!)
+  (rf.bench.hicasso.arm1.runtime/reset-runtime!)
+  (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
   frame-id)
 
 ;; ---------------------------------------------------------------------------
@@ -133,13 +133,13 @@
   known divergence (rf2-2rtt6.88's text-separator row) instead of this
   door."
   [{:keys [i]}]
-  [:li.row {:data-i i} (rt/sub [:hyd/row i])])
+  [:li.row {:data-i i} (rf.bench.hicasso.arm1.runtime/sub [:hyd/row i])])
 
 (defview screen
   "Four boundaries: this one and three rows."
   [_]
   [:div.screen
-   [:h1.title (rt/sub [:hyd/title])]
+   [:h1.title (rf.bench.hicasso.arm1.runtime/sub [:hyd/title])]
    [:ul.rows (for [i (range 3)] [row {:key i :i i}])]])
 
 (def ^:private boundary-count
@@ -172,7 +172,7 @@
   that entered is visibly different from one that was born present."
   [_]
   [presence {:timeout-ms toast-timeout-ms}
-   (for [t (rt/sub [:hyd/toasts])]
+   (for [t (rf.bench.hicasso.arm1.runtime/sub [:hyd/toasts])]
      [:div.toast {:key (:id t)
                   :data-id (:id t)
                   :re-frame.hicasso/mounting   {:class "toast toast--enter"}
@@ -183,7 +183,7 @@
   "One controlled text input — HD-019's shape, on the hydrated path."
   [_]
   [:input#hyd-field.field {:type     "text"
-                           :value    (rt/sub [:hyd/field])
+                           :value    (rf.bench.hicasso.arm1.runtime/sub [:hyd/field])
                            :on-input [:hyd/set-field :re-frame.hicasso/value]}])
 
 (defview revision-field-screen
@@ -192,8 +192,8 @@
   the model owns rather than a literal."
   [_]
   [:input#hyd-field.field {:type     "text"
-                           :value    (rt/sub [:hyd/field])
-                           :re-frame.hicasso/revision (rt/sub [:hyd/revision])
+                           :value    (rf.bench.hicasso.arm1.runtime/sub [:hyd/field])
+                           :re-frame.hicasso/revision (rf.bench.hicasso.arm1.runtime/sub [:hyd/revision])
                            :on-input [:hyd/set-field :re-frame.hicasso/value]}])
 
 (defn- drift!
@@ -221,11 +221,11 @@
   window, which is the state a server render is in, and released
   afterwards so the runtime the hydration is measured on is empty."
   [hiccup]
-  (rt/open-adoption-window!)
-  (let [container (mount/fresh-container!)
-        handle    (mount/root! container frame-id hiccup)
+  (rf.bench.hicasso.arm1.runtime/open-adoption-window!)
+  (let [container (rf.bench.hicasso.arm1.mount/fresh-container!)
+        handle    (rf.bench.hicasso.arm1.mount/root! container frame-id hiccup)
         html      (.-innerHTML container)]
-    (mount/release! handle)
+    (rf.bench.hicasso.arm1.mount/release! handle)
     html))
 
 ;; `server-dom!`, `stamp-server-nodes!`, `server-node?`, `capture-console!`
@@ -244,7 +244,7 @@
 
 (deftest hydrate-root-adopts-the-server-dom-and-the-closer-shuts-the-window
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (fresh!)
@@ -252,10 +252,10 @@
               container (stamp-server-nodes! (server-dom! html))
               title     (.querySelector container ".title")]
           (is (server-node? title) "the stamp is on the server's own node")
-          (rt/reset-body-runs!)
+          (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
           (let [{:keys [captured close!]} (open-console-capture!)
-                handle (mount/hydrate-root! container frame-id [screen {}])]
-            (is (true? (rt/adopting?))
+                handle (rf.bench.hicasso.arm1.mount/hydrate-root! container frame-id [screen {}])]
+            (is (true? (rf.bench.hicasso.arm1.runtime/adopting?))
                 "the window is OPEN the instant `hydrate-root!` returns —
                  `hydrateRoot` was called plain, so this returns before the
                  tree is adopted and the window has to outlive the call")
@@ -265,9 +265,9 @@
                     (close!)
                     (try
                       (is (true? ok) "the closer's passive effect ran")
-                      (is (false? (rt/adopting?))
+                      (is (false? (rf.bench.hicasso.arm1.runtime/adopting?))
                           "and shut the window — adoption is complete, and
-                           `(rt/adopting?)` answering false IS that effect
+                           `(rf.bench.hicasso.arm1.runtime/adopting?)` answering false IS that effect
                            having run, which is the completion signal this
                            door offers in place of a `flushSync`")
                       (is (= [] @captured)
@@ -281,7 +281,7 @@
                           "and so is every row")
                       (is (= "hydrated" (text-of container ".title")))
                       (is (= "alpha" (text-of container ".row[data-i=\"0\"]")))
-                      (finally (mount/release! handle) (done))))))))))))
+                      (finally (rf.bench.hicasso.arm1.mount/release! handle) (done))))))))))))
 
 ;; ===========================================================================
 ;; 2 — the reap horizon does not detach the adopted subscriptions
@@ -289,19 +289,19 @@
 
 (deftest the-reaper-does-not-evict-the-entries-hydration-subscribed-to
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (fresh!)
         (let [html      (server-html! [screen {}])
               container (server-dom! html)
-              handle    (mount/hydrate-root! container frame-id [screen {}])]
+              handle    (rf.bench.hicasso.arm1.mount/hydrate-root! container frame-id [screen {}])]
           (-> (adopted!)
               (.then
                 (fn [ok]
                   (try
                     (is (true? ok) "adoption completed")
-                    (let [stats (rt/stats)]
+                    (let [stats (rf.bench.hicasso.arm1.runtime/stats)]
                       (is (= boundary-count (:boundaries stats))
                           "every boundary committed its reads")
                       (is (= boundary-count (:entries stats))
@@ -317,26 +317,26 @@
                            of something"))
                     ;; The adopted subscription is LIVE, and re-rendering
                     ;; through it does not rebuild the cache.
-                    (mount/dispatch! handle [:hyd/set-row 1 "BETA"])
+                    (rf.bench.hicasso.arm1.mount/dispatch! handle [:hyd/set-row 1 "BETA"])
                     (is (= "BETA" (text-of container ".row[data-i=\"1\"]"))
                         "a write after adoption reaches the adopted boundary")
-                    (is (= boundary-count (:entries (rt/stats)))
+                    (is (= boundary-count (:entries (rf.bench.hicasso.arm1.runtime/stats)))
                         "and mints no second entry — the read sequence is
                          unchanged, so the cache hit keeps `subscribe`'s
                          identity and React never re-subscribes")
-                    (finally (mount/release! handle) (done)))))))))))
+                    (finally (rf.bench.hicasso.arm1.mount/release! handle) (done)))))))))))
 
 ;; ===========================================================================
 ;; 3 — presence is BORN PRESENT under adoption
 ;; ===========================================================================
 
 (deftest a-client-mounted-tray-enters-so-the-row-below-can-answer-false
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [container (mount/fresh-container!)
-            handle    (mount/root! container frame-id [toast-tray {}])]
+      (let [container (rf.bench.hicasso.arm1.mount/fresh-container!)
+            handle    (rf.bench.hicasso.arm1.mount/root! container frame-id [toast-tray {}])]
         (try
           (testing "**the control.** An ordinary client mount meets its
                    children for the first time, so they are `:mounting` and
@@ -347,11 +347,11 @@
               (is (some? toast))
               (is (.contains (.-classList toast) "toast--enter")
                   "the enter override is on the freshly mounted node")))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 (deftest a-hydrated-tray-is-born-present-and-never-replays-its-enter
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (fresh!)
@@ -367,7 +367,7 @@
                 toast     (.querySelector container ".toast")]
             (is (server-node? toast))
             (let [{:keys [captured close!]} (open-console-capture!)
-                  handle (mount/hydrate-root! container frame-id [toast-tray {}])]
+                  handle (rf.bench.hicasso.arm1.mount/hydrate-root! container frame-id [toast-tray {}])]
               (-> (adopted!)
                   (.then
                     (fn [ok]
@@ -387,7 +387,7 @@
                                entering it would replay an animation the user
                                has already watched")
                           (is (= "Saved" (.-textContent after))))
-                        (finally (mount/release! handle) (done)))))))))))))
+                        (finally (rf.bench.hicasso.arm1.mount/release! handle) (done)))))))))))))
 
 ;; ===========================================================================
 ;; 4 — HD-019's rider: the hydrated controlled input
@@ -395,7 +395,7 @@
 
 (deftest the-hydrated-controlled-input-keeps-its-mirror
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (fresh!)
@@ -411,9 +411,9 @@
             (is (server-node? before))
             (is (= "abc" (.-value before))
                 "the field shows the server's value before any JS ran")
-            (rt/reset-body-runs!)
+            (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
             (let [{:keys [captured close!]} (open-console-capture!)
-                  handle (mount/hydrate-root! container frame-id [field-screen {}])]
+                  handle (rf.bench.hicasso.arm1.mount/hydrate-root! container frame-id [field-screen {}])]
               (-> (adopted!)
                   (.then
                     (fn [ok]
@@ -432,18 +432,18 @@
                                runs at the end of a change handler and
                                hydration fires none, so the field holds
                                exactly what the server rendered")
-                          (is (= "abc" (controlled/last-rendered after))
+                          (is (= "abc" (rf.bench.hicasso.front.controlled/last-rendered after))
                               "**and the `defaultValue` mirror is established
                                on the hydrated path too** — the one dependency
                                `front.controlled` has on React, extended to
                                adoption. Without it every caret restore on a
                                hydrated field would converge to the wrong
                                string"))
-                        (is (= 1 (rt/body-runs))
+                        (is (= 1 (rf.bench.hicasso.arm1.runtime/body-runs))
                             (str "one boundary, one body run across the whole "
                                  "adoption — no converge, and so no extra "
-                                 "render; read " (rt/body-runs)))
-                        (finally (mount/release! handle) (done)))))))))))))
+                                 "render; read " (rf.bench.hicasso.arm1.runtime/body-runs)))
+                        (finally (rf.bench.hicasso.arm1.mount/release! handle) (done)))))))))))))
 
 ;; ===========================================================================
 ;; 5 — HD-028's rider: the memo cannot fake adoption
@@ -451,23 +451,23 @@
 
 (deftest the-body-run-count-across-adoption-is-counted-and-not-inferred
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (fresh!)
         (let [html      (server-html! [screen {}])
               container (stamp-server-nodes! (server-dom! html))]
-          (rt/reset-body-runs!)
-          (let [handle (mount/hydrate-root! container frame-id [screen {}])]
+          (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
+          (let [handle (rf.bench.hicasso.arm1.mount/hydrate-root! container frame-id [screen {}])]
             (-> (adopted!)
                 (.then
                   (fn [ok]
                     (try
                       (is (true? ok) "adoption completed")
-                      (is (= boundary-count (rt/body-runs))
+                      (is (= boundary-count (rf.bench.hicasso.arm1.runtime/body-runs))
                           (str "**each boundary's body ran exactly once to "
                                "adopt.** Counted in `run-once`, where a body "
-                               "is invoked — read " (rt/body-runs)))
+                               "is invoked — read " (rf.bench.hicasso.arm1.runtime/body-runs)))
                       (testing "**and the count is real, not memo-inferred**
                                (HD-028's rider). Re-rendering the same tree
                                with equal props bails out at `mint-view!`'s
@@ -478,7 +478,7 @@
                                genuine adoption from a skipped one.
 
                                **This row also pins the hydrated root's
-                               SHAPE** (`mount/tree`). The closer rides as a
+                               SHAPE** (`rf.bench.hicasso.arm1.mount/tree`). The closer rides as a
                                Fragment sibling, and a `render!` that handed
                                the same root a bare provider instead would not
                                be a cheap re-render — React would reconcile a
@@ -487,16 +487,16 @@
                                repair: four body runs and four replaced nodes,
                                i.e. everything the adoption achieved, undone by
                                the first ordinary render"
-                        (rt/reset-body-runs!)
-                        (mount/render! handle [screen {}])
-                        (is (zero? (rt/body-runs))
+                        (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
+                        (rf.bench.hicasso.arm1.mount/render! handle [screen {}])
+                        (is (zero? (rf.bench.hicasso.arm1.runtime/body-runs))
                             (str "a props-equal re-render ran no body; read "
-                                 (rt/body-runs)))
+                                 (rf.bench.hicasso.arm1.runtime/body-runs)))
                         (is (every? server-node?
                                     (array-seq (.querySelectorAll container ".row")))
                             "and every row is still the SERVER'S node — the
                              render did not remount the adopted tree"))
-                      (finally (mount/release! handle) (done))))))))))))
+                      (finally (rf.bench.hicasso.arm1.mount/release! handle) (done))))))))))))
 
 ;; ===========================================================================
 ;; 6 — HD-019's OTHER rider: a `::h/revision` arriving mid-adoption
@@ -513,12 +513,12 @@
 ;;
 ;; **The row below is not a re-run of that race, because `mid-adoption` is
 ;; a fact here rather than a wait.** `hydrate-root!` refuses to `flushSync`,
-;; so it returns before the tree is adopted and `(rt/adopting?)` is TRUE on
+;; so it returns before the tree is adopted and `(rf.bench.hicasso.arm1.runtime/adopting?)` is TRUE on
 ;; the line after — asserted, exactly as §1 asserts it. The dispatch is
 ;; synchronous in that same turn, so no timer, no retry loop and no
 ;; tolerance stands between the two: nothing can interleave and there is
-;; nothing to settle. It goes through `rt/dispatch!` rather than
-;; `mount/dispatch!` deliberately — the latter's `settle!` is a `flushSync`,
+;; nothing to settle. It goes through `rf.bench.hicasso.arm1.runtime/dispatch!` rather than
+;; `rf.bench.hicasso.arm1.mount/dispatch!` deliberately — the latter's `settle!` is a `flushSync`,
 ;; and flushing React mid-adoption would manufacture the very schedule this
 ;; door exists to refuse.
 ;;
@@ -543,7 +543,7 @@
 
 (deftest a-revision-arriving-mid-adoption-is-absorbed-by-the-adoption
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (fresh!)
@@ -561,14 +561,14 @@
                 "the draft really landed, and it landed BEFORE any JS adopted
                  the page — which is the only way a hydrated field can be
                  carrying one at all")
-            (rt/reset-body-runs!)
+            (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
             (let [{:keys [captured close!]} (open-console-capture!)
-                  handle (mount/hydrate-root! container frame-id
+                  handle (rf.bench.hicasso.arm1.mount/hydrate-root! container frame-id
                                               [revision-field-screen {}])]
-              (is (true? (rt/adopting?))
+              (is (true? (rf.bench.hicasso.arm1.runtime/adopting?))
                   "**the window is OPEN**, so the dispatch on the next line is
                    mid-adoption by construction rather than by timing")
-              (rt/dispatch! frame-id [:hyd/set-revision "rev-2"])
+              (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:hyd/set-revision "rev-2"])
               (-> (adopted!)
                   (.then
                     (fn [ok]
@@ -596,20 +596,20 @@
                                not an update, so the per-commit re-assert that
                                carries the whole reset never ran — the draft is
                                exactly where the user left it")
-                          (is (= "abc" (controlled/last-rendered after))
+                          (is (= "abc" (rf.bench.hicasso.front.controlled/last-rendered after))
                               "while the mirror is the MODEL's, so the field is
                                one ordinary commit away from converging"))
-                        (is (= 1 (rt/body-runs))
+                        (is (= 1 (rf.bench.hicasso.arm1.runtime/body-runs))
                             (str "one boundary, ONE body run across the whole "
                                  "adoption — the mid-adoption revision produced "
                                  "no render of its own, which is what ABSORBED "
-                                 "means; read " (rt/body-runs)))
+                                 "means; read " (rf.bench.hicasso.arm1.runtime/body-runs)))
                         (testing "**and the field is not stranded.** The next
                                  revision change after the window shuts resets
                                  it, on the SERVER's own node — the half of
                                  R3's claim that does survive"
-                          (rt/reset-body-runs!)
-                          (mount/dispatch! handle [:hyd/set-revision "rev-3"])
+                          (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
+                          (rf.bench.hicasso.arm1.mount/dispatch! handle [:hyd/set-revision "rev-3"])
                           (let [after (.querySelector container "#hyd-field")]
                             (is (= "abc" (.-value after))
                                 "the draft is discarded and the field
@@ -617,7 +617,7 @@
                             (is (identical? before after)
                                 "WITHOUT REMOUNT — still the server's own node")
                             (is (server-node? after))
-                            (is (= 1 (rt/body-runs))
+                            (is (= 1 (rf.bench.hicasso.arm1.runtime/body-runs))
                                 (str "on one ordinary commit; read "
-                                     (rt/body-runs)))))
-                        (finally (mount/release! handle) (done)))))))))))))
+                                     (rf.bench.hicasso.arm1.runtime/body-runs)))))
+                        (finally (rf.bench.hicasso.arm1.mount/release! handle) (done)))))))))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/hydrate_recoverable_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/hydrate_recoverable_dom_cljs_test.cljs
@@ -41,34 +41,34 @@
   React DOM; under `:node-test` every DOM claim degrades to a stated
   skip."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.bench.hicasso.arm1.hydration-support
              :refer [adopted! open-console-capture! server-dom!]]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
             [re-frame.core :as rf]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace.tooling :as trace-tooling])
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace.tooling :as rf.trace.tooling])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 (def ^:private frame-id ::arm1-hydrate-recoverable)
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (rt/reset-runtime!) (rt/reset-body-runs!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!) (rf.bench.hicasso.arm1.runtime/reset-body-runs!))}))
 
 (defn- skip! [why]
   (is true (str "a hydration claim needs a real React DOM — " why)))
 
 (defn- fresh! []
-  (lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/leave-act-environment!)
   (rf/make-frame {:id frame-id})
-  (rt/reset-runtime!)
-  (rt/reset-body-runs!)
+  (rf.bench.hicasso.arm1.runtime/reset-runtime!)
+  (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
   frame-id)
 
 ;; ---------------------------------------------------------------------------
@@ -101,11 +101,11 @@
   reported) and irrelevant to what it does not (byte identity, which is
   the SSR spike's claim and is made against `react-dom/server`)."
   [label]
-  (rt/open-adoption-window!)
-  (let [container (mount/fresh-container!)
-        handle    (mount/root! container frame-id [screen {:label label}])
+  (rf.bench.hicasso.arm1.runtime/open-adoption-window!)
+  (let [container (rf.bench.hicasso.arm1.mount/fresh-container!)
+        handle    (rf.bench.hicasso.arm1.mount/root! container frame-id [screen {:label label}])
         html      (.-innerHTML container)]
-    (mount/release! handle)
+    (rf.bench.hicasso.arm1.mount/release! handle)
     html))
 
 (defn- watch-mismatches!
@@ -120,10 +120,10 @@
   []
   (let [seen (atom [])
         k    (keyword (str "rf2-2rtt6-97-" (gensym)))]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (= :rf.ssr/hydration-mismatch (:operation ev))
                    (swap! seen conj ev))))
-    {:seen seen :stop! (fn [] (trace-tooling/unregister-listener! k) @seen)}))
+    {:seen seen :stop! (fn [] (rf.trace.tooling/unregister-listener! k) @seen)}))
 
 (defn- tags-of
   "The diagnostic's tags, merged with its top level, so a read is robust
@@ -144,7 +144,7 @@
            site — with no root options this emitted NOTHING and the whole
            complaint was an uncaught window error"
     (async done
-      (if-not (mount/browser?)
+      (if-not (rf.bench.hicasso.arm1.mount/browser?)
         (do (skip! ":node-test has no DOM") (done))
         (do
           (fresh!)
@@ -154,7 +154,7 @@
                 ;; MANUFACTURED fault, asserted on — see the ns docstring.
                 {:keys [captured close!]} (open-console-capture!
                                             {:swallow-uncaught? true})
-                handle    (mount/hydrate-root! container frame-id
+                handle    (rf.bench.hicasso.arm1.mount/hydrate-root! container frame-id
                                                [screen {:label "client"}])]
             (-> (adopted!)
                 (.then
@@ -190,7 +190,7 @@
                       (is (seq @captured)
                           (str "the complaint also reached a channel this
                                 witness watches: " (pr-str @captured)))
-                      (finally (mount/release! handle) (done))))))))))))
+                      (finally (rf.bench.hicasso.arm1.mount/release! handle) (done))))))))))))
 
 ;; ===========================================================================
 ;; 2 — and it is a READING, not a constant
@@ -203,7 +203,7 @@
            emitted, and nothing is reported on either console channel
            either"
     (async done
-      (if-not (mount/browser?)
+      (if-not (rf.bench.hicasso.arm1.mount/browser?)
         (do (skip! ":node-test has no DOM") (done))
         (do
           (fresh!)
@@ -211,7 +211,7 @@
                 container (server-dom! html)
                 {:keys [seen stop!]} (watch-mismatches!)
                 {:keys [captured close!]} (open-console-capture!)
-                handle    (mount/hydrate-root! container frame-id
+                handle    (rf.bench.hicasso.arm1.mount/hydrate-root! container frame-id
                                                [screen {:label "agreed"}])]
             (-> (adopted!)
                 (.then
@@ -227,7 +227,7 @@
                       (is (= [] @captured)
                           (str "and React reported nothing on either channel: "
                                (pr-str @captured)))
-                      (finally (mount/release! handle) (done))))))))))))
+                      (finally (rf.bench.hicasso.arm1.mount/release! handle) (done))))))))))))
 
 ;; ===========================================================================
 ;; 3 — the reporter COMPOSES over React's default; it does not swallow
@@ -241,17 +241,17 @@
            runner treats as fatal would simply stop happening. Drive the
            REAL callback and read both outcomes: the diagnostic fires AND
            the error is still reported"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (do
         (fresh!)
-        (rt/open-adoption-window!)
+        (rf.bench.hicasso.arm1.runtime/open-adoption-window!)
         (let [{:keys [seen stop!]} (watch-mismatches!)
               ;; MANUFACTURED fault, asserted on — see the ns docstring.
               {:keys [captured close!]} (open-console-capture!
                                           {:swallow-uncaught? true})]
           (try
-            (mount/hydration-reporter (js/Error. "manufactured recoverable") nil)
+            (rf.bench.hicasso.arm1.mount/hydration-reporter (js/Error. "manufactured recoverable") nil)
             (is (= 1 (count @seen)) "the diagnostic fired")
             (is (some #(re-find #"manufactured recoverable" %) @captured)
                 (str "and the error was STILL reported — the reporter composes
@@ -260,7 +260,7 @@
             (finally
               (close!)
               (stop!)
-              (rt/close-adoption-window!))))))))
+              (rf.bench.hicasso.arm1.runtime/close-adoption-window!))))))))
 
 ;; ===========================================================================
 ;; 4 — the emit is bounded to the adoption window
@@ -275,7 +275,7 @@
            the closer's passive effect shuts. Drive the REAL callback
            across that boundary: the report happens in BOTH windows, the
            emit in only one"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (do
         (fresh!)
@@ -284,11 +284,11 @@
               {:keys [captured close!]} (open-console-capture!
                                           {:swallow-uncaught? true})]
           (try
-            (rt/open-adoption-window!)
-            (mount/hydration-reporter (js/Error. "inside the window") nil)
+            (rf.bench.hicasso.arm1.runtime/open-adoption-window!)
+            (rf.bench.hicasso.arm1.mount/hydration-reporter (js/Error. "inside the window") nil)
             (is (= 1 (count @seen)) "inside the window it is a mismatch")
-            (rt/close-adoption-window!)
-            (mount/hydration-reporter (js/Error. "after the window") nil)
+            (rf.bench.hicasso.arm1.runtime/close-adoption-window!)
+            (rf.bench.hicasso.arm1.mount/hydration-reporter (js/Error. "after the window") nil)
             (is (= 1 (count @seen))
                 (str "and after the window it is NOT — no second emit. Saw: "
                      (pr-str @seen)))
@@ -298,4 +298,4 @@
             (finally
               (close!)
               (stop!)
-              (rt/close-adoption-window!))))))))
+              (rf.bench.hicasso.arm1.runtime/close-adoption-window!))))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/hydration_support.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/hydration_support.cljs
@@ -21,13 +21,13 @@
     cannot survive re-serialisation: a node still carrying it after
     hydration is the very node the server markup produced.
   - [[adopted!]] is the only completion signal a plain `hydrateRoot`
-    offers. `mount/hydrate-root!` refuses to `flushSync` (inventing a
+    offers. `rf.bench.hicasso.arm1.mount/hydrate-root!` refuses to `flushSync` (inventing a
     schedule no shipped caller has), so a witness waits for the closer's
     passive effect on real timers instead.
 
   Not a namespace anything outside the bench lane may depend on."
-  (:require [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]))
+  (:require [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]))
 
 ;; ---------------------------------------------------------------------------
 ;; The page as it arrives
@@ -37,7 +37,7 @@
   "A container carrying `html`, attached to the document — the page as it
   arrives, before any JavaScript has adopted it."
   [html]
-  (let [container (mount/fresh-container!)]
+  (let [container (rf.bench.hicasso.arm1.mount/fresh-container!)]
     (set! (.-innerHTML container) html)
     container))
 
@@ -59,7 +59,7 @@
 
   ## Why the window is the CALLER's to close
 
-  `hydrateRoot` is called plain (`mount/hydrate-root!` refuses to
+  `hydrateRoot` is called plain (`rf.bench.hicasso.arm1.mount/hydrate-root!` refuses to
   `flushSync`), so it RETURNS BEFORE THE TREE IS ADOPTED: React schedules
   the hydration render and the bodies run in a later turn. A capture
   whose window closes when the call returns is therefore open across the
@@ -87,7 +87,7 @@
   **It is off by default and it belongs at a call site that MANUFACTURES
   a recoverable error and asserts on it — nowhere else.** Anywhere else
   it would be exactly the fail-open the runner's rule exists to prevent.
-  The uncaught error stays uncaught at the DOOR: `mount/hydrate-root!`'s
+  The uncaught error stays uncaught at the DOOR: `rf.bench.hicasso.arm1.mount/hydrate-root!`'s
   reporter emits the framework diagnostic and then ALWAYS reports
   (rf2-2rtt6.97), so composing a diagnostic in did not — and must not —
   make a mismatch quieter than React left it. Every call site that sets
@@ -179,7 +179,7 @@
        (let [deadline (+ (js/Date.now) budget-ms)]
          (letfn [(tick []
                    (cond
-                     (not (rt/adopting?))
+                     (not (rf.bench.hicasso.arm1.runtime/adopting?))
                      ;; Past the closer AND past `entry-reap-horizon-ms`,
                      ;; so a reading of the entry cache is a reading taken
                      ;; on the far side of the race.

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/lifecycle_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/lifecycle_dom_cljs_test.cljs
@@ -38,15 +38,15 @@
   Runtime: `-dom-cljs-test`; under `:node-test` every claim degrades to a
   stated skip."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.bench.hicasso.arm1.boundary :refer [boundary]]
-            [re-frame.bench.hicasso.arm1.hook-probe :as probe]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.codec :as codec]
-            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.arm1.hook-probe :as rf.bench.hicasso.arm1.hook-probe]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
             [re-frame.core :as rf]
-            [re-frame.test-support :as test-support]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]
             ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client])
@@ -82,10 +82,10 @@
     {:db (update db :errors conj (or (ex-message err) (str err)))}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::arm1-lifecycle)
 (def ^:private reads 5)
@@ -93,7 +93,7 @@
 (defn- skip! [why] (is true (str "a lifecycle claim needs a real React DOM — " why)))
 
 (defn- fresh! []
-  (lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/leave-act-environment!)
   (rf/make-frame {:id frame-id :initial-events [[:life/seed reads]]})
   (rf/with-frame frame-id (rf/dispatch-sync [:life/seed reads]))
   frame-id)
@@ -103,7 +103,7 @@
 (defn- teardown-census!
   "Unmount the root, read the live-reference census, and THEN finish the
   release. The order is the entire load-bearing part, and it is not
-  fussiness: `mount/release!` calls `runtime/reset-runtime!`, which
+  fussiness: `rf.bench.hicasso.arm1.mount/release!` calls `runtime/reset-runtime!`, which
   disposes every cell and empties the index **by fiat** — so a census
   taken after it reads all zeros whatever the teardown did or did not
   release. Measured: with `make-subscribe`'s cleanup `release-cell!`
@@ -116,11 +116,11 @@
   than a release."
   [handle]
   (react-dom/flushSync (fn [] (.unmount (:root handle))))
-  (let [census (select-keys (rt/residue) [:cell-refs :boundaries :edges])]
+  (let [census (select-keys (rf.bench.hicasso.arm1.runtime/residue) [:cell-refs :boundaries :edges])]
     ;; `:root nil` so the arm's teardown door does the rest — reset the
     ;; runtime, drop the container — without unmounting a root that is
     ;; already gone.
-    (mount/release! (assoc handle :root nil))
+    (rf.bench.hicasso.arm1.mount/release! (assoc handle :root nil))
     census))
 
 (def ^:private released
@@ -140,10 +140,10 @@
   (swap! !runs inc)
   [:ul.reads
    (for [i (range n)]
-     [:li.read {:key i :data-i i} (str (rt/sub [:life/cell i]))])])
+     [:li.read {:key i :data-i i} (str (rf.bench.hicasso.arm1.runtime/sub [:life/cell i]))])])
 
 (defn- strict-root!
-  "`mount/root!`, wrapped in `React.StrictMode`. Written here rather than
+  "`rf.bench.hicasso.arm1.mount/root!`, wrapped in `React.StrictMode`. Written here rather than
   in the shared mount door because StrictMode is this row's variable and
   every other suite in the arm must keep measuring the ordinary tree."
   [container frame-kw hiccup]
@@ -151,19 +151,19 @@
     (react-dom/flushSync
       (fn [] (.render root (react/createElement
                              react/StrictMode nil
-                             (mount/provider frame-kw (codec/as-element hiccup))))))
+                             (rf.bench.hicasso.arm1.mount/provider frame-kw (rf.bench.hicasso.front.codec/as-element hiccup))))))
     {:root root :frame frame-kw :container container}))
 
 (defn- read-texts [handle]
   (mapv #(.-textContent %) (array-seq (.querySelectorAll (:container handle) ".read"))))
 
 (deftest strictmodes-double-invoke-is-not-additive
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (reset! !runs 0)
-      (let [handle (strict-root! (mount/fresh-container!) frame-id [reader {:n reads}])
+      (let [handle (strict-root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [reader {:n reads}])
             census (volatile! nil)]
         (try
           (testing "the premise: React really did invoke the body twice"
@@ -176,13 +176,13 @@
                    overwrite at the top of every body, so the second
                    invocation resolves the SAME set rather than appending to
                    the first's"
-            (is (= 1 (:entries (rt/stats)))
+            (is (= 1 (:entries (rf.bench.hicasso.arm1.runtime/stats)))
                 "a reset guarded by \"if empty\" would concatenate the two
                  renders' reads and mint a second entry of twice the length"))
           (testing "and the COMMITTED → COMMITTED transition is idempotent —
                    StrictMode mounts the effect, tears it down and mounts it
                    again, and the index is set-valued"
-            (let [{:keys [boundaries edges cells cell-refs]} (rt/stats)]
+            (let [{:keys [boundaries edges cells cell-refs]} (rf.bench.hicasso.arm1.runtime/stats)]
               (is (= 1 boundaries) "one boundary, not two registrations")
               (is (= reads edges) (str "one edge per read, not " (* 2 reads)))
               (is (= reads cells))
@@ -191,7 +191,7 @@
                    not release would read twice this")))
           (testing "the page is right, and a later write still reaches it"
             (is (= (mapv #(str "v" %) (range reads)) (read-texts handle)))
-            (mount/dispatch! handle [:life/set-cell 2 "moved"])
+            (rf.bench.hicasso.arm1.mount/dispatch! handle [:life/set-cell 2 "moved"])
             (is (= "moved" (nth (read-texts handle) 2)))
             (is (= "v1" (nth (read-texts handle) 1)) "and its neighbour did not"))
           (finally (vreset! census (teardown-census! handle))))
@@ -210,30 +210,30 @@
 ;; subscriptions leak" a reading rather than a hope.
 
 (def ^:private before
-  (rt/mint-view! "hmr/before" (fn [_] [:div.hmr {:data-v "1"} (str (rt/sub [:life/a]))])))
+  (rf.bench.hicasso.arm1.runtime/mint-view! "hmr/before" (fn [_] [:div.hmr {:data-v "1"} (str (rf.bench.hicasso.arm1.runtime/sub [:life/a]))])))
 
 (def ^:private after
-  (rt/mint-view! "hmr/after" (fn [_] [:div.hmr {:data-v "2"} (str (rt/sub [:life/b]))])))
+  (rf.bench.hicasso.arm1.runtime/mint-view! "hmr/after" (fn [_] [:div.hmr {:data-v "2"} (str (rf.bench.hicasso.arm1.runtime/sub [:life/b]))])))
 
 (defn- hmr-node [handle] (.querySelector (:container handle) ".hmr"))
 
 (deftest an-hmr-body-swap-keeps-the-root-the-frame-and-app-db
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [container (mount/fresh-container!)
-            handle    (mount/root! container frame-id [before {}])
+      (let [container (rf.bench.hicasso.arm1.mount/fresh-container!)
+            handle    (rf.bench.hicasso.arm1.mount/root! container frame-id [before {}])
             root      (:root handle)
             db-before (db)
             census    (volatile! nil)]
         (try
           (is (= "1" (.getAttribute (hmr-node handle) "data-v")))
           (is (= "alpha" (.-textContent (hmr-node handle))))
-          (is (= 1 (:edges (rt/stats))) "one edge, on the OLD body's read")
+          (is (= 1 (:edges (rf.bench.hicasso.arm1.runtime/stats))) "one edge, on the OLD body's read")
 
           ;; The swap. Same root object, same container, same frame.
-          (mount/render! handle [after {}])
+          (rf.bench.hicasso.arm1.mount/render! handle [after {}])
 
           (testing "HD-021(c)'s four survivals"
             (is (identical? root (:root handle)) "the root survived")
@@ -244,7 +244,7 @@
             (is (= "2" (.getAttribute (hmr-node handle) "data-v")))
             (is (= "beta" (.-textContent (hmr-node handle)))))
           (testing "and no subscription leaks across the swap"
-            (let [{:keys [boundaries edges cell-refs]} (rt/stats)]
+            (let [{:keys [boundaries edges cell-refs]} (rf.bench.hicasso.arm1.runtime/stats)]
               (is (= 1 boundaries) "the old body's registration is gone")
               (is (= 1 edges) "and so is its edge")
               (is (= 1 cell-refs)
@@ -253,7 +253,7 @@
                    reaper's grace window) but it holds NO reference, which is
                    the standing assertion")))
           (testing "the swapped-in body is really wired, not merely painted"
-            (mount/dispatch! handle [:life/set :b "beta-moved"])
+            (rf.bench.hicasso.arm1.mount/dispatch! handle [:life/set :b "beta-moved"])
             (is (= "beta-moved" (.-textContent (hmr-node handle)))))
           (finally (vreset! census (teardown-census! handle))))
         (is (= released @census)
@@ -267,7 +267,7 @@
   "Throws from the render phase when the model says so — which is where a
   React error boundary is the only thing that can catch."
   [_]
-  (when (rt/sub [:life/boom?])
+  (when (rf.bench.hicasso.arm1.runtime/sub [:life/boom?])
     (throw (ex-info "the body threw" {:planted true})))
   [:p.ok "ok"])
 
@@ -276,7 +276,7 @@
   the reset key read from the model like any other value."
   [_]
   [boundary {:fallback  [:p.fallback "caught"]
-             :reset-key (rt/sub [:life/attempt])
+             :reset-key (rf.bench.hicasso.arm1.runtime/sub [:life/attempt])
              :on-error  [:life/record-error]}
    [risky {}]])
 
@@ -284,12 +284,12 @@
 (defn- has? [handle sel] (some? (.querySelector (:container handle) sel)))
 
 (deftest the-boundary-catches-reports-once-and-resets
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (rf/with-frame frame-id (rf/dispatch-sync [:life/set :boom? true]))
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [guarded {}])
+      (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [guarded {}])
             census (volatile! nil)]
         (try
           (testing "the throw is caught and the fallback is on screen"
@@ -303,7 +303,7 @@
           (testing "the render that threw registered NOTHING — HD-002's
                    RENDERING → ∅ row, which needs no cleanup because it never
                    did anything that would need cleaning"
-            (let [{:keys [boundaries edges]} (rt/stats)]
+            (let [{:keys [boundaries edges]} (rf.bench.hicasso.arm1.runtime/stats)]
               (is (= 1 boundaries)
                   "only the host boundary committed; the thrower's
                    registration does not exist")
@@ -311,17 +311,17 @@
 
           (testing "a changed :reset-key retries the child — and a failure
                    after a reset is a NEW failure, so it reports again"
-            (mount/dispatch! handle [:life/set :attempt 1])
+            (rf.bench.hicasso.arm1.mount/dispatch! handle [:life/set :attempt 1])
             (is (has? handle ".fallback") "it threw again, so the fallback stands")
             (is (= ["the body threw" "the body threw"] (errors))))
 
           (testing "and once the cause is gone the child renders"
             (rf/with-frame frame-id (rf/dispatch-sync [:life/set :boom? false]))
-            (mount/dispatch! handle [:life/set :attempt 2])
+            (rf.bench.hicasso.arm1.mount/dispatch! handle [:life/set :attempt 2])
             (is (has? handle ".ok") "the retry succeeded")
             (is (not (has? handle ".fallback")))
             (is (= 2 (count (errors))) "with nothing further reported")
-            (is (= 2 (:boundaries (rt/stats)))
+            (is (= 2 (:boundaries (rf.bench.hicasso.arm1.runtime/stats)))
                 "and the child that now renders holds its own registration"))
           (finally (vreset! census (teardown-census! handle))))
         (is (= released @census)
@@ -342,56 +342,56 @@
            reporting from a lifecycle React runs more than once — moving
            `report!` into `render` is the mutation, and StrictMode is why
            it is visible"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (do
         (fresh!)
         (rf/with-frame frame-id (rf/dispatch-sync [:life/set :boom? true]))
-        (let [handle (strict-root! (mount/fresh-container!) frame-id [guarded {}])]
+        (let [handle (strict-root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [guarded {}])]
           (try
             (is (has? handle ".fallback") "the throw was caught")
             (is (= ["the body threw"] (errors))
                 "ONE record, not one per invocation of the render that threw")
-            (finally (mount/release! handle))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! handle))))))))
 
 (deftest a-function-fallback-sees-the-error
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (rf/with-frame frame-id (rf/dispatch-sync [:life/set :boom? true]))
-      (let [view   (rt/mint-view!
+      (let [view   (rf.bench.hicasso.arm1.runtime/mint-view!
                      "boundary/fn-fallback"
                      (fn [_] [boundary {:fallback (fn [e] [:p.fallback (ex-message e)])}
                               [risky {}]]))
-            handle (mount/root! (mount/fresh-container!) frame-id [view {}])]
+            handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [view {}])]
         (try
           (is (= "the body threw"
                  (.-textContent (.querySelector (:container handle) ".fallback")))
               "the fallback may be a function of the error — the one thing
                beyond static hiccup this boundary offers, and it is why
                `:fallback` is not simply a child")
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 (deftest the-boundary-spends-no-shell-hook
   (testing "HD-020(b)'s ≤2 is the boundary SHELL's budget, and
            `h/error-boundary` is a class — it calls no hooks at all. Counted at
            React's own dispatcher, on a page that wraps one Hicasso
            boundary in another"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
-      (if-not (probe/install!)
+      (if-not (rf.bench.hicasso.arm1.hook-probe/install!)
         (is false (str "React's internals slot was not found, so this claim is "
                        "UNWITNESSED on this build — fix the probe rather than "
                        "reading this as a pass"))
         (do
           (fresh!)
-          (let [container (mount/fresh-container!)
+          (let [container (rf.bench.hicasso.arm1.mount/fresh-container!)
                 handle    (volatile! nil)
-                names     (probe/record!
-                            (fn [] (vreset! handle (mount/root! container frame-id
+                names     (rf.bench.hicasso.arm1.hook-probe/record!
+                            (fn [] (vreset! handle (rf.bench.hicasso.arm1.mount/root! container frame-id
                                                                 [guarded {}]))))]
-            (mount/release! @handle)
+            (rf.bench.hicasso.arm1.mount/release! @handle)
             (is (= ["useContext" "useSyncExternalStore"
                     "useContext" "useSyncExternalStore"]
                    names)

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/mount.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/mount.cljs
@@ -30,11 +30,11 @@
   be inventing a schedule to make a witness easier to write. So that one
   door returns before the tree is adopted, and a witness for it waits for
   the closer instead of for a flush."
-  (:require [re-frame.adapter.context :as adapter-context]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.codec :as codec]
-            [re-frame.interop :as interop]
-            [re-frame.trace :as trace]
+  (:require [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
+            [re-frame.interop :as rf.interop]
+            [re-frame.trace :as rf.trace]
             ["react" :as react]
             ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]))
@@ -43,7 +43,7 @@
   "Scope `frame-kw` for a subtree. Renders no DOM of its own, so it cannot
   move a canonical-DOM parity comparison."
   [frame-kw child]
-  (react/createElement (.-Provider adapter-context/frame-context)
+  (react/createElement (.-Provider rf.adapter.context/frame-context)
                        #js {:value frame-kw}
                        child))
 
@@ -78,7 +78,7 @@
   `re-frame.bench.hicasso.arm1.runtime/retained-inventory`."
   [handle hiccup]
   (let [app (provider (:frame handle)
-                      (codec/root-element (:frame handle) hiccup))]
+                      (rf.bench.hicasso.front.codec/root-element (:frame handle) hiccup))]
     (if (:hydrated? handle)
       (react/createElement (.-Fragment react) nil
                            (react/createElement adoption-window-closer nil)
@@ -121,11 +121,11 @@
   adds nothing for `hydrateRoot` to match and cannot itself mismatch.
 
   Public because that is what makes adoption OBSERVABLE without a probe:
-  `(rt/adopting?)` answering false is this effect having run, which is
+  `(rf.bench.hicasso.arm1.runtime/adopting?)` answering false is this effect having run, which is
   the completion signal a witness waits on in place of the `flushSync`
   [[hydrate-root!]] refuses to perform."
   [_props]
-  (react/useEffect (fn close-window [] (rt/close-adoption-window!) js/undefined)
+  (react/useEffect (fn close-window [] (rf.bench.hicasso.arm1.runtime/close-adoption-window!) js/undefined)
                    #js [])
   nil)
 
@@ -134,7 +134,7 @@
 ;; happens not to enforce. Both emit the same `(x["displayName"] = ...)`,
 ;; and it is the STRING key that keeps the property off Closure's renamer
 ;; under `:advanced` — the reason the arm's other stamps
-;; (`runtime/mint-view!`, `codec/memoize-boundary!`) are spelled this way.
+;; (`runtime/mint-view!`, `rf.bench.hicasso.front.codec/memoize-boundary!`) are spelled this way.
 (unchecked-set adoption-window-closer "displayName" "hicasso/adoption-window-closer")
 
 ;; ---------------------------------------------------------------------------
@@ -187,7 +187,7 @@
   Not an event and it mints no epoch: it fires from a React root-error
   callback, outside any dispatch scope."
   [error]
-  (trace/emit! :warning :rf.ssr/hydration-mismatch
+  (rf.trace/emit! :warning :rf.ssr/hydration-mismatch
                {:error    (some-> error .-message)
                 :where    're-frame.bench.hicasso.arm1.mount/hydrate-root!
                 :recovery :warned-and-replaced}))
@@ -211,14 +211,14 @@
   across the window boundary rather than a copy of it — the spine's own
   reason for publishing `native-hydration-reporter`."
   [error _error-info]
-  (when (rt/adopting?)
+  (when (rf.bench.hicasso.arm1.runtime/adopting?)
     (emit-hydration-mismatch! error))
   (report-recoverable-default! error))
 
 (defn- hydrate-root-options
   "The `react-dom/client` root options for a hydrating root, or nil.
 
-  Nil in production, where the emit DCEs behind `interop/debug-enabled?`
+  Nil in production, where the emit DCEs behind `rf.interop/debug-enabled?`
   and the only thing left to install would be a replica of the default
   React would have run anyway — so the caller passes no options at all
   and the shipped path is exactly what it was. The spine gates the same
@@ -226,7 +226,7 @@
   `:on-recoverable-error`, and this arm has no host-authored callback to
   compose with."
   []
-  (when interop/debug-enabled?
+  (when rf.interop/debug-enabled?
     #js {:onRecoverableError hydration-reporter}))
 
 (defn hydrate-root!
@@ -281,7 +281,7 @@
   the adopted tree down and rebuilds it. [[tree]] is the one place that
   decision is made and `:hydrated?` is what it reads."
   [container frame-kw hiccup]
-  (rt/open-adoption-window!)
+  (rf.bench.hicasso.arm1.runtime/open-adoption-window!)
   (let [handle  {:frame frame-kw :container container :hydrated? true}
         element (tree handle hiccup)
         opts    (hydrate-root-options)]
@@ -319,7 +319,7 @@
   **Not the door a residue assertion takes** — see [[unmount!]]."
   [handle]
   (unmount! handle)
-  (rt/reset-runtime!)
+  (rf.bench.hicasso.arm1.runtime/reset-runtime!)
   nil)
 
 (defn dispatch!
@@ -327,7 +327,7 @@
   witness door; an intent written in a view reaches
   `runtime/dispatch!` on its own."
   [handle event]
-  (rt/dispatch! (:frame handle) event)
+  (rf.bench.hicasso.arm1.runtime/dispatch! (:frame handle) event)
   (settle!)
   nil)
 

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/presence.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/presence.cljs
@@ -25,7 +25,7 @@
   A presence child is hiccup **data**, written in the parent boundary's
   body — but it is **lowered in THIS component's render**, one React
   render later, after that body's dynamic extent has unwound. So
-  `intent/*dispatch*` is unbound at the moment the codec walks it, and
+  `rf.bench.hicasso.front.intent/*dispatch*` is unbound at the moment the codec walks it, and
   before this hook existed an intent at an event position on ANY presence
   child raised `:rf.error/hicasso-intent-outside-boundary` at render, and
   an `h/event` at one raised it at invocation. Loud, never silent — and it
@@ -74,28 +74,28 @@
   applied one render earlier, gated on `runtime/adopting?`. It costs no
   hook, changes no transform, and is scoped to the adoption window; see
   the comment at the binding below."
-  (:require [re-frame.adapter.context :as adapter-context]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.codec :as codec]
-            [re-frame.bench.hicasso.front.intent :as intent]
-            [re-frame.bench.hicasso.front.presence :as presence]
+  (:require [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
+            [re-frame.bench.hicasso.front.intent :as rf.bench.hicasso.front.intent]
+            [re-frame.bench.hicasso.front.presence :as rf.bench.hicasso.front.presence]
             ["react" :as react]))
 
 (defn- now [] (js/Date.now))
 
 (defn- presence-body [js-props]
   (let [props      (or (unchecked-get js-props "rfProps") {})
-        timeout-ms (presence/check-timeout! (:timeout-ms props))
+        timeout-ms (rf.bench.hicasso.front.presence/check-timeout! (:timeout-ms props))
         children   (:children props)
         ;; The frame hook. Classified through the shared reader the whole
         ;; substrate uses, so the no-provider sentinel resolves to nil
         ;; ("no scope") rather than being mistaken for a frame keyword.
-        frame-kw   (adapter-context/context-value->current-frame
-                     (react/useContext adapter-context/frame-context))
-        hook       (react/useState presence/initial)
+        frame-kw   (rf.adapter.context/context-value->current-frame
+                     (react/useContext rf.adapter.context/frame-context))
+        hook       (react/useState rf.bench.hicasso.front.presence/initial)
         state      (aget hook 0)
         set-state  (aget hook 1)
-        stepped    (presence/step state children (now) timeout-ms)
+        stepped    (rf.bench.hicasso.front.presence/step state children (now) timeout-ms)
         ;; BORN PRESENT UNDER ADOPTION (rf2-2rtt6.84). A child a render
         ;; meets for the first time is `:mounting`, which is right for a
         ;; child that is genuinely appearing and wrong for one that is
@@ -118,27 +118,27 @@
         ;; HTML and the client's first pass agree by construction; that
         ;; agreement is the whole reason the flag is read here in the
         ;; RENDER rather than in the effect below.
-        next       (if (rt/adopting?) (presence/settle stepped) stepped)]
+        next       (if (rf.bench.hicasso.arm1.runtime/adopting?) (rf.bench.hicasso.front.presence/settle stepped) stepped)]
     ;; Adjusting state while rendering — React's own answer to "a value
     ;; derived from props that must persist". `step` is idempotent, so the
     ;; equality test converges rather than looping.
     (when-not (= next state) (set-state next))
     (react/useEffect
       (fn []
-        (let [expiry (when-some [d (presence/next-deadline next)]
+        (let [expiry (when-some [d (rf.bench.hicasso.front.presence/next-deadline next)]
                        (js/setTimeout
-                         (fn [] (set-state (fn [s] (presence/expire s (now)))))
+                         (fn [] (set-state (fn [s] (rf.bench.hicasso.front.presence/expire s (now)))))
                          (max 0 (- d (now)))))
               ;; The enter flip lands on a macrotask rather than a layout
               ;; effect: a class flip that beats the browser's first paint
               ;; of the mounting styles animates nothing, and this is the
               ;; weak half the guide teaches around.
-              enter  (when (presence/mounting? next)
-                       (js/setTimeout (fn [] (set-state presence/settle)) 0))]
+              enter  (when (rf.bench.hicasso.front.presence/mounting? next)
+                       (js/setTimeout (fn [] (set-state rf.bench.hicasso.front.presence/settle)) 0))]
           (fn []
             (when expiry (js/clearTimeout expiry))
             (when enter (js/clearTimeout enter)))))
-      #js [(presence/pending-signature next)])
+      #js [(rf.bench.hicasso.front.presence/pending-signature next)])
     ;; THE LOWERING, inside the frame (rf2-2rtt6.66). These children were
     ;; written in the parent's body and are walked here, so the ambient
     ;; frame the codec's intent lowering reads has to be re-established
@@ -146,8 +146,8 @@
     ;; the tray — the binding is unconditional so the branch does not
     ;; exist, and an intent written under a frameless tray still lands on
     ;; the existing loud error naming the intent.
-    (intent/with-frame frame-kw (when frame-kw (rt/frame-dispatch frame-kw))
-      (fn [] (codec/as-element (into [:<>] (presence/render next)))))))
+    (rf.bench.hicasso.front.intent/with-frame frame-kw (when frame-kw (rf.bench.hicasso.arm1.runtime/frame-dispatch frame-kw))
+      (fn [] (rf.bench.hicasso.front.codec/as-element (into [:<>] (rf.bench.hicasso.front.presence/render next)))))))
 
 (def presence
   "`h/presence` — a boundary that retains exiting keyed children for
@@ -155,7 +155,7 @@
   `::h/unmounting` attribute overrides while it is in that phase.
 
       [presence {:timeout-ms 300}
-       (for [t (rt/sub [:toasts/visible])]
+       (for [t (rf.bench.hicasso.arm1.runtime/sub [:toasts/visible])]
          [:div.toast {:key (:id t)
                       ::h/unmounting {:class \"toast toast--exit\"
                                       :inert true :aria-hidden true}}
@@ -166,4 +166,4 @@
   subscription and holds no cell. It inserts no wrapper node and stamps
   no `data-*`; every child it renders is the author's own node with the
   author's own attributes merged."
-  (codec/mark-boundary! (doto presence-body (aset "displayName" "hicasso/presence"))))
+  (rf.bench.hicasso.front.codec/mark-boundary! (doto presence-body (aset "displayName" "hicasso/presence"))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/presence_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/presence_dom_cljs_test.cljs
@@ -20,13 +20,13 @@
   React DOM; under `:node-test` every DOM claim degrades to a stated
   skip."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
             [re-frame.bench.hicasso.arm1.presence :refer [presence]]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
             [re-frame.core :as rf]
-            [re-frame.test-support :as test-support])
+            [re-frame.test-support :as rf.test-support])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 (def ^:private frame-id ::arm1-presence)
@@ -42,19 +42,19 @@
 (rf/reg-event :toasts/set (fn [{:keys [db]} [_ ts]] {:db (assoc db :toasts ts)}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; `:timeout-ms` means two rows here wait on a real clock, and
      ;; `cljs.test` hard-errors on a fn-form fixture in a suite with an
      ;; `(async done …)` test.
      :async?        true
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (defn- skip! [why] (is true (str "a presence claim needs a real React DOM — " why)))
 
 (defn- fresh! [ts]
-  (lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/leave-act-environment!)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [:toasts/set ts]))
   frame-id)
@@ -69,7 +69,7 @@
   attributes on the extracted child."
   [_]
   [presence {:timeout-ms timeout-ms}
-   (for [t (rt/sub [:toasts/visible])]
+   (for [t (rf.bench.hicasso.arm1.runtime/sub [:toasts/visible])]
      [:div.toast {:key (:id t)
                   :data-id (:id t)
                   :re-frame.hicasso/unmounting {:class       "toast--exit"
@@ -91,7 +91,7 @@
   React name — so this is the shape the deny has to be written against."
   [_]
   [presence {:timeout-ms timeout-ms}
-   (for [t (rt/sub [:toasts/visible])]
+   (for [t (rf.bench.hicasso.arm1.runtime/sub [:toasts/visible])]
      [:div.toast {:key (:id t)
                   :data-id (:id t)
                   :re-frame.hicasso/unmounting
@@ -113,23 +113,23 @@
   "Let the enter flip's macrotask land, then let React commit it."
   []
   (js/Promise. (fn [resolve]
-                 (js/setTimeout (fn [] (mount/settle!) (resolve true)) 0))))
+                 (js/setTimeout (fn [] (rf.bench.hicasso.arm1.mount/settle!) (resolve true)) 0))))
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — the inline toast gets its exit attributes, and loses them on re-entry
 ;; ---------------------------------------------------------------------------
 
 (deftest an-inline-toast-gets-the-exit-attributes-while-unmounting
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh! two)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])]
+      (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [toast-tray {}])]
         (try
           (is (= 2 (toast-count handle)) "both toasts are on screen")
           (is (nil? (.getAttribute (node handle 2) "inert"))
               "and neither is exiting")
-          (mount/dispatch! handle [:toasts/set one])
+          (rf.bench.hicasso.arm1.mount/dispatch! handle [:toasts/set one])
           (is (= 2 (toast-count handle))
               "the removed toast is RETAINED — it is gone from app-db and
                still in the document, which is the whole of presence")
@@ -144,30 +144,30 @@
           (is (nil? (.getAttribute (node handle 1) "inert"))
               "while its neighbour is untouched")
           (testing "and re-entry cancels the exit rather than finishing it"
-            (mount/dispatch! handle [:toasts/set two])
+            (rf.bench.hicasso.arm1.mount/dispatch! handle [:toasts/set two])
             (let [back (node handle 2)]
               (is (nil? (.getAttribute back "inert")))
               (is (nil? (.getAttribute back "aria-hidden")))
               (is (not (.contains (.-classList back) "toast--exit")))
               (is (= 2 (toast-count handle)))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 1b — a hostile override reaches neither structural slot on the real node
 ;; ---------------------------------------------------------------------------
 
 (deftest a-hostile-override-reaches-neither-structural-slot-on-the-retained-node
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (reset! !ref-fired [])
       (fresh! two)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [hostile-tray {}])]
+      (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [hostile-tray {}])]
         (try
           (let [before (node handle 2)]
             (is (some? before))
             (is (= [] @!ref-fired) "nothing attached while the toast was present")
-            (mount/dispatch! handle [:toasts/set one])
+            (rf.bench.hicasso.arm1.mount/dispatch! handle [:toasts/set one])
             (is (= 2 (toast-count handle)) "retained, as ever")
             (let [during (node handle 2)]
               (is (.contains (.-classList during) "toast--exit")
@@ -183,7 +183,7 @@
                    key the machine retains it under, and nothing in an override
                    can move that in any spelling — a remount here would restart
                    the exit of a node that is mid-animation")))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 — the node is gone after :timeout-ms, and nothing leaks
@@ -194,16 +194,16 @@
   ;; first async block of a `deftest`, so a skip branch with its own block
   ;; would be a test that silently stopped running in the browser.
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (fresh! two)
-        (let [handle (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])]
-          (mount/dispatch! handle [:toasts/set one])
+        (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [toast-tray {}])]
+          (rf.bench.hicasso.arm1.mount/dispatch! handle [:toasts/set one])
           (is (= 2 (toast-count handle)) "retained, for now")
           (js/setTimeout
             (fn []
-              (mount/settle!)
+              (rf.bench.hicasso.arm1.mount/settle!)
               (try
                 (is (= 1 (toast-count handle))
                     "removal is terminal: :timeout-ms is a clock, not a
@@ -213,7 +213,7 @@
                 (is (some? (node handle 1))
                     "and the toast that never left is still there, so this is
                      removal and not a teardown")
-                (finally (mount/release! handle) (done))))
+                (finally (rf.bench.hicasso.arm1.mount/release! handle) (done))))
             (* 4 timeout-ms)))))))
 
 ;; ---------------------------------------------------------------------------
@@ -222,12 +222,12 @@
 
 (deftest a-mounting-child-flips-to-present-after-paint
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (fresh! [])
-        (let [handle (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])]
-          (mount/dispatch! handle [:toasts/set one])
+        (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [toast-tray {}])]
+          (rf.bench.hicasso.arm1.mount/dispatch! handle [:toasts/set one])
           (is (= 1 (toast-count handle)))
           (-> (settled!)
               (.then (fn [_]
@@ -239,7 +239,7 @@
                               paint, which is why the guide teaches an
                               animation on insertion for enter and keeps the
                               override for exit")
-                         (finally (mount/release! handle)))))
+                         (finally (rf.bench.hicasso.arm1.mount/release! handle)))))
               ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
               ;; the whole remainder of the run synchronously, so a `.catch`
               ;; downstream of it would claim a later namespace's throw as this

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/props_bailout_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/props_bailout_dom_cljs_test.cljs
@@ -57,19 +57,19 @@
   Runtime: `-dom-cljs-test`. Under `:node-test` every claim degrades to a
   stated skip."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.test-support :as test-support])
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.test-support :as rf.test-support])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::arm1-props-bailout-dom)
 
@@ -114,8 +114,8 @@
   [{:keys [id banner]}]
   (swap! !row-runs inc)
   [:li.row {:data-id id}
-   [:span.title (str (:title (rt/sub [:dogfood/todo id])))]
-   [:span.done (if (rt/sub [:dogfood/done? id]) "done" "open")]
+   [:span.title (str (:title (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo id])))]
+   [:span.done (if (rf.bench.hicasso.arm1.runtime/sub [:dogfood/done? id]) "done" "open")]
    (when banner [:span.banner (str banner)])])
 
 (defview page
@@ -125,10 +125,10 @@
   [_]
   (swap! !page-runs inc)
   [:div.page
-   [:h1.chrome (str (rt/sub [:dogfood/draft chrome-key]))]
-   [:span.remaining (str (rt/sub [:dogfood/remaining]))]
+   [:h1.chrome (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/draft chrome-key]))]
+   [:span.remaining (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))]
    [:ul.rows
-    (for [id (rt/sub [:dogfood/visible-ids])]
+    (for [id (rf.bench.hicasso.arm1.runtime/sub [:dogfood/visible-ids])]
       [row {:key id :id id}])]])
 
 (defview forwarding-page
@@ -136,11 +136,11 @@
   one edit, and the whole of claim 3."
   [_]
   (swap! !page-runs inc)
-  (let [banner (rt/sub [:dogfood/draft chrome-key])]
+  (let [banner (rf.bench.hicasso.arm1.runtime/sub [:dogfood/draft chrome-key])]
     [:div.page
      [:h1.chrome (str banner)]
      [:ul.rows
-      (for [id (rt/sub [:dogfood/visible-ids])]
+      (for [id (rf.bench.hicasso.arm1.runtime/sub [:dogfood/visible-ids])]
         [row {:key id :id id :banner banner}])]]))
 
 ;; ---------------------------------------------------------------------------
@@ -150,15 +150,15 @@
 (defn- fresh!
   ([] (fresh! row-count))
   ([n]
-   (lane/leave-act-environment!)
-   (dogfood/make-frame! frame-id n)
-   (dogfood/reseed! frame-id n)
+   (rf.bench.hicasso.lane/leave-act-environment!)
+   (rf.bench.hicasso.front.dogfood/make-frame! frame-id n)
+   (rf.bench.hicasso.front.dogfood/reseed! frame-id n)
    (reset-runs!)
    frame-id))
 
 (defn- mount-page!
   ([] (mount-page! page))
-  ([view] (mount/root! (mount/fresh-container!) frame-id [view {}])))
+  ([view] (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [view {}])))
 
 (defn- rows-of [handle]
   (array-seq (.querySelectorAll (:container handle) "li.row")))
@@ -169,14 +169,14 @@
   (some-> (.querySelector (:container handle) "h1.chrome") (.-textContent)))
 
 (defn- write-chrome! [handle text]
-  (mount/dispatch! handle [:dogfood/edit-draft chrome-key text]))
+  (rf.bench.hicasso.arm1.mount/dispatch! handle [:dogfood/edit-draft chrome-key text]))
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — the cascade is gone
 ;; ---------------------------------------------------------------------------
 
 (deftest a-page-chrome-write-re-renders-no-unchanged-row
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
@@ -184,7 +184,7 @@
         (try
           (let [nodes-before (vec (rows-of handle))
                 text-before  (row-texts handle)
-                edges-before (:edges (rt/stats))]
+                edges-before (:edges (rf.bench.hicasso.arm1.runtime/stats))]
             (is (= row-count (count nodes-before)))
             (reset-runs!)
             (write-chrome! handle "typed")
@@ -205,10 +205,10 @@
             (is (= nodes-before (vec (rows-of handle)))
                 "and they are the IDENTICAL DOM nodes — React neither
                  replaced nor re-patched a subtree")
-            (is (= edges-before (:edges (rt/stats)))
+            (is (= edges-before (:edges (rf.bench.hicasso.arm1.runtime/stats)))
                 "a bail-out is not an unmount: every row still holds its
                  edges, so the next write to one of them still arrives"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 — a subscription still propagates, in the commit that re-renders the page
@@ -222,7 +222,7 @@
            consults the comparator for all 100 rows — every one of which
            has `=` props, including the toggled one, whose props map is
            `{:id 37}` before and after. Exactly one must re-render anyway"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (do
         (fresh!)
@@ -230,7 +230,7 @@
           (try
             (let [before (row-texts handle)]
               (reset-runs!)
-              (mount/dispatch! handle [:dogfood/toggle moved-row])
+              (rf.bench.hicasso.arm1.mount/dispatch! handle [:dogfood/toggle moved-row])
               (is (= 1 (:page (runs)))
                   "the page re-ran — `:dogfood/remaining` moved, so this is
                    genuinely the parent-re-renders case and not a narrow
@@ -245,20 +245,20 @@
                     "exactly one row's DOM moved, and it is the one written to")
                 (is (re-find #"done" (nth after moved-row))
                     "and it moved in the right direction")))
-            (finally (mount/release! handle))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! handle))))))))
 
 (deftest a-frozen-row-would-fail-the-claim-above
   (testing "the toggle assertion is not passing vacuously — the same row
            read `open` before the write, so `differing-indices` above is a
            live comparison rather than one that always answers empty"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (do
         (fresh!)
         (let [handle (mount-page!)]
           (try
             (is (re-find #"open" (nth (row-texts handle) moved-row)))
-            (finally (mount/release! handle))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! handle))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2b — a CONTEXT change still propagates
@@ -274,29 +274,29 @@
            carry different titles: every row's props map is `{:id n}` before
            and after, so props alone would bail every one of them out and
            freeze the page on the old frame's data"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (do
         (fresh!)
-        (lane/leave-act-environment!)
-        (dogfood/make-frame! other-frame-id row-count)
-        (dogfood/reseed! other-frame-id row-count)
+        (rf.bench.hicasso.lane/leave-act-environment!)
+        (rf.bench.hicasso.front.dogfood/make-frame! other-frame-id row-count)
+        (rf.bench.hicasso.front.dogfood/reseed! other-frame-id row-count)
         ;; Give the other frame a row the first frame does not have.
-        (rt/dispatch! other-frame-id [:dogfood/edit-draft moved-row "from the other frame"])
-        (rt/dispatch! other-frame-id [:dogfood/commit moved-row])
+        (rf.bench.hicasso.arm1.runtime/dispatch! other-frame-id [:dogfood/edit-draft moved-row "from the other frame"])
+        (rf.bench.hicasso.arm1.runtime/dispatch! other-frame-id [:dogfood/commit moved-row])
         (let [handle (mount-page!)]
           (try
             (is (re-find #"todo" (nth (row-texts handle) moved-row))
                 "the first frame's data is on screen")
             (reset-runs!)
-            (mount/render! (assoc handle :frame other-frame-id) [page {}])
-            (mount/settle!)
+            (rf.bench.hicasso.arm1.mount/render! (assoc handle :frame other-frame-id) [page {}])
+            (rf.bench.hicasso.arm1.mount/settle!)
             (is (= row-count (:rows (runs)))
                 "every row re-rendered, though not one row's props moved")
             (is (re-find #"from the other frame" (nth (row-texts handle) moved-row))
                 "and the DOM carries the NEW frame's value — a memo that
                  outranked context would have frozen the page here")
-            (finally (mount/release! handle))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! handle))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3 — props still propagate
@@ -308,7 +308,7 @@
            row's props. A bail-out that never re-rendered would be worse
            than one that always did, so this is the half that says the
            comparator is comparing and not simply refusing"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (do
         (fresh!)
@@ -322,7 +322,7 @@
                      " rows' props moved"))
             (is (= row-count (.-length (.querySelectorAll (:container handle) "span.banner")))
                 "and the forwarded value reached the DOM of every one")
-            (finally (mount/release! handle))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! handle))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; A comparison that throws renders, rather than crashing the tree
@@ -344,9 +344,9 @@
   [_]
   (swap! !page-runs inc)
   [:div.page
-   [:h1.chrome (str (rt/sub [:dogfood/draft chrome-key]))]
+   [:h1.chrome (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/draft chrome-key]))]
    [:ul.rows
-    (for [id (take 5 (rt/sub [:dogfood/visible-ids]))]
+    (for [id (take 5 (rf.bench.hicasso.arm1.runtime/sub [:dogfood/visible-ids]))]
       [explosive-row {:key id :id id :boom (Explosive. id)}])]])
 
 (deftest a-props-comparison-that-throws-fails-open
@@ -357,7 +357,7 @@
            (rf2-5al9d7): an extra render is always the safe branch, and
            skipping on a failed comparison risks a stale UI. `areEqual`
            inverts the polarity, so failing open is answering false"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (do
         (fresh!)
@@ -374,14 +374,14 @@
                  an error: the throw was caught and answered false")
             (is (= "boom" (chrome-text handle))
                 "and the page is still live and still painting")
-            (finally (mount/release! handle))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! handle))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4 — it is a law, not a number that holds at one B
 ;; ---------------------------------------------------------------------------
 
 (deftest no-row-re-renders-whatever-the-page-size
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (doseq [n [10 50 200]]
       (fresh! n)
@@ -394,4 +394,4 @@
               (str "zero rows re-rendered at B = " n " — the cascade was
                    linear in B, so a repair that only held at one size
                    would not be a repair"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/ratom_activation_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/ratom_activation_cljs_test.cljs
@@ -51,19 +51,19 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [reagent.core :as r]
             [reagent.ratom :as ratom]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
             [re-frame.core :as rf]
-            [re-frame.test-support :as test-support]))
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       reagent-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
      :ambient-frame nil
      ;; The rebuild claim rides a macrotask — `invalidate-cell!` defers
      ;; the re-attachment on purpose — so the map shape, with `async`.
      :async?        true
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::arm1-ratom-activation)
 
@@ -75,7 +75,7 @@
 (defn- fresh!
   ([] (fresh! 1))
   ([n]
-   (rt/reset-runtime!)
+   (rf.bench.hicasso.arm1.runtime/reset-runtime!)
    (register!)
    (rf/make-frame {:id frame-id :initial-events [[:hic/set-n n]]})
    frame-id))
@@ -94,12 +94,12 @@
   reads, and hand back the notification counter and the release. The
   same shape `arm1/runtime-cljs-test` uses, under a different adapter."
   [body-fn]
-  (rt/render-body frame-id body-fn {})
-  (let [entry (rt/last-reads)
+  (rf.bench.hicasso.arm1.runtime/render-body frame-id body-fn {})
+  (let [entry (rf.bench.hicasso.arm1.runtime/last-reads)
         hits  (volatile! 0)]
     {:entry    entry
      :hits     hits
-     :release! (rt/commit-boundary! entry (fn [] (vswap! hits inc)))}))
+     :release! (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn [] (vswap! hits inc)))}))
 
 (defn- write!
   "The arm's synchronous door, then Reagent's own drain.
@@ -112,7 +112,7 @@
   reaction that never captured is not enqueued by anything, so this call
   moves precisely nothing until [[wire-cell!]] activates."
   [event]
-  (rt/dispatch! frame-id event)
+  (rf.bench.hicasso.arm1.runtime/dispatch! frame-id event)
   (r/flush)
   nil)
 
@@ -123,7 +123,7 @@
   (atom ::never))
 
 (defn- readout-body [_]
-  (let [n (rt/sub [:hic/n])]
+  (let [n (rf.bench.hicasso.arm1.runtime/sub [:hic/n])]
     (reset! !last-read n)
     [:span (str n)]))
 
@@ -140,7 +140,7 @@
             for the life of the mount"
     (fresh! 1)
     (let [b  (mounted! readout-body)
-          rx (rt/cell-reaction (key-of [:hic/n]))]
+          rx (rf.bench.hicasso.arm1.runtime/cell-reaction (key-of [:hic/n]))]
       (try
         (is (some? rx)
             "precondition — the commit built a cell and it holds a reaction")
@@ -170,7 +170,7 @@
         (testing "…and the boundary reads the moved value back through the
                   cell it holds, so the notification is not a bare ping"
           (reset! !last-read ::never)
-          (rt/render-body frame-id readout-body {})
+          (rf.bench.hicasso.arm1.runtime/render-body frame-id readout-body {})
           (is (= 3 @!last-read)
               "the re-render the notification bought read 3 — a WARM read,
                straight off the cell's reaction"))
@@ -223,7 +223,7 @@
         (js/setTimeout
           (fn []
             (try
-              (let [rx     (rt/cell-reaction (key-of [:hic/n]))
+              (let [rx     (rf.bench.hicasso.arm1.runtime/cell-reaction (key-of [:hic/n]))
                     before @(:hits b)]
                 (is (some? rx) "the rebuild re-subscribed")
                 (is (capturing? rx)

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/ratom_activation_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/ratom_activation_dom_cljs_test.cljs
@@ -40,19 +40,19 @@
   under `:node-test` every DOM claim degrades to a stated skip."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent.core :as r]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
             [re-frame.core :as rf]
-            [re-frame.test-support :as test-support])
+            [re-frame.test-support :as rf.test-support])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       reagent-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::arm1-ratom-activation-dom)
 
@@ -65,7 +65,7 @@
   read, so the mounted occurrence repaints only if the commit's cell is
   actually notified."
   [_]
-  [:output#readout (str (rt/sub [:hic/n]))])
+  [:output#readout (str (rf.bench.hicasso.arm1.runtime/sub [:hic/n]))])
 
 (defview bump
   "A committed `:on-click` site — the operator's press, driven for real."
@@ -83,14 +83,14 @@
   (is true (str "a repaint claim needs a real React DOM — " why)))
 
 (defn- fresh! []
-  (lane/leave-act-environment!)
-  (rt/reset-runtime!)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.arm1.runtime/reset-runtime!)
   (rf/reg-sub :hic/n (fn [db _] (:n db)))
   (rf/reg-event :hic/bump (fn [{:keys [db]} _] {:db (update db :n inc)}))
   (rf/reg-event :hic/set-n (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
   (rf/reg-event :hic/set-other (fn [{:keys [db]} [_ v]] {:db (assoc db :other v)}))
   (rf/make-frame {:id frame-id :initial-events [[:hic/set-n 0]]})
-  (rt/reset-body-runs!)
+  (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
   frame-id)
 
 (defn- settle!
@@ -98,17 +98,17 @@
 
   `reagent.core/flush` runs the reactions a write enqueued, which is what
   turns an activated node's recompute into the `notify-w` the cell's watch
-  rides; `mount/settle!` is the empty `flushSync` that lets the sync-lane
+  rides; `rf.bench.hicasso.arm1.mount/settle!` is the empty `flushSync` that lets the sync-lane
   `onStoreChange` that raised commit. The bench spells the pair as
   `(flushSync (fn [] (r/flush)))`, which is the same two acts in one
   call."
   []
   (r/flush)
-  (mount/settle!)
+  (rf.bench.hicasso.arm1.mount/settle!)
   nil)
 
 (defn- write! [handle event]
-  (rt/dispatch! (:frame handle) event)
+  (rf.bench.hicasso.arm1.runtime/dispatch! (:frame handle) event)
   (settle!))
 
 (defn- press! [handle]
@@ -123,11 +123,11 @@
 ;; ===========================================================================
 
 (deftest a-mounted-boundary-repaints-under-the-reagent-adapter
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [page {}])]
+      (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [page {}])]
         (try
           (is (= "0" (readout-text handle))
               "the first render read the seeded value — it always did; the
@@ -146,18 +146,18 @@
           (is (= "2" (readout-text handle))
               "0 → 1 → 2: the channel stays armed rather than firing once")
           (finally
-            (mount/release! handle)))))))
+            (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ===========================================================================
 ;; 2 — a real press, which is what the operator drives
 ;; ===========================================================================
 
 (deftest a-real-press-repaints-the-mounted-boundary
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [page {}])]
+      (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [page {}])]
         (try
           (is (= "0" (readout-text handle)))
           (press! handle)
@@ -167,26 +167,26 @@
               "and the sibling reader repainted off the same movement — the
                whole round trip a page performs, with nothing hand-driven")
           (finally
-            (mount/release! handle)))))))
+            (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ===========================================================================
 ;; 3 — the adversarial companion: activation must not make it chatty
 ;; ===========================================================================
 
 (deftest a-write-that-moved-nothing-repaints-no-boundary
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [page {}])]
+      (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [page {}])]
         (try
           (is (= "0" (readout-text handle)))
-          (rt/reset-body-runs!)
+          (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
           (write! handle [:hic/set-n 0])
-          (is (zero? (rt/body-runs))
+          (is (zero? (rf.bench.hicasso.arm1.runtime/body-runs))
               "an equal re-write moved nothing, so no body re-ran")
           (write! handle [:hic/set-other :noise])
-          (is (zero? (rt/body-runs))
+          (is (zero? (rf.bench.hicasso.arm1.runtime/body-runs))
               "…and neither did a write to a key this sub never reads")
           (is (= "0" (readout-text handle))
               "the DOM is untouched by either write")
@@ -194,7 +194,7 @@
           (testing "positive control — the silences above are silences, not
                     a dead channel that would make this whole row vacuous"
             (write! handle [:hic/set-n 6])
-            (is (pos? (rt/body-runs)))
+            (is (pos? (rf.bench.hicasso.arm1.runtime/body-runs)))
             (is (= "6" (readout-text handle))))
           (finally
-            (mount/release! handle)))))))
+            (rf.bench.hicasso.arm1.mount/release! handle)))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/render_measure_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/render_measure_cljs_test.cljs
@@ -4,7 +4,7 @@
 
   `defview` boundaries now report through Spec 009's Performance
   channel: [[re-frame.bench.hicasso.arm1.runtime/mint-view!]] wraps the
-  component fn React calls in `(performance/mark-and-measure :render
+  component fn React calls in `(rf.performance/mark-and-measure :render
   view-name …)`, so a build that flips
   `re-frame.performance/enabled?` gets one `rf:render:<view-id>`
   User-Timing measure per boundary render.
@@ -51,13 +51,13 @@
   doubles as the bead's SSR clause: a server pass leaves no durable
   registration behind a bracket."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
             [re-frame.core :as rf]
-            [re-frame.performance :as performance :include-macros true]
-            [re-frame.test-support :as test-support]
+            [re-frame.performance :as rf.performance :include-macros true]
+            [re-frame.test-support :as rf.test-support]
             ["react-dom/server" :as react-dom-server])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
@@ -72,10 +72,10 @@
 (rf/reg-event :rm/seed (fn [_ _] {:db {:title "quarterly"}}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (rt/reset-runtime!) (rt/reset-body-runs!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!) (rf.bench.hicasso.arm1.runtime/reset-body-runs!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The page — two boundaries, so "one measure per boundary" has something
@@ -85,7 +85,7 @@
 (defview title-row
   "A boundary that reads, so its body is a real body and not a constant."
   [_]
-  [:h1.title (rt/sub [:rm/title])])
+  [:h1.title (rf.bench.hicasso.arm1.runtime/sub [:rm/title])])
 
 (defview measured-page
   "The outer boundary. Two heads render per pass, which is what makes the
@@ -122,7 +122,7 @@
   renderer calls, minus the browser."
   [hiccup]
   (react-dom-server/renderToString
-    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+    (rf.bench.hicasso.arm1.mount/provider frame-id (rf.bench.hicasso.front.codec/root-element frame-id hiccup))))
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — the id rule (no flag needed; it is a property of the mint)
@@ -139,9 +139,9 @@
     (is (= "re-frame.bench.hicasso.arm1.render-measure-cljs-test/measured-page"
            (.-displayName measured-page)))
     (is (= "rf:render:re-frame.bench.hicasso.arm1.render-measure-cljs-test/title-row"
-           (performance/build-name :render (.-displayName title-row))))
+           (rf.performance/build-name :render (.-displayName title-row))))
     (is (= "rf:render:re-frame.bench.hicasso.arm1.render-measure-cljs-test/measured-page"
-           (performance/build-name :render (.-displayName measured-page))))))
+           (rf.performance/build-name :render (.-displayName measured-page))))))
 
 (deftest the-id-rule-holds-for-a-mint-view-name-without-a-namespace
   (testing "`mint-view!` is also called directly (the frame-prop rows, the
@@ -149,10 +149,10 @@
             it verbatim, so the shape stays `rf:render:<id>` with no
             namespace invented — the same contract a non-namespaced
             `reg-view` keyword id gets."
-    (let [head (rt/mint-view! "bare-row" (fn [_] [:span "x"]))]
+    (let [head (rf.bench.hicasso.arm1.runtime/mint-view! "bare-row" (fn [_] [:span "x"]))]
       (is (= "bare-row" (.-displayName head)))
       (is (= "rf:render:bare-row"
-             (performance/build-name :render (.-displayName head)))))))
+             (rf.performance/build-name :render (.-displayName head)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 — the off path: the render happens, and nothing is measured
@@ -165,16 +165,16 @@
             without them 'no rf: measures landed' is a statement about a
             page that never rendered — and the empty measure stream says
             the bracket added nothing to it."
-    (when-not performance/enabled?
+    (when-not rf.performance/enabled?
       (fresh!)
       (clear-measures!)
-      (rt/reset-body-runs!)
+      (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
       (let [html (server-html [measured-page {}])]
         (is (re-find #"quarterly" html)
             "the page rendered its subscription value — the render is real")
         (is (re-find #"class=\"page\"" html)
             "and its markup is the ordinary markup")
-        (is (= 2 (rt/body-runs))
+        (is (= 2 (rf.bench.hicasso.arm1.runtime/body-runs))
             "two boundary bodies ran — the page and the row")
         (is (= [] (rf-measure-names))
             "and NOTHING reached the User-Timing stream")))))
@@ -185,13 +185,13 @@
             renders would leave ten retained entries in a flag-on build
             with retention on; here they leave none, and the body-run
             count proves ten renders were asked for."
-    (when-not performance/enabled?
+    (when-not rf.performance/enabled?
       (fresh!)
       (clear-measures!)
-      (rt/reset-body-runs!)
+      (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
       (dotimes [_ 5]
         (server-html [measured-page {}]))
-      (is (= 10 (rt/body-runs)) "five passes over two boundaries")
+      (is (= 10 (rf.bench.hicasso.arm1.runtime/body-runs)) "five passes over two boundaries")
       (is (= [] (rf-measure-names))
           "and the retained buffer is still empty"))))
 
@@ -202,11 +202,11 @@
             writes a measure and (retention off) clears it, and holds no
             reference of its own. `stats` is the arm's own enumeration of
             what survived."
-    (when-not performance/enabled?
+    (when-not rf.performance/enabled?
       (fresh!)
       (clear-measures!)
       (server-html [measured-page {}])
-      (is (zero? (:boundaries (rt/stats)))
+      (is (zero? (:boundaries (rf.bench.hicasso.arm1.runtime/stats)))
           "a server pass committed nothing — no registration holds a reader slot")
       (is (= [] (rf-measure-names))
           "and left no User-Timing entry either"))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/render_measure_emit_nightly_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/render_measure_emit_nightly_test.cljs
@@ -32,7 +32,7 @@
 
   [[the-perf-flag-is-actually-on]] is first and is not a courtesy: a
   perf-emission suite whose every row is wrapped in `(when
-  performance/enabled? …)` reads as a pass in a build where the flag is
+  rf.performance/enabled? …)` reads as a pass in a build where the flag is
   off, which is a gate nobody has watched fire. If this file is ever
   compiled into a runner without the goog-defines, it goes red and says
   which flag is missing.
@@ -48,13 +48,13 @@
   [[a-head-react-never-invoked-produces-no-measure]] states exactly
   that, at the level a headless runner can state it."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
             [re-frame.core :as rf]
-            [re-frame.performance :as performance :include-macros true]
-            [re-frame.test-support :as test-support]
+            [re-frame.performance :as rf.performance :include-macros true]
+            [re-frame.test-support :as rf.test-support]
             ["react-dom/server" :as react-dom-server])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
@@ -69,10 +69,10 @@
 (rf/reg-event :rm-on/seed (fn [_ _] {:db {:title "quarterly"}}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (rt/reset-runtime!) (rt/reset-body-runs!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!) (rf.bench.hicasso.arm1.runtime/reset-body-runs!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The page
@@ -80,7 +80,7 @@
 
 (defview title-row
   [_]
-  [:h1.title (rt/sub [:rm-on/title])])
+  [:h1.title (rf.bench.hicasso.arm1.runtime/sub [:rm-on/title])])
 
 (defview note-row
   [_]
@@ -146,7 +146,7 @@
 
 (defn- server-html [hiccup]
   (react-dom-server/renderToString
-    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+    (rf.bench.hicasso.arm1.mount/provider frame-id (rf.bench.hicasso.front.codec/root-element frame-id hiccup))))
 
 (def ^:private page-name
   "re-frame.bench.hicasso.arm1.render-measure-emit-nightly-test/measured-page")
@@ -164,12 +164,12 @@
             decision. A build without the goog-defines would make every
             row below vacuous, so the flags are a row rather than a
             precondition nobody checks."
-    (is performance/enabled?
+    (is rf.performance/enabled?
         (str "re-frame.performance/enabled? is FALSE in this runner. This ns "
              "belongs to the :node-test-perf-nightly build "
              "(:closure-defines {re-frame.performance/enabled? true "
              "re-frame.performance/retain-entries? true}); run it there."))
-    (is performance/retain-entries?
+    (is rf.performance/retain-entries?
         (str "re-frame.performance/retain-entries? is FALSE, so each measure is "
              "cleared right after emit and a synchronous getEntriesByType read "
              "finds nothing. Flip it for this runner."))))
@@ -185,11 +185,11 @@
             pinned naming rule (the head's displayName)."
     (fresh!)
     (clear-measures!)
-    (rt/reset-body-runs!)
+    (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
     (let [html  (server-html [measured-page {}])
           names (render-measure-names)]
       (is (re-find #"quarterly" html) "the page really rendered")
-      (is (= 3 (rt/body-runs)) "three boundary bodies ran")
+      (is (= 3 (rf.bench.hicasso.arm1.runtime/body-runs)) "three boundary bodies ran")
       (is (= #{page-name title-name note-name}
              (set (map #(subs % (count render-prefix)) names)))
           "one entry per rendered head, each named by its displayName")
@@ -223,10 +223,10 @@
             which is bumped somewhere else entirely, agrees."
     (fresh!)
     (clear-measures!)
-    (rt/reset-body-runs!)
+    (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
     (dotimes [_ 3]
       (server-html [measured-page {}]))
-    (is (= 9 (rt/body-runs)))
+    (is (= 9 (rf.bench.hicasso.arm1.runtime/body-runs)))
     (is (= 9 (count (render-measure-names)))
         "one measure per body run — the fence never retried, so the two
          counters are the same number arrived at two ways")
@@ -288,13 +288,13 @@
             its own row rather than an assumption."
     (fresh!)
     (clear-measures!)
-    (rt/reset-body-runs!)
-    (let [row  (rt/mint-frame-prop-view!
+    (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
+    (let [row  (rf.bench.hicasso.arm1.runtime/mint-frame-prop-view!
                  "frame-prop/measured-row"
-                 (fn [_] [:li.fp (str (rt/sub [:rm-on/title]))]))
+                 (fn [_] [:li.fp (str (rf.bench.hicasso.arm1.runtime/sub [:rm-on/title]))]))
           html (server-html [row {}])]
       (is (re-find #"quarterly" html) "the frame-fed boundary rendered")
-      (is (= 1 (rt/body-runs)))
+      (is (= 1 (rf.bench.hicasso.arm1.runtime/body-runs)))
       (is (= [(str render-prefix "frame-prop/measured-row")]
              (render-measure-names))
           "and it emitted exactly one entry, named the same way"))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -155,7 +155,7 @@
   once realised; it would simply never update again.
 
   This arm is safe by construction: [[run-once]] closes the window around
-  `codec/as-element`, and the codec is eager everywhere it walks —
+  `rf.bench.hicasso.front.codec/as-element`, and the codec is eager everywhere it walks —
   `expand-seq` drives a seq to exhaustion, `realize-children` folds one
   into a vector, a seq at a *native* prop position goes through
   `clj->js`, and `front.codec/realize-deep` forces every lazy sequence
@@ -337,9 +337,9 @@
   [[invalidate-cell!]] is the one repair all three reach:
   [[wire-cell!]] arms it per unique key against the reaction's disposal,
   which covers the two transitions that dispose; the third disposes
-  nothing — `registrar/add-replacement-hook!` fires only when a previous
+  nothing — `rf.registrar/add-replacement-hook!` fires only when a previous
   handler existed — so the arm hangs it off
-  `registrar/add-registration-hook!` ([[sub-registered!]]), narrowed to
+  `rf.registrar/add-registration-hook!` ([[sub-registered!]]), narrowed to
   first-time `:sub` registrations and to the cells that hold the id being
   registered. It costs no React hook and no per-boundary object.
 
@@ -364,16 +364,16 @@
   ViewCell-class object graph. No candidate ledger. Codec caching is the
   only accelerant (HD-004); nothing here holds a node reference, plans a
   hole, or writes the DOM."
-  (:require [re-frame.adapter.context :as adapter-context]
-            [re-frame.bench.hicasso.front.codec :as codec]
-            [re-frame.bench.hicasso.front.intent :as intent]
+  (:require [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
+            [re-frame.bench.hicasso.front.intent :as rf.bench.hicasso.front.intent]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.live-frame :as live-frame]
-            [re-frame.performance :as performance :include-macros true]
-            [re-frame.registrar :as registrar]
-            [re-frame.subs :as subs]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.live-frame :as rf.live-frame]
+            [re-frame.performance :as rf.performance :include-macros true]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.subs :as rf.subs]
             ["react" :as react]))
 
 ;; ---------------------------------------------------------------------------
@@ -595,7 +595,7 @@
   minted-per-cell identity (rf2-aqgr2).
 
   A watch key has to be unique *within the watched reference*, and it is:
-  there is at most one cell per `(frame, query)`, `subs/subscribe` hands
+  there is at most one cell per `(frame, query)`, `rf.subs/subscribe` hands
   back that pair's own cached reaction, and no two cells ever hold the
   same reaction — so one namespaced constant collides with nothing this
   arm installs, and its namespace keeps it clear of any other watcher keyed
@@ -688,7 +688,7 @@
   of the registry one, where there is no dead reference to read back
   through because the commit acquires against the live registration."
   [frame-kw]
-  (+ @!generation (frame/frame-commit-epoch frame-kw) @!registry-epoch))
+  (+ @!generation (rf.frame/frame-commit-epoch frame-kw) @!registry-epoch))
 
 (declare flush!)
 
@@ -702,7 +702,7 @@
     (set! (.-disposed cell) true)
     (when-some [r (.-reaction cell)] (remove-watch r cell-watch-key))
     (swap! !cells dissoc (.-subKey cell))
-    (subs/unsubscribe (.-frameKw cell) (.-queryV cell)))
+    (rf.subs/unsubscribe (.-frameKw cell) (.-queryV cell)))
   nil)
 
 (defn- arm-cell-reaper!
@@ -735,7 +735,7 @@
   app-db's watcher set, so the watch below never fires, [[mark-dirty!]] never
   fires — that watch is its only caller — and no write after the mount ever
   becomes re-render work. Measured: the arm painted once and was deaf
-  thereafter. `interop/activate-derived-value!` is the substrate's own op for
+  thereafter. `rf.interop/activate-derived-value!` is the substrate's own op for
   this and is a routed no-op on the React-hook spine, which wires one watch
   per source at construction.
 
@@ -754,16 +754,16 @@
   [^js cell]
   (let [frame-kw (.-frameKw cell)
         query-v  (.-queryV cell)
-        reaction (subs/subscribe query-v {:frame frame-kw})]
+        reaction (rf.subs/subscribe query-v {:frame frame-kw})]
     (set! (.-reaction cell) reaction)
     (when (some? reaction)
       ;; On the substrate's PUSH path, before anything observes or watches it.
-      (interop/activate-derived-value! reaction)
+      (rf.interop/activate-derived-value! reaction)
       ;; ONE baseline deref, before the watch — see `acquire-cell!`.
       @reaction
       (add-watch reaction cell-watch-key
                  (fn [_ _ old nu] (when-not (= old nu) (mark-dirty! cell))))
-      (interop/add-on-dispose! reaction (fn [] (invalidate-cell! cell))))
+      (rf.interop/add-on-dispose! reaction (fn [] (invalidate-cell! cell))))
     cell))
 
 (defn- invalidate-cell!
@@ -806,7 +806,7 @@
     (js/setTimeout
       (fn []
         (when-not (.-disposed cell)
-          (if (nil? (frame/frame-incarnation-token (.-frameKw cell)))
+          (if (nil? (rf.frame/frame-incarnation-token (.-frameKw cell)))
             (dispose-cell! cell)
             (do (wire-cell! cell)
                 ;; Re-stamp and notify: a boundary that painted before the
@@ -818,7 +818,7 @@
 
 (defn- first-registration!
   "**The registry transition no disposal announces** (rf2-2rtt6.44
-  audit follow-up). `registrar/add-replacement-hook!` — the hook the
+  audit follow-up). `rf.registrar/add-replacement-hook!` — the hook the
   sub-cache eviction that [[invalidate-cell!]] rides is built on — fires
   only when a previous handler existed. A *first* `reg-sub` for a query
   therefore evicts nothing, disposes nothing, and would reach an arm that
@@ -829,7 +829,7 @@
   query emits `:rf.error/no-such-sub`, recovers to a nil-yielding
   reaction, and **deliberately does not cache it**, precisely so that a
   later registration is observed by the next `subscribe`
-  (`subs/build-and-cache!*`). This arm has exactly one property that
+  (`rf.subs/build-and-cache!*`). This arm has exactly one property that
   breaks that assumption — a cell holds its reaction for the life of
   every boundary reading the key, and never subscribes again — so the
   recovery the substrate declined to cache was cached anyway, in a cell,
@@ -839,7 +839,7 @@
 
   So the repair is to restore the substrate's assumption rather than to
   keep the recovery honest: the same [[invalidate-cell!]] the disposal
-  path uses, off `registrar/add-registration-hook!` — the public sibling
+  path uses, off `rf.registrar/add-registration-hook!` — the public sibling
   that fires on first-time *and* re-registration. Narrowed to the
   first-time case (`:was` nil), because the re-registration case already
   arrives as a disposal and doing it twice would rebuild one attachment
@@ -867,10 +867,10 @@
   [{:keys [kind id was]}]
   (when (and (= :sub kind) (nil? was))
     ;; `first`, not `(nth … 0)`: a registrar hook's throw is SWALLOWED by
-    ;; `registrar/register!`, so an exception here would not surface as a
+    ;; `rf.registrar/register!`, so an exception here would not surface as a
     ;; failure — it would abandon the rest of the scan silently, leaving
     ;; some cells repaired and some not. `(sub [])` is a legal call that
-    ;; reaches a cell (`subs/subscribe` treats a nil query-id as a miss
+    ;; reaches a cell (`rf.subs/subscribe` treats a nil query-id as a miss
     ;; like any other), and `nth` on it would throw.
     (doseq [^js cell (vals @!cells)]
       (when (and (= id (first (.-queryV cell)))
@@ -909,7 +909,7 @@
 ;; every `:sub` one, and the scan above only on a first-time `:sub`.
 #_:clj-kondo/ignore
 (defonce ^:private first-registration-armed
-  (do (registrar/add-registration-hook! sub-registered!) true))
+  (do (rf.registrar/add-registration-hook! sub-registered!) true))
 
 (defn- acquire-cell!
   "**Commit-phase only.** Take (building if necessary) the durable
@@ -1133,7 +1133,7 @@
      (`observation/probe`), and single-threaded CLJS is what makes the
      unguarded deref safe: nothing can evict between the `get` and the
      `@`.
-  2. **A truly cold key computes PURE** — `subs/compute-sub-with-memo`
+  2. **A truly cold key computes PURE** — `rf.subs/compute-sub-with-memo`
      against ONE coherent frame-state snapshot, minted lazily on the
      run's first cold read ([[run-once]] resets the box, so a fence
      re-run or a StrictMode double-invoke computes against the state
@@ -1142,7 +1142,7 @@
      a cache insert, an in-tick evict and a dispose cascade per read,
      this path pays a registrar lookup and the sub's own body. Each
      compute threads a FRESH per-read memo seeded with
-     `subs/observation-opts-key`, so an unregistered query emits the
+     `rf.subs/observation-opts-key`, so an unregistered query emits the
      always-on `:rf.error/no-such-sub` exactly as the reactive build
      does and recovers to the same nil; the run-level dedup lives in
      the box's own value map, where a key already computed this run is
@@ -1163,7 +1163,7 @@
      predecessor's whole behaviour on that edge, kept rather than
      re-spelled.
 
-  The compute sits inside `live-frame/call-with-frame-resolution` for
+  The compute sits inside `rf.live-frame/call-with-frame-resolution` for
   the same two reasons `subscribe` itself does: an image-loaded frame's
   registrar lookups must resolve through that frame's own image, and the
   wrapper's read-time coalesced flush is what makes a `reg-sub` issued
@@ -1182,32 +1182,32 @@
   the port could stake commit-free Tier-1 reads on the equivalence
   first."
   [frame-kw query-v]
-  (let [frame-record (frame/frame frame-kw)]
+  (let [frame-record (rf.frame/frame frame-kw)]
     (if (nil? frame-record)
-      (subs/subscribe-once query-v {:frame frame-kw})
-      (live-frame/call-with-frame-resolution
+      (rf.subs/subscribe-once query-v {:frame frame-kw})
+      (rf.live-frame/call-with-frame-resolution
         frame-kw
         (fn []
           (if-some [r (:reaction (get @(:sub-cache frame-record) query-v))]
             @r
             (let [^js pr (or (.-probe rstate)
-                             (when-some [fs (frame/frame-state-value frame-kw)]
+                             (when-some [fs (rf.frame/frame-state-value frame-kw)]
                                (let [^js fresh #js {"fs" fs "vals" {}}]
                                  (set! (.-probe rstate) fresh)
                                  fresh)))]
               (if (nil? pr)
                 ;; The frame died between the record resolve and the
                 ;; state read — recover exactly as rung 3 does.
-                (subs/subscribe-once query-v {:frame frame-kw})
+                (rf.subs/subscribe-once query-v {:frame frame-kw})
                 ;; `find`, not `get`: a memoised nil (an unregistered
                 ;; query's recovery) is a HIT, and the one emission per
                 ;; distinct unknown key per run rides on that.
                 (if-some [kv (find (unchecked-get pr "vals") query-v)]
                   (val kv)
-                  (let [v (subs/compute-sub-with-memo
+                  (let [v (rf.subs/compute-sub-with-memo
                             query-v
                             (unchecked-get pr "fs")
-                            (atom {subs/observation-opts-key
+                            (atom {rf.subs/observation-opts-key
                                    {:frame frame-kw}}))]
                     (unchecked-set pr "vals"
                                    (assoc (unchecked-get pr "vals") query-v v))
@@ -1575,13 +1575,13 @@
   ;; count is the one that says so.
   (set! (.-bodyRuns rstate) (inc (.-bodyRuns rstate)))
   (when ^boolean js/goog.DEBUG
-    (codec/set-lowering-owner! (unchecked-get body-fn "displayName")))
+    (rf.bench.hicasso.front.codec/set-lowering-owner! (unchecked-get body-fn "displayName")))
   (try
-    (intent/with-frame frame-kw (frame-dispatch frame-kw)
-      (fn [] (codec/as-element (body-fn props))))
+    (rf.bench.hicasso.front.intent/with-frame frame-kw (frame-dispatch frame-kw)
+      (fn [] (rf.bench.hicasso.front.codec/as-element (body-fn props))))
     (finally
       (set! (.-frame rstate) nil)
-      (when ^boolean js/goog.DEBUG (codec/set-lowering-owner! nil)))))
+      (when ^boolean js/goog.DEBUG (rf.bench.hicasso.front.codec/set-lowering-owner! nil)))))
 
 (defn render-body
   "Run a boundary body under the generation fence and return its element;
@@ -1696,7 +1696,7 @@
   [:use-context/frame :use-sync-external-store/subscription-epoch])
 
 (defn- resolve-frame! [frame-kw]
-  (if (or (nil? frame-kw) (= adapter-context/no-provider-sentinel frame-kw))
+  (if (or (nil? frame-kw) (= rf.adapter.context/no-provider-sentinel frame-kw))
     (fail! :rf.error/no-frame-context
            're-frame.bench.hicasso.arm1.runtime/shell
            (str "A Hicasso boundary rendered with no frame in scope. Mount the "
@@ -1711,7 +1711,7 @@
   position of ordinary code around them, and it is what lets the
   subscription hook close over the reads the body just made."
   [body-fn js-props]
-  (let [frame-kw (resolve-frame! (react/useContext adapter-context/frame-context))
+  (let [frame-kw (resolve-frame! (react/useContext rf.adapter.context/frame-context))
         props    (or (unchecked-get js-props "rfProps") {})
         element  (render-body frame-kw body-fn props)
         ^js entry (.-entry rstate)]
@@ -1907,10 +1907,10 @@
   [view-name body-fn]
   (when ^boolean js/goog.DEBUG (unchecked-set body-fn "displayName" view-name))
   (let [component (fn hicasso-boundary [js-props]
-                    (performance/mark-and-measure :render view-name
+                    (rf.performance/mark-and-measure :render view-name
                       (shell body-fn js-props)))]
     (unchecked-set component "displayName" view-name)
-    (codec/memoize-boundary! (codec/mark-boundary! component))))
+    (rf.bench.hicasso.front.codec/memoize-boundary! (rf.bench.hicasso.front.codec/mark-boundary! component))))
 
 (defn mint-frame-prop-view!
   "[[mint-view!]]'s frame-fed twin (rf2-2rtt6.39): the same boundary, the
@@ -1933,11 +1933,11 @@
   [view-name body-fn]
   (when ^boolean js/goog.DEBUG (unchecked-set body-fn "displayName" view-name))
   (let [component (fn hicasso-frame-prop-boundary [js-props]
-                    (performance/mark-and-measure :render view-name
+                    (rf.performance/mark-and-measure :render view-name
                       (frame-prop-shell body-fn js-props)))]
     (unchecked-set component "displayName" view-name)
-    (codec/memoize-boundary!
-      (codec/mark-frame-prop! (codec/mark-boundary! component)))))
+    (rf.bench.hicasso.front.codec/memoize-boundary!
+      (rf.bench.hicasso.front.codec/mark-frame-prop! (rf.bench.hicasso.front.codec/mark-boundary! component)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Retained inventory — honest accounting, not a claimed absence
@@ -2066,7 +2066,7 @@
      :entries    (reduce + 0 (map (fn [[_ v]] (count v)) @!entries))
      :generation (generation)
      :frames     (count @!frame-ops)
-     :codec      (codec/cache-sizes)}))
+     :codec      (rf.bench.hicasso.front.codec/cache-sizes)}))
 
 (defn entry-buckets
   "The read-set entry cache's bucket occupancy — `{:buckets n :max-bucket

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
@@ -20,36 +20,36 @@
   the watch land in the caller's turn (HD-019's door) and what lets these
   tests read the result on the next line."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.codec :as codec]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
             [re-frame.core :as rf]
-            [re-frame.test-support :as test-support]))
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      ;; The map shape, because the residue claims are `async` — a reaper
      ;; horizon is not observable inside one synchronous test body.
      :async?  true
-     :init-fn (fn [] (rt/reset-runtime!))}))
+     :init-fn (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::arm1-runtime)
 
 (defn- seeded!
   ([] (seeded! 3))
-  ([n] (rt/reset-runtime!) (dogfood/make-frame! frame-id n) frame-id))
+  ([n] (rf.bench.hicasso.arm1.runtime/reset-runtime!) (rf.bench.hicasso.front.dogfood/make-frame! frame-id n) frame-id))
 
 (defn- render
-  "Run a body through the shell's own fence, exactly as `rt/shell` does —
+  "Run a body through the shell's own fence, exactly as `rf.bench.hicasso.arm1.runtime/shell` does —
   minus React, which contributes nothing to what is asserted. Returns the
   read-set entry; the element is discarded because no assertion here is
   about markup."
   ([body-fn] (render body-fn {}))
-  ([body-fn props] (rt/render-body frame-id body-fn props) (rt/last-reads)))
+  ([body-fn props] (rf.bench.hicasso.arm1.runtime/render-body frame-id body-fn props) (rf.bench.hicasso.arm1.runtime/last-reads)))
 
-(defn- reads-of [entry] (rt/reads-of entry))
+(defn- reads-of [entry] (rf.bench.hicasso.arm1.runtime/reads-of entry))
 
 (defn- key-of [query] [frame-id query])
 
@@ -63,7 +63,7 @@
   cleanup, and the only record of it anywhere is its membership in the
   reader list of each key it reads."
   [sub-key]
-  (first (rt/cell-readers sub-key)))
+  (first (rf.bench.hicasso.arm1.runtime/cell-readers sub-key)))
 
 ;; ---------------------------------------------------------------------------
 ;; The hook ledger and the retained inventory (HD-020(b))
@@ -72,15 +72,15 @@
 (deftest the-shell-declares-exactly-two-hooks
   (testing "the ≤2 budget is fully consumed by the subscription/epoch hook
            and the frame-context hook, and there is no room left"
-    (is (= 2 (count rt/shell-hook-ledger)))
+    (is (= 2 (count rf.bench.hicasso.arm1.runtime/shell-hook-ledger)))
     (is (= [:use-context/frame :use-sync-external-store/subscription-epoch]
-           rt/shell-hook-ledger))))
+           rf.bench.hicasso.arm1.runtime/shell-hook-ledger))))
 
 (deftest the-shell-retains-no-use-ref-and-no-use-state
   (testing "HD-020(b) bans useRef in the shell; this arm bans per-instance
            render-phase state outright, because that is what makes two
            hooks reachable rather than three"
-    (let [inv    (rt/retained-inventory)
+    (let [inv    (rf.bench.hicasso.arm1.runtime/retained-inventory)
           tokens (into #{} (map :token) (:per-boundary inv))]
       (is (not (contains? tokens :react/use-ref)))
       (is (not (contains? tokens :react/use-state)))
@@ -105,9 +105,9 @@
   [body-fn]
   (let [entry   (render body-fn)
         hits    (volatile! 0)
-        release (rt/commit-boundary! entry (fn [] (vswap! hits inc)))]
+        release (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn [] (vswap! hits inc)))]
     {:entry entry
-     :reg (last (rt/cell-readers (first (rt/reads-of entry))))
+     :reg (last (rf.bench.hicasso.arm1.runtime/cell-readers (first (rf.bench.hicasso.arm1.runtime/reads-of entry))))
      :hits hits
      :release! release}))
 
@@ -116,18 +116,18 @@
   (testing "`sub` outside a boundary is an error, never a silent read of
            whichever frame happened to be ambient"
     (is (thrown-with-msg? js/Error #"outside a boundary render"
-          (rt/sub [:dogfood/remaining])))
+          (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining])))
     (is (thrown-with-msg? js/Error #"outside a boundary render"
-          (rt/use-subs {:r [:dogfood/remaining]})))))
+          (rf.bench.hicasso.arm1.runtime/use-subs {:r [:dogfood/remaining]})))))
 
 (deftest the-collector-records-the-reads-the-body-actually-made
   (seeded! 3)
   (let [entry (render (fn [_]
-                        (let [ids (rt/sub [:dogfood/visible-ids])]
+                        (let [ids (rf.bench.hicasso.arm1.runtime/sub [:dogfood/visible-ids])]
                           [:ul (when (seq ids)
-                                 [:li (str (rt/sub [:dogfood/todo (first ids)]))])])))]
-    (is (:collector? (rt/last-tiers)))
-    (is (not (:grouped? (rt/last-tiers))))
+                                 [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo (first ids)]))])])))]
+    (is (:collector? (rf.bench.hicasso.arm1.runtime/last-tiers)))
+    (is (not (:grouped? (rf.bench.hicasso.arm1.runtime/last-tiers))))
     (is (= #{(key-of [:dogfood/visible-ids]) (key-of [:dogfood/todo 0])}
            (reads-of entry)))))
 
@@ -136,8 +136,8 @@
   (testing "the surface the operator ruled the only acceptable one: a read
            in a loop and a read donated by a plain helper, both landing on
            the enclosing boundary's edge set"
-    (letfn [(label [id] [:span (str (rt/sub [:dogfood/todo id]))])]
-      (let [entry (render (fn [_] [:ul (for [id (rt/sub [:dogfood/visible-ids])]
+    (letfn [(label [id] [:span (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo id]))])]
+      (let [entry (render (fn [_] [:ul (for [id (rf.bench.hicasso.arm1.runtime/sub [:dogfood/visible-ids])]
                                          [:li (label id)])]))]
         (is (= #{(key-of [:dogfood/visible-ids])
                  (key-of [:dogfood/todo 0])
@@ -157,28 +157,28 @@
            Chromium and flagged it across the tournament.
 
            This arm is safe **by construction rather than by care**: the
-           collector window closes around `codec/as-element`, and the codec
+           collector window closes around `rf.bench.hicasso.front.codec/as-element`, and the codec
            is eager everywhere it walks — `expand-seq` drives a seq to
            exhaustion, `realize-children` folds one into a vector, a seq at
            a NATIVE prop position goes through `clj->js`, and
-           `codec/realize-deep` forces one reachable from a BOUNDARY's
+           `rf.bench.hicasso.front.codec/realize-deep` forces one reachable from a BOUNDARY's
            props at the crossing (rf2-2rtt6.45, whose own suite is
            `arm1/boundary-crossing-cljs-test`). So a lazy read is forced
            inside the window by the same pass that turns hiccup into
            elements. This test is what keeps that true: it fails the moment
            the codec call moves outside `run-once`."
     (let [b (mounted! (fn [_]
-                        [:ul (for [id (rt/sub [:dogfood/visible-ids])]
-                               [:li {:key id} (str (rt/sub [:dogfood/todo id]))])]))]
+                        [:ul (for [id (rf.bench.hicasso.arm1.runtime/sub [:dogfood/visible-ids])]
+                               [:li {:key id} (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo id]))])]))]
       (is (= #{(key-of [:dogfood/visible-ids])
                (key-of [:dogfood/todo 0])
                (key-of [:dogfood/todo 1])
                (key-of [:dogfood/todo 2])}
              (reads-of (:entry b)))
           "every row query the lazy seq produced is an edge")
-      (is (= 4 (:edges (rt/stats)))
+      (is (= 4 (:edges (rf.bench.hicasso.arm1.runtime/stats)))
           "and the commit installed all four, not just the eager one")
-      (rt/dispatch! frame-id [:dogfood/toggle 1])
+      (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 1])
       (is (= 1 @(:hits b))
           "a write to a row query the `for` produced re-runs the boundary —
            the half a first render cannot tell you")
@@ -188,8 +188,8 @@
   (seeded! 3)
   (testing "the same property at the root position, where there is no
            enclosing vector to force the walk"
-    (let [entry (render (fn [_] (for [id (rt/sub [:dogfood/visible-ids])]
-                                  [:li {:key id} (str (rt/sub [:dogfood/todo id]))])))]
+    (let [entry (render (fn [_] (for [id (rf.bench.hicasso.arm1.runtime/sub [:dogfood/visible-ids])]
+                                  [:li {:key id} (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo id]))])))]
       (is (= 4 (count (reads-of entry)))))))
 
 (deftest every-read-that-escapes-the-render-is-loud-rather-than-a-missing-edge
@@ -210,18 +210,18 @@
            was quietly not recorded."
     (let [escaped (volatile! nil)]
       ;; 1. a handler closure — the browser invokes it long after render
-      (render (fn [_] [:button {:on-click (fn [] (vreset! escaped (fn [] (rt/sub [:dogfood/remaining]))))}]))
+      (render (fn [_] [:button {:on-click (fn [] (vreset! escaped (fn [] (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))))}]))
       ;; 2. an author-held delay
       (let [d (volatile! nil)]
-        (render (fn [_] (vreset! d (delay (rt/sub [:dogfood/remaining]))) [:li]))
+        (render (fn [_] (vreset! d (delay (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))) [:li]))
         (is (thrown-with-msg? js/Error #"outside a boundary render" @@d)))
       ;; 3. a lazy seq the body stashed rather than returned
       (let [s (volatile! nil)]
-        (render (fn [_] (vreset! s (map (fn [id] (rt/sub [:dogfood/todo id])) (range 3))) [:li]))
+        (render (fn [_] (vreset! s (map (fn [id] (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo id])) (range 3))) [:li]))
         (is (thrown-with-msg? js/Error #"outside a boundary render" (doall @s))))
       ;; 4. the handler, actually called
       (let [h (volatile! nil)]
-        (render (fn [_] (vreset! h (fn [] (rt/sub [:dogfood/remaining]))) [:li]))
+        (render (fn [_] (vreset! h (fn [] (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))) [:li]))
         (is (thrown-with-msg? js/Error #"outside a boundary render" (@h)))))))
 
 (deftest a-conditional-read-is-an-edge-the-collector-simply-does-not-have
@@ -229,10 +229,10 @@
   (testing "law 4 at the authoring surface: the branch that is not taken
            contributes no edge, which is the collector's whole claim"
     (let [taken     (render (fn [{:keys [editable?]}]
-                              [:li (when editable? (rt/sub [:dogfood/draft 1]))])
+                              [:li (when editable? (rf.bench.hicasso.arm1.runtime/sub [:dogfood/draft 1]))])
                             {:editable? true})
           not-taken (render (fn [{:keys [editable?]}]
-                              [:li (when editable? (rt/sub [:dogfood/draft 1]))])
+                              [:li (when editable? (rf.bench.hicasso.arm1.runtime/sub [:dogfood/draft 1]))])
                             {:editable? false})]
       (is (= #{(key-of [:dogfood/draft 1])} (reads-of taken)))
       (is (= #{} (reads-of not-taken))))))
@@ -243,18 +243,18 @@
            branch still costs its edge"
     (let [entry (render (fn [_]
                           (let [{:keys [todo draft]}
-                                (rt/use-subs {:todo  [:dogfood/todo 1]
+                                (rf.bench.hicasso.arm1.runtime/use-subs {:todo  [:dogfood/todo 1]
                                               :draft [:dogfood/draft 1]})]
                             [:li (:title todo) (when (:done? todo) draft)])))]
-      (is (:grouped? (rt/last-tiers)))
-      (is (not (:collector? (rt/last-tiers))))
+      (is (:grouped? (rf.bench.hicasso.arm1.runtime/last-tiers)))
+      (is (not (:collector? (rf.bench.hicasso.arm1.runtime/last-tiers))))
       (is (= #{(key-of [:dogfood/todo 1]) (key-of [:dogfood/draft 1])}
              (reads-of entry))))))
 
 (deftest grouped-returns-the-snapshot-the-body-destructures
   (seeded! 3)
   (let [captured (volatile! nil)]
-    (render (fn [_] (vreset! captured (rt/use-subs {:todo      [:dogfood/todo 1]
+    (render (fn [_] (vreset! captured (rf.bench.hicasso.arm1.runtime/use-subs {:todo      [:dogfood/todo 1]
                                                     :remaining [:dogfood/remaining]}))
               [:li]))
     (is (= {:id 1 :title "todo 1" :done? false} (:todo @captured)))
@@ -270,10 +270,10 @@
            render-phase code mutates the cell table or a subscription
            ref-count, so an abandoned render needs no cleanup because it
            never did anything that would need cleaning"
-    (let [before (rt/stats)]
-      (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                       (str (rt/sub [:dogfood/remaining]))]))
-      (let [after (rt/stats)]
+    (let [before (rf.bench.hicasso.arm1.runtime/stats)]
+      (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                       (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))]))
+      (let [after (rf.bench.hicasso.arm1.runtime/stats)]
         (is (= (:boundaries before) (:boundaries after)) "no boundary registered")
         (is (= (:edges before) (:edges after)) "no edge added")
         (is (= (:cells before) (:cells after)) "no cell built")
@@ -284,21 +284,21 @@
   (testing "PENDING -> RENDERING, which is the abandoned render: there is
            one scratch and never two, so the second run's reads replace
            the first's rather than joining them"
-    (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                     (str (rt/sub [:dogfood/todo 1]))]))
-    (let [entry (render (fn [_] [:li (str (rt/sub [:dogfood/todo 2]))]))]
+    (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                     (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1]))]))
+    (let [entry (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 2]))]))]
       (is (= #{(key-of [:dogfood/todo 2])} (reads-of entry))))))
 
 (deftest a-body-that-throws-leaves-nothing-behind
   (seeded! 3)
-  (let [before (rt/stats)]
+  (let [before (rf.bench.hicasso.arm1.runtime/stats)]
     (is (thrown? js/Error
-          (render (fn [_] (rt/sub [:dogfood/todo 0]) (throw (js/Error. "body"))))))
+          (render (fn [_] (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]) (throw (js/Error. "body"))))))
     (is (= (select-keys before [:boundaries :edges :cell-refs])
-           (select-keys (rt/stats) [:boundaries :edges :cell-refs])))
+           (select-keys (rf.bench.hicasso.arm1.runtime/stats) [:boundaries :edges :cell-refs])))
     (testing "and the next render starts from a clean scratch rather than
              concatenating the throwing run's reads"
-      (let [entry (render (fn [_] [:li (str (rt/sub [:dogfood/remaining]))]))]
+      (let [entry (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))]))]
         (is (= #{(key-of [:dogfood/remaining])} (reads-of entry)))))))
 
 ;; ---------------------------------------------------------------------------
@@ -311,38 +311,38 @@
            `subscribe` identity does not move, so React does not
            re-subscribe and the commit does no work at all — which is the
            survival metric's flat slope seen from the mechanism's side"
-    (let [body  (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                         (str (rt/sub [:dogfood/todo 1]))
-                         (str (rt/sub [:dogfood/remaining]))])
+    (let [body  (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                         (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1]))
+                         (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))])
           a     (render body)
           b     (render body)]
       (is (identical? a b) "one entry, not two")
       (is (identical? (.-subscribe a) (.-subscribe b))
           "and therefore one `subscribe` identity")
-      (is (= 1 (:entries (rt/stats)))))))
+      (is (= 1 (:entries (rf.bench.hicasso.arm1.runtime/stats)))))))
 
 (deftest a-changed-read-set-takes-a-different-subscribe-identity
   (seeded! 3)
   (testing "which is what makes React's own subscribe/cleanup pair perform
            the edge-set replacement — the whole of the allowed operation"
-    (let [wide   (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                                  (str (rt/sub [:dogfood/todo 1]))]))
-          narrow (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))]
+    (let [wide   (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                                  (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1]))]))
+          narrow (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))]
       (is (not (identical? wide narrow)))
       (is (not (identical? (.-subscribe wide) (.-subscribe narrow)))))))
 
 (deftest a-boundary-holds-exactly-the-edges-its-latest-commit-installed
   (seeded! 3)
-  (let [wide    (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                                 (str (rt/sub [:dogfood/todo 1]))]))
-        release (rt/commit-boundary! wide (fn []))]
-    (is (= 2 (:edges (rt/stats))))
+  (let [wide    (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                                 (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1]))]))
+        release (rf.bench.hicasso.arm1.runtime/commit-boundary! wide (fn []))]
+    (is (= 2 (:edges (rf.bench.hicasso.arm1.runtime/stats))))
     (release)
-    (let [narrow  (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
-          release (rt/commit-boundary! narrow (fn []))
+    (let [narrow  (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))
+          release (rf.bench.hicasso.arm1.runtime/commit-boundary! narrow (fn []))
           b       (boundary-reading (key-of [:dogfood/todo 0]))]
-      (is (= 1 (count (rt/boundary-reads b))))
-      (is (empty? (rt/cell-readers (key-of [:dogfood/todo 1])))
+      (is (= 1 (count (rf.bench.hicasso.arm1.runtime/boundary-reads b))))
+      (is (empty? (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:dogfood/todo 1])))
           "and the dropped key has no reader left behind")
       (release))))
 
@@ -360,30 +360,30 @@
            drops nothing, which is asserted so the docstring's claim is
            checkable rather than argued"
     (let [seen (atom [])]
-      (rt/set-evidence-sink!
+      (rf.bench.hicasso.arm1.runtime/set-evidence-sink!
         (fn [e] (when (= :edges-changed (:event e)) (swap! seen conj e))))
       (try
-        (let [wide  (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                                     (str (rt/sub [:dogfood/todo 1]))]))
-              stop  (rt/commit-boundary! wide (fn []))]
-          (is (= 2 (:cell-refs (rt/stats))))
+        (let [wide  (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                                     (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1]))]))
+              stop  (rf.bench.hicasso.arm1.runtime/commit-boundary! wide (fn []))]
+          (is (= 2 (:cell-refs (rf.bench.hicasso.arm1.runtime/stats))))
           ;; React's own sequence when `subscribe` identity moves: the
           ;; previous cleanup, THEN the new entry's subscribe.
           (stop)
-          (is (= 0 (:cell-refs (rt/stats)))
+          (is (= 0 (:cell-refs (rf.bench.hicasso.arm1.runtime/stats)))
               "every reference is dropped, including the key that did not
                change — there is no cheap route for `n-1 of n unchanged`")
-          (let [narrow (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
-                stop2  (rt/commit-boundary! narrow (fn []))
+          (let [narrow (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))
+                stop2  (rf.bench.hicasso.arm1.runtime/commit-boundary! narrow (fn []))
                 b      (boundary-reading (key-of [:dogfood/todo 0]))]
-            (is (= 1 (:cell-refs (rt/stats))) "and re-acquired from nothing")
-            (is (= #{(key-of [:dogfood/todo 0])} (rt/boundary-reads b))
+            (is (= 1 (:cell-refs (rf.bench.hicasso.arm1.runtime/stats))) "and re-acquired from nothing")
+            (is (= #{(key-of [:dogfood/todo 0])} (rf.bench.hicasso.arm1.runtime/boundary-reads b))
                 "the narrowing landed")
-            (is (empty? (rt/cell-readers (key-of [:dogfood/todo 1])))
+            (is (empty? (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:dogfood/todo 1])))
                 "and it landed through the previous cleanup's
                  drop-everything, not through a difference")
             (stop2)))
-        (finally (rt/set-evidence-sink! nil)))
+        (finally (rf.bench.hicasso.arm1.runtime/set-evidence-sink! nil)))
       (is (= 2 (count @seen)) "two commits, two edge-change records")
       (is (every? (comp empty? :dropped) @seen)
           (str "and neither dropped anything: " (pr-str (mapv :dropped @seen))))
@@ -395,11 +395,11 @@
   (testing "the buffer is a sequence and the entry's read set is
            set-valued; the coercion collapses them, so a key read twice
            takes one membership rather than two"
-    (let [entry   (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                                   (str (rt/sub [:dogfood/todo 0]))]))
-          release (rt/commit-boundary! entry (fn []))]
+    (let [entry   (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                                   (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))
+          release (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn []))]
       (is (= 1 (count (reads-of entry))))
-      (is (= 1 (:edges (rt/stats))))
+      (is (= 1 (:edges (rf.bench.hicasso.arm1.runtime/stats))))
       (release))))
 
 ;; ---------------------------------------------------------------------------
@@ -412,8 +412,8 @@
   binding moved is all it takes for a bulk list to be written this way."
   [n]
   (dotimes [i n]
-    (render (fn [_] [:li (str (rt/sub [:dogfood/remaining]))
-                     (str (rt/sub [:dogfood/todo i]))]))))
+    (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))
+                     (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo i]))]))))
 
 (deftest the-bucket-scan-does-not-grow-with-the-number-of-boundaries
   (seeded! 3)
@@ -424,12 +424,12 @@
            quadratic in rf2-2rtt6.46 — so the claim is that the depth does
            not move between the two"
     (render-shared-first-key! 8)
-    (let [small (rt/entry-buckets)]
-      (is (= 8 (:entries (rt/stats))) "eight distinct read sequences, eight entries")
+    (let [small (rf.bench.hicasso.arm1.runtime/entry-buckets)]
+      (is (= 8 (:entries (rf.bench.hicasso.arm1.runtime/stats))) "eight distinct read sequences, eight entries")
       (seeded! 3)
       (render-shared-first-key! 64)
-      (let [large (rt/entry-buckets)]
-        (is (= 64 (:entries (rt/stats))))
+      (let [large (rf.bench.hicasso.arm1.runtime/entry-buckets)]
+        (is (= 64 (:entries (rf.bench.hicasso.arm1.runtime/stats))))
         (is (= 1 (:max-bucket small)))
         (is (= (:max-bucket small) (:max-bucket large))
             (str "the scan is " (:max-bucket large) " deep at 64 rows and "
@@ -446,29 +446,29 @@
            with no other. Two rows reading a per-row key have distinct
            sequences and therefore an entry each — which is why the entry
            is filed per-boundary for the heap ladder (rf2-2rtt6.34)"
-    (let [a (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
-          b (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
-          c (render (fn [_] [:li (str (rt/sub [:dogfood/todo 1]))]))]
+    (let [a (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))
+          b (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))
+          c (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1]))]))]
       (is (identical? a b) "an identical sequence shares one entry")
       (is (not (identical? a c)) "a per-row key does not")
-      (is (= 2 (:entries (rt/stats))))))
+      (is (= 2 (:entries (rf.bench.hicasso.arm1.runtime/stats))))))
   (testing "and the ordered compare is a false negative, never a wrong
            answer: the same SET read in a different ORDER takes a second
            entry with the same key set"
     (seeded! 3)
-    (let [ab (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                              (str (rt/sub [:dogfood/remaining]))]))
-          ba (render (fn [_] [:li (str (rt/sub [:dogfood/remaining]))
-                              (str (rt/sub [:dogfood/todo 0]))]))]
+    (let [ab (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                              (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))]))
+          ba (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))
+                              (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))]
       (is (not (identical? ab ba)))
       (is (= (reads-of ab) (reads-of ba)) "same edges, so the answer is right")
-      (is (= 2 (:entries (rt/stats))) "and the cost is one extra entry"))))
+      (is (= 2 (:entries (rf.bench.hicasso.arm1.runtime/stats))) "and the cost is one extra entry"))))
 
 (deftest the-retained-inventory-files-the-entry-where-a-heap-ladder-must-count-it
   (testing "rf2-2rtt6.46: `:read-set-entry` under `:shared` under-counted
            per-boundary retention by one entry per boundary on exactly the
            distinct-query rung rf2-2rtt6.34 is taken on"
-    (let [inv    (rt/retained-inventory)
+    (let [inv    (rf.bench.hicasso.arm1.runtime/retained-inventory)
           per-b  (into #{} (map :token) (:per-boundary inv))
           shared (into #{} (map :token) (:shared inv))]
       (is (contains? per-b :read-set-entry))
@@ -482,7 +482,7 @@
            must count one slot per read, not a forward-edge map entry
            plus a reverse-edge set membership plus the singleton set the
            second map retained per key at fan-out 1"
-    (let [per-b (into #{} (map :token) (:per-boundary (rt/retained-inventory)))]
+    (let [per-b (into #{} (map :token) (:per-boundary (rf.bench.hicasso.arm1.runtime/retained-inventory)))]
       (is (contains? per-b :cell/reader-membership))
       (is (not (contains? per-b :index/b->subs)))
       (is (not (contains? per-b :index/sub->bs))))))
@@ -493,13 +493,13 @@
 
 (deftest a-narrow-write-notifies-exactly-the-boundary-that-read-it
   (seeded! 3)
-  (let [a (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
-        b (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 1]))]))]
+  (let [a (mounted! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))
+        b (mounted! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1]))]))]
     (is (= #{(key-of [:dogfood/todo 0])} (reads-of (:entry a))))
     (is (= #{(key-of [:dogfood/todo 1])} (reads-of (:entry b))))
-    (is (= [(:reg a)] (rt/cell-readers (key-of [:dogfood/todo 0]))))
-    (is (= [(:reg b)] (rt/cell-readers (key-of [:dogfood/todo 1]))))
-    (rt/dispatch! frame-id [:dogfood/toggle 0])
+    (is (= [(:reg a)] (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:dogfood/todo 0]))))
+    (is (= [(:reg b)] (rf.bench.hicasso.arm1.runtime/cell-readers (key-of [:dogfood/todo 1]))))
+    (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 0])
     (is (= 1 @(:hits a)) "the reader of the moved subscription re-runs")
     (is (= 0 @(:hits b)) "and nothing else does")
     ((:release! a))
@@ -507,9 +507,9 @@
 
 (deftest two-boundaries-sharing-a-subscription-both-run
   (seeded! 3)
-  (let [a (mounted! (fn [_] [:span (str (rt/sub [:dogfood/remaining]))]))
-        b (mounted! (fn [_] [:span (str (rt/sub [:dogfood/remaining]))]))]
-    (is (= 1 (:cells (rt/stats)))
+  (let [a (mounted! (fn [_] [:span (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))]))
+        b (mounted! (fn [_] [:span (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))]))]
+    (is (= 1 (:cells (rf.bench.hicasso.arm1.runtime/stats)))
         "ONE cell for the shared key, holding two references — and that is
          also what lets `cell-watch-key` be a single namespaced constant
          rather than an identity minted per cell (rf2-aqgr2). A watch key
@@ -518,8 +518,8 @@
          cell's watch. Mint a cell per reader instead and this row goes
          red: two cells on one reaction, and the second `add-watch`
          silently replacing the first's")
-    (is (= 2 (:cell-refs (rt/stats))))
-    (rt/dispatch! frame-id [:dogfood/toggle 0])
+    (is (= 2 (:cell-refs (rf.bench.hicasso.arm1.runtime/stats))))
+    (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 0])
     (is (= 1 @(:hits a)))
     (is (= 1 @(:hits b)))
     ((:release! a))
@@ -527,41 +527,41 @@
 
 (deftest an-unmounted-boundary-is-never-notified-again
   (seeded! 3)
-  (let [a (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))]
+  (let [a (mounted! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))]
     ((:release! a))
-    (rt/dispatch! frame-id [:dogfood/toggle 0])
+    (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 0])
     (is (= 0 @(:hits a)))))
 
 (deftest a-write-that-moves-nothing-notifies-nobody
   (seeded! 3)
-  (let [a (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
-        g (rt/generation)]
+  (let [a (mounted! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))
+        g (rf.bench.hicasso.arm1.runtime/generation)]
     ;; `:dogfood/commit` on a row with no draft is a no-op by construction.
-    (rt/dispatch! frame-id [:dogfood/commit 0])
+    (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/commit 0])
     (is (= 0 @(:hits a)))
-    (is (= g (rt/generation)) "and does not move the generation")
+    (is (= g (rf.bench.hicasso.arm1.runtime/generation)) "and does not move the generation")
     ((:release! a))))
 
 (deftest one-commit-window-is-one-flush-however-many-subscriptions-moved
   (seeded! 3)
-  (let [a (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                             (str (rt/sub [:dogfood/remaining]))]))
-        g (rt/generation)]
-    (rt/with-commit (fn []
+  (let [a (mounted! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                             (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))]))
+        g (rf.bench.hicasso.arm1.runtime/generation)]
+    (rf.bench.hicasso.arm1.runtime/with-commit (fn []
                       (rf/with-frame frame-id (rf/dispatch-sync [:dogfood/toggle 0]))
                       (rf/with-frame frame-id (rf/dispatch-sync [:dogfood/toggle 1]))))
     (is (= 1 @(:hits a)) "one notification, not one per moved subscription")
-    (is (= (inc g) (rt/generation)) "and one generation, not two")
+    (is (= (inc g) (rf.bench.hicasso.arm1.runtime/generation)) "and one generation, not two")
     ((:release! a))))
 
 (deftest a-warm-read-performs-no-new-attach-or-release
   (seeded! 3)
   (testing "validation.md's standing assertion, stated as a reference
            count that does not move across a re-render"
-    (let [a      (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
-          before (:cell-refs (rt/stats))]
-      (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
-      (is (= before (:cell-refs (rt/stats))))
+    (let [a      (mounted! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))
+          before (:cell-refs (rf.bench.hicasso.arm1.runtime/stats))]
+      (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))]))
+      (is (= before (:cell-refs (rf.bench.hicasso.arm1.runtime/stats))))
       ((:release! a)))))
 
 ;; ---------------------------------------------------------------------------
@@ -575,13 +575,13 @@
   (let [runs       (volatile! 0)
         first-read (volatile! nil)
         seen       (volatile! nil)
-        warm       (mounted! (fn [_] [:li (str (rt/sub [:dogfood/done? 0]))]))
+        warm       (mounted! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/done? 0]))]))
         entry      (render (fn [_]
                           (vswap! runs inc)
-                          (vreset! first-read (rt/sub [:dogfood/done? 0]))
+                          (vreset! first-read (rf.bench.hicasso.arm1.runtime/sub [:dogfood/done? 0]))
                           (when (= 1 @runs)
-                            (rt/dispatch! frame-id [:dogfood/toggle 0]))
-                          (vreset! seen (rt/sub [:dogfood/done? 0]))
+                            (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 0]))
+                          (vreset! seen (rf.bench.hicasso.arm1.runtime/sub [:dogfood/done? 0]))
                           [:li (str @seen)]))]
     (is (= 2 @runs) "the fence re-ran the body against the newer commit")
     (is (true? @seen) "and the winning run read the committed value")
@@ -595,28 +595,28 @@
   (seeded! 3)
   (testing "the fence is a ceiling, not a budget — an unfenceable body is
            a write loop and says so"
-    (let [warm (mounted! (fn [_] [:li (str (rt/sub [:dogfood/done? 0]))]))]
+    (let [warm (mounted! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/done? 0]))]))]
       (is (thrown-with-msg? js/Error #"generation-fence-exhausted"
             (render (fn [_]
-                      (rt/sub [:dogfood/done? 0])
-                      (rt/dispatch! frame-id [:dogfood/toggle 0])
-                      [:li (str (rt/sub [:dogfood/done? 0]))]))))
+                      (rf.bench.hicasso.arm1.runtime/sub [:dogfood/done? 0])
+                      (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 0])
+                      [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/done? 0]))]))))
       ((:release! warm)))))
 
 (deftest a-body-that-reads-without-writing-never-moves-the-generation
   (seeded! 3)
-  (let [g (rt/generation)]
-    (render (fn [_] [:li (str (rt/sub [:dogfood/remaining]))]))
-    (is (= g (rt/generation)))))
+  (let [g (rf.bench.hicasso.arm1.runtime/generation)]
+    (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))]))
+    (is (= g (rf.bench.hicasso.arm1.runtime/generation)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Boundaries, heads, and the ABI
 ;; ---------------------------------------------------------------------------
 
 (deftest a-minted-view-is-a-legal-hiccup-head
-  (let [v (rt/mint-view! "test/probe" (fn [_] [:li]))]
+  (let [v (rf.bench.hicasso.arm1.runtime/mint-view! "test/probe" (fn [_] [:li]))]
     (is (fn? v))
-    (is (codec/boundary-head? v))
+    (is (rf.bench.hicasso.front.codec/boundary-head? v))
     (is (= "test/probe" (.-displayName v)))
     (is (true? (unchecked-get v "hicassoBoundary"))
         "the codec's own boundary marker, so a view is a head by
@@ -628,7 +628,7 @@
            and a minted head must stay a function — so the wrapper is
            attached to the head rather than returned in its place, and no
            memo object escapes as the public representation"
-    (let [v (rt/mint-view! "test/memo-probe" (fn [_] [:li]))
+    (let [v (rf.bench.hicasso.arm1.runtime/mint-view! "test/memo-probe" (fn [_] [:li]))
           m (unchecked-get v "hicassoMemo")]
       (is (fn? v) "the head is still the function it always was")
       (is (some? m) "and it carries a wrapper")
@@ -646,21 +646,21 @@
 (deftest a-released-boundary-leaves-no-edge-and-no-reference
   (async done
     (seeded! 3)
-    (let [a (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                               (str (rt/sub [:dogfood/remaining]))]))]
-      (is (= 1 (:boundaries (rt/stats))))
-      (is (= 2 (:edges (rt/stats))))
-      (is (= 2 (:cell-refs (rt/stats))))
+    (let [a (mounted! (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                               (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))]))]
+      (is (= 1 (:boundaries (rf.bench.hicasso.arm1.runtime/stats))))
+      (is (= 2 (:edges (rf.bench.hicasso.arm1.runtime/stats))))
+      (is (= 2 (:cell-refs (rf.bench.hicasso.arm1.runtime/stats))))
       ((:release! a))
-      (is (= 0 (:boundaries (rt/stats))))
-      (is (= 0 (:edges (rt/stats))))
-      (is (= 0 (:cell-refs (rt/stats))))
+      (is (= 0 (:boundaries (rf.bench.hicasso.arm1.runtime/stats))))
+      (is (= 0 (:edges (rf.bench.hicasso.arm1.runtime/stats))))
+      (is (= 0 (:cell-refs (rf.bench.hicasso.arm1.runtime/stats))))
       ;; The cells and the cached entry are reaped one macrotask later —
       ;; the grace that lets a keyed reorder reuse a reaction instead of
       ;; rebuilding it.
       (js/setTimeout (fn []
                        (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                              (rt/residue))
+                              (rf.bench.hicasso.arm1.runtime/residue))
                            "nothing survives the macrotask horizon")
                        (done))
                      8))))
@@ -671,13 +671,13 @@
     ;; The abandoned-render class. Acquisition is commit-owned, so there is
     ;; nothing to unwind — and the cached entry a discarded render minted is
     ;; a cache, dropped at the macrotask horizon rather than undone.
-    (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                     (str (rt/sub [:dogfood/todo 1]))]))
-    (is (= 0 (:boundaries (rt/stats))) "no boundary was ever registered")
-    (is (= 0 (:cell-refs (rt/stats))) "and no reference was ever taken")
-    (is (= 0 (:cells (rt/stats))) "and no cell was ever built")
+    (render (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                     (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 1]))]))
+    (is (= 0 (:boundaries (rf.bench.hicasso.arm1.runtime/stats))) "no boundary was ever registered")
+    (is (= 0 (:cell-refs (rf.bench.hicasso.arm1.runtime/stats))) "and no reference was ever taken")
+    (is (= 0 (:cells (rf.bench.hicasso.arm1.runtime/stats))) "and no cell was ever built")
     (js/setTimeout (fn []
                      (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                            (rt/residue)))
+                            (rf.bench.hicasso.arm1.runtime/residue)))
                      (done))
                    8)))

--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/staged_read_tear_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/staged_read_tear_cljs_test.cljs
@@ -82,22 +82,22 @@
   remaining rows are what stops the repair from being \"re-render
   always\": a clean mount must ask React for nothing."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
-            [re-frame.frame :as frame]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
+            [re-frame.frame :as rf.frame]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
-     :init-fn (fn [] (rt/reset-runtime!))}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
+     :init-fn (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::arm1-staged-tear)
 
 (defn- seeded! []
-  (rt/reset-runtime!)
-  (dogfood/make-frame! frame-id 3)
+  (rf.bench.hicasso.arm1.runtime/reset-runtime!)
+  (rf.bench.hicasso.front.dogfood/make-frame! frame-id 3)
   frame-id)
 
 (defn- render
@@ -105,15 +105,15 @@
   the read-set entry — the object React's `subscribe` and `getSnapshot`
   hang off."
   [body-fn]
-  (rt/render-body frame-id body-fn {})
-  (rt/last-reads))
+  (rf.bench.hicasso.arm1.runtime/render-body frame-id body-fn {})
+  (rf.bench.hicasso.arm1.runtime/last-reads))
 
 (defn- done-row
   "A boundary reading one row's done? flag, and recording what it read.
   The read is the whole body, so the boundary's read set is one key and
   the arithmetic below is one term."
   [seen]
-  (fn [_] (let [v (rt/sub [:dogfood/done? 0])] (vreset! seen v) [:li (str v)])))
+  (fn [_] (let [v (rf.bench.hicasso.arm1.runtime/sub [:dogfood/done? 0])] (vreset! seen v) [:li (str v)])))
 
 ;; ---------------------------------------------------------------------------
 ;; The tear, and its repair
@@ -130,25 +130,25 @@
     (let [seen  (volatile! nil)
           entry (render (done-row seen))]
       (is (false? @seen) "the render read, and this is what it put on screen")
-      (is (zero? (:cells (rt/stats)))
+      (is (zero? (:cells (rf.bench.hicasso.arm1.runtime/stats)))
           "STAGED, not retained: nothing holds this key, so there is no
            cell, no watch and no epoch — `commit-boundary!` below is the
            first acquisition")
-      (let [at-render  (rt/snapshot-of entry)
-            generation (rt/generation)
-            frame-e    (frame/frame-commit-epoch frame-id)]
+      (let [at-render  (rf.bench.hicasso.arm1.runtime/snapshot-of entry)
+            generation (rf.bench.hicasso.arm1.runtime/generation)
+            frame-e    (rf.frame/frame-commit-epoch frame-id)]
         ;; THE GAP.
-        (rt/dispatch! frame-id [:dogfood/toggle 0])
-        (is (= generation (rt/generation))
+        (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 0])
+        (is (= generation (rf.bench.hicasso.arm1.runtime/generation))
             "the generation did NOT move — there was no watch to fire, so
              the change happened within one generation, which is precisely
              the witness §6.1 asks for")
-        (is (> (frame/frame-commit-epoch frame-id) frame-e)
+        (is (> (rf.frame/frame-commit-epoch frame-id) frame-e)
             "but the frame's own physical-install epoch did, and it moved
              without anybody watching anything")
         ;; THE COMMIT: React calls the entry's `subscribe`.
-        (let [release! (rt/commit-boundary! entry (fn []))]
-          (is (not= at-render (rt/snapshot-of entry))
+        (let [release! (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn []))]
+          (is (not= at-render (rf.bench.hicasso.arm1.runtime/snapshot-of entry))
               "so the number React stored at render is not the number it
                re-reads after `subscribe` — `updateStoreInstance` finds a
                moved store and schedules the boundary")
@@ -171,13 +171,13 @@
     (seeded!)
     (let [seen  (volatile! nil)
           entry (render (done-row seen))]
-      (rt/dispatch! frame-id [:dogfood/toggle 0])
+      (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 0])
       (let [hits     (volatile! 0)
-            release! (rt/commit-boundary! entry (fn [] (vswap! hits inc)))]
+            release! (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn [] (vswap! hits inc)))]
         (is (= 0 @hits)
             "the commit notified nobody — the watch was armed one move too
              late to have reported it")
-        (rt/dispatch! frame-id [:dogfood/commit 0])
+        (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/commit 0])
         (is (= 0 @hits)
             "and a later write that moves nothing brings no correction
              either: the ordinary invalidation path is done with this
@@ -191,9 +191,9 @@
            in the application pays a second render."
     (seeded!)
     (let [entry     (render (done-row (volatile! nil)))
-          at-render (rt/snapshot-of entry)
-          release!  (rt/commit-boundary! entry (fn []))]
-      (is (= at-render (rt/snapshot-of entry))
+          at-render (rf.bench.hicasso.arm1.runtime/snapshot-of entry)
+          release!  (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn []))]
+      (is (= at-render (rf.bench.hicasso.arm1.runtime/snapshot-of entry))
           "acquisition alone moves nothing: the cell is born at the same
            basis the staged term reported")
       (release!))))
@@ -208,15 +208,15 @@
            increases."
     (seeded!)
     (let [warm  (render (done-row (volatile! nil)))
-          hold! (rt/commit-boundary! warm (fn []))]
-      (is (= 1 (:cells (rt/stats))) "RETAINED: an earlier commit holds the key")
+          hold! (rf.bench.hicasso.arm1.runtime/commit-boundary! warm (fn []))]
+      (is (= 1 (:cells (rf.bench.hicasso.arm1.runtime/stats))) "RETAINED: an earlier commit holds the key")
       (let [entry      (render (done-row (volatile! nil)))
-            at-render  (rt/snapshot-of entry)
-            generation (rt/generation)]
-        (rt/dispatch! frame-id [:dogfood/toggle 0])
-        (is (= (inc generation) (rt/generation))
+            at-render  (rf.bench.hicasso.arm1.runtime/snapshot-of entry)
+            generation (rf.bench.hicasso.arm1.runtime/generation)]
+        (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 0])
+        (is (= (inc generation) (rf.bench.hicasso.arm1.runtime/generation))
             "the pre-existing watch fired, so the generation moved here")
-        (is (not= at-render (rt/snapshot-of entry))
+        (is (not= at-render (rf.bench.hicasso.arm1.runtime/snapshot-of entry))
             "and the epoch sum moved with it")
         (hold!)))))
 
@@ -239,10 +239,10 @@
           then-  (volatile! nil)]
       (render (fn [_]
                 (vswap! runs inc)
-                (vreset! first- (rt/sub [:dogfood/done? 0]))
+                (vreset! first- (rf.bench.hicasso.arm1.runtime/sub [:dogfood/done? 0]))
                 (when (= 1 @runs)
-                  (rt/dispatch! frame-id [:dogfood/toggle 0]))
-                (vreset! then- (rt/sub [:dogfood/done? 0]))
+                  (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:dogfood/toggle 0]))
+                (vreset! then- (rf.bench.hicasso.arm1.runtime/sub [:dogfood/done? 0]))
                 [:li (str @then-)]))
       (is (= 2 @runs) "the fence re-ran the body against the newer commit")
       (is (= @first- @then-)
@@ -260,10 +260,10 @@
            summed — no second scratch, nothing keyed by a render or an
            attempt, no per-read object, and no commit-phase deref of a
            subscription value."
-    (is (= 2 (count rt/shell-hook-ledger))
+    (is (= 2 (count rf.bench.hicasso.arm1.runtime/shell-hook-ledger))
         "still two hooks; the repair rides `useSyncExternalStore`'s own
          snapshot re-check rather than buying a third")
-    (let [inv (rt/retained-inventory)]
+    (let [inv (rf.bench.hicasso.arm1.runtime/retained-inventory)]
       (is (= #{:use-ref :use-state :view-cell :candidate-ledger}
              (into #{} (map :token) (:absent inv)))
           "the enumerated absences are unchanged")))
@@ -271,9 +271,9 @@
            which is the clause the repair had to stay inside: the staged
            term is READ from the frame, never recorded by the render"
     (seeded!)
-    (let [before (rt/stats)]
+    (let [before (rf.bench.hicasso.arm1.runtime/stats)]
       (render (done-row (volatile! nil)))
-      (let [after (rt/stats)]
+      (let [after (rf.bench.hicasso.arm1.runtime/stats)]
         (is (= (:cells before) (:cells after)) "no cell built")
         (is (= (:cell-refs before) (:cell-refs after)) "no reference taken")
         (is (= (:boundaries before) (:boundaries after)) "no boundary registered")

--- a/bench/hicasso/src/re_frame/bench/hicasso/bench_bytes.test.cjs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/bench_bytes.test.cjs
@@ -25,7 +25,7 @@
 //
 // So the split is by RUNTIME and not by taste:
 //
-//   lane_bytes_cljs_test.cljs   what `lane/utf8-bytes` computes — browser-safe,
+//   lane_bytes_cljs_test.cljs   what `rf.bench.hicasso.lane/utf8-bytes` computes — browser-safe,
 //                               discriminating fixtures, both directions
 //   THIS FILE                   that every repaired site calls it — Node, source
 //                               text, both polarities
@@ -85,19 +85,19 @@ function src(rel) {
 // the alignment, so a half-edit that left `(count …)` in one arm of a `#js`
 // literal cannot satisfy it.
 const CONVERTED = {
-  'clock_app.cljs': ':bytes (lane/utf8-bytes s)',
-  'hd8_clock_app.cljs': ':bytes   (lane/utf8-bytes s)',
-  'shapes/census_clock_app.cljs': ':bytes   (lane/utf8-bytes s)',
-  'walk_profile_app.cljs': ':bytes (lane/utf8-bytes canon-real)',
-  'walk_vs_reagent_app.cljs': ':bytes    (lane/utf8-bytes canon)',
-  'ssr/spike_cljs_test.cljs': ':bytes        (lane/utf8-bytes (:document a))',
-  'ssr/spike_dom_cljs_test.cljs': ':canonical-bytes  (lane/utf8-bytes hydrated-dom)',
+  'clock_app.cljs': ':bytes (rf.bench.hicasso.lane/utf8-bytes s)',
+  'hd8_clock_app.cljs': ':bytes   (rf.bench.hicasso.lane/utf8-bytes s)',
+  'shapes/census_clock_app.cljs': ':bytes   (rf.bench.hicasso.lane/utf8-bytes s)',
+  'walk_profile_app.cljs': ':bytes (rf.bench.hicasso.lane/utf8-bytes canon-real)',
+  'walk_vs_reagent_app.cljs': ':bytes    (rf.bench.hicasso.lane/utf8-bytes canon)',
+  'ssr/spike_cljs_test.cljs': ':bytes        (rf.bench.hicasso.lane/utf8-bytes (:document a))',
+  'ssr/spike_dom_cljs_test.cljs': ':canonical-bytes  (rf.bench.hicasso.lane/utf8-bytes hydrated-dom)',
   'ssr/instance_key_payload_dom_cljs_test.cljs':
-    ':green-edn-bytes (lane/utf8-bytes (:payload-edn green))',
+    ':green-edn-bytes (rf.bench.hicasso.lane/utf8-bytes (:payload-edn green))',
 };
 
 for (const [file, expr] of Object.entries(CONVERTED)) {
-  test(`${file} publishes its byte figure through lane/utf8-bytes`, () => {
+  test(`${file} publishes its byte figure through rf.bench.hicasso.lane/utf8-bytes`, () => {
     assert(src(file).includes(expr), `${file} must read \`${expr}\``);
   });
 }
@@ -105,7 +105,7 @@ for (const [file, expr] of Object.entries(CONVERTED)) {
 test('instance_key_payload also converts the RED arm, not just the green one', () => {
   assert(
     src('ssr/instance_key_payload_dom_cljs_test.cljs').includes(
-      ':red-edn-bytes   (lane/utf8-bytes (:payload-edn red))',
+      ':red-edn-bytes   (rf.bench.hicasso.lane/utf8-bytes (:payload-edn red))',
     ),
     'the red row is half of the obligation witness and is measured the same way',
   );
@@ -174,7 +174,7 @@ test('keywarn_elision asks the FILE for its size, not the decoded string', () =>
 // The helper itself
 // ---------------------------------------------------------------------------
 
-test('lane/utf8-bytes is TextEncoder, which carries no encoding to drop', () => {
+test('rf.bench.hicasso.lane/utf8-bytes is TextEncoder, which carries no encoding to drop', () => {
   // `driver.cjs`'s `utf8Bytes` has to name `'utf8'` explicitly and
   // `bake_bytes.test.cjs` pins that spelling, because `Buffer.byteLength`
   // takes an encoding a later edit could silently change. `TextEncoder`
@@ -190,12 +190,12 @@ test('lane/utf8-bytes is TextEncoder, which carries no encoding to drop', () => 
 });
 
 test('the lane helper is reachable from every file that claims to use it', () => {
-  // A require check, so a converted site cannot read `lane/utf8-bytes` while
+  // A require check, so a converted site cannot read `rf.bench.hicasso.lane/utf8-bytes` while
   // aliasing some other namespace to `lane`.
   for (const file of Object.keys(CONVERTED)) {
     assert(
-      /\[re-frame\.bench\.hicasso\.lane :as lane\]/.test(src(file)),
-      `${file} must alias the lane namespace as \`lane\``,
+      /\[re-frame\.bench\.hicasso\.lane :as rf\.bench\.hicasso\.lane\]/.test(src(file)),
+      `${file} must alias the lane namespace as \`rf.bench.hicasso.lane\``,
     );
   }
 });

--- a/bench/hicasso/src/re_frame/bench/hicasso/chrome_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/chrome_app.cljs
@@ -5,7 +5,7 @@
   HD-028 makes a value-equality bail-out the boundary default. The ruling
   made it conditional on a measurement rather than on the repair being
   obviously right: the default lands only if it removes the 300-row
-  cascade **without a material mount/bulk regression and without pushing
+  cascade **without a material rf.bench.hicasso.arm1.mount/bulk regression and without pushing
   retained heap meaningfully farther past the bar** — because the
   comparator takes React's full `MemoComponent` path and adds an outer
   Fiber per boundary, and the R=0 shell already reads ~1.14 KB against a
@@ -55,13 +55,13 @@
   followed the mutation, so the reading includes the paint either way.
 
   Runs under `:advanced`, which is the production build the bar names."
-  (:require [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.codec :as codec]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.shapes.card :as card]
-            [re-frame.bench.hicasso.shapes.model :as m]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.shapes.card :as rf.bench.hicasso.shapes.card]
+            [re-frame.bench.hicasso.shapes.model :as rf.bench.hicasso.shapes.model]
             [re-frame.core :as rf]
             ["react-dom" :as react-dom]))
 
@@ -81,9 +81,9 @@
   component and no wrapper. Reproduced here rather than described, so the
   `:plain` arm is the old runtime and not an impression of it."
   [view-name body-fn]
-  (let [component (fn hicasso-boundary [js-props] (rt/shell body-fn js-props))]
+  (let [component (fn hicasso-boundary [js-props] (rf.bench.hicasso.arm1.runtime/shell body-fn js-props))]
     (unchecked-set component "displayName" view-name)
-    (codec/mark-boundary! component)))
+    (rf.bench.hicasso.front.codec/mark-boundary! component)))
 
 ;; ---------------------------------------------------------------------------
 ;; Bodies — shared by both arms, so only the mint differs
@@ -102,7 +102,7 @@
   comparator the question that op asks."
   [{:keys [slug]}]
   (swap! !cards inc)
-  (card/card slug))
+  (rf.bench.hicasso.shapes.card/card slug))
 
 (defn- page-body
   "The feed page. Reads the tab (the chrome the `:chrome` op writes), the
@@ -110,8 +110,8 @@
   [card-head]
   (fn page-body* [_]
     (swap! !pages inc)
-    (let [your-feed? (rt/sub [:conduit/your-feed?])
-          rev        (rt/sub [:conduit/page])]
+    (let [your-feed? (rf.bench.hicasso.arm1.runtime/sub [:conduit/your-feed?])
+          rev        (rf.bench.hicasso.arm1.runtime/sub [:conduit/page])]
       [:div.home-page
        [:div.banner [:div.container [:h1.logo-font "conduit"]]]
        [:div.container.page
@@ -127,23 +127,23 @@
                            :class       (when-not your-feed? "active")} "Global Feed"]]]]
           [:div.article-list {:data-testid "article-list"}
            (into [:<>]
-                 (for [slug (rt/sub [:conduit/slugs])]
+                 (for [slug (rf.bench.hicasso.arm1.runtime/sub [:conduit/slugs])]
                    [card-head {:key slug :slug slug :rev rev}]))]]
          [:div.col-md-3
           [:div.sidebar
            [:div.tag-list
             (into [:<>]
-                  (for [tag (rt/sub [:conduit/tags])]
+                  (for [tag (rf.bench.hicasso.arm1.runtime/sub [:conduit/tags])]
                     [:a.tag-pill {:key tag} tag]))]]]]]])))
 
 ;; ---------------------------------------------------------------------------
 ;; The arms
 ;; ---------------------------------------------------------------------------
 
-(def ^:private memo-card (rt/mint-view! "chrome/memo-card" card-body))
+(def ^:private memo-card (rf.bench.hicasso.arm1.runtime/mint-view! "chrome/memo-card" card-body))
 (def ^:private plain-card (plain-view "chrome/plain-card" card-body))
 
-(def ^:private memo-page (rt/mint-view! "chrome/memo-page" (page-body memo-card)))
+(def ^:private memo-page (rf.bench.hicasso.arm1.runtime/mint-view! "chrome/memo-page" (page-body memo-card)))
 (def ^:private plain-page (plain-view "chrome/plain-page" (page-body plain-card)))
 
 (def ^:private arms
@@ -169,8 +169,8 @@
   (get-in (swap! state update-in [:ops arm-id] (fnil inc 0)) [:ops arm-id]))
 
 (defn- seed! [arm]
-  (m/make-frame! (:frame arm) {:articles cards-n :tags tags-n})
-  (m/reseed! (:frame arm) {:articles cards-n :tags tags-n})
+  (rf.bench.hicasso.shapes.model/make-frame! (:frame arm) {:articles cards-n :tags tags-n})
+  (rf.bench.hicasso.shapes.model/reseed! (:frame arm) {:articles cards-n :tags tags-n})
   nil)
 
 (defn- settle-frame
@@ -189,14 +189,14 @@
 (defn- mount-arm!
   "Cold-mount one arm. The container is created OUTSIDE the window."
   [arm]
-  (let [container (lane/fresh-container!)
+  (let [container (rf.bench.hicasso.lane/fresh-container!)
         handle    (volatile! nil)
-        t0        (lane/now-ms)]
+        t0        (rf.bench.hicasso.lane/now-ms)]
     (react-dom/flushSync
-      (fn [] (vreset! handle (mount/root! container (:frame arm) [(:page arm) {}]))))
+      (fn [] (vreset! handle (rf.bench.hicasso.arm1.mount/root! container (:frame arm) [(:page arm) {}]))))
     (-> (settle-frame)
         (.then (fn [_]
-                 (let [ms (- (lane/now-ms) t0)]
+                 (let [ms (- (rf.bench.hicasso.lane/now-ms) t0)]
                    (swap! state assoc-in [:mounted (:id arm)] @handle)
                    {:ms ms}))))))
 
@@ -205,17 +205,17 @@
   body counts the write produced."
   [arm event]
   (reset-runs!)
-  (let [t0 (lane/now-ms)]
-    (rt/dispatch! (:frame arm) event)
+  (let [t0 (rf.bench.hicasso.lane/now-ms)]
+    (rf.bench.hicasso.arm1.runtime/dispatch! (:frame arm) event)
     (react-dom/flushSync (fn [] nil))
     (-> (settle-frame)
-        (.then (fn [_] (merge {:ms (- (lane/now-ms) t0)} (runs)))))))
+        (.then (fn [_] (merge {:ms (- (rf.bench.hicasso.lane/now-ms) t0)} (runs)))))))
 
 (defn- op-event [op op-n]
   (case op
     :chrome (if (odd? op-n) [:conduit/show-your-feed] [:conduit/show-global-feed])
     :bulk   [:conduit/refresh-feed]
-    :narrow [:conduit/favorite (:slug (m/article (mod (* 7 op-n) cards-n)))]
+    :narrow [:conduit/favorite (:slug (rf.bench.hicasso.shapes.model/article (mod (* 7 op-n) cards-n)))]
     ;; STRICTLY INCREASING, and above any seeded value. `(inc (mod op-n
     ;; 5))` cycled, and the frame is reseeded every round — so the write
     ;; periodically set the page number the page already had, app-db did
@@ -227,7 +227,7 @@
 
 (defn- release-arm! [arm]
   (when-some [h (get-in @state [:mounted (:id arm)])]
-    (mount/unmount! h)
+    (rf.bench.hicasso.arm1.mount/unmount! h)
     (swap! state update :mounted dissoc (:id arm)))
   nil)
 
@@ -244,7 +244,7 @@
                    #js {"ms"         ms
                         "boundaries" (inc cards-n)
                         "cards"      (.-length (.querySelectorAll container ".article-preview"))
-                        "elements"   (lane/element-count container)}))))))
+                        "elements"   (rf.bench.hicasso.lane/element-count container)}))))))
 
 (defn ^:export runOp [arm-id op-name]
   (let [arm (arm-of arm-id)
@@ -255,10 +255,10 @@
 
 (defn ^:export releaseArm [arm-id]
   (release-arm! (arm-of arm-id))
-  (-> (lane/settle!) (.then (fn [_] #js {"ok" true}))))
+  (-> (rf.bench.hicasso.lane/settle!) (.then (fn [_] #js {"ok" true}))))
 
 (defn ^:export residue []
-  (let [r (rt/residue)]
+  (let [r (rf.bench.hicasso.arm1.runtime/residue)]
     #js {"cells" (:cells r) "boundaries" (:boundaries r) "edges" (:edges r)}))
 
 (defn ^:export resetRuntime
@@ -273,10 +273,10 @@
   []
   (doseq [a (vals arms)]
     (try (rf/destroy-frame! (:frame a)) (catch :default _e nil)))
-  (rt/reset-runtime!)
+  (rf.bench.hicasso.arm1.runtime/reset-runtime!)
   #js {"ok" true})
 
-(defn ^:export runtimeLabel [] (clj->js (lane/runtime-label)))
+(defn ^:export runtimeLabel [] (clj->js (rf.bench.hicasso.lane/runtime-label)))
 
 (defn ^:export cardsN [] cards-n)
 
@@ -285,10 +285,10 @@
   ;; every one of its own witnesses installs it. Both arms run on the same
   ;; adapter, so it is common-mode and cancels in the delta; what it is
   ;; here for is that `make-frame` needs an installed adapter at all.
-  (rf/init! uix-adapter/adapter)
-  (lane/leave-act-environment!)
+  (rf/init! rf.adapter.uix/adapter)
+  (rf.bench.hicasso.lane/leave-act-environment!)
   (set! (.-HCHROME js/window)
-        (lane/legible-doors
+        (rf.bench.hicasso.lane/legible-doors
         #js {"mountArm"      mountArm
              "runOp"         runOp
              "releaseArm"    releaseArm
@@ -296,8 +296,8 @@
              "resetRuntime"  resetRuntime
              "runtimeLabel"  runtimeLabel
              "cardsN"        cardsN}))
-  (lane/record! "ready" {:arms (mapv (fn [[k v]] {:id k :why (:why v)}) arms)
+  (rf.bench.hicasso.lane/record! "ready" {:arms (mapv (fn [[k v]] {:id k :why (:why v)}) arms)
                          :cards cards-n
-                         :runtime (lane/runtime-label)})
+                         :runtime (rf.bench.hicasso.lane/runtime-label)})
   (set! (.-HCHROME_READY js/window) true)
   nil)

--- a/bench/hicasso/src/re_frame/bench/hicasso/clock_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/clock_app.cljs
@@ -45,7 +45,7 @@
   `install-adapter!` is once per process, so Reagent and UIx cannot be
   interleaved inside one round — that much this lane already knew. What
   this row adds is a second, sharper constraint: a bulk write here is
-  `frame/replace-app-db!`, and **every** arm mounted against that frame
+  `rf.frame/replace-app-db!`, and **every** arm mounted against that frame
   re-renders when it lands. Two substrate arms standing in one segment
   would each pay for the other's writes, and the clock would be reading a
   page carrying an arm that is not under test. So the candidate gets a
@@ -84,16 +84,16 @@
   Owner: rf2-2rtt6.1 (standard); this entry rf2-0qj9w."
   (:require ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as hmount]
-            [re-frame.bench.hicasso.arm1.runtime :as hrt]
-            [re-frame.bench.hicasso.clock-views :as kv]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.p0-reagent-views :as v]
-            [re-frame.bench.hicasso.p0-uix-views :as ux]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.clock-views :as rf.bench.hicasso.clock-views]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.p0-reagent-views :as rf.bench.hicasso.p0-reagent-views]
+            [re-frame.bench.hicasso.p0-uix-views :as rf.bench.hicasso.p0-uix-views]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
+            [re-frame.frame :as rf.frame]
             [reagent.core :as r]
             [reagent.dom.client :as rdc]
             [uix.dom :as uix-dom]))
@@ -132,9 +132,9 @@
   Arm 1's React-hook spine is built over it and its own witnesses install
   it — so the segment names the arm under test rather than the adapter
   underneath it, and the record says which."
-  [{:id :reagent-subs :adapter reagent-adapter/adapter :name "Reagent-on-subs"}
-   {:id :uix-subs     :adapter uix-adapter/adapter     :name "UIx-on-subs"}
-   {:id :hicasso      :adapter uix-adapter/adapter     :name "Hicasso Arm 1 (UIx adapter)"}])
+  [{:id :reagent-subs :adapter rf.adapter.reagent/adapter :name "Reagent-on-subs"}
+   {:id :uix-subs     :adapter rf.adapter.uix/adapter     :name "UIx-on-subs"}
+   {:id :hicasso      :adapter rf.adapter.uix/adapter     :name "Hicasso Arm 1 (UIx adapter)"}])
 
 (defn- segment-named [id] (first (filter #(= id (:id %)) segments)))
 
@@ -152,7 +152,7 @@
   `[:sub :p0/cell]` is registered TWICE in this bundle, at load, from two
   namespaces: `p0-reagent-views/register!` — the shared floor accessor
   every other row's arms read — and `clock-views/register-subs!`, which
-  registers the SAME computation (`v/cell-value`, so there is still one
+  registers the SAME computation (`rf.bench.hicasso.p0-reagent-views/cell-value`, so there is still one
   body) behind the recompute census the keystroke witness gates on.
 
   A second `reg-sub` from a second namespace does not OVERWRITE the first;
@@ -190,26 +190,26 @@
   segment's reactive graph."
   [seg-id]
   (let [{:keys [adapter]} (segment-named seg-id)]
-    (try (rf/destroy-frame! v/subs-frame)
-         (catch :default e (lane/teardown-failure! "enter-segment! destroy-frame!" e)))
+    (try (rf/destroy-frame! rf.bench.hicasso.p0-reagent-views/subs-frame)
+         (catch :default e (rf.bench.hicasso.lane/teardown-failure! "enter-segment! destroy-frame!" e)))
     (when (rf/current-adapter)
       (try (rf/destroy-adapter!)
-           (catch :default e (lane/teardown-failure! "enter-segment! destroy-adapter!" e))))
+           (catch :default e (rf.bench.hicasso.lane/teardown-failure! "enter-segment! destroy-adapter!" e))))
     ;; `reset-runtime!` drops every cell, edge and cached entry the
     ;; candidate holds — and it calls `forget-frame-ops!` on the way, so a
     ;; destroyed-and-recreated frame cannot hand the arm a memoised bundle
     ;; pointing at the previous incarnation.
-    (hrt/reset-runtime!)
+    (rf.bench.hicasso.arm1.runtime/reset-runtime!)
     (rf/init! adapter)
-    ;; `clock-views/register-subs!` and not `v/register!`: it registers
-    ;; BOTH `:p0/cell` (through `v/cell-value`, so there is one body) and
+    ;; `clock-views/register-subs!` and not `rf.bench.hicasso.p0-reagent-views/register!`: it registers
+    ;; BOTH `:p0/cell` (through `rf.bench.hicasso.p0-reagent-views/cell-value`, so there is one body) and
     ;; the indexed `:p0/draft`, both behind the recompute census the
     ;; keystroke witness gates on.
-    (kv/register-subs!)
-    (rf/make-frame {:id v/subs-frame :images clock-images})
-    (frame/replace-app-db! v/subs-frame (v/seed-cells v/cells-n 0))
-    (lane/leave-act-environment!)
-    (swap! state assoc :segment seg-id :cells (zeros v/cells-n))
+    (rf.bench.hicasso.clock-views/register-subs!)
+    (rf/make-frame {:id rf.bench.hicasso.p0-reagent-views/subs-frame :images clock-images})
+    (rf.frame/replace-app-db! rf.bench.hicasso.p0-reagent-views/subs-frame (rf.bench.hicasso.p0-reagent-views/seed-cells rf.bench.hicasso.p0-reagent-views/cells-n 0))
+    (rf.bench.hicasso.lane/leave-act-environment!)
+    (swap! state assoc :segment seg-id :cells (zeros rf.bench.hicasso.p0-reagent-views/cells-n))
     nil))
 
 ;; ---------------------------------------------------------------------------
@@ -238,7 +238,7 @@
    :mount    (fn [container]
                (let [root (react-dom-client/createRoot container)]
                  (react-dom/flushSync
-                   (fn [] (.render root (v/m1-floor (zeros n)))))
+                   (fn [] (.render root (rf.bench.hicasso.p0-reagent-views/m1-floor (zeros n)))))
                  root))
    :unmount  (fn [root] (.unmount root))})
 
@@ -438,7 +438,7 @@
   denominator of every published ratio instead of the control it is
   supposed to break."
   [id d]
-  (assoc (floor-mount-arm id ctl3-cells (/ ctl3-cells v/cells-n))
+  (assoc (floor-mount-arm id ctl3-cells (/ ctl3-cells rf.bench.hicasso.p0-reagent-views/cells-n))
          :dirty d
          :ctl3? true))
 
@@ -473,22 +473,22 @@
 
 (defn- m1-arms [seg-id]
   [plumb-arm
-   (floor-mount-arm :floor v/cells-n 1)
+   (floor-mount-arm :floor rf.bench.hicasso.p0-reagent-views/cells-n 1)
    (case seg-id
      :reagent-subs {:id      :reagent-subs
-                    :cells   v/cells-n
+                    :cells   rf.bench.hicasso.p0-reagent-views/cells-n
                     :mount   (fn [container]
                                (let [root (rdc/create-root container)]
                                  (react-dom/flushSync
-                                   (fn [] (rdc/render root (v/subs-root v/m1-subs v/cells-n))))
+                                   (fn [] (rdc/render root (rf.bench.hicasso.p0-reagent-views/subs-root rf.bench.hicasso.p0-reagent-views/m1-subs rf.bench.hicasso.p0-reagent-views/cells-n))))
                                  root))
                     :unmount (fn [root] (rdc/unmount root))}
      :uix-subs     {:id      :uix-subs
-                    :cells   v/cells-n
+                    :cells   rf.bench.hicasso.p0-reagent-views/cells-n
                     :mount   (fn [container]
                                (let [root (uix-dom/create-root container)]
                                  (react-dom/flushSync
-                                   (fn [] (uix-dom/render-root (ux/subs-root ux/m1 v/cells-n) root)))
+                                   (fn [] (uix-dom/render-root (rf.bench.hicasso.p0-uix-views/subs-root rf.bench.hicasso.p0-uix-views/m1 rf.bench.hicasso.p0-reagent-views/cells-n) root)))
                                  root))
                     :unmount (fn [root] (uix-dom/unmount-root root))}
      ;; `mount/root!` is the candidate's own door — what an Arm 1
@@ -504,11 +504,11 @@
      ;; which is the arm's own behaviour and not the harness's to
      ;; suppress.
      :hicasso      {:id      :hicasso
-                    :cells   v/cells-n
+                    :cells   rf.bench.hicasso.p0-reagent-views/cells-n
                     :mount   (fn [container]
-                               (hmount/root! container v/subs-frame (kv/m1 v/cells-n)))
+                               (rf.bench.hicasso.arm1.mount/root! container rf.bench.hicasso.p0-reagent-views/subs-frame (rf.bench.hicasso.clock-views/m1 rf.bench.hicasso.p0-reagent-views/cells-n)))
                     :unmount (fn [handle] (.unmount ^js (:root handle)))})
-   (floor-mount-arm :ctl-2x (* 2 v/cells-n) 2)])
+   (floor-mount-arm :ctl-2x (* 2 rf.bench.hicasso.p0-reagent-views/cells-n) 2)])
 
 (defn- ctl3-arms
   "The three-point statistic's arms, and they exist on BULK ROWS ONLY.
@@ -548,12 +548,12 @@
   refuted classification."
   [id busy]
   {:id           id
-   :cells        kv/kb-cells-n
+   :cells        rf.bench.hicasso.clock-views/kb-cells-n
    :control?     (pos? busy)
    :mount        (fn [container]
                    (let [root (react-dom-client/createRoot container)]
                      (react-dom/flushSync
-                       (fn [] (.render root (kv/kb-floor-element kv/kb-cells-n busy))))
+                       (fn [] (.render root (rf.bench.hicasso.clock-views/kb-floor-element rf.bench.hicasso.clock-views/kb-cells-n busy))))
                      root))
    :unmount      (fn [root] (.unmount root))})
 
@@ -562,25 +562,25 @@
    (kb-floor-arm :floor 0)
    (case seg-id
      :reagent-subs {:id      :reagent-subs
-                    :cells   kv/kb-cells-n
+                    :cells   rf.bench.hicasso.clock-views/kb-cells-n
                     :mount   (fn [container]
                                (let [root (rdc/create-root container)]
                                  (react-dom/flushSync
-                                   (fn [] (rdc/render root (kv/r-kb-root kv/kb-cells-n))))
+                                   (fn [] (rdc/render root (rf.bench.hicasso.clock-views/r-kb-root rf.bench.hicasso.clock-views/kb-cells-n))))
                                  root))
                     :unmount (fn [root] (rdc/unmount root))}
      :uix-subs     {:id      :uix-subs
-                    :cells   kv/kb-cells-n
+                    :cells   rf.bench.hicasso.clock-views/kb-cells-n
                     :mount   (fn [container]
                                (let [root (uix-dom/create-root container)]
                                  (react-dom/flushSync
-                                   (fn [] (uix-dom/render-root (kv/u-kb-root kv/kb-cells-n) root)))
+                                   (fn [] (uix-dom/render-root (rf.bench.hicasso.clock-views/u-kb-root rf.bench.hicasso.clock-views/kb-cells-n) root)))
                                  root))
                     :unmount (fn [root] (uix-dom/unmount-root root))}
      :hicasso      {:id      :hicasso
-                    :cells   kv/kb-cells-n
+                    :cells   rf.bench.hicasso.clock-views/kb-cells-n
                     :mount   (fn [container]
-                               (hmount/root! container v/subs-frame (kv/kb-form kv/kb-cells-n)))
+                               (rf.bench.hicasso.arm1.mount/root! container rf.bench.hicasso.p0-reagent-views/subs-frame (rf.bench.hicasso.clock-views/kb-form rf.bench.hicasso.clock-views/kb-cells-n)))
                     :unmount (fn [handle] (.unmount ^js (:root handle)))})
    (kb-floor-arm :ctl-50ms 50)])
 
@@ -595,8 +595,8 @@
 
 (defn- expected-elements [row-key arm]
   (if (= :keystroke row-key)
-    (kv/kb-elements (:cells arm))
-    (v/m1-elements (:cells arm))))
+    (rf.bench.hicasso.clock-views/kb-elements (:cells arm))
+    (rf.bench.hicasso.p0-reagent-views/m1-elements (:cells arm))))
 
 ;; ---------------------------------------------------------------------------
 ;; The write, and its read-back
@@ -618,12 +618,12 @@
   and the row would not measure what its name says. K is the number of
   boundaries whose value moves, and this is what makes that true."
   [k val op]
-  (let [n     v/cells-n
+  (let [n     rf.bench.hicasso.p0-reagent-views/cells-n
         prev  (:cells @state)
         start (if (= k 1) (mod (* 7 op) n) 0)
         cells (reduce (fn [cs d] (assoc cs (mod (+ start d) n) val)) prev (range k))]
     (swap! state assoc :cells cells)
-    (frame/replace-app-db! v/subs-frame {:cells cells})
+    (rf.frame/replace-app-db! rf.bench.hicasso.p0-reagent-views/subs-frame {:cells cells})
     (if (= k 1) [start] [start (mod (+ start (dec k)) n)])))
 
 (defn- drain!
@@ -681,10 +681,10 @@
   (let [arm (arm-named row-key arm-id)]
     (if (or (:plumb? arm) (= :mount (:kind (get rows row-key))))
       (settle-frame)
-      (let [container (lane/fresh-container!)
+      (let [container (rf.bench.hicasso.lane/fresh-container!)
             handle    ((:mount arm) container)
             expected  (expected-elements row-key arm)
-            got       (lane/element-count container)]
+            got       (rf.bench.hicasso.lane/element-count container)]
         (when-not (= expected got)
           (throw (js/Error. (str "the " (name arm-id) " arm built " got
                                  " elements where its own " (:cells arm)
@@ -731,7 +731,7 @@
   "Release this arm's standing mount. Never timed."
   [_row-key arm-id]
   (when-some [p (get-in @state [:prepared arm-id])]
-    (lane/release! p)
+    (rf.bench.hicasso.lane/release! p)
     (swap! state update :prepared dissoc arm-id))
   (settle-frame))
 
@@ -751,11 +751,11 @@
   or 600 boundaries is real work and charging it to the mount would price
   a teardown as part of a mount row."
   [_row-key arm]
-  (let [container (lane/fresh-container!)
+  (let [container (rf.bench.hicasso.lane/fresh-container!)
         handle    (volatile! nil)
-        t0        (lane/now-ms)
+        t0        (rf.bench.hicasso.lane/now-ms)
         _         (vreset! handle ((:mount arm) container))
-        ms        (- (lane/now-ms) t0)]
+        ms        (- (rf.bench.hicasso.lane/now-ms) t0)]
     (swap! state assoc :pending {:arm arm :container container :handle @handle})
     (.then (settle-frame) (fn [_] #js {:inPageMs ms :ok true}))))
 
@@ -764,9 +764,9 @@
   the driver AFTER it has read the counters, so nothing here is timed."
   [row-key]
   (if-some [p (:pending @state)]
-    (let [ok? (= (expected-elements row-key (:arm p)) (lane/element-count (:container p)))]
+    (let [ok? (= (expected-elements row-key (:arm p)) (rf.bench.hicasso.lane/element-count (:container p)))]
       (bank! ok?)
-      (lane/release! p)
+      (rf.bench.hicasso.lane/release! p)
       (swap! state assoc :pending nil)
       (.then (settle-frame) (fn [_] #js {:ok ok?})))
     (.then (settle-frame) (fn [_] #js {:ok true}))))
@@ -794,7 +794,7 @@
         ;; makes the control the only gate that can see it.
         dirty  (when-some [d (:dirty arm)]
                  (if (:ctl3-top? arm) (or (:sabotage @state) d) d))
-        t0     (lane/now-ms)
+        t0     (rf.bench.hicasso.lane/now-ms)
         ;; The floor renders INSIDE the `flushSync`, element tree and all,
         ;; and neither half is a convenience. `root.render` called outside
         ;; a React event schedules at React's DEFAULT lane and an empty
@@ -814,21 +814,21 @@
         probes (cond
                  (some? dirty)
                  (do (react-dom/flushSync
-                       (fn [] (.render ^js root (v/m1-floor (dirty-cells n dirty val)))))
+                       (fn [] (.render ^js root (rf.bench.hicasso.p0-reagent-views/m1-floor (dirty-cells n dirty val)))))
                      (cond-> [[0 (str val)] [(dec dirty) (str val)]]
                        (< dirty n) (conj [(dec n) "0"])))
 
                  (:floor? arm)
                  (do (react-dom/flushSync
-                       (fn [] (.render ^js root (v/m1-floor (vec (repeat n val))))))
+                       (fn [] (.render ^js root (rf.bench.hicasso.p0-reagent-views/m1-floor (vec (repeat n val))))))
                      [[0 (str val)] [(dec n) (str val)]])
 
                  :else
                  (let [ps (write-cells! k val op)]
                    (drain! (:id arm))
                    (mapv (fn [i] [i (str val)]) ps)))
-        ms     (- (lane/now-ms) t0)
-        ok?    (every? (fn [[i expect]] (= expect (lane/text-at cont i))) probes)]
+        ms     (- (rf.bench.hicasso.lane/now-ms) t0)
+        ok?    (every? (fn [[i expect]] (= expect (rf.bench.hicasso.lane/text-at cont i))) probes)]
     (bank! ok?)
     (.then (settle-frame) (fn [_] #js {:inPageMs ms :ok ok?}))))
 
@@ -918,7 +918,7 @@
          (fn [_]
            (let [els (draft-fields arm-id)
                  got (mapv (fn [i] (str (some-> els (aget i) .-value)))
-                           (range kv/kb-fields-n))
+                           (range rf.bench.hicasso.clock-views/kb-fields-n))
                  exp (mapv str (js->clj expected))]
              #js {:ok (bank! (= exp got)) :got (clj->js got)}))))
 
@@ -957,18 +957,18 @@
       ;; control so the gate exempts it by the same rule that exempts the
       ;; doubling arm.
       #js {:arm (name arm-id) :hash 0 :bytes 0 :control true}
-      (let [c (lane/fresh-container!)
+      (let [c (rf.bench.hicasso.lane/fresh-container!)
             h ((:mount arm) c)
-            s (lane/canonical c)]
-        (lane/release! {:arm arm :container c :handle h})
+            s (rf.bench.hicasso.lane/canonical c)]
+        (rf.bench.hicasso.lane/release! {:arm arm :container c :handle h})
         ;; The canon mount wrote nothing, but a Hicasso or Reagent arm
         ;; mounted here has warmed the frame's caches. Re-seed so a row's
         ;; first sample meets the same app-db every other one does.
-        (frame/replace-app-db! v/subs-frame (v/seed-cells v/cells-n 0))
-        (swap! state assoc :cells (zeros v/cells-n))
-        ;; `lane/utf8-bytes` and not `count`: the driver prints this under a
+        (rf.frame/replace-app-db! rf.bench.hicasso.p0-reagent-views/subs-frame (rf.bench.hicasso.p0-reagent-views/seed-cells rf.bench.hicasso.p0-reagent-views/cells-n 0))
+        (swap! state assoc :cells (zeros rf.bench.hicasso.p0-reagent-views/cells-n))
+        ;; `rf.bench.hicasso.lane/utf8-bytes` and not `count`: the driver prints this under a
         ;; `bytes` label, and `count` answers UTF-16 code units (rf2-2rtt6.121).
-        #js {:arm (name arm-id) :hash (str-hash s) :bytes (lane/utf8-bytes s)
+        #js {:arm (name arm-id) :hash (str-hash s) :bytes (rf.bench.hicasso.lane/utf8-bytes s)
              :control (boolean (:control? arm))}))))
 
 ;; ---------------------------------------------------------------------------
@@ -976,15 +976,15 @@
 ;; ---------------------------------------------------------------------------
 
 (defn -main []
-  (lane/leave-act-environment!)
-  (swap! state assoc :tally (lane/tally))
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (swap! state assoc :tally (rf.bench.hicasso.lane/tally))
   (set! (.-HCLOCK js/window)
-        (lane/legible-doors
+        (rf.bench.hicasso.lane/legible-doors
         #js {:rows     (clj->js (mapv (fn [[k m]] {:id (name k) :why (:why m)}) rows))
              :segments (clj->js (mapv (fn [s] {:id (name (:id s)) :name (:name s)}) segments))
-             :cellsN    v/cells-n
-             :kbCellsN  kv/kb-cells-n
-             :kbFieldsN kv/kb-fields-n
+             :cellsN    rf.bench.hicasso.p0-reagent-views/cells-n
+             :kbCellsN  rf.bench.hicasso.clock-views/kb-cells-n
+             :kbFieldsN rf.bench.hicasso.clock-views/kb-fields-n
              :enterSegment  (fn [seg] (enter-segment! (keyword seg)) true)
              ;; `dirty` is the DECLARED count and never the sabotaged one.
              ;; The driver's prediction is derived from what the page says
@@ -1011,19 +1011,19 @@
              ;; THE RECOMPUTE CENSUS. Armed and read in a WARM-UP sample,
              ;; so no measured sample carries its cost, and around a REAL
              ;; keypress, so what it counts is the path the row publishes.
-             :censusStart   (fn [] (kv/census-start!) true)
-             :censusTake    (fn [] (kv/census-take!))
+             :censusStart   (fn [] (rf.bench.hicasso.clock-views/census-start!) true)
+             :censusTake    (fn [] (rf.bench.hicasso.clock-views/census-take!))
              :settle        (fn [] (settle-frame))
              :sabotage      (fn [d] (sabotage! d))
-             :tally         (fn [] (clj->js (lane/tally-value (:tally @state))))
-             :teardownCheck (fn [] (clj->js (mapv :where (lane/drain-teardown-failures!))))
-             :runtime       (fn [] (pr-str (lane/runtime-label)))
+             :tally         (fn [] (clj->js (rf.bench.hicasso.lane/tally-value (:tally @state))))
+             :teardownCheck (fn [] (clj->js (mapv :where (rf.bench.hicasso.lane/drain-teardown-failures!))))
+             :runtime       (fn [] (pr-str (rf.bench.hicasso.lane/runtime-label)))
              ;; Both censuses, because neither sees the other's references:
-             ;; `lane/residue` counts attached containers and the frame's
+             ;; `rf.bench.hicasso.lane/residue` counts attached containers and the frame's
              ;; sub-cache, `runtime/residue` counts the candidate's own
              ;; cells, edges and cached entries.
-             :residue       (fn [] (pr-str {:lane (lane/residue v/subs-frame)
-                                            :arm1 (hrt/residue)}))}))
+             :residue       (fn [] (pr-str {:lane (rf.bench.hicasso.lane/residue rf.bench.hicasso.p0-reagent-views/subs-frame)
+                                            :arm1 (rf.bench.hicasso.arm1.runtime/residue)}))}))
   (set! (.-HCLOCK_READY js/window) true)
   (js/console.log ";; HCLOCK ready")
   nil)

--- a/bench/hicasso/src/re_frame/bench/hicasso/clock_views.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/clock_views.cljs
@@ -59,11 +59,11 @@
   directly would price Hicasso's event pipeline against the donors' bare
   write and then call the difference view work. So all three substrate
   arms share one handler, [[write-draft!]] — Hicasso's behind
-  `intent/callback`, HD-024's one callback form, which returns the
+  `rf.bench.hicasso.front.intent/callback`, HD-024's one callback form, which returns the
   function itself.
 
   React's `onChange` fires on the native `input` event, and Hicasso's
-  `:on-change` lowers to the same prop: `intent/lower-prop` claims every
+  `:on-change` lowers to the same prop: `rf.bench.hicasso.front.intent/lower-prop` claims every
   `^on-` position and `slot/prop-name` camelCases it to `onChange`. Same
   prop, same event, same handler.
 
@@ -86,13 +86,13 @@
 
   Owner: rf2-2rtt6.1 (standard); these witnesses rf2-0qj9w."
   (:require ["react" :as react]
-            [re-frame.adapter.uix :as uixa]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
-            [re-frame.bench.hicasso.front.intent :as intent]
-            [re-frame.bench.hicasso.p0-reagent-views :as v]
-            [re-frame.bench.hicasso.p0-uix-views :as ux]
+            [re-frame.bench.hicasso.front.intent :as rf.bench.hicasso.front.intent]
+            [re-frame.bench.hicasso.p0-reagent-views :as rf.bench.hicasso.p0-reagent-views]
+            [re-frame.bench.hicasso.p0-uix-views :as rf.bench.hicasso.p0-uix-views]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
+            [re-frame.frame :as rf.frame]
             [uix.core :refer [$ defui]])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]
                    [re-frame.core :refer [reg-view]]))
@@ -157,7 +157,7 @@
   `p0-reagent-views/register!` because the census has to see it: the grid
   is 100 of the 104 subscriptions a keystroke recomputes, and a census
   that could only see the fields would answer the easy quarter of
-  validation.md's question. It delegates to `v/cell-value`, so there is
+  validation.md's question. It delegates to `rf.bench.hicasso.p0-reagent-views/cell-value`, so there is
   still exactly one body for that computation.
 
   `:p0/draft` is INDEXED and keeps a query id of its own rather than
@@ -169,7 +169,7 @@
   an adapter once per segment and re-registers on every segment entry,
   and a re-register overwrites with the identical handler."
   []
-  (rf/reg-sub :p0/cell  (fn [db [_ i]] (tick! "p0/cell")  (v/cell-value db i)))
+  (rf/reg-sub :p0/cell  (fn [db [_ i]] (tick! "p0/cell")  (rf.bench.hicasso.p0-reagent-views/cell-value db i)))
   (rf/reg-sub :p0/draft (fn [db [_ i]] (tick! "p0/draft") (get-in db [:draft i] "")))
   nil)
 
@@ -178,7 +178,7 @@
 (defn seed
   "The keystroke witness's app-db — the grid's cells plus empty drafts."
   [n]
-  (assoc (v/seed-cells n 0) :draft (vec (repeat kb-fields-n ""))))
+  (assoc (rf.bench.hicasso.p0-reagent-views/seed-cells n 0) :draft (vec (repeat kb-fields-n ""))))
 
 (defn write-draft!
   "THE ONE HANDLER, shared by all three substrate arms.
@@ -200,9 +200,9 @@
   rather than a footnote."
   [i e]
   (let [s      (.. e -target -value)
-        drafts (or (:draft (rf/app-db-value v/subs-frame))
+        drafts (or (:draft (rf/app-db-value rf.bench.hicasso.p0-reagent-views/subs-frame))
                    (vec (repeat kb-fields-n "")))]
-    (frame/replace-app-db! v/subs-frame
+    (rf.frame/replace-app-db! rf.bench.hicasso.p0-reagent-views/subs-frame
                            (assoc (seed kb-cells-n) :draft (assoc drafts i s))))
   nil)
 
@@ -237,7 +237,7 @@
   [:input.draft {:type      "text"
                  :data-i    (str "draft-" i)
                  :value     (sub [:p0/draft i])
-                 :on-change (intent/callback (fn [e] (write-draft! i e)))}])
+                 :on-change (rf.bench.hicasso.front.intent/callback (fn [e] (write-draft! i e)))}])
 
 (defn kb-form
   "The keystroke page: four fields above the grid."
@@ -261,10 +261,10 @@
   [n]
   (into [:form.kbform]
         (conj (mapv (fn [i] ^{:key i} [r-kb-field i]) (range kb-fields-n))
-              [v/m1-subs n])))
+              [rf.bench.hicasso.p0-reagent-views/m1-subs n])))
 
 (defn r-kb-root [n]
-  [rf/frame-provider {:frame v/subs-frame} [r-kb-form n]])
+  [rf/frame-provider {:frame rf.bench.hicasso.p0-reagent-views/subs-frame} [r-kb-form n]])
 
 ;; ---------------------------------------------------------------------------
 ;; UIx — the co-instrumented comparator
@@ -273,7 +273,7 @@
 (defui u-kb-field [{:keys [i]}]
   ($ :input.draft {:type      "text"
                    :data-i    (str "draft-" i)
-                   :value     (uixa/use-subscribe [:p0/draft i])
+                   :value     (rf.adapter.uix/use-subscribe [:p0/draft i])
                    :on-change (fn [e] (write-draft! i e))}))
 
 (defui u-kb-form [{:keys [n]}]
@@ -284,10 +284,10 @@
   ;; the canonical-DOM gate checks rather than takes on trust.
   ($ :form.kbform
      (into-array (mapv (fn [i] ($ u-kb-field {:key i :i i})) (range kb-fields-n)))
-     ($ ux/m1 {:n n})))
+     ($ rf.bench.hicasso.p0-uix-views/m1 {:n n})))
 
 (defn u-kb-root [n]
-  ($ uixa/frame-provider {:frame v/subs-frame}
+  ($ rf.adapter.uix/frame-provider {:frame rf.bench.hicasso.p0-reagent-views/subs-frame}
      ($ u-kb-form {:n n})))
 
 ;; ---------------------------------------------------------------------------
@@ -336,7 +336,7 @@
           drafts (aget state 0)
           put!   (aget state 1)]
       ;; Children as VARARGS rather than as an array: an array child needs
-      ;; a `key` per entry and `v/m1-floor` — which is the M1 floor
+      ;; a `key` per entry and `rf.bench.hicasso.p0-reagent-views/m1-floor` — which is the M1 floor
       ;; unchanged, so that the two floors are one page — does not carry
       ;; one. Varargs is React's own escape from that and costs the page
       ;; nothing.
@@ -357,7 +357,7 @@
                                                                (aset nx i s)
                                                                nx)))))}))
                      (range kb-fields-n))
-               (v/m1-floor (vec (repeat n 0))))))))
+               (rf.bench.hicasso.p0-reagent-views/m1-floor (vec (repeat n 0))))))))
 
 (defn kb-floor-element
   "The floor's element, at `n` boundaries and `busy` milliseconds of

--- a/bench/hicasso/src/re_frame/bench/hicasso/coldmount_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/coldmount_app.cljs
@@ -46,7 +46,7 @@
   ## Method, inherited rather than restated
 
   The converged arm's method, on its witnesses, on its lane: three-plus
-  arms a segment interleaved under `lane/slot-order` (rotating AND
+  arms a segment interleaved under `rf.bench.hicasso.lane/slot-order` (rotating AND
   reflecting), two segments a round with the floor in both, segment order
   alternating with the round, canonical-DOM parity before any clock,
   every mount read back at the arm's own arithmetic, `:ctl-2x` predicted
@@ -70,7 +70,7 @@
       mean and the order-balanced mean coincide BY CONSTRUCTION, which is
       a design property and needs no effect to justify it. This entry
       re-derives its own denominator, so no published row moves.
-    * A RESIDUE GATE per segment-round (`lane/residue` back to baseline
+    * A RESIDUE GATE per segment-round (`rf.bench.hicasso.lane/residue` back to baseline
       after a settle). The `handoff` arm holds a provisional +1 between
       render and commit; a plan in which every render commits must drive
       the census back to zero, and a leak here would silently convert
@@ -131,15 +131,15 @@
   `--config-merge` — no new build id, no `implementation/shadow-cljs.edn`
   edit."
   (:require ["react-dom/client" :as react-dom-client]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.coldmount-views :as cmv]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.p0-converge-app :as converge]
-            [re-frame.bench.hicasso.p0-reagent-views :as v]
-            [re-frame.bench.order-guard :as guard]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.coldmount-views :as rf.bench.hicasso.coldmount-views]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.p0-converge-app :as rf.bench.hicasso.p0-converge-app]
+            [re-frame.bench.hicasso.p0-reagent-views :as rf.bench.hicasso.p0-reagent-views]
+            [re-frame.bench.order-guard :as rf.bench.order-guard]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
+            [re-frame.frame :as rf.frame]
             [reagent.dom.client :as rdc]
             [uix.dom :as uix-dom]))
 
@@ -176,7 +176,7 @@
 
   See the namespace docstring's \"Which schedule these rows speak for\"."
   {:mount-schedule :forced-synchronous
-   :how            "react-dom/flushSync around every mount — the timed ones in lane/mount-arm! and lane/mount-batch!, the counted ones in coldmount-views/witness!"
+   :how            "react-dom/flushSync around every mount — the timed ones in rf.bench.hicasso.lane/mount-arm! and rf.bench.hicasso.lane/mount-batch!, the counted ones in coldmount-views/witness!"
    :arm            "the shipped hook's hand-off MECHANISM, measured where it is allowed to run to completion"
    :not            (str "NOT a shipped-mount-performance claim, and still not one after rf2-2rtt6.71. "
                         "Every mount here is forced with flushSync, and every published row was taken "
@@ -205,8 +205,8 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private segments
-  [{:id :reagent-subs :adapter reagent-adapter/adapter :name "Reagent-on-subs"}
-   {:id :uix-subs     :adapter uix-adapter/adapter     :name "UIx-on-subs"}])
+  [{:id :reagent-subs :adapter rf.adapter.reagent/adapter :name "Reagent-on-subs"}
+   {:id :uix-subs     :adapter rf.adapter.uix/adapter     :name "UIx-on-subs"}])
 
 (defn- segment-order [r]
   (if (even? r) (vec segments) (vec (rseq (vec segments)))))
@@ -221,21 +221,21 @@
 
 (defn- enter-segment!
   "The converged arm's seam, unchanged: tear down, install this segment's
-  adapter, re-register the sub graph (`cmv/register!` — the converged
+  adapter, re-register the sub graph (`rf.bench.hicasso.coldmount-views/register!` — the converged
   layer-1 sub plus the `:<-` chain and the witness chain) and stand the
   frame back up seeded. All outside every measured window; a teardown
   that throws is recorded and adjudicated, never swallowed."
   [{:keys [adapter]}]
-  (try (rf/destroy-frame! v/subs-frame)
-       (catch :default e (lane/teardown-failure! "enter-segment! destroy-frame!" e)))
+  (try (rf/destroy-frame! rf.bench.hicasso.p0-reagent-views/subs-frame)
+       (catch :default e (rf.bench.hicasso.lane/teardown-failure! "enter-segment! destroy-frame!" e)))
   (when (rf/current-adapter)
     (try (rf/destroy-adapter!)
-         (catch :default e (lane/teardown-failure! "enter-segment! destroy-adapter!" e))))
+         (catch :default e (rf.bench.hicasso.lane/teardown-failure! "enter-segment! destroy-adapter!" e))))
   (rf/init! adapter)
-  (cmv/register!)
-  (rf/make-frame {:id v/subs-frame})
-  (frame/replace-app-db! v/subs-frame (v/seed-cells v/cells-n 0))
-  (lane/leave-act-environment!)
+  (rf.bench.hicasso.coldmount-views/register!)
+  (rf/make-frame {:id rf.bench.hicasso.p0-reagent-views/subs-frame})
+  (rf.frame/replace-app-db! rf.bench.hicasso.p0-reagent-views/subs-frame (rf.bench.hicasso.p0-reagent-views/seed-cells rf.bench.hicasso.p0-reagent-views/cells-n 0))
+  (rf.bench.hicasso.lane/leave-act-environment!)
   nil)
 
 ;; ---------------------------------------------------------------------------
@@ -279,13 +279,13 @@
 
 (defn- verify-m1 [n]
   (fn [container]
-    (and (= "0" (lane/text-at container 0))
-         (= "0" (lane/text-at container (dec n))))))
+    (and (= "0" (rf.bench.hicasso.lane/text-at container 0))
+         (= "0" (rf.bench.hicasso.lane/text-at container (dec n))))))
 
 (defn- verify-m2 [n]
   (fn [container]
-    (and (= (v/field-value 0 0) (input-value container "#f0"))
-         (= (v/field-value (dec n) 0)
+    (and (= (rf.bench.hicasso.p0-reagent-views/field-value 0 0) (input-value container "#f0"))
+         (= (rf.bench.hicasso.p0-reagent-views/field-value (dec n) 0)
             (input-value container (str "#f" (dec n)))))))
 
 ;; ---------------------------------------------------------------------------
@@ -293,28 +293,28 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private shapes
-  {:M1 {:elements-of v/m1-elements
+  {:M1 {:elements-of rf.bench.hicasso.p0-reagent-views/m1-elements
         :verify-of   verify-m1
-        :props       {:n v/cells-n}
-        :grid        cmv/m1-grid
-        :uix-cells   cmv/uix-m1-cells
-        :reagent     cmv/reagent-m1-views
-        :floor       v/m1-floor
-        :control     {:predicted (/ (double (v/m1-elements (* 2 v/cells-n)))
-                                    (double (v/m1-elements v/cells-n)))
-                      :basis     (str "element count: " (v/m1-elements (* 2 v/cells-n))
-                                      " / " (v/m1-elements v/cells-n))}}
-   :M2 {:elements-of v/m2-elements
+        :props       {:n rf.bench.hicasso.p0-reagent-views/cells-n}
+        :grid        rf.bench.hicasso.coldmount-views/m1-grid
+        :uix-cells   rf.bench.hicasso.coldmount-views/uix-m1-cells
+        :reagent     rf.bench.hicasso.coldmount-views/reagent-m1-views
+        :floor       rf.bench.hicasso.p0-reagent-views/m1-floor
+        :control     {:predicted (/ (double (rf.bench.hicasso.p0-reagent-views/m1-elements (* 2 rf.bench.hicasso.p0-reagent-views/cells-n)))
+                                    (double (rf.bench.hicasso.p0-reagent-views/m1-elements rf.bench.hicasso.p0-reagent-views/cells-n)))
+                      :basis     (str "element count: " (rf.bench.hicasso.p0-reagent-views/m1-elements (* 2 rf.bench.hicasso.p0-reagent-views/cells-n))
+                                      " / " (rf.bench.hicasso.p0-reagent-views/m1-elements rf.bench.hicasso.p0-reagent-views/cells-n))}}
+   :M2 {:elements-of rf.bench.hicasso.p0-reagent-views/m2-elements
         :verify-of   verify-m2
-        :props       {:n v/fields-n}
-        :grid        cmv/m2-grid
-        :uix-cells   cmv/uix-m2-cells
-        :reagent     cmv/reagent-m2-views
-        :floor       v/m2-floor
-        :control     {:predicted (/ (double (v/m2-elements (* 2 v/fields-n)))
-                                    (double (v/m2-elements v/fields-n)))
-                      :basis     (str "element count: " (v/m2-elements (* 2 v/fields-n))
-                                      " / " (v/m2-elements v/fields-n))}}})
+        :props       {:n rf.bench.hicasso.p0-reagent-views/fields-n}
+        :grid        rf.bench.hicasso.coldmount-views/m2-grid
+        :uix-cells   rf.bench.hicasso.coldmount-views/uix-m2-cells
+        :reagent     rf.bench.hicasso.coldmount-views/reagent-m2-views
+        :floor       rf.bench.hicasso.p0-reagent-views/m2-floor
+        :control     {:predicted (/ (double (rf.bench.hicasso.p0-reagent-views/m2-elements (* 2 rf.bench.hicasso.p0-reagent-views/fields-n)))
+                                    (double (rf.bench.hicasso.p0-reagent-views/m2-elements rf.bench.hicasso.p0-reagent-views/fields-n)))
+                      :basis     (str "element count: " (rf.bench.hicasso.p0-reagent-views/m2-elements (* 2 rf.bench.hicasso.p0-reagent-views/fields-n))
+                                      " / " (rf.bench.hicasso.p0-reagent-views/m2-elements rf.bench.hicasso.p0-reagent-views/fields-n))}}})
 
 (defn- arms-for [shape layer segment-id]
   (let [{:keys [floor grid uix-cells reagent]} (get shapes shape)]
@@ -322,17 +322,17 @@
         (into (case segment-id
                 :reagent-subs
                 [(reagent-mount-arm :reagent-subs
-                   (fn [{:keys [n]}] [v/subs-root (get reagent layer) n]))]
+                   (fn [{:keys [n]}] [rf.bench.hicasso.p0-reagent-views/subs-root (get reagent layer) n]))]
                 :uix-subs
                 [(uix-mount-arm :uix-subs
                    (fn [{:keys [n]}]
-                     (cmv/uix-root grid (get-in uix-cells [:uix-subs layer]) n)))
+                     (rf.bench.hicasso.coldmount-views/uix-root grid (get-in uix-cells [:uix-subs layer]) n)))
                  (uix-mount-arm :uix-xcript
                    (fn [{:keys [n]}]
-                     (cmv/uix-root grid (get-in uix-cells [:uix-xcript layer]) n)))
+                     (rf.bench.hicasso.coldmount-views/uix-root grid (get-in uix-cells [:uix-xcript layer]) n)))
                  (uix-mount-arm :uix-handoff
                    (fn [{:keys [n]}]
-                     (cmv/uix-root grid (get-in uix-cells [:uix-handoff layer]) n)))]))
+                     (rf.bench.hicasso.coldmount-views/uix-root grid (get-in uix-cells [:uix-handoff layer]) n)))]))
         (conj (floor-mount-arm :ctl-2x floor
                                (fn [{:keys [n]}] (zeros (* 2 n))) 2)))))
 
@@ -376,12 +376,12 @@
 (defn- parity-of-segment!
   [{:keys [row-key props arms-for] :as spec} segment-id]
   (let [{:keys [mounts agree? disagree reference]}
-        (lane/parity (arms-for segment-id) props)
+        (rf.bench.hicasso.lane/parity (arms-for segment-id) props)
         wrong (into {}
                     (comp (map (fn [{:keys [arm container]}]
                                  [(:id arm)
                                   {:expected (:elements (expectation spec arm))
-                                   :got      (lane/element-count container)}]))
+                                   :got      (rf.bench.hicasso.lane/element-count container)}]))
                           (remove (fn [[_ {:keys [expected got]}]] (= expected got))))
                     mounts)]
     (try
@@ -394,7 +394,7 @@
                     (seq wrong)
                     (conj {:segment segment-id :row row-key
                            :problem :element-count :arms wrong}))}
-      (finally (doseq [m mounts] (lane/release! m))))))
+      (finally (doseq [m mounts] (rf.bench.hicasso.lane/release! m))))))
 
 (defn- parity! [spec]
   (let [by-seg (reduce (fn [acc {:keys [id] :as segment}]
@@ -420,13 +420,13 @@
             (assoc acc id
                    (case id
                      :reagent-subs
-                     [(cmv/witness! :reagent layer witness-boundaries 0)
-                      (cmv/witness! :reagent layer witness-boundaries 900)]
+                     [(rf.bench.hicasso.coldmount-views/witness! :reagent layer witness-boundaries 0)
+                      (rf.bench.hicasso.coldmount-views/witness! :reagent layer witness-boundaries 900)]
                      :uix-subs
-                     [(cmv/witness! :xcript  layer witness-boundaries 0)
-                      (cmv/witness! :xcript  layer witness-boundaries 900)
-                      (cmv/witness! :handoff layer witness-boundaries 1800)
-                      (cmv/witness! :handoff layer witness-boundaries 2700)
+                     [(rf.bench.hicasso.coldmount-views/witness! :xcript  layer witness-boundaries 0)
+                      (rf.bench.hicasso.coldmount-views/witness! :xcript  layer witness-boundaries 900)
+                      (rf.bench.hicasso.coldmount-views/witness! :handoff layer witness-boundaries 1800)
+                      (rf.bench.hicasso.coldmount-views/witness! :handoff layer witness-boundaries 2700)
                       ;; rf2-2rtt6.25 — the FORCED-SYNCHRONOUS MECHANISM arm.
                       ;; `witness!` mounts inside `flushSync`, and on THAT
                       ;; schedule the shipped hook runs the hand-off to
@@ -434,8 +434,8 @@
                       ;; `createRoot().render()` path it reads the `xcript` row
                       ;; instead — ns docstring, "Which schedule these rows
                       ;; speak for". Own disjoint cell ranges.
-                      (cmv/witness! :shipped layer witness-boundaries 3600)
-                      (cmv/witness! :shipped layer witness-boundaries 4500)])))
+                      (rf.bench.hicasso.coldmount-views/witness! :shipped layer witness-boundaries 3600)
+                      (rf.bench.hicasso.coldmount-views/witness! :shipped layer witness-boundaries 4500)])))
           {}
           segments))
 
@@ -499,21 +499,21 @@
         expect (into {} (map (juxt :id #(expectation spec %))) arms)
         acc    (atom (zipmap (map :id arms) (repeat [])))]
     (dotimes [s (+ (:warmup mount-sampling) (:samples mount-sampling))]
-      (doseq [j (lane/slot-order n s)]
+      (doseq [j (rf.bench.hicasso.lane/slot-order n s)]
         (let [arm (nth arms j)
-              {:keys [ms mounts]} (lane/mount-batch! arm props 1)
+              {:keys [ms mounts]} (rf.bench.hicasso.lane/mount-batch! arm props 1)
               {exp-elements :elements verify :verify} (get expect (:id arm))]
           (doseq [m mounts]
-            (let [ok? (and (= exp-elements (lane/element-count (:container m)))
+            (let [ok? (and (= exp-elements (rf.bench.hicasso.lane/element-count (:container m)))
                            (verify (:container m)))]
               (swap! t (fn [{:keys [of bad]}]
                          {:of (inc of) :bad (if ok? bad (inc bad))}))))
-          (doseq [m mounts] (lane/release! m))
+          (doseq [m mounts] (rf.bench.hicasso.lane/release! m))
           (let [label (str (name row-key) "/" (name segment-id) "/" (name (:id arm)))]
             (if (>= s (:warmup mount-sampling))
-              (do (lane/collect! coll label ms)
+              (do (rf.bench.hicasso.lane/collect! coll label ms)
                   (swap! acc update (:id arm) conj ms))
-              (lane/observe! coll label))))))
+              (rf.bench.hicasso.lane/observe! coll label))))))
     @acc))
 
 (defn- run-round!
@@ -521,25 +521,25 @@
   gate around its mount round. Answers a promise of
   `{segment-id {arm-id [ms …]}}`."
   [spec r coll t]
-  (lane/chain
+  (rf.bench.hicasso.lane/chain
     {}
     (segment-order r)
     (fn [acc {:keys [id] :as segment}]
       (enter-segment! segment)
-      (lane/assert-teardown-clean! (str "entering segment " (name id)))
-      (-> (lane/settle!)
+      (rf.bench.hicasso.lane/assert-teardown-clean! (str "entering segment " (name id)))
+      (-> (rf.bench.hicasso.lane/settle!)
           (.then
             (fn [_]
-              (let [baseline (lane/residue v/subs-frame)
+              (let [baseline (rf.bench.hicasso.lane/residue rf.bench.hicasso.p0-reagent-views/subs-frame)
                     rd       (mount-round! coll t spec id)]
-                (-> (lane/settle!)
+                (-> (rf.bench.hicasso.lane/settle!)
                     (.then
                       (fn [_]
-                        (lane/assert-residue!
-                          baseline v/subs-frame
+                        (rf.bench.hicasso.lane/assert-residue!
+                          baseline rf.bench.hicasso.p0-reagent-views/subs-frame
                           (str "mount round, row " (name (:row-key spec))
                                ", segment " (name id)))
-                        (lane/assert-teardown-clean!
+                        (rf.bench.hicasso.lane/assert-teardown-clean!
                           (str "mount round, segment " (name id)))
                         (assoc acc id rd)))))))))))
 
@@ -547,13 +547,13 @@
 ;; Aggregation — the two numbers, per round, and their ratio
 ;; ---------------------------------------------------------------------------
 
-(defn- p50-of [xs] (:p50 (lane/summarise xs)))
+(defn- p50-of [xs] (:p50 (rf.bench.hicasso.lane/summarise xs)))
 
 (defn- range-of [vs]
-  {:mean (lane/round4 (/ (reduce + 0.0 vs) (count vs)))
-   :min  (lane/round4 (apply min vs))
-   :max  (lane/round4 (apply max vs))
-   :per-round (mapv lane/round4 vs)})
+  {:mean (rf.bench.hicasso.lane/round4 (/ (reduce + 0.0 vs) (count vs)))
+   :min  (rf.bench.hicasso.lane/round4 (apply min vs))
+   :max  (rf.bench.hicasso.lane/round4 (apply max vs))
+   :per-round (mapv rf.bench.hicasso.lane/round4 vs)})
 
 (defn- strata-of
   "The per-round vector split by which segment ran first. Even rounds are
@@ -624,7 +624,7 @@
     {:shipped-uix    a
      :copy-handoff   b
      :ranges-overlap? ovl
-     :medians-apart  (lane/round4 rel)
+     :medians-apart  (rf.bench.hicasso.lane/round4 rel)
      :band           fidelity-band
      :ok?            (and (js/isFinite rel) (or ovl (<= rel fidelity-band)))}))
 
@@ -661,17 +661,17 @@
         resolved? (fn [vs] (not-any? nil? vs))
         fid       (fidelity-of (pick :uix) (pick :handoff))
         rz        (pick :rz)
-        order     (converge/segment-order-verdict rz rounds start-segment)
-        c-rg      (lane/control-verdict (:predicted control)
+        order     (rf.bench.hicasso.p0-converge-app/segment-order-verdict rz rounds start-segment)
+        c-rg      (rf.bench.hicasso.lane/control-verdict (:predicted control)
                                         (select-keys (range-of (pick :ctl-ratio-reagent))
                                                      [:min :max :mean])
                                         control-slack)
-        c-ux      (lane/control-verdict (:predicted control)
+        c-ux      (rf.bench.hicasso.lane/control-verdict (:predicted control)
                                         (select-keys (range-of (pick :ctl-ratio-uix))
                                                      [:min :max :mean])
                                         control-slack)
         verdict   (rule-verdict fractions fractions-seam)]
-    (lane/record! (name row-key)
+    (rf.bench.hicasso.lane/record! (name row-key)
                   {:benchmark   (keyword "hicasso.coldmount" (name row-key))
                    :bead        "rf2-2rtt6.15 (instrument); re-run for rf2-2rtt6.25 as the forced-synchronous MECHANISM arm"
                    :doc         doc
@@ -690,12 +690,12 @@
                                      "delta is measured against")
                    :rounds      rounds
                    :balanced-design? (even? rounds)
-                   :per-round   {:floor-reagent (mapv lane/round4 (pick :floor-reagent))
-                                 :floor-uix     (mapv lane/round4 (pick :floor-uix))
-                                 :reagent-subs  (mapv lane/round4 (pick :reagent))
-                                 :uix-subs      (mapv lane/round4 (pick :uix))
-                                 :uix-xcript    (mapv lane/round4 (pick :xcript))
-                                 :uix-handoff   (mapv lane/round4 (pick :handoff))}
+                   :per-round   {:floor-reagent (mapv rf.bench.hicasso.lane/round4 (pick :floor-reagent))
+                                 :floor-uix     (mapv rf.bench.hicasso.lane/round4 (pick :floor-uix))
+                                 :reagent-subs  (mapv rf.bench.hicasso.lane/round4 (pick :reagent))
+                                 :uix-subs      (mapv rf.bench.hicasso.lane/round4 (pick :uix))
+                                 :uix-xcript    (mapv rf.bench.hicasso.lane/round4 (pick :xcript))
+                                 :uix-handoff   (mapv rf.bench.hicasso.lane/round4 (pick :handoff))}
                    :double-build-ms {:doc "xcript − handoff, per round (ms, UIx segment): the build/dispose/rebuild churn of the cold-mount double build over the row's N cold reads"
                                      :summary (range-of (pick :delta))}
                    :red-zone-excess-ms {:doc "uix-subs − reagent-subs, per round (ms, cross-seam, same run): the mount red-zone excess this row's fraction is priced against"
@@ -710,7 +710,7 @@
                                                 :magnitude :direction-only))
                    :segment-order-control order
                    :status      :evidence})
-    (lane/record! "coldmount-fraction"
+    (rf.bench.hicasso.lane/record! "coldmount-fraction"
                   {:row row-key
                    :layer layer
                    :grade grade
@@ -727,8 +727,8 @@
                               ">= 20% on representative layer-1 AND layer-2/3 mounts -> "
                               "reopen for a hook-scoped provisional hand-off design pass only")
                    :row-verdict verdict})
-    (lane/record! "fidelity" (assoc fid :row row-key :schedule schedule-provenance))
-    (lane/record! "witness-counts"
+    (rf.bench.hicasso.lane/record! "fidelity" (assoc fid :row row-key :schedule schedule-provenance))
+    (rf.bench.hicasso.lane/record! "witness-counts"
                   {:row row-key :layer layer
                    :schedule schedule-provenance
                    :predictions {:xcript  "commits N, rebuilt N, bodyRuns 2N at every layer <= L"
@@ -737,16 +737,16 @@
                                  :reagent "commits 0, rebuilt 0, bodyRuns N at every layer <= L"}
                    :results witness-results
                    :failures wfails})
-    (lane/record! "positive-control"
+    (rf.bench.hicasso.lane/record! "positive-control"
                   {:row row-key
                    :predicted (:predicted control)
                    :basis     (:basis control)
                    :reagent-segment c-rg
                    :uix-segment     c-ux})
-    (lane/record! "verification" {row-key (lane/tally-value t)})
-    (let [vd (lane/guard! (:samples @coll)
+    (rf.bench.hicasso.lane/record! "verification" {row-key (rf.bench.hicasso.lane/tally-value t)})
+    (let [vd (rf.bench.hicasso.lane/guard! (:samples @coll)
                           (str "Hicasso cold-mount double build — " (name row-key)))]
-      (lane/record! "arm-order-guard"
+      (rf.bench.hicasso.lane/record! "arm-order-guard"
                     {:row row-key
                      :tolerance (:tolerance vd)
                      :contaminated? (:contaminated? vd)
@@ -764,7 +764,7 @@
     ;; the driver exits 4.
     (when (or (seq wfails) (not (:ok? fid)))
       (set! (.-HICASSO_CLAIM_FAILED js/window) true))
-    (lane/assert-verified! t (str "row " (name row-key)))
+    (rf.bench.hicasso.lane/assert-verified! t (str "row " (name row-key)))
     nil))
 
 ;; ---------------------------------------------------------------------------
@@ -777,7 +777,7 @@
   order across sample indices, or `both orders` is a claim the schedule
   cannot support."
   [k]
-  (> (count (distinct (map #(guard/slot-order k %) (range 8)))) 1))
+  (> (count (distinct (map #(rf.bench.order-guard/slot-order k %) (range 8)))) 1))
 
 ;; ---------------------------------------------------------------------------
 ;; The run
@@ -786,27 +786,27 @@
 (defn ^:export -main
   []
   (try
-    (lane/leave-act-environment!)
+    (rf.bench.hicasso.lane/leave-act-environment!)
     (cond
-      (not (lane/self-test!))
-      (do (lane/fail! (str "the arm-order guard's SELF-TEST failed — this copy of the rule "
+      (not (rf.bench.hicasso.lane/self-test!))
+      (do (rf.bench.hicasso.lane/fail! (str "the arm-order guard's SELF-TEST failed — this copy of the rule "
                            "no longer behaves like the one the .cjs drivers use, so nothing "
                            "was measured"))
-          (lane/done!))
+          (rf.bench.hicasso.lane/done!))
 
       (not (every? slot-order-varies-at? [2 3 5]))
-      (do (lane/fail! (str "lane/slot-order emits ONE order at a plan size this entry runs "
+      (do (rf.bench.hicasso.lane/fail! (str "rf.bench.hicasso.lane/slot-order emits ONE order at a plan size this entry runs "
                            "(or at the k=2 canary) — the rf2-ouwh8 degeneracy class. Nothing "
                            "is measured until the schedule is repaired; the repair belongs "
                            "to the schedule, never to the tolerance"))
-          (lane/done!))
+          (rf.bench.hicasso.lane/done!))
 
       :else
       (let [row-key (query-row)
             spec    (row-spec row-key)
             {:keys [problems]} (parity! spec)]
         (js/console.log (str ";; HICASSO coldmount row " (name row-key)))
-        (lane/record! "parity"
+        (rf.bench.hicasso.lane/record! "parity"
                       {:row row-key :problems problems :ok? (empty? problems)
                        :note (str "canonical DOM with attribute names sorted, inside each "
                                   "segment AND across the seam, over the judged arms "
@@ -815,34 +815,34 @@
                                   (base-elements spec) " for " (name row-key)
                                   ", and the arm's OWN scale for the 2x control")})
         (if (seq problems)
-          (do (lane/fail! (str "the arms do not build the same page under :advanced — "
+          (do (rf.bench.hicasso.lane/fail! (str "the arms do not build the same page under :advanced — "
                                (pr-str problems)))
-              (lane/done!))
+              (rf.bench.hicasso.lane/done!))
           (let [wit    (witness-sweep! spec)
                 wfails (witness-failures wit (:layer spec))]
             (if (seq wfails)
-              (do (lane/record! "witness-counts"
+              (do (rf.bench.hicasso.lane/record! "witness-counts"
                                 {:row row-key :layer (:layer spec)
                                  :results wit :failures wfails})
                   (set! (.-HICASSO_CLAIM_FAILED js/window) true)
-                  (lane/fail! (str "THE COUNTING WITNESS FALSIFIED A PREDICTION — the "
+                  (rf.bench.hicasso.lane/fail! (str "THE COUNTING WITNESS FALSIFIED A PREDICTION — the "
                                    "construction counts this ablation is built on did not "
                                    "hold, so no clock taken over these arms is attributable: "
                                    (pr-str wfails)))
-                  (lane/done!))
-              (let [coll (lane/sample-collector)
-                    t    (lane/tally)]
-                (-> (lane/chain [] (range rounds)
+                  (rf.bench.hicasso.lane/done!))
+              (let [coll (rf.bench.hicasso.lane/sample-collector)
+                    t    (rf.bench.hicasso.lane/tally)]
+                (-> (rf.bench.hicasso.lane/chain [] (range rounds)
                                 (fn [acc r]
                                   (-> (run-round! spec r coll t)
                                       (.then (fn [slice] (conj acc slice))))))
                     (.then (fn [slices]
                              (publish! spec slices t coll wit wfails)
-                             (lane/done!)
+                             (rf.bench.hicasso.lane/done!)
                              nil))
                     (.catch (fn [e]
-                              (lane/fail! (str "the run rejected: " e))
-                              (lane/done!))))))))))
+                              (rf.bench.hicasso.lane/fail! (str "the run rejected: " e))
+                              (rf.bench.hicasso.lane/done!))))))))))
     (catch :default e
-      (lane/fail! (str "the run threw: " e))
-      (lane/done!))))
+      (rf.bench.hicasso.lane/fail! (str "the run threw: " e))
+      (rf.bench.hicasso.lane/done!))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/coldmount_views.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/coldmount_views.cljs
@@ -34,8 +34,8 @@
   ## The term that was priced, and the schedule on which it is recovered
 
   `re-frame.substrate.spine/use-subscribe` USED TO take a BALANCED
-  render-phase round trip — `subs/subscribe` immediately followed by
-  `subs/unsubscribe` (the rf2-es09qq net-zero rule) — so a render that
+  render-phase round trip — `rf.subs/subscribe` immediately followed by
+  `rf.subs/unsubscribe` (the rf2-es09qq net-zero rule) — so a render that
   never commits retained no ref-count. For a query with NO live cache
   entry that is `0 -> 1 -> 0`, and `1 -> 0` is the disposal edge:
   `re-frame.subs.cache/unsubscribe!` disposes in-tick with no grace
@@ -65,7 +65,7 @@
   | `xcript`  | subscribe + unsubscribe (build #1, dispose #1) | subscribe (build #2) | **2** |
   | `handoff` | subscribe (build #1, +1 held provisionally)    | subscribe (hit) + unsubscribe (2 -> 1) | **1** |
 
-  Both make exactly TWO `subs/subscribe` and TWO `subs/unsubscribe` calls
+  Both make exactly TWO `rf.subs/subscribe` and TWO `rf.subs/unsubscribe` calls
   per mounted read (render, commit, unmount); both install the same
   watch, the same refs, the same six hooks. `xcript - handoff` is
   therefore the build/dispose/rebuild churn ALONE — the clock the shipped
@@ -124,7 +124,7 @@
   `subscribe-fn`; the shipped hook has no such seam, and adding one would
   make the arm a fourth transcription rather than the code under test. So
   the shipped arm reads the same two integers off OBSERVABLE STATE, with
-  the same meanings and no spy on `subs/subscribe` (a spy that substituted
+  the same meanings and no spy on `rf.subs/subscribe` (a spy that substituted
   the reaction would defeat the hand-off's own identity guard and measure
   the instrument):
 
@@ -147,11 +147,11 @@
   (`p0_reagent_views.cljs` / `p0_uix_views.cljs`); the canonical-DOM
   parity gate proves it rather than this docstring."
   (:require ["react" :as react]
-            [re-frame.adapter.uix :as uixa]
-            [re-frame.bench.hicasso.p0-reagent-views :as v]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.p0-reagent-views :as rf.bench.hicasso.p0-reagent-views]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.subs :as subs]
+            [re-frame.frame :as rf.frame]
+            [re-frame.subs :as rf.subs]
             [reagent.dom.client :as rdc]
             [uix.core :refer [$ defui]]
             [uix.dom :as uix-dom]
@@ -182,12 +182,12 @@
 
 (defn register!
   "The full sub graph for one segment: the converged set's layer-1
-  `:p0/cell` (via `v/register!`, unchanged), the identity `:<-` chain the
+  `:p0/cell` (via `rf.bench.hicasso.p0-reagent-views/register!`, unchanged), the identity `:<-` chain the
   layer-2/3 rows read, and the counter-instrumented witness chain.
   Re-registering overwrites with identical handlers, so the per-segment
   re-register is idempotent (the converged arm's own pattern)."
   []
-  (v/register!)
+  (rf.bench.hicasso.p0-reagent-views/register!)
   ;; Parametric `:<-` producers — the index rides the query vector, which
   ;; the static literal `:<-` form cannot express. A parametric single
   ;; input is delivered as `[value]` (Spec 006 §Single input contract).
@@ -201,7 +201,7 @@
   (rf/reg-sub :cm/w1
     (fn [db [_ i]]
       (aset witness-counters "body1" (inc (aget witness-counters "body1")))
-      (nth (:cells db) (mod i v/cells-n))))
+      (nth (:cells db) (mod i rf.bench.hicasso.p0-reagent-views/cells-n))))
   (rf/reg-sub :cm/w2
     (fn [qv] [[:cm/w1 (second qv)]])
     (fn [[cell] _]
@@ -253,8 +253,8 @@
         reaction
         (uix-hooks/use-memo
           (fn []
-            (let [r (subs/subscribe stable-query-v {:frame stable-frame-kw})]
-              (subs/unsubscribe stable-frame-kw stable-query-v)
+            (let [r (rf.subs/subscribe stable-query-v {:frame stable-frame-kw})]
+              (rf.subs/unsubscribe stable-frame-kw stable-query-v)
               r))
           #js [stable-key])
         get-snap
@@ -272,7 +272,7 @@
           (fn [on-change]
             ;; Cold cache (the render round trip disposed the entry), so
             ;; this MISSES and constructs the SECOND reaction.
-            (let [committed (subs/subscribe stable-query-v
+            (let [committed (rf.subs/subscribe stable-query-v
                                             {:frame stable-frame-kw})]
               (set! (.-current committed-ref) #js [stable-key committed])
               (let [k (keyword watch-ns (str (gensym "watch-")))]
@@ -283,7 +283,7 @@
                   (let [stored (.-current committed-ref)]
                     (when (and stored (identical? (aget stored 1) committed))
                       (set! (.-current committed-ref) nil)))
-                  (subs/unsubscribe stable-frame-kw stable-query-v)))))
+                  (rf.subs/unsubscribe stable-frame-kw stable-query-v)))))
           #js [stable-key])]
     (react/useSyncExternalStore subscribe-fn get-snap get-snap)))
 
@@ -311,7 +311,7 @@
         stable-query-v  (aget stable-key 1)
         reaction
         (uix-hooks/use-memo
-          (fn [] (subs/subscribe stable-query-v {:frame stable-frame-kw}))
+          (fn [] (rf.subs/subscribe stable-query-v {:frame stable-frame-kw}))
           #js [stable-key])
         get-snap
         (uix-hooks/use-callback
@@ -329,10 +329,10 @@
             ;; Live entry at ref-count 1, so this HITS: `committed` is
             ;; `identical?` the render-phase handle. Adopt, then release
             ;; the provisional +1 (2 -> 1).
-            (let [committed (subs/subscribe stable-query-v
+            (let [committed (rf.subs/subscribe stable-query-v
                                             {:frame stable-frame-kw})]
               (set! (.-current committed-ref) #js [stable-key committed])
-              (subs/unsubscribe stable-frame-kw stable-query-v)
+              (rf.subs/unsubscribe stable-frame-kw stable-query-v)
               (let [k (keyword watch-ns (str (gensym "watch-")))]
                 (when committed
                   (add-watch committed k (fn [_ _ _ _] (on-change))))
@@ -341,7 +341,7 @@
                   (let [stored (.-current committed-ref)]
                     (when (and stored (identical? (aget stored 1) committed))
                       (set! (.-current committed-ref) nil)))
-                  (subs/unsubscribe stable-frame-kw stable-query-v)))))
+                  (rf.subs/unsubscribe stable-frame-kw stable-query-v)))))
           #js [stable-key])]
     (react/useSyncExternalStore subscribe-fn get-snap get-snap)))
 
@@ -363,55 +363,55 @@
 ;; comment.
 
 (defui s-m1-l1 [{:keys [i]}]
-  (let [cell (uixa/use-subscribe [:p0/cell i])]
+  (let [cell (rf.adapter.uix/use-subscribe [:p0/cell i])]
     ($ :li.row
        ($ :span.lbl "cell ")
        ($ :span.cell {:data-i i} (str cell)))))
 
 (defui s-m1-l2 [{:keys [i]}]
-  (let [cell (uixa/use-subscribe [:cm/l2 i])]
+  (let [cell (rf.adapter.uix/use-subscribe [:cm/l2 i])]
     ($ :li.row
        ($ :span.lbl "cell ")
        ($ :span.cell {:data-i i} (str cell)))))
 
 (defui s-m1-l3 [{:keys [i]}]
-  (let [cell (uixa/use-subscribe [:cm/l3 i])]
+  (let [cell (rf.adapter.uix/use-subscribe [:cm/l3 i])]
     ($ :li.row
        ($ :span.lbl "cell ")
        ($ :span.cell {:data-i i} (str cell)))))
 
 (defui x-m1-l1 [{:keys [i]}]
-  (let [cell (use-sub-xcript v/subs-frame [:p0/cell i])]
+  (let [cell (use-sub-xcript rf.bench.hicasso.p0-reagent-views/subs-frame [:p0/cell i])]
     ($ :li.row
        ($ :span.lbl "cell ")
        ($ :span.cell {:data-i i} (str cell)))))
 
 (defui x-m1-l2 [{:keys [i]}]
-  (let [cell (use-sub-xcript v/subs-frame [:cm/l2 i])]
+  (let [cell (use-sub-xcript rf.bench.hicasso.p0-reagent-views/subs-frame [:cm/l2 i])]
     ($ :li.row
        ($ :span.lbl "cell ")
        ($ :span.cell {:data-i i} (str cell)))))
 
 (defui x-m1-l3 [{:keys [i]}]
-  (let [cell (use-sub-xcript v/subs-frame [:cm/l3 i])]
+  (let [cell (use-sub-xcript rf.bench.hicasso.p0-reagent-views/subs-frame [:cm/l3 i])]
     ($ :li.row
        ($ :span.lbl "cell ")
        ($ :span.cell {:data-i i} (str cell)))))
 
 (defui h-m1-l1 [{:keys [i]}]
-  (let [cell (use-sub-handoff v/subs-frame [:p0/cell i])]
+  (let [cell (use-sub-handoff rf.bench.hicasso.p0-reagent-views/subs-frame [:p0/cell i])]
     ($ :li.row
        ($ :span.lbl "cell ")
        ($ :span.cell {:data-i i} (str cell)))))
 
 (defui h-m1-l2 [{:keys [i]}]
-  (let [cell (use-sub-handoff v/subs-frame [:cm/l2 i])]
+  (let [cell (use-sub-handoff rf.bench.hicasso.p0-reagent-views/subs-frame [:cm/l2 i])]
     ($ :li.row
        ($ :span.lbl "cell ")
        ($ :span.cell {:data-i i} (str cell)))))
 
 (defui h-m1-l3 [{:keys [i]}]
-  (let [cell (use-sub-handoff v/subs-frame [:cm/l3 i])]
+  (let [cell (use-sub-handoff rf.bench.hicasso.p0-reagent-views/subs-frame [:cm/l3 i])]
     ($ :li.row
        ($ :span.lbl "cell ")
        ($ :span.cell {:data-i i} (str cell)))))
@@ -421,70 +421,70 @@
 ;; ---------------------------------------------------------------------------
 
 (defui s-m2-l1 [{:keys [i]}]
-  (let [cell (uixa/use-subscribe [:p0/cell i])]
+  (let [cell (rf.adapter.uix/use-subscribe [:p0/cell i])]
     ($ :div.field
        ($ :label.lbl {:for (str "f" i)} (str "Field " i))
        ($ :input.inp {:id        (str "f" i)
                       :name      (str "f" i)
                       :type      "text"
-                      :value     (v/field-value i cell)
+                      :value     (rf.bench.hicasso.p0-reagent-views/field-value i cell)
                       :read-only true})
-       ($ :p.err (v/field-error i)))))
+       ($ :p.err (rf.bench.hicasso.p0-reagent-views/field-error i)))))
 
 (defui s-m2-l2 [{:keys [i]}]
-  (let [cell (uixa/use-subscribe [:cm/l2 i])]
+  (let [cell (rf.adapter.uix/use-subscribe [:cm/l2 i])]
     ($ :div.field
        ($ :label.lbl {:for (str "f" i)} (str "Field " i))
        ($ :input.inp {:id        (str "f" i)
                       :name      (str "f" i)
                       :type      "text"
-                      :value     (v/field-value i cell)
+                      :value     (rf.bench.hicasso.p0-reagent-views/field-value i cell)
                       :read-only true})
-       ($ :p.err (v/field-error i)))))
+       ($ :p.err (rf.bench.hicasso.p0-reagent-views/field-error i)))))
 
 (defui x-m2-l1 [{:keys [i]}]
-  (let [cell (use-sub-xcript v/subs-frame [:p0/cell i])]
+  (let [cell (use-sub-xcript rf.bench.hicasso.p0-reagent-views/subs-frame [:p0/cell i])]
     ($ :div.field
        ($ :label.lbl {:for (str "f" i)} (str "Field " i))
        ($ :input.inp {:id        (str "f" i)
                       :name      (str "f" i)
                       :type      "text"
-                      :value     (v/field-value i cell)
+                      :value     (rf.bench.hicasso.p0-reagent-views/field-value i cell)
                       :read-only true})
-       ($ :p.err (v/field-error i)))))
+       ($ :p.err (rf.bench.hicasso.p0-reagent-views/field-error i)))))
 
 (defui x-m2-l2 [{:keys [i]}]
-  (let [cell (use-sub-xcript v/subs-frame [:cm/l2 i])]
+  (let [cell (use-sub-xcript rf.bench.hicasso.p0-reagent-views/subs-frame [:cm/l2 i])]
     ($ :div.field
        ($ :label.lbl {:for (str "f" i)} (str "Field " i))
        ($ :input.inp {:id        (str "f" i)
                       :name      (str "f" i)
                       :type      "text"
-                      :value     (v/field-value i cell)
+                      :value     (rf.bench.hicasso.p0-reagent-views/field-value i cell)
                       :read-only true})
-       ($ :p.err (v/field-error i)))))
+       ($ :p.err (rf.bench.hicasso.p0-reagent-views/field-error i)))))
 
 (defui h-m2-l1 [{:keys [i]}]
-  (let [cell (use-sub-handoff v/subs-frame [:p0/cell i])]
+  (let [cell (use-sub-handoff rf.bench.hicasso.p0-reagent-views/subs-frame [:p0/cell i])]
     ($ :div.field
        ($ :label.lbl {:for (str "f" i)} (str "Field " i))
        ($ :input.inp {:id        (str "f" i)
                       :name      (str "f" i)
                       :type      "text"
-                      :value     (v/field-value i cell)
+                      :value     (rf.bench.hicasso.p0-reagent-views/field-value i cell)
                       :read-only true})
-       ($ :p.err (v/field-error i)))))
+       ($ :p.err (rf.bench.hicasso.p0-reagent-views/field-error i)))))
 
 (defui h-m2-l2 [{:keys [i]}]
-  (let [cell (use-sub-handoff v/subs-frame [:cm/l2 i])]
+  (let [cell (use-sub-handoff rf.bench.hicasso.p0-reagent-views/subs-frame [:cm/l2 i])]
     ($ :div.field
        ($ :label.lbl {:for (str "f" i)} (str "Field " i))
        ($ :input.inp {:id        (str "f" i)
                       :name      (str "f" i)
                       :type      "text"
-                      :value     (v/field-value i cell)
+                      :value     (rf.bench.hicasso.p0-reagent-views/field-value i cell)
                       :read-only true})
-       ($ :p.err (v/field-error i)))))
+       ($ :p.err (rf.bench.hicasso.p0-reagent-views/field-error i)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The UIx grids and root
@@ -508,7 +508,7 @@
   ignore it) and renders no DOM of its own, so it cannot move the parity
   gate."
   [grid cell n]
-  ($ uixa/frame-provider {:frame v/subs-frame}
+  ($ rf.adapter.uix/frame-provider {:frame rf.bench.hicasso.p0-reagent-views/subs-frame}
      ($ grid {:cell cell :n n})))
 
 (def uix-m1-cells
@@ -562,9 +562,9 @@
      [:input.inp {:id        (str "f" i)
                   :name      (str "f" i)
                   :type      "text"
-                  :value     (v/field-value i cell)
+                  :value     (rf.bench.hicasso.p0-reagent-views/field-value i cell)
                   :read-only true}]
-     [:p.err (v/field-error i)]]))
+     [:p.err (rf.bench.hicasso.p0-reagent-views/field-error i)]]))
 
 (reg-view ^{:rf/id :cm/m2-l2} rg-m2-l2
   [fields]
@@ -574,8 +574,8 @@
       ^{:key i} [rg-m2-field-l2 i])]
    [:button.submit {:type "submit" :disabled true} "Submit"]])
 
-(def reagent-m1-views {1 v/m1-subs 2 rg-m1-l2 3 rg-m1-l3})
-(def reagent-m2-views {1 v/m2-subs 2 rg-m2-l2})
+(def reagent-m1-views {1 rf.bench.hicasso.p0-reagent-views/m1-subs 2 rg-m1-l2 3 rg-m1-l3})
+(def reagent-m2-views {1 rf.bench.hicasso.p0-reagent-views/m2-subs 2 rg-m2-l2})
 
 ;; ---------------------------------------------------------------------------
 ;; THE COUNTING WITNESS — the same claim, settled exactly
@@ -597,8 +597,8 @@
         reaction
         (uix-hooks/use-memo
           (fn []
-            (let [r (subs/subscribe stable-query-v {:frame stable-frame-kw})]
-              (subs/unsubscribe stable-frame-kw stable-query-v)
+            (let [r (rf.subs/subscribe stable-query-v {:frame stable-frame-kw})]
+              (rf.subs/unsubscribe stable-frame-kw stable-query-v)
               r))
           #js [stable-key])
         get-snap
@@ -614,7 +614,7 @@
         subscribe-fn
         (uix-hooks/use-callback
           (fn [on-change]
-            (let [committed (subs/subscribe stable-query-v
+            (let [committed (rf.subs/subscribe stable-query-v
                                             {:frame stable-frame-kw})]
               (aset witness-counters "commits"
                     (inc (aget witness-counters "commits")))
@@ -634,7 +634,7 @@
                   (let [stored (.-current committed-ref)]
                     (when (and stored (identical? (aget stored 1) committed))
                       (set! (.-current committed-ref) nil)))
-                  (subs/unsubscribe stable-frame-kw stable-query-v)))))
+                  (rf.subs/unsubscribe stable-frame-kw stable-query-v)))))
           #js [stable-key reaction])]
     (react/useSyncExternalStore subscribe-fn get-snap get-snap)))
 
@@ -646,7 +646,7 @@
         stable-query-v  (aget stable-key 1)
         reaction
         (uix-hooks/use-memo
-          (fn [] (subs/subscribe stable-query-v {:frame stable-frame-kw}))
+          (fn [] (rf.subs/subscribe stable-query-v {:frame stable-frame-kw}))
           #js [stable-key])
         get-snap
         (uix-hooks/use-callback
@@ -661,7 +661,7 @@
         subscribe-fn
         (uix-hooks/use-callback
           (fn [on-change]
-            (let [committed (subs/subscribe stable-query-v
+            (let [committed (rf.subs/subscribe stable-query-v
                                             {:frame stable-frame-kw})]
               (aset witness-counters "commits"
                     (inc (aget witness-counters "commits")))
@@ -669,7 +669,7 @@
                 (aset witness-counters "rebuilt"
                       (inc (aget witness-counters "rebuilt"))))
               (set! (.-current committed-ref) #js [stable-key committed])
-              (subs/unsubscribe stable-frame-kw stable-query-v)
+              (rf.subs/unsubscribe stable-frame-kw stable-query-v)
               (let [k (keyword watch-ns (str (gensym "watch-")))]
                 (when committed
                   (add-watch committed k (fn [_ _ _ _] (on-change))))
@@ -678,7 +678,7 @@
                   (let [stored (.-current committed-ref)]
                     (when (and stored (identical? (aget stored 1) committed))
                       (set! (.-current committed-ref) nil)))
-                  (subs/unsubscribe stable-frame-kw stable-query-v)))))
+                  (rf.subs/unsubscribe stable-frame-kw stable-query-v)))))
           #js [stable-key reaction])]
     (react/useSyncExternalStore subscribe-fn get-snap get-snap)))
 
@@ -687,39 +687,39 @@
 (defn- wq [layer i] [(case layer 1 :cm/w1 2 :cm/w2 3 :cm/w3) i])
 
 (defui wx-cell-1 [{:keys [base]}]
-  (let [a (use-sub-witness-xcript v/subs-frame (wq 1 (+ base 0)))
-        b (use-sub-witness-xcript v/subs-frame (wq 1 (+ base 1)))
-        c (use-sub-witness-xcript v/subs-frame (wq 1 (+ base 2)))]
+  (let [a (use-sub-witness-xcript rf.bench.hicasso.p0-reagent-views/subs-frame (wq 1 (+ base 0)))
+        b (use-sub-witness-xcript rf.bench.hicasso.p0-reagent-views/subs-frame (wq 1 (+ base 1)))
+        c (use-sub-witness-xcript rf.bench.hicasso.p0-reagent-views/subs-frame (wq 1 (+ base 2)))]
     ($ :span.wcell {:data-i base} (str (+ a b c)))))
 
 (defui wx-cell-2 [{:keys [base]}]
-  (let [a (use-sub-witness-xcript v/subs-frame (wq 2 (+ base 0)))
-        b (use-sub-witness-xcript v/subs-frame (wq 2 (+ base 1)))
-        c (use-sub-witness-xcript v/subs-frame (wq 2 (+ base 2)))]
+  (let [a (use-sub-witness-xcript rf.bench.hicasso.p0-reagent-views/subs-frame (wq 2 (+ base 0)))
+        b (use-sub-witness-xcript rf.bench.hicasso.p0-reagent-views/subs-frame (wq 2 (+ base 1)))
+        c (use-sub-witness-xcript rf.bench.hicasso.p0-reagent-views/subs-frame (wq 2 (+ base 2)))]
     ($ :span.wcell {:data-i base} (str (+ a b c)))))
 
 (defui wx-cell-3 [{:keys [base]}]
-  (let [a (use-sub-witness-xcript v/subs-frame (wq 3 (+ base 0)))
-        b (use-sub-witness-xcript v/subs-frame (wq 3 (+ base 1)))
-        c (use-sub-witness-xcript v/subs-frame (wq 3 (+ base 2)))]
+  (let [a (use-sub-witness-xcript rf.bench.hicasso.p0-reagent-views/subs-frame (wq 3 (+ base 0)))
+        b (use-sub-witness-xcript rf.bench.hicasso.p0-reagent-views/subs-frame (wq 3 (+ base 1)))
+        c (use-sub-witness-xcript rf.bench.hicasso.p0-reagent-views/subs-frame (wq 3 (+ base 2)))]
     ($ :span.wcell {:data-i base} (str (+ a b c)))))
 
 (defui wh-cell-1 [{:keys [base]}]
-  (let [a (use-sub-witness-handoff v/subs-frame (wq 1 (+ base 0)))
-        b (use-sub-witness-handoff v/subs-frame (wq 1 (+ base 1)))
-        c (use-sub-witness-handoff v/subs-frame (wq 1 (+ base 2)))]
+  (let [a (use-sub-witness-handoff rf.bench.hicasso.p0-reagent-views/subs-frame (wq 1 (+ base 0)))
+        b (use-sub-witness-handoff rf.bench.hicasso.p0-reagent-views/subs-frame (wq 1 (+ base 1)))
+        c (use-sub-witness-handoff rf.bench.hicasso.p0-reagent-views/subs-frame (wq 1 (+ base 2)))]
     ($ :span.wcell {:data-i base} (str (+ a b c)))))
 
 (defui wh-cell-2 [{:keys [base]}]
-  (let [a (use-sub-witness-handoff v/subs-frame (wq 2 (+ base 0)))
-        b (use-sub-witness-handoff v/subs-frame (wq 2 (+ base 1)))
-        c (use-sub-witness-handoff v/subs-frame (wq 2 (+ base 2)))]
+  (let [a (use-sub-witness-handoff rf.bench.hicasso.p0-reagent-views/subs-frame (wq 2 (+ base 0)))
+        b (use-sub-witness-handoff rf.bench.hicasso.p0-reagent-views/subs-frame (wq 2 (+ base 1)))
+        c (use-sub-witness-handoff rf.bench.hicasso.p0-reagent-views/subs-frame (wq 2 (+ base 2)))]
     ($ :span.wcell {:data-i base} (str (+ a b c)))))
 
 (defui wh-cell-3 [{:keys [base]}]
-  (let [a (use-sub-witness-handoff v/subs-frame (wq 3 (+ base 0)))
-        b (use-sub-witness-handoff v/subs-frame (wq 3 (+ base 1)))
-        c (use-sub-witness-handoff v/subs-frame (wq 3 (+ base 2)))]
+  (let [a (use-sub-witness-handoff rf.bench.hicasso.p0-reagent-views/subs-frame (wq 3 (+ base 0)))
+        b (use-sub-witness-handoff rf.bench.hicasso.p0-reagent-views/subs-frame (wq 3 (+ base 1)))
+        c (use-sub-witness-handoff rf.bench.hicasso.p0-reagent-views/subs-frame (wq 3 (+ base 2)))]
     ($ :span.wcell {:data-i base} (str (+ a b c)))))
 
 ;; -- the SHIPPED witness: the real hook, counted off observable state -------
@@ -737,7 +737,7 @@
   boundary more than once, and only the first render is the cold one."
   (atom {}))
 
-(defn- sub-cache-atom [] (:sub-cache (frame/frame v/subs-frame)))
+(defn- sub-cache-atom [] (:sub-cache (rf.frame/frame rf.bench.hicasso.p0-reagent-views/subs-frame)))
 
 (defn- tenant-of [query-v]
   (get-in @(sub-cache-atom) [query-v :reaction]))
@@ -746,7 +746,7 @@
   "The shipped hook, plus one render-phase observation. Reading an atom during
   render is a bench affordance, not a pattern: it records, it does not decide."
   [query-v]
-  (let [value (uixa/use-subscribe v/subs-frame query-v)]
+  (let [value (rf.adapter.uix/use-subscribe rf.bench.hicasso.p0-reagent-views/subs-frame query-v)]
     (swap! shipped-render-observed
            (fn [m] (if (contains? m query-v) m (assoc m query-v (tenant-of query-v)))))
     value))
@@ -801,7 +801,7 @@
                 (if (< k 3)
                   (recur (inc k)
                          (+ acc @(rf/subscribe (wq layer (+ base k))
-                                               {:frame v/subs-frame})))
+                                               {:frame rf.bench.hicasso.p0-reagent-views/subs-frame})))
                   acc))]
     [:span.wcell {:data-i base} (str total)]))
 

--- a/bench/hicasso/src/re_frame/bench/hicasso/controlled_restore_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/controlled_restore_dom_cljs_test.cljs
@@ -143,9 +143,9 @@
     assertion gets one home."
   (:require [clojure.string :as str]
             [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uixa]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.test-support :as test-support]
+            [re-frame.test-support :as rf.test-support]
             [uix.core :refer [$ defui]]
             [uix.compiler.input]
             ;; Required so `:uix-reagent-input` can be SELECTED rather
@@ -261,8 +261,8 @@
 
 (defui cell-view [{:keys [i door converge?]}]
   (swap! !body-runs inc)
-  (let [v                                (uixa/use-subscribe [:cgrid/cell i])
-        {:keys [dispatch dispatch-sync]} (uixa/use-frame)
+  (let [v                                (rf.adapter.uix/use-subscribe [:cgrid/cell i])
+        {:keys [dispatch dispatch-sync]} (rf.adapter.uix/use-frame)
         send                             (if (= :queued door) dispatch dispatch-sync)]
     (swap! !rendered assoc i v)
     ($ :div.cell
@@ -352,7 +352,7 @@
    (reset! !rendered {})
    (let [root (react-dom-client/createRoot container)]
      (react-dom/flushSync
-      (fn [] (.render root ($ uixa/frame-provider {:frame frame-id}
+      (fn [] (.render root ($ rf.adapter.uix/frame-provider {:frame frame-id}
                               ($ grid-view {:n n :door door :converge? converge?})))))
      root)))
 
@@ -418,8 +418,8 @@
 ;; evaluated, so it has to sit below the `reg-*` calls above — a
 ;; `use-fixtures` placed at the top of the file strands every one of
 ;; them and the whole grid renders empty.
-(use-fixtures :each (test-support/make-reset-runtime-fixture
-                     {:adapter uixa/adapter :ambient-frame nil :async? true}))
+(use-fixtures :each (rf.test-support/make-reset-runtime-fixture
+                     {:adapter rf.adapter.uix/adapter :ambient-frame nil :async? true}))
 
 ;; ---------------------------------------------------------------------------
 ;; The selector itself — the reason every row below names an implementation

--- a/bench/hicasso/src/re_frame/bench/hicasso/direct_return_clock_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/direct_return_clock_app.cljs
@@ -32,7 +32,7 @@
   on purpose ([[parity-can-fail?]]), because an equality that cannot
   answer false is not a gate.
 
-  It is MOUNTED-DOM equality here, through `lane/canonical`, and that is
+  It is MOUNTED-DOM equality here, through `rf.bench.hicasso.lane/canonical`, and that is
   a STRONGER claim than the deterministic half made. That file states its
   own limit explicitly: it settles markup under `renderToStaticMarkup`
   and says nothing about a mounted node's properties or what a commit
@@ -44,7 +44,7 @@
 
   One page written twice, at [[boundaries]] boundaries, mounted into a
   fresh container inside ONE `react-dom/flushSync` window
-  (`lane/mount-batch!`). The window therefore holds the substrate's
+  (`rf.bench.hicasso.lane/mount-batch!`). The window therefore holds the substrate's
   element construction AND React's render, commit and DOM mutation —
   which is the point: the escape removes CLJS lowering from a cost React
   otherwise dominates, and a figure that excluded React's share would
@@ -70,7 +70,7 @@
 
   ## The control is adjudicated STRICTLY, and per round (rf2-gsn62)
 
-  `lane/control-verdict-strict` decides it: every round's `:ctl-2x` /
+  `rf.bench.hicasso.lane/control-verdict-strict` decides it: every round's `:ctl-2x` /
   `:hiccup` ratio must sit inside ±25% of 2.00x, and one bad round
   refuses the run however good the others were. This instrument is
   entitled to that rule and the coarse-leg rows are not — the 2026-07-31
@@ -94,7 +94,7 @@
 
   ## The published figure
 
-  `lane/ratio-between :direct :hiccup` over the per-round floor-normalised
+  `rf.bench.hicasso.lane/ratio-between :direct :hiccup` over the per-round floor-normalised
   ratios — direct-return mount time as a fraction of the hiccup spelling's,
   with its range and its `:straddles-1?` flag. A range that includes 1.0
   means INDISTINGUISHABLE and the row must say so rather than quote the
@@ -106,10 +106,10 @@
   existing `:hicasso-bench` build id via `HICASSO_INIT_FN` — no
   `shadow-cljs.edn` edit, which is what the driver's `--config-merge`
   exists for."
-  (:require [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.lane :as lane]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
+            [re-frame.hicasso :as rf.hicasso]
             ["react" :as react]))
 
 (def frame-id ::direct-return-clock)
@@ -158,11 +158,11 @@
   "The ordinary Rung 1 spelling. Two ambient reads, an intent vector at a
   callback slot, and a controlled field."
   [{:keys [id]}]
-  (let [label (h/sub [:dr/label id])
-        n     (count (h/sub [:dr/tags id]))]
+  (let [label (rf.hicasso/sub [:dr/label id])
+        n     (count (rf.hicasso/sub [:dr/tags id]))]
     [:div {:class "row" :on-click [:dr/picked id]}
      [:span {:class "label"} (str label " " n)]
-     [:input {:class "field" :value label :on-input [:dr/edited id ::h/value]}]]))
+     [:input {:class "field" :value label :on-input [:dr/edited id ::rf.hicasso/value]}]]))
 
 (defn direct-body
   "The Rung 3 spelling of the same page. The reads are the boundary's,
@@ -171,8 +171,8 @@
   function — and no controlled repair, so the field's echo is the
   author's to write."
   [{:keys [id]}]
-  (let [label (h/sub [:dr/label id])
-        n     (count (h/sub [:dr/tags id]))]
+  (let [label (rf.hicasso/sub [:dr/label id])
+        n     (count (rf.hicasso/sub [:dr/tags id]))]
     (react/createElement "div" #js {:className "row" :onClick (fn [_] nil)}
       (react/createElement "span" #js {:className "label"} (str label " " n))
       (react/createElement "input" #js {:className "field" :value label
@@ -185,9 +185,9 @@
   [_]
   nil)
 
-(h/defview hiccup-arm [props] (hiccup-body props))
-(h/defview direct-arm [props] (direct-body props))
-(h/defview floor-arm  [props] (floor-body props))
+(rf.hicasso/defview hiccup-arm [props] (hiccup-body props))
+(rf.hicasso/defview direct-arm [props] (direct-body props))
+(rf.hicasso/defview floor-arm  [props] (floor-body props))
 
 ;; ---------------------------------------------------------------------------
 ;; The page — identical for every arm but the body
@@ -216,9 +216,9 @@
 
 (defn- mount-page
   [view]
-  (fn [container _props _n] (h/mount! container {:frame frame-id} (page view))))
+  (fn [container _props _n] (rf.hicasso/mount! container {:frame frame-id} (page view))))
 
-(defn- unmount-page [handle] (h/unmount! handle))
+(defn- unmount-page [handle] (rf.hicasso/unmount! handle))
 
 (def ^:private arms
   [{:id :floor  :k 1 :elements floor-elements :parity-exempt? true
@@ -252,8 +252,8 @@
   splits round one, which is the contrast the guard reported; at
   `:warmup 8` it lands inside the warm-up and no measured sample straddles
   it. `{:warmup 8 :samples 12}` is also what every other harness riding
-  [[lane/mount-batch!]] already runs. That set is checkable and small —
-  `(lane/mount-batch!` has five call sites on this lane, this file,
+  [[rf.bench.hicasso.lane/mount-batch!]] already runs. That set is checkable and small —
+  `(rf.bench.hicasso.lane/mount-batch!` has five call sites on this lane, this file,
   `amp_merge_clock_app`, `coldmount_app`, `p0_converge_app` and
   `p0_reagent_app` — and the last three all sample at 8/12, so the two
   clocks were the lane's only batched-mount outliers. This arm stops
@@ -299,7 +299,7 @@
   probe that cannot pass manufactures a defect and hides real ones behind
   it."
   [arm container]
-  (and (= (:elements arm) (lane/element-count container))
+  (and (= (:elements arm) (rf.bench.hicasso.lane/element-count container))
        (or (= :floor (:id arm))
            (= (expected-far-end) (far-end container)))))
 
@@ -309,10 +309,10 @@
 
 (defn parity!
   "Mount every arm at once and compare the judged arms' canonical DOM.
-  Answers `lane/parity`'s verdict with the mounts already released."
+  Answers `rf.bench.hicasso.lane/parity`'s verdict with the mounts already released."
   []
-  (let [{:keys [mounts] :as p} (lane/parity arms nil)]
-    (doseq [m mounts] (lane/release! m))
+  (let [{:keys [mounts] :as p} (rf.bench.hicasso.lane/parity arms nil)]
+    (doseq [m mounts] (rf.bench.hicasso.lane/release! m))
     p))
 
 (defn parity-can-fail?
@@ -321,15 +321,15 @@
   to the run's own labels afterwards, so nothing downstream is measured
   on the mutated page."
   []
-  (let [before (let [m (lane/mount-arm! (nth arms 1) nil)
-                     s (lane/canonical (:container m))]
-                 (lane/release! m)
+  (let [before (let [m (rf.bench.hicasso.lane/mount-arm! (nth arms 1) nil)
+                     s (rf.bench.hicasso.lane/canonical (:container m))]
+                 (rf.bench.hicasso.lane/release! m)
                  s)]
     (rf/with-frame frame-id
       (rf/dispatch-sync [:dr/seed (seed-db boundaries mutated-label)]))
-    (let [after (let [m (lane/mount-arm! (nth arms 2) nil)
-                      s (lane/canonical (:container m))]
-                  (lane/release! m)
+    (let [after (let [m (rf.bench.hicasso.lane/mount-arm! (nth arms 2) nil)
+                      s (rf.bench.hicasso.lane/canonical (:container m))]
+                  (rf.bench.hicasso.lane/release! m)
                   s)]
       (rf/with-frame frame-id
         (rf/dispatch-sync [:dr/seed (seed-db boundaries default-label)]))
@@ -341,12 +341,12 @@
 
 (defn- measure-one!
   [tally arm]
-  (let [{:keys [ms mounts]} (lane/mount-batch! arm nil (:k arm))]
+  (let [{:keys [ms mounts]} (rf.bench.hicasso.lane/mount-batch! arm nil (:k arm))]
     (doseq [m mounts]
       (let [ok? (verified? arm (:container m))]
         (swap! tally (fn [{:keys [of bad]}]
                        {:of (inc of) :bad (if ok? bad (inc bad))}))))
-    (doseq [m mounts] (lane/release! m))
+    (doseq [m mounts] (rf.bench.hicasso.lane/release! m))
     ms))
 
 (defn- fmt [x n] (.toFixed (double x) n))
@@ -357,7 +357,7 @@
        "BEFORE the clock starts; the :ctl-2x arm's sample is the SAME operation "
        "performed TWICE inside one window, so its per-sample constants double "
        "with its work and its prediction is 2.00x by construction rather than by "
-       "model — adjudicated by lane/control-verdict-strict, which requires EVERY "
+       "model — adjudicated by rf.bench.hicasso.lane/control-verdict-strict, which requires EVERY "
        "round's ctl-2x/hiccup ratio to sit inside ±"
        (.toFixed (* 100.0 control-slack) 0)
        "% of it rather than merely the range, and records the per-round values so "
@@ -375,9 +375,9 @@
 ;; ---------------------------------------------------------------------------
 
 (defn ^:export -main []
-  (rf/init! uix-adapter/adapter)
-  (lane/leave-act-environment!)
-  (lane/self-test!)
+  (rf/init! rf.adapter.uix/adapter)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/self-test!)
   (-> (js/Promise.resolve nil)
       (.then
         (fn [_]
@@ -390,12 +390,12 @@
           ;; known able to disagree.
           (let [p         (parity!)
                 can-fail? (parity-can-fail?)]
-            (lane/record! :direct-return-clock-parity
+            (rf.bench.hicasso.lane/record! :direct-return-clock-parity
                           {:agree?    (:agree? p)
                            :disagree  (:disagree p)
                            :counts    (:counts p)
                            :can-fail? can-fail?
-                           :bytes     (lane/utf8-bytes (or (:reference p) ""))})
+                           :bytes     (rf.bench.hicasso.lane/utf8-bytes (or (:reference p) ""))})
             (when-not (:agree? p)
               (throw (ex-info (str "FAIRNESS GATE: the two arms do not build the same "
                                    "mounted page, so no ratio between them is about the "
@@ -407,40 +407,40 @@
                                    "that cannot answer false is not a gate, and the "
                                    "agreement above is worth nothing.")
                               {}))))
-          (lane/assert-teardown-clean! "the fairness gate")
-          (.then (lane/settle!) (fn [_] nil))))
+          (rf.bench.hicasso.lane/assert-teardown-clean! "the fairness gate")
+          (.then (rf.bench.hicasso.lane/settle!) (fn [_] nil))))
       (.then
         (fn [_]
-          (let [baseline (lane/residue frame-id)
-                tally    (lane/tally)
+          (let [baseline (rf.bench.hicasso.lane/residue frame-id)
+                tally    (rf.bench.hicasso.lane/tally)
                 {:keys [readings samples]}
-                (lane/rounds! arms sampling rounds (partial measure-one! tally))
-                norm     (mapv #(lane/normalise % :floor) readings)
+                (rf.bench.hicasso.lane/rounds! arms sampling rounds (partial measure-one! tally))
+                norm     (mapv #(rf.bench.hicasso.lane/normalise % :floor) readings)
                 ratios   (mapv :ratio norm)
-                summ     (lane/across-rounds ratios)
+                summ     (rf.bench.hicasso.lane/across-rounds ratios)
                 p50s     (mapv :p50 norm)
                 abs      (into {}
                                (map (fn [{:keys [id]}]
-                                      [id (lane/summarise (mapv #(get % id) p50s))]))
+                                      [id (rf.bench.hicasso.lane/summarise (mapv #(get % id) p50s))]))
                                arms)
-                escape   (lane/ratio-between ratios :direct :hiccup)
-                gv       (lane/guard! samples "direct-return clock arms (in-page ms)")
+                escape   (rf.bench.hicasso.lane/ratio-between ratios :direct :hiccup)
+                gv       (rf.bench.hicasso.lane/guard! samples "direct-return clock arms (in-page ms)")
                 ;; THE POSITIVE CONTROL, per round and strictly (rf2-gsn62).
                 ;; `:ctl-2x` is `:hiccup`'s own operation performed twice in
                 ;; one window, so 2.00x is arithmetic rather than a model,
                 ;; and dividing each round by ITS OWN `:hiccup` leaves the
                 ;; floor and the round's drift out of it.
-                ctl-ratio (lane/ratio-between ratios :ctl-2x :hiccup)
-                ctl      (lane/control-verdict-strict
+                ctl-ratio (rf.bench.hicasso.lane/ratio-between ratios :ctl-2x :hiccup)
+                ctl      (rf.bench.hicasso.lane/control-verdict-strict
                            2.0 (:per-round ctl-ratio) control-slack)
-                tv       (lane/tally-value tally)]
-            (lane/assert-teardown-clean! "the measured rounds")
-            (lane/record! :direct-return-clock
+                tv       (rf.bench.hicasso.lane/tally-value tally)]
+            (rf.bench.hicasso.lane/assert-teardown-clean! "the measured rounds")
+            (rf.bench.hicasso.lane/record! :direct-return-clock
                           {:benchmark   :hicasso.P0/direct-return-clock
                            :bead        "rf2-5yn9"
                            :cites       "budgets.md D10-D13 (rf2-hic-033) — the deterministic half, NOT re-derived here"
                            :grade       :distributional
-                           :runtime     (lane/runtime-label)
+                           :runtime     (rf.bench.hicasso.lane/runtime-label)
                            :boundaries  boundaries
                            :elements    {:floor floor-elements :page page-elements}
                            :design      {:rounds rounds :sampling sampling}
@@ -481,10 +481,10 @@
               (set! (.-HICASSO_GUARD_REFUSED js/window) true))
             (when-not (:ok? ctl)
               (set! (.-HICASSO_CONTROL_FAILED js/window) true))
-            (.then (lane/settle!)
+            (.then (rf.bench.hicasso.lane/settle!)
                    (fn [_]
-                     (lane/assert-residue! baseline frame-id "the measured rounds")
-                     (lane/done!))))))
+                     (rf.bench.hicasso.lane/assert-residue! baseline frame-id "the measured rounds")
+                     (rf.bench.hicasso.lane/done!))))))
       (.catch (fn [e]
-                (lane/fail! (or (some-> e .-message) (str e)))
-                (lane/done!)))))
+                (rf.bench.hicasso.lane/fail! (or (some-> e .-message) (str e)))
+                (rf.bench.hicasso.lane/done!)))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/front/census_article_editor_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/front/census_article_editor_cljs_test.cljs
@@ -52,11 +52,11 @@
   compared. If the ported screen were not the same screen, the diff in
   the PR would be measuring two different things."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.bench.hicasso.front.codec :as codec]
-            [re-frame.bench.hicasso.front.controlled :as controlled]
-            [re-frame.bench.hicasso.front.intent :as intent]))
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
+            [re-frame.bench.hicasso.front.controlled :as rf.bench.hicasso.front.controlled]
+            [re-frame.bench.hicasso.front.intent :as rf.bench.hicasso.front.intent]))
 
-(use-fixtures :each {:before (fn [] (codec/reset-caches!))})
+(use-fixtures :each {:before (fn [] (rf.bench.hicasso.front.codec/reset-caches!))})
 
 (def ^:private draft
   {:title "A title" :description "A description" :body "A body" :tagList "a,b"})
@@ -158,7 +158,7 @@
   unchanged; only the type moved."
   [e]
   (into [] (mapcat (fn [group] (filter #(and (some? %)
-                                             (= "input" (controlled/element-tag %)))
+                                             (= "input" (rf.bench.hicasso.front.controlled/element-tag %)))
                                        (children-of group))))
         (children-of e)))
 
@@ -171,8 +171,8 @@
         (js->clj (.-props e))))
 
 (defn- render [hiccup dispatched]
-  (intent/with-frame (fn [ev] (swap! dispatched conj ev))
-                     (fn [] (codec/as-element hiccup))))
+  (rf.bench.hicasso.front.intent/with-frame (fn [ev] (swap! dispatched conj ev))
+                     (fn [] (rf.bench.hicasso.front.codec/as-element hiccup))))
 
 ;; ---------------------------------------------------------------------------
 ;; The port is the same screen

--- a/bench/hicasso/src/re_frame/bench/hicasso/front/codec.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/front/codec.cljs
@@ -203,9 +203,9 @@
   author never wrote an attribute named `revision`, so nothing on the
   page explains the denial except this paragraph."
   (:require [clojure.string :as str]
-            [re-frame.bench.hicasso.front.controlled :as controlled]
-            [re-frame.bench.hicasso.front.intent :as intent]
-            [re-frame.bench.hicasso.front.slot :as slot]
+            [re-frame.bench.hicasso.front.controlled :as rf.bench.hicasso.front.controlled]
+            [re-frame.bench.hicasso.front.intent :as rf.bench.hicasso.front.intent]
+            [re-frame.bench.hicasso.front.slot :as rf.bench.hicasso.front.slot]
             ["react" :as react]))
 
 (declare as-element)
@@ -339,7 +339,7 @@
   ;; one entry per distinct literal, minted on first sight, correct for
   ;; the life of the build.
   ;;
-  ;; `event?` is the name-string's answer (`intent/event-prop?` on the
+  ;; `event?` is the name-string's answer (`rf.bench.hicasso.front.intent/event-prop?` on the
   ;; NAME), and the consumer must gate it on `keyword?` — a symbol
   ;; spelled `on-click` shares the entry but is NOT an event position
   ;; (event-prop? answers false for symbols), which is why the flag is
@@ -353,12 +353,12 @@
   "The [[PropSlot]] for a keyword or symbol prop literal whose name is
   `n`. Every field a pure function of the literal, per the deftype note."
   [k n]
-  (let [js-name (slot/prop-name k)]
+  (let [js-name (rf.bench.hicasso.front.slot/prop-name k)]
     (->PropSlot js-name
                 (reserved-name? js-name)
                 ;; asked of the NAME, not of `k` — a symbol shares the
                 ;; entry, and `event-prop?` already answers a boolean
-                (intent/event-prop? n)
+                (rf.bench.hicasso.front.intent/event-prop? n)
                 ;; "ref" — [[ref-slot]], spelled literally because the def
                 ;; sits below; `identical?` on primitive strings is value
                 ;; comparison.
@@ -388,9 +388,9 @@
   stated on the emitted name rather than on the key."
   [cache]
   (doto cache
-    (unchecked-set "class" (->PropSlot (slot/prop-name :class) false false false true))
-    (unchecked-set "for" (->PropSlot (slot/prop-name :for) false false false false))
-    (unchecked-set "charset" (->PropSlot (slot/prop-name :charset) false false false false))))
+    (unchecked-set "class" (->PropSlot (rf.bench.hicasso.front.slot/prop-name :class) false false false true))
+    (unchecked-set "for" (->PropSlot (rf.bench.hicasso.front.slot/prop-name :for) false false false false))
+    (unchecked-set "charset" (->PropSlot (rf.bench.hicasso.front.slot/prop-name :charset) false false false false))))
 
 (def ^:private prop-cache (seed-prop-cache! (empty-cache)))
 
@@ -430,7 +430,7 @@
   dependence the owned-literal law exists to remove."
   [k]
   (if-not (or (keyword? k) (symbol? k))
-    (if (string? k) (slot/prop-name k) k)
+    (if (string? k) (rf.bench.hicasso.front.slot/prop-name k) k)
     (let [^PropSlot s (prop-slot k (name k))]
       (.-js-name s))))
 
@@ -765,7 +765,7 @@
   lowerable value at an event position, not a marked callback) goes
   straight to [[convert-prop-value]] without entering the lowering at
   all, which is the branch nearly every attribute on a census page
-  takes. The paths [[intent/lower-prop]] IS entered on reproduce its
+  takes. The paths [[rf.bench.hicasso.front.intent/lower-prop]] IS entered on reproduce its
   answers by construction: it re-asks `event-prop?` and re-takes the
   same branch this slot was minted from. A string key keeps the donor's
   uncached path, byte for byte.
@@ -799,12 +799,12 @@
 
                              (and (.-event? s) (keyword? k))
                              (if (or (vector? v) (map? v) (fn? v))
-                               (intent/lower-prop k v)
+                               (rf.bench.hicasso.front.intent/lower-prop k v)
                                v)
 
                              :else
-                             (if (intent/callback? v)
-                               (intent/lower-prop k v)
+                             (if (rf.bench.hicasso.front.intent/callback? v)
+                               (rf.bench.hicasso.front.intent/lower-prop k v)
                                v)))))
         o)
       (let [n (cached-prop-name k)]
@@ -813,7 +813,7 @@
                               (cond
                                 (identical? ref-slot n)   (check-ref! k v)
                                 (identical? class-slot n) (class-names (unchecked-get o class-slot) v)
-                                :else                     (intent/lower-prop k v)))))
+                                :else                     (rf.bench.hicasso.front.intent/lower-prop k v)))))
         o))))
 
 (defn convert-props
@@ -1265,7 +1265,7 @@
      frame, `BRAVO` in another and `ALPHA-TWO` after a write — the
      justification falsified by what it permitted.
   2. **It did not survive the arm's other boundary variant.** A
-     frame-fed head ([[mark-frame-prop!]]) reads `intent/*frame*` at
+     frame-fed head ([[mark-frame-prop!]]) reads `rf.bench.hicasso.front.intent/*frame*` at
      ELEMENT-creation time, which in a fallback is mint time, where the
      var is `nil` — so it baked `nil` in, minted happily, and threw
      `:rf.error/no-frame-prop` one render into the server response.
@@ -2157,8 +2157,8 @@
         ;; map was the whole cost of telling it so (rf2-y1jkm).
         js-props    (convert-props props parsed)
         _           (when-some [r (get props revision-key)]
-                      (unchecked-set js-props controlled/revision-slot r))
-        component   (controlled/install! (.-tag parsed) js-props)]
+                      (unchecked-set js-props rf.bench.hicasso.front.controlled/revision-slot r))
+        component   (rf.bench.hicasso.front.controlled/install! (.-tag parsed) js-props)]
     (when-some [k (:key props)] (unchecked-set js-props "key" k))
     (make-element component js-props argv (if has-props? 2 1))))
 
@@ -2201,11 +2201,11 @@
     (when-some [k (:key props)] (unchecked-set js-props "key" k))
     ;; THE FRAME AS DATA (rf2-2rtt6.39). Only for a head that asked for
     ;; it, so the context-fed incumbent's element carries exactly what it
-    ;; always carried and the two variants are comparable. `intent/*frame*`
+    ;; always carried and the two variants are comparable. `rf.bench.hicasso.front.intent/*frame*`
     ;; is bound by the ancestor body this element is being created inside;
     ;; at the root there is no ancestor body and [[root-element]] binds it.
     (when (frame-prop-head? head)
-      (unchecked-set js-props "rfFrame" intent/*frame*))
+      (unchecked-set js-props "rfFrame" rf.bench.hicasso.front.intent/*frame*))
     (react/createElement (element-type head) js-props)))
 
 (def ^:private html-attr-slots
@@ -2437,7 +2437,7 @@
           class?       (if keyword-ish? (.-class? s) (identical? class-slot slot))
           event?       (if keyword-ish?
                          (and (.-event? s) (keyword? k))
-                         (intent/event-prop? k))]
+                         (rf.bench.hicasso.front.intent/event-prop? k))]
       (when-not reserved?
         (unchecked-set o slot
           (cond
@@ -2445,7 +2445,7 @@
             (check-ref! k v)
 
             (contains? declared slot)
-            (intent/lower-declared-prop k v (get declared slot))
+            (rf.bench.hicasso.front.intent/lower-declared-prop k v (get declared slot))
 
             ;; The slot's own coercion, and the slot's own composition —
             ;; the same law [[convert-entry]] takes at the native
@@ -2469,7 +2469,7 @@
                 ;; one. Both live in the `:else` arm only: no claimed
                 ;; slot pays either, and the NATIVE walk
                 ;; ([[convert-entry]]) is not on this path at all.
-                (when (intent/callback? v)
+                (when (rf.bench.hicasso.front.intent/callback? v)
                   (refuse-unclaimed-host-callback! head k))
                 ;; The SLOT, never the key: `:class` and `:className` are
                 ;; one position, and the named-value rule is written
@@ -2949,7 +2949,7 @@
   intent vector legal, and an intent written outside a boundary stays the
   loud `:rf.error/hicasso-intent-outside-boundary` it was."
   [frame-kw hiccup]
-  (binding [intent/*frame* frame-kw]
+  (binding [rf.bench.hicasso.front.intent/*frame* frame-kw]
     (as-element hiccup)))
 
 ;; ---------------------------------------------------------------------------

--- a/bench/hicasso/src/re_frame/bench/hicasso/front/dogfood_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/front/dogfood_cljs_test.cljs
@@ -26,14 +26,14 @@
   first Hicasso-arm commit that mounts the dogfood screen, and that
   commit belongs to rf2-2rtt6.9 / rf2-2rtt6.10, not to this bead."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.bench.hicasso.front.codec :as codec]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
-            [re-frame.bench.hicasso.front.intent :as intent]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
+            [re-frame.bench.hicasso.front.intent :as rf.bench.hicasso.front.intent]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
-(use-fixtures :each (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+(use-fixtures :each (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (def ^:private frame-id ::dogfood)
 
@@ -41,7 +41,7 @@
   "A frame with `n` to-dos."
   ([] (seeded! 3))
   ([n]
-   (dogfood/make-frame! frame-id n)
+   (rf.bench.hicasso.front.dogfood/make-frame! frame-id n)
    frame-id))
 
 (defn- read-sub [query]
@@ -62,7 +62,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-seeded-shape-is-the-one-the-screen-is-written-against
-  (let [db (dogfood/seed-db 3)]
+  (let [db (rf.bench.hicasso.front.dogfood/seed-db 3)]
     (is (= [0 1 2] (:order db)))
     (is (= 3 (count (:todos db))))
     (is (= {:id 1 :title "todo 1" :done? false} (get-in db [:todos 1])))
@@ -105,7 +105,7 @@
 (deftest keyed-insert-delete-and-reorder-move-the-order-and-nothing-else
   (seeded! 3)
   (testing "insert appends and mints the next id"
-    (send! [:dogfood/edit-draft dogfood/new-draft-key "milk"])
+    (send! [:dogfood/edit-draft rf.bench.hicasso.front.dogfood/new-draft-key "milk"])
     (send! [:dogfood/create])
     (is (= [0 1 2 3] (read-sub [:dogfood/visible-ids])))
     (is (= "milk" (:title (read-sub [:dogfood/todo 3])))))
@@ -132,11 +132,11 @@
   (seeded! 3)
   (send! [:dogfood/edit-draft 0 "zero"])
   (send! [:dogfood/edit-draft 2 "two"])
-  (send! [:dogfood/edit-draft dogfood/new-draft-key "new"])
+  (send! [:dogfood/edit-draft rf.bench.hicasso.front.dogfood/new-draft-key "new"])
   (testing "three instances, one subscription"
     (is (= "zero" (read-sub [:dogfood/draft 0])))
     (is (= "two" (read-sub [:dogfood/draft 2])))
-    (is (= "new" (read-sub [:dogfood/draft dogfood/new-draft-key])))
+    (is (= "new" (read-sub [:dogfood/draft rf.bench.hicasso.front.dogfood/new-draft-key])))
     (is (= "" (read-sub [:dogfood/draft 1])) "an instance nobody typed into"))
   (testing "commit is by explicit caller revision, never by value equality"
     (send! [:dogfood/commit 0])
@@ -160,8 +160,8 @@
 
 (deftest a-lowered-intent-reaches-a-real-event-handler
   (seeded! 3)
-  (let [el (intent/with-frame (frame-dispatch)
-                              (fn [] (codec/as-element
+  (let [el (rf.bench.hicasso.front.intent/with-frame (frame-dispatch)
+                              (fn [] (rf.bench.hicasso.front.codec/as-element
                                       [:button {:on-click [:dogfood/toggle 1]} "toggle"])))
         on-click (aget (.-props el) "onClick")]
     (is (false? (read-sub [:dogfood/done? 1])))
@@ -171,37 +171,37 @@
 
 (deftest the-controlled-field-carries-its-value-through-the-marker
   (seeded! 3)
-  (let [el (intent/with-frame (frame-dispatch)
-                              (fn [] (codec/as-element
-                                      [:input {:value (read-sub [:dogfood/draft dogfood/new-draft-key])
-                                               :on-input [:dogfood/edit-draft dogfood/new-draft-key
+  (let [el (rf.bench.hicasso.front.intent/with-frame (frame-dispatch)
+                              (fn [] (rf.bench.hicasso.front.codec/as-element
+                                      [:input {:value (read-sub [:dogfood/draft rf.bench.hicasso.front.dogfood/new-draft-key])
+                                               :on-input [:dogfood/edit-draft rf.bench.hicasso.front.dogfood/new-draft-key
                                                           :re-frame.hicasso/value]}])))
         on-input (aget (.-props el) "onInput")]
     (is (= "" (aget (.-props el) "value")))
     (on-input #js {:target #js {:value "mi"}})
-    (is (= "mi" (read-sub [:dogfood/draft dogfood/new-draft-key])))
+    (is (= "mi" (read-sub [:dogfood/draft rf.bench.hicasso.front.dogfood/new-draft-key])))
     (on-input #js {:target #js {:value "milk"}})
-    (is (= "milk" (read-sub [:dogfood/draft dogfood/new-draft-key])))))
+    (is (= "milk" (read-sub [:dogfood/draft rf.bench.hicasso.front.dogfood/new-draft-key])))))
 
 (deftest the-form-submits-once-and-prevents-the-browsers-navigation
   (seeded! 3)
-  (send! [:dogfood/edit-draft dogfood/new-draft-key "milk"])
+  (send! [:dogfood/edit-draft rf.bench.hicasso.front.dogfood/new-draft-key "milk"])
   (let [!prevented (atom false)
-        el (intent/with-frame (frame-dispatch)
-                              (fn [] (codec/as-element
+        el (rf.bench.hicasso.front.intent/with-frame (frame-dispatch)
+                              (fn [] (rf.bench.hicasso.front.codec/as-element
                                       [:form {:on-submit [:dogfood/create]}])))
         on-submit (aget (.-props el) "onSubmit")]
     (on-submit #js {:target #js {} :preventDefault (fn [] (reset! !prevented true))})
     (is (true? @!prevented))
     (is (= [0 1 2 3] (read-sub [:dogfood/visible-ids])))
     (is (= "milk" (:title (read-sub [:dogfood/todo 3]))))
-    (is (= "" (read-sub [:dogfood/draft dogfood/new-draft-key])))))
+    (is (= "" (read-sub [:dogfood/draft rf.bench.hicasso.front.dogfood/new-draft-key])))))
 
 (deftest the-key-map-commits-on-enter-cancels-on-escape-and-is-silent-mid-composition
   (seeded! 3)
   (send! [:dogfood/edit-draft 1 "renamed"])
-  (let [el (intent/with-frame (frame-dispatch)
-                              (fn [] (codec/as-element
+  (let [el (rf.bench.hicasso.front.intent/with-frame (frame-dispatch)
+                              (fn [] (rf.bench.hicasso.front.codec/as-element
                                       [:input {:on-key-down {"Enter"  [:dogfood/commit 1]
                                                              "Escape" [:dogfood/cancel 1]}}])))
         on-key-down (aget (.-props el) "onKeyDown")]

--- a/bench/hicasso/src/re_frame/bench/hicasso/front/intent.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/front/intent.cljs
@@ -248,8 +248,8 @@
   [[re-frame.bench.hicasso.front.controlled]] wraps the handler this
   namespace produced, after it has produced it, and nothing about the
   lowering changes because of it (rf2-fki5d)."
-  (:require [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]))
+  (:require [re-frame.frame :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]))
 
 ;; ---------------------------------------------------------------------------
 ;; The ambient frame (HD-020(a))
@@ -329,7 +329,7 @@
   exactly the render extent HD-002 clause (a) governs, so it is exactly
   where ambient `rf/subscribe` / `rf/dispatch` must stop resolving. It is
   bound HERE, fused into the binding this function already performs, rather
-  than through `frame/call-with-ambient-frame-refused` around the call:
+  than through `rf.frame/call-with-ambient-frame-refused` around the call:
   `binding` pushes and pops its whole set once, so the fence costs the arm
   no additional frame — the general seam exists for substrates that are not
   already binding something.
@@ -363,7 +363,7 @@
   ([frame-kw dispatch body-fn]
    (binding [*frame*                       frame-kw
              *dispatch*                    dispatch
-             frame/*ambient-frame-refusal* (cond-> ambient-frame-refusal
+             rf.frame/*ambient-frame-refusal* (cond-> ambient-frame-refusal
                                              frame-kw (assoc :extent-frame frame-kw))]
      (body-fn))))
 
@@ -1023,7 +1023,7 @@
   (let [{:keys [frame payload native? veto]} (unwrap-navigate k v)
         veto-fn (lower-veto k veto)]
     (fn hicasso-navigate [e]
-      (if-some [activate (late-bind/get-fn :routing/activate-link!)]
+      (if-some [activate (rf.late-bind/get-fn :routing/activate-link!)]
         (activate e veto-fn frame payload native?)
         (when veto-fn (veto-fn e)))
       nil)))

--- a/bench/hicasso/src/re_frame/bench/hicasso/front/presence.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/front/presence.cljs
@@ -85,7 +85,7 @@
   spend an effect on it. Deadlines are absolute instants stored when a
   key starts exiting, so a timer re-armed for an unrelated reason cannot
   extend a child's retention past its terminal bound."
-  (:require [re-frame.bench.hicasso.front.codec :as codec]))
+  (:require [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]))
 
 ;; ---------------------------------------------------------------------------
 ;; The reserved keys
@@ -202,7 +202,7 @@
   failure this whole ruling exists to delete."
   [child phase]
   (let [props (props-of child)]
-    (if (codec/boundary-head? (nth child 0))
+    (if (rf.bench.hicasso.front.codec/boundary-head? (nth child 0))
       (do
         (when (some #(contains? props %) override-keys)
           (fail! :rf.error/hicasso-presence-override-on-a-view
@@ -218,7 +218,7 @@
             base     (when props (apply dissoc props override-keys))]
         (cond
           (map? override)
-          (with-props child (merge base (codec/without-structural override)))
+          (with-props child (merge base (rf.bench.hicasso.front.codec/without-structural override)))
 
           ;; Nothing to strip and nothing to merge: the child is already
           ;; exactly what it should render as, so it comes back untouched

--- a/bench/hicasso/src/re_frame/bench/hicasso/front/route_link.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/front/route_link.cljs
@@ -73,8 +73,8 @@
   One click, one semantic event — the navigation, or the app intent that
   cancelled it. See intent.cljs §The navigate head for the click-time
   half."
-  (:require [re-frame.bench.hicasso.front.intent :as intent]
-            [re-frame.late-bind :as late-bind]))
+  (:require [re-frame.bench.hicasso.front.intent :as rf.bench.hicasso.front.intent]
+            [re-frame.late-bind :as rf.late-bind]))
 
 (def ^:private routing-artefact
   "The optional-artefact identity the fail-loud missing-hook error
@@ -148,7 +148,7 @@
 (defn on-click-roster!
   "Refuse, AT RENDER, an `:on-click` outside the route-click roster: nil,
   `[::h/prevent [:app/event]]` (the declarative veto), `h/event`, or a plain
-  function. The same roster [[intent/lower-veto]] enforces at lowering;
+  function. The same roster [[rf.bench.hicasso.front.intent/lower-veto]] enforces at lowering;
   stated twice because the two failures land differently — this one fails
   at the site that wrote the link, with the render stack, before any
   anchor exists. A BARE intent vector is the taught mistake and gets the
@@ -156,24 +156,24 @@
   (Freehand's route-link law, kept)."
   [on-click]
   (when-not (or (nil? on-click)
-                (intent/prevent-head? on-click)
-                (intent/callback? on-click)
+                (rf.bench.hicasso.front.intent/prevent-head? on-click)
+                (rf.bench.hicasso.front.intent/callback? on-click)
                 (fn? on-click))
     (fail! :rf.error/hicasso-route-link-bad-on-click
            'front.route-link/route-link
            (str "route-link's :on-click is the pre-navigation veto; it takes nil, "
-                "[" (pr-str intent/prevent-head) " [:my-event …]] (cancel the "
+                "[" (pr-str rf.bench.hicasso.front.intent/prevent-head) " [:my-event …]] (cancel the "
                 "navigation and dispatch this instead), h/event, or a plain function — "
                 "never " (pr-str on-click) ". A bare intent vector is refused "
                 "because the click already produces the one routing intent; an "
                 "application reaction belongs behind the routing event, or inside "
-                (pr-str intent/prevent-head) " if it replaces the navigation.")
+                (pr-str rf.bench.hicasso.front.intent/prevent-head) " if it replaces the navigation.")
            :veto-with-prevent-a-callback-or-nothing
            {:on-click on-click}))
   on-click)
 
 (defn- require-frame! [to]
-  (or intent/*frame*
+  (or rf.bench.hicasso.front.intent/*frame*
       (fail! :rf.error/hicasso-route-link-outside-boundary
              'front.route-link/route-link
              (str "route-link {:to " (pr-str to) "} was rendered with no ambient "
@@ -203,14 +203,14 @@
         _        (prefetch-declined! props)
         _        (on-click-roster! on-click)
         {:keys [href payload native?]}
-        ((late-bind/require-fn! :routing/link-model
+        ((rf.late-bind/require-fn! :routing/link-model
                                 'route-link
                                 routing-artefact
                                 {:to to})
          (dissoc props :on-click) frame-kw)
         attrs    (-> (apply dissoc props control-keys)
                      (assoc :href href
-                            :on-click [intent/navigate-head
+                            :on-click [rf.bench.hicasso.front.intent/navigate-head
                                        {:frame    frame-kw
                                         :payload  payload
                                         :native?  native?

--- a/bench/hicasso/src/re_frame/bench/hicasso/front/state.cljc
+++ b/bench/hicasso/src/re_frame/bench/hicasso/front/state.cljc
@@ -81,8 +81,8 @@
   is a fail-silent hazard of exactly the class this whole ruling exists to
   delete, so there is no sentinel here and no \"convenience\" arity that
   accepts one."
-  (:require [re-frame.events :as events]
-            [re-frame.subs :as subs]))
+  (:require [re-frame.events :as rf.events]
+            [re-frame.subs :as rf.subs]))
 
 ;; ---------------------------------------------------------------------------
 ;; The spellings
@@ -184,7 +184,7 @@
   "Register `[::h/clear ::concern ikey]`. Idempotent — one handler serves
   every concern, and re-registration replaces it with an identical one."
   []
-  (events/reg-event clear-event-id
+  (rf.events/reg-event clear-event-id
     (fn clear-handler [{:keys [db]} [_ concern ikey]]
       (check-key! concern ikey :clear)
       {:db (clear-entry db concern ikey)})))
@@ -296,11 +296,11 @@
               {:concern concern
                :registered-default (get @!defaults concern)
                :offered-default default}))
-     (subs/reg-sub concern
+     (rf.subs/reg-sub concern
        (fn read-state [db query-v]
          (let [ikey (check-key! concern (nth query-v 1 nil) :read)]
            (get-in db [ui-root concern ikey] default))))
-     (events/reg-event concern
+     (rf.events/reg-event concern
        (fn write-state [{:keys [db]} [_ ikey v]]
          (check-key! concern ikey :write)
          {:db (assoc-in db [ui-root concern ikey] v)}))

--- a/bench/hicasso/src/re_frame/bench/hicasso/front/witnesses_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/front/witnesses_cljs_test.cljs
@@ -8,17 +8,17 @@
   arm's partial-run banner is built on — actually reports an incomplete
   run rather than flattering it."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.bench.hicasso.front.witnesses :as w]))
+            [re-frame.bench.hicasso.front.witnesses :as rf.bench.hicasso.front.witnesses]))
 
 (deftest the-roster-covers-what-validation-enumerates
   (testing "every family the red-zone ratios are set per"
-    (is (= #{:bulk :mount :heap :controlled :correctness} w/families)))
+    (is (= #{:bulk :mount :heap :controlled :correctness} rf.bench.hicasso.front.witnesses/families)))
   (testing "the bulk pair, the mount row, and the two separated curves"
-    (is (contains? w/by-id :bulk/one-commit))
-    (is (contains? w/by-id :bulk/narrow-write))
-    (is (contains? w/by-id :mount/list-and-form))
-    (is (contains? w/by-id :scaling/fixed-reads))
-    (is (contains? w/by-id :scaling/fixed-boundaries)))
+    (is (contains? rf.bench.hicasso.front.witnesses/by-id :bulk/one-commit))
+    (is (contains? rf.bench.hicasso.front.witnesses/by-id :bulk/narrow-write))
+    (is (contains? rf.bench.hicasso.front.witnesses/by-id :mount/list-and-form))
+    (is (contains? rf.bench.hicasso.front.witnesses/by-id :scaling/fixed-reads))
+    (is (contains? rf.bench.hicasso.front.witnesses/by-id :scaling/fixed-boundaries)))
   (testing "the controlled door's six proofs are named, not summarised"
     (is (= [:same-turn-echo
             :mid-string-caret
@@ -26,52 +26,52 @@
             :ime-composition-commits-nothing
             :unchanged-model-rejection
             :async-normalisation]
-           (:asserts (w/by-id :controlled/grid-100)))))
+           (:asserts (rf.bench.hicasso.front.witnesses/by-id :controlled/grid-100)))))
   (testing "the lifecycle row carries the standing teardown assertions"
-    (is (contains? (set (:asserts (w/by-id :lifecycle/strict-abandoned-teardown-hmr)))
+    (is (contains? (set (:asserts (rf.bench.hicasso.front.witnesses/by-id :lifecycle/strict-abandoned-teardown-hmr)))
                    :zero-leaked-subscription-refcounts-after-teardown))
-    (is (contains? (set (:asserts (w/by-id :lifecycle/strict-abandoned-teardown-hmr)))
+    (is (contains? (set (:asserts (rf.bench.hicasso.front.witnesses/by-id :lifecycle/strict-abandoned-teardown-hmr)))
                    :unchanged-hot-read-performs-no-new-attach-or-release)))
   (testing "every kill criterion the witness set is supposed to feed has a witness"
-    (is (every? (w/gates) [:K1 :K2 :K3 :K4]))))
+    (is (every? (rf.bench.hicasso.front.witnesses/gates) [:K1 :K2 :K3 :K4]))))
 
 (deftest every-row-is-completely-declared
-  (doseq [row w/witnesses]
+  (doseq [row rf.bench.hicasso.front.witnesses/witnesses]
     (testing (str (:id row))
       (is (keyword? (:id row)))
-      (is (contains? w/families (:family row)))
+      (is (contains? rf.bench.hicasso.front.witnesses/families (:family row)))
       (is (string? (:what row)))
       (is (map? (:shape row)))
       (is (seq (:asserts row)) "a row with no assertion is a clock with no correctness")
       (is (seq (:gates row)))))
   (testing "the ids are unique"
-    (is (= (count w/witnesses) (count w/by-id)))))
+    (is (= (count rf.bench.hicasso.front.witnesses/witnesses) (count rf.bench.hicasso.front.witnesses/by-id)))))
 
 (deftest the-two-scaling-curves-are-separated
   (testing "fixed reads, growing boundaries"
-    (is (= [1 1 1] (mapv :reads w/fixed-reads-curve)))
-    (is (= [10 100 300] (mapv :boundaries w/fixed-reads-curve))))
+    (is (= [1 1 1] (mapv :reads rf.bench.hicasso.front.witnesses/fixed-reads-curve)))
+    (is (= [10 100 300] (mapv :boundaries rf.bench.hicasso.front.witnesses/fixed-reads-curve))))
   (testing "fixed boundaries, growing reads across the 1/3/7/20 ladder"
-    (is (= [100 100 100 100] (mapv :boundaries w/fixed-boundaries-curve)))
-    (is (= [1 3 7 20] (mapv :reads w/fixed-boundaries-curve))))
+    (is (= [100 100 100 100] (mapv :boundaries rf.bench.hicasso.front.witnesses/fixed-boundaries-curve)))
+    (is (= [1 3 7 20] (mapv :reads rf.bench.hicasso.front.witnesses/fixed-boundaries-curve))))
   (testing "the per-read curve is measured with distinct queries — rf2-2rtt6.16's worst case"
-    (is (every? :distinct-queries? w/fixed-boundaries-curve))))
+    (is (every? :distinct-queries? rf.bench.hicasso.front.witnesses/fixed-boundaries-curve))))
 
 (deftest missing-reports-an-incomplete-run-rather-than-flattering-it
   (testing "a run that reported nothing is missing everything"
-    (is (= (count w/witnesses) (count (w/missing [])))))
+    (is (= (count rf.bench.hicasso.front.witnesses/witnesses) (count (rf.bench.hicasso.front.witnesses/missing [])))))
   (testing "a run missing one row names that row"
-    (let [reported (remove #{:controlled/grid-100} (map :id w/witnesses))]
-      (is (= #{:controlled/grid-100} (w/missing reported)))))
+    (let [reported (remove #{:controlled/grid-100} (map :id rf.bench.hicasso.front.witnesses/witnesses))]
+      (is (= #{:controlled/grid-100} (rf.bench.hicasso.front.witnesses/missing reported)))))
   (testing "only a complete run reports nothing missing"
-    (is (= #{} (w/missing (map :id w/witnesses)))))
+    (is (= #{} (rf.bench.hicasso.front.witnesses/missing (map :id rf.bench.hicasso.front.witnesses/witnesses)))))
   (testing "an id nobody declared does not count toward coverage"
     (is (= #{:controlled/grid-100}
-           (w/missing (conj (vec (remove #{:controlled/grid-100} (map :id w/witnesses)))
+           (rf.bench.hicasso.front.witnesses/missing (conj (vec (remove #{:controlled/grid-100} (map :id rf.bench.hicasso.front.witnesses/witnesses)))
                             :invented/row))))))
 
 (deftest of-family-partitions-the-roster
-  (is (= (count w/witnesses)
-         (reduce + (map #(count (w/of-family %)) w/families))))
-  (is (= 2 (count (w/of-family :bulk))))
-  (is (= 2 (count (w/of-family :heap)))))
+  (is (= (count rf.bench.hicasso.front.witnesses/witnesses)
+         (reduce + (map #(count (rf.bench.hicasso.front.witnesses/of-family %)) rf.bench.hicasso.front.witnesses/families))))
+  (is (= 2 (count (rf.bench.hicasso.front.witnesses/of-family :bulk))))
+  (is (= 2 (count (rf.bench.hicasso.front.witnesses/of-family :heap)))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/generation_fence_coverage_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/generation_fence_coverage_cljs_test.cljs
@@ -6,7 +6,7 @@
   per boundary could stand in for the predecessor's commit-side re-read,
   which compared **three** things between the render that produced an
   element and the commit about to publish it: node identity
-  (`:node-key`), version, and the frame/registry epochs. This file was
+  (`:node-key`), version, and the rf.frame/registry epochs. This file was
   the answer, and the answer was *no* on all three.
 
   **Two of the three have since been closed** — rf2-2rtt6.42 replaced the
@@ -113,21 +113,21 @@
   load-bearing: on an unwatchable host a subscription never notifies and
   the control half would be as still as the axis it is controlling for."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.live-frame :as live-frame]
-            [re-frame.test-support :as test-support]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.live-frame :as rf.live-frame]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      ;; The carried-invariant chain resolves the dynamic-var frame tier
      ;; BEFORE React context, so a fixture-installed ambient frame would
      ;; answer reads for a frame this row never made.
      :ambient-frame nil
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private q [:genfence/v])
 
@@ -136,15 +136,15 @@
   and re-registering a query some other suite reads would be a test
   writing on a neighbour."
   [id db]
-  (live-frame/make-frame {:id id})
-  (frame/replace-app-db! id db)
+  (rf.live-frame/make-frame {:id id})
+  (rf.frame/replace-app-db! id db)
   id)
 
 (defn- reader
   "A boundary whose whole body is one read, so the entry's read set is one
   key and the snapshot arithmetic is one term."
   [seen]
-  (fn [_] (let [v (rt/sub q)] (vreset! seen v) [:li (str v)])))
+  (fn [_] (let [v (rf.bench.hicasso.arm1.runtime/sub q)] (vreset! seen v) [:li (str v)])))
 
 ;; ---------------------------------------------------------------------------
 ;; The registry-epoch axis reaches a staged key and not a held one
@@ -180,21 +180,21 @@
     (rf/reg-sub (first q) (fn [db _] (:v db)))
     (let [seen (volatile! nil)
           f    (make-frame! ::registry {:v 1})]
-      (rt/render-body f (reader seen) {})
-      (let [entry    (rt/last-reads)
-            release! (rt/commit-boundary! entry (fn []))]
+      (rf.bench.hicasso.arm1.runtime/render-body f (reader seen) {})
+      (let [entry    (rf.bench.hicasso.arm1.runtime/last-reads)
+            release! (rf.bench.hicasso.arm1.runtime/commit-boundary! entry (fn []))]
         (is (= 1 @seen) "the render read the value that was true when it ran")
 
         (testing "the CONTROL — the instruments are live on this frame, this
                   boundary and this read set. A real frame-state install
                   moves the basis and moves the number React re-checks."
-          (let [basis    (rt/commit-basis f)
-                snapshot (rt/snapshot-of entry)]
-            (frame/replace-app-db! f {:v 2})
-            (is (> (rt/commit-basis f) basis)
+          (let [basis    (rf.bench.hicasso.arm1.runtime/commit-basis f)
+                snapshot (rf.bench.hicasso.arm1.runtime/snapshot-of entry)]
+            (rf.frame/replace-app-db! f {:v 2})
+            (is (> (rf.bench.hicasso.arm1.runtime/commit-basis f) basis)
                 "a physical frame-state install bumps `frame-commit-epoch`,
                  so the basis moves")
-            (is (not= snapshot (rt/snapshot-of entry))
+            (is (not= snapshot (rf.bench.hicasso.arm1.runtime/snapshot-of entry))
                 "and the retained key's watch fired, so the epoch sum moved
                  too — this is what a MOVE looks like on these instruments")))
 
@@ -205,27 +205,27 @@
           ;; mounted boundary is untouched and a shared frame would let one
           ;; claim borrow the other's stillness.
           (let [staged-f     (make-frame! ::registry-staged {:v 1})
-                _            (rt/render-body staged-f (reader (volatile! nil)) {})
-                staged-entry (rt/last-reads)
-                staged-snap  (rt/snapshot-of staged-entry)
-                basis        (rt/commit-basis f)
-                snapshot     (rt/snapshot-of entry)
-                generation   (rt/generation)]
+                _            (rf.bench.hicasso.arm1.runtime/render-body staged-f (reader (volatile! nil)) {})
+                staged-entry (rf.bench.hicasso.arm1.runtime/last-reads)
+                staged-snap  (rf.bench.hicasso.arm1.runtime/snapshot-of staged-entry)
+                basis        (rf.bench.hicasso.arm1.runtime/commit-basis f)
+                snapshot     (rf.bench.hicasso.arm1.runtime/snapshot-of entry)
+                generation   (rf.bench.hicasso.arm1.runtime/generation)]
             (rf/reg-sub (first q) (fn [db _] (* 10 (:v db))))
-            (is (= generation (rt/generation))
+            (is (= generation (rf.bench.hicasso.arm1.runtime/generation))
                 "the flush generation did not move — a re-registration is not
                  a value change on an acquired reaction, so it never reaches
                  `mark-dirty!`")
-            (is (> (rt/commit-basis f) basis)
+            (is (> (rf.bench.hicasso.arm1.runtime/commit-basis f) basis)
                 "but the basis did: `registry-epoch` is its third term, and a
                  registration is the one thing that moves it (rf2-2rtt6.50)")
-            (is (= snapshot (rt/snapshot-of entry))
+            (is (= snapshot (rf.bench.hicasso.arm1.runtime/snapshot-of entry))
                 "and the MOUNTED boundary's number is still exactly the
                  number it was — its key is held, so its contribution is the
                  cell's frozen stamp and not a live basis read. This is the
                  assertion that separates this term from the one
                  rf2-2rtt6.44 declined")
-            (is (not= staged-snap (rt/snapshot-of staged-entry))
+            (is (not= staged-snap (rf.bench.hicasso.arm1.runtime/snapshot-of staged-entry))
                 "while the STAGED boundary's number moved — its key has no
                  cell, so it contributes the basis live, and React's
                  post-`subscribe` re-check will see the tear")))

--- a/bench/hicasso/src/re_frame/bench/hicasso/hd8_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/hd8_app.cljs
@@ -33,13 +33,13 @@
   rf2-2rtt6.2's `:hicasso-bench` build id.
 
   Normative owner: `docs/design/hicasso/decisions.md` HD-008."
-  (:require [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.adapter.reagent-slim :as slim-adapter]
-            [re-frame.adapter.uix :as uix-adapter]
+  (:require [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.hd8-rows :as rows]
-            [re-frame.bench.hicasso.hd8-witnesses :as w]))
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.hd8-rows :as rf.bench.hicasso.hd8-rows]
+            [re-frame.bench.hicasso.hd8-witnesses :as rf.bench.hicasso.hd8-witnesses]))
 
 (def ^:private rounds 6)
 (def ^:private mount-sampling {:warmup 4 :samples 12})
@@ -198,9 +198,9 @@
 
 (defn- install! [which]
   (rf/init! (case which
-              :reagent reagent-adapter/adapter
-              :slim    slim-adapter/adapter
-              uix-adapter/adapter))
+              :reagent rf.adapter.reagent/adapter
+              :slim    rf.adapter.reagent-slim/adapter
+              rf.adapter.uix/adapter))
   which)
 
 ;; ---------------------------------------------------------------------------
@@ -210,18 +210,18 @@
 (defn- run-all! []
   (let [which    (query-adapter)
         _        (install! which)
-        arm-ids  (get rows/arm-ids-for which)
-        write-ids (get rows/write-arm-ids-for which)
+        arm-ids  (get rf.bench.hicasso.hd8-rows/arm-ids-for which)
+        write-ids (get rf.bench.hicasso.hd8-rows/write-arm-ids-for which)
         ;; THE CLOCK'S OWN GRAIN, taken in the run it governs. Every page in
         ;; this studio asserted "Chrome clamps performance.now() to 100 µs"
         ;; and then reasoned against that constant; the write rows' floor is
         ;; a single commit and sits ON it, so the number decides whether
         ;; those rows have a magnitude at all and is measured rather than
         ;; quoted (rf2-d2tzk).
-        clock    (rows/clock-resolution! clock-resolution-samples)]
-    (lane/leave-act-environment!)
-    (doseq [id arm-ids] (rows/ensure-frame! id))
-    (record! :method (rows/method-record which arm-ids write-ids rounds mount-sampling write-sampling))
+        clock    (rf.bench.hicasso.hd8-rows/clock-resolution! clock-resolution-samples)]
+    (rf.bench.hicasso.lane/leave-act-environment!)
+    (doseq [id arm-ids] (rf.bench.hicasso.hd8-rows/ensure-frame! id))
+    (record! :method (rf.bench.hicasso.hd8-rows/method-record which arm-ids write-ids rounds mount-sampling write-sampling))
     (record! :clock-resolution clock)
     (set! (.-HD8_CLOCK js/window) (clj->js clock))
 
@@ -239,7 +239,7 @@
     ;; `catch` is the fail-closed path (`assert-teardown-clean!` uses it for
     ;; the same reason), and a `when-not` here would print the failure and
     ;; then measure the whole plan anyway.
-    (let [st (rows/yield-correction-self-test)]
+    (let [st (rf.bench.hicasso.hd8-rows/yield-correction-self-test)]
       (record! :yield-correction-self-test st)
       ;; Also on a JS-readable channel, so the driver can fail on it instead
       ;; of parsing EDN it has no reader for.
@@ -265,13 +265,13 @@
     ;; the argument. `parity-can-fail?` below remains the anti-vacuity gate.
 
     ;; ---- the fairness gate, before any clock ------------------------------
-    (let [problems (rows/parity-problems arm-ids)]
+    (let [problems (rf.bench.hicasso.hd8-rows/parity-problems arm-ids)]
       (if (seq problems)
         (do (record! :parity {:ok? false :problems problems})
             (fail! (str "canonical-DOM parity failed — every figure below it would be "
                         "a comparison of two different pages: " (pr-str problems)))
             (done!))
-        (let [can-fail? (rows/parity-can-fail? arm-ids)]
+        (let [can-fail? (rf.bench.hicasso.hd8-rows/parity-can-fail? arm-ids)]
           (record! :parity {:ok? true :can-fail? can-fail?
                             :note (str "every arm built the same page, compared as canonical "
                                        "DOM with attribute names sorted; the same comparison "
@@ -283,7 +283,7 @@
                 (done!))
 
             ;; ---- the positive control, then the lowering check -------------
-            (let [pc (record! :positive-control (rows/positive-control! 3 control-sampling))]
+            (let [pc (record! :positive-control (rf.bench.hicasso.hd8-rows/positive-control! 3 control-sampling))]
               (if-not (:within? pc)
                 ;; FAIL CLOSED. This used to `console.warn` and then measure
                 ;; everything anyway, so a run whose instrument could not see
@@ -301,8 +301,8 @@
                                 "says it must, so no clock figure in this run would be "
                                 "reportable and none was taken."))
                     (done!))
-                (-> (if (rows/donor-run? which)
-                      (rows/lowering-works! which)
+                (-> (if (rf.bench.hicasso.hd8-rows/donor-run? which)
+                      (rf.bench.hicasso.hd8-rows/lowering-works! which)
                       ;; The donor rungs are not in this run's arm set (see
                       ;; `arm-ids-for`), so there is no lowering here to check
                       ;; and a check that trivially passed would be worse than
@@ -325,16 +325,16 @@
 
                           ;; ---- the clocks ----------------------------------
                           (do
-                            (doseq [wit rows/witnesses]
+                            (doseq [wit rf.bench.hicasso.hd8-rows/witnesses]
                               (record-row! (keyword (str "mount-" (name (:id wit))))
-                                           (rows/measure-mount! wit arm-ids rounds mount-sampling))
+                                           (rf.bench.hicasso.hd8-rows/measure-mount! wit arm-ids rounds mount-sampling))
                               ;; A teardown that threw is checked BETWEEN rows,
                               ;; not swallowed until the end: an arm whose
                               ;; unmount failed leaves its watches and its
                               ;; caches standing, and the next row is then
                               ;; measured on a page that is carrying them
                               ;; (rf2-f5roa, from the PR #7263 audit).
-                              (rows/assert-teardown-clean! (str "mount-" (name (:id wit)))))
+                              (rf.bench.hicasso.hd8-rows/assert-teardown-clean! (str "mount-" (name (:id wit)))))
                             ;; The harness microtask, priced before the write rows
                             ;; and outside every one of their windows. A
                             ;; microtask-scheduled arm's window does not contain
@@ -343,22 +343,22 @@
                             ;; — and, since this bead, ADJUDICATED against them
                             ;; rather than left beside them as an observation.
                             (let [yc* (volatile! nil)]
-                              (-> (rows/yield-cost! write-sampling)
+                              (-> (rf.bench.hicasso.hd8-rows/yield-cost! write-sampling)
                                   (.then (fn [yc]
                                            (record! :yield-cost yc)
                                            (vreset! yc* yc)
-                                           (rows/measure-write! write-ids which :narrow rounds write-sampling clock)))
+                                           (rf.bench.hicasso.hd8-rows/measure-write! write-ids which :narrow rounds write-sampling clock)))
                                   (.then (fn [r]
                                            (record-row! :write-narrow r)
-                                           (rows/assert-teardown-clean! "write-narrow")
-                                           (-> (rows/measure-write! write-ids which :bulk rounds write-sampling clock)
+                                           (rf.bench.hicasso.hd8-rows/assert-teardown-clean! "write-narrow")
+                                           (-> (rf.bench.hicasso.hd8-rows/measure-write! write-ids which :bulk rounds write-sampling clock)
                                                (.then (fn [b] #js [r b])))))
                                   (.then
                                     (fn [pair]
                                       (let [narrow (aget pair 0)
                                             bulk   (aget pair 1)]
                                         (record-row! :write-bulk bulk)
-                                        (rows/assert-teardown-clean! "write-bulk")
+                                        (rf.bench.hicasso.hd8-rows/assert-teardown-clean! "write-bulk")
                                         ;; ---- THE CORRECTION-OR-REFUSAL CONTRACT ----
                                         ;; The asymmetry between the two window shapes
                                         ;; used to be recorded here and nothing else:
@@ -373,8 +373,8 @@
                                         ;; positive control takes, for the same reason:
                                         ;; a figure the instrument cannot stand behind
                                         ;; is not a measurement.
-                                        (let [verdicts {:write-narrow (rows/yield-correction narrow which @yc*)
-                                                        :write-bulk   (rows/yield-correction bulk which @yc*)}
+                                        (let [verdicts {:write-narrow (rf.bench.hicasso.hd8-rows/yield-correction narrow which @yc*)
+                                                        :write-bulk   (rf.bench.hicasso.hd8-rows/yield-correction bulk which @yc*)}
                                               refused  (into {} (filter (fn [[_ v]] (= :refused (:verdict v)))) verdicts)]
                                           (record! :yield-correction verdicts)
                                           (doseq [[k v] verdicts] (correction! k v))

--- a/bench/hicasso/src/re_frame/bench/hicasso/hd8_clock_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/hd8_clock_app.cljs
@@ -17,7 +17,7 @@
   [[re-frame.bench.hicasso.hd8-rows]]'s OWN mount arms, unchanged: the same
   mount doors, the same per-arm frames, the same witnesses (`M`, 300
   boundary rows, `3 + 3N` elements; `U`, a 300-cell grid, `1 + N`), the
-  same `lane/mount-arm!` window for the in-page diagnostic reading. It
+  same `rf.bench.hicasso.lane/mount-arm!` window for the in-page diagnostic reading. It
   measures MOUNT ONLY. The write rows are not here: `rf2-d2tzk` records
   that the bulk row's floor sits on the clock clamp on the in-page
   instrument, and on this box the bulk-class rows cannot hold a
@@ -54,12 +54,12 @@
 
   Owner: rf2-2rtt6.1 (standard); this entry rf2-2rtt6.31."
   (:require ["react-dom/client" :as react-dom-client]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.adapter.reagent-slim :as slim-adapter]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.hd8-rows :as rows]
-            [re-frame.bench.hicasso.hd8-witnesses :as w]
-            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.hd8-rows :as rf.bench.hicasso.hd8-rows]
+            [re-frame.bench.hicasso.hd8-witnesses :as rf.bench.hicasso.hd8-witnesses]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
             [re-frame.core :as rf]))
 
 ;; ---------------------------------------------------------------------------
@@ -77,9 +77,9 @@
 
 (defn- install! [which]
   (rf/init! (case which
-              :reagent reagent-adapter/adapter
-              :slim    slim-adapter/adapter
-              uix-adapter/adapter))
+              :reagent rf.adapter.reagent/adapter
+              :slim    rf.adapter.reagent-slim/adapter
+              rf.adapter.uix/adapter))
   which)
 
 ;; ---------------------------------------------------------------------------
@@ -115,9 +115,9 @@
 (def ^:private ctl2x-m-rows
   "The doubling control's data — 600 rows of the same shape `:hd8/seed`
   writes, built once at load so no measured window pays for it."
-  (mapv #(str "r" %) (range (* 2 w/rows-n))))
+  (mapv #(str "r" %) (range (* 2 rf.bench.hicasso.hd8-witnesses/rows-n))))
 
-(def ^:private ctl2x-u-cells (vec (repeat (* 2 w/cells-n) "0")))
+(def ^:private ctl2x-u-cells (vec (repeat (* 2 rf.bench.hicasso.hd8-witnesses/cells-n) "0")))
 
 (defn- ctl2x-arm
   "The floor at TWICE the witness's boundaries — `clock_run.cjs`'s mount
@@ -129,13 +129,13 @@
   SIGNAL; what it cannot certify is exactness, and the driver states both."
   [witness-id]
   {:id       :ctl-2x
-   :cells    (* 2 w/rows-n)
+   :cells    (* 2 rf.bench.hicasso.hd8-witnesses/rows-n)
    :control? true
    :mount    (fn [container _props _n]
                (let [r (react-dom-client/createRoot container)]
                  (.render r (case witness-id
-                              :M (w/floor-m {:rows ctl2x-m-rows :n (* 2 w/rows-n)})
-                              :U (w/floor-u {:cells ctl2x-u-cells :n (* 2 w/cells-n)})))
+                              :M (rf.bench.hicasso.hd8-witnesses/floor-m {:rows ctl2x-m-rows :n (* 2 rf.bench.hicasso.hd8-witnesses/rows-n)})
+                              :U (rf.bench.hicasso.hd8-witnesses/floor-u {:cells ctl2x-u-cells :n (* 2 rf.bench.hicasso.hd8-witnesses/cells-n)})))
                  r))
    :unmount  (fn [r] (.unmount r))})
 
@@ -143,8 +143,8 @@
 
 (defn- witness-arm [witness-id arm-id]
   (case witness-id
-    :M (rows/m-arm arm-id)
-    :U (rows/u-arm arm-id)))
+    :M (rf.bench.hicasso.hd8-rows/m-arm arm-id)
+    :U (rf.bench.hicasso.hd8-rows/u-arm arm-id)))
 
 (defonce ^:private state (atom {:adapter nil :pending nil :tally nil}))
 
@@ -159,11 +159,11 @@
 
 (defn- expected-elements [row-key arm]
   (let [wid (get row-witness row-key)
-        n   (if (= :ctl-2x (:id arm)) (* 2 w/rows-n) w/rows-n)]
+        n   (if (= :ctl-2x (:id arm)) (* 2 rf.bench.hicasso.hd8-witnesses/rows-n) rf.bench.hicasso.hd8-witnesses/rows-n)]
     (cond
       (:plumb? arm) 0
-      (= :M wid)    (w/m-elements n)
-      :else         (w/u-elements n))))
+      (= :M wid)    (rf.bench.hicasso.hd8-witnesses/m-elements n)
+      :else         (rf.bench.hicasso.hd8-witnesses/u-elements n))))
 
 ;; ---------------------------------------------------------------------------
 ;; The frame settle — what makes the driver's delta frame-inclusive
@@ -183,7 +183,7 @@
     ok?))
 
 (defn sample!
-  "ONE mount through `lane/mount-arm!` — the SAME `flushSync` window the
+  "ONE mount through `rf.bench.hicasso.lane/mount-arm!` — the SAME `flushSync` window the
   hd8 instrument times, so the in-page diagnostic reading rides beside the
   protocol one on the same operation — left STANDING, settled to the next
   frame. The tare's operation is the settle and nothing else."
@@ -191,7 +191,7 @@
   (let [arm (arm-named row-key arm-id)]
     (if (:plumb? arm)
       (.then (settle-frame) (fn [_] (bank! true) #js {:inPageMs 0 :ok true}))
-      (let [mnt (lane/mount-arm! arm {:n w/rows-n})]
+      (let [mnt (rf.bench.hicasso.lane/mount-arm! arm {:n rf.bench.hicasso.hd8-witnesses/rows-n})]
         (swap! state assoc :pending {:mnt mnt :arm arm})
         (.then (settle-frame) (fn [_] #js {:inPageMs (:ms mnt) :ok true}))))))
 
@@ -202,9 +202,9 @@
   [row-key]
   (if-some [{:keys [mnt arm]} (:pending @state)]
     (let [ok? (= (expected-elements row-key arm)
-                 (lane/element-count (:container mnt)))]
+                 (rf.bench.hicasso.lane/element-count (:container mnt)))]
       (bank! ok?)
-      (lane/release! mnt)
+      (rf.bench.hicasso.lane/release! mnt)
       (swap! state assoc :pending nil)
       (.then (settle-frame) (fn [_] #js {:ok ok?})))
     (.then (settle-frame) (fn [_] #js {:ok true}))))
@@ -232,14 +232,14 @@
   (let [arm (arm-named row-key arm-id)]
     (if (:plumb? arm)
       #js {:arm (name arm-id) :hash 0 :bytes 0 :control true}
-      (let [mnt (lane/mount-arm! arm {:n w/rows-n})
-            s   (lane/canonical (:container mnt))]
-        (lane/release! mnt)
-        ;; `lane/utf8-bytes` and not `count`: the driver prints this under a
+      (let [mnt (rf.bench.hicasso.lane/mount-arm! arm {:n rf.bench.hicasso.hd8-witnesses/rows-n})
+            s   (rf.bench.hicasso.lane/canonical (:container mnt))]
+        (rf.bench.hicasso.lane/release! mnt)
+        ;; `rf.bench.hicasso.lane/utf8-bytes` and not `count`: the driver prints this under a
         ;; `bytes` label, and `count` answers UTF-16 code units (rf2-2rtt6.121).
         #js {:arm     (name arm-id)
              :hash    (str-hash s)
-             :bytes   (lane/utf8-bytes s)
+             :bytes   (rf.bench.hicasso.lane/utf8-bytes s)
              :control (boolean (:control? arm))}))))
 
 ;; ---------------------------------------------------------------------------
@@ -249,26 +249,26 @@
 (defn ^:export -main []
   (let [which (query-adapter)]
     (install! which)
-    (lane/leave-act-environment!)
-    (swap! state assoc :adapter which :tally (lane/tally))
-    (doseq [id (get arm-ids-for which)] (rows/ensure-frame! id))
+    (rf.bench.hicasso.lane/leave-act-environment!)
+    (swap! state assoc :adapter which :tally (rf.bench.hicasso.lane/tally))
+    (doseq [id (get arm-ids-for which)] (rf.bench.hicasso.hd8-rows/ensure-frame! id))
     ;; hd8's OWN fairness gate, whole and fatal-on-fail: every arm of this
     ;; run builds one page at the stress size and at a small size, and the
     ;; comparison is proven able to answer false. Runs before the driver
     ;; reads a single counter; the driver refuses the run if it failed.
-    (let [problems  (rows/parity-problems (get arm-ids-for which))
+    (let [problems  (rf.bench.hicasso.hd8-rows/parity-problems (get arm-ids-for which))
           can-fail? (when (empty? problems)
-                      (rows/parity-can-fail? (get arm-ids-for which)))]
+                      (rf.bench.hicasso.hd8-rows/parity-can-fail? (get arm-ids-for which)))]
       (set! (.-HD8CLOCK_PARITY js/window)
             (clj->js {"ok"       (and (empty? problems) (boolean can-fail?))
                       "canFail"  (boolean can-fail?)
                       "problems" (mapv pr-str problems)})))
     (set! (.-HD8CLOCK js/window)
-          (lane/legible-doors
+          (rf.bench.hicasso.lane/legible-doors
           #js {:adapter       (name which)
                :plan          (fn [row]
                                 (clj->js (mapv (fn [a] {:id      (name (:id a))
-                                                        :cells   (or (:cells a) w/rows-n)
+                                                        :cells   (or (:cells a) rf.bench.hicasso.hd8-witnesses/rows-n)
                                                         :control (boolean (:control? a))
                                                         :plumb   (boolean (:plumb? a))})
                                                (arms-for (keyword row)))))
@@ -276,10 +276,10 @@
                :sample        (fn [row arm] (sample! (keyword row) (keyword arm)))
                :reap          (fn [row] (reap! (keyword row)))
                :settle        (fn [] (settle-frame))
-               :tally         (fn [] (clj->js (lane/tally-value (:tally @state))))
-               :teardownCheck (fn [] (clj->js (mapv :where (lane/drain-teardown-failures!))))
-               :runtime       (fn [] (pr-str (lane/runtime-label)))
-               :residue       (fn [] (pr-str (lane/residue (rows/frame-of :floor))))}))
+               :tally         (fn [] (clj->js (rf.bench.hicasso.lane/tally-value (:tally @state))))
+               :teardownCheck (fn [] (clj->js (mapv :where (rf.bench.hicasso.lane/drain-teardown-failures!))))
+               :runtime       (fn [] (pr-str (rf.bench.hicasso.lane/runtime-label)))
+               :residue       (fn [] (pr-str (rf.bench.hicasso.lane/residue (rf.bench.hicasso.hd8-rows/frame-of :floor))))}))
     (set! (.-HD8CLOCK_READY js/window) true)
     (js/console.log ";; HD8CLOCK ready")
     nil))

--- a/bench/hicasso/src/re_frame/bench/hicasso/hd8_rows.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/hd8_rows.cljs
@@ -67,7 +67,7 @@
   not reopened by inspection:
 
   1. **The BATCHED write window IS now adopted on the narrow row, and it
-     came with its re-run (rf2-9zysg).** `lane/mount-batch!`'s argument —
+     came with its re-run (rf2-9zysg).** `rf.bench.hicasso.lane/mount-batch!`'s argument —
      timing `k` operations as one sample lifts a reading clear of Chrome's
      100 µs `performance.now()` clamp, and is not the same as summing `k`
      separately-clamped readings — applies to the narrow write row, which
@@ -84,21 +84,21 @@
      passes a batch of one — the pre-batch window exactly — and did not
      move; the mount rows (4–13 ms) never needed it.
 
-  2. **`lane/control-verdict` is WEAKER than [[positive-control!]]'s own
+  2. **`rf.bench.hicasso.lane/control-verdict` is WEAKER than [[positive-control!]]'s own
      rule and would be a downgrade.** The lane passes a control whose
      measured range merely OVERLAPS ±slack of the prediction; this one
      requires EVERY round inside the band. Letting a good round vouch for a
      bad one is how an instrument stops being one, and the stricter rule
      stays.
 
-  3. **`lane/tally` counts `{:of :bad}` in one atom; this row counts them
+  3. **`rf.bench.hicasso.lane/tally` counts `{:of :bad}` in one atom; this row counts them
      PER ARM.** A pooled count says half the writes failed and leaves a
      reader to guess which arm. The per-arm map is the difference between a
      diagnosis and a mystery, and it is threaded immutably through the
      promise chain rather than mutated beside it.
 
   4. **The verdict is adjudicated in the DRIVER, not in ClojureScript.**
-     `lane/guard!` adjudicates in-bundle with the `.cljc` copy of the rule;
+     `rf.bench.hicasso.lane/guard!` adjudicates in-bundle with the `.cljc` copy of the rule;
      `hd8_run.cjs` adjudicates with the `.cjs` copy. The two copies are
      held in step by shared self-test fixtures, and a lane that exercises
      the other one is worth more than the symmetry.
@@ -108,11 +108,11 @@
   (:require ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]
             [clojure.string :as str]
-            [re-frame.adapter.uix :as uixa]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.hd8-witnesses :as w]
+            [re-frame.frame :as rf.frame]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.hd8-witnesses :as rf.bench.hicasso.hd8-witnesses]
             [reagent.core :as reagent]
             [reagent.dom.client :as rdc]
             [reagent.ratom :as reagent-ratom]
@@ -131,8 +131,8 @@
   its dispatch lookup. Runs OUTSIDE every measured window."
   [arm-id]
   (let [fid (frame-of arm-id)]
-    (rf/make-frame {:id fid :initial-events [[:hd8/seed w/cells-n]]})
-    (w/prime-frame! fid)
+    (rf/make-frame {:id fid :initial-events [[:hd8/seed rf.bench.hicasso.hd8-witnesses/cells-n]]})
+    (rf.bench.hicasso.hd8-witnesses/prime-frame! fid)
     fid))
 
 (defn reseed!
@@ -140,10 +140,10 @@
   row never measures a page that a previous round already mutated."
   [arm-id]
   (let [fid (frame-of arm-id)]
-    (rf/with-frame fid (rf/dispatch-sync [:hd8/seed w/cells-n]))
+    (rf/with-frame fid (rf/dispatch-sync [:hd8/seed rf.bench.hicasso.hd8-witnesses/cells-n]))
     nil))
 
-(defn- db-of [arm-id] (frame/frame-app-db-value (frame-of arm-id)))
+(defn- db-of [arm-id] (rf.frame/frame-app-db-value (frame-of arm-id)))
 
 ;; ===========================================================================
 ;; MOUNT arms
@@ -190,7 +190,7 @@
   through the published UIx provider. Not a DOM element, so parity is
   untouched."
   [fid child]
-  ($ uixa/frame-provider {:frame fid} child))
+  ($ rf.adapter.uix/frame-provider {:frame fid} child))
 
 ;; -- the M page -------------------------------------------------------------
 
@@ -198,20 +198,20 @@
   (let [fid (frame-of id)]
     (case id
       :floor        (react-root-arm :floor (fn [{:keys [n]}]
-                                             (w/floor-m {:rows (:rows (db-of :floor))
+                                             (rf.bench.hicasso.hd8-witnesses/floor-m {:rows (:rows (db-of :floor))
                                                          :n    n})))
       :reagent      (reagent-arm :reagent
                                  (fn [{:keys [n]}]
-                                   [rf/frame-provider {:frame fid} [w/rg-m n]]))
+                                   [rf/frame-provider {:frame fid} [rf.bench.hicasso.hd8-witnesses/rg-m n]]))
       :reagent-slim (slim-arm :reagent-slim
                               (fn [{:keys [n]}]
-                                [rf/frame-provider {:frame fid} [w/rg-m n]]))
+                                [rf/frame-provider {:frame fid} [rf.bench.hicasso.hd8-witnesses/rg-m n]]))
       :uix          (react-root-arm :uix (fn [{:keys [n]}]
-                                           (provided fid ($ w/ux-m {:n n}))))
+                                           (provided fid ($ rf.bench.hicasso.hd8-witnesses/ux-m {:n n}))))
       :donor-r1     (react-root-arm :donor-r1 (fn [{:keys [n]}]
-                                                (w/slim-element (w/r1-m n fid))))
+                                                (rf.bench.hicasso.hd8-witnesses/slim-element (rf.bench.hicasso.hd8-witnesses/r1-m n fid))))
       :donor-r2     (react-root-arm :donor-r2 (fn [{:keys [n]}]
-                                                (provided fid (w/slim-element (w/r2-m n))))))))
+                                                (provided fid (rf.bench.hicasso.hd8-witnesses/slim-element (rf.bench.hicasso.hd8-witnesses/r2-m n))))))))
 
 ;; -- the U page (mounted for parity; measured by the write rows) ------------
 
@@ -219,20 +219,20 @@
   (let [fid (frame-of id)]
     (case id
       :floor        (react-root-arm :floor (fn [{:keys [n]}]
-                                             (w/floor-u {:cells (:cells (db-of :floor))
+                                             (rf.bench.hicasso.hd8-witnesses/floor-u {:cells (:cells (db-of :floor))
                                                          :n     n})))
       :reagent      (reagent-arm :reagent
                                  (fn [{:keys [n]}]
-                                   [rf/frame-provider {:frame fid} [w/rg-u n]]))
+                                   [rf/frame-provider {:frame fid} [rf.bench.hicasso.hd8-witnesses/rg-u n]]))
       :reagent-slim (slim-arm :reagent-slim
                               (fn [{:keys [n]}]
-                                [rf/frame-provider {:frame fid} [w/rg-u n]]))
+                                [rf/frame-provider {:frame fid} [rf.bench.hicasso.hd8-witnesses/rg-u n]]))
       :uix          (react-root-arm :uix (fn [{:keys [n]}]
-                                           (provided fid ($ w/ux-u {:n n}))))
+                                           (provided fid ($ rf.bench.hicasso.hd8-witnesses/ux-u {:n n}))))
       :donor-r1     (react-root-arm :donor-r1 (fn [{:keys [n]}]
-                                                (w/slim-element (w/r1-u n fid))))
+                                                (rf.bench.hicasso.hd8-witnesses/slim-element (rf.bench.hicasso.hd8-witnesses/r1-u n fid))))
       :donor-r2     (react-root-arm :donor-r2 (fn [{:keys [n]}]
-                                                (provided fid (w/slim-element (w/r2-u n))))))))
+                                                (provided fid (rf.bench.hicasso.hd8-witnesses/slim-element (rf.bench.hicasso.hd8-witnesses/r2-u n))))))))
 
 ;; ===========================================================================
 ;; The arm sets — one adapter per process (Spec 006)
@@ -298,17 +298,17 @@
   [{:id       :M
     :doc      "300 rows, each a boundary with its own subscription and its own handler — markup-dominant"
     :arm-of   m-arm
-    :props    {:n w/rows-n}
+    :props    {:n rf.bench.hicasso.hd8-witnesses/rows-n}
     :small    {:n 6}
-    :elements (w/m-elements w/rows-n)
-    :small-elements (w/m-elements 6)}
+    :elements (rf.bench.hicasso.hd8-witnesses/m-elements rf.bench.hicasso.hd8-witnesses/rows-n)
+    :small-elements (rf.bench.hicasso.hd8-witnesses/m-elements 6)}
    {:id       :U
     :doc      "a 300-cell grid, same per-cell shape — the page the write rows drive"
     :arm-of   u-arm
-    :props    {:n w/cells-n}
+    :props    {:n rf.bench.hicasso.hd8-witnesses/cells-n}
     :small    {:n 6}
-    :elements (w/u-elements w/cells-n)
-    :small-elements (w/u-elements 6)}])
+    :elements (rf.bench.hicasso.hd8-witnesses/u-elements rf.bench.hicasso.hd8-witnesses/cells-n)
+    :small-elements (rf.bench.hicasso.hd8-witnesses/u-elements 6)}])
 
 (defn arms-for [witness arm-ids] (mapv (:arm-of witness) arm-ids))
 
@@ -322,7 +322,7 @@
   that held under `:none` and failed under `:advanced` would be a renaming
   bug silently deciding the comparison."
   [witness arm-ids props]
-  (lane/parity (arms-for witness arm-ids) props))
+  (rf.bench.hicasso.lane/parity (arms-for witness arm-ids) props))
 
 (defn parity-problems
   "Answer a vector of problems — empty when every arm built one page with
@@ -345,7 +345,7 @@
 
                 (not (pos? (count (get canon (first arm-ids) ""))))
                 (conj {:witness id :size what :problem :built-nothing}))
-              (finally (doseq [mnt mounts] (lane/release! mnt))))))
+              (finally (doseq [mnt mounts] (rf.bench.hicasso.lane/release! mnt))))))
         problems
         [[props elements :stress] [small small-elements :small]]))
     []
@@ -362,21 +362,21 @@
     (try
       (and (not= (:reference a) (:reference b)) (:agree? a) (:agree? b))
       (finally
-        (doseq [mnt (:mounts a)] (lane/release! mnt))
-        (doseq [mnt (:mounts b)] (lane/release! mnt))))))
+        (doseq [mnt (:mounts a)] (rf.bench.hicasso.lane/release! mnt))
+        (doseq [mnt (:mounts b)] (rf.bench.hicasso.lane/release! mnt))))))
 
 ;; ===========================================================================
 ;; The mount clock — with the order-guard's per-sample records
 ;; ===========================================================================
 
-(def ^:private round4 lane/round4)
-(defn- p50 [xs] (:p50 (lane/summarise xs)))
+(def ^:private round4 rf.bench.hicasso.lane/round4)
+(defn- p50 [xs] (:p50 (rf.bench.hicasso.lane/summarise xs)))
 
 (def slot-order
-  "Slot order for `k` arms at sample index `s` — `lane/slot-order`, and
+  "Slot order for `k` arms at sample index `s` — `rf.bench.hicasso.lane/slot-order`, and
   nothing local.
 
-  This was a local override, added because `lane/slot-order` composed a
+  This was a local override, added because `rf.bench.hicasso.lane/slot-order` composed a
   rotation with a reflection and the two CANCEL at `k = 2`: rotating a pair
   by one is the same permutation as reversing it, so `[0 1]` came back at
   every index and a two-arm plan ran in ONE ORDER for ever. The arm-order
@@ -390,7 +390,7 @@
   `rf2-ouwh8` has since repaired the schedule where it lives — so the
   override is gone and this name is the lane's, exactly like every other
   mechanism in this file."
-  lane/slot-order)
+  rf.bench.hicasso.lane/slot-order)
 
 (defn mount-round!
   "One round over `arms`: `(+ warmup samples)` sample indices, every arm
@@ -410,7 +410,7 @@
     (dotimes [s (+ warmup samples)]
       (doseq [j (slot-order k s)]
         (let [arm (nth arms j)
-              mnt (lane/mount-arm! arm props)
+              mnt (rf.bench.hicasso.lane/mount-arm! arm props)
               p   @pos]
           (when (>= s warmup)
             (swap! acc update (:id arm) conj (:ms mnt))
@@ -420,7 +420,7 @@
                               :position    p}))
           (reset! prev (:id arm))
           (swap! pos inc)
-          (lane/release! mnt))))
+          (rf.bench.hicasso.lane/release! mnt))))
     {:readings @acc :samples @recs :position @pos}))
 
 (defn normalise
@@ -466,7 +466,7 @@
   includes 1.0 — in which case the two arms are INDISTINGUISHABLE on this
   witness and the mean must not be quoted as a winner.
 
-  The arithmetic is `lane/ratio-between` and no longer a second copy of it
+  The arithmetic is `rf.bench.hicasso.lane/ratio-between` and no longer a second copy of it
   (rf2-f5roa). It is fed this row's raw `:p50` maps rather than its
   floor-normalised `:ratio` maps — algebraically the floor cancels either
   way, but rounding to four places twice is not the same as rounding once,
@@ -478,7 +478,7 @@
           (keep (fn [[a b]]
                   (when (and (contains? present a) (contains? present b))
                     [(keyword (str (name a) "-over-" (name b)))
-                     (lane/ratio-between p50s a b)])))
+                     (rf.bench.hicasso.lane/ratio-between p50s a b)])))
           head-to-head-pairs)))
 
 (defn measure-mount!
@@ -502,7 +502,7 @@
      :doc       (:doc witness)
      :arms      (vec arm-ids)
      :per-round norm
-     :summary   (lane/across-rounds (mapv :ratio norm))
+     :summary   (rf.bench.hicasso.lane/across-rounds (mapv :ratio norm))
      :head-to-head (head-to-head norm)
      :samples   (:samples acc)}))
 
@@ -596,7 +596,7 @@
   published ranges carry that noise (rf2-9zysg). Timing `k` writes as ONE
   sample lifts the window clear of the clamp, and it is NOT the same as
   summing `k` separately-clamped readings, which quantises `k` times and
-  adds the errors. `lane/mount-batch!` does exactly this for mounts.
+  adds the errors. `rf.bench.hicasso.lane/mount-batch!` does exactly this for mounts.
 
   The cost is that a batched window cannot verify each write in the turn
   its own drain ran in, because there is only one clock. It verifies all
@@ -630,7 +630,7 @@
   carries the evidence, including the positive control (a plain component
   reading a plain `reagent2.core/atom`, no re-frame anywhere on the path)
   that reproduces it in all four bundle compositions. The general form —
-  the same fixed yield in the shared `lane/verified-write!` — is rf2-pq7d8,
+  the same fixed yield in the shared `rf.bench.hicasso.lane/verified-write!` — is rf2-pq7d8,
   and it HAS since been repaired: the lane takes the same `:scheduler`
   declaration and gives it these same two shapes, lifted from here rather
   than invented a second time. That repair is additive — an arm that
@@ -659,9 +659,9 @@
       ;; is one synchronous run, so not even a microtask separates a drain
       ;; from the next write.
       (fn [steps]
-        (let [t0 (lane/now-ms)]
+        (let [t0 (rf.bench.hicasso.lane/now-ms)]
           (doseq [s steps] ((:write! s)) (force!))
-          (let [ms (- (lane/now-ms) t0)]
+          (let [ms (- (rf.bench.hicasso.lane/now-ms) t0)]
             (js/Promise.resolve {:ms ms :oks (verify-all steps)}))))
       ;; Write, yield ONE microtask, drain — per operation, k times, under
       ;; one clock. The next write starts in the turn the previous drain
@@ -669,10 +669,10 @@
       ;; 2k: the fixed yield is preserved per operation, never batched away
       ;; and never doubled.
       (fn [steps]
-        (let [t0 (lane/now-ms)]
+        (let [t0 (rf.bench.hicasso.lane/now-ms)]
           (letfn [(run [ss]
                     (if (empty? ss)
-                      (let [ms (- (lane/now-ms) t0)]
+                      (let [ms (- (rf.bench.hicasso.lane/now-ms) t0)]
                         (js/Promise.resolve {:ms ms :oks (verify-all steps)}))
                       (do ((:write! (first ss)))
                           (-> (js/Promise.resolve nil)
@@ -700,7 +700,7 @@
         force! (fn []
                  (if (= arm-id :floor)
                    (react-dom/flushSync
-                     (fn [] (.render ^js @rt (w/floor-u {:cells @state :n w/cells-n}))))
+                     (fn [] (.render ^js @rt (rf.bench.hicasso.hd8-witnesses/floor-u {:cells @state :n rf.bench.hicasso.hd8-witnesses/cells-n}))))
                    (spine-drain! adapter)))]
     {:id     arm-id
      :mount  (fn [container]
@@ -709,11 +709,11 @@
                    (reset! state (:cells (db-of :floor)))
                    (vreset! rt r)
                    (react-dom/flushSync
-                     (fn [] (.render r (w/floor-u {:cells @state :n w/cells-n}))))
+                     (fn [] (.render r (rf.bench.hicasso.hd8-witnesses/floor-u {:cells @state :n rf.bench.hicasso.hd8-witnesses/cells-n}))))
                    r)
                  (let [handle (volatile! nil)]
                    (react-dom/flushSync
-                     (fn [] (vreset! handle ((:mount arm) container {:n w/cells-n} 0))))
+                     (fn [] (vreset! handle ((:mount arm) container {:n rf.bench.hicasso.hd8-witnesses/cells-n} 0))))
                    @handle)))
      :write! (fn [i val]
                (if (= arm-id :floor)
@@ -725,7 +725,7 @@
                  ;; and the report says so: a fine-grained substrate can and
                  ;; should beat it on a narrow write.
                  (if (= i :all)
-                   (reset! state (vec (repeat w/cells-n val)))
+                   (reset! state (vec (repeat rf.bench.hicasso.hd8-witnesses/cells-n val)))
                    (swap! state assoc i val))
                  (if (= i :all)
                    (rf/dispatch-sync [:hd8/set-all val] {:frame fid})
@@ -752,8 +752,8 @@
 
 (defn release-write-arms!
   "Release every write arm. A throw is RECORDED, never swallowed — and a
-  normal return is not taken at its word: `lane/container-released!` reads
-  each container before it is removed, exactly as `lane/release!` does,
+  normal return is not taken at its word: `rf.bench.hicasso.lane/container-released!` reads
+  each container before it is removed, exactly as `rf.bench.hicasso.lane/release!` does,
   because a root that survives its own unmount does so on a DETACHED tree
   no later census can see (rf2-jk3vj)."
   [mounts]
@@ -761,8 +761,8 @@
     (when (try ((:unmount arm) handle)
                true
                (catch :default e
-                 (lane/teardown-failure! (str "release-write-arms! " (:id arm)) e)))
-      (lane/container-released! (str "release-write-arms! " (:id arm)) container))
+                 (rf.bench.hicasso.lane/teardown-failure! (str "release-write-arms! " (:id arm)) e)))
+      (rf.bench.hicasso.lane/container-released! (str "release-write-arms! " (:id arm)) container))
     (.remove container)))
 
 (defn assert-teardown-clean!
@@ -776,7 +776,7 @@
   — the same fail-closed path parity and the lowering check already take
   (rf2-f5roa, from the PR #7263 audit)."
   [after]
-  (let [fs (lane/drain-teardown-failures!)]
+  (let [fs (rf.bench.hicasso.lane/drain-teardown-failures!)]
     (when (seq fs)
       (throw (ex-info (str "teardown FAILED after " after
                            " — an arm did not unmount, so its React root, watches and "
@@ -807,7 +807,7 @@
   `probes` is a SEQ and used to be a single cell, which was thin on the
   BULK row (rf2-f5roa): a broad write changes all 300 cells, this probed
   cell 0, and a page left stale by a commit landing outside the window can
-  still carry one fresh cell from the previous write. `lane/bulk-probes`
+  still carry one fresh cell from the previous write. `rf.bench.hicasso.lane/bulk-probes`
   is the rule now, and the P0 arm three files away already used it. The
   NARROW row is unchanged and was already right — one cell changes, so one
   probe is the whole page's worth of verification.
@@ -881,15 +881,15 @@
                             ;; batch's k cells are k distinct cells.
                             ;;
                             ;; A broad write changes every cell, so it is
-                            ;; verified at three (`lane/bulk-probes`); a
+                            ;; verified at three (`rf.bench.hicasso.lane/bulk-probes`); a
                             ;; narrow write changes one, so it is verified
                             ;; at that one.
                             ops (mapv (fn [c]
                                         (let [o (+ (* p bk) c)
                                               v (str "v" o)]
                                           (if (= kind :bulk)
-                                            [:all v (lane/bulk-probes o w/cells-n)]
-                                            (let [cell (mod o w/cells-n)]
+                                            [:all v (rf.bench.hicasso.lane/bulk-probes o rf.bench.hicasso.hd8-witnesses/cells-n)]
+                                            (let [cell (mod o rf.bench.hicasso.hd8-witnesses/cells-n)]
                                               [cell v [cell]]))))
                                       (range bk))]
                         (-> (timed-write! mnt ops)
@@ -1119,7 +1119,7 @@
                                 :writes-per-sample (if (= kind :bulk) 1 narrow-batch-k)
                                 :arms         (vec arm-ids)
                                 :per-round    (:rounds-out acc)
-                                :summary      (lane/across-rounds (mapv :ratio (:rounds-out acc)))
+                                :summary      (rf.bench.hicasso.lane/across-rounds (mapv :ratio (:rounds-out acc)))
                                 :head-to-head (head-to-head (:rounds-out acc))
                                 :unverified   (:unverified acc)
                                 :writes       (:total acc)
@@ -1146,10 +1146,10 @@
   would add two resolution ticks per step and price a window the arms
   never run. At `k = 1` this is the original one-turn reading exactly."
   [k]
-  (let [t0 (lane/now-ms)]
+  (let [t0 (rf.bench.hicasso.lane/now-ms)]
     (letfn [(run [n]
               (if (zero? n)
-                (js/Promise.resolve (- (lane/now-ms) t0))
+                (js/Promise.resolve (- (rf.bench.hicasso.lane/now-ms) t0))
                 (-> (js/Promise.resolve nil)
                     (.then (fn [_] (run (dec n)))))))]
       (run k))))
@@ -1203,8 +1203,8 @@
             (.then
               (run narrow-batch-k)
               (fn [xsk]
-                (let [s1  (lane/summarise xs1)
-                      sk  (lane/summarise xsk)
+                (let [s1  (rf.bench.hicasso.lane/summarise xs1)
+                      sk  (rf.bench.hicasso.lane/summarise xsk)
                       per (fn [v] (when (number? v) (/ v narrow-batch-k)))]
                   {:control :harness-microtask-yield
                    ;; The original one-turn reading, unchanged, so nothing
@@ -1245,7 +1245,7 @@
 
 (defn- tick-once
   "One observation of the clock's grain: the first difference
-  [[lane/now-ms]] reports after a busy wait, or `nil` if it reported none
+  [[rf.bench.hicasso.lane/now-ms]] reports after a busy wait, or `nil` if it reported none
   within `spin-cap` reads.
 
   A clamped clock answers the SAME value for every read inside a tick, so
@@ -1254,9 +1254,9 @@
   it answers `nil` so a missing reading fails closed rather than arriving
   as a small number."
   [spin-cap]
-  (let [t0 (lane/now-ms)]
+  (let [t0 (rf.bench.hicasso.lane/now-ms)]
     (loop [i 0]
-      (let [t1 (lane/now-ms)]
+      (let [t1 (rf.bench.hicasso.lane/now-ms)]
         (cond
           (> t1 t0)      (round4 (- t1 t0))
           (>= i spin-cap) nil
@@ -1289,7 +1289,7 @@
   (let [spin-cap 5000000
         ds       (vec (repeatedly n #(tick-once spin-cap)))
         good     (vec (remove nil? ds))
-        s        (lane/summarise good)]
+        s        (rf.bench.hicasso.lane/summarise good)]
     {:control     :clock-resolution
      :tick        (when (= (count good) (count ds)) (:min s))
      :p50         (:p50 s)
@@ -1297,7 +1297,7 @@
      :n           (count ds)
      :unresolved  (- (count ds) (count good))
      :distinct    (vec (sort (distinct good)))
-     :note (str "the smallest difference lane/now-ms reports, measured by spinning until "
+     :note (str "the smallest difference rf.bench.hicasso.lane/now-ms reports, measured by spinning until "
                 "the clock advances. A denominator at this size cannot be told from one "
                 "half its size or twice it, so a ratio taken against it carries the grain "
                 "rather than the arm (rf2-d2tzk)")}))
@@ -1396,7 +1396,7 @@
 
   A floor-normalised entry is formed from its own arm and from the floor,
   which is its denominator; a head-to-head pair from the two arms
-  `lane/ratio-between` named in it. An entry a publication mask has
+  `rf.bench.hicasso.lane/ratio-between` named in it. An entry a publication mask has
   replaced with `:unpublished` contributes nothing, because there is no
   longer a figure there for anything to change.
 
@@ -1612,7 +1612,7 @@
                 ;; dropped — the corrected map carries exactly the pairs the
                 ;; original published, never one it withheld.
                 summary'  (inherit-publication-mask
-                            (lane/across-rounds (mapv :ratio corrected))
+                            (rf.bench.hicasso.lane/across-rounds (mapv :ratio corrected))
                             (:summary row))
                 h2h'      (select-keys (head-to-head corrected)
                                        (keys (:head-to-head row)))
@@ -1665,7 +1665,7 @@
      :arms              arms
      :writes-per-sample k
      :per-round         per-round
-     :summary           (lane/across-rounds (mapv :ratio per-round))
+     :summary           (rf.bench.hicasso.lane/across-rounds (mapv :ratio per-round))
      :head-to-head      (head-to-head per-round)}))
 
 (defn- grain-fixture
@@ -1932,9 +1932,9 @@
   wide enough to pass an honest instrument and far too tight to pass one
   that is not measuring the page."
   [rounds sampling]
-  (let [n         w/rows-n
+  (let [n         rf.bench.hicasso.hd8-witnesses/rows-n
         half      (quot n 2)
-        predicted (/ (double (w/m-elements n)) (double (w/m-elements half)))
+        predicted (/ (double (rf.bench.hicasso.hd8-witnesses/m-elements n)) (double (rf.bench.hicasso.hd8-witnesses/m-elements half)))
         ;; The two sizes are TWO ARMS in ONE round, interleaved and
         ;; reflected like everything else. They were not, in the first cut,
         ;; and the control promptly read 0.42 in one round of three — the
@@ -1943,9 +1943,9 @@
         ;; to detect, which would have made it a source of false alarm
         ;; rather than an instrument.
         full-arm  (react-root-arm :control-full
-                                  (fn [_] (w/floor-m {:rows (:rows (db-of :floor)) :n n})))
+                                  (fn [_] (rf.bench.hicasso.hd8-witnesses/floor-m {:rows (:rows (db-of :floor)) :n n})))
         half-arm  (react-root-arm :control-half
-                                  (fn [_] (w/floor-m {:rows (:rows (db-of :floor)) :n half})))
+                                  (fn [_] (rf.bench.hicasso.hd8-witnesses/floor-m {:rows (:rows (db-of :floor)) :n half})))
         per-round (mapv (fn [_]
                           (let [r (mount-round! [full-arm half-arm] {} sampling 0)]
                             (round4 (/ (p50 (get (:readings r) :control-full))
@@ -1999,11 +1999,11 @@
         cleanup!  (fn []
                     (try (react-dom/flushSync (fn [] (.unmount root)))
                          (catch :default e
-                           (lane/teardown-failure! "lowering-works! cleanup" e)))
+                           (rf.bench.hicasso.lane/teardown-failure! "lowering-works! cleanup" e)))
                     (.remove container)
                     (reseed! :donor-r2))]
     (react-dom/flushSync
-      (fn [] (.render root (provided fid (w/slim-element (w/r2-u 8))))))
+      (fn [] (.render root (provided fid (rf.bench.hicasso.hd8-witnesses/slim-element (rf.bench.hicasso.hd8-witnesses/r2-u 8))))))
     (let [before (cell-text container 3)
           node   (.querySelector container "[data-i=\"3\"]")]
       (.click node)

--- a/bench/hicasso/src/re_frame/bench/hicasso/hd8_witnesses.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/hd8_witnesses.cljs
@@ -106,7 +106,7 @@
   bead is `rf2-2rtt6.1`."
   (:require ["react" :as react]
             [clojure.string :as str]
-            [re-frame.adapter.uix :as uixa]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
             [reagent2.impl.template :as slim-template]
             [uix.core :refer [$ defui]])
@@ -297,8 +297,8 @@
 ;; runs unchanged.
 
 (defui ux-m-row [{:keys [i]}]
-  (let [frame (uixa/use-current-frame)
-        v     (uixa/use-subscribe frame [:hd8/row i])
+  (let [frame (rf.adapter.uix/use-current-frame)
+        v     (rf.adapter.uix/use-subscribe frame [:hd8/row i])
         d     (dispatch-for frame)]
     ($ :li.row {:data-index i :on-click (fn [_] (d [:hd8/touch i]))}
        ($ :span.label "row ")
@@ -312,8 +312,8 @@
           ($ ux-m-row {:key i :i i})))))
 
 (defui ux-u-cell [{:keys [i]}]
-  (let [frame (uixa/use-current-frame)
-        v     (uixa/use-subscribe frame [:hd8/cell i])
+  (let [frame (rf.adapter.uix/use-current-frame)
+        v     (rf.adapter.uix/use-subscribe frame [:hd8/cell i])
         d     (dispatch-for frame)]
     ($ :span.cell {:data-i i :on-click (fn [_] (d [:hd8/touch i]))} v)))
 
@@ -339,7 +339,7 @@
 ;; it, and the gap between the rungs is the price of that purchase.
 
 (defn r1-m-row [i frame]
-  (let [v (uixa/use-subscribe frame [:hd8/row i])
+  (let [v (rf.adapter.uix/use-subscribe frame [:hd8/row i])
         d (dispatch-for frame)]
     [:li.row {:data-index i :on-click (fn [_] (d [:hd8/touch i]))}
      [:span.label "row "]
@@ -352,7 +352,7 @@
     (for [i (range n)] ^{:key i} [:f> r1-m-row i frame])]])
 
 (defn r1-u-cell [i frame]
-  (let [v (uixa/use-subscribe frame [:hd8/cell i])
+  (let [v (rf.adapter.uix/use-subscribe frame [:hd8/cell i])
         d (dispatch-for frame)]
     [:span.cell {:data-i i :on-click (fn [_] (d [:hd8/touch i]))} v]))
 
@@ -406,8 +406,8 @@
              props))
 
 (defn r2-m-row [i]
-  (let [frame (uixa/use-current-frame)
-        v     (uixa/use-subscribe frame [:hd8/row i])
+  (let [frame (rf.adapter.uix/use-current-frame)
+        v     (rf.adapter.uix/use-subscribe frame [:hd8/row i])
         d     (dispatch-for frame)]
     [:li.row (lower-events d {:data-index i :on-click [:hd8/touch i]})
      [:span.label "row "]
@@ -420,8 +420,8 @@
     (for [i (range n)] ^{:key i} [:f> r2-m-row i])]])
 
 (defn r2-u-cell [i]
-  (let [frame (uixa/use-current-frame)
-        v     (uixa/use-subscribe frame [:hd8/cell i])
+  (let [frame (rf.adapter.uix/use-current-frame)
+        v     (rf.adapter.uix/use-subscribe frame [:hd8/cell i])
         d     (dispatch-for frame)]
     [:span.cell (lower-events d {:data-i i :on-click [:hd8/touch i]}) v]))
 

--- a/bench/hicasso/src/re_frame/bench/hicasso/ime_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/ime_app.cljs
@@ -62,10 +62,10 @@
   model over `window`, and leaves every verdict to the driver — the same
   division every bench page in this directory keeps."
   (:require [clojure.string :as str]
-            [re-frame.adapter.uix :as uixa]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
             [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
-            [re-frame.bench.hicasso.front.intent :as intent]
+            [re-frame.bench.hicasso.front.intent :as rf.bench.hicasso.front.intent]
             [re-frame.core :as rf]
             [uix.core :refer [$ defui]]
             [uix.compiler.input]
@@ -209,8 +209,8 @@
   `front.intent/composing?` the hicasso key-map is gated by — so one gate
   is witnessed through both event plumbings, reading the native event."
   [{:keys [field]}]
-  (let [v (uixa/use-subscribe [:ime/cell field])
-        {:keys [dispatch-sync]} (uixa/use-frame)]
+  (let [v (rf.adapter.uix/use-subscribe [:ime/cell field])
+        {:keys [dispatch-sync]} (rf.adapter.uix/use-frame)]
     ($ :input
        {:id        field
         :type      "text"
@@ -221,7 +221,7 @@
         :on-key-down (fn [^js e]
                        (probe-handler-event! field "keydown" e)
                        (when (and (= "Enter" (.-key e))
-                                  (not (intent/composing? e)))
+                                  (not (rf.bench.hicasso.front.intent/composing? e)))
                          (dispatch-sync [:ime/commit field])))
         :on-composition-start  (fn [^js e] (probe-handler-event! field "compositionstart" e))
         :on-composition-update (fn [^js e] (probe-handler-event! field "compositionupdate" e))
@@ -253,11 +253,11 @@
 
 (defn- mount-impl! [impl]
   (case impl
-    "hicasso" (mount/root! (container!) frame-id [ime-grid {}])
+    "hicasso" (rf.bench.hicasso.arm1.mount/root! (container!) frame-id [ime-grid {}])
     (let [c    (container!)
           root (react-dom-client/createRoot c)]
       (react-dom/flushSync
-       (fn [] (.render root ($ uixa/frame-provider {:frame frame-id}
+       (fn [] (.render root ($ rf.adapter.uix/frame-provider {:frame frame-id}
                               ($ ime-grid-uix {})))))
       {:root root :container c})))
 
@@ -283,7 +283,7 @@
     (let [impl (or (some-> (js/URLSearchParams. (.. js/window -location -search))
                            (.get "impl"))
                    "react")]
-      (rf/init! uixa/adapter)
+      (rf/init! rf.adapter.uix/adapter)
       (pin! impl)
       (rf/make-frame {:id frame-id :initial-events [[:ime/seed]]})
       (mount-impl! impl)

--- a/bench/hicasso/src/re_frame/bench/hicasso/inpage_ladder_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/inpage_ladder_app.cljs
@@ -10,7 +10,7 @@
 
   ## The door and the window, stated first
 
-  Every arm here mounts through `lane/mount-arm!` — `createRoot` +
+  Every arm here mounts through `rf.bench.hicasso.lane/mount-arm!` — `createRoot` +
   `.render` inside ONE `react-dom/flushSync`, `performance.now()` on
   either side — which is **the same window, on the same page, at the same
   door** the published in-page term is read through
@@ -44,7 +44,7 @@
   | `nohiccup` | the 141 reads, then a hiccup tree built ONCE at boot | `nolink - nohiccup` = **hiccup materialisation** |
   | `nowalk` | the 141 reads, then a React element tree built ONCE at boot | `nohiccup - nowalk` = **the codec walk** |
   | `noreads` | the frozen element tree, no reads | `nowalk - noreads` = **the 141 reads AND their commit** |
-  | `nomemo` | `noreads` minted WITHOUT `codec/memoize-boundary!` | `noreads - nomemo` = **the HD-028 memo wrapper's fiber** |
+  | `nomemo` | `noreads` minted WITHOUT `rf.bench.hicasso.front.codec/memoize-boundary!` | `noreads - nomemo` = **the HD-028 memo wrapper's fiber** |
   | `bare` | a plain React function component, no shell, no hooks | `nomemo - bare` = **the shell: 2 hooks, the fence, the entry** |
   | `coarse` | `local` at the TWIN's read shape — five coarse reads | `local - coarse` = **the read-shape asymmetry, on our arm** |
   | `floor` | the census floor arm - hand-written `createElement` | the calibrator |
@@ -80,17 +80,17 @@
   HICASSO_INIT_FN=re-frame.bench.hicasso.inpage-ladder-app/-main."
   (:require ["react" :as react]
             ["react-dom/client" :as react-dom-client]
-            [re-frame.adapter.uix :as uixa]
-            [re-frame.bench.hicasso.arm1.mount :as arm1-mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt :refer [sub]]
-            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime :refer [sub]]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
             [re-frame.bench.hicasso.front.route-link :refer [route-link]]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.shapes.census-clock-arms :as arms]
-            [re-frame.bench.hicasso.shapes.large-template :as lt]
-            [re-frame.bench.hicasso.shapes.model :as m]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.shapes.census-clock-arms :as rf.bench.hicasso.shapes.census-clock-arms]
+            [re-frame.bench.hicasso.shapes.large-template :as rf.bench.hicasso.shapes.large-template]
+            [re-frame.bench.hicasso.shapes.model :as rf.bench.hicasso.shapes.model]
             [re-frame.core :as rf]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.late-bind :as rf.late-bind]
             [uix.core :refer [$ defui]])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
@@ -130,9 +130,9 @@
   (atom {}))
 
 (defn- seed-frame! [fid]
-  (m/make-frame! fid lt/seed)
-  (m/reseed! fid lt/seed)
-  (arms/prime-frame! fid)
+  (rf.bench.hicasso.shapes.model/make-frame! fid rf.bench.hicasso.shapes.large-template/seed)
+  (rf.bench.hicasso.shapes.model/reseed! fid rf.bench.hicasso.shapes.large-template/seed)
+  (rf.bench.hicasso.shapes.census-clock-arms/prime-frame! fid)
   (swap! !dispatch assoc fid (:dispatch (rf/capture-frame fid)))
   fid)
 
@@ -173,7 +173,7 @@
     [:div.article-preview {:key         slug
                            :data-testid (str "article-preview-" slug)}
      [:div.article-meta
-      (profile-a "author-link" [:img.user-pic {:src (m/avatar-src (:image author)) :alt ""}])
+      (profile-a "author-link" [:img.user-pic {:src (rf.bench.hicasso.shapes.model/avatar-src (:image author)) :alt ""}])
       [:div.info
        (profile-a "author" username)
        [:span.date createdAt]]
@@ -308,13 +308,13 @@
 
 (def nomemo-page
   "`noreads-page` minted the long way and NOT handed to
-  `codec/memoize-boundary!` — the one difference. `element-type` falls
+  `rf.bench.hicasso.front.codec/memoize-boundary!` — the one difference. `element-type` falls
   back to the head itself when there is no `hicassoMemo`, so this is the
   shell without React's wrapper fiber above it."
   (let [c (fn hicasso-boundary-nomemo [js-props]
-            (rt/shell (fn [_] @!frozen-element) js-props))]
+            (rf.bench.hicasso.arm1.runtime/shell (fn [_] @!frozen-element) js-props))]
     (unchecked-set c "displayName" "inpage-ladder/nomemo")
-    (codec/mark-boundary! c)))
+    (rf.bench.hicasso.front.codec/mark-boundary! c)))
 
 (defn bare-component
   "No shell: no `useContext`, no `useSyncExternalStore`, no generation
@@ -327,12 +327,12 @@
   "The UIx twin's five coarse reads, then the frozen element tree. The
   UIx arm's own body work is `uixlocal − uixbare`."
   [_props]
-  (let [frame (uixa/use-current-frame)]
-    (uixa/use-subscribe frame [:conduit/slugs])
-    (uixa/use-subscribe frame [:census56/articles])
-    (uixa/use-subscribe frame [:conduit/tags])
-    (uixa/use-subscribe frame [:conduit/your-feed?])
-    (uixa/use-subscribe frame [:census56/pending])
+  (let [frame (rf.adapter.uix/use-current-frame)]
+    (rf.adapter.uix/use-subscribe frame [:conduit/slugs])
+    (rf.adapter.uix/use-subscribe frame [:census56/articles])
+    (rf.adapter.uix/use-subscribe frame [:conduit/tags])
+    (rf.adapter.uix/use-subscribe frame [:conduit/your-feed?])
+    (rf.adapter.uix/use-subscribe frame [:census56/pending])
     @!frozen-element))
 
 ;; ---------------------------------------------------------------------------
@@ -356,10 +356,10 @@
 (defn- nav-class [active?] (if active? "nav-link active" "nav-link"))
 
 (def ^:private ux-link-model
-  (delay (late-bind/require-fn! :routing/link-model 'inpage-ladder {} {})))
+  (delay (rf.late-bind/require-fn! :routing/link-model 'inpage-ladder {} {})))
 
 (def ^:private ux-activate-link!
-  (delay (late-bind/require-fn! :routing/activate-link! 'inpage-ladder {} {})))
+  (delay (rf.late-bind/require-fn! :routing/activate-link! 'inpage-ladder {} {})))
 
 (defn- ux-route-attrs
   "`census_clock_arms/route-attrs`, re-spelled — the twins' hoisted-seam
@@ -382,7 +382,7 @@
     ($ :div.article-preview {:key slug :data-testid (str "article-preview-" slug)}
        ($ :div.article-meta
           ($ :a.author-link {:href (:href pic) :on-click (:on-click pic)}
-             ($ :img.user-pic {:src (m/avatar-src (:image author)) :alt ""}))
+             ($ :img.user-pic {:src (rf.bench.hicasso.shapes.model/avatar-src (:image author)) :alt ""}))
           ($ :div.info
              ($ :a.author {:href (:href nam) :on-click (:on-click nam)} username)
              ($ :span.date createdAt))
@@ -433,12 +433,12 @@
                          tag)))))))))
 
 (defn- ux-page-body [link? _props]
-  (let [frame      (uixa/use-current-frame)
-        order      (uixa/use-subscribe frame [:conduit/slugs])
-        articles   (uixa/use-subscribe frame [:census56/articles])
-        tags       (uixa/use-subscribe frame [:conduit/tags])
-        your-feed? (uixa/use-subscribe frame [:conduit/your-feed?])
-        pending    (uixa/use-subscribe frame [:census56/pending])
+  (let [frame      (rf.adapter.uix/use-current-frame)
+        order      (rf.adapter.uix/use-subscribe frame [:conduit/slugs])
+        articles   (rf.adapter.uix/use-subscribe frame [:census56/articles])
+        tags       (rf.adapter.uix/use-subscribe frame [:conduit/tags])
+        your-feed? (rf.adapter.uix/use-subscribe frame [:conduit/your-feed?])
+        pending    (rf.adapter.uix/use-subscribe frame [:census56/pending])
         d          (get @!dispatch frame)]
     (ux-local-chrome your-feed? tags d
                      (for [slug order]
@@ -463,15 +463,15 @@
 (defn- hicasso-arm [id view]
   (let [fid (get local-frames id)]
     (react-root-arm id
-      (fn [] (arm1-mount/provider fid (codec/as-element [view {}]))))))
+      (fn [] (rf.bench.hicasso.arm1.mount/provider fid (rf.bench.hicasso.front.codec/as-element [view {}]))))))
 
 (defn- uix-arm [id view]
   (let [fid (get local-frames id)]
     (react-root-arm id
-      (fn [] ($ uixa/frame-provider {:frame fid} ($ view {}))))))
+      (fn [] ($ rf.adapter.uix/frame-provider {:frame fid} ($ view {}))))))
 
 (defn- ladder-arms []
-  [(arms/arm row-key :hicasso)                              ; :hicasso — `ship`
+  [(rf.bench.hicasso.shapes.census-clock-arms/arm row-key :hicasso)                              ; :hicasso — `ship`
    (hicasso-arm :local    local-page)
    (hicasso-arm :coarse   coarse-page)
    (hicasso-arm :nolink   nolink-page)
@@ -480,14 +480,14 @@
    (hicasso-arm :noreads  noreads-page)
    (hicasso-arm :nomemo   nomemo-page)
    (react-root-arm :bare
-     (fn [] (arm1-mount/provider (:bare local-frames)
+     (fn [] (rf.bench.hicasso.arm1.mount/provider (:bare local-frames)
               (react/createElement bare-component nil))))
-   (arms/arm row-key :floor)
-   (arms/arm row-key :uix)
+   (rf.bench.hicasso.shapes.census-clock-arms/arm row-key :floor)
+   (rf.bench.hicasso.shapes.census-clock-arms/arm row-key :uix)
    (uix-arm :uixlocal  uixlocal-page)
    (uix-arm :uixnolink uixnolink-page)
    (uix-arm :uixbare   uixbare-page)
-   (assoc (arms/arm row-key :ctl-2x) :control? true)])
+   (assoc (rf.bench.hicasso.shapes.census-clock-arms/arm row-key :ctl-2x) :control? true)])
 
 (def ^:private control-ids #{:ctl-2x})
 
@@ -496,15 +496,15 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- canon-of [arm]
-  (let [mnt (lane/mount-arm! arm {})
-        s   (lane/canonical (:container mnt))
-        n   (lane/element-count (:container mnt))]
-    (lane/release! mnt)
+  (let [mnt (rf.bench.hicasso.lane/mount-arm! arm {})
+        s   (rf.bench.hicasso.lane/canonical (:container mnt))
+        n   (rf.bench.hicasso.lane/element-count (:container mnt))]
+    (rf.bench.hicasso.lane/release! mnt)
     {:canonical s :elements n}))
 
 (defn- parity-problems [arms']
   (let [reference (canon-of (first arms'))
-        expected  (arms/expected-elements row-key :hicasso)]
+        expected  (rf.bench.hicasso.shapes.census-clock-arms/expected-elements row-key :hicasso)]
     (into (if (= expected (:elements reference))
             []
             [{:arm :hicasso :problem :element-count
@@ -540,34 +540,34 @@
 
 (defn- rounds-async!
   "The reflecting-schedule sampler, promise-chained. Every sample index
-  visits every arm in [[lane/slot-order]]'s order; warm-up samples are
+  visits every arm in [[rf.bench.hicasso.lane/slot-order]]'s order; warm-up samples are
   taken and discarded; between samples the mount is released and ONE
   macrotask settles, which is what lets the cell reaper run and so what
   makes the next sample's 141 reads COLD again — the property the whole
   ladder is about."
   [arms' {:keys [warmup samples]} rounds']
   (let [k    (count arms')
-        coll (lane/sample-collector)
+        coll (rf.bench.hicasso.lane/sample-collector)
         out  (atom [])]
-    (-> (lane/chain
+    (-> (rf.bench.hicasso.lane/chain
           nil
           (for [round (range rounds')
                 s     (range (+ warmup samples))
-                j     (lane/slot-order k s)]
+                j     (rf.bench.hicasso.lane/slot-order k s)]
             [round s j])
           (fn [_ [round s j]]
             (let [arm (nth arms' j)
-                  mnt (lane/mount-arm! arm {})
+                  mnt (rf.bench.hicasso.lane/mount-arm! arm {})
                   ms  (:ms mnt)]
               ;; OUTSIDE the window: did the boundary's commit run inside
               ;; the flushSync we just timed? 141 live cells says yes.
               (when (= :hicasso (:id arm))
-                (swap! !cells-after-window update (:cells (rt/stats)) (fnil inc 0)))
-              (lane/release! mnt)
+                (swap! !cells-after-window update (:cells (rf.bench.hicasso.arm1.runtime/stats)) (fnil inc 0)))
+              (rf.bench.hicasso.lane/release! mnt)
               (when (>= s warmup)
-                (lane/collect! coll (name (:id arm)) ms)
+                (rf.bench.hicasso.lane/collect! coll (name (:id arm)) ms)
                 (swap! out conj [round (:id arm) ms]))
-              (lane/settle!))))
+              (rf.bench.hicasso.lane/settle!))))
         (.then (fn [_] {:rows @out :samples (:samples @coll)})))))
 
 ;; ---------------------------------------------------------------------------
@@ -597,7 +597,7 @@
   (into {}
         (map (fn [id]
                (let [xs (into [] (comp (filter #(= id (nth % 1))) (map #(nth % 2))) rows)]
-                 [id (assoc (lane/summarise xs) :tmean (trimmed-mean xs))])))
+                 [id (assoc (rf.bench.hicasso.lane/summarise xs) :tmean (trimmed-mean xs))])))
         ids))
 
 (defn- per-round-ratio
@@ -605,7 +605,7 @@
   raw samples pooled across a drifting box."
   [rows ids floor-id rounds']
   (let [round-p50 (fn [round id]
-                    (:p50 (lane/summarise
+                    (:p50 (rf.bench.hicasso.lane/summarise
                             (into [] (comp (filter #(and (= round (nth % 0))
                                                          (= id (nth % 1))))
                                            (map #(nth % 2)))
@@ -614,9 +614,9 @@
           (map (fn [id]
                  (let [vs (mapv (fn [r] (/ (round-p50 r id) (round-p50 r floor-id)))
                                 (range rounds'))]
-                   [id {:mean (lane/round4 (/ (reduce + 0.0 vs) (count vs)))
-                        :min  (lane/round4 (apply min vs))
-                        :max  (lane/round4 (apply max vs))}])))
+                   [id {:mean (rf.bench.hicasso.lane/round4 (/ (reduce + 0.0 vs) (count vs)))
+                        :min  (rf.bench.hicasso.lane/round4 (apply min vs))
+                        :max  (rf.bench.hicasso.lane/round4 (apply max vs))}])))
           ids)))
 
 (defn- arm-line [id {:keys [p50 tmean min max]}]
@@ -632,9 +632,9 @@
 
 (defn- ns-per-op [reps f]
   (let [sink (volatile! nil)
-        t0   (lane/now-ms)]
+        t0   (rf.bench.hicasso.lane/now-ms)]
     (dotimes [_ reps] (vreset! sink (f)))
-    (/ (* 1e6 (- (lane/now-ms) t0)) reps)))
+    (/ (* 1e6 (- (rf.bench.hicasso.lane/now-ms) t0)) reps)))
 
 (def ^:private passes-per-window
   "Body-door passes inside ONE micro window. Chrome clamps
@@ -645,9 +645,9 @@
   8)
 
 (defn- window-ms [reps f]
-  (let [t0 (lane/now-ms)]
+  (let [t0 (rf.bench.hicasso.lane/now-ms)]
     (dotimes [_ reps] (f))
-    (/ (- (lane/now-ms) t0) reps)))
+    (/ (- (rf.bench.hicasso.lane/now-ms) t0) reps)))
 
 (defn- micro-table
   "Independent readings of the three terms the mount ladder infers by
@@ -665,7 +665,7 @@
   []
   (let [fid (:capture local-frames)
         pass (fn [f] (/ (window-ms 30 (fn [] (dotimes [_ passes-per-window]
-                                               (rt/render-body fid f {}))))
+                                               (rf.bench.hicasso.arm1.runtime/render-body fid f {}))))
                         passes-per-window))]
     [[:build+walk+reads-ms (pass (fn [_] (acceptance-hiccup false)))]
      [:walk+reads-ms       (pass (fn [_] (sub-pass!) @!frozen-hiccup))]
@@ -674,7 +674,7 @@
      ;; One `route-link`'s late-bind resolution — the per-anchor asymmetry
      ;; the twins hoist and the candidate does not (207 of these a mount).
      [:late-bind-resolve-ns
-      (ns-per-op 20000 (fn [] (late-bind/require-fn! :routing/link-model 'inpage-ladder {} {})))]]))
+      (ns-per-op 20000 (fn [] (rf.late-bind/require-fn! :routing/link-model 'inpage-ladder {} {})))]]))
 
 (defn- commit-half-ms
   "The commit half, through the runtime's own `commit-boundary!` seam, on
@@ -687,21 +687,21 @@
   (let [reps 12
         one  (fn []
                (let [entries (mapv (fn [f]
-                                     (rt/render-body f (fn [_] (sub-pass!) [:span]) {})
-                                     (rt/last-reads))
+                                     (rf.bench.hicasso.arm1.runtime/render-body f (fn [_] (sub-pass!) [:span]) {})
+                                     (rf.bench.hicasso.arm1.runtime/last-reads))
                                    commit-frames)
-                     t0       (lane/now-ms)
-                     releases (mapv (fn [e] (rt/commit-boundary! e (fn [] nil))) entries)
-                     ms       (- (lane/now-ms) t0)]
+                     t0       (rf.bench.hicasso.lane/now-ms)
+                     releases (mapv (fn [e] (rf.bench.hicasso.arm1.runtime/commit-boundary! e (fn [] nil))) entries)
+                     ms       (- (rf.bench.hicasso.lane/now-ms) t0)]
                  (doseq [r releases] (r))
                  ;; Synchronously, because the cell reaper's grace is a
                  ;; macrotask and this loop never yields — an un-reset
                  ;; runtime would make the next rep's 141 reads WARM and
                  ;; its commit a no-op.
-                 (rt/reset-runtime!)
+                 (rf.bench.hicasso.arm1.runtime/reset-runtime!)
                  (/ ms (count commit-frames))))
         xs   (vec (repeatedly reps one))]
-    (:p50 (lane/summarise xs))))
+    (:p50 (rf.bench.hicasso.lane/summarise xs))))
 
 ;; ---------------------------------------------------------------------------
 ;; Boot
@@ -714,19 +714,19 @@
   it is the arithmetic's 3 + 2 × 69 = 141 distinct reads on the
   1,202-element page."
   [fid]
-  (let [container (arm1-mount/fresh-container!)
-        handle    (arm1-mount/root! container fid [lt/page {}])
-        ^js entry (rt/last-reads)
+  (let [container (rf.bench.hicasso.arm1.mount/fresh-container!)
+        handle    (rf.bench.hicasso.arm1.mount/root! container fid [rf.bench.hicasso.shapes.large-template/page {}])
+        ^js entry (rf.bench.hicasso.arm1.runtime/last-reads)
         ks        (.-keys entry)
-        n         (lane/element-count container)
-        expected  (lt/element-arithmetic)
+        n         (rf.bench.hicasso.lane/element-count container)
+        expected  (rf.bench.hicasso.shapes.large-template/element-arithmetic)
         roster    (let [a #js []]
                     (dotimes [i (alength ks)] (.push a (nth (aget ks i) 1)))
                     a)
         distinct-n (count (into #{} (array-seq roster)))
-        want       (+ 3 (* 2 lt/article-count))]
-    (arm1-mount/unmount! handle)
-    (rt/reset-runtime!)
+        want       (+ 3 (* 2 rf.bench.hicasso.shapes.large-template/article-count))]
+    (rf.bench.hicasso.arm1.mount/unmount! handle)
+    (rf.bench.hicasso.arm1.runtime/reset-runtime!)
     (when-not (= expected n)
       (throw (ex-info (str "harvest FAILED: page has " n " elements, expected " expected) {})))
     (when-not (and (= want (alength roster)) (= want distinct-n))
@@ -738,25 +738,25 @@
   "Build the no-link page's hiccup and its React element tree ONCE, inside
   a real body door on the capture frame."
   [fid]
-  (let [element (rt/render-body fid
+  (let [element (rf.bench.hicasso.arm1.runtime/render-body fid
                                 (fn [_] (let [h (acceptance-hiccup false)]
                                           (reset! !frozen-hiccup h)
                                           h))
                                 {})]
     (reset! !frozen-element element)
-    (rt/reset-runtime!)
+    (rf.bench.hicasso.arm1.runtime/reset-runtime!)
     nil))
 
 (defn ^:export -main []
-  (rf/init! uixa/adapter)
-  (lane/leave-act-environment!)
-  (lane/self-test!)
+  (rf/init! rf.adapter.uix/adapter)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/self-test!)
   (-> (js/Promise.resolve nil)
       (.then
         (fn [_]
           ;; `census_clock_arms` owns the published `ship`, `uix`, `floor`
           ;; and `ctl-2x` arms, so its frames are made its way.
-          (arms/ensure-frames! [:floor :hicasso :uix])
+          (rf.bench.hicasso.shapes.census-clock-arms/ensure-frames! [:floor :hicasso :uix])
           (doseq [[_ fid] local-frames] (seed-frame! fid))
           (doseq [fid commit-frames] (seed-frame! fid))
           (let [{:keys [roster elements]} (harvest-roster! (:capture local-frames))]
@@ -771,32 +771,32 @@
               (js/console.log (str ";; parity OK — " (count arms') " arms, "
                                    (- (count arms') (count control-ids))
                                    " of them byte-identical to the candidate's page"))
-              (-> (lane/settle!)
+              (-> (rf.bench.hicasso.lane/settle!)
                   (.then (fn [_] (rounds-async! arms' sampling rounds)))
                   (.then
                     (fn [{:keys [rows samples]}]
                       (let [ids  (mapv :id arms')
                             p50  (per-arm rows ids)
-                            gv   (lane/guard! samples "in-page ladder (in-page flushSync window, diagnostic)")
-                            ctl  (lane/control-verdict
-                                   (arms/ctl-predicted row-key)
+                            gv   (rf.bench.hicasso.lane/guard! samples "in-page ladder (in-page flushSync window, diagnostic)")
+                            ctl  (rf.bench.hicasso.lane/control-verdict
+                                   (rf.bench.hicasso.shapes.census-clock-arms/ctl-predicted row-key)
                                    (get (per-round-ratio rows [:ctl-2x] :floor rounds) :ctl-2x)
                                    0.25)
                             g    (fn [id] (:tmean (get p50 id)))]
-                        (lane/record! :inpage-ladder-arms
+                        (rf.bench.hicasso.lane/record! :inpage-ladder-arms
                                       (into {} (map (fn [[k v]]
-                                                      [k (-> v (update :min lane/round4)
-                                                             (update :max lane/round4)
-                                                             (update :p50 lane/round4)
-                                                             (update :tmean lane/round4))]))
+                                                      [k (-> v (update :min rf.bench.hicasso.lane/round4)
+                                                             (update :max rf.bench.hicasso.lane/round4)
+                                                             (update :p50 rf.bench.hicasso.lane/round4)
+                                                             (update :tmean rf.bench.hicasso.lane/round4))]))
                                             p50))
-                        (lane/record! :inpage-ladder-rounds
-                                      (mapv (fn [[r id ms]] [r id (lane/round4 ms)]) rows))
-                        (lane/record! :inpage-ladder-ratio-to-floor
+                        (rf.bench.hicasso.lane/record! :inpage-ladder-rounds
+                                      (mapv (fn [[r id ms]] [r id (rf.bench.hicasso.lane/round4 ms)]) rows))
+                        (rf.bench.hicasso.lane/record! :inpage-ladder-ratio-to-floor
                                       (per-round-ratio rows ids :floor rounds))
-                        (lane/record! :inpage-ladder-cells-after-window @!cells-after-window)
-                        (lane/record! :inpage-ladder-decomposition
-                                      (into {} (map (fn [[k v]] [k (lane/round4 v)]))
+                        (rf.bench.hicasso.lane/record! :inpage-ladder-cells-after-window @!cells-after-window)
+                        (rf.bench.hicasso.lane/record! :inpage-ladder-decomposition
+                                      (into {} (map (fn [[k v]] [k (rf.bench.hicasso.lane/round4 v)]))
                                             {:ship                (g :hicasso)
                                              :uix                 (g :uix)
                                              :bare                (g :bare)
@@ -852,9 +852,9 @@
                         (let [micro  (micro-table)
                               mm     (into {} micro)
                               commit (commit-half-ms)]
-                          (lane/record! :inpage-ladder-micro
-                                        (assoc (into {} (map (fn [[k v]] [k (lane/round4 v)])) micro)
-                                               :commit-half-ms (lane/round4 commit)))
+                          (rf.bench.hicasso.lane/record! :inpage-ladder-micro
+                                        (assoc (into {} (map (fn [[k v]] [k (rf.bench.hicasso.lane/round4 v)])) micro)
+                                               :commit-half-ms (rf.bench.hicasso.lane/round4 commit)))
                           (js/console.log ";; ==== MICRO (ms per body-door pass unless named otherwise) ====")
                           (doseq [[k v] micro]
                             (js/console.log (str ";;   " (name k) ": " (fmt v 4))))
@@ -867,13 +867,13 @@
                                                (fmt (- (:reads-ms mm) (:empty-door-ms mm)) 4) " ms/pass ("
                                                (fmt (* 1e3 (/ (- (:reads-ms mm) (:empty-door-ms mm)) 141)) 2)
                                                " µs/read; rf2-6c237 read 2.04)")))
-                        (lane/record! :inpage-ladder-runtime (lane/runtime-label))
+                        (rf.bench.hicasso.lane/record! :inpage-ladder-runtime (rf.bench.hicasso.lane/runtime-label))
                         (when (:refuse? gv)
                           (set! (.-HICASSO_GUARD_REFUSED js/window) true))
                         (when-not (:ok? ctl)
                           (set! (.-HICASSO_CONTROL_FAILED js/window) true))
-                        (lane/assert-teardown-clean! "the in-page ladder")
-                        (lane/done!)))))))))
+                        (rf.bench.hicasso.lane/assert-teardown-clean! "the in-page ladder")
+                        (rf.bench.hicasso.lane/done!)))))))))
       (.catch (fn [e]
-                (lane/fail! (or (some-> e .-message) (str e)))
-                (lane/done!)))))
+                (rf.bench.hicasso.lane/fail! (or (some-> e .-message) (str e)))
+                (rf.bench.hicasso.lane/done!)))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/jsfb_hicasso_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/jsfb_hicasso_app.cljs
@@ -39,10 +39,10 @@
   gates that rather than this docstring.
 
   Owner: rf2-rguy1."
-  (:require [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as hmount]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
             [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
-            [re-frame.bench.hicasso.jsfb-model :as m]
+            [re-frame.bench.hicasso.jsfb-model :as rf.bench.hicasso.jsfb-model]
             [re-frame.core :as rf])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
@@ -105,8 +105,8 @@
   ;; The UIx adapter, for the reason the clock page states: Arm 1's
   ;; React-hook spine is built over it and its own witnesses install it.
   ;; The adapter is the substrate the CANDIDATE runs on, not a third arm.
-  (rf/init! uix-adapter/adapter)
-  (m/reset-seed!)
-  (m/register!)
-  (m/make-frame!)
-  (hmount/root! (js/document.getElementById "main") m/frame-id [app {}]))
+  (rf/init! rf.adapter.uix/adapter)
+  (rf.bench.hicasso.jsfb-model/reset-seed!)
+  (rf.bench.hicasso.jsfb-model/register!)
+  (rf.bench.hicasso.jsfb-model/make-frame!)
+  (rf.bench.hicasso.arm1.mount/root! (js/document.getElementById "main") rf.bench.hicasso.jsfb-model/frame-id [app {}]))

--- a/bench/hicasso/src/re_frame/bench/hicasso/jsfb_reagent_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/jsfb_reagent_app.cljs
@@ -28,8 +28,8 @@
   body for the result rather than trusting this paragraph.
 
   Owner: rf2-rguy1."
-  (:require [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.bench.hicasso.jsfb-model :as m]
+  (:require [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.bench.hicasso.jsfb-model :as rf.bench.hicasso.jsfb-model]
             [re-frame.core :as rf]
             [reagent.dom.client :as rdc])
   (:require-macros [re-frame.core :refer [reg-view with-frame]]))
@@ -51,7 +51,7 @@
   then differ in WHEN they did the work as well as in how, and the ratio
   would stop being a substrate ratio."
   [event]
-  (with-frame m/frame-id (rf/dispatch-sync event)))
+  (with-frame rf.bench.hicasso.jsfb-model/frame-id (rf/dispatch-sync event)))
 
 (reg-view ^{:rf/id :jsfb/row-view} row
   "One row boundary — two subscription reads, one `<tr>`.
@@ -110,9 +110,9 @@
 
 (defn ^:export -main
   []
-  (rf/init! reagent-adapter/adapter)
-  (m/reset-seed!)
-  (m/register!)
-  (m/make-frame!)
+  (rf/init! rf.adapter.reagent/adapter)
+  (rf.bench.hicasso.jsfb-model/reset-seed!)
+  (rf.bench.hicasso.jsfb-model/register!)
+  (rf.bench.hicasso.jsfb-model/make-frame!)
   (let [root (rdc/create-root (js/document.getElementById "main"))]
-    (rdc/render root [rf/frame-provider {:frame m/frame-id} [app]])))
+    (rdc/render root [rf/frame-provider {:frame rf.bench.hicasso.jsfb-model/frame-id} [app]])))

--- a/bench/hicasso/src/re_frame/bench/hicasso/jsfb_uix_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/jsfb_uix_app.cljs
@@ -36,7 +36,7 @@
 
   ## It is `p0-uix-views`' spine, on this page
 
-  `uixa/use-subscribe` — the published spine — one read per boundary, no
+  `rf.adapter.uix/use-subscribe` — the published spine — one read per boundary, no
   `use-memo` around the subscription args, no `set-hiccup-emitter!`. The
   reasons are that namespace's and are not repeated here; what matters is
   that this arm is the same UIx the red zones were derived from, so a
@@ -46,8 +46,8 @@
   with both other arms. The DOM is gated identical across all three.
 
   Owner: rf2-rguy1."
-  (:require [re-frame.adapter.uix :as uixa]
-            [re-frame.bench.hicasso.jsfb-model :as m]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.jsfb-model :as rf.bench.hicasso.jsfb-model]
             [re-frame.core :as rf]
             [uix.core :refer [$ defui]]
             [uix.dom :as uix-dom]))
@@ -57,11 +57,11 @@
   after the render that created it returned, so it resolves no frame from
   context. `dispatch-sync` inside the click turn, like every other arm."
   [event]
-  (rf/with-frame m/frame-id (rf/dispatch-sync event)))
+  (rf/with-frame rf.bench.hicasso.jsfb-model/frame-id (rf/dispatch-sync event)))
 
 (defui row [{:keys [id]}]
-  (let [{:keys [label]} (uixa/use-subscribe [:jsfb/row id])
-        selected?       (uixa/use-subscribe [:jsfb/selected? id])]
+  (let [{:keys [label]} (rf.adapter.uix/use-subscribe [:jsfb/row id])
+        selected?       (rf.adapter.uix/use-subscribe [:jsfb/selected? id])]
     ($ :tr {:class (when selected? "danger")}
        ($ :td.col-md-1 id)
        ($ :td.col-md-4
@@ -73,7 +73,7 @@
 
 (defui table []
   ($ :tbody
-     (for [id (uixa/use-subscribe [:jsfb/order])]
+     (for [id (rf.adapter.uix/use-subscribe [:jsfb/order])]
        ($ row {:key id :id id}))))
 
 (defui button [{:keys [id label event]}]
@@ -100,10 +100,10 @@
 
 (defn ^:export -main
   []
-  (rf/init! uixa/adapter)
-  (m/reset-seed!)
-  (m/register!)
-  (m/make-frame!)
+  (rf/init! rf.adapter.uix/adapter)
+  (rf.bench.hicasso.jsfb-model/reset-seed!)
+  (rf.bench.hicasso.jsfb-model/register!)
+  (rf.bench.hicasso.jsfb-model/make-frame!)
   (uix-dom/render-root
-    ($ uixa/frame-provider {:frame m/frame-id} ($ app))
+    ($ rf.adapter.uix/frame-provider {:frame rf.bench.hicasso.jsfb-model/frame-id} ($ app))
     (uix-dom/create-root (js/document.getElementById "main"))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/keywarn_clock.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/keywarn_clock.cljs
@@ -12,7 +12,7 @@
 
   ## The ablation
 
-  `codec/as-element` on a seq IS
+  `rf.bench.hicasso.front.codec/as-element` on a seq IS
   [[re-frame.bench.hicasso.front.codec/expand-seq]] — its `(seq? x)`
   branch is `expand-seq`'s sole caller. So the ablated arm is a
   five-line local copy of that loop with the dev pre-pass removed and
@@ -40,7 +40,7 @@
   rounds, median-of-rounds; it attributes cost between two arms of one
   walk in one process. Nothing here is a threshold and nothing here is
   compared across runs."
-  (:require [re-frame.bench.hicasso.front.codec :as codec]))
+  (:require [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]))
 
 (def ^:private members 300)
 (def ^:private reps 200)
@@ -51,18 +51,18 @@
   [nm]
   (let [f (fn [_js-props] nil)]
     (unchecked-set f "displayName" nm)
-    (codec/mark-boundary! f)))
+    (rf.bench.hicasso.front.codec/mark-boundary! f)))
 
 (def ^:private row (a-row "keywarn.clock/row"))
 
 (defn- expand-seq-ablated
-  "[[codec/expand-seq]] with the dev pre-pass removed — the shipping loop,
+  "[[rf.bench.hicasso.front.codec/expand-seq]] with the dev pre-pass removed — the shipping loop,
   character for character, minus the one gated line."
   [s]
   (let [a #js []]
     (loop [items (seq s)]
       (when items
-        (.push a (codec/as-element (first items)))
+        (.push a (rf.bench.hicasso.front.codec/as-element (first items)))
         (recur (next items))))
     a))
 
@@ -88,7 +88,7 @@
   [s]
   (let [ship (atom []) abl (atom [])]
     (dotimes [_ rounds]
-      (swap! ship conj (clock codec/as-element s))
+      (swap! ship conj (clock rf.bench.hicasso.front.codec/as-element s))
       (swap! abl conj (clock expand-seq-ablated s)))
     (let [m-ship (median @ship)
           m-abl  (median @abl)]
@@ -113,9 +113,9 @@
         unkeyed (doall (map (fn [_] [row {}]) (range members)))]
     ;; Warm the dedupe: the unkeyed row is meant to price the SCAN after the
     ;; site has spoken, not the one console.warn it speaks with.
-    (codec/set-lowering-owner! "keywarn.clock/list")
-    (codec/as-element unkeyed)
-    (codec/set-lowering-owner! nil)
+    (rf.bench.hicasso.front.codec/set-lowering-owner! "keywarn.clock/list")
+    (rf.bench.hicasso.front.codec/as-element unkeyed)
+    (rf.bench.hicasso.front.codec/set-lowering-owner! nil)
     (println (str ";; keywarn pre-pass — dev build, " members " members, "
                   reps " walks/round, " rounds " interleaved rounds, "
                   "median-of-rounds. ns per member."))

--- a/bench/hicasso/src/re_frame/bench/hicasso/lane.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/lane.cljs
@@ -94,8 +94,8 @@
      of them repaired the ARM. The tolerance is not the arm's to move."
   (:require ["react-dom" :as react-dom]
             [clojure.string :as str]
-            [re-frame.bench.order-guard :as guard]
-            [re-frame.frame :as frame]))
+            [re-frame.bench.order-guard :as rf.bench.order-guard]
+            [re-frame.frame :as rf.frame]))
 
 ;; ---------------------------------------------------------------------------
 ;; Clock and summary — small enough that the lane owes the donor tree nothing
@@ -459,7 +459,7 @@
   where its arms' references live, and nothing more general than that."
   ([frame-id] (residue frame-id nil))
   ([frame-id counters]
-   (let [cache (some-> (frame/frame frame-id) :sub-cache deref)]
+   (let [cache (some-> (rf.frame/frame frame-id) :sub-cache deref)]
      (into {:body-children (.-childElementCount js/document.body)
             :sub-entries   (count cache)
             :sub-ref-count (reduce + 0 (map #(or (:ref-count %) 0) (vals cache)))}
@@ -561,7 +561,7 @@
   copy here would be a second authority with nothing holding it in step —
   and the copy that did exist, in `b6-harness`, is exactly where the `k = 2`
   degeneracy survived a fix to this one."
-  guard/slot-order)
+  rf.bench.order-guard/slot-order)
 
 (defn sample-collector
   "A mutable collector for the guard's samples.
@@ -1378,7 +1378,7 @@
   measure nothing — the copy of the rule it is about to rely on no longer
   behaves like the one the `.cjs` drivers use."
   []
-  (guard/print-self-test!))
+  (rf.bench.order-guard/print-self-test!))
 
 (defn guard!
   "Adjudicate `samples` and print the report. `:refuse?` is what the
@@ -1386,8 +1386,8 @@
   ([samples] (guard! samples nil {}))
   ([samples title] (guard! samples title {}))
   ([samples title opts]
-   (let [v (guard/verdict samples (merge {:tolerance 0.10} opts))]
-     (doseq [l (guard/report-lines v title)] (js/console.log l))
+   (let [v (rf.bench.order-guard/verdict samples (merge {:tolerance 0.10} opts))]
+     (doseq [l (rf.bench.order-guard/report-lines v title)] (js/console.log l))
      v)))
 
 ;; ---------------------------------------------------------------------------

--- a/bench/hicasso/src/re_frame/bench/hicasso/lane_bytes_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/lane_bytes_cljs_test.cljs
@@ -42,7 +42,7 @@
   what a browser can run: the behaviour of the helper itself."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
-            [re-frame.bench.hicasso.lane :as lane]))
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]))
 
 ;; ---------------------------------------------------------------------------
 ;; The fixtures
@@ -78,10 +78,10 @@
            way: on ASCII the two MUST agree, which is exactly why an
            ASCII-only suite could never have caught this."
     (doseq [{:keys [what s]} (rest cases)]
-      (is (not= (count s) (lane/utf8-bytes s))
+      (is (not= (count s) (rf.bench.hicasso.lane/utf8-bytes s))
           (str what ": cannot distinguish the defect")))
     (let [ascii (:s (first cases))]
-      (is (= (count ascii) (lane/utf8-bytes ascii))
+      (is (= (count ascii) (rf.bench.hicasso.lane/utf8-bytes ascii))
           "and on pure ASCII the old expression and the new one agree"))))
 
 (deftest utf8-bytes-answers-bytes-and-count-answers-code-units
@@ -93,7 +93,7 @@
     (doseq [{:keys [what s units bytes] cps :codepoints} cases]
       (is (= units (count s)) (str what ": the fixture is not the string this row describes"))
       (is (= cps (codepoints s)) (str what ": codepoints"))
-      (is (= bytes (lane/utf8-bytes s)) (str what ": bytes")))))
+      (is (= bytes (rf.bench.hicasso.lane/utf8-bytes s)) (str what ": bytes")))))
 
 (deftest the-error-grows-with-the-content
   (testing "**why this is not a rounding difference.** The gap is not a
@@ -103,10 +103,10 @@
            an instrument understating by a growing margin reads plausible for
            ever."
     (let [dashes (str/join (repeat 1000 "\u2014"))]
-      (is (= 3 (lane/utf8-bytes "\u2014")))
+      (is (= 3 (rf.bench.hicasso.lane/utf8-bytes "\u2014")))
       (is (= 1000 (count dashes)))
-      (is (= 3000 (lane/utf8-bytes dashes)))
-      (is (= 2000 (- (lane/utf8-bytes dashes) (count dashes)))
+      (is (= 3000 (rf.bench.hicasso.lane/utf8-bytes dashes)))
+      (is (= 2000 (- (rf.bench.hicasso.lane/utf8-bytes dashes) (count dashes)))
           "the understatement is 2 bytes per em dash and there are a thousand"))))
 
 (deftest utf8-bytes-is-total-over-the-degenerate-inputs
@@ -115,8 +115,8 @@
            still answers a number rather than throwing. `TextEncoder`
            substitutes U+FFFD, three bytes, which is what a UTF-8 encoder
            writing that string to a socket would also do."
-    (is (= 0 (lane/utf8-bytes "")))
-    (is (= 3 (lane/utf8-bytes "\uD834")) "an unpaired high surrogate encodes as U+FFFD")))
+    (is (= 0 (rf.bench.hicasso.lane/utf8-bytes "")))
+    (is (= 3 (rf.bench.hicasso.lane/utf8-bytes "\uD834")) "an unpaired high surrogate encodes as U+FFFD")))
 
 (deftest utf8-bytes-agrees-with-the-encoder-the-lane-already-trusts
   (testing "**a second derivation, not a second call to the same function.**
@@ -131,5 +131,5 @@
       (let [^js buf (.encode (js/TextEncoder.) s)]
         (is (= bytes (.-byteLength buf))
             (str what ": the encoder the digest rows use agrees"))
-        (is (= (lane/utf8-bytes s) (.-byteLength buf))
+        (is (= (rf.bench.hicasso.lane/utf8-bytes s) (.-byteLength buf))
             (str what ": and utf8-bytes agrees with it"))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/lane_control_strict_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/lane_control_strict_cljs_test.cljs
@@ -1,8 +1,8 @@
 (ns re-frame.bench.hicasso.lane-control-strict-cljs-test
   "THE LANE'S TWO CONTROL RULES MUST STAY TWO — pinned (rf2-egdaq).
 
-  `lane/control-verdict` adjudicates a positive control on OVERLAP: the
-  measured range need only meet the ±slack band. `lane/control-verdict-
+  `rf.bench.hicasso.lane/control-verdict` adjudicates a positive control on OVERLAP: the
+  measured range need only meet the ±slack band. `rf.bench.hicasso.lane/control-verdict-
   strict` requires EVERY ROUND inside it. Both are correct for their own
   case — the 2026-07-31 ruling keeps overlap for legs sitting on Chrome's
   100 µs `performance.now()` clamp, where a low round is the quantum
@@ -41,7 +41,7 @@
   Companion to `walk_profile_control_cljs_test`, which pins the same
   every-round discipline for the walk profile's own bespoke control."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.bench.hicasso.lane :as lane]))
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]))
 
 ;; ---------------------------------------------------------------------------
 ;; The shape `amp_merge_clock_app` hands the rule
@@ -54,7 +54,7 @@
 (def ^:private predicted 2.0)
 (def ^:private slack 0.25)
 
-(defn- strict [per-round] (lane/control-verdict-strict predicted per-round slack))
+(defn- strict [per-round] (rf.bench.hicasso.lane/control-verdict-strict predicted per-round slack))
 
 (def ^:private held
   "Five rounds a real instrument with signal produces."
@@ -75,7 +75,7 @@
     (let [s (strict one-bad-round)
           ;; The same five rounds offered to the overlap rule as the
           ;; `{:min :max :mean}` range it takes.
-          o (lane/control-verdict predicted
+          o (rf.bench.hicasso.lane/control-verdict predicted
                                   {:min 1.400 :max 2.104 :mean 1.904}
                                   slack)]
       (is (true? (:ok? o))
@@ -110,8 +110,8 @@
   0.05)
 
 (defn- floor-normalised
-  "The per-round `{id ratio-to-floor}` maps `lane/normalise` produces, which
-  is what an instrument hands `lane/ratio-between`."
+  "The per-round `{id ratio-to-floor}` maps `rf.bench.hicasso.lane/normalise` produces, which
+  is what an instrument hands `rf.bench.hicasso.lane/ratio-between`."
   []
   (mapv (fn [{:keys [hiccup ctl]}]
           {:floor 1.0 :hiccup (/ hiccup floor-ms) :ctl-2x (/ ctl floor-ms)})
@@ -127,14 +127,14 @@
             denominator, and a cross-round prediction never has one"
     (let [hiccups   (mapv :hiccup rounds-ms)
           ctls      (mapv :ctl rounds-ms)
-          predicted (* 2.0 (:p50 (lane/summarise hiccups)))
-          s-ctl     (lane/summarise ctls)
-          aggregate (lane/control-verdict predicted
+          predicted (* 2.0 (:p50 (rf.bench.hicasso.lane/summarise hiccups)))
+          s-ctl     (rf.bench.hicasso.lane/summarise ctls)
+          aggregate (rf.bench.hicasso.lane/control-verdict predicted
                                           {:min  (:min s-ctl)
                                            :max  (:max s-ctl)
                                            :mean (:p50 s-ctl)}
                                           slack)
-          per-round (:per-round (lane/ratio-between (floor-normalised)
+          per-round (:per-round (rf.bench.hicasso.lane/ratio-between (floor-normalised)
                                                     :ctl-2x :hiccup))
           strict'   (strict per-round)]
       (is (= 4.5 predicted)
@@ -145,7 +145,7 @@
           "and the control's whole measured range is 4.40 – 4.60 ms. Named
            fields rather than whole-map equality: this row is about the
            RANGE, and spelling it as `=` on the whole summary also froze
-           `lane/summarise`'s key set here, a long way from the function
+           `rf.bench.hicasso.lane/summarise`'s key set here, a long way from the function
            and from any reader who would think to look. `rf2-xa8wo` adding
            `:p95`/`:p99` reddened it for a reason this row has no opinion
            about. The key set is frozen in `lane_quantile_cljs_test`, where
@@ -230,18 +230,18 @@
   (testing "the mode merged-PR audit #8149 found on the walk profile: a
             band around a prediction of zero is cleared by any reading
             whatever, so passing there is passing on nothing"
-    (let [r (lane/control-verdict-strict 0.0 [0.0 0.0 0.0] slack)]
+    (let [r (rf.bench.hicasso.lane/control-verdict-strict 0.0 [0.0 0.0 0.0] slack)]
       (is (false? (:ok? r)))
       (is (false? (:stated? r)))
       (is (re-find #"states no prediction" (:why r)))))
   (testing "and a NEGATIVE prediction inverts the band rather than
             narrowing it, which is on its own enough to refuse"
-    (is (false? (:ok? (lane/control-verdict-strict -2.0 [-2.0 -2.0] slack))))))
+    (is (false? (:ok? (rf.bench.hicasso.lane/control-verdict-strict -2.0 [-2.0 -2.0] slack))))))
 
 (deftest the-refusal-is-attributed-to-the-right-half
   (testing "two refusals, two causes, two repairs — the arms are innocent
             in one of them"
-    (let [vacuous (lane/control-verdict-strict 0.0 held slack)
+    (let [vacuous (rf.bench.hicasso.lane/control-verdict-strict 0.0 held slack)
           missed  (strict one-bad-round)]
       (is (false? (:stated? vacuous)) "the PREDICTION failed")
       (is (true? (:stated? missed)) "the prediction was real; the ARMS missed it"))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/lane_quantile_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/lane_quantile_cljs_test.cljs
@@ -41,7 +41,7 @@
   window that will point the estimator at an application is a separate
   quiet-box run and is not this bead's — see `budgets.md` §9.4."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.bench.hicasso.lane :as lane]))
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]))
 
 ;; ---------------------------------------------------------------------------
 ;; Helpers
@@ -73,34 +73,34 @@
   (testing "the fixture DISCRIMINATES — the two conventions disagree on it"
     (let [xs (vec (range 1 21))]                            ; 1..20, n = 20
       (is (= 20 (count xs)))
-      (is (not (close? (lane/quantile xs 0.95) (nearest-rank xs 0.95)))
+      (is (not (close? (rf.bench.hicasso.lane/quantile xs 0.95) (nearest-rank xs 0.95)))
           "if these agree the case below has stopped testing the definition")))
 
   (testing "and the answer is the interpolated one, not the nearest rank"
     (let [xs (vec (range 1 21))]
       ;; h = (20-1)*0.95 = 18.05 -> v[18] + (v[19] - v[18]) * 0.05
       ;;                          = 19   + 1 * 0.05 = 19.05
-      (is (close? 19.05 (lane/quantile xs 0.95)))
+      (is (close? 19.05 (rf.bench.hicasso.lane/quantile xs 0.95)))
       (is (= 19 (nearest-rank xs 0.95))
           "the convention NOT taken, stated so the difference is on the page")))
 
   (testing "q = 0 is the minimum and q = 1 is the maximum, exactly"
     (let [xs [7.5 2.25 9.0 4.0]]
-      (is (= 2.25 (lane/quantile xs 0)))
-      (is (= 9.0 (lane/quantile xs 1)))))
+      (is (= 2.25 (rf.bench.hicasso.lane/quantile xs 0)))
+      (is (= 9.0 (rf.bench.hicasso.lane/quantile xs 1)))))
 
   (testing "the sample need not arrive sorted"
     (let [asc  (vec (range 1 21))
           desc (vec (reverse asc))
           shuf [13 2 20 7 1 19 4 11 16 6 3 18 9 14 5 12 17 8 15 10]]
       (is (= (set asc) (set shuf)) "the shuffled fixture is the same sample")
-      (is (close? (lane/quantile asc 0.95) (lane/quantile desc 0.95)))
-      (is (close? (lane/quantile asc 0.95) (lane/quantile shuf 0.95)))))
+      (is (close? (rf.bench.hicasso.lane/quantile asc 0.95) (rf.bench.hicasso.lane/quantile desc 0.95)))
+      (is (close? (rf.bench.hicasso.lane/quantile asc 0.95) (rf.bench.hicasso.lane/quantile shuf 0.95)))))
 
   (testing "a one-sample and an empty sample"
-    (is (= 4.0 (lane/quantile [4.0] 0.99)))
-    (is (nil? (lane/quantile [] 0.95)))
-    (is (nil? (lane/quantile nil 0.95)))))
+    (is (= 4.0 (rf.bench.hicasso.lane/quantile [4.0] 0.99)))
+    (is (nil? (rf.bench.hicasso.lane/quantile [] 0.95)))
+    (is (nil? (rf.bench.hicasso.lane/quantile nil 0.95)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The consistency with `:p50`, which is why this convention and not another
@@ -111,8 +111,8 @@
     (doseq [xs [[3.0 1.0 2.0]
                 [5.0 1.0 4.0 2.0 3.0]
                 (vec (range 1 22))]]
-      (let [p50 (:p50 (lane/summarise xs))]
-        (is (= p50 (lane/quantile xs 0.5))
+      (let [p50 (:p50 (rf.bench.hicasso.lane/summarise xs))]
+        (is (= p50 (rf.bench.hicasso.lane/quantile xs 0.5))
             (str "p50 and quantile 0.5 must be one estimator on " (count xs) " samples"))
         (is (some #(= % p50) xs)
             "an odd count answers a member of its own sample"))))
@@ -123,7 +123,7 @@
                 [0.1 0.3]
                 [2.4 2.5 2.6 2.7 2.8 2.9]
                 (vec (range 1 21))]]
-      (is (close? (:p50 (lane/summarise xs)) (lane/quantile xs 0.5))
+      (is (close? (:p50 (rf.bench.hicasso.lane/summarise xs)) (rf.bench.hicasso.lane/quantile xs 0.5))
           (str "p50 and quantile 0.5 must agree on " (count xs) " samples"))))
 
   (testing "`:p50`'s own spelling is UNCHANGED by this bead — the two-branch
@@ -131,9 +131,9 @@
     ;; The values below are the pre-`rf2-xa8wo` behaviour, transcribed. A
     ;; refactor that routed `:p50` through `quantile` would move a published
     ;; figure by up to one ulp, and this is the assertion that would catch it.
-    (is (= 2.0 (:p50 (lane/summarise [1.0 2.0 3.0]))))
-    (is (= 2.5 (:p50 (lane/summarise [1.0 2.0 3.0 4.0]))))
-    (is (= (/ (+ 0.1 0.3) 2.0) (:p50 (lane/summarise [0.1 0.3]))))))
+    (is (= 2.0 (:p50 (rf.bench.hicasso.lane/summarise [1.0 2.0 3.0]))))
+    (is (= 2.5 (:p50 (rf.bench.hicasso.lane/summarise [1.0 2.0 3.0 4.0]))))
+    (is (= (/ (+ 0.1 0.3) 2.0) (:p50 (rf.bench.hicasso.lane/summarise [0.1 0.3]))))))
 
 ;; ---------------------------------------------------------------------------
 ;; What a SHORT sample does to a tail quantile — the docstring's own caveat,
@@ -144,7 +144,7 @@
   (testing "at n = 20 a p99 sits between the top two readings and is no
             reading the sample ever took"
     (let [xs  (vec (range 1 21))
-          p99 (lane/quantile xs 0.99)]
+          p99 (rf.bench.hicasso.lane/quantile xs 0.99)]
       ;; h = 19*0.99 = 18.81 -> 19 + (20-19)*0.81 = 19.81
       (is (close? 19.81 p99))
       (is (< 19 p99 20) "strictly between the second-largest and the largest")
@@ -154,7 +154,7 @@
   (testing "a quantile never exceeds the maximum, however short the sample"
     (doseq [n [1 2 3 5 20 101]]
       (let [xs (vec (range 1 (inc n)))
-            s  (lane/summarise xs)]
+            s  (rf.bench.hicasso.lane/summarise xs)]
         (is (<= (:p50 s) (:p95 s) (:p99 s) (:max s))
             (str "quantiles must be monotone and bounded by :max at n = " n))
         (is (>= (:p95 s) (:min s)))))))
@@ -167,18 +167,18 @@
 (deftest summarise-carries-the-tail-quantiles-and-keeps-everything-else
   (testing "the four fields every existing caller destructures are unmoved"
     (let [xs (vec (range 1 21))
-          s  (lane/summarise xs)]
+          s  (rf.bench.hicasso.lane/summarise xs)]
       (is (= 20 (:n s)))
       (is (= 1 (:min s)))
       (is (= 20 (:max s)))
       (is (= 10.5 (:p50 s)))))
 
-  (testing "and `:p95` / `:p99` are [[lane/quantile]] and not a second spelling"
+  (testing "and `:p95` / `:p99` are [[rf.bench.hicasso.lane/quantile]] and not a second spelling"
     (let [xs [4.2 1.9 3.3 8.8 2.7 5.1 6.4 7.0 9.6 0.5
               3.9 2.1 6.9 5.5 1.2 8.1 4.7 7.7 0.9 9.1]
-          s  (lane/summarise xs)]
-      (is (= (lane/quantile xs 0.95) (:p95 s)))
-      (is (= (lane/quantile xs 0.99) (:p99 s)))))
+          s  (rf.bench.hicasso.lane/summarise xs)]
+      (is (= (rf.bench.hicasso.lane/quantile xs 0.95) (:p95 s)))
+      (is (= (rf.bench.hicasso.lane/quantile xs 0.99) (:p99 s)))))
 
   (testing "and the summary carries EXACTLY these six keys"
     ;; Frozen here, next to the function, because it used to be frozen by
@@ -187,13 +187,13 @@
     ;; adding a field reddened a test with no opinion about fields. A shape
     ;; worth holding is worth holding where a reader would look for it.
     (is (= #{:n :min :max :p50 :p95 :p99}
-           (set (keys (lane/summarise [1.0 2.0 3.0]))))))
+           (set (keys (rf.bench.hicasso.lane/summarise [1.0 2.0 3.0]))))))
 
   (testing "an empty sample is still `nil` rather than a map of nothings"
-    (is (nil? (lane/summarise [])))
-    (is (nil? (lane/summarise nil))))
+    (is (nil? (rf.bench.hicasso.lane/summarise [])))
+    (is (nil? (rf.bench.hicasso.lane/summarise nil))))
 
   (testing "a one-sample answers that sample at every quantile"
-    (let [s (lane/summarise [3.75])]
+    (let [s (rf.bench.hicasso.lane/summarise [3.75])]
       (is (= 1 (:n s)))
       (is (= 3.75 (:min s) (:max s) (:p50 s) (:p95 s) (:p99 s))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/lane_release_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/lane_release_dom_cljs_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.bench.hicasso.lane-release-dom-cljs-test
-  "`lane/release!`'s claim that a NORMAL RETURN is not proof of release,
+  "`rf.bench.hicasso.lane/release!`'s claim that a NORMAL RETURN is not proof of release,
   and the census extension that lets a family count its own references
   (rf2-2rtt6.2, second audit).
 
@@ -21,7 +21,7 @@
   a stated skip under `:node-test`, which is the posture the other `*-dom`
   suites keep."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.bench.hicasso.lane :as lane]))
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]))
 
 (def ^:private off-browser
   "no DOM on this runtime — the claim is a DOM read taken at release, and
@@ -47,32 +47,32 @@
   (testing "an unmount that returns normally leaving its page standing is
            recorded at the site and adjudicated as a teardown failure —
            the exact shape the second audit planted and watched pass"
-    (if-not (lane/browser?)
+    (if-not (rf.bench.hicasso.lane/browser?)
       (is true off-browser)
-      (do (lane/drain-teardown-failures!) ;; a clean slate for the claim
-          (lane/release! (populated-mount (fn [_c] nil)))
+      (do (rf.bench.hicasso.lane/drain-teardown-failures!) ;; a clean slate for the claim
+          (rf.bench.hicasso.lane/release! (populated-mount (fn [_c] nil)))
           (is (thrown-with-msg? js/Error #"teardown FAILED"
-                (lane/assert-teardown-clean! "the no-op release"))
+                (rf.bench.hicasso.lane/assert-teardown-clean! "the no-op release"))
               "a normal return must not pass for a release")))))
 
 (deftest a-release-that-emptied-its-container-is-clean
   (testing "the same path records nothing when the unmount actually
            releases — the check reads the page, not the promise"
-    (if-not (lane/browser?)
+    (if-not (rf.bench.hicasso.lane/browser?)
       (is true off-browser)
-      (do (lane/drain-teardown-failures!)
-          (lane/release! (populated-mount (fn [c] (.replaceChildren c))))
-          (is (nil? (lane/assert-teardown-clean! "the real release"))
+      (do (rf.bench.hicasso.lane/drain-teardown-failures!)
+          (rf.bench.hicasso.lane/release! (populated-mount (fn [c] (.replaceChildren c))))
+          (is (nil? (rf.bench.hicasso.lane/assert-teardown-clean! "the real release"))
               "an emptied container is the release, observed")))))
 
 (deftest a-throwing-unmount-is-recorded-once
   (testing "a throw is already the record — the container read does not
            stack a second failure onto the same release"
-    (if-not (lane/browser?)
+    (if-not (rf.bench.hicasso.lane/browser?)
       (is true off-browser)
-      (do (lane/drain-teardown-failures!)
-          (lane/release! (populated-mount (fn [_c] (throw (js/Error. "boom")))))
-          (let [fs (lane/drain-teardown-failures!)]
+      (do (rf.bench.hicasso.lane/drain-teardown-failures!)
+          (rf.bench.hicasso.lane/release! (populated-mount (fn [_c] (throw (js/Error. "boom")))))
+          (let [fs (rf.bench.hicasso.lane/drain-teardown-failures!)]
             (is (= 1 (count fs)) "one release, one record")
             (is (= "boom" (:error (first fs)))
                 "and the record carries the throw, not the container count"))))))
@@ -85,19 +85,19 @@
   (testing "a family whose references live outside the frame cache and the
            body supplies its own counter, and the residue assertion
            refuses on it by the same equality"
-    (if-not (lane/browser?)
+    (if-not (rf.bench.hicasso.lane/browser?)
       (is true off-browser)
       (let [live     (atom 0)
             counters {:family-refs (fn [] @live)}
-            baseline (lane/residue ::no-such-frame counters)]
+            baseline (rf.bench.hicasso.lane/residue ::no-such-frame counters)]
         (is (= 0 (:family-refs baseline))
             "the caller's counter is part of the reading")
         (swap! live inc) ;; the surviving root's reference
         (is (thrown-with-msg? js/Error #"RESIDUE"
-              (lane/assert-residue! baseline ::no-such-frame
+              (rf.bench.hicasso.lane/assert-residue! baseline ::no-such-frame
                                     "the row" counters))
             "one live reference outside both built-in counters must refuse")
         (reset! live 0)
-        (is (= baseline (lane/assert-residue! baseline ::no-such-frame
+        (is (= baseline (rf.bench.hicasso.lane/assert-residue! baseline ::no-such-frame
                                               "the row" counters))
             "and back at baseline the same census passes")))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/lane_resolution_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/lane_resolution_cljs_test.cljs
@@ -46,7 +46,7 @@
   This is a test over known inputs. It runs on a loaded box, touches no
   clock, mounts nothing, and pins no figure any budget row reads."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.bench.hicasso.lane :as lane]))
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]))
 
 ;; ---------------------------------------------------------------------------
 ;; The fixture — rf2-9wmqd's `:locale` pair, evidence run 1
@@ -61,8 +61,8 @@
    :locale       {:p50 17.05}})
 
 (def round-ratios
-  "Three rounds of ARM-TO-FLOOR ratios, the shape `lane/normalise`
-  answers and the only shape `lane/ratio-between` accepts.
+  "Three rounds of ARM-TO-FLOOR ratios, the shape `rf.bench.hicasso.lane/normalise`
+  answers and the only shape `rf.bench.hicasso.lane/ratio-between` accepts.
 
   `:donor-locale` is held at `1.046` — `17.05 / 16.30`, so the two inputs
   describe one run rather than two — and `:locale` is that times
@@ -73,7 +73,7 @@
    {:locale 1.06692  :donor-locale 1.046}])
 
 (defn locale-like []
-  (lane/resolution (lane/ratio-between round-ratios :locale :donor-locale)
+  (rf.bench.hicasso.lane/resolution (rf.bench.hicasso.lane/ratio-between round-ratios :locale :donor-locale)
                    summary
                    :idle-frame))
 
@@ -91,9 +91,9 @@
     (let [{:keys [own-work own-work-share]} (locale-like)]
       (is (= 0.75 own-work)
           "the denominator arm's median less the floor's, in ms")
-      (is (= 0.011 (lane/round4 (* 0.25 own-work-share)))
+      (is (= 0.011 (rf.bench.hicasso.lane/round4 (* 0.25 own-work-share)))
           "a 1.25x difference displaces the window ratio to 1.011")
-      (is (= 0.022 (lane/round4 (* 0.5 own-work-share)))
+      (is (= 0.022 (rf.bench.hicasso.lane/round4 (* 0.5 own-work-share)))
           "a 1.5x difference displaces it to 1.022"))))
 
 (deftest the-pair-clears-the-floor-and-still-cannot-resolve-the-line
@@ -103,12 +103,12 @@
            work, because `:resolves-at` sits above it. One test answering
            yes and the other no on the SAME run is what makes them
            different questions rather than two spellings of one."
-    (let [over-floor (lane/across-rounds round-ratios)]
+    (let [over-floor (rf.bench.hicasso.lane/across-rounds round-ratios)]
       (is (false? (:straddles-1? (:locale over-floor)))
           "the measured arm separated from the floor in every round")
       (is (false? (:straddles-1? (:donor-locale over-floor)))
           "so did the donor arm — the shipped gate passes this pair")
-      (is (true? (:straddles-1? (lane/ratio-between round-ratios
+      (is (true? (:straddles-1? (rf.bench.hicasso.lane/ratio-between round-ratios
                                                     :locale :donor-locale)))
           "and the pair itself reads ~1.00x, straddling 1.0")
       (is (> (:resolves-at (locale-like)) 1.5)
@@ -128,7 +128,7 @@
       (is (= 0.0375 spread)
           "the width of `ratio-between`'s `:per-round`")
       (is (= 1.8525 resolves-at))
-      (is (= spread (lane/round4 (* (- resolves-at 1.0) own-work-share)))
+      (is (= spread (rf.bench.hicasso.lane/round4 (* (- resolves-at 1.0) own-work-share)))
           "the figure and the spread are the same statement"))))
 
 (deftest the-floor-and-not-the-noise-is-what-makes-a-run-coarse
@@ -137,8 +137,8 @@
            of `1.85x`. A figure that answered the same either way would
            be reporting noise and nothing about the frame grid, which is
            the term this whole finding is about."
-    (let [lifted (lane/resolution
-                   (lane/ratio-between round-ratios :locale :donor-locale)
+    (let [lifted (rf.bench.hicasso.lane/resolution
+                   (rf.bench.hicasso.lane/ratio-between round-ratios :locale :donor-locale)
                    {:idle-frame {:p50 1.0} :donor-locale {:p50 10.0}}
                    :idle-frame)]
       (is (= 0.9 (:own-work-share lifted))
@@ -156,10 +156,10 @@
            any difference whatever, so the honest answer is `nil` rather
            than a large number that looks like an answer. `:own-work`
            stays published either way, because it is the reason."
-    (let [pair (lane/ratio-between round-ratios :locale :donor-locale)
-          at   (lane/resolution pair {:idle-frame   {:p50 16.30}
+    (let [pair (rf.bench.hicasso.lane/ratio-between round-ratios :locale :donor-locale)
+          at   (rf.bench.hicasso.lane/resolution pair {:idle-frame   {:p50 16.30}
                                       :donor-locale {:p50 16.30}} :idle-frame)
-          below (lane/resolution pair {:idle-frame   {:p50 16.30}
+          below (rf.bench.hicasso.lane/resolution pair {:idle-frame   {:p50 16.30}
                                        :donor-locale {:p50 16.00}} :idle-frame)]
       (is (nil? (:resolves-at at))
           "exactly at the floor")
@@ -175,8 +175,8 @@
            bounds nothing — not that any difference is visible — and the
            `:spread` of `0.0` sitting beside it is what tells a reader
            which of the two it is."
-    (let [flat (lane/resolution
-                 (lane/ratio-between [{:locale 1.046 :donor-locale 1.046}
+    (let [flat (rf.bench.hicasso.lane/resolution
+                 (rf.bench.hicasso.lane/ratio-between [{:locale 1.046 :donor-locale 1.046}
                                       {:locale 1.046 :donor-locale 1.046}]
                                      :locale :donor-locale)
                  summary

--- a/bench/hicasso/src/re_frame/bench/hicasso/lane_schedule_async_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/lane_schedule_async_cljs_test.cljs
@@ -7,7 +7,7 @@
   second driver over the same plan, and the failure mode of a second
   driver is the one this lane has already paid for twice: `slot-order`'s
   `k = 2` degeneracy survived a fix to its own sibling because
-  `b6-harness` held a copy of the rule, and `lane/observe!`'s missing call
+  `b6-harness` held a copy of the rule, and `rf.bench.hicasso.lane/observe!`'s missing call
   was repaired privately in two hand-rolled loops while the ten apps
   riding the shared one kept the fault.
 
@@ -30,7 +30,7 @@
   `rounds-async!` that measured nothing at all — which is exactly what a
   promise chain that dropped its tail would produce."
   (:require [cljs.test :refer-macros [async deftest is testing]]
-            [re-frame.bench.hicasso.lane :as lane]))
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]))
 
 (def ^:private sampling
   "`lane-schedule-cljs-test`'s numbers, carried rather than chosen: this
@@ -56,7 +56,7 @@
   `truth` is every execution in order — warm-up and measured alike."
   [n]
   (let [truth (atom [])
-        out   (lane/rounds! (arms n) sampling rounds
+        out   (rf.bench.hicasso.lane/rounds! (arms n) sampling rounds
                             (fn [arm]
                               (let [i (count @truth)]
                                 (swap! truth conj (name (:id arm)))
@@ -76,7 +76,7 @@
   (let [truth    (atom [])
         in-fl    (atom 0)
         overlaps (atom 0)]
-    (.then (lane/rounds-async! (arms n) sampling rounds
+    (.then (rf.bench.hicasso.lane/rounds-async! (arms n) sampling rounds
                                (fn [arm]
                                  (when (pos? @in-fl) (swap! overlaps inc))
                                  (swap! in-fl inc)
@@ -116,7 +116,7 @@
            test."
     (async done
       (.then
-        (lane/chain nil arm-counts
+        (rf.bench.hicasso.lane/chain nil arm-counts
                     (fn [_ n]
                       (.then (async-run n)
                              (fn [a]
@@ -148,7 +148,7 @@
            tare — needs no wrapper of its own."
     (async done
       (let [as (arms 3)]
-        (.then (lane/rounds-async! as sampling rounds (fn [_] 1.0))
+        (.then (rf.bench.hicasso.lane/rounds-async! as sampling rounds (fn [_] 1.0))
                (fn [{:keys [samples readings]}]
                  (is (= (* rounds (:samples sampling) 3) (count samples)))
                  (is (every? (fn [round]

--- a/bench/hicasso/src/re_frame/bench/hicasso/lane_schedule_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/lane_schedule_cljs_test.cljs
@@ -7,7 +7,7 @@
   `order-guard`'s `:predecessor` factor strata every banked sample by
   exactly that.
 
-  It did throw it away. [[lane/collect!]] carried `:prev` forward from the
+  It did throw it away. [[rf.bench.hicasso.lane/collect!]] carried `:prev` forward from the
   last sample it BANKED, so at each round's first measured sample the
   predecessor it recorded was the PREVIOUS ROUND'S last measured arm —
   never the warm-up sample that had just run. Replaying the schedule
@@ -43,7 +43,7 @@
   ## Arm counts
 
   4, 5, 7, 8 and 9 — `direct_return_clock`'s, `amp_merge_clock`'s before
-  `rf2-z143r`'s ladder and after it, the count `lane/observe!`'s own
+  `rf2-z143r`'s ladder and after it, the count `rf.bench.hicasso.lane/observe!`'s own
   docstring prices the fault at, and `amp_merge_clock`'s again once
   `rf2-v5oto`'s two clean-pair arms land. The fault is invariant to all
   of them, which is the same arithmetic that settles `rf2-6ta5r`'s
@@ -68,7 +68,7 @@
   which is the point: it should not be possible to land the mechanism and
   leave the reasoning that declined it standing."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.bench.hicasso.lane :as lane]))
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]))
 
 ;; ---------------------------------------------------------------------------
 ;; The replay
@@ -80,7 +80,7 @@
   [4 5 7 8 9])
 
 (defn- replay
-  "Run `lane/rounds!` over `n` arms with a stub that records the true
+  "Run `rf.bench.hicasso.lane/rounds!` over `n` arms with a stub that records the true
   execution order and answers each call's index in it.
 
   Answers `{:samples … :readings … :truth […]}`, where `truth` is EVERY
@@ -88,7 +88,7 @@
   [n sampling rounds]
   (let [truth (atom [])
         arms  (mapv (fn [i] {:id (keyword (str "arm-" i))}) (range n))
-        out   (lane/rounds! arms sampling rounds
+        out   (rf.bench.hicasso.lane/rounds! arms sampling rounds
                             (fn [arm]
                               (let [i (count @truth)]
                                 (swap! truth conj (name (:id arm)))
@@ -203,7 +203,7 @@
   "Both samplings the lane's page-mount clocks have run, each with the span
   of PRIOR EXECUTIONS OF ITS OWN ARM that the run's last third sits at.
 
-  `lane/rounds!`'s docstring quotes both spans as the reason a run-level
+  `rf.bench.hicasso.lane/rounds!`'s docstring quotes both spans as the reason a run-level
   pre-warm was declined; these are the same two numbers, checked. The
   file-level [[sampling]] above stays pinned at the pair the predecessor
   fault was found under — that fault is invariant to the numbers and this

--- a/bench/hicasso/src/re_frame/bench/hicasso/lane_window_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/lane_window_dom_cljs_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.bench.hicasso.lane-window-dom-cljs-test
-  "`lane/verified-write!`'s two window shapes, and the claim that neither
+  "`rf.bench.hicasso.lane/verified-write!`'s two window shapes, and the claim that neither
   one serves both scheduler families (rf2-pq7d8).
 
   This is a CORRECTNESS test of the instrument, not a benchmark: nothing
@@ -37,7 +37,7 @@
   ## What would have caught the recorded fault
 
   [[microtask-arm-is-unverified-under-the-yielding-window]] is that test.
-  It goes red on the window `lane/verified-write!` had before rf2-pq7d8,
+  It goes red on the window `rf.bench.hicasso.lane/verified-write!` had before rf2-pq7d8,
   and for the right reason: `N unverified of N` against a DOM that never
   changed. The row that fault produced read `0.16–0.50x` the floor — a
   precise wrong number, and the sixteenth of its kind on these surfaces.
@@ -47,7 +47,7 @@
   a stated skip under `:node-test`, which is the posture the other `*-dom`
   suites keep."
   (:require [cljs.test :refer-macros [async deftest is testing]]
-            [re-frame.bench.hicasso.lane :as lane]))
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]))
 
 (def ^:private off-browser
   "no DOM on this runtime — the claim is a DOM read-back inside a measured
@@ -59,7 +59,7 @@
 
 (defn- cell-container!
   "A container holding one `data-i=\"0\"` cell reading `\"old\"` — the
-  smallest page `lane/text-at` can probe."
+  smallest page `rf.bench.hicasso.lane/text-at` can probe."
   []
   (let [c (js/document.createElement "div")]
     (set! (.-innerHTML c) "<span data-i=\"0\">old</span>")
@@ -126,12 +126,12 @@
      :force!    (fn [] (when-some [v @queue] (commit! container v) (reset! queue nil)))}))
 
 (defn- write-once!
-  "One `lane/verified-write!` against `arm`; answers a promise of
+  "One `rf.bench.hicasso.lane/verified-write!` against `arm`; answers a promise of
   `[result tally-value]`."
   [arm container]
-  (let [t (lane/tally)]
-    (-> (lane/verified-write! t {:arm arm :container container} 0 "new" [0])
-        (.then (fn [r] [r (lane/tally-value t)])))))
+  (let [t (rf.bench.hicasso.lane/tally)]
+    (-> (rf.bench.hicasso.lane/verified-write! t {:arm arm :container container} 0 "new" [0])
+        (.then (fn [r] [r (rf.bench.hicasso.lane/tally-value t)])))))
 
 ;; ---------------------------------------------------------------------------
 ;; The microtask family — the fault, and the repair
@@ -141,7 +141,7 @@
   (testing "a microtask-scheduled arm measured through the YIELDING window
            loses its commit, and the DOM read-back is what says so"
     (async done
-      (if-not (lane/browser?)
+      (if-not (rf.bench.hicasso.lane/browser?)
         (do (is true off-browser) (done))
         (let [c   (cell-container!)
               arm (dissoc (microtask-scheduled-arm c) :scheduler)]
@@ -153,7 +153,7 @@
                            "and the tally must publish it as 1 unverified of 1")
                        ;; The page is untouched, so the milliseconds this
                        ;; window measured are a measurement of nothing.
-                       (is (= "old" (lane/text-at c 0))
+                       (is (= "old" (rf.bench.hicasso.lane/text-at c 0))
                            "the cell must still read the OLD value")
                        ;; The commit is not lost, merely parked: a LATE DOM,
                        ;; not a dead one, which is why the clock reading
@@ -174,7 +174,7 @@
   (testing "declaring :scheduler :microtask puts NOTHING between the write
            and the drain, so the commit lands inside the window"
     (async done
-      (if-not (lane/browser?)
+      (if-not (rf.bench.hicasso.lane/browser?)
         (do (is true off-browser) (done))
         (let [c   (cell-container!)
               arm (microtask-scheduled-arm c)]
@@ -182,7 +182,7 @@
               (.then (fn [[r tally]]
                        (is (true? (:ok? r)) "the write-then-drain window must verify")
                        (is (= {:writes 1 :unverified 0} tally) "0 unverified of 1")
-                       (is (= "new" (lane/text-at c 0))
+                       (is (= "new" (rf.bench.hicasso.lane/text-at c 0))
                            "and the page must actually carry the written value")
                        (is (nil? @(:parked arm))
                            "nothing was parked — the drain got there first")
@@ -200,7 +200,7 @@
   (testing "the yield is LOAD-BEARING for an arm whose notification is
            queued somewhere other than the queue the harness yields to"
     (async done
-      (if-not (lane/browser?)
+      (if-not (rf.bench.hicasso.lane/browser?)
         (do (is true off-browser) (done))
         (let [c   (cell-container!)
               arm (queued-notification-arm c)]
@@ -208,7 +208,7 @@
               (.then (fn [[r tally]]
                        (is (true? (:ok? r)) "the yielding window must verify this family")
                        (is (= {:writes 1 :unverified 0} tally) "0 unverified of 1")
-                       (is (= "new" (lane/text-at c 0)))))
+                       (is (= "new" (rf.bench.hicasso.lane/text-at c 0)))))
               (.catch (fn [e] (is false (str e)) nil))
               (.then (fn [_] (.remove c) (done)))))))))
 
@@ -216,7 +216,7 @@
   (testing "and the write-then-drain window BREAKS that same arm — so
            neither shape is universally right, which is the finding"
     (async done
-      (if-not (lane/browser?)
+      (if-not (rf.bench.hicasso.lane/browser?)
         (do (is true off-browser) (done))
         (let [c   (cell-container!)
               arm (assoc (queued-notification-arm c) :scheduler :microtask)]
@@ -225,7 +225,7 @@
                        (is (false? (:ok? r))
                            "draining immediately must find this arm's queue empty")
                        (is (= {:writes 1 :unverified 1} tally) "1 unverified of 1")
-                       (is (= "old" (lane/text-at c 0)))))
+                       (is (= "old" (rf.bench.hicasso.lane/text-at c 0)))))
               (.catch (fn [e] (is false (str e)) nil))
               (.then (fn [_] (.remove c) (done)))))))))
 
@@ -239,7 +239,7 @@
            makes this change additive and leaves every published P0 row
            standing"
     (async done
-      (if-not (lane/browser?)
+      (if-not (rf.bench.hicasso.lane/browser?)
         (do (is true off-browser) (done))
         (let [c    (cell-container!)
               seen (atom [])
@@ -289,7 +289,7 @@
 
 (defn- ops-for
   "`k` ops, each its OWN cell and its OWN value — the caller obligation
-  `lane/verified-writes!` states, so no read-back can be satisfied by a
+  `rf.bench.hicasso.lane/verified-writes!` states, so no read-back can be satisfied by a
   neighbour's commit."
   [k]
   (mapv (fn [i] [i (str "v" i) [i]]) (range k)))
@@ -300,13 +300,13 @@
            whole batch, which is what makes a batched figure comparable
            with the unbatched one it supersedes"
     (async done
-      (if-not (lane/browser?)
+      (if-not (rf.bench.hicasso.lane/browser?)
         (do (is true off-browser) (done))
         (let [k    3
               c    (grid-container! k)
               seen (atom [])
-              t    (lane/tally)]
-          (-> (lane/verified-writes! t {:arm (recording-arm c seen) :container c} (ops-for k))
+              t    (rf.bench.hicasso.lane/tally)]
+          (-> (rf.bench.hicasso.lane/verified-writes! t {:arm (recording-arm c seen) :container c} (ops-for k))
               (.then (fn [r]
                        (is (= [:wrote :microtask-ran :forced
                                :wrote :microtask-ran :forced
@@ -318,7 +318,7 @@
                        ;; The tally counts OPERATIONS, not samples: a batched
                        ;; row that banked one write per window would publish
                        ;; `N unverified of M` with an M a tenth of the truth.
-                       (is (= {:writes k :unverified 0} (lane/tally-value t))
+                       (is (= {:writes k :unverified 0} (rf.bench.hicasso.lane/tally-value t))
                            "the tally banks every op in the batch")))
               (.catch (fn [e] (is false (str e)) nil))
               (.then (fn [_] (.remove c) (done)))))))))
@@ -328,17 +328,17 @@
            the BROAD row pass a batch of one and not move, while the narrow
            row batches"
     (async done
-      (if-not (lane/browser?)
+      (if-not (rf.bench.hicasso.lane/browser?)
         (do (is true off-browser) (done))
         (let [c    (grid-container! 1)
               seen (atom [])
-              t    (lane/tally)]
-          (-> (lane/verified-writes! t {:arm (recording-arm c seen) :container c} (ops-for 1))
+              t    (rf.bench.hicasso.lane/tally)]
+          (-> (rf.bench.hicasso.lane/verified-writes! t {:arm (recording-arm c seen) :container c} (ops-for 1))
               (.then (fn [r]
                        (is (= [:wrote :microtask-ran :forced] @seen)
                            "one write, one yield, one drain — the unbatched shape")
                        (is (true? (:ok? r)))
-                       (is (= {:writes 1 :unverified 0} (lane/tally-value t)))))
+                       (is (= {:writes 1 :unverified 0} (rf.bench.hicasso.lane/tally-value t)))))
               (.catch (fn [e] (is false (str e)) nil))
               (.then (fn [_] (.remove c) (done)))))))))
 
@@ -346,14 +346,14 @@
   (testing "the microtask family's batched window is one synchronous run —
            not even a microtask separates a drain from the next write"
     (async done
-      (if-not (lane/browser?)
+      (if-not (rf.bench.hicasso.lane/browser?)
         (do (is true off-browser) (done))
         (let [k    3
               c    (grid-container! k)
               seen (atom [])
-              t    (lane/tally)
+              t    (rf.bench.hicasso.lane/tally)
               arm  (assoc (recording-arm c seen) :scheduler :microtask)]
-          (-> (lane/verified-writes! t {:arm arm :container c} (ops-for k))
+          (-> (rf.bench.hicasso.lane/verified-writes! t {:arm arm :container c} (ops-for k))
               (.then (fn [r]
                        ;; The first 2k entries are the WINDOW, and they are
                        ;; write/drain/write/drain with nothing in between. The
@@ -370,7 +370,7 @@
                               (vec (drop (* 2 k) @seen)))
                            "and the arm's own microtasks ran only once the window had closed")
                        (is (zero? (:gap-ms r)) ":gap-ms must be 0.0, not merely small")
-                       (is (= {:writes k :unverified 0} (lane/tally-value t)))))
+                       (is (= {:writes k :unverified 0} (rf.bench.hicasso.lane/tally-value t)))))
               (.catch (fn [e] (is false (str e)) nil))
               (.then (fn [_] (.remove c) (done)))))))))
 
@@ -378,19 +378,19 @@
   (testing "an arm whose commits never land reads `k unverified of k`, not
            one — the count a published row quotes is per OPERATION"
     (async done
-      (if-not (lane/browser?)
+      (if-not (rf.bench.hicasso.lane/browser?)
         (do (is true off-browser) (done))
         (let [k   3
               c   (grid-container! k)
-              t   (lane/tally)
+              t   (rf.bench.hicasso.lane/tally)
               ;; Writes nothing to the page at all: the window's milliseconds
               ;; are real and they measure nothing.
               arm {:id :never-commits :write! (fn [_i _v] nil) :force! (fn [] nil)}]
-          (-> (lane/verified-writes! t {:arm arm :container c} (ops-for k))
+          (-> (rf.bench.hicasso.lane/verified-writes! t {:arm arm :container c} (ops-for k))
               (.then (fn [r]
                        (is (false? (:ok? r)))
                        (is (= [false false false] (:oks r)))
-                       (is (= {:writes k :unverified k} (lane/tally-value t))
+                       (is (= {:writes k :unverified k} (rf.bench.hicasso.lane/tally-value t))
                            "k unverified of k")))
               (.catch (fn [e] (is false (str e)) nil))
               (.then (fn [_] (.remove c) (done)))))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/ledger_frame_clock_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/ledger_frame_clock_app.cljs
@@ -64,7 +64,7 @@
   reading on this lane starts from. Both siblings settle on it outside
   every measurement, and so does [[prepare!]] here. A second copy of it
   is a second thing that can drift, which is the shape
-  `lane/visit-plan`'s own docstring is written against.
+  `rf.bench.hicasso.lane/visit-plan`'s own docstring is written against.
 
   [[frames!]] is the estimator:
 
@@ -79,21 +79,21 @@
 
   ## THE SCHEDULE IS THE LANE'S, BUT THE LOOP CANNOT BE
 
-  `lane/rounds-async!` schedules a sample as a promise of ONE NUMBER, and
+  `rf.bench.hicasso.lane/rounds-async!` schedules a sample as a promise of ONE NUMBER, and
   a frame run yields `K-1` of them, so that loop does not fit. What does
-  fit — and is used — is `lane/visit-plan`, the PLAN both of the lane's
-  loops walk: same `lane/slot-order` reflection, same warm-up boundary,
-  same round boundary. Walking the plan with `lane/chain` and banking a VECTOR
+  fit — and is used — is `rf.bench.hicasso.lane/visit-plan`, the PLAN both of the lane's
+  loops walk: same `rf.bench.hicasso.lane/slot-order` reflection, same warm-up boundary,
+  same round boundary. Walking the plan with `rf.bench.hicasso.lane/chain` and banking a VECTOR
   per visit rather than a number reuses the schedule at the one level
   where it is stated, instead of re-deriving `(count arms)`,
-  `lane/slot-order` and the warm-up boundary here. `lane/visit-plan`
+  `rf.bench.hicasso.lane/slot-order` and the warm-up boundary here. `rf.bench.hicasso.lane/visit-plan`
   prices what a second copy of the schedule has cost this lane: the
   `k = 2` degeneracy that survived a fix to its own sibling, and the
   predecessor tagging that was repaired twice privately while ten apps
   riding the shared loop kept the fault.
 
   One guard sample is banked per VISIT — that visit's median interval —
-  so `lane/collect!`'s `:position` still counts visits across the whole
+  so `rf.bench.hicasso.lane/collect!`'s `:position` still counts visits across the whole
   run and `:predecessor` still names the arm that ran immediately before.
 
   ## WHAT CARRIES THE CLAIM THAT THESE ARE FRAMES UNDER A REAL SCROLL
@@ -109,8 +109,8 @@
      layout and paint — see §WHERE THE OBSERVATION IS READ. A measured
      run is verified when that index ADVANCED across the run, which it
      can only do if the vendor saw the scroll, recomputed its window and
-     React committed the result. It banks into `lane/tally` and
-     `lane/assert-verified!` refuses the run at `N unverified of M`.
+     React committed the result. It banks into `rf.bench.hicasso.lane/tally` and
+     `rf.bench.hicasso.lane/assert-verified!` refuses the run at `N unverified of M`.
 
   3. THE NEGATIVE CONTROL, WHICH IS AN ARM RATHER THAN A ONE-SHOT.
      `:idle-frames` runs the same rAF chain and the same observation with
@@ -152,7 +152,7 @@
   reach it, because every term is on the same clamped grid.
 
   It is therefore adjudicated by [[control-verdict-floor]] and NOT by
-  `lane/control-verdict` or `lane/control-verdict-strict`: both of those
+  `rf.bench.hicasso.lane/control-verdict` or `rf.bench.hicasso.lane/control-verdict-strict`: both of those
   ask whether a measurement sits INSIDE a ±slack band around a
   prediction, and a floor has no upper edge. A blocked frame that ran
   long is not a control failure, it is a slow frame.
@@ -165,9 +165,9 @@
 
   ## WHERE THE OBSERVATION IS READ, AND WHY IT IS THAT PLACE
 
-  `views/ledger-row` writes `aria-rowindex` as `(inc index)` — the row's
+  `rf.hicasso.examples.ledger.views/ledger-row` writes `aria-rowindex` as `(inc index)` — the row's
   MODEL index, Rule 4 of the recipe — onto the element the vendor
-  renders. `vendor/virtual-rows` renders `(range from (inc to))` in
+  renders. `rf.hicasso.examples.ledger.vendor/virtual-rows` renders `(range from (inc to))` in
   order into the spacer, and appends the pinned row LAST when it appends
   one at all. So the spacer's `firstElementChild` is the window's first
   row, and its `aria-rowindex` is a number **only React's own commit
@@ -192,7 +192,7 @@
 
   ## THE GESTURE, AND WHY ITS NUMBERS ARE DERIVED
 
-  [[scroll-step-px]] is `views/row-height` — ONE ROW PER FRAME, which at
+  [[scroll-step-px]] is `rf.hicasso.examples.ledger.views/row-height` — ONE ROW PER FRAME, which at
   60 Hz is about 1,440 px/s: a brisk flick rather than a contrivance, and
   the unit `virtualized-dom-cljs-test` already measures the screen in
   (*a scroll costs the rows that ENTERED*). It is read off the screen's
@@ -200,7 +200,7 @@
   gesture with it instead of silently changing what a frame's work is.
 
   [[start-row]] puts the run clear of both ends of the model:
-  `vendor/window-from` clamps `from` at 0, so a run beginning at the top
+  `rf.hicasso.examples.ledger.vendor/window-from` clamps `from` at 0, so a run beginning at the top
   would spend its first frames with the window standing still for a
   correct reason, and a run ending past the last row would stop advancing
   for another. [[boot!]] derives both bounds from `window-from` itself
@@ -283,15 +283,15 @@
 
   Owner: rf2-xc0bw."
   (:require [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.slice-echo-clock-app :as echo]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.slice-echo-clock-app :as rf.bench.hicasso.slice-echo-clock-app]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.ledger.app :as ledger-app]
-            [re-frame.hicasso.examples.ledger.events :as ledger-events]
-            [re-frame.hicasso.examples.ledger.vendor :as vendor]
-            [re-frame.hicasso.examples.ledger.views :as views]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.ledger.app :as rf.hicasso.examples.ledger.app]
+            [re-frame.hicasso.examples.ledger.events :as rf.hicasso.examples.ledger.events]
+            [re-frame.hicasso.examples.ledger.vendor :as rf.hicasso.examples.ledger.vendor]
+            [re-frame.hicasso.examples.ledger.views :as rf.hicasso.examples.ledger.views]))
 
 ;; ---------------------------------------------------------------------------
 ;; The knobs — every one of them a SCHEDULE knob, never a line
@@ -302,7 +302,7 @@
   own `default-total` — §7's *10K-row behavior* — read from there rather
   than typed, so a run's population cannot disagree with the
   application's."
-  ledger-events/default-total)
+  rf.hicasso.examples.ledger.events/default-total)
 
 (def sampling
   "Per-round warm-up and measured counts. `rf2-h904p`'s values and both
@@ -323,7 +323,7 @@
   to find the time.
 
   **A tail quantile over a short sample is mostly interpolation**
-  (`lane/quantile` prices exactly that). It is less pressing here than on
+  (`rf.bench.hicasso.lane/quantile` prices exactly that). It is less pressing here than on
   the sibling clocks, because a visit banks [[frames-per-run]] − 1
   readings rather than one: at these values each arm's `:summary` is
   taken over 1,740 intervals."
@@ -354,18 +354,18 @@
 (def scroll-step-px
   "How far the viewport is scrolled each frame — ONE ROW.
 
-  Derived from `views/row-height` rather than typed, so the gesture is
+  Derived from `rf.hicasso.examples.ledger.views/row-height` rather than typed, so the gesture is
   stated in the screen's own units and a change to the row height cannot
   quietly change what a frame's work is. At 60 Hz one row a frame is
   about 1,440 px/s: a brisk flick, and the unit
   `virtualized-dom-cljs-test` measures the screen in."
-  views/row-height)
+  rf.hicasso.examples.ledger.views/row-height)
 
 (def start-row
   "The model row every visit's gesture starts at.
 
-  Clear of the model's start by more than `views/overscan`, so
-  `vendor/window-from`'s `(max 0 …)` clamp never bites and the window
+  Clear of the model's start by more than `rf.hicasso.examples.ledger.views/overscan`, so
+  `rf.hicasso.examples.ledger.vendor/window-from`'s `(max 0 …)` clamp never bites and the window
   advances from the run's first frame; and far enough from its end that
   [[frames-per-run]] rows of gesture cannot reach it. [[boot!]] derives
   both bounds from `window-from` itself and refuses rather than trusting
@@ -410,7 +410,7 @@
   [[boot!]] — warm-up visits included, because a verification is worth
   more the more runs it covers."
   []
-  (lane/tally-value (:tally @!state)))
+  (rf.bench.hicasso.lane/tally-value (:tally @!state)))
 
 (def populations
   "Which visits each published figure is taken over.
@@ -495,7 +495,7 @@
                   (js/requestAnimationFrame
                     (fn []
                       (try
-                        (.push at (lane/now-ms))
+                        (.push at (rf.bench.hicasso.lane/now-ms))
                         (.push seen (observe!))
                         (per-frame!)
                         (if (< (.-length at) frames)
@@ -576,7 +576,7 @@
 
 (defn- note-refusal!
   "Keep the FIRST refusal's detail, so a run that dies on `N unverified
-  of M` says which arm went and what it saw. `lane/tally` counts and does
+  of M` says which arm went and what it saw. `rf.bench.hicasso.lane/tally` counts and does
   not describe, and a bare count over a two-part check is a diagnosis the
   operator has to reproduce."
   [v]
@@ -619,7 +619,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- start-top []
-  (* start-row views/row-height))
+  (* start-row rf.hicasso.examples.ledger.views/row-height))
 
 (defn idle-frames
   "The FLOOR, and the standing negative control.
@@ -682,8 +682,8 @@
   FOURTH appears it belongs in `lane`, beside `now-ms`, which is the
   clock it is already spelled against."
   [ms]
-  (let [end (+ (lane/now-ms) ms)]
-    (loop [] (when (< (lane/now-ms) end) (recur)))))
+  (let [end (+ (rf.bench.hicasso.lane/now-ms) ms)]
+    (loop [] (when (< (rf.bench.hicasso.lane/now-ms) end) (recur)))))
 
 (defn blocked-scroller
   "[[scroller]] plus [[blocked-ms]] of blocked main thread, every frame.
@@ -750,7 +750,7 @@
      [[re-frame.bench.hicasso.slice-echo-clock-app/measure-one!]] carries
      the incident that established that.
 
-  4. Assert the reset LANDED, against `vendor/window-from`'s own
+  4. Assert the reset LANDED, against `rf.hicasso.examples.ledger.vendor/window-from`'s own
      arithmetic rather than against a number typed here. A visit that
      began on a stale window would still verify — the scrolling arms
      advance either way — while its early frames were catching up rather
@@ -769,14 +769,14 @@
                        :want        want
                        :got         (.-scrollTop vp)})))
     (.dispatchEvent vp (js/Event. "scroll" #js {:bubbles true}))
-    (-> (echo/after-paint)
-        (.then (fn [_] (echo/after-paint)))
-        (.then (fn [_] (echo/after-paint)))
+    (-> (rf.bench.hicasso.slice-echo-clock-app/after-paint)
+        (.then (fn [_] (rf.bench.hicasso.slice-echo-clock-app/after-paint)))
+        (.then (fn [_] (rf.bench.hicasso.slice-echo-clock-app/after-paint)))
         (.then (fn [_]
-                 (let [[from _] (vendor/window-from want
-                                                    {:row-height      views/row-height
-                                                     :viewport-height views/viewport-height
-                                                     :overscan        views/overscan
+                 (let [[from _] (rf.hicasso.examples.ledger.vendor/window-from want
+                                                    {:row-height      rf.hicasso.examples.ledger.views/row-height
+                                                     :viewport-height rf.hicasso.examples.ledger.views/viewport-height
+                                                     :overscan        rf.hicasso.examples.ledger.views/overscan
                                                      :total           total})
                        seen     ((observer))]
                    (when-not (= from seen)
@@ -801,7 +801,7 @@
   frame's own work is inside it.
 
   It answers a VECTOR and not a number, which is why this driver cannot
-  ride `lane/rounds-async!` and walks `lane/visit-plan` itself. See the
+  ride `rf.bench.hicasso.lane/rounds-async!` and walks `rf.bench.hicasso.lane/visit-plan` itself. See the
   namespace docstring §THE SCHEDULE IS THE LANE'S, BUT THE LOOP CANNOT
   BE."
   [{:keys [id per-frame advance?]}]
@@ -916,7 +916,7 @@
                ;; counter the arms share with a control is a counter whose
                ;; denominator a reader has to reconstruct.
                (swap! !state assoc
-                      :tally             (lane/tally)
+                      :tally             (rf.bench.hicasso.lane/tally)
                       :first-refusal     nil
                       :last-verification nil
                       :advance           {})
@@ -930,7 +930,7 @@
   "Mount the ledger into `container` on `frame-id`, and answer a promise
   of the mounted handle.
 
-  It goes through `h/mount!` — the application's own root door — with the
+  It goes through `rf.hicasso/mount!` — the application's own root door — with the
   application's own view and the `initial-events` `ledger.app` publishes,
   parameterised by the size the application itself defaults to. Nothing
   here reaches under `re-frame.hicasso.impl.*`, nothing rebuilds a view,
@@ -943,7 +943,7 @@
      no observation; a run that discovered that inside a rendering step
      would report it as a null reading.
   2. THE GESTURE FITS THE MODEL, at both ends, derived from
-     `vendor/window-from` rather than from arithmetic repeated here.
+     `rf.hicasso.examples.ledger.vendor/window-from` rather than from arithmetic repeated here.
      `window-from` clamps `from` at zero and `to` at the last row, and a
      clamped window stands still — which would make an honest verification
      failure out of a knob that is simply set too near an edge.
@@ -952,26 +952,26 @@
   DONE HERE. Both are process-wide and belong to whoever owns the
   process; [[-main]] owns the bench page and does both."
   [container frame-id]
-  (let [handle (h/mount! container
+  (let [handle (rf.hicasso/mount! container
                          {:frame          frame-id
-                          :initial-events (ledger-app/initial-events total)}
-                         [views/ledger {}])
-        geom   {:row-height      views/row-height
-                :viewport-height views/viewport-height
-                :overscan        views/overscan
+                          :initial-events (rf.hicasso.examples.ledger.app/initial-events total)}
+                         [rf.hicasso.examples.ledger.views/ledger {}])
+        geom   {:row-height      rf.hicasso.examples.ledger.views/row-height
+                :viewport-height rf.hicasso.examples.ledger.views/viewport-height
+                :overscan        rf.hicasso.examples.ledger.views/overscan
                 :total           total}]
     (swap! !state assoc
            :container         container
            :handle            handle
            :viewport          nil
            :spacer            nil
-           :tally             (lane/tally)
+           :tally             (rf.bench.hicasso.lane/tally)
            :first-refusal     nil
            :last-verification nil
            :advance           {}
            :entry             {})
-    (-> (echo/after-paint)
-        (.then (fn [_] (echo/after-paint)))
+    (-> (rf.bench.hicasso.slice-echo-clock-app/after-paint)
+        (.then (fn [_] (rf.bench.hicasso.slice-echo-clock-app/after-paint)))
         (.then (fn [_]
                  (let [vp     (node-at ".ledger-viewport")
                        spacer (node-at ".ledger-spacer")]
@@ -983,9 +983,9 @@
                                      {:rf.error/id ::viewport-absent
                                       :viewport?   (some? vp)
                                       :spacer?     (some? spacer)})))
-                   (let [[from at-start] (vendor/window-from (start-top) geom)
+                   (let [[from at-start] (rf.hicasso.examples.ledger.vendor/window-from (start-top) geom)
                          last-top       (+ (start-top) (* frames-per-run scroll-step-px))
-                         [_ to]         (vendor/window-from last-top geom)]
+                         [_ to]         (rf.hicasso.examples.ledger.vendor/window-from last-top geom)]
                      (when-not (pos? from)
                        (throw (ex-info (str "start-row " start-row " puts the window's first "
                                             "row at " from ", on window-from's (max 0 …) "
@@ -1016,7 +1016,7 @@
   mounts and unmounts around each of its rows."
   []
   (let [{:keys [container handle]} @!state]
-    (when handle (h/unmount! handle))
+    (when handle (rf.hicasso/unmount! handle))
     (when (and container (.-parentNode container))
       (.removeChild (.-parentNode container) container))
     (swap! !state assoc :container nil :handle nil :viewport nil :spacer nil)
@@ -1032,15 +1032,15 @@
 
   `per-round` is ONE MEASURED VALUE PER ROUND — here the smallest frame
   interval `:ctl-blocked` produced in that round. Round by round and not
-  in aggregate, for the reason `lane/control-verdict-strict` gives about
+  in aggregate, for the reason `rf.bench.hicasso.lane/control-verdict-strict` gives about
   its own band: a cross-round minimum cannot tell a control that held
   every round from one that held on average, and a good round must not be
   allowed to vouch for a bad one.
 
   ## Why neither of the lane's two rules serves
 
-  `lane/control-verdict` asks whether a measured RANGE overlaps a
-  ±`slack` band, and `lane/control-verdict-strict` asks whether every
+  `rf.bench.hicasso.lane/control-verdict` asks whether a measured RANGE overlaps a
+  ±`slack` band, and `rf.bench.hicasso.lane/control-verdict-strict` asks whether every
   round sits INSIDE one. Both need an upper edge, and this prediction has
   none: a blocked frame that ran long is a slow frame and not a control
   failure. Widening a band until it covered that would be inventing a
@@ -1056,7 +1056,7 @@
 
   A floor of zero or less is cleared by any reading whatever, and a
   control with no rounds is the same thing said with no data.
-  `lane/control-verdict-strict` refuses both and prices the incident that
+  `rf.bench.hicasso.lane/control-verdict-strict` refuses both and prices the incident that
   put the rule there: a walk profile shipped a control whose own
   prediction had gone vacuous and reported that it saw what it never
   predicted.
@@ -1083,18 +1083,18 @@
                          (fn [i v]
                            (when (< v predicted)
                              {:round    (inc i)
-                              :measured (lane/round4 v)
-                              :short-by (lane/round4 (- predicted v))}))
+                              :measured (rf.bench.hicasso.lane/round4 v)
+                              :short-by (rf.bench.hicasso.lane/round4 (- predicted v))}))
                          vs)))
         ok?     (and stated? (empty? below))
         floor   (str "predicted floor " (.toFixed predicted 3) " ms")]
     {:rule         :every-round-floor
      :predicted    predicted
      :per-round    vs
-     :measured     (lane/summarise vs)
+     :measured     (rf.bench.hicasso.lane/summarise vs)
      :stated?      stated?
      :versus-floor (when (and (number? floor-p50) (pos? floor-p50))
-                     (lane/round4 (/ predicted floor-p50)))
+                     (rf.bench.hicasso.lane/round4 (/ predicted floor-p50)))
      :below        below
      :ok?          ok?
      :why          (cond
@@ -1129,9 +1129,9 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- fresh-readings
-  "One empty reading vector per arm, per round. `lane/rounds!`'s own
+  "One empty reading vector per arm, per round. `rf.bench.hicasso.lane/rounds!`'s own
   shape, which is private there; the readings map this driver builds has
-  to be the same one `lane/normalise` and the summarisers expect."
+  to be the same one `rf.bench.hicasso.lane/normalise` and the summarisers expect."
   []
   (atom (vec (repeat rounds (zipmap (map :id arms) (repeat []))))))
 
@@ -1144,22 +1144,22 @@
           readings))
 
 (defn run-schedule!
-  "Walk `lane/visit-plan` and answer a promise of
-  `{:readings :samples}` — the same shape `lane/rounds!` and
-  `lane/rounds-async!` answer, so everything downstream of it is the
+  "Walk `rf.bench.hicasso.lane/visit-plan` and answer a promise of
+  `{:readings :samples}` — the same shape `rf.bench.hicasso.lane/rounds!` and
+  `rf.bench.hicasso.lane/rounds-async!` answer, so everything downstream of it is the
   lane's.
 
-  THE SCHEDULE IS NOT RESTATED HERE. `lane/visit-plan` produces the
-  visits, in execution order, with the reflecting `lane/slot-order`
+  THE SCHEDULE IS NOT RESTATED HERE. `rf.bench.hicasso.lane/visit-plan` produces the
+  visits, in execution order, with the reflecting `rf.bench.hicasso.lane/slot-order`
   rotation, the warm-up boundary and the round boundary all decided over
   there. What this loop adds is the one thing the lane's own loops cannot
   do: bank a VECTOR per visit.
 
-  `lane/observe!` is called for warm-up visits and `lane/collect!` for
-  measured ones, exactly as `lane/rounds!`'s own `bank-visit!` does. A
+  `rf.bench.hicasso.lane/observe!` is called for warm-up visits and `rf.bench.hicasso.lane/collect!` for
+  measured ones, exactly as `rf.bench.hicasso.lane/rounds!`'s own `bank-visit!` does. A
   warm-up visit is still a PREDECESSOR — skipping it would leave the
   first measured visit of a block tagged with whatever ran before the
-  warm-up, which `lane/observe!`'s docstring prices at length.
+  warm-up, which `rf.bench.hicasso.lane/observe!`'s docstring prices at length.
 
   ONE GUARD SAMPLE PER VISIT, and it is that visit's MEDIAN interval. The
   guard stratifies by `:predecessor` and `:position` to catch arm-order
@@ -1169,20 +1169,20 @@
   interval as its own guard sample would tag twenty-nine of them with a
   predecessor that is really the same run's own previous frame."
   []
-  (let [coll     (lane/sample-collector)
+  (let [coll     (rf.bench.hicasso.lane/sample-collector)
         readings (fresh-readings)]
     (.then
-      (lane/chain nil (lane/visit-plan arms sampling rounds)
+      (rf.bench.hicasso.lane/chain nil (rf.bench.hicasso.lane/visit-plan arms sampling rounds)
                   (fn [_ {:keys [round arm measured?]}]
                     (.then (measure-one! arm)
                            (fn [xs]
                              (if measured?
-                               (do (lane/collect! coll (name (:id arm))
-                                                  (:p50 (lane/summarise xs)))
+                               (do (rf.bench.hicasso.lane/collect! coll (name (:id arm))
+                                                  (:p50 (rf.bench.hicasso.lane/summarise xs)))
                                    (swap! readings update-in [round (:id arm)] into xs)
                                    (swap! !state update-in [:entry (:id arm)]
                                           (fnil conj []) (first xs)))
-                               (lane/observe! coll (name (:id arm))))
+                               (rf.bench.hicasso.lane/observe! coll (name (:id arm))))
                              nil))))
       (fn [_] {:readings @readings :samples (:samples @coll)}))))
 
@@ -1195,7 +1195,7 @@
   with a minimum below it is a control that failed, and an aggregate that
   reported the median would call it a pass."
   [readings]
-  (mapv (fn [round] (lane/round4 (:min (lane/summarise (get round :ctl-blocked)))))
+  (mapv (fn [round] (rf.bench.hicasso.lane/round4 (:min (rf.bench.hicasso.lane/summarise (get round :ctl-blocked)))))
         readings))
 
 (defn advance-report
@@ -1215,8 +1215,8 @@
         (map (fn [[id a]]
                [id {:runs           (:runs a)
                     :advanced       (:advanced a)
-                    :rows-gained    (lane/summarise (filterv number? (:rows-gained a)))
-                    :frames-changed (lane/summarise (:frames-changed a))}]))
+                    :rows-gained    (rf.bench.hicasso.lane/summarise (filterv number? (:rows-gained a)))
+                    :frames-changed (rf.bench.hicasso.lane/summarise (:frames-changed a))}]))
         advance))
 
 (defn take-plan!
@@ -1231,13 +1231,13 @@
     (run-schedule!)
     (fn [{:keys [readings samples]}]
       (let [by-arm    (readings-by-arm readings)
-            floor-p50 (:p50 (lane/summarise (get by-arm :idle-frames)))
+            floor-p50 (:p50 (rf.bench.hicasso.lane/summarise (get by-arm :idle-frames)))
             control   (control-verdict-floor blocked-ms
                                              (control-per-round readings)
                                              floor-p50)
-            verdict   (lane/guard! samples "ledger per-frame interval")
+            verdict   (rf.bench.hicasso.lane/guard! samples "ledger per-frame interval")
             visits    (* (+ (:warmup sampling) (:samples sampling)) rounds)]
-        (lane/record! :ledger-frame
+        (rf.bench.hicasso.lane/record! :ledger-frame
                       {:window      :frame-interval
                        :population  {:app      're-frame.hicasso.examples.ledger
                                      :views    're-frame.hicasso.examples.ledger.views
@@ -1247,14 +1247,14 @@
                                      ;; restated these integers would be a second source
                                      ;; for them and the first thing to go stale.
                                      :total    total
-                                     :geometry {:row-height      views/row-height
-                                                :viewport-height views/viewport-height
-                                                :overscan        views/overscan
+                                     :geometry {:row-height      rf.hicasso.examples.ledger.views/row-height
+                                                :viewport-height rf.hicasso.examples.ledger.views/viewport-height
+                                                :overscan        rf.hicasso.examples.ledger.views/overscan
                                                 :window-rows     (:window-rows @!state)}
                                      :gesture  {:start-row      start-row
                                                 :step-px        scroll-step-px
                                                 :rows-per-frame (/ scroll-step-px
-                                                                   views/row-height)
+                                                                   rf.hicasso.examples.ledger.views/row-height)
                                                 :frames         frames-per-run}}
                        :schedule    (assoc sampling
                                            :rounds              rounds
@@ -1265,17 +1265,17 @@
                                            :intervals-per-arm   (* (:samples sampling) rounds
                                                                    (dec frames-per-run)))
                        :populations populations
-                       :summary     (into {} (map (fn [[id xs]] [id (lane/summarise xs)])) by-arm)
-                       :entry       (into {} (map (fn [[id xs]] [id (lane/summarise xs)]))
+                       :summary     (into {} (map (fn [[id xs]] [id (rf.bench.hicasso.lane/summarise xs)])) by-arm)
+                       :entry       (into {} (map (fn [[id xs]] [id (rf.bench.hicasso.lane/summarise xs)]))
                                           (:entry @!state))
                        :advance     (advance-report (:advance @!state))
                        :control     control
                        :guard       (select-keys verdict [:refuse? :contaminated?
                                                           :unchecked? :tolerance])
-                       :verification (cond-> (lane/tally-value (:tally @!state))
+                       :verification (cond-> (rf.bench.hicasso.lane/tally-value (:tally @!state))
                                        (:first-refusal @!state)
                                        (assoc :first-refusal (:first-refusal @!state)))
-                       :runtime     (lane/runtime-label)
+                       :runtime     (rf.bench.hicasso.lane/runtime-label)
                        :note        (str "No line is applied to any figure above. U4's frame "
                                          "budget is read against this instrument in its own "
                                          "quiet-box window, not here, and this driver moves "
@@ -1287,17 +1287,17 @@
                                          ":gesture/:step-px divided by :scroll's :p50.")})
         (set! (.-HICASSO_GUARD_REFUSED js/window) (boolean (:refuse? verdict)))
         (set! (.-HICASSO_CONTROL_FAILED js/window) (not (:ok? control)))
-        (lane/assert-verified! (:tally @!state) "ledger per-frame interval")
+        (rf.bench.hicasso.lane/assert-verified! (:tally @!state) "ledger per-frame interval")
         nil))))
 
 (defn ^:export -main []
-  (rf/init! uix-adapter/adapter)
-  (lane/leave-act-environment!)
-  (if-not (lane/self-test!)
-    (lane/fail! (str "the arm-order self-test failed — the copy of the schedule "
+  (rf/init! rf.adapter.uix/adapter)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (if-not (rf.bench.hicasso.lane/self-test!)
+    (rf.bench.hicasso.lane/fail! (str "the arm-order self-test failed — the copy of the schedule "
                      "rule this app is about to rely on no longer behaves like "
                      "the one the .cjs drivers use, so nothing may be measured"))
-    (-> (boot! (or (js/document.getElementById "app") (lane/fresh-container!))
+    (-> (boot! (or (js/document.getElementById "app") (rf.bench.hicasso.lane/fresh-container!))
                ::frame)
         ;; Both halves of the discrimination run BEFORE the first warm-up
         ;; visit and their throws travel the same `.catch` as any other
@@ -1306,6 +1306,6 @@
         ;; publishing a record nobody should read.
         (.then (fn [_] (advance-discrimination!)))
         (.then (fn [_] (take-plan!)))
-        (.catch (fn [e] (lane/fail! (lane/describe-throw "ledger-frame-clock-app" e))))
-        (.then (fn [_] (lane/done!)))))
+        (.catch (fn [e] (rf.bench.hicasso.lane/fail! (rf.bench.hicasso.lane/describe-throw "ledger-frame-clock-app" e))))
+        (.then (fn [_] (rf.bench.hicasso.lane/done!)))))
   nil)

--- a/bench/hicasso/src/re_frame/bench/hicasso/ledger_frame_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/ledger_frame_dom_cljs_test.cljs
@@ -11,9 +11,9 @@
   ## Why this file exists at all
 
   The driver landed without ever having been executed. Every structural
-  claim it makes is carried by a check the RUN performs — [[clock/boot!]]'s
-  two clamp refusals, [[clock/prepare!]]'s reset-settled check, and both
-  halves of [[clock/advance-discrimination!]] — and until this file none
+  claim it makes is carried by a check the RUN performs — [[rf.bench.hicasso.ledger-frame-clock-app/boot!]]'s
+  two clamp refusals, [[rf.bench.hicasso.ledger-frame-clock-app/prepare!]]'s reset-settled check, and both
+  halves of [[rf.bench.hicasso.ledger-frame-clock-app/advance-discrimination!]] — and until this file none
   of them had fired once. A check that has never fired is a check nobody
   has seen discriminate, and the sibling instrument's own history is the
   argument: writing the self-test beside `slice-broad-clock-app` is what
@@ -54,7 +54,7 @@
 
   ## The one inequality that carries the whole claim
 
-  `:ctl-blocked` blocks the main thread for [[clock/blocked-ms]] INSIDE
+  `:ctl-blocked` blocks the main thread for [[rf.bench.hicasso.ledger-frame-clock-app/blocked-ms]] INSIDE
   every frame, after that frame's scroll has been delivered. The frame
   that follows cannot begin until the block ends, so every interval the
   arm produces satisfies
@@ -78,7 +78,7 @@
   A latency. Nothing here reads `:scroll`'s distribution against anything,
   because that reading is `U4`'s and belongs to a pinned quiet-box window
   rather than to a shared PR runner. The positive control's own VERDICT is
-  likewise not adjudicated over a real run — [[clock/control-verdict-floor]]'s
+  likewise not adjudicated over a real run — [[rf.bench.hicasso.ledger-frame-clock-app/control-verdict-floor]]'s
   arithmetic is pinned below on synthetic readings, where a slow box
   cannot reach it, and the verdict itself belongs to the run that takes
   the window.
@@ -90,16 +90,16 @@
   `:node-test`, which is the posture every other `*-dom` suite in this
   tree keeps. The pure rows run on both."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.ledger-frame-clock-app :as clock]
-            [re-frame.hicasso.examples.ledger.vendor :as vendor]
-            [re-frame.hicasso.examples.ledger.views :as views]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.ledger-frame-clock-app :as rf.bench.hicasso.ledger-frame-clock-app]
+            [re-frame.hicasso.examples.ledger.vendor :as rf.hicasso.examples.ledger.vendor]
+            [re-frame.hicasso.examples.ledger.views :as rf.hicasso.examples.ledger.views]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; The MAP shape, because every DOM row is `async`: `cljs.test` refuses
      ;; an async test under a fn-form fixture and ABORTS THE WHOLE NAMESPACE
@@ -109,14 +109,14 @@
      :async?        true
      ;; React's `act` queue is not the browser's scheduler, and every
      ;; reading this instrument takes is a real `requestAnimationFrame`
-     ;; outside it. `clock/-main` leaves that environment before it boots;
+     ;; outside it. `rf.bench.hicasso.ledger-frame-clock-app/-main` leaves that environment before it boots;
      ;; the suite that drives the same code has to leave it too.
      ;;
      ;; NO `register!` CALL, unlike the two slice suites: `examples.ledger.
      ;; app`'s own docstring records that this application has one root, one
      ;; frame and NO ROUTE, so there is no late registration for the reset
      ;; to have captured a baseline in front of.
-     :init-fn       lane/leave-act-environment!}))
+     :init-fn       rf.bench.hicasso.lane/leave-act-environment!}))
 
 (def ^:private off-browser
   "no DOM on this runtime — every claim below is a real mount, a real
@@ -151,7 +151,7 @@
            (str "frame-" (swap! !frame-n inc))))
 
 (defn- with-mounted-ledger
-  "Mount the ledger through the instrument's own [[clock/boot!]], run
+  "Mount the ledger through the instrument's own [[rf.bench.hicasso.ledger-frame-clock-app/boot!]], run
   `f` — which answers a promise — and tear the root down afterwards
   whatever happened.
 
@@ -160,11 +160,11 @@
   file is asking about, so every row below has already exercised them by
   the time its own assertions run."
   [f]
-  (let [container (lane/fresh-container!)]
-    (-> (clock/boot! container (fresh-frame-id))
+  (let [container (rf.bench.hicasso.lane/fresh-container!)]
+    (-> (rf.bench.hicasso.ledger-frame-clock-app/boot! container (fresh-frame-id))
         (.then (fn [_] (f)))
-        (.then (fn [v] (clock/teardown!) v)
-               (fn [e] (clock/teardown!) (throw e))))))
+        (.then (fn [v] (rf.bench.hicasso.ledger-frame-clock-app/teardown!) v)
+               (fn [e] (rf.bench.hicasso.ledger-frame-clock-app/teardown!) (throw e))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The sabotage — the virtualizer cut off from its own scroll events
@@ -186,7 +186,7 @@
   WHAT IT DOES NOT SUPPRESS, and that is the point: the `scrollTop`
   WRITE. `stopPropagation` is not `preventDefault` and touches no
   property, so the offset still moves and
-  [[clock/prepare!]]'s `scrollTop` assertion still passes. That is
+  [[rf.bench.hicasso.ledger-frame-clock-app/prepare!]]'s `scrollTop` assertion still passes. That is
   precisely the state `virtualized-dom-cljs-test` hit twice — the
   instrument's own scroll assertion green and the rendered window
   standing still — and it is the state a check over `scrollTop` alone
@@ -211,27 +211,27 @@
   restores when its body RETURNS, and the body of every row below returns
   a promise immediately — so the knobs would be back at the module's own
   values long before the run that is supposed to be using them reads
-  them. [[clock/run-schedule!]] takes `lane/visit-plan`'s three arguments
-  from these vars synchronously but [[clock/measure-one!]] reads
+  them. [[rf.bench.hicasso.ledger-frame-clock-app/run-schedule!]] takes `rf.bench.hicasso.lane/visit-plan`'s three arguments
+  from these vars synchronously but [[rf.bench.hicasso.ledger-frame-clock-app/measure-one!]] reads
   `frames-per-run` inside a `.then`, so what a `with-redefs` here would
   actually produce is a TINY PLAN RUNNING FULL-LENGTH VISITS: no error,
   no warning, and a row whose arithmetic quietly stops describing the run
   it just took.
 
-  The sibling suites never meet this because `lane/rounds-async!` takes
+  The sibling suites never meet this because `rf.bench.hicasso.lane/rounds-async!` takes
   its schedule as ARGUMENTS; this driver's loop reads the vars, which is
   the price of banking a vector per visit."
   [{:keys [sampling rounds frames]} f]
-  (let [sampling0 clock/sampling
-        rounds0   clock/rounds
-        frames0   clock/frames-per-run
+  (let [sampling0 rf.bench.hicasso.ledger-frame-clock-app/sampling
+        rounds0   rf.bench.hicasso.ledger-frame-clock-app/rounds
+        frames0   rf.bench.hicasso.ledger-frame-clock-app/frames-per-run
         restore!  (fn []
-                    (set! clock/sampling sampling0)
-                    (set! clock/rounds rounds0)
-                    (set! clock/frames-per-run frames0))]
-    (set! clock/sampling sampling)
-    (set! clock/rounds rounds)
-    (set! clock/frames-per-run frames)
+                    (set! rf.bench.hicasso.ledger-frame-clock-app/sampling sampling0)
+                    (set! rf.bench.hicasso.ledger-frame-clock-app/rounds rounds0)
+                    (set! rf.bench.hicasso.ledger-frame-clock-app/frames-per-run frames0))]
+    (set! rf.bench.hicasso.ledger-frame-clock-app/sampling sampling)
+    (set! rf.bench.hicasso.ledger-frame-clock-app/rounds rounds)
+    (set! rf.bench.hicasso.ledger-frame-clock-app/frames-per-run frames)
     (-> (js/Promise.resolve (f))
         (.then (fn [v] (restore!) v)
                (fn [e] (restore!) (throw e))))))
@@ -241,18 +241,18 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private geom
-  "`views/ledger`'s own geometry and the run's own model size, assembled
-  the way [[clock/boot!]] assembles it. Derived rather than typed, so a
+  "`rf.hicasso.examples.ledger.views/ledger`'s own geometry and the run's own model size, assembled
+  the way [[rf.bench.hicasso.ledger-frame-clock-app/boot!]] assembles it. Derived rather than typed, so a
   change to the screen's row height cannot leave this file asserting
   against a page that no longer exists."
-  {:row-height      views/row-height
-   :viewport-height views/viewport-height
-   :overscan        views/overscan
-   :total           clock/total})
+  {:row-height      rf.hicasso.examples.ledger.views/row-height
+   :viewport-height rf.hicasso.examples.ledger.views/viewport-height
+   :overscan        rf.hicasso.examples.ledger.views/overscan
+   :total           rf.bench.hicasso.ledger-frame-clock-app/total})
 
-(defn- window-at [top] (vendor/window-from top geom))
+(defn- window-at [top] (rf.hicasso.examples.ledger.vendor/window-from top geom))
 
-(defn- start-top [] (* clock/start-row views/row-height))
+(defn- start-top [] (* rf.bench.hicasso.ledger-frame-clock-app/start-row rf.hicasso.examples.ledger.views/row-height))
 
 ;; ---------------------------------------------------------------------------
 ;; The mount
@@ -273,7 +273,7 @@
                     "the scroll container the gesture is delivered to is on the page")
                 (is (some? (.querySelector js/document ".ledger-spacer"))
                     "as is the row host the observation is read off")
-                (is (number? ((clock/observer)))
+                (is (number? ((rf.bench.hicasso.ledger-frame-clock-app/observer)))
                     "and the observation answers a MODEL INDEX rather than nil —
                      a spacer holding no row, or an aria-rowindex that is not a
                      number, is a frame whose reading means nothing")
@@ -299,7 +299,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-reset-lands-the-window-where-the-geometry-says
-  (testing "[[clock/prepare!]]'s fourth step, exercised. A visit that
+  (testing "[[rf.bench.hicasso.ledger-frame-clock-app/prepare!]]'s fourth step, exercised. A visit that
            began on a stale window would still VERIFY — the scrolling
            arms advance either way — while its early frames were a
            gesture catching up rather than one being held, and nothing
@@ -309,10 +309,10 @@
       (async done
         (-> (with-mounted-ledger
               (fn []
-                (.then (clock/prepare!)
+                (.then (rf.bench.hicasso.ledger-frame-clock-app/prepare!)
                        (fn [_]
                          (let [[from _] (window-at (start-top))]
-                           (is (= from ((clock/observer)))
+                           (is (= from ((rf.bench.hicasso.ledger-frame-clock-app/observer)))
                                "the rendered window's first row is the row the
                                 geometry puts at that offset")
                            (is (pos? from)
@@ -332,7 +332,7 @@
               (fn []
                 (with-scroll-suppressed
                   (fn []
-                    (.then (clock/prepare!)
+                    (.then (rf.bench.hicasso.ledger-frame-clock-app/prepare!)
                            (fn [_]
                              (is false
                                  "prepare! accepted a reset the virtualizer never saw"))
@@ -352,7 +352,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-built-in-discrimination-runs-both-ways-before-anything-is-measured
-  (testing "[[clock/advance-discrimination!]] takes one idle run and one
+  (testing "[[rf.bench.hicasso.ledger-frame-clock-app/advance-discrimination!]] takes one idle run and one
            scrolling run on the real page and requires the first to
            refuse an advance and the second to produce one. It REJECTS if
            either went the wrong way, so this row resolving at all is the
@@ -366,9 +366,9 @@
       (async done
         (-> (with-mounted-ledger
               (fn []
-                (.then (clock/advance-discrimination!)
+                (.then (rf.bench.hicasso.ledger-frame-clock-app/advance-discrimination!)
                        (fn [_]
-                         (is (= {:writes 0 :unverified 0} (clock/verification))
+                         (is (= {:writes 0 :unverified 0} (rf.bench.hicasso.ledger-frame-clock-app/verification))
                              "the tally is reset behind it, so the first measured
                               visit is the first write")))))
             (.then (fn [_] (done)) (fail-async done)))))))
@@ -390,17 +390,17 @@
         (-> (with-mounted-ledger
               (fn []
                 (.then
-                  (clock/prepare!)
+                  (rf.bench.hicasso.ledger-frame-clock-app/prepare!)
                   (fn [_]
                     (with-scroll-suppressed
                       (fn []
-                        (let [observe! (clock/observer)
-                              work!    ((:per-frame (second clock/arms)))]
-                          (.then (clock/frames! {:frames     clock/frames-per-run
+                        (let [observe! (rf.bench.hicasso.ledger-frame-clock-app/observer)
+                              work!    ((:per-frame (second rf.bench.hicasso.ledger-frame-clock-app/arms)))]
+                          (.then (rf.bench.hicasso.ledger-frame-clock-app/frames! {:frames     rf.bench.hicasso.ledger-frame-clock-app/frames-per-run
                                                  :observe!   observe!
                                                  :per-frame! work!})
                                  (fn [{:keys [at seen]}]
-                                   (let [v (clock/verify :scroll true seen)]
+                                   (let [v (rf.bench.hicasso.ledger-frame-clock-app/verify :scroll true seen)]
                                      (is (not (:verified? v))
                                          "the arm REFUSES a run in which the
                                           virtualizer never saw the gesture")
@@ -411,8 +411,8 @@
                                      (is (= 0 (:rows-gained v))
                                          "the rendered window is exactly where it
                                           started after the whole gesture")
-                                     (is (= (dec clock/frames-per-run)
-                                            (count (clock/intervals at)))
+                                     (is (= (dec rf.bench.hicasso.ledger-frame-clock-app/frames-per-run)
+                                            (count (rf.bench.hicasso.ledger-frame-clock-app/intervals at)))
                                          "and the run still produced its K-1 readings,
                                           which is why a refusal is the only thing
                                           standing between this and a published
@@ -435,11 +435,11 @@
       (async done
         (-> (with-mounted-ledger
               (fn []
-                (.then (clock/measure-one! {:id        :probe-moved-while-idle
-                                            :per-frame clock/scroller
+                (.then (rf.bench.hicasso.ledger-frame-clock-app/measure-one! {:id        :probe-moved-while-idle
+                                            :per-frame rf.bench.hicasso.ledger-frame-clock-app/scroller
                                             :advance?  false})
                        (fn [_]
-                         (is (= {:writes 1 :unverified 1} (clock/verification))
+                         (is (= {:writes 1 :unverified 1} (rf.bench.hicasso.ledger-frame-clock-app/verification))
                              "a run whose window advanced against an arm that
                               predicted stillness is REFUSED")))))
             (.then (fn [_] (done)) (fail-async done)))))))
@@ -470,38 +470,38 @@
         (-> (with-mounted-ledger
               (fn []
                 (.then
-                  (clock/measure-one! {:id        :ctl-blocked
-                                       :per-frame clock/blocked-scroller
+                  (rf.bench.hicasso.ledger-frame-clock-app/measure-one! {:id        :ctl-blocked
+                                       :per-frame rf.bench.hicasso.ledger-frame-clock-app/blocked-scroller
                                        :advance?  true})
                   (fn [blocked]
                     (.then
-                      (clock/measure-one! {:id        :idle-frames
-                                           :per-frame clock/idle-frames
+                      (rf.bench.hicasso.ledger-frame-clock-app/measure-one! {:id        :idle-frames
+                                           :per-frame rf.bench.hicasso.ledger-frame-clock-app/idle-frames
                                            :advance?  false})
                       (fn [idle]
-                        (is (= {:writes 2 :unverified 0} (clock/verification))
+                        (is (= {:writes 2 :unverified 0} (rf.bench.hicasso.ledger-frame-clock-app/verification))
                             "both runs verified — the blocked one advanced its window
                              and the idle one did not")
-                        (is (>= (:min (lane/summarise blocked)) clock/blocked-ms)
+                        (is (>= (:min (rf.bench.hicasso.lane/summarise blocked)) rf.bench.hicasso.ledger-frame-clock-app/blocked-ms)
                             (str "every one of the blocked arm's "
                                  (count blocked) " intervals is at or above the "
-                                 clock/blocked-ms "ms it spent blocking"))
-                        (is (< (:min (lane/summarise idle)) clock/blocked-ms)
+                                 rf.bench.hicasso.ledger-frame-clock-app/blocked-ms "ms it spent blocking"))
+                        (is (< (:min (rf.bench.hicasso.lane/summarise idle)) rf.bench.hicasso.ledger-frame-clock-app/blocked-ms)
                             "and the arm that injected nothing produced an interval
                              below it, so the floor is not cleared by any reading
                              whatever")))))))
             (.then (fn [_] (done)) (fail-async done)))))))
 
 (deftest the-whole-schedule-runs-and-every-run-verifies
-  (testing "[[clock/run-schedule!]] walks `lane/visit-plan` and banks a
+  (testing "[[rf.bench.hicasso.ledger-frame-clock-app/run-schedule!]] walks `rf.bench.hicasso.lane/visit-plan` and banks a
            VECTOR per visit — the one thing the lane's own loops cannot
            do — while leaving the arm ordering, the warm-up boundary and
            the round boundary over there.
 
            The schedule is TINY here and the module's own is not: this row
            asks whether the loop runs and books its visits correctly, and
-           a run that reads a figure wants `clock/sampling`,
-           `clock/rounds` and `clock/frames-per-run`."
+           a run that reads a figure wants `rf.bench.hicasso.ledger-frame-clock-app/sampling`,
+           `rf.bench.hicasso.ledger-frame-clock-app/rounds` and `rf.bench.hicasso.ledger-frame-clock-app/frames-per-run`."
     (if-not (browser?)
       (skip! off-browser)
       (async done
@@ -513,17 +513,17 @@
                 (fn []
                   (with-mounted-ledger
                     (fn []
-                      (.then (clock/run-schedule!)
+                      (.then (rf.bench.hicasso.ledger-frame-clock-app/run-schedule!)
                              (fn [{:keys [readings samples]}]
-                               (is (= (* rounds (:samples sampling) (count clock/arms))
+                               (is (= (* rounds (:samples sampling) (count rf.bench.hicasso.ledger-frame-clock-app/arms))
                                       (count samples))
                                    "one guard sample per MEASURED visit — that visit's
                                     median interval, not one per frame")
                                (is (= rounds (count readings)))
-                               (is (every? (fn [round] (= (count clock/arms) (count round)))
+                               (is (every? (fn [round] (= (count rf.bench.hicasso.ledger-frame-clock-app/arms) (count round)))
                                            readings)
                                    "and every arm has a reading vector in every round")
-                               (doseq [{:keys [id]} clock/arms]
+                               (doseq [{:keys [id]} rf.bench.hicasso.ledger-frame-clock-app/arms]
                                  (is (= (* rounds (:samples sampling) (dec frames))
                                         (count (get (first readings) id)))
                                      (str id " banked K-1 intervals for each of its "
@@ -533,9 +533,9 @@
                                (is (= {:writes     (* rounds
                                                       (+ (:warmup sampling)
                                                          (:samples sampling))
-                                                      (count clock/arms))
+                                                      (count rf.bench.hicasso.ledger-frame-clock-app/arms))
                                        :unverified 0}
-                                      (clock/verification))
+                                      (rf.bench.hicasso.ledger-frame-clock-app/verification))
                                    "0 unverified of M — every run, WARM-UP INCLUDED,
                                     went the way its own arm predicted")))))))
               (.then (fn [_] (done)) (fail-async done))))))))
@@ -548,30 +548,30 @@
   (testing "`K` timestamps give `K-1` intervals. A frame run is not a
            window: there is no `t0` before it and no paint after it, and
            its total length is not a figure this instrument publishes."
-    (is (= [2.0 3.0 4.0] (clock/intervals [1.0 3.0 6.0 10.0]))
+    (is (= [2.0 3.0 4.0] (rf.bench.hicasso.ledger-frame-clock-app/intervals [1.0 3.0 6.0 10.0]))
         "each reading is the distance to the NEXT frame")
-    (is (= 29 (count (clock/intervals (vec (range 30)))))
+    (is (= 29 (count (rf.bench.hicasso.ledger-frame-clock-app/intervals (vec (range 30)))))
         "so a thirty-frame run banks twenty-nine readings")
-    (is (= [] (clock/intervals [1.0]))
+    (is (= [] (rf.bench.hicasso.ledger-frame-clock-app/intervals [1.0]))
         "and a single frame is no reading at all")))
 
 (deftest the-window-check-is-a-two-valued-question-asked-in-both-directions
-  (testing "[[clock/verify]] compares the first frame's observed model
+  (testing "[[rf.bench.hicasso.ledger-frame-clock-app/verify]] compares the first frame's observed model
            index against the last's and asks whether that matches what
            the ARM predicted. Both directions bank into one tally: a
            floor run whose window advanced is exactly as damning as a
            scroll run whose window did not."
-    (is (:verified? (clock/verify :scroll true [100 104 108]))
+    (is (:verified? (rf.bench.hicasso.ledger-frame-clock-app/verify :scroll true [100 104 108]))
         "a scrolling arm whose window moved forward verifies")
-    (is (not (:verified? (clock/verify :scroll true [100 100 100])))
+    (is (not (:verified? (rf.bench.hicasso.ledger-frame-clock-app/verify :scroll true [100 100 100])))
         "and one whose window stood still is REFUSED")
-    (is (:verified? (clock/verify :idle-frames false [100 100 100]))
+    (is (:verified? (rf.bench.hicasso.ledger-frame-clock-app/verify :idle-frames false [100 100 100]))
         "a floor arm whose window stood still verifies")
-    (is (not (:verified? (clock/verify :idle-frames false [100 104 108])))
+    (is (not (:verified? (rf.bench.hicasso.ledger-frame-clock-app/verify :idle-frames false [100 104 108])))
         "and one whose window MOVED is refused — without this direction the
          observation could report movement on a page nothing scrolled and
          every reading would be verified by a check that cannot fail")
-    (let [v (clock/verify :scroll true [100 nil 108])]
+    (let [v (rf.bench.hicasso.ledger-frame-clock-app/verify :scroll true [100 nil 108])]
       (is (not (:verified? v))
           "a frame whose window could not be read is a frame whose reading
            means nothing")
@@ -579,7 +579,7 @@
           "and the count is carried, so an operator is sent to the spacer
            rather than to the gesture"))
     (is (= {:expected :advance :observed :no-advance}
-           (select-keys (clock/verify :scroll true [100 100]) [:expected :observed]))
+           (select-keys (rf.bench.hicasso.ledger-frame-clock-app/verify :scroll true [100 100]) [:expected :observed]))
         "the refusal names both sides rather than only failing")))
 
 (deftest the-descriptive-counts-say-how-far-and-how-often
@@ -589,14 +589,14 @@
            new window, which is a finding about the SUBJECT — a run that
            advanced on a quarter of its frames advanced for real and was
            dropping frames."
-    (is (true? (clock/advanced? [100 108])))
-    (is (false? (clock/advanced? [108 100])) "backwards is not an advance")
-    (is (false? (clock/advanced? [100 nil])) "and an unreadable end is not one either")
-    (is (= 8 (clock/rows-gained [100 104 108])))
-    (is (nil? (clock/rows-gained [nil 108])) "nil rather than a fabricated zero")
-    (is (= 2 (clock/frames-changed [1 1 2 2 3]))
+    (is (true? (rf.bench.hicasso.ledger-frame-clock-app/advanced? [100 108])))
+    (is (false? (rf.bench.hicasso.ledger-frame-clock-app/advanced? [108 100])) "backwards is not an advance")
+    (is (false? (rf.bench.hicasso.ledger-frame-clock-app/advanced? [100 nil])) "and an unreadable end is not one either")
+    (is (= 8 (rf.bench.hicasso.ledger-frame-clock-app/rows-gained [100 104 108])))
+    (is (nil? (rf.bench.hicasso.ledger-frame-clock-app/rows-gained [nil 108])) "nil rather than a fabricated zero")
+    (is (= 2 (rf.bench.hicasso.ledger-frame-clock-app/frames-changed [1 1 2 2 3]))
         "two of the four transitions carried a new window")
-    (is (= 0 (clock/frames-changed [1 1 1]))
+    (is (= 0 (rf.bench.hicasso.ledger-frame-clock-app/frames-changed [1 1 1]))
         "a run the vendor never updated changed on none of them")))
 
 ;; ---------------------------------------------------------------------------
@@ -604,11 +604,11 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-control-predicts-a-floor-and-every-round-must-clear-it
-  (testing "[[clock/control-verdict-floor]] adjudicates round by round and
-           not in aggregate, for the reason `lane/control-verdict-strict`
+  (testing "[[rf.bench.hicasso.ledger-frame-clock-app/control-verdict-floor]] adjudicates round by round and
+           not in aggregate, for the reason `rf.bench.hicasso.lane/control-verdict-strict`
            gives about its own band: a cross-round minimum cannot tell a
            control that held every round from one that held on average."
-    (let [v (clock/control-verdict-floor 50.0 [51.0 52.5 50.0] 16.7)]
+    (let [v (rf.bench.hicasso.ledger-frame-clock-app/control-verdict-floor 50.0 [51.0 52.5 50.0] 16.7)]
       (is (:ok? v) "every round's minimum sits at or above the prediction")
       (is (= :every-round-floor (:rule v)))
       (is (empty? (:below v)))
@@ -624,7 +624,7 @@
            prediction cannot be followed sooner than that, so a round
            below the floor means the instrument is not reading the frames
            it thinks it is."
-    (let [v (clock/control-verdict-floor 50.0 [51.0 49.0 40.0] 16.7)]
+    (let [v (rf.bench.hicasso.ledger-frame-clock-app/control-verdict-floor 50.0 [51.0 49.0 40.0] 16.7)]
       (is (not (:ok? v)))
       (is (= [2 3] (mapv :round (:below v)))
           "each failing round is NAMED, one-based, in schedule order")
@@ -633,17 +633,17 @@
       (is (:stated? v) "the prediction itself was stated — this is a real failure"))))
 
 (deftest the-control-refuses-a-prediction-that-is-not-stated
-  (testing "Anti-vacuity, carried over from `lane/control-verdict-strict`
+  (testing "Anti-vacuity, carried over from `rf.bench.hicasso.lane/control-verdict-strict`
            rather than reinvented. A floor of zero or less is cleared by
            any reading whatever, and a control with no rounds is the same
            thing said with no data. A walk profile once shipped a control
            whose own prediction had gone vacuous and reported that it saw
            what it never predicted."
-    (let [v (clock/control-verdict-floor 0.0 [51.0 52.0] 16.7)]
+    (let [v (rf.bench.hicasso.ledger-frame-clock-app/control-verdict-floor 0.0 [51.0 52.0] 16.7)]
       (is (not (:stated? v)))
       (is (not (:ok? v)) "a floor nothing can fall below is not a control that passed")
       (is (empty? (:below v)) "and no round is blamed for an unstated prediction"))
-    (let [v (clock/control-verdict-floor 50.0 [] 16.7)]
+    (let [v (rf.bench.hicasso.ledger-frame-clock-app/control-verdict-floor 50.0 [] 16.7)]
       (is (not (:stated? v)))
       (is (not (:ok? v)) "a control with no data is not a control that passed"))))
 
@@ -652,26 +652,26 @@
            injection spans, which a reader needs to know whether the floor
            could have been cleared without it. NOTHING is adjudicated
            against it — `:ok?` reads the same with it absent."
-    (is (= 3.0 (:versus-floor (clock/control-verdict-floor 50.0 [51.0] 16.6667)))
+    (is (= 3.0 (:versus-floor (rf.bench.hicasso.ledger-frame-clock-app/control-verdict-floor 50.0 [51.0] 16.6667)))
         "fifty milliseconds is three frames at 60 Hz")
-    (is (nil? (:versus-floor (clock/control-verdict-floor 50.0 [51.0] nil)))
+    (is (nil? (:versus-floor (rf.bench.hicasso.ledger-frame-clock-app/control-verdict-floor 50.0 [51.0] nil)))
         "and a run with no floor arm reports no ratio rather than a fabricated one")
-    (is (= (:ok? (clock/control-verdict-floor 50.0 [51.0] 16.6667))
-           (:ok? (clock/control-verdict-floor 50.0 [51.0] nil)))
+    (is (= (:ok? (rf.bench.hicasso.ledger-frame-clock-app/control-verdict-floor 50.0 [51.0] 16.6667))
+           (:ok? (rf.bench.hicasso.ledger-frame-clock-app/control-verdict-floor 50.0 [51.0] nil)))
         "the verdict does not move with the context")))
 
 (deftest the-adjudicated-figure-is-a-round-minimum-and-not-a-median
-  (testing "[[clock/control-per-round]] takes the SMALLEST interval each
+  (testing "[[rf.bench.hicasso.ledger-frame-clock-app/control-per-round]] takes the SMALLEST interval each
            round produced, because a floor is a claim about the smallest
            reading. A median above the floor with a minimum below it is a
            control that failed, and an aggregate reporting the median
            would call it a pass."
     (let [readings [{:ctl-blocked [60.0 51.0 70.0]}
                     {:ctl-blocked [80.0 49.0 90.0]}]]
-      (is (= [51.0 49.0] (clock/control-per-round readings))
+      (is (= [51.0 49.0] (rf.bench.hicasso.ledger-frame-clock-app/control-per-round readings))
           "one minimum per round")
-      (is (not (:ok? (clock/control-verdict-floor 50.0
-                                                  (clock/control-per-round readings)
+      (is (not (:ok? (rf.bench.hicasso.ledger-frame-clock-app/control-verdict-floor 50.0
+                                                  (rf.bench.hicasso.ledger-frame-clock-app/control-per-round readings)
                                                   16.7)))
           "so round two is caught — every median in it is above the floor and one
            of its readings is not"))))
@@ -685,16 +685,16 @@
            one is for. A fourth added silently would leave that prose
            describing an instrument that no longer exists — the drift
            class this lane keeps paying for."
-    (is (= [:idle-frames :scroll :ctl-blocked] (mapv :id clock/arms))
+    (is (= [:idle-frames :scroll :ctl-blocked] (mapv :id rf.bench.hicasso.ledger-frame-clock-app/arms))
         "floor first, so it leads the schedule")
-    (is (= [:ctl-blocked] (mapv :id (filter :control? clock/arms)))
+    (is (= [:ctl-blocked] (mapv :id (filter :control? rf.bench.hicasso.ledger-frame-clock-app/arms)))
         "and exactly one of them is a control")
-    (is (= [false true true] (mapv :advance? clock/arms))
+    (is (= [false true true] (mapv :advance? rf.bench.hicasso.ledger-frame-clock-app/arms))
         "the floor arm predicts stillness and both scrolling arms predict movement")
-    (is (pos? (:warmup clock/sampling)))
-    (is (pos? (:samples clock/sampling)))
-    (is (pos? clock/rounds))
-    (is (< 1 clock/frames-per-run)
+    (is (pos? (:warmup rf.bench.hicasso.ledger-frame-clock-app/sampling)))
+    (is (pos? (:samples rf.bench.hicasso.ledger-frame-clock-app/sampling)))
+    (is (pos? rf.bench.hicasso.ledger-frame-clock-app/rounds))
+    (is (< 1 rf.bench.hicasso.ledger-frame-clock-app/frames-per-run)
         "a run of one frame yields no interval at all")))
 
 (deftest the-injected-control-duration-clears-the-frame-grid
@@ -704,13 +704,13 @@
            16.7 ms at 60 Hz — so an injection much smaller than one frame
            can be absorbed by the quantisation entirely, and a control
            that fails for the clock is not a control."
-    (is (>= clock/blocked-ms (* 2.0 16.7))
+    (is (>= rf.bench.hicasso.ledger-frame-clock-app/blocked-ms (* 2.0 16.7))
         "at least two rendering intervals at 60 Hz — just under three, which is
          what the driver's own docstring rounds to")))
 
 (deftest the-gesture-fits-the-model-at-both-ends
-  (testing "[[clock/boot!]] refuses a knob set too near either edge of the
-           model, because `vendor/window-from` clamps `from` at zero and
+  (testing "[[rf.bench.hicasso.ledger-frame-clock-app/boot!]] refuses a knob set too near either edge of the
+           model, because `rf.hicasso.examples.ledger.vendor/window-from` clamps `from` at zero and
            `to` at the last row and a CLAMPED WINDOW STANDS STILL — which
            would make an honest verification failure out of a knob.
 
@@ -718,13 +718,13 @@
            are exercised without a browser and a knob moved in the driver
            reds this row rather than three hundred visits into a run."
     (let [[from _]  (window-at (start-top))
-          last-top  (+ (start-top) (* clock/frames-per-run clock/scroll-step-px))
+          last-top  (+ (start-top) (* rf.bench.hicasso.ledger-frame-clock-app/frames-per-run rf.bench.hicasso.ledger-frame-clock-app/scroll-step-px))
           [_ to]    (window-at last-top)]
       (is (pos? from)
           "the gesture starts clear of window-from's (max 0 …) clamp")
-      (is (< to (dec clock/total))
+      (is (< to (dec rf.bench.hicasso.ledger-frame-clock-app/total))
           "and ends clear of the model's last row")
-      (is (= 1 (/ clock/scroll-step-px views/row-height))
+      (is (= 1 (/ rf.bench.hicasso.ledger-frame-clock-app/scroll-step-px rf.hicasso.examples.ledger.views/row-height))
           "the step is ONE ROW, stated in the screen's own units rather than in
            pixels typed here")
       (is (< from to)

--- a/bench/hicasso/src/re_frame/bench/hicasso/link_decomp_probe_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/link_decomp_probe_app.cljs
@@ -9,10 +9,10 @@
   `link-model` is built out of as arms of their own:
 
     :floor       the loop and the `aget`, and nothing else
-    :cedn        `identity/canonical-bytes` on ONE path-param value — the
+    :cedn        `rf.identity/canonical-bytes` on ONE path-param value — the
                  call `route-url`'s `assert-url-value!` fail-closed guard
                  makes per path param per render, whose result it discards
-    :lookup      `registrar/lookup :route` — the route-meta read
+    :lookup      `rf.registrar/lookup :route` — the route-meta read
     :route-url   the whole path-form URL synthesis
     :strategy    `url-strategy-for-frame-id` — the render-time strategy
                  consult, which reads `frame/frame-meta`
@@ -23,17 +23,17 @@
   An arm here is NOT a bar row: these are in-page microsecond figures for
   a diagnostic, interleaved under the arm-order guard so a stage's figure
   does not depend on where in the plan it was measured."
-  (:require [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.shapes.large-template :as lt]
-            [re-frame.bench.hicasso.shapes.model :as m]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.shapes.large-template :as rf.bench.hicasso.shapes.large-template]
+            [re-frame.bench.hicasso.shapes.model :as rf.bench.hicasso.shapes.model]
             [re-frame.core :as rf]
-            [re-frame.identity :as identity]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]
-            [re-frame.routing :as routing]
-            [re-frame.routing.strategy :as strategy]))
+            [re-frame.identity :as rf.identity]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.routing :as rf.routing]
+            [re-frame.routing.strategy :as rf.routing.strategy]))
 
 (def frame-id ::frame)
 
@@ -44,8 +44,8 @@
   links and one article link, from the model's own seed."
   []
   (let [a #js []]
-    (dotimes [i lt/article-count]
-      (let [art (m/article i)
+    (dotimes [i rf.bench.hicasso.shapes.large-template/article-count]
+      (let [art (rf.bench.hicasso.shapes.model/article i)
             u   (:username (:author art))]
         (.push a {:to :conduit.profile/show :params {:username u}})
         (.push a {:to :conduit.profile/show :params {:username u}})
@@ -65,26 +65,26 @@
 (def ^:private passes-per-sample 4)
 
 (defn- timed-door [pass!]
-  (let [t0 (lane/now-ms)]
+  (let [t0 (rf.bench.hicasso.lane/now-ms)]
     (dotimes [_ passes-per-sample]
-      (rt/render-body frame-id (fn [_] (pass!) [:span]) {}))
-    (- (lane/now-ms) t0)))
+      (rf.bench.hicasso.arm1.runtime/render-body frame-id (fn [_] (pass!) [:span]) {}))
+    (- (rf.bench.hicasso.lane/now-ms) t0)))
 
 (def ^:private arm-ids [:floor :cedn :lookup :route-url :strategy :link-model :ctl2])
 
 (defn ^:export -main []
-  (rf/init! uix-adapter/adapter)
-  (lane/leave-act-environment!)
-  (lane/self-test!)
+  (rf/init! rf.adapter.uix/adapter)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/self-test!)
   (-> (js/Promise.resolve nil)
       (.then
         (fn [_]
-          (lt/make-frame! frame-id)
-          (lt/reseed! frame-id)
+          (rf.bench.hicasso.shapes.large-template/make-frame! frame-id)
+          (rf.bench.hicasso.shapes.large-template/reseed! frame-id)
           (let [targets    (link-targets)
                 values     (param-values targets)
                 n          (alength targets)
-                link-model (late-bind/require-fn! :routing/link-model
+                link-model (rf.late-bind/require-fn! :routing/link-model
                                                   'link-decomp-probe {} {})
                 sink       (volatile! nil)
                 arms
@@ -95,19 +95,19 @@
                  {:id :cedn
                   :pass (fn []
                           (dotimes [i n]
-                            (vreset! sink (identity/canonical-bytes (aget values i)))))}
+                            (vreset! sink (rf.identity/canonical-bytes (aget values i)))))}
                  {:id :lookup
                   :pass (fn []
                           (dotimes [i n]
-                            (vreset! sink (registrar/lookup :route (:to (aget targets i))))))}
+                            (vreset! sink (rf.registrar/lookup :route (:to (aget targets i))))))}
                  {:id :route-url
                   :pass (fn []
                           (dotimes [i n]
-                            (vreset! sink (routing/route-url (aget targets i)))))}
+                            (vreset! sink (rf.routing/route-url (aget targets i)))))}
                  {:id :strategy
                   :pass (fn []
                           (dotimes [_ n]
-                            (vreset! sink (strategy/url-strategy-for-frame-id frame-id))))}
+                            (vreset! sink (rf.routing.strategy/url-strategy-for-frame-id frame-id))))}
                  {:id :link-model
                   :pass (fn []
                           (dotimes [i n]
@@ -118,21 +118,21 @@
                             (dotimes [i n]
                               (vreset! sink (link-model (aget targets i) frame-id)))))}]
                 {:keys [readings samples]}
-                (lane/rounds! arms {:warmup 4 :samples 8} 5
+                (rf.bench.hicasso.lane/rounds! arms {:warmup 4 :samples 8} 5
                               (fn [{:keys [pass]}] (timed-door pass)))
                 rows (into {}
                            (map (fn [id]
                                   (let [xs (mapcat #(get % id) readings)]
-                                    [id (lane/summarise (mapv #(/ % passes-per-sample) xs))])))
+                                    [id (rf.bench.hicasso.lane/summarise (mapv #(/ % passes-per-sample) xs))])))
                            arm-ids)
-                gv   (lane/guard! samples "link decomposition (in-page ms, diagnostic)")
-                ctl  (lane/control-verdict (* 2.0 (:p50 (get rows :link-model)))
+                gv   (rf.bench.hicasso.lane/guard! samples "link decomposition (in-page ms, diagnostic)")
+                ctl  (rf.bench.hicasso.lane/control-verdict (* 2.0 (:p50 (get rows :link-model)))
                                            (let [s (get rows :ctl2)]
                                              {:min (:min s) :max (:max s) :mean (:p50 s)})
                                            0.25)]
             (when-not (:ok? ctl)
               (throw (ex-info (str "positive control failed: " (:why ctl)) {})))
-            (lane/record! :link-decomp rows)
+            (rf.bench.hicasso.lane/record! :link-decomp rows)
             (js/console.log ";; ==== LINK DECOMPOSITION (ms per 207-call pass; diagnostic in-page clock) ====")
             (doseq [id arm-ids]
               (let [{:keys [p50 min max]} (get rows id)]
@@ -143,7 +143,7 @@
             (js/console.log (str ";;   control: " (:why ctl)))
             (when (:refuse? gv)
               (set! (.-HICASSO_GUARD_REFUSED js/window) true))
-            (lane/done!))))
+            (rf.bench.hicasso.lane/done!))))
       (.catch (fn [e]
-                (lane/fail! (or (some-> e .-message) (str e)))
-                (lane/done!)))))
+                (rf.bench.hicasso.lane/fail! (or (some-> e .-message) (str e)))
+                (rf.bench.hicasso.lane/done!)))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/link_inner_probe_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/link_inner_probe_app.cljs
@@ -22,15 +22,15 @@
   A replica is not the fn — it is the same expression on the same data,
   which is what a decomposition needs when the stages are `defn-`
   private. The anchor arm (`:route-url`) keeps both probes on one scale."
-  (:require [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.shapes.large-template :as lt]
-            [re-frame.bench.hicasso.shapes.model :as m]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.shapes.large-template :as rf.bench.hicasso.shapes.large-template]
+            [re-frame.bench.hicasso.shapes.model :as rf.bench.hicasso.shapes.model]
             [re-frame.core :as rf]
-            [re-frame.identity :as identity]
-            [re-frame.routing :as routing]
-            [re-frame.routing.address :as address]))
+            [re-frame.identity :as rf.identity]
+            [re-frame.routing :as rf.routing]
+            [re-frame.routing.address :as rf.routing.address]))
 
 (def frame-id ::frame)
 
@@ -38,8 +38,8 @@
 
 (defn- link-targets []
   (let [a #js []]
-    (dotimes [i lt/article-count]
-      (let [art (m/article i)
+    (dotimes [i rf.bench.hicasso.shapes.large-template/article-count]
+      (let [art (rf.bench.hicasso.shapes.model/article i)
             u   (:username (:author art))]
         (.push a {:to :conduit.profile/show :params {:username u}})
         (.push a {:to :conduit.profile/show :params {:username u}})
@@ -98,22 +98,22 @@
 (def ^:private passes-per-sample 4)
 
 (defn- timed-door [pass!]
-  (let [t0 (lane/now-ms)]
+  (let [t0 (rf.bench.hicasso.lane/now-ms)]
     (dotimes [_ passes-per-sample]
-      (rt/render-body frame-id (fn [_] (pass!) [:span]) {}))
-    (- (lane/now-ms) t0)))
+      (rf.bench.hicasso.arm1.runtime/render-body frame-id (fn [_] (pass!) [:span]) {}))
+    (- (rf.bench.hicasso.lane/now-ms) t0)))
 
 (def ^:private arm-ids [:floor :ideal :emit-loop :set-build :addr-keys :route-url :ctl2])
 
 (defn ^:export -main []
-  (rf/init! uix-adapter/adapter)
-  (lane/leave-act-environment!)
-  (lane/self-test!)
+  (rf/init! rf.adapter.uix/adapter)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/self-test!)
   (-> (js/Promise.resolve nil)
       (.then
         (fn [_]
-          (lt/make-frame! frame-id)
-          (lt/reseed! frame-id)
+          (rf.bench.hicasso.shapes.large-template/make-frame! frame-id)
+          (rf.bench.hicasso.shapes.large-template/reseed! frame-id)
           (let [targets (link-targets)
                 ideals  (ideal-parts targets)
                 n       (alength targets)
@@ -145,35 +145,35 @@
                           (dotimes [i n]
                             (let [t (aget targets i)]
                               (vreset! sink
-                                       [(seq (remove address/address-keys (keys t)))
+                                       [(seq (remove rf.routing.address/address-keys (keys t)))
                                         (into (array-map)
-                                              (sort-by (comp identity/canonical-bytes key)
+                                              (sort-by (comp rf.identity/canonical-bytes key)
                                                        (remove (fn [[_ v]] (nil? v)) {})))]))))}
                  {:id :route-url
                   :pass (fn []
                           (dotimes [i n]
-                            (vreset! sink (routing/route-url (aget targets i)))))}
+                            (vreset! sink (rf.routing/route-url (aget targets i)))))}
                  {:id :ctl2
                   :pass (fn []
                           (dotimes [_ 2]
                             (dotimes [i n]
-                              (vreset! sink (routing/route-url (aget targets i))))))}]
+                              (vreset! sink (rf.routing/route-url (aget targets i))))))}]
                 {:keys [readings samples]}
-                (lane/rounds! arms {:warmup 4 :samples 8} 5
+                (rf.bench.hicasso.lane/rounds! arms {:warmup 4 :samples 8} 5
                               (fn [{:keys [pass]}] (timed-door pass)))
                 rows (into {}
                            (map (fn [id]
                                   (let [xs (mapcat #(get % id) readings)]
-                                    [id (lane/summarise (mapv #(/ % passes-per-sample) xs))])))
+                                    [id (rf.bench.hicasso.lane/summarise (mapv #(/ % passes-per-sample) xs))])))
                            arm-ids)
-                gv   (lane/guard! samples "link inner decomposition (in-page ms, diagnostic)")
-                ctl  (lane/control-verdict (* 2.0 (:p50 (get rows :route-url)))
+                gv   (rf.bench.hicasso.lane/guard! samples "link inner decomposition (in-page ms, diagnostic)")
+                ctl  (rf.bench.hicasso.lane/control-verdict (* 2.0 (:p50 (get rows :route-url)))
                                            (let [s (get rows :ctl2)]
                                              {:min (:min s) :max (:max s) :mean (:p50 s)})
                                            0.25)]
             (when-not (:ok? ctl)
               (throw (ex-info (str "positive control failed: " (:why ctl)) {})))
-            (lane/record! :link-inner rows)
+            (rf.bench.hicasso.lane/record! :link-inner rows)
             (js/console.log ";; ==== LINK INNER DECOMPOSITION (ms per 207-call pass; diagnostic) ====")
             (doseq [id arm-ids]
               (let [{:keys [p50 min max]} (get rows id)]
@@ -184,7 +184,7 @@
             (js/console.log (str ";;   control: " (:why ctl)))
             (when (:refuse? gv)
               (set! (.-HICASSO_GUARD_REFUSED js/window) true))
-            (lane/done!))))
+            (rf.bench.hicasso.lane/done!))))
       (.catch (fn [e]
-                (lane/fail! (or (some-> e .-message) (str e)))
-                (lane/done!)))))
+                (rf.bench.hicasso.lane/fail! (or (some-> e .-message) (str e)))
+                (rf.bench.hicasso.lane/done!)))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/link_term_probe_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/link_term_probe_app.cljs
@@ -9,14 +9,14 @@
   `route-url`-only floor? Runs the calls through the runtime's own
   render-body door exactly as `route-link` performs them (same seam, same
   frame), interleaved with the arm-order guard adjudicating."
-  (:require [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.shapes.large-template :as lt]
-            [re-frame.bench.hicasso.shapes.model :as m]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.shapes.large-template :as rf.bench.hicasso.shapes.large-template]
+            [re-frame.bench.hicasso.shapes.model :as rf.bench.hicasso.shapes.model]
             [re-frame.core :as rf]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.routing :as routing]))
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.routing :as rf.routing]))
 
 (def frame-id ::frame)
 
@@ -27,8 +27,8 @@
   links and one article link, from the model's own seed."
   []
   (let [a #js []]
-    (dotimes [i lt/article-count]
-      (let [art (m/article i)
+    (dotimes [i rf.bench.hicasso.shapes.large-template/article-count]
+      (let [art (rf.bench.hicasso.shapes.model/article i)
             u   (:username (:author art))]
         (.push a {:to :conduit.profile/show :params {:username u}})
         (.push a {:to :conduit.profile/show :params {:username u}})
@@ -38,23 +38,23 @@
 (def ^:private passes-per-sample 4)
 
 (defn- timed-door [pass!]
-  (let [t0 (lane/now-ms)]
+  (let [t0 (rf.bench.hicasso.lane/now-ms)]
     (dotimes [_ passes-per-sample]
-      (rt/render-body frame-id (fn [_] (pass!) [:span]) {}))
-    (- (lane/now-ms) t0)))
+      (rf.bench.hicasso.arm1.runtime/render-body frame-id (fn [_] (pass!) [:span]) {}))
+    (- (rf.bench.hicasso.lane/now-ms) t0)))
 
 (defn ^:export -main []
-  (rf/init! uix-adapter/adapter)
-  (lane/leave-act-environment!)
-  (lane/self-test!)
+  (rf/init! rf.adapter.uix/adapter)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/self-test!)
   (-> (js/Promise.resolve nil)
       (.then
         (fn [_]
-          (lt/make-frame! frame-id)
-          (lt/reseed! frame-id)
+          (rf.bench.hicasso.shapes.large-template/make-frame! frame-id)
+          (rf.bench.hicasso.shapes.large-template/reseed! frame-id)
           (let [targets    (link-targets)
                 n          (alength targets)
-                link-model (late-bind/require-fn! :routing/link-model
+                link-model (rf.late-bind/require-fn! :routing/link-model
                                                   'link-term-probe {} {})
                 sink       (volatile! nil)
                 arms
@@ -65,28 +65,28 @@
                  {:id :route-url
                   :pass (fn []
                           (dotimes [i n]
-                            (vreset! sink (routing/route-url (aget targets i)))))}
+                            (vreset! sink (rf.routing/route-url (aget targets i)))))}
                  {:id :ctl2
                   :pass (fn []
                           (dotimes [_ 2]
                             (dotimes [i n]
                               (vreset! sink (link-model (aget targets i) frame-id)))))}]
                 {:keys [readings samples]}
-                (lane/rounds! arms {:warmup 3 :samples 8} 5
+                (rf.bench.hicasso.lane/rounds! arms {:warmup 3 :samples 8} 5
                               (fn [{:keys [pass]}] (timed-door pass)))
                 rows (into {}
                            (map (fn [id]
                                   (let [xs (mapcat #(get % id) readings)]
-                                    [id (lane/summarise (mapv #(/ % passes-per-sample) xs))])))
+                                    [id (rf.bench.hicasso.lane/summarise (mapv #(/ % passes-per-sample) xs))])))
                            [:link-model :route-url :ctl2])
-                gv   (lane/guard! samples "link-term probe (in-page ms, diagnostic)")
-                ctl  (lane/control-verdict (* 2.0 (:p50 (get rows :link-model)))
+                gv   (rf.bench.hicasso.lane/guard! samples "link-term probe (in-page ms, diagnostic)")
+                ctl  (rf.bench.hicasso.lane/control-verdict (* 2.0 (:p50 (get rows :link-model)))
                                            (let [s (get rows :ctl2)]
                                              {:min (:min s) :max (:max s) :mean (:p50 s)})
                                            0.25)]
             (when-not (:ok? ctl)
               (throw (ex-info (str "positive control failed: " (:why ctl)) {})))
-            (lane/record! :link-term rows)
+            (rf.bench.hicasso.lane/record! :link-term rows)
             (js/console.log ";; ==== LINK TERM (ms per 207-link pass; diagnostic in-page clock) ====")
             (doseq [id [:link-model :route-url :ctl2]]
               (let [{:keys [p50 min max]} (get rows id)]
@@ -97,7 +97,7 @@
             (js/console.log (str ";;   control: " (:why ctl)))
             (when (:refuse? gv)
               (set! (.-HICASSO_GUARD_REFUSED js/window) true))
-            (lane/done!))))
+            (rf.bench.hicasso.lane/done!))))
       (.catch (fn [e]
-                (lane/fail! (or (some-> e .-message) (str e)))
-                (lane/done!)))))
+                (rf.bench.hicasso.lane/fail! (or (some-> e .-message) (str e)))
+                (rf.bench.hicasso.lane/done!)))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/p0_converge_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/p0_converge_app.cljs
@@ -98,7 +98,7 @@
 
   ## Three arms a segment, and why not two
 
-  rf2-ouwh8: `lane/slot-order` rotated and then REFLECTED, and at k=2 those
+  rf2-ouwh8: `rf.bench.hicasso.lane/slot-order` rotated and then REFLECTED, and at k=2 those
   two operations cancelled — `[0 1]` rotates to `[1 0]` and reflects back
   to `[0 1]`, at every sample index, for ever. A two-arm plan therefore ran
   in ONE order and `both orders` was a claim it could not support. This
@@ -144,7 +144,7 @@
   ## And the order is ADJUDICATED, not merely run (rf2-a4x1o)
 
   Running both orders is not the same as testing whether the answer
-  depends on them. `lane/guard!` adjudicates arms INSIDE a segment; the
+  depends on them. `rf.bench.hicasso.lane/guard!` adjudicates arms INSIDE a segment; the
   red-zone is a ratio ACROSS the seam and no guard on this page ever
   looked at it by segment order, while `:segment-seam-control` recorded
   the floor's drift and stopped there. [[segment-order-verdict]] asks the
@@ -192,7 +192,7 @@
   pointer without banking a sample, so every recorded sample carries its
   real predecessor). The tolerance was not touched. That second repair
   lived HERE, as a private `mark-predecessor!`, until `rf2-6ta5r` found
-  the same fault still standing in `lane/rounds!` — the shared loop this
+  the same fault still standing in `rf.bench.hicasso.lane/rounds!` — the shared loop this
   entry does not use — and moved the one copy to the lane.
 
   ## What this entry does NOT measure
@@ -213,14 +213,14 @@
   touches no build id and no `implementation/shadow-cljs.edn`."
   (:require ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.p0-reagent-views :as v]
-            [re-frame.bench.hicasso.p0-uix-views :as ux]
-            [re-frame.bench.order-guard :as guard]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.p0-reagent-views :as rf.bench.hicasso.p0-reagent-views]
+            [re-frame.bench.hicasso.p0-uix-views :as rf.bench.hicasso.p0-uix-views]
+            [re-frame.bench.order-guard :as rf.bench.order-guard]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
+            [re-frame.frame :as rf.frame]
             [reagent.core :as r]
             [reagent.dom.client :as rdc]
             [uix.dom :as uix-dom]))
@@ -256,8 +256,8 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private segments
-  [{:id :reagent-subs :adapter reagent-adapter/adapter :name "Reagent-on-subs"}
-   {:id :uix-subs     :adapter uix-adapter/adapter     :name "UIx-on-subs"}])
+  [{:id :reagent-subs :adapter rf.adapter.reagent/adapter :name "Reagent-on-subs"}
+   {:id :uix-subs     :adapter rf.adapter.uix/adapter     :name "UIx-on-subs"}])
 
 (defn- query-start
   "Which segment runs FIRST in round 0 — `?start=uix` or `?start=reagent`.
@@ -312,16 +312,16 @@
   segment is a figure for a page carrying the previous segment's
   reactive graph (rf2-f5roa, from the PR #7268 audit)."
   [{:keys [adapter]}]
-  (try (rf/destroy-frame! v/subs-frame)
-       (catch :default e (lane/teardown-failure! "enter-segment! destroy-frame!" e)))
+  (try (rf/destroy-frame! rf.bench.hicasso.p0-reagent-views/subs-frame)
+       (catch :default e (rf.bench.hicasso.lane/teardown-failure! "enter-segment! destroy-frame!" e)))
   (when (rf/current-adapter)
     (try (rf/destroy-adapter!)
-         (catch :default e (lane/teardown-failure! "enter-segment! destroy-adapter!" e))))
+         (catch :default e (rf.bench.hicasso.lane/teardown-failure! "enter-segment! destroy-adapter!" e))))
   (rf/init! adapter)
-  (v/register!)
-  (rf/make-frame {:id v/subs-frame})
-  (frame/replace-app-db! v/subs-frame (v/seed-cells v/cells-n 0))
-  (lane/leave-act-environment!)
+  (rf.bench.hicasso.p0-reagent-views/register!)
+  (rf/make-frame {:id rf.bench.hicasso.p0-reagent-views/subs-frame})
+  (rf.frame/replace-app-db! rf.bench.hicasso.p0-reagent-views/subs-frame (rf.bench.hicasso.p0-reagent-views/seed-cells rf.bench.hicasso.p0-reagent-views/cells-n 0))
+  (rf.bench.hicasso.lane/leave-act-environment!)
   nil)
 
 ;; ---------------------------------------------------------------------------
@@ -386,8 +386,8 @@
   past its first half."
   [n]
   (fn [container]
-    (and (= "0" (lane/text-at container 0))
-         (= "0" (lane/text-at container (dec n))))))
+    (and (= "0" (rf.bench.hicasso.lane/text-at container 0))
+         (= "0" (rf.bench.hicasso.lane/text-at container (dec n))))))
 
 (defn- verify-m2
   "The first and last field AT THE ARM'S OWN SIZE. Fixed at the witness's
@@ -395,8 +395,8 @@
   from a base one."
   [n]
   (fn [container]
-    (and (= (v/field-value 0 0) (input-value container "#f0"))
-         (= (v/field-value (dec n) 0)
+    (and (= (rf.bench.hicasso.p0-reagent-views/field-value 0 0) (input-value container "#f0"))
+         (= (rf.bench.hicasso.p0-reagent-views/field-value (dec n) 0)
             (input-value container (str "#f" (dec n)))))))
 
 (defn- expectation
@@ -421,41 +421,41 @@
   [{:id          :M1
     :grade       :bar
     :verify-of   verify-m1
-    :elements-of v/m1-elements
+    :elements-of rf.bench.hicasso.p0-reagent-views/m1-elements
     :doc      (str "the 300-boundary sub-reading list — the bulk shape's mount "
                    "counterpart, one subscription read per boundary. "
                    "rf2-2rtt6.2's M1, unchanged")
-    :props    {:n v/cells-n}
-    :control  {:predicted (/ (double (v/m1-elements (* 2 v/cells-n)))
-                             (double (v/m1-elements v/cells-n)))
-               :basis     (str "element count: " (v/m1-elements (* 2 v/cells-n)) " / "
-                               (v/m1-elements v/cells-n))}
+    :props    {:n rf.bench.hicasso.p0-reagent-views/cells-n}
+    :control  {:predicted (/ (double (rf.bench.hicasso.p0-reagent-views/m1-elements (* 2 rf.bench.hicasso.p0-reagent-views/cells-n)))
+                             (double (rf.bench.hicasso.p0-reagent-views/m1-elements rf.bench.hicasso.p0-reagent-views/cells-n)))
+               :basis     (str "element count: " (rf.bench.hicasso.p0-reagent-views/m1-elements (* 2 rf.bench.hicasso.p0-reagent-views/cells-n)) " / "
+                               (rf.bench.hicasso.p0-reagent-views/m1-elements rf.bench.hicasso.p0-reagent-views/cells-n))}
     ;; The `:reagent-ratom` arm sits between the denominator and the
     ;; control, which is rf2-2rtt6.2's own order — the plan is that arm's
     ;; plan with the UIx segment's arm swapped in on the other side of the
     ;; seam, so a reader comparing the two legs is comparing two authors
     ;; and not two orderings.
     :arms-for (fn [segment-id ratom?]
-                (-> [(floor-mount-arm :floor v/m1-floor (fn [{:keys [n]}] (zeros n)))]
+                (-> [(floor-mount-arm :floor rf.bench.hicasso.p0-reagent-views/m1-floor (fn [{:keys [n]}] (zeros n)))]
                     (into (case segment-id
                             :reagent-subs
                             (cond-> [(reagent-mount-arm
                                        :reagent-subs
-                                       (fn [{:keys [n]}] [v/subs-root v/m1-subs n]))]
+                                       (fn [{:keys [n]}] [rf.bench.hicasso.p0-reagent-views/subs-root rf.bench.hicasso.p0-reagent-views/m1-subs n]))]
                               ratom? (conj (reagent-mount-arm
                                              :reagent-ratom
-                                             (fn [{:keys [n]}] [v/m1-ratom n]))))
+                                             (fn [{:keys [n]}] [rf.bench.hicasso.p0-reagent-views/m1-ratom n]))))
                             :uix-subs
                             [(uix-mount-arm
                                :uix-subs
-                               (fn [{:keys [n]}] (ux/subs-root ux/m1 n)))]))
-                    (conj (floor-mount-arm :ctl-2x v/m1-floor
+                               (fn [{:keys [n]}] (rf.bench.hicasso.p0-uix-views/subs-root rf.bench.hicasso.p0-uix-views/m1 n)))]))
+                    (conj (floor-mount-arm :ctl-2x rf.bench.hicasso.p0-reagent-views/m1-floor
                                            (fn [{:keys [n]}] (zeros (* 2 n))) 2))))}
 
    {:id          :M2
     :grade       :diagnostic
     :verify-of   verify-m2
-    :elements-of v/m2-elements
+    :elements-of rf.bench.hicasso.p0-reagent-views/m2-elements
     ;; A SMALLER MOUNT BUDGET THAN THE PAGE DEFAULT, and only here
     ;; (rf2-6i0i2). The sixth round pushed this page over the arm-order
     ;; guard's phase gate: at the default 8+12 sampling a six-round M2
@@ -502,11 +502,11 @@
                      "1.0000 — the quantum wearing a tie's clothes.")
     :doc      (str "the ordinary 12-field form on subs — the shape most "
                    "applications are made of. rf2-2rtt6.2's M2, unchanged")
-    :props    {:n v/fields-n}
-    :control  {:predicted (/ (double (v/m2-elements (* 2 v/fields-n)))
-                             (double (v/m2-elements v/fields-n)))
-               :basis     (str "element count: " (v/m2-elements (* 2 v/fields-n)) " / "
-                               (v/m2-elements v/fields-n))}
+    :props    {:n rf.bench.hicasso.p0-reagent-views/fields-n}
+    :control  {:predicted (/ (double (rf.bench.hicasso.p0-reagent-views/m2-elements (* 2 rf.bench.hicasso.p0-reagent-views/fields-n)))
+                             (double (rf.bench.hicasso.p0-reagent-views/m2-elements rf.bench.hicasso.p0-reagent-views/fields-n)))
+               :basis     (str "element count: " (rf.bench.hicasso.p0-reagent-views/m2-elements (* 2 rf.bench.hicasso.p0-reagent-views/fields-n)) " / "
+                               (rf.bench.hicasso.p0-reagent-views/m2-elements rf.bench.hicasso.p0-reagent-views/fields-n))}
     ;; `ratom?` is IGNORED here, and it is ignored for two reasons rather
     ;; than for want of a `conj` (rf2-2rtt6.21). This is the one row whose
     ;; mount budget already refuses — 720 mounts refused four of six, and
@@ -518,15 +518,15 @@
     ;; witness whose window is three to six of Chrome's 100 us quanta.
     ;; A second author cannot corroborate a number that is the clamp.
     :arms-for (fn [segment-id _ratom?]
-                [(floor-mount-arm :floor v/m2-floor (fn [{:keys [n]}] (zeros n)))
+                [(floor-mount-arm :floor rf.bench.hicasso.p0-reagent-views/m2-floor (fn [{:keys [n]}] (zeros n)))
                  (case segment-id
                    :reagent-subs (reagent-mount-arm
                                    :reagent-subs
-                                   (fn [{:keys [n]}] [v/subs-root v/m2-subs n]))
+                                   (fn [{:keys [n]}] [rf.bench.hicasso.p0-reagent-views/subs-root rf.bench.hicasso.p0-reagent-views/m2-subs n]))
                    :uix-subs     (uix-mount-arm
                                    :uix-subs
-                                   (fn [{:keys [n]}] (ux/subs-root ux/m2 n))))
-                 (floor-mount-arm :ctl-2x v/m2-floor
+                                   (fn [{:keys [n]}] (rf.bench.hicasso.p0-uix-views/subs-root rf.bench.hicasso.p0-uix-views/m2 n))))
+                 (floor-mount-arm :ctl-2x rf.bench.hicasso.p0-reagent-views/m2-floor
                                   (fn [{:keys [n]}] (zeros (* 2 n))) 2)])}])
 
 (defn- witness-named [id] (first (filter #(= id (:id %)) mount-witnesses)))
@@ -552,14 +552,14 @@
      :mount          (fn [container]
                        (let [root (react-dom-client/createRoot container)]
                          (vreset! rt root)
-                         (react-dom/flushSync (fn [] (.render root (v/m1-floor @state))))
+                         (react-dom/flushSync (fn [] (.render root (rf.bench.hicasso.p0-reagent-views/m1-floor @state))))
                          root))
      :write!         (fn [i val]
                        (if (= i :all)
                          (reset! state (vec (repeat n val)))
                          (swap! state assoc i val)))
      :force!         (fn [] (react-dom/flushSync
-                              (fn [] (.render ^js @rt (v/m1-floor @state)))))
+                              (fn [] (.render ^js @rt (rf.bench.hicasso.p0-reagent-views/m1-floor @state)))))
      :unmount        (fn [root] (react-dom/flushSync (fn [] (.unmount root))))}))
 
 (defn- subs-bulk-arm
@@ -567,7 +567,7 @@
   two places: the mount door and the drain.
 
   THE WRITE IS IDENTICAL and it is rf2-2rtt6.2's write —
-  `frame/replace-app-db!` — not a `dispatch-sync`. HD-012 states the bar
+  `rf.frame/replace-app-db!` — not a `dispatch-sync`. HD-012 states the bar
   over VIEW WORK, and rf2-2rtt6.3 measured the event drain at 11%-16% of
   a write on this substrate; routing the converged row through the event
   pipeline would add that leg to both arms, shrink the view-work
@@ -581,16 +581,16 @@
   application actually meets it, and it is the same operation on both
   substrate arms."
   [id mount unmount force!]
-  (let [cells (atom (zeros v/cells-n))]
+  (let [cells (atom (zeros rf.bench.hicasso.p0-reagent-views/cells-n))]
     {:id      id
-     :cells   v/cells-n
+     :cells   rf.bench.hicasso.p0-reagent-views/cells-n
      :mount   mount
      :unmount unmount
      :write!  (fn [i val]
                 (if (= i :all)
-                  (reset! cells (vec (repeat v/cells-n val)))
+                  (reset! cells (vec (repeat rf.bench.hicasso.p0-reagent-views/cells-n val)))
                   (swap! cells assoc i val))
-                (frame/replace-app-db! v/subs-frame {:cells @cells}))
+                (rf.frame/replace-app-db! rf.bench.hicasso.p0-reagent-views/subs-frame {:cells @cells}))
      :force!  force!}))
 
 (defn- reagent-bulk-arm []
@@ -599,7 +599,7 @@
     (fn [container]
       (let [root (rdc/create-root container)]
         (react-dom/flushSync
-          (fn [] (rdc/render root [v/subs-root v/m1-subs v/cells-n])))
+          (fn [] (rdc/render root [rf.bench.hicasso.p0-reagent-views/subs-root rf.bench.hicasso.p0-reagent-views/m1-subs rf.bench.hicasso.p0-reagent-views/cells-n])))
         root))
     (fn [root] (react-dom/flushSync (fn [] (rdc/unmount root))))
     ;; `reagent.core/flush` is Reagent's own documented synchronous render
@@ -612,12 +612,12 @@
     (fn [container]
       (let [root (uix-dom/create-root container)]
         (react-dom/flushSync
-          (fn [] (uix-dom/render-root (ux/subs-root ux/m1 v/cells-n) root)))
+          (fn [] (uix-dom/render-root (rf.bench.hicasso.p0-uix-views/subs-root rf.bench.hicasso.p0-uix-views/m1 rf.bench.hicasso.p0-reagent-views/cells-n) root)))
         root))
     (fn [root] (react-dom/flushSync (fn [] (uix-dom/unmount-root root))))
     ;; `useSyncExternalStore` notifications schedule at React's SYNC lane,
     ;; so an EMPTY flushSync commits them inside the window. Not
-    ;; `uix-adapter/flush-views!`, which wraps React's `act()` — `act`
+    ;; `rf.adapter.uix/flush-views!`, which wraps React's `act()` — `act`
     ;; diverts work to a queue that is not the browser's, and every
     ;; window in this lane is taken outside it.
     (fn [] (react-dom/flushSync (fn [] nil)))))
@@ -628,7 +628,7 @@
   `reagent.core/atom` instead of through a subscription.
 
   It is NOT built by [[subs-bulk-arm]], and the difference is the whole
-  point of the arm: the write installs into `v/ratom-cells` rather than
+  point of the arm: the write installs into `rf.bench.hicasso.p0-reagent-views/ratom-cells` rather than
   into the frame's app-db, so this arm pays no subscription graph, no
   query cache and no frame. Everything else is held identical to the
   `:reagent-subs` arm beside it — the same mount door
@@ -642,16 +642,16 @@
   it in a plan."
   []
   {:id      :reagent-ratom
-   :cells   v/cells-n
+   :cells   rf.bench.hicasso.p0-reagent-views/cells-n
    :mount   (fn [container]
               (let [root (rdc/create-root container)]
                 (react-dom/flushSync
-                  (fn [] (rdc/render root [v/m1-ratom v/cells-n])))
+                  (fn [] (rdc/render root [rf.bench.hicasso.p0-reagent-views/m1-ratom rf.bench.hicasso.p0-reagent-views/cells-n])))
                 root))
    :write!  (fn [i val]
               (if (= i :all)
-                (reset! v/ratom-cells (vec (repeat v/cells-n val)))
-                (swap! v/ratom-cells assoc i val)))
+                (reset! rf.bench.hicasso.p0-reagent-views/ratom-cells (vec (repeat rf.bench.hicasso.p0-reagent-views/cells-n val)))
+                (swap! rf.bench.hicasso.p0-reagent-views/ratom-cells assoc i val)))
    :force!  (fn [] (react-dom/flushSync (fn [] (r/flush))))
    :unmount (fn [root] (react-dom/flushSync (fn [] (rdc/unmount root))))})
 
@@ -662,31 +662,31 @@
   ratom arm there would be a new figure rather than a corroboration, and
   this entry does not mint one while it is answering a different question."
   [segment-id row-key ratom?]
-  (-> [(floor-bulk-arm :floor v/cells-n)]
+  (-> [(floor-bulk-arm :floor rf.bench.hicasso.p0-reagent-views/cells-n)]
       (into (case segment-id
               :reagent-subs (cond-> [(reagent-bulk-arm)]
                               (and ratom? (= row-key :broad))
                               (conj (ratom-bulk-arm)))
               :uix-subs     [(uix-bulk-arm)]))
-      (conj (floor-bulk-arm :ctl-2x (* 2 v/cells-n) 2))))
+      (conj (floor-bulk-arm :ctl-2x (* 2 rf.bench.hicasso.p0-reagent-views/cells-n) 2))))
 
 (defn- mount-bulk-arms!
   "Mount every bulk arm once and CHECK THE PAGE IT BUILT, before a clock is
   read.
 
-  Every bulk arm declares `:cells` and `v/m1-elements` turns that into an
+  Every bulk arm declares `:cells` and `rf.bench.hicasso.p0-reagent-views/m1-elements` turns that into an
   element count by written arithmetic, so this is what makes the bulk
   `:ctl-2x` arm's doubled page load-bearing. Its far-end read-back already
-  derives from `:cells` (`lane/bulk-probes` probes index `cells - 1`), so a
+  derives from `:cells` (`rf.bench.hicasso.lane/bulk-probes` probes index `cells - 1`), so a
   control shrunk to the base 300 cells would still have probed a cell it
   owns; the COUNT is the check a smaller page cannot satisfy. Outside every
   timed window — the arms are mounted once and written to thereafter."
   [arms]
   (mapv (fn [a]
-          (let [c        (lane/fresh-container!)
+          (let [c        (rf.bench.hicasso.lane/fresh-container!)
                 handle   ((:mount a) c)
-                expected (v/m1-elements (:cells a))
-                got      (lane/element-count c)]
+                expected (rf.bench.hicasso.p0-reagent-views/m1-elements (:cells a))
+                got      (rf.bench.hicasso.lane/element-count c)]
             (when-not (= expected got)
               (throw (ex-info (str "the bulk arm " (:id a) " built " got
                                    " elements where its own " (:cells a)
@@ -697,8 +697,8 @@
 
 (defn- release-bulk-arms!
   "Release every bulk arm. A throw is RECORDED, never swallowed — and a
-  normal return is not taken at its word: `lane/container-released!` reads
-  each container before it is removed, exactly as `lane/release!` and
+  normal return is not taken at its word: `rf.bench.hicasso.lane/container-released!` reads
+  each container before it is removed, exactly as `rf.bench.hicasso.lane/release!` and
   `p0_reagent_app`'s sibling do, because a root that survives its own
   unmount does so on a DETACHED tree no later census can see (rf2-jk3vj)."
   [mounts]
@@ -706,8 +706,8 @@
     (when (try ((:unmount arm) handle)
                true
                (catch :default e
-                 (lane/teardown-failure! (str "release-bulk-arms! " (:id arm)) e)))
-      (lane/container-released! (str "release-bulk-arms! " (:id arm)) container))
+                 (rf.bench.hicasso.lane/teardown-failure! (str "release-bulk-arms! " (:id arm)) e)))
+      (rf.bench.hicasso.lane/container-released! (str "release-bulk-arms! " (:id arm)) container))
     (.remove container)))
 
 (def ^:private assert-teardown-clean!
@@ -716,7 +716,7 @@
   authority with nothing holding it in step. Aliased rather than inlined at
   the call sites so this entry's four `assert-teardown-clean!` calls still
   read as the sentences they are."
-  lane/assert-teardown-clean!)
+  rf.bench.hicasso.lane/assert-teardown-clean!)
 
 ;; ---------------------------------------------------------------------------
 ;; One round of one mount witness in one segment
@@ -731,9 +731,9 @@
         expect (into {} (map (juxt :id #(expectation witness %))) arms)
         acc    (atom (zipmap (map :id arms) (repeat [])))]
     (dotimes [s (+ warmup samples)]
-      (doseq [j (lane/slot-order n s)]
+      (doseq [j (rf.bench.hicasso.lane/slot-order n s)]
         (let [arm (nth arms j)
-              {:keys [ms mounts]} (lane/mount-batch! arm props k)
+              {:keys [ms mounts]} (rf.bench.hicasso.lane/mount-batch! arm props k)
               {exp-elements :elements verify :verify} (get expect (:id arm))]
           ;; EVERY mount is read back out of the document against THIS
           ;; ARM'S OWN arithmetic — its exact element count, and both ends
@@ -742,18 +742,18 @@
           ;; rendered only its base prefix is the cheapest 2x arm; this is
           ;; the line that catches both.
           (doseq [m mounts]
-            (let [ok? (and (= exp-elements (lane/element-count (:container m)))
+            (let [ok? (and (= exp-elements (rf.bench.hicasso.lane/element-count (:container m)))
                            (verify (:container m)))]
               (swap! t (fn [{:keys [of bad]}]
                          {:of (inc of) :bad (if ok? bad (inc bad))}))))
-          (doseq [m mounts] (lane/release! m))
+          (doseq [m mounts] (rf.bench.hicasso.lane/release! m))
           (let [label (str (name id) "/" (name segment-id) "/" (name (:id arm)))]
             (if (>= s warmup)
-              (do (lane/collect! coll label ms)
+              (do (rf.bench.hicasso.lane/collect! coll label ms)
                   (swap! acc update (:id arm) conj ms))
               ;; A warm-up sample is DISCARDED but it still ran, so it is
               ;; still the next sample's predecessor.
-              (lane/observe! coll label))))))
+              (rf.bench.hicasso.lane/observe! coll label))))))
     @acc))
 
 ;; ---------------------------------------------------------------------------
@@ -780,7 +780,7 @@
   DISTINCT (they are `(mod (* 7 o) 300)` over consecutive `o`, and 7 is
   coprime with 300, so any run of ten is ten different cells), and the
   microtask-scale tolerance an early op receives grows with `k`
-  ([[lane/verified-writes!]]). Ten buys the clamp headroom and keeps that
+  ([[rf.bench.hicasso.lane/verified-writes!]]). Ten buys the clamp headroom and keeps that
   tolerance at nine turns.
 
   THE BROAD ROW DOES NOT USE THIS. It passes a batch of ONE — the pre-batch
@@ -811,8 +811,8 @@
   (let [n (:cells (:arm mnt))]
     (if (= kind :broad)
       (let [val (next-gen!)]
-        (lane/verified-writes! t mnt [[:all val (lane/bulk-probes val n)]]))
-      (lane/verified-writes!
+        (rf.bench.hicasso.lane/verified-writes! t mnt [[:all val (rf.bench.hicasso.lane/bulk-probes val n)]]))
+      (rf.bench.hicasso.lane/verified-writes!
         t mnt
         (mapv (fn [_]
                 (let [o    (next-op!)
@@ -823,8 +823,8 @@
 
 (defn- seed-bulk!
   [mounts t]
-  (lane/chain nil mounts
-              (fn [_ mnt] (-> (lane/verified-write! t mnt :all 0
+  (rf.bench.hicasso.lane/chain nil mounts
+              (fn [_ mnt] (-> (rf.bench.hicasso.lane/verified-write! t mnt :all 0
                                                     [0 (dec (:cells (:arm mnt)))])
                               (.then (fn [_] nil))))))
 
@@ -837,8 +837,8 @@
   (let [n     (count mounts)
         total (+ (:warmup bulk-sampling) (:samples bulk-sampling))
         acc0  (zipmap (map #(:id (:arm %)) mounts) (repeat []))]
-    (lane/chain {:readings acc0}
-                (for [s (range total) j (lane/slot-order n s)] [s j])
+    (rf.bench.hicasso.lane/chain {:readings acc0}
+                (for [s (range total) j (rf.bench.hicasso.lane/slot-order n s)] [s j])
                 (fn [acc [s j]]
                   (let [mnt   (nth mounts j)
                         id    (:id (:arm mnt))
@@ -846,11 +846,11 @@
                     (-> (bulk-write! t mnt kind s)
                         (.then (fn [{:keys [ms write-ms gap-ms force-ms]}]
                                  (if (>= s (:warmup bulk-sampling))
-                                   (do (lane/collect! coll label ms)
+                                   (do (rf.bench.hicasso.lane/collect! coll label ms)
                                        (swap! legs update [kind segment-id id] (fnil conj [])
                                               {:write write-ms :gap gap-ms :force force-ms})
                                        (update-in acc [:readings id] conj ms))
-                                   (do (lane/observe! coll label)
+                                   (do (rf.bench.hicasso.lane/observe! coll label)
                                        acc))))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -861,13 +861,13 @@
   "One segment-round's raw readings as `{:p50 {id ms} :ratio {id r}}`,
   every ratio against the floor measured in THAT segment of THAT round."
   [readings]
-  (lane/normalise readings :floor))
+  (rf.bench.hicasso.lane/normalise readings :floor))
 
 (defn- range-of [vs]
-  {:mean (lane/round4 (/ (reduce + 0.0 vs) (count vs)))
-   :min  (lane/round4 (apply min vs))
-   :max  (lane/round4 (apply max vs))
-   :per-round (mapv lane/round4 vs)
+  {:mean (rf.bench.hicasso.lane/round4 (/ (reduce + 0.0 vs) (count vs)))
+   :min  (rf.bench.hicasso.lane/round4 (apply min vs))
+   :max  (rf.bench.hicasso.lane/round4 (apply max vs))
+   :per-round (mapv rf.bench.hicasso.lane/round4 vs)
    :straddles-1? (and (<= (apply min vs) 1.0) (>= (apply max vs) 1.0))})
 
 ;; ---------------------------------------------------------------------------
@@ -892,7 +892,7 @@
 
   ## What the arm-order guard cannot see, and why this exists
 
-  `lane/guard!` adjudicates arms INSIDE a segment: it asks whether an arm
+  `rf.bench.hicasso.lane/guard!` adjudicates arms INSIDE a segment: it asks whether an arm
   reads differently for where in the plan it was measured. The red-zone is
   not an arm — it is a ratio of one segment's floor-normalised arm to the
   OTHER segment's, and no guard on this page ever looked at it by segment
@@ -986,7 +986,7 @@
       {:start               start
        :reagent-first       (assoc rf :direction d-rf :n (count (:reagent-first strata)))
        :uix-first           (assoc uf :direction d-uf :n (count (:uix-first strata)))
-       :order-balanced-mean (lane/round4 (/ (+ (:mean rf) (:mean uf)) 2.0))
+       :order-balanced-mean (rf.bench.hicasso.lane/round4 (/ (+ (:mean rf) (:mean uf)) 2.0))
        :balanced-design?    balanced?
        :strata-overlap?     overlap?
        :magnitude-resolved? overlap?
@@ -1023,7 +1023,7 @@
   BOTH TERMS ARE THE REAGENT SEGMENT'S OWN, so the floor divides out
   exactly and the seam is not in the arithmetic at all. The leg is formed
   from the floor-normalised ratios rather than from the raw p50s only
-  because that is the arithmetic `lane/ratio-between` performs on the
+  because that is the arithmetic `rf.bench.hicasso.lane/ratio-between` performs on the
   first author's page, and two authors disagreeing about a division is
   not a finding anybody wants to chase.
 
@@ -1090,7 +1090,7 @@
                          norm)
         ctl-rg     (mapv #(get-in % [:reagent-subs :ratio :ctl-2x]) norm)
         ctl-ux     (mapv #(get-in % [:uix-subs :ratio :ctl-2x]) norm)
-        verdict-of (fn [vs] (lane/control-verdict (:predicted control)
+        verdict-of (fn [vs] (rf.bench.hicasso.lane/control-verdict (:predicted control)
                                                   (select-keys (range-of vs) [:min :max :mean])
                                                   control-slack))
         c-rg       (verdict-of ctl-rg)
@@ -1191,7 +1191,7 @@
   "Canonical-DOM equality across the judged arms, and the element count of
   EVERY arm — the control included — against its own arithmetic.
 
-  The count used to be checked over `lane/parity`'s `counts` map, which
+  The count used to be checked over `rf.bench.hicasso.lane/parity`'s `counts` map, which
   excludes the parity-exempt arms by design, so the one arm building a
   deliberately different page had that page checked nowhere. Exempt from
   the EQUALITY is not exempt from arithmetic: the control is exempt
@@ -1199,12 +1199,12 @@
   exists to make."
   [{:keys [id props arms-for] :as witness} segment-id ratom?]
   (let [{:keys [mounts agree? disagree reference]}
-        (lane/parity (arms-for segment-id ratom?) props)
+        (rf.bench.hicasso.lane/parity (arms-for segment-id ratom?) props)
         wrong (into {}
                     (comp (map (fn [{:keys [arm container]}]
                                  [(:id arm)
                                   {:expected (:elements (expectation witness arm))
-                                   :got      (lane/element-count container)}]))
+                                   :got      (rf.bench.hicasso.lane/element-count container)}]))
                           (remove (fn [[_ {:keys [expected got]}]] (= expected got))))
                     mounts)]
     (try
@@ -1217,7 +1217,7 @@
                     (seq wrong)
                     (conj {:segment segment-id :witness id :problem :element-count
                            :arms wrong}))}
-      (finally (doseq [m mounts] (lane/release! m))))))
+      (finally (doseq [m mounts] (rf.bench.hicasso.lane/release! m))))))
 
 (defn- parity!
   "Both segments' parity for this page's witness, plus the CROSS-segment
@@ -1274,12 +1274,12 @@
   arm runs is part of its window: changing it would move numbers that
   nothing here is re-running."
   []
-  (> (count (distinct (map #(guard/slot-order 2 %) (range 8)))) 1))
+  (> (count (distinct (map #(rf.bench.order-guard/slot-order 2 %) (range 8)))) 1))
 
 (defn- slot-order-varies-at-3?
   "And the three-arm plan this entry actually runs must NOT degenerate."
   []
-  (> (count (distinct (map #(guard/slot-order 3 %) (range 8)))) 1))
+  (> (count (distinct (map #(rf.bench.order-guard/slot-order 3 %) (range 8)))) 1))
 
 (defn- slot-order-varies-at-4?
   "Nor the FOUR-arm plan the Reagent segment runs under `?ratom=on`.
@@ -1289,17 +1289,17 @@
   that only fires on the days it is needed is an assertion nobody
   maintains. That is precisely how the `k = 2` one rotted."
   []
-  (> (count (distinct (map #(guard/slot-order 4 %) (range 8)))) 1))
+  (> (count (distinct (map #(rf.bench.order-guard/slot-order 4 %) (range 8)))) 1))
 
 ;; ---------------------------------------------------------------------------
 ;; The run
 ;; ---------------------------------------------------------------------------
 
 (def ^:private bulk-control
-  {:predicted (/ (double (v/m1-elements (* 2 v/cells-n)))
-                 (double (v/m1-elements v/cells-n)))
-   :basis (str "element count: " (v/m1-elements (* 2 v/cells-n)) " / "
-               (v/m1-elements v/cells-n))})
+  {:predicted (/ (double (rf.bench.hicasso.p0-reagent-views/m1-elements (* 2 rf.bench.hicasso.p0-reagent-views/cells-n)))
+                 (double (rf.bench.hicasso.p0-reagent-views/m1-elements rf.bench.hicasso.p0-reagent-views/cells-n)))
+   :basis (str "element count: " (rf.bench.hicasso.p0-reagent-views/m1-elements (* 2 rf.bench.hicasso.p0-reagent-views/cells-n)) " / "
+               (rf.bench.hicasso.p0-reagent-views/m1-elements rf.bench.hicasso.p0-reagent-views/cells-n))})
 
 (def ^:private row-specs
   "ONE ROW PER PAGE. The first cut ran all four in one page and the guard
@@ -1311,11 +1311,11 @@
   {:M1     {:kind :mount :witness :M1 :row :mount-M1 :grade :bar}
    :M2     {:kind :mount :witness :M2 :row :mount-M2 :grade :diagnostic}
    :broad  {:kind :bulk  :witness :M1 :row :bulk-broad :grade :bar
-            :doc (str "one commit that all " v/cells-n " sub-reading boundaries read, on "
+            :doc (str "one commit that all " rf.bench.hicasso.p0-reagent-views/cells-n " sub-reading boundaries read, on "
                       "rf2-2rtt6.2's M1 page — the make-or-break row")
             :control bulk-control}
    :narrow {:kind :bulk  :witness :M1 :row :bulk-narrow :grade :bar
-            :doc (str narrow-batch-k " commits, each of which exactly ONE of " v/cells-n
+            :doc (str narrow-batch-k " commits, each of which exactly ONE of " rf.bench.hicasso.p0-reagent-views/cells-n
                       " sub-reading boundaries reads, all inside ONE timed window — the "
                       "localisation row. The per-commit figure is the sample divided by "
                       narrow-batch-k)
@@ -1356,7 +1356,7 @@
   `start` leads round 0 and the order alternates from there. Answers a
   promise of `{segment-id readings}`."
   [{:keys [kind witness] :as _spec} row-key start ratom? r coll t legs]
-  (lane/chain
+  (rf.bench.hicasso.lane/chain
     {}
     (segment-order start r)
     (fn [acc {:keys [id] :as segment}]
@@ -1382,9 +1382,9 @@
 (defn- leg-summary [legs]
   (into {}
         (map (fn [[k xs]]
-               [k {:write-ms (:p50 (lane/summarise (map :write xs)))
-                   :gap-ms   (:p50 (lane/summarise (map :gap xs)))
-                   :force-ms (:p50 (lane/summarise (map :force xs)))}]))
+               [k {:write-ms (:p50 (rf.bench.hicasso.lane/summarise (map :write xs)))
+                   :gap-ms   (:p50 (rf.bench.hicasso.lane/summarise (map :gap xs)))
+                   :force-ms (:p50 (rf.bench.hicasso.lane/summarise (map :force xs)))}]))
         legs))
 
 (defn- publish!
@@ -1401,10 +1401,10 @@
                      :writes-per-sample (if (= row :bulk-narrow) narrow-batch-k 1)
                      :start start}
                     slices)]
-    (lane/record! (name row) record)
-    (lane/record! "verification" {row-key (lane/tally-value t)})
-    (when (= kind :bulk) (lane/record! "write-legs" (leg-summary @legs)))
-    (lane/record! "red-zone"
+    (rf.bench.hicasso.lane/record! (name row) record)
+    (rf.bench.hicasso.lane/record! "verification" {row-key (rf.bench.hicasso.lane/tally-value t)})
+    (when (= kind :bulk) (rf.bench.hicasso.lane/record! "write-legs" (leg-summary @legs)))
+    (rf.bench.hicasso.lane/record! "red-zone"
                   {:row row
                    :axis :clock
                    :witness-set "rf2-2rtt6.2"
@@ -1452,7 +1452,7 @@
                               "own witnesses — that figure remains sound as a ratio and is "
                               "simply not comparable with the bar rows.")})
     (when-let [leg (:reactive-leg record)]
-      (lane/record! "reactive-leg"
+      (rf.bench.hicasso.lane/record! "reactive-leg"
                     {:row row
                      :axis :clock
                      :witness-set "rf2-2rtt6.2"
@@ -1482,9 +1482,9 @@
                           "systematic error in how the arm is written; this row is the "
                           "second implementation, and agreement or disagreement with those "
                           "figures is the finding either way.")}))
-    (let [vd (lane/guard! (:samples @coll)
+    (let [vd (rf.bench.hicasso.lane/guard! (:samples @coll)
                           (str "Hicasso P0 converged — " (name row)))]
-      (lane/record! "arm-order-guard"
+      (rf.bench.hicasso.lane/record! "arm-order-guard"
                     {:row row
                      :tolerance (:tolerance vd)
                      :contaminated? (:contaminated? vd)
@@ -1511,40 +1511,40 @@
     ;; M` with N > 0 and the driver would still exit 0, which is what left
     ;; every read-back in this entry — the written cell, the mount's element
     ;; count, the far end of the page — decorative.
-    (lane/assert-verified! t (str "row " (name row)))
+    (rf.bench.hicasso.lane/assert-verified! t (str "row " (name row)))
     nil))
 
 (defn ^:export -main
   []
   (try
-    (lane/leave-act-environment!)
+    (rf.bench.hicasso.lane/leave-act-environment!)
     (cond
-      (not (lane/self-test!))
-      (do (lane/fail! (str "the arm-order guard's SELF-TEST failed — this copy of the rule "
+      (not (rf.bench.hicasso.lane/self-test!))
+      (do (rf.bench.hicasso.lane/fail! (str "the arm-order guard's SELF-TEST failed — this copy of the rule "
                            "no longer behaves like the one the .cjs drivers use, so nothing "
                            "was measured"))
-          (lane/done!))
+          (rf.bench.hicasso.lane/done!))
 
       (not (slot-order-varies-at-2?))
-      (do (lane/fail! (str "slot-order has DEGENERATED at k=2 — it emits one order at every "
+      (do (rf.bench.hicasso.lane/fail! (str "slot-order has DEGENERATED at k=2 — it emits one order at every "
                            "sample index, which is the rf2-ouwh8 defect returning. This entry "
                            "runs three arms and is not itself affected, but the shared rule it "
                            "takes its schedule from is, so nothing here is measured until the "
                            "rule is repaired. The repair belongs to the schedule, never to the "
                            "tolerance"))
-          (lane/done!))
+          (rf.bench.hicasso.lane/done!))
 
       (not (slot-order-varies-at-3?))
-      (do (lane/fail! (str "slot-order emits ONE order at k=3, so the three-arm plan this "
+      (do (rf.bench.hicasso.lane/fail! (str "slot-order emits ONE order at k=3, so the three-arm plan this "
                            "entry runs is a single-order plan and `both orders` would be a "
                            "claim it cannot support"))
-          (lane/done!))
+          (rf.bench.hicasso.lane/done!))
 
       (not (slot-order-varies-at-4?))
-      (do (lane/fail! (str "slot-order emits ONE order at k=4, so the four-arm Reagent "
+      (do (rf.bench.hicasso.lane/fail! (str "slot-order emits ONE order at k=4, so the four-arm Reagent "
                            "segment `?ratom=on` runs would be a single-order plan and the "
                            "reactive leg could not claim `both orders` either"))
-          (lane/done!))
+          (rf.bench.hicasso.lane/done!))
 
       :else
       (let [row-key (query-row)
@@ -1560,7 +1560,7 @@
             ;; reactions whose roots have unmounted but not yet been
             ;; disposed, and every one of them would re-render. Outside the
             ;; window, but it is work the page does not need to do.
-            _       (reset! v/ratom-cells (:cells (v/seed-cells v/cells-n 0)))
+            _       (reset! rf.bench.hicasso.p0-reagent-views/ratom-cells (:cells (rf.bench.hicasso.p0-reagent-views/seed-cells rf.bench.hicasso.p0-reagent-views/cells-n 0)))
             {:keys [problems]} (parity! w ratom?)]
         (js/console.log (str ";; HICASSO row " (name row-key)
                              " — round 0 led by " (name start) ", alternating"
@@ -1569,7 +1569,7 @@
                                     "segment runs "
                                     (pr-str (reagent-segment-arm-ids row-key true))
                                     " (rf2-2rtt6.21)"))))
-        (lane/record! "parity"
+        (rf.bench.hicasso.lane/record! "parity"
                       {:row row-key :problems problems :ok? (empty? problems)
                        :note (str "canonical DOM with attribute names sorted, inside each "
                                   "segment AND across the seam. The element count is checked "
@@ -1579,23 +1579,23 @@
                                   "rendered nothing, and for a 2x control that rendered "
                                   "only its base prefix.")})
         (if (seq problems)
-          (do (lane/fail! (str "the arms do not build the same page under :advanced — "
+          (do (rf.bench.hicasso.lane/fail! (str "the arms do not build the same page under :advanced — "
                                (pr-str problems)))
-              (lane/done!))
-          (let [coll (lane/sample-collector)
-                t    (lane/tally)
+              (rf.bench.hicasso.lane/done!))
+          (let [coll (rf.bench.hicasso.lane/sample-collector)
+                t    (rf.bench.hicasso.lane/tally)
                 legs (atom {})]
-            (-> (lane/chain [] (range rounds)
+            (-> (rf.bench.hicasso.lane/chain [] (range rounds)
                             (fn [acc r]
                               (-> (run-round! spec row-key start ratom? r coll t legs)
                                   (.then (fn [slice] (conj acc slice))))))
                 (.then (fn [slices]
                          (publish! spec row-key start slices t legs coll)
-                         (lane/done!)
+                         (rf.bench.hicasso.lane/done!)
                          nil))
                 (.catch (fn [e]
-                          (lane/fail! (str "the run rejected: " e))
-                          (lane/done!))))))))
+                          (rf.bench.hicasso.lane/fail! (str "the run rejected: " e))
+                          (rf.bench.hicasso.lane/done!))))))))
     (catch :default e
-      (lane/fail! (str "the run threw: " e))
-      (lane/done!))))
+      (rf.bench.hicasso.lane/fail! (str "the run threw: " e))
+      (rf.bench.hicasso.lane/done!))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs
@@ -77,7 +77,7 @@
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.set :as set]
             [clojure.walk :as walk]
-            [re-frame.bench.hicasso.p0-converge-app :as app]))
+            [re-frame.bench.hicasso.p0-converge-app :as rf.bench.hicasso.p0-converge-app]))
 
 ;; ---------------------------------------------------------------------------
 ;; The published vectors
@@ -107,7 +107,7 @@
   "Replay a PUBLISHED five-round vector. Every published five-round run
   was Reagent-start, and the start is stated rather than defaulted."
   [vs]
-  (app/segment-order-verdict vs 5 :reagent-subs))
+  (rf.bench.hicasso.p0-converge-app/segment-order-verdict vs 5 :reagent-subs))
 
 (defn- close-to?
   "Within `tol`. Every figure below is quoted from the studio page at
@@ -213,7 +213,7 @@
            UIx-first rounds reading 0.7 is a figure that says `slower`
            when one segment leads and `faster` when the other does — no
            direction to publish, and the run must not"
-    (let [r (app/segment-order-verdict [1.40 0.70 1.45 0.72 1.38] 5 :reagent-subs)]
+    (let [r (rf.bench.hicasso.p0-converge-app/segment-order-verdict [1.40 0.70 1.45 0.72 1.38] 5 :reagent-subs)]
       (is (= :numerator-slower (:direction (:reagent-first r))))
       (is (= :numerator-faster (:direction (:uix-first r))))
       (is (false? (:direction-agrees? r)))
@@ -235,7 +235,7 @@
            construction — the repair rf2-6i0i2 took, and the design the
            entry now runs"
     (let [vs [1.10 1.20 1.30 1.40 1.50 1.60]
-          r  (app/segment-order-verdict vs 6 :reagent-subs)]
+          r  (rf.bench.hicasso.p0-converge-app/segment-order-verdict vs 6 :reagent-subs)]
       (is (true? (:balanced-design? r)))
       (is (= 3 (:n (:reagent-first r))))
       (is (= 3 (:n (:uix-first r))))
@@ -254,8 +254,8 @@
            which is exactly the confound the counterbalanced runs exist
            to break"
     (let [vs [1.30 1.10 1.25 1.12 1.35 1.11]
-          r  (app/segment-order-verdict vs 6 :reagent-subs)
-          u  (app/segment-order-verdict vs 6 :uix-subs)]
+          r  (rf.bench.hicasso.p0-converge-app/segment-order-verdict vs 6 :reagent-subs)
+          u  (rf.bench.hicasso.p0-converge-app/segment-order-verdict vs 6 :uix-subs)]
       (is (= :reagent-subs (:start r)))
       (is (= :uix-subs (:start u)))
       (is (= [1.30 1.25 1.35] (:per-round (:reagent-first r))))
@@ -268,8 +268,8 @@
            vector that refuses under one start refuses under the other
            with the directions exchanged"
     (let [vs [1.40 0.70 1.45 0.72 1.38 0.69]
-          r  (app/segment-order-verdict vs 6 :reagent-subs)
-          u  (app/segment-order-verdict vs 6 :uix-subs)]
+          r  (rf.bench.hicasso.p0-converge-app/segment-order-verdict vs 6 :reagent-subs)
+          u  (rf.bench.hicasso.p0-converge-app/segment-order-verdict vs 6 :uix-subs)]
       (is (= :numerator-slower (:direction (:reagent-first r))))
       (is (= :numerator-faster (:direction (:reagent-first u))))
       (is (true? (:refuse? r)))
@@ -306,7 +306,7 @@
            {:start :uix-subs     :vs [2.7222 2.4210 2.4444 2.8750 2.3889 2.3889]}]})
 
 (defn- legs [row] (map (fn [{:keys [vs start]}]
-                         (app/segment-order-verdict vs 6 start "the reactive leg's"))
+                         (rf.bench.hicasso.p0-converge-app/segment-order-verdict vs 6 start "the reactive leg's"))
                        (get leg row)))
 
 (deftest every-published-leg-run-resolves-a-magnitude
@@ -572,7 +572,7 @@
   readings give 877/1024 = 0.8564, which is the 0.856 the page
   publishes. A displayed number is not an input."
   [vs start]
-  (let [r (app/segment-order-verdict vs 6 start)]
+  (let [r (rf.bench.hicasso.p0-converge-app/segment-order-verdict vs 6 start)]
     (js/Math.log (/ (mean (:per-round (:reagent-first r)))
                     (mean (:per-round (:uix-first r)))))))
 
@@ -815,7 +815,7 @@
 
 (defn- strata-of [row]
   (mapcat (fn [run]
-            (let [v (app/segment-order-verdict (get run row) 6 (:start run))]
+            (let [v (rf.bench.hicasso.p0-converge-app/segment-order-verdict (get run row) 6 (:start run))]
               [(:reagent-first v) (:uix-first v)]))
           ensemble))
 
@@ -840,7 +840,7 @@
            are the individually-unpublishable points the aggregate rule
            deliberately keeps in the ensemble"
     (let [verdicts (for [run ensemble row rows]
-                     [(:run run) row (app/segment-order-verdict (get run row) 6 (:start run))])
+                     [(:run run) row (rf.bench.hicasso.p0-converge-app/segment-order-verdict (get run row) 6 (:start run))])
           unresolved (remove #(:magnitude-resolved? (nth % 2)) verdicts)]
       (is (= 37 (count (filter #(:magnitude-resolved? (nth % 2)) verdicts))))
       (is (= 3 (count unresolved)))
@@ -854,7 +854,7 @@
            40`, which is the discredited 11-of-12 restated on the
            balanced design and no longer an effect"
     (is (= 23 (count (for [run ensemble row rows
-                           :let [v (app/segment-order-verdict (get run row) 6 (:start run))]
+                           :let [v (rf.bench.hicasso.p0-converge-app/segment-order-verdict (get run row) 6 (:start run))]
                            :when (> (:mean (:reagent-first v)) (:mean (:uix-first v)))]
                        [(:run run) row]))))))
 
@@ -1186,7 +1186,7 @@
            rather than quoted: the two order strata point opposite ways
            across 1.0, so `segment-order-verdict` refuses and the driver
            exits 1. The driver was right"
-    (let [vd (app/segment-order-verdict (:M1 run-5-per-round) 6 :reagent-subs)]
+    (let [vd (rf.bench.hicasso.p0-converge-app/segment-order-verdict (:M1 run-5-per-round) 6 :reagent-subs)]
       (is (true? (:refuse? vd)))
       (is (false? (:direction-agrees? vd)))
       (is (false? (:magnitude-resolved? vd)))
@@ -1198,7 +1198,7 @@
            overlap and every one resolves a magnitude. Run 5 is not a bad
            run; it is a run whose M1 sat on parity"
     (doseq [row [:M2 :broad :narrow]]
-      (let [vd (app/segment-order-verdict (get run-5-per-round row) 6 :reagent-subs)]
+      (let [vd (rf.bench.hicasso.p0-converge-app/segment-order-verdict (get run-5-per-round row) 6 :reagent-subs)]
         (is (false? (:refuse? vd)) (str (name row) " — no refusal"))
         (is (true? (:magnitude-resolved? vd)) (str (name row) " — magnitude resolved"))
         (is (close? (get (nth retake 4) row) (mean (get run-5-per-round row)))
@@ -1292,7 +1292,7 @@
 ;; natural flagged invocation.
 ;;
 ;; Three facts, in the order the run establishes them: which arms the row's
-;; PLAN plants, what [[app/ratom-leg]] DECIDES from a round, and what the
+;; PLAN plants, what [[rf.bench.hicasso.p0-converge-app/ratom-leg]] DECIDES from a round, and what the
 ;; RECORD then publishes. Pure arithmetic over constants — no DOM, no clock,
 ;; no browser, like everything else in this namespace.
 
@@ -1311,7 +1311,7 @@
            every assertion below rests on, and it is asked of the entry's
            own plan rather than restated beside it"
     (doseq [row flagged-rows]
-      (let [ids (set (app/reagent-segment-arm-ids row true))]
+      (let [ids (set (rf.bench.hicasso.p0-converge-app/reagent-segment-arm-ids row true))]
         (is (contains? ids :reagent-subs) (str row " must always run the denominator"))
         (is (= (contains? rows-carrying-the-arm row)
                (contains? ids :reagent-ratom))
@@ -1320,7 +1320,7 @@
            unflagged invocation the instrument the four published rows
            were measured on"
     (doseq [row flagged-rows]
-      (is (not (contains? (set (app/reagent-segment-arm-ids row false)) :reagent-ratom))
+      (is (not (contains? (set (rf.bench.hicasso.p0-converge-app/reagent-segment-arm-ids row false)) :reagent-ratom))
           (str row " under HICASSO_RATOM=off")))))
 
 (deftest the-leg-is-formed-only-when-every-round-measured-the-arm
@@ -1329,21 +1329,21 @@
                                      ratom (assoc :reagent-ratom ratom))}})]
     (testing "six rounds that all measured the arm: the leg is 4.0 / 3.0,
              once per round"
-      (let [l (app/ratom-leg (mapv round (repeat 6 3.0)))]
+      (let [l (rf.bench.hicasso.p0-converge-app/ratom-leg (mapv round (repeat 6 3.0)))]
         (is (= 6 (count l)))
         (is (every? #(close? 1.3333 %) l))))
     (testing "no round measured it — nil, and NOT a quotient over a
              denominator that was never taken. This is the M2 and narrow
              case, and `subs / nil` is `Infinity` in JavaScript rather
              than an error, so nothing downstream would have complained"
-      (is (nil? (app/ratom-leg (mapv round (repeat 6 nil))))))
+      (is (nil? (rf.bench.hicasso.p0-converge-app/ratom-leg (mapv round (repeat 6 nil))))))
     (testing "a PARTIAL arm is no arm: one round short and the leg is nil,
              because a figure that quietly changes what it averages over
              is worse than one that is absent"
-      (is (nil? (app/ratom-leg (mapv round [3.0 3.0 3.0 3.0 3.0 nil])))))
+      (is (nil? (rf.bench.hicasso.p0-converge-app/ratom-leg (mapv round [3.0 3.0 3.0 3.0 3.0 nil])))))
     (testing "and a zero denominator divides to Infinity, so it is refused
              at the same door"
-      (is (nil? (app/ratom-leg (mapv round (repeat 6 0.0))))))))
+      (is (nil? (rf.bench.hicasso.p0-converge-app/ratom-leg (mapv round (repeat 6 0.0))))))))
 
 (def ^:private synthetic-ms
   "One reading vector per arm id, constant, so every ratio the record
@@ -1361,9 +1361,9 @@
   of that row's ACTUAL flagged arm set. The Reagent segment's arms come
   from the entry's own plan, so no premise is transcribed here."
   [row]
-  (let [reagent-arms (select-keys synthetic-ms (app/reagent-segment-arm-ids row true))
+  (let [reagent-arms (select-keys synthetic-ms (rf.bench.hicasso.p0-converge-app/reagent-segment-arm-ids row true))
         uix-arms     (select-keys synthetic-ms [:floor :uix-subs :ctl-2x])]
-    (:record (app/row-record
+    (:record (rf.bench.hicasso.p0-converge-app/row-record
                {:row row
                 :grade :bar
                 :doc "a contract fixture, not a measurement"

--- a/bench/hicasso/src/re_frame/bench/hicasso/p0_reagent_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/p0_reagent_app.cljs
@@ -27,17 +27,17 @@
      every pair. A release that threw is fatal, and so is a release that
      returned normally without releasing — observed twice over: every
      unmount's container is read BEFORE it is detached
-     (`lane/container-released!` — a React root's unmount empties its
+     (`rf.bench.hicasso.lane/container-released!` — a React root's unmount empties its
      container synchronously, so a populated one is a root that was never
-     released), and `lane/residue` reads the attached-container count, the
+     released), and `rf.bench.hicasso.lane/residue` reads the attached-container count, the
      frame's subscription ref-counts AND the watch count on
-     `v/ratom-cells` back to the empty-page baseline, because the ratom
+     `rf.bench.hicasso.p0-reagent-views/ratom-cells` back to the empty-page baseline, because the ratom
      arms' live references sit on that namespace-level atom where neither
      built-in counter can see them. The settle is not politeness to the
      assertion — a mount row is wholly synchronous and Reagent's disposals
      are queued on a macrotask, so without it row N+1 begins on a page
      still carrying every consumer reaction row N mounted
-     (`lane/settle!` carries the three-point measurement).
+     (`rf.bench.hicasso.lane/settle!` carries the three-point measurement).
   4. **The positive control's verdict**, then the guard's.
 
   Nothing publishes until the guard has spoken. `run.cjs` prints the
@@ -52,11 +52,11 @@
   `shadow-cljs.edn`."
   (:require ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.p0-reagent-views :as v]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.p0-reagent-views :as rf.bench.hicasso.p0-reagent-views]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
+            [re-frame.frame :as rf.frame]
             [reagent.core :as r]
             [reagent.dom.client :as rdc]))
 
@@ -128,8 +128,8 @@
   twice the page was the one arm nothing checked past its first half."
   [n]
   (fn [container]
-    (and (= "0" (lane/text-at container 0))
-         (= "0" (lane/text-at container (dec n))))))
+    (and (= "0" (rf.bench.hicasso.lane/text-at container 0))
+         (= "0" (rf.bench.hicasso.lane/text-at container (dec n))))))
 
 (defn- verify-m2
   "The first and last field AT THE ARM'S OWN SIZE — `n` fields, so the far
@@ -137,8 +137,8 @@
   PREFIX and could not tell a doubled form from a base one."
   [n]
   (fn [container]
-    (and (= (v/field-value 0 0) (input-value container "#f0"))
-         (= (v/field-value (dec n) 0)
+    (and (= (rf.bench.hicasso.p0-reagent-views/field-value 0 0) (input-value container "#f0"))
+         (= (rf.bench.hicasso.p0-reagent-views/field-value (dec n) 0)
             (input-value container (str "#f" (dec n)))))))
 
 (defn- expectation
@@ -163,23 +163,23 @@
 (def ^:private mount-witnesses
   [{:id          :M1
     :verify-of   verify-m1
-    :elements-of v/m1-elements
+    :elements-of rf.bench.hicasso.p0-reagent-views/m1-elements
     :doc      (str "the 300-boundary sub-reading list — the bulk shape's mount "
                    "counterpart, one subscription read per boundary")
-    :props    {:n v/cells-n}
-    :control  {:predicted (/ (double (v/m1-elements (* 2 v/cells-n)))
-                             (double (v/m1-elements v/cells-n)))
-               :basis     (str "element count: " (v/m1-elements (* 2 v/cells-n)) " / "
-                               (v/m1-elements v/cells-n))}
-    :arms [(floor-mount-arm :floor v/m1-floor (fn [{:keys [n]}] (zeros n)))
+    :props    {:n rf.bench.hicasso.p0-reagent-views/cells-n}
+    :control  {:predicted (/ (double (rf.bench.hicasso.p0-reagent-views/m1-elements (* 2 rf.bench.hicasso.p0-reagent-views/cells-n)))
+                             (double (rf.bench.hicasso.p0-reagent-views/m1-elements rf.bench.hicasso.p0-reagent-views/cells-n)))
+               :basis     (str "element count: " (rf.bench.hicasso.p0-reagent-views/m1-elements (* 2 rf.bench.hicasso.p0-reagent-views/cells-n)) " / "
+                               (rf.bench.hicasso.p0-reagent-views/m1-elements rf.bench.hicasso.p0-reagent-views/cells-n))}
+    :arms [(floor-mount-arm :floor rf.bench.hicasso.p0-reagent-views/m1-floor (fn [{:keys [n]}] (zeros n)))
            (reagent-mount-arm :reagent-subs
-                              (fn [{:keys [n]}] [v/subs-root v/m1-subs n]))
-           (reagent-mount-arm :reagent-ratom (fn [{:keys [n]}] [v/m1-ratom n]))
-           (floor-mount-arm :ctl-2x v/m1-floor (fn [{:keys [n]}] (zeros (* 2 n))) 2)]}
+                              (fn [{:keys [n]}] [rf.bench.hicasso.p0-reagent-views/subs-root rf.bench.hicasso.p0-reagent-views/m1-subs n]))
+           (reagent-mount-arm :reagent-ratom (fn [{:keys [n]}] [rf.bench.hicasso.p0-reagent-views/m1-ratom n]))
+           (floor-mount-arm :ctl-2x rf.bench.hicasso.p0-reagent-views/m1-floor (fn [{:keys [n]}] (zeros (* 2 n))) 2)]}
 
    {:id          :M2
     :verify-of   verify-m2
-    :elements-of v/m2-elements
+    :elements-of rf.bench.hicasso.p0-reagent-views/m2-elements
     ;; ONE mount per sample, and the batching that would have lifted this
     ;; witness clear of Chrome's 100 µs clamp is NOT USED. It was tried —
     ;; eight mounts in one `flushSync` — and THE ARM-ORDER GUARD REFUSED
@@ -207,16 +207,16 @@
                      "form shape shows no LARGE reactive-system penalty on mount.")
     :doc      (str "the ordinary 12-field form on subs — the shape most "
                    "applications are made of")
-    :props    {:n v/fields-n}
-    :control  {:predicted (/ (double (v/m2-elements (* 2 v/fields-n)))
-                             (double (v/m2-elements v/fields-n)))
-               :basis     (str "element count: " (v/m2-elements (* 2 v/fields-n)) " / "
-                               (v/m2-elements v/fields-n))}
-    :arms [(floor-mount-arm :floor v/m2-floor (fn [{:keys [n]}] (zeros n)))
+    :props    {:n rf.bench.hicasso.p0-reagent-views/fields-n}
+    :control  {:predicted (/ (double (rf.bench.hicasso.p0-reagent-views/m2-elements (* 2 rf.bench.hicasso.p0-reagent-views/fields-n)))
+                             (double (rf.bench.hicasso.p0-reagent-views/m2-elements rf.bench.hicasso.p0-reagent-views/fields-n)))
+               :basis     (str "element count: " (rf.bench.hicasso.p0-reagent-views/m2-elements (* 2 rf.bench.hicasso.p0-reagent-views/fields-n)) " / "
+                               (rf.bench.hicasso.p0-reagent-views/m2-elements rf.bench.hicasso.p0-reagent-views/fields-n))}
+    :arms [(floor-mount-arm :floor rf.bench.hicasso.p0-reagent-views/m2-floor (fn [{:keys [n]}] (zeros n)))
            (reagent-mount-arm :reagent-subs
-                              (fn [{:keys [n]}] [v/subs-root v/m2-subs n]))
-           (reagent-mount-arm :reagent-ratom (fn [{:keys [n]}] [v/m2-ratom n]))
-           (floor-mount-arm :ctl-2x v/m2-floor (fn [{:keys [n]}] (zeros (* 2 n))) 2)]}])
+                              (fn [{:keys [n]}] [rf.bench.hicasso.p0-reagent-views/subs-root rf.bench.hicasso.p0-reagent-views/m2-subs n]))
+           (reagent-mount-arm :reagent-ratom (fn [{:keys [n]}] [rf.bench.hicasso.p0-reagent-views/m2-ratom n]))
+           (floor-mount-arm :ctl-2x rf.bench.hicasso.p0-reagent-views/m2-floor (fn [{:keys [n]}] (zeros (* 2 n))) 2)]}])
 
 ;; ---------------------------------------------------------------------------
 ;; Bulk arms — mounted once, then written to
@@ -233,7 +233,7 @@
      :mount          (fn [container]
                        (let [root (react-dom-client/createRoot container)]
                          (vreset! rt root)
-                         (react-dom/flushSync (fn [] (.render root (v/m1-floor @state))))
+                         (react-dom/flushSync (fn [] (.render root (rf.bench.hicasso.p0-reagent-views/m1-floor @state))))
                          root))
      ;; The render lives in `force!`, not in `write!`, and that is not a
      ;; convenience. `root.render` called outside a React event schedules
@@ -244,19 +244,19 @@
      ;; samples ending on a cell that still held its old value.
      :write!         (fn [_i val] (reset! state (vec (repeat n val))))
      :force!         (fn [] (react-dom/flushSync
-                              (fn [] (.render ^js @rt (v/m1-floor @state)))))
+                              (fn [] (.render ^js @rt (rf.bench.hicasso.p0-reagent-views/m1-floor @state)))))
      :unmount        (fn [root] (react-dom/flushSync (fn [] (.unmount root))))}))
 
 (defn- subs-bulk-arm []
   {:id      :reagent-subs
-   :cells   v/cells-n
+   :cells   rf.bench.hicasso.p0-reagent-views/cells-n
    :mount   (fn [container]
               (let [root (rdc/create-root container)]
                 (react-dom/flushSync
-                  (fn [] (rdc/render root [v/subs-root v/m1-subs v/cells-n])))
+                  (fn [] (rdc/render root [rf.bench.hicasso.p0-reagent-views/subs-root rf.bench.hicasso.p0-reagent-views/m1-subs rf.bench.hicasso.p0-reagent-views/cells-n])))
                 root))
    :write!  (fn [_i val]
-              (frame/replace-app-db! v/subs-frame (v/seed-cells v/cells-n val)))
+              (rf.frame/replace-app-db! rf.bench.hicasso.p0-reagent-views/subs-frame (rf.bench.hicasso.p0-reagent-views/seed-cells rf.bench.hicasso.p0-reagent-views/cells-n val)))
    ;; `reagent.core/flush` is Reagent's own documented synchronous render
    ;; drain, and it is the SAME drain the ratom arm uses. Both Reagent arms
    ;; therefore differ in exactly one thing — where the value came from —
@@ -266,40 +266,40 @@
 
 (defn- ratom-bulk-arm []
   {:id      :reagent-ratom
-   :cells   v/cells-n
+   :cells   rf.bench.hicasso.p0-reagent-views/cells-n
    :mount   (fn [container]
               (let [root (rdc/create-root container)]
                 (react-dom/flushSync
-                  (fn [] (rdc/render root [v/m1-ratom v/cells-n])))
+                  (fn [] (rdc/render root [rf.bench.hicasso.p0-reagent-views/m1-ratom rf.bench.hicasso.p0-reagent-views/cells-n])))
                 root))
-   :write!  (fn [_i val] (reset! v/ratom-cells (vec (repeat v/cells-n val))))
+   :write!  (fn [_i val] (reset! rf.bench.hicasso.p0-reagent-views/ratom-cells (vec (repeat rf.bench.hicasso.p0-reagent-views/cells-n val))))
    :force!  (fn [] (react-dom/flushSync (fn [] (r/flush))))
    :unmount (fn [root] (react-dom/flushSync (fn [] (rdc/unmount root))))})
 
 (defn- make-bulk-arms []
-  [(floor-bulk-arm :floor v/cells-n)
+  [(floor-bulk-arm :floor rf.bench.hicasso.p0-reagent-views/cells-n)
    (subs-bulk-arm)
    (ratom-bulk-arm)
-   (floor-bulk-arm :ctl-2x (* 2 v/cells-n) 2)])
+   (floor-bulk-arm :ctl-2x (* 2 rf.bench.hicasso.p0-reagent-views/cells-n) 2)])
 
 (defn- mount-bulk-arms!
   "Mount every bulk arm once and CHECK THE PAGE IT BUILT, before a clock is
   read.
 
-  Every bulk arm declares `:cells`, and `v/m1-elements` turns that into an
+  Every bulk arm declares `:cells`, and `rf.bench.hicasso.p0-reagent-views/m1-elements` turns that into an
   element count by written arithmetic — so this one line is what makes the
   bulk `:ctl-2x` arm's doubled page load-bearing. Its far-end read-back
-  already derives from `:cells` (`lane/bulk-probes` probes index
+  already derives from `:cells` (`rf.bench.hicasso.lane/bulk-probes` probes index
   `cells - 1`), so a control shrunk to the base 300 cells would still have
   probed a cell it owns; the count is the check that cannot be satisfied by
   a smaller page. Outside every timed window: the arms are mounted once and
   written to thereafter."
   [arms]
   (mapv (fn [a]
-          (let [c        (lane/fresh-container!)
+          (let [c        (rf.bench.hicasso.lane/fresh-container!)
                 handle   ((:mount a) c)
-                expected (v/m1-elements (:cells a))
-                got      (lane/element-count c)]
+                expected (rf.bench.hicasso.p0-reagent-views/m1-elements (:cells a))
+                got      (rf.bench.hicasso.lane/element-count c)]
             (when-not (= expected got)
               (throw (ex-info (str "the bulk arm " (:id a) " built " got
                                    " elements where its own " (:cells a)
@@ -318,19 +318,19 @@
   while every later sample is measured on top of them. The second audit
   then proved the remaining half by mutation: an unmount that RETURNED
   NORMALLY without releasing left the ratom arm's root standing on a
-  detached tree, rooted in `v/ratom-cells` where neither the body census
-  nor the frame's sub-cache could see it — so `lane/container-released!`
+  detached tree, rooted in `rf.bench.hicasso.p0-reagent-views/ratom-cells` where neither the body census
+  nor the frame's sub-cache could see it — so `rf.bench.hicasso.lane/container-released!`
   now reads each container before it is removed, exactly as
-  `lane/release!` does. The caller adjudicates with
-  `lane/assert-teardown-clean!` and proves the reference census with
-  `lane/assert-residue!`."
+  `rf.bench.hicasso.lane/release!` does. The caller adjudicates with
+  `rf.bench.hicasso.lane/assert-teardown-clean!` and proves the reference census with
+  `rf.bench.hicasso.lane/assert-residue!`."
   [mounts]
   (doseq [{:keys [arm handle container]} mounts]
     (when (try ((:unmount arm) handle)
                true
                (catch :default e
-                 (lane/teardown-failure! (str "release-bulk-arms! " (:id arm)) e)))
-      (lane/container-released! (str "release-bulk-arms! " (:id arm)) container))
+                 (rf.bench.hicasso.lane/teardown-failure! (str "release-bulk-arms! " (:id arm)) e)))
+      (rf.bench.hicasso.lane/container-released! (str "release-bulk-arms! " (:id arm)) container))
     (.remove container)))
 
 ;; ---------------------------------------------------------------------------
@@ -340,7 +340,7 @@
 (defn- fixture-common []
   {:reagent-version   "2.0.1"
    :adapter           :rf.adapter/reagent
-   :runtime           (lane/runtime-label)
+   :runtime           (rf.bench.hicasso.lane/runtime-label)
    :denominator       :reagent-subs
    :floor-note        (str "the same DOM built by hand with react/createElement and no "
                            "substrate at all; every ratio is to the floor measured in "
@@ -366,11 +366,11 @@
 (defn- measure-mount!
   [{:keys [id doc props arms control per-sample clock-note] :as witness}]
   (let [k        (or per-sample 1)
-        t        (lane/tally)
+        t        (rf.bench.hicasso.lane/tally)
         elements (base-elements witness)
         expect   (into {} (map (juxt :id #(expectation witness %))) arms)
         one!  (fn [arm]
-                (let [{:keys [ms mounts]} (lane/mount-batch! arm props k)
+                (let [{:keys [ms mounts]} (rf.bench.hicasso.lane/mount-batch! arm props k)
                       {exp-elements :elements verify :verify} (get expect (:id arm))]
                   ;; EVERY mount in the batch is read back out of the
                   ;; document, against THIS ARM'S OWN arithmetic. `verify` is
@@ -384,19 +384,19 @@
                   ;; twice the page and a probe fixed at the witness's size
                   ;; cannot tell it from the base one.
                   (doseq [m mounts]
-                    (let [ok? (and (= exp-elements (lane/element-count (:container m)))
+                    (let [ok? (and (= exp-elements (rf.bench.hicasso.lane/element-count (:container m)))
                                    (verify (:container m)))]
                       (swap! t (fn [{:keys [of bad]}]
                                  {:of (inc of) :bad (if ok? bad (inc bad))}))))
-                  (doseq [m mounts] (lane/release! m))
+                  (doseq [m mounts] (rf.bench.hicasso.lane/release! m))
                   ms))
-        {:keys [readings samples]} (lane/rounds! arms mount-sampling rounds one!
+        {:keys [readings samples]} (rf.bench.hicasso.lane/rounds! arms mount-sampling rounds one!
                                                  (fn [arm] (str (name id) "/"
                                                                 (name (:id arm)))))
-        norm  (mapv #(lane/normalise % :floor) readings)
+        norm  (mapv #(rf.bench.hicasso.lane/normalise % :floor) readings)
         ratios (mapv :ratio norm)
-        summ  (lane/across-rounds ratios)
-        ctl   (lane/control-verdict (:predicted control)
+        summ  (rf.bench.hicasso.lane/across-rounds ratios)
+        ctl   (rf.bench.hicasso.lane/control-verdict (:predicted control)
                                     (select-keys (:ctl-2x summ) [:min :max :mean])
                                     control-slack)
         record
@@ -440,15 +440,15 @@
                                         "checked at its own far end and not at the base "
                                         "page's")})
          :sampling         mount-sampling
-         :verification     (lane/tally-value t)
+         :verification     (rf.bench.hicasso.lane/tally-value t)
          :positive-control (assoc ctl :basis (:basis control))
          :per-round        {:p50 (mapv :p50 norm) :ratio ratios}
          :ratio-to-floor   summ
-         :bar-row          (lane/ratio-between ratios :reagent-subs :floor)
-         :reactive-leg     (lane/ratio-between ratios :reagent-subs :reagent-ratom)
+         :bar-row          (rf.bench.hicasso.lane/ratio-between ratios :reagent-subs :floor)
+         :reactive-leg     (rf.bench.hicasso.lane/ratio-between ratios :reagent-subs :reagent-ratom)
          :status           :evidence}]
-    (lane/record! (str "mount-" (name id)) record)
-    (lane/assert-verified! t (str "mount row " (name id)))
+    (rf.bench.hicasso.lane/record! (str "mount-" (name id)) record)
+    (rf.bench.hicasso.lane/assert-verified! t (str "mount row " (name id)))
     {:id id :record record :samples samples :control ctl}))
 
 ;; ---------------------------------------------------------------------------
@@ -462,16 +462,16 @@
   A broad write changes every cell, so the probe rotates with the value
   AND the far end of the grid is checked: a stale page can still carry one
   fresh cell from the previous write, and a single fixed probe would
-  accept it. The rule is `lane/bulk-probes`, not a literal here — HD-008's
+  accept it. The rule is `rf.bench.hicasso.lane/bulk-probes`, not a literal here — HD-008's
   bulk row probed cell 0 alone while this one probed three (rf2-f5roa)."
   [t mnt]
   (let [n   (:cells (:arm mnt))
         val (next-gen!)]
-    (lane/verified-write! t mnt :all val (lane/bulk-probes val n))))
+    (rf.bench.hicasso.lane/verified-write! t mnt :all val (rf.bench.hicasso.lane/bulk-probes val n))))
 
 (defn- seed-bulk! [mounts t]
-  (lane/chain nil mounts
-              (fn [_ mnt] (-> (lane/verified-write! t mnt :all 0
+  (rf.bench.hicasso.lane/chain nil mounts
+              (fn [_ mnt] (-> (rf.bench.hicasso.lane/verified-write! t mnt :all 0
                                                     [0 (dec (:cells (:arm mnt)))])
                               (.then (fn [_] nil))))))
 
@@ -484,15 +484,15 @@
   (let [k     (count mounts)
         total (+ (:warmup bulk-sampling) (:samples bulk-sampling))
         acc0  (zipmap (map #(:id (:arm %)) mounts) (repeat []))]
-    (lane/chain {:readings acc0}
-                (for [s (range total) j (lane/slot-order k s)] [s j])
+    (rf.bench.hicasso.lane/chain {:readings acc0}
+                (for [s (range total) j (rf.bench.hicasso.lane/slot-order k s)] [s j])
                 (fn [acc [s j]]
                   (let [mnt (nth mounts j)
                         id  (:id (:arm mnt))]
                     (-> (bulk-write! t mnt)
                         (.then (fn [{:keys [ms write-ms gap-ms force-ms]}]
                                  (if (>= s (:warmup bulk-sampling))
-                                   (do (lane/collect! coll (str "bulk/" (name id)) ms)
+                                   (do (rf.bench.hicasso.lane/collect! coll (str "bulk/" (name id)) ms)
                                        (swap! legs update id (fnil conj [])
                                               {:write write-ms :gap gap-ms :force force-ms})
                                        (update-in acc [:readings id] conj ms))
@@ -501,40 +501,40 @@
 (defn- leg-summary [legs]
   (into {}
         (map (fn [[id xs]]
-               [id {:write-ms (:p50 (lane/summarise (map :write xs)))
-                    :gap-ms   (:p50 (lane/summarise (map :gap xs)))
-                    :force-ms (:p50 (lane/summarise (map :force xs)))}]))
+               [id {:write-ms (:p50 (rf.bench.hicasso.lane/summarise (map :write xs)))
+                    :gap-ms   (:p50 (rf.bench.hicasso.lane/summarise (map :gap xs)))
+                    :force-ms (:p50 (rf.bench.hicasso.lane/summarise (map :force xs)))}]))
         legs))
 
 (defn- measure-bulk!
   [mounts]
-  (let [t    (lane/tally)
+  (let [t    (rf.bench.hicasso.lane/tally)
         legs (atom {})
-        coll (lane/sample-collector)]
-    (-> (lane/chain [] (range rounds)
+        coll (rf.bench.hicasso.lane/sample-collector)]
+    (-> (rf.bench.hicasso.lane/chain [] (range rounds)
                     (fn [acc _]
                       (-> (seed-bulk! mounts t)
                           (.then (fn [_] (bulk-round! mounts t legs coll)))
                           (.then (fn [rd] (conj acc (:readings rd)))))))
         (.then
           (fn [readings]
-            (let [norm   (mapv #(lane/normalise % :floor) readings)
+            (let [norm   (mapv #(rf.bench.hicasso.lane/normalise % :floor) readings)
                   ratios (mapv :ratio norm)
-                  summ   (lane/across-rounds ratios)
-                  predicted (/ (double (v/m1-elements (* 2 v/cells-n)))
-                               (double (v/m1-elements v/cells-n)))
-                  ctl    (lane/control-verdict
+                  summ   (rf.bench.hicasso.lane/across-rounds ratios)
+                  predicted (/ (double (rf.bench.hicasso.p0-reagent-views/m1-elements (* 2 rf.bench.hicasso.p0-reagent-views/cells-n)))
+                               (double (rf.bench.hicasso.p0-reagent-views/m1-elements rf.bench.hicasso.p0-reagent-views/cells-n)))
+                  ctl    (rf.bench.hicasso.lane/control-verdict
                            predicted
                            (select-keys (:ctl-2x summ) [:min :max :mean])
                            control-slack)
                   record
                   {:benchmark        :hicasso.P0/bulk-broad
-                   :doc              (str "one commit that all " v/cells-n
+                   :doc              (str "one commit that all " rf.bench.hicasso.p0-reagent-views/cells-n
                                           " sub-reading boundaries read — the "
                                           "make-or-break row")
                    :bead             "rf2-2rtt6.2"
                    :fixture          (merge (fixture-common)
-                                            {:cells v/cells-n
+                                            {:cells rf.bench.hicasso.p0-reagent-views/cells-n
                                              :arms  (mapv #(:id (:arm %)) mounts)
                                              :writes-per-sample 1
                                              :measurement-method
@@ -558,19 +558,19 @@
                                                   "re-render and is NOT a lower bound — a "
                                                   "fine-grained substrate can beat it")})
                    :sampling         bulk-sampling
-                   :verification     (lane/tally-value t)
+                   :verification     (rf.bench.hicasso.lane/tally-value t)
                    :positive-control (assoc ctl :basis
                                             (str "element count: "
-                                                 (v/m1-elements (* 2 v/cells-n)) " / "
-                                                 (v/m1-elements v/cells-n)))
+                                                 (rf.bench.hicasso.p0-reagent-views/m1-elements (* 2 rf.bench.hicasso.p0-reagent-views/cells-n)) " / "
+                                                 (rf.bench.hicasso.p0-reagent-views/m1-elements rf.bench.hicasso.p0-reagent-views/cells-n)))
                    :per-round        {:p50 (mapv :p50 norm) :ratio ratios}
                    :legs             (leg-summary @legs)
                    :ratio-to-floor   summ
-                   :bar-row          (lane/ratio-between ratios :reagent-subs :floor)
-                   :reactive-leg     (lane/ratio-between ratios :reagent-subs :reagent-ratom)
+                   :bar-row          (rf.bench.hicasso.lane/ratio-between ratios :reagent-subs :floor)
+                   :reactive-leg     (rf.bench.hicasso.lane/ratio-between ratios :reagent-subs :reagent-ratom)
                    :status           :evidence}]
-              (lane/record! "bulk-broad" record)
-              (lane/assert-verified! t "the bulk row")
+              (rf.bench.hicasso.lane/record! "bulk-broad" record)
+              (rf.bench.hicasso.lane/assert-verified! t "the bulk row")
               {:record record :samples (:samples @coll) :control ctl}))))))
 
 ;; ---------------------------------------------------------------------------
@@ -581,7 +581,7 @@
   "Canonical-DOM equality across the judged arms, and the element count of
   EVERY arm — the control included — against its own arithmetic.
 
-  The count used to be checked only over `lane/parity`'s `counts` map,
+  The count used to be checked only over `rf.bench.hicasso.lane/parity`'s `counts` map,
   which excludes the parity-exempt arms by design, so the one arm building
   a deliberately different page had that page checked nowhere. Exempt from
   the EQUALITY is not exempt from arithmetic: the control is exempt
@@ -590,12 +590,12 @@
   []
   (reduce
     (fn [problems {:keys [id props arms] :as witness}]
-      (let [{:keys [mounts agree? disagree]} (lane/parity arms props)
+      (let [{:keys [mounts agree? disagree]} (rf.bench.hicasso.lane/parity arms props)
             wrong (into {}
                         (comp (map (fn [{:keys [arm container]}]
                                      [(:id arm)
                                       {:expected (:elements (expectation witness arm))
-                                       :got      (lane/element-count container)}]))
+                                       :got      (rf.bench.hicasso.lane/element-count container)}]))
                               (remove (fn [[_ {:keys [expected got]}]] (= expected got))))
                         mounts)]
         (try
@@ -605,7 +605,7 @@
 
             (seq wrong)
             (conj {:witness id :problem :element-count :arms wrong}))
-          (finally (doseq [m mounts] (lane/release! m))))))
+          (finally (doseq [m mounts] (rf.bench.hicasso.lane/release! m))))))
     []
     mount-witnesses))
 
@@ -614,13 +614,13 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private census
-  "This run's additions to `lane/residue` — the places its own arms' live
+  "This run's additions to `rf.bench.hicasso.lane/residue` — the places its own arms' live
   references sit that the built-in counters cannot see. One entry: the
-  ratom arms' cursor reactions are watches on `v/ratom-cells`, not frame
+  ratom arms' cursor reactions are watches on `rf.bench.hicasso.p0-reagent-views/ratom-cells`, not frame
   subscriptions and not attached DOM, so without this count a ratom root
   that survived its unmount was invisible to the whole census
-  (`v/ratom-watch-count` carries the mechanics)."
-  {:ratom-watches v/ratom-watch-count})
+  (`rf.bench.hicasso.p0-reagent-views/ratom-watch-count` carries the mechanics)."
+  {:ratom-watches rf.bench.hicasso.p0-reagent-views/ratom-watch-count})
 
 (defn- settled!
   "Let the substrate's disposal queue run, then adjudicate the two things a
@@ -630,20 +630,20 @@
   Between rows, never inside a window. A row measured on top of the
   previous row's un-released boundaries is the same class of fault as a
   write that never reached the page, and this is where it is caught — see
-  [[lane/settle!]] for why the yield is load-bearing rather than a
+  [[rf.bench.hicasso.lane/settle!]] for why the yield is load-bearing rather than a
   courtesy to the assertion. The [[census]] rides both the baseline and
   every assertion, so the ratom family is held to the same equality as
   the subs family."
   [baseline after]
-  (-> (lane/settle!)
+  (-> (rf.bench.hicasso.lane/settle!)
       (.then (fn [_]
-               (lane/assert-teardown-clean! after)
-               (lane/assert-residue! baseline v/subs-frame after census)))))
+               (rf.bench.hicasso.lane/assert-teardown-clean! after)
+               (rf.bench.hicasso.lane/assert-residue! baseline rf.bench.hicasso.p0-reagent-views/subs-frame after census)))))
 
 (defn- finish!
   [{:keys [samples controls]}]
-  (let [v (lane/guard! samples "Hicasso P0 — Reagent-on-subs")]
-    (lane/record! "arm-order-guard"
+  (let [v (rf.bench.hicasso.lane/guard! samples "Hicasso P0 — Reagent-on-subs")]
+    (rf.bench.hicasso.lane/record! "arm-order-guard"
                   {:tolerance (:tolerance v)
                    :contaminated? (:contaminated? v)
                    :unchecked? (:unchecked? v)
@@ -652,41 +652,41 @@
     (when (:refuse? v) (set! (.-HICASSO_GUARD_REFUSED js/window) true))
     (when (some (complement :ok?) controls)
       (set! (.-HICASSO_CONTROL_FAILED js/window) true)))
-  (lane/done!))
+  (rf.bench.hicasso.lane/done!))
 
 (defn ^:export -main
   []
   (try
-    (rf/init! reagent-adapter/adapter)
-    (rf/make-frame {:id v/subs-frame})
-    (frame/replace-app-db! v/subs-frame (v/seed-cells v/cells-n 0))
-    (reset! v/ratom-cells (:cells (v/seed-cells v/cells-n 0)))
-    (lane/leave-act-environment!)
+    (rf/init! rf.adapter.reagent/adapter)
+    (rf/make-frame {:id rf.bench.hicasso.p0-reagent-views/subs-frame})
+    (rf.frame/replace-app-db! rf.bench.hicasso.p0-reagent-views/subs-frame (rf.bench.hicasso.p0-reagent-views/seed-cells rf.bench.hicasso.p0-reagent-views/cells-n 0))
+    (reset! rf.bench.hicasso.p0-reagent-views/ratom-cells (:cells (rf.bench.hicasso.p0-reagent-views/seed-cells rf.bench.hicasso.p0-reagent-views/cells-n 0)))
+    (rf.bench.hicasso.lane/leave-act-environment!)
 
-    (if-not (lane/self-test!)
-      (do (lane/fail! (str "the arm-order guard's SELF-TEST failed — this copy of the "
+    (if-not (rf.bench.hicasso.lane/self-test!)
+      (do (rf.bench.hicasso.lane/fail! (str "the arm-order guard's SELF-TEST failed — this copy of the "
                            "rule no longer behaves like the one the .cjs drivers use, "
                            "so nothing was measured"))
-          (lane/done!))
+          (rf.bench.hicasso.lane/done!))
       ;; The residue this run must return to after every row. Taken before
       ;; the first mount of the run, so it is the empty-page, empty-cache
       ;; reading and not a reading of whatever the previous row left.
-      (let [baseline (lane/residue v/subs-frame census)
+      (let [baseline (rf.bench.hicasso.lane/residue rf.bench.hicasso.p0-reagent-views/subs-frame census)
             problems (parity-problems)]
-        (lane/record! "parity" {:problems problems :ok? (empty? problems)})
-        (lane/record! "residue-baseline" baseline)
+        (rf.bench.hicasso.lane/record! "parity" {:problems problems :ok? (empty? problems)})
+        (rf.bench.hicasso.lane/record! "residue-baseline" baseline)
         (if (seq problems)
-          (do (lane/fail! (str "the arms do not build the same page under :advanced — "
+          (do (rf.bench.hicasso.lane/fail! (str "the arms do not build the same page under :advanced — "
                                (pr-str problems)))
-              (lane/done!))
+              (rf.bench.hicasso.lane/done!))
           ;; The rows are CHAINED rather than folded, so a settle point sits
-          ;; between every pair of them. See `lane/settle!`: a mount row is
+          ;; between every pair of them. See `rf.bench.hicasso.lane/settle!`: a mount row is
           ;; wholly synchronous, Reagent's disposals are on a macrotask
           ;; queue, and without the yield row N+1 begins on a page still
           ;; carrying every consumer reaction row N mounted.
           (-> (settled! baseline "parity")
               (.then (fn [_]
-                       (lane/chain []
+                       (rf.bench.hicasso.lane/chain []
                                    mount-witnesses
                                    (fn [acc w]
                                      (let [r (measure-mount! w)]
@@ -700,7 +700,7 @@
                                       (release-bulk-arms! bulk)
                                       (-> (settled! baseline "the bulk row")
                                           (.then (fn [res]
-                                                   (lane/record! "residue-after-bulk" res)
+                                                   (rf.bench.hicasso.lane/record! "residue-after-bulk" res)
                                                    (finish!
                                                      {:samples
                                                       (into (vec (mapcat :samples mounted))
@@ -713,8 +713,8 @@
                                        (release-bulk-arms! bulk)
                                        (throw e)))))))
               (.catch (fn [e]
-                        (lane/fail! (str "the run rejected: " e))
-                        (lane/done!)))))))
+                        (rf.bench.hicasso.lane/fail! (str "the run rejected: " e))
+                        (rf.bench.hicasso.lane/done!)))))))
     (catch :default e
-      (lane/fail! (str "the run threw: " e))
-      (lane/done!))))
+      (rf.bench.hicasso.lane/fail! (str "the run threw: " e))
+      (rf.bench.hicasso.lane/done!))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/p0_uix_views.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/p0_uix_views.cljs
@@ -44,8 +44,8 @@
     and the DOM read-back is what checks it rather than this comment.
 
   Owner: the operator-owned standard bead rf2-2rtt6.1; this arm rf2-a4x1o."
-  (:require [re-frame.adapter.uix :as uixa]
-            [re-frame.bench.hicasso.p0-reagent-views :as v]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.p0-reagent-views :as rf.bench.hicasso.p0-reagent-views]
             [uix.core :refer [$ defui]]))
 
 ;; ---------------------------------------------------------------------------
@@ -57,7 +57,7 @@
 ;; read, and nothing else.
 
 (defui m1-cell [{:keys [i]}]
-  (let [v (uixa/use-subscribe [:p0/cell i])]
+  (let [v (rf.adapter.uix/use-subscribe [:p0/cell i])]
     ($ :li.row
        ($ :span.lbl "cell ")
        ($ :span.cell {:data-i i} (str v)))))
@@ -72,15 +72,15 @@
 ;; ---------------------------------------------------------------------------
 
 (defui m2-field [{:keys [i]}]
-  (let [v (uixa/use-subscribe [:p0/cell i])]
+  (let [v (rf.adapter.uix/use-subscribe [:p0/cell i])]
     ($ :div.field
        ($ :label.lbl {:for (str "f" i)} (str "Field " i))
        ($ :input.inp {:id        (str "f" i)
                       :name      (str "f" i)
                       :type      "text"
-                      :value     (v/field-value i v)
+                      :value     (rf.bench.hicasso.p0-reagent-views/field-value i v)
                       :read-only true})
-       ($ :p.err (v/field-error i)))))
+       ($ :p.err (rf.bench.hicasso.p0-reagent-views/field-error i)))))
 
 (defui m2 [{:keys [n]}]
   ($ :form.p0form
@@ -105,5 +105,5 @@
   application supplies the frame its boundaries resolve `use-subscribe`
   against."
   [view n]
-  ($ uixa/frame-provider {:frame v/subs-frame}
+  ($ rf.adapter.uix/frame-provider {:frame rf.bench.hicasso.p0-reagent-views/subs-frame}
      ($ view {:n n})))

--- a/bench/hicasso/src/re_frame/bench/hicasso/parity_probe_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/parity_probe_app.cljs
@@ -5,9 +5,9 @@
   arms through the same doors as `census_clock_arms/parity-at`; prints and
   exits. Not a witness, not a clock; deleted or kept as lane tooling at
   the reviewer's pleasure."
-  (:require [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.shapes.census-clock-arms :as arms]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.shapes.census-clock-arms :as rf.bench.hicasso.shapes.census-clock-arms]
             [re-frame.core :as rf]))
 
 (defn- first-diff [a b]
@@ -24,20 +24,20 @@
     (subs s from to)))
 
 (defn ^:export -main []
-  (rf/init! uix-adapter/adapter)
-  (lane/leave-act-environment!)
+  (rf/init! rf.adapter.uix/adapter)
+  (rf.bench.hicasso.lane/leave-act-environment!)
   (-> (js/Promise.resolve nil)
       (.then
         (fn [_]
-          (arms/ensure-frames! [:hicasso :uix])
+          (rf.bench.hicasso.shapes.census-clock-arms/ensure-frames! [:hicasso :uix])
           (doseq [row [:large-template :feed :ordinary]]
-            (let [seed (:seed (get arms/rows row))
-                  _    (arms/reseed-row! row [:hicasso :uix] seed)
-                  built [(arms/arm row :uix) (arms/arm row :hicasso)]
-                  p    (lane/parity built {})
+            (let [seed (:seed (get rf.bench.hicasso.shapes.census-clock-arms/rows row))
+                  _    (rf.bench.hicasso.shapes.census-clock-arms/reseed-row! row [:hicasso :uix] seed)
+                  built [(rf.bench.hicasso.shapes.census-clock-arms/arm row :uix) (rf.bench.hicasso.shapes.census-clock-arms/arm row :hicasso)]
+                  p    (rf.bench.hicasso.lane/parity built {})
                   cu   (get (:canon p) :uix)
                   ch   (get (:canon p) :hicasso)]
-              (doseq [m (:mounts p)] (lane/release! m))
+              (doseq [m (:mounts p)] (rf.bench.hicasso.lane/release! m))
               ;; RELABELLED, not converted (rf2-2rtt6.121). These two
               ;; numbers exist to be read beside `first diff at i`, and `i`
               ;; is a `.charAt` index — a code-unit offset. Stating them in
@@ -52,7 +52,7 @@
                   (js/console.log (str ";; first diff at " i))
                   (js/console.log (str ";; UIX     ...[" (window cu i) "]..."))
                   (js/console.log (str ";; HICASSO ...[" (window ch i) "]..."))))))
-          (lane/done!)))
+          (rf.bench.hicasso.lane/done!)))
       (.catch (fn [e]
-                (lane/fail! (or (some-> e .-message) (str e)))
-                (lane/done!)))))
+                (rf.bench.hicasso.lane/fail! (or (some-> e .-message) (str e)))
+                (rf.bench.hicasso.lane/done!)))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/read_profile_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/read_profile_app.cljs
@@ -4,7 +4,7 @@
   rf2-y1jkm cut the interpreter walk ~39% and its closing decomposition
   moved the surviving mount gap off the walk: hicasso in-page 3.300 ms vs
   uix 1.900 ms on the acceptance shape, concentrated in the 141
-  per-instance collector reads — each a cold `subs/subscribe-once`
+  per-instance collector reads — each a cold `rf.subs/subscribe-once`
   (subscribe + deref + unsubscribe per read per mount; cells only exist
   after commit). None of the prior instruments says where INSIDE one cold
   read the time goes. This entry answers that: the acceptance page's own
@@ -27,13 +27,13 @@
   The profiled reads are HARVESTED, not transcribed: the real
   [[re-frame.bench.hicasso.shapes.large-template/page]] is mounted once
   and the read-set entry the mount resolved is read back through the
-  runtime's own [[rt/last-reads]] — its key array IS the page's read
+  runtime's own [[rf.bench.hicasso.arm1.runtime/last-reads]] — its key array IS the page's read
   sequence, in realization order, straight from the machinery under test.
   Boot is fatal unless the roster is exactly the page arithmetic's
   3 + 2 x 69 = 141 reads, all distinct, and the mounted page is the
   1,202-element acceptance page.
 
-  Timed passes run through the runtime's public [[rt/render-body]] door —
+  Timed passes run through the runtime's public [[rf.bench.hicasso.arm1.runtime/render-body]] door —
   one door per pass, the window OUTSIDE the door — so a sample bills
   everything a mount bills per boundary render: the scratch reset, the
   generation fence's two basis reads, the read-set entry resolve, and the
@@ -46,7 +46,7 @@
   |---------------|--------------------------------------------------------|----------------|
   | `ship`        | 141 x `(sub q)` — the shipping collector read          | the whole render-side read term |
   | `local`       | faithful copy of the read shell + `subscribe-once`     | the FROZEN pre-rf2-6c237 path — the ablation baseline, validated against `ship` |
-  | `no-shell`    | 141 x bare `subs/subscribe-once`                       | `local - no-shell` = the Hicasso shell (key alloc, scratch push, cells probe, entry-hit compare) |
+  | `no-shell`    | 141 x bare `rf.subs/subscribe-once`                       | `local - no-shell` = the Hicasso shell (key alloc, scratch push, cells probe, entry-hit compare) |
   | `probe`       | 141 x the candidate: cache peek, else pass-scoped value map, else fresh-memo `compute-sub-with-memo` against one frame-state snapshot | the no-churn cold read (the observation port's cold-probe discipline, value-mapped per pass) |
   | `probe-fresh` | 141 x `compute-sub` (fresh memo per read, no wrap/peek/map) | the bare-compute lower bound the candidate is priced against |
   | `floor`       | 141 x registrar lookup + raw handler call on app-db    | the irreducible compute floor |
@@ -67,7 +67,7 @@
   ## The commit half (phase B — async, settled between samples)
 
   What the render's cold read deliberately does not pay, the commit does:
-  one durable cell per unique key — `subs/subscribe`, the ACTIVATION, the
+  one durable cell per unique key — `rf.subs/subscribe`, the ACTIVATION, the
   baseline deref, the value-change watch, the disposal hook, the `!cells`
   insert — plus one reader membership per key. **That last term re-shaped under
   rf2-dabt3**: the dependency index used to be a second process-global
@@ -75,7 +75,7 @@
   `record-reads!` into it; the readers now live on the cell, so the
   commit pushes one slot per key and the copy prices that instead.
   Phase B prices that half through the runtime's own
-  [[rt/commit-boundary!]] seam on [[frames-per-window]] identically-seeded
+  [[rf.bench.hicasso.arm1.runtime/commit-boundary!]] seam on [[frames-per-window]] identically-seeded
   frames per window, released and settled between samples with a residue
   equality gate.
 
@@ -91,12 +91,12 @@
 
   | arm         | one window is                                     | what it prices |
   |-------------|---------------------------------------------------|----------------|
-  | `commit`    | [[frames-per-window]] frames x `rt/commit-boundary!` on the harvested entry | the shipping commit half |
+  | `commit`    | [[frames-per-window]] frames x `rf.bench.hicasso.arm1.runtime/commit-boundary!` on the harvested entry | the shipping commit half |
   | `c-local`   | faithful copy: cell mint + subscribe + activation + baseline deref + watch + dispose hook + map insert + reader membership | the ablation baseline, validated against `commit` |
   | `c-null`    | `c-local` with NOTHING ablated — the same `C-FULL` mode, under a second id | THE NEGATIVE CONTROL: `c-local - c-null` has a true cost of exactly zero, so what it reads is the instrument's own error and nothing else (rf2-3l6hf) |
   | `c-null-twin` | `c-local` again, at the slot whose kept-sample POSITION FOOTPRINT is `c-local`'s own | the POSITION null: any cost that is a function of sweep position cancels term by term between these two arms, so what it reads is error position cannot explain (rf2-lo7uy) |
   | `c-null-curve` | `c-local` again, at a slot sharing `c-local`'s MEAN position on a different footprint | the CURVATURE null: a linear position drift cancels here too, a curved one does not (rf2-lo7uy) |
-  | `c-noactivate` | `c-local` minus `interop/activate-derived-value!` | ON THIS HOST the uncached hook resolution, a real term (rf2-tcffa); the substrate's capture run under a ratom host (rf2-lzpfj) |
+  | `c-noactivate` | `c-local` minus `rf.interop/activate-derived-value!` | ON THIS HOST the uncached hook resolution, a real term (rf2-tcffa); the substrate's capture run under a ratom host (rf2-lzpfj) |
   | `c-nowatch` | `c-local` minus add-watch + the disposal hook     | the watch wiring |
   | `c-nosub`   | `c-local` with `compute-sub` in place of subscribe + deref | the reaction build + cache insert (the compute is kept, priced by the swap) |
   | `c-noreaders` | `c-local` minus the cell's reader array and the membership push | the fused reverse edge (rf2-dabt3) |
@@ -194,7 +194,7 @@
   one null is one pair of slots (rf2-lo7uy).
 
   **An arm's SLOT is a measured property of it, not a presentation
-  detail.** [[rounds-async!]] visits the arms in [[lane/slot-order]]'s
+  detail.** [[rounds-async!]] visits the arms in [[rf.bench.hicasso.lane/slot-order]]'s
   order, which rotates by the sample index and reflects on odd ones — and
   it is handed the SAMPLE index, not the round, so every round runs the
   identical schedule. An arm therefore occupies the same multiset of sweep
@@ -203,7 +203,7 @@
   within a grid step across three runs: a random error would not, and a
   fixed positional bias would.
 
-  [[slot-footprint]] computes that multiset from [[lane/slot-order]] itself
+  [[slot-footprint]] computes that multiset from [[rf.bench.hicasso.lane/slot-order]] itself
   rather than restating its arithmetic. At the eleven arms this roster now
   carries and this window's `2 + 8` sampling it reads:
 
@@ -246,24 +246,24 @@
   slot — `commit` 0, `c-local` 1, `c-null` 2, through `b-build` 8 — and
   every subject, mode, frame, [[frames-per-window]], [[b-rounds]] and
   [[b-sampling]] is exactly what it was. What cannot be held fixed is `n`,
-  which is an input to [[lane/slot-order]]: eleven arms is a different sweep
+  which is an input to [[rf.bench.hicasso.lane/slot-order]]: eleven arms is a different sweep
   and therefore a new series, the same way nine arms was a new series
   against the eight-arm runs before it. Absolutes are not arm-by-arm
   comparable across that line, and no reading here is.
 
   Owner bead: rf2-6c237. Driver: `run.cjs` with
   HICASSO_INIT_FN=re-frame.bench.hicasso.read-profile-app/-main."
-  (:require [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as arm1-mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt :refer [sub]]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.shapes.large-template :as lt]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime :refer [sub]]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.shapes.large-template :as rf.bench.hicasso.shapes.large-template]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.live-frame :as live-frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.subs :as subs]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.live-frame :as rf.live-frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.subs :as rf.subs]))
 
 ;; ---------------------------------------------------------------------------
 ;; Frames
@@ -277,9 +277,9 @@
   (rf2-3l6hf). It was 4, and 4 could not decompose the commit half.
 
   **A window's resolution is set here and by the KEPT SAMPLE COUNT'S
-  PARITY, because the reported statistic is a p50.** `lane/now-ms` is
+  PARITY, because the reported statistic is a p50.** `rf.bench.hicasso.lane/now-ms` is
   `performance.now`, which Chrome clamps to 100 µs, so every raw window
-  reading is a multiple of 0.1 ms; [[lane/summarise]] takes the mean of
+  reading is a multiple of 0.1 ms; [[rf.bench.hicasso.lane/summarise]] takes the mean of
   the two middle order statistics on an EVEN sample count, which halves
   that to 0.05 ms, and a single order statistic on an ODD one, which does
   not halve it at all; and the row divides by the frame count. So the
@@ -343,8 +343,8 @@
         (range 1 (inc frames-per-window))))
 
 (defn- seed-frame! [id]
-  (lt/make-frame! id)
-  (lt/reseed! id)
+  (rf.bench.hicasso.shapes.large-template/make-frame! id)
+  (rf.bench.hicasso.shapes.large-template/reseed! id)
   id)
 
 ;; ---------------------------------------------------------------------------
@@ -357,19 +357,19 @@
   Fatal unless the page is the 1,202-element page and the roster is the
   arithmetic's 141 distinct reads."
   [frame-id]
-  (let [container (arm1-mount/fresh-container!)
-        handle    (arm1-mount/root! container frame-id [lt/page {}])
-        entry     (rt/last-reads)
+  (let [container (rf.bench.hicasso.arm1.mount/fresh-container!)
+        handle    (rf.bench.hicasso.arm1.mount/root! container frame-id [rf.bench.hicasso.shapes.large-template/page {}])
+        entry     (rf.bench.hicasso.arm1.runtime/last-reads)
         keys'     (.-keys ^js entry)
-        n         (lane/element-count container)
-        expected  (lt/element-arithmetic)
+        n         (rf.bench.hicasso.lane/element-count container)
+        expected  (rf.bench.hicasso.shapes.large-template/element-arithmetic)
         roster    (let [a #js []]
                     (dotimes [i (alength keys')]
                       (.push a (nth (aget keys' i) 1)))
                     a)
         distinct-n (count (into #{} (array-seq roster)))
-        expected-reads (+ 3 (* 2 lt/article-count))]
-    (arm1-mount/unmount! handle)
+        expected-reads (+ 3 (* 2 rf.bench.hicasso.shapes.large-template/article-count))]
+    (rf.bench.hicasso.arm1.mount/unmount! handle)
     (when-not (= expected n)
       (throw (ex-info (str "harvest FAILED: mounted page has " n
                            " elements, expected " expected)
@@ -388,7 +388,7 @@
   (let [by-id (reduce (fn [m q] (update m (nth q 0) (fnil inc 0)))
                       {} (array-seq roster))
         kinds (reduce (fn [m q]
-                        (let [k (:input-kind (registrar/lookup :sub (nth q 0)))]
+                        (let [k (:input-kind (rf.registrar/lookup :sub (nth q 0)))]
                           (update m k (fnil inc 0))))
                       {} (array-seq roster))]
     {:reads      (alength roster)
@@ -413,10 +413,10 @@
   "One sample: K render-body doors on `frame-id`, `pass!` inside each,
   one clock around all K. Answers ms for the window."
   [frame-id pass!]
-  (let [t0 (lane/now-ms)]
+  (let [t0 (rf.bench.hicasso.lane/now-ms)]
     (dotimes [_ passes-per-sample]
-      (rt/render-body frame-id (fn [_] (pass!) [:span]) {}))
-    (- (lane/now-ms) t0)))
+      (rf.bench.hicasso.arm1.runtime/render-body frame-id (fn [_] (pass!) [:span]) {}))
+    (- (rf.bench.hicasso.lane/now-ms) t0)))
 
 ;; ---------------------------------------------------------------------------
 ;; The faithful local copy of the pre-rf2-6c237 read (the frozen baseline)
@@ -465,7 +465,7 @@
         (.push local-scratch sub-key)
         (if-some [^js r (some-> ^js (get local-cells sub-key) (.-reaction))]
           @r
-          (subs/subscribe-once q {:frame frame-id})))))
+          (rf.subs/subscribe-once q {:frame frame-id})))))
   (local-bucket-hash)
   (when (nil? local-entry-keys)
     (set! local-entry-keys (.slice local-scratch)))
@@ -484,7 +484,7 @@
   and deref a live reaction without acquire/release churn; else consult
   the pass-scoped VALUE map, and on a genuine first read compute PURE
   against the pass's one frame-state snapshot with a FRESH per-read memo
-  seeded with `subs/observation-opts-key` (so an unregistered read emits
+  seeded with `rf.subs/observation-opts-key` (so an unregistered read emits
   the always-on `:rf.error/no-such-sub` exactly as the reactive build
   does). The snapshot and the value map are per PASS — the render-scoped
   lifetime the candidate resets at the top of every body run. The
@@ -497,8 +497,8 @@
         n      (alength roster)]
     (dotimes [i n]
       (let [q            (aget roster i)
-            frame-record (frame/frame frame-id)]
-        (live-frame/call-with-frame-resolution
+            frame-record (rf.frame/frame frame-id)]
+        (rf.live-frame/call-with-frame-resolution
           frame-id
           (fn []
             (if-some [r (:reaction (get @(:sub-cache frame-record) q))]
@@ -506,11 +506,11 @@
               (if-some [kv (find (unchecked-get pstate "vals") q)]
                 (val kv)
                 (let [fs (or (unchecked-get pstate "fs")
-                             (let [v (frame/frame-state-value frame-id)]
+                             (let [v (rf.frame/frame-state-value frame-id)]
                                (unchecked-set pstate "fs" v)
                                v))
-                      v  (subs/compute-sub-with-memo
-                           q fs (atom {subs/observation-opts-key
+                      v  (rf.subs/compute-sub-with-memo
+                           q fs (atom {rf.subs/observation-opts-key
                                        {:frame frame-id}}))]
                   (unchecked-set pstate "vals"
                                  (assoc (unchecked-get pstate "vals") q v))
@@ -523,24 +523,24 @@
 (defn- once-pass! [frame-id ^js roster]
   (let [n (alength roster)]
     (dotimes [i n]
-      (subs/subscribe-once (aget roster i) {:frame frame-id}))))
+      (rf.subs/subscribe-once (aget roster i) {:frame frame-id}))))
 
 (defn- fresh-memo-pass! [frame-id ^js roster]
-  (let [fs (frame/frame-state-value frame-id)
+  (let [fs (rf.frame/frame-state-value frame-id)
         n  (alength roster)]
     (dotimes [i n]
-      (subs/compute-sub (aget roster i) fs))))
+      (rf.subs/compute-sub (aget roster i) fs))))
 
 (defn- floor-pass!
   "The irreducible floor: one registrar lookup and one raw layer-1
   handler call per read, against the app-db partition read once."
   [frame-id ^js roster]
-  (let [app-db (:rf.db/app (frame/frame-state-value frame-id))
+  (let [app-db (:rf.db/app (rf.frame/frame-state-value frame-id))
         n      (alength roster)
         sink   (volatile! nil)]
     (dotimes [i n]
       (let [q (aget roster i)]
-        (vreset! sink ((:handler-fn (registrar/lookup :sub (nth q 0)))
+        (vreset! sink ((:handler-fn (rf.registrar/lookup :sub (nth q 0)))
                        app-db q))))
     @sink))
 
@@ -598,7 +598,7 @@
   original no longer builds is an instrument measuring itself (rf2-6wh9o).
 
   Uniqueness is structural here for the same reason it is there: a mode's
-  cells are built one per key of a read SET, `subs/subscribe` hands back
+  cells are built one per key of a read SET, `rf.subs/subscribe` hands back
   the cached reaction for that `(frame, query)`, and [[rounds-async!]]
   runs every teardown and clears every sub-cache between arms behind the
   residue gate — so no two live cells ever hold the same reaction. The
@@ -610,7 +610,7 @@
 (defn- commit-local!
   "Faithful copy of the commit half `make-subscribe` performs for one
   boundary at `mode`: the registration object, one cell per key of the
-  read SET (`subs/subscribe` + the ACTIVATION + the baseline deref + the
+  read SET (`rf.subs/subscribe` + the ACTIVATION + the baseline deref + the
   value-change watch + the disposal hook + the map insert), each cell
   taking the registration onto its reader list. Answers a teardown fn
   that mirrors the returned unsubscribe closure — run OUTSIDE the window.
@@ -649,22 +649,22 @@
       (let [q  (nth sub-key 1)
             r  (if (identical? mode C-NOSUB)
                  nil
-                 (subs/subscribe q {:frame frame-id}))
+                 (rf.subs/subscribe q {:frame frame-id}))
             ^js cell #js {"subKey"   sub-key
                           "frameKw"  frame-id
                           "queryV"   q
                           "reaction" r
-                          "epoch"    (rt/commit-basis frame-id)
+                          "epoch"    (rf.bench.hicasso.arm1.runtime/commit-basis frame-id)
                           "disposed" false}]
         (if (identical? mode C-NOSUB)
-          (subs/compute-sub q fs)
+          (rf.subs/compute-sub q fs)
           (do ;; ACTIVATE, then baseline, then watch — `wire-cell!`'s order.
               (when-not (identical? mode C-NOACTIVATE)
-                (interop/activate-derived-value! r))
+                (rf.interop/activate-derived-value! r))
               @r
               (when-not (identical? mode C-NOWATCH)
                 (add-watch r cell-watch-key (fn [_ _ _ _] nil))
-                (interop/add-on-dispose! r (fn [] nil)))))
+                (rf.interop/add-on-dispose! r (fn [] nil)))))
         ;; The fused reverse edge: one slot per key, which is the
         ;; boundary's edge and its reference at once (rf2-dabt3). The
         ;; array is minted with the registration already in it, exactly
@@ -681,7 +681,7 @@
         (let [^js cell (aget cells i)]
           (when-some [r (.-reaction cell)]
             (remove-watch r cell-watch-key)
-            (subs/unsubscribe frame-id (.-queryV cell))))))))
+            (rf.subs/unsubscribe frame-id (.-queryV cell))))))))
 
 (defn- build-only!
   "141 bare `subscribe` + deref on `frame-id`, holding every reference.
@@ -690,10 +690,10 @@
   [frame-id ^js roster]
   (let [n (alength roster)]
     (dotimes [i n]
-      @(subs/subscribe (aget roster i) {:frame frame-id}))
+      @(rf.subs/subscribe (aget roster i) {:frame frame-id}))
     (fn teardown []
       (dotimes [i n]
-        (subs/unsubscribe frame-id (aget roster i))))))
+        (rf.subs/unsubscribe frame-id (aget roster i))))))
 
 (def phase-b-arm-ids
   "The phase-B roster IN SLOT ORDER — **the vector index IS the arm's
@@ -747,7 +747,7 @@
         ;; drift from the arm it nulls is not one (rf2-3l6hf).
         arms [{:id :commit
                :run (fn []
-                      (mapv (fn [f] (rt/commit-boundary! (get entries f) (fn [] nil)))
+                      (mapv (fn [f] (rf.bench.hicasso.arm1.runtime/commit-boundary! (get entries f) (fn [] nil)))
                             commit-frames))}
               {:id :c-local   :run (mk-local C-FULL)}
               {:id :c-null    :run (mk-local C-FULL)}
@@ -797,10 +797,10 @@
 
 (defn slot-positions
   "The sweep POSITIONS `slot` occupies across ONE round's KEPT samples,
-  with `n` arms under [[lane/slot-order]] and this `sampling`.
+  with `n` arms under [[rf.bench.hicasso.lane/slot-order]] and this `sampling`.
 
   Read OUT of the schedule, never restated: the positions come from
-  `lane/slot-order` itself, which takes them from the order guard, so a
+  `rf.bench.hicasso.lane/slot-order` itself, which takes them from the order guard, so a
   change to the plan moves these numbers instead of leaving them behind
   as a second authority nothing holds in step.
 
@@ -813,7 +813,7 @@
   [n slot {:keys [warmup samples]}]
   (into []
         (map (fn [s]
-               (let [order (lane/slot-order n s)]
+               (let [order (rf.bench.hicasso.lane/slot-order n s)]
                  (first (keep-indexed (fn [pos j] (when (= j slot) pos)) order)))))
         (range warmup (+ warmup samples))))
 
@@ -842,7 +842,7 @@
            (range n) arm-ids))))
 
 (def clock-clamp-ms
-  "The quantum of [[lane/now-ms]] on this host: Chrome clamps
+  "The quantum of [[rf.bench.hicasso.lane/now-ms]] on this host: Chrome clamps
   `performance.now` to 100 µs, so the difference of two readings — which
   is every raw window sample phase B takes — is a multiple of 0.1 ms."
   0.1)
@@ -853,7 +853,7 @@
 
   Three steps, and the middle one is the one that was being taken for
   granted. Raw samples are multiples of [[clock-clamp-ms]].
-  [[lane/summarise]]'s p50 is the MEAN OF THE TWO MIDDLE order statistics
+  [[rf.bench.hicasso.lane/summarise]]'s p50 is the MEAN OF THE TWO MIDDLE order statistics
   when the kept count is even, which puts it on a half-clamp grid, and a
   SINGLE order statistic when it is odd, which leaves it on the full
   clamp. The row then divides by the frame count. A delta is a difference
@@ -874,7 +874,7 @@
   "**The one point behind which every phase-B residue reading is taken** —
   the baseline, the between-sample gate, and the final zero.
 
-  It is [[rt/quiesced!]] and not [[lane/settle!]], and the difference is
+  It is [[rf.bench.hicasso.arm1.runtime/quiesced!]] and not [[rf.bench.hicasso.lane/settle!]], and the difference is
   the whole of rf2-981nt. `settle!` yields ONE macrotask, which is the
   right point for a substrate that queues its disposals there and the
   wrong one for a runtime that arms its entry reaper at a horizon
@@ -894,34 +894,34 @@
 
   The arms are unaffected. A reaped entry is dropped from the runtime's
   entry CACHE, not destroyed — the object survives in the closure phase B
-  holds — and [[rt/commit-boundary!]] reads the entry, never the cache,
+  holds — and [[rf.bench.hicasso.arm1.runtime/commit-boundary!]] reads the entry, never the cache,
   so the `commit` arm acquires the same 141 cells through the same seam
   either way.
 
   **Named rather than spelled out three times**, because this defect was
   invisible for exactly as long as the concept was unnamed: three
-  `lane/settle!` calls look like three ordinary yields, and there was
+  `rf.bench.hicasso.lane/settle!` calls look like three ordinary yields, and there was
   nowhere for the reason to live. Public because
   `read-profile-baseline-cljs-test` drives THIS fn — a witness that
-  called `rt/quiesced!` itself would go green however this instrument
+  called `rf.bench.hicasso.arm1.runtime/quiesced!` itself would go green however this instrument
   settled, which is the vacuous test that let the horizon move under a
   faithful rig in the first place."
   []
-  (rt/quiesced!))
+  (rf.bench.hicasso.arm1.runtime/quiesced!))
 
 (defn- probe-caches-empty? []
-  (every? (fn [f] (zero? (count @(:sub-cache (frame/frame f)))))
+  (every? (fn [f] (zero? (count @(:sub-cache (rf.frame/frame f)))))
           commit-frames))
 
 (defn- rounds-async!
   "The reflecting-schedule sampler, promise-chained: every sample index
-  visits every arm in [[lane/slot-order]]'s order; warm-up samples are
+  visits every arm in [[rf.bench.hicasso.lane/slot-order]]'s order; warm-up samples are
   taken and discarded; between samples the arm's teardowns run, the
   runtime settles behind [[residue-settle!]], and the residue gate must
-  answer clean. Mirrors `lane/rounds!`, which cannot yield.
+  answer clean. Mirrors `rf.bench.hicasso.lane/rounds!`, which cannot yield.
 
   **Readings come back BUCKETED BY ROUND**, one map per round, which is
-  what `lane/rounds!` has always answered and what this fn used to
+  what `rf.bench.hicasso.lane/rounds!` has always answered and what this fn used to
   flatten into a single bucket. Pooling is unchanged — [[arm-rows]]
   `mapcat`s the buckets before it summarises, so the published p50 is the
   same number over the same 64 samples — but the per-round structure now
@@ -929,24 +929,24 @@
   without being re-taken (rf2-3l6hf)."
   [arms {:keys [warmup samples]} rounds' baseline]
   (let [k    (count arms)
-        coll (lane/sample-collector)
+        coll (rf.bench.hicasso.lane/sample-collector)
         acc  (atom (vec (repeat rounds' (zipmap (map :id arms) (repeat [])))))]
-    (-> (lane/chain
+    (-> (rf.bench.hicasso.lane/chain
           nil
           (for [round (range rounds')
                 s     (range (+ warmup samples))
-                j     (lane/slot-order k s)]
+                j     (rf.bench.hicasso.lane/slot-order k s)]
             [round s j])
           (fn [_ [round s j]]
             (let [{:keys [id run]} (nth arms j)
-                  t0        (lane/now-ms)
+                  t0        (rf.bench.hicasso.lane/now-ms)
                   teardowns (run)
-                  ms        (- (lane/now-ms) t0)]
+                  ms        (- (rf.bench.hicasso.lane/now-ms) t0)]
               (doseq [t teardowns] (t))
               (-> (residue-settle!)
                   (.then
                     (fn [_]
-                      (let [now (rt/residue)]
+                      (let [now (rf.bench.hicasso.arm1.runtime/residue)]
                         (when-not (and (= baseline now) (probe-caches-empty?))
                           (throw (ex-info (str "phase-B residue after " (name id)
                                                " — expected " (pr-str baseline)
@@ -955,7 +955,7 @@
                                                  ", and a probe frame's sub-cache is not empty"))
                                           {:arm id :baseline baseline :residue now})))
                         (when (>= s warmup)
-                          (lane/collect! coll (name id) ms)
+                          (rf.bench.hicasso.lane/collect! coll (name id) ms)
                           (swap! acc update-in [round id] conj ms))
                         nil)))))))
         (.then (fn [_] {:readings @acc :samples (:samples @coll)})))))
@@ -968,23 +968,23 @@
   [reps ^js arr f]
   (let [sink (volatile! nil)
         n    (.-length arr)
-        t0   (lane/now-ms)]
+        t0   (rf.bench.hicasso.lane/now-ms)]
     (dotimes [_ reps]
       (dotimes [i n]
         (vreset! sink (f (aget arr i)))))
-    (let [ms (- (lane/now-ms) t0)]
+    (let [ms (- (rf.bench.hicasso.lane/now-ms) t0)]
       (/ (* 1e6 ms) (* reps n)))))
 
 (defn- micro-table [^js roster]
-  (let [fs     (frame/frame-state-value cold-frame)
+  (let [fs     (rf.frame/frame-state-value cold-frame)
         app-db (:rf.db/app fs)
-        cache  (:sub-cache (frame/frame cold-frame))]
-    [[:subscribe-once     (ns-per-op 20 roster (fn [q] (subs/subscribe-once q {:frame cold-frame})))]
-     [:compute-sub        (ns-per-op 20 roster (fn [q] (subs/compute-sub q fs)))]
-     [:handler-invoke     (ns-per-op 200 roster (fn [q] ((:handler-fn (registrar/lookup :sub (nth q 0))) app-db q)))]
-     [:registrar-lookup   (ns-per-op 200 roster (fn [q] (registrar/lookup :sub (nth q 0))))]
-     [:frame-state-value  (ns-per-op 200 roster (fn [_] (frame/frame-state-value cold-frame)))]
-     [:resolution-wrap    (ns-per-op 200 roster (fn [_] (live-frame/call-with-frame-resolution cold-frame (fn [] nil))))]
+        cache  (:sub-cache (rf.frame/frame cold-frame))]
+    [[:subscribe-once     (ns-per-op 20 roster (fn [q] (rf.subs/subscribe-once q {:frame cold-frame})))]
+     [:compute-sub        (ns-per-op 20 roster (fn [q] (rf.subs/compute-sub q fs)))]
+     [:handler-invoke     (ns-per-op 200 roster (fn [q] ((:handler-fn (rf.registrar/lookup :sub (nth q 0))) app-db q)))]
+     [:registrar-lookup   (ns-per-op 200 roster (fn [q] (rf.registrar/lookup :sub (nth q 0))))]
+     [:frame-state-value  (ns-per-op 200 roster (fn [_] (rf.frame/frame-state-value cold-frame)))]
+     [:resolution-wrap    (ns-per-op 200 roster (fn [_] (rf.live-frame/call-with-frame-resolution cold-frame (fn [] nil))))]
      [:cache-peek-miss    (ns-per-op 200 roster (fn [q] (:reaction (get @cache q))))]
      [:sub-key-mint       (ns-per-op 200 roster (fn [q] [cold-frame q]))]]))
 
@@ -1018,7 +1018,7 @@
   (into {}
         (map (fn [id]
                (let [xs (mapcat #(get % id) readings)]
-                 [id (lane/summarise (mapv #(/ % per-window) xs))])))
+                 [id (rf.bench.hicasso.lane/summarise (mapv #(/ % per-window) xs))])))
         arm-ids))
 
 (defn- per-round-p50s
@@ -1036,8 +1036,8 @@
   (into {}
         (map (fn [id]
                [id (mapv (fn [round]
-                           (lane/round4
-                             (:p50 (lane/summarise
+                           (rf.bench.hicasso.lane/round4
+                             (:p50 (rf.bench.hicasso.lane/summarise
                                      (mapv #(/ % per-window) (get round id))))))
                          readings)]))
         arm-ids))
@@ -1049,7 +1049,7 @@
   (let [base (get p50s base-id)]
     (into {}
           (map (fn [id]
-                 [id (mapv (fn [b a] (lane/round4 (- b a)))
+                 [id (mapv (fn [b a] (rf.bench.hicasso.lane/round4 (- b a)))
                            base (get p50s id))]))
           arm-ids)))
 
@@ -1067,9 +1067,9 @@
          (fmt (* 100 (/ d base)) 1) "% of the baseline)")))
 
 (defn ^:export -main []
-  (rf/init! uix-adapter/adapter)
-  (lane/leave-act-environment!)
-  (lane/self-test!)
+  (rf/init! rf.adapter.uix/adapter)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/self-test!)
   (-> (js/Promise.resolve nil)
       (.then
         (fn [_]
@@ -1081,20 +1081,20 @@
                                  (:reads census) " reads ("
                                  (:distinct census) " distinct), from the real page's own entry"))
             ;; Commit the warm frame's cells once, and hold them.
-            (rt/render-body warm-frame (fn [_] (sub-pass! roster) [:span]) {})
-            (let [warm-release (rt/commit-boundary! (rt/last-reads) (fn [] nil))]
-              (-> (lane/settle!)
+            (rf.bench.hicasso.arm1.runtime/render-body warm-frame (fn [_] (sub-pass! roster) [:span]) {})
+            (let [warm-release (rf.bench.hicasso.arm1.runtime/commit-boundary! (rf.bench.hicasso.arm1.runtime/last-reads) (fn [] nil))]
+              (-> (rf.bench.hicasso.lane/settle!)
                   (.then
                     (fn [_]
                       ;; ---- Phase A: the render half, sync + interleaved.
                       (let [arms  (phase-a-arms roster)
                             {:keys [readings samples]}
-                            (lane/rounds! arms sampling rounds
+                            (rf.bench.hicasso.lane/rounds! arms sampling rounds
                                           (fn [{:keys [frame pass]}]
                                             (timed-doors frame pass)))
                             rows  (arm-rows (map :id arms) readings passes-per-sample)
-                            gv    (lane/guard! samples "read-profile phase A (in-page ms, diagnostic)")
-                            ctl   (lane/control-verdict
+                            gv    (rf.bench.hicasso.lane/guard! samples "read-profile phase A (in-page ms, diagnostic)")
+                            ctl   (rf.bench.hicasso.lane/control-verdict
                                     (* 2.0 (:p50 (get rows :no-shell)))
                                     (let [s (get rows :ctl2)]
                                       {:min (:min s) :max (:max s) :mean (:p50 s)})
@@ -1103,17 +1103,17 @@
                           (throw (ex-info (str "phase-A positive control failed: " (:why ctl)) {})))
                         ;; The warm frame's cells must have stayed committed and
                         ;; the cold frame must have stayed cold.
-                        (let [{:keys [cells cell-refs]} (rt/stats)]
+                        (let [{:keys [cells cell-refs]} (rf.bench.hicasso.arm1.runtime/stats)]
                           (when-not (and (= 141 cells) (= 141 cell-refs))
                             (throw (ex-info (str "phase-A residue: cells " cells
                                                  " refs " cell-refs ", expected 141/141 "
                                                  "(the warm frame's held commit and nothing else)")
                                             {}))))
-                        (lane/record! :read-profile-census census)
-                        (lane/record! :read-profile-arms
-                                      (into {} (map (fn [[k v]] [k (-> v (update :min lane/round4)
-                                                                       (update :max lane/round4)
-                                                                       (update :p50 lane/round4))])) rows))
+                        (rf.bench.hicasso.lane/record! :read-profile-census census)
+                        (rf.bench.hicasso.lane/record! :read-profile-arms
+                                      (into {} (map (fn [[k v]] [k (-> v (update :min rf.bench.hicasso.lane/round4)
+                                                                       (update :max rf.bench.hicasso.lane/round4)
+                                                                       (update :p50 rf.bench.hicasso.lane/round4))])) rows))
                         (js/console.log ";; ==== READ PROFILE, PHASE A (ms per 141-read pass; diagnostic in-page clock) ====")
                         (js/console.log (str ";;   reads/pass 141  passes/sample " passes-per-sample
                                              "  design " rounds "x(" (:warmup sampling) "+" (:samples sampling) ")"))
@@ -1139,14 +1139,14 @@
                         ;; harvested through the door.
                         (doseq [f commit-frames] (seed-frame! f))
                         (let [entries (into {} (map (fn [f]
-                                                      (rt/render-body f (fn [_] (sub-pass! roster) [:span]) {})
-                                                      [f (rt/last-reads)]))
+                                                      (rf.bench.hicasso.arm1.runtime/render-body f (fn [_] (sub-pass! roster) [:span]) {})
+                                                      [f (rf.bench.hicasso.arm1.runtime/last-reads)]))
                                             commit-frames)
-                              sets    (into {} (map (fn [f] [f (rt/reads-of (get entries f))])) commit-frames)
-                              fss     (into {} (map (fn [f] [f (frame/frame-state-value f)])) commit-frames)]
+                              sets    (into {} (map (fn [f] [f (rf.bench.hicasso.arm1.runtime/reads-of (get entries f))])) commit-frames)
+                              fss     (into {} (map (fn [f] [f (rf.frame/frame-state-value f)])) commit-frames)]
                           (-> (residue-settle!)
                               (.then (fn [_]
-                                       (let [baseline (rt/residue)]
+                                       (let [baseline (rf.bench.hicasso.arm1.runtime/residue)]
                                          (rounds-async! (phase-b-arms entries sets fss roster)
                                                         b-sampling b-rounds baseline))))
                               (.then
@@ -1155,16 +1155,16 @@
                                         plan (phase-b-slot-plan)
                                         rows (arm-rows ids readings frames-per-window)
                                         p50s (per-round-p50s ids readings frames-per-window)
-                                        gv-b (lane/guard! samples "read-profile phase B (in-page ms, diagnostic)")]
-                                    (lane/record! :read-profile-commit
-                                                  (into {} (map (fn [[k v]] [k (-> v (update :min lane/round4)
-                                                                                   (update :max lane/round4)
-                                                                                   (update :p50 lane/round4))])) rows))
-                                    (lane/record! :read-profile-commit-per-round p50s)
-                                    (lane/record! :read-profile-commit-per-round-deltas
+                                        gv-b (rf.bench.hicasso.lane/guard! samples "read-profile phase B (in-page ms, diagnostic)")]
+                                    (rf.bench.hicasso.lane/record! :read-profile-commit
+                                                  (into {} (map (fn [[k v]] [k (-> v (update :min rf.bench.hicasso.lane/round4)
+                                                                                   (update :max rf.bench.hicasso.lane/round4)
+                                                                                   (update :p50 rf.bench.hicasso.lane/round4))])) rows))
+                                    (rf.bench.hicasso.lane/record! :read-profile-commit-per-round p50s)
+                                    (rf.bench.hicasso.lane/record! :read-profile-commit-per-round-deltas
                                                   (per-round-deltas p50s :c-local delta-arm-ids))
-                                    (lane/record! :read-profile-slot-plan
-                                                  (mapv #(update % :mean-position lane/round4) plan))
+                                    (rf.bench.hicasso.lane/record! :read-profile-slot-plan
+                                                  (mapv #(update % :mean-position rf.bench.hicasso.lane/round4) plan))
                                     (js/console.log ";; ==== READ PROFILE, PHASE B — THE COMMIT HALF (ms per 141-key boundary commit) ====")
                                     (js/console.log (phase-b-design-line b-rounds b-sampling frames-per-window))
                                     (js/console.log ";;   slot plan (each arm's kept-sample sweep positions — the schedule is indexed by SAMPLE, so this footprint repeats identically every round; rf2-lo7uy):")
@@ -1198,8 +1198,8 @@
                                       (set! (.-HICASSO_GUARD_REFUSED js/window) true))
                                     ;; ---- Micro table.
                                     (let [micro (micro-table roster)]
-                                      (lane/record! :read-profile-micro
-                                                    (into {} (map (fn [[k v]] [k (lane/round4 v)])) micro))
+                                      (rf.bench.hicasso.lane/record! :read-profile-micro
+                                                    (into {} (map (fn [[k v]] [k (rf.bench.hicasso.lane/round4 v)])) micro))
                                       (js/console.log ";; ==== MICRO (ns/op over the page's own roster) ====")
                                       (doseq [[k v] micro]
                                         (js/console.log (str ";;   " (name k) ": " (fmt v 1) " ns"))))
@@ -1215,11 +1215,11 @@
                                     (residue-settle!))))
                               (.then
                                 (fn [_]
-                                  (let [res (rt/residue)]
+                                  (let [res (rf.bench.hicasso.arm1.runtime/residue)]
                                     (when-not (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0} res)
                                       (throw (ex-info (str "final residue not clean: " (pr-str res)) {}))))
-                                  (lane/done!)))))))))))))
+                                  (rf.bench.hicasso.lane/done!)))))))))))))
       (.catch (fn [e]
-                (lane/fail! (or (some-> e .-message) (str e)))
-                (lane/done!)))))
+                (rf.bench.hicasso.lane/fail! (or (some-> e .-message) (str e)))
+                (rf.bench.hicasso.lane/done!)))))
 

--- a/bench/hicasso/src/re_frame/bench/hicasso/read_profile_baseline_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/read_profile_baseline_cljs_test.cljs
@@ -10,7 +10,7 @@
 
   Phase B's setup harvests one unclaimed read-set entry per commit frame
   — minted by a render, `refs` still zero, reaper armed. `arm1/runtime`
-  arms that reaper at [[rt/quiesced!]]'s horizon, which rf2-2rtt6.84 moved
+  arms that reaper at [[rf.bench.hicasso.arm1.runtime/quiesced!]]'s horizon, which rf2-2rtt6.84 moved
   from 0 ms to 4 ms so an entry survives long enough for `hydrateRoot`'s
   passive subscribe to claim it. A baseline read one bare macrotask later
   therefore counts every one of those entries, and by the first sampled
@@ -27,7 +27,7 @@
 
   The rows below drive `read-profile-app/residue-settle!` itself rather
   than the runtime primitive underneath it, and that is deliberate: a
-  witness that called [[rt/quiesced!]] directly would stay green however
+  witness that called [[rf.bench.hicasso.arm1.runtime/quiesced!]] directly would stay green however
   the instrument settled, which is precisely the vacuum this file exists
   to fill. Put the instrument back on a bare macrotask and both rows go
   red; move the horizon again and they stay green, because the settle
@@ -37,8 +37,8 @@
 
   Four frames — see [[commit-frames]] for why four is right here and why
   it is NOT phase B's count — one body run each through the same
-  [[rt/render-body]] door phase B's setup uses, and the same
-  [[rt/commit-boundary!]] seam its `commit` arm rides. Nothing here is
+  [[rf.bench.hicasso.arm1.runtime/render-body]] door phase B's setup uses, and the same
+  [[rf.bench.hicasso.arm1.runtime/commit-boundary!]] seam its `commit` arm rides. Nothing here is
   timed and no number is published — the claim is about reachability,
   not cost.
 
@@ -48,20 +48,20 @@
   setup's wall-clock and nothing else. Timing the harvest is not this
   file's business, and this is how it declines to."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.read-profile-app :as app]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.read-profile-app :as rf.bench.hicasso.read-profile-app]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      ;; The map shape, because a reap horizon is not observable inside
      ;; one synchronous test body — every row here is `async`.
      :async?  true
-     :init-fn (fn [] (rt/reset-runtime!))}))
+     :init-fn (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private commit-frames
   "Phase B's identically-seeded commit frames, in miniature — FOUR here
@@ -75,22 +75,22 @@
   [::b1 ::b2 ::b3 ::b4])
 
 (defn- seeded! []
-  (rt/reset-runtime!)
-  (doseq [f commit-frames] (dogfood/make-frame! f 3))
+  (rf.bench.hicasso.arm1.runtime/reset-runtime!)
+  (doseq [f commit-frames] (rf.bench.hicasso.front.dogfood/make-frame! f 3))
   nil)
 
 (defn- render-one!
   "One body run through the runtime's own door, and the read-set entry
-  that run minted read back off [[rt/last-reads]]. The entry comes back
+  that run minted read back off [[rf.bench.hicasso.arm1.runtime/last-reads]]. The entry comes back
   UNCLAIMED — `refs` zero, reaper armed **from this instant** — which is
   the state the real setup leaves behind and the state the baseline is
   taken in."
   [f]
-  (rt/render-body f
-                  (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                           (str (rt/sub [:dogfood/remaining]))])
+  (rf.bench.hicasso.arm1.runtime/render-body f
+                  (fn [_] [:li (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/todo 0]))
+                           (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))])
                   {})
-  (rt/last-reads))
+  (rf.bench.hicasso.arm1.runtime/last-reads))
 
 (defn- harvest!
   "Phase B's setup: [[render-one!]] per frame."
@@ -102,7 +102,7 @@
   through the seam React occupies, for every harvested entry, released
   again outside any window."
   [entries]
-  (let [stops (mapv (fn [e] (rt/commit-boundary! e (fn [] nil))) entries)]
+  (let [stops (mapv (fn [e] (rf.bench.hicasso.arm1.runtime/commit-boundary! e (fn [] nil))) entries)]
     (doseq [stop stops] (stop))
     nil))
 
@@ -120,17 +120,17 @@
              reapers are about to drop — a baseline the run can never
              return to, and the six-against-five the gate threw on"
       (let [!baseline (volatile! nil)]
-        (-> (app/residue-settle!)
-            (.then (fn [_] (vreset! !baseline (rt/residue)) (rt/quiesced!)))
+        (-> (rf.bench.hicasso.read-profile-app/residue-settle!)
+            (.then (fn [_] (vreset! !baseline (rf.bench.hicasso.arm1.runtime/residue)) (rf.bench.hicasso.arm1.runtime/quiesced!)))
             (.then (fn [_]
-                     (is (= @!baseline (rt/residue))
+                     (is (= @!baseline (rf.bench.hicasso.arm1.runtime/residue))
                          "the baseline is a fixed point of the runtime's own
                           settling, so every later sample can reach it")
                      (is (zero? (:entries @!baseline))
                          "and it is the post-reap state: four unclaimed
                           entries, none of them cached by the time the
                           baseline is taken")
-                     (rt/reset-runtime!)
+                     (rf.bench.hicasso.arm1.runtime/reset-runtime!)
                      (done))))))))
 
 ;; ===========================================================================
@@ -155,24 +155,24 @@
     ;; 4 ms goes back to being React's commit margin rather than a budget
     ;; for a test's own setup.
     (render-one! (first commit-frames))
-    (let [settled (lane/settle!)]
+    (let [settled (rf.bench.hicasso.lane/settle!)]
       (run! render-one! (rest commit-frames))
-      (testing "why row 1 is not free: one `lane/settle!` after the render
+      (testing "why row 1 is not free: one `rf.bench.hicasso.lane/settle!` after the render
                every unclaimed entry is STILL cached — that survival is the
                hydration margin rf2-2rtt6.84 bought, and it is what makes a
                residue reading taken there disagree with one taken after the
                runtime has quiesced"
         (-> settled
             (.then (fn [_]
-                     (is (= (count commit-frames) (:entries (rt/residue)))
+                     (is (= (count commit-frames) (:entries (rf.bench.hicasso.arm1.runtime/residue)))
                          "a bare macrotask is inside the horizon: every
                           harvested entry is still in the cache")
-                     (app/residue-settle!)))
+                     (rf.bench.hicasso.read-profile-app/residue-settle!)))
             (.then (fn [_]
-                     (is (zero? (:entries (rt/residue)))
+                     (is (zero? (:entries (rf.bench.hicasso.arm1.runtime/residue)))
                          "past it they are gone — two readings, two answers,
                           and only the second is a baseline")
-                     (rt/reset-runtime!)
+                     (rf.bench.hicasso.arm1.runtime/reset-runtime!)
                      (done))))))))
 
 ;; ===========================================================================
@@ -188,20 +188,20 @@
                end: baseline, one `commit` arm with its teardown, and the
                reading a row's worth of time later. The real run takes
                hundreds of samples over eight arms, so only its very first
-               reading can fall inside the horizon at all — `rt/quiesced!`
+               reading can fall inside the horizon at all — `rf.bench.hicasso.arm1.runtime/quiesced!`
                behind the instrument's own settle is the shortest honest
                stand-in for that, and it is what makes this row decide the
                gate rather than race it"
-        (-> (app/residue-settle!)
+        (-> (rf.bench.hicasso.read-profile-app/residue-settle!)
             (.then (fn [_]
-                     (vreset! !baseline (rt/residue))
+                     (vreset! !baseline (rf.bench.hicasso.arm1.runtime/residue))
                      (commit-arm! entries)
-                     (app/residue-settle!)))
-            (.then (fn [_] (rt/quiesced!)))
+                     (rf.bench.hicasso.read-profile-app/residue-settle!)))
+            (.then (fn [_] (rf.bench.hicasso.arm1.runtime/quiesced!)))
             (.then (fn [_]
-                     (is (= @!baseline (rt/residue))
+                     (is (= @!baseline (rf.bench.hicasso.arm1.runtime/residue))
                          "the commit half acquired 4 x 2 cells and gave
                           every one of them back, and the entry cache is
                           where the baseline left it")
-                     (rt/reset-runtime!)
+                     (rf.bench.hicasso.arm1.runtime/reset-runtime!)
                      (done))))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/read_profile_grid_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/read_profile_grid_cljs_test.cljs
@@ -12,8 +12,8 @@
 
   The line printed `0.05 / frames-per-window` as a CONSTANT over a
   variable, and the 0.05 was only ever true at even parity. The chain is
-  three links: `lane/now-ms` is clamped to 100 µs, so a raw window sample
-  is a multiple of 0.1 ms; `lane/summarise` takes the MEAN OF THE TWO
+  three links: `rf.bench.hicasso.lane/now-ms` is clamped to 100 µs, so a raw window sample
+  is a multiple of 0.1 ms; `rf.bench.hicasso.lane/summarise` takes the MEAN OF THE TWO
   MIDDLE order statistics when the kept count is even — putting the p50
   on a half-clamp grid — and a SINGLE order statistic when it is odd,
   where no halving happens; and the row then divides by the frame count.
@@ -27,7 +27,7 @@
 
   ## What is pinned, and what deliberately is not
 
-  Rows 1–2 pin the MECHANISM — `lane/summarise`'s parity behaviour — at
+  Rows 1–2 pin the MECHANISM — `rf.bench.hicasso.lane/summarise`'s parity behaviour — at
   the level the derivation depends on, because a change there is the
   other way the printed grid could quietly stop being true.
 
@@ -38,7 +38,7 @@
   is not, so it fails the moment the number goes back to being a
   literal.
 
-  Row 5 reads the LIVE shape through `app/phase-b-shape` and states its
+  Row 5 reads the LIVE shape through `rf.bench.hicasso.read-profile-app/phase-b-shape` and states its
   parity and grid. It is not a bar on the shape — the instrument is free
   to move to any parity, and the point of deriving is that it may — it
   simply records which arm of the derivation the shipped window is on,
@@ -49,8 +49,8 @@
   claim is arithmetic."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.read-profile-app :as app]))
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.read-profile-app :as rf.bench.hicasso.read-profile-app]))
 
 (defn- multiple-of?
   "`x` is a multiple of `g`, to within the float slop of dividing two
@@ -64,15 +64,15 @@
 ;; ===========================================================================
 
 (deftest an-odd-sample-count-keeps-the-p50-on-the-full-clock-grid
-  (testing "`lane/summarise` on an odd count answers a member of its own
+  (testing "`rf.bench.hicasso.lane/summarise` on an odd count answers a member of its own
            input, so a set of clamp-multiples summarises to a
            clamp-multiple and nothing finer is reachable"
     (let [xs [0.1 0.2 0.2 0.3 0.5]
-          p  (:p50 (lane/summarise xs))]
+          p  (:p50 (rf.bench.hicasso.lane/summarise xs))]
       (is (= 5 (count xs)) "the fixture is odd, which is the whole point")
       (is (some #{p} xs)
           "an odd-count p50 IS one of the readings, not a blend of two")
-      (is (multiple-of? app/clock-clamp-ms p)
+      (is (multiple-of? rf.bench.hicasso.read-profile-app/clock-clamp-ms p)
           "so it lands on the full 0.1 ms clock grid"))))
 
 ;; ===========================================================================
@@ -80,15 +80,15 @@
 ;; ===========================================================================
 
 (deftest an-even-sample-count-halves-the-grid
-  (testing "`lane/summarise` on an even count averages the two middle
+  (testing "`rf.bench.hicasso.lane/summarise` on an even count averages the two middle
            readings, which reaches values no single clock reading can
            take — that is the halving the design line depends on"
     (let [xs [0.1 0.2 0.3 0.5]
-          p  (:p50 (lane/summarise xs))]
+          p  (:p50 (rf.bench.hicasso.lane/summarise xs))]
       (is (= 4 (count xs)) "the fixture is even")
-      (is (multiple-of? (/ app/clock-clamp-ms 2.0) p)
+      (is (multiple-of? (/ rf.bench.hicasso.read-profile-app/clock-clamp-ms 2.0) p)
           "the p50 is on the half-clamp grid")
-      (is (not (multiple-of? app/clock-clamp-ms p))
+      (is (not (multiple-of? rf.bench.hicasso.read-profile-app/clock-clamp-ms p))
           "and this one is strictly OFF the full-clamp grid — 0.25 is a
            p50 no individual reading could have produced, which is what
            makes the halving real rather than nominal"))))
@@ -99,25 +99,25 @@
 
 (deftest the-derived-grid-follows-the-kept-counts-parity
   (testing "even kept total → half-clamp over frames"
-    (is (= (/ 0.05 32) (app/phase-b-grid-ms 8 {:warmup 2 :samples 8} 32))
+    (is (= (/ 0.05 32) (rf.bench.hicasso.read-profile-app/phase-b-grid-ms 8 {:warmup 2 :samples 8} 32))
         "8 x 8 = 64 kept, even")
-    (is (= (/ 0.05 4) (app/phase-b-grid-ms 4 {:warmup 2 :samples 6} 4))
+    (is (= (/ 0.05 4) (rf.bench.hicasso.read-profile-app/phase-b-grid-ms 4 {:warmup 2 :samples 6} 4))
         "4 x 6 = 24 kept, even — the shape rf2-d360z published, whose
          deltas were all multiples of 0.0125"))
 
   (testing "odd kept total → the FULL clamp over frames, twice as coarse"
-    (is (= (/ 0.1 32) (app/phase-b-grid-ms 9 {:warmup 2 :samples 7} 32))
+    (is (= (/ 0.1 32) (rf.bench.hicasso.read-profile-app/phase-b-grid-ms 9 {:warmup 2 :samples 7} 32))
         "9 x 7 = 63 kept, odd")
-    (is (= (/ 0.1 4) (app/phase-b-grid-ms 1 {:warmup 2 :samples 1} 4))
+    (is (= (/ 0.1 4) (rf.bench.hicasso.read-profile-app/phase-b-grid-ms 1 {:warmup 2 :samples 1} 4))
         "1 x 1 = 1 kept, odd"))
 
   (testing "the two parities differ by exactly the factor the halving is"
-    (is (= 2.0 (/ (app/phase-b-grid-ms 9 {:warmup 2 :samples 7} 32)
-                  (app/phase-b-grid-ms 8 {:warmup 2 :samples 8} 32)))))
+    (is (= 2.0 (/ (rf.bench.hicasso.read-profile-app/phase-b-grid-ms 9 {:warmup 2 :samples 7} 32)
+                  (rf.bench.hicasso.read-profile-app/phase-b-grid-ms 8 {:warmup 2 :samples 8} 32)))))
 
   (testing "frames scale it independently of parity"
-    (is (= 8.0 (/ (app/phase-b-grid-ms 8 {:warmup 2 :samples 8} 4)
-                  (app/phase-b-grid-ms 8 {:warmup 2 :samples 8} 32))))))
+    (is (= 8.0 (/ (rf.bench.hicasso.read-profile-app/phase-b-grid-ms 8 {:warmup 2 :samples 8} 4)
+                  (rf.bench.hicasso.read-profile-app/phase-b-grid-ms 8 {:warmup 2 :samples 8} 32))))))
 
 ;; ===========================================================================
 ;; 4 — the design LINE prints the derivation, not a constant
@@ -126,7 +126,7 @@
 (deftest the-design-line-prints-the-derived-grid-at-both-parities
   (testing "at the even shape the window ships, the line carries the
            halved grid and says so"
-    (let [line (app/phase-b-design-line 8 {:warmup 2 :samples 8} 32)]
+    (let [line (rf.bench.hicasso.read-profile-app/phase-b-design-line 8 {:warmup 2 :samples 8} 32)]
       (is (re-find #"kept = 64 samples/arm \(EVEN" line))
       (is (re-find #"mean of two middle clock readings" line))
       (is (re-find #"grid = 0\.001563 ms/commit" line)
@@ -134,7 +134,7 @@
 
   (testing "it is the PRODUCT that decides, so moving the sample count
            alone need not flip anything — 8 x 7 is still even"
-    (let [line (app/phase-b-design-line 8 {:warmup 2 :samples 7} 32)]
+    (let [line (rf.bench.hicasso.read-profile-app/phase-b-design-line 8 {:warmup 2 :samples 7} 32)]
       (is (re-find #"kept = 56 samples/arm \(EVEN" line))
       (is (re-find #"grid = 0\.001563 ms/commit" line))))
 
@@ -142,7 +142,7 @@
            defect could not have survived: the old line held 0.05 as a
            literal and would print 0.001563 here, understating the real
            grid by 2x"
-    (let [line (app/phase-b-design-line 9 {:warmup 2 :samples 7} 32)]
+    (let [line (rf.bench.hicasso.read-profile-app/phase-b-design-line 9 {:warmup 2 :samples 7} 32)]
       (is (re-find #"kept = 63 samples/arm \(ODD" line))
       (is (re-find #"a single clock reading" line))
       (is (re-find #"grid = 0\.003125 ms/commit" line)
@@ -152,8 +152,8 @@
            tried, rather than a second expression that happens to agree"
     (doseq [[r s f] [[8 8 32] [9 7 32] [4 6 4] [3 5 16] [7 3 128]]]
       (let [sampling {:warmup 2 :samples s}
-            expected (.toFixed (app/phase-b-grid-ms r sampling f) 6)]
-        (is (str/includes? (app/phase-b-design-line r sampling f)
+            expected (.toFixed (rf.bench.hicasso.read-profile-app/phase-b-grid-ms r sampling f) 6)]
+        (is (str/includes? (rf.bench.hicasso.read-profile-app/phase-b-design-line r sampling f)
                            (str "grid = " expected " ms/commit"))
             (str "shape " r "x" s " over " f " frames"))))))
 
@@ -162,7 +162,7 @@
 ;; ===========================================================================
 
 (deftest the-live-shape-is-recorded-with-its-parity
-  (let [{:keys [rounds sampling frames]} (app/phase-b-shape)
+  (let [{:keys [rounds sampling frames]} (rf.bench.hicasso.read-profile-app/phase-b-shape)
         kept (* rounds (:samples sampling))]
     (testing "the live shape's own numbers, read off the instrument"
       (is (pos? rounds))
@@ -173,12 +173,12 @@
              prints — the two cannot drift, because there is one
              expression"
       (is (re-find (re-pattern (str "grid = "
-                                    (.toFixed (app/phase-b-grid-ms rounds sampling frames) 6)
+                                    (.toFixed (rf.bench.hicasso.read-profile-app/phase-b-grid-ms rounds sampling frames) 6)
                                     " ms/commit"))
-                   (app/phase-b-design-line rounds sampling frames))))
+                   (rf.bench.hicasso.read-profile-app/phase-b-design-line rounds sampling frames))))
 
     (testing "and the parity the line names is the parity the kept count
              actually has"
       (is (re-find (re-pattern (str "kept = " kept " samples/arm \\("
                                     (if (even? kept) "EVEN" "ODD")))
-                   (app/phase-b-design-line rounds sampling frames))))))
+                   (rf.bench.hicasso.read-profile-app/phase-b-design-line rounds sampling frames))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/read_profile_slots_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/read_profile_slots_cljs_test.cljs
@@ -14,7 +14,7 @@
 
   `read_profile_app` therefore carries three nulls, and the whole of their
   value is WHERE THEY SIT. `rounds-async!` visits arms in
-  `lane/slot-order`'s reflecting rotation, indexed by the SAMPLE and not
+  `rf.bench.hicasso.lane/slot-order`'s reflecting rotation, indexed by the SAMPLE and not
   the round, so every arm occupies a fixed multiset of sweep positions —
   the same multiset in every round of every run. The layout was chosen so
   that
@@ -40,14 +40,14 @@
   for the window this layout was built to make askable; this namespace
   only refuses to let the instrument drift out from under it."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.read-profile-app :as app]))
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.read-profile-app :as rf.bench.hicasso.read-profile-app]))
 
 (defn- slot-of [id]
-  (first (keep-indexed (fn [i x] (when (= x id) i)) app/phase-b-arm-ids)))
+  (first (keep-indexed (fn [i x] (when (= x id) i)) rf.bench.hicasso.read-profile-app/phase-b-arm-ids)))
 
 (defn- footprint [id]
-  (first (filter (comp #{id} :id) (app/phase-b-slot-plan))))
+  (first (filter (comp #{id} :id) (rf.bench.hicasso.read-profile-app/phase-b-slot-plan))))
 
 ;; ===========================================================================
 ;; 1 — the roster has ONE authority
@@ -58,17 +58,17 @@
            declares, in exactly that order — the vector index IS the slot,
            so a roster that disagreed would put every printed delta on a
            different pair of slots from the one its label names"
-    (is (= app/phase-b-arm-ids
-           (mapv :id (app/phase-b-arms {} {} {} nil)))))
+    (is (= rf.bench.hicasso.read-profile-app/phase-b-arm-ids
+           (mapv :id (rf.bench.hicasso.read-profile-app/phase-b-arms {} {} {} nil)))))
 
   (testing "ids are distinct, because `arm-rows` keys by id and a duplicate
            would silently pool two arms into one row"
-    (is (= (count app/phase-b-arm-ids)
-           (count (set app/phase-b-arm-ids)))))
+    (is (= (count rf.bench.hicasso.read-profile-app/phase-b-arm-ids)
+           (count (set rf.bench.hicasso.read-profile-app/phase-b-arm-ids)))))
 
   (testing "every null is on the roster it is a null of"
-    (is (every? (set app/phase-b-arm-ids) app/null-arm-ids))
-    (is (= 3 (count app/null-arm-ids))
+    (is (every? (set rf.bench.hicasso.read-profile-app/phase-b-arm-ids) rf.bench.hicasso.read-profile-app/null-arm-ids))
+    (is (= 3 (count rf.bench.hicasso.read-profile-app/null-arm-ids))
         "three, because one null cannot say whether what it reads is
          positional")))
 
@@ -83,7 +83,7 @@
            committed transcript"
     (is (= [:commit :c-local :c-null :c-noactivate :c-nowatch
             :c-nosub :c-noreaders :c-nomap :b-build]
-           (subvec app/phase-b-arm-ids 0 9))))
+           (subvec rf.bench.hicasso.read-profile-app/phase-b-arm-ids 0 9))))
 
   (testing "and the two added nulls sit at HIGHER slots than the null they
            join, which is what let the roster grow without a reorder"
@@ -95,16 +95,16 @@
 ;; ===========================================================================
 
 (deftest the-footprint-comes-from-the-schedule-itself
-  (let [{:keys [sampling]} (app/phase-b-shape)
+  (let [{:keys [sampling]} (rf.bench.hicasso.read-profile-app/phase-b-shape)
         {:keys [warmup samples]} sampling
-        n (count app/phase-b-arm-ids)]
+        n (count rf.bench.hicasso.read-profile-app/phase-b-arm-ids)]
 
     (testing "an arm's position at a kept sample is its index in that
-             sample's `lane/slot-order`, arm for arm"
+             sample's `rf.bench.hicasso.lane/slot-order`, arm for arm"
       (doseq [s (range warmup (+ warmup samples))]
-        (let [order (lane/slot-order n s)]
+        (let [order (rf.bench.hicasso.lane/slot-order n s)]
           (doseq [slot (range n)]
-            (is (= (nth (app/slot-positions n slot sampling) (- s warmup))
+            (is (= (nth (rf.bench.hicasso.read-profile-app/slot-positions n slot sampling) (- s warmup))
                    (first (keep-indexed (fn [p j] (when (= j slot) p)) order)))
                 (str "slot " slot " at sample " s))))))
 
@@ -115,7 +115,7 @@
         (is (= (set (range n))
                (into #{}
                      (map (fn [slot]
-                            (nth (app/slot-positions n slot sampling) (- s warmup))))
+                            (nth (rf.bench.hicasso.read-profile-app/slot-positions n slot sampling) (- s warmup))))
                      (range n)))
             (str "sample " s))))
 
@@ -123,7 +123,7 @@
              footprint is longer than another's"
       (is (= #{samples}
              (into #{} (map (fn [{:keys [positions]}] (count positions)))
-                   (app/phase-b-slot-plan)))))))
+                   (rf.bench.hicasso.read-profile-app/phase-b-slot-plan)))))))
 
 ;; ===========================================================================
 ;; 4 — THE LAYOUT: three nulls, three footprints, three questions
@@ -173,7 +173,7 @@
 ;; ===========================================================================
 
 (deftest the-published-nine-arm-null-differenced-two-different-footprints
-  (let [sampling (:sampling (app/phase-b-shape))]
+  (let [sampling (:sampling (rf.bench.hicasso.read-profile-app/phase-b-shape))]
 
     (testing "this row is about the NINE-arm rig rf2-3l6hf ran, and it is
              only about that rig while the sampling is the one it used"
@@ -186,8 +186,8 @@
              the window reported was measured across a positional
              difference, which is exactly the confound the new nulls exist
              to resolve"
-      (let [a (app/slot-footprint 9 1 sampling)
-            b (app/slot-footprint 9 2 sampling)]
+      (let [a (rf.bench.hicasso.read-profile-app/slot-footprint 9 1 sampling)
+            b (rf.bench.hicasso.read-profile-app/slot-footprint 9 2 sampling)]
         (is (not= (:positions a) (:positions b)))
         (is (= 4.5 (:mean-position a)))
         (is (= 3.375 (:mean-position b))

--- a/bench/hicasso/src/re_frame/bench/hicasso/retention_probe.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/retention_probe.cljs
@@ -109,9 +109,9 @@
 
   Owner: rf2-flqpd."
   (:require [goog.object :as gobj]
-            [re-frame.bench.p0-arms :as arms]
-            [re-frame.bench.p0-heap :as heap]
-            [re-frame.frame :as frame]))
+            [re-frame.bench.p0-arms :as rf.bench.p0-arms]
+            [re-frame.bench.p0-heap :as rf.bench.p0-heap]
+            [re-frame.frame :as rf.frame]))
 
 ;; ---------------------------------------------------------------------------
 ;; The census
@@ -147,7 +147,7 @@
   starting value once every root is unmounted."
   [frame-id]
   (try
-    (if-let [f (frame/frame frame-id)]
+    (if-let [f (rf.frame/frame frame-id)]
       (if-let [cache (:sub-cache f)]
         (let [entries   (vals @cache)
               ;; The entry shape is the sub-cache's, not this probe's, so
@@ -175,9 +175,9 @@
   disposes these; a segment entry that left them watched would retain the
   physical container and everything reachable from it — which is H2."
   [frame-id]
-  {:app-db     (try (watch-count (frame/app-db-container frame-id))
+  {:app-db     (try (watch-count (rf.frame/app-db-container frame-id))
                     (catch :default _ :unreadable))
-   :runtime-db (try (watch-count (frame/runtime-db-container frame-id))
+   :runtime-db (try (watch-count (rf.frame/runtime-db-container frame-id))
                     (catch :default _ :unreadable))})
 
 (defn census
@@ -188,8 +188,8 @@
   well, so its absence is reported (`-1`) rather than fatal."
   []
   (let [mem (when (exists? js/performance) (gobj/get js/performance "memory"))]
-    #js {"subCache"     (clj->js (sub-cache-census arms/frame-id))
-         "projections"  (clj->js (projection-census arms/frame-id))
+    #js {"subCache"     (clj->js (sub-cache-census rf.bench.p0-arms/frame-id))
+         "projections"  (clj->js (projection-census rf.bench.p0-arms/frame-id))
          "bodyChildren" (.-childElementCount js/document.body)
          "domElements"  (.-length (.querySelectorAll js/document "*"))
          ;; WHETHER THE PAGE CAN COLLECT AT ALL, reported on every reading.
@@ -214,7 +214,7 @@
   driver can force a collection and a reading taken on the collector's
   own schedule is a reading of the collector."
   []
-  (heap/install!)
+  (rf.bench.p0-heap/install!)
   (set! (.-RETENTION js/window) #js {:census (fn [] (census))})
   (set! (.-RETENTION_READY js/window) true)
   nil)

--- a/bench/hicasso/src/re_frame/bench/hicasso/shapes/bulk_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/shapes/bulk_dom_cljs_test.cljs
@@ -30,45 +30,45 @@
   Runtime: `-dom-cljs-test`. Under `:node-test` every claim degrades to a
   stated skip."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.shapes.card :as card]
-            [re-frame.bench.hicasso.shapes.feed :as shape]
-            [re-frame.bench.hicasso.shapes.large-template :as lt]
-            [re-frame.bench.hicasso.shapes.model :as m]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.shapes.card :as rf.bench.hicasso.shapes.card]
+            [re-frame.bench.hicasso.shapes.feed :as rf.bench.hicasso.shapes.feed]
+            [re-frame.bench.hicasso.shapes.large-template :as rf.bench.hicasso.shapes.large-template]
+            [re-frame.bench.hicasso.shapes.model :as rf.bench.hicasso.shapes.model]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::shape-bulk)
 
 (def ^:private predicted-boundaries
   "One page boundary plus one per card."
-  (inc shape/article-count))
+  (inc rf.bench.hicasso.shapes.feed/article-count))
 
 (def ^:private predicted-reads
   "`3` for the page chrome, `2` per card."
-  (+ 3 (* 2 shape/article-count)))
+  (+ 3 (* 2 rf.bench.hicasso.shapes.feed/article-count)))
 
 (defn- skip! [why]
   (is true (str "shape 3's witness needs a real React DOM — " why)))
 
 (defn- fresh! []
-  (lane/leave-act-environment!)
-  (shape/make-frame! frame-id)
-  (shape/reseed! frame-id)
-  (shape/reset-runs!)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.shapes.feed/make-frame! frame-id)
+  (rf.bench.hicasso.shapes.feed/reseed! frame-id)
+  (rf.bench.hicasso.shapes.feed/reset-runs!)
   frame-id)
 
 (defn- mount! []
-  (mount/root! (mount/fresh-container!) frame-id [shape/page {}]))
+  (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [rf.bench.hicasso.shapes.feed/page {}]))
 
 (defn- q [handle sel] (.querySelector (:container handle) sel))
 (defn- q* [handle sel] (array-seq (.querySelectorAll (:container handle) sel)))
@@ -80,7 +80,7 @@
   (mapv #(.-textContent %) (q* handle "[data-testid^=\"favorites-count-\"]")))
 
 (defn- canonical-card
-  "One card's subtree with attribute names sorted. `lane/canonical` walks a
+  "One card's subtree with attribute names sorted. `rf.bench.hicasso.lane/canonical` walks a
   node's CHILDREN, so the card is cloned into a box first — otherwise the
   card's own tag and attributes would sit outside the comparison, which is
   where a class difference would hide."
@@ -88,57 +88,57 @@
   (let [node (q handle (str "[data-testid=\"article-preview-" slug "\"]"))
         box  (js/document.createElement "div")]
     (.appendChild box (.cloneNode node true))
-    (lane/canonical box)))
+    (rf.bench.hicasso.lane/canonical box)))
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — the page is the shape
 ;; ---------------------------------------------------------------------------
 
 (deftest the-page-is-three-hundred-boundaries
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (let [handle (mount!)]
         (try
-          (let [{:keys [boundaries edges entries]} (rt/stats)
-                measured (lane/element-count (:container handle))]
+          (let [{:keys [boundaries edges entries]} (rf.bench.hicasso.arm1.runtime/stats)
+                measured (rf.bench.hicasso.lane/element-count (:container handle))]
             (is (= predicted-boundaries boundaries)
-                (str shape/article-count " card boundaries plus the page = "
+                (str rf.bench.hicasso.shapes.feed/article-count " card boundaries plus the page = "
                      predicted-boundaries "; measured " boundaries))
-            (is (= shape/article-count (count (q* handle ".article-list > .article-preview"))))
-            (is (= (shape/element-arithmetic) measured)
-                (str "chrome " lt/chrome-elements " + tags " shape/tag-count " + "
-                     shape/article-count " x " card/elements-per-card
-                     " = " (shape/element-arithmetic) "; the DOM holds " measured))
+            (is (= rf.bench.hicasso.shapes.feed/article-count (count (q* handle ".article-list > .article-preview"))))
+            (is (= (rf.bench.hicasso.shapes.feed/element-arithmetic) measured)
+                (str "chrome " rf.bench.hicasso.shapes.large-template/chrome-elements " + tags " rf.bench.hicasso.shapes.feed/tag-count " + "
+                     rf.bench.hicasso.shapes.feed/article-count " x " rf.bench.hicasso.shapes.card/elements-per-card
+                     " = " (rf.bench.hicasso.shapes.feed/element-arithmetic) "; the DOM holds " measured))
             (is (= predicted-reads edges))
             (is (= predicted-boundaries entries)
                 "every card reads a read SEQUENCE only it reads, so the entry
                  cache holds one per boundary — the distinct-query rung
                  `runtime/retained-inventory` says it is priced on"))
-          (is (= {:cards shape/article-count :page 1} (shape/runs))
+          (is (= {:cards rf.bench.hicasso.shapes.feed/article-count :page 1} (rf.bench.hicasso.shapes.feed/runs))
               "and the mount ran every card body once and the page's once")
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 + 3 — one commit, three hundred boundaries, and no parent rebuild
 ;; ---------------------------------------------------------------------------
 
 (deftest one-commit-re-runs-all-three-hundred-card-bodies-and-not-the-page
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (let [handle (mount!)]
         (try
           (let [before (favourite-counts handle)]
-            (is (= shape/article-count (count before)))
-            (shape/reset-runs!)
-            (rt/dispatch! frame-id [:conduit/refresh-feed])
-            (mount/settle!)
-            (is (= shape/article-count (:cards (shape/runs)))
-                (str "one commit re-ran exactly " shape/article-count " card bodies"))
-            (is (= 0 (:page (shape/runs)))
+            (is (= rf.bench.hicasso.shapes.feed/article-count (count before)))
+            (rf.bench.hicasso.shapes.feed/reset-runs!)
+            (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:conduit/refresh-feed])
+            (rf.bench.hicasso.arm1.mount/settle!)
+            (is (= rf.bench.hicasso.shapes.feed/article-count (:cards (rf.bench.hicasso.shapes.feed/runs)))
+                (str "one commit re-ran exactly " rf.bench.hicasso.shapes.feed/article-count " card bodies"))
+            (is (= 0 (:page (rf.bench.hicasso.shapes.feed/runs)))
                 "and did NOT re-run the page. A list that rebuilt its children
                  would produce the identical DOM below and would not be this
                  shape — this is the assertion that tells the two apart")
@@ -146,47 +146,47 @@
               (let [after (favourite-counts handle)]
                 (is (= (mapv #(str (inc (js/parseInt % 10))) before) after)
                     "all 300 counts incremented by one"))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 (deftest the-broad-write-can-answer-false
   (testing "the comparison above is not passing vacuously: a commit that
            moves nothing the cards read moves no card body and no count"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (do
         (fresh!)
         (let [handle (mount!)]
           (try
             (let [before (favourite-counts handle)]
-              (shape/reset-runs!)
-              (rt/dispatch! frame-id [:conduit/go-to-page 2])
-              (mount/settle!)
-              (is (= 0 (:cards (shape/runs))) "no card body ran")
-              (is (= 0 (:page (shape/runs))) "and the page reads no page number, so nor did it")
+              (rf.bench.hicasso.shapes.feed/reset-runs!)
+              (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:conduit/go-to-page 2])
+              (rf.bench.hicasso.arm1.mount/settle!)
+              (is (= 0 (:cards (rf.bench.hicasso.shapes.feed/runs))) "no card body ran")
+              (is (= 0 (:page (rf.bench.hicasso.shapes.feed/runs))) "and the page reads no page number, so nor did it")
               (is (= before (favourite-counts handle)) "and nothing in the DOM moved"))
-            (finally (mount/release! handle))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! handle))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4 — the same card, both decompositions
 ;; ---------------------------------------------------------------------------
 
 (deftest the-card-is-byte-identical-to-the-large-templates
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
-      (lane/leave-act-environment!)
-      (let [slug (shape/slug-at 3)
+      (rf.bench.hicasso.lane/leave-act-environment!)
+      (let [slug (rf.bench.hicasso.shapes.feed/slug-at 3)
             ;; Shape 2's page, on its own seed.
-            _        (m/make-frame! frame-id lt/seed)
-            _        (m/reseed! frame-id lt/seed)
-            template (mount/root! (mount/fresh-container!) frame-id [lt/page {}])
+            _        (rf.bench.hicasso.shapes.model/make-frame! frame-id rf.bench.hicasso.shapes.large-template/seed)
+            _        (rf.bench.hicasso.shapes.model/reseed! frame-id rf.bench.hicasso.shapes.large-template/seed)
+            template (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [rf.bench.hicasso.shapes.large-template/page {}])
             from-template (canonical-card template slug)
-            _        (mount/release! template)
+            _        (rf.bench.hicasso.arm1.mount/release! template)
             ;; Shape 3's page, on its own.
-            _        (m/reseed! frame-id shape/seed)
+            _        (rf.bench.hicasso.shapes.model/reseed! frame-id rf.bench.hicasso.shapes.feed/seed)
             feed     (mount! )
             from-feed (canonical-card feed slug)]
-        (mount/release! feed)
+        (rf.bench.hicasso.arm1.mount/release! feed)
         (is (= from-template from-feed)
             "the ~1,200-element template and the 300-boundary page build the
              SAME card — so the only difference between the two shapes is
@@ -199,21 +199,21 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest three-hundred-boundaries-leave-no-residue
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (async done
       (fresh!)
       (let [handle (mount!)]
-        (rt/dispatch! frame-id [:conduit/refresh-feed])
-        (mount/settle!)
-        (is (pos? (:cell-refs (rt/stats))))
-        (mount/unmount! handle)
+        (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:conduit/refresh-feed])
+        (rf.bench.hicasso.arm1.mount/settle!)
+        (is (pos? (:cell-refs (rf.bench.hicasso.arm1.runtime/stats))))
+        (rf.bench.hicasso.arm1.mount/unmount! handle)
         (js/setTimeout (fn []
                          (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                                (rt/residue))
+                                (rf.bench.hicasso.arm1.runtime/residue))
                              (str predicted-boundaries " boundaries and "
                                   predicted-reads " edges, all released by React's
                                   own cleanup"))
-                         (rt/reset-runtime!)
+                         (rf.bench.hicasso.arm1.runtime/reset-runtime!)
                          (done))
                        8)))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/shapes/card.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/shapes/card.cljs
@@ -56,7 +56,7 @@
   `.cljc`-compatible by construction: no interop, no JS literal."
   (:require [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
             [re-frame.bench.hicasso.front.route-link :refer [route-link]]
-            [re-frame.bench.hicasso.shapes.model :as m]))
+            [re-frame.bench.hicasso.shapes.model :as rf.bench.hicasso.shapes.model]))
 
 (def elements-per-card
   "The element count of one rendered card, with the two tags
@@ -89,7 +89,7 @@
      [:div.article-meta
       (route-link {:to :conduit.profile/show :params {:username (:username author)}
                    :class "author-link"}
-        [:img.user-pic {:src (m/avatar-src (:image author)) :alt ""}])
+        [:img.user-pic {:src (rf.bench.hicasso.shapes.model/avatar-src (:image author)) :alt ""}])
       [:div.info
        (route-link {:to :conduit.profile/show :params {:username (:username author)}
                     :class "author"}

--- a/bench/hicasso/src/re_frame/bench/hicasso/shapes/census_clock_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/shapes/census_clock_app.cljs
@@ -54,10 +54,10 @@
   beside the gate, never as a second gate.
 
   Owner: rf2-2rtt6.1 (standard); this entry rf2-2rtt6.56."
-  (:require [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.shapes.census-clock-arms :as arms]
+  (:require [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.shapes.census-clock-arms :as rf.bench.hicasso.shapes.census-clock-arms]
             [re-frame.core :as rf]))
 
 ;; ---------------------------------------------------------------------------
@@ -73,8 +73,8 @@
 
 (defn- install! [which]
   (rf/init! (case which
-              :reagent reagent-adapter/adapter
-              uix-adapter/adapter))
+              :reagent rf.adapter.reagent/adapter
+              rf.adapter.uix/adapter))
   which)
 
 ;; ---------------------------------------------------------------------------
@@ -91,9 +91,9 @@
 (defonce ^:private state (atom {:adapter nil :pending nil :tally nil}))
 
 (defn- arms-for [row-key]
-  (-> [arms/plumb-arm]
-      (into (map #(arms/arm row-key %)) (get arm-ids-for (:adapter @state)))
-      (conj (arms/arm row-key :ctl-2x))))
+  (-> [rf.bench.hicasso.shapes.census-clock-arms/plumb-arm]
+      (into (map #(rf.bench.hicasso.shapes.census-clock-arms/arm row-key %)) (get arm-ids-for (:adapter @state)))
+      (conj (rf.bench.hicasso.shapes.census-clock-arms/arm row-key :ctl-2x))))
 
 (defn- arm-named [row-key arm-id]
   (first (filter #(= arm-id (:id %)) (arms-for row-key))))
@@ -116,7 +116,7 @@
     ok?))
 
 (defn sample!
-  "ONE mount through `lane/mount-arm!` — the in-page flushSync window
+  "ONE mount through `rf.bench.hicasso.lane/mount-arm!` — the in-page flushSync window
   rides beside the protocol reading on the same operation — left
   STANDING, settled to the next frame. The tare's operation is the settle
   and nothing else."
@@ -124,7 +124,7 @@
   (let [arm (arm-named row-key arm-id)]
     (if (:plumb? arm)
       (.then (settle-frame) (fn [_] (bank! true) #js {:inPageMs 0 :ok true}))
-      (let [mnt (lane/mount-arm! arm {})]
+      (let [mnt (rf.bench.hicasso.lane/mount-arm! arm {})]
         (swap! state assoc :pending {:mnt mnt :arm arm})
         (.then (settle-frame) (fn [_] #js {:inPageMs (:ms mnt) :ok true}))))))
 
@@ -134,10 +134,10 @@
   row must not be charged for."
   [row-key]
   (if-some [{:keys [mnt arm]} (:pending @state)]
-    (let [ok? (= (arms/expected-elements row-key (:id arm))
-                 (lane/element-count (:container mnt)))]
+    (let [ok? (= (rf.bench.hicasso.shapes.census-clock-arms/expected-elements row-key (:id arm))
+                 (rf.bench.hicasso.lane/element-count (:container mnt)))]
       (bank! ok?)
-      (lane/release! mnt)
+      (rf.bench.hicasso.lane/release! mnt)
       (swap! state assoc :pending nil)
       (.then (settle-frame) (fn [_] #js {:ok ok?})))
     (.then (settle-frame) (fn [_] #js {:ok true}))))
@@ -164,14 +164,14 @@
   (let [arm (arm-named row-key arm-id)]
     (if (:plumb? arm)
       #js {:arm (name arm-id) :hash 0 :bytes 0 :control true}
-      (let [mnt (lane/mount-arm! arm {})
-            s   (lane/canonical (:container mnt))]
-        (lane/release! mnt)
-        ;; `lane/utf8-bytes` and not `count`: the driver prints this under a
+      (let [mnt (rf.bench.hicasso.lane/mount-arm! arm {})
+            s   (rf.bench.hicasso.lane/canonical (:container mnt))]
+        (rf.bench.hicasso.lane/release! mnt)
+        ;; `rf.bench.hicasso.lane/utf8-bytes` and not `count`: the driver prints this under a
         ;; `bytes` label, and `count` answers UTF-16 code units (rf2-2rtt6.121).
         #js {:arm     (name arm-id)
              :hash    (str-hash s)
-             :bytes   (lane/utf8-bytes s)
+             :bytes   (rf.bench.hicasso.lane/utf8-bytes s)
              :control (boolean (:control? arm))}))))
 
 ;; ---------------------------------------------------------------------------
@@ -182,23 +182,23 @@
   (let [which   (query-adapter)
         arm-ids (get arm-ids-for which)]
     (install! which)
-    (lane/leave-act-environment!)
-    (swap! state assoc :adapter which :tally (lane/tally))
-    (arms/ensure-frames! arm-ids)
+    (rf.bench.hicasso.lane/leave-act-environment!)
+    (swap! state assoc :adapter which :tally (rf.bench.hicasso.lane/tally))
+    (rf.bench.hicasso.shapes.census-clock-arms/ensure-frames! arm-ids)
     ;; The fairness gate, whole and fatal-on-fail: every arm of this run
     ;; builds each row's page at the stress size and at a small size, the
     ;; counts match the arithmetic, and the comparison is proven able to
     ;; answer false. Runs before the driver reads a single counter; the
     ;; driver refuses the run if it failed.
-    (let [problems  (arms/parity-problems arm-ids)
+    (let [problems  (rf.bench.hicasso.shapes.census-clock-arms/parity-problems arm-ids)
           can-fail? (when (empty? problems)
-                      (arms/parity-can-fail? arm-ids))]
+                      (rf.bench.hicasso.shapes.census-clock-arms/parity-can-fail? arm-ids))]
       (set! (.-C56CLOCK_PARITY js/window)
             (clj->js {"ok"       (and (empty? problems) (boolean can-fail?))
                       "canFail"  (boolean can-fail?)
                       "problems" (mapv pr-str problems)})))
     (set! (.-C56CLOCK js/window)
-          (lane/legible-doors
+          (rf.bench.hicasso.lane/legible-doors
           #js {:adapter       (name which)
                :plan          (fn [row]
                                 (clj->js (mapv (fn [a] {:id      (name (:id a))
@@ -206,16 +206,16 @@
                                                         :plumb   (boolean (:plumb? a))})
                                                (arms-for (keyword row)))))
                :elements      (fn [row arm]
-                                (arms/expected-elements (keyword row) (keyword arm)))
-               :ctlPredicted  (fn [row] (arms/ctl-predicted (keyword row)))
+                                (rf.bench.hicasso.shapes.census-clock-arms/expected-elements (keyword row) (keyword arm)))
+               :ctlPredicted  (fn [row] (rf.bench.hicasso.shapes.census-clock-arms/ctl-predicted (keyword row)))
                :canon         (fn [row arm] (canon! (keyword row) (keyword arm)))
                :sample        (fn [row arm] (sample! (keyword row) (keyword arm)))
                :reap          (fn [row] (reap! (keyword row)))
                :settle        (fn [] (settle-frame))
-               :tally         (fn [] (clj->js (lane/tally-value (:tally @state))))
-               :teardownCheck (fn [] (clj->js (mapv :where (lane/drain-teardown-failures!))))
-               :runtime       (fn [] (pr-str (lane/runtime-label)))
-               :residue       (fn [] (pr-str (lane/residue (arms/frame-of :feed :hicasso))))}))
+               :tally         (fn [] (clj->js (rf.bench.hicasso.lane/tally-value (:tally @state))))
+               :teardownCheck (fn [] (clj->js (mapv :where (rf.bench.hicasso.lane/drain-teardown-failures!))))
+               :runtime       (fn [] (pr-str (rf.bench.hicasso.lane/runtime-label)))
+               :residue       (fn [] (pr-str (rf.bench.hicasso.lane/residue (rf.bench.hicasso.shapes.census-clock-arms/frame-of :feed :hicasso))))}))
     (set! (.-C56CLOCK_READY js/window) true)
     (js/console.log ";; C56CLOCK ready")
     nil))

--- a/bench/hicasso/src/re_frame/bench/hicasso/shapes/census_clock_arms.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/shapes/census_clock_arms.cljs
@@ -79,16 +79,16 @@
   amendment); this entry rf2-2rtt6.56."
   (:require ["react" :as react]
             ["react-dom/client" :as react-dom-client]
-            [re-frame.adapter.uix :as uixa]
-            [re-frame.bench.hicasso.arm1.mount :as arm1-mount]
-            [re-frame.bench.hicasso.front.codec :as codec]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.shapes.feed :as feed]
-            [re-frame.bench.hicasso.shapes.large-template :as lt]
-            [re-frame.bench.hicasso.shapes.model :as m]
-            [re-frame.bench.hicasso.shapes.ordinary :as ordinary]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.shapes.feed :as rf.bench.hicasso.shapes.feed]
+            [re-frame.bench.hicasso.shapes.large-template :as rf.bench.hicasso.shapes.large-template]
+            [re-frame.bench.hicasso.shapes.model :as rf.bench.hicasso.shapes.model]
+            [re-frame.bench.hicasso.shapes.ordinary :as rf.bench.hicasso.shapes.ordinary]
             [re-frame.core :as rf]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.late-bind :as rf.late-bind]
             [reagent.dom.client :as rdc]
             [uix.core :refer [$ defui]])
   (:require-macros [re-frame.core :refer [reg-view]]))
@@ -97,7 +97,7 @@
 ;; The three rows, their seeds and their arithmetic
 ;; ===========================================================================
 ;;
-;; Stress seeds are the roster's own (`lt/seed`, `feed/seed`, and the
+;; Stress seeds are the roster's own (`rf.bench.hicasso.shapes.large-template/seed`, `rf.bench.hicasso.shapes.feed/seed`, and the
 ;; ordinary witness's `{:articles 2 :comments 5 :tags 2}`), so a clock row
 ;; is taken on exactly the page the roster's witnesses assert. Small seeds
 ;; exist for the parity gate — agreement at one size is not evidence until
@@ -105,24 +105,24 @@
 
 (def rows
   {:large-template
-   {:seed     lt/seed
+   {:seed     rf.bench.hicasso.shapes.large-template/seed
     :small-a  {:articles 6 :tags 10}
     :small-b  {:articles 7 :tags 10}
     :elements (fn [{:keys [articles]}]
-                (+ lt/chrome-elements lt/tag-count (* 17 articles)))}
+                (+ rf.bench.hicasso.shapes.large-template/chrome-elements rf.bench.hicasso.shapes.large-template/tag-count (* 17 articles)))}
    :feed
-   {:seed     feed/seed
+   {:seed     rf.bench.hicasso.shapes.feed/seed
     :small-a  {:articles 6 :tags 10}
     :small-b  {:articles 7 :tags 10}
     :elements (fn [{:keys [articles]}]
-                (+ lt/chrome-elements lt/tag-count (* 17 articles)))}
+                (+ rf.bench.hicasso.shapes.large-template/chrome-elements rf.bench.hicasso.shapes.large-template/tag-count (* 17 articles)))}
    :ordinary
    {:seed     {:articles 2 :comments 5 :tags 2}
     :small-a  {:articles 2 :comments 3 :tags 2}
     :small-b  {:articles 2 :comments 4 :tags 2}
     :elements (fn [{:keys [comments]}]
                 (let [mine (count (filter #(zero? (mod % 4)) (range comments)))]
-                  (ordinary/element-arithmetic comments mine)))}})
+                  (rf.bench.hicasso.shapes.ordinary/element-arithmetic comments mine)))}})
 
 (defn- doubled
   "The seed at TWICE the row's card count — what the positive control
@@ -171,8 +171,8 @@
           arm-id  arm-ids
           :when   (not= arm-id :floor)]
     (let [fid (frame-of row-key arm-id)]
-      (m/make-frame! fid (:seed (get rows row-key)))
-      (m/reseed! fid (:seed (get rows row-key)))
+      (rf.bench.hicasso.shapes.model/make-frame! fid (:seed (get rows row-key)))
+      (rf.bench.hicasso.shapes.model/reseed! fid (:seed (get rows row-key)))
       (prime-frame! fid)))
   nil)
 
@@ -182,7 +182,7 @@
   [row-key arm-ids seed]
   (doseq [arm-id arm-ids
           :when  (not= arm-id :floor)]
-    (m/reseed! (frame-of row-key arm-id) seed))
+    (rf.bench.hicasso.shapes.model/reseed! (frame-of row-key arm-id) seed))
   nil)
 
 ;; ===========================================================================
@@ -242,10 +242,10 @@
 ;; resolved routes would be a fourth arm rather than a floor.
 
 (def ^:private link-model
-  (delay (late-bind/require-fn! :routing/link-model 'census-clock-arms {} {})))
+  (delay (rf.late-bind/require-fn! :routing/link-model 'census-clock-arms {} {})))
 
 (def ^:private activate-link!
-  (delay (late-bind/require-fn! :routing/activate-link! 'census-clock-arms {} {})))
+  (delay (rf.late-bind/require-fn! :routing/activate-link! 'census-clock-arms {} {})))
 
 (defn- route-attrs
   "One census anchor's routing-owned half: the href routing synthesises for
@@ -266,7 +266,7 @@
 ;; ARM: the React floor — the calibrator, no substrate at all
 ;; ===========================================================================
 ;;
-;; Hand-written `createElement` over a plain seeded value (`m/seed-db`
+;; Hand-written `createElement` over a plain seeded value (`rf.bench.hicasso.shapes.model/seed-db`
 ;; called directly — no frame, no subscription, no handler indirection).
 ;; One hoisted inert handler, for the reason hd8's floor hoists its own:
 ;; the calibrator must not be billed for a closure per element that no
@@ -286,7 +286,7 @@
               (fel "a" #js {:className "author-link"
                             :href (str "#/profile/" (:username author))}
                    (fel "img" #js {:className "user-pic"
-                                   :src (m/avatar-src (:image author)) :alt ""}))
+                                   :src (rf.bench.hicasso.shapes.model/avatar-src (:image author)) :alt ""}))
               (fel "div" #js {:className "info"}
                    (fel "a" #js {:className "author"
                                  :href (str "#/profile/" (:username author))}
@@ -371,7 +371,7 @@
                 (fel "a" #js {:className "comment-author"
                               :href (str "#/profile/" (:username author))}
                      (fel "img" #js {:className "comment-author-img"
-                                     :src (m/avatar-src (:image author)) :alt ""})
+                                     :src (rf.bench.hicasso.shapes.model/avatar-src (:image author)) :alt ""})
                      " "
                      (:username author))
                 (fel "span" #js {:className "date-posted"} createdAt)
@@ -450,7 +450,7 @@
     ($ :div.article-preview {:key slug :data-testid (str "article-preview-" slug)}
        ($ :div.article-meta
           ($ :a.author-link {:href (:href pic-link) :on-click (:on-click pic-link)}
-             ($ :img.user-pic {:src (m/avatar-src (:image author)) :alt ""}))
+             ($ :img.user-pic {:src (rf.bench.hicasso.shapes.model/avatar-src (:image author)) :alt ""}))
           ($ :div.info
              ($ :a.author {:href (:href name-link) :on-click (:on-click name-link)}
                 (:username author))
@@ -520,12 +520,12 @@
   shape (five coarse reads) is NOT the census's (141 per-instance) —
   the stamp says so on every row."
   [_props]
-  (let [frame      (uixa/use-current-frame)
-        order      (uixa/use-subscribe frame [:conduit/slugs])
-        articles   (uixa/use-subscribe frame [:census56/articles])
-        tags       (uixa/use-subscribe frame [:conduit/tags])
-        your-feed? (uixa/use-subscribe frame [:conduit/your-feed?])
-        pending    (uixa/use-subscribe frame [:census56/pending])
+  (let [frame      (rf.adapter.uix/use-current-frame)
+        order      (rf.adapter.uix/use-subscribe frame [:conduit/slugs])
+        articles   (rf.adapter.uix/use-subscribe frame [:census56/articles])
+        tags       (rf.adapter.uix/use-subscribe frame [:conduit/tags])
+        your-feed? (rf.adapter.uix/use-subscribe frame [:conduit/your-feed?])
+        pending    (rf.adapter.uix/use-subscribe frame [:census56/pending])
         d          (dispatch-for frame)]
     (ux-chrome your-feed? tags d
                (for [slug order]
@@ -536,19 +536,19 @@
   "SHAPE 3's card in UIx — one component per card, the census's own
   per-instance read pair, three hooks."
   [{:keys [slug]}]
-  (let [frame    (uixa/use-current-frame)
-        article  (uixa/use-subscribe frame [:conduit/article slug])
-        pending? (uixa/use-subscribe frame [:conduit/favorite-pending? slug])
+  (let [frame    (rf.adapter.uix/use-current-frame)
+        article  (rf.adapter.uix/use-subscribe frame [:conduit/article slug])
+        pending? (rf.adapter.uix/use-subscribe frame [:conduit/favorite-pending? slug])
         d        (dispatch-for frame)]
     (ux-card-body slug article pending? d frame)))
 
 (defui ux-feed-page
   "SHAPE 3 in UIx — the same feed, one boundary per card."
   [_props]
-  (let [frame      (uixa/use-current-frame)
-        order      (uixa/use-subscribe frame [:conduit/slugs])
-        tags       (uixa/use-subscribe frame [:conduit/tags])
-        your-feed? (uixa/use-subscribe frame [:conduit/your-feed?])
+  (let [frame      (rf.adapter.uix/use-current-frame)
+        order      (rf.adapter.uix/use-subscribe frame [:conduit/slugs])
+        tags       (rf.adapter.uix/use-subscribe frame [:conduit/tags])
+        your-feed? (rf.adapter.uix/use-subscribe frame [:conduit/your-feed?])
         d          (dispatch-for frame)]
     (ux-chrome your-feed? tags d
                (for [slug order]
@@ -560,10 +560,10 @@
   edge the census page charges only to the reader's own (the dogfood UIx
   rendering records the same limit)."
   [{:keys [id]}]
-  (let [frame    (uixa/use-current-frame)
-        c        (uixa/use-subscribe frame [:conduit/comment id])
-        user     (uixa/use-subscribe frame [:conduit/user])
-        deleting? (uixa/use-subscribe frame [:conduit/delete-pending? id])
+  (let [frame    (rf.adapter.uix/use-current-frame)
+        c        (rf.adapter.uix/use-subscribe frame [:conduit/comment id])
+        user     (rf.adapter.uix/use-subscribe frame [:conduit/user])
+        deleting? (rf.adapter.uix/use-subscribe frame [:conduit/delete-pending? id])
         d        (dispatch-for frame)
         {:keys [body createdAt author]} c
         mine?    (= (:username user) (:username author))
@@ -573,7 +573,7 @@
           ($ :p.card-text {:data-testid "comment-body"} body))
        ($ :div.card-footer
           ($ :a.comment-author {:href (:href byline) :on-click (:on-click byline)}
-             ($ :img.comment-author-img {:src (m/avatar-src (:image author)) :alt ""})
+             ($ :img.comment-author-img {:src (rf.bench.hicasso.shapes.model/avatar-src (:image author)) :alt ""})
              " "
              (:username author))
           ($ :span.date-posted createdAt)
@@ -586,9 +586,9 @@
                ($ :i.ion-trash-a)))))))
 
 (defui ux-comment-form [_props]
-  (let [frame    (uixa/use-current-frame)
-        pending? (uixa/use-subscribe frame [:conduit/comment-pending?])
-        draft    (uixa/use-subscribe frame [:conduit/draft m/comment-draft-key])
+  (let [frame    (rf.adapter.uix/use-current-frame)
+        pending? (rf.adapter.uix/use-subscribe frame [:conduit/comment-pending?])
+        draft    (rf.adapter.uix/use-subscribe frame [:conduit/draft rf.bench.hicasso.shapes.model/comment-draft-key])
         d        (dispatch-for frame)]
     ($ :form.card.comment-form {:data-testid "comment-form"
                                 :on-submit   (fn [e]
@@ -601,7 +601,7 @@
               :placeholder "Write a comment..."
               :value       draft
               :disabled    pending?
-              :on-input    (fn [e] (d [:conduit/edit-draft m/comment-draft-key
+              :on-input    (fn [e] (d [:conduit/edit-draft rf.bench.hicasso.shapes.model/comment-draft-key
                                        (.. e -target -value)]))}))
        ($ :div.card-footer
           ($ :button.btn.btn-sm.btn-primary {:type        "submit"
@@ -613,8 +613,8 @@
   "SHAPE 1 in UIx — the article page's comment column, the roster's own
   seven-boundary decomposition."
   [_props]
-  (let [frame (uixa/use-current-frame)
-        ids   (uixa/use-subscribe frame [:conduit/comment-ids])]
+  (let [frame (rf.adapter.uix/use-current-frame)
+        ids   (rf.adapter.uix/use-subscribe frame [:conduit/comment-ids])]
     ($ :div.article-page
        ($ :div.container.page
           ($ :div.row
@@ -653,7 +653,7 @@
     [:div.article-preview {:key slug :data-testid (str "article-preview-" slug)}
      [:div.article-meta
       [:a.author-link {:href (:href pic-link) :on-click (:on-click pic-link)}
-       [:img.user-pic {:src (m/avatar-src (:image author)) :alt ""}]]
+       [:img.user-pic {:src (rf.bench.hicasso.shapes.model/avatar-src (:image author)) :alt ""}]]
       [:div.info
        [:a.author {:href (:href name-link) :on-click (:on-click name-link)} (:username author)]
        [:span.date createdAt]]
@@ -750,7 +750,7 @@
       [:p.card-text {:data-testid "comment-body"} body]]
      [:div.card-footer
       [:a.comment-author {:href (:href byline) :on-click (:on-click byline)}
-       [:img.comment-author-img {:src (m/avatar-src (:image author)) :alt ""}]
+       [:img.comment-author-img {:src (rf.bench.hicasso.shapes.model/avatar-src (:image author)) :alt ""}]
        " "
        (:username author)]
       [:span.date-posted createdAt]
@@ -773,10 +773,10 @@
       [:textarea.form-control {:data-testid "comment-body-input"
                                :rows        3
                                :placeholder "Write a comment..."
-                               :value       @(subscribe [:conduit/draft m/comment-draft-key])
+                               :value       @(subscribe [:conduit/draft rf.bench.hicasso.shapes.model/comment-draft-key])
                                :disabled    pending?
                                :on-input    (fn [e] (dispatch [:conduit/edit-draft
-                                                               m/comment-draft-key
+                                                               rf.bench.hicasso.shapes.model/comment-draft-key
                                                                (.. e -target -value)]))}]]
      [:div.card-footer
       [:button.btn.btn-sm.btn-primary {:type        "submit"
@@ -802,9 +802,9 @@
 ;; ===========================================================================
 
 (def ^:private hicasso-page
-  {:large-template lt/page
-   :feed           feed/page
-   :ordinary       ordinary/screen})
+  {:large-template rf.bench.hicasso.shapes.large-template/page
+   :feed           rf.bench.hicasso.shapes.feed/page
+   :ordinary       rf.bench.hicasso.shapes.ordinary/screen})
 
 (def ^:private ux-page
   {:large-template ux-lt-page
@@ -826,22 +826,22 @@
 
 (defn arm
   "The lane arm for `arm-id` on `row-key` — `{:id :mount :unmount}`, the
-  shape `lane/mount-arm!` times. `:floor` and `:ctl-2x` close over plain
+  shape `rf.bench.hicasso.lane/mount-arm!` times. `:floor` and `:ctl-2x` close over plain
   seeded values built at load; the reactive arms close over their frames."
   [row-key arm-id]
   (let [fid (frame-of row-key arm-id)]
     (case arm-id
-      :floor   (let [db (m/seed-db (:seed (get rows row-key)))]
+      :floor   (let [db (rf.bench.hicasso.shapes.model/seed-db (:seed (get rows row-key)))]
                  (react-root-arm :floor (fn [] (floor-element row-key db))))
-      :ctl-2x  (let [db (m/seed-db (doubled row-key))]
+      :ctl-2x  (let [db (rf.bench.hicasso.shapes.model/seed-db (doubled row-key))]
                  (assoc (react-root-arm :ctl-2x (fn [] (floor-element row-key db)))
                         :control? true
                         :parity-exempt? true))
       :hicasso (react-root-arm :hicasso
-                 (fn [] (arm1-mount/provider fid
-                          (codec/as-element [(get hicasso-page row-key) {}]))))
+                 (fn [] (rf.bench.hicasso.arm1.mount/provider fid
+                          (rf.bench.hicasso.front.codec/as-element [(get hicasso-page row-key) {}]))))
       :uix     (react-root-arm :uix
-                 (fn [] ($ uixa/frame-provider {:frame fid}
+                 (fn [] ($ rf.adapter.uix/frame-provider {:frame fid}
                            ($ (get ux-page row-key) {}))))
       :reagent {:id      :reagent
                 :mount   (fn [container _props _n]
@@ -880,13 +880,13 @@
   [row-key arm-ids seed]
   (reseed-row! row-key arm-ids seed)
   (let [expected (elements-at row-key seed)
-        db       (m/seed-db seed)
+        db       (rf.bench.hicasso.shapes.model/seed-db seed)
         arms     (mapv (fn [id]
                          (if (= id :floor)
                            (react-root-arm :floor (fn [] (floor-element row-key db)))
                            (arm row-key id)))
                        arm-ids)
-        p        (lane/parity arms {})]
+        p        (rf.bench.hicasso.lane/parity arms {})]
     (try
       {:agree?    (:agree? p)
        :counts    (:counts p)
@@ -894,7 +894,7 @@
        :reference (:reference p)
        :disagree  (:disagree p)}
       (finally
-        (doseq [mnt (:mounts p)] (lane/release! mnt))))))
+        (doseq [mnt (:mounts p)] (rf.bench.hicasso.lane/release! mnt))))))
 
 (defn parity-problems
   "Every row, at stress size and at a small size: every arm builds ONE

--- a/bench/hicasso/src/re_frame/bench/hicasso/shapes/feed.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/shapes/feed.cljs
@@ -25,14 +25,14 @@
 
       ;; large-template, one boundary:
       (for [slug (sub [:conduit/slugs])]
-        (card/card slug))
+        (rf.bench.hicasso.shapes.card/card slug))
 
       ;; feed, one boundary per card:
       (for [slug (sub [:conduit/slugs])]
         [article-card {:key slug :slug slug}])
 
   plus the four lines of [[article-card]] below, whose entire body is the
-  same `(card/card slug)`. `bulk_dom_cljs_test` asserts the two pages
+  same `(rf.bench.hicasso.shapes.card/card slug)`. `bulk_dom_cljs_test` asserts the two pages
   build byte-identical card DOM, so \"the only edit\" is a comparison and
   not a claim.
 
@@ -61,9 +61,9 @@
 
   `.cljc`-compatible by construction (HD-020(d))."
   (:require [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
-            [re-frame.bench.hicasso.shapes.card :as card]
-            [re-frame.bench.hicasso.shapes.large-template :as lt]
-            [re-frame.bench.hicasso.shapes.model :as m])
+            [re-frame.bench.hicasso.shapes.card :as rf.bench.hicasso.shapes.card]
+            [re-frame.bench.hicasso.shapes.large-template :as rf.bench.hicasso.shapes.large-template]
+            [re-frame.bench.hicasso.shapes.model :as rf.bench.hicasso.shapes.model])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 (def article-count
@@ -78,7 +78,7 @@
   "Predicted element count — the same chrome as the large template, the
   same card, a different number of them."
   []
-  (+ lt/chrome-elements tag-count (* card/elements-per-card article-count)))
+  (+ rf.bench.hicasso.shapes.large-template/chrome-elements tag-count (* rf.bench.hicasso.shapes.card/elements-per-card article-count)))
 
 (def !card-runs
   "How many card bodies have run. Shape 3's claim is that one commit makes
@@ -100,7 +100,7 @@
   [[re-frame.bench.hicasso.shapes.card]] for why that is the point."
   [{:keys [slug]}]
   (swap! !card-runs inc)
-  (card/card slug))
+  (rf.bench.hicasso.shapes.card/card slug))
 
 (defview page
   "The feed, one boundary per card."
@@ -142,11 +142,11 @@
                                       :data-testid (str "tag-" tag)}
              tag])]]]]]]))
 
-(defn make-frame! [frame-id] (m/make-frame! frame-id seed))
-(defn reseed! [frame-id] (m/reseed! frame-id seed))
+(defn make-frame! [frame-id] (rf.bench.hicasso.shapes.model/make-frame! frame-id seed))
+(defn reseed! [frame-id] (rf.bench.hicasso.shapes.model/reseed! frame-id seed))
 
 (defn slug-at
   "The slug of the `i`th article, for a witness that wants to name one row
   out of three hundred."
   [i]
-  (:slug (m/article i)))
+  (:slug (rf.bench.hicasso.shapes.model/article i)))

--- a/bench/hicasso/src/re_frame/bench/hicasso/shapes/framework_subs_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/shapes/framework_subs_dom_cljs_test.cljs
@@ -68,21 +68,21 @@
   Runtime: `-dom-cljs-test`. Under `:node-test` every claim degrades to a
   stated skip."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.hook-probe :as probe]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt :refer [sub]]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.shapes.model :as m]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.hook-probe :as rf.bench.hicasso.arm1.hook-probe]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime :refer [sub]]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.shapes.model :as rf.bench.hicasso.shapes.model]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
+            [re-frame.fx :as rf.fx]
             [re-frame.http.managed]
             [re-frame.resources]
-            [re-frame.resources.state :as state]
+            [re-frame.resources.state :as rf.resources.state]
             [re-frame.resources.test-support]
             [re-frame.schemas]
-            [re-frame.subs :as subs]
-            [re-frame.test-support :as test-support])
+            [re-frame.subs :as rf.subs]
+            [re-frame.test-support :as rf.test-support])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 ;; ---------------------------------------------------------------------------
@@ -101,15 +101,15 @@
   fixture on an async suite to be a map)."
   {:before (fn []
              (reset! !managed [])
-             (fx/reg-fx :rf.http/managed
+             (rf.fx/reg-fx :rf.http/managed
                         (fn [_ctx args] (swap! !managed conj args) nil)))})
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (rt/reset-runtime!))})
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))})
   capturing-transport-fixture)
 
 (def ^:private frame-id ::shape-framework-subs)
@@ -138,10 +138,10 @@
       {:request {:method :post :url (str "/api/articles/" slug "/favorite")}})))
 
 (defn- fresh! []
-  (lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/leave-act-environment!)
   (register-framework!)
-  (m/make-frame! frame-id seed)
-  (m/reseed! frame-id seed)
+  (rf.bench.hicasso.shapes.model/make-frame! frame-id seed)
+  (rf.bench.hicasso.shapes.model/reseed! frame-id seed)
   frame-id)
 
 ;; ---------------------------------------------------------------------------
@@ -156,7 +156,7 @@
 
 (defn- runs [k] (get @!runs k 0))
 
-(def ^:private slug-0 (:slug (m/article 0)))
+(def ^:private slug-0 (:slug (rf.bench.hicasso.shapes.model/article 0)))
 
 (defn- mutation-read
   "The census's per-row status read, verbatim
@@ -217,19 +217,19 @@
 
 (defn- mount! []
   (reset-runs!)
-  (mount/root! (mount/fresh-container!) frame-id [fw-page {}]))
+  (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [fw-page {}]))
 
 (defn- text [handle testid]
   (some-> (.querySelector (:container handle) (str "[data-testid=\"" testid "\"]"))
           (.-textContent)))
 
 (defn- execute-favorite! []
-  (rt/dispatch! frame-id
+  (rf.bench.hicasso.arm1.runtime/dispatch! frame-id
                 [:rf.mutation/execute {:mutation :conduit/favorite-remote
                                        :params   {:slug slug-0}
                                        :instance [:favorite slug-0]
                                        :cause    [:test ::witness slug-0]}])
-  (mount/settle!))
+  (rf.bench.hicasso.arm1.mount/settle!))
 
 (defn- settle-favorite!
   "Replay the genuine reply-event-append shape the live transport would
@@ -238,34 +238,34 @@
   []
   (let [args (last @!managed)]
     (is (some? (:on-success args)) "the stub transport saw the mutation lowering")
-    (rt/dispatch! frame-id (conj (:on-success args)
+    (rf.bench.hicasso.arm1.runtime/dispatch! frame-id (conj (:on-success args)
                                  {:status :ok :value {:article {:slug slug-0}}}))
-    (mount/settle!)))
+    (rf.bench.hicasso.arm1.mount/settle!)))
 
 (defn- ensure-feed! []
-  (rt/dispatch! frame-id
+  (rf.bench.hicasso.arm1.runtime/dispatch! frame-id
                 [:rf.resource/ensure {:resource :conduit/feed
                                       :scope    :rf.scope/global
                                       :params   {:page 1}
                                       :owner    [:app ::witness 1]}])
-  (mount/settle!))
+  (rf.bench.hicasso.arm1.mount/settle!))
 
 (defn- settle-feed! [total]
-  (let [scoped-key (state/scoped-resource-key :rf.scope/global :conduit/feed {:page 1})
+  (let [scoped-key (rf.resources.state/scoped-resource-key :rf.scope/global :conduit/feed {:page 1})
         runtime-db (:rf.db/runtime (rf/frame-state-value frame-id))
-        work-id    (:current-work (get-in runtime-db (state/entry-path scoped-key)))]
+        work-id    (:current-work (get-in runtime-db (rf.resources.state/entry-path scoped-key)))]
     (is (some? work-id) "ensure minted in-flight work in the frame's runtime-db")
-    (rt/dispatch! frame-id [:rf.resource.internal/succeeded
+    (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:rf.resource.internal/succeeded
                             {:resource/key scoped-key :work/id work-id :generation 1
                              :data {:articlesCount total}}])
-    (mount/settle!)))
+    (rf.bench.hicasso.arm1.mount/settle!)))
 
 ;; ===========================================================================
 ;; 1 — the cell table serves a map-arg framework sub under VALUE equality
 ;; ===========================================================================
 
 (deftest the-sub-key-identity-holds-on-a-map-arg-key
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
@@ -273,51 +273,51 @@
         (try
           (testing "the mount is the arithmetic's page"
             (is (= {:boundaries 5 :cells 8 :edges 9}
-                   (select-keys (rt/stats) [:boundaries :cells :edges]))
+                   (select-keys (rf.bench.hicasso.arm1.runtime/stats) [:boundaries :cells :edges]))
                 (str "1 page + " article-count " cards + 1 detail; the detail's "
                      "read SHARES card 0's cell, which is the map-arg dedup")))
           (testing "a freshly constructed value-equal key finds the cell"
-            (is (some? (rt/cell-reaction [frame-id (mutation-read slug-0)]))
+            (is (some? (rf.bench.hicasso.arm1.runtime/cell-reaction [frame-id (mutation-read slug-0)]))
                 "the map arg is a value, not an object identity")
-            (is (some? (rt/cell-reaction [frame-id resource-read]))
+            (is (some? (rf.bench.hicasso.arm1.runtime/cell-reaction [frame-id resource-read]))
                 "and so is the resource read's"))
           (testing "and finds the readers the cell holds for it (rf2-dabt3:
                    the reverse edge is the cell's own reader list now, so
                    this counts memberships on the table rather than a
                    second map's reader set)"
-            (is (= 2 (count (rt/cell-readers [frame-id (mutation-read slug-0)])))
+            (is (= 2 (count (rf.bench.hicasso.arm1.runtime/cell-readers [frame-id (mutation-read slug-0)])))
                 "card 0 and the detail both hold the shared instance's edge")
-            (is (= 1 (count (rt/cell-readers [frame-id (mutation-read (:slug (m/article 1)))])))
+            (is (= 1 (count (rf.bench.hicasso.arm1.runtime/cell-readers [frame-id (mutation-read (:slug (rf.bench.hicasso.shapes.model/article 1)))])))
                 "card 1's instance has exactly its own reader")
-            (is (= 0 (count (rt/cell-readers [frame-id (mutation-read "no-such-slug")])))
+            (is (= 0 (count (rf.bench.hicasso.arm1.runtime/cell-readers [frame-id (mutation-read "no-such-slug")])))
                 "law 6: an instance nobody reads has no phantom reader"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ===========================================================================
 ;; 2 — the mutation clock: runtime-db installs, never app-db commits
 ;; ===========================================================================
 
 (deftest a-mutation-commit-moves-its-readers-and-only-its-readers
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (let [handle (mount!)]
         (try
           (let [app-db-before (:rf.db/app (rf/frame-state-value frame-id))
-                cells-before  (:cells (rt/stats))]
+                cells-before  (:cells (rf.bench.hicasso.arm1.runtime/stats))]
             (reset-runs!)
             (execute-favorite!)
             (testing "one commit → one body, per reader of the map-arg key"
               (is (= 1 (runs slug-0)) "card 0 re-ran once")
               (is (= 1 (runs :detail)) "law 2: the second reader of the SAME instance re-ran once")
-              (is (= 0 (runs (:slug (m/article 1)))) "card 1 did not")
-              (is (= 0 (runs (:slug (m/article 2)))) "card 2 did not")
+              (is (= 0 (runs (:slug (rf.bench.hicasso.shapes.model/article 1)))) "card 1 did not")
+              (is (= 0 (runs (:slug (rf.bench.hicasso.shapes.model/article 2)))) "card 2 did not")
               (is (= 0 (runs :page)) "the page did not"))
             (testing "the DOM shows the in-flight instance"
               (is (= "pending" (text handle (str "fw-status-" slug-0))))
               (is (= "saving" (text handle "fw-detail")))
-              (is (= "idle" (text handle (str "fw-status-" (:slug (m/article 1)))))))
+              (is (= "idle" (text handle (str "fw-status-" (:slug (rf.bench.hicasso.shapes.model/article 1)))))))
             (testing "the value moved on the runtime-db clock — app-db did not move"
               (is (identical? app-db-before (:rf.db/app (rf/frame-state-value frame-id)))
                   "no app-db write happened; the framework sub moved anyway"))
@@ -330,21 +330,21 @@
               (is (= "settled" (text handle (str "fw-status-" slug-0))))
               (is (= "quiet" (text handle "fw-detail"))))
             (testing "two commits on the same instance reused ONE cell"
-              (is (= cells-before (:cells (rt/stats)))
+              (is (= cells-before (:cells (rf.bench.hicasso.arm1.runtime/stats)))
                   "value-equal map args re-key the same cell — no thrash")))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 (deftest an-app-db-commit-does-not-move-the-runtime-sub
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (let [handle (mount!)]
         (try
-          (let [fav-before (subs/subscribe-once (mutation-read slug-0) {:frame frame-id})]
+          (let [fav-before (rf.subs/subscribe-once (mutation-read slug-0) {:frame frame-id})]
             (reset-runs!)
-            (rt/dispatch! frame-id [:conduit/favorite slug-0])
-            (mount/settle!)
+            (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:conduit/favorite slug-0])
+            (rf.bench.hicasso.arm1.mount/settle!)
             (testing "the app-db write reached the app sub's reader and nothing else"
               (is (= 1 (runs slug-0)) "card 0 re-ran — its article moved")
               (is (= 0 (runs :detail))
@@ -355,15 +355,15 @@
                   "the frame-state resource sub re-derived over the new app-db
                    and its output = cutoff held its reader quiet"))
             (testing "the framework sub's value did not move"
-              (is (= fav-before (subs/subscribe-once (mutation-read slug-0) {:frame frame-id})))))
-          (finally (mount/release! handle)))))))
+              (is (= fav-before (rf.subs/subscribe-once (mutation-read slug-0) {:frame frame-id})))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ===========================================================================
 ;; 3 — the resource clock: the census's list read, ensure → reply
 ;; ===========================================================================
 
 (deftest a-resource-read-follows-the-census-shape-through-the-arm
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
@@ -397,52 +397,52 @@
             (is (= 0 (runs :detail))
                 "its read did not move, so the bail-out held it quiet — this
                  read 1 before the repair, on the cascade rather than the edges"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ===========================================================================
 ;; 4 — the hook budget survives framework subs
 ;; ===========================================================================
 
 (deftest framework-subs-cost-no-third-hook
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
-    (if-not (probe/install!)
+    (if-not (rf.bench.hicasso.arm1.hook-probe/install!)
       (is false (str "React's internals slot was not found, so the ≤2-hook budget "
                      "is UNWITNESSED on the framework-subs page — fix "
                      (pr-str 're-frame.bench.hicasso.arm1.hook-probe)
                      " rather than reading this as a pass."))
       (do
         (fresh!)
-        (let [container (mount/fresh-container!)
+        (let [container (rf.bench.hicasso.arm1.mount/fresh-container!)
               handle    (volatile! nil)
-              names     (probe/record!
-                          (fn [] (vreset! handle (mount/root! container frame-id [fw-page {}]))))
-              stats     (rt/stats)]
+              names     (rf.bench.hicasso.arm1.hook-probe/record!
+                          (fn [] (vreset! handle (rf.bench.hicasso.arm1.mount/root! container frame-id [fw-page {}]))))
+              stats     (rf.bench.hicasso.arm1.runtime/stats)]
           (try
             (is (= 5 (:boundaries stats)))
             (is (= (* 2 (:boundaries stats)) (count names))
                 "two hooks per boundary — a framework sub is a read, and a
                  read cannot reach the hook count")
             (is (= #{"useContext" "useSyncExternalStore"} (set names)))
-            (finally (mount/release! @handle))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! @handle))))))))
 
 ;; ===========================================================================
 ;; Teardown
 ;; ===========================================================================
 
 (deftest the-framework-subs-page-leaves-no-residue
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (async done
       (fresh!)
       (let [handle (mount!)]
         (execute-favorite!)
         (settle-favorite!)
-        (is (pos? (:cell-refs (rt/stats))))
-        (mount/unmount! handle)
+        (is (pos? (:cell-refs (rf.bench.hicasso.arm1.runtime/stats))))
+        (rf.bench.hicasso.arm1.mount/unmount! handle)
         (js/setTimeout (fn []
                          (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                                (rt/residue)))
-                         (rt/reset-runtime!)
+                                (rf.bench.hicasso.arm1.runtime/residue)))
+                         (rf.bench.hicasso.arm1.runtime/reset-runtime!)
                          (done))
                        8)))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/shapes/hook_budget_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/shapes/hook_budget_dom_cljs_test.cljs
@@ -60,22 +60,22 @@
   whose internals slot has moved, the claims degrade to a stated skip or
   to **unwitnessed** — never to a false green."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.hook-probe :as probe]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.shapes.feed :as feed]
-            [re-frame.bench.hicasso.shapes.large-template :as large-template]
-            [re-frame.bench.hicasso.shapes.model :as m]
-            [re-frame.bench.hicasso.shapes.ordinary :as ordinary]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.hook-probe :as rf.bench.hicasso.arm1.hook-probe]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.shapes.feed :as rf.bench.hicasso.shapes.feed]
+            [re-frame.bench.hicasso.shapes.large-template :as rf.bench.hicasso.shapes.large-template]
+            [re-frame.bench.hicasso.shapes.model :as rf.bench.hicasso.shapes.model]
+            [re-frame.bench.hicasso.shapes.ordinary :as rf.bench.hicasso.shapes.ordinary]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::shape-hooks)
 
@@ -93,15 +93,15 @@
   while it mounted, alongside the runtime's own boundary and edge counts —
   read BEFORE the release that would empty them."
   [seed hiccup]
-  (lane/leave-act-environment!)
-  (m/make-frame! frame-id seed)
-  (m/reseed! frame-id seed)
-  (let [container (mount/fresh-container!)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.shapes.model/make-frame! frame-id seed)
+  (rf.bench.hicasso.shapes.model/reseed! frame-id seed)
+  (let [container (rf.bench.hicasso.arm1.mount/fresh-container!)
         handle    (volatile! nil)
-        names     (probe/record!
-                    (fn [] (vreset! handle (mount/root! container frame-id hiccup))))
-        stats     (rt/stats)]
-    (mount/release! @handle)
+        names     (rf.bench.hicasso.arm1.hook-probe/record!
+                    (fn [] (vreset! handle (rf.bench.hicasso.arm1.mount/root! container frame-id hiccup))))
+        stats     (rf.bench.hicasso.arm1.runtime/stats)]
+    (rf.bench.hicasso.arm1.mount/release! @handle)
     {:hooks      names
      :boundaries (:boundaries stats)
      :edges      (:edges stats)}))
@@ -122,16 +122,16 @@
   controlled field exists reds the row that names it."
   [{:label   "1 — ordinary views"
     :seed    {:articles 2 :comments 5 :tags 2}
-    :tree    [ordinary/screen {}]
+    :tree    [rf.bench.hicasso.shapes.ordinary/screen {}]
     ;; The comment draft — `shapes/ordinary`'s one controlled `<textarea>`.
     :shadows 1}
    {:label   "2 — large templates"
-    :seed    large-template/seed
-    :tree    [large-template/page {}]
+    :seed    rf.bench.hicasso.shapes.large-template/seed
+    :tree    [rf.bench.hicasso.shapes.large-template/page {}]
     :shadows 0}
    {:label   "3/4 — bulk + narrow"
-    :seed    feed/seed
-    :tree    [feed/page {}]
+    :seed    rf.bench.hicasso.shapes.feed/seed
+    :tree    [rf.bench.hicasso.shapes.feed/page {}]
     :shadows 0}])
 
 ;; ---------------------------------------------------------------------------
@@ -139,9 +139,9 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest every-shape-costs-exactly-two-hooks-per-boundary
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
-    (if-not (probe/install!)
+    (if-not (rf.bench.hicasso.arm1.hook-probe/install!)
       (unwitnessed!)
       (doseq [{:keys [label seed tree shadows]} shapes]
         (testing label
@@ -161,7 +161,7 @@
                      React runs a component's hooks to completion before it
                      starts the next, so the whole page's sequence is the
                      declared pair repeated"))
-            (is (= (count rt/shell-hook-ledger) 2)
+            (is (= (count rf.bench.hicasso.arm1.runtime/shell-hook-ledger) 2)
                 "and the ledger the runtime declares is still two entries long")
             (testing "the composition shadow's hook, and only it (rf2-digtt)"
               (is (= shadows (count (filter #{shadow-hook} hooks)))
@@ -186,9 +186,9 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-read-count-cannot-reach-the-hook-count
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
-    (if-not (probe/install!)
+    (if-not (rf.bench.hicasso.arm1.hook-probe/install!)
       (unwitnessed!)
       (testing "shape 2 is one boundary making 141 subscription reads, every
                one of them inside a `for` and inside a plain helper called
@@ -196,7 +196,7 @@
                one read, because `subscribe` closes over the read SET and
                nothing else."
         (let [{:keys [hooks boundaries edges]}
-              (mount-and-count large-template/seed [large-template/page {}])]
+              (mount-and-count rf.bench.hicasso.shapes.large-template/seed [rf.bench.hicasso.shapes.large-template/page {}])]
           (is (= 1 boundaries))
           (is (= 141 edges) "141 reads")
           (is (= 2 (count hooks))
@@ -205,15 +205,15 @@
               "in the declared order"))))))
 
 (deftest the-budget-does-not-move-when-the-page-grows
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
-    (if-not (probe/install!)
+    (if-not (rf.bench.hicasso.arm1.hook-probe/install!)
       (unwitnessed!)
       (testing "hooks per boundary is 2 at 50, 150 and 300 mounted card
                boundaries — the axis a bulk row grows along"
         (doseq [n [50 150 300]]
           (let [{:keys [hooks boundaries]}
-                (mount-and-count {:articles n :tags feed/tag-count} [feed/page {}])]
+                (mount-and-count {:articles n :tags rf.bench.hicasso.shapes.feed/tag-count} [rf.bench.hicasso.shapes.feed/page {}])]
             (is (= (inc n) boundaries))
             (is (= (* 2 (inc n)) (count hooks))
                 (str "B = " n ": " (count hooks) " hooks over " boundaries

--- a/bench/hicasso/src/re_frame/bench/hicasso/shapes/large_template.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/shapes/large_template.cljs
@@ -65,8 +65,8 @@
 
   `.cljc`-compatible by construction (HD-020(d))."
   (:require [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
-            [re-frame.bench.hicasso.shapes.card :as card]
-            [re-frame.bench.hicasso.shapes.model :as m])
+            [re-frame.bench.hicasso.shapes.card :as rf.bench.hicasso.shapes.card]
+            [re-frame.bench.hicasso.shapes.model :as rf.bench.hicasso.shapes.model])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 (def article-count
@@ -98,7 +98,7 @@
 (defn element-arithmetic
   "The page's element count, predicted rather than measured."
   []
-  (+ chrome-elements tag-count (* card/elements-per-card article-count)))
+  (+ chrome-elements tag-count (* rf.bench.hicasso.shapes.card/elements-per-card article-count)))
 
 (def !body-runs
   "How many times the page's one body has run."
@@ -138,7 +138,7 @@
            ;; A plain call. It inlines into THIS boundary and donates its
            ;; two reads to it — the whole difference between this shape and
            ;; the next one.
-           (card/card slug))]]
+           (rf.bench.hicasso.shapes.card/card slug))]]
        [:div.col-md-3
         [:div.sidebar
          [:p "Popular Tags"]
@@ -149,5 +149,5 @@
                                       :data-testid (str "tag-" tag)}
              tag])]]]]]]))
 
-(defn make-frame! [frame-id] (m/make-frame! frame-id seed))
-(defn reseed! [frame-id] (m/reseed! frame-id seed))
+(defn make-frame! [frame-id] (rf.bench.hicasso.shapes.model/make-frame! frame-id seed))
+(defn reseed! [frame-id] (rf.bench.hicasso.shapes.model/reseed! frame-id seed))

--- a/bench/hicasso/src/re_frame/bench/hicasso/shapes/large_template_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/shapes/large_template_dom_cljs_test.cljs
@@ -22,21 +22,21 @@
   Runtime: `-dom-cljs-test`. Under `:node-test` every claim degrades to a
   stated skip."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.shapes.card :as card]
-            [re-frame.bench.hicasso.shapes.large-template :as shape]
-            [re-frame.bench.hicasso.shapes.model :as m]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.shapes.card :as rf.bench.hicasso.shapes.card]
+            [re-frame.bench.hicasso.shapes.large-template :as rf.bench.hicasso.shapes.large-template]
+            [re-frame.bench.hicasso.shapes.model :as rf.bench.hicasso.shapes.model]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::shape-large-template)
 
@@ -47,20 +47,20 @@
       per card     [:conduit/article slug] [:conduit/favorite-pending? slug] 2
 
   so `3 + 2 x 69`."
-  (+ 3 (* 2 shape/article-count)))
+  (+ 3 (* 2 rf.bench.hicasso.shapes.large-template/article-count)))
 
 (defn- skip! [why]
   (is true (str "shape 2's witness needs a real React DOM — " why)))
 
 (defn- fresh! []
-  (lane/leave-act-environment!)
-  (shape/make-frame! frame-id)
-  (shape/reseed! frame-id)
-  (shape/reset-runs!)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.shapes.large-template/make-frame! frame-id)
+  (rf.bench.hicasso.shapes.large-template/reseed! frame-id)
+  (rf.bench.hicasso.shapes.large-template/reset-runs!)
   frame-id)
 
 (defn- mount! []
-  (mount/root! (mount/fresh-container!) frame-id [shape/page {}]))
+  (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [rf.bench.hicasso.shapes.large-template/page {}]))
 
 (defn- q [handle sel] (.querySelector (:container handle) sel))
 (defn- q* [handle sel] (array-seq (.querySelectorAll (:container handle) sel)))
@@ -70,17 +70,17 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-page-is-the-size-the-arithmetic-predicts
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (let [handle (mount!)]
         (try
-          (let [predicted (shape/element-arithmetic)
-                measured  (lane/element-count (:container handle))]
+          (let [predicted (rf.bench.hicasso.shapes.large-template/element-arithmetic)
+                measured  (rf.bench.hicasso.lane/element-count (:container handle))]
             (is (= predicted measured)
-                (str "chrome " shape/chrome-elements " + tags " shape/tag-count
-                     " + " shape/article-count " cards x " card/elements-per-card
+                (str "chrome " rf.bench.hicasso.shapes.large-template/chrome-elements " + tags " rf.bench.hicasso.shapes.large-template/tag-count
+                     " + " rf.bench.hicasso.shapes.large-template/article-count " cards x " rf.bench.hicasso.shapes.card/elements-per-card
                      " = " predicted "; the DOM holds " measured))
             (is (<= 1150 measured 1250)
                 (str "and that is the charter's ~1,200-element shape (" measured ")")))
@@ -94,12 +94,12 @@
             ;; class, so the bare selector answers 10 + 69x2 = 148. Its own
             ;; collision, faithfully ported — and the reason the sidebar is
             ;; addressed by the test id the census also wrote.
-            (is (= shape/tag-count
+            (is (= rf.bench.hicasso.shapes.large-template/tag-count
                    (count (q* handle "[data-testid=\"tag-list\"] > .tag-pill")))))
           (testing "and the cards are the model's"
-            (is (= shape/article-count (count (q* handle ".article-list > .article-preview"))))
+            (is (= rf.bench.hicasso.shapes.large-template/article-count (count (q* handle ".article-list > .article-preview"))))
             (doseq [i [0 1 34 68]]
-              (let [a (m/article i)]
+              (let [a (rf.bench.hicasso.shapes.model/article i)]
                 (is (= (:title a)
                        (.-textContent (q handle (str "[data-testid=\"article-preview-"
                                                      (:slug a) "\"] h1"))))
@@ -108,20 +108,20 @@
                        (.-textContent (q handle (str "[data-testid=\"favorites-count-"
                                                      (:slug a) "\"]"))))
                     (str "card " i " carries the model's favourites count")))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 + 3 — one boundary, 141 reads, one read-set entry
 ;; ---------------------------------------------------------------------------
 
 (deftest the-whole-page-is-one-boundary
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (let [handle (mount!)]
         (try
-          (let [{:keys [boundaries edges entries cells]} (rt/stats)]
+          (let [{:keys [boundaries edges entries cells]} (rf.bench.hicasso.arm1.runtime/stats)]
             (is (= 1 boundaries)
                 (str "a large TEMPLATE is one boundary interpreting many "
                      "elements; this page reports " boundaries))
@@ -131,45 +131,45 @@
                 "one cell per unique (frame, query), and every query here is distinct")
             (is (= 1 entries)
                 "one read SEQUENCE, so one cached subscribe/getSnapshot pair"))
-          (is (= 1 @shape/!body-runs) "and its body ran once to build the page")
-          (finally (mount/release! handle)))))))
+          (is (= 1 @rf.bench.hicasso.shapes.large-template/!body-runs) "and its body ran once to build the page")
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4 — the template is live, and re-running it is what it costs
 ;; ---------------------------------------------------------------------------
 
 (deftest a-write-moves-the-dom-and-re-runs-the-one-body-once
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (let [handle (mount!)]
         (try
-          (let [slug   (:slug (m/article 7))
-                before (:favoritesCount (m/article 7))
+          (let [slug   (:slug (rf.bench.hicasso.shapes.model/article 7))
+                before (:favoritesCount (rf.bench.hicasso.shapes.model/article 7))
                 count- (fn [] (.-textContent
                                 (q handle (str "[data-testid=\"favorites-count-" slug "\"]"))))]
             (is (= (str before) (count-)) "the first paint is right — which proves nothing on its own")
-            (reset! shape/!body-runs 0)
-            (rt/dispatch! frame-id [:conduit/favorite slug])
-            (mount/settle!)
+            (reset! rf.bench.hicasso.shapes.large-template/!body-runs 0)
+            (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:conduit/favorite slug])
+            (rf.bench.hicasso.arm1.mount/settle!)
             (is (= (str (inc before)) (count-))
                 "a later write reaches the DOM — the half a first render cannot tell you")
             (is (some? (q handle (str "[data-testid=\"favorite-" slug "\"].active")))
                 "and the favourited class flipped with it")
-            (is (= 1 @shape/!body-runs)
+            (is (= 1 @rf.bench.hicasso.shapes.large-template/!body-runs)
                 "the page's one body re-ran exactly once — which is also the honest
                  cost of this decomposition: a one-card write re-interprets all
                  1,202 elements, and that is what shape 3 exists to change")
             (testing "every other card is untouched"
-              (let [other (:slug (m/article 8))]
-                (is (= (str (:favoritesCount (m/article 8)))
+              (let [other (:slug (rf.bench.hicasso.shapes.model/article 8))]
+                (is (= (str (:favoritesCount (rf.bench.hicasso.shapes.model/article 8)))
                        (.-textContent (q handle (str "[data-testid=\"favorites-count-"
                                                      other "\"]"))))))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 (deftest the-feed-toggle-flips-the-chrome
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
@@ -177,11 +177,11 @@
         (try
           (is (some? (q handle "[data-testid=\"global-feed-tab\"].active")))
           (is (nil? (q handle "[data-testid=\"your-feed-tab\"].active")))
-          (rt/dispatch! frame-id [:conduit/show-your-feed])
-          (mount/settle!)
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:conduit/show-your-feed])
+          (rf.bench.hicasso.arm1.mount/settle!)
           (is (some? (q handle "[data-testid=\"your-feed-tab\"].active")))
           (is (nil? (q handle "[data-testid=\"global-feed-tab\"].active")))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The one authoring spelling this roster uses that nothing else witnesses
@@ -191,7 +191,7 @@
 ;; `preventDefault` IN — `[::h/prevent [:conduit/show-your-feed]]` at the
 ;; event position — where the comment form's `:on-submit` gets it from the
 ;; position's own default. Every other assertion in the roster reaches its
-;; intents through `rt/dispatch!`, which would never have exercised the
+;; intents through `rf.bench.hicasso.arm1.runtime/dispatch!`, which would never have exercised the
 ;; spelling at all. Fired here as a real cancelable click, with the
 ;; un-decorated intent on the same page as the control: if the pair both
 ;; prevented, or neither did, the decorator would not be the thing doing it.
@@ -208,11 +208,11 @@
   [node]
   (let [ev (js/MouseEvent. "click" #js {:bubbles true :cancelable true})]
     (.dispatchEvent node ev)
-    (mount/settle!)
+    (rf.bench.hicasso.arm1.mount/settle!)
     ev))
 
 (deftest the-prevent-head-is-what-prevents
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
@@ -226,34 +226,34 @@
                   "and the intent reached the model")))
           (testing "the control: an ordinary intent on the same page dispatches
                    and does NOT prevent"
-            (let [slug (:slug (m/article 4))
+            (let [slug (:slug (rf.bench.hicasso.shapes.model/article 4))
                   ev   (click! (q handle (str "[data-testid=\"favorite-" slug "\"]")))]
               (is (false? (.-defaultPrevented ev)))
-              (is (= (str (inc (:favoritesCount (m/article 4))))
+              (is (= (str (inc (:favoritesCount (rf.bench.hicasso.shapes.model/article 4))))
                      (.-textContent (q handle (str "[data-testid=\"favorites-count-"
                                                    slug "\"]"))))
                   "and it reached the model too — so the difference between the
                    two is the decorator and nothing else")))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Teardown
 ;; ---------------------------------------------------------------------------
 
 (deftest the-page-leaves-no-residue
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (async done
       (fresh!)
       (let [handle (mount!)]
-        (rt/dispatch! frame-id [:conduit/favorite (:slug (m/article 2))])
-        (mount/settle!)
-        (is (pos? (:cell-refs (rt/stats))))
-        (mount/unmount! handle)
+        (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:conduit/favorite (:slug (rf.bench.hicasso.shapes.model/article 2))])
+        (rf.bench.hicasso.arm1.mount/settle!)
+        (is (pos? (:cell-refs (rf.bench.hicasso.arm1.runtime/stats))))
+        (rf.bench.hicasso.arm1.mount/unmount! handle)
         (js/setTimeout (fn []
                          (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                                (rt/residue))
+                                (rf.bench.hicasso.arm1.runtime/residue))
                              "141 edges and 141 cells, all released by React's own cleanup")
-                         (rt/reset-runtime!)
+                         (rf.bench.hicasso.arm1.runtime/reset-runtime!)
                          (done))
                        8)))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/shapes/model.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/shapes/model.cljs
@@ -85,7 +85,7 @@
   registration is `re-frame.routing`'s own `reg-route` — the roster adds
   no routing machinery, it consumes the artefact's."
   (:require [re-frame.core :as rf]
-            [re-frame.routing :as routing]))
+            [re-frame.routing :as rf.routing]))
 
 ;; ---------------------------------------------------------------------------
 ;; The seed data — Conduit's own field names, from a deterministic index
@@ -295,9 +295,9 @@
   re-registration replaces), and called from [[make-frame!]] so every
   witness that mounts a page has the table its links resolve against."
   []
-  (routing/reg-route :conduit/home {} "/")
-  (routing/reg-route :conduit.profile/show {} "/profile/:username")
-  (routing/reg-route :conduit.article/show {} "/article/:slug")
+  (rf.routing/reg-route :conduit/home {} "/")
+  (rf.routing/reg-route :conduit.profile/show {} "/profile/:username")
+  (rf.routing/reg-route :conduit.article/show {} "/article/:slug")
   nil)
 
 (defn make-frame!
@@ -316,12 +316,12 @@
   did not see it: its runs measured the pre-migration blobs its
   provenance table records, and the branch was rebase-merged over the
   migration without a clock re-run). Declaring the shipped
-  `routing/hash-url-strategy` here makes the routing-owned href the
+  `rf.routing/hash-url-strategy` here makes the routing-owned href the
   census's own form, through routing's law rather than around it."
   [frame-id opts]
   (register-routes!)
   (rf/make-frame {:id frame-id
-                  :url-strategy routing/hash-url-strategy
+                  :url-strategy rf.routing/hash-url-strategy
                   :initial-events [[:conduit/seed opts]]})
   frame-id)
 

--- a/bench/hicasso/src/re_frame/bench/hicasso/shapes/narrow_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/shapes/narrow_dom_cljs_test.cljs
@@ -33,20 +33,20 @@
   Runtime: `-dom-cljs-test`. Under `:node-test` every claim degrades to a
   stated skip."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.shapes.feed :as shape]
-            [re-frame.bench.hicasso.shapes.model :as m]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.shapes.feed :as rf.bench.hicasso.shapes.feed]
+            [re-frame.bench.hicasso.shapes.model :as rf.bench.hicasso.shapes.model]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::shape-narrow)
 
@@ -60,16 +60,16 @@
   (is true (str "shape 4's witness needs a real React DOM — " why)))
 
 (defn- fresh!
-  ([] (fresh! shape/seed))
+  ([] (fresh! rf.bench.hicasso.shapes.feed/seed))
   ([seed]
-   (lane/leave-act-environment!)
-   (m/make-frame! frame-id seed)
-   (m/reseed! frame-id seed)
-   (shape/reset-runs!)
+   (rf.bench.hicasso.lane/leave-act-environment!)
+   (rf.bench.hicasso.shapes.model/make-frame! frame-id seed)
+   (rf.bench.hicasso.shapes.model/reseed! frame-id seed)
+   (rf.bench.hicasso.shapes.feed/reset-runs!)
    frame-id))
 
 (defn- mount! []
-  (mount/root! (mount/fresh-container!) frame-id [shape/page {}]))
+  (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [rf.bench.hicasso.shapes.feed/page {}]))
 
 (defn- q [handle sel] (.querySelector (:container handle) sel))
 (defn- q* [handle sel] (array-seq (.querySelectorAll (:container handle) sel)))
@@ -85,28 +85,28 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest one-write-re-runs-one-body-out-of-three-hundred
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (let [handle (mount!)]
         (try
-          (let [slug   (shape/slug-at moved-index)
+          (let [slug   (rf.bench.hicasso.shapes.feed/slug-at moved-index)
                 node   (q handle (str "[data-testid=\"article-preview-" slug "\"]"))
                 before (favourite-counts handle)]
-            (is (= shape/article-count (count before)))
-            (shape/reset-runs!)
-            (rt/dispatch! frame-id [:conduit/favorite slug])
-            (mount/settle!)
-            (is (= 1 (:cards (shape/runs)))
-                (str "exactly one card body re-ran out of " shape/article-count))
-            (is (= 0 (:page (shape/runs)))
+            (is (= rf.bench.hicasso.shapes.feed/article-count (count before)))
+            (rf.bench.hicasso.shapes.feed/reset-runs!)
+            (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:conduit/favorite slug])
+            (rf.bench.hicasso.arm1.mount/settle!)
+            (is (= 1 (:cards (rf.bench.hicasso.shapes.feed/runs)))
+                (str "exactly one card body re-ran out of " rf.bench.hicasso.shapes.feed/article-count))
+            (is (= 0 (:page (rf.bench.hicasso.shapes.feed/runs)))
                 "and the page boundary did not — it reads the order, and the
                  order did not move")
             (let [after (favourite-counts handle)
                   moved (differing-indices before after)]
               (is (= [moved-index] moved)
-                  (str "exactly one of the " shape/article-count
+                  (str "exactly one of the " rf.bench.hicasso.shapes.feed/article-count
                        " rendered counts differs, and it is the one written to"))
               (is (= (str (inc (js/parseInt (nth before moved-index) 10)))
                      (nth after moved-index))
@@ -114,47 +114,47 @@
             (is (identical? node (q handle (str "[data-testid=\"article-preview-" slug "\"]")))
                 "and the card is the SAME DOM node — React patched it in place
                  rather than replacing a subtree"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 (deftest the-narrow-reading-can-answer-false
   (testing "the assertion above is not passing vacuously: the broad write on
            the same page moves every count, so `differing-indices` is a live
            comparison rather than one that always answers empty"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (do
         (fresh!)
         (let [handle (mount!)]
           (try
             (let [before (favourite-counts handle)]
-              (rt/dispatch! frame-id [:conduit/refresh-feed])
-              (mount/settle!)
-              (is (= shape/article-count
+              (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:conduit/refresh-feed])
+              (rf.bench.hicasso.arm1.mount/settle!)
+              (is (= rf.bench.hicasso.shapes.feed/article-count
                      (count (differing-indices before (favourite-counts handle))))
                   "all 300 differ"))
-            (finally (mount/release! handle))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! handle))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3 — flat in B
 ;; ---------------------------------------------------------------------------
 
 (deftest one-body-runs-whatever-the-page-size
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (doseq [n [50 150 300]]
-      (fresh! {:articles n :tags shape/tag-count})
+      (fresh! {:articles n :tags rf.bench.hicasso.shapes.feed/tag-count})
       (let [handle (mount!)]
         (try
           (is (= n (count (q* handle ".article-list > .article-preview")))
               (str n " boundaries mounted"))
-          (shape/reset-runs!)
-          (rt/dispatch! frame-id [:conduit/favorite (shape/slug-at (quot n 2))])
-          (mount/settle!)
-          (is (= {:cards 1 :page 0} (shape/runs))
+          (rf.bench.hicasso.shapes.feed/reset-runs!)
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:conduit/favorite (rf.bench.hicasso.shapes.feed/slug-at (quot n 2))])
+          (rf.bench.hicasso.arm1.mount/settle!)
+          (is (= {:cards 1 :page 0} (rf.bench.hicasso.shapes.feed/runs))
               (str "one body, at B = " n " — the dirty set is flat in B, which is
                    how validation.md states this shape's win condition: a law,
                    not a ratio"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4 — the cascade, measured rather than discovered on a clock
@@ -171,46 +171,46 @@
            write re-runs the page and NOT ONE card. The card count is what
            witnesses this and not a DOM comparison — the tab chrome does
            move."
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (do
         (fresh!)
         (let [handle (mount!)]
           (try
             (let [before (favourite-counts handle)]
-              (shape/reset-runs!)
-              (rt/dispatch! frame-id [:conduit/show-your-feed])
-              (mount/settle!)
-              (is (= 1 (:page (shape/runs)))
+              (rf.bench.hicasso.shapes.feed/reset-runs!)
+              (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:conduit/show-your-feed])
+              (rf.bench.hicasso.arm1.mount/settle!)
+              (is (= 1 (:page (rf.bench.hicasso.shapes.feed/runs)))
                   "the page re-ran once, which is correct — it reads the tab")
-              (is (= 0 (:cards (shape/runs)))
-                  (str "and not one of the " shape/article-count
+              (is (= 0 (:cards (rf.bench.hicasso.shapes.feed/runs)))
+                  (str "and not one of the " rf.bench.hicasso.shapes.feed/article-count
                        " cards did, none of whose reads moved — this read "
-                       shape/article-count " before the repair"))
+                       rf.bench.hicasso.shapes.feed/article-count " before the repair"))
               (is (= before (favourite-counts handle))
                   "and the cards' own DOM is untouched")
               (is (some? (q handle "[data-testid=\"your-feed-tab\"].active"))
                   "while the chrome the write was ABOUT did move, so the
                    row above is not passing because the write did nothing"))
-            (finally (mount/release! handle))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! handle))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Teardown
 ;; ---------------------------------------------------------------------------
 
 (deftest the-narrow-page-leaves-no-residue
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (async done
       (fresh!)
       (let [handle (mount!)]
-        (rt/dispatch! frame-id [:conduit/favorite (shape/slug-at moved-index)])
-        (mount/settle!)
-        (is (pos? (:cell-refs (rt/stats))))
-        (mount/unmount! handle)
+        (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:conduit/favorite (rf.bench.hicasso.shapes.feed/slug-at moved-index)])
+        (rf.bench.hicasso.arm1.mount/settle!)
+        (is (pos? (:cell-refs (rf.bench.hicasso.arm1.runtime/stats))))
+        (rf.bench.hicasso.arm1.mount/unmount! handle)
         (js/setTimeout (fn []
                          (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                                (rt/residue)))
-                         (rt/reset-runtime!)
+                                (rf.bench.hicasso.arm1.runtime/residue)))
+                         (rf.bench.hicasso.arm1.runtime/reset-runtime!)
                          (done))
                        8)))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/shapes/ordinary.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/shapes/ordinary.cljs
@@ -71,7 +71,7 @@
   on a server."
   (:require [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
             [re-frame.bench.hicasso.front.route-link :refer [route-link]]
-            [re-frame.bench.hicasso.shapes.model :as m])
+            [re-frame.bench.hicasso.shapes.model :as rf.bench.hicasso.shapes.model])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 ;; ---------------------------------------------------------------------------
@@ -142,7 +142,7 @@
      [:div.card-footer
       (route-link {:to :conduit.profile/show :params {:username (:username author)}
                    :class "comment-author"}
-        [:img.comment-author-img {:src (m/avatar-src (:image author)) :alt ""}]
+        [:img.comment-author-img {:src (rf.bench.hicasso.shapes.model/avatar-src (:image author)) :alt ""}]
         " "
         (:username author))
       [:span.date-posted createdAt]
@@ -173,9 +173,9 @@
       [:textarea.form-control {:data-testid "comment-body-input"
                                :rows        3
                                :placeholder "Write a comment..."
-                               :value       (sub [:conduit/draft m/comment-draft-key])
+                               :value       (sub [:conduit/draft rf.bench.hicasso.shapes.model/comment-draft-key])
                                :disabled    pending?
-                               :on-input    [:conduit/edit-draft m/comment-draft-key
+                               :on-input    [:conduit/edit-draft rf.bench.hicasso.shapes.model/comment-draft-key
                                              :re-frame.hicasso/value]}]]
      [:div.card-footer
       [:button.btn.btn-sm.btn-primary {:type        "submit"

--- a/bench/hicasso/src/re_frame/bench/hicasso/shapes/ordinary_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/shapes/ordinary_dom_cljs_test.cljs
@@ -15,7 +15,7 @@
      `<form>` creates a card, clears the draft by explicit revision,
      and **auto-prevents**. The store-write rows beside them witness the
      fan-out from a commit and are named for that — they reach the
-     model through `rt/dispatch!`, so a missing `:on-input`, a
+     model through `rf.bench.hicasso.arm1.runtime/dispatch!`, so a missing `:on-input`, a
      substituted value placeholder or a lost submit prevent leaves every
      one of them green. That was PR #7372's audit finding, and §3b is
      the repair.
@@ -31,19 +31,19 @@
   Runtime: `-dom-cljs-test`, so `:browser-test` runs it against real React
   DOM; under `:node-test` every claim degrades to a stated skip."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.controlled :as controlled]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.shapes.model :as m]
-            [re-frame.bench.hicasso.shapes.ordinary :as shape]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.controlled :as rf.bench.hicasso.front.controlled]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.shapes.model :as rf.bench.hicasso.shapes.model]
+            [re-frame.bench.hicasso.shapes.ordinary :as rf.bench.hicasso.shapes.ordinary]
             [re-frame.core :as rf]
-            [re-frame.test-support :as test-support]))
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      ;; Load-bearing, for the reason `arm1_dogfood_dom_cljs_test` records:
      ;; the fixture's default leaves a dynamic-var frame stamp in scope and
      ;; the carried-invariant chain resolves it BEFORE React context.
@@ -52,7 +52,7 @@
      ;; entry reapers are macrotasks, so the residue a React unmount leaves
      ;; is not readable inside one synchronous test body.
      :async?        true
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::shape-ordinary)
 
@@ -68,14 +68,14 @@
   (is true (str "shape 1's witness needs a real React DOM — " why)))
 
 (defn- fresh! []
-  (lane/leave-act-environment!)
-  (m/make-frame! frame-id seed)
-  (m/reseed! frame-id seed)
-  (shape/reset-runs!)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.shapes.model/make-frame! frame-id seed)
+  (rf.bench.hicasso.shapes.model/reseed! frame-id seed)
+  (rf.bench.hicasso.shapes.ordinary/reset-runs!)
   frame-id)
 
 (defn- mount! []
-  (mount/root! (mount/fresh-container!) frame-id [shape/screen {}]))
+  (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [rf.bench.hicasso.shapes.ordinary/screen {}]))
 
 (defn- q [handle sel] (.querySelector (:container handle) sel))
 (defn- q* [handle sel] (array-seq (.querySelectorAll (:container handle) sel)))
@@ -86,7 +86,7 @@
 ;; app-db" from "the field still shows what the keystroke wrote".
 ;; ---------------------------------------------------------------------------
 
-(defn- draft [] (get-in (rf/app-db-value frame-id) [:drafts m/comment-draft-key] ""))
+(defn- draft [] (get-in (rf/app-db-value frame-id) [:drafts rf.bench.hicasso.shapes.model/comment-draft-key] ""))
 (defn- comment-ids [] (:comment-order (rf/app-db-value frame-id)))
 (defn- body-of [id] (get-in (rf/app-db-value frame-id) [:comments id :body]))
 
@@ -95,7 +95,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-screen-is-layout-form-and-list-at-the-fifty-element-band
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
@@ -113,24 +113,24 @@
             (is (= comment-count (count (q* handle ".comments-list > .card")))))
           (testing "and the whole screen is the ~50-element shape, at the size
                    the arithmetic predicts"
-            (let [predicted (shape/element-arithmetic comment-count mine-count)
-                  n         (lane/element-count (:container handle))]
+            (let [predicted (rf.bench.hicasso.shapes.ordinary/element-arithmetic comment-count mine-count)
+                  n         (rf.bench.hicasso.lane/element-count (:container handle))]
               (is (= predicted n)
-                  (str "chrome " shape/chrome-elements " + form "
-                       shape/form-elements " + " (- comment-count mine-count)
-                       " cards x " shape/elements-per-card " + " mine-count
-                       " own cards x " shape/elements-per-own-card " = " predicted
+                  (str "chrome " rf.bench.hicasso.shapes.ordinary/chrome-elements " + form "
+                       rf.bench.hicasso.shapes.ordinary/form-elements " + " (- comment-count mine-count)
+                       " cards x " rf.bench.hicasso.shapes.ordinary/elements-per-card " + " mine-count
+                       " own cards x " rf.bench.hicasso.shapes.ordinary/elements-per-own-card " = " predicted
                        "; the DOM holds " n))
               (is (<= 40 n 60)
                   (str "and that is the charter's ~50-element shape (" n ")"))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 — the list is the model's, including the per-row branch
 ;; ---------------------------------------------------------------------------
 
 (deftest the-cards-carry-the-models-comments-and-the-author-only-control
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
@@ -139,7 +139,7 @@
           (doseq [i (range comment-count)]
             (let [card (q handle (str "[data-testid=\"comment-card-" i "\"]"))]
               (is (some? card) (str "card " i " rendered"))
-              (is (= (:body (m/comment-for i))
+              (is (= (:body (rf.bench.hicasso.shapes.model/comment-for i))
                      (.-textContent (.querySelector card "[data-testid=\"comment-body\"]")))
                   (str "card " i " carries the model's body"))))
           (testing "the delete control appears on exactly the reader's own comments"
@@ -148,13 +148,13 @@
             (is (some? (q handle "[data-testid=\"delete-comment-0\"]")))
             (is (nil? (q handle "[data-testid=\"delete-comment-1\"]"))
                 "and a comment that is not yours renders no delete control"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3a — the form's fan-out, from a commit
 ;; ---------------------------------------------------------------------------
 ;;
-;; These three reach the model through `rt/dispatch!` and commit with an
+;; These three reach the model through `rf.bench.hicasso.arm1.runtime/dispatch!` and commit with an
 ;; explicit `settle!`. That is the right door for a FAN-OUT claim — *when
 ;; this key moves, this is what the page shows* — and the wrong one for
 ;; any claim about the handlers the page is written with, because it
@@ -164,7 +164,7 @@
 ;; owns that claim now, through the door the browser uses.
 
 (deftest a-draft-commit-fans-out-to-the-controlled-textarea
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
@@ -175,23 +175,23 @@
           ;; the lowered `:on-input` closure eventually calls — but NOT
           ;; the closure, and not the event that reaches it. §3b is where
           ;; that half is witnessed.
-          (rt/dispatch! frame-id [:conduit/edit-draft m/comment-draft-key "nice piece"])
-          (mount/settle!)
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:conduit/edit-draft rf.bench.hicasso.shapes.model/comment-draft-key "nice piece"])
+          (rf.bench.hicasso.arm1.mount/settle!)
           (is (= "nice piece" (.-value (q handle "textarea")))
               "the echo landed without waiting for a later turn")
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 (deftest submitting-creates-a-card-and-clears-the-draft
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (let [handle (mount!)]
         (try
-          (rt/dispatch! frame-id [:conduit/edit-draft m/comment-draft-key "nice piece"])
-          (mount/settle!)
-          (rt/dispatch! frame-id [:conduit/post-comment])
-          (mount/settle!)
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:conduit/edit-draft rf.bench.hicasso.shapes.model/comment-draft-key "nice piece"])
+          (rf.bench.hicasso.arm1.mount/settle!)
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:conduit/post-comment])
+          (rf.bench.hicasso.arm1.mount/settle!)
           (is (= (inc comment-count) (count (q* handle ".comments-list > .card"))))
           (is (= "nice piece"
                  (.-textContent (q handle (str "[data-testid=\"comment-card-" comment-count "\"] "
@@ -202,25 +202,25 @@
                value equality")
           (is (some? (q handle (str "[data-testid=\"delete-comment-" comment-count "\"]")))
               "a comment you just posted is your own, so it gets the control")
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 (deftest an-in-flight-post-disables-the-form
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (let [handle (mount!)]
         (try
           (is (false? (.-disabled (q handle "textarea"))))
-          (rt/dispatch! frame-id [:conduit/begin [:post-comment]])
-          (mount/settle!)
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:conduit/begin [:post-comment]])
+          (rf.bench.hicasso.arm1.mount/settle!)
           (is (true? (.-disabled (q handle "textarea"))) "R-A10: busy discipline")
           (is (true? (.-disabled (q handle "[data-testid=\"comment-submit\"]"))))
           (is (= "Posting…" (.-textContent (q handle "[data-testid=\"comment-submit\"]"))))
-          (rt/dispatch! frame-id [:conduit/settle [:post-comment]])
-          (mount/settle!)
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:conduit/settle [:post-comment]])
+          (rf.bench.hicasso.arm1.mount/settle!)
           (is (false? (.-disabled (q handle "textarea"))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3b — the same form, through the door the browser uses
@@ -258,7 +258,7 @@
 ;;   agree on the line after the event returns. That is the arm's own
 ;;   flush, not this file's.
 ;; - **A submit's page update lands on React's next microtask.** The
-;;   model moves synchronously — `rt/dispatch!` is the arm's synchronous
+;;   model moves synchronously — `rf.bench.hicasso.arm1.runtime/dispatch!` is the arm's synchronous
 ;;   door — but nothing flushes React inside the event, and React 19
 ;;   schedules sync-lane work in a microtask (`ensureRootIsScheduled` →
 ;;   `processRootScheduleInMicrotask`) rather than at the end of
@@ -334,7 +334,7 @@
     (fn [] (.removeEventListener js/window "error" on-err) @!errs)))
 
 (deftest a-real-keystroke-moves-the-model-and-the-field-in-the-callers-turn
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
@@ -345,7 +345,7 @@
             (.setSelectionRange node 0 0)
             (is (= "" (draft)) "the model holds no draft before anything is typed")
             (is (= "" (.-value node)) "and the field agrees with it")
-            (shape/reset-runs!)
+            (rf.bench.hicasso.shapes.ordinary/reset-runs!)
             (let [stop! (error-watch!)
                   ev    (type-into! node "n")
                   errs  (stop!)]
@@ -355,7 +355,7 @@
                   "the :on-input intent reached the model, and ::h/value
                    materialised as the value the field carried — a
                    substituted placeholder lands here")
-              (is (= "n" (controlled/last-rendered node))
+              (is (= "n" (rf.bench.hicasso.front.controlled/last-rendered node))
                   "and React COMMITTED it back into this element in the same
                    turn. Read off React's own mirror of the committed value
                    prop rather than off `.value`, which would read \"n\"
@@ -368,36 +368,36 @@
                   (str "and nothing threw inside the handler — React would have
                         routed it to reportError and left this row green: "
                        (pr-str errs)))
-              (is (= 1 (shape/runs-of :comment-form)) "one keystroke re-ran the form")
-              (is (= 0 (shape/runs-of :screen)) "and not the screen")
-              (is (= 0 (shape/runs-of :comment-card)) "and no card at all"))
+              (is (= 1 (rf.bench.hicasso.shapes.ordinary/runs-of :comment-form)) "one keystroke re-ran the form")
+              (is (= 0 (rf.bench.hicasso.shapes.ordinary/runs-of :screen)) "and not the screen")
+              (is (= 0 (rf.bench.hicasso.shapes.ordinary/runs-of :comment-card)) "and no card at all"))
             ;; A SECOND keystroke, because one cannot tell a live
             ;; placeholder from a constant: the value the intent carries has
             ;; to be what the field holds NOW, not what it held when the
             ;; closure was minted.
             (let [ev (type-into! node "i")]
               (is (= "ni" (draft)) "the placeholder read the field again")
-              (is (= "ni" (controlled/last-rendered node)))
+              (is (= "ni" (rf.bench.hicasso.front.controlled/last-rendered node)))
               (is (= "ni" (.-value node)))
               (is (false? (.-defaultPrevented ev)))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 (deftest submitting-the-rendered-form-posts-and-auto-prevents
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (async done
       (fresh!)
       (let [handle (mount!)
             node   (q handle "textarea.form-control")
             form   (q handle "form.comment-form")
-            finish (fn [] (mount/release! handle) (done))]
+            finish (fn [] (rf.bench.hicasso.arm1.mount/release! handle) (done))]
         (.focus node)
         (.setSelectionRange node 0 0)
         ;; Composed on purpose: the draft this posts arrived through the
         ;; field's own handler, so a broken `:on-input` reds this row too.
         (type-into! node "nice piece")
         (is (= "nice piece" (draft)) "typed through the field, not written past it")
-        (shape/reset-runs!)
+        (rf.bench.hicasso.shapes.ordinary/reset-runs!)
         (let [stop! (error-watch!)
               ev    (submit! form)]
           (is (true? (.-defaultPrevented ev))
@@ -434,9 +434,9 @@
                       "the comment you just posted is your own, so it gets
                        the control"))
                 (testing "and the commit woke the boundaries that read what moved"
-                  (is (= 1 (shape/runs-of :screen)) "the list boundary reads the order")
-                  (is (= 1 (shape/runs-of :comment-form)) "the form reads the draft")
-                  (is (= 1 (shape/runs-of :comment-card))
+                  (is (= 1 (rf.bench.hicasso.shapes.ordinary/runs-of :screen)) "the list boundary reads the order")
+                  (is (= 1 (rf.bench.hicasso.shapes.ordinary/runs-of :comment-form)) "the form reads the draft")
+                  (is (= 1 (rf.bench.hicasso.shapes.ordinary/runs-of :comment-card))
                       "and exactly ONE card body ran — the new row's. The five
                        already on screen bailed out on equal props, so a post
                        is a narrow write and not a list rebuild"))
@@ -447,36 +447,36 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest typing-re-runs-the-form-boundary-and-nothing-else
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (let [handle (mount!)]
         (try
-          (is (= comment-count (shape/runs-of :comment-card)) "the mount ran every card once")
-          (shape/reset-runs!)
-          (rt/dispatch! frame-id [:conduit/edit-draft m/comment-draft-key "n"])
-          (mount/settle!)
-          (is (= 1 (shape/runs-of :comment-form))
+          (is (= comment-count (rf.bench.hicasso.shapes.ordinary/runs-of :comment-card)) "the mount ran every card once")
+          (rf.bench.hicasso.shapes.ordinary/reset-runs!)
+          (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:conduit/edit-draft rf.bench.hicasso.shapes.model/comment-draft-key "n"])
+          (rf.bench.hicasso.arm1.mount/settle!)
+          (is (= 1 (rf.bench.hicasso.shapes.ordinary/runs-of :comment-form))
               "the keystroke re-ran the form")
-          (is (= 0 (shape/runs-of :screen))
+          (is (= 0 (rf.bench.hicasso.shapes.ordinary/runs-of :screen))
               "and did NOT re-run the screen, which reads the order and not the draft")
-          (is (= 0 (shape/runs-of :comment-card))
+          (is (= 0 (rf.bench.hicasso.shapes.ordinary/runs-of :comment-card))
               "and re-ran no card at all — the claim a DOM comparison cannot make")
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 5 — the conditional read costs what the branch costs
 ;; ---------------------------------------------------------------------------
 
 (deftest a-card-that-cannot-delete-does-not-hold-the-delete-edge
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (let [handle (mount!)]
         (try
-          (let [edges (:edges (rt/stats))
+          (let [edges (:edges (rf.bench.hicasso.arm1.runtime/stats))
                 ;; screen: [:conduit/comment-ids]                      = 1
                 ;; form:   [:conduit/comment-pending?] + [:conduit/draft k] = 2
                 ;; card:   [:conduit/comment id] + [:conduit/user]     = 2 each
@@ -489,33 +489,33 @@
             (is (< edges (+ 1 2 (* 3 comment-count)))
                 "and it is strictly fewer than a declaration that named all
                  three reads up front would have cost"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Teardown — read while the runtime still holds it
 ;; ---------------------------------------------------------------------------
 ;;
-;; `mount/release!` resets the runtime, so a residue reading taken after it
+;; `rf.bench.hicasso.arm1.mount/release!` resets the runtime, so a residue reading taken after it
 ;; answers zero however badly teardown went (rf2-2rtt6.48). This one is
 ;; taken between the unmount and the reset.
 
 (deftest the-screen-leaves-no-residue
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (async done
       (fresh!)
       (let [handle (mount!)]
-        (rt/dispatch! frame-id [:conduit/edit-draft m/comment-draft-key "x"])
-        (mount/settle!)
-        (is (pos? (:cell-refs (rt/stats)))
+        (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:conduit/edit-draft rf.bench.hicasso.shapes.model/comment-draft-key "x"])
+        (rf.bench.hicasso.arm1.mount/settle!)
+        (is (pos? (:cell-refs (rf.bench.hicasso.arm1.runtime/stats)))
             "the mounted screen holds references, so the reading below is a
              reading of something")
-        (mount/unmount! handle)
+        (rf.bench.hicasso.arm1.mount/unmount! handle)
         (js/setTimeout (fn []
                          (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                                (rt/residue))
+                                (rf.bench.hicasso.arm1.runtime/residue))
                              "React's own cleanup released every edge, reference
                               and cached entry")
-                         (rt/reset-runtime!)
+                         (rf.bench.hicasso.arm1.runtime/reset-runtime!)
                          (done))
                        8)))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/shapes/route_link_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/shapes/route_link_dom_cljs_test.cljs
@@ -32,24 +32,24 @@
   Runtime: `-dom-cljs-test`. Under `:node-test` every claim degrades to a
   stated skip."
   (:require [cljs.test :refer-macros [async deftest is use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt :refer [sub]]
-            [re-frame.bench.hicasso.front.route-link :as link]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.shapes.card :as card]
-            [re-frame.bench.hicasso.shapes.model :as m]
-            [re-frame.bench.hicasso.shapes.ordinary :as ordinary]
-            [re-frame.subs :as subs]
-            [re-frame.test-support :as test-support])
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime :refer [sub]]
+            [re-frame.bench.hicasso.front.route-link :as rf.bench.hicasso.front.route-link]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.shapes.card :as rf.bench.hicasso.shapes.card]
+            [re-frame.bench.hicasso.shapes.model :as rf.bench.hicasso.shapes.model]
+            [re-frame.bench.hicasso.shapes.ordinary :as rf.bench.hicasso.shapes.ordinary]
+            [re-frame.subs :as rf.subs]
+            [re-frame.test-support :as rf.test-support])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::shape-route-link)
 
@@ -86,17 +86,17 @@
   anchors the clicks below land on."
   [_]
   (ran! :card-host)
-  (card/card (:slug (m/article 0))))
+  (rf.bench.hicasso.shapes.card/card (:slug (rf.bench.hicasso.shapes.model/article 0))))
 
 (defview veto-pair
   [_]
   (ran! :veto-pair)
   [:div
-   (link/route-link {:to :conduit.profile/show :params {:username "jane"}
+   (rf.bench.hicasso.front.route-link/route-link {:to :conduit.profile/show :params {:username "jane"}
                      :class "vetoed" :data-testid "vetoed-link"
                      :on-click [:re-frame.hicasso/prevent [:conduit/show-your-feed]]}
      "vetoed")
-   (link/route-link {:to :conduit.profile/show :params {:username "riku"}
+   (rf.bench.hicasso.front.route-link/route-link {:to :conduit.profile/show :params {:username "riku"}
                      :class "unvetoed" :data-testid "unvetoed-link"}
      "control")])
 
@@ -113,14 +113,14 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- fresh! []
-  (lane/leave-act-environment!)
-  (m/make-frame! frame-id seed)
-  (m/reseed! frame-id seed)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.shapes.model/make-frame! frame-id seed)
+  (rf.bench.hicasso.shapes.model/reseed! frame-id seed)
   (reset-runs!)
   frame-id)
 
 (defn- mount! []
-  (mount/root! (mount/fresh-container!) frame-id [nav-page {}]))
+  (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [nav-page {}]))
 
 (defn- q [handle sel] (.querySelector (:container handle) sel))
 
@@ -128,7 +128,7 @@
   (some-> (q handle (str "[data-testid=\"" testid "\"]")) (.-textContent)))
 
 (defn- current-route []
-  (subs/subscribe-once [:rf/route] {:frame frame-id}))
+  (rf.subs/subscribe-once [:rf/route] {:frame frame-id}))
 
 (defn- click!
   "Fire a real `MouseEvent` at `node` under a document-level guard that
@@ -149,7 +149,7 @@
   `assert-fn` and `done`."
   [assert-fn done]
   (js/setTimeout (fn []
-                   (mount/settle!)
+                   (rf.bench.hicasso.arm1.mount/settle!)
                    (assert-fn)
                    (done))
                  15))
@@ -159,54 +159,54 @@
 ;; ===========================================================================
 
 (deftest the-ported-census-anchors-are-real-routed-anchors
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (let [handle (mount!)]
         (try
-          (let [author (:username (:author (m/article 0)))]
-            ;; `#`-prefixed: `m/make-frame!` declares the census's own
+          (let [author (:username (:author (rf.bench.hicasso.shapes.model/article 0)))]
+            ;; `#`-prefixed: `rf.bench.hicasso.shapes.model/make-frame!` declares the census's own
             ;; hash `:url-strategy` (Conduit is a hash-URL app), so the
             ;; router's synthesis IS the census's `#/…` form — rf2-6c237,
             ;; repairing the rf2-2rtt6.54 parity gap against the
             ;; hand-ported twins in `census_clock_arms`.
             (doseq [[sel href] [[".author-link" (str "#/profile/" author)]
                                 [".author"      (str "#/profile/" author)]
-                                [".preview-link" (str "#/article/" (:slug (m/article 0)))]]]
+                                [".preview-link" (str "#/article/" (:slug (rf.bench.hicasso.shapes.model/article 0)))]]]
               (let [a (q handle sel)]
                 (is (instance? js/HTMLAnchorElement a)
                     (str sel " is a real anchor"))
                 (is (= href (.getAttribute a "href"))
                     (str sel "'s href is the router's synthesis — the port no "
                          "longer hand-builds the URL the router owns")))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 (deftest the-comment-byline-is-a-routed-anchor-too
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [ordinary/screen {}])]
+      (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [rf.bench.hicasso.shapes.ordinary/screen {}])]
         (try
           (let [a (q handle ".comment-author")]
             (is (instance? js/HTMLAnchorElement a))
             (is (re-matches #"#/profile/.+" (.getAttribute a "href"))
                 "ordinary.cljs's byline names a route, not a URL — encoded
                  through the frame's declared census hash strategy"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))
 
 ;; ===========================================================================
 ;; 2 — a real click, a real route change, a real re-render
 ;; ===========================================================================
 
 (deftest a-plain-click-navigates-and-the-page-re-renders
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (async done
       (fresh!)
       (let [handle (mount!)
-            author (:username (:author (m/article 0)))]
+            author (:username (:author (rf.bench.hicasso.shapes.model/article 0)))]
         (is (= "nowhere" (text handle "where-am-i")) "no route yet")
         (reset-runs!)
         (click! (q handle ".author"))
@@ -221,11 +221,11 @@
                  navigation commit reached the index like any other")
             (is (= 1 (runs :where)) "exactly one body ran for it")
             (is (= 0 (runs :card-host)) "the card did not — it reads no route")
-            (mount/release! handle))
+            (rf.bench.hicasso.arm1.mount/release! handle))
           done)))))
 
 (deftest a-modifier-click-stays-native
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (async done
       (fresh!)
@@ -239,7 +239,7 @@
                  open-in-new-tab meaning")
             (is (= "nowhere" (text handle "where-am-i")))
             (is (= 0 (runs :where)) "and nothing re-rendered")
-            (mount/release! handle))
+            (rf.bench.hicasso.arm1.mount/release! handle))
           done)))))
 
 ;; ===========================================================================
@@ -247,20 +247,20 @@
 ;; ===========================================================================
 
 (deftest a-prevent-veto-cancels-the-navigation-and-dispatches-instead
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (async done
       (fresh!)
       (let [handle (mount!)]
-        (is (false? (subs/subscribe-once [:conduit/your-feed?] {:frame frame-id})))
+        (is (false? (rf.subs/subscribe-once [:conduit/your-feed?] {:frame frame-id})))
         (click! (q handle ".vetoed"))
         (js/setTimeout
           (fn []
-            (mount/settle!)
+            (rf.bench.hicasso.arm1.mount/settle!)
             (is (nil? (:route-id (current-route)))
                 "the navigation was vetoed — activate-link! saw
                  defaultPrevented and stood down")
-            (is (true? (subs/subscribe-once [:conduit/your-feed?] {:frame frame-id}))
+            (is (true? (rf.subs/subscribe-once [:conduit/your-feed?] {:frame frame-id}))
                 "and the wrapped app intent dispatched in its place: one
                  click, one semantic event")
             ;; The MUTATION CONTROL: the same anchor without the veto
@@ -268,12 +268,12 @@
             (click! (q handle ".unvetoed"))
             (js/setTimeout
               (fn []
-                (mount/settle!)
+                (rf.bench.hicasso.arm1.mount/settle!)
                 (is (= :conduit.profile/show (:route-id (current-route)))
                     "the unvetoed sibling navigates — the veto, not the
                      machinery, is what cancelled the first click")
                 (is (= {:username "riku"} (:params (current-route))))
-                (mount/release! handle)
+                (rf.bench.hicasso.arm1.mount/release! handle)
                 (done))
               15))
           15)))))
@@ -283,7 +283,7 @@
 ;; ===========================================================================
 
 (deftest the-route-link-page-leaves-no-residue
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (async done
       (fresh!)
@@ -291,12 +291,12 @@
         (click! (q handle ".author"))
         (js/setTimeout
           (fn []
-            (mount/settle!)
-            (mount/unmount! handle)
+            (rf.bench.hicasso.arm1.mount/settle!)
+            (rf.bench.hicasso.arm1.mount/unmount! handle)
             (js/setTimeout (fn []
                              (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                                    (rt/residue)))
-                             (rt/reset-runtime!)
+                                    (rf.bench.hicasso.arm1.runtime/residue)))
+                             (rf.bench.hicasso.arm1.runtime/reset-runtime!)
                              (done))
                            8))
           15)))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/slice_broad_clock_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/slice_broad_clock_app.cljs
@@ -34,7 +34,7 @@
   where the copy is of SHIPPING code (the rf2-2rtt6.32 call-convention
   discipline), and that reason does not reach a sibling arm: two copies
   of one bench mechanism is two things that can drift with nothing
-  holding them in step, which is the shape `lane/visit-plan`'s own
+  holding them in step, which is the shape `rf.bench.hicasso.lane/visit-plan`'s own
   docstring is written against. So the two drivers cannot disagree about
   what a window is, and a repair to the window reaches both.
 
@@ -148,7 +148,7 @@
 
   ## THE FAIRNESS GATE RUNS BEFORE ANY CLOCK, AND IT HAS A NEGATIVE CONTROL
 
-  `lane/canonical` is this lane's one answer to *are these two arms
+  `rf.bench.hicasso.lane/canonical` is this lane's one answer to *are these two arms
   building the same page* — attribute names sorted, so the comparison is
   of the DOM and not of two serialisers. [[assert-parity!]] takes it over
   both containers on the seeded page and REFUSES the run when they
@@ -199,8 +199,8 @@
     element's inline `background-color`** against the target theme's
     `:surface` token. A button's activation behaviour writes no style.
 
-  Both checks are adjudicated per sample, banked into `lane/tally`, and
-  `lane/assert-verified!` refuses the run at `N unverified of M`.
+  Both checks are adjudicated per sample, banked into `rf.bench.hicasso.lane/tally`, and
+  `rf.bench.hicasso.lane/assert-verified!` refuses the run at `N unverified of M`.
 
   ## THE NEGATIVE CONTROLS ON THE ECHOES, TAKEN ONCE AT BOOT
 
@@ -243,9 +243,9 @@
   verdict, the control's verdict and the runtime label. Then two
   comparative figures — `:locale / :donor-locale` and
   `:theme / :donor-theme`, per round and as a range, through
-  `lane/ratio-between` — every arm's range against the floor through
-  `lane/across-rounds`, and per pair what size of difference the run
-  could have SEEN, through `lane/resolution`.
+  `rf.bench.hicasso.lane/ratio-between` — every arm's range against the floor through
+  `rf.bench.hicasso.lane/across-rounds`, and per pair what size of difference the run
+  could have SEEN, through `rf.bench.hicasso.lane/resolution`.
 
   **No line is applied to any of them.** `U3`'s 100 ms `p95`, `C3`'s
   `1.25x` and `C4`'s `1.5x` appear nowhere in this file and none of them
@@ -267,7 +267,7 @@
   `1.00x` for a reason that has nothing to do with either substrate.
 
   That is why `:over-floor` is published beside the comparative figures.
-  It is `lane/across-rounds` over each arm's ratio to `:idle-frame`, and
+  It is `rf.bench.hicasso.lane/across-rounds` over each arm's ratio to `:idle-frame`, and
   its `:straddles-1?` flag is the FIRST of two tests: an arm whose range
   against an EMPTY FRAME includes 1.0 was not separated from the floor by
   this window, and no ratio between two such arms is a reading about
@@ -286,7 +286,7 @@
   quoted that as a pass.
 
   So `:resolution` is published beside `:comparative`, one entry per
-  pair, from `lane/resolution` — see that function for the arithmetic.
+  pair, from `rf.bench.hicasso.lane/resolution` — see that function for the arithmetic.
   Its `:resolves-at` is the smallest difference in the ARMS' OWN WORK
   whose effect on the published ratio would have been as large as the
   scatter this run actually showed. **Read it against the line YOUR row
@@ -303,17 +303,17 @@
   the same finding reached one step later.
 
   Owner: rf2-9wmqd."
-  (:require [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.slice-donor-views :as donor]
-            [re-frame.bench.hicasso.slice-echo-clock-app :as echo]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.slice-donor-views :as rf.bench.hicasso.slice-donor-views]
+            [re-frame.bench.hicasso.slice-echo-clock-app :as rf.bench.hicasso.slice-echo-clock-app]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.slice.db :as slice-db]
-            [re-frame.hicasso.examples.slice.events :as slice-events]
-            [re-frame.hicasso.examples.slice.i18n :as slice-i18n]
-            [re-frame.hicasso.examples.slice.routes :as slice-routes]
-            [re-frame.hicasso.examples.slice.views :as slice-views]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.slice.db :as rf.hicasso.examples.slice.db]
+            [re-frame.hicasso.examples.slice.events :as rf.hicasso.examples.slice.events]
+            [re-frame.hicasso.examples.slice.i18n :as rf.hicasso.examples.slice.i18n]
+            [re-frame.hicasso.examples.slice.routes :as rf.hicasso.examples.slice.routes]
+            [re-frame.hicasso.examples.slice.views :as rf.hicasso.examples.slice.views]
             [uix.dom :as uix-dom]))
 
 ;; ---------------------------------------------------------------------------
@@ -326,7 +326,7 @@
   taken on a different schedule from the row it sits beside is a
   comparison a reader has to reconcile before they can read it.
 
-  **A tail quantile over 12 is mostly interpolation** (`lane/quantile`
+  **A tail quantile over 12 is mostly interpolation** (`rf.bench.hicasso.lane/quantile`
   prices it), so the run that reads this instrument will want more, and
   raising these two is how it gets them.
 
@@ -392,8 +392,8 @@
   is the failure the canonical-DOM gate would report as a page difference
   and a reader would spend an afternoon on. It is the slice's own pair
   from `app.cljs`, opened on the feed rather than on an article."
-  [[::slice-events/seed]
-   [:rf.route/navigate {:to slice-routes/feed}]])
+  [[::rf.hicasso.examples.slice.events/seed]
+   [:rf.route/navigate {:to rf.hicasso.examples.slice.routes/feed}]])
 
 ;; ---------------------------------------------------------------------------
 ;; State
@@ -415,7 +415,7 @@
   [[boot!]] — warm-up visits included, because a verification is worth
   more the more of them there are."
   []
-  (lane/tally-value (:echo-tally @!state)))
+  (rf.bench.hicasso.lane/tally-value (:echo-tally @!state)))
 
 (defn visits
   "`{arm-id n}` — how many windows each arm has taken since the last
@@ -425,7 +425,7 @@
   which is one less, and [[claim-visit!]] is the one place that conversion
   happens. The distinction is worth a line because the first cut of this
   reader published the index under this docstring's words, and the suite
-  row that compares it against `lane/visit-plan`'s per-arm visit count is
+  row that compares it against `rf.bench.hicasso.lane/visit-plan`'s per-arm visit count is
   what found the disagreement.
 
   Exposed because a suite that wants to check the pre-state the driver
@@ -514,7 +514,7 @@
 (def locales
   "The two locales the row alternates between, in `i18n/locales`' order.
   A vector rather than a set so *the other one* is arithmetic."
-  (vec slice-i18n/locales))
+  (vec rf.hicasso.examples.slice.i18n/locales))
 
 (defn- other-locale [now]
   (first (remove #(= % now) locales)))
@@ -529,7 +529,7 @@
   fact whose opposite is a real regression, and a reader of a refusal
   needs to see which of the two went."
   [side want]
-  {:expect   (slice-i18n/t want :app/title)
+  {:expect   (rf.hicasso.examples.slice.i18n/t want :app/title)
    :rendered (some-> (title-heading side) .-textContent)
    :glass    (some-> (locale-select side) .-value)
    :want     (name want)})
@@ -547,7 +547,7 @@
   The token values are already CSSOM's own serialisation
   (`\"rgb(255, 255, 255)\"`), so this is an equality and not a parse."
   [side want]
-  {:expect   (slice-i18n/token want :surface)
+  {:expect   (rf.hicasso.examples.slice.i18n/token want :surface)
    :rendered (some-> (page-root side) .-style .-backgroundColor)
    :want     (name want)})
 
@@ -556,7 +556,7 @@
 
 (defn- note-refusal!
   "Keep the FIRST refusal's detail, so a run that dies on `N unverified of
-  M` says which arm, which conjunct and against what. `lane/tally` counts
+  M` says which arm, which conjunct and against what. `rf.bench.hicasso.lane/tally` counts
   and does not describe."
   [arm-id echo]
   (swap! !state update :first-refusal
@@ -615,7 +615,7 @@
   NOT RELIED ON and could not be — a map has none. The only question
   asked of this roster is *which member is the page not wearing*, which
   is answered by the token values and not by position."
-  (vec (keys slice-i18n/themes)))
+  (vec (keys rf.hicasso.examples.slice.i18n/themes)))
 
 (defn theme-state
   "`{:target <button> :want <theme>}` for one arm: the button to click,
@@ -647,7 +647,7 @@
         current? (fn [^js b] (.contains (.-classList b) "current"))
         marked  (filterv current? buttons)
         now-bg  (some-> (page-root side) .-style .-backgroundColor)
-        want    (first (remove (fn [th] (= (slice-i18n/token th :surface) now-bg)) themes))]
+        want    (first (remove (fn [th] (= (rf.hicasso.examples.slice.i18n/token th :surface) now-bg)) themes))]
     (when-not (= 2 (count themes))
       (throw (ex-info (str "the application's theme table names " (count themes) " themes, and "
                            "this arm's whole rule for choosing a target is *the one the page "
@@ -667,14 +667,14 @@
                       {:rf.error/id ::theme-current-unexpected
                        :side        side
                        :marked      (count marked)})))
-    (when-not (some (fn [th] (= (slice-i18n/token th :surface) now-bg)) themes)
+    (when-not (some (fn [th] (= (rf.hicasso.examples.slice.i18n/token th :surface) now-bg)) themes)
       (throw (ex-info (str "the " (name side) " arm's root is wearing " (pr-str now-bg)
                            ", which is neither theme's :surface token, so the theme echo "
                            "has no target it could be checked against")
                       {:rf.error/id ::theme-surface-unknown
                        :side        side
                        :observed    now-bg
-                       :tokens      (mapv #(slice-i18n/token % :surface) themes)})))
+                       :tokens      (mapv #(rf.hicasso.examples.slice.i18n/token % :surface) themes)})))
     {:target (first (remove current? buttons))
      :want   want}))
 
@@ -703,8 +703,8 @@
   the control has to occupy the interval the window is measuring rather
   than yield it."
   [ms]
-  (let [end (+ (lane/now-ms) ms)]
-    (loop [] (when (< (lane/now-ms) end) (recur)))))
+  (let [end (+ (rf.bench.hicasso.lane/now-ms) ms)]
+    (loop [] (when (< (rf.bench.hicasso.lane/now-ms) end) (recur)))))
 
 (defn- blocked-plan
   "`:locale` on the Hicasso arm, plus [[blocked-ms]] of blocked main
@@ -741,19 +741,19 @@
   "Two frames, outside every window. React's commit and the initial
   events' drain are not the same tick."
   []
-  (.then (echo/after-paint) (fn [_] (echo/after-paint))))
+  (.then (rf.bench.hicasso.slice-echo-clock-app/after-paint) (fn [_] (rf.bench.hicasso.slice-echo-clock-app/after-paint))))
 
 (def seed-locale
   "The locale both frames open in, taken from the application's own seed
   rather than written out. A literal `:en` here would be a second
   authority for a fact `db/seed` already states, and the first thing to go
   stale when the slice ships a third locale and changes its default."
-  (:locale slice-db/seed))
+  (:locale rf.hicasso.examples.slice.db/seed))
 
 (def seed-theme
   "The theme both frames open in, from the same seed and for the same
   reason."
-  (:theme slice-db/seed))
+  (:theme rf.hicasso.examples.slice.db/seed))
 
 (defn- other-theme
   "The theme the application's table names that is not `now`. The same
@@ -776,7 +776,7 @@
 
   PR #8599's audit measured it on this file's own roster. `:locale` and
   `:ctl-blocked` both move the HICASSO frame's locale while only
-  `:donor-locale` moves the donor's, so replaying `lane/visit-plan` at
+  `:donor-locale` moves the donor's, so replaying `rf.bench.hicasso.lane/visit-plan` at
   `{:warmup 8 :samples 12}` puts `:theme` in the non-seed locale on 4 of
   its 12 measured visits per round and `:donor-theme` on 8 of 12. The same
   arithmetic in the other dimension splits the CONTROL from the arm it is
@@ -862,8 +862,8 @@
   [arm visit]
   (let [{:keys [locale theme]} (pre-state arm visit)]
     (rf/with-frame (frame-for (:side arm))
-      (rf/dispatch-sync [::slice-events/set-locale (name locale)])
-      (rf/dispatch-sync [::slice-events/set-theme {:theme theme}]))
+      (rf/dispatch-sync [::rf.hicasso.examples.slice.events/set-locale (name locale)])
+      (rf/dispatch-sync [::rf.hicasso.examples.slice.events/set-theme {:theme theme}]))
     (settle!)))
 
 ;; ---------------------------------------------------------------------------
@@ -877,8 +877,8 @@
   this is called from inside [[measure-one!]], which the lane calls for
   warm-up and measured visits alike and which is handed an ARM rather
   than a visit, so it cannot tell them apart and does not try.
-  `echo/structure-over-measured` narrows the parts to the measured
-  population using the mask `lane/visit-plan` produces.
+  `rf.bench.hicasso.slice-echo-clock-app/structure-over-measured` narrows the parts to the measured
+  population using the mask `rf.bench.hicasso.lane/visit-plan` produces.
 
   The two consumers want different populations, which is why the
   narrowing is at publication rather than here. The TALLY wants every
@@ -924,8 +924,8 @@
   [arm]
   (let [visit (claim-visit! (:id arm))]
     (-> (establish-pre-state! arm visit)
-        (.then (fn [_] (echo/after-paint)))
-        (.then (fn [_] (echo/window! ((:plan arm) !state))))
+        (.then (fn [_] (rf.bench.hicasso.slice-echo-clock-app/after-paint)))
+        (.then (fn [_] (rf.bench.hicasso.slice-echo-clock-app/window! ((:plan arm) !state))))
         (.then (fn [r] (bank-aux! (:id arm) r) (:ms r))))))
 
 ;; ---------------------------------------------------------------------------
@@ -936,7 +936,7 @@
   "Mount both arms into their own containers on their own frames, and
   answer a promise that resolves once both pages are on the screen.
 
-  The Hicasso arm goes through `h/mount!`, the application's own root
+  The Hicasso arm goes through `rf.hicasso/mount!`, the application's own root
   door, with the application's own views and `initial-events`. The donor
   arm makes its frame with `rf/make-frame` — core's own door, carrying
   the SAME `:initial-events` — and renders through `uix.dom`, which is
@@ -986,17 +986,17 @@
   read that rather than the defaults."
   ([] (boot! {:hicasso hicasso-frame :donor donor-frame}))
   ([{hic-frame :hicasso don-frame :donor}]
-   (let [hic-container (lane/fresh-container!)
-         don-container (lane/fresh-container!)
-         handle        (h/mount! hic-container
+   (let [hic-container (rf.bench.hicasso.lane/fresh-container!)
+         don-container (rf.bench.hicasso.lane/fresh-container!)
+         handle        (rf.hicasso/mount! hic-container
                                  {:frame             hic-frame
                                   :identifier-prefix "hic"
                                   :initial-events    initial-events}
-                                 [slice-views/app {}])
+                                 [rf.hicasso.examples.slice.views/app {}])
          _             (rf/make-frame {:id             don-frame
                                        :initial-events initial-events})
          don-root      (uix-dom/create-root don-container {:identifier-prefix "don"})]
-     (uix-dom/render-root (donor/root don-frame) don-root)
+     (uix-dom/render-root (rf.bench.hicasso.slice-donor-views/root don-frame) don-root)
      (swap! !state assoc
             :hicasso-container hic-container
             :hicasso-handle    handle
@@ -1006,7 +1006,7 @@
             :frames            {:hicasso hic-frame :donor don-frame}
             :visits            {}
             :aux               {}
-            :echo-tally        (lane/tally))
+            :echo-tally        (rf.bench.hicasso.lane/tally))
      (.then (settle!)
             (fn [_]
               (doseq [side [:hicasso :donor]]
@@ -1034,7 +1034,7 @@
   measurement and the remedy."
   []
   (let [{:keys [hicasso-container hicasso-handle donor-container donor-root]} @!state]
-    (when hicasso-handle (h/unmount! hicasso-handle))
+    (when hicasso-handle (rf.hicasso/unmount! hicasso-handle))
     (when donor-root (uix-dom/unmount-root donor-root))
     (doseq [c [hicasso-container donor-container]]
       (when (and c (.-parentNode c)) (.removeChild (.-parentNode c) c)))
@@ -1050,8 +1050,8 @@
 (defn pages
   "Both arms' canonical DOM, as `{:hicasso s :donor s}`."
   []
-  {:hicasso (lane/canonical (container-for :hicasso))
-   :donor   (lane/canonical (container-for :donor))})
+  {:hicasso (rf.bench.hicasso.lane/canonical (container-for :hicasso))
+   :donor   (rf.bench.hicasso.lane/canonical (container-for :donor))})
 
 (defn- first-difference
   "The index of the first character at which `a` and `b` differ, and the
@@ -1071,7 +1071,7 @@
   "REFUSE unless both arms are building the same page.
 
   This is the entire fairness guarantee of a cross-arm ratio, in
-  `lane/canonical`'s own words: without it two arms can be timed against
+  `rf.bench.hicasso.lane/canonical`'s own words: without it two arms can be timed against
   each other while building different pages. It runs on the seeded page,
   before any window, because that is the only moment both arms are known
   to be in the same state — every measured arm alternates its own page
@@ -1111,7 +1111,7 @@
         now         (keyword (.-value (locale-select :donor)))
         other       (other-locale now)
         to-locale!  (fn [l] (rf/with-frame (frame-for :donor)
-                              (rf/dispatch-sync [::slice-events/set-locale (name l)])))
+                              (rf/dispatch-sync [::rf.hicasso.examples.slice.events/set-locale (name l)])))
         restore     (fn [] (to-locale! now))
         break       (fn [] (to-locale! other))]
     (break)
@@ -1140,7 +1140,7 @@
   "Take one window over `plan` and require its observation to REFUSE.
   Answers a promise of the refused observation and REJECTS if it passed."
   [label plan]
-  (.then (echo/window! plan)
+  (.then (rf.bench.hicasso.slice-echo-clock-app/window! plan)
          (fn [{:keys [echo]}]
            (when (:verified? echo)
              (throw (ex-info (str label " does not discriminate: a window whose interaction "
@@ -1253,13 +1253,13 @@
   "Each round's arm-to-floor ratio map, which is what both comparative
   figures are built from.
 
-  Every ratio is against the floor measured in THAT round — `lane/normalise`'s
+  Every ratio is against the floor measured in THAT round — `rf.bench.hicasso.lane/normalise`'s
   rule, and the reason this box's drift across rounds is not a term in
-  any published figure. `lane/ratio-between` then divides two of them,
+  any published figure. `rf.bench.hicasso.lane/ratio-between` then divides two of them,
   and the floor cancels: what is left is the per-round ratio of two
   within-round medians."
   [readings]
-  (mapv (fn [round] (:ratio (lane/normalise round :idle-frame))) readings))
+  (mapv (fn [round] (:ratio (rf.bench.hicasso.lane/normalise round :idle-frame))) readings))
 
 (defn control-per-round
   "One adjudicated figure per round: `:ctl-blocked`'s median less
@@ -1270,8 +1270,8 @@
   with its own denominator is what `control-verdict-strict` asks for."
   [readings]
   (mapv (fn [round]
-          (lane/round4 (- (:p50 (lane/summarise (get round :ctl-blocked)))
-                          (:p50 (lane/summarise (get round :locale))))))
+          (rf.bench.hicasso.lane/round4 (- (:p50 (rf.bench.hicasso.lane/summarise (get round :ctl-blocked)))
+                          (:p50 (rf.bench.hicasso.lane/summarise (get round :locale))))))
         readings))
 
 (defn take-plan!
@@ -1283,18 +1283,18 @@
   the evidence on the console rather than only the refusal."
   []
   (.then
-    (lane/rounds-async! arms sampling rounds measure-one!)
+    (rf.bench.hicasso.lane/rounds-async! arms sampling rounds measure-one!)
     (fn [{:keys [readings samples]}]
       (let [by-arm  (readings-by-arm readings)
             ratios  (round-ratios readings)
-            control (lane/control-verdict-strict blocked-ms
+            control (rf.bench.hicasso.lane/control-verdict-strict blocked-ms
                                                  (control-per-round readings)
                                                  control-slack)
-            verdict (lane/guard! samples "slice broad update")
-            summary (into {} (map (fn [[id xs]] [id (lane/summarise xs)])) by-arm)
-            compare {:locale (lane/ratio-between ratios :locale :donor-locale)
-                     :theme  (lane/ratio-between ratios :theme :donor-theme)}]
-        (lane/record! :slice-broad
+            verdict (rf.bench.hicasso.lane/guard! samples "slice broad update")
+            summary (into {} (map (fn [[id xs]] [id (rf.bench.hicasso.lane/summarise xs)])) by-arm)
+            compare {:locale (rf.bench.hicasso.lane/ratio-between ratios :locale :donor-locale)
+                     :theme  (rf.bench.hicasso.lane/ratio-between ratios :theme :donor-theme)}]
+        (rf.bench.hicasso.lane/record! :slice-broad
                       {:window      :interaction-to-paint
                        :population  {:hicasso {:app   're-frame.hicasso.examples.slice
                                                :views 're-frame.hicasso.examples.slice.views
@@ -1308,10 +1308,10 @@
                                      ;; restated three integers would be a second
                                      ;; source for them, and the first thing to go
                                      ;; stale when the seed grows an article.
-                                     :seed    {:articles  (count (:order slice-db/seed))
-                                               :page-size slice-db/page-size
-                                               :pages     (slice-db/page-count
-                                                            (slice-db/listed slice-db/seed))}}
+                                     :seed    {:articles  (count (:order rf.hicasso.examples.slice.db/seed))
+                                               :page-size rf.hicasso.examples.slice.db/page-size
+                                               :pages     (rf.hicasso.examples.slice.db/page-count
+                                                            (rf.hicasso.examples.slice.db/listed rf.hicasso.examples.slice.db/seed))}}
                        :schedule    (assoc sampling
                                            :rounds           rounds
                                            :visits-per-arm   (* (+ (:warmup sampling)
@@ -1320,21 +1320,21 @@
                                            :measured-per-arm (* (:samples sampling) rounds))
                        :populations populations
                        :summary     summary
-                       :structure   (echo/structure-over-measured arms sampling rounds
+                       :structure   (rf.bench.hicasso.slice-echo-clock-app/structure-over-measured arms sampling rounds
                                                                   (:aux @!state))
                        :comparative compare
-                       :over-floor  (lane/across-rounds ratios)
+                       :over-floor  (rf.bench.hicasso.lane/across-rounds ratios)
                        :resolution  (into {}
                                           (map (fn [[pair c]]
-                                                 [pair (lane/resolution c summary :idle-frame)]))
+                                                 [pair (rf.bench.hicasso.lane/resolution c summary :idle-frame)]))
                                           compare)
                        :control     control
                        :guard       (select-keys verdict [:refuse? :contaminated?
                                                           :unchecked? :tolerance])
-                       :echo        (cond-> (lane/tally-value (:echo-tally @!state))
+                       :echo        (cond-> (rf.bench.hicasso.lane/tally-value (:echo-tally @!state))
                                       (:first-refusal @!state)
                                       (assoc :first-refusal (:first-refusal @!state)))
-                       :runtime     (lane/runtime-label)
+                       :runtime     (rf.bench.hicasso.lane/runtime-label)
                        :note        (str "No line is applied to any figure above. U3's 100 ms "
                                          "p95, C3's 1.25x and C4's 1.5x are read against this "
                                          "instrument in their own quiet-box window, not here. "
@@ -1349,14 +1349,14 @@
                                          "Neither figure is a verdict.")})
         (set! (.-HICASSO_GUARD_REFUSED js/window) (boolean (:refuse? verdict)))
         (set! (.-HICASSO_CONTROL_FAILED js/window) (not (:ok? control)))
-        (lane/assert-verified! (:echo-tally @!state) "slice broad update")
+        (rf.bench.hicasso.lane/assert-verified! (:echo-tally @!state) "slice broad update")
         nil))))
 
 (defn ^:export -main []
-  (rf/init! uix-adapter/adapter)
-  (lane/leave-act-environment!)
-  (if-not (lane/self-test!)
-    (lane/fail! (str "the arm-order self-test failed — the copy of the schedule "
+  (rf/init! rf.adapter.uix/adapter)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (if-not (rf.bench.hicasso.lane/self-test!)
+    (rf.bench.hicasso.lane/fail! (str "the arm-order self-test failed — the copy of the schedule "
                      "rule this app is about to rely on no longer behaves like "
                      "the one the .cjs drivers use, so nothing may be measured"))
     (-> (boot!)
@@ -1369,6 +1369,6 @@
         (.then (fn [_] (parity-discrimination!)))
         (.then (fn [_] (echo-discrimination!)))
         (.then (fn [_] (take-plan!)))
-        (.catch (fn [e] (lane/fail! (lane/describe-throw "slice-broad-clock-app" e))))
-        (.then (fn [_] (lane/done!)))))
+        (.catch (fn [e] (rf.bench.hicasso.lane/fail! (rf.bench.hicasso.lane/describe-throw "slice-broad-clock-app" e))))
+        (.then (fn [_] (rf.bench.hicasso.lane/done!)))))
   nil)

--- a/bench/hicasso/src/re_frame/bench/hicasso/slice_broad_window_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/slice_broad_window_dom_cljs_test.cljs
@@ -27,7 +27,7 @@
   **Do the two arms make the same READS?** Two pages can serialise
   identically while one of them subscribes to a value the other reads only
   in a branch it never takes. PR #8599's donor did exactly that with
-  `[::subs/t :feed/empty]`, on a seed that is never empty, so the donor
+  `[::rf.hicasso.examples.slice.subs/t :feed/empty]`, on a seed that is never empty, so the donor
   carried a subscription and a hook the Hicasso arm did not — work in the
   DENOMINATOR, moving `Hicasso / UIx` in the numerator's favour.
   [[the-donor-reads-nothing-the-hicasso-arm-does-not]] compares the two
@@ -37,7 +37,7 @@
 
   **Do PAIRED ARMS see the same page STATE?** The parity gate runs once,
   on the seeded page, before the first window; every arm moves its own
-  page afterwards. The audit's replay of `lane/visit-plan` found `:theme`
+  page afterwards. The audit's replay of `rf.bench.hicasso.lane/visit-plan` found `:theme`
   running in the non-seed locale on 4 of its 12 measured visits per round
   against `:donor-theme`'s 8 of 12, so the comparative theme figure was a
   ratio between two populations.
@@ -49,7 +49,7 @@
 
   ## WHAT THIS FILE DELIBERATELY DOES NOT RE-ADJUDICATE
 
-  **The canonical-DOM parity gate.** `clock/assert-parity!` is a RELEASE
+  **The canonical-DOM parity gate.** `rf.bench.hicasso.slice-broad-clock-app/assert-parity!` is a RELEASE
   gate by construction: under `goog.DEBUG` each Hicasso boundary emits its
   own `data-rf2-source-coord`, the UIx arm emits none, and the two pages
   are correctly not the same page. This suite compiles in dev, so a row
@@ -71,14 +71,14 @@
   because the collector's cell table is process-global and keyed by
   `(frame, query)` while the fixture retires a frame without going through
   the disposal hook that repairs those cells. [[with-both-arms]] and
-  `clock/boot!`'s §MOUNTING TWICE carry the mechanism and the measurement.
+  `rf.bench.hicasso.slice-broad-clock-app/boot!`'s §MOUNTING TWICE carry the mechanism and the measurement.
 
   Two of the rows below are what found it, and they were written for
   something else — which is the argument for having them. The read-roster
   row reported the Hicasso arm's cache as `#{}` against the donor's 34,
   and the schedule row reported `9 unverified of 18`, exactly the nine
   Hicasso-side windows. The same schedule row also caught a real
-  disagreement in the driver's own contract: `clock/visits` published the
+  disagreement in the driver's own contract: `rf.bench.hicasso.slice-broad-clock-app/visits` published the
   last visit INDEX under a docstring promising a COUNT.
 
   ## Runtime
@@ -87,23 +87,23 @@
   them on `:browser-test`; each degrades to a stated skip under
   `:node-test`, which is the posture every other `*-dom` suite in this
   tree keeps. The schedule rows are pure arithmetic over
-  `lane/visit-plan` and run on both."
+  `rf.bench.hicasso.lane/visit-plan` and run on both."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [clojure.set :as set]
-            [re-frame.adapter.uix :as uixa]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.slice-broad-clock-app :as clock]
-            [re-frame.bench.hicasso.slice-echo-clock-app :as echo]
-            [re-frame.hicasso.examples.slice.routes :as slice-routes]
-            [re-frame.hicasso.examples.slice.subs :as subs]
-            [re-frame.subs.tooling :as subs-tooling]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.slice-broad-clock-app :as rf.bench.hicasso.slice-broad-clock-app]
+            [re-frame.bench.hicasso.slice-echo-clock-app :as rf.bench.hicasso.slice-echo-clock-app]
+            [re-frame.hicasso.examples.slice.routes :as rf.hicasso.examples.slice.routes]
+            [re-frame.hicasso.examples.slice.subs :as rf.hicasso.examples.slice.subs]
+            [re-frame.subs.tooling :as rf.subs.tooling]
+            [re-frame.test-support :as rf.test-support]
             [uix.core :as uix :refer [$ defui]]
             [uix.dom :as uix-dom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uixa/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; The MAP shape, because every DOM row is `async`: `cljs.test` refuses
      ;; an async test under a fn-form fixture and ABORTS THE WHOLE NAMESPACE
@@ -114,14 +114,14 @@
      :init-fn       (fn []
                       ;; React's `act` queue is not the browser's scheduler,
                       ;; and every reading this instrument takes is taken
-                      ;; outside it — `lane/leave-act-environment!`'s own
+                      ;; outside it — `rf.bench.hicasso.lane/leave-act-environment!`'s own
                       ;; argument, applied to the suite that drives it.
                       (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
                       ;; The reset restores the registrar to a baseline
                       ;; captured when THIS FORM was evaluated, which is
                       ;; before `slice.routes` finished loading — so the
                       ;; route both arms navigate to would not exist.
-                      (slice-routes/register!))}))
+                      (rf.hicasso.examples.slice.routes/register!))}))
 
 (def ^:private off-browser
   "no DOM on this runtime — the rows below mount two real roots, take real
@@ -155,12 +155,12 @@
                        (str "donor-" n))}))
 
 (defn- with-both-arms
-  "Mount both arms through the instrument's own [[clock/boot!]], run `f` —
+  "Mount both arms through the instrument's own [[rf.bench.hicasso.slice-broad-clock-app/boot!]], run `f` —
   which answers a promise — and tear both roots down afterwards whatever
   happened.
 
   FRESH FRAME IDS PER MOUNT, and this is load-bearing rather than tidy.
-  `clock/boot!`'s §MOUNTING TWICE carries the measurement: the Hicasso
+  `rf.bench.hicasso.slice-broad-clock-app/boot!`'s §MOUNTING TWICE carries the measurement: the Hicasso
   collector's `!cells` table is process-global and keyed by
   `(frame, query)`, the repair for a retired reaction rides a disposal
   hook, and the `:each` fixture retires a frame by resetting
@@ -168,17 +168,17 @@
   a used id therefore renders once and is then DEAF — empty sub-cache, no
   watches, no re-render — while looking perfectly healthy on the glass.
 
-  This suite's first cut booted on `clock/`'s two default ids and CI read
+  This suite's first cut booted on `rf.bench.hicasso.slice-broad-clock-app/`'s two default ids and CI read
   exactly that: the mount row green, and every row after it red. It is the
   discipline `slice-echo-window-dom-cljs-test` already keeps."
   [f]
-  (-> (clock/boot! (fresh-frame-ids))
+  (-> (rf.bench.hicasso.slice-broad-clock-app/boot! (fresh-frame-ids))
       (.then (fn [_] (f)))
-      (.then (fn [v] (clock/teardown!) v)
-             (fn [e] (clock/teardown!) (throw e)))))
+      (.then (fn [v] (rf.bench.hicasso.slice-broad-clock-app/teardown!) v)
+             (fn [e] (rf.bench.hicasso.slice-broad-clock-app/teardown!) (throw e)))))
 
 (defn- arm-of [id]
-  (first (filter #(= id (:id %)) clock/arms)))
+  (first (filter #(= id (:id %)) rf.bench.hicasso.slice-broad-clock-app/arms)))
 
 ;; ---------------------------------------------------------------------------
 ;; The read roster — what each frame has actually subscribed to
@@ -187,9 +187,9 @@
 (defn- roster
   "The set of query vectors live in `frame-id`'s subscription cache.
 
-  `subs-tooling/sub-cache-snapshot` is the tool-facing read of the same
+  `rf.subs.tooling/sub-cache-snapshot` is the tool-facing read of the same
   per-frame cache BOTH substrates go through — Hicasso's collector calls
-  `subs/subscribe` for every `h/sub` edge, and the UIx adapter's
+  `rf.hicasso.examples.slice.subs/subscribe` for every `h/sub` edge, and the UIx adapter's
   `use-subscribe` calls it for every hook — so the two rosters are
   comparable without either arm being asked to report on itself.
 
@@ -197,15 +197,15 @@
   difference is worth stating because it makes this comparison STRONGER
   rather than looser. A cache entry exists for every reaction that was
   materialised, so a `:<-` sub's inputs are in here beside the values a
-  body asked for: reading `[::subs/current-page]` puts `[::subs/listed]`,
-  `[::subs/page]`, `[:rf.route/query]` and `[:rf/route]` in the roster
+  body asked for: reading `[::rf.hicasso.examples.slice.subs/current-page]` puts `[::rf.hicasso.examples.slice.subs/listed]`,
+  `[::rf.hicasso.examples.slice.subs/page]`, `[:rf.route/query]` and `[:rf/route]` in the roster
   too. A donor whose extra read were hidden one layer down — a different
   input chain reaching the same value — would still show up."
   [frame-id]
-  (set (keys (subs-tooling/sub-cache-snapshot frame-id))))
+  (set (keys (rf.subs.tooling/sub-cache-snapshot frame-id))))
 
-(defn- hicasso-roster [] (roster (:hicasso (clock/frames))))
-(defn- donor-roster [] (roster (:donor (clock/frames))))
+(defn- hicasso-roster [] (roster (:hicasso (rf.bench.hicasso.slice-broad-clock-app/frames))))
+(defn- donor-roster [] (roster (:donor (rf.bench.hicasso.slice-broad-clock-app/frames))))
 
 (defn- donor-only
   "What the donor arm reads that the Hicasso arm does not. THE ONE THAT
@@ -214,7 +214,7 @@
   (set/difference (donor-roster) (hicasso-roster)))
 
 (defui empty-label-probe
-  "One UNCONDITIONAL read of `[::subs/t :feed/empty]` on the donor frame.
+  "One UNCONDITIONAL read of `[::rf.hicasso.examples.slice.subs/t :feed/empty]` on the donor frame.
 
   This is exactly the shape `slice-donor-views/feed-page` carried before
   rf2-9wmqd's repair — a hook cannot be conditional, so a branch-local
@@ -224,7 +224,7 @@
   [[the-roster-gate-catches-an-unconditional-branch-local-read]] has a
   fault to catch."
   [_]
-  ($ :span.empty-label-probe (uixa/use-subscribe [::subs/t :feed/empty])))
+  ($ :span.empty-label-probe (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/t :feed/empty])))
 
 (defn- with-probe-mounted
   "Render [[empty-label-probe]] into its own root on the DONOR frame, run
@@ -234,16 +234,16 @@
   the driver's canonical-DOM gate; what it moves is the donor frame's
   subscription cache, which is the thing under test."
   [f]
-  (let [c    (lane/fresh-container!)
+  (let [c    (rf.bench.hicasso.lane/fresh-container!)
         root (uix-dom/create-root c {:identifier-prefix "probe"})
         drop! (fn []
                 (uix-dom/unmount-root root)
                 (when (.-parentNode c) (.removeChild (.-parentNode c) c)))]
-    (uix-dom/render-root ($ uixa/frame-provider {:frame (:donor (clock/frames))}
+    (uix-dom/render-root ($ rf.adapter.uix/frame-provider {:frame (:donor (rf.bench.hicasso.slice-broad-clock-app/frames))}
                             ($ empty-label-probe {}))
                          root)
-    (-> (echo/after-paint)
-        (.then (fn [_] (echo/after-paint)))
+    (-> (rf.bench.hicasso.slice-echo-clock-app/after-paint)
+        (.then (fn [_] (rf.bench.hicasso.slice-echo-clock-app/after-paint)))
         (.then (fn [_] (f)))
         (.then (fn [v] (drop!) v)
                (fn [e] (drop!) (throw e))))))
@@ -255,10 +255,10 @@
 
 (defn- established-runs
   "`{arm-id [pre-state …]}` over the MEASURED visits of one whole run,
-  taking each arm's pre-state from the driver's own [[clock/pre-state]]
+  taking each arm's pre-state from the driver's own [[rf.bench.hicasso.slice-broad-clock-app/pre-state]]
   and from the arm's own visit index.
 
-  The index is counted the way [[clock/claim-visit!]] counts it — every
+  The index is counted the way [[rf.bench.hicasso.slice-broad-clock-app/claim-visit!]] counts it — every
   visit the plan makes, warm-up included — because the driver's counter is
   advanced once per `measure-one!` and `measure-one!` is called for both."
   [arms sampling rounds]
@@ -266,10 +266,10 @@
     (reduce (fn [acc {:keys [arm measured?]}]
               (let [i (get (swap! !n update (:id arm) (fnil inc -1)) (:id arm))]
                 (if measured?
-                  (update acc (:id arm) (fnil conj []) (clock/pre-state arm i))
+                  (update acc (:id arm) (fnil conj []) (rf.bench.hicasso.slice-broad-clock-app/pre-state arm i))
                   acc)))
             {}
-            (lane/visit-plan arms sampling rounds))))
+            (rf.bench.hicasso.lane/visit-plan arms sampling rounds))))
 
 (defn- other-of [roster* now]
   (first (remove #(= % now) roster*)))
@@ -284,8 +284,8 @@
   locale while only `:donor-locale` moves the donor's, and `:theme` /
   `:donor-theme` move one theme each."
   [arms sampling rounds]
-  (let [!st (atom {:hicasso {:locale clock/seed-locale :theme clock/seed-theme}
-                   :donor   {:locale clock/seed-locale :theme clock/seed-theme}})]
+  (let [!st (atom {:hicasso {:locale rf.bench.hicasso.slice-broad-clock-app/seed-locale :theme rf.bench.hicasso.slice-broad-clock-app/seed-theme}
+                   :donor   {:locale rf.bench.hicasso.slice-broad-clock-app/seed-locale :theme rf.bench.hicasso.slice-broad-clock-app/seed-theme}})]
     (reduce (fn [acc {:keys [arm measured?]}]
               (let [{:keys [id side alternates]} arm
                     before (get @!st side)
@@ -293,12 +293,12 @@
                 (when alternates
                   (swap! !st update-in [side alternates]
                          (fn [v] (other-of (if (= :locale alternates)
-                                             clock/locales
-                                             clock/themes)
+                                             rf.bench.hicasso.slice-broad-clock-app/locales
+                                             rf.bench.hicasso.slice-broad-clock-app/themes)
                                            v))))
                 acc'))
             {}
-            (lane/visit-plan arms sampling rounds))))
+            (rf.bench.hicasso.lane/visit-plan arms sampling rounds))))
 
 (def ^:private compared-pairs
   "The three pairs whose two halves are subtracted or divided by each
@@ -316,10 +316,10 @@
   (frequencies (get runs id)))
 
 (defn- non-seed-locales [runs id]
-  (count (remove #(= clock/seed-locale (:locale %)) (get runs id))))
+  (count (remove #(= rf.bench.hicasso.slice-broad-clock-app/seed-locale (:locale %)) (get runs id))))
 
 (defn- non-seed-themes [runs id]
-  (count (remove #(= clock/seed-theme (:theme %)) (get runs id))))
+  (count (remove #(= rf.bench.hicasso.slice-broad-clock-app/seed-theme (:theme %)) (get runs id))))
 
 ;; The audit's own schedule, written out rather than read off the module,
 ;; so the numbers below stay the numbers the audit measured however the
@@ -338,17 +338,17 @@
            same numbers, and the same themes.
 
            Asserted over several schedules, and the last two are the
-           point: `clock/sampling`'s own docstring says a run reading this
+           point: `rf.bench.hicasso.slice-broad-clock-app/sampling`'s own docstring says a run reading this
            instrument will raise `:samples`, so a repair that held at 12
            and failed at 13 would fail exactly when it was first relied
            on."
     (doseq [[sampling rounds] [[audit-sampling audit-rounds]
-                               [clock/sampling clock/rounds]
+                               [rf.bench.hicasso.slice-broad-clock-app/sampling rf.bench.hicasso.slice-broad-clock-app/rounds]
                                [{:warmup 3 :samples 6} 5]
                                [{:warmup 8 :samples 13} 5]
                                [{:warmup 8 :samples 20} 5]]]
-      (let [runs (established-runs clock/arms sampling rounds)]
-        (doseq [{:keys [id]} clock/arms]
+      (let [runs (established-runs rf.bench.hicasso.slice-broad-clock-app/arms sampling rounds)]
+        (doseq [{:keys [id]} rf.bench.hicasso.slice-broad-clock-app/arms]
           (is (= (* rounds (:samples sampling)) (count (get runs id)))
               (str id " has one measured pre-state per measured visit at "
                    (pr-str sampling))))
@@ -367,7 +367,7 @@
            A green here would mean the row above passes whatever the arms
            see, and every state-mix claim this instrument could make would
            be worthless."
-    (let [runs (inherited-runs clock/arms audit-sampling audit-rounds)]
+    (let [runs (inherited-runs rf.bench.hicasso.slice-broad-clock-app/arms audit-sampling audit-rounds)]
       (is (not= (mix runs :theme) (mix runs :donor-theme))
           "the published theme comparative's two halves are NOT one population")
       (is (= (* audit-rounds 4) (non-seed-locales runs :theme))
@@ -385,7 +385,7 @@
            finds"))
     (testing "and the repair closes both at the same schedule, so the
              refusals above are about the rig and not about the replay"
-      (let [runs (established-runs clock/arms audit-sampling audit-rounds)]
+      (let [runs (established-runs rf.bench.hicasso.slice-broad-clock-app/arms audit-sampling audit-rounds)]
         (is (= (mix runs :theme) (mix runs :donor-theme)))
         (is (= (mix runs :ctl-blocked) (mix runs :locale)))))))
 
@@ -393,14 +393,14 @@
   (testing "`locale-plan` and `theme-plan` are written for a rotor — the
            target is always the value the page is NOT showing — and each
            claims its arm takes both directions in equal numbers. Under
-           [[clock/pre-state]] that is a property of the arm rather than a
+           [[rf.bench.hicasso.slice-broad-clock-app/pre-state]] that is a property of the arm rather than a
            consequence of the plan, so it can be asserted.
 
            The floor alternates nothing and holds the seed on every
            visit, which is what makes it a floor."
-    (let [runs (established-runs clock/arms clock/sampling clock/rounds)
-          n    (* clock/rounds (:samples clock/sampling))]
-      (doseq [{:keys [id alternates]} clock/arms]
+    (let [runs (established-runs rf.bench.hicasso.slice-broad-clock-app/arms rf.bench.hicasso.slice-broad-clock-app/sampling rf.bench.hicasso.slice-broad-clock-app/rounds)
+          n    (* rf.bench.hicasso.slice-broad-clock-app/rounds (:samples rf.bench.hicasso.slice-broad-clock-app/sampling))]
+      (doseq [{:keys [id alternates]} rf.bench.hicasso.slice-broad-clock-app/arms]
         (case alternates
           :locale (do (is (= (/ n 2) (non-seed-locales runs id))
                           (str id " opens half its measured windows in each locale"))
@@ -435,12 +435,12 @@
       (async done
         (-> (with-both-arms
               (fn []
-                (let [{:keys [hicasso donor]} (clock/pages)]
+                (let [{:keys [hicasso donor]} (rf.bench.hicasso.slice-broad-clock-app/pages)]
                   (is (pos? (count hicasso)) "the Hicasso arm rendered a page")
                   (is (pos? (count donor)) "and so did the donor arm"))
                 (doseq [side [:hicasso :donor]]
-                  (let [loc (clock/locale-echo-check side clock/seed-locale)
-                        thm (clock/theme-echo-check side clock/seed-theme)]
+                  (let [loc (rf.bench.hicasso.slice-broad-clock-app/locale-echo-check side rf.bench.hicasso.slice-broad-clock-app/seed-locale)
+                        thm (rf.bench.hicasso.slice-broad-clock-app/theme-echo-check side rf.bench.hicasso.slice-broad-clock-app/seed-theme)]
                     (is (= (:expect loc) (:rendered loc))
                         (str "the " (name side) " arm's <h1> carries the seeded"
                              " locale's title"))
@@ -474,27 +474,27 @@
                       "the Hicasso arm's cache holds a real page's worth of reads")
                   (is (< 10 (count don))
                       "and so does the donor arm's")
-                  (is (contains? hic [::subs/feed])
+                  (is (contains? hic [::rf.hicasso.examples.slice.subs/feed])
                       "both arms read the feed off the same registration")
-                  (is (contains? don [::subs/feed]))
-                  (is (contains? hic [::subs/t :app/title])
+                  (is (contains? don [::rf.hicasso.examples.slice.subs/feed]))
+                  (is (contains? hic [::rf.hicasso.examples.slice.subs/t :app/title])
                       "and both read the title string")
-                  (is (contains? don [::subs/t :app/title]))
+                  (is (contains? don [::rf.hicasso.examples.slice.subs/t :app/title]))
                   (is (contains? don [:rf.route/query])
                       "and the roster reaches INPUTS, not just the values a body
                        asked for: neither page reads the route's query directly,
-                       and it is here because `[::subs/page]` is `:<-` it — so a
+                       and it is here because `[::rf.hicasso.examples.slice.subs/page]` is `:<-` it — so a
                        read hidden one layer down would still show up")
 
                   (is (empty? (set/difference don hic))
                       (str "the donor reads NOTHING the Hicasso arm does not — "
                            (pr-str (set/difference don hic))))
 
-                  (is (not (contains? don [::subs/t :feed/empty]))
+                  (is (not (contains? don [::rf.hicasso.examples.slice.subs/t :feed/empty]))
                       "in particular the empty-state string, which the Hicasso
                        body reads only in its empty branch and the seed is never
                        empty (rf2-9wmqd's repair)")
-                  (is (not (contains? hic [::subs/t :feed/empty]))
+                  (is (not (contains? hic [::rf.hicasso.examples.slice.subs/t :feed/empty]))
                       "and the Hicasso arm does not read it either — so the two
                        agree by BOTH not reading it, rather than by the donor
                        having been matched to a read that was never taken")
@@ -510,7 +510,7 @@
 (deftest the-roster-gate-catches-an-unconditional-branch-local-read
   (testing "THE SABOTAGE on the row above, and it is the audit's finding
            replanted rather than an invented fault: one UIx boundary on the
-           donor frame reading `[::subs/t :feed/empty]` unconditionally,
+           donor frame reading `[::rf.hicasso.examples.slice.subs/t :feed/empty]` unconditionally,
            which is what `slice-donor-views/feed-page` did before the
            repair.
 
@@ -527,7 +527,7 @@
                     "before the plant, the donor reads nothing extra")
                 (with-probe-mounted
                   (fn []
-                    (is (= #{[::subs/t :feed/empty]} (donor-only))
+                    (is (= #{[::rf.hicasso.examples.slice.subs/t :feed/empty]} (donor-only))
                         "and with one unconditional branch-local read added on
                          the donor frame, the comparison names it and nothing
                          else")
@@ -540,9 +540,9 @@
 
 (deftest establishing-a-pre-state-puts-the-arms-page-in-it
   (testing "The bridge between the replay rows and the instrument. Those
-           rows assert a property of [[clock/pre-state]], which is
+           rows assert a property of [[rf.bench.hicasso.slice-broad-clock-app/pre-state]], which is
            arithmetic; this one asserts that
-           [[clock/establish-pre-state!]] actually lands that arithmetic on
+           [[rf.bench.hicasso.slice-broad-clock-app/establish-pre-state!]] actually lands that arithmetic on
            the arm's own page, read back through the driver's own echo
            checks rather than through a second reader written here.
 
@@ -553,18 +553,18 @@
       (async done
         (-> (with-both-arms
               (fn []
-                (lane/chain
+                (rf.bench.hicasso.lane/chain
                   nil
                   (for [id    [:locale :donor-locale :theme :donor-theme :ctl-blocked]
                         visit [0 1]]
                     [(arm-of id) visit])
                   (fn [_ [arm visit]]
-                    (.then (clock/establish-pre-state! arm visit)
+                    (.then (rf.bench.hicasso.slice-broad-clock-app/establish-pre-state! arm visit)
                            (fn [_]
-                             (let [{:keys [locale theme]} (clock/pre-state arm visit)
+                             (let [{:keys [locale theme]} (rf.bench.hicasso.slice-broad-clock-app/pre-state arm visit)
                                    side (:side arm)
-                                   loc  (clock/locale-echo-check side locale)
-                                   thm  (clock/theme-echo-check side theme)]
+                                   loc  (rf.bench.hicasso.slice-broad-clock-app/locale-echo-check side locale)
+                                   thm  (rf.bench.hicasso.slice-broad-clock-app/theme-echo-check side theme)]
                                (is (= (:expect loc) (:rendered loc))
                                    (str (:id arm) " visit " visit ": the page's <h1> is in "
                                         locale))
@@ -577,17 +577,17 @@
             (.then (fn [_] (done)) (fail-async done)))))))
 
 (deftest the-whole-schedule-runs-and-every-window-advances-its-own-counter
-  (testing "`lane/rounds-async!` drives all six arms over the two real
+  (testing "`rf.bench.hicasso.lane/rounds-async!` drives all six arms over the two real
            applications, every echo verifies, and — the half this file
            needs — each arm's visit counter has advanced exactly once per
            visit the plan made for it. That counter is the index
-           [[clock/pre-state]] is a function of, so a counter that
+           [[rf.bench.hicasso.slice-broad-clock-app/pre-state]] is a function of, so a counter that
            advanced twice, or not at all, would leave the replay rows
            asserting a property of a schedule the driver does not run.
 
            The schedule is TINY here and the module's own is not: this row
            asks whether the instrument runs, and a run that reads it wants
-           `clock/sampling` and `clock/rounds`."
+           `rf.bench.hicasso.slice-broad-clock-app/sampling` and `rf.bench.hicasso.slice-broad-clock-app/rounds`."
     (if-not (browser?)
       (skip! off-browser)
       (async done
@@ -596,21 +596,21 @@
               per-arm  (* rounds (+ (:warmup sampling) (:samples sampling)))]
           (-> (with-both-arms
                 (fn []
-                  (.then (lane/rounds-async! clock/arms sampling rounds clock/measure-one!)
+                  (.then (rf.bench.hicasso.lane/rounds-async! rf.bench.hicasso.slice-broad-clock-app/arms sampling rounds rf.bench.hicasso.slice-broad-clock-app/measure-one!)
                          (fn [{:keys [readings samples]}]
-                           (is (= (* rounds (:samples sampling) (count clock/arms))
+                           (is (= (* rounds (:samples sampling) (count rf.bench.hicasso.slice-broad-clock-app/arms))
                                   (count samples))
                                "every measured visit was banked for the guard")
                            (is (= rounds (count readings)))
-                           (is (every? (fn [round] (= (count clock/arms) (count round)))
+                           (is (every? (fn [round] (= (count rf.bench.hicasso.slice-broad-clock-app/arms) (count round)))
                                        readings)
                                "and every arm has a reading in every round")
-                           (is (= {:writes (* per-arm (count clock/arms)) :unverified 0}
-                                  (clock/verification))
+                           (is (= {:writes (* per-arm (count rf.bench.hicasso.slice-broad-clock-app/arms)) :unverified 0}
+                                  (rf.bench.hicasso.slice-broad-clock-app/verification))
                                "0 unverified of M — every window, warm-up included,
                                 reached a frame that carried its own echo")
-                           (is (= (into {} (map (fn [{:keys [id]}] [id per-arm])) clock/arms)
-                                  (clock/visits))
+                           (is (= (into {} (map (fn [{:keys [id]}] [id per-arm])) rf.bench.hicasso.slice-broad-clock-app/arms)
+                                  (rf.bench.hicasso.slice-broad-clock-app/visits))
                                "and every arm's visit counter advanced exactly once
                                 per visit — warm-up visits included, because the
                                 pre-state is established for those too")))))
@@ -629,9 +629,9 @@
            that no longer exists — the drift class this lane keeps paying
            for."
     (is (= [:idle-frame :locale :donor-locale :theme :donor-theme :ctl-blocked]
-           (mapv :id clock/arms))
+           (mapv :id rf.bench.hicasso.slice-broad-clock-app/arms))
         "floor first, so it leads the schedule")
-    (is (= [:ctl-blocked] (mapv :id (filter :control? clock/arms)))
+    (is (= [:ctl-blocked] (mapv :id (filter :control? rf.bench.hicasso.slice-broad-clock-app/arms)))
         "and exactly one of them is a control")
     (is (= {:idle-frame   [:hicasso nil]
             :locale       [:hicasso :locale]
@@ -639,23 +639,23 @@
             :theme        [:hicasso :theme]
             :donor-theme  [:donor   :theme]
             :ctl-blocked  [:hicasso :locale]}
-           (into {} (map (juxt :id (juxt :side :alternates))) clock/arms))
+           (into {} (map (juxt :id (juxt :side :alternates))) rf.bench.hicasso.slice-broad-clock-app/arms))
         "every arm declares its side and the dimension it moves")
     (doseq [[a b] compared-pairs]
       (is (= (:alternates (arm-of a)) (:alternates (arm-of b)))
           (str a " and " b " move the same dimension — otherwise there is
                nothing for a comparative to hold constant")))
-    (is (= 2 (count clock/locales)) "the rotor's roster is two locales")
-    (is (= 2 (count clock/themes)) "and two themes")
-    (is (contains? (set clock/locales) clock/seed-locale))
-    (is (contains? (set clock/themes) clock/seed-theme))
-    (is (pos? (:warmup clock/sampling)))
-    (is (pos? (:samples clock/sampling)))
-    (is (even? (:samples clock/sampling))
+    (is (= 2 (count rf.bench.hicasso.slice-broad-clock-app/locales)) "the rotor's roster is two locales")
+    (is (= 2 (count rf.bench.hicasso.slice-broad-clock-app/themes)) "and two themes")
+    (is (contains? (set rf.bench.hicasso.slice-broad-clock-app/locales) rf.bench.hicasso.slice-broad-clock-app/seed-locale))
+    (is (contains? (set rf.bench.hicasso.slice-broad-clock-app/themes) rf.bench.hicasso.slice-broad-clock-app/seed-theme))
+    (is (pos? (:warmup rf.bench.hicasso.slice-broad-clock-app/sampling)))
+    (is (pos? (:samples rf.bench.hicasso.slice-broad-clock-app/sampling)))
+    (is (even? (:samples rf.bench.hicasso.slice-broad-clock-app/sampling))
         "an ODD `:samples` would leave each arm's measured block one visit
          short of a whole number of rotor turns, so the two directions
          would not be taken in equal numbers")
-    (is (pos? clock/rounds))))
+    (is (pos? rf.bench.hicasso.slice-broad-clock-app/rounds))))
 
 (deftest the-record-labels-which-population-each-figure-is-taken-over
   (testing "`:summary`, `:structure`, `:comparative`, `:over-floor` and
@@ -672,4 +672,4 @@
             :over-floor  :measured-visits
             :resolution  :measured-visits
             :echo        :all-visits}
-           clock/populations))))
+           rf.bench.hicasso.slice-broad-clock-app/populations))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/slice_donor_views.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/slice_donor_views.cljs
@@ -55,16 +55,16 @@
   registration the Hicasso arm reads, one per boundary, and every write
   is the same event vector the Hicasso arm's intent lowers to.
 
-  - **The sub graph is `slice.subs`, untouched.** `[::subs/t k]`,
-    `[::subs/token k]`, `[::subs/feed]`, `[::subs/current-page]`,
-    `[::subs/page-count]`, `[::subs/tags-open? slug]`,
-    `[::subs/digest-blocks]` and `[::subs/digest-loading?]` — the same
+  - **The sub graph is `slice.subs`, untouched.** `[::rf.hicasso.examples.slice.subs/t k]`,
+    `[::rf.hicasso.examples.slice.subs/token k]`, `[::rf.hicasso.examples.slice.subs/feed]`, `[::rf.hicasso.examples.slice.subs/current-page]`,
+    `[::rf.hicasso.examples.slice.subs/page-count]`, `[::rf.hicasso.examples.slice.subs/tags-open? slug]`,
+    `[::rf.hicasso.examples.slice.subs/digest-blocks]` and `[::rf.hicasso.examples.slice.subs/digest-loading?]` — the same
     layer-1 and layer-2 registrations, resolved against this arm's own
     frame. Nothing is threaded as a prop that the Hicasso arm subscribes
     to: a row that took its label as a prop would be a different sub
     graph wearing the same name.
   - **The event vectors are `slice.events`', verbatim.**
-    `[::events/set-locale s]` and `[::events/set-theme {:theme t}]` are
+    `[::rf.hicasso.examples.slice.events/set-locale s]` and `[::rf.hicasso.examples.slice.events/set-theme {:theme t}]` are
     what Hicasso's `::h/value` marker and its intent vector lower to, and
     they are what this arm dispatches. The MARKER is Hicasso's
     ergonomics; the EVENT is the application's.
@@ -117,7 +117,7 @@
 
   The three differences above are AUTHORING ones. A fourth was a
   MEASUREMENT one, and it is repaired: this arm's `feed-page` read
-  `[::subs/t :feed/empty]` unconditionally where the Hicasso body reads it
+  `[::rf.hicasso.examples.slice.subs/t :feed/empty]` unconditionally where the Hicasso body reads it
   only in its empty branch, so on a seed that is never empty the donor
   carried a subscription and a hook the Hicasso arm did not. See
   [[feed-empty]].
@@ -157,12 +157,12 @@
   label.
 
   Owner: rf2-9wmqd."
-  (:require [re-frame.adapter.uix :as uixa]
-            [re-frame.hicasso.examples.slice.events :as events]
-            [re-frame.hicasso.examples.slice.i18n :as i18n]
-            [re-frame.hicasso.examples.slice.routes :as routes]
-            [re-frame.hicasso.examples.slice.subs :as subs]
-            [re-frame.routing :as routing]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.hicasso.examples.slice.events :as rf.hicasso.examples.slice.events]
+            [re-frame.hicasso.examples.slice.i18n :as rf.hicasso.examples.slice.i18n]
+            [re-frame.hicasso.examples.slice.routes :as rf.hicasso.examples.slice.routes]
+            [re-frame.hicasso.examples.slice.subs :as rf.hicasso.examples.slice.subs]
+            [re-frame.routing :as rf.routing]
             [uix.core :as uix :refer [$ defui]]))
 
 ;; ---------------------------------------------------------------------------
@@ -174,13 +174,13 @@
 
   `re-frame.hicasso.impl.route-link` takes its href from routing's
   `:routing/link-model` late-bind seam; this arm takes it from
-  `routing/route-url`, the public door onto the same registrations. The
+  `rf.routing/route-url`, the public door onto the same registrations. The
   two are not asserted equal here and they do not need to be: the
   driver's canonical-DOM gate compares the rendered anchors, so a
   disagreement between the two doors REFUSES the run rather than
   publishing a ratio taken over two different pages."
   [address]
-  (routing/route-url address))
+  (rf.routing/route-url address))
 
 (defn- link-click
   "The click a plain UIx application writes on an in-application link:
@@ -233,14 +233,14 @@
   theme buttons.
 
   This is the boundary both measured operations start at. The `<select>`
-  is controlled on `[::subs/locale]` and its `change` dispatches
-  `[::events/set-locale <string>]` — the string a `<select>`'s `.value`
+  is controlled on `[::rf.hicasso.examples.slice.subs/locale]` and its `change` dispatches
+  `[::rf.hicasso.examples.slice.events/set-locale <string>]` — the string a `<select>`'s `.value`
   always is, keyworded by the handler and not by this body, exactly as
   the Hicasso spelling leaves it.
 
   ## THE TWO THEME LABELS ARE READ BEFORE THE LOOP, NOT INSIDE IT
 
-  The Hicasso body reads `(h/sub [::subs/t label-key])` inside the `for`
+  The Hicasso body reads `(h/sub [::rf.hicasso.examples.slice.subs/t label-key])` inside the `for`
   that places the two buttons, and it may: `h/sub` is an ambient
   collector rather than a React hook. `use-subscribe` IS one, and a hook
   reached from inside a `for` is reached from inside a LAZY SEQ — a seq
@@ -254,14 +254,14 @@
   pairs, so both strings are read on every render of the Hicasso body
   too."
   [_]
-  (let [locale-now              (uixa/use-subscribe [::subs/locale])
-        theme-now               (uixa/use-subscribe [::subs/theme])
-        title                   (uixa/use-subscribe [::subs/t :app/title])
-        locale-label            (uixa/use-subscribe [::subs/t :app/locale])
-        theme-label             (uixa/use-subscribe [::subs/t :app/theme])
-        light-label             (uixa/use-subscribe [::subs/t :theme/light])
-        dark-label              (uixa/use-subscribe [::subs/t :theme/dark])
-        {:keys [dispatch-sync]} (uixa/use-frame)]
+  (let [locale-now              (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/locale])
+        theme-now               (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/theme])
+        title                   (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/t :app/title])
+        locale-label            (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/t :app/locale])
+        theme-label             (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/t :app/theme])
+        light-label             (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/t :theme/light])
+        dark-label              (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/t :theme/dark])
+        {:keys [dispatch-sync]} (rf.adapter.uix/use-frame)]
     ($ :header.slice-chrome
        ($ :h1.slice-title title)
 
@@ -269,8 +269,8 @@
        ($ :select#slice-locale.locale
           {:value     (name locale-now)
            :on-change (fn [^js e]
-                        (dispatch-sync [::events/set-locale (.. e -target -value)]))}
-          (for [locale i18n/locales]
+                        (dispatch-sync [::rf.hicasso.examples.slice.events/set-locale (.. e -target -value)]))}
+          (for [locale rf.hicasso.examples.slice.i18n/locales]
             ($ :option {:key (name locale) :value (name locale)} (name locale))))
 
        ($ :div.theme-switch
@@ -280,7 +280,7 @@
                {:key      (name theme)
                 :type     "button"
                 :class    (when (= theme theme-now) "current")
-                :on-click (fn [_] (dispatch-sync [::events/set-theme {:theme theme}]))}
+                :on-click (fn [_] (dispatch-sync [::rf.hicasso.examples.slice.events/set-theme {:theme theme}]))}
                label))))))
 
 ;; ---------------------------------------------------------------------------
@@ -295,10 +295,10 @@
   is `use-subscribe`, so the two reads are two calls — the same two
   edges, on the same two registrations."
   [{:keys [slug title published? tags]}]
-  (let [open?      (uixa/use-subscribe [::subs/tags-open? slug])
-        tags-label (uixa/use-subscribe [::subs/t :feed/tags])
-        {:keys [dispatch dispatch-sync]} (uixa/use-frame)
-        address    {:to routes/article :params {:slug slug}}]
+  (let [open?      (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/tags-open? slug])
+        tags-label (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/t :feed/tags])
+        {:keys [dispatch dispatch-sync]} (rf.adapter.uix/use-frame)
+        address    {:to rf.hicasso.examples.slice.routes/article :params {:slug slug}}]
     ($ :li.article-row
        ($ :a {:class    "article-link"
               :href     (href-for address)
@@ -311,7 +311,7 @@
             ($ :button.tags-toggle
                {:type          "button"
                 :aria-expanded (str (boolean open?))
-                :on-click      (fn [_] (dispatch-sync [::subs/tags-open? slug (not open?)]))}
+                :on-click      (fn [_] (dispatch-sync [::rf.hicasso.examples.slice.subs/tags-open? slug (not open?)]))}
                tags-label)
             (when open?
               ($ :ul.tag-list
@@ -359,13 +359,13 @@
   seed that ever made the feed single-page would move the population
   before it moved this."
   [_]
-  (let [page                  (uixa/use-subscribe [::subs/current-page])
-        pages                 (uixa/use-subscribe [::subs/page-count])
-        {:keys [dispatch]}    (uixa/use-frame)
-        pagination            (uixa/use-subscribe [::subs/t :feed/pagination])
-        previous              (uixa/use-subscribe [::subs/t :feed/previous])
-        next-label            (uixa/use-subscribe [::subs/t :feed/next])
-        page-address          (fn [n] {:to routes/feed :query {:page n}})]
+  (let [page                  (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/current-page])
+        pages                 (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/page-count])
+        {:keys [dispatch]}    (rf.adapter.uix/use-frame)
+        pagination            (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/t :feed/pagination])
+        previous              (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/t :feed/previous])
+        next-label            (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/t :feed/next])
+        page-address          (fn [n] {:to rf.hicasso.examples.slice.routes/feed :query {:page n}})]
     (when (< 1 pages)
       ($ :nav.pager {:aria-label pagination}
          (if (= 1 page)
@@ -429,7 +429,7 @@
   ARE NOT THE SAME."
   [{:keys [block]}]
   (let [warning? (= :warning (:block/tone block))
-        colour   (uixa/use-subscribe [::subs/token (if warning? :danger :accent)])]
+        colour   (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/token (if warning? :danger :accent)])]
     ($ :aside.block-callout {:style {:color colour}}
        (if warning?
          ($ :strong {:class "block-emphasis"} (:block/text block))
@@ -439,7 +439,7 @@
   "A block of a kind this build has no renderer for — the EXPECTED
   failure, which stays data."
   [{:keys [block]}]
-  (let [label (uixa/use-subscribe [::subs/t :digest/unsupported])]
+  (let [label (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/t :digest/unsupported])]
     ($ :p.block-unsupported
        label
        " "
@@ -460,7 +460,7 @@
   COMPONENT and takes the value at runtime, so this is the same
   expression the Hicasso body writes."
   [_]
-  (let [blocks (uixa/use-subscribe [::subs/digest-blocks])]
+  (let [blocks (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/digest-blocks])]
     ($ :div.digest-body
        (for [{:block/keys [id kind] :as block} blocks]
          ($ (get block-views kind unsupported-block) {:key id :block block})))))
@@ -472,15 +472,15 @@
         ;; blocks for its region's `:reset-key`; nothing in this arm's
         ;; markup needs them. Dropping the read would give this boundary a
         ;; SMALLER read set than the one it stands in for — one fewer edge
-        ;; into `[::subs/digest-blocks]`, so one fewer re-render when the
+        ;; into `[::rf.hicasso.examples.slice.subs/digest-blocks]`, so one fewer re-render when the
         ;; digest moves — which is the quiet way a donor becomes a
         ;; strawman.
-        _blocks                 (uixa/use-subscribe [::subs/digest-blocks])
-        loading?                (uixa/use-subscribe [::subs/digest-loading?])
-        heading                 (uixa/use-subscribe [::subs/t :digest/heading])
-        problem                 (uixa/use-subscribe [::subs/t :digest/problem])
-        retry                   (uixa/use-subscribe [::subs/t (if loading? :digest/loading :digest/retry)])
-        {:keys [dispatch-sync]} (uixa/use-frame)]
+        _blocks                 (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/digest-blocks])
+        loading?                (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/digest-loading?])
+        heading                 (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/t :digest/heading])
+        problem                 (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/t :digest/problem])
+        retry                   (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/t (if loading? :digest/loading :digest/retry)])
+        {:keys [dispatch-sync]} (rf.adapter.uix/use-frame)]
     ($ :section.digest
        ($ :h3.digest-heading heading)
        ($ error-region
@@ -489,7 +489,7 @@
                         ($ :button.digest-retry
                            {:type     "button"
                             :disabled loading?
-                            :on-click (fn [_] (dispatch-sync [::events/reload-digest]))}
+                            :on-click (fn [_] (dispatch-sync [::rf.hicasso.examples.slice.events/reload-digest]))}
                            retry))}
           ($ digest-body {})))))
 
@@ -501,7 +501,7 @@
   "The empty state, and the one read on this page that belongs to a BRANCH
   rather than to a body.
 
-  The Hicasso `feed-page` writes `[:p.feed-empty (h/sub [::subs/t
+  The Hicasso `feed-page` writes `[:p.feed-empty (h/sub [::rf.hicasso.examples.slice.subs/t
   :feed/empty])]` inside its empty branch, so a feed with rows in it never
   records an edge on that string. `use-subscribe` is a React hook and a
   hook cannot be conditional, so the transcription that read it beside the
@@ -516,7 +516,7 @@
   is `<p class=\"feed-empty\">…` either way, so the driver's canonical-DOM
   gate reads the same page in both states."
   [_]
-  ($ :p.feed-empty (uixa/use-subscribe [::subs/t :feed/empty])))
+  ($ :p.feed-empty (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/t :feed/empty])))
 
 (defui feed-page
   "The list, keyed by slug. The digest, the pager and the empty state are
@@ -527,8 +527,8 @@
   [[feed-empty]] carries the reason the empty state is a boundary here and
   is markup there."
   [_]
-  (let [rows    (uixa/use-subscribe [::subs/feed])
-        heading (uixa/use-subscribe [::subs/t :feed/heading])]
+  (let [rows    (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/feed])
+        heading (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/t :feed/heading])]
     ($ :section.feed
        ($ :h2 heading)
        ($ digest {})
@@ -560,9 +560,9 @@
   LESS is the one C3's ratio divides by, so the omission cannot flatter
   the numerator."
   [_]
-  (let [surface (uixa/use-subscribe [::subs/token :surface])
-        ink     (uixa/use-subscribe [::subs/token :ink])
-        pane    (uixa/use-subscribe [::subs/t :app/pane-error])]
+  (let [surface (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/token :surface])
+        ink     (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/token :ink])
+        pane    (rf.adapter.uix/use-subscribe [::rf.hicasso.examples.slice.subs/t :app/pane-error])]
     ($ :main.slice {:style {:background surface :color ink}}
        ($ chrome {})
        ($ error-region
@@ -576,5 +576,5 @@
   its own, so it cannot move the canonical-DOM gate. The frame is made by
   the driver, outside every window."
   [frame-id]
-  ($ uixa/frame-provider {:frame frame-id}
+  ($ rf.adapter.uix/frame-provider {:frame frame-id}
      ($ app {})))

--- a/bench/hicasso/src/re_frame/bench/hicasso/slice_echo_clock_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/slice_echo_clock_app.cljs
@@ -59,8 +59,8 @@
      READ OFF THE MIRROR THE APPLICATION WRITES below: the check is
      read out of the DOM INSIDE those rendering steps, before style,
      layout and paint, so a verified sample is one whose painted frame
-     carried the echo. It banks into `lane/tally` and
-     `lane/assert-verified!` refuses the run at `N unverified of M`.
+     carried the echo. It banks into `rf.bench.hicasso.lane/tally` and
+     `rf.bench.hicasso.lane/assert-verified!` refuses the run at `N unverified of M`.
   3. THE NEGATIVE CONTROL ON THE ECHO ITSELF, taken once at boot:
      [[echo-discrimination!]] performs the keystroke's SETUP MUTATION
      ALONE — the native value write, with no DOM event and therefore no
@@ -94,10 +94,10 @@
   therefore adjudicates the INSTRUMENT'S WINDOW and not merely its
   sensitivity.
 
-  It is adjudicated under `lane/control-verdict-strict` — every round
+  It is adjudicated under `rf.bench.hicasso.lane/control-verdict-strict` — every round
   inside the band — and not under the overlap rule, because these legs are
   tens of milliseconds and nowhere near the 100 µs clamp Chrome puts on
-  `performance.now()`. `lane/control-verdict`'s own docstring names that exactly: a
+  `performance.now()`. `rf.bench.hicasso.lane/control-verdict`'s own docstring names that exactly: a
   batched window lifting the legs clear of the quantum is the condition
   under which the strict rule is the one to use.
 
@@ -114,7 +114,7 @@
   banked parts cover every visit, warm-up included — [[bank-aux!]] is
   called from inside [[measure-one!]], which the lane calls for both —
   and [[structure-over-measured]] narrows them to the visits
-  `lane/rounds-async!` actually returned, using the MASK the lane's own
+  `rf.bench.hicasso.lane/rounds-async!` actually returned, using the MASK the lane's own
   [[re-frame.bench.hicasso.lane/visit-plan]] produces rather than a second
   reading of the schedule. At `{:warmup 8 :samples 12}` over five rounds
   that is `60` values per arm on both, against the `100` an unnarrowed
@@ -171,7 +171,7 @@
 
   ## THE POPULATION IS THE SLICE APPLICATION, MOUNTED THROUGH ITS OWN DOOR
 
-  [[boot!]] calls `h/mount!` with the slice's own `[views/app {}]` and the
+  [[boot!]] calls `rf.hicasso/mount!` with the slice's own `[views/app {}]` and the
   same two `:initial-events` its `-main` passes, differing only in which
   route it opens on — which is data the application already takes. Nothing
   here reaches under `re-frame.hicasso.impl.*`, nothing rebuilds a view,
@@ -238,13 +238,13 @@
   writes it only when the element has no `checked` prop, and this one has.
 
   Owner: rf2-xa8wo."
-  (:require [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.lane :as lane]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.slice.events :as slice-events]
-            [re-frame.hicasso.examples.slice.routes :as slice-routes]
-            [re-frame.hicasso.examples.slice.views :as slice-views]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.slice.events :as rf.hicasso.examples.slice.events]
+            [re-frame.hicasso.examples.slice.routes :as rf.hicasso.examples.slice.routes]
+            [re-frame.hicasso.examples.slice.views :as rf.hicasso.examples.slice.views]))
 
 ;; ---------------------------------------------------------------------------
 ;; The knobs — every one of them a SCHEDULE knob, never a line
@@ -260,10 +260,10 @@
   "Per-round warm-up and measured counts.
 
   `:warmup 8` is `rf2-h904p`'s value and is carried rather than chosen:
-  `lane/rounds!`'s docstring records that it puts the +27% step this lane
+  `rf.bench.hicasso.lane/rounds!`'s docstring records that it puts the +27% step this lane
   sees after a site's sixth execution inside the warm-up. `:samples 12`
   is the same file's figure. **A tail quantile over 12 is mostly
-  interpolation** — `lane/quantile`'s docstring prices exactly that — so
+  interpolation** — `rf.bench.hicasso.lane/quantile`'s docstring prices exactly that — so
   the run that reads this instrument will want more, and raising these
   two is how it gets them."
   {:warmup 8 :samples 12})
@@ -336,7 +336,7 @@
   more the more of them there are. Exposed so the DOM self-test can read
   the same counter [[take-plan!]] adjudicates."
   []
-  (lane/tally-value (:echo-tally @!state)))
+  (rf.bench.hicasso.lane/tally-value (:echo-tally @!state)))
 
 (defn banked-structure
   "[[bank-aux!]]'s raw per-arm `{:commit :to-raf :raf-to-paint}` vectors,
@@ -395,7 +395,7 @@
   article's title plus one letter of [[rotor]] ([[keystroke-plan]]) or
   the title the application is already showing ([[toggle-plan]]), and the
   only door into `[:drafts slug :title]` is `::events/edit` carrying
-  `::h/value` off a real `input` event — which is to say, off a value
+  `::rf.hicasso/value` off a real `input` event — which is to say, off a value
   this file typed.
 
   PRINTABLE ASCII, and that is not cosmetic. The first spelling of this
@@ -435,7 +435,7 @@
   "Keep the FIRST refusal's detail, so a run that dies on `N unverified of
   M` says which conjunct went and against what.
 
-  `lane/tally` counts and does not describe, and a bare count over a
+  `rf.bench.hicasso.lane/tally` counts and does not describe, and a bare count over a
   two-part check is a diagnosis the operator has to reproduce. One
   `swap!` on a slot that is written at most once a run is cheaper than
   that."
@@ -503,19 +503,19 @@
   (js/Promise.
     (fn [resolve reject]
       (try
-        (let [t0 (lane/now-ms)]
+        (let [t0 (rf.bench.hicasso.lane/now-ms)]
           (interact!)
-          (let [t-commit (lane/now-ms)]
+          (let [t-commit (rf.bench.hicasso.lane/now-ms)]
             (when after-commit! (after-commit!))
             (js/requestAnimationFrame
               (fn []
                 (try
-                  (let [t-raf (lane/now-ms)
+                  (let [t-raf (rf.bench.hicasso.lane/now-ms)
                         echo  (observe-at-frame)]
                     (js/setTimeout
                       (fn []
                         (try
-                          (let [t-paint (lane/now-ms)]
+                          (let [t-paint (rf.bench.hicasso.lane/now-ms)]
                             (resolve {:ms              (- t-paint t0)
                                       :commit-ms       (- t-commit t0)
                                       :to-raf-ms       (- t-raf t0)
@@ -627,8 +627,8 @@
   the control has to occupy the interval the window is measuring rather
   than yield it."
   [ms]
-  (let [end (+ (lane/now-ms) ms)]
-    (loop [] (when (< (lane/now-ms) end) (recur)))))
+  (let [end (+ (rf.bench.hicasso.lane/now-ms) ms)]
+    (loop [] (when (< (rf.bench.hicasso.lane/now-ms) end) (recur)))))
 
 (defn- blocked-plan
   "[[keystroke-plan]] plus [[blocked-ms]] of blocked main thread on
@@ -668,7 +668,7 @@
   rather than a visit — so it cannot tell them apart, and it does not try.
   It banks everything, and [[structure-over-measured]] narrows the parts
   down to the measured population before they are published, using the
-  mask `lane/visit-plan` produces.
+  mask `rf.bench.hicasso.lane/visit-plan` produces.
 
   The two consumers want different populations, which is why the
   narrowing is at publication rather than here. The TALLY wants every
@@ -831,20 +831,20 @@
   `act` flag have to survive it, so it installs its own through
   `re-frame.test-support`'s reset fixture and restores the flag itself."
   [container frame-id]
-  (let [handle (h/mount! container
+  (let [handle (rf.hicasso/mount! container
                          {:frame          frame-id
-                          :initial-events [[::slice-events/seed]
+                          :initial-events [[::rf.hicasso.examples.slice.events/seed]
                                            [:rf.route/navigate
-                                            {:to     slice-routes/article
+                                            {:to     rf.hicasso.examples.slice.routes/article
                                              :params {:slug article-slug}}]]}
-                         [slice-views/app {}])]
+                         [rf.hicasso.examples.slice.views/app {}])]
     (swap! !state assoc
            :container container
            :handle handle
            :tick 0
            :aux {}
            :first-refusal nil
-           :echo-tally (lane/tally))
+           :echo-tally (rf.bench.hicasso.lane/tally))
     (-> (after-paint)
         (.then (fn [_] (after-paint)))
         (.then (fn [_]
@@ -863,7 +863,7 @@
   self-test mounts and unmounts around each of its rows."
   []
   (let [{:keys [container handle]} @!state]
-    (when handle (h/unmount! handle))
+    (when handle (rf.hicasso/unmount! handle))
     (when (and container (.-parentNode container))
       (.removeChild (.-parentNode container) container))
     (swap! !state assoc :container nil :handle nil :base-title nil)
@@ -883,21 +883,21 @@
   "Per arm id, the `:measured?` flag of each of that arm's visits IN THE
   ORDER [[bank-aux!]] appended them.
 
-  Taken from `lane/visit-plan` — the schedule both of the lane's loops
+  Taken from `rf.bench.hicasso.lane/visit-plan` — the schedule both of the lane's loops
   walk — rather than re-derived from `warmup`, `samples` and
-  `lane/slot-order` here. A second reading of the schedule is the exact
+  `rf.bench.hicasso.lane/slot-order` here. A second reading of the schedule is the exact
   shape this lane has paid for twice, and it would be worse here than
   usual: a mask that drifted would not fail, it would publish a
   distribution over the wrong visits and say nothing.
 
-  The order is safe to rely on because `lane/rounds-async!` runs its
+  The order is safe to rely on because `rf.bench.hicasso.lane/rounds-async!` runs its
   visits SERIALLY — visit *n+1* starts only once *n*'s promise has
   resolved — so [[bank-aux!]]'s appends happen in plan order."
   [arms sampling rounds]
   (reduce (fn [m {:keys [arm measured?]}]
             (update m (:id arm) (fnil conj []) measured?))
           {}
-          (lane/visit-plan arms sampling rounds)))
+          (rf.bench.hicasso.lane/visit-plan arms sampling rounds)))
 
 (defn- keep-measured
   "`xs` narrowed to the visits the lane measured. REFUSES rather than
@@ -928,9 +928,9 @@
     (into {}
           (map (fn [[id {:keys [commit to-raf raf-to-paint]}]]
                  (let [m (get mask id)]
-                   [id {:commit       (lane/summarise (keep-measured id m commit))
-                        :to-raf       (lane/summarise (keep-measured id m to-raf))
-                        :raf-to-paint (lane/summarise (keep-measured id m raf-to-paint))}])))
+                   [id {:commit       (rf.bench.hicasso.lane/summarise (keep-measured id m commit))
+                        :to-raf       (rf.bench.hicasso.lane/summarise (keep-measured id m to-raf))
+                        :raf-to-paint (rf.bench.hicasso.lane/summarise (keep-measured id m raf-to-paint))}])))
           aux)))
 
 (defn control-per-round
@@ -942,8 +942,8 @@
   its own denominator is what `control-verdict-strict` asks for."
   [readings]
   (mapv (fn [round]
-          (lane/round4 (- (:p50 (lane/summarise (get round :ctl-blocked)))
-                          (:p50 (lane/summarise (get round :keystroke))))))
+          (rf.bench.hicasso.lane/round4 (- (:p50 (rf.bench.hicasso.lane/summarise (get round :ctl-blocked)))
+                          (:p50 (rf.bench.hicasso.lane/summarise (get round :keystroke))))))
         readings))
 
 (defn take-plan!
@@ -955,14 +955,14 @@
   the evidence on the console rather than only the refusal."
   []
   (.then
-    (lane/rounds-async! arms sampling rounds measure-one!)
+    (rf.bench.hicasso.lane/rounds-async! arms sampling rounds measure-one!)
     (fn [{:keys [readings samples]}]
       (let [by-arm  (readings-by-arm readings)
-            control (lane/control-verdict-strict blocked-ms
+            control (rf.bench.hicasso.lane/control-verdict-strict blocked-ms
                                                  (control-per-round readings)
                                                  control-slack)
-            verdict (lane/guard! samples "slice interaction-to-paint")]
-        (lane/record! :slice-echo
+            verdict (rf.bench.hicasso.lane/guard! samples "slice interaction-to-paint")]
+        (rf.bench.hicasso.lane/record! :slice-echo
                       {:window     :interaction-to-paint
                        :population {:app   're-frame.hicasso.examples.slice
                                     :route :article
@@ -974,31 +974,31 @@
                                                                rounds)
                                           :measured-per-arm (* (:samples sampling) rounds))
                        :populations populations
-                       :summary    (into {} (map (fn [[id xs]] [id (lane/summarise xs)])) by-arm)
+                       :summary    (into {} (map (fn [[id xs]] [id (rf.bench.hicasso.lane/summarise xs)])) by-arm)
                        :structure  (structure-over-measured arms sampling rounds (:aux @!state))
                        :control    control
                        :guard      (select-keys verdict [:refuse? :contaminated?
                                                          :unchecked? :tolerance])
-                       :echo       (cond-> (lane/tally-value (:echo-tally @!state))
+                       :echo       (cond-> (rf.bench.hicasso.lane/tally-value (:echo-tally @!state))
                                      (:first-refusal @!state)
                                      (assoc :first-refusal (:first-refusal @!state)))
-                       :runtime    (lane/runtime-label)
+                       :runtime    (rf.bench.hicasso.lane/runtime-label)
                        :note       (str "No line is applied to any figure above. U1-U4 are "
                                         "read against this instrument in their own quiet-box "
                                         "window, not here.")})
         (set! (.-HICASSO_GUARD_REFUSED js/window) (boolean (:refuse? verdict)))
         (set! (.-HICASSO_CONTROL_FAILED js/window) (not (:ok? control)))
-        (lane/assert-verified! (:echo-tally @!state) "slice interaction-to-paint")
+        (rf.bench.hicasso.lane/assert-verified! (:echo-tally @!state) "slice interaction-to-paint")
         nil))))
 
 (defn ^:export -main []
-  (rf/init! uix-adapter/adapter)
-  (lane/leave-act-environment!)
-  (if-not (lane/self-test!)
-    (lane/fail! (str "the arm-order self-test failed — the copy of the schedule "
+  (rf/init! rf.adapter.uix/adapter)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (if-not (rf.bench.hicasso.lane/self-test!)
+    (rf.bench.hicasso.lane/fail! (str "the arm-order self-test failed — the copy of the schedule "
                      "rule this app is about to rely on no longer behaves like "
                      "the one the .cjs drivers use, so nothing may be measured"))
-    (-> (boot! (or (js/document.getElementById "app") (lane/fresh-container!))
+    (-> (boot! (or (js/document.getElementById "app") (rf.bench.hicasso.lane/fresh-container!))
                ::frame)
         ;; The echo's negative control runs BEFORE the first warm-up
         ;; visit and its throw travels the same `.catch` as any other
@@ -1006,6 +1006,6 @@
         ;; rather than publishing a record nobody should read.
         (.then (fn [_] (echo-discrimination!)))
         (.then (fn [_] (take-plan!)))
-        (.catch (fn [e] (lane/fail! (lane/describe-throw "slice-echo-clock-app" e))))
-        (.then (fn [_] (lane/done!)))))
+        (.catch (fn [e] (rf.bench.hicasso.lane/fail! (rf.bench.hicasso.lane/describe-throw "slice-echo-clock-app" e))))
+        (.then (fn [_] (rf.bench.hicasso.lane/done!)))))
   nil)

--- a/bench/hicasso/src/re_frame/bench/hicasso/slice_echo_window_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/slice_echo_window_dom_cljs_test.cljs
@@ -65,15 +65,15 @@
   `:node-test`, which is the posture every other `*-dom` suite in this
   tree keeps. The pure rows run on both."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.slice-echo-clock-app :as clock]
-            [re-frame.hicasso.examples.slice.routes :as slice-routes]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.slice-echo-clock-app :as rf.bench.hicasso.slice-echo-clock-app]
+            [re-frame.hicasso.examples.slice.routes :as rf.hicasso.examples.slice.routes]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; The MAP shape, because every DOM row is `async`: `cljs.test` refuses
      ;; an async test under a fn-form fixture and ABORTS THE WHOLE NAMESPACE
@@ -84,14 +84,14 @@
      :init-fn       (fn []
                       ;; React's `act` queue is not the browser's scheduler,
                       ;; and every reading this instrument takes is taken
-                      ;; outside it — `lane/leave-act-environment!`'s own
+                      ;; outside it — `rf.bench.hicasso.lane/leave-act-environment!`'s own
                       ;; argument, applied to the suite that drives it.
                       (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
                       ;; The reset restores the registrar to a baseline
                       ;; captured when THIS FORM was evaluated, which is
                       ;; before `slice.routes` finished loading — so the
                       ;; route the instrument navigates to would not exist.
-                      (slice-routes/register!))}))
+                      (rf.hicasso.examples.slice.routes/register!))}))
 
 (def ^:private off-browser
   "no DOM on this runtime — every claim below is a real mount, a real DOM
@@ -114,7 +114,7 @@
            (str "frame-" (swap! !frame-n inc))))
 
 (defn- with-mounted-slice
-  "Mount the slice through the instrument's own [[clock/boot!]], run
+  "Mount the slice through the instrument's own [[rf.bench.hicasso.slice-echo-clock-app/boot!]], run
   `f` — which answers a promise — and tear the root down afterwards
   whatever happened.
 
@@ -124,20 +124,20 @@
   which the keystroke row types over — would be whatever the last row
   left there."
   [f]
-  (let [container (lane/fresh-container!)]
-    (-> (clock/boot! container (fresh-frame-id))
+  (let [container (rf.bench.hicasso.lane/fresh-container!)]
+    (-> (rf.bench.hicasso.slice-echo-clock-app/boot! container (fresh-frame-id))
         (.then (fn [_] (f)))
-        (.then (fn [v] (clock/teardown!) v)
-               (fn [e] (clock/teardown!) (throw e))))))
+        (.then (fn [v] (rf.bench.hicasso.slice-echo-clock-app/teardown!) v)
+               (fn [e] (rf.bench.hicasso.slice-echo-clock-app/teardown!) (throw e))))))
 
 (defn- plan-for [arm-id]
-  (:plan (first (filter #(= arm-id (:id %)) clock/arms))))
+  (:plan (first (filter #(= arm-id (:id %)) rf.bench.hicasso.slice-echo-clock-app/arms))))
 
 (defn- one-window
   "One reading from `arm-id`'s plan, built and taken the way
-  [[clock/measure-one!]] builds and takes it."
+  [[rf.bench.hicasso.slice-echo-clock-app/measure-one!]] builds and takes it."
   [arm-id]
-  (clock/window! ((plan-for arm-id) nil)))
+  (rf.bench.hicasso.slice-echo-clock-app/window! ((plan-for arm-id) nil)))
 
 (defn- fail-async [done]
   (fn [e]
@@ -154,7 +154,7 @@
   happened.
 
   WHY THE CAPTURE PHASE AT THE DOCUMENT. React 19 attaches its listeners
-  to the ROOT CONTAINER, which `lane/fresh-container!` appends to
+  to the ROOT CONTAINER, which `rf.bench.hicasso.lane/fresh-container!` appends to
   `document.body` — so the container sits strictly below `js/document` on
   every propagation path, and a capture-phase `stopPropagation` here means
   the event never descends to it. The Hicasso handler does not run, so
@@ -275,7 +275,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-echo-refuses-the-setup-mutation-alone
-  (testing "The driver's OWN negative control, exercised. `clock/
+  (testing "The driver's OWN negative control, exercised. `rf.bench.hicasso.slice-echo-clock-app/
            echo-discrimination!` performs the keystroke arm's setup
            mutation and nothing else — the native `value` write, with no
            DOM event and therefore no handler, no dispatch, no state write
@@ -289,13 +289,13 @@
       (async done
         (-> (with-mounted-slice
               (fn []
-                (.then (clock/echo-discrimination!)
+                (.then (rf.bench.hicasso.slice-echo-clock-app/echo-discrimination!)
                        (fn [seen]
                          (is (= (:expect seen) (:glass seen))
                              "the setup mutation DID reach the glass — which is exactly
                               why a check over `.value` alone would have verified a
                               window in which the application did nothing")
-                         (is (= clock/committed-value-sentinel (:rendered seen))
+                         (is (= rf.bench.hicasso.slice-echo-clock-app/committed-value-sentinel (:rendered seen))
                              "and the mirror still carries the sentinel, because no
                               commit ran to overwrite it")
                          (is (not= (:expect seen) (:rendered seen))
@@ -328,7 +328,7 @@
                              (is (= (:expect (:echo echo)) (:glass (:echo echo)))
                                  "even though the typed character is on the glass, put
                                   there by this file's own setup write")
-                             (is (= clock/committed-value-sentinel
+                             (is (= rf.bench.hicasso.slice-echo-clock-app/committed-value-sentinel
                                     (:rendered (:echo echo)))
                                  "the mirror is untouched — no commit reached the
                                   field")))))))
@@ -358,14 +358,14 @@
                              (is (= (:want-checked (:echo echo)) (:checked (:echo echo)))
                                  "while the checkbox flipped anyway — the user agent
                                   did it, and a check over this would have passed")
-                             (is (= clock/committed-value-sentinel
+                             (is (= rf.bench.hicasso.slice-echo-clock-app/committed-value-sentinel
                                     (:rendered (:echo echo)))
                                  "and the mirror is untouched")))))))
             (.then (fn [_] (done)) (fail-async done)))))))
 
 (deftest the-window-extends-past-the-commit-by-the-injected-cost
   (testing "THE DISCRIMINATING ROW. `:ctl-blocked` spends
-           `clock/blocked-ms` on the main thread strictly between the
+           `rf.bench.hicasso.slice-echo-clock-app/blocked-ms` on the main thread strictly between the
            commit and the frame. A commit-bounded window sees none of it;
            this one must see all of it.
 
@@ -378,8 +378,8 @@
               (fn []
                 (.then (one-window :ctl-blocked)
                        (fn [{:keys [ms commit-ms echo]}]
-                         (is (>= (- ms commit-ms) clock/blocked-ms)
-                             (str "at least " clock/blocked-ms "ms of the window lies "
+                         (is (>= (- ms commit-ms) rf.bench.hicasso.slice-echo-clock-app/blocked-ms)
+                             (str "at least " rf.bench.hicasso.slice-echo-clock-app/blocked-ms "ms of the window lies "
                                   "after the point a flushSync window stops"))
                          (is (:verified? echo)
                              "and the blocked frame still carried the echo")))))
@@ -390,14 +390,14 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-whole-schedule-runs-and-every-echo-verifies
-  (testing "`lane/rounds-async!` drives all four arms over the real
+  (testing "`rf.bench.hicasso.lane/rounds-async!` drives all four arms over the real
            application, and the echo tally reads `0 unverified of M` with
            M the whole plan — warm-up visits included, since they bank
            their verification too.
 
            The schedule is TINY here and the module's own is not: this row
            asks whether the instrument runs, and a run that reads it wants
-           `clock/sampling` and `clock/rounds`."
+           `rf.bench.hicasso.slice-echo-clock-app/sampling` and `rf.bench.hicasso.slice-echo-clock-app/rounds`."
     (if-not (browser?)
       (skip! off-browser)
       (async done
@@ -405,26 +405,26 @@
               rounds   1]
           (-> (with-mounted-slice
                 (fn []
-                  (.then (lane/rounds-async! clock/arms sampling rounds clock/measure-one!)
+                  (.then (rf.bench.hicasso.lane/rounds-async! rf.bench.hicasso.slice-echo-clock-app/arms sampling rounds rf.bench.hicasso.slice-echo-clock-app/measure-one!)
                          (fn [{:keys [readings samples]}]
-                           (is (= (* rounds (:samples sampling) (count clock/arms))
+                           (is (= (* rounds (:samples sampling) (count rf.bench.hicasso.slice-echo-clock-app/arms))
                                   (count samples))
                                "every measured visit was banked for the guard")
                            (is (= rounds (count readings)))
                            (is (every? (fn [round]
-                                         (= (count clock/arms) (count round)))
+                                         (= (count rf.bench.hicasso.slice-echo-clock-app/arms) (count round)))
                                        readings)
                                "and every arm has a reading in every round")
                            (is (= {:writes (* rounds
                                               (+ (:warmup sampling) (:samples sampling))
-                                              (count clock/arms))
+                                              (count rf.bench.hicasso.slice-echo-clock-app/arms))
                                    :unverified 0}
-                                  (clock/verification))
+                                  (rf.bench.hicasso.slice-echo-clock-app/verification))
                                "0 unverified of M — every window, warm-up included,
                                 reached a frame that carried its own echo")
-                           (let [banked    (clock/banked-structure)
-                                 published (clock/structure-over-measured
-                                             clock/arms sampling rounds banked)
+                           (let [banked    (rf.bench.hicasso.slice-echo-clock-app/banked-structure)
+                                 published (rf.bench.hicasso.slice-echo-clock-app/structure-over-measured
+                                             rf.bench.hicasso.slice-echo-clock-app/arms sampling rounds banked)
                                  measured  (reduce
                                              (fn [m round]
                                                (reduce-kv
@@ -432,7 +432,7 @@
                                                    (update m id (fnil + 0) (count xs)))
                                                  m round))
                                              {} readings)]
-                             (doseq [{:keys [id]} clock/arms]
+                             (doseq [{:keys [id]} rf.bench.hicasso.slice-echo-clock-app/arms]
                                (is (= (get measured id)
                                       (:n (:commit (get published id)))
                                       (:n (:to-raf (get published id)))
@@ -453,7 +453,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-measured-mask-is-the-lanes-own-schedule
-  (testing "`clock/measured-mask` is derived from `lane/visit-plan` — the
+  (testing "`rf.bench.hicasso.slice-echo-clock-app/measured-mask` is derived from `rf.bench.hicasso.lane/visit-plan` — the
            one statement of the schedule both of the lane's loops walk —
            and not re-derived from `warmup`, `samples` and `slot-order`
            inside the driver. A mask that had drifted from the schedule
@@ -461,10 +461,10 @@
            visits and say nothing about it."
     (let [sampling {:warmup 2 :samples 3}
           rounds   2
-          mask     (clock/measured-mask clock/arms sampling rounds)]
-      (is (= (set (map :id clock/arms)) (set (keys mask)))
+          mask     (rf.bench.hicasso.slice-echo-clock-app/measured-mask rf.bench.hicasso.slice-echo-clock-app/arms sampling rounds)]
+      (is (= (set (map :id rf.bench.hicasso.slice-echo-clock-app/arms)) (set (keys mask)))
           "every arm has a mask")
-      (doseq [{:keys [id]} clock/arms]
+      (doseq [{:keys [id]} rf.bench.hicasso.slice-echo-clock-app/arms]
         (is (= (* rounds (+ (:warmup sampling) (:samples sampling)))
                (count (get mask id)))
             (str id " is visited once per sample index per round"))
@@ -474,7 +474,7 @@
       (is (= [false false true true true false false true true true]
              (get mask :keystroke))
           "and the warm-up block leads EVERY round, not just the first —
-           `lane/rounds!`'s own docstring prices that asymmetry"))))
+           `rf.bench.hicasso.lane/rounds!`'s own docstring prices that asymmetry"))))
 
 (deftest the-record-labels-which-population-each-figure-is-taken-over
   (testing "`:summary` and `:structure` share the measured population
@@ -485,7 +485,7 @@
     (is (= {:summary   :measured-visits
             :structure :measured-visits
             :echo      :all-visits}
-           clock/populations))))
+           rf.bench.hicasso.slice-echo-clock-app/populations))))
 
 ;; ---------------------------------------------------------------------------
 ;; The control's arithmetic, where it cannot flake
@@ -498,11 +498,11 @@
            `p50(:ctl-blocked) - p50(:keystroke)` in milliseconds."
     (let [readings [{:keystroke [10.0 12.0 14.0] :ctl-blocked [60.0 62.0 64.0]}
                     {:keystroke [20.0 20.0 20.0] :ctl-blocked [69.0 70.0 71.0]}]]
-      (is (= [50.0 50.0] (clock/control-per-round readings))
+      (is (= [50.0 50.0] (rf.bench.hicasso.slice-echo-clock-app/control-per-round readings))
           "each round pairs its own two medians")
-      (let [v (lane/control-verdict-strict clock/blocked-ms
-                                           (clock/control-per-round readings)
-                                           clock/control-slack)]
+      (let [v (rf.bench.hicasso.lane/control-verdict-strict rf.bench.hicasso.slice-echo-clock-app/blocked-ms
+                                           (rf.bench.hicasso.slice-echo-clock-app/control-per-round readings)
+                                           rf.bench.hicasso.slice-echo-clock-app/control-slack)]
         (is (:ok? v) "a control that saw exactly what it predicted passes")
         (is (= :every-round (:rule v))
             "under the strict rule — these legs are tens of milliseconds and
@@ -515,9 +515,9 @@
            would sit at zero — and the control has to say so."
     (let [readings [{:keystroke [10.0 12.0 14.0] :ctl-blocked [10.0 12.0 14.0]}
                     {:keystroke [20.0 20.0 20.0] :ctl-blocked [20.0 21.0 20.0]}]
-          v        (lane/control-verdict-strict clock/blocked-ms
-                                                (clock/control-per-round readings)
-                                                clock/control-slack)]
+          v        (rf.bench.hicasso.lane/control-verdict-strict rf.bench.hicasso.slice-echo-clock-app/blocked-ms
+                                                (rf.bench.hicasso.slice-echo-clock-app/control-per-round readings)
+                                                rf.bench.hicasso.slice-echo-clock-app/control-slack)]
       (is (not (:ok? v))
           "an instrument that cannot see a change its own arithmetic predicts
            cannot be trusted with an unpredicted one")
@@ -535,16 +535,16 @@
            16.7 ms at 60 Hz — so an injection much smaller than one frame
            can be absorbed by the quantisation entirely, and a control
            that fails for the clock is not a control."
-    (is (>= clock/blocked-ms (* 2.0 16.7))
+    (is (>= rf.bench.hicasso.slice-echo-clock-app/blocked-ms (* 2.0 16.7))
         "at least two rendering intervals at 60 Hz")
-    (let [{:keys [band predicted]} (lane/control-verdict-strict
-                                     clock/blocked-ms
-                                     [clock/blocked-ms]
-                                     clock/control-slack)]
-      (is (= clock/blocked-ms predicted)
+    (let [{:keys [band predicted]} (rf.bench.hicasso.lane/control-verdict-strict
+                                     rf.bench.hicasso.slice-echo-clock-app/blocked-ms
+                                     [rf.bench.hicasso.slice-echo-clock-app/blocked-ms]
+                                     rf.bench.hicasso.slice-echo-clock-app/control-slack)]
+      (is (= rf.bench.hicasso.slice-echo-clock-app/blocked-ms predicted)
           "the control predicts the injected duration itself — an additive
            prediction that needs no model of the application")
-      (is (<= (first band) clock/blocked-ms (second band))
+      (is (<= (first band) rf.bench.hicasso.slice-echo-clock-app/blocked-ms (second band))
           "and its band is centred on it"))))
 
 (deftest the-arm-roster-is-the-four-rows-the-file-documents
@@ -552,10 +552,10 @@
            estimands they can and cannot serve. A fifth added silently
            would leave that prose describing an instrument that no longer
            exists — the drift class this lane keeps paying for."
-    (is (= [:idle-frame :keystroke :toggle :ctl-blocked] (mapv :id clock/arms))
+    (is (= [:idle-frame :keystroke :toggle :ctl-blocked] (mapv :id rf.bench.hicasso.slice-echo-clock-app/arms))
         "floor first, so it leads the schedule")
-    (is (= [:ctl-blocked] (mapv :id (filter :control? clock/arms)))
+    (is (= [:ctl-blocked] (mapv :id (filter :control? rf.bench.hicasso.slice-echo-clock-app/arms)))
         "and exactly one of them is a control")
-    (is (pos? (:warmup clock/sampling)))
-    (is (pos? (:samples clock/sampling)))
-    (is (pos? clock/rounds))))
+    (is (pos? (:warmup rf.bench.hicasso.slice-echo-clock-app/sampling)))
+    (is (pos? (:samples rf.bench.hicasso.slice-echo-clock-app/sampling)))
+    (is (pos? rf.bench.hicasso.slice-echo-clock-app/rounds))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/ssr/entry.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/ssr/entry.cljs
@@ -59,11 +59,11 @@
        two concurrent requests cannot read each other's app-db;
     2. seeded through the FRAMEWORK'S doors — `:initial-events`, and the
        reserved `:rf/set-db` for a snapshot handed in whole;
-    3. rendered as `(provider frame (codec/root-element frame hiccup))`,
+    3. rendered as `(provider frame (rf.bench.hicasso.front.codec/root-element frame hiccup))`,
        the same two calls `arm1/mount/render!` makes in the browser,
        **inside an open adoption window** — see below;
     4. the payload built out of the FRAMEWORK'S OWN BYTES —
-       `payload-policy/apply-policy` (the fail-closed `:payload`
+       `rf.ssr.payload-policy/apply-policy` (the fail-closed `:payload`
        contract), `project-app-db-egress`, `build-payload`, and
        `html-helpers/escape-edn-script-body` under the pinned
        `__rf_payload` script id. Nothing Hicasso-specific touches the
@@ -75,7 +75,7 @@
 
   ## The wire frame-id is nil, deliberately
 
-  `payload-policy/build-payload`'s first argument is the WIRE
+  `rf.ssr.payload-policy/build-payload`'s first argument is the WIRE
   `:rf/frame-id`, which its docstring is explicit must be a stable id both
   ends agreed on ahead of time and **never a per-request server gensym**
   (rf2-lm2yzy: stamping the gensym guarantees
@@ -105,7 +105,7 @@
   `:rf.ssr/hydration-mismatch` diagnostic. 011 says of that tier, in as
   many words, that it \"deliberately carries **no** such hash\".
 
-  This entry is that tier. `codec/root-element` hands React an element
+  This entry is that tier. `rf.bench.hicasso.front.codec/root-element` hands React an element
   and the tree is walked INSIDE `renderToString`, so at no point does a
   data tree describing the page exist for anything to hash.
 
@@ -128,7 +128,7 @@
   compared two different pages and found them equal. Absence is also the
   shape the wire contract already wants: `:rf/render-hash` is
   `{:optional true} :string` in Spec-Schemas, and
-  `payload-policy/build-payload` omits the key on a nil hash, so nothing
+  `rf.ssr.payload-policy/build-payload` omits the key on a nil hash, so nothing
   Hicasso-specific touches the payload path (R0 holds — this namespace
   supplies the app-db and gets out of the way).
 
@@ -205,13 +205,13 @@
   touched by this bead. [[document]] mirrors `ssr-ring`'s own envelope
   shape closely enough to be recognisable and is a BENCH-LANE page, priced
   and ruled elsewhere."
-  (:require [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.codec :as codec]
+  (:require [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
             [re-frame.core :as rf]
-            [re-frame.ssr.constants :as ssr-constants]
-            [re-frame.ssr.html-helpers :as ssr-html]
-            [re-frame.ssr.payload-policy :as payload-policy]
+            [re-frame.ssr.constants :as rf.ssr.constants]
+            [re-frame.ssr.html-helpers :as rf.ssr.html-helpers]
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]
             ["react-dom/server" :as rdom-server]))
 
 ;; ---------------------------------------------------------------------------
@@ -258,8 +258,8 @@
   lines are re-spelled here rather than required; the two CONSTANTS they
   are made of are shared, which is the part that could drift."
   [payload-edn]
-  (str "<script id=\"" ssr-constants/payload-script-id "\" type=\"application/edn\">"
-       (ssr-html/escape-edn-script-body payload-edn)
+  (str "<script id=\"" rf.ssr.constants/payload-script-id "\" type=\"application/edn\">"
+       (rf.ssr.html-helpers/escape-edn-script-body payload-edn)
        "</script>"))
 
 (defn document
@@ -289,14 +289,14 @@
   (str "<!DOCTYPE html>"
        "<html lang=\"en\">"
        "<head><meta charset=\"utf-8\"><title>"
-       (ssr-html/escape-html (or title "Hicasso SSR")) "</title></head>"
+       (rf.ssr.html-helpers/escape-html (or title "Hicasso SSR")) "</title></head>"
        "<body>"
-       "<div id=\"" (ssr-html/escape-attr (or app-element-id "app")) "\">"
+       "<div id=\"" (rf.ssr.html-helpers/escape-attr (or app-element-id "app")) "\">"
        html
        "</div>"
        script
        (when script-src
-         (str "<script src=\"" (ssr-html/escape-attr script-src) "\"></script>"))
+         (str "<script src=\"" (rf.ssr.html-helpers/escape-attr script-src) "\"></script>"))
        "</body></html>"))
 
 ;; ---------------------------------------------------------------------------
@@ -352,24 +352,24 @@
       ;; The server half of an adoption renders inside the same window as
       ;; the client half — see the namespace docstring. Closed in the
       ;; `finally`.
-      (rt/open-adoption-window!)
+      (rf.bench.hicasso.arm1.runtime/open-adoption-window!)
       (let [;; The hiccup as WRITTEN — there is no server-only tree here.
             ;; `defhost`'s `:ssr` policy is honoured by the gate that is
             ;; the host element's own type, so this entry hands React the
             ;; same form the browser mount hands it; see the namespace
             ;; docstring's §`defhost`'s `:ssr` policy needs nothing here.
             html        (rdom-server/renderToString
-                          (mount/provider frame-id (codec/root-element frame-id hiccup)))
+                          (rf.bench.hicasso.arm1.mount/provider frame-id (rf.bench.hicasso.front.codec/root-element frame-id hiccup)))
             policy-opts (cond-> {:payload payload}
                           (some? client-frame-id) (assoc :client-frame-id client-frame-id)
                           (some? version)         (assoc :version version)
                           (some? schema-digest)   (assoc :schema-digest schema-digest))
-            payload-map (payload-policy/build-payload
+            payload-map (rf.ssr.payload-policy/build-payload
                           ;; WIRE id — the caller's stable one or nil.
                           ;; NEVER `frame-id`.
                           (:client-frame-id policy-opts)
-                          (payload-policy/project-app-db-egress
-                            (payload-policy/apply-policy (rf/app-db-value frame-id) policy-opts)
+                          (rf.ssr.payload-policy/project-app-db-egress
+                            (rf.ssr.payload-policy/apply-policy (rf/app-db-value frame-id) policy-opts)
                             ;; PROJECTION frame — the real per-request one.
                             frame-id)
                           ;; NO RENDER HASH — nil, and `build-payload` omits the
@@ -393,7 +393,7 @@
         ;; so a throw here that skipped it would leave the whole process
         ;; adopting. `destroy-frame!` is the per-request cleanup that may
         ;; itself throw; the window must already be shut when it runs.
-        (rt/close-adoption-window!)
+        (rf.bench.hicasso.arm1.runtime/close-adoption-window!)
         (rf/destroy-frame! frame-id)))))
 
 (defn render-twice

--- a/bench/hicasso/src/re_frame/bench/hicasso/ssr/entry_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/ssr/entry_cljs_test.cljs
@@ -17,21 +17,21 @@
   (:require [cljs.reader :as reader]
             [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.dogfood-collector :as collector]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.codec :as codec]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
-            [re-frame.bench.hicasso.front.intent :as intent]
-            [re-frame.bench.hicasso.ssr.entry :as entry]
-            [re-frame.bench.hicasso.ssr.fixtures :as fixtures]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.dogfood-collector :as rf.bench.hicasso.arm1.dogfood-collector]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
+            [re-frame.bench.hicasso.front.intent :as rf.bench.hicasso.front.intent]
+            [re-frame.bench.hicasso.ssr.entry :as rf.bench.hicasso.ssr.entry]
+            [re-frame.bench.hicasso.ssr.fixtures :as rf.bench.hicasso.ssr.fixtures]
             [re-frame.core :as rf]
-            [re-frame.ssr.constants :as ssr-constants]
+            [re-frame.ssr.constants :as rf.ssr.constants]
             ;; rf2-2rtt6.91 — the entry no longer computes a render hash, so
             ;; the row that keeps the measurement live takes it DIRECTLY.
-            [re-frame.ssr.hash :as ssr-hash]
-            [re-frame.frame :as frame]
-            [re-frame.test-support :as test-support])
+            [re-frame.ssr.hash :as rf.ssr.hash]
+            [re-frame.frame :as rf.frame]
+            [re-frame.test-support :as rf.test-support])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 ;; The adapter is UIx's for the reason `arm1/runtime_cljs_test` gives: it
@@ -41,14 +41,14 @@
 ;; boot, so it belongs to the driver (`ssr/node.cljs`) and to this
 ;; fixture, never to a per-request function.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
-     :init-fn (fn [] (fixtures/register!) (rt/reset-runtime!))}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
+     :init-fn (fn [] (rf.bench.hicasso.ssr.fixtures/register!) (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private dogfood-request
-  {:hiccup   [collector/screen {}]
-   :snapshot (dogfood/seed-db 4)
-   :payload  fixtures/dogfood-payload-keys})
+  {:hiccup   [rf.bench.hicasso.arm1.dogfood-collector/screen {}]
+   :snapshot (rf.bench.hicasso.front.dogfood/seed-db 4)
+   :payload  rf.bench.hicasso.ssr.fixtures/dogfood-payload-keys})
 
 (defn- error-id
   "The `:rf.error/id` a thunk throws, or `::none`."
@@ -63,7 +63,7 @@
 (deftest the-existing-runtime-renders-under-renderToString
   (testing "a Hicasso boundary tree renders to markup under react-dom/server,
            with the frame's own state in it"
-    (let [{:keys [html]} (entry/render dogfood-request)]
+    (let [{:keys [html]} (rf.bench.hicasso.ssr.entry/render dogfood-request)]
       (is (str/includes? html "class=\"dogfood\""))
       (is (str/includes? html "todos"))
       ;; Seeded with four; the header count is a SUBSCRIPTION read, so
@@ -82,21 +82,21 @@
 
 (deftest the-per-request-frame-is-destroyed
   (testing "the request's frame does not outlive the request"
-    (let [{:keys [frame-id]} (entry/render dogfood-request)]
+    (let [{:keys [frame-id]} (rf.bench.hicasso.ssr.entry/render dogfood-request)]
       (is (keyword? frame-id))
       (is (nil? (rf/app-db-value frame-id))
           "destroy-frame! ran in the finally — a per-request frame, not a per-request leak")))
 
   (testing "two requests take different frames"
-    (let [a (entry/render dogfood-request)
-          b (entry/render dogfood-request)]
+    (let [a (rf.bench.hicasso.ssr.entry/render dogfood-request)
+          b (rf.bench.hicasso.ssr.entry/render dogfood-request)]
       (is (not= (:frame-id a) (:frame-id b))))))
 
 (deftest a-server-render-leaves-zero-durable-registration
   (testing "React never subscribes under renderToString, so the ledger is untouched"
-    (rt/reset-runtime!)
-    (entry/render dogfood-request)
-    (let [{:keys [cells cell-refs boundaries edges]} (rt/residue)]
+    (rf.bench.hicasso.arm1.runtime/reset-runtime!)
+    (rf.bench.hicasso.ssr.entry/render dogfood-request)
+    (let [{:keys [cells cell-refs boundaries edges]} (rf.bench.hicasso.arm1.runtime/residue)]
       ;; The four numbers a clean teardown asserts. Here they are zero
       ;; without a teardown at all, because nothing ever committed: every
       ;; `sub` read went through the mutation-free cold probe, and the
@@ -111,7 +111,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-payload-is-the-frameworks-own
-  (let [{:keys [payload payload-edn payload-script]} (entry/render dogfood-request)]
+  (let [{:keys [payload payload-edn payload-script]} (rf.bench.hicasso.ssr.entry/render dogfood-request)]
 
     (testing "the two always-present keys, per Spec 011 (rf2-2rtt6.91 — an
              adoption-tier root carries no `:rf/render-hash`, and the
@@ -127,13 +127,13 @@
       (is (not (str/includes? payload-edn "hicasso.ssr"))))
 
     (testing "the allowlist arm of the fail-closed payload contract"
-      (is (= (set fixtures/dogfood-payload-keys) (set (keys (:rf/app-db payload))))))
+      (is (= (set rf.bench.hicasso.ssr.fixtures/dogfood-payload-keys) (set (keys (:rf/app-db payload))))))
 
     (testing "the script is the pinned id and the framework's EDN escaper"
       (is (str/starts-with? payload-script
-                            (str "<script id=\"" ssr-constants/payload-script-id
+                            (str "<script id=\"" rf.ssr.constants/payload-script-id
                                  "\" type=\"application/edn\">")))
-      (is (= "__rf_payload" ssr-constants/payload-script-id))
+      (is (= "__rf_payload" rf.ssr.constants/payload-script-id))
       (is (str/ends-with? payload-script "</script>")))
 
     (testing "the payload round-trips through the EDN reader"
@@ -142,7 +142,7 @@
 (deftest a-script-breakout-in-the-app-db-is-escaped-by-the-framework
   (testing "the escaper on the payload path is re-frame's, and it is doing work"
     (let [{:keys [payload-script payload-edn]}
-          (entry/render {:hiccup   [:div "x"]
+          (rf.bench.hicasso.ssr.entry/render {:hiccup   [:div "x"]
                          :snapshot {:hostile "</script><!-- pwned"}
                          :payload  [:hostile]})]
       ;; The one thing an EDN payload in a <script> may not contain.
@@ -154,12 +154,12 @@
 (deftest the-payload-policy-is-fail-closed
   (testing "no :payload declared is the framework's refusal, not a default"
     (is (= :rf.error/ssr-missing-payload-policy
-           (error-id #(entry/render (dissoc dogfood-request :payload))))))
+           (error-id #(rf.bench.hicasso.ssr.entry/render (dissoc dogfood-request :payload))))))
 
   (testing "the whole-app-db opt-in is explicit and works"
-    (let [{:keys [payload]} (entry/render (assoc dogfood-request
+    (let [{:keys [payload]} (rf.bench.hicasso.ssr.entry/render (assoc dogfood-request
                                                  :payload :rf.ssr.payload/whole-app-db))]
-      (is (= (set (keys (dogfood/seed-db 4))) (set (keys (:rf/app-db payload))))))))
+      (is (= (set (keys (rf.bench.hicasso.front.dogfood/seed-db 4))) (set (keys (:rf/app-db payload))))))))
 
 (deftest the-interpreted-root-ships-no-render-hash
   (testing "rf2-2rtt6.91, and it is Spec 011's own answer rather than a
@@ -177,7 +177,7 @@
            hash the root hiccup as handed in, and since that form is
            `[<minted head> {props}]` and `canonical-edn` renders every fn
            as `#fn[]`, two different screens took the same value."
-    (let [{:keys [payload document]} (entry/render dogfood-request)]
+    (let [{:keys [payload document]} (rf.bench.hicasso.ssr.entry/render dogfood-request)]
       (is (not (contains? payload :rf/render-hash))
           "ABSENT, not nil — `:rf/render-hash` is `{:optional true} :string`
            in Spec-Schemas, so a nil-valued key is not a legal spelling of
@@ -195,8 +195,8 @@
            A degenerate value is worse than an absent one: an absent value
            cannot be mistaken for evidence, while a constant one is a
            fail-open gate wearing the shape of a check."
-    (let [hash-of  #(ssr-hash/render-tree-hash (:hiccup (fixtures/row %)))
-          dogfood  (ssr-hash/render-tree-hash (:hiccup dogfood-request))
+    (let [hash-of  #(rf.ssr.hash/render-tree-hash (:hiccup (rf.bench.hicasso.ssr.fixtures/row %)))
+          dogfood  (rf.ssr.hash/render-tree-hash (:hiccup dogfood-request))
           conduit  (hash-of "conduit-feed")
           markup   (hash-of "defhost-ssr-policy")]
       (is (= dogfood conduit)
@@ -222,10 +222,10 @@
            are born-present too and the two halves agree by construction.
            This row goes RED if that window is ever removed, narrowed, or
            closed before the render."
-    (let [{:keys [html]} (entry/render (fixtures/row "presence-mounting"))]
+    (let [{:keys [html]} (rf.bench.hicasso.ssr.entry/render (rf.bench.hicasso.ssr.fixtures/row "presence-mounting"))]
       (is (not (str/includes? html "toast--enter"))
           "the server's bytes carry NO enter override — remove
-           `rt/open-adoption-window!` from ssr/entry.cljs and this is the
+           `rf.bench.hicasso.arm1.runtime/open-adoption-window!` from ssr/entry.cljs and this is the
            assertion that goes red")
       (is (zero? (count (re-seq #"toast--enter" html)))
           "zero occurrences, where the defect shipped one per child")
@@ -237,11 +237,11 @@
 
 (deftest the-adoption-window-does-not-outlive-the-request
   (testing "shut going in — the window belongs to a render, not to the process"
-    (is (false? (rt/adopting?))))
+    (is (false? (rf.bench.hicasso.arm1.runtime/adopting?))))
 
   (testing "and shut again on the way out of a render that RETURNED"
-    (entry/render (fixtures/row "presence-mounting"))
-    (is (false? (rt/adopting?))))
+    (rf.bench.hicasso.ssr.entry/render (rf.bench.hicasso.ssr.fixtures/row "presence-mounting"))
+    (is (false? (rf.bench.hicasso.arm1.runtime/adopting?))))
 
   (testing "and on the way out of one that THREW, which is why the close is
            in the `finally`. The flag is module-level, so a render that threw
@@ -249,11 +249,11 @@
            born-present — the failure `close-adoption-window!`'s own
            docstring names."
     (is (= :rf.error/ssr-missing-payload-policy
-           (error-id #(entry/render (dissoc dogfood-request :payload))))
+           (error-id #(rf.bench.hicasso.ssr.entry/render (dissoc dogfood-request :payload))))
         "the render really did throw, and it threw AFTER renderToString had
          run — so the window was genuinely open at the moment of the throw;
          a row where nothing threw would prove nothing")
-    (is (false? (rt/adopting?))
+    (is (false? (rf.bench.hicasso.arm1.runtime/adopting?))
         "the finally shut it anyway")))
 
 ;; ---------------------------------------------------------------------------
@@ -262,8 +262,8 @@
 
 (deftest the-same-request-renders-byte-identical-documents
   (testing "same bundle + same snapshot = byte-identical HTML"
-    (doseq [row fixtures/corpus]
-      (let [{:keys [identical? differs-at] a :first b :second} (entry/render-twice row)]
+    (doseq [row rf.bench.hicasso.ssr.fixtures/corpus]
+      (let [{:keys [identical? differs-at] a :first b :second} (rf.bench.hicasso.ssr.entry/render-twice row)]
         (is identical?
             (str (:id row) " rendered two different documents"
                  (when differs-at
@@ -294,8 +294,8 @@
 (deftest a-host-with-no-declared-policy-renders-nothing
   (testing "the ruled :client-only default, taken from the door — the
            declaration writes no :ssr at all"
-    (is (= :client-only (codec/host-ssr fixtures/default-host)))
-    (let [{:keys [html]} (entry/render (fixtures/row "defhost-ssr-policy"))]
+    (is (= :client-only (rf.bench.hicasso.front.codec/host-ssr rf.bench.hicasso.ssr.fixtures/default-host)))
+    (let [{:keys [html]} (rf.bench.hicasso.ssr.entry/render (rf.bench.hicasso.ssr.fixtures/row "defhost-ssr-policy"))]
       (is (not (str/includes? html "CLIENT-ONLY-WIDGET"))
           "a :client-only host's component must not reach the server HTML")
       (is (not (str/includes? html "client-widget"))))))
@@ -303,9 +303,9 @@
 (deftest a-host-declaring-a-fallback-renders-the-fallback
   (testing "{:fallback hiccup} — including from inside a `for`, the lazy position"
     (is (= {:fallback [:span.host-fallback "loading…"]}
-           (codec/host-ssr fixtures/fallback-host))
+           (rf.bench.hicasso.front.codec/host-ssr rf.bench.hicasso.ssr.fixtures/fallback-host))
         "and the markup below is that declaration's, read back as data")
-    (let [{:keys [html]} (entry/render (fixtures/row "defhost-ssr-policy"))]
+    (let [{:keys [html]} (rf.bench.hicasso.ssr.entry/render (rf.bench.hicasso.ssr.fixtures/row "defhost-ssr-policy"))]
       (is (str/includes? html "class=\"host-fallback\""))
       (is (= 2 (count (re-seq #"loading" html)))
           "both rows of the `for` got their fallback — a mechanism that
@@ -322,9 +322,9 @@
            gate the unadopted arm returns something that is not the
            component, so a transparent wrapper such as a context provider
            takes its whole subtree out of the HTML with it"
-    (is (= :render (codec/host-ssr fixtures/render-host))
+    (is (= :render (rf.bench.hicasso.front.codec/host-ssr rf.bench.hicasso.ssr.fixtures/render-host))
         "read back from the declaration, like every other policy")
-    (let [{:keys [html]} (entry/render (fixtures/row "defhost-ssr-render"))]
+    (let [{:keys [html]} (rf.bench.hicasso.ssr.entry/render (rf.bench.hicasso.ssr.fixtures/row "defhost-ssr-render"))]
       (is (str/includes? html "RENDER-SUBTREE")
           "the crossing's CHILDREN are in the server HTML")
       (is (str/includes? html "class=\"render-subtree\"")
@@ -344,7 +344,7 @@
   [form]
   (cond
     (vector? form) (let [head (nth form 0 nil)]
-                     (if (codec/host-head? head)
+                     (if (rf.bench.hicasso.front.codec/host-head? head)
                        [head]
                        (into [] (mapcat walk-reachable-host-heads) form)))
     (seq? form)    (into [] (mapcat walk-reachable-host-heads) form)
@@ -356,11 +356,11 @@
            this is that reach, measured. Keep this row if a server-side
            pre-walk is ever proposed again: it is the whole argument in two
            numbers."
-    (is (= 3 (count (walk-reachable-host-heads fixtures/host-screen)))
+    (is (= 3 (count (walk-reachable-host-heads rf.bench.hicasso.ssr.fixtures/host-screen)))
         "the CONTROL — the handed-in row's three host uses are visible to a
          walk, so the measurement below is about position and not about a
          walk that finds nothing anywhere")
-    (is (= 0 (count (walk-reachable-host-heads fixtures/nested-host-screen)))
+    (is (= 0 (count (walk-reachable-host-heads rf.bench.hicasso.ssr.fixtures/nested-host-screen)))
         "and the nested row's are INVISIBLE to it: those elements do not
          exist until the boundary body runs inside `renderToString`. A walk
          kept alive beside the gate would therefore be a second mechanism
@@ -376,7 +376,7 @@
            A `ssr.host-policy/apply-policy`-shaped walk over the handed-in
            form renders this row's `:client-only` host's component into the
            HTML, which is the failure this row names."
-    (let [{:keys [html]} (entry/render (fixtures/row "defhost-ssr-nested"))]
+    (let [{:keys [html]} (rf.bench.hicasso.ssr.entry/render (rf.bench.hicasso.ssr.fixtures/row "defhost-ssr-nested"))]
       ;; Non-vacuity first: the boundary body really did run, and its
       ;; native chrome is in the markup — so an absent host region is an
       ;; absent host region and not an absent page.
@@ -412,15 +412,15 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest every-corpus-row-renders
-  (doseq [{:keys [id why] :as row} fixtures/corpus]
+  (doseq [{:keys [id why] :as row} rf.bench.hicasso.ssr.fixtures/corpus]
     (testing (str id " — " why)
-      (let [{:keys [html document payload]} (entry/render row)]
+      (let [{:keys [html document payload]} (rf.bench.hicasso.ssr.entry/render row)]
         (is (seq html) (str id " rendered empty markup"))
         (is (str/starts-with? document "<!DOCTYPE html>"))
         (is (str/includes? document "<div id=\"app\">")
             "the app root carries the id the client bootstrap mounts on —
              a `:or` default that never fires shipped `id=\"\"` once")
-        (is (str/includes? document (str "id=\"" ssr-constants/payload-script-id "\"")))
+        (is (str/includes? document (str "id=\"" rf.ssr.constants/payload-script-id "\"")))
         (is (str/ends-with? document "</body></html>"))
         ;; rf2-2rtt6.91 — EVERY row, not just the two the exclusion row
         ;; names: an adoption-tier root carries no hash at either end.
@@ -454,8 +454,8 @@
   (vreset! scope-probe-seen
            {:ambient  (try (rf/capture-frame)
                            (catch :default e (ex-data e)))
-            :composed (:frame (rf/capture-frame (intent/hframe)))
-            :hframe   (intent/hframe)})
+            :composed (:frame (rf/capture-frame (rf.bench.hicasso.front.intent/hframe)))
+            :hframe   (rf.bench.hicasso.front.intent/hframe)})
   [:p.scope-probe "probe"])
 
 (deftest the-hosts-ambient-scope-does-not-answer-inside-a-per-request-body
@@ -463,11 +463,11 @@
            inside whatever scope the host happens to have established — here
            the fixture's `:rf/default`. A body that resolves ambiently must
            not silently answer the host's frame"
-    (is (= :rf/default frame/*current-frame*)
+    (is (= :rf/default rf.frame/*current-frame*)
         "precondition: the fixture's ambient scope IS live, so a green row
          below is the refusal working rather than nothing to refuse")
-    (let [{:keys [frame-id html]} (entry/render {:hiccup  [scope-probe {}]
-                                                 :payload fixtures/dogfood-payload-keys})
+    (let [{:keys [frame-id html]} (rf.bench.hicasso.ssr.entry/render {:hiccup  [scope-probe {}]
+                                                 :payload rf.bench.hicasso.ssr.fixtures/dogfood-payload-keys})
           {:keys [ambient composed hframe]} @scope-probe-seen]
       (is (str/includes? html "scope-probe") "the body ran under renderToString")
       (is (not= :rf/default frame-id)

--- a/bench/hicasso/src/re_frame/bench/hicasso/ssr/fixtures.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/ssr/fixtures.cljs
@@ -48,7 +48,7 @@
   both rows are written the way an author writes them —
   `(defhost … {:ssr …})` — and the server HTML they assert on is
   therefore evidence about the public declaration."
-  (:require [re-frame.bench.hicasso.arm1.dogfood-collector :as collector]
+  (:require [re-frame.bench.hicasso.arm1.dogfood-collector :as rf.bench.hicasso.arm1.dogfood-collector]
             [re-frame.bench.hicasso.arm1.presence :refer [presence]]
             ;; `defview` and `defhost` are not compilers — they expand to
             ;; `runtime/mint-view!` and `codec/mint-host!` calls, so the
@@ -56,11 +56,11 @@
             ;; this one even though no alias is spelled below.
             [re-frame.bench.hicasso.arm1.runtime]
             [re-frame.bench.hicasso.front.codec]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
-            [re-frame.bench.hicasso.shapes.large-template :as large-template]
-            [re-frame.bench.hicasso.shapes.model :as model]
-            [re-frame.bench.hicasso.ssr.instance-key :as instance-key]
-            [re-frame.routing :as routing]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
+            [re-frame.bench.hicasso.shapes.large-template :as rf.bench.hicasso.shapes.large-template]
+            [re-frame.bench.hicasso.shapes.model :as rf.bench.hicasso.shapes.model]
+            [re-frame.bench.hicasso.ssr.instance-key :as rf.bench.hicasso.ssr.instance-key]
+            [re-frame.routing :as rf.routing]
             ["react" :as react])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defhost defview]]))
 
@@ -219,31 +219,31 @@
   "The ordered roster. See the namespace docstring."
   [{:id     "dogfood-snapshot"
     :why    "the dogfood screen, seeded through the :rf/set-db snapshot-in door, with a key allowlist"
-    :hiccup [collector/screen {}]
-    :snapshot (dogfood/seed-db 8)
+    :hiccup [rf.bench.hicasso.arm1.dogfood-collector/screen {}]
+    :snapshot (rf.bench.hicasso.front.dogfood/seed-db 8)
     :payload  dogfood-payload-keys
     :title    "Hicasso SSR — dogfood (snapshot-in)"
     :script-src "/main.js"}
 
    {:id     "dogfood-initial-events"
     :why    "the same screen through the :initial-events door, and the whole-app-db payload opt-in"
-    :hiccup [collector/screen {}]
+    :hiccup [rf.bench.hicasso.arm1.dogfood-collector/screen {}]
     :initial-events [[:dogfood/seed 3]
                      [:dogfood/toggle 1]
-                     [:dogfood/edit-draft dogfood/new-draft-key "half typed"]]
+                     [:dogfood/edit-draft rf.bench.hicasso.front.dogfood/new-draft-key "half typed"]]
     :payload  :rf.ssr.payload/whole-app-db
     :title    "Hicasso SSR — dogfood (initial-events)"
     :script-src "/main.js"}
 
    {:id     "conduit-feed"
     :why    "a tier-1 bulk shape — the ~1,200-element Conduit feed page, at the size the bar rows are taken at"
-    :hiccup [large-template/page {}]
-    :snapshot   (model/seed-db large-template/seed)
+    :hiccup [rf.bench.hicasso.shapes.large-template/page {}]
+    :snapshot   (rf.bench.hicasso.shapes.model/seed-db rf.bench.hicasso.shapes.large-template/seed)
     ;; The census is a HASH-URL app and its anchors go through routing's
     ;; `link-model`, whose strategy consult defaults to the history
     ;; strategy when a frame declares none — so the frame declares the
     ;; one `shapes/model/make-frame!` declares, through the same door.
-    :frame-opts {:url-strategy routing/hash-url-strategy}
+    :frame-opts {:url-strategy rf.routing/hash-url-strategy}
     :payload    [:articles :order :tags :user :page :your-feed?]
     :title      "Hicasso SSR — conduit feed"
     :script-src "/main.js"}
@@ -288,17 +288,17 @@
    ;; React's own hydration-mismatch machinery and nothing else.
    {:id     "instance-key-payload"
     :why    "server boot events write reg-state instance state and the allowlist NAMES :ui — the obligation met"
-    :hiccup [instance-key/screen {}]
-    :initial-events instance-key/boot-events
-    :payload  (conj instance-key/domain-keys :ui)
+    :hiccup [rf.bench.hicasso.ssr.instance-key/screen {}]
+    :initial-events rf.bench.hicasso.ssr.instance-key/boot-events
+    :payload  (conj rf.bench.hicasso.ssr.instance-key/domain-keys :ui)
     :title    "Hicasso SSR — instance state, :ui shipped"
     :script-src "/main.js"}
 
    {:id     "instance-key-payload-omitted"
     :why    "the SAME page with :ui OMITTED — a well-formed allowlist that strands the instance state, and the red-by-design half of the obligation witness"
-    :hiccup [instance-key/screen {}]
-    :initial-events instance-key/boot-events
-    :payload  instance-key/domain-keys
+    :hiccup [rf.bench.hicasso.ssr.instance-key/screen {}]
+    :initial-events rf.bench.hicasso.ssr.instance-key/boot-events
+    :payload  rf.bench.hicasso.ssr.instance-key/domain-keys
     :title    "Hicasso SSR — instance state, :ui stranded"
     :script-src "/main.js"}])
 
@@ -320,5 +320,5 @@
   Idempotent, and called by every driver and every witness before the
   first render so no caller has to remember an ordering."
   []
-  (model/register-routes!)
+  (rf.bench.hicasso.shapes.model/register-routes!)
   nil)

--- a/bench/hicasso/src/re_frame/bench/hicasso/ssr/hframe_ssr_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/ssr/hframe_ssr_cljs_test.cljs
@@ -9,7 +9,7 @@
   Two same-process renders take two different gensyms, so a body that
   RENDERS the value makes the document nondeterministic. That is an
   authorable hazard rather than a framework one, and it is already
-  instrumented: `entry/render-twice`'s byte comparison is the standing
+  instrumented: `rf.bench.hicasso.ssr.entry/render-twice`'s byte comparison is the standing
   determinism check. Both halves are asserted here — a body that reads
   the id and keeps it out of markup renders byte-identical documents, and
   a body that deliberately prints it does not. The second row is what
@@ -22,7 +22,7 @@
   the adapters publish is client-renderer-only. That contrast no longer
   describes the tree. Since rf2-2rtt6.122 the ambient chain refuses on
   BOTH sides for ONE reason — the arm's own refusal, established by
-  `intent/with-frame` over every render extent, client or server. The
+  `rf.bench.hicasso.front.intent/with-frame` over every render extent, client or server. The
   contrast survives; its explanation changed, and a row asserting a
   renderer-specific server-side throw would now be asserting the wrong
   fact for the wrong reason.
@@ -32,18 +32,18 @@
   is proved (`ssr/entry_cljs_test`)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.intent :as intent]
-            [re-frame.bench.hicasso.ssr.entry :as entry]
-            [re-frame.bench.hicasso.ssr.fixtures :as fixtures]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.intent :as rf.bench.hicasso.front.intent]
+            [re-frame.bench.hicasso.ssr.entry :as rf.bench.hicasso.ssr.entry]
+            [re-frame.bench.hicasso.ssr.fixtures :as rf.bench.hicasso.ssr.fixtures]
             [re-frame.core :as rf]
-            [re-frame.test-support :as test-support])
+            [re-frame.test-support :as rf.test-support])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      ;; `:ambient-frame nil`, where the rest of the SSR suite takes the
      ;; fixture's default — and it is load-bearing rather than tidiness.
      ;; The default root-binds `frame/*current-frame*` to `:rf/default`,
@@ -51,13 +51,13 @@
      ;; FIND and never the carrying, so an ambient carry inside a body
      ;; would resolve `:rf/default` and succeed. That is core behaving
      ;; exactly as specified, and it is not the configuration a server
-     ;; request has: `entry/render` establishes no scope and a host calls
+     ;; request has: `rf.bench.hicasso.ssr.entry/render` establishes no scope and a host calls
      ;; it at top of stack. Measuring the refusal against the fixture's own
      ;; stamp would be measuring the fixture. (The mismatched-scope case is
      ;; interesting in its own right and is pinned deliberately, in
      ;; `arm1/hframe_cljs_test`.)
      :ambient-frame nil
-     :init-fn       (fn [] (fixtures/register!) (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.ssr.fixtures/register!) (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private !seen
   "Every frame id a server body read, newest last."
@@ -73,15 +73,15 @@
   documented correct shape. What it renders is a subscription value, so
   the boundary is an ordinary one."
   [_]
-  (swap! !seen conj (intent/hframe))
-  [:span.row (str (rt/sub [:dogfood/remaining]))])
+  (swap! !seen conj (rf.bench.hicasso.front.intent/hframe))
+  [:span.row (str (rf.bench.hicasso.arm1.runtime/sub [:dogfood/remaining]))])
 
 (defview indiscreet
   "Renders the per-request id INTO the markup. This is the authorable
   hazard the docstring warns about, written on purpose so the
   determinism check can be watched failing."
   [_]
-  [:span.row {:data-frame (str (intent/hframe))}])
+  [:span.row {:data-frame (str (rf.bench.hicasso.front.intent/hframe))}])
 
 (defview carrying
   "Tries the AMBIENT carry — `(rf/capture-frame)`, 0-arity — inside a
@@ -92,12 +92,12 @@
   (reset! !ambient
           (try [::no-throw (rf/capture-frame)]
                (catch :default e (ex-data e))))
-  [:span.row (str (intent/hframe))])
+  [:span.row (str (rf.bench.hicasso.front.intent/hframe))])
 
 (defn- request [hiccup]
   {:hiccup   hiccup
-   :snapshot (:snapshot (fixtures/row "dogfood-snapshot"))
-   :payload  fixtures/dogfood-payload-keys})
+   :snapshot (:snapshot (rf.bench.hicasso.ssr.fixtures/row "dogfood-snapshot"))
+   :payload  rf.bench.hicasso.ssr.fixtures/dogfood-payload-keys})
 
 ;; ---------------------------------------------------------------------------
 ;; W8 — the per-request id, and the one authorable hazard
@@ -109,8 +109,8 @@
            which is what per-request isolation means when the id is the
            thing being read"
     (reset! !seen [])
-    (let [a (entry/render (request [discreet {}]))
-          b (entry/render (request [discreet {}]))]
+    (let [a (rf.bench.hicasso.ssr.entry/render (request [discreet {}]))
+          b (rf.bench.hicasso.ssr.entry/render (request [discreet {}]))]
       (is (= 2 (count @!seen)) "one read per request")
       (is (= [(:frame-id a) (:frame-id b)] @!seen)
           "each body read its OWN request's id, in order")
@@ -123,7 +123,7 @@
            documents are byte-identical anyway — because the value went
            into a read and not into the page"
     (let [{:keys [identical? differs-at] a :first b :second}
-          (entry/render-twice (request [discreet {}]))]
+          (rf.bench.hicasso.ssr.entry/render-twice (request [discreet {}]))]
       (is identical? (str "the two documents differ at index " differs-at))
       (is (not= (:frame-id a) (:frame-id b))
           "and they were different requests — this is the whole point")
@@ -136,7 +136,7 @@
            the existing render-twice byte comparison catches it. A claim
            about a check that has never been watched failing is not a
            check, so here it is failing"
-    (let [{:keys [identical? differs-at] a :first} (entry/render-twice (request [indiscreet {}]))]
+    (let [{:keys [identical? differs-at] a :first} (rf.bench.hicasso.ssr.entry/render-twice (request [indiscreet {}]))]
       (is (not identical?)
           "a document carrying the per-request gensym cannot be
            deterministic, and the determinism witness must say so")
@@ -156,7 +156,7 @@
            exactly as over the client's — so what the server reports is the
            request's own frame, and not a fact about `react-dom/server`"
     (reset! !ambient ::unset)
-    (let [{:keys [document frame-id]} (entry/render (request [carrying {}]))
+    (let [{:keys [document frame-id]} (rf.bench.hicasso.ssr.entry/render (request [carrying {}]))
           data                        @!ambient]
       (is (vector? data)
           (str "expected the carry to be admitted; got " (pr-str data)))
@@ -168,5 +168,5 @@
   (testing "while `h/frame` answers in the same body — the contrast the
            design's W11 exists for, with its explanation updated"
     (reset! !seen [])
-    (let [{:keys [frame-id]} (entry/render (request [discreet {}]))]
+    (let [{:keys [frame-id]} (rf.bench.hicasso.ssr.entry/render (request [discreet {}]))]
       (is (= [frame-id] @!seen)))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/ssr/instance_key.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/ssr/instance_key.cljs
@@ -33,8 +33,8 @@
   structural — did the instance state cross the wire, and what did React
   say when it did not — so every element on the page is either the thing
   being measured or the sibling that proves the page rendered at all."
-  (:require [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.state :as state]
+  (:require [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.state :as rf.bench.hicasso.front.state]
             [re-frame.core :as rf])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
@@ -67,7 +67,7 @@
   "Where the opened panel's flag sits — `[:ui ::open? \"billing\"]`, the
   documented tier. Written out so the witness asserts on the same vector
   the sugar writes rather than on a hand-spelled copy of it."
-  [state/ui-root open? open-key])
+  [rf.bench.hicasso.front.state/ui-root open? open-key])
 
 (defn seed-db
   "The domain half of the app-db: the roster and nothing else. The
@@ -91,7 +91,7 @@
 ;; registrations and a naming convention. Re-registration with the same
 ;; `:default` is the no-op-shaped refresh `reg-state` documents, so a
 ;; reload of this namespace is safe.
-(state/reg-state open? {:default false})
+(rf.bench.hicasso.front.state/reg-state open? {:default false})
 
 ;; ---------------------------------------------------------------------------
 ;; The screen
@@ -107,7 +107,7 @@
   be measuring React's SSR text-separator behaviour (rf2-2rtt6.88)
   alongside the thing under test."
   [{:keys [ikey title]}]
-  (let [shown? (rt/sub [open? ikey])]
+  (let [shown? (rf.bench.hicasso.arm1.runtime/sub [open? ikey])]
     [:section.panel {:data-ikey ikey}
      [:button.panel-toggle {:on-click [open? ikey (not shown?)]} title]
      (when shown?
@@ -120,8 +120,8 @@
   [:div.instance-key-page
    [:h1.title "instance state across the wire"]
    [:div.panels
-    (for [id (rt/sub [::panel-ids])]
-      [panel {:key id :ikey id :title (rt/sub [::panel-title id])}])]])
+    (for [id (rf.bench.hicasso.arm1.runtime/sub [::panel-ids])]
+      [panel {:key id :ikey id :title (rf.bench.hicasso.arm1.runtime/sub [::panel-title id])}])]])
 
 ;; ---------------------------------------------------------------------------
 ;; The two requests, minus their payload policies

--- a/bench/hicasso/src/re_frame/bench/hicasso/ssr/instance_key_payload_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/ssr/instance_key_payload_dom_cljs_test.cljs
@@ -92,22 +92,22 @@
   under `:node-test` too; every DOM claim degrades to a stated skip
   there."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.bench.hicasso.arm1.hydration-support
              :refer [adopted! every-server-node? open-console-capture! server-dom!
                      server-node? stamp-server-nodes!]]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.ssr.entry :as entry]
-            [re-frame.bench.hicasso.ssr.fixtures :as fixtures]
-            [re-frame.bench.hicasso.ssr.instance-key :as instance-key]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.ssr.entry :as rf.bench.hicasso.ssr.entry]
+            [re-frame.bench.hicasso.ssr.fixtures :as rf.bench.hicasso.ssr.fixtures]
+            [re-frame.bench.hicasso.ssr.instance-key :as rf.bench.hicasso.ssr.instance-key]
             [re-frame.core :as rf]
             ;; rf2-2rtt6.91 — the entry emits no hash, so the exclusion row
             ;; takes the measurement it excludes directly.
-            [re-frame.ssr.hash :as ssr-hash]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.ssr.hash :as rf.ssr.hash]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 (def ^:private frame-id ::instance-key-payload)
 
@@ -119,14 +119,14 @@
   "instance-key-payload-omitted")
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
      :init-fn       (fn []
-                      (fixtures/register!)
-                      (rt/reset-runtime!)
-                      (rt/reset-body-runs!))}))
+                      (rf.bench.hicasso.ssr.fixtures/register!)
+                      (rf.bench.hicasso.arm1.runtime/reset-runtime!)
+                      (rf.bench.hicasso.arm1.runtime/reset-body-runs!))}))
 
 (defn- skip! [why]
   (is true (str "a payload-obligation hydration claim needs a real React DOM — " why)))
@@ -140,11 +140,11 @@
   both sides so the hydration measured afterwards starts from an empty
   table."
   [row-id]
-  (rt/reset-runtime!)
-  (rt/reset-body-runs!)
-  (let [result (entry/render (fixtures/row row-id))]
-    (rt/reset-runtime!)
-    (rt/reset-body-runs!)
+  (rf.bench.hicasso.arm1.runtime/reset-runtime!)
+  (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
+  (let [result (rf.bench.hicasso.ssr.entry/render (rf.bench.hicasso.ssr.fixtures/row row-id))]
+    (rf.bench.hicasso.arm1.runtime/reset-runtime!)
+    (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
     result))
 
 (defn- client-frame!
@@ -164,7 +164,7 @@
   payload, so the seeding door is deliberately the least interesting
   part of the row."
   [payload]
-  (lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/leave-act-environment!)
   (rf/make-frame {:id             frame-id
                   :initial-events [[:rf/set-db (:rf/app-db payload)]]})
   frame-id)
@@ -178,10 +178,10 @@
   []
   (let [seen (atom [])
         k    (keyword (str "rf2-2rtt6-99-" (gensym)))]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (= :rf.ssr/hydration-mismatch (:operation ev))
                    (swap! seen conj ev))))
-    {:seen seen :stop! (fn [] (trace-tooling/unregister-listener! k) @seen)}))
+    {:seen seen :stop! (fn [] (rf.trace.tooling/unregister-listener! k) @seen)}))
 
 (defn- tags-of
   "The diagnostic's tags, merged with its top level, so a read is robust
@@ -207,7 +207,7 @@
         {:keys [seen stop!]} (watch-mismatches!)
         {:keys [captured close!]} (open-console-capture! capture-opts)
         before    (some? (open-panel-in container))
-        handle    (mount/hydrate-root! container frame-id [instance-key/screen {}])]
+        handle    (rf.bench.hicasso.arm1.mount/hydrate-root! container frame-id [rf.bench.hicasso.ssr.instance-key/screen {}])]
     (-> (adopted!)
         (.then (fn [ok]
                  (close!)
@@ -248,7 +248,7 @@
                 obliged about: " (:html green)))
 
       (testing "the green row ships the instance state at the documented tier"
-        (is (= true (get-in gdb instance-key/state-path))
+        (is (= true (get-in gdb rf.bench.hicasso.ssr.instance-key/state-path))
             (str "[:ui ::open? \"billing\"] crossed the wire as written. Saw: "
                  (pr-str gdb))))
 
@@ -256,11 +256,11 @@
         (is (not (contains? rdb :ui))
             (str "no :ui partition at all — not an empty one, not a
                   defaulted one; absent: " (pr-str rdb)))
-        (is (nil? (get-in rdb instance-key/state-path))))
+        (is (nil? (get-in rdb rf.bench.hicasso.ssr.instance-key/state-path))))
 
       (testing "and everything else is identical, so `:ui` is the whole
                difference"
-        (is (= (:panels gdb) (:panels rdb) instance-key/panels))
+        (is (= (:panels gdb) (:panels rdb) rf.bench.hicasso.ssr.instance-key/panels))
         (is (= #{:panels :ui} (set (keys gdb))))
         (is (= #{:panels} (set (keys rdb)))))
 
@@ -273,12 +273,12 @@
       (report! "payload"
                {:green-keys (vec (sort-by str (keys gdb)))
                 :red-keys   (vec (sort-by str (keys rdb)))
-                ;; `lane/utf8-bytes` and not `count`, which answers UTF-16
+                ;; `rf.bench.hicasso.lane/utf8-bytes` and not `count`, which answers UTF-16
                 ;; code units (rf2-2rtt6.121). These two are a claim about
                 ;; the WIRE — the testing block above says so in as many
                 ;; words — and the wire carries bytes.
-                :green-edn-bytes (lane/utf8-bytes (:payload-edn green))
-                :red-edn-bytes   (lane/utf8-bytes (:payload-edn red))
+                :green-edn-bytes (rf.bench.hicasso.lane/utf8-bytes (:payload-edn green))
+                :red-edn-bytes   (rf.bench.hicasso.lane/utf8-bytes (:payload-edn red))
                 :html-identical? (= (:html green) (:html red))}))))
 
 ;; ===========================================================================
@@ -295,14 +295,14 @@
            for why it could not be stated over the hash"
     (doseq [row-id [green-id red-id]]
       (let [{:keys [identical? differs-at] a :first b :second}
-            (entry/render-twice (fixtures/row row-id))]
+            (rf.bench.hicasso.ssr.entry/render-twice (rf.bench.hicasso.ssr.fixtures/row row-id))]
         (is identical?
             (str "row " row-id " rendered two DIFFERENT documents"
                  (when differs-at
                    (str " — first difference at character " differs-at))))
         (is (not= (:frame-id a) (:frame-id b))
             (str "row " row-id " took two different per-request frames"))
-        (doseq [{ikey :id ptitle :title} instance-key/panels]
+        (doseq [{ikey :id ptitle :title} rf.bench.hicasso.ssr.instance-key/panels]
           (is (re-find (re-pattern (str "data-ikey=\"" ikey "\"")) (:html a))
               (str "the authored instance key " (pr-str ikey) " is in the
                     markup as written — not an ordinal, not a counter, not
@@ -320,8 +320,8 @@
            rows and the dogfood screen — a different page entirely — take
            one shared constant. Neither an absent value nor a constant one
            can carry a claim, so no claim in this file rests on it"
-    (let [payload (:payload (entry/render (fixtures/row green-id)))
-          hash-of #(ssr-hash/render-tree-hash (:hiccup (fixtures/row %)))
+    (let [payload (:payload (rf.bench.hicasso.ssr.entry/render (rf.bench.hicasso.ssr.fixtures/row green-id)))
+          hash-of #(rf.ssr.hash/render-tree-hash (:hiccup (rf.bench.hicasso.ssr.fixtures/row %)))
           dogfood (hash-of "dogfood-snapshot")
           green   (hash-of green-id)
           red     (hash-of red-id)]
@@ -343,11 +343,11 @@
            finds nothing to reconcile — asserted on the framework's own
            diagnostic AND on both channels React 19 complains through"
     (async done
-      (if-not (mount/browser?)
+      (if-not (rf.bench.hicasso.arm1.mount/browser?)
         (do (skip! ":node-test has no DOM") (done))
         (let [{:keys [html payload]} (server! green-id)]
           (client-frame! payload)
-          (is (= true (get-in (rf/app-db-value frame-id) instance-key/state-path))
+          (is (= true (get-in (rf/app-db-value frame-id) rf.bench.hicasso.ssr.instance-key/state-path))
               "the client frame booted holding the instance state the
                server wrote — which is the whole of what the allowlist
                bought")
@@ -394,7 +394,7 @@
                               :warnings   (count warnings)
                               :panels     (panel-count container)
                               :open-after? (some? (open-panel-in container))})
-                    (finally (mount/release! handle)))))
+                    (finally (rf.bench.hicasso.arm1.mount/release! handle)))))
               ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
               ;; the whole remainder of the run synchronously, so a `.catch`
               ;; downstream of it would claim a later namespace's throw as this
@@ -424,11 +424,11 @@
            row goes on to assert that the door reported it as well as
            emitting it"
     (async done
-      (if-not (mount/browser?)
+      (if-not (rf.bench.hicasso.arm1.mount/browser?)
         (do (skip! ":node-test has no DOM") (done))
         (let [{:keys [html payload]} (server! red-id)]
           (client-frame! payload)
-          (is (nil? (get-in (rf/app-db-value frame-id) instance-key/state-path))
+          (is (nil? (get-in (rf/app-db-value frame-id) rf.bench.hicasso.ssr.instance-key/state-path))
               "the client frame booted WITHOUT the instance state — the
                entry is absent, so `reg-state`'s sub will read its
                `:default`, which is `false`")
@@ -487,7 +487,7 @@
                               :where      (str (:where (tags-of (first mismatches))))
                               :panels     (panel-count container)
                               :open-after? (some? (open-panel-in container))})
-                    (finally (mount/release! handle)))))
+                    (finally (rf.bench.hicasso.arm1.mount/release! handle)))))
               ;; Reports and RELEASES, as above.
               (.catch (fn [e] (is false (str "row 2 threw: " e)) nil))
               (.then (fn [_] (done)))))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/ssr/node.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/ssr/node.cljs
@@ -32,11 +32,11 @@
   wanted to see a ClojureScript map through this seam would be a driver
   reaching into the render entry, which is the coupling the seam exists
   to prevent."
-  (:require [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.dogfood-collector :as collector]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
-            [re-frame.bench.hicasso.ssr.entry :as entry]
-            [re-frame.bench.hicasso.ssr.fixtures :as fixtures]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.dogfood-collector :as rf.bench.hicasso.arm1.dogfood-collector]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
+            [re-frame.bench.hicasso.ssr.entry :as rf.bench.hicasso.ssr.entry]
+            [re-frame.bench.hicasso.ssr.fixtures :as rf.bench.hicasso.ssr.fixtures]
             [re-frame.core :as rf]))
 
 (def ^:const api-slot
@@ -58,15 +58,15 @@
 
 (defn- require-row
   [id]
-  (or (fixtures/row id)
+  (or (rf.bench.hicasso.ssr.fixtures/row id)
       (throw (ex-info (str "No SSR corpus row named " (pr-str id) ". Known: "
-                           (pr-str (fixtures/ids)))
-                      {:id id :known (fixtures/ids)}))))
+                           (pr-str (rf.bench.hicasso.ssr.fixtures/ids)))
+                      {:id id :known (rf.bench.hicasso.ssr.fixtures/ids)}))))
 
 (defn render-fixture
   "Render the corpus row named `id`."
   [id]
-  (result->js (entry/render (require-row id))))
+  (result->js (rf.bench.hicasso.ssr.entry/render (require-row id))))
 
 (defn render-fixture-twice
   "Render the corpus row named `id` TWICE and hand both documents back —
@@ -74,7 +74,7 @@
   entry has already compared them byte-for-byte."
   [id]
   (let [{:keys [identical? differs-at] a :first b :second}
-        (entry/render-twice (require-row id))]
+        (rf.bench.hicasso.ssr.entry/render-twice (require-row id))]
     #js {"first"      (result->js a)
          "second"     (result->js b)
          "identical"  identical?
@@ -89,24 +89,24 @@
   the state is the REQUEST'S and not the process's."
   [n]
   (result->js
-    (entry/render {:hiccup   [collector/screen {}]
-                   :snapshot (dogfood/seed-db n)
-                   :payload  fixtures/dogfood-payload-keys
+    (rf.bench.hicasso.ssr.entry/render {:hiccup   [rf.bench.hicasso.arm1.dogfood-collector/screen {}]
+                   :snapshot (rf.bench.hicasso.front.dogfood/seed-db n)
+                   :payload  rf.bench.hicasso.ssr.fixtures/dogfood-payload-keys
                    :title    (str "Hicasso SSR — live, " n " to-dos")})))
 
 (defn boot!
   "Install the substrate and register what the corpus needs. Once per
   process — Spec 006's law, not a convention."
   []
-  (rf/init! uix-adapter/adapter)
-  (fixtures/register!)
+  (rf/init! rf.adapter.uix/adapter)
+  (rf.bench.hicasso.ssr.fixtures/register!)
   nil)
 
 (defn install!
   "Publish the driver API."
   []
   (unchecked-set js/globalThis api-slot
-                 #js {"ids"          (clj->js (fixtures/ids))
+                 #js {"ids"          (clj->js (rf.bench.hicasso.ssr.fixtures/ids))
                       "render"       render-fixture
                       "renderTwice"  render-fixture-twice
                       "renderDogfood" render-dogfood})

--- a/bench/hicasso/src/re_frame/bench/hicasso/ssr/spike_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/ssr/spike_cljs_test.cljs
@@ -32,7 +32,7 @@
   none, so there is now nothing on the wire to lean on either. The
   measurement stands unchanged and
   [[the-byte-digest-separates-the-two-pages-render-hash-cannot]] still
-  takes that exact pair, now over `ssr-hash/render-tree-hash` directly:
+  takes that exact pair, now over `rf.ssr.hash/render-tree-hash` directly:
   the degeneracy is a fact about hashing an unresolved root form, not
   about this entry, so removing the emission does not retire it. It is
   the reason this row is entitled to say `deterministic` where the
@@ -48,25 +48,25 @@
   different pages to take two different digests."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
             ;; rf2-2rtt6.121 — for `utf8-bytes` alone. The lane is already on
             ;; the `:node-test` classpath (its `*_dom_cljs_test` siblings
             ;; require it and `cljs-test$` matches them too), so this adds no
             ;; dependency the build did not already carry.
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.ssr.entry :as entry]
-            [re-frame.bench.hicasso.ssr.fixtures :as fixtures]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.ssr.entry :as rf.bench.hicasso.ssr.entry]
+            [re-frame.bench.hicasso.ssr.fixtures :as rf.bench.hicasso.ssr.fixtures]
             ;; rf2-2rtt6.91 — the entry ships no render hash, so the control
             ;; row takes the hash it is a control AGAINST directly.
-            [re-frame.ssr.hash :as ssr-hash]
-            [re-frame.test-support :as test-support]))
+            [re-frame.ssr.hash :as rf.ssr.hash]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      :async?  true
-     :init-fn (fn [] (fixtures/register!))}))
+     :init-fn (fn [] (rf.bench.hicasso.ssr.fixtures/register!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; SHA-256
@@ -100,8 +100,8 @@
 
 (deftest x1a-the-seeded-dogfood-snapshot-renders-byte-identical-documents
   (async done
-    (let [row (fixtures/row dogfood-row-id)
-          {:keys [identical? differs-at] a :first b :second} (entry/render-twice row)]
+    (let [row (rf.bench.hicasso.ssr.fixtures/row dogfood-row-id)
+          {:keys [identical? differs-at] a :first b :second} (rf.bench.hicasso.ssr.entry/render-twice row)]
       (is (some? row) "the corpus still carries the row this witness renders")
       (is identical?
            (str "the same bundle and the same snapshot rendered two DIFFERENT "
@@ -121,7 +121,7 @@
               (report! "X1a"
                        {:row          dogfood-row-id
                         :sha256       ha
-                        ;; `lane/utf8-bytes` and not `count` (rf2-2rtt6.121).
+                        ;; `rf.bench.hicasso.lane/utf8-bytes` and not `count` (rf2-2rtt6.121).
                         ;; THIS FIGURE MOVES, and it is the one published
                         ;; figure in this repair that does: measured
                         ;; 2026-08-06, the same document is 3,042 code units
@@ -135,11 +135,11 @@
                         ;; error. The DOCUMENT itself has since shrunk (that
                         ;; bead saw 3,101/3,119), which is corpus drift and
                         ;; nothing to do with the ruler.
-                        :bytes        (lane/utf8-bytes (:document a))
+                        :bytes        (rf.bench.hicasso.lane/utf8-bytes (:document a))
                         ;; rf2-2rtt6.91 — the published column, taken where
                         ;; the fact lives now that the entry emits none.
-                        :render-hash  (str (ssr-hash/render-tree-hash
-                                             (:hiccup (fixtures/row dogfood-row-id))))})))
+                        :render-hash  (str (rf.ssr.hash/render-tree-hash
+                                             (:hiccup (rf.bench.hicasso.ssr.fixtures/row dogfood-row-id))))})))
           ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs the
           ;; whole remainder of the run synchronously, so a `.catch` downstream
           ;; of it would claim a later namespace's throw as this row's and fire
@@ -155,9 +155,9 @@
            row above is measuring the renderer's silence rather than its
            determinism"
     (async done
-      (let [row (fixtures/row dogfood-row-id)
-            eight (:document (entry/render row))
-            nine  (:document (entry/render (assoc row :snapshot (dogfood/seed-db 9))))]
+      (let [row (rf.bench.hicasso.ssr.fixtures/row dogfood-row-id)
+            eight (:document (rf.bench.hicasso.ssr.entry/render row))
+            nine  (:document (rf.bench.hicasso.ssr.entry/render (assoc row :snapshot (rf.bench.hicasso.front.dogfood/seed-db 9))))]
         (is (not= eight nine))
         (-> (js/Promise.all #js [(sha256-hex eight) (sha256-hex nine)])
             (.then (fn [[h8 h9]]
@@ -183,10 +183,10 @@
            have shipped is a constant, so its absence costs this row
            nothing"
     (async done
-      (let [dog       (entry/render (fixtures/row dogfood-row-id))
-            conduit   (entry/render (fixtures/row "conduit-feed"))
-            dog-h     (ssr-hash/render-tree-hash (:hiccup (fixtures/row dogfood-row-id)))
-            conduit-h (ssr-hash/render-tree-hash (:hiccup (fixtures/row "conduit-feed")))]
+      (let [dog       (rf.bench.hicasso.ssr.entry/render (rf.bench.hicasso.ssr.fixtures/row dogfood-row-id))
+            conduit   (rf.bench.hicasso.ssr.entry/render (rf.bench.hicasso.ssr.fixtures/row "conduit-feed"))
+            dog-h     (rf.ssr.hash/render-tree-hash (:hiccup (rf.bench.hicasso.ssr.fixtures/row dogfood-row-id)))
+            conduit-h (rf.ssr.hash/render-tree-hash (:hiccup (rf.bench.hicasso.ssr.fixtures/row "conduit-feed")))]
         (is (not (contains? (:payload dog) :rf/render-hash))
             "no hash on the wire for an adoption-tier root")
         (is (= dog-h conduit-h)

--- a/bench/hicasso/src/re_frame/bench/hicasso/ssr/spike_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/ssr/spike_dom_cljs_test.cljs
@@ -76,7 +76,7 @@
   a debug-gated counter is dead code the compiler removes. (`rstate`
   carries `^js` and its keys are string literals, so `:infer-externs
   :auto` keeps `.-bodyRuns` off Closure's renamer too — the same spelling
-  discipline `mount/adoption-window-closer`'s `displayName` stamp
+  discipline `rf.bench.hicasso.arm1.mount/adoption-window-closer`'s `displayName` stamp
   documents.) So the adversarial hazard (F6) does not reach the counter
   this row reads: it is present in every build, and this row reads it in
   the one whose runtime it stamps. [[runtime-stamp]] records that stamp
@@ -86,26 +86,26 @@
   React DOM; under `:node-test` every DOM claim degrades to a stated
   skip."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.dogfood-collector :as collector]
-            [re-frame.bench.hicasso.arm1.dogfood-script :as script]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.dogfood-collector :as rf.bench.hicasso.arm1.dogfood-collector]
+            [re-frame.bench.hicasso.arm1.dogfood-script :as rf.bench.hicasso.arm1.dogfood-script]
             [re-frame.bench.hicasso.arm1.hydration-support
              :refer [adopted! every-server-node? open-console-capture! server-dom!
                      server-node? stamp-server-nodes!]]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.ssr.entry :as entry]
-            [re-frame.bench.hicasso.ssr.fixtures :as fixtures]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.front.dogfood :as rf.bench.hicasso.front.dogfood]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.ssr.entry :as rf.bench.hicasso.ssr.entry]
+            [re-frame.bench.hicasso.ssr.fixtures :as rf.bench.hicasso.ssr.fixtures]
             [re-frame.core :as rf]
-            [re-frame.test-support :as test-support]))
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private frame-id ::ssr-spike)
 
 (def ^:private todo-count
   "The seeded size, taken from the corpus row rather than chosen here —
-  `fixtures/corpus`'s `dogfood-snapshot` is seeded `(dogfood/seed-db 8)`,
+  `rf.bench.hicasso.ssr.fixtures/corpus`'s `dogfood-snapshot` is seeded `(rf.bench.hicasso.front.dogfood/seed-db 8)`,
   and [[same-snapshot!]] asserts the client frame holds exactly that."
   8)
 
@@ -130,14 +130,14 @@
   {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0})
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
      :init-fn       (fn []
-                      (fixtures/register!)
-                      (rt/reset-runtime!)
-                      (rt/reset-body-runs!))}))
+                      (rf.bench.hicasso.ssr.fixtures/register!)
+                      (rf.bench.hicasso.arm1.runtime/reset-runtime!)
+                      (rf.bench.hicasso.arm1.runtime/reset-body-runs!))}))
 
 (defn- skip! [why]
   (is true (str "an SSR spike row needs a real React DOM — " why)))
@@ -145,7 +145,7 @@
 (defn runtime-stamp
   "The runtime a row was taken on, carried BESIDE the row.
 
-  Deliberately NOT `lane/runtime-label`: that one reports
+  Deliberately NOT `rf.bench.hicasso.lane/runtime-label`: that one reports
   `:optimizations :advanced` as a LITERAL, which is true of every arm in
   the bench lane and false here. A stamp that names the wrong build is
   worse than no stamp."
@@ -170,10 +170,10 @@
   written out, so `the same snapshot` is a checked claim on both sides
   rather than two call sites that happen to agree today."
   []
-  (lane/leave-act-environment!)
-  (dogfood/make-frame! frame-id todo-count)
-  (dogfood/reseed! frame-id todo-count)
-  (is (= (dogfood/seed-db todo-count) (rf/app-db-value frame-id))
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.front.dogfood/make-frame! frame-id todo-count)
+  (rf.bench.hicasso.front.dogfood/reseed! frame-id todo-count)
+  (is (= (rf.bench.hicasso.front.dogfood/seed-db todo-count) (rf/app-db-value frame-id))
       "the client frame holds exactly the snapshot the server rendered")
   frame-id)
 
@@ -193,15 +193,15 @@
   ask for DIFFERENT bytes without inventing a second request shape."
   ([] (server! nil))
   ([opts]
-   (rt/reset-runtime!)
-   (rt/reset-body-runs!)
-   (let [{:keys [html]} (entry/render (merge (fixtures/row "dogfood-snapshot") opts))
-         runs (rt/body-runs)]
+   (rf.bench.hicasso.arm1.runtime/reset-runtime!)
+   (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
+   (let [{:keys [html]} (rf.bench.hicasso.ssr.entry/render (merge (rf.bench.hicasso.ssr.fixtures/row "dogfood-snapshot") opts))
+         runs (rf.bench.hicasso.arm1.runtime/body-runs)]
      ;; The server render is over before anything is hydrated, so its
      ;; counter is read here and the runtime the hydration is measured on
      ;; starts empty.
-     (rt/reset-runtime!)
-     (rt/reset-body-runs!)
+     (rf.bench.hicasso.arm1.runtime/reset-runtime!)
+     (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
      {:html html :body-runs runs})))
 
 (defn- hydrate-and-adopt!
@@ -224,9 +224,9 @@
   ([html capture-opts]
    (let [container (stamp-server-nodes! (server-dom! html))
         {:keys [captured close!]} (open-console-capture! capture-opts)
-         handle    (mount/hydrate-root! container frame-id [collector/screen {}])
+         handle    (rf.bench.hicasso.arm1.mount/hydrate-root! container frame-id [rf.bench.hicasso.arm1.dogfood-collector/screen {}])
          at-return (count @captured)
-         open?     (rt/adopting?)]
+         open?     (rf.bench.hicasso.arm1.runtime/adopting?)]
      (-> (adopted!)
          (.then (fn [ok]
                   (close!)
@@ -241,7 +241,7 @@
   "A cold, ordinary client mount of the same screen on the same frame —
   the control every parity row is stated against."
   []
-  (mount/root! (mount/fresh-container!) frame-id [collector/screen {}]))
+  (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [rf.bench.hicasso.arm1.dogfood-collector/screen {}]))
 
 ;; ===========================================================================
 ;; X1(b) — CANONICAL-DOM PARITY
@@ -249,7 +249,7 @@
 
 (deftest x1b-the-hydrated-dom-equals-the-client-only-dom
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         ;; The CONTROL goes first, on the freshest frame. If it went last a
@@ -257,9 +257,9 @@
         ;; residue from the mount before it.
         (same-snapshot!)
         (let [cold      (client-only!)
-              cold-dom  (lane/canonical (:container cold))
-              cold-runs (rt/body-runs)]
-          (mount/release! cold)
+              cold-dom  (rf.bench.hicasso.lane/canonical (:container cold))
+              cold-runs (rf.bench.hicasso.arm1.runtime/body-runs)]
+          (rf.bench.hicasso.arm1.mount/release! cold)
           (same-snapshot!)
           (let [{:keys [html body-runs]} (server!)]
             (-> (hydrate-and-adopt! html)
@@ -270,7 +270,7 @@
                       (is (= [] warnings)
                           (str "React reported nothing on either channel: "
                                (pr-str warnings)))
-                      (let [hydrated-dom (lane/canonical container)]
+                      (let [hydrated-dom (rf.bench.hicasso.lane/canonical container)]
                         (is (= cold-dom hydrated-dom)
                             "**canonical-DOM parity.** The page React adopted
                              from the server's bytes is the page a cold client
@@ -287,13 +287,13 @@
                              above is an equality of something")
                         (is (= todo-count
                                (.-length (.querySelectorAll container ".row"))))
-                        ;; `lane/utf8-bytes` and not `count`, which answers
+                        ;; `rf.bench.hicasso.lane/utf8-bytes` and not `count`, which answers
                         ;; UTF-16 code units (rf2-2rtt6.121).
-                        (report! "X1b" {:canonical-bytes  (lane/utf8-bytes hydrated-dom)
+                        (report! "X1b" {:canonical-bytes  (rf.bench.hicasso.lane/utf8-bytes hydrated-dom)
                                         :rows             todo-count
                                         :server-body-runs body-runs
                                         :cold-body-runs   cold-runs}))
-                      (finally (mount/release! handle) (done))))))))))))
+                      (finally (rf.bench.hicasso.arm1.mount/release! handle) (done))))))))))))
 
 (deftest x1b-the-canonical-comparator-can-answer-false
   (testing "**the mutation proof for X1(b).** The comparator is a
@@ -302,7 +302,7 @@
            reading if the same call can say `different`. One toggle on the
            hydrated screen, and it does"
     (async done
-      (if-not (mount/browser?)
+      (if-not (rf.bench.hicasso.arm1.mount/browser?)
         (do (skip! ":node-test has no DOM") (done))
         (do
           (same-snapshot!)
@@ -311,12 +311,12 @@
                 (.then
                   (fn [{:keys [handle container]}]
                     (try
-                      (let [before (lane/canonical container)]
-                        (mount/dispatch! handle [:dogfood/toggle 0])
-                        (is (not= before (lane/canonical container))
+                      (let [before (rf.bench.hicasso.lane/canonical container)]
+                        (rf.bench.hicasso.arm1.mount/dispatch! handle [:dogfood/toggle 0])
+                        (is (not= before (rf.bench.hicasso.lane/canonical container))
                             "the same comparator, the same container, one
                              changed row — and it says so"))
-                      (finally (mount/release! handle) (done))))))))))))
+                      (finally (rf.bench.hicasso.arm1.mount/release! handle) (done))))))))))))
 
 ;; ===========================================================================
 ;; X2 — ADOPTION IS REAL
@@ -324,7 +324,7 @@
 
 (deftest x2-adoption-is-real
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (same-snapshot!)
@@ -339,7 +339,7 @@
                          returns before the tree is adopted and the window
                          has to outlive the call")
                     (is (true? adopted?) "the closer's passive effect ran")
-                    (is (false? (rt/adopting?)) "and shut the window")
+                    (is (false? (rf.bench.hicasso.arm1.runtime/adopting?)) "and shut the window")
 
                     (testing "(a) ZERO HYDRATION-MISMATCH WARNINGS, on both
                              the channels React 19 uses, across the WHOLE
@@ -367,15 +367,15 @@
                              ONCE, **counted** in `run-once` where a body is
                              invoked (rf2-2rtt6.84 (6)) rather than inferred
                              from the renders React was asked for"
-                      (is (= boundary-count (rt/body-runs))
+                      (is (= boundary-count (rf.bench.hicasso.arm1.runtime/body-runs))
                           (str "each of the screen's " boundary-count
                                " boundaries ran its body exactly once to "
-                               "adopt — read " (rt/body-runs)))
+                               "adopt — read " (rf.bench.hicasso.arm1.runtime/body-runs)))
                       (is (= boundary-count body-runs)
                           (str "and the SERVER ran the same " boundary-count
                                " bodies for the same screen, so the two sides "
                                "rendered the same tree — read " body-runs))
-                      (is (= boundary-count (inc (:boundaries (rt/stats))))
+                      (is (= boundary-count (inc (:boundaries (rf.bench.hicasso.arm1.runtime/stats))))
                           (str "…and the runtime's own census agrees with the
                                 roster this row names, so " boundary-count
                                " is not a constant nobody checks. `:boundaries`
@@ -386,23 +386,23 @@
                                 correctly absent (`runtime/stats` says exactly
                                 this). Exactly one such boundary on this
                                 screen, hence the `inc`; read "
-                               (:boundaries (rt/stats))))
-                      (is (= boundary-count (:entries (rt/stats)))
+                               (:boundaries (rf.bench.hicasso.arm1.runtime/stats))))
+                      (is (= boundary-count (:entries (rf.bench.hicasso.arm1.runtime/stats)))
                           "**and every one of them is subscribed to an entry
                            still in the cache** — the row the 0 → 4 ms reap
                            horizon exists for")
-                      (is (pos? (:cell-refs (rt/stats)))
+                      (is (pos? (:cell-refs (rf.bench.hicasso.arm1.runtime/stats)))
                           "and the references are real"))
 
-                    (report! "X2" {:body-runs-client (rt/body-runs)
+                    (report! "X2" {:body-runs-client (rf.bench.hicasso.arm1.runtime/body-runs)
                                    :body-runs-server body-runs
                                    :boundary-count   boundary-count
                                    :sync-warnings    sync-warnings
                                    :warnings         warnings
-                                   :stats            (select-keys (rt/stats)
+                                   :stats            (select-keys (rf.bench.hicasso.arm1.runtime/stats)
                                                                   [:cells :cell-refs
                                                                    :boundaries :entries])})
-                    (finally (mount/release! handle) (done)))))))))))
+                    (finally (rf.bench.hicasso.arm1.mount/release! handle) (done)))))))))))
 
 (deftest x2-the-console-capture-can-answer-false
   (testing "**the mutation proof for X2(a), and a measurement of the
@@ -426,11 +426,11 @@
            rule this row does not soften, because the error is not
            unasserted here, it IS the assertion"
     (async done
-      (if-not (mount/browser?)
+      (if-not (rf.bench.hicasso.arm1.mount/browser?)
         (do (skip! ":node-test has no DOM") (done))
         (do
           (same-snapshot!)
-          (let [{:keys [html]} (server! {:snapshot (dogfood/seed-db (inc todo-count))})]
+          (let [{:keys [html]} (server! {:snapshot (rf.bench.hicasso.front.dogfood/seed-db (inc todo-count))})]
             (-> (hydrate-and-adopt! html {:swallow-uncaught? true})
                 (.then
                   (fn [{:keys [handle container warnings sync-warnings]}]
@@ -449,7 +449,7 @@
                       (is (= todo-count (.-length (.querySelectorAll container ".row")))
                           "and the client's model won, as a hydration
                            mismatch's recovery must")
-                      (finally (mount/release! handle) (done))))))))))))
+                      (finally (rf.bench.hicasso.arm1.mount/release! handle) (done))))))))))))
 
 (deftest x2-the-node-identity-check-can-answer-false
   (testing "**the mutation proof for X2(b).** `root!` — an ordinary client
@@ -457,7 +457,7 @@
            nodes away and builds its own. Every stamp must be gone. That is
            the difference `hydrate-root!` makes, stated as a measurement
            rather than as a claim about which API was called"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (do
         (same-snapshot!)
@@ -465,7 +465,7 @@
               container (stamp-server-nodes! (server-dom! html))]
           (is (every-server-node? container ".row")
               "the stamps are on before anything mounts")
-          (let [handle (mount/root! container frame-id [collector/screen {}])]
+          (let [handle (rf.bench.hicasso.arm1.mount/root! container frame-id [rf.bench.hicasso.arm1.dogfood-collector/screen {}])]
             (try
               (is (pos? (.-length (.querySelectorAll container ".row")))
                   "the client mount built the page")
@@ -473,7 +473,7 @@
                   "and NONE of its rows is a server node — a plain mount
                    replaces the DOM, so the identity check in X2(b) is
                    measuring adoption and not merely the presence of markup")
-              (finally (mount/release! handle)))))))))
+              (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))))
 
 (deftest x2-a-props-equal-re-render-runs-no-body
   (testing "**the mutation proof for X2(c)** (HD-028's rider). The counter
@@ -484,7 +484,7 @@
            here — and would then be unable to tell a genuine adoption from
            a skipped one"
     (async done
-      (if-not (mount/browser?)
+      (if-not (rf.bench.hicasso.arm1.mount/browser?)
         (do (skip! ":node-test has no DOM") (done))
         (do
           (same-snapshot!)
@@ -493,17 +493,17 @@
                 (.then
                   (fn [{:keys [handle container]}]
                     (try
-                      (rt/reset-body-runs!)
-                      (mount/render! handle [collector/screen {}])
-                      (is (zero? (rt/body-runs))
+                      (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
+                      (rf.bench.hicasso.arm1.mount/render! handle [rf.bench.hicasso.arm1.dogfood-collector/screen {}])
+                      (is (zero? (rf.bench.hicasso.arm1.runtime/body-runs))
                           (str "a props-equal re-render ran no body; read "
-                               (rt/body-runs)))
+                               (rf.bench.hicasso.arm1.runtime/body-runs)))
                       (is (every-server-node? container ".row")
                           "and every row is still the SERVER'S node — the
                            re-render did not tear the adopted tree down,
-                           which is what `mount/tree`'s hydrated root shape
+                           which is what `rf.bench.hicasso.arm1.mount/tree`'s hydrated root shape
                            buys")
-                      (finally (mount/release! handle) (done))))))))))))
+                      (finally (rf.bench.hicasso.arm1.mount/release! handle) (done))))))))))))
 
 ;; ===========================================================================
 ;; X4 — THE SCREEN IS ALIVE
@@ -526,12 +526,12 @@
                                (fn [record]
                                  (when (= frame-id (:frame record))
                                    (swap! log conj (:event record)))))
-        (script/run-steps!
-          (script/interaction-steps handle)
+        (rf.bench.hicasso.arm1.dogfood-script/run-steps!
+          (rf.bench.hicasso.arm1.dogfood-script/interaction-steps handle)
           (fn []
-            (let [result {:intents @log :dom (lane/canonical (:container handle))}]
+            (let [result {:intents @log :dom (rf.bench.hicasso.lane/canonical (:container handle))}]
               (rf/unregister-listener! :events ::x4)
-              (mount/release! handle)
+              (rf.bench.hicasso.arm1.mount/release! handle)
               (resolve result))))))))
 
 (defn- hydrated-script-run!
@@ -548,7 +548,7 @@
 
 (deftest x4-the-hydrated-screen-dispatches-the-stated-intents
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       ;; The control first, on the freshest frame — same reasoning as X1(b).
       (do
@@ -559,10 +559,10 @@
                             (fn [hydrated-run] [cold-run hydrated-run]))))
             (.then
               (fn [[cold-run hydrated-run]]
-                (is (= script/interaction-intents (:intents cold-run))
+                (is (= rf.bench.hicasso.arm1.dogfood-script/interaction-intents (:intents cold-run))
                     "the client-only screen dispatches exactly the stated
                      intents — and nothing for the two composing keystrokes")
-                (is (= script/interaction-intents (:intents hydrated-run))
+                (is (= rf.bench.hicasso.arm1.dogfood-script/interaction-intents (:intents hydrated-run))
                     "**and so does the HYDRATED screen.** Seventeen real DOM
                      events — clicks, prototype-setter keystrokes, native
                      `keydown`s carrying `isComposing` and `keyCode` — reach
@@ -576,7 +576,7 @@
                      interactions, not just at adoption")
                 (report! "X4" {:steps          17
                                :intents        (count (:intents hydrated-run))
-                               :intents-match? (= script/interaction-intents
+                               :intents-match? (= rf.bench.hicasso.arm1.dogfood-script/interaction-intents
                                                   (:intents hydrated-run))
                                :dom-match?     (= (:dom cold-run) (:dom hydrated-run))})))
             ;; Reports and RELEASES; it never finishes (rf2-o0n1). `done` runs
@@ -593,7 +593,7 @@
            server rendered, and the first keystroke after adoption echoes
            in the caller's own turn, exactly as on the client-only screen"
     (async done
-      (if-not (mount/browser?)
+      (if-not (rf.bench.hicasso.arm1.mount/browser?)
         (do (skip! ":node-test has no DOM") (done))
         (do
           (same-snapshot!)
@@ -613,14 +613,14 @@
                             "and it holds what the server rendered: the
                              seeded app-db carries no draft, so hydration
                              converged nothing")
-                        (script/type-into! input "milk")
-                        (mount/settle!)
+                        (rf.bench.hicasso.arm1.dogfood-script/type-into! input "milk")
+                        (rf.bench.hicasso.arm1.mount/settle!)
                         (is (= "milk" (.-value (.querySelector container ".new-input")))
                             "the echo landed without waiting for a later turn")
                         (is (server-node? (.querySelector container ".new-input"))
                             "and it is STILL the server's node — the echo did
                              not remount the field"))
-                      (finally (mount/release! handle) (done))))))))))))
+                      (finally (rf.bench.hicasso.arm1.mount/release! handle) (done))))))))))))
 
 ;; ===========================================================================
 ;; X5 — TEARDOWN CLEAN
@@ -628,7 +628,7 @@
 
 (deftest x5-unmounting-the-hydrated-root-leaves-no-residue
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (same-snapshot!)
@@ -639,28 +639,28 @@
                   (is (true? adopted?) "adoption completed")
                   ;; Drive it, so the teardown has something to release that
                   ;; the adoption alone did not install.
-                  (mount/dispatch! handle [:dogfood/toggle 0])
-                  (mount/dispatch! handle [:dogfood/set-filter :all])
-                  (is (pos? (:cell-refs (rt/stats)))
+                  (rf.bench.hicasso.arm1.mount/dispatch! handle [:dogfood/toggle 0])
+                  (rf.bench.hicasso.arm1.mount/dispatch! handle [:dogfood/set-filter :all])
+                  (is (pos? (:cell-refs (rf.bench.hicasso.arm1.runtime/stats)))
                       "the hydrated screen holds references, so the reading
                        below is a reading of something")
                   ;; `unmount!`, never `release!`: `release!` resets the
                   ;; runtime, and a reading taken after that reset is a
                   ;; reading of an emptied table — zero however badly the
                   ;; teardown went (rf2-2rtt6.48).
-                  (mount/unmount! handle)
+                  (rf.bench.hicasso.arm1.mount/unmount! handle)
                   (js/setTimeout
                     (fn []
-                      (is (= nothing-retained (rt/residue))
+                      (is (= nothing-retained (rf.bench.hicasso.arm1.runtime/residue))
                           (str "**React's own cleanup released every edge, "
                                "reference and cached entry on the HYDRATED "
-                               "path.** Read " (pr-str (rt/residue))))
-                      (report! "X5" {:residue (rt/residue)})
+                               "path.** Read " (pr-str (rf.bench.hicasso.arm1.runtime/residue))))
+                      (report! "X5" {:residue (rf.bench.hicasso.arm1.runtime/residue)})
                       (rf/destroy-frame! frame-id)
                       (is (nil? (rf/app-db-value frame-id))
                           "and the frame is destroyable — an adopted root
                            leaves nothing holding it open")
-                      (rt/reset-runtime!)
+                      (rf.bench.hicasso.arm1.runtime/reset-runtime!)
                       (done))
                     reaper-horizon-ms)))))))))
 
@@ -672,7 +672,7 @@
            resets the runtime, so it would report zero here too, with a
            whole screen still adopted"
     (async done
-      (if-not (mount/browser?)
+      (if-not (rf.bench.hicasso.arm1.mount/browser?)
         (do (skip! ":node-test has no DOM") (done))
         (do
           (same-snapshot!)
@@ -694,7 +694,7 @@
                     ;; The doomed root's teardown is the ACT UNDER TEST, not
                     ;; cleanup: what follows reads what it left behind. It stays
                     ;; exactly here.
-                    (mount/unmount! (:handle doomed))
+                    (rf.bench.hicasso.arm1.mount/unmount! (:handle doomed))
                     ;; The reaper's horizon is a MACROTASK, and the row has to
                     ;; AWAIT it rather than let a bare timer carry the
                     ;; assertions off the end of the chain. Returned as a
@@ -707,10 +707,10 @@
                         (js/setTimeout
                           (fn []
                             (try
-                              (is (not= nothing-retained (rt/residue))
+                              (is (not= nothing-retained (rf.bench.hicasso.arm1.runtime/residue))
                                   "a live adopted screen is visible to the residue
                                    reading")
-                              (is (pos? (:cell-refs (rt/residue)))
+                              (is (pos? (:cell-refs (rf.bench.hicasso.arm1.runtime/residue)))
                                   "and it is visible as held references, which is
                                    the quantity X5 asserts to be zero")
                               (resolve nil)
@@ -728,5 +728,5 @@
                 ;; thing that rejected — so the row cannot hand a live adopted
                 ;; screen to the namespace after it.
                 (.then (fn [_]
-                         (some-> @survivor* :handle mount/release!)
+                         (some-> @survivor* :handle rf.bench.hicasso.arm1.mount/release!)
                          (done))))))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/topo/arms.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/topo/arms.cljs
@@ -39,7 +39,7 @@
   each other: a memo bail-out that this file counted and the runtime did
   not would be a real disagreement rather than a rounding one."
   (:require [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
-            [re-frame.bench.hicasso.topo.model :as m])
+            [re-frame.bench.hicasso.topo.model :as rf.bench.hicasso.topo.model])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 ;; ---------------------------------------------------------------------------
@@ -176,14 +176,14 @@
   `:boundaries` counts registrations holding at least one read edge — the
   list plus, per arm, its row or chunk boundaries. A `coarse` page is one
   boundary because there is nothing beneath it holding a read."
-  ([arm b] (expected arm b m/window-size))
+  ([arm b] (expected arm b rf.bench.hicasso.topo.model/window-size))
   ([arm b w]
-   (let [rendered (m/rendered-rows arm b w)]
+   (let [rendered (rf.bench.hicasso.topo.model/rendered-rows arm b w)]
      {:rendered-rows rendered
-      :elements      (m/elements-for rendered)
-      :edges         (inc (m/memberships arm b w))
+      :elements      (rf.bench.hicasso.topo.model/elements-for rendered)
+      :edges         (inc (rf.bench.hicasso.topo.model/memberships arm b w))
       :boundaries    (case arm
                        :fine    (inc b)
                        :coarse  1
-                       :chunked (inc (long (Math/ceil (/ b m/chunk-size))))
+                       :chunked (inc (long (Math/ceil (/ b rf.bench.hicasso.topo.model/chunk-size))))
                        :virtual (inc (min b w)))})))

--- a/bench/hicasso/src/re_frame/bench/hicasso/topo/census_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/topo/census_dom_cljs_test.cljs
@@ -53,21 +53,21 @@
   Runtime: `-dom-cljs-test`. Under `:node-test` every claim degrades to a
   stated skip."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt :refer [sub]]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.topo.arms :as arms]
-            [re-frame.bench.hicasso.topo.model :as m]
-            [re-frame.test-support :as test-support])
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime :refer [sub]]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.topo.arms :as rf.bench.hicasso.topo.arms]
+            [re-frame.bench.hicasso.topo.model :as rf.bench.hicasso.topo.model]
+            [re-frame.test-support :as rf.test-support])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (def ^:private frame-id ::topo)
 
@@ -87,13 +87,13 @@
   its DOM and its key scheme are `fine`'s; its read set is not, and the
   extra read moves whenever any row moves."
   [{:keys [i]}]
-  (swap! arms/counters update :row inc)
+  (swap! rf.bench.hicasso.topo.arms/counters update :row inc)
   (let [_shared (sub [:topo/view-model])]
-    (arms/row-markup (assoc (sub [:topo/row i]) :draft (sub [:topo/draft i])))))
+    (rf.bench.hicasso.topo.arms/row-markup (assoc (sub [:topo/row i]) :draft (sub [:topo/draft i])))))
 
 (defview sabotage-list
   [_]
-  (swap! arms/counters update :list inc)
+  (swap! rf.bench.hicasso.topo.arms/counters update :list inc)
   (into [:ul.topo-list {:data-testid "list"}]
         (map (fn [i] [sabotage-row {:key i :i i}]))
         (sub [:topo/order])))
@@ -103,25 +103,25 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- fresh! [b]
-  (lane/leave-act-environment!)
-  (m/make-frame! frame-id b)
-  (m/reseed! frame-id b)
-  (arms/reset-counters!)
-  (rt/reset-body-runs!)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.topo.model/make-frame! frame-id b)
+  (rf.bench.hicasso.topo.model/reseed! frame-id b)
+  (rf.bench.hicasso.topo.arms/reset-counters!)
+  (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
   frame-id)
 
 (defn- mount! [view]
-  (mount/root! (mount/fresh-container!) frame-id [view {}]))
+  (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [view {}]))
 
 (defn- restore!
   "Return the frame to its seed and let the commit land, WITHOUT charging
   it to any operation. Counters are zeroed after the settle, never
   before."
   [b]
-  (rt/dispatch! frame-id [:topo/seed b])
-  (mount/settle!)
-  (arms/reset-counters!)
-  (rt/reset-body-runs!)
+  (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:topo/seed b])
+  (rf.bench.hicasso.arm1.mount/settle!)
+  (rf.bench.hicasso.topo.arms/reset-counters!)
+  (rf.bench.hicasso.arm1.runtime/reset-body-runs!)
   nil)
 
 (defn- operate!
@@ -129,18 +129,18 @@
   instruments."
   [op b]
   (case op
-    :sparse  (rt/dispatch! frame-id [:topo/bump target])
-    :bulk    (rt/dispatch! frame-id [:topo/bump-all])
-    :reorder (rt/dispatch! frame-id [:topo/rotate])
-    :edit    (rt/dispatch! frame-id [:topo/edit target (str "k" b)])
-    :noop    (rt/dispatch! frame-id [:topo/noop-write]))
-  (mount/settle!)
-  (let [{:keys [list row chunk markup]} (arms/runs)]
+    :sparse  (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:topo/bump target])
+    :bulk    (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:topo/bump-all])
+    :reorder (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:topo/rotate])
+    :edit    (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:topo/edit target (str "k" b)])
+    :noop    (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:topo/noop-write]))
+  (rf.bench.hicasso.arm1.mount/settle!)
+  (let [{:keys [list row chunk markup]} (rf.bench.hicasso.topo.arms/runs)]
     {:bodies     (+ list row chunk)
      :list       list
      :row-bodies (+ row chunk)
      :markup     markup
-     :runtime    (rt/body-runs)}))
+     :runtime    (rf.bench.hicasso.arm1.runtime/body-runs)}))
 
 ;; ---------------------------------------------------------------------------
 ;; The record every row appends to
@@ -159,10 +159,10 @@
 (defn- structure-of
   "What the mounted page actually is."
   [handle]
-  (let [{:keys [boundaries edges]} (rt/stats)]
+  (let [{:keys [boundaries edges]} (rf.bench.hicasso.arm1.runtime/stats)]
     {:boundaries    boundaries
      :edges         edges
-     :elements      (lane/element-count (:container handle))
+     :elements      (rf.bench.hicasso.lane/element-count (:container handle))
      ;; `.-length`, not `count`: a `NodeList` implements no CLJS protocol,
      ;; so `count` throws `ICounted` rather than answering — which errored
      ;; all twelve structural cells on this file's first run and is worth a
@@ -170,40 +170,40 @@
      :rendered-rows (.-length (.querySelectorAll (:container handle) "li.topo-row"))}))
 
 (deftest every-arm-is-the-topology-it-claims
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
-    (doseq [b   m/row-counts
-            arm arms/arm-ids]
+    (doseq [b   rf.bench.hicasso.topo.model/row-counts
+            arm rf.bench.hicasso.topo.arms/arm-ids]
       (testing (str arm " at " b " rows")
         (fresh! b)
-        (let [handle (mount! (arms/view-of arm))]
+        (let [handle (mount! (rf.bench.hicasso.topo.arms/view-of arm))]
           (try
-            (is (= (arms/expected arm b) (structure-of handle))
+            (is (= (rf.bench.hicasso.topo.arms/expected arm b) (structure-of handle))
                 (str arm " at B=" b " must hold exactly the boundaries, read edges,
                      elements and rendered rows its arithmetic predicts — a number
                      accepted from the DOM would re-baseline the tournament instead
                      of gating it"))
-            (finally (mount/release! handle))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! handle))))))))
 
 (deftest the-row-family-read-set-cannot-oscillate
   (testing "set stability is a GATE on the coarse arm, not a tiebreak — so it
            is asserted rather than argued: the same page after every one of the
            four operations holds the same read-edge count it mounted with"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
-      (doseq [arm arms/arm-ids]
+      (doseq [arm rf.bench.hicasso.topo.arms/arm-ids]
         (let [b 100]
           (fresh! b)
-          (let [handle (mount! (arms/view-of arm))
-                mounted (:edges (rt/stats))]
+          (let [handle (mount! (rf.bench.hicasso.topo.arms/view-of arm))
+                mounted (:edges (rf.bench.hicasso.arm1.runtime/stats))]
             (try
               (doseq [op [:sparse :bulk :reorder :edit]]
                 (restore! b)
                 (operate! op b)
-                (is (= mounted (:edges (rt/stats)))
+                (is (= mounted (:edges (rf.bench.hicasso.arm1.runtime/stats)))
                     (str arm "'s read set moved under " op " — the coarse arm's
                          precondition is broken and no arm's figure may publish")))
-              (finally (mount/release! handle)))))))))
+              (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 — the census itself: work per arm, per operation, per row count
@@ -217,15 +217,15 @@
   commit costs on a page that is already there."
   []
   (reset! !record [])
-  (doseq [b   m/row-counts
-          arm arms/arm-ids]
+  (doseq [b   rf.bench.hicasso.topo.model/row-counts
+          arm rf.bench.hicasso.topo.arms/arm-ids]
     (fresh! b)
-    (let [handle (mount! (arms/view-of arm))]
+    (let [handle (mount! (rf.bench.hicasso.topo.arms/view-of arm))]
       (try
         (doseq [op [:sparse :bulk :reorder :edit]]
           (restore! b)
           (record! arm b op (operate! op b)))
-        (finally (mount/release! handle)))))
+        (finally (rf.bench.hicasso.arm1.mount/release! handle)))))
   @!record)
 
 (defn- ensure-census!
@@ -240,7 +240,7 @@
   @!record)
 
 (deftest the-work-census
-  (if-not (mount/browser?)
+  (if-not (rf.bench.hicasso.arm1.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (ensure-census!)
@@ -249,7 +249,7 @@
             (str arm "/" op " at B=" b ": this file's body count and the
                  runtime's own `body-runs` are two instruments sharing no
                  traversal, and they must agree"))
-        (is (<= markup (m/rendered-rows arm b))
+        (is (<= markup (rf.bench.hicasso.topo.model/rendered-rows arm b))
             (str arm "/" op " at B=" b " built more rows of markup than the page
                  renders, which is not a topology — it is a bug"))))))
 
@@ -264,28 +264,28 @@
   (testing "a one-row write builds ONE row of markup under `fine`, and every
            rendered row under `coarse`. That gap is the tournament's whole
            sparse result and it grows exactly with B"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
-      (doseq [b m/row-counts]
+      (doseq [b rf.bench.hicasso.topo.model/row-counts]
         (is (= 1 (:markup (work-at :fine b :sparse)))
             (str "fine/sparse at B=" b))
         (is (= b (:markup (work-at :coarse b :sparse)))
             (str "coarse/sparse at B=" b " — the coarse arm has no way to build
                  fewer, which is the price its cheap bulk is bought with"))
-        (is (<= (:markup (work-at :chunked b :sparse)) m/chunk-size)
+        (is (<= (:markup (work-at :chunked b :sparse)) rf.bench.hicasso.topo.model/chunk-size)
             (str "chunked/sparse at B=" b " is bounded by k, not by B"))))))
 
 (deftest the-bulk-finding
   (testing "an all-row write builds every rendered row under EVERY un-windowed
            arm — so on markup alone bulk cannot separate them, and whatever
            separates them there is not the number of rows built"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
-      (doseq [b m/row-counts]
+      (doseq [b rf.bench.hicasso.topo.model/row-counts]
         (doseq [arm [:fine :coarse :chunked]]
           (is (= b (:markup (work-at arm b :bulk)))
               (str arm "/bulk at B=" b)))
-        (is (= (min b m/window-size) (:markup (work-at :virtual b :bulk)))
+        (is (= (min b rf.bench.hicasso.topo.model/window-size) (:markup (work-at :virtual b :bulk)))
             (str "virtual/bulk at B=" b " builds only its window — a different
                  page, and the only arm whose bulk cost does not scale with B"))))))
 
@@ -293,9 +293,9 @@
   (testing "a permutation moves NO row's reads. Under `fine` the list re-runs
            and every row memo-bails, so zero rows of markup are built for a
            table that visibly reorders; under `coarse` all B are rebuilt"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
-      (doseq [b m/row-counts]
+      (doseq [b rf.bench.hicasso.topo.model/row-counts]
         (is (= 0 (:markup (work-at :fine b :reorder)))
             (str "fine/reorder at B=" b " — React moves DOM nodes and runs no
                  body, which is the strongest single result in this census"))
@@ -307,9 +307,9 @@
            row's own draft cell, so it separates the arms exactly as `sparse`
            does — the pipeline in front of it is rf2-hic-045's, not this
            tournament's"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
-      (doseq [b m/row-counts]
+      (doseq [b rf.bench.hicasso.topo.model/row-counts]
         (is (= 1 (:markup (work-at :fine b :edit))) (str "fine/edit at B=" b))
         (is (= b (:markup (work-at :coarse b :edit))) (str "coarse/edit at B=" b))))))
 
@@ -320,31 +320,31 @@
 (deftest the-negative-control-a-write-no-arm-reads
   (testing "the counts above are counting rather than failing to look: a commit
            that moves a key no arm holds moves no body in any arm"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
-      (doseq [arm arms/arm-ids]
+      (doseq [arm rf.bench.hicasso.topo.arms/arm-ids]
         (let [b 100]
           (fresh! b)
-          (let [handle (mount! (arms/view-of arm))]
+          (let [handle (mount! (rf.bench.hicasso.topo.arms/view-of arm))]
             (try
               (restore! b)
               (let [work (operate! :noop b)]
                 (is (= 0 (:bodies work)) (str arm " ran a body on an unread write"))
                 (is (= 0 (:markup work)) (str arm " built markup on an unread write")))
-              (finally (mount/release! handle)))))))))
+              (finally (rf.bench.hicasso.arm1.mount/release! handle)))))))))
 
 (deftest the-census-rejects-a-broken-arm
   (testing "THE SABOTAGE CONTROL. `sabotage-list` is `fine` with one extra read
            per row — the shared view-model — so a one-row write invalidates all
            B. Its DOM is byte-identical to `fine`'s, so only the census can tell
            them apart, and it must"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (let [b 100]
         (fresh! b)
         (let [handle (mount! sabotage-list)]
           (try
-            (is (not= (:edges (arms/expected :fine b)) (:edges (rt/stats)))
+            (is (not= (:edges (rf.bench.hicasso.topo.arms/expected :fine b)) (:edges (rf.bench.hicasso.arm1.runtime/stats)))
                 "the structural check rejects it: the broken arm holds more read
                  edges than fine's arithmetic allows")
             (restore! b)
@@ -355,25 +355,25 @@
               (is (not= 1 (:markup work))
                   "which is the assertion `the-sparse-finding` would have made
                    about a healthy arm, failing here as it must"))
-            (finally (mount/release! handle))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! handle))))))))
 
 (deftest the-sabotage-arm-really-is-fine-in-every-other-respect
   (testing "without this the control proves only that a DIFFERENT PAGE behaves
            differently. The two arms build the same DOM, so the census's red
            above is about the read topology and nothing else"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (let [b 100]
-        (lane/leave-act-environment!)
-        (m/make-frame! frame-id b)
-        (m/reseed! frame-id b)
-        (let [healthy (mount! (arms/view-of :fine))
-              a       (lane/canonical (:container healthy))
-              _       (mount/release! healthy)
-              _       (m/reseed! frame-id b)
+        (rf.bench.hicasso.lane/leave-act-environment!)
+        (rf.bench.hicasso.topo.model/make-frame! frame-id b)
+        (rf.bench.hicasso.topo.model/reseed! frame-id b)
+        (let [healthy (mount! (rf.bench.hicasso.topo.arms/view-of :fine))
+              a       (rf.bench.hicasso.lane/canonical (:container healthy))
+              _       (rf.bench.hicasso.arm1.mount/release! healthy)
+              _       (rf.bench.hicasso.topo.model/reseed! frame-id b)
               broken  (mount! sabotage-list)
-              c       (lane/canonical (:container broken))]
-          (mount/release! broken)
+              c       (rf.bench.hicasso.lane/canonical (:container broken))]
+          (rf.bench.hicasso.arm1.mount/release! broken)
           (is (= a c) "same markup, same keys, same attributes")
           (is (re-find #"topo-row" a) "and the comparison is of a real table"))))))
 
@@ -384,11 +384,11 @@
 (deftest emit-the-census
   (testing "the table this file exists to produce, printed as EDN so the
            tournament page transcribes rather than retypes it"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (do
         (js/console.log (str ";; TOPO-CENSUS "
                              (pr-str (sort-by (juxt :op :b :arm) (ensure-census!)))))
-        (is (= (* (count arms/arm-ids) (count m/row-counts) 4) (count @!record))
+        (is (= (* (count rf.bench.hicasso.topo.arms/arm-ids) (count rf.bench.hicasso.topo.model/row-counts) 4) (count @!record))
             "every arm x row count x operation cell is present — a gap in the
              table must fail here rather than be read as a pass")))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/topo/clock_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/topo/clock_app.cljs
@@ -136,7 +136,7 @@
 
   `batch-k` commits of one operation on one already-mounted page, under
   ONE clock, then — with the clock stopped — two cell-addressed probes
-  read back and banked into `lane/tally`. The batch is `rf2-9zysg`'s
+  read back and banked into `rf.bench.hicasso.lane/tally`. The batch is `rf2-9zysg`'s
   repair for Chrome's 100 µs clamp and the same number the control uses;
   the read-back is `control-app`'s, cell-addressed by `data-testid`
   rather than by the row's own text, because a row's text node
@@ -164,13 +164,13 @@
   [§1.4](../../../../../../../docs/design/hicasso/product/topology-tournament.md#14-the-estimand-and-the-one-substitution-that-is-refused)
   forbids a work census standing in for a clock, and a driver that printed
   them in one table would be doing exactly that."
-  (:require [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.topo.arms :as arms]
-            [re-frame.bench.hicasso.topo.control-app :as ctl]
-            [re-frame.bench.hicasso.topo.model :as m]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.topo.arms :as rf.bench.hicasso.topo.arms]
+            [re-frame.bench.hicasso.topo.control-app :as rf.bench.hicasso.topo.control-app]
+            [re-frame.bench.hicasso.topo.model :as rf.bench.hicasso.topo.model]
             [re-frame.core :as rf]))
 
 ;; ---------------------------------------------------------------------------
@@ -182,9 +182,9 @@
 
   Three of the tournament's four, and the missing one is a RULING rather
   than an omission — see [[unaddressed]]. The order is the roster's own
-  (`arms/arm-ids` less the unaddressed arm), so a reader comparing this
+  (`rf.bench.hicasso.topo.arms/arm-ids` less the unaddressed arm), so a reader comparing this
   table against the census reads the columns in the same order."
-  (into [] (remove #{:virtual}) arms/arm-ids))
+  (into [] (remove #{:virtual}) rf.bench.hicasso.topo.arms/arm-ids))
 
 (def unaddressed
   "The arms this driver deliberately starts no clock on, with the reason
@@ -224,7 +224,7 @@
   "`B ∈ {100, 300, 1000}` — the tournament's own, read from the model
   rather than restated, so the clock table and the census table are
   about the same three pages."
-  m/row-counts)
+  rf.bench.hicasso.topo.model/row-counts)
 
 (def target
   "The row `sparse` and `edit` move, and the row `reorder`'s unchanged
@@ -252,15 +252,15 @@
   `control-app` already carries the value this lane batches at; two
   numbers for one decision is how a table comes to be taken at a depth
   its control was never certified at."
-  ctl/batch-k)
+  rf.bench.hicasso.topo.control-app/batch-k)
 
 (def sampling
   "The control's sampling, for the same reason [[batch-k]] is the
   control's: a cell licensed by a control taken at one depth and measured
   at another is licensed by an experiment that was not run."
-  ctl/sampling)
+  rf.bench.hicasso.topo.control-app/sampling)
 
-(def rounds ctl/rounds)
+(def rounds rf.bench.hicasso.topo.control-app/rounds)
 
 ;; ---------------------------------------------------------------------------
 ;; The deterministic gate every cell passes BEFORE its clock starts
@@ -285,7 +285,7 @@
     (:sparse :edit) (case arm
                       :fine    1
                       :coarse  b
-                      :chunked (min m/chunk-size b))
+                      :chunked (min rf.bench.hicasso.topo.model/chunk-size b))
     :bulk           b
     :reorder        (case arm
                       :fine    0
@@ -319,23 +319,23 @@
   counter."
   [op b committed]
   (case op
-    :sparse  [{:probe :changed   :cell [:n target]              :want (str (+ (:n (m/row target)) committed))}
-              {:probe :unchanged :cell [:n unchanged-probe]     :want (str (:n (m/row unchanged-probe)))}]
+    :sparse  [{:probe :changed   :cell [:n target]              :want (str (+ (:n (rf.bench.hicasso.topo.model/row target)) committed))}
+              {:probe :unchanged :cell [:n unchanged-probe]     :want (str (:n (rf.bench.hicasso.topo.model/row unchanged-probe)))}]
     ;; A broad write leaves no unchanged cell to read, so the second probe is
-    ;; the FAR END of the table — `lane/bulk-probes`' rule, in this file's
+    ;; the FAR END of the table — `rf.bench.hicasso.lane/bulk-probes`' rule, in this file's
     ;; cell-addressed spelling: a commit that got as far as the front of the
     ;; page and no further satisfies the first probe on its own.
-    :bulk    [{:probe :changed   :cell [:n target]              :want (str (+ (:n (m/row target)) committed))}
-              {:probe :far-end   :cell [:n (dec b)]             :want (str (+ (:n (m/row (dec b))) committed))}]
+    :bulk    [{:probe :changed   :cell [:n target]              :want (str (+ (:n (rf.bench.hicasso.topo.model/row target)) committed))}
+              {:probe :far-end   :cell [:n (dec b)]             :want (str (+ (:n (rf.bench.hicasso.topo.model/row (dec b))) committed))}]
     ;; A permutation moves the ORDER and no row's data, so the pair reads
     ;; one of each: the head of the list must have rotated exactly
     ;; `committed` places, and the target row's own `n` must not have moved
     ;; at all.
     :reorder [{:probe :changed   :cell [:head]                  :want (str (mod committed b))}
-              {:probe :unchanged :cell [:n target]              :want (str (:n (m/row target)))}]
+              {:probe :unchanged :cell [:n target]              :want (str (:n (rf.bench.hicasso.topo.model/row target)))}]
     :edit    [{:probe :changed   :cell [:draft target]          :want (draft-value committed)}
               {:probe :unchanged :cell [:draft unchanged-probe] :want ""}]
-    :noop    [{:probe :unchanged :cell [:n target]              :want (str (:n (m/row target)))}
+    :noop    [{:probe :unchanged :cell [:n target]              :want (str (:n (rf.bench.hicasso.topo.model/row target)))}
               {:probe :unchanged :cell [:head]                  :want "0"}]))
 
 (defn- read-cell
@@ -373,11 +373,11 @@
   satisfied by a commit that never happened."
   [frame-id op committed]
   (case op
-    :sparse  (rt/dispatch! frame-id [:topo/bump target])
-    :bulk    (rt/dispatch! frame-id [:topo/bump-all])
-    :reorder (rt/dispatch! frame-id [:topo/rotate])
-    :edit    (rt/dispatch! frame-id [:topo/edit target (draft-value (inc committed))])
-    :noop    (rt/dispatch! frame-id [:topo/noop-write])))
+    :sparse  (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:topo/bump target])
+    :bulk    (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:topo/bump-all])
+    :reorder (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:topo/rotate])
+    :edit    (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:topo/edit target (draft-value (inc committed))])
+    :noop    (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:topo/noop-write])))
 
 (defn window!
   "[[batch-k]] commits of `op` on `page` under ONE clock, then — with the
@@ -386,7 +386,7 @@
   Answers the elapsed milliseconds for the whole batch.
 
   The read-back is outside the window and after the last drain, which is
-  the batched shape `lane/verified-writes!` documents and defends: no
+  the batched shape `rf.bench.hicasso.lane/verified-writes!` documents and defends: no
   macrotask runs between the first write and the last drain, so a commit
   React has parked cannot land inside the window however many microtasks
   pass. What the batch relaxes is microtask-scale lateness, on a
@@ -397,14 +397,14 @@
   window touches shared state that the clock would then be measuring."
   [t {:keys [frame-id container b committed]} op]
   (let [start @committed
-        t0    (lane/now-ms)]
+        t0    (rf.bench.hicasso.lane/now-ms)]
     (dotimes [i batch-k]
       (write! frame-id op (+ start i))
-      (mount/settle!))
-    (let [ms     (- (lane/now-ms) t0)
+      (rf.bench.hicasso.arm1.mount/settle!))
+    (let [ms     (- (rf.bench.hicasso.lane/now-ms) t0)
           total  (swap! committed + batch-k)
           misses (probe-misses container op b total)]
-      ;; `lane/verified-writes!`'s own `bank!`, over this file's probes: one
+      ;; `rf.bench.hicasso.lane/verified-writes!`'s own `bank!`, over this file's probes: one
       ;; tally, one meaning of "verified", one `assert-verified!`.
       (swap! t (fn [{:keys [of bad]}]
                  {:of (+ of (count (expectations op b total)))
@@ -424,13 +424,13 @@
 (defn- structure-of
   "`container`'s own structure. `:boundaries` and `:edges` come from a
   DELTA against the runtime's live table, because all three arms' pages
-  are mounted at once and `rt/stats` counts every live cell in the
+  are mounted at once and `rf.bench.hicasso.arm1.runtime/stats` counts every live cell in the
   process rather than one container's."
   [container before]
-  (let [{:keys [boundaries edges]} (rt/stats)]
+  (let [{:keys [boundaries edges]} (rf.bench.hicasso.arm1.runtime/stats)]
     {:boundaries    (- boundaries (:boundaries before))
      :edges         (- edges (:edges before))
-     :elements      (lane/element-count container)
+     :elements      (rf.bench.hicasso.lane/element-count container)
      :rendered-rows (.-length (.querySelectorAll container "li.topo-row"))}))
 
 (defn- mount-page!
@@ -439,9 +439,9 @@
   mounted, taken as a delta against `before`."
   [arm b before]
   (let [frame-id (get frame-ids [arm b])]
-    (m/make-frame! frame-id b)
-    (m/reseed! frame-id b)
-    (let [handle (mount/root! (mount/fresh-container!) frame-id [(arms/view-of arm) {}])]
+    (rf.bench.hicasso.topo.model/make-frame! frame-id b)
+    (rf.bench.hicasso.topo.model/reseed! frame-id b)
+    (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [(rf.bench.hicasso.topo.arms/view-of arm) {}])]
       {:arm       arm
        :b         b
        :frame-id  frame-id
@@ -455,8 +455,8 @@
   clock. The commit counter is zeroed AFTER the settle, so the probe
   arithmetic of the row about to run starts where the seed does."
   [{:keys [frame-id committed b]}]
-  (rt/dispatch! frame-id [:topo/seed b m/window-size])
-  (mount/settle!)
+  (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:topo/seed b rf.bench.hicasso.topo.model/window-size])
+  (rf.bench.hicasso.arm1.mount/settle!)
   (reset! committed 0)
   nil)
 
@@ -467,11 +467,11 @@
   The counters are a single shared atom, so this runs one page at a time
   and resets immediately before its commit."
   [page op]
-  (arms/reset-counters!)
+  (rf.bench.hicasso.topo.arms/reset-counters!)
   (write! (:frame-id page) op @(:committed page))
-  (mount/settle!)
+  (rf.bench.hicasso.arm1.mount/settle!)
   (swap! (:committed page) inc)
-  (:markup (arms/runs)))
+  (:markup (rf.bench.hicasso.topo.arms/runs)))
 
 ;; ---------------------------------------------------------------------------
 ;; One row of the table — one operation, one row count, every measured arm
@@ -490,7 +490,7 @@
   the topology or it is the floor, and the floor row is measured so a
   reader can tell which."
   [pages op b]
-  (let [t     (lane/tally)
+  (let [t     (rf.bench.hicasso.lane/tally)
         legs  (mapv (fn [arm] {:id arm}) measured-arms)]
     (doseq [arm measured-arms] (reseed-page! (get pages arm)))
     (let [built (into {} (map (fn [arm] [arm (markup-of (get pages arm) op)])) measured-arms)
@@ -500,7 +500,7 @@
                      "publishes for it, so the clock is about to read a page the tournament "
                      "is not about — expected " (pr-str want) ", built " (pr-str built))}
         (let [{:keys [readings samples]}
-              (lane/rounds! legs sampling rounds
+              (rf.bench.hicasso.lane/rounds! legs sampling rounds
                             (fn [a] (window! t (get pages (:id a)) op))
                             (fn [a] (str (name (:id a)) "/" (name op) "@" b)))
               ;; One p50 per arm per round — the within-round median every
@@ -508,10 +508,10 @@
               ;; caller so a published row cannot be read as a mean of
               ;; samples (rf2-pqyxz's correction, on the other instrument).
               per-round (mapv (fn [r]
-                                (into {} (map (fn [[id xs]] [id (:p50 (lane/summarise xs))])) r))
+                                (into {} (map (fn [[id xs]] [id (:p50 (rf.bench.hicasso.lane/summarise xs))])) r))
                               readings)
               centre    (into {} (map (fn [arm]
-                                        [arm (lane/summarise (mapv #(get % arm) per-round))]))
+                                        [arm (rf.bench.hicasso.lane/summarise (mapv #(get % arm) per-round))]))
                               measured-arms)]
           {:markup    built
            :cells     centre
@@ -521,9 +521,9 @@
            ;; is the honesty flag: a range containing 1.0 means the two arms
            ;; are INDISTINGUISHABLE here and the row says so rather than
            ;; quoting a mean as a winner.
-           :ratios    (into {} (map (fn [arm] [arm (lane/ratio-between per-round arm :fine)]))
+           :ratios    (into {} (map (fn [arm] [arm (rf.bench.hicasso.lane/ratio-between per-round arm :fine)]))
                             (remove #{:fine} measured-arms))
-           :guard     (lane/guard! samples (str "topo clock " (name op) " @B=" b))
+           :guard     (rf.bench.hicasso.lane/guard! samples (str "topo clock " (name op) " @B=" b))
            :tally     t})))))
 
 ;; ---------------------------------------------------------------------------
@@ -560,7 +560,7 @@
               :let [f (get-in table [[floor-op b] :cells arm :p50])
                     o (get-in table [[op b] :cells arm :p50])]
               :when (and f o (pos? o))]
-          [[arm op b] (lane/round4 (/ f o))])))
+          [[arm op b] (rf.bench.hicasso.lane/round4 (/ f o))])))
 
 ;; ---------------------------------------------------------------------------
 ;; The control, called rather than reimplemented
@@ -580,17 +580,17 @@
   the caller takes no cell for that arm, which is §1.5 as registered."
   []
   (reduce (fn [acc arm]
-            (let [r (ctl/run-arm! arm)]
+            (let [r (rf.bench.hicasso.topo.control-app/run-arm! arm)]
               (if-let [f (:fatal r)]
                 (reduced (assoc acc arm {:ok? false :why f}))
                 (do
-                  (lane/record! (keyword (str "control-" (name arm)))
+                  (rf.bench.hicasso.lane/record! (keyword (str "control-" (name arm)))
                                 (select-keys r [:verdict :structure :markup]))
                   (when (:refuse? (:guard r))
                     (set! (.-HICASSO_GUARD_REFUSED js/window) true))
                   ;; The lane's ONE adjudication of a read-back. It throws, and
                   ;; it is called AFTER the record above is published.
-                  (lane/assert-verified! (:tally r)
+                  (rf.bench.hicasso.lane/assert-verified! (:tally r)
                                          (str "topo clock control (" (name arm) ")"))
                   (assoc acc arm (:verdict r))))))
           {}
@@ -612,35 +612,35 @@
   []
   (reduce
     (fn [table b]
-      (let [pages (reduce (fn [acc arm] (assoc acc arm (mount-page! arm b (rt/stats))))
+      (let [pages (reduce (fn [acc arm] (assoc acc arm (mount-page! arm b (rf.bench.hicasso.arm1.runtime/stats))))
                           {} measured-arms)]
         (try
           (let [wrong (into [] (remove (fn [arm]
-                                         (= (select-keys (arms/expected arm b)
+                                         (= (select-keys (rf.bench.hicasso.topo.arms/expected arm b)
                                                          [:boundaries :edges :elements :rendered-rows])
                                             (:structure (get pages arm)))))
                             measured-arms)]
             (when (seq wrong)
               (throw (ex-info (str "at B=" b " these pages are not the arms they claim: "
                                    (pr-str (into {} (map (fn [arm]
-                                                           [arm {:expected (arms/expected arm b)
+                                                           [arm {:expected (rf.bench.hicasso.topo.arms/expected arm b)
                                                                  :mounted  (:structure (get pages arm))}]))
                                                  wrong)))
                               {:b b :arms wrong})))
             (reduce (fn [acc op]
                       (let [r (run-row! pages op b)]
                         (when-let [f (:fatal r)] (throw (ex-info f {:op op :b b})))
-                        (lane/record! (keyword (str (name op) "-" b))
+                        (rf.bench.hicasso.lane/record! (keyword (str (name op) "-" b))
                                       (select-keys r [:markup :cells :ratios]))
                         (when (:refuse? (:guard r))
                           (set! (.-HICASSO_GUARD_REFUSED js/window) true))
-                        (lane/assert-verified! (:tally r)
+                        (rf.bench.hicasso.lane/assert-verified! (:tally r)
                                                (str "topo clock " (name op) " @B=" b))
                         (assoc acc [op b] r)))
                     table
                     rows))
           (finally
-            (doseq [arm measured-arms] (mount/release! (:handle (get pages arm))))))))
+            (doseq [arm measured-arms] (rf.bench.hicasso.arm1.mount/release! (:handle (get pages arm))))))))
     {}
     row-counts))
 
@@ -649,11 +649,11 @@
 ;; ---------------------------------------------------------------------------
 
 (defn ^:export -main []
-  (rf/init! uix-adapter/adapter)
-  (lane/leave-act-environment!)
-  (lane/self-test!)
+  (rf/init! rf.adapter.uix/adapter)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/self-test!)
   (try
-    (lane/record! :design
+    (rf.bench.hicasso.lane/record! :design
                   {:arms        measured-arms
                    :unaddressed unaddressed
                    :operations  operations
@@ -665,29 +665,29 @@
                    :target      target
                    :markup      (into {} (for [b row-counts op rows arm measured-arms]
                                            [[arm op b] (markup-expected arm op b)]))})
-    (lane/record! :runtime (lane/runtime-label))
+    (rf.bench.hicasso.lane/record! :runtime (rf.bench.hicasso.lane/runtime-label))
     ;; THE CONTROL RUNS FIRST AND ALONE. If it refuses, the tournament's
     ;; clock half refuses with it and the cells are never taken — which is a
     ;; result, not a failure.
     (let [controls (run-controls!)]
-      (lane/record! :controls (into {} (map (fn [[arm v]] [arm (select-keys v [:predicted :band :rounds :ok? :why])]))
+      (rf.bench.hicasso.lane/record! :controls (into {} (map (fn [[arm v]] [arm (select-keys v [:predicted :band :rounds :ok? :why])]))
                                     controls))
       (if-not (every? :ok? (vals controls))
         (do
           (set! (.-HICASSO_CONTROL_FAILED js/window) true)
-          (lane/fail! (str "the registered positive control refused on "
+          (rf.bench.hicasso.lane/fail! (str "the registered positive control refused on "
                            (pr-str (into [] (comp (remove (comp :ok? val)) (map key)) controls))
                            " — no clock cell is taken for an arm whose instrument is not certified, "
                            "which is topology-tournament.md §1.5 as registered")))
         (let [table (run-table!)]
-          (lane/record! :floor-share (floor-shares table))
-          (lane/record! :summary
+          (rf.bench.hicasso.lane/record! :floor-share (floor-shares table))
+          (rf.bench.hicasso.lane/record! :summary
                         (into {} (for [[[op b] r] table]
-                                   [[op b] {:cells  (into {} (map (fn [[arm s]] [arm (lane/round4 (:p50 s))])) (:cells r))
+                                   [[op b] {:cells  (into {} (map (fn [[arm s]] [arm (rf.bench.hicasso.lane/round4 (:p50 s))])) (:cells r))
                                             :ratios (into {} (map (fn [[arm v]]
                                                                     [arm (select-keys v [:mean :min :max :straddles-1?])]))
                                                           (:ratios r))}]))))))
     (catch :default e
       (set! (.-HICASSO_CONTROL_FAILED js/window) true)
-      (lane/fail! (str "topo clock threw: " (or (ex-message e) (.-message e))))))
-  (lane/done!))
+      (rf.bench.hicasso.lane/fail! (str "topo clock threw: " (or (ex-message e) (.-message e))))))
+  (rf.bench.hicasso.lane/done!))

--- a/bench/hicasso/src/re_frame/bench/hicasso/topo/clock_witness_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/topo/clock_witness_dom_cljs_test.cljs
@@ -31,7 +31,7 @@
      proves the source changed; it does not prove the runtime observed
      the plant. So the witness below mounts a real arm and drives
      `clock-app/window!` itself — the same function the clock run calls,
-     banking into the same `lane/tally` — with the ONE difference that
+     banking into the same `rf.bench.hicasso.lane/tally` — with the ONE difference that
      the commits are dispatched into a frame nothing is mounted over. The
      page therefore never moves while the clock runs and the probes read
      it afterwards, which is the exact fault the read-back exists to
@@ -45,21 +45,21 @@
   they touch no DOM — and every DOM claim degrades to a stated skip
   there."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.topo.arms :as arms]
-            [re-frame.bench.hicasso.topo.clock-app :as clock]
-            [re-frame.bench.hicasso.topo.model :as m]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.topo.arms :as rf.bench.hicasso.topo.arms]
+            [re-frame.bench.hicasso.topo.clock-app :as rf.bench.hicasso.topo.clock-app]
+            [re-frame.bench.hicasso.topo.model :as rf.bench.hicasso.topo.model]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (defn- skip! [why]
   (is true (str "the topology clock witness needs a real React DOM — " why)))
@@ -73,12 +73,12 @@
            tournament's committed window. A driver that measured it anyway and
            labelled the number would publish a figure a reader can quote, so it
            is absent from the roster and its reason travels in the file"
-    (is (= [:fine :coarse :chunked] clock/measured-arms))
-    (is (= #{:virtual} (set (keys clock/unaddressed))))
-    (is (re-find #"rf2-4t36" (:virtual clock/unaddressed))
+    (is (= [:fine :coarse :chunked] rf.bench.hicasso.topo.clock-app/measured-arms))
+    (is (= #{:virtual} (set (keys rf.bench.hicasso.topo.clock-app/unaddressed))))
+    (is (re-find #"rf2-4t36" (:virtual rf.bench.hicasso.topo.clock-app/unaddressed))
         "the reason names the ruling that made it, not this file")
-    (is (= (set arms/arm-ids)
-           (into (set clock/measured-arms) (keys clock/unaddressed)))
+    (is (= (set rf.bench.hicasso.topo.arms/arm-ids)
+           (into (set rf.bench.hicasso.topo.clock-app/measured-arms) (keys rf.bench.hicasso.topo.clock-app/unaddressed)))
         "every arm of the tournament is either measured or unaddressed — an arm
          that fell out of both lists would vanish from the table silently")))
 
@@ -86,9 +86,9 @@
   (testing "`:noop` is measured beside the cells and is not a cell. Folding it
            into `operations` would put a row in the published table that the
            tournament never registered"
-    (is (= [:sparse :bulk :reorder :edit] clock/operations))
-    (is (not (contains? (set clock/operations) clock/floor-op)))
-    (is (= (conj clock/operations clock/floor-op) clock/rows))))
+    (is (= [:sparse :bulk :reorder :edit] rf.bench.hicasso.topo.clock-app/operations))
+    (is (not (contains? (set rf.bench.hicasso.topo.clock-app/operations) rf.bench.hicasso.topo.clock-app/floor-op)))
+    (is (= (conj rf.bench.hicasso.topo.clock-app/operations rf.bench.hicasso.topo.clock-app/floor-op) rf.bench.hicasso.topo.clock-app/rows))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 — the pre-clock gate is the census's published table
@@ -118,20 +118,20 @@
   (testing "a clock cell is only taken on a page that builds the markup the
            census publishes for it, so the arithmetic that decides it must be
            that census and not a near neighbour of it"
-    (doseq [b  m/row-counts
-            op clock/operations]
+    (doseq [b  rf.bench.hicasso.topo.model/row-counts
+            op rf.bench.hicasso.topo.clock-app/operations]
       (is (= (get published-markup [op b])
-             (into {} (map (fn [arm] [arm (clock/markup-expected arm op b)]))
-                   clock/measured-arms))
+             (into {} (map (fn [arm] [arm (rf.bench.hicasso.topo.clock-app/markup-expected arm op b)]))
+                   rf.bench.hicasso.topo.clock-app/measured-arms))
           (str op " at B=" b)))))
 
 (deftest the-floor-row-builds-nothing-in-any-arm
   (testing "`[:topo/noop-write]` moves a key no arm reads, so the floor window
            holds the per-commit cost and no row of markup. A floor that built
            markup would be measuring an operation"
-    (doseq [b   m/row-counts
-            arm clock/measured-arms]
-      (is (= 0 (clock/markup-expected arm clock/floor-op b))
+    (doseq [b   rf.bench.hicasso.topo.model/row-counts
+            arm rf.bench.hicasso.topo.clock-app/measured-arms]
+      (is (= 0 (rf.bench.hicasso.topo.clock-app/markup-expected arm rf.bench.hicasso.topo.clock-app/floor-op b))
           (str arm " at B=" b)))))
 
 ;; ---------------------------------------------------------------------------
@@ -142,9 +142,9 @@
   (testing "a changed probe alone is satisfied by a write that reached every
            row and by a page rebuilt from a stale seed. The second half of
            every pair is what refuses both"
-    (doseq [b  m/row-counts
-            op clock/rows]
-      (let [es (clock/expectations op b 20)]
+    (doseq [b  rf.bench.hicasso.topo.model/row-counts
+            op rf.bench.hicasso.topo.clock-app/rows]
+      (let [es (rf.bench.hicasso.topo.clock-app/expectations op b 20)]
         (is (= 2 (count es)) (str op " at B=" b " must carry exactly two probes"))
         (is (not= #{:changed} (set (map :probe es)))
             (str op " at B=" b " is verified by changed probes alone"))
@@ -155,9 +155,9 @@
   (testing "the read-back's whole arithmetic: whatever the operation moves must
            be a pure function of the commit count, or a window that committed
            nineteen of its twenty writes reads as verified"
-    (doseq [b  m/row-counts
-            op clock/operations]
-      (let [changed (fn [n] (->> (clock/expectations op b n)
+    (doseq [b  rf.bench.hicasso.topo.model/row-counts
+            op rf.bench.hicasso.topo.clock-app/operations]
+      (let [changed (fn [n] (->> (rf.bench.hicasso.topo.clock-app/expectations op b n)
                                  (remove (comp #{:unchanged} :probe))
                                  (map :want)
                                  vec))]
@@ -170,10 +170,10 @@
   (testing "the negative control, written as a read-back: a window over a
            commit no arm reads must leave the page exactly where the seed put
            it, and BOTH probes say so"
-    (doseq [b m/row-counts]
-      (let [es (clock/expectations clock/floor-op b 20)]
+    (doseq [b rf.bench.hicasso.topo.model/row-counts]
+      (let [es (rf.bench.hicasso.topo.clock-app/expectations rf.bench.hicasso.topo.clock-app/floor-op b 20)]
         (is (= [:unchanged :unchanged] (mapv :probe es)) (str "at B=" b))
-        (is (= (mapv :want es) (mapv :want (clock/expectations clock/floor-op b 40)))
+        (is (= (mapv :want es) (mapv :want (rf.bench.hicasso.topo.clock-app/expectations rf.bench.hicasso.topo.clock-app/floor-op b 40)))
             (str "at B=" b ": and the expectation does not depend on how many
                  no-op commits ran, because none of them may reach the page"))))))
 
@@ -189,12 +189,12 @@
   "One real `fine` page at [[witness-b]] rows, seeded. Answers the page map
   `clock-app/window!` takes."
   []
-  (lane/leave-act-environment!)
-  (m/make-frame! page-frame witness-b)
-  (m/reseed! page-frame witness-b)
-  (arms/reset-counters!)
-  (let [handle (mount/root! (mount/fresh-container!) page-frame
-                            [(arms/view-of :fine) {}])]
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.topo.model/make-frame! page-frame witness-b)
+  (rf.bench.hicasso.topo.model/reseed! page-frame witness-b)
+  (rf.bench.hicasso.topo.arms/reset-counters!)
+  (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) page-frame
+                            [(rf.bench.hicasso.topo.arms/view-of :fine) {}])]
     {:handle    handle
      :frame-id  page-frame
      :container (:container handle)
@@ -205,17 +205,17 @@
   (testing "the refusal below has to be a discrimination, so the same window
            over the same page's own frame must read 0 unverified — a probe pair
            that always failed would prove nothing about the one that does"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
-      (doseq [op clock/rows]
+      (doseq [op rf.bench.hicasso.topo.clock-app/rows]
         (let [page (mount-witness!)
-              t    (lane/tally)]
+              t    (rf.bench.hicasso.lane/tally)]
           (try
-            (clock/window! t page op)
-            (is (= {:writes 2 :unverified 0} (lane/tally-value t))
+            (rf.bench.hicasso.topo.clock-app/window! t page op)
+            (is (= {:writes 2 :unverified 0} (rf.bench.hicasso.lane/tally-value t))
                 (str op ": every probe of a page that committed what it claims
                      must read back, or the instrument refuses healthy runs"))
-            (finally (mount/release! (:handle page)))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! (:handle page)))))))))
 
 (deftest the-window-refuses-a-page-that-did-not-commit
   (testing "THE FAULT THE READ-BACK EXISTS TO CATCH. The commits are dispatched
@@ -223,19 +223,19 @@
            `batch-k` settles happen and the observed page never moves. The
            clock still returns a plausible number; the probes are what refuse
            it"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       ;; `:noop` is excluded and the exclusion is the point: its pair is two
       ;; UNCHANGED cells, so a page that committed nothing satisfies it by
       ;; construction. That is what a floor row is, and it is why the floor is
       ;; reported beside the cells rather than trusted as one.
-      (doseq [op clock/operations]
+      (doseq [op rf.bench.hicasso.topo.clock-app/operations]
         (let [page (mount-witness!)
-              _    (m/make-frame! decoy-frame witness-b)
-              t    (lane/tally)]
+              _    (rf.bench.hicasso.topo.model/make-frame! decoy-frame witness-b)
+              t    (rf.bench.hicasso.lane/tally)]
           (try
-            (let [ms     (clock/window! t (assoc page :frame-id decoy-frame) op)
-                  misses (clock/probe-misses (:container page) op witness-b
+            (let [ms     (rf.bench.hicasso.topo.clock-app/window! t (assoc page :frame-id decoy-frame) op)
+                  misses (rf.bench.hicasso.topo.clock-app/probe-misses (:container page) op witness-b
                                              @(:committed page))]
               (is (number? ms)
                   (str op ": the clock still answers — a withheld commit does not
@@ -250,16 +250,16 @@
               (is (contains? (set (map :probe misses)) :changed)
                   (str op ": the probe that must have moved must refuse a page
                        that never moved"))
-              (is (= {:writes 2 :unverified (count misses)} (lane/tally-value t))
+              (is (= {:writes 2 :unverified (count misses)} (rf.bench.hicasso.lane/tally-value t))
                   (str op ": and the window banks exactly what the probes found —
                        a tally that disagreed with a direct read is the accounting
                        fault, one level out from the page"))
               (is (thrown? js/Error
-                    (lane/assert-verified! t (str "topo clock witness " (name op))))
+                    (rf.bench.hicasso.lane/assert-verified! t (str "topo clock witness " (name op))))
                   (str op ": and the lane's ONE adjudication of a read-back must
                        throw on it — a count that is published and never
                        adjudicated is the fault `assert-verified!` exists for")))
-            (finally (mount/release! (:handle page)))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! (:handle page)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 5 — and the gate the driver runs before any clock, live
@@ -270,19 +270,19 @@
            here it is checked against a page. Both are needed: the first says
            the driver states the tournament's numbers, this says the tournament's
            numbers still describe the arm"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
-      (doseq [arm clock/measured-arms
-              op  clock/rows]
-        (lane/leave-act-environment!)
-        (m/make-frame! page-frame witness-b)
-        (m/reseed! page-frame witness-b)
-        (let [handle (mount/root! (mount/fresh-container!) page-frame
-                                  [(arms/view-of arm) {}])]
+      (doseq [arm rf.bench.hicasso.topo.clock-app/measured-arms
+              op  rf.bench.hicasso.topo.clock-app/rows]
+        (rf.bench.hicasso.lane/leave-act-environment!)
+        (rf.bench.hicasso.topo.model/make-frame! page-frame witness-b)
+        (rf.bench.hicasso.topo.model/reseed! page-frame witness-b)
+        (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) page-frame
+                                  [(rf.bench.hicasso.topo.arms/view-of arm) {}])]
           (try
-            (arms/reset-counters!)
-            (clock/write! page-frame op 0)
-            (mount/settle!)
-            (is (= (clock/markup-expected arm op witness-b) (:markup (arms/runs)))
+            (rf.bench.hicasso.topo.arms/reset-counters!)
+            (rf.bench.hicasso.topo.clock-app/write! page-frame op 0)
+            (rf.bench.hicasso.arm1.mount/settle!)
+            (is (= (rf.bench.hicasso.topo.clock-app/markup-expected arm op witness-b) (:markup (rf.bench.hicasso.topo.arms/runs)))
                 (str arm "/" op " at B=" witness-b))
-            (finally (mount/release! handle))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! handle))))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/topo/control_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/topo/control_app.cljs
@@ -133,7 +133,7 @@
   work alone.
 
   So every window here banks TWO cell-addressed probes into
-  `lane/tally`, outside the clock, and [[lane/assert-verified!]] — the
+  `rf.bench.hicasso.lane/tally`, outside the clock, and [[rf.bench.hicasso.lane/assert-verified!]] — the
   lane's one meaning of *verified* — turns any miss into a throw and a
   non-zero exit:
 
@@ -146,12 +146,12 @@
   `data-testid`, so neither can be satisfied by a neighbour's commit.
   `topo/control_witness_dom_cljs_test` mounts a real arm, withholds the
   commit, and asserts this refuses."
-  (:require [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.topo.arms :as arms]
-            [re-frame.bench.hicasso.topo.model :as m]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.topo.arms :as rf.bench.hicasso.topo.arms]
+            [re-frame.bench.hicasso.topo.model :as rf.bench.hicasso.topo.model]
             [re-frame.core :as rf]))
 
 ;; ---------------------------------------------------------------------------
@@ -187,7 +187,7 @@
   [[re-frame.bench.hicasso.topo.model/window-size]] — with the large page
   at twice it. `B` is held at [[virtual-rows]] throughout, so the ONLY
   thing that moves for this arm is the size of the page it renders."
-  m/window-size)
+  rf.bench.hicasso.topo.model/window-size)
 
 (def virtual-rows
   "The table the windowed arm windows. Fixed across its manipulation."
@@ -234,14 +234,14 @@
   (if (= :virtual arm)
     [{:b virtual-rows :w base-window}
      {:b virtual-rows :w (* scale base-window)}]
-    [{:b base-rows :w m/window-size}
-     {:b (* scale base-rows) :w m/window-size}]))
+    [{:b base-rows :w rf.bench.hicasso.topo.model/window-size}
+     {:b (* scale base-rows) :w rf.bench.hicasso.topo.model/window-size}]))
 
 (defn rendered-of
   "How many rows `arm` renders on page `size` — the control's scale
   parameter, read from the model rather than restated here."
   [arm {:keys [b w]}]
-  (m/rendered-rows arm b w))
+  (rf.bench.hicasso.topo.model/rendered-rows arm b w))
 
 (defn predicted
   "`arm`'s predicted factor, from `model/elements-for` at the two rendered
@@ -251,8 +251,8 @@
   (5001/2501) and 1.9901 for the windowed one (201/101)."
   [arm]
   (let [[small large] (sizes arm)]
-    (/ (m/elements-for (rendered-of arm large))
-       (m/elements-for (rendered-of arm small)))))
+    (/ (rf.bench.hicasso.topo.model/elements-for (rendered-of arm large))
+       (rf.bench.hicasso.topo.model/elements-for (rendered-of arm small)))))
 
 (defn band-of
   "`arm`'s registered band — ±[[slack]] of its own [[predicted]]."
@@ -286,7 +286,7 @@
   - **in band**, round-wise rather than pooled, so one bad round refuses
     instead of being averaged away (`census_clock_run/controlVerdict`'s
     rule, and the strict side of the rf2-egdaq split, which kept
-    `lane/control-verdict`'s overlap rule only for clamp-limited clock
+    `rf.bench.hicasso.lane/control-verdict`'s overlap rule only for clamp-limited clock
     legs);
   - **positive in sign**, which is PR #7634's fix — a band alone admits a
     control certifying that more work reads faster;
@@ -304,8 +304,8 @@
         clean   (and (pos? (long (or writes 0))) (zero? (long (or unverified 0))))]
     {:arm          arm
      :rounds       rs
-     :predicted    (lane/round4 predicted)
-     :band         [(lane/round4 lo) (lane/round4 hi)]
+     :predicted    (rf.bench.hicasso.lane/round4 predicted)
+     :band         [(rf.bench.hicasso.lane/round4 lo) (rf.bench.hicasso.lane/round4 hi)]
      :verification verification
      :in-band?     in-band
      :positive?    signed
@@ -318,8 +318,8 @@
                                         " probes; the clock measured a page that did not commit what it claims")
                      (not signed)  "REFUSED ON THE SIGN — a round read the doubled page as no slower, which is a control certifying that more work costs less"
                      (not in-band) (str "REFUSED ON THE BAND — a round fell outside ["
-                                        (lane/round4 lo) ", " (lane/round4 hi) "] around the derived "
-                                        (lane/round4 predicted))
+                                        (rf.bench.hicasso.lane/round4 lo) ", " (rf.bench.hicasso.lane/round4 hi) "] around the derived "
+                                        (rf.bench.hicasso.lane/round4 predicted))
                      :else         "in band, positive and verified in every round")}))
 
 ;; ---------------------------------------------------------------------------
@@ -344,8 +344,8 @@
   `(:n (model/row i))`, and the changed probe advances by exactly one per
   commit because the write is an `inc`."
   [container commits]
-  (let [want-changed   (str (+ (:n (m/row changed-probe)) commits))
-        want-unchanged (str (:n (m/row unchanged-probe)))]
+  (let [want-changed   (str (+ (:n (rf.bench.hicasso.topo.model/row changed-probe)) commits))
+        want-unchanged (str (:n (rf.bench.hicasso.topo.model/row unchanged-probe)))]
     (remove nil?
             [(let [got (n-at container changed-probe)]
                (when-not (= want-changed got)
@@ -359,7 +359,7 @@
   the two probes back and BANK them in `t`.
 
   The read-back is outside the window and after the last drain, which is
-  the batched shape [[lane/verified-writes!]] documents and defends: no
+  the batched shape [[rf.bench.hicasso.lane/verified-writes!]] documents and defends: no
   macrotask runs between the first write and the last drain, so a commit
   React has parked cannot land inside the window however many microtasks
   pass. What the batch relaxes is microtask-scale lateness, on a
@@ -369,14 +369,14 @@
   the page's running commit count, which the probe arithmetic needs and
   which is why it is a page-scoped atom rather than a local."
   [t {:keys [frame-id container limit committed]}]
-  (let [t0 (lane/now-ms)]
+  (let [t0 (rf.bench.hicasso.lane/now-ms)]
     (dotimes [_ batch-k]
-      (rt/dispatch! frame-id [:topo/bump-indexed limit stride])
-      (mount/settle!))
-    (let [ms     (- (lane/now-ms) t0)
+      (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:topo/bump-indexed limit stride])
+      (rf.bench.hicasso.arm1.mount/settle!))
+    (let [ms     (- (rf.bench.hicasso.lane/now-ms) t0)
           total  (swap! committed + batch-k)
           misses (probe-misses container total)]
-      ;; `lane/verified-writes!`'s own `bank!`, over this control's probes:
+      ;; `rf.bench.hicasso.lane/verified-writes!`'s own `bank!`, over this control's probes:
       ;; one tally, one meaning of "verified", one `assert-verified!`.
       (swap! t (fn [{:keys [of bad]}]
                  {:of (+ of 2) :bad (+ bad (count misses))}))
@@ -389,7 +389,7 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private frame-ids
-  (into {} (for [arm arms/arm-ids tag [:small :large]]
+  (into {} (for [arm rf.bench.hicasso.topo.arms/arm-ids tag [:small :large]]
              [[arm tag] (keyword "topo.control" (str (name arm) "-" (name tag)))])))
 
 (defn- mount-page!
@@ -398,9 +398,9 @@
   [arm tag size]
   (let [{:keys [b w]} size
         frame-id (get frame-ids [arm tag])]
-    (m/make-frame! frame-id b w)
-    (m/reseed! frame-id b w)
-    (let [handle (mount/root! (mount/fresh-container!) frame-id [(arms/view-of arm) {}])]
+    (rf.bench.hicasso.topo.model/make-frame! frame-id b w)
+    (rf.bench.hicasso.topo.model/reseed! frame-id b w)
+    (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [(rf.bench.hicasso.topo.arms/view-of arm) {}])]
       {:tag       tag
        :size      size
        :frame-id  frame-id
@@ -412,14 +412,14 @@
 (defn- structure-of
   "`page`'s own structure. `:boundaries` and `:edges` come from a DELTA
   against the runtime's live table, because two pages are mounted at once
-  and `rt/stats` counts every live cell in the process rather than one
+  and `rf.bench.hicasso.arm1.runtime/stats` counts every live cell in the process rather than one
   container's."
   [page before]
-  (let [{:keys [boundaries edges]} (rt/stats)
+  (let [{:keys [boundaries edges]} (rf.bench.hicasso.arm1.runtime/stats)
         container (:container page)]
     {:boundaries    (- boundaries (:boundaries before))
      :edges         (- edges (:edges before))
-     :elements      (lane/element-count container)
+     :elements      (rf.bench.hicasso.lane/element-count container)
      :rendered-rows (.-length (.querySelectorAll container "li.topo-row"))}))
 
 (defn- markup-of
@@ -428,11 +428,11 @@
   [[markup-expected]], which is how a page that is not doing the work its
   arithmetic predicts is caught BEFORE a clock reads it."
   [arm page]
-  (arms/reset-counters!)
-  (rt/dispatch! (:frame-id page) [:topo/bump-indexed (:limit page) stride])
-  (mount/settle!)
+  (rf.bench.hicasso.topo.arms/reset-counters!)
+  (rf.bench.hicasso.arm1.runtime/dispatch! (:frame-id page) [:topo/bump-indexed (:limit page) stride])
+  (rf.bench.hicasso.arm1.mount/settle!)
   (swap! (:committed page) inc)
-  (:markup (arms/runs)))
+  (:markup (rf.bench.hicasso.topo.arms/runs)))
 
 (defn run-arm!
   "One arm's whole control: mount both pages, check each is the arm it
@@ -444,16 +444,16 @@
   arm's two pages and never eight."
   [arm]
   (let [[small large] (sizes arm)
-        t      (lane/tally)
-        base   (rt/stats)
+        t      (rf.bench.hicasso.lane/tally)
+        base   (rf.bench.hicasso.arm1.runtime/stats)
         p-s    (mount-page! arm :small small)
         st-s   (structure-of p-s base)
-        mid    (rt/stats)
+        mid    (rf.bench.hicasso.arm1.runtime/stats)
         p-l    (mount-page! arm :large large)
         st-l   (structure-of p-l mid)
-        want-s (select-keys (arms/expected arm (:b small) (:w small))
+        want-s (select-keys (rf.bench.hicasso.topo.arms/expected arm (:b small) (:w small))
                             [:boundaries :edges :elements :rendered-rows])
-        want-l (select-keys (arms/expected arm (:b large) (:w large))
+        want-l (select-keys (rf.bench.hicasso.topo.arms/expected arm (:b large) (:w large))
                             [:boundaries :edges :elements :rendered-rows])]
     (try
       (cond
@@ -477,42 +477,42 @@
                          " large=" want-mk-l ", built small=" mk-s " large=" mk-l)}
             (let [pages {:small p-s :large p-l}
                   {:keys [readings samples]}
-                  (lane/rounds! [{:id :small} {:id :large}]
+                  (rf.bench.hicasso.lane/rounds! [{:id :small} {:id :large}]
                                 sampling rounds
                                 (fn [a] (window! t (get pages (:id a))))
                                 (fn [a] (str (name arm) "-" (name (:id a)))))
                   ratios (mapv (fn [r]
-                                 (let [p (fn [id] (:p50 (lane/summarise (get r id))))]
-                                   (lane/round4 (/ (p :large) (p :small)))))
+                                 (let [p (fn [id] (:p50 (rf.bench.hicasso.lane/summarise (get r id))))]
+                                   (rf.bench.hicasso.lane/round4 (/ (p :large) (p :small)))))
                                readings)
                   ;; PUBLISHED BEFORE ADJUDICATED: `assert-verified!` throws, and
                   ;; the evidence a reader needs has to be on the console first.
-                  vv     (lane/tally-value t)
+                  vv     (rf.bench.hicasso.lane/tally-value t)
                   v      (verdict arm ratios vv)
-                  gv     (lane/guard! samples (str "topo rendered-scale control (" (name arm) ")"))]
+                  gv     (rf.bench.hicasso.lane/guard! samples (str "topo rendered-scale control (" (name arm) ")"))]
               {:verdict   v
                :guard     gv
                :structure {:small st-s :large st-l}
                :markup    {:small mk-s :large mk-l
-                           :ratio (lane/round4 (/ mk-l mk-s))}
-               :per-round (mapv (fn [r] {:small (lane/summarise (get r :small))
-                                         :large (lane/summarise (get r :large))})
+                           :ratio (rf.bench.hicasso.lane/round4 (/ mk-l mk-s))}
+               :per-round (mapv (fn [r] {:small (rf.bench.hicasso.lane/summarise (get r :small))
+                                         :large (rf.bench.hicasso.lane/summarise (get r :large))})
                                 readings)
                :tally     t}))))
       (finally
-        (mount/release! (:handle p-s))
-        (mount/release! (:handle p-l))))))
+        (rf.bench.hicasso.arm1.mount/release! (:handle p-s))
+        (rf.bench.hicasso.arm1.mount/release! (:handle p-l))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The run
 ;; ---------------------------------------------------------------------------
 
 (defn ^:export -main []
-  (rf/init! uix-adapter/adapter)
-  (lane/leave-act-environment!)
-  (lane/self-test!)
+  (rf/init! rf.adapter.uix/adapter)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/self-test!)
   (try
-    (lane/record! :design
+    (rf.bench.hicasso.lane/record! :design
                   {:scale scale :stride stride :batch-k batch-k
                    :rounds rounds :sampling sampling :slack slack
                    :probes {:changed changed-probe :unchanged unchanged-probe}
@@ -522,16 +522,16 @@
                                                  :rendered [(rendered-of arm s) (rendered-of arm l)]
                                                  :markup [(markup-expected arm s) (markup-expected arm l)]
                                                  :band (band-of arm)}])))
-                                 arms/arm-ids)})
-    (lane/record! :runtime (lane/runtime-label))
+                                 rf.bench.hicasso.topo.arms/arm-ids)})
+    (rf.bench.hicasso.lane/record! :runtime (rf.bench.hicasso.lane/runtime-label))
     (let [results (reduce
                     (fn [acc arm]
                       (let [r (run-arm! arm)]
                         (if-let [f (:fatal r)]
                           (do (set! (.-HICASSO_CONTROL_FAILED js/window) true)
-                              (lane/fail! f)
+                              (rf.bench.hicasso.lane/fail! f)
                               (reduced (assoc acc arm {:fatal f})))
-                          (do (lane/record! (keyword (str "control-" (name arm)))
+                          (do (rf.bench.hicasso.lane/record! (keyword (str "control-" (name arm)))
                                             (select-keys r [:verdict :structure :markup :per-round]))
                               (when (:refuse? (:guard r))
                                 (set! (.-HICASSO_GUARD_REFUSED js/window) true))
@@ -541,16 +541,16 @@
                                                        (:why (:verdict r)))))
                               ;; The lane's ONE adjudication of a read-back. It throws,
                               ;; and it is called AFTER the record above is published.
-                              (lane/assert-verified! (:tally r)
+                              (rf.bench.hicasso.lane/assert-verified! (:tally r)
                                                      (str "topo rendered-scale control (" (name arm) ")"))
                               (assoc acc arm (:verdict r))))))
                     {}
-                    arms/arm-ids)]
-      (lane/record! :summary
+                    rf.bench.hicasso.topo.arms/arm-ids)]
+      (rf.bench.hicasso.lane/record! :summary
                     (into {} (map (fn [[arm v]]
                                     [arm (select-keys v [:predicted :band :rounds :ok? :why])]))
                           results)))
     (catch :default e
       (set! (.-HICASSO_CONTROL_FAILED js/window) true)
-      (lane/fail! (str "topo control threw: " (or (ex-message e) (.-message e))))))
-  (lane/done!))
+      (rf.bench.hicasso.lane/fail! (str "topo control threw: " (or (ex-message e) (.-message e))))))
+  (rf.bench.hicasso.lane/done!))

--- a/bench/hicasso/src/re_frame/bench/hicasso/topo/control_witness_dom_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/topo/control_witness_dom_cljs_test.cljs
@@ -36,7 +36,7 @@
   runtime observed the plant. So the witness below mounts a real arm and
   drives [[re-frame.bench.hicasso.topo.control-app/window!]] itself — the
   same function the clock run calls, banking into the same
-  `lane/tally` — with the ONE difference that the write's `limit` is
+  `rf.bench.hicasso.lane/tally` — with the ONE difference that the write's `limit` is
   zero, so `(range 0 0 stride)` is empty and no row moves. Everything
   else is the control: twenty dispatches, twenty settles, one clock, and
   the probes read afterwards. There is nothing to restore and nothing to
@@ -45,21 +45,21 @@
   Runtime: `-dom-cljs-test`. Under `:node-test` every claim degrades to a
   stated skip."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.topo.arms :as arms]
-            [re-frame.bench.hicasso.topo.control-app :as ctl]
-            [re-frame.bench.hicasso.topo.model :as m]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.topo.arms :as rf.bench.hicasso.topo.arms]
+            [re-frame.bench.hicasso.topo.control-app :as rf.bench.hicasso.topo.control-app]
+            [re-frame.bench.hicasso.topo.model :as rf.bench.hicasso.topo.model]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (rt/reset-runtime!))}))
+     :init-fn       (fn [] (rf.bench.hicasso.arm1.runtime/reset-runtime!))}))
 
 (defn- skip! [why]
   (is true (str "the topology control witness needs a real React DOM — " why)))
@@ -67,25 +67,25 @@
 (def ^:private frame-id ::witness)
 
 (defn- fresh! [b w]
-  (lane/leave-act-environment!)
-  (m/make-frame! frame-id b w)
-  (m/reseed! frame-id b w)
-  (arms/reset-counters!)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.topo.model/make-frame! frame-id b w)
+  (rf.bench.hicasso.topo.model/reseed! frame-id b w)
+  (rf.bench.hicasso.topo.arms/reset-counters!)
   frame-id)
 
 (defn- reseed! [b w]
-  (rt/dispatch! frame-id [:topo/seed b w])
-  (mount/settle!)
-  (arms/reset-counters!)
+  (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:topo/seed b w])
+  (rf.bench.hicasso.arm1.mount/settle!)
+  (rf.bench.hicasso.topo.arms/reset-counters!)
   nil)
 
 (defn- markup-caused-by
   "Rows of markup ONE dispatch of `event` builds on a standing mount."
   [event]
-  (arms/reset-counters!)
-  (rt/dispatch! frame-id event)
-  (mount/settle!)
-  (:markup (arms/runs)))
+  (rf.bench.hicasso.topo.arms/reset-counters!)
+  (rf.bench.hicasso.arm1.runtime/dispatch! frame-id event)
+  (rf.bench.hicasso.arm1.mount/settle!)
+  (:markup (rf.bench.hicasso.topo.arms/runs)))
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — the degeneracy premise, measured rather than asserted
@@ -104,17 +104,17 @@
            runs, so doubling the changed set doubles nothing they do. A
            control predicting 2.00x there refuses a healthy instrument; one
            predicting 1.00x discriminates nothing"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
-      (doseq [arm arms/arm-ids]
-        (fresh! premise-b m/window-size)
-        (let [handle (mount/root! (mount/fresh-container!) frame-id [(arms/view-of arm) {}])]
+      (doseq [arm rf.bench.hicasso.topo.arms/arm-ids]
+        (fresh! premise-b rf.bench.hicasso.topo.model/window-size)
+        (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id [(rf.bench.hicasso.topo.arms/view-of arm) {}])]
           (try
-            (reseed! premise-b m/window-size)
+            (reseed! premise-b rf.bench.hicasso.topo.model/window-size)
             (let [d10 (markup-caused-by [:topo/bump-stride 10])
-                  _   (reseed! premise-b m/window-size)
+                  _   (reseed! premise-b rf.bench.hicasso.topo.model/window-size)
                   d5  (markup-caused-by [:topo/bump-stride 5])
-                  rendered (m/rendered-rows arm premise-b)]
+                  rendered (rf.bench.hicasso.topo.model/rendered-rows arm premise-b)]
               (if (contains? #{:coarse :chunked} arm)
                 (do (is (= rendered d10 d5)
                         (str arm "/bump-stride at B=" premise-b " must build every rendered
@@ -126,7 +126,7 @@
                 (is (= 2 (/ d5 d10))
                     (str arm "/bump-stride does double its markup (" d10 " -> " d5 "),
                          which is the half of the premise that holds"))))
-            (finally (mount/release! handle))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! handle))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 — the replacement discriminates on every arm
@@ -137,9 +137,9 @@
            factor is derived from `model/elements-for` and is bounded away
            from 1.00. Neither number is 2.00, because the `ul` does not
            double — which is `census_clock_arms/ctl-predicted`'s discipline"
-    (doseq [arm arms/arm-ids]
-      (let [p (ctl/predicted arm)
-            {:keys [lo hi]} (ctl/band-of arm)]
+    (doseq [arm rf.bench.hicasso.topo.arms/arm-ids]
+      (let [p (rf.bench.hicasso.topo.control-app/predicted arm)
+            {:keys [lo hi]} (rf.bench.hicasso.topo.control-app/band-of arm)]
         (is (> p 1.9) (str arm "'s predicted factor is " p))
         (is (< p 2.0) (str arm "'s prediction must be BELOW 2.00 — the chrome does
                            not double, and a control printing a round 2.00 is one
@@ -158,26 +158,26 @@
            exactly twice the rows of markup its small page does — including
            `coarse` and `chunked`, where the changed-set control built the
            same number twice"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
-      (doseq [arm arms/arm-ids]
-        (let [[small large] (ctl/sizes arm)]
+      (doseq [arm rf.bench.hicasso.topo.arms/arm-ids]
+        (let [[small large] (rf.bench.hicasso.topo.control-app/sizes arm)]
           (doseq [[tag size] [[:small small] [:large large]]]
             (let [{:keys [b w]} size
-                  limit (ctl/rendered-of arm size)]
+                  limit (rf.bench.hicasso.topo.control-app/rendered-of arm size)]
               (fresh! b w)
-              (let [handle (mount/root! (mount/fresh-container!) frame-id
-                                        [(arms/view-of arm) {}])]
+              (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id
+                                        [(rf.bench.hicasso.topo.arms/view-of arm) {}])]
                 (try
                   (reseed! b w)
-                  (let [built (markup-caused-by [:topo/bump-indexed limit ctl/stride])]
-                    (is (= (ctl/markup-expected arm size) built)
+                  (let [built (markup-caused-by [:topo/bump-indexed limit rf.bench.hicasso.topo.control-app/stride])]
+                    (is (= (rf.bench.hicasso.topo.control-app/markup-expected arm size) built)
                         (str arm "/" tag " must build the markup its arithmetic
                              predicts — this is the number the clock's prediction
                              rests on, and the control checks it on the page before
                              it starts a clock")))
-                  (finally (mount/release! handle))))))
-          (is (= 2 (/ (ctl/markup-expected arm large) (ctl/markup-expected arm small)))
+                  (finally (rf.bench.hicasso.arm1.mount/release! handle))))))
+          (is (= 2 (/ (rf.bench.hicasso.topo.control-app/markup-expected arm large) (rf.bench.hicasso.topo.control-app/markup-expected arm small)))
               (str arm "'s control doubles the rows of markup a commit builds —
                    the property the changed-set control lacked on this arm")))))))
 
@@ -185,28 +185,28 @@
   (testing "the write the whole control rests on: every `stride`-th rendered row
            advances by one per commit and no other row moves. Read out of the
            DOM, on the same cells the control's probes address"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (let [b 100]
-        (fresh! b m/window-size)
-        (let [handle (mount/root! (mount/fresh-container!) frame-id
-                                  [(arms/view-of :fine) {}])
+        (fresh! b rf.bench.hicasso.topo.model/window-size)
+        (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id
+                                  [(rf.bench.hicasso.topo.arms/view-of :fine) {}])
               container (:container handle)]
           (try
-            (reseed! b m/window-size)
+            (reseed! b rf.bench.hicasso.topo.model/window-size)
             (dotimes [_ 3]
-              (rt/dispatch! frame-id [:topo/bump-indexed b ctl/stride])
-              (mount/settle!))
-            (is (= (str (+ (:n (m/row ctl/changed-probe)) 3))
-                   (ctl/n-at container ctl/changed-probe))
+              (rf.bench.hicasso.arm1.runtime/dispatch! frame-id [:topo/bump-indexed b rf.bench.hicasso.topo.control-app/stride])
+              (rf.bench.hicasso.arm1.mount/settle!))
+            (is (= (str (+ (:n (rf.bench.hicasso.topo.model/row rf.bench.hicasso.topo.control-app/changed-probe)) 3))
+                   (rf.bench.hicasso.topo.control-app/n-at container rf.bench.hicasso.topo.control-app/changed-probe))
                 "the changed probe advanced by exactly one per commit")
-            (is (= (str (:n (m/row ctl/unchanged-probe)))
-                   (ctl/n-at container ctl/unchanged-probe))
+            (is (= (str (:n (rf.bench.hicasso.topo.model/row rf.bench.hicasso.topo.control-app/unchanged-probe)))
+                   (rf.bench.hicasso.topo.control-app/n-at container rf.bench.hicasso.topo.control-app/unchanged-probe))
                 "the unchanged probe did not move at all")
-            (is (empty? (ctl/probe-misses container 3))
+            (is (empty? (rf.bench.hicasso.topo.control-app/probe-misses container 3))
                 "so the control's own read-back reports no miss on a page that
                  committed what it claims")
-            (finally (mount/release! handle))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! handle))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3 — the read-back bites
@@ -224,36 +224,36 @@
            tally — with the write's `limit` at zero, so nothing commits. The
            tally must report every probe unverified and `assert-verified!`
            must throw"
-    (if-not (mount/browser?)
+    (if-not (rf.bench.hicasso.arm1.mount/browser?)
       (skip! ":node-test has no DOM")
       (let [b 100]
-        (fresh! b m/window-size)
-        (let [handle (mount/root! (mount/fresh-container!) frame-id
-                                  [(arms/view-of :fine) {}])
+        (fresh! b rf.bench.hicasso.topo.model/window-size)
+        (let [handle (rf.bench.hicasso.arm1.mount/root! (rf.bench.hicasso.arm1.mount/fresh-container!) frame-id
+                                  [(rf.bench.hicasso.topo.arms/view-of :fine) {}])
               container (:container handle)]
           (try
-            (reseed! b m/window-size)
-            (let [t    (lane/tally)
+            (reseed! b rf.bench.hicasso.topo.model/window-size)
+            (let [t    (rf.bench.hicasso.lane/tally)
                   page {:frame-id frame-id :container container
                         :limit 0 :committed (atom 0)}
-                  _ms  (ctl/window! t page)
-                  v    (lane/tally-value t)]
+                  _ms  (rf.bench.hicasso.topo.control-app/window! t page)
+                  v    (rf.bench.hicasso.lane/tally-value t)]
               (is (= 2 (:writes v)) "both probes were read")
               (is (= 1 (:unverified v))
                   "the CHANGED probe must miss — twenty commits were counted and
                    the row's `n` never moved. The unchanged probe is correctly
                    satisfied, which is what makes the pair discriminate between
                    `nothing committed` and `everything committed`")
-              (is (thrown? js/Error (lane/assert-verified! t "non-commit witness"))
+              (is (thrown? js/Error (rf.bench.hicasso.lane/assert-verified! t "non-commit witness"))
                   "and the lane's ONE adjudication of a read-back turns that into
                    a throw, which the driver turns into a non-zero exit")
-              (is (false? (:ok? (ctl/verdict :fine [1.99 1.99 1.99] v)))
+              (is (false? (:ok? (rf.bench.hicasso.topo.control-app/verdict :fine [1.99 1.99 1.99] v)))
                   "so a verdict over perfectly in-band, correctly-signed round
                    ratios still REFUSES on the read-back — the numbers describe a
                    page that did not commit what it claims")
-              (is (re-find #"READ-BACK" (:why (ctl/verdict :fine [1.99 1.99 1.99] v)))
+              (is (re-find #"READ-BACK" (:why (rf.bench.hicasso.topo.control-app/verdict :fine [1.99 1.99 1.99] v)))
                   "and it says which of the three gates refused"))
-            (finally (mount/release! handle))))))))
+            (finally (rf.bench.hicasso.arm1.mount/release! handle))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4 — the verdict arithmetic, without a browser
@@ -265,16 +265,16 @@
   (testing "three gates, any of which refuses. The sign gate is PR #7634's fix:
            a band alone admits a control certifying that MORE WORK READS
            FASTER, which rf2-7iqb5 captured live"
-    (let [{:keys [predicted]} (ctl/band-of :fine)]
-      (is (:ok? (ctl/verdict :fine (repeat 5 predicted) clean))
+    (let [{:keys [predicted]} (rf.bench.hicasso.topo.control-app/band-of :fine)]
+      (is (:ok? (rf.bench.hicasso.topo.control-app/verdict :fine (repeat 5 predicted) clean))
           "a run measuring exactly its prediction passes")
-      (is (not (:ok? (ctl/verdict :fine [predicted predicted 1.40 predicted predicted] clean)))
+      (is (not (:ok? (rf.bench.hicasso.topo.control-app/verdict :fine [predicted predicted 1.40 predicted predicted] clean)))
           "ONE round below the band refuses the whole control — the strict rule,
            so a good round cannot vouch for a bad one")
-      (is (not (:ok? (ctl/verdict :fine (repeat 5 0.5) clean)))
+      (is (not (:ok? (rf.bench.hicasso.topo.control-app/verdict :fine (repeat 5 0.5) clean)))
           "a negative-sign run refuses on the sign, not merely on the band")
-      (is (re-find #"SIGN" (:why (ctl/verdict :fine (repeat 5 0.5) clean))))
-      (is (not (:ok? (ctl/verdict :fine [] clean)))
+      (is (re-find #"SIGN" (:why (rf.bench.hicasso.topo.control-app/verdict :fine (repeat 5 0.5) clean))))
+      (is (not (:ok? (rf.bench.hicasso.topo.control-app/verdict :fine [] clean)))
           "and a control that measured nothing certifies nothing"))))
 
 (deftest the-refused-changed-set-run-would-still-refuse-here
@@ -282,7 +282,7 @@
            replaces measured 1.331 / 1.387 / 1.424 / 1.471 / 1.325 and refused.
            Fed to the NEW verdict on every arm, it refuses again"
     (let [measured [1.331 1.387 1.424 1.471 1.325]]
-      (doseq [arm arms/arm-ids]
-        (is (not (:ok? (ctl/verdict arm measured clean)))
+      (doseq [arm rf.bench.hicasso.topo.arms/arm-ids]
+        (is (not (:ok? (rf.bench.hicasso.topo.control-app/verdict arm measured clean)))
             (str "the replacement's band on " arm " must not retro-admit the
                  refusal it replaces"))))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/walk_profile_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/walk_profile_app.cljs
@@ -33,20 +33,20 @@
   the same [[re-frame.bench.hicasso.shapes.card/card]] calls (69 x 17 =
   1,173 of the 1,202 elements are the card's own markup, byte-for-byte by
   construction). The twin is not trusted: at boot both pages are mounted
-  and their canonical DOM compared (`lane/canonical`, attribute names
+  and their canonical DOM compared (`rf.bench.hicasso.lane/canonical`, attribute names
   sorted), and the run is fatal on disagreement. A profile of a page that
   is not the acceptance page would be rf2-cvvb7's fault with extra steps.
 
   ## The arms
 
-  Realized input (`codec/realize-deep` outside the window) isolates the
+  Realized input (`rf.bench.hicasso.front.codec/realize-deep` outside the window) isolates the
   walk from the body's lazy tail; the one lazy arm prices that tail —
   on a mount the `for` seqs realize INSIDE `as-element`, so the
   mount-billed walk includes the card calls and their sub reads.
 
   | arm           | input    | what it prices |
   |---------------|----------|----------------|
-  | `ship-lazy`   | lazy     | the mount-billed walk: interpretation PLUS the body's lazy card/sub work |
+  | `ship-lazy`   | lazy     | the mount-billed walk: interpretation PLUS the body's lazy rf.bench.hicasso.shapes.card/sub work |
   | `ship`        | realized | the shipping walk alone |
   | `local`       | realized | the in-namespace copy — the ablation baseline, and the in-process A/B's OLD arm |
   | `no-create`   | realized | `local` with `react/createElement` swapped for a two-field object mint |
@@ -66,7 +66,7 @@
   rebuilt the attribute map of every element carrying a `#id`/`.class`
   shorthand — against a `local` copy that performed it. rf2-2rtt6.36
   **deleted** that surgery: the shorthand is folded onto the object the
-  walk EMITS (`codec/fold-shorthand!`), where the slot is already
+  walk EMITS (`rf.bench.hicasso.front.codec/fold-shorthand!`), where the slot is already
   resolved, and the fast lane that existed only to dodge the map copy
   went with it. `convert-props`' three lanes became two.
 
@@ -132,16 +132,16 @@
 
   Owner bead: rf2-y1jkm. Driver: `run.cjs` with
   HICASSO_INIT_FN=re-frame.bench.hicasso.walk-profile-app/-main."
-  (:require [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as arm1-mount]
-            [re-frame.bench.hicasso.arm1.runtime :as rt :refer [sub]]
-            [re-frame.bench.hicasso.front.codec :as codec]
-            [re-frame.bench.hicasso.front.controlled :as controlled]
-            [re-frame.bench.hicasso.front.intent :as intent]
-            [re-frame.bench.hicasso.front.slot :as slot]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.shapes.card :as card]
-            [re-frame.bench.hicasso.shapes.large-template :as lt]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rf.bench.hicasso.arm1.runtime :refer [sub]]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
+            [re-frame.bench.hicasso.front.controlled :as rf.bench.hicasso.front.controlled]
+            [re-frame.bench.hicasso.front.intent :as rf.bench.hicasso.front.intent]
+            [re-frame.bench.hicasso.front.slot :as rf.bench.hicasso.front.slot]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.shapes.card :as rf.bench.hicasso.shapes.card]
+            [re-frame.bench.hicasso.shapes.large-template :as rf.bench.hicasso.shapes.large-template]
             [re-frame.core :as rf]
             ["react" :as react])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
@@ -154,7 +154,7 @@
 
 (defn page-hiccup
   "The large-template page's body forms, verbatim minus the run counter:
-  the same chrome, the same `(card/card slug)` calls, the same tag-pill
+  the same chrome, the same `(rf.bench.hicasso.shapes.card/card slug)` calls, the same tag-pill
   `for`. Must run inside a body context (the reads). The parity gate
   below is what makes this a copy rather than a claim."
   []
@@ -183,7 +183,7 @@
             "Global Feed"]]]]
         [:div.article-list {:data-testid "article-list"}
          (for [slug (sub [:conduit/slugs])]
-           (card/card slug))]]
+           (rf.bench.hicasso.shapes.card/card slug))]]
        [:div.col-md-3
         [:div.sidebar
          [:p "Popular Tags"]
@@ -204,17 +204,17 @@
   canonical DOM agrees and matches the arithmetic. Fatal, before any
   clock."
   []
-  (let [c-real (arm1-mount/fresh-container!)
-        c-twin (arm1-mount/fresh-container!)
-        h-real (arm1-mount/root! c-real frame-id [lt/page {}])
-        h-twin (arm1-mount/root! c-twin frame-id [twin-page {}])
-        canon-real (lane/canonical c-real)
-        canon-twin (lane/canonical c-twin)
-        n-real (lane/element-count c-real)
-        n-twin (lane/element-count c-twin)
-        expected (lt/element-arithmetic)]
-    (arm1-mount/unmount! h-real)
-    (arm1-mount/unmount! h-twin)
+  (let [c-real (rf.bench.hicasso.arm1.mount/fresh-container!)
+        c-twin (rf.bench.hicasso.arm1.mount/fresh-container!)
+        h-real (rf.bench.hicasso.arm1.mount/root! c-real frame-id [rf.bench.hicasso.shapes.large-template/page {}])
+        h-twin (rf.bench.hicasso.arm1.mount/root! c-twin frame-id [twin-page {}])
+        canon-real (rf.bench.hicasso.lane/canonical c-real)
+        canon-twin (rf.bench.hicasso.lane/canonical c-twin)
+        n-real (rf.bench.hicasso.lane/element-count c-real)
+        n-twin (rf.bench.hicasso.lane/element-count c-twin)
+        expected (rf.bench.hicasso.shapes.large-template/element-arithmetic)]
+    (rf.bench.hicasso.arm1.mount/unmount! h-real)
+    (rf.bench.hicasso.arm1.mount/unmount! h-twin)
     (when-not (and (= canon-real canon-twin)
                    (= expected n-real n-twin))
       (throw (ex-info (str "twin parity FAILED: the profiled page is not the "
@@ -222,9 +222,9 @@
                            " expected " expected " canonical "
                            (if (= canon-real canon-twin) "agrees" "DISAGREES") ")")
                       {:expected expected :real n-real :twin n-twin})))
-    ;; `lane/utf8-bytes` and not `count`: `-main` prints this as "canonical
+    ;; `rf.bench.hicasso.lane/utf8-bytes` and not `count`: `-main` prints this as "canonical
     ;; bytes", and `count` answers UTF-16 code units (rf2-2rtt6.121).
-    {:elements n-real :bytes (lane/utf8-bytes canon-real)}))
+    {:elements n-real :bytes (rf.bench.hicasso.lane/utf8-bytes canon-real)}))
 
 ;; ---------------------------------------------------------------------------
 ;; The body-context door
@@ -234,11 +234,11 @@
 
 (defn in-body
   "Run `f` inside a boundary body context — ambient frame bound, reads
-  legal — via the runtime's own public [[rt/render-body]], and answer
+  legal — via the runtime's own public [[rf.bench.hicasso.arm1.runtime/render-body]], and answer
   `(f)`. The trailing `[:span]` is the body's element and is outside
   every timed window."
   [f]
-  (rt/render-body frame-id (fn [_] (vreset! !out (f)) [:span]) {})
+  (rf.bench.hicasso.arm1.runtime/render-body frame-id (fn [_] (vreset! !out (f)) [:span]) {})
   @!out)
 
 ;; ---------------------------------------------------------------------------
@@ -249,7 +249,7 @@
 ;; the donor's three createElement arities, the single-pass props reduce)
 ;; with an integer `mode` consulted at the five phase sites. `case` on an
 ;; int compiles to a JS switch; the full-default instance is validated
-;; against `codec/as-element` in the ARMS table rather than assumed
+;; against `rf.bench.hicasso.front.codec/as-element` in the ARMS table rather than assumed
 ;; equivalent.
 
 (def ^:const M-FULL 0)
@@ -315,7 +315,7 @@
   [mode k v]
   (if (identical? mode M-NO-LOWER)
     (if (or (vector? v) (map? v)) nil v)
-    (intent/lower-prop k v)))
+    (rf.bench.hicasso.front.intent/lower-prop k v)))
 
 (declare local-convert-prop-value)
 
@@ -327,7 +327,7 @@
 
 (defn- walk-fold-shorthand!
   "Fold the tag's `#id`/`.class` shorthand onto the object the walk just
-  emitted — `codec/fold-shorthand!`'s shape, which is private there — or
+  emitted — `rf.bench.hicasso.front.codec/fold-shorthand!`'s shape, which is private there — or
   the no-fold stub, which answers the object untouched.
 
   Asked of the EMITTED object, so there is no spelling left to resolve:
@@ -348,7 +348,7 @@
           (unchecked-set o class-slot
                          (if (undefined? declared)
                            shorthand
-                           (codec/class-names shorthand declared)))))
+                           (rf.bench.hicasso.front.codec/class-names shorthand declared)))))
       o)))
 
 (def ^:private reserved-names #{"__proto__" "prototype" "constructor"})
@@ -375,13 +375,13 @@
 
 (defn- local-prop-name [k]
   (if-not (or (keyword? k) (symbol? k))
-    (if (string? k) (slot/prop-name k) k)
+    (if (string? k) (rf.bench.hicasso.front.slot/prop-name k) k)
     (let [n (name k)]
       (if (reserved-names n)
-        (slot/prop-name k)
+        (rf.bench.hicasso.front.slot/prop-name k)
         (if (.call local-has-own local-prop-cache n)
           (unchecked-get local-prop-cache n)
-          (let [converted (slot/prop-name k)]
+          (let [converted (rf.bench.hicasso.front.slot/prop-name k)]
             (unchecked-set local-prop-cache n converted)
             converted))))))
 
@@ -402,7 +402,7 @@
   ablation baseline AND the in-process A/B's old arm, and an old arm
   that calls the candidate's own converter absorbs the candidate and
   undersells it. PR #7383's audit named this exact site — the `local`
-  walk reached straight into `codec/convert-prop-value`, which that same
+  walk reached straight into `rf.bench.hicasso.front.codec/convert-prop-value`, which that same
   PR changed, so the quoted old-vs-new figure was measured against a
   baseline the candidate had already reached into.
 
@@ -416,7 +416,7 @@
   `merge-shorthand` and the map-copying `dissoc` the candidate also
   replaced were **deleted** from the codec by rf2-2rtt6.36, so there is
   no shipping shape left to copy and rf2-2rtt6.70 re-pointed
-  [[walk-convert-props]] at the lanes that ship. `codec/cached-parse`
+  [[walk-convert-props]] at the lanes that ship. `rf.bench.hicasso.front.codec/cached-parse`
   likewise keeps the candidate's cheaper reserved-name check, because
   the `parse-raw` benefit line prices the TAG CACHE and needs both its
   arms on one parse implementation. So `local` is the pre-optimisation
@@ -469,13 +469,13 @@
                                                 (walk-lower mode k v)))))
                        o)))
                  #js {}
-                 (codec/merge-caller (or props {})))
+                 (rf.bench.hicasso.front.codec/merge-caller (or props {})))
       parsed)))
 
 (defn- walk-parse [mode tag]
   (if (identical? mode M-PARSE-RAW)
-    (codec/parse-tag tag)
-    (codec/cached-parse tag)))
+    (rf.bench.hicasso.front.codec/parse-tag tag)
+    (rf.bench.hicasso.front.codec/cached-parse tag)))
 
 (defn- walk-native [mode argv]
   (let [parsed     (walk-parse mode (nth argv 0))
@@ -485,15 +485,15 @@
         ;; first lane, and wrapping it in an empty map is exactly what
         ;; hides the lane from the clock.
         js-props   (walk-convert-props mode props parsed)]
-    (controlled/install! (.-tag ^js parsed) js-props)
+    (rf.bench.hicasso.front.controlled/install! (.-tag ^js parsed) js-props)
     (when-some [k (:key props)] (unchecked-set js-props "key" k))
     (walk-make-element mode (.-tag ^js parsed) js-props argv (if has-props? 2 1))))
 
 (defn- walk-boundary [mode argv]
   (let [has-props? (map? (nth argv 1 nil))
-        props      (codec/merge-caller (if has-props? (nth argv 1) {}))
-        children   (codec/realize-children argv (if has-props? 2 1))
-        body-props (codec/realize-deep (cond-> (dissoc props :key)
+        props      (rf.bench.hicasso.front.codec/merge-caller (if has-props? (nth argv 1) {}))
+        children   (rf.bench.hicasso.front.codec/realize-children argv (if has-props? 2 1))
+        body-props (rf.bench.hicasso.front.codec/realize-deep (cond-> (dissoc props :key)
                                          children (assoc :children children)))
         head       (nth argv 0)
         js-props   #js {"rfProps" body-props}]
@@ -501,8 +501,8 @@
     ;; The frame-as-a-prop variant's one emission cost (rf2-2rtt6.39).
     ;; Priced at nothing on THIS page — the census counts zero boundaries
     ;; — and copied anyway, so the arm stays a copy of what ships.
-    (when (codec/frame-prop-head? head)
-      (unchecked-set js-props "rfFrame" intent/*frame*))
+    (when (rf.bench.hicasso.front.codec/frame-prop-head? head)
+      (unchecked-set js-props "rfFrame" rf.bench.hicasso.front.intent/*frame*))
     (walk-create mode head js-props)))
 
 (defn- walk-fragment [mode argv]
@@ -518,7 +518,7 @@
       (= :<> head)                 (walk-fragment mode argv)
       (and (or (keyword? head) (symbol? head) (string? head))
            (not (= :<> head)))     (walk-native mode argv)
-      (codec/boundary-head? head)  (walk-boundary mode argv)
+      (rf.bench.hicasso.front.codec/boundary-head? head)  (walk-boundary mode argv)
       :else (throw (ex-info "bad head in local walk" {:head head})))))
 
 (defn- walk-el [mode x]
@@ -574,7 +574,7 @@
                 (cond
                   (= :<> head) (bump :fragment)
                   (or (keyword? head) (symbol? head) (string? head))
-                  (let [p (codec/cached-parse head)]
+                  (let [p (rf.bench.hicasso.front.codec/cached-parse head)]
                     (bump :native)
                     (when (.-className ^js p) (bump :shorthand-class))
                     (when (.-id ^js p) (bump :shorthand-id)))
@@ -600,7 +600,7 @@
   "Whole-page walks inside ONE timing window. Chrome clamps
   `performance.now` to 100 us; eight ~1,200-element walks hold the window
   in whole milliseconds, so the clamp is percent-level noise, not the
-  signal (the same argument as `lane/mount-batch!`)."
+  signal (the same argument as `rf.bench.hicasso.lane/mount-batch!`)."
   8)
 
 (defn- fresh-pages
@@ -614,7 +614,7 @@
 
 (defn- realize-pages! [^js pages]
   (dotimes [i (.-length pages)]
-    (codec/realize-deep (aget pages i)))
+    (rf.bench.hicasso.front.codec/realize-deep (aget pages i)))
   pages)
 
 (defn- timed-walks
@@ -626,14 +626,14 @@
     (fn []
       (let [pages (fresh-pages walks-per-sample)
             _     (when realize? (realize-pages! pages))
-            t0    (lane/now-ms)]
+            t0    (rf.bench.hicasso.lane/now-ms)]
         (dotimes [i walks-per-sample]
           (walk-one (aget pages i)))
-        (- (lane/now-ms) t0)))))
+        (- (rf.bench.hicasso.lane/now-ms) t0)))))
 
 (def ^:private arms
-  [{:id :ship-lazy   :realize? false :walk (fn [h] (codec/as-element h))}
-   {:id :ship        :realize? true  :walk (fn [h] (codec/as-element h))}
+  [{:id :ship-lazy   :realize? false :walk (fn [h] (rf.bench.hicasso.front.codec/as-element h))}
+   {:id :ship        :realize? true  :walk (fn [h] (rf.bench.hicasso.front.codec/as-element h))}
    {:id :local       :realize? true  :walk (fn [h] (walk-el M-FULL h))}
    {:id :no-create   :realize? true  :walk (fn [h] (walk-el M-NO-CREATE h))}
    {:id :no-props    :realize? true  :walk (fn [h] (walk-el M-NO-PROPS h))}
@@ -681,11 +681,11 @@
   [reps ^js arr f]
   (let [sink (volatile! nil)
         n    (.-length arr)
-        t0   (lane/now-ms)]
+        t0   (rf.bench.hicasso.lane/now-ms)]
     (dotimes [_ reps]
       (dotimes [i n]
         (vreset! sink (f (aget arr i)))))
-    (let [ms (- (lane/now-ms) t0)]
+    (let [ms (- (rf.bench.hicasso.lane/now-ms) t0)]
       (/ (* 1e6 ms) (* reps n)))))
 
 (def ^:private micro-reps 300)
@@ -696,16 +696,16 @@
                        (dotimes [i (.-length keys)]
                          (.push a (name (aget keys i))))
                        a)]
-    [[:cached-parse-hit    (ns-per-op micro-reps tags (fn [t] (codec/cached-parse t)))]
-     [:parse-tag-fresh     (ns-per-op (quot micro-reps 10) tags (fn [t] (codec/parse-tag t)))]
-     [:cached-prop-name    (ns-per-op micro-reps keys (fn [k] (codec/cached-prop-name k)))]
-     [:event-prop?-regex   (ns-per-op micro-reps keys (fn [k] (intent/event-prop? k)))]
+    [[:cached-parse-hit    (ns-per-op micro-reps tags (fn [t] (rf.bench.hicasso.front.codec/cached-parse t)))]
+     [:parse-tag-fresh     (ns-per-op (quot micro-reps 10) tags (fn [t] (rf.bench.hicasso.front.codec/parse-tag t)))]
+     [:cached-prop-name    (ns-per-op micro-reps keys (fn [k] (rf.bench.hicasso.front.codec/cached-prop-name k)))]
+     [:event-prop?-regex   (ns-per-op micro-reps keys (fn [k] (rf.bench.hicasso.front.intent/event-prop? k)))]
      [:reserved-set-lookup (ns-per-op micro-reps fixed-names (fn [n] (reserved-names n)))]
      [:reserved-identical  (ns-per-op micro-reps fixed-names
                                       (fn [n] (or (identical? "__proto__" n)
                                                   (identical? "prototype" n)
                                                   (identical? "constructor" n))))]
-     [:convert-prop-value  (ns-per-op micro-reps vals (fn [v] (codec/convert-prop-value v)))]
+     [:convert-prop-value  (ns-per-op micro-reps vals (fn [v] (rf.bench.hicasso.front.codec/convert-prop-value v)))]
      [:create-element-min  (ns-per-op (quot micro-reps 10) tags
                                       (fn [_] (react/createElement "div" simple-props)))]]))
 
@@ -716,14 +716,14 @@
 (defn- fmt [x n] (.toFixed ^number x n))
 
 (defn- arm-rows
-  "Fold `lane/rounds!` readings into per-arm p50/min/max (ms per WALK —
+  "Fold `rf.bench.hicasso.lane/rounds!` readings into per-arm p50/min/max (ms per WALK —
   the window is `walks-per-sample` walks)."
   [readings]
   (into {}
         (map (fn [id]
                (let [xs (mapcat #(get % id) readings)
                      per-walk (mapv #(/ % walks-per-sample) xs)]
-                 [id (lane/summarise per-walk)])))
+                 [id (rf.bench.hicasso.lane/summarise per-walk)])))
         (map :id arms)))
 
 (defn- phase-line [label ship-p50 base p50 elements]
@@ -739,7 +739,7 @@
 ;;
 ;; Until rf2-1huc this arm had none, so `run.cjs`'s `HICASSO_CONTROL_FAILED`
 ;; exit path was dead here: the run was guarded against ORDERING
-;; (`lane/guard!`, exit 2) and against PAGE FIDELITY ([[parity!]], fatal) but
+;; (`rf.bench.hicasso.lane/guard!`, exit 2) and against PAGE FIDELITY ([[parity!]], fatal) but
 ;; not against the instrument HAVING SIGNAL AT ALL. A run whose ablations had
 ;; stopped biting would still print a full table and exit 0.
 
@@ -750,7 +750,7 @@
   fold for a reported figure and the wrong one for a control: pooling is
   exactly how a good round vouches for a bad one."
   [round id]
-  (:p50 (lane/summarise (mapv #(/ % walks-per-sample) (get round id)))))
+  (:p50 (rf.bench.hicasso.lane/summarise (mapv #(/ % walks-per-sample) (get round id)))))
 
 (defn- per-round-delta
   "`hi` minus `lo` in ms per walk, one number per round."
@@ -773,7 +773,7 @@
   parses cost, as this run's OWN micro table prices them.
 
   `parse-raw` differs from `local` at exactly one site — [[walk-parse]]
-  calls `codec/parse-tag` fresh where `local` calls `codec/cached-parse`
+  calls `rf.bench.hicasso.front.codec/parse-tag` fresh where `local` calls `rf.bench.hicasso.front.codec/cached-parse`
   — and it does so once per native element. The MICRO table times both
   primitives over [[collect-roster]]'s tags, which is that same
   population, element for element. So the extra work `parse-raw` does per
@@ -783,7 +783,7 @@
 
   ## Why a FLOOR and not a band
 
-  The bead's candidate was `lane/control-verdict` — a two-sided band
+  The bead's candidate was `rf.bench.hicasso.lane/control-verdict` — a two-sided band
   around this prediction. Costed rather than assumed, it does not hold:
   the micro loop is the CHEAPEST possible arrangement of the same calls
   (one warm array, one call site, no allocation surviving the loop),
@@ -801,7 +801,7 @@
 
   ## Why EVERY ROUND and not an overlap
 
-  `lane/control-verdict` passes a control whose measured range merely
+  `rf.bench.hicasso.lane/control-verdict` passes a control whose measured range merely
   OVERLAPS the band. Its disagreement with `hd8-rows/positive-control!`'s
   every-round-inside rule was rf2-egdaq, settled on 2026-08-21 as a
   SPLIT: the heap arm's ten published figures were re-adjudicated strict
@@ -849,13 +849,13 @@
         ;; than sliding through a comparison that is false either way.
         stated? (pos? floor)]
     {:row        :tag-cache-floor
-     :predicted  (lane/round4 floor)
-     :bar        (lane/round4 bar)
+     :predicted  (rf.bench.hicasso.lane/round4 floor)
+     :bar        (rf.bench.hicasso.lane/round4 bar)
      :slack      control-slack
      :stated?    stated?
      :population {:micro-roster n-tags :walk-parses parses}
-     :per-round  (mapv lane/round4 deltas)
-     :worst      (lane/round4 worst)
+     :per-round  (mapv rf.bench.hicasso.lane/round4 deltas)
+     :worst      (rf.bench.hicasso.lane/round4 worst)
      :ok?        (and same? stated? (>= worst bar))
      :why        (cond
                    (not same?)
@@ -906,8 +906,8 @@
   (let [deltas (per-round-delta readings :ship-lazy :ship)
         worst  (apply min deltas)]
     {:row       :lazy-tail-direction
-     :per-round (mapv lane/round4 deltas)
-     :worst     (lane/round4 worst)
+     :per-round (mapv rf.bench.hicasso.lane/round4 deltas)
+     :worst     (rf.bench.hicasso.lane/round4 worst)
      :ok?       (pos? worst)
      :why       (if (pos? worst)
                   (str "ship-lazy above ship in all " (count deltas)
@@ -941,28 +941,28 @@
     (js/console.log (str ";;   " (name row) ": " (control-status r) " — " why))))
 
 (defn ^:export -main []
-  (rf/init! uix-adapter/adapter)
-  (lane/leave-act-environment!)
-  (lane/self-test!)
+  (rf/init! rf.adapter.uix/adapter)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/self-test!)
   (-> (js/Promise.resolve nil)
       (.then
         (fn [_]
-          (lt/make-frame! frame-id)
-          (lt/reseed! frame-id)
+          (rf.bench.hicasso.shapes.large-template/make-frame! frame-id)
+          (rf.bench.hicasso.shapes.large-template/reseed! frame-id)
           (let [{:keys [elements bytes]} (parity!)]
             (js/console.log (str ";; twin parity OK — " elements " elements, "
-                                 bytes " canonical bytes, identical to lt/page"))
+                                 bytes " canonical bytes, identical to rf.bench.hicasso.shapes.large-template/page"))
             ;; The census + rosters, from one realized page.
-            (let [page (in-body (fn [] (codec/realize-deep (page-hiccup))))
+            (let [page (in-body (fn [] (rf.bench.hicasso.front.codec/realize-deep (page-hiccup))))
                   cs   (census page)
                   roster (collect-roster page)
                   ;; The interleaved rounds.
                   {:keys [readings samples]}
-                  (lane/rounds! arms sampling rounds
+                  (rf.bench.hicasso.lane/rounds! arms sampling rounds
                                 (fn [{:keys [realize? walk]}]
                                   (timed-walks realize? walk)))
                   rows (arm-rows readings)
-                  gv   (lane/guard! samples "walk-profile arms (in-page ms, diagnostic)")
+                  gv   (rf.bench.hicasso.lane/guard! samples "walk-profile arms (in-page ms, diagnostic)")
                   ship (:p50 (get rows :ship))
                   local (:p50 (get rows :local))
                   micro (micro-table roster)
@@ -971,14 +971,14 @@
                   ;; constant carried from a previous one.
                   control [(tag-cache-floor-row readings cs (:tags roster) micro)
                            (lazy-tail-direction-row readings)]]
-              (lane/record! :walk-profile-census cs)
-              (lane/record! :walk-profile-arms
-                            (into {} (map (fn [[k v]] [k (-> v (update :min lane/round4)
-                                                             (update :max lane/round4)
-                                                             (update :p50 lane/round4))])) rows))
-              (lane/record! :walk-profile-micro
-                            (into {} (map (fn [[k v]] [k (lane/round4 v)])) micro))
-              (lane/record! :walk-profile-control control)
+              (rf.bench.hicasso.lane/record! :walk-profile-census cs)
+              (rf.bench.hicasso.lane/record! :walk-profile-arms
+                            (into {} (map (fn [[k v]] [k (-> v (update :min rf.bench.hicasso.lane/round4)
+                                                             (update :max rf.bench.hicasso.lane/round4)
+                                                             (update :p50 rf.bench.hicasso.lane/round4))])) rows))
+              (rf.bench.hicasso.lane/record! :walk-profile-micro
+                            (into {} (map (fn [[k v]] [k (rf.bench.hicasso.lane/round4 v)])) micro))
+              (rf.bench.hicasso.lane/record! :walk-profile-control control)
               (js/console.log ";; ==== WALK PROFILE (ms per whole-page walk; diagnostic in-page clock) ====")
               (js/console.log (str ";;   elements " elements
                                    "  walks/sample " walks-per-sample
@@ -1016,7 +1016,7 @@
               ;; this file ever set it, so that exit was unreachable here.
               (when-not (every? :ok? control)
                 (set! (.-HICASSO_CONTROL_FAILED js/window) true))
-              (lane/done!)))))
+              (rf.bench.hicasso.lane/done!)))))
       (.catch (fn [e]
-                (lane/fail! (or (some-> e .-message) (str e)))
-                (lane/done!)))))
+                (rf.bench.hicasso.lane/fail! (or (some-> e .-message) (str e)))
+                (rf.bench.hicasso.lane/done!)))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/walk_profile_baseline_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/walk_profile_baseline_cljs_test.cljs
@@ -11,12 +11,12 @@
   red, because both numbers still look plausible.
 
   That is not hypothetical here: it is what the merged-PR #7383 audit
-  found. `walk-value` called `codec/convert-prop-value`, and that same
+  found. `walk-value` called `rf.bench.hicasso.front.codec/convert-prop-value`, and that same
   PR reordered `convert-prop-value`'s branches. The prop-NAME half was
   frozen locally in the PR itself (`local-prop-cache`); the prop-VALUE
   half was not, and this file exists because the fix for that is exactly
   the kind of thing a later refactor re-breaks by reaching for the
-  obvious `codec/` name.
+  obvious `rf.bench.hicasso.front.codec/` name.
 
   ## What is asserted, and why in this shape
 
@@ -32,23 +32,23 @@
      same probe, so a zero can never be read off a probe that was never
      live.
 
-  Reverting `walk-value` to `codec/convert-prop-value` fails (2) and
+  Reverting `walk-value` to `rf.bench.hicasso.front.codec/convert-prop-value` fails (2) and
   leaves (1) green, which is the whole point: (1) is why the freeze is
   safe, (2) is why the freeze is there.
 
   ## Deliberately not asserted
 
-  `codec/cached-parse` keeps the candidate's cheaper reserved-name check
+  `rf.bench.hicasso.front.codec/cached-parse` keeps the candidate's cheaper reserved-name check
   in the baseline. That residue is deliberate and reasoned on
   `walk-profile-app/local-convert-prop-value`'s docstring — the
   `parse-raw` benefit line prices the tag cache and needs both its arms
   on one parse implementation — so a test here would only re-litigate
   it, and would go red the day someone freezes it properly."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.bench.hicasso.front.codec :as codec]
-            [re-frame.bench.hicasso.walk-profile-app :as app]))
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
+            [re-frame.bench.hicasso.walk-profile-app :as rf.bench.hicasso.walk-profile-app]))
 
-(use-fixtures :each {:before (fn [] (codec/reset-caches!))})
+(use-fixtures :each {:before (fn [] (rf.bench.hicasso.front.codec/reset-caches!))})
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures
@@ -68,7 +68,7 @@
 
 (def ^:private string-keyed
   "A string-keyed attribute map — the one spelling that reaches
-  `codec/cached-prop-name` on the SHIPPING side, so the control for the
+  `rf.bench.hicasso.front.codec/cached-prop-name` on the SHIPPING side, so the control for the
   prop-name probe has something to count."
   [:div {"data-testid" "string-keyed" "aria-label" "x"}])
 
@@ -91,10 +91,10 @@
           obj    #js {:a 1}
           arr    (array 1 2)]
       (doseq [v ["href" f obj arr 42 nil true false]]
-        (is (identical? v (app/local-convert-prop-value v))
+        (is (identical? v (rf.bench.hicasso.walk-profile-app/local-convert-prop-value v))
             (str "frozen converter must pass " (pr-str v) " through by identity"))
-        (is (identical? (codec/convert-prop-value v)
-                        (app/local-convert-prop-value v))
+        (is (identical? (rf.bench.hicasso.front.codec/convert-prop-value v)
+                        (rf.bench.hicasso.walk-profile-app/local-convert-prop-value v))
             (str "frozen and shipping must agree by identity on " (pr-str v))))))
 
   (testing "the classes the codec CONVERTS, converted the same way"
@@ -105,53 +105,53 @@
                ["a" "b"]
                #{"a"}
                [:conduit/show-your-feed]]]
-      (is (= (js->clj (codec/convert-prop-value v))
-             (js->clj (app/local-convert-prop-value v)))
+      (is (= (js->clj (rf.bench.hicasso.front.codec/convert-prop-value v))
+             (js->clj (rf.bench.hicasso.walk-profile-app/local-convert-prop-value v)))
           (str "frozen and shipping must agree on " (pr-str v)))))
 
   (testing "a nested map camelCases its keys, through the frozen name lookup"
     (is (= {"backgroundColor" "red"}
-           (js->clj (app/local-convert-prop-value {:background-color "red"})))))
+           (js->clj (rf.bench.hicasso.walk-profile-app/local-convert-prop-value {:background-color "red"})))))
 
   (testing "the two are DISTINCT functions — a freeze that aliased the
             shipping var would satisfy every assertion above"
-    (is (not (identical? codec/convert-prop-value app/local-convert-prop-value)))))
+    (is (not (identical? rf.bench.hicasso.front.codec/convert-prop-value rf.bench.hicasso.walk-profile-app/local-convert-prop-value)))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2. The baseline arm does not enter the shipping helpers
 ;; ---------------------------------------------------------------------------
 
 (deftest the-baseline-arm-never-enters-the-shipping-value-converter
-  (let [real codec/convert-prop-value
-        install! (fn [n] (set! codec/convert-prop-value
+  (let [real rf.bench.hicasso.front.codec/convert-prop-value
+        install! (fn [n] (set! rf.bench.hicasso.front.codec/convert-prop-value
                                (fn [v] (swap! n inc) (real v))))
-        restore! (fn [] (set! codec/convert-prop-value real))]
+        restore! (fn [] (set! rf.bench.hicasso.front.codec/convert-prop-value real))]
 
     (testing "CONTROL — the shipping walk does enter it, so the probe is live"
-      (is (pos? (probe install! restore! #(codec/as-element keyword-keyed)))
+      (is (pos? (probe install! restore! #(rf.bench.hicasso.front.codec/as-element keyword-keyed)))
           "the shipping walk must reach convert-prop-value on this fixture"))
 
     (testing "the local arm converts every value through its OWN frozen copy"
-      (is (zero? (probe install! restore! #(app/walk-arm app/M-FULL keyword-keyed)))
+      (is (zero? (probe install! restore! #(rf.bench.hicasso.walk-profile-app/walk-arm rf.bench.hicasso.walk-profile-app/M-FULL keyword-keyed)))
           (str "the `local` arm is the in-process A/B's OLD arm; entering the "
                "shipping converter absorbs the rf2-y1jkm candidate into the "
                "baseline it is measured against (merged-PR #7383 audit)")))
 
     (testing "and so does the no-value ablation, which converts nothing at all"
-      (is (zero? (probe install! restore! #(app/walk-arm app/M-NO-VALUE keyword-keyed)))))))
+      (is (zero? (probe install! restore! #(rf.bench.hicasso.walk-profile-app/walk-arm rf.bench.hicasso.walk-profile-app/M-NO-VALUE keyword-keyed)))))))
 
 (deftest the-baseline-arm-never-enters-the-shipping-prop-name-cache
-  (let [real codec/cached-prop-name
-        install! (fn [n] (set! codec/cached-prop-name
+  (let [real rf.bench.hicasso.front.codec/cached-prop-name
+        install! (fn [n] (set! rf.bench.hicasso.front.codec/cached-prop-name
                                (fn [k] (swap! n inc) (real k))))
-        restore! (fn [] (set! codec/cached-prop-name real))]
+        restore! (fn [] (set! rf.bench.hicasso.front.codec/cached-prop-name real))]
 
     (testing "CONTROL — the shipping walk does enter it on a string-keyed map"
-      (is (pos? (probe install! restore! #(codec/as-element string-keyed)))
+      (is (pos? (probe install! restore! #(rf.bench.hicasso.front.codec/as-element string-keyed)))
           "the shipping walk must reach cached-prop-name on this fixture"))
 
     (testing "the local arm names every prop through local-prop-name"
-      (is (zero? (probe install! restore! #(app/walk-arm app/M-FULL keyword-keyed)))
+      (is (zero? (probe install! restore! #(rf.bench.hicasso.walk-profile-app/walk-arm rf.bench.hicasso.walk-profile-app/M-FULL keyword-keyed)))
           "keyword-keyed props must take the frozen string-valued cache")
-      (is (zero? (probe install! restore! #(app/walk-arm app/M-FULL string-keyed)))
+      (is (zero? (probe install! restore! #(rf.bench.hicasso.walk-profile-app/walk-arm rf.bench.hicasso.walk-profile-app/M-FULL string-keyed)))
           "string-keyed props must take the frozen path too"))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/walk_profile_control_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/walk_profile_control_cljs_test.cljs
@@ -22,7 +22,7 @@
   ## The one assertion that carries the design
 
   [[strict-rule-beats-overlap]] is the reason this file is not merely
-  belt-and-braces. `lane/control-verdict`'s `:ok?` asks whether the
+  belt-and-braces. `rf.bench.hicasso.lane/control-verdict`'s `:ok?` asks whether the
   measured range OVERLAPS the band; the walk profile's control asks
   whether EVERY ROUND clears the bar. rf2-egdaq has since settled that
   disagreement, and it settled as a SPLIT — one rule per instrument, not
@@ -36,7 +36,7 @@
 
   That test drives ONE dataset through BOTH rules and asserts they
   disagree on it: overlap passes, every-round refuses. A worker who
-  \"simplifies\" the control down to `lane/control-verdict` therefore
+  \"simplifies\" the control down to `rf.bench.hicasso.lane/control-verdict` therefore
   discovers it here, rather than in a bench run six months later that
   quietly stopped having teeth.
 
@@ -51,8 +51,8 @@
   and its siblings below pin it by arithmetic instead. That is the second
   reason this file exists and not merely belt-and-braces either."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.walk-profile-app :as wp]))
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.walk-profile-app :as rf.bench.hicasso.walk-profile-app]))
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures — the shapes `-main` actually hands the control
@@ -96,7 +96,7 @@
 (deftest fixture-scaling-matches-the-app
   (testing "the fixture scales by the same K the control divides by — a
             drifted constant would silently move every bar below"
-    (let [rows (wp/tag-cache-floor-row [(healthy 0.20)] census roster micro)]
+    (let [rows (rf.bench.hicasso.walk-profile-app/tag-cache-floor-row [(healthy 0.20)] census roster micro)]
       ;; 1000 tags x 100 ns = 0.1 ms; bar = 0.1 x (1 - 0.25).
       (is (= floor-ms (:predicted rows)))
       (is (= bar-ms (:bar rows)))
@@ -109,7 +109,7 @@
 
 (deftest an-instrument-with-signal-passes
   (testing "every round comfortably above the floor"
-    (let [r (wp/tag-cache-floor-row [(healthy 0.20) (healthy 0.25) (healthy 0.18)]
+    (let [r (rf.bench.hicasso.walk-profile-app/tag-cache-floor-row [(healthy 0.20) (healthy 0.25) (healthy 0.18)]
                                     census roster micro)]
       (is (true? (:ok? r)))
       (is (= 0.18 (:worst r))))))
@@ -117,7 +117,7 @@
 (deftest an-instrument-with-no-signal-refuses
   (testing "the planted-fault shape: the ablation stops biting, so the
             deltas collapse toward zero and the control must refuse"
-    (let [r (wp/tag-cache-floor-row [(healthy 0.01) (healthy 0.02) (healthy -0.01)]
+    (let [r (rf.bench.hicasso.walk-profile-app/tag-cache-floor-row [(healthy 0.01) (healthy 0.02) (healthy -0.01)]
                                     census roster micro)]
       (is (false? (:ok? r)))
       (is (re-find #"BELOW it" (:why r))
@@ -125,12 +125,12 @@
 
 (deftest strict-rule-beats-overlap
   (testing "ONE dataset, TWO rules, opposite verdicts — this is why the
-            control does not call `lane/control-verdict` (rf2-egdaq)"
+            control does not call `rf.bench.hicasso.lane/control-verdict` (rf2-egdaq)"
     (let [readings [(healthy 0.20) (healthy 0.20) (healthy 0.03)]
-          strict   (wp/tag-cache-floor-row readings census roster micro)
+          strict   (rf.bench.hicasso.walk-profile-app/tag-cache-floor-row readings census roster micro)
           ;; The same three rounds offered to the lane's overlap rule, as
           ;; the `{:min :max :mean}` range it takes.
-          overlap  (lane/control-verdict floor-ms {:min 0.03 :max 0.20 :mean 0.1433} 0.25)]
+          overlap  (rf.bench.hicasso.lane/control-verdict floor-ms {:min 0.03 :max 0.20 :mean 0.1433} 0.25)]
       (is (true? (:ok? overlap))
           "the overlap rule PASSES it — a good round vouches for a bad one")
       (is (false? (:ok? strict))
@@ -176,7 +176,7 @@
   (testing "fresh == cached predicts NO extra cost, so there is nothing for
             the walk to have seen — and a control with nothing to see must
             not report that it saw it"
-    (let [r (wp/tag-cache-floor-row [(healthy 0.20) (healthy 0.25)] census roster
+    (let [r (rf.bench.hicasso.walk-profile-app/tag-cache-floor-row [(healthy 0.20) (healthy 0.25)] census roster
                                     micro-converged)]
       (is (= 0.0 (:predicted r)) "the fixture really does state a zero floor")
       (is (false? (:ok? r))
@@ -188,7 +188,7 @@
 (deftest the-audits-exact-converged-case
   (testing "cached 50 ns, fresh 50 ns, observed delta 0 — reported ok TRUE
             at merge 825cd611c8"
-    (let [r (wp/tag-cache-floor-row [(healthy 0.0)] census roster micro-converged)]
+    (let [r (rf.bench.hicasso.walk-profile-app/tag-cache-floor-row [(healthy 0.0)] census roster micro-converged)]
       (is (= 0.0 (:predicted r)))
       (is (= 0.0 (:bar r)))
       (is (= 0.0 (:worst r)))
@@ -198,7 +198,7 @@
   (testing "cached 150 ns, fresh 50 ns, observed delta 0 — reported ok TRUE
             at merge 825cd611c8, because a NEGATIVE floor puts the bar
             below every real measurement"
-    (let [r (wp/tag-cache-floor-row [(healthy 0.0)] census roster micro-inverted)]
+    (let [r (rf.bench.hicasso.walk-profile-app/tag-cache-floor-row [(healthy 0.0)] census roster micro-inverted)]
       (is (= -0.1 (:predicted r)))
       (is (= -0.075 (:bar r)))
       (is (false? (:ok? r)))
@@ -208,7 +208,7 @@
   (testing "the other route to a vacuous bar: nothing to predict over. The
             population rule cannot catch it, because an empty roster and a
             walk that parses nothing agree with each other"
-    (let [r (wp/tag-cache-floor-row [(healthy 0.20)] {:native 0} (make-array 0) micro)]
+    (let [r (rf.bench.hicasso.walk-profile-app/tag-cache-floor-row [(healthy 0.20)] {:native 0} (make-array 0) micro)]
       (is (= 0.0 (:predicted r)))
       (is (false? (:ok? r)))
       (is (false? (:stated? r))))))
@@ -216,8 +216,8 @@
 (deftest an-absent-prediction-is-reported-DIFFERENTLY-from-a-missed-bar
   (testing "two refusals, two causes, two repairs — an operator told only
             `FAILED` would go looking at the arms, where nothing is wrong"
-    (let [vacuous (wp/tag-cache-floor-row [(healthy 0.20)] census roster micro-converged)
-          missed  (wp/tag-cache-floor-row [(healthy 0.01)] census roster micro)]
+    (let [vacuous (rf.bench.hicasso.walk-profile-app/tag-cache-floor-row [(healthy 0.20)] census roster micro-converged)
+          missed  (rf.bench.hicasso.walk-profile-app/tag-cache-floor-row [(healthy 0.01)] census roster micro)]
       (is (false? (:ok? vacuous)))
       (is (false? (:ok? missed)))
       (is (false? (:stated? vacuous)))
@@ -225,22 +225,22 @@
           "the missed bar had a real prediction; it is the ARMS that missed it")
       (is (re-find #"states no prediction" (:why vacuous)))
       (is (re-find #"BELOW it" (:why missed)))
-      (is (= "REFUSED — no prediction" (wp/control-status vacuous)))
-      (is (= "FAILED" (wp/control-status missed)))
-      (is (= "ok" (wp/control-status (wp/tag-cache-floor-row
+      (is (= "REFUSED — no prediction" (rf.bench.hicasso.walk-profile-app/control-status vacuous)))
+      (is (= "FAILED" (rf.bench.hicasso.walk-profile-app/control-status missed)))
+      (is (= "ok" (rf.bench.hicasso.walk-profile-app/control-status (rf.bench.hicasso.walk-profile-app/tag-cache-floor-row
                                        [(healthy 0.20)] census roster micro)))))))
 
 (deftest a-real-prediction-still-passes-on-real-signal
   (testing "the repair must not have closed the door on the healthy case —
             the whole point is a control that can still say yes"
-    (is (true? (:ok? (wp/tag-cache-floor-row [(healthy 0.20) (healthy 0.18)]
+    (is (true? (:ok? (rf.bench.hicasso.walk-profile-app/tag-cache-floor-row [(healthy 0.20) (healthy 0.18)]
                                              census roster micro))))))
 
 (deftest a-roster-that-is-not-the-walks-parse-population-refuses
   (testing "the prediction is per-tag over the micro roster, so a roster
             that is not what the walk parses prices the wrong thing —
             and every delta below is otherwise healthy"
-    (let [r (wp/tag-cache-floor-row [(healthy 0.20) (healthy 0.20)]
+    (let [r (rf.bench.hicasso.walk-profile-app/tag-cache-floor-row [(healthy 0.20) (healthy 0.20)]
                                     {:native 999} roster micro)]
       (is (false? (:ok? r)))
       (is (= {:micro-roster 1000 :walk-parses 999} (:population r))))))
@@ -251,10 +251,10 @@
 
 (deftest the-lazy-arm-must-read-above-the-eager-one-in-every-round
   (testing "ship-lazy does strictly more work than ship by construction"
-    (is (true? (:ok? (wp/lazy-tail-direction-row [(healthy 0.2) (healthy 0.2)])))))
+    (is (true? (:ok? (rf.bench.hicasso.walk-profile-app/lazy-tail-direction-row [(healthy 0.2) (healthy 0.2)])))))
   (testing "a single inverted round refuses, even beside two good ones —
             an inversion means the window is not pricing the walk"
-    (let [r (wp/lazy-tail-direction-row
+    (let [r (rf.bench.hicasso.walk-profile-app/lazy-tail-direction-row
               [(healthy 0.2)
                (round {:local 0.6 :parse-raw 0.8 :ship 1.50 :ship-lazy 1.40})
                (healthy 0.2)])]

--- a/bench/hicasso/src/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
@@ -18,9 +18,9 @@
 
   The page is `walk_profile_app`'s twin of the acceptance shape — the
   same 1,202-element census page, guarded by that file's own fatal
-  canonical-DOM parity gate against the real `lt/page`, so there is one
+  canonical-DOM parity gate against the real `rf.bench.hicasso.shapes.large-template/page`, so there is one
   twin in the lane and not two. It is **realized once, outside every
-  timed window** (`codec/realize-deep`), which is what makes these rows
+  timed window** (`rf.bench.hicasso.front.codec/realize-deep`), which is what makes these rows
   immune to the route-link render term `rf2-cno31` is fixing: every
   `route-link` href on the page is synthesised during realisation and is
   a plain string by the time any arm walks it. No timed window here
@@ -38,7 +38,7 @@
   ## Workload matching is gated, not asserted
 
   Every arm's element tree is rendered into a fresh container and its
-  canonical DOM read (`lane/canonical`, attribute names sorted). The
+  canonical DOM read (`rf.bench.hicasso.lane/canonical`, attribute names sorted). The
   three canonicals and the three element counts are reported beside the
   rows: a decomposition of arms whose OUTPUT differs would be a
   decomposition of nothing.
@@ -58,7 +58,7 @@
   2. STAGES — the same primitive, ours and Reagent's, over the page's own
      literal roster: tag lookup, prop-name lookup, value conversion, the
      whole per-element prop pipeline, the per-element tag hook
-     (`controlled/install!` against `input/input-component?`), and child
+     (`rf.bench.hicasso.front.controlled/install!` against `input/input-component?`), and child
      dispatch. **Absolute ns/element**, because two-thirds of a mount
      window is shared frame work and a ratio cannot be read against it.
   3. CANDIDATES — costed BEFORE anything is landed. Each is a shape the
@@ -67,15 +67,15 @@
 
   Owner bead: rf2-2rtt6.63. Driver: `run.cjs` with
   HICASSO_INIT_FN=re-frame.bench.hicasso.walk-vs-reagent-app/-main."
-  (:require [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.arm1.mount :as arm1-mount]
-            [re-frame.bench.hicasso.front.codec :as codec]
-            [re-frame.bench.hicasso.front.controlled :as controlled]
-            [re-frame.bench.hicasso.front.intent :as intent]
-            [re-frame.bench.hicasso.front.slot :as slot]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.hicasso.shapes.large-template :as lt]
-            [re-frame.bench.hicasso.walk-profile-app :as wp]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.arm1.mount :as rf.bench.hicasso.arm1.mount]
+            [re-frame.bench.hicasso.front.codec :as rf.bench.hicasso.front.codec]
+            [re-frame.bench.hicasso.front.controlled :as rf.bench.hicasso.front.controlled]
+            [re-frame.bench.hicasso.front.intent :as rf.bench.hicasso.front.intent]
+            [re-frame.bench.hicasso.front.slot :as rf.bench.hicasso.front.slot]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.hicasso.shapes.large-template :as rf.bench.hicasso.shapes.large-template]
+            [re-frame.bench.hicasso.walk-profile-app :as rf.bench.hicasso.walk-profile-app]
             [re-frame.core :as rf]
             [reagent.impl.input :as rinput]
             [reagent.impl.protocols :as rp]
@@ -102,7 +102,7 @@
   native one everywhere it can."
   [m]
   (reduce-kv (fn [acc k _v]
-               (if (and (keyword? k) (intent/event-prop? k))
+               (if (and (keyword? k) (rf.bench.hicasso.front.intent/event-prop? k))
                  (assoc acc k noop)
                  acc))
              m
@@ -136,11 +136,11 @@
   answer `[canonical-dom element-count]`. The tree is a value, so this
   runs no interpreter and belongs to no timed window."
   [el]
-  (let [c    (arm1-mount/fresh-container!)
+  (let [c    (rf.bench.hicasso.arm1.mount/fresh-container!)
         root (react-dom-client/createRoot c)]
     (react-dom/flushSync (fn [] (.render root el)))
-    (let [canon (lane/canonical c)
-          n     (lane/element-count c)]
+    (let [canon (rf.bench.hicasso.lane/canonical c)
+          n     (rf.bench.hicasso.lane/element-count c)]
       (react-dom/flushSync (fn [] (.unmount root)))
       (.remove c)
       [canon n])))
@@ -224,12 +224,12 @@
   the only reason that measurement's error was caught. The clock starts
   INSIDE the door, so the door itself is never in the window."
   [witness walk-one]
-  (wp/in-body
+  (rf.bench.hicasso.walk-profile-app/in-body
     (fn []
-      (let [t0 (lane/now-ms)]
+      (let [t0 (rf.bench.hicasso.lane/now-ms)]
         (dotimes [_ walks-per-sample]
           (walk-one witness))
-        (- (lane/now-ms) t0)))))
+        (- (rf.bench.hicasso.lane/now-ms) t0)))))
 
 (def ^:private sampling {:warmup 4 :samples 10})
 (def ^:private rounds 6)
@@ -244,11 +244,11 @@
   [reps ^js arr f]
   (let [sink (volatile! nil)
         n    (.-length arr)
-        t0   (lane/now-ms)]
+        t0   (rf.bench.hicasso.lane/now-ms)]
     (dotimes [_ reps]
       (dotimes [i n]
         (vreset! sink (f (aget arr i)))))
-    (let [ms (- (lane/now-ms) t0)]
+    (let [ms (- (rf.bench.hicasso.lane/now-ms) t0)]
       (/ (* 1e6 ms) (* reps n)))))
 
 (defn- ns-per-op2
@@ -257,11 +257,11 @@
   [reps ^js a ^js b f]
   (let [sink (volatile! nil)
         n    (.-length a)
-        t0   (lane/now-ms)]
+        t0   (rf.bench.hicasso.lane/now-ms)]
     (dotimes [_ reps]
       (dotimes [i n]
         (vreset! sink (f (aget a i) (aget b i)))))
-    (let [ms (- (lane/now-ms) t0)]
+    (let [ms (- (rf.bench.hicasso.lane/now-ms) t0)]
       (/ (* 1e6 ms) (* reps n)))))
 
 (def ^:private micro-reps 200)
@@ -275,7 +275,7 @@
         ;; rows price the PIPELINE and not two different tag lookups.
         h-parsed (let [a #js []]
                    (dotimes [i (.-length el-tags)]
-                     (.push a (codec/cached-parse (aget el-tags i))))
+                     (.push a (rf.bench.hicasso.front.codec/cached-parse (aget el-tags i))))
                    a)
         r-parsed (let [a #js []]
                    (dotimes [i (.-length el-tags)]
@@ -286,29 +286,29 @@
                      (.push a (.-tag ^js (aget h-parsed i))))
                    a)]
     [;; --- tag lookup -------------------------------------------------
-     [:tag-lookup-hicasso (ns-per-op micro-reps tags (fn [t] (codec/cached-parse t)))]
+     [:tag-lookup-hicasso (ns-per-op micro-reps tags (fn [t] (rf.bench.hicasso.front.codec/cached-parse t)))]
      [:tag-lookup-reagent (ns-per-op micro-reps tags
                                      (fn [t] (rtpl/cached-parse nil (name t) t)))]
      ;; --- prop-name lookup -------------------------------------------
-     [:prop-name-hicasso (ns-per-op micro-reps prop-keys (fn [k] (codec/cached-prop-name k)))]
+     [:prop-name-hicasso (ns-per-op micro-reps prop-keys (fn [k] (rf.bench.hicasso.front.codec/cached-prop-name k)))]
      [:prop-name-slim    (ns-per-op micro-reps prop-keys (fn [k] (slim/cached-prop-name k)))]
      [:prop-name-reagent (ns-per-op micro-reps prop-keys (fn [k] (rtpl/cached-prop-name k)))]
      ;; --- value conversion -------------------------------------------
-     [:prop-value-hicasso (ns-per-op micro-reps prop-vals (fn [v] (codec/convert-prop-value v)))]
+     [:prop-value-hicasso (ns-per-op micro-reps prop-vals (fn [v] (rf.bench.hicasso.front.codec/convert-prop-value v)))]
      [:prop-value-slim    (ns-per-op micro-reps prop-vals (fn [v] (slim/convert-prop-value v)))]
      [:prop-value-reagent (ns-per-op micro-reps prop-vals (fn [v] (rtpl/convert-prop-value v)))]
      ;; --- the whole per-element prop pipeline -------------------------
      [:convert-props-hicasso
-      (ns-per-op2 micro-reps el-props h-parsed (fn [p ^js t] (codec/convert-props p t)))]
+      (ns-per-op2 micro-reps el-props h-parsed (fn [p ^js t] (rf.bench.hicasso.front.codec/convert-props p t)))]
      [:convert-props-reagent
       (ns-per-op2 micro-reps el-props r-parsed (fn [p ^js t] (rtpl/convert-props p t)))]
      ;; --- the per-element tag hook ------------------------------------
      [:tag-hook-hicasso (ns-per-op micro-reps tag-strs
-                                   (fn [t] (controlled/install! t #js {})))]
+                                   (fn [t] (rf.bench.hicasso.front.controlled/install! t #js {})))]
      [:tag-hook-reagent (ns-per-op micro-reps tag-strs
                                    (fn [t] (rinput/input-component? t)))]
      ;; --- child dispatch ----------------------------------------------
-     [:string-child-hicasso (ns-per-op micro-reps strings (fn [s] (codec/as-element s)))]
+     [:string-child-hicasso (ns-per-op micro-reps strings (fn [s] (rf.bench.hicasso.front.codec/as-element s)))]
      [:string-child-slim    (ns-per-op micro-reps strings (fn [s] (slim/as-element s)))]
      [:string-child-reagent (ns-per-op micro-reps strings
                                        (fn [s] (rp/as-element rtpl/class-compiler s)))]
@@ -368,7 +368,7 @@
   "All three arms cache the same value shape the codec caches, so the
   rows price the LOOKUP and not two different payloads."
   [k n]
-  (codec/->PropSlot (slot/prop-name k) (reserved-name? n) false false false))
+  (rf.bench.hicasso.front.codec/->PropSlot (rf.bench.hicasso.front.slot/prop-name k) (reserved-name? n) false false false))
 
 (defn- guarded-lookup
   "The shipping lookup shape, written here so every arm is local."
@@ -394,7 +394,7 @@
 (defn- instcheck-lookup [k]
   (let [n (name k)
         v (unchecked-get instcheck-cache n)]
-    (if (instance? codec/PropSlot v)
+    (if (instance? rf.bench.hicasso.front.codec/PropSlot v)
       v
       (let [v' (mint-slot k n)]
         (when-not (reserved-name? n) (unchecked-set instcheck-cache n v'))
@@ -410,10 +410,10 @@
 (defn- guarded-tag-lookup [t]
   (let [k (tag-cache-key t)]
     (if (reserved-name? k)
-      (codec/parse-tag t)
+      (rf.bench.hicasso.front.codec/parse-tag t)
       (if (.call has-own guarded-tag-cache k)
         (unchecked-get guarded-tag-cache k)
-        (let [v (codec/parse-tag t)]
+        (let [v (rf.bench.hicasso.front.codec/parse-tag t)]
           (unchecked-set guarded-tag-cache k v)
           v)))))
 
@@ -421,7 +421,7 @@
   (let [k (tag-cache-key t)
         v (unchecked-get nullproto-tag-cache k)]
     (if (undefined? v)
-      (let [v' (codec/parse-tag t)]
+      (let [v' (rf.bench.hicasso.front.codec/parse-tag t)]
         (when-not (reserved-name? k) (unchecked-set nullproto-tag-cache k v'))
         v')
       v)))
@@ -429,9 +429,9 @@
 (defn- instcheck-tag-lookup [t]
   (let [k (tag-cache-key t)
         v (unchecked-get instcheck-tag-cache k)]
-    (if (instance? codec/ParsedTag v)
+    (if (instance? rf.bench.hicasso.front.codec/ParsedTag v)
       v
-      (let [v' (codec/parse-tag t)]
+      (let [v' (rf.bench.hicasso.front.codec/parse-tag t)]
         (when-not (reserved-name? k) (unchecked-set instcheck-tag-cache k v'))
         v'))))
 
@@ -480,7 +480,7 @@
 ;; No `^js` hint: these read DEFTYPE fields, whose names the compiler
 ;; munges (`js-name` -> `js_name`, `reserved?` -> `reserved_QMARK_`). The
 ;; codec reads them the same way, through its own `^PropSlot` hint.
-(defn- slot= [^codec/PropSlot a ^codec/PropSlot b]
+(defn- slot= [^rf.bench.hicasso.front.codec/PropSlot a ^rf.bench.hicasso.front.codec/PropSlot b]
   (and (= (.-js-name a) (.-js-name b))
        (= (.-reserved? a) (.-reserved? b))))
 
@@ -544,7 +544,7 @@
 ;; first. §1's statement that the route-link term is "structurally absent
 ;; from this instrument" is true of the `route-url` SYNTHESIS — that
 ;; happens once, at `realize-deep`, outside every window — and is not true
-;; of the navigate vector's LOWERING, which `codec/as-element` performs
+;; of the navigate vector's LOWERING, which `rf.bench.hicasso.front.codec/as-element` performs
 ;; inside every timed window of the native arm and never on the plain one.
 ;;
 ;; So the rows below split the gap by carrier and price each against what
@@ -570,9 +570,9 @@
                     props      (when has-props? (nth argv 1))]
                 (when props
                   (doseq [[k v] props]
-                    (when (and (keyword? k) (intent/event-prop? k))
+                    (when (and (keyword? k) (rf.bench.hicasso.front.intent/event-prop? k))
                       (cond
-                        (intent/navigate-head? v) (do (.push nav-ks k)
+                        (rf.bench.hicasso.front.intent/navigate-head? v) (do (.push nav-ks k)
                                                       (.push nav-vs v)
                                                       (.push nav-maps (nth v 1 nil)))
                         (vector? v)               (do (.push int-ks k) (.push int-vs v))
@@ -671,11 +671,11 @@
      [:roster-intent-positions       (.-length intent-keys)]
      [:roster-other-event-positions  (.-length other-keys)]
      ;; --- the navigate carrier: minted by route-link, 1 per link -------
-     [:lower-navigate-native (ns-per-op2 micro-reps nav-keys nav-vals intent/lower-prop)]
-     [:lower-navigate-plain  (ns-per-op2 micro-reps nav-keys nav-plain intent/lower-prop)]
+     [:lower-navigate-native (ns-per-op2 micro-reps nav-keys nav-vals rf.bench.hicasso.front.intent/lower-prop)]
+     [:lower-navigate-plain  (ns-per-op2 micro-reps nav-keys nav-plain rf.bench.hicasso.front.intent/lower-prop)]
      ;; --- the author-written carrier -----------------------------------
-     [:lower-intent-native   (ns-per-op2 micro-reps intent-keys intent-vals intent/lower-prop)]
-     [:lower-intent-plain    (ns-per-op2 micro-reps intent-keys int-plain intent/lower-prop)]
+     [:lower-intent-native   (ns-per-op2 micro-reps intent-keys intent-vals rf.bench.hicasso.front.intent/lower-prop)]
+     [:lower-intent-plain    (ns-per-op2 micro-reps intent-keys int-plain rf.bench.hicasso.front.intent/lower-prop)]
      ;; --- the closed-grammar check inside the navigate carrier ---------
      [:navmap-keyset-shipping (ns-per-op micro-reps nav-maps navmap-keyset-shipping)]
      [:navmap-keyset-scan     (ns-per-op micro-reps nav-maps navmap-keyset-scan)]]))
@@ -1183,32 +1183,32 @@
         (map (fn [id]
                (let [xs       (mapcat #(get % id) readings)
                      per-walk (mapv #(/ % walks-per-sample) xs)]
-                 [id (lane/summarise per-walk)])))
+                 [id (rf.bench.hicasso.lane/summarise per-walk)])))
         (map :id arms)))
 
 (defn ^:export -main []
-  (rf/init! uix-adapter/adapter)
-  (lane/leave-act-environment!)
-  (lane/self-test!)
+  (rf/init! rf.adapter.uix/adapter)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/self-test!)
   (-> (js/Promise.resolve nil)
       (.then
         (fn [_]
-          (lt/make-frame! wp/frame-id)
-          (lt/reseed! wp/frame-id)
-          (let [{:keys [elements bytes]} (wp/parity!)]
+          (rf.bench.hicasso.shapes.large-template/make-frame! rf.bench.hicasso.walk-profile-app/frame-id)
+          (rf.bench.hicasso.shapes.large-template/reseed! rf.bench.hicasso.walk-profile-app/frame-id)
+          (let [{:keys [elements bytes]} (rf.bench.hicasso.walk-profile-app/parity!)]
             (js/console.log (str ";; twin parity OK — " elements " elements, "
-                                 bytes " canonical bytes, identical to lt/page"))
-            (let [native  (wp/in-body (fn [] (codec/realize-deep (wp/page-hiccup))))
+                                 bytes " canonical bytes, identical to rf.bench.hicasso.shapes.large-template/page"))
+            (let [native  (rf.bench.hicasso.walk-profile-app/in-body (fn [] (rf.bench.hicasso.front.codec/realize-deep (rf.bench.hicasso.walk-profile-app/page-hiccup))))
                   plain   (plainify native)
                   roster  (collect-roster plain)
                   arms    [{:id :hicasso        :witness plain
-                            :walk (fn [h] (codec/as-element h))}
+                            :walk (fn [h] (rf.bench.hicasso.front.codec/as-element h))}
                            {:id :slim           :witness plain
                             :walk (fn [h] (slim/as-element h))}
                            {:id :reagent        :witness plain
                             :walk (fn [h] (rp/as-element rtpl/class-compiler h))}
                            {:id :hicasso-native :witness native
-                            :walk (fn [h] (codec/as-element h))}]
+                            :walk (fn [h] (rf.bench.hicasso.front.codec/as-element h))}]
                   ;; ---- workload matching, before any figure ------------
                   ;; The tree is built inside the body door (the native
                   ;; arm's lowering needs it) and RENDERED outside it, so
@@ -1216,27 +1216,27 @@
                   canons  (into {}
                                 (map (fn [{:keys [id witness walk]}]
                                        [id (render-canonical
-                                             (wp/in-body (fn [] (walk witness))))]))
+                                             (rf.bench.hicasso.walk-profile-app/in-body (fn [] (walk witness))))]))
                                 arms)
                   ref-canon (first (get canons :hicasso))
                   parity  (into {}
                                 (map (fn [[id [canon n]]]
-                                       ;; `lane/utf8-bytes` and not `count`:
+                                       ;; `rf.bench.hicasso.lane/utf8-bytes` and not `count`:
                                        ;; printed below as "canonical bytes",
                                        ;; and `count` answers UTF-16 code
                                        ;; units (rf2-2rtt6.121).
                                        [id {:elements n
-                                            :bytes    (lane/utf8-bytes canon)
+                                            :bytes    (rf.bench.hicasso.lane/utf8-bytes canon)
                                             :same?    (= canon ref-canon)
                                             :diverges (when-not (= canon ref-canon)
                                                         (first-divergence ref-canon canon))}]))
                                 canons)
                   ;; ---- the interleaved rounds --------------------------
                   {:keys [readings samples]}
-                  (lane/rounds! arms sampling rounds
+                  (rf.bench.hicasso.lane/rounds! arms sampling rounds
                                 (fn [{:keys [witness walk]}] (timed-walks witness walk)))
                   rows    (arm-rows arms readings)
-                  gv      (lane/guard! samples "walk-vs-reagent arms (in-page ms, diagnostic)")
+                  gv      (rf.bench.hicasso.lane/guard! samples "walk-vs-reagent arms (in-page ms, diagnostic)")
                   stages  (stage-table roster)
                   cand-bad (candidate-agreement roster)
                   cands   (candidate-table roster)
@@ -1247,29 +1247,29 @@
                   ;; inside the body door (rf2-vw412).
                   iroster  (collect-intent-roster native)
                   intent-bad (intent-agreement iroster)
-                  intents  (wp/in-body (fn [] (intent-table iroster)))
+                  intents  (rf.bench.hicasso.walk-profile-app/in-body (fn [] (intent-table iroster)))
                   hic     (:p50 (get rows :hicasso))
                   rgt     (:p50 (get rows :reagent))
                   slm     (:p50 (get rows :slim))]
 
-              (lane/record! :walk-vs-reagent-parity parity)
-              (lane/record! :walk-vs-reagent-arms
+              (rf.bench.hicasso.lane/record! :walk-vs-reagent-parity parity)
+              (rf.bench.hicasso.lane/record! :walk-vs-reagent-arms
                             (into {} (map (fn [[k v]]
-                                            [k (-> v (update :min lane/round4)
-                                                   (update :max lane/round4)
-                                                   (update :p50 lane/round4))]))
+                                            [k (-> v (update :min rf.bench.hicasso.lane/round4)
+                                                   (update :max rf.bench.hicasso.lane/round4)
+                                                   (update :p50 rf.bench.hicasso.lane/round4))]))
                                   rows))
-              (lane/record! :walk-vs-reagent-stages
-                            (into {} (map (fn [[k v]] [k (lane/round4 v)])) stages))
-              (lane/record! :walk-vs-reagent-candidates
+              (rf.bench.hicasso.lane/record! :walk-vs-reagent-stages
+                            (into {} (map (fn [[k v]] [k (rf.bench.hicasso.lane/round4 v)])) stages))
+              (rf.bench.hicasso.lane/record! :walk-vs-reagent-candidates
                             {:disagreements cand-bad
-                             :ns-per-op (into {} (map (fn [[k v]] [k (lane/round4 v)])) cands)})
-              (lane/record! :walk-vs-reagent-slim
+                             :ns-per-op (into {} (map (fn [[k v]] [k (rf.bench.hicasso.lane/round4 v)])) cands)})
+              (rf.bench.hicasso.lane/record! :walk-vs-reagent-slim
                             {:disagreements slim-bad
-                             :ns-per-op (into {} (map (fn [[k v]] [k (lane/round4 v)])) slims)})
-              (lane/record! :walk-vs-reagent-intent
+                             :ns-per-op (into {} (map (fn [[k v]] [k (rf.bench.hicasso.lane/round4 v)])) slims)})
+              (rf.bench.hicasso.lane/record! :walk-vs-reagent-intent
                             {:disagreements intent-bad
-                             :ns-per-op (into {} (map (fn [[k v]] [k (lane/round4 v)])) intents)})
+                             :ns-per-op (into {} (map (fn [[k v]] [k (rf.bench.hicasso.lane/round4 v)])) intents)})
 
               (js/console.log ";; ==== WORKLOAD MATCH (every arm's own DOM, canonical) ====")
               (doseq [{:keys [id]} arms]
@@ -1346,7 +1346,7 @@
 
               (when (:refuse? gv)
                 (set! (.-HICASSO_GUARD_REFUSED js/window) true))
-              (lane/done!)))))
+              (rf.bench.hicasso.lane/done!)))))
       (.catch (fn [e]
-                (lane/fail! (or (some-> e .-message) (str e)))
-                (lane/done!)))))
+                (rf.bench.hicasso.lane/fail! (or (some-> e .-message) (str e)))
+                (rf.bench.hicasso.lane/done!)))))

--- a/bench/hicasso/src/re_frame/bench/hicasso/z3vlz_mixed.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/z3vlz_mixed.cljs
@@ -11,13 +11,13 @@
 
   `?install=reagent` runs the identical probe with stock Reagent installed
   — the bead's positive control, in the bead's own bundle."
-  (:require [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.z3vlz-probe :as probe]
-            [re-frame.bench.hicasso.z3vlz-reagent-substrate :as stock]
-            [re-frame.bench.hicasso.z3vlz-slim-substrate :as slim]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.z3vlz-probe :as rf.bench.hicasso.z3vlz-probe]
+            [re-frame.bench.hicasso.z3vlz-reagent-substrate :as rf.bench.hicasso.z3vlz-reagent-substrate]
+            [re-frame.bench.hicasso.z3vlz-slim-substrate :as rf.bench.hicasso.z3vlz-slim-substrate]
             [re-frame.core :as rf]))
 
-(def ^:export adapter-ref uix-adapter/adapter)
+(def ^:export adapter-ref rf.adapter.uix/adapter)
 
 (defn- install-stock? []
   (boolean (some->> (some-> js/window .-location .-search)
@@ -26,8 +26,8 @@
 (defn ^:export -main []
   (set! (.-Z3VLZ_UIX_ADAPTER js/window) (pr-str (:kind adapter-ref)))
   (let [stock? (install-stock?)]
-    (rf/init! (if stock? stock/adapter slim/adapter))
-    (probe/run-probe! (if stock? stock/substrate slim/substrate)
+    (rf/init! (if stock? rf.bench.hicasso.z3vlz-reagent-substrate/adapter rf.bench.hicasso.z3vlz-slim-substrate/adapter))
+    (rf.bench.hicasso.z3vlz-probe/run-probe! (if stock? rf.bench.hicasso.z3vlz-reagent-substrate/substrate rf.bench.hicasso.z3vlz-slim-substrate/substrate)
                 {:bundle      :mixed
                  :installed   (if stock? :reagent :reagent-slim)
                  :compiled-in [:reagent2 :reagent :uix]}

--- a/bench/hicasso/src/re_frame/bench/hicasso/z3vlz_probe.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/z3vlz_probe.cljs
@@ -65,9 +65,9 @@
   Owner: rf2-z3vlz. Normative context: `docs/design/hicasso/decisions.md`
   HD-008."
   (:require ["react-dom" :as react-dom]
-            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame])
+            [re-frame.frame :as rf.frame])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ---------------------------------------------------------------------------
@@ -144,14 +144,14 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- cells-text [container]
-  (mapv (fn [i] (lane/text-at container i)) (range cells-n)))
+  (mapv (fn [i] (rf.bench.hicasso.lane/text-at container i)) (range cells-n)))
 
 (defn- all-at?
   "EVERY cell, not one. A stale page can still hold one fresh cell from a
   previous write, so a single-probe check verifies almost nothing."
   [container v]
   (let [want (str v)]
-    (every? (fn [i] (= want (lane/text-at container i))) (range cells-n))))
+    (every? (fn [i] (= want (rf.bench.hicasso.lane/text-at container i))) (range cells-n))))
 
 ;; ---------------------------------------------------------------------------
 ;; THE THIRD VARIABLE — the ORDER of write against drain
@@ -201,7 +201,7 @@
                 "still full, so the drain has something to flush")}
    {:id    :yield-then-drain
     :doc   (str "write, yield ONE microtask, then drain — the shape of "
-                "`lane/verified-write!`, and therefore of HD-008's arm")}])
+                "`rf.bench.hicasso.lane/verified-write!`, and therefore of HD-008's arm")}])
 
 ;; ---------------------------------------------------------------------------
 ;; One verified write, with the escalation ladder
@@ -231,7 +231,7 @@
                                          (.then (microtask) (fn [_] (drain!)))))
         db-followed? (when fid
                        (= (vec (repeat cells-n v))
-                          (:cells (frame/frame-app-db-value fid))))]
+                          (:cells (rf.frame/frame-app-db-value fid))))]
     (-> started
         (.then (fn [_] (when (all-at? container v) (vreset! rung :sync))))
         (.then (fn [_]
@@ -262,12 +262,12 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- write-fn
-  "Alternate `frame/replace-app-db!` and a registered event through
+  "Alternate `rf.frame/replace-app-db!` and a registered event through
   `dispatch-sync`. The bead reproduced with BOTH, so a probe that used one
   would leave the other unanswered."
   [fid v mechanism]
   (case mechanism
-    :replace-app-db (fn [] (frame/replace-app-db! fid (seed-db v)))
+    :replace-app-db (fn [] (rf.frame/replace-app-db! fid (seed-db v)))
     :dispatch-sync  (fn [] (rf/dispatch-sync [:z3vlz/set-all v] {:frame fid}))))
 
 ;; ---------------------------------------------------------------------------
@@ -328,7 +328,7 @@
   "Run [[writes-n]] verified writes under EVERY order, serially, against a
   standing mount. Answers a promise of the flat result vector."
   [substrate container fid write-of]
-  (lane/chain []
+  (rf.bench.hicasso.lane/chain []
               (for [{:keys [id]} orders, v (range 1 (inc writes-n))] [id v])
               (fn [acc [order v]]
                 (let [[mech write!] (write-of v)]
@@ -340,8 +340,8 @@
   mounted through the substrate's own door, written through re-frame."
   [{:keys [unmount] :as substrate} fid]
   (rf/make-frame {:id fid})
-  (frame/replace-app-db! fid (seed-db 0))
-  (let [container   (lane/fresh-container!)
+  (rf.frame/replace-app-db! fid (seed-db 0))
+  (let [container   (rf.bench.hicasso.lane/fresh-container!)
         handle      (mount! substrate container (root fid cells-n))
         mount-cells (cells-text container)
         mount-ok?   (all-at? container 0)]
@@ -358,17 +358,17 @@
                  ;; a contaminated document. The container is detached either
                  ;; way; the record is what makes it fatal. A NORMAL return is
                  ;; not taken at its word either (rf2-z3vlz, from the PR #7291
-                 ;; audit): `lane/container-released!` reads the container
-                 ;; before it goes, exactly as `lane/release!` does.
+                 ;; audit): `rf.bench.hicasso.lane/container-released!` reads the container
+                 ;; before it goes, exactly as `rf.bench.hicasso.lane/release!` does.
                  (when (try (unmount handle)
                             true
                             (catch :default e
-                              (lane/teardown-failure! "z3vlz subs-arm unmount" e)))
-                   (lane/container-released! "z3vlz subs-arm unmount" container))
+                              (rf.bench.hicasso.lane/teardown-failure! "z3vlz subs-arm unmount" e)))
+                   (rf.bench.hicasso.lane/container-released! "z3vlz subs-arm unmount" container))
                  (.remove container)
                  {:mount    {:ok? mount-ok? :cells mount-cells}
                   :orders   (tally results)
-                  :teardown (lane/drain-teardown-failures!)
+                  :teardown (rf.bench.hicasso.lane/drain-teardown-failures!)
                   :failed   (vec (take 3 (remove :ok? results)))})))))
 
 (defn- run-raw-control!
@@ -385,7 +385,7 @@
   inert."
   [{:keys [unmount raw-element raw-write!] :as substrate}]
   (raw-write! 0)
-  (let [container (lane/fresh-container!)
+  (let [container (rf.bench.hicasso.lane/fresh-container!)
         handle    (mount! substrate container (raw-element))
         mount-ok? (all-at? container 0)]
     (-> (writes-over-orders! substrate container nil
@@ -397,23 +397,23 @@
                  ;; would be measured on a page still carrying the control's
                  ;; roots and its ratom's watchers. A NORMAL return is not
                  ;; taken at its word either (rf2-z3vlz, from the PR #7291
-                 ;; audit): `lane/container-released!` reads the container
-                 ;; before it goes, exactly as `lane/release!` does.
+                 ;; audit): `rf.bench.hicasso.lane/container-released!` reads the container
+                 ;; before it goes, exactly as `rf.bench.hicasso.lane/release!` does.
                  (when (try (unmount handle)
                             true
                             (catch :default e
-                              (lane/teardown-failure! "z3vlz raw-control unmount" e)))
-                   (lane/container-released! "z3vlz raw-control unmount" container))
+                              (rf.bench.hicasso.lane/teardown-failure! "z3vlz raw-control unmount" e)))
+                   (rf.bench.hicasso.lane/container-released! "z3vlz raw-control unmount" container))
                  (.remove container)
                  {:mount    {:ok? mount-ok?}
                   :orders   (tally results)
-                  :teardown (lane/drain-teardown-failures!)})))))
+                  :teardown (rf.bench.hicasso.lane/drain-teardown-failures!)})))))
 
 ;; ---------------------------------------------------------------------------
 ;; The gate payload — the same figures, in a shape a driver can ADJUDICATE
 ;; ---------------------------------------------------------------------------
 ;;
-;; `lane/record!` parks EDN strings, which are for a reader. A driver that
+;; `rf.bench.hicasso.lane/record!` parks EDN strings, which are for a reader. A driver that
 ;; had to scrape them with regexes would be a second, drifting expression
 ;; of the same arithmetic — and a regex that stopped matching would report
 ;; `?` and pass, which is the fail-open shape this rig is being repaired
@@ -464,15 +464,15 @@
   [substrate {:keys [bundle installed compiled-in]} fid]
   (-> (run-raw-control! substrate)
       (.then (fn [control]
-               (lane/record! :raw-control control)
+               (rf.bench.hicasso.lane/record! :raw-control control)
                (-> (run-subs-arm! substrate fid)
                    (.then (fn [subs] [control subs])))))
       (.then (fn [[control subs]]
-               (lane/record! :subs-arm subs)
+               (rf.bench.hicasso.lane/record! :subs-arm subs)
                (publish-gates! control subs)
                (let [o (:orders subs)
                      un (fn [k] (get-in o [k :summary]))]
-                 (lane/record! :verdict
+                 (rf.bench.hicasso.lane/record! :verdict
                    {:bundle         bundle
                     :installed      installed
                     :compiled-in    compiled-in
@@ -491,11 +491,11 @@
                          "arm-to-arm ratio, so there is nothing for the guard to "
                          "adjudicate. The only numbers here are write and DOM "
                          "read-back counts.")}))
-               (lane/done!)
+               (rf.bench.hicasso.lane/done!)
                nil))
       (.catch (fn [e]
-                (lane/fail! (str "the probe threw: " (.-message e) "\n" (.-stack e)))
-                (lane/done!)
+                (rf.bench.hicasso.lane/fail! (str "the probe threw: " (.-message e) "\n" (.-stack e)))
+                (rf.bench.hicasso.lane/done!)
                 nil))))
 
 (defn run-probe!
@@ -506,8 +506,8 @@
   Answers a promise of the whole record and parks it under
   `window.HICASSO_RESULTS` via [[re-frame.bench.hicasso.lane/record!]]."
   [substrate manifest fid]
-  (lane/leave-act-environment!)
-  (lane/record! :manifest (assoc manifest :runtime (lane/runtime-label)
+  (rf.bench.hicasso.lane/leave-act-environment!)
+  (rf.bench.hicasso.lane/record! :manifest (assoc manifest :runtime (rf.bench.hicasso.lane/runtime-label)
                                           :cells cells-n :writes writes-n))
   ;; SYNCHRONOUS throws get the same treatment as rejections. A mount that
   ;; throws before the first `.then` would otherwise escape the chain
@@ -516,6 +516,6 @@
   (try
     (run-chain! substrate manifest fid)
     (catch :default e
-      (lane/fail! (str "the probe threw synchronously: " (.-message e) "\n" (.-stack e)))
-      (lane/done!)
+      (rf.bench.hicasso.lane/fail! (str "the probe threw synchronously: " (.-message e) "\n" (.-stack e)))
+      (rf.bench.hicasso.lane/done!)
       nil)))

--- a/bench/hicasso/src/re_frame/bench/hicasso/z3vlz_reagent_substrate.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/z3vlz_reagent_substrate.cljs
@@ -17,23 +17,23 @@
   a require whose code `:advanced` could prove dead would not reproduce
   the bundle the bead describes."
   (:require ["react-dom" :as react-dom]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.bench.hicasso.z3vlz-probe :as probe]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.bench.hicasso.z3vlz-probe :as rf.bench.hicasso.z3vlz-probe]
             [reagent.core :as r]
             [reagent.dom.client :as rdc]
             [reagent.ratom :as reagent-ratom]))
 
-(defonce ^:private raw-cells (r/atom (vec (repeat probe/cells-n 0))))
+(defonce ^:private raw-cells (r/atom (vec (repeat rf.bench.hicasso.z3vlz-probe/cells-n 0))))
 
 (defn- raw-list []
   (let [cells @raw-cells]
     [:ul.grid {:role "list"}
-     (for [i (range probe/cells-n)]
+     (for [i (range rf.bench.hicasso.z3vlz-probe/cells-n)]
        ^{:key i} [:li.row
                   [:span.lbl "cell "]
                   [:span.cell {:data-i i} (str (get cells i))]])]))
 
-(def adapter reagent-adapter/adapter)
+(def adapter rf.adapter.reagent/adapter)
 
 (def substrate
   {:label       :reagent
@@ -50,4 +50,4 @@
    ;; it passed 78 of 78 in HD-008 beside a slim arm that failed 78 of 78.
    :drain-with! (fn [f] (react-dom/flushSync (fn [] (f) (reagent-ratom/flush!) (r/flush))))
    :raw-element (fn [] [raw-list])
-   :raw-write!  (fn [v] (reset! raw-cells (vec (repeat probe/cells-n v))))})
+   :raw-write!  (fn [v] (reset! raw-cells (vec (repeat rf.bench.hicasso.z3vlz-probe/cells-n v))))})

--- a/bench/hicasso/src/re_frame/bench/hicasso/z3vlz_slim_only.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/z3vlz_slim_only.cljs
@@ -20,13 +20,13 @@
   `implementation/hicasso/test/re_frame/bench/hicasso/z3vlz_run.cjs` on
   rf2-2rtt6.2's `:hicasso-bench` build id — no new build id, so
   `implementation/shadow-cljs.edn` is untouched."
-  (:require [re-frame.bench.hicasso.z3vlz-probe :as probe]
-            [re-frame.bench.hicasso.z3vlz-slim-substrate :as slim]
+  (:require [re-frame.bench.hicasso.z3vlz-probe :as rf.bench.hicasso.z3vlz-probe]
+            [re-frame.bench.hicasso.z3vlz-slim-substrate :as rf.bench.hicasso.z3vlz-slim-substrate]
             [re-frame.core :as rf]))
 
 (defn ^:export -main []
-  (rf/init! slim/adapter)
-  (probe/run-probe! slim/substrate
+  (rf/init! rf.bench.hicasso.z3vlz-slim-substrate/adapter)
+  (rf.bench.hicasso.z3vlz-probe/run-probe! rf.bench.hicasso.z3vlz-slim-substrate/substrate
               {:bundle      :slim-only
                :installed   :reagent-slim
                :compiled-in [:reagent2]}

--- a/bench/hicasso/src/re_frame/bench/hicasso/z3vlz_slim_reagent.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/z3vlz_slim_reagent.cljs
@@ -11,9 +11,9 @@
   arm that passed 78 of 78 while the slim arm failed 78 of 78), preserved
   here as the brief requires: a negative result about reagent-slim is only
   meaningful beside a positive one taken in the same harness."
-  (:require [re-frame.bench.hicasso.z3vlz-probe :as probe]
-            [re-frame.bench.hicasso.z3vlz-reagent-substrate :as stock]
-            [re-frame.bench.hicasso.z3vlz-slim-substrate :as slim]
+  (:require [re-frame.bench.hicasso.z3vlz-probe :as rf.bench.hicasso.z3vlz-probe]
+            [re-frame.bench.hicasso.z3vlz-reagent-substrate :as rf.bench.hicasso.z3vlz-reagent-substrate]
+            [re-frame.bench.hicasso.z3vlz-slim-substrate :as rf.bench.hicasso.z3vlz-slim-substrate]
             [re-frame.core :as rf]))
 
 (defn install-stock?
@@ -25,8 +25,8 @@
 
 (defn ^:export -main []
   (let [stock? (install-stock?)]
-    (rf/init! (if stock? stock/adapter slim/adapter))
-    (probe/run-probe! (if stock? stock/substrate slim/substrate)
+    (rf/init! (if stock? rf.bench.hicasso.z3vlz-reagent-substrate/adapter rf.bench.hicasso.z3vlz-slim-substrate/adapter))
+    (rf.bench.hicasso.z3vlz-probe/run-probe! (if stock? rf.bench.hicasso.z3vlz-reagent-substrate/substrate rf.bench.hicasso.z3vlz-slim-substrate/substrate)
                 {:bundle      :slim+reagent
                  :installed   (if stock? :reagent :reagent-slim)
                  :compiled-in [:reagent2 :reagent]}

--- a/bench/hicasso/src/re_frame/bench/hicasso/z3vlz_slim_substrate.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/z3vlz_slim_substrate.cljs
@@ -17,13 +17,13 @@
       `reagent2.ratom/flush!` — SETTLE, THEN RENDER. Both halves are
       load-bearing and this is the same drain HD-008's arm used, so a
       difference between the two runs cannot be the drain."
-  (:require [re-frame.adapter.reagent-slim :as slim-adapter]
-            [re-frame.bench.hicasso.z3vlz-probe :as probe]
+  (:require [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
+            [re-frame.bench.hicasso.z3vlz-probe :as rf.bench.hicasso.z3vlz-probe]
             [reagent2.core :as r2]
             [reagent2.dom.client :as rdc2]
             [reagent2.ratom :as ratom2]))
 
-(defonce ^:private raw-cells (r2/atom (vec (repeat probe/cells-n 0))))
+(defonce ^:private raw-cells (r2/atom (vec (repeat rf.bench.hicasso.z3vlz-probe/cells-n 0))))
 
 (defn- raw-list
   "The positive control's component: plain reagent-slim reading a plain
@@ -37,12 +37,12 @@
   []
   (let [cells @raw-cells]
     [:ul.grid {:role "list"}
-     (for [i (range probe/cells-n)]
+     (for [i (range rf.bench.hicasso.z3vlz-probe/cells-n)]
        ^{:key i} [:li.row
                   [:span.lbl "cell "]
                   [:span.cell {:data-i i} (str (get cells i))]])]))
 
-(def adapter slim-adapter/adapter)
+(def adapter rf.adapter.reagent-slim/adapter)
 
 (def substrate
   {:label       :reagent-slim
@@ -59,4 +59,4 @@
    ;; adapter's own `reagent_slim_flush_render_dom_cljs_test` pins it.
    :drain-with! (fn [f] (rdc2/flush-render! (fn [] (f) (ratom2/flush!))))
    :raw-element (fn [] [raw-list])
-   :raw-write!  (fn [v] (reset! raw-cells (vec (repeat probe/cells-n v))))})
+   :raw-write!  (fn [v] (reset! raw-cells (vec (repeat rf.bench.hicasso.z3vlz-probe/cells-n v))))})

--- a/bench/hicasso/src/re_frame/bench/hicasso/z3vlz_slim_uix.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/z3vlz_slim_uix.cljs
@@ -10,17 +10,17 @@
   The UIx adapter is REFERENCED, not merely required — `adapter-ref` is
   exported onto `window` — so `:advanced` cannot prove the namespace dead
   and elide the load-time hook publication that candidate (c) is about."
-  (:require [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.hicasso.z3vlz-probe :as probe]
-            [re-frame.bench.hicasso.z3vlz-slim-substrate :as slim]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.hicasso.z3vlz-probe :as rf.bench.hicasso.z3vlz-probe]
+            [re-frame.bench.hicasso.z3vlz-slim-substrate :as rf.bench.hicasso.z3vlz-slim-substrate]
             [re-frame.core :as rf]))
 
-(def ^:export adapter-ref uix-adapter/adapter)
+(def ^:export adapter-ref rf.adapter.uix/adapter)
 
 (defn ^:export -main []
   (set! (.-Z3VLZ_UIX_ADAPTER js/window) (pr-str (:kind adapter-ref)))
-  (rf/init! slim/adapter)
-  (probe/run-probe! slim/substrate
+  (rf/init! rf.bench.hicasso.z3vlz-slim-substrate/adapter)
+  (rf.bench.hicasso.z3vlz-probe/run-probe! rf.bench.hicasso.z3vlz-slim-substrate/substrate
               {:bundle      :slim+uix
                :installed   :reagent-slim
                :compiled-in [:reagent2 :uix]}

--- a/bench/hicasso/src/re_frame/bench/hicasso_narrow.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso_narrow.cljs
@@ -41,7 +41,7 @@
                            Reagent's own `r/atom` and `make-reaction`,
                            Reagent's own batching. 300 layer-1
                            subscriptions, one per cell. The write door is
-                           `frame/replace-app-db!`, the SAME door the
+                           `rf.frame/replace-app-db!`, the SAME door the
                            donor row used, so the two are comparable
                            leg-for-leg.
 
@@ -135,8 +135,8 @@
   verification tally all existed here and there.
 
   So the shared parts are TAKEN from the lane rather than restated:
-  [[summarise]] and `chain` are `lane/`'s, and the schedule is
-  `guard/slot-order`, which the lane also merely holds. What stays local
+  [[summarise]] and `chain` are `rf.bench.hicasso.lane/`'s, and the schedule is
+  `rf.bench.order-guard/slot-order`, which the lane also merely holds. What stays local
   is what is genuinely this window's — the clock (`(js/performance.now)`
   with no branch inside a timed leg), the six-leg accumulator, and the
   `goog.object` string-literal discipline the `:advanced` bundle needs.
@@ -153,11 +153,11 @@
   Spec donor: rf2-ssn1o (closed, do-not-refile)."
   (:require ["react-dom" :as react-dom]
             [goog.object :as gobj]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.order-guard :as guard]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.order-guard :as rf.bench.order-guard]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
+            [re-frame.frame :as rf.frame]
             [reagent.core :as r]
             [reagent.dom.client :as rdc])
   (:require-macros [re-frame.core :refer [reg-view]]))
@@ -435,8 +435,8 @@
     (fn [i val]
       (case write-door
         :replace-app-db
-        (let [db (frame/frame-app-db-value frame-id)]
-          (frame/replace-app-db!
+        (let [db (rf.frame/frame-app-db-value frame-id)]
+          (rf.frame/replace-app-db!
             frame-id
             (if (= i :all)
               (assoc db :cells (vec (repeat cells-n val)))
@@ -469,7 +469,7 @@
 
 (defn make-arms
   "The measured arms, in the order they are DECLARED — the run order is
-  `guard/slot-order`'s and varies with the sample index."
+  `rf.bench.order-guard/slot-order`'s and varies with the sample index."
   []
   (into [(instrument-arm)
          (bare-ratom-arm)
@@ -497,7 +497,7 @@
   `act` diverts work to its own queue, which is not what a browser does,
   and every reading here is the browser's."
   []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
   nil)
 
@@ -526,8 +526,8 @@
 
 (def ^:private chain
   "Fold `xs` into a serial promise chain, threading an accumulator —
-  `lane/chain`, not a restatement of it (rf2-uhw11)."
-  lane/chain)
+  `rf.bench.hicasso.lane/chain`, not a restatement of it (rf2-uhw11)."
+  rf.bench.hicasso.lane/chain)
 
 (defn- timed-write!
   "One narrow write, clocked at every leg boundary, then verified at the
@@ -600,7 +600,7 @@
 
 (defn run-round!
   "One round: `(+ warmup samples)` sample indices, every arm measured at
-  every index, arm order `guard/slot-order` — rotate, then REFLECT on odd
+  every index, arm order `rf.bench.order-guard/slot-order` — rotate, then REFLECT on odd
   indices.
 
   The reflection is the both-orders discipline in situ. A bare cyclic
@@ -608,7 +608,7 @@
   slot `(a - s) mod k`, so its predecessor is `(a - 1) mod k` at every
   sample index. Reflecting on odd indices replaces every `a -> a+1`
   adjacency with `a -> a-1`, which is what gives each arm two
-  predecessors in balance and lets [[guard/verdict]] ask the question at
+  predecessors in balance and lets [[rf.bench.order-guard/verdict]] ask the question at
   all.
 
   Answers a promise of `{:samples [...] :bad n}` where each sample carries
@@ -621,7 +621,7 @@
   [mounts {:keys [warmup samples writes]} position0]
   (let [k     (count mounts)
         total (+ warmup samples)
-        plan  (vec (for [s (range total) j (guard/slot-order k s)] [s j]))]
+        plan  (vec (for [s (range total) j (rf.bench.order-guard/slot-order k s)] [s j]))]
     (chain {:samples [] :bad 0 :prev nil :pos position0}
            (range (count plan))
       (fn [acc idx]
@@ -659,13 +659,13 @@
   mean alone. Overlapping ranges mean indistinguishable, and a report that
   quotes a central value without its range cannot say that.
 
-  `lane/summarise`, not a restatement of it. This lane and the mount lane
+  `rf.bench.hicasso.lane/summarise`, not a restatement of it. This lane and the mount lane
   are two INSTRUMENTS — a mount is one timed commit, a narrow write is
   write, microtask, flush, verify — but they are one METHOD, and the
   method must not be written down twice (rf2-uhw11). The `slot-order`
   degeneracy this repository has just finished repairing was a method
   written down three times and fixed in one of them (rf2-ouwh8)."
-  lane/summarise)
+  rf.bench.hicasso.lane/summarise)
 
 (defn per-write
   "Divide a per-SAMPLE leg figure by the writes it contains."
@@ -697,7 +697,7 @@
   [samples tolerance]
   (let [by-arm (group-by :arm samples)]
     {:arms   (into {} (map (fn [[id ss]] [id (arm-summary ss)])) by-arm)
-     :guard  (guard/verdict
+     :guard  (rf.bench.order-guard/verdict
                (mapv (fn [s] {:arm         (name (:arm s))
                               :value       (per-write (:total s) (:writes s))
                               :predecessor (some-> (:predecessor s) name)
@@ -725,7 +725,7 @@
   because the guard that adjudicates these figures is the CLJC one this
   bundle carries, not the `.cjs` copy the donor's Node drivers reach."
   []
-  (let [st (guard/self-test)]
+  (let [st (rf.bench.order-guard/self-test)]
     (doseq [c (:checks st)]
       (js/console.log (str ";; HN order-guard " (if (:ok c) "ok  " "FAIL")
                            " " (:name c)

--- a/bench/hicasso/src/re_frame/bench/hicasso_narrow_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso_narrow_app.cljs
@@ -13,8 +13,8 @@
   externs — the reasoning is recorded at the head of
   [[re-frame.bench.hicasso-narrow]]."
   (:require [goog.object :as gobj]
-            [re-frame.bench.hicasso-narrow :as hn]
-            [re-frame.bench.order-guard :as guard]))
+            [re-frame.bench.hicasso-narrow :as rf.bench.hicasso-narrow]
+            [re-frame.bench.order-guard :as rf.bench.order-guard]))
 
 (defonce ^:private mounts (volatile! nil))
 (defonce ^:private by-id (volatile! {}))
@@ -29,11 +29,11 @@
                    {"arm"      (name (:arm s))
                     "position" (:position s)
                     "order"    (name (:order s))
-                    "total"    (hn/per-write (:total s) (:writes s))
-                    "write"    (hn/per-write (:write s) (:writes s))
-                    "gap"      (hn/per-write (:gap s) (:writes s))
-                    "force"    (hn/per-write (:force s) (:writes s))
-                    "control"  (hn/per-write (:control s) (:writes s))
+                    "total"    (rf.bench.hicasso-narrow/per-write (:total s) (:writes s))
+                    "write"    (rf.bench.hicasso-narrow/per-write (:write s) (:writes s))
+                    "gap"      (rf.bench.hicasso-narrow/per-write (:gap s) (:writes s))
+                    "force"    (rf.bench.hicasso-narrow/per-write (:force s) (:writes s))
+                    "control"  (rf.bench.hicasso-narrow/per-write (:control s) (:writes s))
                     "bad"      (:bad s)})
                  ss)))
 
@@ -42,9 +42,9 @@
   the per-write total in milliseconds so the driver can watch the
   trajectory settle."
   [arm-id writes]
-  (-> (hn/run-sample! (get @by-id arm-id) writes)
+  (-> (rf.bench.hicasso-narrow/run-sample! (get @by-id arm-id) writes)
       (.then (fn [a]
-               (hn/per-write (gobj/get a "total") (gobj/get a "writes"))))))
+               (rf.bench.hicasso-narrow/per-write (gobj/get a "total") (gobj/get a "writes"))))))
 
 (defn- run-round!
   "One round, and the driver's running POSITION COUNTER carried across it.
@@ -65,8 +65,8 @@
   now prints the finite-position count per arm beside the strata, so the
   next version of this cannot hide."
   [warmup samples writes position0]
-  (-> (hn/seed-arms! @mounts)
-      (.then (fn [_] (hn/run-round! @mounts
+  (-> (rf.bench.hicasso-narrow/seed-arms! @mounts)
+      (.then (fn [_] (rf.bench.hicasso-narrow/run-round! @mounts
                                     {:warmup warmup :samples samples :writes writes}
                                     position0)))
       (.then (fn [{rows :samples bad :bad}]
@@ -82,13 +82,13 @@
   gate goes red on an empty `flushSync` — a gate that cannot fail has not
   verified anything."
   [writes]
-  (let [mnt (first (hn/mount-arms! [(hn/negative-control-arm)]))]
+  (let [mnt (first (rf.bench.hicasso-narrow/mount-arms! [(rf.bench.hicasso-narrow/negative-control-arm)]))]
     (vreset! neg-mount mnt)
-    (-> (hn/run-sample! mnt writes)
+    (-> (rf.bench.hicasso-narrow/run-sample! mnt writes)
         (.then (fn [a]
                  (let [bad (gobj/get a "bad")
                        n   (gobj/get a "writes")]
-                   (hn/release-arms! [mnt])
+                   (rf.bench.hicasso-narrow/release-arms! [mnt])
                    (vreset! neg-mount nil)
                    (js-obj "bad" bad "writes" n)))))))
 
@@ -96,29 +96,29 @@
   "Fold every collected sample, adjudicate the order question, and answer
   the record plus the guard's own report lines."
   [tolerance]
-  (let [summary (hn/summarise-run @collected tolerance)
+  (let [summary (rf.bench.hicasso-narrow/summarise-run @collected tolerance)
         v       (:guard summary)]
     (js-obj "edn"     (pr-str summary)
-            "lines"   (clj->js (vec (guard/report-lines v "P0 ratom-spine narrow write")))
+            "lines"   (clj->js (vec (rf.bench.order-guard/report-lines v "P0 ratom-spine narrow write")))
             "refuse"  (boolean (:refuse? v))
             "contaminated" (boolean (:contaminated? v))
             "unchecked"    (boolean (:unchecked? v)))))
 
 (defn ^:export -main []
   (try
-    (hn/init-adapter!)
-    (let [arms (hn/make-arms)
-          ms   (hn/mount-arms! arms)]
+    (rf.bench.hicasso-narrow/init-adapter!)
+    (let [arms (rf.bench.hicasso-narrow/make-arms)
+          ms   (rf.bench.hicasso-narrow/mount-arms! arms)]
       (vreset! mounts ms)
       (vreset! by-id (into {} (map (fn [m] [(name (:id (:arm m))) m])) ms))
       (gobj/set js/window "HN"
         (js-obj
           "arms"          (clj->js (mapv #(name (:id %)) arms))
-          "cellsN"        hn/cells-n
+          "cellsN"        rf.bench.hicasso-narrow/cells-n
           ;; The subscription-count ladder, top rung LAST and equal to
           ;; `cellsN` — the top rung is `:spine-replace` itself rather than
           ;; a fourth mounted copy of it.
-          "ladder"        (clj->js hn/ladder-cells)
+          "ladder"        (clj->js rf.bench.hicasso-narrow/ladder-cells)
           ;; Arms whose windows render no cell, so a DOM read-back on them
           ;; would be verifying nothing. The driver excludes these from the
           ;; "N unverified of M" denominator rather than counting a forced
@@ -132,24 +132,24 @@
           "subs"          (clj->js (into {} (map (fn [a] [(name (:id a)) (:subs a)])) arms))
           ;; Run before any measurement: proves this bundle reads the keys
           ;; it writes, under the renaming it was actually compiled with.
-          "integrity"     (fn [] (hn/integrity-probe))
+          "integrity"     (fn [] (rf.bench.hicasso-narrow/integrity-probe))
           ;; Deterministic fixtures replayed from the recorded study. A
           ;; harness whose guard is broken may measure nothing.
-          "guardSelfTest" (fn [] (hn/guard-self-test!))
-          "quantum"       (fn [] (hn/clock-quantum))
-          "prepare"       (fn [ms'] (hn/control-prepare! ms'))
+          "guardSelfTest" (fn [] (rf.bench.hicasso-narrow/guard-self-test!))
+          "quantum"       (fn [] (rf.bench.hicasso-narrow/clock-quantum))
+          "prepare"       (fn [ms'] (rf.bench.hicasso-narrow/control-prepare! ms'))
           "warm"          (fn [arm writes] (warm-window! arm writes))
           ;; The ladder pass runs at a SECOND control size and must not
           ;; land in the headline fold, so the driver clears the collected
           ;; set between passes and adjudicates the ladder from the
           ;; per-sample payload it already holds.
           "reset"         (fn [] (vreset! collected []) true)
-          "seed"          (fn [] (-> (hn/seed-arms! @mounts) (.then (fn [_] true))))
+          "seed"          (fn [] (-> (rf.bench.hicasso-narrow/seed-arms! @mounts) (.then (fn [_] true))))
           "round"         (fn [warmup samples writes pos]
                             (run-round! warmup samples writes pos))
           "negControl"    (fn [writes] (negative-control! writes))
           "report"        (fn [tol] (report! tol))))
-      (-> (hn/seed-arms! ms)
+      (-> (rf.bench.hicasso-narrow/seed-arms! ms)
           (.then (fn [_]
                    (gobj/set js/window "HN_READY" true)
                    (js/console.log ";; HN READY")

--- a/bench/hicasso/src/re_frame/bench/p0_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/p0_app.cljs
@@ -60,12 +60,12 @@
   2026-08-10, enumerated once in `docs/design/hicasso/studio/README.md`;
   this arm rf2-2rtt6.4."
   (:require [cljs.reader :as reader]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.order-guard :as guard]
-            [re-frame.bench.p0-arms :as arms]
-            [re-frame.bench.p0-fixture :as fx]
-            [re-frame.bench.p0-harness :as h]
-            [re-frame.bench.p0-heap :as heap]))
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.order-guard :as rf.bench.order-guard]
+            [re-frame.bench.p0-arms :as rf.bench.p0-arms]
+            [re-frame.bench.p0-fixture :as rf.bench.p0-fixture]
+            [re-frame.bench.p0-harness :as rf.bench.p0-harness]
+            [re-frame.bench.p0-heap :as rf.bench.p0-heap]))
 
 (def order-tolerance
   "A relative difference of medians for the arm-order guard. A browser
@@ -95,7 +95,7 @@
   reported — that is the arm-order guard's rule, applied at the seam it
   cannot see."
   [r]
-  (if (even? r) (vec arms/segments) (vec (rseq (vec arms/segments)))))
+  (if (even? r) (vec rf.bench.p0-arms/segments) (vec (rseq (vec rf.bench.p0-arms/segments)))))
 
 (defn- witness-order
   "Witness order for round `r`, alternating exactly as the segments do.
@@ -109,7 +109,7 @@
   permanent property of one witness, which is the same trap as a fixed arm
   order one level up."
   [r]
-  (if (even? r) (vec arms/mount-witnesses) (vec (rseq (vec arms/mount-witnesses)))))
+  (if (even? r) (vec rf.bench.p0-arms/mount-witnesses) (vec (rseq (vec rf.bench.p0-arms/mount-witnesses)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The parity gate — run before any clock is read, in EVERY segment
@@ -126,7 +126,7 @@
   [segment-id]
   (reduce
     (fn [acc {:keys [id elements arms-for]}]
-      (let [{:keys [mounts agree? canon counts disagree]} (h/parity (arms-for segment-id))]
+      (let [{:keys [mounts agree? canon counts disagree]} (rf.bench.p0-harness/parity (arms-for segment-id))]
         (try
           (assoc acc id
                  {:canon    canon
@@ -138,9 +138,9 @@
                               (conj {:problem  :element-count
                                      :expected elements
                                      :got      counts}))})
-          (finally (doseq [m mounts] (h/release! m))))))
+          (finally (doseq [m mounts] (rf.bench.p0-harness/release! m))))))
     {}
-    arms/mount-witnesses))
+    rf.bench.p0-arms/mount-witnesses))
 
 (defn- parity!
   "Both segments' parity, plus the CROSS-segment check. The floor is in
@@ -149,17 +149,17 @@
   built one page."
   []
   (let [parities (reduce (fn [acc {:keys [id] :as segment}]
-                           (arms/enter-segment! segment)
+                           (rf.bench.p0-arms/enter-segment! segment)
                            (assoc acc id (parity-of-segment! id)))
                          {}
-                         arms/segments)
+                         rf.bench.p0-arms/segments)
         problems (into []
                        (for [[seg ws] parities
                              [w {:keys [problems]}] ws
                              p problems]
                          (assoc p :segment seg :witness w)))
         cross    (into []
-                       (for [{:keys [id]} arms/mount-witnesses
+                       (for [{:keys [id]} rf.bench.p0-arms/mount-witnesses
                              :let [a (get-in parities [:reagent-subs id :canon :floor])
                                    b (get-in parities [:uix-subs id :canon :floor])]
                              :when (not= a b)]
@@ -182,13 +182,13 @@
         pos    (atom 0)
         probes (atom [])]
     (doseq [{:keys [id] :as segment} (segment-order r)]
-      (arms/enter-segment! segment)
-      (swap! probes conj (assoc (h/probe) :round r :segment id))
+      (rf.bench.p0-arms/enter-segment! segment)
+      (swap! probes conj (assoc (rf.bench.p0-harness/probe) :round r :segment id))
       (doseq [{:keys [elements per-sample] :as w} (witness-order r)]
         (let [as (get arms-of [(:id w) id])
               {:keys [readings order bad total position schedule]}
-              (h/mount-round! as sampling elements per-sample @pos)
-              norm (h/normalise readings :floor)]
+              (rf.bench.p0-harness/mount-round! as sampling elements per-sample @pos)
+              norm (rf.bench.p0-harness/normalise readings :floor)]
           (reset! pos position)
           (swap! acc assoc-in [(:id w) id]
                  {:p50 (:p50 norm) :ratio (:ratio norm) :order order
@@ -217,13 +217,13 @@
   rather than about the arms, and the control is the instrument that shows
   it."
   [sampling arms]
-  (let [{:keys [readings]} (h/mount-round! arms
+  (let [{:keys [readings]} (rf.bench.p0-harness/mount-round! arms
                                            (update sampling :warmup * 3)
                                            nil 1 100000)]
     ;; `nil` as the expectation: the two control arms build DIFFERENT
     ;; pages by construction, which is the whole point of the control and
     ;; the one place the element gate cannot apply.
-    (get-in (h/normalise readings :control-1x) [:ratio :control-2x])))
+    (get-in (rf.bench.p0-harness/normalise readings :control-1x) [:ratio :control-2x])))
 
 (defn- bulk-round-of-segments!
   "One round of one bulk `kind` over both segments, in this round's
@@ -231,27 +231,27 @@
   [r kind sampling]
   (let [acc (atom {})
         pos (atom 200000)]
-    (-> (arms/chain nil (segment-order r)
+    (-> (rf.bench.p0-arms/chain nil (segment-order r)
                     (fn [_ segment]
-                      (arms/enter-segment! segment)
-                      (let [mounts (arms/mount-bulk-arms! (arms/bulk-arms (:id segment)))]
-                        (-> (arms/bulk-round! mounts kind sampling @pos)
+                      (rf.bench.p0-arms/enter-segment! segment)
+                      (let [mounts (rf.bench.p0-arms/mount-bulk-arms! (rf.bench.p0-arms/bulk-arms (:id segment)))]
+                        (-> (rf.bench.p0-arms/bulk-round! mounts kind sampling @pos)
                             (.then (fn [{:keys [readings legs order bad total
                                                 position schedule]}]
                                      (reset! pos position)
-                                     (arms/release-bulk-arms! mounts)
-                                     (let [norm (h/normalise readings :floor)]
+                                     (rf.bench.p0-arms/release-bulk-arms! mounts)
+                                     (let [norm (rf.bench.p0-harness/normalise readings :floor)]
                                        (swap! acc assoc (:id segment)
                                               {:p50   (:p50 norm)
                                                :ratio (:ratio norm)
-                                               :legs  (arms/leg-summary legs)
+                                               :legs  (rf.bench.p0-arms/leg-summary legs)
                                                :order order
                                                :bad   bad
                                                :total total
                                                :schedule schedule})
                                        nil)))
                             (.catch (fn [e]
-                                      (arms/release-bulk-arms! mounts)
+                                      (rf.bench.p0-arms/release-bulk-arms! mounts)
                                       (throw e)))))))
         (.then (fn [_] @acc)))))
 
@@ -264,15 +264,15 @@
         ;; through one call site and the sites went megamorphic on nothing
         ;; the benchmark is trying to measure.
         arms-of  (into {}
-                       (for [{:keys [id]} arms/segments
-                             {w :id :keys [arms-for]} arms/mount-witnesses]
+                       (for [{:keys [id]} rf.bench.p0-arms/segments
+                             {w :id :keys [arms-for]} rf.bench.p0-arms/mount-witnesses]
                          [[w id] (arms-for id)]))
         par      (parity! )]
     (if-not (:ok? par)
       (do (fail! (str "the arms do not build the same page under :advanced — "
                       (pr-str (:problems par))))
           (js/Promise.resolve nil))
-      (let [control (control-round! sampling (arms/control-arms))
+      (let [control (control-round! sampling (rf.bench.p0-arms/control-arms))
             {mount-rows :rows probes :probes}
             (mount-round-of-segments! r sampling arms-of)]
         (-> (bulk-round-of-segments! r :broad sampling)
@@ -283,7 +283,7 @@
                                    :parity      par
                                    :probes      probes
                                    :control     control
-                                   :collector   @h/gc-available?
+                                   :collector   @rf.bench.p0-harness/gc-available?
                                    :mount       mount-rows
                                    :bulk-broad  broad
                                    :bulk-narrow narrow}))))))))))
@@ -336,12 +336,12 @@
     {:witness              witness-id
      :doc                  doc
      :arms                 [:floor :reagent-subs :uix-subs]
-     :ratio-to-floor       {:reagent-subs (h/across-rounds (:ratio rg))
-                            :uix-subs     (h/across-rounds (:ratio ux))}
+     :ratio-to-floor       {:reagent-subs (rf.bench.p0-harness/across-rounds (:ratio rg))
+                            :uix-subs     (rf.bench.p0-harness/across-rounds (:ratio ux))}
      :per-round            {:reagent-subs {:p50 (:p50 rg) :ratio (:ratio rg)}
                             :uix-subs     {:p50 (:p50 ux) :ratio (:ratio ux)}}
      :legs                 {:reagent-subs (:legs rg) :uix-subs (:legs ux)}
-     :red-zone-clock       (assoc (h/ratio-of-ratios ux-r rg-r)
+     :red-zone-clock       (assoc (rf.bench.p0-harness/ratio-of-ratios ux-r rg-r)
                                   :axis :clock
                                   :numerator :uix-subs
                                   :denominator :reagent-subs
@@ -360,9 +360,9 @@
                                  "seam's drift and nothing else. It is published rather "
                                  "than assumed to be 1.0.")}
      :schedule             {:reagent-subs (:schedule rg) :uix-subs (:schedule ux)}
-     :order-verdict        {:reagent-subs (guard/verdict (:order rg)
+     :order-verdict        {:reagent-subs (rf.bench.order-guard/verdict (:order rg)
                                                          {:tolerance order-tolerance})
-                            :uix-subs     (guard/verdict (:order ux)
+                            :uix-subs     (rf.bench.order-guard/verdict (:order ux)
                                                          {:tolerance order-tolerance})}
      :verification         {:unverified (+ (:bad rg) (:bad ux))
                             :of         (+ (:total rg) (:total ux))}}))
@@ -388,14 +388,14 @@
         mount    (into {}
                        (map (fn [{:keys [id doc]}]
                               [id (row id doc [:mount id])]))
-                       arms/mount-witnesses)
+                       rf.bench.p0-arms/mount-witnesses)
         broad    (row :U-broad
-                      (str "one write that all " fx/cells-n " subscribed cells read — "
+                      (str "one write that all " rf.bench.p0-fixture/cells-n " subscribed cells read — "
                            "re-render THROUGHPUT, where fine grain buys nothing because "
                            "all the work is genuinely required")
                       [:bulk-broad])
         narrow   (row :U-narrow
-                      (str "one write exactly ONE of " fx/cells-n " subscribed cells "
+                      (str "one write exactly ONE of " rf.bench.p0-fixture/cells-n " subscribed cells "
                            "reads — LOCALISATION, where fine grain either shows up or "
                            "does not")
                       [:bulk-narrow])
@@ -409,15 +409,15 @@
                       "ROUND PER PAGE so no round inherits another's heap. false here "
                       "means the page was launched without --js-flags=--expose-gc and "
                       "this is a DIFFERENT instrument.")}
-     :control   {:predicted arms/control-predicted
+     :control   {:predicted rf.bench.p0-arms/control-predicted
                  :per-round controls
                  :measured  {:mean (/ (reduce + 0.0 controls) (count controls))
                              :min  (apply min controls)
                              :max  (apply max controls)}
                  :note      (str "control-2x / control-1x, predicted from element "
                                  "arithmetic: w1-elements(2n)/w1-elements(n) = "
-                                 (fx/w1-elements (* 2 fx/w1-rows)) "/"
-                                 (fx/w1-elements fx/w1-rows)
+                                 (rf.bench.p0-fixture/w1-elements (* 2 rf.bench.p0-fixture/w1-rows)) "/"
+                                 (rf.bench.p0-fixture/w1-elements rf.bench.p0-fixture/w1-rows)
                                  ". Both arms are FLOOR arms, so the control prices the "
                                  "instrument and not a candidate.")}
      :mount     mount
@@ -447,7 +447,7 @@
   numerator nor the denominator (see `p0-harness/mount-sample!`): counting
   it as verified would let the control dilute a real failure, and counting
   it as unverified would red every run for ever. The control is
-  adjudicated by its own gate instead — [[lane/control-verdict]], below —
+  adjudicated by its own gate instead — [[rf.bench.hicasso.lane/control-verdict]], below —
   and the driver reports it beside this figure rather than folding one
   into the other."
   [agg]
@@ -466,7 +466,7 @@
   printed inside the record and nothing read it, and the positive control
   was published as a bare ratio nothing adjudicated.
 
-  The adjudication is the LANE's, not a second copy: [[lane/control-verdict]]
+  The adjudication is the LANE's, not a second copy: [[rf.bench.hicasso.lane/control-verdict]]
   is what this arm publishes its controls under, and what it DECIDES is not
   this namespace's to change. Read its docstring before quoting `:ok?`: the
   rule is range OVERLAP, not every-round-inside.
@@ -474,7 +474,7 @@
   ## And OVERLAP is the right rule HERE, which is not true of the heap row
   ## (rf2-egdaq, settled)
 
-  The lane spells a second rule — [[lane/control-verdict-strict]], every
+  The lane spells a second rule — [[rf.bench.hicasso.lane/control-verdict-strict]], every
   round inside the band — and `re-frame.bench.p0-heap` moved this driver's
   OTHER row onto it. This row stays on overlap, on measurement rather than
   on inertia. THIS CONTROL IS A CLOCK RATIO. `control-round!` reads two
@@ -507,7 +507,7 @@
   [round-edns slack]
   (let [agg (aggregate (vec round-edns))
         vt  (verification-totals agg)
-        ctl (lane/control-verdict (get-in agg [:control :predicted])
+        ctl (rf.bench.hicasso.lane/control-verdict (get-in agg [:control :predicted])
                                   (select-keys (get-in agg [:control :measured])
                                                [:min :max :mean])
                                   slack)
@@ -527,7 +527,7 @@
 (defn ^:export -main
   []
   (try
-    (h/leave-act-environment!)
+    (rf.bench.p0-harness/leave-act-environment!)
     ;; The arm-order guard's own self-test, BEFORE anything is measured.
     ;; Its checks are recorded fixtures replayed from the live study — the
     ;; 2.0125x, the 0.43% slope, the twelve-window warm-up sweep, the
@@ -535,7 +535,7 @@
     ;; every figure below unpublishable, and finding that out after the run
     ;; is wasteful. THE GUARD REFUSES AND THE DRIVER EXITS 2; the repair is
     ;; to the arm.
-    (let [st (guard/self-test)]
+    (let [st (rf.bench.order-guard/self-test)]
       (set! (.-P0_GUARD_SELF_TEST js/window) (pr-str st))
       (doseq [c (:checks st)]
         (js/console.log (str ";; P0 order-guard " (if (:ok c) "ok  " "FAIL") " " (:name c)
@@ -544,7 +544,7 @@
         (fail! "the arm-order guard's self-test FAILED — nothing may be measured")))
     (case (mode)
       "heap"
-      (do (heap/install!)
+      (do (rf.bench.p0-heap/install!)
           (js/console.log ";; P0 heap instrument installed")
           (set! (.-P0_READY js/window) true))
 

--- a/bench/hicasso/src/re_frame/bench/p0_arms.cljs
+++ b/bench/hicasso/src/re_frame/bench/p0_arms.cljs
@@ -57,13 +57,13 @@
   this arm rf2-2rtt6.4."
   (:require ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.p0-fixture :as fx]
-            [re-frame.bench.p0-floor :as floor]
-            [re-frame.bench.p0-harness :as h]
-            [re-frame.bench.p0-reagent :as rg]
-            [re-frame.bench.p0-uix :as ux]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.p0-fixture :as rf.bench.p0-fixture]
+            [re-frame.bench.p0-floor :as rf.bench.p0-floor]
+            [re-frame.bench.p0-harness :as rf.bench.p0-harness]
+            [re-frame.bench.p0-reagent :as rf.bench.p0-reagent]
+            [re-frame.bench.p0-uix :as rf.bench.p0-uix]
             [re-frame.core :as rf]
             [reagent.core :as r]
             [reagent.dom.client :as rdc]
@@ -82,8 +82,8 @@
 (def segments
   "The two adapter segments. `:id` is the substrate arm's id, which is also
   how a published record names the segment."
-  [{:id :reagent-subs :adapter reagent-adapter/adapter :name "Reagent-on-subs"}
-   {:id :uix-subs     :adapter uix-adapter/adapter     :name "UIx-on-subs"}])
+  [{:id :reagent-subs :adapter rf.adapter.reagent/adapter :name "Reagent-on-subs"}
+   {:id :uix-subs     :adapter rf.adapter.uix/adapter     :name "UIx-on-subs"}])
 
 (defonce ^:private captured (atom nil))
 
@@ -143,18 +143,18 @@
   ARGUMENT rather than an ambient volatile (rf2-2rtt6.140): a width set
   after seeding would be a page whose sub graph and whose db disagree, and
   a parameter that is never ambient cannot be set in the wrong order. It
-  defaults to `fx/cells-n`, so the clock rows and the retention rows —
+  defaults to `rf.bench.p0-fixture/cells-n`, so the clock rows and the retention rows —
   which pass nothing — seed the published page to the byte.
 
   A teardown that throws STOPS the instrument and names the phase — see
   [[teardown!]]."
-  ([segment] (enter-segment! segment fx/cells-n))
+  ([segment] (enter-segment! segment rf.bench.p0-fixture/cells-n))
   ([{:keys [adapter]} grid-width]
    (teardown! "destroy-frame!" #(rf/destroy-frame! frame-id))
    (when (rf/current-adapter)
      (teardown! "destroy-adapter!" #(rf/destroy-adapter!)))
    (rf/init! adapter)
-   (fx/register!)
+   (rf.bench.p0-fixture/register!)
    (rf/make-frame {:id frame-id :initial-events [[:p0/seed (long grid-width)]]})
    (reset! captured (rf/capture-frame frame-id))
    nil))
@@ -183,7 +183,7 @@
   allocation row's warm re-render still has to be the write a real
   application pays for. What differs is that `:p0/write-page` rebuilds
   `:cells` at the width the mounted page actually reads, where
-  `:p0/write-all` rebuilds `fx/cells-n` of them whatever is mounted. That
+  `:p0/write-all` rebuilds `rf.bench.p0-fixture/cells-n` of them whatever is mounted. That
   fixed cost measured 24.4 KB per write on this rig — 57% of the retired
   masking budget before a single boundary had been measured — and it does
   not shrink when the page does.
@@ -233,25 +233,25 @@
   always `[floor <substrate>]` in that declaration order — the harness
   reorders them per sample index, so declaration order decides nothing."
   [{:id        :W1-list
-    :doc       (str "a large template — " fx/w1-rows " rows, one boundary and ONE "
+    :doc       (str "a large template — " rf.bench.p0-fixture/w1-rows " rows, one boundary and ONE "
                     "re-frame2 subscription read per row")
-    :elements   (fx/w1-elements fx/w1-rows)
+    :elements   (rf.bench.p0-fixture/w1-elements rf.bench.p0-fixture/w1-rows)
     ;; 1,203 elements mounts in tens of timer quanta on every arm, so one
     ;; mount is a sample.
     :per-sample 1
     :arms-for (fn [segment-id]
-                [(floor-arm :floor #(floor/w1 (mapv fx/row-value (range fx/w1-rows))))
+                [(floor-arm :floor #(rf.bench.p0-floor/w1 (mapv rf.bench.p0-fixture/row-value (range rf.bench.p0-fixture/w1-rows))))
                  (case segment-id
                    :reagent-subs (reagent-arm :reagent-subs
-                                              #(rg/w1-root frame-id fx/w1-rows))
+                                              #(rf.bench.p0-reagent/w1-root frame-id rf.bench.p0-fixture/w1-rows))
                    :uix-subs     (uix-arm :uix-subs
-                                          #(ux/w1-root frame-id fx/w1-rows)))])}
+                                          #(rf.bench.p0-uix/w1-root frame-id rf.bench.p0-fixture/w1-rows)))])}
 
    {:id        :W3-form
-    :doc       (str "an ordinary " fx/w3-fields "-field form with controlled inputs — "
+    :doc       (str "an ordinary " rf.bench.p0-fixture/w3-fields "-field form with controlled inputs — "
                     "the shape most applications are made of; one subscription read "
                     "per field")
-    :elements   (fx/w3-elements fx/w3-fields)
+    :elements   (rf.bench.p0-fixture/w3-elements rf.bench.p0-fixture/w3-fields)
     ;; 51 elements sits three to eight quanta above Chrome's 100 us clamp,
     ;; and at one mount a sample this instrument MEASURED both segments
     ;; returning exactly 0.75 ms — a ratio of precisely 1.0000 that was the
@@ -260,14 +260,14 @@
     :per-sample 8
     :arms-for (fn [segment-id]
                 [(floor-arm :floor
-                            #(floor/w3 (mapv (fn [i] {:value (fx/field-value i)
-                                                      :error (fx/field-error i)})
-                                             (range fx/w3-fields))))
+                            #(rf.bench.p0-floor/w3 (mapv (fn [i] {:value (rf.bench.p0-fixture/field-value i)
+                                                      :error (rf.bench.p0-fixture/field-error i)})
+                                             (range rf.bench.p0-fixture/w3-fields))))
                  (case segment-id
                    :reagent-subs (reagent-arm :reagent-subs
-                                              #(rg/w3-root frame-id fx/w3-fields))
+                                              #(rf.bench.p0-reagent/w3-root frame-id rf.bench.p0-fixture/w3-fields))
                    :uix-subs     (uix-arm :uix-subs
-                                          #(ux/w3-root frame-id fx/w3-fields)))])}])
+                                          #(rf.bench.p0-uix/w3-root frame-id rf.bench.p0-fixture/w3-fields)))])}])
 
 ;; ---------------------------------------------------------------------------
 ;; THE POSITIVE CONTROL — predicted before it is measured
@@ -284,10 +284,10 @@
   FLOOR so it prices the instrument rather than a substrate, and therefore
   reads the same in both segments."
   []
-  [(floor-arm :control-1x #(floor/w1 (mapv fx/row-value (range fx/w1-rows))))
-   (floor-arm :control-2x #(floor/w1-double (mapv fx/row-value (range fx/w1-rows))))])
+  [(floor-arm :control-1x #(rf.bench.p0-floor/w1 (mapv rf.bench.p0-fixture/row-value (range rf.bench.p0-fixture/w1-rows))))
+   (floor-arm :control-2x #(rf.bench.p0-floor/w1-double (mapv rf.bench.p0-fixture/row-value (range rf.bench.p0-fixture/w1-rows))))])
 
-(def control-predicted floor/control-predicted-ratio)
+(def control-predicted rf.bench.p0-floor/control-predicted-ratio)
 
 ;; ---------------------------------------------------------------------------
 ;; BULK arms
@@ -305,20 +305,20 @@
   read-back caught exactly that on the predecessor's harness: 80 of 320
   floor samples ending on a stale cell."
   []
-  (let [state (atom (vec (repeat fx/cells-n 0)))
+  (let [state (atom (vec (repeat rf.bench.p0-fixture/cells-n 0)))
         root  (volatile! nil)]
     {:id      :floor
      :mount   (fn [container]
                 (let [rt (react-dom-client/createRoot container)]
                   (vreset! root rt)
-                  (react-dom/flushSync (fn [] (.render rt (floor/u-grid @state))))
+                  (react-dom/flushSync (fn [] (.render rt (rf.bench.p0-floor/u-grid @state))))
                   rt))
      :write!  (fn [i v]
                 (if (= i :all)
-                  (reset! state (vec (repeat fx/cells-n v)))
+                  (reset! state (vec (repeat rf.bench.p0-fixture/cells-n v)))
                   (swap! state assoc i v)))
      :force!  (fn [] (react-dom/flushSync
-                       (fn [] (.render ^js @root (floor/u-grid @state)))))
+                       (fn [] (.render ^js @root (rf.bench.p0-floor/u-grid @state)))))
      ;; NOT inside a flushSync — a root's own unmount opens one, and a
      ;; nested flush is scheduled rather than performed (p0-harness).
      :unmount (fn [rt] (.unmount rt))}))
@@ -345,7 +345,7 @@
     :reagent-subs
     (fn [container]
       (let [rt (rdc/create-root container)]
-        (react-dom/flushSync (fn [] (rdc/render rt (rg/u-root frame-id))))
+        (react-dom/flushSync (fn [] (rdc/render rt (rf.bench.p0-reagent/u-root frame-id))))
         rt))
     (fn [rt] (rdc/unmount rt))
     (fn [] (react-dom/flushSync (fn [] (r/flush))))))
@@ -355,7 +355,7 @@
     :uix-subs
     (fn [container]
       (let [rt (uix-dom/create-root container)]
-        (react-dom/flushSync (fn [] (uix-dom/render-root (ux/u-root frame-id) rt)))
+        (react-dom/flushSync (fn [] (uix-dom/render-root (rf.bench.p0-uix/u-root frame-id) rt)))
         rt))
     (fn [rt] (uix-dom/unmount-root rt))
     (fn [] (react-dom/flushSync (fn [] nil)))))
@@ -370,7 +370,7 @@
 
 (defn mount-bulk-arms! [arms]
   (mapv (fn [a]
-          (let [c (h/container!)]
+          (let [c (rf.bench.p0-harness/container!)]
             {:arm a :container c :handle ((:mount a) c)}))
         arms))
 
@@ -396,14 +396,14 @@
   does, it does it in `:gap-ms`, and the floor — which needs no yield —
   is the in-situ control that says what an empty gap costs."
   [{:keys [arm container]} i v]
-  (let [t0 (h/now-ms)]
+  (let [t0 (rf.bench.p0-harness/now-ms)]
     ((:write! arm) i v)
-    (let [t1 (h/now-ms)]
+    (let [t1 (rf.bench.p0-harness/now-ms)]
       (-> (js/Promise.resolve nil)
           (.then (fn [_]
-                   (let [t2 (h/now-ms)]
+                   (let [t2 (rf.bench.p0-harness/now-ms)]
                      ((:force! arm))
-                     (let [t3    (h/now-ms)
+                     (let [t3    (rf.bench.p0-harness/now-ms)
                            probe (if (= i :all) 0 i)]
                        {:ms       (- t3 t0)
                         :write-ms (- t1 t0)
@@ -412,7 +412,7 @@
                         :ok?      (and (= (str v) (cell-text container probe))
                                        (or (not= i :all)
                                            (= (str v) (cell-text container
-                                                                 (dec fx/cells-n)))))}))))))))
+                                                                 (dec rf.bench.p0-fixture/cells-n)))))}))))))))
 
 (defn chain
   "Fold `xs` into a serial promise chain, threading an accumulator."
@@ -441,7 +441,7 @@
   (chain {:ms 0 :write-ms 0 :gap-ms 0 :force-ms 0 :bad 0 :total 0} (range n)
          (fn [acc _]
            (let [v (next-gen!)
-                 i (if (= kind :broad) :all (mod v fx/cells-n))]
+                 i (if (= kind :broad) :all (mod v rf.bench.p0-fixture/cells-n))]
              (-> (timed-write! mnt i v)
                  (.then (fn [{:keys [ms write-ms gap-ms force-ms ok?]}]
                           (cond-> (-> acc
@@ -468,7 +468,7 @@
   (let [k     (count mounts)
         n     (get writes-per-sample kind)
         total (+ warmup samples)
-        sched (h/choose-schedule k total)
+        sched (rf.bench.p0-harness/choose-schedule k total)
         order (:fn sched)]
     (chain {:readings (zipmap (map #(:id (:arm %)) mounts) (repeat []))
             :legs     (zipmap (map #(:id (:arm %)) mounts) (repeat []))
@@ -486,7 +486,7 @@
                    (.then (fn [{:keys [ms write-ms gap-ms force-ms bad total]}]
                             ;; Between samples, never inside a window — see
                             ;; `p0-harness/collect!` for the drift it removes.
-                            (h/collect!)
+                            (rf.bench.p0-harness/collect!)
                             (cond-> (assoc acc :previous id)
                               (>= s warmup)
                               (-> (update :bad + bad)
@@ -507,9 +507,9 @@
   (into {}
         (map (fn [[id xs]]
                [id (when (seq xs)
-                     {:write-ms (h/p50 (map :write xs))
-                      :gap-ms   (h/p50 (map :gap xs))
-                      :force-ms (h/p50 (map :force xs))})]))
+                     {:write-ms (rf.bench.p0-harness/p50 (map :write xs))
+                      :gap-ms   (rf.bench.p0-harness/p50 (map :gap xs))
+                      :force-ms (rf.bench.p0-harness/p50 (map :force xs))})]))
         legs))
 
-(defn canon-of [mounts] (mapv (fn [m] (h/canonical (:container m))) mounts))
+(defn canon-of [mounts] (mapv (fn [m] (rf.bench.p0-harness/canonical (:container m))) mounts))

--- a/bench/hicasso/src/re_frame/bench/p0_floor.cljs
+++ b/bench/hicasso/src/re_frame/bench/p0_floor.cljs
@@ -41,8 +41,8 @@
   2026-08-10, enumerated once in `docs/design/hicasso/studio/README.md`;
   this arm rf2-2rtt6.4."
   (:require ["react" :as react]
-            [re-frame.bench.p0-fixture :as fx]
-            [re-frame.bench.p0-workcount :as wc]))
+            [re-frame.bench.p0-fixture :as rf.bench.p0-fixture]
+            [re-frame.bench.p0-workcount :as rf.bench.p0-workcount]))
 
 (defn- el
   ([tag props] (react/createElement tag props))
@@ -55,7 +55,7 @@
 (def ^:private row-style #js {:paddingLeft "4px" :color "rebeccapurple"})
 
 (defn- w1-row-el [i text]
-  (wc/render!)
+  (rf.bench.p0-workcount/render!)
   (el "li" #js {:key i :className "row cell wide" :style row-style :data-index i}
       #js [(el "img" #js {:key "a" :className "avatar" :src "/avatar.png" :alt ""})
            (el "span" #js {:key "b" :className "label"} "row ")
@@ -76,7 +76,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- w3-field-el [i {:keys [value error]}]
-  (wc/render!)
+  (rf.bench.p0-workcount/render!)
   (el "div" #js {:key i :className "field"}
       #js [(el "label" #js {:key "l" :className "lbl" :htmlFor (str "f" i)}
                (str "Field " i))
@@ -110,7 +110,7 @@
   (el "div" #js {:className "ugrid"}
       (into-array
         (map-indexed
-          (fn [i v] (wc/render!) (el "span" #js {:key i :className "cell" :data-i i} (str v)))
+          (fn [i v] (rf.bench.p0-workcount/render!) (el "span" #js {:key i :className "cell" :data-i i} (str v)))
           cells))))
 
 ;; ---------------------------------------------------------------------------
@@ -144,5 +144,5 @@
   "2403/1203 — the element ratio `w1-double` has to reproduce on the clock.
   Written as arithmetic over the fixture rather than as a literal, so it
   moves if the witness does."
-  (/ (double (fx/w1-elements (* 2 fx/w1-rows)))
-     (double (fx/w1-elements fx/w1-rows))))
+  (/ (double (rf.bench.p0-fixture/w1-elements (* 2 rf.bench.p0-fixture/w1-rows)))
+     (double (rf.bench.p0-fixture/w1-elements rf.bench.p0-fixture/w1-rows))))

--- a/bench/hicasso/src/re_frame/bench/p0_harness.cljs
+++ b/bench/hicasso/src/re_frame/bench/p0_harness.cljs
@@ -57,7 +57,7 @@
   this arm rf2-2rtt6.4."
   (:require ["react-dom" :as react-dom]
             [clojure.string :as str]
-            [re-frame.bench.order-guard :as guard]))
+            [re-frame.bench.order-guard :as rf.bench.order-guard]))
 
 ;; ---------------------------------------------------------------------------
 ;; The clock
@@ -74,7 +74,7 @@
 (defn- round4 [x]
   (/ (js/Math.round (* (double x) 10000.0)) 10000.0))
 
-(defn p50 [xs] (guard/median xs))
+(defn p50 [xs] (rf.bench.order-guard/median xs))
 
 ;; ---------------------------------------------------------------------------
 ;; Canonical DOM — the fairness gate
@@ -373,14 +373,14 @@
   fact is published and the guard's `:unchecked` refusal stands."
   [k samples]
   (let [score (fn [nm f]
-                (let [a  (guard/adjacency k samples f {:seams? true})
+                (let [a  (rf.bench.order-guard/adjacency k samples f {:seams? true})
                       as (vals (:arms a))]
                   {:name            nm
                    :fn              f
                    :min-distinct    (apply min (map :distinct as))
                    :max-modal-share (apply max (map :modal-share as))}))
-        cands [(score :reflecting guard/slot-order)
-               (score :rotating   guard/rotation-only)]
+        cands [(score :reflecting rf.bench.order-guard/slot-order)
+               (score :rotating   rf.bench.order-guard/rotation-only)]
         ok    (filter #(>= (:min-distinct %) 2) cands)]
     (if (seq ok)
       (assoc (apply min-key :max-modal-share ok) :sufficient? true)

--- a/bench/hicasso/src/re_frame/bench/p0_heap.cljs
+++ b/bench/hicasso/src/re_frame/bench/p0_heap.cljs
@@ -72,17 +72,17 @@
   (:require ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]
             [clojure.string :as str]
-            [re-frame.bench.hicasso.lane :as lane]
-            [re-frame.bench.order-guard :as guard]
-            [re-frame.bench.p0-arms :as arms]
-            [re-frame.bench.p0-fixture :as fx]
-            [re-frame.bench.p0-floor :as floor]
-            [re-frame.bench.p0-harness :as h]
-            [re-frame.bench.p0-hicasso :as hic]
-            [re-frame.bench.p0-reagent :as rg]
-            [re-frame.bench.p0-uix :as ux]
-            [re-frame.bench.p0-workcount :as wc]
-            [re-frame.frame :as frame]
+            [re-frame.bench.hicasso.lane :as rf.bench.hicasso.lane]
+            [re-frame.bench.order-guard :as rf.bench.order-guard]
+            [re-frame.bench.p0-arms :as rf.bench.p0-arms]
+            [re-frame.bench.p0-fixture :as rf.bench.p0-fixture]
+            [re-frame.bench.p0-floor :as rf.bench.p0-floor]
+            [re-frame.bench.p0-harness :as rf.bench.p0-harness]
+            [re-frame.bench.p0-hicasso :as rf.bench.p0-hicasso]
+            [re-frame.bench.p0-reagent :as rf.bench.p0-reagent]
+            [re-frame.bench.p0-uix :as rf.bench.p0-uix]
+            [re-frame.bench.p0-workcount :as rf.bench.p0-workcount]
+            [re-frame.frame :as rf.frame]
             ;; THE CANDIDATE ARM'S THREE DOORS, called at four seams, and
             ;; they are the PACKAGE's now (rf2-fe0l). They used to be
             ;; `re-frame.bench.hicasso.arm1.*` — the frozen prototype
@@ -96,9 +96,9 @@
             ;; Bench requiring package is the allowed direction;
             ;; `hicasso/scripts/check_freeze.py`'s SEALED rule forbids
             ;; only package requiring bench.
-            [re-frame.hicasso.impl.collector :as hic-collector]
-            [re-frame.hicasso.test.runtime :as hic-runtime]
-            [re-frame.hicasso.impl.mount :as hic-mount]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
             [reagent.core :as r]
             [reagent.dom.client :as rdc]
             [uix.dom :as uix-dom]))
@@ -107,9 +107,9 @@
   "Boundaries in one root of the `grid` family — the same 300 the clock
   rows drive, so a per-boundary figure here and a bulk ratio there
   describe the same page."
-  fx/cells-n)
+  rf.bench.p0-fixture/cells-n)
 
-(def rows-per-root fx/w1-rows)
+(def rows-per-root rf.bench.p0-fixture/w1-rows)
 
 ;; ---------------------------------------------------------------------------
 ;; Arms — keyed `family/substrate`, the same naming the driver schedules on
@@ -176,7 +176,7 @@
   [hiccup-of selector expected]
   {:selector    selector
    :expected    expected
-   :mount-one   (fn [c i] (hic-mount/root! c arms/frame-id (hiccup-of i)))
+   :mount-one   (fn [c i] (rf.hicasso.impl.mount/root! c rf.bench.p0-arms/frame-id (hiccup-of i)))
    :unmount-one (fn [handle]
                   (react-dom/flushSync (fn [] (.unmount (:root handle)))))})
 
@@ -191,7 +191,7 @@
   by a boundary count its own DOM did not have. At `cells` = [[per-root]]
   it is the arm the table used to hold, to the byte."
   [cells]
-  (assoc (react-root-arm (fn [_] (floor/u-grid (vec (repeat cells 0))))
+  (assoc (react-root-arm (fn [_] (rf.bench.p0-floor/u-grid (vec (repeat cells 0))))
                          ".cell" cells)
          :segment nil :keys-expected 0))
 
@@ -216,26 +216,26 @@
   now a number this instrument checks on every mount instead of an
   argument about a file."
   {:list/floor
-   (assoc (react-root-arm (fn [_] (floor/w1 (mapv fx/row-value (range rows-per-root))))
+   (assoc (react-root-arm (fn [_] (rf.bench.p0-floor/w1 (mapv rf.bench.p0-fixture/row-value (range rows-per-root))))
                           ".row" rows-per-root)
           :segment nil :keys-expected 0)
 
    :list/reagent
-   (assoc (reagent-root-arm (fn [_] (rg/w1-root arms/frame-id rows-per-root))
+   (assoc (reagent-root-arm (fn [_] (rf.bench.p0-reagent/w1-root rf.bench.p0-arms/frame-id rows-per-root))
                             ".row" rows-per-root)
           :segment :reagent-subs :keys-expected rows-per-root)
 
    :list/uix
-   (assoc (uix-root-arm (fn [_] (ux/w1-root arms/frame-id rows-per-root))
+   (assoc (uix-root-arm (fn [_] (rf.bench.p0-uix/w1-root rf.bench.p0-arms/frame-id rows-per-root))
                         ".row" rows-per-root)
           :segment :uix-subs :keys-expected rows-per-root)
 
    :grid/reagent
-   (assoc (reagent-root-arm (fn [_] (rg/u-root arms/frame-id)) ".cell" per-root)
+   (assoc (reagent-root-arm (fn [_] (rf.bench.p0-reagent/u-root rf.bench.p0-arms/frame-id)) ".cell" per-root)
           :segment :reagent-subs :keys-expected per-root)
 
    :grid/uix
-   (assoc (uix-root-arm (fn [_] (ux/u-root arms/frame-id)) ".cell" per-root)
+   (assoc (uix-root-arm (fn [_] (rf.bench.p0-uix/u-root rf.bench.p0-arms/frame-id)) ".cell" per-root)
           :segment :uix-subs :keys-expected per-root)})
 
 ;; ---------------------------------------------------------------------------
@@ -253,8 +253,8 @@
   property of a hand-written page."
   [substrate reads q]
   (let [root-of (case substrate
-                  :reagent (fn [r] (rg/fan-root arms/frame-id (* r per-root) per-root reads))
-                  :uix     (fn [r] (ux/fan-root arms/frame-id (* r per-root) per-root reads)))
+                  :reagent (fn [r] (rf.bench.p0-reagent/fan-root rf.bench.p0-arms/frame-id (* r per-root) per-root reads))
+                  :uix     (fn [r] (rf.bench.p0-uix/fan-root rf.bench.p0-arms/frame-id (* r per-root) per-root reads)))
         base    (case substrate
                   :reagent (reagent-root-arm root-of ".cell" per-root)
                   :uix     (uix-root-arm root-of ".cell" per-root))]
@@ -278,7 +278,7 @@
 ;; on ITS OWN instrument (validation.md:180-189) and this instrument has
 ;; no 3/7/20 rung on any substrate until now.
 ;;
-;; `fx/fan-key` supplies the keys unchanged: at Q = B·R the rule
+;; `rf.bench.p0-fixture/fan-key` supplies the keys unchanged: at Q = B·R the rule
 ;; `(n·R + k) mod Q` is the identity over `0 … B·R−1`, so every one of
 ;; the E edges lands on its own key and Q = E exactly. The DOM is
 ;; identical at every rung on every substrate — one `span.cell` per
@@ -324,13 +324,13 @@
         cells   (long cells)
         base    (case substrate
                   :reagent (reagent-root-arm
-                             (fn [r] (rg/lad-root arms/frame-id (* r cells) cells reads))
+                             (fn [r] (rf.bench.p0-reagent/lad-root rf.bench.p0-arms/frame-id (* r cells) cells reads))
                              ".cell" cells)
                   :uix     (uix-root-arm
-                             (fn [r] (ux/lad-root arms/frame-id (* r cells) cells reads))
+                             (fn [r] (rf.bench.p0-uix/lad-root rf.bench.p0-arms/frame-id (* r cells) cells reads))
                              ".cell" cells)
                   :hicasso (hicasso-root-arm
-                             (fn [r] (hic/lad-grid (* r cells) cells reads))
+                             (fn [r] (rf.bench.p0-hicasso/lad-grid (* r cells) cells reads))
                              ".cell" cells))]
     (assoc base
            ;; The candidate reads through `re-frame.subs` and the
@@ -406,9 +406,9 @@
    ;; own residue lands in the baseline, and no arm's teardown is ever
    ;; forced — which is what leaves the survival metric something to
    ;; measure (rf2-2rtt6.34).
-   (hic-collector/reset-runtime!)
-   (let [segment (first (filter #(= segment-id (:id %)) arms/segments))]
-     (when segment (arms/enter-segment! segment (long grid-width))))
+   (rf.hicasso.impl.collector/reset-runtime!)
+   (let [segment (first (filter #(= segment-id (:id %)) rf.bench.p0-arms/segments))]
+     (when segment (rf.bench.p0-arms/enter-segment! segment (long grid-width))))
    true))
 
 ;; ---------------------------------------------------------------------------
@@ -438,7 +438,7 @@
   quantity the two published heap families disagreed about, and it is
   cheaper to count it than to argue about it."
   []
-  (if-some [f (frame/frame arms/frame-id)]
+  (if-some [f (rf.frame/frame rf.bench.p0-arms/frame-id)]
     (count @(:sub-cache f))
     0))
 
@@ -461,15 +461,15 @@
   (let [opts       (js->clj opts :keywordize-keys true)
         arm        (arm-for (keyword arm-id) opts)
         {:keys [mount-one unmount-one selector expected keys-expected]} arm
-        _          (when-some [q (:keys opts)] (fx/set-fan-keys! q))
-        containers (mapv (fn [_] (h/container!)) (range k))
+        _          (when-some [q (:keys opts)] (rf.bench.p0-fixture/set-fan-keys! q))
+        containers (mapv (fn [_] (rf.bench.p0-harness/container!)) (range k))
         handles    (into [] (map-indexed (fn [i c] (mount-one c i))) containers)
         elements   (.-length (.querySelectorAll js/document selector))
         want       (* k expected)
         live       (live-key-count)]
     (reset! held {:arm (keyword arm-id) :unmount-one unmount-one
                   :handles handles :containers containers})
-    (let [hic (hic-runtime/residue)]
+    (let [hic (rf.hicasso.test.runtime/residue)]
       #js {:elements     elements
            :expected     want
            :keys         live
@@ -1195,11 +1195,11 @@
         ;;
         ;; It sits in the `let`, which is evaluated before `buf[0]` — the
         ;; first sample and therefore the opening of the measured region.
-        ;; `wc/snapshot` allocates an object, so where it is called is not
+        ;; `rf.bench.p0-workcount/snapshot` allocates an object, so where it is called is not
         ;; a style question: inside the region it would be the sampler
         ;; allocating on the arm's behalf, which is the one thing an
         ;; allocation instrument may not do.
-        work0   (wc/snapshot)]
+        work0   (rf.bench.p0-workcount/snapshot)]
     (aset buf 0 (mem))
     (dotimes [i n]
       (let [base (* k i)]
@@ -1207,8 +1207,8 @@
         (cond
           write? (do (vswap! alloc-tick inc)
                      (if all?
-                       (arms/write-all! @alloc-tick)
-                       (arms/write-page! @alloc-tick))
+                       (rf.bench.p0-arms/write-all! @alloc-tick)
+                       (rf.bench.p0-arms/write-page! @alloc-tick))
                      ;; THE SEAM. At stride 2 this is a test of a boolean
                      ;; local and nothing else — the same class of branch
                      ;; as the `reagent?` test immediately below it, which
@@ -1261,12 +1261,12 @@
            ;; Both are read OUTSIDE the sampled region — `work0` before
            ;; `buf[0]`, this one after the last leg's closing sample.
            :work0   work0
-           :work    (wc/snapshot)
+           :work    (rf.bench.p0-workcount/snapshot)
            ;; What the PAGE was compiled with, not what the driver asked
            ;; for. A closure-define that failed to reach the compiler
            ;; leaves counters that never move, which reads exactly like a
            ;; window that did no work.
-           :counting (wc/armed?)
+           :counting (rf.bench.p0-workcount/armed?)
            :text    (when cell (.-textContent cell))})))
 
 ;; ---------------------------------------------------------------------------
@@ -1289,7 +1289,7 @@
                                (if-some [m (.-memory js/performance)]
                                  (.-usedJSHeapSize m)
                                  -1))
-             :slotOrder      (fn [n round] (clj->js (guard/slot-order n round)))
+             :slotOrder      (fn [n round] (clj->js (rf.bench.order-guard/slot-order n round)))
              ;; ONE expression of the arm-order rule, used by both rows.
              ;; The heap row's samples are produced by the DRIVER (only it
              ;; can force a collection), so the driver hands them back in
@@ -1297,7 +1297,7 @@
              ;; the clock row uses in-page. A second copy of the rule in
              ;; JavaScript would be a second place for it to drift.
              :verdict        (fn [samples tolerance]
-                               (pr-str (guard/verdict (js->clj samples :keywordize-keys true)
+                               (pr-str (rf.bench.order-guard/verdict (js->clj samples :keywordize-keys true)
                                                       {:tolerance tolerance})))
              ;; ONE expression of the positive-control rule too, and it is
              ;; the LANE's. The driver owns the collector, so it is the
@@ -1305,7 +1305,7 @@
              ;; per-round readings — and until rf2-95s5b it printed that
              ;; pair as a bare ratio nothing adjudicated.
              ;;
-             ;; THE RULE IS `lane/control-verdict-strict`, EVERY ROUND
+             ;; THE RULE IS `rf.bench.hicasso.lane/control-verdict-strict`, EVERY ROUND
              ;; INSIDE THE BAND (rf2-egdaq). It used to be the lane's
              ;; overlap rule, which asks only that the measured RANGE meet
              ;; the band — and on a counter this precise that is not a
@@ -1358,7 +1358,7 @@
              ;; is built as flat `#js` objects one level down too.
              :controlVerdict (fn [predicted per-round slack]
                                (let [vs (vec (js->clj per-round))
-                                     v  (lane/control-verdict-strict predicted vs slack)]
+                                     v  (rf.bench.hicasso.lane/control-verdict-strict predicted vs slack)]
                                  #js {:ok       (boolean (:ok? v))
                                       :rule     (name (:rule v))
                                       :why      (:why v)
@@ -1372,7 +1372,7 @@
                                                               :measured (:measured o)
                                                               :offBy    (:off-by o)})
                                                        (:outside v)))}))
-             :guardSelfTest  (fn [] (pr-str (guard/self-test)))
+             :guardSelfTest  (fn [] (pr-str (rf.bench.order-guard/self-test)))
              ;; The fan-out sweep's two doors, and both of them are RULES
              ;; rather than arithmetic, so both live here rather than in a
              ;; JavaScript restatement the driver would own alone. The
@@ -1455,7 +1455,7 @@
              ;; HD-002 clause (d)'s failure and a different and worse
              ;; finding than a large per-boundary figure.
              :hicassoResidue (fn []
-                               (let [r (hic-runtime/residue)]
+                               (let [r (rf.hicasso.test.runtime/residue)]
                                  #js {:cells      (:cells r)
                                       :cellRefs   (:cell-refs r)
                                       :boundaries (:boundaries r)
@@ -1475,7 +1475,7 @@
              ;; `--enable-precise-memory-info` and the sampling stride.
              ;; `workCount` is the raw census, for a preflight that wants
              ;; to watch the counters move outside a window.
-             :workArmed      (fn [] (wc/armed?))
-             :workCount      (fn [] (wc/snapshot))
+             :workArmed      (fn [] (rf.bench.p0-workcount/armed?))
+             :workCount      (fn [] (rf.bench.p0-workcount/snapshot))
              :boundariesPerRoot #js {:list rows-per-root :grid per-root}})
   nil)

--- a/bench/hicasso/src/re_frame/bench/p0_hicasso.cljs
+++ b/bench/hicasso/src/re_frame/bench/p0_hicasso.cljs
@@ -65,22 +65,22 @@
   Owner: the operator-owned governance set that superseded rf2-2rtt6.1 on
   2026-08-10, enumerated once in `docs/design/hicasso/studio/README.md`;
   this arm rf2-2rtt6.34."
-  (:require [re-frame.bench.p0-fixture :as fx]
-            [re-frame.bench.p0-workcount :as wc]
+  (:require [re-frame.bench.p0-fixture :as rf.bench.p0-fixture]
+            [re-frame.bench.p0-workcount :as rf.bench.p0-workcount]
             [re-frame.hicasso :refer [sub]])
   (:require-macros [re-frame.hicasso :refer [defview]]))
 
 (defview lad-cell
   "One Hicasso boundary reading `r` DISTINCT subscriptions — the same
-  `:p0/fan` key space, the same `fx/fan-key` rule and the same
+  `:p0/fan` key space, the same `rf.bench.p0-fixture/fan-key` rule and the same
   `span.cell` element the Reagent and UIx ladder cells build, so the three
   arms differ in how a subscription value reaches a boundary and in
   nothing else."
   [{:keys [j n r]}]
-  (wc/render!)
+  (rf.bench.p0-workcount/render!)
   (let [v (loop [k 0 acc 0]
             (if (< k r)
-              (recur (inc k) (+ acc (sub [:p0/fan (fx/fan-key n r k)])))
+              (recur (inc k) (+ acc (sub [:p0/fan (rf.bench.p0-fixture/fan-key n r k)])))
               acc))]
     [:span.cell {:data-i j} (str v)]))
 

--- a/bench/hicasso/src/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/bench/hicasso/src/re_frame/bench/p0_ladder_structural.test.cjs
@@ -460,9 +460,9 @@ test('THE CANDIDATE ARM READS THE PACKAGE — its two doors are the facade', () 
 
 test('THE HEAP RIG READS THE PACKAGE — all three doors, none of them arm1', () => {
   const req = nsRequires(HEAP);
-  assert.match(req, /\[re-frame\.hicasso\.impl\.mount :as hic-mount\]/, 'the mount door');
-  assert.match(req, /\[re-frame\.hicasso\.impl\.collector :as hic-collector\]/, 'the runtime reset');
-  assert.match(req, /\[re-frame\.hicasso\.test\.runtime :as hic-runtime\]/, 'the structural census');
+  assert.match(req, /\[re-frame\.hicasso\.impl\.mount :as rf\.hicasso\.impl\.mount\]/, 'the mount door');
+  assert.match(req, /\[re-frame\.hicasso\.impl\.collector :as rf\.hicasso\.impl\.collector\]/, 'the runtime reset');
+  assert.match(req, /\[re-frame\.hicasso\.test\.runtime :as rf\.hicasso\.test\.runtime\]/, 'the structural census');
   assert.ok(
     !/re-frame\.bench\.hicasso\.arm1/.test(req),
     'p0_heap.cljs must not REQUIRE the frozen prototype (naming it in prose is fine)'
@@ -474,9 +474,9 @@ test('THE FOUR SEAMS CALL THROUGH THOSE ALIASES, and no fifth one is hiding', ()
   // site keeps the old one. These are the four sites rf2-fe0l enumerated,
   // counted in the code and not in the commentary.
   const code = codeOf(HEAP);
-  assert.strictEqual(countOf(code, 'hic-mount/root!'), 1, 'the mount door, once');
-  assert.strictEqual(countOf(code, 'hic-collector/reset-runtime!'), 1, 'the runtime reset, once');
-  assert.strictEqual(countOf(code, 'hic-runtime/residue'), 2, 'the live census and the post-unmount read');
+  assert.strictEqual(countOf(code, 'rf.hicasso.impl.mount/root!'), 1, 'the mount door, once');
+  assert.strictEqual(countOf(code, 'rf.hicasso.impl.collector/reset-runtime!'), 1, 'the runtime reset, once');
+  assert.strictEqual(countOf(code, 'rf.hicasso.test.runtime/residue'), 2, 'the live census and the post-unmount read');
   // The prototype's alias. Its absence is what says no seam was missed.
   assert.strictEqual(countOf(code, 'hic-rt/'), 0, 'no call site left on the old alias');
 });
@@ -2042,11 +2042,11 @@ test('the RETENTION ladder is not moved by any of this', () => {
   // only ever one write to name.
   assert.match(
     HEAP,
-    /\(if all\?\s+\(arms\/write-all! @alloc-tick\)\s+\(arms\/write-page! @alloc-tick\)\)/,
+    /\(if all\?\s+\(rf\.bench\.p0-arms\/write-all! @alloc-tick\)\s+\(rf\.bench\.p0-arms\/write-page! @alloc-tick\)\)/,
     "write-page! is the alloc window's DEFAULT arm and write-all! the else-arm"
   );
   assert.strictEqual(
-    (HEAP.match(/\(arms\/write-all! /g) || []).length,
+    (HEAP.match(/\(rf\.bench\.p0-arms\/write-all! /g) || []).length,
     1,
     'and write-all! is reachable from exactly ONE place in this namespace'
   );
@@ -2121,12 +2121,12 @@ test('the clock and bulk rows are not moved either', () => {
   // and must still call `enter-segment!` with no width — the arity that seeds
   // the published grid to the byte.
   const APP = fs.readFileSync(path.join(__dirname, 'p0_app.cljs'), 'utf8');
-  assert.match(APP, /\(arms\/enter-segment! segment\)/, 'the clock rows pass no width');
+  assert.match(APP, /\(rf\.bench\.p0-arms\/enter-segment! segment\)/, 'the clock rows pass no width');
   assert.doesNotMatch(APP, /:p0\/write-page/, 'and no clock row drives the new write');
   const ARMS = fs.readFileSync(path.join(__dirname, 'p0_arms.cljs'), 'utf8');
   assert.match(
     ARMS,
-    /\(\[segment\] \(enter-segment! segment fx\/cells-n\)\)/,
+    /\(\[segment\] \(enter-segment! segment rf\.bench\.p0-fixture\/cells-n\)\)/,
     'because the default arity IS the published width'
   );
 });

--- a/bench/hicasso/src/re_frame/bench/p0_pageerror_probe.cljs
+++ b/bench/hicasso/src/re_frame/bench/p0_pageerror_probe.cljs
@@ -17,7 +17,7 @@
   the judgement: *a wrong stub is not a cheaper proof, it is a fiction that
   can pass or fail for reasons that have nothing to do with the gate.*
 
-  So there is no stub. `-main` below calls `p0-app/-main` — the published
+  So there is no stub. `-main` below calls `rf.bench.p0-app/-main` — the published
   entry, unchanged — and then schedules a throw from a task the app does
   not own. That is rf2-sib23's fault shape exactly: the page throws AND
   STILL reaches its own completion sentinel, the case no page-side
@@ -25,7 +25,7 @@
 
   ## The throw is DETACHED, and that is the whole point
 
-  A `setTimeout` callback is a task `p0-app/-main` has already returned
+  A `setTimeout` callback is a task `rf.bench.p0-app/-main` has already returned
   from. Its throw escapes the app's `(catch :default e ...)`, sets no
   `window.P0_ERROR`, and rejects no `page.evaluate` — it reaches Playwright
   as `pageerror` and nowhere else. `sentinel.cjs`'s header carries the
@@ -61,11 +61,11 @@
   NOTHING SHIPS THIS. No driver names this namespace by default, no build
   in `shadow-cljs.edn` points at it, and `pageerror_exit_path.test.cjs`
   pins both facts."
-  (:require [re-frame.bench.p0-app :as p0-app]))
+  (:require [re-frame.bench.p0-app :as rf.bench.p0-app]))
 
 (defn ^:export -main
   []
-  (p0-app/-main)
+  (rf.bench.p0-app/-main)
   ;; AFTER the app has returned, and therefore after the sentinel it set.
   (js/setTimeout
    (fn []

--- a/bench/hicasso/src/re_frame/bench/p0_reagent.cljs
+++ b/bench/hicasso/src/re_frame/bench/p0_reagent.cljs
@@ -31,8 +31,8 @@
   Owner: the operator-owned governance set that superseded rf2-2rtt6.1 on
   2026-08-10, enumerated once in `docs/design/hicasso/studio/README.md`;
   this arm rf2-2rtt6.4."
-  (:require [re-frame.bench.p0-fixture :as fx]
-            [re-frame.bench.p0-workcount :as wc]
+  (:require [re-frame.bench.p0-fixture :as rf.bench.p0-fixture]
+            [re-frame.bench.p0-workcount :as rf.bench.p0-workcount]
             [re-frame.core :as rf])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
@@ -41,7 +41,7 @@
 ;; ---------------------------------------------------------------------------
 
 (reg-view w1-row [i]
-  (wc/render!)
+  (rf.bench.p0-workcount/render!)
   (let [text @(subscribe [:p0/row i])]
     [:li.row.cell.wide {:style      {:padding-left "4px" :color "rebeccapurple"}
                         :data-index i}
@@ -61,7 +61,7 @@
 ;; ---------------------------------------------------------------------------
 
 (reg-view w3-field [i]
-  (wc/render!)
+  (rf.bench.p0-workcount/render!)
   (let [{:keys [value error]} @(subscribe [:p0/field i])]
     [:div.field
      [:label.lbl {:for (str "f" i)} (str "Field " i)]
@@ -84,7 +84,7 @@
 ;; ---------------------------------------------------------------------------
 
 (reg-view u-cell [i]
-  (wc/render!)
+  (rf.bench.p0-workcount/render!)
   (let [v @(subscribe [:p0/cell i])]
     [:span.cell {:data-i i} (str v)]))
 
@@ -117,18 +117,18 @@
 ;; prop slot than the rungs it anchors.
 
 (reg-view fan-cell-0 [j _n]
-  (wc/render!)
+  (rf.bench.p0-workcount/render!)
   [:span.cell {:data-i j} "0"])
 
 (reg-view fan-cell-1 [j n]
-  (wc/render!)
-  (let [a @(subscribe [:p0/fan (fx/fan-key n 1 0)])]
+  (rf.bench.p0-workcount/render!)
+  (let [a @(subscribe [:p0/fan (rf.bench.p0-fixture/fan-key n 1 0)])]
     [:span.cell {:data-i j} (str a)]))
 
 (reg-view fan-cell-2 [j n]
-  (wc/render!)
-  (let [a @(subscribe [:p0/fan (fx/fan-key n 2 0)])
-        b @(subscribe [:p0/fan (fx/fan-key n 2 1)])]
+  (rf.bench.p0-workcount/render!)
+  (let [a @(subscribe [:p0/fan (rf.bench.p0-fixture/fan-key n 2 0)])
+        b @(subscribe [:p0/fan (rf.bench.p0-fixture/fan-key n 2 1)])]
     [:span.cell {:data-i j} (str (+ a b))]))
 
 (reg-view fan-grid [offset n-cells reads]
@@ -156,10 +156,10 @@
 ;; same choice for the same reason.
 
 (reg-view lad-cell [j n r]
-  (wc/render!)
+  (rf.bench.p0-workcount/render!)
   (let [v (loop [k 0 acc 0]
             (if (< k r)
-              (recur (inc k) (+ acc @(subscribe [:p0/fan (fx/fan-key n r k)])))
+              (recur (inc k) (+ acc @(subscribe [:p0/fan (rf.bench.p0-fixture/fan-key n r k)])))
               acc))]
     [:span.cell {:data-i j} (str v)]))
 
@@ -193,4 +193,4 @@
   [rf/frame-provider {:frame frame-id} [w3 fields]])
 
 (defn u-root [frame-id]
-  [rf/frame-provider {:frame frame-id} [u-grid fx/cells-n]])
+  [rf/frame-provider {:frame frame-id} [u-grid rf.bench.p0-fixture/cells-n]])

--- a/bench/hicasso/src/re_frame/bench/p0_uix.cljs
+++ b/bench/hicasso/src/re_frame/bench/p0_uix.cljs
@@ -34,9 +34,9 @@
   Owner: the operator-owned governance set that superseded rf2-2rtt6.1 on
   2026-08-10, enumerated once in `docs/design/hicasso/studio/README.md`;
   this arm rf2-2rtt6.4."
-  (:require [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.bench.p0-fixture :as fx]
-            [re-frame.bench.p0-workcount :as wc]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.bench.p0-fixture :as rf.bench.p0-fixture]
+            [re-frame.bench.p0-workcount :as rf.bench.p0-workcount]
             [uix.core :refer [$ defui]]))
 
 ;; ---------------------------------------------------------------------------
@@ -44,8 +44,8 @@
 ;; ---------------------------------------------------------------------------
 
 (defui w1-row [{:keys [i]}]
-  (wc/render!)
-  (let [text (uix-adapter/use-subscribe [:p0/row i])]
+  (rf.bench.p0-workcount/render!)
+  (let [text (rf.adapter.uix/use-subscribe [:p0/row i])]
     ($ :li.row.cell.wide {:style      {:padding-left "4px" :color "rebeccapurple"}
                           :data-index i}
        ($ :img.avatar {:src "/avatar.png" :alt ""})
@@ -64,8 +64,8 @@
 ;; ---------------------------------------------------------------------------
 
 (defui w3-field [{:keys [i]}]
-  (wc/render!)
-  (let [{:keys [value error]} (uix-adapter/use-subscribe [:p0/field i])]
+  (rf.bench.p0-workcount/render!)
+  (let [{:keys [value error]} (rf.adapter.uix/use-subscribe [:p0/field i])]
     ($ :div.field
        ($ :label.lbl {:for (str "f" i)} (str "Field " i))
        ($ :input.inp {:id        (str "f" i)
@@ -87,8 +87,8 @@
 ;; ---------------------------------------------------------------------------
 
 (defui u-cell [{:keys [i]}]
-  (wc/render!)
-  (let [v (uix-adapter/use-subscribe [:p0/cell i])]
+  (rf.bench.p0-workcount/render!)
+  (let [v (rf.adapter.uix/use-subscribe [:p0/cell i])]
     ($ :span.cell {:data-i i} (str v))))
 
 (defui u-grid [{:keys [n]}]
@@ -108,18 +108,18 @@
 ;; rung so the floor subtraction stays honest.
 
 (defui fan-cell-0 [{:keys [j]}]
-  (wc/render!)
+  (rf.bench.p0-workcount/render!)
   ($ :span.cell {:data-i j} "0"))
 
 (defui fan-cell-1 [{:keys [j n]}]
-  (wc/render!)
-  (let [a (uix-adapter/use-subscribe [:p0/fan (fx/fan-key n 1 0)])]
+  (rf.bench.p0-workcount/render!)
+  (let [a (rf.adapter.uix/use-subscribe [:p0/fan (rf.bench.p0-fixture/fan-key n 1 0)])]
     ($ :span.cell {:data-i j} (str a))))
 
 (defui fan-cell-2 [{:keys [j n]}]
-  (wc/render!)
-  (let [a (uix-adapter/use-subscribe [:p0/fan (fx/fan-key n 2 0)])
-        b (uix-adapter/use-subscribe [:p0/fan (fx/fan-key n 2 1)])]
+  (rf.bench.p0-workcount/render!)
+  (let [a (rf.adapter.uix/use-subscribe [:p0/fan (rf.bench.p0-fixture/fan-key n 2 0)])
+        b (rf.adapter.uix/use-subscribe [:p0/fan (rf.bench.p0-fixture/fan-key n 2 1)])]
     ($ :span.cell {:data-i j} (str (+ a b)))))
 
 (defui fan-grid [{:keys [offset n-cells reads]}]
@@ -146,30 +146,30 @@
 ;; is the same shape at R = 0 and at R = 20 and the shell rung is not
 ;; measuring one fewer prop slot than the rungs it anchors.
 
-(defn- lus [n r k] (uix-adapter/use-subscribe [:p0/fan (fx/fan-key n r k)]))
+(defn- lus [n r k] (rf.adapter.uix/use-subscribe [:p0/fan (rf.bench.p0-fixture/fan-key n r k)]))
 
 (defui lad-cell-0 [{:keys [j _n]}]
-  (wc/render!)
+  (rf.bench.p0-workcount/render!)
   ($ :span.cell {:data-i j} "0"))
 
 (defui lad-cell-1 [{:keys [j n]}]
-  (wc/render!)
+  (rf.bench.p0-workcount/render!)
   (let [v (lus n 1 0)]
     ($ :span.cell {:data-i j} (str v))))
 
 (defui lad-cell-3 [{:keys [j n]}]
-  (wc/render!)
+  (rf.bench.p0-workcount/render!)
   (let [v (+ (lus n 3 0) (lus n 3 1) (lus n 3 2))]
     ($ :span.cell {:data-i j} (str v))))
 
 (defui lad-cell-7 [{:keys [j n]}]
-  (wc/render!)
+  (rf.bench.p0-workcount/render!)
   (let [v (+ (lus n 7 0) (lus n 7 1) (lus n 7 2) (lus n 7 3)
              (lus n 7 4) (lus n 7 5) (lus n 7 6))]
     ($ :span.cell {:data-i j} (str v))))
 
 (defui lad-cell-20 [{:keys [j n]}]
-  (wc/render!)
+  (rf.bench.p0-workcount/render!)
   (let [v (+ (lus n 20 0)  (lus n 20 1)  (lus n 20 2)  (lus n 20 3)
              (lus n 20 4)  (lus n 20 5)  (lus n 20 6)  (lus n 20 7)
              (lus n 20 8)  (lus n 20 9)  (lus n 20 10) (lus n 20 11)
@@ -197,28 +197,28 @@
 ;; construction on the arm that happens to own it.
 
 (defn w1-root [frame-id rows]
-  ($ uix-adapter/frame-provider {:frame frame-id}
+  ($ rf.adapter.uix/frame-provider {:frame frame-id}
      ($ w1 {:rows rows})))
 
 (defn w3-root [frame-id fields]
-  ($ uix-adapter/frame-provider {:frame frame-id}
+  ($ rf.adapter.uix/frame-provider {:frame frame-id}
      ($ w3 {:fields fields})))
 
 (defn u-root [frame-id]
-  ($ uix-adapter/frame-provider {:frame frame-id}
-     ($ u-grid {:n fx/cells-n})))
+  ($ rf.adapter.uix/frame-provider {:frame frame-id}
+     ($ u-grid {:n rf.bench.p0-fixture/cells-n})))
 
 (defn fan-root
   "One root of the fan-out arm. `offset` is this root's base in the GLOBAL
   boundary numbering, which is what lets four roots of one frame either
   share every key or share none."
   [frame-id offset n-cells reads]
-  ($ uix-adapter/frame-provider {:frame frame-id}
+  ($ rf.adapter.uix/frame-provider {:frame frame-id}
      ($ fan-grid {:offset offset :n-cells n-cells :reads reads})))
 
 (defn lad-root
   "One root of the ladder arm (rf2-2rtt6.34). `offset` is this root's base
   in the GLOBAL boundary numbering, as [[fan-root]]'s is."
   [frame-id offset n-cells reads]
-  ($ uix-adapter/frame-provider {:frame frame-id}
+  ($ rf.adapter.uix/frame-provider {:frame frame-id}
      ($ lad-grid {:offset offset :n-cells n-cells :reads reads})))

--- a/scripts/require-alias-baseline.edn
+++ b/scripts/require-alias-baseline.edn
@@ -19,7 +19,7 @@
  :surfaces
  {
   ".clj-kondo"                            0
-  "bench"                                 701
+  "bench"                                 0
   "docs"                                  0
   "examples"                              0
   "implementation/adapters"               337


### PR DESCRIPTION
Slice 4 of the rf2-7sx1 require-alias campaign. Takes the whole `bench`
surface to zero and lowers its floor in the same commit, which the two-sided
ratchet requires.

## The move

| | before | after |
|---|---|---|
| `bench` found / floor | 701 / 701 | **0 / 0** |
| repo-wide non-canonical | 5436 | **4735** |
| files / re-frame edges | 2773 / 10771 | 2773 / 10771 (identical) |

701 libspecs and 5000 code use sites across 146 files. 149 files changed,
5743 insertions / 5743 deletions, and **every changed file is +N/-N** — no
line added or removed anywhere, which is what a pure rename looks like.

The baseline diff is **exactly one row**, verified hunk by hunk against the
merge base: `"bench" 701` -> `"bench" 0`. `--write-baseline` did the write and
**HELD `:min-edges` at 9695** (the recompute proposed 9693; lowering it would
loosen the anti-blindness guard). Slice 1 saw it rise, slices 2 and 3 saw it
hold — this is the hold case again.

## Why the whole surface in one slice

Require aliases are **file-local**: renaming an alias in one file changes
nothing in any other, so any partition of the 146 files is equally safe and
splitting buys no correctness. The transformation is uniform, the only real
gate (below) covers all 146 files in one 30-second compile, and the campaign
rule serialises slices — so a 4a/4b split would have run that gate twice and
doubled wall-clock for a mechanical change. The reviewable content is the
method plus the exceptions, both enumerated here.

## What was deliberately NOT renamed, each measured

* **397 literal `:alias/key` keywords** in code (plus 9 in prose). These are
  values whose first segment merely collides with the alias; the checker's own
  failure hint states the rule. Renaming them would change data silently, and
  the ratchet does not read keywords.
* **263 lookbehind near-misses.** `bench/hicasso/` binds five one-character
  aliases (`m` 26, `h` 8, `v` 7, `w` 4, `d` 3), so `<alias>/` matches inside
  longer words, paths and fully-qualified namespaces. Excluding `-`, `.` and
  `/` before the alias is what keeps `:auth/locked` intact.
* **One English slash.** `p0_app.cljs:179` reads "the heap/DOM probes", where
  the slash means "and". `[re-frame.bench.p0-heap :as heap]` is a real alias in
  that file — control: `(heap/install!)` at :547, which *was* renamed — so an
  unreviewed rewrite would have fabricated a `rf.bench.p0-heap/DOM` var that
  does not exist.

Docstring and comment references naming vars in the same file **were** renamed
(491 of them). They are not decoration: many are `[[lane/rounds!]]` cljdoc
wikilinks and backtick-quoted var references, which after the rename would name
an alias the file no longer binds.

## Two structural pins had to follow the code

Both assert on the **text** of `.cljs` files, so the rename moved them. In each
case the var, its namespace and the structural guarantee are unchanged and only
the spelling moved, so the pin was the side to move:

* `bench_bytes.test.cjs` — nine pinned `lane/utf8-bytes` source expressions plus
  a libspec regex.
* `p0_ladder_structural.test.cjs` — three `hic-*` libspec regexes, their three
  call-site counts, and four further regexes over `p0_heap.cljs`,
  `p0_app.cljs` and `p0_arms.cljs`.

The pin against `p0_fixture.cljc` is **untouched**: that file is outside this
surface and was not renamed.

## Gates, with the captured exit code

| gate | exit | result |
|---|---|---|
| `check_require_alias_dialect.py --verbose` | **0** | clean, 4735 non-canonical, every surface at or under its floor |
| `check_require_alias_dialect.py --self-test` | **0** | 79 passed, 0 failed (unmoved) |
| `bench/hicasso` `npm run check` | 1 | see below |

All re-run on the final rebased base.

**`npm run check` exits 1 on this branch and exits 1 on unmodified trunk, with
the same single failure.** Its compile gate — the instrument that matters here,
since it compiles every lane namespace and treats a warning as a failure — reads
**155 namespaces, 0 warnings** both before and after, so no use site was missed.
The two logs are identical apart from a shadow-cljs cache line and timings:
`bench_bytes.test.cjs: 15 passed` both, `p0_ladder_structural.test.cjs: 1/100
failed` both.

That one failure is **pre-existing on trunk** and out of this fence: it pins
`(rf/reg-event :p0/write-all …)` in
`implementation/core/test/re_frame/bench/p0_fixture.cljc`, a file neither this
branch nor any upstream commit since the measured baseline has touched. Filed
separately as rf2-eexx.

CI does not run the bench lane by ruling (rf2-6c12m.1), so the local
`npm run check` is the only real gate on this diff.

## Verification

* **Planted fault**: reverting one libspec to `:as frame` red the ratchet at
  exit 1, naming file, line and libspec against a floor of 0 that exists only on
  this branch. Restore verified by **git blob hash** against the committed
  object, not by reading a diff.
* **Re-classified the rewritten tree against the OLD alias names**: the only
  rename-class occurrence remaining is the declared English slash.
* **Double-prefix check**: zero `rf.rf.`, and zero `rf.` spliced mid-word
  (the `:autrf.hicasso/locked` corruption signature), controlled against the
  146 files carrying the well-formed shape.
* The lookbehind was exercised **in both directions** on 17 cases before it ran
  over anything, including all three of slice 3's recorded near-misses.

`tools` (2294) remains as the campaign's last surface. rf2-7sx1 and rf2-lwx8
both stay open.

