### PR TITLE
test(bench): the write-all pin derives the census alias instead of spelling it (rf2-eexx)

### DIFF
--- a/bench/hicasso/src/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/bench/hicasso/src/re_frame/bench/p0_ladder_structural.test.cjs
@@ -2071,9 +2071,9 @@ test('the RETENTION ladder is not moved by any of this', () => {
   // this file has moved rather than gone. Its CONTENT is that the published
   // write is `(vec (repeat cells-n v))` at the literal published width, and
   // that content is unchanged to the byte. What the handler now also carries
-  // is `(wc/event!)`, the work census `rf2-n1b9h` reads to split
+  // is a census call, the work census `rf2-n1b9h` reads to split
   // `rf2-77gz8`'s two surviving candidates — and the reason that does not
-  // weaken this pin is the pin immediately below it: `wc/event!` is a MACRO
+  // weaken this pin is the pin immediately below it: `event!` is a MACRO
   // behind a `goog-define` that is FALSE by default, so under `:advanced`
   // Closure constant-folds the gate and eliminates the branch, and the
   // compiled write path of an unarmed build is the one every published
@@ -2081,9 +2081,50 @@ test('the RETENTION ladder is not moved by any of this', () => {
   //
   // Byte-identity of the SOURCE was only ever a proxy for constancy of the
   // COMPILED path. Where the two now differ, this file pins both.
+  //
+  // AMENDED A FOURTH TIME (rf2-eexx), and the amendment is why the census
+  // term above is no longer spelled out. This pin used to read the census
+  // call as the literal text `(wc/event!)`, so `1db71eac77` — the
+  // rf2-6r9j.161 require-alias campaign, which moved the fixture's alias for
+  // `re-frame.bench.p0-workcount` from `wc` to the canonical dotted
+  // `rf.bench.p0-workcount` of `spec/Conventions.md` §Require-alias dialect —
+  // reddened it. THE FIXTURE MOVED AND THE PIN WAS STALE, which is the one
+  // reading that permits a change here at all: an alias is COMPILE-TIME
+  // VOCABULARY, binding no var, changing no call target and emitting no
+  // different code, so the retention property this pin guards had not moved
+  // by so much as a byte. Only the word for it had.
+  //
+  // So the alias is DERIVED from the fixture's own `:require` instead of
+  // restated here, and this asks no less than the literal did: the handler
+  // must still be this form to the byte and carry nothing else. The single
+  // term that is pure vocabulary is now read from the fixture rather than
+  // restated, and that `:require` is itself asserted — which the literal
+  // never looked at. It matters here more than it would elsewhere: this lane
+  // is off every per-PR gate by ruling (rf2-6c12m.1), so a pin that rots on a
+  // rename rots UNSEEN until somebody runs `npm run check` by hand, which is
+  // exactly how this one went red on trunk for days.
+  //
+  // MUTATION-PROVED, four plants in the fixture, this suite alone:
+  //   `repeat cells-n v` -> `cells-nx`            RED (retention content bites)
+  //   alias renamed throughout to `wcx`           GREEN (vocabulary is free)
+  //   `:as` dropped from the `:require`           RED (derivation is load-bearing)
+  //   `(<alias>/event!)` dropped from the handler RED (census still pinned)
+  const reEsc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const CENSUS_ALIAS = (FIXTURE.match(/\[re-frame\.bench\.p0-workcount :as ([^\s\]]+)\]/) || [])[1];
+  assert.ok(
+    CENSUS_ALIAS,
+    'the fixture requires the work census, under whatever alias its `:require` declares'
+  );
   assert.match(
     FIXTURE,
-    /\(rf\/reg-event :p0\/write-all\s+\(fn \[\{:keys \[db\]\} \[_ v\]\] \(wc\/event!\) \{:db \(assoc db :cells \(vec \(repeat cells-n v\)\)\)\}\)\)/,
+    new RegExp(
+      reEsc('(rf/reg-event :p0/write-all') +
+        '\\s+' +
+        reEsc(
+          `(fn [{:keys [db]} [_ v]] (${CENSUS_ALIAS}/event!) {:db (assoc db :cells (vec (repeat cells-n v)))})`
+        ) +
+        reEsc(')')
+    ),
     '`:p0/write-all` still rebuilds at the literal `cells-n`, behind the census macro'
   );
   const WORKCOUNT = fs.readFileSync(path.join(CORE_BENCH, 'p0_workcount.cljc'), 'utf8');


### PR DESCRIPTION
## The symptom

`bench/hicasso`'s `npm run check` has been red on unmodified trunk, 1/100 in `p0_ladder_structural.test.cjs`:

```
FAIL  the RETENTION ladder is not moved by any of this
      `:p0/write-all` still rebuilds at the literal `cells-n`, behind the census macro

p0_ladder_structural.test.cjs: 1/100 failed
```

Reproduced here at `exit 1`, matching rf2-eexx's measurement on `f13de844d6` and `c8d26c290c`.

## Which side moved — the fixture did, and the pin was stale

That was the whole question, and it is answerable from history rather than judgement. `git log -S` on the form gives **exactly one commit**, `1db71eac77` (rf2-6r9j.161, *"canonical rf.* require aliases"*). Its diff on `implementation/core/test/re_frame/bench/p0_fixture.cljc` is a pure alias rename:

```diff
-  (:require [re-frame.bench.p0-workcount :as wc]
+  (:require [re-frame.bench.p0-workcount :as rf.bench.p0-workcount]
```

…carrying the four `wc/sub!` and three `wc/event!` call sites with it. `rf.bench.p0-workcount` is the canonical dotted alias `spec/Conventions.md` §Require-alias dialect prescribes for a framework subsystem namespace, so the fixture is at its **end state**, not mid-migration. That commit's own message states the invariant it worked under:

> Aliases are compile-time vocabulary only: no public var, namespace declaration, keyword/event/fx/late-bind id, serialized value, quoted data or external dependency alias changes.

So the retention property the pin guards had not moved by a byte. `:p0/write-all` still reads

```clojure
(fn [{:keys [db]} [_ v]] (rf.bench.p0-workcount/event!)
  {:db (assoc db :cells (vec (repeat cells-n v)))})
```

— the same rebuild of the same literal published width, behind the same census macro, emitting the same code. **The pin was matching the WORD for the census namespace, and the word is the one thing that campaign was licensed to change.**

`implementation/core/test/re_frame/bench/p0_fixture.cljc` is therefore **unchanged** by this PR.

## Why this is not a relaxation

The pin's failure message says a published retention figure would otherwise describe a page it was not taken on, so it is not one to loosen for green. This change does not loosen it.

The alias is now **derived from the fixture's own `:require`** and interpolated into the pattern. Everything that is not vocabulary stays byte-exact — the handler must still be that form and carry nothing else. The single term now read rather than restated is the term that binds no var, changes no call target and emits no different code; and the `:require` it is read from is **itself asserted**, which the old literal never looked at. The pattern is also built by escaping the Clojure form as text rather than by hand-escaped regex, so a reader sees the pinned form as the source spells it.

## Mutation-proved — four plants in the fixture, each run captured

| plant | captured exit | result |
|---|---|---|
| `repeat cells-n v` → `cells-nx` | `1`, 1/100 | RED — retention content still bites |
| alias renamed throughout to `wcx` | `0`, 100 passed | GREEN — vocabulary is free, as claimed |
| `:as` dropped from the `:require` | `1`, 1/100 | RED — the derivation is load-bearing |
| `(<alias>/event!)` dropped from the handler | `1`, 1/100 | RED — the census is still pinned |

The second row is the fix's claim demonstrated; rows 1, 3 and 4 are the guarantee surviving. Row 1 also establishes **which tree the gate read**: the fault existed only in this worktree, so a run that had wandered into another checkout would have come back green. The fixture was restored after each plant and verified by git **blob** hash against HEAD (`f290cdf92844c205c6bdc636b53cf4ee364d267e`).

## Gate

The bench lane is **off every per-PR gate by ruling (rf2-6c12m.1)** — verified at source: `report-changed-surfaces.sh`'s `bench/*` arm sets no output at all and says so explicitly, and `implementation/scripts/_changed-surfaces.test.cjs` pins every output false there. So **CI will not verify this PR**; the captured exit codes below are the whole evidence. `scripts/test-fast-pr.sh` is not applicable either — it does not run this lane, and its tiers are classifier-gated, so a green spine on a `bench/`-only diff would be vacuous.

From `bench/hicasso`, exit codes captured in-shell (never through a pipe):

```
before  node src/re_frame/bench/p0_ladder_structural.test.cjs  -> 1, 1/100 failed
after   node src/re_frame/bench/p0_ladder_structural.test.cjs  -> 0, 100 passed
after   npm run check                                          -> 0, all 24 suites green
```

The full-chain run is the load-bearing one. `check` is `&&`-linked, so while this pin was red **`hicasso_narrow_exit_path.test.cjs` never ran at all**. It now does — 19 passed — confirming no second failure was hiding behind this one. Both `npm run check` runs were re-taken on the final rebased base.

## Scope

One file: `bench/hicasso/src/re_frame/bench/p0_ladder_structural.test.cjs`. No change to the classifier or to `_changed-surfaces.test.cjs` (the one-toucher pair), and none to the fixture or any consumer of it.

Closes rf2-eexx.
