### PR TITLE
docs(spec): the frame-destroyed ownership table drops the retired ui/frames (rf2-22ks)

### DIFF
--- a/implementation/core/test/re_frame/frame_destroyed_subscribe_devtrace_identity_cljs_test.cljc
+++ b/implementation/core/test/re_frame/frame_destroyed_subscribe_devtrace_identity_cljs_test.cljc
@@ -14,9 +14,8 @@
   `capture-frame`'s superseded-`:subscribe` seam (`capture-subscribe!` via
   `emit-captured-frame-superseded!`), which passes the attempted query vector
   as `:event` under `:op :subscribe`. The always-on egress (axis 1) then stays
-  raw because
-  `error-emit/raw-identity-query-vector-event?` skips elision keyed on
-  `(:rf.error/frame-destroyed, :op :subscribe)`.
+  raw because `error-emit/raw-identity-query-vector-event?` skips elision keyed
+  on `(:rf.error/frame-destroyed, :op :subscribe)`.
 
   But the DEV-TRACE egress (axis 2) flows through
   `re-frame.classification/project-trace-event`, which had NO realm-awareness:

--- a/implementation/core/test/re_frame/frame_destroyed_subscribe_devtrace_identity_cljs_test.cljc
+++ b/implementation/core/test/re_frame/frame_destroyed_subscribe_devtrace_identity_cljs_test.cljc
@@ -7,9 +7,14 @@
   ## The residual this file pins closed
 
   #6516 (the wd4ac original) fixed the UI PRODUCER: `re-frame.ui.frames`'
-  `emit-and-throw-frame-destroyed!` now passes the raw query vector on BOTH the
+  `emit-and-throw-frame-destroyed!` passed the raw query vector on BOTH the
   always-on `:event` slot AND the dev-trace `:event` tag for the `:subscribe`
-  realm. The always-on egress (axis 1) then stays raw because
+  realm. That tree was removed on 2026-08-16 (rf2-0yp7w); the live producer of
+  the same shape is `router/emit-frame-destroyed!`, reached from
+  `capture-frame`'s superseded-`:subscribe` seam (`capture-subscribe!` via
+  `emit-captured-frame-superseded!`), which passes the attempted query vector
+  as `:event` under `:op :subscribe`. The always-on egress (axis 1) then stays
+  raw because
   `error-emit/raw-identity-query-vector-event?` skips elision keyed on
   `(:rf.error/frame-destroyed, :op :subscribe)`.
 
@@ -77,7 +82,7 @@
   (rf.registrar/register! :event shared-id {:sensitive [[:token]]}))
 
 (defn- frame-destroyed-devtrace
-  "The axis-2 dev-trace event `emit-and-throw-frame-destroyed!` fans (frames.cljc):
+  "The axis-2 dev-trace event `router/emit-frame-destroyed!` fans (router.cljc):
   `{:operation :rf.error/frame-destroyed :tags {:frame … :op … :event … …}}`."
   [op event]
   {:operation :rf.error/frame-destroyed

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -1244,14 +1244,21 @@ A schema and its catalogue row are **co-edited**, and a conformance test holds t
   ;; `:recovery` declared here could never be satisfied (subs passes one in and
   ;; it does not survive into `:tags`).
   ;;
-  ;; Per-slot ownership — the emitter that stamps it:
-  ;;   :event    router/emit-frame-destroyed! + ui/frames/emit-and-throw-frame-destroyed!
+  ;; Per-slot ownership — the emitter that stamps it. `ui/frames` co-owned
+  ;; `:event`, `:op` and `:reason` here until it was removed on 2026-08-16
+  ;; (rf2-0yp7w); its half of each row is DROPPED rather than re-pointed —
+  ;; there is no successor producer, the view layer that replaced it stamping
+  ;; none of these slots. Every surviving producer below is live, so no SLOT
+  ;; lost its claim the way the `:where` group did (rf2-22ks).
+  ;;   :event    router/emit-frame-destroyed!
   ;;   :query-v  subs/emit-frame-destroyed-recovery!
-  ;;   :op       ui/frames (all four values) + capture-frame pre-check + router/subs
-  ;;             LATE captured-op fences; rf2-alk8a — subs/emit-frame-destroyed-
-  ;;             recovery! stamps `:subscribe` on these dev-trace tags AND the
-  ;;             always-on record (subscribe-realm by construction).
-  ;;   :reason   router + ui/frames (the constant `:frame-destroyed`)
+  ;;   :op       capture-frame pre-check + router's LATE captured-op fences;
+  ;;             rf2-alk8a — subs/emit-frame-destroyed-recovery! stamps
+  ;;             `:subscribe` on these dev-trace tags AND the always-on record
+  ;;             (subscribe-realm by construction). Those cover three of the
+  ;;             four declared `:op` values; `:capture` was the retired seam's
+  ;;             alone and is now unproduced — rf2-xtqs, not this row's fix.
+  ;;   :reason   router (the constant `:frame-destroyed`)
   ;;
   ;; `:where` / `:rf.sub/id` / `:rf.sub/query-v` were declared here until
   ;; 2026-08-21 and are GONE (rf2-63t1i). Their only emitter was the internal


### PR DESCRIPTION
`spec/Spec-Schemas.md`'s `FrameDestroyedTags` per-slot ownership table named `ui/frames` as a co-producer of `:event`, `:op` and `:reason`. That tree was removed on 2026-08-16 (rf2-0yp7w, PR #8322); `git ls-files implementation/ui/` returns 0 against a control of 224 under `implementation/hicasso/`, and `emit-and-throw-frame-destroyed!` has no definition anywhere.

Each row paired a **live** producer with the dead one, so no row could simply be deleted.

## Census (patterns quoted, counts taken separately from listings, `.beads` excluded)

| pattern | occurrences | files |
|---|---|---|
| `ui/frames` | 4 | `spec/Spec-Schemas.md` (3), `error_catalogue_channel_conformance_test.clj` (1) |
| `emit-and-throw-frame-destroyed` | 3 | `frame_destroyed_subscribe_devtrace_identity_cljs_test.cljc` (2), `spec/Spec-Schemas.md` (1, the same line 1248) |
| `re-frame.ui.frames` | 4 | `docs/design/retirement/freehand-and-ui.md` (2), the two test files (1 each) |

Control: `router/emit` reads 24 files, so the instrument reads the tree.

The third axis is the one the earlier censuses did not run, and it adds `docs/design/retirement/freehand-and-ui.md` plus one further line in each test file. It changed no decision — every line it added is retirement bookkeeping — but it is the only axis that shows the population is bounded.

## What changed, and what was read to decide it

**`spec/Spec-Schemas.md` — the dead half of three rows dropped, not re-pointed.** The determination follows rf2-63t1i's note three lines below the table ("a schema slot is a claim about what an emitter produces, so a slot with no producer describes nothing"): nothing succeeded `ui/frames` as a producer of these slots — `emit-frame-destroyed!` / `emit-captured-frame-superseded!` occur in 7 files, all under `implementation/core/`, none in the view layer that replaced it. The surviving attributions are corrected against the emitters themselves rather than carried over:

- `:event` — router only. Read `subs.cljc:1014-1026`: `emit-frame-destroyed-recovery!`'s dev-trace tags map is `{:frame :query-v :recovery :op}`, with no `:event` key. It passes the query vector *positionally*, which lands on the always-on record's `:event`, not on these dev-trace tags.
- `:op` — "router/subs LATE captured-op fences" disambiguated to "router's LATE captured-op fences", matching `router.cljc:2242`'s own docstring ("the `capture-frame` stale-op PRE-CHECK seam, AND the router's LATE captured-op fences"). `subs` was already covered by the rf2-alk8a clause immediately following, so the old spelling double-counted it.
- `:reason` — router only. `subs`' dev-trace tags map carries no `:reason` key.

The **`(all four values)`** coverage claim hung off the dead emitter and is deliberately **not** restated: `:op :capture` has no producer in any source file today (pattern `:op :capture` returns zero hits in source; the only occurrence is `spec/009-Instrumentation.md:2159`, documentation). Its sole producer was the retired UI `(frame)` read seam, and `error_emit.cljc`'s `error-source-coord` already hedges toward unreachability — "fabricate NEITHER coord (nil), **even were an id somehow present**". That is a schema question, not a comment one, and it has gate consequences (the 009 catalogue row and `tags-column-keys-are-documented` move together, and 009 is hot zone), so it is filed as **rf2-xtqs** and cited from the table rather than actioned here.

**`frame_destroyed_subscribe_devtrace_identity_cljs_test.cljc:85` — re-attributed, because here there IS a successor.** The helper builds `{:operation :rf.error/frame-destroyed :tags {:frame … :op … :event … :reason …}}`, which is exactly what `router/emit-frame-destroyed!` fans at `router.cljc:2285-2288`: `(cond-> {:frame frame-id :event event :reason :frame-destroyed} op (assoc :op op))`. The old text also cited `(frames.cljc)`, which today resolves only to `tools/story/src/re_frame/story/frames.cljc`, an unrelated namespace.

**The same file's ns docstring (lines 9-19) — history kept, tense corrected.** "#6516 fixed the UI PRODUCER … **now** passes" was a dated record that had slid into asserting a live producer. Past-tensed, the retirement noted, and pointed at the live path: `capture_frame.cljc:144`'s `capture-subscribe!` calls `emit-captured-frame-superseded!` with the query vector and `:subscribe`, which reaches `emit-frame-destroyed!` and stamps a raw query vector on the dev-trace `:event` under `:op :subscribe` — the exact scenario this file guards. The residual it pins is unchanged by the retirement, living in `classification/project-trace-event` rather than in any producer.

## Sites deliberately LEFT

- **`error_catalogue_channel_conformance_test.clj:1856` and `:1944`** — both are dated, past-tense retirement bookkeeping, and both explicitly assert the removal: `:1856` reads "*both were removed on 2026-08-16 by rf2-0yp7w and neither the artefacts nor that emitter survive*", and `:1944` reads "*nor did the removed `re-frame.ui`'s `ui/frames` before them*". Each exists to explain why a producer census shrank — `:1856` justifies typing `:where` as `:symbol`, `:1944` justifies `FrameDestroyedTags` leaving the list. Deleting them would remove the reasoning and leave the conclusions unsupported. This is CLAUDE.md's deliberate-bookkeeping case, and it means this file's inclusion as a defect site does not survive inspection.
- **`docs/design/retirement/freehand-and-ui.md:164,170`** — the retirement record itself, and outside the fence.

The discriminator throughout is the one that settled rf2-410b and rf2-7s78: a **live present-tense attribution** of a trace slot to a producer is a defect; a **dated record of a retirement** is not.

## Gates

| gate | exit |
|---|---|
| `python scripts/check_doc_slugs.py` | 0 |
| `python -m mkdocs build --strict` | 0 |
| `clojure -M:test -n re-frame.error-catalogue-channel-conformance-test -n re-frame.frame-destroyed-subscribe-devtrace-identity-cljs-test` | 0 — 34 tests, 187 assertions, 0 failures, 0 errors |

**Neither doc gate is the gate for the Spec-Schemas edit, and it was checked by hand.** The block is inside a fenced code block (71 fence toggles precede it, odd; 140 total, even — unchanged by this diff), and both gates strip fences before reading links. What was checked by hand: the three rows against the four emitter definitions cited above, read in full; the fence parity above; and the rendered block re-read in place against the rf2-63t1i paragraph that immediately follows it, which it now dovetails with rather than contradicting.

There is one real structural check on that file: `error_catalogue_channel_conformance_test.clj` parses schema forms straight out of `Spec-Schemas.md` (`tags-schema-form`), so the green JVM run proves the comment edit did not break schema extraction. It proves nothing about the prose.

**Planted fault (provenance only).** With my own edits committed, an unmatched `)` was inserted at line 90 of the devtrace test. The JVM gate went red, exit 1, naming `frame_destroyed_subscribe_devtrace_identity_cljs_test.cljc:90:2` / "Unmatched delimiter: )". Restored and verified by git blob hash against the committed object (`76322baf63b7da381180162124c80a29857b4f32`, matching), not by reading a diff. **This proves the gate reads this worktree's copy of that file and nothing else** — it says nothing about whether the prose is true. The prose was verified by reading the emitters.

Diffed against merge base `1cc284a46e` before pushing: two files, comments and docstrings only, no code touched, nothing reverted.

Closes rf2-22ks.
