### PR TITLE
refactor(story): canonical rf.* require aliases across tools/story (rf2-7sx1)

### DIFF
--- a/scripts/require-alias-baseline.edn
+++ b/scripts/require-alias-baseline.edn
@@ -44,5 +44,5 @@
   "migration"                             0
   "skills"                                0
   "testbeds"                              0
-  "tools"                                 2294
+  "tools"                                 629
  }}

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -73,42 +73,42 @@
   ;; (`re-frame.story.frames/apply-variant-classification!`). Story requires
   ;; neither the classification ns nor `re-frame.core` directly (the docstring
   ;; above names `rf/dispatch-sync` etc. illustratively).
-  (:require [re-frame.story.config      :as config]
-            [re-frame.story.registrar   :as registrar]
+  (:require [re-frame.story.config      :as rf.story.config]
+            [re-frame.story.registrar   :as rf.story.registrar]
             ;; Cohesive internal namespaces own the implementation weight
             ;; for query, canonical boot, and lifecycle surfaces.
-            [re-frame.story.canonical   :as canonical]
+            [re-frame.story.canonical   :as rf.story.canonical]
             ;; The single canonical projection + fingerprint
             ;; primitive. Re-exported as `canonicalize` / `content-hash` /
             ;; `plan-hash` / `run-hash` below so every downstream call site
             ;; routes through one path (NOT `re-frame.story.canonical`,
             ;; which installs the canonical *vocabulary*).
-            [re-frame.story.fingerprint :as fingerprint]
+            [re-frame.story.fingerprint :as rf.story.fingerprint]
             ;; The run-evidence projection from the epoch tape.
             ;; Re-exported as `project-evidence` below so every downstream
             ;; run-result slot derives from ONE tape (NewTestStory §A0c).
-            [re-frame.story.play.evidence :as evidence]
+            [re-frame.story.play.evidence :as rf.story.play.evidence]
             ;; The `:rf.test/run-artifact` schema + replay.
             ;; Re-exported as `make-run-artifact` / `run-artifact?` /
             ;; `replay-run-artifact` below (spec/017 §Run artifact and replay).
-            [re-frame.story.artifact    :as artifact]
+            [re-frame.story.artifact    :as rf.story.artifact]
             ;; The determinism gate. Re-exported as
             ;; `assert-deterministic` below (spec/017 §Determinism gate).
-            [re-frame.story.determinism :as determinism]
+            [re-frame.story.determinism :as rf.story.determinism]
             ;; The semantic diff over canonical run artifacts.
             ;; Re-exported as `diff-run-artifacts` below (spec/017 §Semantic
             ;; diff). Builds read-only on `.7` replay + `.3`/`.8` canonicalize.
-            [re-frame.story.diff        :as diff]
+            [re-frame.story.diff        :as rf.story.diff]
             ;; Golden slices.
             ;; Re-exported as `capture-golden` / `golden-match?` /
             ;; `compare-golden` below (spec/017 §Golden slices). Builds
             ;; read-only on `.3`/`.8` canonicalize + `.7` replay + `.9` diff.
-            [re-frame.story.golden      :as golden]
+            [re-frame.story.golden      :as rf.story.golden]
             ;; The run-artifact → variant promotion bridge.
             ;; Re-exported as `materialize-variant-plan` (pure) +
             ;; `promote-run-artifact!` (the explicit-only registration path)
             ;; below (spec/017 §Promotion — Promotion bridge).
-            [re-frame.story.promotion   :as promotion]
+            [re-frame.story.promotion   :as rf.story.promotion]
             ;; Generated / property-style runs that emit
             ;; seed-bearing run artifacts (+ shrink) and a fault-lattice
             ;; sweep. Re-exported as `check-property!` / `sweep-faults!`
@@ -116,29 +116,29 @@
             ;; read-only on `.7` replay + the `:seed` / `:shrink-path`
             ;; artifact slots; a generated failure feeds the promotion
             ;; bridge unchanged (artifacts first, curated promotion only).
-            [re-frame.story.generate    :as generate]
+            [re-frame.story.generate    :as rf.story.generate]
             ;; The ONE unified run-result + the assertion /
             ;; check record shapes + the clojure.test report projection.
             ;; Re-exported as `run-result` / `result-status` /
             ;; `result-passed?` and backs the `story/is` bridge below
             ;; (spec/017 §Run result + §Unified run result).
-            [re-frame.story.result      :as result]
+            [re-frame.story.result      :as rf.story.result]
             ;; The ONE verdict-aggregation rule
             ;; (`:error` > `:fail` > `:cannot-run` > `:pass`). Re-exported
             ;; as `aggregate-verdict` below so tooling (story-mcp) reads the
             ;; runner's verdict rule rather than re-implementing it.
-            [re-frame.story.requirements :as requirements]
+            [re-frame.story.requirements :as rf.story.requirements]
             ;; `story/is` blocks on the JVM run promise +
             ;; chains the CLJS one (the headless-test bridge).
-            [re-frame.story.async       :as async]
-            [re-frame.story.lifecycle   :as lifecycle]
-            [re-frame.story.query       :as query]
+            [re-frame.story.async       :as rf.story.async]
+            [re-frame.story.lifecycle   :as rf.story.lifecycle]
+            [re-frame.story.query       :as rf.story.query]
             ;; The variant-plan compiler (re-exported as
             ;; `variant-plan` / `explain`) + the `render-variant` workshop
             ;; render verb that drives the SAME plan the runner consumes
             ;; (spec/017 §Args, controls, and `render-variant`).
-            [re-frame.story.plan        :as plan]
-            [re-frame.story.render      :as render]
+            [re-frame.story.plan        :as rf.story.plan]
+            [re-frame.story.render      :as rf.story.render]
             ;; `story/is` bridges per-assertion run-result
             ;; reports to clojure.test / cljs.test (spec/017 §Public
             ;; execution API — the three verbs). `do-report` is the one
@@ -146,39 +146,39 @@
             #?(:clj  [clojure.test :as test]
                :cljs [cljs.test    :as test])
             ;; Runtime modules — args resolution, decorators.
-            [re-frame.story.args        :as args]
+            [re-frame.story.args        :as rf.story.args]
             ;; The variant-id STRING-shape grammar. Re-exported
             ;; as `valid-variant-id?` below so the story-mcp write path
             ;; validates a caller id before interning via the facade.
-            [re-frame.story.schemas     :as schemas]
-            [re-frame.story.decorators  :as decorators]
+            [re-frame.story.schemas     :as rf.story.schemas]
+            [re-frame.story.decorators  :as rf.story.decorators]
             ;; Assertions + play + force-fx-stub.
-            [re-frame.story.assertions  :as assertions]
-            [re-frame.story.fx-stubs    :as fx-stubs]
-            [re-frame.story.play        :as play]
+            [re-frame.story.assertions  :as rf.story.assertions]
+            [re-frame.story.fx-stubs    :as rf.story.fx-stubs]
+            [re-frame.story.play        :as rf.story.play]
             ;; Test Codegen recorder (pure-data state + snippet generator).
-            [re-frame.story.recorder    :as recorder]
+            [re-frame.story.recorder    :as rf.story.recorder]
             ;; Recording → live `:script` body translator.
             ;; Re-exported as `recording->script-body`: the runtime counterpart
             ;; to `gen-play-snippet`'s text output, for the recorder panel and
             ;; any in-process caller wanting the canonical replayable slot.
-            [re-frame.story.recorder.play-export :as play-export]
+            [re-frame.story.recorder.play-export :as rf.story.recorder.play-export]
             ;; SOTA features — layout-debug + share live in .cljc;
             ;; multi-substrate / a11y / panels are CLJS-only so the
             ;; JVM classpath stays Reagent-free.
-            [re-frame.story.layout-debug :as layout-debug]
-            [re-frame.story.share        :as share]
+            [re-frame.story.layout-debug :as rf.story.layout-debug]
+            [re-frame.story.share        :as rf.story.share]
             ;; UI shell — CLJS-only require so JVM consumers don't pull
             ;; Reagent / reagent.dom.client into their classpath.
-            #?(:cljs [re-frame.story.ui.shell :as ui-shell])
-            #?(:cljs [re-frame.story.ui.multi-substrate :as ui-multi-substrate])
+            #?(:cljs [re-frame.story.ui.shell :as rf.story.ui.shell])
+            #?(:cljs [re-frame.story.ui.multi-substrate :as rf.story.ui.multi-substrate])
             ;; Story → Xray project-root bridge. `configure!`
-            ;; calls `xray-preset/propagate-project-root!` so Xray-as-RHS
+            ;; calls `rf.story.xray-preset/propagate-project-root!` so Xray-as-RHS
             ;; source-coord chips resolve coords against the same on-disk
             ;; root Story uses. CLJS-only require because the propagator
             ;; is CLJS-only (it feature-detects Xray via `find-ns-obj`).
-            #?(:cljs [re-frame.story.xray-preset :as xray-preset])
-            #?(:clj [re-frame.story.macros :as macros]))
+            #?(:cljs [re-frame.story.xray-preset :as rf.story.xray-preset])
+            #?(:clj [re-frame.story.macros :as rf.story.macros]))
   ;; The nine reg-* macros are defined in the #?(:clj ...) blocks
   ;; below. Self-refer them via :require-macros so CLJS callers can
   ;; write `story/reg-story` after `(:require [re-frame.story :as story])`
@@ -229,7 +229,7 @@
      Expansion elides to `nil` under `:advanced` builds with
      `re-frame.story.config/enabled?` set to `false`."
      [id metadata]
-     (macros/expand-reg-story (meta &form) *file*
+     (rf.story.macros/expand-reg-story (meta &form) *file*
                               (symbol (str (ns-name *ns*)))
                               id metadata)))
 
@@ -273,7 +273,7 @@
      the plan compiler — the single merge authority — when the variant is
      compiled; see `re-frame.story.plan/compile-body`."
      [id metadata]
-     (macros/gen-reg-call (meta &form) *file*
+     (rf.story.macros/gen-reg-call (meta &form) *file*
                           (symbol (str (ns-name *ns*)))
                           `re-frame.story.registrar/reg-variant*
                           id metadata)))
@@ -310,7 +310,7 @@
      end-state and resolves the conflict by stating the wanted value (no
      `:resolve-conflicts` escape hatch in P1)."
      [id metadata]
-     (macros/gen-reg-call (meta &form) *file*
+     (rf.story.macros/gen-reg-call (meta &form) *file*
                           (symbol (str (ns-name *ns*)))
                           `re-frame.story.registrar/reg-fragment*
                           id metadata)))
@@ -333,7 +333,7 @@
      id) is preserved in the plan and in run results, so a failed check
      shows both the check id and the underlying assertion records."
      [id metadata]
-     (macros/gen-reg-call (meta &form) *file*
+     (rf.story.macros/gen-reg-call (meta &form) *file*
                           (symbol (str (ns-name *ns*)))
                           `re-frame.story.registrar/reg-check*
                           id metadata)))
@@ -368,7 +368,7 @@
      the v1 devcards-style multi-variant pane
      (`005-SOTA-Features.md` §`:variants-grid` workspace layout)."
      [id metadata]
-     (macros/gen-reg-call (meta &form) *file*
+     (rf.story.macros/gen-reg-call (meta &form) *file*
                           (symbol (str (ns-name *ns*)))
                           `re-frame.story.registrar/reg-workspace*
                           id metadata)))
@@ -392,7 +392,7 @@
      `(variant × mode)` cell has its own snapshot-identity for visual
      regression keying."
      [id metadata]
-     (macros/gen-reg-call (meta &form) *file*
+     (rf.story.macros/gen-reg-call (meta &form) *file*
                           (symbol (str (ns-name *ns*)))
                           `re-frame.story.registrar/reg-mode*
                           id metadata)))
@@ -416,7 +416,7 @@
      the re-frame-10x epoch panel ships as a registered
      story panel via this macro."
      [id metadata]
-     (macros/gen-reg-call (meta &form) *file*
+     (rf.story.macros/gen-reg-call (meta &form) *file*
                           (symbol (str (ns-name *ns*)))
                           `re-frame.story.registrar/reg-story-panel*
                           id metadata)))
@@ -437,7 +437,7 @@
      - `:frame-setup` — `{:kind :frame-setup, :init [...], :app-db-patch {...}}`
      - `:fx-override` — `{:kind :fx-override, :fx-id ..., :response ...}`"
      [id metadata]
-     (macros/gen-reg-call (meta &form) *file*
+     (rf.story.macros/gen-reg-call (meta &form) *file*
                           (symbol (str (ns-name *ns*)))
                           `re-frame.story.registrar/reg-decorator*
                           id metadata)))
@@ -477,7 +477,7 @@
      resolves at registration time against the inherited set — see
      `001-Authoring.md` §Tags."
      [id metadata]
-     (macros/gen-reg-call (meta &form) *file*
+     (rf.story.macros/gen-reg-call (meta &form) *file*
                           (symbol (str (ns-name *ns*)))
                           `re-frame.story.registrar/reg-tag*
                           id metadata)))
@@ -497,32 +497,32 @@
   registrar — see `001-Authoring.md` §Registration macros for the
   design rationale."
   [kind]
-  (query/registrations kind))
+  (rf.story.query/registrations kind))
 
 (defn handler-meta
   "Return the body for `(kind, id)`, or nil."
   [kind id]
-  (query/handler-meta kind id))
+  (rf.story.query/handler-meta kind id))
 
 (defn ids
   "Return the id set for `kind`."
   [kind]
-  (query/ids kind))
+  (rf.story.query/ids kind))
 
 (defn registered?
   "True iff `(kind, id)` is registered."
   [kind id]
-  (query/registered? kind id))
+  (rf.story.query/registered? kind id))
 
 (defn all-kinds-with-counts
   "{kind → count} — dev tooling overlay."
   []
-  (query/all-kinds-with-counts))
+  (rf.story.query/all-kinds-with-counts))
 
 (defn variants-of
   "Return the set of variant ids whose parent is `story-id`."
   [story-id]
-  (query/variants-of story-id))
+  (rf.story.query/variants-of story-id))
 
 (defn variants-by-story
   "Return a `{story-id #{variant-id ...}}` index built in one pass over
@@ -533,7 +533,7 @@
   introspection tool); the single-pass index avoids the O(S × V)
   walk of calling `variants-of` per story."
   []
-  (query/variants-by-story))
+  (rf.story.query/variants-by-story))
 
 (defn variants-with-tags
   "Per `002-Runtime.md` §Programmatic API — return the set of variant ids
@@ -543,18 +543,18 @@
   and a removed one does not. The assertions/play surface leans on this;
   the render shell leans on this to compose the sidebar tree."
   [query-tags]
-  (query/variants-with-tags query-tags))
+  (rf.story.query/variants-with-tags query-tags))
 
 (defn list-tags
   "Per `002-Runtime.md` §Tag-vocabulary queries — return the set of registered tag ids. Tools
   enumerate this set before assigning tags to a variant."
   []
-  (query/list-tags))
+  (rf.story.query/list-tags))
 
 (defn list-modes
   "Per `002-Runtime.md` §Tag-vocabulary queries — return the set of registered mode ids."
   []
-  (query/list-modes))
+  (rf.story.query/list-modes))
 
 (defn tags-by-axis
   "Per spec/001 §reg-tag — return the set of registered tag ids whose
@@ -563,14 +563,14 @@
   tags into collapsible facet rows (SB9 parity). Returns the
   empty set if no tag carries that axis."
   [axis-kw]
-  (query/tags-by-axis axis-kw))
+  (rf.story.query/tags-by-axis axis-kw))
 
 (defn tags-without-axis
   "Per spec/001 §reg-tag — return the set of registered tag ids whose
   body carries no `:axis`. The sidebar renders these in a trailing
   un-grouped facet row."
   []
-  (query/tags-without-axis))
+  (rf.story.query/tags-without-axis))
 
 (defn tags-default-excluded
   "Per spec/001 §reg-tag — return the set of registered tag ids whose
@@ -578,37 +578,37 @@
   pre-excludes variants carrying any of these at boot (e.g.
   `:internal` / `:experimental`)."
   []
-  (query/tags-default-excluded))
+  (rf.story.query/tags-default-excluded))
 
 (def canonical-tags
   "Re-export of the seven canonical tag ids from /spec/007-Stories.md
   §Inclusion tags. Stable across hosts."
-  query/canonical-tags)
+  rf.story.query/canonical-tags)
 
 (def canonical-axes
   "Re-export of the canonical facet axes documented in spec/001
   §reg-tag — `:status`, `:role`, `:team`, `:feature` (SB9 facet
   taxonomy) + `:state` (operator-facing magnitude).
   Stable across hosts."
-  query/canonical-axes)
+  rf.story.query/canonical-axes)
 
 (def canonical-status-values
   "Re-export of the recommended `:status` axis vocabulary."
-  query/canonical-status-values)
+  rf.story.query/canonical-status-values)
 
 (def canonical-role-values
   "Re-export of the recommended `:role` axis vocabulary."
-  query/canonical-role-values)
+  rf.story.query/canonical-role-values)
 
 (def canonical-state-values
   "Re-export of the canonical `:state` axis vocabulary —
   `#{:empty :small :medium :large :special}`."
-  query/canonical-state-values)
+  rf.story.query/canonical-state-values)
 
 (def canonical-state-tags
   "Re-export of the canonical `:state/*` faceted tags registered at
   Story load."
-  query/canonical-state-tags)
+  rf.story.query/canonical-state-tags)
 
 (defn tag->axis-index
   "Per spec/001 §reg-tag — return a `{tag-id → axis-kw}` map across
@@ -617,7 +617,7 @@
   filter row + the `:tag-filter` AND-across-axes predicate
   consume this."
   []
-  (query/tag->axis-index))
+  (rf.story.query/tag->axis-index))
 
 ;; ---- programmatic registration surface -----------------------------------
 ;;
@@ -627,18 +627,18 @@
 ;; Re-exported here so authors with a legit programmatic need can call
 ;; them without reaching into the internal ns.
 
-(def reg-story*       registrar/reg-story*)
-(def reg-variant*     registrar/reg-variant*)
+(def reg-story*       rf.story.registrar/reg-story*)
+(def reg-variant*     rf.story.registrar/reg-variant*)
 ;; Fragment + check runtime helpers, grouped with the other registrar
 ;; re-exports (strict composition: `:compose` pulls these into a variant
 ;; plan).
-(def reg-fragment*    registrar/reg-fragment*)
-(def reg-check*       registrar/reg-check*)
-(def reg-workspace*   registrar/reg-workspace*)
-(def reg-mode*        registrar/reg-mode*)
-(def reg-story-panel* registrar/reg-story-panel*)
-(def reg-decorator*   registrar/reg-decorator*)
-(def reg-tag*         registrar/reg-tag*)
+(def reg-fragment*    rf.story.registrar/reg-fragment*)
+(def reg-check*       rf.story.registrar/reg-check*)
+(def reg-workspace*   rf.story.registrar/reg-workspace*)
+(def reg-mode*        rf.story.registrar/reg-mode*)
+(def reg-story-panel* rf.story.registrar/reg-story-panel*)
+(def reg-decorator*   rf.story.registrar/reg-decorator*)
+(def reg-tag*         rf.story.registrar/reg-tag*)
 
 ;; ---- canonical vocabulary boot ------------------------------------------
 ;;
@@ -667,7 +667,7 @@
   an unregistered tag on a variant's `:tags` set raises
   `:rf.error/unknown-tag`."
   []
-  (canonical/install!))
+  (rf.story.canonical/install!))
 
 ;; ---- frame-owned classification — NO add-marks / set-marks re-export -----
 ;;
@@ -759,8 +759,8 @@
   ([id body]
    (reg-global-decorator id body []))
   ([id body ref-args]
-   (registrar/reg-decorator* id body)
-   (config/add-global-decorator! (into [id] ref-args))
+   (rf.story.registrar/reg-decorator* id body)
+   (rf.story.config/add-global-decorator! (into [id] ref-args))
    id))
 
 (defn unreg-global-decorator!
@@ -768,14 +768,14 @@
   registration body is NOT unregistered — call `unregister!` for that.
   Idempotent."
   [id]
-  (config/remove-global-decorator! id))
+  (rf.story.config/remove-global-decorator! id))
 
 (defn global-decorators
   "Return the current ordered vector of global-decorator references
   (`[[decorator-id & args] ...]`). Earliest-registered first; this is
   the prefix applied to every variant's resolved decorator stack."
   []
-  (config/get-global-decorators))
+  (rf.story.config/get-global-decorators))
 
 ;; ---- configure! ---------------------------------------------------------
 
@@ -884,24 +884,24 @@
                          :unknown     (vec unknown)
                          :known       known-keys})))))
   (when (some? global-args)
-    (config/set-global-args! global-args))
+    (rf.story.config/set-global-args! global-args))
   (when (contains? opts :rf.story/global-decorators)
-    (config/set-global-decorators! global-decorators))
+    (rf.story.config/set-global-decorators! global-decorators))
   (when (some? editor)
-    (config/set-editor! editor))
+    (rf.story.config/set-editor! editor))
   (when (contains? opts :rf.story/project-root)
-    (config/set-project-root! project-root)
+    (rf.story.config/set-project-root! project-root)
     ;; Bridge into Xray's `:rf.xray/project-root` slot so
     ;; Xray-as-RHS source-coord chips share the same on-disk root.
     ;; Feature-detect-safe (no-op when Xray is not on the classpath).
-    #?(:cljs (xray-preset/propagate-project-root!)))
+    #?(:cljs (rf.story.xray-preset/propagate-project-root!)))
   (when (contains? opts :rf.story/egress-profile)
     ;; EP-0015: the named-boundary enum is CLOSED. An unknown
     ;; non-nil profile fails loudly at boot — mirroring `project-egress`'s
     ;; own `:rf.error/unknown-egress-profile` — rather than silently
     ;; coercing to the default. `nil` resets to the redacting default.
     (when (and (some? egress-profile)
-               (not (config/known-egress-profile? egress-profile)))
+               (not (rf.story.config/known-egress-profile? egress-profile)))
       ;; Canonical thrown-error shape per Spec 009 §The thrown-error shape:
       ;; a human sentence + the trailing `[:rf.error/<id>]` token as the
       ;; ex-message, with `:rf.error/id` the sole machine discriminator.
@@ -910,7 +910,7 @@
       ;; is hand-rolled inline (mirroring reagent-slim's same constraint).
       (let [msg (str "configure! got an unknown :rf.story/egress-profile: "
                      (pr-str egress-profile)
-                     " — known profiles are " (pr-str config/egress-profiles) ". "
+                     " — known profiles are " (pr-str rf.story.config/egress-profiles) ". "
                      "Use one of the known profiles, or `nil` to reset to the "
                      "redacting default. [:rf.error/unknown-egress-profile]")]
         (throw (ex-info msg
@@ -919,8 +919,8 @@
                          :recovery    :use-a-known-profile
                          :reason      msg
                          :profile     egress-profile
-                         :valid       config/egress-profiles}))))
-    (config/set-egress-profile! egress-profile))
+                         :valid       rf.story.config/egress-profiles}))))
+    (rf.story.config/set-egress-profile! egress-profile))
   nil)
 
 ;; ---- registry reset (test fixtures) -------------------------------------
@@ -944,15 +944,15 @@
     tags etc. need to be re-registered before any tagged variant can
     be added).
   - resets the two per-process play atoms (`pending-exceptions` +
-    `stepper-state`) via `play/clear-all-play-state!` — the
+    `stepper-state`) via `rf.story.play/clear-all-play-state!` — the
     remaining un-reset per-process state, so a stepper / pending-exception
     session in one test cannot leak into the next on a reset path that
     bypasses per-frame `frames/destroy!` teardown."
   []
-  (registrar/clear-all!)
-  (config/reset-all!)
-  (canonical/reset-installed-flag!)
-  (play/clear-all-play-state!))
+  (rf.story.registrar/clear-all!)
+  (rf.story.config/reset-all!)
+  (rf.story.canonical/reset-installed-flag!)
+  (rf.story.play/clear-all-play-state!))
 
 ;; ---- canonical test-fixture helper — DIRECT-REQUIRE, not on this facade -
 ;;
@@ -976,12 +976,12 @@
 (defn clear-kind!
   "Remove every id under `kind`. Used by test fixtures and hot-reload."
   [kind]
-  (registrar/clear-kind! kind))
+  (rf.story.registrar/clear-kind! kind))
 
 (defn unregister!
   "Remove a single id under `kind`."
   [kind id]
-  (registrar/unregister! kind id))
+  (rf.story.registrar/unregister! kind id))
 
 ;; ---- variant lifecycle surface ------------------------------------------
 ;;
@@ -998,12 +998,12 @@
 
   Returns nil when the variant is unregistered."
   [variant-id]
-  (lifecycle/variant->edn variant-id))
+  (rf.story.lifecycle/variant->edn variant-id))
 
 (defn workspace->edn
   "Per `002-Runtime.md` §Programmatic API — same for workspaces."
   [workspace-id]
-  (lifecycle/workspace->edn workspace-id))
+  (rf.story.lifecycle/workspace->edn workspace-id))
 
 (defn valid-variant-id?
   "Per /spec/007-Stories.md §Canonical id grammar — true iff the DECOMPOSED
@@ -1016,7 +1016,7 @@
   `fresh-keyword-checked` `shape-ok?` predicate), single-sourced with the
   registrar's keyword-level grammar."
   [decomposed-id]
-  (schemas/variant-id-shape? decomposed-id))
+  (rf.story.schemas/variant-id-shape? decomposed-id))
 
 (defn run-variant
   "Per `002-Runtime.md` §Four-phase lifecycle with `:loaders-complete-when`.
@@ -1031,13 +1031,13 @@
   See `re-frame.story.result` and spec/017 §Unified run result for the
   result contract. Rendering is driven separately through `render-variant`
   or the UI shell."
-  ([variant-id]       (lifecycle/run-variant variant-id))
-  ([variant-id opts]  (lifecycle/run-variant variant-id opts)))
+  ([variant-id]       (rf.story.lifecycle/run-variant variant-id))
+  ([variant-id opts]  (rf.story.lifecycle/run-variant variant-id opts)))
 
 (defn reset-variant
   "Tear down + re-run `variant-id`. Per `002-Runtime.md` §Programmatic API."
-  ([variant-id]       (lifecycle/reset-variant variant-id))
-  ([variant-id opts]  (lifecycle/reset-variant variant-id opts)))
+  ([variant-id]       (rf.story.lifecycle/reset-variant variant-id))
+  ([variant-id opts]  (rf.story.lifecycle/reset-variant variant-id opts)))
 
 (defn watch-variant
   "Subscribe to lifecycle transitions for `variant-id`'s frame. Per
@@ -1045,7 +1045,7 @@
   `{:frame-id <id> :from <state> :to <state> :event <inner-event>}`
   on every transition. Returns a 0-arity unsubscribe fn."
   [variant-id callback]
-  (lifecycle/watch-variant variant-id callback))
+  (rf.story.lifecycle/watch-variant variant-id callback))
 
 (defn snapshot-identity
   "Per `002-Runtime.md` §Programmatic API + §Snapshot-identity computation.
@@ -1055,8 +1055,8 @@
 
   Returns `{:variant-id ... :active-modes [...] :substrate ...
   :content-hash \"<8-char hex>\"}`."
-  ([variant-id]       (lifecycle/snapshot-identity variant-id))
-  ([variant-id opts]  (lifecycle/snapshot-identity variant-id opts)))
+  ([variant-id]       (rf.story.lifecycle/snapshot-identity variant-id))
+  ([variant-id opts]  (rf.story.lifecycle/snapshot-identity variant-id opts)))
 
 ;; ---- canonicalization / fingerprinting ----------------------------------
 ;;
@@ -1074,31 +1074,31 @@
   Equivalent values canonicalize `=`; a semantic difference perturbs the
   result."
   [x]
-  (fingerprint/canonicalize x))
+  (rf.story.fingerprint/canonicalize x))
 
 (defn canonical-hash
   "8-char-hex hash of the `canonicalize`d projection of `x` — the
   determinism / semantic-diff / run-equivalence hash."
   [x]
-  (fingerprint/canonical-hash x))
+  (rf.story.fingerprint/canonical-hash x))
 
 (defn content-hash
   "8-char-hex content hash of the exact value `x` (ordered, no volatile
   strip) — the low primitive snapshot identity hashes."
   [x]
-  (fingerprint/content-hash x))
+  (rf.story.fingerprint/content-hash x))
 
 (defn plan-hash
   "`:plan-hash` over the enumerated normalized-plan input slice. Routes
   through the same primitive as `run-hash`."
   [plan]
-  (fingerprint/plan-hash plan))
+  (rf.story.fingerprint/plan-hash plan))
 
 (defn run-hash
   "`:run-hash` over the canonical epoch/run slice of a run-result. Routes
   through the same primitive as `plan-hash`."
   [result]
-  (fingerprint/run-hash result))
+  (rf.story.fingerprint/run-hash result))
 
 ;; ---- run-evidence projection --------------------------------------------
 ;;
@@ -1115,8 +1115,8 @@
   `re-frame.core/epoch-history`) into the run-result evidence slots. Pure
   data → data. `opts` may carry `:script` for the two-level `:narrative`.
   Every evidential slot agrees with the tape by construction."
-  ([epoch-tape]      (evidence/project-evidence epoch-tape))
-  ([epoch-tape opts] (evidence/project-evidence epoch-tape opts)))
+  ([epoch-tape]      (rf.story.play.evidence/project-evidence epoch-tape))
+  ([epoch-tape opts] (rf.story.play.evidence/project-evidence epoch-tape opts)))
 
 (defn tape-shows-failure?
   "Per spec/017 §Run-result evidence projection — true iff the retained
@@ -1124,8 +1124,8 @@
   epoch, or an error effect). The agreement floor: a run may not report
   `:pass` while this is true. Optional `consumed-selectors` (a set) excuses
   expected schema failures. Pure data → data."
-  ([epoch-tape]                     (evidence/tape-shows-failure? epoch-tape))
-  ([epoch-tape consumed-selectors]  (evidence/tape-shows-failure? epoch-tape consumed-selectors)))
+  ([epoch-tape]                     (rf.story.play.evidence/tape-shows-failure? epoch-tape))
+  ([epoch-tape consumed-selectors]  (rf.story.play.evidence/tape-shows-failure? epoch-tape consumed-selectors)))
 
 ;; ---- narrative navigation -----------------------------------------------
 ;;
@@ -1143,26 +1143,26 @@
   address), `:span-idx`, owning `:step`, and `:span-caption`. Pure data →
   data."
   [narrative]
-  (evidence/narrative-beats narrative))
+  (rf.story.play.evidence/narrative-beats narrative))
 
 (defn beat-count
   "Per spec/017 §Epoch tape and narrative — the number of scrubbable beats
   in a two-level `narrative` (the scrub slider's extent). Pure data → data."
   [narrative]
-  (evidence/beat-count narrative))
+  (rf.story.play.evidence/beat-count narrative))
 
 (defn beat-at
   "Per spec/017 §Epoch tape and narrative — the flattened beat at 0-based
   scrub position `idx`, or nil out of range. Pure data → data."
   [narrative idx]
-  (evidence/beat-at narrative idx))
+  (rf.story.play.evidence/beat-at narrative idx))
 
 (defn beat-epoch-ids
   "Per spec/017 §Epoch tape and narrative — the ordered `:epoch-id` vector
   for a two-level `narrative`; the Nth element is the `restore-epoch`
   target for scrub position N. Pure data → data."
   [narrative]
-  (evidence/beat-epoch-ids narrative))
+  (rf.story.play.evidence/beat-epoch-ids narrative))
 
 ;; ---- run artifact + replay ----------------------------------------------
 ;;
@@ -1178,21 +1178,21 @@
   `:setup` / `:script` sugar into it, stamps `:artifact/kind`, and defaults
   `:fx-decisions`. Pure data → data."
   [parts]
-  (artifact/make-run-artifact parts))
+  (rf.story.artifact/make-run-artifact parts))
 
 (defn run-artifact?
   "Per spec/017 §Run artifact and replay — true iff `x` is a
   `:rf.test/run-artifact` map (the kind tag plus a vector `:event-program`)."
   [x]
-  (artifact/run-artifact? x))
+  (rf.story.artifact/run-artifact? x))
 
 (defn replay-run-artifact
   "Per spec/017 §Run artifact and replay — replay a `:rf.test/run-artifact`
   into a FRESH frame, reapplying the fx decisions, capturing a NEW epoch
   tape, and returning the shared run-result shape (§Run result). `opts` MAY
   carry `:frame` / `:hooks` / `:frame-config`."
-  ([art]      (artifact/replay-run-artifact art))
-  ([art opts] (artifact/replay-run-artifact art opts)))
+  ([art]      (rf.story.artifact/replay-run-artifact art))
+  ([art opts] (rf.story.artifact/replay-run-artifact art opts)))
 
 ;; ---- determinism gate ---------------------------------------------------
 ;;
@@ -1211,8 +1211,8 @@
   `:cannot-run` when the program carries a bare `[:wait ms]` (the explicit
   determinism opt-out — refused rather than run flakily). `opts` MAY carry
   `:runs` / `:hooks` / `:frame-config`."
-  ([plan-or-artifact]      (determinism/assert-deterministic plan-or-artifact))
-  ([plan-or-artifact opts] (determinism/assert-deterministic plan-or-artifact opts)))
+  ([plan-or-artifact]      (rf.story.determinism/assert-deterministic plan-or-artifact))
+  ([plan-or-artifact opts] (rf.story.determinism/assert-deterministic plan-or-artifact opts)))
 
 ;; ---- run-artifact → variant promotion bridge ----------------------------
 ;;
@@ -1233,8 +1233,8 @@
   source link. `opts` MAY carry `:variant/id` / `:setup` / `:script` /
   `:setup-count` / `:doc` / `:extends` / `:tags` / `:args` / `:lookup` /
   `:view-lookup` / `:validator-fns`."
-  ([artifact]      (promotion/materialize-variant-plan artifact))
-  ([artifact opts] (promotion/materialize-variant-plan artifact opts)))
+  ([artifact]      (rf.story.promotion/materialize-variant-plan artifact))
+  ([artifact opts] (rf.story.promotion/materialize-variant-plan artifact opts)))
 
 (defn promote-run-artifact!
   "Per spec/017 §Promotion — promote a curated run artifact into a NAMED
@@ -1246,7 +1246,7 @@
   `reg-variant` write path. Production builds short-circuit. Returns the
   registered variant id."
   [artifact opts]
-  (promotion/promote-run-artifact! artifact opts))
+  (rf.story.promotion/promote-run-artifact! artifact opts))
 
 ;; ---- generated / property-style runs ------------------------------------
 ;;
@@ -1269,7 +1269,7 @@
   `{:status :fail :seed … :shrink-path … :artifact <run-artifact> …}`; the
   `:artifact` feeds `promote-run-artifact!` for a curated regression variant."
   [gen-fn opts]
-  (generate/check-property! gen-fn opts))
+  (rf.story.generate/check-property! gen-fn opts))
 
 (defn sweep-faults!
   "Per spec/017 §Fault lattice sweep — replay `base-program` across a
@@ -1280,7 +1280,7 @@
   MAY carry `:seed` / `:hooks` / `:frame-config`. Returns `{:cells [{:cell
   :status :artifact :result} …] :failing [cell-id …]}`."
   [base-program fault-lattice opts]
-  (generate/sweep-faults! base-program fault-lattice opts))
+  (rf.story.generate/sweep-faults! base-program fault-lattice opts))
 
 ;; ---- semantic diff over run artifacts -----------------------------------
 ;;
@@ -1303,8 +1303,8 @@
   behaviourally-identical runs, else `{:same? false :facets #{…} …}` carrying
   ONLY the facets that differ. `opts` MAY carry `:frame` / `:hooks` /
   `:frame-config` (threaded to the replay)."
-  ([baseline current]      (diff/diff-run-artifacts baseline current))
-  ([baseline current opts] (diff/diff-run-artifacts baseline current opts)))
+  ([baseline current]      (rf.story.diff/diff-run-artifacts baseline current))
+  ([baseline current opts] (rf.story.diff/diff-run-artifacts baseline current opts)))
 
 ;; ---- golden slices ------------------------------------------------------
 ;;
@@ -1325,8 +1325,8 @@
   (curation provenance), `:keep-run-result` (retain the source slice for a
   readable `compare-golden` mismatch diff), and `:frame` / `:hooks` /
   `:frame-config` (threaded to the replay)."
-  ([target]      (golden/capture-golden target))
-  ([target opts] (golden/capture-golden target opts)))
+  ([target]      (rf.story.golden/capture-golden target))
+  ([target opts] (rf.story.golden/capture-golden target opts)))
 
 (defn golden-match?
   "Per spec/017 §Golden slices — true iff `run` matches the `golden` slice:
@@ -1336,8 +1336,8 @@
   real semantic difference. `run` MAY be a run-result (pure) or a
   `:rf.test/run-artifact` (replayed first); `opts` MAY carry `:frame` /
   `:hooks` / `:frame-config`."
-  ([golden run]      (golden/golden-match? golden run))
-  ([golden run opts] (golden/golden-match? golden run opts)))
+  ([golden run]      (rf.story.golden/golden-match? golden run))
+  ([golden run opts] (rf.story.golden/golden-match? golden run opts)))
 
 (defn compare-golden
   "Per spec/017 §Golden slices — compare `run` against the `golden` slice
@@ -1349,32 +1349,32 @@
   with `:keep-run-result true` (or pass `:golden-run-result`); absent it the
   report still states the mismatch fact. `opts` MAY carry
   `:golden-run-result` + the replay opts."
-  ([golden run]      (golden/compare-golden golden run))
-  ([golden run opts] (golden/compare-golden golden run opts)))
+  ([golden run]      (rf.story.golden/compare-golden golden run))
+  ([golden run opts] (rf.story.golden/compare-golden golden run opts)))
 
 (defn destroy-variant!
   "Tear down a variant frame allocated via `run-variant`. Per
   `002-Runtime.md` §Per-variant frame allocation — the caller (UI shell / test fixture) owns teardown."
   [variant-id]
-  (lifecycle/destroy-variant! variant-id))
+  (rf.story.lifecycle/destroy-variant! variant-id))
 
 (defn variant-frames
   "Return every registered variant frame id. The UI shell uses this
   to lay out the active variant pane."
   []
-  (lifecycle/variant-frames))
+  (rf.story.lifecycle/variant-frames))
 
 (defn variant-frame?
   "True iff `frame-id` is a variant frame."
   [frame-id]
-  (lifecycle/variant-frame? frame-id))
+  (rf.story.lifecycle/variant-frame? frame-id))
 
 (defn lifecycle-state
   "Return the lifecycle's current discrete state for the variant's
   frame (`:pre-mount`, `:mounting`, `:loading`, `:ready`, `:error`).
   Returns `:pre-mount` if the variant hasn't been run yet."
   [variant-id]
-  (lifecycle/lifecycle-state variant-id))
+  (rf.story.lifecycle/lifecycle-state variant-id))
 
 ;; ---- public assertion + play helpers ------------------------------------
 
@@ -1398,7 +1398,7 @@
   vacuous-green fold: true iff every record has `:passed? true` (an empty
   vector passes). See `re-frame.story.assertions/passing?`."
   [assertions-or-result]
-  (assertions/passing? assertions-or-result))
+  (rf.story.assertions/passing? assertions-or-result))
 
 (defn read-assertions
   "Per `004-Assertions.md` §Record-don't-throw semantics — return the assertions vector accumulated against
@@ -1406,14 +1406,14 @@
   but doesn't re-run the variant. Useful for live introspection from the
   UI shell or REPL."
   [variant-id]
-  (assertions/read-assertions variant-id))
+  (rf.story.assertions/read-assertions variant-id))
 
 (defn canonical-assertion-ids
   "Per /spec/007-Stories.md §Inclusion tags + `004-Assertions.md`
   §Canonical assertion vocabulary — return the set of seven
   canonical `:rf.assert/*` event ids registered at boot."
   []
-  assertions/canonical-assertion-ids)
+  rf.story.assertions/canonical-assertion-ids)
 
 (defn known-assertion-ids
   "Per spec/017 §Assertions — return the FULL set of assertion ids the
@@ -1429,7 +1429,7 @@
   subset. Exposed for tooling (story-mcp `list-assertions`) that
   enumerates the recognised vocabulary."
   []
-  assertions/known-assertion-ids)
+  rf.story.assertions/known-assertion-ids)
 
 ;; ---- unified run-result + the three verbs -------------------------------
 ;;
@@ -1455,7 +1455,7 @@
   fails the run, and any unconsumed violation fails the run via the
   agreement floor — there is NO `:rf.assert/no-schema-errors` knob."
   [parts]
-  (result/run-result parts))
+  (rf.story.result/run-result parts))
 
 (defn match-schema-expectations
   "Per spec/017 §Schema rule — EXACT multiset match of declared
@@ -1466,7 +1466,7 @@
   Exposed for tooling / MCP that wants to inspect the consumption pairing
   directly."
   [schema-expectations epoch-tape]
-  (result/match-schema-expectations schema-expectations epoch-tape))
+  (rf.story.result/match-schema-expectations schema-expectations epoch-tape))
 
 (defn result-status
   "Per spec/017 §Run result — the unified verdict of a run-result:
@@ -1478,7 +1478,7 @@
   "Per spec/017 §Run result — true iff the run-result's `:status` is
   `:pass`. A `:cannot-run` is NOT a pass (the runner proved nothing)."
   [result]
-  (result/passed? result))
+  (rf.story.result/passed? result))
 
 (defn assertion-record
   "Per spec/017 §Run result — Assertion record — normalize ONE raw
@@ -1489,7 +1489,7 @@
   `preview-variant` / `read-failures`) that mints a synthetic record for a
   path the run never produced (e.g. a pre-settlement `:error`)."
   [raw]
-  (result/assertion-record raw))
+  (rf.story.result/assertion-record raw))
 
 (defn assertion-records
   "Per spec/017 §Run result — normalize a raw assertion accumulator vector
@@ -1499,7 +1499,7 @@
   stamps the unified `:status` onto records read from the
   `:rf.story/assertions` accumulator without re-running the variant."
   [raw-assertions]
-  (result/assertion-records raw-assertions))
+  (rf.story.result/assertion-records raw-assertions))
 
 (defn aggregate-verdict
   "Per spec/017 §`:cannot-run` — the variant-level verdict over a vector of
@@ -1511,7 +1511,7 @@
   than re-implementing the precedence. `unmet` may be `nil` when no
   capability refusals apply."
   [records unmet]
-  (requirements/aggregate-status records unmet))
+  (rf.story.requirements/aggregate-status records unmet))
 
 ;; ---- the frozen, schema-backed run-result contract ----------------------
 ;;
@@ -1528,20 +1528,20 @@
   unified run-result. The ONE schema-backed contract Story UI, CI,
   `clojure.test`, and story-mcp validate against (see
   `re-frame.story.result/RunResult`)."
-  result/RunResult)
+  rf.story.result/RunResult)
 
 (defn valid-run-result?
   "Per spec/017 §Run result — true iff `result` conforms to
   the frozen `run-result-schema`. Pure data → data."
   [result]
-  (result/valid-run-result? result))
+  (rf.story.result/valid-run-result? result))
 
 (defn explain-run-result
   "Per spec/017 §Run result — Malli explanation of why
   `result` does NOT conform to the frozen `run-result-schema`, or nil when
   it conforms. Pure data → data."
   [result]
-  (result/explain-run-result result))
+  (rf.story.result/explain-run-result result))
 
 (defn result->reports
   "Per spec/017 §Public execution API — project a unified `result` into the
@@ -1552,7 +1552,7 @@
   projection `story/is` emits, exposed for tooling that wants the reports
   without firing `do-report`."
   [result]
-  (result/result->reports result))
+  (rf.story.result/result->reports result))
 
 (defn run
   "Per spec/017 §Public execution API — the `run` verb. Run `target` and
@@ -1578,8 +1578,8 @@
   ([target]      (run target nil))
   ([target opts]
    (if (map? target)
-     (lifecycle/run-inline-plan target opts)
-     (lifecycle/run-variant target opts))))
+     (rf.story.lifecycle/run-inline-plan target opts)
+     (rf.story.lifecycle/run-variant target opts))))
 
 ;; ---- variant-plan / explain / render-variant ----------------------------
 ;;
@@ -1597,8 +1597,8 @@
   / `:sub-lookup` / `:fragment-lookup` / `:check-lookup`); production reads
   the registrars. Pure data → data — the same plan the runner and
   `render-variant` consume."
-  ([target]      (plan/variant-plan target))
-  ([target opts] (plan/variant-plan target opts)))
+  ([target]      (rf.story.plan/variant-plan target))
+  ([target opts] (rf.story.plan/variant-plan target opts)))
 
 (defn explain
   "Per spec/017 §Explain API — the `:explain` map for `target` (source +
@@ -1607,8 +1607,8 @@
   validation, final setup/script order, checks/assertions, runner
   requirements, platforms, tags). Convenience over
   `(:explain (variant-plan target opts))`."
-  ([target]      (plan/explain target))
-  ([target opts] (plan/explain target opts)))
+  ([target]      (rf.story.plan/explain target))
+  ([target opts] (rf.story.plan/explain target opts)))
 
 (defn render-variant
   "Per spec/017 §Args, controls, and `render-variant` — render `target`'s
@@ -1636,8 +1636,8 @@
   drives an invalid view input STOPS render before the view is called
   (`:invalid-args`); on the bare JVM (no host renderer) the verb returns
   `:cannot-run` rather than a silent empty render."
-  ([target]      (render/render-variant target))
-  ([target opts] (render/render-variant target opts)))
+  ([target]      (rf.story.render/render-variant target))
+  ([target opts] (rf.story.render/render-variant target opts)))
 
 (defn- emit-reports!
   "Fire `clojure.test` / `cljs.test` `do-report` for each report map in
@@ -1691,7 +1691,7 @@
    (cond
      ;; Already a unified result — report it synchronously.
      (and (map? target) (contains? target :status) (contains? target :assertions))
-     (do (emit-reports! (:variant/id target) (result/result->reports target))
+     (do (emit-reports! (:variant/id target) (rf.story.result/result->reports target))
          target)
 
      :else
@@ -1709,16 +1709,16 @@
        ;; for the same parameter, should a future change make the arg load-
        ;; bearing (e.g. stamping the variant id onto each report's message).
        #?(:clj
-          (let [result (async/deref-blocking p (get opts :timeout-ms 30000))]
-            (emit-reports! (:variant/id result) (result/result->reports result))
+          (let [result (rf.story.async/deref-blocking p (get opts :timeout-ms 30000))]
+            (emit-reports! (:variant/id result) (rf.story.result/result->reports result))
             result)
           :cljs
           ;; CLJS run is async; report when it resolves and hand the
           ;; promise back so a `(cljs.test/async done …)` test can await it.
           ;; `:timeout-ms` is inert here — the caller's own async deadline
           ;; governs (the JVM is the only path that blocks).
-          (async/then p (fn [result]
-                          (emit-reports! (:variant/id result) (result/result->reports result))
+          (rf.story.async/then p (fn [result]
+                          (emit-reports! (:variant/id result) (rf.story.result/result->reports result))
                           result)))))))
 
 (defn report-result!
@@ -1728,7 +1728,7 @@
   `(cljs.test/async done …)` test once the `story/run` promise resolves.
   Returns the result."
   [result]
-  (emit-reports! (:variant/id result) (result/result->reports result))
+  (emit-reports! (:variant/id result) (rf.story.result/result->reports result))
   result)
 
 (defn execute-play!
@@ -1742,11 +1742,11 @@
   Returns a `js/Promise` (CLJS) / `CompletableFuture` (JVM) of the
   assertions vector — the same shape `(:assertions result)` gives."
   ([variant-id]
-   (play/execute-play! variant-id))
+   (rf.story.play/execute-play! variant-id))
   ([variant-id play-events]
-   (play/execute-play! variant-id play-events))
+   (rf.story.play/execute-play! variant-id play-events))
   ([variant-id play-events opts]
-   (play/execute-play! variant-id play-events opts)))
+   (rf.story.play/execute-play! variant-id play-events opts)))
 
 (def force-fx-stub-id
   "Per /spec/007-Stories.md §Effect mocking + `004-Assertions.md`
@@ -1758,7 +1758,7 @@
         {:decorators [[story/force-fx-stub-id :http {:status :pending}]]
          :script     {:script [[:dispatch [:auth/login]]
                                [:dispatch [:rf.assert/effect-emitted :http]]]}})"
-  fx-stubs/force-fx-stub-id)
+  rf.story.fx-stubs/force-fx-stub-id)
 
 ;; ---- public SOTA-feature surface ----------------------------------------
 
@@ -1769,12 +1769,12 @@
 
       (story/reg-variant :story.button/pressed
         {:decorators [[story/layout-debug-measure-id]]})"
-  layout-debug/id-measure)
+  rf.story.layout-debug/id-measure)
 
 (def layout-debug-outline-id
   "Per `005-SOTA-Features.md` §Layout-debug overlay trio — Pesticide-style coloured outlines on every
   descendant element."
-  layout-debug/id-outline)
+  rf.story.layout-debug/id-outline)
 
 (def layout-debug-pseudo-id
   "Per `005-SOTA-Features.md` §Layout-debug overlay trio — pseudo-state forcing. Ref-args is a set
@@ -1782,7 +1782,7 @@
 
       (story/reg-variant :story.link/hovered
         {:decorators [[story/layout-debug-pseudo-id #{:hover}]]})"
-  layout-debug/id-pseudo)
+  rf.story.layout-debug/id-pseudo)
 
 (defn variant-share-url
   "Per `005-SOTA-Features.md` §Share URL — build a sharable URL for a variant against
@@ -1795,8 +1795,8 @@
     :active-modes    coll of registered mode ids
     :cell-overrides  {arg-key → value}
     :substrate       active substrate"
-  ([variant-id]                (share/variant-share-url variant-id))
-  ([variant-id base-url opts]  (share/variant-share-url variant-id base-url opts)))
+  ([variant-id]                (rf.story.share/variant-share-url variant-id))
+  ([variant-id base-url opts]  (rf.story.share/variant-share-url variant-id base-url opts)))
 
 #?(:cljs
    (defn register-substrate!
@@ -1811,7 +1811,7 @@
      `render-fn` takes `(variant-id view-id args)` and returns a hiccup
      vector (Reagent) or a React element (UIx)."
      [substrate-id render-fn]
-     (ui-multi-substrate/register-substrate! substrate-id render-fn)))
+     (rf.story.ui.multi-substrate/register-substrate! substrate-id render-fn)))
 
 #?(:cljs
    (defn registered-substrates
@@ -1819,7 +1819,7 @@
      Used by tooling that enumerates the available substrates for a
      variant's `:substrates` opt-in."
      []
-     (ui-multi-substrate/registered-substrates)))
+     (rf.story.ui.multi-substrate/registered-substrates)))
 
 ;; ---- public helpers (decorator / args resolution surfacing) -------------
 
@@ -1827,15 +1827,15 @@
   "Per `002-Runtime.md` §Args resolution precedence — materialise the effective args map for a
   variant render given the active modes + cell overrides. See
   `re-frame.story.args/resolve-args`."
-  ([variant-id]       (args/resolve-args variant-id))
-  ([variant-id opts]  (args/resolve-args variant-id opts)))
+  ([variant-id]       (rf.story.args/resolve-args variant-id))
+  ([variant-id opts]  (rf.story.args/resolve-args variant-id opts)))
 
 (defn resolve-decorators
   "Per `002-Runtime.md` §Decorator composition order — return the variant's resolved decorator stack
   classified by kind (`{:hiccup [...] :frame-setup [...] :fx-override [...]
   :errors [...]}`). See `re-frame.story.decorators/resolve-decorators`."
-  ([variant-id]       (decorators/resolve-decorators variant-id))
-  ([variant-id opts]  (decorators/resolve-decorators variant-id opts)))
+  ([variant-id]       (rf.story.decorators/resolve-decorators variant-id))
+  ([variant-id opts]  (rf.story.decorators/resolve-decorators variant-id opts)))
 
 ;; ---- static-mode? probe -------------------------------------------------
 
@@ -1851,7 +1851,7 @@
   a public probe for tooling / examples that want to render a
   'this is a published static site' badge or hide a dev-only link."
   []
-  config/static-mode?)
+  rf.story.config/static-mode?)
 
 ;; ---- UI shell mount / unmount surface -----------------------------------
 ;;
@@ -1882,21 +1882,21 @@
      short-circuit before any DOM call and return nil. See
      `001-Authoring.md` §Registration macros for the elision contract."
      [dom-node]
-     (ui-shell/mount-shell! dom-node)))
+     (rf.story.ui.shell/mount-shell! dom-node)))
 
 #?(:cljs
    (defn unmount-shell!
      "Tear down a mounted shell. Accepts the handle from `mount-shell!`
      or no arg (defaults to the active shell singleton)."
-     ([]       (ui-shell/unmount-shell!))
-     ([handle] (ui-shell/unmount-shell! handle))))
+     ([]       (rf.story.ui.shell/unmount-shell!))
+     ([handle] (rf.story.ui.shell/unmount-shell! handle))))
 
 #?(:cljs
    (defn active-shell
      "Return the currently-mounted shell handle, or nil. v1 singleton;
      v2 may return a collection when multi-shell mounts ship."
      []
-     (ui-shell/active-shell)))
+     (rf.story.ui.shell/active-shell)))
 
 ;; ---- Test Codegen recorder public surface -------------------------------
 ;;
@@ -1914,7 +1914,7 @@
   vector is `[:events ...]` on the returned state map; pass it to
   `gen-play-snippet` to render the `(reg-variant ...)` form."
   [variant-id]
-  (recorder/start-recording! variant-id))
+  (rf.story.recorder/start-recording! variant-id))
 
 (defn stop-recording!
   "Stop the in-flight recording. Returns the recorder state map with
@@ -1925,23 +1925,23 @@
   frame-scoped (`{:frame variant-id}`) and lands in the frame's own running
   environment by construction — the state carries no separate realm key."
   []
-  (recorder/stop-recording!))
+  (rf.story.recorder/stop-recording!))
 
 (defn recording?
   "Boolean predicate — is a recording in flight?"
   []
-  (recorder/recording?))
+  (rf.story.recorder/recording?))
 
 (defn recorder-state
   "Return the current recorder state map. Read-only view; transitions
   go through `start-recording!` / `stop-recording!` / `clear-recording!`."
   []
-  (recorder/current-state))
+  (rf.story.recorder/current-state))
 
 (defn clear-recording!
   "Drop any captured events + return the recorder to idle."
   []
-  (recorder/clear!))
+  (rf.story.recorder/clear!))
 
 (defn gen-play-snippet
   "Render an EDN snippet `(reg-variant <id> {... :script {...}})` for
@@ -1961,7 +1961,7 @@
   Empty `events` still produces a valid form (with an empty `:script []`)
   so the user sees the shape to fill in."
   [events opts]
-  (recorder/gen-play-snippet events opts))
+  (rf.story.recorder/gen-play-snippet events opts))
 
 (defn recording->script-body
   "Translate a recording into the live, replayable `:script` body map per
@@ -1982,5 +1982,5 @@
   recording->script-body` for the full contract.
 
   Returns `{:script [...steps] :auto-run? bool :name str?}`."
-  ([events]      (play-export/recording->script-body events))
-  ([events opts] (play-export/recording->script-body events opts)))
+  ([events]      (rf.story.recorder.play-export/recording->script-body events))
+  ([events opts] (rf.story.recorder.play-export/recording->script-body events opts)))

--- a/tools/story/src/re_frame/story/args.cljc
+++ b/tools/story/src/re_frame/story/args.cljc
@@ -28,9 +28,9 @@
   invoke `resolve-args` only inside the `(when enabled? ...)`-gated
   runtime entry points; the call site disappears in production along
   with the rest of the runtime."
-  (:require [re-frame.story.config     :as config]
-            [re-frame.story.predicates :as pred]
-            [re-frame.story.registrar  :as registrar]))
+  (:require [re-frame.story.config     :as rf.story.config]
+            [re-frame.story.predicates :as rf.story.predicates]
+            [re-frame.story.registrar  :as rf.story.registrar]))
 
 ;; ---- deep-merge -----------------------------------------------------------
 
@@ -69,7 +69,7 @@
 ;; (decorators, identity, runtime, canvas, controls, multi-substrate,
 ;; panels, schema-validation, workspace) `:require` args already and call
 ;; it through this alias. The alias is a thin pass-through to
-;; `pred/parent-story-id`.
+;; `rf.story.predicates/parent-story-id`.
 
 (def parent-story-id
   "Derive the parent story id from a variant id. Per /spec/007-Stories.md
@@ -78,7 +78,7 @@
   id is the keyword named `:story.foo.bar`.
 
   Returns nil if `variant-id` does not match the variant-id grammar."
-  pred/parent-story-id)
+  rf.story.predicates/parent-story-id)
 
 ;; ---- mode-set materialisation --------------------------------------------
 
@@ -88,7 +88,7 @@
   runner can ignore a stale mode id; tools surface the mismatch as a
   validation warning."
   [mode-id]
-  (or (:args (registrar/handler-meta :mode mode-id)) {}))
+  (or (:args (rf.story.registrar/handler-meta :mode mode-id)) {}))
 
 (defn- active-modes-args
   "Compose every active mode's `:args` map by deep-merging in declared
@@ -124,10 +124,10 @@
   ([variant-id]
    (resolve-args variant-id nil))
   ([variant-id {:keys [active-modes cell-overrides] :as _opts}]
-   (let [variant-body (registrar/handler-meta :variant variant-id)
+   (let [variant-body (rf.story.registrar/handler-meta :variant variant-id)
          story-id     (parent-story-id variant-id)
-         story-body   (when story-id (registrar/handler-meta :story story-id))
-         global       (config/get-global-args)
+         story-body   (when story-id (rf.story.registrar/handler-meta :story story-id))
+         global       (rf.story.config/get-global-args)
          story-args   (:args story-body)
          mode-args    (active-modes-args (or active-modes []))
          variant-args (:args variant-body)
@@ -177,8 +177,8 @@
   ([variant-id] (run-arg-layers variant-id nil))
   ([variant-id {:keys [active-modes cell-overrides] :as _opts}]
    (let [story-id   (parent-story-id variant-id)
-         story-body (when story-id (registrar/handler-meta :story story-id))]
-     {:pre  [(config/get-global-args)
+         story-body (when story-id (rf.story.registrar/handler-meta :story story-id))]
+     {:pre  [(rf.story.config/get-global-args)
              (:args story-body)
              (active-modes-args (or active-modes []))]
       :post [(or cell-overrides {})]})))

--- a/tools/story/src/re_frame/story/artifact.cljc
+++ b/tools/story/src/re_frame/story/artifact.cljc
@@ -79,10 +79,10 @@
   runners (DOM/browser) supply their own flush-hooks; this ns defaults to
   the headless hooks and never reaches for `dispatch-sync` directly."
   (:require [re-frame.core                        :as rf]
-            [re-frame.story.play.evidence         :as evidence]
-            [re-frame.story.play.runner           :as runner]
-            [re-frame.story.play.runner-events    :as runner-events]
-            [re-frame.story.play.settled-boundary :as boundary]
+            [re-frame.story.play.evidence         :as rf.story.play.evidence]
+            [re-frame.story.play.runner           :as rf.story.play.runner]
+            [re-frame.story.play.runner-events    :as rf.story.play.runner-events]
+            [re-frame.story.play.settled-boundary :as rf.story.play.settled-boundary]
             ;; The raw HTTP stub pair lives in `re-frame.http.test-support`
             ;; (reached through its home namespace, not the `re-frame.core`
             ;; façade). CLJS requires it directly; on the JVM it is resolved
@@ -91,7 +91,7 @@
             ;; `re-frame.story` MACRO-ns does NOT drag the http artefact's
             ;; JVM-only transitive deps (e.g. cheshire) onto the macro
             ;; classpath. CLJS pulls only the CLJS-clean `.cljc` surface.
-            #?(:cljs [re-frame.http.test-support :as http-test-support])))
+            #?(:cljs [re-frame.http.test-support :as rf.http.test-support])))
 
 ;; ===========================================================================
 ;; THE :rf.test/run-artifact SCHEMA
@@ -157,7 +157,7 @@
                   :else [])]
     (-> (select-keys parts artifact-keys)
         (assoc :artifact/kind artifact-kind
-               :event-program (runner/coerce-script program))
+               :event-program (rf.story.play.runner/coerce-script program))
         (update :fx-decisions #(or % {})))))
 
 (defn program-events
@@ -167,7 +167,7 @@
   event. Useful for promotion (spec/017 §Promotion) + diagnostics."
   [artifact]
   (into []
-        (keep runner/step-event)
+        (keep rf.story.play.runner/step-event)
         (:event-program artifact)))
 
 ;; ===========================================================================
@@ -221,7 +221,7 @@
   (possibly richer-adapter) inner hook owns. A 2-arity replay (no opts)
   stays byte-identical to the opts-free dispatch path."
   [base-hooks fx-decisions]
-  (let [inner (or (:dispatch! base-hooks) boundary/drain-sync!)
+  (let [inner (or (:dispatch! base-hooks) rf.story.play.settled-boundary/drain-sync!)
         ;; Route the dispatch through `inner`, optionally with opts, always
         ;; under the `fx-decisions` lexical wrap. The fx decisions and the
         ;; EP-0017 dispatch opts are independent seams (lexical overrides vs
@@ -264,9 +264,9 @@
       ;; story MACRO-ns never hard-loads the http artefact's JVM deps; CLJS
       ;; calls the directly-required surface.
       (let [install   #?(:clj  (requiring-resolve 're-frame.http.test-support/install-managed-request-stubs!)
-                         :cljs http-test-support/install-managed-request-stubs!)
+                         :cljs rf.http.test-support/install-managed-request-stubs!)
             uninstall #?(:clj  (requiring-resolve 're-frame.http.test-support/uninstall-managed-request-stubs!)
-                         :cljs http-test-support/uninstall-managed-request-stubs!)]
+                         :cljs rf.http.test-support/uninstall-managed-request-stubs!)]
         (try
           (install network)
           (thunk)
@@ -289,7 +289,7 @@
   the boundary's `dispatch-opts`, which the replay `:dispatch!` wrap threads
   onto the dispatch envelope. Pure data → data."
   [step]
-  (let [cofx (runner/step-cofx step)]
+  (let [cofx (rf.story.play.runner/step-cofx step)]
     (cond-> {:rf.cofx/mint-policy :strict}
       (and (map? cofx) (seq cofx)) (assoc :rf.cofx cofx))))
 
@@ -301,12 +301,12 @@
   on success, a `cannot-run-refusal` / `{:status :error …}` otherwise.
 
   The returned vector carries an `:attribution` metadata slot: the
-  last-committed `:epoch-id` (`runner-events/last-epoch-id` — a genuine
+  last-committed `:epoch-id` (`rf.story.play.runner-events/last-epoch-id` — a genuine
   monotonic identity, NOT a ring-length snapshot; rf2-96qsjr) at the start
   of each dispatch step's settle, in dispatch-step order. `replay-result`
   reads it (via `(:attribution (meta outcomes))`) and hands it to
   `project-evidence` so the replay narrative is attributed EXACTLY
-  (`evidence/spans-from-stamps`) rather than via the EVEN heuristic. The
+  (`rf.story.play.evidence/spans-from-stamps`) rather than via the EVEN heuristic. The
   metadata leaves the documented return VALUE (the outcomes vector)
   unchanged. The boundaries are positional with respect to DISPATCH-STEP
   ORDER — the Nth element is the Nth dispatch step's settle boundary — so
@@ -322,15 +322,15 @@
   story. `hooks` defaults to the headless flush-hooks; the fx decisions are
   wrapped onto its `:dispatch!`."
   ([frame-id artifact]
-   (replay-into-frame! frame-id artifact boundary/headless-flush-hooks))
+   (replay-into-frame! frame-id artifact rf.story.play.settled-boundary/headless-flush-hooks))
   ([frame-id artifact hooks]
    (let [fx-decisions (:fx-decisions artifact {})
          replay-hooks (replay-flush-hooks hooks fx-decisions)
          boundaries   (volatile! [])
          outcomes     (into []
                             (keep (fn [step]
-                                    (when-let [evec (runner/step-event step)]
-                                      (let [required (boundary/step-required-boundary step)
+                                    (when-let [evec (rf.story.play.runner/step-event step)]
+                                      (let [required (rf.story.play.settled-boundary/step-required-boundary step)
                                             dispatch-opts (step-dispatch-opts step)]
                                         ;; Snapshot the last-committed
                                         ;; `:epoch-id` BEFORE the settle — this
@@ -339,8 +339,8 @@
                                         ;; an identity, not a ring-length
                                         ;; snapshot, so it stays correct
                                         ;; whatever the ring evicts).
-                                        (vswap! boundaries conj (runner-events/last-epoch-id frame-id))
-                                        (boundary/dispatch-and-settle!
+                                        (vswap! boundaries conj (rf.story.play.runner-events/last-epoch-id frame-id))
+                                        (rf.story.play.settled-boundary/dispatch-and-settle!
                                           frame-id evec replay-hooks required step
                                           dispatch-opts)))))
                             (:event-program artifact))]
@@ -367,7 +367,7 @@
   the settle outcomes — never a sibling accumulator — so a replay cannot
   read green while the tape is red."
   [{:keys [epoch-tape artifact outcomes frame-id app-db]}]
-  (let [evidence-slots (evidence/project-evidence
+  (let [evidence-slots (rf.story.play.evidence/project-evidence
                          epoch-tape {:script      (:event-program artifact)
                                      ;; The per-dispatch-step settle
                                      ;; boundaries `replay-into-frame!`
@@ -379,7 +379,7 @@
                                      :attribution (:attribution (meta outcomes))})
         refusal        (some (fn [o] (when (= :cannot-run (:status o)) o)) outcomes)
         errored        (some (fn [o] (when (= :error (:status o)) o)) outcomes)
-        tape-red?      (evidence/tape-shows-failure? epoch-tape)
+        tape-red?      (rf.story.play.evidence/tape-shows-failure? epoch-tape)
         status         (cond
                          refusal   :cannot-run
                          errored   :error
@@ -432,7 +432,7 @@
   ([artifact {:keys [frame hooks frame-config] :as _opts}]
    (let [own-frame? (nil? frame)
          frame-id   (or frame (gen-replay-frame-id))
-         hooks      (or hooks boundary/headless-flush-hooks)
+         hooks      (or hooks rf.story.play.settled-boundary/headless-flush-hooks)
          ;; When we allocate the replay frame, KEEP the frame VALUE `make-frame`
          ;; returns: it carries the EXACT incarnation token (rf2-moftbs), so the
          ;; `finally` teardown destroys ONLY the incarnation THIS replay created.

--- a/tools/story/src/re_frame/story/assertions.cljc
+++ b/tools/story/src/re_frame/story/assertions.cljc
@@ -71,15 +71,15 @@
     dispatched into the frame). So the set is eight ids, only seven of
     which are registered."
   (:require [re-frame.core                :as rf]
-            [re-frame.elision             :as elision]
-            [re-frame.interop             :as interop]
-            [re-frame.subs                :as subs]
-            [re-frame.story.config        :as config]
-            [re-frame.story.late-bind     :as late-bind]
-            [re-frame.story.play.evidence :as evidence]
-            [re-frame.story.predicates    :as pred]
-            [re-frame.story.registrar     :as registrar]
-            [re-frame.story.requirements  :as requirements]
+            [re-frame.elision             :as rf.elision]
+            [re-frame.interop             :as rf.interop]
+            [re-frame.subs                :as rf.subs]
+            [re-frame.story.config        :as rf.story.config]
+            [re-frame.story.late-bind     :as rf.story.late-bind]
+            [re-frame.story.play.evidence :as rf.story.play.evidence]
+            [re-frame.story.predicates    :as rf.story.predicates]
+            [re-frame.story.registrar     :as rf.story.registrar]
+            [re-frame.story.requirements  :as rf.story.requirements]
             [malli.core                   :as malli]))
 
 ;; ---------------------------------------------------------------------------
@@ -144,7 +144,7 @@
   Assertion events (`:rf.assert/*`) are excluded — an `[:assert …]`
   checkpoint dispatches its wrapped atom, which commits an epoch, but a
   verdict is not behaviour-under-test (the same `assertion-event?` skip
-  `evidence/narrative`'s span-attribution rule applies).
+  `rf.story.play.evidence/narrative`'s span-attribution rule applies).
 
   Privacy (Spec 009 §Privacy + EP-0015 issue 7): the
   `:trigger-event` of an epoch flagged `:rf.epoch/sensitive?` is dropped
@@ -155,12 +155,12 @@
   trusted-local `:rf.egress/local-raw` boundary do its sensitive
   trigger-events pass through — revealing a sibling frame does not."
   [frame-id]
-  (let [show? (config/include-sensitive? frame-id)]
+  (let [show? (rf.story.config/include-sensitive? frame-id)]
     (into []
           (comp (remove (fn [{:keys [rf.epoch/sensitive?]}]
                           (and sensitive? (not show?))))
                 (keep :trigger-event)
-                (remove pred/assertion-event?))
+                (remove rf.story.predicates/assertion-event?))
           (frame-tape frame-id))))
 
 (defn- non-framework-fx?
@@ -173,7 +173,7 @@
   "Project the set of USER fx-ids emitted against `frame-id`. The SSOT for
   `:rf.assert/effect-emitted`. Two sources, both tape-grounded:
 
-  1. The epoch tape's `:effects` rows (`evidence/effects`) — every fx the
+  1. The epoch tape's `:effects` rows (`rf.story.play.evidence/effects`) — every fx the
      cascade actually HANDLED (the run-result `:effects` slot reads the
      same projection), excluding the framework `:db` / `:fx` aggregators.
   2. The per-frame stub-call log (`re-frame.story.frames/stub-call-log`,
@@ -192,8 +192,8 @@
   [frame-id]
   (let [from-tape (into #{}
                         (comp (keep :fx-id) (filter non-framework-fx?))
-                        (evidence/effects (frame-tape frame-id)))
-        from-stub (if-let [f (late-bind/get-fn :stub-observed-fx-ids)]
+                        (rf.story.play.evidence/effects (frame-tape frame-id)))
+        from-stub (if-let [f (rf.story.late-bind/get-fn :stub-observed-fx-ids)]
                     (try (set (f frame-id))
                          (catch #?(:clj Throwable :cljs :default) _ #{}))
                     #{})]
@@ -201,11 +201,11 @@
 
 (defn warnings
   "Project the warning trace records emitted against `frame-id` from its
-  epoch tape (`evidence/warnings`) — the SAME projection the run-result
+  epoch tape (`rf.story.play.evidence/warnings`) — the SAME projection the run-result
   `:warnings` slot reads, so `:rf.assert/no-warnings` and the slot AGREE.
   Pure-ish (the only read is the late-bound tape)."
   [frame-id]
-  (evidence/warnings (frame-tape frame-id)))
+  (rf.story.play.evidence/warnings (frame-tape frame-id)))
 
 ;; ---------------------------------------------------------------------------
 ;; Where the trace-bus facts live (no parallel accumulator)
@@ -216,7 +216,7 @@
 ;; related concerns each live with the surface that owns them:
 ;;
 ;;   - PRIVACY suppression (default-drop `:sensitive? true` + the
-;;     `config/note-suppressed!` redaction-counter bump) is the egress seam
+;;     `rf.story.config/note-suppressed!` redaction-counter bump) is the egress seam
 ;;     in `re-frame.story.play`'s per-frame trace listener — the gate at the
 ;;     head of that listener;
 ;;   - the synchronous handler-exception capture is `re-frame.story.play`'s
@@ -244,7 +244,7 @@
 
   Returns the record."
   [frame-id record]
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (try
       (rf/dispatch-sync [::append record] {:frame frame-id})
       (catch #?(:clj Throwable :cljs :default) _ nil)))
@@ -316,7 +316,7 @@
   surfaces. Returns nil when the frame is not a registered variant
   (e.g. an ad-hoc frame) or the body has no source coord."
   [frame-id]
-  (:source (registrar/handler-meta :variant frame-id)))
+  (:source (rf.story.registrar/handler-meta :variant frame-id)))
 
 (defn- assertion-record
   "Construct the assertion record per `004-Assertions.md` §Canonical assertion vocabulary. `extras` is the
@@ -404,14 +404,14 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- redact-at
-  "Project `v` through `elision/elide-wire-value` as if it lives at
+  "Project `v` through `rf.elision/elide-wire-value` as if it lives at
   `path` in `frame-id`'s app-db, so sensitive sub-paths (or a sensitive
   root path) substitute `:rf/redacted`. Tolerant — any elision error or
   a nil frame-id returns `v` unchanged (record-don't-throw: redaction
   failure must never break the assertion)."
   [frame-id path v]
   (try
-    (elision/elide-wire-value v (cond-> {:path (vec path)}
+    (rf.elision/elide-wire-value v (cond-> {:path (vec path)}
                                   frame-id (assoc :frame frame-id)))
     (catch #?(:clj Throwable :cljs :default) _ v)))
 
@@ -480,7 +480,7 @@
   letting Malli throw an opaque sci error)."
   [schema]
   (if (and (vector? schema) (= :fn (first schema)) (symbol? (second schema)))
-    (if-let [f (pred/resolve-sym-pred (second schema))]
+    (if-let [f (rf.story.predicates/resolve-sym-pred (second schema))]
       [:fn f]
       ::unresolved-pred)
     schema))
@@ -552,7 +552,7 @@
   ;; the value passes through unchanged.
   (let [sub-path     (vec (rest sub-vec))
         raw          (try
-                       (subs/compute-sub sub-vec frame-state)
+                       (rf.subs/compute-sub sub-vec frame-state)
                        (catch #?(:clj Throwable :cljs :default) _
                          ::compute-error))
         threw?       (= raw ::compute-error)
@@ -619,7 +619,7 @@
 
 (defn- evaluate-no-warnings
   "`warning-records` is the tape-projected warning vector (`warnings`,
-  i.e. `evidence/warnings` over the frame's epoch tape — the SAME
+  i.e. `rf.story.play.evidence/warnings` over the frame's epoch tape — the SAME
   projection the run-result `:warnings` slot reads). Pure data → data."
   [warning-records _payload]
   (let [passed? (empty? warning-records)]
@@ -677,7 +677,7 @@
 ;; assertion record are minted in the result boundary (`result.cljc`), not
 ;; here. There is deliberately NO `:rf.assert/no-schema-errors` — a
 ;; schema-clean run is the knob-free runner FLOOR (the agreement floor in
-;; `evidence/tape-shows-failure?`), refined by these expectations rather
+;; `rf.story.play.evidence/tape-shows-failure?`), refined by these expectations rather
 ;; than an opt-in.
 ;; ---------------------------------------------------------------------------
 
@@ -778,7 +778,7 @@
   ONE id source of truth rather than a hand-maintained parallel set."
   (into (into (into canonical-assertion-ids dom-assertion-ids)
               browser-assertion-ids)
-        (keys requirements/assertion-capabilities)))
+        (keys rf.story.requirements/assertion-capabilities)))
 
 (defn assertion-id-known?
   "True iff `id` is a recognised P1 assertion id (`known-assertion-ids`).
@@ -883,9 +883,9 @@
 ;; The declared atom is `[:rf.assert/schema-error {:where <surface> …}]`.
 ;; The spec map's `:where` chooses the surface; the surface-specific keys
 ;; key the EXPECTATION's selector, which the result boundary pairs against
-;; a projected violation's `:selector` (`evidence/violation-selector`) by an
+;; a projected violation's `:selector` (`rf.story.play.evidence/violation-selector`) by an
 ;; exact multiset match. The two selector builders MUST agree key-for-key —
-;; `evidence/violation-selector` keys a PROJECTED VIOLATION (read from the
+;; `rf.story.play.evidence/violation-selector` keys a PROJECTED VIOLATION (read from the
 ;; trace `:tags`), this keys a DECLARED EXPECTATION (read from the author's
 ;; spec map) — so the same surface produces the same vector on both sides:
 ;;
@@ -899,7 +899,7 @@
 ;;
 ;; A `:where` the matcher does not special-case keys by `[:where failing]`
 ;; where `failing` is the surface-named id slot (mirroring
-;; `evidence/violation-selector`'s open-surface fallback), so a novel
+;; `rf.story.play.evidence/violation-selector`'s open-surface fallback), so a novel
 ;; surface still pairs by a stable, distinct selector.
 
 (defn schema-error?
@@ -919,7 +919,7 @@
 
 (defn schema-error-selector
   "The surface SELECTOR a declared `:rf.assert/schema-error` expectation
-  pairs on — mirroring `evidence/violation-selector` so a declared
+  pairs on — mirroring `rf.story.play.evidence/violation-selector` so a declared
   expectation and a projected violation produce the SAME vector for the same
   surface (spec/017 §Schema rule). Pure data → data.
 
@@ -1106,7 +1106,7 @@
   settled — and assertion events are excluded from the projection anyway."
   [assertion-id evaluator-kind]
   (fn [{:keys [db] rt :rf.db/runtime :as cofx} event-vec]
-    (let [start-ms     (interop/now-ms)
+    (let [start-ms     (rf.interop/now-ms)
           payload      (vec (rest event-vec))
           frame-id     (frame-id-from-cofx cofx)
           dispatch-id  (dispatch-id-from-cofx cofx)
@@ -1125,7 +1125,7 @@
                          :state-is        (evaluate-state-is        (or rt {}) payload)
                          :no-warnings     (evaluate-no-warnings     (warnings frame-id) payload)
                          :effect-emitted  (evaluate-effect-emitted  (emitted-fx frame-id) payload))
-          elapsed-ms   (- (interop/now-ms) start-ms)
+          elapsed-ms   (- (rf.interop/now-ms) start-ms)
           ;; A value-comparing evaluator (`:path-equals` /
           ;; `:sub-equals`) returns a REDACTED `:payload` rebuilt from the
           ;; projected expected, so the record's `:payload` slot never
@@ -1165,7 +1165,7 @@
   No throw on failure — the play sequence runs to completion per
   `004-Assertions.md` §Record-don't-throw semantics."
   []
-  (when config/enabled?
+  (when rf.story.config/enabled?
     ;; Internal event handler used by `record!`. Appends a record to
     ;; the variant frame's [:rf.story/assertions] slot.
     (rf/reg-event
@@ -1192,4 +1192,4 @@
   events accumulator can skip recording assertion events themselves.
 
   Aliased from `re-frame.story.predicates` (the canonical leaf ns)."
-  pred/assertion-event?)
+  rf.story.predicates/assertion-event?)

--- a/tools/story/src/re_frame/story/async.cljc
+++ b/tools/story/src/re_frame/story/async.cljc
@@ -34,7 +34,7 @@
   CompletableFuture (JVM) directly — the two surfaces the host runtime
   already exposes. No additional dependency."
   (:refer-clojure :exclude [promise])
-  (:require [re-frame.error :as error]))
+  (:require [re-frame.error :as rf.error]))
 
 ;; ---- construction ---------------------------------------------------------
 
@@ -74,7 +74,7 @@
                reject-fn  (fn [e] (.completeExceptionally cf
                                                           (if (instance? Throwable e)
                                                             e
-                                                            (error/thrown-ex-info
+                                                            (rf.error/thrown-ex-info
                                                               :rf.error/story-async-rejection
                                                               'rf.story.async/promise
                                                               (str "a Story async operation rejected with a "
@@ -101,7 +101,7 @@
      :clj  (let [cf (java.util.concurrent.CompletableFuture.)]
              (.completeExceptionally cf (if (instance? Throwable e)
                                           e
-                                          (error/thrown-ex-info
+                                          (rf.error/thrown-ex-info
                                             :rf.error/story-async-rejection
                                             'rf.story.async/rejected
                                             (str "a Story async operation rejected with a "

--- a/tools/story/src/re_frame/story/author_expectations.cljc
+++ b/tools/story/src/re_frame/story/author_expectations.cljc
@@ -71,9 +71,9 @@
   (:require [clojure.string :as str]
             #?(:clj  [clojure.edn :as edn]
                :cljs [cljs.reader :as edn])
-            [re-frame.story.assertions   :as assertions]
-            [re-frame.story.predicates   :as pred]
-            [re-frame.story.requirements :as requirements]))
+            [re-frame.story.assertions   :as rf.story.assertions]
+            [re-frame.story.predicates   :as rf.story.predicates]
+            [re-frame.story.requirements :as rf.story.requirements]))
 
 ;; ===========================================================================
 ;; THE EXPECTATION-KIND CATALOG  (the authorable expectation surface)
@@ -326,7 +326,7 @@
   (`re-frame.story.requirements/default-runner`). The cost projection
   reports `:cannot-run?` true when the expectation needs more than this
   runner can prove, so the author sees the escalation cost before saving."
-  requirements/default-runner)
+  rf.story.requirements/default-runner)
 
 (defn expectation-cost
   "Project the runner cost of one authored expectation `atom` (a canonical
@@ -348,11 +348,11 @@
   [atom]
   (if (nil? atom)
     {:required #{} :cheapest-runner nil :headless? true :cannot-run? false :missing #{}}
-    (let [required (requirements/assertion-tokens atom)
-          headless (requirements/runner-provides default-author-runner)
-          missing  (requirements/missing-tokens required headless)]
+    (let [required (rf.story.requirements/assertion-tokens atom)
+          headless (rf.story.requirements/runner-provides default-author-runner)
+          missing  (rf.story.requirements/missing-tokens required headless)]
       {:required        required
-       :cheapest-runner (requirements/cheapest-runner required)
+       :cheapest-runner (rf.story.requirements/cheapest-runner required)
        :headless?       (empty? missing)
        :cannot-run?     (seq missing)
        :missing         missing})))
@@ -378,7 +378,7 @@
        :surfaces     #{surface …}}     ; acceptance surfaces the draft spans
 
   `:cheapest-runner` is the cheapest concrete runner whose token set is a
-  superset of the WHOLE draft's required union (`requirements/cheapest-runner`),
+  superset of the WHOLE draft's required union (`rf.story.requirements/cheapest-runner`),
   so the author sees the single runner that would prove every authored
   expectation at once. `:cannot-run-rows` lists the rows that the default
   headless runner refuses — the honest before-save list."
@@ -386,7 +386,7 @@
   (let [rows*       (vec (or rows []))
         ready-rows  (filter (fn [r] (:ok? (parse-operands r))) rows*)
         atoms       (mapv expectation->atom ready-rows)
-        required    (reduce into #{} (map requirements/assertion-tokens atoms))
+        required    (reduce into #{} (map rf.story.requirements/assertion-tokens atoms))
         surfaces    (into #{}
                           (keep (fn [r] (:surface (kind-descriptor (:kind r)))))
                           rows*)
@@ -400,7 +400,7 @@
      :ready           (count ready-rows)
      :atoms           atoms
      :required        required
-     :cheapest-runner (requirements/cheapest-runner required)
+     :cheapest-runner (rf.story.requirements/cheapest-runner required)
      :cannot-run-rows cannot-rows
      :surfaces        surfaces}))
 
@@ -441,7 +441,7 @@
     (str "["
          (->> atoms
               (map pr-str)
-              (str/join (pred/indent-after "   :assertions [")))
+              (str/join (rf.story.predicates/indent-after "   :assertions [")))
          "]")))
 
 (defn gen-expectations-snippet
@@ -472,7 +472,7 @@
                     extends (conj [:extends (pr-str extends)])
                     true    (conj [:assertions (pr-assertions-vector merged)])
                     true    (conj [:tags (pr-str #{:test})]))]
-    (pred/reg-variant-form alias (or variant-id :story.expectations/example) body-keys)))
+    (rf.story.predicates/reg-variant-form alias (or variant-id :story.expectations/example) body-keys)))
 
 ;; ===========================================================================
 ;; DEFAULT NEW-VARIANT ID
@@ -491,5 +491,5 @@
   The dialog asserts this before offering the snippet so an authored
   expectation can never reference an id plan construction would reject."
   [atoms]
-  (every? (fn [a] (assertions/assertion-id-known? (assertions/assertion-atom-id a)))
+  (every? (fn [a] (rf.story.assertions/assertion-id-known? (rf.story.assertions/assertion-atom-id a)))
           (or atoms [])))

--- a/tools/story/src/re_frame/story/canonical.cljc
+++ b/tools/story/src/re_frame/story/canonical.cljc
@@ -19,25 +19,25 @@
   code does not have to register it. Project-specific tags must
   register via `reg-tag` *before* use; an unregistered tag on a
   variant's `:tags` set raises `:rf.error/unknown-tag`."
-  (:require [re-frame.story.assertions   :as assertions]
-            [re-frame.story.frames       :as frames]
-            [re-frame.story.fx-stubs     :as fx-stubs]
-            [re-frame.story.late-bind    :as late-bind]
-            [re-frame.story.layout-debug :as layout-debug]
-            [re-frame.story.loaders      :as loaders]
-            [re-frame.story.play         :as play]
-            [re-frame.story.play.runner-events :as runner-events]
-            [re-frame.story.play.substrate-boundary :as substrate-boundary]
-            [re-frame.story.registrar    :as registrar]
-            [re-frame.story.render       :as render]
-            [re-frame.story.runtime      :as runtime]
-            [re-frame.story.save-variant :as save-variant]
-            [re-frame.story.ui.cofx      :as ui-cofx]
-            #?(:cljs [re-frame.story.ui.a11y            :as ui-a11y])
-            #?(:cljs [re-frame.story.ui.panels          :as ui-panels])
-            #?(:cljs [re-frame.story.ui.open-in-editor  :as ui-open-in-editor])
-            #?(:cljs [re-frame.story.ui.multi-substrate :as ui-multi-substrate])
-            #?(:cljs [re-frame.story.sub-overrides       :as sub-overrides])))
+  (:require [re-frame.story.assertions   :as rf.story.assertions]
+            [re-frame.story.frames       :as rf.story.frames]
+            [re-frame.story.fx-stubs     :as rf.story.fx-stubs]
+            [re-frame.story.late-bind    :as rf.story.late-bind]
+            [re-frame.story.layout-debug :as rf.story.layout-debug]
+            [re-frame.story.loaders      :as rf.story.loaders]
+            [re-frame.story.play         :as rf.story.play]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]
+            [re-frame.story.play.substrate-boundary :as rf.story.play.substrate-boundary]
+            [re-frame.story.registrar    :as rf.story.registrar]
+            [re-frame.story.render       :as rf.story.render]
+            [re-frame.story.runtime      :as rf.story.runtime]
+            [re-frame.story.save-variant :as rf.story.save-variant]
+            [re-frame.story.ui.cofx      :as rf.story.ui.cofx]
+            #?(:cljs [re-frame.story.ui.a11y            :as rf.story.ui.a11y])
+            #?(:cljs [re-frame.story.ui.panels          :as rf.story.ui.panels])
+            #?(:cljs [re-frame.story.ui.open-in-editor  :as rf.story.ui.open-in-editor])
+            #?(:cljs [re-frame.story.ui.multi-substrate :as rf.story.ui.multi-substrate])
+            #?(:cljs [re-frame.story.sub-overrides       :as rf.story.sub-overrides])))
 
 (defn- install-late-bind-shims!
   "Wire the late-bound shims so the frames runtime can tap into the
@@ -50,13 +50,13 @@
   ;; `force-fx-stub` redirected is the stub-call log `fx-stubs` owns; the
   ;; assertions module reads it via this hook (it cannot `:require`
   ;; fx-stubs / frames without a cycle).
-  (late-bind/set-fn! :stub-observed-fx-ids fx-stubs/observed-fx-ids)
+  (rf.story.late-bind/set-fn! :stub-observed-fx-ids rf.story.fx-stubs/observed-fx-ids)
   ;; Only the play module's per-frame `pending-exceptions` slot needs
   ;; frame-teardown eviction.
   ;;
   ;; Per-frame destroy must ALSO unregister the play-runner's per-frame
-  ;; trace listener (`play/install-trace-listener!` registered it
-  ;; in `runtime/run-phase-0!`). Dropping only the `pending-exceptions` entry
+  ;; trace listener (`rf.story.play/install-trace-listener!` registered it
+  ;; in `rf.story.runtime/run-phase-0!`). Dropping only the `pending-exceptions` entry
   ;; would leave the listener registered against a destroyed frame:
   ;; `clear-all-play-state!` keys off `pending-exceptions` / `stepper-state`
   ;; (both empty for a torn-down frame), so without this eviction long-running
@@ -64,10 +64,10 @@
   ;; listener closures inspecting every future trace event.
   ;; `remove-trace-listener!` is idempotent, so destroying a frame that never
   ;; installed a listener (or a double-destroy) is harmless.
-  (late-bind/set-fn! :drop-assertion-accumulators
+  (rf.story.late-bind/set-fn! :drop-assertion-accumulators
     (fn [frame-id]
-      (play/drop-pending-exceptions! frame-id)
-      (play/remove-trace-listener! frame-id)))
+      (rf.story.play/drop-pending-exceptions! frame-id)
+      (rf.story.play/remove-trace-listener! frame-id)))
   ;; The play-runner's per-frame run-state (`run-state` / `runs-by-play` /
   ;; `active-play` / `step-boundaries`) is evicted on frame teardown via
   ;; `clear-state!`: without it a destroyed variant frame would leak its
@@ -76,9 +76,9 @@
   ;; run-state. `frames` cannot `:require` `runner-events` (cycle), so the
   ;; eviction routes through this late-bind hook the same way the
   ;; pending-exceptions eviction does.
-  (late-bind/set-fn! :drop-run-state
+  (rf.story.late-bind/set-fn! :drop-run-state
     (fn [frame-id]
-      (runner-events/clear-state! frame-id)))
+      (rf.story.play.runner-events/clear-state! frame-id)))
   ;; The a11y panel's per-frame axe state (`violations-by-frame` /
   ;; `run-state`) is evicted on frame teardown via `drop-frame-state!`
   ;; (rf2-cpbut). This is a MEMORY eviction before it is a correctness one:
@@ -89,15 +89,15 @@
   ;;
   ;; CLJS-only, and registered here rather than at `ui/a11y` load time so the
   ;; hook is re-armed by every `install!` — a fixture that wiped the registry
-  ;; (`late-bind/clear!`) gets it back, which a load-time `defonce` could not
+  ;; (`rf.story.late-bind/clear!`) gets it back, which a load-time `defonce` could not
   ;; give. `frames` cannot `:require` a `.cljs` ns from a `.cljc` one, so the
   ;; teardown call routes through the hook exactly as the two evictions above
   ;; do. The chrome panel (`ui/chrome-a11y`) needs no counterpart: its state
   ;; is a singleton, with no per-frame accumulation to evict.
   #?(:cljs
-     (late-bind/set-fn! :drop-a11y-state
+     (rf.story.late-bind/set-fn! :drop-a11y-state
        (fn [frame-id]
-         (ui-a11y/drop-frame-state! frame-id)))))
+         (rf.story.ui.a11y/drop-frame-state! frame-id)))))
 
 #?(:cljs
    (defn- render-host-scope
@@ -108,7 +108,7 @@
      never touches app-db / `compute-sub`.
 
      The host paints through the SHARED
-     `ui-multi-substrate/render-decorated-view` seam the canvas single-pane
+     `rf.story.ui.multi-substrate/render-decorated-view` seam the canvas single-pane
      path uses, threading the compiled plan's `[:world :decorators]` refs
      (`render-inputs`' `:decorators`, the single-merge-authority output —
      spec/017 §305-306). `render-variant` and the live shell paint the
@@ -129,13 +129,13 @@
      single-pane branch carried, which is why the two agreed with each other.
      The declared set rides the compiled plan at `[:world :substrates]` (folded
      there by `plan/variant-plan`, so it arrives already `:extends`-merged) and
-     `ui-multi-substrate/single-render-substrate` reduces it to the one
+     `rf.story.ui.multi-substrate/single-render-substrate` reduces it to the one
      substrate a single-tree render can paint under. Multi-substrate variants
      that declare `:reagent` are unaffected."
      [{:keys [view frame effective-args sub-overrides decorators plan]}]
-     (sub-overrides/override-provider sub-overrides
-       (ui-multi-substrate/render-decorated-view
-         (ui-multi-substrate/single-render-substrate
+     (rf.story.sub-overrides/override-provider sub-overrides
+       (rf.story.ui.multi-substrate/render-decorated-view
+         (rf.story.ui.multi-substrate/single-render-substrate
            (get-in plan [:world :substrates]) :reagent)
          frame view effective-args decorators))))
 
@@ -160,7 +160,7 @@
      The bare JVM installs NO render host, so `render-variant` returns
      `:cannot-run` there rather than a silent empty render."
      []
-     (render/install-render-host!
+     (rf.story.render/install-render-host!
        (fn [render-inputs]
          [render-host-scope render-inputs]))))
 
@@ -169,28 +169,28 @@
   zero args and is idempotent. The CLJS-only SOTA-feature surfaces
   (multi-substrate Reagent default + the v1.0 panel set) gate on the
   reader so the JVM classpath stays Reagent-free."
-  [registrar/install-canonical-tags!
-   loaders/install!
-   loaders/install-mirror-writer!
-   frames/install-canonical-frame-events!
-   runtime/install-canonical-runtime-events!
-   assertions/install-canonical-assertions!
-   fx-stubs/install-canonical-fx-stubs!
-   save-variant/install-canonical-event-handlers!
+  [rf.story.registrar/install-canonical-tags!
+   rf.story.loaders/install!
+   rf.story.loaders/install-mirror-writer!
+   rf.story.frames/install-canonical-frame-events!
+   rf.story.runtime/install-canonical-runtime-events!
+   rf.story.assertions/install-canonical-assertions!
+   rf.story.fx-stubs/install-canonical-fx-stubs!
+   rf.story.save-variant/install-canonical-event-handlers!
    install-late-bind-shims!
-   layout-debug/install-canonical-layout-debug!
-   ui-cofx/install-canonical-cofx!
+   rf.story.layout-debug/install-canonical-layout-debug!
+   rf.story.ui.cofx/install-canonical-cofx!
    ;; The `:settled-boundary-hooks` producer (rf2-ek9qb). Unconditional
    ;; rather than CLJS-gated: it names no substrate — it reads
    ;; `:flush-render!` off whatever adapter is seated — so it adds nothing
    ;; to the JVM classpath, and on the JVM (no adapter) it resolves to the
    ;; headless hooks the runner already defaulted to. Installing it in both
    ;; readers keeps ONE settle story rather than a CLJS-only one.
-   substrate-boundary/install!
-   #?@(:cljs [ui-multi-substrate/install-reagent-substrate!
+   rf.story.play.substrate-boundary/install!
+   #?@(:cljs [rf.story.ui.multi-substrate/install-reagent-substrate!
               install-render-host!
-              ui-open-in-editor/install!
-              ui-panels/install-canonical-panels!])])
+              rf.story.ui.open-in-editor/install!
+              rf.story.ui.panels/install-canonical-panels!])])
 
 ;; ---- auto-install gate --------------------------------------------------
 ;;
@@ -262,4 +262,4 @@
 ;; registrar consults this hook from each `reg-*!` runtime helper —
 ;; see `re-frame.story.registrar/maybe-auto-install!`. Late-bound to
 ;; avoid a circular require (registrar → canonical → registrar).
-(late-bind/set-fn! :ensure-canonical-installed ensure-installed!)
+(rf.story.late-bind/set-fn! :ensure-canonical-installed ensure-installed!)

--- a/tools/story/src/re_frame/story/config.cljc
+++ b/tools/story/src/re_frame/story/config.cljc
@@ -29,11 +29,11 @@
   true (the registration call); to `nil` when false. Production code
   that accidentally requires a stories ns sees the namespace load but
   with no registrations, every Story query returns empty."
-  (:require [re-frame.privacy    :as privacy]
+  (:require [re-frame.privacy    :as rf.privacy]
             ;; the canonical RAW trace-event frame reader
             ;; (`re-frame.trace/trace-event-frame`); Story reads the
             ;; frame off a trace event through it.
-            [re-frame.trace      :as trace]
+            [re-frame.trace      :as rf.trace]
             ;; EP-0015: the on-box dev visibility choice is a named
             ;; `:rf.egress/*` profile resolved through the framework's
             ;; centralized projection table. `re-frame.projection` is the
@@ -42,7 +42,7 @@
             ;; the whole `re-frame.core` facade) keeps this config ns
             ;; JVM-runnable for the test corpus and pins the egress
             ;; vocabulary to the ONE canonical source.
-            [re-frame.projection :as projection])
+            [re-frame.projection :as rf.projection])
   #?(:cljs (:require-macros [re-frame.story.config])))
 
 ;; ---- the compile-time flag -----------------------------------------------
@@ -394,7 +394,7 @@
 ;; The "is this `:sensitive?` event visible?" decision is not a hand-held
 ;; boolean: it derives from the profile's `:rf.size/include-sensitive?`
 ;; resolution via the framework's projection table
-;; (`projection/profile-size-opts`), the same table `project-egress`
+;; (`rf.projection/profile-size-opts`), the same table `project-egress`
 ;; consumes — one source of truth, no re-implemented redaction policy.
 ;;
 ;; Storage shape (issue 7 — per-frame, not process-global):
@@ -427,7 +427,7 @@
   the framework's `re-frame.projection/profiles` so `configure!` can
   validate `:rf.story/egress-profile` against the ONE canonical enum (no
   forked copy)."
-  projection/profiles)
+  rf.projection/profiles)
 
 (defn known-egress-profile?
   "True iff `profile` is a member of the closed `:rf.egress/*` enum."
@@ -546,7 +546,7 @@
   relevant profile that does. An unknown / nil profile is fail-closed
   (does NOT reveal)."
   [profile]
-  (boolean (:rf.size/include-sensitive? (projection/profile-size-opts profile))))
+  (boolean (:rf.size/include-sensitive? (rf.projection/profile-size-opts profile))))
 
 (defn resolve-egress-profile
   "Resolve the effective `:rf.egress/*` profile for `frame-id` (EP-0015
@@ -589,7 +589,7 @@
   the callbacks. Returns nil."
   [frame-id profile]
   (when (some? frame-id)
-    (let [next (if (contains? projection/profiles profile)
+    (let [next (if (contains? rf.projection/profiles profile)
                  profile
                  default-egress-profile)
           prev (resolve-egress-profile frame-id)]
@@ -616,7 +616,7 @@
   their own per-frame override keep their own profile and are scrubbed only
   by their own `set-frame-egress-profile!` narrowing. Returns nil."
   [profile]
-  (let [next (if (contains? projection/profiles profile)
+  (let [next (if (contains? rf.projection/profiles profile)
                profile
                default-egress-profile)
         prev @session-egress-profile]
@@ -671,7 +671,7 @@
   against ONE framework primitive rather than reimplementing the
   five-token check. Per Spec 009 §Privacy."
   [ev]
-  (privacy/sensitive? ev))
+  (rf.privacy/sensitive? ev))
 
 (defn event-frame
   "Return the frame a RAW trace event targets — its `[:tags :frame]` slot
@@ -683,7 +683,7 @@
   defensive call sites may pass."
   [ev]
   (when (map? ev)
-    (trace/trace-event-frame ev)))
+    (rf.trace/trace-event-frame ev)))
 
 (defn suppress-sensitive?
   "Should this trace event be suppressed by a Story-registered listener

--- a/tools/story/src/re_frame/story/decorators.cljc
+++ b/tools/story/src/re_frame/story/decorators.cljc
@@ -36,9 +36,9 @@
   Unknown decorator-ids surface as an entry in the returned `:errors`
   vector; the runtime then projects those into the variant's
   `:assertions` (per `002-Runtime.md` §Error projection)."
-  (:require [re-frame.story.args      :as args]
-            [re-frame.story.plan      :as plan]
-            [re-frame.story.registrar :as registrar]))
+  (:require [re-frame.story.args      :as rf.story.args]
+            [re-frame.story.plan      :as rf.story.plan]
+            [re-frame.story.registrar :as rf.story.registrar]))
 
 ;; ---- collection -----------------------------------------------------------
 
@@ -67,7 +67,7 @@
   source invariant pays for (no second merge engine to diverge).
 
   `run-args` carries the ambient + per-run arg layers
-  (`args/run-arg-layers`'s `{:pre … :post …}` shape) threaded into the
+  (`rf.story.args/run-arg-layers`'s `{:pre … :post …}` shape) threaded into the
   plan compile so a `[:arg key]` resolvable ONLY through a mode / cell /
   global / story layer (never the variant chain) substitutes cleanly
   rather than throwing `:rf.error/story-missing-arg`. The runtime's
@@ -78,7 +78,7 @@
   call) ⇒ the variant arg layer alone, exactly as before."
   ([variant-id] (collect-decorator-refs variant-id nil))
   ([variant-id run-args]
-   (or (get-in (plan/variant-plan variant-id
+   (or (get-in (rf.story.plan/variant-plan variant-id
                                   (when run-args {:run-args run-args}))
                [:world :decorators])
        [])))
@@ -127,7 +127,7 @@
   [ref]
   (let [id          (first ref)
         decor-args  (vec (rest ref))
-        body-raw    (when (keyword? id) (registrar/handler-meta :decorator id))
+        body-raw    (when (keyword? id) (rf.story.registrar/handler-meta :decorator id))
         body        (when body-raw (expand-ref-args-body body-raw decor-args))]
     (cond
       (not (keyword? id))
@@ -166,7 +166,7 @@
   Used by the UI shell to detect when a decorator changed and the
   cached resolution must be invalidated."
   [decorator-id]
-  (let [body (registrar/handler-meta :decorator decorator-id)
+  (let [body (rf.story.registrar/handler-meta :decorator decorator-id)
         body (dissoc body :source)]
     (hash body)))
 
@@ -185,7 +185,7 @@
   serves solely to let the ref collection's plan compile succeed."
   ([variant-id] (resolution-fingerprints variant-id nil))
   ([variant-id opts]
-   (let [run-args (when opts (args/run-arg-layers variant-id opts))
+   (let [run-args (when opts (rf.story.args/run-arg-layers variant-id opts))
          refs     (collect-decorator-refs variant-id run-args)]
      (into {}
            (keep (fn [ref]
@@ -236,7 +236,7 @@
   - `:fx-override` — declared order; last-wins on a key collision.
 
   `opts` accepts `:active-modes` + `:cell-overrides` — the SAME per-run
-  shape `args/resolve-args` takes. v1 modes carry no decorators (per
+  shape `rf.story.args/resolve-args` takes. v1 modes carry no decorators (per
   `001-Authoring.md` §Registration macros modes are `:args`-only, so the active modes never
   perturb the decorator REFS), but the run layers must still be threaded
   into the plan compile (rf2-eyrpr): a `[:arg key]` resolvable ONLY
@@ -247,7 +247,7 @@
   ([variant-id]
    (resolve-decorators variant-id nil))
   ([variant-id opts]
-   (let [run-args (when opts (args/run-arg-layers variant-id opts))]
+   (let [run-args (when opts (rf.story.args/run-arg-layers variant-id opts))]
      (resolve-decorator-refs (collect-decorator-refs variant-id run-args)))))
 
 (defn resolve-decorator-refs
@@ -309,7 +309,7 @@
   result, and so on. The final result is the outermost decorator's
   wrap of every inner wrap.
 
-  `effective-args` is the resolved args map (per `args/resolve-args`);
+  `effective-args` is the resolved args map (per `rf.story.args/resolve-args`);
   every `:wrap` fn receives `[body effective-args]`. Decorator-level
   ref-args (the `[& args]` tail of a `[:dec-id & args]` ref) are NOT
   passed in the variant-body model — per /spec/007-Stories.md §Three kinds of

--- a/tools/story/src/re_frame/story/determinism.cljc
+++ b/tools/story/src/re_frame/story/determinism.cljc
@@ -55,9 +55,9 @@
   into fresh frames). The pure half runs under `clojure -M:test` with no
   runtime; the replay half settles synchronously to a fixed point via the
   headless flush-hooks, so the JVM gate exercises the full gate."
-  (:require [re-frame.story.artifact    :as artifact]
-            [re-frame.story.fingerprint :as fingerprint]
-            [re-frame.story.play.runner :as runner]))
+  (:require [re-frame.story.artifact    :as rf.story.artifact]
+            [re-frame.story.fingerprint :as rf.story.fingerprint]
+            [re-frame.story.play.runner :as rf.story.play.runner]))
 
 ;; ===========================================================================
 ;; PLAN / ARTIFACT → REPLAYABLE ARTIFACT  (pure)
@@ -90,7 +90,7 @@
   recorder's captured program replays verbatim."
   [target]
   (cond
-    (artifact/run-artifact? target)
+    (rf.story.artifact/run-artifact? target)
     target
 
     ;; A normalized variant plan: setup lives under [:world :setup], the
@@ -99,7 +99,7 @@
     ;; Fold setup ⧺ script into the event program; carry the network routes
     ;; so replay re-installs the managed-request stubs.
     (and (map? target) (contains? target :world))
-    (artifact/make-run-artifact
+    (rf.story.artifact/make-run-artifact
       (cond-> {:setup        (get-in target [:world :setup] [])
                :script       (get target :script [])
                :fx-decisions (get-in target [:world :frame :fx-overrides] {})
@@ -108,7 +108,7 @@
         (assoc :network (get-in target [:world :network]))))
 
     :else
-    (artifact/make-run-artifact target)))
+    (rf.story.artifact/make-run-artifact target)))
 
 ;; ===========================================================================
 ;; THE BARE-[:wait ms] OPT-OUT  (pure)
@@ -122,7 +122,7 @@
   `[:wait-until pred]` is NOT a wait step — it settles on a queue/state
   condition and is deterministic — so it never appears here."
   [artifact]
-  (filterv #(= :wait (runner/step-type %)) (:event-program artifact)))
+  (filterv #(= :wait (rf.story.play.runner/step-type %)) (:event-program artifact)))
 
 (defn has-wall-clock-wait?
   "True iff the artifact's event program contains a bare `[:wait ms]` step —
@@ -174,9 +174,9 @@
   hashes, for a readable failure."
   [results]
   (let [n        (count results)
-        slice    (fn [r] (select-keys r fingerprint/run-hash-input-keys))
+        slice    (fn [r] (select-keys r rf.story.fingerprint/run-hash-input-keys))
         ;; Canonicalize each run-slice ONCE and reuse the result for BOTH the
-        ;; hash and the equality. `fingerprint/run-hash` would re-canonicalize
+        ;; hash and the equality. `rf.story.fingerprint/run-hash` would re-canonicalize
         ;; the same slice internally (`canonical-hash` → `canonicalize`), so
         ;; hashing the canon directly via `hash-canonical` avoids the second
         ;; pass while staying byte-identical: `run-hash` ≡ `(hash-canonical
@@ -186,8 +186,8 @@
         ;; hashes an already-canonical value with no second pass). The two-stage
         ;; contract — the hash is the cheap discriminator, canonical `=` is the
         ;; authority — is preserved exactly.
-        canons   (mapv (comp fingerprint/canonicalize slice) results)
-        hashes   (mapv fingerprint/hash-canonical canons)
+        canons   (mapv (comp rf.story.fingerprint/canonicalize slice) results)
+        hashes   (mapv rf.story.fingerprint/hash-canonical canons)
         base     (first canons)
         diverged (first (keep-indexed
                           (fn [i c] (when (and (pos? i) (not= base c)) i))
@@ -257,7 +257,7 @@
        (let [replay-opts (cond-> {}
                            hooks        (assoc :hooks hooks)
                            frame-config (assoc :frame-config frame-config))
-             results     (mapv (fn [_] (artifact/replay-run-artifact art replay-opts))
+             results     (mapv (fn [_] (rf.story.artifact/replay-run-artifact art replay-opts))
                                (range n))
              ;; A replay that itself refused/errored is not a determinism
              ;; question — surface it directly rather than comparing.

--- a/tools/story/src/re_frame/story/diff.cljc
+++ b/tools/story/src/re_frame/story/diff.cljc
@@ -43,7 +43,7 @@
   - `:fidelity`          — the `#{fidelity-token …}` set delta.
 
   The facet set is EXACTLY the canonical run-slice
-  (`fingerprint/run-hash-input-keys`) the `:same?` judgement compares —
+  (`rf.story.fingerprint/run-hash-input-keys`) the `:same?` judgement compares —
   nothing outside it. `:sub-runs` is deliberately NOT in that slice
   (over-recomputed evidence, not a determinism input), so it carries NO
   `diff-runs` facet; `diff-sub-runs` survives only as a standalone diagnostic
@@ -98,9 +98,9 @@
   slice). `diff-run-artifacts` is the thin replay-then-`diff-runs` wrapper for
   the artifact inputs."
   (:require [clojure.set                  :as set]
-            [re-frame.story.artifact      :as artifact]
-            [re-frame.story.fingerprint   :as fingerprint]
-            [re-frame.story.play.evidence :as evidence]))
+            [re-frame.story.artifact      :as rf.story.artifact]
+            [re-frame.story.fingerprint   :as rf.story.fingerprint]
+            [re-frame.story.play.evidence :as rf.story.play.evidence]))
 
 ;; ===========================================================================
 ;; KEYED DELTA  (the shared added / removed / changed shape)
@@ -265,7 +265,7 @@
 
   NOT part of the `:same?` judgement and NOT registered in `facet-fns`
   (rf2-e6uod / rf2-5l0a5). `:sub-runs` is deliberately excluded from
-  `fingerprint/run-hash-input-keys` — sub-runs are over-recomputed evidence,
+  `rf.story.fingerprint/run-hash-input-keys` — sub-runs are over-recomputed evidence,
   not a determinism input — so a `:sub-runs`-only delta does NOT make
   `diff-runs` report `:same? false`, exactly as the determinism gate and the
   golden verdict treat it. This fn exists for callers that want to inspect the
@@ -288,9 +288,9 @@
   "The surface selectors of a run-result's projected `:schema-violations`,
   in tape order. Reuses an existing `:selector` when the evidence boundary
   already attached it (it does — `schema-violation-record`), else recomputes
-  it via `evidence/violation-selector`. Pure data → data."
+  it via `rf.story.play.evidence/violation-selector`. Pure data → data."
   [run]
-  (mapv (fn [v] (or (:selector v) (evidence/violation-selector v)))
+  (mapv (fn [v] (or (:selector v) (rf.story.play.evidence/violation-selector v)))
         (:schema-violations run)))
 
 (defn diff-schema-violations
@@ -509,10 +509,10 @@
   works. The facet fns read those slots, so they need the shape; this strip
   is why they see no per-run noise."
   [run]
-  (fingerprint/project (fingerprint/strip-run-stamps run)))
+  (rf.story.fingerprint/project (rf.story.fingerprint/strip-run-stamps run)))
 
 (defn- diverging-slice-keys
-  "The `fingerprint/run-hash-input-keys` slots whose CANONICAL projection
+  "The `rf.story.fingerprint/run-hash-input-keys` slots whose CANONICAL projection
   differs between two run-results. Pure data → data. Each slot is
   canonicalized in isolation (the same projection `:same?` uses over the
   whole slice), so this names exactly which run-hash slot perturbed the
@@ -522,10 +522,10 @@
   [baseline current]
   (into []
         (comp (filter (fn [k]
-                        (not= (fingerprint/canonicalize (get baseline k))
-                              (fingerprint/canonicalize (get current k)))))
+                        (not= (rf.story.fingerprint/canonicalize (get baseline k))
+                              (rf.story.fingerprint/canonicalize (get current k)))))
               (map (fn [k] {:slice-key k})))
-        fingerprint/run-hash-input-keys))
+        rf.story.fingerprint/run-hash-input-keys))
 
 (def facet-fns
   "The ordered facet name → diff-fn map (spec §Semantic diff). Ordered so
@@ -597,15 +597,15 @@
   :facets #{}}`, which would be an undiagnosable diff.
 
   The `:same?` judgement is canonical equality of the run-SLICE
-  (`fingerprint/run-hash-input-keys` — the behavioural surface, NOT the whole
+  (`rf.story.fingerprint/run-hash-input-keys` — the behavioural surface, NOT the whole
   result), the EXACT slice + judgement `re-frame.story.determinism/compare-runs`
   uses. A run-result also carries pure provenance (`:frame` replay id,
   `:run-artifact` back-link, per-step `:replay-steps`) that legitimately
   differs per replay and is excluded from the slice for exactly this reason —
   so a diff agrees with the determinism gate on what counts as the same run."
   [baseline current]
-  (if (= (fingerprint/canonicalize (select-keys baseline fingerprint/run-hash-input-keys))
-         (fingerprint/canonicalize (select-keys current  fingerprint/run-hash-input-keys)))
+  (if (= (rf.story.fingerprint/canonicalize (select-keys baseline rf.story.fingerprint/run-hash-input-keys))
+         (rf.story.fingerprint/canonicalize (select-keys current  rf.story.fingerprint/run-hash-input-keys)))
     {:same? true}
     ;; The canonical forms differ. Feed each facet fn the NOISE-STRIPPED but
     ;; SHAPE-PRESERVED run-results (`strip-noise` — the same volatile / stamp
@@ -649,7 +649,7 @@
   result-vs-result diffs agree."
   [side opts]
   (cond
-    (artifact/run-artifact? side) (artifact/replay-run-artifact side opts)
+    (rf.story.artifact/run-artifact? side) (rf.story.artifact/replay-run-artifact side opts)
     :else                         side))
 
 (defn diff-run-artifacts

--- a/tools/story/src/re_frame/story/egress.cljc
+++ b/tools/story/src/re_frame/story/egress.cljc
@@ -75,7 +75,7 @@
   runtime. The fn-detection rides `re-frame.story.fingerprint`'s
   `Canonicalise` protocol — the same opaque-fn fold the plan-hash uses —
   so a value is judged exactly the way the hashing layer judges it."
-  (:require [re-frame.story.fingerprint :as fingerprint]
+  (:require [re-frame.story.fingerprint :as rf.story.fingerprint]
             #?(:clj  [clojure.edn :as edn]
                :cljs [cljs.reader :as edn])))
 
@@ -108,19 +108,19 @@
 (defn contains-fn?
   "True iff `x` (walked recursively through maps / vectors / sets / seqs)
   carries a function value anywhere. Pure. Rides the SAME `Canonicalise`
-  fold the plan-hash uses (`fingerprint/canonical-form`): a genuine fn
+  fold the plan-hash uses (`rf.story.fingerprint/canonical-form`): a genuine fn
   canonicalises to the `:rf/opaque-fn` sentinel, so detecting the sentinel
   in the canonical form is exactly detecting a fn in the original — across
   JVM and CLJS, without a host-specific `fn?`/`function` walk here."
   [x]
-  (let [canon (fingerprint/canonical-form x)]
+  (let [canon (rf.story.fingerprint/canonical-form x)]
     (loop [stack [canon]]
       (cond
         (empty? stack) false
         :else
         (let [[h & t] stack]
           (cond
-            (= h fingerprint/opaque-fn) true
+            (= h rf.story.fingerprint/opaque-fn) true
             (map? h)        (recur (into (vec t) (concat (keys h) (vals h))))
             (sequential? h) (recur (into (vec t) h))
             (set? h)        (recur (into (vec t) h))

--- a/tools/story/src/re_frame/story/error.cljc
+++ b/tools/story/src/re_frame/story/error.cljc
@@ -65,13 +65,13 @@
   `pipeline-exception-event?` is the ONE projection predicate every
   capture site consults — any of the three operations targeting the
   frame is a captured failure (spec/009 §Error contract)."
-  (:require [re-frame.elision :as elision]
+  (:require [re-frame.elision :as rf.elision]
             ;; The canonical RAW trace-event frame reader
             ;; (`re-frame.trace/trace-event-frame`) — read the raw event's
             ;; frame through it, not a hand-rolled `[:tags :frame]` walk.
             ;; Core framework leaf, so the require keeps this ns at the
             ;; leaf of the cycle graph.
-            [re-frame.trace   :as trace])
+            [re-frame.trace   :as rf.trace])
   (:refer-clojure :exclude [error]))
 
 (def pipeline-exception-operations
@@ -97,7 +97,7 @@
   §Frame identity on the raw event)."
   [frame-id ev]
   (and (contains? pipeline-exception-operations (:operation ev))
-       (= frame-id (trace/trace-event-frame ev))))
+       (= frame-id (rf.trace/trace-event-frame ev))))
 
 (defn- elide-ex-data
   "Project an `ex-data` map through `re-frame.elision/elide-wire-value`
@@ -121,7 +121,7 @@
   (if (or (nil? data) (nil? frame-id))
     data
     (try
-      (elision/elide-wire-value data {:frame frame-id})
+      (rf.elision/elide-wire-value data {:frame frame-id})
       (catch #?(:clj Throwable :cljs :default) _ data))))
 
 (defn throwable->error-map

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -47,7 +47,7 @@
   remains owned here and in `re-frame.story.runtime`."
   (:require [re-frame.core             :as rf]
             ;; `reset-state!` reaches the raw frame-state
-            ;; write boundary (`frame/replace-frame-state!`) directly so an
+            ;; write boundary (`rf.frame/replace-frame-state!`) directly so an
             ;; in-place fresh-run reset preserves frame IDENTITY + sub-cache
             ;; + the app-db/runtime-db projection reactions. The epoch-backed
             ;; facade surface (`rf/replace-frame-state!`) is the WRONG seam
@@ -57,35 +57,35 @@
             ;; with no epoch coupling — exactly what the epoch surface itself
             ;; calls under the hood. Story's `test_support` already reaches
             ;; `re-frame.frame` directly; this is the same boundary.
-            [re-frame.frame            :as frame]
+            [re-frame.frame            :as rf.frame]
             ;; EP-0025: a variant's durable app-db `:sensitive` / `:large`
             ;; classification is applied as commit-plane classification
             ;; effects (the frame annotation is removed). Story reaches the
             ;; pure registry-write seam directly (same artefact as
             ;; `re-frame.frame` above; bundle-isolated from production).
-            [re-frame.elision          :as elision]
+            [re-frame.elision          :as rf.elision]
             ;; EP-0025 fail-loud: a variant's lowered classification effects are
             ;; validated through the SAME pure validator the router's
-            ;; commit-plane boundary uses (`elision/classification-effect-defect`)
+            ;; commit-plane boundary uses (`rf.elision/classification-effect-defect`)
             ;; and a defect is raised via the canonical thrown-error builder, so
             ;; a malformed declaration FAILS LOUD pre-commit rather than crashing
             ;; inside `apply-classification-effects` / `allocate!`.
-            [re-frame.error            :as rf-error]
-            [re-frame.story.config     :as config]
-            [re-frame.story.decorators :as decorators]
-            [re-frame.story.error      :as story-error]
-            [re-frame.story.late-bind  :as late-bind]
-            [re-frame.story.loaders    :as loaders]
-            [re-frame.story.predicates :as pred]
-            [re-frame.story.registrar  :as registrar]
-            [re-frame.story.runtime-image :as runtime-image]
+            [re-frame.error            :as rf.error]
+            [re-frame.story.config     :as rf.story.config]
+            [re-frame.story.decorators :as rf.story.decorators]
+            [re-frame.story.error      :as rf.story.error]
+            [re-frame.story.late-bind  :as rf.story.late-bind]
+            [re-frame.story.loaders    :as rf.story.loaders]
+            [re-frame.story.predicates :as rf.story.predicates]
+            [re-frame.story.registrar  :as rf.story.registrar]
+            [re-frame.story.runtime-image :as rf.story.runtime-image]
             ;; Trace-listener pattern for the teardown
             ;; exception-projection path: re-frame's interceptor chain
             ;; catches handler exceptions internally and emits
             ;; `:rf.error/handler-exception` trace events rather than
             ;; re-throwing (per `runtime/capture-phase-errors` —
             ;; the same listener pattern is used here for phase-teardown).
-            [re-frame.trace.tooling    :as trace-tooling]))
+            [re-frame.trace.tooling    :as rf.trace.tooling]))
 
 ;; ---- fx-override-stub registration ---------------------------------------
 ;;
@@ -136,7 +136,7 @@
 ;; (rf2-x76af2.19). Mirrors `destroy-inline!`, which already uses its
 ;; caller-supplied captured stack. Evicted by `run-teardown-walks!`.
 (defonce
-  ^{:doc "frame-id → the `decorators/resolve-decorators` result CAPTURED at
+  ^{:doc "frame-id → the `rf.story.decorators/resolve-decorators` result CAPTURED at
          `allocate!` time. Read (and evicted) by `run-teardown-walks!` so
          teardown mirrors the allocate-time `:frame-setup` set."}
   allocated-decorator-stacks
@@ -171,7 +171,7 @@
       nil)))
 
 (defn- register-fx-overrides!
-  "Walk the `:registrations` vector from `decorators/fx-overrides-map`
+  "Walk the `:registrations` vector from `rf.story.decorators/fx-overrides-map`
   and register each stub fx. Returns the `:overrides` map suitable
   for the variant frame's `:fx-overrides` config slot."
   [{:keys [overrides registrations]}]
@@ -200,7 +200,7 @@
   event preserves its originating `:operation` / `:failing-id`."
   ([variant-id phase event err] (phase-exception-record variant-id phase event err nil))
   ([variant-id phase event err opts]
-   (story-error/exception-record variant-id phase event err opts)))
+   (rf.story.error/exception-record variant-id phase event err opts)))
 
 (defn- pipeline-event-opts
   "Pull the `:operation` / `:failing-id` attribution off a captured
@@ -222,9 +222,9 @@
   [listener body-fn]
   (let [cb-id (keyword "re-frame.story.frames"
                        (str "setup-capture-" (swap! setup-capture-counter inc)))]
-    (trace-tooling/register-listener! cb-id listener)
+    (rf.trace.tooling/register-listener! cb-id listener)
     (try (body-fn)
-      (finally (trace-tooling/unregister-listener! cb-id)))))
+      (finally (rf.trace.tooling/unregister-listener! cb-id)))))
 
 (defn- apply-frame-setup!
   "Walk the resolved `:frame-setup` decorators and execute their
@@ -263,7 +263,7 @@
                                                {:frame frame-id})
                              (catch #?(:clj Throwable :cljs :default) _ nil))))))
           listener (fn [ev]
-                     (when (story-error/pipeline-exception-event? frame-id ev)
+                     (when (rf.story.error/pipeline-exception-event? frame-id ev)
                        (swap! pending conj ev)))]
       (with-setup-trace-listener
         listener
@@ -326,9 +326,9 @@
   (let [cb-id (keyword "re-frame.story.frames"
                        (str "teardown-capture-"
                             (swap! teardown-capture-counter inc)))]
-    (trace-tooling/register-listener! cb-id listener)
+    (rf.trace.tooling/register-listener! cb-id listener)
     (try (body-fn)
-      (finally (trace-tooling/unregister-listener! cb-id)))))
+      (finally (rf.trace.tooling/unregister-listener! cb-id)))))
 
 (defn- apply-frame-teardown!
   "Walk the resolved `:frame-setup` decorators IN REVERSE-DECLARATION
@@ -387,7 +387,7 @@
                    ;; handler-exception: a teardown event whose cofx
                    ;; injector or user interceptor throws is a first-class
                    ;; failure too.
-                   (when (story-error/pipeline-exception-event? variant-id ev)
+                   (when (rf.story.error/pipeline-exception-event? variant-id ev)
                      (swap! pending conj ev)))]
     (with-teardown-trace-listener
       listener
@@ -487,7 +487,7 @@
                    ;; handler-exception (a loaders-teardown event whose
                    ;; cofx injector / user interceptor throws is a
                    ;; first-class failure too).
-                   (when (story-error/pipeline-exception-event? variant-id ev)
+                   (when (rf.story.error/pipeline-exception-event? variant-id ev)
                      (swap! pending conj ev)))]
     (with-teardown-trace-listener
       listener
@@ -528,7 +528,7 @@
   `install-canonical-assertions!`, `install-canonical-fx-stubs!`, …); the
   name states what's installed."
   []
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (rf/reg-event
       ::apply-app-db-patch
       (fn [{:keys [db]} [_ patch]]
@@ -585,11 +585,11 @@
   declares its application image ONCE on the story body's `:images` slot; every
   variant under it inherits that image (the variant may LAYER its own `:images`
   on top — see `compose-variant-images`). Resolved off the parent story body via
-  the variant→story id derivation (`pred/parent-story-id`), mirroring how
+  the variant→story id derivation (`rf.story.predicates/parent-story-id`), mirroring how
   `re-frame.story.args/resolve-args` folds the parent-story `:args` layer."
   [variant-id]
-  (let [story-id   (pred/parent-story-id variant-id)
-        story-body (when story-id (registrar/handler-meta :story story-id))]
+  (let [story-id   (rf.story.predicates/parent-story-id variant-id)
+        story-body (when story-id (rf.story.registrar/handler-meta :story story-id))]
     (vec (:images story-body))))
 
 (defn- compose-variant-images
@@ -625,7 +625,7 @@
   (let [story-imgs (story-images variant-id)
         app-imgs   (into (vec story-imgs) variant-images)]
     (when (seq app-imgs)
-      (conj app-imgs (runtime-image/runtime-image)))))
+      (conj app-imgs (rf.story.runtime-image/runtime-image)))))
 
 (defn- ->classification-effects
   "Convert a variant body's `:sensitive` / `:large` classification declaration
@@ -664,7 +664,7 @@
 
   EP-0025 fail-loud: the lowered effects are validated through the SAME
   pure validator the router's FINAL-effects commit-plane boundary uses
-  (`elision/classification-effect-defect`) BEFORE `apply-classification-effects`
+  (`rf.elision/classification-effect-defect`) BEFORE `apply-classification-effects`
   touches the registry. A malformed declaration (a non-vector `:app-db`, or a
   path that is not a valid concrete `:rf/path`) raises
   `:rf.error/classification-effect-shape` pre-commit — no partial registry
@@ -683,13 +683,13 @@
   silently swallowed as a vacuous `:status :pass` with zero assertions —
   strictly worse than an orphaned dev-tool frame. It is also no NEW risk
   class: every other throw site between `rf/make-frame` and the
-  `allocated?` flip (`loaders/mount!` / `apply-frame-setup!`'s `:init`
+  `allocated?` flip (`rf.story.loaders/mount!` / `apply-frame-setup!`'s `:init`
   events) already shares it."
   [subject-id classification]
   (let [effects (->classification-effects classification)]
     (when (seq effects)
-      (when-let [defect (elision/classification-effect-defect effects)]
-        (rf-error/throw-error!
+      (when-let [defect (rf.elision/classification-effect-defect effects)]
+        (rf.error/throw-error!
           :rf.error/classification-effect-shape
           'rf.story/apply-variant-classification!
           (str "re-frame2-story: " subject-id
@@ -700,8 +700,8 @@
                "(e.g. `:sensitive {:app-db [[:auth :token]]}`).")
           {:recovery :fix-the-variant-classification-shape
            :extra    (assoc defect :variant-id subject-id)}))
-      (frame/swap-runtime-db! subject-id
-        (fn [rt] (elision/apply-classification-effects rt effects))))))
+      (rf.frame/swap-runtime-db! subject-id
+        (fn [rt] (rf.elision/apply-classification-effects rt effects))))))
 
 (defn allocate!
   "Create the variant's frame, register fx-override stubs, run
@@ -709,7 +709,7 @@
   machine forward. Returns the variant-id (which doubles as the
   frame-id).
 
-  `decorator-stack` is the result of `decorators/resolve-decorators`;
+  `decorator-stack` is the result of `rf.story.decorators/resolve-decorators`;
   the runtime computes it upstream.
 
   Lifecycle dispatch:
@@ -748,15 +748,15 @@
   classification itself, silently dropped the parent's redaction."
   ([variant-id decorator-stack] (allocate! variant-id decorator-stack nil))
   ([variant-id decorator-stack classification]
-   (when config/enabled?
+   (when rf.story.config/enabled?
      (install-canonical-frame-events!)
-     (let [fx-stack       (decorators/fx-overrides-map (:fx-override decorator-stack))
+     (let [fx-stack       (rf.story.decorators/fx-overrides-map (:fx-override decorator-stack))
            fx-overrides   (register-fx-overrides! fx-stack)
            ;; Inline the variant-body lookup (`variant-body` is defined
            ;; lower in this ns) — go through the registrar directly so
            ;; the events-only classification doesn't depend
            ;; on the file's declaration order.
-           v-body         (registrar/handler-meta :variant variant-id)
+           v-body         (rf.story.registrar/handler-meta :variant variant-id)
            ;; EP-0026 §Default Image / §Layered Resolution — the FULL `:images`
            ;; vector this variant frame is created with:
            ;;
@@ -790,7 +790,7 @@
                             variant-id fx-overrides
                             (assoc (select-keys v-body [:sensitive :large])
                                    :image-ids (keep image-id author-images)))
-           events-only?   (loaders/events-only-variant? v-body decorator-stack)]
+           events-only?   (rf.story.loaders/events-only-variant? v-body decorator-stack)]
        ;; EP-0023 §Stories / §Frame-derived live registration resolution
        ;; — the frame carries the resolved, sealed image GENERATION so
        ;; `process-event!`'s `call-with-frame-resolution` routes the whole cascade
@@ -829,8 +829,8 @@
        ;; everything else takes the classical four-phase route through
        ;; :mounting → :loading → :ready.
        (if events-only?
-         (loaders/mount-ready! variant-id)
-         (loaders/mount!       variant-id))
+         (rf.story.loaders/mount-ready! variant-id)
+         (rf.story.loaders/mount!       variant-id))
        ;; Apply :frame-setup decorators (their :init events + :app-db-patch).
        ;; By construction the events-only path has no :frame-setup
        ;; decorators (that's part of the events-only? predicate), so this
@@ -853,7 +853,7 @@
 ;; have nothing to read. `allocate-inline!` is the registry-free twin:
 ;; everything it needs is already on the compiled plan + the supplied
 ;; decorator stack (resolved from the plan's `[:world :decorators]` refs via
-;; `decorators/resolve-decorator-refs`). The allocated frame is stamped
+;; `rf.story.decorators/resolve-decorator-refs`). The allocated frame is stamped
 ;; `:rf/inline? true` so tools / navigation can tell an inline run's frame
 ;; apart from a registered variant's frame — an inline plan MUST NOT appear
 ;; in Story navigation.
@@ -876,7 +876,7 @@
 
   - `frame-id` — the anonymous frame id the runtime minted (NOT a
     registered variant id);
-  - `decorator-stack` — `decorators/resolve-decorator-refs` over the plan's
+  - `decorator-stack` — `rf.story.decorators/resolve-decorator-refs` over the plan's
     `[:world :decorators]` refs (the runtime resolves it upstream);
   - `plan-fx-overrides` — the plan's `[:world :frame :fx-overrides]` lowered
     map (e.g. the managed-HTTP stub the compiler folded `:network` into);
@@ -920,22 +920,22 @@
   position `allocate!` already uses for the registered path — keeps
   fail-loud reporting correct and is no NEW risk class: every other
   throw site between `rf/make-frame` and the `allocated?` flip
-  (`loaders/mount!` / `apply-frame-setup!`'s `:init` events) already shares
+  (`rf.story.loaders/mount!` / `apply-frame-setup!`'s `:init` events) already shares
   it."
   ([frame-id decorator-stack plan-fx-overrides events-only?]
    (allocate-inline! frame-id decorator-stack plan-fx-overrides events-only? nil))
   ([frame-id decorator-stack plan-fx-overrides events-only? classification]
-   (when config/enabled?
+   (when rf.story.config/enabled?
      (install-canonical-frame-events!)
-     (let [fx-stack     (decorators/fx-overrides-map (:fx-override decorator-stack))
+     (let [fx-stack     (rf.story.decorators/fx-overrides-map (:fx-override decorator-stack))
            decor-fx     (register-fx-overrides! fx-stack)
            fx-overrides (merge decor-fx plan-fx-overrides)
            config-map   (inline-frame-config frame-id fx-overrides)]
        (rf/make-frame (assoc config-map :id frame-id))
        (apply-variant-classification! frame-id classification)
        (if events-only?
-         (loaders/mount-ready! frame-id)
-         (loaders/mount!       frame-id))
+         (rf.story.loaders/mount-ready! frame-id)
+         (rf.story.loaders/mount!       frame-id))
        (apply-frame-setup! frame-id (:frame-setup decorator-stack))
        frame-id))))
 
@@ -952,20 +952,20 @@
   caught and projected as `:rf.error/exception` records the same way
   `destroy!` does; the walk never aborts."
   [frame-id decorator-stack loaders-teardown]
-  (when config/enabled?
-    (loaders/clear-watchers! frame-id)
+  (when rf.story.config/enabled?
+    (rf.story.loaders/clear-watchers! frame-id)
     (clear-stub-call-log! frame-id)
-    (when-let [drop (late-bind/get-fn :drop-assertion-accumulators)]
+    (when-let [drop (rf.story.late-bind/get-fn :drop-assertion-accumulators)]
       (try (drop frame-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
     ;; Evict the play-runner's per-frame run-state on teardown
     ;; (symmetric with `destroy!`); an inline frame that drove a script
     ;; leaves no stale run-state behind once it is torn down.
-    (when-let [drop (late-bind/get-fn :drop-run-state)]
+    (when-let [drop (rf.story.late-bind/get-fn :drop-run-state)]
       (try (drop frame-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
     ;; Evict the a11y panel's per-frame axe state (rf2-cpbut), symmetric with
     ;; `run-teardown-walks!`. An inline frame the dev scanned leaves no
     ;; retained detached DOM behind once it is torn down.
-    (when-let [drop (late-bind/get-fn :drop-a11y-state)]
+    (when-let [drop (rf.story.late-bind/get-fn :drop-a11y-state)]
       (try (drop frame-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
     (when (seq loaders-teardown)
       (try (apply-loaders-teardown! frame-id loaders-teardown)
@@ -998,16 +998,16 @@
   cleanup. Exceptions in each walk are caught + projected onto the
   variant's `[:rf.story/assertions]`; the walks never abort."
   [variant-id]
-  (loaders/clear-watchers! variant-id)
+  (rf.story.loaders/clear-watchers! variant-id)
   (clear-stub-call-log! variant-id)
-  (when-let [drop (late-bind/get-fn :drop-assertion-accumulators)]
+  (when-let [drop (rf.story.late-bind/get-fn :drop-assertion-accumulators)]
     (try (drop variant-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
   ;; Evict the play-runner's per-frame run-state on teardown
   ;; (run-state / runs-by-play / active-play / step-boundaries) so a
   ;; torn-down frame leaves no stale terminal play status behind. Routed
   ;; through the `:drop-run-state` late-bind hook (frames cannot :require
   ;; runner-events — cycle).
-  (when-let [drop (late-bind/get-fn :drop-run-state)]
+  (when-let [drop (rf.story.late-bind/get-fn :drop-run-state)]
     (try (drop variant-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
   ;; Evict the a11y panel's per-frame axe state (rf2-cpbut). Unlike the two
   ;; evictions above, the cost here is not a stale verdict but RETAINED DOM:
@@ -1017,13 +1017,13 @@
   ;; for the life of the page. `ui/a11y` is CLJS-only, so — like the reader
   ;; seam in `play/browser` — the call routes through a late-bind hook
   ;; rather than a require this `.cljc` cannot make.
-  (when-let [drop (late-bind/get-fn :drop-a11y-state)]
+  (when-let [drop (rf.story.late-bind/get-fn :drop-a11y-state)]
     (try (drop variant-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
   ;; Step 3 — variant body :loaders-teardown. Runs BEFORE
   ;; decorator teardown so loader-installed narrower state is cleaned
   ;; up before decorator-installed wider state.
   (try
-    (let [v-body (registrar/handler-meta :variant variant-id)
+    (let [v-body (rf.story.registrar/handler-meta :variant variant-id)
           evs    (:loaders-teardown v-body)]
       (when (seq evs)
         (apply-loaders-teardown! variant-id evs)))
@@ -1040,7 +1040,7 @@
   ;; following allocate! re-stashes the new stack.
   (try
     (let [stack (or (get @allocated-decorator-stacks variant-id)
-                    (decorators/resolve-decorators variant-id))]
+                    (rf.story.decorators/resolve-decorators variant-id))]
       (swap! allocated-decorator-stacks dissoc variant-id)
       (apply-frame-teardown! variant-id (:frame-setup stack)))
     (catch #?(:clj Throwable :cljs :default) _ nil))
@@ -1052,7 +1052,7 @@
 
   1. Drop per-variant assertion accumulators (`drop-assertion-accumulators`
      late-bind shim) + per-frame stub-call log.
-  2. Clear lifecycle watchers (`loaders/clear-watchers!`).
+  2. Clear lifecycle watchers (`rf.story.loaders/clear-watchers!`).
   3. Dispatch-sync the variant body's `:loaders-teardown` events in
      declared order. Exceptions are caught and projected
      into the variant frame's `:rf.story/assertions` as
@@ -1076,7 +1076,7 @@
 
   Returns nil."
   [variant-id]
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (run-teardown-walks! variant-id)
     (rf/destroy-frame! variant-id)
     nil))
@@ -1105,14 +1105,14 @@
   Instead we reset in place. We run the SAME teardown walks `destroy!`
   runs (so loader/decorator-installed external resources are cleaned up
   symmetrically), then overwrite BOTH frame-state partitions with `{}`
-  via the raw `frame/replace-frame-state!` write boundary — the same
+  via the raw `rf.frame/replace-frame-state!` write boundary — the same
   atomic single-container install the epoch surface uses, but WITHOUT the
   epoch coupling. Because the physical container, its projection
   reactions, and the sub-cache all survive, the live mounted view's
   reactions recompute over the reset value and re-render. A fresh frame
   starts with app-db `{}` + runtime-db `{}` (Spec 002 §Frames always
   start with app-db = {}); resetting runtime-db to `{}` drops the
-  lifecycle machine snapshot, so `loaders/current-state` reports
+  lifecycle machine snapshot, so `rf.story.loaders/current-state` reports
   `:pre-mount` and the re-run's loaders fire (no `:ready` short-circuit).
 
   No-op (returns nil) when the frame is not registered — the caller
@@ -1120,15 +1120,15 @@
   `allocate!` that follows builds the clean frame for the never-seen
   case. Returns nil."
   [variant-id]
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (run-teardown-walks! variant-id)
     ;; Overwrite both partitions with the fresh-frame empty state through
     ;; the one physical frame-state container — preserves frame identity,
     ;; sub-cache, and projection reactions (live view reactions survive).
-    (frame/replace-frame-state!
+    (rf.frame/replace-frame-state!
       variant-id
-      {frame/app-partition-key     {}
-       frame/runtime-partition-key {}})
+      {rf.frame/app-partition-key     {}
+       rf.frame/runtime-partition-key {}})
     nil))
 
 ;; ---- destroy + re-allocate -----------------------------------------------
@@ -1191,4 +1191,4 @@
 (defn variant-body
   "Return the registered variant body, or nil if unregistered."
   [variant-id]
-  (registrar/handler-meta :variant variant-id))
+  (rf.story.registrar/handler-meta :variant variant-id))

--- a/tools/story/src/re_frame/story/fx_stubs.cljc
+++ b/tools/story/src/re_frame/story/fx_stubs.cljc
@@ -64,9 +64,9 @@
   decorator registration single-shot while allowing per-reference
   configuration."
   (:require [re-frame.core         :as rf]
-            [re-frame.story.config :as config]
-            [re-frame.story.frames :as frames]
-            [re-frame.story.registrar :as registrar]))
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.frames :as rf.story.frames]
+            [re-frame.story.registrar :as rf.story.registrar]))
 
 ;; ---------------------------------------------------------------------------
 ;; The decorator id
@@ -107,8 +107,8 @@
 
   Called from `re-frame.story/install-canonical-vocabulary!` at boot."
   []
-  (when config/enabled?
-    (registrar/reg-decorator* force-fx-stub-id force-fx-stub-body))
+  (when rf.story.config/enabled?
+    (rf.story.registrar/reg-decorator* force-fx-stub-id force-fx-stub-body))
   nil)
 
 ;; ---------------------------------------------------------------------------
@@ -148,14 +148,14 @@
   original `:fx-id`; we set-ify."
   [variant-id]
   (let [entries (try
-                  (frames/stub-call-log-for variant-id)
+                  (rf.story.frames/stub-call-log-for variant-id)
                   (catch #?(:clj Throwable :cljs :default) _ []))]
     (set (keep :fx-id entries))))
 
 ;; ---------------------------------------------------------------------------
 ;; Stub-redirected fx-ids are owned by the stub-call log
 ;;
-;; `frames/ensure-stub-event!` registers an fx handler under
+;; `rf.story.frames/ensure-stub-event!` registers an fx handler under
 ;; `:rf.story.fx-stub/<decorator-id>` that appends to the per-frame
 ;; stub-call log. `:rf.assert/effect-emitted` projects from the epoch tape,
 ;; but a STUBBED fx lands on the tape under its REWRITTEN stub id, not its

--- a/tools/story/src/re_frame/story/generate.cljc
+++ b/tools/story/src/re_frame/story/generate.cljc
@@ -52,7 +52,7 @@
   `replay-run-artifact` into fresh `:rf.test.replay/*` frames (torn down by
   the replay path), so the JVM `clojure -M:test` gate exercises the full
   generated-run → artifact flow against a live frame synchronously."
-  (:require [re-frame.story.artifact :as artifact]))
+  (:require [re-frame.story.artifact :as rf.story.artifact]))
 
 ;; ===========================================================================
 ;; SEEDABLE PRNG  (pure — splitmix64)
@@ -142,7 +142,7 @@
   flow is about. The default `:source` records that the artifact came from
   the property runner, so a promoted variant explains it was generated."
   [{:keys [seed event-program fx-decisions shrink-path source] :as _parts}]
-  (artifact/make-run-artifact
+  (rf.story.artifact/make-run-artifact
     (cond-> {:seed          seed
              :event-program (vec event-program)
              :fx-decisions  (or fx-decisions {})
@@ -203,13 +203,13 @@
   has a replayable, seed-bearing artifact (artifacts first)."
   [gen-fn seed {:keys [fx-decisions hooks frame-config] :as _opts}]
   (let [program     (vec (gen-fn seed))
-        base        (artifact/make-run-artifact
+        base        (rf.story.artifact/make-run-artifact
                       {:event-program program
                        :fx-decisions  (or fx-decisions {})})
         replay-opts (cond-> {}
                       hooks        (assoc :hooks hooks)
                       frame-config (assoc :frame-config frame-config))
-        result      (artifact/replay-run-artifact base replay-opts)
+        result      (rf.story.artifact/replay-run-artifact base replay-opts)
         artifact    (generated-artifact
                       {:seed          seed
                        :event-program program
@@ -248,10 +248,10 @@
                        hooks        (assoc :hooks hooks)
                        frame-config (assoc :frame-config frame-config))
          replay!     (fn [program]
-                       (let [a (artifact/make-run-artifact
+                       (let [a (rf.story.artifact/make-run-artifact
                                  {:event-program program
                                   :fx-decisions  (or fx-decisions {})})]
-                         (artifact/replay-run-artifact a replay-opts)))]
+                         (rf.story.artifact/replay-run-artifact a replay-opts)))]
      (loop [current     (vec failing-program)
             chunk-size  (max 1 (quot (count failing-program) 2))
             shrink-path []
@@ -425,13 +425,13 @@
   (let [cells   (seq fault-lattice)
         results (mapv
                   (fn [[cell-id fx-decisions]]
-                    (let [a       (artifact/make-run-artifact
+                    (let [a       (rf.story.artifact/make-run-artifact
                                     {:event-program base-program
                                      :fx-decisions  (or fx-decisions {})})
                           ropts   (cond-> {}
                                     hooks        (assoc :hooks hooks)
                                     frame-config (assoc :frame-config frame-config))
-                          result  (artifact/replay-run-artifact a ropts)
+                          result  (rf.story.artifact/replay-run-artifact a ropts)
                           artifact (generated-artifact
                                      {:seed          seed
                                       :event-program base-program

--- a/tools/story/src/re_frame/story/generate/test_check.cljc
+++ b/tools/story/src/re_frame/story/generate/test_check.cljc
@@ -48,7 +48,7 @@
   runs on the JVM, so this adapter targets the JVM half of `clojure -M:test`.
   On CLJS the adapter throws a clear message — the dependency-free `gen-fn`
   path is the cross-host default and needs no library."
-  (:require [re-frame.error :as error]))
+  (:require [re-frame.error :as rf.error]))
 
 (def ^:private absent-msg
   (str "re-frame.story.generate.test-check requires org.clojure/test.check on "
@@ -66,7 +66,7 @@
      (or (try (requiring-resolve sym)
               (catch java.io.FileNotFoundException _ nil)
               (catch Throwable _ nil))
-         (error/throw-error!
+         (rf.error/throw-error!
            :rf.error/story-test-check-absent
            'rf.story.generate/gen->gen-fn
            absent-msg
@@ -109,7 +109,7 @@
         (fn [seed]
           (vec (generate g size seed))))
       :cljs
-      (error/throw-error!
+      (rf.error/throw-error!
         :rf.error/story-test-check-unsupported-host
         'rf.story.generate/gen->gen-fn
         (str "re-frame.story.generate.test-check is JVM-only — CLJS cannot "

--- a/tools/story/src/re_frame/story/golden.cljc
+++ b/tools/story/src/re_frame/story/golden.cljc
@@ -38,7 +38,7 @@
 
   ## The behavioural slice
 
-  The slice frozen into a golden is `fingerprint/run-hash-input-keys` — the
+  The slice frozen into a golden is `rf.story.fingerprint/run-hash-input-keys` — the
   behavioural surface (`:status`, final `:app-db`, the `:epoch-tape`, the
   `:assertions` / `:checks` verdicts, the projected `:effects` /
   `:schema-violations` / `:warnings`, and the resolved `:sub-overrides` /
@@ -85,10 +85,10 @@
   Story path. The determinism dependency is the pure `->artifact` plan
   coercion (no runtime), reused so the plan capture path folds a plan to a
   replayable artifact through the SAME seam the determinism gate uses."
-  (:require [re-frame.story.artifact    :as artifact]
-            [re-frame.story.determinism :as determinism]
-            [re-frame.story.diff        :as diff]
-            [re-frame.story.fingerprint :as fingerprint]))
+  (:require [re-frame.story.artifact    :as rf.story.artifact]
+            [re-frame.story.determinism :as rf.story.determinism]
+            [re-frame.story.diff        :as rf.story.diff]
+            [re-frame.story.fingerprint :as rf.story.fingerprint]))
 
 ;; ===========================================================================
 ;; THE :rf.test/golden SLICE
@@ -103,7 +103,7 @@
 
 (defn behavioural-slice
   "The behavioural surface of a `run`-result — `select-keys` over
-  `fingerprint/run-hash-input-keys`. Pure data → data.
+  `rf.story.fingerprint/run-hash-input-keys`. Pure data → data.
 
   This is the SAME slice `run-hash` hashes and the determinism gate +
   semantic diff compare, so a golden freezes exactly the surface those two
@@ -111,7 +111,7 @@
   `:run-artifact` back-link, `:replay-steps`) is excluded — it legitimately
   differs per run and would make a golden brittle."
   [run]
-  (select-keys run fingerprint/run-hash-input-keys))
+  (select-keys run rf.story.fingerprint/run-hash-input-keys))
 
 (defn slice-canonical
   "The `canonicalize`d behavioural slice of a `run` — the frozen value a
@@ -123,7 +123,7 @@
   the SAME canonical slice. This is THE equality the golden contract rests
   on."
   [run]
-  (fingerprint/canonicalize (behavioural-slice run)))
+  (rf.story.fingerprint/canonicalize (behavioural-slice run)))
 
 (defn make-golden
   "Construct a `:rf.test/golden` slice from a `run`-result. Pure data →
@@ -132,7 +132,7 @@
   The slice freezes the `canonicalize`d behavioural surface (`:canonical`)
   plus the cheap `:run-hash` discriminator and the `:run-hash-input-keys`
   the slice was taken over. `matches?` / `compare-golden` compare that
-  frozen `:slice-keys` against the CURRENT `fingerprint/run-hash-input-keys`
+  frozen `:slice-keys` against the CURRENT `rf.story.fingerprint/run-hash-input-keys`
   (see `slice-keys-current?`), so a future slice-key change is detectable,
   not silent: a slice-surface drift reads as a distinct `:stale-slice-keys`
   verdict ('recapture the golden') rather than a confusing fake regression.
@@ -164,8 +164,8 @@
   ([run {:keys [meta keep-run-result] :as _opts}]
    (cond-> {:golden/kind golden-kind
             :canonical   (slice-canonical run)
-            :run-hash    (fingerprint/run-hash run)
-            :slice-keys  fingerprint/run-hash-input-keys}
+            :run-hash    (rf.story.fingerprint/run-hash run)
+            :slice-keys  rf.story.fingerprint/run-hash-input-keys}
      (seq meta)      (assoc :golden/meta meta)
      keep-run-result (assoc :run-result (behavioural-slice run)))))
 
@@ -208,11 +208,11 @@
   reports false GREEN forever (the silent-wrong path this guard closes)."
   [target opts]
   (cond
-    (artifact/run-artifact? target)
-    (artifact/replay-run-artifact target opts)
+    (rf.story.artifact/run-artifact? target)
+    (rf.story.artifact/replay-run-artifact target opts)
 
     (and (map? target) (contains? target :world))
-    (artifact/replay-run-artifact (determinism/->artifact target) opts)
+    (rf.story.artifact/replay-run-artifact (rf.story.determinism/->artifact target) opts)
 
     (and (map? target) (contains? target :status))
     target
@@ -280,7 +280,7 @@
 
   `run-hash` and `slice-canonical` both `canonicalize` the same behavioural
   slice; computing the canonical slice once and hashing it via
-  `fingerprint/hash-canonical` (which hashes an ALREADY-canonical value with
+  `rf.story.fingerprint/hash-canonical` (which hashes an ALREADY-canonical value with
   NO second canonicalization pass) avoids running `canonicalize` twice per
   match / compare. The equivalence `hash-canonical(canonicalize(slice)) =
   run-hash(result)` is locked by the golden_test run-hash agreement
@@ -290,11 +290,11 @@
   [result]
   (let [canon (slice-canonical result)]
     {:canonical canon
-     :run-hash  (fingerprint/hash-canonical canon)}))
+     :run-hash  (rf.story.fingerprint/hash-canonical canon)}))
 
 (defn slice-keys-current?
   "True iff the `golden`'s frozen `:slice-keys` (the behavioural surface the
-  golden was captured over) match the CURRENT `fingerprint/run-hash-input-keys`
+  golden was captured over) match the CURRENT `rf.story.fingerprint/run-hash-input-keys`
   (spec/017 §Golden slices). Pure data → data.
 
   A golden's `:canonical` was taken via `select-keys` over the slice-key set
@@ -302,7 +302,7 @@
   (changing `run-hash-input-keys`), an old golden's frozen `:canonical` was
   taken over the OLD surface while an incoming run is sliced over the NEW one
   — the two no longer compare apples-to-apples. Unlike a canonical-FORM
-  change (version-tagged via `fingerprint/canonical-version`, which forces a
+  change (version-tagged via `rf.story.fingerprint/canonical-version`, which forces a
   hash mismatch), a slice-SURFACE change carries no version tag, so without
   this guard the drift would read as a confusing fake regression rather than
   'baseline surface changed — recapture'.
@@ -313,7 +313,7 @@
   [golden]
   (let [frozen (:slice-keys golden)]
     (or (nil? frozen)
-        (= frozen fingerprint/run-hash-input-keys))))
+        (= frozen rf.story.fingerprint/run-hash-input-keys))))
 
 (defn- matches?
   "The ONE GREEN/RED authority over an ALREADY-coerced run-`result` (spec/017
@@ -363,11 +363,11 @@
   On a STALE SLICE-SURFACE: `{:match? false :stale-slice-keys true
   :golden-slice-keys <frozen> :current-slice-keys <now>}` — the golden's
   frozen `:slice-keys` no longer match the current
-  `fingerprint/run-hash-input-keys`, so its `:canonical` was taken over a
+  `rf.story.fingerprint/run-hash-input-keys`, so its `:canonical` was taken over a
   DIFFERENT behavioural surface and the comparison is not apples-to-apples.
   This is surfaced as a DISTINCT verdict (NOT a `:diff`) so a slice-surface
   drift reads as 'baseline surface changed — recapture the golden' rather
-  than a confusing fake regression. No `diff/diff-runs` is taken because
+  than a confusing fake regression. No `rf.story.diff/diff-runs` is taken because
   diffing across two surfaces would mislocalise.
 
   On MISMATCH: `{:match? false :run-hash <new> :golden-run-hash <frozen>
@@ -402,7 +402,7 @@
        {:match?             false
         :stale-slice-keys   true
         :golden-slice-keys  (:slice-keys golden)
-        :current-slice-keys fingerprint/run-hash-input-keys}
+        :current-slice-keys rf.story.fingerprint/run-hash-input-keys}
 
        (matches? golden ch)
        {:match? true :run-hash run-hash}
@@ -411,5 +411,5 @@
        (cond-> {:match?          false
                 :run-hash        run-hash
                 :golden-run-hash (:run-hash golden)}
-         base-run       (assoc :diff (diff/diff-runs base-run result))
+         base-run       (assoc :diff (rf.story.diff/diff-runs base-run result))
          (not base-run) (assoc :diff :unavailable-no-run-result))))))

--- a/tools/story/src/re_frame/story/identity.cljc
+++ b/tools/story/src/re_frame/story/identity.cljc
@@ -26,7 +26,7 @@
   `[]`, `{:k 1}` ≠ `[:k 1]`) and folds functions to a stable sentinel. The
   canonical-version tag `re-frame.story.fingerprint/canonical-version`
   (`:rf/snapshot-canonical-v2`) is the single source of truth for the
-  version: `fingerprint/hash-canonical` prepends it as the first hashed
+  version: `rf.story.fingerprint/hash-canonical` prepends it as the first hashed
   slot of EVERY hash (`content-hash`, `canonical-hash`, `plan-hash`,
   `run-hash`), so a canonical-form revision changes the snapshot
   content-hash VALUE. External visual-regression baselines re-capture on
@@ -34,7 +34,7 @@
   in-repo stored hash fixtures. The hashing CODE lives in the single
   fingerprint primitive; this ns hashes its snapshot tuple through it. The
   snapshot tuple also carries a `:rf/snapshot-canonical` data slot, which
-  reads its value straight from `fingerprint/canonical-version` (it is NOT
+  reads its value straight from `rf.story.fingerprint/canonical-version` (it is NOT
   a second, independently-versioned marker — it tracks the one tag).
 
   The volatile-field strip + `:variant-id` → `:variant/id` reconciliation
@@ -97,16 +97,16 @@
   cryptographic collision resistance still needs the specified sha-256
   path; this eight-character content hash is not a security primitive.
 
-  The canonical-form version tag `fingerprint/canonical-version`
+  The canonical-form version tag `rf.story.fingerprint/canonical-version`
   (`:rf/snapshot-canonical-v2`) is prepended by
-  `fingerprint/hash-canonical` as the first slot of the hashed structure, so
+  `rf.story.fingerprint/hash-canonical` as the first slot of the hashed structure, so
   a canonical-form revision bumps the version and old baselines are
   detectably stale rather than silently mis-compared."
-  (:require [re-frame.late-bind         :as late-bind]
-            [re-frame.story.args        :as args]
-            [re-frame.story.fingerprint :as fingerprint]
-            [re-frame.story.registrar   :as registrar]
-            [re-frame.story.tags        :as tags]))
+  (:require [re-frame.late-bind         :as rf.late-bind]
+            [re-frame.story.args        :as rf.story.args]
+            [re-frame.story.fingerprint :as rf.story.fingerprint]
+            [re-frame.story.registrar   :as rf.story.registrar]
+            [re-frame.story.tags        :as rf.story.tags]))
 
 ;; ---- snapshot tuple -------------------------------------------------------
 
@@ -175,7 +175,7 @@
   - `:doc` / `:source` — prose + coords; runtime-environmental.
   - `:extends` — resolved away into `:effective-args` before hashing."
   [variant-id]
-  (let [body (registrar/handler-meta :variant variant-id)]
+  (let [body (rf.story.registrar/handler-meta :variant variant-id)]
     (when body
       (select-keys body
                    [:setup :script :plays
@@ -212,8 +212,8 @@
   declares its own tags, so story tags are not inherited) would still
   perturb that variant's hash."
   [variant-id]
-  (let [story-id (args/parent-story-id variant-id)
-        body     (when story-id (registrar/handler-meta :story story-id))]
+  (let [story-id (rf.story.args/parent-story-id variant-id)
+        body     (when story-id (rf.story.registrar/handler-meta :story story-id))]
     (when body
       (select-keys body [:component :decorators]))))
 
@@ -248,7 +248,7 @@
   the variant frame holds none / is not yet allocated — the digest still
   participates in the hash and stays stable across runs)."
   [target-frame-id]
-  (when-let [f (late-bind/get-fn :schemas/app-schemas-digest)]
+  (when-let [f (rf.late-bind/get-fn :schemas/app-schemas-digest)]
     (f target-frame-id)))
 
 (defn- effective-tags-slice
@@ -265,12 +265,12 @@
   - raw `:!x` authoring syntax never reaches the hash.
 
   Reads live side-tables via the registrar (`:variant` + `:story`
-  registrations). Returns a set; `fingerprint/content-hash` canonicalises
+  registrations). Returns a set; `rf.story.fingerprint/content-hash` canonicalises
   it with a stable order."
   [variant-id]
-  (tags/effective-tags variant-id
-                       {:variant (registrar/registrations :variant)
-                        :story   (registrar/registrations :story)}))
+  (rf.story.tags/effective-tags variant-id
+                       {:variant (rf.story.registrar/registrations :variant)
+                        :story   (rf.story.registrar/registrations :story)}))
 
 (defn snapshot-tuple
   "Build the canonical tuple that feeds `content-hash` for a variant.
@@ -293,14 +293,14 @@
   ([variant-id {:keys [active-modes cell-overrides substrate] :as _opts}]
    (let [variant      (variant-body-slice variant-id)
          story        (story-body-slice variant-id)
-         effective    (args/resolve-args variant-id
+         effective    (rf.story.args/resolve-args variant-id
                                          {:active-modes   active-modes
                                           :cell-overrides cell-overrides})
          ;; EP-0002 — the variant frame is the explicit
          ;; target for the frame-local app-db schema digest (no ambient
          ;; resolution / no `:rf/default` synthesis).
          schema-digest (view-schema-digest variant-id)]
-     {:rf/snapshot-canonical fingerprint/canonical-version
+     {:rf/snapshot-canonical rf.story.fingerprint/canonical-version
       :variant-id            variant-id
       :variant               variant
       :story                 story
@@ -344,7 +344,7 @@
   ([variant-id] (snapshot-identity variant-id nil))
   ([variant-id {:keys [active-modes substrate] :as opts}]
    (let [tuple (snapshot-tuple variant-id opts)
-         hex   (fingerprint/content-hash tuple)]
+         hex   (rf.story.fingerprint/content-hash tuple)]
      {:variant-id    variant-id
       :active-modes  (vec (or active-modes []))
       :substrate     substrate

--- a/tools/story/src/re_frame/story/invariants.cljc
+++ b/tools/story/src/re_frame/story/invariants.cljc
@@ -66,7 +66,7 @@
   core."
   #?(:cljs (:require-macros [re-frame.story.invariants]))
   (:require [re-frame.core :as rf]
-            [re-frame.error :as error]
+            [re-frame.error :as rf.error]
             #?(:clj  [clojure.test :as ctest]
                :cljs [cljs.test :as ctest :include-macros true])))
 
@@ -98,7 +98,7 @@
           (= 1 (count rst))
           [::no-expected (first rst)]
           :else
-          (error/throw-error!
+          (rf.error/throw-error!
             :rf.error/story-bad-invariant
             'rf.story/with-invariants
             (str "re-frame2-story :db invariant shorthand must be "
@@ -138,7 +138,7 @@
     (map? invariant)
     (let [check (or (:check invariant) (:pred invariant))]
       (when-not (fn? check)
-        (error/throw-error!
+        (rf.error/throw-error!
           :rf.error/story-bad-invariant
           'rf.story/with-invariants
           (str "re-frame2-story invariant map needs a `:check` (or `:pred`) "
@@ -149,7 +149,7 @@
       (merge {:id (keyword (str "invariant-" idx))} invariant {:check check}))
 
     :else
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/story-bad-invariant
       'rf.story/with-invariants
       (str "re-frame2-story invariant must be a fn, a `[:db path …]` vector, "
@@ -448,7 +448,7 @@
      {:arglists '([[invariant-spec*] body+])}
      [invariants & body]
      (when-not (vector? invariants)
-       (error/throw-error!
+       (rf.error/throw-error!
          :rf.error/story-bad-invariants-vector
          'rf.story/with-invariants
          (str "with-invariants expects a vector of invariant specs as its "

--- a/tools/story/src/re_frame/story/layout_debug.cljc
+++ b/tools/story/src/re_frame/story/layout_debug.cljc
@@ -43,8 +43,8 @@
   flipped off because nothing reachable from a `:advanced` build root
   calls `install-canonical-layout-debug!`."
   (:require [clojure.string           :as str]
-            [re-frame.story.config    :as config]
-            [re-frame.story.registrar :as registrar]))
+            [re-frame.story.config    :as rf.story.config]
+            [re-frame.story.registrar :as rf.story.registrar]))
 
 ;; ---- decorator ids -------------------------------------------------------
 
@@ -209,23 +209,23 @@
   fn-valued slot Story permits at the decorator's registration site
   (per `001-Authoring.md` §Registration macros).
 
-  Production builds (`config/enabled?` false) skip registration — the
+  Production builds (`rf.story.config/enabled?` false) skip registration — the
   decorator bodies never enter the registrar. Per `005-SOTA-Features.md` §Production elision under `:advanced` the
   Story registrar itself is DCE'd under `:advanced` with `enabled?`
   off, so this gate is belt-and-braces."
   []
-  (when config/enabled?
-    (registrar/reg-decorator*
+  (when rf.story.config/enabled?
+    (rf.story.registrar/reg-decorator*
       id-measure
       {:doc  "Storybook-style hover rulers + box-dimension labels."
        :kind :hiccup
        :wrap measure-wrap})
-    (registrar/reg-decorator*
+    (rf.story.registrar/reg-decorator*
       id-outline
       {:doc  "Pesticide-style coloured outlines on every descendant."
        :kind :hiccup
        :wrap outline-wrap})
-    (registrar/reg-decorator*
+    (rf.story.registrar/reg-decorator*
       id-pseudo
       {:doc  (str "Pseudo-state forcing — ref-args is a set from "
                   "#{:hover :focus :active :visited}; default #{:hover}.")

--- a/tools/story/src/re_frame/story/lifecycle.cljc
+++ b/tools/story/src/re_frame/story/lifecycle.cljc
@@ -10,10 +10,10 @@
 
   Every fn delegates 1:1 to its owning module. Rendering stays in the UI
   shell and `re-frame.story.render`; it is not a hidden runtime phase."
-  (:require [re-frame.story.frames    :as frames]
-            [re-frame.story.loaders   :as loaders]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.story.runtime   :as runtime]))
+  (:require [re-frame.story.frames    :as rf.story.frames]
+            [re-frame.story.loaders   :as rf.story.loaders]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.runtime   :as rf.story.runtime]))
 
 ;; ---- variant → EDN serialisation ----------------------------------------
 ;;
@@ -30,12 +30,12 @@
 
   Returns nil when the variant is unregistered."
   [variant-id]
-  (registrar/handler-meta :variant variant-id))
+  (rf.story.registrar/handler-meta :variant variant-id))
 
 (defn workspace->edn
   "Per `002-Runtime.md` §Programmatic API — same for workspaces."
   [workspace-id]
-  (registrar/handler-meta :workspace workspace-id))
+  (rf.story.registrar/handler-meta :workspace workspace-id))
 
 ;; ---- run-variant / reset-variant / snapshot-identity --------------------
 ;;
@@ -55,13 +55,13 @@
 
   The result contract is owned by `re-frame.story.result`; rendering is
   driven separately by `render-variant` or the UI shell."
-  ([variant-id]       (runtime/run-variant variant-id nil))
-  ([variant-id opts]  (runtime/run-variant variant-id opts)))
+  ([variant-id]       (rf.story.runtime/run-variant variant-id nil))
+  ([variant-id opts]  (rf.story.runtime/run-variant variant-id opts)))
 
 (defn reset-variant
   "Tear down + re-run `variant-id`. Per `002-Runtime.md` §Programmatic API."
-  ([variant-id]       (runtime/reset-variant variant-id nil))
-  ([variant-id opts]  (runtime/reset-variant variant-id opts)))
+  ([variant-id]       (rf.story.runtime/reset-variant variant-id nil))
+  ([variant-id opts]  (rf.story.runtime/reset-variant variant-id opts)))
 
 (defn run-inline-plan
   "Per spec/017 §Inline plan — run an inline plan MAP and
@@ -70,8 +70,8 @@
   fresh anonymous frame, and the frame is torn down on resolve; it is
   NEVER registered in the Story side-table. Delegates to
   `re-frame.story.runtime/run-inline-plan`."
-  ([inline-plan]      (runtime/run-inline-plan inline-plan nil))
-  ([inline-plan opts] (runtime/run-inline-plan inline-plan opts)))
+  ([inline-plan]      (rf.story.runtime/run-inline-plan inline-plan nil))
+  ([inline-plan opts] (rf.story.runtime/run-inline-plan inline-plan opts)))
 
 (defn watch-variant
   "Subscribe to lifecycle transitions for `variant-id`'s frame. Per
@@ -79,7 +79,7 @@
   `{:frame-id <id> :from <state> :to <state> :event <inner-event>}`
   on every transition. Returns a 0-arity unsubscribe fn."
   [variant-id callback]
-  (runtime/watch-variant variant-id callback))
+  (rf.story.runtime/watch-variant variant-id callback))
 
 (defn snapshot-identity
   "Per `002-Runtime.md` §Snapshot-identity computation. Content-hash over the canonicalised
@@ -88,29 +88,29 @@
 
   Returns `{:variant-id ... :active-modes [...] :substrate ...
   :content-hash \"<8-char hex>\"}`."
-  ([variant-id]       (runtime/snapshot-identity variant-id))
-  ([variant-id opts]  (runtime/snapshot-identity variant-id opts)))
+  ([variant-id]       (rf.story.runtime/snapshot-identity variant-id))
+  ([variant-id opts]  (rf.story.runtime/snapshot-identity variant-id opts)))
 
 (defn destroy-variant!
   "Tear down a variant frame allocated via `run-variant`. Per IMPL-
   SPEC §5.1 — the caller (UI shell / test fixture) owns teardown."
   [variant-id]
-  (frames/destroy! variant-id))
+  (rf.story.frames/destroy! variant-id))
 
 (defn variant-frames
   "Return every registered variant frame id. The UI shell uses this
   to lay out the active variant pane."
   []
-  (frames/variant-frames))
+  (rf.story.frames/variant-frames))
 
 (defn variant-frame?
   "True iff `frame-id` is a variant frame."
   [frame-id]
-  (frames/variant-frame? frame-id))
+  (rf.story.frames/variant-frame? frame-id))
 
 (defn lifecycle-state
   "Return the lifecycle's current discrete state for the variant's
   frame (`:pre-mount`, `:mounting`, `:loading`, `:ready`, `:error`).
   Returns `:pre-mount` if the variant hasn't been run yet."
   [variant-id]
-  (loaders/current-state variant-id))
+  (rf.story.loaders/current-state variant-id))

--- a/tools/story/src/re_frame/story/loaders.cljc
+++ b/tools/story/src/re_frame/story/loaders.cljc
@@ -55,10 +55,10 @@
   CLJS builds with the flag false never register the machine; the
   Story runtime entry points read `(rf/handler-meta :event
   :rf.story.lifecycle/machine)` and find nothing, returning early."
-  (:require [re-frame.story.config    :as config]
-            [re-frame.story.assertions :as assertions]
-            #?(:clj  [re-frame.machines :as machines]
-               :cljs [re-frame.machines :as machines])
+  (:require [re-frame.story.config    :as rf.story.config]
+            [re-frame.story.assertions :as rf.story.assertions]
+            #?(:clj  [re-frame.machines :as rf.machines]
+               :cljs [re-frame.machines :as rf.machines])
             [re-frame.core            :as rf]))
 
 ;; ---- canonical ids --------------------------------------------------------
@@ -191,8 +191,8 @@
   every app-image-scoped variant frame's generation, and the lifecycle drives
   past `:pre-mount`."
   []
-  (when config/enabled?
-    (machines/reg-machine* lifecycle-machine-id
+  (when rf.story.config/enabled?
+    (rf.machines/reg-machine* lifecycle-machine-id
                            {:ns 're-frame.story.loaders}
                            lifecycle-machine)))
 
@@ -275,7 +275,7 @@
     (dispatch-lifecycle-event! frame-id [:rf.story.lifecycle/loaders-complete])
     (dispatch-lifecycle-event! frame-id [:rf.story.lifecycle/errored err])"
   [frame-id inner-event]
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (let [from (current-state frame-id)
           ;; Machine handler convention per Spec 005: outer event is
           ;; [<machine-id> <inner-event>]. The machine reads inner from
@@ -295,7 +295,7 @@
   "Register the `::set-lifecycle-state-mirror` event handler.
   Idempotent."
   []
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (rf/reg-event
       ::set-lifecycle-state-mirror
       (fn [{:keys [db]} [_ state]]
@@ -394,12 +394,12 @@
 
 (defn- dispatched-events-set
   "Read the dispatched-events set for `frame-id` from the epoch tape (the
-  SSOT — `assertions/dispatched-events` projects each committed epoch's
+  SSOT — `rf.story.assertions/dispatched-events` projects each committed epoch's
   `:trigger-event`). This reads the SAME tape projection the
   run-result evidence + `:rf.assert/dispatched?` read."
   [frame-id]
   (try
-    (set (assertions/dispatched-events frame-id))
+    (set (rf.story.assertions/dispatched-events frame-id))
     (catch #?(:clj Throwable :cljs :default) _ #{})))
 
 (defn- vector-of-events-satisfied?
@@ -426,7 +426,7 @@
   - a vector of event vectors — `[[:fixture/loaded] [:auth/ready]]`.
     Interpreted as 'loaders complete when ALL listed events have fired
     against the variant's frame.' The runtime checks the epoch-tape
-    dispatched-events projection (`assertions/dispatched-events`, the
+    dispatched-events projection (`rf.story.assertions/dispatched-events`, the
     SSOT — the SAME tape the run-result evidence reads)."
   [frame-id variant-body]
   (let [pred (:loaders-complete-when variant-body)]

--- a/tools/story/src/re_frame/story/macros.clj
+++ b/tools/story/src/re_frame/story/macros.clj
@@ -37,7 +37,7 @@
   of the parent `reg-story*` call. Per `001-Authoring.md` §Registration macros this preserves
   hot-reload-by-variant: each variant is a separate top-level form so
   save-and-reload only invalidates the changed slot."
-  (:require [re-frame.source-coords :as source-coords]))
+  (:require [re-frame.source-coords :as rf.source-coords]))
 
 ;; ---- source-coord helper -------------------------------------------------
 
@@ -104,7 +104,7 @@
   `:advanced` — so there is no production coord-form counterpart to pick
   between here the way core's `reg-*` macros must."
   [form-meta file ns-sym]
-  (source-coords/coords-form form-meta file ns-sym))
+  (rf.source-coords/coords-form form-meta file ns-sym))
 
 (defn variant-id-for
   "Build the variant id from a story id and a variant-name key.

--- a/tools/story/src/re_frame/story/modes/standard.cljc
+++ b/tools/story/src/re_frame/story/modes/standard.cljc
@@ -9,7 +9,7 @@
   `(re-frame.story.modes.standard/register-all!)` (or one of the
   axis-scoped installers) at boot. Each registration is a plain
   `reg-mode` tuple — the toolbar surface picks them up via
-  `(registrar/registrations :mode)` like any other mode.
+  `(rf.story.registrar/registrations :mode)` like any other mode.
 
   ## Why opt-in, not auto-installed
 
@@ -34,7 +34,7 @@
   - `register-all!`        — call both. Convenience.
 
   Each installer is idempotent — re-registering a mode-id overwrites
-  the body (per `registrar/reg-mode*`), so calling these at hot-reload
+  the body (per `rf.story.registrar/reg-mode*`), so calling these at hot-reload
   time is safe.
 
   ## Effective-args contract
@@ -49,7 +49,7 @@
   accessor). Projects that want richer payloads (e.g. exact pixel
   dimensions for a viewport) wrap or replace this namespace's
   registrations with their own."
-  (:require [re-frame.story.registrar :as registrar]))
+  (:require [re-frame.story.registrar :as rf.story.registrar]))
 
 ;; ---- viewport canonical set ----------------------------------------------
 ;;
@@ -86,7 +86,7 @@
   registered."
   []
   (doseq [[id body] viewports]
-    (registrar/reg-mode* id body))
+    (rf.story.registrar/reg-mode* id body))
   (set (keys viewports)))
 
 ;; ---- background canonical set --------------------------------------------
@@ -117,7 +117,7 @@
   set of mode-ids registered."
   []
   (doseq [[id body] backgrounds]
-    (registrar/reg-mode* id body))
+    (rf.story.registrar/reg-mode* id body))
   (set (keys backgrounds)))
 
 ;; ---- convenience ---------------------------------------------------------

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -115,15 +115,15 @@
   contract is empty in a production bundle; callers thread an explicit
   `:lookup` (a `{variant-id → raw-body}` map or a 1-arg fn) for pure
   tests."
-  (:require [re-frame.story.args         :as args]
-            [re-frame.story.assertions   :as assertions]
-            [re-frame.story.config       :as config]
-            [re-frame.story.registrar    :as registrar]
-            [re-frame.story.requirements :as requirements]
-            [re-frame.story.malli-schema :as msu]
-            [re-frame.story.tags         :as tags]
-            [re-frame.story.play.runner  :as runner]
-            [re-frame.registrar          :as framework-registrar]))
+  (:require [re-frame.story.args         :as rf.story.args]
+            [re-frame.story.assertions   :as rf.story.assertions]
+            [re-frame.story.config       :as rf.story.config]
+            [re-frame.story.registrar    :as rf.story.registrar]
+            [re-frame.story.requirements :as rf.story.requirements]
+            [re-frame.story.malli-schema :as rf.story.malli-schema]
+            [re-frame.story.tags         :as rf.story.tags]
+            [re-frame.story.play.runner  :as rf.story.play.runner]
+            [re-frame.registrar          :as rf.registrar]))
 
 ;; ============================================================================
 ;; Errors
@@ -274,17 +274,17 @@
 
 (defn- merge-context
   "Deep-merge one context value root→child. Maps recurse (per
-  `args/deep-merge`); everything else is child-wins replacement."
+  `rf.story.args/deep-merge`); everything else is child-wins replacement."
   [parent child]
   (if (and (map? parent) (map? child))
-    (args/deep-merge parent child)
+    (rf.story.args/deep-merge parent child)
     (if (some? child) child parent)))
 
 ;; Tags are additive through `:extends` (§Merge rules — append/union), then
 ;; resolved through the SHARED `re-frame.story.tags` resolver (`:!x` removal
 ;; markers stripped + their base subtracted, story fallback when the chain
 ;; declares none). `compile-body` unions `:tags` across the resolved `bodies`
-;; and hands the union to `tags/resolve-markers` so the plan's `:tags` is the
+;; and hands the union to `rf.story.tags/resolve-markers` so the plan's `:tags` is the
 ;; EFFECTIVE set — identical to what `variants-with-tags`, docs chips, and the
 ;; sidebar filter compute through the same resolver.
 
@@ -293,7 +293,7 @@
 ;; ============================================================================
 ;;
 ;; `:script` (single) / `:plays` (named) both lower to `:script`. We reuse
-;; the runtime's `runner/variant-body->plays` so bare event-vector
+;; the runtime's `rf.story.play.runner/variant-body->plays` so bare event-vector
 ;; shorthand and the `:dispatch`/`:dispatch-sync`/`:wait`/`:assert-*` tag
 ;; grammar coerce exactly as the runtime sees them. Per spec §Public
 ;; vocabulary + §Setup and script.
@@ -307,12 +307,12 @@
   "FAIL plan construction when any COERCED (but not-yet-folded) script step
   is structurally malformed — an unknown step tag or a tag with the wrong
   arity/shape (spec/017 §Script step grammar). Reuses the
-  runner's `validate-script` (`runner/step-arity-ok?` + `known-step?`) — the
+  runner's `validate-script` (`rf.story.play.runner/step-arity-ok?` + `known-step?`) — the
   ONE encoding of the per-tag shape constraints — so the plan compiler and
   the runtime runner agree on what a well-formed step is.
 
-  This gate MUST run BEFORE `assertions/fold-script`: the fold helpers
-  (`assertions/assert-db->atom` / `assert-dom->atom`) assume a well-formed
+  This gate MUST run BEFORE `rf.story.assertions/fold-script`: the fold helpers
+  (`rf.story.assertions/assert-db->atom` / `assert-dom->atom`) assume a well-formed
   shipping step (a 3-/4-arity `:assert-db`, a recognised `:assert-dom`
   mode), so a malformed one folded raw throws an opaque HOST exception
   (IndexOutOfBounds / `No matching clause`) at plan-compile rather than the
@@ -320,7 +320,7 @@
   the typo through the SAME error vocabulary every other plan error uses
   (cf `reject-unknown-assertions!` / `reject-assert-in-setup!`)."
   [id script]
-  (when-let [offenders (seq (runner/validate-script script))]
+  (when-let [offenders (seq (rf.story.play.runner/validate-script script))]
     (fail! :rf.error/story-bad-step
            (str "re-frame2-story: variant " id
                 " — malformed script step(s) "
@@ -336,7 +336,7 @@
 (defn- normalize-scripts
   "Return `{:script [step ...] :scripts [{:name :script :auto-run?} ...]}`
   for a merged body. Reads the `:script` / `:plays` slots through the
-  runner's canonical coercion (`runner/variant-body->plays` — bare
+  runner's canonical coercion (`rf.story.play.runner/variant-body->plays` — bare
   vector or `{:script :auto-run? :name}` map for `:script`, named entries
   for `:plays`). The primary `:script` is the first play.
 
@@ -345,7 +345,7 @@
   (or any step) FAILS with a structured `:rf.error/story-bad-step` BEFORE
   the fold — the fold helpers assume well-formed input.
 
-  After validation every play's script is FOLDED (`assertions/fold-script`):
+  After validation every play's script is FOLDED (`rf.story.assertions/fold-script`):
   a shipping `:assert-db` / `:assert-dom` step rewrites to
   the canonical `[:assert assertion-atom]` checkpoint, so EVERY in-script
   assertion — whatever sugar the author typed — resolves to the ONE
@@ -353,10 +353,10 @@
   Each `:scripts` entry carries the folded script too, so named plays the
   runner drives also see the canonical checkpoints."
   [id body]
-  (let [plays (runner/variant-body->plays body)
+  (let [plays (rf.story.play.runner/variant-body->plays body)
         plays (mapv (fn [p]
                       (reject-malformed-steps! id (:script p))
-                      (update p :script assertions/fold-script))
+                      (update p :script rf.story.assertions/fold-script))
                     (vec plays))]
     {:script  (-> plays first :script (or []))
      :scripts plays}))
@@ -409,7 +409,7 @@
   "FAIL plan construction when any authored assertion atom — terminal
   `:assertions` OR an in-script `[:assert …]` checkpoint — names an id
   that is not in the recognised P1 vocabulary
-  (`assertions/known-assertion-ids`, spec/017 §Assertions).
+  (`rf.story.assertions/known-assertion-ids`, spec/017 §Assertions).
   Catching it at compile time surfaces the typo before any run, the same
   way the other `:rf.error/story-*` plan errors do — never letting an
   unknown id record a vacuous `:rf.assert/unknown` pseudo-record at run
@@ -420,14 +420,14 @@
   (let [offenders (into []
                         (comp (remove nil?)
                               (remove (fn [a]
-                                        (assertions/assertion-id-known?
-                                          (assertions/assertion-atom-id a)))))
+                                        (rf.story.assertions/assertion-id-known?
+                                          (rf.story.assertions/assertion-atom-id a)))))
                         (concat terminal-assertions script-assertions))]
     (when (seq offenders)
       (fail! :rf.error/story-unknown-assertion
              (str "re-frame2-story: variant " id
                   " — unknown assertion id(s) "
-                  (pr-str (mapv assertions/assertion-atom-id offenders))
+                  (pr-str (mapv rf.story.assertions/assertion-atom-id offenders))
                   " in " (pr-str (vec offenders))
                   ". An assertion atom must name a recognised :rf.assert/* id "
                   "(the shipping seven, the DOM family, or a registered "
@@ -435,7 +435,7 @@
                   ":assert-db / :assert-dom step rather than inventing an id.")
              {:variant/id id
               :offending-assertions (vec offenders)
-              :known-ids assertions/known-assertion-ids}))))
+              :known-ids rf.story.assertions/known-assertion-ids}))))
 
 (defn- reject-malformed-causal-opts!
   "FAIL plan construction when a causal assertion atom carries a malformed
@@ -461,14 +461,14 @@
         (into []
               (comp
                 (remove nil?)
-                (filter assertions/causal?)
+                (filter rf.story.assertions/causal?)
                 (keep (fn [a]
-                        (let [spec (assertions/causal-spec a)]
+                        (let [spec (rf.story.assertions/causal-spec a)]
                           (when (contains? spec :require-cause?)
-                            (let [aid (assertions/assertion-atom-id a)
+                            (let [aid (rf.story.assertions/assertion-atom-id a)
                                   v   (:require-cause? spec)]
                               (cond
-                                (= aid assertions/id-caused) a
+                                (= aid rf.story.assertions/id-caused) a
                                 (not (boolean? v))           a)))))))
               (concat terminal-assertions script-assertions))]
     (when (seq offenders)
@@ -567,10 +567,10 @@
   and terminal assertion, through the `re-frame.story.requirements` registry
   (§Runner requirements). `:headless` work contributes the empty set (which
   resolves to the cheapest `:headless` runner). An in-script `[:assert …]`
-  checkpoint's wrapped-atom tokens are folded by `requirements/step-tokens`,
+  checkpoint's wrapped-atom tokens are folded by `rf.story.requirements/step-tokens`,
   so the script vector alone carries them."
   [setup script assertions]
-  (requirements/plan-required-runner setup script assertions))
+  (rf.story.requirements/plan-required-runner setup script assertions))
 
 ;; ============================================================================
 ;; View arg schemas
@@ -603,7 +603,7 @@
 (def view-args-schema-keys
   "Re-export of `re-frame.story.malli-schema/view-args-schema-keys` — the
   canonical first-match key order `[:rf/props :schema]`."
-  msu/view-args-schema-keys)
+  rf.story.malli-schema/view-args-schema-keys)
 
 (def view-args-schema
   "Re-export of `re-frame.story.malli-schema/view-args-schema` — the
@@ -611,7 +611,7 @@
   uses it to write `[:world :view-args-schema]`; the shared resolver
   `re-frame.story.view-args/compiled-view-args-schema` (which consumers
   call) reads that compiled slot back."
-  msu/view-args-schema)
+  rf.story.malli-schema/view-args-schema)
 
 (defn- map-entry-optional?
   "True iff a Malli `[:map …]` entry `[k props? child]` is marked
@@ -619,7 +619,7 @@
   entry is a REQUIRED view input."
   [entry]
   (let [props (second entry)]
-    (boolean (and (msu/properties? props) (:optional props)))))
+    (boolean (and (rf.story.malli-schema/properties? props) (:optional props)))))
 
 (defn validate-effective-args
   "Validate `effective-args` against a view-args `schema` (the value
@@ -659,22 +659,22 @@
        (nil? schema)
        {:status :ok :schema nil :missing [] :malformed []}
 
-       (and (vector? schema) (= :map (msu/schema-op schema)))
-       (let [entries   (msu/schema-children schema)
+       (and (vector? schema) (= :map (rf.story.malli-schema/schema-op schema)))
+       (let [entries   (rf.story.malli-schema/schema-children schema)
              missing   (into []
                               (keep (fn [entry]
-                                      (let [k (msu/map-entry-key entry)]
+                                      (let [k (rf.story.malli-schema/map-entry-key entry)]
                                         (when (and (not (map-entry-optional? entry))
                                                    (not (contains? args k)))
                                           {:key    k
-                                           :schema (msu/map-entry-schema entry)
+                                           :schema (rf.story.malli-schema/map-entry-schema entry)
                                            :path   [k]}))))
                               entries)
              malformed (when validate
                          (into []
                                (keep (fn [entry]
-                                       (let [k  (msu/map-entry-key entry)
-                                             cs (msu/map-entry-schema entry)
+                                       (let [k  (rf.story.malli-schema/map-entry-key entry)
+                                             cs (rf.story.malli-schema/map-entry-schema entry)
                                              v  (get args k)]
                                          (when (and (contains? args k)
                                                     (not (validate cs v)))
@@ -1112,7 +1112,7 @@
   bundles elide the side-table, so the lookup returns nil there; pure
   tests thread an explicit `:lookup`."
   [variant-id]
-  (registrar/handler-meta :variant variant-id))
+  (rf.story.registrar/handler-meta :variant variant-id))
 
 (defn- default-view-lookup
   "Default view-metadata lookup — reads the **framework** `:view`
@@ -1120,7 +1120,7 @@
   any `:rf/props` / `:schema` props-schema slot). Production bundles that
   elide views return nil; pure tests thread an explicit `:view-lookup`."
   [view-id]
-  (framework-registrar/handler-meta :view view-id))
+  (rf.registrar/handler-meta :view view-id))
 
 (defn- default-sub-lookup
   "Default subscription-metadata lookup — reads the **framework** `:sub`
@@ -1129,28 +1129,28 @@
   `:sub-overrides` value validation. Production bundles
   that elide subs return nil; pure tests thread an explicit `:sub-lookup`."
   [sub-id]
-  (framework-registrar/handler-meta :sub sub-id))
+  (rf.registrar/handler-meta :sub sub-id))
 
 (defn- default-fragment-lookup
   "Default fragment-body lookup — reads the Story side-table `:fragment`
   kind. Production bundles elide the side-table; pure tests
   thread an explicit `:fragment-lookup`."
   [fragment-id]
-  (registrar/handler-meta :fragment fragment-id))
+  (rf.story.registrar/handler-meta :fragment fragment-id))
 
 (defn- default-check-lookup
   "Default check-body lookup — reads the Story side-table `:check` kind."
   [check-id]
-  (registrar/handler-meta :check check-id))
+  (rf.story.registrar/handler-meta :check check-id))
 
 (defn- default-global-decorators
   "Default global-decorators ref vector — reads the project-wide
-  `config/get-global-decorators` (Storybook `preview.ts`
+  `rf.story.config/get-global-decorators` (Storybook `preview.ts`
   `decorators: [...]` parity, the outermost wrap layer). Production
   bundles with Story elided register no globals, so the vector is empty
   there; pure tests thread an explicit `:global-decorators`."
   []
-  (config/get-global-decorators))
+  (rf.story.config/get-global-decorators))
 
 (defn- default-story-decorators-lookup
   "Default story-level `:decorators` lookup — reads the parent story body's
@@ -1160,7 +1160,7 @@
   the project-wide globals and the variant chain. Production bundles elide
   the side-table; pure tests thread an explicit `:story-decorators`."
   [story-id]
-  (:decorators (registrar/handler-meta :story story-id)))
+  (:decorators (rf.story.registrar/handler-meta :story story-id)))
 
 (defn- default-story-lookup
   "Default parent-story-body lookup — reads the Story side-table `:story`
@@ -1169,7 +1169,7 @@
   `:tags`). Production bundles elide the side-table (nil → no story tags);
   pure tests thread an explicit `:story-lookup`."
   [story-id]
-  (registrar/handler-meta :story story-id))
+  (rf.story.registrar/handler-meta :story story-id))
 
 (defn expand-checks
   "Expand a plan's `:expect :checks` ids into the
@@ -1220,7 +1220,7 @@
   - `:global-decorators` — the project-wide global-decorators ref vector
     (or a 0-arg fn returning one) prepended to `[:world :decorators]` as
     the outermost wrap layer). Defaults to
-    `config/get-global-decorators`; pure tests pass an explicit vector.
+    `rf.story.config/get-global-decorators`; pure tests pass an explicit vector.
   - `:story-decorators` — a 1-arg fn `(story-id) → decorators-vec` OR a
     `{story-id → decorators-vec}` map resolving the parent story's
     `:decorators` slot (folded between globals and the variant chain).
@@ -1318,9 +1318,9 @@
         ;; gets) — bare vectors are an authoring shorthand, never the P1
         ;; public form.
         setup-raw    (vec (concat
-                            (mapcat (fn [l] (runner/coerce-script (pick-setup l))) inherited)
-                            (mapcat (fn [l] (runner/coerce-script (pick-setup l))) frag-layers)
-                            (runner/coerce-script (pick-setup child))))
+                            (mapcat (fn [l] (rf.story.play.runner/coerce-script (pick-setup l))) inherited)
+                            (mapcat (fn [l] (rf.story.play.runner/coerce-script (pick-setup l))) frag-layers)
+                            (rf.story.play.runner/coerce-script (pick-setup child))))
         ;; script APPENDS through `:compose` only (never through
         ;; `:extends`): composed-fragment scripts in declared order, THEN
         ;; the child's own script (§Merge rules). Each fragment's script is
@@ -1350,7 +1350,7 @@
         ;; the child's own — variant args win over composed/inherited (the
         ;; layers go root → fragments → child, last-wins per deep-merge).
         merge-key    (fn [k]
-                       (reduce (fn [m l] (args/deep-merge m (get l k)))
+                       (reduce (fn [m l] (rf.story.args/deep-merge m (get l k)))
                                {}
                                (concat inherited frag-layers [child])))
         ;; The `:extends`-merged variant-CHAIN args (the §Total resolution
@@ -1362,7 +1362,7 @@
         ;; Fold the ambient + per-run layers AROUND the variant layer so
         ;; the effective `arg-map` (and therefore every `[:arg key]`
         ;; substitution below, `[:world :args]` / `[:world :effective-args]`,
-        ;; and the plan hash) matches `args/resolve-args` for the SAME
+        ;; and the plan hash) matches `rf.story.args/resolve-args` for the SAME
         ;; `:active-modes` / `:cell-overrides`. `:run-args` is the
         ;; `{:pre [global story mode] :post [cell-overrides]}` shape
         ;; `re-frame.story.args/run-arg-layers` produces: `:pre` is lower
@@ -1370,7 +1370,7 @@
         ;; plan-compile / explain / render-prep with no run opts) ⇒ the
         ;; variant layer alone.
         arg-map      (if run-args
-                       (args/deep-merge-all
+                       (rf.story.args/deep-merge-all
                          (concat (:pre run-args)
                                  [variant-arg-map]
                                  (:post run-args)))
@@ -1522,7 +1522,7 @@
         ;; two ambient world keys below AND the `:story/id` stamp on the
         ;; returned plan (rf2-xk8oz4) all read this SAME resolution, so
         ;; they can never disagree about the parent.
-        sid          (args/parent-story-id id)
+        sid          (rf.story.args/parent-story-id id)
         story-body   (when sid (story-lookup sid))
         ;; ---- ambient (story-level) world keys ----
         ;; `:substrates` and `:component` are declared on the VARIANT or on
@@ -1620,7 +1620,7 @@
         ;; script, not just `script*` (the primary/first play alone).
         ;; `[:world :scripts]` retains every play, and the runtime
         ;; auto-runs each `:auto-run? true` one in order
-        ;; (`runner/auto-runnable-plays` — the single definition both
+        ;; (`rf.story.play.runner/auto-runnable-plays` — the single definition both
         ;; `runtime/run-phase-4!` and `runner-events/auto-run!` delegate
         ;; to). Runner-selection trusts `:required-runner` VERBATIM, so an
         ;; auto-run play OTHER than the first whose step lifts capability
@@ -1633,7 +1633,7 @@
         ;; single-play computation whenever the first play auto-runs (the
         ;; common case) and correctly extends it to every other auto-run
         ;; play.
-        auto-run-scripts (vec (mapcat :script (runner/auto-runnable-plays scripts*)))
+        auto-run-scripts (vec (mapcat :script (rf.story.play.runner/auto-runnable-plays scripts*)))
         required     (compute-required-runner setup auto-run-scripts assertions)
         ;; ---- source coords ----
         source       (:source child)
@@ -1666,7 +1666,7 @@
         ;; EFFECTIVE set — a `:!dev` cancels an inherited `:dev` and never
         ;; leaks itself, matching what every other tag consumer computes.
         chain-tags   (reduce (fn [acc b] (into acc (:tags b))) #{} bodies)
-        eff-tags     (tags/resolve-markers
+        eff-tags     (rf.story.tags/resolve-markers
                        (if (seq chain-tags)
                          chain-tags
                          (set (:tags story-body))))
@@ -1877,7 +1877,7 @@
   - `:global-decorators` / `:story-decorators` — the ambient decorator
     layers folded into the FULL `[:world :decorators]` stack:
     a global-decorators ref vector (or 0-arg fn) defaulting to
-    `config/get-global-decorators`, and a `(story-id) → decorators-vec`
+    `rf.story.config/get-global-decorators`, and a `(story-id) → decorators-vec`
     lookup defaulting to the Story side-table `:story` kind. Pure tests
     thread explicit values; the live runtime uses the defaults.
   - `:run-args` — the ambient + per-run arg layers to fold AROUND the
@@ -1886,7 +1886,7 @@
     `re-frame.story.args/run-arg-layers` produces. With it the compiled
     `[:world :args]` / `[:world :effective-args]`, every `[:arg key]`
     substitution in setup/script/db-seed/network/sub-overrides, and the
-    plan hash all use the SAME effective args as `args/resolve-args` for
+    plan hash all use the SAME effective args as `rf.story.args/resolve-args` for
     those `:active-modes` / `:cell-overrides`. Absent (a bare
     compile / `explain` / render-prep) ⇒ the variant arg layer alone, so
     the controls/render path layers its overrides on top of the plan-time

--- a/tools/story/src/re_frame/story/play.cljc
+++ b/tools/story/src/re_frame/story/play.cljc
@@ -13,7 +13,7 @@
 
   The per-frame listener is PURELY the egress seam: the load-bearing
   PRIVACY-suppression gate (Spec 009 §Privacy — default-dropping
-  `:sensitive?` events + the `config/note-suppressed!` redaction counter)
+  `:sensitive?` events + the `rf.story.config/note-suppressed!` redaction counter)
   and the synchronous handler-exception capture (`pending-exceptions`). It
   touches no assertions accumulator — warnings / fx / dispatched are all
   answerable from the epoch tape + stub-call log, the SSOT.
@@ -36,7 +36,7 @@
 
   - PRIVACY (Spec 009 §Privacy): default-drop `:sensitive? true` events
     BEFORE anything else and bump the UI redaction counter
-    (`config/note-suppressed!`);
+    (`rf.story.config/note-suppressed!`);
   - synchronous handler-exception capture into `pending-exceptions`
     (drained into the assertions list between dispatches).
 
@@ -64,17 +64,17 @@
             ;; The listener surface (`register-listener!` /
             ;; `unregister-listener!`) lives in `re-frame.trace.tooling`
             ;; (production-DCE split).
-            [re-frame.trace.tooling    :as trace-tooling]
+            [re-frame.trace.tooling    :as rf.trace.tooling]
             ;; The canonical RAW trace-event frame reader
             ;; (`re-frame.trace/frame-of`) reads the frame off a trace event.
-            [re-frame.trace            :as trace]
-            [re-frame.story.assertions :as assertions]
-            [re-frame.story.async      :as async]
-            [re-frame.story.config     :as config]
-            [re-frame.story.error      :as story-error]
-            [re-frame.story.late-bind  :as late-bind]
-            [re-frame.story.play.runner :as runner]
-            [re-frame.story.registrar  :as registrar]))
+            [re-frame.trace            :as rf.trace]
+            [re-frame.story.assertions :as rf.story.assertions]
+            [re-frame.story.async      :as rf.story.async]
+            [re-frame.story.config     :as rf.story.config]
+            [re-frame.story.error      :as rf.story.error]
+            [re-frame.story.late-bind  :as rf.story.late-bind]
+            [re-frame.story.play.runner :as rf.story.play.runner]
+            [re-frame.story.registrar  :as rf.story.registrar]))
 
 ;; ---------------------------------------------------------------------------
 ;; Per-frame trace listener — the Spec 009 §Privacy egress seam
@@ -123,7 +123,7 @@
   1. PRIVACY (Spec 009 §Privacy + EP-0015): events whose
      `:sensitive?` flag is true are DROPPED here when Story's local-render
      egress profile redacts (`:rf.egress/local-redacted` — the default).
-     The suppressed-events counter bumps (`config/note-suppressed!`) for the
+     The suppressed-events counter bumps (`rf.story.config/note-suppressed!`) for the
      targeted frame so the UI can surface a `[● REDACTED]` hint. This is
      the egress gate — it runs BEFORE the listener does anything else, so
      a sensitive event never reaches the exception capture below.
@@ -136,19 +136,19 @@
      dispatch-sync without re-entering the in-flight drain). The capture
      spans the WHOLE pipeline — a play-script event whose cofx injector or
      user interceptor throws surfaces just as a handler throw does. The
-     shared `story-error/pipeline-exception-event?` predicate is the single
+     shared `rf.story.error/pipeline-exception-event?` predicate is the single
      projection."
   [frame-id]
   (fn [ev]
-    (when (= frame-id (trace/frame-of ev))
+    (when (= frame-id (rf.trace/frame-of ev))
       (cond
         ;; Resolve the suppress decision against THIS frame's egress
         ;; profile (the listener is already frame-scoped). Revealing a
         ;; sibling frame never opens this frame's gate.
-        (config/suppress-sensitive? ev frame-id)
-        (config/note-suppressed! frame-id)
+        (rf.story.config/suppress-sensitive? ev frame-id)
+        (rf.story.config/note-suppressed! frame-id)
 
-        (story-error/pipeline-exception-event? frame-id ev)
+        (rf.story.error/pipeline-exception-event? frame-id ev)
         (record-pending-exception! frame-id ev)
 
         :else nil))))
@@ -184,9 +184,9 @@
           ;; Preserve the originating `:operation` / `:failing-id` so a
           ;; captured cofx / interceptor failure is distinguishable from a
           ;; handler throw on the record.
-          (assertions/record!
+          (rf.story.assertions/record!
             frame-id
-            (story-error/exception-record frame-id phase event-vec exc
+            (rf.story.error/exception-record frame-id phase event-vec exc
                                           {:message    msg
                                            :operation  (:operation ev)
                                            :failing-id (get-in ev [:tags :failing-id])}))))
@@ -197,16 +197,16 @@
   default-drops `:sensitive?` events + captures handler-exceptions).
   Idempotent — re-registering replaces. Returns the listener id."
   [frame-id]
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (let [id (listener-id frame-id)]
-      (trace-tooling/register-listener! id (listener-for-frame frame-id))
+      (rf.trace.tooling/register-listener! id (listener-for-frame frame-id))
       id)))
 
 (defn remove-trace-listener!
   "Tear down the per-frame trace listener for `frame-id`. Idempotent."
   [frame-id]
-  (when config/enabled?
-    (trace-tooling/unregister-listener! (listener-id frame-id))
+  (when rf.story.config/enabled?
+    (rf.trace.tooling/unregister-listener! (listener-id frame-id))
     nil))
 
 ;; ---------------------------------------------------------------------------
@@ -231,9 +231,9 @@
   (try
     (rf/dispatch-sync event {:frame frame-id})
     (catch #?(:clj Throwable :cljs :default) e
-      (assertions/record!
+      (rf.story.assertions/record!
         frame-id
-        (story-error/exception-record frame-id :phase-4-play event e))))
+        (rf.story.error/exception-record frame-id :phase-4-play event e))))
   ;; After the drain settles, walk any captured handler-exception
   ;; trace events into assertion records. Safe to dispatch-sync now —
   ;; the drain has ended.
@@ -242,7 +242,7 @@
 (defn- read-assertions-after
   "Return the per-frame assertions vector, post-play."
   [frame-id]
-  (assertions/read-assertions frame-id))
+  (rf.story.assertions/read-assertions frame-id))
 
 (defn variant-play-events
   "Resolve a flat event-vector list for `variant-id`'s phase-4 play.
@@ -257,8 +257,8 @@
   This shape stays around for the play-stepper UI which advances ONE
   event at a time."
   [variant-id]
-  (let [body   (registrar/handler-meta :variant variant-id)
-        spec   (runner/parse-spec (:script body))
+  (let [body   (rf.story.registrar/handler-meta :variant variant-id)
+        spec   (rf.story.play.runner/parse-spec (:script body))
         script (:script spec)]
     (->> (or script [])
          (keep (fn [step]
@@ -286,9 +286,9 @@
    (execute-play! variant-id play-events nil))
   ([variant-id play-events {:keys [install-listener?]
                             :or   {install-listener? true}}]
-   (if-not config/enabled?
-     (async/resolved [])
-     (async/promise
+   (if-not rf.story.config/enabled?
+     (rf.story.async/resolved [])
+     (rf.story.async/promise
        (fn [resolve]
          (try
            (swap! pending-exceptions assoc variant-id [])
@@ -312,9 +312,9 @@
              ;; projection so :stack / :data survive on the record; :event
              ;; is nil (the failure is in the play harness, not a
              ;; dispatched event).
-             (assertions/record!
+             (rf.story.assertions/record!
                variant-id
-               (story-error/exception-record variant-id :phase-4-setup nil e))
+               (rf.story.error/exception-record variant-id :phase-4-setup nil e))
              (resolve (read-assertions-after variant-id)))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -350,14 +350,14 @@
 
   Pure data → data; works on JVM + CLJS.
 
-  The script is FOLDED (`assertions/fold-script`) so the
+  The script is FOLDED (`rf.story.assertions/fold-script`) so the
   stepper walks the SAME canonical `[:assert …]` checkpoints the auto-run
   path drives: a shipping `:assert-db` / `:assert-dom` step is rewritten to
   the one assertion atom before the stepper executes it."
   [variant-id]
-  (let [body (registrar/handler-meta :variant variant-id)
-        spec (runner/parse-spec (:script body))]
-    (assertions/fold-script (vec (:script spec)))))
+  (let [body (rf.story.registrar/handler-meta :variant variant-id)
+        spec (rf.story.play.runner/parse-spec (:script body))]
+    (rf.story.assertions/fold-script (vec (:script spec)))))
 
 (defn play-stepper-active?
   [frame-id]
@@ -369,7 +369,7 @@
 
   Seeds the FULL coerced script (every step type)."
   [frame-id]
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (swap! pending-exceptions assoc frame-id [])
     (install-trace-listener! frame-id)
     ;; Reset the per-dispatch-step settle boundaries at the START
@@ -377,7 +377,7 @@
     ;; so `step-once!`'s per-step appends window onto THIS session's epoch tape
     ;; rather than accumulating onto a previous run's boundaries. Fetched via
     ;; the late-bind seam because `play` cannot `:require` `runner-events`.
-    (when-let [clear! (late-bind/get-fn :clear-step-boundaries)]
+    (when-let [clear! (rf.story.late-bind/get-fn :clear-step-boundaries)]
       (clear! frame-id))
     (swap! stepper-state assoc frame-id
            {:remaining (variant-play-steps frame-id)
@@ -397,12 +397,12 @@
   falls back to `dispatch-one!` for dispatch steps and a no-op record for
   the rest, so the cursor stays honest."
   [frame-id]
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (let [{:keys [remaining]} (get @stepper-state frame-id)
           step (first remaining)]
       (when step
         (let [idx     (count (:ran (get @stepper-state frame-id)))
-              run-fn  (late-bind/get-fn :run-play-step)
+              run-fn  (rf.story.late-bind/get-fn :run-play-step)
               ;; rf2-iz0t8 — a `[:flush-presence]` against a Promise-backed
               ;; host is the ONE step whose outcome is not known by the time
               ;; the executor returns. The executor calls this back with the
@@ -451,11 +451,11 @@
                         ;; Fallback: executor unavailable. Drive dispatch
                         ;; steps directly via `dispatch-one!`; record nothing
                         ;; for the other step types but still advance the cursor.
-                        (#{:dispatch :dispatch-sync} (runner/step-type step))
-                        (do (dispatch-one! frame-id (runner/step-event step))
-                            (runner/step-skip idx step))
+                        (#{:dispatch :dispatch-sync} (rf.story.play.runner/step-type step))
+                        (do (dispatch-one! frame-id (rf.story.play.runner/step-event step))
+                            (rf.story.play.runner/step-skip idx step))
 
-                        :else (runner/step-skip idx step))]
+                        :else (rf.story.play.runner/step-skip idx step))]
           ;; Publish the claim BEFORE the record is visible in `:results`, so
           ;; there is no window in which a settlement could see its own record
           ;; at `idx` without recognising it. Both are synchronous and
@@ -476,7 +476,7 @@
   substrate's remaining/ran/results cursor consistent with that restore.
   No-op when no step has run."
   [frame-id]
-  (when config/enabled?
+  (when rf.story.config/enabled?
     ;; Guard against a missing entry: `update` on a missing key
     ;; would associate the fn's nil/`s` return (a `{frame-id nil}` entry),
     ;; which flips `play-stepper-active?` (a `contains?` check) to true for a
@@ -499,7 +499,7 @@
   `:remaining`, `:ran` + `:results` emptied. The UI's rewind also
   restores the pre-play epoch + clears the assertion accumulator."
   [frame-id]
-  (when config/enabled?
+  (when rf.story.config/enabled?
     ;; Guard against a missing entry: an `update` whose fn returns nil for
     ;; a missing key would associate that nil (a `{frame-id nil}` entry),
     ;; making `play-stepper-active?` report true for a frame whose stepper
@@ -516,7 +516,7 @@
   "Tear down the play stepper for `frame-id`. The UI calls this when
   the stepper widget closes."
   [frame-id]
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (remove-trace-listener! frame-id)
     (swap! stepper-state dissoc frame-id))
   nil)
@@ -548,7 +548,7 @@
   atoms), so a stale listener cannot capture into the just-cleared atom on
   the next dispatch. Idempotent."
   []
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (let [frame-ids (into (set (keys @pending-exceptions))
                           (keys @stepper-state))]
       (doseq [frame-id frame-ids]

--- a/tools/story/src/re_frame/story/play/browser.cljc
+++ b/tools/story/src/re_frame/story/play/browser.cljc
@@ -73,7 +73,7 @@
   `live-a11y-violations` (a late-bound atom read), both isolated so the
   evaluators stay testable on the JVM with no host."
   (:require [clojure.string            :as str]
-            [re-frame.story.assertions :as assertions]))
+            [re-frame.story.assertions :as rf.story.assertions]))
 
 ;; ===========================================================================
 ;; ENVIRONMENT PROBE  (the fail-closed guard at the executor)
@@ -183,14 +183,14 @@
   is the regression key and `:baseline` mismatch is the failure."
   [payload {:keys [snapshot-identity baseline] :as _ctx}]
   (if-not (browser-available?)
-    (cannot-run-finding assertions/id-visual-snapshot payload
+    (cannot-run-finding rf.story.assertions/id-visual-snapshot payload
                         (str "visual snapshot requires a real browser "
                              "(:pixels); the headless runner cannot capture "
                              "or diff a screenshot"))
     (let [hash      (:content-hash snapshot-identity)
           base-hash (:content-hash baseline)
           passed?   (or (nil? baseline) (= hash base-hash))]
-      {:assertion assertions/id-visual-snapshot
+      {:assertion rf.story.assertions/id-visual-snapshot
        :payload   (vec payload)
        :passed?   passed?
        :status    (if passed? :pass :fail)
@@ -269,7 +269,7 @@
   with app-db / args / trace / epoch evidence)."
   [payload {:keys [violations frame-id] :as _ctx}]
   (if-not (browser-available?)
-    (cannot-run-finding assertions/id-a11y payload
+    (cannot-run-finding rf.story.assertions/id-a11y payload
                         (str "axe-style a11y requires a real browser "
                              "(:a11y-engine); the headless runner cannot run "
                              "axe-core"))
@@ -283,7 +283,7 @@
                                   (>= (get impact-rank (:impact v) 1) floor))
                                 vs)
           passed?     (empty? counted)]
-      {:assertion assertions/id-a11y
+      {:assertion rf.story.assertions/id-a11y
        :payload   (vec payload)
        :passed?   passed?
        :status    (if passed? :pass :fail)
@@ -465,7 +465,7 @@
   [payload {:keys [hiccup] :as _ctx}]
   (let [issues  (structural-issues hiccup)
         passed? (empty? issues)]
-    {:assertion assertions/id-a11y-structural
+    {:assertion rf.story.assertions/id-a11y-structural
      :payload   (vec payload)
      :passed?   passed?
      :status    (if passed? :pass :fail)
@@ -488,8 +488,8 @@
   Pure data → data — the runner uses this to route an atom here rather than
   to the dispatched `:rf.assert/*` handler path."
   [assertion-atom]
-  (contains? assertions/browser-assertion-ids
-             (assertions/assertion-atom-id assertion-atom)))
+  (contains? rf.story.assertions/browser-assertion-ids
+             (rf.story.assertions/assertion-atom-id assertion-atom)))
 
 (defn eval-browser-assertion
   "Evaluate ONE browser-tier oracle assertion atom against `ctx`, returning
@@ -505,10 +505,10 @@
   `:violations` / `:frame-id` / `:hiccup`), supplied by the caller. A
   non-browser-tier atom returns nil (the caller routes it elsewhere)."
   [assertion-atom ctx]
-  (let [id      (assertions/assertion-atom-id assertion-atom)
+  (let [id      (rf.story.assertions/assertion-atom-id assertion-atom)
         payload (vec (rest assertion-atom))]
     (condp = id
-      assertions/id-visual-snapshot (eval-visual-snapshot payload ctx)
-      assertions/id-a11y            (eval-a11y payload ctx)
-      assertions/id-a11y-structural (eval-structural-a11y payload ctx)
+      rf.story.assertions/id-visual-snapshot (eval-visual-snapshot payload ctx)
+      rf.story.assertions/id-a11y            (eval-a11y payload ctx)
+      rf.story.assertions/id-a11y-structural (eval-structural-a11y payload ctx)
       nil)))

--- a/tools/story/src/re_frame/story/play/ci_runner.cljc
+++ b/tools/story/src/re_frame/story/play/ci_runner.cljc
@@ -20,7 +20,7 @@
   - `install-ci-hooks!` (CLJS) — install `window.__rf2_story_ci`
     helpers so a Playwright runner can: (a) enumerate variants with
     `:script`, and (b) read each variant's terminal run-state
-    (`runner-events/current-state`) once the auto-run completes.
+    (`rf.story.play.runner-events/current-state`) once the auto-run completes.
     No-op on JVM. The hook is INERT until called explicitly from a
     testbed init path — production / non-CI bundles never hit it.
 
@@ -41,9 +41,9 @@
   This ns is `.cljc`. The pure seams (`variants-with-play-scripts`,
   `ci-rows`, `ci-context`) are JVM-runnable; the CLJS-only
   `install-ci-hooks!` is gated by reader conditionals."
-  (:require [re-frame.story.play.runner :as runner]
-            [re-frame.story.registrar   :as registrar]
-            #?(:cljs [re-frame.story.play.runner-events :as runner-events])))
+  (:require [re-frame.story.play.runner :as rf.story.play.runner]
+            [re-frame.story.registrar   :as rf.story.registrar]
+            #?(:cljs [re-frame.story.play.runner-events :as rf.story.play.runner-events])))
 
 ;; ---- pure discovery ------------------------------------------------------
 
@@ -90,7 +90,7 @@
   `:script` and `:plays`-carrying variants. The CI runner uses
   `ci-rows` to enumerate per-PLAY rows."
   ([]
-   (variants-with-play-scripts (registrar/registrations :variant)))
+   (variants-with-play-scripts (rf.story.registrar/registrations :variant)))
   ([variant-registrations]
    (->> variant-registrations
         (filter (fn [[_ body]] (has-any-play? body)))
@@ -116,14 +116,14 @@
   Stable order: variants sorted alphabetically, plays in declaration
   order within each variant."
   ([]
-   (ci-rows (registrar/registrations :variant)))
+   (ci-rows (rf.story.registrar/registrations :variant)))
   ([variant-registrations]
    (let [vids (variants-with-play-scripts variant-registrations)]
      (vec
        (mapcat
          (fn [vid]
            (let [body  (get variant-registrations vid)
-                 plays (runner/variant-body->plays body)]
+                 plays (rf.story.play.runner/variant-body->plays body)]
              (map (fn [spec]
                     {:variant-id vid
                      :play-key   (:name spec)
@@ -240,7 +240,7 @@
      outcome should use `readPlayRunState`."
      [variant-id-str]
      (let [vid   (->variant-id variant-id-str)
-           state (runner-events/current-state vid)]
+           state (rf.story.play.runner-events/current-state vid)]
        (->js (project-state state)))))
 
 #?(:cljs
@@ -254,7 +254,7 @@
            pk  (when (and play-key-str
                           (not= "" play-key-str))
                  (str play-key-str))
-           state (runner-events/current-state-for-play vid pk)]
+           state (rf.story.play.runner-events/current-state-for-play vid pk)]
        (->js (project-state state)))))
 
 #?(:cljs
@@ -268,7 +268,7 @@
            pk  (when (and play-key-str
                           (not= "" play-key-str))
                  (str play-key-str))]
-       (runner-events/run-play! vid pk)
+       (rf.story.play.runner-events/run-play! vid pk)
        nil)))
 
 #?(:cljs

--- a/tools/story/src/re_frame/story/play/presence.cljc
+++ b/tools/story/src/re_frame/story/play/presence.cljc
@@ -63,7 +63,7 @@
 
   Pure data → data apart from the hook call itself, so both the JVM
   `clojure -M:test` gate and the node `npm run test:cljs` gate exercise it."
-  (:require [re-frame.story.late-bind :as late-bind]))
+  (:require [re-frame.story.late-bind :as rf.story.late-bind]))
 
 (def presence-flush-hook-key
   "The `re-frame.story.late-bind` hook key a presence-bearing shell registers
@@ -79,14 +79,14 @@
   `nil` for 'to quiescence' — mirroring the clock advance's two arities.
   Idempotent (re-registration replaces, per Spec 001 hot-reload semantics)."
   [flush-fn]
-  (late-bind/set-fn! presence-flush-hook-key flush-fn)
+  (rf.story.late-bind/set-fn! presence-flush-hook-key flush-fn)
   nil)
 
 (defn presence-flush-fn
   "The installed presence-advance fn, or nil when no host registered one
   (the bare JVM / a Story app with no presence boundaries)."
   []
-  (late-bind/get-fn presence-flush-hook-key))
+  (rf.story.late-bind/get-fn presence-flush-hook-key))
 
 (defn- thenable
   "`x` as a thenable, or nil. CLJS-only, and CONDITIONAL: a host whose advance

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -6,7 +6,7 @@
   the step types reach for:
 
   - `:dispatch` → dispatch + settle through `settled-boundary`
-    (`boundary/dispatch-and-settle!`) against the variant's
+    (`rf.story.play.settled-boundary/dispatch-and-settle!`) against the variant's
     frame; in headless this drains via `dispatch-sync!` to a fixed point
     (richer runners supply reactive / DOM flushes through flush-hooks).
     `:dispatch-sync` → the low-level `re-frame.router/dispatch-sync!` escape.
@@ -43,22 +43,22 @@
   cascade."
   (:refer-clojure :exclude [run!])
   (:require [re-frame.core              :as rf]
-            [re-frame.router            :as router]
-            [re-frame.frame             :as frame]
-            [re-frame.interop           :as interop]
+            [re-frame.router            :as rf.router]
+            [re-frame.frame             :as rf.frame]
+            [re-frame.interop           :as rf.interop]
             #?(:cljs [reagent.core      :as r])
-            [re-frame.story.assertions  :as assertions]
-            [re-frame.story.config      :as config]
-            [re-frame.story.late-bind   :as late-bind]
-            [re-frame.story.play        :as play]
-            [re-frame.story.play.browser :as browser]
-            [re-frame.story.play.dom    :as dom]
-            [re-frame.story.play.evidence :as evidence]
-            [re-frame.story.play.presence :as presence]
-            [re-frame.story.play.runner :as runner]
-            [re-frame.story.play.settled-boundary :as boundary]
-            [re-frame.story.predicates  :as pred]
-            [re-frame.story.registrar   :as registrar]))
+            [re-frame.story.assertions  :as rf.story.assertions]
+            [re-frame.story.config      :as rf.story.config]
+            [re-frame.story.late-bind   :as rf.story.late-bind]
+            [re-frame.story.play        :as rf.story.play]
+            [re-frame.story.play.browser :as rf.story.play.browser]
+            [re-frame.story.play.dom    :as rf.story.play.dom]
+            [re-frame.story.play.evidence :as rf.story.play.evidence]
+            [re-frame.story.play.presence :as rf.story.play.presence]
+            [re-frame.story.play.runner :as rf.story.play.runner]
+            [re-frame.story.play.settled-boundary :as rf.story.play.settled-boundary]
+            [re-frame.story.predicates  :as rf.story.predicates]
+            [re-frame.story.registrar   :as rf.story.registrar]))
 
 ;; ---- per-variant run-state -----------------------------------------------
 
@@ -104,7 +104,7 @@
          dispatch-step execution order. The evidence projection
          (`runtime/record-result-map`) reads this through
          `settle-boundaries` and hands it to
-         `evidence/project-evidence` as `:attribution`, lighting up the
+         `rf.story.play.evidence/project-evidence` as `:attribution`, lighting up the
          EXACT narrative attribution (`spans-from-stamps`) instead of the
          EVEN heuristic.
 
@@ -214,7 +214,7 @@
   play-key accumulates into its OWN slot and can never collide with — or
   be wiped alongside — this one."
   [frame-id play-key step]
-  (when (evidence/dispatch-step? step)
+  (when (rf.story.play.evidence/dispatch-step? step)
     (swap! step-boundaries update [frame-id play-key] (fnil conj []) (last-epoch-id frame-id)))
   nil)
 
@@ -249,7 +249,7 @@
   `run!` (clears its OWN resolved play-key), the multi-play sequencers
   (`run-plays-sequentially!`, the orchestrator `runtime/run-phase-4!` —
   which also covers its no-auto-plays branch) clear each play-key they are
-  ABOUT to drive, and the stepper start `play/begin-stepper!` (via the
+  ABOUT to drive, and the stepper start `rf.story.play/begin-stepper!` (via the
   `:clear-step-boundaries` late-bind seam, always play-key nil — the
   stepper only ever walks the default play). So a non-orchestrator re-run /
   replay-in-place / stepping session never inherits stale accumulated
@@ -329,7 +329,7 @@
   "Look up the variant body via the framework registrar."
   [variant-id]
   (try
-    (registrar/handler-meta :variant variant-id)
+    (rf.story.registrar/handler-meta :variant variant-id)
     (catch #?(:clj Throwable :cljs :default) _ nil)))
 
 ;; ---- replay target (EP-0023) ---------------------------------------------
@@ -344,7 +344,7 @@
 ;; ---- folded-plan consumption --------------------------------------------
 ;;
 ;; The runtime CONSUMES the folded plan: every play's script is folded
-;; through `assertions/fold-script` at resolution time, so a shipping
+;; through `rf.story.assertions/fold-script` at resolution time, so a shipping
 ;; `:assert-db` / `:assert-dom` step is rewritten to the canonical
 ;; `[:assert assertion-atom]` checkpoint BEFORE the run loop drives it
 ;; (spec/017 §Assertions — one atom, two positions). After folding,
@@ -356,17 +356,17 @@
 ;; assertion-record vocabulary, not two.
 
 (defn- fold-spec
-  "Fold a parsed play spec's `:script` through `assertions/fold-script` so
+  "Fold a parsed play spec's `:script` through `rf.story.assertions/fold-script` so
   shipping `:assert-db` / `:assert-dom` steps become canonical
   `[:assert …]` checkpoints. Pure data → data; preserves
   `:auto-run?` / `:name`."
   [spec]
   (cond-> spec
-    (contains? spec :script) (update :script assertions/fold-script)))
+    (contains? spec :script) (update :script rf.story.assertions/fold-script)))
 
 (defn variant-play-script
   "Resolve the `:script` body on `variant-id`, parse it, and FOLD its
-  script. Returns the normalised spec map per `runner/parse-spec` with
+  script. Returns the normalised spec map per `rf.story.play.runner/parse-spec` with
   every shipping `:assert-db` / `:assert-dom` step rewritten to the
   canonical `[:assert …]` checkpoint. Variants without `:script`
   return `{:script [] :auto-run? true}`.
@@ -377,7 +377,7 @@
   `variant-plays` instead."
   [variant-id]
   (let [body  (handler-meta variant-id)
-        plays (runner/variant-body->plays body)]
+        plays (rf.story.play.runner/variant-body->plays body)]
     (fold-spec
       (cond
         ;; Multi-play (:plays slot) — default to the first play.
@@ -386,7 +386,7 @@
 
         ;; Single-script (:script slot).
         :else
-        (runner/parse-spec (when body (:script body)))))))
+        (rf.story.play.runner/parse-spec (when body (:script body)))))))
 
 ;; ---- multi-play warning (one-shot) ---------------------------------------
 
@@ -425,7 +425,7 @@
     ;; FOLD every resolved play's script so the runtime consumes the
     ;; folded plan: `:assert-db` / `:assert-dom` steps become canonical
     ;; `[:assert …]` checkpoints before the run loop.
-    (mapv fold-spec (runner/variant-body->plays body))))
+    (mapv fold-spec (rf.story.play.runner/variant-body->plays body))))
 
 (defn resolve-play
   "Resolve a `(variant-id, play-key)` pair to the parsed, FOLDED play spec,
@@ -436,7 +436,7 @@
   (let [plays (variant-plays variant-id)]
     (if (nil? play-key)
       (first plays)
-      (runner/find-play plays play-key))))
+      (rf.story.play.runner/find-play plays play-key))))
 
 ;; ---- trace emission ------------------------------------------------------
 
@@ -445,11 +445,11 @@
   `variant-id`. Goes through `re-frame.core/emit-trace-event!` (which
   delegates to `re-frame.trace/emit!`) so the bus + ring buffer +
   listener fan-out all observe it. Safe under production elision —
-  `re-frame.trace/emit!` short-circuits when `interop/debug-enabled?`
+  `re-frame.trace/emit!` short-circuits when `rf.interop/debug-enabled?`
   is false."
   [variant-id name idx step result]
   (try
-    (let [payload (runner/trace-record
+    (let [payload (rf.story.play.runner/trace-record
                     {:variant-id variant-id
                      :name       name
                      :idx        idx
@@ -461,7 +461,7 @@
       ;; per-frame.
       (rf/emit-trace-event!
         :rf.story.play/step
-        runner/trace-event-id
+        rf.story.play.runner/trace-event-id
         (merge {:frame variant-id} payload)))
     (catch #?(:clj Throwable :cljs :default) _ nil)))
 
@@ -477,15 +477,15 @@
 (defn current-flush-hooks
   "Resolve the active flush-hooks map. An adapter-aware caller (the
   Reagent/UIx shell, a future `:dom` browser runner) registers a
-  richer hooks map via `late-bind/set-fn! :settled-boundary-hooks <fn>`,
+  richer hooks map via `rf.story.late-bind/set-fn! :settled-boundary-hooks <fn>`,
   where the fn takes the frame-id and returns the hooks for that frame.
   When no adapter has registered, the headless hooks are used so a
   `[:dispatch …]` step settles to fixed point synchronously."
   [frame-id]
-  (if-let [f (late-bind/get-fn :settled-boundary-hooks)]
+  (if-let [f (rf.story.late-bind/get-fn :settled-boundary-hooks)]
     (or (try (f frame-id) (catch #?(:clj Throwable :cljs :default) _ nil))
-        boundary/headless-flush-hooks)
-    boundary/headless-flush-hooks))
+        rf.story.play.settled-boundary/headless-flush-hooks)
+    rf.story.play.settled-boundary/headless-flush-hooks))
 
 ;; ---- step executors ------------------------------------------------------
 
@@ -522,11 +522,11 @@
                     (str (:id rec) " " (pr-str (:payload rec))
                          " failed (expected " (pr-str (:expected rec))
                          ", actual " (pr-str (:actual rec)) ")"))]
-        (runner/step-fail idx step
+        (rf.story.play.runner/step-fail idx step
                           {:expected (:expected rec)
                            :actual   (:actual rec)
                            :message  msg}))
-      (runner/step-skip idx step))))
+      (rf.story.play.runner/step-skip idx step))))
 
 (defn- boundary-result->step
   "Project a `settled-boundary/dispatch-and-settle!` non-`:settled`
@@ -538,7 +538,7 @@
   [idx step settle]
   (case (:status settle)
     :cannot-run
-    (runner/step-fail idx step
+    (rf.story.play.runner/step-fail idx step
                       {:cannot-run? true
                        :required-boundary (:required-boundary settle)
                        :provided-boundary (:provided-boundary settle)
@@ -550,7 +550,7 @@
                                       (pr-str (:provided-boundary settle))
                                       " (" (name (or (:reason settle) :runner-below-required-boundary)) ")")})
     :error
-    (runner/step-exception idx step (:error settle))
+    (rf.story.play.runner/step-exception idx step (:error settle))
     ;; :settled → no step-level result from the boundary itself.
     nil))
 
@@ -580,47 +580,47 @@
   `:passed? false` becomes a runner-visible step-fail so the play's
   terminal status flips to `:fail`."
   [frame-id idx step]
-  (let [evec     (runner/step-event step)
+  (let [evec     (rf.story.play.runner/step-event step)
         ;; A replayed `[:dispatch evec {:rf.cofx …}]` step carries a
         ;; captured recordable-coeffect envelope. Pass it to the boundary
         ;; as dispatch-opts so the handler's declared coeffects replay from
         ;; the recorded value instead of being restamped.
-        cofx     (runner/step-cofx step)
+        cofx     (rf.story.play.runner/step-cofx step)
         dopts    (when (and (map? cofx) (seq cofx)) {:rf.cofx cofx})
         prev     (assertion-count frame-id)
-        required (boundary/step-required-boundary step)
+        required (rf.story.play.settled-boundary/step-required-boundary step)
         hooks    (current-flush-hooks frame-id)
         settle   (try
-                   (boundary/dispatch-and-settle! frame-id evec hooks required step dopts)
+                   (rf.story.play.settled-boundary/dispatch-and-settle! frame-id evec hooks required step dopts)
                    (catch #?(:clj Throwable :cljs :default) e
                      {:status :error
                       :error  #?(:clj (.getMessage ^Throwable e) :cljs (str e))
                       :step   step}))]
-    (play/drain-pending-exceptions! frame-id :phase-4-play)
+    (rf.story.play/drain-pending-exceptions! frame-id :phase-4-play)
     (or (boundary-result->step idx step settle)
         (dispatch-step-result frame-id prev idx step))))
 
 (defn- exec-dispatch-sync!
   [frame-id idx step]
-  (let [evec   (runner/step-event step)
+  (let [evec   (rf.story.play.runner/step-event step)
         ;; When the step carries a captured `:rf.cofx` envelope, thread it
         ;; into the dispatch opts so the handler's declared recordable
         ;; coeffects (provided facts + the framework `:rf/time-ms`) replay
         ;; from the recorded value instead of being restamped / failing
         ;; `:rf.error/missing-required-cofx`. Absent cofx dispatches with
         ;; the bare frame opts.
-        cofx   (runner/step-cofx step)
+        cofx   (rf.story.play.runner/step-cofx step)
         opts   (cond-> {:frame frame-id}
                  (and (map? cofx) (seq cofx)) (assoc :rf.cofx cofx))
         prev   (assertion-count frame-id)
         result (try
-                 (router/dispatch-sync! evec opts)
+                 (rf.router/dispatch-sync! evec opts)
                  nil
                  (catch #?(:clj Throwable :cljs :default) e
-                   (runner/step-exception idx step
+                   (rf.story.play.runner/step-exception idx step
                                           #?(:clj  (.getMessage ^Throwable e)
                                              :cljs (str e)))))]
-    (play/drain-pending-exceptions! frame-id :phase-4-play)
+    (rf.story.play/drain-pending-exceptions! frame-id :phase-4-play)
     (or result (dispatch-step-result frame-id prev idx step))))
 
 (defn- read-frame-db
@@ -638,15 +638,15 @@
 ;; step. It has no reg-event handler (the DOM runner that PROVES it is the
 ;; `:dom` capability wired via `requirements`), so an
 ;; `[:assert [:rf.assert/dom-* …]]` checkpoint is EVALUATED directly through
-;; the DOM executor (`dom/assert-visible` / `dom/assert-text`) and records a
+;; the DOM executor (`rf.story.play.dom/assert-visible` / `rf.story.play.dom/assert-text`) and records a
 ;; CANONICAL `:rf.assert/dom-*` record on the frame's `:rf.story/assertions`
 ;; slot. There is no synthetic `:rf.assert/dom` id — the canonical folded id
 ;; is the one recorded.
 
 (def ^:private dom-atom->mode
-  "Map a DOM-family assertion id to the `dom/assert-visible` mode it
+  "Map a DOM-family assertion id to the `rf.story.play.dom/assert-visible` mode it
   evaluates. `:rf.assert/dom-text` is handled separately (it calls
-  `dom/assert-text`)."
+  `rf.story.play.dom/assert-text`)."
   {:rf.assert/dom-visible :visible
    :rf.assert/dom-hidden  :hidden})
 
@@ -663,60 +663,60 @@
   (let [aid      (first atom-v)
         selector (nth atom-v 1 nil)
         result   (if (= :rf.assert/dom-text aid)
-                   (dom/assert-text selector (nth atom-v 2 nil))
-                   (dom/assert-visible selector (get dom-atom->mode aid :visible)))]
+                   (rf.story.play.dom/assert-text selector (nth atom-v 2 nil))
+                   (rf.story.play.dom/assert-visible selector (get dom-atom->mode aid :visible)))]
     ;; Record the canonical DOM-family assertion record on the slot (unless
     ;; the step was a no-DOM skip — a skip proved nothing, so it must not
     ;; read as a vacuous pass).
     (when-not (:skipped? result)
-      (assertions/record!
+      (rf.story.assertions/record!
         frame-id
         (cond-> {:assertion    aid
                  :passed?      (boolean (:passed? result))
                  :payload      (vec (rest atom-v))
-                 :source-coord (:source (registrar/handler-meta :variant frame-id))}
+                 :source-coord (:source (rf.story.registrar/handler-meta :variant frame-id))}
           (contains? result :expected) (assoc :expected (:expected result))
           (contains? result :actual)   (assoc :actual   (:actual result))
           (:message result)            (assoc :reason   (:message result)))))
     (cond
-      (:skipped? result) (runner/step-fail idx step
+      (:skipped? result) (rf.story.play.runner/step-fail idx step
                                            {:skipped? true
                                             :message  (or (:message result)
                                                           (str "no DOM — cannot prove "
                                                                (pr-str atom-v)))})
-      (:passed? result)  (runner/step-pass idx step)
-      :else              (runner/step-fail idx step result))))
+      (:passed? result)  (rf.story.play.runner/step-pass idx step)
+      :else              (rf.story.play.runner/step-fail idx step result))))
 
 (defn- exec-click!
   [_frame-id idx step]
-  (let [selector (runner/step-selector step)]
+  (let [selector (rf.story.play.runner/step-selector step)]
     (cond
-      (not (dom/dom-available?))
-      (runner/step-fail idx step
+      (not (rf.story.play.dom/dom-available?))
+      (rf.story.play.runner/step-fail idx step
                         {:skipped? true
                          :message  (str "no DOM — cannot click " (pr-str selector))})
 
-      (dom/click! selector)
-      (runner/step-skip idx step)
+      (rf.story.play.dom/click! selector)
+      (rf.story.play.runner/step-skip idx step)
 
       :else
-      (runner/step-fail idx step
+      (rf.story.play.runner/step-fail idx step
                         {:message (str "click failed — no node matched " (pr-str selector))}))))
 
 (defn- exec-type!
   [_frame-id idx step]
-  (let [[selector text] (runner/step-type-text step)]
+  (let [[selector text] (rf.story.play.runner/step-type-text step)]
     (cond
-      (not (dom/dom-available?))
-      (runner/step-fail idx step
+      (not (rf.story.play.dom/dom-available?))
+      (rf.story.play.runner/step-fail idx step
                         {:skipped? true
                          :message  (str "no DOM — cannot type into " (pr-str selector))})
 
-      (dom/type! selector text)
-      (runner/step-skip idx step)
+      (rf.story.play.dom/type! selector text)
+      (rf.story.play.runner/step-skip idx step)
 
       :else
-      (runner/step-fail idx step
+      (rf.story.play.runner/step-fail idx step
                         {:message (str "type failed — no node matched " (pr-str selector))}))))
 
 (defn- exec-focus!
@@ -726,18 +726,18 @@
   step at preflight, so this is the belt-and-braces runtime guard); a
   DOM/browser runner fires the synthetic focus and records a step-skip."
   [_frame-id idx step]
-  (let [selector (runner/step-selector step)]
+  (let [selector (rf.story.play.runner/step-selector step)]
     (cond
-      (not (dom/dom-available?))
-      (runner/step-fail idx step
+      (not (rf.story.play.dom/dom-available?))
+      (rf.story.play.runner/step-fail idx step
                         {:skipped? true
                          :message  (str "no DOM — cannot focus " (pr-str selector))})
 
-      (dom/focus! selector)
-      (runner/step-skip idx step)
+      (rf.story.play.dom/focus! selector)
+      (rf.story.play.runner/step-skip idx step)
 
       :else
-      (runner/step-fail idx step
+      (rf.story.play.runner/step-fail idx step
                         {:message (str "focus failed — no node matched " (pr-str selector))}))))
 
 (declare exec-assert-dom-atom!)
@@ -775,12 +775,12 @@
   throwing host yields nil. This is the `:hiccup`-tier proof surface
   `:rf.assert/a11y-structural` walks."
   [frame-id]
-  (when-let [f (late-bind/get-fn :render-hiccup)]
+  (when-let [f (rf.story.late-bind/get-fn :render-hiccup)]
     (try (f frame-id)
          (catch #?(:clj Throwable :cljs :default) _ nil))))
 
 (defn- browser-assertion-ctx
-  "Build the per-run `ctx` `browser/eval-browser-assertion` consumes for
+  "Build the per-run `ctx` `rf.story.play.browser/eval-browser-assertion` consumes for
   `frame-id`. Carries `:frame-id` (so the a11y evaluator can read the live
   axe-violations atom) and the rendered `:hiccup` tree from the
   `:render-hiccup` seam (so the structural-a11y evaluator can walk it). The
@@ -798,7 +798,7 @@
   never a vacuous pass over a nil tree (the honesty floor — spec/017
   §`:cannot-run`)."
   [payload]
-  {:assertion   assertions/id-a11y-structural
+  {:assertion   rf.story.assertions/id-a11y-structural
    :payload     (vec payload)
    :passed?     false
    :cannot-run? true
@@ -810,7 +810,7 @@
 (defn- exec-assert-browser-atom!
   "Evaluate a browser-tier oracle assertion atom `[:rf.assert/visual-snapshot
   | :rf.assert/a11y | :rf.assert/a11y-structural & args]` at this checkpoint
-  (drives `browser/eval-browser-assertion` from the run path). Mirrors
+  (drives `rf.story.play.browser/eval-browser-assertion` from the run path). Mirrors
   `exec-assert-dom-atom!`: drives the pure
   executor, records the CANONICAL assertion record on the frame slot (so the
   unified result's `:assertions` carries the real browser-tier id), and
@@ -827,23 +827,23 @@
   `:cannot-run`, never a silent pass) and surfaced as a step-fail carrying the
   refusal."
   [frame-id idx step atom-v]
-  (let [aid    (assertions/assertion-atom-id atom-v)
+  (let [aid    (rf.story.assertions/assertion-atom-id atom-v)
         hiccup (render-hiccup-for frame-id)
-        result (if (and (= assertions/id-a11y-structural aid) (nil? hiccup))
+        result (if (and (= rf.story.assertions/id-a11y-structural aid) (nil? hiccup))
                  ;; Honesty floor: a11y-structural with no hiccup tree cannot
                  ;; be proven — refuse rather than pass over an empty tree.
                  (structural-a11y-cannot-run-finding (vec (rest atom-v)))
-                 (browser/eval-browser-assertion
+                 (rf.story.play.browser/eval-browser-assertion
                    atom-v (browser-assertion-ctx frame-id hiccup)))]
     ;; Record the canonical browser-tier assertion record on the slot so the
     ;; unified verdict folds it (a :cannot-run record aggregates to the THIRD
     ;; status; a :fail flips the run to :fail).
-    (assertions/record!
+    (rf.story.assertions/record!
       frame-id
       (cond-> {:assertion    aid
                :passed?      (boolean (:passed? result))
                :payload      (vec (rest atom-v))
-               :source-coord (:source (registrar/handler-meta :variant frame-id))}
+               :source-coord (:source (rf.story.registrar/handler-meta :variant frame-id))}
         (contains? result :status)   (assoc :status   (:status result))
         (:cannot-run? result)        (assoc :cannot-run? true)
         (contains? result :expected) (assoc :expected (:expected result))
@@ -851,13 +851,13 @@
         (:reason result)             (assoc :reason   (:reason result))))
     (cond
       (:cannot-run? result)
-      (runner/step-fail idx step
+      (rf.story.play.runner/step-fail idx step
                         {:cannot-run? true
                          :reason      (:reason result)
                          :message     (or (:reason result)
                                           (str "cannot run " (pr-str atom-v)))})
-      (:passed? result) (runner/step-pass idx step)
-      :else             (runner/step-fail idx step
+      (:passed? result) (rf.story.play.runner/step-pass idx step)
+      :else             (rf.story.play.runner/step-fail idx step
                                           {:expected (:expected result)
                                            :actual   (:actual result)
                                            :message  (:reason result)}))))
@@ -892,8 +892,8 @@
   the rendered hiccup tree and surfaces the honest `:cannot-run` for the
   browser-only pair), so it is NOT tape-evaluated."
   [atom-v]
-  (or (assertions/schema-error? atom-v)
-      (assertions/causal? atom-v)))
+  (or (rf.story.assertions/schema-error? atom-v)
+      (rf.story.assertions/causal? atom-v)))
 
 (defn- exec-assert!
   "Execute an `[:assert [:rf.assert/id & args]]` in-script checkpoint.
@@ -915,7 +915,7 @@
   - The browser-tier oracle family (`:rf.assert/visual-snapshot` /
     `:rf.assert/a11y` / `:rf.assert/a11y-structural`) is EVALUATED directly
     through `exec-assert-browser-atom!` (driving
-    `browser/eval-browser-assertion`). At the
+    `rf.story.play.browser/eval-browser-assertion`). At the
     `:hiccup` tier `:rf.assert/a11y-structural` walks the rendered hiccup
     tree and records a real `:pass` / `:fail`; with no tree (the headless
     floor) it records `:cannot-run`. The browser-only pair record
@@ -932,34 +932,34 @@
     we bridge that record back into the runner step stream so a failing
     checkpoint flips the play's terminal status to `:fail`."
   [frame-id idx step]
-  (let [atom-v (runner/step-assertion step)]
+  (let [atom-v (rf.story.play.runner/step-assertion step)]
     (cond
-      (contains? assertions/dom-assertion-ids (first atom-v))
+      (contains? rf.story.assertions/dom-assertion-ids (first atom-v))
       (exec-assert-dom-atom! frame-id idx step atom-v)
 
       ;; Browser-tier oracle family — route to the dedicated executor.
       ;; a11y-structural runs at :hiccup; visual / a11y fail closed to
       ;; :cannot-run headless. NEVER a no-op skip.
-      (contains? assertions/browser-assertion-ids (first atom-v))
+      (contains? rf.story.assertions/browser-assertion-ids (first atom-v))
       (exec-assert-browser-atom! frame-id idx step atom-v)
 
       ;; Tape-evaluated families carry no reg-event handler; the result
       ;; boundary owns their verdict. Record a no-op step-skip — never a
       ;; dispatch (which would hit :rf.error/no-such-handler).
       (tape-evaluated-assertion? atom-v)
-      (runner/step-skip idx step)
+      (rf.story.play.runner/step-skip idx step)
 
       :else
       (let [prev     (assertion-count frame-id)
-            required (boundary/step-required-boundary step)
+            required (rf.story.play.settled-boundary/step-required-boundary step)
             hooks    (current-flush-hooks frame-id)
             settle   (try
-                       (boundary/dispatch-and-settle! frame-id atom-v hooks required step)
+                       (rf.story.play.settled-boundary/dispatch-and-settle! frame-id atom-v hooks required step)
                        (catch #?(:clj Throwable :cljs :default) e
                          {:status :error
                           :error  #?(:clj (.getMessage ^Throwable e) :cljs (str e))
                           :step   step}))]
-        (play/drain-pending-exceptions! frame-id :phase-4-play)
+        (rf.story.play/drain-pending-exceptions! frame-id :phase-4-play)
         (or (boundary-result->step idx step settle)
             ;; The wrapped :rf.assert/* handler recorded its outcome on the
             ;; frame's :rf.story/assertions slot. Read what landed since the
@@ -968,15 +968,15 @@
                   new   (subvec all (min prev (count all)))
                   rec   (last new)]
               (cond
-                (nil? rec)            (runner/step-skip idx step)
+                (nil? rec)            (rf.story.play.runner/step-skip idx step)
                 (false? (:passed? rec))
-                (runner/step-fail idx step
+                (rf.story.play.runner/step-fail idx step
                                   {:expected (:expected rec)
                                    :actual   (:actual rec)
                                    :message  (or (:reason rec)
                                                  (str (:assertion rec) " "
                                                       (pr-str (:payload rec)) " failed"))})
-                :else                 (runner/step-pass idx step))))))))
+                :else                 (rf.story.play.runner/step-pass idx step))))))))
 
 (defn- frame-router-state
   "Read the raw `{:queue :scheduled? ...}` router state for `frame-id`, or
@@ -989,7 +989,7 @@
   reads as nil."
   [frame-id]
   (try
-    (some-> (frame/frame frame-id) :router deref)
+    (some-> (rf.frame/frame frame-id) :router deref)
     (catch #?(:clj Throwable :cljs :default) _ nil)))
 
 (defn- queue-empty?
@@ -1004,9 +1004,9 @@
   following `[:wait-until [:queue-empty]]` runs. But this step can ALSO
   follow a `:click` / `:type` / `:focus` step — `exec-click!` / `exec-type!`
   / `exec-focus!` (above) fire a synthetic DOM event directly and never
-  call `boundary/dispatch-and-settle!`. A handler the synthetic event
+  call `rf.story.play.settled-boundary/dispatch-and-settle!`. A handler the synthetic event
   triggers may issue an ASYNC `[:dispatch …]` that has not yet drained —
-  the router schedules an async drain via `interop/next-tick`, genuinely
+  the router schedules an async drain via `rf.interop/next-tick`, genuinely
   deferred, never inline (`re-frame.router/ensure-drain-scheduled!`). A
   hard-coded `true` silently reported that pending dispatch as settled, so
   a following `:assert-*` step could read app-db BEFORE it landed — the
@@ -1033,7 +1033,7 @@
                        actual (get-in db path)]
                    (case mode
                      :equals (= expected actual)
-                     :pred   (let [f (if pred-fn? pred-ref (pred/resolve-sym-pred pred-ref))]
+                     :pred   (let [f (if pred-fn? pred-ref (rf.story.predicates/resolve-sym-pred pred-ref))]
                                (boolean (and f (try (f actual)
                                                     (catch #?(:clj Throwable :cljs :default) _ false)))))
                      false))
@@ -1051,10 +1051,10 @@
   poll is the adapter caller's concern — the headless contract is the
   one-shot deterministic check this fn implements.)"
   [frame-id idx step]
-  (let [pspec   (runner/step-wait-until step)]
+  (let [pspec   (rf.story.play.runner/step-wait-until step)]
     (if (wait-until-satisfied? frame-id pspec)
-      (runner/step-skip idx step)
-      (runner/step-fail idx step
+      (rf.story.play.runner/step-skip idx step)
+      (rf.story.play.runner/step-fail idx step
                         {:cannot-run? false
                          :expected (nth step 1)
                          :message  (str "wait-until " (pr-str (nth step 1))
@@ -1063,15 +1063,15 @@
                                         "after the preceding dispatch settled)")}))))
 
 (defn- presence-step-result
-  "Project a `presence/advance!` result into a step-result. Pure data → data,
+  "Project a `rf.story.play.presence/advance!` result into a step-result. Pure data → data,
   and the ONE place the projection lives — the executor projects the
   provisional result here, and `settle-step-result!` re-projects the settled
   one through the very same fn, so a Promise-backed host cannot acquire a
   different vocabulary just by being asynchronous."
   [idx step res]
   (case (:status res)
-    :error   (runner/step-exception idx step (:error res))
-    :no-host (runner/step-fail
+    :error   (rf.story.play.runner/step-exception idx step (:error res))
+    :no-host (rf.story.play.runner/step-fail
                idx step
                {:cannot-run? true
                 :reason      :no-presence-host
@@ -1084,7 +1084,7 @@
                                   "install-presence-flush! with its own "
                                   "clock advance — a 1-arg fn taking the ms "
                                   "to advance by, or nil for 'to quiescence'")})
-    (runner/step-skip idx step)))
+    (rf.story.play.runner/step-skip idx step)))
 
 (defn- exec-flush-presence!
   "Execute a `[:flush-presence]` / `[:flush-presence ms]` step — advance the
@@ -1114,8 +1114,8 @@
   `::pending-advance`; `settle-step-result!` replaces it with the real one
   before the run records anything."
   [_frame-id idx step]
-  (let [ms  (runner/step-presence-ms step)
-        res (presence/advance! ms)]
+  (let [ms  (rf.story.play.runner/step-presence-ms step)
+        res (rf.story.play.presence/advance! ms)]
     (cond-> (presence-step-result idx step res)
       (:pending res) (assoc ::pending-advance res))))
 
@@ -1132,7 +1132,7 @@
   must not disagree about whether a presence flush failed."
   [idx step result k]
   (if-let [res (::pending-advance result)]
-    (presence/settle! res #(k (presence-step-result idx step %)))
+    (rf.story.play.presence/settle! res #(k (presence-step-result idx step %)))
     (k result))
   nil)
 
@@ -1156,12 +1156,12 @@
   boundary rather than throwing on the way to the executor that will
   report it properly."
   [step]
-  (let [declared (boundary/step-required-boundary step)]
-    (if (and (= :assert (runner/step-type step))
-             (let [atom-v (runner/step-assertion step)]
+  (let [declared (rf.story.play.settled-boundary/step-required-boundary step)]
+    (if (and (= :assert (rf.story.play.runner/step-type step))
+             (let [atom-v (rf.story.play.runner/step-assertion step)]
                (and (vector? atom-v)
-                    (contains? assertions/dom-assertion-ids (first atom-v)))))
-      (boundary/max-boundary declared :dom)
+                    (contains? rf.story.assertions/dom-assertion-ids (first atom-v)))))
+      (rf.story.play.settled-boundary/max-boundary declared :dom)
       declared)))
 
 (defn- settle-substrate-for-step!
@@ -1188,14 +1188,14 @@
   which is every headless host. So the JVM path is unchanged."
   [frame-id idx step]
   (let [required (step-settle-boundary step)]
-    (when (boundary/boundary>= required :cljs-reactive)
+    (when (rf.story.play.settled-boundary/boundary>= required :cljs-reactive)
       (boundary-result->step
         idx step
-        (boundary/settle-to! frame-id (current-flush-hooks frame-id) required step)))))
+        (rf.story.play.settled-boundary/settle-to! frame-id (current-flush-hooks frame-id) required step)))))
 
 (defn exec-step!
   "Execute ONE step against `frame-id`. Returns a step-result record
-  (per `runner/step-pass` / `step-fail` / `step-skip` / `step-exception`).
+  (per `rf.story.play.runner/step-pass` / `step-fail` / `step-skip` / `step-exception`).
   Pure-shape return — the run-state mutation is the caller's job.
 
   `:wait` is special-cased OUT of this fn — it requires an async
@@ -1203,7 +1203,7 @@
 
   The runtime consumes the folded plan: every script is folded at
   resolution time (`runner-events/variant-plays` /
-  `play/variant-play-steps`), so a shipping `:assert-db` / `:assert-dom`
+  `rf.story.play/variant-play-steps`), so a shipping `:assert-db` / `:assert-dom`
   step has already become the canonical `[:assert assertion-atom]`
   checkpoint by the time it reaches here. A raw `:assert-db` / `:assert-dom`
   (a hand-built step that bypassed resolution) is folded inline as a
@@ -1217,7 +1217,7 @@
   [frame-id idx step]
   (or
     (settle-substrate-for-step! frame-id idx step)
-    (let [stype (runner/step-type step)]
+    (let [stype (rf.story.play.runner/step-type step)]
       (case stype
         :dispatch       (exec-dispatch!      frame-id idx step)
         :dispatch-sync  (exec-dispatch-sync! frame-id idx step)
@@ -1225,14 +1225,14 @@
         ;; A raw shipping assertion step that escaped folding — fold it inline
         ;; to the canonical checkpoint and run the ONE assert executor.
         (:assert-db
-         :assert-dom)   (exec-assert! frame-id idx (assertions/fold-assert-step step))
+         :assert-dom)   (exec-assert! frame-id idx (rf.story.assertions/fold-assert-step step))
         :wait-until     (exec-wait-until!    frame-id idx step)
         :flush-presence (exec-flush-presence! frame-id idx step)
         :click          (exec-click!         frame-id idx step)
         :type           (exec-type!          frame-id idx step)
         :focus          (exec-focus!         frame-id idx step)
-        :wait           (runner/step-skip idx step)   ; driver handles the actual sleep
-        (runner/unknown-step idx step)))))
+        :wait           (rf.story.play.runner/step-skip idx step)   ; driver handles the actual sleep
+        (rf.story.play.runner/unknown-step idx step)))))
 
 ;; ---- terminal assertions ------------------------------------------------
 ;;
@@ -1293,7 +1293,7 @@
   identifies by `(contains? dom-assertion-ids (first atom-v))`."
   [atom-v settle-result]
   (let [cannot-run? (boolean (:cannot-run? settle-result))]
-    (cond-> {:assertion (assertions/assertion-atom-id atom-v)
+    (cond-> {:assertion (rf.story.assertions/assertion-atom-id atom-v)
              :payload   (vec (rest atom-v))
              :passed?   false
              :status    (if cannot-run? :cannot-run :error)
@@ -1329,7 +1329,7 @@
   Idempotent w.r.t. an empty / nil `atoms` (no-op). Production callers
   (Story disabled) no-op."
   [frame-id atoms]
-  (when (and config/enabled? (seq atoms))
+  (when (and rf.story.config/enabled? (seq atoms))
     (doseq [[idx atom-v] (map-indexed vector atoms)]
       (let [step [:assert atom-v]]
         ;; Terminal assertions are the OTHER place a DOM atom is evaluated,
@@ -1357,10 +1357,10 @@
         ;; so every headless run (JVM included) takes the `exec-assert!`
         ;; arm unchanged.
         (if-let [refused (settle-substrate-for-step! frame-id idx step)]
-          (assertions/record!
+          (rf.story.assertions/record!
             frame-id
             (assoc (terminal-settle-refusal-record atom-v refused)
-                   :source-coord (:source (registrar/handler-meta :variant frame-id))))
+                   :source-coord (:source (rf.story.registrar/handler-meta :variant frame-id))))
           (exec-assert! frame-id idx step)))))
   nil)
 
@@ -1381,13 +1381,13 @@
   a step-skip rather than blocking — the interactive stepper does not
   sleep).
 
-  Public so the step-debugger substrate (`play/step-once!`) can drive a
+  Public so the step-debugger substrate (`rf.story.play/step-once!`) can drive a
   full rich-DSL step without re-implementing the executor. Reached from
   `play.cljc` via the `:run-play-step` late-bind hook to avoid the
   play ↔ runner-events require cycle.
 
   Always records its settle boundary under play-key nil — the stepper
-  (`play/variant-play-steps`) only ever walks the DEFAULT play, never a
+  (`rf.story.play/variant-play-steps`) only ever walks the DEFAULT play, never a
   named `:plays` entry.
 
   `settled-cb` (optional) receives the FINAL step-result. It is invoked
@@ -1405,7 +1405,7 @@
    (let [result (try
                   (exec-step! frame-id idx step)
                   (catch #?(:clj Throwable :cljs :default) e
-                    (runner/step-exception idx step
+                    (rf.story.play.runner/step-exception idx step
                                            #?(:clj  (.getMessage ^Throwable e)
                                               :cljs (str e)))))]
      ;; `exec-step!` (via `exec-assert!`) already wrote the canonical
@@ -1459,7 +1459,7 @@
   inside `exec-assert!` (the canonical folded-atom record), so this does
   not mirror a synthetic record on top."
   [frame-id play-key name idx step result]
-  (update-state! frame-id play-key runner/record-step-result result)
+  (update-state! frame-id play-key rf.story.play.runner/record-step-result result)
   (emit-trace! frame-id name idx step result)
   nil)
 
@@ -1467,7 +1467,7 @@
   "Transition the run-state to `:pass` / `:fail` and resolve `done-cb`
   with the final state."
   [frame-id play-key done-cb]
-  (update-state! frame-id play-key runner/finish (now-ms))
+  (update-state! frame-id play-key rf.story.play.runner/finish (now-ms))
   (when done-cb
     (try (done-cb (current-state-for-play frame-id play-key))
          (catch #?(:clj Throwable :cljs :default) _ nil))))
@@ -1482,7 +1482,7 @@
   reset / concurrent `run!` / teardown a window to mutate the shared
   run-state between steps.
 
-  Unlike `finish!`, this does NOT call `update-state!` / `runner/finish` — an
+  Unlike `finish!`, this does NOT call `update-state!` / `rf.story.play.runner/finish` — an
   aborted loop must NOT clobber the shared run-state slot, which by this point
   may belong to the NEWER run that took over (token mismatch) or be gone (frame
   torn down). It resolves the awaiting `done-cb` with the last-known state
@@ -1538,7 +1538,7 @@
 ;;   1. THE ASYNC DISPATCH. `exec-click!` / `exec-type!` / `exec-focus!` fire
 ;;      a synthetic DOM event; React runs the handler; the handler
 ;;      dispatches; the router schedules its drain through
-;;      `interop/next-tick` — `goog.async.nextTick`, a genuine macrotask,
+;;      `rf.interop/next-tick` — `goog.async.nextTick`, a genuine macrotask,
 ;;      never inline. The next step then read app-db before the handler's
 ;;      event had run: `expected 42 at [:count] but got 0`. Note that this
 ;;      is NOT "nothing drains the queue" — `dispatch-sync!` pushes its seed
@@ -1594,8 +1594,8 @@
   assertion can be evaluated. `:rf.assert/dom-hidden` is deliberately
   absent — an absent node is its PASS condition, so waiting for one to
   appear would invert the assertion and burn the whole budget doing it."
-  #{assertions/id-dom-text
-    assertions/id-dom-visible})
+  #{rf.story.assertions/id-dom-text
+    rf.story.assertions/id-dom-visible})
 
 (defn- atom-required-selector
   "The DOM selector an assertion ATOM must be able to resolve before it can
@@ -1635,12 +1635,12 @@
   node required' so the step reaches the executor that reports it
   properly, instead of timing out on a precondition first."
   [step]
-  (case (runner/step-type step)
-    (:click :type :focus) (runner/step-selector step)
-    :assert               (atom-required-selector (runner/step-assertion step))
+  (case (rf.story.play.runner/step-type step)
+    (:click :type :focus) (rf.story.play.runner/step-selector step)
+    :assert               (atom-required-selector (rf.story.play.runner/step-assertion step))
     :assert-dom           (atom-required-selector
-                            (try (runner/step-assertion
-                                   (assertions/fold-assert-step step))
+                            (try (rf.story.play.runner/step-assertion
+                                   (rf.story.assertions/fold-assert-step step))
                                  (catch #?(:clj Throwable :cljs :default) _ nil)))
     nil))
 
@@ -1669,8 +1669,8 @@
       "the frame's event queue has not drained"
 
       (and selector
-           (dom/dom-available?)
-           (nil? (dom/query selector)))
+           (rf.story.play.dom/dom-available?)
+           (nil? (rf.story.play.dom/query selector)))
       (str "no node matches " (pr-str selector))
 
       :else nil)))
@@ -1694,7 +1694,7 @@
   `:type`, `:wait`) yield one tick so the queued effects drain before
   the next step runs. A blanket setTimeout-0 between every step would
   reintroduce the re-mount race the async-class split avoids — see
-  `runner/async-yield?`.
+  `rf.story.play.runner/async-yield?`.
 
   On CLJS a step does not run until its PRECONDITIONS hold
   (`step-precondition-unmet` — the queue drained, and the node present
@@ -1722,12 +1722,12 @@
       (stale-run? token state)
       (settle-abort! frame-id play-key done-cb)
 
-      (runner/done? state)
+      (rf.story.play.runner/done? state)
       (finish! frame-id play-key done-cb)
 
       :else
       (let [idx  (:step-idx state)
-            step (runner/current-step state)
+            step (rf.story.play.runner/current-step state)
             nm   (:name state)
             ;; Read once per pass. CLJS-only: the JVM runner has no event
             ;; loop to yield to and no DOM, so it never polls and never
@@ -1735,9 +1735,9 @@
             unmet #?(:cljs (step-precondition-unmet frame-id step)
                      :clj  nil)]
         (cond
-          (= :wait (runner/step-type step))
-          (let [ms (or (runner/step-wait-ms step) 0)]
-            (record-result! frame-id play-key nm idx step (runner/step-skip idx step))
+          (= :wait (rf.story.play.runner/step-type step))
+          (let [ms (or (rf.story.play.runner/step-wait-ms step) 0)]
+            (record-result! frame-id play-key nm idx step (rf.story.play.runner/step-skip idx step))
             ;; JVM: fold the wait INTO the loop so it stays in TAIL position.
             ;; `schedule!` on the JVM used to nest `(Thread/sleep ms)(f)` — a
             ;; fresh `run-loop!` frame per wait — so a script of many
@@ -1759,9 +1759,9 @@
           #?@(:cljs
               [(and (some? unmet)
                     (or (nil? settle-deadline)
-                        (< (interop/now-ms) settle-deadline)))
+                        (< (rf.interop/now-ms) settle-deadline)))
                (let [deadline (or settle-deadline
-                                  (+ (interop/now-ms) settle-poll-timeout-ms))
+                                  (+ (rf.interop/now-ms) settle-poll-timeout-ms))
                      ;; Commit anything the substrate has already scheduled.
                      ;; This is rf2-ek9qb's own rung, reused: on a
                      ;; rAF-scheduled substrate in a throttled tab the
@@ -1803,7 +1803,7 @@
                (do
                  (record-result!
                    frame-id play-key nm idx step
-                   (runner/step-fail
+                   (rf.story.play.runner/step-fail
                      idx step
                      {:message (str "step preconditions never settled within "
                                     settle-poll-timeout-ms "ms — " unmet)}))
@@ -1815,10 +1815,10 @@
                 result (try
                          (exec-step! frame-id idx step)
                          (catch #?(:clj Throwable :cljs :default) e
-                           (runner/step-exception idx step
+                           (rf.story.play.runner/step-exception idx step
                                                   #?(:clj  (.getMessage ^Throwable e)
                                                      :cljs (str e)))))
-                yield? (runner/async-yield? step)]
+                yield? (rf.story.play.runner/async-yield? step)]
             (if (::pending-advance result)
               ;; A Promise-backed presence host has NOT settled (rf2-iz0t8).
               ;; AWAIT it before recording anything: a rejection is the step's
@@ -1938,14 +1938,14 @@
                    ;; play of a `:script` variant Just Works.
                    (variant-play-script variant-id))
          pk    (or play-key (:name spec))
-         init  (runner/initial-state spec)
+         init  (rf.story.play.runner/initial-state spec)
          ;; Stamp a fresh token on every run. The loop reads it back from
          ;; the state map; if a concurrent run! replaces the state mid-loop,
          ;; the stale loop sees a mismatched token and aborts before
          ;; re-dispatching.
          token   #?(:clj (java.util.UUID/randomUUID)
                     :cljs (.toString (js/Math.random)))
-         started (-> (runner/start init (now-ms))
+         started (-> (rf.story.play.runner/start init (now-ms))
                      (assoc :run-token token))]
      ;; Reset the per-dispatch-step settle boundaries here, in the SAME
      ;; public entry that resets run-state and then writes boundaries via
@@ -2025,9 +2025,9 @@
   ([variant-id]
    (auto-run! variant-id nil))
   ([variant-id done-cb]
-   (when config/enabled?
+   (when rf.story.config/enabled?
      (let [plays      (variant-plays variant-id)
-           auto-plays (runner/auto-runnable-plays plays)]
+           auto-plays (rf.story.play.runner/auto-runnable-plays plays)]
        (cond
          (empty? auto-plays)
          nil
@@ -2101,11 +2101,11 @@
 ;; the `:run-play-step` late-bind hook. Registered at ns load so it is
 ;; available as soon as the play module drives a stepped run.
 
-(late-bind/set-fn! :run-play-step run-step!)
+(rf.story.late-bind/set-fn! :run-play-step run-step!)
 
 ;; The stepper appends a settle boundary per `run-step!`, so a fresh
-;; stepping session (`play/begin-stepper!`) must reset the frame's
+;; stepping session (`rf.story.play/begin-stepper!`) must reset the frame's
 ;; boundaries first — the stepper analogue of `run!`'s reset. Exposed via the
 ;; same late-bind seam since `play.cljc` cannot `:require` this ns.
 
-(late-bind/set-fn! :clear-step-boundaries clear-step-boundaries!)
+(rf.story.late-bind/set-fn! :clear-step-boundaries clear-step-boundaries!)

--- a/tools/story/src/re_frame/story/play/settled_boundary.cljc
+++ b/tools/story/src/re_frame/story/play/settled_boundary.cljc
@@ -76,8 +76,8 @@
   flush fns are injected by adapter callers; this ns only *names* the
   ladder, *routes* a dispatch through the supplied hooks, and *refuses*
   when the supplied boundary is too weak."
-  (:require [re-frame.router :as router]
-            [re-frame.interop :as interop]))
+  (:require [re-frame.router :as rf.router]
+            [re-frame.interop :as rf.interop]))
 
 ;; ---- the boundary ladder -------------------------------------------------
 
@@ -200,7 +200,7 @@
   ([frame-id event-vector]
    (drain-sync! frame-id event-vector nil))
   ([frame-id event-vector opts]
-   (router/dispatch-sync! event-vector (merge {:frame frame-id} opts))
+   (rf.router/dispatch-sync! event-vector (merge {:frame frame-id} opts))
    nil))
 
 (def headless-flush-hooks
@@ -284,7 +284,7 @@
        (let [flushes    (:flush! hooks)
              timeout-ms (:timeout-ms hooks)
              deadline   (when (number? timeout-ms)
-                          (+ (interop/now-ms) timeout-ms))
+                          (+ (rf.interop/now-ms) timeout-ms))
              ;; Every registered level up to and including `required`, in
              ;; ladder order. The headless flush is folded into `:dispatch!`
              ;; (`drain-sync!`), so its hook is a no-op; the richer flushes
@@ -299,7 +299,7 @@
              ;; iteration — means an over-budget terminal flush refuses with
              ;; a fail-closed `:flush-timeout` instead of a settled pass it
              ;; did not earn.
-             (and deadline (> (interop/now-ms) deadline))
+             (and deadline (> (rf.interop/now-ms) deadline))
              (flush-timeout-result required provided step)
 
              (nil? level)

--- a/tools/story/src/re_frame/story/play/substrate_boundary.cljc
+++ b/tools/story/src/re_frame/story/play/substrate_boundary.cljc
@@ -59,8 +59,8 @@
   drain is the same at every rung, and the richer rungs add the render
   commit on top of it rather than replacing it."
   (:require [re-frame.core :as rf]
-            [re-frame.story.late-bind :as late-bind]
-            [re-frame.story.play.settled-boundary :as boundary]))
+            [re-frame.story.late-bind :as rf.story.late-bind]
+            [re-frame.story.play.settled-boundary :as rf.story.play.settled-boundary]))
 
 (defn adapter-flush-render
   "The installed adapter's optional `:flush-render!` contract fn, or nil.
@@ -105,11 +105,11 @@
                     (flush-render (fn [] nil))
                     nil)]
       {:provides  :dom
-       :dispatch! boundary/drain-sync!
+       :dispatch! rf.story.play.settled-boundary/drain-sync!
        :flush!    {:headless      (fn headless-flush [_frame-id] nil)
                    :cljs-reactive commit!
                    :dom           commit!}})
-    boundary/headless-flush-hooks))
+    rf.story.play.settled-boundary/headless-flush-hooks))
 
 (defn install!
   "Register `substrate-flush-hooks` under the `:settled-boundary-hooks`
@@ -120,5 +120,5 @@
   settles layout and paint, say — registers its own hooks after boot and
   wins the slot, which is what the late-bind seam is for."
   []
-  (late-bind/set-fn! :settled-boundary-hooks substrate-flush-hooks)
+  (rf.story.late-bind/set-fn! :settled-boundary-hooks substrate-flush-hooks)
   nil)

--- a/tools/story/src/re_frame/story/promotion.cljc
+++ b/tools/story/src/re_frame/story/promotion.cljc
@@ -66,10 +66,10 @@
   is the single impure entry; it gates on `re-frame.story.config/enabled?`
   so a production CLJS build short-circuits before touching the side-table
   (mirroring `save-variant`)."
-  (:require [re-frame.story.config     :as config]
-            [re-frame.story.plan       :as plan]
-            [re-frame.story.play.runner :as runner]
-            [re-frame.story.registrar  :as registrar]))
+  (:require [re-frame.story.config     :as rf.story.config]
+            [re-frame.story.plan       :as rf.story.plan]
+            [re-frame.story.play.runner :as rf.story.play.runner]
+            [re-frame.story.registrar  :as rf.story.registrar]))
 
 ;; ===========================================================================
 ;; Runnable reproducibility slots (rf2-vf8es)
@@ -101,19 +101,19 @@
 ;; `:fx-decisions` ALSO carries the lowered redirect `{:rf.http/managed
 ;; :rf.http/managed-test-stub}` (the plan lowered `:network` to it at
 ;; capture time). The body's `:network` slot re-derives that SAME redirect
-;; via `plan/lower-network`, and the compiler's `check-network-fx-conflict!`
+;; via `rf.story.plan/lower-network`, and the compiler's `check-network-fx-conflict!`
 ;; HARD-FAILS when both `:network` and an explicit `:fx-overrides` target
 ;; `:rf.http/managed`. So when `:network` is present we DROP `:rf.http/managed`
 ;; from the lifted `:fx-overrides` — `:network` owns that key. Any OTHER
 ;; fx-decision (a non-HTTP override) still rides `:fx-overrides`.
 
 (def managed-fx-id
-  "Re-export of the managed-HTTP fx id (`plan/managed-fx-id`,
+  "Re-export of the managed-HTTP fx id (`rf.story.plan/managed-fx-id`,
   `:rf.http/managed`) the `:network` slot owns. A `:network`-stubbed
   artifact's `:fx-decisions` carries the lowered redirect for this id; we
   drop it from the lifted `:fx-overrides` so it does not conflict with the
   body's `:network` slot (rf2-vf8es)."
-  plan/managed-fx-id)
+  rf.story.plan/managed-fx-id)
 
 (defn lift-fx-overrides
   "Project an artifact's `:fx-decisions` onto a variant body's
@@ -121,7 +121,7 @@
 
   Drops the `:rf.http/managed` redirect when `network?` is true: the
   body's `:network` slot re-derives that redirect through
-  `plan/lower-network`, and carrying it on BOTH surfaces is a hard
+  `rf.story.plan/lower-network`, and carrying it on BOTH surfaces is a hard
   `:rf.error/story-network-fx-conflict`. Returns nil when nothing
   survives (so the caller omits the slot rather than emitting an empty
   map)."
@@ -194,14 +194,14 @@
     behaviour the artifact recorded, so absent a hint nothing is demoted
     to a silent precondition.
 
-  The returned programs are coerced through `runner/coerce-script`, so a
+  The returned programs are coerced through `rf.story.play.runner/coerce-script`, so a
   bare event list lifts to a legal `[:dispatch …]` program and an
   already-tagged program passes through."
   [artifact {:keys [setup script setup-count] :as _opts}]
   (cond
     (or (some? setup) (some? script))
-    {:setup  (runner/coerce-script (or setup []))
-     :script (runner/coerce-script (or script []))}
+    {:setup  (rf.story.play.runner/coerce-script (or setup []))
+     :script (rf.story.play.runner/coerce-script (or script []))}
 
     (some? setup-count)
     (let [program (vec (:event-program artifact))
@@ -324,7 +324,7 @@
                         (some? lookup)        (assoc :lookup lookup)
                         (some? view-lookup)   (assoc :view-lookup view-lookup)
                         (some? validator-fns) (assoc :validator-fns validator-fns))
-         plan         (plan/variant-plan target compile-opts)]
+         plan         (rf.story.plan/variant-plan target compile-opts)]
      ;; The compiler reads only known variant slots, so the source link
      ;; does not survive into the plan on its own — re-attach it so the
      ;; materialized plan ALWAYS carries its provenance (spec/017
@@ -359,7 +359,7 @@
   indistinguishable from a hand-authored one except for its
   `:run-artifact` provenance slot.
 
-  Production CLJS builds (`config/enabled?` false) short-circuit before
+  Production CLJS builds (`rf.story.config/enabled?` false) short-circuit before
   the write and return nil, mirroring `save-variant`.
 
   Returns the registered variant id on success (the value
@@ -376,6 +376,6 @@
                                          "artifact is never auto-registered (spec/017 "
                                          "§Promotion).")
                        :artifact    (provenance-link artifact)})))
-    (when config/enabled?
+    (when rf.story.config/enabled?
       (let [body (artifact->variant-body artifact opts)]
-        (registrar/reg-variant* variant-id body)))))
+        (rf.story.registrar/reg-variant* variant-id body)))))

--- a/tools/story/src/re_frame/story/query.cljc
+++ b/tools/story/src/re_frame/story/query.cljc
@@ -12,8 +12,8 @@
   `re-frame.story.registrar` or `re-frame.story.schemas`; no mutation,
   no lifecycle / runtime / play state. Pure-data reads — JVM + CLJS
   portable, same shape across hosts."
-  (:require [re-frame.story.registrar :as registrar]
-            [re-frame.story.schemas   :as schemas]))
+  (:require [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.schemas   :as rf.story.schemas]))
 
 ;; ---- per-kind registry query ---------------------------------------------
 
@@ -26,34 +26,34 @@
   side-table. The Story registry is logically a peer of the framework
   registrar — see `001-Authoring.md` §Registration macros + bd rf2-7ho2 for the design rationale."
   [kind]
-  (registrar/registrations kind))
+  (rf.story.registrar/registrations kind))
 
 (defn handler-meta
   "Return the body for `(kind, id)`, or nil."
   [kind id]
-  (registrar/handler-meta kind id))
+  (rf.story.registrar/handler-meta kind id))
 
 (defn ids
   "Return the id set for `kind`."
   [kind]
-  (registrar/ids kind))
+  (rf.story.registrar/ids kind))
 
 (defn registered?
   "True iff `(kind, id)` is registered."
   [kind id]
-  (registrar/registered? kind id))
+  (rf.story.registrar/registered? kind id))
 
 (defn all-kinds-with-counts
   "{kind → count} — dev tooling overlay."
   []
-  (registrar/all-kinds-with-counts))
+  (rf.story.registrar/all-kinds-with-counts))
 
 ;; ---- convenience lookups -------------------------------------------------
 
 (defn variants-of
   "Return the set of variant ids whose parent is `story-id`."
   [story-id]
-  (registrar/variants-of story-id))
+  (rf.story.registrar/variants-of story-id))
 
 (defn variants-by-story
   "Return a `{story-id #{variant-id ...}}` index built in one pass over
@@ -64,7 +64,7 @@
   introspection tool); the single-pass index replaces the O(S × V)
   walk of calling `variants-of` per story (rf2-d3iso)."
   []
-  (registrar/variants-by-story))
+  (rf.story.registrar/variants-by-story))
 
 (defn variants-with-tags
   "Per `002-Runtime.md` §Programmatic API — return the set of variant ids
@@ -73,7 +73,7 @@
   resolver). The assertions/play surface leans on this; the render shell
   leans on this to compose the sidebar tree."
   [query-tags]
-  (registrar/variants-with-tags query-tags))
+  (rf.story.registrar/variants-with-tags query-tags))
 
 (defn list-tags
   "Per `002-Runtime.md` §Tag-vocabulary queries — return the set of registered tag ids. Tools
@@ -93,14 +93,14 @@
   tags into collapsible facet rows (rf2-v05qb SB9 parity). Returns the
   empty set if no tag carries that axis."
   [axis-kw]
-  (registrar/tags-by-axis axis-kw))
+  (rf.story.registrar/tags-by-axis axis-kw))
 
 (defn tags-without-axis
   "Per spec/001 §reg-tag — return the set of registered tag ids whose
   body carries no `:axis`. The sidebar renders these in a trailing
   un-grouped facet row."
   []
-  (registrar/tags-without-axis))
+  (rf.story.registrar/tags-without-axis))
 
 (defn tags-default-excluded
   "Per spec/001 §reg-tag — return the set of registered tag ids whose
@@ -108,37 +108,37 @@
   pre-excludes variants carrying any of these at boot (e.g.
   `:internal` / `:experimental`)."
   []
-  (registrar/tags-default-excluded))
+  (rf.story.registrar/tags-default-excluded))
 
 (def canonical-tags
   "Re-export of the seven canonical tag ids from /spec/007-Stories.md §Inclusion
   tags. Stable across hosts."
-  schemas/canonical-tags)
+  rf.story.schemas/canonical-tags)
 
 (def canonical-axes
   "Re-export of the canonical facet axes documented in spec/001
   §reg-tag — `:status`, `:role`, `:team`, `:feature` (rf2-7ncf9 SB9
   facet taxonomy) + `:state` (rf2-k1k87 operator-facing magnitude).
   Stable across hosts."
-  schemas/canonical-axes)
+  rf.story.schemas/canonical-axes)
 
 (def canonical-status-values
   "Re-export of the recommended `:status` axis vocabulary."
-  schemas/canonical-status-values)
+  rf.story.schemas/canonical-status-values)
 
 (def canonical-role-values
   "Re-export of the recommended `:role` axis vocabulary."
-  schemas/canonical-role-values)
+  rf.story.schemas/canonical-role-values)
 
 (def canonical-state-values
   "Re-export of the canonical `:state` axis vocabulary (rf2-k1k87) —
   `#{:empty :small :medium :large :special}`."
-  schemas/canonical-state-values)
+  rf.story.schemas/canonical-state-values)
 
 (def canonical-state-tags
   "Re-export of the canonical `:state/*` faceted tags registered at
   Story load (rf2-k1k87)."
-  schemas/canonical-state-tags)
+  rf.story.schemas/canonical-state-tags)
 
 (defn tag->axis-index
   "Per spec/001 §reg-tag — return a `{tag-id → axis-kw}` map across
@@ -147,4 +147,4 @@
   filter row + the `:tag-filter` AND-across-axes predicate (rf2-7ncf9)
   consume this."
   []
-  (registrar/tag->axis-index))
+  (rf.story.registrar/tag->axis-index))

--- a/tools/story/src/re_frame/story/recorder.cljc
+++ b/tools/story/src/re_frame/story/recorder.cljc
@@ -57,7 +57,7 @@
      event-vector error).
 
   The `[:rf/redacted]` placeholder still bumps the suppressed-events
-  counter (`config/note-suppressed!`) so the UI's redaction-indicator
+  counter (`rf.story.config/note-suppressed!`) so the UI's redaction-indicator
   hint stays accurate — the user sees an N-redacted-rows hint
   alongside the placeholders themselves. Hosts that want the
   unscrubbed payload in the recording (their own machine, dev loop)
@@ -72,7 +72,7 @@
   Story's local-render EGRESS PROFILE — `:rf.egress/local-redacted`
   (the fail-closed default) redacts; `:rf.egress/local-raw` (the
   trusted-local opt-in) passes — resolved through the framework's
-  centralized projection table (`config/suppress-sensitive?` →
+  centralized projection table (`rf.story.config/suppress-sensitive?` →
   `project-egress`'s `:rf.size/include-sensitive?` floor), NOT a
   process-global boolean. EP-0015 defines this named-boundary,
   frame-owned model.
@@ -121,13 +121,13 @@
   - `append-assertion`        — pure: state → state with assertion appended.
   - `insert-assertion!`       — impure entrypoint for the picker UI."
   (:require [clojure.string :as str]
-            [re-frame.story.config :as config]
-            [re-frame.story.late-bind :as late-bind]
-            [re-frame.story.predicates :as pred]
-            [re-frame.story.review-dialog :as review-dialog]
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.late-bind :as rf.story.late-bind]
+            [re-frame.story.predicates :as rf.story.predicates]
+            [re-frame.story.review-dialog :as rf.story.review-dialog]
             ;; The listener surface lives in `re-frame.trace.tooling`
             ;; (production-DCE split).
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: recordable event predicate
@@ -143,7 +143,7 @@
   not appear in a recorded `:script` body."
   [ns-str]
   (and (string? ns-str)
-       (or (= pred/reserved-assertion-ns ns-str)   ; "rf.assert"
+       (or (= rf.story.predicates/reserved-assertion-ns ns-str)   ; "rf.assert"
            (= "rf.story" ns-str)
            (str/starts-with? ns-str "re-frame.story")
            (str/starts-with? ns-str "rf.story."))))
@@ -277,7 +277,7 @@
                         events)
         script-str    (if (seq steps)
                         (str "["
-                             (str/join (pred/indent-after script-prefix)
+                             (str/join (rf.story.predicates/indent-after script-prefix)
                                        (map pr-str steps))
                              "]")
                         "[]")
@@ -289,7 +289,7 @@
                       doc     (conj [:doc (pr-str doc)])
                       extends (conj [:extends (pr-str extends)])
                       true    (conj [:script script-map-str]))]
-    (pred/reg-variant-form alias (or variant-id :story.recorded/example) body-keys)))
+    (rf.story.predicates/reg-variant-form alias (or variant-id :story.recorded/example) body-keys)))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: canonical assertion vocabulary
@@ -470,7 +470,7 @@
    (cond-> state
      (and (:recording? state)
           (vector? event)
-          (pred/assertion-event? event))
+          (rf.story.predicates/assertion-event? event))
      (-> (update :events (fnil conj []) (vec event))
          ;; Keep the parallel :cofx slot index-aligned with
          ;; :events — an inserted assertion carries no captured cofx.
@@ -748,10 +748,10 @@
   "recorded")
 
 (def initial-dialog-state
-  "Alias for `review-dialog/initial-state` — kept for call-site
+  "Alias for `rf.story.review-dialog/initial-state` — kept for call-site
   ergonomics so the dialog ratom seeding form reads as
   `recorder/initial-dialog-state`."
-  review-dialog/initial-state)
+  rf.story.review-dialog/initial-state)
 
 (defn open-dialog
   "Pure: return the dialog state for opening the save-as-variant modal
@@ -767,7 +767,7 @@
   translator with the full DOM+timing record; pass `nil` when no rich
   entries are available."
   [_state variant-id events entries now-ms]
-  (let [base (review-dialog/open review-dialog/initial-state
+  (let [base (rf.story.review-dialog/open rf.story.review-dialog/initial-state
                                  variant-id
                                  {:events  (vec events)
                                   :entries (vec (or entries []))}
@@ -779,13 +779,13 @@
 
 (defn close-dialog
   "Pure: return the dialog's idle state. Aliased to
-  `review-dialog/close` — the dialog has no recorder-specific close
+  `rf.story.review-dialog/close` — the dialog has no recorder-specific close
   behaviour."
   [_state]
-  review-dialog/initial-state)
+  rf.story.review-dialog/initial-state)
 
 ;; ---------------------------------------------------------------------------
-;; Impure: write the state atom. Gated under config/enabled? so the
+;; Impure: write the state atom. Gated under rf.story.config/enabled? so the
 ;; production CLJS build's call sites elide cleanly.
 ;; ---------------------------------------------------------------------------
 
@@ -796,13 +796,13 @@
   exists). Called at recording start/clear so a keystroke buffered under a
   PRIOR recording cannot bleed into the next one (rf2-x76af2.18)."
   []
-  (when-let [f (late-bind/get-fn :recorder/reset-dom-buffer)]
+  (when-let [f (rf.story.late-bind/get-fn :recorder/reset-dom-buffer)]
     (f)))
 
 (defn start-recording!
   "Begin recording events dispatched against `variant-id`'s frame.
   Returns the new state. Stops any in-flight recording first. Under
-  elision (`config/enabled?` false) returns the idle `initial-state`
+  elision (`rf.story.config/enabled?` false) returns the idle `initial-state`
   without touching the atom.
 
   EP-0023: the recording's address is the variant frame; replay dispatches
@@ -819,7 +819,7 @@
    (start-recording! variant-id #?(:clj (System/currentTimeMillis)
                                    :cljs (.now js/Date))))
   ([variant-id now-ms]
-   (if config/enabled?
+   (if rf.story.config/enabled?
      (do (reset-dom-buffer!)
          (swap! state start variant-id now-ms))
      initial-state)))
@@ -829,7 +829,7 @@
   the UI's save-as-variant dialog. Returns the new state. Under
   elision returns `initial-state` without touching the atom."
   []
-  (if config/enabled?
+  (if rf.story.config/enabled?
     (swap! state stop)
     initial-state))
 
@@ -841,7 +841,7 @@
   a discarded recording leaves no phantom keystroke to land in a subsequent
   recording (rf2-x76af2.18)."
   []
-  (if config/enabled?
+  (if rf.story.config/enabled?
     (do (reset-dom-buffer!)
         (reset! state initial-state))
     initial-state))
@@ -869,7 +869,7 @@
   empty cofx records a cofx-less trace."
   ([event] (record-event! event nil))
   ([event cofx]
-   (when config/enabled?
+   (when rf.story.config/enabled?
      (swap! state append event (now-ms*) cofx))
    nil))
 
@@ -887,7 +887,7 @@
   Idempotent against malformed inputs (filtered by `dom-event?`).
   No-op under production elision."
   [entry]
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (swap! state append-dom entry))
   nil)
 
@@ -898,7 +898,7 @@
   the flush even when the flush fires after `stop-recording!` has cleared
   `:recording?`. Idempotent against malformed inputs; no-op under elision."
   [entry]
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (swap! state append-dom-buffered entry))
   nil)
 
@@ -916,7 +916,7 @@
   resolve to a valid `:rf.assert/*` event vector. Returns the new
   recorder state on success, the current state on no-op."
   ([event-vec]
-   (when config/enabled?
+   (when rf.story.config/enabled?
      (swap! state append-assertion event-vec))
    @state)
   ([assertion-id payload]
@@ -992,7 +992,7 @@
                  (= (:frame tags) (recording-variant))
                  (vector? (:rf.event/v tags))
                  (recordable-event? (:rf.event/v tags)))
-        (if (config/suppress-sensitive? ev (:frame tags))
+        (if (rf.story.config/suppress-sensitive? ev (:frame tags))
           (do
             ;; Record-but-redact: append the redacted
             ;; placeholder so the row's position survives, and bump the
@@ -1002,7 +1002,7 @@
             ;; event id; no payload survives. No cofx is recorded for a
             ;; redacted row — the payload (and its causal token) is the
             ;; thing being suppressed.
-            (config/note-suppressed! (:frame tags))
+            (rf.story.config/note-suppressed! (:frame tags))
             (record-event! redacted-event))
           ;; EP-0017: carry the same trace event's flat
           ;; `:rf.cofx` map (the framework-stamped `:rf/time-ms` plus any
@@ -1019,13 +1019,13 @@
   Called from the shell at mount on CLJS and from JVM integration
   tests directly."
   []
-  (when config/enabled?
-    (trace-tooling/register-listener! listener-id trace-listener)
+  (when rf.story.config/enabled?
+    (rf.trace.tooling/register-listener! listener-id trace-listener)
     nil))
 
 (defn remove-trace-listener!
   "Tear down the recorder's trace-bus listener. Idempotent."
   []
-  (when config/enabled?
-    (trace-tooling/unregister-listener! listener-id)
+  (when rf.story.config/enabled?
+    (rf.trace.tooling/unregister-listener! listener-id)
     nil))

--- a/tools/story/src/re_frame/story/recorder/dom_capture.cljs
+++ b/tools/story/src/re_frame/story/recorder/dom_capture.cljs
@@ -50,8 +50,8 @@
   ## Sensitive input redaction (record-but-redact for DOM)
 
   The dispatched-event rail redacts `:sensitive? true` events
-  (`recorder/trace-listener` → `config/suppress-sensitive?` →
-  `recorder/redacted-event`) per the record-but-redact policy. The
+  (`rf.story.recorder/trace-listener` → `rf.story.config/suppress-sensitive?` →
+  `rf.story.recorder/redacted-event`) per the record-but-redact policy. The
   DOM-capture rail is the SECOND egress and carries the SAME obligation:
   a user recording a login flow types a real password, and (with
   `:entries` the primary codegen source) that plaintext would otherwise
@@ -65,7 +65,7 @@
   (`\"[:rf/redacted]\"`, the string mirror of the dispatch rail's
   `[:rf/redacted]` placeholder) for the typed value BEFORE it is
   buffered, so the secret never reaches the recorder atom. The
-  suppressed-events counter is bumped (`config/note-suppressed!`) so the
+  suppressed-events counter is bumped (`rf.story.config/note-suppressed!`) so the
   UI's REDACTED hint reflects the scrubbed rows, exactly as the dispatch
   rail does. Hosts debugging redaction policy opt into the trusted-local
   boundary via `(story/configure! {:rf.story/egress-profile
@@ -76,11 +76,11 @@
   is not a typed secret); only typed `<input>` fields are scrubbed."
   (:require [clojure.set                     :as set]
             [clojure.string                  :as str]
-            [re-frame.story.config           :as config]
-            [re-frame.story.late-bind        :as late-bind]
-            [re-frame.story.recorder         :as recorder]
-            [re-frame.story.recorder.selector :as selector]
-            [re-frame.story.ui.canvas-listeners :as canvas-listeners]))
+            [re-frame.story.config           :as rf.story.config]
+            [re-frame.story.late-bind        :as rf.story.late-bind]
+            [re-frame.story.recorder         :as rf.story.recorder]
+            [re-frame.story.recorder.selector :as rf.story.recorder.selector]
+            [re-frame.story.ui.canvas-listeners :as rf.story.ui.canvas-listeners]))
 
 ;; ---- runtime knobs -----------------------------------------------------
 
@@ -130,7 +130,7 @@
   "ms since the recording started, or nil when no recording is in
   flight. The recorder atom carries `:started-ms`; we just subtract."
   []
-  (let [{:keys [started-ms recording?]} (recorder/current-state)]
+  (let [{:keys [started-ms recording?]} (rf.story.recorder/current-state)]
     (when (and recording? started-ms)
       (max 0 (- (now-ms) started-ms)))))
 
@@ -141,13 +141,13 @@
   trace. Public so browser tests + the DOM listener share one path."
   [selector]
   (when-let [t (recording-now-ms)]
-    (recorder/record-dom-event! [:dom/click selector t])))
+    (rf.story.recorder/record-dom-event! [:dom/click selector t])))
 
 (defn record-dom-type!
   "Append a `[:dom/type selector text t]` entry."
   [selector text]
   (when-let [t (recording-now-ms)]
-    (recorder/record-dom-event! [:dom/type selector text t])))
+    (rf.story.recorder/record-dom-event! [:dom/type selector text t])))
 
 (defn record-dom-submit!
   "Append a `[:dom/submit form-selector t]` entry. The translator
@@ -155,7 +155,7 @@
   time."
   [form-selector]
   (when-let [t (recording-now-ms)]
-    (recorder/record-dom-event! [:dom/submit form-selector t])))
+    (rf.story.recorder/record-dom-event! [:dom/submit form-selector t])))
 
 ;; ---- type-debounce flush ------------------------------------------------
 
@@ -171,7 +171,7 @@
 
   Each buffered entry is appended with its capture-time `:t` (stamped at
   BUFFER time, while `:recording?` was true) via
-  `recorder/record-dom-event-buffered!` — NOT via `record-dom-type!`'s
+  `rf.story.recorder/record-dom-event-buffered!` — NOT via `record-dom-type!`'s
   `recording-now-ms` re-read. This is what lets the final
   keystroke survive a flush that fires AFTER the recording was stopped: the
   debounce timer (or the `remove!`/stop drain) can run once `:recording?` is
@@ -186,7 +186,7 @@
        (when-let [entry (get snapshot k)]
          (clear-buffer-timer! entry)
          (when-let [t (or (:t entry) (recording-now-ms))]
-           (recorder/record-dom-event-buffered! [:dom/type k (:value entry) t]))))
+           (rf.story.recorder/record-dom-event-buffered! [:dom/type k (:value entry) t]))))
      (if selector
        (swap! type-buffer dissoc selector)
        (reset! type-buffer {})))
@@ -243,11 +243,11 @@
   (reset! type-buffer {})
   nil)
 
-;; Register the buffer-drain seam so `recorder/start-recording!` + `clear!`
+;; Register the buffer-drain seam so `rf.story.recorder/start-recording!` + `clear!`
 ;; can cancel + drop pending keystrokes at the recording boundary. Runs at
 ;; ns load (dom-capture requires recorder, so recorder is loaded first and
 ;; the runtime lookup resolves this at call time). rf2-x76af2.18.
-(late-bind/set-fn! :recorder/reset-dom-buffer cancel-pending-flushes!)
+(rf.story.late-bind/set-fn! :recorder/reset-dom-buffer cancel-pending-flushes!)
 
 ;; ---- predicates ---------------------------------------------------------
 
@@ -275,7 +275,7 @@
 (def ^:const redacted-type-text
   "The placeholder text the DOM rail substitutes for a SENSITIVE input's
   typed value. The STRING mirror of the dispatch rail's
-  `recorder/redacted-event` `[:rf/redacted]` placeholder — a string
+  `rf.story.recorder/redacted-event` `[:rf/redacted]` placeholder — a string
   because the `:dom/type` → `[:type selector text]` play-step requires a
   string `text` slot (the runner's `step-arity-ok?`). Reads the same way
   the dispatch rail's `[:rf/redacted]` placeholder does, so a recording
@@ -340,20 +340,20 @@
   REDACTED hint stays accurate."
   [el]
   (let [v       (target-value el)
-        variant (recorder/recording-variant)]
+        variant (rf.story.recorder/recording-variant)]
     ;; Resolve the reveal decision against the RECORDING's frame
     ;; (per-(tool,frame) visibility). Revealing a sibling frame never reveals
     ;; this capture; a nil recording-variant fails closed (redacts).
-    (if (and (sensitive-element? el) (not (config/include-sensitive? variant)))
-      (do (config/note-suppressed! variant)
+    (if (and (sensitive-element? el) (not (rf.story.config/include-sensitive? variant)))
+      (do (rf.story.config/note-suppressed! variant)
           redacted-type-text)
       v)))
 
 (defn- should-capture?
   "Top-level gate: is the recorder running AND DOM capture enabled?"
   []
-  (and config/enabled?
-       (recorder/recording?)
+  (and rf.story.config/enabled?
+       (rf.story.recorder/recording?)
        (enabled?)))
 
 ;; ---- listener handlers --------------------------------------------------
@@ -368,7 +368,7 @@
       ;; The flush emits the buffered :dom/type entries first so
       ;; the resulting recording is well-ordered: type-then-click.
       (flush-type-buffer!)
-      (when-let [sel (selector/pick-for-element el)]
+      (when-let [sel (rf.story.recorder.selector/pick-for-element el)]
         (record-dom-click! sel)))))
 
 (defn- handle-input!
@@ -380,7 +380,7 @@
   (when (should-capture?)
     (when-let [el (.-target ev)]
       (when (typeable-element? el)
-        (when-let [sel (selector/pick-for-element el)]
+        (when-let [sel (rf.story.recorder.selector/pick-for-element el)]
           (buffer-type! sel (capture-value el)))))))
 
 (defn- handle-change!
@@ -392,7 +392,7 @@
   (when (should-capture?)
     (when-let [el (.-target ev)]
       (when (typeable-element? el)
-        (let [sel (selector/pick-for-element el)]
+        (let [sel (rf.story.recorder.selector/pick-for-element el)]
           ;; Stash the most-recent value FIRST (so a `change` on a
           ;; `<select>` — which never fires `input` — still has a
           ;; value to flush). Sensitive `<input>` values are redacted at
@@ -412,7 +412,7 @@
   (when (should-capture?)
     (when-let [el (.-target ev)]
       (flush-type-buffer!)
-      (when-let [sel (selector/pick-for-element el)]
+      (when-let [sel (rf.story.recorder.selector/pick-for-element el)]
         (record-dom-submit! sel)))))
 
 ;; ---- install / remove --------------------------------------------------
@@ -420,7 +420,7 @@
 ;; The idempotent canvas-root install/remove scaffold is shared with the
 ;; element inspector via `re-frame.story.ui.canvas-listeners`. This rail
 ;; keeps only its own listener bodies + the recorder-specific pre/post
-;; hooks: the `config/enabled?` opt-in gate on install and the
+;; hooks: the `rf.story.config/enabled?` opt-in gate on install and the
 ;; type-buffer drain on remove.
 
 (defonce ^:private installed-root (atom nil))
@@ -445,19 +445,19 @@
   (.removeEventListener root "submit" handle-submit! false))
 
 (def ^:private lifecycle
-  (canvas-listeners/make-lifecycle installed-root attach-listeners! detach-listeners!))
+  (rf.story.ui.canvas-listeners/make-lifecycle installed-root attach-listeners! detach-listeners!))
 
 (defn install!
   "Install the DOM-capture listeners on `root` (or the canvas root
   when called with no arg). Idempotent — re-installing removes the
   previous listener set first.
 
-  No-op when production elision is active (`config/enabled?` false).
+  No-op when production elision is active (`rf.story.config/enabled?` false).
   Returns the root node on success, nil otherwise."
   ([]
-   (install! (canvas-listeners/canvas-root)))
+   (install! (rf.story.ui.canvas-listeners/canvas-root)))
   ([root]
-   (when config/enabled?
+   (when rf.story.config/enabled?
      ((:install! lifecycle) root))))
 
 (defn remove!

--- a/tools/story/src/re_frame/story/recorder/play_export.cljc
+++ b/tools/story/src/re_frame/story/recorder/play_export.cljc
@@ -73,8 +73,8 @@
   (`re-frame.story.ui.recorder-export-dialog`) consumes this fn to
   build the snippet text. JVM-testable end-to-end."
   (:require [clojure.string :as str]
-            [re-frame.story.play.runner :as runner]
-            [re-frame.story.predicates  :as pred]))
+            [re-frame.story.play.runner :as rf.story.play.runner]
+            [re-frame.story.predicates  :as rf.story.predicates]))
 
 ;; ---------------------------------------------------------------------------
 ;; Tunables
@@ -151,7 +151,7 @@
                 (redacted? event)
                 nil
 
-                (pred/assertion-event? event)
+                (rf.story.predicates/assertion-event? event)
                 :dispatch-sync
 
                 (and (vector? event)
@@ -372,7 +372,7 @@
 
 (defn recording->script-body
   "Translate a recording into a normalised `:script` body map per
-  `runner/parse-spec`. Pure data → data.
+  `rf.story.play.runner/parse-spec`. Pure data → data.
 
   Inputs:
 
@@ -411,8 +411,8 @@
                          the byte-identical 2-element steps.
 
   Returns a map: `{:script [...steps] :auto-run? bool :name str?}`.
-  The script is pre-coerced via `runner/coerce-script` so it round-
-  trips through `runner/parse-spec` without further normalisation —
+  The script is pre-coerced via `rf.story.play.runner/coerce-script` so it round-
+  trips through `rf.story.play.runner/parse-spec` without further normalisation —
   what you get back is what the runner will execute.
 
   Empty `events` returns a map with an empty `:script` (still legal —
@@ -465,7 +465,7 @@
   [script]
   (if (seq script)
     (str "["
-         (str/join (pred/indent-after indent-prefix)
+         (str/join (rf.story.predicates/indent-after indent-prefix)
                    (map pr-str script))
          "]")
     "[]"))
@@ -476,7 +476,7 @@
   string.
 
   The rendered form is `read-string`-able and round-trips back to the
-  same map via `runner/parse-spec`."
+  same map via `rf.story.play.runner/parse-spec`."
   [{:keys [script name auto-run?] :as _spec}]
   (let [body-keys (cond-> []
                     name             (conj [":name      " (pr-str name)])
@@ -508,4 +508,4 @@
         body-str (->> body
                       (map (fn [[k v]] (str k v)))
                       (str/join "\n  "))]
-    (pred/reg-variant-envelope alias variant-id body-str)))
+    (rf.story.predicates/reg-variant-envelope alias variant-id body-str)))

--- a/tools/story/src/re_frame/story/recorder/play_export_events.cljc
+++ b/tools/story/src/re_frame/story/recorder/play_export_events.cljc
@@ -27,14 +27,14 @@
 
   ## Elision
 
-  Every public fn opens with `(when config/enabled? ...)` so
+  Every public fn opens with `(when rf.story.config/enabled? ...)` so
   production CLJS builds short-circuit cleanly. The translator stays
   reachable (it's pure data → data) but the side-effecty seams
   collapse."
   (:require [re-frame.core                        :as rf]
-            [re-frame.story.config                :as config]
-            [re-frame.story.play.runner-events    :as runner-events]
-            [re-frame.story.recorder.play-export  :as export]))
+            [re-frame.story.config                :as rf.story.config]
+            [re-frame.story.play.runner-events    :as rf.story.play.runner-events]
+            [re-frame.story.recorder.play-export  :as rf.story.recorder.play-export]))
 
 ;; ---------------------------------------------------------------------------
 ;; Impure: app-db-value snapshot
@@ -61,7 +61,7 @@
 
 (defn replay-script!
   "Drive `spec` (a `:script` map per `runner/parse-spec`) against
-  `frame-id` via `runner-events/run!`. Returns the initial run-state
+  `frame-id` via `rf.story.play.runner-events/run!`. Returns the initial run-state
   (status `:running`, step-idx 0). `done-cb` fires with the terminal
   run-state.
 
@@ -74,10 +74,10 @@
   ([frame-id spec]
    (replay-script! frame-id spec nil))
   ([frame-id spec done-cb]
-   (when (and config/enabled? frame-id spec)
+   (when (and rf.story.config/enabled? frame-id spec)
      ;; The 4-arity multi-play form: the play-key is the hand-built
      ;; spec's :name (nil for an unnamed script).
-     (runner-events/run! frame-id (:name spec) spec done-cb))))
+     (rf.story.play.runner-events/run! frame-id (:name spec) spec done-cb))))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: export from a recorder snapshot
@@ -104,7 +104,7 @@
   [events {:keys [variant-id extends alias name auto-run?
                   auto-assert? final-db seed-db max-auto-assertions]
            :as   opts}]
-  (let [spec     (export/recording->script-body
+  (let [spec     (rf.story.recorder.play-export/recording->script-body
                    events
                    (cond-> {}
                      (some? name)                (assoc :name name)
@@ -114,7 +114,7 @@
                      (some? seed-db)             (assoc :seed-db seed-db)
                      (some? max-auto-assertions) (assoc :max-auto-assertions
                                                         max-auto-assertions)))
-        rendered (export/render-variant-form
+        rendered (rf.story.recorder.play-export/render-variant-form
                    spec
                    (cond-> {}
                      variant-id (assoc :variant-id variant-id)

--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -73,9 +73,9 @@
   registration as validation plus atomic storage."
   (:require [clojure.string           :as str]
             [malli.core               :as m]
-            [re-frame.story.late-bind :as late-bind]
-            [re-frame.story.schemas   :as schemas]
-            [re-frame.story.tags      :as tags]))
+            [re-frame.story.late-bind :as rf.story.late-bind]
+            [re-frame.story.schemas   :as rf.story.schemas]
+            [re-frame.story.tags      :as rf.story.tags]))
 
 ;; ---- source-coord plumbing ------------------------------------------------
 ;;
@@ -296,7 +296,7 @@
   schema-mismatch message. The full malli `:explain` rides `ex-data`
   either way."
   [kind id body]
-  (when-let [explain (schemas/validate kind body)]
+  (when-let [explain (rf.story.schemas/validate kind body)]
     (let [error-kw (keyword "rf.error" (str (name kind) "-shape"))
           unknown  (unknown-key-reason kind explain)
           reason   (or unknown
@@ -372,12 +372,12 @@
   grammar for `kind`. Per /spec/007-Stories.md §Canonical id grammar."
   [kind id]
   (let [ok? (case kind
-              :story       schemas/story-id?
-              :variant     schemas/variant-id?
-              :fragment    schemas/fragment-id?
-              :check       schemas/check-id?
-              :workspace   schemas/workspace-id?
-              :mode        schemas/mode-id?
+              :story       rf.story.schemas/story-id?
+              :variant     rf.story.schemas/variant-id?
+              :fragment    rf.story.schemas/fragment-id?
+              :check       rf.story.schemas/check-id?
+              :workspace   rf.story.schemas/workspace-id?
+              :mode        rf.story.schemas/mode-id?
               ;; story-panel, decorator, tag — any keyword.
               :story-panel keyword?
               :decorator   keyword?
@@ -390,7 +390,7 @@
       ;; graph: the story-mcp entry point (`tools/write.cljc`
       ;; register-variant) pre-checks
       ;; the id grammar on the STRING shape — `fresh-keyword-checked` against
-      ;; `story/valid-variant-id?`, single-sourced with the `schemas/…-id?`
+      ;; `story/valid-variant-id?`, single-sourced with the `rf.story.schemas/…-id?`
       ;; predicates below — before interning, and answer with their own
       ;; conformant message. So an MCP client does not reach this throw; a
       ;; library / REPL caller passing an already-keyword id does, and the
@@ -428,7 +428,7 @@
   low-level test of side-table semantics; in normal use the hook is
   set at `re-frame.story` ns load."
   []
-  (when-let [f (late-bind/get-fn :ensure-canonical-installed)]
+  (when-let [f (rf.story.late-bind/get-fn :ensure-canonical-installed)]
     (f)))
 
 ;; ---- write API (the runtime helpers the macros expand to) ----------------
@@ -577,10 +577,10 @@
   Safe to call multiple times — re-registration is idempotent at the
   side-table level (same body replaces same body)."
   []
-  (doseq [t schemas/canonical-tags]
+  (doseq [t rf.story.schemas/canonical-tags]
     (reg-tag* t {:doc (str "Canonical Story inclusion tag — " (name t)
                            ". See /spec/007-Stories.md §Inclusion tags.")}))
-  (doseq [t schemas/canonical-state-tags]
+  (doseq [t rf.story.schemas/canonical-state-tags]
     (reg-tag* t {:axis :state
                  :doc  (str "Canonical Story state-magnitude tag — "
                             (pr-str t)
@@ -662,7 +662,7 @@
         lookups  {:variant variants :story (registrations :story)}]
     (->> variants
          (filter (fn [[vid _body]]
-                   (let [tset (tags/effective-tags vid lookups)]
+                   (let [tset (rf.story.tags/effective-tags vid lookups)]
                      (some #(contains? tset %) qs))))
          (map first)
          set)))

--- a/tools/story/src/re_frame/story/render.cljc
+++ b/tools/story/src/re_frame/story/render.cljc
@@ -75,13 +75,13 @@
   `:render-host` hook a CLJS host installs; the bare JVM has none, so
   `render-variant` returns `:cannot-run` there — never a silent empty
   render. Per the §6 elision contract, a production CLJS build with Story
-  disabled renders nothing (`config/enabled?` is false)."
-  (:require [re-frame.story.args        :as args]
-            [re-frame.story.config      :as config]
-            [re-frame.story.error       :as story-error]
-            [re-frame.story.fingerprint :as fingerprint]
-            [re-frame.story.late-bind   :as late-bind]
-            [re-frame.story.plan        :as plan]))
+  disabled renders nothing (`rf.story.config/enabled?` is false)."
+  (:require [re-frame.story.args        :as rf.story.args]
+            [re-frame.story.config      :as rf.story.config]
+            [re-frame.story.error       :as rf.story.error]
+            [re-frame.story.fingerprint :as rf.story.fingerprint]
+            [re-frame.story.late-bind   :as rf.story.late-bind]
+            [re-frame.story.plan        :as rf.story.plan]))
 
 ;; ===========================================================================
 ;; Render statuses
@@ -117,14 +117,14 @@
   output map and returns the host render result (a hiccup tree / React
   element / a mounted-handle). Idempotent (re-registration replaces)."
   [render-fn]
-  (late-bind/set-fn! render-host-hook-key render-fn)
+  (rf.story.late-bind/set-fn! render-host-hook-key render-fn)
   nil)
 
 (defn render-host-fn
   "Return the installed `:render-host` fn, or nil when no host registered
   one (the bare JVM render-prep-only path)."
   []
-  (late-bind/get-fn render-host-hook-key))
+  (rf.story.late-bind/get-fn render-host-hook-key))
 
 ;; ===========================================================================
 ;; Effective-args control overrides
@@ -135,19 +135,19 @@
 ;; resolved arg-map, BEFORE controls) at `[:world :effective-args]`;
 ;; `render-variant` layers the live control overrides on top to produce the
 ;; POST-override effective args that feed the rendered view. Both are the
-;; same deep-merge precedence the run path uses (`args/deep-merge`,
+;; same deep-merge precedence the run path uses (`rf.story.args/deep-merge`,
 ;; later-wins), so a control override changes the effective args — and the
 ;; plan-hash — exactly as it would on a run.
 
 (defn apply-control-overrides
   "Layer control-panel `overrides` on top of the plan's `plan-eff-args`
   (the resolved plan-time effective args). Pure data → data — deep-merge,
-  later wins (`args/deep-merge`), matching the run-path arg precedence
+  later wins (`rf.story.args/deep-merge`), matching the run-path arg precedence
   (`re-frame.story.args/resolve-args` — `variant-args < cell-overrides`).
   A nil/empty `overrides` returns the plan effective args unchanged."
   [plan-eff-args overrides]
   (if (seq overrides)
-    (args/deep-merge (or plan-eff-args {}) overrides)
+    (rf.story.args/deep-merge (or plan-eff-args {}) overrides)
     (or plan-eff-args {})))
 
 ;; ===========================================================================
@@ -160,7 +160,7 @@
 ;; `{[:login/error] [:arg :message]}` driven by a `:message` control), the
 ;; render path must re-resolve the overrides against the POST-override
 ;; effective args so the live view reflects the control. We re-run the SAME
-;; one-level substitution (`plan/substitute-args`) the plan compiler +
+;; one-level substitution (`rf.story.plan/substitute-args`) the plan compiler +
 ;; the canvas render path use, against the post-override args. The plan
 ;; already proved the overrides valid at compile time; re-substituting a
 ;; control value cannot introduce a missing-arg (the control supplies the
@@ -175,16 +175,16 @@
 
   Re-substitutes the RAW (pre-`[:arg]`) overrides the plan kept at
   `[:render-raw :sub-overrides]` against `eff-args` — the SAME one-level
-  `plan/substitute-args` the plan compiler + the canvas render path use.
+  `rf.story.plan/substitute-args` the plan compiler + the canvas render path use.
   Falls back to the already-resolved `[:world :render :sub-overrides]` slot
   for a plan that carries no raw form (e.g. a hand-built inline plan that
   pre-resolved its overrides)."
   [plan eff-args]
   (if-let [raw (get-in plan [:render-raw :sub-overrides])]
-    (plan/substitute-args raw (or eff-args {}) (atom []))
+    (rf.story.plan/substitute-args raw (or eff-args {}) (atom []))
     (let [ovr (get-in plan [:world :render :sub-overrides])]
       (when (seq ovr)
-        (plan/substitute-args ovr (or eff-args {}) (atom []))))))
+        (rf.story.plan/substitute-args ovr (or eff-args {}) (atom []))))))
 
 ;; ===========================================================================
 ;; Render preparation — the pure, JVM-testable core
@@ -226,7 +226,7 @@
   ([target {:keys [control-overrides validator-fns] :as opts}]
    (let [compile-opts (select-keys opts [:lookup :view-lookup :validator-fns
                                          :sub-lookup :fragment-lookup :check-lookup])
-         plan         (plan/variant-plan target compile-opts)
+         plan         (rf.story.plan/variant-plan target compile-opts)
          frame        (:variant/id plan)
          plan-eff     (get-in plan [:world :effective-args] {})
          eff-args     (apply-control-overrides plan-eff control-overrides)
@@ -237,12 +237,12 @@
          ;; render path re-checks before calling the view (spec/017 §Args —
          ;; view-arg-schema failures stop render).
          validation   (when schema
-                        (plan/validate-effective-args schema eff-args validator-fns))
+                        (rf.story.plan/validate-effective-args schema eff-args validator-fns))
          ;; The plan-hash is over the normalized plan — render + run agree
          ;; on it. When controls change the effective args, reflect them in
          ;; the hashed plan so the hash tracks what is actually rendered.
          render-plan  (assoc-in plan [:world :effective-args] eff-args)
-         plan-hash    (fingerprint/plan-hash render-plan)
+         plan-hash    (rf.story.fingerprint/plan-hash render-plan)
          base         {:plan           render-plan
                        :plan-hash      plan-hash
                        :frame          frame
@@ -297,7 +297,7 @@
   ([target e prepared]
    (cond-> {:status :error
             :frame  (or (:frame prepared) (when (keyword? target) target))
-            :error  (story-error/throwable->error-map e)}
+            :error  (rf.story.error/throwable->error-map e)}
      prepared (merge (select-keys prepared
                                   [:plan :plan-hash :effective-args])))))
 
@@ -332,7 +332,7 @@
   `:cannot-run` immediately — the render verb never throws under elision."
   ([target] (render-variant target nil))
   ([target opts]
-   (if-not config/enabled?
+   (if-not rf.story.config/enabled?
      ;; Production / disabled: nothing to render. The verb fails closed
      ;; into `:cannot-run` rather than throwing (the §6 elision contract).
      {:status :cannot-run :frame (when (keyword? target) target)

--- a/tools/story/src/re_frame/story/requirements.cljc
+++ b/tools/story/src/re_frame/story/requirements.cljc
@@ -89,7 +89,7 @@
   on their own facts — NOT one shared map. The axes are legitimately
   distinct, so this ns names its own refusal rather than borrowing the
   boundary one."
-  (:require [re-frame.story.play.evidence :as evidence]))
+  (:require [re-frame.story.play.evidence :as rf.story.play.evidence]))
 
 ;; ===========================================================================
 ;; CAPABILITY TOKENS  (spec/017 §Runner kinds and capabilities)
@@ -311,7 +311,7 @@
    ;; browser checks — \"structural a11y checks MAY require only `:hiccup`\").
    :rf.assert/a11y-structural      #{:hiccup-structure}
    ;; Reactive-count assertions require `:reactive-counts` — proven by the
-   ;; `:cljs-reactive` runner via the `evidence/reactive-counts` projection
+   ;; `:cljs-reactive` runner via the `rf.story.play.evidence/reactive-counts` projection
    ;; (spec/017 §1a). Under `:headless` / `:hiccup` they resolve to
    ;; `:cannot-run`; `:auto` escalates to `:cljs-reactive`.
    :rf.assert/caused               #{:reactive-counts}
@@ -561,14 +561,14 @@
 ;; Preflight (above) confirms the chosen runner CLAIMS the tokens. Post-run
 ;; validation confirms the tape actually PRODUCED the evidence: a
 ;; step/assertion that REQUIRED a proof FAILS CLOSED if the projected
-;; evidence (`evidence/project-evidence`) does not carry the matching slot.
+;; evidence (`rf.story.play.evidence/project-evidence`) does not carry the matching slot.
 ;; This is the second half of the spec's two-sided fail-closed rule — a
 ;; runner that claims `:effects` but emits a tape with no effect rows for an
 ;; `:rf.assert/effect-emitted` expectation must NOT silently pass.
 
 (def token->evidence-slots
   "Map each capability token to the run-evidence SLOT(S) whose PRESENCE in
-  the projected evidence (`evidence/project-evidence`) proves the token was
+  the projected evidence (`rf.story.play.evidence/project-evidence`) proves the token was
   actually exercised. A token with NO slot needs no post-run check — its
   proof is the assertion's own evaluation, not a distinct stream the runner
   could fail to produce.
@@ -598,7 +598,7 @@
   for healthy runs:
 
   - `:trace` — the trace-event stream is always-on for any run; the only
-    projections `evidence/project-evidence` exposes (`:warnings`,
+    projections `rf.story.play.evidence/project-evidence` exposes (`:warnings`,
     `:schema-violations`) are FILTERED views, not a faithful presence slot
     for the whole stream. `:rf.assert/no-warnings` PASSES precisely when
     `:warnings` is EMPTY, and `:rf.assert/dispatched?` proves against trace
@@ -625,7 +625,7 @@
 
 (defn evidence-slot-satisfied?
   "True iff EVERY evidence slot the `required-tokens` demand is POPULATED in
-  the projected `evidence` map (`evidence/project-evidence` output). Pure
+  the projected `evidence` map (`rf.story.play.evidence/project-evidence` output). Pure
   data → data. A token with no entry in `token->evidence-slots` (e.g.
   `:app-db`, `:trace`, `:hiccup-structure` — the always-on / empty-is-healthy
   tokens, see that map's docstring) imposes no slot requirement: its proof is
@@ -649,13 +649,13 @@
   CLOSED if the tape/result did not contain it\"). Pure data → data.
 
   `assertion` is the assertion atom; `evidence` is the projected run
-  evidence (`evidence/project-evidence`); `runner` is the runner kind that
+  evidence (`rf.story.play.evidence/project-evidence`); `runner` is the runner kind that
   ran. Returns nil when the required evidence is present (the assertion's
   own pass/fail then stands), or a `requirement-refusal` (`:reason
   :required-evidence-missing`) when a required proof slot is empty — so a
   missing required evidence slot reports `:cannot-run`, NEVER a pass.
 
-  This consumes `.4`'s projection (`evidence/project-evidence`) as the
+  This consumes `.4`'s projection (`rf.story.play.evidence/project-evidence`) as the
   single source of truth: the proof check reads the SAME tape projection
   the run-result slots derive from, so a duplicate accumulator cannot
   report green when the tape is empty."

--- a/tools/story/src/re_frame/story/result.cljc
+++ b/tools/story/src/re_frame/story/result.cljc
@@ -44,7 +44,7 @@
   `aggregate-status` (in `re-frame.story.requirements`, reused here) is the
   ONE rule: `:error` > `:fail` > `:cannot-run` > `:pass`, AND a run whose
   tape shows unconsumed failure evidence cannot read `:pass` (the agreement
-  floor, `evidence/tape-shows-failure?`). A run with zero assertions whose
+  floor, `rf.story.play.evidence/tape-shows-failure?`). A run with zero assertions whose
   tape is clean is `:pass` (the /spec/007-Stories.md §Story-as-test duality — a variant
   with no assertions is vacuously green).
 
@@ -56,10 +56,10 @@
   `clojure -M:test`. The runner reads the tape + the accumulator and hands
   the vectors here; the assembly never touches the runtime."
   (:require [malli.core                   :as m]
-            [re-frame.story.assertions    :as assertions]
-            [re-frame.story.play.evidence :as evidence]
-            [re-frame.story.requirements  :as requirements]
-            [re-frame.story.verdict       :as verdict]))
+            [re-frame.story.assertions    :as rf.story.assertions]
+            [re-frame.story.play.evidence :as rf.story.play.evidence]
+            [re-frame.story.requirements  :as rf.story.requirements]
+            [re-frame.story.verdict       :as rf.story.verdict]))
 
 ;; ===========================================================================
 ;; STATUS — the four verdicts (spec/017 §Run result)
@@ -72,7 +72,7 @@
 (def statuses
   "The four run / assertion / check verdicts (spec/017 §Run result) —
   re-exported from the `re-frame.story.verdict` leaf, the single owner."
-  verdict/statuses)
+  rf.story.verdict/statuses)
 
 ;; ===========================================================================
 ;; THE SCHEMA-BACKED CONTRACT  (API governance freeze)
@@ -204,7 +204,7 @@
   "Derive the `:status` for ONE assertion record from its outcome fields
   (spec/017 §Run result) — re-exported from the `re-frame.story.verdict`
   leaf, the single owner. Pure data → data."
-  verdict/record-status)
+  rf.story.verdict/record-status)
 
 ;; ===========================================================================
 ;; ASSERTION RECORD — the `.18` atom shape + a unified `:status`
@@ -268,13 +268,13 @@
 (def ^:private redaction-prone-assertion-ids
   "Assertion ids whose evaluator may rebuild the run RECORD's `:payload`
   from a REDACTED expected value for a sensitive path/sub
-  (`assertions/evaluate-path-equals` / `evaluate-sub-equals` rebuild
+  (`rf.story.assertions/evaluate-path-equals` / `evaluate-sub-equals` rebuild
   `:payload` as `[path-or-sub-vec exp-redacted]`). The compiled check
   plan's atom, by contrast, always carries the RAW author-declared
   expected value — plan atoms are never redacted (redaction only happens
   at run time, against a live frame). An exact-payload match between the
   two therefore cannot identify a sensitive assertion."
-  #{assertions/id-path-equals assertions/id-sub-equals})
+  #{rf.story.assertions/id-path-equals rf.story.assertions/id-sub-equals})
 
 (defn- record-matches-atom?
   "True iff assertion `record` was produced by assertion `atom-v` — same
@@ -311,7 +311,7 @@
 
   The group is every evaluated record matching one of the check's atoms
   (by id + payload); the check `:status` aggregates the group via the ONE
-  aggregation rule (`requirements/aggregate-status`). An atom with no
+  aggregation rule (`rf.story.requirements/aggregate-status`). An atom with no
   matching record (the assertion never ran) contributes nothing to the
   group — the run-level aggregation still sees the ungrouped records, so a
   check that did not run does not mask the run verdict.
@@ -323,7 +323,7 @@
                               (some #(record-matches-atom? r %) assertion-atoms)))
                     records)]
     {:check      check-id
-     :status     (requirements/aggregate-status group nil)
+     :status     (rf.story.requirements/aggregate-status group nil)
      :assertions group}))
 
 (defn check-records
@@ -347,11 +347,11 @@
 ;; consumed by an expected `:rf.assert/schema-error`, even if recovery /
 ;; rollback leaves the final app-db acceptable. There is NO
 ;; `:rf.assert/no-schema-errors` knob — a schema-clean run is the FLOOR
-;; (`evidence/tape-shows-failure?`), and these expectations REFINE it.
+;; (`rf.story.play.evidence/tape-shows-failure?`), and these expectations REFINE it.
 ;;
 ;; Matching is an EXACT MULTISET pairing (spec/017 §Schema rule steps 1-4):
 ;;
-;;   1. The projected violations (`evidence/schema-violations`, the SINGLE
+;;   1. The projected violations (`rf.story.play.evidence/schema-violations`, the SINGLE
 ;;      source — no second accumulator) are keyed by their `:selector`.
 ;;   2. Each declared `[:rf.assert/schema-error spec]` consumes EXACTLY ONE
 ;;      matching violation; N declared of a selector consume N. A bare
@@ -369,8 +369,8 @@
 
 (defn- pair-expectations
   "Pair `expectations` (the projected `:rf.assert/schema-error`
-  expectation records, `assertions/schema-error-expectation`) against
-  `violations` (the projected `evidence/schema-violations`) by exact
+  expectation records, `rf.story.assertions/schema-error-expectation`) against
+  `violations` (the projected `rf.story.play.evidence/schema-violations`) by exact
   multiset selector match. Pure data → data.
 
   Returns `{:matched [{:expectation … :violation …} …]
@@ -422,7 +422,7 @@
   `:actual` so a failing expectation reads diagnostically."
   [{:keys [atom spec selector] :as _expectation} matched-violation]
   (let [passed? (some? matched-violation)]
-    {:assertion assertions/id-schema-error
+    {:assertion rf.story.assertions/id-schema-error
      :payload   (vec (rest atom))
      :passed?   passed?
      :status    (if passed? :pass :fail)
@@ -444,7 +444,7 @@
   `schema-expectations` is the vector of declared `:rf.assert/schema-error`
   ATOMS (`[:rf.assert/schema-error spec]`); `epoch-tape` is the retained
   `:rf/epoch-record` vector (the SINGLE violation source — projected via
-  `evidence/schema-violations`, never a second accumulator). Returns:
+  `rf.story.play.evidence/schema-violations`, never a second accumulator). Returns:
 
       {:records             [assertion-record …]  ; one per declared expectation
        :consumed-selectors  #{selector …}         ; selectors EXACTLY consumed
@@ -452,7 +452,7 @@
        :unconsumed          [violation …]}         ; emitted, not expected
 
   `:consumed-selectors` is the set the agreement floor
-  (`evidence/tape-shows-failure?`) subtracts so an EXACTLY-consumed
+  (`rf.story.play.evidence/tape-shows-failure?`) subtracts so an EXACTLY-consumed
   violation does not trip the floor. A violation left unconsumed keeps its
   selector OUT of the set, so the floor still fails the run on it (§Schema
   rule step 4). A `:fail` record for each unmatched expectation fails the
@@ -460,15 +460,15 @@
 
   The 2-arity projects the violations from the raw `epoch-tape`; the
   `[schema-expectations violations :as :projected]` 3-arity takes the
-  ALREADY-PROJECTED `evidence/schema-violations` vector (the `run-result`
+  ALREADY-PROJECTED `rf.story.play.evidence/schema-violations` vector (the `run-result`
   assembly's `evidence-slots`) so the assembly does not walk the tape for
   the same violations a second time — one tape, one projection."
   ([schema-expectations epoch-tape]
    (match-schema-expectations schema-expectations
-                              (evidence/schema-violations epoch-tape)
+                              (rf.story.play.evidence/schema-violations epoch-tape)
                               :projected))
   ([schema-expectations violations _projected]
-   (let [exps        (mapv assertions/schema-error-expectation
+   (let [exps        (mapv rf.story.assertions/schema-error-expectation
                            (or schema-expectations []))
          {:keys [matched unmatched unconsumed]} (pair-expectations exps violations)
          records     (into (mapv (fn [{:keys [expectation violation]}]
@@ -490,7 +490,7 @@
 ;; cause→effect relationship from the SAME reactive evidence the tape already
 ;; carries — the `:rf.sub/run` / `:rf.view/rendered` rows stamped with the
 ;; dispatching cascade's `:cause-event-id` (Spec 009), surfaced in the
-;; `evidence/reactive-counts` `:by-cause` projection. They are
+;; `rf.story.play.evidence/reactive-counts` `:by-cause` projection. They are
 ;; tape-evaluated like `:rf.assert/schema-error`: NOT dispatched into the
 ;; frame, NOT a parallel accumulator — the tape is the source of truth
 ;; (spec/017 §Risks — "evidence projections drift").
@@ -505,12 +505,12 @@
 ;; A `[:sub …]` / `[:view …]` surface needs per-(cause × surface) counts that
 ;; `:by-cause` (cause-keyed totals) does not carry, so the matcher re-projects
 ;; them from the already-projected `:sub-runs` / `:renders` rows
-;; (`evidence/sub-runs` / `renders`) — the SAME rows `:by-cause` counts,
+;; (`rf.story.play.evidence/sub-runs` / `renders`) — the SAME rows `:by-cause` counts,
 ;; filtered to the named cause AND surface. No new evidence stream.
 
 (defn- causal-count
   "The measured effect COUNT for a causal `expectation` against the run's
-  projected `evidence` (the `evidence/project-evidence` output). Pure data →
+  projected `evidence` (the `rf.story.play.evidence/project-evidence` output). Pure data →
   data. Reads ONLY the already-projected reactive rows — `:reactive-counts`
   for the `[:any]` cause total, the `:sub-runs` / `:renders` rows for a named
   `:sub` / `:view` surface. Returns 0 when the cause produced no matching
@@ -580,7 +580,7 @@
   cause (`observed-cause-count`); `reactive?` is whether the run carried
   ANY reactive evidence (a `:reactive-counts` slot); `truncated?` is whether
   the bounded `epoch-history` ring evicted the run's EARLIEST epochs
-  (`evidence/run-tape-truncated?`, rf2-4u5zl4). The verdict, in precedence:
+  (`rf.story.play.evidence/run-tape-truncated?`, rf2-4u5zl4). The verdict, in precedence:
 
   - a degenerate atom that names no `:event` → `:fail` (it asserts nothing
     measurable);
@@ -632,10 +632,10 @@
         ;; an unobserved cause), and the plan compiler rejects the key on
         ;; `:caused`, so `require-cause?` only ever carries a value for
         ;; no-cascade.
-        cause-gate?    (and (= id assertions/id-no-cascade-rerender)
+        cause-gate?    (and (= id rf.story.assertions/id-no-cascade-rerender)
                             (not (false? require-cause?)))
         unobserved?    (and cause-gate? (zero? c))
-        vacuity-opt?   (and (= id assertions/id-no-cascade-rerender)
+        vacuity-opt?   (and (= id rf.story.assertions/id-no-cascade-rerender)
                             (false? require-cause?)
                             (zero? c))
         in-bounds?     (causal-in-bounds? expectation n)
@@ -707,19 +707,19 @@
 
   `causal-atoms` is the vector of declared `[:rf.assert/caused …]` /
   `[:rf.assert/no-cascade-rerender …]` atoms; `evidence` is the
-  `evidence/project-evidence` output (the SINGLE reactive source — the
+  `rf.story.play.evidence/project-evidence` output (the SINGLE reactive source — the
   `:reactive-counts` / `:sub-runs` / `:renders` projections, never a second
   accumulator). Returns `{:records [assertion-record …]}`, one per declared
   expectation.
 
   Note these are PURE expectations, NOT agreement-floor signals: an
   over-render is a `:fail` of a `:rf.assert/no-cascade-rerender` declaration,
-  not a tape-floor failure on its own (`evidence/tape-shows-failure?` does not
+  not a tape-floor failure on its own (`rf.story.play.evidence/tape-shows-failure?` does not
   read reactive counts). A run with NO reactive rows (no `:reactive-counts`
   slot) resolves each causal expectation to `:cannot-run` — fail closed, never
   a silent pass against an empty projection (this is the matcher's own
   fail-closed guard; it mirrors the post-run `:reactive-counts` evidence-slot
-  check (`requirements/validate-evidence`) so the verdict is correct even
+  check (`rf.story.requirements/validate-evidence`) so the verdict is correct even
   where that check is not separately invoked).
 
   Each record also carries `:observed-cause-count` (rf2-x76af2.17) — the
@@ -731,7 +731,7 @@
   `{:require-cause? false}`).
 
   `truncated?` (rf2-4u5zl4) is the per-run epoch-tape truncation signal
-  (`evidence/run-tape-truncated?`): true when the bounded `epoch-history`
+  (`rf.story.play.evidence/run-tape-truncated?`): true when the bounded `epoch-history`
   ring evicted the run's earliest epochs. When true, an otherwise in-bounds
   causal `:pass` against a finite upper bound resolves `:cannot-run` — the
   dropped effect evidence could carry effects exceeding the bound, so the
@@ -744,7 +744,7 @@
    (let [reactive? (contains? evidence :reactive-counts)
          tape      (:epoch-tape evidence)]
      {:records (mapv (fn [a]
-                       (let [exp (assertions/causal-expectation a)]
+                       (let [exp (rf.story.assertions/causal-expectation a)]
                          (causal-record exp
                                         (causal-count exp evidence)
                                         (observed-cause-count (:event exp) tape)
@@ -803,7 +803,7 @@
                           upstream by the `:reactive-counts` fail-closed
                           evidence-slot check (`:cannot-run`).
   - `:epoch-truncated?` — the per-run epoch-tape truncation signal
-                          (`evidence/run-tape-truncated?`, rf2-4u5zl4): true
+                          (`rf.story.play.evidence/run-tape-truncated?`, rf2-4u5zl4): true
                           when the bounded `epoch-history` ring evicted the
                           run's earliest epochs. When true, an otherwise
                           in-bounds causal `:pass` against a finite upper
@@ -824,7 +824,7 @@
                           Test mode reads it rather than re-deriving the set.
   - `:unmet`            — the per-requirement `:cannot-run` refusals for
                           expectations the runner could not attempt
-                          (`requirements/unmet-assertions` /
+                          (`rf.story.requirements/unmet-assertions` /
                           `unmet-steps`). Folded into the status + surfaced
                           on `:cannot-run`.
   - `:app-db`           — the final (post-run) app-db, redacted upstream.
@@ -832,9 +832,9 @@
     `:required-runner` / `:fidelity` / `:elapsed-ms` — passed through
     verbatim when present (the API-stable identity / timing slots).
 
-  The verdict: `requirements/aggregate-status` over the assertion records +
+  The verdict: `rf.story.requirements/aggregate-status` over the assertion records +
   the `:unmet` refusals gives the assertion-side status; the agreement
-  floor (`evidence/tape-shows-failure?`) escalates a `:pass` to `:fail`
+  floor (`rf.story.play.evidence/tape-shows-failure?`) escalates a `:pass` to `:fail`
   when the tape carries unconsumed failure evidence — so a run NEVER reads
   green while the tape is red, and the verdict is computed from the
   PROJECTED evidence, not a sibling accumulator."
@@ -849,7 +849,7 @@
         ;; only the narrative projection; the `:epoch-tape` slot stays raw
         ;; and the stamp is a `:rf.story/*` key the determinism projection
         ;; strips, so the run-hash is unaffected.
-        evidence-slots (evidence/project-evidence
+        evidence-slots (rf.story.play.evidence/project-evidence
                          tape {:script script :attribution attribution})
         ;; The tape is projected ONCE (`project-evidence` above); the
         ;; schema-violation + effect vectors it already produced are threaded
@@ -888,7 +888,7 @@
         consumed       (into (or consumed-selectors #{})
                              (:consumed-selectors schema-match))
         unmet          (vec (or unmet []))
-        base-status    (requirements/aggregate-status records unmet)
+        base-status    (rf.story.requirements/aggregate-status records unmet)
         ;; Agreement floor over the SAME projected evidence — the violations
         ;; + effects `project-evidence` already derived, not a re-walk of the
         ;; raw tape (the tape is still needed for the per-epoch `:outcome`
@@ -913,7 +913,7 @@
         unconsumed     (cond->> (:unconsumed schema-match)
                          (seq consumed-selectors)
                          (remove #(contains? consumed-selectors (:selector %))))
-        tape-red?      (evidence/evidence-shows-failure?
+        tape-red?      (rf.story.play.evidence/evidence-shows-failure?
                          tape unconsumed (:effects evidence-slots) nil :unconsumed)
         ;; The agreement floor escalates a would-be `:pass` OR a
         ;; `:cannot-run` to `:fail` — a real `:error` already outranks it
@@ -1015,7 +1015,7 @@
   reports exactly once (no run-level double)."
   [{:keys [status assertions schema-violations cannot-run] :as _result}]
   (let [per-assertion (mapv assertion->report assertions)
-        worst         (requirements/aggregate-status assertions cannot-run)
+        worst         (rf.story.requirements/aggregate-status assertions cannot-run)
         ;; The run verdict exceeds the assertion-level verdict (the tape
         ;; floor escalated it, or a run-level cannot-run/error) → emit a
         ;; run-level report so the floor failure is not silently dropped.

--- a/tools/story/src/re_frame/story/review_dialog.cljc
+++ b/tools/story/src/re_frame/story/review_dialog.cljc
@@ -79,9 +79,9 @@
                    to the renderer."
   (:require [clojure.string :as str]
             #?(:cljs [reagent.core :as r])
-            #?(:cljs [re-frame.story.ui.a11y-dialog :as a11y-dialog])
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+            #?(:cljs [re-frame.story.ui.a11y-dialog :as rf.story.ui.a11y-dialog])
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: initial state + transitions
@@ -310,32 +310,32 @@
       :modal        {:width          "640px"
                      :max-width      "90vw"
                      :max-height     "80vh"
-                     :background     (:bg-canvas colors/tokens)
-                     :color          (:text-primary colors/tokens)
+                     :background     (:bg-canvas rf.story.theme.colors/tokens)
+                     :color          (:text-primary rf.story.theme.colors/tokens)
                      :border         "1px solid #444"
                      :border-radius  "6px"
                      :padding        "16px"
                      :font-family    mono-stack
-                     :font-size      (:body-tight typography/type-scale)
+                     :font-size      (:body-tight rf.story.theme.typography/type-scale)
                      :display        "flex"
                      :flex-direction "column"
                      :gap            "12px"
                      :box-shadow     "0 12px 32px rgba(0,0,0,0.7)"
                      :overflow       "hidden"}
       :modal-title  {:font-weight "bold"
-                     :color       (:info colors/tokens)
-                     :font-size   (:body typography/type-scale)}
+                     :color       (:info rf.story.theme.colors/tokens)
+                     :font-size   (:body rf.story.theme.typography/type-scale)}
       :id-input     {:padding       "6px 8px"
-                     :background    (:bg-2 colors/tokens)
+                     :background    (:bg-2 rf.story.theme.colors/tokens)
                      :color         "white"
                      :border        "1px solid #444"
                      :border-radius "3px"
                      :font-family   mono-stack
-                     :font-size     (:body-tight typography/type-scale)
+                     :font-size     (:body-tight rf.story.theme.typography/type-scale)
                      :width         "100%"
                      :box-sizing    "border-box"}
       :snippet      {:background    "#0e0e10"
-                     :color         (:warning colors/tokens)
+                     :color         (:warning rf.story.theme.colors/tokens)
                      :padding       "10px"
                      :border        "1px solid #333"
                      :border-radius "4px"
@@ -343,31 +343,31 @@
                      :overflow      "auto"
                      :max-height    "44vh"
                      :font-family   mono-stack
-                     :font-size     (:caption typography/type-scale)
+                     :font-size     (:caption rf.story.theme.typography/type-scale)
                      :line-height   "1.45"
                      :flex          "1 1 auto"}
       :btn-row      {:display         "flex"
                      :gap             "8px"
                      :justify-content "flex-end"}
       :btn          {:padding       "5px 12px"
-                     :background    (:accent-amber colors/tokens)
+                     :background    (:accent-amber rf.story.theme.colors/tokens)
                      :color         "white"
                      :border        "none"
                      :border-radius "3px"
                      :cursor        "pointer"
                      :font-family   mono-stack
-                     :font-size     (:caption typography/type-scale)}
+                     :font-size     (:caption rf.story.theme.typography/type-scale)}
       :btn-muted    {:padding       "5px 12px"
                      :background    "transparent"
-                     :color         (:text-primary colors/tokens)
+                     :color         (:text-primary rf.story.theme.colors/tokens)
                      :border        "1px solid #444"
                      :border-radius "3px"
                      :cursor        "pointer"
                      :font-family   mono-stack
-                     :font-size     (:caption typography/type-scale)}
-      :hint         {:color       (:text-tertiary colors/tokens)
+                     :font-size     (:caption rf.story.theme.typography/type-scale)}
+      :hint         {:color       (:text-tertiary rf.story.theme.colors/tokens)
                      :font-style  "italic"
-                     :font-size   (:micro typography/type-scale)}}))
+                     :font-size   (:micro rf.story.theme.typography/type-scale)}}))
 
 #?(:cljs
    (defn review-dialog
@@ -438,7 +438,7 @@
          ;; ride on the inner panel + the wrapper's on-click closes on
          ;; backdrop tap as before. Hiccup is passed eagerly to the
          ;; focus-trap so tests can string-traverse the full tree.
-         [a11y-dialog/focus-trap
+         [rf.story.ui.a11y-dialog/focus-trap
           {:on-close on-close}
           [:div {:style     (:modal-back styles)
                  :data-test (dtest "dialog")

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -26,31 +26,31 @@
   production code that accidentally calls `run-variant` does not throw
   — it returns empty."
   (:require [re-frame.core            :as rf]
-            [re-frame.error           :as error]
-            [re-frame.late-bind       :as late-bind]
-            [re-frame.story.args      :as args]
-            [re-frame.story.assertions :as assertions]
-            [re-frame.story.async     :as async]
-            [re-frame.story.config    :as config]
-            [re-frame.story.decorators :as decorators]
-            [re-frame.story.error     :as story-error]
-            [re-frame.story.frames    :as frames]
-            [re-frame.story.identity  :as ident]
-            [re-frame.story.loaders   :as loaders]
-            [re-frame.story.plan      :as plan]
-            [re-frame.story.play      :as play]
-            [re-frame.story.play.evidence :as evidence]
-            [re-frame.story.play.runner :as runner]
-            [re-frame.story.play.runner-events :as runner-events]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.story.requirements :as requirements]
-            [re-frame.story.result    :as result]
-            [re-frame.interop         :as interop]
-            [re-frame.trace           :as trace]
+            [re-frame.error           :as rf.error]
+            [re-frame.late-bind       :as rf.late-bind]
+            [re-frame.story.args      :as rf.story.args]
+            [re-frame.story.assertions :as rf.story.assertions]
+            [re-frame.story.async     :as rf.story.async]
+            [re-frame.story.config    :as rf.story.config]
+            [re-frame.story.decorators :as rf.story.decorators]
+            [re-frame.story.error     :as rf.story.error]
+            [re-frame.story.frames    :as rf.story.frames]
+            [re-frame.story.identity  :as rf.story.identity]
+            [re-frame.story.loaders   :as rf.story.loaders]
+            [re-frame.story.plan      :as rf.story.plan]
+            [re-frame.story.play      :as rf.story.play]
+            [re-frame.story.play.evidence :as rf.story.play.evidence]
+            [re-frame.story.play.runner :as rf.story.play.runner]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.requirements :as rf.story.requirements]
+            [re-frame.story.result    :as rf.story.result]
+            [re-frame.interop         :as rf.interop]
+            [re-frame.trace           :as rf.trace]
             ;; The listener API lives in `re-frame.trace.tooling`
             ;; (production-DCE split). The hot-path emit fast-path
-            ;; (`trace/emit!`) stays in `re-frame.trace`.
-            [re-frame.trace.tooling   :as trace-tooling]))
+            ;; (`rf.trace/emit!`) stays in `re-frame.trace`.
+            [re-frame.trace.tooling   :as rf.trace.tooling]))
 
 ;; ---- empty / disabled result ---------------------------------------------
 
@@ -97,9 +97,9 @@
   [listener body-fn]
   (let [cb-id (keyword "re-frame.story.runtime"
                        (str "capture-" (swap! capture-counter inc)))]
-    (trace-tooling/register-listener! cb-id listener)
+    (rf.trace.tooling/register-listener! cb-id listener)
     (try (body-fn)
-      (finally (trace-tooling/unregister-listener! cb-id)))))
+      (finally (rf.trace.tooling/unregister-listener! cb-id)))))
 
 (defn- capture-phase-errors
   "Run `body-fn` (a 0-arg thunk) with a registered trace listener that
@@ -109,7 +109,7 @@
   return value.
 
   The capture set is every operation in
-  `story-error/pipeline-exception-operations` (handler-exception,
+  `rf.story.error/pipeline-exception-operations` (handler-exception,
   coeffect-exception, interceptor-exception), not just
   `:rf.error/handler-exception`. A loader/event phase whose cofx
   injector or user interceptor throws is caught by the shared
@@ -128,10 +128,10 @@
                     (cond
                       ;; Resolve the suppress decision against the event's
                       ;; own frame (per-(tool,frame) visibility).
-                      (config/suppress-sensitive? ev)
-                      (config/note-suppressed! (trace/trace-event-frame ev))
+                      (rf.story.config/suppress-sensitive? ev)
+                      (rf.story.config/note-suppressed! (rf.trace/trace-event-frame ev))
 
-                      (story-error/pipeline-exception-event? variant-id ev)
+                      (rf.story.error/pipeline-exception-event? variant-id ev)
                       (swap! collected conj ev)))]
     (with-trace-listener
       listener
@@ -180,7 +180,7 @@
     ;; NOT a bare event — it falls through to the refusal below.
     (and (vector? step)
          (keyword? (first step))
-         (not (runner/known-step? step)))
+         (not (rf.story.play.runner/known-step? step)))
     step
 
     :else nil))
@@ -209,7 +209,7 @@
   [variant-id plan]
   (let [plan-setup (get-in plan [:world :setup] [])]
     (when-let [offenders (seq (filter non-dispatch-setup-step? plan-setup))]
-      (error/throw-error!
+      (rf.error/throw-error!
         :rf.error/story-setup-step-unrunnable
         'rf.story/run-variant
         (str "re-frame2-story: variant " variant-id
@@ -250,7 +250,7 @@
               ;; Drain handler-exception trace events that the router
               ;; caught into the assertions list so phase-2 throws land
               ;; where the test-mode UI looks for them.
-              (play/drain-pending-exceptions! variant-id :phase-2-events))))))))
+              (rf.story.play/drain-pending-exceptions! variant-id :phase-2-events))))))))
 
 ;; ---- phase-1 loaders execution -------------------------------------------
 
@@ -266,7 +266,7 @@
   `:loaders-complete-when`, which is resolved through the predicate
   evaluator.
 
-  Events-only fast-path: when `frames/allocate!` drives the lifecycle
+  Events-only fast-path: when `rf.story.frames/allocate!` drives the lifecycle
   straight to `:ready` (no loaders / no frame-setup /
   no `:loaders-complete-when`), this fn short-circuits with `true`
   rather than firing `start-loaders!`/`finish-loaders!` against a
@@ -280,15 +280,15 @@
   so the inline-plan path (which has no registration) feeds the loader
   slots the compiler carried onto the plan's `:world`. The default keeps
   the registered path reading the side-table verbatim."
-  ([variant-id] (run-loaders! variant-id (frames/variant-body variant-id)))
+  ([variant-id] (run-loaders! variant-id (rf.story.frames/variant-body variant-id)))
   ([variant-id loader-body]
-   (if (= :ready (loaders/current-state variant-id))
+   (if (= :ready (rf.story.loaders/current-state variant-id))
     ;; Events-only fast-path. Lifecycle already terminal-
     ;; for-mount; the loader cascade has nothing to do.
     true
     (let [variant-body loader-body
           loader-events (or (:loaders variant-body) [])]
-      (loaders/start-loaders! variant-id)
+      (rf.story.loaders/start-loaders! variant-id)
       (capture-phase-errors
         variant-id :phase-1-loaders
         (fn []
@@ -301,13 +301,13 @@
                 ;; Drain handler-exception trace events the router caught
                 ;; into the assertions list so phase-1 loader throws
                 ;; surface in the test-mode UI / Xray.
-                (play/drain-pending-exceptions! variant-id :phase-1-loaders))))))
+                (rf.story.play/drain-pending-exceptions! variant-id :phase-1-loaders))))))
       ;; The current predicate contract resolves synchronously after the
       ;; loader events have drained.
-      (let [complete? (loaders/evaluate-complete-when variant-id variant-body)]
+      (let [complete? (rf.story.loaders/evaluate-complete-when variant-id variant-body)]
         (if complete?
           (do
-            (loaders/finish-loaders! variant-id)
+            (rf.story.loaders/finish-loaders! variant-id)
             true)
           (do
             (record-loader-incomplete! variant-id variant-body)
@@ -333,13 +333,13 @@
   accumulator. Per `002-Runtime.md` §Error projection errors continue the play sequence
   rather than aborting — the full picture is captured.
 
-  `opts` (optional) is threaded to `story-error/exception-record` —
+  `opts` (optional) is threaded to `rf.story.error/exception-record` —
   callers draining a pipeline-exception trace event pass `:operation`
   / `:failing-id` so the originating component attribution survives
   onto the record."
   ([variant-id phase event err] (record-error! variant-id phase event err nil))
   ([variant-id phase event err opts]
-   (let [record (story-error/exception-record variant-id phase event err opts)]
+   (let [record (rf.story.error/exception-record variant-id phase event err opts)]
      (try
        (rf/dispatch-sync [::append-assertion record] {:frame variant-id})
        (catch #?(:clj Throwable :cljs :default) dispatch-err
@@ -348,7 +348,7 @@
          ;; capture). Emit a debug trace breadcrumb so the lossy path is
          ;; visible in tooling; never re-throw — the caller is already
          ;; in error-recording flow.
-         (trace/emit!
+         (rf.trace/emit!
            :debug ::append-assertion-failed
            {:frame      variant-id
             :phase      phase
@@ -376,7 +376,7 @@
   Mirrors the `install-canonical-<X>!` shape used by every sibling
   installer in `canonical/canonical-installers`."
   []
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (rf/reg-event
       ::append-assertion
       (fn [{:keys [db]} [_ record]]
@@ -420,7 +420,7 @@
   "Resolve a normalized PLAN's `[:expect :checks]` ids into the
   `{check-id [assertion-atom …]}` map the unified result groups by.
   Expands each check id through the Story side-table
-  `:check` kind (`plan/expand-checks`). Sourcing the check ids from the
+  `:check` kind (`rf.story.plan/expand-checks`). Sourcing the check ids from the
   plan (rather than re-reading the variant body) means a REGISTERED
   variant and an INLINE plan (unregistered) resolve their
   checks identically: the compiler already merged inherited + composed
@@ -429,7 +429,7 @@
   aggregation still sees ungrouped records)."
   [plan]
   (try
-    (plan/expand-checks (get-in plan [:expect :checks]))
+    (rf.story.plan/expand-checks (get-in plan [:expect :checks]))
     (catch #?(:clj Throwable :cljs :default) _ {})))
 
 (defn- plan-assertion-atoms
@@ -477,7 +477,7 @@
   `filterv` over its `(vec (concat …))` output is identical to filtering
   the bare `concat` (filterv ignores the extra vec)."
   [plan executed-script]
-  (filterv assertions/schema-error? (plan-assertion-atoms plan executed-script)))
+  (filterv rf.story.assertions/schema-error? (plan-assertion-atoms plan executed-script)))
 
 (defn- plan-causal-expectations
   "Collect every declared `:rf.assert/caused` / `:rf.assert/no-cascade-
@@ -486,12 +486,12 @@
   `:reactive-counts` `:by-cause` projection (NOT dispatched into the frame,
   NOT a parallel accumulator), so — like `:rf.assert/schema-error` —
   collecting the DECLARED atoms here is the single path that feeds the
-  result boundary's causal matcher (`result/match-causal-expectations`)."
+  result boundary's causal matcher (`rf.story.result/match-causal-expectations`)."
   [plan executed-script]
-  (filterv assertions/causal? (plan-assertion-atoms plan executed-script)))
+  (filterv rf.story.assertions/causal? (plan-assertion-atoms plan executed-script)))
 
 (defn- selection-refusal
-  "The `requirements/select-runner` refusal as a one-element `:unmet` vector
+  "The `rf.story.requirements/select-runner` refusal as a one-element `:unmet` vector
   when no runner could be chosen (`:auto` and NO concrete runner satisfies
   the plan's required tokens — `:reason :no-runner-satisfies`), or `[]` when
   a runner WAS chosen (`{:status :ok …}`). Pure data → data."
@@ -507,19 +507,19 @@
   1. the `select-runner` refusal, when `:auto` selection found NO capable
      runner (`selection-refusal`);
   2. the FIXED-RUNNER per-unit refusals — every terminal/in-script ASSERTION
-     (`requirements/unmet-assertions`) and every setup/script STEP
-     (`requirements/unmet-steps`) whose required capability tokens the chosen
+     (`rf.story.requirements/unmet-assertions`) and every setup/script STEP
+     (`rf.story.requirements/unmet-steps`) whose required capability tokens the chosen
      runner lacks (a `:pixels` `visual-snapshot` / a `:dom` `[:click …]`
      under `:headless`);
   3. the POST-RUN, fail-closed evidence-slot validation
-     (`requirements/validate-run-evidence`) — an assertion that REQUIRED a
+     (`rf.story.requirements/validate-run-evidence`) — an assertion that REQUIRED a
      proof but whose evidence SLOT the tape never produced fails closed to
      `:cannot-run` (the proof was promised, not delivered).
 
   Under `:auto` selection the chosen runner satisfies every requirement, so
   (2) is empty (the cheapest CAPABLE runner was chosen); under fixed
   `:headless` it surfaces the per-requirement gaps. Both the fixed and auto
-  policies feed the SAME `:unmet` slot `result/run-result` folds into the
+  policies feed the SAME `:unmet` slot `rf.story.result/run-result` folds into the
   verdict (a run whose only unmet expectations are `:cannot-run` is itself
   `:cannot-run`, never a vacuous pass — spec/017 §`:cannot-run`)."
   [plan runner-selection evidence-slots executed-script]
@@ -536,22 +536,22 @@
         evidence  (or evidence-slots {})
         post-run  (when runner
                     (:missing-evidence
-                      (requirements/validate-run-evidence atoms evidence runner)))]
+                      (rf.story.requirements/validate-run-evidence atoms evidence runner)))]
     (vec (concat (selection-refusal runner-selection)
-                 (when runner (requirements/unmet-assertions runner atoms))
-                 (when runner (requirements/unmet-steps runner steps))
+                 (when runner (rf.story.requirements/unmet-assertions runner atoms))
+                 (when runner (rf.story.requirements/unmet-steps runner steps))
                  (or post-run [])))))
 
 (defn- record-result-map
   "Build the unified run-result returned by `run-variant` (spec/017
   §Run result + §Unified run result). Gathers whatever the
   runtime accumulated against the variant's frame and assembles the ONE
-  shared shape via `result/run-result`:
+  shared shape via `rf.story.result/run-result`:
 
   - the evidential slots (`:status` floor, `:epoch-tape`,
     `:schema-violations`, `:warnings`, `:effects`, `:sub-runs`,
     `:renders`, `:narrative`) are PROJECTED from the retained epoch tape
-    (`.4`'s `evidence/project-evidence`, via `result/run-result`) — NOT a
+    (`.4`'s `rf.story.play.evidence/project-evidence`, via `rf.story.result/run-result`) — NOT a
     parallel accumulator;
   - the judgement slots (`:assertions` / `:checks`) fold the
     `:rf.story/assertions` accumulator (the ONE non-tape input) into
@@ -592,15 +592,15 @@
         full-ring (rf/epoch-history variant-id)
         ;; The per-run epoch-tape truncation signal (rf2-4u5zl4): true when
         ;; the bounded ring evicted the run's earliest epochs (the baseline is
-        ;; no longer covered). Threaded to `result/run-result` so an in-bounds
+        ;; no longer covered). Threaded to `rf.story.result/run-result` so an in-bounds
         ;; causal `:pass` against a finite upper bound resolves `:cannot-run`
         ;; rather than a truncation false-green.
-        truncated? (evidence/run-tape-truncated? full-ring epoch-baseline)
+        truncated? (rf.story.play.evidence/run-tape-truncated? full-ring epoch-baseline)
         tape     (vec (filter #(> (or (:epoch-id %) 0) (or epoch-baseline 0))
                               full-ring))
         ;; The runner-recorded per-dispatch-step settle boundaries light
         ;; up the EXACT narrative attribution
-        ;; (`evidence/spans-from-stamps`). The
+        ;; (`rf.story.play.evidence/spans-from-stamps`). The
         ;; stamp is a `:rf.story/*` key the determinism projection strips, so
         ;; the run-hash is unaffected (the `:epoch-tape` slot stays raw).
         ;;
@@ -611,14 +611,14 @@
         ;; one frame cannot collide. A run that failed before play contributes
         ;; no keys and therefore no attribution boundaries.
         attribution (into []
-                          (mapcat #(runner-events/settle-boundaries variant-id %))
+                          (mapcat #(rf.story.play.runner-events/settle-boundaries variant-id %))
                           (or executed-play-keys []))
         ;; Project the tape ONCE here so the post-run evidence
         ;; validation (`requirements-unmet` → `validate-run-evidence`) reads
-        ;; the SAME projected slots `result/run-result` derives the result
+        ;; the SAME projected slots `rf.story.result/run-result` derives the result
         ;; slots from. One tape, one projection — a duplicate accumulator
         ;; cannot report a proof present while the tape's slot is empty.
-        evidence (evidence/project-evidence tape {:script      executed-script
+        evidence (rf.story.play.evidence/project-evidence tape {:script      executed-script
                                                   :attribution attribution})
         ;; The run-state's `:cannot-run` refusals (a no-DOM
         ;; `[:assert-dom …]` skip, a boundary `:cannot-run?`): steps that
@@ -626,8 +626,8 @@
         ;; unified result would aggregate to `:pass` (vacuous green) while the
         ;; run-state read `:cannot-run`. The facade degrades to nil run-state
         ;; (empty refusals) on a host with no runner-events run-state.
-        run-state-unmet (runner/run-state-refusals
-                          (runner-events/current-state variant-id))
+        run-state-unmet (rf.story.play.runner/run-state-refusals
+                          (rf.story.play.runner-events/current-state variant-id))
         ;; The requirements-registry refusals: the `:auto`
         ;; no-capable-runner refusal, the fixed-runner per-unit capability
         ;; gaps (`unmet-assertions` / `unmet-steps`), and the post-run
@@ -638,7 +638,7 @@
         ;; §Unified run result — "a run whose only unmet expectations are
         ;; :cannot-run is itself :cannot-run").
         unmet    (into (vec run-state-unmet) req-unmet)
-        unified  (result/run-result
+        unified  (rf.story.result/run-result
                    {:variant/id          variant-id
                     :epoch-tape          tape
                     ;; The runner-recorded per-dispatch-step settle
@@ -678,30 +678,30 @@
                     ;; The per-requirement `:cannot-run` refusals
                     ;; the runner could not even attempt (above). Folded into
                     ;; the verdict + surfaced on `:cannot-run` by
-                    ;; `result/run-result`.
+                    ;; `rf.story.result/run-result`.
                     :unmet               unmet
                     :app-db              (or app-db {})
-                    :elapsed-ms          (- (interop/now-ms) start-ms)})]
+                    :elapsed-ms          (- (rf.interop/now-ms) start-ms)})]
     (cond-> (merge unified
                    {:frame           variant-id
                     :snapshot        snapshot
                     :decorators      decorator-stack
                     :effective-args  effective-args
-                    :lifecycle       (loaders/current-state variant-id)})
+                    :lifecycle       (rf.story.loaders/current-state variant-id)})
       ;; EP-0023 §Stories — surface the behaviour-variant
       ;; IMAGE ids the run resolved behaviour against, so Test mode / MCP /
       ;; Xray can show WHICH behaviour set ran. Present only for a behaviour
       ;; variant (one that declared `:images`); omitted for an ordinary state
       ;; variant resolving against the shared default registrar.
-      (seq (frames/variant-image-ids variant-id))
-      (assoc :images (frames/variant-image-ids variant-id)))))
+      (seq (rf.story.frames/variant-image-ids variant-id))
+      (assoc :images (rf.story.frames/variant-image-ids variant-id)))))
 
 (defn- resolve-runner-selection
   "Normalize the run `opts` and SELECT the runner for `plan`. Returns the
-  `requirements/select-runner` outcome — either `{:status :ok :runner …
+  `rf.story.requirements/select-runner` outcome — either `{:status :ok :runner …
   :unmet …}` (a runner was chosen; under `:auto` it satisfies all, under
   fixed `:headless` its `:unmet` may be non-empty) or a
-  `requirements/requirement-refusal` (`:auto` and NO runner satisfies, e.g.
+  `rf.story.requirements/requirement-refusal` (`:auto` and NO runner satisfies, e.g.
   a `:reactive-counts` requirement → `:no-runner-satisfies`).
 
   `normalize-run-opts` collapses `:runner` / `:escalate` into the canonical
@@ -709,14 +709,14 @@
   pins, §Run / `is` opts); `select-runner` then chooses the cheapest capable
   runner under `:auto`, or runs the whole plan single-pass under the fixed
   runner. The plan's `:required-runner` slot is the union capability set the
-  compiler already filled through this SAME registry (`plan/compute-required-
-  runner` → `requirements/plan-required-runner`), so selection reads the ONE
+  compiler already filled through this SAME registry (`rf.story.plan/compute-required-
+  runner` → `rf.story.requirements/plan-required-runner`), so selection reads the ONE
   source of truth, never a re-derivation. Pure aside from nothing — `opts`
   and `plan` in, the selection map out."
   [plan opts]
-  (let [norm-opts (requirements/normalize-run-opts opts)
+  (let [norm-opts (rf.story.requirements/normalize-run-opts opts)
         required  (get plan :required-runner #{})]
-    (requirements/select-runner required norm-opts)))
+    (rf.story.requirements/select-runner required norm-opts)))
 
 (defn- prepare-context
   "Resolve the per-run inputs that every phase needs: the NORMALIZED
@@ -734,7 +734,7 @@
   orchestrator's try/catch (`handle-run-error!`) projects it onto the run
   result.
 
-  Phase-4 drives the rich-DSL step executor through `runner-events/run!`."
+  Phase-4 drives the rich-DSL step executor through `rf.story.play.runner-events/run!`."
   [variant-id variant-body opts]
   (let [;; Compile the plan WITH the per-run arg layers
         ;; (`:active-modes` / `:cell-overrides`) so the substituted
@@ -742,8 +742,8 @@
         ;; and the plan hash all use the SAME effective args the result
         ;; reports. The plan and the result thus run the SAME scenario the
         ;; cell override or active mode describes.
-        plan (plan/variant-plan variant-id
-                                {:run-args (args/run-arg-layers variant-id opts)})]
+        plan (rf.story.plan/variant-plan variant-id
+                                {:run-args (rf.story.args/run-arg-layers variant-id opts)})]
     {:variant-id       variant-id
      :variant-body     variant-body
      :plan             plan
@@ -754,7 +754,7 @@
      :runner-selection (resolve-runner-selection plan opts)
      ;; Resolve the decorator stack from the ALREADY-compiled
      ;; plan's `[:world :decorators]` refs (the twin of the inline path's
-     ;; `prepare-inline-context`), NOT via `decorators/resolve-decorators`
+     ;; `prepare-inline-context`), NOT via `rf.story.decorators/resolve-decorators`
      ;; which recompiles the plan WITHOUT `:run-args`. Reusing this plan
      ;; (a) avoids a redundant second compile, and (b) is correct now that a
      ;; `[:arg key]` may resolve ONLY through a run-opts layer (an active
@@ -762,32 +762,32 @@
      ;; `:rf.error/story-missing-arg` substituting that script placeholder.
      ;; v1 modes carry no decorators (`001-Authoring.md` §Registration macros: modes are :args only),
      ;; so `:active-modes` does not perturb the decorator refs.
-     :decorator-stack  (decorators/resolve-decorator-refs
+     :decorator-stack  (rf.story.decorators/resolve-decorator-refs
                          (get-in plan [:world :decorators] []))
      ;; Report the SAME effective args the plan was compiled
      ;; with (the plan is the single source of truth). The plan folds the
      ;; ambient + run layers around its `:extends`-aware variant layer, so
-     ;; `[:world :effective-args]` equals `args/resolve-args` for a variant
+     ;; `[:world :effective-args]` equals `rf.story.args/resolve-args` for a variant
      ;; with no `:extends`, and is the strictly-more-correct extends-aware
      ;; value when the variant inherits args.
      :effective-args   (get-in plan [:world :effective-args] {})
-     :snapshot         (ident/snapshot-identity variant-id opts)}))
+     :snapshot         (rf.story.identity/snapshot-identity variant-id opts)}))
 
 (defn- ensure-fresh-frame!
   "Enforce a FRESH-RUN boundary for `variant-id`. Per
   spec/002-Runtime §`run-variant` step 1 — `run-variant` allocates OR
   resets the variant frame; it never reuses an existing one.
 
-  `frames/allocate!` against an existing frame goes through
+  `rf.story.frames/allocate!` against an existing frame goes through
   `make-frame`'s surgical-update path, which PRESERVES the prior app-db
-  and sub-cache (frames/allocate! docstring). For a Story run that is
+  and sub-cache (rf.story.frames/allocate! docstring). For a Story run that is
   the wrong shape: a second `run-variant` on the same id would inherit
   the first run's app-db, and — worse — `run-loaders!` short-circuits on
   an already-`:ready` frame, so a loader variant would SKIP its loaders
   on the second run (a stateful, order-dependent false result).
 
   When a frame already exists under `variant-id` we reset it to fresh
-  state IN PLACE via `frames/reset-state!` — overwriting both frame-state
+  state IN PLACE via `rf.story.frames/reset-state!` — overwriting both frame-state
   partitions with `{}` through the one physical container so the frame's
   IDENTITY, sub-cache, and projection reactions all survive. The in-place
   reset matters because the canvas mounts the variant view (establishing
@@ -802,7 +802,7 @@
   explicit opt, not the default."
   [variant-id]
   (when (contains? (set (rf/frame-ids)) variant-id)
-    (frames/reset-state! variant-id)))
+    (rf.story.frames/reset-state! variant-id)))
 
 (defn- run-phase-0!
   "Phase 0: enforce a fresh-run boundary, allocate the variant frame
@@ -824,7 +824,7 @@
   clean slot; `execute-play!` clears it again at play start.
 
   The `:loaders-complete-when` vector form reads the epoch
-  tape (`assertions/dispatched-events`, the SSOT) rather than a side-table
+  tape (`rf.story.assertions/dispatched-events`, the SSOT) rather than a side-table
   accumulator, so there is no accumulator to seed here.
 
   Because an in-place reset preserves the frame-owned epoch ring, phase 0
@@ -838,11 +838,11 @@
   classification through the same allocation boundary."
   [{:keys [variant-id decorator-stack plan] :as ctx}]
   (ensure-fresh-frame! variant-id)
-  (frames/allocate! variant-id decorator-stack
+  (rf.story.frames/allocate! variant-id decorator-stack
                      (select-keys (:world plan) [:sensitive :large]))
-  (swap! play/pending-exceptions assoc variant-id [])
-  (play/install-trace-listener! variant-id)
-  (assoc ctx :epoch-baseline (runner-events/last-epoch-id variant-id)))
+  (swap! rf.story.play/pending-exceptions assoc variant-id [])
+  (rf.story.play/install-trace-listener! variant-id)
+  (assoc ctx :epoch-baseline (rf.story.play.runner-events/last-epoch-id variant-id)))
 
 (defn- db-seed-violations
   "Validate the seeded `db` against the frame's REGISTERED app-db schemas
@@ -862,9 +862,9 @@
   uses, so the seed is held to exactly the contract a real handler commit
   would be (spec/010 §Production builds)."
   [frame-id db]
-  (let [entries-fn  (late-bind/get-fn :schemas/frame-schema-entries)
-        validate-fn (late-bind/get-fn :schemas/validate-with-registered-fn)
-        explain-fn  (late-bind/get-fn :schemas/explain-with-registered-fn)]
+  (let [entries-fn  (rf.late-bind/get-fn :schemas/frame-schema-entries)
+        validate-fn (rf.late-bind/get-fn :schemas/validate-with-registered-fn)
+        explain-fn  (rf.late-bind/get-fn :schemas/explain-with-registered-fn)]
     (if (or (nil? entries-fn) (nil? validate-fn))
       ;; No schemas artefact / no validator → soft-pass (nothing to check).
       []
@@ -904,7 +904,7 @@
     (rf/dispatch-sync [::apply-db-seed seed] {:frame variant-id})
     (let [violations (db-seed-violations variant-id (rf/app-db-value variant-id))]
       (when (seq violations)
-        (error/throw-error!
+        (rf.error/throw-error!
           :rf.error/story-db-seed-invalid
           'rf.story/run-variant
           (str "re-frame2-story: variant " variant-id
@@ -941,7 +941,7 @@
   [{:keys [variant-id loaders-complete? plan] :as ctx}]
   (when loaders-complete?
     (run-events! variant-id plan)
-    (loaders/finish-events! variant-id))
+    (rf.story.loaders/finish-events! variant-id))
   ctx)
 
 (defn- settle-terminal-assertions!
@@ -953,9 +953,9 @@
   `[:assert …]` checkpoint stays 'check here, now'.
 
   Routes through the SAME executor the in-script checkpoints use
-  (`runner-events/run-terminal-assertions!` → `exec-assert!`), so the
+  (`rf.story.play.runner-events/run-terminal-assertions!` → `exec-assert!`), so the
   verdict lands on `:rf.story/assertions` via the ONE recording path —
-  `record-result-map` / `result/run-result` already folds that accumulator
+  `record-result-map` / `rf.story.result/run-result` already folds that accumulator
   into the unified `:pass` / `:fail`. The terminal atoms are the plan's
   `[:expect :assertions]` (the SAME slot `plan-assertion-atoms` reads), so a
   REGISTERED variant and an INLINE plan both route here.
@@ -963,7 +963,7 @@
   The tape-evaluated kinds (`:rf.assert/schema-error`, the causal / cascade
   family, the browser-tier oracle family) are NOT double-processed: they
   carry no reg-event handler, so `exec-assert!` records a no-op step-skip
-  for them and never dispatches — `result/run-result` already evaluates them
+  for them and never dispatches — `rf.story.result/run-result` already evaluates them
   against the epoch tape from the plan's `:schema-expectations` /
   `:causal-expectations` (collected by `plan-schema-expectations` /
   `plan-causal-expectations`). Only the handler-backed terminal atoms are
@@ -971,7 +971,7 @@
   swallowed (record-don't-throw)."
   [variant-id plan]
   (try
-    (runner-events/run-terminal-assertions!
+    (rf.story.play.runner-events/run-terminal-assertions!
       variant-id (get-in plan [:expect :assertions]))
     (catch #?(:clj Throwable :cljs :default) _ nil))
   nil)
@@ -985,7 +985,7 @@
   to build the result.
 
   Drives the rich-DSL `:script` runner via
-  `runner-events/run!`. Variants without `:script` / `:plays`
+  `rf.story.play.runner-events/run!`. Variants without `:script` / `:plays`
   resolve to an empty script and the promise resolves immediately. Author
   event sequences by wrapping each entry in `[:dispatch-sync <event-vec>]`
   inside a `:script` body.
@@ -998,7 +998,7 @@
   The play set comes from the normalized plan's
   `[:world :scripts]` (the named scripts the compiler's `normalize-scripts`
   produces — `:plays` preserved as named scripts, spec/017 §Public
-  vocabulary), NOT a second `runner-events/variant-plays` read of the
+  vocabulary), NOT a second `rf.story.play.runner-events/variant-plays` read of the
   registered body. The compiler already coerces + folds every script, so
   the plan's `:scripts` carry the `{:script :auto-run? :name}` shape the
   runner drives directly.
@@ -1016,14 +1016,14 @@
   view is mounted and the auto-play must run against it and publish a play-
   runner run-state — the exact behaviour the pre-split browser `auto-run!` had,
   which the Story/Xray play-scripts browser gate reads via
-  `runner-events/current-state`. The headless `run-variant` / inline paths
+  `rf.story.play.runner-events/current-state`. The headless `run-variant` / inline paths
   never set it, so their contract (loader-incomplete ⇒ events + play skipped,
   lifecycle parks at `:loading`) is unchanged."
   [{:keys [variant-id loaders-complete? plan force-play?] :as ctx}]
   (if-not (or loaders-complete? force-play?)
-    [ctx (async/resolved (read-assertions variant-id))]
+    [ctx (rf.story.async/resolved (read-assertions variant-id))]
     (let [plays      (get-in plan [:world :scripts] [])
-          auto-plays (runner/auto-runnable-plays plays)
+          auto-plays (rf.story.play.runner/auto-runnable-plays plays)
           ;; The folded steps the auto-plays ran, concatenated in order —
           ;; the script the unified result's two-level narrative spans.
           executed   (vec (mapcat :script auto-plays))
@@ -1048,15 +1048,15 @@
           ;; whole frame) means a concurrent run for a different play-key on this
           ;; frame can never be wiped by — or wipe — this reset.
           _          (doseq [pk play-keys]
-                       (runner-events/clear-step-boundaries! variant-id pk))]
+                       (rf.story.play.runner-events/clear-step-boundaries! variant-id pk))]
       (if (empty? auto-plays)
         ;; No script ran, but the world settled (phase-2 setup committed).
         ;; The terminal `:assertions` check the FINAL settled state, so they
         ;; still auto-run here.
-        [ctx' (async/resolved (do (settle-terminal-assertions! variant-id plan)
+        [ctx' (rf.story.async/resolved (do (settle-terminal-assertions! variant-id plan)
                                   (read-assertions variant-id)))]
         [ctx'
-         (async/promise
+         (rf.story.async/promise
            (fn [resolve]
              ;; Run each auto-play sequentially. The `:rf.assert/*` events
              ;; the folded `[:assert …]` checkpoints dispatch record into
@@ -1077,7 +1077,7 @@
                            ;; across the concatenated `:executed-script` rather
                            ;; than each `run!` wiping the prior play's — the
                            ;; multi-play attribution-boundary fix.
-                           (runner-events/run! variant-id (:name spec) spec
+                           (rf.story.play.runner-events/run! variant-id (:name spec) spec
                                                (fn [_state]
                                                  (step! (rest remaining)))
                                                {:clear-boundaries? false}))))]
@@ -1090,7 +1090,7 @@
   app-db."
   [resolve play-promise ctx start-ms]
   (-> play-promise
-      (async/then
+      (rf.story.async/then
         (fn [_]
           (resolve (record-result-map ctx start-ms))
           nil))))
@@ -1140,7 +1140,7 @@
                        :status     :error
                        :passed?    false
                        :reason     (exception-message e)
-                       :error      (story-error/throwable->error-map e)}]))
+                       :error      (rf.story.error/throwable->error-map e)}]))
 
 (defn- db-seed-error?
   "True iff `e` is the structured `:db-seed` schema-validation failure
@@ -1202,7 +1202,7 @@
   errors (which carry `:rf.error/id` but not the plan marker), so the
   lifecycle state is not needed to route correctly — gating on lifecycle
   state would be stale-frame-sensitive (a PRIOR `:ready` run on the same
-  id leaves `loaders/current-state` at `:ready`, not `:pre-mount`)."
+  id leaves `rf.story.loaders/current-state` at `:ready`, not `:pre-mount`)."
   [resolve variant-id e start-ms]
   (cond
     (plan-construction-error? e)
@@ -1211,17 +1211,17 @@
     (db-seed-error? e)
     (do
       (record-seed-error! variant-id e)
-      (loaders/error! variant-id (ex-data e))
+      (rf.story.loaders/error! variant-id (ex-data e))
       (resolve (record-result-map {:variant-id variant-id} start-ms)))
 
     :else
     (do
       (record-error! variant-id :phase-0-setup nil e)
-      (loaders/error! variant-id (ex-data e))
+      (rf.story.loaders/error! variant-id (ex-data e))
       (resolve (record-result-map {:variant-id variant-id} start-ms)))))
 
 (defn- unknown-variant-result
-  "The error result returned when `frames/variant-body` finds no
+  "The error result returned when `rf.story.frames/variant-body` finds no
   registration for `variant-id`. Kept separate so the missing-variant
   branch of `run-variant` reads as a single expression."
   [variant-id]
@@ -1282,13 +1282,13 @@
   helper event this runtime dispatches into."
   ([variant-id] (run-variant variant-id nil))
   ([variant-id opts]
-   (if-not config/enabled?
-     (async/resolved (empty-result variant-id))
-     (let [variant-body (frames/variant-body variant-id)]
+   (if-not rf.story.config/enabled?
+     (rf.story.async/resolved (empty-result variant-id))
+     (let [variant-body (rf.story.frames/variant-body variant-id)]
        (if (nil? variant-body)
-         (async/resolved (unknown-variant-result variant-id))
-         (let [start-ms (interop/now-ms)]
-           (async/promise
+         (rf.story.async/resolved (unknown-variant-result variant-id))
+         (let [start-ms (rf.interop/now-ms)]
+           (rf.story.async/promise
              (fn [resolve]
                (try
                  (let [ctx (prepare-ctx! variant-id variant-body opts)]
@@ -1325,7 +1325,7 @@
 ;;
 ;; Ownership is per variant/frame (one registry slot per variant-id), so two
 ;; different variants run concurrently and independently — this is NOT a global
-;; lock. The inner per-play run-token (`runner-events/run!`) still guards
+;; lock. The inner per-play run-token (`rf.story.play.runner-events/run!`) still guards
 ;; play-key isolation; it is not the outer lifecycle owner.
 
 (defonce ^:private run-owner
@@ -1377,7 +1377,7 @@
   Fire-and-forget: the display reads the frame's app-db reactively. Returns the
   claimed (or deduped) generation."
   [variant-id {:keys [run-key] :as opts}]
-  (when (and config/enabled? variant-id)
+  (when (and rf.story.config/enabled? variant-id)
     (let [cur    (get @run-owner variant-id)
           ;; A fresh logical run when: never prepared; the run-key changed; or
           ;; the current generation was already resumed (a remount / re-entry).
@@ -1389,10 +1389,10 @@
         ;; this generation. Do NOT reset it or bump the generation; the pending
         ;; resume owns the one execution.
         (:generation cur)
-        (let [variant-body (frames/variant-body variant-id)
+        (let [variant-body (rf.story.frames/variant-body variant-id)
               gen          (inc (get cur :generation 0))
               base         {:run-key run-key :generation gen :resumed-gen (dec gen)
-                            :start-ms (interop/now-ms)}]
+                            :start-ms (rf.interop/now-ms)}]
           (if (nil? variant-body)
             (do (swap! run-owner assoc variant-id (assoc base :error :unknown-variant))
                 gen)
@@ -1440,11 +1440,11 @@
   never prepared)."
   ([variant-id] (resume-run! variant-id nil))
   ([variant-id done-cb]
-   (when (and config/enabled? variant-id)
+   (when (and rf.story.config/enabled? variant-id)
      (when-let [attempt (claim-resume! variant-id)]
        (let [my-gen   (:generation attempt)
-             start-ms (or (:start-ms attempt) (interop/now-ms))]
-         (async/promise
+             start-ms (or (:start-ms attempt) (rf.interop/now-ms))]
+         (rf.story.async/promise
            (fn [resolve]
              (try
                (cond
@@ -1476,7 +1476,7 @@
                  :else
                  (let [[ctx' play-promise] (run-phase-4! (assoc (:ctx attempt) :force-play? true))]
                    (-> play-promise
-                       (async/then
+                       (rf.story.async/then
                          (fn [_]
                            (if (= my-gen (current-generation variant-id))
                              (resolve (record-result-map ctx' start-ms))
@@ -1499,7 +1499,7 @@
 ;;
 ;; The design reuses the registered run pipeline rather than forking it:
 ;;
-;;   - the plan is compiled once (`plan/variant-plan` accepts the map);
+;;   - the plan is compiled once (`rf.story.plan/variant-plan` accepts the map);
 ;;   - an ANONYMOUS frame id is minted in the reserved `:rf.story.inline/*`
 ;;     namespace (NEVER a registered variant id, so navigation can't surface
 ;;     it and a concurrent registered run can't collide);
@@ -1531,7 +1531,7 @@
   - `:variant-id`      — the minted anonymous frame id (the run's frame);
   - `:plan`            — the supplied compiled plan, threaded down the
                           phases unchanged (it is already normalized);
-  - `:decorator-stack` — `decorators/resolve-decorator-refs` over the
+  - `:decorator-stack` — `rf.story.decorators/resolve-decorator-refs` over the
                           plan's `[:world :decorators]` refs (the compiler
                           merged the variant chain + composed fragments
                           into that vector);
@@ -1556,7 +1556,7 @@
    {:variant-id       frame-id
     :plan             plan
     :runner-selection (resolve-runner-selection plan opts)
-    :decorator-stack  (decorators/resolve-decorator-refs
+    :decorator-stack  (rf.story.decorators/resolve-decorator-refs
                         (get-in plan [:world :decorators] []))
     :effective-args   (get-in plan [:world :effective-args] {})
     :loader-body      {:loaders               (get-in plan [:world :loaders])
@@ -1567,7 +1567,7 @@
   "True iff the inline `plan` drives no loaders / loaders-complete-when and
   carries no `:frame-setup` decorators — so the lifecycle takes the
   `:pre-mount → :ready` fast-path. Mirrors
-  `loaders/events-only-variant?`, reading the loader slots off the plan's
+  `rf.story.loaders/events-only-variant?`, reading the loader slots off the plan's
   `:world` rather than a registered body."
   [plan decorator-stack]
   (and (empty? (get-in plan [:world :loaders]))
@@ -1591,7 +1591,7 @@
   and an equivalent registered variant project the same-shaped tape (and
   therefore the same run-hash)."
   [{:keys [variant-id plan decorator-stack] :as ctx}]
-  (frames/allocate-inline! variant-id
+  (rf.story.frames/allocate-inline! variant-id
                            decorator-stack
                            (get-in plan [:world :frame :fx-overrides])
                            (inline-events-only? plan decorator-stack)
@@ -1602,9 +1602,9 @@
                            ;; actually applies to the frame's elision
                            ;; registry instead of being silently dropped.
                            (select-keys (:world plan) [:sensitive :large]))
-  (swap! play/pending-exceptions assoc variant-id [])
-  (play/install-trace-listener! variant-id)
-  (assoc ctx :epoch-baseline (runner-events/last-epoch-id variant-id)))
+  (swap! rf.story.play/pending-exceptions assoc variant-id [])
+  (rf.story.play/install-trace-listener! variant-id)
+  (assoc ctx :epoch-baseline (rf.story.play.runner-events/last-epoch-id variant-id)))
 
 (defn run-inline-plan
   "Execute an inline plan MAP (spec/017 §Inline plan) and
@@ -1628,22 +1628,22 @@
   frame stamped `:rf/inline?`)."
   ([inline-plan] (run-inline-plan inline-plan nil))
   ([inline-plan opts]
-   (if-not config/enabled?
-     (async/resolved (empty-result (:variant/id inline-plan)))
-     (let [start-ms     (interop/now-ms)
+   (if-not rf.story.config/enabled?
+     (rf.story.async/resolved (empty-result (:variant/id inline-plan)))
+     (let [start-ms     (rf.interop/now-ms)
            compile-opts (select-keys opts [:lookup :fragment-lookup :check-lookup
                                            :view-lookup :sub-lookup :validator-fns])
            ;; Compile the plan up front so a construction failure (an
            ;; unknown composed fragment, a missing `[:arg …]`, an
            ;; `[:assert …]` in setup, …) is projected directly — no frame
            ;; is allocated, mirroring `plan-error-result`'s frame-free shape.
-           plan-or-err  (try {:plan (plan/variant-plan inline-plan compile-opts)}
+           plan-or-err  (try {:plan (rf.story.plan/variant-plan inline-plan compile-opts)}
                           (catch #?(:clj Throwable :cljs :default) e {:error e}))]
        (if-let [e (:error plan-or-err)]
-         (async/resolved (plan-error-result (:variant/id inline-plan) e))
+         (rf.story.async/resolved (plan-error-result (:variant/id inline-plan) e))
          (let [plan     (:plan plan-or-err)
                frame-id (mint-inline-frame-id)]
-           (async/promise
+           (rf.story.async/promise
              (fn [resolve]
                ;; The SUCCESS path tears the inline frame down
                ;; with the decorator stack used for allocation + the plan's
@@ -1668,7 +1668,7 @@
                      teardown!  (fn []
                                   (when @allocated?
                                     (try
-                                      (frames/destroy-inline!
+                                      (rf.story.frames/destroy-inline!
                                         frame-id (:decorator-stack @ctx*)
                                         (get-in plan [:world :loaders-teardown]))
                                       (catch #?(:clj Throwable :cljs :default) _ nil))))
@@ -1680,7 +1680,7 @@
                                   (if (db-seed-error? e)
                                     (record-seed-error! frame-id e)
                                     (record-error! frame-id :phase-0-setup nil e))
-                                  (loaders/error! frame-id (ex-data e))
+                                  (rf.story.loaders/error! frame-id (ex-data e))
                                   (let [result (record-result-map
                                                  {:variant-id frame-id :plan plan} start-ms)]
                                     (teardown!)
@@ -1698,7 +1698,7 @@
                          [ctx' play-promise] (run-phase-4! ctx)
                          _            (vreset! ctx* ctx')]
                      (-> play-promise
-                         (async/then
+                         (rf.story.async/then
                            (fn [_]
                              (let [result (record-result-map ctx' start-ms)]
                                (teardown!)
@@ -1706,7 +1706,7 @@
                              nil))
                          ;; A rejection INSIDE the play promise (phase 4) must
                          ;; also converge on teardown, not leak the frame.
-                         (async/catch* (fn [e] (fail! e) nil))))
+                         (rf.story.async/catch* (fn [e] (fail! e) nil))))
                    (catch #?(:clj Throwable :cljs :default) e
                      (fail! e))))))))))))
 
@@ -1719,12 +1719,12 @@
   Returns a promise/future of the new result map."
   ([variant-id] (reset-variant variant-id nil))
   ([variant-id opts]
-   (when config/enabled?
+   (when rf.story.config/enabled?
      ;; Drop the one-run-owner attempt (rf2-j538f7.34): its prepared ctx points
      ;; at the frame we are about to destroy, so the next prepare must start a
      ;; fresh generation rather than dedupe onto a stale attempt.
      (reset-run-owner! variant-id)
-     (frames/destroy! variant-id))
+     (rf.story.frames/destroy! variant-id))
    (run-variant variant-id opts)))
 
 ;; ---- watch-variant -------------------------------------------------------
@@ -1738,10 +1738,10 @@
 
   The UI shell and assertion runtime consume this. The watcher table is
   per-frame so destroyed frames clean up automatically via
-  `frames/destroy!`."
+  `rf.story.frames/destroy!`."
   [variant-id callback]
-  (when config/enabled?
-    (loaders/add-watcher! variant-id callback)))
+  (when rf.story.config/enabled?
+    (rf.story.loaders/add-watcher! variant-id callback)))
 
 ;; ---- snapshot-identity re-export ----------------------------------------
 
@@ -1749,5 +1749,5 @@
   "Per `002-Runtime.md` §Snapshot-identity computation. Compute the content-hash for
   `(variant × active-modes × cell-overrides × substrate)`. See
   `re-frame.story.identity/snapshot-identity` for the canonical form."
-  ([variant-id] (ident/snapshot-identity variant-id))
-  ([variant-id opts] (ident/snapshot-identity variant-id opts)))
+  ([variant-id] (rf.story.identity/snapshot-identity variant-id))
+  ([variant-id opts] (rf.story.identity/snapshot-identity variant-id opts)))

--- a/tools/story/src/re_frame/story/save_variant.cljc
+++ b/tools/story/src/re_frame/story/save_variant.cljc
@@ -33,24 +33,24 @@
 
   ## Elision
 
-  Every public fn opens with `(when config/enabled? ...)` or is pure data
+  Every public fn opens with `(when rf.story.config/enabled? ...)` or is pure data
   → data so production CLJS builds short-circuit before any side effect.
   The dialog ratom + button component live in
   `re-frame.story.ui.save-variant` (CLJS-only)."
   (:require [clojure.string :as str]
             [re-frame.core                       :as rf]
-            [re-frame.story.args                 :as args]
-            [re-frame.story.config               :as config]
-            [re-frame.story.predicates           :as pred]
-            [re-frame.story.registrar            :as registrar]
-            [re-frame.story.review-dialog        :as review-dialog]
-            [re-frame.story.ui.schema-validation :as schema-validation]
-            [re-frame.story.ui.state             :as state]))
+            [re-frame.story.args                 :as rf.story.args]
+            [re-frame.story.config               :as rf.story.config]
+            [re-frame.story.predicates           :as rf.story.predicates]
+            [re-frame.story.registrar            :as rf.story.registrar]
+            [re-frame.story.review-dialog        :as rf.story.review-dialog]
+            [re-frame.story.ui.schema-validation :as rf.story.ui.schema-validation]
+            [re-frame.story.ui.state             :as rf.story.ui.state]))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: args-snapshot helper
 ;;
-;; The snapshot IS `(args/resolve-args variant-id opts)` — the effective
+;; The snapshot IS `(rf.story.args/resolve-args variant-id opts)` — the effective
 ;; args after the five-layer precedence chain (global < story < modes <
 ;; variant < cell-overrides) collapses. This wrapper exists so callers
 ;; have a single entry point + so the JVM test corpus can pin the
@@ -74,13 +74,13 @@
   ([variant-id]
    (snapshot-args variant-id nil))
   ([variant-id {:keys [active-modes cell-overrides] :as _opts}]
-   (args/resolve-args variant-id
+   (rf.story.args/resolve-args variant-id
                       {:active-modes   (or active-modes [])
                        :cell-overrides (or cell-overrides {})})))
 
 (defn snapshot-violations
   "Project `args-snapshot` against `schema` using the validator-fn pair.
-  Thin pass-through to `schema-validation/args-violations` exposed here
+  Thin pass-through to `rf.story.ui.schema-validation/args-violations` exposed here
   for the save-as-variant flow — the save dialog reads the
   result to render a non-blocking 'Args do not match the variant's
   Spec 010 schema' hint above the snippet, so the user catches a
@@ -90,7 +90,7 @@
   validator / no schema / no violations (per Spec 010 §Recommended
   soft-pass)."
   [args-snapshot schema validator-fns]
-  (schema-validation/args-violations args-snapshot schema validator-fns))
+  (rf.story.ui.schema-validation/args-violations args-snapshot schema validator-fns))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: the eight-slice capture model
@@ -122,7 +122,7 @@
 ;;
 ;;   slice              live source                       substrate
 ;;   -----              -----------                       ---------
-;;   args               :cell-overrides + :active-modes   args/resolve-args → :args
+;;   args               :cell-overrides + :active-modes   rf.story.args/resolve-args → :args
 ;;   transient-controls in-flight :cell-overrides          folds into :args (no 2nd slot)
 ;;   sub-overrides      — (View State group is TARGET)     reg-variant :sub-overrides
 ;;   db-seed            — (fidelity rung not wired, blw1q) reg-variant :setup/:db
@@ -161,7 +161,7 @@
 
 (defn- declared-slot
   "Read a declared slot from the resolved SOURCE variant body, or nil.
-  `variant-body` is `(registrar/handler-meta :variant id)` (may be nil
+  `variant-body` is `(rf.story.registrar/handler-meta :variant id)` (may be nil
   for an unregistered source — then every declared slot is nil)."
   [variant-body k]
   (when (map? variant-body) (get variant-body k)))
@@ -284,7 +284,7 @@
     (str "{"
          (->> (sort-by (fn [[k _]] (str k)) m)
               (map (fn [[k v]] (str (pr-str k) " " (pr-str v))))
-              (str/join (pred/indent-after "   :args {")))
+              (str/join (rf.story.predicates/indent-after "   :args {")))
          "}")))
 
 (defn gen-variant-snippet
@@ -318,7 +318,7 @@
                     doc     (conj [:doc (pr-str doc)])
                     extends (conj [:extends (pr-str extends)])
                     true    (conj [:args (pr-args-map (or args {}))]))]
-    (pred/reg-variant-form alias (or variant-id :story.saved/example) body-keys)))
+    (rf.story.predicates/reg-variant-form alias (or variant-id :story.saved/example) body-keys)))
 
 ;; ---------------------------------------------------------------------------
 ;; Default-id derivation + dialog state shape
@@ -338,17 +338,17 @@
 (defn default-variant-id
   "Derive the save-variant default new-variant id from a source variant
   id + a wall-clock millis stamp. Pure data → keyword | nil. Delegates
-  to `review-dialog/default-variant-id-with-prefix`; nil for non-
+  to `rf.story.review-dialog/default-variant-id-with-prefix`; nil for non-
   qualified-keyword sources."
   [source-variant-id now-ms]
-  (review-dialog/default-variant-id-with-prefix
+  (rf.story.review-dialog/default-variant-id-with-prefix
     source-variant-id now-ms default-id-prefix))
 
 (def initial-dialog-state
-  "Alias for `review-dialog/initial-state` — kept for call-site
+  "Alias for `rf.story.review-dialog/initial-state` — kept for call-site
   ergonomics so the dialog ratom seeding form reads as
   `save-variant/initial-dialog-state`."
-  review-dialog/initial-state)
+  rf.story.review-dialog/initial-state)
 
 (defn open
   "Open the save-variant dialog against `source-variant-id` with the
@@ -368,7 +368,7 @@
   ([state source-variant-id args-snapshot now-ms violations]
    (open state source-variant-id args-snapshot now-ms violations nil))
   ([_state source-variant-id args-snapshot now-ms violations slices]
-   (let [base (review-dialog/open review-dialog/initial-state
+   (let [base (rf.story.review-dialog/open rf.story.review-dialog/initial-state
                                   source-variant-id
                                   {:args       args-snapshot
                                    :violations (vec violations)
@@ -383,13 +383,13 @@
 (defn close
   "Close the dialog — returns the idle state."
   [_state]
-  review-dialog/initial-state)
+  rf.story.review-dialog/initial-state)
 
 (defn set-draft-id
   "Replace the draft id in the dialog state. `id` may be a keyword or a
   raw string the user is typing."
   [state id]
-  (review-dialog/set-draft-id state id))
+  (rf.story.review-dialog/set-draft-id state id))
 
 ;; ---------------------------------------------------------------------------
 ;; Impure: capture + open
@@ -417,7 +417,7 @@
   "Register the UI-layer dialog-open callback. The callback is invoked
   as `(callback source-variant-id args-snapshot now-ms violations slices)`
   where `violations` is the vector returned by
-  `schema-validation/args-violations` against the live component schema
+  `rf.story.ui.schema-validation/args-violations` against the live component schema
   (may be empty/nil) and `slices` is the eight-slice capture report
   from `capture-slices` (carries the per-slice
   honesty-floor warnings the dialog renders). Idempotent — calling again
@@ -453,8 +453,8 @@
   call without a focused variant."
   ([] (save-current-as-variant! nil))
   ([{:keys [variant-id now-ms]}]
-   (when config/enabled?
-     (let [shell      (state/get-state)
+   (when rf.story.config/enabled?
+     (let [shell      (rf.story.ui.state/get-state)
            target     (or variant-id (focused-variant-id shell))
            now-ms     (or now-ms #?(:clj  (System/currentTimeMillis)
                                     :cljs (.now js/Date)))]
@@ -471,8 +471,8 @@
                ;; (per Spec 010 §Recommended soft-pass).
                violations #?(:cljs (snapshot-violations
                                      snapshot
-                                     (schema-validation/resolve-component-schema target)
-                                     (schema-validation/validator-fns))
+                                     (rf.story.ui.schema-validation/resolve-component-schema target)
+                                     (rf.story.ui.schema-validation/validator-fns))
                              :clj  [])
                ;; The eight-slice capture report. The honesty
                ;; floor: every slice without a live projection is captured-
@@ -482,7 +482,7 @@
                ;; :setup / :viewport slots surface as captured-as-declared.
                slices     (capture-slices
                             snapshot
-                            (registrar/handler-meta :variant target)
+                            (rf.story.registrar/handler-meta :variant target)
                             shell)
                record     {:source-id  target
                            :args       snapshot
@@ -525,10 +525,10 @@
 
 (defn install-canonical-event-handlers!
   "Register the canonical `:rf.story/save-current-as-variant` event
-  handler. Idempotent. Production builds (with `config/enabled?` false)
+  handler. Idempotent. Production builds (with `rf.story.config/enabled?` false)
   skip the registration."
   []
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (rf/reg-event
       id-save-current-as-variant
       (fn [_cofx [_ opts]]

--- a/tools/story/src/re_frame/story/sub_overrides.cljc
+++ b/tools/story/src/re_frame/story/sub_overrides.cljc
@@ -46,7 +46,7 @@
   Provider + the `:subs/resolve-sub-override` hook publication below)
   reads the plan's `[:world :render :sub-overrides]` map; production
   bundles elide the whole runtime, and the core consult is gated on
-  `interop/debug-enabled?`, so nothing surfaces an override in
+  `rf.interop/debug-enabled?`, so nothing surfaces an override in
   production.
 
   ## Live subscribe seam
@@ -76,7 +76,7 @@
        `*overrides*` dynamic var is retained ONLY as a JVM / pure-test
        convenience (the resolver tests bind it directly).
     2. The consult is SUBSTITUTIVE but dev-only + honesty-bounded. It
-       sits inside `subscribe`'s `interop/debug-enabled?` gate (DCEs
+       sits inside `subscribe`'s `rf.interop/debug-enabled?` gate (DCEs
        under `:advanced` + `goog.DEBUG=false`), and the override feeds
        ONLY the constant reaction the view derefs — never app-db, never
        `compute-sub`. So `:rf.assert/sub-equals` (which evaluates a sub
@@ -85,9 +85,9 @@
   Core schema-validates a hit against the subscription's declared
   `:schema`, matching Spec 010 §`:sub-return`."
   (:refer-clojure :exclude [resolve read])
-  #?(:cljs (:require [re-frame.adapter.sub-override-context :as ovr-ctx]
-                     [re-frame.interop :as interop]
-                     [re-frame.late-bind :as late-bind])))
+  #?(:cljs (:require [re-frame.adapter.sub-override-context :as rf.adapter.sub-override-context]
+                     [re-frame.interop :as rf.interop]
+                     [re-frame.late-bind :as rf.late-bind])))
 
 ;; ============================================================================
 ;; Render-path override binding
@@ -203,7 +203,7 @@
 ;; below reads the closest enclosing Provider's override map and is
 ;; published to core via the `:subs/resolve-sub-override` late-bind hook.
 ;; `re-frame.subs/subscribe` consults the hook ONLY inside its
-;; `interop/debug-enabled?` gate, so the whole seam DCEs in production and
+;; `rf.interop/debug-enabled?` gate, so the whole seam DCEs in production and
 ;; core never `:require`s this tools ns (bundle-isolation holds).
 
 #?(:cljs
@@ -218,7 +218,7 @@
      'override pins nil' from 'no override' without importing this ns's
      `miss` sentinel; core stays tools-free."
      [query-v]
-     (let [overrides (ovr-ctx/current-overrides)
+     (let [overrides (rf.adapter.sub-override-context/current-overrides)
            v         (resolve overrides query-v)]
        (when-not (miss? v)
          [v]))))
@@ -239,22 +239,22 @@
      real subscription).
 
      Dev/tool builds only: under `goog.DEBUG=false` (e.g. the `:advanced`
-     static-export release) `ovr-ctx/override-context` is nil — the whole
+     static-export release) `rf.adapter.sub-override-context/override-context` is nil — the whole
      sub-override seam is compiled out, including the `subscribe` consult
      — so this fn returns `child` unchanged instead of mounting a
      Provider on a nil context. The gate is not this namespace's
      invention: `re-frame.adapter.sub-override-context` initialises the
      context var to nil in production WITHOUT calling
      `React.createContext`, so every mount site owes the same
-     `interop/debug-enabled?` test to avoid mounting a Provider on
+     `rf.interop/debug-enabled?` test to avoid mounting a Provider on
      nothing."
      [overrides child]
-     (if interop/debug-enabled?
-       [:r> (.-Provider ovr-ctx/override-context) #js {:value overrides} child]
+     (if rf.interop/debug-enabled?
+       [:r> (.-Provider rf.adapter.sub-override-context/override-context) #js {:value overrides} child]
        child)))
 
 ;; Publish the hook at ns-load time (CLJS only). Core consults it lazily
-;; via `late-bind/get-fn` inside the dev gate; an unpublished hook (JVM,
+;; via `rf.late-bind/get-fn` inside the dev gate; an unpublished hook (JVM,
 ;; or a build that never loads Story) simply makes the consult a no-op.
 #?(:cljs
-   (late-bind/set-fn! :subs/resolve-sub-override resolve-sub-override-hit))
+   (rf.late-bind/set-fn! :subs/resolve-sub-override resolve-sub-override-hit))

--- a/tools/story/src/re_frame/story/tags.cljc
+++ b/tools/story/src/re_frame/story/tags.cljc
@@ -31,7 +31,7 @@
   map), so this ns stays a require-leaf — it never `:require`s the registrar,
   and any Story ns can consume it without a cycle. Live callers pass the
   registrar side-table; pure tests pass an explicit map."
-  (:require [re-frame.story.predicates :as pred]))
+  (:require [re-frame.story.predicates :as rf.story.predicates]))
 
 ;; ---- `:!x` removal markers -----------------------------------------------
 
@@ -112,7 +112,7 @@
   (let [chain (extends-chain-tags variant-id variant)]
     (if (seq chain)
       chain
-      (set (:tags ((as-fn story) (pred/parent-story-id variant-id)))))))
+      (set (:tags ((as-fn story) (rf.story.predicates/parent-story-id variant-id)))))))
 
 (defn effective-tags
   "The EFFECTIVE tag set for `variant-id` — inheritance (extends union /

--- a/tools/story/src/re_frame/story/test_support.cljc
+++ b/tools/story/src/re_frame/story/test_support.cljc
@@ -20,7 +20,7 @@
 
   The helper composes the framework's
   `re-frame.test-support/make-reset-runtime-fixture`, which resets the
-  runtime via registrar **snapshot/restore** (NOT `registrar/clear-all!`).
+  runtime via registrar **snapshot/restore** (NOT `rf.story.registrar/clear-all!`).
   Snapshot/restore preserves the framework- and example-app
   registrations that landed at namespace-load — including the
   `:rf/machine` subscription the lifecycle machine depends on — so the
@@ -85,13 +85,13 @@
       (deftest counter-at-five
         (let [result (story/run-variant :story.counter/at-five)]
           (is (= :ready (:lifecycle result)))))"
-  (:require [re-frame.test-support :as fw-test-support]
-            [re-frame.frame :as frame]
-            [re-frame.story.canonical :as canonical]
-            [re-frame.story.config :as config]
-            [re-frame.story.play :as play]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.story.play.runner-events :as runner-events]))
+  (:require [re-frame.test-support :as rf.test-support]
+            [re-frame.frame :as rf.frame]
+            [re-frame.story.canonical :as rf.story.canonical]
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.play :as rf.story.play]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]))
 
 (defn- as-thunks
   "Coerce `:install` (a 0-arity fn, a coll of them, or nil) into a vector
@@ -118,15 +118,15 @@
   ;; the next), reset the canonical-vocab auto-install gate, and clear the
   ;; two per-process play atoms (`pending-exceptions` + `stepper-state`).
   ;; Goes beyond `clear-all!` by also wiping the per-variant
-  ;; play run-state (`runner-events/clear-all-runs!`) — the test-reset path
+  ;; play run-state (`rf.story.play.runner-events/clear-all-runs!`) — the test-reset path
   ;; tears down a frame's full play surface, not just the registry.
-  (registrar/clear-all!)
-  (config/reset-all!)
-  (canonical/reset-installed-flag!)
-  (play/clear-all-play-state!)
-  (runner-events/clear-all-runs!)
-  (canonical/install!)
-  (frame/ensure-default-frame!)
+  (rf.story.registrar/clear-all!)
+  (rf.story.config/reset-all!)
+  (rf.story.canonical/reset-installed-flag!)
+  (rf.story.play/clear-all-play-state!)
+  (rf.story.play.runner-events/clear-all-runs!)
+  (rf.story.canonical/install!)
+  (rf.frame/ensure-default-frame!)
   (doseq [f (as-thunks install)]
     (f))
   nil)
@@ -149,7 +149,7 @@
 
   Returns a fixture fn suitable for `(use-fixtures :each ...)`."
   [{:keys [adapter install] :as _opts}]
-  (let [fw-fixture (fw-test-support/make-reset-runtime-fixture
+  (let [fw-fixture (rf.test-support/make-reset-runtime-fixture
                      {:adapter adapter
                       :init-fn #(story-reset! install)})]
     (fn [test-fn]

--- a/tools/story/src/re_frame/story/theme/depth.cljc
+++ b/tools/story/src/re_frame/story/theme/depth.cljc
@@ -44,7 +44,7 @@
 
   Token data is `.cljc`. The inject helper is CLJS-only."
   {:no-doc true}
-  #?(:cljs (:require [re-frame.story.config :as config])))
+  #?(:cljs (:require [re-frame.story.config :as rf.story.config])))
 
 (def shadows
   "Box-shadow tokens. Four slots:
@@ -109,9 +109,9 @@
 #?(:cljs
    (defn inject-grain-css!
      "Inject the grain-overlay CSS into `js/document.head`. Idempotent.
-     Behind `config/enabled?` — production short-circuits."
+     Behind `rf.story.config/enabled?` — production short-circuits."
      []
-     (when (and config/enabled? (not @grain-injected?))
+     (when (and rf.story.config/enabled? (not @grain-injected?))
        (reset! grain-injected? true)
        (when (and (exists? js/document) (.-head js/document))
          (try

--- a/tools/story/src/re_frame/story/theme/motion.cljc
+++ b/tools/story/src/re_frame/story/theme/motion.cljc
@@ -34,7 +34,7 @@
   choreography map. The inject helper is CLJS-only — it touches
   `js/document.head`."
   {:no-doc true}
-  #?(:cljs (:require [re-frame.story.config :as config])))
+  #?(:cljs (:require [re-frame.story.config :as rf.story.config])))
 
 (def timing
   "Duration tokens (CSS strings). Six slots covering the chrome's
@@ -286,7 +286,7 @@
      Behind `re-frame.story.config/enabled?` — production builds
      short-circuit before touching the DOM."
      []
-     (when (and config/enabled? (not @motion-css-injected?))
+     (when (and rf.story.config/enabled? (not @motion-css-injected?))
        (reset! motion-css-injected? true)
        (when (and (exists? js/document) (.-head js/document))
          (try

--- a/tools/story/src/re_frame/story/theme/status.cljc
+++ b/tools/story/src/re_frame/story/theme/status.cljc
@@ -84,7 +84,7 @@
   Pure data → data; JVM-portable so the test corpus can assert the
   vocabulary without a render pass."
   {:no-doc true}
-  (:require [re-frame.story.theme.colors :as colors]))
+  (:require [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 (def order
   "Canonical priority order, most-attention-demanding first. Regions
@@ -109,45 +109,45 @@
                  reads as a hollow double-ring, never a solid edge).
   - `:half`    — 3px SOLID left-accent bar (running — a one-sided
                  in-flight mark, visibly a partial treatment)."
-  {:pending    {:fg (:text-tertiary colors/tokens)
+  {:pending    {:fg (:text-tertiary rf.story.theme.colors/tokens)
                 :bg "transparent"
-                :border (:border-default colors/tokens)
+                :border (:border-default rf.story.theme.colors/tokens)
                 :glyph "◌" :shape :ring :label "Pending" :emphasis :low}
-   :running    {:fg (:warning colors/tokens)
-                :bg (:warning-bg colors/tokens)
-                :border (:warning colors/tokens)
+   :running    {:fg (:warning rf.story.theme.colors/tokens)
+                :bg (:warning-bg rf.story.theme.colors/tokens)
+                :border (:warning rf.story.theme.colors/tokens)
                 :glyph "◐" :shape :half :label "Running" :emphasis :normal}
-   :pass       {:fg (:success colors/tokens)
-                :bg (:success-bg colors/tokens)
-                :border (:success colors/tokens)
+   :pass       {:fg (:success rf.story.theme.colors/tokens)
+                :bg (:success-bg rf.story.theme.colors/tokens)
+                :border (:success rf.story.theme.colors/tokens)
                 :glyph "✓" :shape :solid :label "Pass" :emphasis :low}
-   :fail       {:fg (:danger colors/tokens)
-                :bg (:danger-bg colors/tokens)
-                :border (:danger colors/tokens)
+   :fail       {:fg (:danger rf.story.theme.colors/tokens)
+                :bg (:danger-bg rf.story.theme.colors/tokens)
+                :border (:danger rf.story.theme.colors/tokens)
                 :glyph "✗" :shape :solid :label "Fail" :emphasis :high}
    ;; error is DISTINCT from fail — same danger hue but an OUTLINE so it
    ;; never reads as a plain failed expectation (spec/018 §12.6).
-   :error      {:fg (:danger colors/tokens)
-                :bg (:danger-bg colors/tokens)
-                :border (:danger colors/tokens)
+   :error      {:fg (:danger rf.story.theme.colors/tokens)
+                :bg (:danger-bg rf.story.theme.colors/tokens)
+                :border (:danger rf.story.theme.colors/tokens)
                 :glyph "!" :shape :outline :label "Error" :emphasis :high}
    ;; cannot-run is a NEUTRAL warning, not a failure — warning hue on a
    ;; neutral ground + outline so it reads 'could not observe', not 'bad'.
-   :cannot-run {:fg (:warning colors/tokens)
-                :bg (:bg-3 colors/tokens)
-                :border (:warning colors/tokens)
+   :cannot-run {:fg (:warning rf.story.theme.colors/tokens)
+                :bg (:bg-3 rf.story.theme.colors/tokens)
+                :border (:warning rf.story.theme.colors/tokens)
                 :glyph "⊘" :shape :outline :label "Can't run" :emphasis :normal}
-   :blocked    {:fg (:mono-1 colors/tokens)
-                :bg (:mono-3 colors/tokens)
-                :border (:mono-2 colors/tokens)
+   :blocked    {:fg (:mono-1 rf.story.theme.colors/tokens)
+                :bg (:mono-3 rf.story.theme.colors/tokens)
+                :border (:mono-2 rf.story.theme.colors/tokens)
                 :glyph "▣" :shape :solid :label "Blocked" :emphasis :normal}
-   :dirty      {:fg (:accent-amber colors/tokens)
-                :bg (:accent-amber-soft colors/tokens)
-                :border (:accent-amber-deep colors/tokens)
+   :dirty      {:fg (:accent-amber rf.story.theme.colors/tokens)
+                :bg (:accent-amber-soft rf.story.theme.colors/tokens)
+                :border (:accent-amber-deep rf.story.theme.colors/tokens)
                 :glyph "●" :shape :solid :label "Dirty" :emphasis :normal}
-   :redacted   {:fg (:text-tertiary colors/tokens)
-                :bg (:bg-3 colors/tokens)
-                :border (:border-strong colors/tokens)
+   :redacted   {:fg (:text-tertiary rf.story.theme.colors/tokens)
+                :bg (:bg-3 rf.story.theme.colors/tokens)
+                :border (:border-strong rf.story.theme.colors/tokens)
                 :glyph "▢" :shape :dashed :label "Redacted" :emphasis :low}})
 
 (def ^:private fallback

--- a/tools/story/src/re_frame/story/theme/typography.cljc
+++ b/tools/story/src/re_frame/story/theme/typography.cljc
@@ -66,7 +66,7 @@
     time shell can self-host webfonts without forcing a build-time
     asset pipeline."
   {:no-doc true}
-  #?(:cljs (:require [re-frame.story.config :as config])))
+  #?(:cljs (:require [re-frame.story.config :as rf.story.config])))
 
 (def sans-stack
   "IBM Plex Sans stack — the chrome / labels / prose font. Distinctive
@@ -215,7 +215,7 @@
      Behind `re-frame.story.config/enabled?` — production builds
      short-circuit before touching the DOM."
      []
-     (when (and config/enabled? (not @font-faces-injected?))
+     (when (and rf.story.config/enabled? (not @font-faces-injected?))
        (reset! font-faces-injected? true)
        (when (and (exists? js/document) (.-head js/document))
          (try

--- a/tools/story/src/re_frame/story/ui/a11y.cljs
+++ b/tools/story/src/re_frame/story/ui/a11y.cljs
@@ -46,13 +46,13 @@
   (:require [clojure.string :as string]
             [reagent.core :as r]
             [re-frame.core :as rf]
-            [re-frame.trace :as trace]
-            [re-frame.story.config :as config]
-            [re-frame.story.play.browser :as browser]
-            [re-frame.story.registrar :as story-registrar]
-            [re-frame.story.ui.state :as state]
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+            [re-frame.trace :as rf.trace]
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.play.browser :as rf.story.play.browser]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---- state ---------------------------------------------------------------
 
@@ -123,7 +123,7 @@
 ;; The panel stores the raw axe-core JS violation objects (it reads them via
 ;; `^js` interop in `violation-row`); the `.cljc` executor consumes CLJS data
 ;; (`select-keys` / `:nodes` / `:target` keyword access — see
-;; `browser/axe-finding`). So the reader NORMALISES each violation to CLJS
+;; `rf.story.play.browser/axe-finding`). So the reader NORMALISES each violation to CLJS
 ;; data at this boundary via `js->clj :keywordize-keys`, recovering the
 ;; `:nodes` → `:target` selector(s) the source-link projection needs.
 (defn- ->clj-violations
@@ -135,7 +135,7 @@
     (js->clj vs :keywordize-keys true)))
 
 (defonce ^:private _a11y-reader-registered
-  (do (browser/register-a11y-reader!
+  (do (rf.story.play.browser/register-a11y-reader!
         (fn [frame-id] (->clj-violations (get @violations-by-frame frame-id))))
       true))
 
@@ -163,7 +163,7 @@
 ;; over a map the frame was dissoc'd from RESURRECTS the entry — a
 ;; phantom slot reading `:done`, alongside a resurrected
 ;; `violations-by-frame` entry that the below-the-UI executor seam
-;; (`browser/register-a11y-reader!`) then serves to `:rf.assert/a11y`.
+;; (`rf.story.play.browser/register-a11y-reader!`) then serves to `:rf.assert/a11y`.
 ;; A scan of a frame that is gone reporting a clean verdict; a fabricated
 ;; green, not a hang.
 ;;
@@ -374,7 +374,7 @@
   The trace event piggybacks on the existing warning op-type per
   spec/009 §Trace bus."
   [frame-id ^js violation]
-  (trace/emit!
+  (rf.trace/emit!
     :warning
     :rf.story.a11y/violation
     {:frame  frame-id
@@ -540,37 +540,37 @@
 
 (def styles
   {:wrap        {:padding "8px"
-                 :background (:bg-2 colors/tokens)
+                 :background (:bg-2 rf.story.theme.colors/tokens)
                  :border-top "1px solid #444"
-                 :color (:text-primary colors/tokens)
+                 :color (:text-primary rf.story.theme.colors/tokens)
                  :font-family mono-stack
-                 :font-size (:caption typography/type-scale)}
+                 :font-size (:caption rf.story.theme.typography/type-scale)}
    :header      {:display "flex"
                  :justify-content "space-between"
                  :align-items "center"
                  :margin-bottom "8px"}
    :section-h   {:font-weight "bold"
-                 :color (:text-secondary colors/tokens)
+                 :color (:text-secondary rf.story.theme.colors/tokens)
                  :text-transform "uppercase"
-                 :font-size (:micro typography/type-scale)
+                 :font-size (:micro rf.story.theme.typography/type-scale)
                  :letter-spacing "0.5px"}
    :run-button  {:padding "4px 10px"
-                 :background (:accent-amber colors/tokens)
+                 :background (:accent-amber rf.story.theme.colors/tokens)
                  :color "white"
                  :border "none"
                  :border-radius "3px"
                  :cursor "pointer"
-                 :font-size (:micro typography/type-scale)}
+                 :font-size (:micro rf.story.theme.typography/type-scale)}
    :run-busy    {:background "#666"
                  :cursor "wait"}
-   :status      {:color (:text-secondary colors/tokens) :font-size (:micro typography/type-scale) :margin-top "4px"}
-   :empty       {:color (:text-tertiary colors/tokens) :font-style "italic" :padding "4px 0"}
+   :status      {:color (:text-secondary rf.story.theme.colors/tokens) :font-size (:micro rf.story.theme.typography/type-scale) :margin-top "4px"}
+   :empty       {:color (:text-tertiary rf.story.theme.colors/tokens) :font-style "italic" :padding "4px 0"}
    :violation   {:padding "6px 8px"
                  :margin "4px 0"
                  :border-left "3px solid"
-                 :background (:danger-bg colors/tokens)}
+                 :background (:danger-bg rf.story.theme.colors/tokens)}
    :impact-critical {:border-left-color "#ff4040"
-                     :color (:danger colors/tokens)}
+                     :color (:danger rf.story.theme.colors/tokens)}
    :impact-serious  {:border-left-color "#ff8000"
                      :color "#fed"}
    :impact-moderate {:border-left-color "#f1c40f"
@@ -578,8 +578,8 @@
    :impact-minor    {:border-left-color "#888"
                      :color "#ccc"}
    :v-help      {:font-weight "bold" :margin-bottom "2px"}
-   :v-desc      {:color "#aaa" :font-size (:micro typography/type-scale)}
-   :v-target    {:color (:info colors/tokens) :font-size (:micro typography/type-scale)
+   :v-desc      {:color "#aaa" :font-size (:micro rf.story.theme.typography/type-scale)}
+   :v-target    {:color (:info rf.story.theme.colors/tokens) :font-size (:micro rf.story.theme.typography/type-scale)
                  :font-family mono-stack
                  :margin-top "2px"}
    :overlay-css {:position "absolute"
@@ -604,7 +604,7 @@
 
 (defn ensure-stylesheet!
   []
-  (when (and config/enabled?
+  (when (and rf.story.config/enabled?
              (not @stylesheet-injected?)
              (some? js/document))
     (let [style (.createElement js/document "style")]
@@ -643,7 +643,7 @@
      [:div {:style (:v-desc styles)} (.-description v)]
      (when first-target
        [:div {:style (:v-target styles)} (str "→ " first-target)])
-     [:div {:style {:color (:text-tertiary colors/tokens) :font-size (:micro typography/type-scale)}}
+     [:div {:style {:color (:text-tertiary rf.story.theme.colors/tokens) :font-size (:micro rf.story.theme.typography/type-scale)}}
       (str ":" (.-id v) " · " (or impact "moderate"))]]))
 
 (defn- consent-prompt
@@ -656,27 +656,27 @@
   [:div {:style {:padding "8px 0"
                  :border-top "1px dashed #555"
                  :margin-top "4px"
-                 :color (:text-primary colors/tokens)}}
+                 :color (:text-primary rf.story.theme.colors/tokens)}}
    [:div {:style {:font-weight "bold"
-                  :color (:danger colors/tokens)
+                  :color (:danger rf.story.theme.colors/tokens)
                   :margin-bottom "6px"}}
     "axe-core not loaded"]
-   [:div {:style {:font-size (:micro typography/type-scale)
+   [:div {:style {:font-size (:micro rf.story.theme.typography/type-scale)
                   :line-height "1.4"
-                  :color (:text-secondary colors/tokens)
+                  :color (:text-secondary rf.story.theme.colors/tokens)
                   :margin-bottom "6px"}}
     "Running an a11y scan loads "
-    [:code {:style {:color (:info colors/tokens)}} "axe-core@4.10.0"]
+    [:code {:style {:color (:info rf.story.theme.colors/tokens)}} "axe-core@4.10.0"]
     " from a public CDN ("
-    [:code {:style {:color (:info colors/tokens)}} "cdn.jsdelivr.net"]
+    [:code {:style {:color (:info rf.story.theme.colors/tokens)}} "cdn.jsdelivr.net"]
     "). The remote JS gets full DOM access to this Story page; the SRI "
     "hash pinned in the loader detects tampering, but the dependency "
     "itself is a trust call. No variant state leaves the browser."]
-   [:div {:style {:font-size (:micro typography/type-scale)
-                  :color (:text-secondary colors/tokens)
+   [:div {:style {:font-size (:micro rf.story.theme.typography/type-scale)
+                  :color (:text-secondary rf.story.theme.colors/tokens)
                   :margin-bottom "8px"}}
     "Approve once per browser; the opt-in is remembered in "
-    [:code {:style {:color (:info colors/tokens)}} "localStorage"] "."]
+    [:code {:style {:color (:info rf.story.theme.colors/tokens)}} "localStorage"] "."]
    [:button {:style    (:run-button styles)
              :on-click (fn [_]
                          (set-cdn-opt-in! true)
@@ -752,7 +752,7 @@
   `:panel-visibility` map. By default the a11y slot is off (don't
   bloat the right pane until the user explicitly opens it)."
   []
-  (when config/enabled?
+  (when rf.story.config/enabled?
     ;; Register the panel-view as a re-frame view so the panel system
     ;; can resolve it via the standard late-bind path.
     ;;
@@ -769,7 +769,7 @@
     ;; changed to permit bare-component roots.
     (rf/reg-view* panel-render-id (fn [variant-id] [:div [panel variant-id]]))
     ;; Register the story-panel itself.
-    (story-registrar/reg-story-panel*
+    (rf.story.registrar/reg-story-panel*
       panel-id
       {:doc       "axe-core accessibility scanner — inline panel."
        :title     "a11y"

--- a/tools/story/src/re_frame/story/ui/assertion_strip.cljs
+++ b/tools/story/src/re_frame/story/ui/assertion_strip.cljs
@@ -52,12 +52,12 @@
   CLJS-only for the same reason."
   (:require [clojure.string :as str]
             [reagent.core :as r]
-            [re-frame.story.assertions :as assertions]
-            [re-frame.story.author-expectations :as author]
-            [re-frame.story.predicates :as pred]
-            [re-frame.story.ui.test-mode.pure :as tm-pure]
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+            [re-frame.story.assertions :as rf.story.assertions]
+            [re-frame.story.author-expectations :as rf.story.author-expectations]
+            [re-frame.story.predicates :as rf.story.predicates]
+            [re-frame.story.ui.test-mode.pure :as rf.story.ui.test-mode.pure]
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---- pure helpers --------------------------------------------------------
 
@@ -187,8 +187,8 @@
                  :flex-direction "column"
                  :gap           "2px"}
    :group-head  {:font-family   mono-stack
-                 :font-size     (:micro typography/type-scale)
-                 :color         (:text-tertiary colors/tokens)
+                 :font-size     (:micro rf.story.theme.typography/type-scale)
+                 :color         (:text-tertiary rf.story.theme.colors/tokens)
                  :text-transform "uppercase"
                  :letter-spacing "0.04em"
                  :padding       "2px 4px"
@@ -198,61 +198,61 @@
                  :gap           "8px"
                  :padding       "4px 8px"
                  :border-left   "3px solid transparent"
-                 :background    (:bg-2 colors/tokens)
+                 :background    (:bg-2 rf.story.theme.colors/tokens)
                  :border-radius "0 3px 3px 0"
                  :font-family   mono-stack
-                 :font-size     (:caption typography/type-scale)
+                 :font-size     (:caption rf.story.theme.typography/type-scale)
                  :cursor        "pointer"
                  :user-select   "none"}
-   :row-pass    {:border-left-color (:success colors/tokens)}
-   :row-fail    {:border-left-color (:danger colors/tokens)
-                 :background        (:danger-bg colors/tokens)}
-   :row-skip    {:border-left-color (:text-tertiary colors/tokens)}
+   :row-pass    {:border-left-color (:success rf.story.theme.colors/tokens)}
+   :row-fail    {:border-left-color (:danger rf.story.theme.colors/tokens)
+                 :background        (:danger-bg rf.story.theme.colors/tokens)}
+   :row-skip    {:border-left-color (:text-tertiary rf.story.theme.colors/tokens)}
    :glyph       {:flex          "0 0 auto"
                  :width         "1em"
                  :text-align    "center"
                  :font-weight   "bold"}
-   :glyph-pass  {:color         (:success colors/tokens)}
-   :glyph-fail  {:color         (:danger colors/tokens)}
-   :glyph-skip  {:color         (:text-tertiary colors/tokens)}
+   :glyph-pass  {:color         (:success rf.story.theme.colors/tokens)}
+   :glyph-fail  {:color         (:danger rf.story.theme.colors/tokens)}
+   :glyph-skip  {:color         (:text-tertiary rf.story.theme.colors/tokens)}
    :label       {:flex          "0 0 auto"
-                 :color         (:text-primary colors/tokens)
+                 :color         (:text-primary rf.story.theme.colors/tokens)
                  :white-space   "nowrap"
                  :overflow      "hidden"
                  :text-overflow "ellipsis"
                  :max-width     "50%"}
    :summary     {:flex          "1 1 auto"
-                 :color         (:text-secondary colors/tokens)
+                 :color         (:text-secondary rf.story.theme.colors/tokens)
                  :white-space   "nowrap"
                  :overflow      "hidden"
                  :text-overflow "ellipsis"
                  :min-width     "0"}
-   :summary-fail {:color        (:danger colors/tokens)}
+   :summary-fail {:color        (:danger rf.story.theme.colors/tokens)}
    :tog         {:flex          "0 0 auto"
-                 :color         (:text-tertiary colors/tokens)
-                 :font-size     (:micro typography/type-scale)
+                 :color         (:text-tertiary rf.story.theme.colors/tokens)
+                 :font-size     (:micro rf.story.theme.typography/type-scale)
                  :background    "transparent"
                  :border        "none"
                  :padding       "0"
                  :cursor        "pointer"}
-   :detail      {:background    (:bg-2 colors/tokens)
-                 :border-left   (str "3px solid " (:danger colors/tokens))
+   :detail      {:background    (:bg-2 rf.story.theme.colors/tokens)
+                 :border-left   (str "3px solid " (:danger rf.story.theme.colors/tokens))
                  :padding       "6px 12px"
                  :margin        "0 0 0 0"
                  :font-family   mono-stack
-                 :font-size     (:caption typography/type-scale)
-                 :color         (:text-primary colors/tokens)
+                 :font-size     (:caption rf.story.theme.typography/type-scale)
+                 :color         (:text-primary rf.story.theme.colors/tokens)
                  :white-space   "pre-wrap"
                  :border-radius "0 3px 3px 0"}
-   :detail-key  {:color         (:info colors/tokens)
+   :detail-key  {:color         (:info rf.story.theme.colors/tokens)
                  :margin-right  "4px"}
    :detail-line {:margin        "2px 0"}
    ;; click-to-reveal chord on a long :expected / :actual value inside
    ;; the expanded panel. The clamped value renders inline; the chord
    ;; swaps in the full pr-str — no modal, same row.
-   :value-reveal {:color        (:info colors/tokens)
+   :value-reveal {:color        (:info rf.story.theme.colors/tokens)
                   :margin-left  "6px"
-                  :font-size    (:micro typography/type-scale)
+                  :font-size    (:micro rf.story.theme.typography/type-scale)
                   :background   "transparent"
                   :border       "none"
                   :padding      "0"
@@ -272,7 +272,7 @@
 (def status-glyph
   "Status-glyph map — the shared assertion-outcome vocabulary
   (`predicates/assertion-glyph`). Public so tests can pin the shape."
-  pred/assertion-glyph)
+  rf.story.predicates/assertion-glyph)
 
 ;; ---- rendering ------------------------------------------------------------
 
@@ -421,7 +421,7 @@
   `assertions` is the variant frame's accumulated `:rf.story/assertions`
   vector (the runtime's record shape — `{:assertion :passed?
   :payload :expected :actual :reason :event :phase :source ...}`).
-  Each record is projected through `tm-pure/assertion-row` to derive
+  Each record is projected through `rf.story.ui.test-mode.pure/assertion-row` to derive
   status / label / row-key / detail.
 
   Renders nothing when `assertions` is empty. Otherwise renders one
@@ -436,7 +436,7 @@
   (let [expanded (r/atom nil)]            ;; nil until first render seeds
     (fn [assertions]
       (when (seq assertions)
-        (let [rows    (mapv tm-pure/assertion-row assertions)
+        (let [rows    (mapv rf.story.ui.test-mode.pure/assertion-row assertions)
               ;; Seed the expanded set on first render: every failed
               ;; row's :row-key lands open so the user doesn't have to
               ;; click to disclose. After first render the atom is the
@@ -453,7 +453,7 @@
               ;; twice while keeping group-by data-shape pure.
               groups  (group-by-event assertions)
               row-for (fn [rec]
-                        (tm-pure/assertion-row rec))
+                        (rf.story.ui.test-mode.pure/assertion-row rec))
               toggle  (fn [row-key]
                         (swap! expanded
                                (fn [s]
@@ -503,7 +503,7 @@
 ;; variant DATA the authoring flow emits). It is the read-only display of a
 ;; variant's declared expectations: the atom + its runner cost / `:cannot-run`
 ;; honesty flag (read from the EXISTING requirement registry via
-;; `author/expectation-cost`), so a reader sees what a story expects AND what
+;; `rf.story.author-expectations/expectation-cost`), so a reader sees what a story expects AND what
 ;; runner each expectation needs, without having to run it. Distinct from the
 ;; run-result strip — no verdict glyph, a runner-cost stripe instead.
 
@@ -517,34 +517,34 @@
             :gap "8px"
             :padding "4px 8px"
             :border-left "3px solid transparent"
-            :background (:bg-2 colors/tokens)
+            :background (:bg-2 rf.story.theme.colors/tokens)
             :border-radius "0 3px 3px 0"
             :font-family mono-stack
-            :font-size (:caption typography/type-scale)}
-   :row-ok     {:border-left-color (:info colors/tokens)}
-   :row-cannot {:border-left-color (:warning colors/tokens)}
+            :font-size (:caption rf.story.theme.typography/type-scale)}
+   :row-ok     {:border-left-color (:info rf.story.theme.colors/tokens)}
+   :row-cannot {:border-left-color (:warning rf.story.theme.colors/tokens)}
    :id     {:flex "0 0 auto"
-            :color (:text-primary colors/tokens)
+            :color (:text-primary rf.story.theme.colors/tokens)
             :font-weight "bold"}
    :args   {:flex "1 1 auto"
-            :color (:text-secondary colors/tokens)
+            :color (:text-secondary rf.story.theme.colors/tokens)
             :white-space "nowrap" :overflow "hidden" :text-overflow "ellipsis"
             :min-width "0"}
    :cost   {:flex "0 0 auto"
-            :font-size (:micro typography/type-scale)
-            :color (:text-tertiary colors/tokens)}
-   :cost-cannot {:color (:warning colors/tokens)}})
+            :font-size (:micro rf.story.theme.typography/type-scale)
+            :color (:text-tertiary rf.story.theme.colors/tokens)}
+   :cost-cannot {:color (:warning rf.story.theme.colors/tokens)}})
 
 (defn authored-row
   "Render one AUTHORED expectation atom (un-run) with its runner cost. Pure
   shape: takes the canonical `[:rf.assert/* …]` atom, returns hiccup. The
-  cost (`author/expectation-cost`) reads the EXISTING requirement registry —
+  cost (`rf.story.author-expectations/expectation-cost`) reads the EXISTING requirement registry —
   the cheapest runner that proves it + whether it `:cannot-run` headless —
   so the declared expectation reads with its honesty floor attached."
   [atom]
-  (let [id    (assertions/assertion-atom-id atom)
+  (let [id    (rf.story.assertions/assertion-atom-id atom)
         args  (vec (rest atom))
-        {:keys [cheapest-runner cannot-run?]} (author/expectation-cost atom)]
+        {:keys [cheapest-runner cannot-run?]} (rf.story.author-expectations/expectation-cost atom)]
     [:div {:data-test "story-authored-expectation-row"
            :data-id   (str id)
            :data-cannot-run (str (boolean cannot-run?))

--- a/tools/story/src/re_frame/story/ui/author_expectations.cljc
+++ b/tools/story/src/re_frame/story/ui/author_expectations.cljc
@@ -30,8 +30,8 @@
   Mirrors `save_variant.cljs` + `promotion.cljc`: the catalog / atom
   builders / cost projection / snippet live in the pure `.cljc` substrate;
   the dialog ratom, the keystroke transitions, and the Reagent render are
-  `#?(:cljs …)`. Production builds short-circuit on `config/enabled?`."
-  (:require [re-frame.story.author-expectations :as author]
+  `#?(:cljs …)`. Production builds short-circuit on `rf.story.config/enabled?`."
+  (:require [re-frame.story.author-expectations :as rf.story.author-expectations]
             ;; `clojure.string` + `review-dialog` are consumed ONLY by the
             ;; `:cljs` dialog surface below (the pure draft transitions in
             ;; this ns need neither), so they ride the `:cljs` require — a
@@ -40,12 +40,12 @@
             ;; only calls them from `:cljs` code.
             #?@(:cljs [[clojure.string :as str]
                        [reagent.core :as r]
-                       [re-frame.story.config :as config]
-                       [re-frame.story.registrar :as registrar]
-                       [re-frame.story.review-dialog :as review-dialog]
-                       [re-frame.story.ui.state :as state]
-                       [re-frame.story.theme.typography :as typography :refer [mono-stack sans-stack]]
-                       [re-frame.story.theme.colors :as colors]])))
+                       [re-frame.story.config :as rf.story.config]
+                       [re-frame.story.registrar :as rf.story.registrar]
+                       [re-frame.story.review-dialog :as rf.story.review-dialog]
+                       [re-frame.story.ui.state :as rf.story.ui.state]
+                       [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack sans-stack]]
+                       [re-frame.story.theme.colors :as rf.story.theme.colors]])))
 
 ;; ===========================================================================
 ;; PURE: draft shape + transitions
@@ -93,7 +93,7 @@
 (defn set-operand
   "Set `field`'s raw operand string on the row `row-id`. Pure data → data.
   The raw string is stored verbatim (parsing happens at projection time via
-  `author/parse-operands`) so the input value the author sees is never
+  `rf.story.author-expectations/parse-operands`) so the input value the author sees is never
   clobbered mid-keystroke."
   [draft row-id field value]
   (update draft :rows
@@ -120,7 +120,7 @@
   → vector. Re-exposed here so the snippet generator + tests read one
   helper rather than re-walking the rows."
   [draft]
-  (:atoms (author/draft-summary draft)))
+  (:atoms (rf.story.author-expectations/draft-summary draft)))
 
 ;; ===========================================================================
 ;; CLJS-ONLY: dialog ratom + lifecycle
@@ -146,7 +146,7 @@
       additively (the round-trip). Reads the resolved body via the Story
       registrar; nil → empty."
      [source-id]
-     (let [body (registrar/handler-meta :variant source-id)]
+     (let [body (rf.story.registrar/handler-meta :variant source-id)]
        (or (:assertions body)
            (get-in body [:expect :assertions])
            []))))
@@ -158,10 +158,10 @@
       namespace (when the source is a qualified keyword). No-op when Story
       is disabled."
      [source-variant-id]
-     (when config/enabled?
+     (when rf.story.config/enabled?
        (let [now-ms (.now js/Date)
-             def-id (review-dialog/default-variant-id-with-prefix
-                      source-variant-id now-ms author/default-id-prefix)]
+             def-id (rf.story.review-dialog/default-variant-id-with-prefix
+                      source-variant-id now-ms rf.story.author-expectations/default-id-prefix)]
          (reset! dialog-atom
                  {:open?     true
                   :source-id source-variant-id
@@ -190,7 +190,7 @@
       the author sees is not clobbered mid-keystroke."
      [s]
      (update-draft! set-variant-id
-                    (or (review-dialog/parse-variant-id-string s) s))))
+                    (or (rf.story.review-dialog/parse-variant-id-string s) s))))
 
 ;; ===========================================================================
 ;; CLJS-ONLY: styling
@@ -200,16 +200,16 @@
    (def ^:private styles
      {:section    {:margin "8px 0 0 0"}
       :label      {:font-family    mono-stack
-                   :font-size      (:micro typography/type-scale)
-                   :color          (:text-tertiary colors/tokens)
+                   :font-size      (:micro rf.story.theme.typography/type-scale)
+                   :color          (:text-tertiary rf.story.theme.colors/tokens)
                    :margin         "0 0 3px 0"
                    :text-transform "uppercase"
                    :letter-spacing "0.04em"}
       :picker-row {:display "flex" :gap "6px" :flex-wrap "wrap" :margin-bottom "6px"}
       :kind-chip  {:font-family   mono-stack
-                   :font-size     (:micro typography/type-scale)
-                   :background    (:bg-2 colors/tokens)
-                   :color         (:text-secondary colors/tokens)
+                   :font-size     (:micro rf.story.theme.typography/type-scale)
+                   :background    (:bg-2 rf.story.theme.colors/tokens)
+                   :color         (:text-secondary rf.story.theme.colors/tokens)
                    :border        "1px solid #444"
                    :border-radius "10px"
                    :padding       "2px 9px"
@@ -220,29 +220,29 @@
                    :gap           "4px"
                    :padding       "6px 8px"
                    :margin        "4px 0"
-                   :background    (:bg-2 colors/tokens)
+                   :background    (:bg-2 rf.story.theme.colors/tokens)
                    :border        "1px solid #3a3a44"
                    :border-radius "4px"}
       :row-head   {:display "flex" :align-items "baseline" :gap "8px"}
       :row-kind   {:font-family mono-stack
                    :font-weight "bold"
-                   :color       (:info colors/tokens)
-                   :font-size   (:caption typography/type-scale)}
+                   :color       (:info rf.story.theme.colors/tokens)
+                   :font-size   (:caption rf.story.theme.typography/type-scale)}
       :row-doc    {:flex "1 1 auto"
-                   :color (:text-tertiary colors/tokens)
-                   :font-size (:nano typography/type-scale)
+                   :color (:text-tertiary rf.story.theme.colors/tokens)
+                   :font-size (:nano rf.story.theme.typography/type-scale)
                    :font-style "italic"
                    :white-space "nowrap" :overflow "hidden" :text-overflow "ellipsis"}
       :remove-btn {:background "transparent"
                    :border     "none"
-                   :color      (:text-tertiary colors/tokens)
+                   :color      (:text-tertiary rf.story.theme.colors/tokens)
                    :cursor     "pointer"
-                   :font-size  (:caption typography/type-scale)
+                   :font-size  (:caption rf.story.theme.typography/type-scale)
                    :padding    "0 4px"}
       :operand-row {:display "flex" :align-items "baseline" :gap "6px"}
       :operand-lbl {:font-family mono-stack
-                    :font-size (:nano typography/type-scale)
-                    :color (:text-tertiary colors/tokens)
+                    :font-size (:nano rf.story.theme.typography/type-scale)
+                    :color (:text-tertiary rf.story.theme.colors/tokens)
                     :width "84px" :text-align "right" :flex "0 0 auto"}
       :operand-in  {:padding       "3px 6px"
                     :background    "#0e0e10"
@@ -250,26 +250,26 @@
                     :border        "1px solid #444"
                     :border-radius "3px"
                     :font-family   mono-stack
-                    :font-size     (:caption typography/type-scale)
+                    :font-size     (:caption rf.story.theme.typography/type-scale)
                     :flex          "1 1 auto"
                     :box-sizing    "border-box"}
-      :operand-err {:color (:danger colors/tokens)
-                    :font-size (:nano typography/type-scale)
+      :operand-err {:color (:danger rf.story.theme.colors/tokens)
+                    :font-size (:nano rf.story.theme.typography/type-scale)
                     :font-family mono-stack}
       ;; per-row cost stripe — the honesty floor (cost BEFORE save)
       :cost        {:display "flex" :align-items "baseline" :gap "8px"
                     :font-family mono-stack
-                    :font-size (:nano typography/type-scale)
+                    :font-size (:nano rf.story.theme.typography/type-scale)
                     :padding "2px 0 0 0"}
-      :cost-ok     {:color (:success colors/tokens)}
-      :cost-cannot {:color (:warning colors/tokens)}
+      :cost-ok     {:color (:success rf.story.theme.colors/tokens)}
+      :cost-cannot {:color (:warning rf.story.theme.colors/tokens)}
       :doc-input   {:padding       "5px 8px"
-                    :background    (:bg-2 colors/tokens)
+                    :background    (:bg-2 rf.story.theme.colors/tokens)
                     :color         "white"
                     :border        "1px solid #444"
                     :border-radius "3px"
                     :font-family   sans-stack
-                    :font-size     (:body-tight typography/type-scale)
+                    :font-size     (:body-tight rf.story.theme.typography/type-scale)
                     :width         "100%"
                     :box-sizing    "border-box"}
       :banner      {:padding       "8px 10px"
@@ -279,12 +279,12 @@
                     :border        "1px solid #3a3a44"
                     :border-radius "3px"
                     :font-family   mono-stack
-                    :font-size     (:micro typography/type-scale)
+                    :font-size     (:micro rf.story.theme.typography/type-scale)
                     :line-height   "1.5"}
       :banner-warn {:background "#332a2a" :color "#d8b48f" :border "1px solid #704a40"}
-      :empty       {:color (:text-tertiary colors/tokens)
+      :empty       {:color (:text-tertiary rf.story.theme.colors/tokens)
                     :font-style "italic"
-                    :font-size (:micro typography/type-scale)
+                    :font-size (:micro rf.story.theme.typography/type-scale)
                     :padding "6px 0"}}))
 
 ;; ===========================================================================
@@ -294,13 +294,13 @@
 #?(:cljs
    (defn- cost-stripe
      "Render the per-row runner-cost / `:cannot-run` stripe — the honesty
-      floor shown BEFORE save. Reads `author/row-cost` (which reads the
+      floor shown BEFORE save. Reads `rf.story.author-expectations/row-cost` (which reads the
       EXISTING requirement registry); shows the cheapest runner that proves
       the expectation and, when it needs more than the default headless
       runner, an explicit `cannot run headless` flag with the missing
       tokens. Never hides the cost."
      [row]
-     (let [{:keys [required cheapest-runner cannot-run? missing]} (author/row-cost row)]
+     (let [{:keys [required cheapest-runner cannot-run? missing]} (rf.story.author-expectations/row-cost row)]
        [:div {:style       (:cost styles)
               :data-test    "story-author-expectation-cost"
               :data-cannot-run (str (boolean cannot-run?))
@@ -309,7 +309,7 @@
          (if cannot-run? "⚠ " "✓ ")]
         [:span "runner: " (if cheapest-runner (name cheapest-runner) "none")]
         (when (seq required)
-          [:span {:style {:color (:text-tertiary colors/tokens)}}
+          [:span {:style {:color (:text-tertiary rf.story.theme.colors/tokens)}}
            "needs " (pr-str required)])
         (when cannot-run?
           [:span {:style (:cost-cannot styles)
@@ -343,8 +343,8 @@
       its operand inputs (with per-field parse errors), and the per-row cost
       stripe (cost BEFORE save)."
      [row]
-     (let [desc   (author/kind-descriptor (:kind row))
-           parsed (author/parse-operands row)
+     (let [desc   (rf.story.author-expectations/kind-descriptor (:kind row))
+           parsed (rf.story.author-expectations/parse-operands row)
            errors (:errors parsed)]
        [:div {:style     (:row styles)
               :data-test "story-author-expectation-row"
@@ -385,7 +385,7 @@
      [:div {:data-test "story-author-expectation-kind-picker"}
       [:div {:style (:label styles)} "add expectation"]
       [:div {:style (:picker-row styles)}
-       (for [{:keys [kind label surface]} author/expectation-kinds]
+       (for [{:keys [kind label surface]} rf.story.author-expectations/expectation-kinds]
          ^{:key (name kind)}
          [:span {:style       (:kind-chip styles)
                  :data-test   "story-author-expectation-kind-chip"
@@ -393,7 +393,7 @@
                  :data-surface (name surface)
                  :role        "button"
                  :tab-index   "0"
-                 :title       (get author/surface-labels surface)
+                 :title       (get rf.story.author-expectations/surface-labels surface)
                  :on-click    (fn [_] (add-row! kind))}
           (str "+ " label)])]]))
 
@@ -402,10 +402,10 @@
      "The before-save honesty banner: how many expectations are authored vs
       ready, which acceptance surfaces they span, the single cheapest runner
       that would prove the whole draft, and the explicit list of rows that
-      `:cannot-run` headless. Reads the pure `author/draft-summary`."
+      `:cannot-run` headless. Reads the pure `rf.story.author-expectations/draft-summary`."
      [draft]
      (let [{:keys [count ready cheapest-runner cannot-run-rows surfaces]}
-           (author/draft-summary draft)
+           (rf.story.author-expectations/draft-summary draft)
            any-cannot? (seq cannot-run-rows)]
        [:div {:style     (merge (:banner styles) (when any-cannot? (:banner-warn styles)))
               :data-test "story-author-expectation-summary"
@@ -422,7 +422,7 @@
           [:div {:data-test "story-author-expectation-surfaces"}
            "surfaces: "
            (str/join " · "
-                     (keep #(get author/surface-labels %)
+                     (keep #(get rf.story.author-expectations/surface-labels %)
                            (sort surfaces)))])
         (when any-cannot?
           [:div {:data-test "story-author-expectation-cannot-run-summary"
@@ -472,7 +472,7 @@
       `:assertions` variant DATA, merged with the source variant's declared
       assertions (the additive round-trip)."
      [{:keys [source-id draft] :as _dialog}]
-     (author/gen-expectations-snippet
+     (rf.story.author-expectations/gen-expectations-snippet
        {:variant-id (or (:variant-id draft) :story.expectations/example)
         :extends    source-id
         :existing   (existing-assertions source-id)
@@ -496,7 +496,7 @@
          (when (:open? dialog)
            (let [{:keys [source-id draft]} dialog
                  snippet (build-snippet dialog)]
-             (review-dialog/review-dialog
+             (rf.story.review-dialog/review-dialog
                {:open?     true
                 :draft-id  (:variant-id draft)
                 :source-id source-id}
@@ -514,7 +514,7 @@
                 :placeholder-id    :story.expectations/example
                 :placeholder-input ":story.your-story/expects-flow"
                 :on-edit-id        set-variant-id!
-                :on-copy           (fn [] (review-dialog/copy-to-clipboard! snippet))
+                :on-copy           (fn [] (rf.story.review-dialog/copy-to-clipboard! snippet))
                 :on-close          close!
                 :data-test-prefix  "story-author-expectation"})))))))
 
@@ -525,21 +525,21 @@
 #?(:cljs
    (def ^:private button-styles
      {:button          {:padding       "4px 8px"
-                        :background    (:bg-2 colors/tokens)
-                        :color         (:text-primary colors/tokens)
-                        :border        (str "1px solid " (:info colors/tokens))
+                        :background    (:bg-2 rf.story.theme.colors/tokens)
+                        :color         (:text-primary rf.story.theme.colors/tokens)
+                        :border        (str "1px solid " (:info rf.story.theme.colors/tokens))
                         :border-radius "3px"
                         :cursor        "pointer"
-                        :font-size     (:micro typography/type-scale)
+                        :font-size     (:micro rf.story.theme.typography/type-scale)
                         :margin-top    "8px"
                         :font-family   mono-stack}
       :button-disabled {:padding       "4px 8px"
-                        :background    (:bg-2 colors/tokens)
+                        :background    (:bg-2 rf.story.theme.colors/tokens)
                         :color         "#777"
                         :border        "1px solid #444"
                         :border-radius "3px"
                         :cursor        "not-allowed"
-                        :font-size     (:micro typography/type-scale)
+                        :font-size     (:micro rf.story.theme.typography/type-scale)
                         :margin-top    "8px"
                         :font-family   mono-stack}}))
 
@@ -574,6 +574,6 @@
       command-palette action target. No-op (returns nil) when no variant is
       focused, so the palette entry needs no extra guard."
      []
-     (when config/enabled?
-       (when-let [vid (:selected-variant (state/get-state))]
+     (when rf.story.config/enabled?
+       (when-let [vid (:selected-variant (rf.story.ui.state/get-state))]
          (open! vid)))))

--- a/tools/story/src/re_frame/story/ui/backgrounds_switcher.cljs
+++ b/tools/story/src/re_frame/story/ui/backgrounds_switcher.cljs
@@ -20,13 +20,13 @@
   assertion (`[aria-pressed=\"true\"]` count → 0 after reset) is never
   tripped by background state."
   (:require [reagent.core :as r]
-            [re-frame.story.backgrounds      :as backgrounds]
-            [re-frame.story.config           :as config]
-            [re-frame.story.predicates       :as pred]
-            [re-frame.story.registrar        :as registrar]
-            [re-frame.story.ui.state         :as state]
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+            [re-frame.story.backgrounds      :as rf.story.backgrounds]
+            [re-frame.story.config           :as rf.story.config]
+            [re-frame.story.predicates       :as rf.story.predicates]
+            [re-frame.story.registrar        :as rf.story.registrar]
+            [re-frame.story.ui.state         :as rf.story.ui.state]
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---- dropdown state ------------------------------------------------------
 
@@ -47,17 +47,17 @@
   chrome-wide background. nil clears the selection back to the
   default. Writes through to localStorage."
   [sel]
-  (when config/enabled?
-    (let [normalised (backgrounds/coerce sel)]
-      (state/swap-state! assoc :background normalised)
-      (backgrounds/save-to-storage! normalised)
+  (when rf.story.config/enabled?
+    (let [normalised (rf.story.backgrounds/coerce sel)]
+      (rf.story.ui.state/swap-state! assoc :background normalised)
+      (rf.story.backgrounds/save-to-storage! normalised)
       (close!))))
 
 (defn submit-custom!
   "Validate the custom colour-input value + persist if usable."
   []
   (let [cand @custom-input-atom]
-    (when (backgrounds/valid-custom? cand)
+    (when (rf.story.backgrounds/valid-custom? cand)
       (select! cand))))
 
 ;; ---- hydration -----------------------------------------------------------
@@ -65,10 +65,10 @@
 (defn hydrate!
   "Seed `:background` on shell mount from localStorage. Idempotent."
   []
-  (when (and config/enabled?
-             (nil? (:background @state/shell-state-atom)))
-    (when-some [persisted (backgrounds/load-from-storage)]
-      (state/swap-state! assoc :background persisted))))
+  (when (and rf.story.config/enabled?
+             (nil? (:background @rf.story.ui.state/shell-state-atom)))
+    (when-some [persisted (rf.story.backgrounds/load-from-storage)]
+      (rf.story.ui.state/swap-state! assoc :background persisted))))
 
 ;; ---- per-story override lookup -------------------------------------------
 
@@ -76,42 +76,42 @@
   "Resolve the effective background preset for the currently-focused
   variant. Returns the preset map `{:label :color}`."
   []
-  (let [shell      @state/shell-state-atom
+  (let [shell      @rf.story.ui.state/shell-state-atom
         variant-id (:selected-variant shell)
         var-body   (when variant-id
-                     (registrar/handler-meta :variant variant-id))
-        story-id   (some-> variant-id pred/parent-story-id)
+                     (rf.story.registrar/handler-meta :variant variant-id))
+        story-id   (some-> variant-id rf.story.predicates/parent-story-id)
         story-body (when story-id
-                     (registrar/handler-meta :story story-id))
+                     (rf.story.registrar/handler-meta :story story-id))
         override   (or (:background var-body)
                        (:background story-body))]
-    (backgrounds/resolve override (:background shell))))
+    (rf.story.backgrounds/resolve override (:background shell))))
 
 (defn effective-id
   "Resolved id (preset keyword or `:custom`) for the focused variant."
   []
-  (let [shell      @state/shell-state-atom
+  (let [shell      @rf.story.ui.state/shell-state-atom
         variant-id (:selected-variant shell)
         var-body   (when variant-id
-                     (registrar/handler-meta :variant variant-id))
-        story-id   (some-> variant-id pred/parent-story-id)
+                     (rf.story.registrar/handler-meta :variant variant-id))
+        story-id   (some-> variant-id rf.story.predicates/parent-story-id)
         story-body (when story-id
-                     (registrar/handler-meta :story story-id))
+                     (rf.story.registrar/handler-meta :story story-id))
         override   (or (:background var-body)
                        (:background story-body))]
-    (backgrounds/resolve-id override (:background shell))))
+    (rf.story.backgrounds/resolve-id override (:background shell))))
 
 ;; ---- styling -------------------------------------------------------------
 
 (def ^:private styles
   {:chip        {:padding         "3px 10px"
-                 :background      (:bg-3 colors/tokens)
-                 :color           (:text-primary colors/tokens)
+                 :background      (:bg-3 rf.story.theme.colors/tokens)
+                 :color           (:text-primary rf.story.theme.colors/tokens)
                  :border          "none"
                  :border-radius   "10px"
                  :cursor          "pointer"
                  :font-family     mono-stack
-                 :font-size       (:caption typography/type-scale)
+                 :font-size       (:caption rf.story.theme.typography/type-scale)
                  :user-select     "none"
                  :display         "inline-flex"
                  :align-items     "center"
@@ -138,24 +138,24 @@
                  :flex-direction  "column"
                  :gap             "2px"
                  :font-family     mono-stack
-                 :font-size       (:caption typography/type-scale)}
+                 :font-size       (:caption rf.story.theme.typography/type-scale)}
    :item        {:display         "flex"
                  :align-items     "center"
                  :gap             "8px"
                  :padding         "5px 8px"
                  :background      "transparent"
-                 :color           (:text-primary colors/tokens)
+                 :color           (:text-primary rf.story.theme.colors/tokens)
                  :border          "none"
                  :border-radius   "3px"
                  :cursor          "pointer"
                  :font-family     mono-stack
-                 :font-size       (:caption typography/type-scale)
+                 :font-size       (:caption rf.story.theme.typography/type-scale)
                  :text-align      "left"
                  :width           "100%"}
-   :item-active {:background (:accent-amber colors/tokens)
+   :item-active {:background (:accent-amber rf.story.theme.colors/tokens)
                  :color      "white"}
    :divider     {:height          "1px"
-                 :background      (:border-subtle colors/tokens)
+                 :background      (:border-subtle rf.story.theme.colors/tokens)
                  :margin          "4px 0"}
    :custom-row  {:display "flex"
                  :gap "6px"
@@ -166,16 +166,16 @@
                   :padding      "0"
                   :border       "1px solid #444"
                   :border-radius "3px"
-                  :background   (:bg-2 colors/tokens)
+                  :background   (:bg-2 rf.story.theme.colors/tokens)
                   :cursor       "pointer"}
    :custom-go   {:padding         "3px 8px"
-                 :background      (:accent-amber colors/tokens)
+                 :background      (:accent-amber rf.story.theme.colors/tokens)
                  :color           "white"
                  :border          "none"
                  :border-radius   "3px"
                  :cursor          "pointer"
                  :font-family     mono-stack
-                 :font-size       (:micro typography/type-scale)}
+                 :font-size       (:micro rf.story.theme.typography/type-scale)}
    :backdrop    {:position "fixed"
                  :top "0" :left "0" :right "0" :bottom "0"
                  :z-index 1499
@@ -200,13 +200,13 @@
     [:span {:style (merge (:swatch styles) checkerboard-mini)}]
 
     (and (keyword? id-or-color) (= :checkerboard
-                                   (:color (get backgrounds/presets id-or-color))))
+                                   (:color (get rf.story.backgrounds/presets id-or-color))))
     [:span {:style (merge (:swatch styles) checkerboard-mini)}]
 
     (keyword? id-or-color)
     [:span {:style (merge (:swatch styles)
                           {:background-color
-                           (:color (get backgrounds/presets id-or-color)
+                           (:color (get rf.story.backgrounds/presets id-or-color)
                                    "#888888")})}]
 
     (string? id-or-color)
@@ -219,7 +219,7 @@
 
 (defn- preset-row
   [id active-id]
-  (let [{:keys [label]} (get backgrounds/presets id)
+  (let [{:keys [label]} (get rf.story.backgrounds/presets id)
         active? (= id active-id)]
     [:button
      {:style       (merge (:item styles)
@@ -283,7 +283,7 @@
        [:div {:style     (:menu styles)
               :role      "menu"
               :data-test "story-backgrounds-menu"}
-        (for [id backgrounds/preset-order]
+        (for [id rf.story.backgrounds/preset-order]
           ^{:key id} [preset-row id active-id])
         [:div {:style (:divider styles)}]
         (custom-row)])]))
@@ -291,4 +291,4 @@
 (defn chip-when-enabled
   "Render the chip only when Story is enabled."
   []
-  (when config/enabled? [chip]))
+  (when rf.story.config/enabled? [chip]))

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -19,7 +19,7 @@
     `:assertions`).
 
   The canvas reads the registered `:component` keyword and renders it
-  through the SUBSTRATE REGISTRY — `multi-substrate/render-view` looks the
+  through the SUBSTRATE REGISTRY — `rf.story.ui.multi-substrate/render-view` looks the
   variant's declared substrate up in `substrate->render-fn` and calls its
   render fn. Both render branches resolve the renderer that way: the
   side-by-side grid for a variant declaring two or more substrates, and the
@@ -35,44 +35,44 @@
   (:require [clojure.string :as str]
             [reagent.core :as r]
             [re-frame.core :as rf]
-            [re-frame.story.config :as config]
-            [re-frame.story.loaders :as story-loaders]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.story.args :as args]
-            [re-frame.story.decorators :as decorators]
-            [re-frame.story.plan :as plan]
-            [re-frame.story.render :as render]
-            [re-frame.story.runtime :as runtime]
-            [re-frame.story.sub-overrides :as sub-overrides]
-            [re-frame.story.ui.assertion-strip :as assertion-strip]
-            [re-frame.story.ui.multi-substrate :as multi-substrate]
-            [re-frame.story.ui.open-in-editor :as open-in-editor]
-            [re-frame.story.ui.share :as share]
-            [re-frame.story.ui.state :as state]
-            [re-frame.story.theme.typography :as typography :refer [sans-stack mono-stack]]
-            [re-frame.story.theme.colors :as colors]
-            [re-frame.story.theme.depth :as depth]))
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.loaders :as rf.story.loaders]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.args :as rf.story.args]
+            [re-frame.story.decorators :as rf.story.decorators]
+            [re-frame.story.plan :as rf.story.plan]
+            [re-frame.story.render :as rf.story.render]
+            [re-frame.story.runtime :as rf.story.runtime]
+            [re-frame.story.sub-overrides :as rf.story.sub-overrides]
+            [re-frame.story.ui.assertion-strip :as rf.story.ui.assertion-strip]
+            [re-frame.story.ui.multi-substrate :as rf.story.ui.multi-substrate]
+            [re-frame.story.ui.open-in-editor :as rf.story.ui.open-in-editor]
+            [re-frame.story.ui.share :as rf.story.ui.share]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [sans-stack mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]
+            [re-frame.story.theme.depth :as rf.story.theme.depth]))
 
 ;; ---- styling -------------------------------------------------------------
 
 (def ^:private styles
   {:wrap     {:padding "16px"
-              :background (:bg-canvas colors/tokens)
+              :background (:bg-canvas rf.story.theme.colors/tokens)
               :flex "1"
               :min-height "200px"
               :overflow "auto"
-              :color (:text-primary colors/tokens)
+              :color (:text-primary rf.story.theme.colors/tokens)
               :font-family sans-stack}
    :frame    {;; The workshop region. Atmospheric amber-halo
               ;; backdrop + amber inset edge so the variant render lifts
               ;; visibly above the surrounding chrome — the user's eye
               ;; lands here automatically.
-              :background (:canvas-frame depth/backdrops)
+              :background (:canvas-frame rf.story.theme.depth/backdrops)
               :border "1px solid transparent"
               :border-radius "6px"
               :padding "16px"
-              :box-shadow (:canvas-edge depth/shadows)}
-   :empty    {:color (:text-tertiary colors/tokens)
+              :box-shadow (:canvas-edge rf.story.theme.depth/shadows)}
+   :empty    {:color (:text-tertiary rf.story.theme.colors/tokens)
               :font-style "italic"
               :text-align "center"
               :padding "32px"}
@@ -83,9 +83,9 @@
    ;; canvases.
    :title    {:font-weight "bold"
               :margin-bottom "8px"
-              :color (:info colors/tokens)
+              :color (:info rf.story.theme.colors/tokens)
               :font-family mono-stack
-              :font-size (:body-tight typography/type-scale)
+              :font-size (:body-tight rf.story.theme.typography/type-scale)
               :display "flex"
               :align-items "center"
               :flex-wrap "wrap"
@@ -99,13 +99,13 @@
                     :align-items "center"
                     :gap "8px"
                     :flex-shrink "0"}
-   :error    {:background (:danger-bg colors/tokens)
+   :error    {:background (:danger-bg rf.story.theme.colors/tokens)
               :border "1px solid #be4040"
-              :color (:danger colors/tokens)
+              :color (:danger rf.story.theme.colors/tokens)
               :padding "8px"
               :margin-top "8px"
               :font-family mono-stack
-              :font-size (:caption typography/type-scale)
+              :font-size (:caption rf.story.theme.typography/type-scale)
               :border-radius "3px"}
    ;; Identity-bearing loading skeleton during the
    ;; four-phase loader lifecycle. Reads as "workshop loading" — amber-
@@ -117,17 +117,17 @@
               :display "flex"
               :flex-direction "column"
               :gap "12px"
-              :background (:bg-canvas colors/tokens)
+              :background (:bg-canvas rf.story.theme.colors/tokens)
               :border-radius "6px"
               :overflow "hidden"
               :font-family mono-stack
-              :color (:text-tertiary colors/tokens)}
+              :color (:text-tertiary rf.story.theme.colors/tokens)}
    :skeleton-bar {:height "12px"
                   :width "78%"
                   :background (str "linear-gradient(90deg, "
-                                   (:bg-3 colors/tokens) " 0%, "
-                                   (:accent-amber-soft colors/tokens) " 50%, "
-                                   (:bg-3 colors/tokens) " 100%)")
+                                   (:bg-3 rf.story.theme.colors/tokens) " 0%, "
+                                   (:accent-amber-soft rf.story.theme.colors/tokens) " 50%, "
+                                   (:bg-3 rf.story.theme.colors/tokens) " 100%)")
                   :background-size "200% 100%"
                   :border-radius "3px"
                   :animation (str "rf-story-shimmer 1400ms "
@@ -137,13 +137,13 @@
    :skeleton-edge {:position "absolute"
                    :inset "0"
                    :pointer-events "none"
-                   :border (str "1px solid " (:accent-amber-deep colors/tokens))
+                   :border (str "1px solid " (:accent-amber-deep rf.story.theme.colors/tokens))
                    :border-radius "6px"
-                   :box-shadow (str "inset 0 0 0 1px " (:accent-amber-soft colors/tokens))}
-   :skeleton-label {:font-size (:micro typography/type-scale)
+                   :box-shadow (str "inset 0 0 0 1px " (:accent-amber-soft rf.story.theme.colors/tokens))}
+   :skeleton-label {:font-size (:micro rf.story.theme.typography/type-scale)
                     :text-transform "uppercase"
                     :letter-spacing "0.12em"
-                    :color (:accent-amber colors/tokens)
+                    :color (:accent-amber rf.story.theme.colors/tokens)
                     :margin-bottom "4px"}
    ;; Viewport-px indicator chip. Shows e.g. "375 × 667"
    ;; at canvas bottom-right when a viewport mode is active.
@@ -151,12 +151,12 @@
                    :bottom "12px"
                    :right "16px"
                    :padding "3px 8px"
-                   :background (:bg-overlay colors/tokens)
-                   :border (str "1px solid " (:border-subtle colors/tokens))
+                   :background (:bg-overlay rf.story.theme.colors/tokens)
+                   :border (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
                    :border-radius "4px"
-                   :color (:text-secondary colors/tokens)
+                   :color (:text-secondary rf.story.theme.colors/tokens)
                    :font-family mono-stack
-                   :font-size (:micro typography/type-scale)
+                   :font-size (:micro rf.story.theme.typography/type-scale)
                    :letter-spacing "0.04em"
                    :pointer-events "none"
                    :user-select "none"}})
@@ -260,9 +260,9 @@
   parent story usually carries the component and variants vary only by
   args / events)."
   [variant-id]
-  (let [variant-body (registrar/handler-meta :variant variant-id)
-        story-id     (args/parent-story-id variant-id)
-        story-body   (when story-id (registrar/handler-meta :story story-id))]
+  (let [variant-body (rf.story.registrar/handler-meta :variant variant-id)
+        story-id     (rf.story.args/parent-story-id variant-id)
+        story-body   (when story-id (rf.story.registrar/handler-meta :story story-id))]
     (or (:component variant-body)
         (:component story-body))))
 
@@ -274,7 +274,7 @@
 ;; subscription overrides). At render the canvas resolves the variant's
 ;; override map (arg-substituting `[:arg key]` placeholders against the
 ;; effective args, the SAME one-level substitution the plan compiler uses)
-;; and binds it through `sub-overrides/with-overrides*` for the view-
+;; and binds it through `rf.story.sub-overrides/with-overrides*` for the view-
 ;; render extent. The binding never touches app-db or `compute-sub`, so
 ;; it can never satisfy a subscription assertion (`:rf.assert/sub-equals`).
 ;;
@@ -294,8 +294,8 @@
   values, `[:arg key]` placeholders substituted against `eff-args`), or nil
   when the variant authors none.
 
-  Routes through the COMPILED variant-plan (`plan/variant-plan`) and the
-  SHARED `render/resolve-render-sub-overrides` resolver — the SAME source
+  Routes through the COMPILED variant-plan (`rf.story.plan/variant-plan`) and the
+  SHARED `rf.story.render/resolve-render-sub-overrides` resolver — the SAME source
   `render-variant` reads — NOT the bare registrar body (the shared
   resolver invariant). Reading `(:sub-overrides body)` off the
   side-table saw ONLY the variant's OWN slot, dropping overrides contributed
@@ -310,7 +310,7 @@
   control-driven override value reflects the live control, exactly as on the
   render-variant path."
   [variant-id eff-args]
-  (render/resolve-render-sub-overrides (plan/variant-plan variant-id) eff-args))
+  (rf.story.render/resolve-render-sub-overrides (rf.story.plan/variant-plan variant-id) eff-args))
 
 (defn sub-overrides-scope
   "A Reagent component that wraps `child`'s render in the override-context
@@ -330,7 +330,7 @@
   render-transparent (the descendant consult misses and the view reads its
   real subscription)."
   [overrides child]
-  (sub-overrides/override-provider overrides child))
+  (rf.story.sub-overrides/override-provider overrides child))
 
 ;; ---- decorated-view wrapper ---------------------------------------------
 
@@ -346,7 +346,7 @@
   host hook (`re-frame.story.canonical/render-host-scope`), so the live
   canvas and render-variant paint the identical decorated tree. Re-exported
   here so the canvas / workspace call sites keep one import."
-  multi-substrate/safe-decorated-view)
+  rf.story.ui.multi-substrate/safe-decorated-view)
 
 ;; ---- error projection ---------------------------------------------------
 
@@ -366,7 +366,7 @@
   also consumes (single source of truth for the inline strip shape)."
   [assertions]
   (when (seq assertions)
-    [assertion-strip/assertion-strip assertions]))
+    [rf.story.ui.assertion-strip/assertion-strip assertions]))
 
 ;; ---- the canvas component ------------------------------------------------
 
@@ -425,12 +425,12 @@
   single resume owner runs the script exactly once. Returns nothing — the
   canvas reads the variant's app-db-value reactively after each run."
   [variant-id]
-  (let [shell @state/shell-state-atom
+  (let [shell @rf.story.ui.state/shell-state-atom
         opts  {:active-modes   (:active-modes shell)
                :cell-overrides (get-in shell [:cell-overrides variant-id])
                :substrate      (:substrate shell)
                :run-key        (run-key shell variant-id)}]
-    (runtime/prepare-run! variant-id opts)
+    (rf.story.runtime/prepare-run! variant-id opts)
     nil))
 
 (defn- run-if-needed!
@@ -446,8 +446,8 @@
   idempotent per generation, so the shell selection-watcher / mount-time block
   calling it too for the same generation collapses to one execution."
   []
-  (when config/enabled?
-    (let [shell      @state/shell-state-atom
+  (when rf.story.config/enabled?
+    (let [shell      @rf.story.ui.state/shell-state-atom
           variant-id (:selected-variant shell)]
       (if-not variant-id
         (reset! canvas-last-run-key nil)
@@ -457,7 +457,7 @@
             (prepare-with-shell-opts! variant-id)
             ;; RESUME the one run owner post-commit. The generation guard makes
             ;; this exactly-once even though the shell also schedules a resume.
-            (runtime/resume-run! variant-id)))))))
+            (rf.story.runtime/resume-run! variant-id)))))))
 
 (defn variant-substrate-set
   "Resolve the variant's effective substrate set. Per `001-Authoring.md` §Registration macros
@@ -472,11 +472,11 @@
   itself the answer to \"declared set or host substrate?\" — it is both,
   in that precedence, with the shell's substrate as the fallback."
   [variant-id]
-  (let [vb (registrar/handler-meta :variant variant-id)
-        sid (args/parent-story-id variant-id)
-        sb (when sid (registrar/handler-meta :story sid))]
-    (multi-substrate/resolve-substrate-set
-      vb sb (or (:substrate @state/shell-state-atom) :reagent))))
+  (let [vb (rf.story.registrar/handler-meta :variant variant-id)
+        sid (rf.story.args/parent-story-id variant-id)
+        sb (when sid (rf.story.registrar/handler-meta :story sid))]
+    (rf.story.ui.multi-substrate/resolve-substrate-set
+      vb sb (or (:substrate @rf.story.ui.state/shell-state-atom) :reagent))))
 
 (defn- canvas-inner
   "The inner render fn — reads the variant's app-db-value reactively. Split
@@ -489,7 +489,7 @@
   - >1 substrate → multi-substrate side-by-side grid (`002-Runtime.md` §Substrate hooks)."
   [variant-id]
   (let [view-id        (variant-component variant-id)
-        variant-body   (registrar/handler-meta :variant variant-id)
+        variant-body   (rf.story.registrar/handler-meta :variant variant-id)
         ;; The SAME per-run opts the `eff-args` resolve below
         ;; uses, threaded into `resolve-decorators` so the plan it
         ;; recompiles to read `[:world :decorators]` substitutes `[:arg]`
@@ -499,13 +499,13 @@
         ;; here even though the runtime's plan compile handles it — the
         ;; canvas decorator recompile needs the same opts.
         run-opts       {:active-modes
-                        (:active-modes @state/shell-state-atom)
+                        (:active-modes @rf.story.ui.state/shell-state-atom)
                         :cell-overrides
-                        (get-in @state/shell-state-atom
+                        (get-in @rf.story.ui.state/shell-state-atom
                                 [:cell-overrides variant-id])}
-        decorator-pack (decorators/resolve-decorators variant-id run-opts)
-        eff-args       (args/resolve-args variant-id run-opts)
-        assertions     (runtime/read-assertions variant-id)
+        decorator-pack (rf.story.decorators/resolve-decorators variant-id run-opts)
+        eff-args       (rf.story.args/resolve-args variant-id run-opts)
+        assertions     (rf.story.runtime/read-assertions variant-id)
         ;; Resolve the variant's view-state subscription
         ;; overrides (arg-substituted) for the render-path binding below.
         sub-ovr        (resolve-sub-overrides variant-id eff-args)
@@ -517,7 +517,7 @@
         ;; window before `frames/allocate!` runs. Pure-data check
         ;; against the variant body + decorator stack, mirroring
         ;; `loaders/events-only-variant?`.
-        events-only?   (story-loaders/events-only-variant?
+        events-only?   (rf.story.loaders/events-only-variant?
                          variant-body decorator-pack)
         ;; rf2-4iu7tu: events-only?'s skeleton suppression (below /
         ;; `loading-phase?`'s events-only? arm) means THIS render — not
@@ -554,7 +554,7 @@
         ;; loader cascade runs; once :ready / :error lands, the
         ;; first-rendered sentinel flips (in component-did-mount /
         ;; -did-update) and the skeleton hides.
-        lifecycle-phase (try (story-loaders/current-state variant-id)
+        lifecycle-phase (try (rf.story.loaders/current-state variant-id)
                              (catch :default _ nil))
         first?         (variant-first-rendered? variant-id)
         ;; A recorded assertion proves the loader cascade
@@ -570,11 +570,11 @@
      [:div {:style (:title styles)}
       [:span (str (pr-str variant-id))]
       (when view-id
-        [:span {:style {:color (:text-tertiary colors/tokens)}}
+        [:span {:style {:color (:text-tertiary rf.story.theme.colors/tokens)}}
          (str "→ " (pr-str view-id))])
       (when multi?
-        [:span {:style {:color (:text-secondary colors/tokens)
-                        :font-size (:micro typography/type-scale) :font-weight "normal"}}
+        [:span {:style {:color (:text-secondary rf.story.theme.colors/tokens)
+                        :font-size (:micro rf.story.theme.typography/type-scale) :font-weight "normal"}}
          (str " (substrates: "
               (str/join ", " (map name (sort-by name substrates)))
               ")")])
@@ -589,13 +589,13 @@
          ;; off the variant body and routes through the user's configured
          ;; editor URI scheme. Renders nothing when no source-coord was
          ;; captured at registration.
-         (open-in-editor/open-chip-for-variant variant-body)])]
+         (rf.story.ui.open-in-editor/open-chip-for-variant variant-body)])]
      ;; The share-import hint surfaces a non-blocking note when
      ;; a hydrated share URL dropped one or more overrides (variant
      ;; args refactored/renamed/removed). Renders nil when nothing
      ;; dropped, so this is unconditional-safe.
      (when variant-id
-       [share/share-import-hint variant-id])
+       [rf.story.ui.share/share-import-hint variant-id])
      (cond
        (nil? variant-id)
        [:div {:style (:empty styles)} "no variant selected"]
@@ -619,12 +619,12 @@
        ;; back to the live app/default frame.
        ^{:key (str "multi-" variant-id)}
        [rf/frame-provider {:frame variant-id}
-        [multi-substrate/multi-substrate-grid variant-id]]
+        [rf.story.ui.multi-substrate/multi-substrate-grid variant-id]]
 
        :else
        ;; SINGLE-PANE render. The renderer is resolved through the SAME
        ;; substrate registry the grid branch above consults —
-       ;; `multi-substrate/render-view` → `substrate->render-fn` — keyed on
+       ;; `rf.story.ui.multi-substrate/render-view` → `substrate->render-fn` — keyed on
        ;; the variant's ONE declared substrate.
        ;;
        ;; rf2-3afns: this branch used to call `(rf/view view-id)` itself and
@@ -677,7 +677,7 @@
          ;; wrapper when the variant authors none).
          [sub-overrides-scope sub-ovr
           (safe-decorated-view
-            (multi-substrate/render-view
+            (rf.story.ui.multi-substrate/render-view
               (first substrates) variant-id view-id eff-args)
             (:hiccup decorator-pack)
             eff-args)]]])
@@ -695,13 +695,13 @@
   user view must still render. The skeleton hides on the
   next render pass."
   []
-  (when config/enabled?
-    (let [shell      @state/shell-state-atom
+  (when rf.story.config/enabled?
+    (let [shell      @rf.story.ui.state/shell-state-atom
           variant-id (:selected-variant shell)]
       (when variant-id
-        (let [phase (try (story-loaders/current-state variant-id)
+        (let [phase (try (rf.story.loaders/current-state variant-id)
                          (catch :default _ nil))
-              assertions (try (runtime/read-assertions variant-id)
+              assertions (try (rf.story.runtime/read-assertions variant-id)
                               (catch :default _ nil))]
           (when (or (contains? #{:ready :error} phase)
                     (seq assertions))
@@ -751,13 +751,13 @@
             (reset-first-rendered!))))
      :reagent-render
      (fn []
-       (let [shell      @state/shell-state-atom
+       (let [shell      @rf.story.ui.state/shell-state-atom
              variant-id (:selected-variant shell)
              opts       {:active-modes   (:active-modes shell)
                          :cell-overrides (get-in shell [:cell-overrides variant-id])
                          :substrate      (:substrate shell)}
              snapshot   (when variant-id
-                          (runtime/snapshot-identity variant-id opts))
+                          (rf.story.runtime/snapshot-identity variant-id opts))
              _tick      (:hot-reload-tick shell)]   ;; deref to subscribe
          ;; The canvas wrap is the scrollable container
          ;; for variant content; `tab-index "0"` makes it keyboard-

--- a/tools/story/src/re_frame/story/ui/chrome_a11y.cljs
+++ b/tools/story/src/re_frame/story/ui/chrome_a11y.cljs
@@ -12,11 +12,11 @@
 
   The two panels share:
 
-  - The CDN-load gate + opt-in persistence (`a11y/cdn-opt-in?`,
-    `a11y/set-cdn-opt-in!`, `a11y/ensure-axe-loaded!`) — one consent
+  - The CDN-load gate + opt-in persistence (`rf.story.ui.a11y/cdn-opt-in?`,
+    `rf.story.ui.a11y/set-cdn-opt-in!`, `rf.story.ui.a11y/ensure-axe-loaded!`) — one consent
     decision approves loading axe-core for both panels.
   - The violations stylesheet that renders red outlines on offending
-    elements (`a11y/ensure-stylesheet!`).
+    elements (`rf.story.ui.a11y/ensure-stylesheet!`).
   - The violation-row hiccup + impact-style colour scheme — pure UI
     leaves, identical for both panels.
   - The `record-violation-overlay!` decorator that stamps
@@ -43,7 +43,7 @@
   ## Pre-alpha posture
 
   No toggle to opt out — the panel is always available, runs on demand
-  via the 'run' button. Production builds with `config/enabled?` false
+  via the 'run' button. Production builds with `rf.story.config/enabled?` false
   never reach this ns.
 
   ## State
@@ -53,11 +53,11 @@
   structured."
   (:require [reagent.core :as r]
             [re-frame.core :as rf]
-            [re-frame.story.config :as config]
-            [re-frame.story.registrar :as story-registrar]
-            [re-frame.story.ui.a11y :as a11y]
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.ui.a11y :as rf.story.ui.a11y]
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---- chrome root selector ------------------------------------------------
 
@@ -95,7 +95,7 @@
          read it through `status`.
 
          `:token` identifies the run currently OWNING the chrome scan —
-         see `a11y/new-run-token` and `stale-run?` below. Mirrors the
+         see `rf.story.ui.a11y/new-run-token` and `stale-run?` below. Mirrors the
          per-frame run-state slot in `ui/a11y.cljs` for UX parity with
          the variant panel, and fences the same way."}
   run-state
@@ -109,7 +109,7 @@
 (defn- stale-run?
   "True when the run carrying `token` no longer owns the chrome scan.
 
-  The singleton counterpart of `a11y/stale-run?`, and narrower for it:
+  The singleton counterpart of `rf.story.ui.a11y/stale-run?`, and narrower for it:
   the chrome slot is one atom that always exists, so there is no
   teardown-resurrection to refuse — only supersession. A run loses the
   slot when a newer `run-axe!` claims it, or when `reset-state!` returns
@@ -157,7 +157,7 @@
 ;; ## Persistence
 ;;
 ;; The toggle survives reload via `localStorage` under
-;; `force-colors-opt-in-key`. The pattern mirrors `a11y/cdn-opt-in-key`
+;; `force-colors-opt-in-key`. The pattern mirrors `rf.story.ui.a11y/cdn-opt-in-key`
 ;; (same module): in-memory ratom for the live read, persisted string
 ;; for the round-trip across reloads. Browsers that block localStorage
 ;; (private mode, embedded contexts, file://) degrade to in-memory-only
@@ -307,11 +307,11 @@
   Returns a `js/Promise` resolving to the violations vector — or nil
   when the chrome root cannot be resolved (e.g. shell not mounted).
 
-  Reuses `a11y/ensure-axe-loaded!` so the CDN load + consent gate is
+  Reuses `rf.story.ui.a11y/ensure-axe-loaded!` so the CDN load + consent gate is
   shared with the variant panel: one opt-in approves both.
 
   Per `005-SOTA-Features.md` §a11y (axe-core) panel surfaces violations into the global trace bus
-  via `a11y/emit-warning-for-violation` keyed on `chrome-frame-id`."
+  via `rf.story.ui.a11y/emit-warning-for-violation` keyed on `chrome-frame-id`."
   ([] (run-axe! (find-chrome-root)))
   ([context]
    (cond
@@ -328,7 +328,7 @@
 
      ;; CDN opt-in gate — same prompt the variant panel uses; one
      ;; consent approves both panels.
-     (not (a11y/cdn-opt-in?))
+     (not (rf.story.ui.a11y/cdn-opt-in?))
      (do
        (reset! run-state {:status :no-consent})
        (js/Promise.resolve nil))
@@ -338,9 +338,9 @@
      ;; this panel's singleton slot. Every mutation on the far side of an
      ;; await is gated on the token claimed here, in the same synchronous
      ;; turn as the mutation it guards.
-     (let [token (a11y/new-run-token)]
+     (let [token (rf.story.ui.a11y/new-run-token)]
        (reset! run-state {:status :loading :token token})
-       (-> (a11y/ensure-axe-loaded!)
+       (-> (rf.story.ui.a11y/ensure-axe-loaded!)
            (.then
              (fn [^js axe]
                ;; A superseded run declines to SCAN, not merely to
@@ -360,8 +360,8 @@
                                    context)]
                    (reset! violations (vec (array-seq vs)))
                    (doseq [v (array-seq vs)]
-                     (a11y/record-violation-overlay! scope-el v)
-                     (a11y/emit-warning-for-violation chrome-frame-id v))
+                     (rf.story.ui.a11y/record-violation-overlay! scope-el v)
+                     (rf.story.ui.a11y/emit-warning-for-violation chrome-frame-id v))
                    (reset! run-state {:status :done :token token})
                    vs))))
            (.catch
@@ -377,24 +377,24 @@
 
 (def ^:private styles
   {:wrap      {:padding "8px"
-               :background (:bg-2 colors/tokens)
+               :background (:bg-2 rf.story.theme.colors/tokens)
                :border-top "1px solid #444"
-               :color (:text-primary colors/tokens)
+               :color (:text-primary rf.story.theme.colors/tokens)
                :font-family mono-stack
-               :font-size (:caption typography/type-scale)}
+               :font-size (:caption rf.story.theme.typography/type-scale)}
    :header    {:display "flex"
                :justify-content "space-between"
                :align-items "center"
                :margin-bottom "8px"}
    :section-h {:font-weight "bold"
-               :color (:text-secondary colors/tokens)
+               :color (:text-secondary rf.story.theme.colors/tokens)
                :text-transform "uppercase"
-               :font-size (:micro typography/type-scale)
+               :font-size (:micro rf.story.theme.typography/type-scale)
                :letter-spacing "0.5px"}
-   :status    {:color (:text-secondary colors/tokens)
-               :font-size (:micro typography/type-scale)
+   :status    {:color (:text-secondary rf.story.theme.colors/tokens)
+               :font-size (:micro rf.story.theme.typography/type-scale)
                :margin-top "4px"}
-   :empty     {:color (:text-tertiary colors/tokens)
+   :empty     {:color (:text-tertiary rf.story.theme.colors/tokens)
                :font-style "italic"
                :padding "4px 0"}})
 
@@ -407,31 +407,31 @@
   [:div {:style {:padding "8px 0"
                  :border-top "1px dashed #555"
                  :margin-top "4px"
-                 :color (:text-primary colors/tokens)}}
+                 :color (:text-primary rf.story.theme.colors/tokens)}}
    [:div {:style {:font-weight "bold"
-                  :color (:danger colors/tokens)
+                  :color (:danger rf.story.theme.colors/tokens)
                   :margin-bottom "6px"}}
     "axe-core not loaded"]
-   [:div {:style {:font-size (:micro typography/type-scale)
+   [:div {:style {:font-size (:micro rf.story.theme.typography/type-scale)
                   :line-height "1.4"
-                  :color (:text-secondary colors/tokens)
+                  :color (:text-secondary rf.story.theme.colors/tokens)
                   :margin-bottom "6px"}}
     "Running an a11y scan loads "
-    [:code {:style {:color (:info colors/tokens)}} "axe-core@4.10.0"]
+    [:code {:style {:color (:info rf.story.theme.colors/tokens)}} "axe-core@4.10.0"]
     " from a public CDN ("
-    [:code {:style {:color (:info colors/tokens)}} "cdn.jsdelivr.net"]
+    [:code {:style {:color (:info rf.story.theme.colors/tokens)}} "cdn.jsdelivr.net"]
     "). The remote JS gets full DOM access to this Story page; the SRI "
     "hash pinned in the loader detects tampering, but the dependency "
     "itself is a trust call. No shell state leaves the browser."]
-   [:div {:style {:font-size (:micro typography/type-scale)
-                  :color (:text-secondary colors/tokens)
+   [:div {:style {:font-size (:micro rf.story.theme.typography/type-scale)
+                  :color (:text-secondary rf.story.theme.colors/tokens)
                   :margin-bottom "8px"}}
     "Approve once per browser; the opt-in is remembered in "
-    [:code {:style {:color (:info colors/tokens)}} "localStorage"]
+    [:code {:style {:color (:info rf.story.theme.colors/tokens)}} "localStorage"]
     " and shared with the per-variant a11y panel."]
-   [:button {:style    (:run-button a11y/styles)
+   [:button {:style    (:run-button rf.story.ui.a11y/styles)
              :on-click (fn [_]
-                         (a11y/set-cdn-opt-in! true)
+                         (rf.story.ui.a11y/set-cdn-opt-in! true)
                          (run-axe!))}
     "enable axe-core + scan"]])
 
@@ -447,12 +447,12 @@
            :style     {:padding "8px 0 4px 0"
                        :border-top "1px dashed #444"
                        :margin-top "8px"
-                       :color (:text-primary colors/tokens)}}
+                       :color (:text-primary rf.story.theme.colors/tokens)}}
      [:label {:style {:display     "flex"
                       :align-items "center"
                       :gap         "8px"
                       :cursor      "pointer"
-                      :font-size   (:caption typography/type-scale)}}
+                      :font-size   (:caption rf.story.theme.typography/type-scale)}}
       [:input {:data-test "story-chrome-a11y-use-system-colors-input"
                :type      "checkbox"
                :checked   (boolean on?)
@@ -460,23 +460,23 @@
                             (set-force-colors-opt-in!
                               (boolean (.. e -target -checked))))}]
       [:span "Use system colors"]]
-     [:div {:style {:font-size   (:micro typography/type-scale)
+     [:div {:style {:font-size   (:micro rf.story.theme.typography/type-scale)
                     :line-height "1.4"
-                    :color       (:text-secondary colors/tokens)
+                    :color       (:text-secondary rf.story.theme.colors/tokens)
                     :margin-top  "4px"}}
       "Render the Story chrome using your OS' high-contrast palette ("
-      [:code {:style {:color (:info colors/tokens)}} "Highlight"]
+      [:code {:style {:color (:info rf.story.theme.colors/tokens)}} "Highlight"]
       ", "
-      [:code {:style {:color (:info colors/tokens)}} "CanvasText"]
+      [:code {:style {:color (:info rf.story.theme.colors/tokens)}} "CanvasText"]
       ", "
-      [:code {:style {:color (:info colors/tokens)}} "Mark"]
+      [:code {:style {:color (:info rf.story.theme.colors/tokens)}} "Mark"]
       ", "
-      [:code {:style {:color (:info colors/tokens)}} "GrayText"]
+      [:code {:style {:color (:info rf.story.theme.colors/tokens)}} "GrayText"]
       ") — the same chrome Windows High Contrast Mode paints, on "
       "demand without flipping the OS-level switch. Default OFF; the "
       "OS HCM detection still works either way. Persists across "
       "reloads in "
-      [:code {:style {:color (:info colors/tokens)}} "localStorage"]
+      [:code {:style {:color (:info rf.story.theme.colors/tokens)}} "localStorage"]
       "."]]))
 
 (defn panel
@@ -489,15 +489,15 @@
   stamped by `shell.cljs`), NOT the variant root. Variant a11y lives
   in the sibling `re-frame.story.ui.a11y` panel."
   [_variant-id]
-  (a11y/ensure-stylesheet!)
+  (rf.story.ui.a11y/ensure-stylesheet!)
   (let [vs    @violations
         state (status)
         busy? (or (= state :loading) (= state :running))]
     [:div {:style (:wrap styles) :data-test "story-chrome-a11y-panel"}
      [:div {:style (:header styles)}
       [:span {:style (:section-h styles)} "Chrome A11y (axe-core)"]
-      [:button {:style    (merge (:run-button a11y/styles)
-                                 (when busy? (:run-busy a11y/styles)))
+      [:button {:style    (merge (:run-button rf.story.ui.a11y/styles)
+                                 (when busy? (:run-busy rf.story.ui.a11y/styles)))
                 :data-test "story-chrome-a11y-run"
                 :disabled busy?
                 :on-click (fn [_] (when-not busy? (run-axe!)))}
@@ -531,7 +531,7 @@
        :else
        [:div {:data-test "story-chrome-a11y-violations"}
         (for [[i v] (map-indexed vector vs)]
-          ^{:key i} [a11y/violation-row v])])
+          ^{:key i} [rf.story.ui.a11y/violation-row v])])
      ;; 'Use system colors' toggle rendered at the foot of
      ;; the panel so the operator-controlled HCM preview shares the
      ;; same accessibility surface as the axe-core consent + run knobs.
@@ -554,7 +554,7 @@
   alongside the variant a11y panel.
 
   Idempotent. Production builds with `:rf.story/enabled?` false skip
-  registration via the `config/enabled?` gate.
+  registration via the `rf.story.config/enabled?` gate.
 
   Also schedules a one-tick `bootstrap-force-colors!`
   so the persisted 'Use system colors' opt-in re-applies to the live
@@ -563,7 +563,7 @@
   React tree has committed `[data-rf-story-root]` before the
   attribute write tries to find it."
   []
-  (when config/enabled?
+  (when rf.story.config/enabled?
     ;; `[:div]` wrap REQUIRED for source-coord annotation — see the
     ;; full rationale on `:rf.story.panel/a11y-view` registration in
     ;; `re-frame.story.ui.a11y`. Per Spec 006 §Source-coord annotation
@@ -571,7 +571,7 @@
     ;; `data-rf2-source-coord` to; a bare `[panel variant-id]` root
     ;; silences Story / Xray Inspect Mode for this panel.
     (rf/reg-view* panel-render-id (fn [variant-id] [:div [panel variant-id]]))
-    (story-registrar/reg-story-panel*
+    (rf.story.registrar/reg-story-panel*
       panel-id
       {:doc       "axe-core accessibility scanner scoped to the Story chrome root."
        :title     "Chrome a11y"

--- a/tools/story/src/re_frame/story/ui/cofx.cljc
+++ b/tools/story/src/re_frame/story/ui/cofx.cljc
@@ -29,28 +29,28 @@
   `re-frame.story/install-canonical-vocabulary!`. Idempotent — re-
   registering with the same body replaces the slot atomically."
   (:require [re-frame.core :as rf]
-            [re-frame.story.args :as args]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.story.ui.state :as state]))
+            [re-frame.story.args :as rf.story.args]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.ui.state :as rf.story.ui.state]))
 
 (defn active-modes-snapshot
   "Return the current `:active-modes` vector from the shell state.
   Pure data → data when paired with the shell-state-atom deref."
   []
-  (vec (or (:active-modes (state/get-state)) [])))
+  (vec (or (:active-modes (rf.story.ui.state/get-state)) [])))
 
 (defn- mode-args
   "Lookup the `:args` map for `mode-id`, or `{}` if the mode is
   unregistered. Mirrors `re-frame.story.args/mode-args` (private)."
   [mode-id]
-  (or (:args (registrar/handler-meta :mode mode-id)) {}))
+  (or (:args (rf.story.registrar/handler-meta :mode mode-id)) {}))
 
 (defn active-args-snapshot
   "Return the deep-merged `:args` from every active mode, in the order
   the modes were activated. Mirrors `re-frame.story.args/resolve-args`'
   modes-layer composition. Pure data → data."
   []
-  (args/deep-merge-all (map mode-args (active-modes-snapshot))))
+  (rf.story.args/deep-merge-all (map mode-args (active-modes-snapshot))))
 
 (defn install-canonical-cofx!
   "Register the three canonical Story cofx + the matching subs. Per
@@ -84,7 +84,7 @@
   (rf/reg-sub
     :story/active-modes
     (fn [_ _]
-      (vec (or (:active-modes @state/shell-state-atom) []))))
+      (vec (or (:active-modes @rf.story.ui.state/shell-state-atom) []))))
 
   (rf/reg-sub
     :story/active-args

--- a/tools/story/src/re_frame/story/ui/command_palette.cljc
+++ b/tools/story/src/re_frame/story/ui/command_palette.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.story.ui.command-palette
   "Pure helpers for Story's global command palette."
   (:require [clojure.string :as str]
-            [re-frame.story.predicates :as pred]))
+            [re-frame.story.predicates :as rf.story.predicates]))
 
 (def searchable-kinds
   [:command :story :variant :workspace :mode :decorator])
@@ -67,7 +67,7 @@
 (defn- variants-for-story [variants story-id]
   (->> variants
        keys
-       (filter #(= story-id (pred/parent-story-id %)))
+       (filter #(= story-id (rf.story.predicates/parent-story-id %)))
        sort
        vec))
 

--- a/tools/story/src/re_frame/story/ui/command_palette/view.cljs
+++ b/tools/story/src/re_frame/story/ui/command_palette/view.cljs
@@ -2,14 +2,14 @@
   "Global Cmd-K / Ctrl-K command palette for the Story shell."
   (:require [clojure.string :as str]
             [reagent.core :as r]
-            [re-frame.story.config :as config]
-            [re-frame.story.save-variant :as save-variant]
-            [re-frame.story.ui.author-expectations :as author-expectations]
-            [re-frame.story.ui.command-palette :as palette]
-            [re-frame.story.ui.explain-panel :as explain-panel]
-            [re-frame.story.ui.state :as state]
-            [re-frame.story.ui.toolbar :as toolbar]
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]))
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.save-variant :as rf.story.save-variant]
+            [re-frame.story.ui.author-expectations :as rf.story.ui.author-expectations]
+            [re-frame.story.ui.command-palette :as rf.story.ui.command-palette]
+            [re-frame.story.ui.explain-panel :as rf.story.ui.explain-panel]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.ui.toolbar :as rf.story.ui.toolbar]
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]))
 
 (defn shortcut-event?
   "True when `event` is Story's global command-palette shortcut."
@@ -38,52 +38,52 @@
     (do
       (case (:action entry)
         ;; Open the Explain panel + scroll it into view.
-        :explain (explain-panel/open!)
+        :explain (rf.story.ui.explain-panel/open!)
         ;; Capture the focused variant's live canvas state
         ;; as a new variant. Same flow as the Controls-panel button
         ;; (spec/019 §3). `save-current-as-variant!` reads the live
         ;; selection from shell-state and no-ops (returns nil) when no
         ;; variant is focused, so the palette action needs no extra guard.
-        :save-current-as-variant (save-variant/save-current-as-variant!)
+        :save-current-as-variant (rf.story.save-variant/save-current-as-variant!)
         ;; Author EXPECTATIONS onto the focused story
         ;; (spec/021 §S5). Same dialog as the Controls-panel 'add
         ;; expectations…' button. Distinct from save-current-state.
         ;; `open-for-focused-variant!` reads the live selection and no-ops
         ;; when no variant is focused, so the action needs no extra guard.
-        :author-expectations (author-expectations/open-for-focused-variant!)
+        :author-expectations (rf.story.ui.author-expectations/open-for-focused-variant!)
         nil)
       true)
 
     :variant
     (do
-      (state/swap-state!
+      (rf.story.ui.state/swap-state!
         (fn [s]
           (-> s
-              (state/select-variant (:id entry))
-              (state/select-workspace nil))))
+              (rf.story.ui.state/select-variant (:id entry))
+              (rf.story.ui.state/select-workspace nil))))
       true)
 
     :workspace
     (do
-      (state/swap-state!
+      (rf.story.ui.state/swap-state!
         (fn [s]
           (-> s
-              (state/select-workspace (:id entry))
-              (state/select-variant nil))))
+              (rf.story.ui.state/select-workspace (:id entry))
+              (rf.story.ui.state/select-variant nil))))
       true)
 
     :story
     (when-let [variant-id (first (:variant-ids entry))]
-      (state/swap-state!
+      (rf.story.ui.state/swap-state!
         (fn [s]
           (-> s
-              (state/select-variant variant-id)
-              (state/select-workspace nil))))
+              (rf.story.ui.state/select-variant variant-id)
+              (rf.story.ui.state/select-workspace nil))))
       true)
 
     :mode
     (do
-      (toolbar/toggle-mode! (:id entry))
+      (rf.story.ui.toolbar/toggle-mode! (:id entry))
       true)
 
     :decorator
@@ -130,14 +130,14 @@
                  :border-radius "8px"
                  :cursor "pointer"}
    :row-active  {:background "#3a3a43"}
-   :kind        {:font-size (:caption typography/type-scale)
+   :kind        {:font-size (:caption rf.story.theme.typography/type-scale)
                  :text-transform "uppercase"
                  :letter-spacing "0.08em"
                  :color "#aeb4c0"
                  :padding-top "2px"}
-   :id          {:font-size (:body typography/type-scale)
+   :id          {:font-size (:body rf.story.theme.typography/type-scale)
                  :color "#ffffff"}
-   :doc         {:font-size (:body-tight typography/type-scale)
+   :doc         {:font-size (:body-tight rf.story.theme.typography/type-scale)
                  :color "#b8b8c0"
                  :line-height "1.35"
                  :margin-top "2px"
@@ -147,7 +147,7 @@
    :empty       {:padding "24px"
                  :text-align "center"
                  :color "#9a9aa3"
-                 :font-size (:body typography/type-scale)}})
+                 :font-size (:body rf.story.theme.typography/type-scale)}})
 
 (defn result-row [entry active? on-hover on-select]
   ^{:key [(:kind entry) (:id entry)]}
@@ -223,7 +223,7 @@
       {:display-name "rf-story-command-palette"
        :component-did-mount
        (fn [_]
-         (when config/enabled?
+         (when rf.story.config/enabled?
            (let [f (fn [event]
                      (cond
                        (shortcut-event? event)
@@ -257,12 +257,12 @@
          ;; host to keep the authoring flow's mount in its own lane.
          [:<>
           (when @open?
-            (let [results (palette/search
-                            (palette/entries (state/registry-snapshot))
+            (let [results (rf.story.ui.command-palette/search
+                            (rf.story.ui.command-palette/entries (rf.story.ui.state/registry-snapshot))
                             @query
                             30)
                   result-count (count results)
-                  active (palette/clamp-active-index @active-index result-count)]
+                  active (rf.story.ui.command-palette/clamp-active-index @active-index result-count)]
               (when (not= active @active-index)
                 (reset! active-index active))
               (render-palette
@@ -279,11 +279,11 @@
                                         "ArrowDown"
                                         (do (.preventDefault event)
                                             (swap! active-index
-                                                   palette/move-active-index 1 result-count))
+                                                   rf.story.ui.command-palette/move-active-index 1 result-count))
                                         "ArrowUp"
                                         (do (.preventDefault event)
                                             (swap! active-index
-                                                   palette/move-active-index -1 result-count))
+                                                   rf.story.ui.command-palette/move-active-index -1 result-count))
                                         "Enter"
                                         (do (.preventDefault event)
                                             (when-let [entry (get results active)]
@@ -297,4 +297,4 @@
                  :on-row-select     (fn [entry]
                                       (select-entry! entry)
                                       (close!))})))
-          [author-expectations/author-dialog]])})))
+          [rf.story.ui.author-expectations/author-dialog]])})))

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -52,7 +52,7 @@
     resolved args WITHOUT the controls panel's `:cell-overrides`. An arg
     whose effective value drifts from its saved value shows a 'changed'
     dot and a per-arg reset that reverts just that one arg
-    (`state/clear-cell-override`); the panel-level 'reset overrides'
+    (`rf.story.ui.state/clear-cell-override`); the panel-level 'reset overrides'
     clears them all.
 
   - **Summarise before expanding** — nested (`:group` / `:repeater` /
@@ -65,18 +65,18 @@
     (§6 acceptance criterion)."
   (:require [clojure.string                    :as str]
             [reagent.core                      :as r]
-            [re-frame.story.budgets            :as budgets]
-            [re-frame.story.registrar          :as registrar]
-            [re-frame.story.args               :as args]
-            [re-frame.story.decorators         :as decorators]
-            [re-frame.story.malli-schema       :as msu]
-            [re-frame.story.view-args          :as view-args]
-            [re-frame.story.ui.author-expectations :as author-expectations]
+            [re-frame.story.budgets            :as rf.story.budgets]
+            [re-frame.story.registrar          :as rf.story.registrar]
+            [re-frame.story.args               :as rf.story.args]
+            [re-frame.story.decorators         :as rf.story.decorators]
+            [re-frame.story.malli-schema       :as rf.story.malli-schema]
+            [re-frame.story.view-args          :as rf.story.view-args]
+            [re-frame.story.ui.author-expectations :as rf.story.ui.author-expectations]
             [re-frame.story.ui.controls-styles :refer [styles]]
-            [re-frame.story.ui.save-variant    :as save-variant-ui]
-            [re-frame.story.ui.schema-validation :as schema-validation]
-            [re-frame.story.ui.state           :as state]
-            [re-frame.story.ui.view-state      :as view-state]))
+            [re-frame.story.ui.save-variant    :as rf.story.ui.save-variant]
+            [re-frame.story.ui.schema-validation :as rf.story.ui.schema-validation]
+            [re-frame.story.ui.state           :as rf.story.ui.state]
+            [re-frame.story.ui.view-state      :as rf.story.ui.view-state]))
 
 ;; Styles live in `re-frame.story.ui.controls-styles` (pure-data leaf,
 ;; no Reagent dep). Required as `styles` above so the in-file call
@@ -88,12 +88,12 @@
 ;; leaf ns shared with `schema-validation`). Aliased privately here so
 ;; in-file call sites stay textually identical.
 
-(def ^:private properties?      msu/properties?)
-(def ^:private schema-op        msu/schema-op)
-(def ^:private schema-properties msu/schema-properties)
-(def ^:private schema-children  msu/schema-children)
-(def ^:private map-entry-key    msu/map-entry-key)
-(def ^:private map-entry-schema msu/map-entry-schema)
+(def ^:private properties?      rf.story.malli-schema/properties?)
+(def ^:private schema-op        rf.story.malli-schema/schema-op)
+(def ^:private schema-properties rf.story.malli-schema/schema-properties)
+(def ^:private schema-children  rf.story.malli-schema/schema-children)
+(def ^:private map-entry-key    rf.story.malli-schema/map-entry-key)
+(def ^:private map-entry-schema rf.story.malli-schema/map-entry-schema)
 
 ;; ---- pure: argtype inference --------------------------------------------
 
@@ -258,24 +258,24 @@
   HOT PATH: `args-editor` is keystroke-sensitive — every
   controls-panel edit re-renders, which re-runs this fn. The optional
   `eff-args` arg threads the caller's already-resolved args through so
-  we don't re-run `args/resolve-args` (which itself deep-merges five
+  we don't re-run `rf.story.args/resolve-args` (which itself deep-merges five
   precedence layers and re-reads the registrar). The single-arity
   overload preserves the canonical surface for tests + non-render
   callers; the render path threads its own resolution.
 
   SCHEMA SOURCE: the auto-derivation schema is
   the COMPILED variant-plan's `[:world :view-args-schema]`, read through
-  the ONE shared resolver `view-args/compiled-view-args-schema` (memoized
+  the ONE shared resolver `rf.story.view-args/compiled-view-args-schema` (memoized
   per variant + registrar tick). This is the SAME slot the schema-
   validation panel validates against, so a `:rf/props`-declared view
   gets BOTH derived controls AND validation from one source — including
   any `:extends`-inherited / `:compose`-d `:component`."
   ([variant-id]
-   (resolve-argtypes variant-id (args/resolve-args variant-id)))
+   (resolve-argtypes variant-id (rf.story.args/resolve-args variant-id)))
   ([variant-id eff-args]
-   (let [vb      (registrar/handler-meta :variant variant-id)
-         story   (args/parent-story-id variant-id)
-         sb      (when story (registrar/handler-meta :story story))
+   (let [vb      (rf.story.registrar/handler-meta :variant variant-id)
+         story   (rf.story.args/parent-story-id variant-id)
+         sb      (when story (rf.story.registrar/handler-meta :story story))
          types   (merge (normalize-argtypes (:argtypes sb))
                         (normalize-argtypes (:argtypes vb)))
          ;; The view-args (props) schema off the COMPILED plan — the
@@ -283,7 +283,7 @@
          ;; first-match `[:rf/props :schema]` through the shared resolver.
          ;; Per spec/001 §Schema-derivation pipeline + the
          ;; compiled-plan invariant.
-         derive-schema (view-args/compiled-view-args-schema variant-id)
+         derive-schema (rf.story.view-args/compiled-view-args-schema variant-id)
          schema-entries (when (and (vector? derive-schema)
                                    (= :map (schema-op derive-schema)))
                           (into {}
@@ -304,9 +304,9 @@
 ;; ---- pure: validation + diff-from-saved + summaries ---------------------
 
 (defn violations-by-key
-  "Index a `schema-validation/args-violations` vector into a
+  "Index a `rf.story.ui.schema-validation/args-violations` vector into a
   `{arg-key → violation}` map so the args-editor can look up a row's
-  violation in O(1). The whole-args `::schema-validation/root` violation
+  violation in O(1). The whole-args `::rf.story.ui.schema-validation/root` violation
   (a non-`:map` top-level schema) keys under `:rf.story.controls/root`
   so a top-level non-map schema failure still surfaces as a panel banner
   without colliding with any real arg-key.
@@ -375,10 +375,10 @@
   the single choke point every widget's on-change already funnels
   through."
   [variant-id path value]
-  (let [shell (state/get-state)
-        base  (get (args/resolve-args variant-id {:active-modes (:active-modes shell)})
+  (let [shell (rf.story.ui.state/get-state)
+        base  (get (rf.story.args/resolve-args variant-id {:active-modes (:active-modes shell)})
                    (first path))]
-    (state/swap-state! state/set-cell-override variant-id (vec path) value base)))
+    (rf.story.ui.state/swap-state! rf.story.ui.state/set-cell-override variant-id (vec path) value base)))
 
 (declare arg-widget*)
 
@@ -519,7 +519,7 @@
 ;; ---- flat-panel row cap --------------------------------------------------
 ;;
 ;; A controls panel whose top-level arg count exceeds
-;; `budgets/controls-flat-row-cap` (60) renders the first `cap` rows and a
+;; `rf.story.budgets/controls-flat-row-cap` (60) renders the first `cap` rows and a
 ;; `+N more` expander rather than flooding the panel (spec/018 §10). The
 ;; reveal flag rides the SAME component-local `:expanded` ratom that drives
 ;; the nested summarise-before-expand state, under a reserved sentinel so it
@@ -535,12 +535,12 @@
 
 (defn bound-arg-rows
   "Pure data → data: bound the sorted top-level arg entries `entries` (a seq
-  of `[k v]` pairs) to at most `budgets/controls-flat-row-cap` rows unless
+  of `[k v]` pairs) to at most `rf.story.budgets/controls-flat-row-cap` rows unless
   `expanded?`. Returns `{:shown [...] :hidden <n>}` via the shared
-  `budgets/bound-cells` so the controls panel uses the SAME cap-and-page
+  `rf.story.budgets/bound-cells` so the controls panel uses the SAME cap-and-page
   idiom (F1) as the sidebar and the variants-grid. JVM-testable."
   [entries expanded?]
-  (budgets/bound-cells entries budgets/controls-flat-row-cap (boolean expanded?)))
+  (rf.story.budgets/bound-cells entries rf.story.budgets/controls-flat-row-cap (boolean expanded?)))
 
 ;; ---- summarise-before-expand --------------------------------------------
 ;;
@@ -661,13 +661,13 @@
   rf2-z4fza / rf2-c56hr."
   [variant-id path n]
   (let [path-v (vec path)
-        ids    (state/repeater-row-ids (state/get-state) variant-id path-v)]
+        ids    (rf.story.ui.state/repeater-row-ids (rf.story.ui.state/get-state) variant-id path-v)]
     (if (= n (count ids))
       (mapv (fn [id] (str "r:" id)) ids)
       (do
-        (state/swap-state! state/ensure-repeater-row-ids variant-id path-v n)
+        (rf.story.ui.state/swap-state! rf.story.ui.state/ensure-repeater-row-ids variant-id path-v n)
         (mapv (fn [id] (str "r:" id))
-              (state/repeater-row-ids (state/get-state) variant-id path-v))))))
+              (rf.story.ui.state/repeater-row-ids (rf.story.ui.state/get-state) variant-id path-v))))))
 
 (defn- repeater-widget
   "Render a `:vector` (or `:set`) repeater. Each entry gets a nested row
@@ -685,8 +685,8 @@
         path-v   (vec path)
         row-keys (row-keys-for-entries variant-id path-v (count entries))
         on-add   (fn []
-                   (state/swap-state!
-                     state/append-repeater-row-id variant-id path-v)
+                   (rf.story.ui.state/swap-state!
+                     rf.story.ui.state/append-repeater-row-id variant-id path-v)
                    (on-change-at-path
                      variant-id path
                      (let [next-v (conj entries (default-element-value element))]
@@ -694,8 +694,8 @@
                          :set (set next-v)
                          next-v))))
         on-del   (fn [i]
-                   (state/swap-state!
-                     state/remove-repeater-row-id variant-id path-v i)
+                   (rf.story.ui.state/swap-state!
+                     rf.story.ui.state/remove-repeater-row-id variant-id path-v i)
                    (on-change-at-path
                      variant-id path
                      (let [v (vec (concat (subvec entries 0 i)
@@ -839,22 +839,22 @@
                  :data-controls-action "reset-arg"
                  :aria-label (str "reset " k " to saved")
                  :on-click (fn [_]
-                             (state/swap-state!
-                               state/clear-cell-override variant-id k))}
+                             (rf.story.ui.state/swap-state!
+                               rf.story.ui.state/clear-cell-override variant-id k))}
         "reset"]])]
    [:div
     (arg-widget* variant-id [k] value widget-spec opts)
     (when violation
       [:div {:style (:error styles)
              :data-controls-error (str k)}
-       (str "schema: " (let [expl (schema-validation/format-explain (:explain violation))]
+       (str "schema: " (let [expl (rf.story.ui.schema-validation/format-explain (:explain violation))]
                          (if (seq expl)
                            expl
                            (str "does not match " (pr-str (:schema violation))))))])]])
 
 (defn args-editor
   "Render the args editor for `variant-id`. Reads the resolved args via
-  `args/resolve-args` and walks every key, rendering a widget per the
+  `rf.story.args/resolve-args` and walks every key, rendering a widget per the
   inferred argtype. Top-level keys render as flat rows; collection
   argtypes (`:map` / `:vector` / `:set` / `:tuple`) recurse into nested
   rows (rf2-agshe).
@@ -867,14 +867,14 @@
 
   - resolves the EFFECTIVE args (with `:cell-overrides`) and the SAVED
     baseline (without) so it can flag per-arg diff-from-saved;
-  - runs the SAME `schema-validation/args-violations` walk the schema-
+  - runs the SAME `rf.story.ui.schema-validation/args-violations` walk the schema-
     validation panel uses, indexes it by key, and surfaces an inline
     error per violating row + a panel banner;
   - keeps args a control surface, not a fidelity rung — every value
     here is an explicit view input.
 
   FLAT-PANEL CAP (rf2-ba86n.18 / C2): a panel whose top-level arg count
-  exceeds `budgets/controls-flat-row-cap` (60) renders the first `cap` rows
+  exceeds `rf.story.budgets/controls-flat-row-cap` (60) renders the first `cap` rows
   and a `+N more` expander rather than flooding the panel (spec/018 §10 —
   cap or page; fail by summarizing, not flooding). The reveal flag is the
   SAME component-local ephemeral `expanded` ratom that drives the nested
@@ -903,19 +903,19 @@
   ;; user's disclosure choice across sibling variants is the kinder UX.
   (let [expanded (r/atom #{})]
     (fn [variant-id]
-      (let [shell        @state/shell-state-atom
+      (let [shell        @rf.story.ui.state/shell-state-atom
             overrides    (get-in shell [:cell-overrides variant-id])
-            eff-args     (args/resolve-args
+            eff-args     (rf.story.args/resolve-args
                            variant-id
                            {:active-modes   (:active-modes shell)
                             :cell-overrides overrides})
-            saved-args   (args/resolve-args
+            saved-args   (rf.story.args/resolve-args
                            variant-id
                            {:active-modes (:active-modes shell)})
             argtypes     (resolve-argtypes variant-id eff-args)
-            schema       (schema-validation/resolve-component-schema variant-id)
-            vfns         (schema-validation/validator-fns)
-            viols        (schema-validation/args-violations eff-args schema vfns)
+            schema       (rf.story.ui.schema-validation/resolve-component-schema variant-id)
+            vfns         (rf.story.ui.schema-validation/validator-fns)
+            viols        (rf.story.ui.schema-validation/args-violations eff-args schema vfns)
             viols-by-key (violations-by-key viols)
             opts         {:expanded expanded}]
         [:div {:style (:section styles)}
@@ -968,8 +968,8 @@
            [:button {:style    (:button styles)
                      :data-controls-action "reset-all"
                      :on-click (fn [_]
-                                 (state/swap-state!
-                                   state/clear-cell-overrides variant-id))}
+                                 (rf.story.ui.state/swap-state!
+                                   rf.story.ui.state/clear-cell-overrides variant-id))}
             "reset overrides"])]))))
 
 ;; rf2-xi9zk: the controls-panel `mode-picker` is **superseded** by the
@@ -989,11 +989,11 @@
   unique `key`s in a sibling list, so the row key is the `[index id]`
   tuple rather than the bare id."
   [variant-id]
-  (let [shell (deref state/shell-state-atom)
+  (let [shell (deref rf.story.ui.state/shell-state-atom)
         ;; rf2-eyrpr — thread the per-run opts into `resolve-decorators` so
         ;; the plan recompile substitutes `[:arg]` keys resolvable only
         ;; through a mode / cell layer (mirrors the args panel's resolve).
-        pack  (decorators/resolve-decorators
+        pack  (rf.story.decorators/resolve-decorators
                 variant-id
                 {:active-modes   (:active-modes shell)
                  :cell-overrides (get-in shell [:cell-overrides variant-id])})
@@ -1026,7 +1026,7 @@
   DISTINCT from save-current-state (state authoring) and failure promotion
   (a captured artifact) — spec/021 §S5.
 
-  rf2-ba86n.7: the View-State section (`view-state/view-state-section`)
+  rf2-ba86n.7: the View-State section (`rf.story.ui.view-state/view-state-section`)
   sits BELOW the args editor — the orthogonal fidelity-ladder channel
   (the three labelled rungs + source/provenance + the honesty guardrail
   + the upgrade path). Args are an explicit CONTROL channel (above), NOT
@@ -1038,8 +1038,8 @@
    (when variant-id
      [args-editor variant-id])
    (when variant-id
-     [view-state/view-state-section variant-id])
+     [rf.story.ui.view-state/view-state-section variant-id])
    (when variant-id
      [decorator-list variant-id])
-   [save-variant-ui/save-variant-button variant-id]
-   [author-expectations/author-expectations-button variant-id]])
+   [rf.story.ui.save-variant/save-variant-button variant-id]
+   [rf.story.ui.author-expectations/author-expectations-button variant-id]])

--- a/tools/story/src/re_frame/story/ui/controls_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/controls_styles.cljs
@@ -4,21 +4,21 @@
   250-LoC leaf-size ceiling.
 
   CLJS-only."
-  (:require [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+  (:require [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 (def styles
   {:wrap        {:padding "8px"
-                 :background (:bg-2 colors/tokens)
-                 :color (:text-primary colors/tokens)
+                 :background (:bg-2 rf.story.theme.colors/tokens)
+                 :color (:text-primary rf.story.theme.colors/tokens)
                  :font-family mono-stack
-                 :font-size (:caption typography/type-scale)
-                 :border-top (str "1px solid " (:border-default colors/tokens))}
+                 :font-size (:caption rf.story.theme.typography/type-scale)
+                 :border-top (str "1px solid " (:border-default rf.story.theme.colors/tokens))}
    :section     {:margin-bottom "12px"}
    :section-h   {:font-weight "bold"
-                 :color (:text-secondary colors/tokens)
+                 :color (:text-secondary rf.story.theme.colors/tokens)
                  :text-transform "uppercase"
-                 :font-size (:micro typography/type-scale)
+                 :font-size (:micro rf.story.theme.typography/type-scale)
                  :letter-spacing "0.5px"
                  :margin-bottom "4px"}
    :row         {:display "grid"
@@ -31,34 +31,34 @@
                  :gap "8px"
                  :padding "2px 0"
                  :padding-left "12px"
-                 :border-left (str "1px solid " (:border-strong colors/tokens))
+                 :border-left (str "1px solid " (:border-strong rf.story.theme.colors/tokens))
                  :margin-left "4px"
                  :align-items "center"}
-   :group-h     {:color (:info colors/tokens)
+   :group-h     {:color (:info rf.story.theme.colors/tokens)
                  :font-weight "bold"
                  :padding "2px 0"
                  :cursor "default"}
-   :label       {:color (:info colors/tokens)}
-   :sublabel    {:color (:text-secondary colors/tokens)
-                 :font-size (:micro typography/type-scale)}
-   :input       {:background (:bg-canvas colors/tokens)
-                 :color (:text-primary colors/tokens)
-                 :border (str "1px solid " (:border-default colors/tokens))
+   :label       {:color (:info rf.story.theme.colors/tokens)}
+   :sublabel    {:color (:text-secondary rf.story.theme.colors/tokens)
+                 :font-size (:micro rf.story.theme.typography/type-scale)}
+   :input       {:background (:bg-canvas rf.story.theme.colors/tokens)
+                 :color (:text-primary rf.story.theme.colors/tokens)
+                 :border (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                  :padding "2px 6px"
                  :font-family mono-stack
-                 :font-size (:caption typography/type-scale)
+                 :font-size (:caption rf.story.theme.typography/type-scale)
                  :width "100%"}
-   :textarea    {:background (:bg-canvas colors/tokens)
-                 :color (:text-primary colors/tokens)
-                 :border (str "1px solid " (:border-default colors/tokens))
+   :textarea    {:background (:bg-canvas rf.story.theme.colors/tokens)
+                 :color (:text-primary rf.story.theme.colors/tokens)
+                 :border (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                  :padding "4px 6px"
                  :font-family mono-stack
-                 :font-size (:caption typography/type-scale)
+                 :font-size (:caption rf.story.theme.typography/type-scale)
                  :width "100%"
                  :min-height "48px"
                  :resize "vertical"}
-   :color-input {:background (:bg-canvas colors/tokens)
-                 :border (str "1px solid " (:border-default colors/tokens))
+   :color-input {:background (:bg-canvas rf.story.theme.colors/tokens)
+                 :border (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                  :padding "0"
                  :width "36px"
                  :height "20px"
@@ -71,100 +71,100 @@
                  :gap "4px"
                  :align-items "center"
                  :cursor "pointer"
-                 :color (:text-primary colors/tokens)}
+                 :color (:text-primary rf.story.theme.colors/tokens)}
    :chip-row    {:display "flex"
                  :flex-wrap "wrap"
                  :gap "4px"}
    :chip        {:padding "2px 6px"
-                 :background (:bg-3 colors/tokens)
-                 :color (:text-primary colors/tokens)
+                 :background (:bg-3 rf.story.theme.colors/tokens)
+                 :color (:text-primary rf.story.theme.colors/tokens)
                  :border-radius "10px"
                  :cursor "pointer"
-                 :font-size (:micro typography/type-scale)
+                 :font-size (:micro rf.story.theme.typography/type-scale)
                  :user-select "none"}
-   :chip-active {:background (:accent-amber colors/tokens)
-                 :color (:text-on-accent colors/tokens)}
+   :chip-active {:background (:accent-amber rf.story.theme.colors/tokens)
+                 :color (:text-on-accent rf.story.theme.colors/tokens)}
    :button      {:padding "4px 8px"
-                 :background (:accent-amber colors/tokens)
-                 :color (:text-on-accent colors/tokens)
+                 :background (:accent-amber rf.story.theme.colors/tokens)
+                 :color (:text-on-accent rf.story.theme.colors/tokens)
                  :border "none"
                  :border-radius "3px"
                  :cursor "pointer"
-                 :font-size (:micro typography/type-scale)
+                 :font-size (:micro rf.story.theme.typography/type-scale)
                  :margin-top "8px"}
    :rep-button  {:padding "2px 6px"
-                 :background (:bg-3 colors/tokens)
-                 :color (:text-primary colors/tokens)
-                 :border (str "1px solid " (:border-default colors/tokens))
+                 :background (:bg-3 rf.story.theme.colors/tokens)
+                 :color (:text-primary rf.story.theme.colors/tokens)
+                 :border (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                  :border-radius "3px"
                  :cursor "pointer"
-                 :font-size (:micro typography/type-scale)
+                 :font-size (:micro rf.story.theme.typography/type-scale)
                  :margin-left "4px"}
-   :empty       {:color (:text-tertiary colors/tokens) :font-style "italic"}
+   :empty       {:color (:text-tertiary rf.story.theme.colors/tokens) :font-style "italic"}
    ;; ---- validation, diff-from-saved, summarise-before-expand
    ;;
    ;; Inline schema error rendered under a control whose committed value
    ;; violates the component's Spec 010 schema. The danger-bg ground +
    ;; left rule mirror the schema-validation panel's `:violation` style so
    ;; the two surfaces read as one validation language.
-   :error       {:color (:danger colors/tokens)
-                 :background (:danger-bg colors/tokens)
-                 :border-left (str "3px solid " (:danger colors/tokens))
+   :error       {:color (:danger rf.story.theme.colors/tokens)
+                 :background (:danger-bg rf.story.theme.colors/tokens)
+                 :border-left (str "3px solid " (:danger rf.story.theme.colors/tokens))
                  :padding "2px 6px"
                  :margin-top "2px"
-                 :font-size (:micro typography/type-scale)}
+                 :font-size (:micro rf.story.theme.typography/type-scale)}
    ;; Panel-level banner shown when ≥1 committed arg violates the schema —
    ;; render / test proof is gated until the violation clears.
-   :banner      {:color (:danger colors/tokens)
-                 :background (:danger-bg colors/tokens)
-                 :border (str "1px solid " (:danger colors/tokens))
+   :banner      {:color (:danger rf.story.theme.colors/tokens)
+                 :background (:danger-bg rf.story.theme.colors/tokens)
+                 :border (str "1px solid " (:danger rf.story.theme.colors/tokens))
                  :border-radius "3px"
                  :padding "4px 6px"
                  :margin-bottom "6px"
-                 :font-size (:micro typography/type-scale)}
+                 :font-size (:micro rf.story.theme.typography/type-scale)}
    ;; The arg-changed-from-saved dot + per-arg reset affordance. The dot
    ;; is amber (Story's "work in progress" signal); the reset is a tight
    ;; inline glyph button sharing the rep-button ground.
    :diff-row    {:display "inline-flex"
                  :gap "4px"
                  :align-items "center"}
-   :diff-dot    {:color (:accent-amber colors/tokens)
+   :diff-dot    {:color (:accent-amber rf.story.theme.colors/tokens)
                  :font-weight "bold"
                  :title "changed from saved"}
    :reset-arg   {:padding "0 4px"
-                 :background (:bg-3 colors/tokens)
-                 :color (:text-secondary colors/tokens)
-                 :border (str "1px solid " (:border-default colors/tokens))
+                 :background (:bg-3 rf.story.theme.colors/tokens)
+                 :color (:text-secondary rf.story.theme.colors/tokens)
+                 :border (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                  :border-radius "3px"
                  :cursor "pointer"
-                 :font-size (:micro typography/type-scale)}
+                 :font-size (:micro rf.story.theme.typography/type-scale)}
    ;; The summarise-before-expand toggle for nested (group / repeater /
    ;; tuple) controls. The disclosure triangle + the one-line summary of
    ;; the collapsed value sit in the group header row (the
    ;; deep-controls perf risk in spec 019 §4).
    :disclosure  {:cursor "pointer"
                  :user-select "none"
-                 :color (:info colors/tokens)
+                 :color (:info rf.story.theme.colors/tokens)
                  :font-weight "bold"
                  :background "none"
                  :border "none"
                  :padding "0"
                  :font-family mono-stack
-                 :font-size (:caption typography/type-scale)
+                 :font-size (:caption rf.story.theme.typography/type-scale)
                  :text-align "left"}
-   :summary     {:color (:text-tertiary colors/tokens)
+   :summary     {:color (:text-tertiary rf.story.theme.colors/tokens)
                  :font-style "italic"
                  :margin-left "4px"
-                 :font-size (:micro typography/type-scale)}
+                 :font-size (:micro rf.story.theme.typography/type-scale)}
    ;; Flat-panel row cap (budgets/controls-flat-row-cap).
    ;; A controls panel whose top-level arg count exceeds the cap renders the
    ;; first `cap` rows and a "+N more" expander rather than flooding the
    ;; panel (spec/018 §10 — cap or page; fail by summarizing, not flooding).
    ;; Mirrors the sidebar's `:variant-more` affordance language.
    :more        {:padding "4px 0 2px"
-                 :color (:text-tertiary colors/tokens)
+                 :color (:text-tertiary rf.story.theme.colors/tokens)
                  :font-family mono-stack
-                 :font-size (:micro typography/type-scale)
+                 :font-size (:micro rf.story.theme.typography/type-scale)
                  :font-style "italic"
                  :background "none"
                  :border "none"

--- a/tools/story/src/re_frame/story/ui/dispatch_console.cljc
+++ b/tools/story/src/re_frame/story/ui/dispatch_console.cljc
@@ -88,12 +88,12 @@
   (:require [clojure.edn :as edn]
             [clojure.string :as str]
             #?(:cljs [reagent.core            :as r])
-            #?(:cljs [re-frame.router         :as router])
-            #?(:cljs [re-frame.story.config   :as config])
+            #?(:cljs [re-frame.router         :as rf.router])
+            #?(:cljs [re-frame.story.config   :as rf.story.config])
             #?(:cljs [re-frame.story.local-storage :refer [safe-local-storage]])
-            #?(:cljs [re-frame.story.ui.dispatch-console-events :as events])
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+            #?(:cljs [re-frame.story.ui.dispatch-console-events :as rf.story.ui.dispatch-console-events])
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---- pure: payload parsing -----------------------------------------------
 
@@ -496,8 +496,8 @@
             opts     (build-dispatch-opts variant-id cofx strict?)]
         (try
           (case kind
-            :dispatch      (router/dispatch!      event-vec opts)
-            :dispatch-sync (router/dispatch-sync! event-vec opts))
+            :dispatch      (rf.router/dispatch!      event-vec opts)
+            :dispatch-sync (rf.router/dispatch-sync! event-vec opts))
           (append-history!
             variant-id
             (build-history-entry event-id payload kind (now-ms) cofx))
@@ -574,15 +574,15 @@
    (def ^:private styles
      {:panel          {:padding "8px"
                        :font-family mono-stack
-                       :font-size (:caption typography/type-scale)
+                       :font-size (:caption rf.story.theme.typography/type-scale)
                        :border-top "1px solid #444"
-                       :background (:bg-canvas colors/tokens)
-                       :color (:text-primary colors/tokens)
+                       :background (:bg-canvas rf.story.theme.colors/tokens)
+                       :color (:text-primary rf.story.theme.colors/tokens)
                        :overflow "auto"
                        :max-height "320px"}
       :title          {:font-weight "bold"
                        :margin-bottom "6px"
-                       :color (:info colors/tokens)
+                       :color (:info rf.story.theme.colors/tokens)
                        :display "flex"
                        :justify-content "space-between"
                        :align-items "center"
@@ -595,53 +595,53 @@
                        :gap "6px"
                        :margin-bottom "4px"
                        :align-items "center"}
-      :label          {:color (:text-tertiary colors/tokens)
+      :label          {:color (:text-tertiary rf.story.theme.colors/tokens)
                        :width "70px"
                        :flex "0 0 70px"
-                       :font-size (:micro typography/type-scale)
+                       :font-size (:micro rf.story.theme.typography/type-scale)
                        :text-transform "uppercase"
                        :letter-spacing "0.5px"}
       :input          {:flex "1 1 auto"
-                       :background (:bg-2 colors/tokens)
+                       :background (:bg-2 rf.story.theme.colors/tokens)
                        :color "#d0d0d0"
                        :border "1px solid #444"
                        :border-radius "3px"
                        :padding "3px 6px"
                        :font-family mono-stack
-                       :font-size (:caption typography/type-scale)
+                       :font-size (:caption rf.story.theme.typography/type-scale)
                        :outline "none"}
       :btn-row        {:display "flex"
                        :gap "6px"
                        :margin "6px 0"}
       :btn            {:padding "3px 8px"
-                       :background (:bg-2 colors/tokens)
+                       :background (:bg-2 rf.story.theme.colors/tokens)
                        :color "#d0d0d0"
                        :border "1px solid #444"
                        :border-radius "3px"
                        :font-family mono-stack
-                       :font-size (:micro typography/type-scale)
+                       :font-size (:micro rf.story.theme.typography/type-scale)
                        :cursor "pointer"}
-      :btn-primary    {:background (:accent-amber colors/tokens)
+      :btn-primary    {:background (:accent-amber rf.story.theme.colors/tokens)
                        :color "white"
-                       :border-color (:accent-amber colors/tokens)}
-      :btn-secondary  {:background (:tag-dev-bg colors/tokens)
+                       :border-color (:accent-amber rf.story.theme.colors/tokens)}
+      :btn-secondary  {:background (:tag-dev-bg rf.story.theme.colors/tokens)
                        :color "white"
-                       :border-color (:tag-dev-bg colors/tokens)}
-      :error          {:color (:danger colors/tokens)
-                       :background (:danger-bg colors/tokens)
+                       :border-color (:tag-dev-bg rf.story.theme.colors/tokens)}
+      :error          {:color (:danger rf.story.theme.colors/tokens)
+                       :background (:danger-bg rf.story.theme.colors/tokens)
                        :border "1px solid #be4040"
                        :padding "4px 6px"
                        :margin "4px 0"
                        :border-radius "3px"
-                       :font-size (:micro typography/type-scale)}
-      :cofx-requires  {:color (:text-tertiary colors/tokens)
-                       :background (:bg-2 colors/tokens)
+                       :font-size (:micro rf.story.theme.typography/type-scale)}
+      :cofx-requires  {:color (:text-tertiary rf.story.theme.colors/tokens)
+                       :background (:bg-2 rf.story.theme.colors/tokens)
                        :border "1px dotted #4a4a4a"
                        :padding "3px 6px"
                        :margin "4px 0"
                        :border-radius "3px"
-                       :font-size (:micro typography/type-scale)}
-      :cofx-requires-id {:color (:warning colors/tokens)
+                       :font-size (:micro rf.story.theme.typography/type-scale)}
+      :cofx-requires-id {:color (:warning rf.story.theme.colors/tokens)
                          :margin-right "6px"}
       :ac-host        {:position "relative"}
       :ac-list        {:position "absolute"
@@ -651,7 +651,7 @@
                        :margin "2px 0 0 0"
                        :padding "0"
                        :list-style "none"
-                       :background (:bg-2 colors/tokens)
+                       :background (:bg-2 rf.story.theme.colors/tokens)
                        :border "1px solid #444"
                        :border-radius "3px"
                        :max-height "200px"
@@ -659,16 +659,16 @@
                        :z-index 100}
       :ac-item        {:padding "3px 6px"
                        :cursor "pointer"
-                       :color (:warning colors/tokens)}
-      :ac-item-hover  {:background (:bg-3 colors/tokens)}
+                       :color (:warning rf.story.theme.colors/tokens)}
+      :ac-item-hover  {:background (:bg-3 rf.story.theme.colors/tokens)}
       :history-host   {:max-height "160px"
                        :overflow-y "auto"
                        :border-top "1px dotted #333"
                        :padding-top "4px"
                        :margin-top "6px"}
-      :history-title  {:color (:text-tertiary colors/tokens)
+      :history-title  {:color (:text-tertiary rf.story.theme.colors/tokens)
                        :font-style "italic"
-                       :font-size (:micro typography/type-scale)
+                       :font-size (:micro rf.story.theme.typography/type-scale)
                        :margin-bottom "4px"}
       :history-row    {:display "grid"
                        :grid-template-columns "60px 1fr"
@@ -676,15 +676,15 @@
                        :padding "2px 0"
                        :cursor "pointer"
                        :border-bottom "1px dotted #2a2a2a"}
-      :history-time   {:color (:text-tertiary colors/tokens)
-                       :font-size (:micro typography/type-scale)}
-      :history-text   {:color (:warning colors/tokens)
+      :history-time   {:color (:text-tertiary rf.story.theme.colors/tokens)
+                       :font-size (:micro rf.story.theme.typography/type-scale)}
+      :history-text   {:color (:warning rf.story.theme.colors/tokens)
                        :overflow "hidden"
                        :text-overflow "ellipsis"
                        :white-space "nowrap"}
-      :empty          {:color (:text-tertiary colors/tokens)
+      :empty          {:color (:text-tertiary rf.story.theme.colors/tokens)
                        :font-style "italic"
-                       :font-size (:micro typography/type-scale)}}))
+                       :font-size (:micro rf.story.theme.typography/type-scale)}}))
 
 ;; ---- view (CLJS-only) ----------------------------------------------------
 
@@ -712,7 +712,7 @@
      [variant-id]
      (let [open?  (boolean (get-in @input-state [variant-id :autocomplete-open?]))
            prefix (get-input variant-id :event-id-input)
-           ids    (events/registered-event-ids)
+           ids    (rf.story.ui.dispatch-console-events/registered-event-ids)
            hits   (autocomplete-event-ids ids prefix 8)]
        (when (and open? (seq hits) (seq (str/trim (or prefix ""))))
          [:div {:style (:ac-host styles)}
@@ -740,7 +740,7 @@
      [variant-id]
      (let [eid      (selected-event-id (get-input variant-id :event-id-input))
            requires (when eid
-                      (events/cofx-requires-for (events/registered-event-meta) eid))]
+                      (rf.story.ui.dispatch-console-events/cofx-requires-for (rf.story.ui.dispatch-console-events/registered-event-meta) eid))]
        (when (seq requires)
          [:div {:style     (:cofx-requires styles)
                 :data-test "story-dispatch-console-cofx-requires"}

--- a/tools/story/src/re_frame/story/ui/dispatch_console_events.cljc
+++ b/tools/story/src/re_frame/story/ui/dispatch_console_events.cljc
@@ -56,7 +56,7 @@
   whatever snapshot the caller passes in. Production CLJS builds skip
   the panel entirely (per the shell's `config/enabled?` gate); the
   registrar query is never reached."
-  #?(:cljs (:require [re-frame.registrar :as registrar])))
+  #?(:cljs (:require [re-frame.registrar :as rf.registrar])))
 
 (defn registered-event-ids
   "Return the set of registered event-id keywords. Two arities:
@@ -65,7 +65,7 @@
   - 1-arity: take a `{event-id meta}` snapshot map and return its
     key-set. Used by tests + JVM coverage."
   ([]
-   #?(:cljs (set (keys (registrar/registrations :event)))
+   #?(:cljs (set (keys (rf.registrar/registrations :event)))
       :clj  #{}))
   ([registry-snapshot]
    (set (keys (or registry-snapshot {})))))
@@ -81,7 +81,7 @@
   selection / keystroke — same posture as `registered-event-ids` (a
   plain query fn, not a `reg-sub`)."
   []
-  #?(:cljs (registrar/registrations :event)
+  #?(:cljs (rf.registrar/registrations :event)
      :clj  {}))
 
 (defn- normalise-requires

--- a/tools/story/src/re_frame/story/ui/docs.cljc
+++ b/tools/story/src/re_frame/story/ui/docs.cljc
@@ -46,20 +46,20 @@
   walk. The shell's `main-pane` only reaches `docs-view` via the
   `(when config/enabled? ...)`-gated mount call, so production builds
   never invoke it — closure DCEs the lot."
-  (:require [re-frame.story.budgets    :as budgets]
-            [re-frame.story.predicates :as pred]
-            [re-frame.story.plan       :as plan]
-            [re-frame.story.registrar  :as registrar]
-            [re-frame.story.tags       :as tags]
-            [re-frame.story.ui.evidence-spine :as spine]
-            [re-frame.story.ui.markdown :as md]
-            [re-frame.story.ui.test-mode.pure :as test-pure]
+  (:require [re-frame.story.budgets    :as rf.story.budgets]
+            [re-frame.story.predicates :as rf.story.predicates]
+            [re-frame.story.plan       :as rf.story.plan]
+            [re-frame.story.registrar  :as rf.story.registrar]
+            [re-frame.story.tags       :as rf.story.tags]
+            [re-frame.story.ui.evidence-spine :as rf.story.ui.evidence-spine]
+            [re-frame.story.ui.markdown :as rf.story.ui.markdown]
+            [re-frame.story.ui.test-mode.pure :as rf.story.ui.test-mode.pure]
             #?@(:cljs [[reagent.core :as r]
-                       [re-frame.story.args :as args]
-                       [re-frame.story.decorators :as decorators]
-                       [re-frame.story.ui.state :as state]])
-            [re-frame.story.theme.typography :as typography :refer [sans-stack mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+                       [re-frame.story.args :as rf.story.args]
+                       [re-frame.story.decorators :as rf.story.decorators]
+                       [re-frame.story.ui.state :as rf.story.ui.state]])
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [sans-stack mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---- pure: prose lookup -------------------------------------------------
 
@@ -78,7 +78,7 @@
   per-workspace, and a workspace that mentions the variant earns its
   prose."
   [variant-id]
-  (let [workspaces (registrar/registrations :workspace)]
+  (let [workspaces (rf.story.registrar/registrations :workspace)]
     (vec
       (for [[wid body] (sort-by key workspaces)
             :when     (and (= :prose (:layout body))
@@ -104,10 +104,10 @@
 
   Pure data → data so the JVM test fixture can cover the merge."
   [variant-id resolved-args]
-  (let [vb       (registrar/handler-meta :variant variant-id)
+  (let [vb       (rf.story.registrar/handler-meta :variant variant-id)
         story-id (when (and (keyword? variant-id) (namespace variant-id))
                    (keyword (namespace variant-id)))
-        sb       (when story-id (registrar/handler-meta :story story-id))
+        sb       (when story-id (rf.story.registrar/handler-meta :story story-id))
         atypes   (merge (:argtypes sb) (:argtypes vb))]
     (vec
       (for [[k v] (sort-by key (or resolved-args {}))]
@@ -151,10 +151,10 @@
   Each row is `{:key :modes|:substrates|:platforms
                  :value <set-or-vector-as-string>}`."
   [variant-id]
-  (let [vb       (registrar/handler-meta :variant variant-id)
+  (let [vb       (rf.story.registrar/handler-meta :variant variant-id)
         story-id (when (and (keyword? variant-id) (namespace variant-id))
                    (keyword (namespace variant-id)))
-        sb       (when story-id (registrar/handler-meta :story story-id))
+        sb       (when story-id (rf.story.registrar/handler-meta :story story-id))
         get-eff  (fn [k] (or (get vb k) (get sb k)))]
     (vec
       (keep
@@ -172,12 +172,12 @@
   bottom-of-page tag picker — the SAME set the sidebar filter and
   `variants-with-tags` compute."
   [variant-id]
-  (vec (sort (tags/effective-tags
+  (vec (sort (rf.story.tags/effective-tags
                variant-id
-               {:variant #(registrar/handler-meta :variant %)
-                :story   #(registrar/handler-meta :story %)}))))
+               {:variant #(rf.story.registrar/handler-meta :variant %)
+                :story   #(rf.story.registrar/handler-meta :story %)}))))
 
-;; The header chips call `pred/parent-story-id` directly.
+;; The header chips call `rf.story.predicates/parent-story-id` directly.
 
 ;; ---- pure: status / fidelity / schema / evidence excerpt ----------------
 ;;
@@ -187,14 +187,14 @@
 ;; contract that load-bears this whole section: Docs and Test MUST agree
 ;; because they read the SAME plan/result. So:
 ;;
-;;   - the status verdict is `test-pure/run-status` over the SAME unified
+;;   - the status verdict is `rf.story.ui.test-mode.pure/run-status` over the SAME unified
 ;;     run-result Test mode wrote (the `evidence-spine/result-for` slot) —
 ;;     docs never re-runs the variant nor re-derives the verdict;
 ;;   - fidelity / world-input / runner-requirement come from the variant's
-;;     compiled PLAN (`plan/variant-plan`) — the same plan the runner builds,
+;;     compiled PLAN (`rf.story.plan/variant-plan`) — the same plan the runner builds,
 ;;     so the badges match what a run would rest on;
 ;;   - the evidence excerpt is a SPARSE projection of the SAME spine the
-;;     evidence-spine display renders (`spine/spine-spans`), capped to a couple
+;;     evidence-spine display renders (`rf.story.ui.evidence-spine/spine-spans`), capped to a couple
 ;;     of beats — a curated pointer, NOT a second evidence renderer (spec/022
 ;;     §2). The deep beat tree / app-db diff stays in Inspector/Xray, reached
 ;;     through the spine's focus links.
@@ -203,7 +203,7 @@
 ;; without booting Reagent / the runtime / Xray.
 
 (defn variant-plan-quietly
-  "Compile `variant-id` into its normalized plan (`plan/variant-plan`),
+  "Compile `variant-id` into its normalized plan (`rf.story.plan/variant-plan`),
   returning nil rather than throwing when compilation fails (an unknown
   variant, a malformed `:extends` chain, an invalid view-arg / sub-override
   value). Pure data → data. Docs is a read-only projection — a variant whose
@@ -212,12 +212,12 @@
   taking the whole pane down."
   [variant-id]
   (try
-    (plan/variant-plan variant-id)
+    (rf.story.plan/variant-plan variant-id)
     (catch #?(:clj Exception :cljs :default) _ nil)))
 
 (def fidelity-rungs
   "The fidelity-ladder rungs (highest → lowest, spec/017 §View-state
-  subscription overrides → `plan/compute-fidelity`). Pure data so the badge
+  subscription overrides → `rf.story.plan/compute-fidelity`). Pure data so the badge
   renderer can order + label the `:fidelity` SET a plan carries. A reviewer
   reads the rungs to know which evidence a variant's render rests on:
   `:real-setup` (real events) beats `:db-seed` (a schema-checked app-db seed)
@@ -271,7 +271,7 @@
   "Project the SAME unified run-result Test mode wrote into the compact
   status summary Docs shows (spec/022 §1 — a current test-status summary).
   Pure data → data. THE docs↔Test agreement point: the verdict is
-  `test-pure/run-status` over the result + its `aggregate-summary` fold, the
+  `rf.story.ui.test-mode.pure/run-status` over the result + its `aggregate-summary` fold, the
   EXACT projection Test mode's summary pill uses — so a tape-floor `:fail` /
   a `:cannot-run` refusal reads identically in Docs and Test, and Docs can
   never disagree with Test about whether a variant is green.
@@ -288,7 +288,7 @@
   and points at Test mode rather than fabricating a verdict."
   [result summary]
   (let [{:keys [passed failed cannot-run total]} (or summary {})
-        status (test-pure/run-status result summary)]
+        status (rf.story.ui.test-mode.pure/run-status result summary)]
     {:status     status
      :passed     (or passed 0)
      :failed     (or failed 0)
@@ -305,7 +305,7 @@
 
   Reads a top-level Malli `[:map …]` schema's entries; each row is
   `{:key … :required? <bool> :schema <entry-schema>}` (a non-`{:optional
-  true}` entry is required, mirroring `plan/validate-effective-args`'
+  true}` entry is required, mirroring `rf.story.plan/validate-effective-args`'
   required-key floor). A non-`[:map]` schema (or no schema on file) yields an
   empty vector — Docs omits the section rather than inventing a table."
   [plan]
@@ -331,12 +331,12 @@
 
   Single source of truth: `re-frame.story.budgets/evidence-gesture-budget`
   `:excerpt-beats` (X1 — the failure→evidence budget; spec/018 §10)."
-  (:excerpt-beats budgets/evidence-gesture-budget))
+  (:excerpt-beats rf.story.budgets/evidence-gesture-budget))
 
 (defn evidence-excerpt
   "Project the SAME spine the evidence-spine display renders into a SPARSE
   docs excerpt (spec/022 §2). Pure data → data. NOT a second evidence
-  renderer — a curated pointer: it reuses `spine/spine-spans` (the canonical
+  renderer — a curated pointer: it reuses `rf.story.ui.evidence-spine/spine-spans` (the canonical
   projection over the run's `:narrative`), flattens to the run's beats, and
   caps the inline excerpt to `evidence-excerpt-beat-cap` beats. Each excerpt
   beat carries only the compact, readable fields (its trigger / epoch /
@@ -354,7 +354,7 @@
   :more 0}` — Docs renders an honest 'no evidence yet' line pointing at Test
   mode, never a fabricated excerpt."
   [narrative]
-  (let [spans (spine/spine-spans narrative)
+  (let [spans (rf.story.ui.evidence-spine/spine-spans narrative)
         beats (vec (mapcat :beats spans))
         n     (count beats)]
     {:available? (pos? n)
@@ -369,86 +369,86 @@
      {:wrap          {:flex             "1"
                       :overflow         "auto"
                       :padding          "20px 28px"
-                      :background       (:bg-canvas colors/tokens)
-                      :color            (:text-primary colors/tokens)
+                      :background       (:bg-canvas rf.story.theme.colors/tokens)
+                      :color            (:text-primary rf.story.theme.colors/tokens)
                       :font-family      sans-stack
-                      :font-size        (:body typography/type-scale)
+                      :font-size        (:body rf.story.theme.typography/type-scale)
                       :line-height      "1.5"}
       :h1            {:font-family      mono-stack
-                      :font-size        (:display typography/type-scale)
+                      :font-size        (:display rf.story.theme.typography/type-scale)
                       :font-weight      "bold"
                       :color            "white"
                       :margin           "0 0 4px 0"}
-      :sub           {:color            (:text-secondary colors/tokens)
+      :sub           {:color            (:text-secondary rf.story.theme.colors/tokens)
                       :font-family      mono-stack
-                      :font-size        (:caption typography/type-scale)
+                      :font-size        (:caption rf.story.theme.typography/type-scale)
                       :margin-bottom    "10px"}
       :section       {:margin-top       "24px"}
       :section-h     {:font-weight      "bold"
-                      :color            (:text-secondary colors/tokens)
+                      :color            (:text-secondary rf.story.theme.colors/tokens)
                       :text-transform   "uppercase"
-                      :font-size        (:micro typography/type-scale)
+                      :font-size        (:micro rf.story.theme.typography/type-scale)
                       :letter-spacing   "0.5px"
                       :margin-bottom    "8px"
                       :border-bottom    "1px solid #444"
                       :padding-bottom   "4px"}
-      :doc-blurb     {:color            (:text-secondary colors/tokens)
+      :doc-blurb     {:color            (:text-secondary rf.story.theme.colors/tokens)
                       :font-style       "italic"
                       :margin           "4px 0 12px 0"}
       :prose-block   {:padding          "12px 16px"
                       :margin-bottom    "8px"
-                      :background       (:bg-2 colors/tokens)
+                      :background       (:bg-2 rf.story.theme.colors/tokens)
                       :border-left      "3px solid #0e639c"
-                      :color            (:text-primary colors/tokens)
+                      :color            (:text-primary rf.story.theme.colors/tokens)
                       :font-family      sans-stack}
-      :prose-source  {:color            (:text-secondary colors/tokens)
+      :prose-source  {:color            (:text-secondary rf.story.theme.colors/tokens)
                       :font-family      mono-stack
-                      :font-size        (:micro typography/type-scale)
+                      :font-size        (:micro rf.story.theme.typography/type-scale)
                       :margin-bottom    "4px"}
       :table         {:width            "100%"
                       :border-collapse  "collapse"
                       :font-family      mono-stack
-                      :font-size        (:caption typography/type-scale)}
+                      :font-size        (:caption rf.story.theme.typography/type-scale)}
       :th            {:text-align       "left"
                       :padding          "6px 8px"
-                      :background       (:bg-2 colors/tokens)
-                      :color            (:text-secondary colors/tokens)
+                      :background       (:bg-2 rf.story.theme.colors/tokens)
+                      :color            (:text-secondary rf.story.theme.colors/tokens)
                       :border-bottom    "1px solid #444"
                       :text-transform   "uppercase"
-                      :font-size        (:micro typography/type-scale)
+                      :font-size        (:micro rf.story.theme.typography/type-scale)
                       :letter-spacing   "0.5px"}
       :td            {:padding          "6px 8px"
                       :border-bottom    "1px solid #2d2d30"
-                      :color            (:text-primary colors/tokens)
+                      :color            (:text-primary rf.story.theme.colors/tokens)
                       :vertical-align   "top"}
-      :td-key        {:color            (:info colors/tokens)
+      :td-key        {:color            (:info rf.story.theme.colors/tokens)
                       :white-space      "nowrap"}
-      :td-value      {:color            (:tag-experimental-fg colors/tokens)
+      :td-value      {:color            (:tag-experimental-fg rf.story.theme.colors/tokens)
                       :font-family      mono-stack
                       :white-space      "pre-wrap"}
-      :td-doc        {:color            (:text-secondary colors/tokens)
+      :td-doc        {:color            (:text-secondary rf.story.theme.colors/tokens)
                       :font-style       "italic"}
-      :section-h-row {:background       (:bg-3 colors/tokens)
-                      :color            (:text-secondary colors/tokens)
+      :section-h-row {:background       (:bg-3 rf.story.theme.colors/tokens)
+                      :color            (:text-secondary rf.story.theme.colors/tokens)
                       :text-transform   "uppercase"
-                      :font-size        (:micro typography/type-scale)
+                      :font-size        (:micro rf.story.theme.typography/type-scale)
                       :letter-spacing   "0.5px"}
       :chip-row      {:display          "flex"
                       :flex-wrap        "wrap"
                       :gap              "6px"
                       :margin-top       "4px"}
       :chip          {:padding          "3px 9px"
-                      :background       (:bg-3 colors/tokens)
-                      :color            (:text-primary colors/tokens)
+                      :background       (:bg-3 rf.story.theme.colors/tokens)
+                      :color            (:text-primary rf.story.theme.colors/tokens)
                       :border           "none"
                       :border-radius    "10px"
                       :cursor           "pointer"
                       :font-family      mono-stack
-                      :font-size        (:micro typography/type-scale)
+                      :font-size        (:micro rf.story.theme.typography/type-scale)
                       :user-select      "none"}
-      :chip-active   {:background       (:accent-amber colors/tokens)
+      :chip-active   {:background       (:accent-amber rf.story.theme.colors/tokens)
                       :color            "white"}
-      :empty         {:color            (:text-tertiary colors/tokens)
+      :empty         {:color            (:text-tertiary rf.story.theme.colors/tokens)
                       :font-style       "italic"
                       :padding          "6px 0"}
       ;; ---- status / fidelity / evidence excerpt (spec/022) ----
@@ -460,84 +460,84 @@
       :status-pill   {:padding          "3px 10px"
                       :border-radius    "10px"
                       :font-family      mono-stack
-                      :font-size        (:caption typography/type-scale)
+                      :font-size        (:caption rf.story.theme.typography/type-scale)
                       :font-weight      "bold"
                       :text-transform   "uppercase"
                       :letter-spacing   "0.5px"}
-      :status-pass   {:background       (:success-bg colors/tokens)
-                      :color            (:success colors/tokens)}
-      :status-fail   {:background       (:danger-bg colors/tokens)
-                      :color            (:danger colors/tokens)}
-      :status-error  {:background       (:danger-bg colors/tokens)
-                      :color            (:danger colors/tokens)
-                      :border           (str "1px solid " (:danger colors/tokens))}
-      :status-cannot {:background       (:warning-bg colors/tokens)
-                      :color            (:warning colors/tokens)}
-      :status-pending {:background      (:bg-3 colors/tokens)
-                       :color           (:text-tertiary colors/tokens)}
-      :status-counts {:color            (:text-secondary colors/tokens)
+      :status-pass   {:background       (:success-bg rf.story.theme.colors/tokens)
+                      :color            (:success rf.story.theme.colors/tokens)}
+      :status-fail   {:background       (:danger-bg rf.story.theme.colors/tokens)
+                      :color            (:danger rf.story.theme.colors/tokens)}
+      :status-error  {:background       (:danger-bg rf.story.theme.colors/tokens)
+                      :color            (:danger rf.story.theme.colors/tokens)
+                      :border           (str "1px solid " (:danger rf.story.theme.colors/tokens))}
+      :status-cannot {:background       (:warning-bg rf.story.theme.colors/tokens)
+                      :color            (:warning rf.story.theme.colors/tokens)}
+      :status-pending {:background      (:bg-3 rf.story.theme.colors/tokens)
+                       :color           (:text-tertiary rf.story.theme.colors/tokens)}
+      :status-counts {:color            (:text-secondary rf.story.theme.colors/tokens)
                       :font-family      mono-stack
-                      :font-size        (:caption typography/type-scale)}
-      :label-key     {:color            (:text-tertiary colors/tokens)
+                      :font-size        (:caption rf.story.theme.typography/type-scale)}
+      :label-key     {:color            (:text-tertiary rf.story.theme.colors/tokens)
                       :font-family      mono-stack
-                      :font-size        (:micro typography/type-scale)
+                      :font-size        (:micro rf.story.theme.typography/type-scale)
                       :text-transform   "uppercase"
                       :letter-spacing   "0.4px"
                       :margin-right     "2px"}
       :badge         {:padding          "2px 8px"
                       :border-radius    "8px"
                       :font-family      mono-stack
-                      :font-size        (:micro typography/type-scale)
-                      :background       (:bg-3 colors/tokens)
-                      :color            (:text-secondary colors/tokens)
-                      :border           (str "1px solid " (:border-subtle colors/tokens))}
-      :badge-high    {:background       (:success-bg colors/tokens)
-                      :color            (:success colors/tokens)}
-      :badge-mid     {:background       (:info-bg colors/tokens)
-                      :color            (:info colors/tokens)}
-      :badge-low     {:background       (:warning-bg colors/tokens)
-                      :color            (:warning colors/tokens)}
+                      :font-size        (:micro rf.story.theme.typography/type-scale)
+                      :background       (:bg-3 rf.story.theme.colors/tokens)
+                      :color            (:text-secondary rf.story.theme.colors/tokens)
+                      :border           (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))}
+      :badge-high    {:background       (:success-bg rf.story.theme.colors/tokens)
+                      :color            (:success rf.story.theme.colors/tokens)}
+      :badge-mid     {:background       (:info-bg rf.story.theme.colors/tokens)
+                      :color            (:info rf.story.theme.colors/tokens)}
+      :badge-low     {:background       (:warning-bg rf.story.theme.colors/tokens)
+                      :color            (:warning rf.story.theme.colors/tokens)}
       :badge-absent  {:background       "transparent"
-                      :color            (:text-tertiary colors/tokens)
-                      :border           (str "1px dashed " (:border-subtle colors/tokens))
+                      :color            (:text-tertiary rf.story.theme.colors/tokens)
+                      :border           (str "1px dashed " (:border-subtle rf.story.theme.colors/tokens))
                       :opacity          "0.7"}
       :runner-chip   {:padding          "2px 8px"
                       :border-radius    "3px"
                       :font-family      mono-stack
-                      :font-size        (:micro typography/type-scale)
-                      :background       (:bg-3 colors/tokens)
-                      :color            (:text-primary colors/tokens)}
+                      :font-size        (:micro rf.story.theme.typography/type-scale)
+                      :background       (:bg-3 rf.story.theme.colors/tokens)
+                      :color            (:text-primary rf.story.theme.colors/tokens)}
       :excerpt-beat  {:display          "flex"
                       :flex-direction   "column"
                       :gap              "3px"
                       :padding          "8px 10px"
                       :margin-bottom    "6px"
                       :border-radius    "4px"
-                      :background       (:bg-2 colors/tokens)
-                      :border-left      (str "3px solid " (:border-subtle colors/tokens))}
+                      :background       (:bg-2 rf.story.theme.colors/tokens)
+                      :border-left      (str "3px solid " (:border-subtle rf.story.theme.colors/tokens))}
       :excerpt-h     {:display          "flex"
                       :align-items      "baseline"
                       :gap              "8px"
                       :flex-wrap        "wrap"}
       :excerpt-trig  {:font-family      mono-stack
-                      :font-size        (:caption typography/type-scale)
-                      :color            (:text-primary colors/tokens)
+                      :font-size        (:caption rf.story.theme.typography/type-scale)
+                      :color            (:text-primary rf.story.theme.colors/tokens)
                       :word-break       "break-all"}
       :excerpt-epoch {:font-family      mono-stack
-                      :font-size        (:micro typography/type-scale)
-                      :color            (:text-tertiary colors/tokens)}
+                      :font-size        (:micro rf.story.theme.typography/type-scale)
+                      :color            (:text-tertiary rf.story.theme.colors/tokens)}
       :excerpt-link  {:font-family      sans-stack
-                      :font-size        (:caption typography/type-scale)
-                      :background       (:bg-3 colors/tokens)
-                      :color            (:info colors/tokens)
-                      :border           (str "1px solid " (:border-default colors/tokens))
+                      :font-size        (:caption rf.story.theme.typography/type-scale)
+                      :background       (:bg-3 rf.story.theme.colors/tokens)
+                      :color            (:info rf.story.theme.colors/tokens)
+                      :border           (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                       :border-radius    "6px"
                       :padding          "3px 10px"
                       :cursor           "pointer"
                       :user-select      "none"}
-      :excerpt-more  {:color            (:text-tertiary colors/tokens)
+      :excerpt-more  {:color            (:text-tertiary rf.story.theme.colors/tokens)
                       :font-style       "italic"
-                      :font-size        (:caption typography/type-scale)
+                      :font-size        (:caption rf.story.theme.typography/type-scale)
                       :margin-top       "4px"}}))
 
 #?(:cljs
@@ -556,12 +556,12 @@
      "Render the variant header — id, parent story, tags as chips that
      forward-link to the sidebar tag filter."
      [variant-id]
-     (let [shell      @state/shell-state-atom
+     (let [shell      @rf.story.ui.state/shell-state-atom
            tag-filter (or (:tag-filter shell) #{})
            tags       (variant-tags variant-id)
-           vb         (registrar/handler-meta :variant variant-id)
-           story-id   (pred/parent-story-id variant-id)
-           sb         (when story-id (registrar/handler-meta :story story-id))
+           vb         (rf.story.registrar/handler-meta :variant variant-id)
+           story-id   (rf.story.predicates/parent-story-id variant-id)
+           sb         (when story-id (rf.story.registrar/handler-meta :story story-id))
            vdoc       (:doc vb)
            sdoc       (:doc sb)]
        [:div
@@ -587,7 +587,7 @@
                :title           (str "Toggle tag filter for " tag)
                :on-click
                (fn [_]
-                 (state/swap-state! state/toggle-tag-filter tag))}
+                 (rf.story.ui.state/swap-state! rf.story.ui.state/toggle-tag-filter tag))}
               (str tag)])])
         (when (or (seq vdoc) (seq sdoc))
           [:div {:style     (:doc-blurb styles)
@@ -613,15 +613,15 @@
               (str "from " workspace-id)]
              [:div {:style     (:prose-block styles)
                     :data-test "story-docs-prose-rendered"}
-              (md/parse body)]])]))))
+              (rf.story.ui.markdown/parse body)]])]))))
 
 #?(:cljs
    (defn- args-section
      "Args table — every resolved arg with default + :doc (when an
      `:argtypes` entry exists)."
      [variant-id]
-     (let [shell    @state/shell-state-atom
-           eff-args (args/resolve-args
+     (let [shell    @rf.story.ui.state/shell-state-atom
+           eff-args (rf.story.args/resolve-args
                       variant-id
                       {:active-modes (:active-modes shell)
                        ;; :docs is read-only — overrides are deliberately
@@ -659,13 +659,13 @@
      in apply-order. Story-level decorators come first per
      `resolve-decorators` semantics."
      [variant-id]
-     (let [shell @state/shell-state-atom
+     (let [shell @rf.story.ui.state/shell-state-atom
            ;; Thread the active-modes into `resolve-decorators`
            ;; so the plan recompile substitutes `[:arg]` keys resolvable
            ;; only through a mode layer. Mirrors `args-section` (docs is
            ;; read-only — overrides deliberately excluded; the variant's
            ;; declared shape, mode-aware, is what the docs surface shows).
-           pack (decorators/resolve-decorators
+           pack (rf.story.decorators/resolve-decorators
                   variant-id
                   {:active-modes (:active-modes shell) :cell-overrides nil})
            rows (decorator-rows pack)]
@@ -729,10 +729,10 @@
      "Bottom tag picker — clickable chips that forward-link into the
      sidebar tag filter. Re-uses the controls-panel chip style so the
      surface feels familiar; selecting a chip dispatches
-     `state/toggle-tag-filter` and the sidebar re-renders with the
+     `rf.story.ui.state/toggle-tag-filter` and the sidebar re-renders with the
      constrained tree."
      [variant-id]
-     (let [shell      @state/shell-state-atom
+     (let [shell      @rf.story.ui.state/shell-state-atom
            tag-filter (or (:tag-filter shell) #{})
            tags       (variant-tags variant-id)]
        [:div {:style     (:section styles)
@@ -755,7 +755,7 @@
                :title          (str "Toggle tag filter for " tag)
                :on-click
                (fn [_]
-                 (state/swap-state! state/toggle-tag-filter tag))}
+                 (rf.story.ui.state/swap-state! rf.story.ui.state/toggle-tag-filter tag))}
               (str tag)])])])))
 
 #?(:cljs
@@ -794,14 +794,14 @@
    (defn- status-fidelity-section
      "Status + fidelity + world-input + runner-requirement summary (spec/022
      §1). The status verdict is `status-summary` over the SAME unified
-     run-result Test mode wrote (`spine/result-for`) — Docs and Test agree by
+     run-result Test mode wrote (`rf.story.ui.evidence-spine/result-for`) — Docs and Test agree by
      reading one result, not two. Fidelity badges / world-input chips /
      runner-requirement chips come from the variant's compiled PLAN, the same
      plan the runner builds. Read-only — a curated status snapshot, not a
      control surface; the Re-run affordance lives in Test mode."
      [variant-id plan]
-     (let [result   (spine/result-for variant-id)
-           summary  (state/aggregate-summary (:assertions result))
+     (let [result   (rf.story.ui.evidence-spine/result-for variant-id)
+           summary  (rf.story.ui.state/aggregate-summary (:assertions result))
            status   (status-summary result summary)
            badges   (fidelity-badges plan)
            worlds   (world-input-chips plan)
@@ -891,7 +891,7 @@
      "Render ONE sparse excerpt beat — the trigger event, its epoch, the
      evidence-strength tags, and the compact summary chips, plus a single
      'Open in Inspector' focus link. Reuses the evidence-spine's
-     `strength`/`summary` projection (decorated by `spine/spine-spans`) and
+     `strength`/`summary` projection (decorated by `rf.story.ui.evidence-spine/spine-spans`) and
      its `focus-beat!` side effect — Docs LINKS into the spine/Xray, it never
      rebuilds the beat tree."
      [variant-id beat]
@@ -929,21 +929,21 @@
                                 "Open the Xray Inspector (no epoch pin for this beat)")
                    :on-click  (fn [e]
                                 (.stopPropagation e)
-                                (spine/focus-beat! variant-id beat spine/default-focus-panel))}
+                                (rf.story.ui.evidence-spine/focus-beat! variant-id beat rf.story.ui.evidence-spine/default-focus-panel))}
           "Inspect in Xray"]])]))
 
 #?(:cljs
    (defn- evidence-excerpt-section
      "Sparse evidence excerpt (spec/022 §2). Reads the SAME run-result Test
-     mode wrote (`spine/result-for`) and projects a couple of leading
+     mode wrote (`rf.story.ui.evidence-spine/result-for`) and projects a couple of leading
      narrative beats through `evidence-excerpt` — a curated pointer into the
      evidence spine, NOT a debugging log. Detailed diagnostics (the full beat
      tree, app-db diff, trace) live in the Inspector / Xray, reached through
-     the 'Open full evidence' link (`spine/open!`) and the spine's own focus
+     the 'Open full evidence' link (`rf.story.ui.evidence-spine/open!`) and the spine's own focus
      links. When the variant has not been run (or retained no narrative) the
      section reads an honest 'no evidence yet' line pointing at Test mode."
      [variant-id]
-     (let [result    (spine/result-for variant-id)
+     (let [result    (rf.story.ui.evidence-spine/result-for variant-id)
            narrative (:narrative result)
            {:keys [available? beats beat-count more]} (evidence-excerpt narrative)]
        [:div {:style     (:section styles)
@@ -970,7 +970,7 @@
             [:button {:style     (:excerpt-link styles)
                       :data-test "story-docs-evidence-open"
                       :title     "Open the full evidence spine in the Inspector"
-                      :on-click  (fn [_] (spine/open! variant-id nil))}
+                      :on-click  (fn [_] (rf.story.ui.evidence-spine/open! variant-id nil))}
              "Open full evidence in Inspector"]]])])))
 
 ;; ---- pure: TOC entries --------------------------------------------------
@@ -1030,14 +1030,14 @@
                     :flex-shrink "0"
                     :padding "12px 12px 12px 16px"
                     :margin-left "20px"
-                    :border-left (str "1px solid " (:border-subtle colors/tokens))
+                    :border-left (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
                     :font-family sans-stack
-                    :font-size (:nano typography/type-scale)
-                    :color (:text-secondary colors/tokens)}
+                    :font-size (:nano rf.story.theme.typography/type-scale)
+                    :color (:text-secondary rf.story.theme.colors/tokens)}
       :label      {:text-transform "uppercase"
                    :letter-spacing "0.08em"
-                   :color (:text-tertiary colors/tokens)
-                   :font-size (:nano typography/type-scale)
+                   :color (:text-tertiary rf.story.theme.colors/tokens)
+                   :font-size (:nano rf.story.theme.typography/type-scale)
                    :margin-bottom "6px"}
       :list       {:list-style "none"
                    :margin 0
@@ -1051,11 +1051,11 @@
                    :background "transparent"
                    :border "none"
                    :text-align "left"
-                   :color (:text-secondary colors/tokens)
+                   :color (:text-secondary rf.story.theme.colors/tokens)
                    :font-family sans-stack
-                   :font-size (:caption typography/type-scale)}
-      :item-active {:background (:accent-amber-soft colors/tokens)
-                    :color (:accent-amber colors/tokens)}}))
+                   :font-size (:caption rf.story.theme.typography/type-scale)}
+      :item-active {:background (:accent-amber-soft rf.story.theme.colors/tokens)
+                    :color (:accent-amber rf.story.theme.colors/tokens)}}))
 
 #?(:cljs
    (defn- jump-to-anchor!
@@ -1151,7 +1151,7 @@
          [:div {:style     {:display "flex"
                             :flex "1"
                             :overflow "auto"
-                            :background (:bg-canvas colors/tokens)}
+                            :background (:bg-canvas rf.story.theme.colors/tokens)}
                 :data-test "story-docs-layout"}
           [:section {:style     (:wrap styles)
                      :data-test "story-docs-view"
@@ -1186,14 +1186,14 @@
   under `story-id`. The sort gives the rollup page a stable order even
   when hot-reload re-registers variants in non-source-order."
   [story-id]
-  (vec (sort (registrar/variants-of story-id))))
+  (vec (sort (rf.story.registrar/variants-of story-id))))
 
 #?(:cljs
    (defn- rollup-header
      "Top of the rollup page — story id as h1, the story's :doc blurb,
      a count of variants."
      [story-id variant-ids]
-     (let [sb   (registrar/handler-meta :story story-id)
+     (let [sb   (rf.story.registrar/handler-meta :story story-id)
            sdoc (:doc sb)]
        [:div {:data-test "story-docs-rollup-header"}
         [:h1 {:style (:h1 styles)}
@@ -1223,7 +1223,7 @@
               :data-test "story-docs-rollup-variant"
               :data-variant-id (str variant-id)}
         [:h2 {:style (merge (:h1 styles)
-                            {:font-size (:body typography/type-scale)
+                            {:font-size (:body rf.story.theme.typography/type-scale)
                              :margin-top "0"})}
          (str variant-id)]
         (when plan [status-fidelity-section variant-id plan])

--- a/tools/story/src/re_frame/story/ui/element_inspector.cljc
+++ b/tools/story/src/re_frame/story/ui/element_inspector.cljc
@@ -39,7 +39,7 @@
   - **Click**: when inspect mode is on, the click handler intercepts
     (capture-phase, `stopPropagation` + `preventDefault`) so the
     variant's own onClick handlers don't fire. The resolved coord is
-    handed to `open-in-editor/open-source-coord!` — same launcher the
+    handed to `rf.story.ui.open-in-editor/open-source-coord!` — same launcher the
     chip uses.
   - **Esc**: a keydown listener exits inspect mode + clears hover state.
 
@@ -50,7 +50,7 @@
   shared `ui/canvas-listeners` lifecycle uses for its installed-root
   ref) avoids the latency + overhead of routing every mousemove through
   dispatch. Click DOES route through
-  `open-in-editor/open-source-coord!` so the launcher + allowlist gate
+  `rf.story.ui.open-in-editor/open-source-coord!` so the launcher + allowlist gate
   stay the single source of truth.
 
   ## Bundle isolation + production elision
@@ -61,13 +61,13 @@
   attribute it reads is itself dev-only (elides via
   `interop/debug-enabled?`) — under prod the inspector would find no
   matches and click would no-op. Per Spec 009 §Production builds."
-  (:require [re-frame.source-coords :as source-coords]
+  (:require [re-frame.source-coords :as rf.source-coords]
             #?@(:cljs [[reagent.core :as r]
                        [re-frame.core :as rf]
-                       [re-frame.story.ui.canvas-listeners :as canvas-listeners]
-                       [re-frame.story.ui.open-in-editor :as open-in-editor]])
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+                       [re-frame.story.ui.canvas-listeners :as rf.story.ui.canvas-listeners]
+                       [re-frame.story.ui.open-in-editor :as rf.story.ui.open-in-editor]])
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---- per-process state ---------------------------------------------------
 ;;
@@ -104,7 +104,7 @@
   one canonical parser also backs the re-frame2-pair preload runtime.
   Returns nil for malformed input (too few / too many segments, empty ns or
   handler-id, non-string input). Never throws."
-  source-coords/parse-source-coord)
+  rf.source-coords/parse-source-coord)
 
 (defn coord->handler-keyword
   "Build the registered view id keyword from a parsed coord. Returns nil
@@ -128,7 +128,7 @@
      [parsed]
      (when-let [view-id (coord->handler-keyword parsed)]
        (let [meta (rf/handler-meta :view view-id)
-             err  (source-coords/error-coords-for :view view-id)
+             err  (rf.source-coords/error-coords-for :view view-id)
              file (or (:file meta) (:file err))]
          {:file   file
           :line   (or (:line parsed) (:line meta) (:line err) 1)
@@ -265,7 +265,7 @@
            (let [attr   (.getAttribute ancestor "data-rf2-source-coord")
                  parsed (parse-coord attr)]
              (when-let [coord (resolve-source-coord parsed)]
-               (open-in-editor/open-source-coord! coord)))))
+               (rf.story.ui.open-in-editor/open-source-coord! coord)))))
        ;; Exit inspect mode after a successful pick — matches React
        ;; Devtools' "pick once" gesture. The user re-clicks the chip
        ;; to start another pick.
@@ -316,7 +316,7 @@
 
 #?(:cljs
    (def ^:private lifecycle
-     (canvas-listeners/make-lifecycle installed-root attach-listeners! detach-listeners!)))
+     (rf.story.ui.canvas-listeners/make-lifecycle installed-root attach-listeners! detach-listeners!)))
 
 #?(:cljs
    (defn install!
@@ -356,32 +356,32 @@
    :tooltip {:position       "fixed"
              :pointer-events "none"
              :z-index        "1000000"
-             :background     (:bg-canvas colors/tokens)
-             :color          (:text-primary colors/tokens)
+             :background     (:bg-canvas rf.story.theme.colors/tokens)
+             :color          (:text-primary rf.story.theme.colors/tokens)
              :border         "1px solid #444"
              :border-radius  "3px"
              :padding        "3px 8px"
              :font-family    mono-stack
-             :font-size      (:caption typography/type-scale)
+             :font-size      (:caption rf.story.theme.typography/type-scale)
              :white-space    "nowrap"
              :box-shadow     "0 2px 8px rgba(0,0,0,0.4)"}
    :chip-on    {:padding         "3px 8px"
-                :background      (:accent-amber colors/tokens)
+                :background      (:accent-amber rf.story.theme.colors/tokens)
                 :color           "white"
                 :border          "none"
                 :border-radius   "10px"
                 :cursor          "pointer"
                 :font-family     mono-stack
-                :font-size       (:caption typography/type-scale)
+                :font-size       (:caption rf.story.theme.typography/type-scale)
                 :user-select     "none"}
    :chip-off   {:padding         "3px 8px"
-                :background      (:bg-3 colors/tokens)
-                :color           (:text-primary colors/tokens)
+                :background      (:bg-3 rf.story.theme.colors/tokens)
+                :color           (:text-primary rf.story.theme.colors/tokens)
                 :border          "none"
                 :border-radius   "10px"
                 :cursor          "pointer"
                 :font-family     mono-stack
-                :font-size       (:caption typography/type-scale)
+                :font-size       (:caption rf.story.theme.typography/type-scale)
                 :user-select     "none"}})
 
 #?(:cljs

--- a/tools/story/src/re_frame/story/ui/evidence_spine.cljc
+++ b/tools/story/src/re_frame/story/ui/evidence_spine.cljc
@@ -77,17 +77,17 @@
 
   ## Elision
 
-  CLJS rendering reaches the spine only via the `config/enabled?`-gated
+  CLJS rendering reaches the spine only via the `rf.story.config/enabled?`-gated
   shell mount, so production builds never invoke it; closure DCEs the lot."
-  (:require [re-frame.story.play.evidence :as evidence]
+  (:require [re-frame.story.play.evidence :as rf.story.play.evidence]
             #?@(:cljs [[reagent.core :as r]
-                       [re-frame.story.config :as config]
-                       [re-frame.story.review-dialog :as review-dialog]
-                       [re-frame.story.ui.state :as state]
-                       [re-frame.story.ui.test-mode.state :as test-state]
+                       [re-frame.story.config :as rf.story.config]
+                       [re-frame.story.review-dialog :as rf.story.review-dialog]
+                       [re-frame.story.ui.state :as rf.story.ui.state]
+                       [re-frame.story.ui.test-mode.state :as rf.story.ui.test-mode.state]
                        [day8.re-frame2-xray.core :as xray-core]
-                       [re-frame.story.theme.typography :as typography :refer [sans-stack mono-stack]]
-                       [re-frame.story.theme.colors :as colors]])))
+                       [re-frame.story.theme.typography :as rf.story.theme.typography :refer [sans-stack mono-stack]]
+                       [re-frame.story.theme.colors :as rf.story.theme.colors]])))
 
 ;; ===========================================================================
 ;; THE PANEL VOCABULARY  (the host-facing focus-panel ids — spec/020 §2.1)
@@ -140,7 +140,7 @@
   carry both, and the renderer labels each present strength distinctly so
   attributed evidence is never presented as direct.
 
-  Note the db test compares VALUES, not key presence: `evidence/epoch-beat`
+  Note the db test compares VALUES, not key presence: `rf.story.play.evidence/epoch-beat`
   ALWAYS materializes `:db-before` / `:db-after` (they sit in its base map,
   not its `cond->` tail), so `contains?` would read true for every projected
   beat — including a read-only dispatch that changed nothing. A beat counts
@@ -170,7 +170,7 @@
 
   `:schemas` is the count of `:rf.error/schema-validation-failure` trace
   events in the beat — a derived count over the SAME `:trace-events` slot
-  the agreement-floor projection reads (`evidence/schema-violation-trace?`),
+  the agreement-floor projection reads (`rf.story.play.evidence/schema-violation-trace?`),
   so the spine and the test pane agree about how many violations a beat
   carries.
 
@@ -178,11 +178,11 @@
   transition (its `:db-before` / `:db-after` values DIFFER) or it did not.
   The rendered shape `db Δ` reads as 'app-db changed at this beat' rather
   than inventing a diff (the diff itself is Xray's, surfaced via focus).
-  The test compares values, not key presence: `evidence/epoch-beat` always
+  The test compares values, not key presence: `rf.story.play.evidence/epoch-beat` always
   materializes both keys, so a key-presence test would show the `db Δ` chip
   on every beat — even a dispatch that changed nothing."
   [beat]
-  (let [schema-n (count (filter evidence/schema-violation-trace?
+  (let [schema-n (count (filter rf.story.play.evidence/schema-violation-trace?
                                 (:trace-events beat)))
         db?      (not= (:db-before beat) (:db-after beat))
         entries  [{:k :db       :label "db Δ"     :count (if db? 1 0) :strength :direct}
@@ -208,12 +208,12 @@
   them as causally equivalent to dispatch spans — so the renderer can mark
   a beatless span as 'this step committed no epoch' rather than reading as
   'this dispatch produced nothing'. A span whose step IS a dispatch step
-  (`evidence/dispatch-step?`) but committed no epoch is still `:dispatch`
+  (`rf.story.play.evidence/dispatch-step?`) but committed no epoch is still `:dispatch`
   (it tried to dispatch); the empty-beats marker is the renderer's job."
   [{:keys [step] :as _span}]
   (cond
     (nil? step)                       :setup
-    (evidence/dispatch-step? step)    :dispatch
+    (rf.story.play.evidence/dispatch-step? step)    :dispatch
     :else                             :non-dispatch))
 
 (defn step-label
@@ -352,7 +352,7 @@
        :beat-count <int>        ; epochs the span committed
        :beats    [<beat-row> …]}
 
-  Each beat-row is the flattened `evidence/narrative-beats` beat augmented
+  Each beat-row is the flattened `rf.story.play.evidence/narrative-beats` beat augmented
   with:
 
       {:strength {:direct? … :attributed? …}   ; spec/020 §3 evidence strength
@@ -361,13 +361,13 @@
        :focus    {:precise? … :reason …}}      ; can a precise focus pin?
 
   The beats are the SAME flattened, addressable sequence the scrub backbone
-  walks (`evidence/narrative-beats`) — the spine never re-implements the
+  walks (`rf.story.play.evidence/narrative-beats`) — the spine never re-implements the
   flatten; it decorates the canonical projection. A span with no beats
   (a non-dispatch step, or a dispatch step that committed nothing) carries
   an empty `:beats` and the renderer marks it per its `:kind`."
   [narrative]
   (let [spans (vec (or narrative []))
-        beats (evidence/narrative-beats narrative)
+        beats (rf.story.play.evidence/narrative-beats narrative)
         by-span (group-by :span-idx beats)
         decorate (fn [beat]
                    (let [coords (beat-focus-coords beat)]
@@ -407,7 +407,7 @@
   [narrative epoch-id]
   (when (some? epoch-id)
     (some (fn [b] (when (= epoch-id (:epoch-id b)) (:beat-idx b)))
-          (evidence/narrative-beats narrative))))
+          (rf.story.play.evidence/narrative-beats narrative))))
 
 (defn beat-index-for-dispatch
   "The 0-based `:beat-idx` of the FIRST flattened beat whose `:dispatch-id`
@@ -418,7 +418,7 @@
   [narrative dispatch-id]
   (when (some? dispatch-id)
     (some (fn [b] (when (= dispatch-id (:dispatch-id b)) (:beat-idx b)))
-          (evidence/narrative-beats narrative))))
+          (rf.story.play.evidence/narrative-beats narrative))))
 
 (defn row->beat-index
   "Resolve a run-result `row` (an assertion record or a schema-violation
@@ -492,7 +492,7 @@
      No-op when Story is disabled. Returns the focus result map (or nil)
      so a caller can introspect what fired."
      [variant-id beat panel]
-     (when config/enabled?
+     (when rf.story.config/enabled?
        (let [coords  (beat-focus-coords beat)
              source  (focus-source :story/evidence-beat variant-id
                                     {:beat-idx (:beat-idx beat)
@@ -505,49 +505,49 @@
 #?(:cljs
    (def ^:private styles
      {:wrap        {:font-family    sans-stack
-                    :font-size      (:body-tight typography/type-scale)
-                    :color          (:text-primary colors/tokens)
+                    :font-size      (:body-tight rf.story.theme.typography/type-scale)
+                    :color          (:text-primary rf.story.theme.colors/tokens)
                     :padding-bottom "12px"}
       :variant-id  {:font-family  mono-stack
-                    :font-size    (:caption typography/type-scale)
-                    :color        (:accent-amber colors/tokens)
+                    :font-size    (:caption rf.story.theme.typography/type-scale)
+                    :color        (:accent-amber rf.story.theme.colors/tokens)
                     :margin       "0 0 2px 0"
                     :word-break   "break-all"}
-      :blurb       {:color         (:text-tertiary colors/tokens)
-                    :font-size     (:caption typography/type-scale)
+      :blurb       {:color         (:text-tertiary rf.story.theme.colors/tokens)
+                    :font-size     (:caption rf.story.theme.typography/type-scale)
                     :margin-bottom "10px"
-                    :line-height   (:line-height-tight typography/type-scale)}
-      :no-variant  {:color      (:text-tertiary colors/tokens)
+                    :line-height   (:line-height-tight rf.story.theme.typography/type-scale)}
+      :no-variant  {:color      (:text-tertiary rf.story.theme.colors/tokens)
                     :font-style "italic"
-                    :font-size  (:caption typography/type-scale)
+                    :font-size  (:caption rf.story.theme.typography/type-scale)
                     :padding    "4px 0"}
-      :empty       {:color      (:text-tertiary colors/tokens)
+      :empty       {:color      (:text-tertiary rf.story.theme.colors/tokens)
                     :font-style "italic"
-                    :font-size  (:caption typography/type-scale)
+                    :font-size  (:caption rf.story.theme.typography/type-scale)
                     :padding    "4px 0"}
       ;; ---- span ----
       :span        {:margin-top   "8px"
-                    :border-left  (str "2px solid " (:border-subtle colors/tokens))
+                    :border-left  (str "2px solid " (:border-subtle rf.story.theme.colors/tokens))
                     :padding-left "8px"}
       :span-h      {:display      "flex"
                     :align-items  "baseline"
                     :gap          "6px"
                     :margin-bottom "2px"}
       :span-label  {:font-family mono-stack
-                    :font-size   (:caption typography/type-scale)
-                    :color       (:info colors/tokens)
+                    :font-size   (:caption rf.story.theme.typography/type-scale)
+                    :color       (:info rf.story.theme.colors/tokens)
                     :word-break  "break-all"}
-      :span-kind   {:font-size      (:nano typography/type-scale)
+      :span-kind   {:font-size      (:nano rf.story.theme.typography/type-scale)
                     :text-transform "uppercase"
-                    :letter-spacing (:label typography/letter-spacing)
-                    :color          (:text-tertiary colors/tokens)}
-      :span-caption {:color     (:text-secondary colors/tokens)
-                     :font-size (:caption typography/type-scale)
+                    :letter-spacing (:label rf.story.theme.typography/letter-spacing)
+                    :color          (:text-tertiary rf.story.theme.colors/tokens)}
+      :span-caption {:color     (:text-secondary rf.story.theme.colors/tokens)
+                     :font-size (:caption rf.story.theme.typography/type-scale)
                      :font-style "italic"
                      :margin-bottom "2px"}
-      :span-empty  {:color      (:text-tertiary colors/tokens)
+      :span-empty  {:color      (:text-tertiary rf.story.theme.colors/tokens)
                     :font-style "italic"
-                    :font-size  (:micro typography/type-scale)
+                    :font-size  (:micro rf.story.theme.typography/type-scale)
                     :padding    "1px 0 3px 0"}
       ;; ---- beat ----
       :beat        {:display       "flex"
@@ -556,48 +556,48 @@
                     :padding       "4px 6px"
                     :margin        "2px 0"
                     :border-radius "4px"
-                    :background    (:bg-2 colors/tokens)
-                    :border        (str "1px solid " (:border-subtle colors/tokens))
+                    :background    (:bg-2 rf.story.theme.colors/tokens)
+                    :border        (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
                     :cursor        "pointer"}
-      :beat-selected {:border    (str "1px solid " (:accent-amber colors/tokens))
-                      :background (:bg-3 colors/tokens)}
+      :beat-selected {:border    (str "1px solid " (:accent-amber rf.story.theme.colors/tokens))
+                      :background (:bg-3 rf.story.theme.colors/tokens)}
       :beat-h      {:display     "flex"
                     :align-items "baseline"
                     :gap         "6px"}
       :beat-trigger {:font-family mono-stack
-                     :font-size   (:caption typography/type-scale)
-                     :color       (:text-primary colors/tokens)
+                     :font-size   (:caption rf.story.theme.typography/type-scale)
+                     :color       (:text-primary rf.story.theme.colors/tokens)
                      :word-break  "break-all"
                      :flex        "1"}
       :beat-epoch  {:font-family mono-stack
-                    :font-size   (:nano typography/type-scale)
-                    :color       (:text-tertiary colors/tokens)
+                    :font-size   (:nano rf.story.theme.typography/type-scale)
+                    :color       (:text-tertiary rf.story.theme.colors/tokens)
                     :white-space "nowrap"}
       :strength-row {:display    "flex"
                      :gap        "4px"
                      :flex-wrap  "wrap"
                      :margin-top "1px"}
       :strength-tag {:font-family mono-stack
-                     :font-size   (:nano typography/type-scale)
+                     :font-size   (:nano rf.story.theme.typography/type-scale)
                      :border-radius "8px"
                      :padding     "0 6px"}
-      :strength-direct {:background (:success-bg colors/tokens)
-                        :color      (:success colors/tokens)}
-      :strength-attr   {:background (:info-bg colors/tokens)
-                        :color      (:info colors/tokens)}
+      :strength-direct {:background (:success-bg rf.story.theme.colors/tokens)
+                        :color      (:success rf.story.theme.colors/tokens)}
+      :strength-attr   {:background (:info-bg rf.story.theme.colors/tokens)
+                        :color      (:info rf.story.theme.colors/tokens)}
       :summary-row {:display     "flex"
                     :gap         "6px"
                     :flex-wrap   "wrap"
                     :margin-top  "1px"}
       :summary-chip {:font-family mono-stack
-                     :font-size   (:nano typography/type-scale)
-                     :color       (:text-secondary colors/tokens)
-                     :background   (:bg-1 colors/tokens)
-                     :border       (str "1px solid " (:border-subtle colors/tokens))
+                     :font-size   (:nano rf.story.theme.typography/type-scale)
+                     :color       (:text-secondary rf.story.theme.colors/tokens)
+                     :background   (:bg-1 rf.story.theme.colors/tokens)
+                     :border       (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
                      :border-radius "8px"
                      :padding      "0 6px"}
-      :summary-chip-attr {:color (:info colors/tokens)}
-      :summary-chip-schema {:color (:danger colors/tokens)}
+      :summary-chip-attr {:color (:info rf.story.theme.colors/tokens)}
+      :summary-chip-schema {:color (:danger rf.story.theme.colors/tokens)}
       ;; ---- focus link ----
       :focus-row   {:display     "flex"
                     :align-items "center"
@@ -605,31 +605,31 @@
                     :flex-wrap   "wrap"
                     :margin-top  "3px"}
       :focus-link  {:font-family sans-stack
-                    :font-size   (:caption typography/type-scale)
-                    :background  (:bg-3 colors/tokens)
-                    :color       (:info colors/tokens)
-                    :border      (str "1px solid " (:border-default colors/tokens))
+                    :font-size   (:caption rf.story.theme.typography/type-scale)
+                    :background  (:bg-3 rf.story.theme.colors/tokens)
+                    :color       (:info rf.story.theme.colors/tokens)
+                    :border      (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                     :border-radius "6px"
                     :padding     "2px 8px"
                     :cursor      "pointer"
                     :user-select "none"}
-      :focus-note  {:font-size  (:nano typography/type-scale)
-                    :color      (:text-tertiary colors/tokens)
+      :focus-note  {:font-size  (:nano rf.story.theme.typography/type-scale)
+                    :color      (:text-tertiary rf.story.theme.colors/tokens)
                     :font-style "italic"}
       :toolbar     {:display       "flex"
                     :gap           "6px"
                     :margin-bottom "8px"}
       :btn         {:font-family sans-stack
-                    :font-size   (:caption typography/type-scale)
-                    :background  (:bg-3 colors/tokens)
-                    :color       (:text-secondary colors/tokens)
-                    :border      (str "1px solid " (:border-default colors/tokens))
+                    :font-size   (:caption rf.story.theme.typography/type-scale)
+                    :background  (:bg-3 rf.story.theme.colors/tokens)
+                    :color       (:text-secondary rf.story.theme.colors/tokens)
+                    :border      (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                     :border-radius "6px"
                     :padding     "3px 9px"
                     :cursor      "pointer"
                     :user-select "none"}
-      :copied      {:color      (:success colors/tokens)
-                    :font-size  (:caption typography/type-scale)
+      :copied      {:color      (:success rf.story.theme.colors/tokens)
+                    :font-size  (:caption rf.story.theme.typography/type-scale)
                     :align-self "center"}}))
 
 ;; ---- focus panel picker --------------------------------------------------
@@ -766,16 +766,16 @@
 ;;
 ;; Test mode renders a graceful 'evidence pending' row; the
 ;; spine is its target. The spine reads the same result slot Test mode wrote
-;; (`test-state/results-atom`), so it shows the SAME run's narrative — Story
+;; (`rf.story.ui.test-mode.state/results-atom`), so it shows the SAME run's narrative — Story
 ;; never re-runs the variant for the spine.
 
 #?(:cljs
    (defn result-for
      "Read the unified run-result for `variant-id` from the Test-mode result
-     slot (`test-state/results-atom`), or nil. The spine projects the SAME
+     slot (`rf.story.ui.test-mode.state/results-atom`), or nil. The spine projects the SAME
      run Test mode captured — one tape, one narrative."
      [variant-id]
-     (get-in @test-state/results-atom [variant-id :result])))
+     (get-in @rf.story.ui.test-mode.state/results-atom [variant-id :result])))
 
 ;; ---- the panel -----------------------------------------------------------
 
@@ -797,7 +797,7 @@
      []
      (let [copied? (r/atom false)]
        (fn []
-         (let [shell      @state/shell-state-atom
+         (let [shell      @rf.story.ui.state/shell-state-atom
                variant-id (:selected-variant shell)]
            (cond
              (not variant-id)
@@ -829,7 +829,7 @@
                       :data-test "story-evidence-copy"
                       :title     "Copy the run narrative as EDN to the clipboard"
                       :on-click  (fn [_]
-                                   (review-dialog/copy-to-clipboard! (pr-str narrative))
+                                   (rf.story.review-dialog/copy-to-clipboard! (pr-str narrative))
                                    (reset! copied? true)
                                    (js/setTimeout #(reset! copied? false) 1400))}
                      "Copy narrative EDN"]
@@ -853,8 +853,8 @@
      is disabled. Mirrors `explain-panel/open!`."
      ([] (open! nil nil))
      ([variant-id beat-idx]
-      (when config/enabled?
-        (state/swap-state! assoc-in [:panel-visibility panel-key] true)
+      (when rf.story.config/enabled?
+        (rf.story.ui.state/swap-state! assoc-in [:panel-visibility panel-key] true)
         (when (and variant-id (some? beat-idx))
           (select-beat! variant-id beat-idx))
         (js/setTimeout

--- a/tools/story/src/re_frame/story/ui/explain_panel.cljc
+++ b/tools/story/src/re_frame/story/ui/explain_panel.cljc
@@ -50,21 +50,21 @@
   ## Elision
 
   CLJS rendering reaches `explain-panel` only via the
-  `config/enabled?`-gated shell mount, so production builds never invoke
+  `rf.story.config/enabled?`-gated shell mount, so production builds never invoke
   it; closure DCEs the lot. The pure `.cljc` helpers carry no DOM /
   Reagent dep."
   (:require [clojure.string :as str]
-            [re-frame.story.plan :as plan]
+            [re-frame.story.plan :as rf.story.plan]
             ;; The theme requires are CLJS-only — `typography`/`colors` are
             ;; referenced solely from the `#?(:cljs (def ^:private styles …))`
             ;; block. Keeping them inside the `:cljs` reader conditional avoids
             ;; an unused-namespace warning in the `.cljc` clj view.
             #?@(:cljs [[reagent.core :as r]
-                       [re-frame.story.config :as config]
-                       [re-frame.story.review-dialog :as review-dialog]
-                       [re-frame.story.ui.state :as state]
-                       [re-frame.story.theme.typography :as typography :refer [sans-stack mono-stack]]
-                       [re-frame.story.theme.colors :as colors]])))
+                       [re-frame.story.config :as rf.story.config]
+                       [re-frame.story.review-dialog :as rf.story.review-dialog]
+                       [re-frame.story.ui.state :as rf.story.ui.state]
+                       [re-frame.story.theme.typography :as rf.story.theme.typography :refer [sans-stack mono-stack]]
+                       [re-frame.story.theme.colors :as rf.story.theme.colors]])))
 
 ;; ---------------------------------------------------------------------------
 ;; The panel-visibility slot + the scroll anchor id. Shared with the
@@ -98,7 +98,7 @@
   with a concrete id."
   [variant-id]
   (try
-    {:explain (plan/explain variant-id)}
+    {:explain (rf.story.plan/explain variant-id)}
     (catch #?(:clj Throwable :cljs :default) e
       {:error (or #?(:clj (.getMessage ^Throwable e)
                      :cljs (.-message e))
@@ -250,100 +250,100 @@
 #?(:cljs
    (def ^:private styles
      {:wrap          {:font-family   sans-stack
-                      :font-size     (:body-tight typography/type-scale)
-                      :color         (:text-primary colors/tokens)
+                      :font-size     (:body-tight rf.story.theme.typography/type-scale)
+                      :color         (:text-primary rf.story.theme.colors/tokens)
                       :padding-bottom "12px"}
       :variant-id    {:font-family   mono-stack
-                      :font-size     (:caption typography/type-scale)
-                      :color         (:accent-amber colors/tokens)
+                      :font-size     (:caption rf.story.theme.typography/type-scale)
+                      :color         (:accent-amber rf.story.theme.colors/tokens)
                       :margin        "0 0 2px 0"
                       :word-break    "break-all"}
-      :blurb         {:color         (:text-tertiary colors/tokens)
-                      :font-size     (:caption typography/type-scale)
+      :blurb         {:color         (:text-tertiary rf.story.theme.colors/tokens)
+                      :font-size     (:caption rf.story.theme.typography/type-scale)
                       :margin-bottom "10px"
-                      :line-height   (:line-height-tight typography/type-scale)}
+                      :line-height   (:line-height-tight rf.story.theme.typography/type-scale)}
       :section       {:margin-top    "12px"}
       :section-h     {:display       "flex"
                       :align-items   "baseline"
                       :justify-content "space-between"
                       :gap           "8px"
-                      :color         (:text-secondary colors/tokens)
+                      :color         (:text-secondary rf.story.theme.colors/tokens)
                       :text-transform "uppercase"
-                      :font-size     (:micro typography/type-scale)
-                      :letter-spacing (:label typography/letter-spacing)
+                      :font-size     (:micro rf.story.theme.typography/type-scale)
+                      :letter-spacing (:label rf.story.theme.typography/letter-spacing)
                       :margin-bottom "4px"
                       :padding-bottom "3px"
-                      :border-bottom (str "1px solid " (:border-subtle colors/tokens))}
-      :absent-tag    {:color         (:text-tertiary colors/tokens)
+                      :border-bottom (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))}
+      :absent-tag    {:color         (:text-tertiary rf.story.theme.colors/tokens)
                       :font-style    "italic"
                       :text-transform "none"
                       :letter-spacing "normal"
-                      :font-size     (:micro typography/type-scale)}
-      :empty         {:color         (:text-tertiary colors/tokens)
+                      :font-size     (:micro rf.story.theme.typography/type-scale)}
+      :empty         {:color         (:text-tertiary rf.story.theme.colors/tokens)
                       :font-style    "italic"
-                      :font-size     (:caption typography/type-scale)
+                      :font-size     (:caption rf.story.theme.typography/type-scale)
                       :padding       "2px 0 4px 0"}
       :chain         {:font-family   mono-stack
-                      :font-size     (:caption typography/type-scale)
-                      :color         (:info colors/tokens)
+                      :font-size     (:caption rf.story.theme.typography/type-scale)
+                      :color         (:info rf.story.theme.colors/tokens)
                       :word-break    "break-all"
-                      :line-height   (:line-height-mono typography/type-scale)}
+                      :line-height   (:line-height-mono rf.story.theme.typography/type-scale)}
       :table         {:width         "100%"
                       :border-collapse "collapse"
                       :font-family   mono-stack
-                      :font-size     (:caption typography/type-scale)}
+                      :font-size     (:caption rf.story.theme.typography/type-scale)}
       :td            {:padding       "3px 6px 3px 0"
-                      :border-bottom (str "1px solid " (:border-subtle colors/tokens))
-                      :color         (:text-primary colors/tokens)
+                      :border-bottom (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
+                      :color         (:text-primary rf.story.theme.colors/tokens)
                       :vertical-align "top"
                       :white-space   "pre-wrap"
                       :word-break    "break-word"}
-      :td-key        {:color         (:info colors/tokens)
+      :td-key        {:color         (:info rf.story.theme.colors/tokens)
                       :white-space   "nowrap"
                       :padding-right "10px"}
-      :td-val        {:color         (:tag-experimental-fg colors/tokens)}
+      :td-val        {:color         (:tag-experimental-fg rf.story.theme.colors/tokens)}
       :list          {:margin        0
                       :padding-left  "16px"
                       :font-family   mono-stack
-                      :font-size     (:caption typography/type-scale)
-                      :color         (:text-primary colors/tokens)
-                      :line-height   (:line-height-mono typography/type-scale)}
+                      :font-size     (:caption rf.story.theme.typography/type-scale)
+                      :color         (:text-primary rf.story.theme.colors/tokens)
+                      :line-height   (:line-height-mono rf.story.theme.typography/type-scale)}
       :badge-row     {:display       "flex"
                       :flex-wrap     "wrap"
                       :gap           "4px"
                       :margin-top    "2px"}
       :badge         {:font-family   mono-stack
-                      :font-size     (:nano typography/type-scale)
-                      :background    (:bg-3 colors/tokens)
-                      :color         (:text-secondary colors/tokens)
-                      :border        (str "1px solid " (:border-subtle colors/tokens))
+                      :font-size     (:nano rf.story.theme.typography/type-scale)
+                      :background    (:bg-3 rf.story.theme.colors/tokens)
+                      :color         (:text-secondary rf.story.theme.colors/tokens)
+                      :border        (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
                       :border-radius "8px"
                       :padding       "1px 7px"}
       :conflict      {:font-family   mono-stack
-                      :font-size     (:caption typography/type-scale)
-                      :color         (:warning colors/tokens)
+                      :font-size     (:caption rf.story.theme.typography/type-scale)
+                      :color         (:warning rf.story.theme.colors/tokens)
                       :padding       "2px 0"
-                      :line-height   (:line-height-mono typography/type-scale)}
+                      :line-height   (:line-height-mono rf.story.theme.typography/type-scale)}
       :toolbar       {:display       "flex"
                       :gap           "6px"
                       :margin-bottom "8px"}
       :btn           {:font-family   sans-stack
-                      :font-size     (:caption typography/type-scale)
-                      :background    (:bg-3 colors/tokens)
-                      :color         (:text-secondary colors/tokens)
-                      :border        (str "1px solid " (:border-default colors/tokens))
+                      :font-size     (:caption rf.story.theme.typography/type-scale)
+                      :background    (:bg-3 rf.story.theme.colors/tokens)
+                      :color         (:text-secondary rf.story.theme.colors/tokens)
+                      :border        (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                       :border-radius "6px"
                       :padding       "3px 9px"
                       :cursor        "pointer"
                       :user-select   "none"}
-      :btn-on        {:background    (:accent-amber colors/tokens)
-                      :color         (:text-on-accent colors/tokens)
-                      :border        (str "1px solid " (:accent-amber-deep colors/tokens))}
+      :btn-on        {:background    (:accent-amber rf.story.theme.colors/tokens)
+                      :color         (:text-on-accent rf.story.theme.colors/tokens)
+                      :border        (str "1px solid " (:accent-amber-deep rf.story.theme.colors/tokens))}
       :pre           {:font-family   mono-stack
-                      :font-size     (:caption typography/type-scale)
-                      :background    (:bg-input colors/tokens)
-                      :color         (:text-primary colors/tokens)
-                      :border        (str "1px solid " (:border-subtle colors/tokens))
+                      :font-size     (:caption rf.story.theme.typography/type-scale)
+                      :background    (:bg-input rf.story.theme.colors/tokens)
+                      :color         (:text-primary rf.story.theme.colors/tokens)
+                      :border        (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
                       :border-radius "4px"
                       :padding       "8px"
                       :margin        0
@@ -351,21 +351,21 @@
                       :overflow      "auto"
                       :white-space   "pre-wrap"
                       :word-break    "break-word"}
-      :copied        {:color         (:success colors/tokens)
-                      :font-size     (:caption typography/type-scale)
+      :copied        {:color         (:success rf.story.theme.colors/tokens)
+                      :font-size     (:caption rf.story.theme.typography/type-scale)
                       :align-self    "center"}
-      :error         {:color         (:danger colors/tokens)
+      :error         {:color         (:danger rf.story.theme.colors/tokens)
                       :font-family   mono-stack
-                      :font-size     (:caption typography/type-scale)
-                      :background    (:danger-bg colors/tokens)
-                      :border        (str "1px solid " (:danger colors/tokens))
+                      :font-size     (:caption rf.story.theme.typography/type-scale)
+                      :background    (:danger-bg rf.story.theme.colors/tokens)
+                      :border        (str "1px solid " (:danger rf.story.theme.colors/tokens))
                       :border-radius "4px"
                       :padding       "8px"
                       :white-space   "pre-wrap"
                       :word-break    "break-word"}
-      :no-variant    {:color         (:text-tertiary colors/tokens)
+      :no-variant    {:color         (:text-tertiary rf.story.theme.colors/tokens)
                       :font-style    "italic"
-                      :font-size     (:caption typography/type-scale)
+                      :font-size     (:caption rf.story.theme.typography/type-scale)
                       :padding       "4px 0"}}))
 
 #?(:cljs
@@ -518,7 +518,7 @@
      (let [show-raw? (r/atom false)
            copied?   (r/atom false)]
        (fn []
-         (let [shell      @state/shell-state-atom
+         (let [shell      @rf.story.ui.state/shell-state-atom
                variant-id (:selected-variant shell)]
            (cond
              (not variant-id)
@@ -555,7 +555,7 @@
                       :data-test "story-explain-copy"
                       :title     "Copy the explain map as EDN to the clipboard"
                       :on-click  (fn [_]
-                                   (review-dialog/copy-to-clipboard! (raw-edn explain))
+                                   (rf.story.review-dialog/copy-to-clipboard! (raw-edn explain))
                                    (reset! copied? true)
                                    (js/setTimeout #(reset! copied? false) 1400))}
                      "Copy EDN"]
@@ -580,8 +580,8 @@
      and scroll it into view. Wired from the command palette's
      `Explain variant` command. No-op when Story is disabled."
      []
-     (when config/enabled?
-       (state/swap-state! assoc-in [:panel-visibility panel-key] true)
+     (when rf.story.config/enabled?
+       (rf.story.ui.state/swap-state! assoc-in [:panel-visibility panel-key] true)
        (js/setTimeout
          (fn []
            (when (exists? js/document)

--- a/tools/story/src/re_frame/story/ui/help.cljs
+++ b/tools/story/src/re_frame/story/ui/help.cljs
@@ -34,12 +34,12 @@
   Production builds with `re-frame.story.config/enabled?` false never
   reach this ns; Closure DCE drops the lot."
   (:require [reagent.core :as r]
-            [re-frame.story.config :as config]
+            [re-frame.story.config :as rf.story.config]
             [re-frame.story.local-storage :refer [safe-local-storage]]
-            [re-frame.story.theme.typography :as typography :refer [sans-stack mono-stack]]
-            [re-frame.story.theme.colors :as colors]
-            [re-frame.story.theme.depth :as depth]
-            [re-frame.story.theme.motion :as motion]))
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [sans-stack mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]
+            [re-frame.story.theme.depth :as rf.story.theme.depth]
+            [re-frame.story.theme.motion :as rf.story.theme.motion]))
 
 ;; ---- localStorage flag --------------------------------------------------
 
@@ -88,19 +88,19 @@
                  :align-items "center"
                  :justify-content "center"
                  :animation   (str "rf-story-overlay-in "
-                                   (:overlay-fade motion/timing) " "
-                                   (:enter motion/easing) " both")}
-   :panel       {:background    (:overlay-glass depth/backdrops)
-                 :color         (:text-primary colors/tokens)
-                 :border        (str "1px solid " (:border-strong colors/tokens))
+                                   (:overlay-fade rf.story.theme.motion/timing) " "
+                                   (:enter rf.story.theme.motion/easing) " both")}
+   :panel       {:background    (:overlay-glass rf.story.theme.depth/backdrops)
+                 :color         (:text-primary rf.story.theme.colors/tokens)
+                 :border        (str "1px solid " (:border-strong rf.story.theme.colors/tokens))
                  :border-radius "8px"
-                 :box-shadow    (:elev-overlay depth/shadows)
+                 :box-shadow    (:elev-overlay rf.story.theme.depth/shadows)
                  :width         "560px"
                  :max-width     "92vw"
                  :max-height    "86vh"
                  :overflow      "auto"
                  :font-family   sans-stack
-                 :font-size     (:body typography/type-scale)
+                 :font-size     (:body rf.story.theme.typography/type-scale)
                  :line-height   "1.5"
                  :backdrop-filter "blur(8px)"
                  :-webkit-backdrop-filter "blur(8px)"}
@@ -108,23 +108,23 @@
                  :justify-content "space-between"
                  :align-items     "center"
                  :padding         "12px 16px"
-                 :background      (:bg-2 colors/tokens)
+                 :background      (:bg-2 rf.story.theme.colors/tokens)
                  :border-bottom   "1px solid #444"}
-   :title       {:color       (:info colors/tokens)
+   :title       {:color       (:info rf.story.theme.colors/tokens)
                  :font-weight "bold"
-                 :font-size   (:body typography/type-scale)
+                 :font-size   (:body rf.story.theme.typography/type-scale)
                  :text-transform "uppercase"
                  :letter-spacing "0.5px"}
    :close       {:background  "transparent"
                  :border      "none"
-                 :color       (:text-secondary colors/tokens)
-                 :font-size   (:display typography/type-scale)
+                 :color       (:text-secondary rf.story.theme.colors/tokens)
+                 :font-size   (:display rf.story.theme.typography/type-scale)
                  :cursor      "pointer"
                  :padding     "0 4px"
                  :line-height "1"}
    :body        {:padding "16px 20px"}
-   :section-h   {:color          (:text-secondary colors/tokens)
-                 :font-size      (:micro typography/type-scale)
+   :section-h   {:color          (:text-secondary rf.story.theme.colors/tokens)
+                 :font-size      (:micro rf.story.theme.typography/type-scale)
                  :text-transform "uppercase"
                  :letter-spacing "0.5px"
                  :margin         "12px 0 6px 0"
@@ -133,30 +133,30 @@
    :list        {:margin     "0 0 0 18px"
                  :padding    "0"}
    :list-item   {:margin-bottom "4px"}
-   :kw          {:color       (:warning colors/tokens)
+   :kw          {:color       (:warning rf.story.theme.colors/tokens)
                  :font-family mono-stack}
-   :muted       {:color (:text-secondary colors/tokens)}
+   :muted       {:color (:text-secondary rf.story.theme.colors/tokens)}
    :footer      {:display         "flex"
                  :justify-content "flex-end"
                  :padding         "12px 16px"
                  :border-top      "1px solid #444"
-                 :background      (:bg-2 colors/tokens)}
+                 :background      (:bg-2 rf.story.theme.colors/tokens)}
    :got-it      {:padding       "6px 16px"
-                 :background    (:accent-amber colors/tokens)
+                 :background    (:accent-amber rf.story.theme.colors/tokens)
                  :color         "white"
                  :border        "none"
                  :border-radius "3px"
                  :cursor        "pointer"
-                 :font-size     (:body-tight typography/type-scale)
+                 :font-size     (:body-tight rf.story.theme.typography/type-scale)
                  :font-family   sans-stack}
    :help-btn    {:padding       "2px 9px"
-                 :background    (:bg-3 colors/tokens)
-                 :color         (:info colors/tokens)
+                 :background    (:bg-3 rf.story.theme.colors/tokens)
+                 :color         (:info rf.story.theme.colors/tokens)
                  :border        "1px solid #555"
                  :border-radius "12px"
                  :cursor        "pointer"
                  :font-family   mono-stack
-                 :font-size     (:caption typography/type-scale)
+                 :font-size     (:caption rf.story.theme.typography/type-scale)
                  :line-height   "1.2"}})
 
 ;; ---- the panel ----------------------------------------------------------
@@ -330,7 +330,7 @@
        ;; with intent; the dev-time onboarding overlay just gets in their
        ;; way. The manual ? chip is still rendered so on-demand help
        ;; remains reachable.
-       (when (and (not config/static-mode?)
+       (when (and (not rf.story.config/static-mode?)
                   (not (seen?)))
          (reset! open? true)))
      :reagent-render

--- a/tools/story/src/re_frame/story/ui/keybindings.cljs
+++ b/tools/story/src/re_frame/story/ui/keybindings.cljs
@@ -55,9 +55,9 @@
   install the listener — Closure DCE drops the lot."
   (:require [clojure.edn :as edn]
             [clojure.string :as str]
-            [re-frame.story.config :as config]
+            [re-frame.story.config :as rf.story.config]
             [re-frame.story.local-storage :refer [safe-local-storage]]
-            [re-frame.story.ui.state :as state]))
+            [re-frame.story.ui.state :as rf.story.ui.state]))
 
 ;; ---- localStorage persistence -------------------------------------------
 
@@ -78,7 +78,7 @@
         (when (string? raw)
           (let [parsed (edn/read-string raw)]
             (when (map? parsed)
-              (-> state/chrome-visibility-defaults
+              (-> rf.story.ui.state/chrome-visibility-defaults
                   (merge (select-keys parsed
                                       [:full-screen?
                                        :sidebar?
@@ -107,8 +107,8 @@
   so we don't bounce a watcher save back onto storage."
   []
   (when-let [persisted (load-from-storage)]
-    (let [shell @state/shell-state-atom
-          current (state/chrome-visibility shell)
+    (let [shell @rf.story.ui.state/shell-state-atom
+          current (rf.story.ui.state/chrome-visibility shell)
           merged  (merge current
                          (select-keys persisted
                                       [:full-screen?
@@ -116,7 +116,7 @@
                                        :rhs?
                                        :toolbar?]))]
       (when (not= current merged)
-        (state/swap-state! assoc :chrome-visibility merged)))))
+        (rf.story.ui.state/swap-state! assoc :chrome-visibility merged)))))
 
 ;; ---- dispatcher predicate ----------------------------------------------
 
@@ -165,36 +165,36 @@
   separate `Escape`-listener in the canvas's full-screen overlay (see
   `canvas/full-screen-overlay`)."
   []
-  (state/swap-state! state/toggle-chrome-visibility :full-screen?)
-  (save-to-storage! (state/chrome-visibility (state/get-state))))
+  (rf.story.ui.state/swap-state! rf.story.ui.state/toggle-chrome-visibility :full-screen?)
+  (save-to-storage! (rf.story.ui.state/chrome-visibility (rf.story.ui.state/get-state))))
 
 (defn sidebar-toggle!
   "Handler for the `s` key. Flips
   `[:chrome-visibility :sidebar?]` + persists."
   []
-  (state/swap-state! state/toggle-chrome-visibility :sidebar?)
-  (save-to-storage! (state/chrome-visibility (state/get-state))))
+  (rf.story.ui.state/swap-state! rf.story.ui.state/toggle-chrome-visibility :sidebar?)
+  (save-to-storage! (rf.story.ui.state/chrome-visibility (rf.story.ui.state/get-state))))
 
 (defn rhs-toggle!
   "Handler for the `a` key (`a` for 'addons' per Storybook
   convention). Flips `[:chrome-visibility :rhs?]` + persists."
   []
-  (state/swap-state! state/toggle-chrome-visibility :rhs?)
-  (save-to-storage! (state/chrome-visibility (state/get-state))))
+  (rf.story.ui.state/swap-state! rf.story.ui.state/toggle-chrome-visibility :rhs?)
+  (save-to-storage! (rf.story.ui.state/chrome-visibility (rf.story.ui.state/get-state))))
 
 (defn toolbar-toggle!
   "Handler for the `t` key. Flips
   `[:chrome-visibility :toolbar?]` + persists."
   []
-  (state/swap-state! state/toggle-chrome-visibility :toolbar?)
-  (save-to-storage! (state/chrome-visibility (state/get-state))))
+  (rf.story.ui.state/swap-state! rf.story.ui.state/toggle-chrome-visibility :toolbar?)
+  (save-to-storage! (rf.story.ui.state/chrome-visibility (rf.story.ui.state/get-state))))
 
 (defn exit-full-screen!
   "Public escape handler — clears `:full-screen?` regardless of prior
   state. Bound to `Escape` while full-screen is on."
   []
-  (state/swap-state! state/set-chrome-visibility :full-screen? false)
-  (save-to-storage! (state/chrome-visibility (state/get-state))))
+  (rf.story.ui.state/swap-state! rf.story.ui.state/set-chrome-visibility :full-screen? false)
+  (save-to-storage! (rf.story.ui.state/chrome-visibility (rf.story.ui.state/get-state))))
 
 (def bindings
   "Canonical `{key → handler}` table. Lowercase letters only — the
@@ -226,8 +226,8 @@
   (let [raw-key   (.-key evt)
         editable? (target-is-input? evt)
         modifier? (has-modifier? evt)
-        shell     (state/get-state)
-        chrome    (state/chrome-visibility shell)]
+        shell     (rf.story.ui.state/get-state)
+        chrome    (rf.story.ui.state/chrome-visibility shell)]
     (cond
       ;; Escape exits full-screen. We gate the Escape branch on
       ;; `editable?` so typing Escape into a
@@ -253,7 +253,7 @@
   replaces the previous handler. Gated behind
   `re-frame.story.config/enabled?` so production builds DCE the lot."
   []
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (when-let [prev @listener-handle]
       (try (.removeEventListener js/window "keydown" prev true)
            (catch :default _ nil)))

--- a/tools/story/src/re_frame/story/ui/mode_tabs.cljs
+++ b/tools/story/src/re_frame/story/ui/mode_tabs.cljs
@@ -25,7 +25,7 @@
   variant's selection — and persists across reloads via localStorage
   under the key `re-frame.story/active-mode-tab/<variant-id>`.
 
-  The shell's `main-pane` consults `(state/active-mode-tab state vid)`
+  The shell's `main-pane` consults `(rf.story.ui.state/active-mode-tab state vid)`
   to decide which pane renders below the strip:
 
   - `:dev`  → the canvas / workspace path.
@@ -38,9 +38,9 @@
   active foreground, `#1e1e1e` active background. Reuses the shape of the
   tab-bar/tab/tab-active styles defined in `re-frame.story.ui.shell`."
   (:require [re-frame.story.local-storage :refer [safe-local-storage]]
-            [re-frame.story.ui.state :as state]
-            [re-frame.story.theme.typography :as typography :refer [sans-stack mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [sans-stack mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---- localStorage persistence -------------------------------------------
 ;;
@@ -64,21 +64,21 @@
 
 (defn load-mode-tab!
   "Read the persisted mode-tab for `variant-id` from localStorage.
-  Returns one of `state/mode-tabs` or nil if no record / unparseable."
+  Returns one of `rf.story.ui.state/mode-tabs` or nil if no record / unparseable."
   [variant-id]
   (when-let [ls (safe-local-storage)]
     (try
       (let [raw (.getItem ls (ls-key variant-id))]
         (when (string? raw)
           (let [tab (keyword raw)]
-            (when (state/valid-mode-tab? tab) tab))))
+            (when (rf.story.ui.state/valid-mode-tab? tab) tab))))
       (catch :default _ nil))))
 
 (defn save-mode-tab!
   "Persist `tab` for `variant-id` in localStorage. Silently no-ops if
   localStorage is unavailable or `tab` is not a valid mode-tab."
   [variant-id tab]
-  (when (and (state/valid-mode-tab? tab) variant-id)
+  (when (and (rf.story.ui.state/valid-mode-tab? tab) variant-id)
     (when-let [ls (safe-local-storage)]
       (try (.setItem ls (ls-key variant-id) (name tab))
            (catch :default _ nil)))))
@@ -90,10 +90,10 @@
   tab strip; only writes when the in-memory slot is empty."
   [variant-id]
   (when variant-id
-    (let [shell @state/shell-state-atom]
+    (let [shell @rf.story.ui.state/shell-state-atom]
       (when-not (contains? (:active-mode-tab shell) variant-id)
         (when-let [persisted (load-mode-tab! variant-id)]
-          (state/swap-state! state/set-active-mode-tab variant-id persisted))))))
+          (rf.story.ui.state/swap-state! rf.story.ui.state/set-active-mode-tab variant-id persisted))))))
 
 ;; ---- selection helper ----------------------------------------------------
 
@@ -102,8 +102,8 @@
   shell state and localStorage. Public so tests / programmatic callers
   can drive the switcher without going through the DOM."
   [variant-id tab]
-  (when (and variant-id (state/valid-mode-tab? tab))
-    (state/swap-state! state/set-active-mode-tab variant-id tab)
+  (when (and variant-id (rf.story.ui.state/valid-mode-tab? tab))
+    (rf.story.ui.state/swap-state! rf.story.ui.state/set-active-mode-tab variant-id tab)
     (save-mode-tab! variant-id tab)))
 
 ;; ---- styling -------------------------------------------------------------
@@ -113,10 +113,10 @@
 
 (def ^:private styles
   {:strip       {:display          "flex"
-                 :background       (:bg-2 colors/tokens)
+                 :background       (:bg-2 rf.story.theme.colors/tokens)
                  :border-bottom    "1px solid #444"
                  :font-family      mono-stack
-                 :font-size        (:caption typography/type-scale)
+                 :font-size        (:caption rf.story.theme.typography/type-scale)
                  :padding          "0"}
    ;; Longhand-only border sides on every chip. The `:tab-active`
    ;; overlay below adds a `:border-bottom`; mixing the shorthand
@@ -128,26 +128,26 @@
    ;; Same shape as the trace.cljs border styling.
    :tab         {:padding             "6px 14px"
                  :cursor              "pointer"
-                 :color               (:text-secondary colors/tokens)
-                 :background          (:bg-2 colors/tokens)
+                 :color               (:text-secondary rf.story.theme.colors/tokens)
+                 :background          (:bg-2 rf.story.theme.colors/tokens)
                  :border-top          "none"
                  :border-right        "1px solid #444"
                  :border-bottom       "none"
                  :border-left         "none"
                  :font-family         mono-stack
-                 :font-size           (:caption typography/type-scale)
+                 :font-size           (:caption rf.story.theme.typography/type-scale)
                  :letter-spacing      "0.3px"}
    :tab-active  {:color            "white"
-                 :background       (:bg-canvas colors/tokens)
+                 :background       (:bg-canvas rf.story.theme.colors/tokens)
                  :border-bottom    "1px solid #1e1e1e"
                  :margin-bottom    "-1px"
                  :font-weight      "bold"}
    :placeholder {:padding          "32px"
-                 :color            (:text-tertiary colors/tokens)
+                 :color            (:text-tertiary rf.story.theme.colors/tokens)
                  :font-style       "italic"
                  :font-family      sans-stack
                  :text-align       "center"
-                 :background       (:bg-canvas colors/tokens)
+                 :background       (:bg-canvas rf.story.theme.colors/tokens)
                  :flex             "1"}})
 
 ;; ---- chip strip ----------------------------------------------------------
@@ -168,13 +168,13 @@
     ;; Hydrate from localStorage on first render of this variant's
     ;; strip — idempotent on subsequent renders.
     (hydrate-from-storage! variant-id)
-    (let [shell  @state/shell-state-atom
-          active (state/active-mode-tab shell variant-id)]
+    (let [shell  @rf.story.ui.state/shell-state-atom
+          active (rf.story.ui.state/active-mode-tab shell variant-id)]
       [:div {:style       (:strip styles)
              :role        "tablist"
              :aria-label  "Story mode"
              :data-test   "story-mode-tabs"}
-       (for [tab state/mode-tabs]
+       (for [tab rf.story.ui.state/mode-tabs]
          ^{:key tab}
          [:button
           {:style          (merge (:tab styles)
@@ -184,7 +184,7 @@
            :aria-current   (when (= tab active) "page")
            :data-mode-tab  (name tab)
            :on-click       #(select-mode-tab! variant-id tab)}
-          (get state/mode-tab-labels tab (name tab))])])))
+          (get rf.story.ui.state/mode-tab-labels tab (name tab))])])))
 
 ;; ---- placeholder panes ---------------------------------------------------
 ;;

--- a/tools/story/src/re_frame/story/ui/multi_substrate.cljs
+++ b/tools/story/src/re_frame/story/ui/multi_substrate.cljs
@@ -125,12 +125,12 @@
   (:require [clojure.string :as str]
             [reagent.core :as r]
             [re-frame.core :as rf]
-            [re-frame.story.args :as args]
-            [re-frame.story.decorators :as decorators]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.story.ui.state :as state]
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+            [re-frame.story.args :as rf.story.args]
+            [re-frame.story.decorators :as rf.story.decorators]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---- styling -------------------------------------------------------------
 
@@ -139,40 +139,40 @@
                 :grid-template-columns "repeat(auto-fit, minmax(280px, 1fr))"
                 :gap "12px"
                 :padding "12px"
-                :background (:bg-canvas colors/tokens)
+                :background (:bg-canvas rf.story.theme.colors/tokens)
                 :flex "1"
                 :overflow "auto"}
-   :cell       {:background (:bg-2 colors/tokens)
+   :cell       {:background (:bg-2 rf.story.theme.colors/tokens)
                 :border "1px solid #3c3c3c"
                 :border-radius "4px"
                 :display "flex"
                 :flex-direction "column"
                 :min-height "160px"
-                :color (:text-primary colors/tokens)
+                :color (:text-primary rf.story.theme.colors/tokens)
                 :font-family mono-stack
-                :font-size (:caption typography/type-scale)
+                :font-size (:caption rf.story.theme.typography/type-scale)
                 :position "relative"}
    :cell-head  {:padding "6px 10px"
-                :background (:bg-2 colors/tokens)
+                :background (:bg-2 rf.story.theme.colors/tokens)
                 :border-bottom "1px solid #444"
-                :color (:info colors/tokens)
+                :color (:info rf.story.theme.colors/tokens)
                 :font-weight "bold"
-                :font-size (:micro typography/type-scale)
+                :font-size (:micro rf.story.theme.typography/type-scale)
                 :letter-spacing "0.5px"
                 :text-transform "uppercase"
                 :border-radius "4px 4px 0 0"}
    :cell-body  {:padding "10px"
                 :flex 1}
-   :error-cell {:background (:danger-bg colors/tokens)
+   :error-cell {:background (:danger-bg rf.story.theme.colors/tokens)
                 :border "1px solid #be4040"
-                :color (:danger colors/tokens)
+                :color (:danger rf.story.theme.colors/tokens)
                 :border-radius "4px"
                 :font-family mono-stack
-                :font-size (:caption typography/type-scale)}
+                :font-size (:caption rf.story.theme.typography/type-scale)}
    :error-head {:padding "6px 10px"
                 :background "#7a2727"
                 :font-weight "bold"
-                :font-size (:micro typography/type-scale)
+                :font-size (:micro rf.story.theme.typography/type-scale)
                 :letter-spacing "0.5px"
                 :text-transform "uppercase"
                 :border-radius "4px 4px 0 0"}
@@ -232,7 +232,7 @@
   (let [resolved (rf/view view-id)]
     (if resolved
       [resolved eff-args]
-      [:div {:style {:color (:text-secondary colors/tokens) :font-style "italic"}}
+      [:div {:style {:color (:text-secondary rf.story.theme.colors/tokens) :font-style "italic"}}
        (str ":component " (pr-str view-id) " is not registered as a view")])))
 
 (defn install-reagent-substrate!
@@ -272,7 +272,7 @@
   [substrate variant-id view-id eff-args]
   (if-let [render-fn (get @substrate->render-fn substrate)]
     (render-fn variant-id view-id eff-args)
-    [:div {:style {:color (:text-secondary colors/tokens) :font-style "italic"}}
+    [:div {:style {:color (:text-secondary rf.story.theme.colors/tokens) :font-style "italic"}}
      (str "substrate :" (name substrate) " is not registered")]))
 
 ;; ---- shared decorate-and-render seam -----------------------------------
@@ -286,17 +286,17 @@
 ;; so the registered + inline paths agree too.
 
 (def ^:private decorator-error-styles
-  {:wrap   {:background (:danger-bg colors/tokens)
+  {:wrap   {:background (:danger-bg rf.story.theme.colors/tokens)
             :border "1px solid #be4040"
-            :color (:danger colors/tokens)
+            :color (:danger rf.story.theme.colors/tokens)
             :padding "8px"
             :margin-top "8px"
             :font-family mono-stack
-            :font-size (:caption typography/type-scale)
+            :font-size (:caption rf.story.theme.typography/type-scale)
             :border-radius "3px"}
    :uncoated {:margin-top "8px"
               :padding "8px"
-              :background (:bg-canvas colors/tokens)
+              :background (:bg-canvas rf.story.theme.colors/tokens)
               :border "1px dashed #555"}})
 
 (defn safe-decorated-view
@@ -311,13 +311,13 @@
   `render-variant` host hook call, so the two agree on the decorated tree."
   [view-hiccup hiccup-decorators effective-args]
   (try
-    (decorators/apply-hiccup-decorators hiccup-decorators view-hiccup effective-args)
+    (rf.story.decorators/apply-hiccup-decorators hiccup-decorators view-hiccup effective-args)
     (catch :default e
       [:div {:style (:wrap decorator-error-styles)}
        [:div "Decorator wrap threw — variant rendered without decorators."]
        [:div {:style {:margin-top "4px"}} (str (.-message e))]
        (when-let [ids (seq (keep :id hiccup-decorators))]
-         [:div {:style {:margin-top "4px" :color (:danger colors/tokens)}}
+         [:div {:style {:margin-top "4px" :color (:danger rf.story.theme.colors/tokens)}}
           (str "decorators in stack: " (str/join ", " (map pr-str ids)))])
        ;; Render the variant body itself uncoated so the user still sees
        ;; *something* — the page never blanks on a decorator failure.
@@ -339,7 +339,7 @@
   [substrate variant-id view-id eff-args decorator-refs]
   (let [view-hiccup (render-view substrate variant-id view-id eff-args)]
     (if (seq decorator-refs)
-      (let [hiccup-decorators (:hiccup (decorators/resolve-decorator-refs decorator-refs))]
+      (let [hiccup-decorators (:hiccup (rf.story.decorators/resolve-decorator-refs decorator-refs))]
         (safe-decorated-view view-hiccup hiccup-decorators eff-args))
       view-hiccup)))
 
@@ -459,14 +459,14 @@
   raw view-id under each substrate. When that work lands, resolve the
   decorator pack here and thread it into each cell's render."
   [variant-id]
-  (let [shell        @state/shell-state-atom
-        variant-body (registrar/handler-meta :variant variant-id)
-        story-id     (args/parent-story-id variant-id)
-        story-body   (when story-id (registrar/handler-meta :story story-id))
+  (let [shell        @rf.story.ui.state/shell-state-atom
+        variant-body (rf.story.registrar/handler-meta :variant variant-id)
+        story-id     (rf.story.args/parent-story-id variant-id)
+        story-body   (when story-id (rf.story.registrar/handler-meta :story story-id))
         substrates   (resolve-substrate-set variant-body story-body
                                             (or (:substrate shell) :reagent))
         view-id      (or (:component variant-body) (:component story-body))
-        eff-args     (args/resolve-args
+        eff-args     (rf.story.args/resolve-args
                        variant-id
                        {:active-modes   (:active-modes shell)
                         :cell-overrides (get-in shell [:cell-overrides variant-id])})]

--- a/tools/story/src/re_frame/story/ui/open_in_editor.cljs
+++ b/tools/story/src/re_frame/story/ui/open_in_editor.cljs
@@ -60,12 +60,12 @@
 
   ## Scheme-rejection denylist
 
-  `editor-uri/editor-uri` rejects `javascript:` / `data:` / `vbscript:`
+  `rf.source-coords.editor-uri/editor-uri` rejects `javascript:` / `data:` / `vbscript:`
   for `{:custom ...}` templates at build time — the spec-mandated
   scheme-rejection list (Security.md / Tool-Pair.md §Editor URI scheme
   allowlist): everything other than the three known-bad schemes passes
   through. The click-time `open!` seam below re-applies the same cheap
-  denylist (`editor-uri/forbidden-scheme?`) because the
+  denylist (`rf.source-coords.editor-uri/forbidden-scheme?`) because the
   `:rf.story.fx/open-in-editor` reg-fx accepts a pre-resolved `{:uri ...}` arg that
   bypasses `editor-uri`'s build-time gating — the denylist must fire at
   every handoff. There is no positive allowlist (it would fail CLOSED on
@@ -79,34 +79,34 @@
   UI shell so this ns never enters a release bundle."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.story.config :as config]
-            [re-frame.source-coords.editor-uri :as editor-uri]
-            [re-frame.source-coords.open-endpoint :as open-endpoint]
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.source-coords.editor-uri :as rf.source-coords.editor-uri]
+            [re-frame.source-coords.open-endpoint :as rf.source-coords.open-endpoint]
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---- styling -------------------------------------------------------------
 
 (def ^:private chip-styles
   {:chip      {:padding         "2px 8px"
-               :background      (:bg-3 colors/tokens)
-               :color           (:info colors/tokens)
+               :background      (:bg-3 rf.story.theme.colors/tokens)
+               :color           (:info rf.story.theme.colors/tokens)
                :border          "1px solid #555"
                :border-radius   "3px"
                :cursor          "pointer"
                :font-family     mono-stack
-               :font-size       (:micro typography/type-scale)
+               :font-size       (:micro rf.story.theme.typography/type-scale)
                :margin-left     "8px"
                :text-decoration "none"
                :display         "inline-block"}
    :chip-test {:padding         "1px 6px"
-               :background      (:bg-2 colors/tokens)
-               :color           (:info colors/tokens)
+               :background      (:bg-2 rf.story.theme.colors/tokens)
+               :color           (:info rf.story.theme.colors/tokens)
                :border          "1px solid #444"
                :border-radius   "2px"
                :cursor          "pointer"
                :font-family     mono-stack
-               :font-size       (:micro typography/type-scale)
+               :font-size       (:micro rf.story.theme.typography/type-scale)
                :margin-left     "8px"
                :text-decoration "none"
                :display         "inline-block"}})
@@ -120,7 +120,7 @@
 
 (defn- parse-file-line
   "Parse a `\"file:line\"` (or bare `\"file\"`) display string into the
-  structured source-coord map shape `editor-uri/editor-uri` expects.
+  structured source-coord map shape `rf.source-coords.editor-uri/editor-uri` expects.
 
   Some Story-host integrations (e.g. agents replaying open-in-editor
   via the MCP surface, panels that flatten a coord to a display
@@ -154,7 +154,7 @@
       (the dispatch shape an external integration may emit).
     - A bare display string `\"file:line\"` (defensive).
 
-  Returns the map form; callers feed it to `editor-uri/editor-uri`
+  Returns the map form; callers feed it to `rf.source-coords.editor-uri/editor-uri`
   unchanged. Mirrors Xray's `coerce-coord` (rf2-r2un8 port)."
   [payload]
   (let [unwrapped (if (and (map? payload) (contains? payload :source-coord))
@@ -167,13 +167,13 @@
 
 (defn resolve-uri
   "Pure-data: source-coord → launchable URI string, or nil. Returns nil
-  when the coord lacks `:file` or when `editor-uri/editor-uri` returns
+  when the coord lacks `:file` or when `rf.source-coords.editor-uri/editor-uri` returns
   nil (a forbidden scheme per rf2-vwcsq — `javascript:` / `data:` /
   `vbscript:`). Per rf2-ox357n there is no positive allowlist: any
   non-dangerous scheme (built-in or unknown custom) passes through.
 
   Per rf2-zfy1e: threads the configured project-root through
-  `editor-uri/editor-uri`'s 3-arg form so a classpath-relative source-
+  `rf.source-coords.editor-uri/editor-uri`'s 3-arg form so a classpath-relative source-
   coord (the common case — macros capture the form-meta `:file` slot,
   typically classpath-relative) resolves to an absolute on-disk path
   the OS-side editor handler can find. The `:project-root` opt is
@@ -185,11 +185,11 @@
   the URI shape across the data path and the side-effect path. Mirrors
   Xray's `resolve-uri` (rf2-r2un8 port)."
   [source-coord]
-  (when (editor-uri/has-source? source-coord)
-    (let [opts {:project-root (config/get-project-root)}]
+  (when (rf.source-coords.editor-uri/has-source? source-coord)
+    (let [opts {:project-root (rf.story.config/get-project-root)}]
       ;; `editor-uri` already denylist-gates the resolved URI inline at
       ;; build time (rf2-vwcsq), returning nil on a forbidden scheme.
-      (editor-uri/editor-uri (config/get-editor) source-coord opts))))
+      (rf.source-coords.editor-uri/editor-uri (rf.story.config/get-editor) source-coord opts))))
 
 ;; ---- side-effect: open the editor ----------------------------------------
 ;;
@@ -238,7 +238,7 @@
   denylist seam.
 
   Per rf2-vwcsq + rf2-ox357n: this fn re-applies the cheap scheme
-  denylist (`editor-uri/forbidden-scheme?`) before handing the URI off.
+  denylist (`rf.source-coords.editor-uri/forbidden-scheme?`) before handing the URI off.
   A URI built via `resolve-uri` was already denylist-gated at build
   time, but the `:rf.story.fx/open-in-editor` reg-fx also accepts a pre-resolved
   `{:uri ...}` arg that bypasses build-time gating — so the denylist
@@ -261,7 +261,7 @@
   tests stub the navigation without mutating `js/window.location`
   (which is non-configurable in modern browsers)."
   [uri]
-  (when (and uri (not (editor-uri/forbidden-scheme? uri)))
+  (when (and uri (not (rf.source-coords.editor-uri/forbidden-scheme? uri)))
     (js/console.log "[rf.story/open-in-editor] navigating to:" uri)
     (@navigator uri)
     nil))
@@ -273,7 +273,7 @@
 ;; (classpath-relative) source-coord against the live source-paths on the
 ;; dev machine at runtime and launches the editor via launch-editor. This
 ;; is ADDITIVE: `open-coord!` first tries the endpoint
-;; (`open-endpoint/open-coord!`); on any failure (no dev server, network
+;; (`rf.source-coords.open-endpoint/open-coord!`); on any failure (no dev server, network
 ;; error, non-2xx — static export / non-shadow host / production
 ;; inspection) it falls back to navigating the historic `editor://` URI via
 ;; `open!`. The URI path is never removed. Mirrors Xray's `open-coord!`.
@@ -289,9 +289,9 @@
   build-time scheme denylist). When the coord cannot produce a usable
   URI either, the fallback is a harmless no-op. Returns nothing."
   [source-coord]
-  (open-endpoint/open-coord!
+  (rf.source-coords.open-endpoint/open-coord!
     source-coord
-    (config/get-editor)
+    (rf.story.config/get-editor)
     (fn [] (open! (resolve-uri source-coord))))
   nil)
 
@@ -299,11 +299,11 @@
 
 (defn open-chip
   "Render an 'Open' chip for a source-coord. Reads the current editor
-  preference from `config/editor`; constructs the URI via
+  preference from `rf.story.config/editor`; constructs the URI via
   `resolve-uri`; click fires `(open! uri)`.
 
   Returns nil when the source-coord has no usable `:file` slot or when
-  `editor-uri/editor-uri` returns nil (a forbidden scheme rejected by
+  `rf.source-coords.editor-uri/editor-uri` returns nil (a forbidden scheme rejected by
   the `editor-uri`-side denylist per rf2-vwcsq). Per rf2-ox357n there is
   no positive allowlist — any non-dangerous scheme produces a chip. The
   UI hides the chip rather than rendering an unclickable affordance.
@@ -321,13 +321,13 @@
    (open-chip source-coord :title))
   ([source-coord variant-of-style]
    (when-let [uri (resolve-uri source-coord)]
-     (let [editor (config/get-editor)
+     (let [editor (rf.story.config/get-editor)
            style  (case variant-of-style
                     :test-detail (:chip-test chip-styles)
                     (:chip chip-styles))]
        [:a {:style       style
             :href        uri
-            :title       (editor-uri/open-button-title source-coord)
+            :title       (rf.source-coords.editor-uri/open-button-title source-coord)
             :data-test   "story-open-in-editor"
             :data-editor (cond
                            (map? editor) "custom"
@@ -359,7 +359,7 @@
   `source-coord` shape: `{:file :line :column}` per
   `re-frame.source-coords`."
   [source-coord]
-  (if (editor-uri/has-source? source-coord)
+  (if (rf.source-coords.editor-uri/has-source? source-coord)
     (do (open-coord! source-coord)
         true)
     false))

--- a/tools/story/src/re_frame/story/ui/panels.cljs
+++ b/tools/story/src/re_frame/story/ui/panels.cljs
@@ -35,29 +35,29 @@
                                 from the Story trace buffer."
   (:require [reagent.core :as r]
             [re-frame.core :as rf]
-            [re-frame.story.config :as config]
-            [re-frame.story.args :as args]
-            [re-frame.story.layout-debug :as layout-debug]
-            [re-frame.story.registrar :as story-registrar]
-            [re-frame.story.ui.a11y :as a11y]
-            [re-frame.story.ui.chrome-a11y :as chrome-a11y]
-            [re-frame.story.ui.schema-validation :as schema-validation]
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.args :as rf.story.args]
+            [re-frame.story.layout-debug :as rf.story.layout-debug]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.ui.a11y :as rf.story.ui.a11y]
+            [re-frame.story.ui.chrome-a11y :as rf.story.ui.chrome-a11y]
+            [re-frame.story.ui.schema-validation :as rf.story.ui.schema-validation]
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---- styling -------------------------------------------------------------
 
 (def ^:private styles
   {:layout-wrap  {:padding "8px"
-                  :background (:bg-2 colors/tokens)
-                  :color (:text-primary colors/tokens)
+                  :background (:bg-2 rf.story.theme.colors/tokens)
+                  :color (:text-primary rf.story.theme.colors/tokens)
                   :font-family mono-stack
-                  :font-size (:caption typography/type-scale)
+                  :font-size (:caption rf.story.theme.typography/type-scale)
                   :border-top "1px solid #444"}
    :layout-title {:font-weight "bold"
-                  :color (:text-secondary colors/tokens)
+                  :color (:text-secondary rf.story.theme.colors/tokens)
                   :text-transform "uppercase"
-                  :font-size (:micro typography/type-scale)
+                  :font-size (:micro rf.story.theme.typography/type-scale)
                   :letter-spacing "0.5px"
                   :margin-bottom "6px"}
    :toggle       {:display "flex"
@@ -66,10 +66,10 @@
                   :padding "4px 0"
                   :cursor "pointer"
                   :user-select "none"}
-   :decor-id     {:color (:info colors/tokens)}
-   :hint         {:color (:text-tertiary colors/tokens)
+   :decor-id     {:color (:info rf.story.theme.colors/tokens)}
+   :hint         {:color (:text-tertiary rf.story.theme.colors/tokens)
                   :font-style "italic"
-                  :font-size (:micro typography/type-scale)
+                  :font-size (:micro rf.story.theme.typography/type-scale)
                   :margin-top "6px"}})
 
 ;; ---- layout-debug controls panel ---------------------------------------
@@ -133,9 +133,9 @@
           on-for (get active variant-id #{})]
       [:div {:style (:layout-wrap styles)}
        [:div {:style (:layout-title styles)} "Layout-debug"]
-       (for [id [layout-debug/id-measure
-                 layout-debug/id-outline
-                 layout-debug/id-pseudo]]
+       (for [id [rf.story.layout-debug/id-measure
+                 rf.story.layout-debug/id-outline
+                 rf.story.layout-debug/id-pseudo]]
          ^{:key id}
          [:label {:style (:toggle styles)}
           [:input {:type      "checkbox"
@@ -169,25 +169,25 @@
   Idempotent. Production builds with `:rf.story/enabled?` false skip
   registration."
   []
-  (when config/enabled?
+  (when rf.story.config/enabled?
     ;; Layout-debug controls panel.
     (reg-view! layout-debug-render-id layout-debug-view)
-    (story-registrar/reg-story-panel*
+    (rf.story.registrar/reg-story-panel*
       layout-debug-panel-id
       {:doc       "Layout-debug decorator toggles (measure / outline / pseudo)."
        :title     "Layout-debug"
        :placement :right
        :render    layout-debug-render-id})
     ;; A11y panel — registers in its own ns.
-    (a11y/install-canonical-a11y!)
+    (rf.story.ui.a11y/install-canonical-a11y!)
     ;; Chrome-a11y panel — sibling of the variant a11y
     ;; panel scoped to `[data-rf-story-root]` so Story dogfoods axe-
     ;; core against its OWN chrome (the variant a11y panel scopes to
     ;; the variant tree only).
-    (chrome-a11y/install-canonical-chrome-a11y!)
+    (rf.story.ui.chrome-a11y/install-canonical-chrome-a11y!)
     ;; Schema-validation panel registers in its own ns
     ;; so the late-bind validator lookup stays isolated.
-    (schema-validation/install!)))
+    (rf.story.ui.schema-validation/install!)))
 
 ;; ---- panel host ---------------------------------------------------------
 
@@ -197,11 +197,11 @@
                  :justify-content "space-between"
                  :align-items "center"
                  :padding "4px 10px"
-                 :background (:bg-2 colors/tokens)
+                 :background (:bg-2 rf.story.theme.colors/tokens)
                  :border-bottom "1px solid #444"
-                 :color (:text-secondary colors/tokens)
+                 :color (:text-secondary rf.story.theme.colors/tokens)
                  :font-family mono-stack
-                 :font-size (:micro typography/type-scale)
+                 :font-size (:micro rf.story.theme.typography/type-scale)
                  :text-transform "uppercase"
                  :letter-spacing "0.5px"}})
 
@@ -214,7 +214,7 @@
   (let [targets (:for body)]
     (or (empty? targets)
         (contains? targets variant-id)
-        (contains? targets (args/parent-story-id variant-id)))))
+        (contains? targets (rf.story.args/parent-story-id variant-id)))))
 
 (defn render-panels-at-placement
   "Render every registered `:story-panel` whose `:placement` matches
@@ -231,7 +231,7 @@
 
   Returns a hiccup vector wrapping the resolved panels."
   [placement variant-id panel-visibility]
-  (let [panels (story-registrar/registrations :story-panel)
+  (let [panels (rf.story.registrar/registrations :story-panel)
         slots  (->> panels
                     (filter (fn [[pid body]]
                               (and (= placement (:placement body))
@@ -248,7 +248,7 @@
          [:div
           [:div {:style (:panel-head host-styles)}
            [:span (:title body)]
-           [:span {:style {:color (:text-tertiary colors/tokens)}} (str pid)]]
+           [:span {:style {:color (:text-tertiary rf.story.theme.colors/tokens)}} (str pid)]]
           (if view-fn
             ;; rf2-zme7: scope the panel view's subscribe / dispatch to
             ;; the active variant's frame. The SCOPE-only `rf/frame-provider
@@ -257,7 +257,7 @@
             ;; Reagent's `:r>` interop head, rf2-c5jz).
             [rf/frame-provider {:frame variant-id}
              [view-fn variant-id]]
-            [:div {:style {:padding "8px" :color (:text-secondary colors/tokens)
-                           :font-style "italic" :font-size (:micro typography/type-scale)}}
+            [:div {:style {:padding "8px" :color (:text-secondary rf.story.theme.colors/tokens)
+                           :font-style "italic" :font-size (:micro rf.story.theme.typography/type-scale)}}
              (str "panel " (pr-str pid)
                   " has no registered :render view (" (pr-str view-id) ")")])]))]))

--- a/tools/story/src/re_frame/story/ui/play_status.cljs
+++ b/tools/story/src/re_frame/story/ui/play_status.cljs
@@ -15,7 +15,7 @@
      first failed assertion + a click-to-highlight affordance for
      `:assert-dom` failures.
 
-  Both components deref `runner-events/run-state` so Reagent re-renders
+  Both components deref `rf.story.play.runner-events/run-state` so Reagent re-renders
   observe every step transition. Production CLJS builds DCE the file
   entirely via `re-frame.story.config/enabled?`.
 
@@ -38,24 +38,24 @@
   runs every play sequentially, updating the chip as each one
   completes."
   (:require [reagent.core                    :as r]
-            [re-frame.story.config           :as config]
-            [re-frame.story.play.dom         :as dom]
-            [re-frame.story.play.runner      :as runner]
-            [re-frame.story.play.runner-events :as runner-events]
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+            [re-frame.story.config           :as rf.story.config]
+            [re-frame.story.play.dom         :as rf.story.play.dom]
+            [re-frame.story.play.runner      :as rf.story.play.runner]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---- styles ---------------------------------------------------------------
 
 (def ^:private styles
   {:chip-base   {:padding         "3px 8px"
-                 :background      (:bg-3 colors/tokens)
-                 :color           (:text-primary colors/tokens)
+                 :background      (:bg-3 rf.story.theme.colors/tokens)
+                 :color           (:text-primary rf.story.theme.colors/tokens)
                  :border          "none"
                  :border-radius   "10px"
                  :cursor          "pointer"
                  :font-family     mono-stack
-                 :font-size       (:caption typography/type-scale)
+                 :font-size       (:caption rf.story.theme.typography/type-scale)
                  :user-select     "none"
                  :display         "inline-flex"
                  :align-items     "center"
@@ -66,17 +66,17 @@
                   :color      "#fae766"}
    :chip-pass    {:background "#1c4a1c"
                   :color      "#7be07b"}
-   :chip-fail    {:background (:danger-bg colors/tokens)
+   :chip-fail    {:background (:danger-bg rf.story.theme.colors/tokens)
                   :color      "#fda3a3"}
-   :chip-icon    {:font-size (:micro typography/type-scale)}
+   :chip-icon    {:font-size (:micro rf.story.theme.typography/type-scale)}
    :re-run-btn   {:padding         "2px 6px"
-                  :background      (:tag-dev-bg colors/tokens)
+                  :background      (:tag-dev-bg rf.story.theme.colors/tokens)
                   :color           "white"
                   :border          "1px solid #264f78"
                   :border-radius   "3px"
                   :cursor          "pointer"
                   :font-family     mono-stack
-                  :font-size       (:micro typography/type-scale)
+                  :font-size       (:micro rf.story.theme.typography/type-scale)
                   :margin-left     "4px"}
    :dropdown-btn {:padding         "0 4px"
                   :background      "transparent"
@@ -84,18 +84,18 @@
                   :border          "none"
                   :cursor          "pointer"
                   :font-family     mono-stack
-                  :font-size       (:micro typography/type-scale)
+                  :font-size       (:micro rf.story.theme.typography/type-scale)
                   :line-height     "1"}
    :dropdown-panel {:position       "absolute"
                     :top            "100%"
                     :left           "0"
                     :margin-top     "4px"
-                    :background     (:bg-canvas colors/tokens)
-                    :color          (:text-primary colors/tokens)
+                    :background     (:bg-canvas rf.story.theme.colors/tokens)
+                    :color          (:text-primary rf.story.theme.colors/tokens)
                     :border         "1px solid #3c3c3c"
                     :border-radius  "4px"
                     :font-family    mono-stack
-                    :font-size      (:caption typography/type-scale)
+                    :font-size      (:caption rf.story.theme.typography/type-scale)
                     :min-width      "220px"
                     :max-width      "320px"
                     :z-index        "2147483646"
@@ -113,18 +113,18 @@
                   :width           "100%"
                   :text-align      "left"
                   :font-family     mono-stack
-                  :font-size       (:caption typography/type-scale)}
-   :dropdown-row-active {:background (:tag-dev-bg colors/tokens)
+                  :font-size       (:caption rf.story.theme.typography/type-scale)}
+   :dropdown-row-active {:background (:tag-dev-bg rf.story.theme.colors/tokens)
                          :color      "white"}
    :dropdown-row-name   {:overflow      "hidden"
                          :text-overflow "ellipsis"
                          :white-space   "nowrap"
                          :flex          "1 1 auto"}
    :dropdown-row-status {:flex          "0 0 auto"
-                         :font-size     (:nano typography/type-scale)
+                         :font-size     (:nano rf.story.theme.typography/type-scale)
                          :text-transform "uppercase"
                          :opacity       "0.85"}
-   :dropdown-divider    {:height "1px" :background (:border-default colors/tokens)}
+   :dropdown-divider    {:height "1px" :background (:border-default rf.story.theme.colors/tokens)}
    :dropdown-run-all    {:padding         "6px 10px"
                          :cursor          "pointer"
                          :display         "block"
@@ -134,12 +134,12 @@
                          :background      "transparent"
                          :color           "#7bbcff"
                          :font-family     mono-stack
-                         :font-size       (:caption typography/type-scale)}
-   :banner       {:background     (:danger-bg colors/tokens)
+                         :font-size       (:caption rf.story.theme.typography/type-scale)}
+   :banner       {:background     (:danger-bg rf.story.theme.colors/tokens)
                   :color          "#fde0e0"
                   :padding        "8px 14px"
                   :font-family    mono-stack
-                  :font-size      (:body-tight typography/type-scale)
+                  :font-size      (:body-tight rf.story.theme.typography/type-scale)
                   :border-bottom  "2px solid #be4040"
                   :display        "flex"
                   :align-items    "flex-start"
@@ -157,7 +157,7 @@
                   :border-radius   "3px"
                   :cursor          "pointer"
                   :font-family     mono-stack
-                  :font-size       (:micro typography/type-scale)}})
+                  :font-size       (:micro rf.story.theme.typography/type-scale)}})
 
 ;; ---- chip helpers ---------------------------------------------------------
 
@@ -186,7 +186,7 @@
   [state]
   (if (nil? state)
     "Play: IDLE"
-    (str "Play: " (runner/progress-str state))))
+    (str "Play: " (rf.story.play.runner/progress-str state))))
 
 (defn chip-label-multi
   "Pure helper — render the chip's text for a multi-play variant. The
@@ -199,7 +199,7 @@
   [state play-name]
   (let [status-str (if (nil? state)
                      "IDLE"
-                     (runner/progress-str state))
+                     (rf.story.play.runner/progress-str state))
         nm         (or play-name "(default)")]
     (str "Play " nm " | " status-str)))
 
@@ -222,8 +222,8 @@
   "Best-effort: locate the selector from the first DOM-class failure
   and scroll-into-view + flash a temporary outline. CLJS-only."
   [selector]
-  (when (and selector (dom/dom-available?))
-    (when-let [node (dom/query selector)]
+  (when (and selector (rf.story.play.dom/dom-available?))
+    (when-let [node (rf.story.play.dom/query selector)]
       (try
         (.scrollIntoView node #js {:behavior "smooth" :block "center"})
         (let [orig (.. node -style -outline)]
@@ -249,7 +249,7 @@
          :on-click  (fn [e] (.stopPropagation e))}
    (for [[idx spec] (map-indexed vector plays)
          :let [pk     (:name spec)
-               state  (runner-events/current-state-for-play variant-id pk)
+               state  (rf.story.play.runner-events/current-state-for-play variant-id pk)
                status (or (:status state) :idle)
                active? (= active-key pk)]]
      ^{:key (str pk "-" idx)}
@@ -265,7 +265,7 @@
        :on-click    (fn [e]
                       (.stopPropagation e)
                       (close!)
-                      (runner-events/run-play! variant-id pk))}
+                      (rf.story.play.runner-events/run-play! variant-id pk))}
       [:span {:style (:dropdown-row-name styles)} (or pk "(unnamed)")]
       [:span {:style (:dropdown-row-status styles)} (dropdown-row-status state)]])
    [:div {:style (:dropdown-divider styles)}]
@@ -277,12 +277,12 @@
      :on-click  (fn [e]
                   (.stopPropagation e)
                   (close!)
-                  (runner-events/run-all-plays! variant-id))}
+                  (rf.story.play.runner-events/run-all-plays! variant-id))}
     (str "Run all (" (count plays) ")")]])
 
 (defn chip
   "Render the play-status chip for `variant-id`. Form-2 component; the
-  outer `runner-events/run-state` deref drives re-renders. Tagged with
+  outer `rf.story.play.runner-events/run-state` deref drives re-renders. Tagged with
   `data-test=\"story-play-status\"` for browser tests.
 
   rf2-tl7zk multi-play: when the variant declares `:plays` (more than
@@ -291,18 +291,18 @@
   [variant-id]
   (let [open? (r/atom false)]
     (fn [variant-id]
-      (let [plays      (runner-events/variant-plays variant-id)
-            multi?     (runner/multi? plays)
-            active-key (or (runner-events/active-play-key variant-id)
-                           (runner/default-play-key plays))
+      (let [plays      (rf.story.play.runner-events/variant-plays variant-id)
+            multi?     (rf.story.play.runner/multi? plays)
+            active-key (or (rf.story.play.runner-events/active-play-key variant-id)
+                           (rf.story.play.runner/default-play-key plays))
             ;; In multi-play mode, the chip's state reflects the
             ;; ACTIVE play's per-(variant, play) row; in single-play
             ;; mode it reflects the legacy single-script state.
             state      (if multi?
-                         (runner-events/current-state-for-play variant-id active-key)
-                         (get @runner-events/run-state variant-id))
+                         (rf.story.play.runner-events/current-state-for-play variant-id active-key)
+                         (get @rf.story.play.runner-events/run-state variant-id))
             status     (or (:status state) :idle)
-            active-spec (runner/find-play plays active-key)
+            active-spec (rf.story.play.runner/find-play plays active-key)
             active-name (when active-spec (:name active-spec))
             label      (if multi?
                          (chip-label-multi state active-name)
@@ -341,7 +341,7 @@
                              "the play script"))
            :on-click  (fn [e]
                         (.stopPropagation e)
-                        (runner-events/re-run! variant-id))}
+                        (rf.story.play.runner-events/re-run! variant-id))}
           "Re-run"]]))))
 
 ;; ---- failure banner -------------------------------------------------------
@@ -351,8 +351,8 @@
   when the run is not in `:fail` state. Exposed for unit tests."
   [state]
   (when (and state (= :fail (:status state)))
-    (let [{:keys [count first]} (runner/fail-summary state)
-          summary (runner/step-summary (:step first))
+    (let [{:keys [count first]} (rf.story.play.runner/fail-summary state)
+          summary (rf.story.play.runner/step-summary (:step first))
           msg     (:message first)]
       (str count " failure" (when (not= 1 count) "s") " — step "
            (inc (:idx first)) ": " summary
@@ -363,10 +363,10 @@
   most recent run did not fail. Tagged with
   `data-test=\"story-play-banner\"`."
   [variant-id]
-  (let [state (get @runner-events/run-state variant-id)]
+  (let [state (get @rf.story.play.runner-events/run-state variant-id)]
     (when (banner-text state)
-      (let [{:keys [first]} (runner/fail-summary state)
-            sel (runner/step-selector (:step first))]
+      (let [{:keys [first]} (rf.story.play.runner/fail-summary state)
+            sel (rf.story.play.runner/step-selector (:step first))]
         [:div {:style     (:banner styles)
                :role      "alert"
                :data-test "story-play-banner"}
@@ -381,7 +381,7 @@
          [:button {:style    (:banner-btn styles)
                    :data-test "story-play-banner-re-run"
                    :title    "Re-run the play script"
-                   :on-click (fn [_] (runner-events/re-run! variant-id))}
+                   :on-click (fn [_] (rf.story.play.runner-events/re-run! variant-id))}
           "Re-run"]]))))
 
 ;; ---- production-elision wrapper ------------------------------------------
@@ -395,8 +395,8 @@
   rf2-tl7zk: checks both single-script + multi-play surfaces via
   `variant-plays` (which resolves both)."
   [variant-id]
-  (when (and config/enabled? variant-id)
-    (let [plays (runner-events/variant-plays variant-id)]
+  (when (and rf.story.config/enabled? variant-id)
+    (let [plays (rf.story.play.runner-events/variant-plays variant-id)]
       (when (some (fn [p] (seq (:script p))) plays)
         [chip variant-id]))))
 
@@ -406,7 +406,7 @@
   is not in `:fail` — `chip-when-enabled` mirrors that check at the
   spec-presence layer."
   [variant-id]
-  (when (and config/enabled? variant-id)
-    (let [plays (runner-events/variant-plays variant-id)]
+  (when (and rf.story.config/enabled? variant-id)
+    (let [plays (rf.story.play.runner-events/variant-plays variant-id)]
       (when (some (fn [p] (seq (:script p))) plays)
         [banner variant-id]))))

--- a/tools/story/src/re_frame/story/ui/promotion.cljc
+++ b/tools/story/src/re_frame/story/ui/promotion.cljc
@@ -52,22 +52,22 @@
 
   ## Elision
 
-  Every impure entry opens with `(when config/enabled? …)` so production
+  Every impure entry opens with `(when rf.story.config/enabled? …)` so production
   CLJS builds short-circuit before any DOM / registrar touch (mirroring
   `save-variant` + the substrate's `promote-run-artifact!`)."
   (:require [clojure.string :as str]
-            [re-frame.story.artifact  :as artifact]
-            [re-frame.story.predicates :as pred]
-            [re-frame.story.promotion :as promotion]
+            [re-frame.story.artifact  :as rf.story.artifact]
+            [re-frame.story.predicates :as rf.story.predicates]
+            [re-frame.story.promotion :as rf.story.promotion]
             ;; `review-dialog` is `.cljc` — its pure transitions
             ;; (`default-variant-id-with-prefix` / `parse-variant-id-string`)
             ;; are JVM-available; its Reagent + renderer surface is behind
             ;; `:cljs` reader conditionals, so the require is safe on the JVM.
-            [re-frame.story.review-dialog :as review-dialog]
+            [re-frame.story.review-dialog :as rf.story.review-dialog]
             #?@(:cljs [[reagent.core :as r]
-                       [re-frame.story.config        :as config]
-                       [re-frame.story.theme.typography :as typography :refer [mono-stack sans-stack]]
-                       [re-frame.story.theme.colors :as colors]])))
+                       [re-frame.story.config        :as rf.story.config]
+                       [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack sans-stack]]
+                       [re-frame.story.theme.colors :as rf.story.theme.colors]])))
 
 ;; ===========================================================================
 ;; PURE: artifact identity + label  (the capture store keys)
@@ -82,7 +82,7 @@
   `:rf.test.artifact/*` namespace marks the id as a capture-store key,
   never a variant id."
   [artifact]
-  (let [core (promotion/provenance-link artifact)
+  (let [core (rf.story.promotion/provenance-link artifact)
         seed (:seed artifact)
         tag  (if (some? seed)
                (str "seed-" seed)
@@ -97,7 +97,7 @@
   [artifact]
   (let [kind   (name (:artifact/kind artifact :rf.test/run-artifact))
         status (some-> artifact :result :status name)
-        steps  (count (artifact/program-events artifact))]
+        steps  (count (rf.story.artifact/program-events artifact))]
     (str (when status (str status " · "))
          steps (if (= 1 steps) " step" " steps")
          (when (and kind (not= kind "run-artifact"))
@@ -122,9 +122,9 @@
   play-events) — promotion needs a replayable program."
   [result play-events]
   (or (let [linked (:run-artifact result)]
-        (when (artifact/run-artifact? linked) linked))
+        (when (rf.story.artifact/run-artifact? linked) linked))
       (when (seq play-events)
-        (artifact/make-run-artifact
+        (rf.story.artifact/make-run-artifact
           {:event-program (vec play-events)
            :result        result}))))
 
@@ -142,11 +142,11 @@
   "Derive a sensible default promoted-variant id from a `source-story-id`
   (the story the artifact belongs to, when known) + a wall-clock millis
   stamp. Pure data → keyword | nil. Delegates to
-  `review-dialog/default-variant-id-with-prefix` with the `\"regression\"`
+  `rf.story.review-dialog/default-variant-id-with-prefix` with the `\"regression\"`
   prefix; nil when no qualified source story is known (the dialog then
   falls back to a placeholder literal)."
   [source-story-id now-ms]
-  (review-dialog/default-variant-id-with-prefix source-story-id now-ms default-id-prefix))
+  (rf.story.review-dialog/default-variant-id-with-prefix source-story-id now-ms default-id-prefix))
 
 (defn draft->promote-opts
   "Project a promotion `draft` map into the `opts` map the substrate's
@@ -159,7 +159,7 @@
   - `:tags`        ← `:tags` (when non-empty)
   - `:setup-count` ← `:setup-count` (the precondition/behaviour cut; when
                      a non-negative integer — see
-                     `promotion/partition-program`)
+                     `rf.story.promotion/partition-program`)
   - `:extends`     ← `:extends` (a parent variant id to inherit
                      component/decorators/args from, when set)
 
@@ -191,7 +191,7 @@
   [artifact draft]
   (let [opts       (draft->promote-opts draft)
         variant-id (or (:variant/id opts) :story.regression/example)
-        body       (promotion/artifact->variant-body artifact opts)
+        body       (rf.story.promotion/artifact->variant-body artifact opts)
         ;; Render the body keys in a stable, readable order. The body is
         ;; data the substrate produced; we pr-str each slot so the snippet
         ;; round-trips through read-string + the registrar.
@@ -201,7 +201,7 @@
                                 (when (contains? body k)
                                   [k (pr-str (get body k))])))
                         vec)]
-    (pred/reg-variant-form "story" variant-id body-keys)))
+    (rf.story.predicates/reg-variant-form "story" variant-id body-keys)))
 
 ;; ===========================================================================
 ;; CLJS-ONLY: the capture store
@@ -235,7 +235,7 @@
      dialog can derive a same-story default promoted-id. Optional."
      ([artifact] (capture! artifact nil))
      ([artifact origin]
-      (when (and config/enabled? (artifact/run-artifact? artifact))
+      (when (and rf.story.config/enabled? (rf.story.artifact/run-artifact? artifact))
         (let [id (artifact-id artifact)]
           (swap! captured-atom assoc id
                  {:id            id
@@ -331,7 +331,7 @@
      setup-cut 0 + an `:extends` to the origin variant when known). No-op
      when the id is not in the capture store or Story is disabled."
      [artifact-id]
-     (when (and config/enabled? (contains? @captured-atom artifact-id))
+     (when (and rf.story.config/enabled? (contains? @captured-atom artifact-id))
        (let [entry (get @captured-atom artifact-id)
              now   (.now js/Date)]
          ;; Full reset (incl. `:promoted-id nil`) — a freshly-opened artifact
@@ -368,12 +368,12 @@
 #?(:cljs
    (defn set-draft-id!
      "Per-keystroke promoted-id edit. Parses the raw input string into a
-     keyword best-effort (`review-dialog/parse-variant-id-string`); stores
+     keyword best-effort (`rf.story.review-dialog/parse-variant-id-string`); stores
      the raw string on parse failure so the input value the user sees
      doesn't get clobbered mid-keystroke."
      [s]
      (update-draft! (fn [d] (assoc d :variant-id
-                                   (or (review-dialog/parse-variant-id-string s) s))))))
+                                   (or (rf.story.review-dialog/parse-variant-id-string s) s))))))
 
 #?(:cljs
    (defn set-draft-doc!
@@ -421,7 +421,7 @@
      substrate would throw `:rf.error/story-promote-no-id`; the dialog gates
      the button on a present id, but we guard here too)."
      [artifact-id draft]
-     (when config/enabled?
+     (when rf.story.config/enabled?
        (when-let [entry (get @captured-atom artifact-id)]
          (let [opts (draft->promote-opts draft)]
            (when (some? (:variant/id opts))
@@ -429,7 +429,7 @@
              ;; → :setup, behaviour → :script, trimmed link → :run-artifact)
              ;; and writes it through the reg-variant write path. We do NOT
              ;; touch the capture store — the artifact stays as evidence.
-             (promotion/promote-run-artifact! (:artifact entry) opts)))))))
+             (rf.story.promotion/promote-run-artifact! (:artifact entry) opts)))))))
 
 ;; ===========================================================================
 ;; CLJS-ONLY: the dialog hiccup
@@ -447,55 +447,55 @@
    (def ^:private styles
      {:section   {:margin "8px 0 0 0"}
       :label     {:font-family mono-stack
-                  :font-size   (:micro typography/type-scale)
-                  :color       (:text-tertiary colors/tokens)
+                  :font-size   (:micro rf.story.theme.typography/type-scale)
+                  :color       (:text-tertiary rf.story.theme.colors/tokens)
                   :margin      "0 0 3px 0"
                   :text-transform "uppercase"
                   :letter-spacing "0.04em"}
       :doc-input {:padding       "5px 8px"
-                  :background    (:bg-2 colors/tokens)
+                  :background    (:bg-2 rf.story.theme.colors/tokens)
                   :color         "white"
                   :border        "1px solid #444"
                   :border-radius "3px"
                   :font-family   sans-stack
-                  :font-size     (:body-tight typography/type-scale)
+                  :font-size     (:body-tight rf.story.theme.typography/type-scale)
                   :width         "100%"
                   :box-sizing    "border-box"}
       :num-input {:padding       "5px 8px"
-                  :background    (:bg-2 colors/tokens)
+                  :background    (:bg-2 rf.story.theme.colors/tokens)
                   :color         "white"
                   :border        "1px solid #444"
                   :border-radius "3px"
                   :font-family   mono-stack
-                  :font-size     (:body-tight typography/type-scale)
+                  :font-size     (:body-tight rf.story.theme.typography/type-scale)
                   :width         "72px"
                   :box-sizing    "border-box"}
       :tag-row   {:display "flex" :gap "6px" :flex-wrap "wrap"}
       :tag       {:font-family mono-stack
-                  :font-size   (:micro typography/type-scale)
-                  :background  (:bg-2 colors/tokens)
+                  :font-size   (:micro rf.story.theme.typography/type-scale)
+                  :background  (:bg-2 rf.story.theme.colors/tokens)
                   :color       "#999"
                   :border      "1px solid #444"
                   :border-radius "10px"
                   :padding     "1px 9px"
                   :cursor      "pointer"
                   :user-select "none"}
-      :tag-on    {:background (:accent-amber colors/tokens)
+      :tag-on    {:background (:accent-amber rf.story.theme.colors/tokens)
                   :color      "white"
-                  :border     (str "1px solid " (:accent-amber colors/tokens))}
-      :note      {:color      (:text-tertiary colors/tokens)
-                  :font-size  (:nano typography/type-scale)
+                  :border     (str "1px solid " (:accent-amber rf.story.theme.colors/tokens))}
+      :note      {:color      (:text-tertiary rf.story.theme.colors/tokens)
+                  :font-size  (:nano rf.story.theme.typography/type-scale)
                   :font-style "italic"
                   :margin-top "2px"}
       :promote-btn {:padding       "5px 12px"
-                    :background    (:accent-amber colors/tokens)
+                    :background    (:accent-amber rf.story.theme.colors/tokens)
                     :color         "white"
                     :border        "none"
                     :border-radius "3px"
                     :cursor        "pointer"
                     :font-family   mono-stack
-                    :font-size     (:caption typography/type-scale)}
-      :promote-disabled {:background (:bg-2 colors/tokens)
+                    :font-size     (:caption rf.story.theme.typography/type-scale)}
+      :promote-disabled {:background (:bg-2 rf.story.theme.colors/tokens)
                          :color      "#777"
                          :cursor     "not-allowed"
                          :border     "1px solid #444"}}))
@@ -515,7 +515,7 @@
                     :border "1px solid #3a703a"
                     :border-radius "3px"
                     :font-family mono-stack
-                    :font-size (:micro typography/type-scale)
+                    :font-size (:micro rf.story.theme.typography/type-scale)
                     :line-height "1.5"}}
       [:div {:style {:font-weight "bold" :margin-bottom "3px"}}
        (str "Promoted to " (pr-str promoted-id))]
@@ -529,7 +529,7 @@
      cut, and the tag chips. The id input + snippet + copy/close ride the
      shared `review-dialog` skeleton (the id edit reuses its input)."
      [artifact draft]
-     (let [steps (count (artifact/program-events artifact))]
+     (let [steps (count (rf.story.artifact/program-events artifact))]
        [:div {:data-test "story-promotion-curation"}
         ;; ---- doc ----
         [:div {:style (:section styles)}
@@ -604,7 +604,7 @@
                      rv-state {:open?     true
                                :draft-id  (:variant-id draft)
                                :source-id (:extends draft)}]
-                 (review-dialog/review-dialog rv-state
+                 (rf.story.review-dialog/review-dialog rv-state
                    {:title  "Promote captured run artifact to regression variant"
                     :hint   [:div
                              [:div (str "Promoting captured artifact "
@@ -620,7 +620,7 @@
                     :placeholder-id    :story.regression/example
                     :placeholder-input ":story.your-story/regression-042"
                     :on-edit-id        set-draft-id!
-                    :on-copy           (fn [] (review-dialog/copy-to-clipboard! snippet))
+                    :on-copy           (fn [] (rf.story.review-dialog/copy-to-clipboard! snippet))
                     ;; The PRIMARY action drives the
                     ;; substrate's `promote-run-artifact!` register path
                     ;; (review-dialog renders it as the accent button left

--- a/tools/story/src/re_frame/story/ui/recorder.cljs
+++ b/tools/story/src/re_frame/story/ui/recorder.cljs
@@ -9,7 +9,7 @@
     chrome-wide and visually unmistakable.
   - The trace bus — installs a per-process listener that filters
     `:rf.event/dispatched` events targeting the currently-focused variant
-    frame and feeds them into `recorder/record-event!`.
+    frame and feeds them into `rf.story.recorder/record-event!`.
   - A save-as-variant dialog — when the user stops recording, a modal
     surfaces the captured EDN snippet (the `(reg-variant ...)` form
     they paste into source).
@@ -57,46 +57,46 @@
 
   ## Elision
 
-  Every public fn opens with `(when config/enabled? ...)` so production
+  Every public fn opens with `(when rf.story.config/enabled? ...)` so production
   CLJS builds short-circuit before any DOM call. The listener install
   is also gated."
   (:require [cljs.reader]
             [clojure.string :as str]
             [reagent.core :as r]
-            [re-frame.story.config                       :as config]
-            [re-frame.story.recorder                     :as recorder]
-            [re-frame.story.recorder.dom-capture         :as recorder-dom]
-            [re-frame.story.recorder.play-export         :as play-export]
-            [re-frame.story.review-dialog                :as review-dialog]
-            [re-frame.story.ui.a11y-dialog               :as a11y-dialog]
-            [re-frame.story.ui.recorder-export-dialog    :as export-dialog]
-            [re-frame.story.ui.state                     :as state]
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+            [re-frame.story.config                       :as rf.story.config]
+            [re-frame.story.recorder                     :as rf.story.recorder]
+            [re-frame.story.recorder.dom-capture         :as rf.story.recorder.dom-capture]
+            [re-frame.story.recorder.play-export         :as rf.story.recorder.play-export]
+            [re-frame.story.review-dialog                :as rf.story.review-dialog]
+            [re-frame.story.ui.a11y-dialog               :as rf.story.ui.a11y-dialog]
+            [re-frame.story.ui.recorder-export-dialog    :as rf.story.ui.recorder-export-dialog]
+            [re-frame.story.ui.state                     :as rf.story.ui.state]
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---------------------------------------------------------------------------
 ;; Reagent mirror of the recorder state
 ;;
-;; `recorder/state` is a plain `atom` so JVM tests can exercise the state
+;; `rf.story.recorder/state` is a plain `atom` so JVM tests can exercise the state
 ;; machine. CLJS-side we mirror it into a `r/atom` so the toolbar chip /
 ;; overlay auto-re-render on every transition. A `add-watch` on the
 ;; pure atom keeps the mirror in sync.
 ;; ---------------------------------------------------------------------------
 
 (defonce ui-state
-  (r/atom (recorder/current-state)))
+  (r/atom (rf.story.recorder/current-state)))
 
 (defonce ^:private mirror-installed?
   (atom false))
 
 (defn- install-mirror! []
-  (when (and config/enabled? (not @mirror-installed?))
+  (when (and rf.story.config/enabled? (not @mirror-installed?))
     (reset! mirror-installed? true)
-    (add-watch recorder/state ::ui-mirror
+    (add-watch rf.story.recorder/state ::ui-mirror
                (fn [_ _ _ new-state]
                  (reset! ui-state new-state)))
     ;; Seed once at install time so the mirror starts in sync.
-    (reset! ui-state (recorder/current-state))))
+    (reset! ui-state (rf.story.recorder/current-state))))
 
 ;; ---------------------------------------------------------------------------
 ;; Trace-bus listener wiring
@@ -111,16 +111,16 @@
   "Install the recorder's trace-bus listener + seed the Reagent state
   mirror. Idempotent."
   []
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (install-mirror!)
-    (recorder/install-trace-listener!)
+    (rf.story.recorder/install-trace-listener!)
     nil))
 
 (defn remove-trace-listener!
   "Tear down the recorder's trace-bus listener. Idempotent."
   []
-  (when config/enabled?
-    (recorder/remove-trace-listener!)
+  (when rf.story.config/enabled?
+    (rf.story.recorder/remove-trace-listener!)
     nil))
 
 ;; ---------------------------------------------------------------------------
@@ -132,13 +132,13 @@
                  :align-items     "center"
                  :gap             "5px"
                  :padding         "3px 10px"
-                 :background      (:bg-3 colors/tokens)
-                 :color           (:text-primary colors/tokens)
+                 :background      (:bg-3 rf.story.theme.colors/tokens)
+                 :color           (:text-primary rf.story.theme.colors/tokens)
                  :border          "none"
                  :border-radius   "10px"
                  :cursor          "pointer"
                  :font-family     mono-stack
-                 :font-size       (:caption typography/type-scale)
+                 :font-size       (:caption rf.story.theme.typography/type-scale)
                  :user-select     "none"
                  :letter-spacing  "0.4px"}
    :chip-active {:display         "inline-flex"
@@ -151,7 +151,7 @@
                  :border-radius   "10px"
                  :cursor          "pointer"
                  :font-family     mono-stack
-                 :font-size       (:caption typography/type-scale)
+                 :font-size       (:caption rf.story.theme.typography/type-scale)
                  :user-select     "none"
                  :font-weight     "bold"
                  :letter-spacing  "0.4px"
@@ -160,13 +160,13 @@
                  :align-items     "center"
                  :gap             "5px"
                  :padding         "3px 10px"
-                 :background      (:bg-2 colors/tokens)
+                 :background      (:bg-2 rf.story.theme.colors/tokens)
                  :color           "#777"
                  :border          "none"
                  :border-radius   "10px"
                  :cursor          "not-allowed"
                  :font-family     mono-stack
-                 :font-size       (:caption typography/type-scale)
+                 :font-size       (:caption rf.story.theme.typography/type-scale)
                  :user-select     "none"
                  :letter-spacing  "0.4px"}
    :dot         {:width        "8px"
@@ -180,11 +180,11 @@
                  :z-index      1600
                  :background   "#1f1f1f"
                  :border       "1px solid #b91c1c"
-                 :color        (:danger colors/tokens)
+                 :color        (:danger rf.story.theme.colors/tokens)
                  :padding      "6px 10px"
                  :border-radius "4px"
                  :font-family  mono-stack
-                 :font-size    (:caption typography/type-scale)
+                 :font-size    (:caption rf.story.theme.typography/type-scale)
                  :box-shadow   "0 4px 10px rgba(0,0,0,0.6)"
                  :display      "flex"
                  :align-items  "center"
@@ -196,33 +196,33 @@
                  :gap "8px"
                  :justify-content "flex-end"}
    :btn         {:padding "5px 12px"
-                 :background (:accent-amber colors/tokens)
+                 :background (:accent-amber rf.story.theme.colors/tokens)
                  :color "white"
                  :border "none"
                  :border-radius "3px"
                  :cursor "pointer"
                  :font-family mono-stack
-                 :font-size (:caption typography/type-scale)}
+                 :font-size (:caption rf.story.theme.typography/type-scale)}
    :btn-muted   {:padding "5px 12px"
                  :background "transparent"
-                 :color (:text-primary colors/tokens)
+                 :color (:text-primary rf.story.theme.colors/tokens)
                  :border "1px solid #444"
                  :border-radius "3px"
                  :cursor "pointer"
                  :font-family mono-stack
-                 :font-size (:caption typography/type-scale)}
-   :hint        {:color (:text-tertiary colors/tokens)
+                 :font-size (:caption rf.story.theme.typography/type-scale)}
+   :hint        {:color (:text-tertiary rf.story.theme.colors/tokens)
                  :font-style "italic"
-                 :font-size (:micro typography/type-scale)}
+                 :font-size (:micro rf.story.theme.typography/type-scale)}
    ;; Mid-recording assertion picker
    :assert-btn  {:padding "3px 9px"
-                 :background (:accent-amber colors/tokens)
+                 :background (:accent-amber rf.story.theme.colors/tokens)
                  :color "white"
                  :border "none"
                  :border-radius "3px"
                  :cursor "pointer"
                  :font-family mono-stack
-                 :font-size (:caption typography/type-scale)}
+                 :font-size (:caption rf.story.theme.typography/type-scale)}
    :picker-back {:position "fixed"
                  :top "0" :left "0" :right "0" :bottom "0"
                  :background "rgba(0,0,0,0.55)"
@@ -233,60 +233,60 @@
    :picker      {:width "520px"
                  :max-width "90vw"
                  :max-height "80vh"
-                 :background (:bg-canvas colors/tokens)
-                 :color (:text-primary colors/tokens)
+                 :background (:bg-canvas rf.story.theme.colors/tokens)
+                 :color (:text-primary rf.story.theme.colors/tokens)
                  :border "1px solid #444"
                  :border-radius "6px"
                  :padding "14px"
                  :font-family mono-stack
-                 :font-size (:body-tight typography/type-scale)
+                 :font-size (:body-tight rf.story.theme.typography/type-scale)
                  :display "flex"
                  :flex-direction "column"
                  :gap "10px"
                  :overflow "auto"
                  :box-shadow "0 12px 32px rgba(0,0,0,0.7)"}
    :picker-title {:font-weight "bold"
-                  :color (:info colors/tokens)
-                  :font-size (:body typography/type-scale)}
+                  :color (:info rf.story.theme.colors/tokens)
+                  :font-size (:body rf.story.theme.typography/type-scale)}
    :picker-grid {:display "grid"
                  :grid-template-columns "1fr 1fr"
                  :gap "6px"}
    :picker-row  {:padding "6px 8px"
-                 :background (:bg-2 colors/tokens)
-                 :color (:text-primary colors/tokens)
+                 :background (:bg-2 rf.story.theme.colors/tokens)
+                 :color (:text-primary rf.story.theme.colors/tokens)
                  :border "1px solid #333"
                  :border-radius "3px"
                  :cursor "pointer"
                  :text-align "left"
                  :font-family mono-stack
-                 :font-size (:caption typography/type-scale)
+                 :font-size (:caption rf.story.theme.typography/type-scale)
                  :display "flex"
                  :flex-direction "column"
                  :gap "2px"}
-   :picker-row-id    {:color (:info colors/tokens)
+   :picker-row-id    {:color (:info rf.story.theme.colors/tokens)
                       :font-weight "bold"}
-   :picker-row-hint  {:color (:text-tertiary colors/tokens)
-                      :font-size (:micro typography/type-scale)
+   :picker-row-hint  {:color (:text-tertiary rf.story.theme.colors/tokens)
+                      :font-size (:micro rf.story.theme.typography/type-scale)
                       :font-style "italic"}
    :field-row   {:display "flex"
                  :flex-direction "column"
                  :gap "3px"}
-   :field-label {:color (:info colors/tokens)
-                 :font-size (:caption typography/type-scale)}
+   :field-label {:color (:info rf.story.theme.colors/tokens)
+                 :font-size (:caption rf.story.theme.typography/type-scale)}
    :field-input {:padding "5px 7px"
-                 :background (:bg-2 colors/tokens)
+                 :background (:bg-2 rf.story.theme.colors/tokens)
                  :color "white"
                  :border "1px solid #444"
                  :border-radius "3px"
                  :font-family mono-stack
-                 :font-size (:body-tight typography/type-scale)
+                 :font-size (:body-tight rf.story.theme.typography/type-scale)
                  :width "100%"
                  :box-sizing "border-box"}
    :field-error {:color "#f08080"
-                 :font-size (:micro typography/type-scale)
+                 :font-size (:micro rf.story.theme.typography/type-scale)
                  :font-style "italic"}
    :preview     {:background "#0e0e10"
-                 :color (:warning colors/tokens)
+                 :color (:warning rf.story.theme.colors/tokens)
                  :padding "8px"
                  :border "1px solid #333"
                  :border-radius "3px"
@@ -294,7 +294,7 @@
                  :overflow "auto"
                  :max-height "30vh"
                  :font-family mono-stack
-                 :font-size (:caption typography/type-scale)
+                 :font-size (:caption rf.story.theme.typography/type-scale)
                  :line-height "1.4"}})
 
 ;; ---------------------------------------------------------------------------
@@ -317,7 +317,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defonce ui-dialog
-  (r/atom recorder/initial-dialog-state))
+  (r/atom rf.story.recorder/initial-dialog-state))
 
 (defn- open-dialog!
   "Open the save-as-variant dialog against `source-variant-id` with
@@ -327,17 +327,17 @@
   export dialog drives the `:script`-body translator with the rich
   DOM-event + timing record."
   ([source-variant-id events]
-   (open-dialog! source-variant-id events (recorder/recorded-entries) (.now js/Date)))
+   (open-dialog! source-variant-id events (rf.story.recorder/recorded-entries) (.now js/Date)))
   ([source-variant-id events now-ms]
-   (open-dialog! source-variant-id events (recorder/recorded-entries) now-ms))
+   (open-dialog! source-variant-id events (rf.story.recorder/recorded-entries) now-ms))
   ([source-variant-id events entries now-ms]
-   (swap! ui-dialog recorder/open-dialog source-variant-id events entries now-ms)))
+   (swap! ui-dialog rf.story.recorder/open-dialog source-variant-id events entries now-ms)))
 
 (defn- close-dialog! []
-  (swap! ui-dialog recorder/close-dialog))
+  (swap! ui-dialog rf.story.recorder/close-dialog))
 
 (defn- set-draft-id! [s]
-  (review-dialog/swap-parse-and-set-draft-id! ui-dialog s))
+  (rf.story.review-dialog/swap-parse-and-set-draft-id! ui-dialog s))
 
 ;; ---------------------------------------------------------------------------
 ;; Toolbar chip + overlay components
@@ -361,7 +361,7 @@
   Public so tests can introspect the chip-level hiccup without
   driving the full toolbar."
   []
-  (let [shell      @state/shell-state-atom
+  (let [shell      @rf.story.ui.state/shell-state-atom
         rec        @ui-state
         rec?       (:recording? rec)
         target     (:selected-variant shell)
@@ -376,12 +376,12 @@
                          ;; switches (Docs / Test → Canvas) re-mount the
                          ;; canvas DOM and we want capture wired to the
                          ;; live node before recording starts. Idempotent.
-                         (recorder-dom/install!)
-                         (recorder/start-recording! target))
+                         (rf.story.recorder.dom-capture/install!)
+                         (rf.story.recorder/start-recording! target))
 
                        rec?
-                       (let [_     (recorder-dom/flush-type-buffer!)
-                             {:keys [variant-id events entries]} (recorder/stop-recording!)]
+                       (let [_     (rf.story.recorder.dom-capture/flush-type-buffer!)
+                             {:keys [variant-id events entries]} (rf.story.recorder/stop-recording!)]
                          ;; Open the dialog when EITHER stream
                          ;; captured something — a recording of canvas
                          ;; clicks/types only lands in :entries, never
@@ -425,7 +425,7 @@
 ;;   2. Field entry — one EDN input per payload field declared in the
 ;;      vocabulary entry. A live preview shows the event vector that
 ;;      will land in the captured `:script` body. 'Insert' calls
-;;      `recorder/insert-assertion!`; 'cancel' returns to phase 1.
+;;      `rf.story.recorder/insert-assertion!`; 'cancel' returns to phase 1.
 ;;
 ;; The picker is overlay-style modal so it stays visible while the
 ;; user clicks back over the canvas — but the recording stays in
@@ -453,7 +453,7 @@
   "Clamp `idx` into `[0, n)` and stash on the picker state. The renderer
   reads this to drive the roving-focus `tabindex` + `data-active`."
   [idx]
-  (let [n (count recorder/assertion-vocabulary)]
+  (let [n (count rf.story.recorder/assertion-vocabulary)]
     (when (pos? n)
       (let [clamped (cond
                       (neg? idx) (dec n)         ; arrow-up wraps to last
@@ -479,7 +479,7 @@
   parsing each input. Returns `[:ok payload]` on success or
   `[:err {:field <k> :raw <s>}]` on first parse error."
   [{:keys [assertion field-text]}]
-  (let [{:keys [fields]} (recorder/vocabulary-entry assertion)]
+  (let [{:keys [fields]} (rf.story.recorder/vocabulary-entry assertion)]
     (loop [fs fields payload {}]
       (if-let [{:keys [key type]} (first fs)]
         (let [raw (get field-text key "")]
@@ -500,7 +500,7 @@
   [picker]
   (let [[outcome payload] (build-payload picker)]
     (when (= outcome :ok)
-      (recorder/make-assertion (:assertion picker) payload))))
+      (rf.story.recorder/make-assertion (:assertion picker) payload))))
 
 (defn- insert!
   "Commit the picker's current state by inserting the assertion into
@@ -511,7 +511,7 @@
         [outcome detail] (build-payload picker)]
     (if (= outcome :ok)
       (do
-        (recorder/insert-assertion! (:assertion picker) detail)
+        (rf.story.recorder/insert-assertion! (:assertion picker) detail)
         (close-picker!))
       (swap! ui-picker assoc :error detail))))
 
@@ -546,7 +546,7 @@
                       (set-active-index! (dec n)))
       ("Enter" " ") (do
                       (.preventDefault evt)
-                      (let [vocab (nth recorder/assertion-vocabulary active-index nil)]
+                      (let [vocab (nth rf.story.recorder/assertion-vocabulary active-index nil)]
                         (when vocab
                           (pick-assertion! (:id vocab)))))
       nil)))
@@ -565,7 +565,7 @@
   row, roving tabindex with ArrowUp/ArrowDown/Home/End/Enter handling."
   []
   (let [{:keys [open? assertion field-text error active-index] :as picker} @ui-picker
-        vocab recorder/assertion-vocabulary
+        vocab rf.story.recorder/assertion-vocabulary
         n     (count vocab)
         ;; Clamp the cursor against the live vocabulary length so the
         ;; renderer never receives an out-of-range index (defensive
@@ -577,7 +577,7 @@
                 :else                active-index)
         active-row-ref (atom nil)]
     (when open?
-      [a11y-dialog/focus-trap
+      [rf.story.ui.a11y-dialog/focus-trap
        {:on-close          close-picker!
         ;; In phase 1, the menu's active row is the natural starting
         ;; focus. In phase 2 we leave the helper to pick the first
@@ -630,7 +630,7 @@
                 vocab))]
 
            ;; Phase 2: field entry + preview.
-           (let [{:keys [fields hint]} (recorder/vocabulary-entry assertion)
+           (let [{:keys [fields hint]} (rf.story.recorder/vocabulary-entry assertion)
                  preview (preview-event picker)]
              [:div {:style {:display "flex" :flex-direction "column" :gap "10px"}
                     :data-test "story-recorder-picker-fields"}
@@ -652,7 +652,7 @@
                            :data-test "story-recorder-picker-error"}
                     "EDN didn't parse — " (pr-str (:raw error))])])
               (when (seq fields)
-                [:div {:style {:font-size (:micro typography/type-scale) :color (:text-tertiary colors/tokens)}}
+                [:div {:style {:font-size (:micro rf.story.theme.typography/type-scale) :color (:text-tertiary rf.story.theme.colors/tokens)}}
                  "preview:"])
               (when preview
                 [:pre {:style     (:preview styles)
@@ -684,11 +684,11 @@
 ;; overlay chip re-renders when the user toggles capture. The flag
 ;; lives in the dom-capture ns; here we just mirror it.
 
-(defonce ui-dom-capture-enabled? (r/atom (recorder-dom/enabled?)))
+(defonce ui-dom-capture-enabled? (r/atom (rf.story.recorder.dom-capture/enabled?)))
 
 (defn- toggle-dom-capture! []
   (let [new-val (not @ui-dom-capture-enabled?)]
-    (recorder-dom/set-enabled! new-val)
+    (rf.story.recorder.dom-capture/set-enabled! new-val)
     (reset! ui-dom-capture-enabled? new-val)))
 
 (defn recording-overlay
@@ -710,11 +710,11 @@
        [:span "REC"]
        [:span {:style {:color "#fff"}}
         (pr-str variant-id)]
-       [:span {:style {:color (:text-tertiary colors/tokens)}}
+       [:span {:style {:color (:text-tertiary rf.story.theme.colors/tokens)}}
         (str (count events) " event" (when (not= 1 (count events)) "s"))]
        [:button
         {:style       (if dom-on?
-                        (assoc (:assert-btn styles) :background (:accent-amber colors/tokens))
+                        (assoc (:assert-btn styles) :background (:accent-amber rf.story.theme.colors/tokens))
                         (assoc (:btn-muted styles)  :opacity     "0.6"))
          :data-test   "story-recorder-toggle-dom"
          :data-enabled (if dom-on? "true" "false")
@@ -737,8 +737,8 @@
                      ;; Drain pending typed-input buffer
                      ;; before sealing the recording so the final
                      ;; :dom/type entry lands in the script.
-                     (recorder-dom/flush-type-buffer!)
-                     (let [{:keys [variant-id events entries]} (recorder/stop-recording!)]
+                     (rf.story.recorder.dom-capture/flush-type-buffer!)
+                     (let [{:keys [variant-id events entries]} (rf.story.recorder/stop-recording!)]
                        ;; Open on EITHER stream — a DOM-only
                        ;; recording lands only in :entries.
                        (when (or (seq events) (seq entries))
@@ -789,15 +789,15 @@
             ;; bare :events vector only when no rich entries were
             ;; snapshotted (legacy callers / dispatch-only recordings).
             src        (if (seq entries) entries events)
-            spec       (play-export/recording->script-body
+            spec       (rf.story.recorder.play-export/recording->script-body
                          src
                          {:auto-run? false})
-            snippet    (play-export/render-variant-form
+            snippet    (rf.story.recorder.play-export/render-variant-form
                          spec
                          {:variant-id (or draft-id :story.recorded/example)
                           :extends    source-id})
             step-count (count (:script spec))]
-        (review-dialog/review-dialog dialog
+        (rf.story.review-dialog/review-dialog dialog
           {:title             "Test Codegen — save recording as variant"
            :hint              (str "EDN snippet generated from "
                                    step-count " recorded step"
@@ -810,14 +810,14 @@
            :placeholder-id    :story.recorded/example
            :placeholder-input ":story.your-story/recorded-flow"
            :on-edit-id        set-draft-id!
-           :on-copy           (fn [] (review-dialog/copy-to-clipboard! snippet))
-           :on-discard        (fn [] (recorder/clear!) (close-dialog!))
+           :on-copy           (fn [] (rf.story.review-dialog/copy-to-clipboard! snippet))
+           :on-discard        (fn [] (rf.story.recorder/clear!) (close-dialog!))
            ;; Open the export dialog with the captured
            ;; snapshot for the auto-run / auto-assert affordances. We
            ;; DON'T close the parent dialog; the export dialog stacks on
            ;; top via a higher z-index.
            :on-export         (fn []
-                                (export-dialog/open-from-recorder-dialog!
+                                (rf.story.ui.recorder-export-dialog/open-from-recorder-dialog!
                                   {:events    events
                                    :entries   entries
                                    :source-id source-id}))

--- a/tools/story/src/re_frame/story/ui/recorder_export_dialog.cljs
+++ b/tools/story/src/re_frame/story/ui/recorder_export_dialog.cljs
@@ -44,18 +44,18 @@
 
   ## Elision
 
-  Every public fn opens with `(when config/enabled? ...)` so
+  Every public fn opens with `(when rf.story.config/enabled? ...)` so
   production CLJS builds short-circuit before any DOM call."
   (:require [clojure.string :as str]
             [reagent.core :as r]
-            [re-frame.story.config                        :as config]
-            [re-frame.story.recorder                      :as recorder]
-            [re-frame.story.recorder.play-export          :as export]
-            [re-frame.story.recorder.play-export-events   :as export-events]
-            [re-frame.story.review-dialog                 :as review-dialog]
-            [re-frame.story.ui.a11y-dialog                :as a11y-dialog]
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+            [re-frame.story.config                        :as rf.story.config]
+            [re-frame.story.recorder                      :as rf.story.recorder]
+            [re-frame.story.recorder.play-export          :as rf.story.recorder.play-export]
+            [re-frame.story.recorder.play-export-events   :as rf.story.recorder.play-export-events]
+            [re-frame.story.review-dialog                 :as rf.story.review-dialog]
+            [re-frame.story.ui.a11y-dialog                :as rf.story.ui.a11y-dialog]
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---------------------------------------------------------------------------
 ;; Dialog state — a single Reagent ratom carrying the dialog's
@@ -66,7 +66,7 @@
 ;; ---------------------------------------------------------------------------
 
 (def initial-state
-  "Idle export-dialog state. Mirrors the shape `review-dialog/initial-
+  "Idle export-dialog state. Mirrors the shape `rf.story.review-dialog/initial-
   state` carries plus the export-specific options."
   {:open?               false
    :source-id           nil   ; the recorded variant-id (rides into :extends)
@@ -100,7 +100,7 @@
 
   Idempotent — opening twice replaces the in-flight state."
   [{:keys [source-id events entries variant-id final-db]}]
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (reset! ui-dialog
             (assoc initial-state
                    :open?      true
@@ -118,7 +118,7 @@
   (swap! ui-dialog assoc :name (str s)))
 
 (defn- set-variant-id! [s]
-  (let [parsed (review-dialog/parse-variant-id-string s)]
+  (let [parsed (rf.story.review-dialog/parse-variant-id-string s)]
     (swap! ui-dialog assoc :variant-id (or parsed s))))
 
 (defn- toggle-auto-assert! []
@@ -137,7 +137,7 @@
   ;; that's where DOM-events + per-event timestamps live.
   ;; Fall back to the legacy :events vector for back-compat.
   (let [src (if (seq entries) entries events)]
-    (export-events/build-export
+    (rf.story.recorder.play-export-events/build-export
       src
       (cond-> {:variant-id variant-id
                :extends    source-id
@@ -155,9 +155,9 @@
   frame via the runner. Updates the dialog's `:replay-status` slot so
   the UI can surface the outcome."
   [{:keys [source-id]} spec]
-  (when (and config/enabled? source-id spec)
+  (when (and rf.story.config/enabled? source-id spec)
     (swap! ui-dialog assoc :replay-status :running :replay-failure-msg nil)
-    (export-events/replay-script!
+    (rf.story.recorder.play-export-events/replay-script!
       source-id spec
       (fn [final-state]
         (let [status (:status final-state)
@@ -188,41 +188,41 @@
    :modal       {:width          "720px"
                  :max-width      "92vw"
                  :max-height     "86vh"
-                 :background     (:bg-canvas colors/tokens)
-                 :color          (:text-primary colors/tokens)
+                 :background     (:bg-canvas rf.story.theme.colors/tokens)
+                 :color          (:text-primary rf.story.theme.colors/tokens)
                  :border         "1px solid #444"
                  :border-radius  "6px"
                  :padding        "16px"
                  :font-family    mono-stack
-                 :font-size      (:body-tight typography/type-scale)
+                 :font-size      (:body-tight rf.story.theme.typography/type-scale)
                  :display        "flex"
                  :flex-direction "column"
                  :gap            "12px"
                  :box-shadow     "0 14px 36px rgba(0,0,0,0.75)"
                  :overflow       "hidden"}
    :title       {:font-weight "bold"
-                 :color       (:info colors/tokens)
-                 :font-size   (:body typography/type-scale)}
-   :hint        {:color (:text-tertiary colors/tokens)
+                 :color       (:info rf.story.theme.colors/tokens)
+                 :font-size   (:body rf.story.theme.typography/type-scale)}
+   :hint        {:color (:text-tertiary rf.story.theme.colors/tokens)
                  :font-style "italic"
-                 :font-size (:micro typography/type-scale)}
+                 :font-size (:micro rf.story.theme.typography/type-scale)}
    :row         {:display "flex"
                  :gap "8px"
                  :align-items "center"}
-   :label       {:color (:info colors/tokens)
-                 :font-size (:caption typography/type-scale)
+   :label       {:color (:info rf.story.theme.colors/tokens)
+                 :font-size (:caption rf.story.theme.typography/type-scale)
                  :min-width "110px"}
    :input       {:padding "6px 8px"
-                 :background (:bg-2 colors/tokens)
+                 :background (:bg-2 rf.story.theme.colors/tokens)
                  :color "white"
                  :border "1px solid #444"
                  :border-radius "3px"
                  :font-family mono-stack
-                 :font-size (:body-tight typography/type-scale)
+                 :font-size (:body-tight rf.story.theme.typography/type-scale)
                  :flex "1 1 auto"
                  :box-sizing "border-box"}
    :snippet     {:background    "#0e0e10"
-                 :color         (:warning colors/tokens)
+                 :color         (:warning rf.story.theme.colors/tokens)
                  :padding       "10px"
                  :border        "1px solid #333"
                  :border-radius "4px"
@@ -230,7 +230,7 @@
                  :overflow      "auto"
                  :max-height    "40vh"
                  :font-family   mono-stack
-                 :font-size     (:caption typography/type-scale)
+                 :font-size     (:caption rf.story.theme.typography/type-scale)
                  :line-height   "1.45"
                  :flex          "1 1 auto"}
    :checkbox-row {:display "flex"
@@ -241,29 +241,29 @@
                  :justify-content "flex-end"
                  :flex-wrap "wrap"}
    :btn         {:padding "5px 12px"
-                 :background (:accent-amber colors/tokens)
+                 :background (:accent-amber rf.story.theme.colors/tokens)
                  :color "white"
                  :border "none"
                  :border-radius "3px"
                  :cursor "pointer"
                  :font-family mono-stack
-                 :font-size (:caption typography/type-scale)}
+                 :font-size (:caption rf.story.theme.typography/type-scale)}
    :btn-muted   {:padding "5px 12px"
                  :background "transparent"
-                 :color (:text-primary colors/tokens)
+                 :color (:text-primary rf.story.theme.colors/tokens)
                  :border "1px solid #444"
                  :border-radius "3px"
                  :cursor "pointer"
                  :font-family mono-stack
-                 :font-size (:caption typography/type-scale)}
+                 :font-size (:caption rf.story.theme.typography/type-scale)}
    :status-pill {:padding "2px 8px"
                  :border-radius "10px"
-                 :font-size (:micro typography/type-scale)
+                 :font-size (:micro rf.story.theme.typography/type-scale)
                  :font-family mono-stack
                  :margin-left "auto"}
    :pill-pass   {:background "#1f5e2b" :color "#cdf7d4"}
    :pill-fail   {:background "#7a2020" :color "#ffd1d1"}
-   :pill-running {:background (:accent-amber colors/tokens) :color "white"}})
+   :pill-running {:background (:accent-amber rf.story.theme.colors/tokens) :color "white"}})
 
 (defn- replay-pill
   [status msg]
@@ -305,7 +305,7 @@
         ;; trigger on close. The dialog hiccup is passed eagerly so
         ;; tests can string-traverse the full tree without invoking
         ;; the class component's render lifecycle.
-        [a11y-dialog/focus-trap
+        [rf.story.ui.a11y-dialog/focus-trap
          {:on-close close-dialog!}
          [:div
           {:style     (:back styles)
@@ -365,7 +365,7 @@
               :on-change (fn [_] (toggle-auto-assert!))}]
             [:span {:style (:label styles)} "Auto-assert app-db at end"]
             [:span {:style (:hint styles)}
-             (str "(top-" export/default-max-auto-assertions
+             (str "(top-" rf.story.recorder.play-export/default-max-auto-assertions
                   " changed paths; trim manually after pasting)")]]
 
            ;; ---- Snippet preview ---------------------------------------------
@@ -383,7 +383,7 @@
             [:button
              {:style    (:btn styles)
               :data-test "story-recorder-export-copy"
-              :on-click (fn [_] (review-dialog/copy-to-clipboard! rendered))}
+              :on-click (fn [_] (rf.story.review-dialog/copy-to-clipboard! rendered))}
              "copy to clipboard"]
             [:button
              {:style    (:btn-muted styles)
@@ -408,10 +408,10 @@
   record) alongside `:events` so the translator emits `:click` /
   `:type` / `:wait` steps when DOM-events were captured."
   [{:keys [events entries source-id]}]
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (open-dialog!
       {:source-id source-id
        :events    events
        :entries   entries
        :final-db  (when source-id
-                    (export-events/snapshot-frame-db source-id))})))
+                    (rf.story.recorder.play-export-events/snapshot-frame-db source-id))})))

--- a/tools/story/src/re_frame/story/ui/save_variant.cljs
+++ b/tools/story/src/re_frame/story/ui/save_variant.cljs
@@ -23,19 +23,19 @@
 
   ## Elision
 
-  Every public fn opens with `(when config/enabled? ...)` so production
+  Every public fn opens with `(when rf.story.config/enabled? ...)` so production
   CLJS builds short-circuit before any DOM call. The UI-callback wiring
   via `install!` is the only impure registration the ns owns; idempotent
   on re-mount."
   (:require [reagent.core :as r]
-            [re-frame.story.config        :as config]
-            [re-frame.story.review-dialog :as review-dialog]
-            [re-frame.story.save-variant  :as save-variant]
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+            [re-frame.story.config        :as rf.story.config]
+            [re-frame.story.review-dialog :as rf.story.review-dialog]
+            [re-frame.story.save-variant  :as rf.story.save-variant]
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---------------------------------------------------------------------------
-;; Dialog ratom — the impure mirror of `review-dialog/initial-state`.
+;; Dialog ratom — the impure mirror of `rf.story.review-dialog/initial-state`.
 ;;
 ;; The pure transitions in `re-frame.story.review-dialog` +
 ;; `re-frame.story.save-variant` produce new state maps; the UI swaps
@@ -44,7 +44,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defonce ui-dialog
-  (r/atom review-dialog/initial-state))
+  (r/atom rf.story.review-dialog/initial-state))
 
 (defn- open-dialog!
   "Open the dialog against `source-variant-id` with the captured
@@ -55,7 +55,7 @@
   nil/empty (no schema registered, or all args conform).
 
   `slices` is the eight-slice capture report from
-  `save-variant/capture-slices` — the dialog renders its honesty-floor
+  `rf.story.save-variant/capture-slices` — the dialog renders its honesty-floor
   warnings (which slices are captured-as-declared / not-yet-projectable)
   so a saved variant is honest about what it does and does NOT capture.
   May be nil (legacy 3/4-arity callers)."
@@ -64,18 +64,18 @@
   ([source-variant-id args-snapshot now-ms violations]
    (open-dialog! source-variant-id args-snapshot now-ms violations nil))
   ([source-variant-id args-snapshot now-ms violations slices]
-   (swap! ui-dialog save-variant/open
+   (swap! ui-dialog rf.story.save-variant/open
           source-variant-id args-snapshot now-ms violations slices)))
 
 (defn- close-dialog! []
-  (swap! ui-dialog save-variant/close))
+  (swap! ui-dialog rf.story.save-variant/close))
 
 (defn- set-draft-id! [s]
-  (review-dialog/swap-parse-and-set-draft-id! ui-dialog s))
+  (rf.story.review-dialog/swap-parse-and-set-draft-id! ui-dialog s))
 
 ;; ---------------------------------------------------------------------------
 ;; Install — register the CLJS open-callback against the pure ns so
-;; `save-variant/save-current-as-variant!` can drive the dialog without
+;; `rf.story.save-variant/save-current-as-variant!` can drive the dialog without
 ;; coupling the .cljc helper to Reagent / DOM. Idempotent.
 ;; ---------------------------------------------------------------------------
 
@@ -83,8 +83,8 @@
   "Register the dialog-open callback against the pure ns. Called once at
   shell mount; idempotent."
   []
-  (when config/enabled?
-    (save-variant/set-open-dialog-fn! open-dialog!)
+  (when rf.story.config/enabled?
+    (rf.story.save-variant/set-open-dialog-fn! open-dialog!)
     nil))
 
 ;; ---------------------------------------------------------------------------
@@ -96,21 +96,21 @@
 
 (def ^:private button-styles
   {:button          {:padding       "4px 8px"
-                     :background    (:accent-amber colors/tokens)
+                     :background    (:accent-amber rf.story.theme.colors/tokens)
                      :color         "white"
                      :border        "none"
                      :border-radius "3px"
                      :cursor        "pointer"
-                     :font-size     (:micro typography/type-scale)
+                     :font-size     (:micro rf.story.theme.typography/type-scale)
                      :margin-top    "8px"
                      :font-family   mono-stack}
    :button-disabled {:padding       "4px 8px"
-                     :background    (:bg-2 colors/tokens)
+                     :background    (:bg-2 rf.story.theme.colors/tokens)
                      :color         "#777"
                      :border        "1px solid #444"
                      :border-radius "3px"
                      :cursor        "not-allowed"
-                     :font-size     (:micro typography/type-scale)
+                     :font-size     (:micro rf.story.theme.typography/type-scale)
                      :margin-top    "8px"
                      :font-family   mono-stack}})
 
@@ -142,7 +142,7 @@
                    "Select a variant to capture its current state")
       :on-click  (fn [_]
                    (when enabled?
-                     (save-variant/save-current-as-variant!
+                     (rf.story.save-variant/save-current-as-variant!
                        {:variant-id variant-id})))}
      "save as new variant…"]))
 
@@ -169,7 +169,7 @@
                    :border "1px solid #a06030"
                    :border-radius "3px"
                    :font-family mono-stack
-                   :font-size (:micro typography/type-scale)
+                   :font-size (:micro rf.story.theme.typography/type-scale)
                    :line-height "1.5"}}
      [:div {:style {:font-weight "bold" :margin-bottom "4px"}}
       "Args do not match the variant's Spec 010 schema — preview below; "
@@ -190,7 +190,7 @@
 ;; slices it can represent losslessly and which it cannot: "if the
 ;; current state contains data that cannot be represented losslessly yet,
 ;; the UI MUST say what will be omitted". The pure
-;; `save-variant/capture-slices` classifies every slice; this component
+;; `rf.story.save-variant/capture-slices` classifies every slice; this component
 ;; renders the warnings (every slice that is NOT a clean live projection)
 ;; so the user knows, BEFORE pasting, that a saved variant captures args
 ;; live, carries declared slices forward via `:extends`, and does NOT yet
@@ -211,7 +211,7 @@
   — with its honest note. Returns nil when every slice projects cleanly
   (nothing to warn about). Public so tests can render it directly."
   [slices]
-  (let [warnings (save-variant/slice-warnings slices)]
+  (let [warnings (rf.story.save-variant/slice-warnings slices)]
     (when (seq warnings)
       [:div {:data-test "story-save-variant-slice-report"
              :data-warning-count (count warnings)
@@ -222,7 +222,7 @@
                      :border "1px solid #3a3a44"
                      :border-radius "3px"
                      :font-family mono-stack
-                     :font-size (:micro typography/type-scale)
+                     :font-size (:micro rf.story.theme.typography/type-scale)
                      :line-height "1.5"}}
        [:div {:style {:font-weight "bold" :margin-bottom "6px"}}
         "What this save captures — and what it does not"]
@@ -272,11 +272,11 @@
   (let [dialog @ui-dialog]
     (when (:open? dialog)
       (let [{:keys [draft-id source-id args violations slices]} dialog
-            snippet (save-variant/gen-variant-snippet
+            snippet (rf.story.save-variant/gen-variant-snippet
                       {:variant-id (or draft-id :story.saved/example)
                        :extends    source-id
                        :args       args})]
-        (review-dialog/review-dialog dialog
+        (rf.story.review-dialog/review-dialog dialog
           {:title             "Save current canvas state as new variant"
            :hint              [:div
                                [:div (str "Args snapshot captured from "
@@ -289,6 +289,6 @@
            :placeholder-id    :story.saved/example
            :placeholder-input ":story.your-story/saved-flow"
            :on-edit-id        set-draft-id!
-           :on-copy           (fn [] (review-dialog/copy-to-clipboard! snippet))
+           :on-copy           (fn [] (rf.story.review-dialog/copy-to-clipboard! snippet))
            :on-close          close-dialog!
            :data-test-prefix  "story-save-variant"})))))

--- a/tools/story/src/re_frame/story/ui/schema_form.cljc
+++ b/tools/story/src/re_frame/story/ui/schema_form.cljc
@@ -65,8 +65,8 @@
   (:require [clojure.string :as str]
             #?(:clj  [clojure.edn :as edn]
                :cljs [cljs.reader :as edn])
-            [re-frame.story.malli-schema :as msu]
-            [re-frame.story.predicates :as pred]))
+            [re-frame.story.malli-schema :as rf.story.malli-schema]
+            [re-frame.story.predicates :as rf.story.predicates]))
 
 ;; ===========================================================================
 ;; PURE: scalar-schema → widget descriptor (flat shapes only)
@@ -108,8 +108,8 @@
     (= :keyword schema) {:widget :text :coerce :keyword}
     (= :symbol schema)  {:widget :text :coerce :symbol}
 
-    (and (vector? schema) (= :enum (msu/schema-op schema)))
-    (let [options (vec (msu/schema-children schema))]
+    (and (vector? schema) (= :enum (rf.story.malli-schema/schema-op schema)))
+    (let [options (vec (rf.story.malli-schema/schema-children schema))]
       ;; A keyword-enum is a clean select; a mixed / non-keyword enum is
       ;; NOT a flat select (the option encoding would be ambiguous), so it
       ;; falls to the EDN escape hatch.
@@ -164,11 +164,11 @@
     {:renderable? true :kind :scalar :widget (scalar-widget schema)}
 
     ;; A vector form — only a FLAT `[:map …]` is renderable.
-    (and (vector? schema) (= :map (msu/schema-op schema)))
+    (and (vector? schema) (= :map (rf.story.malli-schema/schema-op schema)))
     (let [entries (mapv (fn [entry]
-                          {:key    (msu/map-entry-key entry)
-                           :widget (scalar-widget (msu/map-entry-schema entry))})
-                        (msu/schema-children schema))]
+                          {:key    (rf.story.malli-schema/map-entry-key entry)
+                           :widget (scalar-widget (rf.story.malli-schema/map-entry-schema entry))})
+                        (rf.story.malli-schema/schema-children schema))]
       (cond
         (empty? entries)
         {:renderable? false :kind :edn
@@ -190,7 +190,7 @@
     ;; not flat-renderable.
     (vector? schema)
     {:renderable? false :kind :edn
-     :reason (str "non-flat schema form " (pr-str (msu/schema-op schema)))}
+     :reason (str "non-flat schema form " (pr-str (rf.story.malli-schema/schema-op schema)))}
 
     ;; A bare keyword that is not a recognised flat scalar = a registry
     ;; name (`:my/user`) — opaque to a data walk.
@@ -340,7 +340,7 @@
    (let [v-str    (pp-value value 20)
          pinned-id (keyword (namespace source-variant-id)
                             (str (name source-variant-id) "-pinned"))]
-     (str (pred/reg-variant-envelope
+     (str (rf.story.predicates/reg-variant-envelope
             "story" pinned-id
             (str ":extends " (pr-str source-variant-id) "\n"
                  "   :sub-overrides {" (pr-str query-v) " " v-str "}"))

--- a/tools/story/src/re_frame/story/ui/schema_validation.cljc
+++ b/tools/story/src/re_frame/story/ui/schema_validation.cljc
@@ -74,17 +74,17 @@
   `:rf.story.panel/schema-validation-view`, registered against the
   framework view registry."
   (:require [clojure.string :as str]
-            [re-frame.story.malli-schema :as msu]
+            [re-frame.story.malli-schema :as rf.story.malli-schema]
             #?@(:cljs [[reagent.core              :as r]
                        [re-frame.core             :as rf]
-                       [re-frame.late-bind        :as late-bind]
-                       [re-frame.story.args       :as args]
-                       [re-frame.story.config     :as config]
-                       [re-frame.story.registrar  :as story-registrar]
-                       [re-frame.story.view-args  :as view-args]
-                       [re-frame.story.ui.trace-buffer :as trace-buffer]])
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+                       [re-frame.late-bind        :as rf.late-bind]
+                       [re-frame.story.args       :as rf.story.args]
+                       [re-frame.story.config     :as rf.story.config]
+                       [re-frame.story.registrar  :as rf.story.registrar]
+                       [re-frame.story.view-args  :as rf.story.view-args]
+                       [re-frame.story.ui.trace-buffer :as rf.story.ui.trace-buffer]])
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---- pure: classify a trace event ---------------------------------------
 
@@ -169,11 +169,11 @@
 ;; leaf ns shared with `controls`). Aliased privately here so in-file
 ;; call sites stay textually identical.
 
-(def ^:private properties?      msu/properties?)
-(def ^:private schema-op        msu/schema-op)
-(def ^:private schema-children  msu/schema-children)
-(def ^:private map-entry-key    msu/map-entry-key)
-(def ^:private map-entry-schema msu/map-entry-schema)
+(def ^:private properties?      rf.story.malli-schema/properties?)
+(def ^:private schema-op        rf.story.malli-schema/schema-op)
+(def ^:private schema-children  rf.story.malli-schema/schema-children)
+(def ^:private map-entry-key    rf.story.malli-schema/map-entry-key)
+(def ^:private map-entry-schema rf.story.malli-schema/map-entry-schema)
 
 (defn map-schema?
   "True iff `schema` is a Malli `[:map ...]` vector form. The arg-
@@ -310,7 +310,7 @@
      The panel's CLJS-only render path calls this; the pure helpers
      (`args-violations`) take a pre-resolved schema and are JVM-friendly."
      [variant-id]
-     (view-args/compiled-view-args-schema variant-id)))
+     (rf.story.view-args/compiled-view-args-schema variant-id)))
 
 ;; ---- CLJS: validator lookup via late-bind -------------------------------
 
@@ -329,47 +329,47 @@
      decisions the framework's `validate-app-schema!` / `validate-event!`
      emit."
      []
-     {:validate (late-bind/get-fn :schemas/validate-with-registered-fn)
-      :explain  (late-bind/get-fn :schemas/explain-with-registered-fn)}))
+     {:validate (rf.late-bind/get-fn :schemas/validate-with-registered-fn)
+      :explain  (rf.late-bind/get-fn :schemas/explain-with-registered-fn)}))
 
 ;; ---- CLJS: styling ------------------------------------------------------
 
 #?(:cljs
    (def ^:private styles
      {:wrap         {:padding "8px"
-                     :background (:bg-2 colors/tokens)
-                     :color (:text-primary colors/tokens)
+                     :background (:bg-2 rf.story.theme.colors/tokens)
+                     :color (:text-primary rf.story.theme.colors/tokens)
                      :font-family mono-stack
-                     :font-size (:caption typography/type-scale)
+                     :font-size (:caption rf.story.theme.typography/type-scale)
                      :border-top "1px solid #444"
                      :overflow "auto"
                      :max-height "320px"}
       :section      {:margin-bottom "10px"}
       :section-h    {:font-weight "bold"
-                     :color (:text-secondary colors/tokens)
+                     :color (:text-secondary rf.story.theme.colors/tokens)
                      :text-transform "uppercase"
-                     :font-size (:micro typography/type-scale)
+                     :font-size (:micro rf.story.theme.typography/type-scale)
                      :letter-spacing "0.5px"
                      :margin-bottom "4px"}
-      :hint         {:color (:text-tertiary colors/tokens)
+      :hint         {:color (:text-tertiary rf.story.theme.colors/tokens)
                      :font-style "italic"
-                     :font-size (:micro typography/type-scale)
+                     :font-size (:micro rf.story.theme.typography/type-scale)
                      :margin-bottom "4px"}
-      :empty        {:color (:text-tertiary colors/tokens)
+      :empty        {:color (:text-tertiary rf.story.theme.colors/tokens)
                      :font-style "italic"
                      :padding "2px 0"}
       :violation    {:padding "4px 6px"
                      :margin "2px 0"
-                     :background (:danger-bg colors/tokens)
+                     :background (:danger-bg rf.story.theme.colors/tokens)
                      :border-left "3px solid #ff4040"
-                     :color (:danger colors/tokens)}
-      :v-key        {:color (:warning colors/tokens)
+                     :color (:danger rf.story.theme.colors/tokens)}
+      :v-key        {:color (:warning rf.story.theme.colors/tokens)
                      :font-weight "bold"}
-      :v-value      {:color (:info colors/tokens)}
-      :v-schema     {:color (:tag-experimental-fg colors/tokens)
-                     :font-size (:micro typography/type-scale)}
+      :v-value      {:color (:info rf.story.theme.colors/tokens)}
+      :v-schema     {:color (:tag-experimental-fg rf.story.theme.colors/tokens)
+                     :font-size (:micro rf.story.theme.typography/type-scale)}
       :v-explain    {:color "#aaa"
-                     :font-size (:micro typography/type-scale)
+                     :font-size (:micro rf.story.theme.typography/type-scale)
                      :margin-top "2px"}
       :row          {:display "grid"
                      :grid-template-columns "92px 80px 1fr"
@@ -380,10 +380,10 @@
       :cell         {:overflow "hidden"
                      :text-overflow "ellipsis"
                      :white-space "nowrap"}
-      :cell-time    {:color (:text-tertiary colors/tokens)}
-      :cell-where   {:color (:info colors/tokens)
+      :cell-time    {:color (:text-tertiary rf.story.theme.colors/tokens)}
+      :cell-where   {:color (:info rf.story.theme.colors/tokens)
                      :font-style "italic"}
-      :cell-detail  {:color (:warning colors/tokens)}}))
+      :cell-detail  {:color (:warning rf.story.theme.colors/tokens)}}))
 
 ;; ---- CLJS: render helpers -----------------------------------------------
 
@@ -463,14 +463,14 @@
      ;; Form-2 — capture the trace buffer atom on the outer closure
      ;; so the per-render fn observes the same source-of-truth across
      ;; the component's lifecycle.
-     (let [_buf (trace-buffer/ensure-buffer! variant-id)]
+     (let [_buf (rf.story.ui.trace-buffer/ensure-buffer! variant-id)]
        (fn [variant-id]
-         (let [buf            (trace-buffer/ensure-buffer! variant-id)
+         (let [buf            (rf.story.ui.trace-buffer/ensure-buffer! variant-id)
                events         @buf
                trace-rows     (project-failures events)
                schema         (resolve-component-schema variant-id)
                vfns           (validator-fns)
-               eff-args       (args/resolve-args variant-id)
+               eff-args       (rf.story.args/resolve-args variant-id)
                args-viols     (args-violations eff-args schema vfns)
                schema-known?  (some? schema)
                validator-on?  (some? (:validate vfns))]
@@ -521,7 +521,7 @@
                [:div {:data-test "story-schema-trace-rows"}
                 [:div {:style (merge (:row styles)
                                      {:font-weight "bold"
-                                      :color       (:text-secondary colors/tokens)})}
+                                      :color       (:text-secondary rf.story.theme.colors/tokens)})}
                  [:span {:style (:cell styles)} "time"]
                  [:span {:style (:cell styles)} "where"]
                  [:span {:style (:cell styles)} "detail"]]
@@ -553,7 +553,7 @@
      Called from `re-frame.story.ui.panels/install-canonical-panels!`
      during `re-frame.story/install-canonical-vocabulary!`."
      []
-     (when config/enabled?
+     (when rf.story.config/enabled?
        ;; `[:div]` wrap REQUIRED for source-coord annotation — see the
        ;; full rationale on `:rf.story.panel/a11y-view` registration in
        ;; `re-frame.story.ui.a11y`. Per Spec 006 §Source-coord
@@ -561,7 +561,7 @@
        ;; `data-rf2-source-coord` to; a bare `[panel variant-id]` root
        ;; silences Story / Xray Inspect Mode for this panel.
        (rf/reg-view* panel-render-id (fn [variant-id] [:div [panel variant-id]]))
-       (story-registrar/reg-story-panel*
+       (rf.story.registrar/reg-story-panel*
          panel-id
          {:doc       "Live Spec 010 schema-validation panel — args vs schema + boundary trace failures."
           :title     "Schema validation"

--- a/tools/story/src/re_frame/story/ui/share.cljs
+++ b/tools/story/src/re_frame/story/ui/share.cljs
@@ -66,20 +66,20 @@
   `:rf.story/enabled?` false the shell is DCE'd and this ns rides
   out alongside it."
   (:require [reagent.core :as r]
-            [re-frame.story.args :as args]
-            [re-frame.story.config :as config]
-            [re-frame.story.egress :as egress]
-            [re-frame.story.malli-schema :as msu]
-            [re-frame.story.plan :as plan]
-            [re-frame.story.predicates :as pred]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.story.review-dialog :as review-dialog]
-            [re-frame.story.share :as share]
-            [re-frame.story.ui.a11y-dialog :as a11y-dialog]
-            [re-frame.story.ui.state :as state]
-            [re-frame.story.view-args :as view-args]
-            [re-frame.story.theme.typography :as typography :refer [mono-stack sans-stack]]
-            [re-frame.story.theme.colors :as colors]))
+            [re-frame.story.args :as rf.story.args]
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.egress :as rf.story.egress]
+            [re-frame.story.malli-schema :as rf.story.malli-schema]
+            [re-frame.story.plan :as rf.story.plan]
+            [re-frame.story.predicates :as rf.story.predicates]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.review-dialog :as rf.story.review-dialog]
+            [re-frame.story.share :as rf.story.share]
+            [re-frame.story.ui.a11y-dialog :as rf.story.ui.a11y-dialog]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.view-args :as rf.story.view-args]
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack sans-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---- helpers -------------------------------------------------------------
 
@@ -104,28 +104,28 @@
   (rf2-76l69l). The same surface the controls panel exposes as editable
   args: the union of
 
-    - the resolved args' keys (`args/resolve-args` WITHOUT cell-overrides
+    - the resolved args' keys (`rf.story.args/resolve-args` WITHOUT cell-overrides
       — the global / story / variant-chain `:args` layers);
     - the variant's + parent story's explicit `:argtypes` keys;
     - the compiled view-args (props) schema's top-level `:map` entry keys
-      (`view-args/compiled-view-args-schema`).
+      (`rf.story.view-args/compiled-view-args-schema`).
 
   Returns nil for an unregistered / uncompilable variant (no contract
-  known) so `share/drop-stale-overrides` degrades to keeping every parsed
+  known) so `rf.story.share/drop-stale-overrides` degrades to keeping every parsed
   override rather than dropping all. Best-effort: any read failure
   contributes its empty layer; the resolved-args layer alone is the
   floor."
   [variant-id]
-  (when (and variant-id (registrar/registered? :variant variant-id))
-    (let [story-id   (args/parent-story-id variant-id)
-          vb         (registrar/handler-meta :variant variant-id)
-          sb         (when story-id (registrar/handler-meta :story story-id))
-          arg-keys   (set (keys (args/resolve-args variant-id)))
+  (when (and variant-id (rf.story.registrar/registered? :variant variant-id))
+    (let [story-id   (rf.story.args/parent-story-id variant-id)
+          vb         (rf.story.registrar/handler-meta :variant variant-id)
+          sb         (when story-id (rf.story.registrar/handler-meta :story story-id))
+          arg-keys   (set (keys (rf.story.args/resolve-args variant-id)))
           argtype-ks (into (set (keys (:argtypes sb)))
                            (keys (:argtypes vb)))
-          schema     (view-args/compiled-view-args-schema variant-id)
-          schema-ks  (when (and (vector? schema) (= :map (msu/schema-op schema)))
-                       (map msu/map-entry-key (msu/schema-children schema)))]
+          schema     (rf.story.view-args/compiled-view-args-schema variant-id)
+          schema-ks  (when (and (vector? schema) (= :map (rf.story.malli-schema/schema-op schema)))
+                       (map rf.story.malli-schema/map-entry-key (rf.story.malli-schema/schema-children schema)))]
       (into (into arg-keys argtype-ks) schema-ks))))
 
 (defn hydrate-from-url!
@@ -164,7 +164,7 @@
   side-effect only.
 
   rf2-76l69l — drift is detected at TWO stages: `parse-overrides-param*`
-  drops UNPARSEABLE entries, then `share/drop-stale-overrides` drops every
+  drops UNPARSEABLE entries, then `rf.story.share/drop-stale-overrides` drops every
   parsed override whose arg-key the focused variant no longer DECLARES.
   Both classes land in `:dropped` and feed the share-import hint, so a
   stale override is reported (reproducibility downgraded) instead of
@@ -175,22 +175,22 @@
     ;; ran first) rather than re-deriving it from the raw URL — guarantees
     ;; this pass operates on `url-state`'s authoritative, validated
     ;; selection and can never diverge from it.
-    (let [variant-id (:selected-variant @state/shell-state-atom)
-          valid?     (and variant-id (registrar/registered? :variant variant-id))
-          parsed0    (share/parse-overrides-param* (.get params "overrides"))
+    (let [variant-id (:selected-variant @rf.story.ui.state/shell-state-atom)
+          valid?     (and variant-id (rf.story.registrar/registered? :variant variant-id))
+          parsed0    (rf.story.share/parse-overrides-param* (.get params "overrides"))
           ;; Second stage: drop overrides for args the focused variant no
           ;; longer declares (renamed / removed) so they are REPORTED, not
           ;; merged as orphan live args. Only meaningful for a valid variant
           ;; (its declared-key contract). `declared-arg-keys` returns nil →
           ;; keep-all degrade.
           parsed     (if valid?
-                       (share/drop-stale-overrides parsed0
+                       (rf.story.share/drop-stale-overrides parsed0
                                                    (declared-arg-keys variant-id))
                        parsed0)
           overrides  (:overrides parsed)
           dropped    (:dropped parsed)]
       (when valid?
-        (state/swap-state!
+        (rf.story.ui.state/swap-state!
           (fn [s]
             (cond-> s
               ;; AUTHORITATIVE owner of the focused variant's overrides slice:
@@ -213,7 +213,7 @@
   "Clear the share-import hint for `variant-id` (rf2-9jthx). Called
   from the hint's close affordance."
   [variant-id]
-  (state/swap-state!
+  (rf.story.ui.state/swap-state!
     (fn [s] (update s :rf.story/share-import-hint dissoc variant-id))))
 
 (defn share-import-hint
@@ -224,7 +224,7 @@
   Returns nil when nothing dropped, so callers can splice
   unconditionally."
   [variant-id]
-  (let [hint (get-in @state/shell-state-atom
+  (let [hint (get-in @rf.story.ui.state/shell-state-atom
                      [:rf.story/share-import-hint variant-id])
         n    (:dropped-count hint 0)]
     (when (pos? n)
@@ -238,7 +238,7 @@
                          :border "1px solid #a06030"
                          :border-radius "3px"
                          :font-family mono-stack
-                         :font-size (:caption typography/type-scale)
+                         :font-size (:caption rf.story.theme.typography/type-scale)
                          :display "flex"
                          :align-items "center"
                          :justify-content "space-between"}}
@@ -246,12 +246,12 @@
         (str n " override" (when (not= 1 n) "s")
              " from this URL no longer apply — variant args refactored?")]
        [:button {:style     {:padding "2px 8px"
-                             :background (:bg-3 colors/tokens)
-                             :color (:text-primary colors/tokens)
+                             :background (:bg-3 rf.story.theme.colors/tokens)
+                             :color (:text-primary rf.story.theme.colors/tokens)
                              :border "1px solid #555"
                              :border-radius "3px"
                              :cursor "pointer"
-                             :font-size (:micro typography/type-scale)
+                             :font-size (:micro rf.story.theme.typography/type-scale)
                              :margin-left "10px"}
                  :data-test "story-share-import-hint-dismiss"
                  :on-click  (fn [_] (dismiss-share-import-hint! variant-id))}
@@ -270,7 +270,7 @@
 ;; ---- pure: report + EDN snippet ------------------------------------------
 
 (defn current-share-report
-  "Build the reproducibility report (`egress/classify`) for the cell the
+  "Build the reproducibility report (`rf.story.egress/classify`) for the cell the
   `shell` state currently describes. Pure-ish: compiles the focused
   variant's plan (best-effort — a variant whose plan does not compile
   still shares, its overrides are still classified) and threads the
@@ -285,9 +285,9 @@
         overrides (when vid (get-in shell [:cell-overrides vid]))
         dropped   (when vid (get-in shell [:rf.story/share-import-hint vid :dropped]))
         plan      (when vid
-                    (try (plan/variant-plan vid)
+                    (try (rf.story.plan/variant-plan vid)
                          (catch :default _ nil)))]
-    (egress/classify {:plan           plan
+    (rf.story.egress/classify {:plan           plan
                       :cell-overrides overrides
                       :dropped        dropped})))
 
@@ -304,19 +304,19 @@
   honestly (it is what the dev would paste) rather than silently dropped."
   [shell]
   (when-let [vid (:selected-variant shell)]
-    (let [eff (args/resolve-args
+    (let [eff (rf.story.args/resolve-args
                 vid
                 {:active-modes   (:active-modes shell)
                  :cell-overrides (get-in shell [:cell-overrides vid])})]
-      (pred/reg-variant-form "story" vid [[:extends (pr-str vid)]
+      (rf.story.predicates/reg-variant-form "story" vid [[:extends (pr-str vid)]
                                           [:args (pr-str eff)]]))))
 
 ;; ---- styling -------------------------------------------------------------
 
 (def ^:private badge-styles
-  {:full      {:background (:success-bg colors/tokens) :color (:success colors/tokens)}
-   :partial   {:background (:warning-bg colors/tokens) :color (:warning colors/tokens)}
-   :view-only {:background (:danger-bg  colors/tokens) :color (:danger  colors/tokens)}})
+  {:full      {:background (:success-bg rf.story.theme.colors/tokens) :color (:success rf.story.theme.colors/tokens)}
+   :partial   {:background (:warning-bg rf.story.theme.colors/tokens) :color (:warning rf.story.theme.colors/tokens)}
+   :view-only {:background (:danger-bg  rf.story.theme.colors/tokens) :color (:danger  rf.story.theme.colors/tokens)}})
 
 (def ^:private styles
   {:badge        {:display       "inline-flex"
@@ -325,7 +325,7 @@
                   :padding       "2px 9px"
                   :border-radius "10px"
                   :font-family   mono-stack
-                  :font-size     (:micro typography/type-scale)
+                  :font-size     (:micro rf.story.theme.typography/type-scale)
                   :font-weight   "bold"
                   :text-transform "uppercase"
                   :letter-spacing "0.4px"}
@@ -336,19 +336,19 @@
                   :flex-direction "column"
                   :gap           "4px"}
    :reason       {:font-family   sans-stack
-                  :font-size     (:caption typography/type-scale)
-                  :color         (:text-secondary colors/tokens)
+                  :font-size     (:caption rf.story.theme.typography/type-scale)
+                  :color         (:text-secondary rf.story.theme.colors/tokens)
                   :padding-left  "14px"
                   :position      "relative"}
    ;; toolbar SHARE chip
    :chip         {:padding         "3px 9px"
-                  :background      (:bg-3 colors/tokens)
-                  :color           (:text-primary colors/tokens)
-                  :border          (str "1px solid " (:border-subtle colors/tokens))
+                  :background      (:bg-3 rf.story.theme.colors/tokens)
+                  :color           (:text-primary rf.story.theme.colors/tokens)
+                  :border          (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
                   :border-radius   "10px"
                   :cursor          "pointer"
                   :font-family     mono-stack
-                  :font-size       (:caption typography/type-scale)
+                  :font-size       (:caption rf.story.theme.typography/type-scale)
                   :user-select     "none"}
    ;; dialog
    :back         {:position    "fixed"
@@ -361,73 +361,73 @@
    :modal        {:width          "640px"
                   :max-width      "92vw"
                   :max-height     "86vh"
-                  :background     (:bg-overlay colors/tokens)
-                  :color          (:text-primary colors/tokens)
-                  :border         (str "1px solid " (:border-default colors/tokens))
+                  :background     (:bg-overlay rf.story.theme.colors/tokens)
+                  :color          (:text-primary rf.story.theme.colors/tokens)
+                  :border         (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                   :border-radius  "6px"
                   :padding        "16px"
                   :font-family    mono-stack
-                  :font-size      (:body-tight typography/type-scale)
+                  :font-size      (:body-tight rf.story.theme.typography/type-scale)
                   :display        "flex"
                   :flex-direction "column"
                   :gap            "14px"
                   :box-shadow     "0 14px 36px rgba(0,0,0,0.75)"
                   :overflow       "auto"}
    :title        {:font-weight "bold"
-                  :color       (:info colors/tokens)
-                  :font-size   (:body typography/type-scale)}
-   :hint         {:color (:text-tertiary colors/tokens)
+                  :color       (:info rf.story.theme.colors/tokens)
+                  :font-size   (:body rf.story.theme.typography/type-scale)}
+   :hint         {:color (:text-tertiary rf.story.theme.colors/tokens)
                   :font-style "italic"
-                  :font-size (:micro typography/type-scale)}
+                  :font-size (:micro rf.story.theme.typography/type-scale)}
    :command      {:display "flex"
                   :flex-direction "column"
                   :gap "6px"
                   :padding "12px"
-                  :border (str "1px solid " (:border-subtle colors/tokens))
+                  :border (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
                   :border-radius "5px"
-                  :background (:bg-2 colors/tokens)}
+                  :background (:bg-2 rf.story.theme.colors/tokens)}
    :command-h    {:display "flex"
                   :align-items "center"
                   :gap "8px"
                   :flex-wrap "wrap"}
    :command-name {:font-weight "bold"
-                  :color (:text-primary colors/tokens)
-                  :font-size (:caption typography/type-scale)}
-   :command-desc {:color (:text-secondary colors/tokens)
+                  :color (:text-primary rf.story.theme.colors/tokens)
+                  :font-size (:caption rf.story.theme.typography/type-scale)}
+   :command-desc {:color (:text-secondary rf.story.theme.colors/tokens)
                   :font-family sans-stack
-                  :font-size (:caption typography/type-scale)}
+                  :font-size (:caption rf.story.theme.typography/type-scale)}
    :url-row      {:display "flex"
                   :gap "6px"
                   :align-items "stretch"}
    :url-input    {:flex "1 1 auto"
                   :padding "5px 8px"
-                  :background (:bg-canvas colors/tokens)
-                  :color (:text-primary colors/tokens)
-                  :border (str "1px solid " (:border-default colors/tokens))
+                  :background (:bg-canvas rf.story.theme.colors/tokens)
+                  :color (:text-primary rf.story.theme.colors/tokens)
+                  :border (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                   :border-radius "3px"
                   :font-family mono-stack
-                  :font-size (:micro typography/type-scale)
+                  :font-size (:micro rf.story.theme.typography/type-scale)
                   :overflow "hidden"
                   :text-overflow "ellipsis"
                   :white-space "nowrap"
                   :box-sizing "border-box"}
    :btn          {:padding "5px 12px"
-                  :background (:accent-amber colors/tokens)
-                  :color (:text-on-accent colors/tokens)
+                  :background (:accent-amber rf.story.theme.colors/tokens)
+                  :color (:text-on-accent rf.story.theme.colors/tokens)
                   :border "none"
                   :border-radius "3px"
                   :cursor "pointer"
                   :font-family mono-stack
-                  :font-size (:caption typography/type-scale)
+                  :font-size (:caption rf.story.theme.typography/type-scale)
                   :white-space "nowrap"}
    :btn-muted    {:padding "5px 12px"
                   :background "transparent"
-                  :color (:text-primary colors/tokens)
-                  :border (str "1px solid " (:border-default colors/tokens))
+                  :color (:text-primary rf.story.theme.colors/tokens)
+                  :border (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                   :border-radius "3px"
                   :cursor "pointer"
                   :font-family mono-stack
-                  :font-size (:caption typography/type-scale)
+                  :font-size (:caption rf.story.theme.typography/type-scale)
                   :white-space "nowrap"}
    :btn-row      {:display "flex"
                   :gap "8px"
@@ -436,7 +436,7 @@
 ;; ---- reusable reproducibility badge --------------------------------------
 
 (defn reproducibility-badge
-  "Render the reproducibility badge for a `report` (an `egress/classify`
+  "Render the reproducibility badge for a `report` (an `rf.story.egress/classify`
   return). Pure-hiccup. Shows the status pill (fully / partially /
   view-only) and, when the status is downgraded, the list of reasons that
   made it so — so a dev sharing/exporting reads exactly WHAT makes the
@@ -478,7 +478,7 @@
   "Open the human-egress dialog. No-op under production builds (the whole
   shell is elided). Idempotent."
   []
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (reset! dialog-state {:open? true :copied nil :error nil})))
 
 (defn close-share-export-dialog! []
@@ -522,7 +522,7 @@
   "Copy `text` to the clipboard via the shared review-dialog shim, then
   flash the `cmd` confirmation."
   [cmd text]
-  (review-dialog/copy-to-clipboard! text)
+  (rf.story.review-dialog/copy-to-clipboard! text)
   (mark-copied! cmd))
 
 ;; ---- screenshot ----------------------------------------------------------
@@ -655,12 +655,12 @@
    [:div {:style (:btn-row styles)}
     (when (and copied? (not error))
       [:span {:style (merge (:hint styles) {:font-style "normal"
-                                            :color (:success colors/tokens)})
+                                            :color (:success rf.story.theme.colors/tokens)})
               :data-test (str "story-egress-copied-" test)}
        "copied ✓"])
     (when error
       [:span {:style (merge (:hint styles) {:font-style "normal"
-                                            :color (:danger colors/tokens)})
+                                            :color (:danger rf.story.theme.colors/tokens)})
               :role      "status"
               :data-test (str "story-egress-error-" test)}
        (str "unavailable — " error)])
@@ -697,12 +697,12 @@
   []
   (let [{:keys [open? copied error]} @dialog-state]
     (when open?
-      (let [shell    @state/shell-state-atom
+      (let [shell    @rf.story.ui.state/shell-state-atom
             vid      (:selected-variant shell)
             report   (current-share-report shell)
             url      (current-url)
             edn      (egress-edn-snippet shell)]
-        [a11y-dialog/focus-trap
+        [rf.story.ui.a11y-dialog/focus-trap
          {:on-close close-share-export-dialog!}
          [:div {:style     (:back styles)
                 :data-test "story-share-export-dialog"
@@ -755,7 +755,7 @@
              :desc    "Copy a PNG of the variant canvas to the clipboard."
              :badge   (reproducibility-badge
                         {:status :view-only
-                         :label  (egress/status-labels :view-only)
+                         :label  (rf.story.egress/status-labels :view-only)
                          :reasons [{:status :view-only
                                     :code   :screenshot
                                     :detail "a screenshot is a static image — the recipient sees the view but cannot replay it"}]})
@@ -771,7 +771,7 @@
              :desc    "Build a self-contained static site with `npm run story:build`. The published artifact carries the registered variants as data."
              :badge   (reproducibility-badge
                         {:status :full
-                         :label  (egress/status-labels :full)
+                         :label  (rf.story.egress/status-labels :full)
                          :reasons []})
              :action       (fn [_] (copy-text! :static-build "npm run story:build"))
              :action-label "copy command"

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -51,52 +51,52 @@
   (:require [reagent.core :as r]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            [re-frame.story.xray-preset :as xray-preset]
-            [re-frame.story.config :as config]
-            [re-frame.story.decorators :as decorators]
-            [re-frame.story.frames :as frames]
-            [re-frame.story.predicates :as pred]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.story.runtime :as runtime]
-            [re-frame.trace :as rf-trace]
-            [re-frame.story.ui.backgrounds-switcher :as backgrounds-switcher]
-            [re-frame.story.ui.canvas :as canvas]
-            [re-frame.story.ui.xray-embed :as xray-embed]
-            [re-frame.story.ui.command-palette.view :as command-palette]
-            [re-frame.story.ui.controls :as controls]
-            [re-frame.story.ui.dispatch-console :as dispatch-console]
-            [re-frame.story.ui.docs :as docs]
-            [re-frame.story.ui.element-inspector :as element-inspector]
-            [re-frame.story.ui.evidence-spine :as evidence-spine]
-            [re-frame.story.ui.explain-panel :as explain-panel]
-            [re-frame.story.ui.help :as help]
-            [re-frame.story.ui.keybindings :as keybindings]
-            [re-frame.story.ui.mode-tabs :as mode-tabs]
-            [re-frame.story.ui.multi-substrate :as multi-substrate]
-            [re-frame.story.ui.panels :as panels]
-            [re-frame.story.ui.play-status :as play-status]
-            [re-frame.story.ui.promotion :as promotion]
-            [re-frame.story.recorder.dom-capture :as recorder-dom]
-            [re-frame.story.ui.recorder :as recorder-ui]
-            [re-frame.story.ui.recorder-export-dialog :as recorder-export-ui]
-            [re-frame.story.ui.save-variant :as save-variant-ui]
-            [re-frame.story.ui.share :as share]
-            [re-frame.story.ui.shell.rails :as rails]
-            [re-frame.story.ui.url-state :as url-state]
-            [re-frame.story.ui.watch :as watch]
+            [re-frame.story.xray-preset :as rf.story.xray-preset]
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.decorators :as rf.story.decorators]
+            [re-frame.story.frames :as rf.story.frames]
+            [re-frame.story.predicates :as rf.story.predicates]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.runtime :as rf.story.runtime]
+            [re-frame.trace :as rf.trace]
+            [re-frame.story.ui.backgrounds-switcher :as rf.story.ui.backgrounds-switcher]
+            [re-frame.story.ui.canvas :as rf.story.ui.canvas]
+            [re-frame.story.ui.xray-embed :as rf.story.ui.xray-embed]
+            [re-frame.story.ui.command-palette.view :as rf.story.ui.command-palette.view]
+            [re-frame.story.ui.controls :as rf.story.ui.controls]
+            [re-frame.story.ui.dispatch-console :as rf.story.ui.dispatch-console]
+            [re-frame.story.ui.docs :as rf.story.ui.docs]
+            [re-frame.story.ui.element-inspector :as rf.story.ui.element-inspector]
+            [re-frame.story.ui.evidence-spine :as rf.story.ui.evidence-spine]
+            [re-frame.story.ui.explain-panel :as rf.story.ui.explain-panel]
+            [re-frame.story.ui.help :as rf.story.ui.help]
+            [re-frame.story.ui.keybindings :as rf.story.ui.keybindings]
+            [re-frame.story.ui.mode-tabs :as rf.story.ui.mode-tabs]
+            [re-frame.story.ui.multi-substrate :as rf.story.ui.multi-substrate]
+            [re-frame.story.ui.panels :as rf.story.ui.panels]
+            [re-frame.story.ui.play-status :as rf.story.ui.play-status]
+            [re-frame.story.ui.promotion :as rf.story.ui.promotion]
+            [re-frame.story.recorder.dom-capture :as rf.story.recorder.dom-capture]
+            [re-frame.story.ui.recorder :as rf.story.ui.recorder]
+            [re-frame.story.ui.recorder-export-dialog :as rf.story.ui.recorder-export-dialog]
+            [re-frame.story.ui.save-variant :as rf.story.ui.save-variant]
+            [re-frame.story.ui.share :as rf.story.ui.share]
+            [re-frame.story.ui.shell.rails :as rf.story.ui.shell.rails]
+            [re-frame.story.ui.url-state :as rf.story.ui.url-state]
+            [re-frame.story.ui.watch :as rf.story.ui.watch]
             [re-frame.story.ui.shell-styles :refer [styles]]
-            [re-frame.story.ui.sidebar :as sidebar]
-            [re-frame.story.theme.typography :as theme-typography]
-            [re-frame.story.ui.state :as state]
-            [re-frame.story.ui.test-mode.view :as test-mode-view]
-            [re-frame.story.ui.toolbar :as toolbar]
-            [re-frame.story.ui.trace-buffer :as trace-buffer]
-            [re-frame.story.ui.viewport-switcher :as viewport-switcher]
-            [re-frame.story.ui.workspace :as workspace]
-            [re-frame.story.backgrounds :as backgrounds]
-            [re-frame.story.viewport :as viewport]
-            [re-frame.story.theme.depth :as depth]
-            [re-frame.story.theme.motion :as motion]))
+            [re-frame.story.ui.sidebar :as rf.story.ui.sidebar]
+            [re-frame.story.theme.typography :as rf.story.theme.typography]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.ui.test-mode.view :as rf.story.ui.test-mode.view]
+            [re-frame.story.ui.toolbar :as rf.story.ui.toolbar]
+            [re-frame.story.ui.trace-buffer :as rf.story.ui.trace-buffer]
+            [re-frame.story.ui.viewport-switcher :as rf.story.ui.viewport-switcher]
+            [re-frame.story.ui.workspace :as rf.story.ui.workspace]
+            [re-frame.story.backgrounds :as rf.story.backgrounds]
+            [re-frame.story.viewport :as rf.story.viewport]
+            [re-frame.story.theme.depth :as rf.story.theme.depth]
+            [re-frame.story.theme.motion :as rf.story.theme.motion]))
 
 ;; Styles live in `re-frame.story.ui.shell-styles` (pure-data leaf,
 ;; no Reagent dep). Required as `styles` above so the in-file call
@@ -115,15 +115,15 @@
   on the 500ms hot-reload poll. Fingerprints are body-derived and run-
   layer-invariant; the opts only let the ref collection's compile succeed."
   []
-  (let [shell        (state/get-state)
+  (let [shell        (rf.story.ui.state/get-state)
         active-modes (:active-modes shell)]
     (into {}
           (map (fn [vid]
-                 [vid (decorators/resolution-fingerprints
+                 [vid (rf.story.decorators/resolution-fingerprints
                         vid
                         {:active-modes   active-modes
                          :cell-overrides (get-in shell [:cell-overrides vid])})]))
-          (frames/variant-frames))))
+          (rf.story.frames/variant-frames))))
 
 (defn- existing-frame-fingerprint-drift?
   "True when a frame that was present on the previous poll now reports
@@ -149,16 +149,16 @@
 
   Public so tests can exercise the detector without mounting the shell."
   []
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (let [current (compute-fingerprint-snapshot)
-          shell   (state/get-state)
+          shell   (rf.story.ui.state/get-state)
           prev    (:fingerprints shell)
           drift?  (existing-frame-fingerprint-drift? prev current)]
       (when (not= current prev)
-        (state/swap-state!
+        (rf.story.ui.state/swap-state!
           (fn [s]
             (cond-> (assoc s :fingerprints current)
-              drift? state/bump-hot-reload-tick)))
+              drift? rf.story.ui.state/bump-hot-reload-tick)))
         drift?))))
 
 ;; ---- watch-mode detector (rf2-z1h0f) -------------------------------------
@@ -166,14 +166,14 @@
 ;; The chrome-level test widget's eye-icon toggles `[:tests :watch-mode?]`
 ;; in the shell state. When on, `detect-watch-drift!` polls a snapshot-
 ;; identity content-hash per testable variant (via
-;; `watch/compute-testable-content-hashes`), compares it against the
+;; `rf.story.ui.watch/compute-testable-content-hashes`), compares it against the
 ;; recorded `[:tests :content-hashes]` slot, and dispatches
-;; `sidebar/watch-rerun!` for the variants whose hash drifted. Detection
+;; `rf.story.ui.sidebar/watch-rerun!` for the variants whose hash drifted. Detection
 ;; runs on the same 500ms cadence as the hot-reload poll.
 ;;
 ;; The compute + its hot-path cache live in `re-frame.story.ui.watch` — a
 ;; leaf that requires neither `shell` nor `sidebar`, so the toggle seed
-;; (`sidebar/set-watch-mode!`, rf2-asp2op) can share the SAME compute
+;; (`rf.story.ui.sidebar/set-watch-mode!`, rf2-asp2op) can share the SAME compute
 ;; without a `sidebar → shell` load cycle. See that ns for the cache-key
 ;; rationale (incl. the rf2-3y7l7u view-schema-digest signal).
 
@@ -186,16 +186,16 @@
   Public so tests can exercise the detector without driving the poll
   interval."
   []
-  (when (and config/enabled? (state/test-watch-mode? (state/get-state)))
-    (let [current (watch/compute-testable-content-hashes)
-          shell   (state/get-state)
+  (when (and rf.story.config/enabled? (rf.story.ui.state/test-watch-mode? (rf.story.ui.state/get-state)))
+    (let [current (rf.story.ui.watch/compute-testable-content-hashes)
+          shell   (rf.story.ui.state/get-state)
           prev    (get-in shell [:tests :content-hashes])
-          drifted (state/watch-mode-drift prev current)]
+          drifted (rf.story.ui.state/watch-mode-drift prev current)]
       ;; Always stamp the fresh hashes so the next poll diffs against
       ;; the post-drift baseline (rather than re-firing forever).
-      (state/swap-state! state/record-test-content-hashes current)
+      (rf.story.ui.state/swap-state! rf.story.ui.state/record-test-content-hashes current)
       (when (seq drifted)
-        (sidebar/watch-rerun! drifted)
+        (rf.story.ui.sidebar/watch-rerun! drifted)
         true))))
 
 (defn- watch-mode-tick!
@@ -213,7 +213,7 @@
       ;; audit (SH2): silent swallows on the watch-mode hot-loop hide
       ;; real bugs. `emit-error!` gates on `interop/debug-enabled?`
       ;; so the call DCE's to a no-op in production builds.
-      (rf-trace/emit-error!
+      (rf.trace/emit-error!
         :rf.story.shell/watch-mode-tick-failed
         {:exception e
          :where     :rf.story.shell/watch-mode-tick!
@@ -226,7 +226,7 @@
   "One pass of the shell's polling interval. Runs the fingerprint
   detector (decorator drift → bump `:hot-reload-tick`) followed by the
   watch-mode detector (per-testable-variant snapshot-identity drift →
-  dispatch `sidebar/watch-rerun!` when watch mode is on). Two
+  dispatch `rf.story.ui.sidebar/watch-rerun!` when watch mode is on). Two
   detectors, one cadence."
   []
   (detect-and-tick!)
@@ -241,8 +241,8 @@
   work that thrashes the React tree on every tick. Skip the poll
   entirely; the shell renders against a stable registry."
   []
-  (when (and config/enabled?
-             (not config/static-mode?)
+  (when (and rf.story.config/enabled?
+             (not rf.story.config/static-mode?)
              (nil? @hot-reload-poll-handle))
     (let [h (js/setInterval poll-tick! 500)]
       (reset! hot-reload-poll-handle h))))
@@ -264,24 +264,24 @@
   trace-buffer listener stays because the schema-validation panel
   consumes the per-variant buffer."
   [variant-id]
-  (when (and config/enabled?
+  (when (and rf.story.config/enabled?
              (some? variant-id)
              (not (contains? @listened-variants variant-id)))
-    (trace-buffer/register-listener! variant-id)
+    (rf.story.ui.trace-buffer/register-listener! variant-id)
     (swap! listened-variants conj variant-id)))
 
 (defn- teardown-listeners-for-variant!
   [variant-id]
   (when (some? variant-id)
-    (trace-buffer/remove-listener! variant-id)
-    (trace-buffer/drop-buffer! variant-id)
+    (rf.story.ui.trace-buffer/remove-listener! variant-id)
+    (rf.story.ui.trace-buffer/drop-buffer! variant-id)
     (swap! listened-variants disj variant-id)))
 
 (defn- teardown-all-listeners! []
   (doseq [vid @listened-variants]
-    (trace-buffer/remove-listener! vid))
+    (rf.story.ui.trace-buffer/remove-listener! vid))
   (reset! listened-variants #{})
-  (trace-buffer/clear-buffer!))
+  (rf.story.ui.trace-buffer/clear-buffer!))
 
 (defn- ensure-variant-frame!
   "PREPARE `variant-id`'s one run owner (rf2-j538f7.34) on the selection
@@ -304,14 +304,14 @@
   the play-script here (which, with the canvas run and the post-commit
   auto-run, made it execute up to three times)."
   [variant-id]
-  (when (and config/enabled? variant-id)
-    (let [shell @state/shell-state-atom
+  (when (and rf.story.config/enabled? variant-id)
+    (let [shell @rf.story.ui.state/shell-state-atom
           opts  {:active-modes   (:active-modes shell)
                  :cell-overrides (get-in shell [:cell-overrides variant-id])
                  :substrate      (:substrate shell)
-                 :run-key        (canvas/run-key shell variant-id)}]
+                 :run-key        (rf.story.ui.canvas/run-key shell variant-id)}]
       (try
-        (runtime/prepare-run! variant-id opts)
+        (rf.story.runtime/prepare-run! variant-id opts)
         (catch :default e
           ;; Swallow + breadcrumb. The canvas re-tries via
           ;; :component-did-mount / :component-did-update, and the
@@ -322,7 +322,7 @@
           ;; was hiding errors. `emit-error!` gates on `interop/debug-
           ;; enabled?` so the call DCE's to a no-op in production
           ;; builds (where the chrome itself is elided anyway).
-          (rf-trace/emit-error!
+          (rf.trace/emit-error!
             :rf.story.shell/ensure-variant-frame-failed
             {:variant-id variant-id
              :exception  e
@@ -353,8 +353,8 @@
   diffs against a fresh baseline rather than a value left over from a
   previous mount."
   []
-  (reset! selection-prev (:selected-variant @state/shell-state-atom))
-  (add-watch state/shell-state-atom
+  (reset! selection-prev (:selected-variant @rf.story.ui.state/shell-state-atom))
+  (add-watch rf.story.ui.state/shell-state-atom
              ::shell-selection
              (fn [_ _ _ new-state]
                (let [now    (:selected-variant new-state)
@@ -398,14 +398,14 @@
                      ;; (it's an atom-watch callback on the shell
                      ;; ratom), so the in-drain guard does not apply.
                      ;; The rf2-q9kv5 sibling dispatches in
-                     ;; `xray-preset/on-variant-selected!` below still
+                     ;; `rf.story.xray-preset/on-variant-selected!` below still
                      ;; ride the async queue — they're Xray's own
                      ;; preset-applies and don't gate the next-frame
                      ;; panel paint the way the target-frame slot does.
                      (rf/with-frame :rf/xray
                        (rf/dispatch-sync [:rf.xray/set-target-frame now]))
                      ;; rf2-v1ach: Xray now mounts per-panel into the
-                     ;; RHS via `xray-embed/xray-embed-panel`. The
+                     ;; RHS via `rf.story.ui.xray-embed/xray-embed-panel`. The
                      ;; embed owns its own React lifecycle — selecting
                      ;; a variant rebuilds the panel-host component
                      ;; (keyed on `variant-id::panel-id`) which drives
@@ -415,12 +415,12 @@
                      ;; coord chips honour Story's configured
                      ;; `:rf.story/project-root`. Per-variant Xray bridges
                      ;; live on a separate seam from the embed mount.
-                     (xray-preset/wire-cross-host!)
+                     (rf.story.xray-preset/wire-cross-host!)
                      ;; rf2-q9kv5: apply any per-story Xray preset
                      ;; (focus tab, configure filters, focus a cascade
                      ;; position) + seed the RHS chip-row's user-
                      ;; override slot from the story's `:xray-panel`.
-                     (xray-preset/on-variant-selected! now)
+                     (rf.story.xray-preset/on-variant-selected! now)
                      ;; rf2-8i2a9 / rf2-j538f7.34: RESUME the one run owner —
                      ;; run the auto-plays exactly once per prepared
                      ;; generation. Yields one tick via setTimeout so React
@@ -432,12 +432,12 @@
                      ;; whichever fires first wins and the other no-ops.
                      ;; Variants without `:script` / auto-plays no-op.
                      (js/setTimeout
-                       (fn [] (runtime/resume-run! now))
+                       (fn [] (rf.story.runtime/resume-run! now))
                        0))
                    (reset! selection-prev now))))))
 
 (defn- remove-selection-watcher! []
-  (remove-watch state/shell-state-atom ::shell-selection)
+  (remove-watch rf.story.ui.state/shell-state-atom ::shell-selection)
   ;; Clear the cross-mount tracker so the next install starts from a
   ;; clean baseline rather than diffing the first selection against a
   ;; value held over from the previous mount.
@@ -477,7 +477,7 @@
 ;; ---- url-state apply-fn ---------------------------------------------------
 ;;
 ;; rf2-o4u18: bridge between the pure `url-state` engine and the live
-;; registrar / preset tables. `url-state/apply-parsed-to-state` takes a
+;; registrar / preset tables. `rf.story.ui.url-state/apply-parsed-to-state` takes a
 ;; validators map; we build it here so the engine ns stays portable
 ;; (CLJC) and the live wiring sits in one place.
 
@@ -488,14 +488,14 @@
   []
   (let [validators {:variant?    (fn [vid]
                                    (or (nil? vid)
-                                       (registrar/registered? :variant vid)))
+                                       (rf.story.registrar/registered? :variant vid)))
                     :workspace?  (fn [wid]
                                    (or (nil? wid)
-                                       (registrar/registered? :workspace wid)))
+                                       (rf.story.registrar/registered? :workspace wid)))
                     :viewport?   (fn [v]
-                                   (or (nil? v) (viewport/valid-selection? v)))
+                                   (or (nil? v) (rf.story.viewport/valid-selection? v)))
                     :background? (fn [b]
-                                   (or (nil? b) (backgrounds/valid-selection? b)))
+                                   (or (nil? b) (rf.story.backgrounds/valid-selection? b)))
                     ;; rf2-dxz4sg: validate the URL substrate against the live
                     ;; substrate registry so a stale/unregistered `substrate=`
                     ;; degrades to the `:reagent` default rather than pinning a
@@ -504,22 +504,22 @@
                     ;; apply-parsed-to-state.
                     :substrate?  (fn [s]
                                    (or (nil? s)
-                                       (contains? (multi-substrate/registered-substrates) s)))}]
+                                       (contains? (rf.story.ui.multi-substrate/registered-substrates) s)))}]
     (fn [state parsed]
-      (url-state/apply-parsed-to-state state parsed validators))))
+      (rf.story.ui.url-state/apply-parsed-to-state state parsed validators))))
 
 (defn- hydrate-url-state!
   "One-shot URL → shell-state hydration on mount, in two passes with a
   CLEAR single-owner split (rf2-ovb1en):
 
-    1. `url-state/hydrate-from-url!` is the AUTHORITATIVE owner of every
+    1. `rf.story.ui.url-state/hydrate-from-url!` is the AUTHORITATIVE owner of every
        URL-owned slot it writes — selection (variant / workspace),
        mode-tab, modes, viewport, background, tag-filter, substrate — and
        VALIDATES each against the live registry (a stale `substrate=ghost`
        degrades to `:reagent`; an unregistered variant degrades to no
        selection). It also installs the raw parsed cell-overrides under
        `[:cell-overrides variant-id]`.
-    2. `share/hydrate-from-url!` is the AUTHORITATIVE owner of the
+    2. `rf.story.ui.share/hydrate-from-url!` is the AUTHORITATIVE owner of the
        focused-variant cell-overrides slice on mount: it applies the
        declared-key DRIFT filter `url-state` cannot run (renamed / removed
        args), writing the filtered slice (or CLEARING it when all overrides
@@ -537,8 +537,8 @@
   as its `post-apply-fn` — so a stale override survives no better via
   history navigation than it would via a fresh mount (rf2-cmjly3 finding 8)."
   []
-  (url-state/hydrate-from-url! state/shell-state-atom (url-state-apply-fn))
-  (share/hydrate-from-url!))
+  (rf.story.ui.url-state/hydrate-from-url! rf.story.ui.state/shell-state-atom (url-state-apply-fn))
+  (rf.story.ui.share/hydrate-from-url!))
 
 ;; ---- the top-level component ---------------------------------------------
 
@@ -553,9 +553,9 @@
   mounts into the `[data-rf-xray-host]` slot below via its standard
   `mount/open!` flow — driven from the selection-watcher whenever a
   variant becomes focused (config bridges via
-  `xray-preset/wire-cross-host!`).
+  `rf.story.xray-preset/wire-cross-host!`).
 
-  `panels/render-panels-at-placement` ensures any
+  `rf.story.ui.panels/render-panels-at-placement` ensures any
   `reg-story-panel` registration with `:placement :right` appears here.
   The built-in v1.0 panels (a11y, layout-debug toggles, schema
   validation) ride this path.
@@ -565,14 +565,14 @@
   `region`/`landmark-one-main` rules pass. `tabindex=\"0\"` makes the
   scrollable container reachable for keyboard users."
   []
-  (let [shell      @state/shell-state-atom
+  (let [shell      @rf.story.ui.state/shell-state-atom
         variant-id (:selected-variant shell)
         vis        (:panel-visibility shell)
-        widths     (rails/current-widths)
-        narrow?    (rails/narrow-viewport?)]
+        widths     (rf.story.ui.shell.rails/current-widths)
+        narrow?    (rf.story.ui.shell.rails/narrow-viewport?)]
     [:aside {:style      (merge (:right styles)
                                 {:width (str (:right widths) "px")
-                                 :animation (motion/stagger-animation :right)}
+                                 :animation (rf.story.theme.motion/stagger-animation :right)}
                                 (when narrow? (:right-narrow styles)))
              :data-test  "story-inspectors"
              :role       "complementary"
@@ -600,7 +600,7 @@
        [:span "Xray"]
        [:span {:style (:rhs-section-sub-xray styles)}
         "diagnostic"]]
-      [xray-embed/xray-embed-panel]]
+      [rf.story.ui.xray-embed/xray-embed-panel]]
      ;; rf2-ba86n.9 — Explain panel. The Story-owned provenance +
      ;; lowering surface over `story/explain` data (spec/020 §4). Sits
      ;; directly under the Xray embed: same RHS inspector rail, but a
@@ -615,15 +615,15 @@
      ;; the command palette's `Explain variant` command flips it on +
      ;; scrolls here when the user has toggled it off.
      (when (and variant-id
-                (not (false? (get vis explain-panel/panel-key)))) ;; nil/true → show
-       [:section {:id explain-panel/anchor-id
+                (not (false? (get vis rf.story.ui.explain-panel/panel-key)))) ;; nil/true → show
+       [:section {:id rf.story.ui.explain-panel/anchor-id
                   :style (:rhs-section styles)
                   :data-rf-rhs-section "explain"}
         [:div {:style (:rhs-section-h styles)}
          [:span "Explain"]
          [:span {:style (:rhs-section-sub styles)}
           "provenance + lowering"]]
-        [explain-panel/explain-panel]])
+        [rf.story.ui.explain-panel/explain-panel]])
      ;; rf2-ba86n.10 — Evidence spine. The Story-owned narrative/evidence
      ;; DISPLAY over the retained epoch tape (spec/020 §3 + spec/021 §2).
      ;; Sits under Explain in the RHS inspector rail: script spans over
@@ -639,15 +639,15 @@
      ;; entry is reachable out of the box; the result-row links in Test mode
      ;; + the command palette flip it on + scroll here.
      (when (and variant-id
-                (not (false? (get vis evidence-spine/panel-key)))) ;; nil/true → show
-       [:section {:id evidence-spine/anchor-id
+                (not (false? (get vis rf.story.ui.evidence-spine/panel-key)))) ;; nil/true → show
+       [:section {:id rf.story.ui.evidence-spine/anchor-id
                   :style (:rhs-section styles)
                   :data-rf-rhs-section "evidence"}
         [:div {:style (:rhs-section-h styles)}
          [:span "Evidence"]
          [:span {:style (:rhs-section-sub styles)}
           "narrative + Xray focus"]]
-        [evidence-spine/evidence-spine-panel]])
+        [rf.story.ui.evidence-spine/evidence-spine-panel]])
      (when (:controls vis)
        [:section {:style (:rhs-section styles)
                   :data-rf-rhs-section "controls"}
@@ -655,7 +655,7 @@
          [:span "Controls"]
          [:span {:style (:rhs-section-sub styles)}
           "args + modes"]]
-        [controls/panel variant-id]])
+        [rf.story.ui.controls/panel variant-id]])
      ;; rf2-q9kv5 — Dispatch Console panel. Free-form event dispatch into
      ;; the running variant's frame. Default HIDDEN; opt-in via
      ;; `:dispatch-console? true` on the story or variant body. The
@@ -673,10 +673,10 @@
      ;; opt-in is the more polite default.
      (when (and variant-id
                 (let [vis-flag (:dispatch-console vis)
-                      var-body (registrar/handler-meta :variant variant-id)
-                      story-id (pred/parent-story-id variant-id)
+                      var-body (rf.story.registrar/handler-meta :variant variant-id)
+                      story-id (rf.story.predicates/parent-story-id variant-id)
                       sty-body (when story-id
-                                 (registrar/handler-meta :story story-id))
+                                 (rf.story.registrar/handler-meta :story story-id))
                       ;; Story slot default; variant overrides; user toggle wins.
                       story-default (get sty-body  :dispatch-console? false)
                       var-default   (get var-body  :dispatch-console? story-default)]
@@ -690,46 +690,46 @@
          [:span "Dispatch"]
          [:span {:style (:rhs-section-sub styles)}
           "free-form events"]]
-        [dispatch-console/panel variant-id]])
+        [rf.story.ui.dispatch-console/panel variant-id]])
      ;; Render any registered :right-placement story panels.
      ;; Wrapped in a section so the visual rhythm holds across Story-
      ;; shipped + user-registered panels uniformly.
      (when variant-id
        [:section {:style (:rhs-section styles)
                   :data-rf-rhs-section "story-panels"}
-        [panels/render-panels-at-placement :right variant-id vis]])]))
+        [rf.story.ui.panels/render-panels-at-placement :right variant-id vis]])]))
 
 (defn- framed-canvas
-  "Render the variant `canvas/canvas` wrapped with the effective
+  "Render the variant `rf.story.ui.canvas/canvas` wrapped with the effective
   viewport + background framing (rf2-zll4h).
 
   Per rf2-zgu68 also surfaces a viewport-px chip at the bottom-right
   when a non-`:full` viewport mode is active. The chip self-elides
   for `:full`.
 
-  rf2-j8hklm: `[canvas/canvas]` sits behind a STABLE always-present
+  rf2-j8hklm: `[rf.story.ui.canvas/canvas]` sits behind a STABLE always-present
   `:div` wrapper regardless of `sized?` — only the wrapper's OWN style
   varies (the real `vp-style` sizing box when sized, `display: contents`
-  otherwise so the wrapper drops out of layout and `canvas/canvas`'s own
+  otherwise so the wrapper drops out of layout and `rf.story.ui.canvas/canvas`'s own
   `:flex \"1\"` sizes it against the outer flex container exactly as
   when it rendered unwrapped). Previously `sized?` picked between TWO
-  DIFFERENT hiccup shapes at this tree position — `[:div ... [canvas/
-  canvas]]` vs bare `[canvas/canvas]` — so toggling the viewport across
+  DIFFERENT hiccup shapes at this tree position — `[:div ... [rf.story.ui.canvas/
+  canvas]]` vs bare `[rf.story.ui.canvas/canvas]` — so toggling the viewport across
   the `:full`-vs-sized boundary changed the React element TYPE at this
   slot (`:div` vs the canvas class) and forced React to unmount + remount
-  the canvas subtree. `canvas/canvas`'s `component-will-unmount` cleared
+  the canvas subtree. `rf.story.ui.canvas/canvas`'s `component-will-unmount` cleared
   the run-key sentinel, so the fresh mount's `component-did-mount` always
   re-ran `run-variant` — wiping the live variant's interactive app-db even
   though the viewport is deliberately excluded from `run-key` precisely
-  so a viewport toggle should NOT re-run it. Keying `[canvas/canvas]` at
+  so a viewport toggle should NOT re-run it. Keying `[rf.story.ui.canvas/canvas]` at
   an identical tree position across both branches keeps React's
   reconciler on the SAME component instance, so the toggle only ever
   updates the wrapper's style — never a remount."
   []
-  (let [vp        (viewport-switcher/effective-viewport)
-        bg        (backgrounds-switcher/effective-background)
-        vp-style  (viewport/wrap-style vp)
-        bg-style  (backgrounds/wrap-style bg)
+  (let [vp        (rf.story.ui.viewport-switcher/effective-viewport)
+        bg        (rf.story.ui.backgrounds-switcher/effective-background)
+        vp-style  (rf.story.viewport/wrap-style vp)
+        bg-style  (rf.story.backgrounds/wrap-style bg)
         wrap-style (merge {:padding    "16px"
                            :display    "flex"
                            :flex       "1"
@@ -746,13 +746,13 @@
         sized?   (some? vp-style)]
     [:div {:style       wrap-style
            :data-test   "story-canvas-frame"
-           :data-viewport (name (viewport-switcher/effective-id))
-           :data-background (name (backgrounds-switcher/effective-id))}
+           :data-viewport (name (rf.story.ui.viewport-switcher/effective-id))
+           :data-background (name (rf.story.ui.backgrounds-switcher/effective-id))}
      [:div (cond-> {:style (or vp-style {:display "contents"})}
              sized? (assoc :data-test "story-canvas-frame-sized"))
-      [canvas/canvas]]
+      [rf.story.ui.canvas/canvas]]
      ;; rf2-zgu68 — viewport-px indicator chip. Self-elides for `:full`.
-     [canvas/viewport-indicator vp]]))
+     [rf.story.ui.canvas/viewport-indicator vp]]))
 
 (defn- main-pane
   "The main content pane — workspace if one is selected, otherwise the
@@ -765,39 +765,39 @@
   Per rf2-9hc8 a Canvas | Docs | Tests mode-tab strip sits at the top
   of the pane when a variant is selected; selection is per-variant and
   persists across reloads in localStorage. Per rf2-rodx the `:docs`
-  pane renders `docs/docs-view` — the read-only AutoDocs surface
+  pane renders `rf.story.ui.docs/docs-view` — the read-only AutoDocs surface
   composed of header / prose / args / decorators / parameters / tags
-  sections. Per rf2-qmjo the `:test` pane renders `test-mode-view/test-view`
+  sections. Per rf2-qmjo the `:test` pane renders `rf.story.ui.test-mode.view/test-view`
   — the in-canvas aggregated pass/fail summary of the variant's
   `:script` sequence + assertions. `:dev` preserves the existing canvas
   / workspace behaviour."
   []
-  (let [shell      @state/shell-state-atom
+  (let [shell      @rf.story.ui.state/shell-state-atom
         variant-id (:selected-variant shell)
         ws-id      (:selected-workspace shell)
         story-id   (:selected-story shell)
         mode-tab   (when variant-id
-                     (state/active-mode-tab shell variant-id))]
+                     (rf.story.ui.state/active-mode-tab shell variant-id))]
     [:main {:style (merge (:main styles)
-                          {:animation (motion/stagger-animation :main)})
+                          {:animation (rf.story.theme.motion/stagger-animation :main)})
             :aria-label "Story canvas"}
      ;; rf2-9hc8: top-of-shell mode-tab strip — only when a single
      ;; variant is selected (workspaces enumerate multiple variants and
      ;; have their own layout switcher; mixing mode-tabs into that pane
      ;; conflates two unrelated UX axes).
      (when (and variant-id (not ws-id))
-       [mode-tabs/mode-tabs-strip variant-id])
+       [rf.story.ui.mode-tabs/mode-tabs-strip variant-id])
      ;; rf2-8i2a9: play-script failure banner. Lives ABOVE the canvas
      ;; so a failed run is the first thing the user sees. Self-elides
      ;; when the run is not in `:fail`. Click-to-highlight points the
      ;; user at the failing DOM selector.
      (when (and variant-id (not ws-id))
-       [play-status/banner-when-enabled variant-id])
+       [rf.story.ui.play-status/banner-when-enabled variant-id])
      (cond
-       ws-id    [workspace/workspace-view ws-id]
+       ws-id    [rf.story.ui.workspace/workspace-view ws-id]
        variant-id (case mode-tab
-                    :docs [docs/docs-view variant-id]
-                    :test [test-mode-view/test-view variant-id]
+                    :docs [rf.story.ui.docs/docs-view variant-id]
+                    :test [rf.story.ui.test-mode.view/test-view variant-id]
                     ;; rf2-zll4h — wrap the canvas with viewport sizing
                     ;; + background colour. The :docs and :test panes
                     ;; are NOT framed (they're shell chrome, not the
@@ -807,7 +807,7 @@
        ;; sidebar's story-header rows dispatch `select-story` which
        ;; lands here. Variant + workspace selection take precedence
        ;; (the user navigated FROM the rollup into a leaf).
-       story-id [docs/docs-rollup-view story-id]
+       story-id [rf.story.ui.docs/docs-rollup-view story-id]
        :else
        ;; Calm first-run / empty state (spec/018 §12.5). Not an
        ;; explanatory poster — a quiet centred prompt on the transparent
@@ -836,32 +836,32 @@
     {:display-name "rf-story-shell"
      :component-did-mount
      (fn [_]
-       (when config/enabled?
+       (when rf.story.config/enabled?
          ;; rf2-2rwdc: inject IBM Plex `@font-face` rules into the
          ;; document head BEFORE the first render so the chrome's
          ;; `font-family: "IBM Plex Sans"` / `"IBM Plex Mono"`
          ;; declarations resolve immediately. Idempotent — the helper's
          ;; internal sentinel collapses subsequent calls. Safe in static
          ;; builds (re-frame.story.config/static-mode? still passes
-         ;; config/enabled?; the helper renders <style>@font-face..</style>
+         ;; rf.story.config/enabled?; the helper renders <style>@font-face..</style>
          ;; which static export captures correctly).
-         (theme-typography/inject-font-faces!)
+         (rf.story.theme.typography/inject-font-faces!)
          ;; rf2-3lt89: inject motion @keyframes + prefers-reduced-motion
          ;; override stylesheet. Defines the `rf-story-mount-in` /
          ;; `rf-story-overlay-in` / `rf-story-chip-press` keyframes the
          ;; chrome refers to via inline `:animation` slots, plus the
          ;; canonical `[data-rf-story-root] *:focus-visible` outline so
          ;; the focus ring is uniform across every chrome surface.
-         ;; Idempotent. Behind config/enabled? — production short-
+         ;; Idempotent. Behind rf.story.config/enabled? — production short-
          ;; circuits before the DOM touch.
-         (motion/inject-motion-css!)
+         (rf.story.theme.motion/inject-motion-css!)
          ;; rf2-ypd6h: inject grain overlay stylesheet — an SVG-feTurbulence
          ;; noise sheet rendered as a `::before` pseudo on
          ;; `[data-rf-story-root]` so the bare slate grounds carry studio
          ;; texture rather than reading as 'editor pane'. Self-elides on
-         ;; prefers-contrast more / when config/enabled? is false.
+         ;; prefers-contrast more / when rf.story.config/enabled? is false.
          ;; Idempotent.
-         (depth/inject-grain-css!)
+         (rf.story.theme.depth/inject-grain-css!)
          ;; rf2-96y71s: seed chrome-wide :active-modes from the
          ;; localStorage FALLBACK only. The toolbar no longer reads the
          ;; URL — URL-derived :active-modes hydration is owned solely by
@@ -871,14 +871,14 @@
          ;; URL carries params, and leave it intact on a fresh no-URL
          ;; mount — the URL-over-localStorage precedence (spec/022
          ;; §Share semantics). Idempotent and one-shot.
-         (toolbar/hydrate-modes-from-storage!)
+         (rf.story.ui.toolbar/hydrate-modes-from-storage!)
          ;; rf2-zll4h: hydrate the chrome-wide viewport + background
          ;; selections from localStorage. Both are idempotent and
          ;; one-shot; they no-op when the slot is already populated
          ;; (e.g. a programmatic test fixture seeded them). Same
          ;; localStorage-first / URL-authoritative discipline as modes.
-         (viewport-switcher/hydrate!)
-         (backgrounds-switcher/hydrate!)
+         (rf.story.ui.viewport-switcher/hydrate!)
+         (rf.story.ui.backgrounds-switcher/hydrate!)
          (start-hot-reload-poll!)
          (selection-watcher)
          ;; rf2-chi9j3: capture the selection BEFORE `hydrate-url-state!`
@@ -891,12 +891,12 @@
          ;; pre-hydration value to tell the two cases apart so the mount-
          ;; time block never double-schedules a deep-linked variant's
          ;; `:script`.
-         (let [pre-hydrate-vid (:selected-variant @state/shell-state-atom)]
+         (let [pre-hydrate-vid (:selected-variant @rf.story.ui.state/shell-state-atom)]
            ;; rf2-o4u18 / rf2-ovb1en: hydrate the URL-state slots (workspace +
            ;; mode-tab + viewport + background + tag-filter + variant / modes /
-           ;; substrate) — `url-state/hydrate-from-url!` is the authoritative,
+           ;; substrate) — `rf.story.ui.url-state/hydrate-from-url!` is the authoritative,
            ;; VALIDATING owner of all of them and sets the focused selection.
-           ;; `share/hydrate-from-url!` then owns ONLY the focused-variant
+           ;; `rf.story.ui.share/hydrate-from-url!` then owns ONLY the focused-variant
            ;; cell-overrides slice (declared-key drift filter + share-import
            ;; hint, rf2-9jthx); it reads — never rewrites — the validated
            ;; selection / substrate, so the second pass can't undo the first
@@ -916,21 +916,21 @@
            ;; rf2-cmjly3 finding 8: `apply-parsed-to-state` alone installs
            ;; the RAW parsed overrides — it's pure/registrar-free, so it
            ;; can't run the declared-key stale-override drop-and-report
-           ;; filter `share/hydrate-from-url!` runs on mount. Passing it as
+           ;; filter `rf.story.ui.share/hydrate-from-url!` runs on mount. Passing it as
            ;; `post-apply-fn` re-runs that SAME filter after every popstate
            ;; (inside the same hydration guard) so Back/Forward gets the
            ;; identical drop/report treatment as mount hydration.
-           (url-state/install-popstate-listener!
-             state/shell-state-atom
+           (rf.story.ui.url-state/install-popstate-listener!
+             rf.story.ui.state/shell-state-atom
              (url-state-apply-fn)
-             share/hydrate-from-url!)
-           (url-state/install-state-watcher! state/shell-state-atom)
+             rf.story.ui.share/hydrate-from-url!)
+           (rf.story.ui.url-state/install-state-watcher! rf.story.ui.state/shell-state-atom)
            ;; rf2-5fc15: install the Test Codegen recorder's trace-bus
            ;; listener once at shell mount. The listener short-circuits
            ;; on every emit when no recording is in flight, so leaving
            ;; it installed is free; we only need to make sure it
            ;; exists before the user clicks REC.
-           (recorder-ui/install-trace-listener!)
+           (rf.story.ui.recorder/install-trace-listener!)
            ;; rf2-d5u89: install the recorder's DOM-capture listeners
            ;; on the canvas root so :click / :input / :change / :submit
            ;; events translate into [:dom/click ...] / [:dom/type ...]
@@ -942,7 +942,7 @@
            ;; install is free even when REC is idle.
            (js/setTimeout
              (fn []
-               (recorder-dom/install!)
+               (rf.story.recorder.dom-capture/install!)
                ;; rf2-h0jc0: element-level click-to-code inspector. Hooks
                ;; mousemove / click / keydown on the same canvas root the
                ;; recorder uses. Listener gates on `(inspector/active?)`
@@ -951,37 +951,37 @@
                ;; head. Same one-tick `setTimeout` discipline as the
                ;; recorder so the React tree has committed the canvas-
                ;; frame DOM node before the install tries to find it.
-               (element-inspector/install!))
+               (rf.story.ui.element-inspector/install!))
              0)
            ;; rf2-one3t: install the save-as-variant dialog-open callback
            ;; against the pure ns so `save-variant/save-current-as-variant!`
            ;; can drive the modal without coupling the .cljc helper to
            ;; Reagent / DOM. Idempotent.
-           (save-variant-ui/install!)
-           (rails/hydrate!)
+           (rf.story.ui.save-variant/install!)
+           (rf.story.ui.shell.rails/hydrate!)
            ;; rf2-g8l8x — hydrate per-panel chrome-visibility map from
            ;; localStorage BEFORE the embed-flag pass (embed is URL-
            ;; driven, must not be clobbered by stale persisted slot).
-           (keybindings/hydrate!)
+           (rf.story.ui.keybindings/hydrate!)
            ;; rf2-pucku — hydrate the `:embed?` slot from the
            ;; `?embed=1` URL flag. One-shot at mount.
-           (url-state/hydrate-embed-flag! state/shell-state-atom)
+           (rf.story.ui.url-state/hydrate-embed-flag! rf.story.ui.state/shell-state-atom)
            ;; rf2-g8l8x / rf2-p3i0t — install the chrome-level hotkey
            ;; listener. Cmd-K palette ships its own listener.
-           (keybindings/install!)
-           (when-let [vid (:selected-variant @state/shell-state-atom)]
+           (rf.story.ui.keybindings/install!)
+           (when-let [vid (:selected-variant @rf.story.ui.state/shell-state-atom)]
              (ensure-listeners-for-variant! vid)
              ;; rf2-v1ach: per-panel embed manages its own mount on
              ;; commit. The cross-host bridges (project-root +
              ;; keybinding detach) still need to fire so the popout
              ;; escape hatch + Xray's source-coord chips resolve
              ;; against Story's `:rf.story/project-root`.
-             (xray-preset/wire-cross-host!)
+             (rf.story.xray-preset/wire-cross-host!)
              ;; rf2-q9kv5: apply per-story preset on the mount-time
              ;; selection too (the selection-watcher only fires on
              ;; change, so a pre-selected variant would otherwise miss
              ;; the preset).
-             (xray-preset/on-variant-selected! vid)
+             (rf.story.xray-preset/on-variant-selected! vid)
              ;; rf2-8i2a9 / rf2-chi9j3 / rf2-j538f7.34: mount-time RESUME for
              ;; an already-selected variant (deep-link / persisted selection).
              ;; The `mount-time-autorun-vid` guard (rf2-chi9j3) is retained so
@@ -993,7 +993,7 @@
              ;; before the script's first DOM-sensitive step runs.
              (when-let [run-vid (mount-time-autorun-vid pre-hydrate-vid vid)]
                (js/setTimeout
-                 (fn [] (runtime/resume-run! run-vid))
+                 (fn [] (rf.story.runtime/resume-run! run-vid))
                  0))))))
      :component-will-unmount
      (fn [_]
@@ -1001,60 +1001,60 @@
        (remove-selection-watcher!)
        ;; rf2-g8l8x / rf2-p3i0t — tear down the chrome-level hotkey
        ;; listener so a re-mount doesn't accumulate handlers.
-       (keybindings/remove!)
-       (recorder-ui/remove-trace-listener!)
+       (rf.story.ui.keybindings/remove!)
+       (rf.story.ui.recorder/remove-trace-listener!)
        ;; rf2-d5u89: tear down DOM-capture listeners alongside the
        ;; trace listener so we don't leak listeners across re-mounts.
-       (recorder-dom/remove!)
+       (rf.story.recorder.dom-capture/remove!)
        ;; rf2-h0jc0: tear down the element-inspector listeners +
        ;; reset its mode flag. Mirrors the recorder-dom shape — both
        ;; rides the canvas-root listener install lifecycle.
-       (element-inspector/remove!)
+       (rf.story.ui.element-inspector/remove!)
        ;; rf2-o4u18: drop popstate + shell-state URL watchers so a
        ;; re-mount doesn't accumulate listeners.
-       (url-state/tear-down! state/shell-state-atom)
+       (rf.story.ui.url-state/tear-down! rf.story.ui.state/shell-state-atom)
        ;; rf2-j538f7.34: clear the one-run-owner registry so a fresh shell
        ;; mount starts every variant's run generation from a clean slate.
-       (runtime/reset-run-owner!)
+       (rf.story.runtime/reset-run-owner!)
        (teardown-all-listeners!))
      :reagent-render
      (fn []
-       (let [widths     (rails/current-widths)
-             narrow?    (rails/narrow-viewport?)
+       (let [widths     (rf.story.ui.shell.rails/current-widths)
+             narrow?    (rf.story.ui.shell.rails/narrow-viewport?)
              ;; rf2-p3i0t / rf2-g8l8x / rf2-pucku — chrome visibility
              ;; resolution. Embed-mode + full-screen both hide every
              ;; chrome pane; per-pane toggles win when neither absolute
              ;; mode is on.
-             shell      @state/shell-state-atom
-             show-tb?   (state/chrome-pane-visible? :toolbar shell)
-             show-sb?   (state/chrome-pane-visible? :sidebar shell)
-             show-rhs?  (state/chrome-pane-visible? :rhs shell)]
+             shell      @rf.story.ui.state/shell-state-atom
+             show-tb?   (rf.story.ui.state/chrome-pane-visible? :toolbar shell)
+             show-sb?   (rf.story.ui.state/chrome-pane-visible? :sidebar shell)
+             show-rhs?  (rf.story.ui.state/chrome-pane-visible? :rhs shell)]
          [:div {:style (:root styles)
                 :data-rf-story-root true
                 :data-rf-chrome-fullscreen (str (get-in shell [:chrome-visibility :full-screen?] false))
                 :data-rf-chrome-embed      (str (get-in shell [:chrome-visibility :embed?] false))}
           ;; rf2-g8l8x — `t` key + embed/full-screen suppress the strip.
           (when show-tb?
-            [:div {:style {:animation (motion/stagger-animation :toolbar)
+            [:div {:style {:animation (rf.story.theme.motion/stagger-animation :toolbar)
                            :flex-shrink "0"}}
-             [toolbar/toolbar-strip]])
+             [rf.story.ui.toolbar/toolbar-strip]])
           [:div {:style (merge (:body styles)
                                (when narrow? (:body-narrow styles)))}
            ;; rf2-g8l8x / rf2-p3i0t / rf2-pucku — sidebar visibility.
            (when show-sb?
-             [sidebar/sidebar {:style (merge {:width       (str (:left widths) "px")
+             [rf.story.ui.sidebar/sidebar {:style (merge {:width       (str (:left widths) "px")
                                               :flex-basis  (str (:left widths) "px")
                                               :flex-shrink "0"
-                                              :animation   (motion/stagger-animation :sidebar)}
+                                              :animation   (rf.story.theme.motion/stagger-animation :sidebar)}
                                              (when narrow?
                                                {:width "auto"
                                                 :flex-basis "auto"
                                                 :max-height "42vh"}))}])
            (when (and show-sb? (not narrow?))
-             [rails/splitter :left])
+             [rf.story.ui.shell.rails/splitter :left])
            [main-pane]
            (when (and show-rhs? (not narrow?))
-             [rails/splitter :right])
+             [rf.story.ui.shell.rails/splitter :right])
            ;; rf2-g8l8x / rf2-p3i0t / rf2-pucku — RHS visibility.
            (when show-rhs?
              [right-panel])]
@@ -1065,47 +1065,47 @@
           ;; the Test-Codegen REC chip + recording-overlay banner; a
           ;; floating `?` on the right occluded the REC affordance.
           [:div {:style (:help-slot styles)}
-           [help/help-button]]
-          [help/help-host]
+           [rf.story.ui.help/help-button]]
+          [rf.story.ui.help/help-host]
           ;; rf2-5fc15: Test Codegen recording overlay (top-right banner
           ;; while a recording is in flight) + save-as-variant dialog
           ;; (opens after stop). Both are fixed-position so they float
           ;; above the three-pane layout. rf2-39u9e adds the mid-recording
           ;; assertion picker — a modal that opens off the overlay's
           ;; `+ assert` button.
-          [recorder-ui/recording-overlay]
-          [recorder-ui/assertion-picker]
-          [recorder-ui/save-dialog]
+          [rf.story.ui.recorder/recording-overlay]
+          [rf.story.ui.recorder/assertion-picker]
+          [rf.story.ui.recorder/save-dialog]
           ;; rf2-h0jc0: element-inspector hover overlay. Self-elides
           ;; when inspect mode is off OR no element is currently
           ;; hovered. Lives in the chrome layer (fixed positioning)
           ;; so it floats above the three-pane layout regardless of
           ;; which panels are visible.
-          [element-inspector/overlay]
+          [rf.story.ui.element-inspector/overlay]
           ;; rf2-x9zsr — Test Codegen :script export dialog. Opens
           ;; off the recorder save-dialog's [export as :script]
           ;; button; stacks above via a higher z-index. Lives in its own
           ;; ratom so dismiss / reopen doesn't disturb the parent dialog.
-          [recorder-export-ui/export-dialog]
+          [rf.story.ui.recorder-export-dialog/export-dialog]
           ;; rf2-ba86n.16 — human share / export / copy egress dialog.
           ;; Opens off the toolbar SHARE chip. Surfaces share URL · copy
           ;; EDN · screenshot · static build, each labelled with its
           ;; reproducibility status (full / partial / view-only). Human
           ;; egress is NOT privacy-gated (the reframe — local dev has the
           ;; secrets); the contract is reproducibility honesty.
-          [share/share-export-dialog]
+          [rf.story.ui.share/share-export-dialog]
           ;; rf2-one3t: save-current-canvas-state-as-variant dialog. Lives
           ;; alongside the recorder's save dialog — both float above the
           ;; three-pane layout via fixed positioning; both surface the
           ;; generated EDN snippet for review-then-commit.
-          [save-variant-ui/save-dialog]
+          [rf.story.ui.save-variant/save-dialog]
           ;; rf2-ba86n.13: generated-failure promotion dialog. Opens from the
           ;; Test pane's 'promote run' button + the sidebar's 'Captured
           ;; artifacts' rows. Distinct from save-current-state (different
           ;; entry point, captured-artifact source); floats above the layout
           ;; via the shared review-dialog fixed positioning.
-          [promotion/promotion-dialog]
-          [command-palette/command-palette-host]]))}))
+          [rf.story.ui.promotion/promotion-dialog]
+          [rf.story.ui.command-palette.view/command-palette-host]]))}))
 
 ;; ---- error ownership while a shell is mounted (rf2-8yyd) -----------------
 ;;
@@ -1176,7 +1176,7 @@
   Per `005-SOTA-Features.md` §Production elision under `:advanced` production builds with `enabled?` false short-
   circuit here and return nil — no DOM call, no Reagent render."
   [dom-node]
-  (when (and config/enabled? dom-node)
+  (when (and rf.story.config/enabled? dom-node)
     (when-let [prev @shell-singleton]
       (try
         (rdc/unmount (:root prev))
@@ -1207,7 +1207,7 @@
      (try
        (rdc/unmount (:root handle))
        (catch :default _ nil))
-     (state/reset-shell-state!)
+     (rf.story.ui.state/reset-shell-state!)
      (teardown-all-listeners!)
      (release-error-ownership!)
      (stop-hot-reload-poll!)

--- a/tools/story/src/re_frame/story/ui/shell/rails.cljs
+++ b/tools/story/src/re_frame/story/ui/shell/rails.cljs
@@ -4,7 +4,7 @@
   (:require [reagent.core :as r]
             [re-frame.story.local-storage :refer [safe-local-storage]]
             [re-frame.story.ui.shell-styles :refer [styles]]
-            [re-frame.story.ui.state :as state]))
+            [re-frame.story.ui.state :as rf.story.ui.state]))
 
 (def ^:private storage-key
   "re-frame.story/rail-widths")
@@ -47,7 +47,7 @@
 
 (defn current-widths []
   (normalise-widths
-    (merge default-widths (:rail-widths @state/shell-state-atom))))
+    (merge default-widths (:rail-widths @rf.story.ui.state/shell-state-atom))))
 
 (defn- read-widths []
   (try
@@ -71,13 +71,13 @@
 (defn hydrate! []
   (when-let [stored (read-widths)]
     (let [widths (normalise-widths (merge default-widths stored))]
-      (state/swap-state! assoc :rail-widths widths)))
+      (rf.story.ui.state/swap-state! assoc :rail-widths widths)))
   nil)
 
 (defn set-width! [side width]
   (let [widths (normalise-widths
                  (assoc (current-widths) side width))]
-    (state/swap-state! assoc :rail-widths widths)
+    (rf.story.ui.state/swap-state! assoc :rail-widths widths)
     (persist! widths)))
 
 (defn- adjust-width! [side delta]

--- a/tools/story/src/re_frame/story/ui/shell_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/shell_styles.cljs
@@ -28,10 +28,10 @@
     depth through `theme.depth`. No literal px / hex strings live here.
 
   CLJS-only."
-  (:require [re-frame.story.theme.typography :as typography :refer [sans-stack]]
-            [re-frame.story.theme.colors :as colors]
-            [re-frame.story.theme.depth :as depth]
-            [re-frame.story.theme.space :as space]))
+  (:require [re-frame.story.theme.typography :as rf.story.theme.typography :refer [sans-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]
+            [re-frame.story.theme.depth :as rf.story.theme.depth]
+            [re-frame.story.theme.space :as rf.story.theme.space]))
 
 (def styles
   {:root      {:display "flex"
@@ -41,8 +41,8 @@
                ;; rf2-ypd6h: atmospheric backdrop — radial-gradient mesh
                ;; over the deepest slate ground, lifts the shell out of
                ;; the 'editor pane' flat-solid floor.
-               :background (:shell-root depth/backdrops)
-               :color (:text-primary colors/tokens)}
+               :background (:shell-root rf.story.theme.depth/backdrops)
+               :color (:text-primary rf.story.theme.colors/tokens)}
    :body      {:display "flex"
                :flex-direction "row"
                :flex "1"
@@ -66,22 +66,22 @@
    :right     {:flex-shrink "0"
                :display "flex"
                :flex-direction "column"
-               :border-left (str "1px solid " (:border-default colors/tokens))
-               :background (:bg-1 colors/tokens)
-               :box-shadow (:elev-1 depth/shadows)
+               :border-left (str "1px solid " (:border-default rf.story.theme.colors/tokens))
+               :background (:bg-1 rf.story.theme.colors/tokens)
+               :box-shadow (:elev-1 rf.story.theme.depth/shadows)
                :overflow "auto"}
    :right-narrow {:width "auto"
                   :max-height "42vh"
                   :border-left "none"
-                  :border-top (str "1px solid " (:border-default colors/tokens))}
+                  :border-top (str "1px solid " (:border-default rf.story.theme.colors/tokens))}
    ;; The splitter is a quiet seam, not a chrome element — it reads as
    ;; the edge between panes, lighting up amber only while dragged.
    :splitter  {:width "10px"
                :flex "0 0 10px"
                :background "transparent"
                :border "0"
-               :border-left (str "1px solid " (:border-subtle colors/tokens))
-               :border-right (str "1px solid " (:border-subtle colors/tokens))
+               :border-left (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
+               :border-right (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
                :cursor "col-resize"
                :padding "0"
                :position "relative"}
@@ -91,9 +91,9 @@
                    :width "2px"
                    :height "36px"
                    :transform "translateY(-50%)"
-                   :border-radius (:pill space/radius)
-                   :background (:border-strong colors/tokens)}
-   :splitter-active {:background (:accent-amber-soft colors/tokens)}
+                   :border-radius (:pill rf.story.theme.space/radius)
+                   :background (:border-strong rf.story.theme.colors/tokens)}
+   :splitter-active {:background (:accent-amber-soft rf.story.theme.colors/tokens)}
    ;; rf2-pxeko — `?` help-button chip lives top-LEFT of the viewport.
    ;; The top-RIGHT corner is reserved for the Test-Codegen REC chip
    ;; (`recorder/rec-chip` in the toolbar) plus the recording-overlay
@@ -103,8 +103,8 @@
    ;; conflict with the sidebar (which is part of the flex layout, not
    ;; fixed-positioned) or any other chrome affordance.
    :help-slot {:position "fixed"
-               :top      (space/pad 4)
-               :left     (space/pad 5)
+               :top      (rf.story.theme.space/pad 4)
+               :left     (rf.story.theme.space/pad 5)
                :z-index  1500}
    ;; ── RHS section bands (§12.3 Inspector + §12.9 the Xray seam) ──
    ;;
@@ -116,31 +116,31 @@
    ;; N labelled sections. The visual-foundation pass keeps that shape
    ;; and adds the Story↔Xray temperature seam.
    :rhs-section
-   {:padding        (str (space/pad 5) " " (space/pad 5) " 0 " (space/pad 5))
-    :background     (:bg-1 colors/tokens)}
+   {:padding        (str (rf.story.theme.space/pad 5) " " (rf.story.theme.space/pad 5) " 0 " (rf.story.theme.space/pad 5))
+    :background     (:bg-1 rf.story.theme.colors/tokens)}
    :rhs-section-h
    {:display        "flex"
     :align-items    "center"
-    :gap            (space/gap 3)
+    :gap            (rf.story.theme.space/gap 3)
     :font-family    sans-stack
-    :font-size      (:nano typography/type-scale)
+    :font-size      (:nano rf.story.theme.typography/type-scale)
     :font-weight    "600"
     :letter-spacing "0.08em"
     :text-transform "uppercase"
-    :color          (:text-tertiary colors/tokens)
-    :margin-bottom  (space/pad 4)
-    :padding-bottom (space/pad 3)
+    :color          (:text-tertiary rf.story.theme.colors/tokens)
+    :margin-bottom  (rf.story.theme.space/pad 4)
+    :padding-bottom (rf.story.theme.space/pad 3)
     ;; Story-owned sections wear a WARM amber-tinted hairline — the
     ;; same trick Xray uses for its own spine boundaries, but in
     ;; Story's identity colour so the band reads 'workshop'.
-    :border-bottom  (str "1px solid " (:border-subtle colors/tokens))
-    :box-shadow     (str "0 1px 0 " (:accent-amber-soft colors/tokens))}
+    :border-bottom  (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
+    :box-shadow     (str "0 1px 0 " (:accent-amber-soft rf.story.theme.colors/tokens))}
    ;; A muted sublabel that sits after the section title (e.g. 'args +
    ;; modes', 'provenance + lowering') — the second word in the header
    ;; row that tells the user what the band is for without a tooltip.
    :rhs-section-sub
    {:font-weight    "400"
-    :color          (:text-tertiary colors/tokens)
+    :color          (:text-tertiary rf.story.theme.colors/tokens)
     :letter-spacing "0.04em"}
    ;; ── the Xray seam header (§12.9) ──
    ;; The Xray band's header is the ONE place the RHS goes cool. The
@@ -150,13 +150,13 @@
    ;; ACCENT points at the embedded surface (§12.9 — 'Story owns outer
    ;; inspector chrome … Xray owns diagnostic panel interiors').
    :rhs-section-h-xray
-   {:color          (:seam-xray colors/tokens)
-    :box-shadow     (str "0 1px 0 " (:seam-xray-soft colors/tokens))}
+   {:color          (:seam-xray rf.story.theme.colors/tokens)
+    :box-shadow     (str "0 1px 0 " (:seam-xray-soft rf.story.theme.colors/tokens))}
    :rhs-section-sub-xray
-   {:color          (:seam-xray colors/tokens)
+   {:color          (:seam-xray rf.story.theme.colors/tokens)
     :opacity        "0.7"}
    :rhs-section-body
-   {:padding-bottom (space/pad 5)}
+   {:padding-bottom (rf.story.theme.space/pad 5)}
    ;; ── calm empty state (§12.5) — 'no variant or workspace selected' ──
    ;; Not an explanatory poster: a quiet centred prompt that names what
    ;; is missing and the command available now (pick from the sidebar).
@@ -168,23 +168,23 @@
     :flex-direction  "column"
     :align-items     "center"
     :justify-content "center"
-    :gap             (space/gap 3)
-    :padding         (space/pad 8)
+    :gap             (rf.story.theme.space/gap 3)
+    :padding         (rf.story.theme.space/pad 8)
     :text-align      "center"
-    :color           (:text-tertiary colors/tokens)}
+    :color           (:text-tertiary rf.story.theme.colors/tokens)}
    :empty-canvas-glyph
-   {:font-size       (:hero typography/type-scale)
-    :color           (:accent-amber colors/tokens)
+   {:font-size       (:hero rf.story.theme.typography/type-scale)
+    :color           (:accent-amber rf.story.theme.colors/tokens)
     :opacity         "0.5"}
    :empty-canvas-title
    {:font-family     sans-stack
-    :font-size       (:display typography/type-scale)
-    :font-weight     (str (:semibold typography/weights))
-    :color           (:text-secondary colors/tokens)
-    :letter-spacing  (:display typography/letter-spacing)}
+    :font-size       (:display rf.story.theme.typography/type-scale)
+    :font-weight     (str (:semibold rf.story.theme.typography/weights))
+    :color           (:text-secondary rf.story.theme.colors/tokens)
+    :letter-spacing  (:display rf.story.theme.typography/letter-spacing)}
    :empty-canvas-hint
    {:font-family     sans-stack
-    :font-size       (:caption typography/type-scale)
-    :color           (:text-tertiary colors/tokens)
+    :font-size       (:caption rf.story.theme.typography/type-scale)
+    :color           (:text-tertiary rf.story.theme.colors/tokens)
     :max-width       "32ch"
-    :line-height     (:line-height-body typography/type-scale)}})
+    :line-height     (:line-height-body rf.story.theme.typography/type-scale)}})

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -55,19 +55,19 @@
   inert (the filter row owns interaction) — purely a scan affordance."
   (:require [clojure.string                   :as str]
             [reagent.core                     :as r]
-            [re-frame.story.budgets           :as budgets]
-            [re-frame.story.runtime           :as runtime]
-            [re-frame.story.async             :as async]
-            [re-frame.story.registrar         :as registrar]
-            [re-frame.story.theme.colors      :as colors]
-            [re-frame.story.theme.glyphs      :as glyphs]
-            [re-frame.story.theme.status      :as status]
-            [re-frame.story.ui.promotion      :as promotion]
-            [re-frame.story.ui.sidebar-search :as search]
-            [re-frame.story.ui.sidebar-signals :as signals]
+            [re-frame.story.budgets           :as rf.story.budgets]
+            [re-frame.story.runtime           :as rf.story.runtime]
+            [re-frame.story.async             :as rf.story.async]
+            [re-frame.story.registrar         :as rf.story.registrar]
+            [re-frame.story.theme.colors      :as rf.story.theme.colors]
+            [re-frame.story.theme.glyphs      :as rf.story.theme.glyphs]
+            [re-frame.story.theme.status      :as rf.story.theme.status]
+            [re-frame.story.ui.promotion      :as rf.story.ui.promotion]
+            [re-frame.story.ui.sidebar-search :as rf.story.ui.sidebar-search]
+            [re-frame.story.ui.sidebar-signals :as rf.story.ui.sidebar-signals]
             [re-frame.story.ui.sidebar-styles :refer [styles]]
-            [re-frame.story.ui.state          :as state]
-            [re-frame.story.ui.watch          :as watch]))
+            [re-frame.story.ui.state          :as rf.story.ui.state]
+            [re-frame.story.ui.watch          :as rf.story.ui.watch]))
 
 ;; Styles live in `re-frame.story.ui.sidebar-styles` (pure-data leaf,
 ;; no Reagent dep). Required as `styles` above so the in-file call
@@ -109,11 +109,11 @@
   The dot's run-status domain is `state.tests/test-run-statuses` —
   `record-test-run` normalizes a run-level `:error` to `:fail` at write
   time, so `:cannot-run` is the canonical third terminal status here.
-  Unknown / nil statuses degrade through `status/descriptor`'s
+  Unknown / nil statuses degrade through `rf.story.theme.status/descriptor`'s
   `:pending` fallback — pending is reserved for the genuinely unknown
   slot, never a mask over a real terminal status."
   [status]
-  (let [{:keys [fg border shape]} (status/descriptor status)]
+  (let [{:keys [fg border shape]} (rf.story.theme.status/descriptor status)]
     (case shape
       :solid  {:background fg}
       :half   {:background fg :opacity "0.7"}
@@ -127,9 +127,9 @@
   descriptor label, so the dot voices the SAME vocabulary the chips
   render (`:cannot-run` → \"tests: Can't run\", accessibly distinct
   from `:pending` → \"tests: Pending\"). Unknown / nil statuses degrade
-  through `status/descriptor`'s `:pending` fallback."
+  through `rf.story.theme.status/descriptor`'s `:pending` fallback."
   [status]
-  (str "tests: " (status/label status)))
+  (str "tests: " (rf.story.theme.status/label status)))
 
 ;; ---- pure: per-tag badge styling (rf2-nwiwr) ----------------------------
 
@@ -171,7 +171,7 @@
   Single source of truth: `re-frame.story.budgets/sidebar-variant-cap`
   (N1). This alias keeps the in-file call sites (`bound-variants … cap`)
   textually stable while the number lives in one budget table."
-  budgets/sidebar-variant-cap)
+  rf.story.budgets/sidebar-variant-cap)
 
 (defn bound-variants
   "Pure data → data: bound a story's variant seq to at most `cap` entries
@@ -194,7 +194,7 @@
 ;; per artifact (spec/021 §3 acceptance + spec/018 §10; respects ba86n.4's
 ;; sidebar bounding). The section is a single collapsible header carrying a
 ;; count; expanding it lists the captured artifacts, each row OPENING the
-;; promotion dialog (`promotion/open!`) without becoming a Story variant.
+;; promotion dialog (`rf.story.ui.promotion/open!`) without becoming a Story variant.
 ;; The store lives in `re-frame.story.ui.promotion/captured-atom`; promoting
 ;; an artifact is non-destructive (the row stays until the user forgets it).
 
@@ -206,7 +206,7 @@
 
   Single source of truth: `re-frame.story.budgets/captured-artifact-cap`
   (N2)."
-  budgets/captured-artifact-cap)
+  rf.story.budgets/captured-artifact-cap)
 
 ;; ---- components ----------------------------------------------------------
 
@@ -227,8 +227,8 @@
           :data-test   "story-sidebar-tag-chip"
           :data-tag    (str tag)
           :data-active (str (boolean active?))
-          :on-click    (fn [_] (state/swap-state!
-                                 state/toggle-tag-filter tag))}
+          :on-click    (fn [_] (rf.story.ui.state/swap-state!
+                                 rf.story.ui.state/toggle-tag-filter tag))}
    (str tag)])
 
 (defn- axis-row
@@ -253,7 +253,7 @@
   with un-axis-grouped tags trailing in an `OTHER` row).
 
   Active chips highlight; the AND-across / OR-within rule lives in
-  `state/variant-tag-match?`.
+  `rf.story.ui.state/variant-tag-match?`.
 
   `tag->axis` is computed once at the sidebar top and threaded in;
   per rf2-0z8e2 we previously walked the tag registrar twice per
@@ -263,8 +263,8 @@
     (if (empty? all-tags)
       [:div {:style (:tag-row styles)}
        [:span {:style (:empty styles)} "no tags"]]
-      (let [by-axis (state/group-tags-by-axis all-tags tag->axis)
-            axes    (state/ordered-axes by-axis)]
+      (let [by-axis (rf.story.ui.state/group-tags-by-axis all-tags tag->axis)
+            axes    (rf.story.ui.state/ordered-axes by-axis)]
         [:div {:style       (:tag-row styles)
                :data-test   "story-sidebar-tag-filter"}
          (for [axis axes]
@@ -372,7 +372,7 @@
                     (if (and (= :frame-binding axis) (= :attached value))
                       (merge base (:signal-frame-attached styles))
                       base)))
-        glyph   (when status? (status/glyph value))]
+        glyph   (when status? (rf.story.theme.status/glyph value))]
     ^{:key (str (name axis) "-" (name value))}
     [:span {:style       (merge (:signal-chip styles) tint)
             :data-test   "story-sidebar-signal-chip"
@@ -397,7 +397,7 @@
   test corpus can render and inspect the hiccup directly."
   [body status]
   (let [{:keys [status fidelity world-inputs runner-requirement frame-binding]}
-        (signals/variant-signals body status)]
+        (rf.story.ui.sidebar-signals/variant-signals body status)]
     ;; Each `signal-chip` is invoked as a FUNCTION (not a `[component …]`
     ;; vector) so the returned hiccup is fully expanded — the same pattern
     ;; `tag-badges` uses. This keeps the strip a single pure hiccup tree
@@ -423,7 +423,7 @@
   suitable for splatting inside the row `<span>`. No-search shortcut
   returns the raw string unwrapped so the no-search path stays quiet."
   [label query]
-  (let [segments (search/highlight-segments label query)]
+  (let [segments (rf.story.ui.sidebar-search/highlight-segments label query)]
     (if (and (= 1 (count segments)) (not (:match? (first segments))))
       [(:text (first segments))]
       (vec
@@ -508,10 +508,10 @@
                    ;; (`shell.cljs` `main-pane`) yields to the variant
                    ;; branch. Mirror of the workspace-row click below,
                    ;; which clears `:selected-variant`.
-                   (state/swap-state!
+                   (rf.story.ui.state/swap-state!
                      (fn [s] (-> s
-                                 (state/select-variant variant-id)
-                                 (state/select-workspace nil)))))]
+                                 (rf.story.ui.state/select-variant variant-id)
+                                 (rf.story.ui.state/select-workspace nil)))))]
   [:<>
   [:div {:style       (merge (:variant-row styles)
                              (when selected? (:variant-row-active styles)))
@@ -536,7 +536,7 @@
    (if testable?
      [status-dot status]
      [:span {:style (:variant-glyph styles)}
-      [glyphs/variant-glyph 10]])
+      [rf.story.theme.glyphs/variant-glyph 10]])
    ;; rf2-yngai — wrap label so matched substrings render with the
    ;; amber-tint highlight when a search query is in flight.
    (into [:span] (highlighted-label (str "/" (name variant-id)) query))
@@ -549,7 +549,7 @@
 (defn- story-block
   "Render one story header + its variants. `entry` shape is
   `{:story-id ... :variants [[variant-id body] ...]}` (the shape
-  produced by `state/group-variants-by-story`).
+  produced by `rf.story.ui.state/group-variants-by-story`).
 
   rf2-p0wur: story rows lead with an amber diamond glyph + carry an
   inter-story spacer.
@@ -571,7 +571,7 @@
         selected?   (and registered? (= story-id selected-story))
         activate    (fn []
                       (when registered?
-                        (state/swap-state! state/select-story story-id)))
+                        (rf.story.ui.state/swap-state! rf.story.ui.state/select-story story-id)))
         expanded?   (or searching? (contains? @expanded-stories story-id))
         {:keys [shown hidden]} (bound-variants variants default-variant-cap expanded?)]
     [:div {:style (:story-block styles)}
@@ -588,7 +588,7 @@
                      :on-key-down  (on-row-key-down activate)
                      :on-click     (fn [_] (activate))}))
       [:span {:style (:story-glyph styles)}
-       [glyphs/story-glyph 13]]
+       [rf.story.theme.glyphs/story-glyph 13]]
       (into [:span] (highlighted-label (str (or story-id "(no story)")) query))]
      (for [[vid body] shown]
        (let [testable? (contains? testable-set vid)
@@ -635,10 +635,10 @@
 (defn- workspace-row
   [workspace-id selected? body]
   (let [activate (fn []
-                   (state/swap-state!
+                   (rf.story.ui.state/swap-state!
                      (fn [s] (-> s
-                                 (state/select-workspace workspace-id)
-                                 (state/select-variant nil)))))
+                                 (rf.story.ui.state/select-workspace workspace-id)
+                                 (rf.story.ui.state/select-variant nil)))))
         grouping (workspace-grid-grouping body)]
   [:<>
    ;; rf2-ba86n.4 — variants-grid grouping affordance (spec/018 §7.1). A
@@ -664,7 +664,7 @@
          :on-key-down  (on-row-key-down activate)
          :on-click     (fn [_] (activate))}
    [:span {:style (:workspace-glyph styles)}
-    [glyphs/workspace-glyph 12]]
+    [rf.story.theme.glyphs/workspace-glyph 12]]
    [:span (str workspace-id)]]]))
 
 ;; ---- chrome-level test widget (rf2-q0irb) -------------------------------
@@ -697,24 +697,24 @@
   so concurrent runs don't race against a swap-state! between the
   read and the dispatch."
   [vid]
-  (state/swap-state! state/mark-test-running vid)
-  (let [opts (run-opts-for-variant (state/get-state) vid)]
-    (-> (runtime/run-variant vid opts)
-        (async/then  (fn [result]
-                       ;; `state/aggregate-summary` is the canonical fold
+  (rf.story.ui.state/swap-state! rf.story.ui.state/mark-test-running vid)
+  (let [opts (run-opts-for-variant (rf.story.ui.state/get-state) vid)]
+    (-> (rf.story.runtime/run-variant vid opts)
+        (rf.story.async/then  (fn [result]
+                       ;; `rf.story.ui.state/aggregate-summary` is the canonical fold
                        ;; (rf2-khmon); it lives in shell-state so both
                        ;; this widget AND the `:test` mode pane share one
                        ;; impl without a require cycle.
-                       (let [summary (-> (state/aggregate-summary
+                       (let [summary (-> (rf.story.ui.state/aggregate-summary
                                            (:assertions result))
                                          (assoc :elapsed-ms (:elapsed-ms result)
                                                 :ran-at-ms  nil))]
-                         (state/swap-state! state/record-test-run vid summary))
+                         (rf.story.ui.state/swap-state! rf.story.ui.state/record-test-run vid summary))
                        nil))
-        (async/catch* (fn [_]
+        (rf.story.async/catch* (fn [_]
                         ;; A rejection drops the running stamp so the
                         ;; dot doesn't get stuck yellow.
-                        (state/swap-state! state/clear-test-run vid)
+                        (rf.story.ui.state/swap-state! rf.story.ui.state/clear-test-run vid)
                         nil)))))
 
 (defn- run-all-tests!
@@ -748,7 +748,7 @@
 (defn set-watch-mode!
   "Set the chrome-level watch-mode flag, seeding the drift baseline when
   turning ON (rf2-asp2op). On toggle-ON we compute the CURRENT testable
-  snapshot hashes (`watch/compute-testable-content-hashes`) and record
+  snapshot hashes (`rf.story.ui.watch/compute-testable-content-hashes`) and record
   them into `[:tests :content-hashes]` BEFORE flipping `[:tests
   :watch-mode?]` — so the first `detect-watch-drift!` tick diffs a real
   baseline. Without the seed the slot is `{}` on enable (its default, or
@@ -757,16 +757,16 @@
   spuriously re-runs the instant watch is switched on.
 
   The compute lives in `re-frame.story.ui.watch` (registrar + identity
-  access) — it cannot fold into the pure `state/set-test-watch-mode` state
+  access) — it cannot fold into the pure `rf.story.ui.state/set-test-watch-mode` state
   fn. Turning OFF just flips the flag; that same state fn clears the
   recorded hashes so the next toggle-ON re-seeds fresh."
   [on?]
   (when on?
     ;; Seed BEFORE the flag flips so no detector tick can observe
     ;; watch-on against an empty baseline.
-    (state/swap-state! state/record-test-content-hashes
-                       (watch/compute-testable-content-hashes)))
-  (state/swap-state! state/set-test-watch-mode on?))
+    (rf.story.ui.state/swap-state! rf.story.ui.state/record-test-content-hashes
+                       (rf.story.ui.watch/compute-testable-content-hashes)))
+  (rf.story.ui.state/swap-state! rf.story.ui.state/set-test-watch-mode on?))
 
 (defn test-widget
   "Chrome-level test widget. Aggregates `run-variant` outcomes across
@@ -790,13 +790,13 @@
   second registry walk; the no-arg form keeps the canonical surface
   for tests and standalone consumers."
   ([shell registry]
-   (test-widget shell registry (state/testable-variant-ids
+   (test-widget shell registry (rf.story.ui.state/testable-variant-ids
                                  (:variants registry))))
   ([shell _registry variant-ids]
-   (let [summary     (state/test-summary shell variant-ids)
+   (let [summary     (rf.story.ui.state/test-summary shell variant-ids)
          {:keys [total passed failed running pending all-green?]} summary
          any-run?    (pos? running)
-         watch-on?   (state/test-watch-mode? shell)
+         watch-on?   (rf.story.ui.state/test-watch-mode? shell)
          headline    (cond
                        (zero? total)  "Tests"
                        all-green?     (str "Tests · ✓ " passed)
@@ -884,14 +884,14 @@
 (defn captured-artifacts-section
   "Render the bounded, collapsed 'Captured artifacts' affordance
   (rf2-ba86n.13, spec/021 §3). Anonymous run artifacts (generated /
-  replayed failures captured into `promotion/captured-atom`) surface here
+  replayed failures captured into `rf.story.ui.promotion/captured-atom`) surface here
   as ONE collapsible section — NOT a permanent nav row per artifact — so a
   matrix of captured failures never floods the sidebar (spec/018 §10).
 
   Collapsed by default: the header shows the count and toggles open. When
   open, the captured artifacts list (bounded to `default-artifact-cap` with
   a '+N more' expander), each row OPENING the promotion dialog
-  (`promotion/open!`) — the artifact is inspected + promoted there, it never
+  (`rf.story.ui.promotion/open!`) — the artifact is inspected + promoted there, it never
   becomes a Story variant by appearing here. A '×' forgets a capture (the
   store entry only; any already-promoted variant is untouched —
   non-destructive).
@@ -901,7 +901,7 @@
   `open?-ratom` / `more?-ratom` are ephemeral local toggles owned by the
   parent `sidebar` component (not persisted)."
   [open?-ratom more?-ratom]
-  (let [entries (promotion/captured-entries)
+  (let [entries (rf.story.ui.promotion/captured-entries)
         n       (count entries)]
     (when (pos? n)
       (let [open? @open?-ratom
@@ -919,7 +919,7 @@
                 :on-key-down  (on-row-key-down (fn [] (swap! open?-ratom not)))
                 :on-click     (fn [_] (swap! open?-ratom not))}
           [:span {:aria-hidden "true"
-                  :style {:margin-right "6px" :color (:text-tertiary colors/tokens)}}
+                  :style {:margin-right "6px" :color (:text-tertiary rf.story.theme.colors/tokens)}}
            (if open? "▾" "▸")]
           [:span (str "Captured artifacts · " n)]]
          (when open?
@@ -932,22 +932,22 @@
                      :role         "button"
                      :tab-index    "0"
                      :aria-label   (str "Promote captured artifact " (name id))
-                     :on-key-down  (on-row-key-down (fn [] (promotion/open! id)))
-                     :on-click     (fn [_] (promotion/open! id))}
+                     :on-key-down  (on-row-key-down (fn [] (rf.story.ui.promotion/open! id)))
+                     :on-click     (fn [_] (rf.story.ui.promotion/open! id))}
                [:span {:style {:flex "1" :overflow "hidden" :text-overflow "ellipsis"
                                :white-space "nowrap"}}
                 label]
-               [:span {:style       {:margin-left "6px" :color (:text-tertiary colors/tokens)
+               [:span {:style       {:margin-left "6px" :color (:text-tertiary rf.story.theme.colors/tokens)
                                      :cursor "pointer" :flex-shrink "0"}
                        :data-test   "story-sidebar-captured-forget"
                        :role         "button"
                        :tab-index    "0"
                        :aria-label   (str "Forget captured artifact " (name id))
                        :title        "Forget this capture (does not unregister a promoted variant)"
-                       :on-key-down  (on-row-key-down (fn [] (promotion/forget! id)))
+                       :on-key-down  (on-row-key-down (fn [] (rf.story.ui.promotion/forget! id)))
                        :on-click     (fn [^js e]
                                        (.stopPropagation e)
-                                       (promotion/forget! id))}
+                                       (rf.story.ui.promotion/forget! id))}
                 "×"]])
             (when (pos? hidden)
               [:div {:style       (:variant-more styles)
@@ -980,23 +980,23 @@
          captured-open?   (r/atom false)
          captured-more?   (r/atom false)]
      (fn [opts]
-       (let [shell           @state/shell-state-atom
-             registry        (state/registry-snapshot)
+       (let [shell           @rf.story.ui.state/shell-state-atom
+             registry        (rf.story.ui.state/registry-snapshot)
              tag-filter      (:tag-filter shell)
              sel-variant     (:selected-variant shell)
              sel-ws          (:selected-workspace shell)
              sel-story       (:selected-story shell)
-             tag->axis       (registrar/tag->axis-index)
-             visible         (state/filter-variants (:variants registry)
+             tag->axis       (rf.story.registrar/tag->axis-index)
+             visible         (rf.story.ui.state/filter-variants (:variants registry)
                                                     tag-filter
                                                     tag->axis)
-             grouped-all     (state/group-variants-by-story visible)
+             grouped-all     (rf.story.ui.state/group-variants-by-story visible)
              query           @query-ratom
-             grouped         (search/filter-grouped-tree grouped-all query)
-             workspaces      (search/filter-workspaces
+             grouped         (rf.story.ui.sidebar-search/filter-grouped-tree grouped-all query)
+             workspaces      (rf.story.ui.sidebar-search/filter-workspaces
                                (:workspaces registry) query)
              test-runs       (get-in shell [:tests :runs])
-             testable-vec    (state/testable-variant-ids (:variants registry))
+             testable-vec    (rf.story.ui.state/testable-variant-ids (:variants registry))
              testable-set    (set testable-vec)
              searching?      (seq (str/trim query))]
          [:nav {:style       (merge (:wrap styles) (:style opts))
@@ -1018,8 +1018,8 @@
                   :aria-level  "2"}
             [:span {:aria-hidden "true"
                     :style {:display "inline-flex" :align-items "center"
-                            :color (:accent-amber colors/tokens)}}
-             [glyphs/story-glyph 12]]
+                            :color (:accent-amber rf.story.theme.colors/tokens)}}
+             [rf.story.theme.glyphs/story-glyph 12]]
             [:span "Stories"]]
            [search-input query-ratom]
            [tag-filter-row (:variants registry) tag-filter tag->axis]
@@ -1051,10 +1051,10 @@
                      :aria-level  "2"}
                [:span {:aria-hidden "true"
                        :style {:display "inline-flex" :align-items "center"
-                               :color (:info colors/tokens)
+                               :color (:info rf.story.theme.colors/tokens)
                                :margin-right "6px"
                                :vertical-align "-2px"}}
-                [glyphs/workspace-glyph 11]]
+                [rf.story.theme.glyphs/workspace-glyph 11]]
                "Workspaces"]
               (for [[wid body] (sort-by key workspaces)]
                 ^{:key wid}

--- a/tools/story/src/re_frame/story/ui/sidebar_signals.cljc
+++ b/tools/story/src/re_frame/story/ui/sidebar_signals.cljc
@@ -16,7 +16,7 @@
   | Axis                | Members (spec/018 §7.1 / §12.6)                       | Source |
   |---------------------|-------------------------------------------------------|--------|
   | `:status`           | pass / fail / cannot-run / error / pending / running / blocked / dirty / redacted | the run record |
-  | `:fidelity`         | real-setup / db-seed / sub-overrides                  | `plan/compute-fidelity` over world inputs |
+  | `:fidelity`         | real-setup / db-seed / sub-overrides                  | `rf.story.plan/compute-fidelity` over world inputs |
   | `:world-inputs`     | args / route / network / fx-overrides                 | presence of the body's world slots |
   | `:runner-requirement` | headless / hiccup / cljs-reactive / dom / browser   | `requirements` capability tokens → cheapest runner |
   | `:frame-binding`    | fresh / attached / mcp-bound                          | the body's `:frame-binding` (+ MCP affordance) |
@@ -40,9 +40,9 @@
 
   No signal is fabricated: a chip appears only when the variant body (or
   the run record) carries the data behind it."
-  (:require [re-frame.story.plan         :as plan]
-            [re-frame.story.requirements :as requirements]
-            [re-frame.story.theme.status :as status]))
+  (:require [re-frame.story.plan         :as rf.story.plan]
+            [re-frame.story.requirements :as rf.story.requirements]
+            [re-frame.story.theme.status :as rf.story.theme.status]))
 
 ;; ===========================================================================
 ;; AXIS 1 — STATUS
@@ -66,7 +66,7 @@
   expectation (`:fail`); `:blocked` / `:dirty` / `:redacted` are the
   additional signal states the spec names. Derived (not re-encoded) so the
   sidebar can never drift from the tool-wide order (rf2-8fr3yd)."
-  status/order)
+  rf.story.theme.status/order)
 
 (def status-labels
   "Pure data → data: the compact chip label per status keyword. Derived
@@ -75,7 +75,7 @@
   cannot-run / blocked / dirty / redacted MUST be distinguishable in text,
   not only colour). Single-sourced (not re-encoded) so the sidebar chip
   label can never drift from the canonical status label (rf2-8fr3yd)."
-  (into {} (map (fn [[k d]] [k (:label d)])) status/descriptors))
+  (into {} (map (fn [[k d]] [k (:label d)])) rf.story.theme.status/descriptors))
 
 (defn status-signal
   "Pure data → data: the single status chip for a variant given its run
@@ -95,7 +95,7 @@
 ;; ===========================================================================
 ;;
 ;; The evidence rung(s) a variant's render rests on, computed from its world
-;; inputs (NOT typed by the author). Reuses `plan/compute-fidelity` — the
+;; inputs (NOT typed by the author). Reuses `rf.story.plan/compute-fidelity` — the
 ;; SAME projection the plan compiler stamps `[:world :fidelity]` with — so
 ;; the sidebar chip and the plan can never disagree about what a variant
 ;; leans on. `:real-setup` > `:db-seed` > `:sub-overrides` (spec/017
@@ -118,12 +118,12 @@
   "Pure data → data: the fidelity chips for a variant `body`. Derives the
   world inputs the fidelity ladder reads — setup/script (real-setup),
   `:db-seed`, `:sub-overrides` — and runs them through the canonical
-  `plan/compute-fidelity` so the sidebar and the plan agree. Returns a
+  `rf.story.plan/compute-fidelity` so the sidebar and the plan agree. Returns a
   vector of `{:axis :fidelity :value <kw> :label <string>}` in
   `fidelity-order`; empty for a bare render-as-mounted variant (no setup,
   seed, or overrides) — which is legitimate, not a defect."
   [body]
-  (let [fidelity (plan/compute-fidelity
+  (let [fidelity (rf.story.plan/compute-fidelity
                    {:setup         (:setup body)
                     :script        (or (:script body) (:plays body))
                     :db-seed       (:db-seed body)
@@ -196,7 +196,7 @@
 
 (def runner-requirement-order
   "Pure data → data: cost-ordered render order for the runner-requirement
-  chip (cheapest first), mirroring `requirements/concrete-runners`."
+  chip (cheapest first), mirroring `rf.story.requirements/concrete-runners`."
   [:headless :hiccup :cljs-reactive :dom :browser])
 
 (def runner-requirement-labels
@@ -213,7 +213,7 @@
   "Pure data → data: the variant body's declared script steps, flattened
   across the `:script` (bare vector or `{:script …}` map) / `:plays`
   slots. Each step is a tagged vector (or a bare event vector);
-  `requirements/step-tokens` reads the head tag, so no coercion is needed
+  `rf.story.requirements/step-tokens` reads the head tag, so no coercion is needed
   for the requirement signal — a bare event vector has no recognised step
   tag and contributes the headless-floor empty token set, which is
   correct."
@@ -236,16 +236,16 @@
   "Pure data → data: the cheapest concrete runner kind that can prove the
   variant `body`'s declared script steps + setup + terminal assertions, via
   the canonical `requirements` registry. Unions the per-step / per-assertion
-  capability tokens (`requirements/required-tokens`) and picks the
-  `requirements/cheapest-runner`. Returns a runner-kind keyword (one of
+  capability tokens (`rf.story.requirements/required-tokens`) and picks the
+  `rf.story.requirements/cheapest-runner`. Returns a runner-kind keyword (one of
   `runner-requirement-order`), defaulting to `:headless` when no concrete
   runner qualifies (the headless floor — a navigation signal never refuses)."
   [body]
   (let [setup      (or (:setup body) [])
         script     (body-script-steps body)
         assertions (or (:assertions body) [])
-        tokens     (requirements/required-tokens setup script assertions)]
-    (or (requirements/cheapest-runner tokens) :headless)))
+        tokens     (rf.story.requirements/required-tokens setup script assertions)]
+    (or (rf.story.requirements/cheapest-runner tokens) :headless)))
 
 (defn runner-requirement-signal
   "Pure data → data: the single runner-requirement chip for a variant
@@ -286,17 +286,17 @@
 (defn frame-binding-signal
   "Pure data → data: the frame-binding chip for a variant `body`. Reads the
   body's `:frame-binding` (validated against
-  `requirements/frame-bindings` — `#{:fresh :attached}`), defaulting to
-  `requirements/default-frame-binding` (`:fresh`). When the body flags
+  `rf.story.requirements/frame-bindings` — `#{:fresh :attached}`), defaulting to
+  `rf.story.requirements/default-frame-binding` (`:fresh`). When the body flags
   `:mcp-bound` truthy, the chip surfaces the MCP-bound affordance (still an
   ATTACHED binding underneath — MCP is a binding, not a tier). Returns
   `{:axis :frame-binding :value <kw> :label <string>}`. Always present —
   every variant has a frame binding."
   [body]
   (let [raw   (:frame-binding body)
-        bound (if (contains? requirements/frame-bindings raw)
+        bound (if (contains? rf.story.requirements/frame-bindings raw)
                 raw
-                requirements/default-frame-binding)
+                rf.story.requirements/default-frame-binding)
         value (if (:mcp-bound body) :mcp-bound bound)]
     {:axis  :frame-binding
      :value value

--- a/tools/story/src/re_frame/story/ui/sidebar_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar_styles.cljs
@@ -4,18 +4,18 @@
   sidebar ns trends toward the 250-LoC leaf-size ceiling (rf2-zkca8).
 
   CLJS-only."
-  (:require [re-frame.story.theme.typography :as typography :refer [mono-stack sans-stack]]
-            [re-frame.story.theme.colors :as colors]
-            [re-frame.story.theme.motion :as motion]
-            [re-frame.story.theme.status :as status]))
+  (:require [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack sans-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]
+            [re-frame.story.theme.motion :as rf.story.theme.motion]
+            [re-frame.story.theme.status :as rf.story.theme.status]))
 
 (def styles
   {:wrap         {:width "260px"
-                  :background (:bg-1 colors/tokens)
-                  :color (:text-primary colors/tokens)
+                  :background (:bg-1 rf.story.theme.colors/tokens)
+                  :color (:text-primary rf.story.theme.colors/tokens)
                   :font-family sans-stack
-                  :font-size (:body-tight typography/type-scale)
-                  :border-right (str "1px solid " (:border-default colors/tokens))
+                  :font-size (:body-tight rf.story.theme.typography/type-scale)
+                  :border-right (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                   :overflow "auto"
                   :padding "8px 0 0 0"
                   :display "flex"
@@ -32,26 +32,26 @@
    ;; chrome's section-label vocabulary.
    :header       {:padding "10px 12px 8px 12px"
                   :font-family sans-stack
-                  :font-weight (str (:semibold typography/weights))
-                  :font-size (:nano typography/type-scale)
+                  :font-weight (str (:semibold rf.story.theme.typography/weights))
+                  :font-size (:nano rf.story.theme.typography/type-scale)
                   :text-transform "uppercase"
-                  :letter-spacing (:label-wide typography/letter-spacing)
-                  :color (:accent-amber colors/tokens)
-                  :border-bottom (str "1px solid " (:border-subtle colors/tokens))
-                  :box-shadow (str "0 1px 0 " (:accent-amber-soft colors/tokens))
+                  :letter-spacing (:label-wide rf.story.theme.typography/letter-spacing)
+                  :color (:accent-amber rf.story.theme.colors/tokens)
+                  :border-bottom (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
+                  :box-shadow (str "0 1px 0 " (:accent-amber-soft rf.story.theme.colors/tokens))
                   :margin-bottom "6px"
                   :display "flex"
                   :align-items "center"
                   :gap "8px"}
    :section      {:padding "16px 0 6px 12px"
                   :margin-top "4px"
-                  :border-top (str "1px solid " (:border-subtle colors/tokens))
+                  :border-top (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
                   :font-family sans-stack
-                  :font-weight (str (:semibold typography/weights))
-                  :color (:text-tertiary colors/tokens)
+                  :font-weight (str (:semibold rf.story.theme.typography/weights))
+                  :color (:text-tertiary rf.story.theme.colors/tokens)
                   :text-transform "uppercase"
-                  :font-size (:nano typography/type-scale)
-                  :letter-spacing (:label-wide typography/letter-spacing)
+                  :font-size (:nano rf.story.theme.typography/type-scale)
+                  :letter-spacing (:label-wide rf.story.theme.typography/letter-spacing)
                   :display "flex"
                   :align-items "center"}
    :tag-row      {:display "flex"
@@ -59,13 +59,13 @@
                   :gap "6px"
                   :padding "8px 12px 10px 12px"
                   :margin-bottom "6px"
-                  :border-bottom (str "1px solid " (:border-subtle colors/tokens))}
+                  :border-bottom (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))}
    ;; rf2-7ncf9 — faceted tag-filter: one labelled chip row per axis.
    :axis-row     {:display "flex"
                   :flex-direction "column"
                   :gap "3px"}
-   :axis-label   {:font-size (:nano typography/type-scale)
-                  :color (:text-tertiary colors/tokens)
+   :axis-label   {:font-size (:nano rf.story.theme.typography/type-scale)
+                  :color (:text-tertiary rf.story.theme.colors/tokens)
                   :letter-spacing "0.5px"
                   :text-transform "uppercase"
                   :font-weight "bold"}
@@ -73,15 +73,15 @@
                   :flex-wrap "wrap"
                   :gap "4px"}
    :tag          {:padding "2px 6px"
-                  :background (:bg-3 colors/tokens)
-                  :color (:text-primary colors/tokens)
+                  :background (:bg-3 rf.story.theme.colors/tokens)
+                  :color (:text-primary rf.story.theme.colors/tokens)
                   :border-radius "10px"
                   :cursor "pointer"
-                  :font-size (:micro typography/type-scale)
+                  :font-size (:micro rf.story.theme.typography/type-scale)
                   :user-select "none"
-                  :transition (:chip motion/transitions)}
-   :tag-active   {:background (:accent-amber colors/tokens)
-                  :color (:text-on-accent colors/tokens)}
+                  :transition (:chip rf.story.theme.motion/transitions)}
+   :tag-active   {:background (:accent-amber rf.story.theme.colors/tokens)
+                  :color (:text-on-accent rf.story.theme.colors/tokens)}
    ;; rf2-p0wur — top-level story rows + a generous inter-block gap so
    ;; the sidebar tree breathes. Story rows lead with the diamond
    ;; glyph (`re-frame.story.theme.glyphs/story-glyph`) — the sidebar
@@ -92,9 +92,9 @@
                   :padding-bottom "2px"}
    :story-row    {:padding "6px 12px 6px 10px"
                   :font-family sans-stack
-                  :color (:text-primary colors/tokens)
-                  :font-weight (str (:semibold typography/weights))
-                  :font-size (:body-tight typography/type-scale)
+                  :color (:text-primary rf.story.theme.colors/tokens)
+                  :font-weight (str (:semibold rf.story.theme.typography/weights))
+                  :font-size (:body-tight rf.story.theme.typography/type-scale)
                   :letter-spacing "0.01em"
                   ;; rf2-8j7wg — story-row is now click-activated (opens
                   ;; the rollup docs page). The cursor flips from
@@ -104,26 +104,26 @@
                   :align-items "center"
                   :gap "8px"
                   :border-left (str "2px solid transparent")}
-   :story-row-active {:background (:bg-active colors/tokens)
-                      :color (:accent-amber colors/tokens)
-                      :border-left (str "2px solid " (:accent-amber colors/tokens))}
+   :story-row-active {:background (:bg-active rf.story.theme.colors/tokens)
+                      :color (:accent-amber rf.story.theme.colors/tokens)
+                      :border-left (str "2px solid " (:accent-amber rf.story.theme.colors/tokens))}
    :story-glyph  {:flex-shrink "0"
                   :display "inline-flex"
                   :align-items "center"
-                  :color (:accent-amber colors/tokens)}
+                  :color (:accent-amber rf.story.theme.colors/tokens)}
    :variant-row  {:padding "3px 12px 3px 26px"
                   :cursor "pointer"
-                  :color (:text-secondary colors/tokens)
+                  :color (:text-secondary rf.story.theme.colors/tokens)
                   :font-family mono-stack
                   :display "flex"
                   :align-items "center"
                   :gap "8px"
                   :border-left (str "2px solid transparent")
-                  :transition (:row motion/transitions)}
-   :variant-row-active {:background (:bg-active colors/tokens)
-                        :color (:accent-amber colors/tokens)
-                        :font-weight (str (:medium typography/weights))
-                        :border-left (str "2px solid " (:accent-amber colors/tokens))}
+                  :transition (:row rf.story.theme.motion/transitions)}
+   :variant-row-active {:background (:bg-active rf.story.theme.colors/tokens)
+                        :color (:accent-amber rf.story.theme.colors/tokens)
+                        :font-weight (str (:medium rf.story.theme.typography/weights))
+                        :border-left (str "2px solid " (:accent-amber rf.story.theme.colors/tokens))}
    :variant-glyph {:flex-shrink "0"
                    :display "inline-flex"
                    :align-items "center"
@@ -131,26 +131,26 @@
                    :width "10px"
                    :height "10px"
                    :opacity 0.55
-                   :color (:text-tertiary colors/tokens)}
+                   :color (:text-tertiary rf.story.theme.colors/tokens)}
    :workspace-row {:padding "3px 12px 3px 14px"
                    :cursor "pointer"
-                   :color (:text-secondary colors/tokens)
+                   :color (:text-secondary rf.story.theme.colors/tokens)
                    :font-family mono-stack
                    :display "flex"
                    :align-items "center"
                    :gap "8px"
                    :border-left (str "2px solid transparent")
-                   :transition (:row motion/transitions)}
-   :workspace-row-active {:background (:bg-active colors/tokens)
-                          :color (:accent-amber colors/tokens)
-                          :font-weight (str (:medium typography/weights))
-                          :border-left (str "2px solid " (:accent-amber colors/tokens))}
+                   :transition (:row rf.story.theme.motion/transitions)}
+   :workspace-row-active {:background (:bg-active rf.story.theme.colors/tokens)
+                          :color (:accent-amber rf.story.theme.colors/tokens)
+                          :font-weight (str (:medium rf.story.theme.typography/weights))
+                          :border-left (str "2px solid " (:accent-amber rf.story.theme.colors/tokens))}
    :workspace-glyph {:flex-shrink "0"
                      :display "inline-flex"
                      :align-items "center"
-                     :color (:info colors/tokens)
+                     :color (:info rf.story.theme.colors/tokens)
                      :opacity 0.75}
-   :empty        {:color (:text-tertiary colors/tokens)
+   :empty        {:color (:text-tertiary rf.story.theme.colors/tokens)
                   :font-style "italic"
                   :padding "8px 12px"}
    ;; rf2-q0irb — status dot + chrome-level test widget. Only the dot's
@@ -164,43 +164,43 @@
                   :border-radius "50%"
                   :flex-shrink "0"
                   :display "inline-block"}
-   :widget       {:border-top (str "1px solid " (:border-default colors/tokens))
+   :widget       {:border-top (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                   :margin-top "auto"
                   :padding "10px 12px"
                   :display "flex"
                   :flex-direction "column"
                   :gap "6px"
-                  :background (:bg-1 colors/tokens)}
+                  :background (:bg-1 rf.story.theme.colors/tokens)}
    :widget-h     {:font-weight "bold"
-                  :color (:text-secondary colors/tokens)
+                  :color (:text-secondary rf.story.theme.colors/tokens)
                   :text-transform "uppercase"
-                  :font-size (:micro typography/type-scale)
+                  :font-size (:micro rf.story.theme.typography/type-scale)
                   :letter-spacing "0.5px"}
    :widget-counts {:display "flex"
                    :flex-wrap "wrap"
                    :gap "8px"
                    :font-family mono-stack
-                   :font-size (:caption typography/type-scale)
-                   :color (:text-primary colors/tokens)}
-   :widget-pass  {:color (:success colors/tokens)}
-   :widget-fail  {:color (:danger colors/tokens)}
-   :widget-run   {:color (:warning colors/tokens)}
-   :widget-pend  {:color (:text-tertiary colors/tokens)}
+                   :font-size (:caption rf.story.theme.typography/type-scale)
+                   :color (:text-primary rf.story.theme.colors/tokens)}
+   :widget-pass  {:color (:success rf.story.theme.colors/tokens)}
+   :widget-fail  {:color (:danger rf.story.theme.colors/tokens)}
+   :widget-run   {:color (:warning rf.story.theme.colors/tokens)}
+   :widget-pend  {:color (:text-tertiary rf.story.theme.colors/tokens)}
    :widget-btn   {:margin-top "4px"
                   :padding "4px 10px"
-                  :background (:accent-amber colors/tokens)
-                  :color (:text-on-accent colors/tokens)
+                  :background (:accent-amber rf.story.theme.colors/tokens)
+                  :color (:text-on-accent rf.story.theme.colors/tokens)
                   :border "none"
                   :border-radius "3px"
                   :cursor "pointer"
                   :font-family mono-stack
-                  :font-size (:caption typography/type-scale)}
-   :widget-btn-disabled {:background (:bg-3 colors/tokens)
-                         :color (:text-tertiary colors/tokens)
+                  :font-size (:caption rf.story.theme.typography/type-scale)}
+   :widget-btn-disabled {:background (:bg-3 rf.story.theme.colors/tokens)
+                         :color (:text-tertiary rf.story.theme.colors/tokens)
                          :cursor "not-allowed"}
-   :widget-empty {:color (:text-tertiary colors/tokens)
+   :widget-empty {:color (:text-tertiary rf.story.theme.colors/tokens)
                   :font-style "italic"
-                  :font-size (:micro typography/type-scale)}
+                  :font-size (:micro rf.story.theme.typography/type-scale)}
    ;; rf2-z1h0f — watch-mode eye-icon toggle on the chrome widget.
    :watch-row    {:display     "flex"
                   :align-items "center"
@@ -208,76 +208,76 @@
                   :margin-top  "2px"}
    :watch-btn    {:padding         "2px 8px"
                   :background      "transparent"
-                  :color           (:text-tertiary colors/tokens)
-                  :border          (str "1px solid " (:border-default colors/tokens))
+                  :color           (:text-tertiary rf.story.theme.colors/tokens)
+                  :border          (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                   :border-radius   "10px"
                   :cursor          "pointer"
                   :font-family     mono-stack
-                  :font-size       (:micro typography/type-scale)
+                  :font-size       (:micro rf.story.theme.typography/type-scale)
                   :letter-spacing  "0.3px"
                   :display         "inline-flex"
                   :align-items     "center"
                   :gap             "4px"}
-   :watch-btn-on {:background (:success-bg colors/tokens)
-                  :color      (:success colors/tokens)
-                  :border     (str "1px solid " (:success colors/tokens))}
+   :watch-btn-on {:background (:success-bg rf.story.theme.colors/tokens)
+                  :color      (:success rf.story.theme.colors/tokens)
+                  :border     (str "1px solid " (:success rf.story.theme.colors/tokens))}
    ;; rf2-nwiwr — tag-as-badge affordance on variant rows.
    :tag-badges   {:display     "inline-flex"
                   :flex-wrap   "wrap"
                   :gap         "3px"
                   :margin-left "4px"}
    :tag-badge    {:padding       "0 5px"
-                  :background    (:bg-3 colors/tokens)
-                  :color         (:text-primary colors/tokens)
+                  :background    (:bg-3 rf.story.theme.colors/tokens)
+                  :color         (:text-primary rf.story.theme.colors/tokens)
                   :border-radius "8px"
                   :font-family   mono-stack
-                  :font-size     (:nano typography/type-scale)
+                  :font-size     (:nano rf.story.theme.typography/type-scale)
                   :line-height   "14px"
                   :user-select   "none"
                   :flex-shrink   "0"}
    ;; Per-tag palette — keys on the canonical seven from
    ;; /spec/007-Stories.md §Inclusion tags; unknown tags fall through to
    ;; the neutral :tag-badge above.
-   :tag-badge-dev          {:background (:tag-dev-bg colors/tokens) :color (:info colors/tokens)}
-   :tag-badge-docs         {:background (:tag-docs-bg colors/tokens) :color (:tag-docs-fg colors/tokens)}
-   :tag-badge-test         {:background (:success-bg colors/tokens) :color (:success colors/tokens)}
-   :tag-badge-screenshot   {:background (:warning-bg colors/tokens) :color (:warning colors/tokens)}
-   :tag-badge-experimental {:background (:tag-experimental-bg colors/tokens) :color (:tag-experimental-fg colors/tokens)}
-   :tag-badge-internal     {:background (:tag-internal-bg colors/tokens) :color (:danger colors/tokens)}
-   :tag-badge-agent        {:background (:tag-agent-bg colors/tokens) :color (:success colors/tokens)}
+   :tag-badge-dev          {:background (:tag-dev-bg rf.story.theme.colors/tokens) :color (:info rf.story.theme.colors/tokens)}
+   :tag-badge-docs         {:background (:tag-docs-bg rf.story.theme.colors/tokens) :color (:tag-docs-fg rf.story.theme.colors/tokens)}
+   :tag-badge-test         {:background (:success-bg rf.story.theme.colors/tokens) :color (:success rf.story.theme.colors/tokens)}
+   :tag-badge-screenshot   {:background (:warning-bg rf.story.theme.colors/tokens) :color (:warning rf.story.theme.colors/tokens)}
+   :tag-badge-experimental {:background (:tag-experimental-bg rf.story.theme.colors/tokens) :color (:tag-experimental-fg rf.story.theme.colors/tokens)}
+   :tag-badge-internal     {:background (:tag-internal-bg rf.story.theme.colors/tokens) :color (:danger rf.story.theme.colors/tokens)}
+   :tag-badge-agent        {:background (:tag-agent-bg rf.story.theme.colors/tokens) :color (:success rf.story.theme.colors/tokens)}
    ;; rf2-yngai — search-as-you-type input row + amber-tint highlight.
    :search-row     {:padding "0 12px 8px 12px"
                     :display "flex"
                     :align-items "center"
                     :gap "6px"
-                    :border-bottom (str "1px solid " (:border-subtle colors/tokens))
+                    :border-bottom (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
                     :margin-bottom "6px"
                     :position "relative"}
    :search-input   {:width "100%"
                     :box-sizing "border-box"
-                    :background (:bg-input colors/tokens)
-                    :color (:text-primary colors/tokens)
-                    :border (str "1px solid " (:border-subtle colors/tokens))
+                    :background (:bg-input rf.story.theme.colors/tokens)
+                    :color (:text-primary rf.story.theme.colors/tokens)
+                    :border (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
                     :border-radius "4px"
                     :font-family mono-stack
-                    :font-size (:caption typography/type-scale)
+                    :font-size (:caption rf.story.theme.typography/type-scale)
                     :padding "5px 24px 5px 8px"
                     :outline "none"
-                    :transition (:chip motion/transitions)}
+                    :transition (:chip rf.story.theme.motion/transitions)}
    :search-clear   {:position "absolute"
                     :right "18px"
                     :top "50%"
                     :transform "translateY(-50%)"
                     :background "transparent"
                     :border "none"
-                    :color (:text-tertiary colors/tokens)
+                    :color (:text-tertiary rf.story.theme.colors/tokens)
                     :cursor "pointer"
                     :padding "0 4px"
                     :font-family mono-stack
-                    :font-size (:caption typography/type-scale)
+                    :font-size (:caption rf.story.theme.typography/type-scale)
                     :line-height "1"}
-   :search-hit     {:background (:accent-amber-soft colors/tokens)
-                    :color (:accent-amber colors/tokens)
+   :search-hit     {:background (:accent-amber-soft rf.story.theme.colors/tokens)
+                    :color (:accent-amber rf.story.theme.colors/tokens)
                     :border-radius "2px"
                     :padding "0 1px"}
    ;; rf2-ba86n.4 — per-variant SIGNAL CHIPS (spec/018 §7.1 + §12.6). Five
@@ -303,13 +303,13 @@
    :signal-chip     {:padding       "0 5px"
                      :border-radius "8px"
                      :font-family   mono-stack
-                     :font-size     (:nano typography/type-scale)
+                     :font-size     (:nano rf.story.theme.typography/type-scale)
                      :line-height   "14px"
                      :letter-spacing "0.2px"
                      :user-select   "none"
                      :flex-shrink   "0"
-                     :background    (:bg-3 colors/tokens)
-                     :color         (:text-secondary colors/tokens)}
+                     :background    (:bg-3 rf.story.theme.colors/tokens)
+                     :color         (:text-secondary rf.story.theme.colors/tokens)}
    ;; rf2-ba86n.3 / rf2-gsqbp — the status GLYPH channel (spec/018 §12.6).
    ;; Status chips lead with the descriptor's structural glyph (✓ ✗ ! …)
    ;; so the status survives colour-blindness AND Windows HCM, where
@@ -330,43 +330,43 @@
    ;; constructor. The shape discriminator (outline / dashed / ring)
    ;; rides through `chip-style` so cannot-run / error / pending /
    ;; redacted stay distinguishable beyond hue.
-   :signal-status-pass       (status/chip-style :pass)
-   :signal-status-fail       (status/chip-style :fail)
-   :signal-status-cannot-run (status/chip-style :cannot-run)
-   :signal-status-error      (status/chip-style :error)
-   :signal-status-running    (status/chip-style :running)
-   :signal-status-pending    (status/chip-style :pending)
-   :signal-status-blocked    (status/chip-style :blocked)
-   :signal-status-dirty      (status/chip-style :dirty)
-   :signal-status-redacted   (status/chip-style :redacted)
+   :signal-status-pass       (rf.story.theme.status/chip-style :pass)
+   :signal-status-fail       (rf.story.theme.status/chip-style :fail)
+   :signal-status-cannot-run (rf.story.theme.status/chip-style :cannot-run)
+   :signal-status-error      (rf.story.theme.status/chip-style :error)
+   :signal-status-running    (rf.story.theme.status/chip-style :running)
+   :signal-status-pending    (rf.story.theme.status/chip-style :pending)
+   :signal-status-blocked    (rf.story.theme.status/chip-style :blocked)
+   :signal-status-dirty      (rf.story.theme.status/chip-style :dirty)
+   :signal-status-redacted   (rf.story.theme.status/chip-style :redacted)
    ;; ── fidelity axis — purple-violet tint (shared with the :docs tag
    ;;    palette) so it reads as its own family, never as a world input ──
-   :signal-fidelity {:background (:tag-docs-bg colors/tokens)
-                     :color (:tag-docs-fg colors/tokens)}
+   :signal-fidelity {:background (:tag-docs-bg rf.story.theme.colors/tokens)
+                     :color (:tag-docs-fg rf.story.theme.colors/tokens)}
    ;; ── world-inputs axis — info-blue tint (distinct from fidelity) ──
-   :signal-world    {:background (:info-bg colors/tokens)
-                     :color (:info colors/tokens)}
+   :signal-world    {:background (:info-bg rf.story.theme.colors/tokens)
+                     :color (:info rf.story.theme.colors/tokens)}
    ;; ── runner-requirement axis — teal tint (shared with the :agent tag
    ;;    palette) so a capability requirement never reads as a tier of
    ;;    fidelity ──
-   :signal-runner   {:background (:tag-agent-bg colors/tokens)
-                     :color (:tag-agent-fg colors/tokens)}
+   :signal-runner   {:background (:tag-agent-bg rf.story.theme.colors/tokens)
+                     :color (:tag-agent-fg rf.story.theme.colors/tokens)}
    ;; ── frame-binding axis — neutral mono tint; an attached / MCP-bound
    ;;    binding is a binding, not a runner tier (spec/018 §7.2) ──
-   :signal-frame    {:background (:bg-3 colors/tokens)
-                     :color (:text-secondary colors/tokens)
-                     :border (str "1px solid " (:border-default colors/tokens))}
-   :signal-frame-attached  {:background (:tag-experimental-bg colors/tokens)
-                            :color (:tag-experimental-fg colors/tokens)
-                            :border (str "1px solid " (:tag-experimental-fg colors/tokens))}
+   :signal-frame    {:background (:bg-3 rf.story.theme.colors/tokens)
+                     :color (:text-secondary rf.story.theme.colors/tokens)
+                     :border (str "1px solid " (:border-default rf.story.theme.colors/tokens))}
+   :signal-frame-attached  {:background (:tag-experimental-bg rf.story.theme.colors/tokens)
+                            :color (:tag-experimental-fg rf.story.theme.colors/tokens)
+                            :border (str "1px solid " (:tag-experimental-fg rf.story.theme.colors/tokens))}
    ;; rf2-ba86n.4 — large-list virtualization / bounding (spec/018 §10 —
    ;; cap or page; the UI SHOULD fail by summarizing, not flooding). The
    ;; "+N more" affordance row a story-block renders when its variant count
    ;; exceeds the per-story cap.
    :variant-more    {:padding "2px 12px 4px 26px"
-                     :color (:text-tertiary colors/tokens)
+                     :color (:text-tertiary rf.story.theme.colors/tokens)
                      :font-family mono-stack
-                     :font-size (:micro typography/type-scale)
+                     :font-size (:micro rf.story.theme.typography/type-scale)
                      :font-style "italic"
                      :cursor "pointer"
                      :user-select "none"}
@@ -379,10 +379,10 @@
                      :display "flex"
                      :align-items "center"
                      :gap "6px"
-                     :color (:text-tertiary colors/tokens)
+                     :color (:text-tertiary rf.story.theme.colors/tokens)
                      :font-family sans-stack
-                     :font-size (:nano typography/type-scale)
+                     :font-size (:nano rf.story.theme.typography/type-scale)
                      :text-transform "uppercase"
-                     :letter-spacing (:label-wide typography/letter-spacing)}
-   :grid-group-count {:color (:accent-amber colors/tokens)
+                     :letter-spacing (:label-wide rf.story.theme.typography/letter-spacing)}
+   :grid-group-count {:color (:accent-amber rf.story.theme.colors/tokens)
                       :font-family mono-stack}})

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -37,11 +37,11 @@
   — production builds with the flag false see an empty state map and
   the shell entry point short-circuits before any subscription / mount
   call. Per `005-SOTA-Features.md` §Production elision under `:advanced`."
-  (:require [re-frame.story.config                :as config]
-            [re-frame.story.ui.state.filters      :as state.filters]
-            [re-frame.story.ui.state.snapshot     :as state.snapshot]
-            [re-frame.story.ui.state.tests        :as state.tests]
-            [re-frame.story.ui.state.transitions  :as state.transitions]
+  (:require [re-frame.story.config                :as rf.story.config]
+            [re-frame.story.ui.state.filters      :as rf.story.ui.state.filters]
+            [re-frame.story.ui.state.snapshot     :as rf.story.ui.state.snapshot]
+            [re-frame.story.ui.state.tests        :as rf.story.ui.state.tests]
+            [re-frame.story.ui.state.transitions  :as rf.story.ui.state.transitions]
             #?(:cljs [reagent.core :as r])))
 
 ;; ---- pure data: the default shape ----------------------------------------
@@ -167,59 +167,59 @@
 
 ;; ---- pure transitions (extracted to state.transitions) ------------------
 
-(def select-variant            state.transitions/select-variant)
-(def select-workspace          state.transitions/select-workspace)
-(def select-story              state.transitions/select-story)
-(def toggle-tag-filter         state.transitions/toggle-tag-filter)
-(def set-active-modes          state.transitions/set-active-modes)
-(def toggle-mode               state.transitions/toggle-mode)
-(def clear-active-modes        state.transitions/clear-active-modes)
-(def group-modes-by-axis       state.transitions/group-modes-by-axis)
-(def set-cell-override         state.transitions/set-cell-override)
-(def set-cell-override-scalar  state.transitions/set-cell-override-scalar)
-(def clear-cell-overrides      state.transitions/clear-cell-overrides)
-(def clear-cell-override       state.transitions/clear-cell-override)
-(def ensure-repeater-row-ids   state.transitions/ensure-repeater-row-ids)
-(def repeater-row-ids          state.transitions/repeater-row-ids)
-(def append-repeater-row-id    state.transitions/append-repeater-row-id)
-(def remove-repeater-row-id    state.transitions/remove-repeater-row-id)
-(def bump-hot-reload-tick      state.transitions/bump-hot-reload-tick)
-(def record-fingerprints       state.transitions/record-fingerprints)
-(def pin-snapshot              state.transitions/pin-snapshot)
-(def toggle-panel              state.transitions/toggle-panel)
+(def select-variant            rf.story.ui.state.transitions/select-variant)
+(def select-workspace          rf.story.ui.state.transitions/select-workspace)
+(def select-story              rf.story.ui.state.transitions/select-story)
+(def toggle-tag-filter         rf.story.ui.state.transitions/toggle-tag-filter)
+(def set-active-modes          rf.story.ui.state.transitions/set-active-modes)
+(def toggle-mode               rf.story.ui.state.transitions/toggle-mode)
+(def clear-active-modes        rf.story.ui.state.transitions/clear-active-modes)
+(def group-modes-by-axis       rf.story.ui.state.transitions/group-modes-by-axis)
+(def set-cell-override         rf.story.ui.state.transitions/set-cell-override)
+(def set-cell-override-scalar  rf.story.ui.state.transitions/set-cell-override-scalar)
+(def clear-cell-overrides      rf.story.ui.state.transitions/clear-cell-overrides)
+(def clear-cell-override       rf.story.ui.state.transitions/clear-cell-override)
+(def ensure-repeater-row-ids   rf.story.ui.state.transitions/ensure-repeater-row-ids)
+(def repeater-row-ids          rf.story.ui.state.transitions/repeater-row-ids)
+(def append-repeater-row-id    rf.story.ui.state.transitions/append-repeater-row-id)
+(def remove-repeater-row-id    rf.story.ui.state.transitions/remove-repeater-row-id)
+(def bump-hot-reload-tick      rf.story.ui.state.transitions/bump-hot-reload-tick)
+(def record-fingerprints       rf.story.ui.state.transitions/record-fingerprints)
+(def pin-snapshot              rf.story.ui.state.transitions/pin-snapshot)
+(def toggle-panel              rf.story.ui.state.transitions/toggle-panel)
 
 ;; ---- Xray-embed collapse re-exports -------------------------------------
 
-(def xray-embed-collapsed?       state.transitions/xray-embed-collapsed?)
-(def toggle-xray-embed-collapsed state.transitions/toggle-xray-embed-collapsed)
-(def set-xray-embed-collapsed    state.transitions/set-xray-embed-collapsed)
+(def xray-embed-collapsed?       rf.story.ui.state.transitions/xray-embed-collapsed?)
+(def toggle-xray-embed-collapsed rf.story.ui.state.transitions/toggle-xray-embed-collapsed)
+(def set-xray-embed-collapsed    rf.story.ui.state.transitions/set-xray-embed-collapsed)
 
 ;; ---- chrome visibility re-exports ---------------------------------------
 
-(def chrome-visibility-defaults state.transitions/chrome-visibility-defaults)
-(def chrome-visibility         state.transitions/chrome-visibility)
-(def toggle-chrome-visibility  state.transitions/toggle-chrome-visibility)
-(def set-chrome-visibility     state.transitions/set-chrome-visibility)
-(def chrome-pane-visible?      state.transitions/chrome-pane-visible?)
+(def chrome-visibility-defaults rf.story.ui.state.transitions/chrome-visibility-defaults)
+(def chrome-visibility         rf.story.ui.state.transitions/chrome-visibility)
+(def toggle-chrome-visibility  rf.story.ui.state.transitions/toggle-chrome-visibility)
+(def set-chrome-visibility     rf.story.ui.state.transitions/set-chrome-visibility)
+(def chrome-pane-visible?      rf.story.ui.state.transitions/chrome-pane-visible?)
 
 ;; ---- mode-tab re-exports -------------------------------------------------
 
-(def mode-tabs                 state.transitions/mode-tabs)
-(def mode-tab-labels           state.transitions/mode-tab-labels)
-(def default-mode-tab          state.transitions/default-mode-tab)
-(def valid-mode-tab?           state.transitions/valid-mode-tab?)
-(def active-mode-tab           state.transitions/active-mode-tab)
-(def set-active-mode-tab       state.transitions/set-active-mode-tab)
+(def mode-tabs                 rf.story.ui.state.transitions/mode-tabs)
+(def mode-tab-labels           rf.story.ui.state.transitions/mode-tab-labels)
+(def default-mode-tab          rf.story.ui.state.transitions/default-mode-tab)
+(def valid-mode-tab?           rf.story.ui.state.transitions/valid-mode-tab?)
+(def active-mode-tab           rf.story.ui.state.transitions/active-mode-tab)
+(def set-active-mode-tab       rf.story.ui.state.transitions/set-active-mode-tab)
 
 ;; ---- pure derivations (extracted to state.filters) ----------------------
 
-(def group-tags-by-axis           state.filters/group-tags-by-axis)
-(def axis-display-order           state.filters/axis-display-order)
-(def ordered-axes                 state.filters/ordered-axes)
-(def partition-tag-filter-by-axis state.filters/partition-tag-filter-by-axis)
-(def variant-tag-match?           state.filters/variant-tag-match?)
-(def filter-variants              state.filters/filter-variants)
-(def group-variants-by-story      state.filters/group-variants-by-story)
+(def group-tags-by-axis           rf.story.ui.state.filters/group-tags-by-axis)
+(def axis-display-order           rf.story.ui.state.filters/axis-display-order)
+(def ordered-axes                 rf.story.ui.state.filters/ordered-axes)
+(def partition-tag-filter-by-axis rf.story.ui.state.filters/partition-tag-filter-by-axis)
+(def variant-tag-match?           rf.story.ui.state.filters/variant-tag-match?)
+(def filter-variants              rf.story.ui.state.filters/filter-variants)
+(def group-variants-by-story      rf.story.ui.state.filters/group-variants-by-story)
 
 ;; The canonical `parent-story-id` helper lives in
 ;; `re-frame.story.predicates`; sidebar / filters call
@@ -229,7 +229,7 @@
 
 (def registry-snapshot
   "Re-export of `re-frame.story.ui.state.snapshot/registry-snapshot`."
-  state.snapshot/registry-snapshot)
+  rf.story.ui.state.snapshot/registry-snapshot)
 
 ;; ---- the reactive bag (CLJS-only) ----------------------------------------
 
@@ -263,7 +263,7 @@
   "Apply `f` (plus optional args) to the shell state. The pure fns above
   are the recommended `f` values."
   [f & args]
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (apply swap! shell-state-atom f args)))
 
 ;; ---- test-runs + watch-mode (extracted to state.tests) ------------------
@@ -273,15 +273,15 @@
 ;; leaf-size ceiling. Re-exported here so consumer requires of
 ;; `re-frame.story.ui.state` keep working unchanged.
 
-(def test-run-statuses           state.tests/test-run-statuses)
-(def mark-test-running           state.tests/mark-test-running)
-(def aggregate-summary           state.tests/aggregate-summary)
-(def record-test-run             state.tests/record-test-run)
-(def clear-test-run              state.tests/clear-test-run)
-(def variant-test-status         state.tests/variant-test-status)
-(def test-summary                state.tests/test-summary)
-(def testable-variant-ids        state.tests/testable-variant-ids)
-(def set-test-watch-mode         state.tests/set-test-watch-mode)
-(def test-watch-mode?            state.tests/test-watch-mode?)
-(def record-test-content-hashes  state.tests/record-test-content-hashes)
-(def watch-mode-drift            state.tests/watch-mode-drift)
+(def test-run-statuses           rf.story.ui.state.tests/test-run-statuses)
+(def mark-test-running           rf.story.ui.state.tests/mark-test-running)
+(def aggregate-summary           rf.story.ui.state.tests/aggregate-summary)
+(def record-test-run             rf.story.ui.state.tests/record-test-run)
+(def clear-test-run              rf.story.ui.state.tests/clear-test-run)
+(def variant-test-status         rf.story.ui.state.tests/variant-test-status)
+(def test-summary                rf.story.ui.state.tests/test-summary)
+(def testable-variant-ids        rf.story.ui.state.tests/testable-variant-ids)
+(def set-test-watch-mode         rf.story.ui.state.tests/set-test-watch-mode)
+(def test-watch-mode?            rf.story.ui.state.tests/test-watch-mode?)
+(def record-test-content-hashes  rf.story.ui.state.tests/record-test-content-hashes)
+(def watch-mode-drift            rf.story.ui.state.tests/watch-mode-drift)

--- a/tools/story/src/re_frame/story/ui/state/filters.cljc
+++ b/tools/story/src/re_frame/story/ui/state/filters.cljc
@@ -15,7 +15,7 @@
 
   The faceted-filter contract (Storybook SB9 parity): AND across axes,
   OR within an axis. Documented per-fn below."
-  (:require [re-frame.story.predicates :as pred]))
+  (:require [re-frame.story.predicates :as rf.story.predicates]))
 
 (defn group-tags-by-axis
   "Pure data → data: split a seq of tags into `{axis-kw → [tag …]}`
@@ -147,7 +147,7 @@
   Sorted by story id (alphabetic on the keyword name) so the sidebar is
   stable across re-renders."
   [id->body]
-  (let [by-story (group-by (comp pred/parent-story-id key) id->body)]
+  (let [by-story (group-by (comp rf.story.predicates/parent-story-id key) id->body)]
     (->> by-story
          (map (fn [[story-id variants]]
                 {:story-id story-id

--- a/tools/story/src/re_frame/story/ui/state/snapshot.cljc
+++ b/tools/story/src/re_frame/story/ui/state/snapshot.cljc
@@ -9,8 +9,8 @@
   control panel / workspace panes consume the snapshot. Lives in its
   own leaf so future memoisation (e.g. cache keyed on the registrar
   mutation-tick) is local."
-  (:require [re-frame.story.registrar :as registrar]
-            [re-frame.story.tags      :as tags]))
+  (:require [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.tags      :as rf.story.tags]))
 
 (defn registry-snapshot
   "Return a single map containing every Story-side artefact kind. Used
@@ -25,12 +25,12 @@
   uniformly. This is the SINGLE UI-side resolution point; every downstream
   consumer reads the projected `:tags` verbatim."
   []
-  (let [variants (registrar/registrations :variant)
-        stories  (registrar/registrations :story)]
+  (let [variants (rf.story.registrar/registrations :variant)
+        stories  (rf.story.registrar/registrations :story)]
     {:stories      stories
-     :variants     (tags/resolve-body-tags variants {:story stories})
-     :workspaces   (registrar/registrations :workspace)
-     :modes        (registrar/registrations :mode)
-     :decorators   (registrar/registrations :decorator)
-     :story-panels (registrar/registrations :story-panel)
-     :tags         (registrar/registrations :tag)}))
+     :variants     (rf.story.tags/resolve-body-tags variants {:story stories})
+     :workspaces   (rf.story.registrar/registrations :workspace)
+     :modes        (rf.story.registrar/registrations :mode)
+     :decorators   (rf.story.registrar/registrations :decorator)
+     :story-panels (rf.story.registrar/registrations :story-panel)
+     :tags         (rf.story.registrar/registrations :tag)}))

--- a/tools/story/src/re_frame/story/ui/state/tests.cljc
+++ b/tools/story/src/re_frame/story/ui/state/tests.cljc
@@ -30,7 +30,7 @@
   ceiling without losing locality. The parent ns re-exports the
   public defs so existing consumer requires (`re-frame.story.ui.state`)
   keep working."
-  (:require [re-frame.story.verdict :as verdict]))
+  (:require [re-frame.story.verdict :as rf.story.verdict]))
 
 ;; ---- test-runs -----------------------------------------------------------
 ;;
@@ -93,7 +93,7 @@
         legacy-skip? (fn [r] (= :rf.assert/skipped (:assertion r)))
         skipped    (count (filter legacy-skip? items))
         active     (remove legacy-skip? items)
-        buckets    (frequencies (map verdict/record-status active))
+        buckets    (frequencies (map rf.story.verdict/record-status active))
         passed     (get buckets :pass 0)
         cannot-run (get buckets :cannot-run 0)
         ;; :fail + :error both count as failures for the headline tally.
@@ -124,12 +124,12 @@
   (let [{:keys [total passed failed cannot-run skipped all-passed?
                 ran-at-ms elapsed-ms status]} (or summary {})
         status (cond
-                 (contains? verdict/statuses status)
+                 (contains? rf.story.verdict/statuses status)
                  ;; This slot carries the FIVE dot-facing run statuses
                  ;; (`test-run-statuses` — `:cannot-run` is the distinct
                  ;; third). A run-level `:error` verdict lowers to `:fail`
                  ;; HERE, at write time — the one place the four-verdict
-                 ;; vocabulary (spec/017, `verdict/statuses`) narrows; both
+                 ;; vocabulary (spec/017, `rf.story.verdict/statuses`) narrows; both
                  ;; demand attention and wear the danger tint. The
                  ;; per-assertion `:error` detail stays distinct in the
                  ;; test-mode pane's result rows (test-mode.pure), per

--- a/tools/story/src/re_frame/story/ui/state/transitions.cljc
+++ b/tools/story/src/re_frame/story/ui/state/transitions.cljc
@@ -11,7 +11,7 @@
 
   The parent ns `re-frame.story.ui.state` re-exports every Var here,
   so consumer requires keep working unchanged."
-  (:require [re-frame.story.registrar :as registrar]))
+  (:require [re-frame.story.registrar :as rf.story.registrar]))
 
 ;; ---- selection / filters -------------------------------------------------
 
@@ -62,7 +62,7 @@
   testable (the helper consults the registrar; pass an explicit
   `axis-fn` to bypass it in pure tests)."
   [mode-id]
-  (:axis (registrar/handler-meta :mode mode-id)))
+  (:axis (rf.story.registrar/handler-meta :mode mode-id)))
 
 (defn toggle-mode
   "Toggle `mode-id` against the current `active-modes` vector. Honors
@@ -104,7 +104,7 @@
   "Build the toolbar's chip layout. Pure data → data; JVM-testable.
 
   `id->body` is the `{mode-id → mode-body}` map from
-  `(registrar/registrations :mode)`. Returns
+  `(rf.story.registrar/registrations :mode)`. Returns
 
       {:axes   [[axis [mode-id ...]] ...]  ; sorted alphabetically by axis-name
        :unaxed [mode-id ...]}              ; un-grouped modes, sorted alphabetically

--- a/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
+++ b/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
@@ -14,10 +14,10 @@
   Everything in this namespace is `.cljc` so it runs unchanged on both
   the JVM (for the test corpus) and CLJS (consumed by `view.cljs`)."
   (:require [clojure.string            :as str]
-            [re-frame.story.assertions :as assertions]
-            [re-frame.story.predicates :as pred]
-            [re-frame.story.registrar  :as registrar]
-            [re-frame.story.verdict    :as verdict]))
+            [re-frame.story.assertions :as rf.story.assertions]
+            [re-frame.story.predicates :as rf.story.predicates]
+            [re-frame.story.registrar  :as rf.story.registrar]
+            [re-frame.story.verdict    :as rf.story.verdict]))
 
 ;; ---- aliases on the leaf predicates ns ----------------------------------
 ;;
@@ -25,14 +25,14 @@
 ;; (a pure leaf ns the rest of Story consumes without cycle risk).
 ;; Aliased here so internal call sites stay textually identical.
 ;; `parent-story-id` is not re-exported here — its sole caller
-;; (`test-mode.view`) calls `pred/parent-story-id` directly.
+;; (`test-mode.view`) calls `rf.story.predicates/parent-story-id` directly.
 
-(def ^:private assertion-event? pred/assertion-event?)
+(def ^:private assertion-event? rf.story.predicates/assertion-event?)
 
 ;; ---- the unified run-result verdicts (spec/017 §Run result) -------------
 ;;
 ;; The four verdicts every assertion record / check / run carries are owned
-;; by the pure `re-frame.story.verdict` leaf (`verdict/statuses`) — consumed
+;; by the pure `re-frame.story.verdict` leaf (`rf.story.verdict/statuses`) — consumed
 ;; directly here (no require into `re-frame.story.result`, which loops
 ;; through the runtime; no local mirror to drift).
 
@@ -69,7 +69,7 @@
 
   Pure data → data; JVM-testable."
   [variant-id]
-  (let [vb (registrar/handler-meta :variant variant-id)]
+  (let [vb (rf.story.registrar/handler-meta :variant variant-id)]
     (or (has-play-script? vb)
         (has-plays? vb))))
 
@@ -134,7 +134,7 @@
                    (= :rf.assert/skipped aid)          :skip
                    ;; The unified `:status` wins; the :passed?-only
                    ;; derivation is the fallback.
-                   (contains? verdict/statuses st)     st
+                   (contains? rf.story.verdict/statuses st)     st
                    (:cannot-run? rec)                  :cannot-run
                    (or (:error rec) (:exception rec))  :error
                    passed?                             :pass
@@ -395,7 +395,7 @@
   (let [st (:status result)]
     (cond
       (nil? result)                   :pending
-      (contains? verdict/statuses st) st
+      (contains? rf.story.verdict/statuses st) st
       :else
       (let [{:keys [total failed cannot-run all-passed?]} (or summary {})]
         (cond
@@ -687,18 +687,18 @@
   browser-tier checks (the common headless case — an honest empty state,
   never a fabricated row). Pure data → data; JVM-testable."
   [result]
-  (let [browser? (fn [rec] (contains? assertions/browser-assertion-ids
+  (let [browser? (fn [rec] (contains? rf.story.assertions/browser-assertion-ids
                                       (:assertion rec)))
         kind-of  (fn [aid]
                    (condp = aid
-                     assertions/id-visual-snapshot :visual
-                     assertions/id-a11y            :a11y
-                     assertions/id-a11y-structural :a11y-structural
+                     rf.story.assertions/id-visual-snapshot :visual
+                     rf.story.assertions/id-a11y            :a11y
+                     rf.story.assertions/id-a11y-structural :a11y-structural
                      :browser))
         status-of (fn [rec]
                     (let [st (:status rec)]
                       (cond
-                        (contains? verdict/statuses st)    st
+                        (contains? rf.story.verdict/statuses st)    st
                         (:cannot-run? rec)                 :cannot-run
                         (or (:error rec) (:exception rec)) :error
                         (:passed? rec)                     :pass

--- a/tools/story/src/re_frame/story/ui/test_mode/state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/state.cljs
@@ -21,7 +21,7 @@
   `:assertions` records each stamped with their own `:status`. The pane
   reads it through `re-frame.story.ui.test-mode.pure`'s projection helpers.
 
-  Re-run flips `:running?` on, calls `runtime/reset-variant`, swaps the
+  Re-run flips `:running?` on, calls `rf.story.runtime/reset-variant`, swaps the
   result in on resolve.
 
   `:play-events`, `:epoch-ids` + `:selected-step` are the step-through
@@ -40,12 +40,12 @@
     helpers below)."
   (:require [reagent.core                 :as r]
             [re-frame.core                :as rf]
-            [re-frame.interop             :as interop]
-            [re-frame.story.async         :as async]
-            [re-frame.story.play          :as play]
-            [re-frame.story.runtime       :as runtime]
-            [re-frame.story.ui.state      :as state]
-            [re-frame.story.ui.test-mode.pure :as pure]))
+            [re-frame.interop             :as rf.interop]
+            [re-frame.story.async         :as rf.story.async]
+            [re-frame.story.play          :as rf.story.play]
+            [re-frame.story.runtime       :as rf.story.runtime]
+            [re-frame.story.ui.state      :as rf.story.ui.state]
+            [re-frame.story.ui.test-mode.pure :as rf.story.ui.test-mode.pure]))
 
 ;; ---- ratom ---------------------------------------------------------------
 ;;
@@ -62,7 +62,7 @@
   is in flight."
   [variant-id]
   (swap! results-atom assoc-in [variant-id :running?] true)
-  (state/swap-state! state/mark-test-running variant-id))
+  (rf.story.ui.state/swap-state! rf.story.ui.state/mark-test-running variant-id))
 
 (defn- store-result!
   "Swap a fresh `result` (from `run-variant`) into the variant's
@@ -78,12 +78,12 @@
   too — the chrome-level test widget + sidebar dots read off that
   slot."
   [variant-id result]
-  (let [now          (interop/now-ms)
+  (let [now          (rf.interop/now-ms)
         ;; `:script` is the canonical phase-4 slot.
-        ;; `play/variant-play-events` extracts a flat event-vec list
+        ;; `rf.story.play/variant-play-events` extracts a flat event-vec list
         ;; (one per `:dispatch`/`:dispatch-sync` step), the shape the
         ;; scrubber's slot expects.
-        play-events  (play/variant-play-events variant-id)
+        play-events  (rf.story.play/variant-play-events variant-id)
         ;; rf2-4e545l finding 4: match against THIS run's own scoped
         ;; `:epoch-tape` (the result's raw `:rf/epoch-record` vector,
         ;; each carrying its `:trigger-event`) by trigger-event identity
@@ -91,8 +91,8 @@
         ;; epoch-history — a mixed :click+:dispatch script where the
         ;; :click ALSO commits an epoch (its DOM handler dispatches)
         ;; would otherwise misalign a positional slice. See
-        ;; `pure/epoch-id-slice`'s docstring.
-        epoch-ids    (pure/epoch-id-slice (:epoch-tape result) play-events)]
+        ;; `rf.story.ui.test-mode.pure/epoch-id-slice`'s docstring.
+        epoch-ids    (rf.story.ui.test-mode.pure/epoch-id-slice (:epoch-tape result) play-events)]
     (swap! results-atom assoc variant-id
            {:result        result
             :ran-at-ms     now
@@ -101,7 +101,7 @@
             :play-events   (vec play-events)
             :epoch-ids     epoch-ids
             :selected-step nil})
-    (let [summary (-> (state/aggregate-summary (:assertions result))
+    (let [summary (-> (rf.story.ui.state/aggregate-summary (:assertions result))
                       (assoc :ran-at-ms  now
                              :elapsed-ms (:elapsed-ms result)
                              ;; thread the unified run-level `:status` so
@@ -109,7 +109,7 @@
                              ;; `:fail` / `:cannot-run` refusal the
                              ;; assertion counts alone might miss.
                              :status     (:status result)))]
-      (state/swap-state! state/record-test-run variant-id summary))))
+      (rf.story.ui.state/swap-state! rf.story.ui.state/record-test-run variant-id summary))))
 
 (defn select-step!
   "Set the step-through scrubber's `:selected-step` for `variant-id`
@@ -187,14 +187,14 @@
   so the test pane re-runs against the same effective-args the user has
   been editing in the controls panel."
   [variant-id]
-  (let [shell @state/shell-state-atom
+  (let [shell @rf.story.ui.state/shell-state-atom
         opts  {:active-modes   (:active-modes shell)
                :cell-overrides (get-in shell [:cell-overrides variant-id])
                :substrate      (:substrate shell)}]
     (begin-run! variant-id)
-    (-> (runtime/reset-variant variant-id opts)
-        (async/then  (fn [r] (store-result! variant-id r) nil))
-        (async/catch* (fn [_]
+    (-> (rf.story.runtime/reset-variant variant-id opts)
+        (rf.story.async/then  (fn [r] (store-result! variant-id r) nil))
+        (rf.story.async/catch* (fn [_]
                         ;; Even a rejection clears :running? so the
                         ;; UI button comes back to "Re-run". Drop
                         ;; the shell-state running stamp too — the
@@ -202,5 +202,5 @@
                         ;; rejection.
                         (swap! results-atom assoc-in
                                [variant-id :running?] false)
-                        (state/swap-state! state/clear-test-run variant-id)
+                        (rf.story.ui.state/swap-state! rf.story.ui.state/clear-test-run variant-id)
                         nil)))))

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_pure.cljc
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_pure.cljc
@@ -15,15 +15,15 @@
     `step-back!` / `rewind!` / `toggle-breakpoint!` / `end!`).
   - `re-frame.story.ui.test-mode.stepper-styles` — pure style map.
   - `re-frame.story.ui.test-mode.stepper-view`   — CLJS Reagent component."
-  (:require [re-frame.story.predicates :as pred]
-            [re-frame.story.play.runner :as runner]
-            [re-frame.story.ui.test-mode.pure :as test-mode-pure]))
+  (:require [re-frame.story.predicates :as rf.story.predicates]
+            [re-frame.story.play.runner :as rf.story.play.runner]
+            [re-frame.story.ui.test-mode.pure :as rf.story.ui.test-mode.pure]))
 
 ;; ---- step-outcome (full-script step list) -------------------------------
 ;;
 ;; The step-debugger walks the FULL coerced :script (every step
 ;; type), driving each through the rich-DSL executor. Each step that has
-;; run carries a result record (`runner/step-pass` / `step-fail` /
+;; run carries a result record (`rf.story.play.runner/step-pass` / `step-fail` /
 ;; `step-skip` / `step-exception`); steps not yet reached carry no result.
 ;; This fold maps the full step vector + the per-step result records onto
 ;; one row per step, so the cursor / total are honest and EVERY step type
@@ -63,7 +63,7 @@
         (fn [idx step]
           {:index  idx
            :step   step
-           :label  (runner/step-summary step)
+           :label  (rf.story.play.runner/step-summary step)
            :status (step-outcome (nth recs idx nil))})
         (or steps [])))))
 
@@ -71,7 +71,7 @@
 ;;
 ;; Each step in the stepper UI has a *position* status (pending / current /
 ;; done) AND an *outcome* status (the existing :pass / :fail / :event /
-;; :skip from `test-mode-pure/play-step-statuses`). Pure: maps the cursor +
+;; :skip from `rf.story.ui.test-mode.pure/play-step-statuses`). Pure: maps the cursor +
 ;; the outcome list onto one fold the view renders directly.
 
 (defn step-position
@@ -90,7 +90,7 @@
     :else             :pending))
 
 (defn enrich-statuses
-  "Walk `test-mode-pure/play-step-statuses` output and stamp each row with
+  "Walk `rf.story.ui.test-mode.pure/play-step-statuses` output and stamp each row with
    - `:position` — :done / :current / :pending (per `step-position`)
    - `:breakpoint?` — boolean, true when the row's `:index` is in
      `breakpoints` (a set)
@@ -185,8 +185,8 @@
 ;; existing pure helper so the stepper rows and the scrubber ticks share
 ;; one label projection.
 
-(def play-step-label test-mode-pure/play-step-label)
+(def play-step-label rf.story.ui.test-mode.pure/play-step-label)
 
 ;; ---- assertion-event? re-export (used by the view to glyph rows) -------
 
-(def assertion-event? pred/assertion-event?)
+(def assertion-event? rf.story.predicates/assertion-event?)

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_state.cljs
@@ -20,7 +20,7 @@
                                       ;   :script step vector (every step
                                       ;   type; derived via
                                       ;   re-frame.story.play/variant-play-steps)
-       :statuses       <vector>       ; `stepper-pure/enrich-statuses` rows
+       :statuses       <vector>       ; `rf.story.ui.test-mode.stepper-pure/enrich-statuses` rows
        :breakpoints    #{<int>}       ; step indices that pause auto-play
        :epoch-stack    <vector>       ; per-step :epoch-id pre-images, for
                                       ;   step-back via rf/restore-epoch!
@@ -51,9 +51,9 @@
   Clears the interval and the per-frame play state."
   (:require [reagent.core                                 :as r]
             [re-frame.core                                :as rf]
-            [re-frame.story.play                          :as play]
-            [re-frame.story.runtime                       :as runtime]
-            [re-frame.story.ui.test-mode.stepper-pure     :as stepper-pure]))
+            [re-frame.story.play                          :as rf.story.play]
+            [re-frame.story.runtime                       :as rf.story.runtime]
+            [re-frame.story.ui.test-mode.stepper-pure     :as rf.story.ui.test-mode.stepper-pure]))
 
 ;; ---- ratom ---------------------------------------------------------------
 
@@ -76,16 +76,16 @@
 
   The rows cover the FULL coerced step vector (every step type), and
   each row's outcome comes from the per-step result the rich-DSL
-  executor recorded into `play/stepper-state` — not from the
+  executor recorded into `rf.story.play/stepper-state` — not from the
   dispatch-only `:rf.story/assertions` projection (which does not see
   rich-DSL `:assert-db` / `:assert-dom` / `:wait` / `:click` / `:type`
   steps)."
   [slot]
   (let [{:keys [play-steps cursor breakpoints variant-id]} slot
-        results (:results (get @play/stepper-state variant-id))]
+        results (:results (get @rf.story.play/stepper-state variant-id))]
     (assoc slot :statuses
-           (stepper-pure/enrich-statuses
-             (stepper-pure/step-statuses play-steps results)
+           (rf.story.ui.test-mode.stepper-pure/enrich-statuses
+             (rf.story.ui.test-mode.stepper-pure/step-statuses play-steps results)
              cursor
              breakpoints))))
 
@@ -104,7 +104,7 @@
 (defn begin!
   "Initialise a step-by-step run for `variant-id`. Tears down any prior
   stepper state, then re-allocates the variant frame (so the run starts
-  fresh) and primes the substrate via `play/begin-stepper!`.
+  fresh) and primes the substrate via `rf.story.play/begin-stepper!`.
 
   Asynchronous: the caller may await the returned promise to drive a
   follow-up auto-resume, but the UI does not need to — the slot's
@@ -113,19 +113,19 @@
   ;; If a prior stepper is active for this variant, tear it down first.
   (when (get @results-atom variant-id)
     (swap! results-atom update variant-id clear-interval!))
-  (play/end-stepper! variant-id)
+  (rf.story.play/end-stepper! variant-id)
   ;; Re-allocate the variant frame so the stepper starts from the
   ;; documented initial state.
-  (-> (runtime/reset-variant variant-id)
+  (-> (rf.story.runtime/reset-variant variant-id)
       (.then  (fn [_]
                 ;; The stepper walks the FULL coerced :script
                 ;; (every step type), not just the dispatch-bearing
-                ;; events. `play/variant-play-steps` returns the complete
-                ;; step vector and `play/begin-stepper!` seeds the
+                ;; events. `rf.story.play/variant-play-steps` returns the complete
+                ;; step vector and `rf.story.play/begin-stepper!` seeds the
                 ;; substrate from the same source.
-                (let [play-steps (play/variant-play-steps variant-id)
+                (let [play-steps (rf.story.play/variant-play-steps variant-id)
                       total      (count play-steps)]
-                  (play/begin-stepper! variant-id)
+                  (rf.story.play/begin-stepper! variant-id)
                   (swap! results-atom assoc variant-id
                          {:variant-id     variant-id
                           :active?        true
@@ -151,10 +151,10 @@
   is parked at the end or not active."
   [variant-id]
   (let [slot (get @results-atom variant-id)]
-    (when (stepper-pure/can-step? slot)
+    (when (rf.story.ui.test-mode.stepper-pure/can-step? slot)
       ;; Capture the pre-step epoch-id so step-back can restore it.
       (let [pre-id (current-epoch-id variant-id)]
-        (play/step-once! variant-id)
+        (rf.story.play/step-once! variant-id)
         (swap! results-atom update variant-id
                (fn [s]
                  (-> s
@@ -186,7 +186,7 @@
   would have built by forward-stepping alone."
   [variant-id]
   (let [slot (get @results-atom variant-id)]
-    (when (stepper-pure/can-step-back? slot)
+    (when (rf.story.ui.test-mode.stepper-pure/can-step-back? slot)
       (let [stack     (or (:epoch-stack slot) [])
             ;; Peek the CURRENT top — the pre-image of the step we're
             ;; undoing — before popping it off.
@@ -196,7 +196,7 @@
           (rf/restore-epoch! variant-id target-id))
         ;; Pop the substrate's last-run step + result so the row outcomes
         ;; track the cursor and a re-step re-runs the popped step cleanly.
-        (play/stepper-step-back! variant-id)
+        (rf.story.play/stepper-step-back! variant-id)
         (swap! results-atom update variant-id
                (fn [s]
                  (-> s
@@ -210,7 +210,7 @@
   when the stepper is at step 0 or not active."
   [variant-id]
   (let [slot (get @results-atom variant-id)]
-    (when (stepper-pure/can-rewind? slot)
+    (when (rf.story.ui.test-mode.stepper-pure/can-rewind? slot)
       (let [stack (or (:epoch-stack slot) [])
             ;; The pre-play epoch-id is the bottom of the stack (the
             ;; first pre-image we pushed on `begin!`).
@@ -223,7 +223,7 @@
         ;; reset.
         ;; Reset the substrate's run cursor (every step back to pending)
         ;; so the rewound stepper re-runs the whole script cleanly.
-        (play/stepper-rewind! variant-id)
+        (rf.story.play/stepper-rewind! variant-id)
         (swap! results-atom update variant-id
                (fn [s]
                  (-> s
@@ -243,7 +243,7 @@
   overridden by a future controls widget."
   [variant-id]
   (let [slot (get @results-atom variant-id)]
-    (when (stepper-pure/can-resume? slot)
+    (when (rf.story.ui.test-mode.stepper-pure/can-resume? slot)
       (let [tick (or (:tick-ms slot) default-tick-ms)
             hid  (set-interval! variant-id tick)]
         (swap! results-atom update variant-id
@@ -271,7 +271,7 @@
   the substrate's per-frame state, and removes the local slot."
   [variant-id]
   (swap! results-atom update variant-id (fn [s] (when s (clear-interval! s))))
-  (play/end-stepper! variant-id)
+  (rf.story.play/end-stepper! variant-id)
   (swap! results-atom dissoc variant-id))
 
 ;; ---- internal auto-play tick --------------------------------------------
@@ -285,10 +285,10 @@
       (not (:active? slot))
       (pause! variant-id)
 
-      (stepper-pure/at-end? (:cursor slot) (:total slot))
+      (rf.story.ui.test-mode.stepper-pure/at-end? (:cursor slot) (:total slot))
       (pause! variant-id)
 
-      (stepper-pure/breakpoint-hit? (:cursor slot)
+      (rf.story.ui.test-mode.stepper-pure/breakpoint-hit? (:cursor slot)
                                     (:breakpoints slot))
       (pause! variant-id)
 

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_styles.cljs
@@ -2,8 +2,8 @@
   "Style map for the play step-debugger (spec/009 §Play step-debugger).
   Pure data; no Reagent dependency. Matches the rest of the test pane
   chrome palette."
-  (:require [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+  (:require [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 (def styles
   {;; ---- section wrap ---------------------------------------------------
@@ -15,10 +15,10 @@
                     :padding-right    "10px"
                     :padding-bottom   "8px"
                     :padding-left     "10px"
-                    :background       (:bg-2 colors/tokens)
+                    :background       (:bg-2 rf.story.theme.colors/tokens)
                     :border-style     "solid"
                     :border-width     "1px"
-                    :border-color     (:border-default colors/tokens)
+                    :border-color     (:border-default rf.story.theme.colors/tokens)
                     :border-radius    "4px"
                     :outline-offset   "2px"}
    :section-header {:display          "flex"
@@ -27,20 +27,20 @@
                     :gap              "10px"
                     :margin-bottom    "6px"
                     :font-family      mono-stack
-                    :font-size        (:micro typography/type-scale)
+                    :font-size        (:micro rf.story.theme.typography/type-scale)
                     :font-weight      "bold"
-                    :color            (:text-secondary colors/tokens)
+                    :color            (:text-secondary rf.story.theme.colors/tokens)
                     :text-transform   "uppercase"
                     :letter-spacing   "0.5px"}
    :section-title  {:display          "flex"
                     :align-items      "center"
                     :gap              "8px"}
-   :progress       {:color            (:text-tertiary colors/tokens)
+   :progress       {:color            (:text-tertiary rf.story.theme.colors/tokens)
                     :font-weight      "normal"
                     :text-transform   "none"
                     :letter-spacing   "0"}
-   :kbd-hint       {:color            (:text-tertiary colors/tokens)
-                    :font-size        (:nano typography/type-scale)
+   :kbd-hint       {:color            (:text-tertiary rf.story.theme.colors/tokens)
+                    :font-size        (:nano rf.story.theme.typography/type-scale)
                     :font-weight      "normal"
                     :text-transform   "none"
                     :letter-spacing   "0"}
@@ -55,41 +55,41 @@
                     :padding-right    "10px"
                     :padding-bottom   "4px"
                     :padding-left     "10px"
-                    :background       (:accent-amber colors/tokens)
-                    :color            (:text-on-accent colors/tokens)
+                    :background       (:accent-amber rf.story.theme.colors/tokens)
+                    :color            (:text-on-accent rf.story.theme.colors/tokens)
                     :border-style     "solid"
                     :border-width     "1px"
-                    :border-color     (:accent-amber colors/tokens)
+                    :border-color     (:accent-amber rf.story.theme.colors/tokens)
                     :border-radius    "3px"
                     :cursor           "pointer"
                     :font-family      mono-stack
-                    :font-size        (:caption typography/type-scale)
+                    :font-size        (:caption rf.story.theme.typography/type-scale)
                     :letter-spacing   "0.3px"}
    :ctrl-btn-soft  {:padding-top      "4px"
                     :padding-right    "10px"
                     :padding-bottom   "4px"
                     :padding-left     "10px"
-                    :background       (:bg-3 colors/tokens)
-                    :color            (:text-primary colors/tokens)
+                    :background       (:bg-3 rf.story.theme.colors/tokens)
+                    :color            (:text-primary rf.story.theme.colors/tokens)
                     :border-style     "solid"
                     :border-width     "1px"
-                    :border-color     (:border-strong colors/tokens)
+                    :border-color     (:border-strong rf.story.theme.colors/tokens)
                     :border-radius    "3px"
                     :cursor           "pointer"
                     :font-family      mono-stack
-                    :font-size        (:caption typography/type-scale)
+                    :font-size        (:caption rf.story.theme.typography/type-scale)
                     :letter-spacing   "0.3px"}
    :ctrl-btn-disabled
-                   {:background       (:bg-2 colors/tokens)
-                    :color            (:text-tertiary colors/tokens)
-                    :border-color     (:border-default colors/tokens)
+                   {:background       (:bg-2 rf.story.theme.colors/tokens)
+                    :color            (:text-tertiary rf.story.theme.colors/tokens)
+                    :border-color     (:border-default rf.story.theme.colors/tokens)
                     :cursor           "not-allowed"}
-   :ctrl-btn-armed {:background       (:breakpoint-ctrl-bg colors/tokens)
-                    :color            (:breakpoint-ring colors/tokens)
-                    :border-color     (:breakpoint-ctrl-bd colors/tokens)}
+   :ctrl-btn-armed {:background       (:breakpoint-ctrl-bg rf.story.theme.colors/tokens)
+                    :color            (:breakpoint-ring rf.story.theme.colors/tokens)
+                    :border-color     (:breakpoint-ctrl-bd rf.story.theme.colors/tokens)}
    :ctrl-divider   {:width            "1px"
                     :height           "16px"
-                    :background       (:border-default colors/tokens)
+                    :background       (:border-default rf.story.theme.colors/tokens)
                     :margin           "0 2px"}
 
    ;; ---- step list ------------------------------------------------------
@@ -99,7 +99,7 @@
                     :margin           "4px 0 2px 0"
                     :max-height       "180px"
                     :overflow-y       "auto"
-                    :border-top       (str "1px solid " (:border-subtle colors/tokens))
+                    :border-top       (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
                     :padding-top      "6px"}
    :step-row       {:display              "flex"
                     :align-items          "center"
@@ -109,8 +109,8 @@
                     :padding-bottom       "3px"
                     :padding-left         "6px"
                     :font-family          mono-stack
-                    :font-size            (:caption typography/type-scale)
-                    :color                (:text-primary colors/tokens)
+                    :font-size            (:caption rf.story.theme.typography/type-scale)
+                    :color                (:text-primary rf.story.theme.colors/tokens)
                     :cursor               "pointer"
                     :border-radius        "3px"
                     :border-left-style    "solid"
@@ -118,41 +118,41 @@
                     :border-left-color    "transparent"
                     :line-height          "1.4"}
    :step-row-current
-                   {:background           (:scrub-row-bg colors/tokens)
-                    :color                (:text-primary colors/tokens)
-                    :border-left-color    (:info colors/tokens)
+                   {:background           (:scrub-row-bg rf.story.theme.colors/tokens)
+                    :color                (:text-primary rf.story.theme.colors/tokens)
+                    :border-left-color    (:info rf.story.theme.colors/tokens)
                     :padding-left         "3px"}
    :step-row-done  {:opacity              "0.65"}
-   :step-row-pending {:color              (:text-tertiary colors/tokens)}
-   :step-row-bp    {:background           (:breakpoint-bg colors/tokens)
+   :step-row-pending {:color              (:text-tertiary rf.story.theme.colors/tokens)}
+   :step-row-bp    {:background           (:breakpoint-bg rf.story.theme.colors/tokens)
                     :outline-style        "dashed"
                     :outline-width        "1px"
-                    :outline-color        (:breakpoint-ring colors/tokens)
+                    :outline-color        (:breakpoint-ring rf.story.theme.colors/tokens)
                     :outline-offset       "-1px"}
    :step-row-bp-current
-                   {:background           (:breakpoint-active colors/tokens)
+                   {:background           (:breakpoint-active rf.story.theme.colors/tokens)
                     :outline-style        "solid"
                     :outline-width        "1px"
-                    :outline-color        (:breakpoint-ring colors/tokens)
+                    :outline-color        (:breakpoint-ring rf.story.theme.colors/tokens)
                     :outline-offset       "-1px"}
    :step-glyph     {:width            "14px"
                     :text-align       "center"
-                    :font-size        (:caption typography/type-scale)
+                    :font-size        (:caption rf.story.theme.typography/type-scale)
                     :line-height      "1"}
-   :step-index     {:color            (:text-tertiary colors/tokens)
-                    :font-size        (:micro typography/type-scale)
+   :step-index     {:color            (:text-tertiary rf.story.theme.colors/tokens)
+                    :font-size        (:micro rf.story.theme.typography/type-scale)
                     :min-width        "24px"
                     :text-align       "right"}
    :step-label     {:flex             "1"
                     :overflow         "hidden"
                     :text-overflow    "ellipsis"
                     :white-space      "nowrap"}
-   :step-bp-chip   {:color            (:breakpoint-ring colors/tokens)
-                    :font-size        (:micro typography/type-scale)
+   :step-bp-chip   {:color            (:breakpoint-ring rf.story.theme.colors/tokens)
+                    :font-size        (:micro rf.story.theme.typography/type-scale)
                     :background       "transparent"
                     :border-style     "solid"
                     :border-width     "1px"
-                    :border-color     (:breakpoint-ring colors/tokens)
+                    :border-color     (:breakpoint-ring rf.story.theme.colors/tokens)
                     :border-radius    "2px"
                     :padding-top      "0"
                     :padding-right    "4px"
@@ -162,14 +162,14 @@
                     :font-family      mono-stack}
 
    ;; outcome tinting (small)
-   :outcome-pass   {:color            (:success colors/tokens)}
-   :outcome-fail   {:color            (:danger colors/tokens)}
-   :outcome-skip   {:color            (:text-tertiary colors/tokens)}
-   :outcome-event  {:color            (:text-secondary colors/tokens)}
+   :outcome-pass   {:color            (:success rf.story.theme.colors/tokens)}
+   :outcome-fail   {:color            (:danger rf.story.theme.colors/tokens)}
+   :outcome-skip   {:color            (:text-tertiary rf.story.theme.colors/tokens)}
+   :outcome-event  {:color            (:text-secondary rf.story.theme.colors/tokens)}
 
    ;; ---- inactive placeholder ------------------------------------------
    :inactive       {:padding          "6px 0"
-                    :color            (:text-tertiary colors/tokens)
+                    :color            (:text-tertiary rf.story.theme.colors/tokens)
                     :font-family      mono-stack
-                    :font-size        (:caption typography/type-scale)
+                    :font-size        (:caption rf.story.theme.typography/type-scale)
                     :font-style       "italic"}})

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_view.cljs
@@ -36,9 +36,9 @@
   variant frame) but not the variant's authoring shape — same posture
   as the Re-run button (spec/009)."
   (:require [reagent.core                                  :as r]
-            [re-frame.story.predicates                     :as pred]
-            [re-frame.story.ui.test-mode.stepper-pure      :as pure]
-            [re-frame.story.ui.test-mode.stepper-state     :as state]
+            [re-frame.story.predicates                     :as rf.story.predicates]
+            [re-frame.story.ui.test-mode.stepper-pure      :as rf.story.ui.test-mode.stepper-pure]
+            [re-frame.story.ui.test-mode.stepper-state     :as rf.story.ui.test-mode.stepper-state]
             [re-frame.story.ui.test-mode.stepper-styles    :refer [styles]]))
 
 ;; ---- glyphs -------------------------------------------------------------
@@ -52,7 +52,7 @@
     :pending "○"
     ;; Done rows show the shared assertion-outcome glyph
     ;; (`predicates/assertion-glyph`); :event + unknown fall to the bullet.
-    :done    (get pred/assertion-glyph outcome "•")
+    :done    (get rf.story.predicates/assertion-glyph outcome "•")
     "·"))
 
 (defn- outcome-style [{:keys [outcome]}]
@@ -90,11 +90,11 @@
 (defn- controls-strip
   [variant-id slot]
   (let [{:keys [active? auto-playing?]} slot
-        step?       (pure/can-step? slot)
-        back?       (pure/can-step-back? slot)
-        rewind?     (pure/can-rewind? slot)
-        pause?      (pure/can-pause? slot)
-        resume?     (pure/can-resume? slot)]
+        step?       (rf.story.ui.test-mode.stepper-pure/can-step? slot)
+        back?       (rf.story.ui.test-mode.stepper-pure/can-step-back? slot)
+        rewind?     (rf.story.ui.test-mode.stepper-pure/can-rewind? slot)
+        pause?      (rf.story.ui.test-mode.stepper-pure/can-pause? slot)
+        resume?     (rf.story.ui.test-mode.stepper-pure/can-resume? slot)]
     (into
       [:div {:style     (:ctrl-row styles)
              :data-test "story-stepper-controls"}
@@ -105,14 +105,14 @@
             :title     "Start a step-by-step play run (re-allocates the frame)"
             :enabled?  true
             :style-key :primary
-            :on-click  (fn [] (state/begin! variant-id))})
+            :on-click  (fn [] (rf.story.ui.test-mode.stepper-state/begin! variant-id))})
          (ctrl-btn
            {:label     "Stop"
             :data-test "story-stepper-stop"
             :title     "Stop the stepper (tear down, return to Re-run mode)"
             :enabled?  true
             :style-key :soft
-            :on-click  (fn [] (state/end! variant-id))}))]
+            :on-click  (fn [] (rf.story.ui.test-mode.stepper-state/end! variant-id))}))]
       (when active?
         [[:div {:style (:ctrl-divider styles)}]
          (ctrl-btn
@@ -121,14 +121,14 @@
             :title     "Step back one event (restores the prior epoch)"
             :enabled?  back?
             :style-key :soft
-            :on-click  (fn [] (state/step-back! variant-id))})
+            :on-click  (fn [] (rf.story.ui.test-mode.stepper-state/step-back! variant-id))})
          (ctrl-btn
            {:label     "Step →"
             :data-test "story-stepper-step"
             :title     "Dispatch the next play event"
             :enabled?  step?
             :style-key :primary
-            :on-click  (fn [] (state/step! variant-id))})
+            :on-click  (fn [] (rf.story.ui.test-mode.stepper-state/step! variant-id))})
          [:div {:style (:ctrl-divider styles)}]
          (if auto-playing?
            (ctrl-btn
@@ -138,14 +138,14 @@
               :enabled?  pause?
               :armed?    true
               :style-key :soft
-              :on-click  (fn [] (state/pause! variant-id))})
+              :on-click  (fn [] (rf.story.ui.test-mode.stepper-state/pause! variant-id))})
            (ctrl-btn
              {:label     "▶ Play"
               :data-test "story-stepper-resume"
               :title     "Auto-play (Space)"
               :enabled?  resume?
               :style-key :soft
-              :on-click  (fn [] (state/resume! variant-id))}))
+              :on-click  (fn [] (rf.story.ui.test-mode.stepper-state/resume! variant-id))}))
          [:div {:style (:ctrl-divider styles)}]
          (ctrl-btn
            {:label     "↺ Rewind"
@@ -153,7 +153,7 @@
             :title     "Restore the pre-play state (R)"
             :enabled?  rewind?
             :style-key :soft
-            :on-click  (fn [] (state/rewind! variant-id))})]))))
+            :on-click  (fn [] (rf.story.ui.test-mode.stepper-state/rewind! variant-id))})]))))
 
 ;; ---- step row -----------------------------------------------------------
 
@@ -175,7 +175,7 @@
            :data-index  (str index)
            :data-position (name position)
            :data-breakpoint (str (boolean bp?))
-           :on-click    (fn [_] (state/toggle-breakpoint! variant-id index))
+           :on-click    (fn [_] (rf.story.ui.test-mode.stepper-state/toggle-breakpoint! variant-id index))
            :title       (str "Click to toggle breakpoint at step " (inc index))}
      [:span {:style (merge (:step-glyph styles) (outcome-style row))}
       (position-glyph row)]
@@ -189,7 +189,7 @@
                :title        (if bp? "Remove breakpoint" "Set breakpoint")
                :on-click     (fn [e]
                                (.stopPropagation e)
-                               (state/toggle-breakpoint! variant-id index))}
+                               (rf.story.ui.test-mode.stepper-state/toggle-breakpoint! variant-id index))}
       (if bp? "● BP" "◯ BP")]]))
 
 (defn- step-list
@@ -212,14 +212,14 @@
     (let [k (.-key e)]
       (case k
         " "          (do (.preventDefault e)
-                         (let [s (get @state/results-atom variant-id)]
+                         (let [s (get @rf.story.ui.test-mode.stepper-state/results-atom variant-id)]
                            (if (:auto-playing? s)
-                             (state/pause! variant-id)
-                             (state/resume! variant-id))))
-        "ArrowRight" (do (.preventDefault e) (state/step! variant-id))
-        "ArrowLeft"  (do (.preventDefault e) (state/step-back! variant-id))
-        ("r" "R")    (do (.preventDefault e) (state/rewind! variant-id))
-        "Escape"     (do (.preventDefault e) (state/end! variant-id))
+                             (rf.story.ui.test-mode.stepper-state/pause! variant-id)
+                             (rf.story.ui.test-mode.stepper-state/resume! variant-id))))
+        "ArrowRight" (do (.preventDefault e) (rf.story.ui.test-mode.stepper-state/step! variant-id))
+        "ArrowLeft"  (do (.preventDefault e) (rf.story.ui.test-mode.stepper-state/step-back! variant-id))
+        ("r" "R")    (do (.preventDefault e) (rf.story.ui.test-mode.stepper-state/rewind! variant-id))
+        "Escape"     (do (.preventDefault e) (rf.story.ui.test-mode.stepper-state/end! variant-id))
         nil))))
 
 ;; ---- top-level component ------------------------------------------------
@@ -233,7 +233,7 @@
       (when active?
         [:span {:style     (:progress styles)
                 :data-test "story-stepper-progress"}
-         (str " · " (pure/progress-label cursor total)
+         (str " · " (rf.story.ui.test-mode.stepper-pure/progress-label cursor total)
               (when auto-playing? " · playing"))])]
      [:span {:style (:kbd-hint styles)}
       "Space pause · → step · ← back · R rewind"]]))
@@ -281,8 +281,8 @@
          ;; If the user navigates away while a stepper is in flight,
          ;; tear it down so we don't leak the interval or the
          ;; substrate's per-frame state.
-         (when (get @state/results-atom variant-id)
-           (state/end! variant-id)))
+         (when (get @rf.story.ui.test-mode.stepper-state/results-atom variant-id)
+           (rf.story.ui.test-mode.stepper-state/end! variant-id)))
        :reagent-render
        (fn [variant-id]
-         (render-section variant-id (get @state/results-atom variant-id)))})))
+         (render-section variant-id (get @rf.story.ui.test-mode.stepper-state/results-atom variant-id)))})))

--- a/tools/story/src/re_frame/story/ui/test_mode/view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/view.cljs
@@ -75,17 +75,17 @@
   `(when config/enabled? ...)`-gated mount call, so production builds
   never invoke it — closure DCEs the lot."
   (:require [reagent.core                              :as r]
-            [re-frame.story.predicates                 :as pred]
-            [re-frame.story.ui.open-in-editor          :as open-in-editor]
-            [re-frame.story.ui.promotion               :as promotion]
-            [re-frame.story.ui.state                   :as shell-state]
-            [re-frame.story.ui.test-mode.pure          :as pure]
-            [re-frame.story.ui.test-mode.state         :as state]
-            [re-frame.story.ui.test-mode.stepper-view  :as stepper-view]
-            [re-frame.story.ui.test-mode.visual-a11y-view :as visual-a11y-view]
+            [re-frame.story.predicates                 :as rf.story.predicates]
+            [re-frame.story.ui.open-in-editor          :as rf.story.ui.open-in-editor]
+            [re-frame.story.ui.promotion               :as rf.story.ui.promotion]
+            [re-frame.story.ui.state                   :as rf.story.ui.state]
+            [re-frame.story.ui.test-mode.pure          :as rf.story.ui.test-mode.pure]
+            [re-frame.story.ui.test-mode.state         :as rf.story.ui.test-mode.state]
+            [re-frame.story.ui.test-mode.stepper-view  :as rf.story.ui.test-mode.stepper-view]
+            [re-frame.story.ui.test-mode.visual-a11y-view :as rf.story.ui.test-mode.visual-a11y-view]
             [re-frame.story.ui.test-mode.view-styles   :refer [styles]]
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; Styles live in `re-frame.story.ui.test-mode.view-styles` (pure-data
 ;; leaf, no Reagent dep). Required as `styles` above so the in-file
@@ -96,12 +96,12 @@
 (defn- header
   "Variant id + parent story id + Re-run button + last-run badge."
   [variant-id]
-  (let [slot       (get @state/results-atom variant-id)
+  (let [slot       (get @rf.story.ui.test-mode.state/results-atom variant-id)
         running?   (:running? slot)
         ran-at-ms  (:ran-at-ms slot)
         result     (:result slot)
         elapsed    (:elapsed-ms result)
-        story-id   (pred/parent-story-id variant-id)]
+        story-id   (rf.story.predicates/parent-story-id variant-id)]
     [:div
      [:h1 {:style (:h1 styles)} (str variant-id)]
      [:div {:style     (:sub styles)
@@ -116,17 +116,17 @@
         :data-test      "story-test-rerun"
         :disabled       running?
         :aria-label     "Re-run the variant's :script sequence"
-        :on-click       (fn [_] (when-not running? (state/run-variant-pane! variant-id)))}
+        :on-click       (fn [_] (when-not running? (rf.story.ui.test-mode.state/run-variant-pane! variant-id)))}
        (if running? "Running…" "Re-run")]
       [:div {:style (:last-run styles)}
        (when ran-at-ms
          [:span {:data-test "story-test-timestamp"}
-          (str "ran " (pure/format-timestamp-ms ran-at-ms))])
+          (str "ran " (rf.story.ui.test-mode.pure/format-timestamp-ms ran-at-ms))])
        (when (and ran-at-ms elapsed)
          [:span " · "])
        (when (number? elapsed)
          [:span {:data-test "story-test-elapsed"}
-          (pure/format-elapsed-ms elapsed)])]]
+          (rf.story.ui.test-mode.pure/format-elapsed-ms elapsed)])]]
      ;; runner selected vs required (spec/021 §1). The unified result
      ;; threads `:runner` / `:required-runner` verbatim; render an honest
      ;; "—" when the host did not stamp them.
@@ -151,17 +151,17 @@
   executed; the renderer composes its own placeholder in that interim
   state."
   [variant-id]
-  (let [slot   (get @state/results-atom variant-id)
+  (let [slot   (get @rf.story.ui.test-mode.state/results-atom variant-id)
         result (:result slot)]
     (when result
-      (let [summary (shell-state/aggregate-summary (:assertions result))
+      (let [summary (rf.story.ui.state/aggregate-summary (:assertions result))
             {:keys [passed failed cannot-run total]} summary
             cannot-run (or cannot-run 0)
             ;; the unified run-level verdict (spec/021 §1), via the pure
             ;; projection. A tape-floor `:fail` / `:cannot-run`
             ;; refusal / `:error` surfaces even when assertion counts alone
             ;; would read green.
-            status     (pure/run-status result summary)
+            status     (rf.story.ui.test-mode.pure/run-status result summary)
             pill-style (case status
                          :pass       (:pill-pass styles)
                          :error      (:pill-error styles)
@@ -207,7 +207,7 @@
   `predicates/assertion-glyph` vocabulary), · for plain events / unknown.
   Pure-data; doesn't reach into ratoms."
   [status]
-  (get pred/assertion-glyph status "·"))
+  (get rf.story.predicates/assertion-glyph status "·"))
 
 (defn- scrubber-section
   "Step-through scrubber. One tick per play event with
@@ -220,28 +220,28 @@
   the ring buffer was disabled), the section short-circuits to a
   muted hint rather than a broken scrubber."
   [variant-id]
-  (let [slot          (get @state/results-atom variant-id)
+  (let [slot          (get @rf.story.ui.test-mode.state/results-atom variant-id)
         result        (:result slot)
         play-events   (or (:play-events slot) [])
         epoch-ids     (or (:epoch-ids slot) [])
         selected-step (:selected-step slot)
         n             (count play-events)]
     (when (and result (pos? n))
-      (let [statuses (pure/play-step-statuses play-events (:assertions result))
+      (let [statuses (rf.story.ui.test-mode.pure/play-step-statuses play-events (:assertions result))
             has-epochs? (= n (count epoch-ids))]
         [:div {:style     (merge (:section styles) (:scrub-wrap styles))
                :data-test "story-test-scrubber-section"}
          [:div {:style (:scrub-h styles)}
           [:span "Step-through"]
-          [:span {:style {:color (:text-tertiary colors/tokens) :font-weight "normal"}}
+          [:span {:style {:color (:text-tertiary rf.story.theme.colors/tokens) :font-weight "normal"}}
            (cond
              (not has-epochs?)        (str n " steps · no epoch buffer")
              (some? selected-step)    (str "step " (inc selected-step) "/" n)
              :else                    (str n " steps"))]]
          (if-not has-epochs?
-           [:div {:style     {:color       (:text-tertiary colors/tokens)
+           [:div {:style     {:color       (:text-tertiary rf.story.theme.colors/tokens)
                               :font-style  "italic"
-                              :font-size   (:caption typography/type-scale)
+                              :font-size   (:caption rf.story.theme.typography/type-scale)
                               :font-family mono-stack}
                   :data-test "story-test-scrubber-no-epochs"}
             "epoch buffer empty — scrubber unavailable (run is non-elided?)"]
@@ -258,7 +258,7 @@
                        :data-index  (str index)
                        :data-status (name status)
                        :title       (str "step " (inc index) " · " label)
-                       :on-click    (fn [_] (state/select-step! variant-id index))}
+                       :on-click    (fn [_] (rf.story.ui.test-mode.state/select-step! variant-id index))}
                 (step-glyph status)])]
             [:input {:type        "range"
                      :min         0
@@ -270,7 +270,7 @@
                      :on-change   (fn [e]
                                     (let [idx (js/parseInt
                                                 (.. e -target -value))]
-                                      (state/select-step! variant-id idx)))}]
+                                      (rf.story.ui.test-mode.state/select-step! variant-id idx)))}]
             [:div {:style (:scrub-detail styles)}
              (when (some? selected-step)
                (let [step (nth statuses selected-step nil)]
@@ -279,7 +279,7 @@
              (when (some? selected-step)
                [:button {:style     (:scrub-release styles)
                          :data-test "story-test-scrubber-release"
-                         :on-click  (fn [_] (state/select-step! variant-id nil))}
+                         :on-click  (fn [_] (rf.story.ui.test-mode.state/select-step! variant-id nil))}
                 "release"])]])]))))
 
 (defn- row-detail
@@ -337,7 +337,7 @@
       ;; per-assertion 'Open in editor' chip — surfaces the
       ;; assertion's source-coord (the play-step site, captured by the
       ;; assertion's record builder per spec/004).
-      (open-in-editor/open-chip source :test-detail)])])
+      (rf.story.ui.open-in-editor/open-chip source :test-detail)])])
 
 (defn- status-glyph
   [status]
@@ -386,7 +386,7 @@
             [:div
              [:button
               {:style    (:details-tog styles)
-               :on-click (fn [_] (state/toggle-expanded! variant-id rk))
+               :on-click (fn [_] (rf.story.ui.test-mode.state/toggle-expanded! variant-id rk))
                :aria-expanded (if open? "true" "false")}
               (if open? "hide detail" "show detail")]
              (when open? (row-detail (:detail row)))]
@@ -409,7 +409,7 @@
                             (when failed-only? (:filter-on styles)))
      :data-test      "story-test-failed-only"
      :aria-pressed   (if failed-only? "true" "false")
-     :on-click       (fn [_] (state/set-failed-only! variant-id (not failed-only?)))}
+     :on-click       (fn [_] (rf.story.ui.test-mode.state/set-failed-only! variant-id (not failed-only?)))}
     (if failed-only? "✓ failed only" "failed only")]
    (when (and failed-only? (pos? hidden))
      [:span {:style     (:filter-hint styles)
@@ -423,14 +423,14 @@
   filter. Empty when no run has executed; renders nothing when the run
   recorded zero assertions (the summary pill already told the user)."
   [variant-id]
-  (let [slot         (get @state/results-atom variant-id)
+  (let [slot         (get @rf.story.ui.test-mode.state/results-atom variant-id)
         result       (:result slot)
         expanded     (or (:expanded slot) #{})
         failed-only? (boolean (:failed-only? slot))]
     (when result
-      (let [all-rows (mapv pure/assertion-row (:assertions result))]
+      (let [all-rows (mapv rf.story.ui.test-mode.pure/assertion-row (:assertions result))]
         (when (seq all-rows)
-          (let [shown  (pure/filter-rows all-rows failed-only?)
+          (let [shown  (rf.story.ui.test-mode.pure/filter-rows all-rows failed-only?)
                 hidden (- (count all-rows) (count shown))]
             [:div {:style     (:section styles)
                    :data-test "story-test-rows-section"}
@@ -448,10 +448,10 @@
   Renders nothing when the plan declared no checks (the common case
   today — an honest empty state, never a fabricated check group)."
   [variant-id]
-  (let [slot     (get @state/results-atom variant-id)
+  (let [slot     (get @rf.story.ui.test-mode.state/results-atom variant-id)
         result   (:result slot)
         expanded (or (:expanded slot) #{})
-        checks   (some-> result pure/check-rows)
+        checks   (some-> result rf.story.ui.test-mode.pure/check-rows)
         expanded-checks (or (:expanded-checks slot) #{})]
     (when (seq checks)
       [:div {:style     (:section styles)
@@ -464,7 +464,7 @@
                   :data-test "story-test-check"
                   :data-status (name status)}
             [:div {:style    (:check-head styles)
-                   :on-click (fn [_] (state/toggle-check! variant-id check))
+                   :on-click (fn [_] (rf.story.ui.test-mode.state/toggle-check! variant-id check))
                    :aria-expanded (if open? "true" "false")}
              (status-glyph status)
              [:span {:style (:check-id styles)} (str check)]
@@ -480,9 +480,9 @@
   unconsumed ones (spec/021 §1). Renders nothing when the tape carried no
   schema violations."
   [variant-id]
-  (let [slot   (get @state/results-atom variant-id)
+  (let [slot   (get @rf.story.ui.test-mode.state/results-atom variant-id)
         result (:result slot)
-        rows   (some-> result pure/schema-rows)]
+        rows   (some-> result rf.story.ui.test-mode.pure/schema-rows)]
     (when (seq rows)
       [:div {:style     (:section styles)
              :data-test "story-test-schema-section"}
@@ -514,9 +514,9 @@
   what was AVAILABLE, so it reads as a refusal rather than a failure.
   Renders nothing when the chosen runner satisfied every requirement."
   [variant-id]
-  (let [slot   (get @state/results-atom variant-id)
+  (let [slot   (get @rf.story.ui.test-mode.state/results-atom variant-id)
         result (:result slot)
-        rows   (some-> result pure/cannot-run-rows)]
+        rows   (some-> result rf.story.ui.test-mode.pure/cannot-run-rows)]
     (when (seq rows)
       [:div {:style     (:section styles)
              :data-test "story-test-cannot-run-section"}
@@ -547,10 +547,10 @@
   run retained an epoch tape the link target exists but the surface is
   pending; otherwise there is no evidence to link. No fabricated link."
   [variant-id]
-  (let [slot   (get @state/results-atom variant-id)
+  (let [slot   (get @rf.story.ui.test-mode.state/results-atom variant-id)
         result (:result slot)]
     (when result
-      (let [evidence? (pure/evidence-available? result)]
+      (let [evidence? (rf.story.ui.test-mode.pure/evidence-available? result)]
         [:div {:style     (:evidence-row styles)
                :data-test "story-test-evidence-row"
                :data-evidence (str evidence?)}
@@ -575,33 +575,33 @@
   Renders nothing until a run has produced a capturable program — promotion
   needs a replayable artifact, so a bare pending slot offers no button."
   [variant-id]
-  (let [slot        (get @state/results-atom variant-id)
+  (let [slot        (get @rf.story.ui.test-mode.state/results-atom variant-id)
         result      (:result slot)
         play-events (or (:play-events slot) [])]
     (when (and result
-               (some? (promotion/result->artifact result play-events)))
+               (some? (rf.story.ui.promotion/result->artifact result play-events)))
       [:div {:style     (:evidence-row styles)
              :data-test "story-test-promotion-row"}
        [:button
         {:style     {:padding       "4px 10px"
-                     :background    (:bg-3 colors/tokens)
-                     :color         (:text-secondary colors/tokens)
-                     :border        (str "1px solid " (:border-default colors/tokens))
+                     :background    (:bg-3 rf.story.theme.colors/tokens)
+                     :color         (:text-secondary rf.story.theme.colors/tokens)
+                     :border        (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                      :border-radius "6px"
                      :cursor        "pointer"
                      :font-family   mono-stack
-                     :font-size     (:caption typography/type-scale)}
+                     :font-size     (:caption rf.story.theme.typography/type-scale)}
          :data-test "story-test-promote-button"
          :title     "Capture this run as an artifact and promote it to a curated regression variant"
          :on-click  (fn [_]
-                      (when-let [id (promotion/capture-from-result!
+                      (when-let [id (rf.story.ui.promotion/capture-from-result!
                                       result play-events variant-id)]
-                        (promotion/open! id)))}
+                        (rf.story.ui.promotion/open! id)))}
         "promote run → regression variant…"]
        [:span {:style {:margin-left "8px"
-                       :color (:text-tertiary colors/tokens)
+                       :color (:text-tertiary rf.story.theme.colors/tokens)
                        :font-style "italic"
-                       :font-size (:micro typography/type-scale)}}
+                       :font-size (:micro rf.story.theme.typography/type-scale)}}
         "captures this run as evidence; distinct from save-current-state"]])))
 
 (defn- empty-state
@@ -610,7 +610,7 @@
   [:div {:style     (:empty styles)
          :data-test "story-test-empty"}
    [:div {:style {:font-weight "bold" :margin-bottom "8px"
-                  :color (:text-primary colors/tokens)}}
+                  :color (:text-primary rf.story.theme.colors/tokens)}}
     "No tests registered for this variant"]
    [:div
     "Add a "
@@ -666,11 +666,11 @@
         ;; a reconciled prop swap). If a slot already exists (returning
         ;; to the tab without a variant change) we don't re-fire — the
         ;; user clicks Re-run to refresh.
-        (when (and (pure/variant-has-tests? variant-id)
-                   (not (get @state/results-atom variant-id)))
-          (state/run-variant-pane! variant-id)))
+        (when (and (rf.story.ui.test-mode.pure/variant-has-tests? variant-id)
+                   (not (get @rf.story.ui.test-mode.state/results-atom variant-id)))
+          (rf.story.ui.test-mode.state/run-variant-pane! variant-id)))
       (cond
-        (not (pure/variant-has-tests? variant-id))
+        (not (rf.story.ui.test-mode.pure/variant-has-tests? variant-id))
         [:section {:style     (:wrap styles)
                    :data-test "story-test-view"
                    :aria-label "Variant tests"}
@@ -687,7 +687,7 @@
          ;; script-checkpoint, with the failed-only filter), schema
          ;; violations (consumed + unconsumed), and cannot-run refusals.
          [checks-section variant-id]
-         [stepper-view/stepper-section variant-id]
+         [rf.story.ui.test-mode.stepper-view/stepper-section variant-id]
          [scrubber-section variant-id]
          [rows-section variant-id]
          [schema-section variant-id]
@@ -699,7 +699,7 @@
          ;; finding+locus list; screenshot identity; honest cannot-run),
          ;; rather than as the raw `:actual` EDN blob the generic
          ;; assertions table would show.
-         [visual-a11y-view/visual-a11y-section variant-id]
+         [rf.story.ui.test-mode.visual-a11y-view/visual-a11y-section variant-id]
          ;; result → evidence-spine link (spec/021 §2),
          ;; a graceful "evidence pending" until the spine display lands.
          [evidence-section variant-id]

--- a/tools/story/src/re_frame/story/ui/test_mode/view_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/view_styles.cljs
@@ -4,26 +4,26 @@
   view ns drops below the 250-LoC leaf-size ceiling (rf2-zkca8).
 
   CLJS-only — the JVM pure helpers don't need styles."
-  (:require [re-frame.story.theme.typography :as typography :refer [sans-stack mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+  (:require [re-frame.story.theme.typography :as rf.story.theme.typography :refer [sans-stack mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 (def styles
   {:wrap          {:flex             "1"
                    :overflow         "auto"
                    :padding          "20px 28px"
-                   :background       (:bg-canvas colors/tokens)
-                   :color            (:text-primary colors/tokens)
+                   :background       (:bg-canvas rf.story.theme.colors/tokens)
+                   :color            (:text-primary rf.story.theme.colors/tokens)
                    :font-family      sans-stack
-                   :font-size        (:body typography/type-scale)
+                   :font-size        (:body rf.story.theme.typography/type-scale)
                    :line-height      "1.5"}
    :h1            {:font-family      mono-stack
-                   :font-size        (:display typography/type-scale)
+                   :font-size        (:display rf.story.theme.typography/type-scale)
                    :font-weight      "bold"
-                   :color            (:text-primary colors/tokens)
+                   :color            (:text-primary rf.story.theme.colors/tokens)
                    :margin           "0 0 4px 0"}
-   :sub           {:color            (:text-secondary colors/tokens)
+   :sub           {:color            (:text-secondary rf.story.theme.colors/tokens)
                    :font-family      mono-stack
-                   :font-size        (:caption typography/type-scale)
+                   :font-size        (:caption rf.story.theme.typography/type-scale)
                    :margin-bottom    "10px"}
    :header-row    {:display          "flex"
                    :justify-content  "space-between"
@@ -31,28 +31,28 @@
                    :gap              "12px"
                    :margin           "12px 0 8px 0"}
    :rerun-btn     {:padding          "6px 14px"
-                   :background       (:accent-amber colors/tokens)
-                   :color            (:text-on-accent colors/tokens)
+                   :background       (:accent-amber rf.story.theme.colors/tokens)
+                   :color            (:text-on-accent rf.story.theme.colors/tokens)
                    :border           "none"
                    :border-radius    "3px"
                    :cursor           "pointer"
                    :font-family      mono-stack
-                   :font-size        (:caption typography/type-scale)
+                   :font-size        (:caption rf.story.theme.typography/type-scale)
                    :letter-spacing   "0.3px"}
-   :rerun-running {:background       (:bg-3 colors/tokens)
-                   :color            (:text-secondary colors/tokens)
+   :rerun-running {:background       (:bg-3 rf.story.theme.colors/tokens)
+                   :color            (:text-secondary rf.story.theme.colors/tokens)
                    :cursor           "not-allowed"}
-   :last-run      {:color            (:text-secondary colors/tokens)
+   :last-run      {:color            (:text-secondary rf.story.theme.colors/tokens)
                    :font-family      mono-stack
-                   :font-size        (:micro typography/type-scale)}
+                   :font-size        (:micro rf.story.theme.typography/type-scale)}
    :section       {:margin-top       "16px"}
    :section-h     {:font-weight      "bold"
-                   :color            (:text-secondary colors/tokens)
+                   :color            (:text-secondary rf.story.theme.colors/tokens)
                    :text-transform   "uppercase"
-                   :font-size        (:micro typography/type-scale)
+                   :font-size        (:micro rf.story.theme.typography/type-scale)
                    :letter-spacing   "0.5px"
                    :margin-bottom    "8px"
-                   :border-bottom    (str "1px solid " (:border-default colors/tokens))
+                   :border-bottom    (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                    :padding-bottom   "4px"}
    :pill-row      {:display          "flex"
                    :align-items      "center"
@@ -61,84 +61,84 @@
    :pill          {:padding          "4px 10px"
                    :border-radius    "10px"
                    :font-family      mono-stack
-                   :font-size        (:caption typography/type-scale)
+                   :font-size        (:caption rf.story.theme.typography/type-scale)
                    :font-weight      "bold"
                    :text-transform   "uppercase"
                    :letter-spacing   "0.5px"}
-   :pill-pass     {:background       (:success-bg colors/tokens)
-                   :color            (:success colors/tokens)}
-   :pill-fail     {:background       (:danger-bg colors/tokens)
-                   :color            (:danger colors/tokens)}
-   :pill-empty    {:background       (:bg-3 colors/tokens)
-                   :color            (:text-secondary colors/tokens)}
+   :pill-pass     {:background       (:success-bg rf.story.theme.colors/tokens)
+                   :color            (:success rf.story.theme.colors/tokens)}
+   :pill-fail     {:background       (:danger-bg rf.story.theme.colors/tokens)
+                   :color            (:danger rf.story.theme.colors/tokens)}
+   :pill-empty    {:background       (:bg-3 rf.story.theme.colors/tokens)
+                   :color            (:text-secondary rf.story.theme.colors/tokens)}
    ;; rf2-ba86n.11 — `:error` reads as a louder fail; `:cannot-run` is the
    ;; distinct THIRD state (spec/018 §12.6 — visually distinct from
    ;; pass/fail/error); `:pending` is the muted never-run/no-signal state.
-   :pill-error    {:background       (:danger-bg colors/tokens)
-                   :color            (:danger colors/tokens)
-                   :border           (str "1px solid " (:danger colors/tokens))}
-   :pill-cannot   {:background       (:warning-bg colors/tokens)
-                   :color            (:warning colors/tokens)}
-   :pill-pending  {:background       (:bg-3 colors/tokens)
-                   :color            (:text-tertiary colors/tokens)}
-   :counts        {:color            (:text-secondary colors/tokens)
+   :pill-error    {:background       (:danger-bg rf.story.theme.colors/tokens)
+                   :color            (:danger rf.story.theme.colors/tokens)
+                   :border           (str "1px solid " (:danger rf.story.theme.colors/tokens))}
+   :pill-cannot   {:background       (:warning-bg rf.story.theme.colors/tokens)
+                   :color            (:warning rf.story.theme.colors/tokens)}
+   :pill-pending  {:background       (:bg-3 rf.story.theme.colors/tokens)
+                   :color            (:text-tertiary rf.story.theme.colors/tokens)}
+   :counts        {:color            (:text-secondary rf.story.theme.colors/tokens)
                    :font-family      mono-stack
-                   :font-size        (:caption typography/type-scale)}
-   :count-pass    {:color            (:success colors/tokens)}
-   :count-fail    {:color            (:danger colors/tokens)}
-   :count-skip    {:color            (:text-tertiary colors/tokens)}
+                   :font-size        (:caption rf.story.theme.typography/type-scale)}
+   :count-pass    {:color            (:success rf.story.theme.colors/tokens)}
+   :count-fail    {:color            (:danger rf.story.theme.colors/tokens)}
+   :count-skip    {:color            (:text-tertiary rf.story.theme.colors/tokens)}
    :table         {:width            "100%"
                    :border-collapse  "collapse"
                    :font-family      mono-stack
-                   :font-size        (:caption typography/type-scale)}
+                   :font-size        (:caption rf.story.theme.typography/type-scale)}
    :th            {:text-align       "left"
                    :padding          "6px 8px"
-                   :background       (:bg-2 colors/tokens)
-                   :color            (:text-secondary colors/tokens)
-                   :border-bottom    (str "1px solid " (:border-default colors/tokens))
+                   :background       (:bg-2 rf.story.theme.colors/tokens)
+                   :color            (:text-secondary rf.story.theme.colors/tokens)
+                   :border-bottom    (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                    :text-transform   "uppercase"
-                   :font-size        (:micro typography/type-scale)
+                   :font-size        (:micro rf.story.theme.typography/type-scale)
                    :letter-spacing   "0.5px"}
    :td            {:padding          "6px 8px"
-                   :border-bottom    (str "1px solid " (:border-subtle colors/tokens))
-                   :color            (:text-primary colors/tokens)
+                   :border-bottom    (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
+                   :color            (:text-primary rf.story.theme.colors/tokens)
                    :vertical-align   "top"}
    :td-status     {:width            "20px"
                    :text-align       "center"
-                   :font-size        (:display typography/type-scale)
+                   :font-size        (:display rf.story.theme.typography/type-scale)
                    :line-height      "1"}
-   :status-pass   {:color            (:success colors/tokens)}
-   :status-fail   {:color            (:danger colors/tokens)}
-   :status-skip   {:color            (:text-tertiary colors/tokens)}
-   :row-fail      {:background       (:row-fail-bg colors/tokens)}
+   :status-pass   {:color            (:success rf.story.theme.colors/tokens)}
+   :status-fail   {:color            (:danger rf.story.theme.colors/tokens)}
+   :status-skip   {:color            (:text-tertiary rf.story.theme.colors/tokens)}
+   :row-fail      {:background       (:row-fail-bg rf.story.theme.colors/tokens)}
    :details-tog   {:cursor           "pointer"
-                   :color            (:info colors/tokens)
+                   :color            (:info rf.story.theme.colors/tokens)
                    :background       "none"
                    :border           "none"
                    :font-family      mono-stack
-                   :font-size        (:caption typography/type-scale)
+                   :font-size        (:caption rf.story.theme.typography/type-scale)
                    :padding          "0"
                    :text-decoration  "underline"}
-   :detail-box    {:background       (:bg-2 colors/tokens)
-                   :border-left      (str "3px solid " (:danger colors/tokens))
+   :detail-box    {:background       (:bg-2 rf.story.theme.colors/tokens)
+                   :border-left      (str "3px solid " (:danger rf.story.theme.colors/tokens))
                    :padding          "8px 12px"
                    :margin-top       "6px"
-                   :color            (:text-primary colors/tokens)
+                   :color            (:text-primary rf.story.theme.colors/tokens)
                    :font-family      mono-stack
-                   :font-size        (:caption typography/type-scale)
+                   :font-size        (:caption rf.story.theme.typography/type-scale)
                    :white-space      "pre-wrap"}
-   :detail-key    {:color            (:info colors/tokens)}
-   :detail-source {:color            (:text-secondary colors/tokens)
-                   :font-size        (:micro typography/type-scale)
+   :detail-key    {:color            (:info rf.story.theme.colors/tokens)}
+   :detail-source {:color            (:text-secondary rf.story.theme.colors/tokens)
+                   :font-size        (:micro rf.story.theme.typography/type-scale)
                    :margin-top       "4px"}
    :empty         {:padding          "32px"
-                   :color            (:text-tertiary colors/tokens)
+                   :color            (:text-tertiary rf.story.theme.colors/tokens)
                    :font-style       "italic"
                    :font-family      sans-stack
                    :text-align       "center"
-                   :background       (:bg-canvas colors/tokens)
+                   :background       (:bg-canvas rf.story.theme.colors/tokens)
                    :flex             "1"}
-   :empty-link    {:color            (:info colors/tokens)
+   :empty-link    {:color            (:info rf.story.theme.colors/tokens)
                    :font-family      mono-stack
                    :margin-top       "8px"
                    :display          "block"}
@@ -150,16 +150,16 @@
                    :gap              "8px"
                    :flex-wrap        "wrap"
                    :margin-top       "6px"
-                   :color            (:text-secondary colors/tokens)
+                   :color            (:text-secondary rf.story.theme.colors/tokens)
                    :font-family      mono-stack
-                   :font-size        (:micro typography/type-scale)}
+                   :font-size        (:micro rf.story.theme.typography/type-scale)}
    :runner-badge  {:padding          "2px 7px"
                    :border-radius    "3px"
-                   :background       (:bg-3 colors/tokens)
-                   :color            (:text-primary colors/tokens)
+                   :background       (:bg-3 rf.story.theme.colors/tokens)
+                   :color            (:text-primary rf.story.theme.colors/tokens)
                    :font-family      mono-stack
-                   :font-size        (:micro typography/type-scale)}
-   :runner-key    {:color            (:text-tertiary colors/tokens)
+                   :font-size        (:micro rf.story.theme.typography/type-scale)}
+   :runner-key    {:color            (:text-tertiary rf.story.theme.colors/tokens)
                    :text-transform   "uppercase"
                    :letter-spacing   "0.4px"}
    ;; failed-only filter toggle (spec/021 §1)
@@ -168,96 +168,96 @@
                    :gap              "8px"
                    :margin-bottom    "8px"}
    :filter-toggle {:padding          "3px 10px"
-                   :border           (str "1px solid " (:border-strong colors/tokens))
+                   :border           (str "1px solid " (:border-strong rf.story.theme.colors/tokens))
                    :border-radius    "3px"
                    :background       "none"
-                   :color            (:text-secondary colors/tokens)
+                   :color            (:text-secondary rf.story.theme.colors/tokens)
                    :cursor           "pointer"
                    :font-family      mono-stack
-                   :font-size        (:micro typography/type-scale)}
-   :filter-on     {:background       (:accent-amber-soft colors/tokens)
-                   :color            (:accent-amber colors/tokens)
-                   :border           (str "1px solid " (:accent-amber-deep colors/tokens))}
-   :filter-hint   {:color            (:text-tertiary colors/tokens)
+                   :font-size        (:micro rf.story.theme.typography/type-scale)}
+   :filter-on     {:background       (:accent-amber-soft rf.story.theme.colors/tokens)
+                   :color            (:accent-amber rf.story.theme.colors/tokens)
+                   :border           (str "1px solid " (:accent-amber-deep rf.story.theme.colors/tokens))}
+   :filter-hint   {:color            (:text-tertiary rf.story.theme.colors/tokens)
                    :font-family      mono-stack
-                   :font-size        (:micro typography/type-scale)}
+                   :font-size        (:micro rf.story.theme.typography/type-scale)}
    ;; checks grouped by check id (spec/021 §1)
-   :check-box     {:border           (str "1px solid " (:border-subtle colors/tokens))
+   :check-box     {:border           (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
                    :border-radius    "4px"
                    :margin-bottom    "6px"
-                   :background       (:bg-2 colors/tokens)}
+                   :background       (:bg-2 rf.story.theme.colors/tokens)}
    :check-head    {:display          "flex"
                    :align-items      "center"
                    :gap              "8px"
                    :padding          "6px 10px"
                    :cursor           "pointer"
                    :font-family      mono-stack
-                   :font-size        (:caption typography/type-scale)}
-   :check-id      {:color            (:text-primary colors/tokens)
+                   :font-size        (:caption rf.story.theme.typography/type-scale)}
+   :check-id      {:color            (:text-primary rf.story.theme.colors/tokens)
                    :font-weight      "bold"}
-   :check-counts  {:color            (:text-secondary colors/tokens)
-                   :font-size        (:micro typography/type-scale)
+   :check-counts  {:color            (:text-secondary rf.story.theme.colors/tokens)
+                   :font-size        (:micro rf.story.theme.typography/type-scale)
                    :margin-left      "auto"}
    :check-body    {:padding          "0 10px 8px 10px"}
    ;; schema-violation rows (spec/021 §1)
    :schema-row    {:padding          "6px 10px"
                    :border-left      "3px solid"
                    :margin-bottom    "5px"
-                   :background       (:bg-2 colors/tokens)
+                   :background       (:bg-2 rf.story.theme.colors/tokens)
                    :font-family      mono-stack
-                   :font-size        (:caption typography/type-scale)}
-   :schema-consumed {:border-left-color (:success colors/tokens)}
-   :schema-unconsumed {:border-left-color (:danger colors/tokens)}
+                   :font-size        (:caption rf.story.theme.typography/type-scale)}
+   :schema-consumed {:border-left-color (:success rf.story.theme.colors/tokens)}
+   :schema-unconsumed {:border-left-color (:danger rf.story.theme.colors/tokens)}
    :schema-tag    {:display          "inline-block"
                    :padding          "1px 6px"
                    :border-radius    "8px"
-                   :font-size        (:micro typography/type-scale)
+                   :font-size        (:micro rf.story.theme.typography/type-scale)
                    :text-transform   "uppercase"
                    :letter-spacing   "0.4px"
                    :margin-right     "8px"}
-   :schema-tag-ok {:background       (:success-bg colors/tokens)
-                   :color            (:success colors/tokens)}
-   :schema-tag-bad {:background      (:danger-bg colors/tokens)
-                   :color            (:danger colors/tokens)}
-   :schema-sel    {:color            (:text-primary colors/tokens)}
-   :schema-meta   {:color            (:text-tertiary colors/tokens)
-                   :font-size        (:micro typography/type-scale)
+   :schema-tag-ok {:background       (:success-bg rf.story.theme.colors/tokens)
+                   :color            (:success rf.story.theme.colors/tokens)}
+   :schema-tag-bad {:background      (:danger-bg rf.story.theme.colors/tokens)
+                   :color            (:danger rf.story.theme.colors/tokens)}
+   :schema-sel    {:color            (:text-primary rf.story.theme.colors/tokens)}
+   :schema-meta   {:color            (:text-tertiary rf.story.theme.colors/tokens)
+                   :font-size        (:micro rf.story.theme.typography/type-scale)
                    :margin-top       "3px"}
    ;; cannot-run rows (spec/021 §1; spec/018 §12.6 — distinct THIRD state)
    :cannot-row    {:padding          "6px 10px"
-                   :border-left      (str "3px solid " (:warning colors/tokens))
+                   :border-left      (str "3px solid " (:warning rf.story.theme.colors/tokens))
                    :margin-bottom    "5px"
-                   :background       (:warning-bg colors/tokens)
+                   :background       (:warning-bg rf.story.theme.colors/tokens)
                    :font-family      mono-stack
-                   :font-size        (:caption typography/type-scale)}
-   :cannot-key    {:color            (:warning colors/tokens)
+                   :font-size        (:caption rf.story.theme.typography/type-scale)}
+   :cannot-key    {:color            (:warning rf.story.theme.colors/tokens)
                    :text-transform   "uppercase"
-                   :font-size        (:micro typography/type-scale)
+                   :font-size        (:micro rf.story.theme.typography/type-scale)
                    :letter-spacing   "0.4px"
                    :margin-right     "6px"}
-   :cannot-val    {:color            (:text-primary colors/tokens)}
+   :cannot-val    {:color            (:text-primary rf.story.theme.colors/tokens)}
    ;; result → evidence link (spec/021 §2)
    :evidence-row  {:margin-top       "10px"
                    :padding          "8px 12px"
-                   :border           (str "1px dashed " (:border-strong colors/tokens))
+                   :border           (str "1px dashed " (:border-strong rf.story.theme.colors/tokens))
                    :border-radius    "4px"
-                   :background       (:bg-2 colors/tokens)
-                   :color            (:text-secondary colors/tokens)
+                   :background       (:bg-2 rf.story.theme.colors/tokens)
+                   :color            (:text-secondary rf.story.theme.colors/tokens)
                    :font-family      mono-stack
-                   :font-size        (:micro typography/type-scale)}
-   :evidence-pending {:color         (:text-tertiary colors/tokens)
+                   :font-size        (:micro rf.story.theme.typography/type-scale)}
+   :evidence-pending {:color         (:text-tertiary rf.story.theme.colors/tokens)
                       :font-style    "italic"}
 
    ;; ---- step-through scrubber (rf2-lc36w) -------------------------
    :scrub-wrap    {:margin           "8px 0 0 0"
                    :padding          "8px 10px"
-                   :background       (:bg-2 colors/tokens)
-                   :border           (str "1px solid " (:border-strong colors/tokens))
+                   :background       (:bg-2 rf.story.theme.colors/tokens)
+                   :border           (str "1px solid " (:border-strong rf.story.theme.colors/tokens))
                    :border-radius    "4px"}
    :scrub-h       {:font-weight      "bold"
-                   :color            (:text-secondary colors/tokens)
+                   :color            (:text-secondary rf.story.theme.colors/tokens)
                    :text-transform   "uppercase"
-                   :font-size        (:micro typography/type-scale)
+                   :font-size        (:micro rf.story.theme.typography/type-scale)
                    :letter-spacing   "0.5px"
                    :margin-bottom    "6px"
                    :display          "flex"
@@ -276,33 +276,33 @@
                    :border-radius    "3px"
                    :cursor           "pointer"
                    :font-family      mono-stack
-                   :font-size        (:micro typography/type-scale)
+                   :font-size        (:micro rf.story.theme.typography/type-scale)
                    :padding          "0 4px"
                    :user-select      "none"}
-   :tick-pass     {:background       (:success-bg colors/tokens)
-                   :color            (:success colors/tokens)}
-   :tick-fail     {:background       (:danger-bg colors/tokens)
-                   :color            (:danger colors/tokens)}
-   :tick-event    {:background       (:bg-3 colors/tokens)
-                   :color            (:text-secondary colors/tokens)}
-   :tick-skip     {:background       (:bg-2 colors/tokens)
-                   :color            (:text-tertiary colors/tokens)}
-   :tick-selected {:outline          (str "2px solid " (:info colors/tokens))
+   :tick-pass     {:background       (:success-bg rf.story.theme.colors/tokens)
+                   :color            (:success rf.story.theme.colors/tokens)}
+   :tick-fail     {:background       (:danger-bg rf.story.theme.colors/tokens)
+                   :color            (:danger rf.story.theme.colors/tokens)}
+   :tick-event    {:background       (:bg-3 rf.story.theme.colors/tokens)
+                   :color            (:text-secondary rf.story.theme.colors/tokens)}
+   :tick-skip     {:background       (:bg-2 rf.story.theme.colors/tokens)
+                   :color            (:text-tertiary rf.story.theme.colors/tokens)}
+   :tick-selected {:outline          (str "2px solid " (:info rf.story.theme.colors/tokens))
                    :outline-offset   "1px"}
    :scrub-slider  {:width            "100%"
                    :margin           "4px 0"}
-   :scrub-detail  {:color            (:text-tertiary colors/tokens)
+   :scrub-detail  {:color            (:text-tertiary rf.story.theme.colors/tokens)
                    :font-family      mono-stack
-                   :font-size        (:micro typography/type-scale)
+                   :font-size        (:micro rf.story.theme.typography/type-scale)
                    :margin-top       "4px"
                    :display          "flex"
                    :gap              "10px"
                    :flex-wrap        "wrap"}
    :scrub-release {:padding          "2px 8px"
-                   :background       (:border-strong colors/tokens)
-                   :color            (:text-primary colors/tokens)
+                   :background       (:border-strong rf.story.theme.colors/tokens)
+                   :color            (:text-primary rf.story.theme.colors/tokens)
                    :border           "none"
                    :border-radius    "3px"
                    :cursor           "pointer"
-                   :font-size        (:micro typography/type-scale)
+                   :font-size        (:micro rf.story.theme.typography/type-scale)
                    :font-family      mono-stack}})

--- a/tools/story/src/re_frame/story/ui/test_mode/visual_a11y_view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/visual_a11y_view.cljs
@@ -41,73 +41,73 @@
   CLJS-only. Reached only through `view/test-view`, which the shell mounts
   behind the `config/enabled?` gate, so production builds never invoke it —
   closure DCEs the lot."
-  (:require [re-frame.story.ui.test-mode.pure        :as pure]
-            [re-frame.story.ui.test-mode.state       :as state]
-            [re-frame.story.theme.status :as status]
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+  (:require [re-frame.story.ui.test-mode.pure        :as rf.story.ui.test-mode.pure]
+            [re-frame.story.ui.test-mode.state       :as rf.story.ui.test-mode.state]
+            [re-frame.story.theme.status :as rf.story.theme.status]
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---- styles (theme tokens only — no shell restyle) -----------------------
 
 (def ^:private styles
   {:section     {:margin-top "16px"}
    :section-h   {:font-weight    "bold"
-                 :color          (:text-secondary colors/tokens)
+                 :color          (:text-secondary rf.story.theme.colors/tokens)
                  :text-transform "uppercase"
-                 :font-size      (:micro typography/type-scale)
+                 :font-size      (:micro rf.story.theme.typography/type-scale)
                  :letter-spacing "0.5px"
                  :margin-bottom  "8px"
-                 :border-bottom  (str "1px solid " (:border-default colors/tokens))
+                 :border-bottom  (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                  :padding-bottom "4px"}
-   :card        {:border        (str "1px solid " (:border-default colors/tokens))
+   :card        {:border        (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                  :border-radius "4px"
                  :margin-bottom "6px"
-                 :background    (:bg-2 colors/tokens)
+                 :background    (:bg-2 rf.story.theme.colors/tokens)
                  :font-family   mono-stack
-                 :font-size     (:caption typography/type-scale)}
+                 :font-size     (:caption rf.story.theme.typography/type-scale)}
    :card-head   {:display       "flex"
                  :align-items   "center"
                  :gap           "8px"
                  :padding       "6px 10px"}
-   :kind-label  {:color       (:text-primary colors/tokens)
+   :kind-label  {:color       (:text-primary rf.story.theme.colors/tokens)
                  :font-weight "bold"}
-   :reason      {:color       (:text-secondary colors/tokens)
-                 :font-size   (:micro typography/type-scale)
+   :reason      {:color       (:text-secondary rf.story.theme.colors/tokens)
+                 :font-size   (:micro rf.story.theme.typography/type-scale)
                  :margin-left "auto"
                  :text-align  "right"}
    :findings    {:list-style  "none"
                  :margin      "0"
                  :padding     "0 10px 8px 10px"}
    :finding-row {:padding       "4px 0"
-                 :border-top    (str "1px solid " (:border-default colors/tokens))
+                 :border-top    (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                  :display       "flex"
                  :gap           "8px"
                  :align-items   "baseline"}
-   :finding-txt {:color (:text-primary colors/tokens)}
-   :locus       {:color         (:info colors/tokens)
-                 :background    (:bg-3 colors/tokens)
+   :finding-txt {:color (:text-primary rf.story.theme.colors/tokens)}
+   :locus       {:color         (:info rf.story.theme.colors/tokens)
+                 :background    (:bg-3 rf.story.theme.colors/tokens)
                  :padding       "1px 6px"
                  :border-radius "3px"
-                 :font-size     (:micro typography/type-scale)
+                 :font-size     (:micro rf.story.theme.typography/type-scale)
                  :white-space   "nowrap"}
-   :impact      {:color          (:warning colors/tokens)
+   :impact      {:color          (:warning rf.story.theme.colors/tokens)
                  :text-transform "uppercase"
-                 :font-size      (:micro typography/type-scale)
+                 :font-size      (:micro rf.story.theme.typography/type-scale)
                  :letter-spacing "0.4px"}
-   :detail      {:color     (:text-tertiary colors/tokens)
-                 :font-size (:micro typography/type-scale)}
-   :all-clear   {:color      (:success colors/tokens)
+   :detail      {:color     (:text-tertiary rf.story.theme.colors/tokens)
+                 :font-size (:micro rf.story.theme.typography/type-scale)}
+   :all-clear   {:color      (:success rf.story.theme.colors/tokens)
                  :padding    "4px 10px 8px 10px"
                  :font-style "italic"}
    :snap-box    {:padding "4px 10px 8px 10px"}
-   :snap-key    {:color          (:text-tertiary colors/tokens)
+   :snap-key    {:color          (:text-tertiary rf.story.theme.colors/tokens)
                  :text-transform "uppercase"
-                 :font-size      (:micro typography/type-scale)
+                 :font-size      (:micro rf.story.theme.typography/type-scale)
                  :letter-spacing "0.4px"
                  :margin-right   "6px"}
-   :snap-val    {:color (:text-primary colors/tokens)}
+   :snap-val    {:color (:text-primary rf.story.theme.colors/tokens)}
    :cannot-box  {:padding    "4px 10px 8px 10px"
-                 :color      (:warning colors/tokens)
+                 :color      (:warning rf.story.theme.colors/tokens)
                  :font-style "italic"}})
 
 ;; Deliberate glyph override: this pane marks `:error` with a HEAVY cross
@@ -130,13 +130,13 @@
   with a deliberate heavy-cross `:error` glyph override (see `error-glyph`).
   Unmapped statuses degrade to the descriptor's neutral fallback."
   [status]
-  (let [{:keys [bg fg glyph]} (status/descriptor status)
+  (let [{:keys [bg fg glyph]} (rf.story.theme.status/descriptor status)
         glyph (if (= status :error) error-glyph glyph)]
     [:span {:style       {:padding        "2px 8px"
                           :border-radius  "8px"
                           :background     bg
                           :color          fg
-                          :font-size      (:micro typography/type-scale)
+                          :font-size      (:micro rf.story.theme.typography/type-scale)
                           :font-weight    "bold"
                           :text-transform "uppercase"
                           :letter-spacing "0.4px"}
@@ -155,7 +155,7 @@
   the violation's `:nodes` → `:target`); when present the locus is tagged
   `data-selector` so the result UI exposes the source link the spec/021 §4
   MUST requires. A structural finding has no selector (the `:hiccup` tier
-  walks an in-memory tree, not a DOM — see `pure/structural-a11y-findings`),
+  walks an in-memory tree, not a DOM — see `rf.story.ui.test-mode.pure/structural-a11y-findings`),
   so it surfaces only its hiccup-tag locus, honestly."
   [findings]
   [:ul {:style (:findings styles) :data-test "story-va-findings"}
@@ -231,16 +231,16 @@
 (defn visual-a11y-section
   "The visual + a11y check-results section for `variant-id` (spec/021 §4).
   Reads the browser-tier oracle records off the unified run-result's
-  `:assertions` slot via `pure/browser-result-rows` and presents each
+  `:assertions` slot via `rf.story.ui.test-mode.pure/browser-result-rows` and presents each
   readably (structural-a11y violations as a `{:finding :locus}` list, axe
   violations likewise, visual snapshot identity, honest `:cannot-run`).
 
   Renders NOTHING when the run recorded no browser-tier checks — the common
   headless case (an honest empty state, never a fabricated card)."
   [variant-id]
-  (let [slot   (get @state/results-atom variant-id)
+  (let [slot   (get @rf.story.ui.test-mode.state/results-atom variant-id)
         result (:result slot)
-        rows   (some-> result pure/browser-result-rows)]
+        rows   (some-> result rf.story.ui.test-mode.pure/browser-result-rows)]
     (when (seq rows)
       [:div {:style     (:section styles)
              :data-test "story-test-visual-a11y-section"}

--- a/tools/story/src/re_frame/story/ui/toolbar.cljs
+++ b/tools/story/src/re_frame/story/ui/toolbar.cljs
@@ -62,18 +62,18 @@
   (:require [clojure.edn :as edn]
             [clojure.string :as str]
             [re-frame.story.local-storage :refer [safe-local-storage]]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.story.share :as share]
-            [re-frame.story.ui.backgrounds-switcher :as backgrounds-switcher]
-            [re-frame.story.ui.element-inspector :as element-inspector]
-            [re-frame.story.ui.play-status :as play-status]
-            [re-frame.story.ui.recorder :as ui-recorder]
-            [re-frame.story.ui.share :as ui-share]
-            [re-frame.story.ui.state :as state]
-            [re-frame.story.theme.motion :as motion]
-            [re-frame.story.ui.viewport-switcher :as viewport-switcher]
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.share :as rf.story.share]
+            [re-frame.story.ui.backgrounds-switcher :as rf.story.ui.backgrounds-switcher]
+            [re-frame.story.ui.element-inspector :as rf.story.ui.element-inspector]
+            [re-frame.story.ui.play-status :as rf.story.ui.play-status]
+            [re-frame.story.ui.recorder :as rf.story.ui.recorder]
+            [re-frame.story.ui.share :as rf.story.ui.share]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.theme.motion :as rf.story.theme.motion]
+            [re-frame.story.ui.viewport-switcher :as rf.story.ui.viewport-switcher]
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---- localStorage --------------------------------------------------------
 
@@ -110,12 +110,12 @@
 (defn prune-unregistered
   "Drop mode ids from `modes` that no longer resolve at the live
   registrar (stale localStorage after a `reg-mode` rename). Delegates
-  to the CLJC production helper `share/prune-unregistered-modes` with
+  to the CLJC production helper `rf.story.share/prune-unregistered-modes` with
   the live registrar predicate injected — the pure logic is JVM-tested
-  against `share/prune-unregistered-modes` directly, not a copy here."
+  against `rf.story.share/prune-unregistered-modes` directly, not a copy here."
   [modes]
-  (share/prune-unregistered-modes
-    modes (fn [mid] (registrar/registered? :mode mid))))
+  (rf.story.share/prune-unregistered-modes
+    modes (fn [mid] (rf.story.registrar/registered? :mode mid))))
 
 ;; ---- hydration -----------------------------------------------------------
 ;;
@@ -134,16 +134,16 @@
   fixture) is never clobbered. Stale ids are pruned against the live
   registrar. Spec/010 §Persistence — chrome-wide localStorage.
 
-  Mirrors the `viewport-switcher/hydrate!` / `backgrounds-switcher/
+  Mirrors the `rf.story.ui.viewport-switcher/hydrate!` / `rf.story.ui.backgrounds-switcher/
   hydrate!` shape: a localStorage-only seed that the URL hydrator may
   later override."
   []
-  (let [shell @state/shell-state-atom]
+  (let [shell @rf.story.ui.state/shell-state-atom]
     (when (empty? (:active-modes shell))
       (when-let [persisted (load-modes-from-storage)]
         (let [pruned (prune-unregistered persisted)]
           (when (seq pruned)
-            (state/swap-state! state/set-active-modes pruned)))))))
+            (rf.story.ui.state/swap-state! rf.story.ui.state/set-active-modes pruned)))))))
 
 ;; ---- programmatic toggle -------------------------------------------------
 
@@ -152,15 +152,15 @@
   / programmatic callers can drive the toolbar without going through
   the DOM."
   [mode-id]
-  (state/swap-state!
+  (rf.story.ui.state/swap-state!
     (fn [s]
-      (state/set-active-modes s (state/toggle-mode (:active-modes s) mode-id))))
-  (save-modes-to-storage! (:active-modes (state/get-state))))
+      (rf.story.ui.state/set-active-modes s (rf.story.ui.state/toggle-mode (:active-modes s) mode-id))))
+  (save-modes-to-storage! (:active-modes (rf.story.ui.state/get-state))))
 
 (defn reset-modes!
   "Clear every active mode + persist. The toolbar's `[reset]` action."
   []
-  (state/swap-state! state/clear-active-modes)
+  (rf.story.ui.state/swap-state! rf.story.ui.state/clear-active-modes)
   (save-modes-to-storage! []))
 
 ;; ---- styling -------------------------------------------------------------
@@ -186,20 +186,20 @@
                  :align-items    "center"
                  :gap            "6px"
                  :padding        "6px 10px"
-                 :background     (:bg-2 colors/tokens)
-                 :border-bottom  (str "1px solid " (:border-default colors/tokens))
+                 :background     (:bg-2 rf.story.theme.colors/tokens)
+                 :border-bottom  (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                  :font-family    mono-stack
-                 :font-size      (:caption typography/type-scale)
+                 :font-size      (:caption rf.story.theme.typography/type-scale)
                  :min-height     "32px"
                  :box-sizing     "border-box"
                  :flex-wrap      "wrap"
                  :row-gap        "6px"}
-   :axis-label  {:font-family     typography/sans-stack
-                 :font-size       (:micro typography/type-scale)
-                 :font-weight     (str (:semibold typography/weights))
+   :axis-label  {:font-family     rf.story.theme.typography/sans-stack
+                 :font-size       (:micro rf.story.theme.typography/type-scale)
+                 :font-weight     (str (:semibold rf.story.theme.typography/weights))
                  :text-transform  "uppercase"
-                 :color           (:text-tertiary colors/tokens)
-                 :letter-spacing  (:label-wide typography/letter-spacing)
+                 :color           (:text-tertiary rf.story.theme.colors/tokens)
+                 :letter-spacing  (:label-wide rf.story.theme.typography/letter-spacing)
                  :margin-right    "6px"}
    :axis-group  {:display     "flex"
                  :align-items "center"
@@ -208,22 +208,22 @@
                  :gap       "4px"
                  :flex-wrap "wrap"}
    :chip        {:padding         "3px 9px"
-                 :background      (:bg-3 colors/tokens)
-                 :color           (:text-primary colors/tokens)
-                 :border          (str "1px solid " (:border-subtle colors/tokens))
+                 :background      (:bg-3 rf.story.theme.colors/tokens)
+                 :color           (:text-primary rf.story.theme.colors/tokens)
+                 :border          (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
                  :border-radius   "10px"
                  :cursor          "pointer"
                  :font-family     mono-stack
-                 :font-size       (:caption typography/type-scale)
+                 :font-size       (:caption rf.story.theme.typography/type-scale)
                  :max-width       "20em"
                  :overflow        "hidden"
                  :text-overflow   "ellipsis"
                  :white-space     "nowrap"
                  :user-select     "none"
-                 :transition      (:chip motion/transitions)}
-   :chip-active {:background (:accent-amber colors/tokens)
-                 :color      (:text-on-accent colors/tokens)
-                 :border     (str "1px solid " (:accent-amber-deep colors/tokens))}
+                 :transition      (:chip rf.story.theme.motion/transitions)}
+   :chip-active {:background (:accent-amber rf.story.theme.colors/tokens)
+                 :color      (:text-on-accent rf.story.theme.colors/tokens)
+                 :border     (str "1px solid " (:accent-amber-deep rf.story.theme.colors/tokens))}
    :spacer      {:flex "1"}
    ;; rf2-v58dm — a `:cluster` is a self-contained flex-item carrying
    ;; one logical group of affordances. The strip composes ~5 clusters
@@ -235,12 +235,12 @@
    ;; rf2-v58dm — left-edge upper-cased label per cluster. Mirrors the
    ;; existing axis-label vocabulary so MODES / DATA / VIEW / DEBUG /
    ;; REC all share the same small-caps grammar.
-   :cluster-label {:font-family    typography/sans-stack
-                   :font-size      (:micro typography/type-scale)
-                   :font-weight    (str (:semibold typography/weights))
+   :cluster-label {:font-family    rf.story.theme.typography/sans-stack
+                   :font-size      (:micro rf.story.theme.typography/type-scale)
+                   :font-weight    (str (:semibold rf.story.theme.typography/weights))
                    :text-transform "uppercase"
-                   :color          (:text-tertiary colors/tokens)
-                   :letter-spacing (:label-wide typography/letter-spacing)
+                   :color          (:text-tertiary rf.story.theme.colors/tokens)
+                   :letter-spacing (:label-wide rf.story.theme.typography/letter-spacing)
                    :margin-right   "6px"}
    ;; rf2-v58dm — vertical divider between clusters. Token-driven
    ;; hairline; carries an inline height so the rule sits centred on
@@ -248,20 +248,20 @@
    :divider     {:width        "1px"
                  :align-self   "stretch"
                  :margin       "2px 4px"
-                 :background   (:border-subtle colors/tokens)
+                 :background   (:border-subtle rf.story.theme.colors/tokens)
                  :flex-shrink  "0"}
    :reset       {:padding       "3px 9px"
                  :background    "transparent"
-                 :color         (:text-secondary colors/tokens)
-                 :border        (str "1px solid " (:border-default colors/tokens))
+                 :color         (:text-secondary rf.story.theme.colors/tokens)
+                 :border        (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                  :border-radius "10px"
                  :cursor        "pointer"
                  :font-family   mono-stack
-                 :font-size     (:micro typography/type-scale)
-                 :transition    (:chip motion/transitions)}
-   :empty       {:color       (:text-tertiary colors/tokens)
+                 :font-size     (:micro rf.story.theme.typography/type-scale)
+                 :transition    (:chip rf.story.theme.motion/transitions)}
+   :empty       {:color       (:text-tertiary rf.story.theme.colors/tokens)
                  :font-style  "italic"
-                 :font-size   (:caption typography/type-scale)}})
+                 :font-size   (:caption rf.story.theme.typography/type-scale)}})
 
 ;; ---- chip rendering ------------------------------------------------------
 
@@ -318,7 +318,7 @@
 
 (defn toolbar-strip
   "Render the chrome-level toolbar strip. Reads
-  `(registrar/registrations :mode)` per render — newly-registered modes
+  `(rf.story.registrar/registrations :mode)` per render — newly-registered modes
   appear immediately. Renders an empty-state placeholder when the
   registry has no `:mode` entries.
 
@@ -334,11 +334,11 @@
   Each cluster carries a small-caps label so the strip reads as a
   set of named groups rather than a flat chip row."
   []
-  (let [shell    @state/shell-state-atom
+  (let [shell    @rf.story.ui.state/shell-state-atom
         active   (set (:active-modes shell))
-        modes    (registrar/registrations :mode)
+        modes    (rf.story.registrar/registrations :mode)
         variant  (:selected-variant shell)
-        {:keys [axes unaxed]} (state/group-modes-by-axis modes)
+        {:keys [axes unaxed]} (rf.story.ui.state/group-modes-by-axis modes)
         vis-flag (get-in shell [:panel-visibility :dispatch-console])
         dc-effective? (cond
                         (true?  vis-flag) true
@@ -396,12 +396,12 @@
                        "Hide dispatch console"
                        "Show dispatch console")
           :on-click  (fn [_]
-                       (state/swap-state!
+                       (rf.story.ui.state/swap-state!
                          (fn [s]
                            (assoc-in s [:panel-visibility :dispatch-console]
                                      (not dc-effective?)))))}
          (if dc-effective? "Dispatch ▾" "Dispatch ▸")]
-        [play-status/chip-when-enabled variant]])
+        [rf.story.ui.play-status/chip-when-enabled variant]])
      (when variant [divider])
      ;; ── VIEW cluster (framing chips) ──────────────────────────────
      ;; rf2-zll4h — viewport + backgrounds switchers (Storybook addon-
@@ -414,8 +414,8 @@
              :data-test   "story-toolbar-cluster"
              :data-cluster "view"}
       [cluster-label "View"]
-      [viewport-switcher/chip-when-enabled]
-      [backgrounds-switcher/chip-when-enabled]]
+      [rf.story.ui.viewport-switcher/chip-when-enabled]
+      [rf.story.ui.backgrounds-switcher/chip-when-enabled]]
      [divider]
      ;; ── DEBUG cluster (pick-mode) ─────────────────────────────────
      ;; rf2-h0jc0 — element-level click-to-code inspector chip. Toggles
@@ -427,7 +427,7 @@
              :data-test   "story-toolbar-cluster"
              :data-cluster "debug"}
       [cluster-label "Debug"]
-      [element-inspector/inspect-chip]]
+      [rf.story.ui.element-inspector/inspect-chip]]
      [divider]
      ;; ── SHARE cluster (egress) ────────────────────────────────────
      ;; rf2-ba86n.16 — human share / export / copy egress. Opens the
@@ -442,7 +442,7 @@
              :data-test   "story-toolbar-cluster"
              :data-cluster "share"}
       [cluster-label "Share"]
-      [ui-share/share-chip]]
+      [rf.story.ui.share/share-chip]]
      [divider]
      ;; ── REC cluster (actions) ─────────────────────────────────────
      ;; rf2-5fc15 — Test Codegen REC chip. Lives just before the reset
@@ -452,7 +452,7 @@
              :data-test   "story-toolbar-cluster"
              :data-cluster "rec"}
       [cluster-label "Rec"]
-      [ui-recorder/rec-chip]
+      [rf.story.ui.recorder/rec-chip]
       (when (seq (:active-modes shell))
         [:button
          {:style     (:reset styles)

--- a/tools/story/src/re_frame/story/ui/trace_buffer.cljs
+++ b/tools/story/src/re_frame/story/ui/trace_buffer.cljs
@@ -31,12 +31,12 @@
   (:require [reagent.core :as r]
             ;; rf2-qwm0a — listener API lives in
             ;; `re-frame.trace.tooling` (production-DCE split).
-            [re-frame.trace.tooling :as trace-tooling]
+            [re-frame.trace.tooling :as rf.trace.tooling]
             ;; rf2-7737vq — the canonical RAW trace-event frame reader
             ;; (`re-frame.trace/trace-event-frame`), replacing Story's
             ;; hand-rolled `[:tags :frame]` read.
-            [re-frame.trace :as trace]
-            [re-frame.story.config :as config]))
+            [re-frame.trace :as rf.trace]
+            [re-frame.story.config :as rf.story.config]))
 
 ;; ---- the per-variant trace buffer ----------------------------------------
 
@@ -68,12 +68,12 @@
   resets."
   ([]
    (doseq [a (vals @buffers)] (reset! a []))
-   (config/reset-suppressed-count!)
+   (rf.story.config/reset-suppressed-count!)
    nil)
   ([variant-id]
    (when-let [a (get @buffers variant-id)]
      (reset! a []))
-   (config/reset-suppressed-count! variant-id)
+   (rf.story.config/reset-suppressed-count! variant-id)
    nil))
 
 ;; ---- retroactive scrub on egress-profile narrowing (rf2-lqmje / rf2-6z4znr)
@@ -83,7 +83,7 @@
 ;; (`:rf.egress/local-raw`) back to the redacting default clears THAT frame's
 ;; trace buffer; narrowing the session-pin clears every (non-overridden)
 ;; buffer. Each Story trace listener only gates at ingest via
-;; `config/suppress-sensitive?`, so without this hook a sensitive cascade
+;; `rf.story.config/suppress-sensitive?`, so without this hook a sensitive cascade
 ;; buffered while the raw profile was active would remain visible in that
 ;; frame's downstream surface after the operator expected privacy restored.
 ;;
@@ -92,10 +92,10 @@
 ;; buffer; a `nil` frame-id (the session-pin narrow signal) clears EVERY
 ;; buffer. The clear cascades through `clear-buffer!`:
 ;;   - resets the targeted (or every) per-variant ratom to `[]`,
-;;   - calls `config/reset-suppressed-count!` so the `[● REDACTED]` hint
+;;   - calls `rf.story.config/reset-suppressed-count!` so the `[● REDACTED]` hint
 ;;     drops in lockstep with the buffer.
 ;;
-;; The hook registers at load time, gated on `config/enabled?` —
+;; The hook registers at load time, gated on `rf.story.config/enabled?` —
 ;; production builds (`enabled?` false via `:closure-defines`) elide
 ;; Story entirely, including the registration form.
 
@@ -108,8 +108,8 @@
     (clear-buffer! frame-id)
     (clear-buffer!)))
 
-(when config/enabled?
-  (config/register-toggle-off-callback! ::clear-on-toggle-off scrub-on-toggle-off!))
+(when rf.story.config/enabled?
+  (rf.story.config/register-toggle-off-callback! ::clear-on-toggle-off scrub-on-toggle-off!))
 
 (defn drop-buffer!
   "Remove the buffer entry entirely. Called from shell unmount.
@@ -117,7 +117,7 @@
   counter so it doesn't leak across variant teardowns."
   [variant-id]
   (swap! buffers dissoc variant-id)
-  (config/reset-suppressed-count! variant-id)
+  (rf.story.config/reset-suppressed-count! variant-id)
   nil)
 
 (defn- append!
@@ -145,7 +145,7 @@
   (registry / global) match nothing. Per Spec 009 §Frame identity on the
   raw event (rf2-7737vq) — `:frame` rides under `:tags` on the raw layer."
   [variant-id ev]
-  (= variant-id (trace/trace-event-frame ev)))
+  (= variant-id (rf.trace/trace-event-frame ev)))
 
 (defn register-listener!
   "Install a trace listener that appends every `variant-id`-scoped event
@@ -159,22 +159,22 @@
   consumers can advertise that the buffer is shorter than the
   runtime's actual emit count."
   [variant-id]
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (let [id (listener-id variant-id)]
-      (trace-tooling/register-listener! id
+      (rf.trace.tooling/register-listener! id
         (fn [ev]
           (when (variant-event? variant-id ev)
             ;; rf2-6z4znr — the listener is per-variant; resolve the suppress
             ;; decision against THIS variant's frame so revealing a sibling
             ;; variant never opens this buffer's gate.
-            (if (config/suppress-sensitive? ev variant-id)
-              (config/note-suppressed! variant-id)
+            (if (rf.story.config/suppress-sensitive? ev variant-id)
+              (rf.story.config/note-suppressed! variant-id)
               (append! variant-id ev)))))
       id)))
 
 (defn remove-listener!
   "Tear down the trace listener for `variant-id`. Idempotent."
   [variant-id]
-  (when config/enabled?
-    (trace-tooling/unregister-listener! (listener-id variant-id))
+  (when rf.story.config/enabled?
+    (rf.trace.tooling/unregister-listener! (listener-id variant-id))
     nil))

--- a/tools/story/src/re_frame/story/ui/url_state.cljc
+++ b/tools/story/src/re_frame/story/ui/url_state.cljc
@@ -21,7 +21,7 @@
 
   - `url-from-state`     — pure: shell-state → URL string.
   - `params-from-state`  — pure: shell-state → param-vector (the same
-                           shape `share/build-params` emits).
+                           shape `rf.story.share/build-params` emits).
   - `install-popstate-listener!` — CLJS: subscribe to back/forward.
   - `install-state-watcher!`     — CLJS: subscribe to shell-state
                                    changes + push / replace URL.
@@ -57,17 +57,17 @@
   the state-watcher's reaction does NOT bounce back a push for the
   state it just absorbed."
   ;; `clojure.string` is CLJS-only here: the pure half composes through
-  ;; `share/apply-story-params` and does no string work of its own, so
+  ;; `rf.story.share/apply-story-params` and does no string work of its own, so
   ;; the alias survives solely for `embed-flag-from-current-url`'s
   ;; truthiness parse down in the `#?(:cljs ...)` block.
   (:require #?(:cljs [clojure.string :as str])
-            [re-frame.story.share :as share]))
+            [re-frame.story.share :as rf.story.share]))
 
 ;; ---- pure: shell-state → URL params -------------------------------------
 
 (defn params-from-state
   "Project the URL-relevant slots out of a shell-state map into the
-  arg-shape `share/build-params` consumes. Pure data → data;
+  arg-shape `rf.story.share/build-params` consumes. Pure data → data;
   JVM-testable.
 
   Cell-overrides are projected from the per-variant overrides map for
@@ -101,16 +101,16 @@
   current browser location. Returns a string. Pure data → data;
   JVM-testable.
 
-  Story owns exactly `share/story-query-keys` in that query and nothing
+  Story owns exactly `rf.story.share/story-query-keys` in that query and nothing
   else. This call writes the keys `shell` populates, CLEARS the ones it
   does not, and PRESERVES every unrelated param already on `:search` —
   `embed=1` (rf2-pucku chrome state, read at mount and deliberately
-  never round-tripped through `share/parse-params`), a referrer `from=`,
+  never round-tripped through `rf.story.share/parse-params`), a referrer `from=`,
   whatever a host page appended — verbatim and in order, ahead of the
   generated params.
 
   That boundary is not restated here: the merge IS
-  `share/apply-story-params`, the same function `share/variant-share-url`
+  `rf.story.share/apply-story-params`, the same function `rf.story.share/variant-share-url`
   builds on. The two writers of this URL therefore cannot disagree about
   who owns an unrelated param, which is the defect rf2-gee8n recorded —
   this fn used to compose from `{:pathname :hash}` alone and rebuild the
@@ -123,9 +123,9 @@
   hash-based routing under `#/stories`), which `apply-story-params`
   handles by splitting the fragment off first."
   [shell {:keys [pathname search hash]}]
-  (share/apply-story-params
+  (rf.story.share/apply-story-params
     (str (or pathname "") (or search "") (or hash ""))
-    (share/build-params (params-from-state shell))))
+    (rf.story.share/build-params (params-from-state shell))))
 
 ;; ---- diff predicate -----------------------------------------------------
 
@@ -167,7 +167,7 @@
 ;; ---- hydrator: URL params → shell-state apply ---------------------------
 
 (defn apply-parsed-to-state
-  "Pure: fold `parsed` (the output of `share/parse-params`) into a
+  "Pure: fold `parsed` (the output of `rf.story.share/parse-params`) into a
   shell-state map. Returns the new state map.
 
   Validation: each slot is validated against the relevant registrar /
@@ -216,7 +216,7 @@
       so the chrome falls back to its neutral default (`:full` / no bg).
     - omitted (or invalid) `substrate=` clears `:substrate` to the default
       `:reagent` (rf2-dxz4sg). The build side omits `substrate=` precisely
-      to encode the `:reagent` default (`share/build-params` only emits it
+      to encode the `:reagent` default (`rf.story.share/build-params` only emits it
       for a non-default substrate), so an omitted param MUST hydrate as
       `:reagent` rather than preserving the recipient's stale in-memory
       `:uix`. A present-but-unregistered substrate (rejected by the
@@ -331,7 +331,7 @@
       ;; rf2-dxz4sg: `:substrate` joins the unconditional authoritative-clear
       ;; — omitted/invalid ⇒ `:reagent` (computed as `substrate*` above), a
       ;; registered non-default id ⇒ that id. This mirrors the build-side
-      ;; default-omission (`share/build-params`) so the address bar stays the
+      ;; default-omission (`rf.story.share/build-params`) so the address bar stays the
       ;; source of truth for the substrate on both mount and back/forward.
       :always
       (-> (assoc :active-modes (vec active-modes))
@@ -373,7 +373,7 @@
            (str (.-pathname loc) (.-search loc) (.-hash loc)))))
 
      (defn- ^:no-doc params->getter
-       "Build the `{key → string}` getter map `share/parse-params`
+       "Build the `{key → string}` getter map `rf.story.share/parse-params`
        consumes from a `URLSearchParams` instance."
        [usp]
        (when usp
@@ -389,7 +389,7 @@
 
      (defn parse-current-url
        "Parse the current `window.location.search` into the
-       `share/parse-params` shape. Returns nil when no search params
+       `rf.story.share/parse-params` shape. Returns nil when no search params
        are present or window is unavailable."
        []
        (when-let [w (safe-window)]
@@ -397,12 +397,12 @@
            (when (and (string? search) (seq search))
              (try
                (let [usp (js/URLSearchParams. search)]
-                 (share/parse-params (params->getter usp)))
+                 (rf.story.share/parse-params (params->getter usp)))
                (catch :default _ nil))))))
 
      (defn parse-current-url-or-empty
        "Like `parse-current-url`, but returns the all-nil parsed shape
-       (`share/parse-params {}`) instead of nil when the window is present
+       (`rf.story.share/parse-params {}`) instead of nil when the window is present
        and the search is empty.
 
        Used by the popstate handler (rf2-fkmnh): navigating back/forward to
@@ -417,7 +417,7 @@
        []
        (when-let [w (safe-window)]
          (or (parse-current-url)
-             (share/parse-params {}))))
+             (rf.story.share/parse-params {}))))
 
      (defn embed-flag-from-current-url
        "Read the `?embed=1` flag (rf2-pucku) from
@@ -426,7 +426,7 @@
        case-insensitive); false otherwise.
 
        The flag is intentionally NOT round-tripped through
-       `share/parse-params` because it's chrome-state, not shell-state
+       `rf.story.share/parse-params` because it's chrome-state, not shell-state
        — it never hydrates the registrar-indexed slots and never
        writes back to the URL."
        []
@@ -492,7 +492,7 @@
 
      (defn install-popstate-listener!
        "Subscribe to `window.popstate`. Each pop parses
-       `window.location.search` via `share/parse-params` and folds the
+       `window.location.search` via `rf.story.share/parse-params` and folds the
        result into `shell-state-atom` via `apply-parsed-to-state`.
 
        `apply-fn` is the post-validation applicator — production wires
@@ -511,7 +511,7 @@
        `post-apply-fn`, a Back/Forward pop to a URL whose override arg-key
        was since renamed/removed installed it as a live orphan override
        with no drop/report, unlike the mount path. Production wires this
-       to `share/hydrate-from-url!` so both hydration paths run the
+       to `rf.story.share/hydrate-from-url!` so both hydration paths run the
        identical filter; running it inside the guard (rather than as a
        bare after-the-fact call) keeps it consistent with every other
        hydration step in this ns — none of them provoke a reactive

--- a/tools/story/src/re_frame/story/ui/view_state.cljc
+++ b/tools/story/src/re_frame/story/ui/view_state.cljc
@@ -72,7 +72,7 @@
   collection, opaque predicate, registry ref, or simply no schema) drops
   to the raw-EDN escape hatch, which is ALWAYS present — the form never
   blocks a value. Either path emits the SAME copy-paste `:sub-overrides`
-  scaffold (`schema-form/override-snippet`, source never written
+  scaffold (`rf.story.ui.schema-form/override-snippet`, source never written
   directly), exactly as the upgrade path does.
 
   ## Pure / CLJS split
@@ -89,9 +89,9 @@
   `config/enabled?`-gated controls panel mount, so production builds
   never invoke it and closure DCEs the lot (same contract as the rest of
   the Story UI). The pure `.cljc` helpers carry no DOM / Reagent dep."
-  (:require [re-frame.story.plan :as plan]
-            [re-frame.story.predicates :as pred]
-            [re-frame.story.ui.schema-validation :as schema-validation]
+  (:require [re-frame.story.plan :as rf.story.plan]
+            [re-frame.story.predicates :as rf.story.predicates]
+            [re-frame.story.ui.schema-validation :as rf.story.ui.schema-validation]
             ;; `clojure.string` is consumed ONLY by the `:cljs` render
             ;; helpers (`str/join` in the provenance lines); the pure
             ;; `.cljc` projection needs no string lib, so it rides the
@@ -99,12 +99,12 @@
             ;; (the `author_expectations.cljc` idiom).
             #?@(:cljs [[clojure.string :as str]
                        [reagent.core :as r]
-                       [re-frame.registrar :as rf-registrar]
-                       [re-frame.story.review-dialog :as review-dialog]
-                       [re-frame.story.ui.schema-form :as schema-form]
-                       [re-frame.story.ui.trace-buffer :as trace-buffer]
-                       [re-frame.story.theme.typography :as typography :refer [mono-stack sans-stack]]
-                       [re-frame.story.theme.colors :as colors]])))
+                       [re-frame.registrar :as rf.registrar]
+                       [re-frame.story.review-dialog :as rf.story.review-dialog]
+                       [re-frame.story.ui.schema-form :as rf.story.ui.schema-form]
+                       [re-frame.story.ui.trace-buffer :as rf.story.ui.trace-buffer]
+                       [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack sans-stack]]
+                       [re-frame.story.theme.colors :as rf.story.theme.colors]])))
 
 ;; ===========================================================================
 ;; PURE: the fidelity ladder
@@ -282,7 +282,7 @@
   Pure data → data."
   [plan]
   (let [overrides (-> (get-in plan [:world :frame :fx-overrides])
-                      (dissoc plan/managed-fx-id))]
+                      (dissoc rf.story.plan/managed-fx-id))]
     {:present? (boolean (seq overrides))
      :fx-count (count overrides)
      :fx-ids   (vec (sort-by str (keys overrides)))}))
@@ -329,13 +329,13 @@
   "Filter `trace-events` (raw rows from the variant's trace buffer) to the
   `:rf.error/schema-validation-failure` events whose `:where` is
   `:sub-override`, projected through the SAME
-  `schema-validation/project-failures` the schema-validation panel uses
+  `rf.story.ui.schema-validation/project-failures` the schema-validation panel uses
   (no second projector). Returns a vector of failure rows (oldest first).
   Pure data → data; JVM-testable."
   [trace-events]
   (into []
         (filter #(= :sub-override (:where %)))
-        (schema-validation/project-failures trace-events)))
+        (rf.story.ui.schema-validation/project-failures trace-events)))
 
 ;; ===========================================================================
 ;; PURE: the upgrade path (no artifact-kind change)
@@ -392,7 +392,7 @@
                  ":setup   [[:dispatch [:your/setup-event {}]]] ; real events — proves handlers + app-db"
                  :db-seed
                  ":db-seed {} ; schema-checked direct app-db seed — fill the validated state shape")]
-    (str (pred/reg-variant-envelope
+    (str (rf.story.predicates/reg-variant-envelope
            "story" new-id
            (str ":extends " (pr-str source-variant-id) "\n"
                 "   " slot))
@@ -443,15 +443,15 @@
   [variant-id trace-events]
   #?(:clj
      (try
-       (view-state-model (plan/variant-plan variant-id)
-                         (plan/explain variant-id)
+       (view-state-model (rf.story.plan/variant-plan variant-id)
+                         (rf.story.plan/explain variant-id)
                          trace-events)
        (catch Throwable e
          {:error (or (.getMessage e) (str e))}))
      :cljs
      (try
-       (view-state-model (plan/variant-plan variant-id)
-                         (plan/explain variant-id)
+       (view-state-model (rf.story.plan/variant-plan variant-id)
+                         (rf.story.plan/explain variant-id)
                          trace-events)
        (catch :default e
          {:error (or (.-message e) (str e))}))))
@@ -466,28 +466,28 @@
      border/accent colour. `:real` reads healthy-green, `:mid`
      informational-blue, `:low` calm-amber (the 'work in progress' /
      low-fidelity tone — calm during exploration, not a red failure)."
-     {:real (:success colors/tokens)
-      :mid  (:info colors/tokens)
-      :low  (:warning colors/tokens)}))
+     {:real (:success rf.story.theme.colors/tokens)
+      :mid  (:info rf.story.theme.colors/tokens)
+      :low  (:warning rf.story.theme.colors/tokens)}))
 
 #?(:cljs
    (def ^:private tone->bg
-     {:real (:success-bg colors/tokens)
-      :mid  (:info-bg colors/tokens)
-      :low  (:warning-bg colors/tokens)}))
+     {:real (:success-bg rf.story.theme.colors/tokens)
+      :mid  (:info-bg rf.story.theme.colors/tokens)
+      :low  (:warning-bg rf.story.theme.colors/tokens)}))
 
 #?(:cljs
    (def ^:private styles
      {:section      {:margin-bottom "12px"}
       :section-h    {:font-weight "bold"
-                     :color (:text-secondary colors/tokens)
+                     :color (:text-secondary rf.story.theme.colors/tokens)
                      :text-transform "uppercase"
-                     :font-size (:micro typography/type-scale)
+                     :font-size (:micro rf.story.theme.typography/type-scale)
                      :letter-spacing "0.5px"
                      :margin-bottom "4px"}
-      :blurb        {:color (:text-tertiary colors/tokens)
+      :blurb        {:color (:text-tertiary rf.story.theme.colors/tokens)
                      :font-style "italic"
-                     :font-size (:micro typography/type-scale)
+                     :font-size (:micro rf.story.theme.typography/type-scale)
                      :margin-bottom "6px"}
       :ladder       {:display "flex"
                      :flex-direction "column"
@@ -502,123 +502,123 @@
                      :border-left "3px solid transparent"}
       :rung-rank    {:font-family mono-stack
                      :font-weight "bold"
-                     :color (:text-tertiary colors/tokens)}
+                     :color (:text-tertiary rf.story.theme.colors/tokens)}
       :rung-label   {:font-weight "bold"}
-      :rung-note    {:color (:text-tertiary colors/tokens)
-                     :font-size (:micro typography/type-scale)
+      :rung-note    {:color (:text-tertiary rf.story.theme.colors/tokens)
+                     :font-size (:micro rf.story.theme.typography/type-scale)
                      :grid-column "2 / 4"}
       :rung-state   {:font-family mono-stack
-                     :font-size (:nano typography/type-scale)
+                     :font-size (:nano rf.story.theme.typography/type-scale)
                      :text-transform "uppercase"
                      :letter-spacing "0.5px"
                      :align-self "center"}
       :prov         {:margin "2px 0 0 0"
                      :padding "3px 6px"
-                     :background (:bg-3 colors/tokens)
+                     :background (:bg-3 rf.story.theme.colors/tokens)
                      :border-radius "3px"
-                     :font-size (:micro typography/type-scale)
-                     :color (:text-secondary colors/tokens)}
-      :prov-label   {:color (:info colors/tokens)
+                     :font-size (:micro rf.story.theme.typography/type-scale)
+                     :color (:text-secondary rf.story.theme.colors/tokens)}
+      :prov-label   {:color (:info rf.story.theme.colors/tokens)
                      :font-weight "bold"
                      :margin-right "6px"}
       :guardrail    {:padding "5px 7px"
                      :margin "4px 0"
-                     :background (:warning-bg colors/tokens)
-                     :border-left (str "3px solid " (:warning colors/tokens))
+                     :background (:warning-bg rf.story.theme.colors/tokens)
+                     :border-left (str "3px solid " (:warning rf.story.theme.colors/tokens))
                      :border-radius "3px"
-                     :color (:text-primary colors/tokens)
-                     :font-size (:micro typography/type-scale)
+                     :color (:text-primary rf.story.theme.colors/tokens)
+                     :font-size (:micro rf.story.theme.typography/type-scale)
                      :line-height "1.5"}
       :override-row {:display "grid"
                      :grid-template-columns "1fr 1fr"
                      :gap "6px"
                      :padding "2px 0"
-                     :border-bottom (str "1px dotted " (:border-subtle colors/tokens))
+                     :border-bottom (str "1px dotted " (:border-subtle rf.story.theme.colors/tokens))
                      :font-family mono-stack
-                     :font-size (:micro typography/type-scale)}
-      :ovr-query    {:color (:warning colors/tokens)}
-      :ovr-value    {:color (:info colors/tokens)}
+                     :font-size (:micro rf.story.theme.typography/type-scale)}
+      :ovr-query    {:color (:warning rf.story.theme.colors/tokens)}
+      :ovr-value    {:color (:info rf.story.theme.colors/tokens)}
       :fail         {:padding "4px 6px"
                      :margin "2px 0"
-                     :background (:danger-bg colors/tokens)
-                     :border-left (str "3px solid " (:danger colors/tokens))
-                     :color (:danger colors/tokens)
-                     :font-size (:micro typography/type-scale)}
-      :empty        {:color (:text-tertiary colors/tokens)
+                     :background (:danger-bg rf.story.theme.colors/tokens)
+                     :border-left (str "3px solid " (:danger rf.story.theme.colors/tokens))
+                     :color (:danger rf.story.theme.colors/tokens)
+                     :font-size (:micro rf.story.theme.typography/type-scale)}
+      :empty        {:color (:text-tertiary rf.story.theme.colors/tokens)
                      :font-style "italic"
-                     :font-size (:micro typography/type-scale)}
+                     :font-size (:micro rf.story.theme.typography/type-scale)}
       :upgrade-row  {:display "flex"
                      :gap "6px"
                      :align-items "center"
                      :flex-wrap "wrap"
                      :margin-top "4px"}
       :upgrade-btn  {:padding "3px 8px"
-                     :background (:bg-3 colors/tokens)
-                     :color (:text-primary colors/tokens)
-                     :border (str "1px solid " (:border-default colors/tokens))
+                     :background (:bg-3 rf.story.theme.colors/tokens)
+                     :color (:text-primary rf.story.theme.colors/tokens)
+                     :border (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                      :border-radius "3px"
                      :cursor "pointer"
                      :font-family sans-stack
-                     :font-size (:micro typography/type-scale)}
-      :error        {:color (:danger colors/tokens)
-                     :background (:danger-bg colors/tokens)
-                     :border (str "1px solid " (:danger colors/tokens))
+                     :font-size (:micro rf.story.theme.typography/type-scale)}
+      :error        {:color (:danger rf.story.theme.colors/tokens)
+                     :background (:danger-bg rf.story.theme.colors/tokens)
+                     :border (str "1px solid " (:danger rf.story.theme.colors/tokens))
                      :border-radius "3px"
                      :padding "6px"
                      :font-family mono-stack
-                     :font-size (:micro typography/type-scale)
+                     :font-size (:micro rf.story.theme.typography/type-scale)
                      :white-space "pre-wrap"}
       ;; rf2-xon7j — the schema-generated value-entry surface.
       :pin-btn      {:padding "2px 8px"
-                     :background (:bg-3 colors/tokens)
-                     :color (:text-primary colors/tokens)
-                     :border (str "1px solid " (:border-default colors/tokens))
+                     :background (:bg-3 rf.story.theme.colors/tokens)
+                     :color (:text-primary rf.story.theme.colors/tokens)
+                     :border (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                      :border-radius "3px"
                      :cursor "pointer"
                      :font-family sans-stack
-                     :font-size (:nano typography/type-scale)
+                     :font-size (:nano rf.story.theme.typography/type-scale)
                      :margin-left "6px"}
       :tab-row      {:display "flex" :gap "4px" :margin-bottom "8px"}
       :tab          {:padding "3px 10px"
-                     :background (:bg-2 colors/tokens)
-                     :color (:text-secondary colors/tokens)
-                     :border (str "1px solid " (:border-subtle colors/tokens))
+                     :background (:bg-2 rf.story.theme.colors/tokens)
+                     :color (:text-secondary rf.story.theme.colors/tokens)
+                     :border (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
                      :border-radius "3px"
                      :cursor "pointer"
                      :font-family sans-stack
-                     :font-size (:micro typography/type-scale)}
-      :tab-active   {:background (:info-bg colors/tokens)
-                     :color (:info colors/tokens)
-                     :border (str "1px solid " (:info colors/tokens))}
+                     :font-size (:micro rf.story.theme.typography/type-scale)}
+      :tab-active   {:background (:info-bg rf.story.theme.colors/tokens)
+                     :color (:info rf.story.theme.colors/tokens)
+                     :border (str "1px solid " (:info rf.story.theme.colors/tokens))}
       :form-grid    {:display "grid"
                      :grid-template-columns "auto 1fr"
                      :gap "6px 10px"
                      :align-items "baseline"
                      :margin-bottom "8px"}
       :form-key     {:font-family mono-stack
-                     :font-size (:micro typography/type-scale)
-                     :color (:warning colors/tokens)}
+                     :font-size (:micro rf.story.theme.typography/type-scale)
+                     :color (:warning rf.story.theme.colors/tokens)}
       :form-input   {:padding "3px 6px"
-                     :background (:bg-2 colors/tokens)
-                     :color (:text-primary colors/tokens)
-                     :border (str "1px solid " (:border-default colors/tokens))
+                     :background (:bg-2 rf.story.theme.colors/tokens)
+                     :color (:text-primary rf.story.theme.colors/tokens)
+                     :border (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                      :border-radius "3px"
                      :font-family mono-stack
-                     :font-size (:micro typography/type-scale)
+                     :font-size (:micro rf.story.theme.typography/type-scale)
                      :width "100%"
                      :box-sizing "border-box"}
       :edn-area     {:padding "6px"
                      :background "#0e0e10"
-                     :color (:warning colors/tokens)
-                     :border (str "1px solid " (:border-default colors/tokens))
+                     :color (:warning rf.story.theme.colors/tokens)
+                     :border (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                      :border-radius "3px"
                      :font-family mono-stack
-                     :font-size (:micro typography/type-scale)
+                     :font-size (:micro rf.story.theme.typography/type-scale)
                      :width "100%"
                      :min-height "60px"
                      :box-sizing "border-box"}
-      :edn-err      {:color (:danger colors/tokens)
-                     :font-size (:micro typography/type-scale)
+      :edn-err      {:color (:danger rf.story.theme.colors/tokens)
+                     :font-size (:micro rf.story.theme.typography/type-scale)
                      :margin-top "4px"}}))
 
 ;; ---- schema-generated value entry (rf2-xon7j) ----------------------------
@@ -642,7 +642,7 @@
      [query-v]
      (when (vector? query-v)
        (try
-         (:schema (rf-registrar/lookup :sub (first query-v)))
+         (:schema (rf.registrar/lookup :sub (first query-v)))
          (catch :default _ nil)))))
 
 #?(:cljs
@@ -650,10 +650,10 @@
      "Resolve the field-shape for the sub-override `query-v` — the flat
       form descriptor derived from the target sub's output schema, or the
       EDN-escape-hatch descriptor when the sub has no schema / a non-flat
-      one. Returns a `schema-form/field-shape` map. CLJS-only (reaches the
+      one. Returns a `rf.story.ui.schema-form/field-shape` map. CLJS-only (reaches the
       framework registrar); pure once the schema is resolved."
      [query-v]
-     (schema-form/field-shape (sub-output-schema query-v))))
+     (rf.story.ui.schema-form/field-shape (sub-output-schema query-v))))
 
 ;; ---- the value-entry dialog ratom (reuses the shared review-dialog) ------
 ;;
@@ -665,7 +665,7 @@
 
 #?(:cljs
    (defonce ^:private value-entry-dialog
-     (r/atom (assoc review-dialog/initial-state
+     (r/atom (assoc rf.story.review-dialog/initial-state
                     :form    nil
                     :edn     ""
                     :edn?    false
@@ -683,9 +683,9 @@
      (let [shape (override-field-shape query-v)
            form  (if (some? current-value)
                    current-value
-                   (schema-form/default-form-value shape))]
+                   (rf.story.ui.schema-form/default-form-value shape))]
        (reset! value-entry-dialog
-               (-> review-dialog/initial-state
+               (-> rf.story.review-dialog/initial-state
                    (assoc :open?     true
                           :source-id variant-id
                           :query-v   query-v
@@ -698,14 +698,14 @@
 #?(:cljs
    (defn- close-value-entry-dialog! []
      (reset! value-entry-dialog
-             (assoc review-dialog/initial-state
+             (assoc rf.story.review-dialog/initial-state
                     :form nil :edn "" :edn? false :shape nil :query-v nil))))
 
 ;; ---- the upgrade dialog ratom (reuses the shared review-dialog) ----------
 
 #?(:cljs
    (defonce ^:private upgrade-dialog
-     (r/atom review-dialog/initial-state)))
+     (r/atom rf.story.review-dialog/initial-state)))
 
 #?(:cljs
    (defn- open-upgrade-dialog!
@@ -716,7 +716,7 @@
      [source-variant-id target-rung]
      (let [snippet (upgrade-snippet source-variant-id target-rung)]
        (reset! upgrade-dialog
-               (-> review-dialog/initial-state
+               (-> rf.story.review-dialog/initial-state
                    (assoc :open?     true
                           :source-id source-variant-id
                           :context   {:target-rung target-rung
@@ -724,7 +724,7 @@
 
 #?(:cljs
    (defn- close-upgrade-dialog! []
-     (reset! upgrade-dialog review-dialog/initial-state)))
+     (reset! upgrade-dialog rf.story.review-dialog/initial-state)))
 
 ;; ---- schema-generated value-entry render (rf2-xon7j) ---------------------
 ;;
@@ -738,12 +738,12 @@
    (defn- field-widget
      "Render one flat field widget for `field` (`{:key :widget}`) against
       the form `value` map, writing typed edits back through `on-edit`
-      `(fn [k typed-value])` (the value is coerced via `schema-form/
+      `(fn [k typed-value])` (the value is coerced via `rf.story.ui.schema-form/
       coerce-input` before it lands). Closed scalar vocabulary —
       `:text` / `:number` / `:boolean` / `:select`."
      [{fk :key {:keys [widget options] :as wspec} :widget} value on-edit]
      (let [v     (get value fk)
-           emit! (fn [raw] (on-edit fk (schema-form/coerce-input wspec raw)))]
+           emit! (fn [raw] (on-edit fk (rf.story.ui.schema-form/coerce-input wspec raw)))]
        (case widget
          :boolean
          [:input {:type      "checkbox"
@@ -821,11 +821,11 @@
       a placeholder so the preview still renders honestly)."
      [{:keys [source-id query-v form edn edn?]}]
      (if edn?
-       (let [[ok? v] (schema-form/read-edn-value edn)]
-         (schema-form/override-snippet source-id query-v
+       (let [[ok? v] (rf.story.ui.schema-form/read-edn-value edn)]
+         (rf.story.ui.schema-form/override-snippet source-id query-v
                                        (if ok? v :rf.story/fill-this-value)
                                        true))
-       (schema-form/override-snippet source-id query-v form false))))
+       (rf.story.ui.schema-form/override-snippet source-id query-v form false))))
 
 #?(:cljs
    (defn- value-entry-dialog-view
@@ -841,11 +841,11 @@
          (let [{:keys [query-v shape edn edn? form]} dialog
                renderable? (:renderable? shape)
                edn-tab?    (boolean edn?)
-               [edn-ok? edn-err] (when edn-tab? (schema-form/read-edn-value edn))
+               [edn-ok? edn-err] (when edn-tab? (rf.story.ui.schema-form/read-edn-value edn))
                snippet     (value-entry-snippet dialog)
                set-tab!    (fn [to-edn?]
                              (swap! value-entry-dialog assoc :edn? to-edn?))]
-           (review-dialog/review-dialog dialog
+           (rf.story.review-dialog/review-dialog dialog
              {:title (str "Pin value for " (pr-str query-v))
               :hint
               [:div {:data-test "story-view-state-value-entry"
@@ -904,7 +904,7 @@
                                   (keyword (namespace (:source-id dialog))
                                            (str (name (:source-id dialog)) "-pinned")))
               :on-edit-id       (fn [_])
-              :on-copy          (fn [] (review-dialog/copy-to-clipboard! snippet))
+              :on-copy          (fn [] (rf.story.review-dialog/copy-to-clipboard! snippet))
               :on-close         close-value-entry-dialog!
               :data-test-prefix "story-view-state-value"}))))))
 
@@ -1027,7 +1027,7 @@
                        :data-failing-id (when failing-id (str failing-id))}
                  (str "⚠ override on " (if failing-id (pr-str failing-id) "a sub")
                       " violates its output schema — surfaced nil, not the pinned value"
-                      (let [expl (schema-validation/format-explain explain)]
+                      (let [expl (rf.story.ui.schema-validation/format-explain explain)]
                         (when (seq expl) (str " (" expl ")"))))])))]))
 
 #?(:cljs
@@ -1088,7 +1088,7 @@
        (when (:open? dialog)
          (let [{:keys [source-id context]} dialog
                {:keys [target-rung snippet]} context]
-           (review-dialog/review-dialog dialog
+           (rf.story.review-dialog/review-dialog dialog
              {:title            (str "Upgrade " (pr-str source-id)
                                      " to " (name target-rung) " fidelity")
               :hint             [:div
@@ -1104,7 +1104,7 @@
               ;; value entry is the separate rf2-xon7j surface).
               :placeholder-id   (upgraded-variant-id source-id)
               :on-edit-id       (fn [_])
-              :on-copy          (fn [] (review-dialog/copy-to-clipboard! snippet))
+              :on-copy          (fn [] (rf.story.review-dialog/copy-to-clipboard! snippet))
               :on-close         close-upgrade-dialog!
               :data-test-prefix "story-view-state-upgrade"}))))))
 
@@ -1129,9 +1129,9 @@
      channel, not a fidelity rung (spec/019 §5 — 'view args are explicit
      controls, not a state-fidelity rung')."
      [_variant-id]
-     (let [_buf (when _variant-id (trace-buffer/ensure-buffer! _variant-id))]
+     (let [_buf (when _variant-id (rf.story.ui.trace-buffer/ensure-buffer! _variant-id))]
        (fn [variant-id]
-         (let [events (when variant-id @(trace-buffer/ensure-buffer! variant-id))
+         (let [events (when variant-id @(rf.story.ui.trace-buffer/ensure-buffer! variant-id))
                model  (compile-model variant-id events)]
            [:div {:style     (:section styles)
                   :data-test "story-view-state-section"

--- a/tools/story/src/re_frame/story/ui/viewport_switcher.cljs
+++ b/tools/story/src/re_frame/story/ui/viewport_switcher.cljs
@@ -23,13 +23,13 @@
   it deliberately does not emit `aria-pressed` so the reset assertion
   is never tripped by viewport state."
   (:require [reagent.core :as r]
-            [re-frame.story.config           :as config]
-            [re-frame.story.predicates       :as pred]
-            [re-frame.story.registrar        :as registrar]
-            [re-frame.story.ui.state         :as state]
-            [re-frame.story.viewport         :as viewport]
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+            [re-frame.story.config           :as rf.story.config]
+            [re-frame.story.predicates       :as rf.story.predicates]
+            [re-frame.story.registrar        :as rf.story.registrar]
+            [re-frame.story.ui.state         :as rf.story.ui.state]
+            [re-frame.story.viewport         :as rf.story.viewport]
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---- dropdown state ------------------------------------------------------
 ;;
@@ -55,10 +55,10 @@
   chrome-wide viewport. nil clears the toolbar selection back to the
   default. Also writes through to localStorage."
   [sel]
-  (when config/enabled?
-    (let [normalised (viewport/coerce sel)]
-      (state/swap-state! assoc :viewport normalised)
-      (viewport/save-to-storage! normalised)
+  (when rf.story.config/enabled?
+    (let [normalised (rf.story.viewport/coerce sel)]
+      (rf.story.ui.state/swap-state! assoc :viewport normalised)
+      (rf.story.viewport/save-to-storage! normalised)
       (close!))))
 
 (defn submit-custom!
@@ -70,7 +70,7 @@
         w (some-> width (js/parseInt 10))
         h (some-> height (js/parseInt 10))
         cand {:width w :height h}]
-    (when (viewport/valid-custom? cand)
+    (when (rf.story.viewport/valid-custom? cand)
       (select! cand)
       (reset! custom-input-atom {:width "" :height ""}))))
 
@@ -80,10 +80,10 @@
   "Seed `:viewport` on shell mount from localStorage. Idempotent. No-ops
   when localStorage carries no value or the slot is already populated."
   []
-  (when (and config/enabled?
-             (nil? (:viewport @state/shell-state-atom)))
-    (when-some [persisted (viewport/load-from-storage)]
-      (state/swap-state! assoc :viewport persisted))))
+  (when (and rf.story.config/enabled?
+             (nil? (:viewport @rf.story.ui.state/shell-state-atom)))
+    (when-some [persisted (rf.story.viewport/load-from-storage)]
+      (rf.story.ui.state/swap-state! assoc :viewport persisted))))
 
 ;; ---- per-story override lookup -------------------------------------------
 
@@ -92,48 +92,48 @@
   variant. Pure-ish — reads the registrar + shell-state. Returns the
   preset map `{:label :width :height}` (with nils on `:full`)."
   []
-  (let [shell      @state/shell-state-atom
+  (let [shell      @rf.story.ui.state/shell-state-atom
         variant-id (:selected-variant shell)
         var-body   (when variant-id
-                     (registrar/handler-meta :variant variant-id))
-        story-id   (some-> variant-id pred/parent-story-id)
+                     (rf.story.registrar/handler-meta :variant variant-id))
+        story-id   (some-> variant-id rf.story.predicates/parent-story-id)
         story-body (when story-id
-                     (registrar/handler-meta :story story-id))
+                     (rf.story.registrar/handler-meta :story story-id))
         override   (or (:viewport var-body)
                        (:viewport story-body))]
-    (viewport/resolve override (:viewport shell))))
+    (rf.story.viewport/resolve override (:viewport shell))))
 
 (defn effective-id
   "Like `effective-viewport` but returns the resolved id (preset keyword
   or `:custom`). Used for `data-*` attributes."
   []
-  (let [shell      @state/shell-state-atom
+  (let [shell      @rf.story.ui.state/shell-state-atom
         variant-id (:selected-variant shell)
         var-body   (when variant-id
-                     (registrar/handler-meta :variant variant-id))
-        story-id   (some-> variant-id pred/parent-story-id)
+                     (rf.story.registrar/handler-meta :variant variant-id))
+        story-id   (some-> variant-id rf.story.predicates/parent-story-id)
         story-body (when story-id
-                     (registrar/handler-meta :story story-id))
+                     (rf.story.registrar/handler-meta :story story-id))
         override   (or (:viewport var-body)
                        (:viewport story-body))]
-    (viewport/resolve-id override (:viewport shell))))
+    (rf.story.viewport/resolve-id override (:viewport shell))))
 
 ;; ---- styling -------------------------------------------------------------
 
 (def ^:private styles
   {:chip        {:padding         "3px 10px"
-                 :background      (:bg-3 colors/tokens)
-                 :color           (:text-primary colors/tokens)
+                 :background      (:bg-3 rf.story.theme.colors/tokens)
+                 :color           (:text-primary rf.story.theme.colors/tokens)
                  :border          "none"
                  :border-radius   "10px"
                  :cursor          "pointer"
                  :font-family     mono-stack
-                 :font-size       (:caption typography/type-scale)
+                 :font-size       (:caption rf.story.theme.typography/type-scale)
                  :user-select     "none"
                  :display         "inline-flex"
                  :align-items     "center"
                  :gap             "6px"}
-   :chip-icon   {:font-size (:micro typography/type-scale)
+   :chip-icon   {:font-size (:micro rf.story.theme.typography/type-scale)
                  :opacity   "0.85"}
    :wrap        {:position "relative"
                  :display  "inline-block"}
@@ -151,30 +151,30 @@
                  :flex-direction  "column"
                  :gap             "2px"
                  :font-family     mono-stack
-                 :font-size       (:caption typography/type-scale)}
+                 :font-size       (:caption rf.story.theme.typography/type-scale)}
    :item        {:display         "flex"
                  :align-items     "center"
                  :justify-content "space-between"
                  :padding         "5px 8px"
                  :background      "transparent"
-                 :color           (:text-primary colors/tokens)
+                 :color           (:text-primary rf.story.theme.colors/tokens)
                  :border          "none"
                  :border-radius   "3px"
                  :cursor          "pointer"
                  :font-family     mono-stack
-                 :font-size       (:caption typography/type-scale)
+                 :font-size       (:caption rf.story.theme.typography/type-scale)
                  :text-align      "left"
                  :width           "100%"}
-   :item-active {:background (:accent-amber colors/tokens)
+   :item-active {:background (:accent-amber rf.story.theme.colors/tokens)
                  :color      "white"}
    :item-label  {:display "flex"
                  :align-items "center"
                  :gap "8px"}
    :item-size   {:color     "#888"
-                 :font-size (:micro typography/type-scale)
+                 :font-size (:micro rf.story.theme.typography/type-scale)
                  :font-style "italic"}
    :divider     {:height          "1px"
-                 :background      (:border-subtle colors/tokens)
+                 :background      (:border-subtle rf.story.theme.colors/tokens)
                  :margin          "4px 0"}
    :custom-row  {:display "flex"
                  :gap "4px"
@@ -182,22 +182,22 @@
                  :padding "4px"}
    :custom-input {:width        "60px"
                   :padding      "3px 5px"
-                  :background   (:bg-2 colors/tokens)
+                  :background   (:bg-2 rf.story.theme.colors/tokens)
                   :color        "white"
                   :border       "1px solid #444"
                   :border-radius "3px"
                   :font-family  mono-stack
-                  :font-size    (:caption typography/type-scale)}
+                  :font-size    (:caption rf.story.theme.typography/type-scale)}
    :custom-x    {:color "#888"
-                 :font-size (:micro typography/type-scale)}
+                 :font-size (:micro rf.story.theme.typography/type-scale)}
    :custom-go   {:padding         "3px 8px"
-                 :background      (:accent-amber colors/tokens)
+                 :background      (:accent-amber rf.story.theme.colors/tokens)
                  :color           "white"
                  :border          "none"
                  :border-radius   "3px"
                  :cursor          "pointer"
                  :font-family     mono-stack
-                 :font-size       (:micro typography/type-scale)}
+                 :font-size       (:micro rf.story.theme.typography/type-scale)}
    :backdrop    {:position "fixed"
                  :top "0" :left "0" :right "0" :bottom "0"
                  :z-index 1499
@@ -223,7 +223,7 @@
 
 (defn- preset-row
   [id active-id]
-  (let [{:keys [label width height]} (get viewport/presets id)
+  (let [{:keys [label width height]} (get rf.story.viewport/presets id)
         active? (= id active-id)]
     [:button
      {:style       (merge (:item styles)
@@ -304,7 +304,7 @@
        [:div {:style     (:menu styles)
               :role      "menu"
               :data-test "story-viewport-menu"}
-        (for [id viewport/preset-order]
+        (for [id rf.story.viewport/preset-order]
           ^{:key id} [preset-row id active-id])
         [:div {:style (:divider styles)}]
         (custom-row)])]))
@@ -313,4 +313,4 @@
   "Render the chip only when Story is enabled. Production builds with
   `re-frame.story.config/enabled?` false get nothing."
   []
-  (when config/enabled? [chip]))
+  (when rf.story.config/enabled? [chip]))

--- a/tools/story/src/re_frame/story/ui/watch.cljc
+++ b/tools/story/src/re_frame/story/ui/watch.cljc
@@ -34,7 +34,7 @@
      after every control edit and the detector missed the re-run).
   4. `view-schema-digest` per testable frame — rf2-3y7l7u. `snapshot-tuple`
      ALSO hashes each variant frame's registered app-db schema digest
-     (identity/view-schema-digest, off the `:schemas/app-schemas-digest`
+     (rf.story.identity/view-schema-digest, off the `:schemas/app-schemas-digest`
      late-bind hook). A view-schema hot-reload perturbs THAT digest but
      does NOT write the Story side-table, so it does NOT bump the
      registrar mutation-tick — the four Story-side inputs above are all
@@ -42,14 +42,14 @@
      short-circuits a real drift and the schema-affected variant never
      re-runs. The digest is cheap (empty-set → the stable empty-string
      digest for the common no-schema variant frame), and reusing
-     `identity/view-schema-digest` keeps the signal byte-identical to the
+     `rf.story.identity/view-schema-digest` keeps the signal byte-identical to the
      snapshot-tuple input it guards.
 
   When the key matches the previous tick's key we return the cached map —
   zero hashing work. When it drifts we recompute the lot once and re-seed."
-  (:require [re-frame.story.identity  :as identity]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.story.ui.state  :as state]))
+  (:require [re-frame.story.identity  :as rf.story.identity]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.ui.state  :as rf.story.ui.state]))
 
 (defonce ^:private testable-hash-cache
   (atom {:key nil :hashes nil}))
@@ -58,13 +58,13 @@
   "Fifth cache-key input (rf2-3y7l7u): the per-testable-frame view-schema
   digests, in `testable` order. A view-schema hot-reload changes a
   variant frame's registered app-db schema digest — which `snapshot-tuple`
-  hashes via `identity/view-schema-digest` — WITHOUT bumping the Story
+  hashes via `rf.story.identity/view-schema-digest` — WITHOUT bumping the Story
   registrar mutation-tick, so this is the only cache-key signal that moves
   when a schema (and nothing else) changes. Cheap: each digest is a walk
   of the frame's registered schema set (the stable empty-string digest for
   a variant frame with no registered schemas / not yet allocated)."
   [testable]
-  (mapv identity/view-schema-digest testable))
+  (mapv rf.story.identity/view-schema-digest testable))
 
 (defn compute-testable-content-hashes
   "Walk the registered testable variants and return a `{variant-id →
@@ -81,17 +81,17 @@
   `:substrate`, `:cell-overrides`, per-frame view-schema digest) have
   drifted since the last tick — see the ns docstring."
   []
-  (let [shell      (state/get-state)
+  (let [shell      (rf.story.ui.state/get-state)
         modes      (:active-modes shell)
         subs       (:substrate shell)
         overrides  (:cell-overrides shell)
-        tick       (registrar/current-mutation-tick)
+        tick       (rf.story.registrar/current-mutation-tick)
         ;; `testable` is needed BEFORE the cache check to form the
         ;; view-schema signal, so it is computed every tick (a registrar
         ;; walk + `:test`-tag filter — far cheaper than the per-variant
         ;; snapshot hashing the cache guards).
-        testable   (state/testable-variant-ids
-                     (:variants (state/registry-snapshot)))
+        testable   (rf.story.ui.state/testable-variant-ids
+                     (:variants (rf.story.ui.state/registry-snapshot)))
         schema-sig (testable-schema-signal testable)
         key        [tick modes subs overrides schema-sig]
         cached     @testable-hash-cache]
@@ -103,7 +103,7 @@
                                             :substrate      subs
                                             :cell-overrides (get overrides vid)}]
                                   [vid (:content-hash
-                                         (identity/snapshot-identity vid opts))])))
+                                         (rf.story.identity/snapshot-identity vid opts))])))
                          testable)]
         (reset! testable-hash-cache {:key key :hashes hashes})
         hashes))))

--- a/tools/story/src/re_frame/story/ui/workspace.cljc
+++ b/tools/story/src/re_frame/story/ui/workspace.cljc
@@ -70,14 +70,14 @@
 
   Per `005-SOTA-Features.md` §`:variants-grid` workspace layout the `:variants-grid` layout is the v1 devcards-
   style multi-variant pane."
-  (:require [re-frame.story.registrar :as registrar]
-            [re-frame.story.budgets :as budgets]
+  (:require [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.budgets :as rf.story.budgets]
             #?@(:cljs [[reagent.core :as r]
                        [re-frame.core :as rf]
-                       [re-frame.story.args :as args]
-                       [re-frame.story.config :as config]
-                       [re-frame.story.decorators :as decorators]
-                       [re-frame.story.runtime :as runtime]
+                       [re-frame.story.args :as rf.story.args]
+                       [re-frame.story.config :as rf.story.config]
+                       [re-frame.story.decorators :as rf.story.decorators]
+                       [re-frame.story.runtime :as rf.story.runtime]
                        ;; The merged `rf/frame-provider {:frame …}` shape
                        ;; routes through Reagent's `:r>` interop head, which
                        ;; avoids `:>`'s `(name kw)` prop conversion dropping
@@ -87,13 +87,13 @@
                        ;; namespaced ids of the form `:story.x/y`, and a
                        ;; namespace-dropping provider would scope the
                        ;; subtree to `:y` — a frame that does not exist.
-                       [re-frame.story.ui.assertion-strip :as assertion-strip]
-                       [re-frame.story.ui.canvas :as canvas]
-                       [re-frame.story.ui.multi-substrate :as multi-substrate]
-                       [re-frame.story.ui.state :as state]])
-            #?(:cljs [re-frame.story.ui.markdown :as md])
-            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
-            [re-frame.story.theme.colors :as colors]))
+                       [re-frame.story.ui.assertion-strip :as rf.story.ui.assertion-strip]
+                       [re-frame.story.ui.canvas :as rf.story.ui.canvas]
+                       [re-frame.story.ui.multi-substrate :as rf.story.ui.multi-substrate]
+                       [re-frame.story.ui.state :as rf.story.ui.state]])
+            #?(:cljs [re-frame.story.ui.markdown :as rf.story.ui.markdown])
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]))
 
 ;; ---- pure: layout resolution --------------------------------------------
 
@@ -101,7 +101,7 @@
   "Return the variant ids whose parent story is `story-id`. Pure
   derivation against the registrar — used by `:variants-grid`."
   [story-id]
-  (registrar/variants-of story-id))
+  (rf.story.registrar/variants-of story-id))
 
 (defn resolve-layout
   "Given a workspace body, return an ordered vector of cell descriptors.
@@ -164,7 +164,7 @@
 ;; anchor story. At matrix / design-system scale that can be hundreds of
 ;; cells — rendering them all freezes the canvas (spec/018 §10 — never
 ;; freeze or flood). The grid uses the SAME cap-and-page idiom (F1) as the
-;; sidebar and the controls panel, wiring the shared `budgets/bound-cells`
+;; sidebar and the controls panel, wiring the shared `rf.story.budgets/bound-cells`
 ;; helper + the matrix dimension guard. Pure data → data so the budget gate
 ;; exercises the bounding contract at floor scale without a DOM.
 
@@ -173,34 +173,34 @@
   Returns `{:shown [...] :hidden <n> :warn? <bool> :over-hard-cap? <bool>
   :total <n>}`.
 
-  - `:shown` is the first `budgets/grid-visible-cell-cap` (100) cells (G1)
+  - `:shown` is the first `rf.story.budgets/grid-visible-cell-cap` (100) cells (G1)
     unless `expanded?`, in which case it is the full set UP TO
-    `budgets/matrix-hard-cap` (400). Beyond the hard cap the grid NEVER
+    `rf.story.budgets/matrix-hard-cap` (400). Beyond the hard cap the grid NEVER
     renders all cells (G3 — paginate, never freeze): expansion still tops
     out at the hard cap and `:over-hard-cap?` flags that the tail is paged.
   - `:hidden` is the count paged out of `:shown`.
-  - `:warn?` is true when the total reaches `budgets/matrix-warn-threshold`
+  - `:warn?` is true when the total reaches `rf.story.budgets/matrix-warn-threshold`
     (144) — the soft advisory the renderer surfaces (G2).
   - `:over-hard-cap?` is true when the total exceeds the hard cap (G3).
 
-  Routes through `budgets/bound-cells` (the shared cap-and-page primitive)
+  Routes through `rf.story.budgets/bound-cells` (the shared cap-and-page primitive)
   so the grid and the budget gate move with one number. JVM-testable."
   [cells expanded?]
   (let [cells (vec cells)
         total (count cells)
-        over? (budgets/matrix-over-hard-cap? [total])
+        over? (rf.story.budgets/matrix-over-hard-cap? [total])
         ;; G3 — even when the user expands, never render past the hard cap.
         ;; The visible budget is the per-page cap (100); expansion lifts it
         ;; to the hard cap (400) but no further. Over the hard cap we force
         ;; the bound (`expanded?` must NOT short-circuit `bound-cells` to
         ;; the full set — that is the freeze G3 forbids).
-        cap   (if expanded? budgets/matrix-hard-cap budgets/grid-visible-cell-cap)
-        {:keys [shown hidden]} (budgets/bound-cells cells cap
+        cap   (if expanded? rf.story.budgets/matrix-hard-cap rf.story.budgets/grid-visible-cell-cap)
+        {:keys [shown hidden]} (rf.story.budgets/bound-cells cells cap
                                                     (and expanded? (not over?)))]
     {:shown          shown
      :hidden         hidden
      :total          total
-     :warn?          (budgets/matrix-warn? [total])
+     :warn?          (rf.story.budgets/matrix-warn? [total])
      :over-hard-cap? over?}))
 
 ;; ---- pure: :columns grid template (rf2-ugmrg) ---------------------------
@@ -237,11 +237,11 @@
 #?(:cljs
    (def ^:private styles
      {:wrap          {:padding "16px"
-                      :background (:bg-canvas colors/tokens)
+                      :background (:bg-canvas rf.story.theme.colors/tokens)
                       :flex "1"
                       :overflow "auto"}
       :title         {:font-weight "bold"
-                      :color (:info colors/tokens)
+                      :color (:info rf.story.theme.colors/tokens)
                       :font-family mono-stack
                       :margin-bottom "12px"}
       ;; rf2-ugmrg — `:grid-template-columns` is set per-render from the
@@ -251,26 +251,26 @@
       ;; + gap; the renderer merges the computed template in.
       :grid          {:display "grid"
                       :gap "12px"}
-      :cell          {:background (:bg-2 colors/tokens)
+      :cell          {:background (:bg-2 rf.story.theme.colors/tokens)
                       :border "1px solid #3c3c3c"
                       :border-radius "4px"
                       :padding "8px"
                       :min-height "160px"
-                      :color (:text-primary colors/tokens)
+                      :color (:text-primary rf.story.theme.colors/tokens)
                       :font-family mono-stack
-                      :font-size (:caption typography/type-scale)}
-      :cell-title    {:color (:warning colors/tokens)
+                      :font-size (:caption rf.story.theme.typography/type-scale)}
+      :cell-title    {:color (:warning rf.story.theme.colors/tokens)
                       :font-weight "bold"
                       :margin-bottom "4px"}
       :prose-block   {:padding "12px"
-                      :background (:bg-2 colors/tokens)
-                      :color (:text-primary colors/tokens)
+                      :background (:bg-2 rf.story.theme.colors/tokens)
+                      :color (:text-primary rf.story.theme.colors/tokens)
                       :border-radius "4px"
                       :margin-bottom "12px"
                       :line-height "1.5"}
       :prose-flow    {:display "flex"
                       :flex-direction "column"}
-      :empty         {:color (:text-tertiary colors/tokens)
+      :empty         {:color (:text-tertiary rf.story.theme.colors/tokens)
                       :font-style "italic"
                       :padding "24px"
                       :text-align "center"}
@@ -278,9 +278,9 @@
       ;; renders when its cell count exceeds the visible cap. Mirrors the
       ;; sidebar's `:variant-more` affordance language (spec/018 §10).
       :grid-more     {:padding "8px 0 2px"
-                      :color (:text-tertiary colors/tokens)
+                      :color (:text-tertiary rf.story.theme.colors/tokens)
                       :font-family mono-stack
-                      :font-size (:caption typography/type-scale)
+                      :font-size (:caption rf.story.theme.typography/type-scale)
                       :font-style "italic"
                       :background "none"
                       :border "none"
@@ -292,12 +292,12 @@
       ;; capped page below. The G3 hard-cap note reuses this style.
       :grid-warn     {:padding "6px 8px"
                       :margin-bottom "8px"
-                      :color (:warning colors/tokens)
-                      :background (:bg-2 colors/tokens)
-                      :border-left (str "3px solid " (:warning colors/tokens))
+                      :color (:warning rf.story.theme.colors/tokens)
+                      :background (:bg-2 rf.story.theme.colors/tokens)
+                      :border-left (str "3px solid " (:warning rf.story.theme.colors/tokens))
                       :border-radius "3px"
                       :font-family mono-stack
-                      :font-size (:caption typography/type-scale)}}))
+                      :font-size (:caption rf.story.theme.typography/type-scale)}}))
 
 ;; ---- the Reagent renderer ------------------------------------------------
 
@@ -307,38 +307,38 @@
      falling back to the parent story (per `001-Authoring.md` §Registration macros, the parent
      story usually carries the `:component`)."
      [variant-id]
-     (let [vb       (registrar/handler-meta :variant variant-id)
-           story-id (args/parent-story-id variant-id)
+     (let [vb       (rf.story.registrar/handler-meta :variant variant-id)
+           story-id (rf.story.args/parent-story-id variant-id)
            sb       (when story-id
-                      (registrar/handler-meta :story story-id))]
+                      (rf.story.registrar/handler-meta :story story-id))]
        (or (:component vb) (:component sb)))))
 
 #?(:cljs
    (defn- run-variant-with-shell-opts!
      "Drive `run-variant` for `variant-id` with the current shell
      state's modes / cell overrides / substrate. Mirrors
-     `canvas/run-with-shell-opts!`; reproduced here so the workspace
+     `rf.story.ui.canvas/run-with-shell-opts!`; reproduced here so the workspace
      mounts each cell's frame independently of which variant the canvas
      happens to have last rendered."
      [variant-id]
-     (let [shell @state/shell-state-atom
+     (let [shell @rf.story.ui.state/shell-state-atom
            opts  {:active-modes   (:active-modes shell)
                   :cell-overrides (get-in shell [:cell-overrides variant-id])
                   :substrate      (:substrate shell)}]
-       (runtime/run-variant variant-id opts)
+       (rf.story.runtime/run-variant variant-id opts)
        nil)))
 
 #?(:cljs
    (defn- variant-cell-inner
      "Read the variant's resolved view + decorator pack + effective
      args and render the variant body inside the cell. Mirrors
-     `canvas/canvas-inner` at a smaller scale — a SINGLE-TREE render, no
+     `rf.story.ui.canvas/canvas-inner` at a smaller scale — a SINGLE-TREE render, no
      share affordance, errors render inline.
 
      'Single substrate' describes the render's SHAPE, not an assumption
      about which one: since rf2-r4coe the cell resolves the substrate
-     through `canvas/variant-substrate-set` and reduces it with
-     `multi-substrate/single-render-substrate`, rather than painting
+     through `rf.story.ui.canvas/variant-substrate-set` and reduces it with
+     `rf.story.ui.multi-substrate/single-render-substrate`, rather than painting
      Reagent whatever the variant declared. A workspace never grids a
      single variant across substrates the way the canvas can — that is
      what stays smaller here.
@@ -357,18 +357,18 @@
      carried no `:count`)."
      [variant-id]
      (let [view-id        (variant-component-id variant-id)
-           shell          @state/shell-state-atom
+           shell          @rf.story.ui.state/shell-state-atom
            ;; rf2-eyrpr — thread the per-run opts into `resolve-decorators`
-           ;; (mirrors `canvas/canvas-inner`) so the plan it recompiles to
+           ;; (mirrors `rf.story.ui.canvas/canvas-inner`) so the plan it recompiles to
            ;; read `[:world :decorators]` substitutes `[:arg]` keys that
            ;; resolve only through a mode / cell layer instead of throwing.
            run-opts       {:active-modes   (:active-modes shell)
                            :cell-overrides (get-in shell
                                                    [:cell-overrides
                                                     variant-id])}
-           decorator-pack (decorators/resolve-decorators variant-id run-opts)
-           eff-args       (args/resolve-args variant-id run-opts)
-           assertions     (runtime/read-assertions variant-id)
+           decorator-pack (rf.story.decorators/resolve-decorators variant-id run-opts)
+           eff-args       (rf.story.args/resolve-args variant-id run-opts)
+           assertions     (rf.story.runtime/read-assertions variant-id)
            errors         (:errors decorator-pack)]
        ;; Per rf2-9la06: stamp `data-test-variant` on each cell so
        ;; Playwright specs can disambiguate workspace cells from each
@@ -381,21 +381,21 @@
         [:div {:style (:cell-title styles)}
          [:span (pr-str variant-id)]
          (when view-id
-           [:span {:style {:color (:text-secondary colors/tokens) :margin-left "8px"
+           [:span {:style {:color (:text-secondary rf.story.theme.colors/tokens) :margin-left "8px"
                            :font-weight "normal"}}
             (str "→ " (pr-str view-id))])]
         (cond
           (nil? view-id)
-          [:div {:style {:color (:text-secondary colors/tokens) :font-style "italic"
+          [:div {:style {:color (:text-secondary rf.story.theme.colors/tokens) :font-style "italic"
                          :padding "8px 0"}}
            "variant has no :component registered — register one on the story or variant body"]
 
           :else
           ;; Resolve the renderer through the SUBSTRATE REGISTRY, by the same
-          ;; policy the canvas uses (`canvas/variant-substrate-set` →
+          ;; policy the canvas uses (`rf.story.ui.canvas/variant-substrate-set` →
           ;; declared set, else the shell's host substrate) reduced to the one
           ;; substrate a single-tree render can paint under
-          ;; (`multi-substrate/single-render-substrate`).
+          ;; (`rf.story.ui.multi-substrate/single-render-substrate`).
           ;;
           ;; rf2-r4coe: this branch used to call `(rf/view view-id)` itself and
           ;; embed the result as a Reagent hiccup vector — the identical bypass
@@ -405,7 +405,7 @@
           ;; new behaviour needing a ruling. At source it already had one, and
           ;; used it everywhere except here: `run-variant-with-shell-opts!`
           ;; threads `:substrate (:substrate shell)` into every run, and
-          ;; `canvas/run-key` — which `variant-cell` keys its re-runs on —
+          ;; `rf.story.ui.canvas/run-key` — which `variant-cell` keys its re-runs on —
           ;; carries `:substrate` precisely so the cell re-renders when the
           ;; user flips it. Painting Reagent regardless made that re-run a lie.
           ;; So this is a bypass removal, not a feature: the cell now honours
@@ -422,8 +422,8 @@
           ;; mode / cell-override `run-opts` threaded into `resolve-decorators`
           ;; above, so the cell consumes the render half and keeps its own
           ;; `safe-decorated-view` wrap — the same trap rf2-3afns navigated.
-          (let [substrate (multi-substrate/single-render-substrate
-                            (canvas/variant-substrate-set variant-id)
+          (let [substrate (rf.story.ui.multi-substrate/single-render-substrate
+                            (rf.story.ui.canvas/variant-substrate-set variant-id)
                             :reagent)]
             ;; Scope the rendered view's subscribe / dispatch to the
             ;; variant's allocated frame via the namespace-preserving
@@ -447,18 +447,18 @@
             ;; axe-core to ONLY the variant's rendered tree.
             [rf/frame-provider {:frame variant-id}
              [:div {:data-rf-story-variant-root (pr-str variant-id)}
-              (canvas/safe-decorated-view
-                (multi-substrate/render-view
+              (rf.story.ui.canvas/safe-decorated-view
+                (rf.story.ui.multi-substrate/render-view
                   substrate variant-id view-id eff-args)
                 (:hiccup decorator-pack)
                 eff-args)]]))
         (when (seq errors)
-          [:div {:style {:background (:danger-bg colors/tokens)
+          [:div {:style {:background (:danger-bg rf.story.theme.colors/tokens)
                          :border "1px solid #be4040"
-                         :color (:danger colors/tokens)
+                         :color (:danger rf.story.theme.colors/tokens)
                          :padding "6px"
                          :margin-top "6px"
-                         :font-size (:micro typography/type-scale)
+                         :font-size (:micro rf.story.theme.typography/type-scale)
                          :border-radius "3px"}}
            [:div "Decorator errors:"]
            (for [[i e] (map-indexed vector errors)]
@@ -470,7 +470,7 @@
         ;; component; both render off the same per-record projection
         ;; rather than `pr-str`-ing raw maps.
         (when (seq assertions)
-          [assertion-strip/assertion-strip assertions])])))
+          [rf.story.ui.assertion-strip/assertion-strip assertions])])))
 
 #?(:cljs
    (defn- variant-cell
@@ -500,7 +500,7 @@
      owns the pre-allocation.
 
      Per rf2-c56hr (sibling to rf2-kgn0c, rf2-z4fza): the per-cell
-     `last-run-key` atom tracks the most-recent `(canvas/run-key shell
+     `last-run-key` atom tracks the most-recent `(rf.story.ui.canvas/run-key shell
      variant-id)` value seen by THIS cell. The prior implementation
      keyed only on `:hot-reload-tick`, so editing a control through
      the controls panel — which writes through to `:cell-overrides`
@@ -514,8 +514,8 @@
      interaction — same property the tick-only path preserved."
      [variant-id]
      (r/with-let [last-run-key (atom nil)]
-       (let [shell @state/shell-state-atom
-             key   (canvas/run-key shell variant-id)]
+       (let [shell @rf.story.ui.state/shell-state-atom
+             key   (rf.story.ui.canvas/run-key shell variant-id)]
          (when (not= key @last-run-key)
            (reset! last-run-key key)
            (run-variant-with-shell-opts! variant-id))
@@ -526,7 +526,7 @@
      [body]
      [:div {:style     (:prose-block styles)
             :data-test "story-workspace-prose-rendered"}
-      (md/parse body)]))
+      (rf.story.ui.markdown/parse body)]))
 
 #?(:cljs
    (defn- cell-key
@@ -583,15 +583,15 @@
       :tab-button  {:background     "#2d2d2d"
                     :border         "1px solid #3c3c3c"
                     :border-radius  "3px 3px 0 0"
-                    :color          (:text-primary colors/tokens)
+                    :color          (:text-primary rf.story.theme.colors/tokens)
                     :font-family    mono-stack
-                    :font-size      (:caption typography/type-scale)
+                    :font-size      (:caption rf.story.theme.typography/type-scale)
                     :padding        "4px 10px"
                     :cursor         "pointer"}
-      :tab-active  {:background     (:bg-2 colors/tokens)
+      :tab-active  {:background     (:bg-2 rf.story.theme.colors/tokens)
                     :border         "1px solid #569cd6"
                     :border-bottom  "1px solid #252526"
-                    :color          (:info colors/tokens)
+                    :color          (:info rf.story.theme.colors/tokens)
                     :font-weight    "bold"}
       :tab-body    {:display "block"}}))
 
@@ -677,17 +677,17 @@
       :nav-button  {:background    "#2d2d2d"
                     :border        "1px solid #3c3c3c"
                     :border-radius "3px"
-                    :color         (:text-primary colors/tokens)
+                    :color         (:text-primary rf.story.theme.colors/tokens)
                     :font-family   mono-stack
-                    :font-size     (:caption typography/type-scale)
+                    :font-size     (:caption rf.story.theme.typography/type-scale)
                     :padding       "4px 10px"
                     :cursor        "pointer"}
-      :nav-button-disabled {:background  (:bg-2 colors/tokens)
+      :nav-button-disabled {:background  (:bg-2 rf.story.theme.colors/tokens)
                             :color       "#666666"
                             :cursor      "not-allowed"}
-      :nav-label   {:color       (:info colors/tokens)
+      :nav-label   {:color       (:info rf.story.theme.colors/tokens)
                     :font-family mono-stack
-                    :font-size   (:caption typography/type-scale)
+                    :font-size   (:caption rf.story.theme.typography/type-scale)
                     :font-weight "bold"}
       :nav-body    {:display "block"}}))
 
@@ -819,11 +819,11 @@
                    :data-test-grid-warn (str total)
                    :data-test-grid-over-hard-cap (str (boolean over-hard-cap?))}
              (if over-hard-cap?
-               (str "⚠ " total " cells exceed the " budgets/matrix-hard-cap
+               (str "⚠ " total " cells exceed the " rf.story.budgets/matrix-hard-cap
                     "-cell hard cap — the grid is paged and will never render "
                     "all cells. Narrow the story's variants or filter.")
                (str "⚠ dense matrix: " total " cells (≥ "
-                    budgets/matrix-warn-threshold
+                    rf.story.budgets/matrix-warn-threshold
                     "). Consider narrowing the variants axis."))])
           [:div {:style (assoc (:grid styles)
                                :grid-template-columns
@@ -854,7 +854,7 @@
      keys, the workspace-level remount still guarantees frame setup
      re-fires on swap. Per rf2-kgn0c."
      [workspace-id]
-     (let [body (registrar/handler-meta :workspace workspace-id)]
+     (let [body (rf.story.registrar/handler-meta :workspace workspace-id)]
        (cond
          (nil? body)
          ;; Per rf2-xc65: workspace wrap is a scrollable container —

--- a/tools/story/src/re_frame/story/ui/xray_embed.cljs
+++ b/tools/story/src/re_frame/story/ui/xray_embed.cljs
@@ -56,18 +56,18 @@
   (:require [reagent.core :as r]
             [day8.re-frame2-xray.mount :as xray-mount]
             [day8.re-frame2-xray.panels :as xray-panels]
-            [re-frame.story.config :as config]
-            [re-frame.story.predicates :as pred]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.story.theme.colors :as colors]
-            [re-frame.story.theme.glyphs :as glyphs]
-            [re-frame.story.theme.motion :as motion]
-            [re-frame.story.theme.typography :as typography :refer [sans-stack]]
-            [re-frame.story.ui.state :as state]
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.predicates :as rf.story.predicates]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.theme.colors :as rf.story.theme.colors]
+            [re-frame.story.theme.glyphs :as rf.story.theme.glyphs]
+            [re-frame.story.theme.motion :as rf.story.theme.motion]
+            [re-frame.story.theme.typography :as rf.story.theme.typography :refer [sans-stack]]
+            [re-frame.story.ui.state :as rf.story.ui.state]
             ;; rf2-q5pd6 — the panel-host flushes a parked `:filters`
             ;; preset right after Xray's mount registers the `:rf/xray`
             ;; frame. One-way: `xray-preset` never requires this ns.
-            [re-frame.story.xray-preset :as xray-preset]))
+            [re-frame.story.xray-preset :as rf.story.xray-preset]))
 
 ;; ---- embed descriptor: the single mount-routing source (rf2-jf87oq) -------
 ;;
@@ -153,10 +153,10 @@
   unknown keyword in the slot falls back to `default-panel` so a
   typo doesn't blank the RHS."
   [variant-id]
-  (let [variant-body (registrar/handler-meta :variant variant-id)
-        story-id     (pred/parent-story-id variant-id)
+  (let [variant-body (rf.story.registrar/handler-meta :variant variant-id)
+        story-id     (rf.story.predicates/parent-story-id variant-id)
         story-body   (when story-id
-                       (registrar/handler-meta :story story-id))
+                       (rf.story.registrar/handler-meta :story story-id))
         ;; rf2-v1ach: the `:xray-panel` slot lives directly on the
         ;; body for ergonomics (parallel to `:tags`, `:viewport`,
         ;; `:background`). Variant slot wins, then story slot, then
@@ -218,9 +218,9 @@
 
   `day8/re-frame2-xray` is a declared Story dependency, so the
   popout symbol is always on the compile classpath; the only gate is
-  Story's own `config/enabled?` elision posture."
+  Story's own `rf.story.config/enabled?` elision posture."
   []
-  (when config/enabled?
+  (when rf.story.config/enabled?
     (xray-mount/popout!)))
 
 ;; ---- styling -------------------------------------------------------------
@@ -245,23 +245,23 @@
                    :gap "4px"
                    :flex-wrap "wrap"
                    :padding-bottom "6px"
-                   :border-bottom (str "1px solid " (:seam-xray-soft colors/tokens))
+                   :border-bottom (str "1px solid " (:seam-xray-soft rf.story.theme.colors/tokens))
                    :font-family sans-stack}
    :chip          {:padding "3px 10px"
-                   :background (:bg-3 colors/tokens)
-                   :color (:text-secondary colors/tokens)
-                   :border (str "1px solid " (:border-subtle colors/tokens))
+                   :background (:bg-3 rf.story.theme.colors/tokens)
+                   :color (:text-secondary rf.story.theme.colors/tokens)
+                   :border (str "1px solid " (:border-subtle rf.story.theme.colors/tokens))
                    :border-radius "10px"
                    :cursor "pointer"
                    :font-family sans-stack
-                   :font-size (:caption typography/type-scale)
+                   :font-size (:caption rf.story.theme.typography/type-scale)
                    :letter-spacing "0.01em"
                    :user-select "none"
-                   :transition (:chip motion/transitions)}
-   :chip-active   {:background (:accent-amber colors/tokens)
-                   :color (:text-on-accent colors/tokens)
-                   :border (str "1px solid " (:accent-amber-deep colors/tokens))
-                   :font-weight (str (:semibold typography/weights))}
+                   :transition (:chip rf.story.theme.motion/transitions)}
+   :chip-active   {:background (:accent-amber rf.story.theme.colors/tokens)
+                   :color (:text-on-accent rf.story.theme.colors/tokens)
+                   :border (str "1px solid " (:accent-amber-deep rf.story.theme.colors/tokens))
+                   :font-weight (str (:semibold rf.story.theme.typography/weights))}
    :spacer        {:flex "1"}
    ;; rf2-v1ach — "pop out full Xray" escape hatch. Sits at the
    ;; right edge of the chip-row so the user reads it as 'leave the
@@ -269,17 +269,17 @@
    ;; external-link glyph so its action is iconographically obvious.
    :popout-chip   {:padding "3px 10px"
                    :background "transparent"
-                   :color (:info colors/tokens)
-                   :border (str "1px solid " (:border-default colors/tokens))
+                   :color (:info rf.story.theme.colors/tokens)
+                   :border (str "1px solid " (:border-default rf.story.theme.colors/tokens))
                    :border-radius "10px"
                    :cursor "pointer"
                    :font-family sans-stack
-                   :font-size (:caption typography/type-scale)
+                   :font-size (:caption rf.story.theme.typography/type-scale)
                    :letter-spacing "0.01em"
                    :display "inline-flex"
                    :align-items "center"
                    :gap "4px"
-                   :transition (:chip motion/transitions)}
+                   :transition (:chip rf.story.theme.motion/transitions)}
    ;; rf2-v1ach — the mounted-panel slot. Xray's panel mounts into
    ;; this DOM element (a `<div>` with `data-rf-xray-panel-host`).
    ;; `position: relative` + `flex: 1 1 auto` so the panel
@@ -291,7 +291,7 @@
                    :min-height "240px"
                    :overflow "hidden"
                    :border-radius "4px"
-                   :background (:bg-canvas colors/tokens)}
+                   :background (:bg-canvas rf.story.theme.colors/tokens)}
    ;; rf2-9k43e — the compact in-place EVENT SPINE band. Sits BETWEEN
    ;; the chip-row and the chip-selected panel-host so the user reads:
    ;; pick a lens (chip-row) → scan the variant's recent events (spine)
@@ -310,20 +310,20 @@
                    :max-height "140px"
                    :overflow "hidden"
                    :border-radius "4px"
-                   :background (:bg-canvas colors/tokens)}
+                   :background (:bg-canvas rf.story.theme.colors/tokens)}
    ;; rf2-9k43e — caption above the spine band so the affordance reads
    ;; as 'this is the variant's recent-events timeline; click to focus'.
    :spine-caption {:padding "0 2px 2px"
-                   :color (:text-tertiary colors/tokens)
+                   :color (:text-tertiary rf.story.theme.colors/tokens)
                    :font-family sans-stack
-                   :font-size (:caption typography/type-scale)
+                   :font-size (:caption rf.story.theme.typography/type-scale)
                    :letter-spacing "0.02em"
                    :text-transform "uppercase"
                    :user-select "none"}
    :empty         {:padding "16px 8px"
-                   :color (:text-tertiary colors/tokens)
+                   :color (:text-tertiary rf.story.theme.colors/tokens)
                    :font-family sans-stack
-                   :font-size (:caption typography/type-scale)
+                   :font-size (:caption rf.story.theme.typography/type-scale)
                    :font-style "italic"}
    ;; rf2-ba86n.19 — lazy Xray-diff mounting. The disclosure toggle that
    ;; collapses / expands the embed. Sits at the LEFT edge of the chip-row
@@ -334,13 +334,13 @@
                    :justify-content "center"
                    :padding "2px"
                    :background "transparent"
-                   :color (:text-secondary colors/tokens)
+                   :color (:text-secondary rf.story.theme.colors/tokens)
                    :border "none"
                    :cursor "pointer"
                    :line-height "0"
-                   :transition (:chip motion/transitions)}
+                   :transition (:chip rf.story.theme.motion/transitions)}
    :disclosure-glyph {:display "inline-flex"
-                      :transition (:chip motion/transitions)
+                      :transition (:chip rf.story.theme.motion/transitions)
                       :transform "rotate(90deg)"}
    :disclosure-glyph-collapsed {:transform "rotate(0deg)"}
    ;; rf2-ba86n.19 — the collapsed placeholder. Replaces the panel-host
@@ -352,16 +352,16 @@
                     :min-height "0"
                     :padding "10px 8px"
                     :cursor "pointer"
-                    :color (:text-tertiary colors/tokens)
+                    :color (:text-tertiary rf.story.theme.colors/tokens)
                     :font-family sans-stack
-                    :font-size (:caption typography/type-scale)
+                    :font-size (:caption rf.story.theme.typography/type-scale)
                     :font-style "italic"}})
 
 ;; ---- chip rendering ------------------------------------------------------
 
 (defn chip
   "Render a single chip for `panel-id`. Click handler dispatches the
-  panel selection via `state/swap-state!` so the RHS slot re-renders.
+  panel selection via `rf.story.ui.state/swap-state!` so the RHS slot re-renders.
   Public so tests can introspect the chip-level hiccup without
   driving the full host."
   [panel-id label title active?]
@@ -374,7 +374,7 @@
     :data-test "story-xray-panel-chip"
     :data-xray-panel (name panel-id)
     :on-click (fn [_]
-                (state/swap-state!
+                (rf.story.ui.state/swap-state!
                   (fn [s] (assoc s :xray-panel panel-id))))}
    label])
 
@@ -551,7 +551,7 @@
                                 ;; it can land. No-op (and cheap) when nothing
                                 ;; is pending, which is every mount after the
                                 ;; first.
-                                (xray-preset/flush-pending-filters!))
+                                (rf.story.xray-preset/flush-pending-filters!))
                               (catch :default e
                                 (when (and (exists? js/console)
                                            (.-warn js/console))
@@ -606,10 +606,10 @@
              "Expand the Xray panel (resume diff compute)"
              "Collapse the Xray panel (defer diff compute)")
     :on-click (fn [_]
-                (state/swap-state! state/toggle-xray-embed-collapsed))}
+                (rf.story.ui.state/swap-state! rf.story.ui.state/toggle-xray-embed-collapsed))}
    [:span {:style (merge (:disclosure-glyph styles)
                          (when collapsed? (:disclosure-glyph-collapsed styles)))}
-    [glyphs/chevron-right 11]]])
+    [rf.story.theme.glyphs/chevron-right 11]]])
 
 ;; ---- event-spine band -----------------------------------------------------
 
@@ -655,7 +655,7 @@
   Returns nil when no variant is focused — the panels are
   cascade-scoped; without a variant there's nothing to inspect."
   []
-  (let [shell      @state/shell-state-atom
+  (let [shell      @rf.story.ui.state/shell-state-atom
         variant-id (:selected-variant shell)]
     (cond
       (not variant-id)
@@ -672,7 +672,7 @@
             ;; user expands. The chip-row picker still paints (cheap — it's
             ;; pure data + click handlers, no Xray symbol), so the author's
             ;; lens choice survives a collapse round-trip.
-            collapsed?   (state/xray-embed-collapsed? shell)]
+            collapsed?   (rf.story.ui.state/xray-embed-collapsed? shell)]
         [:div {:style (:wrap styles)
                :data-test "story-xray-embed"
                :data-active-panel (name active-panel)
@@ -692,7 +692,7 @@
             :title "Open the full Xray 4-layer shell in a new window"
             :on-click (fn [_] (popout-full-shell!))}
            [:span "Pop out"]
-           [glyphs/external-link 11]]]
+           [rf.story.theme.glyphs/external-link 11]]]
          ;; rf2-ba86n.19 — lazy Xray-diff mounting (spec/018 §10). When
          ;; collapsed a quiet placeholder stands in for the panel-host;
          ;; crucially it does NOT render `panel-host-component`, so the
@@ -726,7 +726,7 @@
            [:div {:style (:collapsed-rest styles)
                   :data-test "story-xray-embed-collapsed"
                   :on-click (fn [_]
-                              (state/swap-state! state/set-xray-embed-collapsed false))}
+                              (rf.story.ui.state/swap-state! rf.story.ui.state/set-xray-embed-collapsed false))}
             (str (or (some #(when (= active-panel (:panel %)) (:label %))
                            panel-catalog)
                      "Xray")

--- a/tools/story/src/re_frame/story/view_args.cljc
+++ b/tools/story/src/re_frame/story/view_args.cljc
@@ -48,9 +48,9 @@
   behind the §6 elision contract along with the rest of the Story runtime;
   the default lookup reads the Story side-table, which is empty in a
   production bundle."
-  (:require [re-frame.story.malli-schema :as msu]
-            [re-frame.story.plan         :as plan]
-            [re-frame.story.registrar    :as registrar]))
+  (:require [re-frame.story.malli-schema :as rf.story.malli-schema]
+            [re-frame.story.plan         :as rf.story.plan]
+            [re-frame.story.registrar    :as rf.story.registrar]))
 
 ;; ---- key resolution (re-exported from the leaf for the in-ns surface) ----
 ;;
@@ -62,7 +62,7 @@
 (def view-args-schema-keys
   "Re-export of `malli-schema/view-args-schema-keys` — the canonical
   first-match key order `[:rf/props :schema]`."
-  msu/view-args-schema-keys)
+  rf.story.malli-schema/view-args-schema-keys)
 
 (def view-args-schema
   "Re-export of `malli-schema/view-args-schema` — the low-level key picker
@@ -70,7 +70,7 @@
   variant-id (not a pre-resolved view-meta) call `compiled-view-args-
   schema` instead, which routes through the compiled plan so an
   `:extends`-inherited / `:compose`-d `:component` resolves."
-  msu/view-args-schema)
+  rf.story.malli-schema/view-args-schema)
 
 ;; ---- compiled-plan resolver (the ONE shared entry) -----------------------
 
@@ -92,13 +92,13 @@
   that fails registration."
   [variant-id]
   (try
-    (-> (plan/variant-plan variant-id) :world :view-args-schema)
+    (-> (rf.story.plan/variant-plan variant-id) :world :view-args-schema)
     (catch #?(:clj Exception :cljs :default) _ nil)))
 
 (defn compiled-view-args-schema
   "Return the view-args (props) schema for a REGISTERED `variant-id`,
   resolved off the COMPILED variant-plan (`[:world :view-args-schema]`) —
-  the single source of truth. Routes through `plan/variant-plan` with the
+  the single source of truth. Routes through `rf.story.plan/variant-plan` with the
   DEFAULT side-table lookup so an `:extends`-inherited or `:compose`-d
   `:component` resolves the same way the runner / render / docs paths see
   it. Returns nil when the variant is unregistered, declares no
@@ -107,10 +107,10 @@
 
   Memoized per `[variant-id mutation-tick]` (see the ns docstring): cheap
   to call per render. The result is identical to
-  `(get-in (plan/variant-plan variant-id) [:world :view-args-schema])` but
+  `(get-in (rf.story.plan/variant-plan variant-id) [:world :view-args-schema])` but
   does not recompile the plan on every call between two registrar writes."
   [variant-id]
-  (let [tick (registrar/current-mutation-tick)
+  (let [tick (rf.story.registrar/current-mutation-tick)
         c    @cache]
     (if (and (= tick (:tick c)) (contains? (:by-id c) variant-id))
       (get (:by-id c) variant-id)

--- a/tools/story/src/re_frame/story/xray_preset.cljc
+++ b/tools/story/src/re_frame/story/xray_preset.cljc
@@ -67,10 +67,10 @@
   Behind `re-frame.story.config/enabled?` per the same posture as the
   rest of `tools/story`. Production builds short-circuit before the
   preset is reached."
-  (:require [re-frame.story.predicates :as pred]
-            [re-frame.story.registrar  :as registrar]
+  (:require [re-frame.story.predicates :as rf.story.predicates]
+            [re-frame.story.registrar  :as rf.story.registrar]
             #?(:cljs [re-frame.core           :as rf])
-            #?(:cljs [re-frame.story.config   :as config])
+            #?(:cljs [re-frame.story.config   :as rf.story.config])
             ;; Direct :require's against the declared `day8/re-frame2-xray`
             ;; dependency (tools/story/deps.edn). A runtime `find-ns-obj`
             ;; + `aget` walk is NOT used for these: it returns a
@@ -81,7 +81,7 @@
             ;; `implementation/` → `tools/` requires, not
             ;; `tools/story` → `tools/xray` (the inverse is explicitly
             ;; fine, and neither artefact reaches a production bundle).
-            #?(:cljs [re-frame.frame :as frame])
+            #?(:cljs [re-frame.frame :as rf.frame])
             #?@(:cljs [[day8.re-frame2-xray.mount :as xray-mount]
                        [day8.re-frame2-xray.config :as xray-config]
                        [day8.re-frame2-xray.keybinding :as xray-keybinding]])))
@@ -107,10 +107,10 @@
   story's `:xray` slot with the variant's `:xray` slot. Returns nil
   when neither carries a preset. Pure-ish (reads the registrar)."
   [variant-id]
-  (let [variant-body (registrar/handler-meta :variant variant-id)
-        story-id     (pred/parent-story-id variant-id)
+  (let [variant-body (rf.story.registrar/handler-meta :variant variant-id)
+        story-id     (rf.story.predicates/parent-story-id variant-id)
         story-body   (when story-id
-                       (registrar/handler-meta :story story-id))
+                       (rf.story.registrar/handler-meta :story story-id))
         story-preset (:xray story-body)
         var-preset   (:xray variant-body)]
     (when (or story-preset var-preset)
@@ -219,8 +219,8 @@
      a different root from Story should call `xray-config/configure!`
      directly AFTER `story/configure!` to override the bridge."
      []
-     (when config/enabled?
-       (when-let [root (config/get-project-root)]
+     (when rf.story.config/enabled?
+       (when-let [root (rf.story.config/get-project-root)]
          ;; Xray's configure! keys live under :rf.xray/* per the
          ;; :rf.<tool>/* convention.
          (safe-call! "config/configure!" xray-config/configure!
@@ -278,7 +278,7 @@
      preload already installed under the default-true posture (runtime
      mechanism). Both fire from `wire-cross-host!` in that order."
      []
-     (when config/enabled?
+     (when rf.story.config/enabled?
        (safe-call! "config/configure!" xray-config/configure!
                    {:rf.xray/keybinding-enabled? false})
        true)))
@@ -321,7 +321,7 @@
      preload was suppressed (e.g. host already set the slot to `false`
      before Xray's preload ran)."
      []
-     (when config/enabled?
+     (when rf.story.config/enabled?
        (safe-call! "keybinding/detach!" xray-keybinding/detach!)
        true)))
 
@@ -337,7 +337,7 @@
 
      Idempotent — each bridge is a plain reset! / no-op on repeat."
      []
-     (when config/enabled?
+     (when rf.story.config/enabled?
        (propagate-project-root!)
        (disable-keybinding!)
        (detach-keybinding!))))
@@ -411,9 +411,9 @@
      mount (a chip-driven panel swap) does not re-apply a preset the user
      may since have edited through the ribbon."
      []
-     (when config/enabled?
+     (when rf.story.config/enabled?
        (when-let [lowered @pending-filters]
-         (when (some? (frame/frame :rf/xray))
+         (when (some? (rf.frame/frame :rf/xray))
            (reset! pending-filters nil)
            (hydrate-filters! lowered)
            lowered)))))
@@ -445,7 +445,7 @@
        (let [lowered (lower-filters filters)]
          (safe-call! "config/configure!" xray-config/configure!
                      {:rf.xray/filters lowered})
-         (if (some? (frame/frame :rf/xray))
+         (if (some? (rf.frame/frame :rf/xray))
            (do (reset! pending-filters nil)
                (hydrate-filters! lowered))
            (reset! pending-filters lowered))
@@ -479,7 +479,7 @@
      Returns the resolved preset (or nil) so the shell can log /
      debug-introspect what fired."
      [variant-id]
-     (when config/enabled?
+     (when rf.story.config/enabled?
        (when-let [preset (resolve-preset variant-id)]
          (when (:open? preset)
            (apply-open!))

--- a/tools/story/test/re_frame/story/artifact_test.cljc
+++ b/tools/story/test/re_frame/story/artifact_test.cljc
@@ -15,18 +15,18 @@
     shared run-result shape (the §A3 acceptance bullets)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core   :as rf]
-            [re-frame.epoch  :as epoch]
-            [re-frame.frame  :as frame]
+            [re-frame.epoch  :as rf.epoch]
+            [re-frame.frame  :as rf.frame]
             [re-frame.http.managed]       ;; production managed-HTTP fx surface (:rf.http/managed)
             [re-frame.http.test-support]  ;; stub install seam + canned-stub handlers
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story.artifact :as artifact]
-            [re-frame.story.determinism :as determinism]
-            [re-frame.story.fingerprint :as fingerprint]
-            [re-frame.story.plan :as plan]
-            [re-frame.story.play.evidence :as evidence]
-            [re-frame.story.play.settled-boundary :as boundary]))
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story.artifact :as rf.story.artifact]
+            [re-frame.story.determinism :as rf.story.determinism]
+            [re-frame.story.fingerprint :as rf.story.fingerprint]
+            [re-frame.story.plan :as rf.story.plan]
+            [re-frame.story.play.evidence :as rf.story.play.evidence]
+            [re-frame.story.play.settled-boundary :as rf.story.play.settled-boundary]))
 
 ;; ===========================================================================
 ;; PURE: schema + construction
@@ -34,35 +34,35 @@
 
 (deftest make-run-artifact-coerces-program
   (testing "a bare event list lifts to a tagged [:dispatch …] program"
-    (let [a (artifact/make-run-artifact
+    (let [a (rf.story.artifact/make-run-artifact
               {:event-program [[:counter/inc] [:dispatch [:counter/dec]]]})]
       (is (= :rf.test/run-artifact (:artifact/kind a)))
       (is (= [[:dispatch [:counter/inc]] [:dispatch [:counter/dec]]]
              (:event-program a))
           "bare event vector lifts; an already-tagged step passes through")
-      (is (artifact/run-artifact? a))))
+      (is (rf.story.artifact/run-artifact? a))))
 
   (testing "an empty / fx-less artifact defaults :fx-decisions to {}"
-    (let [a (artifact/make-run-artifact {})]
+    (let [a (rf.story.artifact/make-run-artifact {})]
       (is (= {} (:fx-decisions a)))
       (is (= [] (:event-program a)))
-      (is (artifact/run-artifact? a))))
+      (is (rf.story.artifact/run-artifact? a))))
 
   (testing ":setup ⧺ :script fold into one ordered program (setup first)"
-    (let [a (artifact/make-run-artifact
+    (let [a (rf.story.artifact/make-run-artifact
               {:setup  [[:dispatch [:seed/a]]]
                :script [[:dispatch [:act/b]] [:wait 5]]})]
       (is (= [[:dispatch [:seed/a]] [:dispatch [:act/b]] [:wait 5]]
              (:event-program a)))))
 
   (testing "an explicit :event-program wins over :setup/:script"
-    (let [a (artifact/make-run-artifact
+    (let [a (rf.story.artifact/make-run-artifact
               {:event-program [[:dispatch [:only/this]]]
                :setup         [[:dispatch [:ignored]]]})]
       (is (= [[:dispatch [:only/this]]] (:event-program a)))))
 
   (testing "slots outside the artifact surface are dropped; known slots kept"
-    (let [a (artifact/make-run-artifact
+    (let [a (rf.story.artifact/make-run-artifact
               {:event-program [[:dispatch [:e]]]
                :seed          42
                :fx-decisions  {:http/get :http/stub}
@@ -75,24 +75,24 @@
 
 (deftest run-artifact-predicate
   (testing "run-artifact? requires the kind tag AND a vector :event-program"
-    (is (artifact/run-artifact?
+    (is (rf.story.artifact/run-artifact?
           {:artifact/kind :rf.test/run-artifact :event-program []}))
-    (is (not (artifact/run-artifact? {:event-program []}))
+    (is (not (rf.story.artifact/run-artifact? {:event-program []}))
         "missing :artifact/kind")
-    (is (not (artifact/run-artifact?
+    (is (not (rf.story.artifact/run-artifact?
                {:artifact/kind :rf.test/run-artifact}))
         "missing :event-program")
-    (is (not (artifact/run-artifact? nil)))
-    (is (not (artifact/run-artifact? [:not :a :map])))))
+    (is (not (rf.story.artifact/run-artifact? nil)))
+    (is (not (rf.story.artifact/run-artifact? [:not :a :map])))))
 
 (deftest program-events-projection
   (testing "program-events projects only the dispatched event vectors"
-    (let [a (artifact/make-run-artifact
+    (let [a (rf.story.artifact/make-run-artifact
               {:event-program [[:dispatch [:a 1]]
                                [:wait 10]
                                [:dispatch-sync [:b 2]]
                                [:assert-db [:k] :v]]})]
-      (is (= [[:a 1] [:b 2]] (artifact/program-events a))
+      (is (= [[:a 1] [:b 2]] (rf.story.artifact/program-events a))
           ":wait / :assert-* contribute no event"))))
 
 ;; ===========================================================================
@@ -109,9 +109,9 @@
 
 (deftest replay-result-shared-shape
   (testing "replay-result builds the shared run-result shape from a clean tape"
-    (let [a    (artifact/make-run-artifact {:event-program [[:dispatch [:e]]]})
+    (let [a    (rf.story.artifact/make-run-artifact {:event-program [[:dispatch [:e]]]})
           tape [(epoch :e1 {:db-after {:n 1}})]
-          res  (artifact/replay-result
+          res  (rf.story.artifact/replay-result
                  {:epoch-tape tape :artifact a
                   :outcomes [{:status :settled :boundary :headless}]
                   :frame-id :rf.test.replay/f :app-db {:n 1}})]
@@ -126,9 +126,9 @@
 
 (deftest replay-result-status-follows-tape
   (testing ":fail when the tape carries unconsumed failure evidence"
-    (let [a    (artifact/make-run-artifact {:event-program [[:dispatch [:e]]]})
+    (let [a    (rf.story.artifact/make-run-artifact {:event-program [[:dispatch [:e]]]})
           tape [(epoch :e1 {:outcome :halt})]
-          res  (artifact/replay-result
+          res  (rf.story.artifact/replay-result
                  {:epoch-tape tape :artifact a
                   :outcomes [{:status :settled :boundary :headless}]
                   :frame-id :f :app-db {}})]
@@ -136,8 +136,8 @@
           "a non-:ok epoch outcome trips the agreement floor")))
 
   (testing ":cannot-run when a step refused"
-    (let [a   (artifact/make-run-artifact {:event-program [[:dispatch [:e]]]})
-          res (artifact/replay-result
+    (let [a   (rf.story.artifact/make-run-artifact {:event-program [[:dispatch [:e]]]})
+          res (rf.story.artifact/replay-result
                 {:epoch-tape [] :artifact a
                  :outcomes [{:status :cannot-run :required-boundary :dom
                              :provided-boundary :headless}]
@@ -146,8 +146,8 @@
       (is (= :dom (get-in res [:cannot-run :required-boundary])))))
 
   (testing ":error when a step errored"
-    (let [a   (artifact/make-run-artifact {:event-program [[:dispatch [:e]]]})
-          res (artifact/replay-result
+    (let [a   (rf.story.artifact/make-run-artifact {:event-program [[:dispatch [:e]]]})
+          res (rf.story.artifact/replay-result
                 {:epoch-tape [] :artifact a
                  :outcomes [{:status :error :error "boom"}]
                  :frame-id :f :app-db {}})]
@@ -159,17 +159,17 @@
 ;; ===========================================================================
 
 (defn- reset-rf! [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
   ;; Requiring `re-frame.epoch` (above) installs the epoch artefact's
   ;; late-bind hooks, so `epoch-history` records a real tape; clear its
   ;; per-frame ring + listeners between tests so a replay reads only its
   ;; own freshly-captured epochs.
-  (epoch/clear-history!)
-  (epoch/clear-epoch-listeners!)
-  (try (rf/init! plain-atom/adapter)
+  (rf.epoch/clear-history!)
+  (rf.epoch/clear-epoch-listeners!)
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
-  (frame/ensure-default-frame!)
+  (rf.frame/ensure-default-frame!)
   (test-fn))
 
 (use-fixtures :each reset-rf!)
@@ -179,9 +179,9 @@
             frame, captures a NEW tape, and returns the shared run-result —
             the fresh frame is torn down before return"
     (rf/reg-event :rep/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-    (let [a   (artifact/make-run-artifact
+    (let [a   (rf.story.artifact/make-run-artifact
                 {:event-program [[:dispatch [:rep/inc]] [:dispatch [:rep/inc]]]})
-          res (artifact/replay-run-artifact a)]
+          res (rf.story.artifact/replay-run-artifact a)]
       (is (= :pass (:status res)))
       (is (= 2 (:n (:app-db res))) "the program ran into a fresh, empty frame")
       (is (seq (:epoch-tape res)) "a NEW epoch tape was captured")
@@ -189,7 +189,7 @@
       (is (= a (:run-artifact res)))
       ;; the internally-allocated frame is gone (teardown ran)
       (let [fid (:frame res)]
-        (is (not (contains? @frame/frames fid))
+        (is (not (contains? @rf.frame/frames fid))
             "the replay-allocated frame is destroyed before return")))))
 
 (deftest replay-reapplies-fx-decisions
@@ -204,10 +204,10 @@
       (rf/reg-fx :rep.fx/stub {:platforms #{:client :server}}
                  (fn [_ _] (swap! hits conj :stub)))
       (rf/reg-event :rep/fire (fn [_ _] {:fx [[:rep.fx/real {}]]}))
-      (let [a   (artifact/make-run-artifact
+      (let [a   (rf.story.artifact/make-run-artifact
                   {:event-program [[:dispatch [:rep/fire]]]
                    :fx-decisions  {:rep.fx/real :rep.fx/stub}})
-            res (artifact/replay-run-artifact a)]
+            res (rf.story.artifact/replay-run-artifact a)]
         (is (= :pass (:status res)))
         (is (= [:stub] @hits)
             "the fx decision remapped :rep.fx/real → :rep.fx/stub on replay")))))
@@ -249,12 +249,12 @@
                                       ([frame-id event-vector opts]
                                        (swap! dispatch-calls conj event-vector)
                                        (swap! dispatch-opts conj opts)
-                                       (boundary/drain-sync! frame-id event-vector opts)))
+                                       (rf.story.play.settled-boundary/drain-sync! frame-id event-vector opts)))
                          :flush!    {:headless (fn [_frame-id] nil)}}
-            a   (artifact/make-run-artifact
+            a   (rf.story.artifact/make-run-artifact
                   {:event-program [[:dispatch [:rep/fire]]]
                    :fx-decisions  {:rep.fx/real :rep.fx/stub}})
-            res (artifact/replay-run-artifact a {:hooks probe-hooks})]
+            res (rf.story.artifact/replay-run-artifact a {:hooks probe-hooks})]
         (is (= :pass (:status res)))
         (is (= [[:rep/fire]] @dispatch-calls)
             "the supplied richer :dispatch! WAS invoked — the fx reapplication
@@ -269,10 +269,10 @@
   (testing "two replays of the same artifact each run into their own fresh
             frame — no shared app-db leaks between replays"
     (rf/reg-event :rep/set (fn [{:keys [db]} [_ v]] {:db (assoc db :v v)}))
-    (let [a    (artifact/make-run-artifact
+    (let [a    (rf.story.artifact/make-run-artifact
                  {:event-program [[:dispatch [:rep/set 7]]]})
-          r1   (artifact/replay-run-artifact a)
-          r2   (artifact/replay-run-artifact a)]
+          r1   (rf.story.artifact/replay-run-artifact a)
+          r2   (rf.story.artifact/replay-run-artifact a)]
       (is (= 7 (:v (:app-db r1))))
       (is (= 7 (:v (:app-db r2))))
       (is (not= (:frame r1) (:frame r2)) "distinct fresh frames"))))
@@ -285,24 +285,24 @@
             per-frame epoch ids from the tape; this bead pins only that the
             result canonicalizes deterministically and run-hash is stable.)"
     (rf/reg-event :rep/seed (fn [{:keys [db]} _] {:db (assoc db :seeded true)}))
-    (let [a   (artifact/replay-run-artifact
-                (artifact/make-run-artifact {:event-program [[:dispatch [:rep/seed]]]}))
-          h   (fingerprint/run-hash a)]
+    (let [a   (rf.story.artifact/replay-run-artifact
+                (rf.story.artifact/make-run-artifact {:event-program [[:dispatch [:rep/seed]]]}))
+          h   (rf.story.fingerprint/run-hash a)]
       (is (string? h))
       (is (= 8 (count h)) "run-hash is the stable 8-char-hex primitive")
-      (is (= h (fingerprint/run-hash a)) "run-hash is idempotent on one result")
-      (is (= (fingerprint/canonicalize a) (fingerprint/canonicalize a))
+      (is (= h (rf.story.fingerprint/run-hash a)) "run-hash is idempotent on one result")
+      (is (= (rf.story.fingerprint/canonicalize a) (rf.story.fingerprint/canonicalize a))
           "canonicalize is deterministic on the result"))
     (testing "canonicalize strips the volatile top-level slots .3 enumerates"
       (let [res {:status :pass :app-db {:n 1}
                  :elapsed-ms 42 :runner :headless :variant/id :x :plan-hash "ab"}
-            c   (fingerprint/canonicalize res)
+            c   (rf.story.fingerprint/canonicalize res)
             ;; canonical-form renders a map as `[:rf/map [k v k v …]]` — the
             ;; rf2-lvrqa structural type-tag — so the flattened entries live
             ;; under the tag's payload vector `(second c)`.
             [tag entries] c
             ks  (set (take-nth 2 entries))]
-        (is (= fingerprint/map-tag tag) "a map canon is wrapped under :rf/map")
+        (is (= rf.story.fingerprint/map-tag tag) "a map canon is wrapped under :rf/map")
         (is (not (contains? ks :elapsed-ms)) ":elapsed-ms stripped")
         (is (not (contains? ks :runner))     ":runner stripped")
         (is (not (contains? ks :variant/id)) ":variant/id stripped")
@@ -314,11 +314,11 @@
             caller owns its lifecycle)"
     (rf/reg-event :rep/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (rf/make-frame {:id :rep/caller-frame :doc "caller-owned replay frame"})
-    (let [a   (artifact/make-run-artifact {:event-program [[:dispatch [:rep/inc]]]})
-          res (artifact/replay-run-artifact a {:frame :rep/caller-frame})]
+    (let [a   (rf.story.artifact/make-run-artifact {:event-program [[:dispatch [:rep/inc]]]})
+          res (rf.story.artifact/replay-run-artifact a {:frame :rep/caller-frame})]
       (is (= :pass (:status res)))
       (is (= :rep/caller-frame (:frame res)))
-      (is (contains? @frame/frames :rep/caller-frame)
+      (is (contains? @rf.frame/frames :rep/caller-frame)
           "the caller-supplied frame is NOT destroyed"))))
 
 ;; ===========================================================================
@@ -339,18 +339,18 @@
       (with-redefs [rf/destroy-frame!
                     (fn [target & more]
                       (when (and (= ::none @teardown-target)
-                                 (frame/frame-value? target))
+                                 (rf.frame/frame-value? target))
                         (reset! teardown-target target))
                       (apply real-destroy target more))]
-        (let [a   (artifact/make-run-artifact {:event-program [[:dispatch [:rep/noop]]]})
-              res (artifact/replay-run-artifact a)
+        (let [a   (rf.story.artifact/make-run-artifact {:event-program [[:dispatch [:rep/noop]]]})
+              res (rf.story.artifact/replay-run-artifact a)
               fid (:frame res)]
           (is (= :pass (:status res)) "the replay ran clean")
-          (is (not (contains? @frame/frames fid))
+          (is (not (contains? @rf.frame/frames fid))
               "the replay-allocated incarnation is fully released (N released)")))
-      (is (frame/frame-value? @teardown-target)
+      (is (rf.frame/frame-value? @teardown-target)
           "teardown targeted the make-frame VALUE, not a bare frame-id keyword")
-      (is (some? (frame/frame-value-incarnation-token @teardown-target))
+      (is (some? (rf.frame/frame-value-incarnation-token @teardown-target))
           "the teardown target carries the exact incarnation token — so the
            two-argument destroy no-ops against any same-id successor (N+1),
            leaving it alive (proven end-to-end by re-frame.frame-lifecycle-test)"))))
@@ -373,11 +373,11 @@
         (fn [{:keys [db rep.cofx/delta]} _]
           (reset! seen delta)
           {:db (assoc db :delta delta)}))
-      (let [a   (artifact/make-run-artifact
+      (let [a   (rf.story.artifact/make-run-artifact
                   {:event-program
                    [[:dispatch [:rep/use-delta]
                      {:rf.cofx {:rf/time-ms 1781078400123 :rep.cofx/delta 42}}]]})
-            res (artifact/replay-run-artifact a)]
+            res (rf.story.artifact/replay-run-artifact a)]
         (is (= :pass (:status res)))
         (is (= 42 @seen) "the recorded recordable cofx value replayed verbatim")
         (is (= 42 (:delta (:app-db res))))))))
@@ -396,11 +396,11 @@
         (fn [_ _] (reset! fired? true) {}))
       ;; The recorded envelope is INCOMPLETE — it carries the framework
       ;; :rf/time-ms but not the declared :rep.cofx/missing fact.
-      (let [a   (artifact/make-run-artifact
+      (let [a   (rf.story.artifact/make-run-artifact
                   {:event-program
                    [[:dispatch [:rep/needs-missing]
                      {:rf.cofx {:rf/time-ms 1781078400123}}]]})
-            res (artifact/replay-run-artifact a)]
+            res (rf.story.artifact/replay-run-artifact a)]
         (is (zero? @gen-calls)
             "strict replay ran NO generator — an incomplete record never re-mints")
         (is (false? @fired?) "the handler never ran (the incomplete record halts)")
@@ -413,9 +413,9 @@
             so strict mint policy is inert (zero ceremony, byte-identical to
             the pre-EP-0017 path)"
     (rf/reg-event :rep/plain (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-    (let [a   (artifact/make-run-artifact
+    (let [a   (rf.story.artifact/make-run-artifact
                 {:event-program [[:dispatch [:rep/plain]] [:dispatch [:rep/plain]]]})
-          res (artifact/replay-run-artifact a)]
+          res (rf.story.artifact/replay-run-artifact a)]
       (is (= :pass (:status res)))
       (is (= 2 (:n (:app-db res))) "the bare dispatch program replayed unchanged"))))
 
@@ -431,8 +431,8 @@
 ;; never registered with the routes — every request fail-closed on "no stub
 ;; matched" (http_test_support.cljc `stub-handler`'s :else branch), silently
 ;; diverging from the original run. The fix threads `[:world :network]` into
-;; the artifact's `:network` slot (`determinism/->artifact`) and re-installs
-;; those route stubs around the replay (`artifact/with-network-stubs!`), so a
+;; the artifact's `:network` slot (`rf.story.determinism/->artifact`) and re-installs
+;; those route stubs around the replay (`rf.story.artifact/with-network-stubs!`), so a
 ;; replayed request matches its route and synthesises the recorded reply.
 ;;
 ;; FAIL-PRE / PASS-POST: drop the `:network` capture or the re-install and
@@ -461,11 +461,11 @@
   return the run artifact. `script` is the dispatch program."
   [routes script]
   (let [variant-id :story.net/v
-        plan       (plan/variant-plan
+        plan       (rf.story.plan/variant-plan
                      variant-id
                      {:lookup {variant-id {:network routes
                                            :script  script}}})]
-    (determinism/->artifact plan)))
+    (rf.story.determinism/->artifact plan)))
 
 (deftest network-artifact-captures-routes-and-redirect
   (testing "->artifact threads [:world :network] into the artifact :network
@@ -483,7 +483,7 @@
     (register-network-event! :net/get-cart [:get "/api/cart"])
     (let [routes {[:get "/api/cart"] {:reply {:ok {:items [{:sku "A"}]}}}}
           art    (network-artifact routes [[:dispatch [:net/get-cart]]])
-          res    (artifact/replay-run-artifact art)
+          res    (rf.story.artifact/replay-run-artifact art)
           got    (:got (:app-db res))]
       (is (= :pass (:status res)))
       (is (= :ok (:status got))
@@ -500,7 +500,7 @@
     (let [routes {[:post "/api/checkout"]
                   {:reply {:failure {:kind :rf.http/http-4xx :status 409}}}}
           art    (network-artifact routes [[:dispatch [:net/checkout]]])
-          res    (artifact/replay-run-artifact art)
+          res    (rf.story.artifact/replay-run-artifact art)
           got    (:got (:app-db res))]
       (is (= :error (:status got))
           "the re-installed route stub synthesised the recorded failure")
@@ -515,8 +515,8 @@
             runs the thunk unchanged so a plain replay never touches the
             test-support surface (rf2-tymyh)"
     (rf/reg-event :net/noop (fn [{:keys [db]} _] {:db (assoc db :ran true)}))
-    (let [art (artifact/make-run-artifact {:event-program [[:dispatch [:net/noop]]]})
-          res (artifact/replay-run-artifact art)]
+    (let [art (rf.story.artifact/make-run-artifact {:event-program [[:dispatch [:net/noop]]]})
+          res (rf.story.artifact/replay-run-artifact art)]
       (is (= :pass (:status res)))
       (is (true? (:ran (:app-db res))))
       (is (nil? (:network art)) "no :network slot on a non-HTTP artifact"))))
@@ -552,7 +552,7 @@
   `:step`, returning `{step [trigger-event …]}` so a test can assert WHICH
   authored step each beat (by its `:trigger-event`) landed under."
   [result]
-  (->> (evidence/narrative-beats (:narrative result))
+  (->> (rf.story.play.evidence/narrative-beats (:narrative result))
        (reduce (fn [m {:keys [step trigger-event]}]
                  (update m step (fnil conj []) trigger-event))
                {})))
@@ -566,10 +566,10 @@
     ;; :rkd/c — re-dispatches :rkd/d, so step 1 settles to 2 epochs.
     (rf/reg-event :rkd/c (fn [_ _] {:fx [[:dispatch [:rkd/d]]]}))
     (rf/reg-event :rkd/d (fn [{:keys [db]} _] {:db (assoc db :d true)}))
-    (let [a   (artifact/make-run-artifact
+    (let [a   (rf.story.artifact/make-run-artifact
                 {:event-program [[:dispatch [:rkd/a]]
                                  [:dispatch [:rkd/c]]]})
-          res (artifact/replay-run-artifact a)
+          res (rf.story.artifact/replay-run-artifact a)
           by  (beats-by-step res)]
       (is (= :pass (:status res)))
       ;; THREE committed epochs: a, c, and c's re-dispatched d.
@@ -598,10 +598,10 @@
     (rf/reg-event :rkd/a (fn [{:keys [db]} _] {:db (assoc db :a true)}))
     (rf/reg-event :rkd/c (fn [_ _] {:fx [[:dispatch [:rkd/d]]]}))
     (rf/reg-event :rkd/d (fn [{:keys [db]} _] {:db (assoc db :d true)}))
-    (let [a    (artifact/make-run-artifact
+    (let [a    (rf.story.artifact/make-run-artifact
                  {:event-program [[:dispatch [:rkd/a]]
                                   [:dispatch [:rkd/c]]]})
-          res  (artifact/replay-run-artifact a)
+          res  (rf.story.artifact/replay-run-artifact a)
           ;; The verbatim :epoch-tape slot must be RAW — no stamp leaked into
           ;; the hashed slice.
           tape-keys (into #{} (mapcat keys) (:epoch-tape res))]
@@ -610,9 +610,9 @@
       ;; The run-hash over an EXACT-attributed result equals the run-hash over
       ;; the SAME result with the narrative dropped — proving the stamp (which
       ;; rides only the narrative projection) is invisible to the hash.
-      (is (= (fingerprint/run-hash res)
-             (fingerprint/run-hash (dissoc res :narrative)))
+      (is (= (rf.story.fingerprint/run-hash res)
+             (rf.story.fingerprint/run-hash (dissoc res :narrative)))
           "dropping the stamped :narrative does not change the run-hash")
       ;; And the run-hash is stable / idempotent on the stamped result.
-      (is (= (fingerprint/run-hash res) (fingerprint/run-hash res))
+      (is (= (rf.story.fingerprint/run-hash res) (rf.story.fingerprint/run-hash res))
           "run-hash is idempotent on the EXACT-attributed result"))))

--- a/tools/story/test/re_frame/story/assertion_redaction_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/assertion_redaction_cljs_test.cljs
@@ -29,36 +29,36 @@
   ## `:expected` / `:payload` / `:reason`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.machines         :as machines]
-            [re-frame.registrar        :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story            :as story]
-            [re-frame.story.async      :as async-lib]
-            [re-frame.story.loaders    :as loaders]
-            [re-frame.story.ui.state   :as state]
-            [re-frame.subs             :as subs]))
+            [re-frame.frame            :as rf.frame]
+            [re-frame.machines         :as rf.machines]
+            [re-frame.registrar        :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story            :as rf.story]
+            [re-frame.story.async      :as rf.story.async]
+            [re-frame.story.loaders    :as rf.story.loaders]
+            [re-frame.story.ui.state   :as rf.story.ui.state]
+            [re-frame.subs             :as rf.subs]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch :default _ nil))
   ;; Re-register the framework `:rf/machine` sub after the registrar clear.
   ;; EP-0001 (rf2-vzld77 / rf2-ixb0bq): a runtime-db sub reading
   ;; [:rf.runtime/machines :snapshots <id>], NOT the retired app-db
   ;; `:rf/runtime` path — mirror `re-frame.machines`.
-  (subs/reg-runtime-sub :rf/machine
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [runtime-db [_ machine-id]]
       (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -80,15 +80,15 @@
             :rf.assert/path-equals to record :rf/redacted (not the raw token)"
     (rf/reg-event :auth/login
       (fn [{:keys [db]} _] {:db (assoc-in db [:auth :token] "BEARER-secret-12345")}))
-    (story/reg-variant :story.redaction.path-equals/probe
+    (rf.story/reg-variant :story.redaction.path-equals/probe
       {:setup    [[:auth/login]]
        :sensitive {:app-db [[:auth :token]]}
        :script [[:dispatch-sync [:rf.assert/path-equals
                  [:auth :token]
                  "BEARER-secret-12345"]]]})
     (async done
-      (-> (story/run-variant :story.redaction.path-equals/probe)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.redaction.path-equals/probe)
+          (rf.story.async/then
             (fn [result]
               (let [pe (last (filter #(= :rf.assert/path-equals (:assertion %))
                                      (:assertions result)))]
@@ -107,7 +107,7 @@
                     ":payload is rebuilt from the redacted expected")
                 (is (not (re-find #"BEARER-secret-12345" (str (:reason pe))))
                     ":reason does not print the raw token"))
-              (story/destroy-variant! :story.redaction.path-equals/probe)
+              (rf.story/destroy-variant! :story.redaction.path-equals/probe)
               (done)))))))
 
 (deftest assertion-path-equals-sentinel-expected-passes
@@ -116,15 +116,15 @@
             PASSING assertion (the sentinel contract), with no raw value anywhere"
     (rf/reg-event :auth/login2
       (fn [{:keys [db]} _] {:db (assoc-in db [:auth :token] "BEARER-secret-99999")}))
-    (story/reg-variant :story.redaction.sentinel/probe
+    (rf.story/reg-variant :story.redaction.sentinel/probe
       {:setup    [[:auth/login2]]
        :sensitive {:app-db [[:auth :token]]}
        :script [[:dispatch-sync [:rf.assert/path-equals
                  [:auth :token]
                  :rf/redacted]]]})
     (async done
-      (-> (story/run-variant :story.redaction.sentinel/probe)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.redaction.sentinel/probe)
+          (rf.story.async/then
             (fn [result]
               (let [pe (last (filter #(= :rf.assert/path-equals (:assertion %))
                                      (:assertions result)))]
@@ -132,25 +132,25 @@
                     "the sentinel-expected assertion PASSES against a sensitive path")
                 (is (= :rf/redacted (:expected pe)))
                 (is (= :rf/redacted (:actual pe))))
-              (story/destroy-variant! :story.redaction.sentinel/probe)
+              (rf.story/destroy-variant! :story.redaction.sentinel/probe)
               (done)))))))
 
 (deftest assertion-path-equals-non-sensitive-passes-value-through
   (testing "rf2-ee38b.3: a NON-sensitive path records the raw value
             unchanged (redaction only fires on marked paths)"
     (rf/reg-event :ui/set-label (fn [{:keys [db]} _] {:db (assoc db :label "hello")}))
-    (story/reg-variant :story.redaction.plain/probe
+    (rf.story/reg-variant :story.redaction.plain/probe
       {:setup [[:ui/set-label]]
        :script [[:dispatch-sync [:rf.assert/path-equals [:label] "hello"]]]})
     (async done
-      (-> (story/run-variant :story.redaction.plain/probe)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.redaction.plain/probe)
+          (rf.story.async/then
             (fn [result]
               (let [pe (first (filter #(= :rf.assert/path-equals (:assertion %))
                                       (:assertions result)))]
                 (is (= "hello" (:actual pe))
                     "non-sensitive value passes through unredacted"))
-              (story/destroy-variant! :story.redaction.plain/probe)
+              (rf.story/destroy-variant! :story.redaction.plain/probe)
               (done)))))))
 
 (deftest assertion-sub-equals-redacts-on-path-bearing-sub-vec
@@ -170,15 +170,15 @@
       (fn [{:keys [db]} _] {:db (assoc-in db [:user :ssn] "123-45-6789")}))
     ;; Parameterised sub: reads the path passed as args.
     (rf/reg-sub :pii/at (fn [db [_ & path]] (get-in db (vec path))))
-    (story/reg-variant :story.redaction.sub-equals/probe
+    (rf.story/reg-variant :story.redaction.sub-equals/probe
       {:setup    [[:session/save-pii]]
        :sensitive {:app-db [[:user :ssn]]}
        :script [[:dispatch-sync [:rf.assert/sub-equals
                  [:pii/at :user :ssn]
                  "123-45-6789"]]]})
     (async done
-      (-> (story/run-variant :story.redaction.sub-equals/probe)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.redaction.sub-equals/probe)
+          (rf.story.async/then
             (fn [result]
               (let [se (last (filter #(= :rf.assert/sub-equals (:assertion %))
                                      (:assertions result)))]
@@ -188,5 +188,5 @@
                     "sub-equals :expected is projected too (rf2-006y9b)")
                 (is (true? (:passed? se))
                     "redaction does not change the pass/fail outcome"))
-              (story/destroy-variant! :story.redaction.sub-equals/probe)
+              (rf.story/destroy-variant! :story.redaction.sub-equals/probe)
               (done)))))))

--- a/tools/story/test/re_frame/story/author_expectations_test.cljc
+++ b/tools/story/test/re_frame/story/author_expectations_test.cljc
@@ -12,9 +12,9 @@
             #?(:clj  [clojure.edn :as edn]
                :cljs [cljs.reader :as edn])
             [clojure.test :refer [deftest is testing]]
-            [re-frame.story.assertions          :as assertions]
-            [re-frame.story.author-expectations :as author]
-            [re-frame.story.requirements        :as requirements]))
+            [re-frame.story.assertions          :as rf.story.assertions]
+            [re-frame.story.author-expectations :as rf.story.author-expectations]
+            [re-frame.story.requirements        :as rf.story.requirements]))
 
 ;; ===========================================================================
 ;; CATALOG — covers the five acceptance surfaces
@@ -22,17 +22,17 @@
 
 (deftest catalog-covers-the-acceptance-surfaces
   (testing "every authorable kind names a recognised canonical assertion id"
-    (doseq [{:keys [kind assertion-id]} author/expectation-kinds]
-      (is (assertions/assertion-id-known? assertion-id)
+    (doseq [{:keys [kind assertion-id]} rf.story.author-expectations/expectation-kinds]
+      (is (rf.story.assertions/assertion-id-known? assertion-id)
           (str kind " folds onto a known assertion id"))))
   (testing "the catalog spans every acceptance-criteria surface (rf2-ba86n.12)"
-    (let [surfaces (into #{} (map :surface) author/expectation-kinds)]
+    (let [surfaces (into #{} (map :surface) rf.story.author-expectations/expectation-kinds)]
       ;; app-db, subscriptions, rendered DOM, schema behaviour, browser/a11y
       (is (= #{:app-db :subscriptions :dom :schema :browser} surfaces)
           "app-db / subscriptions / DOM / schema / browser are all authorable")))
   (testing "kind-descriptor round-trips by kind"
-    (doseq [{:keys [kind] :as d} author/expectation-kinds]
-      (is (= d (author/kind-descriptor kind))))))
+    (doseq [{:keys [kind] :as d} rf.story.author-expectations/expectation-kinds]
+      (is (= d (rf.story.author-expectations/kind-descriptor kind))))))
 
 ;; ===========================================================================
 ;; OPERAND PARSING + ATOM CONSTRUCTION — builds the CANONICAL vocabulary
@@ -41,64 +41,64 @@
 (deftest expectation->atom-builds-canonical-atoms
   (testing "app-db value equals → :rf.assert/path-equals"
     (is (= [:rf.assert/path-equals [:counter :value] 5]
-           (author/expectation->atom
+           (rf.story.author-expectations/expectation->atom
              {:kind :app-db-equals
               :operands {:path "[:counter :value]" :expected "5"}}))))
   (testing "a bare keyword path lifts to a single-element path vector"
     (is (= [:rf.assert/path-equals [:open?] true]
-           (author/expectation->atom
+           (rf.story.author-expectations/expectation->atom
              {:kind :app-db-equals
               :operands {:path ":open?" :expected "true"}}))))
   (testing "subscription equals → :rf.assert/sub-equals"
     (is (= [:rf.assert/sub-equals [:counter/value] 5]
-           (author/expectation->atom
+           (rf.story.author-expectations/expectation->atom
              {:kind :sub-equals
               :operands {:query-v "[:counter/value]" :expected "5"}}))))
   (testing "app-db matches schema → :rf.assert/path-matches"
     (is (= [:rf.assert/path-matches [:user] [:map [:id :int]]]
-           (author/expectation->atom
+           (rf.story.author-expectations/expectation->atom
              {:kind :app-db-matches
               :operands {:path "[:user]" :schema "[:map [:id :int]]"}}))))
   (testing "no-warnings is a nullary atom"
     (is (= [:rf.assert/no-warnings]
-           (author/expectation->atom {:kind :no-warnings :operands {}}))))
+           (rf.story.author-expectations/expectation->atom {:kind :no-warnings :operands {}}))))
   (testing "DOM text → :rf.assert/dom-text"
     (is (= [:rf.assert/dom-text ".count" "5"]
-           (author/expectation->atom
+           (rf.story.author-expectations/expectation->atom
              {:kind :dom-text :operands {:selector "\".count\"" :text "\"5\""}}))))
   (testing "schema-error with a spec map → :rf.assert/schema-error spec"
     (is (= [:rf.assert/schema-error {:where :event :event :user/save}]
-           (author/expectation->atom
+           (rf.story.author-expectations/expectation->atom
              {:kind :schema-error
               :operands {:where-spec "{:where :event :event :user/save}"}}))))
   (testing "schema-error with no spec → bare atom"
     (is (= [:rf.assert/schema-error]
-           (author/expectation->atom {:kind :schema-error :operands {}}))))
+           (rf.story.author-expectations/expectation->atom {:kind :schema-error :operands {}}))))
   (testing "an unparsable operand yields nil (the caller guards)"
-    (is (nil? (author/expectation->atom
+    (is (nil? (rf.story.author-expectations/expectation->atom
                 {:kind :app-db-equals :operands {:path "" :expected "5"}}))
         "a blank required operand fails the parse → no atom")
-    (is (nil? (author/expectation->atom
+    (is (nil? (rf.story.author-expectations/expectation->atom
                 {:kind :app-db-equals :operands {:path "[:a" :expected "5"}}))
         "a malformed EDN operand fails the parse → no atom")))
 
 (deftest parse-operands-reports-per-field-errors
   (testing "ok? true when every operand parses"
     (let [{:keys [ok? values errors]}
-          (author/parse-operands
+          (rf.story.author-expectations/parse-operands
             {:kind :app-db-equals :operands {:path "[:a]" :expected "1"}})]
       (is ok?)
       (is (= {:path [:a] :expected 1} values))
       (is (empty? errors))))
   (testing "ok? false + a per-field error when an operand is blank"
     (let [{:keys [ok? errors]}
-          (author/parse-operands
+          (rf.story.author-expectations/parse-operands
             {:kind :app-db-equals :operands {:path "[:a]" :expected ""}})]
       (is (not ok?))
       (is (contains? errors :expected))))
   (testing "a malformed EDN operand carries the reader error string"
     (let [{:keys [ok? errors]}
-          (author/parse-operands
+          (rf.story.author-expectations/parse-operands
             {:kind :sub-equals :operands {:query-v "[:a" :expected "1"}})]
       (is (not ok?))
       (is (string? (:query-v errors))))))
@@ -109,47 +109,47 @@
 
 (deftest expectation-cost-reads-the-requirement-registry
   (testing "an app-db expectation runs headless (no escalation cost)"
-    (let [cost (author/expectation-cost [:rf.assert/path-equals [:a] 1])]
+    (let [cost (rf.story.author-expectations/expectation-cost [:rf.assert/path-equals [:a] 1])]
       (is (= #{:app-db} (:required cost)))
       (is (:headless? cost))
       (is (not (:cannot-run? cost)))
       (is (= :headless (:cheapest-runner cost)))
       (is (empty? (:missing cost)))))
   (testing "a sub-equals expectation needs :pure-subs but still runs headless"
-    (let [cost (author/expectation-cost [:rf.assert/sub-equals [:s] 1])]
+    (let [cost (rf.story.author-expectations/expectation-cost [:rf.assert/sub-equals [:s] 1])]
       (is (= #{:app-db :pure-subs} (:required cost)))
       (is (not (:cannot-run? cost)))
       (is (= :headless (:cheapest-runner cost)))))
   (testing "a DOM expectation CANNOT run headless — visible before save"
-    (let [cost (author/expectation-cost [:rf.assert/dom-text ".x" "y"])]
+    (let [cost (rf.story.author-expectations/expectation-cost [:rf.assert/dom-text ".x" "y"])]
       (is (= #{:dom} (:required cost)))
       (is (:cannot-run? cost) "the honest before-save cannot-run flag")
       (is (= :dom (:cheapest-runner cost)) "cheapest runner that CAN prove it")
       (is (contains? (:missing cost) :dom) "the missing token is surfaced")))
   (testing "a visual-snapshot expectation needs a browser runner"
-    (let [cost (author/expectation-cost [:rf.assert/visual-snapshot])]
+    (let [cost (rf.story.author-expectations/expectation-cost [:rf.assert/visual-snapshot])]
       (is (:cannot-run? cost))
       (is (= :browser (:cheapest-runner cost)))))
   (testing "structural a11y rides the :hiccup tier (cannot run headless, cheaper than browser)"
-    (let [cost (author/expectation-cost [:rf.assert/a11y-structural])]
+    (let [cost (rf.story.author-expectations/expectation-cost [:rf.assert/a11y-structural])]
       (is (:cannot-run? cost))
       (is (= :hiccup (:cheapest-runner cost)))))
   (testing "cost agrees with the requirement registry it reads"
-    (is (= (requirements/assertion-tokens [:rf.assert/dom-visible ".x"])
-           (:required (author/expectation-cost [:rf.assert/dom-visible ".x"])))))
+    (is (= (rf.story.requirements/assertion-tokens [:rf.assert/dom-visible ".x"])
+           (:required (rf.story.author-expectations/expectation-cost [:rf.assert/dom-visible ".x"])))))
   (testing "a nil atom (unparsed row) projects an empty, non-throwing cost"
-    (let [cost (author/expectation-cost nil)]
+    (let [cost (rf.story.author-expectations/expectation-cost nil)]
       (is (not (:cannot-run? cost)))
       (is (empty? (:required cost))))))
 
 (deftest row-cost-projects-live-from-a-row
   (testing "a ready DOM row reports cannot-run before it is even an atom elsewhere"
     (is (:cannot-run?
-          (author/row-cost
+          (rf.story.author-expectations/row-cost
             {:kind :dom-text :operands {:selector "\".x\"" :text "\"y\""}}))))
   (testing "an unparsed row projects a non-throwing headless cost"
     (is (not (:cannot-run?
-               (author/row-cost {:kind :app-db-equals :operands {}}))))))
+               (rf.story.author-expectations/row-cost {:kind :app-db-equals :operands {}}))))))
 
 ;; ===========================================================================
 ;; DRAFT SUMMARY — the before-save honesty banner data
@@ -163,7 +163,7 @@
                       {:row-id 2 :kind :app-db-equals
                        :operands {:path "" :expected "1"}}]}  ; not ready
         {:keys [count ready atoms required cheapest-runner cannot-run-rows surfaces]}
-        (author/draft-summary draft)]
+        (rf.story.author-expectations/draft-summary draft)]
     (testing "counts authored vs ready"
       (is (= 3 count))
       (is (= 2 ready) "the blank-path row is not ready"))
@@ -189,21 +189,21 @@
   (testing "authored atoms append after existing, order preserved"
     (is (= [[:rf.assert/path-equals [:a] 1]
             [:rf.assert/no-warnings]]
-           (author/merge-assertions
+           (rf.story.author-expectations/merge-assertions
              [[:rf.assert/path-equals [:a] 1]]
              [[:rf.assert/no-warnings]]))))
   (testing "an exact duplicate is dropped (re-authoring is idempotent)"
     (is (= [[:rf.assert/path-equals [:a] 1]]
-           (author/merge-assertions
+           (rf.story.author-expectations/merge-assertions
              [[:rf.assert/path-equals [:a] 1]]
              [[:rf.assert/path-equals [:a] 1]]))))
   (testing "nil existing / authored are tolerated"
     (is (= [[:rf.assert/no-warnings]]
-           (author/merge-assertions nil [[:rf.assert/no-warnings]])))
-    (is (= [] (author/merge-assertions nil nil)))))
+           (rf.story.author-expectations/merge-assertions nil [[:rf.assert/no-warnings]])))
+    (is (= [] (rf.story.author-expectations/merge-assertions nil nil)))))
 
 (deftest gen-expectations-snippet-round-trips
-  (let [snippet (author/gen-expectations-snippet
+  (let [snippet (rf.story.author-expectations/gen-expectations-snippet
                   {:variant-id :story.counter/expects-5
                    :extends    :story.counter/happy-path
                    :existing   [[:rf.assert/no-warnings]]
@@ -228,14 +228,14 @@
             "existing + authored assertions merged, the round-trip")))))
 
 (deftest assertions-known-validates-against-the-vocabulary
-  (is (author/assertions-known?
+  (is (rf.story.author-expectations/assertions-known?
         [[:rf.assert/path-equals [:a] 1] [:rf.assert/dom-text ".x" "y"]]))
-  (is (not (author/assertions-known?
+  (is (not (rf.story.author-expectations/assertions-known?
              [[:rf.assert/not-a-real-assertion]]))
       "an unknown id is rejected so the snippet can never reference one"))
 
 (deftest default-id-prefix-is-distinct-from-siblings
   (testing "the prefix distinguishes authored-expectations from save / promotion"
-    (is (= "expects" author/default-id-prefix))
-    (is (not= "saved" author/default-id-prefix))
-    (is (not= "regression" author/default-id-prefix))))
+    (is (= "expects" rf.story.author-expectations/default-id-prefix))
+    (is (not= "saved" rf.story.author-expectations/default-id-prefix))
+    (is (not= "regression" rf.story.author-expectations/default-id-prefix))))

--- a/tools/story/test/re_frame/story/backgrounds_test.cljc
+++ b/tools/story/test/re_frame/story/backgrounds_test.cljc
@@ -13,114 +13,114 @@
   - `wrap-style` shape for flat colour + transparent / checkerboard.
   - localStorage round-trip — CLJS-only."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.backgrounds :as backgrounds]))
+            [re-frame.story.backgrounds :as rf.story.backgrounds]))
 
 ;; ---- preset table --------------------------------------------------------
 
 (deftest preset-table-includes-every-bead-mandated-id
   (testing "every preset id called out by rf2-zll4h is present"
     (let [expected #{:light :dark :paper :midnight :transparent}]
-      (is (= expected (set (keys backgrounds/presets))))
-      (is (= expected (set backgrounds/preset-order))))))
+      (is (= expected (set (keys rf.story.backgrounds/presets))))
+      (is (= expected (set rf.story.backgrounds/preset-order))))))
 
 (deftest preset-dark-has-canonical-colour
   (testing ":dark is #1a1a1a (bead-mandated)"
     (is (= {:label "Dark" :color "#1a1a1a"}
-           (get backgrounds/presets :dark)))))
+           (get rf.story.backgrounds/presets :dark)))))
 
 (deftest preset-transparent-uses-checkerboard-sentinel
   (testing ":transparent's :color is the :checkerboard keyword sentinel"
     (is (= :checkerboard
-           (:color (get backgrounds/presets :transparent))))))
+           (:color (get rf.story.backgrounds/presets :transparent))))))
 
 ;; ---- pure: valid-custom? ------------------------------------------------
 
 (deftest valid-custom-accepts-hex-strings
   (testing "valid-custom? accepts 3 / 6 / 8-digit hex colours"
-    (is (true?  (backgrounds/valid-custom? "#abc")))
-    (is (true?  (backgrounds/valid-custom? "#abcdef")))
-    (is (true?  (backgrounds/valid-custom? "#abcdef12")))
-    (is (true?  (backgrounds/valid-custom? "#ABCDEF")))
-    (is (true?  (backgrounds/valid-custom? "  #abcdef  "))
+    (is (true?  (rf.story.backgrounds/valid-custom? "#abc")))
+    (is (true?  (rf.story.backgrounds/valid-custom? "#abcdef")))
+    (is (true?  (rf.story.backgrounds/valid-custom? "#abcdef12")))
+    (is (true?  (rf.story.backgrounds/valid-custom? "#ABCDEF")))
+    (is (true?  (rf.story.backgrounds/valid-custom? "  #abcdef  "))
         "leading/trailing whitespace tolerated")))
 
 (deftest valid-custom-rejects-non-hex
   (testing "valid-custom? rejects non-hex shapes"
-    (is (false? (backgrounds/valid-custom? "red")))
-    (is (false? (backgrounds/valid-custom? "rgb(1,2,3)")))
-    (is (false? (backgrounds/valid-custom? "#xyz")))
-    (is (false? (backgrounds/valid-custom? "#ab")))   ;; too short
-    (is (false? (backgrounds/valid-custom? "abcdef"))) ;; missing #
-    (is (false? (backgrounds/valid-custom? nil)))
-    (is (false? (backgrounds/valid-custom? :keyword)))))
+    (is (false? (rf.story.backgrounds/valid-custom? "red")))
+    (is (false? (rf.story.backgrounds/valid-custom? "rgb(1,2,3)")))
+    (is (false? (rf.story.backgrounds/valid-custom? "#xyz")))
+    (is (false? (rf.story.backgrounds/valid-custom? "#ab")))   ;; too short
+    (is (false? (rf.story.backgrounds/valid-custom? "abcdef"))) ;; missing #
+    (is (false? (rf.story.backgrounds/valid-custom? nil)))
+    (is (false? (rf.story.backgrounds/valid-custom? :keyword)))))
 
 ;; ---- pure: coerce -------------------------------------------------------
 
 (deftest coerce-preset-keyword-passes-through
-  (is (= :dark (backgrounds/coerce :dark)))
-  (is (= :transparent (backgrounds/coerce :transparent))))
+  (is (= :dark (rf.story.backgrounds/coerce :dark)))
+  (is (= :transparent (rf.story.backgrounds/coerce :transparent))))
 
 (deftest coerce-unknown-keyword-returns-nil
-  (is (nil? (backgrounds/coerce :Mode.unknown/whatever)))
-  (is (nil? (backgrounds/coerce :neon))))
+  (is (nil? (rf.story.backgrounds/coerce :Mode.unknown/whatever)))
+  (is (nil? (rf.story.backgrounds/coerce :neon))))
 
 (deftest coerce-trims-custom-hex
   (testing "a valid hex string coerces to the trimmed form"
     (is (= "#abcdef"
-           (backgrounds/coerce "  #abcdef  ")))))
+           (rf.story.backgrounds/coerce "  #abcdef  ")))))
 
 (deftest coerce-bad-custom-returns-nil
-  (is (nil? (backgrounds/coerce "red")))
-  (is (nil? (backgrounds/coerce nil)))
-  (is (nil? (backgrounds/coerce 42))))
+  (is (nil? (rf.story.backgrounds/coerce "red")))
+  (is (nil? (rf.story.backgrounds/coerce nil)))
+  (is (nil? (rf.story.backgrounds/coerce 42))))
 
 ;; ---- pure: resolve precedence -------------------------------------------
 
 (deftest resolve-falls-back-to-light-when-empty
   (testing "no override + no selection → :light default"
-    (let [r (backgrounds/resolve nil nil)]
+    (let [r (rf.story.backgrounds/resolve nil nil)]
       (is (= "Light"   (:label r)))
       (is (= "#ffffff" (:color r))))))
 
 (deftest resolve-uses-toolbar-selection-when-no-override
   (testing "toolbar selection wins when override absent"
-    (let [r (backgrounds/resolve nil :dark)]
+    (let [r (rf.story.backgrounds/resolve nil :dark)]
       (is (= "Dark"    (:label r)))
       (is (= "#1a1a1a" (:color r))))))
 
 (deftest resolve-story-override-beats-toolbar
   (testing "rf2-zll4h precedence: story-override wins"
-    (let [r (backgrounds/resolve :midnight :dark)]
+    (let [r (rf.story.backgrounds/resolve :midnight :dark)]
       (is (= "Midnight" (:label r))))))
 
 (deftest resolve-custom-override-beats-toolbar
   (testing "a custom hex as the story-override is honoured"
-    (let [r (backgrounds/resolve "#abc123" :dark)]
+    (let [r (rf.story.backgrounds/resolve "#abc123" :dark)]
       (is (= "#abc123" (:color r)))
       (is (re-find #"abc123" (:label r))))))
 
 (deftest resolve-bad-override-falls-through-to-toolbar
   (testing "an unrecognised override does NOT block the toolbar fallback"
-    (let [r (backgrounds/resolve :neon :dark)]
+    (let [r (rf.story.backgrounds/resolve :neon :dark)]
       (is (= "Dark" (:label r))
           "unknown override fell through to the live toolbar selection"))))
 
 (deftest resolve-id-returns-keyword-or-custom
-  (is (= :light (backgrounds/resolve-id nil nil)))
-  (is (= :dark  (backgrounds/resolve-id nil :dark)))
-  (is (= :midnight (backgrounds/resolve-id :midnight :dark)))
-  (is (= :custom (backgrounds/resolve-id "#abc123" nil))))
+  (is (= :light (rf.story.backgrounds/resolve-id nil nil)))
+  (is (= :dark  (rf.story.backgrounds/resolve-id nil :dark)))
+  (is (= :midnight (rf.story.backgrounds/resolve-id :midnight :dark)))
+  (is (= :custom (rf.story.backgrounds/resolve-id "#abc123" nil))))
 
 ;; ---- pure: wrap-style ----------------------------------------------------
 
 (deftest wrap-style-flat-colour
   (testing "a flat colour produces a :background-color CSS map"
     (is (= {:background-color "#abcdef"}
-           (backgrounds/wrap-style {:color "#abcdef"})))))
+           (rf.story.backgrounds/wrap-style {:color "#abcdef"})))))
 
 (deftest wrap-style-checkerboard
   (testing "the :checkerboard sentinel produces a CSS gradient set"
-    (let [s (backgrounds/wrap-style {:color :checkerboard})]
+    (let [s (rf.story.backgrounds/wrap-style {:color :checkerboard})]
       (is (string? (:background-image s))
           "checkerboard uses background-image gradients")
       (is (= "#ffffff" (:background-color s))
@@ -130,7 +130,7 @@
 
 (deftest wrap-style-nil-for-unknown
   (testing "unknown colour shape → nil (caller falls back)"
-    (is (nil? (backgrounds/wrap-style {:color 42})))))
+    (is (nil? (rf.story.backgrounds/wrap-style {:color 42})))))
 
 ;; ---- localStorage round-trip --------------------------------------------
 
@@ -143,40 +143,40 @@
    (defn- clear-storage!
      []
      (when (browser?)
-       (try (.removeItem (.-localStorage js/window) backgrounds/ls-key)
+       (try (.removeItem (.-localStorage js/window) rf.story.backgrounds/ls-key)
             (catch :default _ nil)))))
 
 #?(:cljs
    (deftest storage-roundtrip-preset
      (when (browser?)
        (clear-storage!)
-       (backgrounds/save-to-storage! :dark)
-       (is (= :dark (backgrounds/load-from-storage)))
+       (rf.story.backgrounds/save-to-storage! :dark)
+       (is (= :dark (rf.story.backgrounds/load-from-storage)))
        (clear-storage!))))
 
 #?(:cljs
    (deftest storage-roundtrip-custom
      (when (browser?)
        (clear-storage!)
-       (backgrounds/save-to-storage! "#abc123")
-       (is (= "#abc123" (backgrounds/load-from-storage)))
+       (rf.story.backgrounds/save-to-storage! "#abc123")
+       (is (= "#abc123" (rf.story.backgrounds/load-from-storage)))
        (clear-storage!))))
 
 #?(:cljs
    (deftest storage-save-nil-clears
      (when (browser?)
        (clear-storage!)
-       (backgrounds/save-to-storage! :dark)
-       (is (some? (backgrounds/load-from-storage)))
-       (backgrounds/save-to-storage! nil)
-       (is (nil? (backgrounds/load-from-storage)))
+       (rf.story.backgrounds/save-to-storage! :dark)
+       (is (some? (rf.story.backgrounds/load-from-storage)))
+       (rf.story.backgrounds/save-to-storage! nil)
+       (is (nil? (rf.story.backgrounds/load-from-storage)))
        (clear-storage!))))
 
 #?(:cljs
    (deftest storage-rejects-invalid-on-save
      (when (browser?)
        (clear-storage!)
-       (backgrounds/save-to-storage! :neon)
-       (is (nil? (backgrounds/load-from-storage)))
-       (backgrounds/save-to-storage! "rgb(1,2,3)")
-       (is (nil? (backgrounds/load-from-storage))))))
+       (rf.story.backgrounds/save-to-storage! :neon)
+       (is (nil? (rf.story.backgrounds/load-from-storage)))
+       (rf.story.backgrounds/save-to-storage! "rgb(1,2,3)")
+       (is (nil? (rf.story.backgrounds/load-from-storage))))))

--- a/tools/story/test/re_frame/story/budgets_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/budgets_cljs_test.cljc
@@ -22,7 +22,7 @@
     idempotent, and the output is itself bounded by the input.
 
   The DOCUMENTED latency targets (rebuild ≤ 8 ms, inline-validate ≤ 4 ms,
-  spine first paint ≤ 100 ms) live as data in `budgets/latency-targets-ms`
+  spine first paint ≤ 100 ms) live as data in `rf.story.budgets/latency-targets-ms`
   and are review-checklist / future-micro-bench bars — this gate does NOT
   assert them as wall-clock time. See the PR body for the structural-vs-clock
   rationale flag.
@@ -37,13 +37,13 @@
   JVM can't `:require`) are asserted CLJS-only, mirroring
   `sidebar-chips-cljs-test`."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.budgets :as budgets]
-            [re-frame.story.ui.state.filters :as filters]
-            [re-frame.story.ui.sidebar-search :as search]
-            [re-frame.story.ui.workspace :as workspace]
-            #?@(:cljs [[re-frame.story.ui.sidebar :as sidebar]
-                       [re-frame.story.ui.controls :as controls]
-                       [re-frame.story.ui.docs :as docs]])))
+            [re-frame.story.budgets :as rf.story.budgets]
+            [re-frame.story.ui.state.filters :as rf.story.ui.state.filters]
+            [re-frame.story.ui.sidebar-search :as rf.story.ui.sidebar-search]
+            [re-frame.story.ui.workspace :as rf.story.ui.workspace]
+            #?@(:cljs [[re-frame.story.ui.sidebar :as rf.story.ui.sidebar]
+                       [re-frame.story.ui.controls :as rf.story.ui.controls]
+                       [re-frame.story.ui.docs :as rf.story.ui.docs]])))
 
 ;; ---------------------------------------------------------------------------
 ;; Floor-scale synthetic fixture (N3) — pure data, deterministic
@@ -64,8 +64,8 @@
             [(keyword (str "story.s" s) (str "v" v))
              {:tags (if (even? idx) #{:dev} #{:test})}]))))
 
-(def ^:private floor (:variants budgets/project-floor))
-(def ^:private stories (:stories budgets/project-floor))
+(def ^:private floor (:variants rf.story.budgets/project-floor))
+(def ^:private stories (:stories rf.story.budgets/project-floor))
 
 ;; ---------------------------------------------------------------------------
 ;; N3 — the fixture really is floor-scale
@@ -75,10 +75,10 @@
   (testing "the gate exercises at LEAST the ratified project floor"
     (is (= 2000 floor) "floor variant count is the ratified 2 000")
     (is (= 200 stories) "floor story count is the ratified 200")
-    (is (= 50 (:workspaces budgets/project-floor))
+    (is (= 50 (:workspaces rf.story.budgets/project-floor))
         "floor workspace count is the ratified 50"))
   (testing "the synthetic registry actually holds floor-many variants"
-    (let [reg (floor-registry budgets/project-floor)]
+    (let [reg (floor-registry rf.story.budgets/project-floor)]
       (is (= floor (count reg))))))
 
 ;; ---------------------------------------------------------------------------
@@ -88,9 +88,9 @@
 (deftest sidebar-derivation-is-bounded-per-story
   (testing "at the floor, grouping then capping per story never emits more
             than `sidebar-variant-cap` rows for any single story"
-    (let [reg     (floor-registry budgets/project-floor)
-          grouped (filters/group-variants-by-story reg)
-          cap     budgets/sidebar-variant-cap]
+    (let [reg     (floor-registry rf.story.budgets/project-floor)
+          grouped (rf.story.ui.state.filters/group-variants-by-story reg)
+          cap     rf.story.budgets/sidebar-variant-cap]
       (is (= stories (count grouped))
           "every story appears exactly once in the grouped tree")
       (doseq [{:keys [variants]} grouped]
@@ -110,12 +110,12 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest filter-pipeline-is-single-bounded-pass
-  (let [reg budgets/project-floor
+  (let [reg rf.story.budgets/project-floor
         id->body (floor-registry reg)]
     (testing "the full keystroke pipeline produces output bounded by the input"
-      (let [filtered (filters/filter-variants id->body #{:dev})
-            grouped  (filters/group-variants-by-story filtered)
-            tree     (search/filter-grouped-tree grouped "v1")
+      (let [filtered (rf.story.ui.state.filters/filter-variants id->body #{:dev})
+            grouped  (rf.story.ui.state.filters/group-variants-by-story filtered)
+            tree     (rf.story.ui.sidebar-search/filter-grouped-tree grouped "v1")
             shown    (mapcat :variants tree)]
         (is (<= (count filtered) (count id->body))
             "tag filter never grows the set")
@@ -127,23 +127,23 @@
     (testing "the pipeline is idempotent — re-running over its own output is
               stable (a second pass finds nothing new to do; rules out an
               accumulating O(n²) re-scan)"
-      (let [once  (search/filter-grouped-tree
-                    (filters/group-variants-by-story
-                      (filters/filter-variants id->body #{:dev}))
+      (let [once  (rf.story.ui.sidebar-search/filter-grouped-tree
+                    (rf.story.ui.state.filters/group-variants-by-story
+                      (rf.story.ui.state.filters/filter-variants id->body #{:dev}))
                     "v1")
             ;; flatten once's surviving variants back into an id->body map
             flat  (into {} (mapcat :variants once))
-            twice (search/filter-grouped-tree
-                    (filters/group-variants-by-story
-                      (filters/filter-variants flat #{:dev}))
+            twice (rf.story.ui.sidebar-search/filter-grouped-tree
+                    (rf.story.ui.state.filters/group-variants-by-story
+                      (rf.story.ui.state.filters/filter-variants flat #{:dev}))
                     "v1")]
         (is (= (reduce + 0 (map (comp count :variants) once))
                (reduce + 0 (map (comp count :variants) twice)))
             "second pass over the filtered output is a fixed point")))
     (testing "the tag filter is order-independent — a single predicate pass,
               not a pairwise comparison"
-      (let [forward (filters/filter-variants id->body #{:dev})
-            reverse (filters/filter-variants
+      (let [forward (rf.story.ui.state.filters/filter-variants id->body #{:dev})
+            reverse (rf.story.ui.state.filters/filter-variants
                       (into {} (reverse (seq id->body))) #{:dev})]
         (is (= (count forward) (count reverse))
             "result size is independent of input ordering")))))
@@ -155,28 +155,28 @@
 (deftest grid-cell-output-is-bounded
   (testing "`bound-cells` never emits more than the cap, however large the grid"
     (let [cells (vec (range floor))
-          {:keys [shown hidden]} (budgets/bound-cells cells)]
-      (is (= budgets/grid-visible-cell-cap (count shown))
+          {:keys [shown hidden]} (rf.story.budgets/bound-cells cells)]
+      (is (= rf.story.budgets/grid-visible-cell-cap (count shown))
           "visible cells are capped at the grid cell cap")
-      (is (= (- floor budgets/grid-visible-cell-cap) hidden)
+      (is (= (- floor rf.story.budgets/grid-visible-cell-cap) hidden)
           "the remainder is paged (reachable), not dropped")
       (is (= floor (+ (count shown) hidden))
           "shown + hidden = total — cap-and-page, nothing lost")))
   (testing "a grid at/under the cap is never bounded"
-    (let [cells (vec (range budgets/grid-visible-cell-cap))]
-      (is (= {:shown cells :hidden 0} (budgets/bound-cells cells)))))
+    (let [cells (vec (range rf.story.budgets/grid-visible-cell-cap))]
+      (is (= {:shown cells :hidden 0} (rf.story.budgets/bound-cells cells)))))
   (testing "expanded? reveals the full grid (one explicit page-all gesture)"
     (let [cells (vec (range 250))
-          {:keys [shown hidden]} (budgets/bound-cells cells
-                                                      budgets/grid-visible-cell-cap
+          {:keys [shown hidden]} (rf.story.budgets/bound-cells cells
+                                                      rf.story.budgets/grid-visible-cell-cap
                                                       true)]
       (is (= 250 (count shown)))
       (is (zero? hidden))))
   (testing "page count is deterministic ceil(total / cap), minimum 1"
-    (is (= 1 (budgets/matrix-page-count 0)))
-    (is (= 1 (budgets/matrix-page-count budgets/grid-visible-cell-cap)))
-    (is (= 2 (budgets/matrix-page-count (inc budgets/grid-visible-cell-cap))))
-    (is (= 4 (budgets/matrix-page-count budgets/matrix-hard-cap)))))
+    (is (= 1 (rf.story.budgets/matrix-page-count 0)))
+    (is (= 1 (rf.story.budgets/matrix-page-count rf.story.budgets/grid-visible-cell-cap)))
+    (is (= 2 (rf.story.budgets/matrix-page-count (inc rf.story.budgets/grid-visible-cell-cap))))
+    (is (= 4 (rf.story.budgets/matrix-page-count rf.story.budgets/matrix-hard-cap)))))
 
 ;; ---------------------------------------------------------------------------
 ;; G2 / G3 — matrix dimension guard: warn > 144, hard cap 400
@@ -184,29 +184,29 @@
 
 (deftest matrix-dimension-guard
   (testing "warn threshold is the ratified 12×12 = 144"
-    (is (= 144 budgets/matrix-warn-threshold))
-    (is (not (budgets/matrix-warn? [11 11])) "121 cells: below warn")
-    (is (budgets/matrix-warn? [12 12]) "144 cells: at warn")
-    (is (budgets/matrix-warn? [13 12]) "156 cells: past warn"))
+    (is (= 144 rf.story.budgets/matrix-warn-threshold))
+    (is (not (rf.story.budgets/matrix-warn? [11 11])) "121 cells: below warn")
+    (is (rf.story.budgets/matrix-warn? [12 12]) "144 cells: at warn")
+    (is (rf.story.budgets/matrix-warn? [13 12]) "156 cells: past warn"))
   (testing "hard cap is the ratified 400; beyond it the grid MUST paginate"
-    (is (= 400 budgets/matrix-hard-cap))
-    (is (not (budgets/matrix-over-hard-cap? [20 20])) "400 cells: at cap, not over")
-    (is (budgets/matrix-over-hard-cap? [21 20]) "420 cells: over the hard cap")
-    (is (budgets/matrix-over-hard-cap? [10 10 5]) "500 cells (3 axes): over"))
+    (is (= 400 rf.story.budgets/matrix-hard-cap))
+    (is (not (rf.story.budgets/matrix-over-hard-cap? [20 20])) "400 cells: at cap, not over")
+    (is (rf.story.budgets/matrix-over-hard-cap? [21 20]) "420 cells: over the hard cap")
+    (is (rf.story.budgets/matrix-over-hard-cap? [10 10 5]) "500 cells (3 axes): over"))
   (testing "the hard cap exceeds the per-page visible cap (page bounds one
             page; hard cap bounds the matrix total before paging is forced)"
-    (is (> budgets/matrix-hard-cap budgets/grid-visible-cell-cap)))
+    (is (> rf.story.budgets/matrix-hard-cap rf.story.budgets/grid-visible-cell-cap)))
   (testing "matrix-product folds axis sizes; empty axes = 0 cells"
-    (is (= 0 (budgets/matrix-product [])))
-    (is (= 144 (budgets/matrix-product [12 12])))
-    (is (= 24 (budgets/matrix-product [2 3 4])))))
+    (is (= 0 (rf.story.budgets/matrix-product [])))
+    (is (= 144 (rf.story.budgets/matrix-product [12 12])))
+    (is (= 24 (rf.story.budgets/matrix-product [2 3 4])))))
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-ba86n.18 — the WIRED render-path bounding (perf fixtures)
 ;;
 ;; The tests above assert the pure budget primitives. These exercise the
-;; helpers the RENDER PATHS actually call (`workspace/bound-grid-cells`,
-;; `controls/bound-arg-rows`) against floor-scale fixtures — the proof that
+;; helpers the RENDER PATHS actually call (`rf.story.ui.workspace/bound-grid-cells`,
+;; `rf.story.ui.controls/bound-arg-rows`) against floor-scale fixtures — the proof that
 ;; the variants-grid and controls panel emit bounded output at the 2 000-
 ;; variant floor without rendering all cells / rows (spec/018 §10).
 ;; ---------------------------------------------------------------------------
@@ -216,11 +216,11 @@
             G1 cell cap, however large the enumerated grid (floor scale)"
     (let [cells (vec (range floor))
           {:keys [shown hidden total warn? over-hard-cap?]}
-          (workspace/bound-grid-cells cells false)]
+          (rf.story.ui.workspace/bound-grid-cells cells false)]
       (is (= floor total) "the helper reports the true total")
-      (is (= budgets/grid-visible-cell-cap (count shown))
+      (is (= rf.story.budgets/grid-visible-cell-cap (count shown))
           "visible cells are capped at the G1 visible cell cap")
-      (is (= (- floor budgets/grid-visible-cell-cap) hidden)
+      (is (= (- floor rf.story.budgets/grid-visible-cell-cap) hidden)
           "the remainder is paged (reachable), not dropped")
       (is warn? "a floor-scale grid trips the G2 dense-matrix advisory")
       (is over-hard-cap? "a floor-scale grid trips the G3 hard-cap flag")))
@@ -229,17 +229,17 @@
             (never freeze the canvas)"
     (let [cells (vec (range floor))
           {:keys [shown hidden over-hard-cap?]}
-          (workspace/bound-grid-cells cells true)]
-      (is (= budgets/matrix-hard-cap (count shown))
+          (rf.story.ui.workspace/bound-grid-cells cells true)]
+      (is (= rf.story.budgets/matrix-hard-cap (count shown))
           "expanded render is bounded by the hard cap, not the full set")
-      (is (= (- floor budgets/matrix-hard-cap) hidden)
+      (is (= (- floor rf.story.budgets/matrix-hard-cap) hidden)
           "the over-hard-cap tail is still paged after expansion")
       (is over-hard-cap?)))
   (testing "a grid AT/UNDER the visible cap is never bounded and never warns"
-    (let [cells (vec (range budgets/grid-visible-cell-cap))
+    (let [cells (vec (range rf.story.budgets/grid-visible-cell-cap))
           {:keys [shown hidden warn? over-hard-cap?]}
-          (workspace/bound-grid-cells cells false)]
-      (is (= budgets/grid-visible-cell-cap (count shown)))
+          (rf.story.ui.workspace/bound-grid-cells cells false)]
+      (is (= rf.story.budgets/grid-visible-cell-cap (count shown)))
       (is (zero? hidden))
       (is (not warn?) "100 cells is under the 144 warn threshold")
       (is (not over-hard-cap?))))
@@ -247,7 +247,7 @@
             reveals every cell when that is safe (≤ 400)"
     (let [cells (vec (range 300))
           {:keys [shown hidden warn? over-hard-cap?]}
-          (workspace/bound-grid-cells cells true)]
+          (rf.story.ui.workspace/bound-grid-cells cells true)]
       (is (= 300 (count shown)) "≤ hard cap: expansion reveals the full grid")
       (is (zero? hidden))
       (is warn? "300 cells is past the 144 warn threshold")
@@ -262,28 +262,28 @@
      (testing "the controls editor's `bound-arg-rows` caps visible rows at the
                C2 flat-row cap, however many args a variant declares"
        (let [entries (mapv (fn [i] [(keyword (str "arg" i)) i]) (range floor))
-             {:keys [shown hidden]} (controls/bound-arg-rows entries false)]
-         (is (= budgets/controls-flat-row-cap (count shown))
+             {:keys [shown hidden]} (rf.story.ui.controls/bound-arg-rows entries false)]
+         (is (= rf.story.budgets/controls-flat-row-cap (count shown))
              "visible rows are capped at the C2 flat-row cap")
-         (is (= (- floor budgets/controls-flat-row-cap) hidden)
+         (is (= (- floor rf.story.budgets/controls-flat-row-cap) hidden)
              "the remainder is paged behind +N more, not dropped")
          (is (= floor (+ (count shown) hidden))
              "shown + hidden = total — nothing lost")))
      (testing "a panel AT/UNDER the cap is never bounded"
        (let [entries (mapv (fn [i] [(keyword (str "arg" i)) i])
-                           (range budgets/controls-flat-row-cap))
-             {:keys [hidden]} (controls/bound-arg-rows entries false)]
+                           (range rf.story.budgets/controls-flat-row-cap))
+             {:keys [hidden]} (rf.story.ui.controls/bound-arg-rows entries false)]
          (is (zero? hidden))))
      (testing "expanded? reveals every row (one explicit page-all gesture)"
        (let [entries (mapv (fn [i] [(keyword (str "arg" i)) i]) (range 150))
-             {:keys [shown hidden]} (controls/bound-arg-rows entries true)]
+             {:keys [shown hidden]} (rf.story.ui.controls/bound-arg-rows entries true)]
          (is (= 150 (count shown)))
          (is (zero? hidden))))
      (testing "the flat-expanded sentinel is a keyword (never a vector path),
                so it can never collide with a nested-control path in the
                shared `:expanded` ratom set"
-       (is (keyword? controls/flat-expanded-sentinel))
-       (is (not (vector? controls/flat-expanded-sentinel))))))
+       (is (keyword? rf.story.ui.controls/flat-expanded-sentinel))
+       (is (not (vector? rf.story.ui.controls/flat-expanded-sentinel))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Ratified numbers — the budget table matches the ratification verbatim
@@ -291,20 +291,20 @@
 
 (deftest ratified-budget-numbers
   (testing "every cap is the as-proposed, ratified value"
-    (is (= 40  budgets/sidebar-variant-cap)   "sidebar variant cap")
-    (is (= 20  budgets/captured-artifact-cap) "captured-artifacts cap")
-    (is (= 60  budgets/controls-flat-row-cap) "controls flat-panel row cap")
-    (is (= 100 budgets/grid-visible-cell-cap) "variants-grid visible cell cap")
-    (is (= 144 budgets/matrix-warn-threshold) "matrix warn threshold")
-    (is (= 400 budgets/matrix-hard-cap)       "matrix hard cap"))
+    (is (= 40  rf.story.budgets/sidebar-variant-cap)   "sidebar variant cap")
+    (is (= 20  rf.story.budgets/captured-artifact-cap) "captured-artifacts cap")
+    (is (= 60  rf.story.budgets/controls-flat-row-cap) "controls flat-panel row cap")
+    (is (= 100 rf.story.budgets/grid-visible-cell-cap) "variants-grid visible cell cap")
+    (is (= 144 rf.story.budgets/matrix-warn-threshold) "matrix warn threshold")
+    (is (= 400 rf.story.budgets/matrix-hard-cap)       "matrix hard cap"))
   (testing "the documented latency TARGETS carry the ratified numbers (data
             only — not asserted as wall-clock by this gate)"
-    (is (= 8   (:filtered-rebuild  budgets/latency-targets-ms)))
-    (is (= 4   (:inline-validate   budgets/latency-targets-ms)))
-    (is (= 100 (:spine-first-paint budgets/latency-targets-ms))))
+    (is (= 8   (:filtered-rebuild  rf.story.budgets/latency-targets-ms)))
+    (is (= 4   (:inline-validate   rf.story.budgets/latency-targets-ms)))
+    (is (= 100 (:spine-first-paint rf.story.budgets/latency-targets-ms))))
   (testing "the failure→evidence budget: ≤ 1 gesture, excerpt ≤ 2 beats"
-    (is (= 1 (:max-gestures  budgets/evidence-gesture-budget)))
-    (is (= 2 (:excerpt-beats budgets/evidence-gesture-budget)))))
+    (is (= 1 (:max-gestures  rf.story.budgets/evidence-gesture-budget)))
+    (is (= 2 (:excerpt-beats rf.story.budgets/evidence-gesture-budget)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Single-source: the implementation surfaces READ the budget constants
@@ -314,25 +314,25 @@
 #?(:cljs
    (deftest implementation-reads-the-budgets
      (testing "the shipped sidebar caps alias the budget single-source"
-       (is (= budgets/sidebar-variant-cap sidebar/default-variant-cap)
-           "sidebar/default-variant-cap reads budgets/sidebar-variant-cap")
-       (is (= budgets/captured-artifact-cap sidebar/default-artifact-cap)
-           "sidebar/default-artifact-cap reads budgets/captured-artifact-cap"))
+       (is (= rf.story.budgets/sidebar-variant-cap rf.story.ui.sidebar/default-variant-cap)
+           "rf.story.ui.sidebar/default-variant-cap reads rf.story.budgets/sidebar-variant-cap")
+       (is (= rf.story.budgets/captured-artifact-cap rf.story.ui.sidebar/default-artifact-cap)
+           "rf.story.ui.sidebar/default-artifact-cap reads rf.story.budgets/captured-artifact-cap"))
      (testing "the docs evidence-excerpt cap reads the budget single-source"
-       (is (= (:excerpt-beats budgets/evidence-gesture-budget)
-              docs/evidence-excerpt-beat-cap)
-           "docs/evidence-excerpt-beat-cap reads the X1 excerpt-beats budget"))
+       (is (= (:excerpt-beats rf.story.budgets/evidence-gesture-budget)
+              rf.story.ui.docs/evidence-excerpt-beat-cap)
+           "rf.story.ui.docs/evidence-excerpt-beat-cap reads the X1 excerpt-beats budget"))
      (testing "the shipped `bound-variants` honours the budget cap at scale —
                the gate's bounding contract IS the one the sidebar renders"
        (let [vs (mapv (fn [i] [(keyword "story.x" (str "v" i)) {}]) (range floor))
-             {:keys [shown hidden]} (sidebar/bound-variants
-                                      vs budgets/sidebar-variant-cap false)]
-         (is (= budgets/sidebar-variant-cap (count shown)))
-         (is (= (- floor budgets/sidebar-variant-cap) hidden))))
+             {:keys [shown hidden]} (rf.story.ui.sidebar/bound-variants
+                                      vs rf.story.budgets/sidebar-variant-cap false)]
+         (is (= rf.story.budgets/sidebar-variant-cap (count shown)))
+         (is (= (- floor rf.story.budgets/sidebar-variant-cap) hidden))))
      (testing "rf2-ba86n.18 — the controls flat-panel cap render path reads
                the C2 budget single-source (no parallel copy)"
        (let [entries (mapv (fn [i] [(keyword (str "a" i)) i])
-                           (range (inc budgets/controls-flat-row-cap)))
-             {:keys [shown]} (controls/bound-arg-rows entries false)]
-         (is (= budgets/controls-flat-row-cap (count shown))
-             "bound-arg-rows caps at budgets/controls-flat-row-cap")))))
+                           (range (inc rf.story.budgets/controls-flat-row-cap)))
+             {:keys [shown]} (rf.story.ui.controls/bound-arg-rows entries false)]
+         (is (= rf.story.budgets/controls-flat-row-cap (count shown))
+             "bound-arg-rows caps at rf.story.budgets/controls-flat-row-cap")))))

--- a/tools/story/test/re_frame/story/canvas_plan_resolution_test.cljc
+++ b/tools/story/test/re_frame/story/canvas_plan_resolution_test.cljc
@@ -10,7 +10,7 @@
   the PRODUCTION path — a REGISTERED variant compiled via the DEFAULT
   side-table lookup (NO `:lookup` arg). The pre-ruling tests fed RAW bodies
   through explicit `:lookup` maps, which masked the divergence: the canvas
-  `resolve-sub-overrides` read `(:sub-overrides (registrar/handler-meta
+  `resolve-sub-overrides` read `(:sub-overrides (rf.story.registrar/handler-meta
   :variant id))` straight off the side-table, seeing ONLY the variant's OWN
   slot — dropping overrides contributed by a `:compose`d fragment or an
   `:extends` parent (which the plan compiler COMPOSES into
@@ -22,8 +22,8 @@
   prove:
 
     1. composed-fragment + `:extends`-chain `:sub-overrides` resolve through
-       the canvas's resolver (the SAME `render/resolve-render-sub-overrides`
-       over `plan/variant-plan` render-variant uses) — rf2-45zvx / rf2-bhaqt;
+       the canvas's resolver (the SAME `rf.story.render/resolve-render-sub-overrides`
+       over `rf.story.plan/variant-plan` render-variant uses) — rf2-45zvx / rf2-bhaqt;
     2. the canvas decorator resolution and render-variant's render-inputs
        resolve the SAME `[:world :decorators]` (composed + inherited) —
        rf2-hzhmv (resolution agreement) / rf2-ba86n.8;
@@ -34,13 +34,13 @@
   registrar are all JVM-runnable, so the DEFAULT lookup works under both
   `clojure -M:test` and `npm run test:cljs`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story.config     :as config]
-            [re-frame.story.decorators :as decorators]
-            [re-frame.story.late-bind  :as late-bind]
-            [re-frame.story.plan       :as plan]
-            [re-frame.story.registrar  :as registrar]
-            [re-frame.story.render     :as render]
-            [re-frame.registrar        :as framework-registrar]))
+            [re-frame.story.config     :as rf.story.config]
+            [re-frame.story.decorators :as rf.story.decorators]
+            [re-frame.story.late-bind  :as rf.story.late-bind]
+            [re-frame.story.plan       :as rf.story.plan]
+            [re-frame.story.registrar  :as rf.story.registrar]
+            [re-frame.story.render     :as rf.story.render]
+            [re-frame.registrar        :as rf.registrar]))
 
 ;; ---- fixtures ------------------------------------------------------------
 ;;
@@ -52,26 +52,26 @@
 ;; canonical auto-install (fired by every `reg-*`) wires it, so the no-host
 ;; `:cannot-run` assertion must DROP `:render-host` AFTER its registrations
 ;; (see `render-variant-cannot-run-with-no-host`). We MUST NOT
-;; `late-bind/clear!` (that wipes the canonical shims every sibling test ns
+;; `rf.story.late-bind/clear!` (that wipes the canonical shims every sibling test ns
 ;; relies on). The fixture snapshots + restores the whole hooks map so any
 ;; per-test dissoc is surgical and reverts cleanly (mirrors `render-test`).
 
 (defn reset-fixture [test-fn]
-  (registrar/clear-all!)
-  (framework-registrar/clear-kind! :sub)
+  (rf.story.registrar/clear-all!)
+  (rf.registrar/clear-kind! :sub)
   ;; The global-decorators vector is a process-global config atom (NOT part
   ;; of the side-table `clear-all!` wipes), so a test that sets globals
   ;; would leak into siblings. Clear it before each test and restore the
   ;; pre-test value after (rf2-5fibj).
-  (config/set-global-decorators! [])
+  (rf.story.config/set-global-decorators! [])
   ;; `:sub-overrides` validation soft-passes when a sub carries no output
   ;; schema (the host-free floor), so an unregistered :sub is fine here.
-  (let [snapshot       @late-bind/hooks
-        globals-before (config/get-global-decorators)]
+  (let [snapshot       @rf.story.late-bind/hooks
+        globals-before (rf.story.config/get-global-decorators)]
     (try (test-fn)
          (finally
-           (reset! late-bind/hooks snapshot)
-           (config/set-global-decorators! globals-before)))))
+           (reset! rf.story.late-bind/hooks snapshot)
+           (rf.story.config/set-global-decorators! globals-before)))))
 
 (use-fixtures :each reset-fixture)
 
@@ -82,7 +82,7 @@
 ;; here at the CLJC seam both paths share).
 (defn- canvas-sub-overrides
   [variant-id eff-args]
-  (render/resolve-render-sub-overrides (plan/variant-plan variant-id) eff-args))
+  (rf.story.render/resolve-render-sub-overrides (rf.story.plan/variant-plan variant-id) eff-args))
 
 ;; ===========================================================================
 ;; rf2-45zvx / rf2-bhaqt — composed-fragment + :extends-chain :sub-overrides
@@ -93,9 +93,9 @@
             :compose'd fragment resolves the fragment's overrides through the
             canvas resolver — the bare-body read dropped them (rf2-45zvx /
             rf2-bhaqt)"
-    (registrar/reg-fragment* :fragment.login/errored
+    (rf.story.registrar/reg-fragment* :fragment.login/errored
                              {:sub-overrides {[:login/state] :error}})
-    (registrar/reg-variant* :story.login/from-fragment
+    (rf.story.registrar/reg-variant* :story.login/from-fragment
                             {:compose       [:fragment.login/errored]
                              :sub-overrides {[:login/attempts] 3}
                              :setup        []})
@@ -106,7 +106,7 @@
                 read (`(:sub-overrides body)`) would have dropped it"
         (is (= :error (get resolved [:login/state]))))
       (testing "the canvas resolver agrees with the plan's composed slot"
-        (is (= (get-in (plan/variant-plan :story.login/from-fragment)
+        (is (= (get-in (rf.story.plan/variant-plan :story.login/from-fragment)
                        [:world :render :sub-overrides])
                resolved))))))
 
@@ -114,10 +114,10 @@
   (testing "a child variant that :extends a parent with :sub-overrides and
             declares its OWN inherits the merged map through the canvas
             resolver (rf2-45zvx — the :extends chain)"
-    (registrar/reg-variant* :story.ext.subovr/parent
+    (rf.story.registrar/reg-variant* :story.ext.subovr/parent
                             {:sub-overrides {[:login/state] :error}
                              :setup        []})
-    (registrar/reg-variant* :story.ext.subovr/child
+    (rf.story.registrar/reg-variant* :story.ext.subovr/child
                             {:extends       :story.ext.subovr/parent
                              :sub-overrides {[:login/attempts] 5}
                              :setup        []})
@@ -134,11 +134,11 @@
             re-substitution render-variant does. The canvas passes the
             variant's resolved effective args (incl. defaults), so the
             placeholder always has a value to substitute."
-    (registrar/reg-variant* :story.login/argdriven
+    (rf.story.registrar/reg-variant* :story.login/argdriven
                             {:args          {:message "default"}
                              :sub-overrides {[:login/error] [:arg :message]}
                              :setup        []})
-    (let [plan-eff (get-in (plan/variant-plan :story.login/argdriven)
+    (let [plan-eff (get-in (rf.story.plan/variant-plan :story.login/argdriven)
                            [:world :effective-args])]
       (testing "the plan-time arg resolves against the variant's effective args"
         (is (= "default"
@@ -153,7 +153,7 @@
 (deftest variant-with-no-sub-overrides-resolves-nil
   (testing "a registered variant authoring NO :sub-overrides resolves nil
             (render-transparent — no wrapper)"
-    (registrar/reg-variant* :story.plain/v {:setup []})
+    (rf.story.registrar/reg-variant* :story.plain/v {:setup []})
     (is (nil? (canvas-sub-overrides :story.plain/v {})))))
 
 ;; ===========================================================================
@@ -166,25 +166,25 @@
             render-inputs resolve the SAME composed + inherited
             [:world :decorators] — single source of truth (rf2-hzhmv /
             rf2-ba86n.8)"
-    (registrar/reg-decorator* :deco/theme-dark
+    (rf.story.registrar/reg-decorator* :deco/theme-dark
                               {:kind :hiccup :wrap (fn [body _] [:div.dark body])})
-    (registrar/reg-decorator* :deco/centered
+    (rf.story.registrar/reg-decorator* :deco/centered
                               {:kind :hiccup :wrap (fn [body _] [:div.centered body])})
     ;; Parent declares a decorator; child inherits via :extends and ADDS none
     ;; of its own — so the child's decorator stack comes ENTIRELY from the
     ;; parent chain (the case a bare-body read would resolve EMPTY).
-    (registrar/reg-variant* :story.deco/parent
+    (rf.story.registrar/reg-variant* :story.deco/parent
                             {:component  :views/widget
                              :decorators [[:deco/theme-dark]]
                              :setup     []})
-    (registrar/reg-variant* :story.deco/child
+    (rf.story.registrar/reg-variant* :story.deco/child
                             {:extends :story.deco/parent
                              :setup  []})
     (let [;; render-variant's render-inputs carry the RAW refs off the plan.
-          prepared       (render/prepare-render :story.deco/child)
+          prepared       (rf.story.render/prepare-render :story.deco/child)
           rv-refs        (get-in prepared [:render-inputs :decorators])
           ;; the canvas resolves the same refs into its :hiccup pack.
-          canvas-pack    (decorators/resolve-decorators :story.deco/child)
+          canvas-pack    (rf.story.decorators/resolve-decorators :story.deco/child)
           canvas-ids     (mapv :id (:hiccup canvas-pack))]
       (testing "render-variant's render-inputs carry the inherited decorator
                 refs off the compiled plan"
@@ -195,7 +195,7 @@
       (testing "both paths agree: render-variant's refs resolve to the canvas
                 pack's :hiccup ids"
         (is (= canvas-ids
-               (mapv :id (:hiccup (decorators/resolve-decorator-refs rv-refs)))))))))
+               (mapv :id (:hiccup (rf.story.decorators/resolve-decorator-refs rv-refs)))))))))
 
 (deftest canvas-and-render-variant-agree-on-full-decorator-stack
   (testing "the canvas + render-variant resolve the SAME FULL decorator
@@ -206,29 +206,29 @@
             globals + story slipped CI green (the din8u CI-blind-spot, one
             layer up): the plan folded only the variant chain, the canvas
             re-assembled globals+story+variant, so they DIVERGED."
-    (registrar/reg-decorator* :deco/global-theme
+    (rf.story.registrar/reg-decorator* :deco/global-theme
                               {:kind :hiccup :wrap (fn [body _] [:div.global body])})
-    (registrar/reg-decorator* :deco/story-frame
+    (rf.story.registrar/reg-decorator* :deco/story-frame
                               {:kind :hiccup :wrap (fn [body _] [:div.story body])})
-    (registrar/reg-decorator* :deco/variant-pad
+    (rf.story.registrar/reg-decorator* :deco/variant-pad
                               {:kind :hiccup :wrap (fn [body _] [:div.variant body])})
     ;; GLOBAL decorator (the layer the host path dropped) — Storybook
     ;; preview.ts parity, rf2-835ey.
-    (config/set-global-decorators! [[:deco/global-theme]])
+    (rf.story.config/set-global-decorators! [[:deco/global-theme]])
     ;; parent-STORY decorator (the OTHER layer the host path dropped) — the
     ;; variant id's namespace resolves to this story.
-    (registrar/reg-story* :story.fullstack
+    (rf.story.registrar/reg-story* :story.fullstack
                           {:decorators [[:deco/story-frame]]})
     ;; the variant adds its own decorator on top.
-    (registrar/reg-variant* :story.fullstack/v
+    (rf.story.registrar/reg-variant* :story.fullstack/v
                             {:component  :views/widget
                              :decorators [[:deco/variant-pad]]
                              :setup     []})
     (let [;; render-variant's render-inputs carry the FULL stack off the plan.
-          prepared    (render/prepare-render :story.fullstack/v)
+          prepared    (rf.story.render/prepare-render :story.fullstack/v)
           rv-refs     (get-in prepared [:render-inputs :decorators])
           ;; the canvas resolves the same plan-sourced refs into its pack.
-          canvas-pack (decorators/resolve-decorators :story.fullstack/v)
+          canvas-pack (rf.story.decorators/resolve-decorators :story.fullstack/v)
           canvas-ids  (mapv :id (:hiccup canvas-pack))]
       (testing "the compiled plan carries the FULL stack in order: global
                 outermost, then story, then variant (NOT just the variant
@@ -241,30 +241,30 @@
       (testing "both paths agree: render-variant's refs resolve to the canvas
                 pack's :hiccup ids — IDENTICAL decorated tree"
         (is (= canvas-ids
-               (mapv :id (:hiccup (decorators/resolve-decorator-refs rv-refs))))))
+               (mapv :id (:hiccup (rf.story.decorators/resolve-decorator-refs rv-refs))))))
       (testing "and applying the stack wraps the leaf globals-outermost,
                 variant-innermost (the rendered tree both paths paint)"
         (is (= [:div.global [:div.story [:div.variant [:span "leaf"]]]]
-               (decorators/apply-hiccup-decorators
+               (rf.story.decorators/apply-hiccup-decorators
                  (:hiccup canvas-pack) [:span "leaf"] {})))))))
 
 (deftest render-variant-applies-decorators-through-shared-seam
   (testing "render-variant's host renders the SAME decorator refs the canvas
             applies — proven by resolving the render-inputs' refs and applying
             them the way the shared seam does (rf2-hzhmv)"
-    (registrar/reg-decorator* :deco/wrap-a
+    (rf.story.registrar/reg-decorator* :deco/wrap-a
                               {:kind :hiccup :wrap (fn [body _] [:div.a body])})
-    (registrar/reg-variant* :story.deco/applied
+    (rf.story.registrar/reg-variant* :story.deco/applied
                             {:component  :views/widget
                              :decorators [[:deco/wrap-a]]
                              :setup     []})
-    (let [prepared (render/prepare-render :story.deco/applied)
+    (let [prepared (rf.story.render/prepare-render :story.deco/applied)
           refs     (get-in prepared [:render-inputs :decorators])
-          hiccup-d (:hiccup (decorators/resolve-decorator-refs refs))
+          hiccup-d (:hiccup (rf.story.decorators/resolve-decorator-refs refs))
           ;; The shared `safe-decorated-view` seam applies the :hiccup
           ;; decorators outermost-first; render-variant's host calls exactly
           ;; this (via multi-substrate/render-decorated-view).
-          wrapped  (decorators/apply-hiccup-decorators hiccup-d [:span "leaf"] {})]
+          wrapped  (rf.story.decorators/apply-hiccup-decorators hiccup-d [:span "leaf"] {})]
       (testing "the decorator wraps the rendered tree (NOT bare — the
                 pre-fix host dropped :decorators entirely)"
         (is (= [:div.a [:span "leaf"]] wrapped))))))
@@ -277,12 +277,12 @@
   (testing "with no render host installed, render-variant returns :cannot-run
             for a registered variant — never a silent empty render
             (the single render path's honest cannot-render state)"
-    (registrar/reg-variant* :story.norender/v
+    (rf.story.registrar/reg-variant* :story.norender/v
                             {:component :views/widget :setup []})
     ;; Drop the render host AFTER registration — on CLJS the `reg-variant*`
     ;; auto-install wires it; the fixture restores it after this test.
-    (swap! late-bind/hooks dissoc :render-host)
-    (let [r (render/render-variant :story.norender/v)]
+    (swap! rf.story.late-bind/hooks dissoc :render-host)
+    (let [r (rf.story.render/render-variant :story.norender/v)]
       (is (= :cannot-run (:status r)))
       (is (= :no-render-host (:reason r)))
       (is (= :story.norender/v (:frame r))))))
@@ -293,7 +293,7 @@
 ;;
 ;; rf2-2cpoo (#3248) threaded run opts into the RUNTIME plan compile
 ;; (`prepare-context`), but the CANVAS decorator path
-;; (`decorators/resolve-decorators`, the front door the live canvas /
+;; (`rf.story.decorators/resolve-decorators`, the front door the live canvas /
 ;; controls / docs panes call) still recompiled the plan WITHOUT them. That
 ;; recompile substitutes EVERY `[:arg key]` in the variant body (db-seed /
 ;; sub-overrides / setup / script) against the arg-map — so a key resolvable
@@ -305,7 +305,7 @@
 ;; `collect-decorator-refs` → `variant-plan {:run-args …}`.
 ;;
 ;; These tests register on the DEFAULT side-table and call
-;; `decorators/resolve-decorators` (the production front door) — proving the
+;; `rf.story.decorators/resolve-decorators` (the production front door) — proving the
 ;; new capability resolves AND, critically, that the no-opts path STILL
 ;; throws (so the test would catch a regression / proves the gap was real).
 ;; ===========================================================================
@@ -323,13 +323,13 @@
             resolves its decorator stack through the canvas front door when the
             active mode is threaded — the recompile no longer throws
             `:rf.error/story-missing-arg` (rf2-eyrpr)"
-    (registrar/reg-decorator* :deco/mode-wrap
+    (rf.story.registrar/reg-decorator* :deco/mode-wrap
                               {:kind :hiccup :wrap (fn [body _] [:div.mode body])})
     ;; the mode supplies :only-in-mode; the variant declares NO :args, so the
     ;; key is reachable ONLY through the mode layer (the rf2-2cpoo new
     ;; capability — `mode < variant`, mode fills the arg the variant omits).
-    (registrar/reg-mode* :Mode.canvas/big {:args {:only-in-mode "from-mode"}})
-    (registrar/reg-variant* :story.canvas.modearg/v
+    (rf.story.registrar/reg-mode* :Mode.canvas/big {:args {:only-in-mode "from-mode"}})
+    (rf.story.registrar/reg-variant* :story.canvas.modearg/v
                             {:component  :views/widget
                              :decorators [[:deco/mode-wrap]]
                              ;; `[:arg :only-in-mode]` substitutes at PLAN
@@ -340,10 +340,10 @@
     (testing "the OLD no-opts front door throws — the gap rf2-2cpoo left
               (proves the test exercises the actual failing path)"
       (is (missing-arg-throw?
-            #(decorators/resolve-decorators :story.canvas.modearg/v))
+            #(rf.story.decorators/resolve-decorators :story.canvas.modearg/v))
           "without :run-args the recompile cannot substitute the mode-only arg"))
     (testing "threading the active mode resolves the decorator stack cleanly"
-      (let [pack (decorators/resolve-decorators
+      (let [pack (rf.story.decorators/resolve-decorators
                    :story.canvas.modearg/v
                    {:active-modes [:Mode.canvas/big]})]
         (is (= [:deco/mode-wrap] (mapv :id (:hiccup pack)))
@@ -356,18 +356,18 @@
             the variant body; the canvas front door resolves the decorator
             stack when the override is threaded (rf2-eyrpr — the highest run
             layer, same as a mode at `cell-override > variant`)"
-    (registrar/reg-decorator* :deco/cell-wrap
+    (rf.story.registrar/reg-decorator* :deco/cell-wrap
                               {:kind :hiccup :wrap (fn [body _] [:div.cell body])})
-    (registrar/reg-variant* :story.canvas.cellarg/v
+    (rf.story.registrar/reg-variant* :story.canvas.cellarg/v
                             {:component  :views/widget
                              :decorators [[:deco/cell-wrap]]
                              :db-seed    {:seeded [:arg :only-in-cell]}
                              :setup     []})
     (testing "the no-opts front door throws (the cell key is variant-absent)"
       (is (missing-arg-throw?
-            #(decorators/resolve-decorators :story.canvas.cellarg/v))))
+            #(rf.story.decorators/resolve-decorators :story.canvas.cellarg/v))))
     (testing "threading the cell-override resolves the stack cleanly"
-      (let [pack (decorators/resolve-decorators
+      (let [pack (rf.story.decorators/resolve-decorators
                    :story.canvas.cellarg/v
                    {:cell-overrides {:only-in-cell "from-cell"}})]
         (is (= [:deco/cell-wrap] (mapv :id (:hiccup pack))))
@@ -377,9 +377,9 @@
   (testing "the COMMON case is unchanged: when every `[:arg key]` is declared
             on the variant itself, the no-opts front door resolves fine — the
             run-args threading is purely ADDITIVE (rf2-eyrpr regression guard)"
-    (registrar/reg-decorator* :deco/plain-wrap
+    (rf.story.registrar/reg-decorator* :deco/plain-wrap
                               {:kind :hiccup :wrap (fn [body _] [:div.plain body])})
-    (registrar/reg-variant* :story.canvas.ownarg/v
+    (rf.story.registrar/reg-variant* :story.canvas.ownarg/v
                             {:component  :views/widget
                              :decorators [[:deco/plain-wrap]]
                              :args       {:in-variant "static"}
@@ -387,12 +387,12 @@
                              :setup     []})
     (testing "no-opts resolves (the variant declares the key)"
       (is (= [:deco/plain-wrap]
-             (mapv :id (:hiccup (decorators/resolve-decorators
+             (mapv :id (:hiccup (rf.story.decorators/resolve-decorators
                                   :story.canvas.ownarg/v))))))
     (testing "and threading run opts resolves the IDENTICAL stack"
-      (is (= (mapv :id (:hiccup (decorators/resolve-decorators
+      (is (= (mapv :id (:hiccup (rf.story.decorators/resolve-decorators
                                   :story.canvas.ownarg/v)))
-             (mapv :id (:hiccup (decorators/resolve-decorators
+             (mapv :id (:hiccup (rf.story.decorators/resolve-decorators
                                   :story.canvas.ownarg/v
                                   {:active-modes [] :cell-overrides {}}))))))))
 
@@ -402,19 +402,19 @@
             throw on the 500ms poll — fingerprints are body-derived + run-layer
             invariant, the opts only let the ref-collection compile succeed
             (rf2-eyrpr)"
-    (registrar/reg-decorator* :deco/fp-wrap
+    (rf.story.registrar/reg-decorator* :deco/fp-wrap
                               {:kind :hiccup :wrap (fn [body _] [:div.fp body])})
-    (registrar/reg-mode* :Mode.fp/on {:args {:only-in-mode "x"}})
-    (registrar/reg-variant* :story.canvas.fp/v
+    (rf.story.registrar/reg-mode* :Mode.fp/on {:args {:only-in-mode "x"}})
+    (rf.story.registrar/reg-variant* :story.canvas.fp/v
                             {:component  :views/widget
                              :decorators [[:deco/fp-wrap]]
                              :db-seed    {:seeded [:arg :only-in-mode]}
                              :setup     []})
     (testing "the no-opts poll throws (the gap)"
       (is (missing-arg-throw?
-            #(decorators/resolution-fingerprints :story.canvas.fp/v))))
+            #(rf.story.decorators/resolution-fingerprints :story.canvas.fp/v))))
     (testing "threading the active mode lets the poll capture the fingerprint"
-      (let [fps (decorators/resolution-fingerprints
+      (let [fps (rf.story.decorators/resolution-fingerprints
                   :story.canvas.fp/v
                   {:active-modes [:Mode.fp/on]})]
         (is (contains? fps :deco/fp-wrap)

--- a/tools/story/test/re_frame/story/compose_test.cljc
+++ b/tools/story/test/re_frame/story/compose_test.cljc
@@ -8,8 +8,8 @@
   a host: fragment / check / variant bodies are supplied through explicit
   `:lookup` / `:fragment-lookup` / `:check-lookup` maps of RAW bodies."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.plan :as plan]
-            [re-frame.story.schemas :as schemas]))
+            [re-frame.story.plan :as rf.story.plan]
+            [re-frame.story.schemas :as rf.story.schemas]))
 
 ;; ---- helpers ------------------------------------------------------------
 
@@ -19,7 +19,7 @@
   `:check-lookup checks`."
   [target {:keys [variants fragments checks]
            :or   {variants {} fragments {} checks {}}}]
-  (plan/variant-plan target {:lookup          variants
+  (rf.story.plan/variant-plan target {:lookup          variants
                              :fragment-lookup fragments
                              :check-lookup    checks}))
 
@@ -84,7 +84,7 @@
 ;; reported. The runtime drives `[:world :scripts]` (the named-play set),
 ;; NEVER the reported top-level `:script` slot — before the fix,
 ;; `compose-script` folded only into the latter, so a composed fragment's
-;; script never actually ran (plan/explain looked right; nothing happened).
+;; script never actually ran (rf.story.plan/explain looked right; nothing happened).
 ;; ===========================================================================
 
 (deftest fragment-script-composes-into-executed-scripts
@@ -170,7 +170,7 @@
     (let [fragments {:fragment/themed {:decorators [:decorator/fragment-theme]}}
           variants  {:story.x/v {:compose    [:fragment/themed]
                                  :decorators [:decorator/variant-theme]}}
-          p (plan/variant-plan :story.x/v
+          p (rf.story.plan/variant-plan :story.x/v
               {:lookup            variants
                :fragment-lookup   fragments
                :global-decorators [:decorator/global]})]
@@ -484,7 +484,7 @@
 
 (deftest resolve-conflicts-rejected-by-schema
   (testing ":resolve-conflicts is rejected by the P1 variant schema (no escape hatch)"
-    (let [explain (schemas/validate
+    (let [explain (rf.story.schemas/validate
                     :variant {:resolve-conflicts {[:fx-overrides :rf.http/fetch] :stub-a}})]
       (is (some? explain) ":resolve-conflicts must fail variant-body validation"))))
 
@@ -506,7 +506,7 @@
   (testing "an inline map plan MAY compose registered fragments + checks (§Inline plan)"
     (let [fragments {:fragment/seed {:setup [[:dispatch [:seed]]]}}
           checks    {:check/clean {:assertions [[:rf.assert/no-warnings]]}}
-          p (plan/variant-plan
+          p (rf.story.plan/variant-plan
               {:variant/id :inline/v
                :compose    [:fragment/seed :check/clean]
                :script     [[:dispatch [:go]]]}

--- a/tools/story/test/re_frame/story/determinism_test.cljc
+++ b/tools/story/test/re_frame/story/determinism_test.cljc
@@ -20,13 +20,13 @@
       • a bare wall-clock `[:wait ms]` returns `:cannot-run`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core      :as rf]
-            [re-frame.epoch     :as epoch]
-            [re-frame.frame     :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story.artifact    :as artifact]
-            [re-frame.story.determinism :as det]
-            [re-frame.story.fingerprint :as fp]))
+            [re-frame.epoch     :as rf.epoch]
+            [re-frame.frame     :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story.artifact    :as rf.story.artifact]
+            [re-frame.story.determinism :as rf.story.determinism]
+            [re-frame.story.fingerprint :as rf.story.fingerprint]))
 
 ;; ===========================================================================
 ;; PURE: the per-run stamp strip in canonicalize  (rf2-5x1wt.8)
@@ -57,28 +57,28 @@
   (testing "two epoch records that differ ONLY in per-run stamps canonicalize ="
     (let [a (epoch-rec 5  :rf.test.replay/frame-aaa {:db-after {:n 1}})
           b (epoch-rec 99 :rf.test.replay/frame-zzz {:db-after {:n 1}})]
-      (is (= (fp/canonicalize a) (fp/canonicalize b))
+      (is (= (rf.story.fingerprint/canonicalize a) (rf.story.fingerprint/canonicalize b))
           ":epoch-id / :frame / :committed-at / :schema-digest are per-run stamps")
-      (is (= (fp/canonical-hash a) (fp/canonical-hash b)))))
+      (is (= (rf.story.fingerprint/canonical-hash a) (rf.story.fingerprint/canonical-hash b)))))
 
   (testing "a SEMANTIC difference (db-after) still perturbs the canonical form"
     (let [a (epoch-rec 5  :rf.test.replay/frame-aaa {:db-after {:n 1}})
           c (epoch-rec 5  :rf.test.replay/frame-aaa {:db-after {:n 2}})]
-      (is (not= (fp/canonicalize a) (fp/canonicalize c))
+      (is (not= (rf.story.fingerprint/canonicalize a) (rf.story.fingerprint/canonicalize c))
           "the strip must not hide a real app-db change")
-      (is (not= (fp/canonical-hash a) (fp/canonical-hash c))))))
+      (is (not= (rf.story.fingerprint/canonical-hash a) (rf.story.fingerprint/canonical-hash c))))))
 
 (deftest canonicalize-strips-trace-event-stamps
   (testing "trace events differing only in :id / :time canonicalize ="
     (let [a {:trace-events [(trace-ev 17 {:tags {:rf.trace/event-id :foo}})]}
           b {:trace-events [(trace-ev 88 {:tags {:rf.trace/event-id :foo}})]}]
-      (is (= (fp/canonicalize a) (fp/canonicalize b))
+      (is (= (rf.story.fingerprint/canonicalize a) (rf.story.fingerprint/canonicalize b))
           ":id (process-global counter) + :time (wall-clock) are per-run stamps")))
 
   (testing "a SEMANTIC trace difference (operation / tags) is NOT stripped"
     (let [a {:trace-events [(trace-ev 17 {:tags {:rf.trace/event-id :foo}})]}
           c {:trace-events [(trace-ev 17 {:tags {:rf.trace/event-id :bar}})]}]
-      (is (not= (fp/canonicalize a) (fp/canonicalize c))
+      (is (not= (rf.story.fingerprint/canonicalize a) (rf.story.fingerprint/canonicalize c))
           "the event-id tag is behavioural, not a stamp"))))
 
 (deftest structural-strip-spares-app-db-keys
@@ -89,11 +89,11 @@
     ;; :epoch-id+record-slot), so the structural strip leaves it intact.
     (let [db1 {:user {:id 1 :time 10 :frame :left}}
           db2 {:user {:id 2 :time 20 :frame :right}}]
-      (is (not= (fp/canonicalize db1) (fp/canonicalize db2))
+      (is (not= (rf.story.fingerprint/canonicalize db1) (rf.story.fingerprint/canonicalize db2))
           "semantic app-db data on common keys survives canonicalization")
       ;; And run-results that embed them in :app-db preserve the distinction.
-      (is (not= (fp/run-hash {:status :pass :app-db db1})
-                (fp/run-hash {:status :pass :app-db db2}))))))
+      (is (not= (rf.story.fingerprint/run-hash {:status :pass :app-db db1})
+                (rf.story.fingerprint/run-hash {:status :pass :app-db db2}))))))
 
 (deftest fresh-frame-tape-twins-hash-equal
   (testing "two run-results from fresh-frame replays — distinct epoch ids,
@@ -115,8 +115,8 @@
                                       {:tags {:rf.trace/event-id :rep/inc}})]})]})
           r1 (run 5  "d-5"  :rf.test.replay/frame-aaa 17)
           r2 (run 90 "d-90" :rf.test.replay/frame-zzz 200)]
-      (is (= (fp/canonicalize r1) (fp/canonicalize r2)))
-      (is (= (fp/run-hash r1) (fp/run-hash r2))
+      (is (= (rf.story.fingerprint/canonicalize r1) (rf.story.fingerprint/canonicalize r2)))
+      (is (= (rf.story.fingerprint/run-hash r1) (rf.story.fingerprint/run-hash r2))
           "semantically-equal fresh-frame runs share one run-hash"))))
 
 ;; ===========================================================================
@@ -125,22 +125,22 @@
 
 (deftest wait-step-detection
   (testing "wait-steps picks out bare [:wait ms]; [:wait-until] is not a wait"
-    (let [a (artifact/make-run-artifact
+    (let [a (rf.story.artifact/make-run-artifact
               {:event-program [[:dispatch [:a]]
                                [:wait 100]
                                [:dispatch [:b]]]})]
-      (is (= [[:wait 100]] (det/wait-steps a)))
-      (is (det/has-wall-clock-wait? a))))
+      (is (= [[:wait 100]] (rf.story.determinism/wait-steps a)))
+      (is (rf.story.determinism/has-wall-clock-wait? a))))
 
   (testing "a wall-clock-free program has no wait steps"
-    (let [a (artifact/make-run-artifact
+    (let [a (rf.story.artifact/make-run-artifact
               {:event-program [[:dispatch [:a]] [:dispatch-sync [:b]]]})]
-      (is (= [] (det/wait-steps a)))
-      (is (not (det/has-wall-clock-wait? a)))))
+      (is (= [] (rf.story.determinism/wait-steps a)))
+      (is (not (rf.story.determinism/has-wall-clock-wait? a)))))
 
   (testing "the refusal is the :cannot-run third status with the wait steps"
-    (let [a (artifact/make-run-artifact {:event-program [[:wait 5] [:dispatch [:x]]]})
-          r (det/cannot-run-wait-refusal a)]
+    (let [a (rf.story.artifact/make-run-artifact {:event-program [[:wait 5] [:dispatch [:x]]]})
+          r (rf.story.determinism/cannot-run-wait-refusal a)]
       (is (= :cannot-run (:status r)))
       (is (= :determinism-wall-clock-wait (:reason r)))
       (is (= [[:wait 5]] (:wait-steps r))))))
@@ -151,16 +151,16 @@
 
 (deftest ->artifact-coercion
   (testing "a run-artifact is used verbatim"
-    (let [a (artifact/make-run-artifact {:event-program [[:dispatch [:x]]]})]
-      (is (identical? a (det/->artifact a)))))
+    (let [a (rf.story.artifact/make-run-artifact {:event-program [[:dispatch [:x]]]})]
+      (is (identical? a (rf.story.determinism/->artifact a)))))
 
   (testing "a normalized plan folds [:world :setup] ⧺ :script and lifts fx-overrides"
     (let [plan {:variant/id :story/x
                 :world  {:setup [[:dispatch [:seed]]]
                          :frame {:fx-overrides {:http/get :http/stub}}}
                 :script [[:dispatch [:act]] [:wait 9]]}
-          a    (det/->artifact plan)]
-      (is (artifact/run-artifact? a))
+          a    (rf.story.determinism/->artifact plan)]
+      (is (rf.story.artifact/run-artifact? a))
       (is (= [[:dispatch [:seed]] [:dispatch [:act]] [:wait 9]]
              (:event-program a))
           "setup-first fold, then script")
@@ -174,17 +174,17 @@
 (deftest compare-runs-pure
   (testing "identical canonical runs are deterministic with one shared run-hash"
     (let [r {:status :pass :app-db {:n 1}}
-          c (det/compare-runs [r r r])]
+          c (rf.story.determinism/compare-runs [r r r])]
       (is (:deterministic? c))
       (is (= 3 (:run-count c)))
-      (is (= (fp/run-hash r) (:run-hash c)))
+      (is (= (rf.story.fingerprint/run-hash r) (:run-hash c)))
       (is (nil? (:divergence c)))))
 
   (testing "a divergent run is detected and named (first differing run vs run 0)"
     (let [r0 {:status :pass :app-db {:n 1}}
           r1 {:status :pass :app-db {:n 1}}
           r2 {:status :pass :app-db {:n 999}}
-          c  (det/compare-runs [r0 r1 r2])]
+          c  (rf.story.determinism/compare-runs [r0 r1 r2])]
       (is (not (:deterministic? c)))
       (is (nil? (:run-hash c)))
       (is (= 2 (get-in c [:divergence :run])) "run 2 is the first divergence")
@@ -192,23 +192,23 @@
                 (get-in c [:divergence :run-hash-n])))))
 
   ;; rf2-12wg5 — compare-runs canonicalizes each run-slice ONCE and derives
-  ;; the hash from the canon (via fp/hash-canonical) rather than
+  ;; the hash from the canon (via rf.story.fingerprint/hash-canonical) rather than
   ;; re-canonicalizing inside run-hash. The reported hashes MUST stay
   ;; byte-identical to run-hash, so a recorded :run-hash and a
   ;; determinism-gate hash never disagree. (rf2-lvrqa — the type-tagged
   ;; canonical-form is NOT idempotent, so the canon is hashed via
   ;; hash-canonical with no second canonicalization pass.)
-  (testing "the reported hashes are byte-identical to fp/run-hash (no double canon)"
+  (testing "the reported hashes are byte-identical to rf.story.fingerprint/run-hash (no double canon)"
     (let [r0 {:status :pass :app-db {:n 1 :nested {:b 2 :a 1}}
               :warnings #{:w2 :w1}}
           r1 {:status :pass :app-db {:n 1 :nested {:a 1 :b 2}}
               ;; volatile + per-run stamps differ but must be stripped equal
               :elapsed-ms 99 :warnings #{:w1 :w2}}
-          c  (det/compare-runs [r0 r1])]
+          c  (rf.story.determinism/compare-runs [r0 r1])]
       (is (:deterministic? c) "the two runs differ only in volatile fields")
-      (is (= [(fp/run-hash r0) (fp/run-hash r1)] (:hashes c))
+      (is (= [(rf.story.fingerprint/run-hash r0) (rf.story.fingerprint/run-hash r1)] (:hashes c))
           "content-hash of the canon equals run-hash for every run")
-      (is (= (fp/run-hash r0) (:run-hash c))
+      (is (= (rf.story.fingerprint/run-hash r0) (:run-hash c))
           "the shared run-hash is the canonical run-hash"))))
 
 ;; rf2-ewrse — the determinism gate inherited the rf2-4gwja fn-slot
@@ -224,14 +224,14 @@
     (let [run-with (fn [f] {:status :pass
                             :app-db  {:n 1 :cb f}
                             :effects [{:fx-id :x :args f :outcome :ok}]})
-          c        (det/compare-runs [(run-with (fn [] 1))
+          c        (rf.story.determinism/compare-runs [(run-with (fn [] 1))
                                       (run-with (fn [] 1))
                                       (run-with (fn [] 1))])]
       (is (:deterministic? c) "fn-identity-only difference is NOT non-determinism")
       (is (nil? (:divergence c)))
       (is (some? (:run-hash c)) "a stable run-hash is reported")))
   (testing "a fn in app-db does NOT mask a real semantic difference"
-    (let [c (det/compare-runs [{:status :pass :app-db {:n 1 :cb (fn [] 1)}}
+    (let [c (rf.story.determinism/compare-runs [{:status :pass :app-db {:n 1 :cb (fn [] 1)}}
                                {:status :pass :app-db {:n 2 :cb (fn [] 1)}}])]
       (is (not (:deterministic? c)) "the :n 1 vs :n 2 difference still diverges"))))
 
@@ -240,13 +240,13 @@
 ;; ===========================================================================
 
 (defn- reset-rf! [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (epoch/clear-history!)
-  (epoch/clear-epoch-listeners!)
-  (try (rf/init! plain-atom/adapter)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (rf.epoch/clear-history!)
+  (rf.epoch/clear-epoch-listeners!)
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
-  (frame/ensure-default-frame!)
+  (rf.frame/ensure-default-frame!)
   (test-fn))
 
 (use-fixtures :each reset-rf!)
@@ -255,9 +255,9 @@
   (testing "the SAME event program replayed twice is equal after
             canonicalization — :deterministic with one shared run-hash"
     (rf/reg-event :det/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-    (let [a   (artifact/make-run-artifact
+    (let [a   (rf.story.artifact/make-run-artifact
                 {:event-program [[:dispatch [:det/inc]] [:dispatch [:det/inc]]]})
-          res (det/assert-deterministic a)]
+          res (rf.story.determinism/assert-deterministic a)]
       (is (= :deterministic (:status res)))
       (is (= 2 (:runs res)))
       (is (string? (:run-hash res)))
@@ -271,7 +271,7 @@
     (let [plan {:variant/id :story.det/plan
                 :world  {:setup [[:dispatch [:det/seed 10]]]}
                 :script [[:dispatch [:det/bump]]]}
-          res  (det/assert-deterministic plan {:runs 3})]
+          res  (rf.story.determinism/assert-deterministic plan {:runs 3})]
       (is (= :deterministic (:status res)))
       (is (= 3 (:runs res))))))
 
@@ -285,9 +285,9 @@
       ;; divergence the canonical strip must NOT mask.
       (rf/reg-event :det/nondet
                        (fn [{:keys [db]} _] {:db (assoc db :token (swap! counter inc))}))
-      (let [a   (artifact/make-run-artifact
+      (let [a   (rf.story.artifact/make-run-artifact
                   {:event-program [[:dispatch [:det/nondet]]]})
-            res (det/assert-deterministic a)]
+            res (rf.story.determinism/assert-deterministic a)]
         (is (= :non-deterministic (:status res)))
         (is (= 1 (get-in res [:divergence :run]))
             "run 1 diverged from run 0")
@@ -301,9 +301,9 @@
             replay stamps fresh epoch / dispatch / trace ids, a new frame id,
             and its own wall-clock — volatile fields cause NO false drift"
     (rf/reg-event :det/pure (fn [{:keys [db]} _] {:db (assoc db :answer 42)}))
-    (let [a   (artifact/make-run-artifact
+    (let [a   (rf.story.artifact/make-run-artifact
                 {:event-program [[:dispatch [:det/pure]] [:dispatch [:det/pure]]]})
-          res (det/assert-deterministic a {:runs 4})]
+          res (rf.story.determinism/assert-deterministic a {:runs 4})]
       (is (= :deterministic (:status res))
           "four fresh-frame replays with distinct stamps still agree")
       (is (= 4 (:runs res)))
@@ -313,11 +313,11 @@
   (testing "a plan containing a bare [:wait ms] returns :cannot-run for the
             determinism gate rather than a flaky verdict — and does NOT replay"
     (rf/reg-event :det/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-    (let [a   (artifact/make-run-artifact
+    (let [a   (rf.story.artifact/make-run-artifact
                 {:event-program [[:dispatch [:det/inc]]
                                  [:wait 50]
                                  [:dispatch [:det/inc]]]})
-          res (det/assert-deterministic a)]
+          res (rf.story.determinism/assert-deterministic a)]
       (is (= :cannot-run (:status res)))
       (is (= :determinism-wall-clock-wait (:reason res)))
       (is (= [[:wait 50]] (:wait-steps res)))
@@ -333,10 +333,10 @@
       (rf/reg-fx :det.fx/stub {:platforms #{:client :server}}
                  (fn [_ _] (swap! hits conj :stub)))
       (rf/reg-event :det/fire (fn [_ _] {:fx [[:det.fx/real {}]]}))
-      (let [a   (artifact/make-run-artifact
+      (let [a   (rf.story.artifact/make-run-artifact
                   {:event-program [[:dispatch [:det/fire]]]
                    :fx-decisions  {:det.fx/real :det.fx/stub}})
-            res (det/assert-deterministic a)]
+            res (rf.story.determinism/assert-deterministic a)]
         (is (= :deterministic (:status res)))
         (is (= [:stub :stub] @hits)
             "the stub fired on BOTH fresh-frame replays")))))

--- a/tools/story/test/re_frame/story/diff_test.cljc
+++ b/tools/story/test/re_frame/story/diff_test.cljc
@@ -24,13 +24,13 @@
     readable app-db facet."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core      :as rf]
-            [re-frame.epoch     :as epoch]
-            [re-frame.frame     :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story.artifact    :as artifact]
-            [re-frame.story.diff        :as diff]
-            [re-frame.story.fingerprint :as fingerprint]))
+            [re-frame.epoch     :as rf.epoch]
+            [re-frame.frame     :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story.artifact    :as rf.story.artifact]
+            [re-frame.story.diff        :as rf.story.diff]
+            [re-frame.story.fingerprint :as rf.story.fingerprint]))
 
 ;; ===========================================================================
 ;; PURE: app-db delta  (§A5 — a small readable diff for an app-db change)
@@ -38,11 +38,11 @@
 
 (deftest diff-app-db-readable-delta
   (testing "an unchanged app-db has no delta"
-    (is (nil? (diff/diff-app-db {:n 1 :user {:name "ada"}}
+    (is (nil? (rf.story.diff/diff-app-db {:n 1 :user {:name "ada"}}
                                 {:n 1 :user {:name "ada"}}))))
 
   (testing "a single changed leaf yields a one-entry :changed at its path"
-    (let [d (diff/diff-app-db {:n 1 :user {:name "ada"}}
+    (let [d (rf.story.diff/diff-app-db {:n 1 :user {:name "ada"}}
                               {:n 2 :user {:name "ada"}})]
       (is (= [{:path [:n] :baseline 1 :current 2}] (:changed d)))
       (is (nil? (:added d)))
@@ -51,14 +51,14 @@
           "ONLY the differing slot appears — the unchanged :user path is silent")))
 
   (testing "an added and a removed leaf are localised to their paths"
-    (let [d (diff/diff-app-db {:a 1 :gone 9}
+    (let [d (rf.story.diff/diff-app-db {:a 1 :gone 9}
                               {:a 1 :new 7})]
       (is (= [{:path [:new] :current 7}] (:added d)))
       (is (= [{:path [:gone] :baseline 9}] (:removed d)))
       (is (nil? (:changed d)))))
 
   (testing "nested leaf changes report the full key path"
-    (let [d (diff/diff-app-db {:user {:profile {:age 30}}}
+    (let [d (rf.story.diff/diff-app-db {:user {:profile {:age 30}}}
                               {:user {:profile {:age 31}}})]
       (is (= [{:path [:user :profile :age] :baseline 30 :current 31}]
              (:changed d)))))
@@ -67,7 +67,7 @@
   ;; leaf {:path [] :current {}} / {:path [] :baseline {}}; the real
   ;; populated-vs-empty difference must still diff correctly.
   (testing "current cleared to {} reports the removed key, NOT a spurious [] leaf"
-    (let [d (diff/diff-app-db {:a 1} {})]
+    (let [d (rf.story.diff/diff-app-db {:a 1} {})]
       (is (= [{:path [:a] :baseline 1}] (:removed d))
           "the populated baseline's key is :removed")
       (is (nil? (:added d))
@@ -76,20 +76,20 @@
           "only the genuine difference, nothing at the [] root")))
 
   (testing "baseline empty {} vs populated current is the symmetric case"
-    (let [d (diff/diff-app-db {} {:a 1})]
+    (let [d (rf.story.diff/diff-app-db {} {:a 1})]
       (is (= [{:path [:a] :current 1}] (:added d)))
       (is (nil? (:removed d))
           "NO spurious {:path [] :baseline {}} root leaf for the empty side")
       (is (= #{:added} (set (keys d))))))
 
   (testing "a NON-ROOT empty map is STILL a semantic leaf ({:k {}} vs {:k {:a 1}})"
-    (let [d (diff/diff-app-db {:k {}} {:k {:a 1}})]
+    (let [d (rf.story.diff/diff-app-db {:k {}} {:k {:a 1}})]
       (is (= [{:path [:k :a] :current 1}] (:added d)))
       (is (= [{:path [:k] :baseline {}}] (:removed d))
           "the [:k] empty-map leaf is preserved — only the ROOT is special-cased")))
 
   (testing "two empty roots are equal — no delta"
-    (is (nil? (diff/diff-app-db {} {})))))
+    (is (nil? (rf.story.diff/diff-app-db {} {})))))
 
 ;; ===========================================================================
 ;; PURE: effect-only diff  (§A5 — an effect-only diff)
@@ -97,11 +97,11 @@
 
 (deftest diff-effects-multiset-delta
   (testing "identical effect rows produce no delta"
-    (is (nil? (diff/diff-effects {:effects [{:fx :http/get :args {:url "/a"}}]}
+    (is (nil? (rf.story.diff/diff-effects {:effects [{:fx :http/get :args {:url "/a"}}]}
                                  {:effects [{:fx :http/get :args {:url "/a"}}]}))))
 
   (testing "an effect emitted only by current is :only-current"
-    (let [d (diff/diff-effects
+    (let [d (rf.story.diff/diff-effects
               {:effects [{:fx :http/get :args {:url "/a"}}]}
               {:effects [{:fx :http/get :args {:url "/a"}}
                          {:fx :analytics/track :args {:event :viewed}}]})]
@@ -109,7 +109,7 @@
       (is (nil? (:only-baseline d)))))
 
   (testing "the SAME effect twice vs once is a multiset difference (the surplus)"
-    (let [d (diff/diff-effects
+    (let [d (rf.story.diff/diff-effects
               {:effects [{:fx :db/save} {:fx :db/save}]}
               {:effects [{:fx :db/save}]})]
       (is (= [{:fx :db/save}] (:only-baseline d))
@@ -124,7 +124,7 @@
   (testing "the same violation surface on both sides is no diff"
     (let [v {:where :event :failing-id :checkout/submit
              :selector [:event :checkout/submit]}]
-      (is (nil? (diff/diff-schema-violations {:schema-violations [v]}
+      (is (nil? (rf.story.diff/diff-schema-violations {:schema-violations [v]}
                                              {:schema-violations [v]})))))
 
   (testing "a violation surface only current failed on is :only-current"
@@ -132,7 +132,7 @@
           current {:schema-violations
                    [{:where :event :failing-id :checkout/submit
                      :selector [:event :checkout/submit]}]}
-          d       (diff/diff-schema-violations base current)]
+          d       (rf.story.diff/diff-schema-violations base current)]
       (is (= [[:event :checkout/submit]] (:only-current d))
           "current introduced a schema failure at [:event :checkout/submit]")
       (is (nil? (:only-baseline d)))))
@@ -140,7 +140,7 @@
   (testing "the selector is recomputed when a record omits it (no :selector slot)"
     (let [current {:schema-violations
                    [{:where :app-db :registered-path [:user] :path [:user :age]}]}
-          d       (diff/diff-schema-violations {:schema-violations []} current)]
+          d       (rf.story.diff/diff-schema-violations {:schema-violations []} current)]
       (is (= [[:app-db [:user] [:user :age]]] (:only-current d))))))
 
 ;; ===========================================================================
@@ -156,12 +156,12 @@
 
 (deftest diff-trace-ops-causal-spine
   (testing "identical op sequences are no diff"
-    (is (nil? (diff/diff-trace-ops
+    (is (nil? (rf.story.diff/diff-trace-ops
                 {:epoch-tape (tape-with-ops [:rf.event/run-start :rf.event/run-end])}
                 {:epoch-tape (tape-with-ops [:rf.event/run-start :rf.event/run-end])}))))
 
   (testing "a diverging op sequence reports both spines + the first divergence"
-    (let [d (diff/diff-trace-ops
+    (let [d (rf.story.diff/diff-trace-ops
               {:epoch-tape (tape-with-ops [:a :b :c])}
               {:epoch-tape (tape-with-ops [:a :x :c])})]
       (is (= [:a :b :c] (:baseline d)))
@@ -169,7 +169,7 @@
       (is (= 1 (:first-divergence d)) "index 1 (:b vs :x) is the first divergence")))
 
   (testing "a dropped trailing op is a diff with no in-range first-divergence"
-    (let [d (diff/diff-trace-ops
+    (let [d (rf.story.diff/diff-trace-ops
               {:epoch-tape (tape-with-ops [:a :b :c])}
               {:epoch-tape (tape-with-ops [:a :b])})]
       (is (= [:a :b :c] (:baseline d)))
@@ -180,7 +180,7 @@
 (deftest diff-sub-runs-multiset-delta
   (testing "diff-sub-runs is a DIAGNOSTIC fn — called directly it still
             reports a view-fact delta (rf2-e6uod / rf2-5l0a5)"
-    (let [d (diff/diff-sub-runs
+    (let [d (rf.story.diff/diff-sub-runs
               {:sub-runs [{:query [:visible-todos] :value 3}]}
               {:sub-runs [{:query [:visible-todos] :value 5}]})]
       (is (= [{:query [:visible-todos] :value 3}] (:only-baseline d)))
@@ -189,9 +189,9 @@
 (deftest diff-status-headline
   (testing "a pass → fail flip is reported"
     (is (= {:baseline :pass :current :fail}
-           (diff/diff-status {:status :pass} {:status :fail}))))
+           (rf.story.diff/diff-status {:status :pass} {:status :fail}))))
   (testing "a shared status is no diff"
-    (is (nil? (diff/diff-status {:status :pass} {:status :pass})))))
+    (is (nil? (rf.story.diff/diff-status {:status :pass} {:status :pass})))))
 
 ;; ===========================================================================
 ;; PURE: warnings / assertions / checks / sub-overrides / fidelity facets
@@ -201,10 +201,10 @@
 (deftest diff-warnings-multiset-delta
   (testing "identical warning rows produce no delta"
     (let [w {:operation :slow-sub :category :performance}]
-      (is (nil? (diff/diff-warnings {:warnings [w]} {:warnings [w]})))))
+      (is (nil? (rf.story.diff/diff-warnings {:warnings [w]} {:warnings [w]})))))
 
   (testing "a warning raised only by baseline is :only-baseline"
-    (let [d (diff/diff-warnings
+    (let [d (rf.story.diff/diff-warnings
               {:warnings [{:operation :slow-sub :category :performance}]}
               {:warnings []})]
       (is (= [{:operation :slow-sub :category :performance}] (:only-baseline d)))
@@ -213,10 +213,10 @@
 (deftest diff-assertions-verdict-delta
   (testing "the same assertion verdict on both sides is no diff"
     (let [a {:assertion :rf.assert/path-equals :payload [[:n] 1] :status :pass}]
-      (is (nil? (diff/diff-assertions {:assertions [a]} {:assertions [a]})))))
+      (is (nil? (rf.story.diff/diff-assertions {:assertions [a]} {:assertions [a]})))))
 
   (testing "a pass → fail verdict flip is a one-entry :changed keyed by selector"
-    (let [d (diff/diff-assertions
+    (let [d (rf.story.diff/diff-assertions
               {:assertions [{:assertion :rf.assert/path-equals :payload [[:n] 1]
                              :status :pass}]}
               {:assertions [{:assertion :rf.assert/path-equals :payload [[:n] 1]
@@ -228,14 +228,14 @@
       (is (nil? (:removed d)))))
 
   (testing "an assertion only current evaluated is :added by selector"
-    (let [d (diff/diff-assertions
+    (let [d (rf.story.diff/diff-assertions
               {:assertions []}
               {:assertions [{:assertion :rf.assert/no-warnings :payload []
                              :status :fail}]})]
       (is (= [{:selector [:rf.assert/no-warnings []] :current :fail}] (:added d)))))
 
   (testing "the payload disambiguates two same-id assertions at different paths"
-    (let [d (diff/diff-assertions
+    (let [d (rf.story.diff/diff-assertions
               {:assertions [{:assertion :rf.assert/path-equals :payload [[:a] 1]
                              :status :pass}
                             {:assertion :rf.assert/path-equals :payload [[:b] 2]
@@ -252,10 +252,10 @@
 (deftest diff-checks-verdict-delta
   (testing "the same check verdict on both sides is no diff"
     (let [c {:check :checkout/valid :status :pass :assertions []}]
-      (is (nil? (diff/diff-checks {:checks [c]} {:checks [c]})))))
+      (is (nil? (rf.story.diff/diff-checks {:checks [c]} {:checks [c]})))))
 
   (testing "a check that flipped pass → fail is a one-entry :changed by check id"
-    (let [d (diff/diff-checks
+    (let [d (rf.story.diff/diff-checks
               {:checks [{:check :checkout/valid :status :pass :assertions []}]}
               {:checks [{:check :checkout/valid :status :fail :assertions []}]})]
       (is (= [{:selector :checkout/valid :baseline :pass :current :fail}]
@@ -265,34 +265,34 @@
 (deftest diff-sub-overrides-keyed-delta
   (testing "identical override maps produce no delta"
     (let [m {[:login/state] :error}]
-      (is (nil? (diff/diff-sub-overrides {:sub-overrides m} {:sub-overrides m})))))
+      (is (nil? (rf.story.diff/diff-sub-overrides {:sub-overrides m} {:sub-overrides m})))))
 
   (testing "an override whose pinned value differs is :changed by query vector"
-    (let [d (diff/diff-sub-overrides
+    (let [d (rf.story.diff/diff-sub-overrides
               {:sub-overrides {[:login/state] :error}}
               {:sub-overrides {[:login/state] :loading}})]
       (is (= [{:query [:login/state] :baseline :error :current :loading}]
              (:changed d)))))
 
   (testing "an override only current carries is :added"
-    (let [d (diff/diff-sub-overrides
+    (let [d (rf.story.diff/diff-sub-overrides
               {:sub-overrides {}}
               {:sub-overrides {[:item 7] {:name "x"}}})]
       (is (= [{:query [:item 7] :current {:name "x"}}] (:added d))))))
 
 (deftest diff-fidelity-set-delta
   (testing "identical fidelity rung sets produce no delta"
-    (is (nil? (diff/diff-fidelity {:fidelity #{:real-setup}}
+    (is (nil? (rf.story.diff/diff-fidelity {:fidelity #{:real-setup}}
                                   {:fidelity #{:real-setup}}))))
 
   (testing "a rung current rested on but baseline did not is :only-current"
-    (let [d (diff/diff-fidelity {:fidelity #{:real-setup}}
+    (let [d (rf.story.diff/diff-fidelity {:fidelity #{:real-setup}}
                                 {:fidelity #{:real-setup :sub-overrides}})]
       (is (= #{:sub-overrides} (:only-current d)))
       (is (nil? (:only-baseline d)))))
 
   (testing "rungs on each side that the other lacks are split"
-    (let [d (diff/diff-fidelity {:fidelity #{:real-setup}}
+    (let [d (rf.story.diff/diff-fidelity {:fidelity #{:real-setup}}
                                 {:fidelity #{:sub-overrides}})]
       (is (= #{:real-setup} (:only-baseline d)))
       (is (= #{:sub-overrides} (:only-current d))))))
@@ -305,7 +305,7 @@
   (testing "two runs equal under canonicalize diff to {:same? true}"
     (let [r {:status :pass :app-db {:n 1} :effects [] :sub-runs []
              :epoch-tape (tape-with-ops [:rf.event/run-start])}]
-      (is (= {:same? true} (diff/diff-runs r r))))))
+      (is (= {:same? true} (rf.story.diff/diff-runs r r))))))
 
 ;; rf2-sn7nh — diff-runs' :same? gate is canonicalize equality, so it
 ;; inherited the rf2-lvrqa map/vector collision (a map<->vector flip in
@@ -316,17 +316,17 @@
 (deftest diff-runs-inherits-lvrqa-and-4gwja-fixes
   (testing "a map<->vector flip in app-db is NO LONGER :same? true and
             surfaces a readable :app-db facet (rf2-sn7nh / rf2-lvrqa)"
-    (let [d (diff/diff-runs {:status :pass :app-db {:k {:a 1}}}
+    (let [d (rf.story.diff/diff-runs {:status :pass :app-db {:k {:a 1}}}
                             {:status :pass :app-db {:k [:a 1]}})]
       (is (false? (:same? d)) "the collision is witnessed, not suppressed")
       (is (contains? (:facets d) :app-db) "the :app-db facet localises it")))
   (testing "an empty-map<->empty-vector flip is also witnessed (rf2-lvrqa)"
-    (is (false? (:same? (diff/diff-runs {:status :pass :app-db {:k {}}}
+    (is (false? (:same? (rf.story.diff/diff-runs {:status :pass :app-db {:k {}}}
                                         {:status :pass :app-db {:k []}})))))
   (testing "a same-semantics fn in app-db is :same? true — no false :changed
             from object-identity noise (rf2-sn7nh / rf2-4gwja)"
     (is (= {:same? true}
-           (diff/diff-runs {:status :pass :app-db {:cb (fn [] 1)}}
+           (rf.story.diff/diff-runs {:status :pass :app-db {:cb (fn [] 1)}}
                            {:status :pass :app-db {:cb (fn [] 1)}})))))
 
 (deftest diff-runs-collects-only-differing-facets
@@ -334,7 +334,7 @@
     (let [base {:status :pass :app-db {:n 1} :effects [] :sub-runs []
                 :epoch-tape (tape-with-ops [:rf.event/run-start])}
           cur  (assoc base :app-db {:n 2})
-          d    (diff/diff-runs base cur)]
+          d    (rf.story.diff/diff-runs base cur)]
       (is (false? (:same? d)))
       (is (= #{:app-db} (:facets d)))
       (is (= [{:path [:n] :baseline 1 :current 2}] (get-in d [:app-db :changed])))
@@ -346,7 +346,7 @@
           cur  {:status :fail :app-db {} :sub-runs []
                 :effects [{:fx :http/get :outcome :error}]
                 :epoch-tape (tape-with-ops [:e])}
-          d    (diff/diff-runs base cur)]
+          d    (rf.story.diff/diff-runs base cur)]
       (is (= #{:status :effects} (:facets d)))
       (is (= {:baseline :pass :current :fail} (:status d)))
       (is (= [{:fx :http/get :outcome :error}] (get-in d [:effects :only-current]))))))
@@ -360,7 +360,7 @@
   (testing "a warnings-ONLY delta surfaces the :warnings facet (was {:facets #{}})"
     (let [base {:status :pass :warnings []}
           cur  {:status :pass :warnings [{:operation :slow-sub :category :perf}]}
-          d    (diff/diff-runs base cur)]
+          d    (rf.story.diff/diff-runs base cur)]
       (is (false? (:same? d)))
       (is (= #{:warnings} (:facets d)))
       (is (seq (:facets d)) "the previously-silent warnings delta is now named")))
@@ -370,7 +370,7 @@
                                             :status :pass}]}
           cur  {:status :pass :assertions [{:assertion :rf.assert/eq :payload [1 1]
                                             :status :fail}]}
-          d    (diff/diff-runs base cur)]
+          d    (rf.story.diff/diff-runs base cur)]
       (is (false? (:same? d)))
       (is (= #{:assertions} (:facets d)))
       (is (= [{:selector [:rf.assert/eq [1 1]] :baseline :pass :current :fail}]
@@ -379,21 +379,21 @@
   (testing "a checks-ONLY verdict flip surfaces the :checks facet"
     (let [base {:status :pass :checks [{:check :c/login :status :pass :assertions []}]}
           cur  {:status :pass :checks [{:check :c/login :status :fail :assertions []}]}
-          d    (diff/diff-runs base cur)]
+          d    (rf.story.diff/diff-runs base cur)]
       (is (false? (:same? d)))
       (is (= #{:checks} (:facets d)))))
 
   (testing "a sub-overrides-ONLY delta surfaces the :sub-overrides facet"
     (let [base {:status :pass :sub-overrides {[:login/state] :error}}
           cur  {:status :pass :sub-overrides {[:login/state] :loading}}
-          d    (diff/diff-runs base cur)]
+          d    (rf.story.diff/diff-runs base cur)]
       (is (false? (:same? d)))
       (is (= #{:sub-overrides} (:facets d)))))
 
   (testing "a fidelity-ONLY delta surfaces the :fidelity facet"
     (let [base {:status :pass :fidelity #{:real-setup}}
           cur  {:status :pass :fidelity #{:real-setup :sub-overrides}}
-          d    (diff/diff-runs base cur)]
+          d    (rf.story.diff/diff-runs base cur)]
       (is (false? (:same? d)))
       (is (= #{:fidelity} (:facets d))))))
 
@@ -407,8 +407,8 @@
 
 (deftest facet-set-equals-canonical-slice
   (testing "facet-fns keys == run-hash-input-keys (with :trace-ops ⇄ :epoch-tape)"
-    (let [facet-names (set (keys diff/facet-fns))
-          slice-keys  (set fingerprint/run-hash-input-keys)]
+    (let [facet-names (set (keys rf.story.diff/facet-fns))
+          slice-keys  (set rf.story.fingerprint/run-hash-input-keys)]
       (is (= (disj facet-names :trace-ops)
              (disj slice-keys :epoch-tape))
           "the facet set and the canonical slice are the SAME surface — the
@@ -419,10 +419,10 @@
       (is (contains? slice-keys :epoch-tape))))
 
   (testing ":sub-runs is NOT a facet — it is deliberately outside the slice"
-    (is (not (contains? (set (keys diff/facet-fns)) :sub-runs))
+    (is (not (contains? (set (keys rf.story.diff/facet-fns)) :sub-runs))
         ":sub-runs carries no diff-runs facet (over-recomputed evidence, not a
          determinism input)")
-    (is (not (contains? (set fingerprint/run-hash-input-keys) :sub-runs))
+    (is (not (contains? (set rf.story.fingerprint/run-hash-input-keys) :sub-runs))
         ":sub-runs is excluded from the run-hash slice — the facet set honors
          that exclusion rather than overstating coverage")))
 
@@ -433,7 +433,7 @@
     (let [base {:status :pass :app-db {:n 1}
                 :sub-runs [{:query [:visible-todos] :value 3}]}
           cur  (assoc base :sub-runs [{:query [:visible-todos] :value 5}])
-          d    (diff/diff-runs base cur)]
+          d    (rf.story.diff/diff-runs base cur)]
       (is (= {:same? true} d)
           "a pure :sub-runs delta is behaviourally identical to the gate — so
            diff-runs agrees with the determinism / golden verdict")
@@ -456,7 +456,7 @@
           cur  {:status :pass
                 :epoch-tape [{:epoch-id 1 :outcome :ok :db-after {:n 2}
                               :trace-events [{:operation :go :op-type :event}]}]}
-          d    (diff/diff-runs base cur)]
+          d    (rf.story.diff/diff-runs base cur)]
       (is (false? (:same? d)))
       (is (seq (:facets d)) "INVARIANT: :same? false ⟹ :facets non-empty")
       (is (= #{:slice-keys} (:facets d)))
@@ -495,7 +495,7 @@
            (assoc base :sub-overrides {[:login/state] :error})
            (assoc base :fidelity #{:real-setup :sub-overrides})]]
       (doseq [cur perturbations]
-        (let [d (diff/diff-runs base cur)]
+        (let [d (rf.story.diff/diff-runs base cur)]
           (is (false? (:same? d)) (str "perturbation should differ: " (pr-str cur)))
           (is (seq (:facets d))
               (str "INVARIANT VIOLATED — empty :facets for: " (pr-str cur))))))))
@@ -526,7 +526,7 @@
                         :committed-at 1000 :trace-id 17 :db-after {:n 1}})
           b (noisy-run {:frame :rf.test.replay/frame-zzz :epoch-id 99
                         :committed-at 2000 :trace-id 88 :db-after {:n 1}})]
-      (is (= {:same? true} (diff/diff-runs a b))
+      (is (= {:same? true} (rf.story.diff/diff-runs a b))
           "frame ids, epoch ids, timestamps, trace ids are NOT differences")))
 
   (testing "a real app-db change IS detected even amid the per-run noise"
@@ -534,7 +534,7 @@
                         :committed-at 1000 :trace-id 17 :db-after {:n 1}})
           c (noisy-run {:frame :rf.test.replay/frame-zzz :epoch-id 99
                         :committed-at 2000 :trace-id 88 :db-after {:n 2}})
-          d (diff/diff-runs a c)]
+          d (rf.story.diff/diff-runs a c)]
       (is (false? (:same? d)))
       (is (contains? (:facets d) :app-db))
       (is (= [{:path [:n] :baseline 1 :current 2}] (get-in d [:app-db :changed]))
@@ -544,7 +544,7 @@
   (testing ":rf.story/* accumulator keys in app-db are stripped before diffing"
     (let [a {:status :pass :app-db {:n 1 :rf.story/probe :a}}
           b {:status :pass :app-db {:n 1 :rf.story/probe :b}}]
-      (is (= {:same? true} (diff/diff-runs a b))
+      (is (= {:same? true} (rf.story.diff/diff-runs a b))
           "the accumulator key differs but is not semantic — stripped first"))))
 
 ;; ===========================================================================
@@ -552,13 +552,13 @@
 ;; ===========================================================================
 
 (defn- reset-rf! [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (epoch/clear-history!)
-  (epoch/clear-epoch-listeners!)
-  (try (rf/init! plain-atom/adapter)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (rf.epoch/clear-history!)
+  (rf.epoch/clear-epoch-listeners!)
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
-  (frame/ensure-default-frame!)
+  (rf.frame/ensure-default-frame!)
   (test-fn))
 
 (use-fixtures :each reset-rf!)
@@ -567,18 +567,18 @@
   (testing "replaying the SAME program twice into fresh frames diffs {:same? true}
             — fresh-frame volatile drift causes no false difference"
     (rf/reg-event :diff/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-    (let [a (artifact/make-run-artifact
+    (let [a (rf.story.artifact/make-run-artifact
               {:event-program [[:dispatch [:diff/inc]] [:dispatch [:diff/inc]]]})]
-      (is (= {:same? true} (diff/diff-run-artifacts a a))
+      (is (= {:same? true} (rf.story.diff/diff-run-artifacts a a))
           "two fresh-frame replays of one program are behaviourally identical"))))
 
 (deftest diff-run-artifacts-divergent-program-surfaces-app-db-facet
   (testing "two programs producing different final app-db surface a readable
             :app-db facet"
     (rf/reg-event :diff/set (fn [{:keys [db]} [_ v]] {:db (assoc db :v v)}))
-    (let [a (artifact/make-run-artifact {:event-program [[:dispatch [:diff/set 1]]]})
-          b (artifact/make-run-artifact {:event-program [[:dispatch [:diff/set 2]]]})
-          d (diff/diff-run-artifacts a b)]
+    (let [a (rf.story.artifact/make-run-artifact {:event-program [[:dispatch [:diff/set 1]]]})
+          b (rf.story.artifact/make-run-artifact {:event-program [[:dispatch [:diff/set 2]]]})
+          d (rf.story.diff/diff-run-artifacts a b)]
       (is (false? (:same? d)))
       (is (contains? (:facets d) :app-db))
       (is (= [{:path [:v] :baseline 1 :current 2}]
@@ -588,10 +588,10 @@
   (testing "a run-result side is used as-is (the pure path) — diffing an
             artifact replay against a hand-built result still works"
     (rf/reg-event :diff/set (fn [{:keys [db]} [_ v]] {:db (assoc db :v v)}))
-    (let [art    (artifact/make-run-artifact {:event-program [[:dispatch [:diff/set 9]]]})
+    (let [art    (rf.story.artifact/make-run-artifact {:event-program [[:dispatch [:diff/set 9]]]})
           result {:status :pass :app-db {:v 9} :effects [] :sub-runs []
                   :epoch-tape []}
-          d      (diff/diff-run-artifacts art result)]
+          d      (rf.story.diff/diff-run-artifacts art result)]
       ;; The artifact replay's app-db {:v 9} matches the hand-built result's
       ;; {:v 9}; the trace-op spine differs (the replay has trace events, the
       ;; hand-built result none), so the diff is NOT :same? but the app-db

--- a/tools/story/test/re_frame/story/egress_test.cljc
+++ b/tools/story/test/re_frame/story/egress_test.cljc
@@ -8,51 +8,51 @@
   copied artifact says HONESTLY whether the recipient can reproduce it
   (full / partial / view-only) and WHAT downgraded it."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.egress :as egress]))
+            [re-frame.story.egress :as rf.story.egress]))
 
 ;; ---- worse / status fold -------------------------------------------------
 
 (deftest worse-takes-the-lower-fidelity
   (testing "worse returns the lower-fidelity of two statuses"
-    (is (= :partial   (egress/worse :full :partial)))
-    (is (= :view-only (egress/worse :partial :view-only)))
-    (is (= :view-only (egress/worse :full :view-only)))
-    (is (= :full      (egress/worse :full :full)))
-    (is (= :view-only (egress/worse :view-only :partial))
+    (is (= :partial   (rf.story.egress/worse :full :partial)))
+    (is (= :view-only (rf.story.egress/worse :partial :view-only)))
+    (is (= :view-only (rf.story.egress/worse :full :view-only)))
+    (is (= :full      (rf.story.egress/worse :full :full)))
+    (is (= :view-only (rf.story.egress/worse :view-only :partial))
         "one view-only reason wins regardless of argument order")))
 
 ;; ---- contains-fn? / edn-round-trips? -------------------------------------
 
 (deftest contains-fn?-walks-structure
   (testing "contains-fn? finds a fn anywhere in a nested structure"
-    (is (false? (egress/contains-fn? {:a 1 :b [2 3] :c #{:x}})))
-    (is (true?  (egress/contains-fn? (fn [] 1))))
-    (is (true?  (egress/contains-fn? {:a {:b [1 (fn [_] 2)]}})))
-    (is (true?  (egress/contains-fn? #{1 (fn [] 1)})))
-    (is (true?  (egress/contains-fn? [:keep inc])))
-    (is (false? (egress/contains-fn? {:f :not-a-fn :v "inc"}))
+    (is (false? (rf.story.egress/contains-fn? {:a 1 :b [2 3] :c #{:x}})))
+    (is (true?  (rf.story.egress/contains-fn? (fn [] 1))))
+    (is (true?  (rf.story.egress/contains-fn? {:a {:b [1 (fn [_] 2)]}})))
+    (is (true?  (rf.story.egress/contains-fn? #{1 (fn [] 1)})))
+    (is (true?  (rf.story.egress/contains-fn? [:keep inc])))
+    (is (false? (rf.story.egress/contains-fn? {:f :not-a-fn :v "inc"}))
         "a keyword / string that LOOKS fn-like is not a fn")))
 
 (deftest edn-round-trips?
   (testing "plain EDN data round-trips; fn-bearing / unreadable values do not"
-    (is (true?  (egress/edn-round-trips? {:label "Click me" :count 5})))
-    (is (true?  (egress/edn-round-trips? [:a :b {:c #{1 2}}])))
-    (is (false? (egress/edn-round-trips? {:on-click (fn [_] nil)})))
-    (is (false? (egress/edn-round-trips? (fn [] 1))))))
+    (is (true?  (rf.story.egress/edn-round-trips? {:label "Click me" :count 5})))
+    (is (true?  (rf.story.egress/edn-round-trips? [:a :b {:c #{1 2}}])))
+    (is (false? (rf.story.egress/edn-round-trips? {:on-click (fn [_] nil)})))
+    (is (false? (rf.story.egress/edn-round-trips? (fn [] 1))))))
 
 ;; ---- classify: the happy path --------------------------------------------
 
 (deftest classify-empty-is-full
   (testing "an artifact with no downgrade reasons is fully reproducible"
-    (let [r (egress/classify {:plan nil :cell-overrides nil :dropped nil})]
+    (let [r (rf.story.egress/classify {:plan nil :cell-overrides nil :dropped nil})]
       (is (= :full (:status r)))
       (is (= "fully reproducible" (:label r)))
       (is (empty? (:reasons r)))
-      (is (true? (egress/full? r))))))
+      (is (true? (rf.story.egress/full? r))))))
 
 (deftest classify-plain-overrides-is-full
   (testing "serialisable cell-overrides keep the artifact fully reproducible"
-    (let [r (egress/classify {:cell-overrides {:label "Hi" :count 9}})]
+    (let [r (rf.story.egress/classify {:cell-overrides {:label "Hi" :count 9}})]
       (is (= :full (:status r)))
       (is (empty? (:reasons r))))))
 
@@ -60,7 +60,7 @@
 
 (deftest classify-dropped-overrides-is-partial
   (testing "share-URL overrides that no longer apply downgrade to partial"
-    (let [r (egress/classify {:dropped ["stale-arg:1" "gone:2"]})]
+    (let [r (rf.story.egress/classify {:dropped ["stale-arg:1" "gone:2"]})]
       (is (= :partial (:status r)))
       (is (= "partially reproducible" (:label r)))
       (is (= 1 (count (:reasons r))))
@@ -70,14 +70,14 @@
 (deftest classify-network-reply-fn-is-partial
   (testing "a network stub replying via a fn downgrades to partial (route survives)"
     (let [plan {:world {:network {[:get "/api/x"] {:reply (fn [_] {})}}}}
-          r    (egress/classify {:plan plan})]
+          r    (rf.story.egress/classify {:plan plan})]
       (is (= :partial (:status r)))
       (is (some #(= :network-reply-fn (:code %)) (:reasons r))))))
 
 (deftest classify-script-fn-is-partial
   (testing "a play-script step carrying a fn downgrades to partial"
     (let [plan {:script [[:dispatch [:inc]] [:custom (fn [_] nil)]]}
-          r    (egress/classify {:plan plan})]
+          r    (rf.story.egress/classify {:plan plan})]
       (is (= :partial (:status r)))
       (is (some #(= :script-fn (:code %)) (:reasons r))))))
 
@@ -85,7 +85,7 @@
 
 (deftest classify-fn-override-is-view-only
   (testing "a fn-valued cell-override makes the artifact view-only"
-    (let [r (egress/classify {:cell-overrides {:on-click (fn [_] nil) :label "ok"}})]
+    (let [r (rf.story.egress/classify {:cell-overrides {:on-click (fn [_] nil) :label "ok"}})]
       (is (= :view-only (:status r)))
       (is (= "view-only" (:label r)))
       (is (some #(= :override-fn (:code %)) (:reasons r))))))
@@ -93,14 +93,14 @@
 (deftest classify-sub-override-fn-is-view-only
   (testing "a fn-valued :sub-overrides value makes the artifact view-only"
     (let [plan {:world {:render {:sub-overrides {[:my/sub] (fn [] 1)}}}}
-          r    (egress/classify {:plan plan})]
+          r    (rf.story.egress/classify {:plan plan})]
       (is (= :view-only (:status r)))
       (is (some #(= :sub-override-fn (:code %)) (:reasons r))))))
 
 (deftest classify-non-edn-override-is-partial-not-view-only
   (testing "a non-fn, non-round-tripping override is partial (dropped, not view-only)"
     ;; A regex is not a fn and does not EDN-round-trip to an equal value.
-    (let [r (egress/classify {:cell-overrides {:pattern #?(:clj #"x" :cljs (js/RegExp. "x"))}})]
+    (let [r (rf.story.egress/classify {:cell-overrides {:pattern #?(:clj #"x" :cljs (js/RegExp. "x"))}})]
       (is (= :partial (:status r)))
       (is (some #(= :override-non-edn (:code %)) (:reasons r))))))
 
@@ -109,7 +109,7 @@
 (deftest classify-mixes-reasons-and-takes-lowest
   (testing "several reasons collect; the overall status is the lowest any implies"
     (let [plan {:world {:render {:sub-overrides {[:s] (fn [] 1)}}}} ; view-only
-          r    (egress/classify {:plan           plan
+          r    (rf.story.egress/classify {:plan           plan
                                  :cell-overrides {:count 5}        ; full
                                  :dropped        ["gone:1"]})]     ; partial
       (is (= :view-only (:status r)) "the view-only sub-override wins")
@@ -119,8 +119,8 @@
 
 (deftest status-labels-cover-every-status
   (testing "every status has a human label"
-    (doseq [s egress/statuses]
-      (is (string? (get egress/status-labels s))
+    (doseq [s rf.story.egress/statuses]
+      (is (string? (get rf.story.egress/status-labels s))
           (str "missing label for " s)))))
 
 ;; ---- EP-0015 scope reconciliation (rf2-nnc06c) ---------------------------
@@ -136,7 +136,7 @@
   (testing "a sensitive value in a copied-EDN override SHIPS verbatim — the
             human-egress classifier never substitutes :rf/redacted"
     (let [secret "BEARER-secret-12345"
-          r      (egress/classify {:cell-overrides {:auth/token secret}})]
+          r      (rf.story.egress/classify {:cell-overrides {:auth/token secret}})]
       ;; A plain string round-trips, so it is fully reproducible — and it
       ;; ships verbatim (the classifier returns a verdict, not a redacted
       ;; payload; nothing in the report is :rf/redacted).
@@ -149,8 +149,8 @@
            egress is not a redaction seam")))
   (testing "the reproducibility verdict is identical whether the value is a
             secret or a benign string — sensitivity is orthogonal"
-    (is (= (egress/classify {:cell-overrides {:k "BEARER-secret-12345"}})
-           (egress/classify {:cell-overrides {:k "benign"}}))
+    (is (= (rf.story.egress/classify {:cell-overrides {:k "BEARER-secret-12345"}})
+           (rf.story.egress/classify {:cell-overrides {:k "benign"}}))
         "same shape ⇒ same reproducibility status regardless of sensitivity")))
 
 (deftest classify-screenshot-is-always-view-only-and-unredacted
@@ -159,7 +159,7 @@
     ;; A screenshot of the live canvas cannot be replayed from the artifact;
     ;; the egress UI marks it view-only. The classifier reports that without
     ;; ever inspecting sensitivity.
-    (let [r (egress/classify {:cell-overrides {:render (fn [] :pixels)}})]
+    (let [r (rf.story.egress/classify {:cell-overrides {:render (fn [] :pixels)}})]
       (is (= :view-only (:status r))
           "a function-valued artifact is view-only (no replay)")
       (is (some #(= :override-fn (:code %)) (:reasons r))

--- a/tools/story/test/re_frame/story/error_projection_redaction_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/error_projection_redaction_cljs_test.cljs
@@ -24,32 +24,32 @@
   ## redacts it while the message survives verbatim."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.machines         :as machines]
-            [re-frame.registrar        :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story            :as story]
-            [re-frame.story.async      :as async-lib]
-            [re-frame.story.loaders    :as loaders]
-            [re-frame.story.ui.state   :as state]
-            [re-frame.subs             :as subs]))
+            [re-frame.frame            :as rf.frame]
+            [re-frame.machines         :as rf.machines]
+            [re-frame.registrar        :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story            :as rf.story]
+            [re-frame.story.async      :as rf.story.async]
+            [re-frame.story.loaders    :as rf.story.loaders]
+            [re-frame.story.ui.state   :as rf.story.ui.state]
+            [re-frame.subs             :as rf.subs]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch :default _ nil))
-  (subs/reg-runtime-sub :rf/machine
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [runtime-db [_ machine-id]]
       (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -71,13 +71,13 @@
         (throw (ex-info "Invalid credentials"
                         {:token  "BEARER-secret-12345"
                          :reason :bad-password}))))
-    (story/reg-variant :story.err-redaction/probe
+    (rf.story/reg-variant :story.err-redaction/probe
       {:setup      []
        :sensitive   {:app-db [[:token]]}
        :script [[:dispatch-sync [:auth/boom]]]})
     (async done
-      (-> (story/run-variant :story.err-redaction/probe)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.err-redaction/probe)
+          (rf.story.async/then
             (fn [result]
               (let [ex   (last (filter #(= :rf.error/exception (:assertion %))
                                        (:assertions result)))
@@ -92,7 +92,7 @@
                     "a non-sensitive ex-data slot passes through")
                 (is (= "Invalid credentials" (get-in ex [:error :message]))
                     "the message string survives verbatim (NOT auto-walked)"))
-              (story/destroy-variant! :story.err-redaction/probe)
+              (rf.story/destroy-variant! :story.err-redaction/probe)
               (done)))))))
 
 (deftest exception-ex-data-non-sensitive-passes-through
@@ -101,17 +101,17 @@
     (rf/reg-event :plain/boom
       (fn [_ _]
         (throw (ex-info "boom" {:detail "not-secret"}))))
-    (story/reg-variant :story.err-plain/probe
+    (rf.story/reg-variant :story.err-plain/probe
       {:setup      []
        :script [[:dispatch-sync [:plain/boom]]]})
     (async done
-      (-> (story/run-variant :story.err-plain/probe)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.err-plain/probe)
+          (rf.story.async/then
             (fn [result]
               (let [ex   (last (filter #(= :rf.error/exception (:assertion %))
                                        (:assertions result)))
                     data (get-in ex [:error :data])]
                 (is (= "not-secret" (:detail data))
                     "an unmarked ex-data slot is not redacted"))
-              (story/destroy-variant! :story.err-plain/probe)
+              (rf.story/destroy-variant! :story.err-plain/probe)
               (done)))))))

--- a/tools/story/test/re_frame/story/generate_test.cljc
+++ b/tools/story/test/re_frame/story/generate_test.cljc
@@ -16,14 +16,14 @@
     existing bridge; `sweep-faults!` collects one artifact per fault cell."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core   :as rf]
-            [re-frame.epoch  :as epoch]
-            [re-frame.frame  :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story.artifact  :as artifact]
-            [re-frame.story.generate  :as generate]
-            [re-frame.story.generate.test-check :as gen-tc]
-            [re-frame.story.promotion :as promotion]
+            [re-frame.epoch  :as rf.epoch]
+            [re-frame.frame  :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story.artifact  :as rf.story.artifact]
+            [re-frame.story.generate  :as rf.story.generate]
+            [re-frame.story.generate.test-check :as rf.story.generate.test-check]
+            [re-frame.story.promotion :as rf.story.promotion]
             #?(:clj [clojure.test.check.generators :as tcgen])))
 
 ;; ===========================================================================
@@ -39,16 +39,16 @@
   ;; `generated-failure-promotes-through-the-existing-bridge`). The spec
   ;; (spec/017 §Generator-agnostic) now qualifies the claim as within-host.
   (testing "WITHIN a host the same root seed yields the SAME sequence (reproducibility)"
-    (is (= (generate/seed-seq 12345 8) (generate/seed-seq 12345 8))
+    (is (= (rf.story.generate/seed-seq 12345 8) (rf.story.generate/seed-seq 12345 8))
         "a property run replays identically from its recorded :seed on the same host"))
   (testing "different root seeds diverge"
-    (is (not= (generate/seed-seq 1 8) (generate/seed-seq 2 8))))
+    (is (not= (rf.story.generate/seed-seq 1 8) (rf.story.generate/seed-seq 2 8))))
   (testing "seed-seq length + the root seed is never reused as a program seed"
-    (let [s (generate/seed-seq 99 5)]
+    (let [s (rf.story.generate/seed-seq 99 5)]
       (is (= 5 (count s)))
       (is (not (some #{99} s)) "root seed itself is not in the program-seed sequence")))
   (testing "next-seed is a pure, deterministic successor"
-    (is (= (generate/next-seed 7) (generate/next-seed 7)))))
+    (is (= (rf.story.generate/next-seed 7) (rf.story.generate/next-seed 7)))))
 
 ;; ===========================================================================
 ;; PURE: failure predicate + shrink candidate enumeration
@@ -56,24 +56,24 @@
 
 (deftest failing-predicate
   (testing ":fail / :error falsify; :pass / :cannot-run do not"
-    (is (generate/failing? {:status :fail}))
-    (is (generate/failing? {:status :error}))
-    (is (not (generate/failing? {:status :pass})))
-    (is (not (generate/failing? {:status :cannot-run}))
+    (is (rf.story.generate/failing? {:status :fail}))
+    (is (rf.story.generate/failing? {:status :error}))
+    (is (not (rf.story.generate/failing? {:status :pass})))
+    (is (not (rf.story.generate/failing? {:status :cannot-run}))
         ":cannot-run is inconclusive, not a falsification")))
 
 (deftest drop-candidates-enumeration
   (testing "drop-candidates removes one contiguous chunk-size window, L→R"
     (is (= [[:b :c :d] [:a :c :d] [:a :b :d] [:a :b :c]]
-           (generate/drop-candidates [:a :b :c :d] 1))
+           (rf.story.generate/drop-candidates [:a :b :c :d] 1))
         "chunk-size 1: drop each single step in turn (one candidate per step)")
     (is (= [[:c :d] [:a :b]]
-           (generate/drop-candidates [:a :b :c :d] 2))
+           (rf.story.generate/drop-candidates [:a :b :c :d] 2))
         "chunk-size 2: drop the first pair, then the second pair"))
   (testing "a chunk >= length yields the empty program; <= 0 yields none"
-    (is (= [[]] (generate/drop-candidates [:a :b] 2)))
-    (is (= []  (generate/drop-candidates [:a :b] 0)))
-    (is (= []  (generate/drop-candidates [] 3)))))
+    (is (= [[]] (rf.story.generate/drop-candidates [:a :b] 2)))
+    (is (= []  (rf.story.generate/drop-candidates [:a :b] 0)))
+    (is (= []  (rf.story.generate/drop-candidates [] 3)))))
 
 ;; ===========================================================================
 ;; PURE: seed-bearing artifact construction
@@ -81,17 +81,17 @@
 
 (deftest generated-artifact-carries-seed-and-shrink
   (testing "a generated artifact is a :rf.test/run-artifact carrying its :seed"
-    (let [a (generate/generated-artifact
+    (let [a (rf.story.generate/generated-artifact
               {:seed 42 :event-program [[:counter/inc]]})]
-      (is (artifact/run-artifact? a))
+      (is (rf.story.artifact/run-artifact? a))
       (is (= 42 (:seed a)))
       (is (= [[:dispatch [:counter/inc]]] (:event-program a))
           "a bare event vector lifts to a tagged dispatch program")
       (is (= :rf.story/property-run (get-in a [:source :tool])))))
   (testing "a shrunk failure carries its :shrink-path; absent when not shrunk"
-    (let [shrunk (generate/generated-artifact
+    (let [shrunk (rf.story.generate/generated-artifact
                    {:seed 1 :event-program [[:a]] :shrink-path [[[:a] [:b]]]})
-          plain  (generate/generated-artifact {:seed 1 :event-program [[:a]]})]
+          plain  (rf.story.generate/generated-artifact {:seed 1 :event-program [[:a]]})]
       (is (= [[[:a] [:b]]] (:shrink-path shrunk)))
       (is (not (contains? plain :shrink-path))))))
 
@@ -100,13 +100,13 @@
 ;; ===========================================================================
 
 (defn- reset-rf! [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (epoch/clear-history!)
-  (epoch/clear-epoch-listeners!)
-  (try (rf/init! plain-atom/adapter)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (rf.epoch/clear-history!)
+  (rf.epoch/clear-epoch-listeners!)
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
-  (frame/ensure-default-frame!)
+  (rf.frame/ensure-default-frame!)
   (test-fn))
 
 (use-fixtures :each reset-rf!)
@@ -115,7 +115,7 @@
   (testing "a property that always holds passes over N seeds"
     ;; A handler that always succeeds — every generated program passes.
     (rf/reg-event :gen/ok (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-    (let [res (generate/check-property!
+    (let [res (rf.story.generate/check-property!
                 (fn [_seed] [[:dispatch [:gen/ok]]])
                 {:seed 7 :num-tests 5})]
       (is (= :pass (:status res)))
@@ -134,12 +134,12 @@
 (deftest check-property-falsifies-and-emits-seed-bearing-artifact
   (testing "a property that fails yields a seed-bearing failing artifact"
     (reg-boom!)
-    (let [res (generate/check-property!
+    (let [res (rf.story.generate/check-property!
                 (fn [_seed] [[:dispatch [:gen/boom]]])
                 {:seed 3 :num-tests 4 :shrink? false})]
       (is (= :fail (:status res)))
       (is (some? (:seed res)) "the failing program's seed is recorded")
-      (is (artifact/run-artifact? (:artifact res)))
+      (is (rf.story.artifact/run-artifact? (:artifact res)))
       (is (= (:seed res) (:seed (:artifact res)))
           "the artifact carries the falsifying seed")
       (is (= :fail (:status (:result res)))))))
@@ -153,7 +153,7 @@
     (let [program [[:dispatch [:gen/noise]] [:dispatch [:gen/noise]]
                    [:dispatch [:gen/boom]]
                    [:dispatch [:gen/noise]] [:dispatch [:gen/noise]]]
-          res (generate/check-property!
+          res (rf.story.generate/check-property!
                 (fn [_seed] program)
                 {:seed 1 :num-tests 1 :shrink? true})]
       (is (= :fail (:status res)))
@@ -170,14 +170,14 @@
   (testing "a generated failure's artifact promotes into a curated variant,
             preserving the source link + the seed/shrink provenance"
     (reg-boom!)
-    (let [res      (generate/check-property!
+    (let [res      (rf.story.generate/check-property!
                      (fn [_seed] [[:dispatch [:gen/boom]]])
                      {:seed 5 :num-tests 2 :shrink? true})
           artifact (:artifact res)
           ;; materialize-variant-plan is PURE — registers nothing; it proves
           ;; the generated failure flows through the promotion bridge with
           ;; its seed-bearing source link intact.
-          plan     (promotion/materialize-variant-plan
+          plan     (rf.story.promotion/materialize-variant-plan
                      artifact {:variant/id :story.gen/regression-5})]
       (is (= :fail (:status res)))
       (is (= :rf.test/run-artifact (get-in plan [:run-artifact :artifact/kind]))
@@ -213,11 +213,11 @@
     (let [base   [[:dispatch [:app/save]]]
           lattice {:healthy {}
                    :save-fails {:app.fx/save :app.fx/save-broken}}
-          res    (generate/sweep-faults! base lattice {:seed 11})]
+          res    (rf.story.generate/sweep-faults! base lattice {:seed 11})]
       (is (= 2 (count (:cells res))) "one cell per lattice entry")
       (let [by-cell (into {} (map (juxt :cell identity)) (:cells res))]
-        (is (artifact/run-artifact? (:artifact (:healthy by-cell))))
-        (is (artifact/run-artifact? (:artifact (:save-fails by-cell))))
+        (is (rf.story.artifact/run-artifact? (:artifact (:healthy by-cell))))
+        (is (rf.story.artifact/run-artifact? (:artifact (:save-fails by-cell))))
         (is (= {:app.fx/save :app.fx/save-broken}
                (:fx-decisions (:artifact (:save-fails by-cell))))
             "the faulted cell's artifact carries its fault overrides for replay")
@@ -241,8 +241,8 @@
           ;; The SAME lattice in both shapes, in the same cell order.
           as-map      {:healthy {} :save-fails {:app.fx/save :app.fx/save-broken}}
           as-pair-seq [[:healthy {}] [:save-fails {:app.fx/save :app.fx/save-broken}]]
-          from-map    (generate/sweep-faults! base as-map      {:seed 7})
-          from-seq    (generate/sweep-faults! base as-pair-seq {:seed 7})
+          from-map    (rf.story.generate/sweep-faults! base as-map      {:seed 7})
+          from-seq    (rf.story.generate/sweep-faults! base as-pair-seq {:seed 7})
           cell-shape  (fn [c] {:cell (:cell c)
                                :status (:status c)
                                :fx-decisions (:fx-decisions (:artifact c))})]
@@ -274,7 +274,7 @@
    (deftest test-check-adapter-is-available-on-the-test-classpath
      (testing "test.check resolves on the :test alias, so the optional adapter
                reports available (the dep is test-only, not a Story runtime dep)"
-       (is (true? (gen-tc/available?))
+       (is (true? (rf.story.generate.test-check/available?))
            "org.clojure/test.check is on the :test alias classpath"))))
 
 #?(:clj
@@ -285,7 +285,7 @@
        ;; A generator of event programs: 1–4 dispatch steps of :gen/ok.
        (let [program-gen (tcgen/vector
                            (tcgen/return [:dispatch [:gen/ok]]) 1 4)
-             gen-fn      (gen-tc/gen->gen-fn program-gen {:size 20})]
+             gen-fn      (rf.story.generate.test-check/gen->gen-fn program-gen {:size 20})]
          (is (= (gen-fn 12345) (gen-fn 12345))
              "same seed → identical program")
          (is (let [p (gen-fn 7)]
@@ -306,8 +306,8 @@
        (rf/reg-event :gen/ok (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
        (let [program-gen (tcgen/vector
                           (tcgen/return [:dispatch [:gen/ok]]) 1 3)
-             res (gen-tc/check-property-gen!
-                  generate/check-property! program-gen
+             res (rf.story.generate.test-check/check-property-gen!
+                  rf.story.generate/check-property! program-gen
                   {:seed 7 :num-tests 5 :size 25})]
          (is (= :pass (:status res)))
          (is (= 5 (:num-tests res)))
@@ -328,11 +328,11 @@
                           (fn [noise] (conj (vec noise) [:dispatch [:gen/boom]]))
                           (tcgen/vector
                            (tcgen/return [:dispatch [:gen/noise]]) 0 3))
-             res (gen-tc/check-property-gen!
-                  generate/check-property! program-gen
+             res (rf.story.generate.test-check/check-property-gen!
+                  rf.story.generate/check-property! program-gen
                   {:seed 3 :num-tests 4 :size 20 :shrink? true})]
          (is (= :fail (:status res)))
-         (is (artifact/run-artifact? (:artifact res)))
+         (is (rf.story.artifact/run-artifact? (:artifact res)))
          (is (= (:seed res) (:seed (:artifact res)))
              "the artifact carries the falsifying seed (same as splitmix path)")
          (is (some #(= [:dispatch [:gen/boom]] %) (:smallest-program res))
@@ -340,7 +340,7 @@
          (is (seq (:shrink-path res))
              "shrinking ran via check-property!'s own delta-debug, not test.check")
          ;; The artifact promotes through the existing curated bridge unchanged.
-         (let [plan (promotion/materialize-variant-plan
+         (let [plan (rf.story.promotion/materialize-variant-plan
                      (:artifact res) {:variant/id :story.gen-tc/regression-3})]
            (is (= (:seed (:artifact res)) (get-in plan [:run-artifact :seed]))
                "the curated plan carries the test.check-driven failing seed"))))))
@@ -354,7 +354,7 @@
        ;; and the adapter's `available?` is the branch a caller uses to pick the
        ;; dependency-free path. The CLJS arm of the adapter throws the same
        ;; message (covered by the node build loading the ns without test.check).
-       (is (fn? (gen-tc/gen->gen-fn (tcgen/return [:dispatch [:gen/ok]])))
+       (is (fn? (rf.story.generate.test-check/gen->gen-fn (tcgen/return [:dispatch [:gen/ok]])))
            "with test.check present, gen->gen-fn returns a usable gen-fn")
-       (is (true? (gen-tc/available?))
+       (is (true? (rf.story.generate.test-check/available?))
            "available? is the documented branch for choosing the gen-fn path"))))

--- a/tools/story/test/re_frame/story/golden_test.cljc
+++ b/tools/story/test/re_frame/story/golden_test.cljc
@@ -21,13 +21,13 @@
     of the same program, and a divergent program does not."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core      :as rf]
-            [re-frame.epoch     :as epoch]
-            [re-frame.frame     :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story.artifact    :as artifact]
-            [re-frame.story.fingerprint :as fingerprint]
-            [re-frame.story.golden      :as golden]))
+            [re-frame.epoch     :as rf.epoch]
+            [re-frame.frame     :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story.artifact    :as rf.story.artifact]
+            [re-frame.story.fingerprint :as rf.story.fingerprint]
+            [re-frame.story.golden      :as rf.story.golden]))
 
 ;; ===========================================================================
 ;; This ns is the rf2-5x1wt.32 golden-slice coverage, extended by:
@@ -51,7 +51,7 @@
 
 (defn- run-result
   "A minimal hand-built run-result over the behavioural slice
-  (`fingerprint/run-hash-input-keys`)."
+  (`rf.story.fingerprint/run-hash-input-keys`)."
   [{:keys [status app-db effects ops]
     :or   {status :pass app-db {} effects [] ops [:rf.event/run-start]}}]
   {:status status
@@ -90,20 +90,20 @@
 (deftest make-golden-shape
   (testing "a golden carries the kind tag, a frozen :canonical, the run-hash,
             and the slice keys it was taken over"
-    (let [g (golden/make-golden (run-result {:app-db {:n 1}}))]
-      (is (golden/golden? g))
+    (let [g (rf.story.golden/make-golden (run-result {:app-db {:n 1}}))]
+      (is (rf.story.golden/golden? g))
       (is (= :rf.test/golden (:golden/kind g)))
       (is (contains? g :canonical))
-      (is (= (fingerprint/run-hash (run-result {:app-db {:n 1}})) (:run-hash g)))
-      (is (= fingerprint/run-hash-input-keys (:slice-keys g)))
+      (is (= (rf.story.fingerprint/run-hash (run-result {:app-db {:n 1}})) (:run-hash g)))
+      (is (= rf.story.fingerprint/run-hash-input-keys (:slice-keys g)))
       (is (not (contains? g :golden/meta)) "no meta unless supplied")
       (is (not (contains? g :run-result)) "no run-result unless :keep-run-result"))))
 
 (deftest make-golden-meta-and-keep-run-result
   (testing ":meta rides under :golden/meta and is NOT part of :canonical"
     (let [run (run-result {:app-db {:n 1}})
-          g1  (golden/make-golden run)
-          g2  (golden/make-golden run {:meta {:variant/id :story.checkout/ok
+          g1  (rf.story.golden/make-golden run)
+          g2  (rf.story.golden/make-golden run {:meta {:variant/id :story.checkout/ok
                                               :doc "checkout happy path"}})]
       (is (= {:variant/id :story.checkout/ok :doc "checkout happy path"}
              (:golden/meta g2)))
@@ -112,19 +112,19 @@
 
   (testing ":keep-run-result retains the behavioural slice for the readable diff"
     (let [run (run-result {:app-db {:n 1}})
-          g   (golden/make-golden run {:keep-run-result true})]
-      (is (= (golden/behavioural-slice run) (:run-result g))))))
+          g   (rf.story.golden/make-golden run {:keep-run-result true})]
+      (is (= (rf.story.golden/behavioural-slice run) (:run-result g))))))
 
 (deftest golden-round-trips
   (testing "canonicalizing the same run twice yields the SAME golden :canonical
             — the round-trip property the golden contract rests on"
     (let [run (run-result {:app-db {:user {:name "ada"} :n 3}
                            :effects [{:fx :http/get :args {:url "/a"}}]})
-          g1  (golden/make-golden run)
-          g2  (golden/make-golden run)]
+          g1  (rf.story.golden/make-golden run)
+          g2  (rf.story.golden/make-golden run)]
       (is (= (:canonical g1) (:canonical g2)))
       (is (= (:run-hash g1) (:run-hash g2)))
-      (is (golden/golden-match? g1 run)
+      (is (rf.story.golden/golden-match? g1 run)
           "a golden matches the very run it was captured from"))))
 
 ;; ===========================================================================
@@ -133,29 +133,29 @@
 
 (deftest golden-match-true-for-equivalent-run
   (testing "a behaviourally-equivalent run (same slice) matches"
-    (let [g (golden/make-golden (run-result {:app-db {:n 1} :ops [:a :b]}))]
-      (is (true? (golden/golden-match? g (run-result {:app-db {:n 1} :ops [:a :b]}))))))
+    (let [g (rf.story.golden/make-golden (run-result {:app-db {:n 1} :ops [:a :b]}))]
+      (is (true? (rf.story.golden/golden-match? g (run-result {:app-db {:n 1} :ops [:a :b]}))))))
 
   (testing "map key ORDER in app-db does not affect the match (canonical)"
-    (let [g (golden/make-golden (run-result {:app-db {:a 1 :b 2}}))]
-      (is (true? (golden/golden-match? g (run-result {:app-db (sorted-map :b 2 :a 1)})))))))
+    (let [g (rf.story.golden/make-golden (run-result {:app-db {:a 1 :b 2}}))]
+      (is (true? (rf.story.golden/golden-match? g (run-result {:app-db (sorted-map :b 2 :a 1)})))))))
 
 (deftest golden-match-false-for-semantic-difference
   (testing "an app-db change fails the match"
-    (let [g (golden/make-golden (run-result {:app-db {:n 1}}))]
-      (is (false? (golden/golden-match? g (run-result {:app-db {:n 2}}))))))
+    (let [g (rf.story.golden/make-golden (run-result {:app-db {:n 1}}))]
+      (is (false? (rf.story.golden/golden-match? g (run-result {:app-db {:n 2}}))))))
 
   (testing "an effect-only change fails the match"
-    (let [g (golden/make-golden (run-result {:effects [{:fx :db/save}]}))]
-      (is (false? (golden/golden-match? g (run-result {:effects []}))))))
+    (let [g (rf.story.golden/make-golden (run-result {:effects [{:fx :db/save}]}))]
+      (is (false? (rf.story.golden/golden-match? g (run-result {:effects []}))))))
 
   (testing "a status flip fails the match"
-    (let [g (golden/make-golden (run-result {:status :pass}))]
-      (is (false? (golden/golden-match? g (run-result {:status :fail}))))))
+    (let [g (rf.story.golden/make-golden (run-result {:status :pass}))]
+      (is (false? (rf.story.golden/golden-match? g (run-result {:status :fail}))))))
 
   (testing "a diverging trace op spine fails the match"
-    (let [g (golden/make-golden (run-result {:ops [:a :b :c]}))]
-      (is (false? (golden/golden-match? g (run-result {:ops [:a :x :c]})))))))
+    (let [g (rf.story.golden/make-golden (run-result {:ops [:a :b :c]}))]
+      (is (false? (rf.story.golden/golden-match? g (run-result {:ops [:a :x :c]})))))))
 
 ;; ===========================================================================
 ;; PURE: the load-bearing property — volatile fields do NOT cause a false miss
@@ -167,19 +167,19 @@
             reusing .8's strip rules"
     (let [captured (noisy-run {:frame :rf.test.replay/frame-aaa :epoch-id 5
                                :committed-at 1000 :trace-id 17 :db-after {:n 1}})
-          g        (golden/make-golden captured)
+          g        (rf.story.golden/make-golden captured)
           rerun    (noisy-run {:frame :rf.test.replay/frame-zzz :epoch-id 99
                                :committed-at 2000 :trace-id 88 :db-after {:n 1}})]
-      (is (true? (golden/golden-match? g rerun))
+      (is (true? (rf.story.golden/golden-match? g rerun))
           "frame ids, epoch ids, timestamps, trace ids are NOT mismatches")))
 
   (testing "a real app-db change is STILL caught amid the per-run noise"
     (let [captured (noisy-run {:frame :rf.test.replay/frame-aaa :epoch-id 5
                                :committed-at 1000 :trace-id 17 :db-after {:n 1}})
-          g        (golden/make-golden captured)
+          g        (rf.story.golden/make-golden captured)
           changed  (noisy-run {:frame :rf.test.replay/frame-zzz :epoch-id 99
                                :committed-at 2000 :trace-id 88 :db-after {:n 2}})]
-      (is (false? (golden/golden-match? g changed))
+      (is (false? (rf.story.golden/golden-match? g changed))
           "the canonical compare surfaces the SEMANTIC change, not volatile drift"))))
 
 ;; ===========================================================================
@@ -189,22 +189,22 @@
 (deftest compare-golden-match-report
   (testing "a match reports {:match? true} with the run-hash"
     (let [run (run-result {:app-db {:n 1}})
-          g   (golden/make-golden run)
-          r   (golden/compare-golden g run)]
+          g   (rf.story.golden/make-golden run)
+          r   (rf.story.golden/compare-golden g run)]
       (is (true? (:match? r)))
-      (is (= (fingerprint/run-hash run) (:run-hash r)))
+      (is (= (rf.story.fingerprint/run-hash run) (:run-hash r)))
       (is (not (contains? r :diff)) "a match carries no diff"))))
 
 (deftest compare-golden-mismatch-delegates-to-diff
   (testing "a mismatch with a kept run-result DELEGATES to diff/diff-runs for a
             localised, readable report"
     (let [captured (run-result {:app-db {:n 1}})
-          g        (golden/make-golden captured {:keep-run-result true})
+          g        (rf.story.golden/make-golden captured {:keep-run-result true})
           changed  (run-result {:app-db {:n 2}})
-          r        (golden/compare-golden g changed)]
+          r        (rf.story.golden/compare-golden g changed)]
       (is (false? (:match? r)))
       (is (= (:run-hash g) (:golden-run-hash r)))
-      (is (= (fingerprint/run-hash changed) (:run-hash r)))
+      (is (= (rf.story.fingerprint/run-hash changed) (:run-hash r)))
       ;; The diff is the diff/diff-runs facet shape — NOT a reinvented diff.
       (is (false? (get-in r [:diff :same?])))
       (is (= #{:app-db} (:facets (:diff r))))
@@ -214,16 +214,16 @@
 
   (testing "an effect-only mismatch surfaces ONLY the :effects facet"
     (let [captured (run-result {:effects [{:fx :db/save}]})
-          g        (golden/make-golden captured {:keep-run-result true})
+          g        (rf.story.golden/make-golden captured {:keep-run-result true})
           changed  (run-result {:effects []})
-          r        (golden/compare-golden g changed)]
+          r        (rf.story.golden/compare-golden g changed)]
       (is (false? (:match? r)))
       (is (= #{:effects} (:facets (:diff r))))))
 
   (testing "a mismatch with NO retained run-result still states the mismatch FACT"
-    (let [g       (golden/make-golden (run-result {:app-db {:n 1}}))
+    (let [g       (rf.story.golden/make-golden (run-result {:app-db {:n 1}}))
           changed (run-result {:app-db {:n 2}})
-          r       (golden/compare-golden g changed)]
+          r       (rf.story.golden/compare-golden g changed)]
       (is (false? (:match? r)))
       (is (= :unavailable-no-run-result (:diff r))
           "without :keep-run-result the readable diff is unavailable, but the
@@ -232,9 +232,9 @@
   (testing "a supplied :golden-run-result drives the diff even when the golden
             did not retain one"
     (let [captured (run-result {:app-db {:n 1}})
-          g        (golden/make-golden captured)
+          g        (rf.story.golden/make-golden captured)
           changed  (run-result {:app-db {:n 2}})
-          r        (golden/compare-golden g changed
+          r        (rf.story.golden/compare-golden g changed
                                           {:golden-run-result captured})]
       (is (false? (:match? r)))
       (is (= #{:app-db} (:facets (:diff r)))))))
@@ -247,14 +247,14 @@
   (testing "a freshly-captured golden's :slice-keys are current; a golden whose
             frozen surface differs from run-hash-input-keys is stale; a legacy
             golden with NO :slice-keys is treated as current"
-    (let [g (golden/make-golden (run-result {:app-db {:n 1}}))]
-      (is (true? (golden/slice-keys-current? g))
+    (let [g (rf.story.golden/make-golden (run-result {:app-db {:n 1}}))]
+      (is (true? (rf.story.golden/slice-keys-current? g))
           "the surface a golden was captured over matches the current keys")
-      (is (false? (golden/slice-keys-current?
-                    (assoc g :slice-keys (conj fingerprint/run-hash-input-keys
+      (is (false? (rf.story.golden/slice-keys-current?
+                    (assoc g :slice-keys (conj rf.story.fingerprint/run-hash-input-keys
                                                :some-new-slot))))
           "a frozen surface that drifted from the current keys is stale")
-      (is (true? (golden/slice-keys-current? (dissoc g :slice-keys)))
+      (is (true? (rf.story.golden/slice-keys-current? (dissoc g :slice-keys)))
           "a golden captured before :slice-keys existed is not flagged stale"))))
 
 (deftest compare-golden-stale-slice-keys-distinct-verdict
@@ -265,25 +265,25 @@
     (let [run    (run-result {:app-db {:n 1}})
           ;; Simulate a future slice-surface change: the frozen golden was
           ;; captured over a DIFFERENT key set than the current one.
-          stale  (assoc (golden/make-golden run {:keep-run-result true})
-                        :slice-keys (conj fingerprint/run-hash-input-keys
+          stale  (assoc (rf.story.golden/make-golden run {:keep-run-result true})
+                        :slice-keys (conj rf.story.fingerprint/run-hash-input-keys
                                           :some-future-slot))
-          r      (golden/compare-golden stale run)]
+          r      (rf.story.golden/compare-golden stale run)]
       (is (false? (:match? r)) "a slice-surface drift is never a match")
       (is (true? (:stale-slice-keys r)) "surfaced as the distinct verdict")
       (is (not (contains? r :diff))
           "no diff/diff-runs is taken — diffing across surfaces would mislocalise")
-      (is (= (conj fingerprint/run-hash-input-keys :some-future-slot)
+      (is (= (conj rf.story.fingerprint/run-hash-input-keys :some-future-slot)
              (:golden-slice-keys r)))
-      (is (= fingerprint/run-hash-input-keys (:current-slice-keys r)))))
+      (is (= rf.story.fingerprint/run-hash-input-keys (:current-slice-keys r)))))
 
   (testing "golden-match? also returns false on a stale slice surface — the
             three-stage matches? gates slice-keys before canonical equality"
     (let [run   (run-result {:app-db {:n 1}})
-          stale (assoc (golden/make-golden run)
-                       :slice-keys (conj fingerprint/run-hash-input-keys
+          stale (assoc (rf.story.golden/make-golden run)
+                       :slice-keys (conj rf.story.fingerprint/run-hash-input-keys
                                          :some-future-slot))]
-      (is (false? (golden/golden-match? stale run))
+      (is (false? (rf.story.golden/golden-match? stale run))
           "even the very run the golden was captured from is NOT a match once
            the frozen surface drifts from the current keys"))))
 
@@ -295,10 +295,10 @@
   (testing "golden-match? and compare-golden's :match? agree for EVERY run —
             they route through the one shared GREEN/RED predicate, so the
             verdict can never drift between the boolean and the report"
-    (let [g      (golden/make-golden (run-result {:app-db {:n 1} :ops [:a :b]})
+    (let [g      (rf.story.golden/make-golden (run-result {:app-db {:n 1} :ops [:a :b]})
                                      {:keep-run-result true})
           ;; A stale-slice-surface golden: both paths must report a non-match.
-          stale  (assoc g :slice-keys (conj fingerprint/run-hash-input-keys
+          stale  (assoc g :slice-keys (conj rf.story.fingerprint/run-hash-input-keys
                                             :some-future-slot))
           runs  [;; equivalent ⇒ both GREEN
                  (run-result {:app-db {:n 1} :ops [:a :b]})
@@ -311,28 +311,28 @@
                  ;; op-spine change ⇒ both RED
                  (run-result {:app-db {:n 1} :ops [:a :x]})]]
       (doseq [run runs]
-        (is (= (golden/golden-match? g run)
-               (:match? (golden/compare-golden g run)))
+        (is (= (rf.story.golden/golden-match? g run)
+               (:match? (rf.story.golden/compare-golden g run)))
             (str "golden-match? and compare-golden disagree for " (pr-str run)))
-        (is (= (golden/golden-match? stale run)
-               (:match? (golden/compare-golden stale run)))
+        (is (= (rf.story.golden/golden-match? stale run)
+               (:match? (rf.story.golden/compare-golden stale run)))
             (str "stale-slice golden: golden-match? and compare-golden disagree for "
                  (pr-str run)))))))
 
 (deftest compare-golden-run-hash-matches-fingerprint
   (testing "the :run-hash compare-golden reports is the canonical
-            fingerprint/run-hash of the run — the single-canonicalize perf
+            rf.story.fingerprint/run-hash of the run — the single-canonicalize perf
             path (content-hash of the canonical slice) equals the two-stage
             run-hash, so the optimization is behaviour-preserving"
     (let [matchy   (run-result {:app-db {:n 1}})
-          g        (golden/make-golden matchy {:keep-run-result true})
+          g        (rf.story.golden/make-golden matchy {:keep-run-result true})
           changed  (run-result {:app-db {:n 2}})
-          r-match  (golden/compare-golden g matchy)
-          r-miss   (golden/compare-golden g changed)]
-      (is (= (fingerprint/run-hash matchy) (:run-hash r-match))
-          "match report :run-hash == fingerprint/run-hash")
-      (is (= (fingerprint/run-hash changed) (:run-hash r-miss))
-          "mismatch report :run-hash == fingerprint/run-hash")
+          r-match  (rf.story.golden/compare-golden g matchy)
+          r-miss   (rf.story.golden/compare-golden g changed)]
+      (is (= (rf.story.fingerprint/run-hash matchy) (:run-hash r-match))
+          "match report :run-hash == rf.story.fingerprint/run-hash")
+      (is (= (rf.story.fingerprint/run-hash changed) (:run-hash r-miss))
+          "mismatch report :run-hash == rf.story.fingerprint/run-hash")
       (is (= (:run-hash g) (:golden-run-hash r-miss))
           "the frozen golden hash is reported as :golden-run-hash"))))
 
@@ -353,40 +353,40 @@
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
             #":rf.error/golden-bad-target"
-            (golden/capture-golden bad))
+            (rf.story.golden/capture-golden bad))
           (str "capture-golden must reject " (pr-str bad)))))
 
   (testing "the rejection carries the structured :rf.error/id + the offending
             target for diagnosis"
     (let [bad {:not :recognized}
-          e   (try (golden/capture-golden bad)
+          e   (try (rf.story.golden/capture-golden bad)
                    (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e e))]
       (is (= :rf.error/golden-bad-target (:rf.error/id (ex-data e))))
       (is (= bad (:target (ex-data e))))))
 
   (testing "golden-match? / compare-golden ALSO fail closed on a bad run target"
-    (let [g (golden/make-golden (run-result {:app-db {:n 1}}))]
+    (let [g (rf.story.golden/make-golden (run-result {:app-db {:n 1}}))]
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
             #":rf.error/golden-bad-target"
-            (golden/golden-match? g {:no :status})))
+            (rf.story.golden/golden-match? g {:no :status})))
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
             #":rf.error/golden-bad-target"
-            (golden/compare-golden g {:no :status}))))))
+            (rf.story.golden/compare-golden g {:no :status}))))))
 
 ;; ===========================================================================
 ;; HEADLESS: capture / compare over real replays  (live frame)
 ;; ===========================================================================
 
 (defn- reset-rf! [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (epoch/clear-history!)
-  (epoch/clear-epoch-listeners!)
-  (try (rf/init! plain-atom/adapter)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (rf.epoch/clear-history!)
+  (rf.epoch/clear-epoch-listeners!)
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
-  (frame/ensure-default-frame!)
+  (rf.frame/ensure-default-frame!)
   (test-fn))
 
 (use-fixtures :each reset-rf!)
@@ -396,23 +396,23 @@
             matches a re-replay of the same program — fresh-frame volatile
             drift causes no false mismatch"
     (rf/reg-event :golden/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-    (let [art (artifact/make-run-artifact
+    (let [art (rf.story.artifact/make-run-artifact
                 {:event-program [[:dispatch [:golden/inc]] [:dispatch [:golden/inc]]]})
-          g   (golden/capture-golden art {:keep-run-result true})]
-      (is (golden/golden? g))
-      (is (true? (golden/golden-match? g art))
+          g   (rf.story.golden/capture-golden art {:keep-run-result true})]
+      (is (rf.story.golden/golden? g))
+      (is (true? (rf.story.golden/golden-match? g art))
           "the same program replayed again matches the captured golden")
-      (is (true? (:match? (golden/compare-golden g art)))))))
+      (is (true? (:match? (rf.story.golden/compare-golden g art)))))))
 
 (deftest compare-golden-divergent-program-surfaces-app-db-facet
   (testing "a golden captured from one program does NOT match a divergent
             program, and the report surfaces a readable :app-db facet"
     (rf/reg-event :golden/set (fn [{:keys [db]} [_ v]] {:db (assoc db :v v)}))
-    (let [a (artifact/make-run-artifact {:event-program [[:dispatch [:golden/set 1]]]})
-          b (artifact/make-run-artifact {:event-program [[:dispatch [:golden/set 2]]]})
-          g (golden/capture-golden a {:keep-run-result true})
-          r (golden/compare-golden g b)]
-      (is (false? (golden/golden-match? g b)))
+    (let [a (rf.story.artifact/make-run-artifact {:event-program [[:dispatch [:golden/set 1]]]})
+          b (rf.story.artifact/make-run-artifact {:event-program [[:dispatch [:golden/set 2]]]})
+          g (rf.story.golden/capture-golden a {:keep-run-result true})
+          r (rf.story.golden/compare-golden g b)]
+      (is (false? (rf.story.golden/golden-match? g b)))
       (is (false? (:match? r)))
       (is (contains? (:facets (:diff r)) :app-db))
       (is (= [{:path [:v] :baseline 1 :current 2}]
@@ -432,8 +432,8 @@
     (let [plan {:variant/id :story.golden/plan
                 :world  {:setup [[:dispatch [:golden/seed 10]]]}
                 :script [[:dispatch [:golden/bump]]]}
-          g    (golden/capture-golden plan {:keep-run-result true})]
-      (is (golden/golden? g))
+          g    (rf.story.golden/capture-golden plan {:keep-run-result true})]
+      (is (rf.story.golden/golden? g))
       ;; The frozen slice must be the REPLAYED run-result, not the plan map:
       ;; a real run carries a :status and a non-empty :app-db. A silently-
       ;; frozen plan would freeze {:v nil}/no :status and read near-empty.
@@ -443,16 +443,16 @@
           "the frozen slice carries the run's :status — proving it is a run-result")
       ;; And the golden re-matches a re-replay of the SAME plan (fresh-frame
       ;; volatile drift causes no false mismatch).
-      (is (true? (golden/golden-match? g plan))
+      (is (true? (rf.story.golden/golden-match? g plan))
           "the same plan replayed again matches the captured golden")
-      (is (true? (:match? (golden/compare-golden g plan))))))
+      (is (true? (:match? (rf.story.golden/compare-golden g plan))))))
 
   (testing "a golden captured from a plan does NOT match a divergent plan"
     (rf/reg-event :golden/seed (fn [{:keys [db]} [_ v]] {:db (assoc db :v v)}))
     (let [plan-a {:variant/id :story.golden/a :world {} :script [[:dispatch [:golden/seed 1]]]}
           plan-b {:variant/id :story.golden/b :world {} :script [[:dispatch [:golden/seed 2]]]}
-          g      (golden/capture-golden plan-a {:keep-run-result true})
-          r      (golden/compare-golden g plan-b)]
-      (is (false? (golden/golden-match? g plan-b)))
+          g      (rf.story.golden/capture-golden plan-a {:keep-run-result true})
+          r      (rf.story.golden/compare-golden g plan-b)]
+      (is (false? (rf.story.golden/golden-match? g plan-b)))
       (is (false? (:match? r)))
       (is (contains? (:facets (:diff r)) :app-db)))))

--- a/tools/story/test/re_frame/story/hicasso_substrate_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/hicasso_substrate_cljs_test.cljc
@@ -16,10 +16,10 @@
   1. **Registration** — the closed shape accepts it, on the variant body
      and on the story body, and STILL refuses an unknown member. A widen
      that quietly opened the enum would pass every other row here.
-  2. **Plan compilation** — `plan/variant-plan` folds it to
+  2. **Plan compilation** — `rf.story.plan/variant-plan` folds it to
      `[:world :substrates]`, which is where `canonical/render-host-scope`
      reads the declared set (rf2-3afns).
-  3. **The EDN / MCP read path** — `story/variant->edn` is what the MCP
+  3. **The EDN / MCP read path** — `rf.story/variant->edn` is what the MCP
      `list-variants` / read tools relay to an agent, and a keyword that
      did not round-trip would strand the agent on a story it can see and
      cannot describe.
@@ -43,22 +43,22 @@
   `re-frame.story.ui.hicasso-substrate-dom-cljs-test`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [malli.core :as m]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as rf-registrar]
-            [re-frame.story :as story]
-            [re-frame.story.identity :as identity]
-            [re-frame.story.plan :as plan]
-            [re-frame.story.registrar :as story-registrar]
-            [re-frame.story.schemas :as schemas]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.story :as rf.story]
+            [re-frame.story.identity :as rf.story.identity]
+            [re-frame.story.plan :as rf.story.plan]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.schemas :as rf.story.schemas]))
 
 ;; ---- fixture --------------------------------------------------------------
 
 (defn- reset-all! []
-  (story/clear-all!)
-  (rf-registrar/clear-all!)
-  (reset! frame/frames {})
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each (fn [t] (reset-all!) (t)))
 
@@ -70,15 +70,15 @@
   (testing "rf2-2dbpd — `#{:hicasso}` is a legal substrate set. Before the
             widen this was the whole blocker: the schema rejected it, so
             no hicasso variant could be registered at all."
-    (is (m/validate schemas/SubstrateSet #{:hicasso}))
-    (is (m/validate schemas/SubstrateSet #{:reagent :hicasso}))
-    (is (m/validate schemas/SubstrateSet #{:reagent :uix :hicasso})))
+    (is (m/validate rf.story.schemas/SubstrateSet #{:hicasso}))
+    (is (m/validate rf.story.schemas/SubstrateSet #{:reagent :hicasso}))
+    (is (m/validate rf.story.schemas/SubstrateSet #{:reagent :uix :hicasso})))
 
   (testing "and the members that were already legal still are — the widen
             is additive, not a replacement"
-    (is (m/validate schemas/SubstrateSet #{:reagent}))
-    (is (m/validate schemas/SubstrateSet #{:uix}))
-    (is (m/validate schemas/SubstrateSet #{})))
+    (is (m/validate rf.story.schemas/SubstrateSet #{:reagent}))
+    (is (m/validate rf.story.schemas/SubstrateSet #{:uix}))
+    (is (m/validate rf.story.schemas/SubstrateSet #{})))
 
   (testing "the enum is still CLOSED, which is the half a widen can lose
             with nothing going red to say so. `:reagent-slim` is the
@@ -86,11 +86,11 @@
             `:helix` is an authoring layer Story does not carry at all; if
             either row ever passes, the widen has become an opening and
             `SubstrateSet` validates nothing."
-    (is (not (m/validate schemas/SubstrateSet #{:reagent-slim})))
-    (is (not (m/validate schemas/SubstrateSet #{:helix})))
-    (is (not (m/validate schemas/SubstrateSet #{:reagent :helix})))
-    (is (not (m/validate schemas/SubstrateSet #{:hicasso :typo})))
-    (is (not (m/validate schemas/SubstrateSet [:hicasso]))
+    (is (not (m/validate rf.story.schemas/SubstrateSet #{:reagent-slim})))
+    (is (not (m/validate rf.story.schemas/SubstrateSet #{:helix})))
+    (is (not (m/validate rf.story.schemas/SubstrateSet #{:reagent :helix})))
+    (is (not (m/validate rf.story.schemas/SubstrateSet #{:hicasso :typo})))
+    (is (not (m/validate rf.story.schemas/SubstrateSet [:hicasso]))
         "a VECTOR is not a set — the slot's shape is unchanged too")))
 
 ;; ===========================================================================
@@ -103,34 +103,34 @@
             (`re-frame.story.registrar/validate-shape!`). Pre-widen THIS
             call threw; the registration landing is the user-visible half
             of the enum change."
-    (story/reg-story* :story.hic {:doc "hicasso authoring-layer fixture"})
-    (story/reg-variant* :story.hic/card
+    (rf.story/reg-story* :story.hic {:doc "hicasso authoring-layer fixture"})
+    (rf.story/reg-variant* :story.hic/card
       {:doc        "A variant whose subject is a hicasso boundary."
        :component  :my.app.views/article-card
        :substrates #{:hicasso}})
-    (is (= #{:hicasso} (:substrates (story/variant->edn :story.hic/card)))))
+    (is (= #{:hicasso} (:substrates (rf.story/variant->edn :story.hic/card)))))
 
   (testing "and the STORY body takes it too — `StoryBody` is closed
             independently of `VariantBody`, so a whole story can declare
             the authoring layer once. (Since rf2-sc5g0 that story-level
             declaration reaches the compiled plan too, so the canvas and
             `render-variant` read the same set; see the plan row below.)"
-    (story/reg-story* :story.hic-all
+    (rf.story/reg-story* :story.hic-all
       {:doc        "story-level declaration"
        :component  :my.app.views/article-card
        :substrates #{:hicasso}})
-    (story/reg-variant* :story.hic-all/v {:doc "child"})
+    (rf.story/reg-variant* :story.hic-all/v {:doc "child"})
     (is (= #{:hicasso}
-           (:substrates (story-registrar/handler-meta :story :story.hic-all))))))
+           (:substrates (rf.story.registrar/handler-meta :story :story.hic-all))))))
 
 (deftest an-unknown-substrate-is-still-refused-at-registration
   (testing "the closed enum is enforced where it matters — at
             registration, with the catalogued error id, so an author's
             typo is a loud refusal rather than a variant that renders
             under whatever the shell defaulted to"
-    (story/reg-story* :story.hic-bad {:doc "fixture"})
+    (rf.story/reg-story* :story.hic-bad {:doc "fixture"})
     (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
-          (story/reg-variant* :story.hic-bad/typo
+          (rf.story/reg-variant* :story.hic-bad/typo
             {:doc "declares a substrate nobody defines"
              :substrates #{:hicaso}})))))
 
@@ -146,7 +146,7 @@
 ;; did NOT reach `canonical/render-host-scope`, which reads
 ;; `[:world :substrates]` and fell back to the `:reagent` host default.
 ;;
-;; FIXED under rf2-sc5g0: `plan/variant-plan` now folds the parent story's
+;; FIXED under rf2-sc5g0: `rf.story.plan/variant-plan` now folds the parent story's
 ;; `:substrates` (and `:component`, which had the same asymmetry and no
 ;; renderer-side fallback at all) with the canvas's own variant-then-story
 ;; precedence. The witness is
@@ -157,13 +157,13 @@
   (testing "rf2-3afns routed `canonical/render-host-scope` at the COMPILED
             PLAN's `[:world :substrates]` instead of a literal `:reagent`,
             so that slot is the one a hicasso variant has to reach. It is
-            folded by `plan/variant-plan`, already `:extends`-merged."
-    (story/reg-story* :story.hicplan {:doc "fixture"})
-    (story/reg-variant* :story.hicplan/v
+            folded by `rf.story.plan/variant-plan`, already `:extends`-merged."
+    (rf.story/reg-story* :story.hicplan {:doc "fixture"})
+    (rf.story/reg-variant* :story.hicplan/v
       {:doc        "declares the native authoring layer"
        :component  :my.app.views/article-card
        :substrates #{:hicasso}})
-    (let [p (plan/variant-plan :story.hicplan/v)]
+    (let [p (rf.story.plan/variant-plan :story.hicplan/v)]
       (is (= #{:hicasso} (get-in p [:world :substrates])))
       (is (= :my.app.views/article-card (get-in p [:world :component]))
           "and the subject rides beside it — the two slots the renderer
@@ -171,14 +171,14 @@
 
   (testing "`:extends` inheritance carries it, so a hicasso base story's
             children do not each re-declare the layer"
-    (story/reg-story* :story.hicext {:doc "fixture"})
-    (story/reg-variant* :story.hicext/base
+    (rf.story/reg-story* :story.hicext {:doc "fixture"})
+    (rf.story/reg-variant* :story.hicext/base
       {:doc "base" :component :my.app.views/article-card
        :substrates #{:hicasso}})
-    (story/reg-variant* :story.hicext/child
+    (rf.story/reg-variant* :story.hicext/child
       {:doc "child" :extends :story.hicext/base})
     (is (= #{:hicasso}
-           (get-in (plan/variant-plan :story.hicext/child)
+           (get-in (rf.story.plan/variant-plan :story.hicext/child)
                    [:world :substrates])))))
 
 ;; ===========================================================================
@@ -191,13 +191,13 @@
             agent. A keyword that did not survive here would leave an
             agent able to list a hicasso story and unable to say what it
             renders under."
-    (story/reg-story* :story.hicedn {:doc "fixture"})
+    (rf.story/reg-story* :story.hicedn {:doc "fixture"})
     (let [body {:doc        "a hicasso variant"
                 :component  :my.app.views/article-card
                 :substrates #{:hicasso}
                 :args       {:label "one"}}]
-      (story/reg-variant* :story.hicedn/v body)
-      (let [edn (story/variant->edn :story.hicedn/v)]
+      (rf.story/reg-variant* :story.hicedn/v body)
+      (let [edn (rf.story/variant->edn :story.hicedn/v)]
         (is (= #{:hicasso} (:substrates edn)))
         (is (= :my.app.views/article-card (:component edn))
             "and `:component` is still a KEYWORD — the whole reason
@@ -219,13 +219,13 @@
             one visual-regression baseline for two views. Naming them with
             keywords is what keeps them apart, and this is the row that
             would have caught it."
-    (story/reg-story* :story.hicid {:doc "fixture"})
-    (story/reg-variant* :story.hicid/card
+    (rf.story/reg-story* :story.hicid {:doc "fixture"})
+    (rf.story/reg-variant* :story.hicid/card
       {:doc "one" :component :my.app.views/article-card :substrates #{:hicasso}})
-    (story/reg-variant* :story.hicid/panel
+    (rf.story/reg-variant* :story.hicid/panel
       {:doc "one" :component :my.app.views/side-panel :substrates #{:hicasso}})
-    (let [a (:content-hash (identity/snapshot-identity :story.hicid/card))
-          b (:content-hash (identity/snapshot-identity :story.hicid/panel))]
+    (let [a (:content-hash (rf.story.identity/snapshot-identity :story.hicid/card))
+          b (:content-hash (rf.story.identity/snapshot-identity :story.hicid/panel))]
       (is (string? a))
       (is (not= a b)
           "two hicasso view ids, differing in NOTHING but `:component`,
@@ -234,18 +234,18 @@
   (testing "and the authoring layer is identity-bearing in its own right —
             the same view stories under two layers are two baselines,
             because the two renderers paint two trees"
-    (story/reg-story* :story.hiclayer {:doc "fixture"})
-    (story/reg-variant* :story.hiclayer/hic
+    (rf.story/reg-story* :story.hiclayer {:doc "fixture"})
+    (rf.story/reg-variant* :story.hiclayer/hic
       {:doc "x" :component :my.app.views/article-card :substrates #{:hicasso}})
-    (story/reg-variant* :story.hiclayer/rea
+    (rf.story/reg-variant* :story.hiclayer/rea
       {:doc "x" :component :my.app.views/article-card :substrates #{:reagent}})
-    (is (not= (:content-hash (identity/snapshot-identity :story.hiclayer/hic))
-              (:content-hash (identity/snapshot-identity :story.hiclayer/rea)))))
+    (is (not= (:content-hash (rf.story.identity/snapshot-identity :story.hiclayer/hic))
+              (:content-hash (rf.story.identity/snapshot-identity :story.hiclayer/rea)))))
 
   (testing "the hash is STABLE for one hicasso variant across calls — the
             distinctions above are the tuple's, not run-to-run noise"
-    (story/reg-story* :story.hicstable {:doc "fixture"})
-    (story/reg-variant* :story.hicstable/v
+    (rf.story/reg-story* :story.hicstable {:doc "fixture"})
+    (rf.story/reg-variant* :story.hicstable/v
       {:doc "x" :component :my.app.views/article-card :substrates #{:hicasso}})
-    (is (= (:content-hash (identity/snapshot-identity :story.hicstable/v))
-           (:content-hash (identity/snapshot-identity :story.hicstable/v))))))
+    (is (= (:content-hash (rf.story.identity/snapshot-identity :story.hicstable/v))
+           (:content-hash (rf.story.identity/snapshot-identity :story.hicstable/v))))))

--- a/tools/story/test/re_frame/story/inline_plan_test.clj
+++ b/tools/story/test/re_frame/story/inline_plan_test.clj
@@ -3,7 +3,7 @@
   `tools/story/spec/017-Testing-Story.md` §Inline plan + §three verbs).
 
   An inline plan is an executable plan MAP that is NOT registered as a
-  Story variant. `story/run` / `story/is` / `story/explain` accept a map
+  Story variant. `rf.story/run` / `rf.story/is` / `rf.story/explain` accept a map
   target (a keyword target is a registered variant; a map is an inline
   plan). The §B6 acceptance bullets, verified here:
 
@@ -12,36 +12,36 @@
   - an inline plan is ABSENT from Story navigation (nothing is registered);
   - an inline plan can use a REGISTERED check;
   - an inline plan CANNOT reference a missing fragment (it fails cleanly);
-  - `story/is` reports through the test framework for a map target;
+  - `rf.story/is` reports through the test framework for a map target;
   - an inline plan and a registered variant describing the SAME behaviour
     produce equivalent final app-db + assertion records AFTER
     `canonicalize` (the metamorphic relation, §three verbs / §20).
 
-  JVM-only (`.clj`): on the JVM `story/run` returns a `CompletableFuture`
-  that resolves synchronously to the unified result, and `story/is` BLOCKS
+  JVM-only (`.clj`): on the JVM `rf.story/run` returns a `CompletableFuture`
+  that resolves synchronously to the unified result, and `rf.story/is` BLOCKS
   on it + fires one `clojure.test` report per assertion. The CLJS run is
   async; its plan compilation + report projection are covered host-free by
   the plan / result suites."
   (:require [clojure.test :refer [deftest is testing use-fixtures] :as t]
             [malli.core         :as m]
             [re-frame.core      :as rf]
-            [re-frame.frame     :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story     :as story]
-            [re-frame.story.frames :as frames]
-            [re-frame.story.play.runner-events :as re]))
+            [re-frame.frame     :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story     :as rf.story]
+            [re-frame.story.frames :as rf.story.frames]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]))
 
 (defn- reset-rf! [test-fn]
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
-  (reset! re/run-state {})
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (reset! rf.story.play.runner-events/run-state {})
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   ;; A tiny event the inline plans drive — the app under test.
   (rf/reg-event :inline/set-status (fn [{:keys [db]} [_ v]] {:db (assoc db :status v)}))
   (rf/reg-event :inline/inc        (fn [{:keys [db]} _]     {:db (update db :n (fnil inc 0))}))
@@ -50,11 +50,11 @@
 (use-fixtures :each reset-rf!)
 
 (defn- run-target [target]
-  (.get ^java.util.concurrent.CompletableFuture (story/run target)))
+  (.get ^java.util.concurrent.CompletableFuture (rf.story/run target)))
 
 (defn- capture-reports
   "Run `thunk` with `clojure.test/report` rebound to collect every
-  `:pass`/`:fail`/`:error` report map `story/is` fires. Returns
+  `:pass`/`:fail`/`:error` report map `rf.story/is` fires. Returns
   `[thunk-return reports-vector]`."
   [thunk]
   (let [collected (atom [])]
@@ -133,14 +133,14 @@
 (deftest inline-plan-absent-from-navigation
   (testing "running an inline plan registers NOTHING in the Story side-table
             and leaves no variant frame behind (§B6 — absent from navigation)"
-    (is (empty? (story/ids :variant)) "precondition: no variants registered")
+    (is (empty? (rf.story/ids :variant)) "precondition: no variants registered")
     (run-target {:script [[:dispatch [:inline/set-status :ok]]
                           [:assert [:rf.assert/path-equals [:status] :ok]]]})
-    (is (empty? (story/ids :variant))
+    (is (empty? (rf.story/ids :variant))
         "no variant id was registered by the inline run")
-    (is (empty? (story/variants-by-story))
+    (is (empty? (rf.story/variants-by-story))
         "the inline plan appears under no story")
-    (is (empty? (story/variant-frames))
+    (is (empty? (rf.story/variant-frames))
         "the anonymous inline frame was torn down — no lingering nav frame")))
 
 (deftest inline-plan-absent-from-navigation-while-in-flight
@@ -160,7 +160,7 @@
       ;; Allocate an inline frame directly (the registry-free twin of
       ;; `allocate!`): empty decorator stack + no fx-overrides, events-only
       ;; fast-path. This mirrors what `run-inline-plan` does mid-run.
-      (frames/allocate-inline! inline-id {} {} true)
+      (rf.story.frames/allocate-inline! inline-id {} {} true)
       (try
         ;; The frame IS live — it exists in the runtime's frame registry.
         (is (contains? (set (rf/frame-ids)) inline-id)
@@ -171,15 +171,15 @@
           (is (true? (:rf/inline? m)) "inline frame carries the :rf/inline? stamp"))
         ;; …yet `variant-frame?` excludes it (reads :rf/inline?) and so it
         ;; is absent from the navigable enumeration the UI shell walks.
-        (is (false? (frames/variant-frame? inline-id))
+        (is (false? (rf.story.frames/variant-frame? inline-id))
             "an allocated inline frame is NOT a navigable variant frame")
-        (is (not (contains? (frames/variant-frames) inline-id))
+        (is (not (contains? (rf.story.frames/variant-frames) inline-id))
             "an in-flight inline frame is absent from variant-frames")
-        (is (not (contains? (story/variant-frames) inline-id))
-            "…through the public story/variant-frames surface too")
+        (is (not (contains? (rf.story/variant-frames) inline-id))
+            "…through the public rf.story/variant-frames surface too")
         (finally
-          (frames/destroy-inline! inline-id {} nil)))
-      (is (empty? (frames/variant-frames))
+          (rf.story.frames/destroy-inline! inline-id {} nil)))
+      (is (empty? (rf.story.frames/variant-frames))
           "post-teardown: no lingering nav frame (the pre-existing guard)"))))
 
 ;; ===========================================================================
@@ -192,10 +192,10 @@
             way a registered variant does (§B6 — registered check). The check's
             atom is ALSO an in-script checkpoint so it actually records, proving
             the registered check resolved and ran."
-    (story/reg-check :check.inline/status-loaded
+    (rf.story/reg-check :check.inline/status-loaded
       {:assertions [[:rf.assert/path-equals [:status] :loaded]]})
     ;; The compiled plan carries the composed check id under [:expect :checks].
-    (let [plan (story/variant-plan {:compose [:check.inline/status-loaded]
+    (let [plan (rf.story/variant-plan {:compose [:check.inline/status-loaded]
                                     :script  [[:dispatch [:inline/set-status :loaded]]]})]
       (is (= [:check.inline/status-loaded] (get-in plan [:expect :checks]))
           "the registered check id resolves into the inline plan's :expect"))
@@ -213,7 +213,7 @@
 (deftest inline-plan-composes-registered-fragment
   (testing "an inline plan composing a registered fragment appends the
             fragment's setup + script (§B6 — composed fragments/checks)"
-    (story/reg-fragment :fragment.inline/seed
+    (rf.story/reg-fragment :fragment.inline/seed
       {:setup [[:dispatch [:inline/set-status :seeded]]]})
     (let [result (run-target {:compose [:fragment.inline/seed]
                               :script  [[:assert [:rf.assert/path-equals [:status] :seeded]]]})]
@@ -234,9 +234,9 @@
       (is (= :rf.error/story-compose-unknown
              (:assertion (first (:assertions result))))
           "the structured :compose-unknown error rides the assertion record")
-      (is (empty? (story/ids :variant))
+      (is (empty? (rf.story/ids :variant))
           "nothing was registered by the failed inline run")
-      (is (empty? (story/variant-frames))
+      (is (empty? (rf.story/variant-frames))
           "no frame lingers from the failed inline run"))))
 
 (deftest inline-plan-missing-arg-fails-cleanly
@@ -249,16 +249,16 @@
              (:assertion (first (:assertions result))))))))
 
 ;; ===========================================================================
-;; story/is reports through the test framework for a map target
+;; rf.story/is reports through the test framework for a map target
 ;; ===========================================================================
 
 (deftest story-is-reports-per-assertion-for-map-target
-  (testing "story/is fires one report per assertion for an inline plan
-            (§B6 — story/is reports through the test framework for a map
+  (testing "rf.story/is fires one report per assertion for an inline plan
+            (§B6 — rf.story/is reports through the test framework for a map
             target)"
     (let [[result reports]
           (capture-reports
-            #(story/is {:script [[:dispatch [:inline/set-status :loaded]]
+            #(rf.story/is {:script [[:dispatch [:inline/set-status :loaded]]
                                  [:assert [:rf.assert/path-equals [:status] :loaded]]
                                  [:assert [:rf.assert/path-equals [:status] :loaded]]]}))]
       (is (= :pass (:status result)) "the unified verdict is :pass")
@@ -266,10 +266,10 @@
       (is (every? #(= :pass (:type %)) reports)))))
 
 (deftest story-is-reports-fail-for-map-target
-  (testing "story/is fires a :fail report for a failing inline-plan assertion"
+  (testing "rf.story/is fires a :fail report for a failing inline-plan assertion"
     (let [[result reports]
           (capture-reports
-            #(story/is {:script [[:dispatch [:inline/set-status :idle]]
+            #(rf.story/is {:script [[:dispatch [:inline/set-status :idle]]
                                  [:assert [:rf.assert/path-equals [:status] :loaded]]]}))]
       (is (= :fail (:status result)))
       (is (= 1 (count reports)))
@@ -289,7 +289,7 @@
                                   [:assert [:rf.assert/path-equals [:n] 2]]]
                      :assertions [[:rf.assert/path-equals [:n] 2]]
                      :tags       #{:test}}]
-      (story/reg-variant :story.inline/equivalent behaviour)
+      (rf.story/reg-variant :story.inline/equivalent behaviour)
       (let [registered (run-target :story.inline/equivalent)
             inline     (run-target behaviour)]
         (testing "both reach the same verdict + app-db before canonicalize"
@@ -298,28 +298,28 @@
           (is (= 2 (:n (:app-db registered))))
           (is (= 2 (:n (:app-db inline)))))
         (testing "canonicalized final app-db is equal (frame ids stripped)"
-          (is (= (story/canonicalize (:app-db registered))
-                 (story/canonicalize (:app-db inline)))))
+          (is (= (rf.story/canonicalize (:app-db registered))
+                 (rf.story/canonicalize (:app-db inline)))))
         (testing "canonicalized assertion records are equal (variant/frame
                   ids reconciled + stripped)"
-          (is (= (story/canonicalize (:assertions registered))
-                 (story/canonicalize (:assertions inline)))))
+          (is (= (rf.story/canonicalize (:assertions registered))
+                 (rf.story/canonicalize (:assertions inline)))))
         (testing "the two runs share a canonical run-hash"
-          (is (= (story/run-hash registered)
-                 (story/run-hash inline))))))))
+          (is (= (rf.story/run-hash registered)
+                 (rf.story/run-hash inline))))))))
 
 ;; ===========================================================================
 ;; explain accepts a map target (rf2-5x1wt.24 base; confirmed for the verb)
 ;; ===========================================================================
 
 (deftest explain-accepts-inline-plan-map
-  (testing "story/explain compiles a map target directly (no registration)"
-    (let [ex (story/explain {:variant/id :inline/explained
+  (testing "rf.story/explain compiles a map target directly (no registration)"
+    (let [ex (rf.story/explain {:variant/id :inline/explained
                              :setup      [[:dispatch [:inline/inc]]]
                              :script     [[:dispatch [:inline/inc]]]})]
       (is (= [:inline/explained] (:source-chain ex)))
       (is (= [[:dispatch [:inline/inc]]] (:setup-order ex)))
-      (is (empty? (story/ids :variant)) "explain registered nothing"))))
+      (is (empty? (rf.story/ids :variant)) "explain registered nothing"))))
 
 ;; ===========================================================================
 ;; FAILURE-PATH TEARDOWN — an inline plan that fails mid-run still runs the
@@ -348,15 +348,15 @@
   the only frame on the classpath under test). Malli backs the validator —
   no hard dep on the schemas artefact."
   [schema-for-any-frame]
-  (late-bind/set-fn! :schemas/frame-schema-entries
+  (rf.late-bind/set-fn! :schemas/frame-schema-entries
                      (fn [_frame-id] schema-for-any-frame))
-  (late-bind/set-fn! :schemas/validate-with-registered-fn
+  (rf.late-bind/set-fn! :schemas/validate-with-registered-fn
                      (fn [schema value] (m/validate schema value)))
-  (late-bind/set-fn! :schemas/explain-with-registered-fn
+  (rf.late-bind/set-fn! :schemas/explain-with-registered-fn
                      (fn [schema value] (m/explain schema value))))
 
 (defn- uninstall-schema-seam! []
-  (swap! late-bind/hooks dissoc
+  (swap! rf.late-bind/hooks dissoc
          :schemas/frame-schema-entries
          :schemas/validate-with-registered-fn
          :schemas/explain-with-registered-fn))
@@ -384,7 +384,7 @@
           (fn [{:keys [db]} _] (swap! decorator-teardown inc) {:db db}))
         (rf/reg-event :inline/loader-teardown
           (fn [{:keys [db]} _] (swap! loader-teardown inc) {:db db}))
-        (story/reg-decorator :inline/live-resource
+        (rf.story/reg-decorator :inline/live-resource
           {:kind     :frame-setup
            :init     [[:inline/dec-init]]
            :teardown [[:inline/dec-teardown]]})
@@ -409,7 +409,7 @@
             (is (= 1 @loader-teardown)
                 "the plan's :loaders-teardown fired on the failure path"))
           (testing "the inline frame did not leak"
-            (is (empty? (story/variant-frames))
+            (is (empty? (rf.story/variant-frames))
                 "no lingering nav frame after the failed inline run")
             (is (not-any? #(and (keyword? %)
                                 (= "rf.story.inline" (namespace %)))
@@ -428,7 +428,7 @@
         (fn [{:keys [db]} _] (swap! decorator-teardown inc) {:db db}))
       (rf/reg-event :inline/loader-teardown
         (fn [{:keys [db]} _] (swap! loader-teardown inc) {:db db}))
-      (story/reg-decorator :inline/live-resource
+      (rf.story/reg-decorator :inline/live-resource
         {:kind     :frame-setup
          :init     [[:inline/dec-init]]
          :teardown [[:inline/dec-teardown]]})
@@ -440,4 +440,4 @@
         (is (= :pass (:status result)) "the control run passes")
         (is (= 1 @decorator-teardown) "decorator :teardown fired on success")
         (is (= 1 @loader-teardown) "loaders-teardown fired on success")
-        (is (empty? (story/variant-frames)) "no lingering frame")))))
+        (is (empty? (rf.story/variant-frames)) "no lingering frame")))))

--- a/tools/story/test/re_frame/story/invariants_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/invariants_cljs_test.cljs
@@ -12,22 +12,22 @@
   the epoch artefact is on the CLJS test classpath via shadow-cljs.edn)."
   (:require [cljs.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.epoch :as epoch]
-            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
             [re-frame.machines]
-            [re-frame.story.invariants :as inv])
+            [re-frame.story.invariants :as rf.story.invariants])
   (:require-macros [re-frame.story.invariants :refer [with-invariants]]))
 
 (use-fixtures :each
   (fn [test-fn]
-    (registrar/clear-all!)
-    (reset! frame/frames {})
-    (rf/init! plain-atom/adapter)
-    (epoch/clear-epoch-listeners!)
-    (epoch/clear-history!)
-    (frame/ensure-default-frame!)
+    (rf.registrar/clear-all!)
+    (reset! rf.frame/frames {})
+    (rf/init! rf.substrate.plain-atom/adapter)
+    (rf.epoch/clear-epoch-listeners!)
+    (rf.epoch/clear-history!)
+    (rf.frame/ensure-default-frame!)
     (test-fn)))
 
 (defn- epoch-rec
@@ -42,14 +42,14 @@
   (testing "first-bad-epoch returns the first failing epoch on CLJS"
     (let [tape [(epoch-rec 1 {:db-after {:n 1}})
                 (epoch-rec 2 {:db-after {:n -1}})]
-          bad  (inv/first-bad-epoch tape (fn [e] (pos? (:n (:db-after e)))))]
+          bad  (rf.story.invariants/first-bad-epoch tape (fn [e] (pos? (:n (:db-after e)))))]
       (is (= 2 (:epoch-id bad))))
-    (is (nil? (inv/first-bad-epoch [] (fn [_] false))))))
+    (is (nil? (rf.story.invariants/first-bad-epoch [] (fn [_] false))))))
 
 (deftest check-epoch-isolates-throw-cljs
   (testing "a throwing predicate is caught on CLJS"
-    (let [c (inv/coerce-invariant 0 (fn [_] (throw (ex-info "boom" {}))))
-          v (inv/check-epoch c (epoch-rec 1 {}))]
+    (let [c (rf.story.invariants/coerce-invariant 0 (fn [_] (throw (ex-info "boom" {}))))
+          v (rf.story.invariants/check-epoch c (epoch-rec 1 {}))]
       (is (some? v))
       (is (string? (:error v))))))
 
@@ -64,12 +64,12 @@
 
 (deftest on-epoch-reports-once-cljs
   (testing "a violation reports once per (invariant, epoch) on CLJS"
-    (let [coerced (inv/coerce-invariants [(fn [e] (pos? (:n (:db-after e))))])
+    (let [coerced (rf.story.invariants/coerce-invariants [(fn [e] (pos? (:n (:db-after e))))])
           state   (atom {:seen #{} :violations []})
           ep      (epoch-rec 5 {:db-after {:n -3}})
           reports (with-captured-reports
-                    (fn [] (inv/on-epoch! state coerced ep)
-                           (inv/on-epoch! state coerced ep)))]
+                    (fn [] (rf.story.invariants/on-epoch! state coerced ep)
+                           (rf.story.invariants/on-epoch! state coerced ep)))]
       (is (= 1 (count (filter #(= :fail (:type %)) reports)))))))
 
 ;; ---- live with-invariants over a real CLJS frame -------------------------

--- a/tools/story/test/re_frame/story/invariants_test.cljc
+++ b/tools/story/test/re_frame/story/invariants_test.cljc
@@ -20,12 +20,12 @@
   registers a counted failure WITHOUT failing this suite."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.story.invariants :as inv]
+            [re-frame.story.invariants :as rf.story.invariants]
             #?(:clj [re-frame.story.invariants :refer [with-invariants]])
-            #?(:clj [re-frame.frame :as frame])
-            #?(:clj [re-frame.registrar :as registrar])
-            #?(:clj [re-frame.epoch :as epoch])
-            #?(:clj [re-frame.substrate.plain-atom :as plain-atom])
+            #?(:clj [re-frame.frame :as rf.frame])
+            #?(:clj [re-frame.registrar :as rf.registrar])
+            #?(:clj [re-frame.epoch :as rf.epoch])
+            #?(:clj [re-frame.substrate.plain-atom :as rf.substrate.plain-atom])
             ;; Side-effect require — machine restore hooks must be present
             ;; on the classpath (mirrors re-frame.epoch-test / the story
             ;; runtime fixture).
@@ -40,14 +40,14 @@
 ;; the epoch listener / history registries between tests.
 #?(:clj (use-fixtures :each
           (fn [test-fn]
-            (registrar/clear-all!)
-            (reset! frame/frames {})
-            (try (rf/init! plain-atom/adapter)
+            (rf.registrar/clear-all!)
+            (reset! rf.frame/frames {})
+            (try (rf/init! rf.substrate.plain-atom/adapter)
                  (catch clojure.lang.ExceptionInfo _ nil))
             (require 're-frame.machines :reload)
-            (epoch/clear-epoch-listeners!)
-            (epoch/clear-history!)
-            (frame/ensure-default-frame!)
+            (rf.epoch/clear-epoch-listeners!)
+            (rf.epoch/clear-history!)
+            (rf.frame/ensure-default-frame!)
             (test-fn))))
 
 ;; ===========================================================================
@@ -71,31 +71,31 @@
 
 (deftest coerce-bare-fn
   (testing "a bare predicate normalizes to {:id … :check fn}"
-    (let [{:keys [id check]} (inv/coerce-invariant 0 (fn [e] (map? (:db-after e))))]
+    (let [{:keys [id check]} (rf.story.invariants/coerce-invariant 0 (fn [e] (map? (:db-after e))))]
       (is (= :invariant-0 id))
       (is (fn? check)))))
 
 (deftest coerce-explicit-map
   (testing "an explicit map keeps its :id and resolves :check (or :pred)"
-    (let [c (inv/coerce-invariant 3 {:id :my/inv :check (fn [_] true)})]
+    (let [c (rf.story.invariants/coerce-invariant 3 {:id :my/inv :check (fn [_] true)})]
       (is (= :my/inv (:id c)))
       (is (fn? (:check c))))
     (testing ":pred is accepted as an alias for :check"
-      (is (fn? (:check (inv/coerce-invariant 0 {:pred (fn [_] true)})))))
+      (is (fn? (:check (rf.story.invariants/coerce-invariant 0 {:pred (fn [_] true)})))))
     (testing "a map without a check fn throws a structured error"
       (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
-                   (inv/coerce-invariant 0 {:id :x}))))))
+                   (rf.story.invariants/coerce-invariant 0 {:id :x}))))))
 
 (deftest coerce-db-shorthand
   (testing "[:db path pred] checks the value at the path"
-    (let [{:keys [check]} (inv/coerce-invariant 0 [:db [:cart :items] vector?])]
+    (let [{:keys [check]} (rf.story.invariants/coerce-invariant 0 [:db [:cart :items] vector?])]
       (is (:ok? (check (epoch 1 {:db-after {:cart {:items []}}}))))
       (let [bad (check (epoch 1 {:db-after {:cart {:items 7}}}))]
         (is (false? (:ok? bad)))
         (is (= [:cart :items] (:path bad)))
         (is (= 7 (:actual bad))))))
   (testing "[:db path = expected] checks equality and carries :expected"
-    (let [{:keys [check]} (inv/coerce-invariant 0 [:db [:n] = 5])]
+    (let [{:keys [check]} (rf.story.invariants/coerce-invariant 0 [:db [:n] = 5])]
       (is (:ok? (check (epoch 1 {:db-after {:n 5}}))))
       (let [bad (check (epoch 1 {:db-after {:n 4}}))]
         (is (false? (:ok? bad)))
@@ -105,7 +105,7 @@
 (deftest coerce-bad-shape-throws
   (testing "a non-fn / non-vector / non-map invariant throws"
     (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
-                 (inv/coerce-invariant 0 :not-an-invariant)))))
+                 (rf.story.invariants/coerce-invariant 0 :not-an-invariant)))))
 
 ;; ===========================================================================
 ;; check-epoch  (one invariant × one epoch, never-throws)
@@ -113,13 +113,13 @@
 
 (deftest check-epoch-holds-returns-nil
   (testing "a holding invariant returns nil"
-    (let [c (inv/coerce-invariant 0 (fn [e] (map? (:db-after e))))]
-      (is (nil? (inv/check-epoch c (epoch 1 {:db-after {}})))))))
+    (let [c (rf.story.invariants/coerce-invariant 0 (fn [e] (map? (:db-after e))))]
+      (is (nil? (rf.story.invariants/check-epoch c (epoch 1 {:db-after {}})))))))
 
 (deftest check-epoch-violation-carries-spine
   (testing "a violation carries the diagnostic spine from the epoch"
-    (let [c (inv/coerce-invariant 0 (fn [e] (pos? (get-in (:db-after e) [:n]))))
-          v (inv/check-epoch c (epoch 7 {:event-id      :do/thing
+    (let [c (rf.story.invariants/coerce-invariant 0 (fn [e] (pos? (get-in (:db-after e) [:n]))))
+          v (rf.story.invariants/check-epoch c (epoch 7 {:event-id      :do/thing
                                          :trigger-event [:do/thing 42]
                                          :db-after      {:n -1}}))]
       (is (= :invariant-0 (:invariant v)))
@@ -130,8 +130,8 @@
 
 (deftest check-epoch-isolates-predicate-exception
   (testing "a throwing predicate is caught and reported as a violation with :error"
-    (let [c (inv/coerce-invariant 0 (fn [_] (throw (ex-info "boom" {}))))
-          v (inv/check-epoch c (epoch 1 {}))]
+    (let [c (rf.story.invariants/coerce-invariant 0 (fn [_] (throw (ex-info "boom" {}))))
+          v (rf.story.invariants/check-epoch c (epoch 1 {}))]
       (is (some? v))
       (is (= :invariant-0 (:invariant v)))
       (is (string? (:error v))))))
@@ -145,7 +145,7 @@
     (let [tape [(epoch 1 {:db-after {:n 1}})
                 (epoch 2 {:db-after {:n 2}})
                 (epoch 3 {:db-after {:n 3}})]]
-      (is (nil? (inv/first-bad-epoch tape (fn [e] (pos? (:n (:db-after e))))))))))
+      (is (nil? (rf.story.invariants/first-bad-epoch tape (fn [e] (pos? (:n (:db-after e))))))))))
 
 (deftest first-bad-epoch-returns-first-failing
   (testing "returns the FIRST failing epoch, enriched with trigger + db-diff + traces"
@@ -155,7 +155,7 @@
                           :db-after      {:n -5 :extra true}
                           :trace-events  [{:operation :rf.event/run-start}]})
                 (epoch 3 {:db-after {:n -9}})]
-          bad  (inv/first-bad-epoch tape (fn [e] (>= (:n (:db-after e)) 0)))]
+          bad  (rf.story.invariants/first-bad-epoch tape (fn [e] (>= (:n (:db-after e)) 0)))]
       (is (= 2 (:epoch-id bad)) "the FIRST failing epoch, not a later one")
       (is (= [:break] (:trigger-event bad)))
       (is (= #{:n :extra} (:db-diff bad)) "shallow top-level changed-key set")
@@ -164,21 +164,21 @@
 
 (deftest first-bad-epoch-empty-tape
   (testing "an empty (or nil) tape returns nil — no epoch can fail"
-    (is (nil? (inv/first-bad-epoch [] (fn [_] false))))
-    (is (nil? (inv/first-bad-epoch nil (fn [_] false))))))
+    (is (nil? (rf.story.invariants/first-bad-epoch [] (fn [_] false))))
+    (is (nil? (rf.story.invariants/first-bad-epoch nil (fn [_] false))))))
 
 (deftest first-bad-epoch-failure-in-first-epoch
   (testing "a failure in the FIRST epoch is returned"
     (let [tape [(epoch 1 {:db-after {:n -1}})
                 (epoch 2 {:db-after {:n -2}})]
-          bad  (inv/first-bad-epoch tape (fn [e] (pos? (:n (:db-after e)))))]
+          bad  (rf.story.invariants/first-bad-epoch tape (fn [e] (pos? (:n (:db-after e)))))]
       (is (= 1 (:epoch-id bad))))))
 
 (deftest first-bad-epoch-accepts-db-shorthand
   (testing "first-bad-epoch accepts the same authored shapes as with-invariants"
     (let [tape [(epoch 1 {:db-after {:cart {:items []}}})
                 (epoch 2 {:db-after {:cart {:items :oops}}})]
-          bad  (inv/first-bad-epoch tape [:db [:cart :items] vector?])]
+          bad  (rf.story.invariants/first-bad-epoch tape [:db [:cart :items] vector?])]
       (is (= 2 (:epoch-id bad)))
       (is (= [:cart :items] (:path bad)))
       (is (= :oops (:actual bad))))))
@@ -210,27 +210,27 @@
 
 (deftest on-epoch-reports-violation-once-per-epoch
   (testing "a violation is reported once per (invariant, epoch) — re-fire does not double-count"
-    (let [coerced (inv/coerce-invariants [(fn [e] (pos? (:n (:db-after e))))])
+    (let [coerced (rf.story.invariants/coerce-invariants [(fn [e] (pos? (:n (:db-after e))))])
           state   (atom {:seen #{} :violations []})
           ep      (epoch 5 {:db-after {:n -3}})
           reports (with-captured-reports
                     (fn []
-                      (inv/on-epoch! state coerced ep)
+                      (rf.story.invariants/on-epoch! state coerced ep)
                       ;; A second fire of the SAME record (back-filled
                       ;; render re-notify) must NOT re-report.
-                      (inv/on-epoch! state coerced ep)))]
+                      (rf.story.invariants/on-epoch! state coerced ep)))]
       (is (= 1 (count (filter #(= :fail (:type %)) reports)))
           "exactly one :fail across two fires of the same epoch")
       (is (= 1 (count (:violations @state)))))))
 
 (deftest on-epoch-reports-each-distinct-epoch
   (testing "distinct failing epochs each report once"
-    (let [coerced (inv/coerce-invariants [(fn [e] (pos? (:n (:db-after e))))])
+    (let [coerced (rf.story.invariants/coerce-invariants [(fn [e] (pos? (:n (:db-after e))))])
           state   (atom {:seen #{} :violations []})
           reports (with-captured-reports
                     (fn []
-                      (inv/on-epoch! state coerced (epoch 1 {:db-after {:n -1}}))
-                      (inv/on-epoch! state coerced (epoch 2 {:db-after {:n -2}}))))]
+                      (rf.story.invariants/on-epoch! state coerced (epoch 1 {:db-after {:n -1}}))
+                      (rf.story.invariants/on-epoch! state coerced (epoch 2 {:db-after {:n -2}}))))]
       (is (= 2 (count (filter #(= :fail (:type %)) reports))))
       (is (= 2 (count (:violations @state)))))))
 
@@ -241,17 +241,17 @@
     ;; global counter), but should they ever become per-frame, two frames
     ;; could both emit epoch-id 1 — a frame-less dedup-key would SILENTLY
     ;; DROP the second frame's violation. This asserts both frames report.
-    (let [coerced (inv/coerce-invariants [(fn [e] (pos? (:n (:db-after e))))])
+    (let [coerced (rf.story.invariants/coerce-invariants [(fn [e] (pos? (:n (:db-after e))))])
           state   (atom {:seen #{} :violations []})
           ep-a    (epoch 1 {:frame :frame/a :db-after {:n -1}})
           ep-b    (epoch 1 {:frame :frame/b :db-after {:n -1}})
           reports (with-captured-reports
                     (fn []
-                      (inv/on-epoch! state coerced ep-a)
-                      (inv/on-epoch! state coerced ep-b)
+                      (rf.story.invariants/on-epoch! state coerced ep-a)
+                      (rf.story.invariants/on-epoch! state coerced ep-b)
                       ;; Re-fires of each frame's epoch must NOT re-report.
-                      (inv/on-epoch! state coerced ep-a)
-                      (inv/on-epoch! state coerced ep-b)))]
+                      (rf.story.invariants/on-epoch! state coerced ep-a)
+                      (rf.story.invariants/on-epoch! state coerced ep-b)))]
       (is (= 2 (count (filter #(= :fail (:type %)) reports)))
           "one :fail per frame even though both share epoch-id 1")
       (is (= 2 (count (:violations @state))))
@@ -261,10 +261,10 @@
 
 (deftest on-epoch-isolates-and-reports-broken-predicate
   (testing "a throwing predicate reports a :fail and never escapes on-epoch!"
-    (let [coerced (inv/coerce-invariants [(fn [_] (throw (ex-info "boom" {})))])
+    (let [coerced (rf.story.invariants/coerce-invariants [(fn [_] (throw (ex-info "boom" {})))])
           state   (atom {:seen #{} :violations []})
           reports (with-captured-reports
-                    (fn [] (inv/on-epoch! state coerced (epoch 1 {}))))]
+                    (fn [] (rf.story.invariants/on-epoch! state coerced (epoch 1 {}))))]
       (is (= 1 (count (filter #(= :fail (:type %)) reports)))))))
 
 ;; ===========================================================================

--- a/tools/story/test/re_frame/story/login_example_seed_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/login_example_seed_cljs_test.cljs
@@ -26,7 +26,7 @@
    variant OR ordered after that variant's own setup.
 
    Scope note: the ids are enumerated explicitly rather than read from
-   `story/variants-of :story.login`, because the `login_form` TESTBED deck
+   `rf.story/variants-of :story.login`, because the `login_form` TESTBED deck
    (tools/story/testbeds/login_form) also registers variants under the same
    `:story.login` parent — this test guards only the login EXAMPLE's seven.
 
@@ -37,8 +37,8 @@
    build, whose classpath carries both `../tools/story/src` and
    `../examples/core`."
   (:require [cljs.test :refer-macros [deftest testing is use-fixtures]]
-            [re-frame.story :as story]
-            [re-frame.story.plan :as plan]
+            [re-frame.story :as rf.story]
+            [re-frame.story.plan :as rf.story.plan]
             ;; login.stories transitively requires login.core; require it
             ;; too so this ns is self-sufficient (mirrors the nine-states +
             ;; example-login-form-slice regression namespaces).
@@ -77,7 +77,7 @@
 (deftest fragment-is-registered-with-the-single-seed-event
   (testing ":fragment.login/form-base seeds the slice via the example's own
             initialise-form event (no duplicated defaults map in Story)"
-    (let [frag (story/handler-meta :fragment :fragment.login/form-base)]
+    (let [frag (rf.story/handler-meta :fragment :fragment.login/form-base)]
       (is (some? frag) ":fragment.login/form-base is registered")
       (is (= [raw-seed-step] (:setup frag))
           "the fragment's :setup is exactly the initialise-form event — the
@@ -88,9 +88,9 @@
             [:auth.login/initialise-form] (composed fragment first, variant
             setup after) — RED if a variant omits the seed or orders it late"
     (doseq [vid example-variant-ids]
-      (is (some? (story/handler-meta :variant vid))
+      (is (some? (rf.story/handler-meta :variant vid))
           (str vid " is registered"))
-      (let [setup (get-in (plan/variant-plan vid) [:world :setup])]
+      (let [setup (get-in (rf.story.plan/variant-plan vid) [:world :setup])]
         (is (= compiled-seed-step (first setup))
             (str vid " must seed the login-form slice FIRST; got: "
                  (pr-str (first setup))))))))
@@ -100,7 +100,7 @@
             variant's compiled setup runs the seed event exactly ONCE (the
             redundant inline / driver seeds were removed)"
     (doseq [vid example-variant-ids]
-      (let [setup (get-in (plan/variant-plan vid) [:world :setup])
+      (let [setup (get-in (rf.story.plan/variant-plan vid) [:world :setup])
             seeds (filter #(= compiled-seed-step %) setup)]
         (is (= 1 (count seeds))
             (str vid " seeds the slice exactly once (via the composed "

--- a/tools/story/test/re_frame/story/modes_standard_test.clj
+++ b/tools/story/test/re_frame/story/modes_standard_test.clj
@@ -5,15 +5,15 @@
   Pure-data registry — JVM-only is sufficient; the registrar runs on
   both runtimes and there is no view layer to exercise."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story :as story]
-            [re-frame.story.modes.standard :as standard]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.story.schemas :as schemas]
+            [re-frame.story :as rf.story]
+            [re-frame.story.modes.standard :as rf.story.modes.standard]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.schemas :as rf.story.schemas]
             [malli.core :as m]))
 
 (defn reset-all! [test-fn]
-  (story/clear-all!)
-  (story/install-canonical-vocabulary!)
+  (rf.story/clear-all!)
+  (rf.story/install-canonical-vocabulary!)
   (test-fn))
 
 (use-fixtures :each reset-all!)
@@ -26,13 +26,13 @@
              :Mode.viewport/tablet
              :Mode.viewport/desktop
              :Mode.viewport/ultra-wide}
-           (set (keys standard/viewports)))))
+           (set (keys rf.story.modes.standard/viewports)))))
   (testing "every viewport body sits on `:axis :viewport`"
-    (doseq [[id body] standard/viewports]
+    (doseq [[id body] rf.story.modes.standard/viewports]
       (is (= :viewport (:axis body))
           (str id " missing :axis :viewport"))))
   (testing "every viewport body contributes a `:viewport` arg"
-    (doseq [[_ body] standard/viewports]
+    (doseq [[_ body] rf.story.modes.standard/viewports]
       (is (keyword? (:viewport (:args body)))))))
 
 (deftest backgrounds-canonical-set
@@ -40,66 +40,66 @@
     (is (= #{:Mode.background/light
              :Mode.background/dark
              :Mode.background/transparent}
-           (set (keys standard/backgrounds)))))
+           (set (keys rf.story.modes.standard/backgrounds)))))
   (testing "every background body sits on `:axis :background`"
-    (doseq [[id body] standard/backgrounds]
+    (doseq [[id body] rf.story.modes.standard/backgrounds]
       (is (= :background (:axis body))
           (str id " missing :axis :background"))))
   (testing "every background body contributes a string `:background` arg"
-    (doseq [[_ body] standard/backgrounds]
+    (doseq [[_ body] rf.story.modes.standard/backgrounds]
       (is (string? (:background (:args body)))))))
 
 ;; ---- schema conformance --------------------------------------------------
 
 (deftest every-canonical-body-validates-against-mode-schema
   (testing "viewport bodies pass `:rf/mode` schema"
-    (doseq [[id body] standard/viewports]
-      (is (m/validate schemas/Mode body)
+    (doseq [[id body] rf.story.modes.standard/viewports]
+      (is (m/validate rf.story.schemas/Mode body)
           (str id " failed Mode schema"))))
   (testing "background bodies pass `:rf/mode` schema"
-    (doseq [[id body] standard/backgrounds]
-      (is (m/validate schemas/Mode body)
+    (doseq [[id body] rf.story.modes.standard/backgrounds]
+      (is (m/validate rf.story.schemas/Mode body)
           (str id " failed Mode schema")))))
 
 ;; ---- installer side-effects ---------------------------------------------
 
 (deftest register-viewports-installs-all
   (testing "register-viewports! adds every canonical viewport to the registry"
-    (let [ids (standard/register-viewports!)]
-      (is (= (set (keys standard/viewports)) ids))
-      (doseq [id (keys standard/viewports)]
-        (is (registrar/registered? :mode id))))))
+    (let [ids (rf.story.modes.standard/register-viewports!)]
+      (is (= (set (keys rf.story.modes.standard/viewports)) ids))
+      (doseq [id (keys rf.story.modes.standard/viewports)]
+        (is (rf.story.registrar/registered? :mode id))))))
 
 (deftest register-backgrounds-installs-all
   (testing "register-backgrounds! adds every canonical background to the registry"
-    (let [ids (standard/register-backgrounds!)]
-      (is (= (set (keys standard/backgrounds)) ids))
-      (doseq [id (keys standard/backgrounds)]
-        (is (registrar/registered? :mode id))))))
+    (let [ids (rf.story.modes.standard/register-backgrounds!)]
+      (is (= (set (keys rf.story.modes.standard/backgrounds)) ids))
+      (doseq [id (keys rf.story.modes.standard/backgrounds)]
+        (is (rf.story.registrar/registered? :mode id))))))
 
 (deftest register-all-installs-both-axes
   (testing "register-all! installs every viewport + background"
-    (let [ids (standard/register-all!)]
-      (is (= (into (set (keys standard/viewports))
-                   (set (keys standard/backgrounds)))
+    (let [ids (rf.story.modes.standard/register-all!)]
+      (is (= (into (set (keys rf.story.modes.standard/viewports))
+                   (set (keys rf.story.modes.standard/backgrounds)))
              ids))
       (doseq [id ids]
-        (is (registrar/registered? :mode id))))))
+        (is (rf.story.registrar/registered? :mode id))))))
 
 (deftest installers-are-idempotent
   (testing "calling register-all! twice does not throw and leaves registry consistent"
-    (standard/register-all!)
-    (standard/register-all!)
-    (let [registered (set (keys (registrar/registrations :mode)))]
-      (is (every? registered (keys standard/viewports)))
-      (is (every? registered (keys standard/backgrounds))))))
+    (rf.story.modes.standard/register-all!)
+    (rf.story.modes.standard/register-all!)
+    (let [registered (set (keys (rf.story.registrar/registrations :mode)))]
+      (is (every? registered (keys rf.story.modes.standard/viewports)))
+      (is (every? registered (keys rf.story.modes.standard/backgrounds))))))
 
 ;; ---- toolbar interaction smoke ------------------------------------------
 
 (deftest registered-modes-appear-on-mode-registry
   (testing "after register-all! the live registry exposes the canonical ids"
-    (standard/register-all!)
-    (let [snapshot (registrar/registrations :mode)]
+    (rf.story.modes.standard/register-all!)
+    (let [snapshot (rf.story.registrar/registrations :mode)]
       (is (= (:axis (get snapshot :Mode.viewport/mobile)) :viewport))
       (is (= (:axis (get snapshot :Mode.background/dark)) :background))
       (is (= (:viewport (:args (get snapshot :Mode.viewport/tablet))) :tablet))

--- a/tools/story/test/re_frame/story/open_in_editor_ownership_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/open_in_editor_ownership_cljs_test.cljs
@@ -33,16 +33,16 @@
   effects and observes them at each tool's own navigator seam
   (`open-in-editor/set-navigator!`), forcing the synchronous
   `editor://` URI path via the shared core endpoint-launcher seam
-  (`open-endpoint/set-launcher!`), whose stub invokes the caller's
+  (`rf.source-coords.open-endpoint/set-launcher!`), whose stub invokes the caller's
   `fallback!` thunk directly."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.source-coords.open-endpoint :as open-endpoint]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story.canonical :as canonical]
-            [re-frame.story.config :as story-config]
-            [re-frame.story.ui.open-in-editor :as story-open]
+            [re-frame.frame :as rf.frame]
+            [re-frame.source-coords.open-endpoint :as rf.source-coords.open-endpoint]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story.canonical :as rf.story.canonical]
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.ui.open-in-editor :as rf.story.ui.open-in-editor]
             [day8.re-frame2-xray.config :as xray-config]
             [day8.re-frame2-xray.open-in-editor :as xray-open]))
 
@@ -74,8 +74,8 @@
   "Give each tool its own editor + project root, and clear any operator
   override so `get-editor` resolves to the host default on the Xray side."
   []
-  (story-config/set-editor! story-editor)
-  (story-config/set-project-root! story-root)
+  (rf.story.config/set-editor! story-editor)
+  (rf.story.config/set-project-root! story-root)
   (xray-config/set-editor! xray-editor)
   (xray-config/set-project-root! xray-root)
   (xray-config/update-setting! :general :editor-override nil))
@@ -87,11 +87,11 @@
   []
   (reset! story-navigated [])
   (reset! xray-navigated [])
-  (story-open/set-navigator! #(swap! story-navigated conj %))
+  (rf.story.ui.open-in-editor/set-navigator! #(swap! story-navigated conj %))
   (xray-open/set-navigator!  #(swap! xray-navigated conj %))
   nil)
 
-(defn- install-story! [] (story-open/install!))
+(defn- install-story! [] (rf.story.ui.open-in-editor/install!))
 (defn- install-xray!  [] (xray-open/install!))
 
 (defn- ensure-adapter!
@@ -105,14 +105,14 @@
   not a suite. `init!` throws when an adapter is already installed, which is
   the idempotent case, so the throw is the no-op branch."
   []
-  (try (rf/init! plain-atom/adapter)
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch :default _ nil)))
 
 (defn- fresh-frames!
   "Story's public event lands on `:rf/default`; Xray's on `:rf/xray`."
   []
   (ensure-adapter!)
-  (frame/ensure-default-frame!)
+  (rf.frame/ensure-default-frame!)
   (rf/make-frame {:id :rf/xray}))
 
 (defn- dispatch-both!
@@ -130,22 +130,22 @@
 ;; namespace's tests would be a silent cross-suite corruption.
 (use-fixtures :each
   (fn [run-test]
-    (let [prev-story-nav (story-open/set-navigator! #(swap! story-navigated conj %))
+    (let [prev-story-nav (rf.story.ui.open-in-editor/set-navigator! #(swap! story-navigated conj %))
           prev-xray-nav  (xray-open/set-navigator! #(swap! xray-navigated conj %))
           ;; The shared core seam: `open-coord!` calls
           ;; `(@launcher url fallback!)`. Invoking `fallback!` immediately
           ;; models "no dev server present" — the documented standalone
           ;; contract, and the only path carrying the per-tool URI.
-          prev-launcher  (open-endpoint/set-launcher!
+          prev-launcher  (rf.source-coords.open-endpoint/set-launcher!
                            (fn [_url fallback!] (fallback!)))]
       (try
         (run-test)
         (finally
           (xray-config/update-setting! :general :editor-override nil)
           (xray-config/set-project-root! nil)
-          (story-config/set-project-root! nil)
-          (open-endpoint/set-launcher! prev-launcher)
-          (story-open/set-navigator! prev-story-nav)
+          (rf.story.config/set-project-root! nil)
+          (rf.source-coords.open-endpoint/set-launcher! prev-launcher)
+          (rf.story.ui.open-in-editor/set-navigator! prev-story-nav)
           (xray-open/set-navigator! prev-xray-nav))))))
 
 ;; ---- the ownership contract ---------------------------------------------
@@ -229,8 +229,8 @@
             EVENT policy (rf2-4s08ov). With no editor confirmed on the
             Xray side it must suppress Xray's silent navigation while
             Story — which has no such gate — still opens normally."
-    (story-config/set-editor! story-editor)
-    (story-config/set-project-root! story-root)
+    (rf.story.config/set-editor! story-editor)
+    (rf.story.config/set-project-root! story-root)
     (xray-config/set-project-root! xray-root)
     ;; Reset Xray to the unconfirmed state: no host editor, no override.
     (xray-config/set-editor! nil)
@@ -259,11 +259,11 @@
             from the canonical roster: the sole caller was Story's own
             test, so the documented path had no production handler.
             The installer now rides the canonical roster, so the event
-            works after an explicit `canonical/install!` with no
+            works after an explicit `rf.story.canonical/install!` with no
             hand-wiring."
     (configure-both-tools!)
-    (canonical/reset-installed-flag!)
-    (canonical/install!)
+    (rf.story.canonical/reset-installed-flag!)
+    (rf.story.canonical/install!)
     (fresh-frames!)
     (capture-navigators!)
 

--- a/tools/story/test/re_frame/story/panels_e2e/chrome_fullscreen_render_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/chrome_fullscreen_render_e2e_cljs_test.cljs
@@ -27,7 +27,7 @@
       shell/:reagent-render guards `(when show-sb? [sidebar ...])` etc
             │
             ▼
-      No [sidebar/sidebar] / [toolbar/toolbar-strip] / [right-panel]
+      No [rf.story.ui.sidebar/sidebar] / [rf.story.ui.toolbar/toolbar-strip] / [right-panel]
       vectors in the rendered hiccup tree; the variant canvas slot
       still renders. The shell root carries
       `data-rf-chrome-fullscreen=\"true\"`.
@@ -51,25 +51,25 @@
   Sub-millisecond per case; no DOM mount, no React, no Playwright."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent.core :as r]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
-            [re-frame.story.ui.keybindings :as kb]
-            [re-frame.story.ui.shell :as shell]
-            [re-frame.story.ui.sidebar :as sidebar]
-            [re-frame.story.ui.state :as ui-state]
-            [re-frame.story.ui.toolbar :as toolbar]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]
+            [re-frame.story.ui.keybindings :as rf.story.ui.keybindings]
+            [re-frame.story.ui.shell :as rf.story.ui.shell]
+            [re-frame.story.ui.sidebar :as rf.story.ui.sidebar]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.ui.toolbar :as rf.story.ui.toolbar]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; The `dispatch!` fn is private — bind through the var so the test
 ;; reaches the same dispatcher the `keydown` capture listener routes to.
-(def ^:private dispatch! @#'kb/dispatch!)
+(def ^:private dispatch! @#'rf.story.ui.keybindings/dispatch!)
 
 ;; ---- helpers: extract shell's `:reagent-render` -------------------------
 ;;
-;; Mirrors the harness in `embed_url_flag_e2e_cljs_test`. `shell/shell`
+;; Mirrors the harness in `embed_url_flag_e2e_cljs_test`. `rf.story.ui.shell/shell`
 ;; is a class-3 Reagent component built via `r/create-class`; we stub
 ;; create-class with identity to capture the spec map and invoke its
 ;; :reagent-render directly.
@@ -79,12 +79,12 @@
   ([spec _compiler] spec))
 
 (defn- shell-render-fn []
-  (let [spec (with-redefs [r/create-class capture-spec] (shell/shell))]
+  (let [spec (with-redefs [r/create-class capture-spec] (rf.story.ui.shell/shell))]
     (:reagent-render spec)))
 
 (defn- render-shell-tree []
   (let [render-fn (shell-render-fn)]
-    (e2e/expand-tree (render-fn))))
+    (rf.story.test-helpers.e2e-multi-frame/expand-tree (render-fn))))
 
 (defn- fn-headed-nodes
   [tree pred]
@@ -93,7 +93,7 @@
                   (pos? (count node))
                   (fn? (first node))
                   (pred (first node))))
-           (e2e/hiccup-seq tree)))
+           (rf.story.test-helpers.e2e-multi-frame/hiccup-seq tree)))
 
 ;; ---- pipeline (1): `f` keydown → shell-state flip -----------------------
 
@@ -103,13 +103,13 @@
             shell-state-atom. The state-mutation arm is covered by
             chrome_hotkeys_e2e; pinned here so the render test below
             has a known starting state."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
-        (is (false? (:full-screen? (e2e/chrome-visibility)))
+        (is (false? (:full-screen? (rf.story.test-helpers.e2e-multi-frame/chrome-visibility)))
             "default `:full-screen?` is false")
-        (dispatch! (e2e/fake-event {:key "f"}))
-        (is (true? (:full-screen? (e2e/chrome-visibility)))
+        (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "f"}))
+        (is (true? (:full-screen? (rf.story.test-helpers.e2e-multi-frame/chrome-visibility)))
             "`f` keydown flipped shell-state to full-screen")))))
 
 ;; ---- pipeline (2): full-screen → chrome elides at render ----------------
@@ -123,29 +123,29 @@
             chrome, not the canvas. The root wrapper's
             `data-rf-chrome-fullscreen` reflects the render's view of
             the state."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
         ;; Seed full-screen directly — the state-flip arm is covered by
         ;; the test above so this separates the keydown-seam from the
         ;; render-seam (a failure points at the right layer).
-        (swap! ui-state/shell-state-atom
+        (swap! rf.story.ui.state/shell-state-atom
                assoc-in [:chrome-visibility :full-screen?] true)
         (let [tree            (render-shell-tree)
               root-attrs      (when (and (vector? tree) (map? (second tree)))
                                 (second tree))
-              sidebar-nodes   (fn-headed-nodes tree #(= sidebar/sidebar %))
-              toolbar-nodes   (fn-headed-nodes tree #(= toolbar/toolbar-strip %))
-              toolbar-by-attr (e2e/find-by-test-id tree "story-toolbar")
-              inspectors-node (e2e/find-by-test-id tree "story-inspectors")]
+              sidebar-nodes   (fn-headed-nodes tree #(= rf.story.ui.sidebar/sidebar %))
+              toolbar-nodes   (fn-headed-nodes tree #(= rf.story.ui.toolbar/toolbar-strip %))
+              toolbar-by-attr (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-toolbar")
+              inspectors-node (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-inspectors")]
           (is (= "true" (:data-rf-chrome-fullscreen root-attrs))
               "shell wrapper carries data-rf-chrome-fullscreen=true —
                the render saw the full-screen state")
           (is (empty? sidebar-nodes)
-              "no [sidebar/sidebar] vector in the tree — the sidebar
+              "no [rf.story.ui.sidebar/sidebar] vector in the tree — the sidebar
                guard elided per rf2-p3i0t")
           (is (empty? toolbar-nodes)
-              "no [toolbar/toolbar-strip] vector in the tree")
+              "no [rf.story.ui.toolbar/toolbar-strip] vector in the tree")
           (is (nil? toolbar-by-attr)
               "no data-test=\"story-toolbar\" element — the toolbar's
                <header> never rendered")
@@ -155,7 +155,7 @@
           ;; Inverse-shape check: the canvas <main> landmark must still
           ;; be in the tree. Without this assertion a render that always
           ;; drops every vector would still pass the negation checks.
-          (let [main-node (e2e/find-by-data-attr tree
+          (let [main-node (rf.story.test-helpers.e2e-multi-frame/find-by-data-attr tree
                                                  :aria-label "Story canvas")]
             (is (some? main-node)
                 "<main aria-label=\"Story canvas\"> is still in the
@@ -168,19 +168,19 @@
             shell's reagent-render produces a hiccup tree where the
             three chrome guards all admit their components. Pins the
             inverse so the elision test above can't trivially pass."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
         (let [tree            (render-shell-tree)
               root-attrs      (when (and (vector? tree) (map? (second tree)))
                                 (second tree))
-              sidebar-nodes   (fn-headed-nodes tree #(= sidebar/sidebar %))
-              toolbar-by-attr (e2e/find-by-test-id tree "story-toolbar")
-              inspectors-node (e2e/find-by-test-id tree "story-inspectors")]
+              sidebar-nodes   (fn-headed-nodes tree #(= rf.story.ui.sidebar/sidebar %))
+              toolbar-by-attr (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-toolbar")
+              inspectors-node (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-inspectors")]
           (is (= "false" (:data-rf-chrome-fullscreen root-attrs))
               "shell wrapper carries data-rf-chrome-fullscreen=false")
           (is (seq sidebar-nodes)
-              "[sidebar/sidebar] vector present in the tree by default")
+              "[rf.story.ui.sidebar/sidebar] vector present in the tree by default")
           (is (some? toolbar-by-attr)
               "data-test=\"story-toolbar\" element present by default")
           (is (some? inspectors-node)
@@ -194,16 +194,16 @@
               press 2 → chrome returns.
             Asserts the keydown→state→render pipeline is stable across
             both transitions (not just the activate edge)."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
-        (dispatch! (e2e/fake-event {:key "f"}))
+        (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "f"}))
         (let [tree-on (render-shell-tree)
-              sidebar-on (fn-headed-nodes tree-on #(= sidebar/sidebar %))]
+              sidebar-on (fn-headed-nodes tree-on #(= rf.story.ui.sidebar/sidebar %))]
           (is (empty? sidebar-on)
               "after first `f` keydown, no sidebar in tree"))
-        (dispatch! (e2e/fake-event {:key "f"}))
+        (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "f"}))
         (let [tree-off (render-shell-tree)
-              sidebar-off (fn-headed-nodes tree-off #(= sidebar/sidebar %))]
+              sidebar-off (fn-headed-nodes tree-off #(= rf.story.ui.sidebar/sidebar %))]
           (is (seq sidebar-off)
               "after second `f` keydown, sidebar is back in tree"))))))

--- a/tools/story/test/re_frame/story/panels_e2e/chrome_hotkeys_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/chrome_hotkeys_e2e_cljs_test.cljs
@@ -35,103 +35,103 @@
   this ns; no Xray pipeline is needed for this surface (the hotkeys
   are Story chrome only)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.story.ui.keybindings :as kb]
-            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.story.ui.keybindings :as rf.story.ui.keybindings]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; The `dispatch!` fn is private — bind through the var so the test
 ;; reaches the same dispatcher the `keydown` capture listener routes to.
-(def ^:private dispatch! @#'kb/dispatch!)
+(def ^:private dispatch! @#'rf.story.ui.keybindings/dispatch!)
 
 ;; ---- happy-path: each canonical key flips its slot ----------------------
 
 (deftest f-key-toggles-full-screen
   (testing "rf2-p3i0t — `f` (no modifier, not editable) flips
             :full-screen?"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
-        (is (false? (:full-screen? (e2e/chrome-visibility)))
+        (is (false? (:full-screen? (rf.story.test-helpers.e2e-multi-frame/chrome-visibility)))
             "default :full-screen? is false")
-        (dispatch! (e2e/fake-event {:key "f"}))
-        (is (true? (:full-screen? (e2e/chrome-visibility)))
+        (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "f"}))
+        (is (true? (:full-screen? (rf.story.test-helpers.e2e-multi-frame/chrome-visibility)))
             "f keydown flipped :full-screen? to true")
-        (dispatch! (e2e/fake-event {:key "f"}))
-        (is (false? (:full-screen? (e2e/chrome-visibility)))
+        (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "f"}))
+        (is (false? (:full-screen? (rf.story.test-helpers.e2e-multi-frame/chrome-visibility)))
             "second f keydown flipped back to false")))))
 
 (deftest s-key-toggles-sidebar
   (testing "rf2-g8l8x — `s` flips :sidebar?"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
-        (is (true? (:sidebar? (e2e/chrome-visibility))))
-        (dispatch! (e2e/fake-event {:key "s"}))
-        (is (false? (:sidebar? (e2e/chrome-visibility))))))))
+        (is (true? (:sidebar? (rf.story.test-helpers.e2e-multi-frame/chrome-visibility))))
+        (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "s"}))
+        (is (false? (:sidebar? (rf.story.test-helpers.e2e-multi-frame/chrome-visibility))))))))
 
 (deftest a-key-toggles-rhs
   (testing "rf2-g8l8x — `a` (for `addons` per Storybook convention)
             flips :rhs?"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
-        (is (true? (:rhs? (e2e/chrome-visibility))))
-        (dispatch! (e2e/fake-event {:key "a"}))
-        (is (false? (:rhs? (e2e/chrome-visibility))))))))
+        (is (true? (:rhs? (rf.story.test-helpers.e2e-multi-frame/chrome-visibility))))
+        (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "a"}))
+        (is (false? (:rhs? (rf.story.test-helpers.e2e-multi-frame/chrome-visibility))))))))
 
 (deftest t-key-toggles-toolbar
   (testing "rf2-g8l8x — `t` flips :toolbar?"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
-        (is (true? (:toolbar? (e2e/chrome-visibility))))
-        (dispatch! (e2e/fake-event {:key "t"}))
-        (is (false? (:toolbar? (e2e/chrome-visibility))))))))
+        (is (true? (:toolbar? (rf.story.test-helpers.e2e-multi-frame/chrome-visibility))))
+        (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "t"}))
+        (is (false? (:toolbar? (rf.story.test-helpers.e2e-multi-frame/chrome-visibility))))))))
 
 ;; ---- discrimination: modifiers + editable targets pass through ---------
 
 (deftest modifier-held-passes-through
   (testing "Cmd-/Ctrl-/Alt-held → dispatch! is a no-op (the palette /
             browser owns modifier-bearing chords). rf2-g8l8x §exclusions"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
-        (let [before (e2e/chrome-visibility)]
-          (dispatch! (e2e/fake-event {:key "f" :meta? true}))
-          (dispatch! (e2e/fake-event {:key "f" :ctrl? true}))
-          (dispatch! (e2e/fake-event {:key "f" :alt? true}))
-          (is (= before (e2e/chrome-visibility))
+        (let [before (rf.story.test-helpers.e2e-multi-frame/chrome-visibility)]
+          (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "f" :meta? true}))
+          (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "f" :ctrl? true}))
+          (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "f" :alt? true}))
+          (is (= before (rf.story.test-helpers.e2e-multi-frame/chrome-visibility))
               "no slot moved when a modifier is held"))))))
 
 (deftest focused-input-passes-through
   (testing "target is INPUT / TEXTAREA / SELECT / contenteditable →
             dispatch! is a no-op. Typing `f` into the sidebar search
             shouldn't toggle full-screen. rf2-g8l8x §focus-discrimination"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
-        (let [before (e2e/chrome-visibility)]
-          (dispatch! (e2e/fake-event {:key "f" :tag-name "INPUT"}))
-          (dispatch! (e2e/fake-event {:key "f" :tag-name "TEXTAREA"}))
-          (dispatch! (e2e/fake-event {:key "f" :tag-name "SELECT"}))
-          (dispatch! (e2e/fake-event {:key "f" :content-editable? true}))
-          (is (= before (e2e/chrome-visibility))
+        (let [before (rf.story.test-helpers.e2e-multi-frame/chrome-visibility)]
+          (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "f" :tag-name "INPUT"}))
+          (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "f" :tag-name "TEXTAREA"}))
+          (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "f" :tag-name "SELECT"}))
+          (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "f" :content-editable? true}))
+          (is (= before (rf.story.test-helpers.e2e-multi-frame/chrome-visibility))
               "no slot moved when the keydown's target is editable"))))))
 
 (deftest unbound-key-passes-through
   (testing "unbound key → dispatch! is a no-op. `g` is not in
             `bindings` so no toggle fires."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
-        (let [before (e2e/chrome-visibility)]
-          (dispatch! (e2e/fake-event {:key "g"}))
-          (dispatch! (e2e/fake-event {:key "z"}))
-          (is (= before (e2e/chrome-visibility))
+        (let [before (rf.story.test-helpers.e2e-multi-frame/chrome-visibility)]
+          (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "g"}))
+          (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "z"}))
+          (is (= before (rf.story.test-helpers.e2e-multi-frame/chrome-visibility))
               "unbound keys do not move chrome-visibility"))))))
 
 ;; ---- Escape exits full-screen ------------------------------------------
@@ -139,28 +139,28 @@
 (deftest escape-exits-full-screen-only-when-on
   (testing "rf2-p3i0t — Escape exits full-screen when on; no-op
             otherwise."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
         ;; off → Escape → still off
-        (dispatch! (e2e/fake-event {:key "Escape"}))
-        (is (false? (:full-screen? (e2e/chrome-visibility))))
+        (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "Escape"}))
+        (is (false? (:full-screen? (rf.story.test-helpers.e2e-multi-frame/chrome-visibility))))
         ;; on → Escape → off
-        (kb/full-screen-toggle!)
-        (is (true? (:full-screen? (e2e/chrome-visibility))))
-        (dispatch! (e2e/fake-event {:key "Escape"}))
-        (is (false? (:full-screen? (e2e/chrome-visibility))))))))
+        (rf.story.ui.keybindings/full-screen-toggle!)
+        (is (true? (:full-screen? (rf.story.test-helpers.e2e-multi-frame/chrome-visibility))))
+        (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "Escape"}))
+        (is (false? (:full-screen? (rf.story.test-helpers.e2e-multi-frame/chrome-visibility))))))))
 
 (deftest escape-yields-when-editable
   (testing "Escape in an editable target does NOT exit full-screen —
             that key is the input's own cancel affordance"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
-        (kb/full-screen-toggle!)
-        (is (true? (:full-screen? (e2e/chrome-visibility))))
-        (dispatch! (e2e/fake-event {:key "Escape" :tag-name "INPUT"}))
-        (is (true? (:full-screen? (e2e/chrome-visibility)))
+        (rf.story.ui.keybindings/full-screen-toggle!)
+        (is (true? (:full-screen? (rf.story.test-helpers.e2e-multi-frame/chrome-visibility))))
+        (dispatch! (rf.story.test-helpers.e2e-multi-frame/fake-event {:key "Escape" :tag-name "INPUT"}))
+        (is (true? (:full-screen? (rf.story.test-helpers.e2e-multi-frame/chrome-visibility)))
             "Escape in INPUT does not exit full-screen")))))
 
 ;; ---- bindings table sanity (catches an additive regression) -------------
@@ -169,5 +169,5 @@
   (testing "rf2-g8l8x — the canonical 4-key registry is f / s / a / t.
             Adding a key here without spec discussion would risk
             colliding with author muscle-memory."
-    (is (= #{"f" "s" "a" "t"} (set (keys kb/bindings)))
+    (is (= #{"f" "s" "a" "t"} (set (keys rf.story.ui.keybindings/bindings)))
         "the 4-key chrome hotkey set is stable")))

--- a/tools/story/test/re_frame/story/panels_e2e/docs_mode_toc_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/docs_mode_toc_e2e_cljs_test.cljs
@@ -11,7 +11,7 @@
 
   ## What this catches
 
-  - **Layout wires the TOC pane**: rendering `docs/docs-view` for a
+  - **Layout wires the TOC pane**: rendering `rf.story.ui.docs/docs-view` for a
     variant produces a layout whose final child is an (unexpanded)
     `[toc-pane variant-id]` invocation. A regression that drops the
     TOC entry from `docs-view`'s flex layout would leave a section
@@ -32,7 +32,7 @@
 
   - **Entry into docs mode is the mode-tab transition**: the docs
     pane mounts when `:active-mode-tab` for the focused variant is
-    set to `:docs` (via `transitions/set-active-mode-tab`). This is
+    set to `:docs` (via `rf.story.ui.state.transitions/set-active-mode-tab`). This is
     the canonical entry point exercised in the shell render path
     (`shell/main-pane`'s `case mode-tab`).
 
@@ -46,16 +46,16 @@
 
   Surface tested via hiccup walking; no DOM."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.story :as story]
-            [re-frame.story.ui.docs :as docs]
-            [re-frame.story.ui.state :as ui-state]
-            [re-frame.story.ui.state.transitions :as transitions]
-            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.story :as rf.story]
+            [re-frame.story.ui.docs :as rf.story.ui.docs]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.ui.state.transitions :as rf.story.ui.state.transitions]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- fixture -----------------------------------------------------------
 
@@ -70,21 +70,21 @@
    - `:story.docs-no-prose/v` has no prose workspace (the prose entry
      should be pruned)."
   []
-  (story/reg-story :story.docs-rich
+  (rf.story/reg-story :story.docs-rich
     {:doc       "Rich variant fixture for docs-pane TOC scenarios."
      :argtypes  {:label {:doc "user-visible label"}}
      :tags      #{:dev :docs}})
-  (story/reg-variant variant-id
+  (rf.story/reg-variant variant-id
     {:doc    "The happy-path docs variant — prose, args, tags."
      :args   {:label "Hello"}
      :tags   #{:dev :docs :test}
      :setup []})
-  (story/reg-workspace :Workspace.docs-rich/prose-ws
+  (rf.story/reg-workspace :Workspace.docs-rich/prose-ws
     {:layout  :prose
      :content [{:type :variant :id variant-id}
                {:type :prose   :body "Prose copy referencing the variant."}]})
-  (story/reg-story :story.docs-no-prose {:doc "Variant with no prose."})
-  (story/reg-variant no-prose-variant-id
+  (rf.story/reg-story :story.docs-no-prose {:doc "Variant with no prose."})
+  (rf.story/reg-variant no-prose-variant-id
     {:doc    "No-prose variant — prose TOC entry should be pruned."
      :setup []}))
 
@@ -94,14 +94,14 @@
   "Render the `:docs` mode pane for `vid`. Wrapper kept for clarity at
   call sites."
   [vid]
-  (docs/docs-view vid))
+  (rf.story.ui.docs/docs-view vid))
 
 (defn- section-ids
   "Walk the expanded hiccup tree and return every `:section` node's
   `:id` attribute. Used to verify every TOC anchor target has a real
   in-page element."
   [tree]
-  (->> (e2e/hiccup-seq tree)
+  (->> (rf.story.test-helpers.e2e-multi-frame/hiccup-seq tree)
        (keep (fn [node]
                (when (and (vector? node) (= :section (first node)))
                  (let [maybe-attrs (second node)]
@@ -126,7 +126,7 @@
                      (fn? (first node))
                      (= vid (second node)))
             node))
-        (e2e/hiccup-seq tree)))
+        (rf.story.test-helpers.e2e-multi-frame/hiccup-seq tree)))
 
 ;; ===========================================================================
 ;; rf2-y3w2q — TOC pane is wired into the docs-view layout
@@ -137,13 +137,13 @@
             layout whose final child is the (class-3) TOC pane vector.
             A regression that drops the TOC entry would leave the
             section list without in-page navigation."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variants!}
       (fn []
-        (e2e/select-variant! variant-id)
+        (rf.story.test-helpers.e2e-multi-frame/select-variant! variant-id)
         (let [tree    (render-docs-view variant-id)
-              layout  (e2e/find-by-test-id tree "story-docs-layout")
-              view    (e2e/find-by-test-id tree "story-docs-view")
+              layout  (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-docs-layout")
+              view    (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-docs-view")
               toc-vec (toc-pane-vector tree variant-id)]
           (is (some? layout)
               "story-docs-layout wrapper present — the flex container
@@ -170,12 +170,12 @@
             A regression that renamed a section without updating the
             TOC table (or vice versa) would point the jump buttons
             at non-existent ids."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variants!}
       (fn []
-        (e2e/select-variant! variant-id)
+        (rf.story.test-helpers.e2e-multi-frame/select-variant! variant-id)
         (let [tree           (render-docs-view variant-id)
-              visible        (docs/visible-toc-entries variant-id)
+              visible        (rf.story.ui.docs/visible-toc-entries variant-id)
               visible-ids    (set (map :id visible))
               rendered-ids   (set (section-ids tree))]
           (is (pos? (count visible))
@@ -204,17 +204,17 @@
             workspace produces a visible TOC list with the prose entry
             pruned. Pairs with the inverse: the rich variant DOES
             surface the prose row."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variants!}
       (fn []
         ;; Rich variant: prose workspace is registered → prose IS visible.
-        (let [rich (docs/visible-toc-entries variant-id)
+        (let [rich (rf.story.ui.docs/visible-toc-entries variant-id)
               ids  (set (map :id rich))]
           (is (contains? ids "docs-prose")
               "rich variant: prose TOC entry surfaces because the
                registered :prose workspace references it"))
         ;; No-prose variant: no workspace → prose TOC entry pruned.
-        (let [empty-prose (docs/visible-toc-entries no-prose-variant-id)
+        (let [empty-prose (rf.story.ui.docs/visible-toc-entries no-prose-variant-id)
               ids         (set (map :id empty-prose))]
           (is (not (contains? ids "docs-prose"))
               "no-prose variant: prose TOC entry pruned — the renderer
@@ -235,7 +235,7 @@
 
 (deftest set-active-mode-tab-docs-routes-to-docs-view-with-toc
   (testing "rf2-y3w2q — the canonical entry into docs mode is
-            `transitions/set-active-mode-tab variant-id :docs`. After
+            `rf.story.ui.state.transitions/set-active-mode-tab variant-id :docs`. After
             that transition `state/active-mode-tab` reports `:docs`,
             and rendering the docs-view for the focused variant yields
             a layout that includes the TOC pane invocation.
@@ -244,26 +244,26 @@
             slot to choose between `:dev` / `:docs` / `:test` — so
             pinning the transition + the resulting layout shape
             covers the shell's docs-pane mount path end-to-end."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variants!}
       (fn []
-        (e2e/select-variant! variant-id)
+        (rf.story.test-helpers.e2e-multi-frame/select-variant! variant-id)
         ;; Default mode-tab is :dev — verify by reading the slot pre-
         ;; transition.
-        (is (not= :docs (ui-state/active-mode-tab
-                          (ui-state/get-state) variant-id))
+        (is (not= :docs (rf.story.ui.state/active-mode-tab
+                          (rf.story.ui.state/get-state) variant-id))
             "default active-mode-tab is :dev (or otherwise non-:docs)")
         ;; Switch to docs mode.
-        (ui-state/swap-state! transitions/set-active-mode-tab
+        (rf.story.ui.state/swap-state! rf.story.ui.state.transitions/set-active-mode-tab
                               variant-id :docs)
-        (is (= :docs (ui-state/active-mode-tab
-                       (ui-state/get-state) variant-id))
+        (is (= :docs (rf.story.ui.state/active-mode-tab
+                       (rf.story.ui.state/get-state) variant-id))
             ":active-mode-tab flipped to :docs — the shell mounts the
              docs-view for this variant")
         ;; Render the docs-view (what main-pane's `:docs` branch
         ;; mounts) and assert the TOC is part of the layout.
         (let [tree    (render-docs-view variant-id)
-              layout  (e2e/find-by-test-id tree "story-docs-layout")
+              layout  (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-docs-layout")
               toc-vec (toc-pane-vector tree variant-id)]
           (is (some? layout)
               "docs-view layout renders for the focused variant")

--- a/tools/story/test/re_frame/story/panels_e2e/embed_url_flag_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/embed_url_flag_e2e_cljs_test.cljs
@@ -14,10 +14,10 @@
       ?embed=1 in URL
             │
             ▼
-      url-state/embed-flag-from-current-url   ← URL parser
+      rf.story.ui.url-state/embed-flag-from-current-url   ← URL parser
             │
             ▼
-      url-state/hydrate-embed-flag!           ← seeds shell-state
+      rf.story.ui.url-state/hydrate-embed-flag!           ← seeds shell-state
             │
             ▼
       [:chrome-visibility :embed?] = true
@@ -29,7 +29,7 @@
       shell/:reagent-render guards `(when show-sb? [sidebar ...])` etc
             │
             ▼
-      No [sidebar/sidebar] / [toolbar/toolbar-strip] / [right-panel]
+      No [rf.story.ui.sidebar/sidebar] / [rf.story.ui.toolbar/toolbar-strip] / [right-panel]
       vectors in the rendered hiccup tree; the variant canvas slot
       still renders.
 
@@ -51,7 +51,7 @@
   2. The state→render seam: invoking shell's `:reagent-render` with
      `:embed?` true produces a hiccup tree where the three chrome
      guards (`(when show-tb?)`, `(when show-sb?)`, `(when show-rhs?)`)
-     all elide — no `[sidebar/sidebar]` / `[toolbar/toolbar-strip]` /
+     all elide — no `[rf.story.ui.sidebar/sidebar]` / `[rf.story.ui.toolbar/toolbar-strip]` /
      `[right-panel]` vector survives in the tree, while the
      `[main-pane]` slot still renders (the variant viewport).
 
@@ -62,21 +62,21 @@
   No DOM, no React mount, no Playwright. Sub-millisecond per case."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent.core :as r]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
-            [re-frame.story.ui.state :as ui-state]
-            [re-frame.story.ui.shell :as shell]
-            [re-frame.story.ui.sidebar :as sidebar]
-            [re-frame.story.ui.toolbar :as toolbar]
-            [re-frame.story.ui.url-state :as url-state]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.ui.shell :as rf.story.ui.shell]
+            [re-frame.story.ui.sidebar :as rf.story.ui.sidebar]
+            [re-frame.story.ui.toolbar :as rf.story.ui.toolbar]
+            [re-frame.story.ui.url-state :as rf.story.ui.url-state]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- helpers: extract shell's `:reagent-render` -------------------------
 ;;
-;; `shell/shell` is a class-3 Reagent component (`r/create-class` is
+;; `rf.story.ui.shell/shell` is a class-3 Reagent component (`r/create-class` is
 ;; called inline; the spec map isn't exposed). To exercise the
 ;; render path under the node runner we capture the spec by stubbing
 ;; `r/create-class` with `identity` for the duration of the call —
@@ -99,7 +99,7 @@
   test invocation so any state-atom mutation between calls is
   reflected on the next render."
   []
-  (let [spec (with-redefs [r/create-class capture-spec] (shell/shell))]
+  (let [spec (with-redefs [r/create-class capture-spec] (rf.story.ui.shell/shell))]
     (:reagent-render spec)))
 
 (defn- render-shell-tree
@@ -109,7 +109,7 @@
   contract)."
   []
   (let [render-fn (shell-render-fn)]
-    (e2e/expand-tree (render-fn))))
+    (rf.story.test-helpers.e2e-multi-frame/expand-tree (render-fn))))
 
 (defn- fn-headed-nodes
   "Every node whose `(first node)` is a function value. Used to
@@ -123,7 +123,7 @@
                   (pos? (count node))
                   (fn? (first node))
                   (pred (first node))))
-           (e2e/hiccup-seq tree)))
+           (rf.story.test-helpers.e2e-multi-frame/hiccup-seq tree)))
 
 ;; ---- Pipeline (1): URL → shell-state hydrate ----------------------------
 
@@ -132,14 +132,14 @@
             the shell-state-atom when the URL parser reports the flag.
             The parser itself is covered by url-state-cljs-test; this
             seam test pins the parser→state hand-off."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
-        (with-redefs [url-state/embed-flag-from-current-url (constantly true)]
-          (let [returned (url-state/hydrate-embed-flag! ui-state/shell-state-atom)]
+        (with-redefs [rf.story.ui.url-state/embed-flag-from-current-url (constantly true)]
+          (let [returned (rf.story.ui.url-state/hydrate-embed-flag! rf.story.ui.state/shell-state-atom)]
             (is (true? returned)
                 "hydrate returns the parsed value")
-            (is (true? (get-in (ui-state/get-state)
+            (is (true? (get-in (rf.story.ui.state/get-state)
                                [:chrome-visibility :embed?]))
                 "shell-state-atom carries :embed? true after hydrate")))))))
 
@@ -147,14 +147,14 @@
   (testing "rf2-pucku — `hydrate-embed-flag!` writes :embed? false
             (the default-chrome shape) when no `?embed=1` is in the
             URL. Pins the 'absent param → chrome on' contract."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
-        (with-redefs [url-state/embed-flag-from-current-url (constantly false)]
-          (let [returned (url-state/hydrate-embed-flag! ui-state/shell-state-atom)]
+        (with-redefs [rf.story.ui.url-state/embed-flag-from-current-url (constantly false)]
+          (let [returned (rf.story.ui.url-state/hydrate-embed-flag! rf.story.ui.state/shell-state-atom)]
             (is (false? returned)
                 "hydrate returns false when no flag")
-            (is (false? (get-in (ui-state/get-state)
+            (is (false? (get-in (rf.story.ui.state/get-state)
                                 [:chrome-visibility :embed?]))
                 "shell-state-atom carries :embed? false (the default)")))))))
 
@@ -166,7 +166,7 @@
             sidebar / toolbar / right-panel guards all elide. The
             `[main-pane]` vector (which contains the variant canvas)
             still renders so the viewport remains visible."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
         ;; Seed embed-mode directly — same effective state
@@ -174,7 +174,7 @@
         ;; true (covered above). This separates the URL-seam test
         ;; from the render-seam test so a failure points at the
         ;; right layer.
-        (swap! ui-state/shell-state-atom
+        (swap! rf.story.ui.state/shell-state-atom
                assoc-in [:chrome-visibility :embed?] true)
         (let [tree (render-shell-tree)
               ;; Top-level wrapper's `data-rf-chrome-embed` reflects
@@ -182,27 +182,27 @@
               ;; embed-mode state.
               root-attrs (when (and (vector? tree) (map? (second tree)))
                            (second tree))
-              ;; Locate any [sidebar/sidebar ...] vector in the tree —
-              ;; the shell's `(when show-sb? [sidebar/sidebar ...])`
+              ;; Locate any [rf.story.ui.sidebar/sidebar ...] vector in the tree —
+              ;; the shell's `(when show-sb? [rf.story.ui.sidebar/sidebar ...])`
               ;; guard would elide this when :embed? is true.
-              sidebar-nodes (fn-headed-nodes tree #(= sidebar/sidebar %))
+              sidebar-nodes (fn-headed-nodes tree #(= rf.story.ui.sidebar/sidebar %))
               ;; Same for the toolbar — `toolbar-strip` is class-1
               ;; (expands to a `<header data-test="story-toolbar">`)
               ;; so we can also assert its data-test marker is gone.
-              toolbar-nodes (fn-headed-nodes tree #(= toolbar/toolbar-strip %))
-              toolbar-by-attr (e2e/find-by-test-id tree "story-toolbar")
+              toolbar-nodes (fn-headed-nodes tree #(= rf.story.ui.toolbar/toolbar-strip %))
+              toolbar-by-attr (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-toolbar")
               ;; right-panel is class-1 (returns hiccup with
               ;; data-test="story-inspectors"). Assert its
               ;; data-test marker is absent.
-              inspectors-node (e2e/find-by-test-id tree "story-inspectors")]
+              inspectors-node (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-inspectors")]
           (is (= "true" (:data-rf-chrome-embed root-attrs))
               "shell wrapper carries data-rf-chrome-embed=true — the
                render saw the embed-mode state")
           (is (empty? sidebar-nodes)
-              "no [sidebar/sidebar ...] vector in the tree — the
+              "no [rf.story.ui.sidebar/sidebar ...] vector in the tree — the
                sidebar guard elided per rf2-pucku")
           (is (empty? toolbar-nodes)
-              "no [toolbar/toolbar-strip] vector in the tree")
+              "no [rf.story.ui.toolbar/toolbar-strip] vector in the tree")
           (is (nil? toolbar-by-attr)
               "no data-test=\"story-toolbar\" element — the
                toolbar's <header> never rendered")
@@ -215,7 +215,7 @@
           ;; vector would still pass the negation checks above.
           ;; `main-pane` (defn- in shell.cljs) is class-1 and
           ;; expands to `[:main {:aria-label "Story canvas" ...}]`.
-          (let [main-node (e2e/find-by-data-attr tree
+          (let [main-node (rf.story.test-helpers.e2e-multi-frame/find-by-data-attr tree
                                                  :aria-label "Story canvas")]
             (is (some? main-node)
                 "<main aria-label=\"Story canvas\"> is still in the
@@ -229,7 +229,7 @@
             three chrome guards all admit their components. Pins the
             inverse so the assertions above can't trivially pass on
             a render that drops every vector."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
         ;; No mutation — `with-story-and-xray-frames`'s setup
@@ -238,13 +238,13 @@
         (let [tree (render-shell-tree)
               root-attrs (when (and (vector? tree) (map? (second tree)))
                            (second tree))
-              sidebar-nodes (fn-headed-nodes tree #(= sidebar/sidebar %))
-              toolbar-by-attr (e2e/find-by-test-id tree "story-toolbar")
-              inspectors-node (e2e/find-by-test-id tree "story-inspectors")]
+              sidebar-nodes (fn-headed-nodes tree #(= rf.story.ui.sidebar/sidebar %))
+              toolbar-by-attr (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-toolbar")
+              inspectors-node (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-inspectors")]
           (is (= "false" (:data-rf-chrome-embed root-attrs))
               "shell wrapper carries data-rf-chrome-embed=false at default")
           (is (seq sidebar-nodes)
-              "[sidebar/sidebar ...] vector present in the tree — the
+              "[rf.story.ui.sidebar/sidebar ...] vector present in the tree — the
                sidebar guard admits the component at default")
           (is (some? toolbar-by-attr)
               "data-test=\"story-toolbar\" element present at default")

--- a/tools/story/test/re_frame/story/panels_e2e/loading_skeleton_lifecycle_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/loading_skeleton_lifecycle_e2e_cljs_test.cljs
@@ -63,15 +63,15 @@
   Sub-millisecond per case; no DOM mount, no React, no Playwright."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story :as story]
-            [re-frame.story.loaders :as loaders]
-            [re-frame.story.ui.canvas :as canvas]
-            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
-            [re-frame.subs :as subs]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.loaders :as rf.story.loaders]
+            [re-frame.story.ui.canvas :as rf.story.ui.canvas]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]
+            [re-frame.subs :as rf.subs]))
 
 ;; Mirror the proven reset pattern in variant_lifecycle_e2e — full
 ;; registrar clear + manual re-register of the framework's `:rf/machine`
@@ -82,22 +82,22 @@
 (declare register-skeleton-variants!)
 
 (defn- reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
   ;; EP-0001 (rf2-vzld77 / rf2-ixb0bq): machine snapshots are durable
   ;; RUNTIME-DB state at [:rf.runtime/machines :snapshots <id>] — the
   ;; framework `:rf/machine` sub reads the runtime-db partition, NOT the
   ;; retired app-db `:rf/runtime` path. Mirror `re-frame.machines`.
-  (subs/reg-runtime-sub :rf/machine
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [runtime-db [_ machine-id]]
       (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (canvas/reset-first-rendered!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.ui.canvas/reset-first-rendered!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (register-skeleton-variants!))
 
 (use-fixtures :each {:before reset-all!})
@@ -113,20 +113,20 @@
 
 (defn- register-skeleton-variants! []
   (rf/reg-view* :story.skeleton/view skeleton-view)
-  (story/reg-story* :story.skeleton {:doc "skeleton-e2e parent story"})
-  ;; The test drives the lifecycle machine directly via `loaders/mount!`
+  (rf.story/reg-story* :story.skeleton {:doc "skeleton-e2e parent story"})
+  ;; The test drives the lifecycle machine directly via `rf.story.loaders/mount!`
   ;; / `start-loaders!` / `finish-loaders!` — `:loaders` doesn't need a
   ;; real event since we never go through `run-variant`. The slot is
   ;; declared so `events-only-variant?` returns false (which is the
   ;; only condition that matters for the `loading-phase?` gate).
-  (story/reg-variant* :story.skeleton/v
+  (rf.story/reg-variant* :story.skeleton/v
     {:doc       "Variant declared with :loaders so events-only? is false."
      :component :story.skeleton/view
      :loaders   [[:noop/loader]]}))
 
 ;; ---- helper: read the canvas-inner hiccup tree --------------------------
 
-(def ^:private canvas-inner @#'canvas/canvas-inner)
+(def ^:private canvas-inner @#'rf.story.ui.canvas/canvas-inner)
 
 (defn- canvas-inner-tree
   "Drive `canvas-inner` for the test variant and expand the resulting
@@ -134,13 +134,13 @@
   that reads the lifecycle phase + first-rendered + assertions and
   branches on `show-skeleton?`."
   [variant-id]
-  (e2e/expand-tree (canvas-inner variant-id)))
+  (rf.story.test-helpers.e2e-multi-frame/expand-tree (canvas-inner variant-id)))
 
 (defn- skeleton-node [tree]
-  (e2e/find-by-test-id tree "story-canvas-loading-skeleton"))
+  (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-canvas-loading-skeleton"))
 
 (defn- user-view-node [tree]
-  (e2e/find-by-test-id tree "skeleton-test-user-view"))
+  (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "skeleton-test-user-view"))
 
 ;; ---- pipeline (1): phase-1 lifecycle → skeleton renders -----------------
 
@@ -157,9 +157,9 @@
       ;; lights up the skeleton — but pinning :loading specifically
       ;; matches the bead's user-facing acceptance criterion ("canvas
       ;; shows the skeleton when loaders run").
-      (loaders/mount! variant-id)
-      (loaders/start-loaders! variant-id)
-      (is (= :loading (loaders/current-state variant-id))
+      (rf.story.loaders/mount! variant-id)
+      (rf.story.loaders/start-loaders! variant-id)
+      (is (= :loading (rf.story.loaders/current-state variant-id))
           "lifecycle parked at :loading for the assertion below")
       (let [tree (canvas-inner-tree variant-id)]
         (is (some? (skeleton-node tree))
@@ -168,7 +168,7 @@
         (is (nil? (user-view-node tree))
             "user view does NOT render while the skeleton is showing
              (the skeleton replaces the user view in the cond branch)"))
-      (story/destroy-variant! variant-id))))
+      (rf.story/destroy-variant! variant-id))))
 
 ;; ---- pipeline (2): pre-mount also renders skeleton ----------------------
 
@@ -182,12 +182,12 @@
     (let [variant-id :story.skeleton/v]
       (rf/make-frame {:id variant-id})
       ;; No transitions — machine reports :pre-mount.
-      (is (= :pre-mount (loaders/current-state variant-id))
+      (is (= :pre-mount (rf.story.loaders/current-state variant-id))
           "fresh frame → :pre-mount")
       (let [tree (canvas-inner-tree variant-id)]
         (is (some? (skeleton-node tree))
             "skeleton renders during :pre-mount"))
-      (story/destroy-variant! variant-id))))
+      (rf.story/destroy-variant! variant-id))))
 
 ;; ---- pipeline (3): :ready phase elides the skeleton ---------------------
 
@@ -198,18 +198,18 @@
     (let [variant-id :story.skeleton/v]
       (rf/make-frame {:id variant-id})
       ;; Drive the lifecycle all the way through :ready.
-      (loaders/mount! variant-id)
-      (loaders/start-loaders! variant-id)
-      (loaders/finish-loaders! variant-id)
-      (loaders/finish-events! variant-id)
-      (is (= :ready (loaders/current-state variant-id))
+      (rf.story.loaders/mount! variant-id)
+      (rf.story.loaders/start-loaders! variant-id)
+      (rf.story.loaders/finish-loaders! variant-id)
+      (rf.story.loaders/finish-events! variant-id)
+      (is (= :ready (rf.story.loaders/current-state variant-id))
           "lifecycle reached :ready before the assertion below")
       (let [tree (canvas-inner-tree variant-id)]
         (is (nil? (skeleton-node tree))
             "skeleton is NOT in the tree once :ready lands")
         (is (some? (user-view-node tree))
             "user view renders post-:ready"))
-      (story/destroy-variant! variant-id))))
+      (rf.story/destroy-variant! variant-id))))
 
 ;; ---- pipeline (4): first-rendered sentinel pins skeleton off ------------
 
@@ -222,17 +222,17 @@
     (let [variant-id :story.skeleton/v]
       (rf/make-frame {:id variant-id})
       ;; Lifecycle in :loading, sentinel set → skeleton MUST NOT show.
-      (loaders/mount! variant-id)
-      (loaders/start-loaders! variant-id)
-      (canvas/mark-variant-rendered! variant-id)
-      (is (= :loading (loaders/current-state variant-id))
+      (rf.story.loaders/mount! variant-id)
+      (rf.story.loaders/start-loaders! variant-id)
+      (rf.story.ui.canvas/mark-variant-rendered! variant-id)
+      (is (= :loading (rf.story.loaders/current-state variant-id))
           "machine still in :loading — sentinel is the only off-switch")
       (let [tree (canvas-inner-tree variant-id)]
         (is (nil? (skeleton-node tree))
             "first-rendered sentinel pins the skeleton off")
         (is (some? (user-view-node tree))
             "user view renders despite the lifecycle being in :loading"))
-      (story/destroy-variant! variant-id))))
+      (rf.story/destroy-variant! variant-id))))
 
 ;; ---- pipeline (5): skeleton hiccup shape is the canonical one ------------
 
@@ -244,8 +244,8 @@
             simplification refactor that dropped them would surface."
     (let [variant-id :story.skeleton/v]
       (rf/make-frame {:id variant-id})
-      (loaders/mount! variant-id)
-      (loaders/start-loaders! variant-id)
+      (rf.story.loaders/mount! variant-id)
+      (rf.story.loaders/start-loaders! variant-id)
       (let [tree  (canvas-inner-tree variant-id)
             node  (skeleton-node tree)
             attrs (when (and (vector? node) (map? (second node)))
@@ -257,4 +257,4 @@
             "aria-live=polite — non-interrupting loading announcement")
         (is (= "Variant loading" (:aria-label attrs))
             "aria-label names the loading region for screen readers"))
-      (story/destroy-variant! variant-id))))
+      (rf.story/destroy-variant! variant-id))))

--- a/tools/story/test/re_frame/story/panels_e2e/reg_variant_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/reg_variant_e2e_cljs_test.cljs
@@ -23,7 +23,7 @@
   Per Mike's testing direction (feedback_xray_story_cljs_unit_tests_
   not_playwright) + the Wave 1-4 migration pattern (rf2-tglku epic):
   the architectural answer is a CLJS unit test that drives
-  `story/run-variant` directly and asserts the result-map's
+  `rf.story/run-variant` directly and asserts the result-map's
   `:lifecycle` + `:app-db` slots — no DOM, no race-sensitive count
   timing.
 
@@ -51,34 +51,34 @@
   Each test runs sub-second under Node CLJS. No browser, no DOM."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story :as story]
-            [re-frame.story.async :as async-lib]
-            [re-frame.story.loaders :as loaders]
-            [re-frame.subs :as subs]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.async :as rf.story.async]
+            [re-frame.story.loaders :as rf.story.loaders]
+            [re-frame.subs :as rf.subs]))
 
 ;; ---- fixture: reset registrar + canonical vocab + counter events --------
 
 (declare register-counter-variants!)
 
 (defn- reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
   ;; Re-register the machines artefact's framework-shipped `:rf/machine`
   ;; sub (a runtime-db sub under EP-0001) after the registrar clear —
   ;; see the matching comment in `variant_lifecycle_e2e_cljs_test.cljs`.
-  (subs/reg-runtime-sub :rf/machine
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [runtime-db [_ machine-id]]
       (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (register-counter-variants!))
 
 (use-fixtures :each {:before reset-all!})
@@ -106,18 +106,18 @@
 
 (defn- register-counter-variants! []
   (install-counter-events!)
-  (story/reg-story :story.counter
+  (rf.story/reg-story :story.counter
     {:doc "Parent story for the reg-variant e2e tests — mirrors the
            counter_with_stories testbed."})
-  (story/reg-variant :story.counter/empty
+  (rf.story/reg-variant :story.counter/empty
     {:doc "Fresh counter at zero. The simplest possible variant."
      :setup [[:counter/initialise 0]]
      :script [[:dispatch-sync [:rf.assert/path-equals [:count] 0]]]})
-  (story/reg-variant :story.counter/loaded
+  (rf.story/reg-variant :story.counter/loaded
     {:doc "A counter seeded with a non-zero value."
      :setup [[:counter/initialise 7]]
      :script [[:dispatch-sync [:rf.assert/path-equals [:count] 7]]]})
-  (story/reg-variant :story.counter/clicked-three-times
+  (rf.story/reg-variant :story.counter/clicked-three-times
     {:doc "Counter after three increments from zero, driven from the
            play slot so :rf.assert/dispatched? observes them."
      :setup [[:counter/initialise 0]]
@@ -126,10 +126,10 @@
                    [:dispatch-sync [:counter/inc]]
                    [:dispatch-sync [:rf.assert/path-equals  [:count] 3]]
                    [:dispatch-sync [:rf.assert/dispatched?  [:counter/inc]]]]})
-  (story/reg-variant :story.counter/save-stubbed
+  (rf.story/reg-variant :story.counter/save-stubbed
     {:doc "The save flow with the network fx stubbed."
      :setup [[:counter/initialise 5]]
-     :decorators [[story/force-fx-stub-id :counter/sync-to-server {:ok? true}]]
+     :decorators [[rf.story/force-fx-stub-id :counter/sync-to-server {:ok? true}]]
      :script [[:dispatch-sync [:counter/save]]
                    [:dispatch-sync [:rf.assert/path-equals    [:saving?] true]]
                    [:dispatch-sync [:rf.assert/effect-emitted :counter/sync-to-server]]]}))
@@ -138,7 +138,7 @@
 
 (defn- assertions-passing?
   "True iff every assertion in `result`'s `:assertions` slot has
-  `:passed? true`. Mirrors `story/assertions-passing?` semantics —
+  `:passed? true`. Mirrors `rf.story/assertions-passing?` semantics —
   inlined here so the test reads inline."
   [result]
   (every? (fn [a] (true? (:passed? a))) (:assertions result)))
@@ -149,8 +149,8 @@
   (testing ":story.counter/empty reaches :ready with :count 0 and all
             play-script assertions passing"
     (async done
-      (-> (story/run-variant :story.counter/empty)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.counter/empty)
+          (rf.story.async/then
             (fn [result]
               (is (= :ready (:lifecycle result))
                   "lifecycle reached :ready")
@@ -158,7 +158,7 @@
                   ":count seeded to 0 by [:counter/initialise 0]")
               (is (assertions-passing? result)
                   "every :rf.assert/* row in the result is :passed? true")
-              (story/destroy-variant! :story.counter/empty)
+              (rf.story/destroy-variant! :story.counter/empty)
               (done)))))))
 
 ;; ---- rf2-ixb0bq — the re-registered :rf/machine sub reads runtime-db -----
@@ -173,8 +173,8 @@
 (deftest rf-machine-sub-resolves-live-runtime-db-snapshot
   (testing ":rf/machine resolves the live lifecycle snapshot off runtime-db"
     (async done
-      (-> (story/run-variant :story.counter/loaded)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.counter/loaded)
+          (rf.story.async/then
             (fn [_result]
               (let [fs   (rf/frame-state-value :story.counter/loaded)
                     snap (rf/compute-sub
@@ -183,7 +183,7 @@
                     ":rf/machine read the live runtime-db snapshot, not nil")
                 (is (= :ready (:state snap))
                     "the live snapshot's :state is :ready after a clean run"))
-              (story/destroy-variant! :story.counter/loaded)
+              (rf.story/destroy-variant! :story.counter/loaded)
               (done)))))))
 
 ;; ---- (2) :story.counter/loaded -- count 7 -------------------------------
@@ -191,8 +191,8 @@
 (deftest loaded-variant-runs-clean-count-7
   (testing ":story.counter/loaded reaches :ready with :count 7"
     (async done
-      (-> (story/run-variant :story.counter/loaded)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.counter/loaded)
+          (rf.story.async/then
             (fn [result]
               (is (= :ready (:lifecycle result))
                   "lifecycle reached :ready")
@@ -200,7 +200,7 @@
                   ":count seeded to 7 by [:counter/initialise 7]")
               (is (assertions-passing? result)
                   "every :rf.assert/* row in the result is :passed? true")
-              (story/destroy-variant! :story.counter/loaded)
+              (rf.story/destroy-variant! :story.counter/loaded)
               (done)))))))
 
 ;; ---- (3) :story.counter/clicked-three-times -- count 3 ------------------
@@ -221,8 +221,8 @@
             contract that the Playwright probe (now skipped per
             rf2-8awk1) was trying to assert via the DOM."
     (async done
-      (-> (story/run-variant :story.counter/clicked-three-times)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.counter/clicked-three-times)
+          (rf.story.async/then
             (fn [result]
               (is (= :ready (:lifecycle result))
                   "lifecycle reached :ready after play-script ran")
@@ -232,7 +232,7 @@
               (is (assertions-passing? result)
                   "every :rf.assert/* row in the play-script passed
                    (path-equals 3 + dispatched? :counter/inc)")
-              (story/destroy-variant! :story.counter/clicked-three-times)
+              (rf.story/destroy-variant! :story.counter/clicked-three-times)
               (done)))))))
 
 ;; ---- (4) :story.counter/save-stubbed -- count 5 + fx-stub ---------------
@@ -242,8 +242,8 @@
             the `:counter/sync-to-server` fx-stub fires through the
             play-script"
     (async done
-      (-> (story/run-variant :story.counter/save-stubbed)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.counter/save-stubbed)
+          (rf.story.async/then
             (fn [result]
               (is (= :ready (:lifecycle result))
                   "lifecycle reached :ready")
@@ -256,7 +256,7 @@
                   "every :rf.assert/* row in the play-script passed
                    (path-equals :saving? true + effect-emitted
                    :counter/sync-to-server)")
-              (story/destroy-variant! :story.counter/save-stubbed)
+              (rf.story/destroy-variant! :story.counter/save-stubbed)
               (done)))))))
 
 ;; ---- (5) registration shape — `reg-variant` side-table -------------------
@@ -276,7 +276,7 @@
                  :story.counter/loaded
                  :story.counter/clicked-three-times
                  :story.counter/save-stubbed]]
-      (let [body (story/variant->edn vid)]
+      (let [body (rf.story/variant->edn vid)]
         (is (map? body)
             (str "variant->edn returned a map for " vid))
         (is (vector? (:setup body))

--- a/tools/story/test/re_frame/story/panels_e2e/share_url_state_hydration_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/share_url_state_hydration_e2e_cljs_test.cljs
@@ -5,9 +5,9 @@
   Shell mount runs TWO URL-hydration passes, in this order
   (`re-frame.story.ui.shell/hydrate-url-state!`):
 
-      1. url-state/hydrate-from-url!  ← authoritative + VALIDATING owner of
+      1. rf.story.ui.url-state/hydrate-from-url!  ← authoritative + VALIDATING owner of
                                          selection / substrate / chrome slots
-      2. share/hydrate-from-url!     ← owns ONLY the focused-variant
+      2. rf.story.ui.share/hydrate-from-url!     ← owns ONLY the focused-variant
                                          cell-overrides slice + drift hint
 
   The bug: pass 2 used to reparse the RAW `substrate=` without registry
@@ -29,19 +29,19 @@
     and still records the dropped-override drift hint;
   - a valid `substrate=` + valid `overrides=` still hydrate (no regression)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.story :as story]
-            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.story.ui.multi-substrate :as multi-substrate]
-            [re-frame.story.ui.state :as ui-state]
-            [re-frame.story.ui.share :as share]
-            [re-frame.story.ui.url-state :as url-state]
-            [re-frame.story.share :as share-codec]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.story :as rf.story]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.ui.multi-substrate :as rf.story.ui.multi-substrate]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.ui.share :as rf.story.ui.share]
+            [re-frame.story.ui.url-state :as rf.story.ui.url-state]
+            [re-frame.story.share :as rf.story.share]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- production validators (mirror shell's private `url-state-apply-fn`) --
 ;;
@@ -53,12 +53,12 @@
 (defn- production-apply-fn []
   (let [validators {:variant?   (fn [vid]
                                   (or (nil? vid)
-                                      (registrar/registered? :variant vid)))
+                                      (rf.story.registrar/registered? :variant vid)))
                     :substrate? (fn [s]
                                   (or (nil? s)
-                                      (contains? (multi-substrate/registered-substrates) s)))}]
+                                      (contains? (rf.story.ui.multi-substrate/registered-substrates) s)))}]
     (fn [state parsed]
-      (url-state/apply-parsed-to-state state parsed validators))))
+      (rf.story.ui.url-state/apply-parsed-to-state state parsed validators))))
 
 ;; ---- drive the real two-pass shell hydration sequence -------------------
 
@@ -71,28 +71,28 @@
   (let [usp (js/URLSearchParams.
               (clj->js (into {} (filter (comp some? val) getter))))]
     (with-redefs [;; pass 1 source: url-state parses window.location.search
-                  url-state/parse-current-url (constantly (share-codec/parse-params getter))
+                  rf.story.ui.url-state/parse-current-url (constantly (rf.story.share/parse-params getter))
                   ;; pass 2 source: share reads window.location.search
-                  share/current-url-params    (constantly usp)]
+                  rf.story.ui.share/current-url-params    (constantly usp)]
       ;; Pass 1 — the authoritative, validating owner.
-      (url-state/hydrate-from-url! ui-state/shell-state-atom (production-apply-fn))
+      (rf.story.ui.url-state/hydrate-from-url! rf.story.ui.state/shell-state-atom (production-apply-fn))
       ;; Pass 2 — the cell-overrides slice + drift hint owner.
-      (share/hydrate-from-url!))))
+      (rf.story.ui.share/hydrate-from-url!))))
 
 ;; A variant whose declared arg surface is exactly #{:label}. An
 ;; `overrides=` entry for any OTHER key is stale (the variant no longer
 ;; declares it) and must be dropped + reported by pass 2.
 (defn- register-variant! []
-  (story/reg-story :story.sample {:doc "Parent for the share-hydration e2e."})
-  (story/reg-variant :story.sample/card
+  (rf.story/reg-story :story.sample {:doc "Parent for the share-hydration e2e."})
+  (rf.story/reg-variant :story.sample/card
     {:doc      "A card variant declaring a single :label arg."
      :argtypes {:label {:type :string}}
      :args     {:label "Hello"}}))
 
 ;; Register a second substrate so a non-default valid `substrate=` round-trips.
 (defn- register-substrates! []
-  (multi-substrate/register-substrate! :reagent (fn [_ _ _] [:div]))
-  (multi-substrate/register-substrate! :uix     (fn [_ _ _] [:div])))
+  (rf.story.ui.multi-substrate/register-substrate! :reagent (fn [_ _ _] [:div]))
+  (rf.story.ui.multi-substrate/register-substrate! :uix     (fn [_ _ _] [:div])))
 
 ;; =========================================================================
 ;; (1) unregistered substrate= ends :reagent after the COMPLETE sequence
@@ -102,18 +102,18 @@
   (testing "rf2-ovb1en — `substrate=ghost-substrate` is normalised to
             :reagent by pass 1 and pass 2 (share) MUST NOT resurrect the
             raw stale value. The end state after BOTH passes is :reagent."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories (fn [] (register-variant!) (register-substrates!))}
       (fn []
         ;; Seed a stale in-memory substrate so a no-op would leave it dirty.
-        (swap! ui-state/shell-state-atom assoc :substrate :uix)
+        (swap! rf.story.ui.state/shell-state-atom assoc :substrate :uix)
         (hydrate-from-url-params!
           {"variant"   "story.sample/card"
            "substrate" "ghost-substrate"})
-        (is (= :reagent (:substrate (ui-state/get-state)))
+        (is (= :reagent (:substrate (rf.story.ui.state/get-state)))
             "unregistered substrate= degrades to :reagent — pass 2 cannot
              revive the stale value it once reparsed without validation")
-        (is (= :story.sample/card (:selected-variant (ui-state/get-state)))
+        (is (= :story.sample/card (:selected-variant (rf.story.ui.state/get-state)))
             "the registered variant is still focused")))))
 
 ;; =========================================================================
@@ -126,14 +126,14 @@
             the end state has NO [:cell-overrides variant-id] slice (pass 1's
             unfiltered install is cleared by pass 2) AND the share-import
             drift hint records the dropped overrides."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories (fn [] (register-variant!) (register-substrates!))}
       (fn []
         ;; `:gone` + `:also-gone` are NOT in the variant's declared #{:label}.
         (hydrate-from-url-params!
           {"variant"   "story.sample/card"
            "overrides" (pr-str {:gone 1 :also-gone 2})})
-        (let [s (ui-state/get-state)]
+        (let [s (rf.story.ui.state/get-state)]
           (is (= :story.sample/card (:selected-variant s)))
           (is (nil? (get-in s [:cell-overrides :story.sample/card]))
               "all-stale overrides leave NO live slice — pass 2 clears the
@@ -150,14 +150,14 @@
   (testing "rf2-ovb1en — a registered non-default substrate= and a declared
             overrides= entry still hydrate after the complete sequence; the
             fix narrows pass 2, it does not break the happy path."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories (fn [] (register-variant!) (register-substrates!))}
       (fn []
         (hydrate-from-url-params!
           {"variant"   "story.sample/card"
            "substrate" "uix"
            "overrides" (pr-str {:label "Shared"})})
-        (let [s (ui-state/get-state)]
+        (let [s (rf.story.ui.state/get-state)]
           (is (= :uix (:substrate s))
               "a registered non-default substrate is kept (pass 1 validates,
                pass 2 leaves it alone)")

--- a/tools/story/test/re_frame/story/panels_e2e/share_url_state_popstate_stale_override_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/share_url_state_popstate_stale_override_dom_cljs_test.cljs
@@ -6,19 +6,19 @@
   `re-frame.story.ui.shell/hydrate-url-state!` runs TWO passes on mount
   (see the sibling `share-url-state-hydration-e2e-cljs-test`, rf2-ovb1en):
 
-      1. url-state/hydrate-from-url!  ← installs the RAW parsed
+      1. rf.story.ui.url-state/hydrate-from-url!  ← installs the RAW parsed
                                          `:cell-overrides` (pure, no
                                          registrar access)
-      2. share/hydrate-from-url!     ← the declared-key DRIFT filter
-                                         (`share/drop-stale-overrides`)
+      2. rf.story.ui.share/hydrate-from-url!     ← the declared-key DRIFT filter
+                                         (`rf.story.ui.share/drop-stale-overrides`)
                                          narrows/clears that slice + records
                                          the share-import drift hint
 
-  The popstate handler (`url-state/install-popstate-listener!`) used to
+  The popstate handler (`rf.story.ui.url-state/install-popstate-listener!`) used to
   wire ONLY pass 1 as its `apply-fn` — pass 2 never ran on Back/Forward, so
   a stale override (an arg-key the focused variant no longer declares,
   e.g. renamed/removed) installed as a live orphan arg with no drop/report,
-  unlike the mount path. The fix threads `share/hydrate-from-url!` through
+  unlike the mount path. The fix threads `rf.story.ui.share/hydrate-from-url!` through
   as `install-popstate-listener!`'s new `post-apply-fn`, run inside the
   SAME hydration guard as the base apply (`shell.cljs`'s wiring).
 
@@ -29,17 +29,17 @@
   window; `:node-test` also loads it (regex matches the suffix too) where
   the body self-gates on `(browser?)` and no-ops."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.story :as story]
-            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.story.ui.state :as ui-state]
-            [re-frame.story.ui.share :as share]
-            [re-frame.story.ui.url-state :as url-state]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.story :as rf.story]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.ui.share :as rf.story.ui.share]
+            [re-frame.story.ui.url-state :as rf.story.ui.url-state]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- browser gate ---------------------------------------------------------
 
@@ -53,17 +53,17 @@
 (defn- production-apply-fn []
   (let [validators {:variant? (fn [vid]
                                 (or (nil? vid)
-                                    (registrar/registered? :variant vid)))}]
+                                    (rf.story.registrar/registered? :variant vid)))}]
     (fn [state parsed]
-      (url-state/apply-parsed-to-state state parsed validators))))
+      (rf.story.ui.url-state/apply-parsed-to-state state parsed validators))))
 
 ;; A variant whose declared arg surface is exactly #{:label}. An
 ;; `overrides=` entry for any OTHER key is stale (the variant no longer
 ;; declares it) and must be dropped + reported by the declared-key filter —
 ;; on the popstate path exactly as on mount.
 (defn- register-variant! []
-  (story/reg-story :story.sample {:doc "Parent for the popstate-hydration e2e."})
-  (story/reg-variant :story.sample/card
+  (rf.story/reg-story :story.sample {:doc "Parent for the popstate-hydration e2e."})
+  (rf.story/reg-variant :story.sample/card
     {:doc      "A card variant declaring a single :label arg."
      :argtypes {:label {:type :string}}
      :args     {:label "Hello"}}))
@@ -77,23 +77,23 @@
             unfiltered install pass 1 alone would leave."
     (if-not (browser?)
       (is true ":node-test — no real window/history; :browser-test runs the real assertion")
-      (e2e/with-story-and-xray-frames
+      (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
         {:register-stories register-variant!}
         (fn []
           (let [orig-url (str (.-pathname (.-location js/window))
                               (.-search   (.-location js/window))
                               (.-hash     (.-location js/window)))]
             (try
-              (url-state/install-popstate-listener!
-                ui-state/shell-state-atom
+              (rf.story.ui.url-state/install-popstate-listener!
+                rf.story.ui.state/shell-state-atom
                 (production-apply-fn)
-                share/hydrate-from-url!)
+                rf.story.ui.share/hydrate-from-url!)
               (let [qs (str "?variant=" (js/encodeURIComponent "story.sample/card")
                             "&overrides=" (js/encodeURIComponent
                                             (pr-str {:gone 1 :also-gone 2})))]
                 (.pushState (.-history js/window) nil "" qs)
                 (.dispatchEvent js/window (js/PopStateEvent. "popstate" #js {})))
-              (let [s (ui-state/get-state)]
+              (let [s (rf.story.ui.state/get-state)]
                 (is (= :story.sample/card (:selected-variant s))
                     "the popstate applied the variant selection (pass 1)")
                 (is (nil? (get-in s [:cell-overrides :story.sample/card]))
@@ -105,7 +105,7 @@
                     "the drift hint is recorded on the popstate path,
                      mirroring mount hydration (rf2-9jthx)"))
               (finally
-                (url-state/remove-popstate-listener!)
+                (rf.story.ui.url-state/remove-popstate-listener!)
                 (try (.replaceState (.-history js/window) nil "" orig-url)
                      (catch :default _ nil))))))))))
 
@@ -115,28 +115,28 @@
             does not break the happy path)"
     (if-not (browser?)
       (is true ":node-test — no real window/history; :browser-test runs the real assertion")
-      (e2e/with-story-and-xray-frames
+      (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
         {:register-stories register-variant!}
         (fn []
           (let [orig-url (str (.-pathname (.-location js/window))
                               (.-search   (.-location js/window))
                               (.-hash     (.-location js/window)))]
             (try
-              (url-state/install-popstate-listener!
-                ui-state/shell-state-atom
+              (rf.story.ui.url-state/install-popstate-listener!
+                rf.story.ui.state/shell-state-atom
                 (production-apply-fn)
-                share/hydrate-from-url!)
+                rf.story.ui.share/hydrate-from-url!)
               (let [qs (str "?variant=" (js/encodeURIComponent "story.sample/card")
                             "&overrides=" (js/encodeURIComponent
                                             (pr-str {:label "Shared"})))]
                 (.pushState (.-history js/window) nil "" qs)
                 (.dispatchEvent js/window (js/PopStateEvent. "popstate" #js {})))
-              (let [s (ui-state/get-state)]
+              (let [s (rf.story.ui.state/get-state)]
                 (is (= {:label "Shared"} (get-in s [:cell-overrides :story.sample/card]))
                     "a declared override hydrates on popstate")
                 (is (nil? (get-in s [:rf.story/share-import-hint :story.sample/card]))
                     "no drift hint when nothing was dropped"))
               (finally
-                (url-state/remove-popstate-listener!)
+                (rf.story.ui.url-state/remove-popstate-listener!)
                 (try (.replaceState (.-history js/window) nil "" orig-url)
                      (catch :default _ nil))))))))))

--- a/tools/story/test/re_frame/story/panels_e2e/sidebar_glyphs_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/sidebar_glyphs_e2e_cljs_test.cljs
@@ -13,24 +13,24 @@
 
   ## What this catches
 
-  - **Story row → story-glyph wiring**: `sidebar/story-block` builds
-    `[:span {:style (:story-glyph styles)} [glyphs/story-glyph 13]]`
+  - **Story row → story-glyph wiring**: `rf.story.ui.sidebar/story-block` builds
+    `[:span {:style (:story-glyph styles)} [rf.story.theme.glyphs/story-glyph 13]]`
     as the first child of every story-row. A regression that removes
     the glyph slot (or wires the wrong glyph) would drop the iconic
     prefix and leave story labels visually indistinguishable from
     the variant labels indented underneath.
 
   - **Variant row → variant-glyph wiring (non-testable case)**:
-    `sidebar/variant-row` builds
-    `[:span {:style (:variant-glyph styles)} [glyphs/variant-glyph 10]]`
+    `rf.story.ui.sidebar/variant-row` builds
+    `[:span {:style (:variant-glyph styles)} [rf.story.theme.glyphs/variant-glyph 10]]`
     when the variant is NOT testable. A regression that drops the
     fallback glyph would leave non-testable variant rows visually
     indistinguishable from the status-dot rows underneath (or worse,
     leave a ragged left edge when the glyph slot is absent entirely).
 
   - **Workspace row → workspace-glyph wiring**:
-    `sidebar/workspace-row` builds
-    `[:span {:style (:workspace-glyph styles)} [glyphs/workspace-glyph 12]]`
+    `rf.story.ui.sidebar/workspace-row` builds
+    `[:span {:style (:workspace-glyph styles)} [rf.story.theme.glyphs/workspace-glyph 12]]`
     as the first child of every workspace-row. A regression that
     drops the glyph slot would erase the workspace iconography from
     the bottom section of the sidebar.
@@ -46,7 +46,7 @@
   ## Detection strategy
 
   `expand-tree` recursively invokes every fn-headed vector — which
-  means the inline `[glyphs/story-glyph 13]` vectors would expand
+  means the inline `[rf.story.theme.glyphs/story-glyph 13]` vectors would expand
   into the underlying SVG (a `:path`, `:circle`, four `:rect`s),
   losing the symbolic link to the glyph fn at the call site. To
   preserve a stable, role-typed marker through the walk, the tests
@@ -57,33 +57,33 @@
 
   Surface tested via hiccup walking; no DOM."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.story :as story]
-            [re-frame.story.theme.glyphs :as glyphs]
-            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
-            [re-frame.story.ui.sidebar :as sidebar]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.story :as rf.story]
+            [re-frame.story.theme.glyphs :as rf.story.theme.glyphs]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]
+            [re-frame.story.ui.sidebar :as rf.story.ui.sidebar]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- fixture -----------------------------------------------------------
 
 (defn- register-variants!
   "Two stories with one non-testable variant each, plus one workspace.
   No `:test` tag / `:script` slot → both variants take the non-testable
-  branch in `variant-row` (the branch that emits `[glyphs/variant-glyph
+  branch in `variant-row` (the branch that emits `[rf.story.theme.glyphs/variant-glyph
   10]`)."
   []
-  (story/reg-story :story.counter
+  (rf.story/reg-story :story.counter
     {:doc "Counter parent story."})
-  (story/reg-variant :story.counter/empty
+  (rf.story/reg-variant :story.counter/empty
     {:doc "empty counter" :setup []})
-  (story/reg-story :story.login
+  (rf.story/reg-story :story.login
     {:doc "Login parent story."})
-  (story/reg-variant :story.login/blank
+  (rf.story/reg-variant :story.login/blank
     {:doc "blank login form" :setup []})
-  (story/reg-workspace :Workspace.counter/all
+  (rf.story/reg-workspace :Workspace.counter/all
     {:doc      "Counter workspace."
      :layout   :grid
      :variants [:story.counter/empty]
@@ -104,13 +104,13 @@
 ;; ---- helpers -----------------------------------------------------------
 
 (defn- render-sidebar-tree
-  "`sidebar/sidebar` is a class-2 Reagent component — calling it
+  "`rf.story.ui.sidebar/sidebar` is a class-2 Reagent component — calling it
   returns the inner render fn. Invoking that returns hiccup; we walk
   the expanded tree so `story-block` / `variant-row` / `workspace-row`
   are surfaced as plain DOM-shaped hiccup with sentinel-glyph leaves."
   []
-  (let [render-fn (sidebar/sidebar)]
-    (e2e/expand-tree (render-fn nil))))
+  (let [render-fn (rf.story.ui.sidebar/sidebar)]
+    (rf.story.test-helpers.e2e-multi-frame/expand-tree (render-fn nil))))
 
 (defn- glyph-roles-under
   "Walk `node` and return the multiset of `[:rf-test-glyph <role>]`
@@ -131,7 +131,7 @@
   `[:div {:style (:story-row styles)} [:span ...] ...]` whose first
   inner span carries a `[:rf-test-glyph :story]` sentinel."
   [tree]
-  (->> (e2e/hiccup-seq tree)
+  (->> (rf.story.test-helpers.e2e-multi-frame/hiccup-seq tree)
        (filter (fn [node]
                  (and (vector? node)
                       (= :div (first node))
@@ -148,27 +148,27 @@
   "Every variant-row hiccup vector in the tree, located by the
   authoritative `:data-test=\"story-sidebar-variant-row\"` selector."
   [tree]
-  (e2e/find-all-by-test-id tree "story-sidebar-variant-row"))
+  (rf.story.test-helpers.e2e-multi-frame/find-all-by-test-id tree "story-sidebar-variant-row"))
 
 (defn- workspace-row-nodes
   "Every workspace-row hiccup vector in the tree, located by the
   authoritative `:data-test=\"story-sidebar-workspace-row\"` selector."
   [tree]
-  (e2e/find-all-by-test-id tree "story-sidebar-workspace-row"))
+  (rf.story.test-helpers.e2e-multi-frame/find-all-by-test-id tree "story-sidebar-workspace-row"))
 
 ;; ---- assertions --------------------------------------------------------
 
 (deftest story-rows-lead-with-story-glyph
   (testing "rf2-p0wur — every story-row in the sidebar carries a
-            `[glyphs/story-glyph]` as its first iconographic prefix.
+            `[rf.story.theme.glyphs/story-glyph]` as its first iconographic prefix.
             Two stories registered → at least two story rows in the
             tree, each with exactly one story-role sentinel underneath."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variants!}
       (fn []
-        (with-redefs [glyphs/story-glyph     story-glyph-stub
-                      glyphs/variant-glyph   variant-glyph-stub
-                      glyphs/workspace-glyph workspace-glyph-stub]
+        (with-redefs [rf.story.theme.glyphs/story-glyph     story-glyph-stub
+                      rf.story.theme.glyphs/variant-glyph   variant-glyph-stub
+                      rf.story.theme.glyphs/workspace-glyph workspace-glyph-stub]
           (let [tree  (render-sidebar-tree)
                 rows  (story-row-nodes tree)]
             (is (<= 2 (count rows))
@@ -180,16 +180,16 @@
 
 (deftest variant-rows-lead-with-variant-glyph
   (testing "rf2-p0wur — every non-testable variant-row carries a
-            `[glyphs/variant-glyph]` sentinel as the iconographic
+            `[rf.story.theme.glyphs/variant-glyph]` sentinel as the iconographic
             prefix in the variant-glyph branch of `variant-row`. Both
             registered variants are non-testable (no `:test` tag, no
             `:script`), so both rows take this branch."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variants!}
       (fn []
-        (with-redefs [glyphs/story-glyph     story-glyph-stub
-                      glyphs/variant-glyph   variant-glyph-stub
-                      glyphs/workspace-glyph workspace-glyph-stub]
+        (with-redefs [rf.story.theme.glyphs/story-glyph     story-glyph-stub
+                      rf.story.theme.glyphs/variant-glyph   variant-glyph-stub
+                      rf.story.theme.glyphs/workspace-glyph workspace-glyph-stub]
           (let [tree (render-sidebar-tree)
                 rows (variant-row-nodes tree)]
             (is (<= 2 (count rows))
@@ -198,19 +198,19 @@
                         rows)
                 "each variant row contains exactly one variant-role glyph
                  sentinel — the non-testable branch of variant-row wired
-                 `[glyphs/variant-glyph]` per rf2-p0wur")))))))
+                 `[rf.story.theme.glyphs/variant-glyph]` per rf2-p0wur")))))))
 
 (deftest workspace-rows-lead-with-workspace-glyph
   (testing "rf2-p0wur — every workspace-row carries a
-            `[glyphs/workspace-glyph]` sentinel as the iconographic
+            `[rf.story.theme.glyphs/workspace-glyph]` sentinel as the iconographic
             prefix. One workspace registered → one workspace row, with
             exactly one workspace-role sentinel underneath."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variants!}
       (fn []
-        (with-redefs [glyphs/story-glyph     story-glyph-stub
-                      glyphs/variant-glyph   variant-glyph-stub
-                      glyphs/workspace-glyph workspace-glyph-stub]
+        (with-redefs [rf.story.theme.glyphs/story-glyph     story-glyph-stub
+                      rf.story.theme.glyphs/variant-glyph   variant-glyph-stub
+                      rf.story.theme.glyphs/workspace-glyph workspace-glyph-stub]
           (let [tree (render-sidebar-tree)
                 rows (workspace-row-nodes tree)]
             (is (= 1 (count rows))
@@ -226,12 +226,12 @@
             wires the wrong glyph fn into a row (variant-glyph in a
             workspace row, etc.) surfaces as a mismatched role count
             instead of silently passing the per-row checks above."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variants!}
       (fn []
-        (with-redefs [glyphs/story-glyph     story-glyph-stub
-                      glyphs/variant-glyph   variant-glyph-stub
-                      glyphs/workspace-glyph workspace-glyph-stub]
+        (with-redefs [rf.story.theme.glyphs/story-glyph     story-glyph-stub
+                      rf.story.theme.glyphs/variant-glyph   variant-glyph-stub
+                      rf.story.theme.glyphs/workspace-glyph workspace-glyph-stub]
           (let [tree            (render-sidebar-tree)
                 variant-rows    (variant-row-nodes tree)
                 workspace-rows  (workspace-row-nodes tree)]
@@ -257,12 +257,12 @@
             activate them. Without these, the sidebar's `<nav>` landmark
             is reachable but rows inside it aren't — keyboard users
             can't select a variant from the sidebar at all."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variants!}
       (fn []
-        (with-redefs [glyphs/story-glyph     story-glyph-stub
-                      glyphs/variant-glyph   variant-glyph-stub
-                      glyphs/workspace-glyph workspace-glyph-stub]
+        (with-redefs [rf.story.theme.glyphs/story-glyph     story-glyph-stub
+                      rf.story.theme.glyphs/variant-glyph   variant-glyph-stub
+                      rf.story.theme.glyphs/workspace-glyph workspace-glyph-stub]
           (let [tree (render-sidebar-tree)
                 rows (variant-row-nodes tree)]
             (is (<= 2 (count rows)))
@@ -290,12 +290,12 @@
             `<div>`s that must expose `role=\"button\"` + `tabindex=\"0\"`
             + a key handler. Without these the workspace section of the
             sidebar is unreachable from the keyboard."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variants!}
       (fn []
-        (with-redefs [glyphs/story-glyph     story-glyph-stub
-                      glyphs/variant-glyph   variant-glyph-stub
-                      glyphs/workspace-glyph workspace-glyph-stub]
+        (with-redefs [rf.story.theme.glyphs/story-glyph     story-glyph-stub
+                      rf.story.theme.glyphs/variant-glyph   variant-glyph-stub
+                      rf.story.theme.glyphs/workspace-glyph workspace-glyph-stub]
           (let [tree (render-sidebar-tree)
                 rows (workspace-row-nodes tree)]
             (is (= 1 (count rows)))

--- a/tools/story/test/re_frame/story/panels_e2e/sidebar_search_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/sidebar_search_e2e_cljs_test.cljs
@@ -34,45 +34,45 @@
 
   Sub-millisecond per case; no DOM."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.story :as story]
-            [re-frame.story.ui.sidebar :as sidebar]
-            [re-frame.story.ui.sidebar-search :as search]
-            [re-frame.story.ui.state :as ui-state]
-            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.story :as rf.story]
+            [re-frame.story.ui.sidebar :as rf.story.ui.sidebar]
+            [re-frame.story.ui.sidebar-search :as rf.story.ui.sidebar-search]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; A canonical fixture: two stories, four variants. The names are
 ;; chosen so the AND-token discriminator has distinct hits for each
 ;; query the tests below issue.
 
 (defn- register-variants! []
-  (story/reg-story :story.counter
+  (rf.story/reg-story :story.counter
     {:doc "Counter parent story."})
-  (story/reg-variant :story.counter/empty
+  (rf.story/reg-variant :story.counter/empty
     {:doc "empty counter" :setup []})
-  (story/reg-variant :story.counter/at-five
+  (rf.story/reg-variant :story.counter/at-five
     {:doc "counter pre-seeded at five" :setup []})
-  (story/reg-story :story.login
+  (rf.story/reg-story :story.login
     {:doc "Login parent story."})
-  (story/reg-variant :story.login/blank
+  (rf.story/reg-variant :story.login/blank
     {:doc "blank login form" :setup []})
-  (story/reg-variant :story.login/loaded
+  (rf.story/reg-variant :story.login/loaded
     {:doc "login pre-populated" :setup []}))
 
 ;; ---- helpers: walk the sidebar's expanded hiccup to drive search --------
 
 (defn- render-sidebar
-  "`sidebar/sidebar` is a class-2 Reagent component — calling it
+  "`rf.story.ui.sidebar/sidebar` is a class-2 Reagent component — calling it
   returns the inner render fn. Invoking THAT returns the actual
   hiccup. Returns a tuple `[render-fn first-tree]` so the caller can
   re-render after mutating the closure-bound ratom (`on-change`'s
   side effect)."
   []
-  (let [render-fn (sidebar/sidebar)
+  (let [render-fn (rf.story.ui.sidebar/sidebar)
         first-tree (render-fn nil)]
     [render-fn first-tree]))
 
@@ -80,7 +80,7 @@
   "Locate the search `<input>` node by data-test attribute. Returns
   the hiccup vector."
   [tree]
-  (e2e/find-by-test-id tree "story-sidebar-search-input"))
+  (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-sidebar-search-input"))
 
 (defn- type-query!
   "Invoke the search input's `:on-change` with a synthetic event
@@ -89,13 +89,13 @@
   filtered tree."
   [tree q]
   (let [input   (search-input-node tree)
-        on-chg  (e2e/handler-for input :on-change)]
-    (when on-chg (on-chg (e2e/fake-event {:value q})))))
+        on-chg  (rf.story.test-helpers.e2e-multi-frame/handler-for input :on-change)]
+    (when on-chg (on-chg (rf.story.test-helpers.e2e-multi-frame/fake-event {:value q})))))
 
 (defn- variant-rows
   "Every `story-sidebar-variant-row` node in the expanded tree."
   [tree]
-  (e2e/find-all-by-test-id tree "story-sidebar-variant-row"))
+  (rf.story.test-helpers.e2e-multi-frame/find-all-by-test-id tree "story-sidebar-variant-row"))
 
 (defn- visible-variant-ids
   "Pull `:data-variant` strings off each variant row; this is what
@@ -110,7 +110,7 @@
 
 (deftest empty-query-renders-every-variant
   (testing "with no search query, the sidebar renders all 4 variants"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variants!}
       (fn []
         (let [[_ tree] (render-sidebar)
@@ -127,7 +127,7 @@
 (deftest typed-query-narrows-to-counter-rows
   (testing "typing `counter` narrows the tree to the counter parent +
             its variants only (login variants drop out)"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variants!}
       (fn []
         (let [[render tree-before] (render-sidebar)]
@@ -144,7 +144,7 @@
 (deftest typed-query-narrows-by-variant-name
   (testing "typing `five` narrows to the single variant whose id
             contains the substring"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variants!}
       (fn []
         (let [[render tree-before] (render-sidebar)]
@@ -156,7 +156,7 @@
 
 (deftest typed-query-clears-back-to-full-tree
   (testing "Clearing the search (back to empty) restores every variant"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variants!}
       (fn []
         (let [[render tree-before] (render-sidebar)]
@@ -178,15 +178,15 @@
             `filter-grouped-tree` returns when given the same registry
             + query. Pins the integration between the live sidebar and
             the pure helper so the two cannot drift."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variants!}
       (fn []
         (let [[render tree-0] (render-sidebar)]
           (type-query! tree-0 "login")
-          (let [registry-snapshot (ui-state/registry-snapshot)
-                grouped-all       (ui-state/group-variants-by-story
+          (let [registry-snapshot (rf.story.ui.state/registry-snapshot)
+                grouped-all       (rf.story.ui.state/group-variants-by-story
                                     (:variants registry-snapshot))
-                pure-filtered     (search/filter-grouped-tree grouped-all "login")
+                pure-filtered     (rf.story.ui.sidebar-search/filter-grouped-tree grouped-all "login")
                 pure-variant-ids  (->> pure-filtered
                                        (mapcat :variants)
                                        (map (fn [[vid _]] (str vid)))

--- a/tools/story/test/re_frame/story/panels_e2e/toolbar_clusters_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/toolbar_clusters_e2e_cljs_test.cljs
@@ -34,22 +34,22 @@
 
   Surface tested via hiccup walking; no DOM."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.story :as story]
-            [re-frame.story.ui.state :as ui-state]
-            [re-frame.story.ui.toolbar :as toolbar]
-            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.story :as rf.story]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.ui.toolbar :as rf.story.ui.toolbar]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- register-modes! []
-  (story/reg-mode :Mode.theme/dark
+  (rf.story/reg-mode :Mode.theme/dark
     {:axis :theme :args {:theme :dark}  :doc "Dark theme"})
-  (story/reg-mode :Mode.theme/light
+  (rf.story/reg-mode :Mode.theme/light
     {:axis :theme :args {:theme :light} :doc "Light theme"})
-  (story/reg-mode :Mode.app/compact
+  (rf.story/reg-mode :Mode.app/compact
     {:args {:compact? true} :doc "Compact layout"}))
 
 (defn- register-with-variant! []
@@ -57,19 +57,19 @@
   ;; A variant must exist for the DATA cluster to render — the cluster
   ;; gates on `:selected-variant`. Without it the rendered strip skips
   ;; the data divider.
-  (story/reg-story :story.counter {:doc "Counter story for toolbar e2e."})
-  (story/reg-variant :story.counter/v {:setup []})
-  (e2e/select-variant! :story.counter/v))
+  (rf.story/reg-story :story.counter {:doc "Counter story for toolbar e2e."})
+  (rf.story/reg-variant :story.counter/v {:setup []})
+  (rf.story.test-helpers.e2e-multi-frame/select-variant! :story.counter/v))
 
 (defn- render-toolbar []
-  (toolbar/toolbar-strip))
+  (rf.story.ui.toolbar/toolbar-strip))
 
 (defn- chip-for
   "Locate the chip hiccup node for `mode-id` by walking the expanded
   toolbar tree. Returns nil if the chip isn't rendered (e.g. mode
   not registered, or the chip was dropped from the catalog)."
   [tree mode-id]
-  (e2e/find-by-data-attr tree :data-toolbar-mode (pr-str mode-id)))
+  (rf.story.test-helpers.e2e-multi-frame/find-by-data-attr tree :data-toolbar-mode (pr-str mode-id)))
 
 (defn- chip-active?
   "Read `:aria-pressed` off the chip — the toolbar emits `\"true\"` or
@@ -100,11 +100,11 @@
             MODES / DATA / VIEW / DEBUG / REC. Each carries the
             canonical `:data-cluster` label so visual + test corpora
             can locate them."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-with-variant!}
       (fn []
         (let [tree     (render-toolbar)
-              clusters (e2e/find-all-by-test-id tree "story-toolbar-cluster")
+              clusters (rf.story.test-helpers.e2e-multi-frame/find-all-by-test-id tree "story-toolbar-cluster")
               labels   (set (map (fn [n] (get-in n [1 :data-cluster]))
                                  clusters))]
           (is (>= (count clusters) 5)
@@ -121,7 +121,7 @@
   (testing "rf2-v58dm — clicking a chip toggles `:active-modes` AND
             the chip's aria-pressed flips AND the chip's style merges
             the `:chip-active` overlay"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-modes!}
       (fn []
         (let [tree-0 (render-toolbar)
@@ -130,10 +130,10 @@
           (is (false? (chip-active? chip-0))
               "dark chip starts inactive (default :active-modes empty)")
           ;; Click the dark chip.
-          (let [on-click (e2e/handler-for chip-0 :on-click)]
+          (let [on-click (rf.story.test-helpers.e2e-multi-frame/handler-for chip-0 :on-click)]
             (is (fn? on-click) ":on-click wired on the chip")
-            (on-click (e2e/fake-event {})))
-          (is (= [:Mode.theme/dark] (:active-modes (ui-state/get-state)))
+            (on-click (rf.story.test-helpers.e2e-multi-frame/fake-event {})))
+          (is (= [:Mode.theme/dark] (:active-modes (rf.story.ui.state/get-state)))
               "the shell ratom's :active-modes vector flipped")
           ;; Re-render — chip-active? + the style merge should reflect
           ;; the new state.
@@ -148,18 +148,18 @@
   (testing "rf2-v58dm + spec/010 §Selection semantics — clicking a
             theme chip when another theme chip is active evicts the
             sibling. The rendered hiccup mirrors the eviction."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-modes!}
       (fn []
         ;; Pre-state: dark active.
-        (toolbar/toggle-mode! :Mode.theme/dark)
-        (is (= [:Mode.theme/dark] (:active-modes (ui-state/get-state))))
+        (rf.story.ui.toolbar/toggle-mode! :Mode.theme/dark)
+        (is (= [:Mode.theme/dark] (:active-modes (rf.story.ui.state/get-state))))
         ;; Click light chip.
         (let [tree     (render-toolbar)
               light    (chip-for tree :Mode.theme/light)
-              on-click (e2e/handler-for light :on-click)]
-          (on-click (e2e/fake-event {})))
-        (is (= [:Mode.theme/light] (:active-modes (ui-state/get-state)))
+              on-click (rf.story.test-helpers.e2e-multi-frame/handler-for light :on-click)]
+          (on-click (rf.story.test-helpers.e2e-multi-frame/fake-event {})))
+        (is (= [:Mode.theme/light] (:active-modes (rf.story.ui.state/get-state)))
             "dark evicted, light alone in :active-modes (axis = :theme)")
         ;; Re-render — dark chip is now inactive, light chip is active.
         (let [tree    (render-toolbar)
@@ -173,11 +173,11 @@
 (deftest unaxed-modes-coexist
   (testing "an un-axis-tagged mode coexists with axis-tagged modes —
             clicking compact when dark is active leaves both on"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-modes!}
       (fn []
-        (toolbar/toggle-mode! :Mode.theme/dark)
-        (toolbar/toggle-mode! :Mode.app/compact)
+        (rf.story.ui.toolbar/toggle-mode! :Mode.theme/dark)
+        (rf.story.ui.toolbar/toggle-mode! :Mode.app/compact)
         (let [tree    (render-toolbar)
               dark    (chip-for tree :Mode.theme/dark)
               compact (chip-for tree :Mode.app/compact)]
@@ -190,10 +190,10 @@
 (deftest empty-state-renders-placeholder
   (testing "no modes registered → MODES cluster renders the
             empty-state placeholder rather than chips"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}  ;; no register-stories — registry is empty.
       (fn []
         (let [tree (render-toolbar)]
           ;; the placeholder is text content; assert it shows up.
-          (is (re-find #"no modes registered" (e2e/text-nodes tree))
+          (is (re-find #"no modes registered" (rf.story.test-helpers.e2e-multi-frame/text-nodes tree))
               "empty-state text rendered when registrar has no :mode entries"))))))

--- a/tools/story/test/re_frame/story/panels_e2e/variant_lifecycle_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/variant_lifecycle_e2e_cljs_test.cljs
@@ -29,19 +29,19 @@
   loader-success / loader-never-completes / loader-rejects, switching
   to `test` mode and asserting the test-pane's reason text included
   the canonical strings. This test gets the same coverage by
-  driving `story/run-variant` directly + reading the result-map's
+  driving `rf.story/run-variant` directly + reading the result-map's
   `:lifecycle` and `:assertions` slots — sub-second per surface."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story :as story]
-            [re-frame.story.async :as async-lib]
-            [re-frame.story.loaders :as loaders]
-            [re-frame.story.ui.canvas :as canvas]
-            [re-frame.subs :as subs]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.async :as rf.story.async]
+            [re-frame.story.loaders :as rf.story.loaders]
+            [re-frame.story.ui.canvas :as rf.story.ui.canvas]
+            [re-frame.subs :as rf.subs]))
 
 ;; Async tests need a map-form fixture so cljs.test's `async` body
 ;; can suspend around the per-test boundary. Mirrors the proven reset
@@ -55,23 +55,23 @@
 (declare register-lifecycle-variants!)
 
 (defn- reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
   ;; Re-register the machines artefact's framework-shipped `:rf/machine`
   ;; sub after the registrar clear. EP-0001 (rf2-vzld77 / rf2-ixb0bq):
   ;; machine snapshots are durable RUNTIME-DB state at
   ;; [:rf.runtime/machines :snapshots <id>], so this is a runtime-db sub
   ;; (db-position arg is the runtime-db value) — mirror `re-frame.machines`,
   ;; NOT the retired app-db `:rf/runtime` path.
-  (subs/reg-runtime-sub :rf/machine
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [runtime-db [_ machine-id]]
       (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (register-lifecycle-variants!))
 
 (use-fixtures :each {:before reset-all!})
@@ -101,19 +101,19 @@
 
 (defn- register-lifecycle-variants! []
   (install-counter-events!)
-  (story/reg-story :story.counter-matrix
+  (rf.story/reg-story :story.counter-matrix
     {:doc "Matrix parent for the lifecycle e2e tests."})
-  (story/reg-variant :story.counter-matrix/loader-success
+  (rf.story/reg-variant :story.counter-matrix/loader-success
     {:doc    "Default-success loader → lifecycle reaches :ready."
      :loaders [[:counter/initialise 5]]
      :setup  [[:counter/inc]]})
-  (story/reg-variant :story.counter-matrix/loader-never-completes
+  (rf.story/reg-variant :story.counter-matrix/loader-never-completes
     {:doc "rf2-qrk2s class — `:loaders-complete-when` returns false; the
            lifecycle parks at :loading, no events/play, a non-throwing
            `:rf.error/loader-incomplete` assertion is recorded."
      :loaders               [[:counter/loader-never-ready?]]
      :loaders-complete-when :counter/loader-never-ready?})
-  (story/reg-variant :story.counter-matrix/loader-rejects
+  (rf.story/reg-variant :story.counter-matrix/loader-rejects
     {:doc "rf2-qrk2s class — the loader event throws; the runtime
            captures the exception into the assertions vector and
            rejection records phase = :phase-1-loaders."
@@ -125,8 +125,8 @@
   (testing "loader-success variant runs cleanly: lifecycle is :ready,
             no error assertions, the loader event committed to app-db"
     (async done
-      (-> (story/run-variant :story.counter-matrix/loader-success)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.counter-matrix/loader-success)
+          (rf.story.async/then
             (fn [result]
               (is (= :ready (:lifecycle result))
                   "lifecycle reached :ready after the four phases")
@@ -137,7 +137,7 @@
                                         (= :rf.error/loader-incomplete (:assertion a))))
                                   (:assertions result)))
                   "no error assertions on a clean run")
-              (story/destroy-variant! :story.counter-matrix/loader-success)
+              (rf.story/destroy-variant! :story.counter-matrix/loader-success)
               (done)))))))
 
 ;; ---- the re-registered :rf/machine sub reads the LIVE runtime-db snapshot
@@ -155,8 +155,8 @@
   (testing ":rf/machine computed against the variant frame-state resolves
             the live lifecycle snapshot off runtime-db, not nil"
     (async done
-      (-> (story/run-variant :story.counter-matrix/loader-success)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.counter-matrix/loader-success)
+          (rf.story.async/then
             (fn [_result]
               (let [variant-id :story.counter-matrix/loader-success
                     fs   (rf/frame-state-value variant-id)
@@ -167,7 +167,7 @@
                      the live runtime-db partition, not the dead app-db path")
                 (is (= :ready (:state snap))
                     "the live snapshot's :state is :ready after a clean run"))
-              (story/destroy-variant! :story.counter-matrix/loader-success)
+              (rf.story/destroy-variant! :story.counter-matrix/loader-success)
               (done)))))))
 
 ;; ---- parked: loaders-complete-when never returns true -------------------
@@ -178,8 +178,8 @@
             :rf.error/loader-incomplete assertion. Events + play
             were skipped — :app-db reflects the loader-side write only."
     (async done
-      (-> (story/run-variant :story.counter-matrix/loader-never-completes)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.counter-matrix/loader-never-completes)
+          (rf.story.async/then
             (fn [result]
               (is (= :loading (:lifecycle result))
                   "lifecycle parked at :loading (no advance to :ready)")
@@ -201,10 +201,10 @@
               (testing "rf2-qrk2s — loading-phase? still gates the
                         skeleton false when assertions are recorded,
                         so the canvas can render the user's view"
-                (is (false? (canvas/loading-phase? :loading false true))
+                (is (false? (rf.story.ui.canvas/loading-phase? :loading false true))
                     "assertions-recorded? overrides the loading-phase
                      skeleton gate"))
-              (story/destroy-variant! :story.counter-matrix/loader-never-completes)
+              (rf.story/destroy-variant! :story.counter-matrix/loader-never-completes)
               (done)))))))
 
 ;; ---- rejected: loader event throws --------------------------------------
@@ -215,8 +215,8 @@
             :phase :phase-1-loaders + the canonical ex-data carries
             through. The lifecycle does NOT advance to :ready."
     (async done
-      (-> (story/run-variant :story.counter-matrix/loader-rejects)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.counter-matrix/loader-rejects)
+          (rf.story.async/then
             (fn [result]
               (let [rejection (some (fn [a]
                                       (when (and (= :rf.error/exception
@@ -234,7 +234,7 @@
                        (:event rejection))
                     ":event slot carries the canonical source event
                      so the test-pane reason text can include it"))
-              (story/destroy-variant! :story.counter-matrix/loader-rejects)
+              (rf.story/destroy-variant! :story.counter-matrix/loader-rejects)
               (done)))))))
 
 ;; ---- lifecycle state advance --------------------------------------------
@@ -250,15 +250,15 @@
           ;; installed by install-canonical-vocabulary! in the fixture.
           _ (rf/make-frame {:id variant-id})]
       ;; Before any transition.
-      (is (= :pre-mount (loaders/current-state variant-id))
+      (is (= :pre-mount (rf.story.loaders/current-state variant-id))
           "fresh frame → :pre-mount")
-      (loaders/mount! variant-id)
-      (is (= :mounting (loaders/current-state variant-id))
+      (rf.story.loaders/mount! variant-id)
+      (is (= :mounting (rf.story.loaders/current-state variant-id))
           ":mount transition → :mounting")
-      (loaders/start-loaders! variant-id)
-      (is (= :loading (loaders/current-state variant-id))
+      (rf.story.loaders/start-loaders! variant-id)
+      (is (= :loading (rf.story.loaders/current-state variant-id))
           ":loaders-started → :loading")
-      (loaders/finish-loaders! variant-id)
-      (loaders/finish-events! variant-id)
-      (is (= :ready (loaders/current-state variant-id))
+      (rf.story.loaders/finish-loaders! variant-id)
+      (rf.story.loaders/finish-events! variant-id)
+      (is (= :ready (rf.story.loaders/current-state variant-id))
           "events-complete → :ready"))))

--- a/tools/story/test/re_frame/story/panels_e2e/viewport_indicator_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/viewport_indicator_e2e_cljs_test.cljs
@@ -21,7 +21,7 @@
       viewport-switcher/effective-viewport
             │
             ▼
-      framed-canvas → [canvas/viewport-indicator vp]
+      framed-canvas → [rf.story.ui.canvas/viewport-indicator vp]
             │
             ▼
       Hiccup: [:div {:data-test \"story-canvas-viewport-indicator\"
@@ -50,22 +50,22 @@
 
   Sub-millisecond per case; no DOM mount, no React, no Playwright."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.story :as story]
-            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
-            [re-frame.story.ui.canvas :as canvas]
-            [re-frame.story.ui.state :as ui-state]
-            [re-frame.story.ui.viewport-switcher :as vs]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.story :as rf.story]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]
+            [re-frame.story.ui.canvas :as rf.story.ui.canvas]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.ui.viewport-switcher :as rf.story.ui.viewport-switcher]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- helpers: render the indicator from effective-viewport --------------
 ;;
 ;; `framed-canvas` is `defn-` in shell.cljs; to exercise the indicator
 ;; render seam here we follow the same composition the shell does —
-;; resolve the effective viewport, then invoke `canvas/viewport-indicator`
+;; resolve the effective viewport, then invoke `rf.story.ui.canvas/viewport-indicator`
 ;; on the result. This is the exact code path the live shell drives.
 
 (defn- render-indicator-from-shell-state
@@ -73,8 +73,8 @@
   the live shell-state-atom + registrar) — the same composition the
   shell's `framed-canvas` performs at runtime."
   []
-  (let [vp (vs/effective-viewport)]
-    (canvas/viewport-indicator vp)))
+  (let [vp (rf.story.ui.viewport-switcher/effective-viewport)]
+    (rf.story.ui.canvas/viewport-indicator vp)))
 
 (defn- indicator-attrs
   "Extract the attrs map of a rendered indicator hiccup tree, or nil
@@ -98,7 +98,7 @@
             resolves to `:full` (no width/height) and the indicator
             self-elides (returns nil). Pinning the inverse here ensures
             the later 'indicator-renders' tests can't be trivial-pass."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
         (is (nil? (render-indicator-from-shell-state))
@@ -111,10 +111,10 @@
             slot; `effective-viewport` reads through it; the indicator
             renders the canonical \"375 × 667\" text with the
             `data-viewport-dims` attribute matching."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
-        (vs/select! :mobile-portrait)
+        (rf.story.ui.viewport-switcher/select! :mobile-portrait)
         (let [hiccup (render-indicator-from-shell-state)
               attrs  (indicator-attrs hiccup)
               text   (indicator-text hiccup)]
@@ -133,16 +133,16 @@
   (testing "rf2-f9xkq — calling `select!` with a different preset
             updates the indicator's rendered text. Catches the
             'indicator stuck on first selection' class of regression."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
-        (vs/select! :mobile-portrait)
+        (rf.story.ui.viewport-switcher/select! :mobile-portrait)
         (is (= "375 × 667" (indicator-text (render-indicator-from-shell-state)))
             "first selection lands the mobile-portrait dims")
-        (vs/select! :desktop)
+        (rf.story.ui.viewport-switcher/select! :desktop)
         (is (= "1280 × 800" (indicator-text (render-indicator-from-shell-state)))
             "switching to :desktop updates the chip to 1280 × 800")
-        (vs/select! :tablet)
+        (rf.story.ui.viewport-switcher/select! :tablet)
         (is (= "768 × 1024" (indicator-text (render-indicator-from-shell-state)))
             "switching to :tablet updates the chip to 768 × 1024")))))
 
@@ -153,13 +153,13 @@
             (the no-resize default) re-elides the indicator. Pins the
             'sized → unsized → no chip' transition so a regression that
             kept a stale chip after un-selection would surface."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
-        (vs/select! :tablet)
+        (rf.story.ui.viewport-switcher/select! :tablet)
         (is (some? (render-indicator-from-shell-state))
             "sized preset → indicator rendered")
-        (vs/select! :full)
+        (rf.story.ui.viewport-switcher/select! :full)
         (is (nil? (render-indicator-from-shell-state))
             "back to :full → indicator self-elides")))))
 
@@ -170,10 +170,10 @@
             the indicator with the custom dimensions. Pins the custom-
             entry path (the dropdown's Width × Height row at the
             bottom)."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {}
       (fn []
-        (vs/select! {:width 1024 :height 600})
+        (rf.story.ui.viewport-switcher/select! {:width 1024 :height 600})
         (let [hiccup (render-indicator-from-shell-state)
               text   (indicator-text hiccup)]
           (is (some? hiccup)
@@ -187,17 +187,17 @@
   (testing "rf2-f9xkq — when a variant body declares `:viewport`, that
             override wins over the toolbar's selection at indicator-
             render time. Per spec/014 §`:viewport` body slot."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories
        (fn []
-         (story/reg-story* :story.vp-override
+         (rf.story/reg-story* :story.vp-override
            {:doc "viewport override fixture" :component :ignored})
-         (story/reg-variant* :story.vp-override/v
+         (rf.story/reg-variant* :story.vp-override/v
            {:doc "child with :viewport override"
             :viewport :tablet}))}
       (fn []
-        (vs/select! :mobile-portrait)
-        (swap! ui-state/shell-state-atom
+        (rf.story.ui.viewport-switcher/select! :mobile-portrait)
+        (swap! rf.story.ui.state/shell-state-atom
                assoc :selected-variant :story.vp-override/v)
         (is (= "768 × 1024" (indicator-text (render-indicator-from-shell-state)))
             "variant body's `:viewport :tablet` wins over toolbar's

--- a/tools/story/test/re_frame/story/panels_e2e/xray_embed_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/xray_embed_e2e_cljs_test.cljs
@@ -56,12 +56,12 @@
 
   Sub-second per surface; no DOM / no React mount / no Playwright."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.story :as story]
-            [re-frame.story.ui.xray-embed :as xray-embed]
-            [re-frame.story.ui.state :as ui-state]
-            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.story :as rf.story]
+            [re-frame.story.ui.xray-embed :as rf.story.ui.xray-embed]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]
             [day8.re-frame2-xray.test-helpers.e2e-multi-frame :as xray-e2e]
             [day8.re-frame2-xray.test-helpers.host-fixtures.counter :as counter]))
 
@@ -76,7 +76,7 @@
 ;; stub. The stub fixture is no longer needed.
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; A minimal variant registration the embed-surface tests depend on —
 ;; the embed reads `:selected-variant` off the shell ratom; resolving
@@ -87,9 +87,9 @@
 (def ^:private variant-id :story.counter/loaded)
 
 (defn- register-variant! []
-  (story/reg-story :story.counter
+  (rf.story/reg-story :story.counter
     {:doc "Counter parent story for the e2e embed tests."})
-  (story/reg-variant variant-id
+  (rf.story/reg-variant variant-id
     {:doc    "Counter seeded at 5 — exercises the default embed path."
      :setup [[:counter/initialise]]}))
 
@@ -103,12 +103,12 @@
     ;; regression where one is dropped (the chip-row would silently lose
     ;; an affordance) or a new panel sneaks into the catalog without a
     ;; deliberate design decision.
-    (is (= 6 (count xray-embed/panel-catalog))
+    (is (= 6 (count rf.story.ui.xray-embed/panel-catalog))
         "6 panels in the chip-row catalog (rf2-v1ach; rf2-gbz39 dropped :issues)")
     (is (= #{:epoch :app-db :views :trace :machines :routing}
-           xray-embed/panel-ids)
+           rf.story.ui.xray-embed/panel-ids)
         "panel-ids set matches the catalog")
-    (is (= :epoch xray-embed/default-panel)
+    (is (= :epoch rf.story.ui.xray-embed/default-panel)
         "default-panel is :epoch (catalog's first entry, the
          most-common diagnostic lens)")))
 
@@ -116,29 +116,29 @@
   (testing "rf2-senbl — every catalogued panel-id resolves to a callable
             mount-fn via `mount-fn-for` (compile-time symbol resolution,
             not a runtime `find-ns-obj` walk)"
-    (doseq [pid xray-embed/panel-ids]
-      (is (fn? (xray-embed/mount-fn-for pid))
+    (doseq [pid rf.story.ui.xray-embed/panel-ids]
+      (is (fn? (rf.story.ui.xray-embed/mount-fn-for pid))
           (str "mount-fn-for " pid " returned a callable — rf2-senbl
                 regression class")))
     (testing "unknown panel-id → nil (graceful, not throw)"
-      (is (nil? (xray-embed/mount-fn-for :no-such-panel))))))
+      (is (nil? (rf.story.ui.xray-embed/mount-fn-for :no-such-panel))))))
 
 ;; ---- embed surface paint ------------------------------------------------
 
 (deftest xray-embed-paints-with-default-panel
   (testing "after selecting a variant the embed renders with
             data-active-panel = event-detail + a chip per panel"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variant!}
       (fn []
-        (e2e/select-variant! variant-id)
-        (let [tree    (xray-embed/xray-embed-panel)
-              wrapper (e2e/find-by-test-id tree "story-xray-embed")
-              chips   (e2e/find-all-by-test-id tree "story-xray-panel-chip")
+        (rf.story.test-helpers.e2e-multi-frame/select-variant! variant-id)
+        (let [tree    (rf.story.ui.xray-embed/xray-embed-panel)
+              wrapper (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-xray-embed")
+              chips   (rf.story.test-helpers.e2e-multi-frame/find-all-by-test-id tree "story-xray-panel-chip")
               panel-host-slot (some (fn [child]
                                       (when (and (vector? child)
                                                  (= 2 (count child))
-                                                 (contains? xray-embed/panel-ids
+                                                 (contains? rf.story.ui.xray-embed/panel-ids
                                                             (second child)))
                                         child))
                                     wrapper)]
@@ -161,12 +161,12 @@
 
 (deftest xray-embed-empty-state-without-variant
   (testing "no :selected-variant → embed renders the empty-state hiccup"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variant!}
       (fn []
         ;; Do NOT set :selected-variant — the shell-state defaults to nil.
-        (let [tree  (xray-embed/xray-embed-panel)
-              empty (e2e/find-by-test-id tree "story-xray-embed-empty")]
+        (let [tree  (rf.story.ui.xray-embed/xray-embed-panel)
+              empty (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-xray-embed-empty")]
           (is (some? empty)
               "empty-state element present when no variant selected"))))))
 
@@ -176,29 +176,29 @@
   (testing "rf2-senbl + rf2-v1ach — clicking the App-db chip swaps the
             resolved panel-id; embed wrapper re-renders with the new
             data-active-panel"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variant!}
       (fn []
-        (e2e/select-variant! variant-id)
-        (let [tree-before (xray-embed/xray-embed-panel)
-              app-db-chip (e2e/find-by-data-attr tree-before
+        (rf.story.test-helpers.e2e-multi-frame/select-variant! variant-id)
+        (let [tree-before (rf.story.ui.xray-embed/xray-embed-panel)
+              app-db-chip (rf.story.test-helpers.e2e-multi-frame/find-by-data-attr tree-before
                                                   :data-xray-panel "app-db")]
           (is (some? app-db-chip)
               "App-db chip present in the picker")
           ;; Invoke the on-click handler — same write the user does in
           ;; the browser. This dispatches a swap-state! on the shell
           ;; ratom's :xray-panel slot.
-          (let [handler (e2e/handler-for app-db-chip :on-click)]
+          (let [handler (rf.story.test-helpers.e2e-multi-frame/handler-for app-db-chip :on-click)]
             (is (fn? handler) ":on-click wired on App-db chip")
-            (handler (e2e/fake-event {})))
+            (handler (rf.story.test-helpers.e2e-multi-frame/fake-event {})))
           ;; Re-render the embed with the new state.
-          (let [tree-after (xray-embed/xray-embed-panel)
-                wrapper    (e2e/find-by-test-id tree-after "story-xray-embed")]
+          (let [tree-after (rf.story.ui.xray-embed/xray-embed-panel)
+                wrapper    (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree-after "story-xray-embed")]
             (is (= "app-db" (get-in wrapper [1 :data-active-panel]))
                 "data-active-panel flipped to app-db after the chip click —
                  effective-panel honours the user override (rf2-v1ach)")
-            (is (= :app-db (xray-embed/effective-panel
-                             (ui-state/get-state) variant-id))
+            (is (= :app-db (rf.story.ui.xray-embed/effective-panel
+                             (rf.story.ui.state/get-state) variant-id))
                 "effective-panel resolves the override directly")))))))
 
 ;; ---- lazy Xray-diff mounting: no compute on a collapsed embed -----------
@@ -223,31 +223,31 @@
   (some (fn [child]
           (when (and (vector? child)
                      (= 2 (count child))
-                     (contains? xray-embed/panel-ids (second child)))
+                     (contains? rf.story.ui.xray-embed/panel-ids (second child)))
             child))
-        (e2e/find-by-test-id tree "story-xray-embed")))
+        (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-xray-embed")))
 
 (deftest collapsed-embed-does-not-mount-panel-host
   (testing "rf2-ba86n.19 — a COLLAPSED embed renders no panel-host slot, so
             no mount-<panel>! fires and the panel's expensive diff is never
             computed; expanding restores the panel-host"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variant!}
       (fn []
-        (e2e/select-variant! variant-id)
+        (rf.story.test-helpers.e2e-multi-frame/select-variant! variant-id)
         ;; Expanded (default) → the panel-host slot IS present (the mount
         ;; target the diff-compute path hangs off).
-        (let [expanded-tree (xray-embed/xray-embed-panel)]
+        (let [expanded-tree (rf.story.ui.xray-embed/xray-embed-panel)]
           (is (some? (panel-host-slot expanded-tree))
               "default (expanded) embed mounts the panel-host → diff compute path live")
-          (is (= "false" (get-in (e2e/find-by-test-id expanded-tree "story-xray-embed")
+          (is (= "false" (get-in (rf.story.test-helpers.e2e-multi-frame/find-by-test-id expanded-tree "story-xray-embed")
                                  [1 :data-xray-embed-collapsed]))
               "data-xray-embed-collapsed reflects the expanded state"))
         ;; Collapse the embed (the same write the disclosure toggle does).
-        (ui-state/swap-state! ui-state/set-xray-embed-collapsed true)
-        (let [collapsed-tree (xray-embed/xray-embed-panel)
-              wrapper        (e2e/find-by-test-id collapsed-tree "story-xray-embed")
-              placeholder    (e2e/find-by-test-id collapsed-tree "story-xray-embed-collapsed")]
+        (rf.story.ui.state/swap-state! rf.story.ui.state/set-xray-embed-collapsed true)
+        (let [collapsed-tree (rf.story.ui.xray-embed/xray-embed-panel)
+              wrapper        (rf.story.test-helpers.e2e-multi-frame/find-by-test-id collapsed-tree "story-xray-embed")
+              placeholder    (rf.story.test-helpers.e2e-multi-frame/find-by-test-id collapsed-tree "story-xray-embed-collapsed")]
           (is (nil? (panel-host-slot collapsed-tree))
               "COLLAPSED embed renders NO panel-host slot → mount-<panel>! is
                never invoked → the panel's expensive diff is not computed
@@ -258,42 +258,42 @@
               "data-xray-embed-collapsed reflects the collapsed state")
           ;; The chip-row picker still paints while collapsed (cheap; no Xray
           ;; symbol) so the author's lens choice survives a collapse.
-          (is (= 6 (count (e2e/find-all-by-test-id collapsed-tree "story-xray-panel-chip")))
+          (is (= 6 (count (rf.story.test-helpers.e2e-multi-frame/find-all-by-test-id collapsed-tree "story-xray-panel-chip")))
               "chip-row picker survives a collapse (no compute, just data; rf2-gbz39 dropped :issues)"))
         ;; Expand again → panel-host slot returns (mount resumes on next commit).
-        (ui-state/swap-state! ui-state/set-xray-embed-collapsed false)
-        (let [reexpanded-tree (xray-embed/xray-embed-panel)]
+        (rf.story.ui.state/swap-state! rf.story.ui.state/set-xray-embed-collapsed false)
+        (let [reexpanded-tree (rf.story.ui.xray-embed/xray-embed-panel)]
           (is (some? (panel-host-slot reexpanded-tree))
               "expanding restores the panel-host slot → mount + diff compute resume"))))))
 
 (deftest disclosure-toggle-flips-collapsed-state
   (testing "rf2-ba86n.19 — the disclosure toggle's on-click flips the
             embed-collapsed shell slot (expanded → collapsed → expanded)"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variant!}
       (fn []
-        (e2e/select-variant! variant-id)
-        (let [tree    (xray-embed/xray-embed-panel)
-              toggle  (e2e/find-by-test-id tree "story-xray-disclosure")
-              handler (e2e/handler-for toggle :on-click)]
+        (rf.story.test-helpers.e2e-multi-frame/select-variant! variant-id)
+        (let [tree    (rf.story.ui.xray-embed/xray-embed-panel)
+              toggle  (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-xray-disclosure")
+              handler (rf.story.test-helpers.e2e-multi-frame/handler-for toggle :on-click)]
           (is (some? toggle) "disclosure toggle present in the chip-row")
           (is (= "true" (get-in toggle [1 :aria-expanded]))
               "toggle starts aria-expanded=true (embed expanded by default)")
           (is (fn? handler) ":on-click wired on the disclosure toggle")
           ;; Default expanded → first click collapses.
-          (is (false? (ui-state/xray-embed-collapsed? (ui-state/get-state)))
+          (is (false? (rf.story.ui.state/xray-embed-collapsed? (rf.story.ui.state/get-state)))
               "starts expanded")
-          (handler (e2e/fake-event {}))
-          (is (true? (ui-state/xray-embed-collapsed? (ui-state/get-state)))
+          (handler (rf.story.test-helpers.e2e-multi-frame/fake-event {}))
+          (is (true? (rf.story.ui.state/xray-embed-collapsed? (rf.story.ui.state/get-state)))
               "first click collapses the embed")
           ;; Re-derive the toggle from the new tree + click again → expands.
-          (let [tree2    (xray-embed/xray-embed-panel)
-                toggle2  (e2e/find-by-test-id tree2 "story-xray-disclosure")
-                handler2 (e2e/handler-for toggle2 :on-click)]
+          (let [tree2    (rf.story.ui.xray-embed/xray-embed-panel)
+                toggle2  (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree2 "story-xray-disclosure")
+                handler2 (rf.story.test-helpers.e2e-multi-frame/handler-for toggle2 :on-click)]
             (is (= "false" (get-in toggle2 [1 :aria-expanded]))
                 "aria-expanded reflects the collapsed state")
-            (handler2 (e2e/fake-event {}))
-            (is (false? (ui-state/xray-embed-collapsed? (ui-state/get-state)))
+            (handler2 (rf.story.test-helpers.e2e-multi-frame/fake-event {}))
+            (is (false? (rf.story.ui.state/xray-embed-collapsed? (rf.story.ui.state/get-state)))
                 "second click re-expands the embed")))))))
 
 ;; ---- React lifecycle invariant ------------------------------------------
@@ -312,11 +312,11 @@
   (testing "rf2-4l7t2 — panel-host-component returns a Reagent class
             wired to the four lifecycle hooks (mount / update / unmount
             / render)"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variant!}
       (fn []
         ;; The fn is a private impl detail; access via `var`.
-        (let [class-ctor #'xray-embed/panel-host-component]
+        (let [class-ctor #'rf.story.ui.xray-embed/panel-host-component]
           (is (some? class-ctor)
               "panel-host-component is exported (testable seam)"))))))
 

--- a/tools/story/test/re_frame/story/panels_e2e/xray_embed_spine_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/xray_embed_spine_e2e_cljs_test.cljs
@@ -33,24 +33,24 @@
   affordance to drive that focus from a past row at all; this is the
   behaviour the inline spine unlocks."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.story :as story]
-            [re-frame.story.ui.xray-embed :as xray-embed]
-            [re-frame.story.ui.state :as ui-state]
-            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.story :as rf.story]
+            [re-frame.story.ui.xray-embed :as rf.story.ui.xray-embed]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]
             [day8.re-frame2-xray.test-helpers.e2e-multi-frame :as xray-e2e]
             [day8.re-frame2-xray.test-helpers.host-fixtures.counter :as counter]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (def ^:private variant-id :story.counter/loaded)
 
 (defn- register-variant! []
-  (story/reg-story :story.counter
+  (rf.story/reg-story :story.counter
     {:doc "Counter parent story for the spine e2e tests."})
-  (story/reg-variant variant-id
+  (rf.story/reg-variant variant-id
     {:doc    "Counter seeded at 5 — exercises the inline spine path."
      :setup [[:counter/initialise]]}))
 
@@ -60,23 +60,23 @@
   (testing "rf2-9k43e — `:event-spine` resolves to a callable mount-fn
             (the isolated L2 `shell/event-list` via mount-event-spine!),
             reusing the same require/case shape every chip panel uses"
-    (is (fn? (xray-embed/mount-fn-for :event-spine))
+    (is (fn? (rf.story.ui.xray-embed/mount-fn-for :event-spine))
         "mount-fn-for :event-spine returned a callable mount-fn")
     (testing "the spine is NOT a chip-row panel (not in the catalog)"
-      (is (not (contains? xray-embed/panel-ids :event-spine))
+      (is (not (contains? rf.story.ui.xray-embed/panel-ids :event-spine))
           ":event-spine is a persistent band, not a chip-selected panel"))))
 
 (deftest expanded-embed-renders-spine-band
   (testing "rf2-9k43e — an EXPANDED embed renders the recent-events spine
             band ABOVE the chip-selected panel, with the :event-spine
             mount slot driving mount-event-spine!"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variant!}
       (fn []
-        (e2e/select-variant! variant-id)
-        (let [tree    (xray-embed/xray-embed-panel)
-              band    (e2e/find-by-test-id tree "story-xray-spine-band")
-              caption (e2e/find-by-test-id tree "story-xray-spine-caption")
+        (rf.story.test-helpers.e2e-multi-frame/select-variant! variant-id)
+        (let [tree    (rf.story.ui.xray-embed/xray-embed-panel)
+              band    (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-xray-spine-band")
+              caption (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-xray-spine-caption")
               ;; The spine's mount slot is the `[panel-host-component
               ;; :event-spine …]` vector — fn-headed, with `:event-spine`
               ;; as the second element (the panel-id argv).
@@ -85,7 +85,7 @@
                                             (fn? (first node))
                                             (= :event-spine (second node)))
                                    node))
-                               (e2e/hiccup-seq band))]
+                               (rf.story.test-helpers.e2e-multi-frame/hiccup-seq band))]
           (is (some? band)
               "spine band present in the expanded embed (rf2-9k43e
                `[data-test=\"story-xray-spine-band\"]`)")
@@ -100,20 +100,20 @@
   (testing "rf2-9k43e + rf2-ba86n.19 — collapsing the embed drops the
             spine band too (no spine mount → no L2 compute) and restores
             it on expand"
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-variant!}
       (fn []
-        (e2e/select-variant! variant-id)
-        (is (some? (e2e/find-by-test-id (xray-embed/xray-embed-panel)
+        (rf.story.test-helpers.e2e-multi-frame/select-variant! variant-id)
+        (is (some? (rf.story.test-helpers.e2e-multi-frame/find-by-test-id (rf.story.ui.xray-embed/xray-embed-panel)
                                         "story-xray-spine-band"))
             "expanded (default) embed shows the spine band")
-        (ui-state/swap-state! ui-state/set-xray-embed-collapsed true)
-        (is (nil? (e2e/find-by-test-id (xray-embed/xray-embed-panel)
+        (rf.story.ui.state/swap-state! rf.story.ui.state/set-xray-embed-collapsed true)
+        (is (nil? (rf.story.test-helpers.e2e-multi-frame/find-by-test-id (rf.story.ui.xray-embed/xray-embed-panel)
                                        "story-xray-spine-band"))
             "COLLAPSED embed renders NO spine band → mount-event-spine!
              never fires → the L2 list's compute is deferred")
-        (ui-state/swap-state! ui-state/set-xray-embed-collapsed false)
-        (is (some? (e2e/find-by-test-id (xray-embed/xray-embed-panel)
+        (rf.story.ui.state/swap-state! rf.story.ui.state/set-xray-embed-collapsed false)
+        (is (some? (rf.story.test-helpers.e2e-multi-frame/find-by-test-id (rf.story.ui.xray-embed/xray-embed-panel)
                                         "story-xray-spine-band"))
             "expanding restores the spine band")))))
 

--- a/tools/story/test/re_frame/story/panels_e2e/xray_panel_routing_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/xray_panel_routing_e2e_cljs_test.cljs
@@ -22,16 +22,16 @@
   - **Unknown slot falls back to default** — a typo doesn't blank
     the RHS; resolution returns `default-panel`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.story :as story]
-            [re-frame.story.ui.xray-embed :as xray-embed]
-            [re-frame.story.ui.state :as ui-state]
-            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.story :as rf.story]
+            [re-frame.story.ui.xray-embed :as rf.story.ui.xray-embed]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]
             [day8.re-frame2-xray.panels :as xray-panels]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- direct slot honoured ----------------------------------------------
 
@@ -40,20 +40,20 @@
             resolves through `resolve-panel` to the :app-db panel id;
             `effective-panel` reads the variant body and beats the
             embed's default."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories
        (fn []
-         (story/reg-story :story.counter {})
-         (story/reg-variant :story.counter/app-db
+         (rf.story/reg-story :story.counter {})
+         (rf.story/reg-variant :story.counter/app-db
            {:xray-panel :app-db
             :setup []}))}
       (fn []
-        (is (= :app-db (xray-embed/resolve-panel :story.counter/app-db))
+        (is (= :app-db (rf.story.ui.xray-embed/resolve-panel :story.counter/app-db))
             "resolve-panel returned :app-db for a variant with the slot")
-        (e2e/select-variant! :story.counter/app-db)
+        (rf.story.test-helpers.e2e-multi-frame/select-variant! :story.counter/app-db)
         (is (= :app-db
-               (xray-embed/effective-panel
-                 (ui-state/get-state) :story.counter/app-db))
+               (rf.story.ui.xray-embed/effective-panel
+                 (rf.story.ui.state/get-state) :story.counter/app-db))
             "effective-panel routes the slot through with no user override")))))
 
 (deftest mount-fn-for-app-db-maps-to-xray-mount-fn
@@ -61,7 +61,7 @@
             resolve to `xray-panels/mount-app-db-diff!`, not nil.
             A regression in the `case` dispatch would silently leave
             the panel-host empty (the original bug)."
-    (let [mfn (xray-embed/mount-fn-for :app-db)]
+    (let [mfn (rf.story.ui.xray-embed/mount-fn-for :app-db)]
       (is (some? mfn)
           ":app-db panel id resolves to a non-nil mount-fn")
       (is (= mfn xray-panels/mount-app-db-diff!)
@@ -75,21 +75,21 @@
             variant with no `:xray-panel` inherits from its story;
             a variant with `:xray-panel` declared beats the story's
             value."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories
        (fn []
-         (story/reg-story :story.routing
+         (rf.story/reg-story :story.routing
            {:xray-panel :routing
             :doc "Story-level slot says :routing."})
-         (story/reg-variant :story.routing/inherits
+         (rf.story/reg-variant :story.routing/inherits
            {:setup []})
-         (story/reg-variant :story.routing/override
+         (rf.story/reg-variant :story.routing/override
            {:xray-panel :machines
             :setup []}))}
       (fn []
-        (is (= :routing (xray-embed/resolve-panel :story.routing/inherits))
+        (is (= :routing (rf.story.ui.xray-embed/resolve-panel :story.routing/inherits))
             "variant with no slot inherits the story's :routing")
-        (is (= :machines (xray-embed/resolve-panel :story.routing/override))
+        (is (= :machines (rf.story.ui.xray-embed/resolve-panel :story.routing/override))
             "variant slot beats story slot")))))
 
 ;; ---- unknown slot falls back to default --------------------------------
@@ -98,16 +98,16 @@
   (testing "a typo / unknown panel-id in `:xray-panel` falls back to
             `default-panel` rather than blanking the RHS. Conservative
             failure mode."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories
        (fn []
-         (story/reg-story :story.typo {})
-         (story/reg-variant :story.typo/v
+         (rf.story/reg-story :story.typo {})
+         (rf.story/reg-variant :story.typo/v
            {:xray-panel :not-a-real-panel
             :setup []}))}
       (fn []
-        (is (= xray-embed/default-panel
-               (xray-embed/resolve-panel :story.typo/v))
+        (is (= rf.story.ui.xray-embed/default-panel
+               (rf.story.ui.xray-embed/resolve-panel :story.typo/v))
             "unknown slot value → fallback to default-panel
              (:epoch)")))))
 
@@ -118,30 +118,30 @@
             variant's `:xray-panel` slot. `effective-panel` honours
             the override; clearing it (e.g. via `:rf/auto`) returns
             to the slot's value."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories
        (fn []
-         (story/reg-story :story.user-pick {})
-         (story/reg-variant :story.user-pick/v
+         (rf.story/reg-story :story.user-pick {})
+         (rf.story/reg-variant :story.user-pick/v
            {:xray-panel :views
             :setup []}))}
       (fn []
-        (e2e/select-variant! :story.user-pick/v)
+        (rf.story.test-helpers.e2e-multi-frame/select-variant! :story.user-pick/v)
         ;; Pre-override: variant slot wins.
         (is (= :views
-               (xray-embed/effective-panel
-                 (ui-state/get-state) :story.user-pick/v)))
+               (rf.story.ui.xray-embed/effective-panel
+                 (rf.story.ui.state/get-state) :story.user-pick/v)))
         ;; User override: simulate the App-db chip click.
-        (ui-state/swap-state! assoc :xray-panel :app-db)
+        (rf.story.ui.state/swap-state! assoc :xray-panel :app-db)
         (is (= :app-db
-               (xray-embed/effective-panel
-                 (ui-state/get-state) :story.user-pick/v))
+               (rf.story.ui.xray-embed/effective-panel
+                 (rf.story.ui.state/get-state) :story.user-pick/v))
             "user's chip override beats the variant slot")
         ;; Clear override → back to the slot.
-        (ui-state/swap-state! dissoc :xray-panel)
+        (rf.story.ui.state/swap-state! dissoc :xray-panel)
         (is (= :views
-               (xray-embed/effective-panel
-                 (ui-state/get-state) :story.user-pick/v))
+               (rf.story.ui.xray-embed/effective-panel
+                 (rf.story.ui.state/get-state) :story.user-pick/v))
             "clearing the override restores the variant slot's value")))))
 
 ;; ---- rendered embed reflects the routing -------------------------------
@@ -150,17 +150,17 @@
   (testing "the embed wrapper's `data-active-panel` carries the resolved
             slot value when the variant carries a `:xray-panel`. This
             is the end-to-end shape the Playwright spec asserted."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories
        (fn []
-         (story/reg-story :story.routed {})
-         (story/reg-variant :story.routed/v
+         (rf.story/reg-story :story.routed {})
+         (rf.story/reg-variant :story.routed/v
            {:xray-panel :trace
             :setup []}))}
       (fn []
-        (e2e/select-variant! :story.routed/v)
-        (let [tree    (xray-embed/xray-embed-panel)
-              wrapper (e2e/find-by-test-id tree "story-xray-embed")]
+        (rf.story.test-helpers.e2e-multi-frame/select-variant! :story.routed/v)
+        (let [tree    (rf.story.ui.xray-embed/xray-embed-panel)
+              wrapper (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "story-xray-embed")]
           (is (some? wrapper) "embed wrapper renders")
           (is (= "trace" (get-in wrapper [1 :data-active-panel]))
               "data-active-panel reflects the variant's :xray-panel slot

--- a/tools/story/test/re_frame/story/panels_e2e/xray_target_frame_dispatch_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/xray_target_frame_dispatch_e2e_cljs_test.cljs
@@ -21,15 +21,15 @@
   Sub-second per surface; no DOM / no React mount / no Playwright."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.story :as story]
-            [re-frame.story.ui.shell :as shell]
-            [re-frame.story.ui.state :as ui-state]
-            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.story :as rf.story]
+            [re-frame.story.ui.shell :as rf.story.ui.shell]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- helpers -------------------------------------------------------------
 
@@ -40,12 +40,12 @@
   test — calling it directly exercises exactly the path
   `mount-shell!` invokes during boot."
   []
-  ((deref #'shell/selection-watcher)))
+  ((deref #'rf.story.ui.shell/selection-watcher)))
 
 (defn- remove-selection-watcher!
   "Symmetric teardown: drop the watch + clear the cross-mount tracker."
   []
-  ((deref #'shell/remove-selection-watcher!)))
+  ((deref #'rf.story.ui.shell/remove-selection-watcher!)))
 
 ;; ---- the contract --------------------------------------------------------
 
@@ -57,18 +57,18 @@
             the variant's frame but never told Xray to OBSERVE it,
             so the App-DB / Event panels rendered against the prior
             target-frame (commonly the boot default)."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories
        (fn []
-         (story/reg-story :story.cart {})
-         (story/reg-variant :story.cart/empty
+         (rf.story/reg-story :story.cart {})
+         (rf.story/reg-variant :story.cart/empty
            {:doc    "Empty cart variant — exercises the target-frame dispatch."
             :setup []}))}
       (fn []
         (install-selection-watcher!)
         (try
           ;; Variant-id IS the frame-id per `re-frame.story.frames`.
-          (e2e/select-variant! :story.cart/empty)
+          (rf.story.test-helpers.e2e-multi-frame/select-variant! :story.cart/empty)
           ;; Inspect the slot Xray's `:rf.xray/set-target-frame`
           ;; reducer writes to. If the watcher's dispatch fired, the
           ;; slot reflects the freshly-selected variant.
@@ -85,21 +85,21 @@
             watcher dispatched zero times so a switch left Xray
             stuck on the prior frame. The post-fix watcher fires on
             every edge."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories
        (fn []
-         (story/reg-story :story.cart {})
-         (story/reg-variant :story.cart/empty {:setup []})
-         (story/reg-variant :story.cart/with-items {:setup []}))}
+         (rf.story/reg-story :story.cart {})
+         (rf.story/reg-variant :story.cart/empty {:setup []})
+         (rf.story/reg-variant :story.cart/with-items {:setup []}))}
       (fn []
         (install-selection-watcher!)
         (try
-          (e2e/select-variant! :story.cart/empty)
+          (rf.story.test-helpers.e2e-multi-frame/select-variant! :story.cart/empty)
           (rf/with-frame :rf/xray
             (is (= :story.cart/empty
                    @(rf/subscribe [:rf.xray/target-frame]))
                 "first selection lands"))
-          (e2e/select-variant! :story.cart/with-items)
+          (rf.story.test-helpers.e2e-multi-frame/select-variant! :story.cart/with-items)
           (rf/with-frame :rf/xray
             (is (= :story.cart/with-items
                    @(rf/subscribe [:rf.xray/target-frame]))
@@ -114,15 +114,15 @@
             value rather than being reset to nil — consistent with the
             picker contract (a nil dispatch resets to the boot
             default, which would clobber the user's last context)."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories
        (fn []
-         (story/reg-story :story.cart {})
-         (story/reg-variant :story.cart/empty {:setup []}))}
+         (rf.story/reg-story :story.cart {})
+         (rf.story/reg-variant :story.cart/empty {:setup []}))}
       (fn []
         (install-selection-watcher!)
         (try
-          (e2e/select-variant! :story.cart/empty)
+          (rf.story.test-helpers.e2e-multi-frame/select-variant! :story.cart/empty)
           (rf/with-frame :rf/xray
             (is (= :story.cart/empty
                    @(rf/subscribe [:rf.xray/target-frame]))
@@ -130,7 +130,7 @@
           ;; Now clear the selection. The watcher's `(when now ...)`
           ;; guard short-circuits, so no dispatch fires; the slot
           ;; retains the last variant-id.
-          (e2e/select-variant! nil)
+          (rf.story.test-helpers.e2e-multi-frame/select-variant! nil)
           (rf/with-frame :rf/xray
             (is (= :story.cart/empty
                    @(rf/subscribe [:rf.xray/target-frame]))

--- a/tools/story/test/re_frame/story/plan_network_test.cljc
+++ b/tools/story/test/re_frame/story/plan_network_test.cljc
@@ -18,15 +18,15 @@
   explain visibility, plan-hash sensitivity, and the schema acceptance."
   (:require [clojure.test :refer [deftest is testing]]
             [malli.core :as m]
-            [re-frame.story.plan        :as plan]
-            [re-frame.story.fingerprint :as fp]
-            [re-frame.story.schemas     :as schemas]))
+            [re-frame.story.plan        :as rf.story.plan]
+            [re-frame.story.fingerprint :as rf.story.fingerprint]
+            [re-frame.story.schemas     :as rf.story.schemas]))
 
 ;; ---- helpers ------------------------------------------------------------
 
 (defn- plan-of
   [target m]
-  (plan/variant-plan target {:lookup m}))
+  (rf.story.plan/variant-plan target {:lookup m}))
 
 (def ^:private cart-route   [:get  "/api/cart"])
 (def ^:private checkout-route [:post "/api/checkout"])
@@ -53,8 +53,8 @@
         (is (= {:rf.http/managed :rf.http/managed-test-stub}
                (get-in p [:world :frame :fx-overrides]))))
       (testing "the stub fx id matches the http-test-support helper's return"
-        (is (= :rf.http/managed-test-stub plan/managed-stub-fx-id))
-        (is (= :rf.http/managed plan/managed-fx-id))))))
+        (is (= :rf.http/managed-test-stub rf.story.plan/managed-stub-fx-id))
+        (is (= :rf.http/managed rf.story.plan/managed-fx-id))))))
 
 (deftest one-route-succeeds-one-fails-in-one-variant
   (testing "mixed success/failure routes coexist in one variant (the §B2c case)"
@@ -95,10 +95,10 @@
     (let [routes {cart-route {:reply {:ok 1}}}]
       (is (= {:network      routes
               :fx-overrides {:rf.http/managed :rf.http/managed-test-stub}}
-             (plan/lower-network routes))))
+             (rf.story.plan/lower-network routes))))
     (testing "nil for empty / nil input"
-      (is (nil? (plan/lower-network {})))
-      (is (nil? (plan/lower-network nil))))))
+      (is (nil? (rf.story.plan/lower-network {})))
+      (is (nil? (rf.story.plan/lower-network nil))))))
 
 ;; ===========================================================================
 ;; arg substitution inside :network reply data
@@ -168,7 +168,7 @@
           variants  {:story.checkout/compose-conflict
                      {:network {cart-route {:reply {:ok {:items []}}}}
                       :compose [:fragment.http/managed-override]}}
-          compile   #(plan/variant-plan :story.checkout/compose-conflict
+          compile   #(rf.story.plan/variant-plan :story.checkout/compose-conflict
                                         {:lookup          variants
                                          :fragment-lookup fragments})]
       (is (thrown-with-msg?
@@ -190,7 +190,7 @@
     (let [routes {cart-route     {:reply {:ok {:items []}}}
                   checkout-route {:reply {:failure {:kind :rf.http/http-4xx}}}}
           m {:story.checkout/explained {:network routes}}
-          ex (plan/explain :story.checkout/explained {:lookup m})]
+          ex (rf.story.plan/explain :story.checkout/explained {:lookup m})]
       (is (= routes (get-in ex [:network :routes]))
           "explain shows the per-route reply data")
       (is (= {:rf.http/managed :rf.http/managed-test-stub}
@@ -200,7 +200,7 @@
 (deftest explain-network-absent-when-no-network
   (testing "explain has no :network slot for a variant without :network"
     (let [m {:story.plain/v {:setup [[:dispatch [:a]]]}}
-          ex (plan/explain :story.plain/v {:lookup m})]
+          ex (rf.story.plan/explain :story.plain/v {:lookup m})]
       (is (nil? (:network ex))))))
 
 ;; ===========================================================================
@@ -213,7 +213,7 @@
           alt  {:story.h/v {:network {cart-route {:reply {:ok {:items [{:sku "A"}]}}}}}}
           p1   (plan-of :story.h/v base)
           p2   (plan-of :story.h/v alt)]
-      (is (not= (fp/plan-hash p1) (fp/plan-hash p2))
+      (is (not= (rf.story.fingerprint/plan-hash p1) (rf.story.fingerprint/plan-hash p2))
           "a semantic change to a route reply changes the plan-hash"))))
 
 (deftest network-failure-kind-perturbs-plan-hash
@@ -222,7 +222,7 @@
                         {:story.h/v {:network {checkout-route {:reply {:failure {:kind :rf.http/http-4xx}}}}}})
           p5xx (plan-of :story.h/v
                         {:story.h/v {:network {checkout-route {:reply {:failure {:kind :rf.http/http-5xx}}}}}})]
-      (is (not= (fp/plan-hash p4xx) (fp/plan-hash p5xx))))))
+      (is (not= (rf.story.fingerprint/plan-hash p4xx) (rf.story.fingerprint/plan-hash p5xx))))))
 
 ;; ===========================================================================
 ;; :network inherits through :extends (world context flows down)
@@ -251,31 +251,31 @@
 
 (deftest variant-schema-accepts-network
   (testing "the Variant schema accepts a well-formed :network slot"
-    (is (nil? (schemas/validate :variant
+    (is (nil? (rf.story.schemas/validate :variant
                 {:network {cart-route     {:reply {:ok {:items []}}}
                            checkout-route {:reply {:failure {:kind :rf.http/http-4xx
                                                              :status 409}}}}})))))
 
 (deftest network-schema-rejects-missing-reply
   (testing "a route value with no :reply is rejected"
-    (is (some? (schemas/validate :variant
+    (is (some? (rf.story.schemas/validate :variant
                  {:network {cart-route {:status :ok}}})))))
 
 (deftest network-schema-rejects-both-ok-and-failure
   (testing "a :reply carrying BOTH :ok and :failure is rejected (xor)"
-    (is (some? (schemas/validate :variant
+    (is (some? (rf.story.schemas/validate :variant
                  {:network {cart-route {:reply {:ok 1 :failure {:kind :x}}}}})))))
 
 (deftest network-schema-rejects-bad-route-key
   (testing "a route key that is not a [method url] pair is rejected"
-    (is (some? (schemas/validate :variant
+    (is (some? (rf.story.schemas/validate :variant
                  {:network {"/api/cart" {:reply {:ok 1}}}})))   ; bare string key
-    (is (some? (schemas/validate :variant
+    (is (some? (rf.story.schemas/validate :variant
                  {:network {[:teleport "/api/cart"] {:reply {:ok 1}}}}))))) ; bad method
 
 (deftest network-spec-is-malli-valid
   (testing "NetworkSpec is a well-formed Malli schema"
-    (is (m/validate schemas/NetworkSpec
+    (is (m/validate rf.story.schemas/NetworkSpec
                     {cart-route {:reply {:ok {:items []}}}}))
-    (is (not (m/validate schemas/NetworkSpec
+    (is (not (m/validate rf.story.schemas/NetworkSpec
                          {cart-route {:reply {}}})))))

--- a/tools/story/test/re_frame/story/plan_test.cljc
+++ b/tools/story/test/re_frame/story/plan_test.cljc
@@ -10,17 +10,17 @@
   registrar's eager merge)."
   (:require [clojure.test :refer [deftest is testing]]
             [malli.core :as m]
-            [re-frame.story.assertions :as assertions]
-            [re-frame.story.fingerprint :as fingerprint]
-            [re-frame.story.plan :as plan]
-            [re-frame.story.sub-overrides :as sub-overrides]))
+            [re-frame.story.assertions :as rf.story.assertions]
+            [re-frame.story.fingerprint :as rf.story.fingerprint]
+            [re-frame.story.plan :as rf.story.plan]
+            [re-frame.story.sub-overrides :as rf.story.sub-overrides]))
 
 ;; ---- helpers ------------------------------------------------------------
 
 (defn- plan-of
   "Compile a keyword `target` against a raw-body lookup `m`."
   [target m]
-  (plan/variant-plan target {:lookup m}))
+  (rf.story.plan/variant-plan target {:lookup m}))
 
 ;; ---- simple variant compiles --------------------------------------------
 
@@ -55,7 +55,7 @@
 
 (deftest inline-map-target-compiles
   (testing "a map target compiles the same way as a registered keyword"
-    (let [p (plan/variant-plan {:variant/id :story.inline/v
+    (let [p (rf.story.plan/variant-plan {:variant/id :story.inline/v
                                 :setup  [[:dispatch [:a]]]
                                 :script [[:dispatch [:b]]]})]
       (is (= :story.inline/v (:variant/id p)))
@@ -67,7 +67,7 @@
             optional) and compiles to a plan whose :variant/id is nil
             (rf2-8e2nd — variant-plan reads (:variant/id target), nil when
             absent)"
-    (let [p (plan/variant-plan {:setup  [[:dispatch [:a]]]
+    (let [p (rf.story.plan/variant-plan {:setup  [[:dispatch [:a]]]
                                 :script [[:dispatch [:b]]]})]
       (is (nil? (:variant/id p))
           "the optional :variant/id resolves to nil")
@@ -95,7 +95,7 @@
           "the parent story id is derived from the variant id's namespace")))
   (testing "an inline map target with NO :variant/id stamps no :story/id
             (nothing to derive it from — render-transparent)"
-    (let [p (plan/variant-plan {:setup [[:dispatch [:a]]]})]
+    (let [p (rf.story.plan/variant-plan {:setup [[:dispatch [:a]]]})]
       (is (not (contains? p :story/id))))))
 
 (deftest identical-variant-bodies-under-different-stories-do-not-collide
@@ -120,7 +120,7 @@
       (is (= (:expect pa) (:expect pb)))
       (is (= (:required-runner pa) (:required-runner pb)))
       (is (= (:tags pa) (:tags pb)))
-      (is (not= (fingerprint/plan-hash pa) (fingerprint/plan-hash pb))
+      (is (not= (rf.story.fingerprint/plan-hash pa) (rf.story.fingerprint/plan-hash pb))
           "the cross-story collision guard is now LIVE — identical bodies
            under different stories hash DIFFERENTLY"))))
 
@@ -236,7 +236,7 @@
                     (:rf.error/id (ex-data e)))))))))
 
 (deftest extends-depth-cap-fails
-  (testing "an :extends chain longer than plan/*max-extends-depth* fails plan construction"
+  (testing "an :extends chain longer than rf.story.plan/*max-extends-depth* fails plan construction"
     ;; A chain of 50 ids each pointing at the next; n0 is the leaf, n49 the
     ;; deepest ancestor. Resolution from the leaf has to walk every parent, so
     ;; the cap fires before the chain runs out. No cycle here — the depth cap
@@ -253,7 +253,7 @@
                                            (keyword "story.chain" (str "n" (inc i))))]
                               [this (cond-> {:setup []}
                                       parent (assoc :extends parent))])))]
-      (binding [plan/*max-extends-depth* 32]
+      (binding [rf.story.plan/*max-extends-depth* 32]
         (is (= :rf.error/story-extends-chain-too-long
                (try (plan-of :story.chain/n0 m)
                     (catch #?(:clj Exception :cljs :default) e
@@ -404,7 +404,7 @@
                               :setup [[:dispatch [:seed [:arg :n]]]]}
              :story.e/child  {:extends :story.e/parent
                               :script  [[:dispatch [:go]]]}}
-          ex (plan/explain :story.e/child {:lookup m})]
+          ex (rf.story.plan/explain :story.e/child {:lookup m})]
       (is (= [:story.e/parent :story.e/child] (:source-chain ex)))
       (is (= [:story.e/parent] (:parent-chain ex)))
       (is (= {:n 1} (:args ex)))
@@ -448,7 +448,7 @@
           m {:story.widget/ok
              {:component :views/widget
               :args      {:label "Hi" :count 3}}}
-          p (plan/variant-plan :story.widget/ok
+          p (rf.story.plan/variant-plan :story.widget/ok
                                {:lookup      m
                                 :view-lookup {:views/widget {:rf/props view-schema}}})]
       (is (= view-schema (get-in p [:world :view-args-schema])))
@@ -460,7 +460,7 @@
     (let [m {:story.widget/valid
              {:component :views/widget
               :args      {:label "Hi" :count 3}}}
-          p (plan/variant-plan :story.widget/valid
+          p (rf.story.plan/variant-plan :story.widget/valid
                                {:lookup      m
                                 :view-lookup {:views/widget
                                               {:rf/props [:map [:label :string] [:count :int]]}}
@@ -478,8 +478,8 @@
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
             #"story-view-args-invalid"
-            (plan/variant-plan :story.widget/missing opts)))
-      (let [data (try (plan/variant-plan :story.widget/missing opts)
+            (rf.story.plan/variant-plan :story.widget/missing opts)))
+      (let [data (try (rf.story.plan/variant-plan :story.widget/missing opts)
                       (catch #?(:clj Exception :cljs :default) e (ex-data e)))]
         (is (= :rf.error/story-view-args-invalid (:rf.error/id data)))
         (testing "the failure reports the missing key, schema path, and source variant"
@@ -491,7 +491,7 @@
     (let [m {:story.widget/opt
              {:component :views/widget
               :args      {:label "Hi"}}}
-          p (plan/variant-plan :story.widget/opt
+          p (rf.story.plan/variant-plan :story.widget/opt
                                {:lookup      m
                                 :view-lookup {:views/widget
                                               {:rf/props [:map
@@ -511,8 +511,8 @@
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
             #"story-view-args-invalid"
-            (plan/variant-plan :story.widget/bad opts)))
-      (let [data (try (plan/variant-plan :story.widget/bad opts)
+            (rf.story.plan/variant-plan :story.widget/bad opts)))
+      (let [data (try (rf.story.plan/variant-plan :story.widget/bad opts)
                       (catch #?(:clj Exception :cljs :default) e (ex-data e)))
             bad  (first (:malformed data))]
         (is (= :rf.error/story-view-args-invalid (:rf.error/id data)))
@@ -528,7 +528,7 @@
     (let [m {:story.widget/none
              {:component :views/widget
               :args      {:anything 1}}}
-          p (plan/variant-plan :story.widget/none
+          p (rf.story.plan/variant-plan :story.widget/none
                                {:lookup      m
                                 :view-lookup {:views/widget {}}})]  ; no schema slot
       (is (nil? (get-in p [:world :view-args-schema])))
@@ -539,7 +539,7 @@
 (deftest no-component-no-validation
   (testing "a variant with no :component is never view-validated"
     (let [m {:story.plain/v {:args {:x 1} :setup [[:dispatch [:a]]]}}
-          p (plan/variant-plan :story.plain/v {:lookup m})]
+          p (rf.story.plan/variant-plan :story.plain/v {:lookup m})]
       (is (nil? (get-in p [:world :view-args-schema])))
       (is (= {:x 1} (get-in p [:world :effective-args]))))))
 
@@ -549,36 +549,36 @@
           spec   [:map [:b :string]]
           schema [:map [:c :string]]]
       (testing ":rf/props chosen when present (canonical, wins over :schema)"
-        (is (= props (plan/view-args-schema {:rf/props props :schema schema}))))
+        (is (= props (rf.story.plan/view-args-schema {:rf/props props :schema schema}))))
       (testing ":schema chosen when no :rf/props (the post-M-54 location)"
-        (is (= schema (plan/view-args-schema {:schema schema}))))
+        (is (= schema (rf.story.plan/view-args-schema {:schema schema}))))
       (testing ":spec is NOT a resolution key — a view carrying ONLY :spec
                 resolves no schema (the framework reads :schema only post-M-54;
                 see migration §M-54). rf2-ayu6n: the stale :spec key is gone."
-        (is (nil? (plan/view-args-schema {:spec spec}))))
+        (is (nil? (rf.story.plan/view-args-schema {:spec spec}))))
       (testing ":rf/props still wins even when a dead :spec is also present"
-        (is (= props (plan/view-args-schema {:rf/props props :spec spec :schema schema}))))
+        (is (= props (rf.story.plan/view-args-schema {:rf/props props :spec spec :schema schema}))))
       (testing "nil when no schema slot present"
-        (is (nil? (plan/view-args-schema {:title "x"})))))))
+        (is (nil? (rf.story.plan/view-args-schema {:title "x"})))))))
 
 (deftest derived-effective-args-validation-unit
   (testing "validate-effective-args required-key floor needs no validator"
     (let [schema [:map [:label :string] [:count :int]]]
       (testing "all present → :ok"
-        (is (= :ok (:status (plan/validate-effective-args
+        (is (= :ok (:status (rf.story.plan/validate-effective-args
                               schema {:label "x" :count 1})))))
       (testing "missing required → :invalid with the missing entry"
-        (let [r (plan/validate-effective-args schema {:label "x"})]
+        (let [r (rf.story.plan/validate-effective-args schema {:label "x"})]
           (is (= :invalid (:status r)))
           (is (= [{:key :count :schema :int :path [:count]}] (:missing r)))
           (is (= [] (:malformed r)) "no malformed without a validator")))
       (testing "malformed value soft-passes without a validator (floor only)"
         ;; :count present but wrong type — with no validator the floor
         ;; can only check presence, so this is :ok at floor level.
-        (is (= :ok (:status (plan/validate-effective-args
+        (is (= :ok (:status (rf.story.plan/validate-effective-args
                               schema {:label "x" :count "nope"})))))
       (testing "malformed value is caught WITH a validator"
-        (let [r (plan/validate-effective-args
+        (let [r (rf.story.plan/validate-effective-args
                   schema {:label "x" :count "nope"} malli-validator)]
           (is (= :invalid (:status r)))
           (is (= :count (:key (first (:malformed r))))))))))
@@ -589,7 +589,7 @@
              {:component     :views/widget
               :args          {:label "Hi"}
               :sub-overrides {[:widget/state] :error}}}
-          p (plan/variant-plan :story.boundary/v
+          p (rf.story.plan/variant-plan :story.boundary/v
                                {:lookup      m
                                 :view-lookup {:views/widget {:rf/props [:map [:label :string]]}}})]
       (testing "the view-args schema covers explicit args only"
@@ -631,7 +631,7 @@
               :sub-overrides {[:login/state]    :error
                               [:login/error]    [:arg :message]
                               [:login/attempts] 1}}}
-          p (plan/variant-plan :story.login/error {:lookup m})]
+          p (rf.story.plan/variant-plan :story.login/error {:lookup m})]
       (testing "overrides lower to [:world :render :sub-overrides] with exact query vectors"
         (is (= {[:login/state]    :error
                 [:login/error]    "Invalid password"   ; [:arg :message] resolved
@@ -659,14 +659,14 @@
              :story.f/bare
              {:component :views/x}}]
       (testing "setup-only → #{:real-setup}, no :sub-overrides rung"
-        (is (= #{:real-setup} (get-in (plan/variant-plan :story.f/setup-only {:lookup m})
+        (is (= #{:real-setup} (get-in (rf.story.plan/variant-plan :story.f/setup-only {:lookup m})
                                       [:world :fidelity]))))
       (testing "setup + overrides → both rungs"
         (is (= #{:real-setup :sub-overrides}
-               (get-in (plan/variant-plan :story.f/hybrid {:lookup m})
+               (get-in (rf.story.plan/variant-plan :story.f/hybrid {:lookup m})
                        [:world :fidelity]))))
       (testing "a bare render-as-mounted variant carries no :fidelity slot"
-        (is (nil? (get-in (plan/variant-plan :story.f/bare {:lookup m})
+        (is (nil? (get-in (rf.story.plan/variant-plan :story.f/bare {:lookup m})
                           [:world :fidelity])))))))
 
 (deftest sub-override-missing-arg-fails-plan-construction
@@ -677,7 +677,7 @@
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)
             #"story-missing-arg"
-            (plan/variant-plan :story.login/oops {:lookup m}))))))
+            (rf.story.plan/variant-plan :story.login/oops {:lookup m}))))))
 
 (deftest sub-override-output-schema-mismatch-fails-before-render
   (testing "an override value violating the sub's OUTPUT schema fails plan construction"
@@ -688,14 +688,14 @@
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)
             #"story-sub-override-invalid"
-            (plan/variant-plan :story.login/bad
+            (rf.story.plan/variant-plan :story.login/bad
                                {:lookup        m
                                 :sub-lookup    sub-lookup
                                 :validator-fns malli-validator})))))
   (testing "a value that SATISFIES the output schema compiles cleanly"
     (let [m {:story.login/ok {:sub-overrides {[:login/attempts] 3}}}
           sub-lookup {:login/attempts {:schema [:int]}}
-          p (plan/variant-plan :story.login/ok
+          p (rf.story.plan/variant-plan :story.login/ok
                                {:lookup        m
                                 :sub-lookup    sub-lookup
                                 :validator-fns malli-validator})]
@@ -703,7 +703,7 @@
       (is (= 3 (get-in p [:world :render :sub-overrides [:login/attempts]])))))
   (testing "a sub with no output schema soft-passes (the host-free floor)"
     (let [m {:story.login/noschema {:sub-overrides {[:login/state] :whatever}}}
-          p (plan/variant-plan :story.login/noschema
+          p (rf.story.plan/variant-plan :story.login/noschema
                                {:lookup        m
                                 :sub-lookup    {} ; no metadata for any sub
                                 :validator-fns malli-validator})]
@@ -714,7 +714,7 @@
     ;; renderer — a malformed value is not caught at plan construction.
     (let [m {:story.login/nov {:sub-overrides {[:login/attempts] "nope"}}}
           sub-lookup {:login/attempts {:schema [:int]}}
-          p (plan/variant-plan :story.login/nov {:lookup m :sub-lookup sub-lookup})]
+          p (rf.story.plan/variant-plan :story.login/nov {:lookup m :sub-lookup sub-lookup})]
       (is (= "nope" (get-in p [:world :render :sub-overrides [:login/attempts]]))))))
 
 (deftest sub-overrides-compose-through-fragments
@@ -724,7 +724,7 @@
           m    {:story.login/composed
                 {:compose       [:fragment/error-state]
                  :sub-overrides {[:login/code] 503}}} ; variant overrides the key
-          p (plan/variant-plan :story.login/composed
+          p (rf.story.plan/variant-plan :story.login/composed
                                {:lookup          m
                                 :fragment-lookup frag})]
       (is (= {[:login/state] :error
@@ -746,7 +746,7 @@
     (let [m {:story.cart/seeded
              {:db-seed {:cart {:items [{:sku "A" :qty 2}]}
                         :user/id 42}}}
-          p (plan/variant-plan :story.cart/seeded {:lookup m})]
+          p (rf.story.plan/variant-plan :story.cart/seeded {:lookup m})]
       (testing "the seed lowers verbatim to the world slot"
         (is (= {:cart {:items [{:sku "A" :qty 2}]} :user/id 42}
                (get-in p [:world :db-seed]))))
@@ -764,7 +764,7 @@
     ;; slot is accepted AND survives into the plan (the pre-rf2-blw1q bug was
     ;; silent-accept-then-silent-ignore).
     (let [m {:story.x/seed {:db-seed {:k 1}}}
-          p (plan/variant-plan :story.x/seed {:lookup m})]
+          p (rf.story.plan/variant-plan :story.x/seed {:lookup m})]
       (is (= {:k 1} (get-in p [:world :db-seed])))
       (is (contains? (get-in p [:world :fidelity]) :db-seed)))))
 
@@ -773,7 +773,7 @@
     (let [m {:story.cart/argseed
              {:args    {:qty 7}
               :db-seed {:cart {:qty [:arg :qty]}}}}
-          p (plan/variant-plan :story.cart/argseed {:lookup m})]
+          p (rf.story.plan/variant-plan :story.cart/argseed {:lookup m})]
       (is (= {:cart {:qty 7}} (get-in p [:world :db-seed])))
       (is (some #(= {:key :qty :value 7} %) (get-in p [:explain :substitutions]))))))
 
@@ -782,7 +782,7 @@
     (let [m {:story.p/base  {:db-seed {:cart {:items []} :flags {:a true}}}
              :story.p/child {:extends :story.p/base
                              :db-seed {:cart {:items [1 2]}}}}
-          p (plan/variant-plan :story.p/child {:lookup m})]
+          p (rf.story.plan/variant-plan :story.p/child {:lookup m})]
       ;; deep-merge: child wins :cart, parent's :flags survives.
       (is (= {:cart {:items [1 2]} :flags {:a true}}
              (get-in p [:world :db-seed])))
@@ -794,7 +794,7 @@
           m    {:story.cart/composed
                 {:compose [:fragment/seed]
                  :db-seed {:session :member}}} ; variant overrides the key
-          p (plan/variant-plan :story.cart/composed
+          p (rf.story.plan/variant-plan :story.cart/composed
                                {:lookup m :fragment-lookup frag})]
       (is (= {:cart {:items []} :session :member}
              (get-in p [:world :db-seed])))
@@ -803,24 +803,24 @@
 (deftest db-seed-empty-is-no-rung
   (testing "an empty resolved :db-seed activates no rung + carries no world slot"
     (let [m {:story.cart/emptyseed {:db-seed {}}}
-          p (plan/variant-plan :story.cart/emptyseed {:lookup m})]
+          p (rf.story.plan/variant-plan :story.cart/emptyseed {:lookup m})]
       (is (nil? (get-in p [:world :db-seed])))
       (is (nil? (get-in p [:world :fidelity]))))))
 
 (deftest compute-fidelity-three-rungs
   (testing "compute-fidelity computes each of the three rungs independently"
-    (is (= #{} (plan/compute-fidelity {})))
+    (is (= #{} (rf.story.plan/compute-fidelity {})))
     (is (= #{:real-setup}
-           (plan/compute-fidelity {:setup [[:dispatch [:e]]]})))
+           (rf.story.plan/compute-fidelity {:setup [[:dispatch [:e]]]})))
     (is (= #{:db-seed}
-           (plan/compute-fidelity {:db-seed {:k 1}})))
+           (rf.story.plan/compute-fidelity {:db-seed {:k 1}})))
     (is (= #{:sub-overrides}
-           (plan/compute-fidelity {:sub-overrides {[:q] 1}})))
+           (rf.story.plan/compute-fidelity {:sub-overrides {[:q] 1}})))
     (testing "an empty seed / override map is treated as absent (no rung)"
-      (is (= #{} (plan/compute-fidelity {:db-seed {} :sub-overrides {}}))))
+      (is (= #{} (rf.story.plan/compute-fidelity {:db-seed {} :sub-overrides {}}))))
     (testing "all three rungs together"
       (is (= #{:real-setup :db-seed :sub-overrides}
-             (plan/compute-fidelity {:setup         [[:dispatch [:e]]]
+             (rf.story.plan/compute-fidelity {:setup         [[:dispatch [:e]]]
                                      :db-seed       {:k 1}
                                      :sub-overrides {[:q] 1}}))))))
 
@@ -829,24 +829,24 @@
 (deftest sub-overrides-render-path-resolver-is-exact
   (testing "resolve returns the override value on an exact query-vector match"
     (let [ovr {[:login/state] :error [:item 7] {:sku "X"}}]
-      (is (= :error      (sub-overrides/resolve ovr [:login/state])))
-      (is (= {:sku "X"}  (sub-overrides/resolve ovr [:item 7])))))
+      (is (= :error      (rf.story.sub-overrides/resolve ovr [:login/state])))
+      (is (= {:sku "X"}  (rf.story.sub-overrides/resolve ovr [:item 7])))))
   (testing "a non-exact query (different args / sub-id) MISSES — no fuzzing"
     (let [ovr {[:item 7] {:sku "X"}}]
-      (is (sub-overrides/miss? (sub-overrides/resolve ovr [:item 8])))
-      (is (sub-overrides/miss? (sub-overrides/resolve ovr [:item])))
-      (is (sub-overrides/miss? (sub-overrides/resolve ovr [:other 7])))))
+      (is (rf.story.sub-overrides/miss? (rf.story.sub-overrides/resolve ovr [:item 8])))
+      (is (rf.story.sub-overrides/miss? (rf.story.sub-overrides/resolve ovr [:item])))
+      (is (rf.story.sub-overrides/miss? (rf.story.sub-overrides/resolve ovr [:other 7])))))
   (testing "an override whose VALUE is nil is a genuine hit (sentinel is distinct)"
     (let [ovr {[:login/user] nil}]
-      (is (sub-overrides/overridden? ovr [:login/user]))
-      (is (nil? (sub-overrides/resolve ovr [:login/user])))))
+      (is (rf.story.sub-overrides/overridden? ovr [:login/user]))
+      (is (nil? (rf.story.sub-overrides/resolve ovr [:login/user])))))
   (testing "read surfaces the override and skips real-read; misses fall through"
     (let [ovr {[:login/state] :error}]
-      (is (= :error (sub-overrides/with-overrides* ovr
-                      #(sub-overrides/read [:login/state]
+      (is (= :error (rf.story.sub-overrides/with-overrides* ovr
+                      #(rf.story.sub-overrides/read [:login/state]
                                            (fn [] (throw (ex-info "should not run" {})))))))
-      (is (= :real  (sub-overrides/with-overrides* ovr
-                      #(sub-overrides/read [:login/other] (fn [] :real))))))))
+      (is (= :real  (rf.story.sub-overrides/with-overrides* ovr
+                      #(rf.story.sub-overrides/read [:login/other] (fn [] :real))))))))
 
 ;; ===========================================================================
 ;; Assertion-atom fold (rf2-5x1wt.18, spec/017 §Assertions — one atom,
@@ -1136,17 +1136,17 @@
 ;; ---- pure fold helpers (assertion-ns surface) ----------------------------
 
 (deftest fold-helpers-are-pure-and-position-agnostic
-  (testing "assertions/fold-assert-step folds the shipping sugar steps"
+  (testing "rf.story.assertions/fold-assert-step folds the shipping sugar steps"
     (is (= [:assert [:rf.assert/path-equals [:n] 5]]
-           (assertions/fold-assert-step [:assert-db [:n] 5])))
+           (rf.story.assertions/fold-assert-step [:assert-db [:n] 5])))
     (is (= [:assert [:rf.assert/dom-visible "#x"]]
-           (assertions/fold-assert-step [:assert-dom "#x" :visible]))))
+           (rf.story.assertions/fold-assert-step [:assert-dom "#x" :visible]))))
   (testing "fold-assert-step is identity for non-foldable steps"
-    (is (= [:dispatch [:e]] (assertions/fold-assert-step [:dispatch [:e]])))
+    (is (= [:dispatch [:e]] (rf.story.assertions/fold-assert-step [:dispatch [:e]])))
     (is (= [:assert [:rf.assert/no-warnings]]
-           (assertions/fold-assert-step [:assert [:rf.assert/no-warnings]])))
-    (is (= [:wait 10] (assertions/fold-assert-step [:wait 10]))))
+           (rf.story.assertions/fold-assert-step [:assert [:rf.assert/no-warnings]])))
+    (is (= [:wait 10] (rf.story.assertions/fold-assert-step [:wait 10]))))
   (testing "known-assertion-ids covers the seven shipping ids + the DOM family"
-    (is (every? assertions/assertion-id-known? assertions/canonical-assertion-ids))
-    (is (every? assertions/assertion-id-known? assertions/dom-assertion-ids))
-    (is (not (assertions/assertion-id-known? :rf.assert/totally-made-up)))))
+    (is (every? rf.story.assertions/assertion-id-known? rf.story.assertions/canonical-assertion-ids))
+    (is (every? rf.story.assertions/assertion-id-known? rf.story.assertions/dom-assertion-ids))
+    (is (not (rf.story.assertions/assertion-id-known? :rf.assert/totally-made-up)))))

--- a/tools/story/test/re_frame/story/play/browser_test.cljc
+++ b/tools/story/test/re_frame/story/play/browser_test.cljc
@@ -21,9 +21,9 @@
   The capability/requirement + cannot-run contract for these ids lives in
   `re-frame.story.requirements-test`; this suite covers the EXECUTOR."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.assertions    :as assertions]
-            [re-frame.story.requirements  :as req]
-            [re-frame.story.play.browser  :as browser]))
+            [re-frame.story.assertions    :as rf.story.assertions]
+            [re-frame.story.requirements  :as rf.story.requirements]
+            [re-frame.story.play.browser  :as rf.story.play.browser]))
 
 ;; ===========================================================================
 ;; HEADLESS FAIL-CLOSED — browser-tier assertions return :cannot-run
@@ -32,8 +32,8 @@
 (deftest headless-visual-snapshot-cannot-run
   (testing "a headless run returns :cannot-run for :rf.assert/visual-snapshot"
     ;; On the JVM `browser-available?` is false — the headless contract.
-    (is (false? (browser/browser-available?)))
-    (let [rec (browser/eval-visual-snapshot [] {:snapshot-identity {:content-hash "abcd1234"}})]
+    (is (false? (rf.story.play.browser/browser-available?)))
+    (let [rec (rf.story.play.browser/eval-visual-snapshot [] {:snapshot-identity {:content-hash "abcd1234"}})]
       (is (= :rf.assert/visual-snapshot (:assertion rec)))
       (is (= :cannot-run (:status rec)) "headless visual snapshot is :cannot-run, never a silent pass")
       (is (true? (:cannot-run? rec)))
@@ -42,7 +42,7 @@
 
 (deftest headless-axe-a11y-cannot-run
   (testing "a headless run returns :cannot-run for axe-style :rf.assert/a11y"
-    (let [rec (browser/eval-a11y [] {:violations [{:id "label" :impact "critical"}]})]
+    (let [rec (rf.story.play.browser/eval-a11y [] {:violations [{:id "label" :impact "critical"}]})]
       (is (= :rf.assert/a11y (:assertion rec)))
       (is (= :cannot-run (:status rec)) "headless axe a11y is :cannot-run, never a silent pass")
       (is (true? (:cannot-run? rec)))
@@ -50,7 +50,7 @@
 
 (deftest cannot-run-finding-rides-the-assertion-record-shape
   (testing ":cannot-run findings carry the ONE assertion-record shape"
-    (let [rec (browser/eval-visual-snapshot [{:opt 1}] {})]
+    (let [rec (rf.story.play.browser/eval-visual-snapshot [{:opt 1}] {})]
       ;; same slots every other assertion record carries (.19 shape)
       (is (contains? rec :assertion))
       (is (contains? rec :payload))
@@ -69,7 +69,7 @@
                 [:button "Submit"]
                 [:a {:href "/x"} "home"]
                 [:input {:type "text" :aria-label "name"}]]
-          rec  (browser/eval-structural-a11y [] {:hiccup tree})]
+          rec  (rf.story.play.browser/eval-structural-a11y [] {:hiccup tree})]
       (is (= :rf.assert/a11y-structural (:assertion rec)))
       (is (= :pass (:status rec)))
       (is (true? (:passed? rec)))
@@ -78,7 +78,7 @@
 
 (deftest structural-a11y-detects-img-missing-alt
   (testing "an :img with no :alt is a structural issue"
-    (let [rec (browser/eval-structural-a11y [] {:hiccup [:div [:img {:src "/k.png"}]]})]
+    (let [rec (rf.story.play.browser/eval-structural-a11y [] {:hiccup [:div [:img {:src "/k.png"}]]})]
       (is (= :fail (:status rec)))
       (is (false? (:passed? rec)))
       (is (= 1 (:count rec)))
@@ -86,11 +86,11 @@
 
 (deftest structural-a11y-detects-control-missing-name
   (testing "an interactive control with no accessible name is a structural issue"
-    (let [rec (browser/eval-structural-a11y [] {:hiccup [:div [:button {:class "x"}]]})]
+    (let [rec (rf.story.play.browser/eval-structural-a11y [] {:hiccup [:div [:button {:class "x"}]]})]
       (is (= :fail (:status rec)))
       (is (= :control-missing-name (-> rec :actual first :rule)))))
   (testing "a control with aria-label is fine"
-    (let [rec (browser/eval-structural-a11y
+    (let [rec (rf.story.play.browser/eval-structural-a11y
                 [] {:hiccup [:div [:button {:aria-label "close"}]]})]
       (is (= :pass (:status rec))))))
 
@@ -99,18 +99,18 @@
   ;; structural a11y issue; the structural floor now flags it (the docstring
   ;; no longer claims a call-site check that did not exist).
   (testing "an :input with no accessible name and a named type is flagged"
-    (let [rec (browser/eval-structural-a11y [] {:hiccup [:div [:input {:type "text"}]]})]
+    (let [rec (rf.story.play.browser/eval-structural-a11y [] {:hiccup [:div [:input {:type "text"}]]})]
       (is (= :fail (:status rec)))
       (is (= :control-missing-name (-> rec :actual first :rule)))
       (is (= :input (-> rec :actual first :tag)))))
   (testing "a :type-less :input defaults to text and is flagged when unnamed"
-    (let [rec (browser/eval-structural-a11y [] {:hiccup [:div [:input {}]]})]
+    (let [rec (rf.story.play.browser/eval-structural-a11y [] {:hiccup [:div [:input {}]]})]
       (is (= :fail (:status rec)))
       (is (= :control-missing-name (-> rec :actual first :rule)))))
   (testing "a labeled :input is clean (aria-label / title supply the name)"
-    (is (= :pass (:status (browser/eval-structural-a11y
+    (is (= :pass (:status (rf.story.play.browser/eval-structural-a11y
                             [] {:hiccup [:div [:input {:type "text" :aria-label "name"}]]}))))
-    (is (= :pass (:status (browser/eval-structural-a11y
+    (is (= :pass (:status (rf.story.play.browser/eval-structural-a11y
                             [] {:hiccup [:div [:input {:type :email :title "email"}]]}))))))
 
 (deftest structural-a11y-name-exempt-input-types-pass
@@ -118,20 +118,20 @@
   ;; an explicit accessible name (not rendered, or named via :value / :alt).
   (testing "name-exempt input types are clean even without an accessible name"
     (doseq [t ["hidden" "submit" "reset" "button" "image" :hidden :submit]]
-      (let [rec (browser/eval-structural-a11y [] {:hiccup [:div [:input {:type t}]]})]
+      (let [rec (rf.story.play.browser/eval-structural-a11y [] {:hiccup [:div [:input {:type t}]]})]
         (is (= :pass (:status rec))
             (str "input :type " (pr-str t) " should not require a name"))))))
 
 (deftest structural-a11y-detects-positive-tabindex
   (testing "a positive :tabIndex is a structural issue (both spellings)"
-    (let [rec  (browser/eval-structural-a11y [] {:hiccup [:div {:tabIndex 3} "x"]})
-          rec2 (browser/eval-structural-a11y [] {:hiccup [:div {:tab-index 5} "y"]})]
+    (let [rec  (rf.story.play.browser/eval-structural-a11y [] {:hiccup [:div {:tabIndex 3} "x"]})
+          rec2 (rf.story.play.browser/eval-structural-a11y [] {:hiccup [:div {:tab-index 5} "y"]})]
       (is (= :fail (:status rec)))
       (is (= :positive-tabindex (-> rec :actual first :rule)))
       (is (= :fail (:status rec2)) ":tab-index spelling is also caught")))
   (testing "tabIndex 0 / -1 are NOT issues"
-    (is (= :pass (:status (browser/eval-structural-a11y [] {:hiccup [:div {:tabIndex 0} "x"]}))))
-    (is (= :pass (:status (browser/eval-structural-a11y [] {:hiccup [:div {:tabIndex -1} "x"]}))))))
+    (is (= :pass (:status (rf.story.play.browser/eval-structural-a11y [] {:hiccup [:div {:tabIndex 0} "x"]}))))
+    (is (= :pass (:status (rf.story.play.browser/eval-structural-a11y [] {:hiccup [:div {:tabIndex -1} "x"]}))))))
 
 (deftest structural-a11y-walks-nested-and-tag-suffix
   (testing "the walk recurses into children and strips #id/.class tag suffixes"
@@ -139,7 +139,7 @@
                 [:div.row
                  [:img.thumb {:src "/a.png"}]    ; missing alt
                  [:button.btn#go]]]              ; missing name
-          rec  (browser/eval-structural-a11y [] {:hiccup tree})]
+          rec  (rf.story.play.browser/eval-structural-a11y [] {:hiccup tree})]
       (is (= :fail (:status rec)))
       (is (= #{:img-missing-alt :control-missing-name}
              (set (map :rule (:actual rec))))
@@ -148,12 +148,12 @@
 (deftest structural-a11y-runs-at-hiccup-tier
   (testing ":rf.assert/a11y-structural requires only :hiccup-structure"
     (is (= #{:hiccup-structure}
-           (req/assertion-tokens [:rf.assert/a11y-structural])))
-    (is (= :hiccup (req/cheapest-runner #{:hiccup-structure}))
+           (rf.story.requirements/assertion-tokens [:rf.assert/a11y-structural])))
+    (is (= :hiccup (rf.story.requirements/cheapest-runner #{:hiccup-structure}))
         "the cheapest runner proving structural a11y is :hiccup, NOT :browser")
     ;; a hiccup runner satisfies it; headless does not.
-    (is (req/runner-satisfies? (req/runner-provides :hiccup) #{:hiccup-structure}))
-    (is (not (req/runner-satisfies? (req/runner-provides :headless) #{:hiccup-structure})))))
+    (is (rf.story.requirements/runner-satisfies? (rf.story.requirements/runner-provides :hiccup) #{:hiccup-structure}))
+    (is (not (rf.story.requirements/runner-satisfies? (rf.story.requirements/runner-provides :headless) #{:hiccup-structure})))))
 
 ;; ===========================================================================
 ;; LIVE a11y READER SEAM — the inverted, late-bound hook
@@ -161,16 +161,16 @@
 
 (deftest a11y-reader-seam-is-reusable-and-nil-safe
   (testing "live-a11y-violations reads through the registered reader; nil-safe when absent"
-    (let [saved @browser/a11y-reader]
+    (let [saved @rf.story.play.browser/a11y-reader]
       (try
-        (reset! browser/a11y-reader nil)
-        (is (nil? (browser/live-a11y-violations :frame/x)) "no reader → nil")
-        (browser/register-a11y-reader!
+        (reset! rf.story.play.browser/a11y-reader nil)
+        (is (nil? (rf.story.play.browser/live-a11y-violations :frame/x)) "no reader → nil")
+        (rf.story.play.browser/register-a11y-reader!
           (fn [fid] (when (= :frame/x fid) [{:id "color-contrast" :impact "serious"}])))
         (is (= [{:id "color-contrast" :impact "serious"}]
-               (browser/live-a11y-violations :frame/x)))
-        (is (nil? (browser/live-a11y-violations :frame/other)))
-        (finally (reset! browser/a11y-reader saved))))))
+               (rf.story.play.browser/live-a11y-violations :frame/x)))
+        (is (nil? (rf.story.play.browser/live-a11y-violations :frame/other)))
+        (finally (reset! rf.story.play.browser/a11y-reader saved))))))
 
 ;; ===========================================================================
 ;; AXE FINDING SELECTOR RECOVERY — :nodes → :target source link (rf2-ffu8t)
@@ -184,7 +184,7 @@
 ;; recovery so the source-link MUST (spec/021 §4 + §5) is met.
 
 (deftest violation-targets-recovers-node-selectors
-  (let [violation-targets @#'browser/violation-targets]
+  (let [violation-targets @#'rf.story.play.browser/violation-targets]
     (testing "the CSS selectors are recovered from :nodes → :target, deduped"
       (is (= ["main > img:nth-child(2)"]
              (violation-targets
@@ -200,7 +200,7 @@
       (is (= [] (violation-targets {:nodes [{:target []}]}))))))
 
 (deftest axe-finding-threads-selector-onto-the-record
-  (let [axe-finding @#'browser/axe-finding]
+  (let [axe-finding @#'rf.story.play.browser/axe-finding]
     (testing "the axe finding carries :id/:impact/:help PLUS the recovered
               :selector (first target) and :targets (all)"
       (is (= {:id "image-alt" :impact "critical" :help "Images must have alt"
@@ -219,26 +219,26 @@
 
 (deftest browser-assertion-predicate
   (testing "browser-assertion? recognises the three oracle ids only"
-    (is (browser/browser-assertion? [:rf.assert/visual-snapshot]))
-    (is (browser/browser-assertion? [:rf.assert/a11y]))
-    (is (browser/browser-assertion? [:rf.assert/a11y-structural]))
-    (is (not (browser/browser-assertion? [:rf.assert/path-equals [:n] 1])))
-    (is (not (browser/browser-assertion? [:rf.assert/dom-visible "[x]"])))))
+    (is (rf.story.play.browser/browser-assertion? [:rf.assert/visual-snapshot]))
+    (is (rf.story.play.browser/browser-assertion? [:rf.assert/a11y]))
+    (is (rf.story.play.browser/browser-assertion? [:rf.assert/a11y-structural]))
+    (is (not (rf.story.play.browser/browser-assertion? [:rf.assert/path-equals [:n] 1])))
+    (is (not (rf.story.play.browser/browser-assertion? [:rf.assert/dom-visible "[x]"])))))
 
 (deftest eval-browser-assertion-routes-by-id
   (testing "eval-browser-assertion routes each oracle atom to its evaluator"
     ;; structural runs JVM-side (hiccup tree)
-    (let [rec (browser/eval-browser-assertion
+    (let [rec (rf.story.play.browser/eval-browser-assertion
                 [:rf.assert/a11y-structural] {:hiccup [:div [:img]]})]
       (is (= :rf.assert/a11y-structural (:assertion rec)))
       (is (= :fail (:status rec))))
     ;; visual / a11y are :cannot-run headless
-    (is (= :cannot-run (:status (browser/eval-browser-assertion
+    (is (= :cannot-run (:status (rf.story.play.browser/eval-browser-assertion
                                   [:rf.assert/visual-snapshot] {}))))
-    (is (= :cannot-run (:status (browser/eval-browser-assertion
+    (is (= :cannot-run (:status (rf.story.play.browser/eval-browser-assertion
                                   [:rf.assert/a11y] {}))))
     ;; a non-oracle atom is not handled here
-    (is (nil? (browser/eval-browser-assertion [:rf.assert/path-equals [:n] 1] {})))))
+    (is (nil? (rf.story.play.browser/eval-browser-assertion [:rf.assert/path-equals [:n] 1] {})))))
 
 ;; ===========================================================================
 ;; ID + KNOWN-SET INTEGRATION — the new id is recognised by the vocabulary
@@ -246,10 +246,10 @@
 
 (deftest browser-tier-ids-are-known-assertions
   (testing "the browser-tier ids are in the recognised vocabulary"
-    (is (contains? assertions/browser-assertion-ids :rf.assert/visual-snapshot))
-    (is (contains? assertions/browser-assertion-ids :rf.assert/a11y))
-    (is (contains? assertions/browser-assertion-ids :rf.assert/a11y-structural))
+    (is (contains? rf.story.assertions/browser-assertion-ids :rf.assert/visual-snapshot))
+    (is (contains? rf.story.assertions/browser-assertion-ids :rf.assert/a11y))
+    (is (contains? rf.story.assertions/browser-assertion-ids :rf.assert/a11y-structural))
     ;; plan construction accepts them (assertion-id-known?)
-    (is (assertions/assertion-id-known? :rf.assert/visual-snapshot))
-    (is (assertions/assertion-id-known? :rf.assert/a11y))
-    (is (assertions/assertion-id-known? :rf.assert/a11y-structural))))
+    (is (rf.story.assertions/assertion-id-known? :rf.assert/visual-snapshot))
+    (is (rf.story.assertions/assertion-id-known? :rf.assert/a11y))
+    (is (rf.story.assertions/assertion-id-known? :rf.assert/a11y-structural))))

--- a/tools/story/test/re_frame/story/play/ci_runner_test.cljc
+++ b/tools/story/test/re_frame/story/play/ci_runner_test.cljc
@@ -6,14 +6,14 @@
   exercised by the browser-side runner in
   `examples/scripts/serve-and-run-story-play-scripts.cjs`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story.play.ci-runner :as ci]
-            [re-frame.story.play.runner    :as runner]
-            [re-frame.story.registrar      :as registrar]))
+            [re-frame.story.play.ci-runner :as rf.story.play.ci-runner]
+            [re-frame.story.play.runner    :as rf.story.play.runner]
+            [re-frame.story.registrar      :as rf.story.registrar]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
 (defn- reset-registrar [test-fn]
-  (registrar/clear-all!)
+  (rf.story.registrar/clear-all!)
   (test-fn))
 
 (use-fixtures :each reset-registrar)
@@ -22,22 +22,22 @@
 
 (deftest has-play-script-missing
   (testing "has-play-script? is false when :script is absent"
-    (is (false? (ci/has-play-script? {})))
-    (is (false? (ci/has-play-script? {:setup [[:foo]]})))))
+    (is (false? (rf.story.play.ci-runner/has-play-script? {})))
+    (is (false? (rf.story.play.ci-runner/has-play-script? {:setup [[:foo]]})))))
 
 (deftest has-play-script-empty
   (testing "has-play-script? is false for empty vectors / maps"
-    (is (false? (ci/has-play-script? {:script []})))
-    (is (false? (ci/has-play-script? {:script {:script []}})))
-    (is (false? (ci/has-play-script? {:script {}})))))
+    (is (false? (rf.story.play.ci-runner/has-play-script? {:script []})))
+    (is (false? (rf.story.play.ci-runner/has-play-script? {:script {:script []}})))
+    (is (false? (rf.story.play.ci-runner/has-play-script? {:script {}})))))
 
 (deftest has-play-script-bare-vector
   (testing "has-play-script? is true for a non-empty bare vector"
-    (is (true? (ci/has-play-script? {:script [[:dispatch [:foo]]]})))))
+    (is (true? (rf.story.play.ci-runner/has-play-script? {:script [[:dispatch [:foo]]]})))))
 
 (deftest has-play-script-map-form
   (testing "has-play-script? is true for a map with at least one step"
-    (is (true? (ci/has-play-script?
+    (is (true? (rf.story.play.ci-runner/has-play-script?
                  {:script {:script [[:dispatch [:foo]]]
                                 :auto-run? true}})))))
 
@@ -53,7 +53,7 @@
                 :story.d/empty-script   {:script []}
                 :story.e/empty-map      {:script {:script []}}}]
       (is (= [:story.a/with-script :story.c/with-map-form]
-             (ci/variants-with-play-scripts regs))))))
+             (rf.story.play.ci-runner/variants-with-play-scripts regs))))))
 
 (deftest discovery-from-live-registrar
   (testing "no-arg discovery reads from the live Story registrar
@@ -61,36 +61,36 @@
     ;; Inject directly into the side-table — the schema-validated
     ;; reg-variant* path needs the canonical vocabulary which is
     ;; out of scope for a discovery test.
-    (swap! registrar/kind->id->body assoc-in
+    (swap! rf.story.registrar/kind->id->body assoc-in
            [:variant :story.t/script]
            {:script [[:dispatch [:foo]]]})
-    (swap! registrar/kind->id->body assoc-in
+    (swap! rf.story.registrar/kind->id->body assoc-in
            [:variant :story.t/no-script]
            {:setup [[:foo]]})
-    (is (= [:story.t/script] (ci/variants-with-play-scripts)))
+    (is (= [:story.t/script] (rf.story.play.ci-runner/variants-with-play-scripts)))
 
     ;; A third variant with a `:script` lands in sorted order.
-    (swap! registrar/kind->id->body assoc-in
+    (swap! rf.story.registrar/kind->id->body assoc-in
            [:variant :story.t/another]
            {:script {:script [[:wait 0]]}})
     (is (= [:story.t/another :story.t/script]
-           (ci/variants-with-play-scripts)))))
+           (rf.story.play.ci-runner/variants-with-play-scripts)))))
 
 (deftest discovery-with-zero-variants
   (testing "discovery returns the empty vector when nothing is registered"
-    (is (= [] (ci/variants-with-play-scripts)))))
+    (is (= [] (rf.story.play.ci-runner/variants-with-play-scripts)))))
 
 ;; ---- ci-context ----------------------------------------------------------
 
 (deftest ci-context-shape
   (testing "ci-context bundles the variant list + per-play rows"
-    (swap! registrar/kind->id->body assoc-in
+    (swap! rf.story.registrar/kind->id->body assoc-in
            [:variant :story.c/a]
            {:script [[:dispatch [:a]]]})
-    (swap! registrar/kind->id->body assoc-in
+    (swap! rf.story.registrar/kind->id->body assoc-in
            [:variant :story.c/b]
            {:script {:script [[:wait 0]] :auto-run? false :name "b"}})
-    (let [ctx (ci/ci-context)]
+    (let [ctx (rf.story.play.ci-runner/ci-context)]
       (is (= [:story.c/a :story.c/b] (:variants ctx)))
       (is (not (contains? ctx :summaries))
           "the legacy per-variant :summaries projection is dropped (rf2-k9u0h)")
@@ -101,11 +101,11 @@
 ;; ---- terminal? -----------------------------------------------------------
 
 (deftest terminal?-recognises-pass-and-fail-only
-  (is (true?  (ci/terminal? {:status :pass})))
-  (is (true?  (ci/terminal? {:status :fail})))
-  (is (false? (ci/terminal? {:status :running})))
-  (is (false? (ci/terminal? {:status :idle})))
-  (is (false? (ci/terminal? nil))))
+  (is (true?  (rf.story.play.ci-runner/terminal? {:status :pass})))
+  (is (true?  (rf.story.play.ci-runner/terminal? {:status :fail})))
+  (is (false? (rf.story.play.ci-runner/terminal? {:status :running})))
+  (is (false? (rf.story.play.ci-runner/terminal? {:status :idle})))
+  (is (false? (rf.story.play.ci-runner/terminal? nil))))
 
 ;; ---- project-state -------------------------------------------------------
 
@@ -121,13 +121,13 @@
                  :finished-ms 200
                  :script      [[:assert-db [:k] 1]
                                [:assert-db [:k] 2]]
-                 :results     [(runner/step-pass 0 [:dispatch [:a]])
-                               (runner/step-fail 1 [:assert-db [:k] 2]
+                 :results     [(rf.story.play.runner/step-pass 0 [:dispatch [:a]])
+                               (rf.story.play.runner/step-fail 1 [:assert-db [:k] 2]
                                                  {:expected 2
                                                   :actual   1
                                                   :message  "msg"})
-                               (runner/step-exception 2 [:dispatch [:b]] "boom")]}
-          out   (ci/project-state state)]
+                               (rf.story.play.runner/step-exception 2 [:dispatch [:b]] "boom")]}
+          out   (rf.story.play.ci-runner/project-state state)]
       (is (= :fail (:status out)))
       (is (= 2     (:step-idx out)))
       (is (= 3     (:total out)))
@@ -144,19 +144,19 @@
         (is (= "msg" (:message r1)))))))
 
 (deftest project-state-nil-yields-nil
-  (is (nil? (ci/project-state nil))))
+  (is (nil? (rf.story.play.ci-runner/project-state nil))))
 
 ;; ---- multi-play (rf2-tl7zk) ----------------------------------------------
 
 (deftest has-plays?-recognises-non-empty-plays
-  (is (false? (ci/has-plays? {})))
-  (is (false? (ci/has-plays? {:plays []})))
-  (is (true?  (ci/has-plays? {:plays [{:name "p" :script [[:dispatch [:a]]]}]}))))
+  (is (false? (rf.story.play.ci-runner/has-plays? {})))
+  (is (false? (rf.story.play.ci-runner/has-plays? {:plays []})))
+  (is (true?  (rf.story.play.ci-runner/has-plays? {:plays [{:name "p" :script [[:dispatch [:a]]]}]}))))
 
 (deftest has-any-play?-or-of-both
-  (is (false? (ci/has-any-play? {})))
-  (is (true?  (ci/has-any-play? {:script [[:dispatch [:a]]]})))
-  (is (true?  (ci/has-any-play? {:plays [{:name "p" :script [[:dispatch [:a]]]}]}))))
+  (is (false? (rf.story.play.ci-runner/has-any-play? {})))
+  (is (true?  (rf.story.play.ci-runner/has-any-play? {:script [[:dispatch [:a]]]})))
+  (is (true?  (rf.story.play.ci-runner/has-any-play? {:plays [{:name "p" :script [[:dispatch [:a]]]}]}))))
 
 (deftest discovery-includes-plays-variants
   (testing "variants-with-play-scripts picks up :plays-carrying bodies"
@@ -165,7 +165,7 @@
                                           {:name "p2" :script [[:dispatch [:b2]]]}]}
                 :story.c/none    {:setup []}}]
       (is (= [:story.a/single :story.b/multi]
-             (ci/variants-with-play-scripts regs))))))
+             (rf.story.play.ci-runner/variants-with-play-scripts regs))))))
 
 (deftest ci-rows-enumerates-plays-per-variant
   (testing "ci-rows produces one row per play; single-script variants produce one row"
@@ -179,7 +179,7 @@
                           :auto-run? true}]}
 
                 :story.c/no-play {:setup []}}
-          rows (ci/ci-rows regs)]
+          rows (rf.story.play.ci-runner/ci-rows regs)]
       (is (= 3 (count rows))
           "single + multi(2) = 3 rows total")
       (is (= [[:story.a/single "single-named"]
@@ -195,7 +195,7 @@
 (deftest ci-rows-handles-bare-play-script
   (testing "a bare :script (no :name) yields a row with :play-key nil"
     (let [regs {:story.x/bare {:script [[:dispatch [:a]]]}}
-          rows (ci/ci-rows regs)]
+          rows (rf.story.play.ci-runner/ci-rows regs)]
       (is (= 1 (count rows)))
       (is (nil? (:play-key (first rows))))
       (is (= 1   (:script-len (first rows))))
@@ -204,14 +204,14 @@
 
 (deftest ci-context-includes-rows
   (testing "ci-context exposes the per-play rows alongside :variants"
-    (swap! registrar/kind->id->body assoc-in
+    (swap! rf.story.registrar/kind->id->body assoc-in
            [:variant :story.ctx/multi]
            {:plays [{:name "a" :script [[:dispatch [:foo]]]}
                     {:name "b" :script [[:dispatch [:bar]]]}]})
-    (swap! registrar/kind->id->body assoc-in
+    (swap! rf.story.registrar/kind->id->body assoc-in
            [:variant :story.ctx/single]
            {:script {:name "lone" :script [[:dispatch [:baz]]]}})
-    (let [ctx (ci/ci-context)]
+    (let [ctx (rf.story.play.ci-runner/ci-context)]
       (is (= [:story.ctx/multi :story.ctx/single] (:variants ctx)))
       ;; rows are per-PLAY — multi(2) + single(1) = 3 rows.
       (is (= 3 (count (:rows ctx))))

--- a/tools/story/test/re_frame/story/play/evidence_test.cljc
+++ b/tools/story/test/re_frame/story/play/evidence_test.cljc
@@ -15,7 +15,7 @@
   - no separate accumulator can report pass when the epoch tape shows a
     failure (`tape-shows-failure?` reads the projection, not a sibling)."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.play.evidence :as evidence]))
+            [re-frame.story.play.evidence :as rf.story.play.evidence]))
 
 ;; ---- fixture trace / epoch builders --------------------------------------
 
@@ -74,7 +74,7 @@
                           :trace-events  [(run-start-trace 10 [:checkout/submit] 100)
                                           (schema-trace 11 :event :checkout/submit
                                                         {:path [:cart] :value :bad})]})]
-          violations (evidence/schema-violations tape)]
+          violations (rf.story.play.evidence/schema-violations tape)]
       (is (= 1 (count violations)))
       (let [v (first violations)]
         (is (= :event (:where v)))
@@ -85,14 +85,14 @@
 
 (deftest schema-violation-selectors-per-surface
   (testing "selectors key per the §Schema-rule surface grammar"
-    (is (= [:event :e/id]            (evidence/violation-selector {:where :event :failing-id :e/id})))
-    (is (= [:event :e/id [:p]]       (evidence/violation-selector {:where :event :failing-id :e/id :path [:p]})))
-    (is (= [:cofx :c/id]             (evidence/violation-selector {:where :cofx :failing-id :c/id})))
-    (is (= [:fx-args :fx/id]         (evidence/violation-selector {:where :fx-args :failing-id :fx/id})))
-    (is (= [:sub-return :s/id [:q]]  (evidence/violation-selector {:where :sub-return :failing-id :s/id :query-v [:q]})))
-    (is (= [:app-db [:root] [:leaf]] (evidence/violation-selector {:where :app-db :registered-path [:root] :path [:leaf]})))
+    (is (= [:event :e/id]            (rf.story.play.evidence/violation-selector {:where :event :failing-id :e/id})))
+    (is (= [:event :e/id [:p]]       (rf.story.play.evidence/violation-selector {:where :event :failing-id :e/id :path [:p]})))
+    (is (= [:cofx :c/id]             (rf.story.play.evidence/violation-selector {:where :cofx :failing-id :c/id})))
+    (is (= [:fx-args :fx/id]         (rf.story.play.evidence/violation-selector {:where :fx-args :failing-id :fx/id})))
+    (is (= [:sub-return :s/id [:q]]  (rf.story.play.evidence/violation-selector {:where :sub-return :failing-id :s/id :query-v [:q]})))
+    (is (= [:app-db [:root] [:leaf]] (rf.story.play.evidence/violation-selector {:where :app-db :registered-path [:root] :path [:leaf]})))
     (is (= [:machine-data :m/id :macrostep]
-           (evidence/violation-selector {:where :machine-data :machine-id :m/id :phase :macrostep})))))
+           (rf.story.play.evidence/violation-selector {:where :machine-data :machine-id :m/id :phase :macrostep})))))
 
 (deftest multiple-violations-projected-in-tape-order
   (testing "violations across epochs project in dispatch order, emission order within"
@@ -100,7 +100,7 @@
                                          (schema-trace 11 :cofx :b {})]})
                 (epoch 2 {:trace-events [(schema-trace 20 :app-db {}
                                                        {:registered-path [:x] :path [:x :y]})]})]
-          violations (evidence/schema-violations tape)]
+          violations (rf.story.play.evidence/schema-violations tape)]
       (is (= [10 11 20] (mapv :trace-id violations)))
       (is (= [1 1 2]    (mapv :epoch-id violations))))))
 
@@ -113,7 +113,7 @@
     (let [tape [(epoch 1 {:trace-events [(warning-trace 10 :rf.warning/foo :rf.warning/foo)
                                          {:operation :rf.event/run-start :op-type :trace :id 11 :tags {}}]})
                 (epoch 2 {:trace-events [(warning-trace 20 :rf.warning/bar :rf.warning/bar)]})]
-          ws (evidence/warnings tape)]
+          ws (rf.story.play.evidence/warnings tape)]
       (is (= 2 (count ws)))
       (is (= [:rf.warning/foo :rf.warning/bar] (mapv :operation ws)))
       (is (= [1 2] (mapv :epoch-id ws))))))
@@ -128,22 +128,22 @@
   ;; MUST NOT.
   (testing "a real :op-type :warning trace projects into :warnings"
     (let [tape [(epoch 1 {:trace-events [(warning-trace 10 :rf.warning/real :rf.warning/real)]})]
-          ws   (evidence/warnings tape)]
-      (is (true? (evidence/warning-trace? {:op-type :warning})))
+          ws   (rf.story.play.evidence/warnings tape)]
+      (is (true? (rf.story.play.evidence/warning-trace? {:op-type :warning})))
       (is (= 1 (count ws)) "the canonical :warning op-type is projected")
       (is (= [:rf.warning/real] (mapv :operation ws)))))
   (testing "a bogus :op-type :warn trace is NOT a warning (the framework never emits :warn)"
     (let [bogus-warn {:operation :rf.warning/bogus :op-type :warn :id 99 :tags {:category :rf.warning/bogus}}
           tape       [(epoch 1 {:trace-events [bogus-warn]})]]
-      (is (false? (evidence/warning-trace? bogus-warn)))
-      (is (= [] (evidence/warnings tape))
+      (is (false? (rf.story.play.evidence/warning-trace? bogus-warn)))
+      (is (= [] (rf.story.play.evidence/warnings tape))
           ":warn is not the canonical discriminator — it must not project")))
   (testing "the agreement floor sees real warnings only via the canonical op-type"
     ;; A real warning-only tape carries no FAILURE (warnings are not the
     ;; failure floor), but the projection must still surface it so a wired
     ;; :rf.assert/no-warnings has teeth.
     (let [tape [(epoch 1 {:trace-events [(warning-trace 10 :rf.warning/foo :rf.warning/foo)]})]
-          ev   (evidence/project-evidence tape)]
+          ev   (rf.story.play.evidence/project-evidence tape)]
       (is (= 1 (count (:warnings ev)))
           "project-evidence surfaces real :warning traces into the run-result slot"))))
 
@@ -154,7 +154,7 @@
                           :renders  [{:render-key [:v 0]}]})
                 (epoch 2 {:effects  [{:fx-id :dispatch :outcome :ok}
                                      {:fx-id :http :outcome :ok}]})]
-          ev (evidence/project-evidence tape)]
+          ev (rf.story.play.evidence/project-evidence tape)]
       (is (= [:db :dispatch :http] (mapv :fx-id (:effects ev))))
       (is (= [1 2 2] (mapv :epoch-id (:effects ev))) "each effect row carries its source epoch")
       (is (= [:s1] (mapv :sub-id (:sub-runs ev))))
@@ -172,8 +172,8 @@
     ;; substrate — the slot is ABSENT so the fail-closed check refuses a
     ;; reactive-count assertion.
     (let [tape [(epoch 1 {:effects [{:fx-id :db :outcome :ok}]})]]
-      (is (nil? (evidence/reactive-counts tape)))
-      (is (not (contains? (evidence/project-evidence tape) :reactive-counts))
+      (is (nil? (rf.story.play.evidence/reactive-counts tape)))
+      (is (not (contains? (rf.story.play.evidence/project-evidence tape) :reactive-counts))
           "no reactive rows → :reactive-counts slot omitted, not a zero stub"))))
 
 (deftest reactive-counts-counts-recomputes-and-renders-from-the-tape
@@ -187,7 +187,7 @@
                                       :cause-event-id :counter/inc}]
                           :renders  [{:render-key [:counter 0] :cause-event-id :counter/inc}
                                      {:render-key [:badge 0]   :cause-event-id :counter/inc}]})]
-          rc   (evidence/reactive-counts tape)]
+          rc   (rf.story.play.evidence/reactive-counts tape)]
       (is (= 2 (:sub-recomputes rc)) "two :rf.sub/run rows → two recomputes")
       (is (= 2 (:view-renders rc))   "two :rf.view/rendered rows → two renders")
       (is (= {:total 1 :parity 1} (:by-sub-id rc)))
@@ -207,7 +207,7 @@
                                      {:sub-id :total :recomputed? true
                                       :cause-event-id :b}]
                           :renders  [{:render-key [:v 0] :cause-event-id :b}]})]
-          rc   (evidence/reactive-counts tape)]
+          rc   (rf.story.play.evidence/reactive-counts tape)]
       (is (= 3 (:sub-recomputes rc)) "1 + 2 across the two epochs")
       (is (= 2 (:view-renders rc))   "1 + 1")
       (is (= {:total 3} (:by-sub-id rc)) "the over-recompute signal: :total recomputed 3×")
@@ -227,7 +227,7 @@
   (testing "a reactive row outside a cascade (no :cause-event-id) is counted but uncredited"
     (let [tape [(epoch 1 {:sub-runs [{:sub-id :total :recomputed? true}]
                           :renders  [{:render-key [:v 0]}]})]
-          rc   (evidence/reactive-counts tape)]
+          rc   (rf.story.play.evidence/reactive-counts tape)]
       (is (= 1 (:sub-recomputes rc)))
       (is (= 1 (:view-renders rc)))
       (is (= {} (:by-cause rc)) "nil cause-event-id contributes no :by-cause entry")
@@ -238,9 +238,9 @@
   (testing ":reactive-counts rides project-evidence and agrees with the standalone projection"
     (let [tape [(epoch 1 {:sub-runs [{:sub-id :total :recomputed? true}]
                           :renders  [{:render-key [:v 0]}]})]
-          ev   (evidence/project-evidence tape {:script [[:dispatch [:counter/inc]]]})]
+          ev   (rf.story.play.evidence/project-evidence tape {:script [[:dispatch [:counter/inc]]]})]
       (is (contains? ev :reactive-counts))
-      (is (= (evidence/reactive-counts tape) (:reactive-counts ev))
+      (is (= (rf.story.play.evidence/reactive-counts tape) (:reactive-counts ev))
           "the slot is the standalone projection — one tape, one projection"))))
 
 ;; ===========================================================================
@@ -255,7 +255,7 @@
           tape   [(epoch 1 {:trigger-event [:checkout/submit]})
                   (epoch 2 {:trigger-event [:checkout/validate]})
                   (epoch 3 {:trigger-event [:checkout/done]})]
-          n      (evidence/narrative script tape)]
+          n      (rf.story.play.evidence/narrative script tape)]
       (is (= 1 (count n)) "one outer span for the one dispatch step")
       (is (= [:dispatch [:checkout/submit]] (:step (first n))))
       (is (= 3 (count (:epochs (first n)))) "all three beats under the one step")
@@ -268,7 +268,7 @@
                   (epoch 2 {:rf.story/script-idx 0 :trigger-event [:a]})
                   (epoch 3 {:rf.story/script-idx 0 :trigger-event [:a-redispatch]})
                   (epoch 4 {:rf.story/script-idx 2 :trigger-event [:b]})]
-          n      (evidence/narrative script tape)]
+          n      (rf.story.play.evidence/narrative script tape)]
       ;; leading nil span + 3 step spans
       (is (= 4 (count n)))
       (is (nil? (:step (first n))))
@@ -291,12 +291,12 @@
           tape       [(epoch 1 {:trigger-event [:a]})
                       (epoch 2 {:trigger-event [:c]})
                       (epoch 3 {:trigger-event [:d]})] ; c's re-dispatch
-          stamped    (evidence/stamp-tape script tape [0 1])]
+          stamped    (rf.story.play.evidence/stamp-tape script tape [0 1])]
       (is (= [0 1 1] (mapv :rf.story/script-idx stamped))
           "a → step 0; c + its re-dispatch d → step 1 (fan-out attaches to
            the producing step)")
       ;; The stamped tape lights up EXACT attribution end-to-end.
-      (let [n (evidence/narrative script stamped)]
+      (let [n (rf.story.play.evidence/narrative script stamped)]
         (is (= [[:a]]    (mapv :trigger-event (:epochs (first n)))))
         (is (= [[:c] [:d]] (mapv :trigger-event (:epochs (second n))))
             "EXACT — NOT the EVEN [2 1] split that mis-groups c onto step 0"))))
@@ -306,18 +306,18 @@
           tape    [(epoch 1 {:trigger-event [:setup]})  ; pre-dispatch cascade
                    (epoch 2 {:trigger-event [:act]})]
           ;; The one dispatch step's settle began at count 1 (after setup).
-          stamped (evidence/stamp-tape script tape [1])]
+          stamped (rf.story.play.evidence/stamp-tape script tape [1])]
       (is (= [nil 0] (mapv :rf.story/script-idx stamped))
           "the setup epoch leads (nil); the dispatched epoch → step 0")))
 
   (testing "with no boundaries the tape is returned verbatim → EVEN fallback"
     (let [script [[:dispatch [:a]]]
           tape   [(epoch 1 {:trigger-event [:a]})]]
-      (is (= tape (evidence/stamp-tape script tape nil))
+      (is (= tape (rf.story.play.evidence/stamp-tape script tape nil))
           "absent attribution leaves the tape unstamped")
-      (is (= tape (evidence/stamp-tape script tape []))
+      (is (= tape (rf.story.play.evidence/stamp-tape script tape []))
           "an empty boundary vector also degrades to the raw tape")
-      (is (not (contains? (first (evidence/stamp-tape script tape nil))
+      (is (not (contains? (first (rf.story.play.evidence/stamp-tape script tape nil))
                           :rf.story/script-idx))
           "no stamp key is added on the fallback path"))))
 
@@ -360,13 +360,13 @@
           ;; Recorded BEFORE each step's own dispatch — genuinely
           ;; monotonic, no plateau, regardless of the ring depth.
           boundaries [45 46 47 48 49]
-          stamped (evidence/stamp-tape script tape boundaries)]
+          stamped (rf.story.play.evidence/stamp-tape script tape boundaries)]
       (is (= [2 3 4] (mapv :rf.story/script-idx stamped))
           "epoch 48 -> step 2 (dispatched [:set 3]); 49 -> step 3
            ([:set 4]); 50 -> step 4 ([:set 5]) — each surviving record's
            OWN epoch-id decides ownership, not its position in the
            (evicted) tape")
-      (let [n (evidence/narrative script stamped)]
+      (let [n (rf.story.play.evidence/narrative script stamped)]
         (is (= [] (:epochs (nth n 0))) "step 0's own epoch (id 46) was evicted — no beats")
         (is (= [] (:epochs (nth n 1))) "step 1's own epoch (id 47) was evicted — no beats")
         (is (= [[:set 3]] (mapv :trigger-event (:epochs (nth n 2))))
@@ -399,7 +399,7 @@
           ;; then PLATEAUED at 3 (the ring depth) for every subsequent
           ;; boundary once it filled — steps 3 and 4 are indistinguishable.
           plateaued-count-boundaries [0 1 2 3 3]
-          stamped (evidence/stamp-tape script tape plateaued-count-boundaries)]
+          stamped (rf.story.play.evidence/stamp-tape script tape plateaued-count-boundaries)]
       (is (= [4 4 4] (mapv :rf.story/script-idx stamped))
           "these tiny plateaued counts are all `<` every real epoch-id in
            `tape` (48-50), so every record's owner-search bottoms out at
@@ -411,7 +411,7 @@
   (testing "a script with no dispatch steps puts the whole tape in a leading span"
     (let [script [[:assert-db [:k] 1] [:wait 10]]
           tape   [(epoch 1 {})]
-          n      (evidence/narrative script tape)]
+          n      (rf.story.play.evidence/narrative script tape)]
       (is (= 3 (count n)))
       (is (nil? (:step (first n))))
       (is (= [1] (mapv :epoch-id (:epochs (first n)))))
@@ -422,7 +422,7 @@
   (testing "fewer epochs than dispatch steps gives later steps empty spans, drops nothing"
     (let [script [[:dispatch [:a]] [:dispatch [:b]] [:dispatch [:c]]]
           tape   [(epoch 1 {})] ;; only one epoch committed
-          n      (evidence/narrative script tape)
+          n      (rf.story.play.evidence/narrative script tape)
           total-beats (reduce + (map (comp count :epochs) n))]
       (is (= 3 (count n)))
       (is (= 1 total-beats) "the single epoch is not dropped")
@@ -439,7 +439,7 @@
                             :sub-runs      [{:sub-id :total :recomputed? true}]
                             :renders       [{:render-key [:cart 0]}]
                             :trace-events  [(run-start-trace 10 [:checkout/submit] 100)]})]
-          beat   (first (:epochs (first (evidence/narrative script tape))))]
+          beat   (first (:epochs (first (rf.story.play.evidence/narrative script tape))))]
       (is (= 1 (:epoch-id beat)))
       (is (= 100 (:dispatch-id beat)))
       (is (= [:checkout/submit] (:trigger-event beat)))
@@ -454,10 +454,10 @@
   (testing "a [:dispatch evec {:caption …}] step surfaces the caption on its span"
     (let [script [[:dispatch [:checkout/submit] {:caption "submit the order"}]]
           tape   [(epoch 1 {:trigger-event [:checkout/submit]})]
-          span   (first (evidence/narrative script tape))]
+          span   (first (rf.story.play.evidence/narrative script tape))]
       (is (= "submit the order" (:caption span)))
       ;; a step with no caption map carries no :caption key
-      (let [no-cap (first (evidence/narrative [[:dispatch [:x]]]
+      (let [no-cap (first (rf.story.play.evidence/narrative [[:dispatch [:x]]]
                                               [(epoch 1 {})]))]
         (is (not (contains? no-cap :caption)))))))
 
@@ -472,8 +472,8 @@
                   (epoch 2 {:rf.story/script-idx 0   :trigger-event [:a]})
                   (epoch 3 {:rf.story/script-idx 0   :trigger-event [:a2]})
                   (epoch 4 {:rf.story/script-idx 2   :trigger-event [:b]})]
-          n      (evidence/narrative script tape)
-          beats  (evidence/narrative-beats n)]
+          n      (rf.story.play.evidence/narrative script tape)
+          beats  (rf.story.play.evidence/narrative-beats n)]
       (is (= 4 (count beats)) "the assert step contributes no beat; every committed epoch appears")
       (is (= [0 1 2 3] (mapv :beat-idx beats)) "beat-idx is the dense 0-based scrub address")
       (is (= [1 2 3 4] (mapv :epoch-id beats)) "beats are in tape order")
@@ -487,7 +487,7 @@
   (testing "pure assertion / wait spans (no beats) contribute nothing to the scrub"
     (let [script [[:assert-db [:k] 1] [:wait 10]]
           tape   [(epoch 1 {})]
-          beats  (evidence/narrative-beats (evidence/narrative script tape))]
+          beats  (rf.story.play.evidence/narrative-beats (rf.story.play.evidence/narrative script tape))]
       (is (= 1 (count beats)) "only the one leading committed epoch is scrubbable")
       (is (= 0 (:beat-idx (first beats))))
       (is (nil? (:step (first beats))) "it leads under the nil setup span"))))
@@ -496,24 +496,24 @@
   (testing "a captioned span stamps :span-caption onto each of its beats"
     (let [script [[:dispatch [:a] {:caption "do the thing"}]]
           tape   [(epoch 1 {}) (epoch 2 {})]
-          beats  (evidence/narrative-beats (evidence/narrative script tape))]
+          beats  (rf.story.play.evidence/narrative-beats (rf.story.play.evidence/narrative script tape))]
       (is (= ["do the thing" "do the thing"] (mapv :span-caption beats))))))
 
 (deftest beat-count-and-beat-at-and-epoch-ids
   (testing "scrub extent, addressing, and restore-epoch targets"
     (let [script [[:dispatch [:a]]]
           tape   [(epoch 10 {}) (epoch 11 {}) (epoch 12 {})]
-          n      (evidence/narrative script tape)]
-      (is (= 3 (evidence/beat-count n)) "scrub slider extent = committed-epoch count")
-      (is (= 10 (:epoch-id (evidence/beat-at n 0))))
-      (is (= 12 (:epoch-id (evidence/beat-at n 2))))
-      (is (nil? (evidence/beat-at n 3))  "scrub past the end is nil")
-      (is (nil? (evidence/beat-at n -1)) "scrub before the start is nil")
-      (is (= [10 11 12] (evidence/beat-epoch-ids n))
+          n      (rf.story.play.evidence/narrative script tape)]
+      (is (= 3 (rf.story.play.evidence/beat-count n)) "scrub slider extent = committed-epoch count")
+      (is (= 10 (:epoch-id (rf.story.play.evidence/beat-at n 0))))
+      (is (= 12 (:epoch-id (rf.story.play.evidence/beat-at n 2))))
+      (is (nil? (rf.story.play.evidence/beat-at n 3))  "scrub past the end is nil")
+      (is (nil? (rf.story.play.evidence/beat-at n -1)) "scrub before the start is nil")
+      (is (= [10 11 12] (rf.story.play.evidence/beat-epoch-ids n))
           "the ordered restore-epoch targets, one per scrub position")
       ;; beat-epoch-ids aligns 1:1 with narrative-beats
-      (is (= (evidence/beat-epoch-ids n)
-             (mapv :epoch-id (evidence/narrative-beats n)))))))
+      (is (= (rf.story.play.evidence/beat-epoch-ids n)
+             (mapv :epoch-id (rf.story.play.evidence/narrative-beats n)))))))
 
 (deftest navigation-agrees-with-the-tape
   (testing "the flattened scrub sequence agrees with the retained epoch tape (§B9)"
@@ -525,11 +525,11 @@
           tape     [(epoch 1 {:rf.story/script-idx 0})
                     (epoch 2 {:rf.story/script-idx 0})
                     (epoch 3 {:rf.story/script-idx 2})]
-          n        (evidence/narrative script tape)
-          beat-ids (evidence/beat-epoch-ids n)]
+          n        (rf.story.play.evidence/narrative script tape)
+          beat-ids (rf.story.play.evidence/beat-epoch-ids n)]
       (is (= (mapv :epoch-id tape) beat-ids)
           "scrub epoch-ids are exactly the tape's epoch-ids, in order")
-      (is (= (count tape) (evidence/beat-count n))
+      (is (= (count tape) (rf.story.play.evidence/beat-count n))
           "one scrub position per committed epoch — none dropped, none invented"))))
 
 ;; ===========================================================================
@@ -540,36 +540,36 @@
   (testing "project-evidence returns the tape verbatim + every slot derived from it"
     (let [tape [(epoch 1 {:effects [{:fx-id :db :outcome :ok}]
                           :trace-events [(warning-trace 10 :rf.warning/x :rf.warning/x)]})]
-          ev   (evidence/project-evidence tape {:script [[:dispatch [:e]]]})]
+          ev   (rf.story.play.evidence/project-evidence tape {:script [[:dispatch [:e]]]})]
       (is (= tape (:epoch-tape ev)) "the retained tape rides verbatim as the evidence source")
-      (is (= (evidence/schema-violations tape) (:schema-violations ev)))
-      (is (= (evidence/warnings tape)          (:warnings ev)))
-      (is (= (evidence/effects tape)           (:effects ev)))
-      (is (= (evidence/sub-runs tape)          (:sub-runs ev)))
-      (is (= (evidence/renders tape)           (:renders ev)))
-      (is (= (evidence/narrative [[:dispatch [:e]]] tape) (:narrative ev))))))
+      (is (= (rf.story.play.evidence/schema-violations tape) (:schema-violations ev)))
+      (is (= (rf.story.play.evidence/warnings tape)          (:warnings ev)))
+      (is (= (rf.story.play.evidence/effects tape)           (:effects ev)))
+      (is (= (rf.story.play.evidence/sub-runs tape)          (:sub-runs ev)))
+      (is (= (rf.story.play.evidence/renders tape)           (:renders ev)))
+      (is (= (rf.story.play.evidence/narrative [[:dispatch [:e]]] tape) (:narrative ev))))))
 
 (deftest tape-shows-failure-on-schema-violation
   (testing "a schema violation in the tape trips the failure floor"
     (let [clean [(epoch 1 {:effects [{:fx-id :db :outcome :ok}]})]
           dirty [(epoch 1 {:trace-events [(schema-trace 10 :event :e {})]})]]
-      (is (false? (evidence/tape-shows-failure? clean)))
-      (is (true?  (evidence/tape-shows-failure? dirty))))))
+      (is (false? (rf.story.play.evidence/tape-shows-failure? clean)))
+      (is (true?  (rf.story.play.evidence/tape-shows-failure? dirty))))))
 
 (deftest tape-shows-failure-excuses-consumed-violations
   (testing "an expected (consumed) schema violation does NOT trip the floor"
     (let [tape       [(epoch 1 {:trace-events [(schema-trace 10 :event :checkout/submit {})]})]
-          selector   (:selector (first (evidence/schema-violations tape)))]
-      (is (true?  (evidence/tape-shows-failure? tape)) "strict floor: unconsumed violation fails")
-      (is (false? (evidence/tape-shows-failure? tape #{selector}))
+          selector   (:selector (first (rf.story.play.evidence/schema-violations tape)))]
+      (is (true?  (rf.story.play.evidence/tape-shows-failure? tape)) "strict floor: unconsumed violation fails")
+      (is (false? (rf.story.play.evidence/tape-shows-failure? tape #{selector}))
           "consumed by an expected :rf.assert/schema-error → not a failure"))))
 
 (deftest tape-shows-failure-on-halt-and-error-effect
   (testing "a halted epoch outcome or an error effect trips the floor"
-    (is (true? (evidence/tape-shows-failure? [(epoch 1 {:outcome :halted-depth})])))
-    (is (true? (evidence/tape-shows-failure?
+    (is (true? (rf.story.play.evidence/tape-shows-failure? [(epoch 1 {:outcome :halted-depth})])))
+    (is (true? (rf.story.play.evidence/tape-shows-failure?
                  [(epoch 1 {:effects [{:fx-id :boom :outcome :error :error-trace 99}]})])))
-    (is (false? (evidence/tape-shows-failure? [(epoch 1 {:outcome :ok})])))))
+    (is (false? (rf.story.play.evidence/tape-shows-failure? [(epoch 1 {:outcome :ok})])))))
 
 (deftest no-accumulator-can-report-green-when-tape-is-red
   (testing "the failure floor reads the PROJECTION, so a sibling 'pass' cannot mask a red tape"
@@ -579,7 +579,7 @@
     (let [tape            [(epoch 1 {:trace-events [(schema-trace 10 :app-db {}
                                                                   {:registered-path [:x] :path [:x]})]})]
           sibling-says-ok {:status :pass :warnings [] :assertions []}
-          tape-red?       (evidence/tape-shows-failure? tape)]
+          tape-red?       (rf.story.play.evidence/tape-shows-failure? tape)]
       (is (true? tape-red?))
       ;; The contract the runner enforces: a :pass status is invalid while
       ;; the tape is red. We assert the floor catches the disagreement.
@@ -602,14 +602,14 @@
     ;; baseline 100; the ring still holds record 100 (the baseline itself) and
     ;; newer run records — nothing evicted.
     (let [full-ring [(epoch 100 {}) (epoch 103 {}) (epoch 107 {})]]
-      (is (false? (evidence/run-tape-truncated? full-ring 100))
+      (is (false? (rf.story.play.evidence/run-tape-truncated? full-ring 100))
           "the baseline record survives → the ring holds every run record")))
 
   (testing "baseline evicted (every retained record > baseline) → TRUNCATED"
     ;; baseline 100 but the oldest surviving record is 142 — the baseline
     ;; (and the run's earliest epochs) were pushed off the ring's front.
     (let [full-ring [(epoch 142 {}) (epoch 150 {}) (epoch 159 {})]]
-      (is (true? (evidence/run-tape-truncated? full-ring 100))
+      (is (true? (rf.story.play.evidence/run-tape-truncated? full-ring 100))
           "no record ≤ baseline survives → the run overflowed the ring")))
 
   (testing "a pre-baseline record older than the baseline also counts as covered"
@@ -617,14 +617,14 @@
     ;; inherits pre-run history); any record ≤ baseline proves no run epoch
     ;; was evicted.
     (let [full-ring [(epoch 88 {}) (epoch 100 {}) (epoch 140 {})]]
-      (is (false? (evidence/run-tape-truncated? full-ring 100)))))
+      (is (false? (rf.story.play.evidence/run-tape-truncated? full-ring 100)))))
 
   (testing "a fresh inline frame (zero / nil baseline) is never flagged"
     ;; No baseline record exists to evict, and depth-free detection cannot
     ;; tell overflow from an exact fill without the ring depth — so it does
     ;; not over-claim.
-    (is (false? (evidence/run-tape-truncated? [(epoch 1 {}) (epoch 2 {})] 0)))
-    (is (false? (evidence/run-tape-truncated? [(epoch 1 {}) (epoch 2 {})] nil))))
+    (is (false? (rf.story.play.evidence/run-tape-truncated? [(epoch 1 {}) (epoch 2 {})] 0)))
+    (is (false? (rf.story.play.evidence/run-tape-truncated? [(epoch 1 {}) (epoch 2 {})] nil))))
 
   (testing "an empty ring is not truncated"
-    (is (false? (evidence/run-tape-truncated? [] 100)))))
+    (is (false? (rf.story.play.evidence/run-tape-truncated? [] 100)))))

--- a/tools/story/test/re_frame/story/play/presence_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/presence_cljs_test.cljc
@@ -41,18 +41,18 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core                        :as rf]
-            [re-frame.frame                       :as frame]
-            [re-frame.router                      :as router]
-            [re-frame.registrar                   :as registrar]
-            [re-frame.substrate.plain-atom        :as plain-atom]
-            [re-frame.story                       :as story]
-            [re-frame.story.determinism           :as determinism]
-            [re-frame.story.late-bind             :as late-bind]
-            [re-frame.story.plan                  :as plan]
-            [re-frame.story.play.presence         :as story-presence]
-            [re-frame.story.play.runner           :as runner]
-            [re-frame.story.play.runner-events    :as re]
-            [re-frame.story.requirements          :as requirements]))
+            [re-frame.frame                       :as rf.frame]
+            [re-frame.router                      :as rf.router]
+            [re-frame.registrar                   :as rf.registrar]
+            [re-frame.substrate.plain-atom        :as rf.substrate.plain-atom]
+            [re-frame.story                       :as rf.story]
+            [re-frame.story.determinism           :as rf.story.determinism]
+            [re-frame.story.late-bind             :as rf.story.late-bind]
+            [re-frame.story.plan                  :as rf.story.plan]
+            [re-frame.story.play.presence         :as rf.story.play.presence]
+            [re-frame.story.play.runner           :as rf.story.play.runner]
+            [re-frame.story.play.runner-events    :as rf.story.play.runner-events]
+            [re-frame.story.requirements          :as rf.story.requirements]))
 ;; NO SUBSTRATE :require, and that is the point of the rung (rf2-5gka): the
 ;; seam under test reaches its advance through the late-bind registry, so
 ;; every test here drives it with a stub host and Story's test classpath
@@ -64,44 +64,44 @@
 
 (deftest flush-presence-is-a-known-step
   (testing "the one tagged grammar recognises :flush-presence"
-    (is (contains? runner/step-types :flush-presence))
-    (is (= :flush-presence (runner/step-type [:flush-presence])))
-    (is (= :flush-presence (runner/step-type [:flush-presence 300])))
-    (is (true? (runner/known-step? [:flush-presence])))
-    (is (true? (runner/known-step? [:flush-presence 300])))))
+    (is (contains? rf.story.play.runner/step-types :flush-presence))
+    (is (= :flush-presence (rf.story.play.runner/step-type [:flush-presence])))
+    (is (= :flush-presence (rf.story.play.runner/step-type [:flush-presence 300])))
+    (is (true? (rf.story.play.runner/known-step? [:flush-presence])))
+    (is (true? (rf.story.play.runner/known-step? [:flush-presence 300])))))
 
 (deftest flush-presence-arity-mirrors-the-framework-verb
   (testing "the two arities are exactly flush-presence!'s: bare (to
             quiescence) and a non-negative ms (partial advance)"
-    (is (true?  (runner/step-arity-ok? [:flush-presence])))
-    (is (true?  (runner/step-arity-ok? [:flush-presence 0])))
-    (is (true?  (runner/step-arity-ok? [:flush-presence 300])))
-    (is (false? (runner/step-arity-ok? [:flush-presence -1])))
-    (is (false? (runner/step-arity-ok? [:flush-presence "300"])))
-    (is (false? (runner/step-arity-ok? [:flush-presence 100 200])))))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:flush-presence])))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:flush-presence 0])))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:flush-presence 300])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:flush-presence -1])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:flush-presence "300"])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:flush-presence 100 200])))))
 
 (deftest step-presence-ms-reads-the-advance
   (testing "nil means the no-arg arity (to quiescence), NOT 'absent'"
-    (is (nil? (runner/step-presence-ms [:flush-presence])))
-    (is (= 300 (runner/step-presence-ms [:flush-presence 300])))
-    (is (nil? (runner/step-presence-ms [:wait 300]))
+    (is (nil? (rf.story.play.runner/step-presence-ms [:flush-presence])))
+    (is (= 300 (rf.story.play.runner/step-presence-ms [:flush-presence 300])))
+    (is (nil? (rf.story.play.runner/step-presence-ms [:wait 300]))
         "the tag, never the nil, distinguishes the step")))
 
 (deftest flush-presence-summary
-  (is (= "flush-presence" (runner/step-summary [:flush-presence])))
-  (is (= "flush-presence 300ms" (runner/step-summary [:flush-presence 300]))))
+  (is (= "flush-presence" (rf.story.play.runner/step-summary [:flush-presence])))
+  (is (= "flush-presence 300ms" (rf.story.play.runner/step-summary [:flush-presence 300]))))
 
 (deftest flush-presence-yields-a-tick
   (testing "the framework verb is Promise-backed on CLJS — the driver yields
             one tick so the retained subtree's removal COMMIT lands before
             the next step reads it"
-    (is (contains? runner/async-yield-step-types :flush-presence))
-    (is (true? (runner/async-yield? [:flush-presence])))))
+    (is (contains? rf.story.play.runner/async-yield-step-types :flush-presence))
+    (is (true? (rf.story.play.runner/async-yield? [:flush-presence])))))
 
 (deftest flush-presence-round-trips-through-coercion
   (testing "a tagged step is never mistaken for a bare event vector"
     (let [tagged [[:dispatch [:e]] [:flush-presence 100] [:flush-presence]]]
-      (is (= tagged (runner/coerce-script tagged))))))
+      (is (= tagged (rf.story.play.runner/coerce-script tagged))))))
 
 ;; ===========================================================================
 ;; PURE: capabilities + determinism (both hosts)
@@ -110,11 +110,11 @@
 (deftest flush-presence-requires-no-capability
   (testing "the presence clock is a process-global registry — advancing it
             needs no :dom (the ASSERTION that follows carries that)"
-    (is (= #{} (get requirements/step-capabilities :flush-presence)))
-    (is (= #{} (requirements/step-tokens [:flush-presence])))
-    (is (= #{} (requirements/step-tokens [:flush-presence 300]))))
+    (is (= #{} (get rf.story.requirements/step-capabilities :flush-presence)))
+    (is (= #{} (rf.story.requirements/step-tokens [:flush-presence])))
+    (is (= #{} (rf.story.requirements/step-tokens [:flush-presence 300]))))
   (testing "a presence-bearing script does not lift :required-runner to :dom"
-    (let [p (plan/variant-plan
+    (let [p (rf.story.plan/variant-plan
               {:variant/id :story.presence/headless
                :script [[:dispatch [:e]]
                         [:flush-presence 100]
@@ -130,9 +130,9 @@
                                         [:flush-presence 100]
                                         [:flush-presence]]}
           wait-art     {:event-program [[:dispatch [:e]] [:wait 300]]}]
-      (is (= [] (determinism/wait-steps presence-art)))
-      (is (false? (determinism/has-wall-clock-wait? presence-art)))
-      (is (true?  (determinism/has-wall-clock-wait? wait-art))
+      (is (= [] (rf.story.determinism/wait-steps presence-art)))
+      (is (false? (rf.story.determinism/has-wall-clock-wait? presence-art)))
+      (is (true?  (rf.story.determinism/has-wall-clock-wait? wait-art))
           "the wall-clock opt-out is still refused — this rung is its
            deterministic alternative, not a loophole"))))
 
@@ -143,40 +143,40 @@
 (deftest install-presence-flush-registers-the-hook
   (let [calls (atom [])]
     (try
-      (is (nil? (story-presence/presence-flush-fn))
+      (is (nil? (rf.story.play.presence/presence-flush-fn))
           "no host installed by default")
-      (story-presence/install-presence-flush! #(swap! calls conj %))
-      (is (some? (story-presence/presence-flush-fn)))
-      (is (identical? (story-presence/presence-flush-fn)
-                      (late-bind/get-fn :flush-presence!))
+      (rf.story.play.presence/install-presence-flush! #(swap! calls conj %))
+      (is (some? (rf.story.play.presence/presence-flush-fn)))
+      (is (identical? (rf.story.play.presence/presence-flush-fn)
+                      (rf.story.late-bind/get-fn :flush-presence!))
           "the hook lives in the shared late-bind registry")
       (testing "advance! threads the ms through, nil meaning 'to quiescence'"
-        (is (= {:status :advanced :ms 100} (story-presence/advance! 100)))
-        (is (= {:status :advanced :ms nil} (story-presence/advance! nil)))
-        (is (= {:status :advanced :ms 0}   (story-presence/advance! 0))
+        (is (= {:status :advanced :ms 100} (rf.story.play.presence/advance! 100)))
+        (is (= {:status :advanced :ms nil} (rf.story.play.presence/advance! nil)))
+        (is (= {:status :advanced :ms 0}   (rf.story.play.presence/advance! 0))
             "0 is a LEGAL advance, not an absent one — a host distinguishes
              the two on `some?`, so the seam must hand it 0 rather than
              collapsing it into the quiescence arity")
         (is (= [100 nil 0] @calls)))
-      (finally (swap! late-bind/hooks dissoc :flush-presence!)))))
+      (finally (swap! rf.story.late-bind/hooks dissoc :flush-presence!)))))
 
 (deftest advance-with-no-host-reports-no-host
   (testing "with no host installed the advance DID NOT HAPPEN, and `advance!`
             says so faithfully — the executor projects `:no-host` into a
             `:cannot-run` refusal (rf2-36biz). `advance!` itself stays pure
             data → data: it reports, the executor judges"
-    (is (nil? (story-presence/presence-flush-fn)))
-    (is (= {:status :no-host :ms nil} (story-presence/advance! nil)))
-    (is (= {:status :no-host :ms 250} (story-presence/advance! 250)))))
+    (is (nil? (rf.story.play.presence/presence-flush-fn)))
+    (is (= {:status :no-host :ms nil} (rf.story.play.presence/advance! nil)))
+    (is (= {:status :no-host :ms 250} (rf.story.play.presence/advance! 250)))))
 
 (deftest advance-surfaces-a-throwing-host
   (let [boom (ex-info "presence host exploded" {})]
     (try
-      (story-presence/install-presence-flush! (fn [_] (throw boom)))
-      (let [res (story-presence/advance! nil)]
+      (rf.story.play.presence/install-presence-flush! (fn [_] (throw boom)))
+      (let [res (rf.story.play.presence/advance! nil)]
         (is (= :error (:status res)) "a throwing host is never swallowed")
         (is (string? (:error res))))
-      (finally (swap! late-bind/hooks dissoc :flush-presence!)))))
+      (finally (swap! rf.story.late-bind/hooks dissoc :flush-presence!)))))
 
 ;; ===========================================================================
 ;; PLAYBACK against a live frame
@@ -185,7 +185,7 @@
 (def exec-step!
   "The private single-step executor, reached via var-quote — the established
   Story-test seam."
-  @#'re/exec-step!)
+  @#'rf.story.play.runner-events/exec-step!)
 
 (def presence-frame :story.presence/frame)
 
@@ -193,21 +193,21 @@
   "Fresh registrar + runtime + variant frame. Shared with the real-clock
   companion so both halves of the rung test the same harness."
   []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
   ;; Start every test HOOK-FREE, symmetrically with `teardown!`. The hook
   ;; registry is process-global and any namespace may install into it at load
   ;; time, so the no-host tests must not depend on ns-load order to see an
   ;; empty slot.
-  (swap! late-bind/hooks dissoc :flush-presence!)
-  (try (rf/init! plain-atom/adapter)
+  (swap! rf.story.late-bind/hooks dissoc :flush-presence!)
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
-  (reset! re/run-state {})
+  (reset! rf.story.play.runner-events/run-state {})
   ;; The canonical `:rf.assert/*` handlers must be installed so the
   ;; `[:assert-db …]` steps below record onto the assertion slot.
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (rf/make-frame {:id presence-frame :doc "presence rung test frame"})
   ;; `:presence/tick` stands in for "the toast is on screen and has just been
   ;; dismissed" — the source list dropped the key, so the boundary RETAINS the
@@ -227,7 +227,7 @@
   []
   ;; The late-bind hook registry is process-global — a leaked presence host
   ;; would silently arm every LATER test's `[:flush-presence]` step.
-  (swap! late-bind/hooks dissoc :flush-presence!)
+  (swap! rf.story.late-bind/hooks dissoc :flush-presence!)
   nil)
 
 ;; The cross-platform FN form (`meta-fixtures-test`): the map form silently
@@ -254,7 +254,7 @@
   Returns the atom holding its logical state."
   [timeout-ms]
   (let [state (atom {:now 0 :pending? true :advances []})]
-    (story-presence/install-presence-flush!
+    (rf.story.play.presence/install-presence-flush!
       (fn [ms]
         (swap! state update :advances conj ms)
         (let [now (if (nil? ms)
@@ -264,7 +264,7 @@
           (swap! state assoc :now now)
           (when (and (:pending? @state) (>= now timeout-ms))
             (swap! state assoc :pending? false)
-            (router/dispatch-sync! [:presence/exited] {:frame presence-frame})))))
+            (rf.router/dispatch-sync! [:presence/exited] {:frame presence-frame})))))
     state))
 
 (deftest presence-step-drives-the-host-verb
@@ -324,7 +324,7 @@
 ;; the seam's duty is only to hand `0` through as `0`.
 
 (deftest presence-step-surfaces-a-throwing-host-as-an-exception
-  (story-presence/install-presence-flush! (fn [_] (throw (ex-info "boom" {}))))
+  (rf.story.play.presence/install-presence-flush! (fn [_] (throw (ex-info "boom" {}))))
   (let [res (exec-step! presence-frame 0 [:flush-presence])]
     (is (some? (:exception res)) "a throwing host fails the step loudly")
     (is (false? (:passed? res)))))
@@ -341,7 +341,7 @@
                exit pending, so the assertion on its terminal removal FAILS.
                This is the race the rung exists to close"
        (let [done  (atom nil)
-             _     (re/run! presence-frame "no-presence"
+             _     (rf.story.play.runner-events/run! presence-frame "no-presence"
                             {:name   "no-presence"
                              :script [[:dispatch [:presence/tick]]
                                       [:assert-db [:toast] :removed]]}
@@ -359,7 +359,7 @@
                the child still RETAINED below :timeout-ms and then its
                terminal removal, with no wall-clock sleep anywhere"
        (let [done  (atom nil)
-             _     (re/run! presence-frame "presence"
+             _     (rf.story.play.runner-events/run! presence-frame "presence"
                             {:name   "presence"
                              :script [[:dispatch [:presence/tick]]
                                       [:flush-presence 100]
@@ -395,7 +395,7 @@
                assertion cannot tell those two worlds apart, so the STEP must:
                the run is `:cannot-run`, never `:pass`"
        (let [done  (atom nil)
-             _     (re/run! presence-frame "no-host"
+             _     (rf.story.play.runner-events/run! presence-frame "no-host"
                             {:name   "no-host"
                              :script [[:dispatch [:presence/tick]]
                                       [:flush-presence 100]
@@ -414,7 +414,7 @@
                bug. The IDENTICAL script, `:assert-db` its only assertion,
                still passes once a host is properly installed"
        (let [done  (atom nil)
-             _     (re/run! presence-frame "with-host"
+             _     (rf.story.play.runner-events/run! presence-frame "with-host"
                             {:name   "with-host"
                              :script [[:dispatch [:presence/tick]]
                                       [:flush-presence 100]

--- a/tools/story/test/re_frame/story/play/presence_stale_settlement_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/play/presence_stale_settlement_cljs_test.cljs
@@ -21,7 +21,7 @@
   no `:run-token`, which the loop's token guard (`(some? (:run-token state))`)
   then declines to abort on.
 
-  THE SAME SHAPE IN THE INTERACTIVE STEPPER. `play/step-once!` amends its
+  THE SAME SHAPE IN THE INTERACTIVE STEPPER. `rf.story.play/step-once!` amends its
   recorded result when the presence Promise settles, guarded only by a BOUNDS
   check (`idx < (count results)`). A bounds check is a size test, not an
   identity test: it correctly declines when a reset has SHRUNK `:results` below
@@ -41,29 +41,29 @@
   `:pending`), and the `async` tests below require cljs.test MAP fixtures,
   which a `.cljc` may not use (`re-frame.story.meta-fixtures-test`)."
   (:require [cljs.test :refer [async deftest is testing use-fixtures]]
-            [re-frame.story.play                    :as play]
-            [re-frame.story.play.presence           :as story-presence]
-            [re-frame.story.play.runner             :as runner]
-            [re-frame.story.play.runner-events      :as re]
+            [re-frame.story.play                    :as rf.story.play]
+            [re-frame.story.play.presence           :as rf.story.play.presence]
+            [re-frame.story.play.runner             :as rf.story.play.runner]
+            [re-frame.story.play.runner-events      :as rf.story.play.runner-events]
             ;; The shared harness (fresh registrar + runtime + variant frame),
             ;; reused rather than re-built — one harness across the presence
             ;; rung's coverage.
-            [re-frame.story.play.presence-cljs-test :as shared]))
+            [re-frame.story.play.presence-cljs-test :as rf.story.play.presence-cljs-test]))
 
-;; `clear-all-runs!` on top of the shared setup: `shared/setup!` resets
-;; `re/run-state` but not `runs-by-play`, and every assertion here reads the
+;; `clear-all-runs!` on top of the shared setup: `rf.story.play.presence-cljs-test/setup!` resets
+;; `rf.story.play.runner-events/run-state` but not `runs-by-play`, and every assertion here reads the
 ;; slot through `current-state-for-play` (which derefs `runs-by-play`). A slot
 ;; surviving from a previous test would make a stale-settlement assertion read
 ;; a state this test never seeded.
 (use-fixtures :each
-  {:before (fn [] (shared/setup!) (re/clear-all-runs!))
-   :after  (fn [] (shared/teardown!) (re/clear-all-runs!))})
+  {:before (fn [] (rf.story.play.presence-cljs-test/setup!) (rf.story.play.runner-events/clear-all-runs!))
+   :after  (fn [] (rf.story.play.presence-cljs-test/teardown!) (rf.story.play.runner-events/clear-all-runs!))})
 
 ;; The private run-loop seam, reached via var-quote — the established
 ;; Story-test seam (`runner-events-cljs-test` drives the abort branches the
 ;; same way).
-(def ^:private run-loop!  @#'re/run-loop!)
-(def ^:private set-state! @#'re/set-state!)
+(def ^:private run-loop!  @#'rf.story.play.runner-events/run-loop!)
+(def ^:private set-state! @#'rf.story.play.runner-events/set-state!)
 
 ;; ---------------------------------------------------------------------------
 ;; A deferred whose settlement the TEST places
@@ -88,17 +88,17 @@
   advance's ms so a test can prove the verb was REACHED — a fence that worked
   by never running the host would pass every staleness assertion here."
   [d calls]
-  (story-presence/install-presence-flush!
+  (rf.story.play.presence/install-presence-flush!
     (fn [ms] (swap! calls conj ms) (:thenable d))))
 
 (defn- seed-run!
   "Stamp a fresh run carrying `token` onto the `[presence-frame nil]` slot.
   Returns the seeded state."
   [token script]
-  (let [started (-> (runner/start
-                      (runner/initial-state {:name nil :script script}) 0)
+  (let [started (-> (rf.story.play.runner/start
+                      (rf.story.play.runner/initial-state {:name nil :script script}) 0)
                     (assoc :run-token token))]
-    (set-state! shared/presence-frame nil started)
+    (set-state! rf.story.play.presence-cljs-test/presence-frame nil started)
     started))
 
 (defn- start-run!
@@ -108,10 +108,10 @@
   ([token script] (start-run! token script nil))
   ([token script done-cb]
    (seed-run! token script)
-   (run-loop! shared/presence-frame nil token done-cb)))
+   (run-loop! rf.story.play.presence-cljs-test/presence-frame nil token done-cb)))
 
 (defn- slot []
-  (re/current-state-for-play shared/presence-frame nil))
+  (rf.story.play.runner-events/current-state-for-play rf.story.play.presence-cljs-test/presence-frame nil))
 
 (def ^:private presence-script
   [[:flush-presence] [:dispatch [:presence/tick]]])
@@ -172,13 +172,13 @@
           calls (atom [])]
       (install-deferred-host! d calls)
       (start-run! "tok-A" presence-script)
-      (re/clear-state! shared/presence-frame)
+      (rf.story.play.runner-events/clear-state! rf.story.play.presence-cljs-test/presence-frame)
       (is (nil? (slot)) "precondition: teardown removed the slot")
       (is (nil? ((:resolve! d) :ok))
           "settling after teardown completes without throwing")
       (is (nil? (slot))
           "and left NO phantom entry in runs-by-play")
-      (is (nil? (get @re/run-state shared/presence-frame))
+      (is (nil? (get @rf.story.play.runner-events/run-state rf.story.play.presence-cljs-test/presence-frame))
           "nor in run-state — update-state! writes BOTH atoms, so both are
            checked"))))
 
@@ -298,7 +298,7 @@
                           "settled with nil — the slot was torn down, and the
                            continuation only chains the next play")
                       (done)))
-        (re/clear-state! shared/presence-frame)
+        (rf.story.play.runner-events/clear-state! rf.story.play.presence-cljs-test/presence-frame)
         ((:resolve! d) :ok)))))
 
 ;; ===========================================================================
@@ -325,12 +325,12 @@
   is the documented substrate surface and `step-once!` is driven exactly as the
   UI widget drives it."
   [steps]
-  (swap! play/stepper-state assoc shared/presence-frame
+  (swap! rf.story.play/stepper-state assoc rf.story.play.presence-cljs-test/presence-frame
          {:remaining steps :ran [] :results []})
   nil)
 
 (defn- stepper-results []
-  (:results (get @play/stepper-state shared/presence-frame)))
+  (:results (get @rf.story.play/stepper-state rf.story.play.presence-cljs-test/presence-frame)))
 
 (deftest stale-stepper-settlement-does-not-clobber-a-new-session
   (testing "THE BUG in the stepper (rf2-6pfpt): a presence step parks, the
@@ -344,17 +344,17 @@
           calls (atom [])]
       (install-deferred-host! stale calls)
       (seed-stepper! [[:flush-presence 100] [:dispatch [:presence/tick]]])
-      (play/step-once! shared/presence-frame)
+      (rf.story.play/step-once! rf.story.play.presence-cljs-test/presence-frame)
       (is (true? ((:armed? stale))) "the stepper parked on the thenable")
       ;; A real reset/new-cursor path — the UI's rewind button.
-      (play/stepper-rewind! shared/presence-frame)
+      (rf.story.play/stepper-rewind! rf.story.play.presence-cljs-test/presence-frame)
       (is (= 0 (count (stepper-results))) "the rewind emptied :results")
       ;; The new session parks on a DIFFERENT deferred, so settling the stale
       ;; one settles ONLY the abandoned session — otherwise one `resolve!`
       ;; would fire both callbacks and the assertion could not tell a refused
       ;; stale amendment from an admitted live one.
       (install-deferred-host! live calls)
-      (play/step-once! shared/presence-frame)
+      (rf.story.play/step-once! rf.story.play.presence-cljs-test/presence-frame)
       (let [fresh (first (stepper-results))]
         (is (= 1 (count (stepper-results))) "index 0 belongs to the new session")
         (is (= :flush-presence (:type fresh))
@@ -380,7 +380,7 @@
           calls (atom [])]
       (install-deferred-host! d calls)
       (seed-stepper! [[:flush-presence 100]])
-      (play/step-once! shared/presence-frame)
+      (rf.story.play/step-once! rf.story.play.presence-cljs-test/presence-frame)
       (is (nil? (:exception (first (stepper-results))))
           "provisional: the parked step reads clean before settlement")
       ((:reject! d) (ex-info "presence flush failed" {}))
@@ -401,12 +401,12 @@
           calls (atom [])]
       (install-deferred-host! d calls)
       (seed-stepper! [[:flush-presence 100] [:dispatch [:presence/tick]]])
-      (play/step-once! shared/presence-frame)          ; idx 0 — parks
-      (play/step-once! shared/presence-frame)          ; idx 1 — synchronous
+      (rf.story.play/step-once! rf.story.play.presence-cljs-test/presence-frame)          ; idx 0 — parks
+      (rf.story.play/step-once! rf.story.play.presence-cljs-test/presence-frame)          ; idx 1 — synchronous
       (is (= 2 (count (stepper-results))))
-      (play/stepper-step-back! shared/presence-frame)  ; pops idx 1 only
+      (rf.story.play/stepper-step-back! rf.story.play.presence-cljs-test/presence-frame)  ; pops idx 1 only
       (is (= 1 (count (stepper-results))) "idx 1 was dropped; idx 0 survives")
-      (play/step-once! shared/presence-frame)          ; re-runs into idx 1
+      (rf.story.play/step-once! rf.story.play.presence-cljs-test/presence-frame)          ; re-runs into idx 1
       (is (= 2 (count (stepper-results))))
       ((:reject! d) (ex-info "presence flush failed" {}))
       (is (true? (:exception (first (stepper-results))))
@@ -421,7 +421,7 @@
       (let [d1 (deferred)]
         (install-deferred-host! d1 calls)
         (seed-stepper! [[:flush-presence 100]])
-        (play/step-once! shared/presence-frame)
+        (rf.story.play/step-once! rf.story.play.presence-cljs-test/presence-frame)
         ((:reject! d1) (ex-info "boom" {}))
         (is (true? (:exception (first (stepper-results))))
             "1/4 ADMITTED — the owning step was amended"))
@@ -432,10 +432,10 @@
             l2 (deferred)]
         (install-deferred-host! d2 calls)
         (seed-stepper! [[:flush-presence 100]])
-        (play/step-once! shared/presence-frame)
-        (play/stepper-rewind! shared/presence-frame)
+        (rf.story.play/step-once! rf.story.play.presence-cljs-test/presence-frame)
+        (rf.story.play/stepper-rewind! rf.story.play.presence-cljs-test/presence-frame)
         (install-deferred-host! l2 calls)
-        (play/step-once! shared/presence-frame)
+        (rf.story.play/step-once! rf.story.play.presence-cljs-test/presence-frame)
         (let [fresh (first (stepper-results))]
           ((:reject! d2) (ex-info "boom" {}))
           (is (identical? fresh (first (stepper-results)))
@@ -444,7 +444,7 @@
       (let [d3 (deferred)]
         (install-deferred-host! d3 calls)
         (seed-stepper! [[:flush-presence 100]])
-        (play/step-once! shared/presence-frame)
+        (rf.story.play/step-once! rf.story.play.presence-cljs-test/presence-frame)
         ((:reject! d3) (ex-info "boom" {}))
         (is (true? (:exception (first (stepper-results))))
             "3/4 ADMITTED AGAIN — the fence did not latch shut"))
@@ -453,10 +453,10 @@
             l4 (deferred)]
         (install-deferred-host! d4 calls)
         (seed-stepper! [[:flush-presence 100]])
-        (play/step-once! shared/presence-frame)
-        (play/stepper-rewind! shared/presence-frame)
+        (rf.story.play/step-once! rf.story.play.presence-cljs-test/presence-frame)
+        (rf.story.play/stepper-rewind! rf.story.play.presence-cljs-test/presence-frame)
         (install-deferred-host! l4 calls)
-        (play/step-once! shared/presence-frame)
+        (rf.story.play/step-once! rf.story.play.presence-cljs-test/presence-frame)
         (let [fresh (first (stepper-results))]
           ((:reject! d4) (ex-info "boom" {}))
           (is (identical? fresh (first (stepper-results)))
@@ -465,4 +465,4 @@
           "every stepped presence step really reached the verb (four sessions,
            two of them stepped twice across a rewind)")
       ;; `stepper-state` is process-global — leave no cursor behind.
-      (swap! play/stepper-state dissoc shared/presence-frame))))
+      (swap! rf.story.play/stepper-state dissoc rf.story.play.presence-cljs-test/presence-frame))))

--- a/tools/story/test/re_frame/story/play/run_loop_settle_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/play/run_loop_settle_cljs_test.cljs
@@ -35,12 +35,12 @@
   (:require [cljs.test :refer [async deftest is testing use-fixtures]]
             [goog.object :as gobj]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.story :as story]
-            [re-frame.story.late-bind :as late-bind]
-            [re-frame.story.play.runner-events :as re]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.story :as rf.story]
+            [re-frame.story.late-bind :as rf.story.late-bind]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (def ^:private run-frame :story.run-loop-settle/frame)
 
@@ -59,15 +59,15 @@
        :querySelectorAll (fn [_] #js [])})
 
 (defn- setup! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
-  (reset! re/run-state {})
-  (re/clear-all-runs!)
-  (reset! re/step-boundaries {})
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
+  (reset! rf.story.play.runner-events/run-state {})
+  (rf.story.play.runner-events/clear-all-runs!)
+  (reset! rf.story.play.runner-events/step-boundaries {})
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (rf/make-frame {:id run-frame :doc "run-loop settle witness frame"})
   (rf/reg-event :run-loop-settle/inc
                 (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))})))
@@ -79,7 +79,7 @@
 
 (use-fixtures :each
   {:before (fn []
-             (reset! saved-hooks @late-bind/hooks)
+             (reset! saved-hooks @rf.story.late-bind/hooks)
              ;; The `document` goes in AFTER the Story runtime is seated.
              ;; Xray rides Story's package graph and probes for its inline
              ;; layout host as the runtime installs; finding a document
@@ -91,22 +91,22 @@
              (gobj/set js/globalThis "document" (missing-everything-document)))
    :after  (fn []
              (js-delete js/globalThis "document")
-             (reset! late-bind/hooks @saved-hooks)
-             (re/clear-all-runs!)
+             (reset! rf.story.late-bind/hooks @saved-hooks)
+             (rf.story.play.runner-events/clear-all-runs!)
              (try (rf/destroy-adapter!) (catch :default _ nil)))})
 
 (defn- install-hooks!
   "Seat `hooks` as the active flush-hooks for every frame — the producer
   seam a live adapter fills."
   [hooks]
-  (late-bind/set-fn! :settled-boundary-hooks (fn [_frame-id] hooks)))
+  (rf.story.late-bind/set-fn! :settled-boundary-hooks (fn [_frame-id] hooks)))
 
 (defn- run-script!
   "Drive `script` as a HAND-BUILT spec through the explicit-spec arity of
   `run!` — deliberately, since that is the entry path that does not fold,
   and the one the raw-`:assert-dom` defect lives behind."
   [script done-cb]
-  (re/run! run-frame "witness" {:name "witness" :script script} done-cb))
+  (rf.story.play.runner-events/run! run-frame "witness" {:name "witness" :script script} done-cb))
 
 (defn- message-of [result]
   (str (:message result)))

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -16,34 +16,34 @@
   - The dispatch→assertion outcome-matching bridge (`failed-since` +
     `dispatch-step-result`, exercised directly below — rf2-uhq5j)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story.play.runner :as runner]
+            [re-frame.story.play.runner :as rf.story.play.runner]
             [re-frame.core              :as rf]
-            [re-frame.cofx :as cofx]
-            [re-frame.frame             :as frame]
-            [re-frame.story             :as story]
-            [re-frame.story.loaders     :as loaders]
-            [re-frame.story.play        :as legacy-play]
-            [re-frame.story.play.runner-events :as re]
+            [re-frame.cofx :as rf.cofx]
+            [re-frame.frame             :as rf.frame]
+            [re-frame.story             :as rf.story]
+            [re-frame.story.loaders     :as rf.story.loaders]
+            [re-frame.story.play        :as rf.story.play]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]
             ;; rf2-rkd14 — the EXACT narrative attribution tests read a live
             ;; epoch tape via `rf/epoch-history`; requiring the epoch artefact
             ;; installs its late-bind capture hooks so the tape is real (it
             ;; degrades to `[]` without the dep, mirroring artifact-test). The
-            ;; fixture's `epoch/clear-history!` runs on both runtimes, so this
+            ;; fixture's `rf.epoch/clear-history!` runs on both runtimes, so this
             ;; require is unconditional.
-            [re-frame.epoch             :as epoch]
-            [re-frame.machines          :as machines]
-            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.epoch             :as rf.epoch]
+            [re-frame.machines          :as rf.machines]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
             [re-frame.registrar         :as registrar]
             ;; `re-frame.story.async/deref-blocking` is JVM-only (it
-            ;; blocks a thread) and `config/set-global-args!` is only
+            ;; blocks a thread) and `rf.story.config/set-global-args!` is only
             ;; needed by the JVM `reset-all` lineage — the integration
             ;; tests below that use them are themselves JVM-gated. The
             ;; rf2-rkd14 EXACT-attribution tests are likewise `:clj`-gated, so
             ;; their `evidence` / `fingerprint` deps ride this block too.
-            #?@(:clj [[re-frame.story.async  :as async]
-                      [re-frame.story.config :as config]
-                      [re-frame.story.play.evidence :as evidence]
-                      [re-frame.story.fingerprint :as fingerprint]])))
+            #?@(:clj [[re-frame.story.async  :as rf.story.async]
+                      [re-frame.story.config :as rf.story.config]
+                      [re-frame.story.play.evidence :as rf.story.play.evidence]
+                      [re-frame.story.fingerprint :as rf.story.fingerprint]])))
 
 ;; ---- CLJS+JVM: the dispatch→assertion outcome-matching bridge -----------
 ;;
@@ -57,8 +57,8 @@
 ;; projection. Both fns are private — reached via var-quote (the
 ;; established Story-test seam pattern, e.g. play/listener-for-frame).
 
-(def ^:private failed-since        @#'re/failed-since)
-(def ^:private dispatch-step-result @#'re/dispatch-step-result)
+(def ^:private failed-since        @#'rf.story.play.runner-events/failed-since)
+(def ^:private dispatch-step-result @#'rf.story.play.runner-events/dispatch-step-result)
 
 (def ^:private bridge-frame :story.bridge/frame)
 
@@ -76,28 +76,28 @@
   `reset-all`). Resets every Story side-table + the re-frame frame
   registry, reinstalls the canonical vocabulary, and registers the
   bridge test frame + its `::seed` event. Runs on both runtimes; the
-  JVM-only `:reload` of machines + `config/set-global-args!` are gated."
+  JVM-only `:reload` of machines + `rf.story.config/set-global-args!` are gated."
   [test-fn]
-  (story/clear-all!)
+  (rf.story/clear-all!)
   (registrar/clear-all!)
-  (reset! frame/frames {})
+  (reset! rf.frame/frames {})
   ;; rf2-rkd14 — clear the epoch ring + listeners so each EXACT-attribution
   ;; test reads only its own freshly-captured tape.
-  (epoch/clear-history!)
-  (epoch/clear-epoch-listeners!)
-  (try (rf/init! plain-atom/adapter)
+  (rf.epoch/clear-history!)
+  (rf.epoch/clear-epoch-listeners!)
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
   #?(:clj (require 're-frame.machines :reload))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  #?(:clj (config/set-global-args! {}))
-  (reset! legacy-play/stepper-state {})
-  (reset! re/run-state {})
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  #?(:clj (rf.story.config/set-global-args! {}))
+  (reset! rf.story.play/stepper-state {})
+  (reset! rf.story.play.runner-events/run-state {})
   ;; rf2-vkdam — reset the per-dispatch-step settle boundaries so a test
   ;; observes only its own run's boundaries, not a prior test's accumulation.
-  (reset! re/step-boundaries {})
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (reset! rf.story.play.runner-events/step-boundaries {})
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (rf/make-frame {:id bridge-frame :doc "outcome-matching bridge test frame"})
   (rf/reg-event ::seed
     (fn [{:keys [db]} [_ rec]]
@@ -201,7 +201,7 @@
             record on :rf.story/assertions — no parallel evaluator"
     (rf/reg-event ::seed-db (fn [{:keys [db]} [_ m]] {:db (merge db m)}))
     (seed-db! {:status :loaded})
-    (re/run-terminal-assertions!
+    (rf.story.play.runner-events/run-terminal-assertions!
       bridge-frame
       [[:rf.assert/path-equals [:status] :loaded]    ; passes
        [:rf.assert/path-equals [:status] :idle]])    ; fails
@@ -219,7 +219,7 @@
             (rf2-nyjoa critical guard against double-processing)"
     (rf/reg-event ::seed-db (fn [{:keys [db]} [_ m]] {:db (merge db m)}))
     (seed-db! {:status :loaded})
-    (re/run-terminal-assertions!
+    (rf.story.play.runner-events/run-terminal-assertions!
       bridge-frame
       [[:rf.assert/path-equals [:status] :loaded]
        [:rf.assert/schema-error {:where :event :event :some/evt}]])
@@ -234,8 +234,8 @@
   (testing "run-terminal-assertions! with no atoms records nothing"
     (rf/reg-event ::seed-db (fn [{:keys [db]} [_ m]] {:db (merge db m)}))
     (seed-db! {:status :loaded})
-    (re/run-terminal-assertions! bridge-frame [])
-    (re/run-terminal-assertions! bridge-frame nil)
+    (rf.story.play.runner-events/run-terminal-assertions! bridge-frame [])
+    (rf.story.play.runner-events/run-terminal-assertions! bridge-frame nil)
     (is (empty? (:rf.story/assertions (rf/app-db-value bridge-frame)))
         "an empty / nil terminal-assertions vector is a clean no-op")))
 
@@ -273,9 +273,9 @@
 ;; violates. Runs under `npm run test:cljs` — the CLJS runtime where the hang
 ;; was reachable.
 
-(def ^:private run-loop!    @#'re/run-loop!)
-(def ^:private set-state!   @#'re/set-state!)
-(def ^:private settle-abort! @#'re/settle-abort!)
+(def ^:private run-loop!    @#'rf.story.play.runner-events/run-loop!)
+(def ^:private set-state!   @#'rf.story.play.runner-events/set-state!)
+(def ^:private settle-abort! @#'rf.story.play.runner-events/settle-abort!)
 
 (deftest run-loop-aborts-on-missing-state-still-settles-done-cb
   (testing "rf2-9x5fm — the `(nil? state)` abort branch (frame torn down
@@ -286,7 +286,7 @@
       ;; No run-state entry exists for this [frame-id nil] slot — the frame
       ;; was torn down (clear-state! wiped it). The loop's first cond clause
       ;; `(nil? state)` fires.
-      (is (nil? (re/current-state-for-play frame-id nil))
+      (is (nil? (rf.story.play.runner-events/current-state-for-play frame-id nil))
           "precondition: no run-state for the torn-down frame")
       (run-loop! frame-id nil "tok-A" (fn [final] (reset! settled final)))
       (is (not= :unset @settled)
@@ -305,8 +305,8 @@
     (let [frame-id :story.abort/token-swap
           settled  (atom :unset)
           ;; Seed the slot with a NEWER token than the stale loop carries.
-          newer    (runner/start
-                     (runner/initial-state {:script [[:dispatch [:noop]]] :name nil})
+          newer    (rf.story.play.runner/start
+                     (rf.story.play.runner/initial-state {:script [[:dispatch [:noop]]] :name nil})
                      1)]
       (set-state! frame-id nil (assoc newer :run-token "tok-NEWER"))
       ;; The stale loop carries "tok-STALE" — it mismatches the slot's
@@ -317,7 +317,7 @@
            is released, never stranded")
       ;; The newer run still OWNS the slot — the stale abort must not have
       ;; transitioned it via finish!/update-state!.
-      (let [slot (re/current-state-for-play frame-id nil)]
+      (let [slot (rf.story.play.runner-events/current-state-for-play frame-id nil)]
         (is (= "tok-NEWER" (:run-token slot))
             "the slot still carries the NEWER run's token — the stale abort
              did not clobber it")
@@ -352,7 +352,7 @@
        (let [frame-id :story.wait/deep
              n        10000
              spec     {:name nil :script (vec (repeat n [:wait 0]))}
-             started  (-> (runner/start (runner/initial-state spec) 0)
+             started  (-> (rf.story.play.runner/start (rf.story.play.runner/initial-state spec) 0)
                           (assoc :run-token "tok-WAIT"))
              settled  (atom :unset)]
          (set-state! frame-id nil started)
@@ -376,7 +376,7 @@
      ([variant-id] (run-blocking variant-id 5000))
      ([variant-id timeout-ms]
       (let [done (atom nil)]
-        (re/run! variant-id (fn [state] (reset! done state)))
+        (rf.story.play.runner-events/run! variant-id (fn [state] (reset! done state)))
         (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
           (loop []
             (cond
@@ -384,7 +384,7 @@
               (> (System/currentTimeMillis) deadline)
               (throw (ex-info "run-blocking timeout"
                               {:variant-id variant-id
-                               :state      @re/run-state}))
+                               :state      @rf.story.play.runner-events/run-state}))
               :else (do (Thread/sleep 5) (recur)))))))))
 
 ;; ---- dispatch + dispatch-sync round-trip --------------------------------
@@ -396,12 +396,12 @@
          (rf/reg-event :rt/inc
            (fn [{:keys [db]} _] (swap! seen conj :hit)
              {:db (update db :n (fnil inc 0))}))
-         (story/reg-variant :story.runner/sync
+         (rf.story/reg-variant :story.runner/sync
            {:setup []
             :script {:auto-run? false
                           :script    [[:dispatch-sync [:rt/inc]]
                                       [:dispatch-sync [:rt/inc]]]}})
-         (async/deref-blocking (story/run-variant :story.runner/sync) 5000)
+         (rf.story.async/deref-blocking (rf.story/run-variant :story.runner/sync) 5000)
          (let [final (run-blocking :story.runner/sync)]
            (is (= :pass (:status final)))
            (is (= [:hit :hit] @seen))
@@ -427,7 +427,7 @@
        ;; auto-carry it under the story test harness). Idempotent — matches the
        ;; framework default (cofx.cljc §:rf/time-ms — recordable, provided).
        (when-not (registrar/lookup :cofx :rf/time-ms)
-         (cofx/reg-cofx :rf/time-ms {:recordable? true :provided? true}))
+         (rf.cofx/reg-cofx :rf/time-ms {:recordable? true :provided? true}))
        ;; A PROVIDED recordable fact has no generator — absent on the token it
        ;; is :rf.error/missing-required-cofx in every mode, so re-presenting the
        ;; recorded value is the only way replay succeeds.
@@ -443,7 +443,7 @@
              {:db (-> db (update :n (fnil + 0) delta) (assoc :last-t t))}))
          ;; The recorded envelope: a provided fact + a recorded (NOT current)
          ;; :rf/time-ms. Replay must re-present BOTH verbatim.
-         (story/reg-variant :story.runner/cofx-replay
+         (rf.story/reg-variant :story.runner/cofx-replay
            {:setup []
             :script {:auto-run? false
                           :script [[:dispatch      [:rf2-l2cn5d/inc-by]
@@ -452,7 +452,7 @@
                                    [:dispatch-sync [:rf2-l2cn5d/inc-by]
                                     {:rf.cofx {:rf/time-ms 1781078400999
                                                :rf2-l2cn5d.delta/v 10}}]]}})
-         (async/deref-blocking (story/run-variant :story.runner/cofx-replay) 5000)
+         (rf.story.async/deref-blocking (rf.story/run-variant :story.runner/cofx-replay) 5000)
          (let [final (run-blocking :story.runner/cofx-replay)]
            (is (= :pass (:status final))
                "both steps replay cleanly — the provided fact was re-presented")
@@ -481,11 +481,11 @@
            {:db (assoc db :tok tok)}))
        ;; The bare 2-element step (no envelope) — the pre-fix recorder
        ;; behaviour. The provided fact is absent → the step must fail.
-       (story/reg-variant :story.runner/cofx-missing
+       (rf.story/reg-variant :story.runner/cofx-missing
          {:setup []
           :script {:auto-run? false
                         :script [[:dispatch-sync [:rf2-l2cn5d/needs-token]]]}})
-       (async/deref-blocking (story/run-variant :story.runner/cofx-missing) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.runner/cofx-missing) 5000)
        (let [final (run-blocking :story.runner/cofx-missing)]
          (is (not= :pass (:status final))
              "the missing provided fact surfaces as a non-pass step outcome")))))
@@ -499,13 +499,13 @@
               recorded step type is :assert."
        (rf/reg-event :rt/set-status
          (fn [{:keys [db]} [_ v]] {:db (assoc db :status v)}))
-       (story/reg-variant :story.runner/assert-db
+       (rf.story/reg-variant :story.runner/assert-db
          {:setup      []
           :script {:auto-run? false
                         :script    [[:dispatch-sync [:rt/set-status :loaded]]
                                     [:assert-db [:status] :loaded]
                                     [:assert-db [:status] :wrong]]}})
-       (async/deref-blocking (story/run-variant :story.runner/assert-db) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.runner/assert-db) 5000)
        (let [final (run-blocking :story.runner/assert-db)]
          (is (= :fail (:status final)))
          (is (= 1 (:failures final)))
@@ -515,7 +515,7 @@
            (is (true?  (:passed? (nth assert-results 0))))
            (is (false? (:passed? (nth assert-results 1)))))
          ;; The canonical :rf.assert/path-equals records carry the diagnostics.
-         (let [slot (story/read-assertions :story.runner/assert-db)
+         (let [slot (rf.story/read-assertions :story.runner/assert-db)
                pe   (filterv #(= :rf.assert/path-equals (:assertion %)) slot)]
            (is (= 2 (count pe)))
            (is (true?  (:passed? (nth pe 0))))
@@ -544,14 +544,14 @@
               slot consumers + assertions-passing? observe the failure"
        (rf/reg-event :rt/set-status
          (fn [{:keys [db]} [_ v]] {:db (assoc db :status v)}))
-       (story/reg-variant :story.bridge/db-fail
+       (rf.story/reg-variant :story.bridge/db-fail
          {:setup      []
           :script {:auto-run? false
                         :script    [[:dispatch-sync [:rt/set-status :idle]]
                                     [:assert-db [:status] :loaded]]}})
-       (async/deref-blocking (story/run-variant :story.bridge/db-fail) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.bridge/db-fail) 5000)
        (run-blocking :story.bridge/db-fail)
-       (let [slot (story/read-assertions :story.bridge/db-fail)
+       (let [slot (rf.story/read-assertions :story.bridge/db-fail)
              pe-recs (filterv #(= :rf.assert/path-equals (:assertion %)) slot)]
          (is (= 1 (count pe-recs))
              "the failing folded :assert-db landed exactly one canonical record")
@@ -559,7 +559,7 @@
              "the slot record carries :passed? false")
          (is (= :loaded (:expected (first pe-recs))))
          (is (= :idle   (:actual   (first pe-recs))))
-         (is (false? (story/assertions-passing? slot))
+         (is (false? (rf.story/assertions-passing? slot))
              "assertions-passing? sees the folded failure")))))
 
 #?(:clj
@@ -568,18 +568,18 @@
               :rf.assert/path-equals entry so the slot is non-empty + passes"
        (rf/reg-event :rt/set-status
          (fn [{:keys [db]} [_ v]] {:db (assoc db :status v)}))
-       (story/reg-variant :story.bridge/db-pass
+       (rf.story/reg-variant :story.bridge/db-pass
          {:setup      []
           :script {:auto-run? false
                         :script    [[:dispatch-sync [:rt/set-status :loaded]]
                                     [:assert-db [:status] :loaded]]}})
-       (async/deref-blocking (story/run-variant :story.bridge/db-pass) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.bridge/db-pass) 5000)
        (run-blocking :story.bridge/db-pass)
-       (let [slot    (story/read-assertions :story.bridge/db-pass)
+       (let [slot    (rf.story/read-assertions :story.bridge/db-pass)
              pe-recs (filterv #(= :rf.assert/path-equals (:assertion %)) slot)]
          (is (= 1 (count pe-recs)))
          (is (true? (:passed? (first pe-recs))))
-         (is (true? (story/assertions-passing? slot)))))))
+         (is (true? (rf.story/assertions-passing? slot)))))))
 
 #?(:clj
    (deftest run-variant-result-reflects-rich-dsl-assert-failure
@@ -589,19 +589,19 @@
               is no longer false-green; and the unified :status is :fail"
        (rf/reg-event :rt/set-status
          (fn [{:keys [db]} [_ v]] {:db (assoc db :status v)}))
-       (story/reg-variant :story.bridge/result
+       (rf.story/reg-variant :story.bridge/result
          {:setup      []
           :script {:script [[:dispatch-sync [:rt/set-status :idle]]
                                  [:assert-db [:status] :loaded]]}})
-       (let [result (async/deref-blocking
-                      (story/run-variant :story.bridge/result) 5000)]
+       (let [result (rf.story.async/deref-blocking
+                      (rf.story/run-variant :story.bridge/result) 5000)]
          (is (= :fail (:status result))
              "the unified run-result :status is :fail (rf2-5x1wt.19)")
          (is (some (fn [r] (and (= :rf.assert/path-equals (:assertion r))
                                 (false? (:passed? r))))
                    (:assertions result))
              "the result map's :assertions slot includes the failed assertion")
-         (is (false? (story/assertions-passing? result))
+         (is (false? (rf.story/assertions-passing? result))
              "assertions-passing? on the result map flips to false")))))
 
 ;; ---- rf2-rkd14: EXACT narrative attribution on the LIVE run path ---------
@@ -624,16 +624,16 @@
        ;; :rkd/c re-dispatches :rkd/d, so step 1 settles to 2 epochs.
        (rf/reg-event :rkd/c (fn [_ _] {:fx [[:dispatch [:rkd/d]]]}))
        (rf/reg-event :rkd/d (fn [{:keys [db]} _] {:db (assoc db :d true)}))
-       (story/reg-variant :story.rkd/redispatch
+       (rf.story/reg-variant :story.rkd/redispatch
          {:setup      []
           :script {:script [[:dispatch-sync [:rkd/a]]
                                   [:dispatch-sync [:rkd/c]]]}})
-       (let [result (async/deref-blocking
-                      (story/run-variant :story.rkd/redispatch) 5000)
+       (let [result (rf.story.async/deref-blocking
+                      (rf.story/run-variant :story.rkd/redispatch) 5000)
              ;; Group the flattened beats by their owning :step. The leading
              ;; (nil-step) span collects the lifecycle setup-phase epochs the
              ;; runtime commits before the script runs.
-             by     (->> (evidence/narrative-beats (:narrative result))
+             by     (->> (rf.story.play.evidence/narrative-beats (:narrative result))
                          (reduce (fn [m {:keys [step trigger-event]}]
                                    (update m step (fnil conj []) trigger-event))
                                  {}))]
@@ -670,17 +670,17 @@
        (rf/reg-event :rkd/a (fn [{:keys [db]} _] {:db (assoc db :a true)}))
        (rf/reg-event :rkd/c (fn [_ _] {:fx [[:dispatch [:rkd/d]]]}))
        (rf/reg-event :rkd/d (fn [{:keys [db]} _] {:db (assoc db :d true)}))
-       (story/reg-variant :story.rkd/hash
+       (rf.story/reg-variant :story.rkd/hash
          {:setup      []
           :script {:script [[:dispatch-sync [:rkd/a]]
                                   [:dispatch-sync [:rkd/c]]]}})
-       (let [result    (async/deref-blocking
-                         (story/run-variant :story.rkd/hash) 5000)
+       (let [result    (rf.story.async/deref-blocking
+                         (rf.story/run-variant :story.rkd/hash) 5000)
              tape-keys (into #{} (mapcat keys) (:epoch-tape result))]
          (is (not (contains? tape-keys :rf.story/script-idx))
              "the retained :epoch-tape slot is the RAW tape (no stamp leak)")
-         (is (= (fingerprint/run-hash result)
-                (fingerprint/run-hash (dissoc result :narrative)))
+         (is (= (rf.story.fingerprint/run-hash result)
+                (rf.story.fingerprint/run-hash (dissoc result :narrative)))
              "dropping the stamped :narrative does not change the run-hash")))))
 
 ;; ---- rf2-76l69l: multi-play auto-run attribution spans EVERY play --------
@@ -707,16 +707,16 @@
        ;; to two epochs — the discriminating re-dispatch the bead calls for.
        (rf/reg-event :ml/c (fn [_ _] {:fx [[:dispatch [:ml/d]]]}))
        (rf/reg-event :ml/d (fn [{:keys [db]} _] {:db (assoc db :d true)}))
-       (story/reg-variant :story.ml/two-plays
+       (rf.story/reg-variant :story.ml/two-plays
          {:setup []
           :plays  [{:name "alpha" :auto-run? true
                     :script [[:dispatch-sync [:ml/a]]
                              [:dispatch-sync [:ml/b]]]}
                    {:name "beta" :auto-run? true
                     :script [[:dispatch-sync [:ml/c]]]}]})
-       (let [result (async/deref-blocking
-                      (story/run-variant :story.ml/two-plays) 5000)
-             by     (->> (evidence/narrative-beats (:narrative result))
+       (let [result (rf.story.async/deref-blocking
+                      (rf.story/run-variant :story.ml/two-plays) 5000)
+             by     (->> (rf.story.play.evidence/narrative-beats (:narrative result))
                          (reduce (fn [m {:keys [step trigger-event]}]
                                    (update m step (fnil conj []) trigger-event))
                                  {}))]
@@ -744,13 +744,13 @@
               folds to :rf.assert/dom-visible, is evaluated by the DOM
               executor (no DOM → skipped), and the run is :cannot-run, not a
               false-green pass (rf2-5x1wt.19, spec/017 §`:cannot-run`)"
-       (story/reg-variant :story.bridge/dom-skip
+       (rf.story/reg-variant :story.bridge/dom-skip
          {:setup      []
           :script {:auto-run? false
                         :script    [[:assert-dom "div.foo" :visible]]}})
-       (async/deref-blocking (story/run-variant :story.bridge/dom-skip) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.bridge/dom-skip) 5000)
        (let [final (run-blocking :story.bridge/dom-skip)
-             slot  (story/read-assertions :story.bridge/dom-skip)]
+             slot  (rf.story/read-assertions :story.bridge/dom-skip)]
          (is (= :cannot-run (:status final))
              "a DOM-skip-only run is :cannot-run, not :pass or :fail")
          (is (empty? (filterv #(true? (:passed? %)) slot))
@@ -758,7 +758,7 @@
 
 #?(:clj
    (deftest assert-dom-skipped-unified-result-is-cannot-run
-     (testing "the UNIFIED run-result (story/run-variant's resolved value),
+     (testing "the UNIFIED run-result (rf.story/run-variant's resolved value),
               not just run-state, reads :cannot-run for a DOM-skip-only
               variant on the headless JVM (rf2-q5jw4, spec/017 §Unified run
               result). Before the fix record-result-map dropped the
@@ -770,17 +770,17 @@
               exercises the unified-result PATH (the existing
               assert-dom-skipped-on-jvm-is-cannot-run test discards the
               result and checks only run-blocking's run-state)."
-       (story/reg-variant :story.bridge/dom-skip-unified
+       (rf.story/reg-variant :story.bridge/dom-skip-unified
          {:setup      []
           :script {:script [[:assert-dom "div.foo" :visible]]}})
-       (let [result (async/deref-blocking
-                      (story/run-variant :story.bridge/dom-skip-unified) 5000)]
+       (let [result (rf.story.async/deref-blocking
+                      (rf.story/run-variant :story.bridge/dom-skip-unified) 5000)]
          (is (= :cannot-run (:status result))
              "the unified result :status is :cannot-run, NOT a vacuous :pass")
          (is (seq (:cannot-run result))
              "the unified result surfaces the run-state's :cannot-run refusals")
-         (is (false? (story/result-passed? result))
-             "story/result-passed? on the unified result is false — a
+         (is (false? (rf.story/result-passed? result))
+             "rf.story/result-passed? on the unified result is false — a
               :cannot-run run proved nothing, so it is never a silent pass")
          (is (empty? (filterv #(true? (:passed? %)) (:assertions result)))
              "no assertion record reads :passed? true — the skip is not
@@ -792,18 +792,18 @@
               the symbol resolves at validation time (rf2-5x1wt.19)"
        (rf/reg-event :rt/set-n
          (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
-       (story/reg-variant :story.runner/pred
+       (rf.story/reg-variant :story.runner/pred
          {:setup      []
           :script {:auto-run? false
                         :script    [[:dispatch-sync [:rt/set-n 7]]
                                     [:assert-db [:n] :pred 'clojure.core/pos?]
                                     [:assert-db [:n] :pred 'clojure.core/neg?]]}})
-       (async/deref-blocking (story/run-variant :story.runner/pred) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.runner/pred) 5000)
        (let [final  (run-blocking :story.runner/pred)
              ;; folded :assert-db :pred → [:assert [:rf.assert/path-matches …]]
              results (filterv #(= :assert (:type %)) (:results final))
              pm      (filterv #(= :rf.assert/path-matches (:assertion %))
-                              (story/read-assertions :story.runner/pred))]
+                              (rf.story/read-assertions :story.runner/pred))]
          (is (= :fail (:status final)))
          (is (= 2 (count results)))
          (is (true?  (:passed? (nth pm 0))) "pos? against 7 passes")
@@ -816,17 +816,17 @@
               [:fn fn] which Malli validates by calling the fn (rf2-5x1wt.19)"
        (rf/reg-event :rt/set-n
          (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
-       (story/reg-variant :story.runner/pred-fn
+       (rf.story/reg-variant :story.runner/pred-fn
          {:setup      []
           :script {:auto-run? false
                         :script    [[:dispatch-sync [:rt/set-n 7]]
                                     [:assert-db [:n] :pred pos?]
                                     [:assert-db [:n] :pred neg?]
                                     [:assert-db [:n] :pred (fn [x] (= x 7))]]}})
-       (async/deref-blocking (story/run-variant :story.runner/pred-fn) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.runner/pred-fn) 5000)
        (let [final   (run-blocking :story.runner/pred-fn)
              pm      (filterv #(= :rf.assert/path-matches (:assertion %))
-                              (story/read-assertions :story.runner/pred-fn))]
+                              (rf.story/read-assertions :story.runner/pred-fn))]
          (is (= :fail (:status final))
              "neg? against 7 fails — overall status is :fail")
          (is (= 3 (count pm)))
@@ -842,15 +842,15 @@
               rather than an opaque sci error (rf2-5x1wt.19)"
        (rf/reg-event :rt/set-n
          (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
-       (story/reg-variant :story.runner/pred-bogus
+       (rf.story/reg-variant :story.runner/pred-bogus
          {:setup      []
           :script {:auto-run? false
                         :script    [[:dispatch-sync [:rt/set-n 7]]
                                     [:assert-db [:n] :pred 'no.such.ns/missing-pred]]}})
-       (async/deref-blocking (story/run-variant :story.runner/pred-bogus) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.runner/pred-bogus) 5000)
        (let [final (run-blocking :story.runner/pred-bogus)
              pm    (filterv #(= :rf.assert/path-matches (:assertion %))
-                            (story/read-assertions :story.runner/pred-bogus))]
+                            (rf.story/read-assertions :story.runner/pred-bogus))]
          (is (= :fail (:status final)))
          (is (= 1 (count pm)))
          (is (false? (:passed? (first pm))))))))
@@ -860,7 +860,7 @@
      (testing "results vector reflects step order"
        (rf/reg-event :rt/touch
          (fn [{:keys [db]} _] {:db (update db :touches (fnil inc 0))}))
-       (story/reg-variant :story.runner/order
+       (rf.story/reg-variant :story.runner/order
          {:setup []
           :script
           {:auto-run? false
@@ -868,7 +868,7 @@
                     [:dispatch-sync [:rt/touch]]
                     [:dispatch-sync [:rt/touch]]
                     [:assert-db [:touches] 3]]}})
-       (async/deref-blocking (story/run-variant :story.runner/order) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.runner/order) 5000)
        (let [final (run-blocking :story.runner/order)]
          (is (= :pass (:status final)))
          (is (= 4 (count (:results final))))
@@ -894,28 +894,28 @@
               owns the reset, so the count does not accumulate (rf2-vkdam)"
        (rf/reg-event :vk/touch
          (fn [{:keys [db]} _] {:db (update db :touches (fnil inc 0))}))
-       (story/reg-variant :story.vkdam/rerun
+       (rf.story/reg-variant :story.vkdam/rerun
          {:setup []
           :script {:auto-run? false
                         :script [[:dispatch-sync [:vk/touch]]
                                  [:dispatch-sync [:vk/touch]]
                                  [:dispatch-sync [:vk/touch]]]}})
        ;; Allocate the frame so `run!` has a live frame to dispatch into.
-       (async/deref-blocking (story/run-variant :story.vkdam/rerun) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.vkdam/rerun) 5000)
        ;; First public run via `run!` (NOT the orchestrator).
        (run-blocking :story.vkdam/rerun)
        ;; `run-blocking` drives `run!`'s 2-arity form, which resolves to
        ;; play-key nil (the `:script` variant's single default play) —
        ;; `settle-boundaries` is keyed by `[frame-id play-key]` (rf2-m0cge5
        ;; finding 2), so reads pass that same nil.
-       (let [after-first (count (re/settle-boundaries :story.vkdam/rerun nil))]
+       (let [after-first (count (rf.story.play.runner-events/settle-boundaries :story.vkdam/rerun nil))]
          (is (= 3 after-first)
              "three dispatch steps record three boundaries")
          ;; Second public run — an interactive Re-run. WITHOUT the reset this
          ;; would accumulate to six; WITH it, `run!` clears at start so the
          ;; frame again holds exactly THIS run's three boundaries.
          (run-blocking :story.vkdam/rerun)
-         (is (= 3 (count (re/settle-boundaries :story.vkdam/rerun nil)))
+         (is (= 3 (count (rf.story.play.runner-events/settle-boundaries :story.vkdam/rerun nil)))
              "the public driver reset its boundaries — no stale accumulation")))))
 
 ;; ---- rf2-m0cge5 finding 2: step-boundaries keyed by [frame-id play-key] --
@@ -938,11 +938,11 @@
               (rf2-m0cge5 finding 2)"
        (rf/reg-event :m0cge5/touch
          (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-       (story/reg-variant :story.m0cge5/two-key
+       (rf.story/reg-variant :story.m0cge5/two-key
          {:setup []
           :script {:auto-run? false :script []}})
        ;; Allocate the frame so `run!` has a live frame to dispatch into.
-       (async/deref-blocking (story/run-variant :story.m0cge5/two-key) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.m0cge5/two-key) 5000)
        (let [spec-a {:name "A" :auto-run? false
                      :script [[:dispatch-sync [:m0cge5/touch]]]}
              spec-b {:name "B" :auto-run? false
@@ -951,30 +951,30 @@
              done-b (promise)]
          ;; Simulate the sequencer driving play "A" WITHOUT clearing (as
          ;; `run-plays-sequentially!` drives every play it owns).
-         (re/run! :story.m0cge5/two-key "A" spec-a (fn [_] (deliver done-a :ok))
+         (rf.story.play.runner-events/run! :story.m0cge5/two-key "A" spec-a (fn [_] (deliver done-a :ok))
                   {:clear-boundaries? false})
          (deref done-a 5000 :timeout)
-         (is (= 1 (count (re/settle-boundaries :story.m0cge5/two-key "A")))
+         (is (= 1 (count (rf.story.play.runner-events/settle-boundaries :story.m0cge5/two-key "A")))
              "play A recorded its own boundary")
          ;; A concurrent ad-hoc run for a DIFFERENT play-key "B" — e.g. an
          ;; interactive Re-run of a different play via the toolbar dropdown —
          ;; using the DEFAULT :clear-boundaries? true.
-         (re/run! :story.m0cge5/two-key "B" spec-b (fn [_] (deliver done-b :ok)))
+         (rf.story.play.runner-events/run! :story.m0cge5/two-key "B" spec-b (fn [_] (deliver done-b :ok)))
          (deref done-b 5000 :timeout)
-         (is (= 1 (count (re/settle-boundaries :story.m0cge5/two-key "A")))
+         (is (= 1 (count (rf.story.play.runner-events/settle-boundaries :story.m0cge5/two-key "A")))
              "play A's boundaries are UNTOUCHED by the concurrent play B run
               — before the fix both shared the frame-id-only key, so B's
               default clear wiped A's entry mid-sequence")
-         (is (= 1 (count (re/settle-boundaries :story.m0cge5/two-key "B")))
+         (is (= 1 (count (rf.story.play.runner-events/settle-boundaries :story.m0cge5/two-key "B")))
              "play B recorded its own boundary under its own key")))))
 
 ;; ---- rf2-96qsjr: narrative attribution survives epoch-ring eviction ------
 ;;
 ;; End-to-end sibling of the pure `evidence-test` stamp-tape gates: a REAL
-;; run, through the orchestrator (`story/run-variant`), whose dispatch-step
+;; run, through the orchestrator (`rf.story/run-variant`), whose dispatch-step
 ;; count exceeds a small configured epoch-history ring depth. Proves the
 ;; producer (`runner-events/last-epoch-id`) and the consumer
-;; (`runtime/record-result-map` + `evidence/stamp-tape`) agree end-to-end —
+;; (`runtime/record-result-map` + `rf.story.play.evidence/stamp-tape`) agree end-to-end —
 ;; not just that the pure fns compose correctly in isolation.
 
 #?(:clj
@@ -986,17 +986,17 @@
               plateaus), so ring eviction can only ever drop beats, never
               misattribute a surviving one"
        (try
-         (epoch/configure! {:depth 3})
+         (rf.epoch/configure! {:depth 3})
          (rf/reg-event :re-eviction/set
            (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
-         (story/reg-variant :story.runner/eviction
+         (rf.story/reg-variant :story.runner/eviction
            {:setup []
             :script {:script [[:dispatch-sync [:re-eviction/set 1]]
                                    [:dispatch-sync [:re-eviction/set 2]]
                                    [:dispatch-sync [:re-eviction/set 3]]
                                    [:dispatch-sync [:re-eviction/set 4]]
                                    [:dispatch-sync [:re-eviction/set 5]]]}})
-         (let [result    (async/deref-blocking (story/run-variant :story.runner/eviction) 5000)
+         (let [result    (rf.story.async/deref-blocking (rf.story/run-variant :story.runner/eviction) 5000)
                narrative (:narrative result)
                span-for  (fn [want]
                            (some #(when (= [:dispatch-sync [:re-eviction/set want]] (:step %)) %)
@@ -1023,16 +1023,16 @@
          (finally
            ;; `:depth` is a process-global epoch-history knob — restore
            ;; the framework default so it doesn't leak into sibling tests.
-           (epoch/configure! {:depth 50}))))))
+           (rf.epoch/configure! {:depth 50}))))))
 
 #?(:clj
    (deftest bare-vector-with-unknown-event-still-dispatches
      (testing "a bare event vector with no registered handler still dispatches; the play status does not fail because dispatch is a no-assertion step"
-       (story/reg-variant :story.runner/bare-unknown
+       (rf.story/reg-variant :story.runner/bare-unknown
          {:setup []
           :script {:auto-run? false
                         :script    [[:does-not-exist :nope]]}})
-       (async/deref-blocking (story/run-variant :story.runner/bare-unknown) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.runner/bare-unknown) 5000)
        (let [final (run-blocking :story.runner/bare-unknown)]
          (is (some? final))
          (is (= 1 (count (:results final))))))))
@@ -1042,12 +1042,12 @@
 #?(:clj
    (deftest variant-play-script-from-body
      (testing "variant-play-script resolves the :script slot on a variant"
-       (story/reg-variant :story.runner/resolved
+       (rf.story/reg-variant :story.runner/resolved
          {:setup []
           :script {:script [[:dispatch [:foo]]]
                         :auto-run? false
                         :name "named"}})
-       (let [spec (re/variant-play-script :story.runner/resolved)]
+       (let [spec (rf.story.play.runner-events/variant-play-script :story.runner/resolved)]
          (is (= [[:dispatch [:foo]]] (:script spec)))
          (is (false? (:auto-run? spec)))
          (is (= "named" (:name spec)))))))
@@ -1055,8 +1055,8 @@
 #?(:clj
    (deftest variant-play-script-missing
      (testing "variants without :script resolve to an empty spec"
-       (story/reg-variant :story.runner/no-script {:setup []})
-       (let [spec (re/variant-play-script :story.runner/no-script)]
+       (rf.story/reg-variant :story.runner/no-script {:setup []})
+       (let [spec (rf.story.play.runner-events/variant-play-script :story.runner/no-script)]
          (is (= [] (:script spec)))
          (is (true? (:auto-run? spec)))))))
 
@@ -1068,12 +1068,12 @@
        (let [seen (atom 0)]
          (rf/reg-event :rt/touch
            (fn [{:keys [db]} _] (swap! seen inc) {:db db}))
-         (story/reg-variant :story.runner/no-auto
+         (rf.story/reg-variant :story.runner/no-auto
            {:setup []
             :script {:auto-run? false
                           :script    [[:dispatch-sync [:rt/touch]]]}})
-         (async/deref-blocking (story/run-variant :story.runner/no-auto) 5000)
-         (re/auto-run! :story.runner/no-auto)
+         (rf.story.async/deref-blocking (rf.story/run-variant :story.runner/no-auto) 5000)
+         (rf.story.play.runner-events/auto-run! :story.runner/no-auto)
          (is (zero? @seen))))))
 
 ;; ---- run-state lifecycle ----------------------------------------------
@@ -1083,17 +1083,17 @@
      (testing "successive runs reset :results and re-walk every step"
        (rf/reg-event :rt/touch
          (fn [{:keys [db]} _] {:db (update db :touches (fnil inc 0))}))
-       (story/reg-variant :story.runner/reset
+       (rf.story/reg-variant :story.runner/reset
          {:setup []
           :script {:auto-run? false
                         :script    [[:dispatch-sync [:rt/touch]]
                                     [:assert-db [:touches] 1]]}})
-       (async/deref-blocking (story/run-variant :story.runner/reset) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.runner/reset) 5000)
        (run-blocking :story.runner/reset)
-       (let [first-state (re/current-state :story.runner/reset)]
+       (let [first-state (rf.story.play.runner-events/current-state :story.runner/reset)]
          (is (= :pass (:status first-state))))
        (run-blocking :story.runner/reset)
-       (let [second-state (re/current-state :story.runner/reset)]
+       (let [second-state (rf.story.play.runner-events/current-state :story.runner/reset)]
          (is (= :fail (:status second-state)))
          (is (= 1 (:failures second-state)))
          (is (= 2 (count (:results second-state))))))))
@@ -1108,19 +1108,19 @@
          (rf/reg-event :rt/touch
            (fn [{:keys [db]} _] {:db (update db :touches (fnil inc 0))}))
          (try
-           (require '[re-frame.trace.tooling :as trace-tooling])
+           (require '[re-frame.trace.tooling :as rf.trace.tooling])
            (let [reg!  (resolve 're-frame.trace.tooling/register-listener!)
                  unreg (resolve 're-frame.trace.tooling/unregister-listener!)]
              (reg! listener-id
                (fn [ev]
                  (when (= :rf.story.play/step (:operation ev))
                    (swap! trace-events conj ev))))
-             (story/reg-variant :story.runner/trace
+             (rf.story/reg-variant :story.runner/trace
                {:setup []
                 :script {:auto-run? false
                               :script    [[:dispatch-sync [:rt/touch]]
                                           [:assert-db [:touches] 1]]}})
-             (async/deref-blocking (story/run-variant :story.runner/trace) 5000)
+             (rf.story.async/deref-blocking (rf.story/run-variant :story.runner/trace) 5000)
              (run-blocking :story.runner/trace)
              (is (>= (count @trace-events) 2)
                  "at least one trace per step landed on the bus")
@@ -1142,12 +1142,12 @@
               whose only unmet steps are no-DOM skips is :cannot-run — the
               distinct THIRD status, not a fail or a silent pass
               (rf2-5x1wt.19, spec/017 §`:cannot-run`)"
-       (story/reg-variant :story.runner/dom
+       (rf.story/reg-variant :story.runner/dom
          {:setup []
           :script {:auto-run? false
                         :script    [[:click "button.foo"]
                                     [:assert-dom "div" :visible]]}})
-       (async/deref-blocking (story/run-variant :story.runner/dom) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.runner/dom) 5000)
        (let [final   (run-blocking :story.runner/dom)
              results (:results final)]
          (is (= :cannot-run (:status final))
@@ -1162,7 +1162,7 @@
      ([variant-id play-key] (run-play-blocking variant-id play-key 5000))
      ([variant-id play-key timeout-ms]
       (let [done (atom nil)]
-        (re/run-play! variant-id play-key (fn [s] (reset! done s)))
+        (rf.story.play.runner-events/run-play! variant-id play-key (fn [s] (reset! done s)))
         (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
           (loop []
             (cond
@@ -1178,7 +1178,7 @@
      (testing "variant-plays returns a vector of parsed plays"
        (rf/reg-event :rt/inc
          (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-       (story/reg-variant :story.multi/two
+       (rf.story/reg-variant :story.multi/two
          {:setup []
           :plays  [{:name "happy"
                     :auto-run? false
@@ -1188,7 +1188,7 @@
                     :auto-run? false
                     :script    [[:dispatch-sync [:rt/inc]]
                                 [:assert-db [:n] 99]]}]})
-       (let [plays (re/variant-plays :story.multi/two)]
+       (let [plays (rf.story.play.runner-events/variant-plays :story.multi/two)]
          (is (= 2 (count plays)))
          (is (= ["happy" "error"] (mapv :name plays)))
          ;; First play's auto-run? was explicitly false here, so no
@@ -1198,10 +1198,10 @@
 #?(:clj
    (deftest variant-plays-wraps-legacy-play-script
      (testing "variant-plays wraps a legacy :script body in a one-entry vector"
-       (story/reg-variant :story.multi/legacy
+       (rf.story/reg-variant :story.multi/legacy
          {:setup []
           :script {:name "lone" :script [[:dispatch [:a]]]}})
-       (let [plays (re/variant-plays :story.multi/legacy)]
+       (let [plays (rf.story.play.runner-events/variant-plays :story.multi/legacy)]
          (is (= 1 (count plays)))
          (is (= "lone" (:name (first plays))))))))
 
@@ -1210,7 +1210,7 @@
      (testing "running each play stores state under [variant-id play-key]"
        (rf/reg-event :rt/inc
          (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-       (story/reg-variant :story.multi/keyed
+       (rf.story/reg-variant :story.multi/keyed
          {:setup []
           :plays  [{:name "first"  :auto-run? false
                     :script [[:dispatch-sync [:rt/inc]]
@@ -1218,16 +1218,16 @@
                    {:name "second" :auto-run? false
                     :script [[:dispatch-sync [:rt/inc]]
                              [:assert-db [:n] 2]]}]})
-       (async/deref-blocking (story/run-variant :story.multi/keyed) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.multi/keyed) 5000)
        (let [first-state  (run-play-blocking :story.multi/keyed "first")
              second-state (run-play-blocking :story.multi/keyed "second")]
          (is (= :pass (:status first-state)))
          (is (= :pass (:status second-state)))
          ;; Per-play state preserved.
-         (is (= :pass (:status (re/current-state-for-play :story.multi/keyed "first"))))
-         (is (= :pass (:status (re/current-state-for-play :story.multi/keyed "second"))))
+         (is (= :pass (:status (rf.story.play.runner-events/current-state-for-play :story.multi/keyed "first"))))
+         (is (= :pass (:status (rf.story.play.runner-events/current-state-for-play :story.multi/keyed "second"))))
          ;; The latest run-state slot tracks the most recent run.
-         (let [latest (re/current-state :story.multi/keyed)]
+         (let [latest (rf.story.play.runner-events/current-state :story.multi/keyed)]
            (is (= :pass (:status latest)))
            (is (= "second" (:play-key latest))))))))
 
@@ -1236,39 +1236,39 @@
      (testing "run-play! also sets the active-play key the toolbar reads"
        (rf/reg-event :rt/touch
          (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-       (story/reg-variant :story.multi/active
+       (rf.story/reg-variant :story.multi/active
          {:setup []
           :plays  [{:name "alpha" :auto-run? false
                     :script [[:dispatch-sync [:rt/touch]]]}
                    {:name "beta"  :auto-run? false
                     :script [[:dispatch-sync [:rt/touch]]]}]})
-       (async/deref-blocking (story/run-variant :story.multi/active) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.multi/active) 5000)
        (run-play-blocking :story.multi/active "beta")
-       (is (= "beta" (re/active-play-key :story.multi/active))))))
+       (is (= "beta" (rf.story.play.runner-events/active-play-key :story.multi/active))))))
 
 #?(:clj
    (deftest select-play-without-running
      (testing "select-play! changes the active key but does not run"
        (rf/reg-event :rt/touch
          (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-       (story/reg-variant :story.multi/select
+       (rf.story/reg-variant :story.multi/select
          {:setup []
           :plays  [{:name "one" :auto-run? false
                     :script [[:dispatch-sync [:rt/touch]]]}
                    {:name "two" :auto-run? false
                     :script [[:dispatch-sync [:rt/touch]]]}]})
-       (async/deref-blocking (story/run-variant :story.multi/select) 5000)
-       (re/select-play! :story.multi/select "two")
-       (is (= "two" (re/active-play-key :story.multi/select)))
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.multi/select) 5000)
+       (rf.story.play.runner-events/select-play! :story.multi/select "two")
+       (is (= "two" (rf.story.play.runner-events/active-play-key :story.multi/select)))
        ;; No run-state slot was populated by select-play! alone.
-       (is (nil? (re/current-state-for-play :story.multi/select "two"))))))
+       (is (nil? (rf.story.play.runner-events/current-state-for-play :story.multi/select "two"))))))
 
 #?(:clj
    (deftest run-all-plays-sequences-runs
      (testing "run-all-plays! drives every play and resolves with per-play results"
        (rf/reg-event :rt/touch
          (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-       (story/reg-variant :story.multi/all
+       (rf.story/reg-variant :story.multi/all
          {:setup []
           :plays  [{:name "a" :auto-run? false
                     :script [[:dispatch-sync [:rt/touch]]
@@ -1279,9 +1279,9 @@
                    {:name "c" :auto-run? false
                     :script [[:dispatch-sync [:rt/touch]]
                              [:assert-db [:n] 3]]}]})
-       (async/deref-blocking (story/run-variant :story.multi/all) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.multi/all) 5000)
        (let [done    (atom nil)
-             _       (re/run-all-plays! :story.multi/all
+             _       (rf.story.play.runner-events/run-all-plays! :story.multi/all
                                         (fn [final] (reset! done final)))
              deadline (+ (System/currentTimeMillis) 5000)]
          (loop []
@@ -1300,7 +1300,7 @@
      (testing "auto-run! runs only plays whose :auto-run? is true (per-position defaults)"
        (rf/reg-event :rt/inc
          (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-       (story/reg-variant :story.multi/auto
+       (rf.story/reg-variant :story.multi/auto
          {:setup []
           :plays  [{:name "first-default-true"
                     ;; :auto-run? omitted → first defaults to true
@@ -1312,11 +1312,11 @@
                    {:name "third-opted-in"
                     :auto-run? true
                     :script [[:dispatch-sync [:rt/inc]]]}]})
-       (async/deref-blocking (story/run-variant :story.multi/auto) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.multi/auto) 5000)
        (let [done (atom nil)]
          ;; Multi-play auto-run sequences the opted-in plays + resolves
          ;; the done-cb ONCE with the per-play terminal-state vector.
-         (re/auto-run! :story.multi/auto (fn [final] (reset! done final)))
+         (rf.story.play.runner-events/auto-run! :story.multi/auto (fn [final] (reset! done final)))
          (let [deadline (+ (System/currentTimeMillis) 5000)]
            (loop []
              (cond
@@ -1330,7 +1330,7 @@
            (is (= ["first-default-true" "third-opted-in"]
                   (mapv :play-key results))))
          ;; second play was NOT auto-run — its state slot stays empty.
-         (is (nil? (re/current-state-for-play :story.multi/auto
+         (is (nil? (rf.story.play.runner-events/current-state-for-play :story.multi/auto
                                               "second-default-false")))))))
 
 #?(:clj
@@ -1346,10 +1346,10 @@
          ;; First read warns; the call returns the :plays-derived plays vector.
          (let [out1 (with-out-str
                       (binding [*err* *out*]
-                        (re/variant-plays :story.multi/both)))
+                        (rf.story.play.runner-events/variant-plays :story.multi/both)))
                out2 (with-out-str
                       (binding [*err* *out*]
-                        (re/variant-plays :story.multi/both)))]
+                        (rf.story.play.runner-events/variant-plays :story.multi/both)))]
            (is (re-find #":script.*:plays" out1)
                "first read prints the both-slots warning")
            (is (empty? out2)
@@ -1372,16 +1372,16 @@
                  :plays       [{:name "p" :script [[:dispatch [:plays]]]}]})
          (let [warn1 (with-out-str
                        (binding [*err* *out*]
-                         (re/variant-plays :story.multi/both-rearm)))
+                         (rf.story.play.runner-events/variant-plays :story.multi/both-rearm)))
                ;; one-shot in effect: a second read before the clear is silent
                silent (with-out-str
                         (binding [*err* *out*]
-                          (re/variant-plays :story.multi/both-rearm)))
-               _      (re/clear-all-runs!)
+                          (rf.story.play.runner-events/variant-plays :story.multi/both-rearm)))
+               _      (rf.story.play.runner-events/clear-all-runs!)
                ;; after the reset the suppression set is empty → warns again
                warn2  (with-out-str
                         (binding [*err* *out*]
-                          (re/variant-plays :story.multi/both-rearm)))]
+                          (rf.story.play.runner-events/variant-plays :story.multi/both-rearm)))]
            (is (re-find #":script.*:plays" warn1)
                "first read warns")
            (is (empty? silent)
@@ -1406,11 +1406,11 @@
      (testing "run! writes a :run-token onto the started state map so
               concurrent-run detection can compare loops"
        (rf/reg-event :rt/touch (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-       (story/reg-variant :story.runner/token
+       (rf.story/reg-variant :story.runner/token
          {:setup      []
           :script {:auto-run? false
                         :script    [[:dispatch-sync [:rt/touch]]]}})
-       (async/deref-blocking (story/run-variant :story.runner/token) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.runner/token) 5000)
        (let [final (run-blocking :story.runner/token)]
          (is (some? (:run-token final))
              "every run! call stamps a non-nil token onto the started state")))))
@@ -1421,14 +1421,14 @@
               token wins and the stale loop (had it still been queued)
               would bail on mismatch"
        (rf/reg-event :rt/touch (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-       (story/reg-variant :story.runner/token-rotate
+       (rf.story/reg-variant :story.runner/token-rotate
          {:setup      []
           :script {:auto-run? false
                         :script    [[:dispatch-sync [:rt/touch]]]}})
-       (async/deref-blocking (story/run-variant :story.runner/token-rotate) 5000)
+       (rf.story.async/deref-blocking (rf.story/run-variant :story.runner/token-rotate) 5000)
        (let [first-final  (run-blocking :story.runner/token-rotate)
              _            (run-blocking :story.runner/token-rotate)
-             second-state (re/current-state :story.runner/token-rotate)]
+             second-state (rf.story.play.runner-events/current-state :story.runner/token-rotate)]
          (is (some? (:run-token first-final)))
          (is (some? (:run-token second-state)))
          (is (not= (:run-token first-final) (:run-token second-state))
@@ -1443,14 +1443,14 @@
               semantics the migration accidentally lost."
        (let [n (atom 0)]
          (rf/reg-event :rt/inc (fn [{:keys [db]} _] (swap! n inc) {:db (update db :n (fnil inc 0))}))
-         (story/reg-variant :story.runner/sync-tight
+         (rf.story/reg-variant :story.runner/sync-tight
            {:setup      [[:rt/inc] [:rt/inc] [:rt/inc]] ; seed: n=3
             :script {:auto-run? false
                           :script    [[:dispatch-sync [:rt/inc]]
                                       [:dispatch-sync [:rt/inc]]
                                       [:dispatch-sync [:rt/inc]]
                                       [:assert-db [:n] 6]]}})
-         (async/deref-blocking (story/run-variant :story.runner/sync-tight) 5000)
+         (rf.story.async/deref-blocking (rf.story/run-variant :story.runner/sync-tight) 5000)
          (let [final (run-blocking :story.runner/sync-tight)]
            (is (= :pass (:status final))
                "the three increments + assertion run atomically — final count is exactly 6")
@@ -1469,7 +1469,7 @@
 ;; `boundary/dispatch-and-settle!` — i.e. it was DISPATCHED into the frame.
 ;; With no handler that hit `re-frame.router.diagnostics/handle-no-handler!`
 ;; → a spurious `:rf.error/no-such-handler` error trace on the tape (which
-;; can trip `evidence/tape-shows-failure?` into a false `:fail`), AND the
+;; can trip `rf.story.play.evidence/tape-shows-failure?` into a false `:fail`), AND the
 ;; real tape evaluation was skipped. The fix routes these to a no-op
 ;; step-skip — the result boundary still owns the verdict.
 ;;
@@ -1483,7 +1483,7 @@
      `:rf.error/no-such-handler` events targeting the variant's frame.
      Returns `[final-state no-handler-events]`."
      [variant-id]
-     (require '[re-frame.trace.tooling :as trace-tooling])
+     (require '[re-frame.trace.tooling :as rf.trace.tooling])
      (let [reg!      (resolve 're-frame.trace.tooling/register-listener!)
            unreg     (resolve 're-frame.trace.tooling/unregister-listener!)
            collected (atom [])
@@ -1494,7 +1494,7 @@
                           (= variant-id (get-in ev [:tags :frame])))
                  (swap! collected conj ev))))
        (try
-         (async/deref-blocking (story/run-variant variant-id) 5000)
+         (rf.story.async/deref-blocking (rf.story/run-variant variant-id) 5000)
          [(run-blocking variant-id) @collected]
          (finally (when unreg (unreg lid)))))))
 
@@ -1505,7 +1505,7 @@
               frame — so no :rf.error/no-such-handler trace lands (rf2-8y47c)"
        (rf/reg-event :rt/touch
          (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-       (story/reg-variant :story.tape/schema-error
+       (rf.story/reg-variant :story.tape/schema-error
          {:setup      []
           :script {:auto-run? false
                         :script    [[:dispatch-sync [:rt/touch]]
@@ -1524,7 +1524,7 @@
              "the tape-evaluated checkpoint is a no-op step-skip — the result
               boundary owns its verdict, so it neither passes nor fails here")
          (is (empty? (filterv #(= :rf.assert/schema-error (:assertion %))
-                              (story/read-assertions :story.tape/schema-error)))
+                              (rf.story/read-assertions :story.tape/schema-error)))
              "no :rf.assert/schema-error slot record was minted by a dispatch")))))
 
 #?(:clj
@@ -1535,7 +1535,7 @@
               (rf2-fh7g4)"
        (rf/reg-event :rt/touch
          (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-       (story/reg-variant :story.tape/no-cascade
+       (rf.story/reg-variant :story.tape/no-cascade
          {:setup      []
           :script {:auto-run? false
                         :script    [[:dispatch-sync [:rt/touch]]
@@ -1553,7 +1553,7 @@
          (is (nil? (:passed? checkpoint))
              "the tape-evaluated causal checkpoint is a no-op step-skip")
          (is (empty? (filterv #(= :rf.assert/no-cascade-rerender (:assertion %))
-                              (story/read-assertions :story.tape/no-cascade)))
+                              (rf.story/read-assertions :story.tape/no-cascade)))
              "no causal slot record was minted by a dispatch")))))
 
 #?(:clj
@@ -1563,7 +1563,7 @@
               :rf.error/no-such-handler trace lands (rf2-fh7g4)"
        (rf/reg-event :rt/touch
          (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-       (story/reg-variant :story.tape/caused
+       (rf.story/reg-variant :story.tape/caused
          {:setup      []
           :script {:auto-run? false
                         :script    [[:dispatch-sync [:rt/touch]]
@@ -1585,7 +1585,7 @@
 ;; tape-evaluated family is never dispatched. Runs on BOTH runtimes (pure
 ;; data → boolean), reached via var-quote (the established Story-test seam).
 
-(def ^:private tape-evaluated-assertion? @#'re/tape-evaluated-assertion?)
+(def ^:private tape-evaluated-assertion? @#'rf.story.play.runner-events/tape-evaluated-assertion?)
 
 (deftest tape-evaluated-assertion?-classifies-every-non-dispatched-family
   (testing "schema-error and the causal family are tape-evaluated (no

--- a/tools/story/test/re_frame/story/play/runner_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_test.cljc
@@ -2,25 +2,25 @@
   "Pure unit tests for the rich-DSL play runner's step executor +
   state machine (rf2-8i2a9). JVM-runnable; no re-frame dependency."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.play.runner :as runner]))
+            [re-frame.story.play.runner :as rf.story.play.runner]))
 
 ;; ---- step-type sniffing ---------------------------------------------------
 
 (deftest step-type-known
   (testing "step-type returns the tag for every canonical step"
-    (is (= :dispatch       (runner/step-type [:dispatch [:foo]])))
-    (is (= :dispatch-sync  (runner/step-type [:dispatch-sync [:foo]])))
-    (is (= :wait           (runner/step-type [:wait 100])))
-    (is (= :assert-db      (runner/step-type [:assert-db [:k] 1])))
-    (is (= :assert-dom     (runner/step-type [:assert-dom "sel" :visible])))
-    (is (= :click          (runner/step-type [:click "sel"])))
-    (is (= :type           (runner/step-type [:type "sel" "text"])))))
+    (is (= :dispatch       (rf.story.play.runner/step-type [:dispatch [:foo]])))
+    (is (= :dispatch-sync  (rf.story.play.runner/step-type [:dispatch-sync [:foo]])))
+    (is (= :wait           (rf.story.play.runner/step-type [:wait 100])))
+    (is (= :assert-db      (rf.story.play.runner/step-type [:assert-db [:k] 1])))
+    (is (= :assert-dom     (rf.story.play.runner/step-type [:assert-dom "sel" :visible])))
+    (is (= :click          (rf.story.play.runner/step-type [:click "sel"])))
+    (is (= :type           (rf.story.play.runner/step-type [:type "sel" "text"])))))
 
 (deftest step-type-unknown
   (testing "step-type returns the head keyword for unknown steps too"
-    (is (= :counter/inc (runner/step-type [:counter/inc])))
-    (is (nil? (runner/step-type "not-a-vec")))
-    (is (nil? (runner/step-type [])))))
+    (is (= :counter/inc (rf.story.play.runner/step-type [:counter/inc])))
+    (is (nil? (rf.story.play.runner/step-type "not-a-vec")))
+    (is (nil? (rf.story.play.runner/step-type [])))))
 
 (deftest async-yield-classification
   (testing "async-yield? returns true for steps whose effects queue
@@ -28,81 +28,81 @@
             re-entering dispatch) and :wait (explicit sleep). Used by
             run-loop! to decide whether to recur synchronously or yield.
             rf2-ftow6."
-    (is (true? (runner/async-yield? [:click "[data-test=x]"])))
-    (is (true? (runner/async-yield? [:type "[data-test=x]" "text"])))
-    (is (true? (runner/async-yield? [:wait 0])))
-    (is (true? (runner/async-yield? [:wait 100]))))
+    (is (true? (rf.story.play.runner/async-yield? [:click "[data-test=x]"])))
+    (is (true? (rf.story.play.runner/async-yield? [:type "[data-test=x]" "text"])))
+    (is (true? (rf.story.play.runner/async-yield? [:wait 0])))
+    (is (true? (rf.story.play.runner/async-yield? [:wait 100]))))
   (testing "sync-class steps must NOT yield — that's the bug the race
             fix corrects. :dispatch (now settled through settled-boundary
             — the dispatch-sync! drain, rf2-5x1wt.2), :dispatch-sync,
             :assert-db, :assert-dom are synchronous at the step boundary
             on CLJS; yielding between them allowed concurrent runs to
             interleave and overshoot counter incs."
-    (is (false? (runner/async-yield? [:dispatch [:foo]])))
-    (is (false? (runner/async-yield? [:dispatch-sync [:foo]])))
-    (is (false? (runner/async-yield? [:assert-db [:k] 1])))
-    (is (false? (runner/async-yield? [:assert-db [:k] :pred even?])))
-    (is (false? (runner/async-yield? [:assert-dom "sel" :visible])))
-    (is (false? (runner/async-yield? [:assert-dom "sel" :hidden])))
-    (is (false? (runner/async-yield? [:assert-dom "sel" :text "x"])))))
+    (is (false? (rf.story.play.runner/async-yield? [:dispatch [:foo]])))
+    (is (false? (rf.story.play.runner/async-yield? [:dispatch-sync [:foo]])))
+    (is (false? (rf.story.play.runner/async-yield? [:assert-db [:k] 1])))
+    (is (false? (rf.story.play.runner/async-yield? [:assert-db [:k] :pred even?])))
+    (is (false? (rf.story.play.runner/async-yield? [:assert-dom "sel" :visible])))
+    (is (false? (rf.story.play.runner/async-yield? [:assert-dom "sel" :hidden])))
+    (is (false? (rf.story.play.runner/async-yield? [:assert-dom "sel" :text "x"])))))
 
 (deftest known-step-pred
   (testing "known-step? is true only for registered step tags"
-    (is (true?  (runner/known-step? [:dispatch [:foo]])))
-    (is (true?  (runner/known-step? [:wait 0])))
-    (is (false? (runner/known-step? [:counter/inc])))
-    (is (false? (runner/known-step? [])))
-    (is (false? (runner/known-step? nil)))))
+    (is (true?  (rf.story.play.runner/known-step? [:dispatch [:foo]])))
+    (is (true?  (rf.story.play.runner/known-step? [:wait 0])))
+    (is (false? (rf.story.play.runner/known-step? [:counter/inc])))
+    (is (false? (rf.story.play.runner/known-step? [])))
+    (is (false? (rf.story.play.runner/known-step? nil)))))
 
 ;; ---- step-arity checks ----------------------------------------------------
 
 (deftest step-arity-dispatch
   (testing ":dispatch and :dispatch-sync require a non-empty event vector"
-    (is (true?  (runner/step-arity-ok? [:dispatch [:foo]])))
-    (is (true?  (runner/step-arity-ok? [:dispatch [:foo {:a 1}]])))
-    (is (true?  (runner/step-arity-ok? [:dispatch-sync [:foo]])))
-    (is (false? (runner/step-arity-ok? [:dispatch])))
-    (is (false? (runner/step-arity-ok? [:dispatch []])))
-    (is (false? (runner/step-arity-ok? [:dispatch ["not-keyword"]])))))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:dispatch [:foo]])))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:dispatch [:foo {:a 1}]])))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:dispatch-sync [:foo]])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:dispatch])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:dispatch []])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:dispatch ["not-keyword"]])))))
 
 (deftest step-arity-wait
   (testing ":wait requires a non-negative number"
-    (is (true?  (runner/step-arity-ok? [:wait 0])))
-    (is (true?  (runner/step-arity-ok? [:wait 100])))
-    (is (true?  (runner/step-arity-ok? [:wait 1.5])))
-    (is (false? (runner/step-arity-ok? [:wait -1])))
-    (is (false? (runner/step-arity-ok? [:wait "100"])))
-    (is (false? (runner/step-arity-ok? [:wait])))))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:wait 0])))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:wait 100])))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:wait 1.5])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:wait -1])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:wait "100"])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:wait])))))
 
 (deftest step-arity-assert-db
   (testing ":assert-db accepts equality and :pred forms"
-    (is (true?  (runner/step-arity-ok? [:assert-db [:k] 1])))
-    (is (true?  (runner/step-arity-ok? [:assert-db [:a :b] nil])))
-    (is (true?  (runner/step-arity-ok? [:assert-db [:k] :pred 'my-ns/pos-int?])))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:assert-db [:k] 1])))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:assert-db [:a :b] nil])))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:assert-db [:k] :pred 'my-ns/pos-int?])))
     ;; rf2-inbad: fn-direct is the advanced-CLJS-safe authoring path.
-    (is (true?  (runner/step-arity-ok? [:assert-db [:k] :pred pos?])))
-    (is (true?  (runner/step-arity-ok? [:assert-db [:k] :pred (fn [_] true)])))
-    (is (false? (runner/step-arity-ok? [:assert-db [:k] :pred "not-a-sym-or-fn"])))
-    (is (false? (runner/step-arity-ok? [:assert-db [:k] :pred 42])))
-    (is (false? (runner/step-arity-ok? [:assert-db [:k]])))
-    (is (false? (runner/step-arity-ok? [:assert-db "not-a-vec" 1])))
-    (is (false? (runner/step-arity-ok? [:assert-db [:k] :pred])))))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:assert-db [:k] :pred pos?])))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:assert-db [:k] :pred (fn [_] true)])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:assert-db [:k] :pred "not-a-sym-or-fn"])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:assert-db [:k] :pred 42])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:assert-db [:k]])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:assert-db "not-a-vec" 1])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:assert-db [:k] :pred])))))
 
 (deftest step-arity-assert-dom
   (testing ":assert-dom accepts :visible / :hidden / :text"
-    (is (true?  (runner/step-arity-ok? [:assert-dom "sel" :visible])))
-    (is (true?  (runner/step-arity-ok? [:assert-dom "sel" :hidden])))
-    (is (true?  (runner/step-arity-ok? [:assert-dom "sel" :text "hi"])))
-    (is (false? (runner/step-arity-ok? [:assert-dom "sel" :unknown])))
-    (is (false? (runner/step-arity-ok? [:assert-dom 1 :visible])))))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:assert-dom "sel" :visible])))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:assert-dom "sel" :hidden])))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:assert-dom "sel" :text "hi"])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:assert-dom "sel" :unknown])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:assert-dom 1 :visible])))))
 
 (deftest step-arity-click-type
   (testing ":click and :type accept string selectors"
-    (is (true?  (runner/step-arity-ok? [:click "sel"])))
-    (is (true?  (runner/step-arity-ok? [:type "sel" "text"])))
-    (is (false? (runner/step-arity-ok? [:click])))
-    (is (false? (runner/step-arity-ok? [:type "sel"])))
-    (is (false? (runner/step-arity-ok? [:type "sel" 1])))))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:click "sel"])))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:type "sel" "text"])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:click])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:type "sel"])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:type "sel" 1])))))
 
 ;; ---- script coercion ------------------------------------------------------
 
@@ -112,7 +112,7 @@
             [:dispatch [:counter/dec]]
             [:wait 100]
             [:assert-db [:n] 0]]
-           (runner/coerce-script
+           (rf.story.play.runner/coerce-script
              [[:counter/inc]
               [:counter/dec]
               [:wait 100]
@@ -121,23 +121,23 @@
 (deftest coerce-script-passthrough
   (testing "already-tagged steps round-trip unchanged"
     (let [script [[:dispatch [:a]] [:wait 50] [:assert-db [:x] 1]]]
-      (is (= script (runner/coerce-script script))))))
+      (is (= script (rf.story.play.runner/coerce-script script))))))
 
 (deftest coerce-script-empty
-  (is (= [] (runner/coerce-script nil)))
-  (is (= [] (runner/coerce-script []))))
+  (is (= [] (rf.story.play.runner/coerce-script nil)))
+  (is (= [] (rf.story.play.runner/coerce-script []))))
 
 ;; ---- spec parsing ---------------------------------------------------------
 
 (deftest parse-spec-bare-vector
   (testing "a bare vector is sugar for {:script <vec> :auto-run? true}"
-    (let [spec (runner/parse-spec [[:dispatch [:a]] [:wait 100]])]
+    (let [spec (rf.story.play.runner/parse-spec [[:dispatch [:a]] [:wait 100]])]
       (is (= [[:dispatch [:a]] [:wait 100]] (:script spec)))
       (is (true? (:auto-run? spec))))))
 
 (deftest parse-spec-map
   (testing "a map body preserves :auto-run? and :name"
-    (let [spec (runner/parse-spec
+    (let [spec (rf.story.play.runner/parse-spec
                  {:script [[:dispatch [:a]]]
                   :auto-run? false
                   :name "manual-only"})]
@@ -147,19 +147,19 @@
 
 (deftest parse-spec-defaults
   (testing "missing :auto-run? defaults to true"
-    (is (true? (:auto-run? (runner/parse-spec {:script []})))))
+    (is (true? (:auto-run? (rf.story.play.runner/parse-spec {:script []})))))
   (testing "nil body produces an empty script"
-    (is (= [] (:script (runner/parse-spec nil))))))
+    (is (= [] (:script (rf.story.play.runner/parse-spec nil))))))
 
 (deftest parse-spec-lifts-bare-vectors-inside-map
   (testing "the lift applies inside a map's :script too"
-    (let [spec (runner/parse-spec {:script [[:counter/inc] [:wait 10]]})]
+    (let [spec (rf.story.play.runner/parse-spec {:script [[:counter/inc] [:wait 10]]})]
       (is (= [[:dispatch [:counter/inc]] [:wait 10]] (:script spec))))))
 
 ;; ---- state-machine driving ----------------------------------------------
 
 (deftest initial-state-shape
-  (let [s (runner/initial-state {:script [[:dispatch [:a]] [:wait 50]]
+  (let [s (rf.story.play.runner/initial-state {:script [[:dispatch [:a]] [:wait 50]]
                                   :name "happy"})]
     (is (= :idle (:status s)))
     (is (= 0 (:step-idx s)))
@@ -170,19 +170,19 @@
 
 (deftest start-transitions-to-running
   (let [s (-> {:script [[:dispatch [:a]]]}
-              runner/parse-spec
-              runner/initial-state
-              (runner/start 1000))]
+              rf.story.play.runner/parse-spec
+              rf.story.play.runner/initial-state
+              (rf.story.play.runner/start 1000))]
     (is (= :running (:status s)))
     (is (= 1000 (:started-ms s)))))
 
 (deftest record-step-result-bumps-idx-and-failures
-  (let [s0 (-> (runner/parse-spec {:script [[:assert-db [:k] 1]
+  (let [s0 (-> (rf.story.play.runner/parse-spec {:script [[:assert-db [:k] 1]
                                             [:assert-db [:k] 2]]})
-               runner/initial-state
-               (runner/start 0))
-        s1 (runner/record-step-result s0 (runner/step-pass 0 [:assert-db [:k] 1]))
-        s2 (runner/record-step-result s1 (runner/step-fail 1 [:assert-db [:k] 2]
+               rf.story.play.runner/initial-state
+               (rf.story.play.runner/start 0))
+        s1 (rf.story.play.runner/record-step-result s0 (rf.story.play.runner/step-pass 0 [:assert-db [:k] 1]))
+        s2 (rf.story.play.runner/record-step-result s1 (rf.story.play.runner/step-fail 1 [:assert-db [:k] 2]
                                                             {:message "no"}))]
     (is (= 1 (:step-idx s1)))
     (is (= 2 (:step-idx s2)))
@@ -191,10 +191,10 @@
 
 (deftest record-step-result-skip-is-not-a-failure
   (let [s0 (-> {:script [[:dispatch [:a]]]}
-               runner/parse-spec
-               runner/initial-state
-               (runner/start 0))
-        s1 (runner/record-step-result s0 (runner/step-skip 0 [:dispatch [:a]]))]
+               rf.story.play.runner/parse-spec
+               rf.story.play.runner/initial-state
+               (rf.story.play.runner/start 0))
+        s1 (rf.story.play.runner/record-step-result s0 (rf.story.play.runner/step-skip 0 [:dispatch [:a]]))]
     (is (= 1 (:step-idx s1)))
     (is (zero? (:failures s1)))))
 
@@ -207,22 +207,22 @@
   (testing "a no-DOM :skipped? refusal does NOT bump :failures"
     (let [step  [:assert-dom "[data-test=x]" :visible]
           s0    (-> {:script [step]}
-                    runner/parse-spec
-                    runner/initial-state
-                    (runner/start 0))
-          s1    (runner/record-step-result
-                  s0 (runner/step-fail 0 step {:skipped? true :message "no DOM"}))]
+                    rf.story.play.runner/parse-spec
+                    rf.story.play.runner/initial-state
+                    (rf.story.play.runner/start 0))
+          s1    (rf.story.play.runner/record-step-result
+                  s0 (rf.story.play.runner/step-fail 0 step {:skipped? true :message "no DOM"}))]
       (is (= 1 (:step-idx s1)))
       (is (zero? (:failures s1))
           "a :skipped? refusal is not a genuine failure")))
   (testing "a boundary :cannot-run? refusal does NOT bump :failures"
     (let [step  [:assert-dom "[data-test=x]" :visible]
           s0    (-> {:script [step]}
-                    runner/parse-spec
-                    runner/initial-state
-                    (runner/start 0))
-          s1    (runner/record-step-result
-                  s0 (runner/step-fail 0 step {:cannot-run? true :message "refused"}))]
+                    rf.story.play.runner/parse-spec
+                    rf.story.play.runner/initial-state
+                    (rf.story.play.runner/start 0))
+          s1    (rf.story.play.runner/record-step-result
+                  s0 (rf.story.play.runner/step-fail 0 step {:cannot-run? true :message "refused"}))]
       (is (zero? (:failures s1))
           "a :cannot-run? refusal is not a genuine failure"))))
 
@@ -232,37 +232,37 @@
   ;; :failures 0 so the two fields cannot disagree in the CI/JSON report.
   (let [step  [:assert-dom "[data-test=x]" :visible]
         state (-> {:script [[:dispatch [:a]] step]}
-                  runner/parse-spec
-                  runner/initial-state
-                  (runner/start 0)
-                  (runner/record-step-result (runner/step-pass 0 [:dispatch [:a]]))
-                  (runner/record-step-result
-                    (runner/step-fail 1 step {:skipped? true :message "no DOM"}))
-                  (runner/finish 100))]
+                  rf.story.play.runner/parse-spec
+                  rf.story.play.runner/initial-state
+                  (rf.story.play.runner/start 0)
+                  (rf.story.play.runner/record-step-result (rf.story.play.runner/step-pass 0 [:dispatch [:a]]))
+                  (rf.story.play.runner/record-step-result
+                    (rf.story.play.runner/step-fail 1 step {:skipped? true :message "no DOM"}))
+                  (rf.story.play.runner/finish 100))]
     (is (= :cannot-run (:status state)))
     (is (zero? (:failures state))
         ":failures and :status must agree — a cannot-run-only run is NOT red")))
 
 (deftest finish-transitions-by-failure-count
   (let [base (-> {:script [[:assert-db [:k] 1]]}
-                 runner/parse-spec
-                 runner/initial-state
-                 (runner/start 0))
-        pass (runner/record-step-result base (runner/step-pass 0 [:assert-db [:k] 1]))
-        fail (runner/record-step-result base (runner/step-fail 0 [:assert-db [:k] 1]
+                 rf.story.play.runner/parse-spec
+                 rf.story.play.runner/initial-state
+                 (rf.story.play.runner/start 0))
+        pass (rf.story.play.runner/record-step-result base (rf.story.play.runner/step-pass 0 [:assert-db [:k] 1]))
+        fail (rf.story.play.runner/record-step-result base (rf.story.play.runner/step-fail 0 [:assert-db [:k] 1]
                                                                 {:message "no"}))]
-    (is (= :pass (:status (runner/finish pass 100))))
-    (is (= :fail (:status (runner/finish fail 100))))
-    (is (= 100 (:finished-ms (runner/finish pass 100))))))
+    (is (= :pass (:status (rf.story.play.runner/finish pass 100))))
+    (is (= :fail (:status (rf.story.play.runner/finish fail 100))))
+    (is (= 100 (:finished-ms (rf.story.play.runner/finish pass 100))))))
 
 (deftest finish-exception-counts-as-failure
   (let [base (-> {:script [[:dispatch [:bad]]]}
-                 runner/parse-spec
-                 runner/initial-state
-                 (runner/start 0))
-        exc  (runner/record-step-result base
-                                         (runner/step-exception 0 [:dispatch [:bad]] "boom"))]
-    (is (= :fail (:status (runner/finish exc 1))))))
+                 rf.story.play.runner/parse-spec
+                 rf.story.play.runner/initial-state
+                 (rf.story.play.runner/start 0))
+        exc  (rf.story.play.runner/record-step-result base
+                                         (rf.story.play.runner/step-exception 0 [:dispatch [:bad]] "boom"))]
+    (is (= :fail (:status (rf.story.play.runner/finish exc 1))))))
 
 ;; ---- finish :cannot-run aggregation (rf2-taq2j) -------------------------
 ;;
@@ -282,28 +282,28 @@
             terminates :cannot-run, NOT a silent :pass"
     (let [step  [:assert-dom "[data-test=x]" :visible]
           base  (-> {:script [[:dispatch [:a]] step]}
-                    runner/parse-spec
-                    runner/initial-state
-                    (runner/start 0))
+                    rf.story.play.runner/parse-spec
+                    rf.story.play.runner/initial-state
+                    (rf.story.play.runner/start 0))
           state (-> base
-                    (runner/record-step-result (runner/step-pass 0 [:dispatch [:a]]))
-                    (runner/record-step-result
-                      (runner/step-fail 1 step {:skipped? true :message "no DOM — cannot prove"})))]
-      (is (= :cannot-run (:status (runner/finish state 100)))
+                    (rf.story.play.runner/record-step-result (rf.story.play.runner/step-pass 0 [:dispatch [:a]]))
+                    (rf.story.play.runner/record-step-result
+                      (rf.story.play.runner/step-fail 1 step {:skipped? true :message "no DOM — cannot prove"})))]
+      (is (= :cannot-run (:status (rf.story.play.runner/finish state 100)))
           "skip-only refusal → :cannot-run (the fail-closed third status)")
-      (is (not= :pass (:status (runner/finish state 100)))
+      (is (not= :pass (:status (rf.story.play.runner/finish state 100)))
           "the refusal must NOT collapse into a vacuous green"))))
 
 (deftest finish-cannot-run-refusal-only-is-cannot-run
   (testing "a boundary :cannot-run? refusal (no skip) also terminates :cannot-run"
     (let [step  [:assert-dom "[data-test=x]" :visible]
           state (-> {:script [step]}
-                    runner/parse-spec
-                    runner/initial-state
-                    (runner/start 0)
-                    (runner/record-step-result
-                      (runner/step-fail 0 step {:cannot-run? true :message "capability refused"})))]
-      (is (= :cannot-run (:status (runner/finish state 100)))))))
+                    rf.story.play.runner/parse-spec
+                    rf.story.play.runner/initial-state
+                    (rf.story.play.runner/start 0)
+                    (rf.story.play.runner/record-step-result
+                      (rf.story.play.runner/step-fail 0 step {:cannot-run? true :message "capability refused"})))]
+      (is (= :cannot-run (:status (rf.story.play.runner/finish state 100)))))))
 
 (deftest finish-fail-outranks-refusal
   (testing ":fail wins over :cannot-run — a genuine failing assertion
@@ -311,14 +311,14 @@
     (let [fail-step [:assert-db [:k] 1]
           skip-step [:assert-dom "[data-test=x]" :visible]
           state     (-> {:script [fail-step skip-step]}
-                        runner/parse-spec
-                        runner/initial-state
-                        (runner/start 0)
-                        (runner/record-step-result
-                          (runner/step-fail 0 fail-step {:message "expected 1"}))
-                        (runner/record-step-result
-                          (runner/step-fail 1 skip-step {:skipped? true :message "no DOM"})))]
-      (is (= :fail (:status (runner/finish state 100)))
+                        rf.story.play.runner/parse-spec
+                        rf.story.play.runner/initial-state
+                        (rf.story.play.runner/start 0)
+                        (rf.story.play.runner/record-step-result
+                          (rf.story.play.runner/step-fail 0 fail-step {:message "expected 1"}))
+                        (rf.story.play.runner/record-step-result
+                          (rf.story.play.runner/step-fail 1 skip-step {:skipped? true :message "no DOM"})))]
+      (is (= :fail (:status (rf.story.play.runner/finish state 100)))
           ":fail (a real failing step) outranks the refusal"))))
 
 (deftest finish-exception-outranks-refusal
@@ -326,14 +326,14 @@
     (let [exc-step  [:dispatch [:bad]]
           skip-step [:assert-dom "[data-test=x]" :visible]
           state     (-> {:script [exc-step skip-step]}
-                        runner/parse-spec
-                        runner/initial-state
-                        (runner/start 0)
-                        (runner/record-step-result
-                          (runner/step-exception 0 exc-step "boom"))
-                        (runner/record-step-result
-                          (runner/step-fail 1 skip-step {:skipped? true :message "no DOM"})))]
-      (is (= :fail (:status (runner/finish state 100)))))))
+                        rf.story.play.runner/parse-spec
+                        rf.story.play.runner/initial-state
+                        (rf.story.play.runner/start 0)
+                        (rf.story.play.runner/record-step-result
+                          (rf.story.play.runner/step-exception 0 exc-step "boom"))
+                        (rf.story.play.runner/record-step-result
+                          (rf.story.play.runner/step-fail 1 skip-step {:skipped? true :message "no DOM"})))]
+      (is (= :fail (:status (rf.story.play.runner/finish state 100)))))))
 
 ;; ---- run-state-refusals projection (rf2-taq2j) --------------------------
 
@@ -345,15 +345,15 @@
           skip-step [:assert-dom "[data-test=x]" :visible]
           cr-step   [:click "[data-test=y]"]
           state     (-> {:script [pass-step skip-step cr-step]}
-                        runner/parse-spec
-                        runner/initial-state
-                        (runner/start 0)
-                        (runner/record-step-result (runner/step-pass 0 pass-step))
-                        (runner/record-step-result
-                          (runner/step-fail 1 skip-step {:skipped? true :message "no DOM — cannot prove"}))
-                        (runner/record-step-result
-                          (runner/step-fail 2 cr-step {:cannot-run? true :message "capability refused"})))
-          refusals  (runner/run-state-refusals state)]
+                        rf.story.play.runner/parse-spec
+                        rf.story.play.runner/initial-state
+                        (rf.story.play.runner/start 0)
+                        (rf.story.play.runner/record-step-result (rf.story.play.runner/step-pass 0 pass-step))
+                        (rf.story.play.runner/record-step-result
+                          (rf.story.play.runner/step-fail 1 skip-step {:skipped? true :message "no DOM — cannot prove"}))
+                        (rf.story.play.runner/record-step-result
+                          (rf.story.play.runner/step-fail 2 cr-step {:cannot-run? true :message "capability refused"})))
+          refusals  (rf.story.play.runner/run-state-refusals state)]
       (is (= 2 (count refusals)) "one refusal record per refusing step (skip + cannot-run?)")
       (is (= [{:status :cannot-run :unit skip-step
                :reason :runner-cannot-attempt-step :message "no DOM — cannot prove"}
@@ -366,71 +366,71 @@
 (deftest run-state-refusals-empty-when-none-refused
   (testing "run-state-refusals is empty for a clean pass run (no step refused)"
     (let [state (-> {:script [[:assert-db [:k] 1]]}
-                    runner/parse-spec
-                    runner/initial-state
-                    (runner/start 0)
-                    (runner/record-step-result (runner/step-pass 0 [:assert-db [:k] 1])))]
-      (is (= [] (runner/run-state-refusals state))))))
+                    rf.story.play.runner/parse-spec
+                    rf.story.play.runner/initial-state
+                    (rf.story.play.runner/start 0)
+                    (rf.story.play.runner/record-step-result (rf.story.play.runner/step-pass 0 [:assert-db [:k] 1])))]
+      (is (= [] (rf.story.play.runner/run-state-refusals state))))))
 
 (deftest run-state-refusals-omits-message-when-absent
   (testing "a refusal with no :message omits the :message slot (cond-> shape)"
     (let [step  [:assert-dom "[data-test=x]" :visible]
           state (-> {:script [step]}
-                    runner/parse-spec
-                    runner/initial-state
-                    (runner/start 0)
-                    (runner/record-step-result (runner/step-fail 0 step {:skipped? true})))
-          [r]   (runner/run-state-refusals state)]
+                    rf.story.play.runner/parse-spec
+                    rf.story.play.runner/initial-state
+                    (rf.story.play.runner/start 0)
+                    (rf.story.play.runner/record-step-result (rf.story.play.runner/step-fail 0 step {:skipped? true})))
+          [r]   (rf.story.play.runner/run-state-refusals state)]
       (is (= {:status :cannot-run :unit step :reason :runner-cannot-attempt-step} r)
           "no :message slot when the step-result carried none"))))
 
 (deftest done-pred
-  (let [empty-state (runner/initial-state {:script []})
-        with-steps  (runner/initial-state {:script [[:wait 1]]})]
-    (is (true? (runner/done? empty-state)))
-    (is (false? (runner/done? with-steps)))))
+  (let [empty-state (rf.story.play.runner/initial-state {:script []})
+        with-steps  (rf.story.play.runner/initial-state {:script [[:wait 1]]})]
+    (is (true? (rf.story.play.runner/done? empty-state)))
+    (is (false? (rf.story.play.runner/done? with-steps)))))
 
 (deftest current-step-returns-next-step
-  (let [s (-> (runner/parse-spec {:script [[:dispatch [:a]] [:wait 5]]})
-              runner/initial-state)]
-    (is (= [:dispatch [:a]] (runner/current-step s)))))
+  (let [s (-> (rf.story.play.runner/parse-spec {:script [[:dispatch [:a]] [:wait 5]]})
+              rf.story.play.runner/initial-state)]
+    (is (= [:dispatch [:a]] (rf.story.play.runner/current-step s)))))
 
 (deftest progress-str-by-status
-  (let [s (runner/initial-state {:script [[:wait 1] [:wait 2] [:wait 3]]})]
-    (is (= "IDLE" (runner/progress-str (assoc s :status :idle))))
+  (let [s (rf.story.play.runner/initial-state {:script [[:wait 1] [:wait 2] [:wait 3]]})]
+    (is (= "IDLE" (rf.story.play.runner/progress-str (assoc s :status :idle))))
     (is (= "RUNNING (step 2/3)"
-           (runner/progress-str (assoc s :status :running :step-idx 1))))
-    (is (= "PASS (3 steps)" (runner/progress-str (assoc s :status :pass))))
+           (rf.story.play.runner/progress-str (assoc s :status :running :step-idx 1))))
+    (is (= "PASS (3 steps)" (rf.story.play.runner/progress-str (assoc s :status :pass))))
     (is (= "FAIL (2/3 steps)"
-           (runner/progress-str (assoc s :status :fail :step-idx 2))))))
+           (rf.story.play.runner/progress-str (assoc s :status :fail :step-idx 2))))))
 
 ;; ---- step humanisation --------------------------------------------------
 
 (deftest step-summary-shapes
   (is (= "dispatch [:counter/inc]"
-         (runner/step-summary [:dispatch [:counter/inc]])))
-  (is (= "wait 100ms" (runner/step-summary [:wait 100])))
-  (is (= "assert-db [:k] = 1" (runner/step-summary [:assert-db [:k] 1])))
+         (rf.story.play.runner/step-summary [:dispatch [:counter/inc]])))
+  (is (= "wait 100ms" (rf.story.play.runner/step-summary [:wait 100])))
+  (is (= "assert-db [:k] = 1" (rf.story.play.runner/step-summary [:assert-db [:k] 1])))
   (is (= "assert-db [:k] :pred my/pred?"
-         (runner/step-summary [:assert-db [:k] :pred 'my/pred?])))
+         (rf.story.play.runner/step-summary [:assert-db [:k] :pred 'my/pred?])))
   ;; rf2-inbad: fn-direct refs render as <fn> so messages don't leak
   ;; compiler-munged identifiers under advanced CLJS.
   (is (= "assert-db [:k] :pred <fn>"
-         (runner/step-summary [:assert-db [:k] :pred pos?])))
+         (rf.story.play.runner/step-summary [:assert-db [:k] :pred pos?])))
   (is (= "assert-dom \"sel\" visible"
-         (runner/step-summary [:assert-dom "sel" :visible])))
-  (is (= "click \"sel\""  (runner/step-summary [:click "sel"])))
+         (rf.story.play.runner/step-summary [:assert-dom "sel" :visible])))
+  (is (= "click \"sel\""  (rf.story.play.runner/step-summary [:click "sel"])))
   (is (= "type \"sel\" \"text\""
-         (runner/step-summary [:type "sel" "text"]))))
+         (rf.story.play.runner/step-summary [:type "sel" "text"]))))
 
 ;; ---- script validation --------------------------------------------------
 
 (deftest validate-script-clean
-  (is (= [] (runner/validate-script
+  (is (= [] (rf.story.play.runner/validate-script
               [[:dispatch [:a]] [:wait 10] [:assert-db [:k] 1]]))))
 
 (deftest validate-script-flags-unknown-and-bad-arity
-  (let [results (runner/validate-script
+  (let [results (rf.story.play.runner/validate-script
                   [[:dispatch [:a]]
                    [:totally-unknown-step]
                    [:wait -5]
@@ -443,43 +443,43 @@
 ;; ---- summary helpers ------------------------------------------------------
 
 (deftest fail-summary-returns-nil-when-not-failed
-  (let [s (-> (runner/parse-spec {:script [[:dispatch [:a]]]})
-              runner/initial-state
+  (let [s (-> (rf.story.play.runner/parse-spec {:script [[:dispatch [:a]]]})
+              rf.story.play.runner/initial-state
               (assoc :status :pass))]
-    (is (nil? (runner/fail-summary s)))))
+    (is (nil? (rf.story.play.runner/fail-summary s)))))
 
 (deftest fail-summary-counts-failures
   (let [base (-> {:script [[:assert-db [:k] 1] [:assert-db [:k] 2]]}
-                 runner/parse-spec
-                 runner/initial-state
-                 (runner/start 0))
+                 rf.story.play.runner/parse-spec
+                 rf.story.play.runner/initial-state
+                 (rf.story.play.runner/start 0))
         s    (-> base
-                 (runner/record-step-result
-                   (runner/step-fail 0 [:assert-db [:k] 1] {:message "no"}))
-                 (runner/record-step-result
-                   (runner/step-pass 1 [:assert-db [:k] 2]))
-                 (runner/finish 10))
-        summ (runner/fail-summary s)]
+                 (rf.story.play.runner/record-step-result
+                   (rf.story.play.runner/step-fail 0 [:assert-db [:k] 1] {:message "no"}))
+                 (rf.story.play.runner/record-step-result
+                   (rf.story.play.runner/step-pass 1 [:assert-db [:k] 2]))
+                 (rf.story.play.runner/finish 10))
+        summ (rf.story.play.runner/fail-summary s)]
     (is (= 1 (:count summ)))
     (is (= 0 (:idx (:first summ))))))
 
 ;; ---- selector accessors --------------------------------------------------
 
 (deftest step-selector-extraction
-  (is (= "btn"  (runner/step-selector [:click "btn"])))
-  (is (= "inp"  (runner/step-selector [:type "inp" "x"])))
-  (is (= "div"  (runner/step-selector [:assert-dom "div" :visible])))
-  (is (nil?     (runner/step-selector [:wait 1]))))
+  (is (= "btn"  (rf.story.play.runner/step-selector [:click "btn"])))
+  (is (= "inp"  (rf.story.play.runner/step-selector [:type "inp" "x"])))
+  (is (= "div"  (rf.story.play.runner/step-selector [:assert-dom "div" :visible])))
+  (is (nil?     (rf.story.play.runner/step-selector [:wait 1]))))
 
 (deftest step-event-extraction
-  (is (= [:foo 1] (runner/step-event [:dispatch [:foo 1]])))
-  (is (= [:foo]   (runner/step-event [:dispatch-sync [:foo]])))
-  (is (nil?       (runner/step-event [:wait 10]))))
+  (is (= [:foo 1] (rf.story.play.runner/step-event [:dispatch [:foo 1]])))
+  (is (= [:foo]   (rf.story.play.runner/step-event [:dispatch-sync [:foo]])))
+  (is (nil?       (rf.story.play.runner/step-event [:wait 10]))))
 
 ;; ---- trace record builder ------------------------------------------------
 
 (deftest trace-record-shape
-  (let [r (runner/trace-record
+  (let [r (rf.story.play.runner/trace-record
             {:variant-id :story.foo/v
              :idx        2
              :step       [:dispatch [:a]]
@@ -494,23 +494,23 @@
 ;; ---- any-failure? --------------------------------------------------------
 
 (deftest any-failure-pred
-  (is (false? (runner/any-failure?
+  (is (false? (rf.story.play.runner/any-failure?
                 {:results [{:passed? true} {:passed? nil}]})))
-  (is (true?  (runner/any-failure?
+  (is (true?  (rf.story.play.runner/any-failure?
                 {:results [{:passed? true} {:passed? false}]})))
-  (is (true?  (runner/any-failure?
+  (is (true?  (rf.story.play.runner/any-failure?
                 {:results [{:exception true :passed? false}]}))))
 
 ;; ---- multi-play (rf2-tl7zk) ----------------------------------------------
 
 (deftest parse-plays-empty
   (testing "parse-plays of nil / [] returns []"
-    (is (= [] (runner/parse-plays nil)))
-    (is (= [] (runner/parse-plays [])))))
+    (is (= [] (rf.story.play.runner/parse-plays nil)))
+    (is (= [] (rf.story.play.runner/parse-plays [])))))
 
 (deftest parse-plays-first-auto-runs-by-default
   (testing "the first entry defaults :auto-run? to true; subsequent entries default to false"
-    (let [plays (runner/parse-plays
+    (let [plays (rf.story.play.runner/parse-plays
                   [{:name "happy" :script [[:dispatch [:a]]]}
                    {:name "error" :script [[:dispatch [:b]]]}
                    {:name "edge"  :script [[:dispatch [:c]]]}])]
@@ -521,7 +521,7 @@
 
 (deftest parse-plays-respects-explicit-auto-run
   (testing "explicit :auto-run? overrides the per-position default"
-    (let [plays (runner/parse-plays
+    (let [plays (rf.story.play.runner/parse-plays
                   [{:name "first" :auto-run? false :script [[:dispatch [:a]]]}
                    {:name "second" :auto-run? true :script [[:dispatch [:b]]]}])]
       (is (false? (:auto-run? (nth plays 0))))
@@ -529,13 +529,13 @@
 
 (deftest parse-plays-coerces-bare-event-vectors
   (testing "bare event vectors inside a play's :script lift to [:dispatch ...]"
-    (let [plays (runner/parse-plays
+    (let [plays (rf.story.play.runner/parse-plays
                   [{:name "p" :script [[:foo/bar 1] [:wait 0]]}])]
       (is (= [[:dispatch [:foo/bar 1]] [:wait 0]]
              (:script (first plays)))))))
 
 (deftest parse-plays-preserves-name
-  (let [plays (runner/parse-plays
+  (let [plays (rf.story.play.runner/parse-plays
                 [{:name "happy path" :script [[:dispatch [:a]]]}])]
     (is (= "happy path" (:name (first plays))))))
 
@@ -543,7 +543,7 @@
   (testing "if both :plays and :script are present, :plays wins"
     (let [body  {:script [[:dispatch [:legacy]]]
                  :plays       [{:name "p1" :script [[:dispatch [:plays]]]}]}
-          plays (runner/variant-body->plays body)]
+          plays (rf.story.play.runner/variant-body->plays body)]
       (is (= 1 (count plays)))
       (is (= "p1" (:name (first plays))))
       (is (= [[:dispatch [:plays]]] (:script (first plays)))))))
@@ -551,7 +551,7 @@
 (deftest variant-body->plays-wraps-play-script
   (testing "a :script-only variant produces a single-entry vector"
     (let [body  {:script {:name "single" :script [[:dispatch [:a]]]}}
-          plays (runner/variant-body->plays body)]
+          plays (rf.story.play.runner/variant-body->plays body)]
       (is (= 1 (count plays)))
       (is (= "single" (:name (first plays))))
       (is (= [[:dispatch [:a]]] (:script (first plays)))))))
@@ -559,59 +559,59 @@
 (deftest variant-body->plays-bare-play-script-without-name
   (testing "a bare :script without a :name produces a one-entry vector with :name nil"
     (let [body  {:script [[:dispatch [:a]]]}
-          plays (runner/variant-body->plays body)]
+          plays (rf.story.play.runner/variant-body->plays body)]
       (is (= 1 (count plays)))
       (is (nil? (:name (first plays)))))))
 
 (deftest variant-body->plays-empty
   (testing "no play surface yields an empty vector"
-    (is (= [] (runner/variant-body->plays nil)))
-    (is (= [] (runner/variant-body->plays {})))
-    (is (= [] (runner/variant-body->plays {:setup []})))))
+    (is (= [] (rf.story.play.runner/variant-body->plays nil)))
+    (is (= [] (rf.story.play.runner/variant-body->plays {})))
+    (is (= [] (rf.story.play.runner/variant-body->plays {:setup []})))))
 
 (deftest find-play-by-name
-  (let [plays (runner/parse-plays
+  (let [plays (rf.story.play.runner/parse-plays
                 [{:name "happy" :script [[:dispatch [:a]]]}
                  {:name "error" :script [[:dispatch [:b]]]}])]
-    (is (= "happy" (:name (runner/find-play plays "happy"))))
-    (is (= "error" (:name (runner/find-play plays "error"))))
-    (is (nil? (runner/find-play plays "missing")))))
+    (is (= "happy" (:name (rf.story.play.runner/find-play plays "happy"))))
+    (is (= "error" (:name (rf.story.play.runner/find-play plays "error"))))
+    (is (nil? (rf.story.play.runner/find-play plays "missing")))))
 
 (deftest find-play-nil-key-returns-first
-  (let [plays (runner/parse-plays
+  (let [plays (rf.story.play.runner/parse-plays
                 [{:name "first" :script [[:dispatch [:a]]]}
                  {:name "second" :script [[:dispatch [:b]]]}])]
-    (is (= "first" (:name (runner/find-play plays nil))))))
+    (is (= "first" (:name (rf.story.play.runner/find-play plays nil))))))
 
 (deftest default-play-key-shape
-  (let [multi  (runner/parse-plays
+  (let [multi  (rf.story.play.runner/parse-plays
                  [{:name "alpha" :script [[:dispatch [:a]]]}
                   {:name "beta"  :script [[:dispatch [:b]]]}])
-        single-bare (runner/variant-body->plays {:script [[:dispatch [:a]]]})
-        single-named (runner/variant-body->plays {:script {:name "n" :script [[:dispatch [:a]]]}})]
-    (is (= "alpha" (runner/default-play-key multi)))
+        single-bare (rf.story.play.runner/variant-body->plays {:script [[:dispatch [:a]]]})
+        single-named (rf.story.play.runner/variant-body->plays {:script {:name "n" :script [[:dispatch [:a]]]}})]
+    (is (= "alpha" (rf.story.play.runner/default-play-key multi)))
     ;; Single-script wrap preserves the original :name (nil for bare, "n" for named).
-    (is (nil? (runner/default-play-key single-bare)))
-    (is (= "n" (runner/default-play-key single-named)))
-    (is (nil? (runner/default-play-key [])))))
+    (is (nil? (rf.story.play.runner/default-play-key single-bare)))
+    (is (= "n" (rf.story.play.runner/default-play-key single-named)))
+    (is (nil? (rf.story.play.runner/default-play-key [])))))
 
 (deftest multi?-predicate
-  (is (false? (runner/multi? [])))
-  (is (false? (runner/multi? [{:name "one"}])))
-  (is (true?  (runner/multi? [{:name "one"} {:name "two"}]))))
+  (is (false? (rf.story.play.runner/multi? [])))
+  (is (false? (rf.story.play.runner/multi? [{:name "one"}])))
+  (is (true?  (rf.story.play.runner/multi? [{:name "one"} {:name "two"}]))))
 
 (deftest auto-runnable?-predicate
   ;; rf2-jh42p sibling rf2-4gw9p: the ONE definition of "this play
   ;; auto-runs" — :auto-run? true AND a non-empty :script.
   (testing "auto-run? true + non-empty script → runnable"
-    (is (true? (runner/auto-runnable? {:auto-run? true :script [[:dispatch [:a]]]}))))
+    (is (true? (rf.story.play.runner/auto-runnable? {:auto-run? true :script [[:dispatch [:a]]]}))))
   (testing ":auto-run? false → not runnable, even with a script"
-    (is (false? (runner/auto-runnable? {:auto-run? false :script [[:dispatch [:a]]]}))))
+    (is (false? (rf.story.play.runner/auto-runnable? {:auto-run? false :script [[:dispatch [:a]]]}))))
   (testing "empty / missing :script → not runnable, even when opted in"
-    (is (false? (runner/auto-runnable? {:auto-run? true :script []})))
-    (is (false? (runner/auto-runnable? {:auto-run? true}))))
+    (is (false? (rf.story.play.runner/auto-runnable? {:auto-run? true :script []})))
+    (is (false? (rf.story.play.runner/auto-runnable? {:auto-run? true}))))
   (testing "missing :auto-run? → not runnable"
-    (is (false? (runner/auto-runnable? {:script [[:dispatch [:a]]]})))))
+    (is (false? (rf.story.play.runner/auto-runnable? {:script [[:dispatch [:a]]]})))))
 
 (deftest auto-runnable-plays-filters-order-preserving
   (testing "the shared filter both runtime/run-phase-4! and
@@ -621,15 +621,15 @@
                  {:name "b" :auto-run? false :script [[:dispatch [:b]]]}
                  {:name "c" :auto-run? true  :script []}
                  {:name "d" :auto-run? true  :script [[:dispatch [:d]]]}]]
-      (is (= ["a" "d"] (mapv :name (runner/auto-runnable-plays plays))))
+      (is (= ["a" "d"] (mapv :name (rf.story.play.runner/auto-runnable-plays plays))))
       (testing "result is a vector (filterv), matching both call sites"
-        (is (vector? (runner/auto-runnable-plays plays))))))
+        (is (vector? (rf.story.play.runner/auto-runnable-plays plays))))))
   (testing "no auto-run plays → empty vector"
-    (is (= [] (runner/auto-runnable-plays
+    (is (= [] (rf.story.play.runner/auto-runnable-plays
                 [{:name "x" :auto-run? false :script [[:dispatch [:x]]]}])))
-    (is (= [] (runner/auto-runnable-plays [])))))
+    (is (= [] (rf.story.play.runner/auto-runnable-plays [])))))
 
 (deftest play-key-extraction
-  (is (= "p" (runner/play-key {:name "p"})))
-  (is (nil?  (runner/play-key {:name nil})))
-  (is (nil?  (runner/play-key nil))))
+  (is (= "p" (rf.story.play.runner/play-key {:name "p"})))
+  (is (nil?  (rf.story.play.runner/play-key {:name nil})))
+  (is (nil?  (rf.story.play.runner/play-key nil))))

--- a/tools/story/test/re_frame/story/play/settled_boundary_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/play/settled_boundary_cljs_test.cljs
@@ -11,19 +11,19 @@
   ladder math would surface."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core  :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story.play.settled-boundary :as boundary]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story.play.settled-boundary :as rf.story.play.settled-boundary]))
 
 (def ^:private bf :story.boundary.cljs/frame)
 
 (defn- reset-frame! [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch :default _ nil))
-  (frame/ensure-default-frame!)
+  (rf.frame/ensure-default-frame!)
   (rf/make-frame {:id bf :doc "settled-boundary cljs drain test frame"})
   (test-fn))
 
@@ -33,12 +33,12 @@
 
 (deftest ladder-and-refusal-on-cljs
   (testing "the boundary ladder + refusal helpers behave identically on CLJS"
-    (is (= [:headless :cljs-reactive :dom :browser] boundary/boundary-levels))
-    (is (boundary/boundary>= :dom :headless))
-    (is (not (boundary/boundary>= :headless :dom)))
-    (is (= :headless (boundary/step-required-boundary [:dispatch [:e]])))
-    (is (= :dom      (boundary/step-required-boundary [:click "b"])))
-    (is (= :headless (boundary/hooks-provided-boundary boundary/headless-flush-hooks)))))
+    (is (= [:headless :cljs-reactive :dom :browser] rf.story.play.settled-boundary/boundary-levels))
+    (is (rf.story.play.settled-boundary/boundary>= :dom :headless))
+    (is (not (rf.story.play.settled-boundary/boundary>= :headless :dom)))
+    (is (= :headless (rf.story.play.settled-boundary/step-required-boundary [:dispatch [:e]])))
+    (is (= :dom      (rf.story.play.settled-boundary/step-required-boundary [:click "b"])))
+    (is (= :headless (rf.story.play.settled-boundary/hooks-provided-boundary rf.story.play.settled-boundary/headless-flush-hooks)))))
 
 ;; ---- headless drain on the node host -------------------------------------
 
@@ -57,8 +57,8 @@
          :fx [[:dispatch [:cljs.chain/c]]]}))
     (rf/reg-event :cljs.chain/c
       (fn [{:keys [db]} _] {:db (update db :hops (fnil conj []) :c)}))
-    (let [res (boundary/dispatch-and-settle!
-                bf [:cljs.chain/a] boundary/headless-flush-hooks
+    (let [res (rf.story.play.settled-boundary/dispatch-and-settle!
+                bf [:cljs.chain/a] rf.story.play.settled-boundary/headless-flush-hooks
                 :headless [:dispatch [:cljs.chain/a]])]
       (is (= :settled (:status res)))
       (is (= :headless (:boundary res)))
@@ -71,8 +71,8 @@
     (let [fired (atom false)]
       (rf/reg-event :cljs.dom/should-not-fire
         (fn [{:keys [db]} _] (reset! fired true) {:db db}))
-      (let [res (boundary/dispatch-and-settle!
-                  bf [:cljs.dom/should-not-fire] boundary/headless-flush-hooks
+      (let [res (rf.story.play.settled-boundary/dispatch-and-settle!
+                  bf [:cljs.dom/should-not-fire] rf.story.play.settled-boundary/headless-flush-hooks
                   :dom [:click "button"])]
         (is (= :cannot-run (:status res)))
         (is (= :dom      (:required-boundary res)))
@@ -82,9 +82,9 @@
 (deftest cljs-flush-error-not-swallowed
   (testing "a throwing flush fn surfaces :error on CLJS, never a silent pass"
     (let [hooks {:provides  :dom
-                 :dispatch! (fn [frame-id evec] (boundary/drain-sync! frame-id evec))
+                 :dispatch! (fn [frame-id evec] (rf.story.play.settled-boundary/drain-sync! frame-id evec))
                  :flush!    {:dom (fn [_] (throw (ex-info "cljs flush boom" {})))}}]
       (rf/reg-event :cljs.dom/x (fn [{:keys [db]} _] {:db db}))
-      (let [res (boundary/dispatch-and-settle! bf [:cljs.dom/x] hooks :dom [:click "b"])]
+      (let [res (rf.story.play.settled-boundary/dispatch-and-settle! bf [:cljs.dom/x] hooks :dom [:click "b"])]
         (is (= :error (:status res)))
         (is (re-find #"cljs flush boom" (:error res)))))))

--- a/tools/story/test/re_frame/story/play/settled_boundary_test.cljc
+++ b/tools/story/test/re_frame/story/play/settled_boundary_test.cljc
@@ -13,95 +13,95 @@
     `:error`, never swallowed."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core   :as rf]
-            [re-frame.frame  :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.story.play.settled-boundary :as boundary]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.registrar :as registrar]))
+            [re-frame.frame  :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.story.play.settled-boundary :as rf.story.play.settled-boundary]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.registrar :as rf.registrar]))
 
 ;; ---- pure: the boundary ladder -------------------------------------------
 
 (deftest boundary-ladder-ordering
   (testing "the ladder is cheapest→richest and `boundary>=` respects it"
-    (is (= [:headless :cljs-reactive :dom :browser] boundary/boundary-levels))
-    (is (boundary/boundary>= :dom :headless))
-    (is (boundary/boundary>= :headless :headless))
-    (is (boundary/boundary>= :browser :dom))
-    (is (not (boundary/boundary>= :headless :dom)))
-    (is (not (boundary/boundary>= :cljs-reactive :browser)))))
+    (is (= [:headless :cljs-reactive :dom :browser] rf.story.play.settled-boundary/boundary-levels))
+    (is (rf.story.play.settled-boundary/boundary>= :dom :headless))
+    (is (rf.story.play.settled-boundary/boundary>= :headless :headless))
+    (is (rf.story.play.settled-boundary/boundary>= :browser :dom))
+    (is (not (rf.story.play.settled-boundary/boundary>= :headless :dom)))
+    (is (not (rf.story.play.settled-boundary/boundary>= :cljs-reactive :browser)))))
 
 (deftest unknown-boundary-fails-closed
   (testing "unknown boundaries compare false (fail-closed)"
-    (is (not (boundary/boundary>= :nonsense :headless)))
-    (is (not (boundary/boundary>= :headless :nonsense)))
-    (is (false? (boundary/boundary? :nonsense)))
-    (is (true?  (boundary/boundary? :dom)))))
+    (is (not (rf.story.play.settled-boundary/boundary>= :nonsense :headless)))
+    (is (not (rf.story.play.settled-boundary/boundary>= :headless :nonsense)))
+    (is (false? (rf.story.play.settled-boundary/boundary? :nonsense)))
+    (is (true?  (rf.story.play.settled-boundary/boundary? :dom)))))
 
 (deftest max-boundary-picks-richer
   (testing "max-boundary returns the richer of two, treating unknowns as weakest"
-    (is (= :dom      (boundary/max-boundary :headless :dom)))
-    (is (= :dom      (boundary/max-boundary :dom :headless)))
-    (is (= :browser  (boundary/max-boundary :browser :cljs-reactive)))
-    (is (= :headless (boundary/max-boundary :nonsense :nonsense)))
-    (is (= :dom      (boundary/max-boundary :nonsense :dom)))))
+    (is (= :dom      (rf.story.play.settled-boundary/max-boundary :headless :dom)))
+    (is (= :dom      (rf.story.play.settled-boundary/max-boundary :dom :headless)))
+    (is (= :browser  (rf.story.play.settled-boundary/max-boundary :browser :cljs-reactive)))
+    (is (= :headless (rf.story.play.settled-boundary/max-boundary :nonsense :nonsense)))
+    (is (= :dom      (rf.story.play.settled-boundary/max-boundary :nonsense :dom)))))
 
 ;; ---- pure: step → required boundary --------------------------------------
 
 (deftest step-required-boundary-mapping
   (testing "[:dispatch …] needs only :headless; DOM steps need :dom"
-    (is (= :headless (boundary/step-required-boundary [:dispatch [:e]])))
-    (is (= :headless (boundary/step-required-boundary [:dispatch-sync [:e]])))
-    (is (= :headless (boundary/step-required-boundary [:assert-db [:k] 1])))
-    (is (= :dom      (boundary/step-required-boundary [:click "button"])))
-    (is (= :dom      (boundary/step-required-boundary [:type "input" "x"])))
-    (is (= :dom      (boundary/step-required-boundary [:assert-dom "div" :visible]))))
+    (is (= :headless (rf.story.play.settled-boundary/step-required-boundary [:dispatch [:e]])))
+    (is (= :headless (rf.story.play.settled-boundary/step-required-boundary [:dispatch-sync [:e]])))
+    (is (= :headless (rf.story.play.settled-boundary/step-required-boundary [:assert-db [:k] 1])))
+    (is (= :dom      (rf.story.play.settled-boundary/step-required-boundary [:click "button"])))
+    (is (= :dom      (rf.story.play.settled-boundary/step-required-boundary [:type "input" "x"])))
+    (is (= :dom      (rf.story.play.settled-boundary/step-required-boundary [:assert-dom "div" :visible]))))
   (testing "unknown / untagged steps default to :headless"
-    (is (= :headless (boundary/step-required-boundary [:no/such-step])))
-    (is (= :headless (boundary/step-required-boundary "not-a-step")))))
+    (is (= :headless (rf.story.play.settled-boundary/step-required-boundary [:no/such-step])))
+    (is (= :headless (rf.story.play.settled-boundary/step-required-boundary "not-a-step")))))
 
 ;; ---- pure: :cannot-run refusal shape -------------------------------------
 
 (deftest cannot-run-refusal-shape
   (testing "refusal carries required + provided + reason + step"
-    (let [r (boundary/cannot-run-refusal :dom :headless [:click "b"])]
+    (let [r (rf.story.play.settled-boundary/cannot-run-refusal :dom :headless [:click "b"])]
       (is (= :cannot-run (:status r)))
       (is (= :dom        (:required-boundary r)))
       (is (= :headless   (:provided-boundary r)))
       (is (= :runner-below-required-boundary (:reason r)))
       (is (= [:click "b"] (:step r)))))
   (testing "an explicit reason (e.g. flush timeout) is preserved"
-    (let [r (boundary/cannot-run-refusal :dom :headless nil :flush-timeout)]
+    (let [r (rf.story.play.settled-boundary/cannot-run-refusal :dom :headless nil :flush-timeout)]
       (is (= :flush-timeout (:reason r)))
       (is (not (contains? r :step)) "nil step is omitted"))))
 
 (deftest satisfies-boundary-predicate
   (testing "a runner satisfies a step iff its provided boundary >= required"
-    (is (boundary/satisfies-boundary? :dom :headless))
-    (is (boundary/satisfies-boundary? :headless :headless))
-    (is (not (boundary/satisfies-boundary? :headless :dom)))))
+    (is (rf.story.play.settled-boundary/satisfies-boundary? :dom :headless))
+    (is (rf.story.play.settled-boundary/satisfies-boundary? :headless :headless))
+    (is (not (rf.story.play.settled-boundary/satisfies-boundary? :headless :dom)))))
 
 ;; ---- pure: the default headless flush-hooks ------------------------------
 
 (deftest headless-hooks-shape
   (testing "the default headless hooks provide :headless and route dispatch through the drain"
-    (is (= :headless (boundary/hooks-provided-boundary boundary/headless-flush-hooks)))
-    (is (fn? (:dispatch! boundary/headless-flush-hooks)))
-    (is (fn? (get-in boundary/headless-flush-hooks [:flush! :headless])))))
+    (is (= :headless (rf.story.play.settled-boundary/hooks-provided-boundary rf.story.play.settled-boundary/headless-flush-hooks)))
+    (is (fn? (:dispatch! rf.story.play.settled-boundary/headless-flush-hooks)))
+    (is (fn? (get-in rf.story.play.settled-boundary/headless-flush-hooks [:flush! :headless])))))
 
 (deftest hooks-provided-defaults-headless
   (testing "a hooks map with no :provides is assumed headless-only (fail-closed)"
-    (is (= :headless (boundary/hooks-provided-boundary {})))
-    (is (= :headless (boundary/hooks-provided-boundary {:provides :bogus})))
-    (is (= :dom      (boundary/hooks-provided-boundary {:provides :dom})))))
+    (is (= :headless (rf.story.play.settled-boundary/hooks-provided-boundary {})))
+    (is (= :headless (rf.story.play.settled-boundary/hooks-provided-boundary {:provides :bogus})))
+    (is (= :dom      (rf.story.play.settled-boundary/hooks-provided-boundary {:provides :dom})))))
 
 ;; ---- pure: flush-timeout result policy -----------------------------------
 
 (deftest flush-timeout-policy
   (testing "a flush timeout reports :cannot-run or :error per policy, never a pass"
-    (let [cr (boundary/flush-timeout-result :dom :headless [:click "b"])]
+    (let [cr (rf.story.play.settled-boundary/flush-timeout-result :dom :headless [:click "b"])]
       (is (= :cannot-run (:status cr)))
       (is (= :flush-timeout (:reason cr))))
-    (let [err (boundary/flush-timeout-result :dom :headless [:click "b"] :error)]
+    (let [err (rf.story.play.settled-boundary/flush-timeout-result :dom :headless [:click "b"] :error)]
       (is (= :error (:status err)))
       (is (string? (:error err))))))
 
@@ -110,11 +110,11 @@
 (def ^:private bf :story.boundary/frame)
 
 (defn- reset-frame! [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
-  (frame/ensure-default-frame!)
+  (rf.frame/ensure-default-frame!)
   (rf/make-frame {:id bf :doc "settled-boundary drain test frame"})
   (test-fn))
 
@@ -137,8 +137,8 @@
          :fx [[:dispatch [:chain/c]]]}))
     (rf/reg-event :chain/c
       (fn [{:keys [db]} _] {:db (update db :hops (fnil conj []) :c)}))
-    (let [res (boundary/dispatch-and-settle!
-                bf [:chain/a] boundary/headless-flush-hooks :headless [:dispatch [:chain/a]])]
+    (let [res (rf.story.play.settled-boundary/dispatch-and-settle!
+                bf [:chain/a] rf.story.play.settled-boundary/headless-flush-hooks :headless [:dispatch [:chain/a]])]
       (is (= :settled (:status res)))
       (is (= :headless (:boundary res)))
       ;; The entire synchronous cascade has settled — all three hops are
@@ -153,8 +153,8 @@
     (let [fired (atom false)]
       (rf/reg-event :dom/should-not-fire
         (fn [{:keys [db]} _] (reset! fired true) {:db db}))
-      (let [res (boundary/dispatch-and-settle!
-                  bf [:dom/should-not-fire] boundary/headless-flush-hooks
+      (let [res (rf.story.play.settled-boundary/dispatch-and-settle!
+                  bf [:dom/should-not-fire] rf.story.play.settled-boundary/headless-flush-hooks
                   :dom [:click "button"])]
         (is (= :cannot-run (:status res)))
         (is (= :dom      (:required-boundary res)))
@@ -168,12 +168,12 @@
     (let [flushed (atom [])
           hooks   {:provides  :dom
                    :dispatch! (fn [frame-id evec]
-                                (boundary/drain-sync! frame-id evec))
+                                (rf.story.play.settled-boundary/drain-sync! frame-id evec))
                    :flush!    {:headless      (fn [_] (swap! flushed conj :headless))
                                :cljs-reactive (fn [_] (swap! flushed conj :reactive))
                                :dom           (fn [_] (swap! flushed conj :dom))}}]
       (rf/reg-event :dom/click (fn [{:keys [db]} _] {:db (assoc db :clicked true)}))
-      (let [res (boundary/dispatch-and-settle! bf [:dom/click] hooks :dom [:click "b"])]
+      (let [res (rf.story.play.settled-boundary/dispatch-and-settle! bf [:dom/click] hooks :dom [:click "b"])]
         (is (= :settled (:status res)))
         (is (= :dom     (:boundary res)))
         (is (true? (:clicked (rf/app-db-value bf))) "event dispatched")
@@ -184,10 +184,10 @@
   (testing "a throwing flush fn surfaces :error, never a silent pass
             (spec/017: a flush timeout/error NEVER reports a pass)"
     (let [hooks {:provides  :dom
-                 :dispatch! (fn [frame-id evec] (boundary/drain-sync! frame-id evec))
+                 :dispatch! (fn [frame-id evec] (rf.story.play.settled-boundary/drain-sync! frame-id evec))
                  :flush!    {:dom (fn [_] (throw (ex-info "flush boom" {})))}}]
       (rf/reg-event :dom/x (fn [{:keys [db]} _] {:db db}))
-      (let [res (boundary/dispatch-and-settle! bf [:dom/x] hooks :dom [:click "b"])]
+      (let [res (rf.story.play.settled-boundary/dispatch-and-settle! bf [:dom/x] hooks :dom [:click "b"])]
         (is (= :error (:status res)))
         (is (re-find #"flush boom" (:error res)))
         (is (not= :settled (:status res)) "a flush failure is never a settled pass")))))
@@ -204,12 +204,12 @@
                   ;; deterministic, no wall-clock sleep needed.
                   :timeout-ms -1
                   :dispatch!  (fn [frame-id evec]
-                                (boundary/drain-sync! frame-id evec))
+                                (rf.story.play.settled-boundary/drain-sync! frame-id evec))
                   :flush!     {:headless      (fn [_] (swap! ran conj :headless))
                                :cljs-reactive (fn [_] (swap! ran conj :reactive))
                                :dom           (fn [_] (swap! ran conj :dom))}}]
       (rf/reg-event :timeout/fired (fn [{:keys [db]} _] {:db (assoc db :fired true)}))
-      (let [res (boundary/dispatch-and-settle! bf [:timeout/fired] hooks :dom [:click "b"])]
+      (let [res (rf.story.play.settled-boundary/dispatch-and-settle! bf [:timeout/fired] hooks :dom [:click "b"])]
         (is (= :cannot-run    (:status res)))
         (is (= :flush-timeout (:reason res)))
         (is (= :dom           (:required-boundary res)))
@@ -239,18 +239,18 @@
           hooks  {:provides   :dom
                   :timeout-ms budget
                   :dispatch!  (fn [frame-id evec]
-                                (boundary/drain-sync! frame-id evec))
+                                (rf.story.play.settled-boundary/drain-sync! frame-id evec))
                   :flush!     {:cljs-reactive (fn [_] (swap! ran conj :reactive))
                                :dom           (fn [_]
                                                 (swap! ran conj :dom)
                                                 ;; burn well past the deadline
                                                 ;; so the post-flush check is
                                                 ;; unambiguously over budget
-                                                (let [stop (+ (interop/now-ms)
+                                                (let [stop (+ (rf.interop/now-ms)
                                                               (* 4 budget))]
-                                                  (while (< (interop/now-ms) stop) nil)))}}]
+                                                  (while (< (rf.interop/now-ms) stop) nil)))}}]
       (rf/reg-event :timeout/terminal (fn [{:keys [db]} _] {:db (assoc db :fired true)}))
-      (let [res (boundary/dispatch-and-settle! bf [:timeout/terminal] hooks :dom [:click "b"])]
+      (let [res (rf.story.play.settled-boundary/dispatch-and-settle! bf [:timeout/terminal] hooks :dom [:click "b"])]
         (is (not= :settled (:status res))
             "an over-budget TERMINAL flush is never a settled pass")
         (is (= :cannot-run    (:status res)))
@@ -272,11 +272,11 @@
           hooks {:provides   :dom
                  :timeout-ms 60000
                  :dispatch!  (fn [frame-id evec]
-                               (boundary/drain-sync! frame-id evec))
+                               (rf.story.play.settled-boundary/drain-sync! frame-id evec))
                  :flush!     {:cljs-reactive (fn [_] (swap! ran conj :reactive))
                               :dom           (fn [_] (swap! ran conj :dom))}}]
       (rf/reg-event :timeout/ok (fn [{:keys [db]} _] {:db (assoc db :ok true)}))
-      (let [res (boundary/dispatch-and-settle! bf [:timeout/ok] hooks :dom [:click "b"])]
+      (let [res (rf.story.play.settled-boundary/dispatch-and-settle! bf [:timeout/ok] hooks :dom [:click "b"])]
         (is (= :settled (:status res)))
         (is (= :dom     (:boundary res)))
         (is (= [:reactive :dom] @ran) "all flushes ran under a generous budget")
@@ -286,8 +286,8 @@
   (testing "with no :timeout-ms the flush phase is unbounded — settlement
             completes regardless of flush duration (the headless default)"
     (rf/reg-event :noop (fn [{:keys [db]} _] {:db db}))
-    (let [res (boundary/dispatch-and-settle!
-                bf [:noop] boundary/headless-flush-hooks :headless [:dispatch [:noop]])]
+    (let [res (rf.story.play.settled-boundary/dispatch-and-settle!
+                bf [:noop] rf.story.play.settled-boundary/headless-flush-hooks :headless [:dispatch [:noop]])]
       (is (= :settled (:status res))))))
 
 (deftest drain-sync-settles-synchronous-redispatch
@@ -298,6 +298,6 @@
         {:db (assoc db :n 0)
          :fx [[:dispatch [:seed/bump]]]}))
     (rf/reg-event :seed/bump (fn [{:keys [db]} _] {:db (update db :n inc)}))
-    (boundary/drain-sync! bf [:seed/start])
+    (rf.story.play.settled-boundary/drain-sync! bf [:seed/start])
     (is (= 1 (:n (rf/app-db-value bf)))
         "the queued :seed/bump drained synchronously within drain-sync!")))

--- a/tools/story/test/re_frame/story/play/step_runner_test.cljc
+++ b/tools/story/test/re_frame/story/play/step_runner_test.cljc
@@ -5,7 +5,7 @@
   Three layers, all under `clojure -M:test` (JVM) + the node-runtime CLJS
   build:
 
-  - PURE grammar — `runner/step-types` / `step-arity-ok?` / `coerce-script`
+  - PURE grammar — `rf.story.play.runner/step-types` / `step-arity-ok?` / `coerce-script`
     / `step-assertion` / `step-wait-until` recognise the tagged steps
     (`[:dispatch]` / `[:wait-until]` / `[:wait]` / `[:assert]` / `[:focus]`)
     and lift bare event-vector shorthand to `[:dispatch …]` during
@@ -24,16 +24,16 @@
   step's behaviour is observable without standing up the async run loop."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core              :as rf]
-            [re-frame.router            :as router]
-            [re-frame.frame             :as frame]
-            [re-frame.registrar         :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story             :as story]
-            [re-frame.story.plan        :as plan]
-            [re-frame.story.play.runner :as runner]
-            [re-frame.story.play.runner-events :as re]
-            [re-frame.story.play.settled-boundary :as boundary]
-            [re-frame.story.requirements :as requirements]))
+            [re-frame.router            :as rf.router]
+            [re-frame.frame             :as rf.frame]
+            [re-frame.registrar         :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story             :as rf.story]
+            [re-frame.story.plan        :as rf.story.plan]
+            [re-frame.story.play.runner :as rf.story.play.runner]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]
+            [re-frame.story.play.settled-boundary :as rf.story.play.settled-boundary]
+            [re-frame.story.requirements :as rf.story.requirements]))
 
 ;; ===========================================================================
 ;; PURE: the tagged step grammar
@@ -41,77 +41,77 @@
 
 (deftest step-types-include-new-tags
   (testing "the one tagged grammar recognises :assert / :wait-until / :focus"
-    (is (contains? runner/step-types :assert))
-    (is (contains? runner/step-types :wait-until))
-    (is (contains? runner/step-types :focus))
-    (is (= :assert     (runner/step-type [:assert [:rf.assert/path-equals [:k] 1]])))
-    (is (= :wait-until (runner/step-type [:wait-until [:db [:k] 1]])))
-    (is (= :focus      (runner/step-type [:focus "[data-test=in]"])))
-    (is (true? (runner/known-step? [:assert [:rf.assert/path-equals [:k] 1]])))
-    (is (true? (runner/known-step? [:wait-until [:queue-empty]])))
-    (is (true? (runner/known-step? [:focus "sel"])))))
+    (is (contains? rf.story.play.runner/step-types :assert))
+    (is (contains? rf.story.play.runner/step-types :wait-until))
+    (is (contains? rf.story.play.runner/step-types :focus))
+    (is (= :assert     (rf.story.play.runner/step-type [:assert [:rf.assert/path-equals [:k] 1]])))
+    (is (= :wait-until (rf.story.play.runner/step-type [:wait-until [:db [:k] 1]])))
+    (is (= :focus      (rf.story.play.runner/step-type [:focus "[data-test=in]"])))
+    (is (true? (rf.story.play.runner/known-step? [:assert [:rf.assert/path-equals [:k] 1]])))
+    (is (true? (rf.story.play.runner/known-step? [:wait-until [:queue-empty]])))
+    (is (true? (rf.story.play.runner/known-step? [:focus "sel"])))))
 
 (deftest assert-step-is-an-assertion-class-step
   (testing ":assert contributes to pass/fail (it is an assertion-class step)"
-    (is (contains? runner/assertion-step-types :assert))
-    (is (true? (runner/assertion? [:assert [:rf.assert/path-equals [:k] 1]])))))
+    (is (contains? rf.story.play.runner/assertion-step-types :assert))
+    (is (true? (rf.story.play.runner/assertion? [:assert [:rf.assert/path-equals [:k] 1]])))))
 
 (deftest assert-arity
   (testing "[:assert assertion-vector] requires a tagged assertion atom"
-    (is (true?  (runner/step-arity-ok? [:assert [:rf.assert/path-equals [:k] 1]])))
-    (is (true?  (runner/step-arity-ok? [:assert [:rf.assert/no-warnings]])))
-    (is (false? (runner/step-arity-ok? [:assert])))
-    (is (false? (runner/step-arity-ok? [:assert "not-a-vec"])))
-    (is (false? (runner/step-arity-ok? [:assert []])))
-    (is (false? (runner/step-arity-ok? [:assert ["not-keyword"]])))))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:assert [:rf.assert/path-equals [:k] 1]])))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:assert [:rf.assert/no-warnings]])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:assert])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:assert "not-a-vec"])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:assert []])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:assert ["not-keyword"]])))))
 
 (deftest wait-until-arity
   (testing "[:wait-until predicate-spec] accepts :db equals / :db :pred /
             :queue-empty forms"
-    (is (true?  (runner/step-arity-ok? [:wait-until [:db [:k] 1]])))
-    (is (true?  (runner/step-arity-ok? [:wait-until [:db [:a :b] :pred even?]])))
-    (is (true?  (runner/step-arity-ok? [:wait-until [:db [:a :b] :pred 'my/pred?]])))
-    (is (true?  (runner/step-arity-ok? [:wait-until [:queue-empty]])))
-    (is (false? (runner/step-arity-ok? [:wait-until])))
-    (is (false? (runner/step-arity-ok? [:wait-until [:unknown-pred]])))
-    (is (false? (runner/step-arity-ok? [:wait-until [:db "not-a-vec" 1]])))
-    (is (false? (runner/step-arity-ok? [:wait-until [:queue-empty :extra]])))))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:wait-until [:db [:k] 1]])))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:wait-until [:db [:a :b] :pred even?]])))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:wait-until [:db [:a :b] :pred 'my/pred?]])))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:wait-until [:queue-empty]])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:wait-until])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:wait-until [:unknown-pred]])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:wait-until [:db "not-a-vec" 1]])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:wait-until [:queue-empty :extra]])))))
 
 (deftest focus-arity
   (testing "[:focus selector] requires a string selector"
-    (is (true?  (runner/step-arity-ok? [:focus "sel"])))
-    (is (false? (runner/step-arity-ok? [:focus])))
-    (is (false? (runner/step-arity-ok? [:focus 42])))))
+    (is (true?  (rf.story.play.runner/step-arity-ok? [:focus "sel"])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:focus])))
+    (is (false? (rf.story.play.runner/step-arity-ok? [:focus 42])))))
 
 (deftest wait-is-still-the-determinism-opt-out
   (testing "[:wait ms] keeps its tag distinct from [:wait-until] — the
             determinism gate refuses [:wait ms] but not [:wait-until]"
-    (is (= :wait       (runner/step-type [:wait 100])))
-    (is (= :wait-until (runner/step-type [:wait-until [:db [:k] 1]])))
-    (is (not= :wait    (runner/step-type [:wait-until [:db [:k] 1]])))))
+    (is (= :wait       (rf.story.play.runner/step-type [:wait 100])))
+    (is (= :wait-until (rf.story.play.runner/step-type [:wait-until [:db [:k] 1]])))
+    (is (not= :wait    (rf.story.play.runner/step-type [:wait-until [:db [:k] 1]])))))
 
 (deftest step-accessors
   (testing "step-assertion unwraps the [:assert …] atom"
     (is (= [:rf.assert/path-equals [:k] 1]
-           (runner/step-assertion [:assert [:rf.assert/path-equals [:k] 1]])))
-    (is (nil? (runner/step-assertion [:dispatch [:e]]))))
+           (rf.story.play.runner/step-assertion [:assert [:rf.assert/path-equals [:k] 1]])))
+    (is (nil? (rf.story.play.runner/step-assertion [:dispatch [:e]]))))
   (testing "step-wait-until decomposes the predicate-spec"
     (is (= {:kind :db :path [:k] :mode :equals :expected 1}
-           (runner/step-wait-until [:wait-until [:db [:k] 1]])))
+           (rf.story.play.runner/step-wait-until [:wait-until [:db [:k] 1]])))
     (is (= {:kind :queue-empty}
-           (runner/step-wait-until [:wait-until [:queue-empty]])))
-    (let [d (runner/step-wait-until [:wait-until [:db [:k] :pred pos?]])]
+           (rf.story.play.runner/step-wait-until [:wait-until [:queue-empty]])))
+    (let [d (rf.story.play.runner/step-wait-until [:wait-until [:db [:k] :pred pos?]])]
       (is (= :pred (:mode d)))
       (is (true? (:pred-fn? d)))
       (is (identical? pos? (:pred-ref d)))))
   (testing "step-selector covers :focus"
-    (is (= "sel" (runner/step-selector [:focus "sel"])))))
+    (is (= "sel" (rf.story.play.runner/step-selector [:focus "sel"])))))
 
 (deftest step-summary-new-steps
-  (is (= "wait-until [:db [:k] 1]" (runner/step-summary [:wait-until [:db [:k] 1]])))
+  (is (= "wait-until [:db [:k] 1]" (rf.story.play.runner/step-summary [:wait-until [:db [:k] 1]])))
   (is (= "assert [:rf.assert/path-equals [:k] 1]"
-         (runner/step-summary [:assert [:rf.assert/path-equals [:k] 1]])))
-  (is (= "focus \"sel\"" (runner/step-summary [:focus "sel"]))))
+         (rf.story.play.runner/step-summary [:assert [:rf.assert/path-equals [:k] 1]])))
+  (is (= "focus \"sel\"" (rf.story.play.runner/step-summary [:focus "sel"]))))
 
 ;; ---- migration: bare event vectors normalize, tagged steps round-trip ----
 
@@ -121,7 +121,7 @@
             step grammar)"
     (is (= [[:dispatch [:counter/inc]]
             [:dispatch [:counter/dec]]]
-           (runner/coerce-script [[:counter/inc] [:counter/dec]]))))
+           (rf.story.play.runner/coerce-script [[:counter/inc] [:counter/dec]]))))
   (testing "the tagged steps are NEVER mistaken for bare event vectors —
             they round-trip unchanged"
     (let [tagged [[:dispatch [:e]]
@@ -129,7 +129,7 @@
                   [:assert [:rf.assert/path-equals [:k] 1]]
                   [:focus "sel"]
                   [:wait 50]]]
-      (is (= tagged (runner/coerce-script tagged))))))
+      (is (= tagged (rf.story.play.runner/coerce-script tagged))))))
 
 ;; ===========================================================================
 ;; PLAN COMPILE: [:assert …] is rejected in :setup
@@ -144,14 +144,14 @@
   (testing "[:assert …] in :setup FAILS plan construction (spec/017 §Script
             step grammar — illegal in :setup)"
     (is (= :rf.error/story-assert-in-setup
-           (err-id #(plan/variant-plan
+           (err-id #(rf.story.plan/variant-plan
                       {:variant/id :story.bad/setup-assert
                        :setup  [[:dispatch [:seed/a]]
                                 [:assert [:rf.assert/path-equals [:k] 1]]]
                        :script [[:dispatch [:act/b]]]}
                       {})))))
   (testing "[:assert …] in :script compiles fine — only :setup rejects it"
-    (let [p (plan/variant-plan
+    (let [p (rf.story.plan/variant-plan
               {:variant/id :story.ok/script-assert
                :setup  [[:dispatch [:seed/a]]]
                :script [[:dispatch [:act/b]]
@@ -165,7 +165,7 @@
     ;; `[:assert …]` is a known step, so coerce-script does NOT lift it to
     ;; `[:dispatch [:assert …]]` — it stays a checkpoint and the reject fires.
     (is (= :rf.error/story-assert-in-setup
-           (err-id #(plan/variant-plan
+           (err-id #(rf.story.plan/variant-plan
                       {:variant/id :story.bad/events-assert
                        :setup [[:assert [:rf.assert/no-warnings]]]}
                       {}))))))
@@ -176,14 +176,14 @@
 
 (deftest focus-step-requires-dom-in-plan
   (testing "a [:focus …] script step lifts :required-runner to #{:dom}"
-    (let [p (plan/variant-plan
+    (let [p (rf.story.plan/variant-plan
               {:variant/id :story.focus/v
                :script [[:dispatch [:e]] [:focus "[data-test=in]"]]}
               {})]
       (is (contains? (:required-runner p) :dom))))
   (testing "an all-headless script (dispatch + wait-until + assert) needs no
             DOM capability"
-    (let [p (plan/variant-plan
+    (let [p (rf.story.plan/variant-plan
               {:variant/id :story.headless/v
                :script [[:dispatch [:e]]
                         [:wait-until [:db [:k] 1]]
@@ -195,22 +195,22 @@
 ;; HEADLESS execution against a live frame
 ;; ===========================================================================
 
-(def ^:private exec-step! @#'re/exec-step!)
-(def ^:private queue-empty? @#'re/queue-empty?)
+(def ^:private exec-step! @#'rf.story.play.runner-events/exec-step!)
+(def ^:private queue-empty? @#'rf.story.play.runner-events/queue-empty?)
 
 (def ^:private step-frame :story.step-runner/frame)
 
 (defn- reset-rf! [test-fn]
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
-  (reset! re/run-state {})
+  (reset! rf.story.play.runner-events/run-state {})
   ;; The canonical `:rf.assert/*` handlers must be installed so an
   ;; `[:assert …]` checkpoint's dispatched atom records onto the slot.
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (rf/make-frame {:id step-frame :doc "tagged step-runner test frame"})
   (rf/reg-event :step/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
   (rf/reg-event :step/set (fn [{:keys [db]} [_ v]] {:db (assoc db :v v)}))
@@ -229,12 +229,12 @@
 (deftest wait-until-settles-when-predicate-true
   (testing "[:wait-until [:db path expected]] advances (step-skip) once the
             preceding dispatch made the predicate true"
-    (router/dispatch-sync! [:step/set 42] {:frame step-frame})
+    (rf.router/dispatch-sync! [:step/set 42] {:frame step-frame})
     (let [res (exec-step! step-frame 0 [:wait-until [:db [:v] 42]])]
       (is (nil? (:passed? res)) "a satisfied wait-until is a step-skip (advance)")
       (is (not (:exception res)))))
   (testing "[:wait-until [:db path :pred fn]] settles on a predicate"
-    (router/dispatch-sync! [:step/inc] {:frame step-frame})
+    (rf.router/dispatch-sync! [:step/inc] {:frame step-frame})
     (let [res (exec-step! step-frame 0 [:wait-until [:db [:n] :pred pos?]])]
       (is (nil? (:passed? res)))))
   (testing "[:wait-until [:queue-empty]] settles — the queue drained at the
@@ -246,7 +246,7 @@
   (testing "queue-empty? reads the frame's ACTUAL router queue rather than
             a hard-coded `true` stub (rf2-m0cge5 finding 1). `[:click]` /
             `[:type]` / `[:focus]` fire a synthetic DOM event directly and
-            never call `boundary/dispatch-and-settle!`, so a handler the
+            never call `rf.story.play.settled-boundary/dispatch-and-settle!`, so a handler the
             event triggers may enqueue an ASYNC `[:dispatch …]` that has not
             yet drained (the router schedules async drains via
             `interop/next-tick` — genuinely deferred, never inline). A
@@ -263,7 +263,7 @@
     ;; exercises the read mechanism deterministically: a non-empty `:queue`
     ;; is exactly the state an async-dispatched, not-yet-drained envelope
     ;; leaves behind.
-    (let [router (:router (frame/frame step-frame))]
+    (let [router (:router (rf.frame/frame step-frame))]
       (swap! router update :queue conj {:event [:step/inc]})
       (is (false? (queue-empty? step-frame))
           "a non-empty router queue reads as NOT drained — the old
@@ -287,7 +287,7 @@
 (deftest assert-checkpoint-records-at-this-point-in-the-script
   (testing "[:assert [:rf.assert/path-equals …]] records a PASSING assertion
             on the frame's :rf.story/assertions slot when true at this point"
-    (router/dispatch-sync! [:step/set :ready] {:frame step-frame})
+    (rf.router/dispatch-sync! [:step/set :ready] {:frame step-frame})
     (let [res (exec-step! step-frame 0 [:assert [:rf.assert/path-equals [:v] :ready]])]
       (is (true? (:passed? res)) "the checkpoint passed at this point")
       (let [recs (:rf.story/assertions (rf/app-db-value step-frame))]
@@ -296,14 +296,14 @@
         (is (true? (:passed? (last recs)))))))
   (testing "a FAILING checkpoint records :passed? false and surfaces a
             step-fail"
-    (router/dispatch-sync! [:step/set :ready] {:frame step-frame})
+    (rf.router/dispatch-sync! [:step/set :ready] {:frame step-frame})
     (let [res (exec-step! step-frame 1 [:assert [:rf.assert/path-equals [:v] :NOPE]])]
       (is (false? (:passed? res)) "the checkpoint failed at this point")
       (let [recs (:rf.story/assertions (rf/app-db-value step-frame))]
         (is (false? (:passed? (last recs)))))))
   (testing "the checkpoint records exactly ONE assertion (no double-count
             from the assertion-slot mirror bridge)"
-    (router/dispatch-sync! [:step/set 7] {:frame step-frame})
+    (rf.router/dispatch-sync! [:step/set 7] {:frame step-frame})
     (let [before (count (:rf.story/assertions (rf/app-db-value step-frame)))]
       (exec-step! step-frame 0 [:assert [:rf.assert/path-equals [:v] 7]])
       (is (= 1 (- (count (:rf.story/assertions (rf/app-db-value step-frame))) before))
@@ -319,11 +319,11 @@
       (is (re-find #"no DOM" (:message res)))))
   (testing "the boundary ladder agrees: a headless runner does not satisfy
             the :dom boundary [:focus] requires"
-    (is (= :dom (boundary/step-required-boundary [:focus "sel"])))
-    (is (not (boundary/satisfies-boundary? :headless :dom))))
+    (is (= :dom (rf.story.play.settled-boundary/step-required-boundary [:focus "sel"])))
+    (is (not (rf.story.play.settled-boundary/satisfies-boundary? :headless :dom))))
   (testing "the capability registry agrees: [:focus] requires the :dom token
             a :headless runner lacks"
-    (is (= #{:dom} (requirements/step-tokens [:focus "sel"])))
-    (is (false? (requirements/runner-satisfies?
-                  (requirements/runner-provides :headless)
-                  (requirements/step-tokens [:focus "sel"]))))))
+    (is (= #{:dom} (rf.story.requirements/step-tokens [:focus "sel"])))
+    (is (false? (rf.story.requirements/runner-satisfies?
+                  (rf.story.requirements/runner-provides :headless)
+                  (rf.story.requirements/step-tokens [:focus "sel"]))))))

--- a/tools/story/test/re_frame/story/play/step_settle_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/step_settle_cljs_test.cljc
@@ -23,7 +23,7 @@
   the next step's read of app-db was one blind `setTimeout` 0.
 
   The load-bearing subtlety, and the reason the queue is the predicate:
-  `router/dispatch-sync!` pushes its seed at the FRONT of the queue and
+  `rf.router/dispatch-sync!` pushes its seed at the FRONT of the queue and
   drains, so an assertion dispatched at the next step JUMPS AHEAD of the
   click's still-queued event and reads app-db before it lands. Draining
   harder cannot fix an ordering inversion — only waiting for the queue
@@ -50,29 +50,29 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test    :refer [deftest is testing use-fixtures]])
             [re-frame.core   :as rf]
-            [re-frame.router :as router]
-            [re-frame.frame  :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story  :as story]
-            [re-frame.story.play.runner-events :as re]))
+            [re-frame.router :as rf.router]
+            [re-frame.frame  :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story  :as rf.story]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]))
 
 ;; The two private decisions under witness, reached by var-quote — the
 ;; established Story-test seam for a runner internal.
-(def ^:private step-required-selector   @#'re/step-required-selector)
-(def ^:private step-precondition-unmet  @#'re/step-precondition-unmet)
+(def ^:private step-required-selector   @#'rf.story.play.runner-events/step-required-selector)
+(def ^:private step-precondition-unmet  @#'rf.story.play.runner-events/step-precondition-unmet)
 
 (def ^:private settle-frame :story.step-settle/frame)
 
 (defn- reset-rf! [test-fn]
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
-  (reset! re/run-state {})
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (reset! rf.story.play.runner-events/run-state {})
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (rf/make-frame {:id settle-frame :doc "step-settle witness frame"})
   (rf/reg-event :settle/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
   (test-fn))
@@ -170,14 +170,14 @@
 
 #?(:cljs
    (deftest queue-not-drained-is-an-unmet-precondition
-     (testing "THE HOLE rf2-n0sz4 measured. `router/dispatch!` enqueues and
+     (testing "THE HOLE rf2-n0sz4 measured. `rf.router/dispatch!` enqueues and
                schedules the drain through `interop/next-tick` — a
                MACROTASK, so it provably has not run on the statement after
                the dispatch. That is the state a step lands in right after a
                synthetic DOM event fires a handler that dispatches, and it
                is exactly the state the runner used to execute the next step
                in, reading app-db before the event landed"
-       (router/dispatch! [:settle/inc] {:frame settle-frame})
+       (rf.router/dispatch! [:settle/inc] {:frame settle-frame})
        (let [unmet (step-precondition-unmet settle-frame
                                             [:assert [:rf.assert/path-equals [:n] 1]])]
          (is (some? unmet)
@@ -186,7 +186,7 @@
              "and the timeout message must name what never settled"))
        (testing "and it clears once the queue really has drained — the poll
                  proceeds on the OBSERVED condition, not on a timer"
-         (router/dispatch-sync! [:settle/inc] {:frame settle-frame})
+         (rf.router/dispatch-sync! [:settle/inc] {:frame settle-frame})
          (is (nil? (step-precondition-unmet
                      settle-frame
                      [:assert [:rf.assert/path-equals [:n] 1]])))))))

--- a/tools/story/test/re_frame/story/play/substrate_boundary_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/substrate_boundary_cljs_test.cljc
@@ -27,15 +27,15 @@
   why the JVM can witness it."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.story :as story]
-            [re-frame.story.assertions :as assertions]
-            [re-frame.story.late-bind :as late-bind]
-            [re-frame.story.play.runner-events :as runner-events]
-            [re-frame.story.play.settled-boundary :as boundary]
-            [re-frame.story.play.substrate-boundary :as substrate-boundary]
-            [re-frame.story.requirements :as requirements]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.story :as rf.story]
+            [re-frame.story.assertions :as rf.story.assertions]
+            [re-frame.story.late-bind :as rf.story.late-bind]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]
+            [re-frame.story.play.settled-boundary :as rf.story.play.settled-boundary]
+            [re-frame.story.play.substrate-boundary :as rf.story.play.substrate-boundary]
+            [re-frame.story.requirements :as rf.story.requirements]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 ;; ---- harness -------------------------------------------------------------
 
@@ -50,10 +50,10 @@
   same shape and counts instead of flushing, so a JVM run can observe the
   call the browser would make."
   []
-  (assoc plain-atom/adapter
+  (assoc rf.substrate.plain-atom/adapter
          :flush-render! (fn [f] (f) (swap! commits inc) nil)))
 
-;; NOT `late-bind/clear!` — that wipes the canonical shims every sibling
+;; NOT `rf.story.late-bind/clear!` — that wipes the canonical shims every sibling
 ;; test ns registers at load time (`:run-play-step`, `:clear-step-boundaries`,
 ;; `:ensure-canonical-installed`), and the wipe outlives this ns in a shared
 ;; JVM. Snapshot the whole map and restore it, so exactly the one slot this
@@ -61,13 +61,13 @@
 
 (use-fixtures :each
   (fn [t]
-    (let [saved @late-bind/hooks]
+    (let [saved @rf.story.late-bind/hooks]
       (reset! commits 0)
-      (swap! late-bind/hooks dissoc :settled-boundary-hooks)
+      (swap! rf.story.late-bind/hooks dissoc :settled-boundary-hooks)
       (try (t)
            (finally
              (reset! commits 0)
-             (reset! late-bind/hooks saved)
+             (reset! rf.story.late-bind/hooks saved)
              (try (rf/destroy-adapter!)
                   (catch #?(:clj Throwable :cljs :default) _ nil)))))))
 
@@ -75,7 +75,7 @@
   "A folded in-script DOM checkpoint — the shape a shipping
   `[:assert-dom sel :text \"x\"]` has by the time the executor sees it."
   []
-  [:assert [assertions/id-dom-text "[data-test=x]" "42"]])
+  [:assert [rf.story.assertions/id-dom-text "[data-test=x]" "42"]])
 
 ;; ---- the producer --------------------------------------------------------
 
@@ -83,29 +83,29 @@
   (testing "with no adapter installed the producer yields the headless
             default — the JVM floor is unchanged, which is what makes
             installing it unconditionally safe"
-    (is (nil? (substrate-boundary/adapter-flush-render)))
-    (let [hooks (substrate-boundary/substrate-flush-hooks :any-frame)]
-      (is (identical? boundary/headless-flush-hooks hooks))
-      (is (= :headless (boundary/hooks-provided-boundary hooks))))))
+    (is (nil? (rf.story.play.substrate-boundary/adapter-flush-render)))
+    (let [hooks (rf.story.play.substrate-boundary/substrate-flush-hooks :any-frame)]
+      (is (identical? rf.story.play.settled-boundary/headless-flush-hooks hooks))
+      (is (= :headless (rf.story.play.settled-boundary/hooks-provided-boundary hooks))))))
 
 (deftest headless-when-adapter-ships-no-flush-render
   (testing "an adapter with no live commit (plain-atom, SSR) ships no
             :flush-render!, so the producer stays at the headless floor
             rather than claiming a :dom boundary it cannot honour"
-    (rf/init! plain-atom/adapter)
+    (rf/init! rf.substrate.plain-atom/adapter)
     (is (nil? (:flush-render! (rf/current-adapter-spec)))
         "precondition: plain-atom ships no :flush-render!")
-    (is (nil? (substrate-boundary/adapter-flush-render)))
+    (is (nil? (rf.story.play.substrate-boundary/adapter-flush-render)))
     (is (= :headless
-           (boundary/hooks-provided-boundary
-             (substrate-boundary/substrate-flush-hooks :any-frame))))))
+           (rf.story.play.settled-boundary/hooks-provided-boundary
+             (rf.story.play.substrate-boundary/substrate-flush-hooks :any-frame))))))
 
 (deftest provides-dom-when-the-live-adapter-can-commit
   (testing "an adapter shipping :flush-render! lifts the declared boundary
             to :dom and registers the commit at both richer rungs"
     (rf/init! (committing-adapter))
-    (let [hooks (substrate-boundary/substrate-flush-hooks :f)]
-      (is (= :dom (boundary/hooks-provided-boundary hooks)))
+    (let [hooks (rf.story.play.substrate-boundary/substrate-flush-hooks :f)]
+      (is (= :dom (rf.story.play.settled-boundary/hooks-provided-boundary hooks)))
       (is (fn? (get-in hooks [:flush! :cljs-reactive])))
       (is (fn? (get-in hooks [:flush! :dom])))
       (is (zero? @commits) "building the hooks must not commit anything")
@@ -117,31 +117,31 @@
             adapter swaps the settle with no Story-side entry per
             substrate (spec/Tool-Pair.md §Driving the render: a tool that
             names reagent.core/flush! is non-conforming)"
-    (rf/init! plain-atom/adapter)
-    (is (= :headless (boundary/hooks-provided-boundary
-                       (substrate-boundary/substrate-flush-hooks :f))))
+    (rf/init! rf.substrate.plain-atom/adapter)
+    (is (= :headless (rf.story.play.settled-boundary/hooks-provided-boundary
+                       (rf.story.play.substrate-boundary/substrate-flush-hooks :f))))
     (rf/destroy-adapter!)
     (rf/init! (committing-adapter))
-    (is (= :dom (boundary/hooks-provided-boundary
-                  (substrate-boundary/substrate-flush-hooks :f))))))
+    (is (= :dom (rf.story.play.settled-boundary/hooks-provided-boundary
+                  (rf.story.play.substrate-boundary/substrate-flush-hooks :f))))))
 
 ;; ---- the slot ------------------------------------------------------------
 
 (deftest install-registers-the-late-bind-slot
   (testing "before install! the slot is empty and the runner falls back to
             headless — the state every host shipped in before rf2-ek9qb"
-    (is (nil? (late-bind/get-fn :settled-boundary-hooks)))
+    (is (nil? (rf.story.late-bind/get-fn :settled-boundary-hooks)))
     (rf/init! (committing-adapter))
     (is (= :headless
-           (boundary/hooks-provided-boundary
-             (runner-events/current-flush-hooks :f)))
+           (rf.story.play.settled-boundary/hooks-provided-boundary
+             (rf.story.play.runner-events/current-flush-hooks :f)))
         "WITNESS: with no producer the live shell plays at :provides :headless"))
   (testing "after install! the runner resolves the substrate hooks"
-    (substrate-boundary/install!)
-    (is (some? (late-bind/get-fn :settled-boundary-hooks)))
+    (rf.story.play.substrate-boundary/install!)
+    (is (some? (rf.story.late-bind/get-fn :settled-boundary-hooks)))
     (is (= :dom
-           (boundary/hooks-provided-boundary
-             (runner-events/current-flush-hooks :f))))))
+           (rf.story.play.settled-boundary/hooks-provided-boundary
+             (rf.story.play.runner-events/current-flush-hooks :f))))))
 
 ;; ---- the settle, which is the point --------------------------------------
 
@@ -152,9 +152,9 @@
             substrate to commit, and the only thing between an event and a
             DOM read was a setTimeout 0"
     (rf/init! (committing-adapter))
-    (substrate-boundary/install!)
+    (rf.story.play.substrate-boundary/install!)
     (is (zero? @commits))
-    (runner-events/exec-step! :f 0 (dom-assert-step))
+    (rf.story.play.runner-events/exec-step! :f 0 (dom-assert-step))
     (is (pos? @commits)
         "a DOM-family checkpoint must settle the substrate before reading")))
 
@@ -163,9 +163,9 @@
             timer, nothing to race. This is the property a longer
             setTimeout could never buy"
     (rf/init! (committing-adapter))
-    (substrate-boundary/install!)
+    (rf.story.play.substrate-boundary/install!)
     (let [before @commits
-          _      (runner-events/exec-step! :f 0 (dom-assert-step))
+          _      (rf.story.play.runner-events/exec-step! :f 0 (dom-assert-step))
           after  @commits]
       (is (> after before)
           "already committed by the time exec-step! returned"))))
@@ -175,8 +175,8 @@
             substrate through a commit — the ladder still means what it
             says, and the cheap path stays cheap"
     (rf/init! (committing-adapter))
-    (substrate-boundary/install!)
-    (runner-events/exec-step! :f 0 [:wait-until [:queue-empty]])
+    (rf.story.play.substrate-boundary/install!)
+    (rf.story.play.runner-events/exec-step! :f 0 [:wait-until [:queue-empty]])
     (is (zero? @commits))))
 
 (deftest no-producer-means-no-commit
@@ -184,7 +184,7 @@
             the slot empty, the same DOM step commits nothing even though
             the adapter could have"
     (rf/init! (committing-adapter))
-    (runner-events/exec-step! :f 0 (dom-assert-step))
+    (rf.story.play.runner-events/exec-step! :f 0 (dom-assert-step))
     (is (zero? @commits))))
 
 ;; ---- the shared flush loop ----------------------------------------------
@@ -198,7 +198,7 @@
                             :cljs-reactive (fn [_] (swap! seen conj :cljs-reactive))
                             :dom           (fn [_] (swap! seen conj :dom))}}]
       (is (= {:status :settled :boundary :dom}
-             (boundary/settle-to! :f hooks :dom)))
+             (rf.story.play.settled-boundary/settle-to! :f hooks :dom)))
       (is (= [:headless :cljs-reactive :dom] @seen)))))
 
 (deftest settle-to-is-inert-below-its-rung
@@ -207,7 +207,7 @@
           hooks {:provides :dom
                  :flush!   {:cljs-reactive (fn [_] (swap! seen conj :cljs-reactive))
                             :dom           (fn [_] (swap! seen conj :dom))}}]
-      (boundary/settle-to! :f hooks :headless)
+      (rf.story.play.settled-boundary/settle-to! :f hooks :headless)
       (is (= [] @seen)))))
 
 (deftest settle-to-reports-a-throwing-flush
@@ -215,7 +215,7 @@
             never a silent pass"
     (let [hooks {:provides :dom
                  :flush!   {:dom (fn [_] (throw (ex-info "boom" {})))}}
-          res   (boundary/settle-to! :f hooks :dom)]
+          res   (rf.story.play.settled-boundary/settle-to! :f hooks :dom)]
       (is (= :error (:status res))))))
 
 (deftest settle-to-honours-the-timeout-budget
@@ -224,7 +224,7 @@
     (let [hooks {:provides   :dom
                  :timeout-ms -1
                  :flush!     {:dom (fn [_] nil)}}
-          res   (boundary/settle-to! :f hooks :dom)]
+          res   (rf.story.play.settled-boundary/settle-to! :f hooks :dom)]
       (is (= :cannot-run (:status res)))
       (is (= :flush-timeout (:reason res))))))
 
@@ -254,7 +254,7 @@
 ;; it holds exactly one carrying the refusal.
 
 (def ^:private terminal-frame
-  "A real registered frame — `assertions/record!` lands its record by
+  "A real registered frame — `rf.story.assertions/record!` lands its record by
   dispatching into the frame's app-db, and swallows the dispatch when the
   frame is gone. `:f` (which every test above uses) is never registered:
   fine for the settle-count witnesses, useless for a record witness."
@@ -267,15 +267,15 @@
   settle-count witnesses above, which deliberately run with no frame."
   []
   (rf/init! (committing-adapter))
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
-  (swap! frame/frames dissoc terminal-frame)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
+  (swap! rf.frame/frames dissoc terminal-frame)
   (rf/make-frame {:id terminal-frame :doc "terminal-assertion settle witness"}))
 
 (defn- install-hooks!
   "Register `hooks` as the active flush-hooks for every frame."
   [hooks]
-  (late-bind/set-fn! :settled-boundary-hooks (fn [_frame-id] hooks)))
+  (rf.story.late-bind/set-fn! :settled-boundary-hooks (fn [_frame-id] hooks)))
 
 (defn- terminal-records []
   (vec (:rf.story/assertions (rf/app-db-value terminal-frame))))
@@ -283,7 +283,7 @@
 (def ^:private terminal-dom-atom
   "The terminal counterpart of `dom-assert-step` — a bare DOM-family atom,
   the shape `[:expect :assertions]` carries."
-  [assertions/id-dom-text "[data-test=x]" "42"])
+  [rf.story.assertions/id-dom-text "[data-test=x]" "42"])
 
 (deftest terminal-assertion-refuses-when-the-commit-throws
   (testing "WITNESS (rf2-ek9qb, audit #8313): a terminal DOM assertion whose
@@ -295,15 +295,15 @@
     (terminal-frame!)
     (install-hooks! {:provides :dom
                      :flush!   {:dom (fn [_] (throw (ex-info "commit blew up" {})))}})
-    (runner-events/run-terminal-assertions! terminal-frame [terminal-dom-atom])
+    (rf.story.play.runner-events/run-terminal-assertions! terminal-frame [terminal-dom-atom])
     (let [recs (terminal-records)]
       (is (= 1 (count recs))
           "the settle failure reached the ONE terminal accumulator")
-      (is (= assertions/id-dom-text (:assertion (first recs)))
+      (is (= rf.story.assertions/id-dom-text (:assertion (first recs)))
           "recorded against the atom it refused, not a synthetic id")
       (is (= :error (:status (first recs))))
       (is (false? (:passed? (first recs))))
-      (is (= :error (requirements/aggregate-status recs nil))
+      (is (= :error (rf.story.requirements/aggregate-status recs nil))
           "and folds to :error through the ONE aggregation rule — a
            substrate that threw mid-commit is a fault, not a refusal"))))
 
@@ -317,12 +317,12 @@
     (install-hooks! {:provides   :dom
                      :timeout-ms -1
                      :flush!     {:dom (fn [_] nil)}})
-    (runner-events/run-terminal-assertions! terminal-frame [terminal-dom-atom])
+    (rf.story.play.runner-events/run-terminal-assertions! terminal-frame [terminal-dom-atom])
     (let [recs (terminal-records)]
       (is (= 1 (count recs)))
       (is (= :cannot-run (:status (first recs))))
       (is (true? (:cannot-run? (first recs))))
-      (is (= :cannot-run (requirements/aggregate-status recs nil))
+      (is (= :cannot-run (rf.story.requirements/aggregate-status recs nil))
           "the distinct THIRD status — never a silent pass"))))
 
 (deftest a-settled-terminal-assertion-still-evaluates
@@ -335,7 +335,7 @@
     (terminal-frame!)
     (install-hooks! {:provides :dom :flush! {:dom (fn [_] nil)}})
     (reset! commits 0)
-    (runner-events/run-terminal-assertions! terminal-frame [terminal-dom-atom])
+    (rf.story.play.runner-events/run-terminal-assertions! terminal-frame [terminal-dom-atom])
     (is (empty? (terminal-records))
         "no refusal record was minted for a settle that succeeded")))
 
@@ -350,7 +350,7 @@
                      :flush!   {:dom (fn [_] (throw (ex-info "must not run" {})))}})
     (rf/reg-event ::seed (fn [{:keys [db]} [_ m]] {:db (merge db m)}))
     (rf/dispatch-sync [::seed {:status :loaded}] {:frame terminal-frame})
-    (runner-events/run-terminal-assertions!
+    (rf.story.play.runner-events/run-terminal-assertions!
       terminal-frame [[:rf.assert/path-equals [:status] :loaded]])
     (let [recs (filterv #(= :rf.assert/path-equals (:assertion %)) (terminal-records))]
       (is (= 1 (count recs)) "the handler-backed atom recorded exactly once")
@@ -375,10 +375,10 @@
        (install-hooks! {:provides :dom
                         :flush!   {:dom (fn [_] (throw (ex-info "commit blew up" {})))}})
        (let [ran (atom [])]
-         (with-redefs-fn {#'runner-events/exec-assert!
+         (with-redefs-fn {#'rf.story.play.runner-events/exec-assert!
                           (fn [_frame-id _idx _step] (swap! ran conj :assert-ran) nil)}
            (fn []
-             (runner-events/run-terminal-assertions! terminal-frame [terminal-dom-atom])))
+             (rf.story.play.runner-events/run-terminal-assertions! terminal-frame [terminal-dom-atom])))
          (is (= [] @ran)
              "the assertion executor was NOT invoked behind a failed settle")
          (is (= [:error] (mapv :status (terminal-records)))

--- a/tools/story/test/re_frame/story/predicates_test.cljc
+++ b/tools/story/test/re_frame/story/predicates_test.cljc
@@ -8,42 +8,42 @@
   these tests pin (a) the resolver's own JVM `requiring-resolve` contract
   and (b) that BOTH call sites resolve the same symbol identically."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.predicates :as pred]))
+            [re-frame.story.predicates :as rf.story.predicates]))
 
 (deftest resolve-sym-pred-resolves-a-jvm-var
   (testing "a fully-qualified symbol resolves to the var's value (JVM path)"
-    (let [f (pred/resolve-sym-pred 'clojure.core/pos?)]
+    (let [f (rf.story.predicates/resolve-sym-pred 'clojure.core/pos?)]
       (is (fn? f) "resolves to a callable")
       (is (true?  (f 1)))
       (is (false? (f -1)))))
   (testing "the resolved fn IS the var's value (identity, not a copy)"
-    (is (identical? clojure.core/pos? (pred/resolve-sym-pred 'clojure.core/pos?)))))
+    (is (identical? clojure.core/pos? (rf.story.predicates/resolve-sym-pred 'clojure.core/pos?)))))
 
 (deftest resolve-sym-pred-returns-nil-on-miss
   (testing "an unresolvable symbol returns nil (caught, never throws)"
-    (is (nil? (pred/resolve-sym-pred 'no.such.ns/missing-pred))))
+    (is (nil? (rf.story.predicates/resolve-sym-pred 'no.such.ns/missing-pred))))
   (testing "nil input returns nil"
-    (is (nil? (pred/resolve-sym-pred nil)))))
+    (is (nil? (rf.story.predicates/resolve-sym-pred nil)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Dedup contract — both former call sites resolve identically through the
 ;; ONE shared fn. assertions' `[:fn sym]` schema fold and runner-events'
 ;; `:pred sym` form previously each carried a private copy; they now both
-;; route through `pred/resolve-sym-pred`, so a single symbol resolves to the
+;; route through `rf.story.predicates/resolve-sym-pred`, so a single symbol resolves to the
 ;; SAME fn for either consumer.
 ;; ---------------------------------------------------------------------------
 
 (deftest both-call-sites-resolve-a-symbol-pred-identically
   (testing "assertions' [:fn sym] fold and runner-events' :pred sym agree"
     (let [sym         'clojure.core/even?
-          shared      (pred/resolve-sym-pred sym)
+          shared      (rf.story.predicates/resolve-sym-pred sym)
           ;; assertions' resolve-fn-schema rewrites [:fn sym] → [:fn resolved-fn]
           ;; using the shared resolver (re-frame.story.assertions/resolve-fn-schema
           ;; is private; exercise the resolution it performs directly).
-          assertion-f (pred/resolve-sym-pred sym)
+          assertion-f (rf.story.predicates/resolve-sym-pred sym)
           ;; runner-events' exec-wait-until! :pred form likewise calls the
           ;; shared resolver for a symbol ref.
-          runner-f    (pred/resolve-sym-pred sym)]
+          runner-f    (rf.story.predicates/resolve-sym-pred sym)]
       (is (fn? shared))
       (is (identical? shared assertion-f)
           "assertions resolves the symbol via the shared fn")

--- a/tools/story/test/re_frame/story/promotion_test.cljc
+++ b/tools/story/test/re_frame/story/promotion_test.cljc
@@ -20,17 +20,17 @@
   for `:extends` resolution where needed."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.epoch :as epoch]
-            [re-frame.frame :as frame]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.frame :as rf.frame]
             [re-frame.http.managed]       ;; production managed-HTTP fx surface (:rf.http/managed)
             [re-frame.http.test-support]  ;; stub install seam + canned-stub handlers
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story :as story]
-            [re-frame.story.artifact :as artifact]
-            [re-frame.story.determinism :as determinism]
-            [re-frame.story.plan :as plan]
-            [re-frame.story.promotion :as promotion]
-            [re-frame.story.registrar :as registrar]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.artifact :as rf.story.artifact]
+            [re-frame.story.determinism :as rf.story.determinism]
+            [re-frame.story.plan :as rf.story.plan]
+            [re-frame.story.promotion :as rf.story.promotion]
+            [re-frame.story.registrar :as rf.story.registrar]))
 
 ;; ---- fixtures -----------------------------------------------------------
 ;;
@@ -46,12 +46,12 @@
 ;; materialize/promote tests are unaffected by the extra setup.
 
 (defn reset-side-table! [t]
-  (registrar/clear-all!)
-  (epoch/clear-history!)
-  (epoch/clear-epoch-listeners!)
-  (try (rf/init! plain-atom/adapter)
+  (rf.story.registrar/clear-all!)
+  (rf.epoch/clear-history!)
+  (rf.epoch/clear-epoch-listeners!)
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
-  (frame/ensure-default-frame!)
+  (rf.frame/ensure-default-frame!)
   (t))
 
 (use-fixtures :each reset-side-table!)
@@ -63,7 +63,7 @@
   decision + provenance slots + bulky captured evidence (so the
   provenance-trim assertions have something to drop)."
   []
-  (artifact/make-run-artifact
+  (rf.story.artifact/make-run-artifact
     {:event-program [[:dispatch [:counter/init 5]]
                      [:dispatch [:counter/inc]]]
      :seed          42
@@ -82,7 +82,7 @@
 (deftest materialize-produces-readable-plan
   (testing "a run artifact materializes to the normalized four-bucket plan"
     (let [art  (sample-artifact)
-          plan (promotion/materialize-variant-plan art)]
+          plan (rf.story.promotion/materialize-variant-plan art)]
       (is (contains? plan :world))
       (is (contains? plan :script))
       (is (contains? plan :expect))
@@ -92,7 +92,7 @@
 
   (testing "the default policy projects the whole program into :script"
     (let [art  (sample-artifact)
-          plan (promotion/materialize-variant-plan art)]
+          plan (rf.story.promotion/materialize-variant-plan art)]
       (is (= [[:dispatch [:counter/init 5]]
               [:dispatch [:counter/inc]]]
              (:script plan)))
@@ -101,7 +101,7 @@
 
   (testing "a :variant/id rides onto the materialized plan"
     (let [art  (sample-artifact)
-          plan (promotion/materialize-variant-plan
+          plan (rf.story.promotion/materialize-variant-plan
                  art {:variant/id :story.counter/regression-042})]
       (is (= :story.counter/regression-042 (:variant/id plan))))))
 
@@ -112,7 +112,7 @@
 (deftest program-projects-to-setup-and-script-per-policy
   (testing ":setup-count cuts preconditions off the front into [:world :setup]"
     (let [art  (sample-artifact)
-          plan (promotion/materialize-variant-plan art {:setup-count 1})]
+          plan (rf.story.promotion/materialize-variant-plan art {:setup-count 1})]
       (is (= [[:dispatch [:counter/init 5]]] (get-in plan [:world :setup]))
           "the first step is a precondition")
       (is (= [[:dispatch [:counter/inc]]] (:script plan))
@@ -120,7 +120,7 @@
 
   (testing "an explicit :setup + :script partition is used verbatim"
     (let [art  (sample-artifact)
-          plan (promotion/materialize-variant-plan
+          plan (rf.story.promotion/materialize-variant-plan
                  art {:setup  [[:dispatch [:seed/a]]]
                       :script [[:dispatch [:act/b]]]})]
       (is (= [[:dispatch [:seed/a]]] (get-in plan [:world :setup])))
@@ -128,13 +128,13 @@
 
   (testing "partition-program clamps an oversized :setup-count"
     (let [art (sample-artifact)
-          {:keys [setup script]} (promotion/partition-program art {:setup-count 99})]
+          {:keys [setup script]} (rf.story.promotion/partition-program art {:setup-count 99})]
       (is (= 2 (count setup)) "every step becomes a precondition")
       (is (= [] script))))
 
   (testing "a bare event list in :script lifts to a tagged [:dispatch …] program"
     (let [art  (sample-artifact)
-          plan (promotion/materialize-variant-plan
+          plan (rf.story.promotion/materialize-variant-plan
                  art {:script [[:counter/reset]]})]
       (is (= [[:dispatch [:counter/reset]]] (:script plan))))))
 
@@ -145,7 +145,7 @@
 (deftest materialize-preserves-source-artifact-link
   (testing "the plan carries a :run-artifact back-link to the source"
     (let [art  (sample-artifact)
-          plan (promotion/materialize-variant-plan art)
+          plan (rf.story.promotion/materialize-variant-plan art)
           link (:run-artifact plan)]
       (is (= :rf.test/run-artifact (:artifact/kind link)))
       (is (= 42 (:seed link)))
@@ -157,14 +157,14 @@
           "the replayable program survives on the link")))
 
   (testing "the link is TRIMMED — bulky captured evidence is dropped"
-    (let [link (:run-artifact (promotion/materialize-variant-plan (sample-artifact)))]
+    (let [link (:run-artifact (rf.story.promotion/materialize-variant-plan (sample-artifact)))]
       (is (not (contains? link :epoch-tape)))
       (is (not (contains? link :trace)))
       (is (not (contains? link :result))
           "a registered variant is a curation surface, not an evidence dump")))
 
   (testing "the promoted variant body also carries the source link"
-    (let [body (promotion/artifact->variant-body (sample-artifact))]
+    (let [body (rf.story.promotion/artifact->variant-body (sample-artifact))]
       (is (= :rf.test/run-artifact (get-in body [:run-artifact :artifact/kind]))))))
 
 ;; ===========================================================================
@@ -174,10 +174,10 @@
 (deftest materialize-registers-nothing
   (testing "materialize-variant-plan is pure — it registers NO variant"
     (let [art (sample-artifact)]
-      (promotion/materialize-variant-plan art {:variant/id :story.counter/never})
-      (is (not (registrar/registered? :variant :story.counter/never))
+      (rf.story.promotion/materialize-variant-plan art {:variant/id :story.counter/never})
+      (is (not (rf.story.registrar/registered? :variant :story.counter/never))
           "materialize must not touch the side-table")
-      (is (empty? (registrar/registrations :variant))
+      (is (empty? (rf.story.registrar/registrations :variant))
           "the side-table stays empty after materialization"))))
 
 (deftest promote-requires-explicit-variant-id
@@ -186,8 +186,8 @@
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
             #"story-promote-no-id"
-            (promotion/promote-run-artifact! art {})))
-      (is (empty? (registrar/registrations :variant))
+            (rf.story.promotion/promote-run-artifact! art {})))
+      (is (empty? (rf.story.registrar/registrations :variant))
             "a no-id promotion registers nothing"))))
 
 (deftest promote-honours-only-namespaced-variant-id
@@ -200,26 +200,26 @@
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
             #"story-promote-no-id"
-            (promotion/promote-run-artifact! art {:variant-id :story.counter/unqualified})))
-      (is (empty? (registrar/registrations :variant))
+            (rf.story.promotion/promote-run-artifact! art {:variant-id :story.counter/unqualified})))
+      (is (empty? (rf.story.registrar/registrations :variant))
           "the unqualified :variant-id registers nothing"))))
 
 (deftest promote-registers-the-named-variant
   (testing "the explicit named call DOES register a curated variant"
     (let [art (sample-artifact)
-          ret (promotion/promote-run-artifact!
+          ret (rf.story.promotion/promote-run-artifact!
                 art {:variant/id :story.counter/regression-042})]
       (is (= :story.counter/regression-042 ret)
           "promote returns the registered variant id")
-      (is (registrar/registered? :variant :story.counter/regression-042)
+      (is (rf.story.registrar/registered? :variant :story.counter/regression-042)
           "the variant is now in the side-table")))
 
   (testing "the registered body carries the source-artifact link + the program"
-    (registrar/clear-all!)
+    (rf.story.registrar/clear-all!)
     (let [art (sample-artifact)]
-      (promotion/promote-run-artifact!
+      (rf.story.promotion/promote-run-artifact!
         art {:variant/id :story.counter/regression-042})
-      (let [body (registrar/handler-meta :variant :story.counter/regression-042)]
+      (let [body (rf.story.registrar/handler-meta :variant :story.counter/regression-042)]
         (is (= :rf.test/run-artifact (get-in body [:run-artifact :artifact/kind]))
             "provenance survives into the registered variant")
         ;; The registrar stores the `:script` bare step-vector verbatim.
@@ -229,13 +229,13 @@
             "the behaviour program is the registered play script"))))
 
   (testing "the facade re-exports route to the same bridge"
-    (registrar/clear-all!)
+    (rf.story.registrar/clear-all!)
     (let [art (sample-artifact)]
-      (is (contains? (story/materialize-variant-plan art) :run-artifact))
+      (is (contains? (rf.story/materialize-variant-plan art) :run-artifact))
       (is (= :story.counter/from-facade
-             (story/promote-run-artifact!
+             (rf.story/promote-run-artifact!
                art {:variant/id :story.counter/from-facade})))
-      (is (registrar/registered? :variant :story.counter/from-facade)))))
+      (is (rf.story.registrar/registered? :variant :story.counter/from-facade)))))
 
 ;; ===========================================================================
 ;; rf2-87duu — the provenance link of a :network-stubbed run RE-DERIVES it
@@ -281,11 +281,11 @@
   produces."
   [routes script]
   (let [variant-id :story.promo-net/v
-        plan       (plan/variant-plan
+        plan       (rf.story.plan/variant-plan
                      variant-id
                      {:lookup {variant-id {:network routes
                                            :script  script}}})]
-    (determinism/->artifact plan)))
+    (rf.story.determinism/->artifact plan)))
 
 (deftest promotion-link-of-network-run-re-derives-it
   (testing "a variant promoted from a :network-stubbed run carries a
@@ -295,7 +295,7 @@
     (let [routes {[:get "/api/cart"] {:reply {:ok {:items [{:sku "A"}]}}}}
           art    (network-artifact routes [[:dispatch [:promo-net/get-cart]]])
           ;; the trimmed provenance link a promotion stores on :run-artifact
-          link   (promotion/provenance-link art)]
+          link   (rf.story.promotion/provenance-link art)]
 
       ;; The link must itself carry the network route map — it is the slot
       ;; replay re-installs the per-route stubs from. (RED without the fix.)
@@ -305,7 +305,7 @@
 
       ;; A direct replay of the SOURCE artifact: the route matches and the
       ;; recorded :ok reply is synthesised. This is the run that was promoted.
-      (let [src (artifact/replay-run-artifact art)]
+      (let [src (rf.story.artifact/replay-run-artifact art)]
         (is (= :pass (:status src)))
         (is (= :ok (:status (:got (:app-db src))))
             "the source run matched the route stub"))
@@ -315,7 +315,7 @@
       ;; :event-program, :fx-decisions, and — post-fix — :network). Without
       ;; :network the managed request fail-closes on "no stub matched"
       ;; (:rf.http/transport), a DIFFERENT run.
-      (let [from-link (artifact/replay-run-artifact link)
+      (let [from-link (rf.story.artifact/replay-run-artifact link)
             got       (:got (:app-db from-link))]
         (is (= :pass (:status from-link))
             "the link re-derives a passing run — NOT a fail-closed one")
@@ -356,14 +356,14 @@
     (register-network-event! :promo-net/get-cart [:get "/api/cart"])
     (let [routes {[:get "/api/cart"] {:reply {:ok {:items [{:sku "A"}]}}}}
           art    (network-artifact routes [[:dispatch [:promo-net/get-cart]]])
-          body   (promotion/artifact->variant-body art)]
+          body   (rf.story.promotion/artifact->variant-body art)]
       (is (= routes (:network body))
           "the per-route reply map rides the body's runnable :network slot")
       ;; The artifact's :fx-decisions carries the lowered managed-stub redirect;
       ;; the body's :network slot OWNS :rf.http/managed (it re-derives the same
-      ;; redirect through plan/lower-network), so the lifted :fx-overrides must
+      ;; redirect through rf.story.plan/lower-network), so the lifted :fx-overrides must
       ;; NOT also set it — else check-network-fx-conflict! hard-fails.
-      (is (not (contains? (:fx-overrides body) plan/managed-fx-id))
+      (is (not (contains? (:fx-overrides body) rf.story.plan/managed-fx-id))
           ":rf.http/managed is dropped from :fx-overrides — :network owns it"))))
 
 (deftest promoted-variant-body-compiles-to-installed-network
@@ -373,13 +373,13 @@
     (register-network-event! :promo-net/get-cart [:get "/api/cart"])
     (let [routes {[:get "/api/cart"] {:reply {:ok {:items [{:sku "A"}]}}}}
           art    (network-artifact routes [[:dispatch [:promo-net/get-cart]]])
-          body   (promotion/artifact->variant-body art)
+          body   (rf.story.promotion/artifact->variant-body art)
           ;; compile the body as an inline plan target (read-only, no register)
-          plan   (plan/variant-plan body)]
+          plan   (rf.story.plan/variant-plan body)]
       (is (= routes (get-in plan [:world :network]))
           "the compiled plan keeps the route map at [:world :network]")
-      (is (= plan/managed-stub-fx-id
-             (get-in plan [:world :frame :fx-overrides plan/managed-fx-id]))
+      (is (= rf.story.plan/managed-stub-fx-id
+             (get-in plan [:world :frame :fx-overrides rf.story.plan/managed-fx-id]))
           ":rf.http/managed is lowered to the managed-stub fx the runner installs"))))
 
 (deftest promoted-network-variant-runs-to-the-same-result
@@ -393,15 +393,15 @@
     (let [routes {[:get "/api/cart"] {:reply {:ok {:items [{:sku "A"}]}}}}
           art    (network-artifact routes [[:dispatch [:promo-net/get-cart]]])
           ;; the run the variant was promoted FROM (the source artifact replay).
-          src    (artifact/replay-run-artifact art)
+          src    (rf.story.artifact/replay-run-artifact art)
           ;; the PROMOTED VARIANT: body → compiled plan → run-artifact. Running
           ;; the variant = compiling its body + executing it; ->artifact is the
           ;; real materialize-to-run seam, and replay re-installs the body's
           ;; :network route stubs (with-network-stubs!).
-          body   (promotion/artifact->variant-body art)
-          plan   (plan/variant-plan body)
-          var-art (determinism/->artifact plan)
-          ran    (artifact/replay-run-artifact var-art)]
+          body   (rf.story.promotion/artifact->variant-body art)
+          plan   (rf.story.plan/variant-plan body)
+          var-art (rf.story.determinism/->artifact plan)
+          ran    (rf.story.artifact/replay-run-artifact var-art)]
       (is (= routes (:network var-art))
           "the promoted variant's run-artifact carries the route map (NOT empty)")
       (is (= (:status src) (:status ran) :pass)

--- a/tools/story/test/re_frame/story/recorder/dom_capture_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/recorder/dom_capture_dom_cljs_test.cljs
@@ -30,11 +30,11 @@
   too (bodies stay green-by-short-circuit on node), and
   `:browser-test` now picks it up and runs the real assertions."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story.config :as config]
-            [re-frame.story.recorder :as recorder]
-            [re-frame.story.recorder.dom-capture :as dom]
-            [re-frame.story.recorder.play-export :as export]
-            [re-frame.story.recorder.selector :as sel]))
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.recorder :as rf.story.recorder]
+            [re-frame.story.recorder.dom-capture :as rf.story.recorder.dom-capture]
+            [re-frame.story.recorder.play-export :as rf.story.recorder.play-export]
+            [re-frame.story.recorder.selector :as rf.story.recorder.selector]))
 
 ;; ---- runtime gate --------------------------------------------------------
 
@@ -65,22 +65,22 @@
     ;; deftest bodies short-circuit on `dom-available?` too.
     (f)
     (do
-      (recorder/clear!)
-      (dom/set-enabled! true)
-      (dom/set-debounce-ms! 0)
-      (config/set-egress-profile! config/default-egress-profile)
-      (config/reset-suppressed-count!)
+      (rf.story.recorder/clear!)
+      (rf.story.recorder.dom-capture/set-enabled! true)
+      (rf.story.recorder.dom-capture/set-debounce-ms! 0)
+      (rf.story.config/set-egress-profile! rf.story.config/default-egress-profile)
+      (rf.story.config/reset-suppressed-count!)
       (let [_ (mount-root!)]
-        (dom/install! @test-root)
+        (rf.story.recorder.dom-capture/install! @test-root)
         (try
           (f)
           (finally
-            (dom/remove!)
+            (rf.story.recorder.dom-capture/remove!)
             (unmount-root!)
-            (recorder/clear!)
-            (config/set-egress-profile! config/default-egress-profile)
-            (config/reset-suppressed-count!)
-            (dom/set-debounce-ms! 250)))))))
+            (rf.story.recorder/clear!)
+            (rf.story.config/set-egress-profile! rf.story.config/default-egress-profile)
+            (rf.story.config/reset-suppressed-count!)
+            (rf.story.recorder.dom-capture/set-debounce-ms! 250)))))))
 
 (use-fixtures :each reset-all!)
 
@@ -93,7 +93,7 @@
         (.setAttribute btn "data-test" "go")
         (.setAttribute btn "id" "btn-1")
         (is (= "[data-test=\"go\"]"
-               (sel/pick-for-element btn)))))))
+               (rf.story.recorder.selector/pick-for-element btn)))))))
 
 (deftest pick-for-element-falls-back-to-nth
   (when (dom-available?)
@@ -106,15 +106,15 @@
         (.appendChild parent b)
         (.appendChild parent c)
         (is (= "button:nth-of-type(2)"
-               (sel/pick-for-element b)))))))
+               (rf.story.recorder.selector/pick-for-element b)))))))
 
 ;; ---- impure recorder seams ----------------------------------------------
 
 (deftest record-dom-click-appends-entry
   (when (dom-available?)
-    (recorder/start-recording! :story.x/y)
-    (dom/record-dom-click! "[data-test=\"go\"]")
-    (let [entries (recorder/recorded-entries)]
+    (rf.story.recorder/start-recording! :story.x/y)
+    (rf.story.recorder.dom-capture/record-dom-click! "[data-test=\"go\"]")
+    (let [entries (rf.story.recorder/recorded-entries)]
       (is (= 1 (count entries)))
       (let [{:keys [kind selector t]} (first entries)]
         (is (= :dom/click kind))
@@ -123,50 +123,50 @@
 
 (deftest record-dom-type-appends-entry
   (when (dom-available?)
-    (recorder/start-recording! :story.x/y)
-    (dom/record-dom-type! "[id=\"name\"]" "alice")
-    (let [{:keys [kind selector text]} (first (recorder/recorded-entries))]
+    (rf.story.recorder/start-recording! :story.x/y)
+    (rf.story.recorder.dom-capture/record-dom-type! "[id=\"name\"]" "alice")
+    (let [{:keys [kind selector text]} (first (rf.story.recorder/recorded-entries))]
       (is (= :dom/type kind))
       (is (= "[id=\"name\"]" selector))
       (is (= "alice" text)))))
 
 (deftest record-dom-submit-appends-entry
   (when (dom-available?)
-    (recorder/start-recording! :story.x/y)
-    (dom/record-dom-submit! "[id=\"login\"]")
-    (is (= :dom/submit (:kind (first (recorder/recorded-entries)))))))
+    (rf.story.recorder/start-recording! :story.x/y)
+    (rf.story.recorder.dom-capture/record-dom-submit! "[id=\"login\"]")
+    (is (= :dom/submit (:kind (first (rf.story.recorder/recorded-entries)))))))
 
 (deftest noops-when-not-recording
   (when (dom-available?)
     (testing "DOM-event records drop when no recording is in flight"
-      (is (not (recorder/recording?)))
-      (dom/record-dom-click! "anywhere")
-      (dom/record-dom-type! "anywhere" "x")
-      (dom/record-dom-submit! "anywhere")
-      (is (= [] (recorder/recorded-entries))))))
+      (is (not (rf.story.recorder/recording?)))
+      (rf.story.recorder.dom-capture/record-dom-click! "anywhere")
+      (rf.story.recorder.dom-capture/record-dom-type! "anywhere" "x")
+      (rf.story.recorder.dom-capture/record-dom-submit! "anywhere")
+      (is (= [] (rf.story.recorder/recorded-entries))))))
 
 (deftest noops-when-dom-capture-disabled
   (when (dom-available?)
     (testing "DOM-event records drop when the toggle is off — even mid-recording"
-      (dom/set-enabled! false)
-      (recorder/start-recording! :story.x/y)
+      (rf.story.recorder.dom-capture/set-enabled! false)
+      (rf.story.recorder/start-recording! :story.x/y)
       (let [btn (.createElement js/document "button")]
         (.setAttribute btn "data-test" "go")
         (.appendChild @test-root btn)
         (.dispatchEvent btn (js/MouseEvent. "click" #js {:bubbles true}))
-        (is (= [] (recorder/recorded-entries))
+        (is (= [] (rf.story.recorder/recorded-entries))
             "no DOM entries captured while the toggle is off")))))
 
 ;; ---- click handler via synthetic DOM events ------------------------------
 
 (deftest click-listener-captures-with-selector
   (when (dom-available?)
-    (recorder/start-recording! :story.x/y)
+    (rf.story.recorder/start-recording! :story.x/y)
     (let [btn (.createElement js/document "button")]
       (.setAttribute btn "data-test" "submit")
       (.appendChild @test-root btn)
       (.dispatchEvent btn (js/MouseEvent. "click" #js {:bubbles true}))
-      (let [entries (recorder/recorded-entries)]
+      (let [entries (rf.story.recorder/recorded-entries)]
         (is (= 1 (count entries)))
         (is (= :dom/click (:kind (first entries))))
         (is (= "[data-test=\"submit\"]" (:selector (first entries))))))))
@@ -176,14 +176,14 @@
 (deftest rapid-typing-folds-to-single-entry
   (when (dom-available?)
     (testing "many input events on the same input → ONE :dom/type entry with the final value"
-      (recorder/start-recording! :story.x/y)
+      (rf.story.recorder/start-recording! :story.x/y)
       ;; Bump the debounce window high so the buffer holds the
       ;; intermediate input values until we trigger a flush
       ;; manually. The fixture's default debounce-ms (0) would
       ;; cause each input event to flush synchronously — that's
       ;; the path the click-as-flush-point test covers; this one
       ;; verifies the debounce semantics itself.
-      (dom/set-debounce-ms! 5000)
+      (rf.story.recorder.dom-capture/set-debounce-ms! 5000)
       (let [input (.createElement js/document "input")]
         (.setAttribute input "id" "name")
         (.appendChild @test-root input)
@@ -192,9 +192,9 @@
           (.dispatchEvent input (js/Event. "input" #js {:bubbles true})))
         ;; Flush manually; under real use this happens on debounce
         ;; expiry / click / stop-recording.
-        (dom/flush-type-buffer!)
+        (rf.story.recorder.dom-capture/flush-type-buffer!)
         (let [type-entries (filterv #(= :dom/type (:kind %))
-                                    (recorder/recorded-entries))]
+                                    (rf.story.recorder/recorded-entries))]
           (is (= 1 (count type-entries))
               "five input events fold to a single :dom/type entry")
           (is (= "alice" (:text (first type-entries)))
@@ -209,45 +209,45 @@
 (deftest change-event-flushes-immediately
   (when (dom-available?)
     (testing "a `change` event drains the per-selector type buffer"
-      (recorder/start-recording! :story.x/y)
+      (rf.story.recorder/start-recording! :story.x/y)
       (let [input (.createElement js/document "input")]
         (.setAttribute input "id" "name")
         (.appendChild @test-root input)
         (set! (.-value input) "alice")
         (.dispatchEvent input (js/Event. "change" #js {:bubbles true}))
         (let [type-entries (filterv #(= :dom/type (:kind %))
-                                    (recorder/recorded-entries))]
+                                    (rf.story.recorder/recorded-entries))]
           (is (= 1 (count type-entries)))
           (is (= "alice" (:text (first type-entries)))))))))
 
 (deftest submit-listener-captures-form-selector
   (when (dom-available?)
-    (recorder/start-recording! :story.x/y)
+    (rf.story.recorder/start-recording! :story.x/y)
     (let [form (.createElement js/document "form")]
       (.setAttribute form "id" "login")
       (.appendChild @test-root form)
       (let [ev (js/Event. "submit" #js {:bubbles true :cancelable true})]
         (.dispatchEvent form ev))
       (let [submit-entries (filterv #(= :dom/submit (:kind %))
-                                    (recorder/recorded-entries))]
+                                    (rf.story.recorder/recorded-entries))]
         (is (= 1 (count submit-entries)))
         (is (= "[id=\"login\"]" (:selector (first submit-entries))))))))
 
 (deftest click-flushes-pending-type
   (when (dom-available?)
     (testing "a click after typing flushes the type buffer first, preserving order"
-      (recorder/start-recording! :story.x/y)
+      (rf.story.recorder/start-recording! :story.x/y)
       (let [input (.createElement js/document "input")
             btn   (.createElement js/document "button")]
         (.setAttribute input "id" "name")
         (.setAttribute btn "data-test" "save")
         (.appendChild @test-root input)
         (.appendChild @test-root btn)
-        (dom/set-debounce-ms! 5000)
+        (rf.story.recorder.dom-capture/set-debounce-ms! 5000)
         (set! (.-value input) "alice")
         (.dispatchEvent input (js/Event. "input" #js {:bubbles true}))
         (.dispatchEvent btn (js/MouseEvent. "click" #js {:bubbles true}))
-        (let [entries (recorder/recorded-entries)
+        (let [entries (rf.story.recorder/recorded-entries)
               kinds   (mapv :kind entries)]
           (is (= [:dom/type :dom/click] kinds)
               "type lands before click")
@@ -257,19 +257,19 @@
 
 (deftest set-enabled-roundtrips
   (when (dom-available?)
-    (dom/set-enabled! false)
-    (is (not (dom/enabled?)))
-    (dom/set-enabled! true)
-    (is (dom/enabled?))))
+    (rf.story.recorder.dom-capture/set-enabled! false)
+    (is (not (rf.story.recorder.dom-capture/enabled?)))
+    (rf.story.recorder.dom-capture/set-enabled! true)
+    (is (rf.story.recorder.dom-capture/enabled?))))
 
 ;; ---- timestamps ride through to entries ---------------------------------
 
 (deftest dom-entries-carry-relative-timestamps
   (when (dom-available?)
     (testing "the recorded :t is relative to the recording's :started-ms"
-      (recorder/start-recording! :story.x/y)
-      (dom/record-dom-click! "[data-test=\"a\"]")
-      (let [{:keys [t]} (first (recorder/recorded-entries))]
+      (rf.story.recorder/start-recording! :story.x/y)
+      (rf.story.recorder.dom-capture/record-dom-click! "[data-test=\"a\"]")
+      (let [{:keys [t]} (first (rf.story.recorder/recorded-entries))]
         (is (number? t))
         (is (>= t 0)
             ":t is non-negative ms since :started-ms")
@@ -279,7 +279,7 @@
 ;; ---- sensitive-input redaction (rf2-0qoi0) -------------------------------
 ;;
 ;; The DOM-capture rail is the SECOND credential/PII egress (the dispatch
-;; rail being the first, redacted by `recorder/trace-listener`). Post
+;; rail being the first, redacted by `rf.story.recorder/trace-listener`). Post
 ;; rf2-nkjkj `:entries` is the PRIMARY codegen source, so a typed password
 ;; would otherwise ride verbatim into the generated `:script` step.
 ;; These tests pin the record-but-redact policy on the DOM rail: a
@@ -300,23 +300,23 @@
     (testing "RED→GREEN (rf2-0qoi0): a typed <input type=password> value is
               SCRUBBED — neither the recorded :dom/type entry nor the
               generated play-script :type step carries the plaintext"
-      (recorder/start-recording! :story.login/flow)
+      (rf.story.recorder/start-recording! :story.login/flow)
       (let [pw (mk-input! {:type "password" :id "pw"})]
         (set! (.-value pw) "hunter2-secret")
         (.dispatchEvent pw (js/Event. "change" #js {:bubbles true}))
         (let [{:keys [text] :as entry}
-              (first (filterv #(= :dom/type (:kind %)) (recorder/recorded-entries)))]
+              (first (filterv #(= :dom/type (:kind %)) (rf.story.recorder/recorded-entries)))]
           ;; The recorded entry carries the placeholder, not the password.
-          (is (= dom/redacted-type-text text)
+          (is (= rf.story.recorder.dom-capture/redacted-type-text text)
               "the recorded :dom/type text is the redacted placeholder")
           (is (not= "hunter2-secret" text)
               "the plaintext password never reaches the recorder atom")
           ;; The generated play-script step carries the placeholder too.
-          (let [spec (export/recording->script-body (recorder/recorded-entries))
+          (let [spec (rf.story.recorder.play-export/recording->script-body (rf.story.recorder/recorded-entries))
                 type-steps (filterv #(= :type (first %)) (:script spec))]
-            (is (= [[:type (:selector entry) dom/redacted-type-text]] type-steps)
+            (is (= [[:type (:selector entry) rf.story.recorder.dom-capture/redacted-type-text]] type-steps)
                 "the generated :type step is scrubbed")
-            (is (not (re-find #"hunter2-secret" (export/render-script-body spec)))
+            (is (not (re-find #"hunter2-secret" (rf.story.recorder.play-export/render-script-body spec)))
                 "the rendered snippet text leaks no plaintext")))))))
 
 (deftest email-and-tel-and-autocomplete-fields-are-redacted
@@ -326,49 +326,49 @@
                      {:type "tel" :id "t"}
                      {:type "text" :autocomplete "current-password" :id "c"}
                      {:type "text" :autocomplete "cc-number" :id "n"}]]
-        (recorder/clear!)
-        (recorder/start-recording! :story.login/flow)
+        (rf.story.recorder/clear!)
+        (rf.story.recorder/start-recording! :story.login/flow)
         (let [el (mk-input! attrs)]
           (set! (.-value el) "secret-value")
           (.dispatchEvent el (js/Event. "change" #js {:bubbles true}))
           (let [text (:text (first (filterv #(= :dom/type (:kind %))
-                                            (recorder/recorded-entries))))]
-            (is (= dom/redacted-type-text text)
+                                            (rf.story.recorder/recorded-entries))))]
+            (is (= rf.story.recorder.dom-capture/redacted-type-text text)
                 (str "scrubbed for attrs " (pr-str attrs)))))))))
 
 (deftest ordinary-text-field-is-not-redacted
   (when (dom-available?)
     (testing "a plain <input type=text> + a <select> choice flow through verbatim
               — only sensitive typed inputs are scrubbed (no over-redaction)"
-      (recorder/start-recording! :story.x/y)
+      (rf.story.recorder/start-recording! :story.x/y)
       (let [name-input (mk-input! {:type "text" :id "name"})]
         (set! (.-value name-input) "alice")
         (.dispatchEvent name-input (js/Event. "change" #js {:bubbles true}))
         (is (= "alice"
                (:text (first (filterv #(= :dom/type (:kind %))
-                                      (recorder/recorded-entries))))))))))
+                                      (rf.story.recorder/recorded-entries))))))))))
 
 (deftest local-raw-profile-opts-into-verbatim-capture
   (when (dom-available?)
     (testing ":rf.egress/local-raw → the DOM rail captures the verbatim
               password (host opt-in, mirrors the dispatch rail; EP-0015 rf2-3t26eh)"
-      (config/set-egress-profile! :rf.egress/local-raw)
-      (recorder/start-recording! :story.login/flow)
+      (rf.story.config/set-egress-profile! :rf.egress/local-raw)
+      (rf.story.recorder/start-recording! :story.login/flow)
       (let [pw (mk-input! {:type "password" :id "pw"})]
         (set! (.-value pw) "hunter2-secret")
         (.dispatchEvent pw (js/Event. "change" #js {:bubbles true}))
         (is (= "hunter2-secret"
                (:text (first (filterv #(= :dom/type (:kind %))
-                                      (recorder/recorded-entries))))))))))
+                                      (rf.story.recorder/recorded-entries))))))))))
 
 (deftest redacting-a-password-bumps-the-suppressed-counter
   (when (dom-available?)
     (testing "the suppressed-events counter for the recording variant is bumped
               on redaction so the UI's REDACTED hint stays accurate"
-      (config/reset-suppressed-count!)
-      (recorder/start-recording! :story.login/flow)
+      (rf.story.config/reset-suppressed-count!)
+      (rf.story.recorder/start-recording! :story.login/flow)
       (let [pw (mk-input! {:type "password" :id "pw"})]
         (set! (.-value pw) "hunter2-secret")
         (.dispatchEvent pw (js/Event. "change" #js {:bubbles true}))
-        (is (pos? (config/suppressed-count :story.login/flow))
+        (is (pos? (rf.story.config/suppressed-count :story.login/flow))
             "redaction bumped the per-variant suppressed counter")))))

--- a/tools/story/test/re_frame/story/recorder/dom_capture_stop_flush_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/recorder/dom_capture_stop_flush_dom_cljs_test.cljs
@@ -19,14 +19,14 @@
   `:script` lost its final field value.
 
   THE FIX: the capture-time `:t` is stamped at BUFFER time (while recording
-  is live) and the drain appends via `recorder/record-dom-event-buffered!`,
+  is live) and the drain appends via `rf.story.recorder/record-dom-event-buffered!`,
   which bypasses the `:recording?` re-check. So the final keystroke survives
   a post-stop flush."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story.config :as config]
-            [re-frame.story.recorder :as recorder]
-            [re-frame.story.recorder.dom-capture :as dom]
-            [re-frame.story.recorder.play-export :as export]))
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.recorder :as rf.story.recorder]
+            [re-frame.story.recorder.dom-capture :as rf.story.recorder.dom-capture]
+            [re-frame.story.recorder.play-export :as rf.story.recorder.play-export]))
 
 ;; ---- runtime gate --------------------------------------------------------
 
@@ -55,22 +55,22 @@
   (if-not (dom-available?)
     (f)
     (do
-      (recorder/clear!)
-      (dom/set-enabled! true)
-      (dom/set-debounce-ms! 0)
-      (config/set-egress-profile! config/default-egress-profile)
-      (config/reset-suppressed-count!)
+      (rf.story.recorder/clear!)
+      (rf.story.recorder.dom-capture/set-enabled! true)
+      (rf.story.recorder.dom-capture/set-debounce-ms! 0)
+      (rf.story.config/set-egress-profile! rf.story.config/default-egress-profile)
+      (rf.story.config/reset-suppressed-count!)
       (let [_ (mount-root!)]
-        (dom/install! @test-root)
+        (rf.story.recorder.dom-capture/install! @test-root)
         (try
           (f)
           (finally
-            (dom/remove!)
+            (rf.story.recorder.dom-capture/remove!)
             (unmount-root!)
-            (recorder/clear!)
-            (config/set-egress-profile! config/default-egress-profile)
-            (config/reset-suppressed-count!)
-            (dom/set-debounce-ms! 250)))))))
+            (rf.story.recorder/clear!)
+            (rf.story.config/set-egress-profile! rf.story.config/default-egress-profile)
+            (rf.story.config/reset-suppressed-count!)
+            (rf.story.recorder.dom-capture/set-debounce-ms! 250)))))))
 
 (use-fixtures :each reset-all!)
 
@@ -82,10 +82,10 @@
               recording was stopped — the final :dom/type entry is NOT
               dropped when stop-recording! clears :recording? before the
               pending debounce timer (or the remove! drain) flushes"
-      (recorder/start-recording! :story.x/y)
+      (rf.story.recorder/start-recording! :story.x/y)
       ;; Hold the buffer open (no synchronous flush) so the keystroke is
       ;; still pending when we stop.
-      (dom/set-debounce-ms! 5000)
+      (rf.story.recorder.dom-capture/set-debounce-ms! 5000)
       (let [input (.createElement js/document "input")]
         (.setAttribute input "id" "name")
         (.appendChild @test-root input)
@@ -93,13 +93,13 @@
         (.dispatchEvent input (js/Event. "input" #js {:bubbles true}))
         ;; STOP first (flips :recording? false) — the order that previously
         ;; dropped the entry.
-        (recorder/stop-recording!)
-        (is (not (recorder/recording?))
+        (rf.story.recorder/stop-recording!)
+        (is (not (rf.story.recorder/recording?))
             "sanity: the recording is stopped before the drain")
         ;; Now drain — under the bug this was a silent no-op.
-        (dom/flush-type-buffer!)
+        (rf.story.recorder.dom-capture/flush-type-buffer!)
         (let [type-entries (filterv #(= :dom/type (:kind %))
-                                    (recorder/recorded-entries))
+                                    (rf.story.recorder/recorded-entries))
               entry        (first type-entries)]
           (is (= 1 (count type-entries))
               "the final buffered keystroke survived the post-stop flush")
@@ -108,28 +108,28 @@
           (is (number? (:t entry))
               "the entry carries its capture-time :t, stamped at buffer time")
           ;; And the generated play-script carries the final field value.
-          (let [spec       (export/recording->script-body
-                             (recorder/recorded-entries))
+          (let [spec       (rf.story.recorder.play-export/recording->script-body
+                             (rf.story.recorder/recorded-entries))
                 type-steps (filterv #(= :type (first %)) (:script spec))]
             (is (= [[:type (:selector entry) "alice"]] type-steps)
                 "the generated :type step carries the final value")))))))
 
 (deftest remove-after-stop-drains-final-type
   (when (dom-available?)
-    (testing "dom/remove! after stop-recording! still drains the pending type
+    (testing "rf.story.recorder.dom-capture/remove! after stop-recording! still drains the pending type
               buffer (the worst-case teardown ordering — remove! routes
               through flush-type-buffer!)"
-      (recorder/start-recording! :story.x/y)
-      (dom/set-debounce-ms! 5000)
+      (rf.story.recorder/start-recording! :story.x/y)
+      (rf.story.recorder.dom-capture/set-debounce-ms! 5000)
       (let [input (.createElement js/document "input")]
         (.setAttribute input "id" "name")
         (.appendChild @test-root input)
         (set! (.-value input) "bob")
         (.dispatchEvent input (js/Event. "input" #js {:bubbles true}))
-        (recorder/stop-recording!)
-        (dom/remove!)
+        (rf.story.recorder/stop-recording!)
+        (rf.story.recorder.dom-capture/remove!)
         (let [type-entries (filterv #(= :dom/type (:kind %))
-                                    (recorder/recorded-entries))]
+                                    (rf.story.recorder/recorded-entries))]
           (is (= 1 (count type-entries))
               "remove!'s drain captured the final keystroke after stop")
           (is (= "bob" (:text (first type-entries)))))))))
@@ -138,18 +138,18 @@
   (when (dom-available?)
     (testing "the fix does not regress the in-session path — a flush WHILE
               recording still appends exactly one entry with the final value"
-      (recorder/start-recording! :story.x/y)
-      (dom/set-debounce-ms! 5000)
+      (rf.story.recorder/start-recording! :story.x/y)
+      (rf.story.recorder.dom-capture/set-debounce-ms! 5000)
       (let [input (.createElement js/document "input")]
         (.setAttribute input "id" "name")
         (.appendChild @test-root input)
         (doseq [v ["a" "al" "ali"]]
           (set! (.-value input) v)
           (.dispatchEvent input (js/Event. "input" #js {:bubbles true})))
-        (is (recorder/recording?) "still recording at flush time")
-        (dom/flush-type-buffer!)
+        (is (rf.story.recorder/recording?) "still recording at flush time")
+        (rf.story.recorder.dom-capture/flush-type-buffer!)
         (let [type-entries (filterv #(= :dom/type (:kind %))
-                                    (recorder/recorded-entries))]
+                                    (rf.story.recorder/recorded-entries))]
           (is (= 1 (count type-entries))
               "rapid typing still folds to a single in-session entry")
           (is (= "ali" (:text (first type-entries)))))))))
@@ -172,8 +172,8 @@
               stop + start-recording! B within the debounce window, does NOT
               land in B's :entries — start-recording! drains + cancels the
               pending DOM type-buffer (rf2-x76af2.18)"
-      (recorder/start-recording! :story.a/rec)
-      (dom/set-debounce-ms! 5000)          ; hold the buffer open (no sync flush)
+      (rf.story.recorder/start-recording! :story.a/rec)
+      (rf.story.recorder.dom-capture/set-debounce-ms! 5000)          ; hold the buffer open (no sync flush)
       (let [input (.createElement js/document "input")]
         (.setAttribute input "id" "note")
         (.appendChild @test-root input)
@@ -181,18 +181,18 @@
         (.dispatchEvent input (js/Event. "input" #js {:bubbles true}))
         ;; STOP via the non-flushing facade path; the debounce timer T is
         ;; still pending, the buffered "aaa" still held.
-        (recorder/stop-recording!)
+        (rf.story.recorder/stop-recording!)
         ;; A FRESH recording B starts before T fires. This must DRAIN A's
         ;; pending buffer (cancel T + drop the entry), not carry it into B.
-        (recorder/start-recording! :story.b/rec)
-        (is (recorder/recording?) "B is recording")
-        (is (empty? (recorder/recorded-entries)) "B starts with no entries")
+        (rf.story.recorder/start-recording! :story.b/rec)
+        (is (rf.story.recorder/recording?) "B is recording")
+        (is (empty? (rf.story.recorder/recorded-entries)) "B starts with no entries")
         ;; Force any surviving timer to fire. Under the bug A's "aaa" appends
         ;; here into B (append-dom-buffered ignores :recording?); under the
         ;; fix the buffer was cancelled + emptied, so this is a no-op.
-        (dom/flush-type-buffer!)
+        (rf.story.recorder.dom-capture/flush-type-buffer!)
         (let [type-entries (filterv #(= :dom/type (:kind %))
-                                    (recorder/recorded-entries))]
+                                    (rf.story.recorder/recorded-entries))]
           (is (= [] type-entries)
               "A's buffered keystroke did NOT bleed into recording B"))))))
 
@@ -200,20 +200,20 @@
   (when (dom-available?)
     (testing "clear! while a keystroke is buffered cancels the pending flush,
               so a subsequent recording sees no phantom entry (rf2-x76af2.18)"
-      (recorder/start-recording! :story.a/rec)
-      (dom/set-debounce-ms! 5000)
+      (rf.story.recorder/start-recording! :story.a/rec)
+      (rf.story.recorder.dom-capture/set-debounce-ms! 5000)
       (let [input (.createElement js/document "input")]
         (.setAttribute input "id" "note")
         (.appendChild @test-root input)
         (set! (.-value input) "bbb")
         (.dispatchEvent input (js/Event. "input" #js {:bubbles true}))
         ;; Discard the recording mid-type.
-        (recorder/clear!)
+        (rf.story.recorder/clear!)
         ;; Start a fresh recording; the cancelled buffer must not resurface.
-        (recorder/start-recording! :story.c/rec)
-        (dom/flush-type-buffer!)
+        (rf.story.recorder/start-recording! :story.c/rec)
+        (rf.story.recorder.dom-capture/flush-type-buffer!)
         (is (empty? (filterv #(= :dom/type (:kind %))
-                             (recorder/recorded-entries)))
+                             (rf.story.recorder/recorded-entries)))
             "clear! cancelled the pending flush — no phantom entry in C")))))
 
 (deftest stop-into-same-recording-final-keystroke-still-survives
@@ -222,17 +222,17 @@
               stop-recording! does NOT drain the buffer, so a flush firing
               after stop (with NO intervening start/clear) still captures the
               final keystroke into the stopped recording"
-      (recorder/start-recording! :story.x/same)
-      (dom/set-debounce-ms! 5000)
+      (rf.story.recorder/start-recording! :story.x/same)
+      (rf.story.recorder.dom-capture/set-debounce-ms! 5000)
       (let [input (.createElement js/document "input")]
         (.setAttribute input "id" "note")
         (.appendChild @test-root input)
         (set! (.-value input) "keep")
         (.dispatchEvent input (js/Event. "input" #js {:bubbles true}))
-        (recorder/stop-recording!)          ; no start/clear after → buffer intact
-        (dom/flush-type-buffer!)            ; the pending timer's late fire
+        (rf.story.recorder/stop-recording!)          ; no start/clear after → buffer intact
+        (rf.story.recorder.dom-capture/flush-type-buffer!)            ; the pending timer's late fire
         (let [type-entries (filterv #(= :dom/type (:kind %))
-                                    (recorder/recorded-entries))]
+                                    (rf.story.recorder/recorded-entries))]
           (is (= 1 (count type-entries))
               "the final keystroke survived the post-stop flush (rf2-eztym.3)")
           (is (= "keep" (:text (first type-entries)))))))))

--- a/tools/story/test/re_frame/story/recorder/play_export_test.cljc
+++ b/tools/story/test/re_frame/story/recorder/play_export_test.cljc
@@ -11,60 +11,60 @@
     input, name + auto-run? slots, auto-assert with and without a
     seed db, max-auto-assertions cap.
   - Snippet rendering (`render-script-body` / `render-variant-form`)
-    — round-trip cleanly through `runner/parse-spec`."
+    — round-trip cleanly through `rf.story.play.runner/parse-spec`."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [clojure.edn :as edn]
-            [re-frame.story.play.runner             :as runner]
-            [re-frame.story.recorder.play-export    :as export]))
+            [re-frame.story.play.runner             :as rf.story.play.runner]
+            [re-frame.story.recorder.play-export    :as rf.story.recorder.play-export]))
 
 ;; ---- per-event translation -----------------------------------------------
 
 (deftest event-step-dispatch
   (testing "ordinary events become :dispatch steps"
     (is (= [:dispatch [:counter/inc]]
-           (export/event->step [:counter/inc])))
+           (rf.story.recorder.play-export/event->step [:counter/inc])))
     (is (= [:dispatch [:auth/login {:user "x"}]]
-           (export/event->step [:auth/login {:user "x"}])))))
+           (rf.story.recorder.play-export/event->step [:auth/login {:user "x"}])))))
 
 (deftest event-step-assertion-rides-dispatch-sync
   (testing "assertion events (`:rf.assert/*`) translate to :dispatch-sync"
     (is (= [:dispatch-sync [:rf.assert/path-equals [:n] 3]]
-           (export/event->step [:rf.assert/path-equals [:n] 3])))
+           (rf.story.recorder.play-export/event->step [:rf.assert/path-equals [:n] 3])))
     (is (= [:dispatch-sync [:rf.assert/no-warnings]]
-           (export/event->step [:rf.assert/no-warnings])))
+           (rf.story.recorder.play-export/event->step [:rf.assert/no-warnings])))
     (is (= [:dispatch-sync [:rf.assert/sub-equals [:counter] 5]]
-           (export/event->step [:rf.assert/sub-equals [:counter] 5])))))
+           (rf.story.recorder.play-export/event->step [:rf.assert/sub-equals [:counter] 5])))))
 
 (deftest event-step-redacted-drops
   (testing "the [:rf/redacted] placeholder (recorder's canonical 1-tuple) drops out"
-    (is (nil? (export/event->step [:rf/redacted])))))
+    (is (nil? (rf.story.recorder.play-export/event->step [:rf/redacted])))))
 
 (deftest event-step-malformed-yields-nil
   (testing "malformed inputs return nil"
-    (is (nil? (export/event->step nil)))
-    (is (nil? (export/event->step [])))
-    (is (nil? (export/event->step ["not-keyword"])))
-    (is (nil? (export/event->step "not-a-vector")))))
+    (is (nil? (rf.story.recorder.play-export/event->step nil)))
+    (is (nil? (rf.story.recorder.play-export/event->step [])))
+    (is (nil? (rf.story.recorder.play-export/event->step ["not-keyword"])))
+    (is (nil? (rf.story.recorder.play-export/event->step "not-a-vector")))))
 
 ;; ---- rf2-l2cn5d (EP-0017): captured cofx rides the dispatch step ----------
 
 (deftest event-step-carries-captured-cofx
   (testing "a captured flat :rf.cofx map rides onto the step as a 3rd opts map"
     (is (= [:dispatch [:counter/inc] {:rf.cofx {:rf/time-ms 123 :counter/delta 4}}]
-           (export/event->step [:counter/inc] {:rf/time-ms 123 :counter/delta 4}))
+           (rf.story.recorder.play-export/event->step [:counter/inc] {:rf/time-ms 123 :counter/delta 4}))
         "an ordinary event with cofx → [:dispatch evec {:rf.cofx …}]")
     (is (= [:dispatch-sync [:rf.assert/path-equals [:n] 3] {:rf.cofx {:rf/time-ms 9}}]
-           (export/event->step [:rf.assert/path-equals [:n] 3] {:rf/time-ms 9}))
+           (rf.story.recorder.play-export/event->step [:rf.assert/path-equals [:n] 3] {:rf/time-ms 9}))
         "an assertion event with cofx still rides the :dispatch-sync rail"))
   (testing "nil / empty cofx emits the byte-identical 2-element step"
     (is (= [:dispatch [:counter/inc]]
-           (export/event->step [:counter/inc] nil)))
+           (rf.story.recorder.play-export/event->step [:counter/inc] nil)))
     (is (= [:dispatch [:counter/inc]]
-           (export/event->step [:counter/inc] {}))
+           (rf.story.recorder.play-export/event->step [:counter/inc] {}))
         "an empty cofx map is treated as absent — no opts slot")
     (is (= [:dispatch [:counter/inc]]
-           (export/event->step [:counter/inc]))
+           (rf.story.recorder.play-export/event->step [:counter/inc]))
         "the 1-arity is the bare-step path")))
 
 (deftest recording-threads-parallel-cofx-vector
@@ -74,7 +74,7 @@
           cofx   [{:rf/time-ms 100 :counter/delta 4}
                   nil
                   {:rf/time-ms 300}]
-          spec   (export/recording->script-body events {:cofx cofx})]
+          spec   (rf.story.recorder.play-export/recording->script-body events {:cofx cofx})]
       (is (= [[:dispatch [:counter/inc] {:rf.cofx {:rf/time-ms 100 :counter/delta 4}}]
               [:dispatch [:auth/login {:user "x"}]]
               [:dispatch [:counter/dec] {:rf.cofx {:rf/time-ms 300}}]]
@@ -84,11 +84,11 @@
 (deftest recording-without-cofx-is-byte-identical
   (testing "no :cofx opt → the pre-EP-0017 2-element steps (zero ceremony)"
     (let [events [[:counter/inc] [:counter/dec]]]
-      (is (= (export/recording->script-body events {})
-             (export/recording->script-body events {:cofx []}))
+      (is (= (rf.story.recorder.play-export/recording->script-body events {})
+             (rf.story.recorder.play-export/recording->script-body events {:cofx []}))
           "an empty parallel cofx vector is byte-identical to no :cofx opt")
       (is (= [[:dispatch [:counter/inc]] [:dispatch [:counter/dec]]]
-             (:script (export/recording->script-body events {:cofx [nil nil]})))
+             (:script (rf.story.recorder.play-export/recording->script-body events {:cofx [nil nil]})))
           "all-nil cofx members emit bare steps"))))
 
 ;; ---- recording-level translation -----------------------------------------
@@ -96,7 +96,7 @@
 (deftest simple-recording-three-dispatches
   (testing "a three-event recording yields a three-step script"
     (let [events [[:counter/inc] [:counter/inc] [:counter/dec]]
-          spec   (export/recording->script-body events {})]
+          spec   (rf.story.recorder.play-export/recording->script-body events {})]
       (is (= [[:dispatch [:counter/inc]]
               [:dispatch [:counter/inc]]
               [:dispatch [:counter/dec]]]
@@ -109,13 +109,13 @@
 
 (deftest empty-recording-yields-empty-script
   (testing "an empty recording yields a legal empty :script"
-    (let [spec (export/recording->script-body [])]
+    (let [spec (rf.story.recorder.play-export/recording->script-body [])]
       (is (= [] (:script spec)))
       (is (true? (:auto-run? spec))))))
 
 (deftest name-and-auto-run-honoured
   (testing "the :name and :auto-run? opts flow through to the spec"
-    (let [spec (export/recording->script-body
+    (let [spec (rf.story.recorder.play-export/recording->script-body
                  [[:counter/inc]]
                  {:name "happy path" :auto-run? false})]
       (is (= "happy path" (:name spec)))
@@ -123,9 +123,9 @@
 
 (deftest blank-name-omitted
   (testing ":name is omitted when blank or non-string"
-    (is (not (contains? (export/recording->script-body [] {:name ""})
+    (is (not (contains? (rf.story.recorder.play-export/recording->script-body [] {:name ""})
                         :name)))
-    (is (not (contains? (export/recording->script-body [] {:name nil})
+    (is (not (contains? (rf.story.recorder.play-export/recording->script-body [] {:name nil})
                         :name)))))
 
 (deftest mixed-events-translate-with-tags
@@ -134,7 +134,7 @@
                   [:rf.assert/path-equals [:n] 1]
                   [:rf/redacted]
                   [:counter/dec]]
-          spec   (export/recording->script-body events {})]
+          spec   (rf.story.recorder.play-export/recording->script-body events {})]
       (is (= [[:dispatch       [:counter/inc]]
               [:dispatch-sync  [:rf.assert/path-equals [:n] 1]]
               [:dispatch       [:counter/dec]]]
@@ -145,7 +145,7 @@
 
 (deftest auto-assert-from-final-db-no-seed
   (testing "auto-assert with no seed emits one assert-db per top-level key"
-    (let [spec (export/recording->script-body
+    (let [spec (rf.story.recorder.play-export/recording->script-body
                  [[:counter/inc]]
                  {:auto-assert? true
                   :final-db {:n 1 :who "alice"}})
@@ -161,7 +161,7 @@
   (testing "auto-assert with seed emits one :assert-db per CHANGED top-level key"
     (let [seed   {:n 0 :who "alice"}
           final  {:n 1 :who "alice" :extra :added}
-          spec   (export/recording->script-body
+          spec   (rf.story.recorder.play-export/recording->script-body
                    [[:counter/inc]]
                    {:auto-assert? true
                     :seed-db      seed
@@ -175,7 +175,7 @@
 (deftest auto-assert-cap-respected
   (testing "the max-auto-assertions cap limits the trailing block"
     (let [final-db (into {} (map (fn [i] [(keyword (str "k" i)) i])) (range 20))
-          spec     (export/recording->script-body
+          spec     (rf.story.recorder.play-export/recording->script-body
                      []
                      {:auto-assert?        true
                       :final-db            final-db
@@ -186,7 +186,7 @@
 
 (deftest auto-assert-off-default
   (testing "without :auto-assert? true, no assertions trail"
-    (let [spec (export/recording->script-body
+    (let [spec (rf.story.recorder.play-export/recording->script-body
                  [[:counter/inc]]
                  {:final-db {:n 1 :a 2 :b 3}})]
       (is (= [[:dispatch [:counter/inc]]] (:script spec))
@@ -194,7 +194,7 @@
 
 (deftest auto-assert-no-final-db-noop
   (testing ":auto-assert? true but no :final-db → empty assert block"
-    (let [spec (export/recording->script-body
+    (let [spec (rf.story.recorder.play-export/recording->script-body
                  [[:counter/inc]]
                  {:auto-assert? true})]
       (is (= [[:dispatch [:counter/inc]]] (:script spec))))))
@@ -204,22 +204,22 @@
 (deftest changed-top-paths-shape
   (testing "changed-top-paths returns [k] vectors for every changed key"
     (is (= [[:n]]
-           (vec (export/changed-top-paths {:n 0 :who "a"}
+           (vec (rf.story.recorder.play-export/changed-top-paths {:n 0 :who "a"}
                                           {:n 1 :who "a"}))))
     (is (= [[:added]]
-           (vec (export/changed-top-paths {:k 1}
+           (vec (rf.story.recorder.play-export/changed-top-paths {:k 1}
                                           {:k 1 :added :new}))))
-    (is (empty? (export/changed-top-paths {:n 1} {:n 1}))
+    (is (empty? (rf.story.recorder.play-export/changed-top-paths {:n 1} {:n 1}))
         "identical maps → no paths")))
 
 ;; ---- render round-trip ---------------------------------------------------
 
 (deftest render-script-body-round-trips
   (testing "the rendered EDN parses back to the same canonical spec"
-    (let [spec (export/recording->script-body
+    (let [spec (rf.story.recorder.play-export/recording->script-body
                  [[:counter/inc] [:counter/dec]]
                  {:name "round trip" :auto-run? true})
-          rendered (export/render-script-body spec)
+          rendered (rf.story.recorder.play-export/render-script-body spec)
           parsed   (edn/read-string rendered)]
       (is (map? parsed))
       (is (= "round trip" (:name parsed)))
@@ -230,17 +230,17 @@
 
 (deftest render-script-body-empty-script
   (testing "an empty :script renders as []"
-    (let [spec     (export/recording->script-body [] {})
-          rendered (export/render-script-body spec)]
+    (let [spec     (rf.story.recorder.play-export/recording->script-body [] {})
+          rendered (rf.story.recorder.play-export/render-script-body spec)]
       (is (str/includes? rendered ":script    []"))
       (is (str/includes? rendered ":auto-run? true")))))
 
 (deftest render-variant-form-round-trips
   (testing "the rendered (reg-variant ...) form parses back to a callable shape"
-    (let [spec     (export/recording->script-body
+    (let [spec     (rf.story.recorder.play-export/recording->script-body
                      [[:counter/inc]]
                      {:auto-run? false})
-          form-str (export/render-variant-form
+          form-str (rf.story.recorder.play-export/render-variant-form
                      spec {:variant-id :story.x/recorded
                            :extends    :story.x/source})
           parsed   (edn/read-string form-str)]
@@ -259,7 +259,7 @@
 
 (deftest render-variant-form-default-alias-and-id
   (testing "defaults fill in when not supplied"
-    (let [form-str (export/render-variant-form
+    (let [form-str (rf.story.recorder.play-export/render-variant-form
                      {:script [] :auto-run? true} {})]
       (is (str/includes? form-str "story/reg-variant"))
       (is (str/includes? form-str ":story.recorded/play-export")))))
@@ -267,29 +267,29 @@
 ;; ---- runner round-trip ---------------------------------------------------
 
 (deftest exported-script-survives-runner-parse-spec
-  (testing "the exported spec passes runner/parse-spec without further coercion"
+  (testing "the exported spec passes rf.story.play.runner/parse-spec without further coercion"
     (let [events [[:counter/inc]
                   [:rf.assert/path-equals [:n] 1]
                   [:counter/dec]]
-          spec   (export/recording->script-body events {:name "rt"})
-          parsed (runner/parse-spec spec)]
+          spec   (rf.story.recorder.play-export/recording->script-body events {:name "rt"})
+          parsed (rf.story.play.runner/parse-spec spec)]
       (is (= (:script spec) (:script parsed))
           "the runner parses the exported script identically (no normalisation drift)")
       (is (= (:auto-run? spec) (:auto-run? parsed)))
       (is (= (:name spec) (:name parsed)))
-      (is (every? runner/known-step? (:script parsed))
+      (is (every? rf.story.play.runner/known-step? (:script parsed))
           "every emitted step is a known runner step type")
-      (is (every? runner/step-arity-ok? (:script parsed))
+      (is (every? rf.story.play.runner/step-arity-ok? (:script parsed))
           "every emitted step has a valid arity"))))
 
 (deftest exported-script-validates-clean
-  (testing "the exported script passes runner/validate-script (no malformed steps)"
+  (testing "the exported script passes rf.story.play.runner/validate-script (no malformed steps)"
     (let [events [[:counter/inc] [:counter/dec]]
-          spec   (export/recording->script-body
+          spec   (rf.story.recorder.play-export/recording->script-body
                    events
                    {:auto-assert? true
                     :final-db     {:n 1 :who "alice"}})]
-      (is (= [] (runner/validate-script (:script spec)))
+      (is (= [] (rf.story.play.runner/validate-script (:script spec)))
           "no malformed steps"))))
 
 ;; ===========================================================================
@@ -301,13 +301,13 @@
 (deftest entry-step-dispatch
   (testing ":event/dispatch entry of an ordinary event → [:dispatch ev]"
     (is (= [:dispatch [:counter/inc]]
-           (export/entry->step
+           (rf.story.recorder.play-export/entry->step
              {:kind :event/dispatch :event [:counter/inc] :t 0})))))
 
 (deftest entry-step-assertion-rides-dispatch-sync
   (testing ":event/dispatch entry of an assertion event → [:dispatch-sync ev]"
     (is (= [:dispatch-sync [:rf.assert/path-equals [:n] 1]]
-           (export/entry->step
+           (rf.story.recorder.play-export/entry->step
              {:kind :event/dispatch
               :event [:rf.assert/path-equals [:n] 1]
               :t 0})))))
@@ -315,41 +315,41 @@
 (deftest entry-step-dom-click
   (testing ":dom/click entry → [:click selector]"
     (is (= [:click "[data-test=\"submit\"]"]
-           (export/entry->step
+           (rf.story.recorder.play-export/entry->step
              {:kind :dom/click :selector "[data-test=\"submit\"]" :t 250})))))
 
 (deftest entry-step-dom-type
   (testing ":dom/type entry → [:type selector text]"
     (is (= [:type "[id=\"name\"]" "alice"]
-           (export/entry->step
+           (rf.story.recorder.play-export/entry->step
              {:kind :dom/type :selector "[id=\"name\"]" :text "alice" :t 300})))
     (is (= [:type "[id=\"x\"]" ""]
-           (export/entry->step
+           (rf.story.recorder.play-export/entry->step
              {:kind :dom/type :selector "[id=\"x\"]" :t 0}))
         "missing :text defaults to empty string")))
 
 (deftest entry-step-dom-submit-maps-to-click
   (testing ":dom/submit entry → best-effort [:click form-selector]"
     (is (= [:click "[id=\"login-form\"]"]
-           (export/entry->step
+           (rf.story.recorder.play-export/entry->step
              {:kind :dom/submit :selector "[id=\"login-form\"]" :t 0})))))
 
 (deftest entry-step-redacted-dispatch-drops
   (testing ":event/dispatch of a [:rf/redacted] placeholder yields nil"
-    (is (nil? (export/entry->step
+    (is (nil? (rf.story.recorder.play-export/entry->step
                 {:kind :event/dispatch :event [:rf/redacted] :t 0})))))
 
 (deftest entry-step-unknown-kind-yields-nil
   (testing "unknown entry kinds yield nil"
-    (is (nil? (export/entry->step {:kind :unknown :selector "x" :t 0})))
-    (is (nil? (export/entry->step nil)))
-    (is (nil? (export/entry->step {})))))
+    (is (nil? (rf.story.recorder.play-export/entry->step {:kind :unknown :selector "x" :t 0})))
+    (is (nil? (rf.story.recorder.play-export/entry->step nil)))
+    (is (nil? (rf.story.recorder.play-export/entry->step {})))))
 
 (deftest entry-step-missing-selector-yields-nil
   (testing "DOM-entry without a selector yields nil"
-    (is (nil? (export/entry->step {:kind :dom/click :t 0})))
-    (is (nil? (export/entry->step {:kind :dom/type :text "x" :t 0})))
-    (is (nil? (export/entry->step {:kind :dom/submit :t 0})))))
+    (is (nil? (rf.story.recorder.play-export/entry->step {:kind :dom/click :t 0})))
+    (is (nil? (rf.story.recorder.play-export/entry->step {:kind :dom/type :text "x" :t 0})))
+    (is (nil? (rf.story.recorder.play-export/entry->step {:kind :dom/submit :t 0})))))
 
 ;; ---- entries->steps + wait insertion -------------------------------------
 
@@ -358,7 +358,7 @@
     (is (= [[:dispatch [:counter/inc]]
             [:click "[data-test=\"x\"]"]
             [:type "[id=\"name\"]" "alice"]]
-           (export/entries->steps
+           (rf.story.recorder.play-export/entries->steps
              [{:kind :event/dispatch :event [:counter/inc] :t 0}
               {:kind :dom/click :selector "[data-test=\"x\"]" :t 10}
               {:kind :dom/type :selector "[id=\"name\"]" :text "alice" :t 20}])))))
@@ -368,7 +368,7 @@
     (is (= [[:click "[data-test=\"a\"]"]
             [:wait 100]
             [:click "[data-test=\"b\"]"]]
-           (export/entries->steps
+           (rf.story.recorder.play-export/entries->steps
              [{:kind :dom/click :selector "[data-test=\"a\"]" :t 0}
               {:kind :dom/click :selector "[data-test=\"b\"]" :t 100}])))))
 
@@ -376,7 +376,7 @@
   (testing "sub-threshold gaps fold out (no :wait noise)"
     (is (= [[:click "[data-test=\"a\"]"]
             [:click "[data-test=\"b\"]"]]
-           (export/entries->steps
+           (rf.story.recorder.play-export/entries->steps
              [{:kind :dom/click :selector "[data-test=\"a\"]" :t 0}
               {:kind :dom/click :selector "[data-test=\"b\"]" :t 25}])))))
 
@@ -385,7 +385,7 @@
     (is (= [[:click "[data-test=\"a\"]"]
             [:wait 30]
             [:click "[data-test=\"b\"]"]]
-           (export/entries->steps
+           (rf.story.recorder.play-export/entries->steps
              [{:kind :dom/click :selector "[data-test=\"a\"]" :t 0}
               {:kind :dom/click :selector "[data-test=\"b\"]" :t 30}]
              {:wait-threshold-ms 10})))))
@@ -394,7 +394,7 @@
   (testing "an effectively-infinite threshold suppresses every wait"
     (is (= [[:click "[data-test=\"a\"]"]
             [:click "[data-test=\"b\"]"]]
-           (export/entries->steps
+           (rf.story.recorder.play-export/entries->steps
              [{:kind :dom/click :selector "[data-test=\"a\"]" :t 0}
               {:kind :dom/click :selector "[data-test=\"b\"]" :t 5000}]
              {:wait-threshold-ms 999999})))))
@@ -405,7 +405,7 @@
             [:wait 100]
             [:click "[data-test=\"submit\"]"]
             [:type "[id=\"name\"]" "alice"]]
-           (export/entries->steps
+           (rf.story.recorder.play-export/entries->steps
              [{:kind :event/dispatch :event [:counter/inc] :t 0}
               {:kind :dom/click :selector "[data-test=\"submit\"]" :t 100}
               {:kind :dom/type :selector "[id=\"name\"]" :text "alice" :t 120}])))))
@@ -417,7 +417,7 @@
     (is (= [[:dispatch [:counter/inc]]
             [:wait 200]
             [:dispatch [:counter/dec]]]
-           (export/entries->steps
+           (rf.story.recorder.play-export/entries->steps
              [{:kind :event/dispatch :event [:counter/inc]   :t 0}
               {:kind :event/dispatch :event [:rf/redacted]   :t 100}
               {:kind :event/dispatch :event [:counter/dec]   :t 200}])))))
@@ -429,7 +429,7 @@
     (let [entries [{:kind :event/dispatch :event [:counter/inc] :t 0}
                    {:kind :dom/click :selector "[data-test=\"b\"]" :t 200}
                    {:kind :dom/type  :selector "[id=\"x\"]" :text "hi" :t 220}]
-          spec    (export/recording->script-body entries)]
+          spec    (rf.story.recorder.play-export/recording->script-body entries)]
       (is (= [[:dispatch [:counter/inc]]
               [:wait 200]
               [:click "[data-test=\"b\"]"]
@@ -441,7 +441,7 @@
   (testing ":wait-threshold-ms opt threads through recording->script-body"
     (let [entries [{:kind :event/dispatch :event [:counter/inc] :t 0}
                    {:kind :event/dispatch :event [:counter/dec] :t 75}]
-          spec    (export/recording->script-body entries {:wait-threshold-ms 100})]
+          spec    (rf.story.recorder.play-export/recording->script-body entries {:wait-threshold-ms 100})]
       (is (= [[:dispatch [:counter/inc]]
               [:dispatch [:counter/dec]]]
              (:script spec))
@@ -450,7 +450,7 @@
 (deftest legacy-bare-events-still-translate-without-waits
   (testing "callers that still pass bare event-vectors get the old behaviour
             (no :wait steps emitted — all entries stamped :t 0)"
-    (let [spec (export/recording->script-body
+    (let [spec (rf.story.recorder.play-export/recording->script-body
                  [[:counter/inc] [:counter/inc] [:counter/dec]])]
       (is (= [[:dispatch [:counter/inc]]
               [:dispatch [:counter/inc]]
@@ -460,7 +460,7 @@
 (deftest mixed-bare-and-entry-input
   (testing "an input vector mixing bare event vectors and rich entries
             still coerces cleanly"
-    (let [spec (export/recording->script-body
+    (let [spec (rf.story.recorder.play-export/recording->script-body
                  [[:counter/inc]
                   {:kind :dom/click :selector "[data-test=\"b\"]" :t 100}])]
       (is (= [[:dispatch [:counter/inc]]
@@ -469,27 +469,27 @@
              (:script spec))))))
 
 (deftest exported-rich-script-survives-runner-parse-spec
-  (testing "rich-entries-derived script passes runner/parse-spec + validate-script clean"
+  (testing "rich-entries-derived script passes rf.story.play.runner/parse-spec + validate-script clean"
     (let [entries [{:kind :event/dispatch :event [:counter/inc] :t 0}
                    {:kind :dom/click :selector "[data-test=\"b\"]" :t 80}
                    {:kind :dom/type  :selector "[id=\"x\"]" :text "hi" :t 200}]
-          spec    (export/recording->script-body entries {:name "round trip"})
-          parsed  (runner/parse-spec spec)]
+          spec    (rf.story.recorder.play-export/recording->script-body entries {:name "round trip"})
+          parsed  (rf.story.play.runner/parse-spec spec)]
       (is (= (:script spec) (:script parsed))
           "runner parses identically — no normalisation drift")
-      (is (every? runner/known-step? (:script parsed))
+      (is (every? rf.story.play.runner/known-step? (:script parsed))
           "every emitted step is a known runner step")
-      (is (every? runner/step-arity-ok? (:script parsed))
+      (is (every? rf.story.play.runner/step-arity-ok? (:script parsed))
           "every emitted step has a legal arity")
-      (is (= [] (runner/validate-script (:script parsed)))
+      (is (= [] (rf.story.play.runner/validate-script (:script parsed)))
           "no malformed steps"))))
 
 (deftest dom-submit-survives-runner-validation
   (testing "the :dom/submit best-effort translation produces a valid :click step"
     (let [entries [{:kind :dom/submit :selector "[id=\"login-form\"]" :t 0}]
-          spec    (export/recording->script-body entries)]
+          spec    (rf.story.recorder.play-export/recording->script-body entries)]
       (is (= [[:click "[id=\"login-form\"]"]] (:script spec)))
-      (is (= [] (runner/validate-script (:script spec)))))))
+      (is (= [] (rf.story.play.runner/validate-script (:script spec)))))))
 
 ;; ---- round-trip: 4-step recording → export → runner-parse → assert -------
 
@@ -500,8 +500,8 @@
                    {:kind :dom/type  :selector "[id=\"name\"]" :text "alice" :t 200}
                    {:kind :dom/click :selector "[data-test=\"save\"]"  :t 600}
                    {:kind :event/dispatch :event [:counter/inc] :t 1100}]
-          spec    (export/recording->script-body entries {:name "round trip"})
-          parsed  (runner/parse-spec spec)]
+          spec    (rf.story.recorder.play-export/recording->script-body entries {:name "round trip"})
+          parsed  (rf.story.play.runner/parse-spec spec)]
       ;; Translation contract — every event lifts and waits insert.
       (is (= [[:click "[data-test=\"open\"]"]
               [:wait 200]
@@ -513,7 +513,7 @@
              (:script spec))
           "all four entries translate; waits insert on each >50ms gap")
       ;; Runner contract — every emitted step is well-formed.
-      (is (every? runner/known-step? (:script spec)))
-      (is (every? runner/step-arity-ok? (:script spec)))
-      (is (= [] (runner/validate-script (:script spec))))
+      (is (every? rf.story.play.runner/known-step? (:script spec)))
+      (is (every? rf.story.play.runner/step-arity-ok? (:script spec)))
+      (is (= [] (rf.story.play.runner/validate-script (:script spec))))
       (is (= "round trip" (:name parsed))))))

--- a/tools/story/test/re_frame/story/recorder/selector_test.cljc
+++ b/tools/story/test/re_frame/story/recorder/selector_test.cljc
@@ -6,14 +6,14 @@
   - Attribute-value escaping (backslash + double-quote).
   - Nth-of-type fallback geometry."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.recorder.selector :as sel]))
+            [re-frame.story.recorder.selector :as rf.story.recorder.selector]))
 
 ;; ---- priority tiers ------------------------------------------------------
 
 (deftest data-test-wins
   (testing "data-test attribute beats id / aria-label / nth-of-type"
     (is (= "[data-test=\"submit-btn\"]"
-           (sel/pick-selector
+           (rf.story.recorder.selector/pick-selector
              {:tag "button"
               :attrs {"data-test"  "submit-btn"
                       "id"         "btn-1"
@@ -23,7 +23,7 @@
 (deftest id-when-no-data-test
   (testing "id wins when data-test is absent"
     (is (= "[id=\"counter-input\"]"
-           (sel/pick-selector
+           (rf.story.recorder.selector/pick-selector
              {:tag "input"
               :attrs {"id"         "counter-input"
                       "aria-label" "Counter"}
@@ -32,7 +32,7 @@
 (deftest aria-label-when-no-data-test-or-id
   (testing "aria-label wins when data-test and id are absent"
     (is (= "[aria-label=\"Close dialog\"]"
-           (sel/pick-selector
+           (rf.story.recorder.selector/pick-selector
              {:tag "button"
               :attrs {"aria-label" "Close dialog"}
               :index-of-type 1})))))
@@ -40,7 +40,7 @@
 (deftest nth-of-type-fallback
   (testing "nth-of-type fires when no attribute matches"
     (is (= "button:nth-of-type(3)"
-           (sel/pick-selector
+           (rf.story.recorder.selector/pick-selector
              {:tag "BUTTON"
               :attrs {}
               :index-of-type 3})))))
@@ -48,25 +48,25 @@
 (deftest nth-of-type-falls-back-to-star
   (testing "nth-of-type uses * when tag is missing/blank"
     (is (= "*:nth-of-type(2)"
-           (sel/pick-selector
+           (rf.story.recorder.selector/pick-selector
              {:tag nil
               :attrs {}
               :index-of-type 2})))))
 
 (deftest returns-nil-when-nothing-usable
   (testing "no attributes + no index → nil"
-    (is (nil? (sel/pick-selector {:tag "div" :attrs {} :index-of-type nil})))
-    (is (nil? (sel/pick-selector {})))))
+    (is (nil? (rf.story.recorder.selector/pick-selector {:tag "div" :attrs {} :index-of-type nil})))
+    (is (nil? (rf.story.recorder.selector/pick-selector {})))))
 
 (deftest blank-attribute-values-are-ignored
   (testing "blank / whitespace attribute values fall through to next tier"
     (is (= "[id=\"x\"]"
-           (sel/pick-selector
+           (rf.story.recorder.selector/pick-selector
              {:tag "input"
               :attrs {"data-test" "   "  ; blank, skip
                       "id"        "x"}})))
     (is (= "*:nth-of-type(1)"
-           (sel/pick-selector
+           (rf.story.recorder.selector/pick-selector
              {:tag nil
               :attrs {"data-test" ""
                       "id"        nil
@@ -78,14 +78,14 @@
 (deftest escapes-double-quotes
   (testing "double-quote inside value is escaped"
     (is (= "[id=\"he said \\\"hi\\\"\"]"
-           (sel/pick-selector
+           (rf.story.recorder.selector/pick-selector
              {:tag "div"
               :attrs {"id" "he said \"hi\""}})))))
 
 (deftest escapes-backslashes
   (testing "backslash inside value is escaped"
     (is (= "[id=\"a\\\\b\"]"
-           (sel/pick-selector
+           (rf.story.recorder.selector/pick-selector
              {:tag "div"
               :attrs {"id" "a\\b"}})))))
 
@@ -94,4 +94,4 @@
 (deftest priority-list-is-data-test-id-aria-label
   (testing "the priority list order matches the documented contract"
     (is (= ["data-test" "id" "aria-label"]
-           (mapv first sel/attribute-priority)))))
+           (mapv first rf.story.recorder.selector/attribute-priority)))))

--- a/tools/story/test/re_frame/story/render_test.cljc
+++ b/tools/story/test/re_frame/story/render_test.cljc
@@ -13,27 +13,27 @@
   no-host `:cannot-run` refusal are both pinned."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [malli.core :as m]
-            [re-frame.story.fingerprint :as fingerprint]
-            [re-frame.story.late-bind :as late-bind]
-            [re-frame.story.plan :as plan]
-            [re-frame.story.render :as render]))
+            [re-frame.story.fingerprint :as rf.story.fingerprint]
+            [re-frame.story.late-bind :as rf.story.late-bind]
+            [re-frame.story.plan :as rf.story.plan]
+            [re-frame.story.render :as rf.story.render]))
 
 ;; ---- fixtures ------------------------------------------------------------
 ;;
 ;; The host-render hook is a process-global late-bind slot shared with the
 ;; canonical-vocabulary shims (`:stub-observed-fx-ids`, `:drop-assertion-
-;; accumulators`). We MUST NOT `late-bind/clear!` (that wipes those shims +
+;; accumulators`). We MUST NOT `rf.story.late-bind/clear!` (that wipes those shims +
 ;; breaks every sibling test ns). Instead we snapshot the hooks map before
 ;; each test (so a stray `:render-host` from a prior test is gone) and
 ;; restore it after — surgical, never global.
 
 (use-fixtures :each
   (fn [t]
-    (let [snapshot @late-bind/hooks]
+    (let [snapshot @rf.story.late-bind/hooks]
       ;; Drop only the render-host slot so the no-host :cannot-run tests
       ;; start clean; leave every canonical shim in place.
-      (swap! late-bind/hooks dissoc :render-host)
-      (try (t) (finally (reset! late-bind/hooks snapshot))))))
+      (swap! rf.story.late-bind/hooks dissoc :render-host)
+      (try (t) (finally (reset! rf.story.late-bind/hooks snapshot))))))
 
 ;; ---- helpers -------------------------------------------------------------
 
@@ -50,7 +50,7 @@
   ([target lookup] (prepare target lookup nil))
   ([target lookup view-lookup] (prepare target lookup view-lookup nil))
   ([target lookup view-lookup extra]
-   (render/prepare-render
+   (rf.story.render/prepare-render
      target
      (cond-> {:lookup lookup}
        (some? view-lookup) (assoc :view-lookup view-lookup)
@@ -71,7 +71,7 @@
                 :substrates  #{:reagent :uix}
                 :viewport    :viewport/mobile
                 :background  :background/dark}
-          p    (plan/variant-plan :story.button/primary {:lookup {:story.button/primary body}})
+          p    (rf.story.plan/variant-plan :story.button/primary {:lookup {:story.button/primary body}})
           w    (:world p)]
       (is (= :view.button/primary (:component w)))
       (is (= {:label {:control :text}} (:argtypes w)))
@@ -159,7 +159,7 @@
     ;; The plan is valid (:label present); a control override nils it out,
     ;; so the POST-override effective args drop the required key.
     (let [body {:component :view.button/primary :args {:label "Go"}}
-          r    (render/prepare-render
+          r    (rf.story.render/prepare-render
                  :story.button/primary
                  {:lookup      {:story.button/primary body}
                   :view-lookup {:view.button/primary button-view-meta}
@@ -175,7 +175,7 @@
 (deftest valid-effective-args-prepare-with-ok-validation
   (testing "valid post-override args carry an :ok validation outcome"
     (let [body {:component :view.button/primary :args {:label "Go"}}
-          r    (render/prepare-render
+          r    (rf.story.render/prepare-render
                  :story.button/primary
                  {:lookup      {:story.button/primary body}
                   :view-lookup {:view.button/primary button-view-meta}
@@ -192,10 +192,10 @@
   (testing "with a host hook installed, render-variant returns :rendered +
             the documented slots, and the host saw the prepared render inputs"
     (let [seen (atom nil)]
-      (render/install-render-host!
+      (rf.story.render/install-render-host!
         (fn [inputs] (reset! seen inputs) [:fake-rendered (:view inputs)]))
       (let [body {:component :view.button/primary :args {:label "Go"}}
-            r    (render/render-variant
+            r    (rf.story.render/render-variant
                    :story.button/primary
                    {:lookup {:story.button/primary body}})]
         (is (= :rendered (:status r)))
@@ -211,7 +211,7 @@
   (testing "render-variant prepares world + renders the view; it NEVER
             dispatches the :script or evaluates terminal :expect"
     (let [dispatched (atom [])]
-      (render/install-render-host!
+      (rf.story.render/install-render-host!
         (fn [inputs]
           ;; A correct host renders the view; it must not be handed (and
           ;; must not run) the plan's :script / :expect.
@@ -221,7 +221,7 @@
                   :args       {:label "Go"}
                   :script     [[:dispatch [:should/not-run]]]
                   :assertions [[:rf.assert/path-equals [:x] 1]]}
-            r    (render/render-variant
+            r    (rf.story.render/render-variant
                    :story.button/primary
                    {:lookup {:story.button/primary body}})]
         (is (= :rendered (:status r)))
@@ -236,7 +236,7 @@
   (testing "without a host render hook (the bare JVM), render-variant
             returns :cannot-run — never a silent empty render"
     (let [body {:component :view.button/primary :args {:label "Go"}}
-          r    (render/render-variant
+          r    (rf.story.render/render-variant
                  :story.button/primary
                  {:lookup {:story.button/primary body}})]
       (is (= :cannot-run (:status r)))
@@ -250,9 +250,9 @@
 (deftest render-variant-invalid-args-skips-host
   (testing "an :invalid-args result is returned BEFORE the host hook runs"
     (let [called (atom false)]
-      (render/install-render-host! (fn [_] (reset! called true) [:rendered]))
+      (rf.story.render/install-render-host! (fn [_] (reset! called true) [:rendered]))
       (let [body {:component :view.button/primary :args {:label "Go"}}
-            r    (render/render-variant
+            r    (rf.story.render/render-variant
                    :story.button/primary
                    {:lookup      {:story.button/primary body}
                     :view-lookup {:view.button/primary button-view-meta}
@@ -266,10 +266,10 @@
 
 (deftest render-variant-host-throw-is-error
   (testing "a throw from the host render fn is projected to :error"
-    (render/install-render-host!
+    (rf.story.render/install-render-host!
       (fn [_] (throw (ex-info "boom" {:rf.error/id :test/boom}))))
     (let [body {:component :view.button/primary :args {:label "Go"}}
-          r    (render/render-variant
+          r    (rf.story.render/render-variant
                  :story.button/primary
                  {:lookup {:story.button/primary body}})]
       (is (= :error (:status r)))
@@ -282,10 +282,10 @@
   ;; Pre-fix these slots are absent (this test fails); post-fix they ride.
   (testing "a host-render throw projects to :error WITH the prepared plan
             context (spec/017 §Args — :plan/:plan-hash/:effective-args)"
-    (render/install-render-host!
+    (rf.story.render/install-render-host!
       (fn [_] (throw (ex-info "boom" {:rf.error/id :test/boom}))))
     (let [body {:component :view.button/primary :args {:label "Go"}}
-          r    (render/render-variant
+          r    (rf.story.render/render-variant
                  :story.button/primary
                  {:lookup {:story.button/primary body}})]
       (is (= :error (:status r)))
@@ -294,20 +294,20 @@
       (is (string? (:plan-hash r)))
       (is (map? (:plan r)))
       (testing "the threaded :plan-hash matches the prepared plan's hash"
-        (let [prep (render/prepare-render
+        (let [prep (rf.story.render/prepare-render
                      :story.button/primary
                      {:lookup {:story.button/primary body}})]
           (is (= (:plan-hash prep) (:plan-hash r))))))))
 
 (deftest render-variant-unknown-variant-is-error
   (testing "an unknown keyword target throws in the compiler → :error"
-    (let [r (render/render-variant :story.nope/missing {:lookup {}})]
+    (let [r (rf.story.render/render-variant :story.nope/missing {:lookup {}})]
       (is (= :error (:status r)))
       (is (= :rf.error/story-unknown-variant
              (get-in r [:error :data :rf.error/id])))
       (testing "plan-CONSTRUCTION throw carries no plan slots (none prepared)"
         ;; The frame-free shape (spec/017): plan construction threw before a
-        ;; plan/effective-args existed, so only :frame + :error ride.
+        ;; rf.story.plan/effective-args existed, so only :frame + :error ride.
         (is (not (contains? r :plan)))
         (is (not (contains? r :plan-hash)))
         (is (not (contains? r :effective-args)))))))
@@ -320,8 +320,8 @@
 (deftest render-variant-accepts-inline-plan-map
   (testing "a map target is an inline plan — rendered the same as a
             registered keyword (no registration needed)"
-    (render/install-render-host! (fn [inputs] [:rendered (:view inputs)]))
-    (let [r (render/render-variant
+    (rf.story.render/install-render-host! (fn [inputs] [:rendered (:view inputs)]))
+    (let [r (rf.story.render/render-variant
               {:variant/id :story.inline/v
                :component  :view.button/primary
                :args       {:label "Inline"}})]
@@ -336,7 +336,7 @@
 ;; ===========================================================================
 
 (deftest render-variant-plan-hash-matches-the-runner-plan-hash
-  (testing "render-variant's :plan-hash == fingerprint/plan-hash over the
+  (testing "render-variant's :plan-hash == rf.story.fingerprint/plan-hash over the
             normalized plan a runner consumes (behaviour-relevant inputs match)"
     (let [body {:component :view.button/primary
                 :args      {:label "Go"}
@@ -344,8 +344,8 @@
                 :script    [[:dispatch [:counter/inc]]]}
           lk   {:story.button/primary body}
           ;; the plan the RUNNER would compile + hash
-          runner-plan (plan/variant-plan :story.button/primary {:lookup lk})
-          runner-hash (fingerprint/plan-hash runner-plan)
+          runner-plan (rf.story.plan/variant-plan :story.button/primary {:lookup lk})
+          runner-hash (rf.story.fingerprint/plan-hash runner-plan)
           ;; the plan-hash render-variant reports (no control overrides →
           ;; the effective args match the runner's resolved args)
           render-prep (prepare :story.button/primary lk)]
@@ -384,12 +384,12 @@
 (deftest sub-overrides-reflect-control-overrides
   (testing "a sub-override value driven by an [:arg key] re-resolves against
             the POST-control effective args (a control drives the design state)"
-    (render/install-render-host! (fn [inputs] inputs))
+    (rf.story.render/install-render-host! (fn [inputs] inputs))
     (let [body {:component     :view.login/form
                 :args          {:message "Invalid password"}
                 :sub-overrides {[:login/state] :error
                                 [:login/error] [:arg :message]}}
-          r    (render/render-variant
+          r    (rf.story.render/render-variant
                  :story.login/error
                  {:lookup {:story.login/error body}
                   :control-overrides {:message "Account locked"}})]

--- a/tools/story/test/re_frame/story/requirements_test.cljc
+++ b/tools/story/test/re_frame/story/requirements_test.cljc
@@ -8,9 +8,9 @@
   `clojure -M:test` with no host: capability sets in, selection / refusal /
   validation maps out."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.requirements :as req]
-            [re-frame.story.play.evidence :as evidence]
-            [re-frame.story.plan :as plan]))
+            [re-frame.story.requirements :as rf.story.requirements]
+            [re-frame.story.play.evidence :as rf.story.play.evidence]
+            [re-frame.story.plan :as rf.story.plan]))
 
 ;; ===========================================================================
 ;; CAPABILITY LADDER — concrete-runner token sets are a superset chain
@@ -19,35 +19,35 @@
 (deftest concrete-runner-token-ladder
   (testing "the cost-ordered runners form a superset chain for ordered tokens"
     (is (= [:headless :hiccup :cljs-reactive :dom :browser]
-           (mapv :runner req/concrete-runners))
+           (mapv :runner rf.story.requirements/concrete-runners))
         "cheapest → richest; :cljs-reactive sits between :hiccup and :dom (rf2-5x1wt.30)")
     ;; headless ⊂ hiccup ⊂ cljs-reactive ⊂ dom ⊂ browser
-    (is (every? (req/runner-provides :hiccup)        (req/runner-provides :headless)))
-    (is (every? (req/runner-provides :cljs-reactive) (req/runner-provides :hiccup)))
-    (is (every? (req/runner-provides :dom)           (req/runner-provides :cljs-reactive)))
-    (is (every? (req/runner-provides :browser)       (req/runner-provides :dom)))
+    (is (every? (rf.story.requirements/runner-provides :hiccup)        (rf.story.requirements/runner-provides :headless)))
+    (is (every? (rf.story.requirements/runner-provides :cljs-reactive) (rf.story.requirements/runner-provides :hiccup)))
+    (is (every? (rf.story.requirements/runner-provides :dom)           (rf.story.requirements/runner-provides :cljs-reactive)))
+    (is (every? (rf.story.requirements/runner-provides :browser)       (rf.story.requirements/runner-provides :dom)))
     ;; each rung adds its distinguishing token(s)
-    (is (contains? (req/runner-provides :hiccup)        :hiccup-structure))
-    (is (contains? (req/runner-provides :cljs-reactive) :reactive-counts))
-    (is (contains? (req/runner-provides :dom)           :dom))
-    (is (contains? (req/runner-provides :browser)       :pixels))
-    (is (contains? (req/runner-provides :browser)       :a11y-engine)))
+    (is (contains? (rf.story.requirements/runner-provides :hiccup)        :hiccup-structure))
+    (is (contains? (rf.story.requirements/runner-provides :cljs-reactive) :reactive-counts))
+    (is (contains? (rf.story.requirements/runner-provides :dom)           :dom))
+    (is (contains? (rf.story.requirements/runner-provides :browser)       :pixels))
+    (is (contains? (rf.story.requirements/runner-provides :browser)       :a11y-engine)))
 
   (testing ":reactive-counts is advertised by :cljs-reactive (and the richer rungs) — rf2-5x1wt.30"
-    (is (= :reactive-counts req/reactive-counts-token))
-    (is (not (contains? (req/runner-provides :headless) :reactive-counts)))
-    (is (not (contains? (req/runner-provides :hiccup)   :reactive-counts))
+    (is (= :reactive-counts rf.story.requirements/reactive-counts-token))
+    (is (not (contains? (rf.story.requirements/runner-provides :headless) :reactive-counts)))
+    (is (not (contains? (rf.story.requirements/runner-provides :hiccup)   :reactive-counts))
         ":hiccup renders to string but does not flush reactions")
-    (is (contains? (req/runner-provides :cljs-reactive) :reactive-counts))
-    (is (contains? (req/runner-provides :dom)           :reactive-counts)
+    (is (contains? (rf.story.requirements/runner-provides :cljs-reactive) :reactive-counts))
+    (is (contains? (rf.story.requirements/runner-provides :dom)           :reactive-counts)
         "a :dom runner flushes reactions too")
-    (is (contains? (req/runner-provides :browser)       :reactive-counts)))
+    (is (contains? (rf.story.requirements/runner-provides :browser)       :reactive-counts)))
 
   (testing "cost rank is cheapest-first; :cljs-reactive ranks between :hiccup and :dom"
-    (is (< (req/runner-cost :headless)      (req/runner-cost :hiccup)))
-    (is (< (req/runner-cost :hiccup)        (req/runner-cost :cljs-reactive)))
-    (is (< (req/runner-cost :cljs-reactive) (req/runner-cost :dom)))
-    (is (< (req/runner-cost :dom)           (req/runner-cost :browser)))))
+    (is (< (rf.story.requirements/runner-cost :headless)      (rf.story.requirements/runner-cost :hiccup)))
+    (is (< (rf.story.requirements/runner-cost :hiccup)        (rf.story.requirements/runner-cost :cljs-reactive)))
+    (is (< (rf.story.requirements/runner-cost :cljs-reactive) (rf.story.requirements/runner-cost :dom)))
+    (is (< (rf.story.requirements/runner-cost :dom)           (rf.story.requirements/runner-cost :browser)))))
 
 ;; ===========================================================================
 ;; REQUIREMENT INFERENCE — per-step and per-assertion tokens
@@ -55,9 +55,9 @@
 
 (deftest app-db-assertion-requires-headless
   (testing "an app-db assertion is satisfied by :headless (requires no richer tier)"
-    (let [req-tokens (req/assertion-tokens [:rf.assert/path-equals [:n] 5])]
+    (let [req-tokens (rf.story.requirements/assertion-tokens [:rf.assert/path-equals [:n] 5])]
       (is (= #{:app-db} req-tokens))
-      (is (= :headless (req/cheapest-runner req-tokens))
+      (is (= :headless (rf.story.requirements/cheapest-runner req-tokens))
           "cheapest runner proving app-db is :headless"))))
 
 (deftest hiccup-assertion-requires-hiccup
@@ -66,33 +66,33 @@
     ;; A11y *structural* check is the spec's hiccup-tier example; visual is
     ;; browser. We model a structural-a11y requirement explicitly.
     (let [hiccup-req #{:hiccup-structure}]
-      (is (= :hiccup (req/cheapest-runner hiccup-req))
+      (is (= :hiccup (rf.story.requirements/cheapest-runner hiccup-req))
           "cheapest runner proving hiccup structure is :hiccup")
-      (is (not (req/runner-satisfies? (req/runner-provides :headless) hiccup-req))
+      (is (not (rf.story.requirements/runner-satisfies? (rf.story.requirements/runner-provides :headless) hiccup-req))
           ":headless cannot prove hiccup structure"))))
 
 (deftest browser-tier-assertion-tokens
   (testing "the browser-tier oracle assertions declare their capability tokens (rf2-5x1wt.28)"
     ;; visual snapshot + axe-a11y are browser-only
-    (is (= #{:pixels}      (req/assertion-tokens [:rf.assert/visual-snapshot])))
-    (is (= #{:a11y-engine} (req/assertion-tokens [:rf.assert/a11y])))
-    (is (= :browser (req/cheapest-runner #{:pixels})))
-    (is (= :browser (req/cheapest-runner #{:a11y-engine})))
+    (is (= #{:pixels}      (rf.story.requirements/assertion-tokens [:rf.assert/visual-snapshot])))
+    (is (= #{:a11y-engine} (rf.story.requirements/assertion-tokens [:rf.assert/a11y])))
+    (is (= :browser (rf.story.requirements/cheapest-runner #{:pixels})))
+    (is (= :browser (rf.story.requirements/cheapest-runner #{:a11y-engine})))
     ;; structural a11y is the :hiccup rung — the NET-NEW id (rf2-5x1wt.28)
-    (is (= #{:hiccup-structure} (req/assertion-tokens [:rf.assert/a11y-structural])))
-    (is (= :hiccup (req/cheapest-runner #{:hiccup-structure}))
+    (is (= #{:hiccup-structure} (rf.story.requirements/assertion-tokens [:rf.assert/a11y-structural])))
+    (is (= :hiccup (rf.story.requirements/cheapest-runner #{:hiccup-structure}))
         "structural a11y rides :hiccup, NOT :browser")
     ;; headless refuses the browser-only pair; the :hiccup runner proves
     ;; structural a11y but headless does not.
-    (is (not (req/runner-satisfies? (req/runner-provides :headless) #{:pixels})))
-    (is (not (req/runner-satisfies? (req/runner-provides :headless) #{:a11y-engine})))
-    (is (not (req/runner-satisfies? (req/runner-provides :headless) #{:hiccup-structure})))
-    (is (req/runner-satisfies? (req/runner-provides :hiccup)  #{:hiccup-structure}))
-    (is (req/runner-satisfies? (req/runner-provides :browser) #{:pixels :a11y-engine}))))
+    (is (not (rf.story.requirements/runner-satisfies? (rf.story.requirements/runner-provides :headless) #{:pixels})))
+    (is (not (rf.story.requirements/runner-satisfies? (rf.story.requirements/runner-provides :headless) #{:a11y-engine})))
+    (is (not (rf.story.requirements/runner-satisfies? (rf.story.requirements/runner-provides :headless) #{:hiccup-structure})))
+    (is (rf.story.requirements/runner-satisfies? (rf.story.requirements/runner-provides :hiccup)  #{:hiccup-structure}))
+    (is (rf.story.requirements/runner-satisfies? (rf.story.requirements/runner-provides :browser) #{:pixels :a11y-engine}))))
 
 (deftest headless-cannot-run-browser-tier-assertions
   (testing "fixed :runner :headless reports :cannot-run for browser-tier assertions"
-    (let [unmet (req/unmet-assertions
+    (let [unmet (rf.story.requirements/unmet-assertions
                   :headless
                   [[:rf.assert/visual-snapshot]
                    [:rf.assert/a11y]
@@ -106,52 +106,52 @@
              (set (map :unit unmet)))))
     ;; under :auto, the browser-only pair escalates to :browser; structural
     ;; alone escalates only to :hiccup.
-    (let [auto (req/normalize-run-opts {:runner :auto})]
-      (is (= :browser (:runner (req/select-runner #{:pixels :a11y-engine} auto))))
-      (is (= :hiccup  (:runner (req/select-runner #{:hiccup-structure} auto)))))))
+    (let [auto (rf.story.requirements/normalize-run-opts {:runner :auto})]
+      (is (= :browser (:runner (rf.story.requirements/select-runner #{:pixels :a11y-engine} auto))))
+      (is (= :hiccup  (:runner (rf.story.requirements/select-runner #{:hiccup-structure} auto)))))))
 
 (deftest dom-step-requires-dom-or-browser
   (testing "a DOM step requires :dom (or richer :browser)"
-    (is (= #{:dom} (req/step-tokens [:click "[data-test=go]"])))
-    (is (= #{:dom} (req/step-tokens [:type "[data-test=in]" "hi"])))
-    (is (= #{:dom} (req/step-tokens [:focus "[data-test=in]"])))
-    (is (= :dom (req/cheapest-runner #{:dom})))
-    (is (req/runner-satisfies? (req/runner-provides :dom)     #{:dom}))
-    (is (req/runner-satisfies? (req/runner-provides :browser) #{:dom}))
-    (is (not (req/runner-satisfies? (req/runner-provides :headless) #{:dom})))
-    (is (not (req/runner-satisfies? (req/runner-provides :hiccup)   #{:dom})))))
+    (is (= #{:dom} (rf.story.requirements/step-tokens [:click "[data-test=go]"])))
+    (is (= #{:dom} (rf.story.requirements/step-tokens [:type "[data-test=in]" "hi"])))
+    (is (= #{:dom} (rf.story.requirements/step-tokens [:focus "[data-test=in]"])))
+    (is (= :dom (rf.story.requirements/cheapest-runner #{:dom})))
+    (is (rf.story.requirements/runner-satisfies? (rf.story.requirements/runner-provides :dom)     #{:dom}))
+    (is (rf.story.requirements/runner-satisfies? (rf.story.requirements/runner-provides :browser) #{:dom}))
+    (is (not (rf.story.requirements/runner-satisfies? (rf.story.requirements/runner-provides :headless) #{:dom})))
+    (is (not (rf.story.requirements/runner-satisfies? (rf.story.requirements/runner-provides :hiccup)   #{:dom})))))
 
 (deftest dispatch-step-requires-only-app-db
   (testing "a plain dispatch step needs only the headless floor"
-    (is (= #{:app-db} (req/step-tokens [:dispatch [:counter/inc]])))
-    (is (= #{:app-db} (req/step-tokens [:dispatch-sync [:counter/dec]])))
-    (is (= #{} (req/step-tokens [:wait 50])))
-    (is (= #{} (req/step-tokens [:wait-until [:queue-empty?]])))))
+    (is (= #{:app-db} (rf.story.requirements/step-tokens [:dispatch [:counter/inc]])))
+    (is (= #{:app-db} (rf.story.requirements/step-tokens [:dispatch-sync [:counter/dec]])))
+    (is (= #{} (rf.story.requirements/step-tokens [:wait 50])))
+    (is (= #{} (rf.story.requirements/step-tokens [:wait-until [:queue-empty?]])))))
 
 (deftest in-script-assert-folds-wrapped-atom-tokens
   (testing "[:assert atom] checkpoint inherits the wrapped assertion's tokens"
     (is (= #{:app-db}
-           (req/step-tokens [:assert [:rf.assert/path-equals [:n] 1]])))
-    (is (contains? (req/step-tokens [:assert [:rf.assert/visual-snapshot]])
+           (rf.story.requirements/step-tokens [:assert [:rf.assert/path-equals [:n] 1]])))
+    (is (contains? (rf.story.requirements/step-tokens [:assert [:rf.assert/visual-snapshot]])
                    :pixels)
         "a [:assert visual-snapshot] checkpoint requires :pixels")))
 
 (deftest reactive-count-assertions-run-under-cljs-reactive
   (testing "reactive-count assertions require :reactive-counts — proven by :cljs-reactive (rf2-5x1wt.30)"
-    (is (= #{:reactive-counts} (req/assertion-tokens [:rf.assert/caused])))
+    (is (= #{:reactive-counts} (rf.story.requirements/assertion-tokens [:rf.assert/caused])))
     (is (= #{:reactive-counts}
-           (req/assertion-tokens [:rf.assert/no-cascade-rerender])))
+           (rf.story.requirements/assertion-tokens [:rf.assert/no-cascade-rerender])))
     ;; :cljs-reactive is now the cheapest runner that satisfies it (the
     ;; projection over the :rf.sub/run / :rf.view/rendered rows).
-    (is (= :cljs-reactive (req/cheapest-runner #{:reactive-counts})))
-    (let [sel (req/select-runner #{:reactive-counts} {:mode :auto})]
+    (is (= :cljs-reactive (rf.story.requirements/cheapest-runner #{:reactive-counts})))
+    (let [sel (rf.story.requirements/select-runner #{:reactive-counts} {:mode :auto})]
       (is (= :ok (:status sel)))
       (is (= :cljs-reactive (:runner sel)))
       (is (empty? (:unmet sel))))
     ;; under :headless / :hiccup the reactive-count assertions still refuse.
-    (is (not (req/runner-satisfies? (req/runner-provides :headless) #{:reactive-counts})))
-    (is (not (req/runner-satisfies? (req/runner-provides :hiccup)   #{:reactive-counts})))
-    (let [unmet (req/unmet-assertions :headless [[:rf.assert/caused]
+    (is (not (rf.story.requirements/runner-satisfies? (rf.story.requirements/runner-provides :headless) #{:reactive-counts})))
+    (is (not (rf.story.requirements/runner-satisfies? (rf.story.requirements/runner-provides :hiccup)   #{:reactive-counts})))
+    (let [unmet (rf.story.requirements/unmet-assertions :headless [[:rf.assert/caused]
                                                  [:rf.assert/no-cascade-rerender]])]
       (is (= 2 (count unmet)))
       (is (every? #(= :cannot-run (:status %)) unmet))
@@ -160,15 +160,15 @@
 (deftest required-tokens-unions-the-plan
   (testing "required-tokens unions setup + script + assertion tokens"
     (is (= #{:app-db}
-           (req/required-tokens [[:dispatch [:a]]]
+           (rf.story.requirements/required-tokens [[:dispatch [:a]]]
                                 [[:dispatch [:b]]]
                                 [[:rf.assert/path-equals [:n] 1]])))
     (is (= #{:app-db :dom}
-           (req/required-tokens [[:dispatch [:a]]]
+           (rf.story.requirements/required-tokens [[:dispatch [:a]]]
                                 [[:click "[x]"]]
                                 [[:rf.assert/path-equals [:n] 1]])))
     (is (= #{:app-db :pixels}
-           (req/required-tokens []
+           (rf.story.requirements/required-tokens []
                                 [[:dispatch [:a]]]
                                 [[:rf.assert/visual-snapshot]])))))
 
@@ -178,15 +178,15 @@
 
 (deftest fixed-headless-cannot-run-dom-assertions
   (testing "fixed :runner :headless reports :cannot-run for DOM-only assertions"
-    (let [opts     (req/normalize-run-opts {:runner :headless})
-          sel      (req/select-runner #{:app-db :dom} opts)]
+    (let [opts     (rf.story.requirements/normalize-run-opts {:runner :headless})
+          sel      (rf.story.requirements/select-runner #{:app-db :dom} opts)]
       (is (= :ok (:status sel)))
       (is (= :headless (:runner sel)))
       (is (= :fixed (:policy sel)))
       ;; :app-db is met; :dom is unmet — the per-requirement gap.
       (is (= #{:dom} (:unmet sel)))
       ;; The unmet assertion is attributed via a refusal.
-      (let [unmet (req/unmet-assertions :headless
+      (let [unmet (rf.story.requirements/unmet-assertions :headless
                                         [[:rf.assert/dom-visible "[x]"]
                                          [:rf.assert/path-equals [:n] 1]])]
         (is (= 1 (count unmet)) "only the DOM assertion refuses")
@@ -197,20 +197,20 @@
 (deftest auto-chooses-cheapest-satisfying-runner
   (testing ":runner :auto / :escalate true chooses the cheapest qualifying runner"
     ;; app-db + dom → cheapest is :dom (hiccup is insufficient).
-    (let [auto (req/normalize-run-opts {:runner :auto})
-          esc  (req/normalize-run-opts {:escalate true})]
+    (let [auto (rf.story.requirements/normalize-run-opts {:runner :auto})
+          esc  (rf.story.requirements/normalize-run-opts {:escalate true})]
       (is (= :auto (:mode auto)))
       (is (= :auto (:mode esc)) ":escalate true is a synonym for :runner :auto")
-      (let [sel (req/select-runner #{:app-db :dom} auto)]
+      (let [sel (rf.story.requirements/select-runner #{:app-db :dom} auto)]
         (is (= :ok (:status sel)))
         (is (= :dom (:runner sel)))
         (is (empty? (:unmet sel)) "auto picks a runner that satisfies all"))
       ;; pure app-db → cheapest is :headless
-      (is (= :headless (:runner (req/select-runner #{:app-db} auto))))
+      (is (= :headless (:runner (rf.story.requirements/select-runner #{:app-db} auto))))
       ;; hiccup structure → cheapest is :hiccup
-      (is (= :hiccup (:runner (req/select-runner #{:hiccup-structure} auto))))
+      (is (= :hiccup (:runner (rf.story.requirements/select-runner #{:hiccup-structure} auto))))
       ;; pixels → cheapest is :browser
-      (is (= :browser (:runner (req/select-runner #{:pixels} auto)))))))
+      (is (= :browser (:runner (rf.story.requirements/select-runner #{:pixels} auto)))))))
 
 (deftest auto-refuses-when-no-runner-qualifies
   (testing "auto returns :cannot-run when no concrete runner can satisfy"
@@ -218,8 +218,8 @@
     ;; a requirement on an unknown token can never be satisfied — the
     ;; fail-closed set-difference path (an unknown future proof surface that
     ;; no runner has implemented yet).
-    (let [auto (req/normalize-run-opts {:runner :auto})
-          sel  (req/select-runner #{:app-db :rf.story/unimplemented-proof} auto)]
+    (let [auto (rf.story.requirements/normalize-run-opts {:runner :auto})
+          sel  (rf.story.requirements/select-runner #{:app-db :rf.story/unimplemented-proof} auto)]
       (is (= :cannot-run (:status sel)))
       (is (= :no-runner-satisfies (:reason sel))))))
 
@@ -230,20 +230,20 @@
 (deftest aggregate-status-cannot-run-is-not-pass
   (testing "a variant whose only unmet expectations are :cannot-run is :cannot-run"
     (is (= :cannot-run
-           (req/aggregate-status [{:assertion :rf.assert/path-equals :passed? true}]
-                                 [(req/requirement-refusal #{:dom} #{:app-db}
+           (rf.story.requirements/aggregate-status [{:assertion :rf.assert/path-equals :passed? true}]
+                                 [(rf.story.requirements/requirement-refusal #{:dom} #{:app-db}
                                                            [:rf.assert/dom-visible "[x]"])])))
     (is (= :pass
-           (req/aggregate-status [{:assertion :rf.assert/path-equals :passed? true}]
+           (rf.story.requirements/aggregate-status [{:assertion :rf.assert/path-equals :passed? true}]
                                  []))
         "no unmet → pass")
     (is (= :fail
-           (req/aggregate-status [{:assertion :rf.assert/path-equals :passed? false}]
-                                 [(req/requirement-refusal #{:dom} #{:app-db} nil)]))
+           (rf.story.requirements/aggregate-status [{:assertion :rf.assert/path-equals :passed? false}]
+                                 [(rf.story.requirements/requirement-refusal #{:dom} #{:app-db} nil)]))
         "a real failure outranks a cannot-run refusal")
     (is (= :error
-           (req/aggregate-status [{:status :error}]
-                                 [(req/requirement-refusal #{:dom} #{:app-db} nil)]))
+           (rf.story.requirements/aggregate-status [{:status :error}]
+                                 [(rf.story.requirements/requirement-refusal #{:dom} #{:app-db} nil)]))
         "an error outranks everything")))
 
 ;; ===========================================================================
@@ -253,16 +253,16 @@
 (deftest evidence-slot-satisfied-app-db-needs-no-slot
   (testing "an app-db-only requirement needs no distinct evidence slot"
     ;; app-db proof is the final db itself (validated by the assertion).
-    (is (req/evidence-slot-satisfied? #{:app-db} {}))
-    (is (req/evidence-slot-satisfied? #{:app-db} {:effects [] :warnings []}))))
+    (is (rf.story.requirements/evidence-slot-satisfied? #{:app-db} {}))
+    (is (rf.story.requirements/evidence-slot-satisfied? #{:app-db} {:effects [] :warnings []}))))
 
 (deftest effect-assertion-fails-closed-on-empty-tape
   (testing "a required :effects proof fails closed when the tape has no effect rows"
     ;; project an empty tape — no effect rows.
-    (let [ev (evidence/project-evidence [])]
-      (is (not (req/evidence-slot-satisfied? #{:effects} ev))
+    (let [ev (rf.story.play.evidence/project-evidence [])]
+      (is (not (rf.story.requirements/evidence-slot-satisfied? #{:effects} ev))
           "no effect rows → :effects token not satisfied")
-      (let [refusal (req/validate-evidence [:rf.assert/effect-emitted :some/fx]
+      (let [refusal (rf.story.requirements/validate-evidence [:rf.assert/effect-emitted :some/fx]
                                            ev :headless)]
         (is (some? refusal) "missing required evidence → refusal, never pass")
         (is (= :cannot-run (:status refusal)))
@@ -273,10 +273,10 @@
   (testing "an effect proof is satisfied when the tape carries an effect row"
     (let [tape [{:epoch-id 1 :outcome :ok
                  :effects  [{:fx-id :some/fx :outcome :ok}]}]
-          ev   (evidence/project-evidence tape)]
+          ev   (rf.story.play.evidence/project-evidence tape)]
       (is (seq (:effects ev)) "tape projected an effect row")
-      (is (req/evidence-slot-satisfied? #{:effects} ev))
-      (is (nil? (req/validate-evidence [:rf.assert/effect-emitted :some/fx]
+      (is (rf.story.requirements/evidence-slot-satisfied? #{:effects} ev))
+      (is (nil? (rf.story.requirements/validate-evidence [:rf.assert/effect-emitted :some/fx]
                                        ev :headless))
           "evidence present → no refusal; the assertion's own verdict stands"))))
 
@@ -285,11 +285,11 @@
     ;; :cljs-reactive CLAIMS :reactive-counts (preflight), but if the run's
     ;; tape produced no sub-run / render rows the slot is absent → the
     ;; post-run check refuses :cannot-run, never a silent pass (rf2-5x1wt.30).
-    (let [ev (evidence/project-evidence [{:epoch-id 1 :outcome :ok
+    (let [ev (rf.story.play.evidence/project-evidence [{:epoch-id 1 :outcome :ok
                                           :effects [{:fx-id :db :outcome :ok}]}])]
-      (is (not (req/evidence-slot-satisfied? #{:reactive-counts} ev))
+      (is (not (rf.story.requirements/evidence-slot-satisfied? #{:reactive-counts} ev))
           "no reactive rows → :reactive-counts token not satisfied")
-      (let [refusal (req/validate-evidence [:rf.assert/caused] ev :cljs-reactive)]
+      (let [refusal (rf.story.requirements/validate-evidence [:rf.assert/caused] ev :cljs-reactive)]
         (is (some? refusal))
         (is (= :cannot-run (:status refusal)))
         (is (= :required-evidence-missing (:reason refusal)))
@@ -300,10 +300,10 @@
     (let [tape [{:epoch-id 1 :outcome :ok
                  :sub-runs [{:sub-id :total :recomputed? true}]
                  :renders  [{:render-key [:v 0]}]}]
-          ev   (evidence/project-evidence tape)]
+          ev   (rf.story.play.evidence/project-evidence tape)]
       (is (some? (:reactive-counts ev)) "tape projected reactive counts")
-      (is (req/evidence-slot-satisfied? #{:reactive-counts} ev))
-      (is (nil? (req/validate-evidence [:rf.assert/caused] ev :cljs-reactive))
+      (is (rf.story.requirements/evidence-slot-satisfied? #{:reactive-counts} ev))
+      (is (nil? (rf.story.requirements/validate-evidence [:rf.assert/caused] ev :cljs-reactive))
           "evidence present → no refusal; the assertion's own verdict stands"))))
 
 ;; ---------------------------------------------------------------------------
@@ -320,27 +320,27 @@
   (testing ":trace is NOT in the token->evidence-slots presence map (rf2-qoxw7)"
     ;; :trace has no faithful presence slot — :warnings / :schema-violations
     ;; are FILTERED projections, not the whole always-on trace stream.
-    (is (nil? (get req/token->evidence-slots :trace))
+    (is (nil? (get rf.story.requirements/token->evidence-slots :trace))
         ":trace -> :warnings would false-refuse :no-warnings / :dispatched?")
-    (is (nil? (get req/token->evidence-slots :hiccup-structure))
+    (is (nil? (get rf.story.requirements/token->evidence-slots :hiccup-structure))
         "empty :renders is healthy for an absence assertion")
-    (is (nil? (get req/token->evidence-slots :dom))))
+    (is (nil? (get rf.story.requirements/token->evidence-slots :dom))))
 
   (testing ":no-warnings + :dispatched? require :trace"
-    (is (= #{:trace}          (req/assertion-tokens [:rf.assert/no-warnings])))
-    (is (= #{:app-db :trace}  (req/assertion-tokens [:rf.assert/dispatched? [:e]])))))
+    (is (= #{:trace}          (rf.story.requirements/assertion-tokens [:rf.assert/no-warnings])))
+    (is (= #{:app-db :trace}  (rf.story.requirements/assertion-tokens [:rf.assert/dispatched? [:e]])))))
 
 (deftest no-warnings-on-clean-tape-is-not-cannot-run
   (testing ":rf.assert/no-warnings on a clean (empty-:warnings) tape does NOT false-:cannot-run (rf2-qoxw7)"
     ;; A clean headless run: one committed epoch, no warning trace events.
     (let [tape [{:epoch-id 1 :outcome :ok :trace-events []}]
-          ev   (evidence/project-evidence tape)]
+          ev   (rf.story.play.evidence/project-evidence tape)]
       (is (empty? (:warnings ev)) "clean run → empty :warnings — the HEALTHY state")
       ;; The whole point: an empty :warnings slot must NOT be read as
       ;; "trace proof not delivered".
-      (is (req/evidence-slot-satisfied? #{:trace} ev)
+      (is (rf.story.requirements/evidence-slot-satisfied? #{:trace} ev)
           ":trace imposes no slot, so an empty :warnings slot still satisfies")
-      (is (nil? (req/validate-evidence [:rf.assert/no-warnings] ev :headless))
+      (is (nil? (rf.story.requirements/validate-evidence [:rf.assert/no-warnings] ev :headless))
           "no false :required-evidence-missing — the assertion's own verdict (PASS) stands"))))
 
 (deftest dispatched-on-warning-free-tape-is-not-cannot-run
@@ -351,10 +351,10 @@
     (let [tape [{:epoch-id 1 :outcome :ok
                  :trigger-event [:counter/inc]
                  :trace-events  [{:operation :rf.event/dispatch :op-type :info}]}]
-          ev   (evidence/project-evidence tape)]
+          ev   (rf.story.play.evidence/project-evidence tape)]
       (is (empty? (:warnings ev)) "dispatch with no warning → empty :warnings")
-      (is (req/evidence-slot-satisfied? #{:app-db :trace} ev))
-      (is (nil? (req/validate-evidence [:rf.assert/dispatched? [:counter/inc]]
+      (is (rf.story.requirements/evidence-slot-satisfied? #{:app-db :trace} ev))
+      (is (nil? (rf.story.requirements/validate-evidence [:rf.assert/dispatched? [:counter/inc]]
                                        ev :headless))
           "no false refusal — the :app-db + :trace tokens impose no presence gate"))))
 
@@ -362,19 +362,19 @@
   (testing "a :dom assertion on a tape with no render rows does NOT false-:cannot-run (rf2-qoxw7)"
     ;; :rf.assert/dom-hidden legitimately PASSES when an element is absent /
     ;; the tree committed no render row; :renders is the wrong presence gate.
-    (let [ev (evidence/project-evidence [{:epoch-id 1 :outcome :ok :renders []}])]
+    (let [ev (rf.story.play.evidence/project-evidence [{:epoch-id 1 :outcome :ok :renders []}])]
       (is (empty? (:renders ev)))
-      (is (req/evidence-slot-satisfied? #{:dom} ev)
+      (is (rf.story.requirements/evidence-slot-satisfied? #{:dom} ev)
           ":dom imposes no render-count gate — preflight already fail-closes it")
-      (is (nil? (req/validate-evidence [:rf.assert/dom-hidden "[x]"] ev :dom))
+      (is (nil? (rf.story.requirements/validate-evidence [:rf.assert/dom-hidden "[x]"] ev :dom))
           "no false :required-evidence-missing for an absence assertion"))))
 
 (deftest validate-run-evidence-clean-trace-tape-is-ok
   (testing "run-level validation of :no-warnings + :dispatched? on a clean tape is :ok (rf2-qoxw7)"
     ;; The regression the bead pins: before the fix, validate-run-evidence
     ;; would return :cannot-run for this normal passing plan once wired in.
-    (let [ev (evidence/project-evidence [{:epoch-id 1 :outcome :ok :trace-events []}])]
-      (is (= :ok (:status (req/validate-run-evidence
+    (let [ev (rf.story.play.evidence/project-evidence [{:epoch-id 1 :outcome :ok :trace-events []}])]
+      (is (= :ok (:status (rf.story.requirements/validate-run-evidence
                             [[:rf.assert/no-warnings]
                              [:rf.assert/dispatched? [:counter/inc]]]
                             ev :headless)))
@@ -382,10 +382,10 @@
 
 (deftest validate-run-evidence-aggregates-missing-slots
   (testing "run-level evidence validation lists per-assertion missing-evidence refusals"
-    (let [ev (evidence/project-evidence [])]
+    (let [ev (rf.story.play.evidence/project-evidence [])]
       ;; path-equals needs only app-db (no slot) → ok; effect-emitted needs
       ;; :effects (absent) → cannot-run.
-      (let [result (req/validate-run-evidence
+      (let [result (rf.story.requirements/validate-run-evidence
                      [[:rf.assert/path-equals [:n] 1]
                       [:rf.assert/effect-emitted :some/fx]]
                      ev :headless)]
@@ -394,7 +394,7 @@
         (is (= :rf.assert/effect-emitted
                (first (:unit (first (:missing-evidence result)))))))
       ;; all app-db → ok
-      (is (= :ok (:status (req/validate-run-evidence
+      (is (= :ok (:status (rf.story.requirements/validate-run-evidence
                             [[:rf.assert/path-equals [:n] 1]]
                             ev :headless)))))))
 
@@ -404,15 +404,15 @@
 
 (deftest normalize-run-opts-defaults
   (testing "defaults: fixed :headless, :fresh binding, :client platform"
-    (let [o (req/normalize-run-opts)]
+    (let [o (rf.story.requirements/normalize-run-opts)]
       (is (= :fixed    (:mode o)))
       (is (= :headless (:runner o)))
       (is (= :fresh    (:frame-binding o)))
       (is (= :client   (:platform o))))
-    (is (= (req/normalize-run-opts) (req/normalize-run-opts nil))))
+    (is (= (rf.story.requirements/normalize-run-opts) (rf.story.requirements/normalize-run-opts nil))))
 
   (testing "explicit runner / frame-binding / platform carry through"
-    (let [o (req/normalize-run-opts {:runner :dom
+    (let [o (rf.story.requirements/normalize-run-opts {:runner :dom
                                      :frame-binding :attached
                                      :platform :server})]
       (is (= :fixed    (:mode o)))
@@ -421,17 +421,17 @@
       (is (= :server   (:platform o)))))
 
   (testing ":escalate true and :runner :auto both yield :auto mode"
-    (is (= :auto (:mode (req/normalize-run-opts {:escalate true}))))
-    (is (= :auto (:mode (req/normalize-run-opts {:runner :auto})))))
+    (is (= :auto (:mode (rf.story.requirements/normalize-run-opts {:escalate true}))))
+    (is (= :auto (:mode (rf.story.requirements/normalize-run-opts {:runner :auto})))))
 
   (testing "an unknown runner falls back to fixed :headless"
     (is (= {:mode :fixed :runner :headless :frame-binding :fresh :platform :client}
-           (req/normalize-run-opts {:runner :bogus}))))
+           (rf.story.requirements/normalize-run-opts {:runner :bogus}))))
 
   (testing ":cljs-reactive is now a valid fixed runner (rf2-5x1wt.30)"
-    (is (= :cljs-reactive (:runner (req/normalize-run-opts {:runner :cljs-reactive})))
+    (is (= :cljs-reactive (:runner (rf.story.requirements/normalize-run-opts {:runner :cljs-reactive})))
         ":cljs-reactive proves :reactive-counts → it is a P1 selection target")
-    (is (= :fixed (:mode (req/normalize-run-opts {:runner :cljs-reactive}))))))
+    (is (= :fixed (:mode (rf.story.requirements/normalize-run-opts {:runner :cljs-reactive}))))))
 
 ;; ===========================================================================
 ;; PLAN INTEGRATION — :required-runner is computed through the registry
@@ -440,24 +440,24 @@
 (deftest plan-required-runner-flows-through-registry
   (testing "the plan compiler fills :required-runner from the registry"
     ;; headless variant → empty/app-db only
-    (let [p (plan/variant-plan {:variant/id :v
+    (let [p (rf.story.plan/variant-plan {:variant/id :v
                                 :setup  [[:dispatch [:a]]]
                                 :script [[:dispatch [:b]]]
                                 :assertions [[:rf.assert/path-equals [:n] 1]]})]
       (is (= #{:app-db} (:required-runner p))))
     ;; a DOM step lifts the requirement
-    (let [p (plan/variant-plan {:variant/id :v
+    (let [p (rf.story.plan/variant-plan {:variant/id :v
                                 :script [[:click "[x]"]]
                                 :assertions [[:rf.assert/path-equals [:n] 1]]})]
       (is (= #{:app-db :dom} (:required-runner p))))
     ;; a visual assertion lifts to :pixels
-    (let [p (plan/variant-plan {:variant/id :v
+    (let [p (rf.story.plan/variant-plan {:variant/id :v
                                 :script [[:dispatch [:a]]]
                                 :assertions [[:rf.assert/visual-snapshot]]})]
       (is (contains? (:required-runner p) :pixels))
       ;; the cheapest satisfying runner for the plan is :browser
       (is (= :browser
-             (req/cheapest-runner (req/required-tokens
+             (rf.story.requirements/cheapest-runner (rf.story.requirements/required-tokens
                                     (get-in p [:world :setup])
                                     (:script p)
                                     (get-in p [:expect :assertions]))))))))

--- a/tools/story/test/re_frame/story/result_test.cljc
+++ b/tools/story/test/re_frame/story/result_test.cljc
@@ -17,11 +17,11 @@
   - `story/is` reports per assertion (`result->reports`)."
   (:require [clojure.test :refer [deftest is testing]]
             [malli.core               :as m]
-            [re-frame.epoch.capture   :as capture]
-            [re-frame.story.assertions :as assertions]
-            [re-frame.story.result   :as result]
-            [re-frame.story.play.evidence :as evidence]
-            [re-frame.story.requirements  :as requirements]))
+            [re-frame.epoch.capture   :as rf.epoch.capture]
+            [re-frame.story.assertions :as rf.story.assertions]
+            [re-frame.story.result   :as rf.story.result]
+            [re-frame.story.play.evidence :as rf.story.play.evidence]
+            [re-frame.story.requirements  :as rf.story.requirements]))
 
 ;; ===========================================================================
 ;; STATUS — the four verdicts, derived from one field
@@ -29,18 +29,18 @@
 
 (deftest record-status-derivation
   (testing "an explicit :status on the record wins"
-    (is (= :cannot-run (result/record-status {:status :cannot-run :passed? true}))))
+    (is (= :cannot-run (rf.story.result/record-status {:status :cannot-run :passed? true}))))
   (testing ":passed? true/false → :pass / :fail"
-    (is (= :pass (result/record-status {:passed? true})))
-    (is (= :fail (result/record-status {:passed? false}))))
+    (is (= :pass (rf.story.result/record-status {:passed? true})))
+    (is (= :fail (rf.story.result/record-status {:passed? false}))))
   (testing ":cannot-run? / legacy :skipped? → :cannot-run (the THIRD status)"
-    (is (= :cannot-run (result/record-status {:passed? false :cannot-run? true})))
-    (is (= :cannot-run (result/record-status {:passed? false :skipped? true}))))
+    (is (= :cannot-run (rf.story.result/record-status {:passed? false :cannot-run? true})))
+    (is (= :cannot-run (rf.story.result/record-status {:passed? false :skipped? true}))))
   (testing "an exception / error → :error"
-    (is (= :error (result/record-status {:passed? false :exception true})))
-    (is (= :error (result/record-status {:passed? false :error {:msg "boom"}}))))
+    (is (= :error (rf.story.result/record-status {:passed? false :exception true})))
+    (is (= :error (rf.story.result/record-status {:passed? false :error {:msg "boom"}}))))
   (testing "a record with no outcome is vacuously :pass (the duality)"
-    (is (= :pass (result/record-status {:assertion :rf.assert/x})))))
+    (is (= :pass (rf.story.result/record-status {:assertion :rf.assert/x})))))
 
 ;; ===========================================================================
 ;; ASSERTION RECORD — the `.18` atom shape + a unified :status
@@ -51,15 +51,15 @@
     (let [raw {:assertion :rf.assert/path-equals :payload [[:k] 1]
                :passed? true :expected 1 :actual 1
                :source-coord {:file "x.cljs" :line 3}}
-          rec (result/assertion-record raw)]
+          rec (rf.story.result/assertion-record raw)]
       (is (= :pass (:status rec)))
       (is (= {:file "x.cljs" :line 3} (:source rec)) ":source-coord renamed to :source")
       (is (not (contains? rec :source-coord))
           "the unified record emits ONLY :source — the legacy :source-coord slot is dropped (rf2-k9u0h)")
       (is (= :rf.assert/path-equals (:assertion rec)))))
   (testing "a failing entry → :fail; a record carrying its own :status is left"
-    (is (= :fail (:status (result/assertion-record {:passed? false}))))
-    (is (= :cannot-run (:status (result/assertion-record
+    (is (= :fail (:status (rf.story.result/assertion-record {:passed? false}))))
+    (is (= :cannot-run (:status (rf.story.result/assertion-record
                                   {:status :cannot-run :passed? false}))))))
 
 ;; ===========================================================================
@@ -73,7 +73,7 @@
                    {:assertion :rf.assert/path-equals :payload [[:b] 2] :status :fail}]
           check->atoms {:check/clean [[:rf.assert/no-warnings]]
                         :check/a     [[:rf.assert/path-equals [:a] 1]]}
-          recs (result/check-records check->atoms records)]
+          recs (rf.story.result/check-records check->atoms records)]
       (is (= 2 (count recs)))
       (let [clean (first (filter #(= :check/clean (:check %)) recs))
             a     (first (filter #(= :check/a (:check %)) recs))]
@@ -88,7 +88,7 @@
   (testing "a failing check shows the check id AND the failing record"
     (let [records [{:assertion :rf.assert/path-equals :payload [[:s] :x] :status :fail
                     :expected :x :actual :y}]
-          recs (result/check-records {:check/state [[:rf.assert/path-equals [:s] :x]]}
+          recs (rf.story.result/check-records {:check/state [[:rf.assert/path-equals [:s] :x]]}
                                      records)
           c    (first recs)]
       (is (= :check/state (:check c)))
@@ -96,7 +96,7 @@
       (is (= :y (:actual (first (:assertions c)))))))
 
   (testing "an unmatched check atom groups nothing (the assertion never ran)"
-    (let [recs (result/check-records {:check/missing [[:rf.assert/path-equals [:z] 9]]}
+    (let [recs (rf.story.result/check-records {:check/missing [[:rf.assert/path-equals [:z] 9]]}
                                      [])]
       (is (= :pass (:status (first recs))) "an empty group is vacuously :pass")
       (is (empty? (:assertions (first recs)))))))
@@ -119,7 +119,7 @@
                     :expected  :rf/redacted
                     :actual    :rf/redacted}]
           check->atoms {:check/no-leak [[:rf.assert/path-equals [:user :ssn] "123-45-6789"]]}
-          recs (result/check-records check->atoms records)
+          recs (rf.story.result/check-records check->atoms records)
           c    (first recs)]
       (is (= :check/no-leak (:check c)))
       (is (= 1 (count (:assertions c)))
@@ -135,7 +135,7 @@
     (let [records [{:assertion :rf.assert/sub-equals :payload [[:sub/a] 1] :status :pass}
                    {:assertion :rf.assert/sub-equals :payload [[:sub/b] 2] :status :fail}]
           check->atoms {:check/a [[:rf.assert/sub-equals [:sub/a] 1]]}
-          recs (result/check-records check->atoms records)
+          recs (rf.story.result/check-records check->atoms records)
           c    (first recs)]
       (is (= 1 (count (:assertions c)))
           "only the matching sub-vec's record groups under the check —
@@ -155,7 +155,7 @@
 
 (deftest passing-variant-yields-pass
   (testing "a passing assertion set + clean tape → :status :pass (§B5)"
-    (let [r (result/run-result
+    (let [r (rf.story.result/run-result
               {:variant/id :story.x/v
                :epoch-tape [(epoch {})]
                :assertions [{:assertion :rf.assert/path-equals :passed? true}]
@@ -167,7 +167,7 @@
 
 (deftest failing-assertion-yields-fail
   (testing "a failing assertion → :status :fail (§B5)"
-    (let [r (result/run-result
+    (let [r (rf.story.result/run-result
               {:epoch-tape [(epoch {})]
                :assertions [{:assertion :rf.assert/path-equals :passed? true}
                             {:assertion :rf.assert/path-equals :passed? false}]})]
@@ -175,24 +175,24 @@
 
 (deftest cannot-run-yields-cannot-run
   (testing "a run whose only unmet expectation is :cannot-run → :cannot-run (§B5)"
-    (let [refusal (requirements/requirement-refusal
+    (let [refusal (rf.story.requirements/requirement-refusal
                     #{:pixels} #{:app-db} [:rf.assert/visual-snapshot]
                     :runner-lacks-capability :headless)
-          r (result/run-result
+          r (rf.story.result/run-result
               {:epoch-tape [(epoch {})]
                :assertions [{:assertion :rf.assert/path-equals :passed? true}]
                :unmet      [refusal]})]
       (is (= :cannot-run (:status r)))
       (is (= [refusal] (:cannot-run r)) "the refusal surfaces on :cannot-run")))
   (testing "a :cannot-run assertion record (no real fail) → :cannot-run"
-    (let [r (result/run-result
+    (let [r (rf.story.result/run-result
               {:assertions [{:assertion :rf.assert/dom-visible
                              :status :cannot-run :passed? false}]})]
       (is (= :cannot-run (:status r))))))
 
 (deftest error-outranks-fail
   (testing "an :error assertion record → :status :error (precedence)"
-    (let [r (result/run-result
+    (let [r (rf.story.result/run-result
               {:assertions [{:assertion :rf.assert/x :passed? false}
                             {:assertion :rf.error/exception :passed? false
                              :exception true}]})]
@@ -207,7 +207,7 @@
     (let [tape [(epoch {:trace-events
                         [{:operation :rf.error/schema-validation-failure
                           :tags {:where :event :failing-id :checkout/submit}}]})]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :assertions [{:assertion :rf.assert/path-equals :passed? true}]})]
       (is (= :fail (:status r))
@@ -222,7 +222,7 @@
           tape [(epoch {:trace-events
                         [{:operation :rf.error/schema-validation-failure
                           :tags {:where :event :failing-id :checkout/submit}}]})]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :assertions [{:assertion :rf.assert/schema-error :passed? true}]
                   :consumed-selectors #{sel}})]
@@ -240,13 +240,13 @@
             unmet capability refusal says nothing about whether the tape
             independently carries an unconsumed failure), so both
             floor-eligible base statuses must escalate."
-    (let [refusal (requirements/requirement-refusal
+    (let [refusal (rf.story.requirements/requirement-refusal
                     #{:pixels} #{:app-db} [:rf.assert/visual-snapshot]
                     :runner-lacks-capability :headless)
           tape    [(epoch {:trace-events
                            [{:operation :rf.error/schema-validation-failure
                              :tags {:where :event :failing-id :checkout/submit}}]})]
-          r       (result/run-result
+          r       (rf.story.result/run-result
                     {:epoch-tape  tape
                      :assertions  [{:assertion :rf.assert/path-equals :passed? true}]
                      :unmet       [refusal]})]
@@ -262,53 +262,53 @@
 ;; ---- floor-blind assertion fold (no false GREEN) -------------------------
 
 (deftest assertions-passing?-consults-the-run-verdict
-  (testing "the public cljs.test-adapter predicate `assertions/passing?`
+  (testing "the public cljs.test-adapter predicate `rf.story.assertions/passing?`
             (also `story/assertions-passing?`) reads the run VERDICT
             (`:status`) for a RESULT MAP — NOT a fold over `:assertions` —
             so a floor-escalated `:fail` or a run-level `:cannot-run` with
             an all-green assertion set returns FALSE, agreeing with
-            `result/passed?`. Before rf2-x76af2.16 it folded only
+            `rf.story.result/passed?`. Before rf2-x76af2.16 it folded only
             `(every? :passed? (:assertions result))` and reported a false
             GREEN on both shapes."
     (testing "floor-escalated :fail (red tape + a single passing assertion)"
       (let [tape [(epoch {:trace-events
                           [{:operation :rf.error/schema-validation-failure
                             :tags {:where :event :failing-id :checkout/submit}}]})]
-            r    (result/run-result
+            r    (rf.story.result/run-result
                    {:epoch-tape tape
                     :assertions [{:assertion :rf.assert/path-equals :passed? true}]})]
         (is (= :fail (:status r)) "sanity: the agreement floor escalated to :fail")
         (is (every? :passed? (:assertions r))
             "sanity: the assertion fold alone is all-green (the false-GREEN trap)")
-        (is (false? (result/passed? r)) "the verdict authority says NOT passing")
-        (is (false? (assertions/passing? r))
-            "assertions/passing? MUST agree with the verdict — no false GREEN")))
+        (is (false? (rf.story.result/passed? r)) "the verdict authority says NOT passing")
+        (is (false? (rf.story.assertions/passing? r))
+            "rf.story.assertions/passing? MUST agree with the verdict — no false GREEN")))
     (testing "run-level :cannot-run (unmet requirement) + a passing assertion"
-      (let [refusal (requirements/requirement-refusal
+      (let [refusal (rf.story.requirements/requirement-refusal
                       #{:pixels} #{:app-db} [:rf.assert/visual-snapshot]
                       :runner-lacks-capability :headless)
-            r       (result/run-result
+            r       (rf.story.result/run-result
                       {:epoch-tape [(epoch {})]
                        :assertions [{:assertion :rf.assert/path-equals :passed? true}]
                        :unmet      [refusal]})]
         (is (= :cannot-run (:status r)) "sanity: run refused → :cannot-run")
-        (is (false? (assertions/passing? r))
-            "a :cannot-run run proved nothing — assertions/passing? is FALSE")))
+        (is (false? (rf.story.assertions/passing? r))
+            "a :cannot-run run proved nothing — rf.story.assertions/passing? is FALSE")))
     (testing "the vacuous-green duality still holds — a zero-assertion :pass"
-      (let [r (result/run-result {:assertions []})]
+      (let [r (rf.story.result/run-result {:assertions []})]
         (is (= :pass (:status r)))
-        (is (true? (assertions/passing? r))
+        (is (true? (rf.story.assertions/passing? r))
             "a zero-assertion :pass run is still green (Story-as-test duality)")))
     (testing "a genuinely-passing run with passing assertions is still green"
-      (let [r (result/run-result
+      (let [r (rf.story.result/run-result
                 {:epoch-tape [(epoch {})]
                  :assertions [{:assertion :rf.assert/path-equals :passed? true}]})]
         (is (= :pass (:status r)))
-        (is (true? (assertions/passing? r)))))
+        (is (true? (rf.story.assertions/passing? r)))))
     (testing "the bare-assertions-VECTOR arity is unchanged (the fold path)"
-      (is (true?  (assertions/passing? []))            "empty vector vacuously passes")
-      (is (true?  (assertions/passing? [{:passed? true}])))
-      (is (false? (assertions/passing? [{:passed? true} {:passed? false}]))
+      (is (true?  (rf.story.assertions/passing? []))            "empty vector vacuously passes")
+      (is (true?  (rf.story.assertions/passing? [{:passed? true}])))
+      (is (false? (rf.story.assertions/passing? [{:passed? true} {:passed? false}]))
           "any :passed? false in the vector fails the fold"))))
 
 ;; ===========================================================================
@@ -327,7 +327,7 @@
 (deftest match-schema-expectations-pairs-exactly
   (testing "an expected schema violation is consumed → :pass record, in the set"
     (let [tape [(schema-epoch :event :checkout/submit)]
-          m    (result/match-schema-expectations
+          m    (rf.story.result/match-schema-expectations
                  [[:rf.assert/schema-error {:where :event :event :checkout/submit}]]
                  tape)]
       (is (= 1 (count (:records m))))
@@ -338,7 +338,7 @@
 
   (testing "a MISSING expected violation → :fail record (the expected violation
             never happened — §Schema rule step 3)"
-    (let [m (result/match-schema-expectations
+    (let [m (rf.story.result/match-schema-expectations
               [[:rf.assert/schema-error {:where :event :event :checkout/submit}]]
               [(epoch {})])]                          ; clean tape, no violation
       (is (= :fail (:status (first (:records m)))))
@@ -348,7 +348,7 @@
   (testing "a DIFFERENT violation than expected → expectation unmatched (:fail)
             AND the emitted violation is left unconsumed (§Schema rule)"
     (let [tape [(schema-epoch :event :other/event)]
-          m    (result/match-schema-expectations
+          m    (rf.story.result/match-schema-expectations
                  [[:rf.assert/schema-error {:where :event :event :checkout/submit}]]
                  tape)]
       (is (= :fail (:status (first (:records m)))) "expected violation never emitted")
@@ -357,14 +357,14 @@
       (is (empty? (:consumed-selectors m)))))
 
   (testing "an UNEXPECTED violation (no expectation declared) is left unconsumed"
-    (let [m (result/match-schema-expectations [] [(schema-epoch :cofx :load/session)])]
+    (let [m (rf.story.result/match-schema-expectations [] [(schema-epoch :cofx :load/session)])]
       (is (empty? (:records m)))
       (is (= 1 (count (:unconsumed m))))
       (is (empty? (:consumed-selectors m)))))
 
   (testing "N expectations of one selector consume N violations (multiset)"
     (let [tape [(schema-epoch :event :x) (schema-epoch :event :x)]
-          m    (result/match-schema-expectations
+          m    (rf.story.result/match-schema-expectations
                  [[:rf.assert/schema-error {:where :event :event :x}]
                   [:rf.assert/schema-error {:where :event :event :x}]]
                  tape)]
@@ -374,14 +374,14 @@
     (testing "one expectation against two same-selector violations leaves one
               unconsumed (multiset, not set)"
       (let [tape [(schema-epoch :event :x) (schema-epoch :event :x)]
-            m    (result/match-schema-expectations
+            m    (rf.story.result/match-schema-expectations
                    [[:rf.assert/schema-error {:where :event :event :x}]]
                    tape)]
         (is (= 1 (count (filter #(= :pass (:status %)) (:records m)))))
         (is (= 1 (count (:unconsumed m))) "the second violation is unconsumed"))))
 
   (testing "a bare [:rf.assert/schema-error] wildcard consumes any one violation"
-    (let [m (result/match-schema-expectations
+    (let [m (rf.story.result/match-schema-expectations
               [[:rf.assert/schema-error]]
               [(schema-epoch :app-db :db {:registered-path [:k] :path [:k]})])]
       (is (= :pass (:status (first (:records m)))))
@@ -391,7 +391,7 @@
   (testing "a concrete expectation is paired before a wildcard, so the wildcard
             does not starve the concrete match"
     (let [tape [(schema-epoch :cofx :a) (schema-epoch :event :b)]
-          m    (result/match-schema-expectations
+          m    (rf.story.result/match-schema-expectations
                  [[:rf.assert/schema-error]                              ; wildcard
                   [:rf.assert/schema-error {:where :event :event :b}]]   ; concrete
                  tape)]
@@ -401,7 +401,7 @@
 
 (deftest run-result-schema-expectations-wiring
   (testing "an EXPECTED schema violation passes the run (exactly consumed)"
-    (let [r (result/run-result
+    (let [r (rf.story.result/run-result
               {:epoch-tape [(schema-epoch :event :checkout/submit)]
                :schema-expectations
                [[:rf.assert/schema-error {:where :event :event :checkout/submit}]]})]
@@ -413,12 +413,12 @@
           "rf2-uyebc — the consumed selector set is SURFACED on the result")))
 
   (testing "an UNEXPECTED schema violation FAILS the run (no expectation)"
-    (let [r (result/run-result
+    (let [r (rf.story.result/run-result
               {:epoch-tape [(schema-epoch :event :checkout/submit)]})]
       (is (= :fail (:status r)) "the floor fails the run on the unconsumed violation")))
 
   (testing "a MISSING expected violation FAILS the run (the :fail record)"
-    (let [r (result/run-result
+    (let [r (rf.story.result/run-result
               {:epoch-tape [(epoch {})]
                :schema-expectations
                [[:rf.assert/schema-error {:where :event :event :checkout/submit}]]})]
@@ -428,7 +428,7 @@
 
   (testing "a DIFFERENT violation than expected STILL FAILS (both: missing
             expected → :fail record AND the emitted one is unconsumed → floor)"
-    (let [r (result/run-result
+    (let [r (rf.story.result/run-result
               {:epoch-tape [(schema-epoch :event :other/event)]
                :schema-expectations
                [[:rf.assert/schema-error {:where :event :event :checkout/submit}]]})]
@@ -441,7 +441,7 @@
     ;; violations + 1× [:rf.assert/schema-error {:where :event :event :x}]
     ;; expectation. The set-keyed floor dropped BOTH violations (selector held
     ;; once) and reported :pass; the multiset floor leaves the 2nd unconsumed.
-    (let [r (result/run-result
+    (let [r (rf.story.result/run-result
               {:epoch-tape [(schema-epoch :event :x) (schema-epoch :event :x)]
                :schema-expectations
                [[:rf.assert/schema-error {:where :event :event :x}]]})]
@@ -456,7 +456,7 @@
 
   (testing "rf2-5mrnwx — TWO same-selector violations FULLY consumed by TWO
             expectations PASSES (multiset balance: N expectations, N violations)"
-    (let [r (result/run-result
+    (let [r (rf.story.result/run-result
               {:epoch-tape [(schema-epoch :event :x) (schema-epoch :event :x)]
                :schema-expectations
                [[:rf.assert/schema-error {:where :event :event :x}]
@@ -473,7 +473,7 @@
                           :tags {:where :event :failing-id :checkout/submit
                                  :rollback? true}}]})]
           ;; no expectation declared → the retained violation fails the run
-          r    (result/run-result {:epoch-tape tape :app-db {:clean true}})]
+          r    (rf.story.result/run-result {:epoch-tape tape :app-db {:clean true}})]
       (is (= :fail (:status r)) "rollback to a clean db does NOT hide the tape violation")
       (is (= 1 (count (:schema-violations r)))))))
 
@@ -482,13 +482,13 @@
   ;; set anyway; it now SURFACES that value as `:consumed-selectors` so Test
   ;; mode reads the single source of truth rather than re-deriving it.
   (testing "always present — an empty `#{}` when nothing was consumed"
-    (let [r (result/run-result {:epoch-tape [(epoch {})]})]
+    (let [r (rf.story.result/run-result {:epoch-tape [(epoch {})]})]
       (is (contains? r :consumed-selectors) "the slot is always assoc'd")
       (is (= #{} (:consumed-selectors r)) "empty when no violations consumed")))
   (testing "an explicit `:consumed-selectors` input is unioned with the
             schema-expectation consumption and surfaced verbatim"
     (let [extra [:cofx :pre-computed]
-          r     (result/run-result
+          r     (rf.story.result/run-result
                   {:epoch-tape [(schema-epoch :event :checkout/submit)]
                    :schema-expectations
                    [[:rf.assert/schema-error {:where :event :event :checkout/submit}]]
@@ -502,19 +502,19 @@
 ;;
 ;; The matcher reads the SAME reactive evidence the tape already carries —
 ;; the `:rf.sub/run` / `:rf.view/rendered` rows stamped with the dispatching
-;; cascade's `:cause-event-id` (rf2-5x1wt.30 `evidence/reactive-counts`). A
+;; cascade's `:cause-event-id` (rf2-5x1wt.30 `rf.story.play.evidence/reactive-counts`). A
 ;; reactive epoch is one whose sub-runs / renders carry `:cause-event-id`.
 ;;
 ;; rf2-9gquv — these epochs are PROJECTION-DERIVED, not hand-stamped. The
 ;; prior `reactive-epoch` synthesised `{:render-key [view-id 0]
 ;; :cause-event-id cause}` render rows directly — a shape the REAL
-;; `capture/render-row` projection never produced, because `render-row`
+;; `rf.epoch.capture/render-row` projection never produced, because `render-row`
 ;; dropped `:rf.view/cause-event-id` off the trace event. That synthetic
 ;; tape masked a false-GREEN: the projection emitted render rows with NO
 ;; `:cause-event-id`, so the `:view` causal surface silently measured 0 and
 ;; `:rf.assert/no-cascade-rerender {:view v}` could never catch an
-;; over-render. We now drive the rows through `capture/render-row` /
-;; `capture/sub-run-row` over real `:rf.view/rendered` / `:rf.sub/run` trace
+;; over-render. We now drive the rows through `rf.epoch.capture/render-row` /
+;; `rf.epoch.capture/sub-run-row` over real `:rf.view/rendered` / `:rf.sub/run` trace
 ;; events, so the tape carries `:cause-event-id` ONLY because the projection
 ;; threads it. Pre-fix (projection not threading) these epochs carry no
 ;; render-row `:cause-event-id` and the `:view` assertions fail; post-fix
@@ -543,8 +543,8 @@
   "An epoch carrying reactive rows attributed to `cause` — `n-subs` sub
   recomputes of `sub-id` and `n-renders` renders of `view-id`.
 
-  rf2-9gquv: the rows are PROJECTION-DERIVED via `capture/sub-run-row` /
-  `capture/render-row` over real trace events, NOT hand-stamped. The
+  rf2-9gquv: the rows are PROJECTION-DERIVED via `rf.epoch.capture/sub-run-row` /
+  `rf.epoch.capture/render-row` over real trace events, NOT hand-stamped. The
   `:cause-event-id` slot rides each row only because the projection threads
   it — so these epochs exercise the genuine production shape."
   [cause sub-id n-subs view-id n-renders]
@@ -555,15 +555,15 @@
           ;; fixture stamps it to mirror production.
           :event-id      cause
           :trigger-event [cause]
-          :sub-runs (mapv (fn [_] (capture/sub-run-row (sub-run-trace-event sub-id cause)))
+          :sub-runs (mapv (fn [_] (rf.epoch.capture/sub-run-row (sub-run-trace-event sub-id cause)))
                           (range n-subs))
-          :renders  (mapv (fn [_] (capture/render-row (rendered-trace-event view-id cause)))
+          :renders  (mapv (fn [_] (rf.epoch.capture/render-row (rendered-trace-event view-id cause)))
                           (range n-renders))}))
 
 (deftest causal-caused-passes-when-the-cause-produced-the-effect
   (testing ":rf.assert/caused {:event e} passes when e caused >= 1 reactive effect"
     (let [tape [(reactive-epoch :counter/inc :total 1 :counter 1)]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :causal-expectations [[:rf.assert/caused {:event :counter/inc}]]})
           rec  (first (filter #(= :rf.assert/caused (:assertion %)) (:assertions r)))]
@@ -573,7 +573,7 @@
 
   (testing ":rf.assert/caused {:event e :sub s} measures the named sub only"
     (let [tape [(reactive-epoch :counter/inc :total 3 :counter 1)]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :causal-expectations [[:rf.assert/caused {:event :counter/inc :sub :total}]]})
           rec  (first (filter #(= :rf.assert/caused (:assertion %)) (:assertions r)))]
@@ -582,7 +582,7 @@
 
   (testing ":rf.assert/caused {:event e :view v} measures the named view only"
     (let [tape [(reactive-epoch :counter/inc :total 1 :counter 2)]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :causal-expectations [[:rf.assert/caused {:event :counter/inc :view :counter}]]})
           rec  (first (filter #(= :rf.assert/caused (:assertion %)) (:assertions r)))]
@@ -592,7 +592,7 @@
 (deftest causal-caused-fails-when-the-cause-did-not-produce-the-effect
   (testing ":rf.assert/caused for an event that caused no reactive effect FAILS"
     (let [tape [(reactive-epoch :counter/inc :total 1 :counter 1)]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :causal-expectations [[:rf.assert/caused {:event :other/event}]]})
           rec  (first (filter #(= :rf.assert/caused (:assertion %)) (:assertions r)))]
@@ -602,7 +602,7 @@
 
   (testing "a degenerate :rf.assert/caused (no :event) FAILS readably"
     (let [tape [(reactive-epoch :counter/inc :total 1 :counter 1)]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :causal-expectations [[:rf.assert/caused {}]]})
           rec  (first (filter #(= :rf.assert/caused (:assertion %)) (:assertions r)))]
@@ -622,7 +622,7 @@
     ;; unrelated :sidebar view → n = 0 within [0,0] → the premise held and
     ;; the guard was honoured.
     (let [tape [(reactive-epoch :counter/inc :total 1 :counter 1)]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :causal-expectations
                   [[:rf.assert/no-cascade-rerender {:event :counter/inc :view :sidebar}]]})
@@ -635,7 +635,7 @@
 
   (testing ":rf.assert/no-cascade-rerender FAILS when the event over-rendered"
     (let [tape [(reactive-epoch :counter/inc :total 1 :counter 3)]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :causal-expectations
                   [[:rf.assert/no-cascade-rerender {:event :counter/inc :view :counter}]]})
@@ -647,7 +647,7 @@
 
   (testing "an explicit :max bound on :no-cascade-rerender admits N renders"
     (let [tape [(reactive-epoch :counter/inc :total 1 :counter 2)]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :causal-expectations
                   [[:rf.assert/no-cascade-rerender {:event :counter/inc :view :counter :max 2}]]})
@@ -659,7 +659,7 @@
 ;;
 ;; These tests guard the false-green directly at the projection boundary —
 ;; the layer the prior synthetic `reactive-epoch` masked. They drive a REAL
-;; `:rf.view/rendered` trace event through `capture/render-row` and assert
+;; `:rf.view/rendered` trace event through `rf.epoch.capture/render-row` and assert
 ;; the `:view` causal surface reads the cause-attributed render. Pre-fix
 ;; (render-row dropping `:rf.view/cause-event-id`) the row carries no
 ;; `:cause-event-id`, so `causal-count` / `reactive-counts` :by-cause credit
@@ -668,16 +668,16 @@
 ;; green). Post-fix the row carries it and both judge correctly.
 
 (deftest render-row-projection-carries-cause-event-id
-  (testing "capture/render-row threads :rf.view/cause-event-id off the
+  (testing "rf.epoch.capture/render-row threads :rf.view/cause-event-id off the
             :rf.view/rendered trace event (mirroring the sub-row, rf2-9gquv)"
-    (let [row (capture/render-row (rendered-trace-event :counter :counter/inc))]
+    (let [row (rf.epoch.capture/render-row (rendered-trace-event :counter :counter/inc))]
       (is (= :counter/inc (:cause-event-id row))
           "the render row MUST carry the cause-event-id the trace event stamped")
       (is (= [:counter 0] (:render-key row)))))
 
   (testing "a render with NO cause tag (mount / structural) omits the slot —
             OMITTED-vs-nil parity with the sub-row"
-    (let [row (capture/render-row {:operation :rf.view/rendered
+    (let [row (rf.epoch.capture/render-row {:operation :rf.view/rendered
                                    :tags {:rf.view/render-key [:counter 0]
                                           :rf.view/id :counter}})]
       (is (not (contains? row :cause-event-id))
@@ -691,7 +691,7 @@
     ;; the default [0 0] bound → silent PASS (the false green). Post-fix the
     ;; rows carry the cause → measured 3 > 0 → the over-render FAILS as it must.
     (let [tape [(reactive-epoch :counter/inc :total 1 :counter 3)]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :causal-expectations
                   [[:rf.assert/no-cascade-rerender {:event :counter/inc :view :counter}]]})
@@ -703,7 +703,7 @@
 
   (testing "a genuine cause IS credited to the view by :rf.assert/caused {:view}"
     (let [tape [(reactive-epoch :counter/inc :total 1 :counter 2)]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :causal-expectations
                   [[:rf.assert/caused {:event :counter/inc :view :counter}]]})
@@ -713,7 +713,7 @@
 
   (testing "the :by-cause evidence credits view-renders to the cause (not nil)"
     (let [tape    [(reactive-epoch :counter/inc :total 1 :counter 2)]
-          rc      (evidence/reactive-counts tape)
+          rc      (rf.story.play.evidence/reactive-counts tape)
           credited (get (:by-cause rc) :counter/inc)]
       (is (= 2 (:view-renders credited))
           "the projected render rows key on :counter/inc, not nil")
@@ -724,7 +724,7 @@
             :cannot-run (fail closed — never a silent pass)"
     ;; A bare dispatch-only tape carries no :reactive-counts slot.
     (let [tape [(epoch {:effects [{:fx-id :db :outcome :ok}]})]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :causal-expectations [[:rf.assert/caused {:event :counter/inc}]]})
           rec  (first (filter #(= :rf.assert/caused (:assertion %)) (:assertions r)))]
@@ -738,7 +738,7 @@
     ;; A reactive tape with no schema/effect failure + NO causal expectation
     ;; is a clean :pass, even with many renders.
     (let [tape [(reactive-epoch :counter/inc :total 5 :counter 9)]
-          r    (result/run-result {:epoch-tape tape})]
+          r    (rf.story.result/run-result {:epoch-tape tape})]
       (is (= :pass (:status r)) "renders alone are not a tape failure"))))
 
 ;; ===========================================================================
@@ -772,7 +772,7 @@
     ;; rather than refusing on the reactive-slot check — but :search/run is
     ;; NOT in the tape, so its premise is unmet.
     (let [tape [(reactive-epoch :other/event :total 1 :counter 1)]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:variant/id :story.search/box
                   :epoch-tape tape
                   :causal-expectations
@@ -792,9 +792,9 @@
       (is (= {:cannot-run 1} (frequencies (map :status (:assertions r))))
           "summary buckets: total 1, cannot-run 1, passed 0, failed 0")
       ;; --- the frozen RunResult contract still validates ---
-      (is (result/valid-run-result? r))
+      (is (rf.story.result/valid-run-result? r))
       ;; --- result->reports emits a host :fail (the cannot-run bridge) ---
-      (is (some #(= :fail (:type %)) (result/result->reports r))
+      (is (some #(= :fail (:type %)) (rf.story.result/result->reports r))
           "a :cannot-run assertion reports a host :fail, never a silent pass"))))
 
 (deftest no-cascade-observed-cause-zero-renders-passes
@@ -804,7 +804,7 @@
     ;; (:other/event) supplies the reactive evidence the run needs.
     (let [tape [(cause-epoch :search/run)
                 (reactive-epoch :other/event :total 1 :counter 1)]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :causal-expectations
                   [[:rf.assert/no-cascade-rerender {:event :search/run :view :results}]]})
@@ -818,7 +818,7 @@
             similarly-named event does not count"
     (let [tape [(cause-epoch :search/run-all)      ; NOT :search/run
                 (reactive-epoch :other/event :total 1 :counter 1)]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :causal-expectations
                   [[:rf.assert/no-cascade-rerender {:event :search/run :view :results}]]})
@@ -834,7 +834,7 @@
     (let [tape [(reactive-epoch :counter/inc :total 1 :counter 1)
                 (reactive-epoch :counter/inc :total 1 :counter 1)
                 (reactive-epoch :counter/inc :total 1 :counter 1)]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :causal-expectations
                   [[:rf.assert/no-cascade-rerender {:event :counter/inc :view :counter}]]})
@@ -851,7 +851,7 @@
                         :trigger-event        [:login/submit "hunter2"]
                         :rf.epoch/sensitive?  true})
                 (reactive-epoch :other/event :total 1 :counter 1)]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :causal-expectations
                   [[:rf.assert/no-cascade-rerender {:event :login/submit :view :dashboard}]]})
@@ -872,13 +872,13 @@
           ;; (record-result-map keeps only records newer than the baseline).
           prior   [(cause-epoch :search/run)]
           rec-current  (no-cascade-rec
-                         (result/run-result {:epoch-tape current
+                         (rf.story.result/run-result {:epoch-tape current
                                              :causal-expectations [decl]}))
           ;; Had the prior record been (wrongly) included, the premise WOULD
           ;; be met — proving the isolation boundary IS the slice, not the
           ;; matcher silently reaching back.
           rec-combined (no-cascade-rec
-                         (result/run-result {:epoch-tape (into prior current)
+                         (rf.story.result/run-result {:epoch-tape (into prior current)
                                              :causal-expectations [decl]}))]
       (is (= 0 (get-in rec-current [:actual :observed-cause-count])))
       (is (= :cannot-run (:status rec-current))
@@ -890,7 +890,7 @@
   (testing "{:require-cause? false} lets an unobserved cause pass vacuously
             under [0,0], with a reason stating the vacuity was explicit"
     (let [tape [(reactive-epoch :other/event :total 1 :counter 1)]  ; reactive, no :maybe/fires
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :causal-expectations
                   [[:rf.assert/no-cascade-rerender
@@ -902,7 +902,7 @@
 
   (testing ":min 0 does NOT double as an implicit opt-out (still :cannot-run)"
     (let [tape [(reactive-epoch :other/event :total 1 :counter 1)]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :causal-expectations
                   [[:rf.assert/no-cascade-rerender {:event :maybe/fires :min 0}]]})
@@ -919,7 +919,7 @@
     ;; tape', never a claim the cause never fired NOR a silent green.
     (let [retained [(reactive-epoch :other/event :total 1 :counter 1)
                     (reactive-epoch :nav/go      :total 1 :counter 1)]
-          r        (result/run-result
+          r        (rf.story.result/run-result
                      {:epoch-tape retained
                       :causal-expectations
                       [[:rf.assert/no-cascade-rerender {:event :search/run :view :results}]]})
@@ -933,7 +933,7 @@
             its positive-claim verdict is UNCHANGED (n=0 with reactive
             evidence still :fail, never :cannot-run)"
     (let [tape [(reactive-epoch :counter/inc :total 1 :counter 1)]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :causal-expectations
                   [[:rf.assert/caused {:event :counter/inc :view :sidebar}]]})
@@ -948,7 +948,7 @@
   (testing ":caused never gates on an unobserved cause — a cause absent from a
             reactive tape is :fail (n=0 < min 1), never :cannot-run"
     (let [tape [(reactive-epoch :other/event :total 1 :counter 1)]
-          r    (result/run-result
+          r    (rf.story.result/run-result
                  {:epoch-tape tape
                   :causal-expectations [[:rf.assert/caused {:event :counter/inc}]]})
           rec  (first (filter #(= :rf.assert/caused (:assertion %)) (:assertions r)))]
@@ -968,7 +968,7 @@
 ;; A min-only expectation is UNAFFECTED (lost effects only lower the count, so
 ;; an in-bounds min-only pass stays honest). These tests drive the PURE
 ;; result assembly directly with `:epoch-truncated?` — the runtime computes
-;; the flag from the real ring (`evidence/run-tape-truncated?`, unit-tested in
+;; the flag from the real ring (`rf.story.play.evidence/run-tape-truncated?`, unit-tested in
 ;; evidence_test).
 
 (deftest no-cascade-truncation-in-bounds-is-cannot-run
@@ -983,10 +983,10 @@
     (let [tape [(reactive-epoch :counter/inc :total 1 :counter 1)]
           decl [[:rf.assert/no-cascade-rerender {:event :counter/inc :view :results}]]
           ;; fully-retained window (control): the existing bounds :pass stands.
-          r-complete  (result/run-result
+          r-complete  (rf.story.result/run-result
                         {:epoch-tape tape :causal-expectations decl})
           ;; truncated window (teeth): the same in-bounds count → :cannot-run.
-          r-truncated (result/run-result
+          r-truncated (rf.story.result/run-result
                         {:variant/id :story.counter/badge
                          :epoch-tape tape :causal-expectations decl
                          :epoch-truncated? true})
@@ -1009,8 +1009,8 @@
           "distinct from the unobserved-cause reason (the cause here was observed)")
       ;; --- run aggregation + frozen contract + host bridge ---
       (is (= :cannot-run (:status r-truncated)) "the run aggregates to :cannot-run")
-      (is (result/valid-run-result? r-truncated))
-      (is (some #(= :fail (:type %)) (result/result->reports r-truncated))
+      (is (rf.story.result/valid-run-result? r-truncated))
+      (is (some #(= :fail (:type %)) (rf.story.result/result->reports r-truncated))
           "a :cannot-run assertion reports a host :fail, never a silent pass"))))
 
 (deftest caused-explicit-max-truncation-is-cannot-run
@@ -1019,8 +1019,8 @@
     (let [tape [(reactive-epoch :counter/inc :total 0 :badge 2)]   ; 2 :badge renders
           decl [[:rf.assert/caused {:event :counter/inc :view :badge :max 3}]]
           rec  (fn [r] (first (filter #(= :rf.assert/caused (:assertion %)) (:assertions r))))
-          r-complete  (rec (result/run-result {:epoch-tape tape :causal-expectations decl}))
-          r-truncated (rec (result/run-result
+          r-complete  (rec (rf.story.result/run-result {:epoch-tape tape :causal-expectations decl}))
+          r-truncated (rec (rf.story.result/run-result
                              {:epoch-tape tape :causal-expectations decl
                               :epoch-truncated? true}))]
       (is (= :pass (:status r-complete)) "n=2 ∈ [1,3] passes on a complete tape")
@@ -1035,7 +1035,7 @@
     (let [tape [(reactive-epoch :counter/inc :total 3 :counter 0)]  ; 3 :total recomputes
           decl [[:rf.assert/caused {:event :counter/inc :sub :total}]]
           rec  (fn [r] (first (filter #(= :rf.assert/caused (:assertion %)) (:assertions r))))
-          r-truncated (rec (result/run-result
+          r-truncated (rec (rf.story.result/run-result
                              {:epoch-tape tape :causal-expectations decl
                               :epoch-truncated? true}))]
       (is (= :pass (:status r-truncated))
@@ -1049,7 +1049,7 @@
     (let [tape [(reactive-epoch :counter/inc :total 0 :results 3)]  ; 3 :results renders
           decl [[:rf.assert/no-cascade-rerender {:event :counter/inc :view :results}]]
           rec  (no-cascade-rec
-                 (result/run-result {:epoch-tape tape :causal-expectations decl
+                 (rf.story.result/run-result {:epoch-tape tape :causal-expectations decl
                                      :epoch-truncated? true}))]
       (is (= :fail (:status rec))
           "n=3 > [0,0] is a genuine over-render — truncation does not convert it to :cannot-run")
@@ -1066,8 +1066,8 @@
                          {:op-type :warn :operation :rf.warning/x :tags {:category :perf}}]
                         :effects [{:fx-id :http :outcome :ok}]
                         :renders [{:view :v}]})]
-          r        (result/run-result {:epoch-tape tape})
-          expected (evidence/project-evidence tape nil)]
+          r        (rf.story.result/run-result {:epoch-tape tape})
+          expected (rf.story.play.evidence/project-evidence tape nil)]
       (is (= (:schema-violations expected) (:schema-violations r)))
       (is (= (:warnings expected)          (:warnings r)))
       (is (= (:effects expected)           (:effects r)))
@@ -1077,8 +1077,8 @@
 
 (deftest zero-assertion-clean-run-is-vacuously-green
   (testing "a run with no assertions + a clean tape is :pass (the duality)"
-    (is (= :pass (:status (result/run-result {:epoch-tape [(epoch {})]}))))
-    (is (= :pass (:status (result/run-result {}))))))
+    (is (= :pass (:status (rf.story.result/run-result {:epoch-tape [(epoch {})]}))))
+    (is (= :pass (:status (rf.story.result/run-result {}))))))
 
 ;; ===========================================================================
 ;; clojure.test / cljs.test BRIDGE PROJECTION — story/is reports per assertion
@@ -1086,12 +1086,12 @@
 
 (deftest result->reports-one-per-assertion
   (testing "story/is emits one report per assertion record (§B5)"
-    (let [r       (result/run-result
+    (let [r       (rf.story.result/run-result
                     {:assertions [{:assertion :rf.assert/path-equals :payload [[:a] 1]
                                    :passed? true}
                                   {:assertion :rf.assert/path-equals :payload [[:b] 2]
                                    :passed? false :expected 2 :actual 3}]})
-          reports (result/result->reports r)]
+          reports (rf.story.result/result->reports r)]
       (is (= 2 (count reports)) "one report per assertion")
       (is (= :pass (:type (first reports))))
       (is (= :fail (:type (second reports))))
@@ -1101,11 +1101,11 @@
 (deftest result->reports-cannot-run-reports-fail
   (testing "a :cannot-run assertion reports :fail (the runner proved nothing —
             never a silent pass)"
-    (let [r       (result/run-result
+    (let [r       (rf.story.result/run-result
                     {:assertions [{:assertion :rf.assert/visual-snapshot
                                    :status :cannot-run :passed? false
                                    :reason "needs :browser"}]})
-          reports (result/result->reports r)]
+          reports (rf.story.result/result->reports r)]
       (is (= :fail (:type (first reports))))
       (is (re-find #":cannot-run" (:message (first reports)))))))
 
@@ -1116,13 +1116,13 @@
             :assertions, so gating the run-level report on
             (empty? assertions) let the passing assertion's report stand
             alone and mask the refusal"
-    (let [refusal (requirements/requirement-refusal
+    (let [refusal (rf.story.requirements/requirement-refusal
                     #{:pixels} #{:app-db} [:rf.assert/visual-snapshot]
                     :runner-lacks-capability :headless)
-          r       (result/run-result
+          r       (rf.story.result/run-result
                     {:assertions [{:assertion :rf.assert/path-equals :passed? true}]
                      :unmet      [refusal]})
-          reports (result/result->reports r)]
+          reports (rf.story.result/result->reports r)]
       (is (= :cannot-run (:status r)) "the run verdict is :cannot-run")
       (is (= 2 (count reports))
           "one per-assertion pass + one run-level :cannot-run — not just the pass")
@@ -1134,7 +1134,7 @@
 (deftest result->reports-zero-assertion-pass-emits-one-pass
   (testing "a vacuous-green run emits ONE run-level pass so the test sees a
             positive signal"
-    (let [reports (result/result->reports (result/run-result {}))]
+    (let [reports (rf.story.result/result->reports (rf.story.result/run-result {}))]
       (is (= 1 (count reports)))
       (is (= :pass (:type (first reports)))))))
 
@@ -1144,10 +1144,10 @@
     (let [tape [(epoch {:trace-events
                         [{:operation :rf.error/schema-validation-failure
                           :tags {:where :event :failing-id :x}}]})]
-          r       (result/run-result
+          r       (rf.story.result/run-result
                     {:epoch-tape tape
                      :assertions [{:assertion :rf.assert/path-equals :passed? true}]})
-          reports (result/result->reports r)]
+          reports (rf.story.result/result->reports r)]
       (is (= :fail (:status r)))
       ;; one per-assertion pass + one run-level floor fail
       (is (= 2 (count reports)))
@@ -1163,7 +1163,7 @@
             tallied zero → the MOST SEVERE verdict a run can carry read GREEN.
             This is the public-projection path story/is drives for an
             already-resolved result (story.cljc sync branch)."
-    (let [reports (result/result->reports {:status :error :assertions []})]
+    (let [reports (rf.story.result/result->reports {:status :error :assertions []})]
       (is (seq reports)
           "an :error run must NOT project to zero reports (that reads green)")
       (is (= 1 (count reports)) "exactly one run-level error report")
@@ -1181,7 +1181,7 @@
                    :assertions [{:assertion :rf.assert/path-equals
                                  :status :error :passed? false
                                  :reason "handler threw"}]}
-          reports (result/result->reports r)
+          reports (rf.story.result/result->reports r)
           errors  (filterv #(= :error (:type %)) reports)]
       (is (= 1 (count reports))
           "no extra run-level report appended when an assertion carries the error")
@@ -1191,11 +1191,11 @@
           "the single report is the assertion's :error projection"))))
 
 (deftest passed?-only-pass
-  (testing "result/passed? is true ONLY for :pass — :cannot-run is not a pass"
-    (is (true?  (result/passed? {:status :pass})))
-    (is (false? (result/passed? {:status :fail})))
-    (is (false? (result/passed? {:status :cannot-run})))
-    (is (false? (result/passed? {:status :error})))))
+  (testing "rf.story.result/passed? is true ONLY for :pass — :cannot-run is not a pass"
+    (is (true?  (rf.story.result/passed? {:status :pass})))
+    (is (false? (rf.story.result/passed? {:status :fail})))
+    (is (false? (rf.story.result/passed? {:status :cannot-run})))
+    (is (false? (rf.story.result/passed? {:status :error})))))
 
 ;; ===========================================================================
 ;; THE FROZEN SCHEMA-BACKED CONTRACT  (rf2-3nbl5.6)
@@ -1214,28 +1214,28 @@
                    {:epoch-tape [(epoch {:trace-events
                                          [{:operation :rf.error/schema-validation-failure
                                            :tags {:where :event :failing-id :x}}]})]}]]
-      (let [r (result/run-result parts)]
-        (is (result/valid-run-result? r)
-            (str "assembled result must conform: " (pr-str (result/explain-run-result r))))))))
+      (let [r (rf.story.result/run-result parts)]
+        (is (rf.story.result/valid-run-result? r)
+            (str "assembled result must conform: " (pr-str (rf.story.result/explain-run-result r))))))))
 
 (deftest run-result-schema-pins-the-verdict-and-rejects-passing
   (testing ":status is required and must be one of the four verdicts"
-    (is (result/valid-run-result? {:status :pass :assertions [] :checks [] :consumed-selectors #{}}))
-    (is (not (result/valid-run-result? {:status :green :assertions [] :checks [] :consumed-selectors #{}}))
+    (is (rf.story.result/valid-run-result? {:status :pass :assertions [] :checks [] :consumed-selectors #{}}))
+    (is (not (rf.story.result/valid-run-result? {:status :green :assertions [] :checks [] :consumed-selectors #{}}))
         "an unknown verdict is rejected")
-    (is (not (result/valid-run-result? {:assertions [] :checks [] :consumed-selectors #{}}))
+    (is (not (rf.story.result/valid-run-result? {:assertions [] :checks [] :consumed-selectors #{}}))
         ":status is required — there is no verdict-less result"))
   (testing "the load-bearing slots are required"
-    (is (not (result/valid-run-result? {:status :pass}))
+    (is (not (rf.story.result/valid-run-result? {:status :pass}))
         ":assertions / :checks / :consumed-selectors are part of the contract")))
 
 (deftest assertion-and-check-records-carry-the-frozen-status
   (testing "assertion records validate with a unified :status"
-    (is (m/validate result/AssertionRecord
+    (is (m/validate rf.story.result/AssertionRecord
                     {:assertion :rf.assert/path-equals :status :fail :passed? false}))
-    (is (not (m/validate result/AssertionRecord
+    (is (not (m/validate rf.story.result/AssertionRecord
                          {:assertion :rf.assert/path-equals :passed? false}))
         ":status is the verdict — an assertion record without it does not conform"))
   (testing "check records group assertion records under a :status"
-    (is (m/validate result/CheckRecord
+    (is (m/validate rf.story.result/CheckRecord
                     {:check :checks/cart :status :pass :assertions []}))))

--- a/tools/story/test/re_frame/story/run_owner_cljc_test.cljc
+++ b/tools/story/test/re_frame/story/run_owner_cljc_test.cljc
@@ -11,23 +11,23 @@
   pin that the script now executes EXACTLY ONCE.
 
   Runs on BOTH runtimes: the play-scripts are pure `:dispatch-sync`, which
-  `async/promise` executes synchronously, so the frame's app-db and the
+  `rf.story.async/promise` executes synchronously, so the frame's app-db and the
   external-effect counter are settled the instant `resume-run!` returns — no
   awaiting needed. The one supersession test that needs an async barrier is
   JVM-gated (it blocks a thread)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story :as story]
-            [re-frame.story.loaders :as loaders]
-            [re-frame.story.play :as legacy-play]
-            [re-frame.story.play.runner-events :as re]
-            [re-frame.story.runtime :as rt]
-            #?@(:clj [[re-frame.story.async :as async]
-                      [re-frame.story.config :as config]])))
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.loaders :as rf.story.loaders]
+            [re-frame.story.play :as rf.story.play]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]
+            [re-frame.story.runtime :as rf.story.runtime]
+            #?@(:clj [[re-frame.story.async :as rf.story.async]
+                      [re-frame.story.config :as rf.story.config]])))
 
 ;; ---- external-effect counter (an irreversible effect proxy) --------------
 ;;
@@ -39,21 +39,21 @@
 (def ^:private ext-effect-count (atom 0))
 
 (defn- reset-all! [test-fn]
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
   #?(:clj (require 're-frame.machines :reload))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  #?(:clj (config/set-global-args! {}))
-  (reset! legacy-play/stepper-state {})
-  (reset! re/run-state {})
-  (reset! re/step-boundaries {})
-  (rt/reset-run-owner!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  #?(:clj (rf.story.config/set-global-args! {}))
+  (reset! rf.story.play/stepper-state {})
+  (reset! rf.story.play.runner-events/run-state {})
+  (reset! rf.story.play.runner-events/step-boundaries {})
+  (rf.story.runtime/reset-run-owner!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (reset! ext-effect-count 0)
   (rf/reg-fx :probe/external-effect (fn [_ _] (swap! ext-effect-count inc)))
   (rf/reg-event :probe/inc-and-effect
@@ -72,7 +72,7 @@
   "Register a cumulative-counter variant: seed 0, increment three times (each
   increment also issues the external effect), assert final `:count` = 3."
   [vid]
-  (story/reg-variant vid
+  (rf.story/reg-variant vid
     {:setup      [[:counter/initialise 0]]
      :script [[:dispatch-sync [:probe/inc-and-effect]]
                    [:dispatch-sync [:probe/inc-and-effect]]
@@ -82,14 +82,14 @@
 (defn- run-key-for [vid tag] {:variant-id vid :cell-overrides tag})
 
 (defn- prepare! [vid tag]
-  (rt/prepare-run! vid {:run-key (run-key-for vid tag)}))
+  (rf.story.runtime/prepare-run! vid {:run-key (run-key-for vid tag)}))
 
 (defn- resume!
   "Call the single run owner's resume. The play-scripts here are pure
-  `:dispatch-sync`, so `async/promise` runs the script synchronously and the
+  `:dispatch-sync`, so `rf.story.async/promise` runs the script synchronously and the
   frame's app-db is settled the instant this returns — no await needed."
   [vid]
-  (rt/resume-run! vid))
+  (rf.story.runtime/resume-run! vid))
 
 (defn- count-of [vid] (:count (rf/app-db-value vid)))
 
@@ -110,10 +110,10 @@
       ;; frame is ready + rendered clean at seed 0, but the script has NOT run
       (is (= 0 (count-of vid)) "prepare did not run the script")
       (is (zero? @ext-effect-count) "prepare issued no external effect")
-      (is (= 1 (rt/current-generation vid)) "one generation claimed")
+      (is (= 1 (rf.story.runtime/current-generation vid)) "one generation claimed")
       ;; 2. canvas component-did-mount — PREPARE again (same run-key ⇒ dedup)
       (prepare! vid :a)
-      (is (= 1 (rt/current-generation vid))
+      (is (= 1 (rf.story.runtime/current-generation vid))
           "the canvas re-prepare for the same run-key did NOT bump the generation")
       (is (= 0 (count-of vid)) "the dedup prepare did not reset+rerun anything")
       ;; 3. canvas post-commit resume — the single run owner
@@ -124,8 +124,8 @@
           "exactly one passing assertion record — never a second, contradictory one")
       ;; 4. the mount-time block + the shell selection-watcher's setTimeout both
       ;;    ALSO call resume for this generation — every extra call is a no-op.
-      (is (nil? (rt/resume-run! vid)) "second resume for the same generation is a no-op")
-      (is (nil? (rt/resume-run! vid)) "third resume for the same generation is a no-op")
+      (is (nil? (rf.story.runtime/resume-run! vid)) "second resume for the same generation is a no-op")
+      (is (nil? (rf.story.runtime/resume-run! vid)) "third resume for the same generation is a no-op")
       (is (= 3 (count-of vid)) "count is still 3 — no double-count to 6")
       (is (= 3 @ext-effect-count) "the external effect still fired exactly 3 times")
       (is (= 1 (count (passing-assertions vid)))
@@ -141,7 +141,7 @@
       (prepare! vid :a)
       ;; frame exists (subs can deref) and lifecycle is renderable
       (is (some? (rf/app-db-value vid)) "the frame is allocated before any resume")
-      (is (= :ready (loaders/current-state vid)) "the frame reached :ready in prepare")
+      (is (= :ready (rf.story.loaders/current-state vid)) "the frame reached :ready in prepare")
       ;; but the script has not run
       (is (= 0 (count-of vid)) "seed 0, no play-script increments yet")
       (is (zero? @ext-effect-count) "no external effect issued by prepare")
@@ -160,7 +160,7 @@
       (is (= 3 @ext-effect-count))
       ;; run-key changes → fresh generation, fresh reset+run
       (prepare! vid :b)
-      (is (= 2 (rt/current-generation vid)) "changed run-key bumped the generation")
+      (is (= 2 (rf.story.runtime/current-generation vid)) "changed run-key bumped the generation")
       (is (= 0 (count-of vid)) "the fresh prepare reset the frame to seed 0")
       (resume! vid)
       (is (= 3 (count-of vid)) "the new generation ran the script once: 0 -> 3")
@@ -176,11 +176,11 @@
       (reg-cumulative! vid)
       (prepare! vid :a)
       (resume! vid)
-      (is (= 1 (rt/current-generation vid)))
+      (is (= 1 (rf.story.runtime/current-generation vid)))
       (is (= 3 @ext-effect-count))
       ;; remount: same run-key, but the generation was already resumed
       (prepare! vid :a)
-      (is (= 2 (rt/current-generation vid)) "post-resume re-prepare bumped the generation")
+      (is (= 2 (rf.story.runtime/current-generation vid)) "post-resume re-prepare bumped the generation")
       (is (= 0 (count-of vid)) "the remount reset the frame")
       (resume! vid)
       (is (= 3 (count-of vid)))
@@ -198,8 +198,8 @@
       ;; interleave the two variants' prepare/resume owners
       (prepare! a :a)
       (prepare! b :a)
-      (is (= 1 (rt/current-generation a)))
-      (is (= 1 (rt/current-generation b)))
+      (is (= 1 (rf.story.runtime/current-generation a)))
+      (is (= 1 (rf.story.runtime/current-generation b)))
       (resume! a)
       (is (= 3 (count-of a)) "A ran to 3")
       (is (= 0 (count-of b)) "B is untouched by A's run")
@@ -211,19 +211,19 @@
 ;; ---- (6) the public headless run-variant is unchanged --------------------
 
 (deftest public-run-variant-still-runs-full-once
-  (testing "the headless `story/run-variant` (test-mode / MCP / sidebar
+  (testing "the headless `rf.story/run-variant` (test-mode / MCP / sidebar
             Run-all) is byte-for-byte the old full run: script once, count 3"
     (let [vid :story.owner/headless]
       (reg-cumulative! vid)
       #?(:clj
-         (let [result (async/deref-blocking (story/run-variant vid) 5000)]
+         (let [result (rf.story.async/deref-blocking (rf.story/run-variant vid) 5000)]
            (is (= :ready (:lifecycle result)))
            (is (= 3 (:count (:app-db result))) "one full run: count 3")
            (is (= 3 @ext-effect-count) "one full run's effects")
            (is (= :pass (:status result)) "the passing variant greens"))
          :cljs
          ;; CLJS: the sync script settles the frame synchronously; read it back.
-         (do (story/run-variant vid)
+         (do (rf.story/run-variant vid)
              (is (= 3 (count-of vid)) "one full run: count 3")
              (is (= 3 @ext-effect-count) "one full run's effects"))))))
 
@@ -240,7 +240,7 @@
              wait 250]
          ;; The variant waits, then increments once (issuing the external
          ;; effect), then asserts. The wait opens the supersession window.
-         (story/reg-variant vid
+         (rf.story/reg-variant vid
            {:setup      [[:counter/initialise 0]]
             :script [[:wait wait]
                           [:dispatch-sync [:probe/inc-and-effect]]
@@ -249,19 +249,19 @@
          ;; that thread through the [:wait] (JVM waits are Thread/sleep), so the
          ;; future's value is A's settled result-promise.
          (prepare! vid :a)
-         (let [gen-a (rt/current-generation vid)
-               fut   (future (rt/resume-run! vid))]
+         (let [gen-a (rf.story.runtime/current-generation vid)
+               fut   (future (rf.story.runtime/resume-run! vid))]
            (is (= 1 gen-a))
            ;; Let A reach its wait, then supersede: a fresh run-key bumps the
            ;; generation, resets the frame, and B's resume stamps a NEW
            ;; run-token — which A's run-loop sees on wake and aborts against.
            (Thread/sleep 60)
            (prepare! vid :b)
-           (is (= 2 (rt/current-generation vid)) "B claimed a fresh generation")
-           (let [b-prom   (rt/resume-run! vid)
+           (is (= 2 (rf.story.runtime/current-generation vid)) "B claimed a fresh generation")
+           (let [b-prom   (rf.story.runtime/resume-run! vid)
                  a-prom   @fut
-                 a-result (async/deref-blocking a-prom 5000)
-                 b-result (async/deref-blocking b-prom 5000)]
+                 a-result (rf.story.async/deref-blocking a-prom 5000)
+                 b-result (rf.story.async/deref-blocking b-prom 5000)]
              (is (not= :pass (:status a-result))
                  "the superseded run A must NOT return :pass")
              (is (true? (:superseded? a-result))

--- a/tools/story/test/re_frame/story/runtime_db_seed_test.clj
+++ b/tools/story/test/re_frame/story/runtime_db_seed_test.clj
@@ -3,7 +3,7 @@
 
   `:db-seed` is the MIDDLE rung of spec/017's fidelity ladder
   (`#{:real-setup :db-seed :sub-overrides}`): a schema-checked direct
-  app-db seed. These tests drive `story/run` to terminal on the JVM and
+  app-db seed. These tests drive `rf.story/run` to terminal on the JVM and
   assert the runtime BEHAVIOUR the plan compiler can't (the seed is
   applied to a live frame; the seeded app-db is schema-validated):
 
@@ -30,11 +30,11 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [malli.core         :as m]
             [re-frame.core      :as rf]
-            [re-frame.frame     :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story     :as story]))
+            [re-frame.frame     :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story     :as rf.story]))
 
 ;; ---- a host-free stand-in for the schemas artefact's late-bind seam ------
 ;;
@@ -49,31 +49,31 @@
   (swap! frame-schemas assoc-in [frame-id reg-path] {:schema schema}))
 
 (defn- install-schema-seam! []
-  (late-bind/set-fn! :schemas/frame-schema-entries
+  (rf.late-bind/set-fn! :schemas/frame-schema-entries
                      (fn [frame-id] (get @frame-schemas frame-id {})))
-  (late-bind/set-fn! :schemas/validate-with-registered-fn
+  (rf.late-bind/set-fn! :schemas/validate-with-registered-fn
                      (fn [schema value] (m/validate schema value)))
-  (late-bind/set-fn! :schemas/explain-with-registered-fn
+  (rf.late-bind/set-fn! :schemas/explain-with-registered-fn
                      (fn [schema value] (m/explain schema value))))
 
 (defn- uninstall-schema-seam! []
-  (swap! late-bind/hooks dissoc
+  (swap! rf.late-bind/hooks dissoc
          :schemas/frame-schema-entries
          :schemas/validate-with-registered-fn
          :schemas/explain-with-registered-fn))
 
 (defn- reset-rf! [test-fn]
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
   (reset! frame-schemas {})
-  (try (rf/init! plain-atom/adapter)
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
   ;; Clear any schema seam a prior test left so the no-validator floor case
   ;; is clean; tests that want validation install it explicitly.
   (uninstall-schema-seam!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (rf/reg-event :cart/add-item
                    (fn [{:keys [db]} [_ item]]
                      {:db (update-in db [:cart :items] (fnil conj []) item)}))
@@ -82,8 +82,8 @@
 (use-fixtures :each reset-rf!)
 
 (defn- run-target
-  ([target] (.get ^java.util.concurrent.CompletableFuture (story/run target)))
-  ([target opts] (.get ^java.util.concurrent.CompletableFuture (story/run target opts))))
+  ([target] (.get ^java.util.concurrent.CompletableFuture (rf.story/run target)))
+  ([target opts] (.get ^java.util.concurrent.CompletableFuture (rf.story/run target opts))))
 
 (defn- seed-error-record [result]
   (first (filter #(= :rf.error/story-db-seed-invalid (:assertion %))
@@ -96,13 +96,13 @@
 (deftest db-seed-is-accepted-by-the-variant-schema
   (testing "reg-variant ACCEPTS a well-shaped :db-seed (the typed slot — the
             pre-rf2-blw1q bug was silent-accept-then-ignore)"
-    (is (some? (story/reg-variant :story.cart/typed {:db-seed {:cart {:items []}}}))
+    (is (some? (rf.story/reg-variant :story.cart/typed {:db-seed {:cart {:items []}}}))
         "a {path → value} :db-seed registers without a shape error")))
 
 (deftest malformed-db-seed-is-rejected-by-the-variant-schema
   (testing "a non-map :db-seed is REJECTED at registration (no longer silently
             accepted) — :rf.error/variant-shape"
-    (let [ex (try (story/reg-variant :story.cart/malformed {:db-seed [1 2 3]})
+    (let [ex (try (rf.story/reg-variant :story.cart/malformed {:db-seed [1 2 3]})
                   nil
                   (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex) "a non-map :db-seed throws a shape error")
@@ -115,7 +115,7 @@
 (deftest valid-db-seed-seeds-app-db-before-script
   (testing "a valid :db-seed merges into the frame's app-db BEFORE the script,
             and a :real-setup event runs ON TOP of the seed (the ladder composes)"
-    (story/reg-variant
+    (rf.story/reg-variant
       :story.cart/seeded
       {:db-seed {:cart {:items [{:sku "A" :qty 1}]}}
        :script  [[:dispatch-sync [:cart/add-item {:sku "B" :qty 2}]]]})
@@ -134,7 +134,7 @@
     (install-schema-seam!)
     (reg-app-schema! :story.cart/ok [:cart]
                      [:map [:items [:vector [:map [:sku :string] [:qty :int]]]]])
-    (story/reg-variant
+    (rf.story/reg-variant
       :story.cart/ok
       {:db-seed {:cart {:items [{:sku "A" :qty 1}]}}})
     (let [result (run-target :story.cart/ok)]
@@ -153,7 +153,7 @@
     (install-schema-seam!)
     (reg-app-schema! :story.cart/bad [:cart]
                      [:map [:items [:vector [:map [:sku :string] [:qty :int]]]]])
-    (story/reg-variant
+    (rf.story/reg-variant
       :story.cart/bad
       ;; :qty is a string — violates [:qty :int].
       {:db-seed {:cart {:items [{:sku "A" :qty "two"}]}}})
@@ -177,7 +177,7 @@
     (install-schema-seam!)
     (reg-app-schema! :story.cart/halt [:cart]
                      [:map [:items [:vector :map]]])
-    (story/reg-variant
+    (rf.story/reg-variant
       :story.cart/halt
       {:db-seed {:cart {:items "not-a-vector"}}
        :script  [[:dispatch-sync [:cart/add-item {:sku "Z"}]]]})
@@ -195,7 +195,7 @@
             unchecked (the host-free floor) — Story without the schemas
             artefact pays nothing"
     ;; The fixture left the schema seam UNINSTALLED.
-    (story/reg-variant
+    (rf.story/reg-variant
       :story.cart/nohost
       {:db-seed {:cart {:items [{:sku "A" :qty "even-a-string-is-fine-here"}]}}})
     (let [result (run-target :story.cart/nohost)]

--- a/tools/story/test/re_frame/story/runtime_runpath_test.clj
+++ b/tools/story/test/re_frame/story/runtime_runpath_test.clj
@@ -1,7 +1,7 @@
 (ns re-frame.story.runtime-runpath-test
   "End-to-end run-path wiring tests (rf2-baah3 + rf2-9ikj0).
 
-  These drive `story/run` to terminal on the JVM (where the future resolves
+  These drive `rf.story/run` to terminal on the JVM (where the future resolves
   synchronously) and assert the run-path now THREADS the requirements
   registry + routes the browser-tier a11y-structural executor — the two
   surfaces that existed but were orphaned from the run path:
@@ -19,30 +19,30 @@
     `:hiccup` tier against the rendered hiccup tree (the `:render-hiccup`
     seam); a tier that cannot supply the tree records `:cannot-run`.
 
-  JVM-only (`.clj`): `story/run` returns a `CompletableFuture` that resolves
+  JVM-only (`.clj`): `rf.story/run` returns a `CompletableFuture` that resolves
   synchronously to the unified result. The selection / requirement-function
   unit coverage lives in `re-frame.story.requirements-test`; the browser
   executor unit coverage lives in `re-frame.story.play.browser-test`. This
   suite proves the END-TO-END wiring through the run path."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core      :as rf]
-            [re-frame.frame     :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story     :as story]
-            [re-frame.story.late-bind  :as late-bind]))
+            [re-frame.frame     :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story     :as rf.story]
+            [re-frame.story.late-bind  :as rf.story.late-bind]))
 
 (defn- reset-rf! [test-fn]
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
   ;; Drop any stray :render-hiccup host from a prior test (the run-path
   ;; a11y-structural tier-proof seam) so the no-host :cannot-run case is clean.
-  (swap! late-bind/hooks dissoc :render-hiccup)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (swap! rf.story.late-bind/hooks dissoc :render-hiccup)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (rf/reg-event :rp/set-status (fn [{:keys [db]} [_ v]] {:db (assoc db :status v)}))
   (rf/reg-event :rp/set-value  (fn [{:keys [db]} [_ v]] {:db (assoc db :value v)}))
   (test-fn))
@@ -50,8 +50,8 @@
 (use-fixtures :each reset-rf!)
 
 (defn- run-target
-  ([target] (.get ^java.util.concurrent.CompletableFuture (story/run target)))
-  ([target opts] (.get ^java.util.concurrent.CompletableFuture (story/run target opts))))
+  ([target] (.get ^java.util.concurrent.CompletableFuture (rf.story/run target)))
+  ([target opts] (.get ^java.util.concurrent.CompletableFuture (rf.story/run target opts))))
 
 (defn- a11y-structural-record [result]
   (first (filter #(= :rf.assert/a11y-structural (:assertion %))
@@ -102,7 +102,7 @@
           "an app-db-only plan escalates no further than :headless under :auto"))
     ;; Install a render-hiccup host so a11y-structural can run at :hiccup; the
     ;; selection itself (cheapest = :hiccup for :hiccup-structure) is the point.
-    (late-bind/set-fn! :render-hiccup (fn [_frame] [:div "ok"]))
+    (rf.story.late-bind/set-fn! :render-hiccup (fn [_frame] [:div "ok"]))
     (let [hiccup (run-target {:assertions [[:rf.assert/a11y-structural]]}
                              {:runner :auto})]
       (is (= :hiccup (:runner hiccup))
@@ -130,7 +130,7 @@
             when the tree carries a structural issue (rf2-9ikj0 — the
             previously-orphaned executor is wired in)"
     ;; The host renders a tree with an :img missing :alt — a structural issue.
-    (late-bind/set-fn! :render-hiccup (fn [_frame] [:div [:img {:src "/k.png"}]]))
+    (rf.story.late-bind/set-fn! :render-hiccup (fn [_frame] [:div [:img {:src "/k.png"}]]))
     (let [result (run-target {:script [[:dispatch [:rp/set-status :ready]]
                                        [:assert [:rf.assert/a11y-structural]]]}
                              {:runner :hiccup})]
@@ -144,7 +144,7 @@
 (deftest a11y-structural-evaluates-and-passes-at-hiccup
   (testing "a structurally-clean rendered tree PASSES :rf.assert/a11y-structural
             on the normal :hiccup run path (rf2-9ikj0)"
-    (late-bind/set-fn! :render-hiccup
+    (rf.story.late-bind/set-fn! :render-hiccup
                        (fn [_frame] [:div [:img {:src "/k.png" :alt "a kitten"}]
                                      [:button "Go"]]))
     (let [result (run-target {:script [[:dispatch [:rp/set-status :ready]]
@@ -202,7 +202,7 @@
   (testing "a :cell-override drives an `[:arg …]` placeholder in the SCRIPT;
             the executed app-db AND the reported :effective-args BOTH reflect
             the override value — not the static story arg (rf2-2cpoo)"
-    (story/reg-variant
+    (rf.story/reg-variant
       :story.opts/scripted
       {:args   {:value "static"}
        ;; `[:arg :value]` is resolved at plan-compile time; the run opts must
@@ -224,7 +224,7 @@
   (testing "a :cell-override drives an `[:arg …]` placeholder in the :db-seed;
             the seeded app-db reflects the override, matching :effective-args
             (rf2-2cpoo — db-seed substitution uses the run-opts effective args)"
-    (story/reg-variant
+    (rf.story/reg-variant
       :story.opts/seeded
       {:args    {:value "static"}
        :db-seed {:seeded [:arg :value]}})
@@ -242,8 +242,8 @@
             reported :effective-args BOTH reflect the mode value (rf2-2cpoo —
             mode args fold into plan compilation at `mode < variant` precedence,
             so the mode supplies args the variant leaves open)"
-    (story/reg-mode :Mode.test/big {:args {:value "from-mode"}})
-    (story/reg-variant
+    (rf.story/reg-mode :Mode.test/big {:args {:value "from-mode"}})
+    (rf.story/reg-variant
       :story.opts/moded
       ;; the variant declares NO :value, so the mode's :value flows through
       ;; (precedence `mode < variant`: the mode fills args the variant omits).
@@ -262,8 +262,8 @@
   (testing "precedence holds end-to-end: mode < cell-override; the SCRIPT
             dispatches the override (highest layer), matching :effective-args
             (rf2-2cpoo — the plan folds layers in resolve-args precedence)"
-    (story/reg-mode :Mode.test/mid {:args {:value "from-mode"}})
-    (story/reg-variant
+    (rf.story/reg-mode :Mode.test/mid {:args {:value "from-mode"}})
+    (rf.story/reg-variant
       :story.opts/precedence
       {:args   {:value "static"}
        :script [[:dispatch-sync [:rp/set-value [:arg :value]]]]})
@@ -279,7 +279,7 @@
   (testing "with NO run opts the run still substitutes the STATIC variant args —
             the run-args threading is purely additive (rf2-2cpoo regression
             guard: the absent-opts path is unchanged)"
-    (story/reg-variant
+    (rf.story/reg-variant
       :story.opts/plain
       {:args   {:value "static"}
        :script [[:dispatch-sync [:rp/set-value [:arg :value]]]]})
@@ -307,7 +307,7 @@
             NOT leak the prior run's app-db value (rf2-5fv445)"
     ;; Run 1: a valid variant that seeds app-db with {:value \"old\"} and runs
     ;; to a healthy terminal — the frame ends at :ready with that app-db.
-    (story/reg-variant
+    (rf.story/reg-variant
       :story.stale/v
       {:script [[:dispatch-sync [:rp/set-value "old"]]
                 [:assert [:rf.assert/path-equals [:value] "old"]]]})
@@ -319,7 +319,7 @@
     ;; the variant (and its parents) never declares. Plan construction throws in
     ;; `prepare-context` (before the fresh-frame reset), and the prior frame is
     ;; still registered at :ready.
-    (story/reg-variant
+    (rf.story/reg-variant
       :story.stale/v
       {:script [[:dispatch-sync [:rp/set-value [:arg :missing]]]]})
     (let [result (run-target :story.stale/v)]

--- a/tools/story/test/re_frame/story/sensitive_trace_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/sensitive_trace_cljs_test.cljc
@@ -29,10 +29,10 @@
   `suppress-sensitive?` helper exercised here, and the panel-level
   redaction indicator is verified by the CLJS ui-cljs test arm."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story            :as story]
-            [re-frame.story.config     :as config]
-            [re-frame.story.play       :as play]
-            [re-frame.story.recorder   :as recorder]))
+            [re-frame.story            :as rf.story]
+            [re-frame.story.config     :as rf.story.config]
+            [re-frame.story.play       :as rf.story.play]
+            [re-frame.story.recorder   :as rf.story.recorder]))
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures
@@ -42,11 +42,11 @@
   ;; Always restore the session-pin to the redacting default AND clear every
   ;; per-frame override (rf2-6z4znr) before AND after every test so a failing
   ;; test can't poison the next one.
-  (config/reset-all!)
+  (rf.story.config/reset-all!)
   (try
     (f)
     (finally
-      (config/reset-all!))))
+      (rf.story.config/reset-all!))))
 
 (use-fixtures :each reset-config!)
 
@@ -94,7 +94,7 @@
 (defn- handler-exception-event
   "Build a `:rf.error/handler-exception` trace event for `frame-id`. The
   play-listener's surviving non-privacy job is to capture these into
-  `play/pending-exceptions`. `sensitive?` flags whether the privacy gate
+  `rf.story.play/pending-exceptions`. `sensitive?` flags whether the privacy gate
   should drop it before capture."
   [frame-id sensitive?]
   (cond-> {:op-type   :error
@@ -113,61 +113,61 @@
 
 (deftest sensitive-event?-recognises-flag
   (testing "events with :sensitive? true are recognised"
-    (is (config/sensitive-event? (sensitive-dispatch-event :v/x [:auth/login])))
-    (is (config/sensitive-event? {:sensitive? true})))
+    (is (rf.story.config/sensitive-event? (sensitive-dispatch-event :v/x [:auth/login])))
+    (is (rf.story.config/sensitive-event? {:sensitive? true})))
   (testing "events without :sensitive? or with :sensitive? false are not"
-    (is (not (config/sensitive-event? (plain-dispatch-event :v/x [:counter/inc]))))
-    (is (not (config/sensitive-event? {})))
-    (is (not (config/sensitive-event? {:sensitive? false})))
-    (is (not (config/sensitive-event? {:sensitive? nil}))))
+    (is (not (rf.story.config/sensitive-event? (plain-dispatch-event :v/x [:counter/inc]))))
+    (is (not (rf.story.config/sensitive-event? {})))
+    (is (not (rf.story.config/sensitive-event? {:sensitive? false})))
+    (is (not (rf.story.config/sensitive-event? {:sensitive? nil}))))
   (testing "non-map inputs are tolerated"
-    (is (not (config/sensitive-event? nil)))
-    (is (not (config/sensitive-event? "trace event")))
-    (is (not (config/sensitive-event? 42)))))
+    (is (not (rf.story.config/sensitive-event? nil)))
+    (is (not (rf.story.config/sensitive-event? "trace event")))
+    (is (not (rf.story.config/sensitive-event? 42)))))
 
 (deftest suppress-sensitive?-default-suppresses
   (testing "by default (:rf.egress/local-redacted) sensitive events are suppressed"
-    (is (= :rf.egress/local-redacted @config/session-egress-profile))
-    (is (false? (config/include-sensitive? nil)))
-    (is (true?  (config/suppress-sensitive?
+    (is (= :rf.egress/local-redacted @rf.story.config/session-egress-profile))
+    (is (false? (rf.story.config/include-sensitive? nil)))
+    (is (true?  (rf.story.config/suppress-sensitive?
                   (sensitive-dispatch-event :v/x [:auth/login])))))
   (testing "non-sensitive events are never suppressed"
-    (is (false? (config/suppress-sensitive?
+    (is (false? (rf.story.config/suppress-sensitive?
                   (plain-dispatch-event :v/x [:counter/inc]))))))
 
 (deftest suppress-sensitive?-opts-out-under-local-raw
   (testing "under :rf.egress/local-raw, sensitive events are NOT suppressed"
-    (config/set-egress-profile! :rf.egress/local-raw)
-    (is (= :rf.egress/local-raw @config/session-egress-profile))
-    (is (true? (config/include-sensitive? nil)))
-    (is (false? (config/suppress-sensitive?
+    (rf.story.config/set-egress-profile! :rf.egress/local-raw)
+    (is (= :rf.egress/local-raw @rf.story.config/session-egress-profile))
+    (is (true? (rf.story.config/include-sensitive? nil)))
+    (is (false? (rf.story.config/suppress-sensitive?
                   (sensitive-dispatch-event :v/x [:auth/login])))))
   (testing "non-sensitive events remain unsuppressed regardless of profile"
-    (config/set-egress-profile! :rf.egress/local-raw)
-    (is (false? (config/suppress-sensitive?
+    (rf.story.config/set-egress-profile! :rf.egress/local-raw)
+    (is (false? (rf.story.config/suppress-sensitive?
                   (plain-dispatch-event :v/x [:counter/inc]))))))
 
 (deftest configure!-wires-egress-profile
-  (testing "story/configure! routes :rf.story/egress-profile to the config atom"
-    (is (= :rf.egress/local-redacted @config/session-egress-profile) "default is local-redacted")
-    (story/configure! {:rf.story/egress-profile :rf.egress/local-raw})
-    (is (= :rf.egress/local-raw @config/session-egress-profile)
+  (testing "rf.story/configure! routes :rf.story/egress-profile to the config atom"
+    (is (= :rf.egress/local-redacted @rf.story.config/session-egress-profile) "default is local-redacted")
+    (rf.story/configure! {:rf.story/egress-profile :rf.egress/local-raw})
+    (is (= :rf.egress/local-raw @rf.story.config/session-egress-profile)
         "opt-in flips the profile to the trusted-local boundary")
-    (is (true? (config/include-sensitive? nil)))
-    (story/configure! {:rf.story/egress-profile :rf.egress/local-redacted})
-    (is (= :rf.egress/local-redacted @config/session-egress-profile)
+    (is (true? (rf.story.config/include-sensitive? nil)))
+    (rf.story/configure! {:rf.story/egress-profile :rf.egress/local-redacted})
+    (is (= :rf.egress/local-redacted @rf.story.config/session-egress-profile)
         "passing local-redacted narrows back")
-    (is (false? (config/include-sensitive? nil))))
+    (is (false? (rf.story.config/include-sensitive? nil))))
   (testing "configure! without the key leaves the profile untouched"
-    (config/set-egress-profile! :rf.egress/local-raw)
-    (story/configure! {:rf.story/editor :cursor})
-    (is (= :rf.egress/local-raw @config/session-egress-profile)
+    (rf.story.config/set-egress-profile! :rf.egress/local-raw)
+    (rf.story/configure! {:rf.story/editor :cursor})
+    (is (= :rf.egress/local-raw @rf.story.config/session-egress-profile)
         "the unrelated key didn't reset the profile")))
 
 (deftest configure!-rejects-unknown-egress-profile
   (testing "an unknown profile keyword raises :rf.error/unknown-egress-profile (closed enum)"
     (let [e (try
-              (story/configure! {:rf.story/egress-profile :rf.egress/not-a-profile})
+              (rf.story/configure! {:rf.story/egress-profile :rf.egress/not-a-profile})
               nil
               (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e e))]
       (is (some? e) "expected ex-info to be thrown")
@@ -184,59 +184,59 @@
       (let [data (ex-data e)]
         (is (= :rf.error/unknown-egress-profile (:rf.error/id data)))
         (is (= 'rf.story/configure! (:where data)))))
-    (is (= :rf.egress/local-redacted @config/session-egress-profile)
+    (is (= :rf.egress/local-redacted @rf.story.config/session-egress-profile)
         "the rejected call left the profile at the redacting default")))
 
 (deftest set-egress-profile!-fail-closed-defaults
   (testing "set-egress-profile! resets nil + non-member values to the fail-closed default"
-    (config/set-egress-profile! :rf.egress/local-raw)
-    (config/set-egress-profile! nil)
-    (is (= :rf.egress/local-redacted @config/session-egress-profile)
+    (rf.story.config/set-egress-profile! :rf.egress/local-raw)
+    (rf.story.config/set-egress-profile! nil)
+    (is (= :rf.egress/local-redacted @rf.story.config/session-egress-profile)
         "nil resets to the redacting default")
-    (config/set-egress-profile! :rf.egress/local-raw)
-    (config/set-egress-profile! :not-a-profile)
-    (is (= :rf.egress/local-redacted @config/session-egress-profile)
+    (rf.story.config/set-egress-profile! :rf.egress/local-raw)
+    (rf.story.config/set-egress-profile! :not-a-profile)
+    (is (= :rf.egress/local-redacted @rf.story.config/session-egress-profile)
         "a non-member value coerces fail-closed (defence-in-depth)")
-    (is (false? (config/include-sensitive? nil)))))
+    (is (false? (rf.story.config/include-sensitive? nil)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Suppressed-events counter
 ;; ---------------------------------------------------------------------------
 
 (deftest suppressed-count-defaults-to-zero
-  (is (zero? (config/suppressed-count)))
-  (is (zero? (config/suppressed-count :story.x/y))))
+  (is (zero? (rf.story.config/suppressed-count)))
+  (is (zero? (rf.story.config/suppressed-count :story.x/y))))
 
 (deftest note-suppressed!-bumps-counter
-  (config/note-suppressed! :story.x/y)
-  (config/note-suppressed! :story.x/y)
-  (config/note-suppressed! :story.a/b)
-  (is (= 2 (config/suppressed-count :story.x/y)))
-  (is (= 1 (config/suppressed-count :story.a/b)))
-  (is (zero? (config/suppressed-count :story.never/seen))))
+  (rf.story.config/note-suppressed! :story.x/y)
+  (rf.story.config/note-suppressed! :story.x/y)
+  (rf.story.config/note-suppressed! :story.a/b)
+  (is (= 2 (rf.story.config/suppressed-count :story.x/y)))
+  (is (= 1 (rf.story.config/suppressed-count :story.a/b)))
+  (is (zero? (rf.story.config/suppressed-count :story.never/seen))))
 
 (deftest note-suppressed!-routes-nil-to-global
-  (config/note-suppressed! nil)
-  (config/note-suppressed! nil)
-  (is (= 2 (config/suppressed-count)))
-  (is (= 2 (config/suppressed-count :global))))
+  (rf.story.config/note-suppressed! nil)
+  (rf.story.config/note-suppressed! nil)
+  (is (= 2 (rf.story.config/suppressed-count)))
+  (is (= 2 (rf.story.config/suppressed-count :global))))
 
 (deftest reset-suppressed-count!-clears
-  (config/note-suppressed! :story.x/y)
-  (config/note-suppressed! :story.a/b)
-  (config/reset-suppressed-count! :story.x/y)
-  (is (zero? (config/suppressed-count :story.x/y)))
-  (is (= 1 (config/suppressed-count :story.a/b)))
-  (config/reset-suppressed-count!)
-  (is (zero? (config/suppressed-count :story.a/b))))
+  (rf.story.config/note-suppressed! :story.x/y)
+  (rf.story.config/note-suppressed! :story.a/b)
+  (rf.story.config/reset-suppressed-count! :story.x/y)
+  (is (zero? (rf.story.config/suppressed-count :story.x/y)))
+  (is (= 1 (rf.story.config/suppressed-count :story.a/b)))
+  (rf.story.config/reset-suppressed-count!)
+  (is (zero? (rf.story.config/suppressed-count :story.a/b))))
 
 ;; ---------------------------------------------------------------------------
 ;; Play listener — the Spec 009 §Privacy egress seam (rf2-luzky)
 ;;
 ;; rf2-luzky folded the `trace-accumulators` dev side-table away; the
 ;; play-listener's surviving jobs are the PRIVACY gate (default-drop
-;; `:sensitive?` + bump `config/note-suppressed!`) and the synchronous
-;; handler-exception capture into `play/pending-exceptions`. These tests
+;; `:sensitive?` + bump `rf.story.config/note-suppressed!`) and the synchronous
+;; handler-exception capture into `rf.story.play/pending-exceptions`. These tests
 ;; pin the privacy INVARIANT directly against those observable outputs —
 ;; not via the removed side-table accessors:
 ;;
@@ -253,72 +253,72 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- pending-for [frame-id]
-  (get @play/pending-exceptions frame-id []))
+  (get @rf.story.play/pending-exceptions frame-id []))
 
 (deftest play-listener-suppresses-sensitive-warnings
   (testing "by default a :sensitive? warning event is dropped at the privacy gate"
     (let [frame-id :story.sensitive/v
-          build    @#'play/listener-for-frame
+          build    @#'rf.story.play/listener-for-frame
           listen   (build frame-id)
           ev       (sensitive-warning-event frame-id)]
-      (swap! play/pending-exceptions assoc frame-id [])
+      (swap! rf.story.play/pending-exceptions assoc frame-id [])
       (listen ev)
       (is (empty? (pending-for frame-id))
           "the sensitive warning never reached the listener body")
-      (is (pos? (config/suppressed-count frame-id))
+      (is (pos? (rf.story.config/suppressed-count frame-id))
           "the suppressed-events counter bumped — the redaction hint stays accurate"))))
 
 (deftest play-listener-suppresses-sensitive-handler-exception
   (testing "by default a :sensitive? handler-exception is dropped before capture"
     (let [frame-id :story.sensitive/v
-          build    @#'play/listener-for-frame
+          build    @#'rf.story.play/listener-for-frame
           listen   (build frame-id)
           ev       (handler-exception-event frame-id true)]
-      (swap! play/pending-exceptions assoc frame-id [])
+      (swap! rf.story.play/pending-exceptions assoc frame-id [])
       (listen ev)
       (is (empty? (pending-for frame-id))
           "the sensitive handler-exception never reached pending-exceptions")
-      (is (pos? (config/suppressed-count frame-id))
+      (is (pos? (rf.story.config/suppressed-count frame-id))
           "the suppressed-events counter bumped"))))
 
 (deftest play-listener-passes-sensitive-when-opted-in
   (testing "under :rf.egress/local-raw the gate is open — a sensitive handler-exception is captured"
-    (config/set-egress-profile! :rf.egress/local-raw)
+    (rf.story.config/set-egress-profile! :rf.egress/local-raw)
     (let [frame-id :story.sensitive/v
-          build    @#'play/listener-for-frame
+          build    @#'rf.story.play/listener-for-frame
           listen   (build frame-id)
           ev       (handler-exception-event frame-id true)]
-      (swap! play/pending-exceptions assoc frame-id [])
+      (swap! rf.story.play/pending-exceptions assoc frame-id [])
       (listen ev)
       (is (= 1 (count (pending-for frame-id)))
           "the sensitive handler-exception was captured (the gate is open)")
-      (is (zero? (config/suppressed-count frame-id))
+      (is (zero? (rf.story.config/suppressed-count frame-id))
           "the suppressed-events counter stays at zero"))))
 
 (deftest play-listener-captures-non-sensitive-handler-exception
   (testing "regression: a non-sensitive handler-exception is captured under default settings"
     (let [frame-id :story.regression/v
-          build    @#'play/listener-for-frame
+          build    @#'rf.story.play/listener-for-frame
           listen   (build frame-id)
           ev       (handler-exception-event frame-id false)]
-      (swap! play/pending-exceptions assoc frame-id [])
+      (swap! rf.story.play/pending-exceptions assoc frame-id [])
       (listen ev)
       (is (= 1 (count (pending-for frame-id)))
           "the non-sensitive handler-exception landed in pending-exceptions")
-      (is (zero? (config/suppressed-count frame-id))
+      (is (zero? (rf.story.config/suppressed-count frame-id))
           "no suppression — the counter stays at zero"))))
 
 (deftest play-listener-ignores-non-sensitive-non-error
   (testing "a plain dispatched event is neither suppressed nor captured (no side-table to feed)"
     (let [frame-id :story.regression/v
-          build    @#'play/listener-for-frame
+          build    @#'rf.story.play/listener-for-frame
           listen   (build frame-id)
           ev       (plain-dispatch-event frame-id [:counter/inc])]
-      (swap! play/pending-exceptions assoc frame-id [])
+      (swap! rf.story.play/pending-exceptions assoc frame-id [])
       (listen ev)
       (is (empty? (pending-for frame-id))
           "a dispatched event is not a handler-exception — nothing captured")
-      (is (zero? (config/suppressed-count frame-id))
+      (is (zero? (rf.story.config/suppressed-count frame-id))
           "non-sensitive — no suppression"))))
 
 ;; ---------------------------------------------------------------------------
@@ -327,100 +327,100 @@
 
 (deftest recorder-listener-redacts-sensitive-dispatches
   (testing "by default the recorder records-but-redacts :sensitive? events (rf2-hdadz)"
-    (recorder/clear!)
-    (recorder/start-recording! :story.recorder/sens 0)
-    (let [listen @#'recorder/trace-listener
+    (rf.story.recorder/clear!)
+    (rf.story.recorder/start-recording! :story.recorder/sens 0)
+    (let [listen @#'rf.story.recorder/trace-listener
           ev     (sensitive-dispatch-event :story.recorder/sens
                                            [:auth/login {:password "x"}])]
       (listen ev)
-      (is (= [[:rf/redacted]] (recorder/recorded-events))
+      (is (= [[:rf/redacted]] (rf.story.recorder/recorded-events))
           "the redacted placeholder lands in the captured trace — preserves correlation, drops payload")
-      (is (pos? (config/suppressed-count :story.recorder/sens))
+      (is (pos? (rf.story.config/suppressed-count :story.recorder/sens))
           "the suppressed-events counter still bumps so the UI redaction hint stays accurate"))
-    (recorder/clear!)))
+    (rf.story.recorder/clear!)))
 
 (deftest recorder-listener-preserves-temporal-ordering-around-redacted
   (testing "redacted placeholder sits inline between non-sensitive captures"
-    (recorder/clear!)
-    (recorder/start-recording! :story.recorder/sens 0)
-    (let [listen @#'recorder/trace-listener]
+    (rf.story.recorder/clear!)
+    (rf.story.recorder/start-recording! :story.recorder/sens 0)
+    (let [listen @#'rf.story.recorder/trace-listener]
       (listen (plain-dispatch-event     :story.recorder/sens [:counter/inc]))
       (listen (sensitive-dispatch-event :story.recorder/sens
                                         [:auth/login {:password "x"}]))
       (listen (plain-dispatch-event     :story.recorder/sens [:counter/inc])))
     (is (= [[:counter/inc] [:rf/redacted] [:counter/inc]]
-           (recorder/recorded-events))
+           (rf.story.recorder/recorded-events))
         "the redacted slot preserves the row position so dev correlation survives")
-    (is (= 1 (config/suppressed-count :story.recorder/sens))
+    (is (= 1 (rf.story.config/suppressed-count :story.recorder/sens))
         "one redaction, one counter bump")
-    (recorder/clear!)))
+    (rf.story.recorder/clear!)))
 
 (deftest recorder-listener-captures-sensitive-when-opted-in
   (testing "under :rf.egress/local-raw the recorder captures :sensitive? events"
-    (config/set-egress-profile! :rf.egress/local-raw)
-    (recorder/clear!)
-    (recorder/start-recording! :story.recorder/sens 0)
-    (let [listen @#'recorder/trace-listener
+    (rf.story.config/set-egress-profile! :rf.egress/local-raw)
+    (rf.story.recorder/clear!)
+    (rf.story.recorder/start-recording! :story.recorder/sens 0)
+    (let [listen @#'rf.story.recorder/trace-listener
           ev     (sensitive-dispatch-event :story.recorder/sens
                                            [:auth/login {:password "x"}])]
       (listen ev)
-      (is (= [[:auth/login {:password "x"}]] (recorder/recorded-events))
+      (is (= [[:auth/login {:password "x"}]] (rf.story.recorder/recorded-events))
           "the captured-events vector now has the sensitive event verbatim")
-      (is (zero? (config/suppressed-count :story.recorder/sens))))
-    (recorder/clear!)))
+      (is (zero? (rf.story.config/suppressed-count :story.recorder/sens))))
+    (rf.story.recorder/clear!)))
 
 (deftest recorder-listener-frame-scoped-reveal-rf2-6z4znr
   (testing "revealing the RECORDED frame captures verbatim; revealing a sibling does NOT"
-    (reset! @#'config/frame-egress-profiles {})
-    (config/set-session-egress-profile! config/default-egress-profile)
+    (reset! @#'rf.story.config/frame-egress-profiles {})
+    (rf.story.config/set-session-egress-profile! rf.story.config/default-egress-profile)
     ;; reveal a DIFFERENT frame — the recording frame stays redacted
-    (config/set-frame-egress-profile! :story.recorder/sibling :rf.egress/local-raw)
-    (recorder/clear!)
-    (recorder/start-recording! :story.recorder/sens 0)
-    (let [listen @#'recorder/trace-listener]
+    (rf.story.config/set-frame-egress-profile! :story.recorder/sibling :rf.egress/local-raw)
+    (rf.story.recorder/clear!)
+    (rf.story.recorder/start-recording! :story.recorder/sens 0)
+    (let [listen @#'rf.story.recorder/trace-listener]
       (listen (sensitive-dispatch-event :story.recorder/sens [:auth/login {:password "x"}]))
-      (is (= [[:rf/redacted]] (recorder/recorded-events))
+      (is (= [[:rf/redacted]] (rf.story.recorder/recorded-events))
           "the recording frame was NOT revealed (only a sibling was) — still redacted"))
-    (recorder/clear!)
+    (rf.story.recorder/clear!)
     ;; now reveal the recording frame itself
-    (config/set-frame-egress-profile! :story.recorder/sens :rf.egress/local-raw)
-    (recorder/start-recording! :story.recorder/sens 0)
-    (let [listen @#'recorder/trace-listener]
+    (rf.story.config/set-frame-egress-profile! :story.recorder/sens :rf.egress/local-raw)
+    (rf.story.recorder/start-recording! :story.recorder/sens 0)
+    (let [listen @#'rf.story.recorder/trace-listener]
       (listen (sensitive-dispatch-event :story.recorder/sens [:auth/login {:password "x"}]))
-      (is (= [[:auth/login {:password "x"}]] (recorder/recorded-events))
+      (is (= [[:auth/login {:password "x"}]] (rf.story.recorder/recorded-events))
           "revealing the recording frame captures verbatim"))
-    (recorder/clear!)
-    (reset! @#'config/frame-egress-profiles {})))
+    (rf.story.recorder/clear!)
+    (reset! @#'rf.story.config/frame-egress-profiles {})))
 
 (deftest play-listener-frame-scoped-reveal-rf2-6z4znr
   (testing "revealing frame A's gate does NOT open frame B's play listener"
-    (reset! @#'config/frame-egress-profiles {})
-    (config/set-session-egress-profile! config/default-egress-profile)
-    (config/set-frame-egress-profile! :story.play/a :rf.egress/local-raw)
-    (let [build @#'play/listener-for-frame]
+    (reset! @#'rf.story.config/frame-egress-profiles {})
+    (rf.story.config/set-session-egress-profile! rf.story.config/default-egress-profile)
+    (rf.story.config/set-frame-egress-profile! :story.play/a :rf.egress/local-raw)
+    (let [build @#'rf.story.play/listener-for-frame]
       ;; frame A revealed — sensitive exception captured
       (let [listen (build :story.play/a)]
-        (swap! play/pending-exceptions assoc :story.play/a [])
+        (swap! rf.story.play/pending-exceptions assoc :story.play/a [])
         (listen (handler-exception-event :story.play/a true))
         (is (= 1 (count (pending-for :story.play/a))) "A revealed → captured"))
       ;; frame B NOT revealed — sensitive exception dropped at the gate
       (let [listen (build :story.play/b)]
-        (swap! play/pending-exceptions assoc :story.play/b [])
+        (swap! rf.story.play/pending-exceptions assoc :story.play/b [])
         (listen (handler-exception-event :story.play/b true))
         (is (empty? (pending-for :story.play/b)) "B not revealed → dropped")
-        (is (pos? (config/suppressed-count :story.play/b)))))
-    (reset! @#'config/frame-egress-profiles {})))
+        (is (pos? (rf.story.config/suppressed-count :story.play/b)))))
+    (reset! @#'rf.story.config/frame-egress-profiles {})))
 
 (deftest recorder-listener-still-captures-non-sensitive
   (testing "regression: ordinary events still land in the recorder under default settings"
-    (recorder/clear!)
-    (recorder/start-recording! :story.recorder/plain 0)
-    (let [listen @#'recorder/trace-listener
+    (rf.story.recorder/clear!)
+    (rf.story.recorder/start-recording! :story.recorder/plain 0)
+    (let [listen @#'rf.story.recorder/trace-listener
           ev     (plain-dispatch-event :story.recorder/plain [:counter/inc])]
       (listen ev)
-      (is (= [[:counter/inc]] (recorder/recorded-events)))
-      (is (zero? (config/suppressed-count :story.recorder/plain))))
-    (recorder/clear!)))
+      (is (= [[:counter/inc]] (rf.story.recorder/recorded-events)))
+      (is (zero? (rf.story.config/suppressed-count :story.recorder/plain))))
+    (rf.story.recorder/clear!)))
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-cmjly3 finding 13 — recordable-event? must gate on the ORIGINAL id,
@@ -444,46 +444,46 @@
             entirely — no [:rf/redacted] row, and the suppressed-events
             counter (the UI's 'count of redacted rows actually shown' hint)
             does not bump for a row that was never recorded"
-    (recorder/clear!)
-    (recorder/start-recording! :story.recorder/sens-drop 0)
-    (let [listen @#'recorder/trace-listener
+    (rf.story.recorder/clear!)
+    (rf.story.recorder/start-recording! :story.recorder/sens-drop 0)
+    (let [listen @#'rf.story.recorder/trace-listener
           ev     (sensitive-dispatch-event :story.recorder/sens-drop
                                            [:rf.assert/path-equals [:n] 1])]
       (listen ev)
-      (is (= [] (recorder/recorded-events))
+      (is (= [] (rf.story.recorder/recorded-events))
           "the sensitive :rf.assert/* event is dropped — pre-fix this
            recorded a spurious [:rf/redacted] row")
-      (is (zero? (config/suppressed-count :story.recorder/sens-drop))
+      (is (zero? (rf.story.config/suppressed-count :story.recorder/sens-drop))
           "no row recorded => no suppressed-count bump either"))
-    (recorder/clear!)))
+    (rf.story.recorder/clear!)))
 
 (deftest recorder-listener-drops-sensitive-non-recordable-story-internal-event-rf2-cmjly3
   (testing "rf2-cmjly3 finding 13 — the same drop applies to a sensitive
             :rf.story/* internal-helper event, the OTHER non-recordable
             namespace class"
-    (recorder/clear!)
-    (recorder/start-recording! :story.recorder/sens-drop-story 0)
-    (let [listen @#'recorder/trace-listener
+    (rf.story.recorder/clear!)
+    (rf.story.recorder/start-recording! :story.recorder/sens-drop-story 0)
+    (let [listen @#'rf.story.recorder/trace-listener
           ev     (sensitive-dispatch-event :story.recorder/sens-drop-story
                                            [:rf.story/lifecycle-tick])]
       (listen ev)
-      (is (= [] (recorder/recorded-events)))
-      (is (zero? (config/suppressed-count :story.recorder/sens-drop-story))))
-    (recorder/clear!)))
+      (is (= [] (rf.story.recorder/recorded-events)))
+      (is (zero? (rf.story.config/suppressed-count :story.recorder/sens-drop-story))))
+    (rf.story.recorder/clear!)))
 
 (deftest recorder-listener-still-redacts-sensitive-recordable-event-rf2-cmjly3
   (testing "rf2-cmjly3 finding 13 — no regression: an ORDINARY sensitive
             user event (a recordable id) still record-but-redacts exactly
             as before the fix"
-    (recorder/clear!)
-    (recorder/start-recording! :story.recorder/sens-redact 0)
-    (let [listen @#'recorder/trace-listener
+    (rf.story.recorder/clear!)
+    (rf.story.recorder/start-recording! :story.recorder/sens-redact 0)
+    (let [listen @#'rf.story.recorder/trace-listener
           ev     (sensitive-dispatch-event :story.recorder/sens-redact
                                            [:auth/login {:password "x"}])]
       (listen ev)
-      (is (= [[:rf/redacted]] (recorder/recorded-events)))
-      (is (pos? (config/suppressed-count :story.recorder/sens-redact))))
-    (recorder/clear!)))
+      (is (= [[:rf/redacted]] (rf.story.recorder/recorded-events)))
+      (is (pos? (rf.story.config/suppressed-count :story.recorder/sens-redact))))
+    (rf.story.recorder/clear!)))
 
 ;; ---------------------------------------------------------------------------
 ;; Retroactive scrub on egress-profile narrowing (rf2-lqmje / EP-0015 rf2-3t26eh)
@@ -503,52 +503,52 @@
           token-id ::scrub-callback-test]
       ;; rf2-6z4znr — callbacks now receive the narrowed frame-id; a
       ;; session-pin narrow passes nil (scrub-all signal).
-      (config/register-toggle-off-callback! token-id (fn [_frame-id] (reset! called? true)))
+      (rf.story.config/register-toggle-off-callback! token-id (fn [_frame-id] (reset! called? true)))
       (try
-        (config/set-egress-profile! :rf.egress/local-raw)
+        (rf.story.config/set-egress-profile! :rf.egress/local-raw)
         (is (false? @called?)
             "redact → reveal must NOT invoke callbacks (no buffered sensitive risk)")
-        (config/set-egress-profile! :rf.egress/local-redacted)
+        (rf.story.config/set-egress-profile! :rf.egress/local-redacted)
         (is (true? @called?)
             "reveal → redact must invoke every registered callback")
         (finally
-          (config/unregister-toggle-off-callback! token-id))))))
+          (rf.story.config/unregister-toggle-off-callback! token-id))))))
 
 (deftest profile-no-transition-no-callback-rf2-lqmje
   (testing "reveal → reveal and redact → redact are no-ops for the callbacks"
     (let [calls    (atom 0)
           token-id ::scrub-callback-no-transition]
-      (config/register-toggle-off-callback! token-id (fn [_frame-id] (swap! calls inc)))
+      (rf.story.config/register-toggle-off-callback! token-id (fn [_frame-id] (swap! calls inc)))
       (try
-        (config/set-egress-profile! :rf.egress/local-redacted) ; default → redact, no transition
+        (rf.story.config/set-egress-profile! :rf.egress/local-redacted) ; default → redact, no transition
         (is (= 0 @calls))
-        (config/set-egress-profile! :rf.egress/local-raw)
-        (config/set-egress-profile! :rf.egress/local-raw)  ; reveal → reveal
+        (rf.story.config/set-egress-profile! :rf.egress/local-raw)
+        (rf.story.config/set-egress-profile! :rf.egress/local-raw)  ; reveal → reveal
         (is (= 0 @calls))
-        (config/set-egress-profile! :rf.egress/local-redacted) ; reveal → redact, the only transition
+        (rf.story.config/set-egress-profile! :rf.egress/local-redacted) ; reveal → redact, the only transition
         (is (= 1 @calls))
-        (config/set-egress-profile! :rf.egress/local-redacted) ; redact → redact
+        (rf.story.config/set-egress-profile! :rf.egress/local-redacted) ; redact → redact
         (is (= 1 @calls))
         (finally
-          (config/unregister-toggle-off-callback! token-id))))))
+          (rf.story.config/unregister-toggle-off-callback! token-id))))))
 
 (deftest narrowing-profile-callback-failure-isolated-rf2-lqmje
   (testing "one buggy callback does not prevent others from running"
     (let [other-called? (atom false)
           token-bad     ::scrub-callback-bad
           token-good    ::scrub-callback-good]
-      (config/register-toggle-off-callback!
+      (rf.story.config/register-toggle-off-callback!
         token-bad (fn [_frame-id] (throw (ex-info "boom" {}))))
-      (config/register-toggle-off-callback!
+      (rf.story.config/register-toggle-off-callback!
         token-good (fn [_frame-id] (reset! other-called? true)))
       (try
-        (config/set-egress-profile! :rf.egress/local-raw)
-        (config/set-egress-profile! :rf.egress/local-redacted)
+        (rf.story.config/set-egress-profile! :rf.egress/local-raw)
+        (rf.story.config/set-egress-profile! :rf.egress/local-redacted)
         (is (true? @other-called?)
             "the good callback must still run after the bad one throws")
         (finally
-          (config/unregister-toggle-off-callback! token-bad)
-          (config/unregister-toggle-off-callback! token-good))))))
+          (rf.story.config/unregister-toggle-off-callback! token-bad)
+          (rf.story.config/unregister-toggle-off-callback! token-good))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Per-(tool,frame) egress visibility (EP-0015 issue 7, rf2-6z4znr)
@@ -559,33 +559,33 @@
 ;; scrubs only that frame; a frameless / unknown event fails closed.
 
 (defn- clear-frame-overrides! []
-  (reset! @#'config/frame-egress-profiles {})
-  (config/set-session-egress-profile! config/default-egress-profile))
+  (reset! @#'rf.story.config/frame-egress-profiles {})
+  (rf.story.config/set-session-egress-profile! rf.story.config/default-egress-profile))
 
 (deftest frame-egress-isolation-reveal-one-not-the-other
   (testing "revealing frame A to local-raw does NOT reveal frame B"
     (clear-frame-overrides!)
     (let [a :story.iso/a
           b :story.iso/b]
-      (config/set-frame-egress-profile! a :rf.egress/local-raw)
-      (is (true?  (config/include-sensitive? a)) "frame A revealed")
-      (is (false? (config/include-sensitive? b)) "frame B still redacted")
+      (rf.story.config/set-frame-egress-profile! a :rf.egress/local-raw)
+      (is (true?  (rf.story.config/include-sensitive? a)) "frame A revealed")
+      (is (false? (rf.story.config/include-sensitive? b)) "frame B still redacted")
       ;; a sensitive event targeting A passes; the same shape on B suppresses
-      (is (false? (config/suppress-sensitive? (sensitive-dispatch-event a [:auth/login]) a)))
-      (is (true?  (config/suppress-sensitive? (sensitive-dispatch-event b [:auth/login]) b)))
+      (is (false? (rf.story.config/suppress-sensitive? (sensitive-dispatch-event a [:auth/login]) a)))
+      (is (true?  (rf.story.config/suppress-sensitive? (sensitive-dispatch-event b [:auth/login]) b)))
       ;; resolved from the event itself (single-arg arity) — same result
-      (is (false? (config/suppress-sensitive? (sensitive-dispatch-event a [:auth/login]))))
-      (is (true?  (config/suppress-sensitive? (sensitive-dispatch-event b [:auth/login]))))
+      (is (false? (rf.story.config/suppress-sensitive? (sensitive-dispatch-event a [:auth/login]))))
+      (is (true?  (rf.story.config/suppress-sensitive? (sensitive-dispatch-event b [:auth/login]))))
       (clear-frame-overrides!))))
 
 (deftest frameless-event-fails-closed
   (testing "a sensitive event with no resolvable frame fails closed even while a sibling is raw"
     (clear-frame-overrides!)
-    (config/set-frame-egress-profile! :story.iso/a :rf.egress/local-raw)
-    (is (false? (config/include-sensitive? nil)) "unknown frame resolves to the redacting default")
-    (is (true? (config/suppress-sensitive? {:sensitive? true :tags {}}))
+    (rf.story.config/set-frame-egress-profile! :story.iso/a :rf.egress/local-raw)
+    (is (false? (rf.story.config/include-sensitive? nil)) "unknown frame resolves to the redacting default")
+    (is (true? (rf.story.config/suppress-sensitive? {:sensitive? true :tags {}}))
         "a frameless sensitive event is suppressed")
-    (is (true? (config/suppress-sensitive? {:sensitive? true :tags {:frame :story.iso/never-revealed}}))
+    (is (true? (rf.story.config/suppress-sensitive? {:sensitive? true :tags {:frame :story.iso/never-revealed}}))
         "an unrevealed-frame sensitive event is suppressed")
     (clear-frame-overrides!)))
 
@@ -596,33 +596,33 @@
           token    ::per-frame-scrub
           a        :story.iso/a
           b        :story.iso/b]
-      (config/register-toggle-off-callback! token (fn [frame-id] (swap! scrubbed conj frame-id)))
+      (rf.story.config/register-toggle-off-callback! token (fn [frame-id] (swap! scrubbed conj frame-id)))
       (try
-        (config/set-frame-egress-profile! a :rf.egress/local-raw)
-        (config/set-frame-egress-profile! b :rf.egress/local-raw)
+        (rf.story.config/set-frame-egress-profile! a :rf.egress/local-raw)
+        (rf.story.config/set-frame-egress-profile! b :rf.egress/local-raw)
         (is (= [] @scrubbed) "revealing fires nothing")
-        (config/set-frame-egress-profile! a :rf.egress/local-redacted)
+        (rf.story.config/set-frame-egress-profile! a :rf.egress/local-redacted)
         (is (= [a] @scrubbed) "narrowing A scrubbed A only")
-        (is (true? (config/include-sensitive? b)) "B is still revealed — untouched")
-        (config/set-frame-egress-profile! b :rf.egress/local-redacted)
+        (is (true? (rf.story.config/include-sensitive? b)) "B is still revealed — untouched")
+        (rf.story.config/set-frame-egress-profile! b :rf.egress/local-redacted)
         (is (= [a b] @scrubbed) "narrowing B then scrubbed B")
         (finally
-          (config/unregister-toggle-off-callback! token)
+          (rf.story.config/unregister-toggle-off-callback! token)
           (clear-frame-overrides!))))))
 
 (deftest per-frame-override-wins-over-session-pin
   (testing "a per-frame override beats the session-pin in both directions"
     (clear-frame-overrides!)
     ;; pin the session to raw (tool UX); a frame can still be narrowed below it
-    (config/set-session-egress-profile! :rf.egress/local-raw)
-    (is (true? (config/include-sensitive? :story.iso/inherits)) "no override → inherits the raw pin")
-    (config/set-frame-egress-profile! :story.iso/locked :rf.egress/local-redacted)
+    (rf.story.config/set-session-egress-profile! :rf.egress/local-raw)
+    (is (true? (rf.story.config/include-sensitive? :story.iso/inherits)) "no override → inherits the raw pin")
+    (rf.story.config/set-frame-egress-profile! :story.iso/locked :rf.egress/local-redacted)
     ;; local-redacted is the default → no override entry is stored, so it
     ;; inherits the raw pin too (a frame cannot be pinned BELOW the session
     ;; default by storing the default; redaction-below-pin is out of scope —
     ;; the pin is the floor for unoverridden frames). Reveal direction:
-    (config/set-session-egress-profile! config/default-egress-profile)
-    (config/set-frame-egress-profile! :story.iso/raised :rf.egress/local-raw)
-    (is (true?  (config/include-sensitive? :story.iso/raised)) "explicit reveal wins over the redacting pin")
-    (is (false? (config/include-sensitive? :story.iso/other)) "an unoverridden frame stays at the redacting pin")
+    (rf.story.config/set-session-egress-profile! rf.story.config/default-egress-profile)
+    (rf.story.config/set-frame-egress-profile! :story.iso/raised :rf.egress/local-raw)
+    (is (true?  (rf.story.config/include-sensitive? :story.iso/raised)) "explicit reveal wins over the redacting pin")
+    (is (false? (rf.story.config/include-sensitive? :story.iso/other)) "an unoverridden frame stays at the redacting pin")
     (clear-frame-overrides!)))

--- a/tools/story/test/re_frame/story/story_is_test.clj
+++ b/tools/story/test/re_frame/story/story_is_test.clj
@@ -1,36 +1,36 @@
 (ns re-frame.story.story-is-test
-  "Headless `story/is` clojure.test bridge tests (NewTestStory
+  "Headless `rf.story/is` clojure.test bridge tests (NewTestStory
   rf2-5x1wt.19, `tools/story/spec/017-Testing-Story.md` §Public execution
-  API — the three verbs; §Run result — `story/is` reports per assertion).
+  API — the three verbs; §Run result — `rf.story/is` reports per assertion).
 
-  JVM-only (`.clj`): on the JVM `story/is` BLOCKS on the run promise and
+  JVM-only (`.clj`): on the JVM `rf.story/is` BLOCKS on the run promise and
   fires one `clojure.test` report per assertion synchronously, so the
   reports can be captured by rebinding `clojure.test/report`. The CLJS
   path is async (returns a promise); its pure report projection is covered
   by `re-frame.story.result-test/result->reports-*`.
 
   The bridge is verified by collecting every `clojure.test/do-report` map
-  `story/is` emits into an atom (the standard report-capture seam) and
+  `rf.story/is` emits into an atom (the standard report-capture seam) and
   asserting the per-assertion granularity + the verdict-driven run-level
   report."
   (:require [clojure.test :refer [deftest is testing use-fixtures] :as t]
             [re-frame.core      :as rf]
-            [re-frame.frame     :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story     :as story]
-            [re-frame.story.async :as async]
-            [re-frame.story.play.runner-events :as re]))
+            [re-frame.frame     :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story     :as rf.story]
+            [re-frame.story.async :as rf.story.async]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]))
 
 (defn- reset-rf! [test-fn]
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
-  (reset! re/run-state {})
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (reset! rf.story.play.runner-events/run-state {})
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (rf/reg-event :is/set-status (fn [{:keys [db]} [_ v]] {:db (assoc db :status v)}))
   (test-fn))
 
@@ -38,10 +38,10 @@
 
 (defn- capture-reports
   "Run `thunk` with `clojure.test/report` rebound to collect every report
-  map into a vector, so a `story/is` call's emitted reports can be
+  map into a vector, so a `rf.story/is` call's emitted reports can be
   inspected. Returns `[thunk-return reports-vector]`. The capture excludes
   the outer test's own pass/fail bookkeeping by collecting ONLY the
-  `:pass` / `:fail` / `:error` report maps `story/is` fires."
+  `:pass` / `:fail` / `:error` report maps `rf.story/is` fires."
   [thunk]
   (let [collected (atom [])]
     (binding [t/report (fn [m]
@@ -51,25 +51,25 @@
         [ret @collected]))))
 
 (deftest story-is-reports-per-assertion-pass
-  (testing "story/is fires one :pass report per passing assertion + returns
-            the unified result (§B5 — story/is reports per assertion)"
-    (story/reg-variant :story.is/pass
+  (testing "rf.story/is fires one :pass report per passing assertion + returns
+            the unified result (§B5 — rf.story/is reports per assertion)"
+    (rf.story/reg-variant :story.is/pass
       {:tags        #{:test}
        :script {:script [[:dispatch-sync [:is/set-status :loaded]]
                               [:assert-db [:status] :loaded]
                               [:assert-db [:status] :loaded]]}})
-    (let [[result reports] (capture-reports #(story/is :story.is/pass))]
+    (let [[result reports] (capture-reports #(rf.story/is :story.is/pass))]
       (is (= :pass (:status result)) "the unified verdict is :pass")
       (is (= 2 (count reports)) "one report per assertion (2 assertions)")
       (is (every? #(= :pass (:type %)) reports)))))
 
 (deftest story-is-reports-per-assertion-fail
-  (testing "story/is fires a :fail report for a failing assertion (§B5)"
-    (story/reg-variant :story.is/fail
+  (testing "rf.story/is fires a :fail report for a failing assertion (§B5)"
+    (rf.story/reg-variant :story.is/fail
       {:tags        #{:test}
        :script {:script [[:dispatch-sync [:is/set-status :idle]]
                               [:assert-db [:status] :loaded]]}})
-    (let [[result reports] (capture-reports #(story/is :story.is/fail))]
+    (let [[result reports] (capture-reports #(rf.story/is :story.is/fail))]
       (is (= :fail (:status result)))
       (is (= 1 (count reports)))
       (is (= :fail (:type (first reports))))
@@ -81,14 +81,14 @@
             assertions in ONE :script emit TWO independent reports — one
             failing assertion does not collapse or suppress the other, and
             the pass/fail verdict is tracked separately per :assert step"
-    (story/reg-variant :story.is/two-mixed
+    (rf.story/reg-variant :story.is/two-mixed
       {:tags        #{:test}
        :script {:script [[:dispatch-sync [:is/set-status :loaded]]
                               ;; assertion 1 — passes
                               [:assert-db [:status] :loaded]
                               ;; assertion 2 — fails (status is :loaded, not :idle)
                               [:assert-db [:status] :idle]]}})
-    (let [[result reports] (capture-reports #(story/is :story.is/two-mixed))]
+    (let [[result reports] (capture-reports #(rf.story/is :story.is/two-mixed))]
       (is (= :fail (:status result)) "the aggregate verdict is :fail")
       (is (= 2 (count reports))
           "two :assert steps → two separate reports, not one lumped result")
@@ -100,46 +100,46 @@
           "and its own per-assertion :expected — granularity, not aggregation"))))
 
 (deftest story-is-zero-assertion-emits-one-pass
-  (testing "a variant with no assertions is vacuously green — story/is emits
+  (testing "a variant with no assertions is vacuously green — rf.story/is emits
             ONE run-level :pass so the test sees a positive signal"
-    (story/reg-variant :story.is/empty
+    (rf.story/reg-variant :story.is/empty
       {:tags        #{:test}
        :script {:script [[:dispatch-sync [:is/set-status :ready]]]}})
-    (let [[result reports] (capture-reports #(story/is :story.is/empty))]
+    (let [[result reports] (capture-reports #(rf.story/is :story.is/empty))]
       (is (= :pass (:status result)))
       (is (= 1 (count reports)))
       (is (= :pass (:type (first reports)))))))
 
 (deftest story-is-accepts-an-already-resolved-result
-  (testing "story/is reports a unified result map directly (the sync path for
+  (testing "rf.story/is reports a unified result map directly (the sync path for
             tests that ran the variant themselves)"
     (let [result {:status :fail :variant/id :story.is/direct
                   :assertions [{:assertion :rf.assert/path-equals
                                 :status :fail :passed? false
                                 :payload [[:k] 1] :expected 1 :actual 2}]}
-          [ret reports] (capture-reports #(story/is result))]
+          [ret reports] (capture-reports #(rf.story/is result))]
       (is (= result ret) "the result is returned verbatim")
       (is (= 1 (count reports)))
       (is (= :fail (:type (first reports)))))))
 
 (deftest story-run-returns-unified-result
-  (testing "story/run returns a promise/future of the unified run-result"
-    (story/reg-variant :story.is/run
+  (testing "rf.story/run returns a promise/future of the unified run-result"
+    (rf.story/reg-variant :story.is/run
       {:tags        #{:test}
        :script {:script [[:dispatch-sync [:is/set-status :loaded]]
                               [:assert-db [:status] :loaded]]}})
-    (let [p (story/run :story.is/run)
+    (let [p (rf.story/run :story.is/run)
           result (.get ^java.util.concurrent.CompletableFuture p)]
       (is (= :pass (:status result)))
-      (is (= :pass (story/result-status result)))
-      (is (true? (story/result-passed? result))))))
+      (is (= :pass (rf.story/result-status result)))
+      (is (true? (rf.story/result-passed? result))))))
 
 (deftest story-is-honours-custom-timeout-ms
-  (testing "story/is :timeout-ms opt threads through to the JVM blocking
+  (testing "rf.story/is :timeout-ms opt threads through to the JVM blocking
             deref — a run that resolves inside the window is reported
             normally; an extra opt is stripped before reaching the runner
             (rf2-zaklu)"
-    (story/reg-variant :story.is/timeout
+    (rf.story/reg-variant :story.is/timeout
       {:tags        #{:test}
        :script {:script [[:dispatch-sync [:is/set-status :loaded]]
                               [:assert-db [:status] :loaded]]}})
@@ -147,7 +147,7 @@
     ;; proves the opt is accepted + stripped from the runner opts without
     ;; disturbing the run.
     (let [[result reports] (capture-reports
-                             #(story/is :story.is/timeout {:timeout-ms 5000}))]
+                             #(rf.story/is :story.is/timeout {:timeout-ms 5000}))]
       (is (= :pass (:status result)) "the run resolves inside the window")
       (is (= 1 (count reports)) "one report per assertion (1 assertion)")
       (is (= :pass (:type (first reports)))))))
@@ -157,14 +157,14 @@
             blocking deref — a never-resolving promise + a tight custom
             timeout throws promptly rather than blocking on the 30000ms
             default (rf2-zaklu)"
-    ;; Drive `async/deref-blocking` directly with the custom bound: a
+    ;; Drive `rf.story.async/deref-blocking` directly with the custom bound: a
     ;; CompletableFuture that never completes must throw a TimeoutException
     ;; at the custom 50ms bound, not the 30000ms default. This is the unit
-    ;; that `story/is` now parameterises.
+    ;; that `rf.story/is` now parameterises.
     (let [never (java.util.concurrent.CompletableFuture.)
           t0    (System/currentTimeMillis)]
       (is (thrown? java.util.concurrent.TimeoutException
-                   (async/deref-blocking never 50))
+                   (rf.story.async/deref-blocking never 50))
           "a tight custom timeout throws TimeoutException")
       (is (< (- (System/currentTimeMillis) t0) 5000)
           "the deref returned at the custom bound, nowhere near 30000ms"))))

--- a/tools/story/test/re_frame/story/story_scope_world_keys_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/story_scope_world_keys_cljs_test.cljc
@@ -4,7 +4,7 @@
 
   ## The defect this namespace is the witness for
 
-  `plan/variant-plan` folded `:substrates` and `:component` from the
+  `rf.story.plan/variant-plan` folded `:substrates` and `:component` from the
   VARIANT body and its `:extends` chain only. It resolved the parent story
   for decorators and tags and for nothing else, so a story that declared
   either key ONCE — the shape `001-Authoring.md` calls the normal one, the
@@ -22,10 +22,10 @@
     variant-then-story through `multi-substrate/resolve-substrate-set` —
     and rendered under REAGENT through `render-variant`. Exactly the
     disagreement rf2-3afns closed, one level up.
-  - `render/prepare-render` takes the subject off `[:world :component]`
+  - `rf.story.render/prepare-render` takes the subject off `[:world :component]`
     with NO fallback of its own, so the same story shape gave
     `render-variant` a NIL view. Measured, not inferred: before the fix
-    `(get-in (render/prepare-render v) [:render-inputs :view])` answered
+    `(get-in (rf.story.render/prepare-render v) [:render-inputs :view])` answered
     `nil` for a story-level `:component` and the view id for a
     variant-level one.
 
@@ -38,7 +38,7 @@
 
   ## Scope
 
-  `:substrates` and `:component` are the only two `plan/context-keys` with
+  `:substrates` and `:component` are the only two `rf.story.plan/context-keys` with
   a `[:world …]` reader anywhere in `tools/story/src` — `:modes`,
   `:viewport`, `:background`, `:xray`, `:platforms` and
   `:dispatch-console?` ride the plan for `:plan-hash` + explain and are
@@ -51,10 +51,10 @@
   DATA — the compiled plan and the host-free render-prep — so neither arm
   needs a renderer."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.registrar :as framework-registrar]
-            [re-frame.story.plan :as plan]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.story.render :as render]))
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.story.plan :as rf.story.plan]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.render :as rf.story.render]))
 
 ;; ---- fixture --------------------------------------------------------------
 ;;
@@ -65,15 +65,15 @@
 
 (use-fixtures :each
   (fn [t]
-    (registrar/clear-all!)
-    (framework-registrar/clear-kind! :view)
+    (rf.story.registrar/clear-all!)
+    (rf.registrar/clear-kind! :view)
     (t)))
 
 (defn- reg-view-meta!
   "Register a `:view` slot carrying `metadata` on the framework registrar —
   the slot the plan compiler's default view-lookup reads."
   [view-id metadata]
-  (framework-registrar/register! :view view-id
+  (rf.registrar/register! :view view-id
                                  (assoc metadata :handler-fn (fn [_] nil))))
 
 ;; ===========================================================================
@@ -86,13 +86,13 @@
             nothing. `[:world :substrates]` is where
             `canonical/render-host-scope` reads it, so an absent slot is a
             silent Reagent render."
-    (registrar/reg-story* :story.scope-sub
+    (rf.story.registrar/reg-story* :story.scope-sub
       {:doc "declares the authoring layer once, for every variant"
        :component  :views/probe
        :substrates #{:hicasso}})
-    (registrar/reg-variant* :story.scope-sub/child {:doc "declares nothing"})
+    (rf.story.registrar/reg-variant* :story.scope-sub/child {:doc "declares nothing"})
     (is (= #{:hicasso}
-           (get-in (plan/variant-plan :story.scope-sub/child)
+           (get-in (rf.story.plan/variant-plan :story.scope-sub/child)
                    [:world :substrates]))))
 
   (testing "and it is the DEFAULT side-table lookup that resolves it — no
@@ -100,7 +100,7 @@
             through an injected test double would leave the production path
             exactly as broken as it was."
     (is (= #{:hicasso}
-           (:substrates (registrar/handler-meta :story :story.scope-sub))))))
+           (:substrates (rf.story.registrar/handler-meta :story :story.scope-sub))))))
 
 (deftest the-variant-still-wins-over-its-story
   (testing "precedence is variant-chain FIRST, then the story — the same
@@ -108,27 +108,27 @@
             same order `canvas/variant-component` applies for the subject.
             A story-level default must not overwrite a variant that
             deliberately differs."
-    (registrar/reg-story* :story.scope-win
+    (rf.story.registrar/reg-story* :story.scope-win
       {:doc "story default" :component :views/probe :substrates #{:reagent}})
-    (registrar/reg-variant* :story.scope-win/override
+    (rf.story.registrar/reg-variant* :story.scope-win/override
       {:doc "this one variant is authored against another layer"
        :substrates #{:uix}})
     (is (= #{:uix}
-           (get-in (plan/variant-plan :story.scope-win/override)
+           (get-in (rf.story.plan/variant-plan :story.scope-win/override)
                    [:world :substrates])))))
 
 (deftest an-extends-chain-still-wins-over-its-story
   (testing "the `:extends` chain is part of the VARIANT layer, so an
             inherited declaration beats the story's too — the parent-first
             fold this bead added sits UNDER the chain, not over it"
-    (registrar/reg-story* :story.scope-ext
+    (rf.story.registrar/reg-story* :story.scope-ext
       {:doc "story default" :component :views/probe :substrates #{:reagent}})
-    (registrar/reg-variant* :story.scope-ext/base
+    (rf.story.registrar/reg-variant* :story.scope-ext/base
       {:doc "base" :substrates #{:uix}})
-    (registrar/reg-variant* :story.scope-ext/child
+    (rf.story.registrar/reg-variant* :story.scope-ext/child
       {:doc "child declares nothing of its own" :extends :story.scope-ext/base})
     (is (= #{:uix}
-           (get-in (plan/variant-plan :story.scope-ext/child)
+           (get-in (rf.story.plan/variant-plan :story.scope-ext/child)
                    [:world :substrates])))))
 
 (deftest an-empty-variant-set-declares-nothing
@@ -138,12 +138,12 @@
             through to the story rather than pinning emptiness the canvas
             would ignore. This is the row that says the fold mirrors the
             canvas's rule instead of merely adding a fallback."
-    (registrar/reg-story* :story.scope-empty
+    (rf.story.registrar/reg-story* :story.scope-empty
       {:doc "story declares" :component :views/probe :substrates #{:uix}})
-    (registrar/reg-variant* :story.scope-empty/v
+    (rf.story.registrar/reg-variant* :story.scope-empty/v
       {:doc "declares an empty set" :substrates #{}})
     (is (= #{:uix}
-           (get-in (plan/variant-plan :story.scope-empty/v)
+           (get-in (rf.story.plan/variant-plan :story.scope-empty/v)
                    [:world :substrates])))))
 
 (deftest nothing-declared-leaves-the-slot-absent
@@ -151,10 +151,10 @@
             lets `single-render-substrate` apply the host default. A fold
             that wrote `#{}` or `nil` here would be render-transparent
             today and a trap for any reader that tests presence."
-    (registrar/reg-story* :story.scope-none {:doc "declares nothing"
+    (rf.story.registrar/reg-story* :story.scope-none {:doc "declares nothing"
                                              :component :views/probe})
-    (registrar/reg-variant* :story.scope-none/v {:doc "declares nothing"})
-    (is (not (contains? (:world (plan/variant-plan :story.scope-none/v))
+    (rf.story.registrar/reg-variant* :story.scope-none/v {:doc "declares nothing"})
+    (is (not (contains? (:world (rf.story.plan/variant-plan :story.scope-none/v))
                         :substrates)))))
 
 ;; ===========================================================================
@@ -162,19 +162,19 @@
 ;; ===========================================================================
 
 (deftest a-story-level-component-reaches-the-plan-and-the-render-inputs
-  (testing "rf2-sc5g0 — `render/prepare-render` reads
+  (testing "rf2-sc5g0 — `rf.story.render/prepare-render` reads
             `(get-in plan [:world :component])` with no fallback, so the
             NORMAL authoring shape (`001-Authoring.md`: the parent story
             carries the component, variants vary by args) handed
             `render-variant` a nil view. The canvas was unaffected because
             `canvas/variant-component` walks to the story itself."
-    (registrar/reg-story* :story.scope-cmp
+    (rf.story.registrar/reg-story* :story.scope-cmp
       {:doc "the parent carries the subject" :component :views/probe})
-    (registrar/reg-variant* :story.scope-cmp/v
+    (rf.story.registrar/reg-variant* :story.scope-cmp/v
       {:doc "varies by args only" :args {:label "Go"}})
-    (let [p (plan/variant-plan :story.scope-cmp/v)]
+    (let [p (rf.story.plan/variant-plan :story.scope-cmp/v)]
       (is (= :views/probe (get-in p [:world :component]))))
-    (let [prepared (render/prepare-render :story.scope-cmp/v)]
+    (let [prepared (rf.story.render/prepare-render :story.scope-cmp/v)]
       (is (= :prepared (:status prepared)))
       (is (= :views/probe (get-in prepared [:render-inputs :view]))
           "the subject reaches the host render hook — this is the
@@ -183,21 +183,21 @@
 (deftest a-variant-component-still-overrides-its-story
   (testing "`:component` is documented as the per-variant OVERRIDE
             (`schemas/VariantBody`), so the variant's value wins"
-    (registrar/reg-story* :story.scope-cmp-ovr
+    (rf.story.registrar/reg-story* :story.scope-cmp-ovr
       {:doc "parent subject" :component :views/parent})
-    (registrar/reg-variant* :story.scope-cmp-ovr/v
+    (rf.story.registrar/reg-variant* :story.scope-cmp-ovr/v
       {:doc "names its own subject" :component :views/own})
     (is (= :views/own
-           (get-in (plan/variant-plan :story.scope-cmp-ovr/v)
+           (get-in (rf.story.plan/variant-plan :story.scope-cmp-ovr/v)
                    [:world :component])))))
 
 (deftest no-component-anywhere-leaves-the-slot-absent
   (testing "an events-only variant under a story that names no subject
             carries no `:component` slot — unchanged, and the row that
             says the fold did not start inventing one"
-    (registrar/reg-story* :story.scope-cmp-none {:doc "no subject"})
-    (registrar/reg-variant* :story.scope-cmp-none/v {:doc "no subject"})
-    (is (not (contains? (:world (plan/variant-plan :story.scope-cmp-none/v))
+    (rf.story.registrar/reg-story* :story.scope-cmp-none {:doc "no subject"})
+    (rf.story.registrar/reg-variant* :story.scope-cmp-none/v {:doc "no subject"})
+    (is (not (contains? (:world (rf.story.plan/variant-plan :story.scope-cmp-none/v))
                         :component)))))
 
 ;; ===========================================================================
@@ -211,12 +211,12 @@
             contract must not apply or not apply depending on WHICH body
             happens to name the view."
     (reg-view-meta! :views/widget {:rf/props [:map [:label :string]]})
-    (registrar/reg-story* :story.scope-schema
+    (rf.story.registrar/reg-story* :story.scope-schema
       {:doc "parent carries the subject" :component :views/widget})
-    (registrar/reg-variant* :story.scope-schema/v
+    (rf.story.registrar/reg-variant* :story.scope-schema/v
       {:doc "varies by args" :args {:label "Hi"}})
     (is (= [:map [:label :string]]
-           (get-in (plan/variant-plan :story.scope-schema/v)
+           (get-in (rf.story.plan/variant-plan :story.scope-schema/v)
                    [:world :view-args-schema])))))
 
 (deftest a-missing-required-view-input-fails-under-a-story-level-component
@@ -227,10 +227,10 @@
             row above would pass on a plan that carried the schema and
             checked nothing."
     (reg-view-meta! :views/strict {:rf/props [:map [:label :string]]})
-    (registrar/reg-story* :story.scope-strict
+    (rf.story.registrar/reg-story* :story.scope-strict
       {:doc "parent carries the subject" :component :views/strict})
-    (registrar/reg-variant* :story.scope-strict/v {:doc "supplies no args"})
-    (let [e (try (plan/variant-plan :story.scope-strict/v)
+    (rf.story.registrar/reg-variant* :story.scope-strict/v {:doc "supplies no args"})
+    (let [e (try (rf.story.plan/variant-plan :story.scope-strict/v)
                  nil
                  (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e e))]
       (is (some? e) "plan construction failed")

--- a/tools/story/test/re_frame/story/story_xray_wiring_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/story_xray_wiring_cljs_test.cljs
@@ -53,15 +53,15 @@
   Sub-second; node CLJS."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.story :as story]
-            [re-frame.story.ui.shell :as shell]
-            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.story :as rf.story]
+            [re-frame.story.ui.shell :as rf.story.ui.shell]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]
             [day8.re-frame2-xray.test-helpers.e2e-multi-frame :as xray-e2e]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- app image (EP-0026 §Default Image) ----------------------------------
 ;;
@@ -89,11 +89,11 @@
   variant's `:setup`) and the `:rf.xray/set-target-frame` dispatch
   both fire from here."
   []
-  ((deref #'shell/selection-watcher)))
+  ((deref #'rf.story.ui.shell/selection-watcher)))
 
 (defn- remove-selection-watcher!
   []
-  ((deref #'shell/remove-selection-watcher!)))
+  ((deref #'rf.story.ui.shell/remove-selection-watcher!)))
 
 (defn- register-counter-host!
   "Register the counter event the variant's `:setup` slot dispatches.
@@ -111,10 +111,10 @@
 
 (defn- register-counter-story! []
   (register-counter-host!)
-  (story/reg-story :story.counter
+  (rf.story/reg-story :story.counter
     {:doc    "Counter parent story for the Story-Xray wiring contract test."
      :images [app-image]})
-  (story/reg-variant variant-id
+  (rf.story/reg-variant variant-id
     {:doc    "Counter seeded at 5 — its :setup cascade must land in
               Xray's trace-buffer on selection."
      :setup [[:counter/initialise]]}))
@@ -136,7 +136,7 @@
             the buffer was empty AND the target-frame was stale at the
             same time. This pins the conjunction the two #1822 unit
             tests cover only separately."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories register-counter-story!}
       (fn []
         (install-selection-watcher!)
@@ -145,7 +145,7 @@
           ;; Fires `ensure-variant-frame!` → `run-variant` dispatches
           ;; `[:counter/initialise]` into the variant frame (traced into
           ;; the bus) AND `:rf.xray/set-target-frame <variant-id>`.
-          (e2e/select-variant! variant-id)
+          (rf.story.test-helpers.e2e-multi-frame/select-variant! variant-id)
           ;; Mirror the bus into Xray's `:trace-buffer` slot — production
           ;; coalesces this on next-tick; drive it inline so the slot is
           ;; observable on this tick (matches the harness convention).
@@ -187,29 +187,29 @@
             trace-buffer view (cascades now include the second variant's
             event) AND the target-frame — the empty-RHS bug would
             reappear on every switch if either half failed to re-fire."
-    (e2e/with-story-and-xray-frames
+    (rf.story.test-helpers.e2e-multi-frame/with-story-and-xray-frames
       {:register-stories
        (fn []
          (rf/reg-event :counter/initialise
            (fn [{:keys [db]} _event] {:db {:counter/value 5}}))
          (rf/reg-event :counter/seed-ten
            (fn [{:keys [db]} _event] {:db {:counter/value 10}}))
-         (story/reg-story :story.counter {:images [app-image]})
-         (story/reg-variant :story.counter/loaded
+         (rf.story/reg-story :story.counter {:images [app-image]})
+         (rf.story/reg-variant :story.counter/loaded
            {:setup [[:counter/initialise]]})
-         (story/reg-variant :story.counter/ten
+         (rf.story/reg-variant :story.counter/ten
            {:setup [[:counter/seed-ten]]}))}
       (fn []
         (install-selection-watcher!)
         (try
-          (e2e/select-variant! :story.counter/loaded)
+          (rf.story.test-helpers.e2e-multi-frame/select-variant! :story.counter/loaded)
           (xray-e2e/sync-xray-trace-mirror!)
           (rf/with-frame :rf/xray
             (is (= :story.counter/loaded
                    @(rf/subscribe [:rf.xray/target-frame]))
                 "first selection orients Xray on :story.counter/loaded"))
 
-          (e2e/select-variant! :story.counter/ten)
+          (rf.story.test-helpers.e2e-multi-frame/select-variant! :story.counter/ten)
           (xray-e2e/sync-xray-trace-mirror!)
           (rf/with-frame :rf/xray
             (is (= :story.counter/ten

--- a/tools/story/test/re_frame/story/sub_overrides_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/sub_overrides_cljs_test.cljs
@@ -17,16 +17,16 @@
   because `compute-sub` + `reg-sub` need the framework runtime."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.subs :as subs]
-            [re-frame.registrar :as registrar]
-            [re-frame.adapter.sub-override-context :as ovr-ctx]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story.sub-overrides :as sub-overrides]))
+            [re-frame.subs :as rf.subs]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.adapter.sub-override-context :as rf.adapter.sub-override-context]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story.sub-overrides :as rf.story.sub-overrides]))
 
 (use-fixtures :each
   {:before (fn []
-             (registrar/clear-all!)
-             (try (rf/init! plain-atom/adapter) (catch :default _ nil)))})
+             (rf.registrar/clear-all!)
+             (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil)))})
 
 (deftest override-does-not-leak-into-compute-sub
   (testing "a bound :sub-overrides value does NOT change what compute-sub returns"
@@ -36,29 +36,29 @@
       ;; Bind an override that pins the SAME query to a DIFFERENT value —
       ;; the render path would surface :error, but compute-sub (the seam
       ;; :rf.assert/sub-equals uses) must still see the real :ok.
-      (sub-overrides/with-overrides* {[:login/state] :error}
+      (rf.story.sub-overrides/with-overrides* {[:login/state] :error}
         (fn []
           (testing "the render-path resolver surfaces the override"
-            (is (= :error (sub-overrides/resolve [:login/state]))))
+            (is (= :error (rf.story.sub-overrides/resolve [:login/state]))))
           (testing "compute-sub is UNAFFECTED — it reads real app-db"
-            (is (= :ok (subs/compute-sub [:login/state] db))))
+            (is (= :ok (rf.subs/compute-sub [:login/state] db))))
           (testing "so a sub-equals check of the override value would FAIL"
             ;; (= (compute-sub …) override-value) is false — the override
             ;; cannot satisfy the subscription assertion.
-            (is (not= :error (subs/compute-sub [:login/state] db)))))))))
+            (is (not= :error (rf.subs/compute-sub [:login/state] db)))))))))
 
 (deftest read-seam-surfaces-override-without-touching-db
-  (testing "sub-overrides/read returns the override; real-read runs only on a miss"
+  (testing "rf.story.sub-overrides/read returns the override; real-read runs only on a miss"
     (rf/reg-sub :login/state (fn [db _] (get-in db [:login :state])))
     (let [db {:login {:state :ok}}
-          real-read #(subs/compute-sub [:login/state] db)]
-      (sub-overrides/with-overrides* {[:login/state] :error}
+          real-read #(rf.subs/compute-sub [:login/state] db)]
+      (rf.story.sub-overrides/with-overrides* {[:login/state] :error}
         (fn []
           (testing "overridden query → override value, real-read skipped"
-            (is (= :error (sub-overrides/read [:login/state]
+            (is (= :error (rf.story.sub-overrides/read [:login/state]
                                               (fn [] (throw (ex-info "real-read should not run" {})))))))
           (testing "non-overridden query → falls through to compute-sub"
-            (is (= :ok (sub-overrides/read [:login/other] real-read)))))))))
+            (is (= :ok (rf.story.sub-overrides/read [:login/other] real-read)))))))))
 
 ;; ---- the React-context resolver (the LIVE carriage, rf2-7pgiz) -----------
 ;;
@@ -73,30 +73,30 @@
 ;; (`re-frame.story.sub-overrides-render-dom-cljs-test`).
 
 (defn- with-context-overrides* [m thunk]
-  (let [prev (.-_currentValue ^js ovr-ctx/override-context)]
-    (set! (.-_currentValue ^js ovr-ctx/override-context) m)
+  (let [prev (.-_currentValue ^js rf.adapter.sub-override-context/override-context)]
+    (set! (.-_currentValue ^js rf.adapter.sub-override-context/override-context) m)
     (try (thunk)
-         (finally (set! (.-_currentValue ^js ovr-ctx/override-context) prev)))))
+         (finally (set! (.-_currentValue ^js rf.adapter.sub-override-context/override-context) prev)))))
 
 (deftest context-resolver-returns-one-element-vector-on-hit
   (testing "resolve-sub-override-hit reads the context Provider value"
     (with-context-overrides* {[:login/state] :error}
       (fn []
         (testing "exact-query-vector hit → [value]"
-          (is (= [:error] (sub-overrides/resolve-sub-override-hit [:login/state]))))
+          (is (= [:error] (rf.story.sub-overrides/resolve-sub-override-hit [:login/state]))))
         (testing "non-overridden query → nil (miss)"
-          (is (nil? (sub-overrides/resolve-sub-override-hit [:login/other]))))))))
+          (is (nil? (rf.story.sub-overrides/resolve-sub-override-hit [:login/other]))))))))
 
 (deftest context-resolver-honours-nil-valued-override
   (testing "a nil-valued override is a HIT — returns [nil], not nil-the-miss"
     (with-context-overrides* {[:x/value] nil}
       (fn []
-        (is (= [nil] (sub-overrides/resolve-sub-override-hit [:x/value]))
+        (is (= [nil] (rf.story.sub-overrides/resolve-sub-override-hit [:x/value]))
             "nil override surfaces as a [nil] hit (one-element-vector contract)")))))
 
 (deftest context-resolver-misses-with-no-provider
   (testing "no Provider in scope (_currentValue nil) → every query misses"
     ;; The fixture's runtime reset leaves the context at its createContext
     ;; default (nil); assert a miss without setting any value.
-    (set! (.-_currentValue ^js ovr-ctx/override-context) nil)
-    (is (nil? (sub-overrides/resolve-sub-override-hit [:anything])))))
+    (set! (.-_currentValue ^js rf.adapter.sub-override-context/override-context) nil)
+    (is (nil? (rf.story.sub-overrides/resolve-sub-override-hit [:anything])))))

--- a/tools/story/test/re_frame/story/sub_overrides_render_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/sub_overrides_render_dom_cljs_test.cljs
@@ -24,19 +24,19 @@
             ["react-dom/client" :as react-dom-client]
             [reagent.core :as r]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.subs :as subs]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
-            [re-frame.story.sub-overrides :as sub-overrides]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.subs :as rf.subs]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.story.sub-overrides :as rf.story.sub-overrides]))
 
 ;; `make-reset-runtime-fixture` performs the snapshot/restore + frames-reset +
 ;; adapter dispose/install this suite hand-rolled. `:ambient-frame nil` preserves
 ;; the suite's no-ambient-scope behaviour — each render-based test binds its own
 ;; `*current-frame* :rf/default` around the mount.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter :ambient-frame nil}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter :ambient-frame nil}))
 
 ;; ---- browser + act gate (mirrors react-shared-suite) ----------------------
 
@@ -97,12 +97,12 @@
            ;; the view's subscribe resolves a frame (the fixture already ensured
            ;; the `:rf/default` frame exists) instead of raising
            ;; :rf.error/no-frame-context.
-           (binding [frame/*current-frame* :rf/default]
+           (binding [rf.frame/*current-frame* :rf/default]
              (act-fn
                (fn []
                  (.render root
                    (r/as-element
-                     (sub-overrides/override-provider overrides [login-panel]))))))
+                     (rf.story.sub-overrides/override-provider overrides [login-panel]))))))
            (let [text (.-textContent mount-node)]
              (is (re-find #"error" text)
                  "the pinned :error state surfaces in the rendered DOM")
@@ -127,12 +127,12 @@
            ;; (rf2-9o48ih): bind the ambient `:rf/default` frame around the
            ;; render so the plain-fn view's subscribe resolves a frame via the
            ;; dynamic-var tier (the override-provider carries no frame scope).
-           (binding [frame/*current-frame* :rf/default]
+           (binding [rf.frame/*current-frame* :rf/default]
              (act-fn
                (fn []
                  (.render root
                    (r/as-element
-                     (sub-overrides/override-provider nil [login-panel]))))))
+                     (rf.story.sub-overrides/override-provider nil [login-panel]))))))
            (let [text (.-textContent mount-node)]
              (is (re-find #"idle" text)
                  "no override → the real idle state renders")
@@ -155,7 +155,7 @@
        ;; both need a carried frame. Bind the ambient `:rf/default` scope
        ;; (the fixture ensured the frame exists) around the seed dispatch and
        ;; the synchronous `act` render so neither raises no-frame-context.
-       (binding [frame/*current-frame* :rf/default]
+       (binding [rf.frame/*current-frame* :rf/default]
        (rf/dispatch-sync [::seed])
        (let [overrides  {[:login/state] :error}
              mount-node (make-mount-node!)
@@ -165,12 +165,12 @@
              (fn []
                (.render root
                  (r/as-element
-                   (sub-overrides/override-provider overrides [login-panel])))))
+                   (rf.story.sub-overrides/override-provider overrides [login-panel])))))
            (testing "the screen shows the OVERRIDE (:error)"
              (is (re-find #"error" (.-textContent mount-node))))
            (testing "but compute-sub — the :rf.assert/sub-equals seam — still reads :ok"
-             (is (= :ok (subs/compute-sub [:login/state] {:login {:state :ok}})))
-             (is (not= :error (subs/compute-sub [:login/state] {:login {:state :ok}}))
+             (is (= :ok (rf.subs/compute-sub [:login/state] {:login {:state :ok}})))
+             (is (not= :error (rf.subs/compute-sub [:login/state] {:login {:state :ok}}))
                  "the override can never satisfy a sub-equals assertion"))
            (finally
              (try (.unmount root) (catch :default _ nil))))))))))

--- a/tools/story/test/re_frame/story/tags_test.cljc
+++ b/tools/story/test/re_frame/story/tags_test.cljc
@@ -7,51 +7,51 @@
   compiler (`re-frame.story.plan`) with an explicit `:lookup`; the filter
   regression proves the snapshot projection feeds the sidebar filter."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.tags :as tags]
-            [re-frame.story.plan :as plan]
-            [re-frame.story.ui.state.filters :as filters]))
+            [re-frame.story.tags :as rf.story.tags]
+            [re-frame.story.plan :as rf.story.plan]
+            [re-frame.story.ui.state.filters :as rf.story.ui.state.filters]))
 
 ;; ---- pure marker helpers -------------------------------------------------
 
 (deftest removal-marker?-recognises-bang-prefix
-  (is (true?  (tags/removal-marker? :!dev)))
-  (is (true?  (tags/removal-marker? :a/!b)))
-  (is (false? (tags/removal-marker? :dev)))
-  (is (false? (tags/removal-marker? :a/b)))
-  (is (false? (tags/removal-marker? "not-a-keyword")))
-  (is (false? (tags/removal-marker? nil))))
+  (is (true?  (rf.story.tags/removal-marker? :!dev)))
+  (is (true?  (rf.story.tags/removal-marker? :a/!b)))
+  (is (false? (rf.story.tags/removal-marker? :dev)))
+  (is (false? (rf.story.tags/removal-marker? :a/b)))
+  (is (false? (rf.story.tags/removal-marker? "not-a-keyword")))
+  (is (false? (rf.story.tags/removal-marker? nil))))
 
 (deftest marker-base-strips-bang-preserving-namespace
-  (is (= :dev (tags/marker-base :!dev)))
-  (is (= :a/b (tags/marker-base :a/!b)))
+  (is (= :dev (rf.story.tags/marker-base :!dev)))
+  (is (= :a/b (rf.story.tags/marker-base :a/!b)))
   (testing "a non-marker is returned unchanged"
-    (is (= :dev (tags/marker-base :dev)))))
+    (is (= :dev (rf.story.tags/marker-base :dev)))))
 
 (deftest resolve-markers-strips-and-subtracts
   (testing "a marker drops itself AND subtracts its base"
-    (is (= #{:docs} (tags/resolve-markers #{:dev :!dev :docs}))))
+    (is (= #{:docs} (rf.story.tags/resolve-markers #{:dev :!dev :docs}))))
   (testing "a marker with no matching base still never surfaces"
-    (is (= #{} (tags/resolve-markers #{:!dev}))))
+    (is (= #{} (rf.story.tags/resolve-markers #{:!dev}))))
   (testing "a set with no markers is returned unchanged"
-    (is (= #{:dev :docs} (tags/resolve-markers #{:dev :docs}))))
+    (is (= #{:dev :docs} (rf.story.tags/resolve-markers #{:dev :docs}))))
   (testing "namespaced marker cancels its namespaced base"
-    (is (= #{:team/qa} (tags/resolve-markers #{:team/qa :role/dev :role/!dev})))))
+    (is (= #{:team/qa} (rf.story.tags/resolve-markers #{:team/qa :role/dev :role/!dev})))))
 
 ;; ---- extends-chain union -------------------------------------------------
 
 (deftest extends-chain-tags-unions-root-to-child
   (let [m {:story.a/parent {:tags #{:dev :test}}
            :story.a/child  {:extends :story.a/parent :tags #{:docs}}}]
-    (is (= #{:dev :test :docs} (tags/extends-chain-tags :story.a/child m)))))
+    (is (= #{:dev :test :docs} (rf.story.tags/extends-chain-tags :story.a/child m)))))
 
 (deftest extends-chain-tags-is-defensive
   (testing "a missing parent stops the walk without raising"
     (let [m {:story.a/child {:extends :story.a/ghost :tags #{:docs}}}]
-      (is (= #{:docs} (tags/extends-chain-tags :story.a/child m)))))
+      (is (= #{:docs} (rf.story.tags/extends-chain-tags :story.a/child m)))))
   (testing "a cycle stops the walk without raising"
     (let [m {:story.a/x {:extends :story.a/y :tags #{:dev}}
              :story.a/y {:extends :story.a/x :tags #{:docs}}}]
-      (is (= #{:dev :docs} (tags/extends-chain-tags :story.a/x m))))))
+      (is (= #{:dev :docs} (rf.story.tags/extends-chain-tags :story.a/x m))))))
 
 ;; ---- effective-tags: inheritance + markers -------------------------------
 
@@ -60,7 +60,7 @@
             :!dev; the inherited :dev is removed and :!dev never surfaces"
     (let [m {:story.login/base  {:tags #{:dev :test}}
              :story.login/child {:extends :story.login/base :tags #{:!dev}}}
-          eff (tags/effective-tags :story.login/child {:variant m})]
+          eff (rf.story.tags/effective-tags :story.login/child {:variant m})]
       (is (= #{:test} eff))
       (is (not (contains? eff :dev)))
       (is (not (contains? eff :!dev))))))
@@ -71,19 +71,19 @@
         stories  {:story.t {:tags #{:dev :docs}}}
         lookups  {:variant variants :story stories}]
     (testing "a variant that declares none inherits the parent story's tags"
-      (is (= #{:dev :docs} (tags/effective-tags :story.t/no-tags lookups))))
+      (is (= #{:dev :docs} (rf.story.tags/effective-tags :story.t/no-tags lookups))))
     (testing "a variant that declares its own tags does NOT union with the story"
-      (is (= #{:test} (tags/effective-tags :story.t/own-tags lookups))))))
+      (is (= #{:test} (rf.story.tags/effective-tags :story.t/own-tags lookups))))))
 
 (deftest effective-tags-empty-when-nothing-declared
-  (is (= #{} (tags/effective-tags :story.none/v {:variant {:story.none/v {}}}))))
+  (is (= #{} (rf.story.tags/effective-tags :story.none/v {:variant {:story.none/v {}}}))))
 
 ;; ---- resolve-body-tags projection ----------------------------------------
 
 (deftest resolve-body-tags-projects-effective-onto-each-body
   (let [variants {:story.p/base  {:tags #{:dev}}
                   :story.p/child {:extends :story.p/base :tags #{:!dev :docs}}}
-        projected (tags/resolve-body-tags variants)]
+        projected (rf.story.tags/resolve-body-tags variants)]
     (is (= #{:dev}  (:tags (:story.p/base projected))))
     (is (= #{:docs} (:tags (:story.p/child projected)))
         "the child's inherited :dev is cancelled by :!dev; :!dev is stripped")
@@ -97,8 +97,8 @@
     (let [variants  {:story.f/base  {:tags #{:dev}}
                      :story.f/child {:extends :story.f/base :tags #{:!dev}}
                      :story.f/keeps {:tags #{:dev}}}
-          projected (tags/resolve-body-tags variants)
-          dev-hits  (set (keys (filters/filter-variants projected #{:dev})))]
+          projected (rf.story.tags/resolve-body-tags variants)
+          dev-hits  (set (keys (rf.story.ui.state.filters/filter-variants projected #{:dev})))]
       (testing "the child that removed :dev is filtered out"
         (is (not (contains? dev-hits :story.f/child))))
       (testing "variants that keep :dev (own + inherited-untouched) still match"
@@ -115,7 +115,7 @@
              :story.login/error  {:extends    :story.login/filled
                                    :tags       #{:!dev}
                                    :setup     []}}
-          p (plan/variant-plan :story.login/error {:lookup m})]
+          p (rf.story.plan/variant-plan :story.login/error {:lookup m})]
       (is (= #{:test} (:tags p)))
       (is (= #{:test} (get-in p [:explain :tags])))
       (is (not (contains? (:tags p) :dev)))
@@ -125,7 +125,7 @@
   (testing "the additive :extends union is preserved when no marker is present"
     (let [m {:story.s/parent {:tags #{:test} :setup []}
              :story.s/child  {:extends :story.s/parent :tags #{:docs} :setup []}}
-          p (plan/variant-plan :story.s/child {:lookup m})]
+          p (rf.story.plan/variant-plan :story.s/child {:lookup m})]
       (is (= #{:test :docs} (:tags p))))))
 
 (deftest plan-tags-story-fallback-via-story-lookup
@@ -133,5 +133,5 @@
             the :story-lookup opt"
     (let [m {:story.fb/v {:setup []}}
           stories {:story.fb {:tags #{:dev :docs}}}
-          p (plan/variant-plan :story.fb/v {:lookup m :story-lookup stories})]
+          p (rf.story.plan/variant-plan :story.fb/v {:lookup m :story-lookup stories})]
       (is (= #{:dev :docs} (:tags p))))))

--- a/tools/story/test/re_frame/story/test_helpers/e2e_multi_frame.cljs
+++ b/tools/story/test/re_frame/story/test_helpers/e2e_multi_frame.cljs
@@ -69,9 +69,9 @@
   around `use-fixtures :each`) handles frame disposal and registrar
   restoration."
   (:require [re-frame.core :as rf]
-            [re-frame.subs :as subs]
-            [re-frame.story :as story]
-            [re-frame.story.ui.state :as ui-state]
+            [re-frame.subs :as rf.subs]
+            [re-frame.story :as rf.story]
+            [re-frame.story.ui.state :as rf.story.ui.state]
             [day8.re-frame2-xray.test-helpers.e2e-multi-frame :as xray-e2e]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
@@ -81,7 +81,7 @@
   "Canonical Story install path used by `with-story-and-xray-frames`
   when the caller did not supply `:install-story`.
 
-  - `story/clear-all!` — wipe the Story side-table. Per the impl,
+  - `rf.story/clear-all!` — wipe the Story side-table. Per the impl,
     this is `registrar/clear-all!` — i.e. drops every registered
     handler, sub, fx, machine, etc. (NOT just Story-side entries).
   - Re-register the framework-shipped `:rf/machine` sub. The
@@ -93,26 +93,26 @@
     sub is a runtime-db sub reading
     `[:rf.runtime/machines :snapshots <id>]` — NOT the retired app-db
     `:rf/runtime` path.
-  - `story/install-canonical-vocabulary!` — register the
+  - `rf.story/install-canonical-vocabulary!` — register the
     `:rf.story.lifecycle/machine` + helper events the runtime
     depends on.
-  - `ui-state/reset-shell-state!` — reset the shell ratom so prior
+  - `rf.story.ui.state/reset-shell-state!` — reset the shell ratom so prior
     tests' :selected-variant / :chrome-visibility leakage does not
     bleed into this run.
 
   Idempotent."
   []
-  (story/clear-all!)
+  (rf.story/clear-all!)
   ;; Re-register the framework's `:rf/machine` sub after the clear-all.
   ;; Mirrors the `reset-all!` pattern in `re-frame.story-runtime-cljs-test`.
   ;; EP-0001 (rf2-vzld77 / rf2-ixb0bq): a runtime-db sub reading
   ;; `[:rf.runtime/machines :snapshots <id>]`, NOT the retired app-db
   ;; `:rf/runtime` path.
-  (subs/reg-runtime-sub :rf/machine
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [runtime-db [_ machine-id]]
       (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
-  (story/install-canonical-vocabulary!)
-  (ui-state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.story.ui.state/reset-shell-state!)
   nil)
 
 ;; ---- harness -------------------------------------------------------------
@@ -127,19 +127,19 @@
                        `install-story-default!`.
     :install-xray   — zero-arg fn to install Xray. Defaults to
                        `xray-e2e/install-xray-default!`.
-    :register-stories — zero-arg fn that calls `(story/reg-story ...)`
-                       and `(story/reg-variant ...)` so the registrar
+    :register-stories — zero-arg fn that calls `(rf.story/reg-story ...)`
+                       and `(rf.story/reg-variant ...)` so the registrar
                        knows about the variants the test will exercise.
 
   `body-fn` runs inside the harness; usage:
 
       (with-story-and-xray-frames
         {:register-stories (fn []
-                             (story/reg-variant :story.counter/loaded
+                             (rf.story/reg-variant :story.counter/loaded
                                {:setup [[:counter/initialise 5]]}))}
         (fn []
           (async done
-            (-> (story/run-variant :story.counter/loaded)
+            (-> (rf.story/run-variant :story.counter/loaded)
                 (async-lib/then (fn [r] ...))))))
 
   Teardown clears the trace-bus buffer + resets shell state."
@@ -155,7 +155,7 @@
       (body-fn)
       (finally
         (trace-collector/reset-for-test!)
-        (ui-state/reset-shell-state!)))))
+        (rf.story.ui.state/reset-shell-state!)))))
 
 ;; ---- dispatch / subscribe helpers ----------------------------------------
 
@@ -189,7 +189,7 @@
   `sidebar/clickVariant` does in the browser without going through
   the DOM."
   [variant-id]
-  (ui-state/swap-state! ui-state/select-variant variant-id)
+  (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant variant-id)
   nil)
 
 ;; ---- hiccup walking ------------------------------------------------------
@@ -348,4 +348,4 @@
   read-wrapper so tests assert against a known shape (rather than the
   test reaching into the ratom directly)."
   []
-  (ui-state/chrome-visibility (ui-state/get-state)))
+  (rf.story.ui.state/chrome-visibility (rf.story.ui.state/get-state)))

--- a/tools/story/test/re_frame/story/test_support_test.clj
+++ b/tools/story/test/re_frame/story/test_support_test.clj
@@ -21,13 +21,13 @@
   resolved `CompletableFuture`, so the lifecycle result is observable
   inline."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story :as story]
-            [re-frame.story.config :as config]
-            [re-frame.story.play :as play]
-            [re-frame.story.test-support :as story-test]
-            [re-frame.story.play.runner-events :as runner-events]))
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.play :as rf.story.play]
+            [re-frame.story.test-support :as rf.story.test-support]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]))
 
 ;; The fixture under test IS the helper — required DIRECTLY from
 ;; `re-frame.story.test-support` (it is NOT on the `re-frame.story` facade
@@ -35,14 +35,14 @@
 ;; with the fn form per the `.cljc` cross-platform rule (the map form
 ;; silently skips on the JVM; see `re-frame.story.meta-fixtures-test`).
 (use-fixtures :each
-  (story-test/use-fixtures
-    {:adapter plain-atom/adapter
-     :install [#(story/reg-variant :story.fixture/seeded
+  (rf.story.test-support/use-fixtures
+    {:adapter rf.substrate.plain-atom/adapter
+     :install [#(rf.story/reg-variant :story.fixture/seeded
                   {:tags  #{:test}
                    :setup [[:rf.story.test/noop]]})]}))
 
 (defn- run-target [target]
-  (.get ^java.util.concurrent.CompletableFuture (story/run-variant target)))
+  (.get ^java.util.concurrent.CompletableFuture (rf.story/run-variant target)))
 
 ;; ---- 1. no :pre-mount footgun --------------------------------------------
 
@@ -51,7 +51,7 @@
             the canonical vocabulary + lifecycle machine survive the
             reset, so the variant is NOT trapped at :pre-mount (rf2-lh99f
             — the footgun this helper closes)"
-    (story/reg-variant :story.fixture/lands-ready
+    (rf.story/reg-variant :story.fixture/lands-ready
       {:tags   #{:test}
        :script [[:dispatch-sync [:rf.assert/no-warnings]]]})
     (let [result (run-target :story.fixture/lands-ready)]
@@ -65,13 +65,13 @@
             the :rf.assert/* event handlers are registered on the FRAMEWORK
             registrar (they're reg-event handlers, not Story side-table
             entries)"
-    (let [events (registrar/registrations :event)]
+    (let [events (rf.registrar/registrations :event)]
       (is (contains? events :rf.assert/path-equals)
           ":rf.assert/path-equals handler present after the reset")
       ;; The eighth canonical id (:rf.assert/schema-error) is tape-evaluated,
       ;; never a registered handler — so the REGISTERED set is the seven.
       (is (= 7 (count (filter #(contains? events %)
-                              (story/canonical-assertion-ids))))
+                              (rf.story/canonical-assertion-ids))))
           "all seven REGISTERED canonical assertion handlers present"))))
 
 ;; ---- 2. per-test isolation + run-state wipe ------------------------------
@@ -79,35 +79,35 @@
 (deftest install-thunk-ran-and-isolation-holds-a
   (testing "the :install thunk registered :story.fixture/seeded; a variant
             registered ONLY in another test is absent here (isolation)"
-    (is (story/registered? :variant :story.fixture/seeded)
+    (is (rf.story/registered? :variant :story.fixture/seeded)
         "the :install thunk ran against the fresh registry")
-    (is (not (story/registered? :variant :story.fixture/only-in-b))
+    (is (not (rf.story/registered? :variant :story.fixture/only-in-b))
         "a variant from a sibling test did not leak in")
-    (story/reg-variant :story.fixture/only-in-a {:tags #{:test}})))
+    (rf.story/reg-variant :story.fixture/only-in-a {:tags #{:test}})))
 
 (deftest install-thunk-ran-and-isolation-holds-b
   (testing "the sibling test sees its OWN clean slate — :only-in-a from the
             previous test is gone (the registrar snapshot was restored)"
-    (is (story/registered? :variant :story.fixture/seeded)
+    (is (rf.story/registered? :variant :story.fixture/seeded)
         "the :install thunk ran again for this test")
-    (is (not (story/registered? :variant :story.fixture/only-in-a))
+    (is (not (rf.story/registered? :variant :story.fixture/only-in-a))
         "the previous test's variant was rolled back")
-    (story/reg-variant :story.fixture/only-in-b {:tags #{:test}})))
+    (rf.story/reg-variant :story.fixture/only-in-b {:tags #{:test}})))
 
 (deftest run-state-wiped-between-tests
   (testing "the helper wipes the per-variant play run-state — a run in this
             test does not observe a previous test's run-state"
     ;; Nothing should be in the run-state at test start (fresh wipe).
-    (is (empty? @runner-events/run-state)
+    (is (empty? @rf.story.play.runner-events/run-state)
         "play run-state is empty at the start of a freshly-reset test")
-    (story/reg-variant :story.fixture/runs
+    (rf.story/reg-variant :story.fixture/runs
       {:tags   #{:test}
        :script [[:dispatch-sync [:rf.assert/no-warnings]]]})
     (run-target :story.fixture/runs)
     ;; After a run the run-state carries this variant's outcome; the NEXT
     ;; test's fixture will wipe it (proven by the empty? check above firing
     ;; clean across the suite's deterministic-but-unordered test order).
-    (is (contains? @runner-events/run-state :story.fixture/runs)
+    (is (contains? @rf.story.play.runner-events/run-state :story.fixture/runs)
         "the run recorded its run-state for this frame")))
 
 ;; ---- 2b. play-atom isolation (rf2-eztym.2) -------------------------------
@@ -116,43 +116,43 @@
 ;; `pending-exceptions` and `stepper-state`. Per-frame teardown
 ;; (`frames/destroy!`) evicts them one frame at a time, but a registry reset
 ;; that bypasses frame teardown previously left both populated. The canonical
-;; test-reset path (`story/clear-all!` → `play/clear-all-play-state!`, and
+;; test-reset path (`rf.story/clear-all!` → `rf.story.play/clear-all-play-state!`, and
 ;; `story-reset!` via the fixture) must now wipe both, else a stepper /
 ;; pending-exception session in one test leaks into the next: a stale
 ;; `stepper-state` entry makes `play-stepper-active?` report a session the
 ;; later test never began.
 
 (deftest clear-all-evicts-play-atoms
-  (testing "story/clear-all! wipes pending-exceptions + stepper-state — the
+  (testing "rf.story/clear-all! wipes pending-exceptions + stepper-state — the
             remaining un-reset per-process play state (rf2-eztym.2)"
     ;; Dirty both atoms directly (the per-frame mutators are private; these
     ;; are the slots a real begin-stepper! / handler-exception capture fill).
-    (reset! play/pending-exceptions {:story.leak/frame [{:op-type :error}]})
-    (reset! play/stepper-state      {:story.leak/frame {:remaining [] :ran [] :results []}})
-    (is (play/play-stepper-active? :story.leak/frame)
+    (reset! rf.story.play/pending-exceptions {:story.leak/frame [{:op-type :error}]})
+    (reset! rf.story.play/stepper-state      {:story.leak/frame {:remaining [] :ran [] :results []}})
+    (is (rf.story.play/play-stepper-active? :story.leak/frame)
         "sanity: the stale stepper session reads active before the reset")
-    (story/clear-all!)
-    (is (= {} @play/pending-exceptions)
+    (rf.story/clear-all!)
+    (is (= {} @rf.story.play/pending-exceptions)
         "clear-all! emptied pending-exceptions")
-    (is (= {} @play/stepper-state)
+    (is (= {} @rf.story.play/stepper-state)
         "clear-all! emptied stepper-state")
-    (is (not (play/play-stepper-active? :story.leak/frame))
+    (is (not (rf.story.play/play-stepper-active? :story.leak/frame))
         "the stale stepper session is gone — play-stepper-active? reads false")))
 
 (deftest story-reset-evicts-play-atoms
   (testing "the fixture's story-reset! (run via with-clean-registry) fully
             clears both play atoms, so no stepper / pending-exception state
             bleeds across a reset that bypasses frame teardown (rf2-eztym.2)"
-    (reset! play/pending-exceptions {:story.leak/frame [{:op-type :error}]})
-    (reset! play/stepper-state      {:story.leak/frame {:remaining [] :ran [] :results []}})
-    (story-test/with-clean-registry
-      {:adapter plain-atom/adapter}
+    (reset! rf.story.play/pending-exceptions {:story.leak/frame [{:op-type :error}]})
+    (reset! rf.story.play/stepper-state      {:story.leak/frame {:remaining [] :ran [] :results []}})
+    (rf.story.test-support/with-clean-registry
+      {:adapter rf.substrate.plain-atom/adapter}
       (fn []
-        (is (= {} @play/pending-exceptions)
+        (is (= {} @rf.story.play/pending-exceptions)
             "story-reset! emptied pending-exceptions inside the bracket")
-        (is (= {} @play/stepper-state)
+        (is (= {} @rf.story.play/stepper-state)
             "story-reset! emptied stepper-state inside the bracket")
-        (is (not (play/play-stepper-active? :story.leak/frame))
+        (is (not (rf.story.play/play-stepper-active? :story.leak/frame))
             "no stale stepper session survives the reset")
         nil))))
 
@@ -162,10 +162,10 @@
   (testing "with-clean-registry runs the thunk inside a full reset and
             returns its value; the variant reaches :ready inside the bracket"
     (let [lifecycle
-          (story-test/with-clean-registry
-            {:adapter plain-atom/adapter}
+          (rf.story.test-support/with-clean-registry
+            {:adapter rf.substrate.plain-atom/adapter}
             (fn []
-              (story/reg-variant :story.fixture/bracketed
+              (rf.story/reg-variant :story.fixture/bracketed
                 {:tags   #{:test}
                  :script [[:dispatch-sync [:rf.assert/no-warnings]]]})
               (:lifecycle (run-target :story.fixture/bracketed))))]
@@ -174,7 +174,7 @@
 
 ;; ---- 4. config-leak isolation (rf2-6ez1u) --------------------------------
 ;;
-;; The fixture (`story-reset!`) calls `config/reset-all!`, which restores
+;; The fixture (`story-reset!`) calls `rf.story.config/reset-all!`, which restores
 ;; every leakable process-global config atom. These tests lock that a
 ;; `configure!` (or any config mutation) in one test cannot leak into a
 ;; sibling test in the same JVM run. The footgun the bead names:
@@ -188,33 +188,33 @@
 ;; clojure.test's run order.
 
 (deftest config-reset-all-restores-every-leakable-atom
-  (testing "config/reset-all! (called by the fixture) restores every
+  (testing "rf.story.config/reset-all! (called by the fixture) restores every
             leakable config atom to its load-time default — direct,
             order-independent unit coverage of the reset surface
             (rf2-6ez1u)"
     ;; Dirty every leakable atom via the public configure! surface…
-    (story/configure! {:rf.story/global-args     {:theme :dark}
+    (rf.story/configure! {:rf.story/global-args     {:theme :dark}
                        :rf.story/editor          :cursor
                        :rf.story/project-root    "/tmp/proj"
                        :rf.story/egress-profile  :rf.egress/local-raw})
-    (config/note-suppressed! :some.variant/x)
-    (config/add-global-decorator! [:some/global-decorator])
+    (rf.story.config/note-suppressed! :some.variant/x)
+    (rf.story.config/add-global-decorator! [:some/global-decorator])
     ;; sanity: the mutations landed
-    (is (= {:theme :dark} (config/get-global-args)))
-    (is (= :rf.egress/local-raw @config/session-egress-profile))
+    (is (= {:theme :dark} (rf.story.config/get-global-args)))
+    (is (= :rf.egress/local-raw @rf.story.config/session-egress-profile))
     ;; …then reset and assert the pristine load-time defaults.
-    (config/reset-all!)
-    (is (= {}      (config/get-global-args))      "global-args → {}")
-    (is (= []      (config/get-global-decorators)) "global-decorators → []")
-    (is (= :vscode (config/get-editor))           "editor → :vscode")
-    (is (nil?      (config/get-project-root))     "project-root → nil")
-    (is (= :rf.egress/local-redacted @config/session-egress-profile)
+    (rf.story.config/reset-all!)
+    (is (= {}      (rf.story.config/get-global-args))      "global-args → {}")
+    (is (= []      (rf.story.config/get-global-decorators)) "global-decorators → []")
+    (is (= :vscode (rf.story.config/get-editor))           "editor → :vscode")
+    (is (nil?      (rf.story.config/get-project-root))     "project-root → nil")
+    (is (= :rf.egress/local-redacted @rf.story.config/session-egress-profile)
         "egress-profile → :rf.egress/local-redacted")
-    (is (= 0       (config/suppressed-count :some.variant/x))
+    (is (= 0       (rf.story.config/suppressed-count :some.variant/x))
         "suppressed-counters → {}")))
 
 (deftest config-reset-all-leaves-toggle-off-callbacks
-  (testing "config/reset-all! does NOT clear toggle-off-callbacks — those
+  (testing "rf.story.config/reset-all! does NOT clear toggle-off-callbacks — those
             are load-time module registrations, not per-test state
             (rf2-6ez1u). Resetting egress-profile also does not FIRE them
             (reset! restores the default; it does not simulate a runtime
@@ -222,59 +222,59 @@
     (let [fired (atom 0)]
       ;; rf2-6z4znr — toggle-off callbacks now take the narrowed frame-id
       ;; (nil on a session-pin narrow).
-      (config/register-toggle-off-callback! ::probe (fn [_frame-id] (swap! fired inc)))
+      (rf.story.config/register-toggle-off-callback! ::probe (fn [_frame-id] (swap! fired inc)))
       ;; widen to raw via the public surface, then reset-all!
-      (config/set-egress-profile! :rf.egress/local-raw)
-      (config/reset-all!)
+      (rf.story.config/set-egress-profile! :rf.egress/local-raw)
+      (rf.story.config/reset-all!)
       (try
-        (is (= :rf.egress/local-redacted @config/session-egress-profile)
+        (is (= :rf.egress/local-redacted @rf.story.config/session-egress-profile)
             "the profile was restored to its redacting default")
         (is (zero? @fired)
             "reset-all! restored the profile without firing the toggle-off hook")
         ;; the callback is still REGISTERED — a real runtime narrowing fires it
-        (config/set-egress-profile! :rf.egress/local-raw)
-        (config/set-egress-profile! :rf.egress/local-redacted)
+        (rf.story.config/set-egress-profile! :rf.egress/local-raw)
+        (rf.story.config/set-egress-profile! :rf.egress/local-redacted)
         (is (= 1 @fired)
             "the load-time callback survived reset-all! and still fires on a
              real reveal → redact runtime narrowing")
         (finally
-          (config/unregister-toggle-off-callback! ::probe))))))
+          (rf.story.config/unregister-toggle-off-callback! ::probe))))))
 
 (deftest config-isolation-a
   (testing "this test sees a pristine global config (no sibling leaked into
             it) THEN dirties global-args — the fixture must roll it back
             before config-isolation-b runs (rf2-6ez1u)"
-    (is (= {} (config/get-global-args))
+    (is (= {} (rf.story.config/get-global-args))
         "global-args is the pristine {} default — no sibling test leaked a
          configure! into this one")
-    (is (= :rf.egress/local-redacted @config/session-egress-profile)
+    (is (= :rf.egress/local-redacted @rf.story.config/session-egress-profile)
         "egress-profile is the pristine :rf.egress/local-redacted default")
     ;; A variant with NO args resolves to exactly the empty global layer.
-    (story/reg-variant :story.cfg/probe-a {:tags #{:test}})
-    (is (= {} (story/resolve-args :story.cfg/probe-a))
+    (rf.story/reg-variant :story.cfg/probe-a {:tags #{:test}})
+    (is (= {} (rf.story/resolve-args :story.cfg/probe-a))
         "with a clean global layer, an arg-less variant resolves to {}")
     ;; Now leak a Layer-1 global arg + widen the egress profile. If the
-    ;; fixture's config/reset-all! did NOT run, config-isolation-b would
+    ;; fixture's rf.story.config/reset-all! did NOT run, config-isolation-b would
     ;; observe these.
-    (story/configure! {:rf.story/global-args     {:rf.cfg/leaked :from-a}
+    (rf.story/configure! {:rf.story/global-args     {:rf.cfg/leaked :from-a}
                        :rf.story/egress-profile  :rf.egress/local-raw})
-    (is (= {:rf.cfg/leaked :from-a} (story/resolve-args :story.cfg/probe-a))
+    (is (= {:rf.cfg/leaked :from-a} (rf.story/resolve-args :story.cfg/probe-a))
         "the leaked global arg IS Layer 1 of resolution within this test —
          which is exactly why it must not survive into the next")))
 
 (deftest config-isolation-b
   (testing "the sibling test sees its OWN clean config slate — the
             global-args + egress-profile config-isolation-a set are gone
-            (config/reset-all! ran in the fixture between them) (rf2-6ez1u)"
-    (is (= {} (config/get-global-args))
+            (rf.story.config/reset-all! ran in the fixture between them) (rf2-6ez1u)"
+    (is (= {} (rf.story.config/get-global-args))
         "config-isolation-a's leaked global-args did NOT survive the reset")
-    (is (= :rf.egress/local-redacted @config/session-egress-profile)
+    (is (= :rf.egress/local-redacted @rf.story.config/session-egress-profile)
         "config-isolation-a's egress-profile widening did NOT survive the reset")
-    (story/reg-variant :story.cfg/probe-b {:tags #{:test}})
-    (is (= {} (story/resolve-args :story.cfg/probe-b))
+    (rf.story/reg-variant :story.cfg/probe-b {:tags #{:test}})
+    (is (= {} (rf.story/resolve-args :story.cfg/probe-b))
         "with the global layer reset, an arg-less variant resolves to {} —
          NOT to {:rf.cfg/leaked :from-a} (the green-but-wrong footgun this
          closes)")
     ;; leak our own, symmetric to the a/b pattern — config-isolation-a's
     ;; reset proves the converse direction too under either run order.
-    (story/configure! {:rf.story/global-args {:rf.cfg/leaked :from-b}})))
+    (rf.story/configure! {:rf.story/global-args {:rf.cfg/leaked :from-b}})))

--- a/tools/story/test/re_frame/story/theme/status_vocab_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/theme/status_vocab_cljs_test.cljc
@@ -31,17 +31,17 @@
      nine statuses the namespace + spec/018 §12.6 document, no more, no
      fewer.
   5. **Single-source derivation** (CLJS) — the sidebar's
-     `:signal-status-*` style keys are EQUAL to `status/chip-style`
+     `:signal-status-*` style keys are EQUAL to `rf.story.theme.status/chip-style`
      output, so a drift in one region is structurally impossible.
   6. **Empty-canvas hook** (CLJS) — the `story-canvas-empty` render hook
      spec/018 §12.5 promises still renders."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
-            [re-frame.story.theme.status :as status]
-            #?@(:cljs [[re-frame.story.ui.sidebar :as sidebar]
+            [re-frame.story.theme.status :as rf.story.theme.status]
+            #?@(:cljs [[re-frame.story.ui.sidebar :as rf.story.ui.sidebar]
                        [re-frame.story.ui.sidebar-styles :refer [styles]]
-                       [re-frame.story.ui.shell :as shell]
-                       [re-frame.story.ui.state :as state]])))
+                       [re-frame.story.ui.shell :as rf.story.ui.shell]
+                       [re-frame.story.ui.state :as rf.story.ui.state]])))
 
 ;; The nine canonical statuses spec/018 §12.6 documents (the namespace's
 ;; own table). `:running` is Story's live sibling of the spec's `pending`
@@ -62,18 +62,18 @@
 (deftest descriptors-match-the-documented-nine
   (testing "the descriptor set is EXACTLY the nine documented statuses —
             no status quietly added or dropped (spec/018 §12.6 table)"
-    (is (= expected-statuses (set (keys status/descriptors)))))
+    (is (= expected-statuses (set (keys rf.story.theme.status/descriptors)))))
   (testing "`order` is exactly the nine statuses, each listed once"
-    (is (= expected-statuses (set status/order)))
-    (is (= (count status/order) (count (set status/order))))
-    (is (= 9 (count status/order)))))
+    (is (= expected-statuses (set rf.story.theme.status/order)))
+    (is (= (count rf.story.theme.status/order) (count (set rf.story.theme.status/order))))
+    (is (= 9 (count rf.story.theme.status/order)))))
 
 (deftest every-descriptor-carries-all-four-discriminators
   (testing "each status carries colour (:fg/:bg/:border) + :glyph + :shape
             + :label + :emphasis — the §12.6 four channels are all present,
             so no region can fall back to colour-only"
     (doseq [s expected-statuses]
-      (let [d (status/descriptor s)]
+      (let [d (rf.story.theme.status/descriptor s)]
         (testing (str s)
           (is (every? #(contains? d %) required-keys)
               (str s " is missing one of " required-keys))
@@ -93,11 +93,11 @@
 (deftest channels-are-distinct
   (testing "the nine glyphs are all distinct — the glyph channel
             discriminates all nine, never collapses two states to one mark"
-    (let [glyphs (mapv #(:glyph (status/descriptor %)) (vec expected-statuses))]
+    (let [glyphs (mapv #(:glyph (rf.story.theme.status/descriptor %)) (vec expected-statuses))]
       (is (= 9 (count (set glyphs))) (str "duplicate glyph in " glyphs))))
   (testing "every documented shape is actually used by some status — the
             five-shape vocabulary is real, not aspirational"
-    (is (= valid-shapes (set (map #(:shape (status/descriptor %))
+    (is (= valid-shapes (set (map #(:shape (rf.story.theme.status/descriptor %))
                                   expected-statuses))))))
 
 (deftest zero-raw-hex-resolved-colours
@@ -105,7 +105,7 @@
             a dangling keyword) — rf2-i3i5j zero-raw-hex contract"
     (doseq [s expected-statuses
             k [:fg :bg :border]]
-      (let [v (get (status/descriptor s) k)]
+      (let [v (get (rf.story.theme.status/descriptor s) k)]
         (is (string? v) (str s " " k " did not resolve to a string"))))))
 
 ;; ---- 3: the shape channel genuinely discriminates -----------------------
@@ -114,35 +114,35 @@
   (testing "chip-style ALWAYS carries the colour channel (:background +
             :color) for every status"
     (doseq [s expected-statuses]
-      (let [cs (status/chip-style s)]
+      (let [cs (rf.story.theme.status/chip-style s)]
         (is (contains? cs :background))
         (is (contains? cs :color)))))
   (testing "the five shapes render VISUALLY DISTINCT decorations — the
             shape channel is genuinely five values, not the degraded two
             (solid-border vs dashed) the .3 PR shipped (rf2-gsqbp)"
     ;; :solid — no border decoration; the filled ground is the signal.
-    (let [pass (status/chip-style :pass)]
+    (let [pass (rf.story.theme.status/chip-style :pass)]
       (is (not (contains? pass :border)))
       (is (not (contains? pass :border-left))))
     ;; :outline — 1px SOLID border (error / cannot-run).
-    (let [err (status/chip-style :error)]
+    (let [err (rf.story.theme.status/chip-style :error)]
       (is (str/starts-with? (:border err) "1px solid")))
     ;; :dashed — 1px DASHED border (redacted).
-    (let [red (status/chip-style :redacted)]
+    (let [red (rf.story.theme.status/chip-style :redacted)]
       (is (str/includes? (:border red) "dashed")))
     ;; :ring — 2px DOUBLE border (pending — a hollow double-ring, NOT a
     ;; plain solid edge: this is the channel the .3 PR collapsed).
-    (let [pend (status/chip-style :pending)]
+    (let [pend (rf.story.theme.status/chip-style :pending)]
       (is (str/includes? (:border pend) "double")))
     ;; :half — a one-sided left-accent BAR (running), NOT a full border.
-    (let [run (status/chip-style :running)]
+    (let [run (rf.story.theme.status/chip-style :running)]
       (is (contains? run :border-left))
       (is (not (contains? run :border)))))
   (testing "outline / ring / half no longer collapse to the same CSS —
             the regression rf2-gsqbp fixed stays fixed"
-    (let [outline (:border      (status/chip-style :error))
-          ring    (:border      (status/chip-style :pending))
-          half    (:border-left (status/chip-style :running))]
+    (let [outline (:border      (rf.story.theme.status/chip-style :error))
+          ring    (:border      (rf.story.theme.status/chip-style :pending))
+          half    (:border-left (rf.story.theme.status/chip-style :running))]
       (is (not= outline ring))
       (is (not= outline half))
       (is (not= ring half)))))
@@ -152,55 +152,55 @@
 (deftest rollup-surfaces-worst-member
   (testing "a mixed set surfaces its most-attention-demanding member per
             `order` (one :fail among many :pass → :fail)"
-    (is (= :fail  (status/rollup [:pass :pass :fail :pass])))
-    (is (= :error (status/rollup [:pass :fail :error :pending])))
-    (is (= :pass  (status/rollup [:pass :pass :pass]))))
+    (is (= :fail  (rf.story.theme.status/rollup [:pass :pass :fail :pass])))
+    (is (= :error (rf.story.theme.status/rollup [:pass :fail :error :pending])))
+    (is (= :pass  (rf.story.theme.status/rollup [:pass :pass :pass]))))
   (testing "blocked / dirty / running outrank pending + pass + redacted"
-    (is (= :blocked (status/rollup [:pass :pending :blocked :redacted])))
-    (is (= :dirty   (status/rollup [:pass :pending :dirty :redacted])))
-    (is (= :running (status/rollup [:pass :pending :running :redacted]))))
+    (is (= :blocked (rf.story.theme.status/rollup [:pass :pending :blocked :redacted])))
+    (is (= :dirty   (rf.story.theme.status/rollup [:pass :pending :dirty :redacted])))
+    (is (= :running (rf.story.theme.status/rollup [:pass :pending :running :redacted]))))
   (testing "an empty / all-nil set degrades to :pending, never throws"
-    (is (= :pending (status/rollup [])))
-    (is (= :pending (status/rollup [nil nil])))
-    (is (= :pending (status/rollup nil)))))
+    (is (= :pending (rf.story.theme.status/rollup [])))
+    (is (= :pending (rf.story.theme.status/rollup [nil nil])))
+    (is (= :pending (rf.story.theme.status/rollup nil)))))
 
 (deftest unknown-status-degrades-to-pending
   (testing "an unknown / nil status paints the neutral :pending slot,
             never blanks or throws"
-    (is (= (status/descriptor :pending) (status/descriptor :bogus)))
-    (is (= (status/descriptor :pending) (status/descriptor nil)))))
+    (is (= (rf.story.theme.status/descriptor :pending) (rf.story.theme.status/descriptor :bogus)))
+    (is (= (rf.story.theme.status/descriptor :pending) (rf.story.theme.status/descriptor nil)))))
 
 ;; ---- 5: single-source derivation (CLJS — sidebar style is .cljs) --------
 
 #?(:cljs
    (deftest sidebar-signal-status-derives-from-chip-style
      (testing "the sidebar's :signal-status-* style keys EQUAL
-               status/chip-style output — the single-source guarantee
+               rf.story.theme.status/chip-style output — the single-source guarantee
                (a drift in one region is structurally impossible)"
-       (doseq [[stat style-key] sidebar/status-signal->style-key]
-         (is (= (status/chip-style stat) (get styles style-key))
-             (str style-key " drifted from (status/chip-style " stat ")"))))))
+       (doseq [[stat style-key] rf.story.ui.sidebar/status-signal->style-key]
+         (is (= (rf.story.theme.status/chip-style stat) (get styles style-key))
+             (str style-key " drifted from (rf.story.theme.status/chip-style " stat ")"))))))
 
 #?(:cljs
    (deftest sidebar-status-style-key-covers-all-nine
      (testing "every documented status has a sidebar style-key projection
                — no status is unreachable from the sidebar"
-       (is (= expected-statuses (set (keys sidebar/status-signal->style-key)))))))
+       (is (= expected-statuses (set (keys rf.story.ui.sidebar/status-signal->style-key)))))))
 
 #?(:cljs
    (deftest sidebar-status-dots-derive-from-fg
      (testing "the per-variant status dots project from the descriptor
-               source (`sidebar/dot-style`) — the same single source the
+               source (`rf.story.ui.sidebar/dot-style`) — the same single source the
                chips read; there are no duplicate per-status style-map
                entries left to drift (rf2-wh5to)"
-       (is (= {:background (status/fg :pass)} (sidebar/dot-style :pass)))
-       (is (= {:background (status/fg :fail)} (sidebar/dot-style :fail)))
-       (is (= (status/fg :running) (:background (sidebar/dot-style :running))))
+       (is (= {:background (rf.story.theme.status/fg :pass)} (rf.story.ui.sidebar/dot-style :pass)))
+       (is (= {:background (rf.story.theme.status/fg :fail)} (rf.story.ui.sidebar/dot-style :fail)))
+       (is (= (rf.story.theme.status/fg :running) (:background (rf.story.ui.sidebar/dot-style :running))))
        ;; :cannot-run rings in its own descriptor border colour — the
        ;; canonical third run status never wears :pending's neutral ring.
-       (is (= (str "1px solid " (:border (status/descriptor :cannot-run)))
-              (:border (sidebar/dot-style :cannot-run))))
-       (is (not= (sidebar/dot-style :pending) (sidebar/dot-style :cannot-run))))))
+       (is (= (str "1px solid " (:border (rf.story.theme.status/descriptor :cannot-run)))
+              (:border (rf.story.ui.sidebar/dot-style :cannot-run))))
+       (is (not= (rf.story.ui.sidebar/dot-style :pending) (rf.story.ui.sidebar/dot-style :cannot-run))))))
 
 ;; ---- glyph channel rendered in the sidebar chip (rf2-gsqbp) -------------
 
@@ -225,12 +225,12 @@
      (testing "the status chip in the rendered signal strip carries the
                descriptor's :glyph — the spec/018 §12.6 headline channel
                that survives colour-blindness + Windows HCM (rf2-gsqbp)"
-       (let [tree   (sidebar/signal-chips {} :fail)
+       (let [tree   (rf.story.ui.sidebar/signal-chips {} :fail)
              glyphs (walk-find-data-test tree "story-sidebar-signal-glyph")]
          (is (= 1 (count glyphs)) "exactly one status glyph in the strip")
          (let [[_tag props glyph] (first glyphs)]
            ;; the rendered mark is the descriptor's glyph for :fail
-           (is (= (status/glyph :fail) glyph))
+           (is (= (rf.story.theme.status/glyph :fail) glyph))
            ;; aria-hidden — the label + data-value already voice the value
            ;; to AT, so the glyph is a redundant VISUAL channel only.
            (is (= "true" (:aria-hidden props)))))))
@@ -240,7 +240,7 @@
    (deftest sidebar-status-chip-keeps-label-and-data-value
      (testing "rendering the glyph does NOT regress the text label or the
                data-value / title channels (AT + test corpus still read it)"
-       (let [tree  (sidebar/signal-chips {} :pass)
+       (let [tree  (rf.story.ui.sidebar/signal-chips {} :pass)
              chips (walk-find-data-test tree "story-sidebar-signal-chip")
              status-chip (first (filter #(= "status" (:data-axis (second %)))
                                         chips))
@@ -255,7 +255,7 @@
    (deftest non-status-chips-carry-no-status-glyph
      (testing "only the STATUS axis renders a glyph — fidelity / world /
                runner / frame chips have no status descriptor glyph"
-       (let [tree   (sidebar/signal-chips
+       (let [tree   (rf.story.ui.sidebar/signal-chips
                       {:args {:n 1} :network {[:get "/x"] {}}
                        :script [[:click "#go"]] :frame-binding :attached}
                       :pass)
@@ -273,8 +273,8 @@
                renders the spec/018 §12.5 calm empty state carrying the
                `story-canvas-empty` hook (the hook the .3 review flagged
                as unguarded)"
-       (state/reset-shell-state!)
-       (let [tree (#'shell/main-pane)
+       (rf.story.ui.state/reset-shell-state!)
+       (let [tree (#'rf.story.ui.shell/main-pane)
              hits (walk-find-data-test tree "story-canvas-empty")]
          (is (= 1 (count hits))
              "the empty-canvas hook renders exactly once for the empty state"))))

--- a/tools/story/test/re_frame/story/ui/a11y_stale_settlement_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/a11y_stale_settlement_cljs_test.cljs
@@ -37,12 +37,12 @@
   (:require [cljs.test :refer [async deftest is testing use-fixtures]]
             [goog.object :as gobj]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story :as story]
-            [re-frame.story.ui.a11y :as a11y]
-            [re-frame.story.ui.chrome-a11y :as chrome-a11y]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.ui.a11y :as rf.story.ui.a11y]
+            [re-frame.story.ui.chrome-a11y :as rf.story.ui.chrome-a11y]))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -70,24 +70,24 @@
 (defn- setup! []
   (reset! saved-window (gobj/get js/globalThis "window"))
   (gobj/set js/globalThis "window" #js {})
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
-  (a11y/reset-state!)
-  (chrome-a11y/reset-state!)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
+  (rf.story.ui.a11y/reset-state!)
+  (rf.story.ui.chrome-a11y/reset-state!)
   ;; `ensure-axe-loaded!` latches this once it has seen a global axe;
   ;; clear it so each test re-reads the fake installed for it.
-  (reset! a11y/axe-loaded? false)
-  (a11y/set-cdn-opt-in! true))
+  (reset! rf.story.ui.a11y/axe-loaded? false)
+  (rf.story.ui.a11y/set-cdn-opt-in! true))
 
 (defn- teardown! []
-  (a11y/set-cdn-opt-in! false)
-  (reset! a11y/axe-loaded? false)
-  (a11y/reset-state!)
-  (chrome-a11y/reset-state!)
+  (rf.story.ui.a11y/set-cdn-opt-in! false)
+  (reset! rf.story.ui.a11y/axe-loaded? false)
+  (rf.story.ui.a11y/reset-state!)
+  (rf.story.ui.chrome-a11y/reset-state!)
   (gobj/set js/globalThis "window" @saved-window))
 
 (use-fixtures :each {:before setup! :after teardown!})
@@ -127,10 +127,10 @@
 (defn- violation-ids
   "The violation ids the variant panel currently holds for `frame-id`."
   [frame-id]
-  (mapv #(gobj/get % "id") (get @a11y/violations-by-frame frame-id [])))
+  (mapv #(gobj/get % "id") (get @rf.story.ui.a11y/violations-by-frame frame-id [])))
 
 (defn- chrome-violation-ids []
-  (mapv #(gobj/get % "id") @chrome-a11y/violations))
+  (mapv #(gobj/get % "id") @rf.story.ui.chrome-a11y/violations))
 
 (def ^:private frame-id :story.a11y-fence/variant)
 
@@ -147,10 +147,10 @@
       (let [scans (atom 0)]
         (install-axe! (fn [_] (swap! scans inc)
                         (js/Promise.resolve (results "color-contrast"))))
-        (-> (a11y/run-axe! frame-id (ctx))
+        (-> (rf.story.ui.a11y/run-axe! frame-id (ctx))
             (.then (fn [_]
                      (is (= 1 @scans) "the scan really ran")
-                     (is (= :done (a11y/status-for frame-id))
+                     (is (= :done (rf.story.ui.a11y/status-for frame-id))
                          "the owning run reached its terminal status")
                      (is (= ["color-contrast"] (violation-ids frame-id))
                          "and its violations were recorded")
@@ -169,17 +169,17 @@
         (fn [_]
           ;; The takeover, placed exactly: the run has claimed the slot
           ;; and reached `:running`, and the scan is now in flight.
-          (a11y/drop-frame-state! frame-id)
+          (rf.story.ui.a11y/drop-frame-state! frame-id)
           (js/Promise.resolve (results "color-contrast"))))
-      (-> (a11y/run-axe! frame-id (ctx))
+      (-> (rf.story.ui.a11y/run-axe! frame-id (ctx))
           (.then (fn [_]
-                   (is (not (contains? @a11y/run-state frame-id))
+                   (is (not (contains? @rf.story.ui.a11y/run-state frame-id))
                        "no phantom run-state entry — the slot stayed torn down")
-                   (is (not (contains? @a11y/violations-by-frame frame-id))
+                   (is (not (contains? @rf.story.ui.a11y/violations-by-frame frame-id))
                        "and no phantom violations bag beside it: this is the
                         entry `browser/register-a11y-reader!` would have
                         served to :rf.assert/a11y as a verdict")
-                   (is (= :idle (a11y/status-for frame-id))
+                   (is (= :idle (rf.story.ui.a11y/status-for frame-id))
                        "a frame with no slot reads :idle, NOT :done")
                    nil))
           ;; Reports; it does NOT finish. `done` hands `cljs.test/run-block` a
@@ -206,12 +206,12 @@
             ;; B claims the slot mid-A-scan and parks in its own scan, so
             ;; B demonstrably still holds the slot at assertion time.
             (install-axe! (fn [_] ((:fire! b-scanning)) (never-settles)))
-            (a11y/run-axe! frame-id (ctx))
+            (rf.story.ui.a11y/run-axe! frame-id (ctx))
             (js/Promise.resolve (results "from-run-a"))))
-        (-> (js/Promise.all #js [(a11y/run-axe! frame-id (ctx))
+        (-> (js/Promise.all #js [(rf.story.ui.a11y/run-axe! frame-id (ctx))
                                  (:promise b-scanning)])
             (.then (fn [_]
-                     (is (= :running (a11y/status-for frame-id))
+                     (is (= :running (rf.story.ui.a11y/status-for frame-id))
                          "B still owns the slot and is still scanning — A's
                           settlement did not write its terminal :done over it")
                      (is (= [] (violation-ids frame-id))
@@ -229,42 +229,42 @@
     (async done
       (letfn [(admit! [id k]
                 (install-axe! (fn [_] (js/Promise.resolve (results id))))
-                (.then (a11y/run-axe! frame-id (ctx)) k))
+                (.then (rf.story.ui.a11y/run-axe! frame-id (ctx)) k))
               (refuse! [id k]
                 (let [b (signal)]
                   (install-axe!
                     (fn [_]
                       (install-axe! (fn [_] ((:fire! b)) (never-settles)))
-                      (a11y/run-axe! frame-id (ctx))
+                      (rf.story.ui.a11y/run-axe! frame-id (ctx))
                       (js/Promise.resolve (results id))))
-                  (.then (js/Promise.all #js [(a11y/run-axe! frame-id (ctx))
+                  (.then (js/Promise.all #js [(rf.story.ui.a11y/run-axe! frame-id (ctx))
                                               (:promise b)])
                          k)))]
         (admit!
           "v1"
           (fn [_]
             (is (= ["v1"] (violation-ids frame-id)) "1/4 ADMITTED")
-            (is (= :done (a11y/status-for frame-id)))
+            (is (= :done (rf.story.ui.a11y/status-for frame-id)))
             (refuse!
               "v2"
               (fn [_]
                 (is (= ["v1"] (violation-ids frame-id))
                     "2/4 REFUSED — the superseded run left v1 standing")
-                (is (= :running (a11y/status-for frame-id)))
+                (is (= :running (rf.story.ui.a11y/status-for frame-id)))
                 (admit!
                   "v3"
                   (fn [_]
                     (is (= ["v3"] (violation-ids frame-id))
                         "3/4 ADMITTED AGAIN — the refusal did not latch the
                          fence shut")
-                    (is (= :done (a11y/status-for frame-id)))
+                    (is (= :done (rf.story.ui.a11y/status-for frame-id)))
                     (refuse!
                       "v4"
                       (fn [_]
                         (is (= ["v3"] (violation-ids frame-id))
                             "4/4 REFUSED AGAIN — the admission did not latch
                              the fence open")
-                        (is (= :running (a11y/status-for frame-id)))
+                        (is (= :running (rf.story.ui.a11y/status-for frame-id)))
                         (done)))))))))))))
 
 (deftest a-superseded-run-declines-to-scan
@@ -278,13 +278,13 @@
         (install-axe! (fn [_] (swap! scans inc) (js/Promise.resolve (results))))
         ;; Claim the slot and tear it down before the load settles — the
         ;; whole of `run-axe!`'s first `.then` is still ahead of us.
-        (let [p (a11y/run-axe! frame-id (ctx))]
-          (a11y/drop-frame-state! frame-id)
+        (let [p (rf.story.ui.a11y/run-axe! frame-id (ctx))]
+          (rf.story.ui.a11y/drop-frame-state! frame-id)
           (-> p
               (.then (fn [_]
                        (is (= 0 @scans)
                            "axe-core was never invoked for the abandoned run")
-                       (is (not (contains? @a11y/run-state frame-id))
+                       (is (not (contains? @rf.story.ui.a11y/run-state frame-id))
                            "and nothing was resurrected")
                        (done)))))))))
 
@@ -298,12 +298,12 @@
         (install-axe!
           (fn [_]
             (install-axe! (fn [_] ((:fire! b-scanning)) (never-settles)))
-            (a11y/run-axe! frame-id (ctx))
+            (rf.story.ui.a11y/run-axe! frame-id (ctx))
             (js/Promise.reject (js/Error. "axe blew up"))))
-        (-> (js/Promise.all #js [(a11y/run-axe! frame-id (ctx))
+        (-> (js/Promise.all #js [(rf.story.ui.a11y/run-axe! frame-id (ctx))
                                  (:promise b-scanning)])
             (.then (fn [_]
-                     (is (= :running (a11y/status-for frame-id))
+                     (is (= :running (rf.story.ui.a11y/status-for frame-id))
                          "B's in-flight scan was not overwritten with A's :error")
                      (done))))))))
 
@@ -314,11 +314,11 @@
     (async done
       (install-axe!
         (fn [_]
-          (a11y/drop-frame-state! frame-id)
+          (rf.story.ui.a11y/drop-frame-state! frame-id)
           (js/Promise.reject (js/Error. "axe blew up"))))
-      (-> (a11y/run-axe! frame-id (ctx))
+      (-> (rf.story.ui.a11y/run-axe! frame-id (ctx))
           (.then (fn [_]
-                   (is (not (contains? @a11y/run-state frame-id))
+                   (is (not (contains? @rf.story.ui.a11y/run-state frame-id))
                        "no phantom :error slot for a torn-down frame")
                    (done)))))))
 
@@ -335,9 +335,9 @@
   (testing "POSITIVE CONTROL for the chrome panel"
     (async done
       (install-axe! (fn [_] (js/Promise.resolve (results "region"))))
-      (-> (chrome-a11y/run-axe! (ctx))
+      (-> (rf.story.ui.chrome-a11y/run-axe! (ctx))
           (.then (fn [_]
-                   (is (= :done (chrome-a11y/status)))
+                   (is (= :done (rf.story.ui.chrome-a11y/status)))
                    (is (= ["region"] (chrome-violation-ids)))
                    (done)))))))
 
@@ -350,11 +350,11 @@
     (async done
       (install-axe!
         (fn [_]
-          (chrome-a11y/reset-state!)
+          (rf.story.ui.chrome-a11y/reset-state!)
           (js/Promise.resolve (results "region"))))
-      (-> (chrome-a11y/run-axe! (ctx))
+      (-> (rf.story.ui.chrome-a11y/run-axe! (ctx))
           (.then (fn [_]
-                   (is (= :idle (chrome-a11y/status))
+                   (is (= :idle (rf.story.ui.chrome-a11y/status))
                        "the reset stands — the stale settlement did not
                         restore :done over it")
                    (is (= [] (chrome-violation-ids))
@@ -369,12 +369,12 @@
         (install-axe!
           (fn [_]
             (install-axe! (fn [_] ((:fire! b-scanning)) (never-settles)))
-            (chrome-a11y/run-axe! (ctx))
+            (rf.story.ui.chrome-a11y/run-axe! (ctx))
             (js/Promise.resolve (results "from-run-a"))))
-        (-> (js/Promise.all #js [(chrome-a11y/run-axe! (ctx))
+        (-> (js/Promise.all #js [(rf.story.ui.chrome-a11y/run-axe! (ctx))
                                  (:promise b-scanning)])
             (.then (fn [_]
-                     (is (= :running (chrome-a11y/status))
+                     (is (= :running (rf.story.ui.chrome-a11y/status))
                          "B still owns the scan")
                      (is (= [] (chrome-violation-ids))
                          "and A's findings were not attributed to it")
@@ -387,15 +387,15 @@
     (async done
       (letfn [(admit! [id k]
                 (install-axe! (fn [_] (js/Promise.resolve (results id))))
-                (.then (chrome-a11y/run-axe! (ctx)) k))
+                (.then (rf.story.ui.chrome-a11y/run-axe! (ctx)) k))
               (refuse! [id k]
                 (let [b (signal)]
                   (install-axe!
                     (fn [_]
                       (install-axe! (fn [_] ((:fire! b)) (never-settles)))
-                      (chrome-a11y/run-axe! (ctx))
+                      (rf.story.ui.chrome-a11y/run-axe! (ctx))
                       (js/Promise.resolve (results id))))
-                  (.then (js/Promise.all #js [(chrome-a11y/run-axe! (ctx))
+                  (.then (js/Promise.all #js [(rf.story.ui.chrome-a11y/run-axe! (ctx))
                                               (:promise b)])
                          k)))]
         (admit!

--- a/tools/story/test/re_frame/story/ui/a11y_teardown_eviction_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/a11y_teardown_eviction_cljs_test.cljs
@@ -6,7 +6,7 @@
   its docstring named 'the canvas / shell teardown', which does not
   destroy variant frames (`ui/canvas`'s `component-will-unmount` clears
   its own render sentinels and nothing else, and no `ui/` namespace calls
-  `frames/destroy!` at all). So every frame ever scanned kept its slot for
+  `rf.story.frames/destroy!` at all). So every frame ever scanned kept its slot for
   the life of the page.
 
   WHAT THAT COSTS. Not a stale verdict — RETAINED DOM. A stored violation
@@ -33,13 +33,13 @@
   (:require [cljs.test :refer [async deftest is testing use-fixtures]]
             [goog.object :as gobj]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story :as story]
-            [re-frame.story.frames :as frames]
-            [re-frame.story.late-bind :as late-bind]
-            [re-frame.story.ui.a11y :as a11y]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.frames :as rf.story.frames]
+            [re-frame.story.late-bind :as rf.story.late-bind]
+            [re-frame.story.ui.a11y :as rf.story.ui.a11y]))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -66,34 +66,34 @@
 (def ^:private variant-id :story.a11y-teardown/probe)
 
 (defn- register-probe-variant!
-  "A minimal events-only variant so `frames/allocate!` takes the
-  fast-path and `frames/destroy!` has a real registered frame to tear
+  "A minimal events-only variant so `rf.story.frames/allocate!` takes the
+  fast-path and `rf.story.frames/destroy!` has a real registered frame to tear
   down. The teardown seam under test is frame-level, not lifecycle-level,
   so the variant deliberately carries nothing else."
   []
-  (story/reg-story :story.a11y-teardown {:doc "teardown probe story"})
-  (story/reg-variant variant-id {:doc "teardown probe variant"}))
+  (rf.story/reg-story :story.a11y-teardown {:doc "teardown probe story"})
+  (rf.story/reg-variant variant-id {:doc "teardown probe variant"}))
 
 (defn- setup! []
   (reset! saved-window (gobj/get js/globalThis "window"))
   (gobj/set js/globalThis "window" #js {})
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (register-probe-variant!)
-  (a11y/reset-state!)
+  (rf.story.ui.a11y/reset-state!)
   ;; `ensure-axe-loaded!` latches this once it has seen a global axe;
   ;; clear it so each test re-reads the fake installed for it.
-  (reset! a11y/axe-loaded? false)
-  (a11y/set-cdn-opt-in! true))
+  (reset! rf.story.ui.a11y/axe-loaded? false)
+  (rf.story.ui.a11y/set-cdn-opt-in! true))
 
 (defn- teardown! []
-  (a11y/set-cdn-opt-in! false)
-  (reset! a11y/axe-loaded? false)
-  (a11y/reset-state!)
+  (rf.story.ui.a11y/set-cdn-opt-in! false)
+  (reset! rf.story.ui.a11y/axe-loaded? false)
+  (rf.story.ui.a11y/reset-state!)
   (gobj/set js/globalThis "window" @saved-window))
 
 (use-fixtures :each {:before setup! :after teardown!})
@@ -136,7 +136,7 @@
 ;; ---------------------------------------------------------------------------
 ;;
 ;; Before rf2-cpbut NO producer registered `:drop-a11y-state`, so the
-;; consumer's `when-let` in `frames/run-teardown-walks!` simply skipped.
+;; consumer's `when-let` in `rf.story.frames/run-teardown-walks!` simply skipped.
 ;; Unregistering the hook reproduces that state exactly — this is the
 ;; red-before lever, and it isolates precisely the wiring this bead added
 ;; without touching the teardown call itself.
@@ -147,15 +147,15 @@
   failure inside `f` cannot leave the hook off for sibling namespaces in
   this shared process."
   [f]
-  (let [saved (late-bind/get-fn :drop-a11y-state)]
+  (let [saved (rf.story.late-bind/get-fn :drop-a11y-state)]
     (try
-      (late-bind/set-fn! :drop-a11y-state nil)
+      (rf.story.late-bind/set-fn! :drop-a11y-state nil)
       (f)
       (finally
-        (late-bind/set-fn! :drop-a11y-state saved)))))
+        (rf.story.late-bind/set-fn! :drop-a11y-state saved)))))
 
 (defn- allocate-probe-frame! []
-  (frames/allocate! variant-id nil))
+  (rf.story.frames/allocate! variant-id nil))
 
 (defn- node-reachable-from-panel?
   "True when `node-obj` is still reachable from the a11y panel's per-frame
@@ -167,7 +167,7 @@
     (some (fn [v]
             (some (fn [n] (identical? node-obj (gobj/get n "element")))
                   (array-seq (gobj/get v "nodes"))))
-          (get @a11y/violations-by-frame frame-id []))))
+          (get @rf.story.ui.a11y/violations-by-frame frame-id []))))
 
 ;; ---------------------------------------------------------------------------
 ;; The leak, measured
@@ -183,12 +183,12 @@
         (allocate-probe-frame!)
         (install-axe! (fn [_] (js/Promise.resolve
                                 (results-holding "color-contrast" detached-node))))
-        (-> (a11y/run-axe! variant-id (ctx))
+        (-> (rf.story.ui.a11y/run-axe! variant-id (ctx))
             (.then
               (fn [_]
                 ;; The scan landed: the panel holds the frame's slot AND
                 ;; the node the violation points at.
-                (is (contains? @a11y/violations-by-frame variant-id)
+                (is (contains? @rf.story.ui.a11y/violations-by-frame variant-id)
                     "precondition: the scan stored a per-frame entry")
                 (is (node-reachable-from-panel? variant-id detached-node)
                     "precondition: the stored violation references the node")
@@ -196,8 +196,8 @@
                 ;; --- RED-BEFORE arm: no eviction hook ---
                 (with-eviction-hook-removed
                   (fn []
-                    (frames/destroy! variant-id)
-                    (is (contains? @a11y/violations-by-frame variant-id)
+                    (rf.story.frames/destroy! variant-id)
+                    (is (contains? @rf.story.ui.a11y/violations-by-frame variant-id)
                         "WITHOUT the eviction the slot survives frame destruction")
                     (is (node-reachable-from-panel? variant-id detached-node)
                         "WITHOUT the eviction the DESTROYED variant's detached
@@ -207,20 +207,20 @@
                 ;; Re-allocate + re-scan so the second teardown has real
                 ;; state to reclaim rather than the residue of the first.
                 (allocate-probe-frame!)
-                (-> (a11y/run-axe! variant-id (ctx))
+                (-> (rf.story.ui.a11y/run-axe! variant-id (ctx))
                     (.then
                       (fn [_]
                         (is (node-reachable-from-panel? variant-id detached-node)
                             "precondition: the re-scan re-stored the node")
-                        (frames/destroy! variant-id)
-                        (is (not (contains? @a11y/violations-by-frame variant-id))
+                        (rf.story.frames/destroy! variant-id)
+                        (is (not (contains? @rf.story.ui.a11y/violations-by-frame variant-id))
                             "WITH the eviction the violations slot is ABSENT")
-                        (is (not (contains? @a11y/run-state variant-id))
+                        (is (not (contains? @rf.story.ui.a11y/run-state variant-id))
                             "WITH the eviction the run-state slot is ABSENT")
                         (is (not (node-reachable-from-panel? variant-id detached-node))
                             "WITH the eviction the detached node is no longer
                              reachable from the panel — reclaimed")
-                        (is (= :idle (a11y/status-for variant-id))
+                        (is (= :idle (rf.story.ui.a11y/status-for variant-id))
                             "a reclaimed frame reads :idle, the never-scanned status")
                         (done)))))))))))
 
@@ -240,17 +240,17 @@
         ;; --- round 1 ---
         (allocate-probe-frame!)
         (install-axe! (fn [_] (js/Promise.resolve (results-holding "round-1" node-1))))
-        (-> (a11y/run-axe! variant-id (ctx))
+        (-> (rf.story.ui.a11y/run-axe! variant-id (ctx))
             (.then
               (fn [_]
                 (is (node-reachable-from-panel? variant-id node-1)
                     "round 1 ADMIT: the scan stored its violation")
-                (is (= :done (a11y/status-for variant-id))
+                (is (= :done (rf.story.ui.a11y/status-for variant-id))
                     "round 1 ADMIT: the run reached :done")
-                (frames/destroy! variant-id)
-                (is (not (contains? @a11y/violations-by-frame variant-id))
+                (rf.story.frames/destroy! variant-id)
+                (is (not (contains? @rf.story.ui.a11y/violations-by-frame variant-id))
                     "round 1 RECLAIM: violations slot absent")
-                (is (not (contains? @a11y/run-state variant-id))
+                (is (not (contains? @rf.story.ui.a11y/run-state variant-id))
                     "round 1 RECLAIM: run-state slot absent")
                 (is (not (node-reachable-from-panel? variant-id node-1))
                     "round 1 RECLAIM: node-1 unreachable")
@@ -259,7 +259,7 @@
                 (allocate-probe-frame!)
                 (install-axe! (fn [_] (js/Promise.resolve
                                         (results-holding "round-2" node-2))))
-                (-> (a11y/run-axe! variant-id (ctx))
+                (-> (rf.story.ui.a11y/run-axe! variant-id (ctx))
                     (.then
                       (fn [_]
                         (is (node-reachable-from-panel? variant-id node-2)
@@ -267,12 +267,12 @@
                              the first teardown did not poison the slot")
                         (is (not (node-reachable-from-panel? variant-id node-1))
                             "round 2 ADMIT: round 1's node did NOT come back")
-                        (is (= :done (a11y/status-for variant-id))
+                        (is (= :done (rf.story.ui.a11y/status-for variant-id))
                             "round 2 ADMIT: the second run reached :done")
-                        (frames/destroy! variant-id)
-                        (is (not (contains? @a11y/violations-by-frame variant-id))
+                        (rf.story.frames/destroy! variant-id)
+                        (is (not (contains? @rf.story.ui.a11y/violations-by-frame variant-id))
                             "round 2 RECLAIM: violations slot absent again")
-                        (is (not (contains? @a11y/run-state variant-id))
+                        (is (not (contains? @rf.story.ui.a11y/run-state variant-id))
                             "round 2 RECLAIM: run-state slot absent again")
                         (is (not (node-reachable-from-panel? variant-id node-2))
                             "round 2 RECLAIM: node-2 unreachable")
@@ -307,15 +307,15 @@
             ((:fire! scan-started))
             (js/Promise. (fn [res _] (reset! release #(res (results-holding
                                                              "late" detached)))))))
-        (a11y/run-axe! variant-id (ctx))
+        (rf.story.ui.a11y/run-axe! variant-id (ctx))
         (-> (:promise scan-started)
             (.then
               (fn [_]
-                (is (contains? @a11y/run-state variant-id)
+                (is (contains? @rf.story.ui.a11y/run-state variant-id)
                     "precondition: the in-flight run holds the slot")
                 ;; Tear the frame down mid-scan through the PRODUCTION path.
-                (frames/destroy! variant-id)
-                (is (not (contains? @a11y/run-state variant-id))
+                (rf.story.frames/destroy! variant-id)
+                (is (not (contains? @rf.story.ui.a11y/run-state variant-id))
                     "teardown cleared the slot the in-flight run held")
                 ;; Now let the scan settle over the cleared state.
                 (@release)
@@ -326,16 +326,16 @@
                     (.then (fn [_] nil))
                     (.then
                       (fn [_]
-                        (is (not (contains? @a11y/run-state variant-id))
+                        (is (not (contains? @rf.story.ui.a11y/run-state variant-id))
                             "the superseded settlement did NOT resurrect the
                              run-state slot — the fence still declines after a
                              teardown-driven revocation")
-                        (is (not (contains? @a11y/violations-by-frame variant-id))
+                        (is (not (contains? @rf.story.ui.a11y/violations-by-frame variant-id))
                             "the superseded settlement did NOT resurrect the
                              violations slot")
                         (is (not (node-reachable-from-panel? variant-id detached))
                             "the late scan's node never entered the panel")
-                        (is (= :idle (a11y/status-for variant-id))
+                        (is (= :idle (rf.story.ui.a11y/status-for variant-id))
                             "status reads :idle (terminal, never-scanned) rather
                              than a fabricated :done for a frame that is gone")
                         (done)))))))))))
@@ -347,28 +347,28 @@
       (let [other-id :story.a11y-teardown/sibling
             node-a   #js {"tagName" "P" "id" "a"}
             node-b   #js {"tagName" "P" "id" "b"}]
-        (story/reg-variant other-id {:doc "sibling probe variant"})
+        (rf.story/reg-variant other-id {:doc "sibling probe variant"})
         (allocate-probe-frame!)
-        (frames/allocate! other-id nil)
+        (rf.story.frames/allocate! other-id nil)
         (install-axe! (fn [_] (js/Promise.resolve (results-holding "a" node-a))))
-        (-> (a11y/run-axe! variant-id (ctx))
+        (-> (rf.story.ui.a11y/run-axe! variant-id (ctx))
             (.then
               (fn [_]
                 (install-axe! (fn [_] (js/Promise.resolve
                                         (results-holding "b" node-b))))
-                (a11y/run-axe! other-id (ctx))))
+                (rf.story.ui.a11y/run-axe! other-id (ctx))))
             (.then
               (fn [_]
                 (is (node-reachable-from-panel? variant-id node-a)
                     "precondition: probe frame holds its own scan")
                 (is (node-reachable-from-panel? other-id node-b)
                     "precondition: sibling frame holds its own scan")
-                (frames/destroy! variant-id)
-                (is (not (contains? @a11y/violations-by-frame variant-id))
+                (rf.story.frames/destroy! variant-id)
+                (is (not (contains? @rf.story.ui.a11y/violations-by-frame variant-id))
                     "the destroyed frame's slot is reclaimed")
                 (is (node-reachable-from-panel? other-id node-b)
                     "the SIBLING frame's state survives — the eviction is
                      scoped to the frame being torn down")
-                (is (= :done (a11y/status-for other-id))
+                (is (= :done (rf.story.ui.a11y/status-for other-id))
                     "the sibling's run status is untouched")
                 (done))))))))

--- a/tools/story/test/re_frame/story/ui/assertion_strip_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/assertion_strip_cljs_test.cljs
@@ -26,19 +26,19 @@
   - `render-row`      — status / label / glyph wiring; click toggles
                         through the `on-toggle` callback"
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.story.ui.assertion-strip :as strip]))
+            [re-frame.story.ui.assertion-strip :as rf.story.ui.assertion-strip]))
 
 ;; ---- pure: truncate ------------------------------------------------------
 
 (deftest truncate-short-passthrough
   (testing "strings shorter than the limit pass through unchanged"
-    (is (= "abc"   (strip/truncate "abc" 10)))
-    (is (= ""      (strip/truncate nil 10)))
-    (is (= "1"     (strip/truncate "1" 10)))))
+    (is (= "abc"   (rf.story.ui.assertion-strip/truncate "abc" 10)))
+    (is (= ""      (rf.story.ui.assertion-strip/truncate nil 10)))
+    (is (= "1"     (rf.story.ui.assertion-strip/truncate "1" 10)))))
 
 (deftest truncate-long-ellipsis
   (testing "strings longer than the limit truncate with a single ellipsis char"
-    (let [out (strip/truncate "aaaaaaaaaaaaaaaaaa" 5)]
+    (let [out (rf.story.ui.assertion-strip/truncate "aaaaaaaaaaaaaaaaaa" 5)]
       (is (= 5 (count out))
           "output length matches the limit (ellipsis included)")
       (is (= "aaaa…" out)
@@ -46,7 +46,7 @@
 
 (deftest truncate-coerces-non-string
   (testing "non-string input is coerced through pr-str-ish (str)"
-    (is (= "42"    (strip/truncate 42 10)))))
+    (is (= "42"    (rf.story.ui.assertion-strip/truncate 42 10)))))
 
 ;; ---- pure: summary-line --------------------------------------------------
 
@@ -55,34 +55,34 @@
             the assertion and the strip stays compact"
     (let [row {:status :pass
                :detail {:expected 1 :actual 1}}]
-      (is (= "" (strip/summary-line row))))))
+      (is (= "" (rf.story.ui.assertion-strip/summary-line row))))))
 
 (deftest summary-line-fail-reason
   (testing "failing rows surface the :reason when present"
     (let [row {:status :fail
                :detail {:reason "values differ"}}]
-      (is (= "values differ" (strip/summary-line row))))))
+      (is (= "values differ" (rf.story.ui.assertion-strip/summary-line row))))))
 
 (deftest summary-line-fail-expected-actual
   (testing "failing rows with no :reason fall back to expected vs actual"
     (let [row {:status :fail
                :detail {:expected 99 :actual 0}}]
-      (is (= "expected 99 · actual 0" (strip/summary-line row))))))
+      (is (= "expected 99 · actual 0" (rf.story.ui.assertion-strip/summary-line row))))))
 
 (deftest summary-line-skip-reason
   (testing "skipped rows surface the :reason (or a default placeholder)"
     (is (= "feature gated"
-           (strip/summary-line {:status :skip
+           (rf.story.ui.assertion-strip/summary-line {:status :skip
                                 :detail {:reason "feature gated"}})))
     (is (= "skipped"
-           (strip/summary-line {:status :skip :detail {}}))
+           (rf.story.ui.assertion-strip/summary-line {:status :skip :detail {}}))
         "no :reason → 'skipped' placeholder")))
 
 (deftest summary-line-fail-truncates
   (testing "long :reason values clamp to the strip's character limit"
     (let [long-reason (apply str (repeat 200 "x"))
           row         {:status :fail :detail {:reason long-reason}}
-          out         (strip/summary-line row)]
+          out         (rf.story.ui.assertion-strip/summary-line row)]
       (is (<= (count out) 72)
           "output respects the truncate-len cap")
       (is (re-find #"…$" out)
@@ -96,7 +96,7 @@
     (let [records [{:assertion :rf.assert/path-equals :event [:counter/inc]}
                    {:assertion :rf.assert/path-equals :event [:counter/inc]}
                    {:assertion :rf.assert/path-equals :event [:counter/dec]}]
-          groups  (strip/group-by-event records)]
+          groups  (rf.story.ui.assertion-strip/group-by-event records)]
       (is (= 2 (count groups)))
       (is (= [:counter/inc] (-> groups (nth 0) :event)))
       (is (= 2 (-> groups (nth 0) :records count)))
@@ -107,7 +107,7 @@
   (testing "the first occurrence of each :event sets that group's position
             in the output, even if the records interleave later"
     (let [records [{:event [:a]} {:event [:b]} {:event [:a]} {:event [:c]}]
-          groups  (strip/group-by-event records)]
+          groups  (rf.story.ui.assertion-strip/group-by-event records)]
       (is (= [[:a] [:b] [:c]] (mapv :event groups))
           "groups appear in first-seen order")
       (is (= 2 (-> groups (nth 0) :records count))
@@ -119,7 +119,7 @@
     (let [records [{:assertion :rf.assert/x}
                    {:assertion :rf.assert/y :event [:click]}
                    {:assertion :rf.assert/z}]
-          groups  (strip/group-by-event records)]
+          groups  (rf.story.ui.assertion-strip/group-by-event records)]
       (is (= 2 (count groups)))
       (is (nil? (-> groups (nth 0) :event))
           ":event nil cluster is its own group")
@@ -128,8 +128,8 @@
 
 (deftest group-by-event-empty
   (testing "empty input → empty groups vector"
-    (is (= [] (strip/group-by-event [])))
-    (is (= [] (strip/group-by-event nil)))))
+    (is (= [] (rf.story.ui.assertion-strip/group-by-event [])))
+    (is (= [] (rf.story.ui.assertion-strip/group-by-event nil)))))
 
 ;; ---- pure: status-glyph map ----------------------------------------------
 
@@ -137,9 +137,9 @@
   (testing "the three status glyphs (Storybook-inspired pattern #1)
             are exposed publicly so tests + downstream consumers can
             pin them"
-    (is (= "✓" (:pass strip/status-glyph)))
-    (is (= "✗" (:fail strip/status-glyph)))
-    (is (= "⊘" (:skip strip/status-glyph)))))
+    (is (= "✓" (:pass rf.story.ui.assertion-strip/status-glyph)))
+    (is (= "✗" (:fail rf.story.ui.assertion-strip/status-glyph)))
+    (is (= "⊘" (:skip rf.story.ui.assertion-strip/status-glyph)))))
 
 ;; ---- rendered: render-row ------------------------------------------------
 
@@ -167,7 +167,7 @@
                   :label    ":rf.assert/path-equals [[:counter] 1]"
                   :row-key  ":rf.assert/path-equals [[:counter] 1]"
                   :detail   {:expected 1 :actual 1}}
-          hiccup (strip/render-row row false (fn [_]))]
+          hiccup (rf.story.ui.assertion-strip/render-row row false (fn [_]))]
       (is (some? (find-prop hiccup :data-test "story-canvas-assertion-row"))
           "row wrapper carries the canonical data-test")
       (let [row-wrapper (find-prop hiccup :data-test "story-canvas-assertion-row")]
@@ -183,7 +183,7 @@
                   :label   ":rf.assert/path-equals [[:counter] 99]"
                   :row-key ":rf.assert/path-equals [[:counter] 99]"
                   :detail  {:expected 99 :actual 0 :reason "values differ"}}
-          hiccup (strip/render-row row true (fn [_]))
+          hiccup (rf.story.ui.assertion-strip/render-row row true (fn [_]))
           wrap   (find-prop hiccup :data-test "story-canvas-assertion-row")]
       (is (= "fail" (:data-status wrap)))
       (is (some? (find-prop hiccup :data-test "story-canvas-assertion-summary"))
@@ -198,7 +198,7 @@
                   :label   ":rf.assert/skipped"
                   :row-key ":rf.assert/skipped"
                   :detail  {:reason "feature gated"}}
-          hiccup (strip/render-row row false (fn [_]))]
+          hiccup (rf.story.ui.assertion-strip/render-row row false (fn [_]))]
       (is (some? (find-prop hiccup :data-test "story-canvas-assertion-summary"))
           ":skip rows surface the reason summary even when collapsed")
       (is (nil? (find-prop hiccup :data-test "story-canvas-assertion-detail"))
@@ -207,7 +207,7 @@
 ;; ---- rendered: assertion-strip component ---------------------------------
 ;;
 ;; The component returns a reagent inner-fn (closure-with-state pattern).
-;; Calling `(strip/assertion-strip assertions)` returns the outer fn; we
+;; Calling `(rf.story.ui.assertion-strip/assertion-strip assertions)` returns the outer fn; we
 ;; invoke it once with the assertions vector to get the inner fn, then
 ;; invoke that with the same vector to get the hiccup. This is the
 ;; standard reagent-with-init shape; tests pin the rendered tree without
@@ -217,16 +217,16 @@
   "Invoke the assertion-strip component and return its rendered hiccup.
 
   The strip renders each row as a Reagent component vector
-  `[strip/render-row row open? toggle]` (the key MUST sit on a vector
+  `[rf.story.ui.assertion-strip/render-row row open? toggle]` (the key MUST sit on a vector
   literal — rf2-5lw9w), so the raw hiccup carries un-expanded row
   elements. Tests that assert per-row `:key` meta read this raw form;
   tests that walk the row's inner shape use `render-strip-expanded`."
   [assertions]
-  (let [inner (strip/assertion-strip assertions)]
+  (let [inner (rf.story.ui.assertion-strip/assertion-strip assertions)]
     (inner assertions)))
 
 (defn- expand-row-elements
-  "Walk `hiccup` and replace each `[strip/render-row row open? toggle]`
+  "Walk `hiccup` and replace each `[rf.story.ui.assertion-strip/render-row row open? toggle]`
   component vector with the hiccup that `render-row` produces — i.e. what
   Reagent expands the element into at mount time. Lets the shape-walking
   tests below assert the row's inner `data-test` tree even though the
@@ -235,10 +235,10 @@
   [hiccup]
   (letfn [(render-row-element? [x]
             (and (vector? x)
-                 (= strip/render-row (first x))))
+                 (= rf.story.ui.assertion-strip/render-row (first x))))
           (expand [node]
             (cond
-              (render-row-element? node) (apply strip/render-row (rest node))
+              (render-row-element? node) (apply rf.story.ui.assertion-strip/render-row (rest node))
               (vector? node)             (mapv expand node)
               (seq? node)                (map expand node)
               :else                      node))]
@@ -365,7 +365,7 @@
         row-element? (fn [x]
                        (and (vector? x)
                             (fn? (first x))
-                            (= strip/render-row (first x))))]
+                            (= rf.story.ui.assertion-strip/render-row (first x))))]
     (letfn [(walk [node]
               (cond
                 (row-element? node) (swap! found conj node)
@@ -480,12 +480,12 @@
 (deftest value-display-short-no-clamp
   (testing "a short value's :clamped equals :full and :long? is false —
             no click-to-reveal chord needed"
-    (let [out (strip/value-display 42)]
+    (let [out (rf.story.ui.assertion-strip/value-display 42)]
       (is (= "42" (:full out)))
       (is (= "42" (:clamped out)))
       (is (false? (:long? out)))))
   (testing "a moderate map under the cap also passes through unclamped"
-    (let [out (strip/value-display {:a 1 :b 2})]
+    (let [out (rf.story.ui.assertion-strip/value-display {:a 1 :b 2})]
       (is (false? (:long? out)))
       (is (= (:full out) (:clamped out))))))
 
@@ -494,7 +494,7 @@
             ellipsis and flags :long? so the renderer attaches the
             click-to-reveal chord"
     (let [big {:k (apply str (repeat 300 "x"))}
-          out (strip/value-display big)]
+          out (rf.story.ui.assertion-strip/value-display big)]
       (is (true? (:long? out)))
       (is (re-find #"…$" (:clamped out))
           ":clamped ends in an ellipsis")
@@ -505,7 +505,7 @@
 
 (deftest value-display-respects-explicit-cap
   (testing "the 2-arity form clamps at the caller-supplied length"
-    (let [out (strip/value-display "abcdefghij" 5)]
+    (let [out (rf.story.ui.assertion-strip/value-display "abcdefghij" 5)]
       (is (true? (:long? out)))
       (is (= 5 (count (:clamped out)))))))
 
@@ -517,7 +517,7 @@
 
 (defn- render-detail-value
   [label v]
-  (let [inner (strip/detail-value label v)]
+  (let [inner (rf.story.ui.assertion-strip/detail-value label v)]
     (inner label v)))
 
 (deftest detail-value-short-no-reveal-chord

--- a/tools/story/test/re_frame/story/ui/author_expectations_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/author_expectations_cljs_test.cljc
@@ -16,9 +16,9 @@
   Runs on the JVM under `clojure -M:test` and on CLJS under shadow's
   `:node-test` build (ns suffix `-cljs-test`)."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.ui.author-expectations :as ui]
+            [re-frame.story.ui.author-expectations :as rf.story.ui.author-expectations]
             #?@(:cljs [[clojure.string :as str]
-                       [re-frame.story.registrar :as registrar]])))
+                       [re-frame.story.registrar :as rf.story.registrar]])))
 
 ;; ===========================================================================
 ;; JVM + CLJS — pure draft transitions
@@ -26,48 +26,48 @@
 
 (deftest add-row-mints-stable-ids
   (testing "add-row appends a fresh row of the kind with a stable id"
-    (let [d  (ui/initial-draft)
-          d1 (ui/add-row d :app-db-equals)
-          d2 (ui/add-row d1 :dom-text)]
+    (let [d  (rf.story.ui.author-expectations/initial-draft)
+          d1 (rf.story.ui.author-expectations/add-row d :app-db-equals)
+          d2 (rf.story.ui.author-expectations/add-row d1 :dom-text)]
       (is (= 2 (count (:rows d2))))
       (is (= [:app-db-equals :dom-text] (mapv :kind (:rows d2))))
       (is (= [0 1] (mapv :row-id (:rows d2)))
           "row ids are stable + monotonic so React keys survive edits"))))
 
 (deftest remove-row-drops-by-id
-  (let [d (-> (ui/initial-draft)
-              (ui/add-row :app-db-equals)
-              (ui/add-row :no-warnings))]
-    (is (= [1] (mapv :row-id (:rows (ui/remove-row d 0)))))
+  (let [d (-> (rf.story.ui.author-expectations/initial-draft)
+              (rf.story.ui.author-expectations/add-row :app-db-equals)
+              (rf.story.ui.author-expectations/add-row :no-warnings))]
+    (is (= [1] (mapv :row-id (:rows (rf.story.ui.author-expectations/remove-row d 0)))))
     (is (= 2 (count (:rows d))) "remove is non-mutating")))
 
 (deftest set-operand-stores-raw-string
   (testing "set-operand stores the raw value verbatim (parsed at projection)"
-    (let [d (-> (ui/initial-draft)
-                (ui/add-row :app-db-equals)
-                (ui/set-operand 0 :path "[:a]")
-                (ui/set-operand 0 :expected "5"))]
+    (let [d (-> (rf.story.ui.author-expectations/initial-draft)
+                (rf.story.ui.author-expectations/add-row :app-db-equals)
+                (rf.story.ui.author-expectations/set-operand 0 :path "[:a]")
+                (rf.story.ui.author-expectations/set-operand 0 :expected "5"))]
       (is (= "[:a]" (get-in (first (:rows d)) [:operands :path])))
       (is (= "5" (get-in (first (:rows d)) [:operands :expected]))))))
 
 (deftest set-variant-id-and-doc
-  (let [d (-> (ui/initial-draft)
-              (ui/set-variant-id :story.x/expects-1)
-              (ui/set-doc "why"))]
+  (let [d (-> (rf.story.ui.author-expectations/initial-draft)
+              (rf.story.ui.author-expectations/set-variant-id :story.x/expects-1)
+              (rf.story.ui.author-expectations/set-doc "why"))]
     (is (= :story.x/expects-1 (:variant-id d)))
     (is (= "why" (:doc d)))))
 
 (deftest draft-atoms-projects-ready-rows
   (testing "draft-atoms yields canonical atoms for the ready rows only"
-    (let [d (-> (ui/initial-draft)
-                (ui/add-row :app-db-equals)
-                (ui/set-operand 0 :path "[:a]")
-                (ui/set-operand 0 :expected "1")
-                (ui/add-row :no-warnings)         ; nullary, always ready
-                (ui/add-row :sub-equals))]        ; operands blank → not ready
+    (let [d (-> (rf.story.ui.author-expectations/initial-draft)
+                (rf.story.ui.author-expectations/add-row :app-db-equals)
+                (rf.story.ui.author-expectations/set-operand 0 :path "[:a]")
+                (rf.story.ui.author-expectations/set-operand 0 :expected "1")
+                (rf.story.ui.author-expectations/add-row :no-warnings)         ; nullary, always ready
+                (rf.story.ui.author-expectations/add-row :sub-equals))]        ; operands blank → not ready
       (is (= [[:rf.assert/path-equals [:a] 1]
               [:rf.assert/no-warnings]]
-             (ui/draft-atoms d))))))
+             (rf.story.ui.author-expectations/draft-atoms d))))))
 
 ;; ===========================================================================
 ;; CLJS-only — button hiccup
@@ -76,7 +76,7 @@
 #?(:cljs
    (deftest button-disabled-without-variant
      (testing "the button is disabled + hinted when no variant is focused"
-       (let [attrs (second (ui/author-expectations-button nil))]
+       (let [attrs (second (rf.story.ui.author-expectations/author-expectations-button nil))]
          (is (true? (:disabled attrs)))
          (is (str/includes? (:title attrs) "Select a variant"))
          (is (= "story-author-expectation-button" (:data-test attrs)))))))
@@ -84,7 +84,7 @@
 #?(:cljs
    (deftest button-enabled-with-variant
      (testing "the button enables when a variant is focused"
-       (let [attrs (second (ui/author-expectations-button :story.x/y))]
+       (let [attrs (second (rf.story.ui.author-expectations/author-expectations-button :story.x/y))]
          (is (false? (:disabled attrs)))
          (is (fn? (:on-click attrs)))))))
 
@@ -97,41 +97,41 @@
      "Realise the form-2 author-dialog into hiccup (call the component, then
       its returned render fn)."
      []
-     ((ui/author-dialog))))
+     ((rf.story.ui.author-expectations/author-dialog))))
 
 #?(:cljs
    (deftest dialog-not-rendered-when-closed
      (testing "the dialog renders nil while its ratom is closed"
-       (reset! ui/dialog-atom ui/initial-dialog-state)
+       (reset! rf.story.ui.author-expectations/dialog-atom rf.story.ui.author-expectations/initial-dialog-state)
        (is (nil? (render-dialog))))))
 
 #?(:cljs
    (deftest open-seeds-an-empty-draft-with-default-id
      (testing "open! flips :open? and seeds a default expects-<ms> id"
-       (registrar/clear-all!)
-       (ui/open! :story.counter/happy-path)
-       (let [d @ui/dialog-atom]
+       (rf.story.registrar/clear-all!)
+       (rf.story.ui.author-expectations/open! :story.counter/happy-path)
+       (let [d @rf.story.ui.author-expectations/dialog-atom]
          (is (:open? d))
          (is (= :story.counter/happy-path (:source-id d)))
          (is (empty? (:rows (:draft d))) "starts with no expectations")
          (is (qualified-keyword? (:variant-id (:draft d))))
          (is (str/includes? (name (:variant-id (:draft d))) "expects")
              "the default id carries the 'expects' prefix"))
-       (ui/close!))))
+       (rf.story.ui.author-expectations/close!))))
 
 #?(:cljs
    (deftest dialog-shows-cost-before-save-and-cannot-run
      (testing "the open dialog renders the per-row cost + a cannot-run flag
                for a DOM expectation — the honesty floor BEFORE save"
-       (registrar/clear-all!)
-       (ui/open! :story.counter/happy-path)
+       (rf.story.registrar/clear-all!)
+       (rf.story.ui.author-expectations/open! :story.counter/happy-path)
        ;; author one headless app-db expectation + one DOM expectation
-       (ui/add-row! :app-db-equals)
-       (ui/set-operand! 0 :path "[:counter :value]")
-       (ui/set-operand! 0 :expected "5")
-       (ui/add-row! :dom-text)
-       (ui/set-operand! 1 :selector "\".count\"")
-       (ui/set-operand! 1 :text "\"5\"")
+       (rf.story.ui.author-expectations/add-row! :app-db-equals)
+       (rf.story.ui.author-expectations/set-operand! 0 :path "[:counter :value]")
+       (rf.story.ui.author-expectations/set-operand! 0 :expected "5")
+       (rf.story.ui.author-expectations/add-row! :dom-text)
+       (rf.story.ui.author-expectations/set-operand! 1 :selector "\".count\"")
+       (rf.story.ui.author-expectations/set-operand! 1 :text "\"5\"")
        (let [flat (str (render-dialog))]
          (is (str/includes? flat "story-author-expectation-dialog"))
          ;; both authored rows are present as components (the per-row cost
@@ -154,7 +154,7 @@
          (is (str/includes? flat ":rf.assert/dom-text"))
          (is (str/includes? flat ":extends"))
          (is (str/includes? flat ":story.counter/happy-path")))
-       (ui/close!))))
+       (rf.story.ui.author-expectations/close!))))
 
 #?(:cljs
    (deftest expectation-row-renders-per-row-cost-stripe
@@ -163,7 +163,7 @@
                (realised directly, since the strip lives inside the component)"
        (let [row  {:row-id 0 :kind :dom-text
                    :operands {:selector "\".count\"" :text "\"5\""}}
-             flat (str (#'ui/expectation-row row))]
+             flat (str (#'rf.story.ui.author-expectations/expectation-row row))]
          (is (str/includes? flat "story-author-expectation-cost"))
          (is (str/includes? flat "story-author-expectation-cannot-run"))
          (is (str/includes? flat "cannot run headless"))
@@ -173,26 +173,26 @@
    (deftest dialog-merges-existing-declared-assertions
      (testing "the snippet merges the source variant's declared :assertions
                with the authored atoms (the additive round-trip)"
-       (registrar/clear-all!)
-       (registrar/install-canonical-tags!)
+       (rf.story.registrar/clear-all!)
+       (rf.story.registrar/install-canonical-tags!)
        ;; register a source variant that already declares an assertion
-       (registrar/reg-variant* :story.counter/has-assert
+       (rf.story.registrar/reg-variant* :story.counter/has-assert
          {:assertions [[:rf.assert/no-warnings]]
           :tags       #{:test}})
-       (ui/open! :story.counter/has-assert)
-       (ui/add-row! :app-db-equals)
-       (ui/set-operand! 0 :path "[:n]")
-       (ui/set-operand! 0 :expected "1")
+       (rf.story.ui.author-expectations/open! :story.counter/has-assert)
+       (rf.story.ui.author-expectations/add-row! :app-db-equals)
+       (rf.story.ui.author-expectations/set-operand! 0 :path "[:n]")
+       (rf.story.ui.author-expectations/set-operand! 0 :expected "1")
        (let [flat (str (render-dialog))]
          (is (str/includes? flat ":rf.assert/no-warnings") "existing kept")
          (is (str/includes? flat ":rf.assert/path-equals") "authored added"))
-       (ui/close!))))
+       (rf.story.ui.author-expectations/close!))))
 
 #?(:cljs
    (deftest kind-picker-covers-all-surfaces
      (testing "the rendered dialog kind-picker offers a chip per catalog kind"
-       (registrar/clear-all!)
-       (ui/open! :story.x/y)
+       (rf.story.registrar/clear-all!)
+       (rf.story.ui.author-expectations/open! :story.x/y)
        (let [flat (str (render-dialog))]
          (is (str/includes? flat "story-author-expectation-kind-picker"))
          ;; one chip per kind — spot-check the five acceptance surfaces
@@ -201,4 +201,4 @@
          (is (str/includes? flat "dom-text"))
          (is (str/includes? flat "schema-error"))
          (is (str/includes? flat "a11y")))
-       (ui/close!))))
+       (rf.story.ui.author-expectations/close!))))

--- a/tools/story/test/re_frame/story/ui/backgrounds_switcher_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/backgrounds_switcher_cljs_test.cljc
@@ -9,20 +9,20 @@
   - The chip emits `aria-haspopup` rather than `aria-pressed` so the
     toolbar reset assertion is not tripped."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story :as story]
-            #?@(:cljs [[re-frame.story.backgrounds :as backgrounds]
-                       [re-frame.story.ui.backgrounds-switcher :as bs]
-                       [re-frame.story.ui.state :as state]])))
+            [re-frame.story :as rf.story]
+            #?@(:cljs [[re-frame.story.backgrounds :as rf.story.backgrounds]
+                       [re-frame.story.ui.backgrounds-switcher :as rf.story.ui.backgrounds-switcher]
+                       [re-frame.story.ui.state :as rf.story.ui.state]])))
 
 #?(:cljs
    (defn reset-all! []
-     (story/clear-all!)
-     (state/reset-shell-state!)
-     (bs/close!)
+     (rf.story/clear-all!)
+     (rf.story.ui.state/reset-shell-state!)
+     (rf.story.ui.backgrounds-switcher/close!)
      (when (and (exists? js/window) (.-localStorage js/window))
-       (try (.removeItem (.-localStorage js/window) backgrounds/ls-key)
+       (try (.removeItem (.-localStorage js/window) rf.story.backgrounds/ls-key)
             (catch :default _ nil)))
-     (story/install-canonical-vocabulary!)))
+     (rf.story/install-canonical-vocabulary!)))
 
 #?(:cljs
    (use-fixtures :each (fn [t] (reset-all!) (t))))
@@ -32,67 +32,67 @@
 #?(:cljs
    (deftest cljs-select-writes-shell-state
      (testing "select! lands the normalised choice on shell-state-atom"
-       (bs/select! :dark)
-       (is (= :dark (:background (state/get-state))))
-       (bs/select! :midnight)
-       (is (= :midnight (:background (state/get-state)))))))
+       (rf.story.ui.backgrounds-switcher/select! :dark)
+       (is (= :dark (:background (rf.story.ui.state/get-state))))
+       (rf.story.ui.backgrounds-switcher/select! :midnight)
+       (is (= :midnight (:background (rf.story.ui.state/get-state)))))))
 
 #?(:cljs
    (deftest cljs-select-custom-writes-hex
      (testing "a custom hex persists as a trimmed string"
-       (bs/select! "#abc123")
-       (is (= "#abc123" (:background (state/get-state)))))))
+       (rf.story.ui.backgrounds-switcher/select! "#abc123")
+       (is (= "#abc123" (:background (rf.story.ui.state/get-state)))))))
 
 #?(:cljs
    (deftest cljs-select-drops-unknown
      (testing "unknown preset → slot cleared"
-       (bs/select! :dark)
-       (is (= :dark (:background (state/get-state))))
-       (bs/select! :neon)
-       (is (nil? (:background (state/get-state)))))))
+       (rf.story.ui.backgrounds-switcher/select! :dark)
+       (is (= :dark (:background (rf.story.ui.state/get-state))))
+       (rf.story.ui.backgrounds-switcher/select! :neon)
+       (is (nil? (:background (rf.story.ui.state/get-state)))))))
 
 ;; ---- per-story override resolution --------------------------------------
 
 #?(:cljs
    (deftest cljs-effective-background-respects-variant-override
      (testing "rf2-zll4h: per-variant :background body slot beats toolbar"
-       (story/reg-story* :story.bg-override
+       (rf.story/reg-story* :story.bg-override
          {:doc "background override fixture" :component :ignored
           :background :paper})
-       (story/reg-variant* :story.bg-override/v
+       (rf.story/reg-variant* :story.bg-override/v
          {:doc "child" :background :midnight})
-       (state/swap-state! assoc :background :dark)
-       (state/swap-state! assoc :selected-variant :story.bg-override/v)
-       (let [eff (bs/effective-background)]
+       (rf.story.ui.state/swap-state! assoc :background :dark)
+       (rf.story.ui.state/swap-state! assoc :selected-variant :story.bg-override/v)
+       (let [eff (rf.story.ui.backgrounds-switcher/effective-background)]
          (is (= "Midnight" (:label eff))
              "variant :background (:midnight) wins over toolbar (:dark)"))
-       (is (= :midnight (bs/effective-id))))))
+       (is (= :midnight (rf.story.ui.backgrounds-switcher/effective-id))))))
 
 #?(:cljs
    (deftest cljs-effective-background-falls-through-to-story
      (testing "no variant override → parent story's :background applies"
-       (story/reg-story* :story.bg-story-only
+       (rf.story/reg-story* :story.bg-story-only
          {:doc "story-level override only" :component :ignored
           :background :paper})
-       (story/reg-variant* :story.bg-story-only/v
+       (rf.story/reg-variant* :story.bg-story-only/v
          {:doc "child"})
-       (state/swap-state! assoc :background :dark)
-       (state/swap-state! assoc :selected-variant :story.bg-story-only/v)
-       (let [eff (bs/effective-background)]
+       (rf.story.ui.state/swap-state! assoc :background :dark)
+       (rf.story.ui.state/swap-state! assoc :selected-variant :story.bg-story-only/v)
+       (let [eff (rf.story.ui.backgrounds-switcher/effective-background)]
          (is (= "Paper" (:label eff))))
-       (is (= :paper (bs/effective-id))))))
+       (is (= :paper (rf.story.ui.backgrounds-switcher/effective-id))))))
 
 #?(:cljs
    (deftest cljs-effective-background-falls-through-to-toolbar
      (testing "no override → toolbar selection takes effect"
-       (state/swap-state! assoc :background :dark)
-       (let [eff (bs/effective-background)]
+       (rf.story.ui.state/swap-state! assoc :background :dark)
+       (let [eff (rf.story.ui.backgrounds-switcher/effective-background)]
          (is (= "Dark" (:label eff)))))))
 
 #?(:cljs
    (deftest cljs-effective-background-default-is-light
      (testing "no override + no selection → :light"
-       (let [eff (bs/effective-background)]
+       (let [eff (rf.story.ui.backgrounds-switcher/effective-background)]
          (is (= "Light" (:label eff)))
          (is (= "#ffffff" (:color eff)))))))
 
@@ -101,13 +101,13 @@
 #?(:cljs
    (deftest cljs-chip-renders-without-throwing
      (testing "chip-when-enabled returns a hiccup tree"
-       (let [hiccup (bs/chip-when-enabled)]
+       (let [hiccup (rf.story.ui.backgrounds-switcher/chip-when-enabled)]
          (is (some? hiccup))))))
 
 #?(:cljs
    (deftest cljs-chip-uses-aria-haspopup-not-aria-pressed
      (testing "rf2-zll4h reset-gate: chip MUST NOT emit aria-pressed='true'"
-       (let [hiccup (bs/chip)]
+       (let [hiccup (rf.story.ui.backgrounds-switcher/chip)]
          (let [flat (->> (tree-seq coll? seq hiccup)
                          (filter map?))
                attrs-with-button (filter #(or (:aria-haspopup %)
@@ -121,7 +121,7 @@
 #?(:cljs
    (deftest cljs-chip-data-attrs
      (testing "chip carries data-test + data-background for browser specs"
-       (let [hiccup (bs/chip)
+       (let [hiccup (rf.story.ui.backgrounds-switcher/chip)
              flat   (->> (tree-seq coll? seq hiccup)
                          (filter map?))
              attrs  (filter #(= "story-toolbar-backgrounds"
@@ -139,17 +139,17 @@
 #?(:cljs
    (deftest cljs-hydrate-from-storage-seeds-empty-slot
      (when (browser?)
-       (backgrounds/save-to-storage! :dark)
-       (state/reset-shell-state!)
-       (is (nil? (:background (state/get-state))))
-       (bs/hydrate!)
-       (is (= :dark (:background (state/get-state)))))))
+       (rf.story.backgrounds/save-to-storage! :dark)
+       (rf.story.ui.state/reset-shell-state!)
+       (is (nil? (:background (rf.story.ui.state/get-state))))
+       (rf.story.ui.backgrounds-switcher/hydrate!)
+       (is (= :dark (:background (rf.story.ui.state/get-state)))))))
 
 #?(:cljs
    (deftest cljs-hydrate-skips-populated-slot
      (when (browser?)
-       (backgrounds/save-to-storage! :dark)
-       (state/swap-state! assoc :background :midnight)
-       (bs/hydrate!)
-       (is (= :midnight (:background (state/get-state)))
+       (rf.story.backgrounds/save-to-storage! :dark)
+       (rf.story.ui.state/swap-state! assoc :background :midnight)
+       (rf.story.ui.backgrounds-switcher/hydrate!)
+       (is (= :midnight (:background (rf.story.ui.state/get-state)))
            "populated slot was preserved"))))

--- a/tools/story/test/re_frame/story/ui/canvas_skeleton_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/canvas_skeleton_cljs_test.cljs
@@ -14,35 +14,35 @@
   - `viewport-indicator`    — hidden for `:full` (no width/height);
                               shows `\"WxH\"` text for sized presets"
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.story.ui.canvas :as canvas]))
+            [re-frame.story.ui.canvas :as rf.story.ui.canvas]))
 
-(use-fixtures :each {:before (fn [] (canvas/reset-first-rendered!))})
+(use-fixtures :each {:before (fn [] (rf.story.ui.canvas/reset-first-rendered!))})
 
 ;; ---- loading-phase? -----------------------------------------------------
 
 (deftest loading-phase-pre-mount-mounting-loading
   (testing "pre-mount / mounting / loading + not-rendered? + no assertions → true"
-    (is (true? (canvas/loading-phase? :pre-mount false false)))
-    (is (true? (canvas/loading-phase? :mounting  false false)))
-    (is (true? (canvas/loading-phase? :loading   false false)))))
+    (is (true? (rf.story.ui.canvas/loading-phase? :pre-mount false false)))
+    (is (true? (rf.story.ui.canvas/loading-phase? :mounting  false false)))
+    (is (true? (rf.story.ui.canvas/loading-phase? :loading   false false)))))
 
 (deftest loading-phase-ready-or-error
   (testing ":ready / :error → false"
-    (is (false? (canvas/loading-phase? :ready false false)))
-    (is (false? (canvas/loading-phase? :error false false)))))
+    (is (false? (rf.story.ui.canvas/loading-phase? :ready false false)))
+    (is (false? (rf.story.ui.canvas/loading-phase? :error false false)))))
 
 (deftest loading-phase-first-rendered-overrides
   (testing "first-rendered? true → false regardless of phase"
-    (is (false? (canvas/loading-phase? :loading true false)))
-    (is (false? (canvas/loading-phase? :pre-mount true false)))))
+    (is (false? (rf.story.ui.canvas/loading-phase? :loading true false)))
+    (is (false? (rf.story.ui.canvas/loading-phase? :pre-mount true false)))))
 
 (deftest loading-phase-assertions-recorded-overrides
   (testing "assertions-recorded? true → false even when phase is loading
             (rf2-qrk2s: loader-never-completes / loader-rejects park the
             lifecycle at :loading but the user view must render)"
-    (is (false? (canvas/loading-phase? :loading   false true)))
-    (is (false? (canvas/loading-phase? :pre-mount false true)))
-    (is (false? (canvas/loading-phase? :mounting  false true)))))
+    (is (false? (rf.story.ui.canvas/loading-phase? :loading   false true)))
+    (is (false? (rf.story.ui.canvas/loading-phase? :pre-mount false true)))
+    (is (false? (rf.story.ui.canvas/loading-phase? :mounting  false true)))))
 
 (deftest loading-phase-events-only-overrides
   (testing "rf2-043cm — events-only? true → false even when phase is in
@@ -51,33 +51,33 @@
             skeleton must NEVER engage for them, including the brief
             pre-allocate window where `current-state` could still
             report `:pre-mount`."
-    (is (false? (canvas/loading-phase? :pre-mount false false true)))
-    (is (false? (canvas/loading-phase? :mounting  false false true)))
-    (is (false? (canvas/loading-phase? :loading   false false true)))
-    (is (false? (canvas/loading-phase? :ready     false false true))))
+    (is (false? (rf.story.ui.canvas/loading-phase? :pre-mount false false true)))
+    (is (false? (rf.story.ui.canvas/loading-phase? :mounting  false false true)))
+    (is (false? (rf.story.ui.canvas/loading-phase? :loading   false false true)))
+    (is (false? (rf.story.ui.canvas/loading-phase? :ready     false false true))))
   (testing "events-only? false reverts to the classical predicate"
-    (is (true?  (canvas/loading-phase? :pre-mount false false false)))
-    (is (false? (canvas/loading-phase? :ready     false false false)))))
+    (is (true?  (rf.story.ui.canvas/loading-phase? :pre-mount false false false)))
+    (is (false? (rf.story.ui.canvas/loading-phase? :ready     false false false)))))
 
 (deftest loading-phase-3-arg-overload-is-back-compat
   (testing "rf2-043cm — the 3-arg overload (phase / first? / assertions?)
             stays a back-compat surface for callers / tests written
             against the pre-rf2-043cm signature. It defaults
             `events-only?` to false."
-    (is (true?  (canvas/loading-phase? :loading   false false)))
-    (is (false? (canvas/loading-phase? :ready     false false)))))
+    (is (true?  (rf.story.ui.canvas/loading-phase? :loading   false false)))
+    (is (false? (rf.story.ui.canvas/loading-phase? :ready     false false)))))
 
 (deftest loading-phase-nil-or-unknown
   (testing "nil phase → false (no skeleton when phase isn't known)"
-    (is (false? (canvas/loading-phase? nil false false))))
+    (is (false? (rf.story.ui.canvas/loading-phase? nil false false))))
   (testing "unknown phase → false"
-    (is (false? (canvas/loading-phase? :something-else false false)))))
+    (is (false? (rf.story.ui.canvas/loading-phase? :something-else false false)))))
 
 ;; ---- loading-skeleton hiccup shape --------------------------------------
 
 (deftest loading-skeleton-hiccup-shape
   (testing "hiccup root carries the canonical data-test"
-    (let [hiccup (canvas/loading-skeleton)
+    (let [hiccup (rf.story.ui.canvas/loading-skeleton)
           [_tag props] hiccup]
       (is (= "story-canvas-loading-skeleton" (:data-test props)))
       (is (= "status" (:role props)))
@@ -87,30 +87,30 @@
 
 (deftest first-rendered-sentinel-round-trip
   (testing "marker round-trips through the per-variant set"
-    (canvas/reset-first-rendered!)
-    (is (false? (canvas/variant-first-rendered? :story.x/y)))
-    (canvas/mark-variant-rendered! :story.x/y)
-    (is (true? (canvas/variant-first-rendered? :story.x/y)))
-    (canvas/reset-first-rendered! :story.x/y)
-    (is (false? (canvas/variant-first-rendered? :story.x/y))))
+    (rf.story.ui.canvas/reset-first-rendered!)
+    (is (false? (rf.story.ui.canvas/variant-first-rendered? :story.x/y)))
+    (rf.story.ui.canvas/mark-variant-rendered! :story.x/y)
+    (is (true? (rf.story.ui.canvas/variant-first-rendered? :story.x/y)))
+    (rf.story.ui.canvas/reset-first-rendered! :story.x/y)
+    (is (false? (rf.story.ui.canvas/variant-first-rendered? :story.x/y))))
   (testing "reset all"
-    (canvas/mark-variant-rendered! :story.a/one)
-    (canvas/mark-variant-rendered! :story.b/two)
-    (is (true? (canvas/variant-first-rendered? :story.a/one)))
-    (canvas/reset-first-rendered!)
-    (is (false? (canvas/variant-first-rendered? :story.a/one)))
-    (is (false? (canvas/variant-first-rendered? :story.b/two)))))
+    (rf.story.ui.canvas/mark-variant-rendered! :story.a/one)
+    (rf.story.ui.canvas/mark-variant-rendered! :story.b/two)
+    (is (true? (rf.story.ui.canvas/variant-first-rendered? :story.a/one)))
+    (rf.story.ui.canvas/reset-first-rendered!)
+    (is (false? (rf.story.ui.canvas/variant-first-rendered? :story.a/one)))
+    (is (false? (rf.story.ui.canvas/variant-first-rendered? :story.b/two)))))
 
 ;; ---- viewport-indicator -------------------------------------------------
 
 (deftest viewport-indicator-elides-for-full
   (testing ":full preset has no width/height → indicator hidden"
-    (is (nil? (canvas/viewport-indicator {:label "Full" :width nil :height nil})))
-    (is (nil? (canvas/viewport-indicator {})))))
+    (is (nil? (rf.story.ui.canvas/viewport-indicator {:label "Full" :width nil :height nil})))
+    (is (nil? (rf.story.ui.canvas/viewport-indicator {})))))
 
 (deftest viewport-indicator-shows-dims
   (testing "sized preset → chip with WxH text"
-    (let [hiccup (canvas/viewport-indicator {:label "iPhone" :width 375 :height 667})
+    (let [hiccup (rf.story.ui.canvas/viewport-indicator {:label "iPhone" :width 375 :height 667})
           [_tag props text] hiccup]
       (is (= "story-canvas-viewport-indicator" (:data-test props)))
       (is (= "375 × 667" text)))))

--- a/tools/story/test/re_frame/story/ui/canvas_substrate_routing_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/canvas_substrate_routing_cljs_test.cljs
@@ -7,7 +7,7 @@
 
   Story's substrate abstraction is an open runtime registry with a public
   `register-substrate!` — and the default render path did not use it.
-  `canvas/canvas-inner` used the declared substrate set only as a COUNT: a set
+  `rf.story.ui.canvas/canvas-inner` used the declared substrate set only as a COUNT: a set
   of size one fell to the `:else` branch, which called `(rf/view view-id)`
   itself and embedded the result as a Reagent hiccup vector.
   `canonical/render-host-scope` passed a LITERAL `:reagent` into the shared
@@ -33,7 +33,7 @@
 
   ## Registry hygiene
 
-  `substrate->render-fn` is a `defonce` atom that `story/clear-all!` does not
+  `substrate->render-fn` is a `defonce` atom that `rf.story/clear-all!` does not
   touch, so a `:uix` stub registered here would leak into every namespace that
   runs after this one — including `render_shell_cljs_test`'s
   `unregistered-substrate-renders-inline-error-cell`, whose precondition is
@@ -42,50 +42,50 @@
   Sub-millisecond per case; no DOM mount, no React, no Playwright."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story :as story]
-            [re-frame.story.loaders :as loaders]
-            [re-frame.story.render :as render]
-            [re-frame.story.ui.canvas :as canvas]
-            [re-frame.story.ui.multi-substrate :as multi-substrate]
-            [re-frame.story.ui.state :as state]
-            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
-            [re-frame.subs :as subs]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.loaders :as rf.story.loaders]
+            [re-frame.story.render :as rf.story.render]
+            [re-frame.story.ui.canvas :as rf.story.ui.canvas]
+            [re-frame.story.ui.multi-substrate :as rf.story.ui.multi-substrate]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]
+            [re-frame.subs :as rf.subs]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (declare register-probe-views!)
 
 (defn- reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
   ;; EP-0001 (rf2-vzld77 / rf2-ixb0bq): machine snapshots are durable
   ;; RUNTIME-DB state at [:rf.runtime/machines :snapshots <id>] — the framework
   ;; `:rf/machine` sub reads the runtime-db partition, NOT the retired app-db
   ;; `:rf/runtime` path. Mirror `re-frame.machines`. Without it the lifecycle
   ;; machine cannot resolve and the canvas reads `:pre-mount` indefinitely.
-  (subs/reg-runtime-sub :rf/machine
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [runtime-db [_ machine-id]]
       (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (canvas/reset-first-rendered!)
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.ui.canvas/reset-first-rendered!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   ;; Start every case from a KNOWN-EMPTY :uix slot. Individual tests register
   ;; the stub when they want the registered path; the unregistered-substrate
   ;; test wants it absent.
-  (multi-substrate/unregister-substrate! :uix)
+  (rf.story.ui.multi-substrate/unregister-substrate! :uix)
   (register-probe-views!))
 
 (defn- restore-registry! []
-  (multi-substrate/unregister-substrate! :uix))
+  (rf.story.ui.multi-substrate/unregister-substrate! :uix))
 
 (use-fixtures :each {:before reset-all! :after restore-registry!})
 
@@ -108,25 +108,25 @@
 
 (defn- register-probe-views! []
   (rf/reg-view* :views/probe reagent-probe-view)
-  (story/reg-story* :story.substrate-routing {:doc "rf2-3afns witness story"})
+  (rf.story/reg-story* :story.substrate-routing {:doc "rf2-3afns witness story"})
   ;; `:loaders` is declared so `events-only-variant?` returns false — the only
   ;; condition that matters for the `loading-phase?` skeleton gate. The test
   ;; drives the lifecycle machine directly, so the slot needs no real event.
-  (story/reg-variant* :story.substrate-routing/uix-only
+  (rf.story/reg-variant* :story.substrate-routing/uix-only
     {:doc        "Declares ONE substrate, and it is not Reagent."
      :component  :views/probe
      :substrates #{:uix}
      :loaders    [[:noop/loader]]})
   ;; rf2-sc5g0 — the same declaration, one level up. The STORY names the
   ;; subject and the layer; the variant names neither and inherits both.
-  (story/reg-story* :story.substrate-story-scope
+  (rf.story/reg-story* :story.substrate-story-scope
     {:doc        "rf2-sc5g0 witness — story-level :component + :substrates"
      :component  :views/probe
      :substrates #{:uix}})
-  (story/reg-variant* :story.substrate-story-scope/inherits
+  (rf.story/reg-variant* :story.substrate-story-scope/inherits
     {:doc     "Declares neither :component nor :substrates."
      :loaders [[:noop/loader]]})
-  (story/reg-variant* :story.substrate-routing/reagent-only
+  (rf.story/reg-variant* :story.substrate-routing/reagent-only
     {:doc        "Declares ONE substrate, Reagent — the unchanged baseline."
      :component  :views/probe
      :substrates #{:reagent}
@@ -134,7 +134,7 @@
 
 ;; ---- helpers -------------------------------------------------------------
 
-(def ^:private canvas-inner @#'canvas/canvas-inner)
+(def ^:private canvas-inner @#'rf.story.ui.canvas/canvas-inner)
 
 (defn- ready-tree
   "Drive `variant-id`'s lifecycle to `:ready`, then render the canvas's inner
@@ -144,18 +144,18 @@
   fail for the wrong reason."
   [variant-id]
   (rf/make-frame {:id variant-id})
-  (loaders/mount! variant-id)
-  (loaders/start-loaders! variant-id)
-  (loaders/finish-loaders! variant-id)
-  (loaders/finish-events! variant-id)
-  (canvas/mark-variant-rendered! variant-id)
-  (e2e/expand-tree (canvas-inner variant-id)))
+  (rf.story.loaders/mount! variant-id)
+  (rf.story.loaders/start-loaders! variant-id)
+  (rf.story.loaders/finish-loaders! variant-id)
+  (rf.story.loaders/finish-events! variant-id)
+  (rf.story.ui.canvas/mark-variant-rendered! variant-id)
+  (rf.story.test-helpers.e2e-multi-frame/expand-tree (canvas-inner variant-id)))
 
 (defn- rendered-under-uix? [tree]
-  (some? (e2e/find-by-test-id tree "uix-stub-render")))
+  (some? (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "uix-stub-render")))
 
 (defn- rendered-under-reagent? [tree]
-  (some? (e2e/find-by-test-id tree "reagent-view-render")))
+  (some? (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "reagent-view-render")))
 
 ;; ===========================================================================
 ;; THE WITNESS — the canvas single-pane path honours the declared substrate
@@ -167,7 +167,7 @@
             This is the bead's defect stated as an assertion: before the fix
             the canvas `:else` branch called `(rf/view view-id)` itself, so
             this tree carried `reagent-view-render` and no uix marker at all."
-    (story/register-substrate! :uix uix-stub-render)
+    (rf.story/register-substrate! :uix uix-stub-render)
     (let [variant-id :story.substrate-routing/uix-only
           tree       (ready-tree variant-id)]
       (is (rendered-under-uix? tree)
@@ -177,14 +177,14 @@
           "and it did NOT also paint Reagent — a UIx user gets a UIx render,
            which is the whole defect (a silent Reagent render is what they
            got before)")
-      (story/destroy-variant! variant-id))))
+      (rf.story/destroy-variant! variant-id))))
 
 (deftest single-pane-substrate-is-resolved-not-counted
   (testing "rf2-3afns — the substrate SET SIZE decides grid-vs-single-pane and
             nothing else. A one-element set is not a licence to assume
             Reagent: swap the sole declared substrate and the renderer swaps
             with it, with the count held constant at one."
-    (story/register-substrate! :uix uix-stub-render)
+    (rf.story/register-substrate! :uix uix-stub-render)
     (let [uix-tree     (ready-tree :story.substrate-routing/uix-only)
           reagent-tree (ready-tree :story.substrate-routing/reagent-only)]
       (is (and (rendered-under-uix? uix-tree)
@@ -194,8 +194,8 @@
                (not (rendered-under-uix? reagent-tree)))
           "#{:reagent} → the built-in reagent render fn (the baseline this
            fix must not disturb — the same count, the other renderer)")
-      (story/destroy-variant! :story.substrate-routing/uix-only)
-      (story/destroy-variant! :story.substrate-routing/reagent-only))))
+      (rf.story/destroy-variant! :story.substrate-routing/uix-only)
+      (rf.story/destroy-variant! :story.substrate-routing/reagent-only))))
 
 (deftest single-pane-says-so-when-the-substrate-is-unregistered
   (testing "rf2-3afns — the user-visible half of the fix. With :uix declared
@@ -203,11 +203,11 @@
             silently painting Reagent. Silence was the defect's real cost: a
             UIx user got a Reagent render and no signal that anything was
             wrong."
-    (is (not (contains? @multi-substrate/substrate->render-fn :uix))
+    (is (not (contains? @rf.story.ui.multi-substrate/substrate->render-fn :uix))
         "precondition: :uix absent from the registry")
     (let [variant-id :story.substrate-routing/uix-only
           tree       (ready-tree variant-id)
-          text       (e2e/text-nodes tree)]
+          text       (rf.story.test-helpers.e2e-multi-frame/text-nodes tree)]
       (is (re-find #"is not registered" text)
           "the miss is named — `render-view`'s FRAGMENT-level diagnostic,
            the counterpart to the grid's cell-level error cell")
@@ -217,7 +217,7 @@
       (is (not (rendered-under-reagent? tree))
           "it did NOT fall back to Reagent — falling back silently is the
            bug, not the remedy")
-      (story/destroy-variant! variant-id))))
+      (rf.story/destroy-variant! variant-id))))
 
 ;; ===========================================================================
 ;; render-variant's host hook — the second pinned site
@@ -229,16 +229,16 @@
             #{:uix} variant under Reagent too. The canvas and the host agreed
             with each other only because both were wrong the same way; they
             must now agree by both being right."
-    (story/register-substrate! :uix uix-stub-render)
-    (let [result (render/render-variant :story.substrate-routing/uix-only)
-          tree   (e2e/expand-tree (:rendered result))]
+    (rf.story/register-substrate! :uix uix-stub-render)
+    (let [result (rf.story.render/render-variant :story.substrate-routing/uix-only)
+          tree   (rf.story.test-helpers.e2e-multi-frame/expand-tree (:rendered result))]
       (is (= :rendered (:status result))
           "the CLJS canonical vocabulary installs the host → :rendered")
       (is (rendered-under-uix? tree)
           "render-variant painted through the :uix render fn")
       (is (not (rendered-under-reagent? tree))
           "and not through Reagent")
-      (story/destroy-variant! :story.substrate-routing/uix-only))))
+      (rf.story/destroy-variant! :story.substrate-routing/uix-only))))
 
 ;; ===========================================================================
 ;; rf2-sc5g0 — the same disagreement with the declaration ONE LEVEL UP
@@ -260,38 +260,38 @@
             the :uix render fn. Before the fix the plan carried no
             `:substrates` (so the host default :reagent won) and no
             `:component` (so the view was nil)."
-    (story/register-substrate! :uix uix-stub-render)
-    (let [result (render/render-variant :story.substrate-story-scope/inherits)
-          tree   (e2e/expand-tree (:rendered result))]
+    (rf.story/register-substrate! :uix uix-stub-render)
+    (let [result (rf.story.render/render-variant :story.substrate-story-scope/inherits)
+          tree   (rf.story.test-helpers.e2e-multi-frame/expand-tree (:rendered result))]
       (is (= :rendered (:status result)))
       (is (rendered-under-uix? tree)
           "the inherited layer reached the host — the substrate half")
-      (is (re-find #":views/probe" (e2e/text-nodes tree))
+      (is (re-find #":views/probe" (rf.story.test-helpers.e2e-multi-frame/text-nodes tree))
           "and the inherited SUBJECT reached it too: the uix stub prints the
            view-id it was handed, so a nil view would print `nil` here. This
            is the `:component` half, which had no fallback in
-           `render/prepare-render` at all.")
+           `rf.story.render/prepare-render` at all.")
       (is (not (rendered-under-reagent? tree))
           "and it did NOT fall back to Reagent")
-      (story/destroy-variant! :story.substrate-story-scope/inherits))))
+      (rf.story/destroy-variant! :story.substrate-story-scope/inherits))))
 
 (deftest story-level-declaration-makes-canvas-and-host-agree
   (testing "rf2-sc5g0 — the canvas single-pane path ALREADY honoured a
             story-level declaration, which is exactly why the disagreement
             was invisible: the live shell painted UIx while `render-variant`
             painted Reagent, for the same variant. Both must now be UIx."
-    (story/register-substrate! :uix uix-stub-render)
+    (rf.story/register-substrate! :uix uix-stub-render)
     (let [variant-id  :story.substrate-story-scope/inherits
           canvas-tree (ready-tree variant-id)
-          host-tree   (e2e/expand-tree
-                        (:rendered (render/render-variant variant-id)))]
+          host-tree   (rf.story.test-helpers.e2e-multi-frame/expand-tree
+                        (:rendered (rf.story.render/render-variant variant-id)))]
       (is (and (rendered-under-uix? canvas-tree)
                (not (rendered-under-reagent? canvas-tree)))
           "the canvas — the control, unchanged by this fix")
       (is (and (rendered-under-uix? host-tree)
                (not (rendered-under-reagent? host-tree)))
           "and the host, which is what changed")
-      (story/destroy-variant! variant-id))))
+      (rf.story/destroy-variant! variant-id))))
 
 ;; ===========================================================================
 ;; single-render-substrate — the policy, on its own terms
@@ -304,21 +304,21 @@
 (deftest single-render-substrate-policy
   (testing "one declared substrate wins outright — the case the whole bead is
             about"
-    (is (= :uix (multi-substrate/single-render-substrate #{:uix} :reagent)))
-    (is (= :reagent (multi-substrate/single-render-substrate #{:reagent} :reagent))))
+    (is (= :uix (rf.story.ui.multi-substrate/single-render-substrate #{:uix} :reagent)))
+    (is (= :reagent (rf.story.ui.multi-substrate/single-render-substrate #{:reagent} :reagent))))
 
   (testing "nothing declared falls back to the host default"
-    (is (= :reagent (multi-substrate/single-render-substrate nil :reagent)))
-    (is (= :reagent (multi-substrate/single-render-substrate #{} :reagent))))
+    (is (= :reagent (rf.story.ui.multi-substrate/single-render-substrate nil :reagent)))
+    (is (= :reagent (rf.story.ui.multi-substrate/single-render-substrate #{} :reagent))))
 
   (testing "a multi-substrate variant that DECLARED the host default keeps it
             — the common #{:reagent :uix} case is behaviour-unchanged"
-    (is (= :reagent (multi-substrate/single-render-substrate #{:reagent :uix} :reagent))))
+    (is (= :reagent (rf.story.ui.multi-substrate/single-render-substrate #{:reagent :uix} :reagent))))
 
   (testing "a multi-substrate variant that did NOT declare the host default
             gets a declared one, chosen deterministically by name rather than
             by hash order — never the undeclared default"
-    (let [picked (multi-substrate/single-render-substrate #{:uix :custom} :reagent)]
+    (let [picked (rf.story.ui.multi-substrate/single-render-substrate #{:uix :custom} :reagent)]
       (is (contains? #{:uix :custom} picked)
           "the pick is one the variant actually declared")
       (is (= :custom picked)

--- a/tools/story/test/re_frame/story/ui/chrome_a11y_force_colors_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/chrome_a11y_force_colors_cljs_test.cljs
@@ -15,8 +15,8 @@
   - `bootstrap-force-colors!` re-applies the persisted state to
     `<html>` so the toggle survives reload."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.story.theme.motion :as motion]
-            [re-frame.story.ui.chrome-a11y :as chrome-a11y]))
+            [re-frame.story.theme.motion :as rf.story.theme.motion]
+            [re-frame.story.ui.chrome-a11y :as rf.story.ui.chrome-a11y]))
 
 ;; ---- fixture: clear storage + reset bootstrap sentinel + clear attr ----
 
@@ -24,21 +24,21 @@
   (when (and (exists? js/globalThis) (.-localStorage js/globalThis))
     (try
       (.removeItem (.-localStorage js/globalThis)
-                   chrome-a11y/force-colors-opt-in-key)
+                   rf.story.ui.chrome-a11y/force-colors-opt-in-key)
       (catch :default _ nil))))
 
 (defn- reset-attribute! []
   ;; Clear any attribute left behind by a prior test so each test
-  ;; observes a clean baseline. `chrome-a11y/apply-force-colors-
+  ;; observes a clean baseline. `rf.story.ui.chrome-a11y/apply-force-colors-
   ;; attribute!` with `false` removes the attribute; safe when
   ;; absent.
-  (chrome-a11y/apply-force-colors-attribute! false))
+  (rf.story.ui.chrome-a11y/apply-force-colors-attribute! false))
 
 (defn- reset-in-memory-state! []
   ;; The bootstrap sentinel + ratom live in `defonce` so they survive
   ;; across tests. Force a clean state by writing false, which also
   ;; sets the bootstrap flag so subsequent reads don't re-read storage.
-  (chrome-a11y/set-force-colors-opt-in! false))
+  (rf.story.ui.chrome-a11y/set-force-colors-opt-in! false))
 
 (use-fixtures :each
   {:before (fn []
@@ -62,7 +62,7 @@
   (testing "rf2-846h2 — opt-in defaults to false when localStorage is
             empty (or unavailable). The system-token chrome only
             activates under explicit operator opt-in or OS HCM."
-    (is (false? (chrome-a11y/force-colors-opt-in?)))))
+    (is (false? (rf.story.ui.chrome-a11y/force-colors-opt-in?)))))
 
 ;; ---- set / clear --------------------------------------------------------
 
@@ -71,23 +71,23 @@
             the in-memory ratom AND stamps the attribute on `<html>`
             so the sibling selectors in `theme/motion.cljc` fire on
             the next paint."
-    (chrome-a11y/set-force-colors-opt-in! true)
-    (is (true? (chrome-a11y/force-colors-opt-in?))
+    (rf.story.ui.chrome-a11y/set-force-colors-opt-in! true)
+    (is (true? (rf.story.ui.chrome-a11y/force-colors-opt-in?))
         "ratom reflects the new value")
     (when-let [html (html-root)]
       (is (= "active"
-             (.getAttribute html chrome-a11y/force-colors-attribute))
+             (.getAttribute html rf.story.ui.chrome-a11y/force-colors-attribute))
           "<html> carries the active attribute"))))
 
 (deftest set-false-clears-attribute-on-html-root
   (testing "rf2-846h2 — flipping the toggle off clears the attribute
             so the chrome reverts to author-encoded colours."
-    (chrome-a11y/set-force-colors-opt-in! true)
-    (chrome-a11y/set-force-colors-opt-in! false)
-    (is (false? (chrome-a11y/force-colors-opt-in?))
+    (rf.story.ui.chrome-a11y/set-force-colors-opt-in! true)
+    (rf.story.ui.chrome-a11y/set-force-colors-opt-in! false)
+    (is (false? (rf.story.ui.chrome-a11y/force-colors-opt-in?))
         "ratom reflects the flipped value")
     (when-let [html (html-root)]
-      (is (nil? (.getAttribute html chrome-a11y/force-colors-attribute))
+      (is (nil? (.getAttribute html rf.story.ui.chrome-a11y/force-colors-attribute))
           "<html> attribute cleared"))))
 
 ;; ---- bootstrap restores persisted state --------------------------------
@@ -101,13 +101,13 @@
     ;; the in-memory atom path so bootstrap re-reads storage.
     (when (and (exists? js/globalThis) (.-localStorage js/globalThis))
       (.setItem (.-localStorage js/globalThis)
-                chrome-a11y/force-colors-opt-in-key
+                rf.story.ui.chrome-a11y/force-colors-opt-in-key
                 "true"))
     ;; Reset bootstrap sentinel + ratom so the next force-colors-opt-in?
     ;; re-reads storage. We can't reach into defonce directly without an
     ;; explicit reset helper; the apply path is idempotent so we drive it
     ;; via the public set fn after seeding storage.
-    (chrome-a11y/bootstrap-force-colors!)
+    (rf.story.ui.chrome-a11y/bootstrap-force-colors!)
     (when-let [html (html-root)]
       ;; The in-memory state may still be false from the fixture reset
       ;; (defonce sentinel held); bootstrap reads via `force-colors-opt-
@@ -115,10 +115,10 @@
       ;; round-trip works via the persisted side: when storage holds
       ;; "true", a fresh apply via `set-force-colors-opt-in! true`
       ;; followed by `bootstrap-force-colors!` keeps the attribute on.
-      (chrome-a11y/set-force-colors-opt-in! true)
-      (chrome-a11y/bootstrap-force-colors!)
+      (rf.story.ui.chrome-a11y/set-force-colors-opt-in! true)
+      (rf.story.ui.chrome-a11y/bootstrap-force-colors!)
       (is (= "active"
-             (.getAttribute html chrome-a11y/force-colors-attribute))
+             (.getAttribute html rf.story.ui.chrome-a11y/force-colors-attribute))
           "<html> carries the active attribute after bootstrap"))))
 
 ;; ---- apply is no-op-safe ------------------------------------------------
@@ -129,8 +129,8 @@
             root or without an `<html>` document (defensive: the
             helper is called from the bootstrap path that may run
             before the React tree commits)."
-    (is (nil? (chrome-a11y/apply-force-colors-attribute! true)))
-    (is (nil? (chrome-a11y/apply-force-colors-attribute! false)))))
+    (is (nil? (rf.story.ui.chrome-a11y/apply-force-colors-attribute! true)))
+    (is (nil? (rf.story.ui.chrome-a11y/apply-force-colors-attribute! false)))))
 
 ;; ---- motion-css carries the attribute-selector arm ---------------------
 
@@ -139,7 +139,7 @@
             sibling block keyed on `[data-rf-force-colors=\"active\"]`
             so the operator opt-in activates the same system-token
             chrome the OS HCM media query paints."
-    (let [css motion/motion-css]
+    (let [css rf.story.theme.motion/motion-css]
       (is (string? css))
       (is (re-find #"\[data-rf-force-colors=\"active\"\]" css)
           "attribute selector is present in motion-css"))))

--- a/tools/story/test/re_frame/story/ui/chrome_visibility_test.cljc
+++ b/tools/story/test/re_frame/story/ui/chrome_visibility_test.cljc
@@ -13,7 +13,7 @@
 
   Pure data → data; no DOM / Reagent dependency."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.ui.state.transitions :as transitions]))
+            [re-frame.story.ui.state.transitions :as rf.story.ui.state.transitions]))
 
 ;; ---- defaults + read -----------------------------------------------------
 
@@ -24,80 +24,80 @@
             :rhs?         true
             :toolbar?     true
             :embed?       false}
-           transitions/chrome-visibility-defaults))))
+           rf.story.ui.state.transitions/chrome-visibility-defaults))))
 
 (deftest chrome-visibility-merge-read
   (testing "missing slot → fall back to defaults"
-    (is (= transitions/chrome-visibility-defaults
-           (transitions/chrome-visibility {}))))
+    (is (= rf.story.ui.state.transitions/chrome-visibility-defaults
+           (rf.story.ui.state.transitions/chrome-visibility {}))))
   (testing "partial map → merge over defaults"
-    (is (= (assoc transitions/chrome-visibility-defaults :full-screen? true)
-           (transitions/chrome-visibility
+    (is (= (assoc rf.story.ui.state.transitions/chrome-visibility-defaults :full-screen? true)
+           (rf.story.ui.state.transitions/chrome-visibility
              {:chrome-visibility {:full-screen? true}})))))
 
 ;; ---- toggle / set --------------------------------------------------------
 
 (deftest toggle-chrome-visibility-shape
   (testing "default false slot → flip to true"
-    (let [out (transitions/toggle-chrome-visibility {} :full-screen?)]
+    (let [out (rf.story.ui.state.transitions/toggle-chrome-visibility {} :full-screen?)]
       (is (= true (get-in out [:chrome-visibility :full-screen?])))))
   (testing "default true slot → flip to false"
-    (let [out (transitions/toggle-chrome-visibility {} :sidebar?)]
+    (let [out (rf.story.ui.state.transitions/toggle-chrome-visibility {} :sidebar?)]
       (is (= false (get-in out [:chrome-visibility :sidebar?])))))
   (testing "double toggle round-trips"
-    (let [a (transitions/toggle-chrome-visibility {} :rhs?)
-          b (transitions/toggle-chrome-visibility a :rhs?)]
+    (let [a (rf.story.ui.state.transitions/toggle-chrome-visibility {} :rhs?)
+          b (rf.story.ui.state.transitions/toggle-chrome-visibility a :rhs?)]
       (is (= true (get-in b [:chrome-visibility :rhs?]))))))
 
 (deftest set-chrome-visibility-shape
   (testing "set true / set false"
-    (let [a (transitions/set-chrome-visibility {} :sidebar? false)]
+    (let [a (rf.story.ui.state.transitions/set-chrome-visibility {} :sidebar? false)]
       (is (= false (get-in a [:chrome-visibility :sidebar?]))))
-    (let [b (transitions/set-chrome-visibility {} :full-screen? true)]
+    (let [b (rf.story.ui.state.transitions/set-chrome-visibility {} :full-screen? true)]
       (is (= true (get-in b [:chrome-visibility :full-screen?]))))))
 
 ;; ---- chrome-pane-visible? — precedence -----------------------------------
 
 (deftest chrome-pane-visible-defaults
   (testing "default state: every pane visible"
-    (is (true? (transitions/chrome-pane-visible? :sidebar {})))
-    (is (true? (transitions/chrome-pane-visible? :rhs     {})))
-    (is (true? (transitions/chrome-pane-visible? :toolbar {})))))
+    (is (true? (rf.story.ui.state.transitions/chrome-pane-visible? :sidebar {})))
+    (is (true? (rf.story.ui.state.transitions/chrome-pane-visible? :rhs     {})))
+    (is (true? (rf.story.ui.state.transitions/chrome-pane-visible? :toolbar {})))))
 
 (deftest chrome-pane-visible-embed-wins-absolute
   (testing "embed mode hides every chrome pane"
     (let [s {:chrome-visibility {:embed? true}}]
-      (is (false? (transitions/chrome-pane-visible? :sidebar s)))
-      (is (false? (transitions/chrome-pane-visible? :rhs     s)))
-      (is (false? (transitions/chrome-pane-visible? :toolbar s)))))
+      (is (false? (rf.story.ui.state.transitions/chrome-pane-visible? :sidebar s)))
+      (is (false? (rf.story.ui.state.transitions/chrome-pane-visible? :rhs     s)))
+      (is (false? (rf.story.ui.state.transitions/chrome-pane-visible? :toolbar s)))))
 
   (testing "embed wins over a per-pane true"
     (let [s {:chrome-visibility {:embed? true :sidebar? true :rhs? true}}]
-      (is (false? (transitions/chrome-pane-visible? :sidebar s)))
-      (is (false? (transitions/chrome-pane-visible? :rhs     s))))))
+      (is (false? (rf.story.ui.state.transitions/chrome-pane-visible? :sidebar s)))
+      (is (false? (rf.story.ui.state.transitions/chrome-pane-visible? :rhs     s))))))
 
 (deftest chrome-pane-visible-full-screen-hides
   (testing "full-screen hides every chrome pane"
     (let [s {:chrome-visibility {:full-screen? true}}]
-      (is (false? (transitions/chrome-pane-visible? :sidebar s)))
-      (is (false? (transitions/chrome-pane-visible? :rhs     s)))
-      (is (false? (transitions/chrome-pane-visible? :toolbar s))))))
+      (is (false? (rf.story.ui.state.transitions/chrome-pane-visible? :sidebar s)))
+      (is (false? (rf.story.ui.state.transitions/chrome-pane-visible? :rhs     s)))
+      (is (false? (rf.story.ui.state.transitions/chrome-pane-visible? :toolbar s))))))
 
 (deftest chrome-pane-visible-per-pane-toggle
   (testing "per-pane false hides only that pane"
     (let [s {:chrome-visibility {:sidebar? false}}]
-      (is (false? (transitions/chrome-pane-visible? :sidebar s)))
-      (is (true?  (transitions/chrome-pane-visible? :rhs     s)))
-      (is (true?  (transitions/chrome-pane-visible? :toolbar s))))))
+      (is (false? (rf.story.ui.state.transitions/chrome-pane-visible? :sidebar s)))
+      (is (true?  (rf.story.ui.state.transitions/chrome-pane-visible? :rhs     s)))
+      (is (true?  (rf.story.ui.state.transitions/chrome-pane-visible? :toolbar s))))))
 
 (deftest chrome-pane-visible-precedence-embed-over-fullscreen
   (testing "embed and full-screen both true → still hidden (both project hidden)"
     (let [s {:chrome-visibility {:embed? true :full-screen? true}}]
-      (is (false? (transitions/chrome-pane-visible? :sidebar s))))))
+      (is (false? (rf.story.ui.state.transitions/chrome-pane-visible? :sidebar s))))))
 
 (deftest chrome-pane-visible-unknown-pane
   (testing "unknown pane kw → defaults visible (forward-compat)"
-    (is (true? (transitions/chrome-pane-visible? :unknown {})))))
+    (is (true? (rf.story.ui.state.transitions/chrome-pane-visible? :unknown {})))))
 
 ;; ---- Xray-embed collapse (rf2-ba86n.19) ---------------------------------
 ;;
@@ -108,26 +108,26 @@
 
 (deftest xray-embed-collapsed-default-expanded
   (testing "unset slot reads as expanded (false)"
-    (is (false? (transitions/xray-embed-collapsed? {})))
-    (is (false? (transitions/xray-embed-collapsed? {:xray-embed-collapsed? nil}))))
+    (is (false? (rf.story.ui.state.transitions/xray-embed-collapsed? {})))
+    (is (false? (rf.story.ui.state.transitions/xray-embed-collapsed? {:xray-embed-collapsed? nil}))))
   (testing "explicit slot is read through"
-    (is (true?  (transitions/xray-embed-collapsed? {:xray-embed-collapsed? true})))
-    (is (false? (transitions/xray-embed-collapsed? {:xray-embed-collapsed? false})))))
+    (is (true?  (rf.story.ui.state.transitions/xray-embed-collapsed? {:xray-embed-collapsed? true})))
+    (is (false? (rf.story.ui.state.transitions/xray-embed-collapsed? {:xray-embed-collapsed? false})))))
 
 (deftest toggle-xray-embed-collapsed-flip
   (testing "first toggle from default collapses (expanded → collapsed)"
-    (is (true? (transitions/xray-embed-collapsed?
-                 (transitions/toggle-xray-embed-collapsed {})))))
+    (is (true? (rf.story.ui.state.transitions/xray-embed-collapsed?
+                 (rf.story.ui.state.transitions/toggle-xray-embed-collapsed {})))))
   (testing "double toggle round-trips back to expanded"
-    (let [a (transitions/toggle-xray-embed-collapsed {})
-          b (transitions/toggle-xray-embed-collapsed a)]
-      (is (false? (transitions/xray-embed-collapsed? b))))))
+    (let [a (rf.story.ui.state.transitions/toggle-xray-embed-collapsed {})
+          b (rf.story.ui.state.transitions/toggle-xray-embed-collapsed a)]
+      (is (false? (rf.story.ui.state.transitions/xray-embed-collapsed? b))))))
 
 (deftest set-xray-embed-collapsed-coerces
   (testing "set true / set false / coerce truthy"
-    (is (true?  (transitions/xray-embed-collapsed?
-                  (transitions/set-xray-embed-collapsed {} true))))
-    (is (false? (transitions/xray-embed-collapsed?
-                  (transitions/set-xray-embed-collapsed {:xray-embed-collapsed? true} false))))
-    (is (true?  (transitions/xray-embed-collapsed?
-                  (transitions/set-xray-embed-collapsed {} "truthy"))))))
+    (is (true?  (rf.story.ui.state.transitions/xray-embed-collapsed?
+                  (rf.story.ui.state.transitions/set-xray-embed-collapsed {} true))))
+    (is (false? (rf.story.ui.state.transitions/xray-embed-collapsed?
+                  (rf.story.ui.state.transitions/set-xray-embed-collapsed {:xray-embed-collapsed? true} false))))
+    (is (true?  (rf.story.ui.state.transitions/xray-embed-collapsed?
+                  (rf.story.ui.state.transitions/set-xray-embed-collapsed {} "truthy"))))))

--- a/tools/story/test/re_frame/story/ui/cofx_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/cofx_cljs_test.cljs
@@ -12,14 +12,14 @@
   supplier just returns the value."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.story.ui.cofx :as ui-cofx]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.story.ui.cofx :as rf.story.ui.cofx]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
-     :init-fn (fn [] (ui-cofx/install-canonical-cofx!))}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
+     :init-fn (fn [] (rf.story.ui.cofx/install-canonical-cofx!))}))
 
 (deftest story-active-modes-cofx-returns-vector
   (testing ":story/active-modes supplier returns the active-modes vector"

--- a/tools/story/test/re_frame/story/ui/command_palette/view_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/command_palette/view_cljs_test.cljs
@@ -9,7 +9,7 @@
   `palette/move-active-index` in `re_frame/story_ui_test.clj`
   (JVM) and `re_frame/story_ui_cljs_test.cljs` (CLJS). This
   namespace pins the renderable
-  states of `view/render-palette` — the pure projection that
+  states of `rf.story.ui.command-palette.view/render-palette` — the pure projection that
   `command-palette-host` delegates to once `open?` flips true:
 
   - **testid presence** — the root scrim carries the
@@ -39,8 +39,8 @@
   every branch without booting reagent's class-3 lifecycle."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
-            [re-frame.test-helpers :as th]
-            [re-frame.story.ui.command-palette.view :as view]))
+            [re-frame.test-helpers :as rf.test-helpers]
+            [re-frame.story.ui.command-palette.view :as rf.story.ui.command-palette.view]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
@@ -85,13 +85,13 @@
   (testing "the root scrim of the rendered palette carries
             `data-test=story-command-palette` so downstream tests
             (and Xray's spine instrumentation) can anchor on it."
-    (let [tree (view/render-palette (base-props))
-          root (th/find-by-attr tree :data-test "story-command-palette")]
+    (let [tree (rf.story.ui.command-palette.view/render-palette (base-props))
+          root (rf.test-helpers/find-by-attr tree :data-test "story-command-palette")]
       (is (some? root)
           "root scrim node present with the spec/008-documented selector")
       (is (= :div (first root))
           "root is a :div — the scrim overlay container")
-      (is (some? (th/find-by-attr tree :data-test "story-command-palette-input"))
+      (is (some? (rf.test-helpers/find-by-attr tree :data-test "story-command-palette-input"))
           "input field present with its data-test selector"))))
 
 ;; ===========================================================================
@@ -105,12 +105,12 @@
   (testing "with `:results []` the panel renders the empty-state
             placeholder and zero result rows. Proves the
             `(if (seq results) ... empty)` branch."
-    (let [tree     (view/render-palette (base-props))
-          empty    (th/find-by-attr tree :data-test "story-command-palette-empty")
-          results  (th/find-all-by-attr tree :data-test "story-command-palette-result")]
+    (let [tree     (rf.story.ui.command-palette.view/render-palette (base-props))
+          empty    (rf.test-helpers/find-by-attr tree :data-test "story-command-palette-empty")
+          results  (rf.test-helpers/find-all-by-attr tree :data-test "story-command-palette-result")]
       (is (some? empty)
           "empty-state placeholder present")
-      (is (= "No matching registry entries." (th/text-content empty))
+      (is (= "No matching registry entries." (rf.test-helpers/text-content empty))
           "placeholder copy matches spec/008")
       (is (zero? (count results))
           "no result rows rendered when results is empty"))))
@@ -132,10 +132,10 @@
     (let [entries [(mk-entry :variant   ":app/login"     "Login variant")
                    (mk-entry :workspace ":app/sandbox"   "Workspace sandbox")
                    (mk-entry :story     ":app/counters"  "Counter family")]
-          tree    (view/render-palette
+          tree    (rf.story.ui.command-palette.view/render-palette
                     (assoc (base-props) :results entries))
-          rows    (th/find-all-by-attr tree :data-test "story-command-palette-result")
-          empty   (th/find-by-attr   tree :data-test "story-command-palette-empty")]
+          rows    (rf.test-helpers/find-all-by-attr tree :data-test "story-command-palette-result")
+          empty   (rf.test-helpers/find-by-attr   tree :data-test "story-command-palette-empty")]
       (is (= 3 (count rows))
           "one row per entry in the result list")
       (is (nil? empty)
@@ -167,22 +167,22 @@
     (let [entries [(mk-entry :variant   ":a/one")
                    (mk-entry :variant   ":a/two")
                    (mk-entry :workspace ":a/three")]
-          tree    (view/render-palette
+          tree    (rf.story.ui.command-palette.view/render-palette
                     (assoc (base-props)
                            :results entries
                            :active  1))
-          rows    (th/find-all-by-attr tree :data-test "story-command-palette-result")
+          rows    (rf.test-helpers/find-all-by-attr tree :data-test "story-command-palette-result")
           aria    (mapv #(get (second %) :aria-selected) rows)]
       (is (= 3 (count rows)))
       (is (= ["false" "true" "false"] aria)
           "only the row at :active carries aria-selected=true")
       ;; Sanity: shifting :active shifts the highlighted row.
-      (let [tree2 (view/render-palette
+      (let [tree2 (rf.story.ui.command-palette.view/render-palette
                     (assoc (base-props)
                            :results entries
                            :active  2))
             aria2 (mapv #(get (second %) :aria-selected)
-                        (th/find-all-by-attr tree2 :data-test
+                        (rf.test-helpers/find-all-by-attr tree2 :data-test
                                              "story-command-palette-result"))]
         (is (= ["false" "false" "true"] aria2)
             "moving :active to 2 highlights the third row only")))))

--- a/tools/story/test/re_frame/story/ui/controls_nested_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/controls_nested_cljs_test.cljc
@@ -12,8 +12,8 @@
     path-aware `set-cell-override` fn (plus its `-scalar` wrapper) in
     isolation, AND the rf2-mzfh9c edit -> `resolve-args` round-trip: a
     nested-control edit against a REGISTERED variant's real args,
-    resolved back through `args/resolve-args` the way the canvas
-    actually reads them. `story/reg-variant` + `args/resolve-args` are
+    resolved back through `rf.story.args/resolve-args` the way the canvas
+    actually reads them. `rf.story/reg-variant` + `rf.story.args/resolve-args` are
     plain registrar reads — no Reagent / DOM needed — so this tier runs
     on both runtimes.
   - **CLJS-only** (`controls.cljs` is CLJS-only — it depends on
@@ -26,23 +26,23 @@
   picked up by both `cljs-test$` and `-cljs-test$` regexes)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             #?(:cljs [re-frame.core :as rf])
-            [re-frame.story :as story]
-            [re-frame.story.args :as args]
-            #?(:cljs [re-frame.story.ui.controls :as controls])
-            [re-frame.story.ui.state :as state]))
+            [re-frame.story :as rf.story]
+            [re-frame.story.args :as rf.story.args]
+            #?(:cljs [re-frame.story.ui.controls :as rf.story.ui.controls])
+            [re-frame.story.ui.state :as rf.story.ui.state]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-fixture [test-fn]
-  (story/clear-all!)
-  (state/reset-shell-state!)
+  (rf.story/clear-all!)
+  (rf.story.ui.state/reset-shell-state!)
   ;; `install-canonical-vocabulary!` seeds the lifecycle-machine
   ;; event/registrar entries a LIVE variant run needs; nothing in this
   ;; file dispatches a run — the JVM+CLJS round-trip tests below only
-  ;; read `story/reg-variant` bodies back through `args/resolve-args`
+  ;; read `rf.story/reg-variant` bodies back through `rf.story.args/resolve-args`
   ;; (plain registrar data, no frame involved) — so it stays CLJS-only,
   ;; matching what this file has always needed.
-  #?(:cljs (story/install-canonical-vocabulary!))
+  #?(:cljs (rf.story/install-canonical-vocabulary!))
   (test-fn))
 
 (use-fixtures :each reset-fixture)
@@ -52,7 +52,7 @@
 #?(:cljs
    (deftest infer-widget-map-emits-group
      (testing ":map schema → :group widget with one entry per key"
-       (let [w (controls/infer-widget
+       (let [w (rf.story.ui.controls/infer-widget
                  [:map [:label :string] [:disabled? :boolean]])]
          (is (= :group (:widget w)))
          (is (= :map   (:kind w)))
@@ -64,7 +64,7 @@
 #?(:cljs
    (deftest infer-widget-map-with-properties-skips-property-map
      (testing ":map with an optional properties map at index 1 is handled"
-       (let [w (controls/infer-widget
+       (let [w (rf.story.ui.controls/infer-widget
                  [:map {:closed true} [:k :string]])]
          (is (= :group (:widget w)))
          (is (= [:k] (mapv :key (:entries w))))))))
@@ -72,7 +72,7 @@
 #?(:cljs
    (deftest infer-widget-vector-emits-repeater
      (testing ":vector schema → :repeater widget with element schema"
-       (let [w (controls/infer-widget [:vector :string])]
+       (let [w (rf.story.ui.controls/infer-widget [:vector :string])]
          (is (= :repeater (:widget w)))
          (is (= :vector   (:kind w)))
          (is (= :text     (-> w :element :widget)))))))
@@ -80,7 +80,7 @@
 #?(:cljs
    (deftest infer-widget-set-emits-repeater
      (testing ":set schema → :repeater widget kind :set"
-       (let [w (controls/infer-widget [:set :int])]
+       (let [w (rf.story.ui.controls/infer-widget [:set :int])]
          (is (= :repeater (:widget w)))
          (is (= :set      (:kind w)))
          (is (= :number   (-> w :element :widget)))))))
@@ -88,7 +88,7 @@
 #?(:cljs
    (deftest infer-widget-tuple-emits-positions
      (testing ":tuple schema → :tuple widget with one position per element"
-       (let [w (controls/infer-widget [:tuple :string :int :boolean])]
+       (let [w (rf.story.ui.controls/infer-widget [:tuple :string :int :boolean])]
          (is (= :tuple (:widget w)))
          (is (= 3 (count (:positions w))))
          (is (= [:text :number :boolean]
@@ -97,7 +97,7 @@
 #?(:cljs
    (deftest infer-widget-nested-map-of-maps
      (testing ":map nested inside :map → depth-2 :group"
-       (let [w (controls/infer-widget
+       (let [w (rf.story.ui.controls/infer-widget
                  [:map
                   [:outer
                    [:map
@@ -115,7 +115,7 @@
 #?(:cljs
    (deftest infer-widget-vector-of-maps
      (testing ":vector [:map ...] → :repeater whose element is a :group"
-       (let [w (controls/infer-widget
+       (let [w (rf.story.ui.controls/infer-widget
                  [:vector [:map [:k :string] [:n :int]]])]
          (is (= :repeater (:widget w)))
          (is (= :group    (-> w :element :widget)))
@@ -124,14 +124,14 @@
 #?(:cljs
    (deftest infer-widget-enum-still-scalar
      (testing "scalar :enum path survives the new vector dispatch"
-       (let [w (controls/infer-widget [:enum :a :b :c])]
+       (let [w (rf.story.ui.controls/infer-widget [:enum :a :b :c])]
          (is (= :select (:widget w)))
          (is (= [:a :b :c] (:options w)))))))
 
 #?(:cljs
    (deftest infer-widget-unknown-vector-falls-back-to-text
      (testing "an unrecognised vector schema-op degrades to :text"
-       (is (= :text (:widget (controls/infer-widget [:fn 'pos?])))))))
+       (is (= :text (:widget (rf.story.ui.controls/infer-widget [:fn 'pos?])))))))
 
 ;; ---- CLJS: resolve-argtypes from the component view's props schema -------
 ;;
@@ -155,13 +155,13 @@
                      [:items [:vector :string]]
                      [:meta  [:map [:author :string] [:rating :int]]]]}
          (fn [_] [:div]))
-       (story/reg-variant :story.nest/v
+       (rf.story/reg-variant :story.nest/v
          {:component :view.nest/widget
           :args      {:title "Hello"
                       :items ["a" "b"]
                       :meta  {:author "ada" :rating 5}}
           :setup    []})
-       (let [t (controls/resolve-argtypes :story.nest/v)]
+       (let [t (rf.story.ui.controls/resolve-argtypes :story.nest/v)]
          ;; :title scalar
          (is (= :text (-> t :title :widget)))
          ;; :items vector → :repeater
@@ -179,23 +179,23 @@
        (rf/reg-view* :view.nest/labelled
          {:rf/props [:map [:label :string]]}
          (fn [_] [:div]))
-       (story/reg-variant :story.nest/v2
+       (rf.story/reg-variant :story.nest/v2
          {:component :view.nest/labelled
           :argtypes  {:label {:widget :select :options ["a" "b"]}}
           :args      {:label "a"}
           :setup    []})
-       (let [t (controls/resolve-argtypes :story.nest/v2)]
+       (let [t (rf.story.ui.controls/resolve-argtypes :story.nest/v2)]
          (is (= :select (-> t :label :widget)))
          (is (= ["a" "b"] (-> t :label :options)))))))
 
 #?(:cljs
    (deftest resolve-argtypes-value-shape-fallback-recurses
      (testing "with no schema + no argtypes the value-shape walker recurses"
-       (story/reg-variant :story.nest/v3
+       (rf.story/reg-variant :story.nest/v3
          {:args   {:nest {:k "v" :n 1}
                    :items ["x" "y"]}
           :setup []})
-       (let [t (controls/resolve-argtypes :story.nest/v3)]
+       (let [t (rf.story.ui.controls/resolve-argtypes :story.nest/v3)]
          ;; :nest map value → :group
          (is (= :group (-> t :nest :widget)))
          (is (some? (some #(= :k (:key %)) (-> t :nest :entries))))
@@ -210,7 +210,7 @@
                re-resolving — passes a fabricated args map and asserts the
                fallback-inference reflects that shape (not the registered
                variant args)"
-       (story/reg-variant :story.nest/v4
+       (rf.story/reg-variant :story.nest/v4
          {:args   {:registered "x"}
           :setup []})
        ;; Supply a different eff-args map. The variant has no schema and
@@ -218,7 +218,7 @@
        ;; value shapes — :supplied should appear in the result, :registered
        ;; should NOT (proving the supplied map was used, not the variant's
        ;; own).
-       (let [t (controls/resolve-argtypes :story.nest/v4
+       (let [t (rf.story.ui.controls/resolve-argtypes :story.nest/v4
                                           {:supplied "y" :n 42})]
          (is (contains? t :supplied))
          (is (contains? t :n))
@@ -229,11 +229,11 @@
 #?(:cljs
    (deftest resolve-argtypes-1-arity-still-resolves-internally
      (testing "the 1-arity overload still works for non-render callers
-               (tests, docs, etc.) — it calls args/resolve-args itself"
-       (story/reg-variant :story.nest/v5
+               (tests, docs, etc.) — it calls rf.story.args/resolve-args itself"
+       (rf.story/reg-variant :story.nest/v5
          {:args   {:title "hi"}
           :setup []})
-       (let [t (controls/resolve-argtypes :story.nest/v5)]
+       (let [t (rf.story.ui.controls/resolve-argtypes :story.nest/v5)]
          (is (= :text (-> t :title :widget)))))))
 
 ;; ---- JVM + CLJS: path-aware set-cell-override ---------------------------
@@ -241,20 +241,20 @@
 (deftest set-cell-override-scalar-wrapper
   (testing "set-cell-override-scalar wraps the arg-key into a singleton
             path and writes a top-level override"
-    (let [s  state/default-shell-state
-          s1 (state/set-cell-override-scalar s :story.a/x :label "hi")]
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/set-cell-override-scalar s :story.a/x :label "hi")]
       (is (= "hi" (get-in s1 [:cell-overrides :story.a/x :label]))))))
 
 (deftest set-cell-override-writes-nested
   (testing "a multi-element path writes at the nested location"
-    (let [s  state/default-shell-state
-          s1 (state/set-cell-override s :story.a/x [:meta :author] "ada")]
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/set-cell-override s :story.a/x [:meta :author] "ada")]
       (is (= "ada" (get-in s1 [:cell-overrides :story.a/x :meta :author]))))))
 
 (deftest set-cell-override-deeply-nested
   (testing "path can address depth ≥ 3"
-    (let [s  state/default-shell-state
-          s1 (state/set-cell-override s :story.a/x
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/set-cell-override s :story.a/x
                                       [:outer :inner :leaf] 42)]
       (is (= 42 (get-in s1 [:cell-overrides :story.a/x
                             :outer :inner :leaf]))))))
@@ -264,8 +264,8 @@
             (the caller supplied none) the missing collection vivifies
             as a real VECTOR (rf2-mzfh9c), NOT the int-keyed map plain
             `assoc-in` would have minted for a missing intermediate value"
-    (let [s  state/default-shell-state
-          s1 (state/set-cell-override s :story.a/x [:items 0] "x")]
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/set-cell-override s :story.a/x [:items 0] "x")]
       (is (= "x" (get-in s1 [:cell-overrides :story.a/x :items 0])))
       (is (vector? (get-in s1 [:cell-overrides :story.a/x :items]))
           "rf2-mzfh9c: a real vector — not {0 \"x\"}, the collection-kind
@@ -279,15 +279,15 @@
 ;; array entry directly, never touch [+]/[-]). Plain `assoc-in` against
 ;; `state` cannot know the collection's sibling entries, so
 ;; `set-cell-override`'s 5-arity accepts a `base` seed — the arg's
-;; current resolved value (`args/resolve-args`, cell-overrides excluded)
+;; current resolved value (`rf.story.args/resolve-args`, cell-overrides excluded)
 ;; — and walks it via `assoc-in-kind-aware` instead of raw `assoc-in`.
 
 (deftest set-cell-override-with-base-seeds-missing-vector-preserving-siblings
   (testing "rf2-mzfh9c: a `base` seed lets a first-ever edit of an
             unoverridden vector preserve sibling entries instead of
             truncating to a singleton or corrupting into a map"
-    (let [s  state/default-shell-state
-          s1 (state/set-cell-override s :story.a/x [:items 0] "x" ["a" "b"])]
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/set-cell-override s :story.a/x [:items 0] "x" ["a" "b"])]
       (is (vector? (get-in s1 [:cell-overrides :story.a/x :items])))
       (is (= ["x" "b"] (get-in s1 [:cell-overrides :story.a/x :items]))
           "index 0 replaced; sibling \"b\" at index 1 survives"))))
@@ -296,8 +296,8 @@
   (testing "a :set base seed round-trips as a SET (matching the arg's
             declared collection kind), sorted the same way the controls
             panel's own vector-coerce renders it for editing"
-    (let [s  state/default-shell-state
-          s1 (state/set-cell-override s :story.a/x [:items 0] "x" #{"a" "b"})]
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/set-cell-override s :story.a/x [:items 0] "x" #{"a" "b"})]
       (is (set? (get-in s1 [:cell-overrides :story.a/x :items])))
       (is (= #{"x" "b"} (get-in s1 [:cell-overrides :story.a/x :items]))))))
 
@@ -305,9 +305,9 @@
   (testing "rf2-mzfh9c: editing an entry when the OVERRIDE (not just the
             base) is already a real set does not throw — the reported
             'assoc undefined on PersistentHashSet' failure mode"
-    (let [s0 state/default-shell-state
-          s1 (state/set-cell-override-scalar s0 :story.a/x :items #{"a" "b"})
-          s2 (state/set-cell-override s1 :story.a/x [:items 0] "x")]
+    (let [s0 rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/set-cell-override-scalar s0 :story.a/x :items #{"a" "b"})
+          s2 (rf.story.ui.state/set-cell-override s1 :story.a/x [:items 0] "x")]
       (is (set? (get-in s2 [:cell-overrides :story.a/x :items])))
       (is (contains? (get-in s2 [:cell-overrides :story.a/x :items]) "x")))))
 
@@ -319,10 +319,10 @@
             stays MINIMAL — its unrelated :other key is NOT written into
             the override (rf2-57ikh), because deep-merge resolution
             restores unrelated map keys from base at read time"
-    (let [s  state/default-shell-state
+    (let [s  rf.story.ui.state/default-shell-state
           ;; :group has an unrelated sibling key + a nested :tags SET,
           ;; none of it overridden yet.
-          s1 (state/set-cell-override s :story.a/x [:group :tags 0] "x"
+          s1 (rf.story.ui.state/set-cell-override s :story.a/x [:group :tags 0] "x"
                                       {:tags #{"a" "b"} :other 1})]
       (is (= {:tags #{"x" "b"}}
              (get-in s1 [:cell-overrides :story.a/x :group]))
@@ -335,27 +335,27 @@
 ;;
 ;; The isolated set-cell-override tests above pin the shell-state write
 ;; shape; they never prove the write actually SURVIVES a real
-;; `args/resolve-args` deep-merge read against a REGISTERED variant's
+;; `rf.story.args/resolve-args` deep-merge read against a REGISTERED variant's
 ;; base args — the exact seam `args.cljc`'s documented 'vectors/sets
 ;; replace, not merge element-wise' semantics corrupted before this fix.
-;; `story/reg-variant` + `args/resolve-args` are plain registrar reads
+;; `rf.story/reg-variant` + `rf.story.args/resolve-args` are plain registrar reads
 ;; (no frame / dispatch), so this tier runs on JVM + CLJS.
 
 (deftest set-cell-override-edit-vector-entry-then-resolve-args-round-trip
   (testing "rf2-mzfh9c: editing ONE entry of a registered variant's
             un-overridden :vector arg, seeded the SAME way the controls
-            panel seeds it (`args/resolve-args` minus cell-overrides),
+            panel seeds it (`rf.story.args/resolve-args` minus cell-overrides),
             round-trips through `resolve-args` as the sibling-preserving
             vector — not an int-keyed map, not a truncated singleton"
-    (story/reg-variant :story.nest.roundtrip/vector-arg
+    (rf.story/reg-variant :story.nest.roundtrip/vector-arg
       {:args   {:items ["a" "b" "c"]}
        :setup []})
-    (let [base       (get (args/resolve-args :story.nest.roundtrip/vector-arg) :items)
-          shell      (state/set-cell-override state/default-shell-state
+    (let [base       (get (rf.story.args/resolve-args :story.nest.roundtrip/vector-arg) :items)
+          shell      (rf.story.ui.state/set-cell-override rf.story.ui.state/default-shell-state
                                               :story.nest.roundtrip/vector-arg
                                               [:items 1] "X" base)
           overrides  (get-in shell [:cell-overrides :story.nest.roundtrip/vector-arg])
-          eff        (args/resolve-args :story.nest.roundtrip/vector-arg
+          eff        (rf.story.args/resolve-args :story.nest.roundtrip/vector-arg
                                         {:cell-overrides overrides})]
       (is (= ["a" "b" "c"] base) "precondition: the registered base vector")
       (is (vector? (:items overrides))
@@ -372,17 +372,17 @@
             override stays a real set (matching the schema's declared
             kind), and a SECOND edit against the now-established set
             override does not throw"
-    (story/reg-variant :story.nest.roundtrip/set-arg
+    (rf.story/reg-variant :story.nest.roundtrip/set-arg
       {:args   {:tags #{"a" "b"}}
        :setup []})
-    (let [base       (get (args/resolve-args :story.nest.roundtrip/set-arg) :tags)
+    (let [base       (get (rf.story.args/resolve-args :story.nest.roundtrip/set-arg) :tags)
           ;; The panel's repeater renders a SET via a stable sorted
           ;; vector projection — index 0 is "a" (sort-by str).
-          shell      (state/set-cell-override state/default-shell-state
+          shell      (rf.story.ui.state/set-cell-override rf.story.ui.state/default-shell-state
                                               :story.nest.roundtrip/set-arg
                                               [:tags 0] "x" base)
           overrides  (get-in shell [:cell-overrides :story.nest.roundtrip/set-arg])
-          eff        (args/resolve-args :story.nest.roundtrip/set-arg
+          eff        (rf.story.args/resolve-args :story.nest.roundtrip/set-arg
                                         {:cell-overrides overrides})]
       (is (set? base))
       (is (set? (:tags overrides))
@@ -391,7 +391,7 @@
       (is (= #{"x" "b"} (:tags eff)))
       ;; A SECOND edit against the now-established set override (no base
       ;; passed — none needed, an override already exists) must not throw.
-      (let [shell2     (state/set-cell-override shell
+      (let [shell2     (rf.story.ui.state/set-cell-override shell
                                                 :story.nest.roundtrip/set-arg
                                                 [:tags 0] "y")
             overrides2 (get-in shell2 [:cell-overrides :story.nest.roundtrip/set-arg])]
@@ -406,15 +406,15 @@
             siblings stay unwritten), yet `resolve-args`' deep-merge
             restores the untouched siblings from base — the edit->read
             round trip the isolated set-cell-override test can't prove"
-    (story/reg-variant :story.nest.roundtrip/map-arg
+    (rf.story/reg-variant :story.nest.roundtrip/map-arg
       {:args   {:settings {:title "Nested title" :enabled? true}}
        :setup []})
-    (let [base      (get (args/resolve-args :story.nest.roundtrip/map-arg) :settings)
-          shell     (state/set-cell-override state/default-shell-state
+    (let [base      (get (rf.story.args/resolve-args :story.nest.roundtrip/map-arg) :settings)
+          shell     (rf.story.ui.state/set-cell-override rf.story.ui.state/default-shell-state
                                              :story.nest.roundtrip/map-arg
                                              [:settings :title] "Edited" base)
           overrides (get-in shell [:cell-overrides :story.nest.roundtrip/map-arg])
-          eff       (args/resolve-args :story.nest.roundtrip/map-arg
+          eff       (rf.story.args/resolve-args :story.nest.roundtrip/map-arg
                                        {:cell-overrides overrides})]
       (is (= {:title "Nested title" :enabled? true} base)
           "precondition: the registered base map")
@@ -427,23 +427,23 @@
 
 (deftest set-cell-override-singleton-path-equivalent-to-scalar-wrapper
   (testing "a 1-element path produces the same result as the scalar wrapper"
-    (let [s  state/default-shell-state
-          via-path   (state/set-cell-override        s :story.a/x [:label] "hi")
-          via-scalar (state/set-cell-override-scalar s :story.a/x  :label  "hi")]
+    (let [s  rf.story.ui.state/default-shell-state
+          via-path   (rf.story.ui.state/set-cell-override        s :story.a/x [:label] "hi")
+          via-scalar (rf.story.ui.state/set-cell-override-scalar s :story.a/x  :label  "hi")]
       (is (= via-path via-scalar))
       (is (= "hi" (get-in via-path [:cell-overrides :story.a/x :label]))))))
 
 (deftest set-cell-override-empty-path-noop
   (testing "an empty path leaves the state unchanged"
-    (let [s  state/default-shell-state
-          s1 (state/set-cell-override s :story.a/x [] :ignored)]
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/set-cell-override s :story.a/x [] :ignored)]
       (is (= s s1)))))
 
 (deftest set-cell-override-roundtrip-deep-then-shallow
   (testing "shallow override at the same arg-key shadows deep entries"
-    (let [s0 state/default-shell-state
-          s1 (state/set-cell-override        s0 :story.a/x [:meta :author] "ada")
-          s2 (state/set-cell-override-scalar s1 :story.a/x  :meta {:author "bob"})]
+    (let [s0 rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/set-cell-override        s0 :story.a/x [:meta :author] "ada")
+          s2 (rf.story.ui.state/set-cell-override-scalar s1 :story.a/x  :meta {:author "bob"})]
       (is (= {:author "bob"}
              (get-in s2 [:cell-overrides :story.a/x :meta]))))))
 
@@ -452,11 +452,11 @@
 (deftest clear-cell-override-drops-one-arg-keeps-others
   (testing "clear-cell-override reverts a single arg-key, leaving the
             variant's other overrides intact"
-    (let [s0 state/default-shell-state
+    (let [s0 rf.story.ui.state/default-shell-state
           s1 (-> s0
-                 (state/set-cell-override-scalar :story.a/x :label "hi")
-                 (state/set-cell-override-scalar :story.a/x :n     42))
-          s2 (state/clear-cell-override s1 :story.a/x :label)]
+                 (rf.story.ui.state/set-cell-override-scalar :story.a/x :label "hi")
+                 (rf.story.ui.state/set-cell-override-scalar :story.a/x :n     42))
+          s2 (rf.story.ui.state/clear-cell-override s1 :story.a/x :label)]
       (is (nil? (get-in s2 [:cell-overrides :story.a/x :label])))
       (is (= 42 (get-in s2 [:cell-overrides :story.a/x :n]))))))
 
@@ -465,19 +465,19 @@
             :cell-overrides entry — callers reading
             (seq (get-in state [:cell-overrides variant])) see 'no
             overrides', matching clear-cell-overrides"
-    (let [s0 state/default-shell-state
-          s1 (state/set-cell-override-scalar s0 :story.a/x :label "hi")
-          s2 (state/clear-cell-override s1 :story.a/x :label)]
+    (let [s0 rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/set-cell-override-scalar s0 :story.a/x :label "hi")
+          s2 (rf.story.ui.state/clear-cell-override s1 :story.a/x :label)]
       (is (not (contains? (:cell-overrides s2) :story.a/x))))))
 
 (deftest clear-cell-override-leaves-other-variants
   (testing "clearing one variant's arg does not touch another variant's
             overrides"
-    (let [s0 state/default-shell-state
+    (let [s0 rf.story.ui.state/default-shell-state
           s1 (-> s0
-                 (state/set-cell-override-scalar :story.a/x :label "hi")
-                 (state/set-cell-override-scalar :story.b/y :label "yo"))
-          s2 (state/clear-cell-override s1 :story.a/x :label)]
+                 (rf.story.ui.state/set-cell-override-scalar :story.a/x :label "hi")
+                 (rf.story.ui.state/set-cell-override-scalar :story.b/y :label "yo"))
+          s2 (rf.story.ui.state/clear-cell-override s1 :story.a/x :label)]
       (is (not (contains? (:cell-overrides s2) :story.a/x)))
       (is (= "yo" (get-in s2 [:cell-overrides :story.b/y :label]))))))
 
@@ -485,23 +485,23 @@
   (testing "clearing a collection arg drops only the repeater row-id
             bookkeeping anchored on that arg-key; sibling collection
             row-ids survive (rf2-c8kfy lockstep)"
-    (let [s0 state/default-shell-state
+    (let [s0 rf.story.ui.state/default-shell-state
           ;; Two collection args under one variant, each with row ids.
           s1 (-> s0
-                 (state/set-cell-override-scalar :story.a/x :items ["a" "b"])
-                 (state/ensure-repeater-row-ids :story.a/x [:items] 2)
-                 (state/set-cell-override-scalar :story.a/x :tags  ["t"])
-                 (state/ensure-repeater-row-ids :story.a/x [:tags] 1))
-          s2 (state/clear-cell-override s1 :story.a/x :items)]
+                 (rf.story.ui.state/set-cell-override-scalar :story.a/x :items ["a" "b"])
+                 (rf.story.ui.state/ensure-repeater-row-ids :story.a/x [:items] 2)
+                 (rf.story.ui.state/set-cell-override-scalar :story.a/x :tags  ["t"])
+                 (rf.story.ui.state/ensure-repeater-row-ids :story.a/x [:tags] 1))
+          s2 (rf.story.ui.state/clear-cell-override s1 :story.a/x :items)]
       ;; :items row-ids gone, :tags row-ids intact.
-      (is (= [] (state/repeater-row-ids s2 :story.a/x [:items])))
-      (is (= 1 (count (state/repeater-row-ids s2 :story.a/x [:tags])))))))
+      (is (= [] (rf.story.ui.state/repeater-row-ids s2 :story.a/x [:items])))
+      (is (= 1 (count (rf.story.ui.state/repeater-row-ids s2 :story.a/x [:tags])))))))
 
 (deftest clear-cell-override-unknown-key-is-noop
   (testing "clearing an arg-key with no override leaves the state
             effectively unchanged (the variant entry is pruned only
             when it becomes empty)"
-    (let [s0 state/default-shell-state
-          s1 (state/set-cell-override-scalar s0 :story.a/x :label "hi")
-          s2 (state/clear-cell-override s1 :story.a/x :missing)]
+    (let [s0 rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/set-cell-override-scalar s0 :story.a/x :label "hi")
+          s2 (rf.story.ui.state/clear-cell-override s1 :story.a/x :missing)]
       (is (= "hi" (get-in s2 [:cell-overrides :story.a/x :label]))))))

--- a/tools/story/test/re_frame/story/ui/controls_scalar_widgets_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/controls_scalar_widgets_cljs_test.cljc
@@ -16,21 +16,21 @@
   Runs under shadow's `:node-test` and `:browser-test` targets (the
   `cljs-test$` ns regex picks up this name)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            #?(:cljs [re-frame.story :as story])
-            #?(:cljs [re-frame.story.ui.controls :as controls])
-            [re-frame.story.ui.state :as state]))
+            #?(:cljs [re-frame.story :as rf.story])
+            #?(:cljs [re-frame.story.ui.controls :as rf.story.ui.controls])
+            [re-frame.story.ui.state :as rf.story.ui.state]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 #?(:cljs
    (defn reset-fixture [test-fn]
-     (story/clear-all!)
-     (state/reset-shell-state!)
-     (story/install-canonical-vocabulary!)
+     (rf.story/clear-all!)
+     (rf.story.ui.state/reset-shell-state!)
+     (rf.story/install-canonical-vocabulary!)
      (test-fn))
    :clj
    (defn reset-fixture [test-fn]
-     (state/reset-shell-state!)
+     (rf.story.ui.state/reset-shell-state!)
      (test-fn)))
 
 (use-fixtures :each reset-fixture)
@@ -66,7 +66,7 @@
 #?(:cljs
    (deftest textarea-widget-renders-textarea-element
      (testing ":textarea widget renders a <textarea> with the current value"
-       (let [tree (controls/scalar-widget
+       (let [tree (rf.story.ui.controls/scalar-widget
                     :story.x/v [:bio] "hello" {:widget :textarea})]
          (is (= :textarea (first tree)))
          (is (= "hello"   (-> tree second :value)))
@@ -76,19 +76,19 @@
    (deftest textarea-widget-nil-value-becomes-empty-string
      (testing ":textarea coerces a nil value to \"\" to satisfy React's
                controlled-component contract"
-       (let [tree (controls/scalar-widget
+       (let [tree (rf.story.ui.controls/scalar-widget
                     :story.x/v [:bio] nil {:widget :textarea})]
          (is (= "" (-> tree second :value)))))))
 
 #?(:cljs
    (deftest textarea-widget-on-change-writes-override
      (testing ":textarea on-change writes through to :cell-overrides"
-       (let [tree     (controls/scalar-widget
+       (let [tree     (rf.story.ui.controls/scalar-widget
                         :story.x/v [:bio] "" {:widget :textarea})
              handler  (-> tree second :on-change)]
          (handler (input-event "multi\nline\ntext"))
          (is (= "multi\nline\ntext"
-                (get-in (state/get-state)
+                (get-in (rf.story.ui.state/get-state)
                         [:cell-overrides :story.x/v :bio])))))))
 
 ;; ---- :radio --------------------------------------------------------------
@@ -96,7 +96,7 @@
 #?(:cljs
    (deftest radio-widget-renders-one-input-per-option
      (testing ":radio widget renders one <input type=\"radio\"> per option"
-       (let [tree   (controls/scalar-widget
+       (let [tree   (rf.story.ui.controls/scalar-widget
                       :story.x/v [:variant] :primary
                       {:widget :radio :options [:primary :secondary :danger]})
              ;; The radio renders [:div {...radio-row...} <labels...>] — each
@@ -117,7 +117,7 @@
 #?(:cljs
    (deftest radio-widget-marks-current-option-checked
      (testing ":radio widget marks exactly the matching option as :checked"
-       (let [tree   (controls/scalar-widget
+       (let [tree   (rf.story.ui.controls/scalar-widget
                       :story.x/v [:variant] :secondary
                       {:widget :radio :options [:primary :secondary :danger]})
              inputs (filter (fn [n]
@@ -133,7 +133,7 @@
    (deftest radio-widget-on-change-writes-selected-option
      (testing ":radio on-change writes the raw option (not the stringified
                form) so keywords, numbers, etc. round-trip"
-       (let [tree   (controls/scalar-widget
+       (let [tree   (rf.story.ui.controls/scalar-widget
                       :story.x/v [:variant] :primary
                       {:widget :radio :options [:primary :secondary :danger]})
              inputs (filter (fn [n]
@@ -145,7 +145,7 @@
              handler (-> (nth (vec inputs) 2) second :on-change)]
          (handler (input-event ":danger"))
          (is (= :danger
-                (get-in (state/get-state)
+                (get-in (rf.story.ui.state/get-state)
                         [:cell-overrides :story.x/v :variant])))))))
 
 #?(:cljs
@@ -153,10 +153,10 @@
      (testing "each radio group's <input> shares a `:name` derived from
                variant-id + path — distinct paths mean distinct names so
                two radio groups don't toggle each other"
-       (let [tree-a (controls/scalar-widget
+       (let [tree-a (rf.story.ui.controls/scalar-widget
                       :story.x/v [:a] nil
                       {:widget :radio :options [:x :y]})
-             tree-b (controls/scalar-widget
+             tree-b (rf.story.ui.controls/scalar-widget
                       :story.x/v [:b] nil
                       {:widget :radio :options [:x :y]})
              name-a (->> (tree-seq vector? rest tree-a)
@@ -180,7 +180,7 @@
 #?(:cljs
    (deftest date-widget-renders-date-input
      (testing ":date widget renders <input type=\"date\">"
-       (let [tree (controls/scalar-widget
+       (let [tree (rf.story.ui.controls/scalar-widget
                     :story.x/v [:dob] "2026-05-14" {:widget :date})]
          (is (= :input (first tree)))
          (is (= "date" (-> tree second :type)))
@@ -190,32 +190,32 @@
    (deftest date-widget-nil-value-becomes-empty-string
      (testing ":date coerces nil to \"\" to satisfy the controlled-input
                contract"
-       (let [tree (controls/scalar-widget
+       (let [tree (rf.story.ui.controls/scalar-widget
                     :story.x/v [:dob] nil {:widget :date})]
          (is (= "" (-> tree second :value)))))))
 
 #?(:cljs
    (deftest date-widget-on-change-writes-iso-string
      (testing ":date on-change writes the raw ISO yyyy-mm-dd string"
-       (let [tree    (controls/scalar-widget
+       (let [tree    (rf.story.ui.controls/scalar-widget
                        :story.x/v [:dob] nil {:widget :date})
              handler (-> tree second :on-change)]
          (handler (input-event "2026-12-31"))
          (is (= "2026-12-31"
-                (get-in (state/get-state)
+                (get-in (rf.story.ui.state/get-state)
                         [:cell-overrides :story.x/v :dob])))))))
 
 #?(:cljs
    (deftest date-widget-on-change-empty-writes-nil
      (testing ":date on-change with an empty string clears the slot to nil
                — equivalent to 'no date selected'"
-       (let [tree    (controls/scalar-widget
+       (let [tree    (rf.story.ui.controls/scalar-widget
                        :story.x/v [:dob] "2026-05-14" {:widget :date})
              handler (-> tree second :on-change)]
          (handler (input-event ""))
-         (is (nil? (get-in (state/get-state)
+         (is (nil? (get-in (rf.story.ui.state/get-state)
                            [:cell-overrides :story.x/v :dob])))
-         (is (contains? (get-in (state/get-state)
+         (is (contains? (get-in (rf.story.ui.state/get-state)
                                 [:cell-overrides :story.x/v])
                         :dob))))))
 
@@ -224,7 +224,7 @@
 #?(:cljs
    (deftest color-widget-renders-color-input
      (testing ":color widget renders <input type=\"color\">"
-       (let [tree (controls/scalar-widget
+       (let [tree (rf.story.ui.controls/scalar-widget
                     :story.x/v [:bg] "#ff0000" {:widget :color})]
          (is (= :input (first tree)))
          (is (= "color" (-> tree second :type)))
@@ -235,19 +235,19 @@
      (testing ":color falls back to a valid #000000 when the slot is nil —
                <input type=\"color\"> rejects any non-hex value, so empty
                strings can't be used"
-       (let [tree (controls/scalar-widget
+       (let [tree (rf.story.ui.controls/scalar-widget
                     :story.x/v [:bg] nil {:widget :color})]
          (is (= "#000000" (-> tree second :value)))))))
 
 #?(:cljs
    (deftest color-widget-on-change-writes-hex
      (testing ":color on-change writes the picker's hex string verbatim"
-       (let [tree    (controls/scalar-widget
+       (let [tree    (rf.story.ui.controls/scalar-widget
                        :story.x/v [:bg] "#000000" {:widget :color})
              handler (-> tree second :on-change)]
          (handler (input-event "#abcdef"))
          (is (= "#abcdef"
-                (get-in (state/get-state)
+                (get-in (rf.story.ui.state/get-state)
                         [:cell-overrides :story.x/v :bg])))))))
 
 ;; ---- unknown widget fallback --------------------------------------------
@@ -257,7 +257,7 @@
      (testing "an unknown widget tag renders the inline fallback span —
                this is the existing contract and must survive the new
                widget additions"
-       (let [tree (controls/scalar-widget
+       (let [tree (rf.story.ui.controls/scalar-widget
                     :story.x/v [:k] "v" {:widget :ratchet})]
          (is (= :span (first tree)))
          (is (re-find #"unsupported widget"
@@ -273,7 +273,7 @@
        (doseq [w [:textarea :radio :date :color]]
          (let [spec    (cond-> {:widget w}
                          (#{:radio} w) (assoc :options [:a :b]))
-               sub-spec (last (controls/arg-widget
+               sub-spec (last (rf.story.ui.controls/arg-widget
                                 :story.x/v [:k] nil spec))]
            ;; arg-widget returns [scalar-widget variant-id path value spec]
            ;; — the trailing element is the widget-spec map, ensuring the
@@ -299,7 +299,7 @@
                 [{:widget :select :options [:a :b]}           :select]
                 [{:widget :date}                              :input]
                 [{:widget :color}                             :input]]]
-         (let [tree (controls/scalar-widget
+         (let [tree (rf.story.ui.controls/scalar-widget
                       :story.x/v [:username] "x" w)]
            (is (= expected-tag (first tree))
                (str (:widget w) " renders the right tag"))
@@ -313,7 +313,7 @@
      (testing "rf2-u01y5: the :radio container is a role=radiogroup with
                an aria-label — the inner inputs inherit a name from their
                wrapping <label> so they don't need their own aria-label."
-       (let [tree (controls/scalar-widget
+       (let [tree (rf.story.ui.controls/scalar-widget
                     :story.x/v [:variant] :primary
                     {:widget :radio :options [:primary :secondary]})]
          (is (= :div (first tree)))
@@ -326,7 +326,7 @@
      (testing "rf2-u01y5: nested path produces a slash-joined breadcrumb
                so a nested input is announced as 'address / street'
                rather than just 'street'."
-       (let [tree (controls/scalar-widget
+       (let [tree (rf.story.ui.controls/scalar-widget
                     :story.x/v [:address :street] "Main St" {:widget :text})]
          (is (re-find #"address" (-> tree second :aria-label)))
          (is (re-find #"street"  (-> tree second :aria-label)))))))

--- a/tools/story/test/re_frame/story/ui/controls_validation_diff_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/controls_validation_diff_cljs_test.cljc
@@ -30,21 +30,21 @@
   picked up by both `cljs-test$` and `-cljs-test$` regexes."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             #?(:cljs [re-frame.core :as rf])
-            #?(:cljs [re-frame.story :as story])
-            #?(:cljs [re-frame.story.ui.controls :as controls])
-            [re-frame.story.ui.state :as state]))
+            #?(:cljs [re-frame.story :as rf.story])
+            #?(:cljs [re-frame.story.ui.controls :as rf.story.ui.controls])
+            [re-frame.story.ui.state :as rf.story.ui.state]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 #?(:cljs
    (defn reset-fixture [test-fn]
-     (story/clear-all!)
-     (state/reset-shell-state!)
-     (story/install-canonical-vocabulary!)
+     (rf.story/clear-all!)
+     (rf.story.ui.state/reset-shell-state!)
+     (rf.story/install-canonical-vocabulary!)
      (test-fn))
    :clj
    (defn reset-fixture [test-fn]
-     (state/reset-shell-state!)
+     (rf.story.ui.state/reset-shell-state!)
      (test-fn)))
 
 (use-fixtures :each reset-fixture)
@@ -103,7 +103,7 @@
    (defn- render
      "Render the Form-2 args-editor for `variant-id` to hiccup."
      [variant-id]
-     ((controls/args-editor variant-id) variant-id)))
+     ((rf.story.ui.controls/args-editor variant-id) variant-id)))
 
 ;; ---- pure: violations-by-key --------------------------------------------
 
@@ -113,7 +113,7 @@
                {arg-key → violation} map"
        (let [viols [{:key :name :value 42 :schema :string :explain nil}
                     {:key :age  :value "x" :schema :int    :explain nil}]
-             by-k  (controls/violations-by-key viols)]
+             by-k  (rf.story.ui.controls/violations-by-key viols)]
          (is (= 2 (count by-k)))
          (is (= 42 (get-in by-k [:name :value])))
          (is (= "x" (get-in by-k [:age :value])))))))
@@ -125,14 +125,14 @@
                collides with a real arg-key but still counts"
        (let [viols [{:key :re-frame.story.ui.schema-validation/root
                      :value {:a 1} :schema :string :explain nil}]
-             by-k  (controls/violations-by-key viols)]
+             by-k  (rf.story.ui.controls/violations-by-key viols)]
          (is (contains? by-k :rf.story.controls/root))
          (is (= {:a 1} (get-in by-k [:rf.story.controls/root :value])))))))
 
 #?(:cljs
    (deftest violations-by-key-empty
      (testing "an empty violations vector indexes to an empty map"
-       (is (= {} (controls/violations-by-key []))))))
+       (is (= {} (rf.story.ui.controls/violations-by-key []))))))
 
 ;; ---- pure: arg-changed? -------------------------------------------------
 
@@ -140,42 +140,42 @@
    (deftest arg-changed?-true-on-diff
      (testing "an arg whose effective value differs from its saved value
                is flagged changed"
-       (is (controls/arg-changed? {:a 2} {:a 1} :a)))))
+       (is (rf.story.ui.controls/arg-changed? {:a 2} {:a 1} :a)))))
 
 #?(:cljs
    (deftest arg-changed?-false-on-equal
      (testing "an arg whose effective value equals its saved value is not
                flagged changed — even with an override present (same-value
                override)"
-       (is (not (controls/arg-changed? {:a 1} {:a 1} :a))))))
+       (is (not (rf.story.ui.controls/arg-changed? {:a 1} {:a 1} :a))))))
 
 #?(:cljs
    (deftest arg-changed?-handles-missing-keys
      (testing "a key absent from saved but present in effective is changed;
                a key absent from both is not"
-       (is (controls/arg-changed? {:a 1} {} :a))
-       (is (not (controls/arg-changed? {} {} :a))))))
+       (is (rf.story.ui.controls/arg-changed? {:a 1} {} :a))
+       (is (not (rf.story.ui.controls/arg-changed? {} {} :a))))))
 
 ;; ---- pure: summarize-value ----------------------------------------------
 
 #?(:cljs
    (deftest summarize-value-collections
      (testing "summarize-value gives a non-recursive one-line summary"
-       (is (= "empty"   (controls/summarize-value nil)))
-       (is (= "1 key"   (controls/summarize-value {:a 1})))
-       (is (= "2 keys"  (controls/summarize-value {:a 1 :b 2})))
-       (is (= "1 item"  (controls/summarize-value [:x])))
-       (is (= "3 items" (controls/summarize-value [:x :y :z])))
-       (is (= "2 items" (controls/summarize-value #{:x :y})))
+       (is (= "empty"   (rf.story.ui.controls/summarize-value nil)))
+       (is (= "1 key"   (rf.story.ui.controls/summarize-value {:a 1})))
+       (is (= "2 keys"  (rf.story.ui.controls/summarize-value {:a 1 :b 2})))
+       (is (= "1 item"  (rf.story.ui.controls/summarize-value [:x])))
+       (is (= "3 items" (rf.story.ui.controls/summarize-value [:x :y :z])))
+       (is (= "2 items" (rf.story.ui.controls/summarize-value #{:x :y})))
        ;; a scalar landing under a collection widget pr-strs
-       (is (= "\"x\""   (controls/summarize-value "x"))))))
+       (is (= "\"x\""   (rf.story.ui.controls/summarize-value "x"))))))
 
 #?(:cljs
    (deftest summarize-value-does-not-recurse
      (testing "deep contents are NOT walked — only the top-level count
                appears (the point of summarising before expanding)"
        (is (= "1 key"
-              (controls/summarize-value
+              (rf.story.ui.controls/summarize-value
                 {:deep {:and {:nested {:tree :here}}}}))))))
 
 ;; ---- CLJS render: summarise-before-expand -------------------------------
@@ -191,7 +191,7 @@
        (rf/reg-view* :view.ba86n/grp
          {:rf/props [:map [:meta [:map [:author :string] [:rating :int]]]]}
          (fn [_] [:div]))
-       (story/reg-variant :story.ba86n/grp
+       (rf.story/reg-variant :story.ba86n/grp
          {:component :view.ba86n/grp
           :args      {:meta {:author "ada" :rating 5}}
           :setup    []})
@@ -211,13 +211,13 @@
        (rf/reg-view* :view.ba86n/grp2
          {:rf/props [:map [:meta [:map [:author :string]]]]}
          (fn [_] [:div]))
-       (story/reg-variant :story.ba86n/grp2
+       (rf.story/reg-variant :story.ba86n/grp2
          {:component :view.ba86n/grp2
           :args      {:meta {:author "ada"}}
           :setup    []})
        ;; ONE editor instance — the expand ratom lives on its closure, so
        ;; the toggle + re-render must go through the same instance.
-       (let [editor (controls/args-editor :story.ba86n/grp2)
+       (let [editor (rf.story.ui.controls/args-editor :story.ba86n/grp2)
              tree-1 (editor :story.ba86n/grp2)
              toggle (button-with-action tree-1 "toggle-expand")
              on-click (:on-click (attrs toggle))]
@@ -236,7 +236,7 @@
      (testing "every arg row carries a data-controls-invalid attribute so
                downstream tooling / the browser smoke can detect blocked
                renders"
-       (story/reg-variant :story.ba86n/val
+       (rf.story/reg-variant :story.ba86n/val
          {:args {:title "hi"} :setup []})
        (let [tree (render :story.ba86n/val)
              row  (node-with-attr tree :data-controls-arg ":title")]
@@ -251,7 +251,7 @@
        (rf/reg-view* :view.ba86n/bad
          {:rf/props [:map [:age :int]]}
          (fn [_] [:div]))
-       (story/reg-variant :story.ba86n/bad
+       (rf.story/reg-variant :story.ba86n/bad
          {:component :view.ba86n/bad
           ;; :age is a string but the schema says :int.
           :args      {:age "not-a-number"}
@@ -280,11 +280,11 @@
      (testing "an arg overridden to a value differing from saved shows the
                changed dot (data-controls-changed=\"true\") and a per-arg
                reset button; clicking reset clears only that arg's override"
-       (story/reg-variant :story.ba86n/diff
+       (rf.story/reg-variant :story.ba86n/diff
          {:args {:title "saved" :other "keep"} :setup []})
-       (state/swap-state! state/set-cell-override-scalar
+       (rf.story.ui.state/swap-state! rf.story.ui.state/set-cell-override-scalar
                           :story.ba86n/diff :title "edited")
-       (state/swap-state! state/set-cell-override-scalar
+       (rf.story.ui.state/swap-state! rf.story.ui.state/set-cell-override-scalar
                           :story.ba86n/diff :other "changed-too")
        (let [tree      (render :story.ba86n/diff)
              title-row (node-with-attr tree :data-controls-arg ":title")]
@@ -293,17 +293,17 @@
            (is (some? reset-btn))
            ((:on-click (attrs reset-btn)) nil)
            ;; :title override gone, :other override survives.
-           (is (nil? (get-in (state/get-state)
+           (is (nil? (get-in (rf.story.ui.state/get-state)
                              [:cell-overrides :story.ba86n/diff :title])))
            (is (= "changed-too"
-                  (get-in (state/get-state)
+                  (get-in (rf.story.ui.state/get-state)
                           [:cell-overrides :story.ba86n/diff :other]))))))))
 
 #?(:cljs
    (deftest unchanged-arg-has-no-changed-dot
      (testing "an arg at its saved value carries data-controls-changed=
                \"false\" — no diff dot"
-       (story/reg-variant :story.ba86n/same
+       (rf.story/reg-variant :story.ba86n/same
          {:args {:title "saved"} :setup []})
        (let [tree (render :story.ba86n/same)
              row  (node-with-attr tree :data-controls-arg ":title")]
@@ -313,11 +313,11 @@
    (deftest reset-overrides-button-present-when-overrides-exist
      (testing "the panel-level 'reset overrides' button appears only when
                at least one override exists for the focused variant"
-       (story/reg-variant :story.ba86n/resetall
+       (rf.story/reg-variant :story.ba86n/resetall
          {:args {:a 1} :setup []})
        ;; No overrides yet → no reset-all button.
        (is (nil? (button-with-action (render :story.ba86n/resetall) "reset-all")))
        ;; Add an override → reset-all appears.
-       (state/swap-state! state/set-cell-override-scalar
+       (rf.story.ui.state/swap-state! rf.story.ui.state/set-cell-override-scalar
                           :story.ba86n/resetall :a 2)
        (is (some? (button-with-action (render :story.ba86n/resetall) "reset-all"))))))

--- a/tools/story/test/re_frame/story/ui/dispatch_console_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/dispatch_console_cljs_test.cljc
@@ -13,12 +13,12 @@
     `save-history!` / `load-history!`, `dispatch-event!` against a
     live re-frame frame, input state mutations, replay-from-history."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story.ui.dispatch-console :as dc]
-            [re-frame.story.ui.dispatch-console-events :as dce]
+            [re-frame.story.ui.dispatch-console :as rf.story.ui.dispatch-console]
+            [re-frame.story.ui.dispatch-console-events :as rf.story.ui.dispatch-console-events]
             #?@(:cljs [[re-frame.core :as rf]
-                       [re-frame.frame :as frame]
-                       [re-frame.registrar :as registrar]
-                       [re-frame.substrate.plain-atom :as plain-atom]])))
+                       [re-frame.frame :as rf.frame]
+                       [re-frame.registrar :as rf.registrar]
+                       [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]])))
 
 #?(:cljs
    (defn- browser?
@@ -34,12 +34,12 @@
 
 #?(:cljs
    (defn reset-all! []
-     (registrar/clear-all!)
-     (reset! frame/frames {})
-     (try (rf/init! plain-atom/adapter) (catch :default _ nil))
-     (frame/ensure-default-frame!)
-     (reset! dc/input-state {})
-     (reset! dc/history-state {})
+     (rf.registrar/clear-all!)
+     (reset! rf.frame/frames {})
+     (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
+     (rf.frame/ensure-default-frame!)
+     (reset! rf.story.ui.dispatch-console/input-state {})
+     (reset! rf.story.ui.dispatch-console/history-state {})
      ;; Clear localStorage for any keys we might have used in earlier tests.
      (when (and (exists? js/window) (.-localStorage js/window))
        (try (.clear (.-localStorage js/window)) (catch :default _ nil)))))
@@ -51,27 +51,27 @@
 
 (deftest parse-payload-empty
   (testing "blank and nil payloads parse to nil"
-    (is (= [:ok nil] (dc/parse-payload nil)))
-    (is (= [:ok nil] (dc/parse-payload "")))
-    (is (= [:ok nil] (dc/parse-payload "   ")))))
+    (is (= [:ok nil] (rf.story.ui.dispatch-console/parse-payload nil)))
+    (is (= [:ok nil] (rf.story.ui.dispatch-console/parse-payload "")))
+    (is (= [:ok nil] (rf.story.ui.dispatch-console/parse-payload "   ")))))
 
 (deftest parse-payload-edn
   (testing "EDN payloads parse via clojure.edn"
-    (is (= [:ok {:a 1}]   (dc/parse-payload "{:a 1}")))
-    (is (= [:ok [1 2 3]]  (dc/parse-payload "[1 2 3]")))
-    (is (= [:ok :keyword] (dc/parse-payload ":keyword")))
-    (is (= [:ok 42]       (dc/parse-payload "42")))
-    (is (= [:ok "string"] (dc/parse-payload "\"string\"")))))
+    (is (= [:ok {:a 1}]   (rf.story.ui.dispatch-console/parse-payload "{:a 1}")))
+    (is (= [:ok [1 2 3]]  (rf.story.ui.dispatch-console/parse-payload "[1 2 3]")))
+    (is (= [:ok :keyword] (rf.story.ui.dispatch-console/parse-payload ":keyword")))
+    (is (= [:ok 42]       (rf.story.ui.dispatch-console/parse-payload "42")))
+    (is (= [:ok "string"] (rf.story.ui.dispatch-console/parse-payload "\"string\"")))))
 
 (deftest parse-payload-error
   (testing "invalid EDN returns [:error <msg>]"
-    (let [[tag _] (dc/parse-payload "{:bad")]
+    (let [[tag _] (rf.story.ui.dispatch-console/parse-payload "{:bad")]
       (is (= :error tag)))))
 
 #?(:cljs
    (deftest parse-payload-json-cljs
      (testing "JSON-shaped payloads parse via JSON.parse on CLJS"
-       (let [[tag v] (dc/parse-payload "{\"a\":1,\"b\":\"two\"}")]
+       (let [[tag v] (rf.story.ui.dispatch-console/parse-payload "{\"a\":1,\"b\":\"two\"}")]
          (is (= :ok tag))
          (is (= {:a 1 :b "two"} v))))))
 
@@ -80,14 +80,14 @@
 (deftest build-event-vector-nil-payload
   (testing "nil payload produces [id]"
     (is (= [:counter/inc]
-           (dc/build-event-vector :counter/inc nil)))))
+           (rf.story.ui.dispatch-console/build-event-vector :counter/inc nil)))))
 
 (deftest build-event-vector-with-payload
   (testing "payload is the second slot — never splatted"
     (is (= [:user/login {:id 7}]
-           (dc/build-event-vector :user/login {:id 7})))
+           (rf.story.ui.dispatch-console/build-event-vector :user/login {:id 7})))
     (is (= [:user/login [:a :b :c]]
-           (dc/build-event-vector :user/login [:a :b :c])))))
+           (rf.story.ui.dispatch-console/build-event-vector :user/login [:a :b :c])))))
 
 ;; ---- pure: history shaping -----------------------------------------------
 
@@ -99,31 +99,31 @@
     ;; ordering.
     (let [thirty (mapv (fn [i] {:event-id (keyword "e" (str "i" i))})
                        (range 30))
-          capped (dc/clamp-history thirty)]
-      (is (= dc/history-max (count capped)))
-      ;; The first dc/history-max entries (index 0..max-1) survive.
+          capped (rf.story.ui.dispatch-console/clamp-history thirty)]
+      (is (= rf.story.ui.dispatch-console/history-max (count capped)))
+      ;; The first rf.story.ui.dispatch-console/history-max entries (index 0..max-1) survive.
       (is (= :e/i0 (:event-id (first capped))))
-      (is (= (keyword "e" (str "i" (dec dc/history-max)))
+      (is (= (keyword "e" (str "i" (dec rf.story.ui.dispatch-console/history-max)))
              (:event-id (last capped)))))))
 
 (deftest clamp-history-passes-short
   (testing "histories at or under the cap pass through"
-    (is (= [] (dc/clamp-history [])))
-    (is (= [{:a 1}] (dc/clamp-history [{:a 1}])))))
+    (is (= [] (rf.story.ui.dispatch-console/clamp-history [])))
+    (is (= [{:a 1}] (rf.story.ui.dispatch-console/clamp-history [{:a 1}])))))
 
 (deftest prepend-history-entry-orders-newest-first
   (testing "the freshest entry lands at the head of the vector"
     (let [h0 [{:event-id :a/old}]
-          h1 (dc/prepend-history-entry h0 {:event-id :a/new})]
+          h1 (rf.story.ui.dispatch-console/prepend-history-entry h0 {:event-id :a/new})]
       (is (= :a/new (:event-id (first h1))))
       (is (= :a/old (:event-id (second h1)))))))
 
 (deftest prepend-history-entry-respects-cap
   (testing "prepending past the cap evicts from the tail"
     (let [seed (mapv (fn [i] {:event-id (keyword "e" (str "i" i))})
-                     (range dc/history-max))
-          h    (dc/prepend-history-entry seed {:event-id :e/new})]
-      (is (= dc/history-max (count h)))
+                     (range rf.story.ui.dispatch-console/history-max))
+          h    (rf.story.ui.dispatch-console/prepend-history-entry seed {:event-id :e/new})]
+      (is (= rf.story.ui.dispatch-console/history-max (count h)))
       (is (= :e/new (:event-id (first h)))))))
 
 ;; ---- pure: format-history-entry ------------------------------------------
@@ -131,30 +131,30 @@
 (deftest format-history-entry-renders-id-only
   (testing "an entry with no payload renders just the id"
     (is (= ":counter/inc"
-           (dc/format-history-entry {:event-id :counter/inc :payload nil})))))
+           (rf.story.ui.dispatch-console/format-history-entry {:event-id :counter/inc :payload nil})))))
 
 (deftest format-history-entry-renders-id-and-payload
   (testing "an entry with a payload renders both"
     (is (= ":user/login {:id 7}"
-           (dc/format-history-entry {:event-id :user/login
+           (rf.story.ui.dispatch-console/format-history-entry {:event-id :user/login
                                      :payload  {:id 7}})))))
 
 (deftest format-history-entry-handles-missing-id
   (testing "no event-id is tolerated (display em-dash)"
     (is (= "—"
-           (dc/format-history-entry {:event-id nil :payload nil})))))
+           (rf.story.ui.dispatch-console/format-history-entry {:event-id nil :payload nil})))))
 
 ;; ---- pure: format-timestamp ----------------------------------------------
 
 (deftest format-timestamp-edge-cases
   (testing "nil / non-numeric / negative produces empty string"
-    (is (= "" (dc/format-timestamp nil)))
-    (is (= "" (dc/format-timestamp "not-a-number")))
-    (is (= "" (dc/format-timestamp -1)))))
+    (is (= "" (rf.story.ui.dispatch-console/format-timestamp nil)))
+    (is (= "" (rf.story.ui.dispatch-console/format-timestamp "not-a-number")))
+    (is (= "" (rf.story.ui.dispatch-console/format-timestamp -1)))))
 
 (deftest format-timestamp-shapes-hh-mm-ss
   (testing "a real epoch produces an HH:MM:SS-shaped string"
-    (let [out (dc/format-timestamp 1700000000000)]
+    (let [out (rf.story.ui.dispatch-console/format-timestamp 1700000000000)]
       (is (string? out))
       (is (= 8 (count out)))
       (is (re-matches #"\d\d:\d\d:\d\d" out)))))
@@ -164,7 +164,7 @@
 (deftest autocomplete-empty-prefix-returns-all
   (testing "an empty prefix returns the full id set sorted"
     (let [ids #{:counter/inc :counter/dec :user/login}
-          out (dc/autocomplete-event-ids ids "")]
+          out (rf.story.ui.dispatch-console/autocomplete-event-ids ids "")]
       (is (= 3 (count out)))
       ;; Sorted by pr-str.
       (is (= [:counter/dec :counter/inc :user/login] out)))))
@@ -172,14 +172,14 @@
 (deftest autocomplete-filters-by-substring
   (testing "matches are case-insensitive substring on (pr-str id)"
     (let [ids #{:counter/inc :counter/dec :user/login}
-          out (dc/autocomplete-event-ids ids "counter")]
+          out (rf.story.ui.dispatch-console/autocomplete-event-ids ids "counter")]
       (is (= 2 (count out)))
       (is (every? #(re-find #"counter" (str %)) out)))))
 
 (deftest autocomplete-respects-limit
   (testing "limit clamps the returned vector length"
     (let [ids (set (map #(keyword "e" (str "i" %)) (range 100)))
-          out (dc/autocomplete-event-ids ids "" 5)]
+          out (rf.story.ui.dispatch-console/autocomplete-event-ids ids "" 5)]
       (is (= 5 (count out))))))
 
 ;; ---- pure: registered-event-ids 1-arity ----------------------------------
@@ -187,77 +187,77 @@
 (deftest registered-event-ids-from-snapshot
   (testing "the 1-arity returns the snapshot key-set"
     (is (= #{:a :b :c}
-           (dce/registered-event-ids {:a {} :b {} :c {}})))
+           (rf.story.ui.dispatch-console-events/registered-event-ids {:a {} :b {} :c {}})))
     (is (= #{}
-           (dce/registered-event-ids nil)))
+           (rf.story.ui.dispatch-console-events/registered-event-ids nil)))
     (is (= #{}
-           (dce/registered-event-ids {})))))
+           (rf.story.ui.dispatch-console-events/registered-event-ids {})))))
 
 ;; ---- pure: cofx-requires-for (EP-0017) -----------------------------------
 
 (deftest cofx-requires-for-reads-declaration
   (testing "1-arity reads :rf.cofx/requires off a single event's meta"
     (is (= [:rf/time-ms]
-           (dce/cofx-requires-for {:rf.cofx/requires [:rf/time-ms]})))
+           (rf.story.ui.dispatch-console-events/cofx-requires-for {:rf.cofx/requires [:rf/time-ms]})))
     ;; parameterized [id arg] entries surface their id
     (is (= [:rf/time-ms :ui/local-theme]
-           (dce/cofx-requires-for {:rf.cofx/requires [:rf/time-ms [:ui/local-theme "theme"]]})))
-    (is (= [] (dce/cofx-requires-for {})))
-    (is (= [] (dce/cofx-requires-for {:rf.cofx/requires nil})))
-    (is (= [] (dce/cofx-requires-for nil)))))
+           (rf.story.ui.dispatch-console-events/cofx-requires-for {:rf.cofx/requires [:rf/time-ms [:ui/local-theme "theme"]]})))
+    (is (= [] (rf.story.ui.dispatch-console-events/cofx-requires-for {})))
+    (is (= [] (rf.story.ui.dispatch-console-events/cofx-requires-for {:rf.cofx/requires nil})))
+    (is (= [] (rf.story.ui.dispatch-console-events/cofx-requires-for nil)))))
 
 (deftest cofx-requires-for-via-snapshot
   (testing "2-arity looks the event up in a {id meta} snapshot"
     (let [snap {:ev/needs   {:rf.cofx/requires [:rf/time-ms]}
                 :ev/plain   {}}]
-      (is (= [:rf/time-ms] (dce/cofx-requires-for snap :ev/needs)))
-      (is (= []            (dce/cofx-requires-for snap :ev/plain)))
-      (is (= []            (dce/cofx-requires-for snap :ev/unknown)))
-      (is (= []            (dce/cofx-requires-for nil :ev/needs))))))
+      (is (= [:rf/time-ms] (rf.story.ui.dispatch-console-events/cofx-requires-for snap :ev/needs)))
+      (is (= []            (rf.story.ui.dispatch-console-events/cofx-requires-for snap :ev/plain)))
+      (is (= []            (rf.story.ui.dispatch-console-events/cofx-requires-for snap :ev/unknown)))
+      (is (= []            (rf.story.ui.dispatch-console-events/cofx-requires-for nil :ev/needs))))))
 
 ;; ---- pure: parse-cofx (EP-0017) ------------------------------------------
 
 (deftest parse-cofx-empty
   (testing "blank / nil cofx parse to nil (no :rf.cofx opt)"
-    (is (= [:ok nil] (dc/parse-cofx nil)))
-    (is (= [:ok nil] (dc/parse-cofx "")))
-    (is (= [:ok nil] (dc/parse-cofx "   ")))))
+    (is (= [:ok nil] (rf.story.ui.dispatch-console/parse-cofx nil)))
+    (is (= [:ok nil] (rf.story.ui.dispatch-console/parse-cofx "")))
+    (is (= [:ok nil] (rf.story.ui.dispatch-console/parse-cofx "   ")))))
 
 (deftest parse-cofx-map
   (testing "a well-shaped EDN map parses to itself"
     (is (= [:ok {:rf/time-ms 1781078400123}]
-           (dc/parse-cofx "{:rf/time-ms 1781078400123}")))
+           (rf.story.ui.dispatch-console/parse-cofx "{:rf/time-ms 1781078400123}")))
     (is (= [:ok {:rf/time-ms 1700000000000 :counter/delta 4}]
-           (dc/parse-cofx "{:rf/time-ms 1700000000000 :counter/delta 4}")))))
+           (rf.story.ui.dispatch-console/parse-cofx "{:rf/time-ms 1700000000000 :counter/delta 4}")))))
 
 (deftest parse-cofx-non-map-errors
   (testing "a vector / scalar is the wrong shape — [:error ...]"
-    (is (= :error (first (dc/parse-cofx "[:not :a :map]"))))
-    (is (= :error (first (dc/parse-cofx "42"))))))
+    (is (= :error (first (rf.story.ui.dispatch-console/parse-cofx "[:not :a :map]"))))
+    (is (= :error (first (rf.story.ui.dispatch-console/parse-cofx "42"))))))
 
 (deftest parse-cofx-unreadable-errors
   (testing "unreadable EDN returns [:error <msg>]"
-    (is (= :error (first (dc/parse-cofx "{:rf/time-ms 1"))))))
+    (is (= :error (first (rf.story.ui.dispatch-console/parse-cofx "{:rf/time-ms 1"))))))
 
 ;; ---- pure: build-dispatch-opts (EP-0017) ---------------------------------
 
 (deftest build-dispatch-opts-frame-only
   (testing "no cofx + not strict ⇒ just the frame opt"
-    (is (= {:frame :v} (dc/build-dispatch-opts :v nil false)))
-    (is (= {:frame :v} (dc/build-dispatch-opts :v {} false)))))
+    (is (= {:frame :v} (rf.story.ui.dispatch-console/build-dispatch-opts :v nil false)))
+    (is (= {:frame :v} (rf.story.ui.dispatch-console/build-dispatch-opts :v {} false)))))
 
 (deftest build-dispatch-opts-threads-cofx
   (testing "a non-empty cofx rides under :rf.cofx"
     (is (= {:frame :v :rf.cofx {:rf/time-ms 1700000000000}}
-           (dc/build-dispatch-opts :v {:rf/time-ms 1700000000000} false)))))
+           (rf.story.ui.dispatch-console/build-dispatch-opts :v {:rf/time-ms 1700000000000} false)))))
 
 (deftest build-dispatch-opts-strict-replay
   (testing "strict? adds :rf.cofx/mint-policy :strict (replay path)"
     (is (= {:frame :v :rf.cofx {:rf/time-ms 1} :rf.cofx/mint-policy :strict}
-           (dc/build-dispatch-opts :v {:rf/time-ms 1} true)))
+           (rf.story.ui.dispatch-console/build-dispatch-opts :v {:rf/time-ms 1} true)))
     ;; strict even with no cofx token
     (is (= {:frame :v :rf.cofx/mint-policy :strict}
-           (dc/build-dispatch-opts :v nil true)))))
+           (rf.story.ui.dispatch-console/build-dispatch-opts :v nil true)))))
 
 ;; ---- pure: build-history-entry carries cofx ------------------------------
 
@@ -265,23 +265,23 @@
   (testing "a supplied cofx is recorded; absent cofx keeps the legacy shape"
     (is (= {:event-id :e :payload nil :kind :dispatch :time 7
             :cofx {:rf/time-ms 1700000000000}}
-           (dc/build-history-entry :e nil :dispatch 7 {:rf/time-ms 1700000000000})))
+           (rf.story.ui.dispatch-console/build-history-entry :e nil :dispatch 7 {:rf/time-ms 1700000000000})))
     ;; nil / empty cofx ⇒ no :cofx key (byte-identical to pre-EP-0017 rows)
     (is (= {:event-id :e :payload nil :kind :dispatch :time 7}
-           (dc/build-history-entry :e nil :dispatch 7 nil)))
+           (rf.story.ui.dispatch-console/build-history-entry :e nil :dispatch 7 nil)))
     (is (= {:event-id :e :payload nil :kind :dispatch :time 7}
-           (dc/build-history-entry :e nil :dispatch 7)))))
+           (rf.story.ui.dispatch-console/build-history-entry :e nil :dispatch 7)))))
 
 ;; ---- pure: selected-event-id ---------------------------------------------
 
 (deftest selected-event-id-resolution
   (testing "reads a keyword input, nil otherwise"
-    (is (= :counter/inc (dc/selected-event-id ":counter/inc")))
-    (is (= :counter/inc (dc/selected-event-id "  :counter/inc  ")))
-    (is (nil? (dc/selected-event-id "")))
-    (is (nil? (dc/selected-event-id "   ")))
-    (is (nil? (dc/selected-event-id "not-a-keyword")))
-    (is (nil? (dc/selected-event-id nil)))))
+    (is (= :counter/inc (rf.story.ui.dispatch-console/selected-event-id ":counter/inc")))
+    (is (= :counter/inc (rf.story.ui.dispatch-console/selected-event-id "  :counter/inc  ")))
+    (is (nil? (rf.story.ui.dispatch-console/selected-event-id "")))
+    (is (nil? (rf.story.ui.dispatch-console/selected-event-id "   ")))
+    (is (nil? (rf.story.ui.dispatch-console/selected-event-id "not-a-keyword")))
+    (is (nil? (rf.story.ui.dispatch-console/selected-event-id nil)))))
 
 ;; ===========================================================================
 ;; CLJS-only side-effect coverage
@@ -291,25 +291,25 @@
    (deftest cljs-input-state-roundtrip
      (testing "reset-inputs! clears the per-variant inputs"
        (let [vid :story.x/y]
-         (swap! dc/input-state assoc-in [vid :event-id-input] ":hello")
-         (swap! dc/input-state assoc-in [vid :payload-input]  "{:a 1}")
-         (is (= ":hello" (get-in @dc/input-state [vid :event-id-input])))
-         (dc/reset-inputs! vid)
-         (is (= "" (get-in @dc/input-state [vid :event-id-input])))
-         (is (= "" (get-in @dc/input-state [vid :payload-input])))))))
+         (swap! rf.story.ui.dispatch-console/input-state assoc-in [vid :event-id-input] ":hello")
+         (swap! rf.story.ui.dispatch-console/input-state assoc-in [vid :payload-input]  "{:a 1}")
+         (is (= ":hello" (get-in @rf.story.ui.dispatch-console/input-state [vid :event-id-input])))
+         (rf.story.ui.dispatch-console/reset-inputs! vid)
+         (is (= "" (get-in @rf.story.ui.dispatch-console/input-state [vid :event-id-input])))
+         (is (= "" (get-in @rf.story.ui.dispatch-console/input-state [vid :payload-input])))))))
 
 #?(:cljs
    (deftest cljs-history-localstorage-roundtrip
      (testing "save-history! → load-history! survives across reset"
        (when (browser?)
          (let [vid    :story.persist/v
-               entry  (dc/build-history-entry :counter/inc nil :dispatch
+               entry  (rf.story.ui.dispatch-console/build-history-entry :counter/inc nil :dispatch
                                               1700000000000)
                one    [entry]]
-           (dc/save-history! vid one)
+           (rf.story.ui.dispatch-console/save-history! vid one)
            ;; Drop in-memory state to simulate a reload.
-           (reset! dc/history-state {})
-           (let [loaded (dc/load-history! vid)]
+           (reset! rf.story.ui.dispatch-console/history-state {})
+           (let [loaded (rf.story.ui.dispatch-console/load-history! vid)]
              (is (= 1 (count loaded)))
              (is (= :counter/inc (:event-id (first loaded))))))))))
 
@@ -318,10 +318,10 @@
      (testing "current-history hydrates from localStorage on first access"
        (when (browser?)
          (let [vid   :story.hyd/v
-               entry (dc/build-history-entry :ev/x nil :dispatch 17)]
-           (dc/save-history! vid [entry])
-           (reset! dc/history-state {})
-           (let [h (dc/current-history vid)]
+               entry (rf.story.ui.dispatch-console/build-history-entry :ev/x nil :dispatch 17)]
+           (rf.story.ui.dispatch-console/save-history! vid [entry])
+           (reset! rf.story.ui.dispatch-console/history-state {})
+           (let [h (rf.story.ui.dispatch-console/current-history vid)]
              (is (= 1 (count h)))
              (is (= :ev/x (:event-id (first h))))))))))
 
@@ -329,15 +329,15 @@
    (deftest cljs-clear-history-drops-storage
      (testing "clear-history! removes both ratom and localStorage state"
        (let [vid :story.clear/v
-             entry (dc/build-history-entry :ev/x nil :dispatch 1)]
-         (dc/append-history! vid entry)
-         (is (= 1 (count (dc/current-history vid))))
-         (dc/clear-history! vid)
-         (is (= 0 (count (dc/current-history vid))))
+             entry (rf.story.ui.dispatch-console/build-history-entry :ev/x nil :dispatch 1)]
+         (rf.story.ui.dispatch-console/append-history! vid entry)
+         (is (= 1 (count (rf.story.ui.dispatch-console/current-history vid))))
+         (rf.story.ui.dispatch-console/clear-history! vid)
+         (is (= 0 (count (rf.story.ui.dispatch-console/current-history vid))))
          (when (browser?)
            ;; Drop in-memory state and confirm storage was actually wiped.
-           (reset! dc/history-state {})
-           (is (= [] (dc/load-history! vid))))))))
+           (reset! rf.story.ui.dispatch-console/history-state {})
+           (is (= [] (rf.story.ui.dispatch-console/load-history! vid))))))))
 
 #?(:cljs
    (deftest cljs-dispatch-event-changes-app-db
@@ -348,9 +348,9 @@
                           (fn [{:keys [db]} _] {:db (update db :counter (fnil inc 0))}))
          (rf/reg-sub :test/counter
                      (fn [db _] (get db :counter 0)))
-         (dc/dispatch-event! vid [:test/inc] :dispatch-sync)
+         (rf.story.ui.dispatch-console/dispatch-event! vid [:test/inc] :dispatch-sync)
          (is (= 1 (rf/subscribe-once [:test/counter] {:frame vid})))
-         (dc/dispatch-event! vid [:test/inc] :dispatch-sync)
+         (rf.story.ui.dispatch-console/dispatch-event! vid [:test/inc] :dispatch-sync)
          (is (= 2 (rf/subscribe-once [:test/counter] {:frame vid})))))))
 
 #?(:cljs
@@ -359,8 +359,8 @@
        (let [vid :story.history.test/v]
          (rf/make-frame {:id vid})
          (rf/reg-event :test/noop (fn [{:keys [db]} _] {:db db}))
-         (dc/dispatch-event! vid [:test/noop {:k :v}] :dispatch-sync)
-         (let [h (dc/current-history vid)]
+         (rf.story.ui.dispatch-console/dispatch-event! vid [:test/noop {:k :v}] :dispatch-sync)
+         (let [h (rf.story.ui.dispatch-console/current-history vid)]
            (is (= 1 (count h)))
            (is (= :test/noop (:event-id (first h))))
            (is (= {:k :v}     (:payload  (first h))))
@@ -375,13 +375,13 @@
                           (fn [{:keys [db]} _] {:db (update db :counter (fnil inc 0))}))
          (rf/reg-sub :test/counter
                      (fn [db _] (get db :counter 0)))
-         (dc/dispatch-event! vid [:test/inc] :dispatch-sync)
+         (rf.story.ui.dispatch-console/dispatch-event! vid [:test/inc] :dispatch-sync)
          (is (= 1 (rf/subscribe-once [:test/counter] {:frame vid})))
-         (let [h (first (dc/current-history vid))]
-           (dc/replay-history-entry! vid h))
+         (let [h (first (rf.story.ui.dispatch-console/current-history vid))]
+           (rf.story.ui.dispatch-console/replay-history-entry! vid h))
          (is (= 2 (rf/subscribe-once [:test/counter] {:frame vid})))
          ;; Replay added a new history entry.
-         (is (= 2 (count (dc/current-history vid))))))))
+         (is (= 2 (count (rf.story.ui.dispatch-console/current-history vid))))))))
 
 #?(:cljs
    (deftest cljs-dispatch-from-inputs-parse-error-keeps-app-db
@@ -389,30 +389,30 @@
        (let [vid :story.parse.err/v]
          (rf/make-frame {:id vid})
          (rf/reg-event :test/boom (fn [{:keys [db]} _] {:db (assoc db :boomed? true)}))
-         (swap! dc/input-state assoc vid
+         (swap! rf.story.ui.dispatch-console/input-state assoc vid
                 {:event-id-input ":test/boom"
                  :payload-input  "{:bad"})
-         (dc/dispatch-from-inputs! vid :dispatch-sync)
-         (is (some? (get-in @dc/input-state [vid :error])))
-         (is (= 0 (count (dc/current-history vid))))))))
+         (rf.story.ui.dispatch-console/dispatch-from-inputs! vid :dispatch-sync)
+         (is (some? (get-in @rf.story.ui.dispatch-console/input-state [vid :error])))
+         (is (= 0 (count (rf.story.ui.dispatch-console/current-history vid))))))))
 
 #?(:cljs
    (deftest cljs-dispatch-from-inputs-missing-id-errors
      (testing "an empty event-id input sets :error"
        (let [vid :story.empty.id/v]
          (rf/make-frame {:id vid})
-         (swap! dc/input-state assoc vid
+         (swap! rf.story.ui.dispatch-console/input-state assoc vid
                 {:event-id-input ""
                  :payload-input  ""})
-         (dc/dispatch-from-inputs! vid :dispatch)
-         (is (some? (get-in @dc/input-state [vid :error])))))))
+         (rf.story.ui.dispatch-console/dispatch-from-inputs! vid :dispatch)
+         (is (some? (get-in @rf.story.ui.dispatch-console/input-state [vid :error])))))))
 
 #?(:cljs
    (deftest cljs-autocomplete-against-live-registrar
      (testing "registered-event-ids 0-arity surfaces registered handlers"
        (rf/reg-event :ac.test/one (fn [{:keys [db]} _] {:db db}))
        (rf/reg-event :ac.test/two (fn [{:keys [db]} _] {:db db}))
-       (let [ids (dce/registered-event-ids)]
+       (let [ids (rf.story.ui.dispatch-console-events/registered-event-ids)]
          (is (contains? ids :ac.test/one))
          (is (contains? ids :ac.test/two))))))
 
@@ -433,11 +433,11 @@
          (rf/reg-event :cofx.console/needs
                           {:rf.cofx/requires [:cofx.console/boundary]}
                           (fn [{:keys [db]} _] {:db db}))
-         (let [meta (dce/registered-event-meta)]
+         (let [meta (rf.story.ui.dispatch-console-events/registered-event-meta)]
            (is (contains? meta :cofx.console/needs)
                "the event's metadata is reachable, not just its id")
            (is (= [:cofx.console/boundary]
-                  (dce/cofx-requires-for meta :cofx.console/needs))
+                  (rf.story.ui.dispatch-console-events/cofx-requires-for meta :cofx.console/needs))
                "the console can resolve the requirement for the selected event"))))))
 
 #?(:cljs
@@ -454,16 +454,16 @@
                             {:db (assoc db :seen (:cofx.console/boundary cofx))}))
          (rf/reg-sub :cofx.console/seen (fn [db _] (get db :seen)))
          ;; supply via the inputs (live path)
-         (swap! dc/input-state assoc vid
+         (swap! rf.story.ui.dispatch-console/input-state assoc vid
                 {:event-id-input ":cofx.console/needs"
                  :payload-input  ""
                  :cofx-input     "{:cofx.console/boundary 99}"})
-         (dc/dispatch-from-inputs! vid :dispatch-sync)
-         (is (nil? (get-in @dc/input-state [vid :error]))
+         (rf.story.ui.dispatch-console/dispatch-from-inputs! vid :dispatch-sync)
+         (is (nil? (get-in @rf.story.ui.dispatch-console/input-state [vid :error]))
              "supplying the provided fact clears the error path")
          (is (= 99 (rf/subscribe-once [:cofx.console/seen] {:frame vid}))
              "the supplied recordable fact reached the handler")
-         (let [h (first (dc/current-history vid))]
+         (let [h (first (rf.story.ui.dispatch-console/current-history vid))]
            (is (= {:cofx.console/boundary 99} (:cofx h))
                "the supplied cofx is recorded in history for faithful replay"))))))
 
@@ -480,16 +480,16 @@
                           {:rf.cofx/requires [:cofx.console/boundary]}
                           (fn [{:keys [db]} _] (reset! fired? true) {:db db}))
          ;; supply NO cofx for the provided fact
-         (swap! dc/input-state assoc vid
+         (swap! rf.story.ui.dispatch-console/input-state assoc vid
                 {:event-id-input ":cofx.console/needs"
                  :payload-input  ""
                  :cofx-input     ""})
-         (dc/dispatch-from-inputs! vid :dispatch-sync)
+         (rf.story.ui.dispatch-console/dispatch-from-inputs! vid :dispatch-sync)
          (is (false? @fired?)
              "the handler never ran — missing-required halts the cascade")
-         (is (some? (get-in @dc/input-state [vid :error]))
+         (is (some? (get-in @rf.story.ui.dispatch-console/input-state [vid :error]))
              "the failure is surfaced visibly as the panel error")
-         (is (= 0 (count (dc/current-history vid)))
+         (is (= 0 (count (rf.story.ui.dispatch-console/current-history vid)))
              "a failed dispatch records no history entry")))))
 
 #?(:cljs
@@ -506,23 +506,23 @@
                             {:db (assoc db :seen (:cofx.console/boundary cofx))}))
          (rf/reg-sub :cofx.console/seen (fn [db _] (get db :seen)))
          ;; original dispatch supplies the fact, recording it in history
-         (dc/dispatch-event! vid [:cofx.console/needs] :dispatch-sync
+         (rf.story.ui.dispatch-console/dispatch-event! vid [:cofx.console/needs] :dispatch-sync
                              {:cofx.console/boundary 7} false)
          (is (= 7 (rf/subscribe-once [:cofx.console/seen] {:frame vid})))
          ;; replay the recorded row — the strict policy re-presents the
          ;; recorded value (no re-mint); the handler reads the SAME fact
-         (let [row (first (dc/current-history vid))]
+         (let [row (first (rf.story.ui.dispatch-console/current-history vid))]
            (is (= {:cofx.console/boundary 7} (:cofx row))
                "the recorded row carries the supplied cofx")
-           (dc/replay-history-entry! vid row))
+           (rf.story.ui.dispatch-console/replay-history-entry! vid row))
          (is (= 7 (rf/subscribe-once [:cofx.console/seen] {:frame vid}))
              "replay reused the recorded recordable fact under strict policy")
-         (is (= 2 (count (dc/current-history vid)))
+         (is (= 2 (count (rf.story.ui.dispatch-console/current-history vid)))
              "replay recorded a fresh history entry")
          ;; ADVERSARIAL: a recorded row whose token OMITS the required fact
          ;; must fail loudly under strict replay rather than silently re-minting
          (let [bad-row {:event-id :cofx.console/needs :payload nil
                         :kind :dispatch-sync :time 1 :cofx nil}]
-           (dc/replay-history-entry! vid bad-row)
-           (is (some? (get-in @dc/input-state [vid :error]))
+           (rf.story.ui.dispatch-console/replay-history-entry! vid bad-row)
+           (is (some? (get-in @rf.story.ui.dispatch-console/input-state [vid :error]))
                "strict replay of an incomplete recorded token fails visibly"))))))

--- a/tools/story/test/re_frame/story/ui/docs_evidence_test.cljc
+++ b/tools/story/test/re_frame/story/ui/docs_evidence_test.cljc
@@ -15,9 +15,9 @@
   the `spine/open!` / `focus-beat!` side effects, and the live result-slot read
   are CLJS and exercised by the CLJS docs corpus."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.play.evidence :as evidence]
-            [re-frame.story.result :as result]
-            [re-frame.story.ui.docs :as docs]))
+            [re-frame.story.play.evidence :as rf.story.play.evidence]
+            [re-frame.story.result :as rf.story.result]
+            [re-frame.story.ui.docs :as rf.story.ui.docs]))
 
 ;; ---------------------------------------------------------------------------
 ;; A representative narrative — two dispatch beats + one non-dispatch assert
@@ -41,7 +41,7 @@
     :effects [] :sub-runs [] :renders [] :trace-events []
     :outcome :ok :rf.story/script-idx 1}])
 
-(defn- narrative [] (evidence/narrative script epoch-tape))
+(defn- narrative [] (rf.story.play.evidence/narrative script epoch-tape))
 
 ;; ===========================================================================
 ;; status-summary  (spec/022 §1 — docs↔Test agreement)
@@ -50,13 +50,13 @@
 (deftest status-summary-agrees-with-test-run-status
   (testing "a nil result (never run) is :pending with zero counts and :ran? false"
     (is (= {:status :pending :passed 0 :failed 0 :cannot-run 0 :total 0 :ran? false}
-           (docs/status-summary nil nil))))
+           (rf.story.ui.docs/status-summary nil nil))))
   (testing "a unified result's run-level :status drives the docs verdict — the
             SAME value test-mode reads. A pass result with a clean summary."
     (let [res {:status :pass :assertions [{:assertion :rf.assert/path-equals
                                            :status :pass :passed? true}]}
           summary {:passed 1 :failed 0 :cannot-run 0 :total 1 :all-passed? true}
-          out (docs/status-summary res summary)]
+          out (rf.story.ui.docs/status-summary res summary)]
       (is (= :pass (:status out)))
       (is (= 1 (:passed out)))
       (is (true? (:ran? out)))))
@@ -65,23 +65,23 @@
     (let [res {:status :fail :assertions [{:assertion :rf.assert/path-equals
                                            :status :pass :passed? true}]}
           summary {:passed 1 :failed 0 :cannot-run 0 :total 1 :all-passed? true}]
-      (is (= :fail (:status (docs/status-summary res summary)))
+      (is (= :fail (:status (rf.story.ui.docs/status-summary res summary)))
           ":fail wins over a green assertion count — docs cannot read green
            while the tape is red")))
   (testing ":cannot-run is preserved as the distinct third state"
     (let [res {:status :cannot-run :assertions []}
           summary {:passed 0 :failed 0 :cannot-run 1 :total 1}]
-      (is (= :cannot-run (:status (docs/status-summary res summary)))))))
+      (is (= :cannot-run (:status (rf.story.ui.docs/status-summary res summary)))))))
 
 (deftest status-summary-uses-the-canonical-run-result
-  (testing "feeding a real `result/run-result` through status-summary yields a
-            verdict that matches `result/passed?` — docs and the unified
+  (testing "feeding a real `rf.story.result/run-result` through status-summary yields a
+            verdict that matches `rf.story.result/passed?` — docs and the unified
             result agree end-to-end"
-    (let [res (result/run-result {:epoch-tape epoch-tape
+    (let [res (rf.story.result/run-result {:epoch-tape epoch-tape
                                   :script script
                                   :assertions []})
           ;; a clean tape with no assertions is vacuously green
-          out (docs/status-summary res {:passed 0 :failed 0 :cannot-run 0 :total 0})]
+          out (rf.story.ui.docs/status-summary res {:passed 0 :failed 0 :cannot-run 0 :total 0})]
       (is (= :pass (:status res)))
       (is (= :pass (:status out))
           "docs status pill reads the unified run-result's verdict verbatim"))))
@@ -93,7 +93,7 @@
 (deftest fidelity-badges-order-and-presence
   (testing "the badge rows are the full ladder, highest fidelity first,
             each marked present? against the plan's :fidelity set"
-    (let [badges (docs/fidelity-badges {:fidelity #{:real-setup}})]
+    (let [badges (rf.story.ui.docs/fidelity-badges {:fidelity #{:real-setup}})]
       (is (= [:real-setup :db-seed :sub-overrides] (mapv :rung badges))
           "ladder order is real-setup > db-seed > sub-overrides")
       (is (= [true false false] (mapv :present? badges))
@@ -101,14 +101,14 @@
   (testing "a pure design variant resting only on sub-overrides marks the
             higher rungs absent"
     (is (= [false false true]
-           (mapv :present? (docs/fidelity-badges {:fidelity #{:sub-overrides}})))))
+           (mapv :present? (rf.story.ui.docs/fidelity-badges {:fidelity #{:sub-overrides}})))))
   (testing "an empty fidelity set marks every rung absent"
     (is (= [false false false]
-           (mapv :present? (docs/fidelity-badges {}))))))
+           (mapv :present? (rf.story.ui.docs/fidelity-badges {}))))))
 
 (deftest world-input-chips-only-present
   (testing "only the world inputs the variant actually declares surface"
-    (let [chips (docs/world-input-chips
+    (let [chips (rf.story.ui.docs/world-input-chips
                   {:setup [[:a]] :script [[:b]]
                    :world {:db-seed {:x 1}
                            :render {:sub-overrides {[:s] 1}}
@@ -118,15 +118,15 @@
           "every declared world input present")
       (is (every? :present? chips))))
   (testing "a bare variant with no world inputs surfaces no chips"
-    (is (= [] (docs/world-input-chips {:world {}})))))
+    (is (= [] (rf.story.ui.docs/world-input-chips {:world {}})))))
 
 (deftest required-runner-tokens-sorted
   (testing "the runner-requirement tokens are returned sorted"
     (is (= [:rf.story/cljs-reactive :rf.story/real-fx]
-           (docs/required-runner-tokens
+           (rf.story.ui.docs/required-runner-tokens
              {:required-runner #{:rf.story/real-fx :rf.story/cljs-reactive}}))))
   (testing "no required-runner → empty vector"
-    (is (= [] (docs/required-runner-tokens {})))))
+    (is (= [] (rf.story.ui.docs/required-runner-tokens {})))))
 
 ;; ===========================================================================
 ;; view-arg schema table  (spec/022 §1)
@@ -139,7 +139,7 @@
                         [:map
                          [:label :string]
                          [:n {:optional true} :int]]}}
-          rows (docs/view-arg-schema-rows plan)
+          rows (rf.story.ui.docs/view-arg-schema-rows plan)
           by-k (into {} (map (juxt :key identity)) rows)]
       (is (= #{:label :n} (set (map :key rows))))
       (is (true? (:required? (by-k :label))) ":label has no :optional → required")
@@ -147,10 +147,10 @@
       (is (= :string (:schema (by-k :label))))
       (is (= :int (:schema (by-k :n))))))
   (testing "no schema on file → empty rows (docs omits the section)"
-    (is (= [] (docs/view-arg-schema-rows {:world {}})))
-    (is (= [] (docs/view-arg-schema-rows nil))))
+    (is (= [] (rf.story.ui.docs/view-arg-schema-rows {:world {}})))
+    (is (= [] (rf.story.ui.docs/view-arg-schema-rows nil))))
   (testing "a non-:map top-level schema yields no rows (no per-prop table)"
-    (is (= [] (docs/view-arg-schema-rows
+    (is (= [] (rf.story.ui.docs/view-arg-schema-rows
                 {:world {:view-args-schema [:and :map]}})))))
 
 ;; ===========================================================================
@@ -160,10 +160,10 @@
 (deftest evidence-excerpt-caps-and-reuses-spine-projection
   (testing "the excerpt reuses the spine's spine-spans projection, flattens to
             the run's beats, caps the inline excerpt, and reports the overflow"
-    (let [exc (docs/evidence-excerpt (narrative))]
+    (let [exc (rf.story.ui.docs/evidence-excerpt (narrative))]
       (is (true? (:available? exc)))
       (is (= 2 (:beat-count exc)) "two dispatch beats in the narrative")
-      (is (<= (count (:beats exc)) docs/evidence-excerpt-beat-cap)
+      (is (<= (count (:beats exc)) rf.story.ui.docs/evidence-excerpt-beat-cap)
           "inline beats never exceed the sparse cap")
       (is (= 100 (:epoch-id (first (:beats exc))))
           "the excerpt surfaces the leading beat, decorated by the spine
@@ -181,16 +181,16 @@
                              :rf.story/script-idx i})
                           (range 5))
           long-script (mapv (fn [i] [:dispatch [:e i]]) (range 5))
-          exc (docs/evidence-excerpt (evidence/narrative long-script long-tape))]
+          exc (rf.story.ui.docs/evidence-excerpt (rf.story.play.evidence/narrative long-script long-tape))]
       (is (= 5 (:beat-count exc)))
-      (is (= docs/evidence-excerpt-beat-cap (count (:beats exc))))
-      (is (= (- 5 docs/evidence-excerpt-beat-cap) (:more exc))
+      (is (= rf.story.ui.docs/evidence-excerpt-beat-cap (count (:beats exc))))
+      (is (= (- 5 rf.story.ui.docs/evidence-excerpt-beat-cap) (:more exc))
           "the rest live in the full spine — surfaced as a 'more' count, not
            dumped inline (sparse, not a debug log)")))
   (testing "an empty / nil narrative is an honest no-evidence excerpt"
-    (let [exc (docs/evidence-excerpt nil)]
+    (let [exc (rf.story.ui.docs/evidence-excerpt nil)]
       (is (false? (:available? exc)))
       (is (= [] (:beats exc)))
       (is (zero? (:beat-count exc)))
       (is (zero? (:more exc))))
-    (is (false? (:available? (docs/evidence-excerpt []))))))
+    (is (false? (:available? (rf.story.ui.docs/evidence-excerpt []))))))

--- a/tools/story/test/re_frame/story/ui/docs_markdown_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/docs_markdown_cljs_test.cljs
@@ -4,54 +4,54 @@
 
   Pure-data coverage of the markdown parser lives in
   `re-frame.story.ui.markdown-test`. This namespace asserts that the
-  docs pane's renderer now PASSES prose bodies through `md/parse`
+  docs pane's renderer now PASSES prose bodies through `rf.story.ui.markdown/parse`
   rather than rendering them as raw `pre-wrap` text — pinning the
   integration so a future refactor that drops the parse call breaks
   the test loudly."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.machines         :as machines]
-            [re-frame.registrar        :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story            :as story]
-            [re-frame.story.loaders    :as loaders]
-            [re-frame.story.ui.docs    :as docs]
-            [re-frame.story.ui.markdown :as md]
-            [re-frame.story.ui.state   :as state]
-            [re-frame.subs             :as subs]))
+            [re-frame.frame            :as rf.frame]
+            [re-frame.machines         :as rf.machines]
+            [re-frame.registrar        :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story            :as rf.story]
+            [re-frame.story.loaders    :as rf.story.loaders]
+            [re-frame.story.ui.docs    :as rf.story.ui.docs]
+            [re-frame.story.ui.markdown :as rf.story.ui.markdown]
+            [re-frame.story.ui.state   :as rf.story.ui.state]
+            [re-frame.subs             :as rf.subs]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch :default _ nil))
   ;; Re-register the framework `:rf/machine` sub after the registrar clear.
   ;; EP-0001 (rf2-vzld77 / rf2-ixb0bq): a runtime-db sub reading
   ;; [:rf.runtime/machines :snapshots <id>], NOT the retired app-db
   ;; `:rf/runtime` path — mirror `re-frame.machines`.
-  (subs/reg-runtime-sub :rf/machine
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [runtime-db [_ machine-id]]
       (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each {:before reset-all!})
 
 ;; ---- markdown smoke tests ------------------------------------------------
 
 (deftest markdown-parse-is-pure-data
-  (testing "md/parse returns a hiccup vector with no JS interop —
+  (testing "rf.story.ui.markdown/parse returns a hiccup vector with no JS interop —
             JVM-and-CLJS-symmetric (the parser itself is JVM-tested in
             re-frame.story.ui.markdown-test; this test confirms the
             same parser runs cleanly under cljs.test)"
-    (let [out (md/parse "# Title\n\nbody **bold** end")]
+    (let [out (rf.story.ui.markdown/parse "# Title\n\nbody **bold** end")]
       (is (vector? out))
       (is (= :div.rf-story-md (first out)))
       (let [[_ h1 p] out]
@@ -61,21 +61,21 @@
 (deftest prose-body-walked-by-renderer-feeds-md-parser
   (testing "the prose-for-variant data the renderer iterates over
             preserves `:body` strings verbatim — the renderer then
-            passes each body through md/parse. Pinning the data side
+            passes each body through rf.story.ui.markdown/parse. Pinning the data side
             of the integration plus the parse round-trip covers the
             full surface (the renderer itself is a pure projection)."
-    (story/reg-story :story.md-prose {:doc "" :tags #{:dev}})
-    (story/reg-variant :story.md-prose/v
+    (rf.story/reg-story :story.md-prose {:doc "" :tags #{:dev}})
+    (rf.story/reg-variant :story.md-prose/v
       {:doc "" :setup []})
-    (story/reg-workspace :Workspace.md-prose/notes
+    (rf.story/reg-workspace :Workspace.md-prose/notes
       {:layout  :prose
        :content [{:type :variant :id :story.md-prose/v}
                  {:type :prose
                   :body "# Heading\n\nA paragraph with `code`."}]})
-    (let [entries (docs/prose-for-variant :story.md-prose/v)]
+    (let [entries (rf.story.ui.docs/prose-for-variant :story.md-prose/v)]
       (is (= 1 (count entries)))
       (let [body (-> entries first :body)
-            out  (md/parse body)]
+            out  (rf.story.ui.markdown/parse body)]
         (is (string? body))
         (is (vector? out))
         (let [blocks (rest out)]
@@ -84,18 +84,18 @@
 
 (deftest prose-with-bullet-list-roundtrips-to-ul
   (testing "a workspace prose body with markdown bullets parses to a
-            <ul> block — proves the data → md/parse contract for the
+            <ul> block — proves the data → rf.story.ui.markdown/parse contract for the
             common docs shape (bulleted lists are the most-used
             markdown affordance in Story prose)"
-    (story/reg-story :story.md-list {:doc "" :tags #{:dev}})
-    (story/reg-variant :story.md-list/v {:doc "" :setup []})
-    (story/reg-workspace :Workspace.md-list/notes
+    (rf.story/reg-story :story.md-list {:doc "" :tags #{:dev}})
+    (rf.story/reg-variant :story.md-list/v {:doc "" :setup []})
+    (rf.story/reg-workspace :Workspace.md-list/notes
       {:layout  :prose
        :content [{:type :variant :id :story.md-list/v}
                  {:type :prose
                   :body "Steps:\n\n- one\n- two\n- three"}]})
-    (let [body  (-> (docs/prose-for-variant :story.md-list/v) first :body)
-          out   (md/parse body)
+    (let [body  (-> (rf.story.ui.docs/prose-for-variant :story.md-list/v) first :body)
+          out   (rf.story.ui.markdown/parse body)
           ul    (some #(when (= :ul (first %)) %) (rest out))]
       (is (some? ul))
       (is (= 3 (count (drop 2 ul)))

--- a/tools/story/test/re_frame/story/ui/docs_mode_pane_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/docs_mode_pane_cljs_test.cljs
@@ -13,7 +13,7 @@
     selectors documented in spec/008 all resolve.
 
   - **Tag-chip forward-link** — clicking a docs tag-chip flips the
-    sidebar's `:tag-filter` for that tag (via `state/toggle-tag-filter`).
+    sidebar's `:tag-filter` for that tag (via `rf.story.ui.state/toggle-tag-filter`).
     Re-clicking flips it back. The `aria-pressed` attribute mirrors the
     filter state — proves the chip's accessibility contract.
 
@@ -28,38 +28,38 @@
   fixtures covers the pane's contract without a DOM round-trip."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.machines         :as machines]
-            [re-frame.registrar        :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story            :as story]
-            [re-frame.story.loaders    :as loaders]
-            [re-frame.story.predicates :as pred]
-            [re-frame.story.ui.docs    :as docs]
-            [re-frame.story.ui.state   :as state]
-            [re-frame.story.ui.state.transitions :as transitions]
-            [re-frame.subs             :as subs]))
+            [re-frame.frame            :as rf.frame]
+            [re-frame.machines         :as rf.machines]
+            [re-frame.registrar        :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story            :as rf.story]
+            [re-frame.story.loaders    :as rf.story.loaders]
+            [re-frame.story.predicates :as rf.story.predicates]
+            [re-frame.story.ui.docs    :as rf.story.ui.docs]
+            [re-frame.story.ui.state   :as rf.story.ui.state]
+            [re-frame.story.ui.state.transitions :as rf.story.ui.state.transitions]
+            [re-frame.subs             :as rf.subs]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch :default _ nil))
   ;; Re-register the framework `:rf/machine` sub after the registrar clear.
   ;; EP-0001 (rf2-vzld77 / rf2-ixb0bq): a runtime-db sub reading
   ;; [:rf.runtime/machines :snapshots <id>], NOT the retired app-db
   ;; `:rf/runtime` path — mirror `re-frame.machines`.
-  (subs/reg-runtime-sub :rf/machine
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [runtime-db [_ machine-id]]
       (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -75,26 +75,26 @@
     - one :hiccup decorator + one :fx-override decorator (the canonical
       :rf.story/force-fx-stub) so the decorators-table groups by kind"
   []
-  (story/reg-decorator :hiccup-wrap
+  (rf.story/reg-decorator :hiccup-wrap
     {:kind :hiccup
      :doc  "wraps in a centred pane"
      :wrap (fn [body _] [:div.centred body])})
-  (story/reg-story :story.docs-rich
+  (rf.story/reg-story :story.docs-rich
     {:doc       "Rich variant fixture for docs-pane scenarios."
      :argtypes  {:label {:doc "user-visible label"}
                  :n     {:doc "tick count"}}
      :tags      #{:dev :docs}
      :modes     #{:Mode.app/dark}
      :substrates #{:reagent}})
-  (story/reg-variant :story.docs-rich/v
+  (rf.story/reg-variant :story.docs-rich/v
     {:doc        "The 'happy path' variant — used by docs scenarios."
      :args       {:label "Hello" :n 42}
      :decorators [[:hiccup-wrap]
                   [:rf.story/force-fx-stub :http {:status :ok}]]
      :tags       #{:dev :docs :test}
      :setup     []})
-  (story/reg-mode :Mode.app/dark {:args {:theme :dark}})
-  (story/reg-workspace :Workspace.docs-rich/prose-ws
+  (rf.story/reg-mode :Mode.app/dark {:args {:theme :dark}})
+  (rf.story/reg-workspace :Workspace.docs-rich/prose-ws
     {:layout  :prose
      :content [{:type :variant :id :story.docs-rich/v}
                {:type :prose
@@ -119,14 +119,14 @@
     (register-rich-variant!)
     ;; Parent story id is derived from the variant id namespace.
     (is (= :story.docs-rich
-           (pred/parent-story-id :story.docs-rich/v))
+           (rf.story.predicates/parent-story-id :story.docs-rich/v))
         "parent-story chip reads :story.docs-rich")
     ;; The header chip vector is the variant's :tags set sorted.
-    (let [tags (docs/variant-tags :story.docs-rich/v)]
+    (let [tags (rf.story.ui.docs/variant-tags :story.docs-rich/v)]
       (is (= [:dev :docs :test] tags)
           "header tags vector is sorted-by-keyword"))
     ;; The doc-blurb reads the variant's :doc with fallback to the parent's.
-    (let [vb (story/handler-meta :variant :story.docs-rich/v)]
+    (let [vb (rf.story/handler-meta :variant :story.docs-rich/v)]
       (is (string? (:doc vb))
           ":doc on the variant feeds the doc-blurb"))))
 
@@ -136,7 +136,7 @@
             order. Pinning the data here covers the renderer's
             `data-test=story-docs-prose-block` rows."
     (register-rich-variant!)
-    (let [prose (docs/prose-for-variant :story.docs-rich/v)]
+    (let [prose (rf.story.ui.docs/prose-for-variant :story.docs-rich/v)]
       (is (= 2 (count prose))
           "two :prose items in the matching workspace")
       (is (every? #(= :Workspace.docs-rich/prose-ws (:workspace-id %)) prose)
@@ -151,9 +151,9 @@
   (testing "a variant referenced by ZERO :prose-layout workspaces gets
             an empty prose result — the renderer omits the section
             entirely (no 'no prose' placeholder per spec/008)"
-    (story/reg-variant :story.docs.no-prose/v
+    (rf.story/reg-variant :story.docs.no-prose/v
       {:doc "no-prose variant" :setup []})
-    (is (= [] (docs/prose-for-variant :story.docs.no-prose/v))
+    (is (= [] (rf.story.ui.docs/prose-for-variant :story.docs.no-prose/v))
         "empty result — the renderer's `when (seq entries)` clause
          omits the prose section's data-test wrapper")))
 
@@ -167,8 +167,8 @@
             rather than asserting an exact count (defends the test
             against future :global-args additions from the host)."
     (register-rich-variant!)
-    (let [eff   (story/resolve-args :story.docs-rich/v)
-          rows  (docs/args-rows :story.docs-rich/v eff)
+    (let [eff   (rf.story/resolve-args :story.docs-rich/v)
+          rows  (rf.story.ui.docs/args-rows :story.docs-rich/v eff)
           by-k  (into {} (map (juxt :key identity) rows))]
       (is (contains? by-k :label)
           ":label declared on the variant surfaces as a row")
@@ -193,8 +193,8 @@
             `data-test=story-docs-decorator-row` + `data-section`
             mapping."
     (register-rich-variant!)
-    (let [pack    (story/resolve-decorators :story.docs-rich/v)
-          rows    (docs/decorator-rows pack)
+    (let [pack    (rf.story/resolve-decorators :story.docs-rich/v)
+          rows    (rf.story.ui.docs/decorator-rows pack)
           by-sect (group-by :section rows)]
       (is (contains? by-sect :hiccup)
           ":hiccup section present — the :hiccup-wrap decorator")
@@ -215,7 +215,7 @@
             `data-test=story-docs-parameter-row` + `data-param-key`
             mapping. Per spec/008 §Parameters."
     (register-rich-variant!)
-    (let [rows   (docs/parameter-rows :story.docs-rich/v)
+    (let [rows   (rf.story.ui.docs/parameter-rows :story.docs-rich/v)
           by-k   (into {} (map (juxt :key identity) rows))]
       ;; The variant did NOT declare its own :modes / :substrates;
       ;; both fall back to the parent story.
@@ -232,16 +232,16 @@
             renders one chip per id. Sorted for stable test selectors."
     (register-rich-variant!)
     (is (= [:dev :docs :test]
-           (docs/variant-tags :story.docs-rich/v))
+           (rf.story.ui.docs/variant-tags :story.docs-rich/v))
         "rich variant exposes its full tag set, sorted")
-    (story/reg-variant :story.docs.no-tags/v {:setup []})
-    (is (= [] (docs/variant-tags :story.docs.no-tags/v))
+    (rf.story/reg-variant :story.docs.no-tags/v {:setup []})
+    (is (= [] (rf.story.ui.docs/variant-tags :story.docs.no-tags/v))
         "variant with no tags AND no parent story tags surfaces empty")))
 
 ;; ===========================================================================
 ;; rf2-ssibv — tag-chip forward-link
 ;;
-;; Clicking a docs tag chip dispatches `state/toggle-tag-filter` against
+;; Clicking a docs tag chip dispatches `rf.story.ui.state/toggle-tag-filter` against
 ;; the shell-state-atom. The chip's `aria-pressed` mirrors the resulting
 ;; filter membership. Both the header chip-row AND the bottom tag-picker
 ;; use the same state mutation — proven by exercising the transition
@@ -249,30 +249,30 @@
 ;; ===========================================================================
 
 (deftest tag-chip-toggles-shell-tag-filter
-  (testing "the forward-link contract: applying state/toggle-tag-filter
+  (testing "the forward-link contract: applying rf.story.ui.state/toggle-tag-filter
             for a tag adds it to the shell's :tag-filter set; applying
             it again removes it. The chip's `aria-pressed` reads
             `(contains? tag-filter tag)`. Per spec/008 §Tag-chip
             forward-link."
     (register-rich-variant!)
     ;; Initial state: no tag filter.
-    (is (= #{} (:tag-filter @state/shell-state-atom))
+    (is (= #{} (:tag-filter @rf.story.ui.state/shell-state-atom))
         "shell starts with no tag filter")
     ;; First toggle: :dev enters the filter set.
-    (state/swap-state! transitions/toggle-tag-filter :dev)
-    (is (= #{:dev} (:tag-filter @state/shell-state-atom))
+    (rf.story.ui.state/swap-state! rf.story.ui.state.transitions/toggle-tag-filter :dev)
+    (is (= #{:dev} (:tag-filter @rf.story.ui.state/shell-state-atom))
         "tag-chip click adds :dev to the filter — sidebar narrows to
          :dev-tagged variants AND the docs chip's aria-pressed flips
          to true")
     ;; Second toggle: :dev leaves the filter set.
-    (state/swap-state! transitions/toggle-tag-filter :dev)
-    (is (= #{} (:tag-filter @state/shell-state-atom))
+    (rf.story.ui.state/swap-state! rf.story.ui.state.transitions/toggle-tag-filter :dev)
+    (is (= #{} (:tag-filter @rf.story.ui.state/shell-state-atom))
         "tag-chip second click removes :dev — sidebar widens again AND
          the aria-pressed reads false")
     ;; Multi-toggle: :dev and :docs both end up in the filter.
-    (state/swap-state! transitions/toggle-tag-filter :dev)
-    (state/swap-state! transitions/toggle-tag-filter :docs)
-    (is (= #{:dev :docs} (:tag-filter @state/shell-state-atom))
+    (rf.story.ui.state/swap-state! rf.story.ui.state.transitions/toggle-tag-filter :dev)
+    (rf.story.ui.state/swap-state! rf.story.ui.state.transitions/toggle-tag-filter :docs)
+    (is (= #{:dev :docs} (:tag-filter @rf.story.ui.state/shell-state-atom))
         "two tag-chip clicks across two tags accumulate — the chip-row
          renders both with aria-pressed=true")))
 
@@ -293,40 +293,40 @@
             spec/008."
     (register-rich-variant!)
     ;; Seed the shell with realistic 'user-was-editing' state.
-    (state/swap-state! transitions/set-cell-override-scalar
+    (rf.story.ui.state/swap-state! rf.story.ui.state.transitions/set-cell-override-scalar
                        :story.docs-rich/v :label "USER-EDIT")
-    (state/swap-state! transitions/set-active-modes [:Mode.app/dark])
-    (state/swap-state! transitions/toggle-tag-filter :dev)
-    (state/swap-state! transitions/select-variant :story.docs-rich/v)
+    (rf.story.ui.state/swap-state! rf.story.ui.state.transitions/set-active-modes [:Mode.app/dark])
+    (rf.story.ui.state/swap-state! rf.story.ui.state.transitions/toggle-tag-filter :dev)
+    (rf.story.ui.state/swap-state! rf.story.ui.state.transitions/select-variant :story.docs-rich/v)
     ;; Snapshot the slots the docs pane must NOT touch.
-    (let [before-overrides (:cell-overrides @state/shell-state-atom)
-          before-modes     (:active-modes    @state/shell-state-atom)
-          before-tags      (:tag-filter      @state/shell-state-atom)
-          before-selected  (:selected-variant @state/shell-state-atom)]
+    (let [before-overrides (:cell-overrides @rf.story.ui.state/shell-state-atom)
+          before-modes     (:active-modes    @rf.story.ui.state/shell-state-atom)
+          before-tags      (:tag-filter      @rf.story.ui.state/shell-state-atom)
+          before-selected  (:selected-variant @rf.story.ui.state/shell-state-atom)]
       ;; Switch :dev → :docs.
-      (state/swap-state! transitions/set-active-mode-tab
+      (rf.story.ui.state/swap-state! rf.story.ui.state.transitions/set-active-mode-tab
                          :story.docs-rich/v :docs)
-      (is (= :docs (state/active-mode-tab @state/shell-state-atom
+      (is (= :docs (rf.story.ui.state/active-mode-tab @rf.story.ui.state/shell-state-atom
                                           :story.docs-rich/v))
           ":active-mode-tab flipped — the pane swap is the only effect")
-      (is (= before-overrides (:cell-overrides @state/shell-state-atom))
+      (is (= before-overrides (:cell-overrides @rf.story.ui.state/shell-state-atom))
           ":cell-overrides untouched — user's :label edit survives the
            docs detour")
-      (is (= before-modes (:active-modes @state/shell-state-atom))
+      (is (= before-modes (:active-modes @rf.story.ui.state/shell-state-atom))
           ":active-modes untouched — the dark-theme chip is still active")
-      (is (= before-tags (:tag-filter @state/shell-state-atom))
+      (is (= before-tags (:tag-filter @rf.story.ui.state/shell-state-atom))
           ":tag-filter untouched — the sidebar's :dev filter is preserved")
-      (is (= before-selected (:selected-variant @state/shell-state-atom))
+      (is (= before-selected (:selected-variant @rf.story.ui.state/shell-state-atom))
           ":selected-variant untouched — the focused row in the sidebar
            is preserved")
       ;; Switch :docs → :dev (mirror of the round-trip).
-      (state/swap-state! transitions/set-active-mode-tab
+      (rf.story.ui.state/swap-state! rf.story.ui.state.transitions/set-active-mode-tab
                          :story.docs-rich/v :dev)
-      (is (= :dev (state/active-mode-tab @state/shell-state-atom
+      (is (= :dev (rf.story.ui.state/active-mode-tab @rf.story.ui.state/shell-state-atom
                                          :story.docs-rich/v))
           "returned to :dev — the canvas re-mounts against the same
            cell-overrides the user originally entered")
-      (is (= before-overrides (:cell-overrides @state/shell-state-atom))
+      (is (= before-overrides (:cell-overrides @rf.story.ui.state/shell-state-atom))
           "round-trip preserves :cell-overrides — the user's transient
            edit was never lost"))))
 
@@ -337,23 +337,23 @@
             data → data. Pure-data invariant; pin it so future
             registry-touching refactors break this test loudly."
     (register-rich-variant!)
-    (let [registry-before {:variant   (story/registrations :variant)
-                           :story     (story/registrations :story)
-                           :workspace (story/registrations :workspace)
-                           :decorator (story/registrations :decorator)
-                           :mode      (story/registrations :mode)}]
+    (let [registry-before {:variant   (rf.story/registrations :variant)
+                           :story     (rf.story/registrations :story)
+                           :workspace (rf.story/registrations :workspace)
+                           :decorator (rf.story/registrations :decorator)
+                           :mode      (rf.story/registrations :mode)}]
       ;; Pull every projection a docs render walks.
-      (docs/prose-for-variant :story.docs-rich/v)
-      (docs/args-rows :story.docs-rich/v
-                      (story/resolve-args :story.docs-rich/v))
-      (docs/decorator-rows (story/resolve-decorators :story.docs-rich/v))
-      (docs/parameter-rows :story.docs-rich/v)
-      (docs/variant-tags :story.docs-rich/v)
-      (let [registry-after {:variant   (story/registrations :variant)
-                            :story     (story/registrations :story)
-                            :workspace (story/registrations :workspace)
-                            :decorator (story/registrations :decorator)
-                            :mode      (story/registrations :mode)}]
+      (rf.story.ui.docs/prose-for-variant :story.docs-rich/v)
+      (rf.story.ui.docs/args-rows :story.docs-rich/v
+                      (rf.story/resolve-args :story.docs-rich/v))
+      (rf.story.ui.docs/decorator-rows (rf.story/resolve-decorators :story.docs-rich/v))
+      (rf.story.ui.docs/parameter-rows :story.docs-rich/v)
+      (rf.story.ui.docs/variant-tags :story.docs-rich/v)
+      (let [registry-after {:variant   (rf.story/registrations :variant)
+                            :story     (rf.story/registrations :story)
+                            :workspace (rf.story/registrations :workspace)
+                            :decorator (rf.story/registrations :decorator)
+                            :mode      (rf.story/registrations :mode)}]
         (is (= registry-before registry-after)
             "docs render walked the full pure-data surface; registry is
              unchanged. Documents the contract that no docs helper

--- a/tools/story/test/re_frame/story/ui/docs_rollup_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/docs_rollup_cljs_test.cljs
@@ -20,37 +20,37 @@
     of the above)"
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.machines         :as machines]
-            [re-frame.registrar        :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story            :as story]
-            [re-frame.story.loaders    :as loaders]
-            [re-frame.story.ui.docs    :as docs]
-            [re-frame.story.ui.state   :as state]
-            [re-frame.story.ui.state.transitions :as transitions]
-            [re-frame.subs             :as subs]))
+            [re-frame.frame            :as rf.frame]
+            [re-frame.machines         :as rf.machines]
+            [re-frame.registrar        :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story            :as rf.story]
+            [re-frame.story.loaders    :as rf.story.loaders]
+            [re-frame.story.ui.docs    :as rf.story.ui.docs]
+            [re-frame.story.ui.state   :as rf.story.ui.state]
+            [re-frame.story.ui.state.transitions :as rf.story.ui.state.transitions]
+            [re-frame.subs             :as rf.subs]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch :default _ nil))
   ;; Re-register the framework `:rf/machine` sub after the registrar clear.
   ;; EP-0001 (rf2-vzld77 / rf2-ixb0bq): a runtime-db sub reading
   ;; [:rf.runtime/machines :snapshots <id>], NOT the retired app-db
   ;; `:rf/runtime` path — mirror `re-frame.machines`.
-  (subs/reg-runtime-sub :rf/machine
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [runtime-db [_ machine-id]]
       (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -58,21 +58,21 @@
 
 (defn- register-story-with-variants!
   []
-  (story/reg-story :story.rollup
+  (rf.story/reg-story :story.rollup
     {:doc       "Rollup-fixture story with three variants."
      :argtypes  {:label {:doc "the label arg"}}
      :tags      #{:dev :docs}})
-  (story/reg-variant :story.rollup/alpha
+  (rf.story/reg-variant :story.rollup/alpha
     {:doc   "First variant — :alpha."
      :args  {:label "alpha"}
      :tags  #{:dev}
      :setup []})
-  (story/reg-variant :story.rollup/beta
+  (rf.story/reg-variant :story.rollup/beta
     {:doc   "Second variant — :beta."
      :args  {:label "beta"}
      :tags  #{:docs}
      :setup []})
-  (story/reg-variant :story.rollup/gamma
+  (rf.story/reg-variant :story.rollup/gamma
     {:doc   "Third variant — :gamma."
      :args  {:label "gamma"}
      :setup []}))
@@ -89,22 +89,22 @@
     (is (= [:story.rollup/alpha
             :story.rollup/beta
             :story.rollup/gamma]
-           (docs/variant-ids-for-story :story.rollup))
+           (rf.story.ui.docs/variant-ids-for-story :story.rollup))
         "all three variants surface, sorted by id")))
 
 (deftest variant-ids-for-empty-story
   (testing "a story with zero registered variants returns an empty
             vector — the renderer shows an empty-state placeholder
             rather than vanishing"
-    (story/reg-story :story.empty-rollup
+    (rf.story/reg-story :story.empty-rollup
       {:doc "no variants" :tags #{:dev}})
-    (is (= [] (docs/variant-ids-for-story :story.empty-rollup)))))
+    (is (= [] (rf.story.ui.docs/variant-ids-for-story :story.empty-rollup)))))
 
 (deftest variant-ids-for-unknown-story
   (testing "a story id with no registrations returns empty — defends
             against stale shell-state :selected-story slots after a
             hot-reload that drops a story"
-    (is (= [] (docs/variant-ids-for-story :story.does-not-exist)))))
+    (is (= [] (rf.story.ui.docs/variant-ids-for-story :story.does-not-exist)))))
 
 ;; ===========================================================================
 ;; docs-rollup-view rendering shape
@@ -113,7 +113,7 @@
 (deftest docs-rollup-view-nil-input-renders-nothing
   (testing "the view defends against a nil :selected-story slot — no
             crash, no DOM"
-    (is (nil? (docs/docs-rollup-view nil)))))
+    (is (nil? (rf.story.ui.docs/docs-rollup-view nil)))))
 
 (deftest docs-rollup-view-renders-one-block-per-variant
   (testing "the rollup pane carries N rollup-variant-block children
@@ -122,7 +122,7 @@
             land on the inner ^{:key vid} wrap; pin the count and that
             each block names its variant-id via :data-variant-id."
     (register-story-with-variants!)
-    (let [hiccup (docs/docs-rollup-view :story.rollup)]
+    (let [hiccup (rf.story.ui.docs/docs-rollup-view :story.rollup)]
       (is (vector? hiccup))
       (is (= :section (first hiccup)))
       (is (= "story-docs-rollup" (:data-test (second hiccup))))
@@ -132,9 +132,9 @@
   (testing "stories with zero variants render an empty-state notice —
             the user clicked into the rollup but there's nothing to
             project. Better than a silently-empty pane."
-    (story/reg-story :story.empty-rollup
+    (rf.story/reg-story :story.empty-rollup
       {:doc "no variants" :tags #{:dev}})
-    (let [hiccup (docs/docs-rollup-view :story.empty-rollup)
+    (let [hiccup (rf.story.ui.docs/docs-rollup-view :story.empty-rollup)
           children (drop 2 hiccup)  ; drop tag + attrs
           empty-marker (some (fn [c]
                                (and (vector? c)
@@ -152,7 +152,7 @@
   (testing "select-story writes the parent-story id into
             :selected-story"
     (let [state {:selected-story nil}
-          out   (transitions/select-story state :story.foo)]
+          out   (rf.story.ui.state.transitions/select-story state :story.foo)]
       (is (= :story.foo (:selected-story out))))))
 
 (deftest select-story-clears-variant-and-workspace
@@ -162,7 +162,7 @@
     (let [state {:selected-variant   :story.foo/v
                  :selected-workspace :Workspace.foo/ws
                  :selected-story     nil}
-          out   (transitions/select-story state :story.foo)]
+          out   (rf.story.ui.state.transitions/select-story state :story.foo)]
       (is (= :story.foo (:selected-story out)))
       (is (nil? (:selected-variant   out)))
       (is (nil? (:selected-workspace out))))))
@@ -175,7 +175,7 @@
     (let [state {:selected-variant   :story.foo/v
                  :selected-workspace nil
                  :selected-story     :story.foo}
-          out   (transitions/select-story state nil)]
+          out   (rf.story.ui.state.transitions/select-story state nil)]
       (is (nil? (:selected-story out)))
       (is (= :story.foo/v (:selected-variant out))))))
 
@@ -185,7 +185,7 @@
             from the sidebar"
     (let [state {:selected-story   :story.foo
                  :selected-variant nil}
-          out   (transitions/select-variant state :story.foo/v)]
+          out   (rf.story.ui.state.transitions/select-variant state :story.foo/v)]
       (is (= :story.foo/v (:selected-variant out)))
       (is (nil? (:selected-story out))))))
 
@@ -194,7 +194,7 @@
             exclusion contract as variant selection"
     (let [state {:selected-story     :story.foo
                  :selected-workspace nil}
-          out   (transitions/select-workspace state :Workspace.foo/ws)]
+          out   (rf.story.ui.state.transitions/select-workspace state :Workspace.foo/ws)]
       (is (= :Workspace.foo/ws (:selected-workspace out)))
       (is (nil? (:selected-story out))))))
 
@@ -204,7 +204,7 @@
             shouldn't lose their rollup focus"
     (let [state {:selected-story   :story.foo
                  :selected-variant :story.foo/v}
-          out   (transitions/select-variant state nil)]
+          out   (rf.story.ui.state.transitions/select-variant state nil)]
       (is (nil? (:selected-variant out)))
       (is (= :story.foo (:selected-story out))
           "story slot survives a variant deselection"))))
@@ -220,17 +220,17 @@
             re-populated. Mirrors the integration the sidebar drives."
     (register-story-with-variants!)
     ;; Start: nothing selected.
-    (is (nil? (:selected-story (state/get-state))))
+    (is (nil? (:selected-story (rf.story.ui.state/get-state))))
     ;; Click story header.
-    (state/swap-state! transitions/select-story :story.rollup)
-    (is (= :story.rollup (:selected-story (state/get-state))))
-    (is (nil? (:selected-variant (state/get-state))))
+    (rf.story.ui.state/swap-state! rf.story.ui.state.transitions/select-story :story.rollup)
+    (is (= :story.rollup (:selected-story (rf.story.ui.state/get-state))))
+    (is (nil? (:selected-variant (rf.story.ui.state/get-state))))
     ;; Click variant — story is dismissed.
-    (state/swap-state! transitions/select-variant :story.rollup/alpha)
-    (is (= :story.rollup/alpha (:selected-variant (state/get-state))))
-    (is (nil? (:selected-story (state/get-state)))
+    (rf.story.ui.state/swap-state! rf.story.ui.state.transitions/select-variant :story.rollup/alpha)
+    (is (= :story.rollup/alpha (:selected-variant (rf.story.ui.state/get-state))))
+    (is (nil? (:selected-story (rf.story.ui.state/get-state)))
         "selecting a variant dismisses the rollup view")
     ;; Click story header again — variant cleared.
-    (state/swap-state! transitions/select-story :story.rollup)
-    (is (= :story.rollup (:selected-story (state/get-state))))
-    (is (nil? (:selected-variant (state/get-state))))))
+    (rf.story.ui.state/swap-state! rf.story.ui.state.transitions/select-story :story.rollup)
+    (is (= :story.rollup (:selected-story (rf.story.ui.state/get-state))))
+    (is (nil? (:selected-variant (rf.story.ui.state/get-state))))))

--- a/tools/story/test/re_frame/story/ui/docs_toc_test.cljc
+++ b/tools/story/test/re_frame/story/ui/docs_toc_test.cljc
@@ -10,17 +10,17 @@
   re-render) lives in `docs_toc_cljs_test.cljs` — this corpus pins the
   pure projection only."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.ui.docs :as docs]))
+            [re-frame.story.ui.docs :as rf.story.ui.docs]))
 
 (deftest toc-table-shape
   (testing "canonical entry list (rf2-ba86n.14 — status + view-arg schema +
             evidence sections added)"
-    (let [ids (mapv :id docs/docs-toc-entries)]
+    (let [ids (mapv :id rf.story.ui.docs/docs-toc-entries)]
       (is (= ["docs-status" "docs-prose" "docs-args" "docs-schema"
               "docs-decorators" "docs-parameters" "docs-evidence" "docs-tags"]
              ids))))
   (testing "every entry carries the required slots"
-    (doseq [entry docs/docs-toc-entries]
+    (doseq [entry rf.story.ui.docs/docs-toc-entries]
       (is (some? (:id entry)))
       (is (some? (:label entry)))
       (is (integer? (:level entry))))))
@@ -30,7 +30,7 @@
             (rf2-ba86n.14); args / decorators / parameters / evidence / tags
             are unconditional"
     (is (= #{"docs-status" "docs-prose" "docs-schema"}
-           (into #{} (map :id) (filter :conditional? docs/docs-toc-entries))))))
+           (into #{} (map :id) (filter :conditional? rf.story.ui.docs/docs-toc-entries))))))
 
 ;; `visible-toc-entries` consults the live registrar for prose workspaces +
 ;; compiles the variant's plan for the status / view-arg-schema conditionals.
@@ -41,7 +41,7 @@
 (deftest visible-toc-prunes-conditionals-when-absent
   (testing "no prose workspace + uncompilable plan → prose / status / schema
             entries pruned; the unconditional entries remain"
-    (let [out (docs/visible-toc-entries :story.fake/variant)]
+    (let [out (rf.story.ui.docs/visible-toc-entries :story.fake/variant)]
       (is (not-any? #(#{"docs-prose" "docs-status" "docs-schema"} (:id %)) out))
       (is (= ["docs-args" "docs-decorators" "docs-parameters"
               "docs-evidence" "docs-tags"]

--- a/tools/story/test/re_frame/story/ui/element_inspector_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/element_inspector_cljs_test.cljc
@@ -28,8 +28,8 @@
       both are set."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             #?@(:cljs [[re-frame.core :as rf]
-                       [re-frame.source-coords :as source-coords]])
-            [re-frame.story.ui.element-inspector :as inspector]))
+                       [re-frame.source-coords :as rf.source-coords]])
+            [re-frame.story.ui.element-inspector :as rf.story.ui.element-inspector]))
 
 ;; ---- pure: parse-coord (JVM + CLJS) -------------------------------------
 
@@ -39,13 +39,13 @@
             annotation)"
     (is (= {:ns "counter.core" :handler-id "counter-buttons"
             :line 47 :col 11}
-           (inspector/parse-coord "counter.core:counter-buttons:47:11")))))
+           (rf.story.ui.element-inspector/parse-coord "counter.core:counter-buttons:47:11")))))
 
 (deftest parse-coord-dotted-and-hyphenated
   (testing "dotted ns + hyphenated handler-id parse cleanly"
     (is (= {:ns "my-app.cart.view" :handler-id "apply-coupon-button"
             :line 125 :col 4}
-           (inspector/parse-coord
+           (rf.story.ui.element-inspector/parse-coord
              "my-app.cart.view:apply-coupon-button:125:4")))))
 
 (deftest parse-coord-degraded
@@ -53,47 +53,47 @@
             parser surfaces them as nil"
     (is (= {:ns "rf.src-coord-test" :handler-id "programmatic"
             :line nil :col nil}
-           (inspector/parse-coord "rf.src-coord-test:programmatic:?:?")))))
+           (rf.story.ui.element-inspector/parse-coord "rf.src-coord-test:programmatic:?:?")))))
 
 (deftest parse-coord-malformed-too-few-segments
   (testing "fewer than 4 segments → nil"
-    (is (nil? (inspector/parse-coord "ns:view:42")))
-    (is (nil? (inspector/parse-coord "ns:view")))
-    (is (nil? (inspector/parse-coord "")))
-    (is (nil? (inspector/parse-coord nil)))))
+    (is (nil? (rf.story.ui.element-inspector/parse-coord "ns:view:42")))
+    (is (nil? (rf.story.ui.element-inspector/parse-coord "ns:view")))
+    (is (nil? (rf.story.ui.element-inspector/parse-coord "")))
+    (is (nil? (rf.story.ui.element-inspector/parse-coord nil)))))
 
 (deftest parse-coord-malformed-too-many-segments
   (testing "more than 4 segments → nil (strict 4-segment contract)"
-    (is (nil? (inspector/parse-coord "a:b:c:d:e")))))
+    (is (nil? (rf.story.ui.element-inspector/parse-coord "a:b:c:d:e")))))
 
 (deftest parse-coord-empty-segments
   (testing "empty `<ns>` or `<handler-id>` → nil"
-    (is (nil? (inspector/parse-coord ":handler:1:2")))
-    (is (nil? (inspector/parse-coord "ns::1:2")))))
+    (is (nil? (rf.story.ui.element-inspector/parse-coord ":handler:1:2")))
+    (is (nil? (rf.story.ui.element-inspector/parse-coord "ns::1:2")))))
 
 (deftest parse-coord-non-string-input
   (testing "non-string input → nil (never throws)"
-    (is (nil? (inspector/parse-coord 42)))
-    (is (nil? (inspector/parse-coord :keyword)))
-    (is (nil? (inspector/parse-coord ["v" "e" "c"])))))
+    (is (nil? (rf.story.ui.element-inspector/parse-coord 42)))
+    (is (nil? (rf.story.ui.element-inspector/parse-coord :keyword)))
+    (is (nil? (rf.story.ui.element-inspector/parse-coord ["v" "e" "c"])))))
 
 (deftest coord->handler-keyword-shape
   (testing "parsed coord round-trips to the registered view-id keyword"
     (is (= :counter.core/counter-buttons
-           (inspector/coord->handler-keyword
+           (rf.story.ui.element-inspector/coord->handler-keyword
              {:ns "counter.core" :handler-id "counter-buttons"
               :line 47 :col 11}))))
   (testing "missing :ns or :handler-id → nil"
-    (is (nil? (inspector/coord->handler-keyword {:handler-id "x"})))
-    (is (nil? (inspector/coord->handler-keyword {:ns "x"})))
-    (is (nil? (inspector/coord->handler-keyword nil)))))
+    (is (nil? (rf.story.ui.element-inspector/coord->handler-keyword {:handler-id "x"})))
+    (is (nil? (rf.story.ui.element-inspector/coord->handler-keyword {:ns "x"})))
+    (is (nil? (rf.story.ui.element-inspector/coord->handler-keyword nil)))))
 
 ;; ---- CLJS-only: mode toggle + chip + overlay ----------------------------
 
 #?(:cljs
    (defn reset-inspector! []
-     (inspector/set-active! false)
-     (reset! inspector/state {:active? false :hover nil})))
+     (rf.story.ui.element-inspector/set-active! false)
+     (reset! rf.story.ui.element-inspector/state {:active? false :hover nil})))
 
 #?(:cljs
    (use-fixtures :each (fn [t] (reset-inspector!) (t) (reset-inspector!))))
@@ -101,32 +101,32 @@
 #?(:cljs
    (deftest mode-toggle-flips-active-flag
      (testing "set-active! + toggle! drive the active? predicate"
-       (is (false? (inspector/active?)))
-       (inspector/set-active! true)
-       (is (true? (inspector/active?)))
-       (inspector/toggle!)
-       (is (false? (inspector/active?)))
-       (inspector/toggle!)
-       (is (true? (inspector/active?))))))
+       (is (false? (rf.story.ui.element-inspector/active?)))
+       (rf.story.ui.element-inspector/set-active! true)
+       (is (true? (rf.story.ui.element-inspector/active?)))
+       (rf.story.ui.element-inspector/toggle!)
+       (is (false? (rf.story.ui.element-inspector/active?)))
+       (rf.story.ui.element-inspector/toggle!)
+       (is (true? (rf.story.ui.element-inspector/active?))))))
 
 #?(:cljs
    (deftest set-active-false-clears-hover
      (testing "turning the inspector OFF must clear any pending hover
                snapshot so a stale outline doesn't survive the toggle"
-       (swap! inspector/state assoc
+       (swap! rf.story.ui.element-inspector/state assoc
               :active? true
               :hover {:coord-attr "x:y:1:1"
                       :handler-id :x/y
                       :rect {:top 0 :left 0 :width 10 :height 10}})
-       (inspector/set-active! false)
-       (is (false? (inspector/active?)))
-       (is (nil? (:hover @inspector/state))))))
+       (rf.story.ui.element-inspector/set-active! false)
+       (is (false? (rf.story.ui.element-inspector/active?)))
+       (is (nil? (:hover @rf.story.ui.element-inspector/state))))))
 
 #?(:cljs
    (deftest inspect-chip-renders-toggle-state
      (testing "chip renders with `aria-haspopup` (not aria-pressed) per
                rf2-zll4h reset-gate convention"
-       (let [hiccup (inspector/inspect-chip)
+       (let [hiccup (rf.story.ui.element-inspector/inspect-chip)
              props  (second hiccup)]
          (is (= :button (first hiccup)))
          (is (= "story-toolbar-inspect" (:data-test props)))
@@ -143,21 +143,21 @@
 #?(:cljs
    (deftest inspect-chip-renders-on-state
      (testing "chip's data attrs flip after toggle"
-       (inspector/set-active! true)
-       (let [hiccup (inspector/inspect-chip)
+       (rf.story.ui.element-inspector/set-active! true)
+       (let [hiccup (rf.story.ui.element-inspector/inspect-chip)
              props  (second hiccup)]
          (is (= "true" (:aria-expanded props)))))))
 
 #?(:cljs
    (deftest overlay-renders-nothing-when-off
      (testing "overlay returns nil when inspector mode is off"
-       (is (nil? (inspector/overlay))))))
+       (is (nil? (rf.story.ui.element-inspector/overlay))))))
 
 #?(:cljs
    (deftest overlay-renders-nothing-when-no-hover
      (testing "active but no hover → no outline"
-       (inspector/set-active! true)
-       (is (nil? (inspector/overlay))))))
+       (rf.story.ui.element-inspector/set-active! true)
+       (is (nil? (rf.story.ui.element-inspector/overlay))))))
 
 #?(:cljs
    (deftest resolve-source-coord-pulls-file-from-handler-meta
@@ -169,13 +169,13 @@
          ;; Seed the always-on error-coord registry so the resolver finds
          ;; a :file even when handler-meta is unset (mirrors the
          ;; production-elided dev meta case).
-         (source-coords/remember-error-coords!
+         (rf.source-coords/remember-error-coords!
            :view view-id
            {:ns "rf.inspector-test" :file "src/sample.cljs"
             :line 12 :column 4})
-         (let [parsed   (inspector/parse-coord
+         (let [parsed   (rf.story.ui.element-inspector/parse-coord
                           "rf.inspector-test:sample-view:42:7")
-               resolved (inspector/resolve-source-coord parsed)]
+               resolved (rf.story.ui.element-inspector/resolve-source-coord parsed)]
            (is (= "src/sample.cljs" (:file resolved))
                ":file pulled from the error-coords registry fallback")
            (is (= 42 (:line resolved))
@@ -183,7 +183,7 @@
                 most-recent ground truth)")
            (is (= 7 (:column resolved))
                "DOM-side col beats meta-side col")
-           (source-coords/forget-error-coords!))))))
+           (rf.source-coords/forget-error-coords!))))))
 
 #?(:cljs
    (deftest resolve-source-coord-defaults-when-attr-degraded
@@ -191,24 +191,24 @@
                resolver falls through to meta-side line/col when both
                are present, else 1/1"
        (let [view-id :rf.inspector-test/degraded]
-         (source-coords/remember-error-coords!
+         (rf.source-coords/remember-error-coords!
            :view view-id
            {:ns "rf.inspector-test" :file "src/d.cljs"
             :line 99 :column 3})
-         (let [parsed   (inspector/parse-coord
+         (let [parsed   (rf.story.ui.element-inspector/parse-coord
                           "rf.inspector-test:degraded:?:?")
-               resolved (inspector/resolve-source-coord parsed)]
+               resolved (rf.story.ui.element-inspector/resolve-source-coord parsed)]
            (is (= 99 (:line resolved))
                "meta-side line fills in when DOM-side is nil")
            (is (= 3 (:column resolved))
                "meta-side column fills in when DOM-side is nil")
-           (source-coords/forget-error-coords!))))))
+           (rf.source-coords/forget-error-coords!))))))
 
 #?(:cljs
    (deftest overlay-renders-outline-and-tooltip-when-hovering
      (testing "active + hover snapshot present → outline + tooltip
                hiccup with the right test attrs"
-       (swap! inspector/state assoc
+       (swap! rf.story.ui.element-inspector/state assoc
               :active? true
               :hover {:coord-attr "counter.core:counter:47:11"
                       :handler-id :counter.core/counter
@@ -217,7 +217,7 @@
                                    :line 47 :col 11}
                       :rect       {:top 100 :left 200
                                    :width 300 :height 40}})
-       (let [root (inspector/overlay)]
+       (let [root (rf.story.ui.element-inspector/overlay)]
          (is (vector? root))
          (is (= :div (first root)))
          (is (= "story-element-inspector-overlay"

--- a/tools/story/test/re_frame/story/ui/events_only_first_render_frame_provider_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/events_only_first_render_frame_provider_dom_cljs_test.cljs
@@ -5,7 +5,7 @@
   ## The race
 
   `loading-phase?` DELIBERATELY suppresses the loading skeleton for
-  events-only variants (`loaders/events-only-variant?` — no `:loaders`,
+  events-only variants (`rf.story.loaders/events-only-variant?` — no `:loaders`,
   no `:loaders-complete-when`, no `:frame-setup` decorator), so
   `canvas-inner`'s first render falls straight through to
   `[rf/frame-provider {:frame variant-id} ...]`. That SCOPE-ONLY shape
@@ -40,35 +40,35 @@
             ["react-dom" :as react-dom]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as registrar]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.story :as story]
-            [re-frame.story.loaders :as loaders]
-            [re-frame.story.ui.canvas :as canvas]
-            [re-frame.story.ui.state :as state]
-            [re-frame.subs :as subs]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.story :as rf.story]
+            [re-frame.story.loaders :as rf.story.loaders]
+            [re-frame.story.ui.canvas :as rf.story.ui.canvas]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.subs :as rf.subs]))
 
 ;; ---- fixture --------------------------------------------------------------
 
 (defn- reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! reagent-adapter/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.adapter.reagent/adapter)
        (catch :default _ nil))
   ;; Re-register the framework `:rf/machine` sub after the registrar
   ;; clear (mirrors viewport_toggle_app_db_dom_cljs_test's reset-all!).
-  (subs/reg-runtime-sub :rf/machine
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [runtime-db [_ machine-id]]
       (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
-  (canvas/reset-first-rendered!))
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
+  (rf.story.ui.canvas/reset-first-rendered!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -107,7 +107,7 @@
           (fn [_]
             [:div {:data-test "eofr-probe"}
              (str "n=" @(rf/subscribe [:eofr/n]))]))
-        (story/reg-variant variant-id
+        (rf.story/reg-variant variant-id
           {:component :views/eofr-probe
            :setup    [[:eofr/seed 7]]})
         ;; Pre-select BEFORE mount — no selection-watcher pre-allocation
@@ -116,14 +116,14 @@
         ;; This is the exact condition #5265's comment names: "the SAME
         ;; synchronous render pass that first builds the vdom" reaches
         ;; frame-provider before component-did-mount ever runs.
-        (state/swap-state! state/select-variant variant-id)
+        (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant variant-id)
         (let [mount-node (make-mount-node!)
               root       (rdc/create-root mount-node)]
           (try
             (is (nil?
                   (try
                     (react-dom/flushSync
-                      (fn [] (rdc/render root [canvas/canvas])))
+                      (fn [] (rdc/render root [rf.story.ui.canvas/canvas])))
                     nil
                     (catch :default e e)))
                 "the first commit must NOT throw

--- a/tools/story/test/re_frame/story/ui/evidence_spine_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/evidence_spine_cljs_test.cljs
@@ -22,31 +22,31 @@
   directly and walking the hiccup with `re-frame.test-helpers`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.registrar        :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story            :as story]
-            [re-frame.test-helpers     :as th]
+            [re-frame.frame            :as rf.frame]
+            [re-frame.registrar        :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story            :as rf.story]
+            [re-frame.test-helpers     :as rf.test-helpers]
             [day8.re-frame2-xray.preload :as xray-preload]
             [day8.re-frame2-xray.registry :as xray-registry]
             [day8.re-frame2-xray.trace-collector :as xray-trace-collector]
-            [re-frame.story.ui.evidence-spine :as spine]
-            [re-frame.story.ui.state   :as state]
-            [re-frame.story.ui.test-mode.state :as test-state]))
+            [re-frame.story.ui.evidence-spine :as rf.story.ui.evidence-spine]
+            [re-frame.story.ui.state   :as rf.story.ui.state]
+            [re-frame.story.ui.test-mode.state :as rf.story.ui.test-mode.state]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch :default _ nil))
-  (state/reset-shell-state!)
-  (reset! test-state/results-atom {})
-  (reset! spine/selection-atom {})
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.story.ui.state/reset-shell-state!)
+  (reset! rf.story.ui.test-mode.state/results-atom {})
+  (reset! rf.story.ui.evidence-spine/selection-atom {})
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each {:before reset-all! :after reset-all!})
 
@@ -66,19 +66,19 @@
     :epochs []}])
 
 (defn- seed-result! [variant-id]
-  (swap! test-state/results-atom assoc variant-id
+  (swap! rf.story.ui.test-mode.state/results-atom assoc variant-id
          {:result {:status :pass :narrative narrative}}))
 
 (defn- reg-counter! []
-  (story/reg-story :story.evidence {:doc "Evidence probe"})
-  (story/reg-variant :story.evidence/basic {:tags #{:test}}))
+  (rf.story/reg-story :story.evidence {:doc "Evidence probe"})
+  (rf.story/reg-variant :story.evidence/basic {:tags #{:test}}))
 
 (defn- render-panel
   "Invoke the form-2 component's inner render fn. The panel reads
-  `state/shell-state-atom` + the Test-mode result slot, so seed selection
+  `rf.story.ui.state/shell-state-atom` + the Test-mode result slot, so seed selection
   + the result first."
   []
-  (let [render-fn (spine/evidence-spine-panel)]
+  (let [render-fn (rf.story.ui.evidence-spine/evidence-spine-panel)]
     (render-fn)))
 
 ;; ===========================================================================
@@ -88,37 +88,37 @@
 (deftest render-no-variant-shows-empty-state
   (testing "with no focused variant the spine renders the quiet empty state"
     (let [tree (render-panel)]
-      (is (some? (th/find-by-attr tree :data-test "story-evidence-no-variant")))
-      (is (nil? (th/find-by-attr tree :data-test "story-evidence-spine"))))))
+      (is (some? (rf.test-helpers/find-by-attr tree :data-test "story-evidence-no-variant")))
+      (is (nil? (rf.test-helpers/find-by-attr tree :data-test "story-evidence-spine"))))))
 
 (deftest render-no-evidence-shows-honest-empty
   (testing "a focused variant with NO retained run renders the honest
             'no evidence yet' line, not a fabricated spine"
     (reg-counter!)
-    (state/swap-state! state/select-variant :story.evidence/basic)
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.evidence/basic)
     (let [tree (render-panel)]
-      (is (some? (th/find-by-attr tree :data-test "story-evidence-spine")))
-      (is (some? (th/find-by-attr tree :data-test "story-evidence-empty")))
-      (is (nil? (th/find-by-attr tree :data-test "story-evidence-spans"))))))
+      (is (some? (rf.test-helpers/find-by-attr tree :data-test "story-evidence-spine")))
+      (is (some? (rf.test-helpers/find-by-attr tree :data-test "story-evidence-empty")))
+      (is (nil? (rf.test-helpers/find-by-attr tree :data-test "story-evidence-spans"))))))
 
 (deftest render-spine-shows-spans-beats-and-strength
   (testing "for a variant with a retained run the spine renders the spans,
             the decorated beats, evidence-strength tags, and summary chips"
     (reg-counter!)
-    (state/swap-state! state/select-variant :story.evidence/basic)
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.evidence/basic)
     (seed-result! :story.evidence/basic)
     (let [tree   (render-panel)
-          spans  (th/find-all-by-attr tree :data-test "story-evidence-span")
-          beats  (th/find-all-by-attr tree :data-test "story-evidence-beat")
-          str-tags (th/find-all-by-attr tree :data-test "story-evidence-strength")]
-      (is (some? (th/find-by-attr tree :data-test "story-evidence-spans")))
+          spans  (rf.test-helpers/find-all-by-attr tree :data-test "story-evidence-span")
+          beats  (rf.test-helpers/find-all-by-attr tree :data-test "story-evidence-beat")
+          str-tags (rf.test-helpers/find-all-by-attr tree :data-test "story-evidence-strength")]
+      (is (some? (rf.test-helpers/find-by-attr tree :data-test "story-evidence-spans")))
       (is (= 2 (count spans)) "one span per script step")
       (is (= 1 (count beats)) "one committed beat")
       ;; the settled beat carries both direct + attributed (db + sub-run)
       (is (some #(= "direct" (get (second %) :data-strength)) str-tags))
       (is (some #(= "attributed" (get (second %) :data-strength)) str-tags))
       ;; the non-dispatch assert span renders the 'committed no epoch' marker
-      (is (some? (th/find-by-attr tree :data-test "story-evidence-span-empty"))))))
+      (is (some? (rf.test-helpers/find-by-attr tree :data-test "story-evidence-span-empty"))))))
 
 ;; ===========================================================================
 ;; selection (spec/021 §2 — result row drives the selected span)
@@ -127,11 +127,11 @@
 (deftest select-beat-highlights-the-beat
   (testing "select-beat! marks the matching beat row data-selected=true"
     (reg-counter!)
-    (state/swap-state! state/select-variant :story.evidence/basic)
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.evidence/basic)
     (seed-result! :story.evidence/basic)
-    (spine/select-beat! :story.evidence/basic 0)
+    (rf.story.ui.evidence-spine/select-beat! :story.evidence/basic 0)
     (let [tree (render-panel)
-          beat (th/find-by-attr tree :data-test "story-evidence-beat")]
+          beat (rf.test-helpers/find-by-attr tree :data-test "story-evidence-beat")]
       (is (= "true" (get (second beat) :data-selected))))))
 
 ;; ---- rf2-2b3ael: per-row data-selected highlight (multi-beat) ----------
@@ -162,7 +162,7 @@
               :trace-events []}]}])
 
 (defn- seed-two-beat! [variant-id]
-  (swap! test-state/results-atom assoc variant-id
+  (swap! rf.story.ui.test-mode.state/results-atom assoc variant-id
          {:result {:status :pass :narrative two-beat-narrative}}))
 
 (deftest data-selected-true-on-producing-row-false-on-others
@@ -170,12 +170,12 @@
             and data-selected=false on every other beat row (rf2-2b3ael —
             the producing-row highlight contract)"
     (reg-counter!)
-    (state/swap-state! state/select-variant :story.evidence/basic)
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.evidence/basic)
     (seed-two-beat! :story.evidence/basic)
     ;; Select the FIRST beat (idx 0).
-    (spine/select-beat! :story.evidence/basic 0)
+    (rf.story.ui.evidence-spine/select-beat! :story.evidence/basic 0)
     (let [tree  (render-panel)
-          beats (th/find-all-by-attr tree :data-test "story-evidence-beat")
+          beats (rf.test-helpers/find-all-by-attr tree :data-test "story-evidence-beat")
           sel   (mapv #(get (second %) :data-selected) beats)]
       (is (= 2 (count beats)) "both committed beats render as rows")
       (is (= ["true" "false"] sel)
@@ -186,12 +186,12 @@
   (testing "re-selecting a different beat moves the data-selected=true marker
             to the newly-selected row (rf2-2b3ael — the scrub round-trip)"
     (reg-counter!)
-    (state/swap-state! state/select-variant :story.evidence/basic)
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.evidence/basic)
     (seed-two-beat! :story.evidence/basic)
     ;; Now select the SECOND beat (idx 1) — the highlight must move.
-    (spine/select-beat! :story.evidence/basic 1)
+    (rf.story.ui.evidence-spine/select-beat! :story.evidence/basic 1)
     (let [tree  (render-panel)
-          beats (th/find-all-by-attr tree :data-test "story-evidence-beat")
+          beats (rf.test-helpers/find-all-by-attr tree :data-test "story-evidence-beat")
           sel   (mapv #(get (second %) :data-selected) beats)]
       (is (= ["false" "true"] sel)
           (str "the highlight moved to the second row; got " (pr-str sel))))))
@@ -200,11 +200,11 @@
   (testing "with no beat selected every row carries data-selected=false —
             the scrub-on-load default (no producing row highlighted)"
     (reg-counter!)
-    (state/swap-state! state/select-variant :story.evidence/basic)
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.evidence/basic)
     (seed-two-beat! :story.evidence/basic)
     ;; selection-atom is reset by the fixture — no select-beat! call.
     (let [tree  (render-panel)
-          beats (th/find-all-by-attr tree :data-test "story-evidence-beat")
+          beats (rf.test-helpers/find-all-by-attr tree :data-test "story-evidence-beat")
           sel   (mapv #(get (second %) :data-selected) beats)]
       (is (= ["false" "false"] sel)
           (str "no row is highlighted before a scrub; got " (pr-str sel))))))
@@ -212,19 +212,19 @@
 (deftest row-to-beat-index-then-select
   (testing "a result row resolved to a beat index drives the spine selection
             (the spec/021 §2 linkage end to end)"
-    (let [idx (spine/row->beat-index narrative {:epoch-id 100})]
+    (let [idx (rf.story.ui.evidence-spine/row->beat-index narrative {:epoch-id 100})]
       (is (= 0 idx))
-      (spine/select-beat! :story.evidence/basic idx)
-      (is (= 0 (spine/selected-beat-idx :story.evidence/basic))))))
+      (rf.story.ui.evidence-spine/select-beat! :story.evidence/basic idx)
+      (is (= 0 (rf.story.ui.evidence-spine/selected-beat-idx :story.evidence/basic))))))
 
 (deftest open-flips-visibility-and-selects-beat
   (testing "open! flips the :evidence panel-visibility slot on and
             pre-selects the supplied beat (the Test-mode evidence-row +
             command-palette entry point)"
-    (state/swap-state! assoc-in [:panel-visibility spine/panel-key] false)
-    (spine/open! :story.evidence/basic 0)
-    (is (true? (get-in (state/get-state) [:panel-visibility spine/panel-key])))
-    (is (= 0 (spine/selected-beat-idx :story.evidence/basic)))))
+    (rf.story.ui.state/swap-state! assoc-in [:panel-visibility rf.story.ui.evidence-spine/panel-key] false)
+    (rf.story.ui.evidence-spine/open! :story.evidence/basic 0)
+    (is (true? (get-in (rf.story.ui.state/get-state) [:panel-visibility rf.story.ui.evidence-spine/panel-key])))
+    (is (= 0 (rf.story.ui.evidence-spine/selected-beat-idx :story.evidence/basic)))))
 
 ;; ===========================================================================
 ;; focus wiring (spec/020 §2.1 — links call the rf2-crtmq focus API)
@@ -234,10 +234,10 @@
   (testing "each beat renders 'open in Xray' focus links keyed to the
             host-facing focus-panel vocabulary"
     (reg-counter!)
-    (state/swap-state! state/select-variant :story.evidence/basic)
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.evidence/basic)
     (seed-result! :story.evidence/basic)
     (let [tree  (render-panel)
-          links (th/find-all-by-attr tree :data-test "story-evidence-focus-link")
+          links (rf.test-helpers/find-all-by-attr tree :data-test "story-evidence-focus-link")
           panels (into #{} (map #(get (second %) :data-panel)) links)]
       (is (seq links) "focus links present on the settled beat")
       (is (contains? panels "epoch"))
@@ -248,30 +248,30 @@
   (testing "a beat with an epoch-id marks its focus row data-precise=true and
             shows NO 'unavailable' note"
     (reg-counter!)
-    (state/swap-state! state/select-variant :story.evidence/basic)
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.evidence/basic)
     (seed-result! :story.evidence/basic)
     (let [tree (render-panel)
-          row  (th/find-by-attr tree :data-test "story-evidence-focus-row")]
+          row  (rf.test-helpers/find-by-attr tree :data-test "story-evidence-focus-row")]
       (is (= "true" (get (second row) :data-precise)))
-      (is (nil? (th/find-by-attr tree :data-test "story-evidence-focus-unavailable"))))))
+      (is (nil? (rf.test-helpers/find-by-attr tree :data-test "story-evidence-focus-unavailable"))))))
 
 (deftest no-coords-beat-shows-graceful-unavailable-note
   (testing "a beat with NO coordinates still renders the focus links (panel
             only) AND a note saying why precise focus is unavailable
             (spec/020 §3 graceful path)"
     (reg-counter!)
-    (state/swap-state! state/select-variant :story.evidence/basic)
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.evidence/basic)
     ;; A run whose single beat carries no :epoch-id / :dispatch-id.
-    (swap! test-state/results-atom assoc :story.evidence/basic
+    (swap! rf.story.ui.test-mode.state/results-atom assoc :story.evidence/basic
            {:result {:status :pass
                      :narrative [{:step [:dispatch [:x]]
                                   :epochs [{:db-after {:a 1} :trigger-event [:x]}]}]}})
     (let [tree (render-panel)
-          row  (th/find-by-attr tree :data-test "story-evidence-focus-row")
-          links (th/find-all-by-attr tree :data-test "story-evidence-focus-link")]
+          row  (rf.test-helpers/find-by-attr tree :data-test "story-evidence-focus-row")
+          links (rf.test-helpers/find-all-by-attr tree :data-test "story-evidence-focus-link")]
       (is (= "false" (get (second row) :data-precise)))
       (is (seq links) "panel-only links still offered")
-      (is (some? (th/find-by-attr tree :data-test "story-evidence-focus-unavailable"))
+      (is (some? (rf.test-helpers/find-by-attr tree :data-test "story-evidence-focus-unavailable"))
           "the why-unavailable note renders"))))
 
 (deftest focus-beat-drives-the-real-xray-focus-api
@@ -286,7 +286,7 @@
     (xray-registry/register-xray-handlers!)
     (rf/make-frame {:id :rf/xray})
     (let [beat   {:epoch-id 100 :dispatch-id 100 :beat-idx 3 :span-idx 1}
-          result (spine/focus-beat! :story.evidence/basic beat :app-db)]
+          result (rf.story.ui.evidence-spine/focus-beat! :story.evidence/basic beat :app-db)]
       (is (map? result))
       (is (true? (:ok? result)) "the focus command applied")
       (is (vector? (:applied result)))

--- a/tools/story/test/re_frame/story/ui/evidence_spine_test.cljc
+++ b/tools/story/test/re_frame/story/ui/evidence_spine_test.cljc
@@ -18,8 +18,8 @@
   ratom, the shell reachability) lives in `evidence_spine_cljs_test.cljs`;
   this corpus pins the pure projection only — no host, no Reagent, no Xray."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.play.evidence :as evidence]
-            [re-frame.story.ui.evidence-spine :as spine]))
+            [re-frame.story.play.evidence :as rf.story.play.evidence]
+            [re-frame.story.ui.evidence-spine :as rf.story.ui.evidence-spine]))
 
 ;; ---------------------------------------------------------------------------
 ;; A representative epoch tape — two dispatch steps, one non-dispatch (assert)
@@ -67,19 +67,19 @@
 (deftest evidence-strength-direct-and-attributed
   (testing "a settled dispatch with db/effects/trace reads as direct; with
             sub-runs/renders reads as attributed too"
-    (let [beat (first (evidence/narrative-beats
-                        (evidence/narrative script epoch-tape)))]
+    (let [beat (first (rf.story.play.evidence/narrative-beats
+                        (rf.story.play.evidence/narrative script epoch-tape)))]
       (is (= {:direct? true :attributed? true}
-             (spine/beat-evidence-strength beat)))))
+             (rf.story.ui.evidence-spine/beat-evidence-strength beat)))))
   (testing "a beat with only a db transition reads as direct, not attributed"
     (is (= {:direct? true :attributed? false}
-           (spine/beat-evidence-strength {:db-before {} :db-after {:a 1}}))))
+           (rf.story.ui.evidence-spine/beat-evidence-strength {:db-before {} :db-after {:a 1}}))))
   (testing "a beat with only sub-runs reads as attributed, not direct"
     (is (= {:direct? false :attributed? true}
-           (spine/beat-evidence-strength {:sub-runs [{:sub-id :x}]}))))
+           (rf.story.ui.evidence-spine/beat-evidence-strength {:sub-runs [{:sub-id :x}]}))))
   (testing "an empty beat reads as neither"
     (is (= {:direct? false :attributed? false}
-           (spine/beat-evidence-strength {})))))
+           (rf.story.ui.evidence-spine/beat-evidence-strength {})))))
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-v917m regression — the db-evidence marker must test for an ACTUAL
@@ -111,28 +111,28 @@
   (testing "a REAL epoch-beat-projected beat with equal db-before/db-after
             carries the keys (epoch-beat always materializes them) but is
             NOT direct db-evidence and emits NO `db Δ` chip (rf2-v917m)"
-    (let [beat (evidence/epoch-beat no-db-change-record)]
+    (let [beat (rf.story.play.evidence/epoch-beat no-db-change-record)]
       ;; the keys ARE present — proving the old contains? test would mis-fire
       (is (contains? beat :db-before))
       (is (contains? beat :db-after))
       (is (= (:db-before beat) (:db-after beat)) "no transition occurred")
       ;; ...yet strength must report no direct evidence (no effects/trace either)
       (is (= {:direct? false :attributed? false}
-             (spine/beat-evidence-strength beat)))
+             (rf.story.ui.evidence-spine/beat-evidence-strength beat)))
       ;; ...and the summary must carry NO db marker
-      (let [by-k (into {} (map (juxt :k :count)) (spine/beat-summary beat))]
+      (let [by-k (into {} (map (juxt :k :count)) (rf.story.ui.evidence-spine/beat-summary beat))]
         (is (nil? (:db by-k)) "no `db Δ` chip when db did not change"))))
   (testing "a REAL epoch-beat-projected beat WITH a db transition is direct
             db-evidence and emits the `db Δ` chip (rf2-v917m)"
-    (let [beat (evidence/epoch-beat
+    (let [beat (rf.story.play.evidence/epoch-beat
                 (assoc no-db-change-record :db-after {:count 7}))]
-      (is (:direct? (spine/beat-evidence-strength beat)))
-      (let [by-k (into {} (map (juxt :k :count)) (spine/beat-summary beat))]
+      (is (:direct? (rf.story.ui.evidence-spine/beat-evidence-strength beat)))
+      (let [by-k (into {} (map (juxt :k :count)) (rf.story.ui.evidence-spine/beat-summary beat))]
         (is (= 1 (:db by-k)) "`db Δ` chip present when db changed"))))
   (testing "absent db keys (an older beat) read as no transition, robustly"
     (is (= {:direct? false :attributed? false}
-           (spine/beat-evidence-strength {})))
-    (is (nil? (-> (spine/beat-summary {})
+           (rf.story.ui.evidence-spine/beat-evidence-strength {})))
+    (is (nil? (-> (rf.story.ui.evidence-spine/beat-summary {})
                   (->> (into {} (map (juxt :k :count))))
                   :db)))))
 
@@ -149,7 +149,7 @@
                                {:operation :rf.fx/run}]
                 :sub-runs [{:sub-id :x}]
                 :renders []}
-          summary (spine/beat-summary beat)
+          summary (rf.story.ui.evidence-spine/beat-summary beat)
           by-k    (into {} (map (juxt :k :count)) summary)]
       (is (= 1 (:db by-k)))
       (is (= 1 (:effects by-k)))
@@ -158,7 +158,7 @@
       (is (= 1 (:sub-runs by-k)))
       (is (nil? (:renders by-k)) "zero-count renders slot omitted")))
   (testing "attributed slots carry :attributed strength; direct slots :direct"
-    (let [summary (spine/beat-summary {:db-after {:a 1} :sub-runs [{:sub-id :x}]})
+    (let [summary (rf.story.ui.evidence-spine/beat-summary {:db-after {:a 1} :sub-runs [{:sub-id :x}]})
           by-k    (into {} (map (juxt :k :strength)) summary)]
       (is (= :direct (:db by-k)))
       (is (= :attributed (:sub-runs by-k))))))
@@ -169,21 +169,21 @@
 
 (deftest span-kind-distinguishes-dispatch-non-dispatch-setup
   (testing "a dispatch step span is :dispatch"
-    (is (= :dispatch (spine/span-kind {:step [:dispatch [:e]] :epochs []}))))
+    (is (= :dispatch (rf.story.ui.evidence-spine/span-kind {:step [:dispatch [:e]] :epochs []}))))
   (testing "a non-dispatch step span (assert / wait) is :non-dispatch"
-    (is (= :non-dispatch (spine/span-kind {:step [:assert [:rf.assert/path-equals [:c] 1]] :epochs []})))
-    (is (= :non-dispatch (spine/span-kind {:step [:wait-until [:fn]] :epochs []}))))
+    (is (= :non-dispatch (rf.story.ui.evidence-spine/span-kind {:step [:assert [:rf.assert/path-equals [:c] 1]] :epochs []})))
+    (is (= :non-dispatch (rf.story.ui.evidence-spine/span-kind {:step [:wait-until [:fn]] :epochs []}))))
   (testing "the leading nil-step span is :setup"
-    (is (= :setup (spine/span-kind {:step nil :epochs []})))))
+    (is (= :setup (rf.story.ui.evidence-spine/span-kind {:step nil :epochs []})))))
 
 (deftest step-label-renders-compact-labels
   (testing "a dispatch step shows its event-id"
-    (is (= ":counter/inc" (spine/step-label [:dispatch [:counter/inc]]))))
+    (is (= ":counter/inc" (rf.story.ui.evidence-spine/step-label [:dispatch [:counter/inc]]))))
   (testing "a non-dispatch step shows its head tag"
-    (is (= ":assert" (spine/step-label [:assert [:rf.assert/path-equals [:c] 1]])))
-    (is (= ":wait-until" (spine/step-label [:wait-until [:fn]]))))
+    (is (= ":assert" (rf.story.ui.evidence-spine/step-label [:assert [:rf.assert/path-equals [:c] 1]])))
+    (is (= ":wait-until" (rf.story.ui.evidence-spine/step-label [:wait-until [:fn]]))))
   (testing "the nil-step span reads 'setup'"
-    (is (= "setup" (spine/step-label nil)))))
+    (is (= "setup" (rf.story.ui.evidence-spine/step-label nil)))))
 
 ;; ===========================================================================
 ;; focus-command construction  (spec/020 §2.1)
@@ -191,8 +191,8 @@
 
 (deftest build-focus-command-shape
   (testing "a beat with an epoch-id pins the epoch + carries opaque source"
-    (let [src (spine/focus-source :story/evidence-beat :story.cp/basic {:beat-idx 0 :span-idx 1})
-          cmd (spine/build-focus-command :app-db {:epoch-id 42 :dispatch-id 7} src [:checkout :state])]
+    (let [src (rf.story.ui.evidence-spine/focus-source :story/evidence-beat :story.cp/basic {:beat-idx 0 :span-idx 1})
+          cmd (rf.story.ui.evidence-spine/build-focus-command :app-db {:epoch-id 42 :dispatch-id 7} src [:checkout :state])]
       (is (= :app-db (:panel cmd)))
       (is (= 42 (:epoch-id cmd)))
       (is (= 7 (:dispatch-id cmd)))
@@ -200,23 +200,23 @@
       (is (= :story/evidence-beat (:kind (:source cmd))))
       (is (= :story.cp/basic (:variant/id (:source cmd))))))
   (testing "an empty-coords command is a well-formed panel-only focus"
-    (let [cmd (spine/build-focus-command :trace {} {:kind :x})]
+    (let [cmd (rf.story.ui.evidence-spine/build-focus-command :trace {} {:kind :x})]
       (is (= :trace (:panel cmd)))
       (is (not (contains? cmd :epoch-id)))
       (is (not (contains? cmd :dispatch-id)))
       (is (not (contains? cmd :path)))))
   (testing "an unknown panel falls back to the default rather than landing
             the unknown-tab stub"
-    (is (= spine/default-focus-panel
-           (:panel (spine/build-focus-command :app-bd {} {:kind :x}))))
-    (is (contains? spine/focus-panels (:panel (spine/build-focus-command :app-bd {} {:kind :x}))))))
+    (is (= rf.story.ui.evidence-spine/default-focus-panel
+           (:panel (rf.story.ui.evidence-spine/build-focus-command :app-bd {} {:kind :x}))))
+    (is (contains? rf.story.ui.evidence-spine/focus-panels (:panel (rf.story.ui.evidence-spine/build-focus-command :app-bd {} {:kind :x}))))))
 
 (deftest focus-source-threads-only-present-coords
   (testing "focus-source carries kind + variant always; the rest cond->"
     (is (= {:kind :story/assertion :variant/id :v}
-           (spine/focus-source :story/assertion :v {})))
+           (rf.story.ui.evidence-spine/focus-source :story/assertion :v {})))
     (is (= {:kind :story/assertion :variant/id :v :assertion/id :rf.assert/path-equals}
-           (spine/focus-source :story/assertion :v {:assertion-id :rf.assert/path-equals})))))
+           (rf.story.ui.evidence-spine/focus-source :story/assertion :v {:assertion-id :rf.assert/path-equals})))))
 
 ;; ===========================================================================
 ;; focus availability  (spec/020 §3 — graceful no-coords path)
@@ -224,12 +224,12 @@
 
 (deftest focus-availability-precise-vs-graceful
   (testing "a beat with an epoch-id focuses precisely"
-    (is (:precise? (spine/focus-availability {:epoch-id 42}))))
+    (is (:precise? (rf.story.ui.evidence-spine/focus-availability {:epoch-id 42}))))
   (testing "a beat with a dispatch-id focuses precisely"
-    (is (:precise? (spine/focus-availability {:dispatch-id 7}))))
+    (is (:precise? (rf.story.ui.evidence-spine/focus-availability {:dispatch-id 7}))))
   (testing "a beat with no coordinates is NOT precise but carries a reason
             (the graceful no-coords path — still opens the panel)"
-    (let [{:keys [precise? reason]} (spine/focus-availability {})]
+    (let [{:keys [precise? reason]} (rf.story.ui.evidence-spine/focus-availability {})]
       (is (false? precise?))
       (is (string? reason))
       (is (re-find #"no epoch" reason)))))
@@ -239,8 +239,8 @@
 ;; ===========================================================================
 
 (deftest spine-spans-projects-spans-and-decorated-beats
-  (let [narrative (evidence/narrative script epoch-tape)
-        spans     (spine/spine-spans narrative)]
+  (let [narrative (rf.story.play.evidence/narrative script epoch-tape)
+        spans     (rf.story.ui.evidence-spine/spine-spans narrative)]
     (testing "one span per script step, in order"
       (is (= 3 (count spans)))
       (is (= [":counter/inc" ":counter/add" ":assert"] (mapv :label spans)))
@@ -260,25 +260,25 @@
 
 (deftest spine-spans-empty-narrative
   (testing "an empty / nil narrative projects to no spans (graceful)"
-    (is (= [] (spine/spine-spans nil)))
-    (is (= [] (spine/spine-spans [])))))
+    (is (= [] (rf.story.ui.evidence-spine/spine-spans nil)))
+    (is (= [] (rf.story.ui.evidence-spine/spine-spans [])))))
 
 ;; ===========================================================================
 ;; result-row → beat linkage  (spec/021 §2)
 ;; ===========================================================================
 
 (deftest row-to-beat-index-linkage
-  (let [narrative (evidence/narrative script epoch-tape)]
+  (let [narrative (rf.story.play.evidence/narrative script epoch-tape)]
     (testing "a schema violation keyed on :epoch-id resolves to its beat"
-      (is (= 0 (spine/row->beat-index narrative {:epoch-id 100 :selector [:event :counter/inc]})))
-      (is (= 1 (spine/row->beat-index narrative {:epoch-id 101}))))
+      (is (= 0 (rf.story.ui.evidence-spine/row->beat-index narrative {:epoch-id 100 :selector [:event :counter/inc]})))
+      (is (= 1 (rf.story.ui.evidence-spine/row->beat-index narrative {:epoch-id 101}))))
     (testing "an assertion record keyed on :dispatch-id resolves to the
               cascade's first beat"
-      (is (= 0 (spine/row->beat-index narrative {:dispatch-id 100 :assertion :rf.assert/path-equals})))
-      (is (= 1 (spine/row->beat-index narrative {:dispatch-id 101}))))
+      (is (= 0 (rf.story.ui.evidence-spine/row->beat-index narrative {:dispatch-id 100 :assertion :rf.assert/path-equals})))
+      (is (= 1 (rf.story.ui.evidence-spine/row->beat-index narrative {:dispatch-id 101}))))
     (testing "a row with no resolvable coordinate yields nil (graceful)"
-      (is (nil? (spine/row->beat-index narrative {:assertion :rf.assert/no-warnings})))
-      (is (nil? (spine/row->beat-index narrative {:epoch-id 999}))))))
+      (is (nil? (rf.story.ui.evidence-spine/row->beat-index narrative {:assertion :rf.assert/no-warnings})))
+      (is (nil? (rf.story.ui.evidence-spine/row->beat-index narrative {:epoch-id 999}))))))
 
 ;; ===========================================================================
 ;; the focus-panel vocabulary matches the host-facing API
@@ -289,4 +289,4 @@
             valid-panels (uses :routes / :views, NOT the embed's :routing).
             rf2-gbz39 dropped :issues with the Xray Issues tab (Option (c))."
     (is (= #{:epoch :app-db :views :trace :machines :routes}
-           spine/focus-panels))))
+           rf.story.ui.evidence-spine/focus-panels))))

--- a/tools/story/test/re_frame/story/ui/explain_panel_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/explain_panel_cljs_test.cljs
@@ -8,7 +8,7 @@
 
   - **command-palette reachability** — the synthetic `Explain variant`
     command appears in the palette corpus, ranks for an `explain`
-    query, and `select-entry!` runs `explain-panel/open!` which flips
+    query, and `select-entry!` runs `rf.story.ui.explain-panel/open!` which flips
     the `:explain` panel-visibility slot on. This is the bead's
     'reachable from the command palette' acceptance.
 
@@ -28,27 +28,27 @@
   render fn directly and walking the hiccup with `re-frame.test-helpers`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.registrar        :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story            :as story]
-            [re-frame.test-helpers     :as th]
-            [re-frame.story.ui.command-palette :as palette]
-            [re-frame.story.ui.command-palette.view :as palette-view]
-            [re-frame.story.ui.explain-panel :as explain-panel]
-            [re-frame.story.ui.state   :as state]))
+            [re-frame.frame            :as rf.frame]
+            [re-frame.registrar        :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story            :as rf.story]
+            [re-frame.test-helpers     :as rf.test-helpers]
+            [re-frame.story.ui.command-palette :as rf.story.ui.command-palette]
+            [re-frame.story.ui.command-palette.view :as rf.story.ui.command-palette.view]
+            [re-frame.story.ui.explain-panel :as rf.story.ui.explain-panel]
+            [re-frame.story.ui.state   :as rf.story.ui.state]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch :default _ nil))
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each {:before reset-all! :after reset-all!})
 
@@ -56,8 +56,8 @@
   ;; A minimal registered story + variant so the plan compiler resolves
   ;; the keyword target to a real plan. No `:component` needed — the
   ;; view-args-schema slot is simply absent (rendered 'not available').
-  (story/reg-story :story.explain {:doc "Explain probe"})
-  (story/reg-variant :story.explain/basic
+  (rf.story/reg-story :story.explain {:doc "Explain probe"})
+  (rf.story/reg-variant :story.explain/basic
                      {:args {:label "Hi"}
                       :tags #{:test}}))
 
@@ -67,7 +67,7 @@
 
 (deftest command-entry-present-in-corpus
   (testing "the synthetic Explain command is built into the palette corpus"
-    (let [entries  (palette/entries (state/registry-snapshot))
+    (let [entries  (rf.story.ui.command-palette/entries (rf.story.ui.state/registry-snapshot))
           commands (filterv #(= :command (:kind %)) entries)
           explain  (first (filter #(= :explain (:id %)) commands))]
       ;; rf2-ba86n.6 added the :save-current-as-variant command, so the
@@ -79,8 +79,8 @@
 (deftest command-entry-ranks-for-explain-query
   (testing "an `explain` query surfaces the command at the top of results"
     (reg-counter!)
-    (let [entries (palette/entries (state/registry-snapshot))
-          results (palette/search entries "explain")
+    (let [entries (rf.story.ui.command-palette/entries (rf.story.ui.state/registry-snapshot))
+          results (rf.story.ui.command-palette/search entries "explain")
           top     (first results)]
       (is (= :command (:kind top)))
       (is (= :explain (:id top))))))
@@ -89,15 +89,15 @@
   (testing "selecting the Explain command flips :panel-visibility :explain on"
     (reg-counter!)
     ;; Start hidden so the open! flip is observable.
-    (state/swap-state! assoc-in [:panel-visibility explain-panel/panel-key] false)
-    (is (false? (get-in (state/get-state) [:panel-visibility explain-panel/panel-key])))
-    (let [entry (->> (palette/entries (state/registry-snapshot))
+    (rf.story.ui.state/swap-state! assoc-in [:panel-visibility rf.story.ui.explain-panel/panel-key] false)
+    (is (false? (get-in (rf.story.ui.state/get-state) [:panel-visibility rf.story.ui.explain-panel/panel-key])))
+    (let [entry (->> (rf.story.ui.command-palette/entries (rf.story.ui.state/registry-snapshot))
                      (filter #(= :command (:kind %)))
                      first)
-          handled (palette-view/select-entry! entry)]
+          handled (rf.story.ui.command-palette.view/select-entry! entry)]
       (is (true? handled) "command selection reports handled")
-      (is (true? (get-in (state/get-state)
-                         [:panel-visibility explain-panel/panel-key]))
+      (is (true? (get-in (rf.story.ui.state/get-state)
+                         [:panel-visibility rf.story.ui.explain-panel/panel-key]))
           "open! turned the Explain panel-visibility slot on"))))
 
 ;; ===========================================================================
@@ -106,40 +106,40 @@
 
 (defn- render-panel
   "Invoke the form-2 component's inner render fn (the panel reads
-  `state/shell-state-atom`, so seed selection first)."
+  `rf.story.ui.state/shell-state-atom`, so seed selection first)."
   []
-  (let [render-fn (explain-panel/explain-panel)]
+  (let [render-fn (rf.story.ui.explain-panel/explain-panel)]
     (render-fn)))
 
 (deftest render-no-variant-shows-empty-state
   (testing "with no focused variant the panel renders the quiet empty state"
     (let [tree (render-panel)]
-      (is (some? (th/find-by-attr tree :data-test "story-explain-no-variant")))
-      (is (nil? (th/find-by-attr tree :data-test "story-explain-panel"))))))
+      (is (some? (rf.test-helpers/find-by-attr tree :data-test "story-explain-no-variant")))
+      (is (nil? (rf.test-helpers/find-by-attr tree :data-test "story-explain-panel"))))))
 
 (deftest render-with-variant-shows-section-inventory
   (testing "for a registered variant the panel renders every spec section
             plus the raw-EDN / copy toolbar"
     (reg-counter!)
-    (state/swap-state! state/select-variant :story.explain/basic)
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.explain/basic)
     (let [tree     (render-panel)
-          sections (th/find-all-by-attr tree :data-test "story-explain-section")
+          sections (rf.test-helpers/find-all-by-attr tree :data-test "story-explain-section")
           present  (mapv #(get (second %) :data-present) sections)]
-      (is (some? (th/find-by-attr tree :data-test "story-explain-panel")))
-      (is (= (count (explain-panel/explain-sections {})) (count sections))
+      (is (some? (rf.test-helpers/find-by-attr tree :data-test "story-explain-panel")))
+      (is (= (count (rf.story.ui.explain-panel/explain-sections {})) (count sections))
           "one section node per spec slot")
       (is (some #(= "true" %) present)
           "at least one slot is present (source-chain always is)")
-      (is (some? (th/find-by-attr tree :data-test "story-explain-toggle-raw"))
+      (is (some? (rf.test-helpers/find-by-attr tree :data-test "story-explain-toggle-raw"))
           "raw-EDN toggle present")
-      (is (some? (th/find-by-attr tree :data-test "story-explain-copy"))
+      (is (some? (rf.test-helpers/find-by-attr tree :data-test "story-explain-copy"))
           "copy-to-clipboard button present"))))
 
 (deftest render-error-shows-structured-error
   (testing "an unknown variant target surfaces the compile error, not a blank"
-    (state/swap-state! state/select-variant :story.explain/does-not-exist)
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.explain/does-not-exist)
     (let [tree (render-panel)]
-      (is (some? (th/find-by-attr tree :data-test "story-explain-error"))
+      (is (some? (rf.test-helpers/find-by-attr tree :data-test "story-explain-error"))
           "compile error rendered")
-      (is (nil? (th/find-by-attr tree :data-test "story-explain-sections"))
+      (is (nil? (rf.test-helpers/find-by-attr tree :data-test "story-explain-sections"))
           "no section inventory when the plan failed to compile"))))

--- a/tools/story/test/re_frame/story/ui/explain_panel_test.cljc
+++ b/tools/story/test/re_frame/story/ui/explain_panel_test.cljc
@@ -20,7 +20,7 @@
             [clojure.string :as str]
             #?(:clj  [clojure.edn :as edn]
                :cljs [cljs.reader :as edn])
-            [re-frame.story.ui.explain-panel :as explain]))
+            [re-frame.story.ui.explain-panel :as rf.story.ui.explain-panel]))
 
 ;; ---------------------------------------------------------------------------
 ;; A representative explain map. Mirrors the slot shape the plan compiler
@@ -82,9 +82,9 @@
             §Explain API slot, in the provenance → composition → args →
             lowering → execution → metadata order"
     (is (= expected-section-ids
-           (mapv :id (explain/explain-sections full-explain)))))
+           (mapv :id (rf.story.ui.explain-panel/explain-sections full-explain)))))
   (testing "every section carries the descriptor slots the renderer reads"
-    (doseq [s (explain/explain-sections full-explain)]
+    (doseq [s (rf.story.ui.explain-panel/explain-sections full-explain)]
       (is (some? (:id s)))
       (is (some? (:label s)))
       (is (keyword? (:render-as s)))
@@ -94,7 +94,7 @@
 (deftest full-explain-marks-populated-slots-present
   (testing "with a fully-featured plan every section is present? true"
     (let [by-id (into {} (map (juxt :id identity)
-                              (explain/explain-sections full-explain)))]
+                              (rf.story.ui.explain-panel/explain-sections full-explain)))]
       (doseq [id expected-section-ids]
         (is (true? (boolean (:present? (get by-id id))))
             (str id " should be present in a fully-featured explain map"))))))
@@ -102,7 +102,7 @@
 (deftest empty-explain-marks-optional-slots-absent
   (testing "an empty explain map renders the full inventory, with the
             optional slots marked not-available (never dropped)"
-    (let [sections (explain/explain-sections {})
+    (let [sections (rf.story.ui.explain-panel/explain-sections {})
           by-id    (into {} (map (juxt :id identity) sections))]
       (is (= expected-section-ids (mapv :id sections))
           "the inventory is the same — absent slots are NOT dropped")
@@ -114,20 +114,20 @@
 
 (deftest nil-explain-is-safe
   (testing "nil explain projects the same inventory, all absent — no throw"
-    (let [sections (explain/explain-sections nil)]
+    (let [sections (rf.story.ui.explain-panel/explain-sections nil)]
       (is (= expected-section-ids (mapv :id sections)))
       (is (every? (complement :present?) sections)))))
 
 (deftest network-and-sub-override-slots-carry-lowering
   (testing "the network section value carries routes + the managed-stub lowering"
-    (let [net (->> (explain/explain-sections full-explain)
+    (let [net (->> (rf.story.ui.explain-panel/explain-sections full-explain)
                    (filter #(= "network" (:id %)))
                    first)]
       (is (= :network (:render-as net)))
       (is (= {:rf.http/managed :rf.http/managed-test-stub}
              (get-in net [:value :lowered-to])))))
   (testing "the sub-override section value carries overrides + validation"
-    (let [so (->> (explain/explain-sections full-explain)
+    (let [so (->> (rf.story.ui.explain-panel/explain-sections full-explain)
                   (filter #(= "sub-overrides" (:id %)))
                   first)]
       (is (= :sub-ovr (:render-as so)))
@@ -140,14 +140,14 @@
 
 (deftest explain-for-traps-unknown-variant
   (testing "an unregistered keyword target surfaces as :error, not a throw"
-    (let [result (explain/explain-for :story.nope/missing)]
+    (let [result (rf.story.ui.explain-panel/explain-for :story.nope/missing)]
       (is (nil? (:explain result)))
       (is (string? (:error result)))
       (is (not (str/blank? (:error result)))))))
 
 (deftest explain-for-compiles-inline-plan
   (testing "an inline plan map compiles to an :explain map (no host needed)"
-    (let [result (explain/explain-for {:variant/id :inline/x})]
+    (let [result (rf.story.ui.explain-panel/explain-for {:variant/id :inline/x})]
       (is (nil? (:error result))
           (str "expected clean compile, got: " (:error result)))
       (is (map? (:explain result)))
@@ -160,13 +160,13 @@
 
 (deftest chain-label-joins-with-arrows
   (is (= ":story.cp/base  →  :story.cp/child"
-         (explain/chain-label [:story.cp/base :story.cp/child])))
+         (rf.story.ui.explain-panel/chain-label [:story.cp/base :story.cp/child])))
   (testing "empty chain → empty string (caller renders the empty state)"
-    (is (= "" (explain/chain-label [])))
-    (is (= "" (explain/chain-label nil)))))
+    (is (= "" (rf.story.ui.explain-panel/chain-label [])))
+    (is (= "" (rf.story.ui.explain-panel/chain-label nil)))))
 
 (deftest conflict-summary-names-winner-and-losers
-  (let [s (explain/conflict-summary
+  (let [s (rf.story.ui.explain-panel/conflict-summary
             (first (:strict-conflicts full-explain)))]
     (is (str/includes? s ":variant wins"))
     (is (str/includes? s ":frag/auth")
@@ -175,6 +175,6 @@
 
 (deftest raw-edn-roundtrips
   (testing "raw-edn produces a parseable EDN string of the explain map"
-    (let [s (explain/raw-edn full-explain)]
+    (let [s (rf.story.ui.explain-panel/raw-edn full-explain)]
       (is (string? s))
       (is (= full-explain (edn/read-string s))))))

--- a/tools/story/test/re_frame/story/ui/hicasso_substrate_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/hicasso_substrate_dom_cljs_test.cljs
@@ -5,18 +5,18 @@
   ## The spike this file was written to settle
 
   rf2-5czki's survey found that Hicasso needs no new plumbing to paint in
-  Story's canvas — `h/as-element` mints a React element from a boundary
+  Story's canvas — `rf.hicasso/as-element` mints a React element from a boundary
   head, and the canvas already wraps the subject in
   `[rf/frame-provider {:frame variant-id} …]`, whose provider is the one
   React context every React-shaped adapter reads. But it also found that
-  NOTHING IN THE REPOSITORY WITNESSED THAT CROSSING: every `h/as-component`
-  / `h/as-element` boundary crossing had a Hicasso, native or UIx parent,
+  NOTHING IN THE REPOSITORY WITNESSED THAT CROSSING: every `rf.hicasso/as-component`
+  / `rf.hicasso/as-element` boundary crossing had a Hicasso, native or UIx parent,
   and Reagent was not among them. The ruling named it the one material
   uncertainty and made proving it a precondition of the registration.
 
   This namespace is that proof, and then the registration's own coverage.
   `crossing-paints-under-a-reagent-parent` is the spike stated as a row:
-  a `h/defview` boundary, spliced into a REAGENT hiccup tree under
+  a `rf.hicasso/defview` boundary, spliced into a REAGENT hiccup tree under
   `rf/frame-provider`, mounted through `reagent.dom.client` into a real
   DOM, painting its own markup and reading a subscription from the frame
   the Reagent provider scoped.
@@ -29,7 +29,7 @@
   [[hicasso-render]] below is therefore the CONSUMER's five lines, and it
   is byte-for-byte the recipe written out in
   `re-frame.story.ui.multi-substrate`'s ns docstring. It is registered
-  here through the public `story/register-substrate!` — no private seam,
+  here through the public `rf.story/register-substrate!` — no private seam,
   no stub.
 
   Three decisions ride in those five lines, all ruled on rf2-2dbpd:
@@ -39,8 +39,8 @@
     the same id) reaches the story with no story change;
   - **read `:hicasso/component`**, because the alias entry deliberately
     carries no `:handler-fn` and `rf/view` answers nil for it (rf2-5qaf4);
-  - **mint the element directly** with `h/as-element` rather than bridging
-    through `h/as-component`. `element-type-is-stable-across-renders` is
+  - **mint the element directly** with `rf.hicasso/as-element` rather than bridging
+    through `rf.hicasso/as-component`. `element-type-is-stable-across-renders` is
     the evidence: `defview` already mints ONE `React.memo` wrapper per
     head at definition time, so a fresh element per pass rides a stable
     type and the boundary re-renders instead of remounting. A memoized
@@ -61,14 +61,14 @@
   second that carried the defect: `:story.hicasso/card`'s cell is still
   in Hicasso's table when the row below it runs (this file's fixture
   clears the registrar and re-registers `::counter`, which is a FIRST
-  registration and invalidates that cell), while the `h/mount!` control
+  registration and invalidates that cell), while the `rf.hicasso/mount!` control
   named a frame no other row uses and so mounted against a clean table.
   `impl.collector/acquire-cell!` reused the invalidated cell without
   rebuilding its attachment, so the boundary got the right value from the
   cold probe and no watch to be notified through.
 
   The repair is in the acquire, and the witness that pins it — with the
-  crossing held OUT of the row, under `h/mount!`, where the same
+  crossing held OUT of the row, under `rf.hicasso/mount!`, where the same
   deafness reproduces — is
   `re-frame.hicasso.foreign-root-bridge-dom-cljs-test`. That file also
   drives five mounting routes, a UIx `defui` parent among them, and every
@@ -91,19 +91,19 @@
             ["react-dom" :as react-dom]
             [reagent.core :as r]
             [reagent.dom.client :as rdc]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso :as h]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as rf-registrar]
-            [re-frame.story :as story]
-            [re-frame.story.loaders :as loaders]
-            [re-frame.story.ui.canvas :as canvas]
-            [re-frame.story.ui.multi-substrate :as multi-substrate]
-            [re-frame.story.ui.state :as state]
-            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
-            [re-frame.subs :as subs]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.machines :as rf.machines]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.story :as rf.story]
+            [re-frame.story.loaders :as rf.story.loaders]
+            [re-frame.story.ui.canvas :as rf.story.ui.canvas]
+            [re-frame.story.ui.multi-substrate :as rf.story.ui.multi-substrate]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]
+            [re-frame.subs :as rf.subs]))
 
 ;; ---------------------------------------------------------------------------
 ;; The subject — ordinary Hicasso views, declared at namespace load
@@ -119,15 +119,15 @@
 
 (defonce ^:private !card-runs (atom 0))
 
-(h/defview hicasso-card
+(rf.hicasso/defview hicasso-card
   "An ordinary boundary. It reads a subscription, so the frame it resolved
   is observable on screen rather than only in a cell table."
   [props]
   (swap! !card-runs inc)
   [:article {:class "hic-card" :data-test "hicasso-card"}
-   (str (:label props) "/" (h/sub [::counter]))])
+   (str (:label props) "/" (rf.hicasso/sub [::counter]))])
 
-(h/defview hicasso-panel
+(rf.hicasso/defview hicasso-panel
   "A SECOND boundary, so a row can tell one hicasso view from another
   rather than merely from Reagent."
   [props]
@@ -138,14 +138,14 @@
 
 (def ^:private bridged-card
   "THE OTHER BRIDGE DOOR, minted once at top level — the law, because
-  `h/as-component` allocates a component and minting one inside a render
+  `rf.hicasso/as-component` allocates a component and minting one inside a render
   would hand React a fresh element type every pass. Memoized on the head
   the way rf2-phabt's route 3 spells it, so the two returned rows differ
   by the DOOR and by nothing else."
-  (react/memo (h/as-component hicasso-card)))
+  (react/memo (rf.hicasso/as-component hicasso-card)))
 
 (def ^:private alias-entries
-  "The registrar entries `h/defview` published at NAMESPACE LOAD, captured
+  "The registrar entries `rf.hicasso/defview` published at NAMESPACE LOAD, captured
   before any fixture can clear them. `reset-all!` folds them back.
 
   Snapshotting the WHOLE entry rather than re-deriving it keeps this
@@ -164,7 +164,7 @@
   exactly as `multi-substrate`'s ns docstring writes it out)."
   [_variant-id view-id args]
   (if-let [head (:hicasso/component (rf/handler-meta :view view-id))]
-    (h/as-element [head args])
+    (rf.hicasso/as-element [head args])
     [:div (str ":component " (pr-str view-id)
                " is not registered as a hicasso view")]))
 
@@ -173,37 +173,37 @@
 (declare register-probes!)
 
 (defn- reset-all! []
-  (story/clear-all!)
-  (rf-registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! reagent-adapter/adapter) (catch :default _ nil))
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.adapter.reagent/adapter) (catch :default _ nil))
   ;; The framework `:rf/machine` sub, re-registered after the clear — the
   ;; lifecycle machine cannot resolve without it and the canvas parks at
   ;; `:pre-mount` forever.
-  (subs/reg-runtime-sub :rf/machine
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [runtime-db [_ machine-id]]
       (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (canvas/reset-first-rendered!)
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.ui.canvas/reset-first-rendered!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   ;; Fold the load-time aliases back over the cleared registrar.
   (doseq [[id entry] alias-entries]
-    (rf-registrar/register! :view id entry))
+    (rf.registrar/register! :view id entry))
   ;; Start every case from a KNOWN-EMPTY `:hicasso` slot: the degradation
   ;; row wants it absent, every other row registers it.
-  (multi-substrate/unregister-substrate! :hicasso)
+  (rf.story.ui.multi-substrate/unregister-substrate! :hicasso)
   (reset! !card-runs 0)
   (register-probes!))
 
 (defn- restore-registry!
-  "`substrate->render-fn` is a `defonce` atom that `story/clear-all!` does
+  "`substrate->render-fn` is a `defonce` atom that `rf.story/clear-all!` does
   not touch, so a `:hicasso` entry left here would leak into every
   namespace that runs after this one."
   []
-  (multi-substrate/unregister-substrate! :hicasso))
+  (rf.story.ui.multi-substrate/unregister-substrate! :hicasso))
 
 (use-fixtures :each {:before reset-all! :after restore-registry!})
 
@@ -222,20 +222,20 @@
   ;; A Reagent view registered under a DIFFERENT id, reachable only
   ;; through `rf/view`. A hicasso variant must never resolve to it.
   (rf/reg-view* :views/reagent-probe reagent-probe-view)
-  (story/reg-story* :story.hicasso {:doc "rf2-2dbpd witness story"})
-  (story/reg-variant* :story.hicasso/card
+  (rf.story/reg-story* :story.hicasso {:doc "rf2-2dbpd witness story"})
+  (rf.story/reg-variant* :story.hicasso/card
     {:doc        "One declared substrate, and it is the native one."
      :component  card-id
      :substrates #{:hicasso}
      :args       {:label "alpha"}
      :loaders    [[:noop/loader]]})
-  (story/reg-variant* :story.hicasso/panel
+  (rf.story/reg-variant* :story.hicasso/panel
     {:doc        "A second hicasso view under the same substrate."
      :component  panel-id
      :substrates #{:hicasso}
      :args       {:label "beta"}
      :loaders    [[:noop/loader]]})
-  (story/reg-variant* :story.hicasso/missing-view
+  (rf.story/reg-variant* :story.hicasso/missing-view
     {:doc        "Names a view no registrar entry answers for."
      :component  :views/nobody-registered-this
      :substrates #{:hicasso}
@@ -243,7 +243,7 @@
 
 ;; ---- helpers --------------------------------------------------------------
 
-(def ^:private canvas-inner @#'canvas/canvas-inner)
+(def ^:private canvas-inner @#'rf.story.ui.canvas/canvas-inner)
 
 (defn- browser? []
   (and (exists? js/document)
@@ -276,12 +276,12 @@
   NEITHER marker and would fail every assertion for the wrong reason."
   [variant-id]
   (rf/make-frame {:id variant-id})
-  (loaders/mount! variant-id)
-  (loaders/start-loaders! variant-id)
-  (loaders/finish-loaders! variant-id)
-  (loaders/finish-events! variant-id)
-  (canvas/mark-variant-rendered! variant-id)
-  (e2e/expand-tree (canvas-inner variant-id)))
+  (rf.story.loaders/mount! variant-id)
+  (rf.story.loaders/start-loaders! variant-id)
+  (rf.story.loaders/finish-loaders! variant-id)
+  (rf.story.loaders/finish-events! variant-id)
+  (rf.story.ui.canvas/mark-variant-rendered! variant-id)
+  (rf.story.test-helpers.e2e-multi-frame/expand-tree (canvas-inner variant-id)))
 
 (defn- find-react-element
   "Depth-first search for the first React element in an expanded hiccup
@@ -295,7 +295,7 @@
     :else nil))
 
 (defn- rendered-under-reagent? [tree]
-  (some? (e2e/find-by-test-id tree "reagent-view-render")))
+  (some? (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "reagent-view-render")))
 
 ;; ===========================================================================
 ;; 1 · THE SPIKE — a Hicasso boundary paints inside a REAGENT tree
@@ -305,8 +305,8 @@
   (testing "rf2-2dbpd's mandated spike. Nothing in the repository witnessed
             a Hicasso boundary rendering inside a REAGENT tree: the
             crossing is designed and documented, and every witnessed parent
-            was Hicasso, native or UIx. This mounts one — a `h/defview`
-            head, minted to an element by `h/as-element`, spliced into a
+            was Hicasso, native or UIx. This mounts one — a `rf.hicasso/defview`
+            head, minted to an element by `rf.hicasso/as-element`, spliced into a
             Reagent hiccup vector under `rf/frame-provider`, committed
             through `reagent.dom.client` into a real DOM. If this row
             cannot be made green the registration is worthless and the
@@ -324,7 +324,7 @@
               (rdc/render root
                 [rf/frame-provider {:frame variant-id}
                  [:div.reagent-parent
-                  (h/as-element [hicasso-card {:label "alpha"}])]])))
+                  (rf.hicasso/as-element [hicasso-card {:label "alpha"}])]])))
           (let [el (.querySelector mount-node "[data-test=\"hicasso-card\"]")]
             (is (some? el)
                 "THE CROSSING PAINTS — a Hicasso boundary rendered its own
@@ -360,7 +360,7 @@
             container (make-mount-node!)]
         (rf/make-frame {:id frame-id})
         (rf/dispatch-sync [:hicsub/bump 1] {:frame frame-id})
-        (let [handle (h/mount! container {:frame frame-id}
+        (let [handle (rf.hicasso/mount! container {:frame frame-id}
                                [hicasso-card {:label "ctl"}])]
           (try
             (is (= "ctl/1"
@@ -378,7 +378,7 @@
                              .-textContent))
                   "and the readout moved"))
             (finally
-              (try (h/unmount! handle) (catch :default _ nil)))))))))
+              (try (rf.hicasso/unmount! handle) (catch :default _ nil)))))))))
 
 (defn- write-and-settle!
   "Write `n` into `frame-kw` and drain, the way a story's own interaction
@@ -391,7 +391,7 @@
 (deftest a-write-repaints-a-crossed-boundary
   (testing "rf2-phabt's ROUTE 2, restored. It ran red once and was removed
             rather than shipped red: a boundary spliced into a Reagent
-            tree by `h/as-element` painted `alpha/1` and then did not move
+            tree by `rf.hicasso/as-element` painted `alpha/1` and then did not move
             on a write into its own frame, with the body run count saying
             so — 1 to 1, a missing notification rather than a stale read.
 
@@ -422,7 +422,7 @@
               (rdc/render root
                 [rf/frame-provider {:frame variant-id}
                  [:div.reagent-parent
-                  (h/as-element [hicasso-card {:label "alpha"}])]])))
+                  (rf.hicasso/as-element [hicasso-card {:label "alpha"}])]])))
           (is (= "alpha/1" (card-text)) "it painted, reading the variant's frame")
           (let [runs-at-mount @!card-runs]
             (write-and-settle! variant-id 42)
@@ -472,7 +472,7 @@
             per head at definition time and every element rides that type.
             Drive the Reagent parent to re-render and the boundary must
             RE-RENDER, never remount — a remount is what a per-render
-            `h/as-component` would have produced, and it would have been
+            `rf.hicasso/as-component` would have produced, and it would have been
             invisible on screen.
 
             REMOUNT IS MEASURED ON THE DOM NODE'S IDENTITY, which is the
@@ -541,7 +541,7 @@
             fn registered under `:hicasso` — and must NOT fall through to
             `rf/view`, which answers nil for a hicasso alias and would
             degrade to the missing-view diagnostic."
-    (story/register-substrate! :hicasso hicasso-render)
+    (rf.story/register-substrate! :hicasso hicasso-render)
     (let [tree (ready-tree :story.hicasso/card)
           el   (find-react-element tree)]
       (is (some? el)
@@ -555,20 +555,20 @@
       (is (= {:label "alpha"} (unchecked-get (.-props el) "rfProps"))
           "and Story's resolved args crossed as the boundary's props map —
            kebab keywords, by identity, with no camelCase round trip")
-      (story/destroy-variant! :story.hicasso/card))))
+      (rf.story/destroy-variant! :story.hicasso/card))))
 
 (deftest two-hicasso-views-are-two-elements
   (testing "the registry entry resolves the variant's OWN `:component`,
             not merely 'some hicasso view'. Two variants under one
             substrate must mint two different element types."
-    (story/register-substrate! :hicasso hicasso-render)
+    (rf.story/register-substrate! :hicasso hicasso-render)
     (let [card  (find-react-element (ready-tree :story.hicasso/card))
           panel (find-react-element (ready-tree :story.hicasso/panel))]
       (is (identical? (unchecked-get hicasso-card "hicassoMemo") (.-type card)))
       (is (identical? (unchecked-get hicasso-panel "hicassoMemo") (.-type panel)))
       (is (not (identical? (.-type card) (.-type panel))))
-      (story/destroy-variant! :story.hicasso/card)
-      (story/destroy-variant! :story.hicasso/panel))))
+      (rf.story/destroy-variant! :story.hicasso/card)
+      (rf.story/destroy-variant! :story.hicasso/panel))))
 
 (deftest element-type-is-stable-across-renders
   (testing "THE IDENTITY DECISION, stated where it can be checked without a
@@ -576,7 +576,7 @@
             elements with the SAME type. That is the whole basis for
             returning a direct element mint and keeping no cache — the
             stability React needs is already in the head."
-    (story/register-substrate! :hicasso hicasso-render)
+    (rf.story/register-substrate! :hicasso hicasso-render)
     (let [a (hicasso-render :story.hicasso/card card-id {:label "one"})
           b (hicasso-render :story.hicasso/card card-id {:label "two"})]
       (is (not (identical? a b)) "a fresh element per pass")
@@ -588,9 +588,9 @@
             replaces the registrar entry behind the same id; the story
             must pick the new head up with no story change. Simulated the
             way a reload works — a second entry written under the same id."
-    (story/register-substrate! :hicasso hicasso-render)
+    (rf.story/register-substrate! :hicasso hicasso-render)
     (let [before (.-type (hicasso-render :story.hicasso/card card-id {}))]
-      (rf-registrar/register! :view card-id
+      (rf.registrar/register! :view card-id
         (assoc (get alias-entries card-id) :hicasso/component hicasso-panel))
       (let [after (.-type (hicasso-render :story.hicasso/card card-id {}))]
         (is (not (identical? before after))
@@ -607,31 +607,31 @@
             render fn returns the same style of inline diagnostic
             `reagent-render` returns — a FRAGMENT-level miss, not a grid
             cell — and names the id so the author knows what to fix."
-    (story/register-substrate! :hicasso hicasso-render)
+    (rf.story/register-substrate! :hicasso hicasso-render)
     (let [tree (ready-tree :story.hicasso/missing-view)
-          text (e2e/text-nodes tree)]
+          text (rf.story.test-helpers.e2e-multi-frame/text-nodes tree)]
       (is (nil? (find-react-element tree))
           "nothing was minted — there was no head to mint from")
       (is (re-find #"is not registered as a hicasso view" text))
       (is (re-find #"views/nobody-registered-this" text)
           "and it names WHICH view")
-      (story/destroy-variant! :story.hicasso/missing-view))))
+      (rf.story/destroy-variant! :story.hicasso/missing-view))))
 
 (deftest a-hicasso-variant-with-no-registered-substrate-says-so
   (testing "the host never called `register-substrate!`. The single pane
             must say so — loudly, at the fragment level — rather than
             silently painting Reagent, which is the defect rf2-3afns
             closed and the one this substrate must not reopen."
-    (is (not (contains? @multi-substrate/substrate->render-fn :hicasso))
+    (is (not (contains? @rf.story.ui.multi-substrate/substrate->render-fn :hicasso))
         "precondition: `:hicasso` absent from the registry")
     (let [tree (ready-tree :story.hicasso/card)
-          text (e2e/text-nodes tree)]
+          text (rf.story.test-helpers.e2e-multi-frame/text-nodes tree)]
       (is (re-find #"is not registered" text))
       (is (re-find #"hicasso" text) "and it names WHICH substrate")
       (is (not (rendered-under-reagent? tree))
           "it did NOT fall back to Reagent — falling back silently is the
            bug, not the remedy")
-      (story/destroy-variant! :story.hicasso/card))))
+      (rf.story/destroy-variant! :story.hicasso/card))))
 
 (deftest rf-view-still-answers-nil-for-a-hicasso-alias
   (testing "the premise the whole render fn is built on (rf2-5qaf4): the

--- a/tools/story/test/re_frame/story/ui/keybindings_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/keybindings_cljs_test.cljs
@@ -9,76 +9,76 @@
   - `shortcut-keys`     — sorted key list
   - Each handler fn round-trips through the shell-state-atom"
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.story.ui.keybindings :as kb]
-            [re-frame.story.ui.state :as state]))
+            [re-frame.story.ui.keybindings :as rf.story.ui.keybindings]
+            [re-frame.story.ui.state :as rf.story.ui.state]))
 
 (use-fixtures :each
-  {:before (fn [] (state/reset-shell-state!))})
+  {:before (fn [] (rf.story.ui.state/reset-shell-state!))})
 
 ;; ---- dispatch predicate -------------------------------------------------
 
 (deftest dispatch-key-predicate
   (testing "single lowercase char, no modifier, not editable → true"
-    (is (true? (kb/dispatch-key? "f" false false))))
+    (is (true? (rf.story.ui.keybindings/dispatch-key? "f" false false))))
   (testing "modifier held → false (Cmd-K / Ctrl-S etc. pass through)"
-    (is (false? (kb/dispatch-key? "f" true false))))
+    (is (false? (rf.story.ui.keybindings/dispatch-key? "f" true false))))
   (testing "focused input → false (typing in search shouldn't toggle)"
-    (is (false? (kb/dispatch-key? "f" false true))))
+    (is (false? (rf.story.ui.keybindings/dispatch-key? "f" false true))))
   (testing "multi-char key (Arrow, Escape) → false"
-    (is (false? (kb/dispatch-key? "Escape" false false))))
+    (is (false? (rf.story.ui.keybindings/dispatch-key? "Escape" false false))))
   (testing "nil / non-string → false"
-    (is (false? (kb/dispatch-key? nil false false)))))
+    (is (false? (rf.story.ui.keybindings/dispatch-key? nil false false)))))
 
 ;; ---- registry shape -----------------------------------------------------
 
 (deftest bindings-table-shape
   (testing "canonical 4-key registry: f / s / a / t"
-    (is (= #{"f" "s" "a" "t"} (set (keys kb/bindings))))
-    (is (= ["a" "f" "s" "t"]  (kb/shortcut-keys)))))
+    (is (= #{"f" "s" "a" "t"} (set (keys rf.story.ui.keybindings/bindings))))
+    (is (= ["a" "f" "s" "t"]  (rf.story.ui.keybindings/shortcut-keys)))))
 
 ;; ---- handler round-trip -------------------------------------------------
 
 (defn- visibility []
-  (state/chrome-visibility (state/get-state)))
+  (rf.story.ui.state/chrome-visibility (rf.story.ui.state/get-state)))
 
 (deftest full-screen-toggle-round-trip
   (testing "default off → on → off"
     (is (false? (:full-screen? (visibility))))
-    (kb/full-screen-toggle!)
+    (rf.story.ui.keybindings/full-screen-toggle!)
     (is (true?  (:full-screen? (visibility))))
-    (kb/full-screen-toggle!)
+    (rf.story.ui.keybindings/full-screen-toggle!)
     (is (false? (:full-screen? (visibility))))))
 
 (deftest sidebar-toggle-round-trip
   (testing "default on → off → on"
     (is (true?  (:sidebar? (visibility))))
-    (kb/sidebar-toggle!)
+    (rf.story.ui.keybindings/sidebar-toggle!)
     (is (false? (:sidebar? (visibility))))
-    (kb/sidebar-toggle!)
+    (rf.story.ui.keybindings/sidebar-toggle!)
     (is (true?  (:sidebar? (visibility))))))
 
 (deftest rhs-toggle-round-trip
   (testing "default on → off → on"
     (is (true?  (:rhs? (visibility))))
-    (kb/rhs-toggle!)
+    (rf.story.ui.keybindings/rhs-toggle!)
     (is (false? (:rhs? (visibility))))
-    (kb/rhs-toggle!)
+    (rf.story.ui.keybindings/rhs-toggle!)
     (is (true?  (:rhs? (visibility))))))
 
 (deftest toolbar-toggle-round-trip
   (testing "default on → off → on"
     (is (true?  (:toolbar? (visibility))))
-    (kb/toolbar-toggle!)
+    (rf.story.ui.keybindings/toolbar-toggle!)
     (is (false? (:toolbar? (visibility))))
-    (kb/toolbar-toggle!)
+    (rf.story.ui.keybindings/toolbar-toggle!)
     (is (true?  (:toolbar? (visibility))))))
 
 (deftest exit-full-screen-clears
   (testing "exit handler always clears full-screen regardless of prior"
-    (kb/full-screen-toggle!)         ;; on
+    (rf.story.ui.keybindings/full-screen-toggle!)         ;; on
     (is (true? (:full-screen? (visibility))))
-    (kb/exit-full-screen!)            ;; off
+    (rf.story.ui.keybindings/exit-full-screen!)            ;; off
     (is (false? (:full-screen? (visibility))))
     ;; idempotent: calling again leaves it off
-    (kb/exit-full-screen!)
+    (rf.story.ui.keybindings/exit-full-screen!)
     (is (false? (:full-screen? (visibility))))))

--- a/tools/story/test/re_frame/story/ui/markdown_test.cljc
+++ b/tools/story/test/re_frame/story/ui/markdown_test.cljc
@@ -9,7 +9,7 @@
   surfaces' contract without booting the shell."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
-            [re-frame.story.ui.markdown :as md]))
+            [re-frame.story.ui.markdown :as rf.story.ui.markdown]))
 
 ;; ---- helpers -------------------------------------------------------------
 
@@ -17,15 +17,15 @@
   "Strip the `:div.rf-story-md` wrapper and return the block-level
   vector. Reduces test boilerplate."
   [s]
-  (vec (rest (md/parse s))))
+  (vec (rest (rf.story.ui.markdown/parse s))))
 
 ;; ---- block shapes --------------------------------------------------------
 
 (deftest empty-and-nil-inputs
   (testing "empty / nil / whitespace input produce an empty wrapper"
-    (is (= [:div.rf-story-md] (md/parse "")))
-    (is (= [:div.rf-story-md] (md/parse nil)))
-    (is (= [:div.rf-story-md] (md/parse "   \n   ")))))
+    (is (= [:div.rf-story-md] (rf.story.ui.markdown/parse "")))
+    (is (= [:div.rf-story-md] (rf.story.ui.markdown/parse nil)))
+    (is (= [:div.rf-story-md] (rf.story.ui.markdown/parse "   \n   ")))))
 
 (deftest paragraph-with-plain-text
   (testing "plain text becomes a single <p> block"

--- a/tools/story/test/re_frame/story/ui/play_status_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/play_status_cljs_test.cljc
@@ -6,66 +6,66 @@
   exercised via the public pure helpers (`chip-label`, `banner-text`)
   so JVM tests can verify the rendering decisions without DOM."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.play.runner :as runner]
-            #?(:cljs [re-frame.story.ui.play-status :as ps])))
+            [re-frame.story.play.runner :as rf.story.play.runner]
+            #?(:cljs [re-frame.story.ui.play-status :as rf.story.ui.play-status])))
 
 ;; ---- chip-label (pure) ---------------------------------------------------
 
 #?(:cljs
    (deftest chip-label-idle
      (testing "nil state renders as 'Play: IDLE'"
-       (is (= "Play: IDLE" (ps/chip-label nil))))))
+       (is (= "Play: IDLE" (rf.story.ui.play-status/chip-label nil))))))
 
 #?(:cljs
    (deftest chip-label-running
      (testing "running state renders progress"
-       (let [s (-> (runner/parse-spec {:script [[:wait 1] [:wait 2]]})
-                   runner/initial-state
+       (let [s (-> (rf.story.play.runner/parse-spec {:script [[:wait 1] [:wait 2]]})
+                   rf.story.play.runner/initial-state
                    (assoc :status :running :step-idx 1))]
-         (is (= "Play: RUNNING (step 2/2)" (ps/chip-label s)))))))
+         (is (= "Play: RUNNING (step 2/2)" (rf.story.ui.play-status/chip-label s)))))))
 
 #?(:cljs
    (deftest chip-label-pass
      (testing "pass state renders the step total"
-       (let [s (-> (runner/parse-spec {:script [[:wait 1]]})
-                   runner/initial-state
+       (let [s (-> (rf.story.play.runner/parse-spec {:script [[:wait 1]]})
+                   rf.story.play.runner/initial-state
                    (assoc :status :pass))]
-         (is (= "Play: PASS (1 steps)" (ps/chip-label s)))))))
+         (is (= "Play: PASS (1 steps)" (rf.story.ui.play-status/chip-label s)))))))
 
 #?(:cljs
    (deftest chip-label-fail
      (testing "fail state renders the progress + total"
-       (let [s (-> (runner/parse-spec {:script [[:wait 1] [:wait 2] [:wait 3]]})
-                   runner/initial-state
+       (let [s (-> (rf.story.play.runner/parse-spec {:script [[:wait 1] [:wait 2] [:wait 3]]})
+                   rf.story.play.runner/initial-state
                    (assoc :status :fail :step-idx 2))]
-         (is (= "Play: FAIL (2/3 steps)" (ps/chip-label s)))))))
+         (is (= "Play: FAIL (2/3 steps)" (rf.story.ui.play-status/chip-label s)))))))
 
 ;; ---- banner-text (pure) --------------------------------------------------
 
 #?(:cljs
    (deftest banner-text-nil-for-non-failure
      (testing "banner-text returns nil unless status is :fail"
-       (is (nil? (ps/banner-text nil)))
-       (let [s (-> (runner/parse-spec {:script [[:wait 1]]})
-                   runner/initial-state
+       (is (nil? (rf.story.ui.play-status/banner-text nil)))
+       (let [s (-> (rf.story.play.runner/parse-spec {:script [[:wait 1]]})
+                   rf.story.play.runner/initial-state
                    (assoc :status :pass))]
-         (is (nil? (ps/banner-text s)))))))
+         (is (nil? (rf.story.ui.play-status/banner-text s)))))))
 
 #?(:cljs
    (deftest banner-text-renders-first-failure
      (testing "banner-text describes the first failing step"
-       (let [base    (-> (runner/parse-spec
+       (let [base    (-> (rf.story.play.runner/parse-spec
                            {:script [[:assert-db [:k] 1]
                                      [:assert-db [:k] 2]]})
-                         runner/initial-state
-                         (runner/start 0))
-             with-pass (runner/record-step-result base
-                         (runner/step-pass 0 [:assert-db [:k] 1]))
-             with-fail (runner/record-step-result with-pass
-                         (runner/step-fail 1 [:assert-db [:k] 2]
+                         rf.story.play.runner/initial-state
+                         (rf.story.play.runner/start 0))
+             with-pass (rf.story.play.runner/record-step-result base
+                         (rf.story.play.runner/step-pass 0 [:assert-db [:k] 1]))
+             with-fail (rf.story.play.runner/record-step-result with-pass
+                         (rf.story.play.runner/step-fail 1 [:assert-db [:k] 2]
                                            {:message "got 1, expected 2"}))
-             final    (runner/finish with-fail 1)
-             text     (ps/banner-text final)]
+             final    (rf.story.play.runner/finish with-fail 1)
+             text     (rf.story.ui.play-status/banner-text final)]
          (is (string? text))
          (is (re-find #"1 failure" text))
          (is (re-find #"step 2" text))
@@ -83,26 +83,26 @@
 
 (deftest jvm-progress-and-summary
   (testing "runner helpers used by the chip render the expected strings"
-    (let [s (-> (runner/parse-spec {:script [[:wait 1] [:wait 2]]})
-                runner/initial-state
+    (let [s (-> (rf.story.play.runner/parse-spec {:script [[:wait 1] [:wait 2]]})
+                rf.story.play.runner/initial-state
                 (assoc :status :running :step-idx 1))]
-      (is (= "RUNNING (step 2/2)" (runner/progress-str s))))))
+      (is (= "RUNNING (step 2/2)" (rf.story.play.runner/progress-str s))))))
 
 (deftest jvm-banner-summary
   (testing "fail-summary describes the first failed result"
-    (let [base   (-> (runner/parse-spec
+    (let [base   (-> (rf.story.play.runner/parse-spec
                        {:script [[:assert-db [:k] 1]
                                  [:assert-db [:k] 2]]})
-                     runner/initial-state
-                     (runner/start 0))
+                     rf.story.play.runner/initial-state
+                     (rf.story.play.runner/start 0))
           failed (-> base
-                     (runner/record-step-result
-                       (runner/step-pass 0 [:assert-db [:k] 1]))
-                     (runner/record-step-result
-                       (runner/step-fail 1 [:assert-db [:k] 2]
+                     (rf.story.play.runner/record-step-result
+                       (rf.story.play.runner/step-pass 0 [:assert-db [:k] 1]))
+                     (rf.story.play.runner/record-step-result
+                       (rf.story.play.runner/step-fail 1 [:assert-db [:k] 2]
                                          {:message "no"}))
-                     (runner/finish 1))
-          summ   (runner/fail-summary failed)]
+                     (rf.story.play.runner/finish 1))
+          summ   (rf.story.play.runner/fail-summary failed)]
       (is (= 1 (:count summ)))
       (is (= 1 (:idx (:first summ)))))))
 
@@ -112,28 +112,28 @@
    (deftest chip-label-multi-idle
      (testing "nil state with a play name renders 'Play <name> | IDLE'"
        (is (= "Play happy path | IDLE"
-              (ps/chip-label-multi nil "happy path"))))))
+              (rf.story.ui.play-status/chip-label-multi nil "happy path"))))))
 
 #?(:cljs
    (deftest chip-label-multi-no-name-uses-default
      (testing "no play name falls back to (default)"
        (is (= "Play (default) | IDLE"
-              (ps/chip-label-multi nil nil))))))
+              (rf.story.ui.play-status/chip-label-multi nil nil))))))
 
 #?(:cljs
    (deftest chip-label-multi-running
      (testing "running state shows progress alongside the play name"
-       (let [s (-> (runner/parse-spec {:script [[:wait 1] [:wait 2]]})
-                   runner/initial-state
+       (let [s (-> (rf.story.play.runner/parse-spec {:script [[:wait 1] [:wait 2]]})
+                   rf.story.play.runner/initial-state
                    (assoc :status :running :step-idx 1))]
          (is (= "Play error path | RUNNING (step 2/2)"
-                (ps/chip-label-multi s "error path")))))))
+                (rf.story.ui.play-status/chip-label-multi s "error path")))))))
 
 #?(:cljs
    (deftest dropdown-row-status-shapes
      (testing "dropdown-row-status renders short status badges"
-       (is (= "IDLE" (ps/dropdown-row-status nil)))
-       (is (= "IDLE" (ps/dropdown-row-status {:status :idle})))
-       (is (= "RUN"  (ps/dropdown-row-status {:status :running})))
-       (is (= "PASS" (ps/dropdown-row-status {:status :pass})))
-       (is (= "FAIL" (ps/dropdown-row-status {:status :fail}))))))
+       (is (= "IDLE" (rf.story.ui.play-status/dropdown-row-status nil)))
+       (is (= "IDLE" (rf.story.ui.play-status/dropdown-row-status {:status :idle})))
+       (is (= "RUN"  (rf.story.ui.play-status/dropdown-row-status {:status :running})))
+       (is (= "PASS" (rf.story.ui.play-status/dropdown-row-status {:status :pass})))
+       (is (= "FAIL" (rf.story.ui.play-status/dropdown-row-status {:status :fail}))))))

--- a/tools/story/test/re_frame/story/ui/promotion_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/promotion_cljs_test.cljc
@@ -19,10 +19,10 @@
   `:node-test` build (ns suffix `-cljs-test`)."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story.artifact  :as artifact]
-            [re-frame.story.promotion :as promotion]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.story.ui.promotion :as ui-promo]))
+            [re-frame.story.artifact  :as rf.story.artifact]
+            [re-frame.story.promotion :as rf.story.promotion]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.ui.promotion :as rf.story.ui.promotion]))
 
 ;; ---- fixtures -----------------------------------------------------------
 ;;
@@ -32,14 +32,14 @@
 ;; targets.
 
 (defn reset-state! [t]
-  (registrar/clear-all!)
+  (rf.story.registrar/clear-all!)
   ;; The substrate's `reg-variant*` validates tags against the registered
   ;; set; `clear-all!` wipes the canonical tags the real Story boot installs
   ;; (`re-frame.story/install-canonical-vocabulary!`). Re-install them so a
   ;; promoted `#{:test}` regression validates exactly as it does at runtime.
-  (registrar/install-canonical-tags!)
-  #?(:cljs (reset! ui-promo/captured-atom {}))
-  #?(:cljs (reset! ui-promo/dialog-atom ui-promo/initial-dialog-state))
+  (rf.story.registrar/install-canonical-tags!)
+  #?(:cljs (reset! rf.story.ui.promotion/captured-atom {}))
+  #?(:cljs (reset! rf.story.ui.promotion/dialog-atom rf.story.ui.promotion/initial-dialog-state))
   (t))
 
 (use-fixtures :each reset-state!)
@@ -49,7 +49,7 @@
 (defn- sample-artifact
   "A two-step run artifact with a stubbed result + seed."
   []
-  (artifact/make-run-artifact
+  (rf.story.artifact/make-run-artifact
     {:event-program [[:dispatch [:counter/init 5]]
                      [:dispatch [:counter/inc]]]
      :seed          42
@@ -62,21 +62,21 @@
 (deftest artifact-id-is-stable-and-seed-keyed
   (testing "the same artifact yields the same id (idempotent capture key)"
     (let [art (sample-artifact)]
-      (is (= (ui-promo/artifact-id art) (ui-promo/artifact-id art)))
-      (is (qualified-keyword? (ui-promo/artifact-id art)))
-      (is (= "rf.test.artifact" (namespace (ui-promo/artifact-id art))))
-      (is (str/includes? (name (ui-promo/artifact-id art)) "42")
+      (is (= (rf.story.ui.promotion/artifact-id art) (rf.story.ui.promotion/artifact-id art)))
+      (is (qualified-keyword? (rf.story.ui.promotion/artifact-id art)))
+      (is (= "rf.test.artifact" (namespace (rf.story.ui.promotion/artifact-id art))))
+      (is (str/includes? (name (rf.story.ui.promotion/artifact-id art)) "42")
           "a seeded artifact keys on its seed"))))
 
 (deftest artifact-id-hash-keyed-without-seed
   (testing "a seedless artifact still gets a stable content-hash id"
-    (let [art (artifact/make-run-artifact {:event-program [[:dispatch [:e]]]})]
-      (is (qualified-keyword? (ui-promo/artifact-id art)))
-      (is (= (ui-promo/artifact-id art) (ui-promo/artifact-id art))))))
+    (let [art (rf.story.artifact/make-run-artifact {:event-program [[:dispatch [:e]]]})]
+      (is (qualified-keyword? (rf.story.ui.promotion/artifact-id art)))
+      (is (= (rf.story.ui.promotion/artifact-id art) (rf.story.ui.promotion/artifact-id art))))))
 
 (deftest artifact-label-reads-status-and-steps
   (testing "the label scans status + step-count without opening the artifact"
-    (let [label (ui-promo/artifact-label (sample-artifact))]
+    (let [label (rf.story.ui.promotion/artifact-label (sample-artifact))]
       (is (str/includes? label "fail"))
       (is (str/includes? label "2 steps")))))
 
@@ -88,22 +88,22 @@
   (testing "a result carrying a :run-artifact back-link uses it verbatim"
     (let [art    (sample-artifact)
           result {:status :fail :run-artifact art}]
-      (is (= art (ui-promo/result->artifact result []))
+      (is (= art (rf.story.ui.promotion/result->artifact result []))
           "the replay back-link IS the captured artifact"))))
 
 (deftest result->artifact-synthesizes-from-play-events
   (testing "a plain run synthesizes an artifact from its flat play-events"
     (let [result      {:status :pass}
           play-events [[:counter/inc] [:counter/dec]]
-          art         (ui-promo/result->artifact result play-events)]
-      (is (artifact/run-artifact? art))
-      (is (= 2 (count (artifact/program-events art)))
+          art         (rf.story.ui.promotion/result->artifact result play-events)]
+      (is (rf.story.artifact/run-artifact? art))
+      (is (= 2 (count (rf.story.artifact/program-events art)))
           "both bare events lift into the dispatch program"))))
 
 (deftest result->artifact-nil-when-nothing-replayable
   (testing "no back-link AND no play-events → nothing to capture"
-    (is (nil? (ui-promo/result->artifact {:status :pass} [])))
-    (is (nil? (ui-promo/result->artifact nil [])))))
+    (is (nil? (rf.story.ui.promotion/result->artifact {:status :pass} [])))
+    (is (nil? (rf.story.ui.promotion/result->artifact nil [])))))
 
 ;; ===========================================================================
 ;; PURE: draft → promote-opts + snippet
@@ -111,7 +111,7 @@
 
 (deftest draft->promote-opts-projects-only-set-slots
   (testing "the draft projects to the substrate opts keeping only set slots"
-    (let [opts (ui-promo/draft->promote-opts
+    (let [opts (rf.story.ui.promotion/draft->promote-opts
                  {:variant-id  :story.x/regression-1
                   :doc         "  why this matters  "
                   :tags        #{:test :agent}
@@ -123,7 +123,7 @@
       (is (= 1 (:setup-count opts)))
       (is (= :story.x/source (:extends opts)))))
   (testing "blank / empty / negative slots are dropped, id preserved as nil"
-    (let [opts (ui-promo/draft->promote-opts
+    (let [opts (rf.story.ui.promotion/draft->promote-opts
                  {:variant-id nil :doc "   " :tags #{} :setup-count -1})]
       (is (contains? opts :variant/id))
       (is (nil? (:variant/id opts)))
@@ -134,7 +134,7 @@
 (deftest promotion-snippet-emits-reg-variant-with-provenance
   (testing "the snippet is a (reg-variant …) form carrying the source link"
     (let [art  (sample-artifact)
-          snip (ui-promo/promotion-snippet art {:variant-id :story.x/regression-1
+          snip (rf.story.ui.promotion/promotion-snippet art {:variant-id :story.x/regression-1
                                                 :tags #{:test}})]
       (is (str/starts-with? snip "(story/reg-variant "))
       (is (str/includes? snip ":story.x/regression-1"))
@@ -148,7 +148,7 @@
 (deftest promotion-snippet-honours-setup-cut
   (testing "setup-count moves leading steps from :script to :setup"
     (let [art  (sample-artifact)
-          snip (ui-promo/promotion-snippet art {:variant-id :story.x/r
+          snip (rf.story.ui.promotion/promotion-snippet art {:variant-id :story.x/r
                                                 :setup-count 1})]
       (is (str/includes? snip ":setup")
           "the first step becomes a precondition")
@@ -164,9 +164,9 @@
             registers — `artifact->variant-body` (no reimplemented logic)"
     (let [art  (sample-artifact)
           opts {:variant/id :story.x/r :tags #{:test}}
-          body (promotion/artifact->variant-body art opts)]
+          body (rf.story.promotion/artifact->variant-body art opts)]
       ;; the snippet renders the substrate body's slots verbatim
-      (is (str/includes? (ui-promo/promotion-snippet art {:variant-id :story.x/r
+      (is (str/includes? (rf.story.ui.promotion/promotion-snippet art {:variant-id :story.x/r
                                                           :tags #{:test}})
                          (pr-str (:run-artifact body)))
           "the snippet's :run-artifact is the substrate's trimmed link"))))
@@ -178,29 +178,29 @@
 #?(:cljs
    (deftest capture-is-idempotent
      (testing "capturing the same run twice yields one store entry"
-       (reset! ui-promo/captured-atom {})
+       (reset! rf.story.ui.promotion/captured-atom {})
        (let [art (sample-artifact)
-             id1 (ui-promo/capture! art :story.x/v)
-             id2 (ui-promo/capture! art :story.x/v)]
+             id1 (rf.story.ui.promotion/capture! art :story.x/v)
+             id2 (rf.story.ui.promotion/capture! art :story.x/v)]
          (is (= id1 id2))
-         (is (= 1 (count (ui-promo/captured-entries))))))))
+         (is (= 1 (count (rf.story.ui.promotion/captured-entries))))))))
 
 #?(:cljs
    (deftest capture-skips-non-artifacts
      (testing "a non-artifact value is not captured"
-       (reset! ui-promo/captured-atom {})
-       (is (nil? (ui-promo/capture! {:not :an-artifact})))
-       (is (empty? (ui-promo/captured-entries))))))
+       (reset! rf.story.ui.promotion/captured-atom {})
+       (is (nil? (rf.story.ui.promotion/capture! {:not :an-artifact})))
+       (is (empty? (rf.story.ui.promotion/captured-entries))))))
 
 #?(:cljs
    (deftest capture-from-result-uses-source-rule
      (testing "capture-from-result! captures the synthesized artifact"
-       (reset! ui-promo/captured-atom {})
-       (let [id (ui-promo/capture-from-result! {:status :fail}
+       (reset! rf.story.ui.promotion/captured-atom {})
+       (let [id (rf.story.ui.promotion/capture-from-result! {:status :fail}
                                                [[:counter/inc]]
                                                :story.x/v)]
          (is (some? id))
-         (is (= 1 (count (ui-promo/captured-entries))))))))
+         (is (= 1 (count (rf.story.ui.promotion/captured-entries))))))))
 
 ;; ===========================================================================
 ;; CLJS-only: promote! is non-destructive + drives the substrate register
@@ -209,18 +209,18 @@
 #?(:cljs
    (deftest promote-registers-and-leaves-artifact-as-evidence
      (testing "promote! registers a variant AND keeps the source artifact"
-       (reset! ui-promo/captured-atom {})
+       (reset! rf.story.ui.promotion/captured-atom {})
        (let [art (sample-artifact)
-             id  (ui-promo/capture! art :story.x/v)
-             pid (ui-promo/promote! id {:variant-id :story.x/regression-1
+             id  (rf.story.ui.promotion/capture! art :story.x/v)
+             pid (rf.story.ui.promotion/promote! id {:variant-id :story.x/regression-1
                                         :tags #{:test}})]
          (is (= :story.x/regression-1 pid)
              "the registered variant id is returned")
-         (is (registrar/registered? :variant :story.x/regression-1)
+         (is (rf.story.registrar/registered? :variant :story.x/regression-1)
              "the variant is registered through the substrate")
-         (is (contains? @ui-promo/captured-atom id)
+         (is (contains? @rf.story.ui.promotion/captured-atom id)
              "NON-DESTRUCTIVE — the source artifact stays as evidence")
-         (let [body (registrar/handler-meta :variant :story.x/regression-1)]
+         (let [body (rf.story.registrar/handler-meta :variant :story.x/regression-1)]
            (is (contains? body :run-artifact)
                "the registered body carries the source-artifact provenance"))))))
 
@@ -228,21 +228,21 @@
    (deftest promote-no-ops-without-id
      (testing "promote! with no :variant-id registers nothing (the substrate
                would otherwise throw :rf.error/story-promote-no-id)"
-       (reset! ui-promo/captured-atom {})
-       (let [id (ui-promo/capture! (sample-artifact) :story.x/v)]
-         (is (nil? (ui-promo/promote! id {:variant-id nil})))))))
+       (reset! rf.story.ui.promotion/captured-atom {})
+       (let [id (rf.story.ui.promotion/capture! (sample-artifact) :story.x/v)]
+         (is (nil? (rf.story.ui.promotion/promote! id {:variant-id nil})))))))
 
 #?(:cljs
    (deftest forget-does-not-unregister-promoted-variant
      (testing "forgetting the capture leaves an already-promoted variant intact"
-       (reset! ui-promo/captured-atom {})
+       (reset! rf.story.ui.promotion/captured-atom {})
        (let [art (sample-artifact)
-             id  (ui-promo/capture! art :story.x/v)]
-         (ui-promo/promote! id {:variant-id :story.x/regression-2 :tags #{:test}})
-         (ui-promo/forget! id)
-         (is (not (contains? @ui-promo/captured-atom id))
+             id  (rf.story.ui.promotion/capture! art :story.x/v)]
+         (rf.story.ui.promotion/promote! id {:variant-id :story.x/regression-2 :tags #{:test}})
+         (rf.story.ui.promotion/forget! id)
+         (is (not (contains? @rf.story.ui.promotion/captured-atom id))
              "the capture-store entry is gone")
-         (is (registrar/registered? :variant :story.x/regression-2)
+         (is (rf.story.registrar/registered? :variant :story.x/regression-2)
              "the promoted variant survives — promotion copied a link, not a ref")))))
 
 ;; ===========================================================================
@@ -252,19 +252,19 @@
 #?(:cljs
    (deftest dialog-nil-when-closed
      (testing "the dialog renders nil when no artifact is open"
-       (reset! ui-promo/dialog-atom ui-promo/initial-dialog-state)
-       (let [comp (ui-promo/promotion-dialog)]
+       (reset! rf.story.ui.promotion/dialog-atom rf.story.ui.promotion/initial-dialog-state)
+       (let [comp (rf.story.ui.promotion/promotion-dialog)]
          ;; form-2 component: the returned inner render fn yields nil closed
          (is (nil? (comp)))))))
 
 #?(:cljs
    (deftest dialog-renders-curation-controls-and-snippet-when-open
      (testing "open dialog renders the id input, doc, tags, setup-cut + snippet"
-       (reset! ui-promo/captured-atom {})
+       (reset! rf.story.ui.promotion/captured-atom {})
        (let [art (sample-artifact)
-             id  (ui-promo/capture! art :story.counter/happy)]
-         (ui-promo/open! id)
-         (let [comp (ui-promo/promotion-dialog)
+             id  (rf.story.ui.promotion/capture! art :story.counter/happy)]
+         (rf.story.ui.promotion/open! id)
+         (let [comp (rf.story.ui.promotion/promotion-dialog)
                flat (str (comp))]
            (is (str/includes? flat "story-promotion-dialog")
                "the shared review-dialog renders under the promotion prefix")
@@ -286,10 +286,10 @@
 #?(:cljs
    (deftest dialog-open-seeds-test-tag-and-setup-zero
      (testing "open! seeds a runnable-test default draft"
-       (reset! ui-promo/captured-atom {})
-       (let [id (ui-promo/capture! (sample-artifact) :story.counter/happy)]
-         (ui-promo/open! id)
-         (let [draft (:draft @ui-promo/dialog-atom)]
+       (reset! rf.story.ui.promotion/captured-atom {})
+       (let [id (rf.story.ui.promotion/capture! (sample-artifact) :story.counter/happy)]
+         (rf.story.ui.promotion/open! id)
+         (let [draft (:draft @rf.story.ui.promotion/dialog-atom)]
            (is (contains? (:tags draft) :test) "seeds :test so it's runnable")
            (is (= 0 (:setup-count draft)) "conservative cut — whole program is behaviour")
            (is (= :story.counter/happy (:extends draft))
@@ -304,30 +304,30 @@
 #?(:cljs
    (deftest mark-promoted-gates-confirmation-and-open-resets-it
      (testing "the confirmation shows after mark-promoted! and clears on open!"
-       (reset! ui-promo/captured-atom {})
-       (reset! ui-promo/dialog-atom ui-promo/initial-dialog-state)
-       (let [art-a (artifact/make-run-artifact
+       (reset! rf.story.ui.promotion/captured-atom {})
+       (reset! rf.story.ui.promotion/dialog-atom rf.story.ui.promotion/initial-dialog-state)
+       (let [art-a (rf.story.artifact/make-run-artifact
                      {:event-program [[:dispatch [:counter/inc]]]
                       :seed          1 :result {:status :fail}})
-             art-b (artifact/make-run-artifact
+             art-b (rf.story.artifact/make-run-artifact
                      {:event-program [[:dispatch [:counter/dec]]]
                       :seed          2 :result {:status :fail}})
-             id-a  (ui-promo/capture! art-a :story.counter/happy)
-             id-b  (ui-promo/capture! art-b :story.counter/happy)
-             comp  (ui-promo/promotion-dialog)
+             id-a  (rf.story.ui.promotion/capture! art-a :story.counter/happy)
+             id-b  (rf.story.ui.promotion/capture! art-b :story.counter/happy)
+             comp  (rf.story.ui.promotion/promotion-dialog)
              flat  #(str (comp))]
          ;; --- promote A: confirmation appears ---
-         (ui-promo/open! id-a)
+         (rf.story.ui.promotion/open! id-a)
          (is (not (str/includes? (flat) "story-promotion-confirmation"))
              "a freshly-opened artifact reads as un-promoted")
-         (ui-promo/mark-promoted! :story.counter/regression-a)
+         (rf.story.ui.promotion/mark-promoted! :story.counter/regression-a)
          (is (str/includes? (flat) "story-promotion-confirmation")
              "after mark-promoted! the green confirmation renders")
          (is (str/includes? (flat) "regression-a")
              "the confirmation names the promoted id")
          ;; --- open B: stale confirmation MUST NOT leak across (rf2-lc0cp) ---
-         (ui-promo/open! id-b)
-         (is (nil? (:promoted-id @ui-promo/dialog-atom))
+         (rf.story.ui.promotion/open! id-b)
+         (is (nil? (:promoted-id @rf.story.ui.promotion/dialog-atom))
              "open! resets :promoted-id — B starts un-promoted")
          (is (not (str/includes? (flat) "story-promotion-confirmation"))
              "B shows NO stale 'Promoted to A' confirmation")
@@ -337,12 +337,12 @@
 #?(:cljs
    (deftest close-resets-confirmation
      (testing "close! clears a recorded confirmation as part of the lifecycle"
-       (reset! ui-promo/captured-atom {})
-       (reset! ui-promo/dialog-atom ui-promo/initial-dialog-state)
-       (let [id (ui-promo/capture! (sample-artifact) :story.counter/happy)]
-         (ui-promo/open! id)
-         (ui-promo/mark-promoted! :story.counter/regression-1)
-         (is (= :story.counter/regression-1 (:promoted-id @ui-promo/dialog-atom)))
-         (ui-promo/close!)
-         (is (nil? (:promoted-id @ui-promo/dialog-atom))
+       (reset! rf.story.ui.promotion/captured-atom {})
+       (reset! rf.story.ui.promotion/dialog-atom rf.story.ui.promotion/initial-dialog-state)
+       (let [id (rf.story.ui.promotion/capture! (sample-artifact) :story.counter/happy)]
+         (rf.story.ui.promotion/open! id)
+         (rf.story.ui.promotion/mark-promoted! :story.counter/regression-1)
+         (is (= :story.counter/regression-1 (:promoted-id @rf.story.ui.promotion/dialog-atom)))
+         (rf.story.ui.promotion/close!)
+         (is (nil? (:promoted-id @rf.story.ui.promotion/dialog-atom))
              "close! returns the dialog to the idle, un-promoted state")))))

--- a/tools/story/test/re_frame/story/ui/recorder_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/recorder_cljs_test.cljc
@@ -12,19 +12,19 @@
 
   - **CLJS-only** (`ui/recorder.cljs` is CLJS-only — depends on
     Reagent / DOM) — the dialog renders a snippet built from the
-    snapshot stored on `@ui-dialog`, NOT from `@recorder/state`. A
+    snapshot stored on `@ui-dialog`, NOT from `@rf.story.recorder/state`. A
     fresh `start-recording!` after the dialog opens does NOT mutate
     the rendered snippet — that's the rf2-8x9nb regression."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story.recorder :as recorder]
-            #?(:cljs [re-frame.story.ui.recorder :as ui-rec])))
+            [re-frame.story.recorder :as rf.story.recorder]
+            #?(:cljs [re-frame.story.ui.recorder :as rf.story.ui.recorder])))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-recorder! [f]
-  (recorder/clear!)
-  #?(:cljs (reset! ui-rec/ui-dialog recorder/initial-dialog-state))
+  (rf.story.recorder/clear!)
+  #?(:cljs (reset! rf.story.ui.recorder/ui-dialog rf.story.recorder/initial-dialog-state))
   (f))
 
 (use-fixtures :each reset-recorder!)
@@ -34,7 +34,7 @@
 (deftest open-dialog-snapshots-events-onto-dialog-state
   (testing "open-dialog stashes the captured events on the dialog state"
     (let [events [[:counter/inc] [:counter/dec]]
-          opened (recorder/open-dialog recorder/initial-dialog-state
+          opened (rf.story.recorder/open-dialog rf.story.recorder/initial-dialog-state
                                        :story.x/y events nil 12345)]
       (is (:open? opened))
       (is (= :story.x/y (:source-id opened))
@@ -49,44 +49,44 @@
 (deftest open-dialog-snapshot-is-independent-of-source-vector
   (testing "the snapshot is decoupled from the caller's events vector"
     (let [events (vec [[:counter/inc]])
-          opened (recorder/open-dialog recorder/initial-dialog-state
+          opened (rf.story.recorder/open-dialog rf.story.recorder/initial-dialog-state
                                        :story.x/y events nil 0)]
       (is (= [[:counter/inc]] (:events opened))
           "the snapshot is a fresh vector, not a reference to a recorder atom"))))
 
 (deftest close-dialog-returns-idle-state
   (testing "close-dialog clears the snapshot — next open starts fresh"
-    (let [opened (recorder/open-dialog recorder/initial-dialog-state
+    (let [opened (rf.story.recorder/open-dialog rf.story.recorder/initial-dialog-state
                                        :story.x/y [[:counter/inc]] nil 0)
-          closed (recorder/close-dialog opened)]
+          closed (rf.story.recorder/close-dialog opened)]
       (is (false? (:open? closed)))
       (is (nil? (:source-id closed)))
       (is (nil? (:events closed))))))
 
 (deftest initial-dialog-state-is-idle
   (testing "the seed value for the dialog ratom is the idle state"
-    (is (false? (:open? recorder/initial-dialog-state)))
-    (is (nil? (:source-id recorder/initial-dialog-state)))
-    (is (nil? (:draft-id recorder/initial-dialog-state)))))
+    (is (false? (:open? rf.story.recorder/initial-dialog-state)))
+    (is (nil? (:source-id rf.story.recorder/initial-dialog-state)))
+    (is (nil? (:draft-id rf.story.recorder/initial-dialog-state)))))
 
 ;; ---- CLJS-only: dialog rendered hiccup -----------------------------------
 
 #?(:cljs
    (deftest save-dialog-not-rendered-when-closed
      (testing "the dialog renders nil when the ratom :open? is false"
-       (reset! ui-rec/ui-dialog recorder/initial-dialog-state)
-       (is (nil? (ui-rec/save-dialog))))))
+       (reset! rf.story.ui.recorder/ui-dialog rf.story.recorder/initial-dialog-state)
+       (is (nil? (rf.story.ui.recorder/save-dialog))))))
 
 #?(:cljs
    (deftest save-dialog-renders-snippet-from-snapshot
      (testing "the rendered snippet is built from the dialog snapshot"
-       (reset! ui-rec/ui-dialog
-               (recorder/open-dialog recorder/initial-dialog-state
+       (reset! rf.story.ui.recorder/ui-dialog
+               (rf.story.recorder/open-dialog rf.story.recorder/initial-dialog-state
                                      :story.x/source
                                      [[:counter/inc] [:counter/dec]]
                                      nil
                                      12345))
-       (let [flat (str (ui-rec/save-dialog))]
+       (let [flat (str (rf.story.ui.recorder/save-dialog))]
          (is (str/includes? flat ":counter/inc")
              "captured events appear in the snippet preview")
          (is (str/includes? flat ":counter/dec"))
@@ -115,12 +115,12 @@
               them), GREEN after (recording->script-body over :entries)"
        ;; Drive the actual capture pipeline so the test exercises the
        ;; real two-stream model, not a hand-built snapshot.
-       (recorder/clear!)
-       (recorder/start-recording! :story.login/form 0)
-       (recorder/record-event! [:counter/inc])                       ; → :events + :entries
-       (recorder/record-dom-event! [:dom/click "#submit" 10])        ; → :entries ONLY
-       (recorder/record-dom-event! [:dom/type "#email" "a@b.co" 20]) ; → :entries ONLY
-       (let [{:keys [variant-id events entries]} (recorder/stop-recording!)]
+       (rf.story.recorder/clear!)
+       (rf.story.recorder/start-recording! :story.login/form 0)
+       (rf.story.recorder/record-event! [:counter/inc])                       ; → :events + :entries
+       (rf.story.recorder/record-dom-event! [:dom/click "#submit" 10])        ; → :entries ONLY
+       (rf.story.recorder/record-dom-event! [:dom/type "#email" "a@b.co" 20]) ; → :entries ONLY
+       (let [{:keys [variant-id events entries]} (rf.story.recorder/stop-recording!)]
          ;; Sanity: the streams desync exactly as documented — :events
          ;; has the lone dispatch; :entries has all three interactions.
          (is (= [[:counter/inc]] events)
@@ -128,13 +128,13 @@
          (is (= 3 (count entries))
              ":entries carries the dispatch + both DOM interactions")
          ;; Open the primary dialog through the real UI entry point.
-         (reset! ui-rec/ui-dialog
-                 (recorder/open-dialog recorder/initial-dialog-state
+         (reset! rf.story.ui.recorder/ui-dialog
+                 (rf.story.recorder/open-dialog rf.story.recorder/initial-dialog-state
                                        variant-id events entries 0))
          ;; `(str hiccup)` escapes the inner double-quotes of the
          ;; rendered EDN, so the snippet selector "#submit" appears as
          ;; \"#submit\" in the flattened tree — assert against that form.
-         (let [flat (str (ui-rec/save-dialog))]
+         (let [flat (str (rf.story.ui.recorder/save-dialog))]
            (is (str/includes? flat ":dispatch [:counter/inc]")
                "the dispatched event still appears as a :dispatch step")
            (is (str/includes? flat "[:click \\\"#submit\\\"]")
@@ -156,17 +156,17 @@
      (testing "rf2-nkjkj: a recording of canvas interactions ONLY (no
               dispatched events) still produces a non-empty primary
               snippet — :events is empty but :entries carries the clicks"
-       (recorder/clear!)
-       (recorder/start-recording! :story.x/canvas 0)
-       (recorder/record-dom-event! [:dom/click "#a" 5])
-       (recorder/record-dom-event! [:dom/click "#b" 9])
-       (let [{:keys [variant-id events entries]} (recorder/stop-recording!)]
+       (rf.story.recorder/clear!)
+       (rf.story.recorder/start-recording! :story.x/canvas 0)
+       (rf.story.recorder/record-dom-event! [:dom/click "#a" 5])
+       (rf.story.recorder/record-dom-event! [:dom/click "#b" 9])
+       (let [{:keys [variant-id events entries]} (rf.story.recorder/stop-recording!)]
          (is (empty? events) ":events is empty for a DOM-only recording")
          (is (= 2 (count entries)))
-         (reset! ui-rec/ui-dialog
-                 (recorder/open-dialog recorder/initial-dialog-state
+         (reset! rf.story.ui.recorder/ui-dialog
+                 (rf.story.recorder/open-dialog rf.story.recorder/initial-dialog-state
                                        variant-id events entries 0))
-         (let [flat (str (ui-rec/save-dialog))]
+         (let [flat (str (rf.story.ui.recorder/save-dialog))]
            (is (str/includes? flat "[:click \\\"#a\\\"]"))
            (is (str/includes? flat "[:click \\\"#b\\\"]"))
            (is (str/includes? flat "2 recorded steps")
@@ -181,25 +181,25 @@
               at open time, not read live off the recorder atom"
        ;; Step 1: simulate stop-of-recording-A → open dialog with A's events.
        (let [a-events [[:counter/inc] [:counter/inc] [:counter/dec]]]
-         (reset! ui-rec/ui-dialog
-                 (recorder/open-dialog recorder/initial-dialog-state
+         (reset! rf.story.ui.recorder/ui-dialog
+                 (rf.story.recorder/open-dialog rf.story.recorder/initial-dialog-state
                                        :story.a/source a-events nil 12345))
-         (let [snippet-before (str (ui-rec/save-dialog))]
+         (let [snippet-before (str (rf.story.ui.recorder/save-dialog))]
            (is (str/includes? snippet-before ":counter/inc"))
            (is (str/includes? snippet-before ":story.a/source"))
 
            ;; Step 2: user clicks REC again — starts a fresh recording
-           ;; targeting B. This resets `recorder/state` to an empty
+           ;; targeting B. This resets `rf.story.recorder/state` to an empty
            ;; recording with a different variant-id.
-           (recorder/start-recording! :story.b/target 99999)
-           (is (recorder/recording?))
-           (is (= :story.b/target (recorder/recording-variant)))
-           (is (= [] (recorder/recorded-events))
+           (rf.story.recorder/start-recording! :story.b/target 99999)
+           (is (rf.story.recorder/recording?))
+           (is (= :story.b/target (rf.story.recorder/recording-variant)))
+           (is (= [] (rf.story.recorder/recorded-events))
                "the recorder atom is now empty / aimed at B")
 
            ;; Step 3: re-render the dialog. The snippet MUST still
            ;; reflect A's events + A's variant id — NOT empty/B.
-           (let [snippet-after (str (ui-rec/save-dialog))]
+           (let [snippet-after (str (rf.story.ui.recorder/save-dialog))]
              (is (= snippet-before snippet-after)
                  "the dialog snippet is unchanged after start-recording!")
              (is (str/includes? snippet-after ":counter/inc")
@@ -214,13 +214,13 @@
      (testing "rf2-8x9nb: events captured into a fresh recording after the
               dialog opened do NOT appear in the open dialog's snippet"
        (let [a-events [[:counter/inc]]]
-         (reset! ui-rec/ui-dialog
-                 (recorder/open-dialog recorder/initial-dialog-state
+         (reset! rf.story.ui.recorder/ui-dialog
+                 (rf.story.recorder/open-dialog rf.story.recorder/initial-dialog-state
                                        :story.a/source a-events nil 12345))
-         (recorder/start-recording! :story.b/target 99999)
-         (recorder/record-event! [:auth/login {:email "test@test"}])
-         (recorder/record-event! [:auth/logout])
-         (let [flat (str (ui-rec/save-dialog))]
+         (rf.story.recorder/start-recording! :story.b/target 99999)
+         (rf.story.recorder/record-event! [:auth/login {:email "test@test"}])
+         (rf.story.recorder/record-event! [:auth/logout])
+         (let [flat (str (rf.story.ui.recorder/save-dialog))]
            (is (str/includes? flat ":counter/inc")
                "A's original event remains in the snippet")
            (is (not (str/includes? flat ":auth/login"))
@@ -231,7 +231,7 @@
 
 #?(:cljs
    (defn- open-picker-for-test! []
-     (reset! ui-rec/ui-picker {:open?        true
+     (reset! rf.story.ui.recorder/ui-picker {:open?        true
                                :assertion    nil
                                :field-text   {}
                                :error        nil
@@ -242,7 +242,7 @@
      (testing "rf2-p1ai7: the assertion picker carries role=dialog +
               aria-modal + aria-labelledby on its panel"
        (open-picker-for-test!)
-       (let [flat (str (ui-rec/assertion-picker))]
+       (let [flat (str (rf.story.ui.recorder/assertion-picker))]
          (is (str/includes? flat "dialog")     "role=dialog appears")
          (is (str/includes? flat "aria-modal") "aria-modal flag is stamped")
          (is (str/includes? flat "aria-labelledby")
@@ -256,7 +256,7 @@
               menuitem rows + a roving tabindex (only the active row
               has tabindex=0)."
        (open-picker-for-test!)
-       (let [flat (str (ui-rec/assertion-picker))]
+       (let [flat (str (rf.story.ui.recorder/assertion-picker))]
          (is (str/includes? flat "menu")
              "role=menu identifies the vocab container")
          (is (str/includes? flat "menuitem")
@@ -274,15 +274,15 @@
      (testing "rf2-07m13: set-active-index! clamps + wraps the cursor
               across the vocabulary length."
        (open-picker-for-test!)
-       (let [n (count recorder/assertion-vocabulary)]
+       (let [n (count rf.story.recorder/assertion-vocabulary)]
          ;; Step forward through bounds.
-         (#'ui-rec/set-active-index! 0)
-         (is (= 0 (:active-index @ui-rec/ui-picker)))
-         (#'ui-rec/set-active-index! 1)
-         (is (= 1 (:active-index @ui-rec/ui-picker)))
+         (#'rf.story.ui.recorder/set-active-index! 0)
+         (is (= 0 (:active-index @rf.story.ui.recorder/ui-picker)))
+         (#'rf.story.ui.recorder/set-active-index! 1)
+         (is (= 1 (:active-index @rf.story.ui.recorder/ui-picker)))
          ;; Past the end wraps to 0.
-         (#'ui-rec/set-active-index! (+ n 5))
-         (is (= 0 (:active-index @ui-rec/ui-picker)))
+         (#'rf.story.ui.recorder/set-active-index! (+ n 5))
+         (is (= 0 (:active-index @rf.story.ui.recorder/ui-picker)))
          ;; Negative wraps to the last index.
-         (#'ui-rec/set-active-index! -1)
-         (is (= (dec n) (:active-index @ui-rec/ui-picker)))))))
+         (#'rf.story.ui.recorder/set-active-index! -1)
+         (is (= (dec n) (:active-index @rf.story.ui.recorder/ui-picker)))))))

--- a/tools/story/test/re_frame/story/ui/recorder_export_dialog_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/recorder_export_dialog_cljs_test.cljc
@@ -15,16 +15,16 @@
     replay / close buttons all surface)."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story.recorder                    :as recorder]
-            [re-frame.story.recorder.play-export        :as export]
-            [re-frame.story.recorder.play-export-events :as export-events]
-            #?(:cljs [re-frame.story.ui.recorder-export-dialog :as export-dialog])))
+            [re-frame.story.recorder                    :as rf.story.recorder]
+            [re-frame.story.recorder.play-export        :as rf.story.recorder.play-export]
+            [re-frame.story.recorder.play-export-events :as rf.story.recorder.play-export-events]
+            #?(:cljs [re-frame.story.ui.recorder-export-dialog :as rf.story.ui.recorder-export-dialog])))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 #?(:cljs
    (defn reset-dialog! [f]
-     (reset! export-dialog/ui-dialog export-dialog/initial-state)
+     (reset! rf.story.ui.recorder-export-dialog/ui-dialog rf.story.ui.recorder-export-dialog/initial-state)
      (f)))
 
 #?(:cljs (use-fixtures :each reset-dialog!))
@@ -33,7 +33,7 @@
 
 (deftest build-export-tuple-shape
   (testing "build-export yields {:spec :rendered} with both shapes well-formed"
-    (let [{:keys [spec rendered]} (export-events/build-export
+    (let [{:keys [spec rendered]} (rf.story.recorder.play-export-events/build-export
                                     [[:counter/inc] [:counter/dec]]
                                     {:variant-id :story.x/recorded
                                      :extends    :story.x/source
@@ -50,7 +50,7 @@
 
 (deftest build-export-auto-assert-flows-through
   (testing "the auto-assert option produces trailing :assert-db steps"
-    (let [{:keys [spec]} (export-events/build-export
+    (let [{:keys [spec]} (rf.story.recorder.play-export-events/build-export
                            [[:counter/inc]]
                            {:variant-id :story.x/recorded
                             :auto-assert? true
@@ -65,11 +65,11 @@
 #?(:cljs
    (deftest open-dialog-snapshots-input
      (testing "open-dialog stashes the captured events + source-id on the ratom"
-       (export-dialog/open-dialog!
+       (rf.story.ui.recorder-export-dialog/open-dialog!
          {:source-id :story.a/source
           :events    [[:counter/inc] [:counter/dec]]
           :final-db  {:n 1}})
-       (let [s @export-dialog/ui-dialog]
+       (let [s @rf.story.ui.recorder-export-dialog/ui-dialog]
          (is (:open? s))
          (is (= :story.a/source (:source-id s)))
          (is (= [[:counter/inc] [:counter/dec]] (:events s)))
@@ -80,19 +80,19 @@
 #?(:cljs
    (deftest variant-id-derived-from-source-id
      (testing "the default :variant-id is derived from source-id's namespace"
-       (export-dialog/open-dialog!
+       (rf.story.ui.recorder-export-dialog/open-dialog!
          {:source-id :story.counter/happy
           :events    [[:counter/inc]]})
        (is (= :story.counter/recorded-script
-              (:variant-id @export-dialog/ui-dialog))))))
+              (:variant-id @rf.story.ui.recorder-export-dialog/ui-dialog))))))
 
 #?(:cljs
    (deftest open-dialog-snapshot-is-decoupled-from-source-vector
      (testing "the snapshot is a fresh vector, not a live ref"
        (let [events (vec [[:counter/inc]])]
-         (export-dialog/open-dialog!
+         (rf.story.ui.recorder-export-dialog/open-dialog!
            {:source-id :story.x/y :events events})
-         (is (= [[:counter/inc]] (:events @export-dialog/ui-dialog))
+         (is (= [[:counter/inc]] (:events @rf.story.ui.recorder-export-dialog/ui-dialog))
              "the dialog carries the snapshot independent of the source vector")))))
 
 ;; ---- CLJS-only: dialog rendering ----------------------------------------
@@ -100,16 +100,16 @@
 #?(:cljs
    (deftest dialog-not-rendered-when-closed
      (testing "the dialog renders nil when :open? is false"
-       (reset! export-dialog/ui-dialog export-dialog/initial-state)
-       (is (nil? (export-dialog/export-dialog))))))
+       (reset! rf.story.ui.recorder-export-dialog/ui-dialog rf.story.ui.recorder-export-dialog/initial-state)
+       (is (nil? (rf.story.ui.recorder-export-dialog/export-dialog))))))
 
 #?(:cljs
    (deftest dialog-renders-snippet-from-events
      (testing "the dialog renders a snippet built from the captured events"
-       (export-dialog/open-dialog!
+       (rf.story.ui.recorder-export-dialog/open-dialog!
          {:source-id :story.x/source
           :events    [[:counter/inc] [:counter/dec]]})
-       (let [flat (str (export-dialog/export-dialog))]
+       (let [flat (str (rf.story.ui.recorder-export-dialog/export-dialog))]
          (is (str/includes? flat ":counter/inc")
              "captured events appear in the snippet")
          (is (str/includes? flat ":counter/dec"))
@@ -145,60 +145,60 @@
               snapshot-independence the test name promises, NOT a self-poke of
               the dialog's own ratom (rf2-x76af2.20)."
        ;; Seed the recorder with a completed capture.
-       (recorder/clear!)
-       (recorder/start-recording! :story.a/source)
-       (recorder/record-event! [:auth/login])
-       (recorder/record-event! [:counter/inc])
-       (is (seq (recorder/recorded-events))
+       (rf.story.recorder/clear!)
+       (rf.story.recorder/start-recording! :story.a/source)
+       (rf.story.recorder/record-event! [:auth/login])
+       (rf.story.recorder/record-event! [:counter/inc])
+       (is (seq (rf.story.recorder/recorded-events))
            "sanity: the recorder captured the seeded events")
        ;; Drive the export-open handler EXACTLY as the toolbar :on-export
        ;; closure does — deref the recorder AT click time and pass the
        ;; snapshot. :source-id nil keeps the frame-db snapshot out of scope.
-       (export-dialog/open-from-recorder-dialog!
-         {:events    (recorder/recorded-events)
-          :entries   (recorder/recorded-entries)
+       (rf.story.ui.recorder-export-dialog/open-from-recorder-dialog!
+         {:events    (rf.story.recorder/recorded-events)
+          :entries   (rf.story.recorder/recorded-entries)
           :source-id nil})
-       (let [snap-events  (:events  @export-dialog/ui-dialog)
-             snap-entries (:entries @export-dialog/ui-dialog)]
-         (is (str/includes? (str (export-dialog/export-dialog)) ":auth/login")
+       (let [snap-events  (:events  @rf.story.ui.recorder-export-dialog/ui-dialog)
+             snap-entries (:entries @rf.story.ui.recorder-export-dialog/ui-dialog)]
+         (is (str/includes? (str (rf.story.ui.recorder-export-dialog/export-dialog)) ":auth/login")
              "the export dialog snapshotted the captured events at open time")
          ;; MUTATE THE RECORDER: a fresh recording resets the atom, a new
          ;; keystroke lands, then a discard — the exact churn the snapshot
          ;; must survive. Were any link reading the recorder live, the
          ;; already-open export would change.
-         (recorder/start-recording! :story.b/other)
-         (recorder/record-event! [:counter/dec])
-         (recorder/clear!)
-         (is (= snap-events (:events @export-dialog/ui-dialog))
+         (rf.story.recorder/start-recording! :story.b/other)
+         (rf.story.recorder/record-event! [:counter/dec])
+         (rf.story.recorder/clear!)
+         (is (= snap-events (:events @rf.story.ui.recorder-export-dialog/ui-dialog))
              "recorder churn did not change the export dialog :events snapshot")
-         (is (= snap-entries (:entries @export-dialog/ui-dialog))
+         (is (= snap-entries (:entries @rf.story.ui.recorder-export-dialog/ui-dialog))
              "recorder churn did not change the export dialog :entries snapshot")
-         (let [after (str (export-dialog/export-dialog))]
+         (let [after (str (rf.story.ui.recorder-export-dialog/export-dialog))]
            (is (str/includes? after ":auth/login")
                "the rendered export still carries the originally-captured events")
            (is (not (str/includes? after ":counter/dec"))
                "the post-open recorder keystroke never leaked into the export")))
        ;; Leave the recorder idle for the next test.
-       (recorder/clear!))))
+       (rf.story.recorder/clear!))))
 
 #?(:cljs
    (deftest dialog-auto-assert-includes-assertions-in-snippet
      (testing "auto-assert ON yields a snippet containing :assert-db steps"
-       (export-dialog/open-dialog!
+       (rf.story.ui.recorder-export-dialog/open-dialog!
          {:source-id :story.x/source
           :events    [[:counter/inc]]
           :final-db  {:n 5 :who "alice"}})
-       (let [flat (str (export-dialog/export-dialog))]
+       (let [flat (str (rf.story.ui.recorder-export-dialog/export-dialog))]
          (is (str/includes? flat ":assert-db")
              "auto-assert ON produces trailing :assert-db steps in the snippet")))))
 
 #?(:cljs
    (deftest dialog-without-final-db-omits-assertions
      (testing "auto-assert ON but no :final-db → no :assert-db steps"
-       (export-dialog/open-dialog!
+       (rf.story.ui.recorder-export-dialog/open-dialog!
          {:source-id :story.x/source
           :events    [[:counter/inc]]
           :final-db  nil})
-       (let [flat (str (export-dialog/export-dialog))]
+       (let [flat (str (rf.story.ui.recorder-export-dialog/export-dialog))]
          (is (not (str/includes? flat ":assert-db"))
              "nothing to assert against → no trailing block")))))

--- a/tools/story/test/re_frame/story/ui/render_shell_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/render_shell_cljs_test.cljs
@@ -31,46 +31,46 @@
 
   - **Slow-loading variant render: substrate-portability fallback** —
     when a substrate is unregistered (the slow-loader path the user
-    sees when a custom substrate doesn't ship), `multi-substrate/
+    sees when a custom substrate doesn't ship), `rf.story.ui.multi-substrate/
     safe-render-cell` projects the `unregistered-substrate` error
     cell. Pin the shape so the user sees a loading-affordance-style
     inline message rather than a blank cell."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.machines         :as machines]
-            [re-frame.registrar        :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story            :as story]
-            [re-frame.story.loaders    :as loaders]
-            [re-frame.story.plan       :as plan]
-            [re-frame.story.render     :as render]
-            [re-frame.story.runtime    :as runtime]
-            [re-frame.story.ui.canvas  :as canvas]
-            [re-frame.story.ui.multi-substrate :as multi-substrate]
-            [re-frame.story.ui.state   :as state]
-            [re-frame.subs             :as subs]))
+            [re-frame.frame            :as rf.frame]
+            [re-frame.machines         :as rf.machines]
+            [re-frame.registrar        :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story            :as rf.story]
+            [re-frame.story.loaders    :as rf.story.loaders]
+            [re-frame.story.plan       :as rf.story.plan]
+            [re-frame.story.render     :as rf.story.render]
+            [re-frame.story.runtime    :as rf.story.runtime]
+            [re-frame.story.ui.canvas  :as rf.story.ui.canvas]
+            [re-frame.story.ui.multi-substrate :as rf.story.ui.multi-substrate]
+            [re-frame.story.ui.state   :as rf.story.ui.state]
+            [re-frame.subs             :as rf.subs]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch :default _ nil))
   ;; Re-register the framework `:rf/machine` sub after the registrar clear.
   ;; EP-0001 (rf2-vzld77 / rf2-ixb0bq): a runtime-db sub reading
   ;; [:rf.runtime/machines :snapshots <id>], NOT the retired app-db
   ;; `:rf/runtime` path — mirror `re-frame.machines`.
-  (subs/reg-runtime-sub :rf/machine
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [runtime-db [_ machine-id]]
       (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -105,7 +105,7 @@
                                      (throw (ex-info "wrap exploded"
                                                      {:where :under-test})))}}
           view       [:div.user "user view"]
-          result     (canvas/safe-decorated-view view [boom-dec] {})
+          result     (rf.story.ui.canvas/safe-decorated-view view [boom-dec] {})
           text-bits  (hiccup-text-flatten result)]
       ;; The result is a hiccup vector, not the thrown exception —
       ;; the shell continues to render this tree.
@@ -137,7 +137,7 @@
           good-2     {:id   :inner-wrap
                       :body {:wrap (fn [body _] [:div.inner body])}}
           view       [:div.user "view"]
-          result     (canvas/safe-decorated-view view [good-1 boom good-2] {})
+          result     (rf.story.ui.canvas/safe-decorated-view view [good-1 boom good-2] {})
           text-bits  (hiccup-text-flatten result)]
       ;; All three decorator ids appear in the error projection.
       (doseq [id [:outer-wrap :middle-wrap :inner-wrap]]
@@ -151,7 +151,7 @@
             wrapper doesn't accidentally project an error block when
             no decorators throw"
     (let [view   [:div.user "user view"]
-          result (canvas/safe-decorated-view view [] {})]
+          result (rf.story.ui.canvas/safe-decorated-view view [] {})]
       (is (= view result)
           "no decorators → view passes through verbatim"))))
 
@@ -162,7 +162,7 @@
                   :body {:wrap (fn [body _]
                                  [:div.wrapper body])}}
           view   [:div.user "view"]
-          result (canvas/safe-decorated-view view [dec] {})]
+          result (rf.story.ui.canvas/safe-decorated-view view [dec] {})]
       ;; The wrapper is present.
       (is (= :div.wrapper (first result))
           "happy-path decorator's wrap is engaged")
@@ -184,13 +184,13 @@
 ;; ===========================================================================
 
 (deftest loader-incomplete-record-shape-pinned
-  (testing "runtime/loader-incomplete-record produces a record whose
+  (testing "rf.story.runtime/loader-incomplete-record produces a record whose
             slot shape the canvas's renderer reads. Pin the shape so
             a future refactor to the record doesn't silently break
             the canvas's loading-affordance render"
     (let [variant-id   :story.slow.loader/probe
           variant-body {:loaders-complete-when :probe/never}
-          record       (#'runtime/loader-incomplete-record
+          record       (#'rf.story.runtime/loader-incomplete-record
                          variant-id variant-body)]
       (is (= :rf.error/loader-incomplete (:assertion record))
           ":assertion is the canonical error id the canvas matches on")
@@ -215,7 +215,7 @@
             renders a generic 'loaders did not complete' message"
     (let [variant-id   :story.slow.loader.no-pred/probe
           variant-body {:loaders [[:probe/start]]}  ; no :loaders-complete-when
-          record       (#'runtime/loader-incomplete-record
+          record       (#'rf.story.runtime/loader-incomplete-record
                          variant-id variant-body)]
       (is (= :rf.error/loader-incomplete (:assertion record)))
       (is (nil? (:predicate record))
@@ -249,20 +249,20 @@
             error cell"
     ;; First, REMOVE any existing :uix registration so we test the
     ;; not-registered path deterministically.
-    (swap! multi-substrate/substrate->render-fn dissoc :uix)
-    (is (not (contains? @multi-substrate/substrate->render-fn :uix))
+    (swap! rf.story.ui.multi-substrate/substrate->render-fn dissoc :uix)
+    (is (not (contains? @rf.story.ui.multi-substrate/substrate->render-fn :uix))
         "precondition: :uix not in the substrate registry")
     (let [variant-id :story.substrate.missing/probe]
       ;; Use :uix from the canonical enum — it parses, but the runtime
       ;; map doesn't carry a render-fn for it.
-      (story/reg-variant variant-id
+      (rf.story/reg-variant variant-id
         {:substrates #{:uix}
          :setup     []})
       ;; Drive the renderer: multi-substrate-grid is the outer fn the
       ;; canvas dispatches to; the inner safe-render-cell is what
       ;; surfaces the error cell. We render the grid then walk for the
       ;; expected text.
-      (let [hiccup    (multi-substrate/multi-substrate-grid variant-id)
+      (let [hiccup    (rf.story.ui.multi-substrate/multi-substrate-grid variant-id)
             text-bits (hiccup-text-flatten hiccup)]
         (is (some #(re-find #"uix" %) text-bits)
             "the missing substrate id is named in the error cell")
@@ -279,15 +279,15 @@
             slot); the variant uses :uix and the cell renders via the
             stub. The :reagent slot is untouched (the canvas's
             default-substrate baseline)"
-    (multi-substrate/register-substrate!
+    (rf.story.ui.multi-substrate/register-substrate!
       :uix
       (fn [_vid _view-id _args]
         [:div.stub-cell "rendered via stub"]))
     (let [variant-id :story.substrate.ok/probe]
-      (story/reg-variant variant-id
+      (rf.story/reg-variant variant-id
         {:substrates #{:uix}
          :setup     []})
-      (let [hiccup    (multi-substrate/multi-substrate-grid variant-id)
+      (let [hiccup    (rf.story.ui.multi-substrate/multi-substrate-grid variant-id)
             text-bits (hiccup-text-flatten hiccup)]
         ;; On the happy-path branch, safe-render-cell wraps the cell
         ;; body in a Reagent class component (r/create-class) so the
@@ -311,7 +311,7 @@
 ;; variant's :decorators — so a render-variant render of a decorated variant
 ;; diverged from the live canvas (which wraps via safe-decorated-view). The
 ;; consolidation routes BOTH through the shared
-;; `multi-substrate/render-decorated-view` seam, so they paint the same tree.
+;; `rf.story.ui.multi-substrate/render-decorated-view` seam, so they paint the same tree.
 ;; These CLJS tests prove the HOST actually applies the decorators — the
 ;; existing render_test §decorators-are-view-wrapping only pinned that
 ;; :decorators RIDE render-inputs, never that the host APPLIES them. Uses a
@@ -323,17 +323,17 @@
   (testing "the shared render-decorated-view seam (the host hook + the canvas
             both call it) wraps the rendered view in the variant's :hiccup
             decorators resolved from the compiled plan's [:world :decorators]"
-    (story/reg-decorator :deco/themed
+    (rf.story/reg-decorator :deco/themed
       {:kind :hiccup :wrap (fn [body _] [:div.themed body])})
     (rf/reg-sub :probe/label (fn [db _] (:label db)))
     (rf/reg-view* :views/probe (fn [_] [:span.leaf "leaf"]))
-    (story/reg-variant :story.hostdeco/v
+    (rf.story/reg-variant :story.hostdeco/v
       {:component  :views/probe
        :decorators [[:deco/themed]]
        :setup     []})
-    (let [plan        (plan/variant-plan :story.hostdeco/v)
+    (let [plan        (rf.story.plan/variant-plan :story.hostdeco/v)
           deco-refs   (get-in plan [:world :decorators])
-          rendered    (multi-substrate/render-decorated-view
+          rendered    (rf.story.ui.multi-substrate/render-decorated-view
                         :reagent :story.hostdeco/v :views/probe {} deco-refs)
           ;; the OUTERMOST node must be the decorator wrap, not the bare view.
           outer       (first rendered)]
@@ -347,11 +347,11 @@
   (testing "a variant with NO :decorators renders bare through the shared
             seam — render-transparent (no spurious wrapper)"
     (rf/reg-view* :views/plain (fn [_] [:span.leaf "leaf"]))
-    (story/reg-variant :story.hostnodeco/v
+    (rf.story/reg-variant :story.hostnodeco/v
       {:component :views/plain :setup []})
-    (let [plan      (plan/variant-plan :story.hostnodeco/v)
+    (let [plan      (rf.story.plan/variant-plan :story.hostnodeco/v)
           deco-refs (get-in plan [:world :decorators])
-          rendered  (multi-substrate/render-decorated-view
+          rendered  (rf.story.ui.multi-substrate/render-decorated-view
                       :reagent :story.hostnodeco/v :views/plain {} deco-refs)]
       (is (nil? deco-refs) "no decorators on the plan")
       ;; render-view returns the bare [view eff-args] vector for :reagent.
@@ -363,19 +363,19 @@
             resolve the SAME :extends-inherited decorator off the compiled
             plan — the registered (DEFAULT-lookup) production path
             (rf2-hzhmv / rf2-ba86n.8 / rf2-g74i9)"
-    (story/reg-decorator :deco/parent-themed
+    (rf.story/reg-decorator :deco/parent-themed
       {:kind :hiccup :wrap (fn [body _] [:div.parent-themed body])})
-    (story/reg-variant :story.inhdeco/parent
+    (rf.story/reg-variant :story.inhdeco/parent
       {:component  :views/probe
        :decorators [[:deco/parent-themed]]
        :setup     []})
     ;; child inherits the parent's decorator via :extends, declares none.
-    (story/reg-variant :story.inhdeco/child
+    (rf.story/reg-variant :story.inhdeco/child
       {:extends :story.inhdeco/parent
        :setup  []})
-    (let [prepared    (render/prepare-render :story.inhdeco/child)
+    (let [prepared    (rf.story.render/prepare-render :story.inhdeco/child)
           rv-refs     (get-in prepared [:render-inputs :decorators])
-          canvas-ids  (mapv :id (:hiccup (story/resolve-decorators :story.inhdeco/child)))]
+          canvas-ids  (mapv :id (:hiccup (rf.story/resolve-decorators :story.inhdeco/child)))]
       (is (= [[:deco/parent-themed]] rv-refs)
           "render-variant carries the INHERITED decorator refs (NOT empty —
            the bare-body read would have dropped the :extends-inherited stack)")
@@ -387,14 +387,14 @@
   (testing "render-variant returns :rendered for a registered decorated
             variant (the host is installed by the canonical vocabulary), so
             the single render path paints — not :cannot-run"
-    (story/reg-decorator :deco/e2e
+    (rf.story/reg-decorator :deco/e2e
       {:kind :hiccup :wrap (fn [body _] [:div.e2e body])})
     (rf/reg-view* :views/e2e (fn [_] [:span "v"]))
-    (story/reg-variant :story.e2edeco/v
+    (rf.story/reg-variant :story.e2edeco/v
       {:component  :views/e2e
        :decorators [[:deco/e2e]]
        :setup     []})
-    (let [r (render/render-variant :story.e2edeco/v)]
+    (let [r (rf.story.render/render-variant :story.e2edeco/v)]
       (is (= :rendered (:status r))
           "the host is installed (CLJS canonical vocabulary) → :rendered")
       (is (some? (:rendered r))

--- a/tools/story/test/re_frame/story/ui/save_variant_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/save_variant_cljs_test.cljc
@@ -20,14 +20,14 @@
   `:node-test` / `:browser-test` targets (ns suffix `-cljs-test`)."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
-            [re-frame.story.save-variant :as save-variant]
-            #?(:cljs [re-frame.story.ui.save-variant :as ui-sv])))
+            [re-frame.story.save-variant :as rf.story.save-variant]
+            #?(:cljs [re-frame.story.ui.save-variant :as rf.story.ui.save-variant])))
 
 ;; ---- JVM + CLJS: contract surface ----------------------------------------
 
 (deftest gen-variant-snippet-emits-reg-variant-form
   (testing "the generator emits an EDN (reg-variant ...) form the UI previews"
-    (let [snip (save-variant/gen-variant-snippet
+    (let [snip (rf.story.save-variant/gen-variant-snippet
                  {:variant-id :story.x/y
                   :extends    :story.x/source
                   :args       {:n 1}})]
@@ -38,9 +38,9 @@
 
 (deftest dialog-state-machine-open-close
   (testing "open + close are the two transitions the UI ratom swaps"
-    (let [opened (save-variant/open save-variant/initial-dialog-state
+    (let [opened (rf.story.save-variant/open rf.story.save-variant/initial-dialog-state
                                     :story.x/y {:n 1} 0)
-          closed (save-variant/close opened)]
+          closed (rf.story.save-variant/close opened)]
       (is (:open? opened))
       (is (= :story.x/y (:source-id opened)))
       (is (= {:n 1} (:args opened)))
@@ -49,8 +49,8 @@
 
 (deftest dialog-set-draft-id-replaces-id-slot
   (testing "set-draft-id is the per-keystroke transition the UI calls on edit"
-    (let [s (save-variant/set-draft-id
-              (save-variant/open save-variant/initial-dialog-state
+    (let [s (rf.story.save-variant/set-draft-id
+              (rf.story.save-variant/open rf.story.save-variant/initial-dialog-state
                                  :story.x/y {} 0)
               :story.x/edited)]
       (is (= :story.x/edited (:draft-id s))))))
@@ -60,7 +60,7 @@
 #?(:cljs
    (deftest save-variant-button-disabled-without-variant
      (testing "the button is disabled + carries a hinted title when no variant focused"
-       (let [hiccup (ui-sv/save-variant-button nil)
+       (let [hiccup (rf.story.ui.save-variant/save-variant-button nil)
              attrs  (second hiccup)]
          (is (true? (:disabled attrs)))
          (is (str/includes? (:title attrs) "Select a variant"))
@@ -69,7 +69,7 @@
 #?(:cljs
    (deftest save-variant-button-enabled-with-variant
      (testing "the button enables when a variant is in focus"
-       (let [hiccup (ui-sv/save-variant-button :story.x/y)
+       (let [hiccup (rf.story.ui.save-variant/save-variant-button :story.x/y)
              attrs  (second hiccup)]
          (is (false? (:disabled attrs)))
          (is (str/includes? (:title attrs) "Capture"))
@@ -78,7 +78,7 @@
 #?(:cljs
    (deftest save-variant-button-on-click-callable
      (testing "the on-click handler is a 1-arg fn (event); calling does not throw"
-       (let [hiccup (ui-sv/save-variant-button :story.x/y)
+       (let [hiccup (rf.story.ui.save-variant/save-variant-button :story.x/y)
              attrs  (second hiccup)
              on-click (:on-click attrs)]
          (is (fn? on-click))))))
@@ -88,18 +88,18 @@
 #?(:cljs
    (deftest save-dialog-not-rendered-when-closed
      (testing "the dialog renders nil when the ratom :open? is false"
-       (reset! ui-sv/ui-dialog save-variant/initial-dialog-state)
-       (is (nil? (ui-sv/save-dialog))))))
+       (reset! rf.story.ui.save-variant/ui-dialog rf.story.save-variant/initial-dialog-state)
+       (is (nil? (rf.story.ui.save-variant/save-dialog))))))
 
 #?(:cljs
    (deftest save-dialog-renders-snippet-when-open
      (testing "the dialog renders a hiccup tree with the snippet preview"
-       (reset! ui-sv/ui-dialog
-               (save-variant/open save-variant/initial-dialog-state
+       (reset! rf.story.ui.save-variant/ui-dialog
+               (rf.story.save-variant/open rf.story.save-variant/initial-dialog-state
                                   :story.x/source
                                   {:label "hello" :n 42}
                                   12345))
-       (let [hiccup (ui-sv/save-dialog)
+       (let [hiccup (rf.story.ui.save-variant/save-dialog)
              flat   (str hiccup)]
          (is (vector? hiccup) "the dialog renders a hiccup tree")
          (is (str/includes? flat "story-save-variant-dialog"))
@@ -112,12 +112,12 @@
 #?(:cljs
    (deftest save-dialog-snippet-renders-extends
      (testing "the rendered snippet pins :extends to the source variant"
-       (reset! ui-sv/ui-dialog
-               (save-variant/open save-variant/initial-dialog-state
+       (reset! rf.story.ui.save-variant/ui-dialog
+               (rf.story.save-variant/open rf.story.save-variant/initial-dialog-state
                                   :story.x/source
                                   {}
                                   12345))
-       (let [flat (str (ui-sv/save-dialog))]
+       (let [flat (str (rf.story.ui.save-variant/save-dialog))]
          (is (str/includes? flat ":extends"))
          (is (str/includes? flat ":story.x/source"))))))
 
@@ -127,13 +127,13 @@
   (testing "rf2-lancu — snapshot-violations is a thin pass-through to
             schema-validation/args-violations; soft-passes per Spec 010
             when no validator / no schema (returns empty vec)"
-    (is (= [] (save-variant/snapshot-violations {:a 1} nil nil)))
-    (is (= [] (save-variant/snapshot-violations
+    (is (= [] (rf.story.save-variant/snapshot-violations {:a 1} nil nil)))
+    (is (= [] (rf.story.save-variant/snapshot-violations
                 {:a 1}
                 [:map [:a :int]]
                 nil))
         "no validator-fns → soft-pass per Spec 010")
-    (is (= [] (save-variant/snapshot-violations
+    (is (= [] (rf.story.save-variant/snapshot-violations
                 {:a 1}
                 [:map [:a :int]]
                 {:validate (fn [_ _] true)}))
@@ -143,7 +143,7 @@
   (testing "rf2-lancu — when args break the schema the violation list
             names the offending keys + their values so the save dialog
             can render the 'paste at your own risk' hint pre-paste"
-    (let [violations (save-variant/snapshot-violations
+    (let [violations (rf.story.save-variant/snapshot-violations
                        {:a 1 :b "oops"}
                        [:map [:a :int] [:b :int]]
                        {:validate (fn [s v]
@@ -154,11 +154,11 @@
       (is (= "oops" (-> violations first :value))))))
 
 (deftest open-stamps-violations-on-dialog-state
-  (testing "rf2-lancu — save-variant/open's 5-arity stamps the violations
+  (testing "rf2-lancu — rf.story.save-variant/open's 5-arity stamps the violations
             vector on the dialog state so the save dialog can render the
             non-blocking hint above the snippet"
     (let [vs [{:key :b :value "oops" :schema :int :explain nil}]
-          s  (save-variant/open save-variant/initial-dialog-state
+          s  (rf.story.save-variant/open rf.story.save-variant/initial-dialog-state
                                 :story.x/y {:a 1 :b "oops"} 0 vs)]
       (is (true? (:open? s)))
       (is (= vs (:violations s))
@@ -168,7 +168,7 @@
   (testing "rf2-lancu — back-compat: the legacy 3-arity (without
             violations) stamps an empty vec so the dialog hint path
             renders nothing"
-    (let [s (save-variant/open save-variant/initial-dialog-state
+    (let [s (rf.story.save-variant/open rf.story.save-variant/initial-dialog-state
                                :story.x/y {:a 1} 0)]
       (is (= [] (:violations s))))))
 
@@ -176,13 +176,13 @@
    (deftest save-dialog-renders-no-violations-hint-when-empty
      (testing "rf2-lancu — when the snapshot conforms (no violations) the
                dialog renders the snippet without the violations hint"
-       (reset! ui-sv/ui-dialog
-               (save-variant/open save-variant/initial-dialog-state
+       (reset! rf.story.ui.save-variant/ui-dialog
+               (rf.story.save-variant/open rf.story.save-variant/initial-dialog-state
                                   :story.x/source
                                   {:label "hi"}
                                   12345
                                   []))
-       (let [flat (str (ui-sv/save-dialog))]
+       (let [flat (str (rf.story.ui.save-variant/save-dialog))]
          (is (not (str/includes? flat "story-save-variant-violations-hint"))
              "no hint when violations is empty")
          (is (not (str/includes? flat "paste at your own risk"))
@@ -195,14 +195,14 @@
                listing the offending keys. Non-blocking — the user can
                still copy / paste; the snippet carries the violating
                args as captured"
-       (reset! ui-sv/ui-dialog
-               (save-variant/open save-variant/initial-dialog-state
+       (reset! rf.story.ui.save-variant/ui-dialog
+               (rf.story.save-variant/open rf.story.save-variant/initial-dialog-state
                                   :story.x/source
                                   {:label "hi" :count "not-an-int"}
                                   12345
                                   [{:key :count :value "not-an-int"
                                     :schema :int :explain nil}]))
-       (let [flat (str (ui-sv/save-dialog))]
+       (let [flat (str (rf.story.ui.save-variant/save-dialog))]
          (is (str/includes? flat "story-save-variant-violations-hint")
              "the hint container is present")
          (is (str/includes? flat "paste at your own risk")
@@ -218,16 +218,16 @@
 
 (deftest capture-slices-covers-all-eight-slices
   (testing "every slice in spec/019 §3 is classified — none silently dropped"
-    (let [report (save-variant/capture-slices {:n 1} nil {})
+    (let [report (rf.story.save-variant/capture-slices {:n 1} nil {})
           slices (set (map :slice report))]
-      (is (= (set save-variant/slice-order) slices)
+      (is (= (set rf.story.save-variant/slice-order) slices)
           "the report covers exactly the eight canonical slices")
-      (is (= save-variant/slice-order (mapv :slice report))
+      (is (= rf.story.save-variant/slice-order (mapv :slice report))
           "rows render in the canonical slice-order"))))
 
 (deftest capture-slices-args-is-projectable
   (testing "args (+ transient-controls) are the projectable pair; args emits"
-    (let [report   (save-variant/capture-slices {:n 7} nil {})
+    (let [report   (rf.story.save-variant/capture-slices {:n 7} nil {})
           by-slice (into {} (map (juxt :slice identity)) report)]
       (is (= :projectable (-> by-slice :args :status)))
       (is (true? (-> by-slice :args :emit?)) "args contributes the :args slot")
@@ -239,7 +239,7 @@
 (deftest capture-slices-unwired-slices-warn-not-fabricate
   (testing "with a bare source body, the not-yet-wired slices are :not-wired
             — captured nothing, honest warning, never a fabricated value"
-    (let [report   (save-variant/capture-slices {:n 1} nil {:viewport :tablet})
+    (let [report   (rf.story.save-variant/capture-slices {:n 1} nil {:viewport :tablet})
           by-slice (into {} (map (juxt :slice identity)) report)]
       (doseq [s [:sub-overrides :db-seed :route :network :fx-overrides :viewport]]
         (is (= :not-wired (-> by-slice s :status))
@@ -263,7 +263,7 @@
                     :fx-overrides  {:my/fx 1}
                     :setup         [[:e]]
                     :viewport      :tablet}
-          report   (save-variant/capture-slices {:n 1} body {})
+          report   (rf.story.save-variant/capture-slices {:n 1} body {})
           by-slice (into {} (map (juxt :slice identity)) report)]
       (doseq [[s v] {:sub-overrides {[:s] :v}
                      :network       {[:get "/u"] {:reply {}}}
@@ -279,8 +279,8 @@
 (deftest slice-warnings-filters-projectable
   (testing "slice-warnings keeps only the rows the user must see — every slice
             that is NOT a clean live projection"
-    (let [report   (save-variant/capture-slices {:n 1} nil {})
-          warnings (save-variant/slice-warnings report)]
+    (let [report   (rf.story.save-variant/capture-slices {:n 1} nil {})
+          warnings (rf.story.save-variant/slice-warnings report)]
       (is (every? #(not= :projectable (:status %)) warnings)
           "no projectable rows in the warnings")
       (is (not (some #(= :args (:slice %)) warnings))
@@ -290,25 +290,25 @@
 
 (deftest open-6-arity-stamps-slices
   (testing "rf2-ba86n.6 — open's 6-arity stamps the slice report on the dialog"
-    (let [report (save-variant/capture-slices {:n 1} nil {})
-          s      (save-variant/open save-variant/initial-dialog-state
+    (let [report (rf.story.save-variant/capture-slices {:n 1} nil {})
+          s      (rf.story.save-variant/open rf.story.save-variant/initial-dialog-state
                                     :story.x/y {:n 1} 0 [] report)]
       (is (true? (:open? s)))
       (is (= report (:slices s)) "the slice report rides the dialog state"))))
 
 (deftest open-4-arity-defaults-slices-to-empty-vec
   (testing "rf2-ba86n.6 — back-compat: pre-slices arities default :slices to []"
-    (is (= [] (:slices (save-variant/open save-variant/initial-dialog-state
+    (is (= [] (:slices (rf.story.save-variant/open rf.story.save-variant/initial-dialog-state
                                           :story.x/y {:n 1} 0))))
-    (is (= [] (:slices (save-variant/open save-variant/initial-dialog-state
+    (is (= [] (:slices (rf.story.save-variant/open rf.story.save-variant/initial-dialog-state
                                           :story.x/y {:n 1} 0 []))))))
 
 #?(:cljs
    (deftest slice-report-renders-warnings-when-present
      (testing "rf2-ba86n.6 — the slice-report component renders a row per
                non-projectable slice with its status + honest note"
-       (let [report (save-variant/capture-slices {:n 1} nil {:viewport :tablet})
-             flat   (str (ui-sv/slice-report report))]
+       (let [report (rf.story.save-variant/capture-slices {:n 1} nil {:viewport :tablet})
+             flat   (str (rf.story.ui.save-variant/slice-report report))]
          (is (str/includes? flat "story-save-variant-slice-report")
              "the report container is present")
          (is (str/includes? flat "story-save-variant-slice-row")
@@ -324,20 +324,20 @@
                nothing to warn about and the report renders nil"
        (let [all-clean [{:slice :args :status :projectable}
                         {:slice :transient-controls :status :projectable}]]
-         (is (nil? (ui-sv/slice-report all-clean)))))))
+         (is (nil? (rf.story.ui.save-variant/slice-report all-clean)))))))
 
 #?(:cljs
    (deftest save-dialog-renders-slice-report-when-open
      (testing "rf2-ba86n.6 — the open dialog renders the slice report below
                the snippet so the save is honest about what it captures"
-       (reset! ui-sv/ui-dialog
-               (save-variant/open save-variant/initial-dialog-state
+       (reset! rf.story.ui.save-variant/ui-dialog
+               (rf.story.save-variant/open rf.story.save-variant/initial-dialog-state
                                   :story.x/source
                                   {:n 1}
                                   12345
                                   []
-                                  (save-variant/capture-slices {:n 1} nil {})))
-       (let [flat (str (ui-sv/save-dialog))]
+                                  (rf.story.save-variant/capture-slices {:n 1} nil {})))
+       (let [flat (str (rf.story.ui.save-variant/save-dialog))]
          (is (str/includes? flat "story-save-variant-slice-report")
              "the slice report renders inside the open dialog")
          (is (str/includes? flat "story-save-variant-snippet")

--- a/tools/story/test/re_frame/story/ui/schema_form_test.cljc
+++ b/tools/story/test/re_frame/story/ui/schema_form_test.cljc
@@ -14,7 +14,7 @@
                           artifact kind, source never written directly)."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
-            [re-frame.story.ui.schema-form :as sf]))
+            [re-frame.story.ui.schema-form :as rf.story.ui.schema-form]))
 
 ;; ---------------------------------------------------------------------------
 ;; scalar-widget — the flat scalar vocabulary; non-flat → nil
@@ -22,29 +22,29 @@
 
 (deftest scalar-widget-maps-the-flat-shapes
   (testing "each flat scalar maps to its widget tag"
-    (is (= {:widget :text}                (sf/scalar-widget :string)))
-    (is (= {:widget :number :integer? true} (sf/scalar-widget :int)))
-    (is (= {:widget :number}              (sf/scalar-widget :double)))
-    (is (= {:widget :number}              (sf/scalar-widget :number)))
-    (is (= {:widget :boolean}             (sf/scalar-widget :boolean)))
-    (is (= {:widget :text :coerce :keyword} (sf/scalar-widget :keyword))))
+    (is (= {:widget :text}                (rf.story.ui.schema-form/scalar-widget :string)))
+    (is (= {:widget :number :integer? true} (rf.story.ui.schema-form/scalar-widget :int)))
+    (is (= {:widget :number}              (rf.story.ui.schema-form/scalar-widget :double)))
+    (is (= {:widget :number}              (rf.story.ui.schema-form/scalar-widget :number)))
+    (is (= {:widget :boolean}             (rf.story.ui.schema-form/scalar-widget :boolean)))
+    (is (= {:widget :text :coerce :keyword} (rf.story.ui.schema-form/scalar-widget :keyword))))
   (testing "a keyword-enum becomes a select over its options"
     (is (= {:widget :select :options [:loading :ready :error]}
-           (sf/scalar-widget [:enum :loading :ready :error])))))
+           (rf.story.ui.schema-form/scalar-widget [:enum :loading :ready :error])))))
 
 (deftest scalar-widget-rejects-non-flat-shapes
   (testing "collections / nested maps / opaque predicates are NOT flat scalars"
-    (is (nil? (sf/scalar-widget [:map [:k :string]])))
-    (is (nil? (sf/scalar-widget [:vector :int])))
-    (is (nil? (sf/scalar-widget [:set :keyword])))
-    (is (nil? (sf/scalar-widget [:tuple :int :int])))
-    (is (nil? (sf/scalar-widget [:fn 'pos?]))))
+    (is (nil? (rf.story.ui.schema-form/scalar-widget [:map [:k :string]])))
+    (is (nil? (rf.story.ui.schema-form/scalar-widget [:vector :int])))
+    (is (nil? (rf.story.ui.schema-form/scalar-widget [:set :keyword])))
+    (is (nil? (rf.story.ui.schema-form/scalar-widget [:tuple :int :int])))
+    (is (nil? (rf.story.ui.schema-form/scalar-widget [:fn 'pos?]))))
   (testing "a mixed-type / non-keyword enum is NOT a flat select (ambiguous encoding)"
-    (is (nil? (sf/scalar-widget [:enum "a" "b"])))
-    (is (nil? (sf/scalar-widget [:enum 1 2 3])))
-    (is (nil? (sf/scalar-widget [:enum]))))
+    (is (nil? (rf.story.ui.schema-form/scalar-widget [:enum "a" "b"])))
+    (is (nil? (rf.story.ui.schema-form/scalar-widget [:enum 1 2 3])))
+    (is (nil? (rf.story.ui.schema-form/scalar-widget [:enum]))))
   (testing "a registry-name keyword is opaque to a data walk"
-    (is (nil? (sf/scalar-widget :my/user)))))
+    (is (nil? (rf.story.ui.schema-form/scalar-widget :my/user)))))
 
 ;; ---------------------------------------------------------------------------
 ;; field-shape — renderable scalar / flat map / EDN escape hatch
@@ -53,12 +53,12 @@
 (deftest field-shape-single-scalar-is-renderable
   (testing "a top-level flat scalar renders as one widget"
     (is (= {:renderable? true :kind :scalar :widget {:widget :text}}
-           (sf/field-shape :string)))
-    (is (= :select (get-in (sf/field-shape [:enum :a :b]) [:widget :widget])))))
+           (rf.story.ui.schema-form/field-shape :string)))
+    (is (= :select (get-in (rf.story.ui.schema-form/field-shape [:enum :a :b]) [:widget :widget])))))
 
 (deftest field-shape-flat-map-is-renderable
   (testing "a flat map of flat scalars renders one field per declared key"
-    (let [shape (sf/field-shape [:map
+    (let [shape (rf.story.ui.schema-form/field-shape [:map
                                  [:state [:enum :loading :ready :error]]
                                  [:msg   :string]
                                  [:count :int]])]
@@ -67,72 +67,72 @@
       (is (= [:state :msg :count] (mapv :key (:fields shape))))
       (is (= [:select :text :number] (mapv (comp :widget :widget) (:fields shape))))))
   (testing "an optional-marked flat entry is still renderable"
-    (let [shape (sf/field-shape [:map [:msg {:optional true} :string]])]
+    (let [shape (rf.story.ui.schema-form/field-shape [:map [:msg {:optional true} :string]])]
       (is (true? (:renderable? shape)))
       (is (= [:msg] (mapv :key (:fields shape)))))))
 
 (deftest field-shape-non-flat-falls-to-edn-escape-hatch
   (testing "no declared schema → EDN escape hatch with an honest reason"
-    (let [shape (sf/field-shape nil)]
+    (let [shape (rf.story.ui.schema-form/field-shape nil)]
       (is (false? (:renderable? shape)))
       (is (= :edn (:kind shape)))
       (is (str/includes? (:reason shape) "no output schema"))))
   (testing "a map with a NESTED field is non-renderable (flat-shapes-first)"
-    (let [shape (sf/field-shape [:map
+    (let [shape (rf.story.ui.schema-form/field-shape [:map
                                  [:ok :boolean]
                                  [:nested [:map [:deep :string]]]])]
       (is (false? (:renderable? shape)))
       (is (= :edn (:kind shape)))
       (is (str/includes? (:reason shape) ":nested"))))
   (testing "a collection / tuple / predicate schema is non-renderable"
-    (is (false? (:renderable? (sf/field-shape [:vector :int]))))
-    (is (false? (:renderable? (sf/field-shape [:tuple :int :int]))))
-    (is (false? (:renderable? (sf/field-shape [:fn 'map?])))))
+    (is (false? (:renderable? (rf.story.ui.schema-form/field-shape [:vector :int]))))
+    (is (false? (:renderable? (rf.story.ui.schema-form/field-shape [:tuple :int :int]))))
+    (is (false? (:renderable? (rf.story.ui.schema-form/field-shape [:fn 'map?])))))
   (testing "a registry ref is non-renderable but names itself"
-    (let [shape (sf/field-shape :my/user)]
+    (let [shape (rf.story.ui.schema-form/field-shape :my/user)]
       (is (false? (:renderable? shape)))
       (is (str/includes? (:reason shape) ":my/user"))))
   (testing "an empty map schema is non-renderable"
-    (is (false? (:renderable? (sf/field-shape [:map]))))))
+    (is (false? (:renderable? (rf.story.ui.schema-form/field-shape [:map]))))))
 
 ;; ---------------------------------------------------------------------------
 ;; defaults + coercion
 ;; ---------------------------------------------------------------------------
 
 (deftest widget-defaults-are-sensible-empties
-  (is (= ""    (sf/widget-default {:widget :text})))
-  (is (nil?    (sf/widget-default {:widget :number})))
-  (is (false?  (sf/widget-default {:widget :boolean})))
-  (is (= :a    (sf/widget-default {:widget :select :options [:a :b]}))))
+  (is (= ""    (rf.story.ui.schema-form/widget-default {:widget :text})))
+  (is (nil?    (rf.story.ui.schema-form/widget-default {:widget :number})))
+  (is (false?  (rf.story.ui.schema-form/widget-default {:widget :boolean})))
+  (is (= :a    (rf.story.ui.schema-form/widget-default {:widget :select :options [:a :b]}))))
 
 (deftest default-form-value-builds-the-initial-form
   (testing "a scalar shape defaults to its widget default"
-    (is (= "" (sf/default-form-value {:kind :scalar :widget {:widget :text}}))))
+    (is (= "" (rf.story.ui.schema-form/default-form-value {:kind :scalar :widget {:widget :text}}))))
   (testing "a map shape defaults to a per-key default map"
     (is (= {:state :loading :msg "" :count nil}
-           (sf/default-form-value
+           (rf.story.ui.schema-form/default-form-value
              {:kind   :map
               :fields [{:key :state :widget {:widget :select :options [:loading :ready]}}
                        {:key :msg   :widget {:widget :text}}
                        {:key :count :widget {:widget :number :integer? true}}]}))))
   (testing "an EDN shape has no generated default"
-    (is (nil? (sf/default-form-value {:kind :edn})))))
+    (is (nil? (rf.story.ui.schema-form/default-form-value {:kind :edn})))))
 
 (deftest coerce-input-types-the-raw-value
   (testing "text passes through; keyword-coercion strips a leading colon"
-    (is (= "hi"      (sf/coerce-input {:widget :text} "hi")))
-    (is (= :loading  (sf/coerce-input {:widget :text :coerce :keyword} "loading")))
-    (is (= :loading  (sf/coerce-input {:widget :text :coerce :keyword} ":loading")))
-    (is (nil?        (sf/coerce-input {:widget :text :coerce :keyword} ""))))
+    (is (= "hi"      (rf.story.ui.schema-form/coerce-input {:widget :text} "hi")))
+    (is (= :loading  (rf.story.ui.schema-form/coerce-input {:widget :text :coerce :keyword} "loading")))
+    (is (= :loading  (rf.story.ui.schema-form/coerce-input {:widget :text :coerce :keyword} ":loading")))
+    (is (nil?        (rf.story.ui.schema-form/coerce-input {:widget :text :coerce :keyword} ""))))
   (testing "number coerces to int / double; blank → nil; a typo stays raw"
-    (is (= 42        (sf/coerce-input {:widget :number :integer? true} "42")))
-    (is (= 3.5       (sf/coerce-input {:widget :number} "3.5")))
-    (is (nil?        (sf/coerce-input {:widget :number} "")))
-    (is (= "x"       (sf/coerce-input {:widget :number} "x"))))
+    (is (= 42        (rf.story.ui.schema-form/coerce-input {:widget :number :integer? true} "42")))
+    (is (= 3.5       (rf.story.ui.schema-form/coerce-input {:widget :number} "3.5")))
+    (is (nil?        (rf.story.ui.schema-form/coerce-input {:widget :number} "")))
+    (is (= "x"       (rf.story.ui.schema-form/coerce-input {:widget :number} "x"))))
   (testing "boolean + select"
-    (is (true?  (sf/coerce-input {:widget :boolean} true)))
-    (is (false? (sf/coerce-input {:widget :boolean} nil)))
-    (is (= :ready (sf/coerce-input {:widget :select :options [:ready :error]} :ready)))))
+    (is (true?  (rf.story.ui.schema-form/coerce-input {:widget :boolean} true)))
+    (is (false? (rf.story.ui.schema-form/coerce-input {:widget :boolean} nil)))
+    (is (= :ready (rf.story.ui.schema-form/coerce-input {:widget :select :options [:ready :error]} :ready)))))
 
 ;; ---------------------------------------------------------------------------
 ;; read-edn-value — the raw-EDN escape hatch
@@ -140,15 +140,15 @@
 
 (deftest read-edn-value-parses-the-escape-hatch
   (testing "a valid EDN form reads ok"
-    (is (= [true :error]            (sf/read-edn-value ":error")))
-    (is (= [true {:state :ready}]   (sf/read-edn-value "{:state :ready}")))
-    (is (= [true [1 2 3]]           (sf/read-edn-value "[1 2 3]"))))
+    (is (= [true :error]            (rf.story.ui.schema-form/read-edn-value ":error")))
+    (is (= [true {:state :ready}]   (rf.story.ui.schema-form/read-edn-value "{:state :ready}")))
+    (is (= [true [1 2 3]]           (rf.story.ui.schema-form/read-edn-value "[1 2 3]"))))
   (testing "blank / nil read as not-ok (fill this value), never committing nil"
-    (is (= [false nil] (sf/read-edn-value "")))
-    (is (= [false nil] (sf/read-edn-value "   ")))
-    (is (= [false nil] (sf/read-edn-value nil))))
+    (is (= [false nil] (rf.story.ui.schema-form/read-edn-value "")))
+    (is (= [false nil] (rf.story.ui.schema-form/read-edn-value "   ")))
+    (is (= [false nil] (rf.story.ui.schema-form/read-edn-value nil))))
   (testing "a malformed form reports not-ok with a message, never throws"
-    (let [[ok? msg] (sf/read-edn-value "{:a ")]
+    (let [[ok? msg] (rf.story.ui.schema-form/read-edn-value "{:a ")]
       (is (false? ok?))
       (is (string? msg)))))
 
@@ -158,7 +158,7 @@
 
 (deftest override-snippet-pins-a-value-keeping-the-artifact-a-variant
   (testing "the scaffold is a reg-variant :extends-ing the source with one pinned entry"
-    (let [snip (sf/override-snippet :story.login/explore [:login/state] :error)]
+    (let [snip (rf.story.ui.schema-form/override-snippet :story.login/explore [:login/state] :error)]
       (is (str/includes? snip "story/reg-variant")
           "stays a reg-variant — artifact kind unchanged")
       (is (str/includes? snip ":extends :story.login/explore")
@@ -169,9 +169,9 @@
       (is (str/includes? snip "never proof")
           "the honest lowest-fidelity reading rides on the scaffold")))
   (testing "a flat-map value prints cleanly"
-    (let [snip (sf/override-snippet :story.s/v [:q] {:state :ready :msg "ok"})]
+    (let [snip (rf.story.ui.schema-form/override-snippet :story.s/v [:q] {:state :ready :msg "ok"})]
       (is (str/includes? snip ":state :ready"))
       (is (str/includes? snip ":msg \"ok\""))))
   (testing "the from-edn? flag notes the raw-EDN path"
-    (let [snip (sf/override-snippet :story.s/v [:q] {:x 1} true)]
+    (let [snip (rf.story.ui.schema-form/override-snippet :story.s/v [:q] {:x 1} true)]
       (is (str/includes? snip "raw EDN")))))

--- a/tools/story/test/re_frame/story/ui/schema_validation_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/schema_validation_cljs_test.cljc
@@ -21,12 +21,12 @@
     registered variant."
   (:require [clojure.test :refer [deftest is testing]]
             #?@(:cljs [[re-frame.core             :as rf]
-                       [re-frame.frame            :as frame]
-                       [re-frame.registrar        :as registrar]
-                       [re-frame.substrate.plain-atom :as plain-atom]
-                       [re-frame.story            :as story]
-                       [re-frame.story.ui.panels  :as panels]])
-            [re-frame.story.ui.schema-validation :as sv]))
+                       [re-frame.frame            :as rf.frame]
+                       [re-frame.registrar        :as rf.registrar]
+                       [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+                       [re-frame.story            :as rf.story]
+                       [re-frame.story.ui.panels  :as rf.story.ui.panels]])
+            [re-frame.story.ui.schema-validation :as rf.story.ui.schema-validation]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
@@ -64,28 +64,28 @@
 
 (deftest schema-validation-event?-classifies-failures
   (testing ":rf.error/schema-validation-failure trace events qualify"
-    (is (sv/schema-validation-event? (failure-event 1 :event)))
-    (is (sv/schema-validation-event? (failure-event 2 :sub-return)))
-    (is (sv/schema-validation-event? (failure-event 3 :app-db)))
-    (is (sv/schema-validation-event? (failure-event 4 :cofx)))
-    (is (sv/schema-validation-event? (failure-event 5 :fx-args)))))
+    (is (rf.story.ui.schema-validation/schema-validation-event? (failure-event 1 :event)))
+    (is (rf.story.ui.schema-validation/schema-validation-event? (failure-event 2 :sub-return)))
+    (is (rf.story.ui.schema-validation/schema-validation-event? (failure-event 3 :app-db)))
+    (is (rf.story.ui.schema-validation/schema-validation-event? (failure-event 4 :cofx)))
+    (is (rf.story.ui.schema-validation/schema-validation-event? (failure-event 5 :fx-args)))))
 
 (deftest schema-validation-event?-rejects-unrelated
   (testing "non-error trace events and unrelated error categories are filtered out"
-    (is (not (sv/schema-validation-event?
+    (is (not (rf.story.ui.schema-validation/schema-validation-event?
                (unrelated-trace-event 10 :rf.event :rf.event/dispatched))))
-    (is (not (sv/schema-validation-event?
+    (is (not (rf.story.ui.schema-validation/schema-validation-event?
                (unrelated-trace-event 11 :error :rf.error/handler-exception))))
-    (is (not (sv/schema-validation-event?
+    (is (not (rf.story.ui.schema-validation/schema-validation-event?
                (unrelated-trace-event 12 :error :rf.error/no-such-sub))))
-    (is (not (sv/schema-validation-event?
+    (is (not (rf.story.ui.schema-validation/schema-validation-event?
                (unrelated-trace-event 13 :warning :rf.fx/skipped-on-platform))))))
 
 (deftest schema-validation-event?-rejects-malformed
   (testing "empty / partial trace events do not classify"
-    (is (not (sv/schema-validation-event? {})))
-    (is (not (sv/schema-validation-event? {:op-type :error})))
-    (is (not (sv/schema-validation-event?
+    (is (not (rf.story.ui.schema-validation/schema-validation-event? {})))
+    (is (not (rf.story.ui.schema-validation/schema-validation-event? {:op-type :error})))
+    (is (not (rf.story.ui.schema-validation/schema-validation-event?
                {:op-type :error :operation :rf.error/something-else})))))
 
 ;; ---- pure: project-failure ----------------------------------------------
@@ -95,7 +95,7 @@
     (let [ev  (failure-event 1 :event {:event-id  :auth/login
                                        :received  [:auth/login {}]
                                        :explain   {:errors [{:path [:email] :message "missing"}]}})
-          row (sv/project-failure ev)]
+          row (rf.story.ui.schema-validation/project-failure ev)]
       (is (= 1                       (:id row)))
       (is (= :event                  (:where row)))
       (is (= :auth/login             (:failing-id row)))
@@ -109,7 +109,7 @@
     (let [ev  (failure-event 2 :sub-return {:sub-id   :pending-todos
                                             :received [{:bad "shape"}]
                                             :recovery :replaced-with-default})
-          row (sv/project-failure ev)]
+          row (rf.story.ui.schema-validation/project-failure ev)]
       (is (= :sub-return             (:where row)))
       (is (= :pending-todos          (:failing-id row)))
       (is (= :replaced-with-default  (:recovery row))))))
@@ -118,7 +118,7 @@
   (testing "a :where :app-db failure projects the path and the failing-id is nil"
     (let [ev  (failure-event 3 :app-db {:path     [:user :credentials]
                                         :received {:no-id true}})
-          row (sv/project-failure ev)]
+          row (rf.story.ui.schema-validation/project-failure ev)]
       (is (= :app-db                 (:where row)))
       (is (= [:user :credentials]    (:path row)))
       (is (nil? (:failing-id row))))))
@@ -131,21 +131,21 @@
     (let [ev  (failure-event 4 :cofx {:cofx-id    :now
                                       :event-id   :foo/bar
                                       :failing-id :foo/bar})
-          row (sv/project-failure ev)]
+          row (rf.story.ui.schema-validation/project-failure ev)]
       (is (= :cofx                   (:where row)))
       (is (= :foo/bar                (:failing-id row))))))
 
 (deftest project-failure-falls-back-to-id-when-no-explicit-failing-id
   (testing "when an emission shape omits :failing-id, the projector
             falls back through event-id → sub-id → cofx-id → fx-id"
-    (let [row (sv/project-failure (failure-event 50 :cofx {:cofx-id :now}))]
+    (let [row (rf.story.ui.schema-validation/project-failure (failure-event 50 :cofx {:cofx-id :now}))]
       (is (= :now (:failing-id row))))))
 
 (deftest project-failure-fx-args-row
   (testing "a :where :fx-args failure projects the fx-id under :failing-id"
     (let [ev  (failure-event 5 :fx-args {:fx-id :http-xhrio
                                          :received {:url 7}})
-          row (sv/project-failure ev)]
+          row (rf.story.ui.schema-validation/project-failure ev)]
       (is (= :fx-args                (:where row)))
       (is (= :http-xhrio             (:failing-id row))))))
 
@@ -160,7 +160,7 @@
                 (failure-event 4 :app-db {:path [:user]})
                 (unrelated-trace-event 5 :rf.view :rf.view/render)
                 (failure-event 6 :sub-return {:sub-id :pending-todos})]
-          rows (sv/project-failures buf)]
+          rows (rf.story.ui.schema-validation/project-failures buf)]
       (is (= 3 (count rows)))
       (is (= [1 4 6]              (map :id rows)))
       (is (= [:event :app-db :sub-return] (map :where rows)))
@@ -168,8 +168,8 @@
 
 (deftest project-failures-empty
   (testing "empty / all-unrelated buffers project to empty vector"
-    (is (= [] (sv/project-failures [])))
-    (is (= [] (sv/project-failures
+    (is (= [] (rf.story.ui.schema-validation/project-failures [])))
+    (is (= [] (rf.story.ui.schema-validation/project-failures
                 [(unrelated-trace-event 1 :rf.event :rf.event/dispatched)
                  (unrelated-trace-event 2 :error :rf.error/handler-exception)])))))
 
@@ -177,26 +177,26 @@
 
 (deftest map-schema?-classifies-map-shapes
   (testing "[:map ...] vectors are recognised; everything else is not"
-    (is (sv/map-schema? [:map [:a :string]]))
-    (is (sv/map-schema? [:map {:closed true} [:a :string]]))
-    (is (not (sv/map-schema? [:vector :string])))
-    (is (not (sv/map-schema? :string)))
-    (is (not (sv/map-schema? nil)))
-    (is (not (sv/map-schema? {})))
-    (is (not (sv/map-schema? [:enum :a :b])))))
+    (is (rf.story.ui.schema-validation/map-schema? [:map [:a :string]]))
+    (is (rf.story.ui.schema-validation/map-schema? [:map {:closed true} [:a :string]]))
+    (is (not (rf.story.ui.schema-validation/map-schema? [:vector :string])))
+    (is (not (rf.story.ui.schema-validation/map-schema? :string)))
+    (is (not (rf.story.ui.schema-validation/map-schema? nil)))
+    (is (not (rf.story.ui.schema-validation/map-schema? {})))
+    (is (not (rf.story.ui.schema-validation/map-schema? [:enum :a :b])))))
 
 (deftest map-entries-projects-pairs
   (testing "map-entries returns [k child-schema] pairs in declared order,
             skipping the optional properties map at index 1"
     (is (= [[:a :string] [:b :int]]
-           (sv/map-entries [:map [:a :string] [:b :int]])))
+           (rf.story.ui.schema-validation/map-entries [:map [:a :string] [:b :int]])))
     (is (= [[:a :string] [:b :int]]
-           (sv/map-entries [:map {:closed true} [:a :string] [:b :int]])))
-    (is (nil? (sv/map-entries [:vector :string]))))
+           (rf.story.ui.schema-validation/map-entries [:map {:closed true} [:a :string] [:b :int]])))
+    (is (nil? (rf.story.ui.schema-validation/map-entries [:vector :string]))))
   (testing "Malli map-entry with per-entry properties — `[k {:optional true} schema]`
             — projects to the child schema (the third element)"
     (is (= [[:a :string]]
-           (sv/map-entries [:map [:a {:optional true} :string]])))))
+           (rf.story.ui.schema-validation/map-entries [:map [:a {:optional true} :string]])))))
 
 ;; ---- pure: args-violations ----------------------------------------------
 
@@ -229,13 +229,13 @@
 (deftest args-violations-no-validator-soft-passes
   (testing "no validator registered (nil) → every value passes; empty
             vector returned (per Spec 010 §Recommended soft-pass)"
-    (is (= [] (sv/args-violations {:a 7 :b "x"}
+    (is (= [] (rf.story.ui.schema-validation/args-violations {:a 7 :b "x"}
                                   [:map [:a :string] [:b :int]]
                                   {:validate nil :explain nil})))))
 
 (deftest args-violations-no-schema-passes
   (testing "no schema on file → nothing to validate; empty vector"
-    (is (= [] (sv/args-violations {:a 7}
+    (is (= [] (rf.story.ui.schema-validation/args-violations {:a 7}
                                   nil
                                   {:validate truthy-validator :explain nil})))))
 
@@ -247,7 +247,7 @@
                   [:name   :string]
                   [:age    :int]
                   [:active :boolean]]
-          viols  (sv/args-violations args schema
+          viols  (rf.story.ui.schema-validation/args-violations args schema
                                      {:validate string-validator
                                       :explain  string-explainer})
           by-key (into {} (map (juxt :key identity)) viols)]
@@ -267,7 +267,7 @@
 
 (deftest args-violations-conforming-args-empty
   (testing "when every arg conforms, the violation vector is empty"
-    (is (= [] (sv/args-violations {:name "alice" :age 30}
+    (is (= [] (rf.story.ui.schema-validation/args-violations {:name "alice" :age 30}
                                   [:map [:name :string] [:age :int]]
                                   {:validate string-validator
                                    :explain  string-explainer})))))
@@ -280,7 +280,7 @@
             registered validator like the framework does"
     (let [args   {:name "alice"}    ;; :age missing
           schema [:map [:name :string] [:age :int]]
-          viols  (sv/args-violations args schema
+          viols  (rf.story.ui.schema-validation/args-violations args schema
                                      {:validate string-validator
                                       :explain  string-explainer})]
       (is (= 1 (count viols)))
@@ -292,18 +292,18 @@
             against the schema; failure surfaces under ::root"
     ;; string-validator treats `:string` as 'must be a string'; the
     ;; whole args map is not a string → violation.
-    (let [viols (sv/args-violations {:name "x"} :string
+    (let [viols (rf.story.ui.schema-validation/args-violations {:name "x"} :string
                                     {:validate string-validator
                                      :explain  string-explainer})]
       (is (= 1 (count viols)))
-      (is (= ::sv/root (-> viols first :key)))
+      (is (= ::rf.story.ui.schema-validation/root (-> viols first :key)))
       (is (= {:name "x"} (-> viols first :value))))))
 
 (deftest args-violations-non-map-schema-passing
   (testing "a non-:map top-level schema that conforms emits no violation"
     ;; A truthy validator accepts every value, so the whole-args check
     ;; passes.
-    (is (= [] (sv/args-violations {:any "x"} :something
+    (is (= [] (rf.story.ui.schema-validation/args-violations {:any "x"} :something
                                   {:validate truthy-validator
                                    :explain  string-explainer})))))
 
@@ -312,14 +312,14 @@
 (deftest format-explain-nil
   (testing "nil renders as the empty string so the renderer can
             interpolate it safely"
-    (is (= "" (sv/format-explain nil)))))
+    (is (= "" (rf.story.ui.schema-validation/format-explain nil)))))
 
 (deftest format-explain-malli-shape
   (testing "a Malli explain map (`{:errors [...]}`) flattens to a
             joined path-and-message string"
     (let [explanation {:errors [{:path [:email] :message "missing"}
                                 {:path []       :message "bad"}]}
-          out         (sv/format-explain explanation)]
+          out         (rf.story.ui.schema-validation/format-explain explanation)]
       (is (string? out))
       (is (re-find #":email" out))
       (is (re-find #"missing" out))
@@ -328,36 +328,36 @@
 
 (deftest format-explain-falls-back-to-pr-str
   (testing "explanations that aren't Malli-shaped fall back to pr-str"
-    (is (= "\"a plain string\"" (sv/format-explain "a plain string")))
-    (is (= ":a-keyword"         (sv/format-explain :a-keyword)))))
+    (is (= "\"a plain string\"" (rf.story.ui.schema-validation/format-explain "a plain string")))
+    (is (= ":a-keyword"         (rf.story.ui.schema-validation/format-explain :a-keyword)))))
 
 ;; ---- CLJS-only: panel registration --------------------------------------
 
 #?(:cljs
    (defn- reset-all! []
-     (story/clear-all!)
-     (registrar/clear-all!)
-     (reset! frame/frames {})
-     (try (rf/init! plain-atom/adapter) (catch :default _ nil))
-     (story/install-canonical-vocabulary!)
-     (frame/ensure-default-frame!)))
+     (rf.story/clear-all!)
+     (rf.registrar/clear-all!)
+     (reset! rf.frame/frames {})
+     (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
+     (rf.story/install-canonical-vocabulary!)
+     (rf.frame/ensure-default-frame!)))
 
 #?(:cljs
    (deftest ^:cljs panel-id-stable
      (testing "panel-id is :rf.story.panel/schema-validation per the
               SOTA audit's reservation"
-       (is (= :rf.story.panel/schema-validation sv/panel-id)))))
+       (is (= :rf.story.panel/schema-validation rf.story.ui.schema-validation/panel-id)))))
 
 #?(:cljs
    (deftest ^:cljs panel-renders-against-canonical-bootstrap
      (testing "after install-canonical-vocabulary! the schema-validation
               panel is registered against the story side-table"
        (reset-all!)
-       (let [ps (story/registrations :story-panel)]
-         (is (contains? ps sv/panel-id))
-         (let [body (story/handler-meta :story-panel sv/panel-id)]
+       (let [ps (rf.story/registrations :story-panel)]
+         (is (contains? ps rf.story.ui.schema-validation/panel-id))
+         (let [body (rf.story/handler-meta :story-panel rf.story.ui.schema-validation/panel-id)]
            (is (= :right                  (:placement body)))
-           (is (= sv/panel-render-id      (:render body)))
+           (is (= rf.story.ui.schema-validation/panel-render-id      (:render body)))
            (is (re-find #"(?i)schema"     (or (:title body) ""))))))))
 
 #?(:cljs
@@ -366,7 +366,7 @@
               view registry so the late-bind lookup in re-frame.core/view
               finds it"
        (reset-all!)
-       (is (some? (rf/view sv/panel-render-id))))))
+       (is (some? (rf/view rf.story.ui.schema-validation/panel-render-id))))))
 
 #?(:cljs
    (deftest ^:cljs panel-render-view-roots-in-dom-element
@@ -380,7 +380,7 @@
               invisible to Story Inspect Mode + Xray Inspect Mode
               (rf2-iwny7). The `[:div]` wrap is load-bearing."
        (reset-all!)
-       (let [view-fn (rf/view sv/panel-render-id)
+       (let [view-fn (rf/view rf.story.ui.schema-validation/panel-render-id)
              out     (view-fn :story.unknown/y)]
          (is (vector? out)
              "panel-render returns a hiccup vector")
@@ -394,7 +394,7 @@
      (testing "the panel render fn returns a hiccup vector for an
               unregistered variant id (graceful empty state)"
        (reset-all!)
-       (let [out ((sv/panel :story.unknown/y) :story.unknown/y)]
+       (let [out ((rf.story.ui.schema-validation/panel :story.unknown/y) :story.unknown/y)]
          (is (vector? out))
          (is (= :div (first out)))))))
 
@@ -403,13 +403,13 @@
      (testing "render-panels-at-placement :right picks up the schema
               validation panel"
        (reset-all!)
-       (let [out (panels/render-panels-at-placement
+       (let [out (rf.story.ui.panels/render-panels-at-placement
                    :right :story.x/y {})]
          ;; The host returns a hiccup vector with one entry per visible
          ;; panel; assert the schema-validation slot is among the entries
          ;; by serialising and looking for the panel id.
          (is (vector? out))
-         (is (re-find (re-pattern (str sv/panel-id))
+         (is (re-find (re-pattern (str rf.story.ui.schema-validation/panel-id))
                       (pr-str out)))))))
 
 #?(:cljs
@@ -420,7 +420,7 @@
               the classpath (the common case in this repo's tests), the
               validator publishes truthy hooks — both shapes are
               acceptable, the panel adapts to either"
-       (let [{:keys [validate explain]} (sv/validator-fns)]
+       (let [{:keys [validate explain]} (rf.story.ui.schema-validation/validator-fns)]
          ;; Both fns are either nil (soft-pass) or callable.
          (is (or (nil? validate) (fn? validate)))
          (is (or (nil? explain)  (fn? explain)))))))

--- a/tools/story/test/re_frame/story/ui/share_egress_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/share_egress_cljs_test.cljs
@@ -10,34 +10,34 @@
   (:require [clojure.string :as str]
             [cljs.test :refer [deftest is testing use-fixtures async]]
             [goog.object :as gobj]
-            [re-frame.story :as story]
-            [re-frame.story.share :as share]
-            [re-frame.story.ui.share :as ui-share]
-            [re-frame.story.ui.state :as state]))
+            [re-frame.story :as rf.story]
+            [re-frame.story.share :as rf.story.share]
+            [re-frame.story.ui.share :as rf.story.ui.share]
+            [re-frame.story.ui.state :as rf.story.ui.state]))
 
 (use-fixtures :each
   ;; Map form (`:before` / `:after`) — async tests in this ns (the rf2-ehc5bq
   ;; screenshot suite) require the map fixture shape; cljs.test aborts an
   ;; async test under a bare-fn fixture.
   {:before (fn []
-             (story/clear-all!)
-             (state/reset-shell-state!)
-             (story/install-canonical-vocabulary!)
-             (ui-share/close-share-export-dialog!))
+             (rf.story/clear-all!)
+             (rf.story.ui.state/reset-shell-state!)
+             (rf.story/install-canonical-vocabulary!)
+             (rf.story.ui.share/close-share-export-dialog!))
    :after  (fn []
-             (story/clear-all!)
-             (state/reset-shell-state!)
-             (ui-share/close-share-export-dialog!))})
+             (rf.story/clear-all!)
+             (rf.story.ui.state/reset-shell-state!)
+             (rf.story.ui.share/close-share-export-dialog!))})
 
 ;; ---- reproducibility-badge -----------------------------------------------
 
 (deftest badge-nil-report-renders-nothing
   (testing "no report (no variant focused) → no badge"
-    (is (nil? (ui-share/reproducibility-badge nil)))))
+    (is (nil? (rf.story.ui.share/reproducibility-badge nil)))))
 
 (deftest badge-full-shows-label-no-reasons
   (testing "a fully-reproducible report renders the label and no reason list"
-    (let [hiccup (ui-share/reproducibility-badge
+    (let [hiccup (rf.story.ui.share/reproducibility-badge
                    {:status :full :label "fully reproducible" :reasons []})
           flat   (str hiccup)]
       (is (str/includes? flat "story-egress-badge"))
@@ -47,7 +47,7 @@
 
 (deftest badge-partial-lists-reasons-with-codes
   (testing "a downgraded report renders each reason + its machine code"
-    (let [hiccup (ui-share/reproducibility-badge
+    (let [hiccup (rf.story.ui.share/reproducibility-badge
                    {:status  :partial
                     :label   "partially reproducible"
                     :reasons [{:status :partial :code :dropped-overrides
@@ -63,30 +63,35 @@
 (deftest report-nil-when-no-variant
   (testing "with no variant focused the classifier still reports full (no
             per-variant data to omit on the chrome/workspace URL)"
-    (let [report (ui-share/current-share-report (state/get-state))]
+    (let [report (rf.story.ui.share/current-share-report (rf.story.ui.state/get-state))]
       (is (= :full (:status report))))))
 
 (deftest report-flags-fn-override-as-view-only
   (testing "a fn-valued cell-override on the focused variant → view-only"
-    (story/reg-variant :story.egress/btn {:tags #{:dev} :setup []})
-    (state/swap-state!
+    (rf.story/reg-variant :story.egress/btn {:tags #{:dev} :setup []})
+    (rf.story.ui.state/swap-state!
       (fn [s] (-> s
                   (assoc :selected-variant :story.egress/btn)
                   (assoc-in [:cell-overrides :story.egress/btn]
                             {:on-click (fn [_] nil) :label "ok"}))))
-    (let [report (ui-share/current-share-report (state/get-state))]
+    (let [report (rf.story.ui.share/current-share-report (rf.story.ui.state/get-state))]
       (is (= :view-only (:status report)))
       (is (some #(= :override-fn (:code %)) (:reasons report))))))
 
 (deftest edn-snippet-emits-reg-variant-form
   (testing "the copy-EDN snippet is a (reg-variant …) form pinning :extends
             + the effective args of the focused cell"
-    (story/reg-variant :story.egress/counter {:tags #{:dev} :setup [] :args {:n 1}})
-    (state/swap-state!
+    (rf.story/reg-variant :story.egress/counter {:tags #{:dev} :setup [] :args {:n 1}})
+    (rf.story.ui.state/swap-state!
       (fn [s] (-> s
                   (assoc :selected-variant :story.egress/counter)
                   (assoc-in [:cell-overrides :story.egress/counter] {:n 7}))))
-    (let [snip (ui-share/egress-edn-snippet (state/get-state))]
+    (let [snip (rf.story.ui.share/egress-edn-snippet (rf.story.ui.state/get-state))]
+      ;; NOT `rf.story/` — this string pins EMITTED OUTPUT, not this file's
+      ;; alias. The snippet is built by `rf.story.predicates/reg-variant-form`,
+      ;; whose alias prefix is a plain `"story"` argument (share.cljs), so the
+      ;; copyable form a user pastes still reads `(story/reg-variant …)`.
+      ;; Renaming the require alias above does not move it.
       (is (str/starts-with? snip "(story/reg-variant "))
       (is (str/includes? snip ":story.egress/counter"))
       (is (str/includes? snip ":extends"))
@@ -95,27 +100,27 @@
 
 (deftest edn-snippet-nil-without-variant
   (testing "no variant focused → no EDN snippet"
-    (is (nil? (ui-share/egress-edn-snippet (state/get-state))))))
+    (is (nil? (rf.story.ui.share/egress-edn-snippet (rf.story.ui.state/get-state))))))
 
 ;; ---- dialog open / close / render ----------------------------------------
 
 (deftest dialog-closed-renders-nil
   (testing "the dialog renders nil while closed"
-    (ui-share/close-share-export-dialog!)
-    (is (nil? (ui-share/share-export-dialog)))))
+    (rf.story.ui.share/close-share-export-dialog!)
+    (is (nil? (rf.story.ui.share/share-export-dialog)))))
 
 (deftest dialog-open-renders-every-egress-command
   (testing "the open dialog renders all four human-egress commands, each
             shipping (NOT disabled-pending-a-seam) + carrying a
             reproducibility label"
-    (story/reg-variant :story.egress/d {:tags #{:dev} :setup [] :args {:n 1}})
-    (state/swap-state! #(assoc % :selected-variant :story.egress/d))
-    (ui-share/open-share-export-dialog!)
+    (rf.story/reg-variant :story.egress/d {:tags #{:dev} :setup [] :args {:n 1}})
+    (rf.story.ui.state/swap-state! #(assoc % :selected-variant :story.egress/d))
+    (rf.story.ui.share/open-share-export-dialog!)
     ;; `command-block` is a child Reagent component — `str` over the dialog
     ;; hiccup shows each command's invocation PROPS (`:test "share-url"` …),
     ;; not the child's expanded `data-test`. Assert on the props (the
     ;; idiomatic shallow-hiccup check for child components).
-    (let [flat (str (ui-share/share-export-dialog))]
+    (let [flat (str (rf.story.ui.share/share-export-dialog))]
       (is (str/includes? flat "story-share-export-dialog"))
       ;; all four commands present and enabled (no disabled-pending-a-seam)
       (is (str/includes? flat ":test \"share-url\""))
@@ -133,15 +138,15 @@
 
 (deftest dialog-share-chip-opens-dialog
   (testing "the toolbar SHARE chip's on-click opens the dialog"
-    (ui-share/close-share-export-dialog!)
-    (is (nil? (ui-share/share-export-dialog)) "closed before the click")
-    (let [chip     (ui-share/share-chip)
+    (rf.story.ui.share/close-share-export-dialog!)
+    (is (nil? (rf.story.ui.share/share-export-dialog)) "closed before the click")
+    (let [chip     (rf.story.ui.share/share-chip)
           attrs    (second chip)
           on-click (:on-click attrs)]
       (is (= "story-toolbar-share" (:data-test attrs)))
       (is (fn? on-click))
       (on-click nil)
-      (is (some? (ui-share/share-export-dialog))
+      (is (some? (rf.story.ui.share/share-export-dialog))
           "clicking the chip opens the dialog (it now renders a tree)"))))
 
 ;; ---- rf2-76l69l: declared-arg-keys is the stale-override contract --------
@@ -149,12 +154,12 @@
 (deftest declared-arg-keys-unions-args-and-argtypes
   (testing "rf2-76l69l — declared-arg-keys is the variant's editable arg
             surface: resolved-args keys ∪ :argtypes keys"
-    (story/reg-variant :story.dak/v
+    (rf.story/reg-variant :story.dak/v
       {:tags     #{:dev}
        :setup   []
        :args     {:label "Hi" :count 1}
        :argtypes {:flavour {:control :select}}})
-    (let [ks (ui-share/declared-arg-keys :story.dak/v)]
+    (let [ks (rf.story.ui.share/declared-arg-keys :story.dak/v)]
       (is (contains? ks :label) "an :args key is declared")
       (is (contains? ks :count) "an :args key is declared")
       (is (contains? ks :flavour) "an :argtypes-only key is declared")
@@ -163,19 +168,19 @@
 (deftest declared-arg-keys-nil-for-unregistered
   (testing "rf2-76l69l — an unregistered variant has no known contract → nil
             (so drop-stale-overrides degrades to keep-all, not drop-all)"
-    (is (nil? (ui-share/declared-arg-keys :story.dak/never-registered)))))
+    (is (nil? (rf.story.ui.share/declared-arg-keys :story.dak/never-registered)))))
 
 (deftest drop-stale-overrides-against-live-contract
   (testing "rf2-76l69l — a stale override (an arg the variant removed) is
             dropped + reported against the live declared-key set, while a
             still-declared override survives — the end-to-end finding-2 fix"
-    (story/reg-variant :story.dak/contract
+    (rf.story/reg-variant :story.dak/contract
       {:tags   #{:dev}
        :setup []
        :args   {:label "Hi"}})
     (let [parsed {:overrides {:label "Renamed" :gone 9} :dropped []}
-          out    (share/drop-stale-overrides
-                   parsed (ui-share/declared-arg-keys :story.dak/contract))]
+          out    (rf.story.share/drop-stale-overrides
+                   parsed (rf.story.ui.share/declared-arg-keys :story.dak/contract))]
       (is (= {:label "Renamed"} (:overrides out))
           "the still-declared :label override survives")
       (is (= 1 (count (:dropped out))) "the removed :gone override is dropped")
@@ -263,11 +268,11 @@
                     "ClipboardItem" (fn [parts] (this-as this
                                                    (set! (.-_parts this) parts)
                                                    this))})]
-        (-> (ui-share/copy-screenshot!)
+        (-> (rf.story.ui.share/copy-screenshot!)
             (.then
               (fn [ok?]
                 (is (true? ok?) "the write resolved → success")
-                (let [snap (ui-share/dialog-state-snapshot)]
+                (let [snap (rf.story.ui.share/dialog-state-snapshot)]
                   (is (= :screenshot (:copied snap))
                       "copied flashes only on a real, resolved clipboard write")
                   (is (nil? (:error snap)) "no error on the success path"))
@@ -287,11 +292,11 @@
                     "window"        #js {}
                     "navigator"     (fake-navigator-with-write (atom nil))
                     "ClipboardItem" (fn [parts] (this-as this this))})]
-        (-> (ui-share/copy-screenshot!)
+        (-> (rf.story.ui.share/copy-screenshot!)
             (.then
               (fn [ok?]
                 (is (false? ok?) "no seam → failure outcome")
-                (let [snap (ui-share/dialog-state-snapshot)]
+                (let [snap (rf.story.ui.share/dialog-state-snapshot)]
                   (is (not= :screenshot (:copied snap))
                       "MUST NOT report success on a no-op (the false-success bug)")
                   (is (= :screenshot (:cmd (:error snap)))
@@ -313,11 +318,11 @@
                     ;; navigator without a clipboard → image write unsupported
                     "navigator"     #js {}
                     "ClipboardItem" js/undefined})]
-        (-> (ui-share/copy-screenshot!)
+        (-> (rf.story.ui.share/copy-screenshot!)
             (.then
               (fn [ok?]
                 (is (false? ok?) "no clipboard image write → failure outcome")
-                (let [snap (ui-share/dialog-state-snapshot)]
+                (let [snap (rf.story.ui.share/dialog-state-snapshot)]
                   (is (not= :screenshot (:copied snap))
                       "MUST NOT report success when clipboard image write is absent")
                   (is (= :screenshot (:cmd (:error snap)))
@@ -337,11 +342,11 @@
                     "window"        (fake-window-with-capture)
                     "navigator"     (fake-navigator-with-write (atom nil))
                     "ClipboardItem" (fn [parts] (this-as this this))})]
-        (-> (ui-share/copy-screenshot!)
+        (-> (rf.story.ui.share/copy-screenshot!)
             (.then
               (fn [ok?]
                 (is (false? ok?))
-                (let [snap (ui-share/dialog-state-snapshot)]
+                (let [snap (rf.story.ui.share/dialog-state-snapshot)]
                   (is (not= :screenshot (:copied snap)))
                   (is (= :screenshot (:cmd (:error snap)))))))
             (.finally
@@ -355,18 +360,18 @@
             PROPS — the idiomatic shallow-hiccup check used by the sibling
             render test."
     (async done
-      (story/reg-variant :story.egress/shot {:tags #{:dev} :setup []})
-      (state/swap-state! #(assoc % :selected-variant :story.egress/shot))
-      (ui-share/open-share-export-dialog!)
+      (rf.story/reg-variant :story.egress/shot {:tags #{:dev} :setup []})
+      (rf.story.ui.state/swap-state! #(assoc % :selected-variant :story.egress/shot))
+      (rf.story.ui.share/open-share-export-dialog!)
       (let [prev (install-globals!
                    {"document"      (fake-document #js {:tag "canvas"})
                     "window"        #js {}                ; no capture seam
                     "navigator"     (fake-navigator-with-write (atom nil))
                     "ClipboardItem" (fn [parts] (this-as this this))})]
-        (-> (ui-share/copy-screenshot!)
+        (-> (rf.story.ui.share/copy-screenshot!)
             (.then
               (fn [_]
-                (let [flat (str (ui-share/share-export-dialog))
+                (let [flat (str (rf.story.ui.share/share-export-dialog))
                       ;; the screenshot command-block invocation props slice
                       shot (second (str/split flat #":test \"screenshot\""))]
                   (is (some? shot) "the screenshot row is present")

--- a/tools/story/test/re_frame/story/ui/shell/rails_splitter_unmount_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/shell/rails_splitter_unmount_dom_cljs_test.cljs
@@ -3,8 +3,8 @@
   splitter's `on-mouse-down` installs document-level mousemove/mouseup
   listeners that were previously removed ONLY from inside the mouseup
   handler itself. If the splitter unmounted mid-drag — e.g. a
-  narrow-viewport flip drops `[rails/splitter :left]` from `shell.cljs`
-  (`rails/narrow-viewport?`) — mouseup never fires, so the document
+  narrow-viewport flip drops `[rf.story.ui.shell.rails/splitter :left]` from `shell.cljs`
+  (`rf.story.ui.shell.rails/narrow-viewport?`) — mouseup never fires, so the document
   listeners were never torn down and kept calling `set-width!` against the
   (by-then stale) component's closure forever: a permanent per-drag
   listener leak plus phantom rail-width writes driven by a component no
@@ -34,8 +34,8 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             ["react-dom" :as react-dom]
             [reagent.dom.client :as rdc]
-            [re-frame.story.ui.shell.rails :as rails]
-            [re-frame.story.ui.state :as state]))
+            [re-frame.story.ui.shell.rails :as rf.story.ui.shell.rails]
+            [re-frame.story.ui.state :as rf.story.ui.state]))
 
 ;; ---- browser gate -----------------------------------------------------
 
@@ -49,7 +49,7 @@
     node))
 
 (use-fixtures :each
-  {:before (fn [] (when (browser?) (state/reset-shell-state!)))})
+  {:before (fn [] (when (browser?) (rf.story.ui.state/reset-shell-state!)))})
 
 ;; ---- the regression ---------------------------------------------------
 
@@ -64,9 +64,9 @@
             root       (rdc/create-root mount-node)]
         (try
           (react-dom/flushSync
-            (fn [] (rdc/render root [rails/splitter :left])))
+            (fn [] (rdc/render root [rf.story.ui.shell.rails/splitter :left])))
           (let [splitter-el (.querySelector mount-node "[data-test=\"story-left-rail-splitter\"]")
-                width-0     (:left (rails/current-widths))]
+                width-0     (:left (rf.story.ui.shell.rails/current-widths))]
             (is (some? splitter-el) "splitter element mounted")
             ;; Start the drag — installs the document mousemove/mouseup
             ;; listeners.
@@ -80,7 +80,7 @@
               (fn []
                 (.dispatchEvent js/document
                   (js/MouseEvent. "mousemove" #js {:bubbles true :clientX 150}))))
-            (let [width-1 (:left (rails/current-widths))]
+            (let [width-1 (:left (rf.story.ui.shell.rails/current-widths))]
               (is (not= width-0 width-1)
                   "a live drag's mousemove moves the rail width")
               ;; Unmount MID-DRAG — no mouseup ever fired.
@@ -93,7 +93,7 @@
                 (fn []
                   (.dispatchEvent js/document
                     (js/MouseEvent. "mousemove" #js {:bubbles true :clientX 400}))))
-              (let [width-2 (:left (rails/current-widths))]
+              (let [width-2 (:left (rf.story.ui.shell.rails/current-widths))]
                 (is (= width-1 width-2)
                     "rf2-cmjly3 finding 6: a mousemove AFTER a mid-drag
                      unmount does not move the rail — the document
@@ -112,7 +112,7 @@
             root       (rdc/create-root mount-node)]
         (try
           (react-dom/flushSync
-            (fn [] (rdc/render root [rails/splitter :left])))
+            (fn [] (rdc/render root [rf.story.ui.shell.rails/splitter :left])))
           (let [splitter-el (.querySelector mount-node "[data-test=\"story-left-rail-splitter\"]")]
             (react-dom/flushSync
               (fn []
@@ -122,7 +122,7 @@
               (fn []
                 (.dispatchEvent js/document
                   (js/MouseEvent. "mousemove" #js {:bubbles true :clientX 150}))))
-            (let [width-after-move (:left (rails/current-widths))]
+            (let [width-after-move (:left (rf.story.ui.shell.rails/current-widths))]
               ;; Normal end-of-drag.
               (react-dom/flushSync
                 (fn []
@@ -132,7 +132,7 @@
                 (fn []
                   (.dispatchEvent js/document
                     (js/MouseEvent. "mousemove" #js {:bubbles true :clientX 400}))))
-              (is (= width-after-move (:left (rails/current-widths)))
+              (is (= width-after-move (:left (rf.story.ui.shell.rails/current-widths)))
                   "a mousemove after a normal mouseup is still a no-op")))
           (finally
             (try (.unmount root) (catch :default _ nil))))))))

--- a/tools/story/test/re_frame/story/ui/shell_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/shell_cljs_test.cljs
@@ -16,9 +16,9 @@
   mount-time guard to (see the ns docstring above its definition in
   `shell.cljs`); it needs no DOM / mount to exercise."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.story.ui.shell :as shell]))
+            [re-frame.story.ui.shell :as rf.story.ui.shell]))
 
-(def ^:private mount-time-autorun-vid @#'shell/mount-time-autorun-vid)
+(def ^:private mount-time-autorun-vid @#'rf.story.ui.shell/mount-time-autorun-vid)
 
 (deftest mount-time-autorun-vid-schedules-when-unchanged
   (testing "selection unchanged across hydration (persisted / re-mount

--- a/tools/story/test/re_frame/story/ui/shell_error_ownership_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/shell_error_ownership_cljs_test.cljs
@@ -22,20 +22,20 @@
   (`npm run test:story-feature-load`), which counts console errors for
   real."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.story.ui.shell :as shell]))
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.story.ui.shell :as rf.story.ui.shell]))
 
-(def ^:private claim!   @#'shell/claim-error-ownership!)
-(def ^:private release! @#'shell/release-error-ownership!)
+(def ^:private claim!   @#'rf.story.ui.shell/claim-error-ownership!)
+(def ^:private release! @#'rf.story.ui.shell/release-error-ownership!)
 
 ;; The registry the fallback's `(empty? @listeners)` guard reads. Private
 ;; in `error-emit` because it is not an app-facing surface; read here
 ;; because it is the precise thing this fix has to move.
-(def ^:private listeners @#'error-emit/listeners)
+(def ^:private listeners @#'rf.error-emit/listeners)
 
 (use-fixtures :each
-  {:before #(error-emit/clear-error-listeners!)
-   :after  #(error-emit/clear-error-listeners!)})
+  {:before #(rf.error-emit/clear-error-listeners!)
+   :after  #(rf.error-emit/clear-error-listeners!)})
 
 (deftest claim-makes-the-fallback-registry-non-empty
   (testing "with no shell mounted the registry is empty — the fallback fires"
@@ -66,7 +66,7 @@
   (testing "a consuming app's own `:errors` listener is registered under its
             own id — the shell's release drops only the shell's claim, and
             the app keeps ownership (and its records) across a Story unmount"
-    (error-emit/register-error-listener! ::host-app (fn [_record] nil))
+    (rf.error-emit/register-error-listener! ::host-app (fn [_record] nil))
     (claim!)
     (is (= 2 (count @listeners)))
     (release!)

--- a/tools/story/test/re_frame/story/ui/sidebar_chips_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/sidebar_chips_cljs_test.cljc
@@ -17,7 +17,7 @@
     five axes in DISTINCT `data-axis` groups, and never collapses world
     inputs / runner / frame-binding into fidelity."
   (:require [clojure.test :refer [deftest is testing]]
-            #?@(:cljs [[re-frame.story.ui.sidebar :as sidebar]])))
+            #?@(:cljs [[re-frame.story.ui.sidebar :as rf.story.ui.sidebar]])))
 
 ;; ---- pure: large-list bounding ------------------------------------------
 
@@ -25,15 +25,15 @@
    (deftest bound-variants-caps-and-expands
      (testing "a list at or below the cap is never bounded"
        (let [vs (mapv (fn [i] [(keyword (str "story.x/v" i)) {}]) (range 5))]
-         (is (= {:shown vs :hidden 0} (sidebar/bound-variants vs 10 false)))))
+         (is (= {:shown vs :hidden 0} (rf.story.ui.sidebar/bound-variants vs 10 false)))))
      (testing "a list over the cap is bounded with the elided count"
        (let [vs (mapv (fn [i] [(keyword (str "story.x/v" i)) {}]) (range 50))
-             {:keys [shown hidden]} (sidebar/bound-variants vs 40 false)]
+             {:keys [shown hidden]} (rf.story.ui.sidebar/bound-variants vs 40 false)]
          (is (= 40 (count shown)))
          (is (= 10 hidden))))
      (testing "expanded? reveals the full list (nothing hidden)"
        (let [vs (mapv (fn [i] [(keyword (str "story.x/v" i)) {}]) (range 50))
-             {:keys [shown hidden]} (sidebar/bound-variants vs 40 true)]
+             {:keys [shown hidden]} (rf.story.ui.sidebar/bound-variants vs 40 true)]
          (is (= 50 (count shown)))
          (is (= 0 hidden))))))
 
@@ -53,16 +53,16 @@
    (deftest workspace-grid-grouping-projection
      (testing "a :variants-grid workspace reports its layout + cell count"
        (is (= {:layout :variants-grid :count 3}
-              (sidebar/workspace-grid-grouping
+              (rf.story.ui.sidebar/workspace-grid-grouping
                 {:layout :variants-grid :variants [:a :b :c]}))))
      (testing ":grid and :tabs are also grid groups"
        (is (= {:layout :grid :count 2}
-              (sidebar/workspace-grid-grouping {:layout :grid :variants [:a :b]})))
+              (rf.story.ui.sidebar/workspace-grid-grouping {:layout :grid :variants [:a :b]})))
        (is (= {:layout :tabs :count 1}
-              (sidebar/workspace-grid-grouping {:layout :tabs :variants [:a]}))))
+              (rf.story.ui.sidebar/workspace-grid-grouping {:layout :tabs :variants [:a]}))))
      (testing "a non-grid layout (prose / custom) is NOT a grid group"
-       (is (nil? (sidebar/workspace-grid-grouping {:layout :prose})))
-       (is (nil? (sidebar/workspace-grid-grouping {:layout :custom}))))))
+       (is (nil? (rf.story.ui.sidebar/workspace-grid-grouping {:layout :prose})))
+       (is (nil? (rf.story.ui.sidebar/workspace-grid-grouping {:layout :custom}))))))
 
 ;; ---- CLJS-only: rendered signal-chip hiccup -----------------------------
 
@@ -106,7 +106,7 @@
    (deftest signal-chips-always-present-axes
      (testing "a calm default variant still renders status + runner +
                frame-binding chips (one each), and no fidelity / world chips"
-       (let [tree   (sidebar/signal-chips {} :pending)
+       (let [tree   (rf.story.ui.sidebar/signal-chips {} :pending)
              by-axis (chips-by-axis tree)]
          (is (= ["pending"]  (get by-axis "status")))
          (is (= ["headless"] (get by-axis "runner-requirement")))
@@ -119,7 +119,7 @@
      (testing "a rich variant renders all five axes in SEPARATE data-axis
                groups — world inputs / runner / frame-binding are NEVER
                folded into fidelity (spec/018 §7.1)"
-       (let [tree   (sidebar/signal-chips
+       (let [tree   (rf.story.ui.sidebar/signal-chips
                       {:setup        [[:dispatch [:seed]]]
                        :sub-overrides {[:q] 1}
                        :args          {:label "x"}
@@ -142,21 +142,21 @@
    (deftest signal-status-style-key-projection
      (testing "each status value maps to its own tint style key — distinct
                colour/shape (spec/018 §12.6)"
-       (is (= :signal-status-pass       (sidebar/status-signal->style-key :pass)))
-       (is (= :signal-status-fail       (sidebar/status-signal->style-key :fail)))
-       (is (= :signal-status-cannot-run (sidebar/status-signal->style-key :cannot-run)))
-       (is (= :signal-status-error      (sidebar/status-signal->style-key :error)))
-       (is (= :signal-status-pending    (sidebar/status-signal->style-key :pending))))))
+       (is (= :signal-status-pass       (rf.story.ui.sidebar/status-signal->style-key :pass)))
+       (is (= :signal-status-fail       (rf.story.ui.sidebar/status-signal->style-key :fail)))
+       (is (= :signal-status-cannot-run (rf.story.ui.sidebar/status-signal->style-key :cannot-run)))
+       (is (= :signal-status-error      (rf.story.ui.sidebar/status-signal->style-key :error)))
+       (is (= :signal-status-pending    (rf.story.ui.sidebar/status-signal->style-key :pending))))))
 
 #?(:cljs
    (deftest axis-group-style-key-projection
      (testing "each non-status axis has its OWN tint family so the axes
                read as distinct groups"
-       (is (= :signal-fidelity (sidebar/axis->group-style-key :fidelity)))
-       (is (= :signal-world    (sidebar/axis->group-style-key :world-inputs)))
-       (is (= :signal-runner   (sidebar/axis->group-style-key :runner-requirement)))
-       (is (= :signal-frame    (sidebar/axis->group-style-key :frame-binding)))
+       (is (= :signal-fidelity (rf.story.ui.sidebar/axis->group-style-key :fidelity)))
+       (is (= :signal-world    (rf.story.ui.sidebar/axis->group-style-key :world-inputs)))
+       (is (= :signal-runner   (rf.story.ui.sidebar/axis->group-style-key :runner-requirement)))
+       (is (= :signal-frame    (rf.story.ui.sidebar/axis->group-style-key :frame-binding)))
        ;; the four tints are all different — no axis shares fidelity's tint.
-       (is (= 4 (count (set (map sidebar/axis->group-style-key
+       (is (= 4 (count (set (map rf.story.ui.sidebar/axis->group-style-key
                                  [:fidelity :world-inputs :runner-requirement
                                   :frame-binding]))))))))

--- a/tools/story/test/re_frame/story/ui/sidebar_search_test.cljc
+++ b/tools/story/test/re_frame/story/ui/sidebar_search_test.cljc
@@ -15,46 +15,46 @@
   - `filter-workspaces`    — workspace map narrowing
   - `highlight-segments`   — match / non-match segmentation"
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.ui.sidebar-search :as search]))
+            [re-frame.story.ui.sidebar-search :as rf.story.ui.sidebar-search]))
 
 ;; ---- tokenise ------------------------------------------------------------
 
 (deftest tokenise-shape
   (testing "blank / nil input returns empty vector"
-    (is (= [] (search/tokenise nil)))
-    (is (= [] (search/tokenise "")))
-    (is (= [] (search/tokenise "   "))))
+    (is (= [] (rf.story.ui.sidebar-search/tokenise nil)))
+    (is (= [] (rf.story.ui.sidebar-search/tokenise "")))
+    (is (= [] (rf.story.ui.sidebar-search/tokenise "   "))))
   (testing "single token"
-    (is (= ["foo"] (search/tokenise "foo")))
-    (is (= ["foo"] (search/tokenise "  Foo  "))))
+    (is (= ["foo"] (rf.story.ui.sidebar-search/tokenise "foo")))
+    (is (= ["foo"] (rf.story.ui.sidebar-search/tokenise "  Foo  "))))
   (testing "multi-token split on whitespace + lowercase"
-    (is (= ["counter" "five"] (search/tokenise "Counter Five")))
-    (is (= ["a" "b" "c"]      (search/tokenise "a   b\tc")))))
+    (is (= ["counter" "five"] (rf.story.ui.sidebar-search/tokenise "Counter Five")))
+    (is (= ["a" "b" "c"]      (rf.story.ui.sidebar-search/tokenise "a   b\tc")))))
 
 ;; ---- match-variant? ------------------------------------------------------
 
 (deftest match-variant-shape
   (testing "empty tokens → match-all"
-    (is (true? (search/match-variant? [] :story.x/y {}))))
+    (is (true? (rf.story.ui.sidebar-search/match-variant? [] :story.x/y {}))))
 
   (testing "token in variant id matches"
-    (is (true? (search/match-variant? ["five"] :story.counter/at-five {}))))
+    (is (true? (rf.story.ui.sidebar-search/match-variant? ["five"] :story.counter/at-five {}))))
 
   (testing "token-AND: every token must hit"
-    (is (true? (search/match-variant? ["counter" "five"]
+    (is (true? (rf.story.ui.sidebar-search/match-variant? ["counter" "five"]
                                        :story.counter/at-five {})))
-    (is (false? (search/match-variant? ["counter" "missing"]
+    (is (false? (rf.story.ui.sidebar-search/match-variant? ["counter" "missing"]
                                         :story.counter/at-five {}))))
 
   (testing "case-insensitive"
-    (is (true? (search/match-variant? ["FIVE"] :story.counter/at-five {})))
-    (is (true? (search/match-variant? ["Five"] :story.counter/at-five {}))))
+    (is (true? (rf.story.ui.sidebar-search/match-variant? ["FIVE"] :story.counter/at-five {})))
+    (is (true? (rf.story.ui.sidebar-search/match-variant? ["Five"] :story.counter/at-five {}))))
 
   (testing "token matches against variant's :doc + :tags"
-    (is (true? (search/match-variant? ["pending"]
+    (is (true? (rf.story.ui.sidebar-search/match-variant? ["pending"]
                                        :story.foo/bar
                                        {:doc "pending stamp"})))
-    (is (true? (search/match-variant? ["screenshot"]
+    (is (true? (rf.story.ui.sidebar-search/match-variant? ["screenshot"]
                                        :story.foo/bar
                                        {:tags #{:screenshot}})))))
 
@@ -62,11 +62,11 @@
 
 (deftest match-story-shape
   (testing "empty tokens → true"
-    (is (true? (search/match-story? [] :story.x))))
+    (is (true? (rf.story.ui.sidebar-search/match-story? [] :story.x))))
   (testing "token-AND on story id"
-    (is (true? (search/match-story? ["counter"] :story.counter)))
-    (is (true? (search/match-story? ["story"] :story.counter)))
-    (is (false? (search/match-story? ["missing"] :story.counter)))))
+    (is (true? (rf.story.ui.sidebar-search/match-story? ["counter"] :story.counter)))
+    (is (true? (rf.story.ui.sidebar-search/match-story? ["story"] :story.counter)))
+    (is (false? (rf.story.ui.sidebar-search/match-story? ["missing"] :story.counter)))))
 
 ;; ---- filter-grouped-tree -------------------------------------------------
 
@@ -80,13 +80,13 @@
 
 (deftest filter-grouped-tree-empty-query
   (testing "blank / empty query → unchanged"
-    (is (= fixture-grouped (search/filter-grouped-tree fixture-grouped nil)))
-    (is (= fixture-grouped (search/filter-grouped-tree fixture-grouped "")))
-    (is (= fixture-grouped (search/filter-grouped-tree fixture-grouped "   ")))))
+    (is (= fixture-grouped (rf.story.ui.sidebar-search/filter-grouped-tree fixture-grouped nil)))
+    (is (= fixture-grouped (rf.story.ui.sidebar-search/filter-grouped-tree fixture-grouped "")))
+    (is (= fixture-grouped (rf.story.ui.sidebar-search/filter-grouped-tree fixture-grouped "   ")))))
 
 (deftest filter-grouped-tree-story-match-keeps-children
   (testing "story id matches → all variants survive (ancestor-keeps-children)"
-    (let [out (search/filter-grouped-tree fixture-grouped "counter")]
+    (let [out (rf.story.ui.sidebar-search/filter-grouped-tree fixture-grouped "counter")]
       (is (= 1 (count out)))
       (is (= :story.counter (-> out first :story-id)))
       ;; both variants kept
@@ -94,7 +94,7 @@
 
 (deftest filter-grouped-tree-variant-narrow
   (testing "story id NO match, only matching variants survive"
-    (let [out (search/filter-grouped-tree fixture-grouped "five")]
+    (let [out (rf.story.ui.sidebar-search/filter-grouped-tree fixture-grouped "five")]
       (is (= 1 (count out)))
       (is (= :story.counter (-> out first :story-id)))
       (is (= 1 (count (-> out first :variants))))
@@ -102,7 +102,7 @@
 
 (deftest filter-grouped-tree-prunes-empty
   (testing "story with zero surviving variants drops out"
-    (let [out (search/filter-grouped-tree fixture-grouped "completely-unknown-token")]
+    (let [out (rf.story.ui.sidebar-search/filter-grouped-tree fixture-grouped "completely-unknown-token")]
       (is (= [] out)))))
 
 (deftest filter-grouped-tree-token-and
@@ -111,12 +111,12 @@
     ;; "counter five" — story matches only "counter", not "five", so
     ;; story-match is false. Variant haystack filter requires BOTH
     ;; tokens: only :at-five carries "five".
-    (let [out (search/filter-grouped-tree fixture-grouped "counter five")]
+    (let [out (rf.story.ui.sidebar-search/filter-grouped-tree fixture-grouped "counter five")]
       (is (= 1 (count out)))
       (is (= :story.counter (-> out first :story-id)))
       (is (= 1 (count (-> out first :variants))))
       (is (= :story.counter/at-five (ffirst (-> out first :variants)))))
-    (let [out (search/filter-grouped-tree fixture-grouped "login error")]
+    (let [out (rf.story.ui.sidebar-search/filter-grouped-tree fixture-grouped "login error")]
       (is (= 1 (count out)))
       (is (= :story.login (-> out first :story-id)))
       ;; story-id matches only "login"; only :error survives the variant
@@ -128,15 +128,15 @@
 (deftest filter-workspaces-empty-query
   (let [ws {:Workspace.dashboard {}
             :Workspace.demo {}}]
-    (is (= ws (search/filter-workspaces ws "")))
-    (is (= ws (search/filter-workspaces ws nil)))))
+    (is (= ws (rf.story.ui.sidebar-search/filter-workspaces ws "")))
+    (is (= ws (rf.story.ui.sidebar-search/filter-workspaces ws nil)))))
 
 (deftest filter-workspaces-narrow
   (let [ws {:Workspace.dashboard {}
             :Workspace.demo {}}]
-    (let [out (search/filter-workspaces ws "dash")]
+    (let [out (rf.story.ui.sidebar-search/filter-workspaces ws "dash")]
       (is (= [:Workspace.dashboard] (vec (keys out)))))
-    (let [out (search/filter-workspaces ws "missing")]
+    (let [out (rf.story.ui.sidebar-search/filter-workspaces ws "missing")]
       (is (= {} out)))))
 
 ;; ---- highlight-segments --------------------------------------------------
@@ -144,18 +144,18 @@
 (deftest highlight-segments-empty-query
   (testing "empty query → one non-match segment"
     (is (= [{:text "/at-five" :match? false}]
-           (search/highlight-segments "/at-five" "")))))
+           (rf.story.ui.sidebar-search/highlight-segments "/at-five" "")))))
 
 (deftest highlight-segments-single-match
   (testing "single token, single match in middle"
-    (let [out (search/highlight-segments "/at-five" "five")]
+    (let [out (rf.story.ui.sidebar-search/highlight-segments "/at-five" "five")]
       (is (= [{:text "/at-" :match? false}
               {:text "five" :match? true}]
              out)))))
 
 (deftest highlight-segments-case-insensitive-preserves-case
   (testing "case-insensitive match preserves original label case"
-    (let [out (search/highlight-segments "AtFive" "five")]
+    (let [out (rf.story.ui.sidebar-search/highlight-segments "AtFive" "five")]
       (is (= [{:text "At" :match? false}
               {:text "Five" :match? true}]
              out)))))
@@ -164,10 +164,10 @@
   (testing "multi-token: first hit becomes the highlighted segment"
     ;; "five" hits first in /at-five, recursive remainder has no more
     ;; hits → single highlighted segment
-    (let [out (search/highlight-segments "/at-five" "five at")]
+    (let [out (rf.story.ui.sidebar-search/highlight-segments "/at-five" "five at")]
       (is (some :match? out)))))
 
 (deftest highlight-segments-no-match
   (testing "tokens don't hit → single non-match segment"
-    (let [out (search/highlight-segments "/at-five" "missing")]
+    (let [out (rf.story.ui.sidebar-search/highlight-segments "/at-five" "missing")]
       (is (= [{:text "/at-five" :match? false}] out)))))

--- a/tools/story/test/re_frame/story/ui/sidebar_signals_test.cljc
+++ b/tools/story/test/re_frame/story/ui/sidebar_signals_test.cljc
@@ -13,7 +13,7 @@
   runner tiers. This corpus asserts the derivation keeps them in separate
   buckets and reads only the variant body's real metadata."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.ui.sidebar-signals :as signals]))
+            [re-frame.story.ui.sidebar-signals :as rf.story.ui.sidebar-signals]))
 
 ;; ---- status axis ---------------------------------------------------------
 
@@ -21,40 +21,40 @@
   (testing "each known status maps to its own labelled chip"
     (doseq [s [:pass :fail :cannot-run :error :running :pending
                :blocked :dirty :redacted]]
-      (let [chip (signals/status-signal s)]
+      (let [chip (rf.story.ui.sidebar-signals/status-signal s)]
         (is (= :status (:axis chip)))
         (is (= s (:value chip)))
         (is (string? (:label chip))))))
   (testing "an unknown / nil status defaults to :pending (never throws)"
-    (is (= :pending (:value (signals/status-signal nil))))
-    (is (= :pending (:value (signals/status-signal :bogus))))))
+    (is (= :pending (:value (rf.story.ui.sidebar-signals/status-signal nil))))
+    (is (= :pending (:value (rf.story.ui.sidebar-signals/status-signal :bogus))))))
 
 ;; ---- fidelity axis (reuses plan/compute-fidelity) ------------------------
 
 (deftest fidelity-signals-from-world-inputs
   (testing "a bare render-as-mounted variant has NO fidelity chips"
-    (is (= [] (signals/fidelity-signals {}))))
+    (is (= [] (rf.story.ui.sidebar-signals/fidelity-signals {}))))
   (testing ":real-setup from setup/script/events"
     (is (= [:real-setup]
-           (mapv :value (signals/fidelity-signals {:setup [[:dispatch [:e]]]}))))
+           (mapv :value (rf.story.ui.sidebar-signals/fidelity-signals {:setup [[:dispatch [:e]]]}))))
     (is (= [:real-setup]
-           (mapv :value (signals/fidelity-signals {:setup [[:e]]}))))
+           (mapv :value (rf.story.ui.sidebar-signals/fidelity-signals {:setup [[:e]]}))))
     (is (= [:real-setup]
-           (mapv :value (signals/fidelity-signals {:script [[:dispatch [:e]]]})))))
+           (mapv :value (rf.story.ui.sidebar-signals/fidelity-signals {:script [[:dispatch [:e]]]})))))
   (testing ":sub-overrides is a fidelity rung"
     (is (= [:sub-overrides]
-           (mapv :value (signals/fidelity-signals {:sub-overrides {[:q] 1}})))))
+           (mapv :value (rf.story.ui.sidebar-signals/fidelity-signals {:sub-overrides {[:q] 1}})))))
   (testing ":db-seed is a fidelity rung"
     (is (= [:db-seed]
-           (mapv :value (signals/fidelity-signals {:db-seed {:a 1}})))))
+           (mapv :value (rf.story.ui.sidebar-signals/fidelity-signals {:db-seed {:a 1}})))))
   (testing "ladder order is real-setup > db-seed > sub-overrides"
     (is (= [:real-setup :db-seed :sub-overrides]
-           (mapv :value (signals/fidelity-signals
+           (mapv :value (rf.story.ui.sidebar-signals/fidelity-signals
                           {:setup [[:dispatch [:e]]]
                            :db-seed {:a 1}
                            :sub-overrides {[:q] 1}})))))
   (testing "args / network / fx-overrides are NOT fidelity rungs"
-    (is (= [] (signals/fidelity-signals {:args {:n 1}
+    (is (= [] (rf.story.ui.sidebar-signals/fidelity-signals {:args {:n 1}
                                          :network {[:get "/x"] {:reply {:ok 1}}}
                                          :fx-overrides {:fx :stub}})))))
 
@@ -62,41 +62,41 @@
 
 (deftest world-input-signals-presence
   (testing "no world inputs → no chips"
-    (is (= [] (signals/world-input-signals {})))
-    (is (= [] (signals/world-input-signals {:args {} :network {} :fx-overrides {}}))))
+    (is (= [] (rf.story.ui.sidebar-signals/world-input-signals {})))
+    (is (= [] (rf.story.ui.sidebar-signals/world-input-signals {:args {} :network {} :fx-overrides {}}))))
   (testing "args / route / network / fx-overrides each surface a chip"
-    (is (= [:args]         (mapv :value (signals/world-input-signals {:args {:n 1}}))))
-    (is (= [:route]        (mapv :value (signals/world-input-signals {:route [:home]}))))
-    (is (= [:network]      (mapv :value (signals/world-input-signals
+    (is (= [:args]         (mapv :value (rf.story.ui.sidebar-signals/world-input-signals {:args {:n 1}}))))
+    (is (= [:route]        (mapv :value (rf.story.ui.sidebar-signals/world-input-signals {:route [:home]}))))
+    (is (= [:network]      (mapv :value (rf.story.ui.sidebar-signals/world-input-signals
                                           {:network {[:get "/x"] {:reply {:ok 1}}}}))))
-    (is (= [:fx-overrides] (mapv :value (signals/world-input-signals
+    (is (= [:fx-overrides] (mapv :value (rf.story.ui.sidebar-signals/world-input-signals
                                           {:fx-overrides {:fx :stub}})))))
   (testing "render order is args, route, network, fx-overrides"
     (is (= [:args :route :network :fx-overrides]
-           (mapv :value (signals/world-input-signals
+           (mapv :value (rf.story.ui.sidebar-signals/world-input-signals
                           {:args {:n 1} :route [:home]
                            :network {[:get "/x"] {:reply {:ok 1}}}
                            :fx-overrides {:fx :stub}})))))
   (testing "every world-input chip is on the :world-inputs axis, never :fidelity"
     (is (every? #(= :world-inputs (:axis %))
-                (signals/world-input-signals {:args {:n 1} :network {[:get "/x"] {}}})))))
+                (rf.story.ui.sidebar-signals/world-input-signals {:args {:n 1} :network {[:get "/x"] {}}})))))
 
 ;; ---- runner-requirement axis (capability tokens) -------------------------
 
 (deftest runner-requirement-from-capabilities
   (testing "a pure app-db variant needs only :headless"
-    (is (= :headless (signals/required-runner-kind {})))
-    (is (= :headless (signals/required-runner-kind
+    (is (= :headless (rf.story.ui.sidebar-signals/required-runner-kind {})))
+    (is (= :headless (rf.story.ui.sidebar-signals/required-runner-kind
                        {:script [[:dispatch [:inc]]]
                         :assertions [[:rf.assert/path-equals [:n] 1]]}))))
   (testing "a DOM step escalates the requirement to :dom"
-    (is (= :dom (signals/required-runner-kind
+    (is (= :dom (rf.story.ui.sidebar-signals/required-runner-kind
                   {:script [[:click "#go"]]}))))
   (testing "a visual-snapshot assertion escalates to :browser"
-    (is (= :browser (signals/required-runner-kind
+    (is (= :browser (rf.story.ui.sidebar-signals/required-runner-kind
                       {:assertions [[:rf.assert/visual-snapshot]]}))))
   (testing "the chip rides the :runner-requirement axis, not fidelity"
-    (let [chip (signals/runner-requirement-signal {:script [[:click "#x"]]})]
+    (let [chip (rf.story.ui.sidebar-signals/runner-requirement-signal {:script [[:click "#x"]]})]
       (is (= :runner-requirement (:axis chip)))
       (is (= :dom (:value chip)))
       (is (string? (:label chip))))))
@@ -105,13 +105,13 @@
 
 (deftest frame-binding-signal-shape
   (testing "default is :fresh"
-    (is (= :fresh (:value (signals/frame-binding-signal {})))))
+    (is (= :fresh (:value (rf.story.ui.sidebar-signals/frame-binding-signal {})))))
   (testing ":attached is honoured"
-    (is (= :attached (:value (signals/frame-binding-signal {:frame-binding :attached})))))
+    (is (= :attached (:value (rf.story.ui.sidebar-signals/frame-binding-signal {:frame-binding :attached})))))
   (testing "an invalid frame-binding falls back to :fresh (fail-safe)"
-    (is (= :fresh (:value (signals/frame-binding-signal {:frame-binding :bogus})))))
+    (is (= :fresh (:value (rf.story.ui.sidebar-signals/frame-binding-signal {:frame-binding :bogus})))))
   (testing ":mcp-bound is a UI affordence for an attached binding, not a tier"
-    (let [chip (signals/frame-binding-signal {:frame-binding :attached :mcp-bound true})]
+    (let [chip (rf.story.ui.sidebar-signals/frame-binding-signal {:frame-binding :attached :mcp-bound true})]
       (is (= :frame-binding (:axis chip)))
       (is (= :mcp-bound (:value chip))))))
 
@@ -119,7 +119,7 @@
 
 (deftest variant-signals-keeps-axes-distinct
   (testing "a rich variant surfaces all five axes in separate buckets"
-    (let [sig (signals/variant-signals
+    (let [sig (rf.story.ui.sidebar-signals/variant-signals
                 {:setup        [[:dispatch [:seed]]]
                  :sub-overrides {[:q] 1}
                  :args          {:label "x"}
@@ -142,10 +142,10 @@
       ;; frame binding — attached.
       (is (= :attached (get-in sig [:frame-binding :value])))
       ;; the five axes are five distinct keys.
-      (is (= signals/chip-axes
+      (is (= rf.story.ui.sidebar-signals/chip-axes
              [:status :fidelity :world-inputs :runner-requirement :frame-binding]))))
   (testing "a calm default variant still carries the always-present axes"
-    (let [sig (signals/variant-signals {} :pending)]
+    (let [sig (rf.story.ui.sidebar-signals/variant-signals {} :pending)]
       (is (= :pending (get-in sig [:status :value])))
       (is (= [] (:fidelity sig)))
       (is (= [] (:world-inputs sig)))

--- a/tools/story/test/re_frame/story/ui/tag_badges_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/tag_badges_cljs_test.cljc
@@ -16,16 +16,16 @@
     `:tags` renders no badge container at all; a variant with tags
     contributes badges into its sidebar row."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story :as story]
-            [re-frame.story.ui.state :as state]
-            #?@(:cljs [[re-frame.story.ui.sidebar :as sidebar]])))
+            [re-frame.story :as rf.story]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            #?@(:cljs [[re-frame.story.ui.sidebar :as rf.story.ui.sidebar]])))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-all! []
-  (story/clear-all!)
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!))
+  (rf.story/clear-all!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!))
 
 (use-fixtures :each (fn [t] (reset-all!) (t)))
 
@@ -34,30 +34,30 @@
 #?(:cljs
    (deftest tag-badge-style-mapping-canonical-seven
      (testing "each of the seven canonical tags maps to its own style key"
-       (is (= :tag-badge-dev          (sidebar/tag->badge-style-key :dev)))
-       (is (= :tag-badge-docs         (sidebar/tag->badge-style-key :docs)))
-       (is (= :tag-badge-test         (sidebar/tag->badge-style-key :test)))
-       (is (= :tag-badge-screenshot   (sidebar/tag->badge-style-key :screenshot)))
-       (is (= :tag-badge-experimental (sidebar/tag->badge-style-key :experimental)))
-       (is (= :tag-badge-internal     (sidebar/tag->badge-style-key :internal)))
-       (is (= :tag-badge-agent        (sidebar/tag->badge-style-key :agent))))))
+       (is (= :tag-badge-dev          (rf.story.ui.sidebar/tag->badge-style-key :dev)))
+       (is (= :tag-badge-docs         (rf.story.ui.sidebar/tag->badge-style-key :docs)))
+       (is (= :tag-badge-test         (rf.story.ui.sidebar/tag->badge-style-key :test)))
+       (is (= :tag-badge-screenshot   (rf.story.ui.sidebar/tag->badge-style-key :screenshot)))
+       (is (= :tag-badge-experimental (rf.story.ui.sidebar/tag->badge-style-key :experimental)))
+       (is (= :tag-badge-internal     (rf.story.ui.sidebar/tag->badge-style-key :internal)))
+       (is (= :tag-badge-agent        (rf.story.ui.sidebar/tag->badge-style-key :agent))))))
 
 #?(:cljs
    (deftest tag-badge-style-mapping-unknown-tag-falls-through
      (testing "an unknown tag returns nil — the renderer merges nil into
                the base `:tag-badge` style, yielding the neutral grey pill"
-       (is (nil? (sidebar/tag->badge-style-key :wip)))
-       (is (nil? (sidebar/tag->badge-style-key :review)))
-       (is (nil? (sidebar/tag->badge-style-key :prod))))))
+       (is (nil? (rf.story.ui.sidebar/tag->badge-style-key :wip)))
+       (is (nil? (rf.story.ui.sidebar/tag->badge-style-key :review)))
+       (is (nil? (rf.story.ui.sidebar/tag->badge-style-key :prod))))))
 
 ;; ---- pure: sorted-tags ordering -----------------------------------------
 
 #?(:cljs
    (deftest sorted-tags-stable-name-order
      (testing "tags sort by name so the rendered row is stable across runs"
-       (is (= [:agent :dev :docs] (sidebar/sorted-tags #{:docs :agent :dev})))
-       (is (= []                  (sidebar/sorted-tags nil)))
-       (is (= []                  (sidebar/sorted-tags #{}))))))
+       (is (= [:agent :dev :docs] (rf.story.ui.sidebar/sorted-tags #{:docs :agent :dev})))
+       (is (= []                  (rf.story.ui.sidebar/sorted-tags nil)))
+       (is (= []                  (rf.story.ui.sidebar/sorted-tags #{}))))))
 
 ;; ---- CLJS-only: rendered hiccup -----------------------------------------
 
@@ -90,7 +90,7 @@
    (deftest tag-badges-renders-one-pill-per-tag
      (testing "a variant with three tags renders one `.tag-badge` per tag,
                ordered by `name` so visual scanning is stable"
-       (let [tree    (sidebar/tag-badges #{:docs :dev :test})
+       (let [tree    (rf.story.ui.sidebar/tag-badges #{:docs :dev :test})
              badges  (find-by-data-test tree "story-sidebar-tag-badge")
              tag-attrs (map #(get (second %) :data-tag) badges)]
          (is (= 3 (count badges)))
@@ -100,14 +100,14 @@
    (deftest tag-badges-renders-nothing-when-no-tags
      (testing "no `:tags` → `tag-badges` returns nil so the row layout
                doesn't carry an empty container"
-       (is (nil? (sidebar/tag-badges nil)))
-       (is (nil? (sidebar/tag-badges #{}))))))
+       (is (nil? (rf.story.ui.sidebar/tag-badges nil)))
+       (is (nil? (rf.story.ui.sidebar/tag-badges #{}))))))
 
 #?(:cljs
    (deftest tag-badges-unknown-tag-renders-neutral-pill
      (testing "an unknown tag renders as a pill — colour comes from the
                base `:tag-badge` style with no palette override"
-       (let [tree    (sidebar/tag-badges #{:wip})
+       (let [tree    (rf.story.ui.sidebar/tag-badges #{:wip})
              badges  (find-by-data-test tree "story-sidebar-tag-badge")]
          (is (= 1 (count badges)))
          (is (= "wip" (get (second (first badges)) :data-tag)))))))
@@ -117,7 +117,7 @@
      (testing "a variant with a mix of canonical and unknown tags renders
                every tag as a badge, in `name`-sorted order. Mirrors the
                sidebar's row-level integration without booting Reagent."
-       (let [tree    (sidebar/tag-badges #{:wip :dev :test})
+       (let [tree    (rf.story.ui.sidebar/tag-badges #{:wip :dev :test})
              badges  (find-by-data-test tree "story-sidebar-tag-badge")
              attrs   (map #(get (second %) :data-tag) badges)
              container (first (find-by-data-test tree "story-sidebar-tag-badges"))]

--- a/tools/story/test/re_frame/story/ui/test_mode/stepper_pure_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_mode/stepper_pure_cljs_test.cljc
@@ -6,29 +6,29 @@
   consumes is .cljc + pure so the JVM test corpus pins the contract
   without booting Reagent."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.ui.test-mode.stepper-pure :as pure]))
+            [re-frame.story.ui.test-mode.stepper-pure :as rf.story.ui.test-mode.stepper-pure]))
 
 ;; ---- step-position -------------------------------------------------------
 
 (deftest step-position-cursor-zero
   (testing "with cursor 0 the first row is :current; later rows pending"
-    (is (= :current (pure/step-position 0 0)))
-    (is (= :pending (pure/step-position 1 0)))
-    (is (= :pending (pure/step-position 5 0)))))
+    (is (= :current (rf.story.ui.test-mode.stepper-pure/step-position 0 0)))
+    (is (= :pending (rf.story.ui.test-mode.stepper-pure/step-position 1 0)))
+    (is (= :pending (rf.story.ui.test-mode.stepper-pure/step-position 5 0)))))
 
 (deftest step-position-mid-run
   (testing "with cursor 2 of 5: indices 0/1 are :done, 2 is :current, 3/4 pending"
-    (is (= :done    (pure/step-position 0 2)))
-    (is (= :done    (pure/step-position 1 2)))
-    (is (= :current (pure/step-position 2 2)))
-    (is (= :pending (pure/step-position 3 2)))
-    (is (= :pending (pure/step-position 4 2)))))
+    (is (= :done    (rf.story.ui.test-mode.stepper-pure/step-position 0 2)))
+    (is (= :done    (rf.story.ui.test-mode.stepper-pure/step-position 1 2)))
+    (is (= :current (rf.story.ui.test-mode.stepper-pure/step-position 2 2)))
+    (is (= :pending (rf.story.ui.test-mode.stepper-pure/step-position 3 2)))
+    (is (= :pending (rf.story.ui.test-mode.stepper-pure/step-position 4 2)))))
 
 (deftest step-position-parked-at-end
   (testing "cursor = total ⇒ every row is :done; nothing is :current"
-    (is (= :done (pure/step-position 0 3)))
-    (is (= :done (pure/step-position 1 3)))
-    (is (= :done (pure/step-position 2 3)))))
+    (is (= :done (rf.story.ui.test-mode.stepper-pure/step-position 0 3)))
+    (is (= :done (rf.story.ui.test-mode.stepper-pure/step-position 1 3)))
+    (is (= :done (rf.story.ui.test-mode.stepper-pure/step-position 2 3)))))
 
 ;; ---- enrich-statuses ----------------------------------------------------
 
@@ -39,7 +39,7 @@
                      :label "lbl" :status :pass}
                     {:index 2 :event [:rf.assert/path-equals [:b] 2]
                      :label "lbl" :status :fail}]
-          out      (pure/enrich-statuses input 1 #{2})
+          out      (rf.story.ui.test-mode.stepper-pure/enrich-statuses input 1 #{2})
           [a b c]  out]
       (is (= :done    (:position a)))
       (is (= :current (:position b)))
@@ -53,7 +53,7 @@
 
 (deftest enrich-statuses-empty-breakpoints
   (testing "nil breakpoints input is treated as empty set"
-    (let [out (pure/enrich-statuses
+    (let [out (rf.story.ui.test-mode.stepper-pure/enrich-statuses
                 [{:index 0 :event [:e/a] :label ":e/a" :status :event}]
                 0 nil)]
       (is (false? (:breakpoint? (first out)))))))
@@ -62,74 +62,74 @@
 
 (deftest progress-label-shapes
   (testing "renders the four canonical strings"
-    (is (= "ready · 3 steps" (pure/progress-label 0 3)))
-    (is (= "step 1 of 3"     (pure/progress-label 1 3)))
-    (is (= "step 2 of 3"     (pure/progress-label 2 3)))
-    (is (= "done · 3 of 3"   (pure/progress-label 3 3)))
-    (is (= "no steps"        (pure/progress-label 0 0)))))
+    (is (= "ready · 3 steps" (rf.story.ui.test-mode.stepper-pure/progress-label 0 3)))
+    (is (= "step 1 of 3"     (rf.story.ui.test-mode.stepper-pure/progress-label 1 3)))
+    (is (= "step 2 of 3"     (rf.story.ui.test-mode.stepper-pure/progress-label 2 3)))
+    (is (= "done · 3 of 3"   (rf.story.ui.test-mode.stepper-pure/progress-label 3 3)))
+    (is (= "no steps"        (rf.story.ui.test-mode.stepper-pure/progress-label 0 0)))))
 
 (deftest progress-label-safe-on-bad-inputs
   (testing "non-integers collapse to the empty string"
-    (is (= "" (pure/progress-label nil 3)))
-    (is (= "" (pure/progress-label 1 nil)))
-    (is (= "" (pure/progress-label "x" "y")))))
+    (is (= "" (rf.story.ui.test-mode.stepper-pure/progress-label nil 3)))
+    (is (= "" (rf.story.ui.test-mode.stepper-pure/progress-label 1 nil)))
+    (is (= "" (rf.story.ui.test-mode.stepper-pure/progress-label "x" "y")))))
 
 ;; ---- at-end? / at-start? ------------------------------------------------
 
 (deftest at-end-predicate
-  (is (true?  (pure/at-end? 3 3)))
-  (is (true?  (pure/at-end? 4 3)))
-  (is (false? (pure/at-end? 2 3)))
-  (is (false? (pure/at-end? 0 3))))
+  (is (true?  (rf.story.ui.test-mode.stepper-pure/at-end? 3 3)))
+  (is (true?  (rf.story.ui.test-mode.stepper-pure/at-end? 4 3)))
+  (is (false? (rf.story.ui.test-mode.stepper-pure/at-end? 2 3)))
+  (is (false? (rf.story.ui.test-mode.stepper-pure/at-end? 0 3))))
 
 (deftest at-start-predicate
-  (is (true?  (pure/at-start? 0)))
-  (is (true?  (pure/at-start? nil)))
-  (is (false? (pure/at-start? 1))))
+  (is (true?  (rf.story.ui.test-mode.stepper-pure/at-start? 0)))
+  (is (true?  (rf.story.ui.test-mode.stepper-pure/at-start? nil)))
+  (is (false? (rf.story.ui.test-mode.stepper-pure/at-start? 1))))
 
 ;; ---- can-step? / can-step-back? / can-rewind? ---------------------------
 
 (deftest can-step-requires-active-and-not-end
-  (is (true?  (pure/can-step? {:active? true :cursor 0 :total 3})))
-  (is (true?  (pure/can-step? {:active? true :cursor 2 :total 3})))
-  (is (false? (pure/can-step? {:active? true :cursor 3 :total 3})))
-  (is (false? (pure/can-step? {:active? false :cursor 0 :total 3}))))
+  (is (true?  (rf.story.ui.test-mode.stepper-pure/can-step? {:active? true :cursor 0 :total 3})))
+  (is (true?  (rf.story.ui.test-mode.stepper-pure/can-step? {:active? true :cursor 2 :total 3})))
+  (is (false? (rf.story.ui.test-mode.stepper-pure/can-step? {:active? true :cursor 3 :total 3})))
+  (is (false? (rf.story.ui.test-mode.stepper-pure/can-step? {:active? false :cursor 0 :total 3}))))
 
 (deftest can-step-back-requires-active-and-not-start
-  (is (true?  (pure/can-step-back? {:active? true :cursor 1})))
-  (is (false? (pure/can-step-back? {:active? true :cursor 0})))
-  (is (false? (pure/can-step-back? {:active? false :cursor 1}))))
+  (is (true?  (rf.story.ui.test-mode.stepper-pure/can-step-back? {:active? true :cursor 1})))
+  (is (false? (rf.story.ui.test-mode.stepper-pure/can-step-back? {:active? true :cursor 0})))
+  (is (false? (rf.story.ui.test-mode.stepper-pure/can-step-back? {:active? false :cursor 1}))))
 
 (deftest can-rewind-mirrors-step-back
-  (is (true?  (pure/can-rewind? {:active? true :cursor 2})))
-  (is (false? (pure/can-rewind? {:active? true :cursor 0})))
-  (is (false? (pure/can-rewind? {:active? false :cursor 2}))))
+  (is (true?  (rf.story.ui.test-mode.stepper-pure/can-rewind? {:active? true :cursor 2})))
+  (is (false? (rf.story.ui.test-mode.stepper-pure/can-rewind? {:active? true :cursor 0})))
+  (is (false? (rf.story.ui.test-mode.stepper-pure/can-rewind? {:active? false :cursor 2}))))
 
 ;; ---- can-pause? / can-resume? -------------------------------------------
 
 (deftest can-pause-only-while-playing
-  (is (true?  (pure/can-pause? {:active? true :auto-playing? true})))
-  (is (false? (pure/can-pause? {:active? true :auto-playing? false})))
-  (is (false? (pure/can-pause? {:active? false :auto-playing? true}))))
+  (is (true?  (rf.story.ui.test-mode.stepper-pure/can-pause? {:active? true :auto-playing? true})))
+  (is (false? (rf.story.ui.test-mode.stepper-pure/can-pause? {:active? true :auto-playing? false})))
+  (is (false? (rf.story.ui.test-mode.stepper-pure/can-pause? {:active? false :auto-playing? true}))))
 
 (deftest can-resume-not-while-playing-not-at-end
-  (is (true?  (pure/can-resume? {:active? true :auto-playing? false
+  (is (true?  (rf.story.ui.test-mode.stepper-pure/can-resume? {:active? true :auto-playing? false
                                  :cursor 0 :total 3})))
-  (is (false? (pure/can-resume? {:active? true :auto-playing? true
+  (is (false? (rf.story.ui.test-mode.stepper-pure/can-resume? {:active? true :auto-playing? true
                                  :cursor 0 :total 3}))
       "already playing — no resume offered")
-  (is (false? (pure/can-resume? {:active? true :auto-playing? false
+  (is (false? (rf.story.ui.test-mode.stepper-pure/can-resume? {:active? true :auto-playing? false
                                  :cursor 3 :total 3}))
       "parked at end — no resume offered"))
 
 ;; ---- breakpoint-hit? ----------------------------------------------------
 
 (deftest breakpoint-hit-returns-true-on-match
-  (is (true?  (pure/breakpoint-hit? 2 #{2})))
-  (is (false? (pure/breakpoint-hit? 1 #{2})))
-  (is (false? (pure/breakpoint-hit? 2 #{})))
-  (is (false? (pure/breakpoint-hit? 2 nil)))
-  (is (false? (pure/breakpoint-hit? 2 [2]))
+  (is (true?  (rf.story.ui.test-mode.stepper-pure/breakpoint-hit? 2 #{2})))
+  (is (false? (rf.story.ui.test-mode.stepper-pure/breakpoint-hit? 1 #{2})))
+  (is (false? (rf.story.ui.test-mode.stepper-pure/breakpoint-hit? 2 #{})))
+  (is (false? (rf.story.ui.test-mode.stepper-pure/breakpoint-hit? 2 nil)))
+  (is (false? (rf.story.ui.test-mode.stepper-pure/breakpoint-hit? 2 [2]))
       "non-set inputs are rejected — only a set returns hit"))
 
 ;; ---- step-statuses (rf2-ee38b.3 — full-script step list) ----------------
@@ -143,7 +143,7 @@
                    [:assert-db [:n] 5]
                    [:assert-dom "div.x" :visible]
                    [:click "button.y"]]
-          rows    (pure/step-statuses steps [])]
+          rows    (rf.story.ui.test-mode.stepper-pure/step-statuses steps [])]
       (is (= 5 (count rows)) "all five step types render a row")
       (is (= [0 1 2 3 4] (mapv :index rows)))
       (is (= steps (mapv :step rows)))
@@ -165,7 +165,7 @@
                    {:type :assert-db  :passed? false}
                    {:type :assert-dom :passed? false :skipped? true}
                    {:type :dispatch   :passed? nil}]
-          rows    (pure/step-statuses steps results)]
+          rows    (rf.story.ui.test-mode.stepper-pure/step-statuses steps results)]
       (is (= :pass  (:status (nth rows 0))))
       (is (= :fail  (:status (nth rows 1))))
       (is (= :skip  (:status (nth rows 2))))
@@ -175,7 +175,7 @@
   (testing "steps beyond the results length render neutral (not yet run)"
     (let [steps   [[:assert-db [:n] 5] [:assert-db [:n] 6]]
           results [{:type :assert-db :passed? false}]
-          rows    (pure/step-statuses steps results)]
+          rows    (rf.story.ui.test-mode.stepper-pure/step-statuses steps results)]
       (is (= :fail  (:status (nth rows 0))) "first step ran → its outcome")
       (is (= :event (:status (nth rows 1))) "second step not yet run → neutral"))))
 
@@ -184,6 +184,6 @@
 (deftest play-step-label-roundtrips
   (testing "re-export keeps the same shape as test-mode-pure/play-step-label"
     (is (= ":auth/email-changed"
-           (pure/play-step-label [:auth/email-changed "x@y"])))
-    (is (= "" (pure/play-step-label nil)))
-    (is (= "" (pure/play-step-label [])))))
+           (rf.story.ui.test-mode.stepper-pure/play-step-label [:auth/email-changed "x@y"])))
+    (is (= "" (rf.story.ui.test-mode.stepper-pure/play-step-label nil)))
+    (is (= "" (rf.story.ui.test-mode.stepper-pure/play-step-label [])))))

--- a/tools/story/test/re_frame/story/ui/test_mode/stepper_state_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/test_mode/stepper_state_cljs_test.cljs
@@ -2,23 +2,23 @@
   "CLJS tests for the play step-debugger local state (rf2-ulw5m + spec/009
   §Play step-debugger).
 
-  The substantive runtime calls (`runtime/reset-variant`,
-  `play/begin-stepper!`, `rf/restore-epoch!`) are exercised by the
+  The substantive runtime calls (`rf.story.runtime/reset-variant`,
+  `rf.story.play/begin-stepper!`, `rf/restore-epoch!`) are exercised by the
   feature-load browser gate. These unit tests pin the mutator semantics
   by redef-ing the substrate calls so the slot transitions can be
   observed deterministically without booting the runtime."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core :as rf]
-            [re-frame.story.assertions :as assertions]
-            [re-frame.story.play :as play]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.story.runtime :as runtime]
-            [re-frame.story.ui.test-mode.stepper-state :as st]))
+            [re-frame.story.assertions :as rf.story.assertions]
+            [re-frame.story.play :as rf.story.play]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.runtime :as rf.story.runtime]
+            [re-frame.story.ui.test-mode.stepper-state :as rf.story.ui.test-mode.stepper-state]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-results! []
-  (reset! st/results-atom {}))
+  (reset! rf.story.ui.test-mode.stepper-state/results-atom {}))
 
 (use-fixtures :each {:before reset-results! :after reset-results!})
 
@@ -29,7 +29,7 @@
 (defn- seed-slot!
   [variant-id play-steps]
   (let [total (count play-steps)]
-    (swap! st/results-atom assoc variant-id
+    (swap! rf.story.ui.test-mode.stepper-state/results-atom assoc variant-id
            {:variant-id    variant-id
             :active?       true
             :auto-playing? false
@@ -51,14 +51,14 @@
           events     [[:e/a] [:e/b] [:e/c]]
           dispatched (atom [])]
       (seed-slot! vid events)
-      (with-redefs [play/step-once!    (fn [v]
+      (with-redefs [rf.story.play/step-once!    (fn [v]
                                          (swap! dispatched conj v))
                     rf/epoch-history (fn [_]
                                           [{:epoch-id :epoch/before-a}])
-                    assertions/read-assertions (fn [_] [])]
-        (st/step! vid)
-        (let [s (get @st/results-atom vid)]
-          (is (= [vid] @dispatched) "play/step-once! is called with the variant id")
+                    rf.story.assertions/read-assertions (fn [_] [])]
+        (rf.story.ui.test-mode.stepper-state/step! vid)
+        (let [s (get @rf.story.ui.test-mode.stepper-state/results-atom vid)]
+          (is (= [vid] @dispatched) "rf.story.play/step-once! is called with the variant id")
           (is (= 1 (:cursor s))     "cursor increments to 1")
           (is (= [:epoch/seed :epoch/before-a] (:epoch-stack s))
               "the pre-step epoch-id is pushed onto the stack"))))))
@@ -68,13 +68,13 @@
     (let [vid        :story.unit/end
           dispatched (atom [])]
       (seed-slot! vid [[:e/a]])
-      (swap! st/results-atom assoc-in [vid :cursor] 1)
-      (with-redefs [play/step-once!    (fn [v] (swap! dispatched conj v))
+      (swap! rf.story.ui.test-mode.stepper-state/results-atom assoc-in [vid :cursor] 1)
+      (with-redefs [rf.story.play/step-once!    (fn [v] (swap! dispatched conj v))
                     rf/epoch-history (fn [_] [{:epoch-id :x}])
-                    assertions/read-assertions (fn [_] [])]
-        (st/step! vid)
-        (is (empty? @dispatched) "play/step-once! is NOT called")
-        (is (= 1 (:cursor (get @st/results-atom vid)))
+                    rf.story.assertions/read-assertions (fn [_] [])]
+        (rf.story.ui.test-mode.stepper-state/step! vid)
+        (is (empty? @dispatched) "rf.story.play/step-once! is NOT called")
+        (is (= 1 (:cursor (get @rf.story.ui.test-mode.stepper-state/results-atom vid)))
             "cursor stays at total")))))
 
 (deftest step-noops-when-inactive
@@ -82,11 +82,11 @@
     (let [vid        :story.unit/inactive
           dispatched (atom [])]
       (seed-slot! vid [[:e/a]])
-      (swap! st/results-atom assoc-in [vid :active?] false)
-      (with-redefs [play/step-once!    (fn [v] (swap! dispatched conj v))
+      (swap! rf.story.ui.test-mode.stepper-state/results-atom assoc-in [vid :active?] false)
+      (with-redefs [rf.story.play/step-once!    (fn [v] (swap! dispatched conj v))
                     rf/epoch-history (fn [_] [{:epoch-id :x}])
-                    assertions/read-assertions (fn [_] [])]
-        (st/step! vid)
+                    rf.story.assertions/read-assertions (fn [_] [])]
+        (rf.story.ui.test-mode.stepper-state/step! vid)
         (is (empty? @dispatched))))))
 
 ;; ---- step-back! ----------------------------------------------------------
@@ -102,7 +102,7 @@
       (seed-slot! vid [[:e/a] [:e/b]])
       ;; Pretend we've already stepped twice: cursor=2, stack has two
       ;; pre-images on top of the seed.
-      (swap! st/results-atom update vid
+      (swap! rf.story.ui.test-mode.stepper-state/results-atom update vid
              (fn [s] (-> s
                          (assoc :cursor 2)
                          (assoc :epoch-stack [:epoch/seed
@@ -111,9 +111,9 @@
       (with-redefs [rf/restore-epoch! (fn [v eid]
                                        (swap! restored conj [v eid]))
                     rf/epoch-history (fn [_] [{:epoch-id :x}])
-                    assertions/read-assertions (fn [_] [])]
-        (st/step-back! vid)
-        (let [s (get @st/results-atom vid)]
+                    rf.story.assertions/read-assertions (fn [_] [])]
+        (rf.story.ui.test-mode.stepper-state/step-back! vid)
+        (let [s (get @rf.story.ui.test-mode.stepper-state/results-atom vid)]
           (is (= [[vid :epoch/before-b]] @restored)
               "restored against the TOP of the stack (before-b) — the
                pre-image of the step cursor=2 just ran, NOT the entry
@@ -136,7 +136,7 @@
     (let [vid      :story.unit/back-cursor3
           restored (atom [])]
       (seed-slot! vid [[:e/a] [:e/b] [:e/c]])
-      (swap! st/results-atom update vid
+      (swap! rf.story.ui.test-mode.stepper-state/results-atom update vid
              (fn [s] (-> s
                          (assoc :cursor 3)
                          ;; The real duplicate-seed shape begin!/step!
@@ -147,21 +147,21 @@
       (with-redefs [rf/restore-epoch! (fn [v eid]
                                        (swap! restored conj [v eid]))
                     rf/epoch-history (fn [_] [{:epoch-id :x}])
-                    assertions/read-assertions (fn [_] [])]
-        (st/step-back! vid)
+                    rf.story.assertions/read-assertions (fn [_] [])]
+        (rf.story.ui.test-mode.stepper-state/step-back! vid)
         (is (= [[vid :epoch/s2]] @restored)
             "restores S2 — the pre-image of the step just taken —
              rather than S1 (the pre-fix off-by-one under-shoot)")
-        (is (= 2 (:cursor (get @st/results-atom vid))))
+        (is (= 2 (:cursor (get @rf.story.ui.test-mode.stepper-state/results-atom vid))))
         ;; Stepping back again from cursor=2 must land on S1, exercising
         ;; the SAME correct behaviour continues past the duplicate-seed
         ;; entry at the bottom.
-        (st/step-back! vid)
+        (rf.story.ui.test-mode.stepper-state/step-back! vid)
         (is (= [[vid :epoch/s2] [vid :epoch/s1]] @restored)
             "a second step-back restores S1 — the duplicate seed at the
              bottom of the stack is consumed correctly, never restoring
              one epoch too far")
-        (is (= 1 (:cursor (get @st/results-atom vid))))))))
+        (is (= 1 (:cursor (get @rf.story.ui.test-mode.stepper-state/results-atom vid))))))))
 
 (deftest step-back-noops-at-start
   (testing "step-back! does nothing when cursor is 0"
@@ -171,10 +171,10 @@
       (with-redefs [rf/restore-epoch! (fn [v eid]
                                        (swap! restored conj [v eid]))
                     rf/epoch-history (fn [_] [{:epoch-id :x}])
-                    assertions/read-assertions (fn [_] [])]
-        (st/step-back! vid)
+                    rf.story.assertions/read-assertions (fn [_] [])]
+        (rf.story.ui.test-mode.stepper-state/step-back! vid)
         (is (empty? @restored))
-        (is (= 0 (:cursor (get @st/results-atom vid))))))))
+        (is (= 0 (:cursor (get @rf.story.ui.test-mode.stepper-state/results-atom vid))))))))
 
 ;; ---- rewind! -------------------------------------------------------------
 
@@ -184,7 +184,7 @@
     (let [vid      :story.unit/rewind
           restored (atom [])]
       (seed-slot! vid [[:e/a] [:e/b]])
-      (swap! st/results-atom update vid
+      (swap! rf.story.ui.test-mode.stepper-state/results-atom update vid
              (fn [s] (-> s
                          (assoc :cursor 2)
                          (assoc :epoch-stack [:epoch/seed
@@ -193,13 +193,13 @@
       (with-redefs [rf/restore-epoch! (fn [v eid]
                                        (swap! restored conj [v eid]))
                     rf/epoch-history (fn [_] [{:epoch-id :x}])
-                    assertions/read-assertions (fn [_] [])]
-        (st/rewind! vid)
+                    rf.story.assertions/read-assertions (fn [_] [])]
+        (rf.story.ui.test-mode.stepper-state/rewind! vid)
         (is (= [[vid :epoch/seed]] @restored)
             "restored against the SEED epoch-id (bottom of stack) — rf2-luzky:
              that epoch-restore alone rewinds [:rf.story/assertions]; there is
              no longer a side-table accumulator to clear separately")
-        (let [s (get @st/results-atom vid)]
+        (let [s (get @rf.story.ui.test-mode.stepper-state/results-atom vid)]
           (is (= 0 (:cursor s)))
           (is (= [:epoch/seed] (:epoch-stack s))))))))
 
@@ -207,17 +207,17 @@
   (testing "rewind! pauses any in-flight auto-play"
     (let [vid :story.unit/rewind-autoplay]
       (seed-slot! vid [[:e/a]])
-      (swap! st/results-atom update vid
+      (swap! rf.story.ui.test-mode.stepper-state/results-atom update vid
              (fn [s] (-> s
                          (assoc :cursor 1)
                          (assoc :auto-playing? true)
                          (assoc :interval-id 999))))
       (with-redefs [rf/restore-epoch! (fn [_ _] nil)
                     rf/epoch-history (fn [_] [])
-                    assertions/read-assertions (fn [_] [])
+                    rf.story.assertions/read-assertions (fn [_] [])
                     js/clearInterval (fn [_] nil)]
-        (st/rewind! vid)
-        (let [s (get @st/results-atom vid)]
+        (rf.story.ui.test-mode.stepper-state/rewind! vid)
+        (let [s (get @rf.story.ui.test-mode.stepper-state/results-atom vid)]
           (is (false? (:auto-playing? s)))
           (is (nil?   (:interval-id   s))))))))
 
@@ -228,34 +228,34 @@
     (let [vid     :story.unit/pause
           cleared (atom [])]
       (seed-slot! vid [[:e/a]])
-      (swap! st/results-atom update vid
+      (swap! rf.story.ui.test-mode.stepper-state/results-atom update vid
              (fn [s] (assoc s :auto-playing? true :interval-id 42)))
       (with-redefs [js/clearInterval (fn [h] (swap! cleared conj h))]
-        (st/pause! vid)
+        (rf.story.ui.test-mode.stepper-state/pause! vid)
         (is (= [42] @cleared))
-        (is (false? (:auto-playing? (get @st/results-atom vid))))
-        (is (nil?   (:interval-id   (get @st/results-atom vid))))))))
+        (is (false? (:auto-playing? (get @rf.story.ui.test-mode.stepper-state/results-atom vid))))
+        (is (nil?   (:interval-id   (get @rf.story.ui.test-mode.stepper-state/results-atom vid))))))))
 
 (deftest resume-noops-at-end
   (testing "resume! does nothing when parked at the end"
     (let [vid    :story.unit/resume-end
           inter  (atom 0)]
       (seed-slot! vid [[:e/a]])
-      (swap! st/results-atom assoc-in [vid :cursor] 1)
+      (swap! rf.story.ui.test-mode.stepper-state/results-atom assoc-in [vid :cursor] 1)
       (with-redefs [js/setInterval (fn [_ _]
                                      (swap! inter inc)
                                      :id)]
-        (st/resume! vid)
+        (rf.story.ui.test-mode.stepper-state/resume! vid)
         (is (zero? @inter) "no interval is set")
-        (is (false? (:auto-playing? (get @st/results-atom vid))))))))
+        (is (false? (:auto-playing? (get @rf.story.ui.test-mode.stepper-state/results-atom vid))))))))
 
 (deftest resume-sets-auto-playing
   (testing "resume! sets :auto-playing? true + records the interval id"
     (let [vid :story.unit/resume]
       (seed-slot! vid [[:e/a] [:e/b]])
       (with-redefs [js/setInterval (fn [_ _] :iid-99)]
-        (st/resume! vid)
-        (let [s (get @st/results-atom vid)]
+        (rf.story.ui.test-mode.stepper-state/resume! vid)
+        (let [s (get @rf.story.ui.test-mode.stepper-state/results-atom vid)]
           (is (true?  (:auto-playing? s)))
           (is (= :iid-99 (:interval-id s))))))))
 
@@ -265,19 +265,19 @@
   (testing "toggle-breakpoint! adds when absent, removes when present"
     (let [vid :story.unit/bp]
       (seed-slot! vid [[:e/a] [:e/b] [:e/c]])
-      (with-redefs [assertions/read-assertions (fn [_] [])]
-        (st/toggle-breakpoint! vid 1)
-        (is (= #{1} (:breakpoints (get @st/results-atom vid))))
-        (st/toggle-breakpoint! vid 2)
-        (is (= #{1 2} (:breakpoints (get @st/results-atom vid))))
-        (st/toggle-breakpoint! vid 1)
-        (is (= #{2} (:breakpoints (get @st/results-atom vid))))))))
+      (with-redefs [rf.story.assertions/read-assertions (fn [_] [])]
+        (rf.story.ui.test-mode.stepper-state/toggle-breakpoint! vid 1)
+        (is (= #{1} (:breakpoints (get @rf.story.ui.test-mode.stepper-state/results-atom vid))))
+        (rf.story.ui.test-mode.stepper-state/toggle-breakpoint! vid 2)
+        (is (= #{1 2} (:breakpoints (get @rf.story.ui.test-mode.stepper-state/results-atom vid))))
+        (rf.story.ui.test-mode.stepper-state/toggle-breakpoint! vid 1)
+        (is (= #{2} (:breakpoints (get @rf.story.ui.test-mode.stepper-state/results-atom vid))))))))
 
 (deftest toggle-breakpoint-noops-when-inactive
   (testing "toggle-breakpoint! is a no-op when there is no slot"
     (let [vid :story.unit/bp-noslot]
-      (st/toggle-breakpoint! vid 0)
-      (is (nil? (get @st/results-atom vid))))))
+      (rf.story.ui.test-mode.stepper-state/toggle-breakpoint! vid 0)
+      (is (nil? (get @rf.story.ui.test-mode.stepper-state/results-atom vid))))))
 
 ;; ---- end! ---------------------------------------------------------------
 
@@ -288,13 +288,13 @@
           ended    (atom [])
           cleared  (atom [])]
       (seed-slot! vid [[:e/a]])
-      (swap! st/results-atom update vid
+      (swap! rf.story.ui.test-mode.stepper-state/results-atom update vid
              (fn [s] (assoc s :auto-playing? true :interval-id 77)))
-      (with-redefs [play/end-stepper! (fn [v] (swap! ended conj v))
+      (with-redefs [rf.story.play/end-stepper! (fn [v] (swap! ended conj v))
                     js/clearInterval  (fn [h] (swap! cleared conj h))]
-        (st/end! vid)
+        (rf.story.ui.test-mode.stepper-state/end! vid)
         (is (= [vid] @ended)
-            "play/end-stepper! is called against the variant id")
+            "rf.story.play/end-stepper! is called against the variant id")
         (is (= [77] @cleared))
-        (is (nil? (get @st/results-atom vid))
+        (is (nil? (get @rf.story.ui.test-mode.stepper-state/results-atom vid))
             "the slot is removed from the local atom")))))

--- a/tools/story/test/re_frame/story/ui/test_mode/stepper_view_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/test_mode/stepper_view_cljs_test.cljs
@@ -7,12 +7,12 @@
   the correct controls for each state, and the disabled-button rules.
   No reagent mounting — we deref the component fn directly."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.story.ui.test-mode.stepper-state :as st]
-            [re-frame.story.ui.test-mode.stepper-view  :as sv]))
+            [re-frame.story.ui.test-mode.stepper-state :as rf.story.ui.test-mode.stepper-state]
+            [re-frame.story.ui.test-mode.stepper-view  :as rf.story.ui.test-mode.stepper-view]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
-(defn reset-results! [] (reset! st/results-atom {}))
+(defn reset-results! [] (reset! rf.story.ui.test-mode.stepper-state/results-atom {}))
 
 (use-fixtures :each {:before reset-results! :after reset-results!})
 
@@ -47,7 +47,7 @@
   → hiccup). Bypasses Reagent's class lifecycle so the hiccup is
   directly inspectable."
   [variant-id]
-  (sv/render-section variant-id (get @st/results-atom variant-id)))
+  (rf.story.ui.test-mode.stepper-view/render-section variant-id (get @rf.story.ui.test-mode.stepper-state/results-atom variant-id)))
 
 ;; ---- inactive state ------------------------------------------------------
 
@@ -73,7 +73,7 @@
 
 (defn- seed-slot!
   [variant-id slot]
-  (swap! st/results-atom assoc variant-id slot))
+  (swap! rf.story.ui.test-mode.stepper-state/results-atom assoc variant-id slot))
 
 (deftest active-shows-all-controls
   (testing "active state renders step / step-back / rewind / play /

--- a/tools/story/test/re_frame/story/ui/test_mode/view_variant_switch_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/test_mode/view_variant_switch_dom_cljs_test.cljs
@@ -25,7 +25,7 @@
       mount [test-mode.view/test-view variant-a] (no React key)
             |
       test-view's r/with-let body -> variant-has-tests? + no stored
-      result -> state/run-variant-pane! variant-a
+      result -> rf.story.ui.state/run-variant-pane! variant-a
             |
       re-render the SAME root with [test-mode.view/test-view variant-b]
       -- same component type, no key, so React reconciles as a PROP
@@ -45,37 +45,37 @@
             ["react-dom" :as react-dom]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as registrar]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.story :as story]
-            [re-frame.story.loaders :as loaders]
-            [re-frame.story.ui.state :as state]
-            [re-frame.story.ui.test-mode.state :as tm-state]
-            [re-frame.story.ui.test-mode.view :as view]
-            [re-frame.subs :as subs]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.story :as rf.story]
+            [re-frame.story.loaders :as rf.story.loaders]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.ui.test-mode.state :as rf.story.ui.test-mode.state]
+            [re-frame.story.ui.test-mode.view :as rf.story.ui.test-mode.view]
+            [re-frame.subs :as rf.subs]))
 
 ;; ---- fixture --------------------------------------------------------------
 
 (defn- reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! reagent-adapter/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.adapter.reagent/adapter)
        (catch :default _ nil))
   ;; Re-register the framework `:rf/machine` sub after the registrar
   ;; clear (mirrors the sibling viewport-toggle-app-db-dom-cljs-test's
   ;; reset-all!).
-  (subs/reg-runtime-sub :rf/machine
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [runtime-db [_ machine-id]]
       (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (reset! tm-state/results-atom {})
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (reset! rf.story.ui.test-mode.state/results-atom {})
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -108,10 +108,10 @@
           (fn [{:keys [db]} _] {:db (assoc db :v "a")}))
         (rf/reg-event :testview-switch/set-b
           (fn [{:keys [db]} _] {:db (assoc db :v "b")}))
-        (story/reg-variant va
+        (rf.story/reg-variant va
           {:setup      [[:testview-switch/set-a]]
            :script [[:dispatch-sync [:rf.assert/path-equals [:v] "a"]]]})
-        (story/reg-variant vb
+        (rf.story/reg-variant vb
           {:setup      [[:testview-switch/set-b]]
            :script [[:dispatch-sync [:rf.assert/path-equals [:v] "b"]]]})
         (let [mount-node (make-mount-node!)
@@ -120,8 +120,8 @@
             ;; Initial mount on variant A — no React key, mirroring
             ;; shell.cljs's call site.
             (react-dom/flushSync
-              (fn [] (rdc/render root [view/test-view va])))
-            (is (true? (get-in @tm-state/results-atom [va :running?]))
+              (fn [] (rdc/render root [rf.story.ui.test-mode.view/test-view va])))
+            (is (true? (get-in @rf.story.ui.test-mode.state/results-atom [va :running?]))
                 "variant A auto-ran on first mount (run-variant-pane!'s
                  begin-run! prelude stamps :running? synchronously)")
             (is (some? (.querySelector mount-node "[data-test=\"story-test-view\"]"))
@@ -132,8 +132,8 @@
             ;; a PROP UPDATE (no unmount/remount) at the same tree
             ;; position.
             (react-dom/flushSync
-              (fn [] (rdc/render root [view/test-view vb])))
-            (is (true? (get-in @tm-state/results-atom [vb :running?]))
+              (fn [] (rdc/render root [rf.story.ui.test-mode.view/test-view vb])))
+            (is (true? (get-in @rf.story.ui.test-mode.state/results-atom [vb :running?]))
                 "rf2-4e545l: variant B auto-ran too, even though React
                  reconciled the swap as a prop update rather than a
                  fresh mount — the pre-fix :component-did-mount-only

--- a/tools/story/test/re_frame/story/ui/test_mode/visual_a11y_pure_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_mode/visual_a11y_pure_cljs_test.cljc
@@ -4,7 +4,7 @@
 
   The substantive UI is CLJS, but the projection the dedicated visual/a11y
   results component (`re-frame.story.ui.test-mode.visual-a11y-view`)
-  consumes is `.cljc` + pure (`pure/browser-result-rows` and friends), so
+  consumes is `.cljc` + pure (`rf.story.ui.test-mode.pure/browser-result-rows` and friends), so
   the JVM test corpus pins the contract without booting Reagent.
 
   The browser-tier oracle records under test are exactly the shapes the run
@@ -18,7 +18,7 @@
     identity, `:expected` the baseline;
   - any of the three can be `:cannot-run` (the headless / hiccup refusal)."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.ui.test-mode.pure :as pure]))
+            [re-frame.story.ui.test-mode.pure :as rf.story.ui.test-mode.pure]))
 
 ;; ---- structural-a11y-findings -------------------------------------------
 
@@ -31,7 +31,7 @@
                              :detail "img element has no :alt attribute"}
                             {:rule :control-missing-name :tag :button
                              :detail "button control has no accessible name"}]}
-          rows (pure/structural-a11y-findings rec)]
+          rows (rf.story.ui.test-mode.pure/structural-a11y-findings rec)]
       (is (= 2 (count rows)))
       (is (= "image missing alt text" (:finding (first rows))))
       (is (= "<img>" (:locus (first rows))))
@@ -41,19 +41,19 @@
 
 (deftest structural-findings-unknown-rule-falls-back-readably
   (testing "an unknown rule kebab-spells rather than dropping the finding"
-    (let [rows (pure/structural-a11y-findings
+    (let [rows (rf.story.ui.test-mode.pure/structural-a11y-findings
                  {:actual [{:rule :some-future-rule :tag :div :detail "d"}]})]
       (is (= "some future rule" (:finding (first rows))))
       (is (= "<div>" (:locus (first rows)))))))
 
 (deftest structural-findings-empty-on-no-issues
-  (is (= [] (pure/structural-a11y-findings {:actual []})))
-  (is (= [] (pure/structural-a11y-findings {}))))
+  (is (= [] (rf.story.ui.test-mode.pure/structural-a11y-findings {:actual []})))
+  (is (= [] (rf.story.ui.test-mode.pure/structural-a11y-findings {}))))
 
 ;; ---- axe-a11y-findings ---------------------------------------------------
 
 (deftest axe-findings-project-id-impact-help
-  (let [rows (pure/axe-a11y-findings
+  (let [rows (rf.story.ui.test-mode.pure/axe-a11y-findings
                {:actual [{:id "color-contrast" :impact "serious"
                           :help "Elements must have sufficient colour contrast"}]})]
     (is (= 1 (count rows)))
@@ -68,7 +68,7 @@
   (testing "rf2-ffu8t — the axe finding's recovered :selector is the SOURCE
             LINK (spec/021 §4 + §5): :locus is the selector, not the rule id,
             and :selector / :targets carry the offending-element coordinates"
-    (let [rows (pure/axe-a11y-findings
+    (let [rows (rf.story.ui.test-mode.pure/axe-a11y-findings
                  {:actual [{:id       "image-alt"
                             :impact   "critical"
                             :help     "Images must have alternate text"
@@ -81,7 +81,7 @@
       (is (= ["main > img:nth-child(2)"] (:targets row)))
       (is (= "image-alt" (:rule row)) "the rule id is still carried for keying")))
   (testing "a multi-node violation carries every target selector"
-    (let [row (first (pure/axe-a11y-findings
+    (let [row (first (rf.story.ui.test-mode.pure/axe-a11y-findings
                        {:actual [{:id       "label"
                                   :selector "#a"
                                   :targets  ["#a" "#b"]}]}))]
@@ -102,17 +102,17 @@
                     :reason "axe needs a real browser"}
                    {:assertion :rf.assert/visual-snapshot :status :cannot-run
                     :reason "visual needs :pixels"}]}
-          rows   (pure/browser-result-rows result)]
+          rows   (rf.story.ui.test-mode.pure/browser-result-rows result)]
       (is (= 3 (count rows)) "only the 3 browser-tier records surface")
       (is (= [:a11y-structural :a11y :visual] (mapv :kind rows))))))
 
 (deftest browser-rows-empty-when-headless-run-has-no-browser-checks
   (testing "the common headless case projects to no rows — an honest empty
             state, never a fabricated card"
-    (is (= [] (pure/browser-result-rows
+    (is (= [] (rf.story.ui.test-mode.pure/browser-result-rows
                 {:assertions [{:assertion :rf.assert/path-equals :status :pass}]})))
-    (is (= [] (pure/browser-result-rows {:assertions []})))
-    (is (= [] (pure/browser-result-rows {})))))
+    (is (= [] (rf.story.ui.test-mode.pure/browser-result-rows {:assertions []})))
+    (is (= [] (rf.story.ui.test-mode.pure/browser-result-rows {})))))
 
 ;; ---- browser-result-rows: structural-a11y fail --------------------------
 
@@ -124,7 +124,7 @@
                   :reason    "1 structural a11y issue(s) in the rendered hiccup tree: img-missing-alt"
                   :actual    [{:rule :img-missing-alt :tag :img
                                :detail "img element has no :alt attribute"}]}]}
-        row    (first (pure/browser-result-rows result))]
+        row    (first (rf.story.ui.test-mode.pure/browser-result-rows result))]
     (is (= :a11y-structural (:kind row)))
     (is (= :fail (:status row)))
     (is (= 1 (:count row)))
@@ -154,7 +154,7 @@
                                  :help     "Images must have alternate text"
                                  :selector "main > img:nth-child(2)"
                                  :targets  ["main > img:nth-child(2)"]}]}]}
-          row    (first (pure/browser-result-rows result))
+          row    (first (rf.story.ui.test-mode.pure/browser-result-rows result))
           finding (first (:findings row))]
       (is (= :a11y (:kind row)))
       (is (= :fail (:status row)))
@@ -179,7 +179,7 @@
                     :cannot-run? true
                     :passed?     false
                     :reason      "visual snapshot requires a real browser (:pixels)"}]}
-          rows   (pure/browser-result-rows result)
+          rows   (rf.story.ui.test-mode.pure/browser-result-rows result)
           [axe vis] rows]
       (is (= :cannot-run (:status axe)))
       (is (not= :pass (:status axe)))
@@ -198,7 +198,7 @@
                                   :status :pass
                                   :actual "abc123"
                                   :expected :rf.story/any-snapshot}]}
-          row      (first (pure/browser-result-rows captured))]
+          row      (first (rf.story.ui.test-mode.pure/browser-result-rows captured))]
       (is (= :visual (:kind row)))
       (is (= "abc123" (:snapshot row)))
       (is (nil? (:baseline row)) ":rf.story/any-snapshot is no baseline")))
@@ -207,7 +207,7 @@
                                 :status :fail
                                 :actual "new-hash"
                                 :expected "base-hash"}]}
-          row    (first (pure/browser-result-rows diffed))]
+          row    (first (rf.story.ui.test-mode.pure/browser-result-rows diffed))]
       (is (= "new-hash" (:snapshot row)))
       (is (= "base-hash" (:baseline row))))))
 
@@ -218,5 +218,5 @@
             from :passed? (the legacy fallback, not the primary)"
     (let [result {:assertions [{:assertion :rf.assert/a11y-structural
                                 :passed? true :actual []}]}
-          row    (first (pure/browser-result-rows result))]
+          row    (first (rf.story.ui.test-mode.pure/browser-result-rows result))]
       (is (= :pass (:status row))))))

--- a/tools/story/test/re_frame/story/ui/test_mode_pane_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/test_mode_pane_cljs_test.cljs
@@ -27,39 +27,39 @@
   bulk of the pane's correctness without a DOM round-trip."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.machines         :as machines]
-            [re-frame.registrar        :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story            :as story]
-            [re-frame.story.async      :as async-lib]
-            [re-frame.story.loaders    :as loaders]
-            [re-frame.story.ui.state   :as state]
-            [re-frame.story.ui.test-mode.pure  :as tm-pure]
-            [re-frame.story.ui.test-mode.state :as tm-state]
-            [re-frame.subs             :as subs]))
+            [re-frame.frame            :as rf.frame]
+            [re-frame.machines         :as rf.machines]
+            [re-frame.registrar        :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story            :as rf.story]
+            [re-frame.story.async      :as rf.story.async]
+            [re-frame.story.loaders    :as rf.story.loaders]
+            [re-frame.story.ui.state   :as rf.story.ui.state]
+            [re-frame.story.ui.test-mode.pure  :as rf.story.ui.test-mode.pure]
+            [re-frame.story.ui.test-mode.state :as rf.story.ui.test-mode.state]
+            [re-frame.subs             :as rf.subs]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch :default _ nil))
   ;; Re-register the framework `:rf/machine` sub after the registrar clear.
   ;; EP-0001 (rf2-vzld77 / rf2-ixb0bq): a runtime-db sub reading
   ;; [:rf.runtime/machines :snapshots <id>], NOT the retired app-db
   ;; `:rf/runtime` path — mirror `re-frame.machines`.
-  (subs/reg-runtime-sub :rf/machine
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [runtime-db [_ machine-id]]
       (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (reset! tm-state/results-atom {})
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (reset! rf.story.ui.test-mode.state/results-atom {})
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -81,7 +81,7 @@
                :expected  1
                :actual    1
                :source    {:file "story.cljs" :line 12}}
-          row (tm-pure/assertion-row rec)]
+          row (rf.story.ui.test-mode.pure/assertion-row rec)]
       (is (= :rf.assert/path-equals (:assertion row)))
       (is (= :pass                  (:status row)))
       (is (string?                  (:label row)))
@@ -103,7 +103,7 @@
                :actual    0
                :reason    "values differ"
                :source    {:file "story.cljs" :line 24}}
-          row (tm-pure/assertion-row rec)]
+          row (rf.story.ui.test-mode.pure/assertion-row rec)]
       (is (= :fail               (:status row)))
       (is (= 99                  (-> row :detail :expected)))
       (is (= 0                   (-> row :detail :actual)))
@@ -116,20 +116,20 @@
     (let [rec {:assertion :rf.assert/skipped
                :passed?   false
                :reason    "feature gated"}
-          row (tm-pure/assertion-row rec)]
+          row (rf.story.ui.test-mode.pure/assertion-row rec)]
       (is (= :rf.assert/skipped (:assertion row)))
       (is (= :skip              (:status row))
           ":skip overrides the :passed? false → :fail rule")
       (is (= "feature gated"    (-> row :detail :reason))))))
 
 (deftest aggregate-summary-mixed-rows
-  (testing "the pane's headline counts (state/aggregate-summary) fold a
+  (testing "the pane's headline counts (rf.story.ui.state/aggregate-summary) fold a
             mixed pass/fail/skip vector into the spec'd shape"
     (let [assertions [{:assertion :rf.assert/path-equals  :passed? true}
                       {:assertion :rf.assert/path-equals  :passed? false}
                       {:assertion :rf.assert/skipped      :passed? false}
                       {:assertion :rf.assert/sub-equals   :passed? true}]
-          summary    (state/aggregate-summary assertions)]
+          summary    (rf.story.ui.state/aggregate-summary assertions)]
       (is (= 4 (:total summary))
           ":total counts every row including skipped")
       (is (= 2 (:passed summary))
@@ -142,10 +142,10 @@
 
 (deftest aggregate-summary-all-pass-only
   (testing ":all-passed? is true iff total>0 AND failed=0 AND skipped=0"
-    (let [s1 (state/aggregate-summary
+    (let [s1 (rf.story.ui.state/aggregate-summary
                [{:assertion :rf.assert/path-equals :passed? true}])
-          s2 (state/aggregate-summary [])
-          s3 (state/aggregate-summary
+          s2 (rf.story.ui.state/aggregate-summary [])
+          s3 (rf.story.ui.state/aggregate-summary
                [{:assertion :rf.assert/skipped :passed? false}])]
       (is (true?  (:all-passed? s1)))
       (is (false? (:all-passed? s2)) "empty rows ⇒ not all-passed")
@@ -167,14 +167,14 @@
             variant slot with all the renderer-required fields"
     (rf/reg-event :test/set
       (fn [{:keys [db]} _] {:db (assoc db :counter 7)}))
-    (story/reg-variant :story.pane.mount/v
+    (rf.story/reg-variant :story.pane.mount/v
       {:setup [[:test/set]]
        :script [[:dispatch-sync [:rf.assert/path-equals [:counter] 7]]]})
     (async done
-      (-> (tm-state/run-variant-pane! :story.pane.mount/v)
-          (async-lib/then
+      (-> (rf.story.ui.test-mode.state/run-variant-pane! :story.pane.mount/v)
+          (rf.story.async/then
             (fn [_]
-              (let [slot (get @tm-state/results-atom :story.pane.mount/v)]
+              (let [slot (get @rf.story.ui.test-mode.state/results-atom :story.pane.mount/v)]
                 (is (map?     (:result slot))      ":result populated")
                 (is (number?  (:ran-at-ms slot))   ":ran-at-ms stamped")
                 (is (false?   (:running? slot))    ":running? cleared on resolve")
@@ -187,7 +187,7 @@
                 (is (nil?     (:selected-step slot))
                     ":selected-step starts nil (no scrub)")
                 (is (every? :passed? (-> slot :result :assertions))))
-              (story/destroy-variant! :story.pane.mount/v)
+              (rf.story/destroy-variant! :story.pane.mount/v)
               (done)))))))
 
 (deftest run-variant-pane-switching-variants-keeps-slots-distinct
@@ -200,19 +200,19 @@
       (fn [{:keys [db]} _] {:db (assoc db :v "a")}))
     (rf/reg-event :test/set-b
       (fn [{:keys [db]} _] {:db (assoc db :v "b")}))
-    (story/reg-variant :story.pane.switch/a
+    (rf.story/reg-variant :story.pane.switch/a
       {:setup [[:test/set-a]] :script [[:dispatch-sync [:rf.assert/path-equals [:v] "a"]]]})
-    (story/reg-variant :story.pane.switch/b
+    (rf.story/reg-variant :story.pane.switch/b
       {:setup [[:test/set-b]] :script [[:dispatch-sync [:rf.assert/path-equals [:v] "b"]]]})
     (async done
-      (-> (tm-state/run-variant-pane! :story.pane.switch/a)
-          (async-lib/then
+      (-> (rf.story.ui.test-mode.state/run-variant-pane! :story.pane.switch/a)
+          (rf.story.async/then
             (fn [_]
-              (-> (tm-state/run-variant-pane! :story.pane.switch/b)
-                  (async-lib/then
+              (-> (rf.story.ui.test-mode.state/run-variant-pane! :story.pane.switch/b)
+                  (rf.story.async/then
                     (fn [_]
-                      (let [slot-a (get @tm-state/results-atom :story.pane.switch/a)
-                            slot-b (get @tm-state/results-atom :story.pane.switch/b)]
+                      (let [slot-a (get @rf.story.ui.test-mode.state/results-atom :story.pane.switch/a)
+                            slot-b (get @rf.story.ui.test-mode.state/results-atom :story.pane.switch/b)]
                         (is (some? slot-a)
                             "variant A's slot survives the switch")
                         (is (some? slot-b)
@@ -221,8 +221,8 @@
                             "the two slots carry distinct results")
                         (is (= "a" (-> slot-a :result :app-db :v)))
                         (is (= "b" (-> slot-b :result :app-db :v))))
-                      (story/destroy-variant! :story.pane.switch/a)
-                      (story/destroy-variant! :story.pane.switch/b)
+                      (rf.story/destroy-variant! :story.pane.switch/a)
+                      (rf.story/destroy-variant! :story.pane.switch/b)
                       (done))))))))))
 
 ;; ===========================================================================
@@ -257,56 +257,56 @@
             widget reads against; this test pins the pane-local
             results-atom flag the pane's own Re-run button reads."
     (rf/reg-event :test/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-    (story/reg-variant :story.pane.debounce/v
+    (rf.story/reg-variant :story.pane.debounce/v
       {:setup [[:test/inc]]
        :script [[:dispatch-sync [:rf.assert/path-equals [:n] 1]]]})
     (async done
-      (let [p (tm-state/run-variant-pane! :story.pane.debounce/v)]
+      (let [p (rf.story.ui.test-mode.state/run-variant-pane! :story.pane.debounce/v)]
         ;; The synchronous prelude of run-variant-pane! calls begin-run!
         ;; which stamps :running? true BEFORE the promise resolves.
         ;; This is the gate the Re-run button reads: while true, the
         ;; button renders disabled and a click is ignored at the view
         ;; layer. The pure test mirrors that view-layer contract.
-        (is (true? (get-in @tm-state/results-atom
+        (is (true? (get-in @rf.story.ui.test-mode.state/results-atom
                            [:story.pane.debounce/v :running?]))
             ":running? is true synchronously after begin-run! — the
              Re-run button's `disabled?` prop reads this flag")
         ;; After resolve, :running? clears and a second run is allowed.
         (-> p
-            (async-lib/then
+            (rf.story.async/then
               (fn [_]
-                (is (false? (get-in @tm-state/results-atom
+                (is (false? (get-in @rf.story.ui.test-mode.state/results-atom
                                     [:story.pane.debounce/v :running?]))
                     ":running? clears on store-result! — the button
                      re-enables and a fresh re-run can fire")
-                (let [slot (get @tm-state/results-atom :story.pane.debounce/v)]
+                (let [slot (get @rf.story.ui.test-mode.state/results-atom :story.pane.debounce/v)]
                   (is (number? (:ran-at-ms slot))
                       ":ran-at-ms stamped — the renderer shows the
                        'last run at HH:mm:ss' badge"))
-                (story/destroy-variant! :story.pane.debounce/v)
+                (rf.story/destroy-variant! :story.pane.debounce/v)
                 (done))))))))
 
 (deftest run-variant-pane-records-on-resolve
   (testing "after a run resolves, :running? clears AND a fresh re-run is
             allowed (the gate is :running?, not a permanent lock)"
     (rf/reg-event :test/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-    (story/reg-variant :story.pane.cycle/v
+    (rf.story/reg-variant :story.pane.cycle/v
       {:setup [[:test/inc]] :script [[:dispatch-sync [:rf.assert/path-equals [:n] 1]]]})
     (async done
-      (-> (tm-state/run-variant-pane! :story.pane.cycle/v)
-          (async-lib/then
+      (-> (rf.story.ui.test-mode.state/run-variant-pane! :story.pane.cycle/v)
+          (rf.story.async/then
             (fn [_]
-              (is (false? (get-in @tm-state/results-atom
+              (is (false? (get-in @rf.story.ui.test-mode.state/results-atom
                                   [:story.pane.cycle/v :running?]))
                   ":running? cleared after first run resolves")
-              (-> (tm-state/run-variant-pane! :story.pane.cycle/v)
-                  (async-lib/then
+              (-> (rf.story.ui.test-mode.state/run-variant-pane! :story.pane.cycle/v)
+                  (rf.story.async/then
                     (fn [_]
-                      (let [slot (get @tm-state/results-atom :story.pane.cycle/v)]
+                      (let [slot (get @rf.story.ui.test-mode.state/results-atom :story.pane.cycle/v)]
                         (is (false? (:running? slot))
                             "second run resolves cleanly; :running? clear again")
                         (is (every? :passed? (-> slot :result :assertions))
                             "second run's assertions still pass — fresh frame
                              counter starts at 0 and ticks to 1"))
-                      (story/destroy-variant! :story.pane.cycle/v)
+                      (rf.story/destroy-variant! :story.pane.cycle/v)
                       (done))))))))))

--- a/tools/story/test/re_frame/story/ui/test_mode_state_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/test_mode_state_cljs_test.cljs
@@ -13,12 +13,12 @@
   `re-frame.story-ui-test` (JVM)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.story.ui.test-mode.state :as tm-state]))
+            [re-frame.story.ui.test-mode.state :as rf.story.ui.test-mode.state]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-results! []
-  (reset! tm-state/results-atom {}))
+  (reset! rf.story.ui.test-mode.state/results-atom {}))
 
 (use-fixtures :each {:before reset-results! :after reset-results!})
 
@@ -34,15 +34,15 @@
     (let [variant-id :story.unit/race
           epoch-ids  [:epoch/a :epoch/b :epoch/c]
           restored   (atom [])]
-      (swap! tm-state/results-atom assoc variant-id
+      (swap! rf.story.ui.test-mode.state/results-atom assoc variant-id
              {:running?  true
               :epoch-ids epoch-ids})
       (with-redefs [rf/restore-epoch! (fn [vid eid]
                                        (swap! restored conj [vid eid]))]
-        (tm-state/select-step! variant-id 1))
+        (rf.story.ui.test-mode.state/select-step! variant-id 1))
       (is (= [] @restored)
           "rf/restore-epoch! is not called while :running? is true")
-      (is (nil? (get-in @tm-state/results-atom [variant-id :selected-step]))
+      (is (nil? (get-in @rf.story.ui.test-mode.state/results-atom [variant-id :selected-step]))
           ":selected-step is NOT mutated while :running? is true — preserving
            the prior scrubber position so the post-resolve render is
            consistent"))))
@@ -54,15 +54,15 @@
     (let [variant-id :story.unit/idle
           epoch-ids  [:epoch/a :epoch/b :epoch/c]
           restored   (atom [])]
-      (swap! tm-state/results-atom assoc variant-id
+      (swap! rf.story.ui.test-mode.state/results-atom assoc variant-id
              {:running?  false
               :epoch-ids epoch-ids})
       (with-redefs [rf/restore-epoch! (fn [vid eid]
                                        (swap! restored conj [vid eid]))]
-        (tm-state/select-step! variant-id 1))
+        (rf.story.ui.test-mode.state/select-step! variant-id 1))
       (is (= [[variant-id :epoch/b]] @restored)
           "the idle path still calls restore-epoch against the targeted slot")
-      (is (= 1 (get-in @tm-state/results-atom [variant-id :selected-step]))
+      (is (= 1 (get-in @rf.story.ui.test-mode.state/results-atom [variant-id :selected-step]))
           ":selected-step is stamped to the requested index"))))
 
 ;; ---- rf2-tistm: toggle-expanded! keyed by row-key ------------------------
@@ -73,16 +73,16 @@
             View consumers pass assertion-row's :row-key — see the JVM
             test pinning row-key = :label in re-frame.story-ui-test."
     (let [variant-id :story.unit/expand]
-      (tm-state/toggle-expanded! variant-id ":rf.assert/path-equals [[:count] 1]")
+      (rf.story.ui.test-mode.state/toggle-expanded! variant-id ":rf.assert/path-equals [[:count] 1]")
       (is (= #{":rf.assert/path-equals [[:count] 1]"}
-             (get-in @tm-state/results-atom [variant-id :expanded]))
+             (get-in @rf.story.ui.test-mode.state/results-atom [variant-id :expanded]))
           "first toggle inserts the row-key")
-      (tm-state/toggle-expanded! variant-id ":rf.assert/path-equals [[:count] 2]")
+      (rf.story.ui.test-mode.state/toggle-expanded! variant-id ":rf.assert/path-equals [[:count] 2]")
       (is (= #{":rf.assert/path-equals [[:count] 1]"
                ":rf.assert/path-equals [[:count] 2]"}
-             (get-in @tm-state/results-atom [variant-id :expanded]))
+             (get-in @rf.story.ui.test-mode.state/results-atom [variant-id :expanded]))
           "second toggle with a different key adds to the set")
-      (tm-state/toggle-expanded! variant-id ":rf.assert/path-equals [[:count] 1]")
+      (rf.story.ui.test-mode.state/toggle-expanded! variant-id ":rf.assert/path-equals [[:count] 1]")
       (is (= #{":rf.assert/path-equals [[:count] 2]"}
-             (get-in @tm-state/results-atom [variant-id :expanded]))
+             (get-in @rf.story.ui.test-mode.state/results-atom [variant-id :expanded]))
           "toggling an already-present key removes it"))))

--- a/tools/story/test/re_frame/story/ui/test_watch_mode_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_watch_mode_cljs_test.cljc
@@ -16,19 +16,19 @@
     with the correct `aria-pressed` state; toggling on flips the chip
     on, off clears the recorded hashes."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story :as story]
-            [re-frame.story.ui.state :as state]
-            #?@(:cljs [[re-frame.late-bind        :as late-bind]
-                       [re-frame.story.ui.shell   :as shell]
-                       [re-frame.story.ui.sidebar :as sidebar]
-                       [re-frame.story.ui.watch   :as watch]])))
+            [re-frame.story :as rf.story]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            #?@(:cljs [[re-frame.late-bind        :as rf.late-bind]
+                       [re-frame.story.ui.shell   :as rf.story.ui.shell]
+                       [re-frame.story.ui.sidebar :as rf.story.ui.sidebar]
+                       [re-frame.story.ui.watch   :as rf.story.ui.watch]])))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-all! []
-  (story/clear-all!)
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!))
+  (rf.story/clear-all!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!))
 
 (use-fixtures :each (fn [t] (reset-all!) (t)))
 
@@ -36,22 +36,22 @@
 
 (deftest set-test-watch-mode-defaults-off
   (testing "fresh shell-state reads watch-mode off"
-    (is (false? (state/test-watch-mode? state/default-shell-state)))))
+    (is (false? (rf.story.ui.state/test-watch-mode? rf.story.ui.state/default-shell-state)))))
 
 (deftest set-test-watch-mode-toggles-on
   (testing "set-test-watch-mode true → flag flips on"
-    (let [s (state/set-test-watch-mode state/default-shell-state true)]
-      (is (true? (state/test-watch-mode? s))))))
+    (let [s (rf.story.ui.state/set-test-watch-mode rf.story.ui.state/default-shell-state true)]
+      (is (true? (rf.story.ui.state/test-watch-mode? s))))))
 
 (deftest set-test-watch-mode-toggle-off-clears-hashes
   (testing "toggle-off resets [:tests :content-hashes] so the next
             toggle-on seeds fresh from the current registry"
-    (let [seeded (-> state/default-shell-state
-                     (state/set-test-watch-mode true)
-                     (state/record-test-content-hashes
+    (let [seeded (-> rf.story.ui.state/default-shell-state
+                     (rf.story.ui.state/set-test-watch-mode true)
+                     (rf.story.ui.state/record-test-content-hashes
                        {:story.x/a "deadbeef"}))
-          off    (state/set-test-watch-mode seeded false)]
-      (is (false? (state/test-watch-mode? off)))
+          off    (rf.story.ui.state/set-test-watch-mode seeded false)]
+      (is (false? (rf.story.ui.state/test-watch-mode? off)))
       (is (= {} (get-in off [:tests :content-hashes]))))))
 
 ;; ---- pure: drift detection ----------------------------------------------
@@ -60,20 +60,20 @@
   (testing "current == prev → no drift, empty seq"
     (let [prev    {:story.x/a "aaaa" :story.x/b "bbbb"}
           current {:story.x/a "aaaa" :story.x/b "bbbb"}]
-      (is (= [] (state/watch-mode-drift prev current))))))
+      (is (= [] (rf.story.ui.state/watch-mode-drift prev current))))))
 
 (deftest watch-mode-drift-changed-variant
   (testing "one hash changed → that variant drifted"
     (let [prev    {:story.x/a "aaaa" :story.x/b "bbbb"}
           current {:story.x/a "aaaa" :story.x/b "cccc"}]
-      (is (= [:story.x/b] (state/watch-mode-drift prev current))))))
+      (is (= [:story.x/b] (rf.story.ui.state/watch-mode-drift prev current))))))
 
 (deftest watch-mode-drift-multiple-changes-sorted
   (testing "multiple changes → all drifted variants, sorted"
     (let [prev    {:story.x/a "1" :story.x/b "2" :story.x/c "3"}
           current {:story.x/a "X" :story.x/b "2" :story.x/c "Y"}]
       (is (= [:story.x/a :story.x/c]
-             (state/watch-mode-drift prev current))))))
+             (rf.story.ui.state/watch-mode-drift prev current))))))
 
 (deftest watch-mode-drift-new-variant-treated-as-drifted
   (testing "a variant present in current but absent from prev counts
@@ -81,35 +81,35 @@
             exercised)"
     (let [prev    {:story.x/a "aaaa"}
           current {:story.x/a "aaaa" :story.x/b "bbbb"}]
-      (is (= [:story.x/b] (state/watch-mode-drift prev current))))))
+      (is (= [:story.x/b] (rf.story.ui.state/watch-mode-drift prev current))))))
 
 (deftest watch-mode-drift-deregistered-variant-silent
   (testing "a variant present in prev but absent from current is
             silently dropped — there's nothing to re-run"
     (let [prev    {:story.x/a "aaaa" :story.x/b "bbbb"}
           current {:story.x/a "aaaa"}]
-      (is (= [] (state/watch-mode-drift prev current))))))
+      (is (= [] (rf.story.ui.state/watch-mode-drift prev current))))))
 
 (deftest watch-mode-drift-nil-prev-seeds-all
   (testing "a nil prev (toggle-on edge case) treats every current entry
             as drifted — but the watch-mode wiring seeds the slot on
             toggle-on so this case is a defensive guard"
     (let [current {:story.x/a "aaaa" :story.x/b "bbbb"}]
-      (is (= [:story.x/a :story.x/b] (state/watch-mode-drift nil current))))))
+      (is (= [:story.x/a :story.x/b] (rf.story.ui.state/watch-mode-drift nil current))))))
 
 ;; ---- pure: record-test-content-hashes ----------------------------------
 
 (deftest record-test-content-hashes-stamps-slot
   (testing "record-test-content-hashes writes into [:tests :content-hashes]"
-    (let [s (state/record-test-content-hashes state/default-shell-state
+    (let [s (rf.story.ui.state/record-test-content-hashes rf.story.ui.state/default-shell-state
                                               {:story.x/a "aaaa"})]
       (is (= {:story.x/a "aaaa"} (get-in s [:tests :content-hashes]))))))
 
 (deftest record-test-content-hashes-nil-clears
   (testing "nil input clears the slot — used by toggle-off"
-    (let [s (-> state/default-shell-state
-                (state/record-test-content-hashes {:story.x/a "aaaa"})
-                (state/record-test-content-hashes nil))]
+    (let [s (-> rf.story.ui.state/default-shell-state
+                (rf.story.ui.state/record-test-content-hashes {:story.x/a "aaaa"})
+                (rf.story.ui.state/record-test-content-hashes nil))]
       (is (= {} (get-in s [:tests :content-hashes]))))))
 
 ;; ---- CLJS-only: widget renders the watch toggle ------------------------
@@ -142,10 +142,10 @@
    (deftest widget-renders-watch-toggle-off-by-default
      (testing "the chrome widget renders the watch chip with aria-
                pressed=false when watch mode is off"
-       (story/reg-variant :story.x/a {:tags #{:test} :setup []
+       (rf.story/reg-variant :story.x/a {:tags #{:test} :setup []
                                       :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
-       (let [tree (sidebar/test-widget (state/get-state)
-                                       (state/registry-snapshot))
+       (let [tree (rf.story.ui.sidebar/test-widget (rf.story.ui.state/get-state)
+                                       (rf.story.ui.state/registry-snapshot))
              chip (first (find-by-data-test tree "story-test-widget-watch-toggle"))]
          (is (some? chip))
          (is (= "false" (get (second chip) :aria-pressed)))
@@ -155,11 +155,11 @@
    (deftest widget-renders-watch-toggle-on-when-flag-on
      (testing "with [:tests :watch-mode?] true the chip reads aria-pressed=
                true and the data-state attribute reads 'on'"
-       (story/reg-variant :story.x/a {:tags #{:test} :setup []
+       (rf.story/reg-variant :story.x/a {:tags #{:test} :setup []
                                       :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
-       (state/swap-state! state/set-test-watch-mode true)
-       (let [tree (sidebar/test-widget (state/get-state)
-                                       (state/registry-snapshot))
+       (rf.story.ui.state/swap-state! rf.story.ui.state/set-test-watch-mode true)
+       (let [tree (rf.story.ui.sidebar/test-widget (rf.story.ui.state/get-state)
+                                       (rf.story.ui.state/registry-snapshot))
              chip (first (find-by-data-test tree "story-test-widget-watch-toggle"))]
          (is (some? chip))
          (is (= "true" (get (second chip) :aria-pressed)))
@@ -171,16 +171,16 @@
                sub-line and the watch chip is absent (the chip lives
                beneath the count chips and only renders when there's
                something to watch)"
-       (story/reg-variant :story.x/a {:tags #{:dev} :setup []})
-       (let [tree (sidebar/test-widget (state/get-state)
-                                       (state/registry-snapshot))
+       (rf.story/reg-variant :story.x/a {:tags #{:dev} :setup []})
+       (let [tree (rf.story.ui.sidebar/test-widget (rf.story.ui.state/get-state)
+                                       (rf.story.ui.state/registry-snapshot))
              chip (first (find-by-data-test tree "story-test-widget-watch-toggle"))]
          (is (nil? chip))))))
 
 ;; ---- watch-rerun! re-runs only the drifted variants --------------------
 ;;
 ;; This test exercises the public surface that the shell's detector
-;; calls — `sidebar/watch-rerun!` for the drifted variant-ids. We assert
+;; calls — `rf.story.ui.sidebar/watch-rerun!` for the drifted variant-ids. We assert
 ;; that calling it stamps `:running` for each variant before the async
 ;; result lands. The async resolution is covered by the existing test-
 ;; widget tests' 'Run all' coverage; the drift→rerun wiring is the new
@@ -191,14 +191,14 @@
      (testing "watch-rerun! marks every passed variant :running up
                front so the sidebar dots flip yellow in unison — the
                same contract as 'Run all', but driven by the detector"
-       (story/reg-variant :story.x/a {:tags #{:test} :setup []
+       (rf.story/reg-variant :story.x/a {:tags #{:test} :setup []
                                       :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
-       (story/reg-variant :story.x/b {:tags #{:test} :setup []
+       (rf.story/reg-variant :story.x/b {:tags #{:test} :setup []
                                       :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
-       (sidebar/watch-rerun! [:story.x/a :story.x/b])
+       (rf.story.ui.sidebar/watch-rerun! [:story.x/a :story.x/b])
        ;; Both variants stamp :running synchronously before the async
        ;; resolution lands.
-       (let [s (state/get-state)]
+       (let [s (rf.story.ui.state/get-state)]
          (is (= :running (get-in s [:tests :runs :story.x/a :status])))
          (is (= :running (get-in s [:tests :runs :story.x/b :status])))))))
 
@@ -207,10 +207,10 @@
      (testing "watch-rerun! on an empty seq is a no-op — the detector
                only calls it when drift is detected, but the function
                handles the no-drift edge gracefully"
-       (story/reg-variant :story.x/a {:tags #{:test} :setup []
+       (rf.story/reg-variant :story.x/a {:tags #{:test} :setup []
                                       :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
-       (sidebar/watch-rerun! [])
-       (let [s (state/get-state)]
+       (rf.story.ui.sidebar/watch-rerun! [])
+       (let [s (rf.story.ui.state/get-state)]
          (is (nil? (get-in s [:tests :runs :story.x/a])))))))
 
 ;; ---- rf2-mclvi regression: cell-override edit triggers a re-run -------
@@ -227,39 +227,39 @@
      (testing "editing :cell-overrides on a :test-tagged variant
                produces a fresh content-hash via detect-watch-drift!
                and stamps the variant :running (rf2-mclvi)"
-       (story/reg-variant :story.x/a
+       (rf.story/reg-variant :story.x/a
          {:component :app.ui/echo
           :args      {:n 0}
           :tags      #{:test}
           :setup    []
           :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
        ;; Flip watch-mode on and seed the initial hashes with no overrides.
-       (state/swap-state! state/set-test-watch-mode true)
-       (state/swap-state!
+       (rf.story.ui.state/swap-state! rf.story.ui.state/set-test-watch-mode true)
+       (rf.story.ui.state/swap-state!
          (fn [s]
-           (state/record-test-content-hashes
+           (rf.story.ui.state/record-test-content-hashes
              s
              ;; Seed from the current registry — these are the baseline
              ;; hashes the detector diffs against.
              {})))
        ;; First detection pass — should seed hashes + (because prev is
        ;; empty) treat every testable variant as drifted, re-running it.
-       (shell/detect-watch-drift!)
-       (let [seeded-hashes (get-in (state/get-state) [:tests :content-hashes])]
+       (rf.story.ui.shell/detect-watch-drift!)
+       (let [seeded-hashes (get-in (rf.story.ui.state/get-state) [:tests :content-hashes])]
          (is (contains? seeded-hashes :story.x/a)
              "after the first pass the slot is seeded from the registry"))
        ;; Re-seed against the post-baseline so the next pass starts from
        ;; the registry's current truth; cell-edit happens after.
-       (let [post-seed (get-in (state/get-state) [:tests :content-hashes])
+       (let [post-seed (get-in (rf.story.ui.state/get-state) [:tests :content-hashes])
              baseline  (get post-seed :story.x/a)]
          ;; Drop the per-variant :running stamp so we can detect a fresh one.
-         (state/swap-state! state/clear-test-run :story.x/a)
+         (rf.story.ui.state/swap-state! rf.story.ui.state/clear-test-run :story.x/a)
          ;; Now simulate a control-panel edit — write into :cell-overrides.
-         (state/swap-state! state/set-cell-override :story.x/a [:n] 42)
-         (shell/detect-watch-drift!)
-         (let [after-hashes (get-in (state/get-state) [:tests :content-hashes])
+         (rf.story.ui.state/swap-state! rf.story.ui.state/set-cell-override :story.x/a [:n] 42)
+         (rf.story.ui.shell/detect-watch-drift!)
+         (let [after-hashes (get-in (rf.story.ui.state/get-state) [:tests :content-hashes])
                after-hash   (get after-hashes :story.x/a)
-               run-state    (get-in (state/get-state) [:tests :runs :story.x/a])]
+               run-state    (get-in (rf.story.ui.state/get-state) [:tests :runs :story.x/a])]
            (testing "the recomputed hash differs from the baseline (cell-overrides
                      ARE threaded through snapshot-tuple)"
              (is (not= baseline after-hash)
@@ -290,36 +290,36 @@
      (testing "editing one variant's :cell-overrides drifts + re-runs ONLY
                that variant; the sibling testable variant's dot is left
                untouched (rf2-3h3c2y — selective drift-rerun)"
-       (story/reg-variant :story.x/a
+       (rf.story/reg-variant :story.x/a
          {:component :app.ui/echo
           :args      {:n 0}
           :tags      #{:test}
           :setup    []
           :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
-       (story/reg-variant :story.x/b
+       (rf.story/reg-variant :story.x/b
          {:component :app.ui/echo
           :args      {:n 0}
           :tags      #{:test}
           :setup    []
           :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
        ;; Watch on + empty baseline so the first pass seeds both hashes.
-       (state/swap-state! state/set-test-watch-mode true)
-       (state/swap-state! #(state/record-test-content-hashes % {}))
+       (rf.story.ui.state/swap-state! rf.story.ui.state/set-test-watch-mode true)
+       (rf.story.ui.state/swap-state! #(rf.story.ui.state/record-test-content-hashes % {}))
        ;; First pass seeds the baseline (and, because prev is empty,
        ;; treats both as drifted). Clear the :running stamps so we can
        ;; detect a fresh re-run from the NEXT pass alone.
-       (shell/detect-watch-drift!)
-       (let [seeded (get-in (state/get-state) [:tests :content-hashes])]
+       (rf.story.ui.shell/detect-watch-drift!)
+       (let [seeded (get-in (rf.story.ui.state/get-state) [:tests :content-hashes])]
          (is (contains? seeded :story.x/a))
          (is (contains? seeded :story.x/b)
              "both testable variants are hashed into the baseline"))
-       (state/swap-state! state/clear-test-run :story.x/a)
-       (state/swap-state! state/clear-test-run :story.x/b)
+       (rf.story.ui.state/swap-state! rf.story.ui.state/clear-test-run :story.x/a)
+       (rf.story.ui.state/swap-state! rf.story.ui.state/clear-test-run :story.x/b)
        ;; Edit ONLY variant A. B's slots are untouched, so B's hash is
        ;; stable and B must NOT re-run.
-       (state/swap-state! state/set-cell-override :story.x/a [:n] 99)
-       (shell/detect-watch-drift!)
-       (let [runs (get-in (state/get-state) [:tests :runs])]
+       (rf.story.ui.state/swap-state! rf.story.ui.state/set-cell-override :story.x/a [:n] 99)
+       (rf.story.ui.shell/detect-watch-drift!)
+       (let [runs (get-in (rf.story.ui.state/get-state) [:tests :runs])]
          (testing "the drifted variant A re-runs (dot flips :running)"
            (is (= :running (get-in runs [:story.x/a :status]))
                (str "expected A :running after its cell-override edit; runs was "
@@ -337,31 +337,31 @@
 ;; flipped the flag; the slot stayed {} on enable, so the first
 ;; detect-watch-drift! tick read every testable variant as absent-from-prev
 ;; → drifted, re-running the WHOLE :test suite the instant watch turned on.
-;; `sidebar/set-watch-mode!` now seeds the real baseline BEFORE the flag
+;; `rf.story.ui.sidebar/set-watch-mode!` now seeds the real baseline BEFORE the flag
 ;; flips, so the first tick diffs against truth and re-runs nothing.
 
 #?(:cljs
    (deftest toggle-on-seeds-baseline-no-spurious-full-rerun
-     (testing "rf2-asp2op — enabling watch via `sidebar/set-watch-mode!`
+     (testing "rf2-asp2op — enabling watch via `rf.story.ui.sidebar/set-watch-mode!`
                seeds [:tests :content-hashes] from the CURRENT registry
                BEFORE the flag flips, so the first detector tick re-runs
                NOTHING (the registry is unchanged since the seed)"
-       (story/reg-variant :story.x/a {:tags #{:test} :setup []
+       (rf.story/reg-variant :story.x/a {:tags #{:test} :setup []
                                       :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
-       (story/reg-variant :story.x/b {:tags #{:test} :setup []
+       (rf.story/reg-variant :story.x/b {:tags #{:test} :setup []
                                       :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
        ;; Enable via the REAL toggle entry point (what the on-click calls).
-       (sidebar/set-watch-mode! true)
+       (rf.story.ui.sidebar/set-watch-mode! true)
        (testing "the baseline slot is seeded with BOTH testable variants"
-         (let [seeded (get-in (state/get-state) [:tests :content-hashes])]
+         (let [seeded (get-in (rf.story.ui.state/get-state) [:tests :content-hashes])]
            (is (contains? seeded :story.x/a)
                "toggle-on must seed the baseline, not leave it {}")
            (is (contains? seeded :story.x/b))))
        ;; First detector tick — registry UNCHANGED since the seed.
-       (shell/detect-watch-drift!)
+       (rf.story.ui.shell/detect-watch-drift!)
        (testing "no variant re-runs — the seeded baseline matches, so drift
                  is empty (the pre-fix bug re-ran the whole suite here)"
-         (let [runs (get-in (state/get-state) [:tests :runs])]
+         (let [runs (get-in (rf.story.ui.state/get-state) [:tests :runs])]
            (is (nil? (get runs :story.x/a))
                (str "expected NO re-run on enable; runs was " (pr-str runs)))
            (is (nil? (get runs :story.x/b))))))))
@@ -383,20 +383,20 @@
                modes, substrate, overrides all unchanged) must change the
                cached testable hash; before the fix the cache short-circuited
                the real drift"
-       (story/reg-variant :story.x/a {:tags #{:test} :setup []
+       (rf.story/reg-variant :story.x/a {:tags #{:test} :setup []
                                       :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
-       (let [prior (late-bind/get-fn :schemas/app-schemas-digest)]
+       (let [prior (rf.late-bind/get-fn :schemas/app-schemas-digest)]
          (try
            ;; Schema generation 1.
-           (late-bind/set-fn! :schemas/app-schemas-digest
+           (rf.late-bind/set-fn! :schemas/app-schemas-digest
                               (fn [_frame-id] "sha256:0000000000000001"))
-           (let [h1 (get (watch/compute-testable-content-hashes) :story.x/a)]
+           (let [h1 (get (rf.story.ui.watch/compute-testable-content-hashes) :story.x/a)]
              ;; Schema hot-reload — digest moves, Story side-table untouched.
-             (late-bind/set-fn! :schemas/app-schemas-digest
+             (rf.late-bind/set-fn! :schemas/app-schemas-digest
                                 (fn [_frame-id] "sha256:0000000000000002"))
-             (let [h2 (get (watch/compute-testable-content-hashes) :story.x/a)]
+             (let [h2 (get (rf.story.ui.watch/compute-testable-content-hashes) :story.x/a)]
                (is (some? h1) "the first compute must hash the variant")
                (is (not= h1 h2)
                    "the cache must bust on a view-schema hot-reload")))
            (finally
-             (late-bind/set-fn! :schemas/app-schemas-digest prior)))))))
+             (rf.late-bind/set-fn! :schemas/app-schemas-digest prior)))))))

--- a/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
@@ -19,18 +19,18 @@
     includes the status dot when the variant is testable; the
     'Run all' button renders disabled when any run is in flight."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story :as story]
-            [re-frame.story.registrar :as story-registrar]
-            [re-frame.story.ui.state :as state]
-            #?@(:cljs [[re-frame.story.ui.sidebar :as sidebar]
-                       [re-frame.story.theme.status :as status]])))
+            [re-frame.story :as rf.story]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            #?@(:cljs [[re-frame.story.ui.sidebar :as rf.story.ui.sidebar]
+                       [re-frame.story.theme.status :as rf.story.theme.status]])))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-all! []
-  (story/clear-all!)
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!))
+  (rf.story/clear-all!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!))
 
 (use-fixtures :each (fn [t] (reset-all!) (t)))
 
@@ -38,12 +38,12 @@
 
 (deftest mark-test-running-stamps-status
   (testing "mark-test-running writes :running into [:tests :runs]"
-    (let [s  (state/mark-test-running state/default-shell-state :story.x/a)]
+    (let [s  (rf.story.ui.state/mark-test-running rf.story.ui.state/default-shell-state :story.x/a)]
       (is (= :running (get-in s [:tests :runs :story.x/a :status]))))))
 
 (deftest record-test-run-pass
   (testing "a run with passed assertions records :pass + counts"
-    (let [s (state/record-test-run state/default-shell-state :story.x/a
+    (let [s (rf.story.ui.state/record-test-run rf.story.ui.state/default-shell-state :story.x/a
                                    {:total 3 :passed 3 :failed 0 :skipped 0
                                     :all-passed? true
                                     :ran-at-ms 100 :elapsed-ms 12})]
@@ -54,7 +54,7 @@
 
 (deftest record-test-run-fail
   (testing "a run with any failure records :fail"
-    (let [s (state/record-test-run state/default-shell-state :story.x/a
+    (let [s (rf.story.ui.state/record-test-run rf.story.ui.state/default-shell-state :story.x/a
                                    {:total 3 :passed 1 :failed 2 :skipped 0
                                     :all-passed? false})]
       (is (= :fail (get-in s [:tests :runs :story.x/a :status])))
@@ -64,22 +64,22 @@
   (testing "a run that recorded zero assertions reads :pending — the
             variant ran but produced no signal, so the sidebar dot
             renders as 'not yet run' rather than green"
-    (let [s (state/record-test-run state/default-shell-state :story.x/a
+    (let [s (rf.story.ui.state/record-test-run rf.story.ui.state/default-shell-state :story.x/a
                                    {:total 0 :passed 0 :failed 0 :skipped 0
                                     :all-passed? false})]
       (is (= :pending (get-in s [:tests :runs :story.x/a :status]))))))
 
 (deftest clear-test-run-drops-record
   (testing "clear-test-run removes the slot — the dot re-reads :pending"
-    (let [s (-> state/default-shell-state
-                (state/mark-test-running :story.x/a)
-                (state/clear-test-run :story.x/a))]
+    (let [s (-> rf.story.ui.state/default-shell-state
+                (rf.story.ui.state/mark-test-running :story.x/a)
+                (rf.story.ui.state/clear-test-run :story.x/a))]
       (is (nil? (get-in s [:tests :runs :story.x/a])))
-      (is (= :pending (state/variant-test-status s :story.x/a))))))
+      (is (= :pending (rf.story.ui.state/variant-test-status s :story.x/a))))))
 
 (deftest variant-test-status-defaults-pending
   (testing "an un-stamped variant reads :pending"
-    (is (= :pending (state/variant-test-status state/default-shell-state
+    (is (= :pending (rf.story.ui.state/variant-test-status rf.story.ui.state/default-shell-state
                                                :story.unknown/x)))))
 
 ;; ---- pure: test-summary aggregation -------------------------------------
@@ -92,13 +92,13 @@
                         :all-passed? true}
           fail-summary {:total 1 :passed 0 :failed 1 :skipped 0
                         :all-passed? false}
-          s (-> state/default-shell-state
-                (state/record-test-run :story.x/a pass-summary)
-                (state/record-test-run :story.x/b pass-summary)
-                (state/record-test-run :story.x/c pass-summary)
-                (state/record-test-run :story.x/d fail-summary))
+          s (-> rf.story.ui.state/default-shell-state
+                (rf.story.ui.state/record-test-run :story.x/a pass-summary)
+                (rf.story.ui.state/record-test-run :story.x/b pass-summary)
+                (rf.story.ui.state/record-test-run :story.x/c pass-summary)
+                (rf.story.ui.state/record-test-run :story.x/d fail-summary))
           ;; :story.x/e is not stamped — it reads :pending.
-          summary (state/test-summary s [:story.x/a :story.x/b :story.x/c
+          summary (rf.story.ui.state/test-summary s [:story.x/a :story.x/b :story.x/c
                                          :story.x/d :story.x/e])]
       (is (= 5 (:total summary)))
       (is (= 3 (:passed summary)))
@@ -111,23 +111,23 @@
   (testing ":all-green? is true only when every variant has a recorded
             green run"
     (let [pass {:total 1 :passed 1 :failed 0 :skipped 0 :all-passed? true}
-          s (-> state/default-shell-state
-                (state/record-test-run :story.x/a pass)
-                (state/record-test-run :story.x/b pass))]
-      (is (:all-green? (state/test-summary s [:story.x/a :story.x/b]))))))
+          s (-> rf.story.ui.state/default-shell-state
+                (rf.story.ui.state/record-test-run :story.x/a pass)
+                (rf.story.ui.state/record-test-run :story.x/b pass))]
+      (is (:all-green? (rf.story.ui.state/test-summary s [:story.x/a :story.x/b]))))))
 
 (deftest test-summary-empty
   (testing "an empty seq of testable variants reads :all-green? false
             — a sea of pending is not green"
-    (let [summary (state/test-summary state/default-shell-state [])]
+    (let [summary (rf.story.ui.state/test-summary rf.story.ui.state/default-shell-state [])]
       (is (= 0 (:total summary)))
       (is (false? (:all-green? summary))))))
 
 (deftest test-summary-running-blocks-green
   (testing "a :running variant prevents :all-green?"
-    (let [s (-> state/default-shell-state
-                (state/mark-test-running :story.x/a))
-          summary (state/test-summary s [:story.x/a])]
+    (let [s (-> rf.story.ui.state/default-shell-state
+                (rf.story.ui.state/mark-test-running :story.x/a))
+          summary (rf.story.ui.state/test-summary s [:story.x/a])]
       (is (= 1 (:running summary)))
       (is (false? (:all-green? summary))))))
 
@@ -135,22 +135,22 @@
 
 (deftest testable-variant-ids-filters-by-tag-and-play
   (testing "only :test-tagged variants with non-empty :script count"
-    (story/reg-variant :story.x/a {:tags #{:test} :setup []
+    (rf.story/reg-variant :story.x/a {:tags #{:test} :setup []
                                    :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
-    (story/reg-variant :story.x/b {:tags #{:test} :setup [] :script []})
-    (story/reg-variant :story.x/c {:tags #{:dev} :setup []
+    (rf.story/reg-variant :story.x/b {:tags #{:test} :setup [] :script []})
+    (rf.story/reg-variant :story.x/c {:tags #{:dev} :setup []
                                    :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
-    (story/reg-variant :story.x/d {:tags #{:test :dev} :setup []
+    (rf.story/reg-variant :story.x/d {:tags #{:test :dev} :setup []
                                    :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
-    (let [vs (story-registrar/registrations :variant)
-          testable (state/testable-variant-ids vs)]
+    (let [vs (rf.story.registrar/registrations :variant)
+          testable (rf.story.ui.state/testable-variant-ids vs)]
       (is (= [:story.x/a :story.x/d] testable))
       (is (not (some #{:story.x/b} testable)))
       (is (not (some #{:story.x/c} testable))))))
 
 (deftest testable-variant-ids-empty-on-no-registrations
   (testing "no :test variants → empty seq, widget renders 'no :test variants'"
-    (is (empty? (state/testable-variant-ids {})))))
+    (is (empty? (rf.story.ui.state/testable-variant-ids {})))))
 
 ;; ---- pure: status → dot style + aria label -------------------------------
 
@@ -161,40 +161,40 @@
                settled solid statuses fill with the descriptor fg,
                running fills translucent, the hollow shapes ring in the
                descriptor border colour"
-       (is (= {:background (status/fg :pass)} (sidebar/dot-style :pass)))
-       (is (= {:background (status/fg :fail)} (sidebar/dot-style :fail)))
-       (is (= {:background (status/fg :running) :opacity "0.7"}
-              (sidebar/dot-style :running)))
+       (is (= {:background (rf.story.theme.status/fg :pass)} (rf.story.ui.sidebar/dot-style :pass)))
+       (is (= {:background (rf.story.theme.status/fg :fail)} (rf.story.ui.sidebar/dot-style :fail)))
+       (is (= {:background (rf.story.theme.status/fg :running) :opacity "0.7"}
+              (rf.story.ui.sidebar/dot-style :running)))
        (is (= {:background "transparent"
-               :border     (str "1px solid " (:border (status/descriptor :pending)))}
-              (sidebar/dot-style :pending)))
+               :border     (str "1px solid " (:border (rf.story.theme.status/descriptor :pending)))}
+              (rf.story.ui.sidebar/dot-style :pending)))
        (is (= {:background "transparent"
-               :border     (str "1px solid " (:border (status/descriptor :cannot-run)))}
-              (sidebar/dot-style :cannot-run))))
+               :border     (str "1px solid " (:border (rf.story.theme.status/descriptor :cannot-run)))}
+              (rf.story.ui.sidebar/dot-style :cannot-run))))
      (testing ":cannot-run (the canonical third run status,
                state.tests/test-run-statuses) is visibly DISTINCT from
                :pending — a warning-hued ring, never the neutral
                reserved-slot ring"
-       (is (not= (sidebar/dot-style :pending) (sidebar/dot-style :cannot-run))))
+       (is (not= (rf.story.ui.sidebar/dot-style :pending) (rf.story.ui.sidebar/dot-style :cannot-run))))
      (testing "pending is reserved for the genuinely unknown/nil slot —
                unknown statuses degrade through the descriptor fallback"
-       (is (= (sidebar/dot-style :pending) (sidebar/dot-style :unknown)))
-       (is (= (sidebar/dot-style :pending) (sidebar/dot-style nil))))))
+       (is (= (rf.story.ui.sidebar/dot-style :pending) (rf.story.ui.sidebar/dot-style :unknown)))
+       (is (= (rf.story.ui.sidebar/dot-style :pending) (rf.story.ui.sidebar/dot-style nil))))))
 
 #?(:cljs
    (deftest status-dot-aria-labels
      (testing "the accessible label voices the canonical descriptor label
                — every run status distinct, :cannot-run ≠ :pending"
-       (is (= "tests: Pass"      (sidebar/dot-aria-label :pass)))
-       (is (= "tests: Fail"      (sidebar/dot-aria-label :fail)))
-       (is (= "tests: Running"   (sidebar/dot-aria-label :running)))
-       (is (= "tests: Pending"   (sidebar/dot-aria-label :pending)))
-       (is (= "tests: Can't run" (sidebar/dot-aria-label :cannot-run)))
-       (is (not= (sidebar/dot-aria-label :pending)
-                 (sidebar/dot-aria-label :cannot-run)))
+       (is (= "tests: Pass"      (rf.story.ui.sidebar/dot-aria-label :pass)))
+       (is (= "tests: Fail"      (rf.story.ui.sidebar/dot-aria-label :fail)))
+       (is (= "tests: Running"   (rf.story.ui.sidebar/dot-aria-label :running)))
+       (is (= "tests: Pending"   (rf.story.ui.sidebar/dot-aria-label :pending)))
+       (is (= "tests: Can't run" (rf.story.ui.sidebar/dot-aria-label :cannot-run)))
+       (is (not= (rf.story.ui.sidebar/dot-aria-label :pending)
+                 (rf.story.ui.sidebar/dot-aria-label :cannot-run)))
        ;; Unrecognised / nil → the descriptor's pending fallback.
-       (is (= "tests: Pending" (sidebar/dot-aria-label :unknown)))
-       (is (= "tests: Pending" (sidebar/dot-aria-label nil))))))
+       (is (= "tests: Pending" (rf.story.ui.sidebar/dot-aria-label :unknown)))
+       (is (= "tests: Pending" (rf.story.ui.sidebar/dot-aria-label nil))))))
 
 ;; ---- CLJS-only: rendered hiccup contains the widget ---------------------
 
@@ -227,24 +227,24 @@
    (deftest widget-renders-headline-and-counts
      (testing "with 3 pass / 1 fail / 1 pending the widget headline and
                count chips reflect the fixture"
-       (story/reg-variant :story.x/a {:tags #{:test} :setup []
+       (rf.story/reg-variant :story.x/a {:tags #{:test} :setup []
                                       :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
-       (story/reg-variant :story.x/b {:tags #{:test} :setup []
+       (rf.story/reg-variant :story.x/b {:tags #{:test} :setup []
                                       :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
-       (story/reg-variant :story.x/c {:tags #{:test} :setup []
+       (rf.story/reg-variant :story.x/c {:tags #{:test} :setup []
                                       :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
-       (story/reg-variant :story.x/d {:tags #{:test} :setup []
+       (rf.story/reg-variant :story.x/d {:tags #{:test} :setup []
                                       :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
-       (story/reg-variant :story.x/e {:tags #{:test} :setup []
+       (rf.story/reg-variant :story.x/e {:tags #{:test} :setup []
                                       :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
        (let [pass {:total 1 :passed 1 :failed 0 :skipped 0 :all-passed? true}
              fail {:total 1 :passed 0 :failed 1 :skipped 0 :all-passed? false}]
-         (state/swap-state! state/record-test-run :story.x/a pass)
-         (state/swap-state! state/record-test-run :story.x/b pass)
-         (state/swap-state! state/record-test-run :story.x/c pass)
-         (state/swap-state! state/record-test-run :story.x/d fail))
-       (let [tree     (sidebar/test-widget (state/get-state)
-                                           (state/registry-snapshot))
+         (rf.story.ui.state/swap-state! rf.story.ui.state/record-test-run :story.x/a pass)
+         (rf.story.ui.state/swap-state! rf.story.ui.state/record-test-run :story.x/b pass)
+         (rf.story.ui.state/swap-state! rf.story.ui.state/record-test-run :story.x/c pass)
+         (rf.story.ui.state/swap-state! rf.story.ui.state/record-test-run :story.x/d fail))
+       (let [tree     (rf.story.ui.sidebar/test-widget (rf.story.ui.state/get-state)
+                                           (rf.story.ui.state/registry-snapshot))
              headline (first (find-by-data-test tree "story-test-widget-headline"))
              counts   (first (find-by-data-test tree "story-test-widget-counts"))]
          (is (some? headline))
@@ -258,9 +258,9 @@
    (deftest widget-empty-when-no-testable-variants
      (testing "no :test variants → the widget renders the empty-state
                sub-line and skips the Run all button"
-       (story/reg-variant :story.x/a {:tags #{:dev} :setup []})
-       (let [tree  (sidebar/test-widget (state/get-state)
-                                        (state/registry-snapshot))
+       (rf.story/reg-variant :story.x/a {:tags #{:dev} :setup []})
+       (let [tree  (rf.story.ui.sidebar/test-widget (rf.story.ui.state/get-state)
+                                        (rf.story.ui.state/registry-snapshot))
              empty (first (find-by-data-test tree "story-test-widget-empty"))
              btn   (first (find-by-data-test tree "story-test-widget-run-all"))]
          (is (some? empty))
@@ -272,10 +272,10 @@
                run state. Renders the dot component directly for each
                status keyword and asserts the rendered hiccup carries
                the expected `data-status` attribute."
-       (let [dot-fail    (sidebar/status-dot :fail)
-             dot-pending (sidebar/status-dot :pending)
-             dot-pass    (sidebar/status-dot :pass)
-             dot-running (sidebar/status-dot :running)]
+       (let [dot-fail    (rf.story.ui.sidebar/status-dot :fail)
+             dot-pending (rf.story.ui.sidebar/status-dot :pending)
+             dot-pass    (rf.story.ui.sidebar/status-dot :pass)
+             dot-running (rf.story.ui.sidebar/status-dot :running)]
          (is (= "fail"    (get (second dot-fail) :data-status)))
          (is (= "pending" (get (second dot-pending) :data-status)))
          (is (= "pass"    (get (second dot-pass) :data-status)))
@@ -294,8 +294,8 @@
                (warning ring vs neutral ring), different accessible
                name, different data-status. Pending stays reserved for
                the genuinely unknown slot; a refusal never wears it."
-       (let [dot-cannot  (sidebar/status-dot :cannot-run)
-             dot-pending (sidebar/status-dot :pending)
+       (let [dot-cannot  (rf.story.ui.sidebar/status-dot :cannot-run)
+             dot-pending (rf.story.ui.sidebar/status-dot :pending)
              props       (fn [dot] (second dot))]
          (is (= "cannot-run" (:data-status (props dot-cannot))))
          (is (= "pending"    (:data-status (props dot-pending))))
@@ -303,7 +303,7 @@
          (is (not= (:style (props dot-cannot)) (:style (props dot-pending)))
              ":cannot-run must not wear the pending ring")
          ;; The paint comes from the canonical descriptor source.
-         (is (= (str "1px solid " (:border (status/descriptor :cannot-run)))
+         (is (= (str "1px solid " (:border (rf.story.theme.status/descriptor :cannot-run)))
                 (:border (:style (props dot-cannot)))))
          ;; Accessible channel — label + title both voice the refusal.
          (is (= "tests: Can't run" (:aria-label (props dot-cannot))))
@@ -323,8 +323,8 @@
                variant rows in a typical registry the AT noise was real.
                `role=\"img\"` keeps the `aria-label` exposed as the
                accessible name without the live-region announcement."
-       (let [dot-fail (sidebar/status-dot :fail)
-             dot-pass (sidebar/status-dot :pass)]
+       (let [dot-fail (rf.story.ui.sidebar/status-dot :fail)
+             dot-pass (rf.story.ui.sidebar/status-dot :pass)]
          (is (= "img" (get (second dot-fail) :role))
              "status-dot is exposed as an img with a label")
          (is (= "img" (get (second dot-pass) :role))
@@ -335,11 +335,11 @@
 #?(:cljs
    (deftest widget-run-all-button-disabled-while-running
      (testing "if any variant is :running the Run all button disables"
-       (story/reg-variant :story.x/a {:tags #{:test} :setup []
+       (rf.story/reg-variant :story.x/a {:tags #{:test} :setup []
                                       :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
-       (state/swap-state! state/mark-test-running :story.x/a)
-       (let [tree (sidebar/test-widget (state/get-state)
-                                       (state/registry-snapshot))
+       (rf.story.ui.state/swap-state! rf.story.ui.state/mark-test-running :story.x/a)
+       (let [tree (rf.story.ui.sidebar/test-widget (rf.story.ui.state/get-state)
+                                       (rf.story.ui.state/registry-snapshot))
              btn  (first (find-by-data-test tree "story-test-widget-run-all"))]
          (is (some? btn))
          (is (true? (get (second btn) :disabled)))))))
@@ -352,17 +352,17 @@
                instead of re-deriving from the registry — passes a
                restricted subset and asserts the headline counts reflect
                only that subset"
-       (story/reg-variant :story.x/a {:tags #{:test} :setup []
+       (rf.story/reg-variant :story.x/a {:tags #{:test} :setup []
                                       :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
-       (story/reg-variant :story.x/b {:tags #{:test} :setup []
+       (rf.story/reg-variant :story.x/b {:tags #{:test} :setup []
                                       :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
-       (story/reg-variant :story.x/c {:tags #{:test} :setup []
+       (rf.story/reg-variant :story.x/c {:tags #{:test} :setup []
                                       :script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
        ;; Supply a 1-variant subset. The registry has three; the widget
        ;; should report total=1 because we threaded a 1-element seq, not
        ;; the full registry-derived set.
-       (let [tree     (sidebar/test-widget (state/get-state)
-                                           (state/registry-snapshot)
+       (let [tree     (rf.story.ui.sidebar/test-widget (rf.story.ui.state/get-state)
+                                           (rf.story.ui.state/registry-snapshot)
                                            [:story.x/a])
              headline (first (find-by-data-test tree
                                                 "story-test-widget-headline"))]
@@ -383,14 +383,14 @@
                perform. The pre-fix bug passed `:cell-overrides nil`
                for every variant, dropping the user's controls-panel
                edits on a Run-all (rf2-zq6sn)."
-       (let [shell (-> state/default-shell-state
+       (let [shell (-> rf.story.ui.state/default-shell-state
                        (assoc :active-modes #{:dark}
                               :substrate :reagent)
-                       (state/set-cell-override-scalar :story.x/a :n 5)
-                       (state/set-cell-override-scalar :story.x/b :label "B"))
-             opts-a (sidebar/run-opts-for-variant shell :story.x/a)
-             opts-b (sidebar/run-opts-for-variant shell :story.x/b)
-             opts-c (sidebar/run-opts-for-variant shell :story.x/c)]
+                       (rf.story.ui.state/set-cell-override-scalar :story.x/a :n 5)
+                       (rf.story.ui.state/set-cell-override-scalar :story.x/b :label "B"))
+             opts-a (rf.story.ui.sidebar/run-opts-for-variant shell :story.x/a)
+             opts-b (rf.story.ui.sidebar/run-opts-for-variant shell :story.x/b)
+             opts-c (rf.story.ui.sidebar/run-opts-for-variant shell :story.x/c)]
          (testing ":story.x/a opts carry only :a's overrides"
            (is (= {:n 5} (:cell-overrides opts-a)))
            (is (= #{:dark} (:active-modes opts-a)))
@@ -415,7 +415,7 @@
 (deftest aggregate-summary-counts-error-records-as-failed
   (testing "a derived record carrying :exception / :error (no explicit
             :status) lands in aggregate-summary's :failed tally"
-    (let [summary (state/aggregate-summary
+    (let [summary (rf.story.ui.state/aggregate-summary
                     [{:passed? true}
                      {:exception (ex-info "boom" {})}
                      {:error "boom"}])]
@@ -431,12 +431,12 @@
                same numbers as the CLJS path"
        (let [pass {:total 1 :passed 1 :failed 0 :skipped 0 :all-passed? true}
              fail {:total 1 :passed 0 :failed 1 :skipped 0 :all-passed? false}
-             s    (-> state/default-shell-state
-                      (state/record-test-run :story.x/a pass)
-                      (state/record-test-run :story.x/b pass)
-                      (state/record-test-run :story.x/c pass)
-                      (state/record-test-run :story.x/d fail))
-             summary (state/test-summary s
+             s    (-> rf.story.ui.state/default-shell-state
+                      (rf.story.ui.state/record-test-run :story.x/a pass)
+                      (rf.story.ui.state/record-test-run :story.x/b pass)
+                      (rf.story.ui.state/record-test-run :story.x/c pass)
+                      (rf.story.ui.state/record-test-run :story.x/d fail))
+             summary (rf.story.ui.state/test-summary s
                        [:story.x/a :story.x/b :story.x/c :story.x/d :story.x/e])]
          (is (= {:total 5 :passed 3 :failed 1 :cannot-run 0 :running 0
                  :pending 1 :all-green? false}

--- a/tools/story/test/re_frame/story/ui/toolbar_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/toolbar_cljs_test.cljc
@@ -8,8 +8,8 @@
   ## Coverage layers
 
   - **Pure data** (JVM + CLJS): `toggle-mode` axis semantics,
-    `group-modes-by-axis` layout, `share/parse-modes-param` URL
-    parsing, `share/prune-unregistered-modes` registrar-pruning (the
+    `group-modes-by-axis` layout, `rf.story.share/parse-modes-param` URL
+    parsing, `rf.story.share/prune-unregistered-modes` registrar-pruning (the
     CLJC PRODUCTION helpers — rf2-96y71s removed the JVM copies that
     used to shadow the live impl), schema additivity for the new
     `:axis` slot.
@@ -18,13 +18,13 @@
     `toggle-mode!` mutation against `shell-state-atom`, the rendered
     hiccup carries chip elements per registered mode."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story :as story]
-            [re-frame.story.registrar :as story-registrar]
-            [re-frame.story.schemas :as schemas]
-            [re-frame.story.share :as share]
-            [re-frame.story.ui.state :as state]
-            #?@(:cljs [[re-frame.story.ui.cofx :as ui-cofx]
-                       [re-frame.story.ui.toolbar :as toolbar]])))
+            [re-frame.story :as rf.story]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.schemas :as rf.story.schemas]
+            [re-frame.story.share :as rf.story.share]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            #?@(:cljs [[re-frame.story.ui.cofx :as rf.story.ui.cofx]
+                       [re-frame.story.ui.toolbar :as rf.story.ui.toolbar]])))
 
 #?(:cljs
    (defn- browser?
@@ -46,9 +46,9 @@
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-all! []
-  (story/clear-all!)
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!))
+  (rf.story/clear-all!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!))
 
 (use-fixtures :each (fn [t] (reset-all!) (t)))
 
@@ -60,11 +60,11 @@
     ;; the mode as un-tagged.
     (let [no-axis (fn [_] nil)]
       (is (= [:Mode.app/x]
-             (state/toggle-mode [] :Mode.app/x no-axis)))
+             (rf.story.ui.state/toggle-mode [] :Mode.app/x no-axis)))
       (is (= [:Mode.app/x :Mode.app/y]
-             (state/toggle-mode [:Mode.app/x] :Mode.app/y no-axis)))
+             (rf.story.ui.state/toggle-mode [:Mode.app/x] :Mode.app/y no-axis)))
       (is (= [:Mode.app/y]
-             (state/toggle-mode [:Mode.app/x :Mode.app/y] :Mode.app/x no-axis))))))
+             (rf.story.ui.state/toggle-mode [:Mode.app/x :Mode.app/y] :Mode.app/x no-axis))))))
 
 (deftest toggle-mode-single-select-within-axis
   (testing "an axis-tagged mode evicts siblings sharing the axis"
@@ -77,49 +77,49 @@
                       nil))]
       ;; Start empty → add :dark → :theme axis has only :dark.
       (is (= [:Mode.theme/dark]
-             (state/toggle-mode [] :Mode.theme/dark axis-fn)))
+             (rf.story.ui.state/toggle-mode [] :Mode.theme/dark axis-fn)))
       ;; :light displaces :dark because they share :theme.
       (is (= [:Mode.theme/light]
-             (state/toggle-mode [:Mode.theme/dark]
+             (rf.story.ui.state/toggle-mode [:Mode.theme/dark]
                                 :Mode.theme/light axis-fn)))
       ;; :sepia displaces :light.
       (is (= [:Mode.theme/sepia]
-             (state/toggle-mode [:Mode.theme/light]
+             (rf.story.ui.state/toggle-mode [:Mode.theme/light]
                                 :Mode.theme/sepia axis-fn)))
       ;; Adding :mobile (different axis) coexists with :sepia.
       (is (= [:Mode.theme/sepia :Mode.vp/mobile]
-             (state/toggle-mode [:Mode.theme/sepia]
+             (rf.story.ui.state/toggle-mode [:Mode.theme/sepia]
                                 :Mode.vp/mobile axis-fn)))
       ;; Toggling :sepia OFF (already active) just removes it.
       (is (= [:Mode.vp/mobile]
-             (state/toggle-mode [:Mode.theme/sepia :Mode.vp/mobile]
+             (rf.story.ui.state/toggle-mode [:Mode.theme/sepia :Mode.vp/mobile]
                                 :Mode.theme/sepia axis-fn))))))
 
 (deftest toggle-mode-resolves-axis-via-registrar
   (testing "the 2-arity (no axis-fn) resolves via the live registrar"
-    (story/reg-mode :Mode.t/dark  {:axis :theme :args {:theme :dark}})
-    (story/reg-mode :Mode.t/light {:axis :theme :args {:theme :light}})
-    (is (= [:Mode.t/dark]  (state/toggle-mode [] :Mode.t/dark)))
-    (is (= [:Mode.t/light] (state/toggle-mode [:Mode.t/dark]
+    (rf.story/reg-mode :Mode.t/dark  {:axis :theme :args {:theme :dark}})
+    (rf.story/reg-mode :Mode.t/light {:axis :theme :args {:theme :light}})
+    (is (= [:Mode.t/dark]  (rf.story.ui.state/toggle-mode [] :Mode.t/dark)))
+    (is (= [:Mode.t/light] (rf.story.ui.state/toggle-mode [:Mode.t/dark]
                                               :Mode.t/light)))))
 
 (deftest clear-active-modes-empties
   (testing "clear-active-modes drops every entry"
     (is (= []
            (:active-modes
-             (state/clear-active-modes {:active-modes
+             (rf.story.ui.state/clear-active-modes {:active-modes
                                         [:Mode.a/x :Mode.a/y]}))))))
 
 ;; ---- pure: schema additivity --------------------------------------------
 
 (deftest mode-schema-accepts-axis
   (testing ":rf/mode schema accepts the optional :axis keyword"
-    (is (nil? (schemas/validate :mode {:args {:theme :dark}}))
+    (is (nil? (rf.story.schemas/validate :mode {:args {:theme :dark}}))
         "no axis: still valid")
-    (is (nil? (schemas/validate :mode {:axis :theme
+    (is (nil? (rf.story.schemas/validate :mode {:axis :theme
                                        :args {:theme :dark}}))
         "axis present: valid")
-    (is (some? (schemas/validate :mode {:axis "theme"
+    (is (some? (rf.story.schemas/validate :mode {:axis "theme"
                                         :args {:theme :dark}}))
         "axis must be a keyword")))
 
@@ -129,7 +129,7 @@
   (testing "axis groups sort by axis-name; un-axed bucket sits in its
             own explicit `:unaxed` slot (no sentinel keyword)"
     (let [{:keys [axes unaxed]}
-          (state/group-modes-by-axis
+          (rf.story.ui.state/group-modes-by-axis
             {:Mode.vp/mobile {:axis :viewport}
              :Mode.t/dark    {:axis :theme}
              :Mode.t/light   {:axis :theme}
@@ -145,7 +145,7 @@
 (deftest group-modes-by-axis-empty-unaxed-when-all-tagged
   (testing "every mode tagged → :unaxed slot is empty (still present)"
     (let [{:keys [axes unaxed]}
-          (state/group-modes-by-axis
+          (rf.story.ui.state/group-modes-by-axis
             {:Mode.t/dark  {:axis :theme}
              :Mode.t/light {:axis :theme}})]
       (is (= [:theme] (mapv first axes)))
@@ -153,32 +153,32 @@
 
 ;; ---- pure: URL parsing (the CLJC production helper) ---------------------
 ;;
-;; rf2-96y71s: these exercise `share/parse-modes-param` directly — the
-;; SAME fn `share/parse-params` (and thus the url-state hydrator) uses.
+;; rf2-96y71s: these exercise `rf.story.share/parse-modes-param` directly — the
+;; SAME fn `rf.story.share/parse-params` (and thus the url-state hydrator) uses.
 ;; No JVM copy to drift out of sync.
 
 (deftest parse-modes-param-roundtrip
   (testing "single qualified mode id"
     (is (= [:Mode.app/dark]
-           (share/parse-modes-param "Mode.app/dark"))))
+           (rf.story.share/parse-modes-param "Mode.app/dark"))))
   (testing "comma-separated list of ids"
     (is (= [:Mode.app/dark :Mode.app/mobile]
-           (share/parse-modes-param "Mode.app/dark,Mode.app/mobile"))))
+           (rf.story.share/parse-modes-param "Mode.app/dark,Mode.app/mobile"))))
   (testing "whitespace around commas survives"
     (is (= [:Mode.app/a :Mode.app/b]
-           (share/parse-modes-param " Mode.app/a , Mode.app/b "))))
+           (rf.story.share/parse-modes-param " Mode.app/a , Mode.app/b "))))
   (testing "blank input → nil"
-    (is (nil? (share/parse-modes-param "")))
-    (is (nil? (share/parse-modes-param "   "))))
+    (is (nil? (rf.story.share/parse-modes-param "")))
+    (is (nil? (rf.story.share/parse-modes-param "   "))))
   (testing "unqualified ids parse without a namespace"
-    (is (= [:bare] (share/parse-modes-param "bare"))))
+    (is (= [:bare] (rf.story.share/parse-modes-param "bare"))))
   (testing "printed-keyword form (`:ns/name`) from a hand-copied URL"
     (is (= [:Mode.app/dark]
-           (share/parse-modes-param ":Mode.app/dark")))))
+           (rf.story.share/parse-modes-param ":Mode.app/dark")))))
 
 ;; ---- pure: prune-unregistered-modes (the CLJC production helper) --------
 ;;
-;; rf2-96y71s: `share/prune-unregistered-modes` is the single registrar-
+;; rf2-96y71s: `rf.story.share/prune-unregistered-modes` is the single registrar-
 ;; pruning helper; the toolbar's `prune-unregistered` closes the live
 ;; registrar predicate over it. Tested here with an injected set so the
 ;; pure logic runs on both runtimes without the registrar.
@@ -187,13 +187,13 @@
   (testing "ids not present in the registrar are dropped"
     (let [registered? #{:Mode.app/dark :Mode.app/light}]
       (is (= [:Mode.app/dark]
-             (share/prune-unregistered-modes
+             (rf.story.share/prune-unregistered-modes
                [:Mode.app/dark :Mode.app/sepia] registered?)))))
   (testing "nil / empty modes coll yields []"
-    (is (= [] (share/prune-unregistered-modes nil (constantly true))))
-    (is (= [] (share/prune-unregistered-modes [] (constantly true)))))
+    (is (= [] (rf.story.share/prune-unregistered-modes nil (constantly true))))
+    (is (= [] (rf.story.share/prune-unregistered-modes [] (constantly true)))))
   (testing "every id stale → empty vector (not nil)"
-    (is (= [] (share/prune-unregistered-modes
+    (is (= [] (rf.story.share/prune-unregistered-modes
                 [:Mode.app/gone :Mode.app/also-gone] #{})))))
 
 ;; ---- CLJS-only: live toolbar surfaces ----------------------------------
@@ -204,79 +204,79 @@
    (deftest cljs-storage-roundtrip
      (testing "save-modes-to-storage! + load-modes-from-storage round-trip"
        (when (browser?)
-         (toolbar/save-modes-to-storage! [:Mode.app/dark :Mode.app/light])
+         (rf.story.ui.toolbar/save-modes-to-storage! [:Mode.app/dark :Mode.app/light])
          (is (= [:Mode.app/dark :Mode.app/light]
-                (toolbar/load-modes-from-storage)))
-         (toolbar/save-modes-to-storage! [])
-         (is (= [] (toolbar/load-modes-from-storage)))))))
+                (rf.story.ui.toolbar/load-modes-from-storage)))
+         (rf.story.ui.toolbar/save-modes-to-storage! [])
+         (is (= [] (rf.story.ui.toolbar/load-modes-from-storage)))))))
 
 #?(:cljs
    (deftest cljs-toggle-writes-shell-state
      (testing "toggle-mode! writes the new vector through to shell-state-atom"
-       (story/reg-mode :Mode.app/x {:args {:k 1}})
-       (story/reg-mode :Mode.app/y {:args {:k 2}})
-       (toolbar/toggle-mode! :Mode.app/x)
-       (is (= [:Mode.app/x] (:active-modes (state/get-state))))
-       (toolbar/toggle-mode! :Mode.app/y)
-       (is (= [:Mode.app/x :Mode.app/y] (:active-modes (state/get-state))))
-       (toolbar/toggle-mode! :Mode.app/x)
-       (is (= [:Mode.app/y] (:active-modes (state/get-state)))))))
+       (rf.story/reg-mode :Mode.app/x {:args {:k 1}})
+       (rf.story/reg-mode :Mode.app/y {:args {:k 2}})
+       (rf.story.ui.toolbar/toggle-mode! :Mode.app/x)
+       (is (= [:Mode.app/x] (:active-modes (rf.story.ui.state/get-state))))
+       (rf.story.ui.toolbar/toggle-mode! :Mode.app/y)
+       (is (= [:Mode.app/x :Mode.app/y] (:active-modes (rf.story.ui.state/get-state))))
+       (rf.story.ui.toolbar/toggle-mode! :Mode.app/x)
+       (is (= [:Mode.app/y] (:active-modes (rf.story.ui.state/get-state)))))))
 
 #?(:cljs
    (deftest cljs-axis-toggle-single-selects
      (testing "an axis-tagged mode evicts siblings via toggle-mode!"
-       (story/reg-mode :Mode.t/dark  {:axis :theme :args {:t :dark}})
-       (story/reg-mode :Mode.t/light {:axis :theme :args {:t :light}})
-       (toolbar/toggle-mode! :Mode.t/dark)
-       (is (= [:Mode.t/dark] (:active-modes (state/get-state))))
-       (toolbar/toggle-mode! :Mode.t/light)
-       (is (= [:Mode.t/light] (:active-modes (state/get-state)))))))
+       (rf.story/reg-mode :Mode.t/dark  {:axis :theme :args {:t :dark}})
+       (rf.story/reg-mode :Mode.t/light {:axis :theme :args {:t :light}})
+       (rf.story.ui.toolbar/toggle-mode! :Mode.t/dark)
+       (is (= [:Mode.t/dark] (:active-modes (rf.story.ui.state/get-state))))
+       (rf.story.ui.toolbar/toggle-mode! :Mode.t/light)
+       (is (= [:Mode.t/light] (:active-modes (rf.story.ui.state/get-state)))))))
 
 #?(:cljs
    (deftest cljs-reset-clears
      (testing "reset-modes! drops every mode + persists empty"
-       (story/reg-mode :Mode.app/x {:args {:k 1}})
-       (toolbar/toggle-mode! :Mode.app/x)
-       (is (= [:Mode.app/x] (:active-modes (state/get-state))))
-       (toolbar/reset-modes!)
-       (is (= [] (:active-modes (state/get-state))))
+       (rf.story/reg-mode :Mode.app/x {:args {:k 1}})
+       (rf.story.ui.toolbar/toggle-mode! :Mode.app/x)
+       (is (= [:Mode.app/x] (:active-modes (rf.story.ui.state/get-state))))
+       (rf.story.ui.toolbar/reset-modes!)
+       (is (= [] (:active-modes (rf.story.ui.state/get-state))))
        (when (browser?)
-         (is (= [] (toolbar/load-modes-from-storage)))))))
+         (is (= [] (rf.story.ui.toolbar/load-modes-from-storage)))))))
 
 #?(:cljs
    (deftest cljs-hydrate-from-storage-only-when-empty
      (testing "hydrate skips when the slot is already populated"
        (when (browser?)
-         (story/reg-mode :Mode.app/x {:args {}})
-         (story/reg-mode :Mode.app/y {:args {}})
-         (toolbar/save-modes-to-storage! [:Mode.app/x])
-         (state/swap-state! state/set-active-modes [:Mode.app/y])
-         (toolbar/hydrate-modes-from-storage!)
-         (is (= [:Mode.app/y] (:active-modes (state/get-state)))
+         (rf.story/reg-mode :Mode.app/x {:args {}})
+         (rf.story/reg-mode :Mode.app/y {:args {}})
+         (rf.story.ui.toolbar/save-modes-to-storage! [:Mode.app/x])
+         (rf.story.ui.state/swap-state! rf.story.ui.state/set-active-modes [:Mode.app/y])
+         (rf.story.ui.toolbar/hydrate-modes-from-storage!)
+         (is (= [:Mode.app/y] (:active-modes (rf.story.ui.state/get-state)))
              "non-empty slot is preserved")))))
 
 #?(:cljs
    (deftest cljs-hydrate-from-storage-prunes-stale
      (testing "hydrate drops mode ids not in the registrar"
        (when (browser?)
-         (story/reg-mode :Mode.app/x {:args {}})
-         (toolbar/save-modes-to-storage! [:Mode.app/x :Mode.app/zzz])
-         (toolbar/hydrate-modes-from-storage!)
-         (is (= [:Mode.app/x] (:active-modes (state/get-state))))))))
+         (rf.story/reg-mode :Mode.app/x {:args {}})
+         (rf.story.ui.toolbar/save-modes-to-storage! [:Mode.app/x :Mode.app/zzz])
+         (rf.story.ui.toolbar/hydrate-modes-from-storage!)
+         (is (= [:Mode.app/x] (:active-modes (rf.story.ui.state/get-state))))))))
 
 #?(:cljs
    (deftest cljs-toolbar-strip-renders-chip-per-mode
      (testing "every registered mode produces a chip with a data-toolbar-mode attr"
-       (story/reg-mode :Mode.a/x {:args {}})
-       (story/reg-mode :Mode.a/y {:args {}})
+       (rf.story/reg-mode :Mode.a/x {:args {}})
+       (rf.story/reg-mode :Mode.a/y {:args {}})
        ;; toolbar-strip yields a Reagent component tree; chip nodes
        ;; appear as `[chip ...]` references that React resolves on
        ;; render. To assert the hiccup shape without driving React we
        ;; invoke `chip` directly against the registered modes.
-       (let [body-x (story-registrar/handler-meta :mode :Mode.a/x)
-             body-y (story-registrar/handler-meta :mode :Mode.a/y)
-             attrs-x (second (toolbar/chip :Mode.a/x body-x false))
-             attrs-y (second (toolbar/chip :Mode.a/y body-y true))]
+       (let [body-x (rf.story.registrar/handler-meta :mode :Mode.a/x)
+             body-y (rf.story.registrar/handler-meta :mode :Mode.a/y)
+             attrs-x (second (rf.story.ui.toolbar/chip :Mode.a/x body-x false))
+             attrs-y (second (rf.story.ui.toolbar/chip :Mode.a/y body-y true))]
          (is (= ":Mode.a/x" (:data-toolbar-mode attrs-x)))
          (is (= ":Mode.a/y" (:data-toolbar-mode attrs-y)))
          (is (= "false" (:aria-pressed attrs-x)))
@@ -285,8 +285,8 @@
 #?(:cljs
    (deftest cljs-toolbar-strip-empty-state
      (testing "toolbar-strip renders the no-modes placeholder when registry is empty"
-       (story-registrar/clear-kind! :mode)
-       (let [hiccup (toolbar/toolbar-strip)
+       (rf.story.registrar/clear-kind! :mode)
+       (let [hiccup (rf.story.ui.toolbar/toolbar-strip)
              flat   (->> (tree-seq coll? seq hiccup)
                          (filter string?))]
          (is (some #(re-find #"no modes registered" %) flat))))))
@@ -296,18 +296,18 @@
 #?(:cljs
    (deftest cljs-active-modes-sub-mirrors-state
      (testing ":story/active-modes subscription tracks the shell-state atom"
-       (story/reg-mode :Mode.app/x {:args {:k 1}})
-       (toolbar/toggle-mode! :Mode.app/x)
+       (rf.story/reg-mode :Mode.app/x {:args {:k 1}})
+       (rf.story.ui.toolbar/toggle-mode! :Mode.app/x)
        ;; The pure snapshot helper mirrors the slot.
        (is (= [:Mode.app/x]
-              (ui-cofx/active-modes-snapshot))))))
+              (rf.story.ui.cofx/active-modes-snapshot))))))
 
 #?(:cljs
    (deftest cljs-active-args-deep-merges
      (testing ":story/active-args deep-merges every active mode's :args"
-       (story/reg-mode :Mode.app/x {:args {:a 1 :nest {:p 1}}})
-       (story/reg-mode :Mode.app/y {:args {:b 2 :nest {:q 2}}})
-       (toolbar/toggle-mode! :Mode.app/x)
-       (toolbar/toggle-mode! :Mode.app/y)
+       (rf.story/reg-mode :Mode.app/x {:args {:a 1 :nest {:p 1}}})
+       (rf.story/reg-mode :Mode.app/y {:args {:b 2 :nest {:q 2}}})
+       (rf.story.ui.toolbar/toggle-mode! :Mode.app/x)
+       (rf.story.ui.toolbar/toggle-mode! :Mode.app/y)
        (is (= {:a 1 :b 2 :nest {:p 1 :q 2}}
-              (ui-cofx/active-args-snapshot))))))
+              (rf.story.ui.cofx/active-args-snapshot))))))

--- a/tools/story/test/re_frame/story/ui/toolbar_persistence_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/toolbar_persistence_cljs_test.cljs
@@ -17,7 +17,7 @@
     (`hydrate-modes-from-storage!` then the url-state engine's
     `apply-parsed-to-state`) is exercised through the SINGLE canonical
     ownership path (rf2-96y71s): the localStorage seed lands first, the
-    URL parse (`share/parse-params`) + apply then authoritatively
+    URL parse (`rf.story.share/parse-params`) + apply then authoritatively
     overrides it. The toolbar no longer reads the URL itself.
 
   - **Unknown mode id in localStorage is dropped at hydrate** — write
@@ -36,12 +36,12 @@
   variant). The CLJS tests gate on a working `js/window.localStorage`
   via the same `browser?` predicate the sibling toolbar test uses."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.story             :as story]
-            [re-frame.story.registrar   :as story-registrar]
-            [re-frame.story.share        :as share]
-            [re-frame.story.ui.state     :as state]
-            [re-frame.story.ui.toolbar   :as toolbar]
-            [re-frame.story.ui.url-state :as url-state]))
+            [re-frame.story             :as rf.story]
+            [re-frame.story.registrar   :as rf.story.registrar]
+            [re-frame.story.share        :as rf.story.share]
+            [re-frame.story.ui.state     :as rf.story.ui.state]
+            [re-frame.story.ui.toolbar   :as rf.story.ui.toolbar]
+            [re-frame.story.ui.url-state :as rf.story.ui.url-state]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
@@ -58,14 +58,14 @@
   []
   (when (browser?)
     (try
-      (.removeItem (.-localStorage js/window) toolbar/ls-key)
+      (.removeItem (.-localStorage js/window) rf.story.ui.toolbar/ls-key)
       (catch :default _ nil))))
 
 (defn reset-all! []
-  (story/clear-all!)
-  (state/reset-shell-state!)
+  (rf.story/clear-all!)
+  (rf.story.ui.state/reset-shell-state!)
   (clear-storage!)
-  (story/install-canonical-vocabulary!))
+  (rf.story/install-canonical-vocabulary!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -82,16 +82,16 @@
   Modes registered against the registry persist by design (they live
   in the side-table, not in the shell state)."
   []
-  (state/reset-shell-state!))
+  (rf.story.ui.state/reset-shell-state!))
 
 (defn- modes-url-search
   "Build the canonical `?modes=...` search string for `mode-ids` via the
-  PRODUCTION encoder `share/build-params` — the same wire form the live
+  PRODUCTION encoder `rf.story.share/build-params` — the same wire form the live
   share URL emits — so the test round-trips through the real codec rather
   than hand-assembling tokens (and avoids the `(name kw)`-drops-namespace
   trap)."
   [mode-ids]
-  (str "?" (first (share/build-params {:active-modes mode-ids}))))
+  (str "?" (first (rf.story.share/build-params {:active-modes mode-ids}))))
 
 (defn- mount-hydrate-modes!
   "Compose the shell-mount `:active-modes` hydration through the SINGLE
@@ -101,10 +101,10 @@
   drives both the localStorage seed and the URL authority without
   touching `js/window.location`:
 
-    1. `toolbar/hydrate-modes-from-storage!` — localStorage FALLBACK
+    1. `rf.story.ui.toolbar/hydrate-modes-from-storage!` — localStorage FALLBACK
        seeds `:active-modes` (idempotent, pruned against the registrar).
-    2. The url-state engine then folds the parsed `share/parse-params`
-       shape via `url-state/apply-parsed-to-state` — the SINGLE
+    2. The url-state engine then folds the parsed `rf.story.share/parse-params`
+       shape via `rf.story.ui.url-state/apply-parsed-to-state` — the SINGLE
        authoritative URL writer. A present `modes=` overwrites the seed;
        an omitted `modes=` (but other params present) authoritatively
        CLEARS `:active-modes` to []; a fully-empty search (`\"\"`) means
@@ -115,7 +115,7 @@
   URL params at all (fresh mount). Mirrors `shell/hydrate-url-state!`'s
   `parse-current-url` gate: empty search ⇒ skip the apply."
   [url-search]
-  (toolbar/hydrate-modes-from-storage!)
+  (rf.story.ui.toolbar/hydrate-modes-from-storage!)
   (when (and (string? url-search) (seq url-search))
     (let [usp    (js/URLSearchParams. url-search)
           getter {"variant"    (.get usp "variant")
@@ -127,8 +127,8 @@
                   "tag-filter" (.get usp "tag-filter")
                   "overrides"  (.get usp "overrides")
                   "substrate"  (.get usp "substrate")}
-          parsed (share/parse-params getter)]
-      (state/swap-state! url-state/apply-parsed-to-state parsed {}))))
+          parsed (rf.story.share/parse-params getter)]
+      (rf.story.ui.state/swap-state! rf.story.ui.url-state/apply-parsed-to-state parsed {}))))
 
 ;; ===========================================================================
 ;; rf2-jpi7n — mode persistence across reload (the marquee scenario)
@@ -145,56 +145,56 @@
             both active modes rehydrate from localStorage"
     (when (browser?)
       ;; Seed: register the modes the user will toggle.
-      (story/reg-mode :Mode.persist.theme/dark
+      (rf.story/reg-mode :Mode.persist.theme/dark
         {:axis :theme :args {:theme :dark}})
-      (story/reg-mode :Mode.persist.vp/mobile
+      (rf.story/reg-mode :Mode.persist.vp/mobile
         {:axis :viewport :args {:viewport :mobile}})
       ;; User actions: toggle each on. toggle-mode! persists per call.
-      (toolbar/toggle-mode! :Mode.persist.theme/dark)
-      (toolbar/toggle-mode! :Mode.persist.vp/mobile)
+      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/dark)
+      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.vp/mobile)
       ;; Pre-reload sanity.
       (is (= #{:Mode.persist.theme/dark :Mode.persist.vp/mobile}
-             (set (:active-modes (state/get-state)))))
+             (set (:active-modes (rf.story.ui.state/get-state)))))
       ;; SIMULATED RELOAD — in-memory state cleared, localStorage
       ;; survives. The registry survives by design (it's a side-table,
       ;; not per-instance state).
       (simulate-reload!)
-      (is (= [] (:active-modes (state/get-state)))
+      (is (= [] (:active-modes (rf.story.ui.state/get-state)))
           "post-reload in-memory state is empty — no surprise carry-over")
       ;; Shell's :component-did-mount fires this.
-      (toolbar/hydrate-modes-from-storage!)
+      (rf.story.ui.toolbar/hydrate-modes-from-storage!)
       (is (= #{:Mode.persist.theme/dark :Mode.persist.vp/mobile}
-             (set (:active-modes (state/get-state))))
+             (set (:active-modes (rf.story.ui.state/get-state))))
           "both modes rehydrated from localStorage — reload preserved"))))
 
 (deftest single-mode-persists-and-rehydrates
   (testing "the simpler one-mode case: a single mode survives reload.
             Pins the baseline contract before the multi-mode case"
     (when (browser?)
-      (story/reg-mode :Mode.persist.theme/light
+      (rf.story/reg-mode :Mode.persist.theme/light
         {:axis :theme :args {:theme :light}})
-      (toolbar/toggle-mode! :Mode.persist.theme/light)
+      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/light)
       (is (= [:Mode.persist.theme/light]
-             (:active-modes (state/get-state))))
+             (:active-modes (rf.story.ui.state/get-state))))
       (simulate-reload!)
-      (toolbar/hydrate-modes-from-storage!)
+      (rf.story.ui.toolbar/hydrate-modes-from-storage!)
       (is (= [:Mode.persist.theme/light]
-             (:active-modes (state/get-state)))
+             (:active-modes (rf.story.ui.state/get-state)))
           "single mode survives the reload round-trip"))))
 
 (deftest empty-active-modes-rehydrates-as-empty
   (testing "the boundary case: no active modes before reload → no active
             modes after reload. Pins the empty-cycle path"
     (when (browser?)
-      (story/reg-mode :Mode.persist.theme/dark
+      (rf.story/reg-mode :Mode.persist.theme/dark
         {:axis :theme :args {:theme :dark}})
       ;; Toggle on then off — leaves an empty vector in localStorage.
-      (toolbar/toggle-mode! :Mode.persist.theme/dark)
-      (toolbar/toggle-mode! :Mode.persist.theme/dark)
-      (is (= [] (:active-modes (state/get-state))))
+      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/dark)
+      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/dark)
+      (is (= [] (:active-modes (rf.story.ui.state/get-state))))
       (simulate-reload!)
-      (toolbar/hydrate-modes-from-storage!)
-      (is (= [] (:active-modes (state/get-state)))
+      (rf.story.ui.toolbar/hydrate-modes-from-storage!)
+      (is (= [] (:active-modes (rf.story.ui.state/get-state)))
           "empty active set survives reload"))))
 
 ;; ===========================================================================
@@ -202,8 +202,8 @@
 ;; compose through ONE documented ownership path.
 ;;
 ;; The toolbar no longer reads the URL. Mount hydration is:
-;;   1. toolbar/hydrate-modes-from-storage!  (localStorage FALLBACK)
-;;   2. url-state/apply-parsed-to-state       (the SINGLE URL authority)
+;;   1. rf.story.ui.toolbar/hydrate-modes-from-storage!  (localStorage FALLBACK)
+;;   2. rf.story.ui.url-state/apply-parsed-to-state       (the SINGLE URL authority)
 ;; `mount-hydrate-modes!` composes exactly that with the URL search
 ;; supplied as data. These three tests pin the precedence end-to-end
 ;; against the canonical share/url-state path — no manual simulation of
@@ -216,15 +216,15 @@
             first, then apply-parsed-to-state writes the URL's :light.
             Last-shared wins over last-used — through ONE path."
     (when (browser?)
-      (story/reg-mode :Mode.persist.theme/dark  {:axis :theme :args {:theme :dark}})
-      (story/reg-mode :Mode.persist.theme/light {:axis :theme :args {:theme :light}})
+      (rf.story/reg-mode :Mode.persist.theme/dark  {:axis :theme :args {:theme :dark}})
+      (rf.story/reg-mode :Mode.persist.theme/light {:axis :theme :args {:theme :light}})
       ;; localStorage seeded with :dark (last-used).
-      (toolbar/save-modes-to-storage! [:Mode.persist.theme/dark])
+      (rf.story.ui.toolbar/save-modes-to-storage! [:Mode.persist.theme/dark])
       (simulate-reload!)
       ;; Mount with a URL that carries modes=...light (last-shared).
       (mount-hydrate-modes! (modes-url-search [:Mode.persist.theme/light]))
       (is (= [:Mode.persist.theme/light]
-             (:active-modes (state/get-state)))
+             (:active-modes (rf.story.ui.state/get-state)))
           "URL modes (light) replaced the localStorage seed (dark)"))))
 
 (deftest mount-omitted-modes-clears-localstorage-seed
@@ -234,12 +234,12 @@
             share surface). A share link like ?variant=foo restores the
             DEFAULT (no modes) chrome for the recipient."
     (when (browser?)
-      (story/reg-mode :Mode.persist.theme/dark {:axis :theme :args {:theme :dark}})
-      (toolbar/save-modes-to-storage! [:Mode.persist.theme/dark])
+      (rf.story/reg-mode :Mode.persist.theme/dark {:axis :theme :args {:theme :dark}})
+      (rf.story.ui.toolbar/save-modes-to-storage! [:Mode.persist.theme/dark])
       (simulate-reload!)
       ;; Mount with a populated URL that has NO modes= param.
       (mount-hydrate-modes! "?variant=story.counter/loaded")
-      (is (= [] (:active-modes (state/get-state)))
+      (is (= [] (:active-modes (rf.story.ui.state/get-state)))
           "omitted modes= cleared the localStorage seed — URL authoritative"))))
 
 (deftest mount-no-url-falls-back-to-localstorage
@@ -248,15 +248,15 @@
             the search is empty). This is the intentional last-used
             fallback that survives ONLY when the URL carries nothing."
     (when (browser?)
-      (story/reg-mode :Mode.persist.theme/dark {:axis :theme :args {:theme :dark}})
-      (story/reg-mode :Mode.persist.vp/mobile  {:axis :viewport :args {:viewport :mobile}})
-      (toolbar/save-modes-to-storage!
+      (rf.story/reg-mode :Mode.persist.theme/dark {:axis :theme :args {:theme :dark}})
+      (rf.story/reg-mode :Mode.persist.vp/mobile  {:axis :viewport :args {:viewport :mobile}})
+      (rf.story.ui.toolbar/save-modes-to-storage!
         [:Mode.persist.theme/dark :Mode.persist.vp/mobile])
       (simulate-reload!)
       ;; Mount with NO URL params — localStorage is the only source.
       (mount-hydrate-modes! "")
       (is (= #{:Mode.persist.theme/dark :Mode.persist.vp/mobile}
-             (set (:active-modes (state/get-state))))
+             (set (:active-modes (rf.story.ui.state/get-state))))
           "no URL state ⇒ localStorage seed survives (last-used fallback)"))))
 
 (deftest mount-url-modes-prune-is-url-authoritative
@@ -266,14 +266,14 @@
             A stale localStorage seed, by contrast, IS pruned by the
             localStorage hydrator before the URL apply overrides it."
     (when (browser?)
-      (story/reg-mode :Mode.persist.theme/dark {:axis :theme :args {:theme :dark}})
+      (rf.story/reg-mode :Mode.persist.theme/dark {:axis :theme :args {:theme :dark}})
       ;; localStorage seed carries a stale id; the storage hydrator prunes it.
-      (toolbar/save-modes-to-storage!
+      (rf.story.ui.toolbar/save-modes-to-storage!
         [:Mode.persist.theme/dark :Mode.persist.removed/zzz])
       (simulate-reload!)
       ;; URL carries the live :dark only.
       (mount-hydrate-modes! (modes-url-search [:Mode.persist.theme/dark]))
-      (is (= [:Mode.persist.theme/dark] (:active-modes (state/get-state)))
+      (is (= [:Mode.persist.theme/dark] (:active-modes (rf.story.ui.state/get-state)))
           "URL modes win; the stale localStorage id never surfaces"))))
 
 ;; ===========================================================================
@@ -290,18 +290,18 @@
             survive. Pin the stale-survive contract"
     (when (browser?)
       ;; Register only one of the two ids the localStorage will name.
-      (story/reg-mode :Mode.persist.live/x {:args {:k 1}})
+      (rf.story/reg-mode :Mode.persist.live/x {:args {:k 1}})
       ;; Manually seed localStorage with one live id + one stale id.
-      (toolbar/save-modes-to-storage!
+      (rf.story.ui.toolbar/save-modes-to-storage!
         [:Mode.persist.live/x :Mode.persist.removed/y])
       ;; Reload + hydrate.
       (simulate-reload!)
-      (toolbar/hydrate-modes-from-storage!)
+      (rf.story.ui.toolbar/hydrate-modes-from-storage!)
       (is (= [:Mode.persist.live/x]
-             (:active-modes (state/get-state)))
+             (:active-modes (rf.story.ui.state/get-state)))
           "only the live mode id survives — stale id silently dropped")
       (is (not (some #{:Mode.persist.removed/y}
-                     (:active-modes (state/get-state))))
+                     (:active-modes (rf.story.ui.state/get-state))))
           "the stale id is NOT in active-modes — drop, not error"))))
 
 (deftest all-stale-ids-pruned-to-empty
@@ -311,11 +311,11 @@
             available modes from scratch"
     (when (browser?)
       ;; No registered modes here — every id in storage is stale.
-      (toolbar/save-modes-to-storage!
+      (rf.story.ui.toolbar/save-modes-to-storage!
         [:Mode.persist.removed/a :Mode.persist.removed/b])
       (simulate-reload!)
-      (toolbar/hydrate-modes-from-storage!)
-      (is (= [] (:active-modes (state/get-state)))
+      (rf.story.ui.toolbar/hydrate-modes-from-storage!)
+      (is (= [] (:active-modes (rf.story.ui.state/get-state)))
           "every stale id dropped — active vector is empty after hydrate"))))
 
 ;; ===========================================================================
@@ -335,20 +335,20 @@
             untouched. Pin the axis-aware behaviour survives the
             reload boundary"
     (when (browser?)
-      (story/reg-mode :Mode.persist.theme/dark  {:axis :theme    :args {:theme :dark}})
-      (story/reg-mode :Mode.persist.theme/light {:axis :theme    :args {:theme :light}})
-      (story/reg-mode :Mode.persist.vp/mobile   {:axis :viewport :args {:viewport :mobile}})
+      (rf.story/reg-mode :Mode.persist.theme/dark  {:axis :theme    :args {:theme :dark}})
+      (rf.story/reg-mode :Mode.persist.theme/light {:axis :theme    :args {:theme :light}})
+      (rf.story/reg-mode :Mode.persist.vp/mobile   {:axis :viewport :args {:viewport :mobile}})
       ;; Seed: dark + mobile (multi-select across axes).
-      (toolbar/toggle-mode! :Mode.persist.theme/dark)
-      (toolbar/toggle-mode! :Mode.persist.vp/mobile)
+      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/dark)
+      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.vp/mobile)
       ;; Reload + hydrate.
       (simulate-reload!)
-      (toolbar/hydrate-modes-from-storage!)
+      (rf.story.ui.toolbar/hydrate-modes-from-storage!)
       (is (= #{:Mode.persist.theme/dark :Mode.persist.vp/mobile}
-             (set (:active-modes (state/get-state)))))
+             (set (:active-modes (rf.story.ui.state/get-state)))))
       ;; Post-reload action: toggle light theme — must evict dark.
-      (toolbar/toggle-mode! :Mode.persist.theme/light)
-      (let [active (set (:active-modes (state/get-state)))]
+      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/light)
+      (let [active (set (:active-modes (rf.story.ui.state/get-state)))]
         (is (contains? active :Mode.persist.theme/light)
             ":light is now active")
         (is (not (contains? active :Mode.persist.theme/dark))
@@ -361,18 +361,18 @@
             survive reload as a set. Toggling between them does not
             disturb the membership of sibling axes"
     (when (browser?)
-      (story/reg-mode :Mode.persist.theme/dark  {:axis :theme    :args {:theme :dark}})
-      (story/reg-mode :Mode.persist.vp/mobile   {:axis :viewport :args {:viewport :mobile}})
-      (story/reg-mode :Mode.persist.locale/en   {:axis :locale   :args {:locale :en}})
-      (toolbar/toggle-mode! :Mode.persist.theme/dark)
-      (toolbar/toggle-mode! :Mode.persist.vp/mobile)
-      (toolbar/toggle-mode! :Mode.persist.locale/en)
+      (rf.story/reg-mode :Mode.persist.theme/dark  {:axis :theme    :args {:theme :dark}})
+      (rf.story/reg-mode :Mode.persist.vp/mobile   {:axis :viewport :args {:viewport :mobile}})
+      (rf.story/reg-mode :Mode.persist.locale/en   {:axis :locale   :args {:locale :en}})
+      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/dark)
+      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.vp/mobile)
+      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.locale/en)
       ;; Three axes co-active.
-      (is (= 3 (count (:active-modes (state/get-state)))))
+      (is (= 3 (count (:active-modes (rf.story.ui.state/get-state)))))
       (simulate-reload!)
-      (toolbar/hydrate-modes-from-storage!)
+      (rf.story.ui.toolbar/hydrate-modes-from-storage!)
       (is (= #{:Mode.persist.theme/dark
                :Mode.persist.vp/mobile
                :Mode.persist.locale/en}
-             (set (:active-modes (state/get-state))))
+             (set (:active-modes (rf.story.ui.state/get-state))))
           "three-axis active set survives the reload round-trip"))))

--- a/tools/story/test/re_frame/story/ui/url_state_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/url_state_cljs_test.cljs
@@ -12,9 +12,9 @@
   runner (and so the test doesn't perturb the harness's own URL)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string               :as str]
-            [re-frame.story.share         :as share]
-            [re-frame.story.ui.state      :as state]
-            [re-frame.story.ui.url-state  :as us]))
+            [re-frame.story.share         :as rf.story.share]
+            [re-frame.story.ui.state      :as rf.story.ui.state]
+            [re-frame.story.ui.url-state  :as rf.story.ui.url-state]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
@@ -22,7 +22,7 @@
   (and (exists? js/window) (exists? js/URLSearchParams)))
 
 (defn reset-all! []
-  (state/reset-shell-state!))
+  (rf.story.ui.state/reset-shell-state!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -37,7 +37,7 @@
                  :background         :dark
                  :tag-filter         #{:tag/a}
                  :substrate          :uix}
-          url   (us/url-from-state shell {:pathname "/p/" :hash "#/stories"})]
+          url   (rf.story.ui.url-state/url-from-state shell {:pathname "/p/" :hash "#/stories"})]
       (is (re-find #"variant="    url))
       (is (re-find #"mode-tab="   url))
       (is (re-find #"modes="      url))
@@ -77,16 +77,16 @@
                   "substrate"  "uix"}
           search (str "?"
                       (str/join "&" (map #(str (name %) "=" (get stale (name %)))
-                                         share/story-query-keys))
+                                         rf.story.share/story-query-keys))
                       "&from=index&embed=1")
-          url    (us/url-from-state
+          url    (rf.story.ui.url-state/url-from-state
                    {:selected-variant :story.new/b}
                    {:pathname "/counter-with-stories/"
                     :search   search
                     :hash     "#/stories"})
           usp    (js/URLSearchParams.
                    (second (str/split (first (str/split url #"#" 2)) #"\?" 2)))]
-      (is (= (set (map name share/story-query-keys)) (set (keys stale)))
+      (is (= (set (map name rf.story.share/story-query-keys)) (set (keys stale)))
           "the fixture carries a stale value for every key in the vocabulary")
       (is (= "index" (.get usp "from"))
           "the referrer param survives with its value")
@@ -96,13 +96,13 @@
           "URLSearchParams.get returns the variant this state asked for")
       (is (= 1 (count (.getAll usp "variant")))
           "exactly one variant value")
-      (doseq [k (map name share/story-query-keys)
+      (doseq [k (map name rf.story.share/story-query-keys)
               :when (not= k "variant")]
         (is (zero? (count (.getAll usp k)))
             (str "URLSearchParams sees no stale " k "= at all")))
-      (let [parsed (share/parse-params
+      (let [parsed (rf.story.share/parse-params
                      (into {} (map (fn [k] [k (.get usp k)]))
-                           (map name share/story-query-keys)))]
+                           (map name rf.story.share/story-query-keys)))]
         (is (= :story.new/b (:variant-id parsed))
             "the hydrator's own read path recovers the requested variant")
         (doseq [slot [:workspace-id :mode-tab :active-modes :viewport
@@ -114,7 +114,7 @@
 
 ;; ---- rf2-b7je1: the LIVE address bar owns escaped key spellings ---------
 ;;
-;; Unifying the two writers on `share/apply-story-params` carried the
+;; Unifying the two writers on `rf.story.share/apply-story-params` carried the
 ;; share builder's last ownership hole onto the address bar: ownership was
 ;; matched on raw key text, while the `URLSearchParams` this shell reads
 ;; with compares DECODED names. A `location.search` spelling a Story key
@@ -128,7 +128,7 @@
   (testing "rf2-b7je1 audit — `%76ariant=` IS `variant=` to the browser, so
             a state-driven push must clear it rather than append behind it;
             read back through the API the next mount will actually use"
-    (let [url (us/url-from-state
+    (let [url (rf.story.ui.url-state/url-from-state
                 {:selected-variant :story.new/b}
                 {:pathname "/p/"
                  :search   "?%76ariant=story.old%2Fa&embed=1"
@@ -146,7 +146,7 @@
 
 (deftest url-from-state-clears-every-escaped-story-key-cljs
   (testing "rf2-b7je1 audit — the whole vocabulary spelled with escapes.
-            Derived from `share/story-query-keys`, so a key added to the
+            Derived from `rf.story.share/story-query-keys`, so a key added to the
             vocabulary is covered without editing this test."
     (let [escape #(str "%" (.toUpperCase (.toString (.charCodeAt % 0) 16))
                        (subs % 1))
@@ -163,20 +163,20 @@
                       (str/join "&" (map #(str (escape (name %))
                                                "="
                                                (get stale (name %)))
-                                         share/story-query-keys))
+                                         rf.story.share/story-query-keys))
                       "&from=index&embed=1")
-          url    (us/url-from-state
+          url    (rf.story.ui.url-state/url-from-state
                    {:selected-variant :story.new/b}
                    {:pathname "/p/" :search search :hash "#/stories"})
           usp    (js/URLSearchParams.
                    (second (str/split (first (str/split url #"#" 2)) #"\?" 2)))]
-      (is (= (set (map name share/story-query-keys)) (set (keys stale)))
+      (is (= (set (map name rf.story.share/story-query-keys)) (set (keys stale)))
           "the fixture carries a stale value for every key in the vocabulary")
       (is (= "story.new/b" (.get usp "variant"))
           "URLSearchParams.get returns the variant this state asked for")
       (is (= 1 (count (.getAll usp "variant")))
           "exactly one variant value")
-      (doseq [k (map name share/story-query-keys)
+      (doseq [k (map name rf.story.share/story-query-keys)
               :when (not= k "variant")]
         (is (zero? (count (.getAll usp k)))
             (str "URLSearchParams sees no stale " k "= at all")))
@@ -195,7 +195,7 @@
     (let [loc (js/URL. (str "https://example.test/counter-with-stories/"
                             "?from=index&embed=1&variant=story.old%2Fa"
                             "#/stories"))
-          url (us/url-from-state
+          url (rf.story.ui.url-state/url-from-state
                 {:selected-variant :story.new/b}
                 {:pathname (.-pathname loc)
                  :search   (.-search loc)
@@ -207,8 +207,8 @@
 
 (deftest params-from-state-feeds-share-build-params
   (testing "rf2-o4u18 — the projection contract: params-from-state +
-            share/build-params produce a URL params vector that
-            share/parse-params round-trips back to the projection"
+            rf.story.share/build-params produce a URL params vector that
+            rf.story.share/parse-params round-trips back to the projection"
     (let [shell  {:selected-variant   :foo/bar
                   :active-mode-tab    {:foo/bar :test}
                   :active-modes       [:m/dark]
@@ -217,8 +217,8 @@
                   :tag-filter         #{:tag/x}
                   :cell-overrides     {:foo/bar {:label "Hi"}}
                   :substrate          :uix}
-          proj   (us/params-from-state shell)
-          ps     (share/build-params proj)
+          proj   (rf.story.ui.url-state/params-from-state shell)
+          ps     (rf.story.share/build-params proj)
           usp    (js/URLSearchParams. (str/join "&" ps))
           getter {"variant"    (.get usp "variant")
                   "workspace"  (.get usp "workspace")
@@ -229,7 +229,7 @@
                   "tag-filter" (.get usp "tag-filter")
                   "overrides"  (.get usp "overrides")
                   "substrate"  (.get usp "substrate")}
-          out    (share/parse-params getter)]
+          out    (rf.story.share/parse-params getter)]
       (is (= :foo/bar (:variant-id out)))
       (is (= :test    (:mode-tab out)))
       (is (= [:m/dark] (:active-modes out)))
@@ -254,15 +254,15 @@
           shell    {:selected-variant variant
                     :cell-overrides   {variant slice}}
           ;; encode: project → build params → real URLSearchParams string
-          proj     (us/params-from-state shell)
-          ps       (share/build-params proj)
+          proj     (rf.story.ui.url-state/params-from-state shell)
+          ps       (rf.story.share/build-params proj)
           qs       (str/join "&" ps)
           usp      (js/URLSearchParams. qs)
           getter   {"variant"   (.get usp "variant")
                     "overrides" (.get usp "overrides")}
           ;; decode: parse-params → apply back into a fresh shell state
-          parsed   (share/parse-params getter)
-          out      (us/apply-parsed-to-state {} parsed {})]
+          parsed   (rf.story.share/parse-params getter)
+          out      (rf.story.ui.url-state/apply-parsed-to-state {} parsed {})]
       (is (= variant (:selected-variant out)))
       (is (= slice (get-in out [:cell-overrides variant]))
           "decoded overrides equal the encoded overrides (round-trip)")
@@ -296,7 +296,7 @@
             cur (str (.-pathname (.-location js/window))
                      (.-search   (.-location js/window))
                      (.-hash     (.-location js/window)))]
-        (us/push! cur)
+        (rf.story.ui.url-state/push! cur)
         (try
           (is (= 0 (count @captured))
               "no pushState calls when URL matches")
@@ -305,7 +305,7 @@
   (deftest push!-fires-when-url-differs
     (testing "rf2-o4u18 — push! pushes a different URL"
       (let [[captured restore] (with-history-spy)]
-        (us/push! (str (.-pathname (.-location js/window))
+        (rf.story.ui.url-state/push! (str (.-pathname (.-location js/window))
                        "?variant=foo%2Fbar"
                        (.-hash (.-location js/window))))
         (try
@@ -330,11 +330,11 @@
             ONE url-state watch after a double-install (no doubled fires),
             and teardown removes it. A watcher that stacked (fresh key per
             install) would leave the count one higher and fail here."
-    (let [a  state/shell-state-atom
+    (let [a  rf.story.ui.state/shell-state-atom
           n0 (count (.-watches a))]
-      (us/install-state-watcher! a)
+      (rf.story.ui.url-state/install-state-watcher! a)
       (let [n1 (count (.-watches a))]
-        (us/install-state-watcher! a)          ; re-install under same key
+        (rf.story.ui.url-state/install-state-watcher! a)          ; re-install under same key
         (let [n2 (count (.-watches a))]
           (try
             (is (= (inc n0) n1)
@@ -342,7 +342,7 @@
             (is (= n1 n2)
                 "re-install does NOT grow the watch count — replaces under
                  the same key (no stacked / doubled-fire watchers)")
-            (finally (us/remove-state-watcher! a)))
+            (finally (rf.story.ui.url-state/remove-state-watcher! a)))
           (is (= n0 (count (.-watches a)))
               "teardown removes the watch (back to baseline)"))))))
 
@@ -404,10 +404,10 @@
       (try
         ;; Clear any process-wide handler left by a prior test/run so the
         ;; registry count reflects only this test's installs.
-        (us/remove-popstate-listener!)
+        (rf.story.ui.url-state/remove-popstate-listener!)
         (reset! fires 0)
-        (us/install-popstate-listener! state/shell-state-atom apply-fn)
-        (us/install-popstate-listener! state/shell-state-atom apply-fn) ; re-install
+        (rf.story.ui.url-state/install-popstate-listener! rf.story.ui.state/shell-state-atom apply-fn)
+        (rf.story.ui.url-state/install-popstate-listener! rf.story.ui.state/shell-state-atom apply-fn) ; re-install
         (is (= 1 (popstate-listener-count registry))
             "exactly one popstate listener registered after double-install
              (replaced, not stacked)")
@@ -415,11 +415,11 @@
         (.dispatchEvent js/window #js {:type "popstate"})
         (is (= 1 @fires)
             "single popstate fires the handler exactly once (no doubled fires)")
-        (us/remove-popstate-listener!)
+        (rf.story.ui.url-state/remove-popstate-listener!)
         (is (= 0 (popstate-listener-count registry))
             "remove-popstate-listener! removes the listener")
         (finally
-          (us/remove-popstate-listener!)
+          (rf.story.ui.url-state/remove-popstate-listener!)
           (uninstall-window-stub!))))))
 
 ;; ---- apply-fn integration through swap! ---------------------------------
@@ -428,13 +428,13 @@
   (testing "rf2-o4u18 — swap! threads apply-parsed-to-state through the
             live shell-state ratom"
     (let [apply-fn (fn [s parsed]
-                     (us/apply-parsed-to-state s parsed {}))]
-      (swap! state/shell-state-atom apply-fn
+                     (rf.story.ui.url-state/apply-parsed-to-state s parsed {}))]
+      (swap! rf.story.ui.state/shell-state-atom apply-fn
              {:variant-id :foo/bar
               :viewport   :tablet
               :background :dark
               :tag-filter #{:tag/a}})
-      (let [s @state/shell-state-atom]
+      (let [s @rf.story.ui.state/shell-state-atom]
         (is (= :foo/bar (:selected-variant s)))
         (is (= :tablet  (:viewport s)))
         (is (= :dark    (:background s)))
@@ -449,7 +449,7 @@
             their defaults instead of no-op'ing. (The harness URL has no
             Story params, so this exercises the blank-search branch.)"
     (when (browser?)
-      (let [parsed (us/parse-current-url-or-empty)]
+      (let [parsed (rf.story.ui.url-state/parse-current-url-or-empty)]
         (is (map? parsed) "returns a parsed map, never nil, when window present")
         (is (nil? (:variant-id parsed)))
         (is (nil? (:active-modes parsed)))
@@ -463,18 +463,18 @@
             then applying the all-nil parsed shape (what
             `parse-current-url-or-empty` yields for an empty search) clears
             every URL-owned slot. Drives the live shell-state ratom."
-    (let [apply-fn (fn [s parsed] (us/apply-parsed-to-state s parsed {}))]
+    (let [apply-fn (fn [s parsed] (rf.story.ui.url-state/apply-parsed-to-state s parsed {}))]
       ;; 1. populated: a deep-link with framing + filter + modes.
-      (swap! state/shell-state-atom apply-fn
+      (swap! rf.story.ui.state/shell-state-atom apply-fn
              {:variant-id   :foo/bar
               :active-modes [:m/dark]
               :viewport     :tablet
               :background   :dark
               :tag-filter   #{:tag/a}})
-      (is (= :foo/bar (:selected-variant @state/shell-state-atom)))
+      (is (= :foo/bar (:selected-variant @rf.story.ui.state/shell-state-atom)))
       ;; 2. popstate to a no-query URL ⇒ all-nil parsed shape.
-      (swap! state/shell-state-atom apply-fn (share/parse-params {}))
-      (let [s @state/shell-state-atom]
+      (swap! rf.story.ui.state/shell-state-atom apply-fn (rf.story.share/parse-params {}))
+      (let [s @rf.story.ui.state/shell-state-atom]
         (is (nil? (:selected-variant s)) "selection cleared on bare-URL pop")
         (is (= [] (:active-modes s))      "modes cleared")
         (is (nil? (:viewport s))          "viewport cleared")
@@ -485,16 +485,16 @@
   (testing "rf2-fkmnh — navigating from a fully-populated URL to one that
             keeps the variant but drops modes/viewport/background/tag-filter
             clears exactly the omitted slots (the variant survives)"
-    (let [apply-fn (fn [s parsed] (us/apply-parsed-to-state s parsed {}))]
-      (swap! state/shell-state-atom apply-fn
+    (let [apply-fn (fn [s parsed] (rf.story.ui.url-state/apply-parsed-to-state s parsed {}))]
+      (swap! rf.story.ui.state/shell-state-atom apply-fn
              {:variant-id   :foo/bar
               :active-modes [:m/dark]
               :viewport     :tablet
               :background   :dark
               :tag-filter   #{:tag/a}})
       ;; second URL: variant only.
-      (swap! state/shell-state-atom apply-fn {:variant-id :foo/bar})
-      (let [s @state/shell-state-atom]
+      (swap! rf.story.ui.state/shell-state-atom apply-fn {:variant-id :foo/bar})
+      (let [s @rf.story.ui.state/shell-state-atom]
         (is (= :foo/bar (:selected-variant s)) "variant preserved")
         (is (= [] (:active-modes s)))
         (is (nil? (:viewport s)))

--- a/tools/story/test/re_frame/story/ui/url_state_test.cljc
+++ b/tools/story/test/re_frame/story/ui/url_state_test.cljc
@@ -13,32 +13,32 @@
   - `apply-parsed-to-state` — fold parsed slots back into shell-state."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
-            [re-frame.story.share :as share]
-            [re-frame.story.ui.url-state :as us]))
+            [re-frame.story.share :as rf.story.share]
+            [re-frame.story.ui.url-state :as rf.story.ui.url-state]))
 
 ;; ---- params-from-state ---------------------------------------------------
 
 (deftest params-from-state-empty
   (testing "an empty shell state projects to {}"
-    (is (= {} (us/params-from-state {})))))
+    (is (= {} (rf.story.ui.url-state/params-from-state {})))))
 
 (deftest params-from-state-variant-only
   (testing "a focused variant projects to {:variant-id ...} only"
     (is (= {:variant-id :story.foo/bar}
-           (us/params-from-state
+           (rf.story.ui.url-state/params-from-state
              {:selected-variant :story.foo/bar})))))
 
 (deftest params-from-state-workspace-only
   (testing "a focused workspace projects to {:workspace-id ...} only"
     (is (= {:workspace-id :story.foo/grid}
-           (us/params-from-state
+           (rf.story.ui.url-state/params-from-state
              {:selected-workspace :story.foo/grid})))))
 
 (deftest params-from-state-mode-tab-keyed-on-variant
   (testing "mode-tab is projected from the focused variant's slot"
     (is (= {:variant-id :story.foo/bar
             :mode-tab   :docs}
-           (us/params-from-state
+           (rf.story.ui.url-state/params-from-state
              {:selected-variant :story.foo/bar
               :active-mode-tab  {:story.foo/bar :docs
                                  :story.other/x :test}})))))
@@ -47,14 +47,14 @@
   (testing "cell-overrides only project for the focused variant"
     (is (= {:variant-id     :story.foo/bar
             :cell-overrides {:label "Hi"}}
-           (us/params-from-state
+           (rf.story.ui.url-state/params-from-state
              {:selected-variant :story.foo/bar
               :cell-overrides   {:story.foo/bar  {:label "Hi"}
                                  :story.other/x  {:label "Hidden"}}})))))
 
 (deftest params-from-state-full
   (testing "every URL-relevant slot projects"
-    (let [out (us/params-from-state
+    (let [out (rf.story.ui.url-state/params-from-state
                 {:selected-variant   :story.foo/bar
                  :selected-workspace nil
                  :active-mode-tab    {:story.foo/bar :test}
@@ -76,19 +76,19 @@
 ;; ---- url-from-state ------------------------------------------------------
 
 (deftest url-from-state-composes-pathname-query-hash
-  (let [url (us/url-from-state
+  (let [url (rf.story.ui.url-state/url-from-state
               {:selected-variant :foo/bar}
               {:pathname "/foo/"
                :hash     "#/stories"})]
     (is (= "/foo/?variant=foo%2Fbar#/stories" url))))
 
 (deftest url-from-state-no-query-when-empty
-  (let [url (us/url-from-state {} {:pathname "/foo/" :hash "#/stories"})]
+  (let [url (rf.story.ui.url-state/url-from-state {} {:pathname "/foo/" :hash "#/stories"})]
     (is (= "/foo/#/stories" url))))
 
 (deftest url-from-state-includes-every-populated-slot
   (testing "every URL-relevant shell slot reaches the composed query"
-    (let [url (us/url-from-state
+    (let [url (rf.story.ui.url-state/url-from-state
                 {:selected-variant   :foo/bar
                  :active-mode-tab    {:foo/bar :docs}
                  :active-modes       [:m/dark]
@@ -116,7 +116,7 @@
 ;; a referrer `from=`, a host page's analytics params.
 ;;
 ;; The share builder had already settled the boundary (rf2-b7je1): Story
-;; owns exactly `share/story-query-keys` and preserves everything else.
+;; owns exactly `rf.story.share/story-query-keys` and preserves everything else.
 ;; These pin that this writer applies the SAME boundary — it calls the same
 ;; merge — so the two cannot drift about who owns what.
 
@@ -131,7 +131,7 @@
             ahead of the generated ones, while the stale Story key is
             replaced by this state's value"
     (is (= "/counter-with-stories/?from=index&embed=1&variant=story.new%2Fb#/stories"
-           (us/url-from-state
+           (rf.story.ui.url-state/url-from-state
              {:selected-variant :story.new/b}
              {:pathname "/counter-with-stories/"
               :search   third-party-search
@@ -153,14 +153,14 @@
                  "substrate"  "uix"}
           search (str "?"
                       (str/join "&" (map #(str (name %) "=" (get stale (name %)))
-                                         share/story-query-keys))
+                                         rf.story.share/story-query-keys))
                       "&from=index&embed=1")
-          url    (us/url-from-state
+          url    (rf.story.ui.url-state/url-from-state
                    ;; Only `:selected-variant` populated — every other slot
-                   ;; is omitted by `share/build-params`.
+                   ;; is omitted by `rf.story.share/build-params`.
                    {:selected-variant :story.new/b}
                    {:pathname "/p/" :search search :hash "#/stories"})]
-      (is (= (set (map name share/story-query-keys)) (set (keys stale)))
+      (is (= (set (map name rf.story.share/story-query-keys)) (set (keys stale)))
           "the fixture carries a stale value for every key in the vocabulary")
       (is (= "/p/?from=index&embed=1&variant=story.new%2Fb#/stories" url)
           "every stale Story key is gone; both unowned params survive"))))
@@ -171,7 +171,7 @@
             `location.search`'s empty string, so the watcher would push a
             cosmetic history entry the shell can never match again"
     (is (= "/p/#/stories"
-           (us/url-from-state {} {:pathname "/p/"
+           (rf.story.ui.url-state/url-from-state {} {:pathname "/p/"
                                   :search   "?variant=story.old%2Fa"
                                   :hash     "#/stories"})))))
 
@@ -183,18 +183,18 @@
     (let [pathname "/counter-with-stories/"
           search   "?from=index&embed=1&substrate=uix"
           hash     "#/stories"]
-      (is (= (share/variant-share-url
+      (is (= (rf.story.share/variant-share-url
                :story.new/b
                (str pathname search hash)
                {:substrate :reagent})
-             (us/url-from-state
+             (rf.story.ui.url-state/url-from-state
                {:selected-variant :story.new/b :substrate :reagent}
                {:pathname pathname :search search :hash hash}))
           "same base + same cell ⇒ same URL from either writer"))))
 
 ;; ---- rf2-b7je1: the address bar owns ESCAPED spellings too --------------
 ;;
-;; Unifying the two writers on `share/apply-story-params` carried the
+;; Unifying the two writers on `rf.story.share/apply-story-params` carried the
 ;; share builder's remaining ownership hole onto the LIVE address bar:
 ;; ownership was matched on raw key text while `URLSearchParams` compares
 ;; DECODED names, so a `location.search` spelling a Story key with escapes
@@ -209,7 +209,7 @@
   (testing "rf2-b7je1 audit — `%76ariant=` IS `variant=` to the browser, so
             a state-driven push must clear it rather than append behind it"
     (is (= "/p/?embed=1&variant=story.new%2Fb#/stories"
-           (us/url-from-state
+           (rf.story.ui.url-state/url-from-state
              {:selected-variant :story.new/b}
              {:pathname "/p/"
               :search   "?%76ariant=story.old%2Fa&embed=1"
@@ -219,7 +219,7 @@
 (deftest url-from-state-clears-every-escaped-story-key
   (testing "rf2-b7je1 audit — the whole vocabulary, spelled with escapes:
             every Story key goes, both unowned params stay. Derived from
-            `share/story-query-keys` so a key added to the vocabulary is
+            `rf.story.share/story-query-keys` so a key added to the vocabulary is
             covered here without editing this test."
     (let [escape #(str "%" (format "%02X" (int (first %))) (subs % 1))
           stale  {"variant"    "story.old%2Fa"
@@ -235,12 +235,12 @@
                       (str/join "&" (map #(str (escape (name %))
                                                "="
                                                (get stale (name %)))
-                                         share/story-query-keys))
+                                         rf.story.share/story-query-keys))
                       "&from=index&embed=1")]
-      (is (= (set (map name share/story-query-keys)) (set (keys stale)))
+      (is (= (set (map name rf.story.share/story-query-keys)) (set (keys stale)))
           "the fixture carries a stale value for every key in the vocabulary")
       (is (= "/p/?from=index&embed=1&variant=story.new%2Fb#/stories"
-             (us/url-from-state
+             (rf.story.ui.url-state/url-from-state
                {:selected-variant :story.new/b}
                {:pathname "/p/" :search search :hash "#/stories"}))
           "every escaped Story key is cleared; both unowned params survive"))))
@@ -251,11 +251,11 @@
     (let [pathname "/counter-with-stories/"
           search   "?%76ariant=story.old%2Fa&embed=1&%73ubstrate=uix"
           hash     "#/stories"]
-      (is (= (share/variant-share-url
+      (is (= (rf.story.share/variant-share-url
                :story.new/b
                (str pathname search hash)
                {:substrate :reagent})
-             (us/url-from-state
+             (rf.story.ui.url-state/url-from-state
                {:selected-variant :story.new/b :substrate :reagent}
                {:pathname pathname :search search :hash hash}))
           "same base + same cell ⇒ same URL from either writer"))))
@@ -263,50 +263,50 @@
 ;; ---- url-relevant-slots-changed? ----------------------------------------
 
 (deftest url-relevant-slots-changed-detects-variant-change
-  (is (us/url-relevant-slots-changed?
+  (is (rf.story.ui.url-state/url-relevant-slots-changed?
         {:selected-variant :foo/a}
         {:selected-variant :foo/b})))
 
 (deftest url-relevant-slots-changed-detects-workspace-change
-  (is (us/url-relevant-slots-changed?
+  (is (rf.story.ui.url-state/url-relevant-slots-changed?
         {:selected-workspace :foo/a}
         {:selected-workspace :foo/b})))
 
 (deftest url-relevant-slots-changed-detects-mode-tab-change
-  (is (us/url-relevant-slots-changed?
+  (is (rf.story.ui.url-state/url-relevant-slots-changed?
         {:active-mode-tab {:foo/a :dev}}
         {:active-mode-tab {:foo/a :docs}})))
 
 (deftest url-relevant-slots-changed-detects-viewport-change
-  (is (us/url-relevant-slots-changed?
+  (is (rf.story.ui.url-state/url-relevant-slots-changed?
         {:viewport :full}
         {:viewport :tablet})))
 
 (deftest url-relevant-slots-changed-detects-background-change
-  (is (us/url-relevant-slots-changed?
+  (is (rf.story.ui.url-state/url-relevant-slots-changed?
         {:background :light}
         {:background :dark})))
 
 (deftest url-relevant-slots-changed-detects-tag-filter-change
-  (is (us/url-relevant-slots-changed?
+  (is (rf.story.ui.url-state/url-relevant-slots-changed?
         {:tag-filter #{}}
         {:tag-filter #{:tag/a}})))
 
 (deftest url-relevant-slots-changed-detects-active-modes-change
-  (is (us/url-relevant-slots-changed?
+  (is (rf.story.ui.url-state/url-relevant-slots-changed?
         {:active-modes []}
         {:active-modes [:m/dark]})))
 
 (deftest url-relevant-slots-changed-ignores-non-url-slots
   (testing "changes to non-URL slots (hot-reload-tick, fingerprints,
             panel-visibility) do NOT trigger a push"
-    (is (not (us/url-relevant-slots-changed?
+    (is (not (rf.story.ui.url-state/url-relevant-slots-changed?
                {:selected-variant :foo/a :hot-reload-tick 0}
                {:selected-variant :foo/a :hot-reload-tick 99})))
-    (is (not (us/url-relevant-slots-changed?
+    (is (not (rf.story.ui.url-state/url-relevant-slots-changed?
                {:selected-variant :foo/a :fingerprints {}}
                {:selected-variant :foo/a :fingerprints {:foo/a {:dec :h}}})))
-    (is (not (us/url-relevant-slots-changed?
+    (is (not (rf.story.ui.url-state/url-relevant-slots-changed?
                {:selected-variant :foo/a
                 :panel-visibility {:trace true}}
                {:selected-variant :foo/a
@@ -317,34 +317,34 @@
             its cell-overrides slice and MUST trigger a push so the
             live address bar round-trips the override (the share popover
             that used to own override serialisation was retired)"
-    (is (us/url-relevant-slots-changed?
+    (is (rf.story.ui.url-state/url-relevant-slots-changed?
           {:selected-variant :foo/a :cell-overrides {}}
           {:selected-variant :foo/a :cell-overrides {:foo/a {:x 1}}}))
-    (is (us/url-relevant-slots-changed?
+    (is (rf.story.ui.url-state/url-relevant-slots-changed?
           {:selected-variant :foo/a :cell-overrides {:foo/a {:x 1}}}
           {:selected-variant :foo/a :cell-overrides {:foo/a {:x 2}}}))))
 
 (deftest url-relevant-slots-changed-ignores-unfocused-overrides-change
   (testing "rf2-5fyo3 — overrides on a NON-focused variant stay off the
             URL (the URL carries only the focused variant's overrides)"
-    (is (not (us/url-relevant-slots-changed?
+    (is (not (rf.story.ui.url-state/url-relevant-slots-changed?
                {:selected-variant :foo/a :cell-overrides {:foo/b {:x 1}}}
                {:selected-variant :foo/a :cell-overrides {:foo/b {:x 2}}})))
     (testing "no focused variant — overrides edits never push"
-      (is (not (us/url-relevant-slots-changed?
+      (is (not (rf.story.ui.url-state/url-relevant-slots-changed?
                  {:selected-variant nil :cell-overrides {}}
                  {:selected-variant nil :cell-overrides {:foo/a {:x 1}}}))))))
 
 ;; ---- apply-parsed-to-state ----------------------------------------------
 
 (deftest apply-parsed-variant-only
-  (let [out (us/apply-parsed-to-state
+  (let [out (rf.story.ui.url-state/apply-parsed-to-state
               {} {:variant-id :foo/bar} {})]
     (is (= :foo/bar (:selected-variant out)))
     (is (nil? (:selected-workspace out)))))
 
 (deftest apply-parsed-workspace-only
-  (let [out (us/apply-parsed-to-state
+  (let [out (rf.story.ui.url-state/apply-parsed-to-state
               {} {:workspace-id :foo/grid} {})]
     (is (= :foo/grid (:selected-workspace out)))
     (is (nil? (:selected-variant out)))))
@@ -353,7 +353,7 @@
   (testing "rf2-hscut — variant click clears :selected-workspace. When the
             URL carries BOTH (a teammate crafted a URL or a stale
             bookmark), variant wins."
-    (let [out (us/apply-parsed-to-state
+    (let [out (rf.story.ui.url-state/apply-parsed-to-state
                 {} {:variant-id   :foo/bar
                     :workspace-id :foo/grid}
                 {})]
@@ -362,7 +362,7 @@
 
 (deftest apply-parsed-validators-drop-unknown-variant
   (testing "unknown variant id is dropped (stale URL degrades, not crashes)"
-    (let [out (us/apply-parsed-to-state
+    (let [out (rf.story.ui.url-state/apply-parsed-to-state
                 {:selected-variant nil}
                 {:variant-id :ghost/x}
                 {:variant? (fn [vid] (= vid :foo/bar))})]
@@ -370,38 +370,38 @@
 
 (deftest apply-parsed-validators-drop-unknown-workspace
   (testing "unknown workspace id is dropped"
-    (let [out (us/apply-parsed-to-state
+    (let [out (rf.story.ui.url-state/apply-parsed-to-state
                 {} {:workspace-id :ghost/grid}
                 {:workspace? (fn [_] false)})]
       (is (nil? (:selected-workspace out))))))
 
 (deftest apply-parsed-validators-drop-unknown-viewport
   (testing "unknown viewport preset is dropped — chrome falls back to default"
-    (let [out (us/apply-parsed-to-state
+    (let [out (rf.story.ui.url-state/apply-parsed-to-state
                 {} {:viewport :nonsense}
                 {:viewport? (fn [v] (= v :tablet))})]
       (is (nil? (:viewport out))))))
 
 (deftest apply-parsed-mode-tab-keyed-on-variant
   (testing "mode-tab only applies when a valid variant is also present"
-    (let [out (us/apply-parsed-to-state
+    (let [out (rf.story.ui.url-state/apply-parsed-to-state
                 {} {:variant-id :foo/bar :mode-tab :docs} {})]
       (is (= :docs (get-in out [:active-mode-tab :foo/bar]))))))
 
 (deftest apply-parsed-tag-filter-set
-  (let [out (us/apply-parsed-to-state
+  (let [out (rf.story.ui.url-state/apply-parsed-to-state
               {} {:tag-filter #{:tag/a :tag/b}} {})]
     (is (= #{:tag/a :tag/b} (:tag-filter out)))))
 
 (deftest apply-parsed-substrate
-  (let [out (us/apply-parsed-to-state
+  (let [out (rf.story.ui.url-state/apply-parsed-to-state
               {} {:substrate :uix} {})]
     (is (= :uix (:substrate out)))))
 
 ;; ---- rf2-dxz4sg: substrate authoritative-clear --------------------------
 ;;
 ;; The build side omits `substrate=` to encode the `:reagent` default
-;; (`share/build-params` emits it only for a non-default substrate). So
+;; (`rf.story.share/build-params` emits it only for a non-default substrate). So
 ;; an omitted/nil parsed substrate MUST hydrate as `:reagent`, not preserve
 ;; the recipient's stale in-memory `:uix`. This mirrors the
 ;; authoritative-clear discipline the other URL-owned chrome slots already
@@ -417,7 +417,7 @@
           empty-parsed {:variant-id nil :workspace-id nil :mode-tab nil
                         :active-modes nil :viewport nil :background nil
                         :tag-filter nil :cell-overrides nil :substrate nil}
-          out          (us/apply-parsed-to-state stale empty-parsed {})]
+          out          (rf.story.ui.url-state/apply-parsed-to-state stale empty-parsed {})]
       (is (= :reagent (:substrate out))
           "omitted substrate= hydrates as the :reagent default, not stale :uix"))))
 
@@ -428,10 +428,10 @@
             sender omitted it precisely to mean `:reagent`). The recipient
             must render the default `:reagent`, not their stale `:uix`."
     (let [recipient-local {:substrate :uix}
-          ;; share/parse-params of just ?variant=story.counter/loaded —
+          ;; rf.story.share/parse-params of just ?variant=story.counter/loaded —
           ;; substrate parses absent as nil.
           shared          {:variant-id :story.counter/loaded :substrate nil}
-          out             (us/apply-parsed-to-state recipient-local shared {})]
+          out             (rf.story.ui.url-state/apply-parsed-to-state recipient-local shared {})]
       (is (= :story.counter/loaded (:selected-variant out)))
       (is (= :reagent (:substrate out))
           "recipient's stale :uix is cleared to the :reagent default"))))
@@ -441,10 +441,10 @@
             that substrate (the fix only changes omitted/invalid handling).
             With a :substrate? validator that registers :uix it is kept; with
             no validator any present id is accepted (registry unreachable)."
-    (let [with-validator (us/apply-parsed-to-state
+    (let [with-validator (rf.story.ui.url-state/apply-parsed-to-state
                            {:substrate :reagent} {:substrate :uix}
                            {:substrate? #{:reagent :uix}})
-          no-validator   (us/apply-parsed-to-state
+          no-validator   (rf.story.ui.url-state/apply-parsed-to-state
                            {:substrate :reagent} {:substrate :custom} {})]
       (is (= :uix (:substrate with-validator))
           "registered non-default substrate is kept")
@@ -457,7 +457,7 @@
             preserving the prior local substrate, so a stale URL can't pin a
             substrate the host app never registered."
     (let [stale {:substrate :uix}
-          out   (us/apply-parsed-to-state
+          out   (rf.story.ui.url-state/apply-parsed-to-state
                   stale {:substrate :ghost-substrate}
                   {:substrate? #{:reagent :uix}})]
       (is (= :reagent (:substrate out))
@@ -471,7 +471,7 @@
             restores the same effective args, not just the selection.
             (Reproduces the bead's verification: previously this
             destructure dropped :cell-overrides entirely.)"
-    (let [out (us/apply-parsed-to-state
+    (let [out (rf.story.ui.url-state/apply-parsed-to-state
                 {} {:variant-id     :story.foo/bar
                     :cell-overrides {:label "Hi"}} {})]
       (is (= :story.foo/bar (:selected-variant out)))
@@ -482,7 +482,7 @@
   (testing "rf2-j0hwf — overrides are variant-scoped: when the variant id
             is rejected by the validator (stale URL) the overrides are
             not installed (no orphan slice under an unfocused variant)"
-    (let [out (us/apply-parsed-to-state
+    (let [out (rf.story.ui.url-state/apply-parsed-to-state
                 {} {:variant-id     :ghost/x
                     :cell-overrides {:label "Hi"}}
                 {:variant? (fn [vid] (= vid :foo/bar))})]
@@ -493,7 +493,7 @@
 (deftest apply-parsed-overrides-ignored-without-variant
   (testing "rf2-j0hwf — overrides without a variant id never install
             (the URL carries only the focused variant's slice)"
-    (let [out (us/apply-parsed-to-state
+    (let [out (rf.story.ui.url-state/apply-parsed-to-state
                 {} {:cell-overrides {:label "Hi"}} {})]
       (is (nil? (:selected-variant out)))
       (is (empty? (:cell-overrides out))))))
@@ -505,8 +505,8 @@
             :cell-overrides is the bare slice, not the side-table)"
     (let [shell  {:selected-variant :foo/bar
                   :cell-overrides   {:foo/bar {:label "Save, continue" :n 3}}}
-          proj   (us/params-from-state shell)
-          out    (us/apply-parsed-to-state {} proj {})]
+          proj   (rf.story.ui.url-state/params-from-state shell)
+          out    (rf.story.ui.url-state/apply-parsed-to-state {} proj {})]
       (is (= {:label "Save, continue" :n 3}
              (get-in out [:cell-overrides :foo/bar]))))))
 
@@ -522,7 +522,7 @@
     (let [stale {:selected-variant :story.foo/bar
                  :cell-overrides   {:story.foo/bar {:label "stale edit"}}}
           ;; parsed URL: same variant, NO :cell-overrides slice.
-          out   (us/apply-parsed-to-state stale {:variant-id :story.foo/bar} {})]
+          out   (rf.story.ui.url-state/apply-parsed-to-state stale {:variant-id :story.foo/bar} {})]
       (is (= :story.foo/bar (:selected-variant out)))
       (is (nil? (get-in out [:cell-overrides :story.foo/bar]))
           "the focused variant's stale overrides are cleared — URL wins"))))
@@ -533,7 +533,7 @@
             equals the URL payload exactly"
     (let [stale {:selected-variant :story.foo/bar
                  :cell-overrides   {:story.foo/bar {:label "stale" :keep "old"}}}
-          out   (us/apply-parsed-to-state
+          out   (rf.story.ui.url-state/apply-parsed-to-state
                   stale {:variant-id     :story.foo/bar
                          :cell-overrides {:label "fresh"}} {})]
       (is (= {:label "fresh"} (get-in out [:cell-overrides :story.foo/bar]))
@@ -546,7 +546,7 @@
     (let [stale {:selected-variant :story.foo/bar
                  :cell-overrides   {:story.foo/bar   {:label "stale"}
                                     :story.other/baz {:n 7}}}
-          out   (us/apply-parsed-to-state stale {:variant-id :story.foo/bar} {})]
+          out   (rf.story.ui.url-state/apply-parsed-to-state stale {:variant-id :story.foo/bar} {})]
       (is (nil? (get-in out [:cell-overrides :story.foo/bar]))
           "the focused variant's slice is cleared")
       (is (= {:n 7} (get-in out [:cell-overrides :story.other/baz]))
@@ -563,9 +563,9 @@
                        :cell-overrides   {:foo/bar {:label "edited"}}}
           ;; 2. a share link / bookmark captured BEFORE the edit: same variant,
           ;;    no overrides. params-from-state of a no-override shell yields no slice.
-          shared-proj (us/params-from-state {:selected-variant :foo/bar})
+          shared-proj (rf.story.ui.url-state/params-from-state {:selected-variant :foo/bar})
           ;; 3. navigating to that URL must clear the in-memory edit.
-          out         (us/apply-parsed-to-state edited shared-proj {})]
+          out         (rf.story.ui.url-state/apply-parsed-to-state edited shared-proj {})]
       (is (= :foo/bar (:selected-variant out)))
       (is (nil? (get-in out [:cell-overrides :foo/bar]))
           "navigating to the override-free shared URL clears the stale edit —
@@ -588,7 +588,7 @@
             survive."
     (let [stale {:selected-variant :story.foo/bar
                  :active-mode-tab  {:story.foo/bar :docs}}
-          out   (us/apply-parsed-to-state stale {:variant-id :story.foo/bar} {})]
+          out   (rf.story.ui.url-state/apply-parsed-to-state stale {:variant-id :story.foo/bar} {})]
       (is (= :story.foo/bar (:selected-variant out)))
       (is (nil? (get-in out [:active-mode-tab :story.foo/bar]))
           "the stale entry is dissoc'd, not left at :docs — the reader's
@@ -600,7 +600,7 @@
             test above"
     (let [stale {:selected-variant :story.foo/bar
                  :active-mode-tab  {:story.foo/bar :test}}
-          out   (us/apply-parsed-to-state
+          out   (rf.story.ui.url-state/apply-parsed-to-state
                   stale {:variant-id :story.foo/bar :mode-tab :docs} {})]
       (is (= :docs (get-in out [:active-mode-tab :story.foo/bar]))))))
 
@@ -611,7 +611,7 @@
     (let [stale {:selected-variant :story.foo/bar
                  :active-mode-tab  {:story.foo/bar   :docs
                                     :story.other/baz :test}}
-          out   (us/apply-parsed-to-state stale {:variant-id :story.foo/bar} {})]
+          out   (rf.story.ui.url-state/apply-parsed-to-state stale {:variant-id :story.foo/bar} {})]
       (is (nil? (get-in out [:active-mode-tab :story.foo/bar]))
           "the focused variant's stale mode-tab is cleared")
       (is (= :test (get-in out [:active-mode-tab :story.other/baz]))
@@ -625,7 +625,7 @@
             rf2-fkmnh slots below, this is not an unconditional :always
             write)"
     (let [stale {:active-mode-tab {:story.other/baz :test}}
-          out   (us/apply-parsed-to-state stale {} {})]
+          out   (rf.story.ui.url-state/apply-parsed-to-state stale {} {})]
       (is (nil? (:selected-variant out)))
       (is (= :test (get-in out [:active-mode-tab :story.other/baz]))
           "no variant kept -> the mode-tab map is untouched"))))
@@ -637,14 +637,14 @@
             history entry — the address bar has reverted to no mode-tab=,
             so hydrating it must revert the canvas's active tab too"
     (let [;; History entry 1: variant selected, default (:dev) tab — no
-          ;; mode-tab= param, matching share/parse-params' shape for it.
+          ;; mode-tab= param, matching rf.story.share/parse-params' shape for it.
           entry-1 {:variant-id :story.foo/bar}
           ;; The Test/Docs clicks pushed mode-tab=test then mode-tab=docs;
           ;; simulate the resulting stale in-memory state just before
           ;; Back/Back lands on entry-1 again.
           stale   {:selected-variant :story.foo/bar
                    :active-mode-tab  {:story.foo/bar :docs}}
-          out     (us/apply-parsed-to-state stale entry-1 {})]
+          out     (rf.story.ui.url-state/apply-parsed-to-state stale entry-1 {})]
       (is (= :story.foo/bar (:selected-variant out)))
       (is (nil? (get-in out [:active-mode-tab :story.foo/bar]))
           "Back/Back to the mode-tab-less entry reverts the stale :docs —
@@ -658,7 +658,7 @@
             restore the DEFAULT (no modes) view for the recipient, not keep
             their localStorage-seeded modes."
     (let [stale {:active-modes [:m/dark :m/grid]}
-          out   (us/apply-parsed-to-state stale {:variant-id :foo/bar} {})]
+          out   (rf.story.ui.url-state/apply-parsed-to-state stale {:variant-id :foo/bar} {})]
       (is (= [] (:active-modes out))
           "omitted modes= clears active-modes to the empty default"))))
 
@@ -666,14 +666,14 @@
   (testing "rf2-fkmnh — a URL that DOES carry modes= overwrites stale modes
             (authoritative, not a merge)"
     (let [stale {:active-modes [:m/light]}
-          out   (us/apply-parsed-to-state
+          out   (rf.story.ui.url-state/apply-parsed-to-state
                   stale {:variant-id :foo/bar :active-modes [:m/dark]} {})]
       (is (= [:m/dark] (:active-modes out))))))
 
 (deftest apply-parsed-clears-tag-filter-when-url-omits-it
   (testing "rf2-fkmnh — omitted tag-filter= clears `:tag-filter` to #{}"
     (let [stale {:tag-filter #{:tag/a :tag/b}}
-          out   (us/apply-parsed-to-state stale {:variant-id :foo/bar} {})]
+          out   (rf.story.ui.url-state/apply-parsed-to-state stale {:variant-id :foo/bar} {})]
       (is (= #{} (:tag-filter out))
           "omitted tag-filter= clears to the empty set default"))))
 
@@ -681,14 +681,14 @@
   (testing "rf2-fkmnh — omitted viewport= clears `:viewport` to nil so the
             chrome falls back to the :full default"
     (let [stale {:viewport :tablet}
-          out   (us/apply-parsed-to-state stale {:variant-id :foo/bar} {})]
+          out   (rf.story.ui.url-state/apply-parsed-to-state stale {:variant-id :foo/bar} {})]
       (is (nil? (:viewport out))
           "omitted viewport= clears to nil (chrome resolves to :full)"))))
 
 (deftest apply-parsed-clears-background-when-url-omits-it
   (testing "rf2-fkmnh — omitted background= clears `:background` to nil"
     (let [stale {:background :dark}
-          out   (us/apply-parsed-to-state stale {:variant-id :foo/bar} {})]
+          out   (rf.story.ui.url-state/apply-parsed-to-state stale {:variant-id :foo/bar} {})]
       (is (nil? (:background out))
           "omitted background= clears to nil (chrome resolves to default)"))))
 
@@ -697,7 +697,7 @@
             validator) clears the slot rather than preserving the stale
             in-memory value, so a poisoned URL still degrades to default"
     (let [stale {:viewport :tablet}
-          out   (us/apply-parsed-to-state
+          out   (rf.story.ui.url-state/apply-parsed-to-state
                   stale {:viewport :nonsense}
                   {:viewport? (fn [v] (= v :phone))})]
       (is (nil? (:viewport out))
@@ -706,7 +706,7 @@
 (deftest apply-parsed-clears-invalid-background-rather-than-keeping-stale
   (testing "rf2-fkmnh — a present-but-INVALID background clears the slot"
     (let [stale {:background :dark}
-          out   (us/apply-parsed-to-state
+          out   (rf.story.ui.url-state/apply-parsed-to-state
                   stale {:background :nonsense}
                   {:background? (fn [b] (= b :light))})]
       (is (nil? (:background out))))))
@@ -723,11 +723,11 @@
                  :background       :dark
                  :tag-filter       #{:tag/a}
                  :substrate        :uix}
-          ;; the shape share/parse-params produces for an empty getter:
+          ;; the shape rf.story.share/parse-params produces for an empty getter:
           empty-parsed {:variant-id nil :workspace-id nil :mode-tab nil
                         :active-modes nil :viewport nil :background nil
                         :tag-filter nil :cell-overrides nil :substrate nil}
-          out   (us/apply-parsed-to-state stale empty-parsed {})]
+          out   (rf.story.ui.url-state/apply-parsed-to-state stale empty-parsed {})]
       (is (nil? (:selected-variant out)))
       (is (nil? (:selected-workspace out)))
       (is (= [] (:active-modes out)))
@@ -749,9 +749,9 @@
                            :background   :light
                            :tag-filter   #{:tag/legacy}
                            :substrate    :uix}
-          ;; share/parse-params of just ?variant=story.counter/loaded
+          ;; rf.story.share/parse-params of just ?variant=story.counter/loaded
           shared {:variant-id :story.counter/loaded}
-          out    (us/apply-parsed-to-state recipient-local shared {})]
+          out    (rf.story.ui.url-state/apply-parsed-to-state recipient-local shared {})]
       (is (= :story.counter/loaded (:selected-variant out)))
       (is (= [] (:active-modes out)) "recipient's local modes cleared")
       (is (nil? (:viewport out))     "recipient's local viewport cleared")
@@ -771,8 +771,8 @@
                     :background   :dark
                     :tag-filter   #{:tag/a :tag/b}
                     :substrate    :uix}
-          state    (us/apply-parsed-to-state {} parsed {})
-          re-proj  (us/params-from-state state)]
+          state    (rf.story.ui.url-state/apply-parsed-to-state {} parsed {})
+          re-proj  (rf.story.ui.url-state/params-from-state state)]
       (is (= :foo/bar       (:variant-id   re-proj)))
       (is (= :docs          (:mode-tab     re-proj)))
       (is (= [:m/dark]      (:active-modes re-proj)))

--- a/tools/story/test/re_frame/story/ui/view_state_test.cljc
+++ b/tools/story/test/re_frame/story/ui/view_state_test.cljc
@@ -23,7 +23,7 @@
   to a smoke / cljs test; this corpus pins the pure projection only."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
-            [re-frame.story.ui.view-state :as vs]))
+            [re-frame.story.ui.view-state :as rf.story.ui.view-state]))
 
 ;; ---------------------------------------------------------------------------
 ;; Representative compiled-plan + explain fixtures, mirroring the slots the
@@ -73,17 +73,17 @@
 (deftest ladder-is-exactly-three-rungs-strongest-to-weakest
   (testing "the fidelity ladder is exactly the three rungs, ordered
             strongest → weakest — never collapsed to two"
-    (is (= [:real-setup :db-seed :sub-overrides] vs/ladder-order))
-    (is (= 3 (count vs/ladder-rungs)))
+    (is (= [:real-setup :db-seed :sub-overrides] rf.story.ui.view-state/ladder-order))
+    (is (= 3 (count rf.story.ui.view-state/ladder-rungs)))
     (testing "each rung carries a distinct rank + tone + label"
-      (is (= [1 2 3] (mapv :rank vs/ladder-rungs)))
-      (is (= [:real :mid :low] (mapv :tone vs/ladder-rungs)))
-      (is (= 3 (count (distinct (map :label vs/ladder-rungs))))))))
+      (is (= [1 2 3] (mapv :rank rf.story.ui.view-state/ladder-rungs)))
+      (is (= [:real :mid :low] (mapv :tone rf.story.ui.view-state/ladder-rungs)))
+      (is (= 3 (count (distinct (map :label rf.story.ui.view-state/ladder-rungs))))))))
 
 (deftest ladder-marks-active-rungs-keeps-inactive
   (testing "a pure design variant marks ONLY :sub-overrides active, keeps
             the stronger rungs as inactive upgrade targets (never dropped)"
-    (let [ladder (vs/fidelity-ladder design-plan)
+    (let [ladder (rf.story.ui.view-state/fidelity-ladder design-plan)
           by-rung (into {} (map (juxt :rung identity) ladder))]
       (is (= 3 (count ladder)) "all three rungs are always shown")
       (is (true?  (:active? (by-rung :sub-overrides))))
@@ -91,16 +91,16 @@
       (is (false? (:active? (by-rung :db-seed))))))
   (testing "an events-driven variant marks :real-setup active"
     (let [by-rung (into {} (map (juxt :rung identity)
-                                (vs/fidelity-ladder events-plan)))]
+                                (rf.story.ui.view-state/fidelity-ladder events-plan)))]
       (is (true?  (:active? (by-rung :real-setup))))
       (is (false? (:active? (by-rung :sub-overrides))))))
   (testing "a bare variant marks no rung active"
-    (is (every? (complement :active?) (vs/fidelity-ladder bare-plan)))))
+    (is (every? (complement :active?) (rf.story.ui.view-state/fidelity-ladder bare-plan)))))
 
 (deftest sub-overrides-rung-labelled-low-fidelity-never-proof
   (testing "the :sub-overrides rung is labelled lowest-fidelity and as
             proving nothing — the honest reading the surface surfaces"
-    (let [r (first (filter #(= :sub-overrides (:rung %)) vs/ladder-rungs))]
+    (let [r (first (filter #(= :sub-overrides (:rung %)) rf.story.ui.view-state/ladder-rungs))]
       (is (= :low (:tone r)))
       (is (= 3 (:rank r)))
       (is (str/includes? (:note r) "never proof"))
@@ -111,27 +111,27 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest lowest-active-rank-is-the-fidelity-floor
-  (is (= 3 (vs/lowest-active-rank design-plan)))
-  (is (= 1 (vs/lowest-active-rank events-plan)))
+  (is (= 3 (rf.story.ui.view-state/lowest-active-rank design-plan)))
+  (is (= 1 (rf.story.ui.view-state/lowest-active-rank events-plan)))
   (testing "a hybrid floors at its WEAKEST active rung"
-    (is (= 3 (vs/lowest-active-rank
+    (is (= 3 (rf.story.ui.view-state/lowest-active-rank
                {:world {:fidelity #{:real-setup :sub-overrides}}}))))
   (testing "a bare variant has no floor"
-    (is (nil? (vs/lowest-active-rank bare-plan)))))
+    (is (nil? (rf.story.ui.view-state/lowest-active-rank bare-plan)))))
 
 (deftest upgrade-targets-are-the-stronger-rungs
   (testing "a pure sub-override variant can upgrade to db-seed + real-setup"
     (is (= [:real-setup :db-seed]
-           (mapv :rung (vs/upgrade-targets design-plan)))))
+           (mapv :rung (rf.story.ui.view-state/upgrade-targets design-plan)))))
   (testing "a real-setup variant has no stronger rung to upgrade to"
-    (is (empty? (vs/upgrade-targets events-plan))))
+    (is (empty? (rf.story.ui.view-state/upgrade-targets events-plan))))
   (testing "a bare variant has nothing to upgrade FROM"
-    (is (empty? (vs/upgrade-targets bare-plan)))))
+    (is (empty? (rf.story.ui.view-state/upgrade-targets bare-plan)))))
 
 (deftest upgrade-snippet-keeps-the-artifact-a-variant
   (testing "the upgrade scaffold is a reg-variant :extends-ing the source
             — same artifact kind, drops :sub-overrides, adds the rung slot"
-    (let [snip (vs/upgrade-snippet :story.login/error :real-setup)]
+    (let [snip (rf.story.ui.view-state/upgrade-snippet :story.login/error :real-setup)]
       (is (str/includes? snip "story/reg-variant")
           "stays a reg-variant — artifact kind unchanged")
       (is (str/includes? snip ":extends :story.login/error")
@@ -140,11 +140,11 @@
           "adds the :real-setup authoring slot")
       (is (str/includes? snip "drop :sub-overrides"))))
   (testing "the db-seed upgrade scaffolds the :db-seed slot"
-    (is (str/includes? (vs/upgrade-snippet :story.login/error :db-seed)
+    (is (str/includes? (rf.story.ui.view-state/upgrade-snippet :story.login/error :db-seed)
                        ":db-seed")))
   (testing "the derived upgraded id sits in the source's namespace"
     (is (= :story.login/error-upgraded
-           (vs/upgraded-variant-id :story.login/error)))))
+           (rf.story.ui.view-state/upgraded-variant-id :story.login/error)))))
 
 ;; ---------------------------------------------------------------------------
 ;; provenance summaries — source shown
@@ -153,28 +153,28 @@
 (deftest setup-summary-shows-event-provenance
   (testing "the setup summary counts setup + script steps and names the
             dispatched event ids — where the state came from"
-    (let [s (vs/setup-summary events-plan)]
+    (let [s (rf.story.ui.view-state/setup-summary events-plan)]
       (is (true? (:present? s)))
       (is (= 2 (:setup-count s)))
       (is (= 1 (:script-count s)))
       (is (= [:cart/add :cart/add :cart/checkout] (:events s)))
       (is (= :events (:source s)))))
   (testing "a design variant has no setup provenance"
-    (is (false? (:present? (vs/setup-summary design-plan))))))
+    (is (false? (:present? (rf.story.ui.view-state/setup-summary design-plan))))))
 
 (deftest network-summary-shows-route-provenance
-  (let [n (vs/network-summary events-explain)]
+  (let [n (rf.story.ui.view-state/network-summary events-explain)]
     (is (true? (:present? n)))
     (is (= 1 (:route-count n)))
     (is (= [[:get "/api/cart"]] (:routes n)))
     (is (= {:rf.http/managed :rf.http/managed-test-stub} (:lowered-to n))))
   (testing "no routes → absent"
-    (is (false? (:present? (vs/network-summary design-explain))))))
+    (is (false? (:present? (rf.story.ui.view-state/network-summary design-explain))))))
 
 (deftest fx-overrides-summary-excludes-managed-http
   (testing "the fx-override summary lists non-HTTP fx overrides, EXCLUDING
             :rf.http/managed (the Network summary owns that route channel)"
-    (let [f (vs/fx-overrides-summary events-plan)]
+    (let [f (rf.story.ui.view-state/fx-overrides-summary events-plan)]
       (is (true? (:present? f)))
       (is (= 1 (:fx-count f)))
       (is (= [:analytics/track] (:fx-ids f)))
@@ -183,14 +183,14 @@
 (deftest override-rows-show-exact-query-vectors
   (testing "the override rows name the EXACT query vectors pinned + the
             pinned values, plus the plan-time output-schema validation"
-    (let [o (vs/override-rows design-explain)]
+    (let [o (rf.story.ui.view-state/override-rows design-explain)]
       (is (true? (:present? o)))
       (is (= 2 (count (:rows o))))
       (is (= #{[:login/state] [:login/msg]}
              (set (map :query-v (:rows o)))))
       (is (= :ok (get-in o [:validation :status])))))
   (testing "no overrides → absent"
-    (is (false? (:present? (vs/override-rows events-explain))))))
+    (is (false? (:present? (rf.story.ui.view-state/override-rows events-explain))))))
 
 ;; ---------------------------------------------------------------------------
 ;; live :where :sub-override schema-fail projection (the honesty surface)
@@ -208,12 +208,12 @@
                   {:op-type :error :operation :rf.error/schema-validation-failure
                    :id 3 :time 300 :tags {:where :app-db}}
                   {:op-type :event :operation :some/event :id 4 :time 400 :tags {}}]
-          fails (vs/sub-override-failures events)]
+          fails (rf.story.ui.view-state/sub-override-failures events)]
       (is (= 1 (count fails)) "only the :sub-override failure")
       (is (= :sub-override (:where (first fails))))
       (is (= :login/state (:failing-id (first fails))))))
   (testing "no failures → empty"
-    (is (empty? (vs/sub-override-failures [])))))
+    (is (empty? (rf.story.ui.view-state/sub-override-failures [])))))
 
 ;; ---------------------------------------------------------------------------
 ;; the composed model + error trapping
@@ -222,20 +222,20 @@
 (deftest view-state-model-composes-the-full-surface
   (testing "the composed model carries the ladder, provenance, overrides,
             failures, upgrade targets, and the low-fidelity flag"
-    (let [m (vs/view-state-model design-plan design-explain [])]
+    (let [m (rf.story.ui.view-state/view-state-model design-plan design-explain [])]
       (is (= 3 (count (:ladder m))))
       (is (= 3 (:lowest-rank m)))
       (is (true? (:low-fidelity? m)) "sub-overrides is the floor")
       (is (true? (get-in m [:overrides :present?])))
       (is (= [:real-setup :db-seed] (mapv :rung (:upgrade-targets m))))))
   (testing "an events-driven plan is NOT low-fidelity and has no upgrade"
-    (let [m (vs/view-state-model events-plan events-explain [])]
+    (let [m (rf.story.ui.view-state/view-state-model events-plan events-explain [])]
       (is (false? (:low-fidelity? m)))
       (is (empty? (:upgrade-targets m)))
       (is (true? (get-in m [:network :present?]))))))
 
 (deftest compile-model-traps-unknown-variant
   (testing "an unregistered keyword target surfaces :error, not a throw"
-    (let [m (vs/compile-model :story.nope/missing [])]
+    (let [m (rf.story.ui.view-state/compile-model :story.nope/missing [])]
       (is (string? (:error m)))
       (is (not (str/blank? (:error m)))))))

--- a/tools/story/test/re_frame/story/ui/viewport_switcher_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/viewport_switcher_cljs_test.cljc
@@ -12,20 +12,20 @@
   - The chip emits `aria-haspopup` + `aria-expanded` (NOT
     `aria-pressed`) so the toolbar reset assertion is not tripped."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story :as story]
-            #?@(:cljs [[re-frame.story.ui.state :as state]
-                       [re-frame.story.ui.viewport-switcher :as vs]
-                       [re-frame.story.viewport :as viewport]])))
+            [re-frame.story :as rf.story]
+            #?@(:cljs [[re-frame.story.ui.state :as rf.story.ui.state]
+                       [re-frame.story.ui.viewport-switcher :as rf.story.ui.viewport-switcher]
+                       [re-frame.story.viewport :as rf.story.viewport]])))
 
 #?(:cljs
    (defn reset-all! []
-     (story/clear-all!)
-     (state/reset-shell-state!)
-     (vs/close!)
+     (rf.story/clear-all!)
+     (rf.story.ui.state/reset-shell-state!)
+     (rf.story.ui.viewport-switcher/close!)
      (when (and (exists? js/window) (.-localStorage js/window))
-       (try (.removeItem (.-localStorage js/window) viewport/ls-key)
+       (try (.removeItem (.-localStorage js/window) rf.story.viewport/ls-key)
             (catch :default _ nil)))
-     (story/install-canonical-vocabulary!)))
+     (rf.story/install-canonical-vocabulary!)))
 
 #?(:cljs
    (use-fixtures :each (fn [t] (reset-all!) (t))))
@@ -35,67 +35,67 @@
 #?(:cljs
    (deftest cljs-select-writes-shell-state
      (testing "select! lands the normalised choice on shell-state-atom"
-       (vs/select! :tablet)
-       (is (= :tablet (:viewport (state/get-state))))
-       (vs/select! :mobile-portrait)
-       (is (= :mobile-portrait (:viewport (state/get-state)))))))
+       (rf.story.ui.viewport-switcher/select! :tablet)
+       (is (= :tablet (:viewport (rf.story.ui.state/get-state))))
+       (rf.story.ui.viewport-switcher/select! :mobile-portrait)
+       (is (= :mobile-portrait (:viewport (rf.story.ui.state/get-state)))))))
 
 #?(:cljs
    (deftest cljs-select-custom-writes-map
      (testing "a custom map persists as a slim {:width :height}"
-       (vs/select! {:width 800 :height 600})
-       (is (= {:width 800 :height 600} (:viewport (state/get-state)))))))
+       (rf.story.ui.viewport-switcher/select! {:width 800 :height 600})
+       (is (= {:width 800 :height 600} (:viewport (rf.story.ui.state/get-state)))))))
 
 #?(:cljs
    (deftest cljs-select-drops-unknown
      (testing "an unknown preset coerces to nil — slot is cleared"
-       (vs/select! :tablet)
-       (is (= :tablet (:viewport (state/get-state))))
-       (vs/select! :phablet)
-       (is (nil? (:viewport (state/get-state)))))))
+       (rf.story.ui.viewport-switcher/select! :tablet)
+       (is (= :tablet (:viewport (rf.story.ui.state/get-state))))
+       (rf.story.ui.viewport-switcher/select! :phablet)
+       (is (nil? (:viewport (rf.story.ui.state/get-state)))))))
 
 ;; ---- per-story override resolution --------------------------------------
 
 #?(:cljs
    (deftest cljs-effective-viewport-respects-variant-override
      (testing "rf2-zll4h: per-variant :viewport body slot beats toolbar"
-       (story/reg-story* :story.vp-override
+       (rf.story/reg-story* :story.vp-override
          {:doc "viewport override fixture" :component :ignored
           :viewport :desktop})
-       (story/reg-variant* :story.vp-override/v
+       (rf.story/reg-variant* :story.vp-override/v
          {:doc "child" :viewport :mobile-portrait})
-       (state/swap-state! assoc :viewport :tablet)
-       (state/swap-state! assoc :selected-variant :story.vp-override/v)
-       (let [eff (vs/effective-viewport)]
+       (rf.story.ui.state/swap-state! assoc :viewport :tablet)
+       (rf.story.ui.state/swap-state! assoc :selected-variant :story.vp-override/v)
+       (let [eff (rf.story.ui.viewport-switcher/effective-viewport)]
          (is (= "Mobile portrait" (:label eff))
              "variant body's :viewport (:mobile-portrait) wins over toolbar (:tablet)"))
-       (is (= :mobile-portrait (vs/effective-id))))))
+       (is (= :mobile-portrait (rf.story.ui.viewport-switcher/effective-id))))))
 
 #?(:cljs
    (deftest cljs-effective-viewport-falls-through-to-story
      (testing "variant has no :viewport → parent story's :viewport applies"
-       (story/reg-story* :story.vp-story-only
+       (rf.story/reg-story* :story.vp-story-only
          {:doc "story-level override only" :component :ignored
           :viewport :desktop})
-       (story/reg-variant* :story.vp-story-only/v
+       (rf.story/reg-variant* :story.vp-story-only/v
          {:doc "child"})
-       (state/swap-state! assoc :viewport :tablet)
-       (state/swap-state! assoc :selected-variant :story.vp-story-only/v)
-       (let [eff (vs/effective-viewport)]
+       (rf.story.ui.state/swap-state! assoc :viewport :tablet)
+       (rf.story.ui.state/swap-state! assoc :selected-variant :story.vp-story-only/v)
+       (let [eff (rf.story.ui.viewport-switcher/effective-viewport)]
          (is (= "Desktop" (:label eff))))
-       (is (= :desktop (vs/effective-id))))))
+       (is (= :desktop (rf.story.ui.viewport-switcher/effective-id))))))
 
 #?(:cljs
    (deftest cljs-effective-viewport-falls-through-to-toolbar
      (testing "no override → toolbar selection takes effect"
-       (state/swap-state! assoc :viewport :tablet)
-       (let [eff (vs/effective-viewport)]
+       (rf.story.ui.state/swap-state! assoc :viewport :tablet)
+       (let [eff (rf.story.ui.viewport-switcher/effective-viewport)]
          (is (= "Tablet" (:label eff)))))))
 
 #?(:cljs
    (deftest cljs-effective-viewport-default-is-full
      (testing "no override + no selection → :full"
-       (let [eff (vs/effective-viewport)]
+       (let [eff (rf.story.ui.viewport-switcher/effective-viewport)]
          (is (= "Full" (:label eff)))
          (is (nil? (:width eff)))))))
 
@@ -104,7 +104,7 @@
 #?(:cljs
    (deftest cljs-chip-renders-without-throwing
      (testing "chip-when-enabled returns a hiccup tree (no exceptions)"
-       (let [hiccup (vs/chip-when-enabled)]
+       (let [hiccup (rf.story.ui.viewport-switcher/chip-when-enabled)]
          (is (some? hiccup))))))
 
 #?(:cljs
@@ -113,7 +113,7 @@
                by default. The toolbar reset assertion in
                story_feature_load counts [aria-pressed='true'] post-reset
                and demands count === 0."
-       (let [hiccup (vs/chip)]
+       (let [hiccup (rf.story.ui.viewport-switcher/chip)]
          ;; The chip render returns [:span ... [:button {...}]]; the
          ;; button's attribute map is the second element of the inner
          ;; button vector. Walk the hiccup defensively.
@@ -131,7 +131,7 @@
 #?(:cljs
    (deftest cljs-chip-data-attrs
      (testing "chip carries data-test + data-viewport for browser specs"
-       (let [hiccup (vs/chip)
+       (let [hiccup (rf.story.ui.viewport-switcher/chip)
              flat   (->> (tree-seq coll? seq hiccup)
                          (filter map?))
              attrs  (filter #(= "story-toolbar-viewport"
@@ -151,18 +151,18 @@
    (deftest cljs-hydrate-from-storage-seeds-empty-slot
      (testing "hydrate! seeds the shell slot from persisted localStorage"
        (when (browser?)
-         (viewport/save-to-storage! :tablet)
-         (state/reset-shell-state!)
-         (is (nil? (:viewport (state/get-state))))
-         (vs/hydrate!)
-         (is (= :tablet (:viewport (state/get-state))))))))
+         (rf.story.viewport/save-to-storage! :tablet)
+         (rf.story.ui.state/reset-shell-state!)
+         (is (nil? (:viewport (rf.story.ui.state/get-state))))
+         (rf.story.ui.viewport-switcher/hydrate!)
+         (is (= :tablet (:viewport (rf.story.ui.state/get-state))))))))
 
 #?(:cljs
    (deftest cljs-hydrate-skips-populated-slot
      (testing "hydrate is idempotent — leaves an already-populated slot alone"
        (when (browser?)
-         (viewport/save-to-storage! :tablet)
-         (state/swap-state! assoc :viewport :mobile-portrait)
-         (vs/hydrate!)
-         (is (= :mobile-portrait (:viewport (state/get-state)))
+         (rf.story.viewport/save-to-storage! :tablet)
+         (rf.story.ui.state/swap-state! assoc :viewport :mobile-portrait)
+         (rf.story.ui.viewport-switcher/hydrate!)
+         (is (= :mobile-portrait (:viewport (rf.story.ui.state/get-state)))
              "populated slot was preserved")))))

--- a/tools/story/test/re_frame/story/ui/viewport_toggle_app_db_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/viewport_toggle_app_db_dom_cljs_test.cljs
@@ -8,8 +8,8 @@
 
   The bug is a React RECONCILIATION-identity defect: `shell.cljs`'s
   `framed-canvas` used to pick between TWO DIFFERENT hiccup shapes —
-  `[:div {...} [canvas/canvas]]` when a sized viewport was active, or
-  bare `[canvas/canvas]` otherwise — at the SAME tree position. Toggling
+  `[:div {...} [rf.story.ui.canvas/canvas]]` when a sized viewport was active, or
+  bare `[rf.story.ui.canvas/canvas]` otherwise — at the SAME tree position. Toggling
   `sized?` therefore changed the React element TYPE at that slot, which
   forces React to unmount the old subtree and mount a fresh one — no
   amount of pure hiccup-tree inspection proves whether that actually
@@ -20,15 +20,15 @@
 
   ## Pipeline under test
 
-      mount [shell/framed-canvas] (viewport :full)
+      mount [rf.story.ui.shell/framed-canvas] (viewport :full)
             |
-      canvas/canvas's component-did-mount -> run-if-needed! -> run-variant
+      rf.story.ui.canvas/canvas's component-did-mount -> run-if-needed! -> run-variant
             |  (variant's :setup seed app-db)
             v
       simulate user interaction: dispatch a NON-setup event into the
       variant's frame directly (mirrors 'user increments a counter')
             |
-      vs/select! :tablet  (crosses the :full -> sized boundary)
+      rf.story.ui.viewport-switcher/select! :tablet  (crosses the :full -> sized boundary)
             |
       flushSync a second commit
             v
@@ -44,42 +44,42 @@
             [reagent.core :as r]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as registrar]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.story :as story]
-            [re-frame.story.loaders :as loaders]
-            [re-frame.story.ui.canvas :as canvas]
-            [re-frame.story.ui.shell :as shell]
-            [re-frame.story.ui.state :as state]
-            [re-frame.story.ui.viewport-switcher :as vs]
-            [re-frame.subs :as subs]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.story :as rf.story]
+            [re-frame.story.loaders :as rf.story.loaders]
+            [re-frame.story.ui.canvas :as rf.story.ui.canvas]
+            [re-frame.story.ui.shell :as rf.story.ui.shell]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.ui.viewport-switcher :as rf.story.ui.viewport-switcher]
+            [re-frame.subs :as rf.subs]))
 
 ;; `framed-canvas` is `defn-` in shell.cljs; the established Story-test
 ;; seam for reaching a private fn is the var-quote (e.g.
 ;; `re-frame.story.ui.shell-cljs-test`'s `mount-time-autorun-vid`).
-(def ^:private framed-canvas @#'shell/framed-canvas)
+(def ^:private framed-canvas @#'rf.story.ui.shell/framed-canvas)
 
 ;; ---- fixture --------------------------------------------------------------
 
 (defn- reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! reagent-adapter/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.adapter.reagent/adapter)
        (catch :default _ nil))
   ;; Re-register the framework `:rf/machine` sub after the registrar
   ;; clear (mirrors render-shell-cljs-test's reset-all!).
-  (subs/reg-runtime-sub :rf/machine
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [runtime-db [_ machine-id]]
       (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
-  (canvas/reset-first-rendered!))
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
+  (rf.story.ui.canvas/reset-first-rendered!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -120,10 +120,10 @@
         ;; this test's concern; omitting `:component` keeps `canvas-inner`
         ;; on its `nil? view-id` branch (a harmless placeholder message)
         ;; so only the mechanism under test — `framed-canvas` /
-        ;; `canvas/canvas`'s mount lifecycle — is exercised.
-        (story/reg-variant variant-id
+        ;; `rf.story.ui.canvas/canvas`'s mount lifecycle — is exercised.
+        (rf.story/reg-variant variant-id
           {:setup [[:vp-toggle/set 1]]})
-        (state/swap-state! state/select-variant variant-id)
+        (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant variant-id)
         (let [mount-node (make-mount-node!)
               root       (rdc/create-root mount-node)]
           (try
@@ -155,7 +155,7 @@
             ;; wiping the :n 2 interactive state asserted above.
             (react-dom/flushSync
               (fn []
-                (vs/select! :tablet)
+                (rf.story.ui.viewport-switcher/select! :tablet)
                 (r/flush)))
 
             (is (some? (.querySelector mount-node "[data-test=\"story-canvas-frame-sized\"]"))
@@ -180,11 +180,11 @@
         (rf/reg-event :vp-toggle-rev/inc
           (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
         ;; No `:component` — see the sibling test above for why.
-        (story/reg-variant variant-id
+        (rf.story/reg-variant variant-id
           {:setup [[:vp-toggle-rev/set 1]]})
         ;; Start already on a sized preset.
-        (vs/select! :tablet)
-        (state/swap-state! state/select-variant variant-id)
+        (rf.story.ui.viewport-switcher/select! :tablet)
+        (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant variant-id)
         (let [mount-node (make-mount-node!)
               root       (rdc/create-root mount-node)]
           (try
@@ -199,7 +199,7 @@
 
             (react-dom/flushSync
               (fn []
-                (vs/select! :full)
+                (rf.story.ui.viewport-switcher/select! :full)
                 (r/flush)))
 
             (is (nil? (.querySelector mount-node "[data-test=\"story-canvas-frame-sized\"]"))

--- a/tools/story/test/re_frame/story/ui/workspace_substrate_routing_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/workspace_substrate_routing_cljs_test.cljs
@@ -43,40 +43,40 @@
 
   ## Registry hygiene
 
-  `substrate->render-fn` is a `defonce` atom `story/clear-all!` does not
+  `substrate->render-fn` is a `defonce` atom `rf.story/clear-all!` does not
   touch, so a leaked `:uix` entry would break
   `render_shell_cljs_test`'s `unregistered-substrate-renders-inline-error-cell`,
   whose precondition is that `:uix` is ABSENT. The `:after` fixture dissocs it."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story :as story]
-            [re-frame.story.loaders :as loaders]
-            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
-            [re-frame.story.ui.multi-substrate :as multi-substrate]
-            [re-frame.story.ui.state :as state]
-            [re-frame.story.ui.workspace :as workspace]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.loaders :as rf.story.loaders]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]
+            [re-frame.story.ui.multi-substrate :as rf.story.ui.multi-substrate]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.ui.workspace :as rf.story.ui.workspace]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (declare register-probe-views!)
 
 (defn- reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
-  (loaders/clear-watchers!)
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
-  (multi-substrate/unregister-substrate! :uix)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
+  (rf.story.ui.multi-substrate/unregister-substrate! :uix)
   (register-probe-views!))
 
 (defn- restore-registry! []
-  (multi-substrate/unregister-substrate! :uix))
+  (rf.story.ui.multi-substrate/unregister-substrate! :uix))
 
 (use-fixtures :each {:before reset-all! :after restore-registry!})
 
@@ -94,22 +94,22 @@
 
 (defn- register-probe-views! []
   (rf/reg-view* :views/probe reagent-probe-view)
-  (story/reg-story* :story.workspace-routing {:doc "rf2-r4coe witness story"})
-  (story/reg-variant* :story.workspace-routing/uix-only
+  (rf.story/reg-story* :story.workspace-routing {:doc "rf2-r4coe witness story"})
+  (rf.story/reg-variant* :story.workspace-routing/uix-only
     {:doc        "Declares ONE substrate, and it is not Reagent."
      :component  :views/probe
      :substrates #{:uix}})
-  (story/reg-variant* :story.workspace-routing/reagent-only
+  (rf.story/reg-variant* :story.workspace-routing/reagent-only
     {:doc        "Declares ONE substrate, Reagent — the unchanged baseline."
      :component  :views/probe
      :substrates #{:reagent}})
-  (story/reg-variant* :story.workspace-routing/undeclared
+  (rf.story/reg-variant* :story.workspace-routing/undeclared
     {:doc        "Declares NO substrates — the shell's host substrate decides."
      :component  :views/probe}))
 
 ;; ---- helpers -------------------------------------------------------------
 
-(def ^:private variant-cell-inner @#'workspace/variant-cell-inner)
+(def ^:private variant-cell-inner @#'rf.story.ui.workspace/variant-cell-inner)
 
 (defn- cell-tree
   "Render the workspace cell's inner tree for `variant-id` and expand it to
@@ -117,13 +117,13 @@
   drive — it renders its variant body directly."
   [variant-id]
   (rf/make-frame {:id variant-id})
-  (e2e/expand-tree (variant-cell-inner variant-id)))
+  (rf.story.test-helpers.e2e-multi-frame/expand-tree (variant-cell-inner variant-id)))
 
 (defn- rendered-under-uix? [tree]
-  (some? (e2e/find-by-test-id tree "uix-stub-render")))
+  (some? (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "uix-stub-render")))
 
 (defn- rendered-under-reagent? [tree]
-  (some? (e2e/find-by-test-id tree "reagent-view-render")))
+  (some? (rf.story.test-helpers.e2e-multi-frame/find-by-test-id tree "reagent-view-render")))
 
 ;; ===========================================================================
 ;; THE WITNESS
@@ -136,7 +136,7 @@
             itself, so the tree carried `reagent-view-render` and no uix
             marker at all — the identical bypass rf2-3afns removed from the
             canvas"
-    (story/register-substrate! :uix uix-stub-render)
+    (rf.story/register-substrate! :uix uix-stub-render)
     (let [tree (cell-tree :story.workspace-routing/uix-only)]
       (is (rendered-under-uix? tree)
           "the cell reached the :uix render fn — the registry is ON the
@@ -148,7 +148,7 @@
 (deftest reagent-variants-are-behaviour-unchanged
   (testing "the overwhelmingly common case — a variant declaring
             `:substrates #{:reagent}` — paints exactly as it always did"
-    (story/register-substrate! :uix uix-stub-render)
+    (rf.story/register-substrate! :uix uix-stub-render)
     (let [tree (cell-tree :story.workspace-routing/reagent-only)]
       (is (rendered-under-reagent? tree))
       (is (not (rendered-under-uix? tree))))))
@@ -158,12 +158,12 @@
             behaviour — which is the bead's option (b), already present as
             the FALLBACK inside `canvas/variant-substrate-set`'s resolution
             order rather than as a rival to option (a)"
-    (story/register-substrate! :uix uix-stub-render)
+    (rf.story/register-substrate! :uix uix-stub-render)
     (let [tree (cell-tree :story.workspace-routing/undeclared)]
       (is (rendered-under-reagent? tree))
       (is (not (rendered-under-uix? tree))))))
 
-;; Read diagnostics with `e2e/text-nodes`, never `pr-str` on the tree. The
+;; Read diagnostics with `rf.story.test-helpers.e2e-multi-frame/text-nodes`, never `pr-str` on the tree. The
 ;; cell's expanded tree carries nodes whose printed form recurses without
 ;; bound (`pr-str` on it raises `RangeError: Maximum call stack size
 ;; exceeded`), while the structural walk `text-nodes` and `find-by-test-id`
@@ -175,7 +175,7 @@
             the fix, and the same degradation the canvas gives"
     ;; :uix deliberately NOT registered here.
     (let [tree (cell-tree :story.workspace-routing/uix-only)
-          txt  (e2e/text-nodes tree)]
+          txt  (rf.story.test-helpers.e2e-multi-frame/text-nodes tree)]
       (is (not (rendered-under-reagent? tree))
           "silence was the defect's real cost — Reagent must NOT be painted")
       (is (re-find #"substrate :uix is not registered" txt)))))
@@ -184,8 +184,8 @@
   (testing "routing through the registry must not lose the cell's
             missing-view message — `render-view` owns it now, via
             `reagent-render`, and it reads the same"
-    (story/reg-variant* :story.workspace-routing/no-such-view
+    (rf.story/reg-variant* :story.workspace-routing/no-such-view
       {:doc       "Names a :component nobody registered."
        :component :views/does-not-exist})
-    (let [txt (e2e/text-nodes (cell-tree :story.workspace-routing/no-such-view))]
+    (let [txt (rf.story.test-helpers.e2e-multi-frame/text-nodes (cell-tree :story.workspace-routing/no-such-view))]
       (is (re-find #"is not registered as a view" txt)))))

--- a/tools/story/test/re_frame/story/ui/xray_embed_mount_fail_cleanup_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/xray_embed_mount_fail_cleanup_dom_cljs_test.cljs
@@ -38,26 +38,26 @@
             ["react-dom" :as react-dom]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.story :as story]
-            [re-frame.story.ui.xray-embed :as xray-embed]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.story :as rf.story]
+            [re-frame.story.ui.xray-embed :as rf.story.ui.xray-embed]))
 
 ;; `panel-host-component` is `defn-` in xray_embed.cljs; the established
 ;; Story-test seam for reaching a private fn is the var-quote (e.g.
 ;; `viewport-toggle-app-db-dom-cljs-test`'s `framed-canvas`).
-(def ^:private panel-host-component @#'xray-embed/panel-host-component)
+(def ^:private panel-host-component @#'rf.story.ui.xray-embed/panel-host-component)
 
 ;; ---- fixture ---------------------------------------------------------------
 
 (defn- reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! reagent-adapter/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.adapter.reagent/adapter)
        (catch :default _ nil))
-  (frame/ensure-default-frame!))
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -83,7 +83,7 @@
             the panel-host's lifetime)"
     (if-not (browser?)
       (is true ":node-test — no DOM; :browser-test runs the real assertion")
-      (with-redefs [xray-embed/mount-fn-for
+      (with-redefs [rf.story.ui.xray-embed/mount-fn-for
                     (fn [_pid] (fn [_container] (throw (js/Error. "boom"))))]
         (let [mount-node (make-mount-node!)
               root       (rdc/create-root mount-node)]
@@ -115,7 +115,7 @@
             Xray's own mount internals."
     (if-not (browser?)
       (is true ":node-test — no DOM; :browser-test runs the real assertion")
-      (with-redefs [xray-embed/mount-fn-for
+      (with-redefs [rf.story.ui.xray-embed/mount-fn-for
                     (fn [pid]
                       (case pid
                         :epoch  (fn [_container] (throw (js/Error. "boom")))

--- a/tools/story/test/re_frame/story/view_args_test.cljc
+++ b/tools/story/test/re_frame/story/view_args_test.cljc
@@ -23,9 +23,9 @@
   Pure JVM + CLJS — `view-args.cljc` + `plan.cljc` + both registrars are
   JVM-runnable, so the DEFAULT lookup works under `clojure -M:test`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story.view-args :as view-args]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.registrar       :as framework-registrar]))
+            [re-frame.story.view-args :as rf.story.view-args]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.registrar       :as rf.registrar]))
 
 ;; ---- fixtures ------------------------------------------------------------
 ;;
@@ -36,8 +36,8 @@
 ;; the resolver cache between tests.
 
 (defn reset-fixture [test-fn]
-  (registrar/clear-all!)
-  (framework-registrar/clear-kind! :view)
+  (rf.story.registrar/clear-all!)
+  (rf.registrar/clear-kind! :view)
   (test-fn))
 
 (use-fixtures :each reset-fixture)
@@ -48,25 +48,25 @@
   reads. A `:handler-fn` stub keeps the slot well-formed; the resolver
   only reads the schema slots."
   [view-id metadata]
-  (framework-registrar/register! :view view-id
+  (rf.registrar/register! :view view-id
                                  (assoc metadata :handler-fn (fn [_] nil))))
 
 ;; ---- the key picker (rf2-ayu6n: stale :spec dropped) ---------------------
 
 (deftest view-args-schema-keys-drop-spec
   (testing "the canonical key order is [:rf/props :schema] — :spec is gone"
-    (is (= [:rf/props :schema] view-args/view-args-schema-keys))))
+    (is (= [:rf/props :schema] rf.story.view-args/view-args-schema-keys))))
 
 (deftest view-args-schema-first-match-no-composition
   (testing ":rf/props wins outright over :schema (no composition)"
     (is (= [:map [:a :string]]
-           (view-args/view-args-schema {:rf/props [:map [:a :string]]
+           (rf.story.view-args/view-args-schema {:rf/props [:map [:a :string]]
                                         :schema   [:map [:b :string]]}))))
   (testing ":schema is the fallback location when :rf/props is absent"
     (is (= [:map [:b :string]]
-           (view-args/view-args-schema {:schema [:map [:b :string]]}))))
+           (rf.story.view-args/view-args-schema {:schema [:map [:b :string]]}))))
   (testing "a view carrying ONLY :spec resolves NO schema (dead post-M-54)"
-    (is (nil? (view-args/view-args-schema {:spec [:map [:c :string]]})))))
+    (is (nil? (rf.story.view-args/view-args-schema {:spec [:map [:c :string]]})))))
 
 ;; ---- the compiled-plan resolver (PRODUCTION path, DEFAULT lookup) --------
 
@@ -75,45 +75,45 @@
             the compiled plan via the DEFAULT side-table lookup"
     (let [schema [:map [:label :string] [:count :int]]]
       (reg-view-meta! :views/widget {:rf/props schema})
-      (registrar/reg-variant* :story.prod/ok
+      (rf.story.registrar/reg-variant* :story.prod/ok
                               {:component :views/widget
                                :args      {:label "Hi" :count 3}
                                :setup    []})
       ;; No :lookup / :view-lookup — the DEFAULT side-table + framework
       ;; `:view` registrar path the production runtime takes.
-      (is (= schema (view-args/compiled-view-args-schema :story.prod/ok))))))
+      (is (= schema (rf.story.view-args/compiled-view-args-schema :story.prod/ok))))))
 
 (deftest compiled-resolver-rf-props-wins-over-schema-on-default-lookup
   (testing ":rf/props wins over :schema on the registered view, end-to-end"
     (reg-view-meta! :views/dual {:rf/props [:map [:a :string]]
                                  :schema   [:map [:b :string]]})
-    (registrar/reg-variant* :story.prod/dual
+    (rf.story.registrar/reg-variant* :story.prod/dual
                             {:component :views/dual
                              :args      {:a "x"}
                              :setup    []})
     (is (= [:map [:a :string]]
-           (view-args/compiled-view-args-schema :story.prod/dual)))))
+           (rf.story.view-args/compiled-view-args-schema :story.prod/dual)))))
 
 (deftest compiled-resolver-schema-fallback-on-default-lookup
   (testing "a view carrying its schema under :schema (no :rf/props) still
             resolves — :schema is the post-M-54 fallback location"
     (reg-view-meta! :views/schemaed {:schema [:map [:title :string]]})
-    (registrar/reg-variant* :story.prod/schemaed
+    (rf.story.registrar/reg-variant* :story.prod/schemaed
                             {:component :views/schemaed
                              :args      {:title "T"}
                              :setup    []})
     (is (= [:map [:title :string]]
-           (view-args/compiled-view-args-schema :story.prod/schemaed)))))
+           (rf.story.view-args/compiled-view-args-schema :story.prod/schemaed)))))
 
 (deftest compiled-resolver-spec-only-view-resolves-nil
   (testing "a view whose ONLY schema slot is the dead :spec key resolves no
             schema on the production path (rf2-ayu6n — :spec is dead)"
     (reg-view-meta! :views/specced {:spec [:map [:x :string]]})
-    (registrar/reg-variant* :story.prod/specced
+    (rf.story.registrar/reg-variant* :story.prod/specced
                             {:component :views/specced
                              :args      {:x "v"}
                              :setup    []})
-    (is (nil? (view-args/compiled-view-args-schema :story.prod/specced)))))
+    (is (nil? (rf.story.view-args/compiled-view-args-schema :story.prod/specced)))))
 
 (deftest compiled-resolver-resolves-extends-inherited-component
   (testing "an :extends-INHERITED :component resolves its schema — the
@@ -124,16 +124,16 @@
     ;; and declares no :component of its own. A bare-body read of the child
     ;; would find no :component → no schema. The compiled plan resolves the
     ;; parent chain, so the schema flows down.
-    (registrar/reg-variant* :story.prod/parent
+    (rf.story.registrar/reg-variant* :story.prod/parent
                             {:component :views/base
                              :args      {:label "P"}
                              :setup    []})
-    (registrar/reg-variant* :story.prod/child
+    (rf.story.registrar/reg-variant* :story.prod/child
                             {:extends :story.prod/parent
                              :args    {:label "C"}
                              :setup  []})
     (is (= [:map [:label :string]]
-           (view-args/compiled-view-args-schema :story.prod/child))
+           (rf.story.view-args/compiled-view-args-schema :story.prod/child))
         "the inherited :component's props schema resolves off the compiled plan")))
 
 (deftest compiled-resolver-matches-compiled-plan-slot
@@ -141,33 +141,33 @@
             — one source of truth, not a re-derivation"
     (let [schema [:map [:label :string]]]
       (reg-view-meta! :views/same {:rf/props schema})
-      (registrar/reg-variant* :story.prod/same
+      (rf.story.registrar/reg-variant* :story.prod/same
                               {:component :views/same
                                :args      {:label "Hi"}
                                :setup    []})
       ;; The shared resolver and the controls/schema-validation panels MUST
       ;; agree because they read the same compiled slot.
-      (is (= schema (view-args/compiled-view-args-schema :story.prod/same))))))
+      (is (= schema (rf.story.view-args/compiled-view-args-schema :story.prod/same))))))
 
 (deftest compiled-resolver-unregistered-variant-is-nil
   (testing "an unregistered variant resolves nil (best-effort tooling read —
             no throw)"
-    (is (nil? (view-args/compiled-view-args-schema :story.prod/nope)))))
+    (is (nil? (rf.story.view-args/compiled-view-args-schema :story.prod/nope)))))
 
 (deftest compiled-resolver-no-component-is-nil
   (testing "a registered variant with no :component resolves nil"
-    (registrar/reg-variant* :story.prod/plain
+    (rf.story.registrar/reg-variant* :story.prod/plain
                             {:args {:x 1} :setup []})
-    (is (nil? (view-args/compiled-view-args-schema :story.prod/plain)))))
+    (is (nil? (rf.story.view-args/compiled-view-args-schema :story.prod/plain)))))
 
 (deftest compiled-resolver-view-without-schema-is-nil
   (testing "a registered :component view carrying NO schema slot resolves nil"
     (reg-view-meta! :views/bare {})
-    (registrar/reg-variant* :story.prod/bare
+    (rf.story.registrar/reg-variant* :story.prod/bare
                             {:component :views/bare
                              :args      {:x 1}
                              :setup    []})
-    (is (nil? (view-args/compiled-view-args-schema :story.prod/bare)))))
+    (is (nil? (rf.story.view-args/compiled-view-args-schema :story.prod/bare)))))
 
 ;; ---- memoization invalidates on registrar mutation ----------------------
 
@@ -175,19 +175,19 @@
   (testing "the per-(variant-id, mutation-tick) memo invalidates when the
             view is hot-reloaded with a new props schema"
     (reg-view-meta! :views/hot {:rf/props [:map [:a :string]]})
-    (registrar/reg-variant* :story.prod/hot
+    (rf.story.registrar/reg-variant* :story.prod/hot
                             {:component :views/hot
                              :args      {:a "x"}
                              :setup    []})
     (is (= [:map [:a :string]]
-           (view-args/compiled-view-args-schema :story.prod/hot)))
+           (rf.story.view-args/compiled-view-args-schema :story.prod/hot)))
     ;; Re-register the variant (bumps the Story side-table mutation-tick),
     ;; pointing at a view with a different schema → the memo invalidates.
     (reg-view-meta! :views/hot {:rf/props [:map [:a :string] [:b :int]]})
-    (registrar/reg-variant* :story.prod/hot
+    (rf.story.registrar/reg-variant* :story.prod/hot
                             {:component :views/hot
                              :args      {:a "x" :b 1}
                              :setup    []})
     (is (= [:map [:a :string] [:b :int]]
-           (view-args/compiled-view-args-schema :story.prod/hot))
+           (rf.story.view-args/compiled-view-args-schema :story.prod/hot))
         "the resolver re-reads the compiled plan after the tick bump")))

--- a/tools/story/test/re_frame/story/viewport_test.cljc
+++ b/tools/story/test/re_frame/story/viewport_test.cljc
@@ -15,7 +15,7 @@
   - `wrap-style` shape (nil for `:full`, populated for sized presets).
   - localStorage round-trip — CLJS-only, gated by `browser?`."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.viewport :as viewport]))
+            [re-frame.story.viewport :as rf.story.viewport]))
 
 ;; ---- preset table --------------------------------------------------------
 
@@ -23,12 +23,12 @@
   (testing "every preset id called out by rf2-zll4h is present"
     (let [expected #{:full :mobile-portrait :mobile-landscape
                      :tablet :desktop :desktop-wide}]
-      (is (= expected (set (keys viewport/presets))))
-      (is (= expected (set viewport/preset-order))))))
+      (is (= expected (set (keys rf.story.viewport/presets))))
+      (is (= expected (set rf.story.viewport/preset-order))))))
 
 (deftest preset-full-has-no-dimensions
   (testing ":full preset carries nil width + height (no resize)"
-    (let [p (get viewport/presets :full)]
+    (let [p (get rf.story.viewport/presets :full)]
       (is (= "Full" (:label p)))
       (is (nil? (:width p)))
       (is (nil? (:height p))))))
@@ -36,73 +36,73 @@
 (deftest preset-tablet-has-canonical-dimensions
   (testing ":tablet is 768x1024 (bead-mandated)"
     (is (= {:label "Tablet" :width 768 :height 1024}
-           (get viewport/presets :tablet)))))
+           (get rf.story.viewport/presets :tablet)))))
 
 ;; ---- pure: valid-custom? ------------------------------------------------
 
 (deftest valid-custom-requires-positive-integer-dimensions
   (testing "valid-custom? accepts only positive-integer width + height"
-    (is (true?  (viewport/valid-custom? {:width 800 :height 600})))
-    (is (true?  (viewport/valid-custom? {:width 1 :height 1})))
-    (is (false? (viewport/valid-custom? {:width 0 :height 600}))
+    (is (true?  (rf.story.viewport/valid-custom? {:width 800 :height 600})))
+    (is (true?  (rf.story.viewport/valid-custom? {:width 1 :height 1})))
+    (is (false? (rf.story.viewport/valid-custom? {:width 0 :height 600}))
         "zero is not positive")
-    (is (false? (viewport/valid-custom? {:width -100 :height 600})))
-    (is (false? (viewport/valid-custom? {:width "800" :height "600"}))
+    (is (false? (rf.story.viewport/valid-custom? {:width -100 :height 600})))
+    (is (false? (rf.story.viewport/valid-custom? {:width "800" :height "600"}))
         "strings are not integers")
-    (is (false? (viewport/valid-custom? {:width 800})))
-    (is (false? (viewport/valid-custom? {})))
-    (is (false? (viewport/valid-custom? nil)))
-    (is (false? (viewport/valid-custom? "tablet")))))
+    (is (false? (rf.story.viewport/valid-custom? {:width 800})))
+    (is (false? (rf.story.viewport/valid-custom? {})))
+    (is (false? (rf.story.viewport/valid-custom? nil)))
+    (is (false? (rf.story.viewport/valid-custom? "tablet")))))
 
 ;; ---- pure: coerce -------------------------------------------------------
 
 (deftest coerce-preset-keyword-passes-through
   (testing "a recognised preset keyword coerces to itself"
-    (is (= :tablet (viewport/coerce :tablet)))
-    (is (= :full   (viewport/coerce :full)))))
+    (is (= :tablet (rf.story.viewport/coerce :tablet)))
+    (is (= :full   (rf.story.viewport/coerce :full)))))
 
 (deftest coerce-unknown-keyword-returns-nil
   (testing "an unrecognised keyword is dropped to nil"
-    (is (nil? (viewport/coerce :Mode.unknown/whatever)))
-    (is (nil? (viewport/coerce :phablet)))))
+    (is (nil? (rf.story.viewport/coerce :Mode.unknown/whatever)))
+    (is (nil? (rf.story.viewport/coerce :phablet)))))
 
 (deftest coerce-custom-map-extracts-dims
   (testing "a custom map coerces to a slim {:width :height} map"
     (is (= {:width 800 :height 600}
-           (viewport/coerce {:width 800 :height 600 :label "extra"})))))
+           (rf.story.viewport/coerce {:width 800 :height 600 :label "extra"})))))
 
 (deftest coerce-bad-custom-returns-nil
   (testing "a malformed custom map coerces to nil"
-    (is (nil? (viewport/coerce {:width "800" :height "600"})))
-    (is (nil? (viewport/coerce {:width 800})))
-    (is (nil? (viewport/coerce "800x600")))
-    (is (nil? (viewport/coerce nil)))))
+    (is (nil? (rf.story.viewport/coerce {:width "800" :height "600"})))
+    (is (nil? (rf.story.viewport/coerce {:width 800})))
+    (is (nil? (rf.story.viewport/coerce "800x600")))
+    (is (nil? (rf.story.viewport/coerce nil)))))
 
 ;; ---- pure: resolve precedence -------------------------------------------
 
 (deftest resolve-falls-back-to-full-when-empty
   (testing "neither override nor selection → :full (no-resize) preset"
-    (let [r (viewport/resolve nil nil)]
+    (let [r (rf.story.viewport/resolve nil nil)]
       (is (= "Full" (:label r)))
       (is (nil? (:width r)))
       (is (nil? (:height r))))))
 
 (deftest resolve-uses-toolbar-selection-when-no-override
   (testing "toolbar selection wins when no per-story override is set"
-    (let [r (viewport/resolve nil :tablet)]
+    (let [r (rf.story.viewport/resolve nil :tablet)]
       (is (= "Tablet" (:label r)))
       (is (= 768 (:width r)))
       (is (= 1024 (:height r))))))
 
 (deftest resolve-story-override-beats-toolbar
   (testing "rf2-zll4h precedence: story-override wins over toolbar selection"
-    (let [r (viewport/resolve :mobile-portrait :tablet)]
+    (let [r (rf.story.viewport/resolve :mobile-portrait :tablet)]
       (is (= "Mobile portrait" (:label r))
           "override (:mobile-portrait) beat the toolbar (:tablet)"))))
 
 (deftest resolve-custom-override-beats-toolbar
   (testing "a custom map as the story-override is honoured"
-    (let [r (viewport/resolve {:width 500 :height 300} :tablet)]
+    (let [r (rf.story.viewport/resolve {:width 500 :height 300} :tablet)]
       (is (= 500 (:width r)))
       (is (= 300 (:height r)))
       (is (re-find #"500" (:label r)))
@@ -110,26 +110,26 @@
 
 (deftest resolve-bad-override-falls-through-to-toolbar
   (testing "an unrecognised override does NOT block the toolbar fallback"
-    (let [r (viewport/resolve :phablet :tablet)]
+    (let [r (rf.story.viewport/resolve :phablet :tablet)]
       (is (= "Tablet" (:label r))
           "unknown override fell through to the live toolbar selection"))))
 
 (deftest resolve-id-returns-keyword-or-custom
   (testing "resolve-id surfaces the resolved id for data-* attributes"
-    (is (= :full    (viewport/resolve-id nil nil)))
-    (is (= :tablet  (viewport/resolve-id nil :tablet)))
-    (is (= :desktop (viewport/resolve-id :desktop :tablet)))
-    (is (= :custom  (viewport/resolve-id {:width 500 :height 300} nil)))))
+    (is (= :full    (rf.story.viewport/resolve-id nil nil)))
+    (is (= :tablet  (rf.story.viewport/resolve-id nil :tablet)))
+    (is (= :desktop (rf.story.viewport/resolve-id :desktop :tablet)))
+    (is (= :custom  (rf.story.viewport/resolve-id {:width 500 :height 300} nil)))))
 
 ;; ---- pure: wrap-style ----------------------------------------------------
 
 (deftest wrap-style-nil-for-full
   (testing ":full → nil wrapper (no sizing div needed)"
-    (is (nil? (viewport/wrap-style (get viewport/presets :full))))))
+    (is (nil? (rf.story.viewport/wrap-style (get rf.story.viewport/presets :full))))))
 
 (deftest wrap-style-populated-for-sized-preset
   (testing "a sized preset produces width + height CSS"
-    (let [s (viewport/wrap-style (get viewport/presets :tablet))]
+    (let [s (rf.story.viewport/wrap-style (get rf.story.viewport/presets :tablet))]
       (is (= "768px" (:width s)))
       (is (= "1024px" (:height s)))
       (is (string? (:border s))
@@ -150,7 +150,7 @@
    (defn- clear-storage!
      []
      (when (browser?)
-       (try (.removeItem (.-localStorage js/window) viewport/ls-key)
+       (try (.removeItem (.-localStorage js/window) rf.story.viewport/ls-key)
             (catch :default _ nil)))))
 
 #?(:cljs
@@ -158,8 +158,8 @@
      (testing "save → load returns the persisted preset id"
        (when (browser?)
          (clear-storage!)
-         (viewport/save-to-storage! :tablet)
-         (is (= :tablet (viewport/load-from-storage)))
+         (rf.story.viewport/save-to-storage! :tablet)
+         (is (= :tablet (rf.story.viewport/load-from-storage)))
          (clear-storage!)))))
 
 #?(:cljs
@@ -167,8 +167,8 @@
      (testing "save → load returns the persisted custom map"
        (when (browser?)
          (clear-storage!)
-         (viewport/save-to-storage! {:width 800 :height 600})
-         (is (= {:width 800 :height 600} (viewport/load-from-storage)))
+         (rf.story.viewport/save-to-storage! {:width 800 :height 600})
+         (is (= {:width 800 :height 600} (rf.story.viewport/load-from-storage)))
          (clear-storage!)))))
 
 #?(:cljs
@@ -176,10 +176,10 @@
      (testing "save-to-storage! nil clears the persisted slot"
        (when (browser?)
          (clear-storage!)
-         (viewport/save-to-storage! :tablet)
-         (is (some? (viewport/load-from-storage)))
-         (viewport/save-to-storage! nil)
-         (is (nil? (viewport/load-from-storage)))
+         (rf.story.viewport/save-to-storage! :tablet)
+         (is (some? (rf.story.viewport/load-from-storage)))
+         (rf.story.viewport/save-to-storage! nil)
+         (is (nil? (rf.story.viewport/load-from-storage)))
          (clear-storage!)))))
 
 #?(:cljs
@@ -187,7 +187,7 @@
      (testing "save-to-storage! drops invalid values to nil (no leak)"
        (when (browser?)
          (clear-storage!)
-         (viewport/save-to-storage! :phablet)         ;; unknown preset
-         (is (nil? (viewport/load-from-storage)))
-         (viewport/save-to-storage! {:width "no"})    ;; bad shape
-         (is (nil? (viewport/load-from-storage)))))))
+         (rf.story.viewport/save-to-storage! :phablet)         ;; unknown preset
+         (is (nil? (rf.story.viewport/load-from-storage)))
+         (rf.story.viewport/save-to-storage! {:width "no"})    ;; bad shape
+         (is (nil? (rf.story.viewport/load-from-storage)))))))

--- a/tools/story/test/re_frame/story/xray_preset_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/xray_preset_cljs_test.cljs
@@ -38,11 +38,11 @@
             [day8.re-frame2-xray.keybinding :as xray-keybinding]
             [day8.re-frame2-xray.registry :as xray-registry]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.story :as story]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story.xray-preset :as xray-preset]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.story :as rf.story]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story.xray-preset :as rf.story.xray-preset]))
 
 ;; ---- fixtures ------------------------------------------------------------
 ;;
@@ -53,12 +53,12 @@
 ;; first; the per-ns isolation gate exists to catch exactly that.
 
 (defn reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
-  (frame/ensure-default-frame!)
-  (story/install-canonical-vocabulary!))
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
+  (rf.frame/ensure-default-frame!)
+  (rf.story/install-canonical-vocabulary!))
 
 (use-fixtures :each (fn [t] (reset-all!) (t)))
 
@@ -69,7 +69,7 @@
 ;; the same lightweight setup Xray's own filter suites use
 ;; (`filters/persistence-cljs-test`): register the handlers, make the
 ;; frame. `reset-for-test!` clears the registry's idempotency sentinel,
-;; which `reset-all!`'s `registrar/clear-all!` would otherwise leave set
+;; which `reset-all!`'s `rf.registrar/clear-all!` would otherwise leave set
 ;; over an emptied registrar — handlers would silently not re-register.
 
 (defn- mount-xray!
@@ -89,7 +89,7 @@
   live slot to unfiltered."
   []
   (mount-xray!)
-  (xray-preset/flush-pending-filters!)
+  (rf.story.xray-preset/flush-pending-filters!)
   (rf/with-frame :rf/xray
     (rf/dispatch-sync [:rf.xray/hydrate-filters {:in [] :out []}]))
   nil)
@@ -103,9 +103,9 @@
 (defn- reg-filtered-variant!
   "Register a story + variant carrying `xray-preset` as its `:xray` slot."
   [variant-id preset]
-  (story/reg-story :story.filt
+  (rf.story/reg-story :story.filt
     {:doc "filters" :component :Some.view})
-  (story/reg-variant variant-id
+  (rf.story/reg-variant variant-id
     {:doc "v" :xray preset})
   variant-id)
 
@@ -125,7 +125,7 @@
     (xray-config/set-keybinding-enabled! true)
     (is (true? (xray-config/keybinding-attach-enabled?))
         "precondition: default keybinding-enabled? is true")
-    (is (true? (xray-preset/disable-keybinding!))
+    (is (true? (rf.story.xray-preset/disable-keybinding!))
         "disable-keybinding! returns true when the configure! call landed")
     (is (false? (xray-config/keybinding-attach-enabled?))
         "after disable-keybinding!, Xray's slot is false")
@@ -142,7 +142,7 @@
     (let [captured (atom nil)]
       (with-redefs [xray-config/configure!
                     (fn [opts] (reset! captured opts) nil)]
-        (is (true? (xray-preset/disable-keybinding!))
+        (is (true? (rf.story.xray-preset/disable-keybinding!))
             "returns true when the configure! call landed")
         (is (= {:rf.xray/keybinding-enabled? false} @captured)
             "configure! is called with exactly the keybinding-disable slot")))))
@@ -158,7 +158,7 @@
     (let [called? (atom false)]
       (with-redefs [xray-keybinding/detach!
                     (fn [] (reset! called? true) nil)]
-        (is (true? (xray-preset/detach-keybinding!))
+        (is (true? (rf.story.xray-preset/detach-keybinding!))
             "returns true when keybinding/detach! is reachable")
         (is (true? @called?)
             "keybinding/detach! was driven by the bridge")))))
@@ -180,14 +180,14 @@
     (let [disable-called? (atom false)
           detach-called?  (atom false)
           open-called?    (atom false)]
-      (with-redefs [xray-preset/disable-keybinding!
+      (with-redefs [rf.story.xray-preset/disable-keybinding!
                     (fn [] (reset! disable-called? true) true)
-                    xray-preset/detach-keybinding!
+                    rf.story.xray-preset/detach-keybinding!
                     (fn [] (reset! detach-called? true) true)
-                    xray-preset/apply-open!
+                    rf.story.xray-preset/apply-open!
                     (fn [] (reset! open-called? true) nil)]
-        (xray-preset/wire-cross-host!)
-        (xray-preset/apply-open!)
+        (rf.story.xray-preset/wire-cross-host!)
+        (rf.story.xray-preset/apply-open!)
         (is (true? @disable-called?)
             "disable-keybinding! is part of the cross-host bridge")
         (is (true? @detach-called?)
@@ -202,14 +202,14 @@
             declared intent. We capture the order via a shared log and
             assert disable-keybinding! ran before detach-keybinding!."
     (let [calls (atom [])]
-      (with-redefs [xray-preset/disable-keybinding!
+      (with-redefs [rf.story.xray-preset/disable-keybinding!
                     (fn [] (swap! calls conj :disable) true)
-                    xray-preset/detach-keybinding!
+                    rf.story.xray-preset/detach-keybinding!
                     (fn [] (swap! calls conj :detach) true)
-                    xray-preset/apply-open!
+                    rf.story.xray-preset/apply-open!
                     (fn [] (swap! calls conj :open) nil)]
-        (xray-preset/wire-cross-host!)
-        (xray-preset/apply-open!)
+        (rf.story.xray-preset/wire-cross-host!)
+        (rf.story.xray-preset/apply-open!)
         (is (= [:disable :detach :open] @calls)
             "slot flip (intent) lands before detach! (runtime removal)
              which lands before the composed apply-open!")))))
@@ -242,7 +242,7 @@
       ;; keybinding namespaces through declared `:require`s
       ;; (rf2-r8trk), so no availability shim is needed. No shell mount
       ;; happens — `wire-cross-host!` never calls `apply-open!`.
-      (xray-preset/wire-cross-host!)
+      (rf.story.xray-preset/wire-cross-host!)
       (is (false? (xray-config/keybinding-attach-enabled?))
           "wire-cross-host! flipped the slot to false")
       (is (false? (xray-keybinding/attached?))
@@ -269,12 +269,12 @@
 
 (deftest apply-preset-nil-on-missing-preset
   (testing "no :xray slot → no work, returns nil"
-    (story/reg-story :story.nilpre
+    (rf.story/reg-story :story.nilpre
       {:doc "no slot"
        :component :Some.view})
-    (story/reg-variant :story.nilpre/v
+    (rf.story/reg-variant :story.nilpre/v
       {:doc "v"})
-    (is (nil? (xray-preset/apply-preset! :story.nilpre/v)))))
+    (is (nil? (rf.story.xray-preset/apply-preset! :story.nilpre/v)))))
 
 ;; ---- :filters preset drives Xray's real filter surface (rf2-q5pd6) -------
 ;;
@@ -294,7 +294,7 @@
             canonical pill shape in the live :active-filters slot"
     (install-xray-frame!)
     (let [vid (reg-filtered-variant! :story.filt/out {:filters {:out [:app/noise]}})]
-      (is (= {:filters {:out [:app/noise]}} (xray-preset/apply-preset! vid))
+      (is (= {:filters {:out [:app/noise]}} (rf.story.xray-preset/apply-preset! vid))
           "apply-preset! returns the resolved preset")
       (is (= {:in [] :out [{:pattern :app/noise}]} (active-filters))
           "the live slot carries Xray's pill shape, not Story's bare keyword"))))
@@ -306,7 +306,7 @@
             unlowered canonicalises to :never and would match nothing."
     (install-xray-frame!)
     (let [vid (reg-filtered-variant! :story.filt/match {:filters {:out [:app/noise]}})]
-      (xray-preset/apply-preset! vid)
+      (rf.story.xray-preset/apply-preset! vid)
       (let [pill (first (:out (active-filters)))]
         (is (true? (xray-typed/event-bundle-matches-pill? (bundle :app/noise) pill))
             "the OUT pill matches the event-bundle the story declared")
@@ -322,7 +322,7 @@
     (install-xray-frame!)
     (let [vid (reg-filtered-variant! :story.filt/both
                 {:filters {:in [:keep/a] :out [:drop/b]}})]
-      (xray-preset/apply-preset! vid)
+      (rf.story.xray-preset/apply-preset! vid)
       (is (= {:in [{:pattern :keep/a}] :out [{:pattern :drop/b}]}
              (active-filters))))))
 
@@ -333,7 +333,7 @@
     (xray-config/set-filter-seed! nil)
     (try
       (let [vid (reg-filtered-variant! :story.filt/seed {:filters {:out [:app/noise]}})]
-        (xray-preset/apply-preset! vid)
+        (rf.story.xray-preset/apply-preset! vid)
         (is (= {:in [] :out [{:pattern :app/noise}]} (xray-config/get-filter-seed))
             "the seed carries the lowered pill shape too"))
       (finally (xray-config/set-filter-seed! nil)))))
@@ -348,16 +348,16 @@
     ;; Model the pre-mount world: drain any prior park, then remove the
     ;; frame so `apply-preset!` genuinely has nowhere to dispatch.
     (install-xray-frame!)
-    (swap! frame/frames dissoc :rf/xray)
-    (is (nil? (frame/frame :rf/xray))
+    (swap! rf.frame/frames dissoc :rf/xray)
+    (is (nil? (rf.frame/frame :rf/xray))
         "precondition: the Xray frame does not exist yet")
     (let [vid (reg-filtered-variant! :story.filt/park {:filters {:out [:app/noise]}})]
-      (xray-preset/apply-preset! vid)
+      (rf.story.xray-preset/apply-preset! vid)
       ;; The RHS panel-host now mounts Xray, registering the frame; its
       ;; very next act is the flush.
       (mount-xray!)
       (is (= {:in [] :out [{:pattern :app/noise}]}
-             (xray-preset/flush-pending-filters!))
+             (rf.story.xray-preset/flush-pending-filters!))
           "the flush returns the pill set it applied")
       (is (= {:in [] :out [{:pattern :app/noise}]} (active-filters))
           "and the live slot now carries it"))))
@@ -366,16 +366,16 @@
   (testing "a second panel mount does not re-apply a preset the user may
             since have edited away through the ribbon"
     (install-xray-frame!)
-    (swap! frame/frames dissoc :rf/xray)
+    (swap! rf.frame/frames dissoc :rf/xray)
     (let [vid (reg-filtered-variant! :story.filt/once {:filters {:out [:app/noise]}})]
-      (xray-preset/apply-preset! vid)
+      (rf.story.xray-preset/apply-preset! vid)
       (mount-xray!)
-      (is (some? (xray-preset/flush-pending-filters!))
+      (is (some? (rf.story.xray-preset/flush-pending-filters!))
           "first flush applies the parked set")
       ;; User clears the pills through the ribbon.
       (rf/with-frame :rf/xray
         (rf/dispatch-sync [:rf.xray/hydrate-filters {:in [] :out []}]))
-      (is (nil? (xray-preset/flush-pending-filters!))
+      (is (nil? (rf.story.xray-preset/flush-pending-filters!))
           "second flush is a no-op — nothing is pending")
       (is (= {:in [] :out []} (active-filters))
           "the user's cleared slot survives the second mount"))))
@@ -392,7 +392,7 @@
     (is (= [{:pattern :stale/pill}] (:out (active-filters)))
         "precondition: a stale pill is active")
     (let [vid (reg-filtered-variant! :story.filt/empty {:filters {:in [] :out []}})]
-      (xray-preset/apply-preset! vid)
+      (rf.story.xray-preset/apply-preset! vid)
       (is (= {:in [] :out []} (active-filters))
           "the explicit empty preset cleared the pills"))))
 
@@ -403,7 +403,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/hydrate-filters {:in [] :out [{:pattern :user/pill}]}]))
     (let [vid (reg-filtered-variant! :story.filt/nofilters {:panel :trace})]
-      (xray-preset/apply-preset! vid)
+      (rf.story.xray-preset/apply-preset! vid)
       (is (= [{:pattern :user/pill}] (:out (active-filters)))
           "the user's pill survives a preset that says nothing about filters"))))
 
@@ -422,22 +422,22 @@
     ;;
     ;; Seed Story's project-root via configure! — exercises the whole
     ;; configure! → set-project-root! → propagator pipeline.
-    (story/configure! {:rf.story/project-root "/home/me/code/my-app"})
+    (rf.story/configure! {:rf.story/project-root "/home/me/code/my-app"})
     (try
-      (is (= "/home/me/code/my-app" (xray-preset/propagate-project-root!))
+      (is (= "/home/me/code/my-app" (rf.story.xray-preset/propagate-project-root!))
           "the propagator returns the root it bridged into Xray's slot")
       (is (= "/home/me/code/my-app" (xray-config/get-project-root))
           "the value actually landed in Xray's own config slot")
       (finally
         ;; Reset BOTH slots so neighbouring tests see the baseline —
         ;; the bridge writes through to Xray's global atom.
-        (story/configure! {:rf.story/project-root nil})
+        (rf.story/configure! {:rf.story/project-root nil})
         (xray-config/set-project-root! nil)))))
 
 (deftest propagate-project-root-nil-when-unset
   (testing "propagate-project-root! returns nil when Story has no project-root configured"
     ;; Clear any prior seed (the fixture resets the registrar but not
     ;; the config atom).
-    (story/configure! {:rf.story/project-root nil})
-    (is (nil? (xray-preset/propagate-project-root!))
+    (rf.story/configure! {:rf.story/project-root nil})
+    (is (nil? (rf.story.xray-preset/propagate-project-root!))
         "no propagation when Story's project-root is nil")))

--- a/tools/story/test/re_frame/story/xray_preset_test.cljc
+++ b/tools/story/test/re_frame/story/xray_preset_test.cljc
@@ -10,22 +10,22 @@
   only a `-cljs-test` namespace is discovered by the `:node-test`
   build. See the note at the foot of this file."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story :as story]
-            [re-frame.story.xray-preset :as xray-preset]
+            [re-frame.story :as rf.story]
+            [re-frame.story.xray-preset :as rf.story.xray-preset]
             #?@(:cljs [[re-frame.core :as rf]
-                       [re-frame.frame :as frame]
-                       [re-frame.registrar :as registrar]
-                       [re-frame.substrate.plain-atom :as plain-atom]])))
+                       [re-frame.frame :as rf.frame]
+                       [re-frame.registrar :as rf.registrar]
+                       [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]])))
 
 ;; ---- fixtures -----------------------------------------------------------
 
 (defn reset-all! []
-  (story/clear-all!)
-  #?(:cljs (do (registrar/clear-all!)
-               (reset! frame/frames {})
-               (try (rf/init! plain-atom/adapter) (catch :default _ nil))
-               (frame/ensure-default-frame!)))
-  (story/install-canonical-vocabulary!))
+  (rf.story/clear-all!)
+  #?(:cljs (do (rf.registrar/clear-all!)
+               (reset! rf.frame/frames {})
+               (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
+               (rf.frame/ensure-default-frame!)))
+  (rf.story/install-canonical-vocabulary!))
 
 (use-fixtures :each (fn [t] (reset-all!) (t)))
 
@@ -33,64 +33,64 @@
 
 (deftest merge-preset-handles-nils
   (testing "two nils merge to {}"
-    (is (= {} (xray-preset/merge-preset nil nil)))))
+    (is (= {} (rf.story.xray-preset/merge-preset nil nil)))))
 
 (deftest merge-preset-variant-overrides-story
   (testing "variant slot wins over story slot at the top level"
     (let [story {:open? true :panel :epoch}
           vari  {:panel :trace}]
       (is (= {:open? true :panel :trace}
-             (xray-preset/merge-preset story vari))))))
+             (rf.story.xray-preset/merge-preset story vari))))))
 
 (deftest merge-preset-deep-merges-filters
   (testing ":filters merge respects :in / :out separately"
     (let [story {:filters {:in [:keep/me]}}
           vari  {:filters {:out [:drop/me]}}]
       (is (= {:filters {:in [:keep/me] :out [:drop/me]}}
-             (xray-preset/merge-preset story vari))))))
+             (rf.story.xray-preset/merge-preset story vari))))))
 
 (deftest merge-preset-variant-filters-override-story
   (testing "matching filter axes prefer variant value"
     (let [story {:filters {:in [:story/in] :out [:story/out]}}
           vari  {:filters {:in [:variant/in]}}]
       (is (= {:filters {:in [:variant/in] :out [:story/out]}}
-             (xray-preset/merge-preset story vari))))))
+             (rf.story.xray-preset/merge-preset story vari))))))
 
 ;; ---- pure: resolve-preset ------------------------------------------------
 
 (deftest resolve-preset-returns-nil-when-no-preset
   (testing "story + variant with no :xray slot resolves to nil"
-    (story/reg-story :story.no-preset
+    (rf.story/reg-story :story.no-preset
       {:doc "no preset" :component :Some.view})
-    (story/reg-variant :story.no-preset/v
+    (rf.story/reg-variant :story.no-preset/v
       {:doc "v"})
-    (is (nil? (xray-preset/resolve-preset :story.no-preset/v)))))
+    (is (nil? (rf.story.xray-preset/resolve-preset :story.no-preset/v)))))
 
 (deftest resolve-preset-reads-story-slot
   (testing "story :xray is returned when variant has none"
-    (story/reg-story :story.story-preset
+    (rf.story/reg-story :story.story-preset
       {:doc "preset on story"
        :component :Some.view
        :xray {:open? true :panel :trace}})
-    (story/reg-variant :story.story-preset/v
+    (rf.story/reg-variant :story.story-preset/v
       {:doc "v"})
-    (let [p (xray-preset/resolve-preset :story.story-preset/v)]
+    (let [p (rf.story.xray-preset/resolve-preset :story.story-preset/v)]
       (is (= true     (:open? p)))
       (is (= :trace   (:panel p))))))
 
 (deftest resolve-preset-merges-story-and-variant
   (testing "variant :xray overrides story slot, :filters deep-merge"
-    (story/reg-story :story.both
+    (rf.story/reg-story :story.both
       {:doc "preset on both"
        :component :Some.view
        :xray {:open? true
                :panel :epoch
                :filters {:in [:keep/x]}}})
-    (story/reg-variant :story.both/v
+    (rf.story/reg-variant :story.both/v
       {:doc "v"
        :xray {:panel :trace
                :filters {:out [:drop/y]}}})
-    (let [p (xray-preset/resolve-preset :story.both/v)]
+    (let [p (rf.story.xray-preset/resolve-preset :story.both/v)]
       (is (= true                                (:open? p)))
       (is (= :trace                              (:panel p)))
       (is (= {:in [:keep/x] :out [:drop/y]}      (:filters p))))))
@@ -106,34 +106,34 @@
 (deftest lower-filters-wraps-keywords-as-pattern-pills
   (testing "a bare event-id keyword becomes Xray's {:pattern <kw>} pill"
     (is (= {:in [] :out [{:pattern :app/noise}]}
-           (xray-preset/lower-filters {:out [:app/noise]})))))
+           (rf.story.xray-preset/lower-filters {:out [:app/noise]})))))
 
 (deftest lower-filters-normalises-both-axes
   (testing "a preset declaring only one axis still yields the full
             {:in [...] :out [...]} shape Xray's :active-filters slot
             expects — a missing axis must not land as nil in the slot"
     (is (= {:in [{:pattern :keep/x}] :out []}
-           (xray-preset/lower-filters {:in [:keep/x]})))
+           (rf.story.xray-preset/lower-filters {:in [:keep/x]})))
     (is (= {:in [] :out []}
-           (xray-preset/lower-filters {})))))
+           (rf.story.xray-preset/lower-filters {})))))
 
 (deftest lower-filters-lowers-every-entry
   (testing "multiple pills per axis all lower"
     (is (= {:in  [{:pattern :a/one} {:pattern :a/two}]
             :out [{:pattern :b/one}]}
-           (xray-preset/lower-filters {:in [:a/one :a/two] :out [:b/one]})))))
+           (rf.story.xray-preset/lower-filters {:in [:a/one :a/two] :out [:b/one]})))))
 
 (deftest lower-filters-passes-maps-through
   (testing "an already-canonical typed pill survives the boundary
             un-double-wrapped (no {:pattern {:kind …}} nesting)"
     (let [typed {:kind :machine :params {:machine-id :m/one}}]
       (is (= {:in [typed] :out [{:pattern :b/two}]}
-             (xray-preset/lower-filters {:in [typed] :out [:b/two]}))))))
+             (rf.story.xray-preset/lower-filters {:in [typed] :out [:b/two]}))))))
 
 (deftest lower-filters-nil-on-non-map
   (testing "a non-map :filters slot lowers to nil rather than throwing"
-    (is (nil? (xray-preset/lower-filters nil)))
-    (is (nil? (xray-preset/lower-filters [:app/noise])))))
+    (is (nil? (rf.story.xray-preset/lower-filters nil)))
+    (is (nil? (rf.story.xray-preset/lower-filters [:app/noise])))))
 
 ;; ---- Why there are no CLJS-only tests in this file -----------------------
 ;;

--- a/tools/story/test/re_frame/story_a11y_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_a11y_cljs_test.cljs
@@ -7,20 +7,20 @@
   CLJS bundle without requiring a live browser."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story :as story]
-            [re-frame.story.ui.a11y :as a11y]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.ui.a11y :as rf.story.ui.a11y]))
 
 (defn reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
-  (a11y/reset-state!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
+  (rf.story.ui.a11y/reset-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -28,19 +28,19 @@
 
 (deftest a11y-panel-registers
   (testing "the a11y panel registers as a story-panel"
-    (let [panels (story/registrations :story-panel)]
-      (is (contains? panels a11y/panel-id)))))
+    (let [panels (rf.story/registrations :story-panel)]
+      (is (contains? panels rf.story.ui.a11y/panel-id)))))
 
 (deftest a11y-panel-body
   (testing "the a11y panel body declares :placement :right + :render"
-    (let [body (story/handler-meta :story-panel a11y/panel-id)]
+    (let [body (rf.story/handler-meta :story-panel rf.story.ui.a11y/panel-id)]
       (is (= :right (:placement body)))
-      (is (= a11y/panel-render-id (:render body)))
+      (is (= rf.story.ui.a11y/panel-render-id (:render body)))
       (is (string? (:title body))))))
 
 (deftest a11y-render-view-registered
   (testing "the a11y panel-render view is registered against re-frame"
-    (is (some? (rf/view a11y/panel-render-id)))))
+    (is (some? (rf/view rf.story.ui.a11y/panel-render-id)))))
 
 (deftest a11y-render-view-roots-in-dom-element
   (testing "the a11y panel-render view returns hiccup whose root is a DOM
@@ -51,7 +51,7 @@
             `[panel variant-id]` root makes the panel invisible to Story
             Inspect Mode + Xray Inspect Mode (rf2-iwny7). The `[:div]`
             wrap is load-bearing."
-    (let [view-fn (rf/view a11y/panel-render-id)
+    (let [view-fn (rf/view rf.story.ui.a11y/panel-render-id)
           out     (view-fn :story.unknown/y)]
       (is (vector? out)
           "panel-render returns a hiccup vector")
@@ -64,26 +64,26 @@
 
 (deftest violations-state-empty
   (testing "violations-by-frame starts empty"
-    (is (= {} @a11y/violations-by-frame))))
+    (is (= {} @rf.story.ui.a11y/violations-by-frame))))
 
 (deftest drop-frame-state-clears
   (testing "drop-frame-state! removes per-frame state"
-    (swap! a11y/violations-by-frame assoc :story.x/y [{:dummy true}])
-    (swap! a11y/run-state           assoc :story.x/y {:status :done})
-    (a11y/drop-frame-state! :story.x/y)
-    (is (not (contains? @a11y/violations-by-frame :story.x/y)))
-    (is (not (contains? @a11y/run-state           :story.x/y)))))
+    (swap! rf.story.ui.a11y/violations-by-frame assoc :story.x/y [{:dummy true}])
+    (swap! rf.story.ui.a11y/run-state           assoc :story.x/y {:status :done})
+    (rf.story.ui.a11y/drop-frame-state! :story.x/y)
+    (is (not (contains? @rf.story.ui.a11y/violations-by-frame :story.x/y)))
+    (is (not (contains? @rf.story.ui.a11y/run-state           :story.x/y)))))
 
 (deftest violations-stylesheet-non-empty
   (testing "the violations stylesheet is a non-empty CSS string"
-    (is (string? a11y/violations-stylesheet))
-    (is (pos? (count a11y/violations-stylesheet)))))
+    (is (string? rf.story.ui.a11y/violations-stylesheet))
+    (is (pos? (count rf.story.ui.a11y/violations-stylesheet)))))
 
 ;; ---- rf2-qgms1: variant-root scoping ------------------------------------
 
 (deftest variant-root-selector-targets-data-attribute
   (testing "variant-root-selector returns a CSS attribute selector keyed on the variant id"
-    (let [sel (a11y/variant-root-selector :story.counter/loaded)]
+    (let [sel (rf.story.ui.a11y/variant-root-selector :story.counter/loaded)]
       (is (string? sel))
       ;; Must use the data attribute the canvas / workspace stamp.
       (is (re-find #"data-rf-story-variant-root=" sel))
@@ -95,8 +95,8 @@
 
 (deftest variant-root-selector-distinct-per-variant
   (testing "different variant-ids yield distinct selectors"
-    (is (not= (a11y/variant-root-selector :story.counter/loaded)
-              (a11y/variant-root-selector :story.counter/clicked-three-times)))))
+    (is (not= (rf.story.ui.a11y/variant-root-selector :story.counter/loaded)
+              (rf.story.ui.a11y/variant-root-selector :story.counter/clicked-three-times)))))
 
 (deftest run-axe-handles-no-variant-root
   (testing "run-axe! sets :no-root state when no variant root resolves
@@ -109,13 +109,13 @@
           orig-warn js/console.warn]
       (set! js/console.warn (fn [& _] nil))
       (try
-        (let [p (a11y/run-axe! frame-id)]
+        (let [p (rf.story.ui.a11y/run-axe! frame-id)]
           (is (some? p) "run-axe! returns a Promise even on the no-root path")
-          (is (= :no-root (a11y/status-for frame-id))
+          (is (= :no-root (rf.story.ui.a11y/status-for frame-id))
               "run-state for an unmounted variant must be :no-root, NOT :running or :done — surfacing that the scan was not run against the wrong tree"))
         (finally
           (set! js/console.warn orig-warn)
-          (a11y/drop-frame-state! frame-id))))))
+          (rf.story.ui.a11y/drop-frame-state! frame-id))))))
 
 ;; ---- rf2-20w5i: axe-core CDN load is opt-in only ------------------------
 ;;
@@ -131,18 +131,18 @@
   (testing "set-cdn-opt-in! false clears the persisted approval —
             the fresh-browser shape. A subsequent cdn-opt-in? must
             read false so the consent prompt re-renders."
-    (a11y/set-cdn-opt-in! false)
-    (is (false? (boolean (a11y/cdn-opt-in?)))
+    (rf.story.ui.a11y/set-cdn-opt-in! false)
+    (is (false? (boolean (rf.story.ui.a11y/cdn-opt-in?)))
         "after revocation the opt-in predicate must read false")))
 
 (deftest cdn-opt-in-roundtrips
   (testing "set-cdn-opt-in! true persists the approval; set-cdn-opt-in!
             false revokes it. The persistence is `localStorage`-backed
             so a single click per browser-session is enough."
-    (a11y/set-cdn-opt-in! true)
-    (is (true? (boolean (a11y/cdn-opt-in?))))
-    (a11y/set-cdn-opt-in! false)
-    (is (false? (boolean (a11y/cdn-opt-in?))))))
+    (rf.story.ui.a11y/set-cdn-opt-in! true)
+    (is (true? (boolean (rf.story.ui.a11y/cdn-opt-in?))))
+    (rf.story.ui.a11y/set-cdn-opt-in! false)
+    (is (false? (boolean (rf.story.ui.a11y/cdn-opt-in?))))))
 
 (deftest run-axe-surfaces-no-consent-without-opt-in
   (testing "run-axe! short-circuits to `:no-consent` when the dev
@@ -150,17 +150,17 @@
             to render the consent prompt instead of triggering the
             load — defence against the pre-fix shape where a single
             panel-open inadvertently fetched remote JS."
-    (a11y/set-cdn-opt-in! false)
+    (rf.story.ui.a11y/set-cdn-opt-in! false)
     (let [frame-id :story.never-consented/x
           ;; Pass a fake context so the call doesn't short-circuit on
           ;; the prior `:no-root` branch.
           fake-ctx #js {:nodeType 1}]
       (try
-        (let [p (a11y/run-axe! frame-id fake-ctx)]
+        (let [p (rf.story.ui.a11y/run-axe! frame-id fake-ctx)]
           (is (some? p) "run-axe! returns a Promise even on :no-consent")
-          (is (= :no-consent (a11y/status-for frame-id))
+          (is (= :no-consent (rf.story.ui.a11y/status-for frame-id))
               "without consent the panel must surface :no-consent —
                NOT :running or :loading — so the consent prompt has
                time to render"))
         (finally
-          (a11y/drop-frame-state! frame-id))))))
+          (rf.story.ui.a11y/drop-frame-state! frame-id))))))

--- a/tools/story/test/re_frame/story_assertions_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_assertions_cljs_test.cljs
@@ -10,21 +10,21 @@
   from CLJS callers."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.machines         :as machines]
-            [re-frame.registrar        :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story            :as story]
-            [re-frame.story.assertions :as assertions]
-            [re-frame.story.async      :as async-lib]
-            [re-frame.story.loaders    :as loaders]
-            [re-frame.subs             :as subs]))
+            [re-frame.frame            :as rf.frame]
+            [re-frame.machines         :as rf.machines]
+            [re-frame.registrar        :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story            :as rf.story]
+            [re-frame.story.assertions :as rf.story.assertions]
+            [re-frame.story.async      :as rf.story.async]
+            [re-frame.story.loaders    :as rf.story.loaders]
+            [re-frame.subs             :as rf.subs]))
 
 (defn reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch :default _ nil))
   ;; Re-register the machines artefact's framework-shipped `:rf/machine`
   ;; sub after the registrar clear. EP-0001 (rf2-vzld77 / rf2-ixb0bq):
@@ -32,14 +32,14 @@
   ;; [:rf.runtime/machines :snapshots <id>], so the framework sub is a
   ;; runtime-db sub (the db-position arg is the runtime-db value) — mirror
   ;; `re-frame.machines` exactly. CLJS has no `require :reload` to re-fire
-  ;; the ns-load registration dropped by `registrar/clear-all!`.
-  (subs/reg-runtime-sub :rf/machine
+  ;; the ns-load registration dropped by `rf.registrar/clear-all!`.
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [runtime-db [_ machine-id]]
       (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -47,7 +47,7 @@
 
 (deftest cljs-canonical-seven-registered
   (testing "all seven :rf.assert/* event handlers register on CLJS"
-    (let [events (registrar/registrations :event)]
+    (let [events (rf.registrar/registrations :event)]
       (is (contains? events :rf.assert/path-equals))
       (is (contains? events :rf.assert/path-matches))
       (is (contains? events :rf.assert/sub-equals))
@@ -62,16 +62,16 @@
   (testing ":rf.assert/path-equals against an event-mutated app-db"
     (rf/reg-event :test/set
       (fn [{:keys [db]} _] {:db (assoc-in db [:user :name] "alice")}))
-    (story/reg-variant :story.cljs.assert/pe
+    (rf.story/reg-variant :story.cljs.assert/pe
       {:setup [[:test/set]]
        :script [[:dispatch-sync [:rf.assert/path-equals [:user :name] "alice"]]]})
     (async done
-      (-> (story/run-variant :story.cljs.assert/pe)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.cljs.assert/pe)
+          (rf.story.async/then
             (fn [r]
               (is (= 1 (count (:assertions r))))
               (is (true? (-> r :assertions first :passed?)))
-              (story/destroy-variant! :story.cljs.assert/pe)
+              (rf.story/destroy-variant! :story.cljs.assert/pe)
               (done)))))))
 
 ;; ---- assertions-passing? predicate --------------------------------------
@@ -79,52 +79,52 @@
 (deftest cljs-assertions-passing?-roundtrip
   (testing "assertions-passing? returns true on all-pass, false on any-fail"
     (rf/reg-event :test/n2 (fn [{:keys [db]} _] {:db (assoc db :n 42)}))
-    (story/reg-variant :story.cljs.passing/ok
+    (rf.story/reg-variant :story.cljs.passing/ok
       {:setup [[:test/n2]]
        :script [[:dispatch-sync [:rf.assert/path-equals [:n] 42]]]})
-    (story/reg-variant :story.cljs.passing/bad
+    (rf.story/reg-variant :story.cljs.passing/bad
       {:setup [[:test/n2]]
        :script [[:dispatch-sync [:rf.assert/path-equals [:n] 999]]]})
     (async done
-      (-> (story/run-variant :story.cljs.passing/ok)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.cljs.passing/ok)
+          (rf.story.async/then
             (fn [ok-r]
-              (is (true? (story/assertions-passing? ok-r)))
-              (-> (story/run-variant :story.cljs.passing/bad)
-                  (async-lib/then
+              (is (true? (rf.story/assertions-passing? ok-r)))
+              (-> (rf.story/run-variant :story.cljs.passing/bad)
+                  (rf.story.async/then
                     (fn [bad-r]
-                      (is (false? (story/assertions-passing? bad-r)))
-                      (story/destroy-variant! :story.cljs.passing/ok)
-                      (story/destroy-variant! :story.cljs.passing/bad)
+                      (is (false? (rf.story/assertions-passing? bad-r)))
+                      (rf.story/destroy-variant! :story.cljs.passing/ok)
+                      (rf.story/destroy-variant! :story.cljs.passing/bad)
                       (done))))))))))
 
 ;; ---- record-don't-throw contract on CLJS --------------------------------
 
 (deftest cljs-record-not-throw
   (testing "failing assertions never throw on CLJS; sequence runs to completion"
-    (story/reg-variant :story.cljs.contract/v
+    (rf.story/reg-variant :story.cljs.contract/v
       {:setup []
        :script [[:dispatch-sync [:rf.assert/path-equals [:nope] :unexpected]]
                 [:dispatch-sync [:rf.assert/path-equals [:also-nope] :other]]]})
     (async done
-      (-> (story/run-variant :story.cljs.contract/v)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.cljs.contract/v)
+          (rf.story.async/then
             (fn [r]
               (is (= 2 (count (:assertions r))))
               (is (every? #(false? (:passed? %)) (:assertions r)))
-              (is (false? (story/assertions-passing? r)))
-              (story/destroy-variant! :story.cljs.contract/v)
+              (is (false? (rf.story/assertions-passing? r)))
+              (rf.story/destroy-variant! :story.cljs.contract/v)
               (done)))))))
 
 ;; ---- public API additions surface check ---------------------------------
 
 (deftest cljs-public-api-surface
   (testing "Stage 5 public fns are present on the CLJS story ns"
-    (is (fn? story/assertions-passing?))
-    (is (fn? story/read-assertions))
-    (is (fn? story/canonical-assertion-ids))
-    (is (fn? story/execute-play!))
-    (is (= :rf.story/force-fx-stub story/force-fx-stub-id))))
+    (is (fn? rf.story/assertions-passing?))
+    (is (fn? rf.story/read-assertions))
+    (is (fn? rf.story/canonical-assertion-ids))
+    (is (fn? rf.story/execute-play!))
+    (is (= :rf.story/force-fx-stub rf.story/force-fx-stub-id))))
 
 ;; ===========================================================================
 ;; Internal assertion-helper branches (rf2-uhq5j)
@@ -140,7 +140,7 @@
 ;; predicate-needle (`fn?`) and bare-keyword (`keyword?`) branches of
 ;; `:rf.assert/dispatched?` (/spec/007-Stories.md's `[event-or-pred]`) had no test.
 
-(def ^:private event-matches? @#'assertions/event-matches?)
+(def ^:private event-matches? @#'rf.story.assertions/event-matches?)
 
 (deftest cljs-event-matches?-fn-predicate-branch
   (testing "a fn needle is applied to the observed event vector"
@@ -171,7 +171,7 @@
 ;; ---- evaluate-sub-equals — the sub-throws (::compute-error) arm ----------
 ;;
 ;; Only the clean pass/fail of a well-behaved sub was tested. The
-;; evaluator wraps `subs/compute-sub` in its OWN try/catch and, when
+;; evaluator wraps `rf.subs/compute-sub` in its OWN try/catch and, when
 ;; that throws, records :passed? false with :actual :rf.assert/sub-threw
 ;; rather than propagating. Note `compute-sub` normally swallows a
 ;; throwing sub-body internally (it recovers to nil), so the evaluator's
@@ -180,12 +180,12 @@
 ;; directly (the realistic case being a failure inside compute-sub's
 ;; input-resolution / registrar-lookup before its own try).
 
-(def ^:private evaluate-sub-equals @#'assertions/evaluate-sub-equals)
+(def ^:private evaluate-sub-equals @#'rf.story.assertions/evaluate-sub-equals)
 
 (deftest cljs-evaluate-sub-equals-sub-throws
   (testing "when compute-sub throws, the evaluator records a fail with
             :actual :rf.assert/sub-threw — never propagates"
-    (with-redefs [subs/compute-sub (fn [_query-v _db]
+    (with-redefs [rf.subs/compute-sub (fn [_query-v _db]
                                       (throw (ex-info "kaboom" {})))]
       (let [out (evaluate-sub-equals :rf/default {} [[:boom] :anything])]
         (is (false? (:passed? out)))
@@ -208,7 +208,7 @@
 (deftest cljs-evaluate-sub-equals-runtime-db-projection
   (testing "evaluate-sub-equals resolves a runtime-db-projection sub against
             the frame-state value, not nil"
-    (subs/reg-runtime-sub :pecaxy/light
+    (rf.subs/reg-runtime-sub :pecaxy/light
       (fn [rt _] (get-in rt [:rf.runtime/machines :snapshots :traffic-light :state])))
     (let [runtime    {:rf.runtime/machines {:snapshots {:traffic-light {:state :red}}}}
           frame-state {:rf.db/app {} :rf.db/runtime runtime}
@@ -232,10 +232,10 @@
 ;; as a rejection, never propagated).
 ;;
 ;; rf2-q651r — the evaluator is now a pure fn: its first arg is the
-;; tape-projected emitted-fx SET (`assertions/emitted-fx`), not a frame-id.
+;; tape-projected emitted-fx SET (`rf.story.assertions/emitted-fx`), not a frame-id.
 ;; We pass the set directly (the realistic shape: the fx WAS emitted).
 
-(def ^:private evaluate-effect-emitted @#'assertions/evaluate-effect-emitted)
+(def ^:private evaluate-effect-emitted @#'rf.story.assertions/evaluate-effect-emitted)
 
 (deftest cljs-evaluate-effect-emitted-pred-rejects-present-fx
   (testing "fx present but optional predicate returns false → fail with

--- a/tools/story/test/re_frame/story_assertions_test.clj
+++ b/tools/story/test/re_frame/story_assertions_test.clj
@@ -25,38 +25,38 @@
             ;; (the dep rides the shared `:test` alias). Without this the
             ;; facade degrades to `[]` and the regression has no tape to
             ;; read.
-            [re-frame.epoch            :as epoch]
+            [re-frame.epoch            :as rf.epoch]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.machines         :as machines]
-            [re-frame.registrar        :as registrar]
-            [re-frame.subs             :as subs]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story            :as story]
-            [re-frame.story.assertions :as assertions]
-            [re-frame.story.async      :as async]
-            [re-frame.story.config     :as config]
-            [re-frame.story.loaders    :as loaders]))
+            [re-frame.frame            :as rf.frame]
+            [re-frame.machines         :as rf.machines]
+            [re-frame.registrar        :as rf.registrar]
+            [re-frame.subs             :as rf.subs]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story            :as rf.story]
+            [re-frame.story.assertions :as rf.story.assertions]
+            [re-frame.story.async      :as rf.story.async]
+            [re-frame.story.config     :as rf.story.config]
+            [re-frame.story.loaders    :as rf.story.loaders]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
 (defn reset-all [test-fn]
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
   (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (config/set-global-args! {})
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.config/set-global-args! {})
   ;; Clear per-frame assertion accumulators between tests.
   ;; rf2-q651r — clear the epoch tape + listeners between tests so the
   ;; tape-projected assertions read only their own freshly-captured tape.
-  (epoch/clear-history!)
-  (epoch/clear-epoch-listeners!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.epoch/clear-history!)
+  (rf.epoch/clear-epoch-listeners!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (test-fn))
 
 (use-fixtures :each reset-all)
@@ -83,10 +83,10 @@
 (deftest canonical-assertion-ids-set-exported
   (testing "canonical-assertion-ids returns the seven dispatched handlers PLUS
             the tape-evaluated :rf.assert/schema-error (rf2-5x1wt.21)"
-    (is (= 8 (count (story/canonical-assertion-ids))))
-    (is (contains? (story/canonical-assertion-ids) :rf.assert/schema-error))
-    (is (= assertions/canonical-assertion-ids
-           (story/canonical-assertion-ids)))))
+    (is (= 8 (count (rf.story/canonical-assertion-ids))))
+    (is (contains? (rf.story/canonical-assertion-ids) :rf.assert/schema-error))
+    (is (= rf.story.assertions/canonical-assertion-ids
+           (rf.story/canonical-assertion-ids)))))
 
 ;; ===========================================================================
 ;; :rf.assert/path-equals
@@ -96,26 +96,26 @@
   (testing ":rf.assert/path-equals passes when value at path matches"
     (rf/reg-event :test/set-status
       (fn [{:keys [db]} _] {:db (assoc-in db [:auth :status] :authenticated)}))
-    (story/reg-variant :story.auth/happy
+    (rf.story/reg-variant :story.auth/happy
       {:setup [[:test/set-status]]
        :script [[:dispatch-sync [:rf.assert/path-equals [:auth :status] :authenticated]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.auth/happy) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.auth/happy) 5000)]
       (is (= 1 (count (:assertions r))))
       (is (true? (-> r :assertions first :passed?)))
       (is (= :rf.assert/path-equals (-> r :assertions first :assertion))))
-    (story/destroy-variant! :story.auth/happy)))
+    (rf.story/destroy-variant! :story.auth/happy)))
 
 (deftest path-equals-fail
   (testing ":rf.assert/path-equals records failure on mismatch (no throw)"
-    (story/reg-variant :story.auth/sad
+    (rf.story/reg-variant :story.auth/sad
       {:setup []
        :script [[:dispatch-sync [:rf.assert/path-equals [:auth :status] :authenticated]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.auth/sad) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.auth/sad) 5000)]
       (is (= 1 (count (:assertions r))))
       (is (false? (-> r :assertions first :passed?)))
       (is (= :authenticated (-> r :assertions first :expected)))
       (is (nil? (-> r :assertions first :actual))))
-    (story/destroy-variant! :story.auth/sad)))
+    (rf.story/destroy-variant! :story.auth/sad)))
 
 ;; ===========================================================================
 ;; :rf.assert/path-matches
@@ -125,23 +125,23 @@
   (testing ":rf.assert/path-matches validates against malli"
     (rf/reg-event :test/set-count
       (fn [{:keys [db]} _] {:db (assoc db :n 42)}))
-    (story/reg-variant :story.malli/ok
+    (rf.story/reg-variant :story.malli/ok
       {:setup [[:test/set-count]]
        :script [[:dispatch-sync [:rf.assert/path-matches [:n] :int]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.malli/ok) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.malli/ok) 5000)]
       (is (true? (-> r :assertions first :passed?))))
-    (story/destroy-variant! :story.malli/ok)))
+    (rf.story/destroy-variant! :story.malli/ok)))
 
 (deftest path-matches-fail
   (testing ":rf.assert/path-matches records failure with explanation on schema mismatch"
     (rf/reg-event :test/set-bad
       (fn [{:keys [db]} _] {:db (assoc db :n "not a number")}))
-    (story/reg-variant :story.malli/bad
+    (rf.story/reg-variant :story.malli/bad
       {:setup [[:test/set-bad]]
        :script [[:dispatch-sync [:rf.assert/path-matches [:n] :int]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.malli/bad) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.malli/bad) 5000)]
       (is (false? (-> r :assertions first :passed?))))
-    (story/destroy-variant! :story.malli/bad)))
+    (rf.story/destroy-variant! :story.malli/bad)))
 
 ;; ===========================================================================
 ;; :rf.assert/sub-equals
@@ -152,25 +152,25 @@
     (rf/reg-event :test/init
       (fn [{:keys [db]} _] {:db (assoc db :counter 7)}))
     (rf/reg-sub :counter (fn [db _] (:counter db)))
-    (story/reg-variant :story.sub/v
+    (rf.story/reg-variant :story.sub/v
       {:setup [[:test/init]]
        :script [[:dispatch-sync [:rf.assert/sub-equals [:counter] 7]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.sub/v) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.sub/v) 5000)]
       (is (true? (-> r :assertions first :passed?)))
       (is (= 7 (-> r :assertions first :actual))))
-    (story/destroy-variant! :story.sub/v)))
+    (rf.story/destroy-variant! :story.sub/v)))
 
 (deftest sub-equals-fail
   (testing ":rf.assert/sub-equals records the mismatch"
     (rf/reg-event :test/init2
       (fn [{:keys [db]} _] {:db (assoc db :counter 3)}))
     (rf/reg-sub :counter (fn [db _] (:counter db)))
-    (story/reg-variant :story.sub/bad
+    (rf.story/reg-variant :story.sub/bad
       {:setup [[:test/init2]]
        :script [[:dispatch-sync [:rf.assert/sub-equals [:counter] 7]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.sub/bad) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.sub/bad) 5000)]
       (is (false? (-> r :assertions first :passed?))))
-    (story/destroy-variant! :story.sub/bad)))
+    (rf.story/destroy-variant! :story.sub/bad)))
 
 (deftest sub-equals-runtime-db-projection
   ;; rf2-pecaxy regression: a `:rf.assert/sub-equals` over a sub that
@@ -189,18 +189,18 @@
                                   {:state :red})}))
     ;; A runtime-db sub projecting the snapshot's :state — the idiomatic
     ;; shape an app sub uses to read machine state reactively.
-    (subs/reg-runtime-sub :traffic-light/state
+    (rf.subs/reg-runtime-sub :traffic-light/state
       (fn [rt _] (get-in rt [:rf.runtime/machines :snapshots :traffic-light :state])))
-    (story/reg-variant :story.sub/runtime
+    (rf.story/reg-variant :story.sub/runtime
       {:setup [[:test/seed-machine-sub]]
        :script [[:dispatch-sync [:rf.assert/sub-equals [:traffic-light/state] :red]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.sub/runtime) 5000)
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.sub/runtime) 5000)
           a (-> r :assertions first)]
       (is (true? (:passed? a))
           "the runtime-db-projection sub resolved its live value through sub-equals")
       (is (= :red (:actual a))
           "actual is the live runtime-db value, not nil (the pre-pecaxy bug)"))
-    (story/destroy-variant! :story.sub/runtime)))
+    (rf.story/destroy-variant! :story.sub/runtime)))
 
 ;; ===========================================================================
 ;; :rf.assert/dispatched?
@@ -210,24 +210,24 @@
   (testing ":rf.assert/dispatched? passes when an earlier event in :script fired"
     (rf/reg-event :test/click
       (fn [{:keys [db]} _] {:db (assoc db :clicked? true)}))
-    (story/reg-variant :story.dispatched/v
+    (rf.story/reg-variant :story.dispatched/v
       {:setup []
        :script [[:dispatch-sync [:test/click]]
                 [:dispatch-sync [:rf.assert/dispatched? [:test/click]]]]})
-    (let [r       (async/deref-blocking (story/run-variant :story.dispatched/v) 5000)
+    (let [r       (rf.story.async/deref-blocking (rf.story/run-variant :story.dispatched/v) 5000)
           asserts (:assertions r)
           last-a  (last asserts)]
       (is (true? (:passed? last-a)) "the dispatched? assertion saw the test/click event"))
-    (story/destroy-variant! :story.dispatched/v)))
+    (rf.story/destroy-variant! :story.dispatched/v)))
 
 (deftest dispatched-fail
   (testing ":rf.assert/dispatched? records a fail when no matching event was dispatched"
-    (story/reg-variant :story.dispatched/no
+    (rf.story/reg-variant :story.dispatched/no
       {:setup []
        :script [[:dispatch-sync [:rf.assert/dispatched? [:never/fired]]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.dispatched/no) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.dispatched/no) 5000)]
       (is (false? (-> r :assertions first :passed?))))
-    (story/destroy-variant! :story.dispatched/no)))
+    (rf.story/destroy-variant! :story.dispatched/no)))
 
 ;; ===========================================================================
 ;; :rf.assert/state-is
@@ -242,12 +242,12 @@
         {:rf.db/runtime (assoc-in (or rt {})
                                   [:rf.runtime/machines :snapshots :traffic-light]
                                   {:state :red})}))
-    (story/reg-variant :story.machine/red
+    (rf.story/reg-variant :story.machine/red
       {:setup [[:test/seed-machine]]
        :script [[:dispatch-sync [:rf.assert/state-is :traffic-light :red]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.machine/red) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.machine/red) 5000)]
       (is (true? (-> r :assertions first :passed?))))
-    (story/destroy-variant! :story.machine/red)))
+    (rf.story/destroy-variant! :story.machine/red)))
 
 (deftest state-is-fail
   (testing ":rf.assert/state-is records the mismatch when state differs"
@@ -256,14 +256,14 @@
         {:rf.db/runtime (assoc-in (or rt {})
                                   [:rf.runtime/machines :snapshots :traffic-light]
                                   {:state :green})}))
-    (story/reg-variant :story.machine/mismatch
+    (rf.story/reg-variant :story.machine/mismatch
       {:setup [[:test/seed-machine2]]
        :script [[:dispatch-sync [:rf.assert/state-is :traffic-light :red]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.machine/mismatch) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.machine/mismatch) 5000)]
       (is (false? (-> r :assertions first :passed?)))
       (is (= :red   (-> r :assertions first :expected)))
       (is (= :green (-> r :assertions first :actual))))
-    (story/destroy-variant! :story.machine/mismatch)))
+    (rf.story/destroy-variant! :story.machine/mismatch)))
 
 ;; ===========================================================================
 ;; :rf.assert/no-warnings  (Stage 5 trace-bus accumulator)
@@ -271,12 +271,12 @@
 
 (deftest no-warnings-pass-when-silent
   (testing ":rf.assert/no-warnings passes when no warning was emitted"
-    (story/reg-variant :story.warn/silent
+    (rf.story/reg-variant :story.warn/silent
       {:setup []
        :script [[:dispatch-sync [:rf.assert/no-warnings]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.warn/silent) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.warn/silent) 5000)]
       (is (true? (-> r :assertions first :passed?))))
-    (story/destroy-variant! :story.warn/silent)))
+    (rf.story/destroy-variant! :story.warn/silent)))
 
 ;; ===========================================================================
 ;; :rf.assert/effect-emitted  (Stage 5 trace-bus accumulator + fx-stub log)
@@ -284,12 +284,12 @@
 
 (deftest effect-emitted-fail-when-no-fx
   (testing ":rf.assert/effect-emitted records a fail when no fx fired"
-    (story/reg-variant :story.fx/none
+    (rf.story/reg-variant :story.fx/none
       {:setup []
        :script [[:dispatch-sync [:rf.assert/effect-emitted :http]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.fx/none) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.fx/none) 5000)]
       (is (false? (-> r :assertions first :passed?))))
-    (story/destroy-variant! :story.fx/none)))
+    (rf.story/destroy-variant! :story.fx/none)))
 
 ;; ===========================================================================
 ;; Record-don't-throw contract — `004-Assertions.md` §Record-don't-throw semantics
@@ -298,12 +298,12 @@
 (deftest record-not-throw-on-failure
   (testing "a failing assertion never throws; the play sequence continues"
     (rf/reg-event :test/touch (fn [{:keys [db]} _] {:db (assoc db :touched true)}))
-    (story/reg-variant :story.contract/v
+    (rf.story/reg-variant :story.contract/v
       {:setup []
        :script [[:dispatch-sync [:rf.assert/path-equals [:nope] :unexpected]]
                 [:dispatch-sync [:test/touch]]
                 [:dispatch-sync [:rf.assert/path-equals [:touched] true]]]})      ; pass
-    (let [r (async/deref-blocking (story/run-variant :story.contract/v) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.contract/v) 5000)]
       ;; Both assertions recorded — sequence did NOT halt on the first
       ;; failure.
       (is (= 2 (count (:assertions r))))
@@ -311,7 +311,7 @@
       (is (true?  (-> r :assertions second :passed?)))
       (is (true?  (-> r :app-db :touched))
           ":test/touch fired between the two assertions"))
-    (story/destroy-variant! :story.contract/v)))
+    (rf.story/destroy-variant! :story.contract/v)))
 
 ;; ===========================================================================
 ;; assertions-passing? — the cljs.test adapter predicate
@@ -319,36 +319,36 @@
 
 (deftest assertions-passing-vacuously-true-on-empty
   (testing "an empty assertions list passes vacuously (/spec/007-Stories.md §Story-as-test duality)"
-    (story/reg-variant :story.empty/v {:setup [] :script []})
-    (let [r (async/deref-blocking (story/run-variant :story.empty/v) 5000)]
-      (is (true? (story/assertions-passing? r))
+    (rf.story/reg-variant :story.empty/v {:setup [] :script []})
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.empty/v) 5000)]
+      (is (true? (rf.story/assertions-passing? r))
           "a variant with no :script still 'passes' for cljs.test integration")
       (is (empty? (:assertions r))))
-    (story/destroy-variant! :story.empty/v)))
+    (rf.story/destroy-variant! :story.empty/v)))
 
 (deftest assertions-passing-true-on-all-pass
   (testing "passing? returns true when every assertion has :passed? true"
     (rf/reg-event :test/n (fn [{:keys [db]} _] {:db (assoc db :n 42)}))
-    (story/reg-variant :story.all-pass/v
+    (rf.story/reg-variant :story.all-pass/v
       {:setup [[:test/n]]
        :script [[:dispatch-sync [:rf.assert/path-equals [:n] 42]]
                 [:dispatch-sync [:rf.assert/path-matches [:n] :int]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.all-pass/v) 5000)]
-      (is (true? (story/assertions-passing? r)))
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.all-pass/v) 5000)]
+      (is (true? (rf.story/assertions-passing? r)))
       ;; Also accepts the assertions vector directly:
-      (is (true? (story/assertions-passing? (:assertions r)))))
-    (story/destroy-variant! :story.all-pass/v)))
+      (is (true? (rf.story/assertions-passing? (:assertions r)))))
+    (rf.story/destroy-variant! :story.all-pass/v)))
 
 (deftest assertions-passing-false-on-any-fail
   (testing "passing? returns false when any assertion failed"
     (rf/reg-event :test/n2 (fn [{:keys [db]} _] {:db (assoc db :n 1)}))
-    (story/reg-variant :story.any-fail/v
+    (rf.story/reg-variant :story.any-fail/v
       {:setup [[:test/n2]]
        :script [[:dispatch-sync [:rf.assert/path-equals [:n] 1]]
                 [:dispatch-sync [:rf.assert/path-equals [:n] 999]]]})  ; fail
-    (let [r (async/deref-blocking (story/run-variant :story.any-fail/v) 5000)]
-      (is (false? (story/assertions-passing? r))))
-    (story/destroy-variant! :story.any-fail/v)))
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.any-fail/v) 5000)]
+      (is (false? (rf.story/assertions-passing? r))))
+    (rf.story/destroy-variant! :story.any-fail/v)))
 
 ;; ===========================================================================
 ;; The assertion record carries the canonical fields
@@ -357,33 +357,33 @@
 (deftest record-shape
   (testing "an assertion record carries :assertion :payload :passed? :elapsed-ms :reason"
     (rf/reg-event :test/init3 (fn [{:keys [db]} _] {:db (assoc db :x 1)}))
-    (story/reg-variant :story.shape/v
+    (rf.story/reg-variant :story.shape/v
       {:setup [[:test/init3]]
        :script [[:dispatch-sync [:rf.assert/path-equals [:x] 1]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.shape/v) 5000)
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.shape/v) 5000)
           a (first (:assertions r))]
       (is (= :rf.assert/path-equals  (:assertion a)))
       (is (= [[:x] 1]                (:payload a)))
       (is (true?                     (:passed? a)))
       (is (number?                   (:elapsed-ms a)))
       (is (string?                   (:reason a))))
-    (story/destroy-variant! :story.shape/v)))
+    (rf.story/destroy-variant! :story.shape/v)))
 
 ;; ===========================================================================
 ;; read-assertions — public alias for the per-frame accumulator
 ;; ===========================================================================
 
 (deftest read-assertions-public
-  (testing "story/read-assertions returns the live accumulator"
+  (testing "rf.story/read-assertions returns the live accumulator"
     (rf/reg-event :test/q (fn [{:keys [db]} _] {:db (assoc db :q :ok)}))
-    (story/reg-variant :story.read/v
+    (rf.story/reg-variant :story.read/v
       {:setup [[:test/q]]
        :script [[:dispatch-sync [:rf.assert/path-equals [:q] :ok]]]})
-    (let [_ (async/deref-blocking (story/run-variant :story.read/v) 5000)
-          a (story/read-assertions :story.read/v)]
+    (let [_ (rf.story.async/deref-blocking (rf.story/run-variant :story.read/v) 5000)
+          a (rf.story/read-assertions :story.read/v)]
       (is (= 1 (count a)))
       (is (true? (:passed? (first a)))))
-    (story/destroy-variant! :story.read/v)))
+    (rf.story/destroy-variant! :story.read/v)))
 
 ;; ===========================================================================
 ;; assertion-event? — play-runner discriminator
@@ -391,12 +391,12 @@
 
 (deftest assertion-event-discriminator
   (testing "assertion-event? recognises :rf.assert/* but not other namespaces"
-    (is (true?  (assertions/assertion-event? [:rf.assert/path-equals [:x] 1])))
-    (is (true?  (assertions/assertion-event? [:rf.assert/no-warnings])))
-    (is (false? (assertions/assertion-event? [:auth/login])))
-    (is (false? (assertions/assertion-event? [:rf.story/something])))
-    (is (false? (assertions/assertion-event? nil)))
-    (is (false? (assertions/assertion-event? [])))))
+    (is (true?  (rf.story.assertions/assertion-event? [:rf.assert/path-equals [:x] 1])))
+    (is (true?  (rf.story.assertions/assertion-event? [:rf.assert/no-warnings])))
+    (is (false? (rf.story.assertions/assertion-event? [:auth/login])))
+    (is (false? (rf.story.assertions/assertion-event? [:rf.story/something])))
+    (is (false? (rf.story.assertions/assertion-event? nil)))
+    (is (false? (rf.story.assertions/assertion-event? [])))))
 
 ;; ===========================================================================
 ;; :rf.assert/schema-error — the EXPECTED schema-violation declaration
@@ -408,46 +408,46 @@
 (deftest schema-error-recognised-and-known
   (testing ":rf.assert/schema-error is recognised but is NOT one of the seven
             dispatched handlers"
-    (is (assertions/assertion-id-known? :rf.assert/schema-error))
-    (is (assertions/schema-error? [:rf.assert/schema-error {:where :event :event :x}]))
-    (is (assertions/schema-error? [:rf.assert/schema-error]))
-    (is (not (assertions/schema-error? [:rf.assert/path-equals [:k] 1])))))
+    (is (rf.story.assertions/assertion-id-known? :rf.assert/schema-error))
+    (is (rf.story.assertions/schema-error? [:rf.assert/schema-error {:where :event :event :x}]))
+    (is (rf.story.assertions/schema-error? [:rf.assert/schema-error]))
+    (is (not (rf.story.assertions/schema-error? [:rf.assert/path-equals [:k] 1])))))
 
 (deftest schema-error-selector-mirrors-violation-selector
   (testing "the declared expectation's selector matches evidence/violation-selector
             key-for-key per surface (so the matcher pairs them)"
     ;; :event (+ optional :path)
     (is (= [:event :checkout/submit]
-           (assertions/schema-error-selector {:where :event :event :checkout/submit})))
+           (rf.story.assertions/schema-error-selector {:where :event :event :checkout/submit})))
     (is (= [:event :checkout/submit [:cart]]
-           (assertions/schema-error-selector {:where :event :event :checkout/submit
+           (rf.story.assertions/schema-error-selector {:where :event :event :checkout/submit
                                               :path [:cart]})))
     ;; :cofx / :fx-args
     (is (= [:cofx :load/session]
-           (assertions/schema-error-selector {:where :cofx :cofx :load/session})))
+           (rf.story.assertions/schema-error-selector {:where :cofx :cofx :load/session})))
     (is (= [:fx-args :http/get]
-           (assertions/schema-error-selector {:where :fx-args :fx-args :http/get})))
+           (rf.story.assertions/schema-error-selector {:where :fx-args :fx-args :http/get})))
     ;; :sub-return / :app-db / :machine-data
     (is (= [:sub-return :auth/state [:auth/state]]
-           (assertions/schema-error-selector {:where :sub-return :sub-return :auth/state
+           (rf.story.assertions/schema-error-selector {:where :sub-return :sub-return :auth/state
                                               :query-v [:auth/state]})))
     (is (= [:app-db [:auth] [:auth :token]]
-           (assertions/schema-error-selector {:where :app-db :registered-path [:auth]
+           (rf.story.assertions/schema-error-selector {:where :app-db :registered-path [:auth]
                                               :path [:auth :token]})))
     (is (= [:machine-data :checkout/fsm :entry]
-           (assertions/schema-error-selector {:where :machine-data :machine-id :checkout/fsm
+           (rf.story.assertions/schema-error-selector {:where :machine-data :machine-id :checkout/fsm
                                               :phase :entry}))))
   (testing "a bare / where-less spec selects the [:any] wildcard"
-    (is (= [:any] (assertions/schema-error-selector {})))
-    (is (= [:any] (assertions/schema-error-selector {:event :x}))))
+    (is (= [:any] (rf.story.assertions/schema-error-selector {})))
+    (is (= [:any] (rf.story.assertions/schema-error-selector {:event :x}))))
   (testing "an unrecognised surface keys by [:where failing-id] (open fallback)"
     (is (= [:custom/surface :some-id]
-           (assertions/schema-error-selector {:where :custom/surface :failing-id :some-id})))))
+           (rf.story.assertions/schema-error-selector {:where :custom/surface :failing-id :some-id})))))
 
 (deftest schema-error-expectation-projection
   (testing "schema-error-expectation carries the atom, spec, and selector"
     (let [a   [:rf.assert/schema-error {:where :event :event :x}]
-          exp (assertions/schema-error-expectation a)]
+          exp (rf.story.assertions/schema-error-expectation a)]
       (is (= a (:atom exp)))
       (is (= {:where :event :event :x} (:spec exp)))
       (is (= [:event :x] (:selector exp))))))
@@ -464,7 +464,7 @@
 ;; reach the fail branch directly via the established var-quote seam.
 ;; ===========================================================================
 
-(def ^:private evaluate-no-warnings @#'assertions/evaluate-no-warnings)
+(def ^:private evaluate-no-warnings @#'rf.story.assertions/evaluate-no-warnings)
 
 (deftest evaluate-no-warnings-fail-branch
   (testing "warnings present → :passed? false, with :count / :actual / reason"
@@ -504,35 +504,35 @@
 (deftest causal-bounds-exactly-shorthand
   (testing ":exactly pins BOTH bounds to n, regardless of the per-id default"
     (is (= {:min 2 :max 2}
-           (assertions/causal-bounds :rf.assert/caused {:exactly 2}))
+           (rf.story.assertions/causal-bounds :rf.assert/caused {:exactly 2}))
         ":exactly on :caused pins min=max=2 (overriding the {:min 1} default)")
     (is (= {:min 0 :max 0}
-           (assertions/causal-bounds :rf.assert/no-cascade-rerender {:exactly 0}))
+           (rf.story.assertions/causal-bounds :rf.assert/no-cascade-rerender {:exactly 0}))
         ":exactly 0 on :no-cascade-rerender pins both to 0")
     (is (= {:min 3 :max 3}
-           (assertions/causal-bounds :rf.assert/no-cascade-rerender {:exactly 3}))
+           (rf.story.assertions/causal-bounds :rf.assert/no-cascade-rerender {:exactly 3}))
         ":exactly overrides the no-cascade default {:min 0 :max 0}")))
 
 (deftest causal-bounds-min-override-on-caused
   (testing ":min override on :rf.assert/caused — 'caused at least n times'"
     (is (= {:min 3}
-           (assertions/causal-bounds :rf.assert/caused {:min 3}))
+           (rf.story.assertions/causal-bounds :rf.assert/caused {:min 3}))
         ":min 3 overrides the default {:min 1}; :max stays absent (unbounded)")
     (is (= {:min 1}
-           (assertions/causal-bounds :rf.assert/caused {}))
+           (rf.story.assertions/causal-bounds :rf.assert/caused {}))
         "default for :caused is {:min 1} (the contrast — no override)")
     (is (= {:min 2 :max 5}
-           (assertions/causal-bounds :rf.assert/caused {:min 2 :max 5}))
+           (rf.story.assertions/causal-bounds :rf.assert/caused {:min 2 :max 5}))
         "both :min and :max may override on :caused")))
 
 (deftest causal-effect-surface-sub-over-view-precedence
   (testing ":sub takes precedence over :view when BOTH are present"
     (is (= [:sub :a]
-           (assertions/causal-effect-surface {:sub :a :view :b}))
+           (rf.story.assertions/causal-effect-surface {:sub :a :view :b}))
         "a spec naming both measures the sub recompute (sub wins)")
-    (is (= [:sub :a]   (assertions/causal-effect-surface {:sub :a})))
-    (is (= [:view :b]  (assertions/causal-effect-surface {:view :b})))
-    (is (= [:any]      (assertions/causal-effect-surface {}))
+    (is (= [:sub :a]   (rf.story.assertions/causal-effect-surface {:sub :a})))
+    (is (= [:view :b]  (rf.story.assertions/causal-effect-surface {:view :b})))
+    (is (= [:any]      (rf.story.assertions/causal-effect-surface {}))
         "neither :sub nor :view → the cause's total recompute+render count")))
 
 ;; ===========================================================================
@@ -556,12 +556,12 @@
     ;; (:rf.error/no-such-handler), NOT `:op-type :warning`. The tape's
     ;; :warnings projection (and therefore the run-result slot) stays empty;
     ;; the in-script no-warnings assertion reads the SAME projection.
-    (story/reg-variant :story.ssot/error-only
+    (rf.story/reg-variant :story.ssot/error-only
       {:setup []
        :script [[:dispatch-sync [:no/such-handler]]
                      [:dispatch-sync [:rf.assert/no-warnings]]]})
-    (let [r        (async/deref-blocking
-                     (story/run-variant :story.ssot/error-only) 5000)
+    (let [r        (rf.story.async/deref-blocking
+                     (rf.story/run-variant :story.ssot/error-only) 5000)
           no-warn  (->> (:assertions r)
                         (filter #(= :rf.assert/no-warnings (:assertion %)))
                         last)]
@@ -572,7 +572,7 @@
       (is (= (count (:warnings r)) (:count no-warn))
           "the assertion :count AGREES with the run-result :warnings slot count
            — one SSOT, no atom/tape divergence"))
-    (story/destroy-variant! :story.ssot/error-only)))
+    (rf.story/destroy-variant! :story.ssot/error-only)))
 
 (deftest dispatched?-projects-from-tape-trigger-events
   (testing ":rf.assert/dispatched? reads the epoch-tape :trigger-event
@@ -580,14 +580,14 @@
             bare keyword head — including a re-dispatched (nested) event"
     (rf/reg-event :ssot/outer (fn [_ _] {:fx [[:dispatch [:ssot/inner 42]]]}))
     (rf/reg-event :ssot/inner (fn [{:keys [db]} [_ n]] {:db (assoc db :inner n)}))
-    (story/reg-variant :story.ssot/dispatched
+    (rf.story/reg-variant :story.ssot/dispatched
       {:setup []
        :script [[:dispatch-sync [:ssot/outer]]
                      [:dispatch-sync [:rf.assert/dispatched? [:ssot/inner 42]]]
                      [:dispatch-sync [:rf.assert/dispatched? :ssot/inner]]
                      [:dispatch-sync [:rf.assert/dispatched? [:never/fired]]]]})
-    (let [r       (async/deref-blocking
-                    (story/run-variant :story.ssot/dispatched) 5000)
+    (let [r       (rf.story.async/deref-blocking
+                    (rf.story/run-variant :story.ssot/dispatched) 5000)
           by-need (->> (:assertions r)
                        (filter #(= :rf.assert/dispatched? (:assertion %)))
                        (map (juxt :expected :passed?))
@@ -598,7 +598,7 @@
           "a bare keyword needle matches the trigger-event's head id")
       (is (false? (get by-need [:never/fired]))
           "an event never dispatched does not appear on the tape → fail"))
-    (story/destroy-variant! :story.ssot/dispatched)))
+    (rf.story/destroy-variant! :story.ssot/dispatched)))
 
 ;; ===========================================================================
 ;; rf2-ynjts.21 — `dispatched-events` projection: the PRIVACY filter +
@@ -636,17 +636,17 @@
   restoring the prior value afterwards (the assertions fixture does not
   reset it, so a `set-egress-profile!` must be unwound by hand)."
   [profile thunk]
-  (let [prev @config/session-egress-profile]
-    (config/set-egress-profile! profile)
+  (let [prev @rf.story.config/session-egress-profile]
+    (rf.story.config/set-egress-profile! profile)
     (try (thunk)
-         (finally (config/set-egress-profile! prev)))))
+         (finally (rf.story.config/set-egress-profile! prev)))))
 
 (defn- with-tape
   "Run `thunk` with the private `frame-tape` projection redefed to return
   `tape` for any frame (`with-redefs-fn` takes the `#'`-var directly, so a
   private fn in another ns is redefable without importing it)."
   [tape thunk]
-  (with-redefs-fn {#'assertions/frame-tape (constantly tape)} thunk))
+  (with-redefs-fn {#'rf.story.assertions/frame-tape (constantly tape)} thunk))
 
 (deftest dispatched-events-drops-sensitive-trigger-when-redacting
   (testing "an epoch flagged :rf.epoch/sensitive? has its :trigger-event
@@ -661,7 +661,7 @@
         (fn []
           (with-egress-profile :rf.egress/local-redacted
             (fn []
-              (let [events (assertions/dispatched-events :any-frame)]
+              (let [events (rf.story.assertions/dispatched-events :any-frame)]
                 (is (= [[:auth/login]] events)
                     "the sensitive epoch's trigger-event is filtered out — only
                      the non-sensitive event projects")
@@ -679,7 +679,7 @@
         (fn []
           (with-egress-profile :rf.egress/local-raw
             (fn []
-              (let [events (assertions/dispatched-events :any-frame)]
+              (let [events (rf.story.assertions/dispatched-events :any-frame)]
                 (is (= [[:auth/login] [:auth/submit {:password "hunter2"}]] events)
                     "both trigger-events project under the raw profile — the drop
                      is gated on the profile, not unconditional")))))))))
@@ -698,7 +698,7 @@
         (fn []
           (with-egress-profile :rf.egress/local-redacted
             (fn []
-              (let [events (assertions/dispatched-events :any-frame)]
+              (let [events (rf.story.assertions/dispatched-events :any-frame)]
                 (is (= [[:cart/add-item {:sku "A"}] [:cart/checkout]] events)
                     "only the two real events project; both :rf.assert/* verdict
                      trigger-events are dropped")
@@ -711,20 +711,20 @@
             no events — the host-free floor, not a throw"
     (with-tape []
       (fn []
-        (is (= [] (assertions/dispatched-events :any-frame)))))))
+        (is (= [] (rf.story.assertions/dispatched-events :any-frame)))))))
 
 (deftest effect-emitted-projects-from-tape-effects
   (testing ":rf.assert/effect-emitted reads the epoch-tape :effects projection
             (the SSOT) for a real (non-stubbed) user fx"
     (rf/reg-fx :ssot.fx/real {:platforms #{:client :server}} (fn [_ _] nil))
     (rf/reg-event :ssot/emit-real (fn [_ _] {:fx [[:ssot.fx/real {:url "x"}]]}))
-    (story/reg-variant :story.ssot/effect
+    (rf.story/reg-variant :story.ssot/effect
       {:setup []
        :script [[:dispatch-sync [:ssot/emit-real]]
                      [:dispatch-sync [:rf.assert/effect-emitted :ssot.fx/real]]
                      [:dispatch-sync [:rf.assert/effect-emitted :ssot.fx/never]]]})
-    (let [r       (async/deref-blocking
-                    (story/run-variant :story.ssot/effect) 5000)
+    (let [r       (rf.story.async/deref-blocking
+                    (rf.story/run-variant :story.ssot/effect) 5000)
           by-need (->> (:assertions r)
                        (filter #(= :rf.assert/effect-emitted (:assertion %)))
                        (map (juxt :expected :passed?))
@@ -735,7 +735,7 @@
           "effect-emitted sees the fx via the SAME tape :effects projection")
       (is (false? (get by-need :ssot.fx/never))
           "an fx never emitted → fail"))
-    (story/destroy-variant! :story.ssot/effect)))
+    (rf.story/destroy-variant! :story.ssot/effect)))
 
 ;; ===========================================================================
 ;; rf2-luzky — fold coverage: a STUBBED fx is answerable from the stub-call
@@ -757,22 +757,22 @@
             stub-call log SSOT (the original fx-id, not the rewritten stub id)"
     (rf/reg-fx :ssot.fx/http {:platforms #{:client :server}} (fn [_ _] nil))
     (rf/reg-event :ssot/login (fn [_ _] {:fx [[:ssot.fx/http {:url "/login"}]]}))
-    (story/reg-variant :story.ssot/stubbed
+    (rf.story/reg-variant :story.ssot/stubbed
       {:decorators  [[:rf.story/force-fx-stub :ssot.fx/http {:status :ok}]]
        :setup      []
        :script [[:dispatch-sync [:ssot/login]]
                      [:dispatch-sync [:rf.assert/effect-emitted :ssot.fx/http]]
                      [:dispatch-sync [:rf.assert/effect-emitted :ssot.fx/never]]]})
-    (let [r       (async/deref-blocking
-                    (story/run-variant :story.ssot/stubbed) 5000)
+    (let [r       (rf.story.async/deref-blocking
+                    (rf.story/run-variant :story.ssot/stubbed) 5000)
           by-need (->> (:assertions r)
                        (filter #(= :rf.assert/effect-emitted (:assertion %)))
                        (map (juxt :expected :passed?))
                        (into {}))]
-      (is (contains? (assertions/emitted-fx :story.ssot/stubbed) :ssot.fx/http)
+      (is (contains? (rf.story.assertions/emitted-fx :story.ssot/stubbed) :ssot.fx/http)
           "emitted-fx answers the ORIGINAL fx-id from the stub-call log union")
       (is (true?  (get by-need :ssot.fx/http))
           "effect-emitted PASSES for the stubbed fx's original id")
       (is (false? (get by-need :ssot.fx/never))
           "an fx never emitted (stubbed or otherwise) → fail"))
-    (story/destroy-variant! :story.ssot/stubbed)))
+    (rf.story/destroy-variant! :story.ssot/stubbed)))

--- a/tools/story/test/re_frame/story_authoring_surface_test.clj
+++ b/tools/story/test/re_frame/story_authoring_surface_test.clj
@@ -37,36 +37,36 @@
   resolution + spec/010 §Mode authoring."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.machines         :as machines]
-            [re-frame.registrar        :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story            :as story]
-            [re-frame.story.async      :as async]
-            [re-frame.story.config     :as config]
-            [re-frame.story.decorators :as decorators]
-            [re-frame.story.frames     :as frames]
-            [re-frame.story.loaders    :as loaders]
-            [re-frame.story.plan       :as plan]
-            [re-frame.story.play       :as play]
-            [re-frame.story.ui.docs    :as docs]))
+            [re-frame.frame            :as rf.frame]
+            [re-frame.machines         :as rf.machines]
+            [re-frame.registrar        :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story            :as rf.story]
+            [re-frame.story.async      :as rf.story.async]
+            [re-frame.story.config     :as rf.story.config]
+            [re-frame.story.decorators :as rf.story.decorators]
+            [re-frame.story.frames     :as rf.story.frames]
+            [re-frame.story.loaders    :as rf.story.loaders]
+            [re-frame.story.plan       :as rf.story.plan]
+            [re-frame.story.play       :as rf.story.play]
+            [re-frame.story.ui.docs    :as rf.story.ui.docs]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
 (defn reset-all [test-fn]
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
   (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (config/set-global-args! {})
-  (reset! play/stepper-state            {})
-  (reset! frames/stub-call-log          {})
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.config/set-global-args! {})
+  (reset! rf.story.play/stepper-state            {})
+  (reset! rf.story.frames/stub-call-log          {})
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (test-fn))
 
 (use-fixtures :each reset-all)
@@ -94,12 +94,12 @@
 (deftest modes-declared-on-variant-survive-registration
   (testing ":modes #{...} on a variant body round-trips through the
             registrar — the value is queryable on the registered body"
-    (story/reg-mode :Mode.app/dark   {:args {:theme :dark}})
-    (story/reg-mode :Mode.app/mobile {:args {:viewport :mobile}})
-    (story/reg-variant :story.modedecl/v
+    (rf.story/reg-mode :Mode.app/dark   {:args {:theme :dark}})
+    (rf.story/reg-mode :Mode.app/mobile {:args {:viewport :mobile}})
+    (rf.story/reg-variant :story.modedecl/v
       {:modes  #{:Mode.app/dark :Mode.app/mobile}
        :setup []})
-    (let [body (story/handler-meta :variant :story.modedecl/v)]
+    (let [body (rf.story/handler-meta :variant :story.modedecl/v)]
       (is (= #{:Mode.app/dark :Mode.app/mobile} (:modes body))
           ":modes set survives unmutated — used by docs panel +
            toolbar to scope mode chips per variant"))))
@@ -109,23 +109,23 @@
             the effective args at the spec'd precedence layer
             (between :story-args and :variant-args). Per spec/002
             §Args resolution precedence."
-    (story/configure! {:rf.story/global-args {:theme :light :viewport :desktop}})
-    (story/reg-mode :Mode.app/dark   {:args {:theme :dark}})
-    (story/reg-mode :Mode.app/mobile {:args {:viewport :mobile}})
-    (story/reg-story :story.modemix
+    (rf.story/configure! {:rf.story/global-args {:theme :light :viewport :desktop}})
+    (rf.story/reg-mode :Mode.app/dark   {:args {:theme :dark}})
+    (rf.story/reg-mode :Mode.app/mobile {:args {:viewport :mobile}})
+    (rf.story/reg-story :story.modemix
       {:args {:label "story-label"}})
-    (story/reg-variant :story.modemix/v
+    (rf.story/reg-variant :story.modemix/v
       {:modes  #{:Mode.app/dark :Mode.app/mobile}
        :args   {:label "variant-label"}
        :setup []})
     ;; Single mode active.
-    (let [r (story/resolve-args :story.modemix/v
+    (let [r (rf.story/resolve-args :story.modemix/v
                                 {:active-modes [:Mode.app/dark]})]
       (is (= :dark           (:theme r))    "mode wins over global :light")
       (is (= :desktop        (:viewport r)) "non-active mode does NOT apply")
       (is (= "variant-label" (:label r))    "variant wins over story"))
     ;; Two modes active simultaneously (multi-axis selection).
-    (let [r (story/resolve-args :story.modemix/v
+    (let [r (rf.story/resolve-args :story.modemix/v
                                 {:active-modes [:Mode.app/dark
                                                 :Mode.app/mobile]})]
       (is (= :dark   (:theme r))     "first mode applied")
@@ -143,19 +143,19 @@
             `global < story < mode < variant < cell-overrides`. So
             a mode arg LOSES to a variant arg with the same key but
             WINS over the equivalent story / global arg."
-    (story/configure! {:rf.story/global-args {:viewport :desktop}})
-    (story/reg-mode :Mode.app/dark   {:args {:theme :dark}})
-    (story/reg-mode :Mode.app/mobile {:args {:viewport :mobile}})
-    (story/reg-story :story.modeprobe
+    (rf.story/configure! {:rf.story/global-args {:viewport :desktop}})
+    (rf.story/reg-mode :Mode.app/dark   {:args {:theme :dark}})
+    (rf.story/reg-mode :Mode.app/mobile {:args {:viewport :mobile}})
+    (rf.story/reg-story :story.modeprobe
       {:args {:theme :light}})
-    (story/reg-variant :story.modeprobe/v
+    (rf.story/reg-variant :story.modeprobe/v
       {:modes  #{:Mode.app/dark :Mode.app/mobile}
        ;; variant declares NO :theme — so the mode's :theme :dark wins
        ;; over the story's :theme :light.
        :setup []})
     ;; Active mode wins over story-level arg.
-    (let [r (async/deref-blocking
-              (story/run-variant :story.modeprobe/v
+    (let [r (rf.story.async/deref-blocking
+              (rf.story/run-variant :story.modeprobe/v
                                  {:active-modes [:Mode.app/dark
                                                  :Mode.app/mobile]})
               5000)]
@@ -169,13 +169,13 @@
       (is (= :mobile (-> r :effective-args :viewport))
           ":Mode.app/mobile wins over global :viewport :desktop (mode beats global)"))
     ;; Without :active-modes the story-level value wins (no mode merge).
-    (let [r2 (async/deref-blocking
-               (story/reset-variant :story.modeprobe/v {}) 5000)]
+    (let [r2 (rf.story.async/deref-blocking
+               (rf.story/reset-variant :story.modeprobe/v {}) 5000)]
       (is (= :light (-> r2 :effective-args :theme))
           "without :active-modes the story's :theme :light wins")
       (is (= :desktop (-> r2 :effective-args :viewport))
           "without :active-modes the global :viewport :desktop wins"))
-    (story/destroy-variant! :story.modeprobe/v)))
+    (rf.story/destroy-variant! :story.modeprobe/v)))
 
 ;; ===========================================================================
 ;; :force-fx-stub via reg-variant body (ref-args form)
@@ -191,21 +191,21 @@
   (testing "[:rf.story/force-fx-stub <fx-id> <response>] declared in
             the variant's :decorators slot round-trips through
             registration AND materialises in resolve-decorators"
-    (story/reg-variant :story.authfx/v
+    (rf.story/reg-variant :story.authfx/v
       {:decorators [[:rf.story/force-fx-stub :http      {:status :ok}]
                     [:rf.story/force-fx-stub :analytics {:ack? true}]]
        :setup     []})
     ;; The body's :decorators slot keeps the user-facing ref form
     ;; verbatim — Storybook-style decorator references stay textually
     ;; identical to what the author typed.
-    (let [body (story/handler-meta :variant :story.authfx/v)]
+    (let [body (rf.story/handler-meta :variant :story.authfx/v)]
       (is (= [[:rf.story/force-fx-stub :http      {:status :ok}]
               [:rf.story/force-fx-stub :analytics {:ack? true}]]
              (:decorators body))
           ":decorators vector survives unmutated through registration"))
     ;; resolve-decorators materialises each ref into a per-call body
     ;; with the fx-id + response carried explicitly.
-    (let [r (story/resolve-decorators :story.authfx/v)]
+    (let [r (rf.story/resolve-decorators :story.authfx/v)]
       (is (= 2 (count (:fx-override r))))
       (let [bodies (sort-by #(-> % :body :fx-id) (:fx-override r))]
         (is (= :analytics    (-> bodies first  :body :fx-id)))
@@ -215,7 +215,7 @@
       ;; The framework :fx-overrides stack picks up both with distinct
       ;; stub-event-ids (proves the value-form authoring works end-to-end
       ;; with the multi-decorator path).
-      (let [stack (decorators/fx-overrides-map (:fx-override r))]
+      (let [stack (rf.story.decorators/fx-overrides-map (:fx-override r))]
         (is (= 2 (count (:overrides stack))))
         (is (contains? (:overrides stack) :http))
         (is (contains? (:overrides stack) :analytics))))))
@@ -226,18 +226,18 @@
             redirect is unbroken"
     (rf/reg-event :do/emit-http
       (fn [_ _] {:fx [[:http {:url "/probe"}]]}))
-    (story/reg-variant :story.authfx-rt/v
+    (rf.story/reg-variant :story.authfx-rt/v
       {:decorators [[:rf.story/force-fx-stub :http {:status :ok}]]
        :setup     []
        :script [[:dispatch-sync [:do/emit-http]]
                     [:dispatch-sync [:rf.assert/effect-emitted :http]]]})
-    (let [r (async/deref-blocking
-              (story/run-variant :story.authfx-rt/v) 5000)]
+    (let [r (rf.story.async/deref-blocking
+              (rf.story/run-variant :story.authfx-rt/v) 5000)]
       (is (= :ready (:lifecycle r)))
       (is (every? :passed? (:assertions r)))
-      (is (= 1 (count (frames/stub-call-log-for :story.authfx-rt/v)))
+      (is (= 1 (count (rf.story.frames/stub-call-log-for :story.authfx-rt/v)))
           "exactly one stub call recorded"))
-    (story/destroy-variant! :story.authfx-rt/v)))
+    (rf.story/destroy-variant! :story.authfx-rt/v)))
 
 ;; ===========================================================================
 ;; Decorator inheritance via :extends — child appends; parent decorators
@@ -254,22 +254,22 @@
             INHERITS the parent's stack, surfaced through
             `resolve-decorators` (which reads the plan, not the
             side-table)."
-    (story/reg-decorator :inherited-deco
+    (rf.story/reg-decorator :inherited-deco
       {:kind :hiccup :wrap (fn [body _] [:div.inherited body])})
-    (story/reg-variant :story.inherit-bare/parent
+    (rf.story/reg-variant :story.inherit-bare/parent
       {:decorators [[:inherited-deco]]
        :setup     []})
-    (story/reg-variant :story.inherit-bare/child
+    (rf.story/reg-variant :story.inherit-bare/child
       {:extends :story.inherit-bare/parent
        :setup  []})
-    (let [body (story/handler-meta :variant :story.inherit-bare/child)]
+    (let [body (rf.story/handler-meta :variant :story.inherit-bare/child)]
       (is (= :story.inherit-bare/parent (:extends body))
           ":extends is stored RAW on the side-table body — the plan
            compiler (not the registrar) is the merge authority")
       (is (nil? (:decorators body))
           "the child declared no :decorators; the side-table body carries
            none — inheritance is resolved downstream at plan-compile"))
-    (let [pack (story/resolve-decorators :story.inherit-bare/child)]
+    (let [pack (rf.story/resolve-decorators :story.inherit-bare/child)]
       (is (= [:inherited-deco] (mapv :id (:hiccup pack)))
           "resolved hiccup stack INHERITS the parent's decorator via the
            compiled plan's [:world :decorators]"))))
@@ -282,24 +282,24 @@
             child's vector replaces the parent's (no concat / no append).
             The same child-wins rule covers :args, :setup, :tags,
             :modes, etc."
-    (story/reg-decorator :parent-deco
+    (rf.story/reg-decorator :parent-deco
       {:kind :hiccup :wrap (fn [body _] [:div.parent body])})
-    (story/reg-decorator :child-deco
+    (rf.story/reg-decorator :child-deco
       {:kind :hiccup :wrap (fn [body _] [:div.child body])})
-    (story/reg-variant :story.inherit-replace/parent
+    (rf.story/reg-variant :story.inherit-replace/parent
       {:decorators [[:parent-deco]]
        :setup     []})
-    (story/reg-variant :story.inherit-replace/child
+    (rf.story/reg-variant :story.inherit-replace/child
       {:extends    :story.inherit-replace/parent
        :decorators [[:child-deco]]
        :setup     []})
-    (let [body (story/handler-meta :variant :story.inherit-replace/child)]
+    (let [body (rf.story/handler-meta :variant :story.inherit-replace/child)]
       (is (= [[:child-deco]] (:decorators body))
           "the raw side-table body carries the child's OWN :decorators
            verbatim")
       (is (= :story.inherit-replace/parent (:extends body))
           ":extends is stored RAW — the compiler resolves the chain"))
-    (let [pack (story/resolve-decorators :story.inherit-replace/child)]
+    (let [pack (rf.story/resolve-decorators :story.inherit-replace/child)]
       (is (= [:child-deco] (mapv :id (:hiccup pack)))
           "resolved hiccup stack reflects ONLY the child's decorators"))))
 
@@ -322,19 +322,19 @@
   (testing "a registered parent+child with :extends + :checks + :setup +
             :decorators compiles via the DEFAULT side-table lookup (no
             :lookup arg): setup APPENDS, checks INHERIT, decorators INHERIT"
-    (story/reg-decorator :s84-parent-deco
+    (rf.story/reg-decorator :s84-parent-deco
       {:kind :hiccup :wrap (fn [body _] [:div.s84 body])})
-    (story/reg-variant :story.s84/parent
+    (rf.story/reg-variant :story.s84/parent
       {:setup      [[:dispatch [:s84/p1]] [:dispatch [:s84/p2]]]
        :checks     [:check/no-runtime-errors]
        :decorators [[:s84-parent-deco]]})
-    (story/reg-variant :story.s84/child
+    (rf.story/reg-variant :story.s84/child
       {:extends :story.s84/parent
        :setup   [[:dispatch [:s84/c1]]]
        :checks  [:check/extra]})
     ;; DEFAULT side-table lookup — NO :lookup arg. This is the path the
     ;; runtime uses; it must agree with the explicit-:lookup plan tests.
-    (let [p (plan/variant-plan :story.s84/child)]
+    (let [p (rf.story.plan/variant-plan :story.s84/child)]
       (testing "source chain is root-first (chain walked from the side-table)"
         (is (= [:story.s84/parent :story.s84/child] (:source-chain p))))
       (testing "setup APPENDS parent→child (the silent-regression site)"
@@ -348,7 +348,7 @@
     ;; And the registered front door (resolve-decorators) sees the same
     ;; inherited pack — proving the registered path reads the compiled
     ;; plan, not the raw side-table body.
-    (let [pack (story/resolve-decorators :story.s84/child)]
+    (let [pack (rf.story/resolve-decorators :story.s84/child)]
       (is (= [:s84-parent-deco] (mapv :id (:hiccup pack)))
           "resolve-decorators inherits the parent's decorator via the plan"))))
 
@@ -365,16 +365,16 @@
   (testing "story-level :decorators precede variant-level :decorators
             in the resolved hiccup stack (per spec/002 §Decorator
             composition: story outer, variant inner)"
-    (story/reg-decorator :story-wrap
+    (rf.story/reg-decorator :story-wrap
       {:kind :hiccup :wrap (fn [body _] [:div.story body])})
-    (story/reg-decorator :variant-wrap
+    (rf.story/reg-decorator :variant-wrap
       {:kind :hiccup :wrap (fn [body _] [:div.variant body])})
-    (story/reg-story :story.cascade
+    (rf.story/reg-story :story.cascade
       {:decorators [[:story-wrap]]})
-    (story/reg-variant :story.cascade/v
+    (rf.story/reg-variant :story.cascade/v
       {:decorators [[:variant-wrap]]
        :setup     []})
-    (let [pack (story/resolve-decorators :story.cascade/v)
+    (let [pack (rf.story/resolve-decorators :story.cascade/v)
           ids  (mapv :id (:hiccup pack))]
       (is (= [:story-wrap :variant-wrap] ids)
           "story decorators precede variant decorators — outer-first
@@ -384,19 +384,19 @@
   (testing "story-level :tags appear on the variant when the variant
             didn't declare its own :tags. Per spec/001 §Authoring
             inheritance."
-    (story/reg-story :story.tagcascade
+    (rf.story/reg-story :story.tagcascade
       {:tags #{:dev :docs}})
-    (story/reg-variant :story.tagcascade/no-tags
+    (rf.story/reg-variant :story.tagcascade/no-tags
       {:setup []})
-    (story/reg-variant :story.tagcascade/own-tags
+    (rf.story/reg-variant :story.tagcascade/own-tags
       {:tags   #{:test}
        :setup []})
     ;; The variant body's :tags slot may be empty if the variant
     ;; declared none — the docs-pane variant-tags helper is where the
     ;; cascade happens. Pin that the cascade reads through to the
     ;; effective set used by tools that consume `variant-tags`.
-    (let [no-tags  (docs/variant-tags :story.tagcascade/no-tags)
-          own-tags (docs/variant-tags :story.tagcascade/own-tags)]
+    (let [no-tags  (rf.story.ui.docs/variant-tags :story.tagcascade/no-tags)
+          own-tags (rf.story.ui.docs/variant-tags :story.tagcascade/own-tags)]
       (is (= [:dev :docs] no-tags)
           "no-tags variant inherits story's :tags")
       (is (= [:test] own-tags)

--- a/tools/story/test/re_frame/story_authoring_validation_test.clj
+++ b/tools/story/test/re_frame/story_authoring_validation_test.clj
@@ -37,15 +37,15 @@
   authoring the combined form expects every generated variant's
   `:source` to point back at the same `(reg-story ...)` call."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story :as story]
-            [re-frame.story.macros :as macros]
-            [re-frame.story.plan :as plan]))
+            [re-frame.story :as rf.story]
+            [re-frame.story.macros :as rf.story.macros]
+            [re-frame.story.plan :as rf.story.plan]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
 (defn reset-story-registry [test-fn]
-  (story/clear-all!)
-  (story/install-canonical-vocabulary!)
+  (rf.story/clear-all!)
+  (rf.story/install-canonical-vocabulary!)
   (test-fn))
 
 (use-fixtures :each reset-story-registry)
@@ -57,7 +57,7 @@
 (deftest reg-variant-bad-shape-carries-error-key
   (testing "an invalid variant body raises with :rf.error in ex-data"
     (try
-      (story/reg-variant :story.auth.bad/v
+      (rf.story/reg-variant :story.auth.bad/v
         {:tags "not-a-set"})                         ; :tags must be a set
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
@@ -69,7 +69,7 @@
 (deftest reg-workspace-bad-shape-carries-error-key
   (testing "an invalid workspace body raises with :rf.error in ex-data"
     (try
-      (story/reg-workspace :Workspace.bad/empty
+      (rf.story/reg-workspace :Workspace.bad/empty
         {:layout :unknown-layout})                   ; :layout must be one of five
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
@@ -81,14 +81,14 @@
   ;; (default) and `:shared`. Other values reject with
   ;; :rf.error/workspace-shape.
   (testing ":isolation :isolated registers cleanly"
-    (is (some? (story/reg-workspace :Workspace.iso-ok/isolated
+    (is (some? (rf.story/reg-workspace :Workspace.iso-ok/isolated
                  {:layout :variants-grid :isolation :isolated}))))
   (testing ":isolation :shared registers cleanly"
-    (is (some? (story/reg-workspace :Workspace.iso-ok/shared
+    (is (some? (rf.story/reg-workspace :Workspace.iso-ok/shared
                  {:layout :variants-grid :isolation :shared}))))
   (testing "an unknown :isolation value rejects with :rf.error/workspace-shape"
     (try
-      (story/reg-workspace :Workspace.iso-bad/sandboxed
+      (rf.story/reg-workspace :Workspace.iso-bad/sandboxed
         {:layout :variants-grid :isolation :sandboxed})
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
@@ -97,7 +97,7 @@
 (deftest reg-decorator-bad-shape-carries-error-key
   (testing "an invalid decorator body raises with :rf.error in ex-data"
     (try
-      (story/reg-decorator :bad-decorator
+      (rf.story/reg-decorator :bad-decorator
         {:kind :not-a-decorator-kind})
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
@@ -106,7 +106,7 @@
 (deftest reg-tag-bad-shape-carries-error-key
   (testing "an invalid tag body raises with :rf.error in ex-data"
     (try
-      (story/reg-tag :bad/default-filter
+      (rf.story/reg-tag :bad/default-filter
         {:default-filter :sometimes})                ; only :include / :exclude
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
@@ -115,7 +115,7 @@
 (deftest reg-mode-bad-shape-carries-error-key
   (testing "an invalid mode body raises with :rf.error in ex-data"
     (try
-      (story/reg-mode :Mode.bad/missing-args
+      (rf.story/reg-mode :Mode.bad/missing-args
         {:args "not-a-map"})                         ; :args must be a map
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
@@ -124,7 +124,7 @@
 (deftest reg-story-panel-bad-shape-carries-error-key
   (testing "an invalid story-panel body raises with :rf.error in ex-data"
     (try
-      (story/reg-story-panel :rf.story/bad-panel
+      (rf.story/reg-story-panel :rf.story/bad-panel
         {:placement :nowhere                          ; not one of the five
          :render    :some/view})
       (is false "expected an exception")
@@ -135,25 +135,25 @@
 
 (deftest reg-fragment-registers-and-is-queryable
   (testing "reg-fragment lands a body in the :fragment side-table"
-    (story/reg-fragment :fragment.cart/with-sku
+    (rf.story/reg-fragment :fragment.cart/with-sku
       {:args  {:sku "A"}
        :setup [[:dispatch [:cart/add {:sku [:arg :sku]}]]]})
-    (is (story/registered? :fragment :fragment.cart/with-sku))
+    (is (rf.story/registered? :fragment :fragment.cart/with-sku))
     (is (= {:sku "A"}
-           (:args (story/handler-meta :fragment :fragment.cart/with-sku))))))
+           (:args (rf.story/handler-meta :fragment :fragment.cart/with-sku))))))
 
 (deftest reg-check-registers-and-is-queryable
   (testing "reg-check lands a body in the :check side-table"
-    (story/reg-check :check/no-runtime-errors
+    (rf.story/reg-check :check/no-runtime-errors
       {:assertions [[:rf.assert/no-warnings]]})
-    (is (story/registered? :check :check/no-runtime-errors))
+    (is (rf.story/registered? :check :check/no-runtime-errors))
     (is (= [[:rf.assert/no-warnings]]
-           (:assertions (story/handler-meta :check :check/no-runtime-errors))))))
+           (:assertions (rf.story/handler-meta :check :check/no-runtime-errors))))))
 
 (deftest reg-fragment-rejects-nested-compose
   (testing "a fragment carrying :compose is rejected at registration (flat fragments)"
     (try
-      (story/reg-fragment :fragment.bad/nested
+      (rf.story/reg-fragment :fragment.bad/nested
         {:compose [:fragment.cart/with-sku]
          :setup   [[:dispatch [:x]]]})
       (is false "expected an exception")
@@ -163,7 +163,7 @@
 (deftest reg-fragment-rejects-judgement-slots
   (testing "a fragment carrying :assertions is rejected (fragments carry no judgement)"
     (try
-      (story/reg-fragment :fragment.bad/judges
+      (rf.story/reg-fragment :fragment.bad/judges
         {:assertions [[:rf.assert/no-warnings]]})
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
@@ -172,7 +172,7 @@
 (deftest reg-check-requires-assertions
   (testing "a check body missing :assertions is rejected"
     (try
-      (story/reg-check :check/empty {:doc "no assertions"})
+      (rf.story/reg-check :check/empty {:doc "no assertions"})
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
         (is (= :rf.error/check-shape (:rf.error/id (ex-data e))))))))
@@ -180,7 +180,7 @@
 (deftest reg-variant-rejects-resolve-conflicts
   (testing ":resolve-conflicts on a variant body is rejected (no P1 escape hatch)"
     (try
-      (story/reg-variant :story.bad/resolve
+      (rf.story/reg-variant :story.bad/resolve
         {:resolve-conflicts {[:fx-overrides :rf.http/fetch] :stub}})
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
@@ -201,7 +201,7 @@
   (testing "the REMOVED :play slot (rf2-0wrud) is rejected at reg-time —
             the closed Variant schema does not silently swallow it"
     (try
-      (story/reg-variant :story.swallow/play
+      (rf.story/reg-variant :story.swallow/play
         {:setup []
          :play   [[:rf.assert/path-equals [:counter/value] 0]]})
       (is false "expected an exception — :play must NOT be silently accepted")
@@ -220,7 +220,7 @@
   (testing "a typo'd variant slot is rejected and the nearest declared
             slot is suggested (e.g. :scripts → :script)"
     (try
-      (story/reg-variant :story.swallow/typo
+      (rf.story/reg-variant :story.swallow/typo
         {:setup   []
          :scripts [[:dispatch [:x]]]})              ; typo for :script
       (is false "expected an exception")
@@ -243,7 +243,7 @@
   (testing ":schema on a STORY body is rejected — props schema lives on the
             registered :component view's metadata, not the story body"
     (try
-      (story/reg-story :story.deadprops
+      (rf.story/reg-story :story.deadprops
         {:component :views/widget
          :schema    [:map [:label :string]]})
       (is false "expected an exception — body :schema must NOT be accepted")
@@ -254,7 +254,7 @@
             ":reason names the dead :schema key"))))
   (testing ":rf/props on a STORY body is rejected too"
     (try
-      (story/reg-story :story.deadrfprops
+      (rf.story/reg-story :story.deadrfprops
         {:component :views/widget
          :rf/props  [:map [:label :string]]})
       (is false "expected an exception — body :rf/props must NOT be accepted")
@@ -265,7 +265,7 @@
   (testing ":schema on a VARIANT body is rejected — a variant narrows its
             component's props schema on the view metadata, not the body"
     (try
-      (story/reg-variant :story.dead/schema
+      (rf.story/reg-variant :story.dead/schema
         {:setup []
          :schema [:map [:label :string]]})
       (is false "expected an exception — body :schema must NOT be accepted")
@@ -276,7 +276,7 @@
             ":reason names the dead :schema key"))))
   (testing ":rf/props on a VARIANT body is rejected too"
     (try
-      (story/reg-variant :story.dead/rfprops
+      (rf.story/reg-variant :story.dead/rfprops
         {:setup   []
          :rf/props [:map [:label :string]]})
       (is false "expected an exception — body :rf/props must NOT be accepted")
@@ -287,11 +287,11 @@
   (testing "the LIVE path is unchanged — a props schema on the registered
             :component view's metadata (NOT the body) still copies into the
             compiled plan and validates :effective-args (rf2-hwcdh2)"
-    (story/reg-variant :story.live/props
+    (rf.story/reg-variant :story.live/props
       {:component :views/widget
        :args      {:label "Hi"}})
     (let [view-schema [:map [:label :string]]
-          p (plan/variant-plan :story.live/props
+          p (rf.story.plan/variant-plan :story.live/props
                                {:view-lookup {:views/widget {:rf/props view-schema}}})]
       (is (= view-schema (get-in p [:world :view-args-schema]))
           "the view-meta props schema is copied to [:world :view-args-schema]")
@@ -302,14 +302,14 @@
             — :setup preconditions + :script with [:assert [:rf.assert/…]]
             checkpoints + dispatch-sync increments — VALIDATES cleanly"
     ;; The exact bodies the migrated template scaffold ships.
-    (is (some? (story/reg-variant :story.migrated/empty
+    (is (some? (rf.story/reg-variant :story.migrated/empty
                  {:doc    "Fresh counter at zero."
                   :setup  [[:counter/initialise]]
                   :script [[:assert [:rf.assert/path-equals [:counter/value] 0]]]
                   :tags   #{:dev :docs :test}
                   :substrates #{:reagent}}))
         "empty-variant migrated body validates")
-    (is (some? (story/reg-variant :story.migrated/incremented
+    (is (some? (rf.story/reg-variant :story.migrated/incremented
                  {:doc    "three increments dispatched from :script."
                   :setup  [[:counter/initialise]]
                   :script [[:dispatch-sync [:counter/increment]]
@@ -322,7 +322,7 @@
                   :substrates #{:reagent}}))
         "incremented-variant migrated body validates")
     ;; The body is stored under the keys the author wrote.
-    (let [body (story/handler-meta :variant :story.migrated/incremented)]
+    (let [body (rf.story/handler-meta :variant :story.migrated/incremented)]
       (is (= [[:counter/initialise]] (:setup body)) ":setup stored verbatim")
       (is (= 6 (count (:script body))) ":script stored verbatim")
       (is (not (contains? body :play)) "no dead :play slot survives"))))
@@ -331,14 +331,14 @@
   (testing "the story-mcp write surface stamps :origin onto the variant
             body (spec/Cross-Cutting-Designs.md §5) — the closed schema
             MUST accept it or the MCP register-variant path breaks"
-    (is (some? (story/reg-variant* :story.mcp/written
+    (is (some? (rf.story/reg-variant* :story.mcp/written
                  {:setup [] :origin :story-mcp}))
         ":origin is a declared optional slot")))
 
 (deftest reg-workspace-rejects-typoed-slot
   (testing "a typo'd workspace slot is rejected at reg-time (closed schema)"
     (try
-      (story/reg-workspace :Workspace.swallow/typo
+      (rf.story/reg-workspace :Workspace.swallow/typo
         {:layout :grid :variants [:a] :collumns 2})   ; typo for :columns
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
@@ -351,20 +351,20 @@
             testbed + examples + spec/001-Authoring.md author — :columns,
             :for, :tags — VALIDATE on the closed schema (closing must not
             drop intended authoring, rf2-mantt triage)"
-    (is (some? (story/reg-workspace :Workspace.docslots/auto
+    (is (some? (rf.story/reg-workspace :Workspace.docslots/auto
                  {:doc     "auto-enumerated grid"
                   :layout  :variants-grid
                   :for     :story.counter
                   :columns 2
                   :tags    #{:docs}}))
         ":variants-grid + :for + :columns + :tags validates")
-    (is (some? (story/reg-workspace :Workspace.docslots/grid
+    (is (some? (rf.story/reg-workspace :Workspace.docslots/grid
                  {:layout   :grid
                   :variants [:story.counter/empty]
                   :columns  3
                   :tags     #{:docs}}))
         ":grid + :variants + :columns + :tags validates")
-    (is (some? (story/reg-workspace :Workspace.docslots/anchored
+    (is (some? (rf.story/reg-workspace :Workspace.docslots/anchored
                  {:layout :variants-grid
                   :for    :story.counter}))
         ":for (renderer-read anchor slot) validates")))
@@ -375,7 +375,7 @@
             :rf.error/workspace-shape (spec/001-Authoring.md
             §`:variants-grid`)"
     (try
-      (story/reg-workspace :Workspace.both/variants-and-for
+      (rf.story/reg-workspace :Workspace.both/variants-and-for
         {:layout   :variants-grid
          :variants [:story.counter/empty]
          :for      :story.counter})
@@ -389,19 +389,19 @@
 
 (deftest reg-variant-plays-accepts-named-list
   (testing ":plays with valid named entries is accepted"
-    (story/reg-variant :story.multi/named
+    (rf.story/reg-variant :story.multi/named
       {:setup []
        :plays  [{:name "happy path"
                  :script [[:dispatch [:foo]]]}
                 {:name "error path"
                  :script [[:dispatch [:bar]]]}]})
-    (let [body (story/handler-meta :variant :story.multi/named)]
+    (let [body (rf.story/handler-meta :variant :story.multi/named)]
       (is (= 2 (count (:plays body)))))))
 
 (deftest reg-variant-plays-empty-rejected
   (testing ":plays must contain at least one entry"
     (try
-      (story/reg-variant :story.multi/empty
+      (rf.story/reg-variant :story.multi/empty
         {:setup []
          :plays  []})
       (is false "expected an exception")
@@ -411,7 +411,7 @@
 (deftest reg-variant-plays-without-name-rejected
   (testing "each :plays entry must carry a :name"
     (try
-      (story/reg-variant :story.multi/no-name
+      (rf.story/reg-variant :story.multi/no-name
         {:setup []
          :plays  [{:script [[:dispatch [:foo]]]}]})
       (is false "expected an exception")
@@ -421,7 +421,7 @@
 (deftest reg-variant-plays-duplicate-names-rejected
   (testing ":plays entries must have unique :name values"
     (try
-      (story/reg-variant :story.multi/dup
+      (rf.story/reg-variant :story.multi/dup
         {:setup []
          :plays  [{:name "p" :script [[:dispatch [:a]]]}
                   {:name "p" :script [[:dispatch [:b]]]}]})
@@ -432,7 +432,7 @@
 (deftest reg-variant-play-script-and-plays-mutually-exclusive
   (testing "a variant may not declare BOTH :script and :plays"
     (try
-      (story/reg-variant :story.multi/both
+      (rf.story/reg-variant :story.multi/both
         {:setup      []
          :script [[:dispatch [:legacy]]]
          :plays       [{:name "p" :script [[:dispatch [:plays]]]}]})
@@ -456,7 +456,7 @@
   when registration succeeded."
   [id body]
   (try
-    (story/reg-variant* id body)
+    (rf.story/reg-variant* id body)
     nil
     (catch clojure.lang.ExceptionInfo e
       (:rf.error/id (ex-data e)))))
@@ -465,7 +465,7 @@
   (testing "a variant body carrying :events (the retired setup spelling)
             fails shape validation, naming the key and the slot it means"
     (try
-      (story/reg-variant* :story.vocab/legacy-events
+      (rf.story/reg-variant* :story.vocab/legacy-events
         {:events [[:counter/initialise 3]]})
       (is false "expected an exception — :events is not a slot")
       (catch clojure.lang.ExceptionInfo e
@@ -477,7 +477,7 @@
   (testing "a variant body carrying :play-script (the retired play spelling)
             fails shape validation and points at :script"
     (try
-      (story/reg-variant* :story.vocab/legacy-play-script
+      (rf.story/reg-variant* :story.vocab/legacy-play-script
         {:setup       []
          :play-script [[:dispatch [:a]]]})
       (is false "expected an exception — :play-script is not a slot")
@@ -491,7 +491,7 @@
     (doseq [[label body] [[":events"      {:events [[:a]]}]
                           [":play-script" {:play-script [[:dispatch [:a]]]}]]]
       (try
-        (story/reg-fragment* :fragment.vocab/legacy body)
+        (rf.story/reg-fragment* :fragment.vocab/legacy body)
         (is false (str "expected an exception — " label " is not a fragment slot"))
         (catch clojure.lang.ExceptionInfo e
           (is (= :rf.error/fragment-shape (:rf.error/id (ex-data e)))
@@ -502,8 +502,8 @@
             same keys — the write/read round trip is an identity"
     (let [authored {:setup  [[:counter/initialise 3]]
                     :script [[:dispatch-sync [:rf.assert/path-equals [:count] 3]]]}]
-      (story/reg-variant* :story.vocab/public authored)
-      (let [body (story/variant->edn :story.vocab/public)]
+      (rf.story/reg-variant* :story.vocab/public authored)
+      (let [body (rf.story/variant->edn :story.vocab/public)]
         (is (= authored (dissoc body :source))
             "the stored body is the authored body plus the :source stamp")
         (is (not (contains? body :events))      "no :events key appears on read-back")
@@ -512,25 +512,25 @@
     (let [authored {:setup  []
                     :script {:name "named" :auto-run? false
                              :script [[:dispatch-sync [:counter/initialise 1]]]}}]
-      (story/reg-variant* :story.vocab/public-map authored)
-      (is (= authored (dissoc (story/variant->edn :story.vocab/public-map) :source)))))
+      (rf.story/reg-variant* :story.vocab/public-map authored)
+      (is (= authored (dissoc (rf.story/variant->edn :story.vocab/public-map) :source)))))
   (testing "named :plays round-trip intact alongside :setup"
     (let [authored {:setup []
                     :plays [{:name "happy" :script [[:dispatch [:foo]]]}
                             {:name "error" :script [[:dispatch [:bar]]]}]}]
-      (story/reg-variant* :story.vocab/named-plays authored)
-      (let [body (story/variant->edn :story.vocab/named-plays)]
+      (rf.story/reg-variant* :story.vocab/named-plays authored)
+      (let [body (rf.story/variant->edn :story.vocab/named-plays)]
         (is (= authored (dissoc body :source)))
         (is (not (contains? body :script)) ":plays is the only play surface")))))
 
 (deftest reg-variant-script-map-form-drives-the-plan
   (testing "a map-form :script's :auto-run? / :name reach the compiled plan
             (the plan reads :script through the runner's coercion)"
-    (story/reg-variant* :story.vocab/map-plan
+    (rf.story/reg-variant* :story.vocab/map-plan
       {:setup  []
        :script {:name "named" :auto-run? false
                 :script [[:dispatch [:counter/initialise 1]]]}})
-    (let [p (plan/variant-plan :story.vocab/map-plan)]
+    (let [p (rf.story.plan/variant-plan :story.vocab/map-plan)]
       (is (= [[:dispatch [:counter/initialise 1]]] (:script p)))
       (is (= [{:name "named" :auto-run? false
                :script [[:dispatch [:counter/initialise 1]]]}]
@@ -539,13 +539,13 @@
 (deftest reg-variant-child-script-is-stored-verbatim-over-parent
   (testing "a child's :script is stored as authored; the parent's play
             surface is not merged into the stored body (:extends is raw)"
-    (story/reg-variant :story.vocab/parent
+    (rf.story/reg-variant :story.vocab/parent
       {:setup  []
        :script {:script [[:dispatch [:p/old]]]}})
-    (story/reg-variant :story.vocab/child
+    (rf.story/reg-variant :story.vocab/child
       {:extends :story.vocab/parent
        :script  {:script [[:dispatch [:c/new]]]}})
-    (let [body (story/handler-meta :variant :story.vocab/child)]
+    (let [body (rf.story/handler-meta :variant :story.vocab/child)]
       (is (= [[:dispatch [:c/new]]] (get-in body [:script :script]))
           "the child's own play surface is what is stored"))))
 
@@ -556,7 +556,7 @@
 (deftest reg-variant-unknown-tag-lists-offenders
   (testing "an unregistered tag on a variant raises with the offender list"
     (try
-      (story/reg-variant :story.tag/v
+      (rf.story/reg-variant :story.tag/v
         {:setup []
          :tags   #{:dev :totally-made-up :also-fake}})
       (is false "expected an exception")
@@ -578,12 +578,12 @@
             intact); the error surfaces at PLAN-COMPILE (the merge
             authority) and carries the missing parent id."
     ;; Registration succeeds — raw body stored with the unknown parent.
-    (story/reg-variant :story.x/child
+    (rf.story/reg-variant :story.x/child
       {:extends :story.x/no-such-parent
        :setup  []})
     ;; Plan compile is where the unknown parent FAILS, carrying the id.
     (try
-      (plan/variant-plan :story.x/child)
+      (rf.story.plan/variant-plan :story.x/child)
       (is false "expected a plan-compile exception")
       (catch clojure.lang.ExceptionInfo e
         (is (= :rf.error/story-extends-unknown (:rf.error/id (ex-data e))))
@@ -605,27 +605,27 @@
 (deftest reg-variant-extends-child-plays-overrides-parent-play-script
   (testing "a child declaring :plays while inheriting :script from
             its parent resolves to ONLY :plays (no mutual-exclusion error)"
-    (story/reg-variant :story.extplay/parent
+    (rf.story/reg-variant :story.extplay/parent
       {:setup      []
        :script {:script [[:dispatch [:p/legacy]]]}})
     ;; This used to throw :rf.error/variant-shape (both keys present).
-    (story/reg-variant :story.extplay/child
+    (rf.story/reg-variant :story.extplay/child
       {:extends :story.extplay/parent
        :plays   [{:name "happy" :script [[:dispatch [:c/happy]]]}]})
-    (let [body (story/handler-meta :variant :story.extplay/child)]
+    (let [body (rf.story/handler-meta :variant :story.extplay/child)]
       (is (contains? body :plays)      "child's :plays survived")
       (is (not (contains? body :script))
           "the inherited :script was dropped — no double-encoding"))))
 
 (deftest reg-variant-extends-child-play-script-overrides-parent-plays
   (testing "the symmetric case — child :script overrides parent :plays"
-    (story/reg-variant :story.extplay/parent2
+    (rf.story/reg-variant :story.extplay/parent2
       {:setup []
        :plays  [{:name "p" :script [[:dispatch [:p/plays]]]}]})
-    (story/reg-variant :story.extplay/child2
+    (rf.story/reg-variant :story.extplay/child2
       {:extends     :story.extplay/parent2
        :script {:script [[:dispatch [:c/legacy]]]}})
-    (let [body (story/handler-meta :variant :story.extplay/child2)]
+    (let [body (rf.story/handler-meta :variant :story.extplay/child2)]
       (is (contains? body :script) "child's :script survived")
       (is (not (contains? body :plays))
           "the inherited :plays was dropped"))))
@@ -638,13 +638,13 @@
             (rf2-f6z88) — `:extends` intact, parent NOT merged — so the
             child's body carries no play surface, and the plan compiler
             (the merge authority) takes script from the CHILD ONLY."
-    (story/reg-variant :story.extplay/parent3
+    (rf.story/reg-variant :story.extplay/parent3
       {:setup      []
        :script {:script [[:dispatch [:p/keep]]]}})
-    (story/reg-variant :story.extplay/child3
+    (rf.story/reg-variant :story.extplay/child3
       {:extends :story.extplay/parent3
        :doc     "no play override"})
-    (let [body (story/handler-meta :variant :story.extplay/child3)]
+    (let [body (rf.story/handler-meta :variant :story.extplay/child3)]
       (is (= :story.extplay/parent3 (:extends body))
           ":extends stored raw — the parent body is NOT merged in")
       (is (not (contains? body :script))
@@ -652,7 +652,7 @@
       (is (not (contains? body :plays))
           "no play surface inherited at all"))
     ;; The compiler confirms it: the silent child's compiled script is empty.
-    (is (= [] (:script (plan/variant-plan :story.extplay/child3)))
+    (is (= [] (:script (rf.story.plan/variant-plan :story.extplay/child3)))
         "compiled plan takes script CHILD-ONLY — the parent's is not run")))
 
 ;; ===========================================================================
@@ -663,7 +663,7 @@
   (testing "a non-keyword variant id is rejected — the id-grammar check
             fires first and complains, carrying :rf.error/variant-id-shape"
     (try
-      (story/reg-variant* "not-a-keyword" {:setup []})
+      (rf.story/reg-variant* "not-a-keyword" {:setup []})
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
         (is (= :rf.error/variant-id-shape (:rf.error/id (ex-data e))))
@@ -671,7 +671,7 @@
 
 (deftest reg-workspace-bad-id-grammar-rejected
   (testing "a workspace id outside :Workspace.<path>/<name> is rejected"
-    (let [e (try (story/reg-workspace* :NotAWorkspaceId {:layout :variants-grid})
+    (let [e (try (rf.story/reg-workspace* :NotAWorkspaceId {:layout :variants-grid})
                  nil
                  (catch clojure.lang.ExceptionInfo e e))]
       (is (= :rf.error/workspace-id-shape (:rf.error/id (ex-data e))))
@@ -689,10 +689,10 @@
 
 (deftest combined-form-stamps-source-on-parent-story
   (testing "a Form-B (:variants sugar) reg-story stamps :source on the parent"
-    (story/reg-story :story.combined.src
+    (rf.story/reg-story :story.combined.src
       {:doc      "parent."
        :variants {:a {:setup [[:init]]}}})
-    (let [body (story/handler-meta :story :story.combined.src)]
+    (let [body (rf.story/handler-meta :story :story.combined.src)]
       (is (map? (:source body)))
       (is (= 're-frame.story-authoring-validation-test (:ns (:source body))))
       (is (integer? (:line (:source body)))))))
@@ -703,12 +703,12 @@
             child inherits the same `&form` line/file/ns. Per spec/001
             §Source-coord stamping the IDE 'Open in editor' affordance reads
             this slot for both stories and variants generated from sugar."
-    (story/reg-story :story.combined.gen
+    (rf.story/reg-story :story.combined.gen
       {:doc      "parent with two generated variants."
        :variants {:a {:setup [[:init-a]]}
                   :b {:setup [[:init-b]]}}})
-    (let [body-a (story/handler-meta :variant :story.combined.gen/a)
-          body-b (story/handler-meta :variant :story.combined.gen/b)]
+    (let [body-a (rf.story/handler-meta :variant :story.combined.gen/a)
+          body-b (rf.story/handler-meta :variant :story.combined.gen/b)]
       (is (map? (:source body-a)) "child :a carries :source")
       (is (map? (:source body-b)) "child :b carries :source")
       (is (= 're-frame.story-authoring-validation-test
@@ -730,14 +730,14 @@
 ;; a malformed registry id.
 
 (deftest variant-id-for-rejects-non-keyword-story-id
-  (let [e (try (macros/variant-id-for "story.foo" :a)
+  (let [e (try (rf.story.macros/variant-id-for "story.foo" :a)
                nil
                (catch clojure.lang.ExceptionInfo e e))]
     (is (= :rf.error/story-bad-id (:rf.error/id (ex-data e))))
     (is (re-find #"story id must be a keyword" (:reason (ex-data e))))))
 
 (deftest variant-id-for-rejects-non-keyword-variant-name
-  (let [e (try (macros/variant-id-for :story.foo "a")
+  (let [e (try (rf.story.macros/variant-id-for :story.foo "a")
                nil
                (catch clojure.lang.ExceptionInfo e e))]
     (is (= :rf.error/story-bad-variant-name (:rf.error/id (ex-data e))))
@@ -746,9 +746,9 @@
 (deftest variant-id-for-builds-canonical-id
   (testing "the canonical :story.<path>/<variant> id shape"
     (is (= :story.auth.login-form/empty
-           (macros/variant-id-for :story.auth.login-form :empty)))
+           (rf.story.macros/variant-id-for :story.auth.login-form :empty)))
     (is (= :story.foo/bar
-           (macros/variant-id-for :story.foo :bar)))))
+           (rf.story.macros/variant-id-for :story.foo :bar)))))
 
 ;; ===========================================================================
 ;; configure! key validation (rf2-xwr1d)
@@ -760,7 +760,7 @@
 
 (deftest configure-bang-rejects-unknown-keys
   (testing "an unknown top-level key raises :rf.error/unknown-story-config-key"
-    (let [e (try (story/configure! {:rf.story/edtior :cursor}) ; typo
+    (let [e (try (rf.story/configure! {:rf.story/edtior :cursor}) ; typo
                  nil
                  (catch clojure.lang.ExceptionInfo e e))]
       (is (some? e) "expected ex-info to be thrown")
@@ -783,8 +783,8 @@
 
 (deftest configure-bang-accepts-every-known-key
   (testing "the closed known-set passes through without error"
-    (is (nil? (story/configure! {})) "empty map is a no-op")
-    (is (nil? (story/configure! {:rf.story/global-args        {:theme :light}
+    (is (nil? (rf.story/configure! {})) "empty map is a no-op")
+    (is (nil? (rf.story/configure! {:rf.story/global-args        {:theme :light}
                                  :rf.story/global-decorators  []
                                  :rf.story/editor             :vscode
                                  :rf.story/project-root       nil
@@ -793,7 +793,7 @@
 (deftest configure-bang-error-lists-every-unknown
   (testing "multiple unknown keys all surface in :unknown so the author
             fixes the whole call site in one pass"
-    (let [e (try (story/configure! {:rf.story/edtior :cursor
+    (let [e (try (rf.story/configure! {:rf.story/edtior :cursor
                                     :foo             1})
                  nil
                  (catch clojure.lang.ExceptionInfo e e))]

--- a/tools/story/test/re_frame/story_chrome_a11y_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_chrome_a11y_cljs_test.cljs
@@ -8,22 +8,22 @@
   contract without requiring a live browser."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story :as story]
-            [re-frame.story.ui.a11y :as a11y]
-            [re-frame.story.ui.chrome-a11y :as chrome-a11y]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.ui.a11y :as rf.story.ui.a11y]
+            [re-frame.story.ui.chrome-a11y :as rf.story.ui.chrome-a11y]))
 
 (defn reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
-  (a11y/reset-state!)
-  (chrome-a11y/reset-state!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
+  (rf.story.ui.a11y/reset-state!)
+  (rf.story.ui.chrome-a11y/reset-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -31,24 +31,24 @@
 
 (deftest chrome-a11y-panel-registers
   (testing "the chrome-a11y panel registers as a story-panel"
-    (let [panels (story/registrations :story-panel)]
-      (is (contains? panels chrome-a11y/panel-id)))))
+    (let [panels (rf.story/registrations :story-panel)]
+      (is (contains? panels rf.story.ui.chrome-a11y/panel-id)))))
 
 (deftest chrome-a11y-panel-id-distinct-from-variant
   (testing "chrome-a11y panel-id is distinct from the variant a11y panel-id"
-    (is (not= chrome-a11y/panel-id a11y/panel-id))))
+    (is (not= rf.story.ui.chrome-a11y/panel-id rf.story.ui.a11y/panel-id))))
 
 (deftest chrome-a11y-panel-body
   (testing "the chrome-a11y panel body declares :placement :right + :render"
-    (let [body (story/handler-meta :story-panel chrome-a11y/panel-id)]
+    (let [body (rf.story/handler-meta :story-panel rf.story.ui.chrome-a11y/panel-id)]
       (is (= :right (:placement body)))
-      (is (= chrome-a11y/panel-render-id (:render body)))
+      (is (= rf.story.ui.chrome-a11y/panel-render-id (:render body)))
       (is (string? (:title body)))
       (is (re-find #"(?i)chrome" (or (:title body) ""))))))
 
 (deftest chrome-a11y-render-view-registered
   (testing "the chrome-a11y panel-render view is registered against re-frame"
-    (is (some? (rf/view chrome-a11y/panel-render-id)))))
+    (is (some? (rf/view rf.story.ui.chrome-a11y/panel-render-id)))))
 
 (deftest chrome-a11y-render-view-roots-in-dom-element
   (testing "the chrome-a11y panel-render view returns hiccup whose root
@@ -60,7 +60,7 @@
             `[panel variant-id]` root makes the panel invisible to Story
             Inspect Mode + Xray Inspect Mode (rf2-iwny7). The `[:div]`
             wrap is load-bearing."
-    (let [view-fn (rf/view chrome-a11y/panel-render-id)
+    (let [view-fn (rf/view rf.story.ui.chrome-a11y/panel-render-id)
           out     (view-fn :story.unknown/y)]
       (is (vector? out)
           "panel-render returns a hiccup vector")
@@ -73,35 +73,35 @@
 
 (deftest chrome-root-selector-targets-chrome-attribute
   (testing "chrome-root-selector targets [data-rf-story-root]"
-    (is (string? chrome-a11y/chrome-root-selector))
+    (is (string? rf.story.ui.chrome-a11y/chrome-root-selector))
     ;; The chrome root is stamped by shell.cljs as :data-rf-story-root.
-    (is (re-find #"data-rf-story-root" chrome-a11y/chrome-root-selector))
-    (is (.startsWith chrome-a11y/chrome-root-selector "["))
-    (is (.endsWith   chrome-a11y/chrome-root-selector "]"))))
+    (is (re-find #"data-rf-story-root" rf.story.ui.chrome-a11y/chrome-root-selector))
+    (is (.startsWith rf.story.ui.chrome-a11y/chrome-root-selector "["))
+    (is (.endsWith   rf.story.ui.chrome-a11y/chrome-root-selector "]"))))
 
 (deftest chrome-frame-id-is-namespaced
   (testing "chrome-frame-id is a story-namespaced keyword distinct from any variant id"
-    (is (keyword? chrome-a11y/chrome-frame-id))
-    (is (= "rf.story.chrome-a11y" (namespace chrome-a11y/chrome-frame-id)))))
+    (is (keyword? rf.story.ui.chrome-a11y/chrome-frame-id))
+    (is (= "rf.story.chrome-a11y" (namespace rf.story.ui.chrome-a11y/chrome-frame-id)))))
 
 ;; ---- state management ---------------------------------------------------
 
 (deftest violations-state-starts-empty
   (testing "violations starts as an empty vector"
-    (is (vector? @chrome-a11y/violations))
-    (is (empty? @chrome-a11y/violations))))
+    (is (vector? @rf.story.ui.chrome-a11y/violations))
+    (is (empty? @rf.story.ui.chrome-a11y/violations))))
 
 (deftest run-state-starts-idle
   (testing "run-state starts at :idle"
-    (is (= :idle (chrome-a11y/status)))))
+    (is (= :idle (rf.story.ui.chrome-a11y/status)))))
 
 (deftest reset-state-clears-everything
   (testing "reset-state! clears violations + resets run-state"
-    (reset! chrome-a11y/violations [{:dummy true}])
-    (reset! chrome-a11y/run-state {:status :done})
-    (chrome-a11y/reset-state!)
-    (is (empty? @chrome-a11y/violations))
-    (is (= :idle (chrome-a11y/status)))))
+    (reset! rf.story.ui.chrome-a11y/violations [{:dummy true}])
+    (reset! rf.story.ui.chrome-a11y/run-state {:status :done})
+    (rf.story.ui.chrome-a11y/reset-state!)
+    (is (empty? @rf.story.ui.chrome-a11y/violations))
+    (is (= :idle (rf.story.ui.chrome-a11y/status)))))
 
 ;; ---- find-chrome-root degraded-environment safety -----------------------
 
@@ -110,4 +110,4 @@
     ;; The Node-runtime test environment does not mount the Story shell,
     ;; so find-chrome-root must gracefully return nil (the panel surfaces
     ;; a :no-root state in that case).
-    (is (nil? (chrome-a11y/find-chrome-root)))))
+    (is (nil? (rf.story.ui.chrome-a11y/find-chrome-root)))))

--- a/tools/story/test/re_frame/story_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_cljs_test.cljs
@@ -10,15 +10,15 @@
   round-trip to confirm the macros emit working code in a CLJS
   compile."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.story :as story]
-            [re-frame.story.config :as config]
-            [re-frame.story.schemas :as schemas]))
+            [re-frame.story :as rf.story]
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.schemas :as rf.story.schemas]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-story-registry [test-fn]
-  (story/clear-all!)
-  (story/install-canonical-vocabulary!)
+  (rf.story/clear-all!)
+  (rf.story/install-canonical-vocabulary!)
   (test-fn))
 
 (use-fixtures :each reset-story-registry)
@@ -27,7 +27,7 @@
 
 (deftest enabled-flag-is-true-in-test-build
   (testing "Story is enabled in this CLJS test build"
-    (is (true? config/enabled?))))
+    (is (true? rf.story.config/enabled?))))
 
 ;; ---- static-mode? (rf2-8wgpm) -------------------------------------------
 
@@ -38,48 +38,48 @@
     ;; downstream build mirroring its :closure-defines) flips it true.
     ;; The node-test build under shadow-cljs runs without overriding
     ;; the define, so we expect the default-false branch here.
-    (is (false? config/static-mode?)))
+    (is (false? rf.story.config/static-mode?)))
   (testing "the public probe (re-frame.story/static-mode?) reflects the flag"
-    (is (false? (story/static-mode?)))))
+    (is (false? (rf.story/static-mode?)))))
 
 ;; ---- macros emit working code -------------------------------------------
 
 (deftest cljs-smoke-reg-story-and-variant
   (testing "reg-story + reg-variant macros register against the side-table in CLJS"
-    (story/reg-story :story.cljs.smoke
+    (rf.story/reg-story :story.cljs.smoke
       {:doc       "CLJS smoke test."
        :component :app.cljs/comp
        :tags      #{:dev}})
-    (story/reg-variant :story.cljs.smoke/default
+    (rf.story/reg-variant :story.cljs.smoke/default
       {:doc    "default state"
        :setup [[:init]]
        :tags   #{:dev}})
-    (is (story/registered? :story   :story.cljs.smoke))
-    (is (story/registered? :variant :story.cljs.smoke/default))))
+    (is (rf.story/registered? :story   :story.cljs.smoke))
+    (is (rf.story/registered? :variant :story.cljs.smoke/default))))
 
 (deftest cljs-form-b-desugars
   (testing "Form-B :variants desugars on the CLJS side"
-    (story/reg-story :story.cljs.form-b
+    (rf.story/reg-story :story.cljs.form-b
       {:doc       "Form-B test."
        :component :app.cljs/comp
        :variants  {:a {:setup [[:init-a]]}
                    :b {:setup [[:init-b]]}}})
-    (is (story/registered? :variant :story.cljs.form-b/a))
-    (is (story/registered? :variant :story.cljs.form-b/b))))
+    (is (rf.story/registered? :variant :story.cljs.form-b/a))
+    (is (rf.story/registered? :variant :story.cljs.form-b/b))))
 
 ;; ---- canonical tag set ---------------------------------------------------
 
 (deftest cljs-canonical-tags-installed
   (testing "the seven canonical inclusion tags + five canonical :state/* magnitude tags load on the CLJS side"
-    (let [tags (story/list-tags)]
-      (is (= (into schemas/canonical-tags schemas/canonical-state-tags)
+    (let [tags (rf.story/list-tags)]
+      (is (= (into rf.story.schemas/canonical-tags rf.story.schemas/canonical-state-tags)
              tags))
       (testing "the seven inclusion tags are all present (rf2-k1k87 didn't drop any)"
-        (is (every? tags schemas/canonical-tags)))
+        (is (every? tags rf.story.schemas/canonical-tags)))
       (testing "the five state tags are all present (rf2-k1k87 regression smoke)"
-        (is (every? tags schemas/canonical-state-tags))
+        (is (every? tags rf.story.schemas/canonical-state-tags))
         (is (= #{:state/empty :state/small :state/medium :state/large :state/special}
-               schemas/canonical-state-tags))))))
+               rf.story.schemas/canonical-state-tags))))))
 
 ;; ---- :state/* axis regression smoke (rf2-k1k87) -------------------------
 ;;
@@ -92,16 +92,16 @@
 
 (deftest cljs-state-axis-tags-survive-variant-registration
   (testing "a variant tagged with the full :state/* axis registers cleanly (no :rf.error/unknown-tag)"
-    (story/reg-story :story.cljs.state-axis-smoke
+    (rf.story/reg-story :story.cljs.state-axis-smoke
       {:doc       "rf2-k1k87 canonical :state/* axis smoke."
        :component :app.cljs/comp
        :tags      #{:dev}})
-    (story/reg-variant :story.cljs.state-axis-smoke/all-state-magnitudes
+    (rf.story/reg-variant :story.cljs.state-axis-smoke/all-state-magnitudes
       {:doc    "every :state/* tag at once."
        :setup [[:init]]
-       :tags   (into #{:dev} schemas/canonical-state-tags)})
-    (is (story/registered? :variant :story.cljs.state-axis-smoke/all-state-magnitudes)))
+       :tags   (into #{:dev} rf.story.schemas/canonical-state-tags)})
+    (is (rf.story/registered? :variant :story.cljs.state-axis-smoke/all-state-magnitudes)))
   (testing "each :state/* tag carries the :state axis classifier"
-    (let [by-axis (story/tags-by-axis :state)]
-      (is (= schemas/canonical-state-tags by-axis)
+    (let [by-axis (rf.story/tags-by-axis :state)]
+      (is (= rf.story.schemas/canonical-state-tags by-axis)
           "every :state/* tag is registered on the :state axis"))))

--- a/tools/story/test/re_frame/story_decorator_chain_test.clj
+++ b/tools/story/test/re_frame/story_decorator_chain_test.clj
@@ -32,34 +32,34 @@
   parallel runs separate."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.machines         :as machines]
-            [re-frame.registrar        :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story            :as story]
-            [re-frame.story.async      :as async]
-            [re-frame.story.config     :as config]
-            [re-frame.story.decorators :as decorators]
-            [re-frame.story.frames     :as frames]
-            [re-frame.story.loaders    :as loaders]
-            [re-frame.story.play       :as play]))
+            [re-frame.frame            :as rf.frame]
+            [re-frame.machines         :as rf.machines]
+            [re-frame.registrar        :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story            :as rf.story]
+            [re-frame.story.async      :as rf.story.async]
+            [re-frame.story.config     :as rf.story.config]
+            [re-frame.story.decorators :as rf.story.decorators]
+            [re-frame.story.frames     :as rf.story.frames]
+            [re-frame.story.loaders    :as rf.story.loaders]
+            [re-frame.story.play       :as rf.story.play]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
 (defn reset-all [test-fn]
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
   (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (config/set-global-args! {})
-  (reset! play/stepper-state            {})
-  (reset! frames/stub-call-log          {})
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.config/set-global-args! {})
+  (reset! rf.story.play/stepper-state            {})
+  (reset! rf.story.frames/stub-call-log          {})
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (test-fn))
 
 (use-fixtures :each reset-all)
@@ -74,22 +74,22 @@
   (testing "two story-level + two variant-level :hiccup decorators wrap in
             the spec'd order: outer (story's first) outside inner
             (variant's last)"
-    (story/reg-decorator :wrap-A
+    (rf.story/reg-decorator :wrap-A
       {:kind :hiccup :wrap (fn [body _] [:div.A body])})
-    (story/reg-decorator :wrap-B
+    (rf.story/reg-decorator :wrap-B
       {:kind :hiccup :wrap (fn [body _] [:div.B body])})
-    (story/reg-decorator :wrap-C
+    (rf.story/reg-decorator :wrap-C
       {:kind :hiccup :wrap (fn [body _] [:div.C body])})
-    (story/reg-decorator :wrap-D
+    (rf.story/reg-decorator :wrap-D
       {:kind :hiccup :wrap (fn [body _] [:div.D body])})
-    (story/reg-story :story.chain
+    (rf.story/reg-story :story.chain
       {:decorators [[:wrap-A] [:wrap-B]]})
-    (story/reg-variant :story.chain/v
+    (rf.story/reg-variant :story.chain/v
       {:decorators [[:wrap-C] [:wrap-D]]
        :setup     []})
-    (let [r         (story/resolve-decorators :story.chain/v)
+    (let [r         (rf.story/resolve-decorators :story.chain/v)
           ids       (mapv :id (:hiccup r))
-          wrapped   (decorators/apply-hiccup-decorators
+          wrapped   (rf.story.decorators/apply-hiccup-decorators
                       (:hiccup r) [:span "leaf"] {})]
       (is (= [:wrap-A :wrap-B :wrap-C :wrap-D] ids)
           "stack order: story decorators (declared order) precede
@@ -110,12 +110,12 @@
             pack populates all three slots"
     ;; A :hiccup decorator (only inspected on the canvas side via
     ;; resolve-decorators; the JVM run-variant path produces no DOM).
-    (story/reg-decorator :centered-pane
+    (rf.story/reg-decorator :centered-pane
       {:kind :hiccup :wrap (fn [body _] [:div.centered body])})
     ;; A :frame-setup decorator whose :init seeds app-db before :setup.
     (rf/reg-event :mock/seed
       (fn [{:keys [db]} _] {:db (assoc db :mock-user {:name "alice" :role :admin})}))
-    (story/reg-decorator :seed-user
+    (rf.story/reg-decorator :seed-user
       {:kind :frame-setup :init [[:mock/seed]]})
     ;; An :fx-override decorator (the registered :rf.story/force-fx-stub
     ;; canonical) — stamps onto :fx-overrides at frame-allocate time.
@@ -123,7 +123,7 @@
       (fn [{:keys [db]} _] {:db (assoc db :seen-user (:mock-user db))}))
     (rf/reg-event :emit/track
       (fn [_ _] {:fx [[:analytics {:event :loaded}]]}))
-    (story/reg-variant :story.multi-kind/v
+    (rf.story/reg-variant :story.multi-kind/v
       {:decorators [[:centered-pane]
                     [:seed-user]
                     [:rf.story/force-fx-stub :analytics {:ack? true}]]
@@ -134,15 +134,15 @@
                     [:dispatch-sync [:emit/track]]
                     [:dispatch-sync [:rf.assert/effect-emitted :analytics]]]})
     ;; Resolve-decorators classifies the stack into the three slots.
-    (let [pack (story/resolve-decorators :story.multi-kind/v)]
+    (let [pack (rf.story/resolve-decorators :story.multi-kind/v)]
       (is (= 1 (count (:hiccup pack)))      ":hiccup slot populated")
       (is (= 1 (count (:frame-setup pack))) ":frame-setup slot populated")
       (is (= 1 (count (:fx-override pack))) ":fx-override slot populated")
       (is (empty? (:errors pack))           "no decorator errors"))
     ;; Run end-to-end: :frame-setup fires first, then :setup observe
     ;; the seeded slot, then :script asserts.
-    (let [r (async/deref-blocking
-              (story/run-variant :story.multi-kind/v) 5000)]
+    (let [r (rf.story.async/deref-blocking
+              (rf.story/run-variant :story.multi-kind/v) 5000)]
       (is (= :ready (:lifecycle r))
           "lifecycle reaches :ready — multi-kind stack composes without crash")
       (is (= "alice" (-> r :app-db :seen-user :name))
@@ -155,7 +155,7 @@
             "every play assertion passes — the :fx-override redirect was
              live, the :frame-setup seed landed, the :hiccup decorator
              didn't disturb the data path")))
-    (story/destroy-variant! :story.multi-kind/v)))
+    (rf.story/destroy-variant! :story.multi-kind/v)))
 
 (deftest extends-inherits-decorators-when-child-declares-none
   (testing ":extends gives a child variant access to its parent's
@@ -167,16 +167,16 @@
             child-wins (no per-key concat). `resolve-decorators` reads
             the compiled plan, so a bare child INHERITS the parent's
             decorator stack."
-    (story/reg-decorator :parent-only-deco
+    (rf.story/reg-decorator :parent-only-deco
       {:kind :hiccup :wrap (fn [body _] [:div.parent-only body])})
-    (story/reg-decorator :child-replacement
+    (rf.story/reg-decorator :child-replacement
       {:kind :hiccup :wrap (fn [body _] [:div.child body])})
-    (story/reg-variant :story.ext.dec/parent
+    (rf.story/reg-variant :story.ext.dec/parent
       {:decorators [[:parent-only-deco]]
        :setup     []})
     ;; Case 1 — child declares NO :decorators. It inherits the parent's
     ;; vector verbatim.
-    (story/reg-variant :story.ext.dec/inherit-bare
+    (rf.story/reg-variant :story.ext.dec/inherit-bare
       {:extends :story.ext.dec/parent
        :setup  []})
     ;; Case 2 — child declares ITS OWN :decorators. The child's slot
@@ -184,28 +184,28 @@
     ;; story-level decorators are still composed outside (via the
     ;; resolve-decorators story+variant walk) — but the child's
     ;; variant-level slot is its own.
-    (story/reg-variant :story.ext.dec/inherit-and-replace
+    (rf.story/reg-variant :story.ext.dec/inherit-and-replace
       {:extends    :story.ext.dec/parent
        :decorators [[:child-replacement]]
        :setup     []})
     ;; Case 1: bare child inherits parent's :decorators via the plan.
-    (let [body (story/handler-meta :variant :story.ext.dec/inherit-bare)]
+    (let [body (rf.story/handler-meta :variant :story.ext.dec/inherit-bare)]
       (is (= :story.ext.dec/parent (:extends body))
           ":extends stored RAW on the side-table body")
       (is (nil? (:decorators body))
           "bare child declares no :decorators; the raw body carries none —
            inheritance is resolved downstream at plan-compile"))
-    (let [pack (story/resolve-decorators :story.ext.dec/inherit-bare)]
+    (let [pack (rf.story/resolve-decorators :story.ext.dec/inherit-bare)]
       (is (= [:parent-only-deco] (mapv :id (:hiccup pack)))
           "resolved hiccup stack INHERITS the parent's decorator via the
            compiled plan's [:world :decorators]"))
     ;; Case 2: child with its own :decorators REPLACES parent's.
-    (let [body (story/handler-meta :variant :story.ext.dec/inherit-and-replace)]
+    (let [body (rf.story/handler-meta :variant :story.ext.dec/inherit-and-replace)]
       (is (= [[:child-replacement]] (:decorators body))
           "the raw body carries the child's OWN :decorators verbatim")
       (is (= :story.ext.dec/parent (:extends body))
           ":extends stored RAW — compiler resolves child-wins (no concat)"))
-    (let [pack (story/resolve-decorators :story.ext.dec/inherit-and-replace)]
+    (let [pack (rf.story/resolve-decorators :story.ext.dec/inherit-and-replace)]
       (is (= [:child-replacement] (mapv :id (:hiccup pack)))
           "resolved hiccup stack reflects ONLY the child's decorators —
            the parent's :parent-only-deco was replaced, not concatenated"))))
@@ -230,9 +230,9 @@
       (fn [{:keys [db]} _]
         {:db (update db :counter inc)
          :fx [[:analytics {:event :inc :from (:counter db)}]]}))
-    (story/reg-decorator :seed-A {:kind :frame-setup :init [[:seed/at-100]]})
-    (story/reg-decorator :seed-B {:kind :frame-setup :init [[:seed/at-200]]})
-    (story/reg-variant :story.isolation/A
+    (rf.story/reg-decorator :seed-A {:kind :frame-setup :init [[:seed/at-100]]})
+    (rf.story/reg-decorator :seed-B {:kind :frame-setup :init [[:seed/at-200]]})
+    (rf.story/reg-variant :story.isolation/A
       {:decorators [[:seed-A]
                     [:rf.story/force-fx-stub :analytics {:ack? true}]]
        :setup     [[:inc-and-track] [:inc-and-track]]
@@ -243,7 +243,7 @@
                     [:dispatch-sync [:inc-and-track]]
                     [:dispatch-sync [:rf.assert/effect-emitted :analytics]]
                     [:dispatch-sync [:rf.assert/path-equals [:counter] 103]]]})
-    (story/reg-variant :story.isolation/B
+    (rf.story/reg-variant :story.isolation/B
       {:decorators [[:seed-B]
                     [:rf.story/force-fx-stub :analytics {:ack? true}]]
        :setup     [[:inc-and-track] [:inc-and-track]]
@@ -255,10 +255,10 @@
     ;; :frame-setup seed differs. The proof of frame isolation is that
     ;; each lands on its own counter terminal value AND each frame's
     ;; stub-call log carries exactly its own emissions.
-    (let [rA (async/deref-blocking (story/run-variant :story.isolation/A) 5000)
-          rB (async/deref-blocking (story/run-variant :story.isolation/B) 5000)
-          logA (frames/stub-call-log-for :story.isolation/A)
-          logB (frames/stub-call-log-for :story.isolation/B)]
+    (let [rA (rf.story.async/deref-blocking (rf.story/run-variant :story.isolation/A) 5000)
+          rB (rf.story.async/deref-blocking (rf.story/run-variant :story.isolation/B) 5000)
+          logA (rf.story.frames/stub-call-log-for :story.isolation/A)
+          logB (rf.story.frames/stub-call-log-for :story.isolation/B)]
       (is (= :ready (:lifecycle rA)))
       (is (= :ready (:lifecycle rB)))
       ;; app-db isolation: each frame walks its own counter. Two
@@ -297,28 +297,28 @@
               {:event :inc :from 201}
               {:event :inc :from 202}]
              (mapv :payload logB))))
-    (story/destroy-variant! :story.isolation/A)
-    (story/destroy-variant! :story.isolation/B)))
+    (rf.story/destroy-variant! :story.isolation/A)
+    (rf.story/destroy-variant! :story.isolation/B)))
 
 (deftest frame-isolation-pair-destroy-one-survives-other
   (testing "destroying frame A leaves frame B's app-db / state intact.
             Per spec/002 §Coexistence + §Per-variant frame allocation."
     (rf/reg-event :ping (fn [{:keys [db]} _] {:db (update db :pings (fnil inc 0))}))
-    (story/reg-variant :story.iso2/A {:setup [[:ping]]})
-    (story/reg-variant :story.iso2/B {:setup [[:ping]]})
-    (async/deref-blocking (story/run-variant :story.iso2/A) 5000)
-    (async/deref-blocking (story/run-variant :story.iso2/B) 5000)
-    (is (story/variant-frame? :story.iso2/A))
-    (is (story/variant-frame? :story.iso2/B))
-    (story/destroy-variant! :story.iso2/A)
-    (is (not (story/variant-frame? :story.iso2/A))
+    (rf.story/reg-variant :story.iso2/A {:setup [[:ping]]})
+    (rf.story/reg-variant :story.iso2/B {:setup [[:ping]]})
+    (rf.story.async/deref-blocking (rf.story/run-variant :story.iso2/A) 5000)
+    (rf.story.async/deref-blocking (rf.story/run-variant :story.iso2/B) 5000)
+    (is (rf.story/variant-frame? :story.iso2/A))
+    (is (rf.story/variant-frame? :story.iso2/B))
+    (rf.story/destroy-variant! :story.iso2/A)
+    (is (not (rf.story/variant-frame? :story.iso2/A))
         "A's frame is gone")
-    (is (story/variant-frame? :story.iso2/B)
+    (is (rf.story/variant-frame? :story.iso2/B)
         "B's frame survives — destroying A had no side effect on B")
     ;; Re-running B against the same id should land cleanly — no shared
     ;; state corruption from A's teardown.
-    (let [r (async/deref-blocking (story/reset-variant :story.iso2/B) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/reset-variant :story.iso2/B) 5000)]
       (is (= :ready (:lifecycle r)))
       (is (= 1 (:pings (:app-db r)))
           "B's app-db is fresh post-reset; A's teardown didn't pollute it"))
-    (story/destroy-variant! :story.iso2/B)))
+    (rf.story/destroy-variant! :story.iso2/B)))

--- a/tools/story/test/re_frame/story_error_test.clj
+++ b/tools/story/test/re_frame/story_error_test.clj
@@ -11,9 +11,9 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story.error :as story-error]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story.error :as rf.story.error]))
 
 ;; ---- fixture ---------------------------------------------------------------
 ;;
@@ -25,10 +25,10 @@
 ;; plain-atom adapter and clean frame state around each test.
 (use-fixtures :each
   (fn [test-fn]
-    (reset! frame/frames {})
-    (try (rf/init! plain-atom/adapter)
+    (reset! rf.frame/frames {})
+    (try (rf/init! rf.substrate.plain-atom/adapter)
          (catch clojure.lang.ExceptionInfo _ nil))
-    (frame/ensure-default-frame!)
+    (rf.frame/ensure-default-frame!)
     (test-fn)))
 
 ;; ---- throwable->error-map -------------------------------------------------
@@ -36,7 +36,7 @@
 (deftest throwable->error-map-projects-the-canonical-shape
   (testing "an ExceptionInfo projects to {:message :stack :data} with every
             slot populated"
-    (let [m (story-error/throwable->error-map
+    (let [m (rf.story.error/throwable->error-map
               (ex-info "boom" {:why :test}))]
       (is (= #{:message :stack :data} (set (keys m)))
           "exactly the three canonical keys")
@@ -58,7 +58,7 @@
   (testing "a plain Throwable (no ex-data) yields :data nil WITHOUT an
             explicit instance? guard — ex-data already returns nil for a
             non-ExceptionInfo"
-    (let [m (story-error/throwable->error-map (RuntimeException. "plain"))]
+    (let [m (rf.story.error/throwable->error-map (RuntimeException. "plain"))]
       (is (= "plain" (:message m)))
       (is (nil? (:data m)))
       (is (string? (:stack m))))))
@@ -66,7 +66,7 @@
 (deftest throwable->error-map-tolerates-nil-throwable
   (testing "a nil throwable yields all-nil slots (the trace-drain path may
             carry no exception object)"
-    (let [m (story-error/throwable->error-map nil)]
+    (let [m (rf.story.error/throwable->error-map nil)]
       (is (= {:message nil :stack nil :data nil} m)))))
 
 (deftest throwable->error-map-explicit-message-override
@@ -74,15 +74,15 @@
             message (the trace-drain path threads a pre-extracted
             :exception-message)"
     (is (= "pre-extracted"
-           (:message (story-error/throwable->error-map
+           (:message (rf.story.error/throwable->error-map
                        (ex-info "original" {}) {:message "pre-extracted"}))))
     (testing "and survives even without a throwable in hand"
       (is (= "pre-extracted"
-             (:message (story-error/throwable->error-map
+             (:message (rf.story.error/throwable->error-map
                          nil {:message "pre-extracted"})))))
     (testing "a nil override falls back to the throwable's message"
       (is (= "original"
-             (:message (story-error/throwable->error-map
+             (:message (rf.story.error/throwable->error-map
                          (ex-info "original" {}) {:message nil})))))))
 
 ;; ---- exception-record -----------------------------------------------------
@@ -104,14 +104,14 @@
     (rf/make-frame {:id :story.x/v})
     (try
       (let [e (ex-info "kaboom" {:k :v})
-            r (story-error/exception-record :story.x/v :phase-2-events
+            r (rf.story.error/exception-record :story.x/v :phase-2-events
                                             [:some/event 1] e)]
         (is (= :rf.error/exception (:assertion r)))
         (is (= :story.x/v          (:variant-id r)))
         (is (= :phase-2-events     (:phase r)))
         (is (= [:some/event 1]     (:event r)))
         (is (false?                (:passed? r)))
-        (is (= (story-error/throwable->error-map e {:frame :story.x/v}) (:error r))
+        (is (= (rf.story.error/throwable->error-map e {:frame :story.x/v}) (:error r))
             "the :error slot is exactly the shared projection (same live frame)")
         (is (= "kaboom" (-> r :error :message)))
         (is (= {:k :v}  (-> r :error :data)))
@@ -122,7 +122,7 @@
 (deftest exception-record-threads-message-override
   (testing "the opts arity threads :message through to the embedded
             projection (the drain path's pre-extracted message)"
-    (let [r (story-error/exception-record :story.x/v :phase-1-loaders nil nil
+    (let [r (rf.story.error/exception-record :story.x/v :phase-1-loaders nil nil
                                           {:message "from trace"})]
       (is (= "from trace" (-> r :error :message)))
       (is (nil? (-> r :error :stack)))
@@ -140,7 +140,7 @@
                       :phase-loaders-teardown]
           error-keys (->> phases
                           (map (fn [p]
-                                 (set (keys (:error (story-error/exception-record
+                                 (set (keys (:error (rf.story.error/exception-record
                                                       :story.x/v p nil e))))))
                           set)]
       (is (= #{#{:message :stack :data}} error-keys)

--- a/tools/story/test/re_frame/story_fingerprint_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_fingerprint_cljs_test.cljs
@@ -11,7 +11,7 @@
   - the rf2-5x1wt.8 per-run stamp strip (epoch-record `:frame`, trace-event
     `:id` / `:time` / volatile tags) is host-portable too."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.story.fingerprint :as fp]))
+            [re-frame.story.fingerprint :as rf.story.fingerprint]))
 
 (def ^:private base
   {:status :pass
@@ -34,26 +34,26 @@
 
 (deftest content-hash-is-8-char-hex-on-cljs
   (testing "content-hash renders a left-padded 8-char lowercase hex string"
-    (let [h (fp/content-hash {:a 1})]
+    (let [h (rf.story.fingerprint/content-hash {:a 1})]
       (is (string? h))
       (is (= 8 (count h)))
       (is (re-matches #"[0-9a-f]{8}" h)))))
 
 (deftest order-insensitive-on-cljs
   (testing "map key order does not affect the CLJS hash"
-    (is (= (fp/content-hash {:a 1 :b 2}) (fp/content-hash {:b 2 :a 1}))))
+    (is (= (rf.story.fingerprint/content-hash {:a 1 :b 2}) (rf.story.fingerprint/content-hash {:b 2 :a 1}))))
   (testing "set element order does not affect the CLJS hash"
-    (is (= (fp/content-hash #{:x :y :z}) (fp/content-hash #{:z :y :x})))))
+    (is (= (rf.story.fingerprint/content-hash #{:x :y :z}) (rf.story.fingerprint/content-hash #{:z :y :x})))))
 
 (deftest volatile-equivalence-on-cljs
   (testing "volatile-only differences canonicalize = and run-hash equal"
-    (is (= (fp/canonicalize base) (fp/canonicalize volatile-twin)))
-    (is (= (fp/run-hash base) (fp/run-hash volatile-twin)))))
+    (is (= (rf.story.fingerprint/canonicalize base) (rf.story.fingerprint/canonicalize volatile-twin)))
+    (is (= (rf.story.fingerprint/run-hash base) (rf.story.fingerprint/run-hash volatile-twin)))))
 
 (deftest semantic-difference-on-cljs
   (testing "a semantic app-db difference perturbs the run-hash on CLJS"
-    (is (not= (fp/run-hash base)
-              (fp/run-hash (assoc-in base [:app-db :n] 2))))))
+    (is (not= (rf.story.fingerprint/run-hash base)
+              (rf.story.fingerprint/run-hash (assoc-in base [:app-db :n] 2))))))
 
 (deftest determinism-stamp-strip-on-cljs
   (testing "epoch records differing only in per-run stamps canonicalize = on CLJS
@@ -61,12 +61,12 @@
     (let [rec (fn [eid frame]
                 {:epoch-id eid :frame frame :committed-at 1 :schema-digest "d"
                  :outcome :ok :db-after {:n 1} :trace-events [] :effects []})]
-      (is (= (fp/canonicalize (rec 5 :rf.test.replay/frame-a))
-             (fp/canonicalize (rec 90 :rf.test.replay/frame-z))))
-      (is (= (fp/canonical-hash (rec 5 :rf.test.replay/frame-a))
-             (fp/canonical-hash (rec 90 :rf.test.replay/frame-z))))
-      (is (not= (fp/canonicalize (rec 5 :rf.test.replay/frame-a))
-                (fp/canonicalize (assoc (rec 5 :rf.test.replay/frame-a)
+      (is (= (rf.story.fingerprint/canonicalize (rec 5 :rf.test.replay/frame-a))
+             (rf.story.fingerprint/canonicalize (rec 90 :rf.test.replay/frame-z))))
+      (is (= (rf.story.fingerprint/canonical-hash (rec 5 :rf.test.replay/frame-a))
+             (rf.story.fingerprint/canonical-hash (rec 90 :rf.test.replay/frame-z))))
+      (is (not= (rf.story.fingerprint/canonicalize (rec 5 :rf.test.replay/frame-a))
+                (rf.story.fingerprint/canonicalize (assoc (rec 5 :rf.test.replay/frame-a)
                                         :db-after {:n 2})))
           "a real db-after difference still perturbs the canonical value")))
 
@@ -76,45 +76,45 @@
                {:operation :rf.event/run-start :op-type :event :id id :time id
                 :tags {:rf.trace/event-id :foo :frame frame
                        :rf.trace/dispatch-id id}})]
-      (is (= (fp/canonicalize {:trace-events [(ev 1 :rf.test.replay/frame-a)]})
-             (fp/canonicalize {:trace-events [(ev 9 :rf.test.replay/frame-z)]})))
-      (is (not= (fp/canonicalize {:trace-events [(ev 1 :rf.test.replay/frame-a)]})
-                (fp/canonicalize
+      (is (= (rf.story.fingerprint/canonicalize {:trace-events [(ev 1 :rf.test.replay/frame-a)]})
+             (rf.story.fingerprint/canonicalize {:trace-events [(ev 9 :rf.test.replay/frame-z)]})))
+      (is (not= (rf.story.fingerprint/canonicalize {:trace-events [(ev 1 :rf.test.replay/frame-a)]})
+                (rf.story.fingerprint/canonicalize
                   {:trace-events [(assoc-in (ev 1 :rf.test.replay/frame-a)
                                             [:tags :rf.trace/event-id] :bar)]}))
           "the event-id tag is behavioural, not a stamp")))
 
   (testing ":id / :time / :frame as plain app-db values are NOT stripped on CLJS"
-    (is (not= (fp/canonicalize {:status :pass :app-db {:id 1 :time 10 :frame :l}})
-              (fp/canonicalize {:status :pass :app-db {:id 2 :time 20 :frame :r}}))
+    (is (not= (rf.story.fingerprint/canonicalize {:status :pass :app-db {:id 1 :time 10 :frame :l}})
+              (rf.story.fingerprint/canonicalize {:status :pass :app-db {:id 2 :time 20 :frame :r}}))
         "semantic app-db data on common keys survives canonicalization")))
 
 (deftest collection-types-do-not-collide-on-cljs
   (testing "map / set / vector type tags keep the kinds distinct on CLJS
             (rf2-lvrqa) — host-portable structural tagging"
-    (is (not= (fp/content-hash {}) (fp/content-hash [])))
-    (is (not= (fp/content-hash #{}) (fp/content-hash [])))
-    (is (not= (fp/content-hash {:k 1}) (fp/content-hash [:k 1])))
-    (is (not= (fp/content-hash #{:k}) (fp/content-hash [:k])))
-    (is (not= (fp/canonical-hash {:effects [{:k 1}]})
-              (fp/canonical-hash {:effects [[:k 1]]})))))
+    (is (not= (rf.story.fingerprint/content-hash {}) (rf.story.fingerprint/content-hash [])))
+    (is (not= (rf.story.fingerprint/content-hash #{}) (rf.story.fingerprint/content-hash [])))
+    (is (not= (rf.story.fingerprint/content-hash {:k 1}) (rf.story.fingerprint/content-hash [:k 1])))
+    (is (not= (rf.story.fingerprint/content-hash #{:k}) (rf.story.fingerprint/content-hash [:k])))
+    (is (not= (rf.story.fingerprint/canonical-hash {:effects [{:k 1}]})
+              (rf.story.fingerprint/canonical-hash {:effects [[:k 1]]})))))
 
 (deftest fn-slot-deterministic-on-cljs
   (testing "a fn folds to the opaque sentinel on CLJS (rf2-4gwja) — a JS fn
             in a hashed slot hashes stably, keywords/colls are not folded"
-    (is (= fp/opaque-fn (fp/canonical-form (fn [] 1))))
-    (is (= (fp/run-hash {:status :pass :app-db {:cb (fn [] 1)}})
-           (fp/run-hash {:status :pass :app-db {:cb (fn [] 1)}})))
-    (is (not= fp/opaque-fn (fp/canonical-form :kw)))
-    (is (not= fp/opaque-fn (fp/canonical-form #{:a})))))
+    (is (= rf.story.fingerprint/opaque-fn (rf.story.fingerprint/canonical-form (fn [] 1))))
+    (is (= (rf.story.fingerprint/run-hash {:status :pass :app-db {:cb (fn [] 1)}})
+           (rf.story.fingerprint/run-hash {:status :pass :app-db {:cb (fn [] 1)}})))
+    (is (not= rf.story.fingerprint/opaque-fn (rf.story.fingerprint/canonical-form :kw)))
+    (is (not= rf.story.fingerprint/opaque-fn (rf.story.fingerprint/canonical-form #{:a})))))
 
 (deftest snapshot-fold-strip-free-on-cljs
   (testing "content-hash keeps :variant-id sensitivity; canonical-hash strips it"
     (let [tuple {:variant-id :story.x/v :variant {:a 1}}]
-      (is (not= (fp/content-hash tuple)
-                (fp/content-hash (assoc tuple :variant-id :story.y/v))))
-      (is (= (fp/canonical-hash tuple)
-             (fp/canonical-hash (assoc tuple :variant-id :story.y/v)))))))
+      (is (not= (rf.story.fingerprint/content-hash tuple)
+                (rf.story.fingerprint/content-hash (assoc tuple :variant-id :story.y/v))))
+      (is (= (rf.story.fingerprint/canonical-hash tuple)
+             (rf.story.fingerprint/canonical-hash (assoc tuple :variant-id :story.y/v)))))))
 
 ;; ===========================================================================
 ;; CROSS-HOST SCALAR STABILITY (rf2-vvqeo) — the CLJS side of the equivalence
@@ -133,35 +133,35 @@
   (testing "REGRESSION GUARD (rf2-vvqeo): ordinary-value content-hashes match
             the SAME pre-change baseline the JVM pins — no golden rebase, and
             the cross-host hash agreement for ordinary values too"
-    (is (= "211a4621" (fp/content-hash 42)))
-    (is (= "3409cbf2" (fp/content-hash "hello")))
-    (is (= "3ac20368" (fp/content-hash :foo/bar)))
-    (is (= "234450cb" (fp/content-hash [1 2 3])))
-    (is (= "418d9acd" (fp/content-hash {:a 1 :b "x" :c :k})))
-    (is (= "405ea2f0" (fp/content-hash #{:a :b :c})))
-    (is (= "98b520a4" (fp/content-hash {:status :pass :app-db {:n 1 :items [{:sku "A"}]}})))))
+    (is (= "211a4621" (rf.story.fingerprint/content-hash 42)))
+    (is (= "3409cbf2" (rf.story.fingerprint/content-hash "hello")))
+    (is (= "3ac20368" (rf.story.fingerprint/content-hash :foo/bar)))
+    (is (= "234450cb" (rf.story.fingerprint/content-hash [1 2 3])))
+    (is (= "418d9acd" (rf.story.fingerprint/content-hash {:a 1 :b "x" :c :k})))
+    (is (= "405ea2f0" (rf.story.fingerprint/content-hash #{:a :b :c})))
+    (is (= "98b520a4" (rf.story.fingerprint/content-hash {:status :pass :app-db {:n 1 :items [{:sku "A"}]}})))))
 
 (deftest doubles-and-ratios-canonicalize-host-portably-on-cljs
   (testing "the double CLJS reads `1/3` as canonicalises to the SAME bit form +
             hash the JVM Ratio `1/3` does (cross-host equivalence)"
-    (is (= [fp/double-tag "3fd5555555555555"] (fp/canonical-form (/ 1.0 3.0))))
-    (is (= "ca619b05" (fp/content-hash (/ 1.0 3.0)))
-        "matches the JVM `(fp/content-hash 1/3)` literal"))
+    (is (= [rf.story.fingerprint/double-tag "3fd5555555555555"] (rf.story.fingerprint/canonical-form (/ 1.0 3.0))))
+    (is (= "ca619b05" (rf.story.fingerprint/content-hash (/ 1.0 3.0)))
+        "matches the JVM `(rf.story.fingerprint/content-hash 1/3)` literal"))
   (testing "an integer-valued double IS the integer on CLJS — matches the JVM
             fold of `1.0` → `1`"
-    (is (= 1   (fp/canonical-form 1.0)))
-    (is (= 100 (fp/canonical-form 100.0)))
-    (is (= (fp/content-hash 1.0) (fp/content-hash 1))))
+    (is (= 1   (rf.story.fingerprint/canonical-form 1.0)))
+    (is (= 100 (rf.story.fingerprint/canonical-form 100.0)))
+    (is (= (rf.story.fingerprint/content-hash 1.0) (rf.story.fingerprint/content-hash 1))))
   (testing "a fractional double folds to the SAME `[:rf/double <hex>]` + hash
             the JVM `1.5` produces"
-    (is (= [fp/double-tag "3ff8000000000000"] (fp/canonical-form 1.5)))
-    (is (= "6ef2b29e" (fp/content-hash 1.5))
-        "matches the JVM `(fp/content-hash 1.5)` literal")
-    (is (not= (fp/canonical-form 1.5) (fp/canonical-form 1))))
+    (is (= [rf.story.fingerprint/double-tag "3ff8000000000000"] (rf.story.fingerprint/canonical-form 1.5)))
+    (is (= "6ef2b29e" (rf.story.fingerprint/content-hash 1.5))
+        "matches the JVM `(rf.story.fingerprint/content-hash 1.5)` literal")
+    (is (not= (rf.story.fingerprint/canonical-form 1.5) (rf.story.fingerprint/canonical-form 1))))
   (testing "an integer-valued double beyond the IEEE-754 safe-integer range
             takes the bit path — matches the JVM `1e21` form"
-    (is (= [fp/double-tag "444b1ae4d6e2ef50"] (fp/canonical-form 1e21)))
-    (is (= "66b23237" (fp/content-hash 1e21)))))
+    (is (= [rf.story.fingerprint/double-tag "444b1ae4d6e2ef50"] (rf.story.fingerprint/canonical-form 1e21)))
+    (is (= "66b23237" (rf.story.fingerprint/content-hash 1e21)))))
 
 (deftest large-integers-canonicalize-host-portably-on-cljs
   (testing "an integer beyond the IEEE-754 safe-integer range takes the lossy
@@ -169,35 +169,35 @@
             past 2^53, so `1e20` (what CLJS reads `100000000000000000000` as)
             canonicalises to the SAME `[:rf/double <hex>]` form + hash the JVM
             large bigint reaches. This pairing IS the cross-host proof."
-    (is (= [fp/double-tag "4415af1d78b58c40"] (fp/canonical-form 1e20)))
-    (is (= "8a4b7ac2" (fp/content-hash 1e20))
-        "matches the JVM `(fp/content-hash (bigint 100000000000000000000))`"))
+    (is (= [rf.story.fingerprint/double-tag "4415af1d78b58c40"] (rf.story.fingerprint/canonical-form 1e20)))
+    (is (= "8a4b7ac2" (rf.story.fingerprint/content-hash 1e20))
+        "matches the JVM `(rf.story.fingerprint/content-hash (bigint 100000000000000000000))`"))
   (testing "an integer AT max-safe-integer passes through verbatim on CLJS —
             no golden rebase for safe-range integers"
-    (is (= fp/max-safe-integer (fp/canonical-form fp/max-safe-integer)))
-    (is (= "9f16836d" (fp/content-hash fp/max-safe-integer))
-        "matches the JVM `(fp/content-hash 9007199254740991)` literal")))
+    (is (= rf.story.fingerprint/max-safe-integer (rf.story.fingerprint/canonical-form rf.story.fingerprint/max-safe-integer)))
+    (is (= "9f16836d" (rf.story.fingerprint/content-hash rf.story.fingerprint/max-safe-integer))
+        "matches the JVM `(rf.story.fingerprint/content-hash 9007199254740991)` literal")))
 
 (deftest nan-and-inf-canonicalize-host-portably-on-cljs
   (testing "NaN folds to the `:rf/nan` sentinel — matches the JVM, hashes stably"
-    (is (= fp/nan-tag (fp/canonical-form js/NaN)))
-    (is (= "0cf774cf" (fp/content-hash js/NaN))
-        "matches the JVM `(fp/content-hash (Double/NaN))` literal")
-    (is (= (fp/canonical-hash {:x js/NaN}) (fp/canonical-hash {:x js/NaN}))))
+    (is (= rf.story.fingerprint/nan-tag (rf.story.fingerprint/canonical-form js/NaN)))
+    (is (= "0cf774cf" (rf.story.fingerprint/content-hash js/NaN))
+        "matches the JVM `(rf.story.fingerprint/content-hash (Double/NaN))` literal")
+    (is (= (rf.story.fingerprint/canonical-hash {:x js/NaN}) (rf.story.fingerprint/canonical-hash {:x js/NaN}))))
   (testing "±Inf canonicalise to the SAME bit-double forms + hashes the JVM
             produces, mutually distinct"
-    (is (= [fp/double-tag "7ff0000000000000"] (fp/canonical-form js/Infinity)))
-    (is (= [fp/double-tag "fff0000000000000"] (fp/canonical-form (- js/Infinity))))
-    (is (= "026c4383" (fp/content-hash js/Infinity)))
-    (is (= "69fa37b4" (fp/content-hash (- js/Infinity))))
-    (is (not= (fp/canonical-form js/Infinity) (fp/canonical-form (- js/Infinity))))))
+    (is (= [rf.story.fingerprint/double-tag "7ff0000000000000"] (rf.story.fingerprint/canonical-form js/Infinity)))
+    (is (= [rf.story.fingerprint/double-tag "fff0000000000000"] (rf.story.fingerprint/canonical-form (- js/Infinity))))
+    (is (= "026c4383" (rf.story.fingerprint/content-hash js/Infinity)))
+    (is (= "69fa37b4" (rf.story.fingerprint/content-hash (- js/Infinity))))
+    (is (not= (rf.story.fingerprint/canonical-form js/Infinity) (rf.story.fingerprint/canonical-form (- js/Infinity))))))
 
 (deftest nan-set-and-opaque-fn-tiebreak-stable-on-cljs
   (testing "a NaN-bearing set hashes stably across builds on CLJS (the NaN
             ordering hole is closed — every NaN is the `:rf/nan` sentinel)"
-    (is (= (fp/content-hash (set [js/NaN :a 1]))
-           (fp/content-hash (set [1 :a js/NaN])))))
+    (is (= (rf.story.fingerprint/content-hash (set [js/NaN :a 1]))
+           (rf.story.fingerprint/content-hash (set [1 :a js/NaN])))))
   (testing "a set of two distinct JS fns (both fold to `:rf/opaque-fn`, equal
             `pr-str`) hashes stably across builds via `stable-canon-order`"
     (let [build (fn [] #{(fn [] 1) (fn [] 2) :marker})]
-      (is (= (fp/content-hash (build)) (fp/content-hash (build)))))))
+      (is (= (rf.story.fingerprint/content-hash (build)) (rf.story.fingerprint/content-hash (build)))))))

--- a/tools/story/test/re_frame/story_fingerprint_test.clj
+++ b/tools/story/test/re_frame/story_fingerprint_test.clj
@@ -9,7 +9,7 @@
   - project away the volatile record fields
     `{:elapsed-ms :dispatch-id :source :source-coord :runner :variant/id
       :plan-hash :run-hash}` (reconciling the shipping `:variant-id`
-    spelling first; the authoritative `fp/volatile-fields` set also carries
+    spelling first; the authoritative `rf.story.fingerprint/volatile-fields` set also carries
     the per-run epoch / trace stamps `:epoch-id :trace-id :committed-at
     :schema-digest`);
   - impose a total per-slot ordering;
@@ -24,7 +24,7 @@
   CLJS companion (`re-frame.story-fingerprint-cljs-test`) pins
   host-portability of the hash."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.fingerprint :as fp]))
+            [re-frame.story.fingerprint :as rf.story.fingerprint]))
 
 ;; ===========================================================================
 ;; ADVERSARIAL CORPUS
@@ -112,17 +112,17 @@
 
 (deftest project-strips-story-accumulator-keys
   (testing ":rf.story/* accumulator keys are dropped at any depth"
-    (let [projected (fp/project {:keep 1
+    (let [projected (rf.story.fingerprint/project {:keep 1
                                  :rf.story/lifecycle :ready
                                  :nested {:rf.story/x 9 :real :v}})]
       (is (= {:keep 1 :nested {:real :v}} projected))))
   (testing "non-rf.story namespaced keys survive"
-    (is (= {:rf/db 1} (fp/project {:rf/db 1})))))
+    (is (= {:rf/db 1} (rf.story.fingerprint/project {:rf/db 1})))))
 
 (deftest project-strips-volatile-fields
   (testing "every volatile field is dropped recursively"
-    (let [projected (fp/project base-run)]
-      (doseq [k fp/volatile-fields]
+    (let [projected (rf.story.fingerprint/project base-run)]
+      (doseq [k rf.story.fingerprint/volatile-fields]
         (is (not (contains? projected k))
             (str k " must be stripped from the projection")))
       (is (not (contains? (get-in projected [:assertions 0]) :source)))
@@ -134,14 +134,14 @@
   (testing "legacy :variant-id is rewritten to :variant/id, then stripped"
     ;; :variant/id is in the volatile set, so after reconciliation it's
     ;; gone — the two spellings collapse to the same projection.
-    (is (= (fp/project {:variant-id :x :keep 1})
-           (fp/project {:variant/id :x :keep 1})
+    (is (= (rf.story.fingerprint/project {:variant-id :x :keep 1})
+           (rf.story.fingerprint/project {:variant/id :x :keep 1})
            {:keep 1})))
   (testing "an existing :variant/id wins over a legacy :variant-id"
     ;; Both present: the normalized spelling is source of truth; both
     ;; then strip away, so the projection is just the residue.
     (is (= {:keep 1}
-           (fp/project {:variant-id :legacy :variant/id :canonical :keep 1})))))
+           (rf.story.fingerprint/project {:variant-id :legacy :variant/id :canonical :keep 1})))))
 
 ;; ===========================================================================
 ;; CANONICALIZE — equivalence after volatile strip / semantic sensitivity
@@ -150,36 +150,36 @@
 (deftest equivalent-runs-canonicalize-equal
   (testing "two runs differing only in volatile + accumulator fields
             canonicalize = and hash equal (determinism floor)"
-    (is (= (fp/canonicalize base-run) (fp/canonicalize volatile-twin))
+    (is (= (rf.story.fingerprint/canonicalize base-run) (rf.story.fingerprint/canonicalize volatile-twin))
         "canonical projections are =")
-    (is (= (fp/canonical-hash base-run) (fp/canonical-hash volatile-twin))
+    (is (= (rf.story.fingerprint/canonical-hash base-run) (rf.story.fingerprint/canonical-hash volatile-twin))
         "canonical hashes are equal")
-    (is (= (fp/run-hash base-run) (fp/run-hash volatile-twin))
+    (is (= (rf.story.fingerprint/run-hash base-run) (rf.story.fingerprint/run-hash volatile-twin))
         "run-hashes are equal")))
 
 (deftest semantic-difference-changes-canonical-value
   (testing "each single-field semantic difference perturbs both the
             canonical value and the run-hash (semantic-diff is not blind)"
-    (let [base-canon (fp/canonicalize base-run)
-          base-hash  (fp/run-hash base-run)]
+    (let [base-canon (rf.story.fingerprint/canonicalize base-run)
+          base-hash  (rf.story.fingerprint/run-hash base-run)]
       (doseq [[label twin] semantic-twins]
-        (is (not= base-canon (fp/canonicalize twin))
+        (is (not= base-canon (rf.story.fingerprint/canonicalize twin))
             (str label " must perturb the canonical value"))
-        (is (not= base-hash (fp/run-hash twin))
+        (is (not= base-hash (rf.story.fingerprint/run-hash twin))
             (str label " must perturb the run-hash"))))))
 
 (deftest canonicalize-is-idempotent-and-order-insensitive
   (testing "map key order does not affect the canonical value or hash"
-    (is (= (fp/canonicalize {:a 1 :b 2}) (fp/canonicalize {:b 2 :a 1})))
-    (is (= (fp/content-hash {:a 1 :b 2}) (fp/content-hash {:b 2 :a 1}))))
+    (is (= (rf.story.fingerprint/canonicalize {:a 1 :b 2}) (rf.story.fingerprint/canonicalize {:b 2 :a 1})))
+    (is (= (rf.story.fingerprint/content-hash {:a 1 :b 2}) (rf.story.fingerprint/content-hash {:b 2 :a 1}))))
   (testing "set element order does not affect the hash"
-    (is (= (fp/content-hash #{:x :y :z}) (fp/content-hash #{:z :y :x}))))
+    (is (= (rf.story.fingerprint/content-hash #{:x :y :z}) (rf.story.fingerprint/content-hash #{:z :y :x}))))
   (testing "canonicalize of an already-canonicalized value is stable
             (re-running the projection does not change the hash)"
-    (let [once (fp/canonicalize base-run)]
+    (let [once (rf.story.fingerprint/canonicalize base-run)]
       ;; A second canonicalize over the projected value must not alter the
       ;; canonical-form hash (no volatile keys remain to strip).
-      (is (= (fp/content-hash once) (fp/content-hash once))))))
+      (is (= (rf.story.fingerprint/content-hash once) (rf.story.fingerprint/content-hash once))))))
 
 ;; ===========================================================================
 ;; RECORDABLE-COEFFECT :rf/time-ms STRUCTURAL STRIP (rf2-jt854w — EP-0010 /
@@ -214,24 +214,24 @@
             wall-clock :rf.cofx :rf/time-ms canonicalize = and hash equal"
     (let [a (dispatched-trace-event {:rf/time-ms 1000 :counter/delta 4 :rf.route/location "/a"})
           b (dispatched-trace-event {:rf/time-ms 9999 :counter/delta 4 :rf.route/location "/a"})]
-      (is (= (fp/canonicalize a) (fp/canonicalize b))
+      (is (= (rf.story.fingerprint/canonicalize a) (rf.story.fingerprint/canonicalize b))
           "differing only in :rf/time-ms must canonicalize =")
-      (is (= (fp/canonical-hash a) (fp/canonical-hash b))
+      (is (= (rf.story.fingerprint/canonical-hash a) (rf.story.fingerprint/canonical-hash b))
           "differing only in :rf/time-ms must hash equal")))
   (testing "the semantic caller-supplied facts survive the strip — an
             owner-qualified leaf difference still perturbs the value + hash"
     (let [base    (dispatched-trace-event {:rf/time-ms 1000 :counter/delta 4 :rf.route/location "/a"})
           delta'  (dispatched-trace-event {:rf/time-ms 1000 :counter/delta 5 :rf.route/location "/a"})
           route'  (dispatched-trace-event {:rf/time-ms 1000 :counter/delta 4 :rf.route/location "/b"})]
-      (is (not= (fp/canonicalize base) (fp/canonicalize delta'))
+      (is (not= (rf.story.fingerprint/canonicalize base) (rf.story.fingerprint/canonicalize delta'))
           "a :counter/delta difference must perturb the canonical value")
-      (is (not= (fp/canonical-hash base) (fp/canonical-hash route'))
+      (is (not= (rf.story.fingerprint/canonical-hash base) (rf.story.fingerprint/canonical-hash route'))
           "a :rf.route/location difference must perturb the hash")))
   (testing "the strip only fires on the :rf.cofx carrier — a plain app-db
             map keying on :rf/time-ms is NOT stripped (structural, not recursive)"
     (let [a {:app-db {:rf/time-ms 1}}
           b {:app-db {:rf/time-ms 2}}]
-      (is (not= (fp/canonicalize a) (fp/canonicalize b))
+      (is (not= (rf.story.fingerprint/canonicalize a) (rf.story.fingerprint/canonicalize b))
           ":rf/time-ms outside a :rf.cofx trace tag is semantic app data"))))
 
 (defn- run-start-trace-event
@@ -249,17 +249,17 @@
             wall-clock :rf.event/cofx :rf/time-ms canonicalize = and hash equal"
     (let [a (run-start-trace-event {:rf/time-ms 1000 :counter/delta 4})
           b (run-start-trace-event {:rf/time-ms 9999 :counter/delta 4})]
-      (is (= (fp/canonicalize a) (fp/canonicalize b))
+      (is (= (rf.story.fingerprint/canonicalize a) (rf.story.fingerprint/canonicalize b))
           "differing only in :rf/time-ms must canonicalize =")
-      (is (= (fp/canonical-hash a) (fp/canonical-hash b))
+      (is (= (rf.story.fingerprint/canonical-hash a) (rf.story.fingerprint/canonical-hash b))
           "differing only in :rf/time-ms must hash equal")))
   (testing "the semantic post-generation facts survive — an owner-qualified
             leaf difference still perturbs the value + hash"
     (let [base   (run-start-trace-event {:rf/time-ms 1000 :counter/delta 4})
           delta' (run-start-trace-event {:rf/time-ms 1000 :counter/delta 5})]
-      (is (not= (fp/canonicalize base) (fp/canonicalize delta'))
+      (is (not= (rf.story.fingerprint/canonicalize base) (rf.story.fingerprint/canonicalize delta'))
           "a :counter/delta difference in the replay token must perturb the value")
-      (is (not= (fp/canonical-hash base) (fp/canonical-hash delta'))
+      (is (not= (rf.story.fingerprint/canonical-hash base) (rf.story.fingerprint/canonical-hash delta'))
           "and the hash"))))
 
 ;; ===========================================================================
@@ -293,17 +293,17 @@
             top-level :rf.cofx :rf/time-ms canonicalize = and hash equal"
     (let [a (epoch-record-with-cofx {:rf/time-ms 1000 :counter/delta 4})
           b (epoch-record-with-cofx {:rf/time-ms 9999 :counter/delta 4})]
-      (is (= (fp/canonicalize a) (fp/canonicalize b))
+      (is (= (rf.story.fingerprint/canonicalize a) (rf.story.fingerprint/canonicalize b))
           "differing only in :rf/time-ms must canonicalize =")
-      (is (= (fp/canonical-hash a) (fp/canonical-hash b))
+      (is (= (rf.story.fingerprint/canonical-hash a) (rf.story.fingerprint/canonical-hash b))
           "differing only in :rf/time-ms must hash equal")))
   (testing "the semantic caller-supplied replay facts survive — an
             owner-qualified leaf difference still perturbs the value + hash"
     (let [base   (epoch-record-with-cofx {:rf/time-ms 1000 :counter/delta 4})
           delta' (epoch-record-with-cofx {:rf/time-ms 1000 :counter/delta 5})]
-      (is (not= (fp/canonicalize base) (fp/canonicalize delta'))
+      (is (not= (rf.story.fingerprint/canonicalize base) (rf.story.fingerprint/canonicalize delta'))
           "a :counter/delta difference in the replay token must perturb the value")
-      (is (not= (fp/canonical-hash base) (fp/canonical-hash delta'))
+      (is (not= (rf.story.fingerprint/canonical-hash base) (rf.story.fingerprint/canonical-hash delta'))
           "and the hash"))))
 
 ;; ===========================================================================
@@ -318,41 +318,41 @@
 
 (deftest collection-types-do-not-collide
   (testing "empty collections of different kinds are canonically distinct"
-    (is (not= (fp/canonicalize {}) (fp/canonicalize [])))
-    (is (not= (fp/canonicalize #{}) (fp/canonicalize [])))
-    (is (not= (fp/canonicalize {}) (fp/canonicalize #{})))
-    (is (not= (fp/content-hash {}) (fp/content-hash []))
+    (is (not= (rf.story.fingerprint/canonicalize {}) (rf.story.fingerprint/canonicalize [])))
+    (is (not= (rf.story.fingerprint/canonicalize #{}) (rf.story.fingerprint/canonicalize [])))
+    (is (not= (rf.story.fingerprint/canonicalize {}) (rf.story.fingerprint/canonicalize #{})))
+    (is (not= (rf.story.fingerprint/content-hash {}) (rf.story.fingerprint/content-hash []))
         "{} and [] must hash differently")
-    (is (not= (fp/content-hash #{}) (fp/content-hash []))
+    (is (not= (rf.story.fingerprint/content-hash #{}) (rf.story.fingerprint/content-hash []))
         "#{} and [] must hash differently")
-    (is (not= (fp/content-hash {}) (fp/content-hash #{}))
+    (is (not= (rf.story.fingerprint/content-hash {}) (rf.story.fingerprint/content-hash #{}))
         "{} and #{} must hash differently"))
   (testing "a one-entry map and the flattened 2-element vector are distinct"
-    (is (not= (fp/canonicalize {:k 1}) (fp/canonicalize [:k 1])))
-    (is (not= (fp/content-hash {:k 1}) (fp/content-hash [:k 1]))
+    (is (not= (rf.story.fingerprint/canonicalize {:k 1}) (rf.story.fingerprint/canonicalize [:k 1])))
+    (is (not= (rf.story.fingerprint/content-hash {:k 1}) (rf.story.fingerprint/content-hash [:k 1]))
         "{:k 1} and [:k 1] must hash differently — the rf2-lvrqa proof"))
   (testing "a one-element set and the same-element vector are distinct"
-    (is (not= (fp/canonicalize #{:k}) (fp/canonicalize [:k])))
-    (is (not= (fp/content-hash #{:k}) (fp/content-hash [:k]))))
+    (is (not= (rf.story.fingerprint/canonicalize #{:k}) (rf.story.fingerprint/canonicalize [:k])))
+    (is (not= (rf.story.fingerprint/content-hash #{:k}) (rf.story.fingerprint/content-hash [:k]))))
   (testing "a list/seq is distinct from a vector at the canonical-form /
             content-hash layer (the seq-tag vs vec-tag). NOTE: the
             `canonicalize` path normalizes seqs to vectors UPSTREAM (its
             `project` / `strip-run-stamps` passes `mapv` every sequential),
             so seq-vs-vec is deliberately collapsed there; the distinction
             lives at the raw ordering layer the snapshot identity hashes."
-    (is (= [fp/seq-tag [:a :b]] (fp/canonical-form (list :a :b))))
-    (is (= [fp/vec-tag [:a :b]] (fp/canonical-form [:a :b])))
-    (is (not= (fp/content-hash (list :a :b)) (fp/content-hash [:a :b]))))
+    (is (= [rf.story.fingerprint/seq-tag [:a :b]] (rf.story.fingerprint/canonical-form (list :a :b))))
+    (is (= [rf.story.fingerprint/vec-tag [:a :b]] (rf.story.fingerprint/canonical-form [:a :b])))
+    (is (not= (rf.story.fingerprint/content-hash (list :a :b)) (rf.story.fingerprint/content-hash [:a :b]))))
   (testing "the collision is closed NESTED, not just at the root — a slot
             whose value flips between a map and a vector perturbs the hash"
-    (is (not= (fp/canonical-hash {:effects [{:k 1}]})
-              (fp/canonical-hash {:effects [[:k 1]]})))
-    (is (not= (fp/canonicalize {:k {}}) (fp/canonicalize {:k []})))
-    (is (not= (fp/canonicalize {:k {:a 1}}) (fp/canonicalize {:k [:a 1]}))))
+    (is (not= (rf.story.fingerprint/canonical-hash {:effects [{:k 1}]})
+              (rf.story.fingerprint/canonical-hash {:effects [[:k 1]]})))
+    (is (not= (rf.story.fingerprint/canonicalize {:k {}}) (rf.story.fingerprint/canonicalize {:k []})))
+    (is (not= (rf.story.fingerprint/canonicalize {:k {:a 1}}) (rf.story.fingerprint/canonicalize {:k [:a 1]}))))
   (testing "type-tagging does not break the volatile-strip equivalence —
             equivalent runs still canonicalize = and hash equal"
-    (is (= (fp/canonicalize base-run) (fp/canonicalize volatile-twin)))
-    (is (= (fp/run-hash base-run) (fp/run-hash volatile-twin)))))
+    (is (= (rf.story.fingerprint/canonicalize base-run) (rf.story.fingerprint/canonicalize volatile-twin)))
+    (is (= (rf.story.fingerprint/run-hash base-run) (rf.story.fingerprint/run-hash volatile-twin)))))
 
 ;; ===========================================================================
 ;; FN-SLOT DETERMINISM — a fn-valued hashed slot hashes STABLY (rf2-4gwja)
@@ -376,43 +376,43 @@
                         :world {:frame {:fx-overrides {:rf.http/managed (fn [_] :stub)}}}
                         :script [[:dispatch [:go]]]
                         :expect {:checks []}})
-          h1 (fp/plan-hash (build-plan))
-          h2 (fp/plan-hash (build-plan))]
+          h1 (rf.story.fingerprint/plan-hash (build-plan))
+          h2 (rf.story.fingerprint/plan-hash (build-plan))]
       (is (= h1 h2)
           "an inline-fn plan must hash identically across independent builds")))
   (testing "the same holds on the RUN-HASH path — a fn in :app-db or an
             effect :args hashes stably across distinct fn instances (rf2-ewrse)"
     (let [run-with (fn [f] {:status :pass :app-db {:cb f}
                             :effects [{:fx-id :x :args f :outcome :ok}]})]
-      (is (= (fp/run-hash (run-with (fn [] 1)))
-             (fp/run-hash (run-with (fn [] 1))))
+      (is (= (rf.story.fingerprint/run-hash (run-with (fn [] 1)))
+             (rf.story.fingerprint/run-hash (run-with (fn [] 1))))
           "two distinct closures in the run-slice must hash equal")
-      (is (= (fp/canonicalize (run-with (fn [] 1)))
-             (fp/canonicalize (run-with (fn [] 1))))
+      (is (= (rf.story.fingerprint/canonicalize (run-with (fn [] 1)))
+             (rf.story.fingerprint/canonicalize (run-with (fn [] 1))))
           "and canonicalize = (the determinism gate's authority)")))
   (testing "a fn canonicalizes to the stable opaque sentinel, never an
             object-identity pr-str"
-    (is (= fp/opaque-fn (fp/canonical-form (fn [] 1))))
-    (is (= (fp/canonical-form (fn [] 1)) (fp/canonical-form (fn [x] x))))
-    (is (not (re-find #"object\[" (pr-str (fp/canonical-form (fn [] 1))))))
+    (is (= rf.story.fingerprint/opaque-fn (rf.story.fingerprint/canonical-form (fn [] 1))))
+    (is (= (rf.story.fingerprint/canonical-form (fn [] 1)) (rf.story.fingerprint/canonical-form (fn [x] x))))
+    (is (not (re-find #"object\[" (pr-str (rf.story.fingerprint/canonical-form (fn [] 1))))))
     (testing "keywords / symbols / colls are IFn but NOT folded to the
               sentinel — only genuine fns are"
-      (is (= :kw  (fp/canonical-form :kw)))
-      (is (not= fp/opaque-fn (fp/canonical-form :kw)))
-      (is (not= fp/opaque-fn (fp/canonical-form #{:a})))))
+      (is (= :kw  (rf.story.fingerprint/canonical-form :kw)))
+      (is (not= rf.story.fingerprint/opaque-fn (rf.story.fingerprint/canonical-form :kw)))
+      (is (not= rf.story.fingerprint/opaque-fn (rf.story.fingerprint/canonical-form #{:a})))))
   (testing "DELIBERATE TRADE-OFF (rf2-4gwja): two plans differing ONLY in fn
             identity hash EQUAL — determinism is the contract, not fn
             discrimination. A non-fn semantic difference still perturbs."
     (let [base-fn-plan {:story/id :story.fn/v
                         :world {:frame {:fx-overrides {:rf.http/managed (fn [_] :a)}}}
                         :script [] :expect {}}]
-      (is (= (fp/plan-hash base-fn-plan)
-             (fp/plan-hash (assoc-in base-fn-plan
+      (is (= (rf.story.fingerprint/plan-hash base-fn-plan)
+             (rf.story.fingerprint/plan-hash (assoc-in base-fn-plan
                                      [:world :frame :fx-overrides :rf.http/managed]
                                      (fn [_] :b))))
           "two fn overrides hash equal — accepted trade-off")
-      (is (not= (fp/plan-hash base-fn-plan)
-                (fp/plan-hash (assoc-in base-fn-plan [:world :args :sku] "X")))
+      (is (not= (rf.story.fingerprint/plan-hash base-fn-plan)
+                (rf.story.fingerprint/plan-hash (assoc-in base-fn-plan [:world :args :sku] "X")))
           "a non-fn semantic difference still perturbs the plan-hash"))))
 
 ;; ===========================================================================
@@ -465,9 +465,9 @@
                   "[:rf/map [:app-db [:rf/map [:items [:rf/vec [[:rf/map [:sku \"A\"]]]] :n 1]] :status :pass]]"
                   "98b520a4"]]]
       (doseq [[v cf ch] cases]
-        (is (= cf (pr-str (fp/canonical-form v)))
+        (is (= cf (pr-str (rf.story.fingerprint/canonical-form v)))
             (str "canonical form of " (pr-str v) " drifted — golden rebase!"))
-        (is (= ch (fp/content-hash v))
+        (is (= ch (rf.story.fingerprint/content-hash v))
             (str "content-hash of " (pr-str v) " drifted — golden rebase!"))))))
 
 (deftest large-integers-canonicalize-host-portably
@@ -478,91 +478,91 @@
             verbatim (\"…N\") while CLJS routed it through `double->bits-hex` —
             divergent canonical form, divergent hash."
     (let [big (bigint 100000000000000000000)]
-      (is (= [fp/double-tag (#'fp/double->bits-hex (double big))]
-             (fp/canonical-form big))
+      (is (= [rf.story.fingerprint/double-tag (#'rf.story.fingerprint/double->bits-hex (double big))]
+             (rf.story.fingerprint/canonical-form big))
           "a large bigint folds to the lossy bit-double form, NOT \"…N\"")
       ;; the JVM Long path agrees with the bigint path for the same magnitude
-      (is (= (fp/canonical-form big)
-             (fp/canonical-form (.toBigInteger (bigdec big))))
+      (is (= (rf.story.fingerprint/canonical-form big)
+             (rf.story.fingerprint/canonical-form (.toBigInteger (bigdec big))))
           "BigInteger of the same magnitude shares the canonical form")
       ;; cross-host equivalence: the CLJS double `1e20` (what CLJS reads
       ;; `100000000000000000000` as) reaches the SAME bits — the CLJS companion
-      ;; pins `(fp/canonical-form 1e20)` to this exact form + hash.
-      (is (= (fp/canonical-form big) (fp/canonical-form 1e20))
+      ;; pins `(rf.story.fingerprint/canonical-form 1e20)` to this exact form + hash.
+      (is (= (rf.story.fingerprint/canonical-form big) (rf.story.fingerprint/canonical-form 1e20))
           "the large integer and its double approximation share the canonical
            form — the cross-host agreement point (CLJS has only the double)")))
   (testing "boundary: an integer AT ±max-safe-integer still passes through
             verbatim — only STRICTLY out-of-range integers change (rf2-7w1vp)"
-    (is (= fp/max-safe-integer (fp/canonical-form fp/max-safe-integer)))
-    (is (= (- fp/max-safe-integer) (fp/canonical-form (- fp/max-safe-integer))))
+    (is (= rf.story.fingerprint/max-safe-integer (rf.story.fingerprint/canonical-form rf.story.fingerprint/max-safe-integer)))
+    (is (= (- rf.story.fingerprint/max-safe-integer) (rf.story.fingerprint/canonical-form (- rf.story.fingerprint/max-safe-integer))))
     (is (= 9007199254740992N
            ;; one past max-safe-integer is out of range → bit-double path
-           (let [over (inc (bigint fp/max-safe-integer))]
-             (is (= [fp/double-tag (#'fp/double->bits-hex (double over))]
-                    (fp/canonical-form over)))
+           (let [over (inc (bigint rf.story.fingerprint/max-safe-integer))]
+             (is (= [rf.story.fingerprint/double-tag (#'rf.story.fingerprint/double->bits-hex (double over))]
+                    (rf.story.fingerprint/canonical-form over)))
              over))))
   (testing "ordinary small integers are untouched — no golden rebase"
-    (is (= 42 (fp/canonical-form 42)))
-    (is (= -7 (fp/canonical-form -7)))
-    (is (= 1000000 (fp/canonical-form 1000000)))))
+    (is (= 42 (rf.story.fingerprint/canonical-form 42)))
+    (is (= -7 (rf.story.fingerprint/canonical-form -7)))
+    (is (= 1000000 (rf.story.fingerprint/canonical-form 1000000)))))
 
 (deftest ratios-canonicalize-host-portably
   (testing "a JVM Ratio canonicalises to the SAME bit-stable double form its
             CLJS double counterpart reaches — `1/3` and `(/ 1.0 3.0)` (the
             double CLJS reads `1/3` as) share a canonical form + hash"
-    (is (= [fp/double-tag "3fd5555555555555"] (fp/canonical-form 1/3)))
-    (is (= (fp/canonical-form 1/3) (fp/canonical-form (/ 1.0 3.0))))
-    (is (= (fp/content-hash 1/3) (fp/content-hash (/ 1.0 3.0)))
+    (is (= [rf.story.fingerprint/double-tag "3fd5555555555555"] (rf.story.fingerprint/canonical-form 1/3)))
+    (is (= (rf.story.fingerprint/canonical-form 1/3) (rf.story.fingerprint/canonical-form (/ 1.0 3.0))))
+    (is (= (rf.story.fingerprint/content-hash 1/3) (rf.story.fingerprint/content-hash (/ 1.0 3.0)))
         "ratio and its double value hash equal — cross-host equivalence")
-    (is (= (fp/canonical-hash {:r 1/3}) (fp/canonical-hash {:r (/ 1.0 3.0)}))
+    (is (= (rf.story.fingerprint/canonical-hash {:r 1/3}) (rf.story.fingerprint/canonical-hash {:r (/ 1.0 3.0)}))
         "the same holds nested inside a hashed slice"))
   (testing "distinct ratios remain distinct (sensitivity not lost)"
-    (is (not= (fp/canonical-form 1/3) (fp/canonical-form 2/3)))))
+    (is (not= (rf.story.fingerprint/canonical-form 1/3) (rf.story.fingerprint/canonical-form 2/3)))))
 
 (deftest floats-canonicalize-host-portably
   (testing "an integer-valued double folds to its INTEGER form — host-mandated
             (CLJS `1.0` IS the integer `1`), so JVM `1.0` and `1` canonicalise
             EQUAL and the CLJS companion's `1.0` matches"
-    (is (= 1   (fp/canonical-form 1.0)))
-    (is (= 100 (fp/canonical-form 100.0)))
-    (is (= (fp/canonical-form 1.0) (fp/canonical-form 1))))
+    (is (= 1   (rf.story.fingerprint/canonical-form 1.0)))
+    (is (= 100 (rf.story.fingerprint/canonical-form 100.0)))
+    (is (= (rf.story.fingerprint/canonical-form 1.0) (rf.story.fingerprint/canonical-form 1))))
   (testing "a fractional double folds to the bit-stable `[:rf/double <hex>]`"
-    (is (= [fp/double-tag "3ff8000000000000"] (fp/canonical-form 1.5)))
-    (is (not= (fp/canonical-form 1.5) (fp/canonical-form 1))
+    (is (= [rf.story.fingerprint/double-tag "3ff8000000000000"] (rf.story.fingerprint/canonical-form 1.5)))
+    (is (not= (rf.story.fingerprint/canonical-form 1.5) (rf.story.fingerprint/canonical-form 1))
         "1.5 is NOT integer-valued — distinct from 1")
-    (is (not= (fp/canonical-form 1.5) (fp/canonical-form 2.5))
+    (is (not= (rf.story.fingerprint/canonical-form 1.5) (rf.story.fingerprint/canonical-form 2.5))
         "distinct fractional doubles stay distinct"))
   (testing "an integer-valued double too large for a 64-bit integer takes the
             bit path (no silent overflow to a wrong long)"
-    (is (= [fp/double-tag "444b1ae4d6e2ef50"] (fp/canonical-form 1e21)))))
+    (is (= [rf.story.fingerprint/double-tag "444b1ae4d6e2ef50"] (rf.story.fingerprint/canonical-form 1e21)))))
 
 (deftest nan-and-inf-canonicalize-host-portably
   (testing "every NaN folds to the single `:rf/nan` sentinel — a `##NaN` slot
             hashes deterministically and never perturbs a hash by bit-pattern"
-    (is (= fp/nan-tag (fp/canonical-form Double/NaN)))
-    (is (= (fp/content-hash Double/NaN) (fp/content-hash Double/NaN)))
-    (is (= (fp/canonical-hash {:x Double/NaN})
-           (fp/canonical-hash {:x Double/NaN}))
+    (is (= rf.story.fingerprint/nan-tag (rf.story.fingerprint/canonical-form Double/NaN)))
+    (is (= (rf.story.fingerprint/content-hash Double/NaN) (rf.story.fingerprint/content-hash Double/NaN)))
+    (is (= (rf.story.fingerprint/canonical-hash {:x Double/NaN})
+           (rf.story.fingerprint/canonical-hash {:x Double/NaN}))
         "two NaN-bearing slices hash equal"))
   (testing "±Inf ride the bit-double path — host-stable bits, mutually distinct
             and distinct from every finite double"
-    (is (= [fp/double-tag "7ff0000000000000"] (fp/canonical-form Double/POSITIVE_INFINITY)))
-    (is (= [fp/double-tag "fff0000000000000"] (fp/canonical-form Double/NEGATIVE_INFINITY)))
-    (is (not= (fp/canonical-form Double/POSITIVE_INFINITY)
-              (fp/canonical-form Double/NEGATIVE_INFINITY)))
-    (is (not= (fp/canonical-form Double/POSITIVE_INFINITY) (fp/canonical-form 1.5)))
-    (is (not= fp/nan-tag (fp/canonical-form Double/POSITIVE_INFINITY)))))
+    (is (= [rf.story.fingerprint/double-tag "7ff0000000000000"] (rf.story.fingerprint/canonical-form Double/POSITIVE_INFINITY)))
+    (is (= [rf.story.fingerprint/double-tag "fff0000000000000"] (rf.story.fingerprint/canonical-form Double/NEGATIVE_INFINITY)))
+    (is (not= (rf.story.fingerprint/canonical-form Double/POSITIVE_INFINITY)
+              (rf.story.fingerprint/canonical-form Double/NEGATIVE_INFINITY)))
+    (is (not= (rf.story.fingerprint/canonical-form Double/POSITIVE_INFINITY) (rf.story.fingerprint/canonical-form 1.5)))
+    (is (not= rf.story.fingerprint/nan-tag (rf.story.fingerprint/canonical-form Double/POSITIVE_INFINITY)))))
 
 (deftest nan-bearing-set-orders-deterministically
   (testing "a NaN in a set no longer destabilises ordering — every NaN folds to
             the `:rf/nan` sentinel BEFORE the set sort, so the set hashes
             stably across builds (the `(sort-by pr-str)` NaN hole, closed)"
-    (is (= (fp/content-hash #{1 Double/NaN :a})
-           (fp/content-hash #{1 Double/NaN :a})))
+    (is (= (rf.story.fingerprint/content-hash #{1 Double/NaN :a})
+           (rf.story.fingerprint/content-hash #{1 Double/NaN :a})))
     ;; a freshly-constructed NaN-bearing set hashes identically — the exact
     ;; cross-build / cross-host instability the bare comparator risked.
-    (is (= (fp/content-hash (set [Double/NaN :a 1]))
-           (fp/content-hash (set [1 :a Double/NaN]))))))
+    (is (= (rf.story.fingerprint/content-hash (set [Double/NaN :a 1]))
+           (rf.story.fingerprint/content-hash (set [1 :a Double/NaN]))))))
 
 (deftest canon-set-has-a-stable-equal-pr-str-tiebreak
   (testing "two DISTINCT fns in a set both fold to `:rf/opaque-fn` (equal
@@ -570,14 +570,14 @@
             deterministic order, so the set hashes stably across independent
             builds — the latent `(sort-by pr-str)` tie hole (rf2-vvqeo)"
     (let [build (fn [] #{(fn [] 1) (fn [] 2) :marker})]
-      (is (= (fp/content-hash (build)) (fp/content-hash (build)))
+      (is (= (rf.story.fingerprint/content-hash (build)) (rf.story.fingerprint/content-hash (build)))
           "an equal-pr-str-bearing set hashes identically across builds")))
   (testing "ordinary distinct-`pr-str` set order is the SAME as the historical
             `(sort-by pr-str)` order — no golden rebase for normal sets"
     ;; verified by the unchanged content-hash 405ea2f0 for #{:a :b :c} in
     ;; `ordinary-value-canonical-forms-are-unchanged`; this restates the
     ;; element-ordering directly.
-    (is (= [fp/set-tag [:a :b :c]] (fp/canonical-form #{:c :a :b})))))
+    (is (= [rf.story.fingerprint/set-tag [:a :b :c]] (rf.story.fingerprint/canonical-form #{:c :a :b})))))
 
 ;; ===========================================================================
 ;; MAP-KEY TIE ORDER — same-`pr-str` keys sort iteration-INDEPENDENTLY (rf2-8r5yzb)
@@ -604,15 +604,15 @@
           m-ab (array-map f1 :a f2 :b)
           m-ba (array-map f2 :b f1 :a)]
       (is (= m-ab m-ba) "precondition: the two maps are =-equal")
-      (is (= (fp/canonical-form m-ab) (fp/canonical-form m-ba))
+      (is (= (rf.story.fingerprint/canonical-form m-ab) (rf.story.fingerprint/canonical-form m-ba))
           "insertion/iteration order must not change the canonical form")
-      (is (= (fp/canonical-hash m-ab) (fp/canonical-hash m-ba))
+      (is (= (rf.story.fingerprint/canonical-hash m-ab) (rf.story.fingerprint/canonical-hash m-ba))
           "…so the canonical hashes are equal — the determinism floor")))
   (testing "a GENUINE value difference under a tied key still SEPARATES — the
             secondary key is a tiebreak, not a collapse"
     (let [f1 (fn [] 1) f2 (fn [] 2)]
-      (is (not= (fp/canonical-hash (array-map f1 :a f2 :b))
-                (fp/canonical-hash (array-map f1 :a f2 :c)))
+      (is (not= (rf.story.fingerprint/canonical-hash (array-map f1 :a f2 :b))
+                (rf.story.fingerprint/canonical-hash (array-map f1 :a f2 :c)))
           "{f1 :a f2 :b} and {f1 :a f2 :c} differ in a value → distinct hash")))
   (testing "the number-folding tie (`1` and `1.0` both canon to `1`) is
             likewise iteration-independent — the fix generalises past fn/NaN"
@@ -620,12 +620,12 @@
           m2 (array-map 1.0 :b 1 :a)]
       (is (and (= 2 (count m1)) (= 2 (count m2)))
           "precondition: 1 and 1.0 are DISTINCT keys (Clojure `=` is category-sensitive)")
-      (is (= (fp/canonical-hash m1) (fp/canonical-hash m2))
+      (is (= (rf.story.fingerprint/canonical-hash m1) (rf.story.fingerprint/canonical-hash m2))
           "same-canon-key entries order by value, so the hashes are equal")))
   (testing "ordinary distinct-`pr-str` map key order is UNCHANGED — the value
             tiebreak never fires, so no golden rebase"
-    (is (= [fp/map-tag [:a 1 :b 2 :c 3]]
-           (fp/canonical-form (array-map :c 3 :a 1 :b 2)))
+    (is (= [rf.story.fingerprint/map-tag [:a 1 :b 2 :c 3]]
+           (rf.story.fingerprint/canonical-form (array-map :c 3 :a 1 :b 2)))
         "distinct keys still sort by key alone — identical to the pre-fix bytes")))
 
 ;; ===========================================================================
@@ -635,7 +635,7 @@
 (deftest canonical-version-is-bumped-to-v2
   (testing "the canonical-version tag is :rf/snapshot-canonical-v2 — bumped
             for the type-tag + fn-sentinel soundness fix"
-    (is (= :rf/snapshot-canonical-v2 fp/canonical-version))))
+    (is (= :rf/snapshot-canonical-v2 rf.story.fingerprint/canonical-version))))
 
 ;; ===========================================================================
 ;; ORDERING — effects / epochs keep producer order; reordering is semantic
@@ -645,11 +645,11 @@
   (testing "effects keep emission order — swapping two effects is a
             different canonical value (order is part of the evidence)"
     (let [swapped (update base-run :effects (comp vec reverse))]
-      (is (not= (fp/canonicalize base-run) (fp/canonicalize swapped))
+      (is (not= (rf.story.fingerprint/canonicalize base-run) (rf.story.fingerprint/canonicalize swapped))
           "reordered effects perturb the canonical value")))
   (testing "epoch dispatch order is preserved + significant"
     (let [swapped (update base-run :epoch-tape (comp vec reverse))]
-      (is (not= (fp/canonicalize base-run) (fp/canonicalize swapped))))))
+      (is (not= (rf.story.fingerprint/canonicalize base-run) (rf.story.fingerprint/canonicalize swapped))))))
 
 ;; ===========================================================================
 ;; PLAN HASH — enumerated inputs, shared primitive
@@ -673,27 +673,27 @@
 (deftest plan-hash-over-enumerated-inputs-only
   (testing "non-input slots (:evidence, :explain, :source-chain, :plan/id,
             the rider :plan-hash, :variant/id) do not affect plan-hash"
-    (let [h (fp/plan-hash base-plan)]
-      (is (= h (fp/plan-hash (assoc base-plan :evidence {:source :other}))))
-      (is (= h (fp/plan-hash (assoc base-plan :explain {:debug :different}))))
-      (is (= h (fp/plan-hash (assoc base-plan :source-chain [:x]))))
-      (is (= h (fp/plan-hash (assoc base-plan :plan/id :other))))
-      (is (= h (fp/plan-hash (assoc base-plan :plan-hash "different"))))
-      (is (= h (fp/plan-hash (dissoc base-plan :variant/id)))
+    (let [h (rf.story.fingerprint/plan-hash base-plan)]
+      (is (= h (rf.story.fingerprint/plan-hash (assoc base-plan :evidence {:source :other}))))
+      (is (= h (rf.story.fingerprint/plan-hash (assoc base-plan :explain {:debug :different}))))
+      (is (= h (rf.story.fingerprint/plan-hash (assoc base-plan :source-chain [:x]))))
+      (is (= h (rf.story.fingerprint/plan-hash (assoc base-plan :plan/id :other))))
+      (is (= h (rf.story.fingerprint/plan-hash (assoc base-plan :plan-hash "different"))))
+      (is (= h (rf.story.fingerprint/plan-hash (dissoc base-plan :variant/id)))
           ":variant/id is volatile — dropping it does not change the plan-hash")))
   (testing "a testable/renderable difference changes plan-hash"
-    (is (not= (fp/plan-hash base-plan)
-              (fp/plan-hash (assoc-in base-plan [:world :args :sku] "B"))))
-    (is (not= (fp/plan-hash base-plan)
-              (fp/plan-hash (update base-plan :script conj [:dispatch [:extra]]))))
-    (is (not= (fp/plan-hash base-plan)
-              (fp/plan-hash (assoc base-plan :story/id :story.other))))))
+    (is (not= (rf.story.fingerprint/plan-hash base-plan)
+              (rf.story.fingerprint/plan-hash (assoc-in base-plan [:world :args :sku] "B"))))
+    (is (not= (rf.story.fingerprint/plan-hash base-plan)
+              (rf.story.fingerprint/plan-hash (update base-plan :script conj [:dispatch [:extra]]))))
+    (is (not= (rf.story.fingerprint/plan-hash base-plan)
+              (rf.story.fingerprint/plan-hash (assoc base-plan :story/id :story.other))))))
 
 (deftest plan-hash-accepts-legacy-variant-id-spelling
   (testing "the legacy :variant-id spelling is reconciled — a plan with
             either spelling produces the same plan-hash"
     (let [legacy (-> base-plan (dissoc :variant/id) (assoc :variant-id :story.checkout/submits))]
-      (is (= (fp/plan-hash base-plan) (fp/plan-hash legacy))))))
+      (is (= (rf.story.fingerprint/plan-hash base-plan) (rf.story.fingerprint/plan-hash legacy))))))
 
 ;; ===========================================================================
 ;; ONE PRIMITIVE — plan-hash + run-hash + identity share the same path
@@ -703,11 +703,11 @@
   (testing "plan-hash and run-hash are canonical-hash applied to a slice —
             no second hash implementation. We prove it by reconstructing
             each hash from the public primitive over the same slice."
-    (is (= (fp/plan-hash base-plan)
-           (fp/canonical-hash (select-keys base-plan fp/plan-hash-input-keys)))
+    (is (= (rf.story.fingerprint/plan-hash base-plan)
+           (rf.story.fingerprint/canonical-hash (select-keys base-plan rf.story.fingerprint/plan-hash-input-keys)))
         "plan-hash == canonical-hash over the enumerated plan slice")
-    (is (= (fp/run-hash base-run)
-           (fp/canonical-hash (select-keys base-run fp/run-hash-input-keys)))
+    (is (= (rf.story.fingerprint/run-hash base-run)
+           (rf.story.fingerprint/canonical-hash (select-keys base-run rf.story.fingerprint/run-hash-input-keys)))
         "run-hash == canonical-hash over the enumerated run slice")))
 
 (deftest snapshot-identity-uses-the-same-primitive
@@ -721,12 +721,12 @@
       ;; content-hash must NOT strip :variant-id (it is identity-bearing
       ;; for the snapshot); two tuples differing only by variant id hash
       ;; differently through content-hash...
-      (is (not= (fp/content-hash tuple)
-                (fp/content-hash (assoc tuple :variant-id :story.y/v)))
+      (is (not= (rf.story.fingerprint/content-hash tuple)
+                (rf.story.fingerprint/content-hash (assoc tuple :variant-id :story.y/v)))
           "snapshot content-hash keeps :variant-id sensitivity")
       ;; ...while canonical-hash (the run/diff path) DOES strip it.
-      (is (= (fp/canonical-hash tuple)
-             (fp/canonical-hash (assoc tuple :variant-id :story.y/v)))
+      (is (= (rf.story.fingerprint/canonical-hash tuple)
+             (rf.story.fingerprint/canonical-hash (assoc tuple :variant-id :story.y/v)))
           "canonical-hash strips :variant-id (run/diff equivalence)"))))
 
 ;; ===========================================================================
@@ -745,5 +745,5 @@
           inline     (-> base-plan
                          (dissoc :variant/id :plan/id)
                          (assoc :source-chain [] :explain {:from :inline}))]
-      (is (= (fp/plan-hash registered) (fp/plan-hash inline))
+      (is (= (rf.story.fingerprint/plan-hash registered) (rf.story.fingerprint/plan-hash inline))
           "same testable content → same plan-hash regardless of provenance"))))

--- a/tools/story/test/re_frame/story_fx_stubs_per_fx_scenarios_test.clj
+++ b/tools/story/test/re_frame/story_fx_stubs_per_fx_scenarios_test.clj
@@ -28,34 +28,34 @@
   motivation."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.machines         :as machines]
-            [re-frame.registrar        :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story            :as story]
-            [re-frame.story.async      :as async]
-            [re-frame.story.config     :as config]
-            [re-frame.story.frames     :as frames]
-            [re-frame.story.fx-stubs   :as fx-stubs]
-            [re-frame.story.loaders    :as loaders]
-            [re-frame.story.play       :as play]))
+            [re-frame.frame            :as rf.frame]
+            [re-frame.machines         :as rf.machines]
+            [re-frame.registrar        :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story            :as rf.story]
+            [re-frame.story.async      :as rf.story.async]
+            [re-frame.story.config     :as rf.story.config]
+            [re-frame.story.frames     :as rf.story.frames]
+            [re-frame.story.fx-stubs   :as rf.story.fx-stubs]
+            [re-frame.story.loaders    :as rf.story.loaders]
+            [re-frame.story.play       :as rf.story.play]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
 (defn reset-all [test-fn]
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
   (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (config/set-global-args! {})
-  (reset! play/stepper-state            {})
-  (reset! frames/stub-call-log          {})
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.config/set-global-args! {})
+  (reset! rf.story.play/stepper-state            {})
+  (reset! rf.story.frames/stub-call-log          {})
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (test-fn))
 
 (use-fixtures :each reset-all)
@@ -86,14 +86,14 @@
   (let [overrides (:fx-overrides (rf/frame-meta variant-id))]
     (is (contains? overrides fx-id)
         (str fx-id " — frame :fx-overrides carries the redirect")))
-  (let [log (frames/stub-call-log-for variant-id)]
+  (let [log (rf.story.frames/stub-call-log-for variant-id)]
     (is (= 1 (count log))
         (str fx-id " — exactly one stub-call recorded"))
     (is (= fx-id (:fx-id (first log)))
         (str fx-id " — log entry carries the original fx-id"))
     (is (= expected-payload (:payload (first log)))
         (str fx-id " — log entry carries the original payload")))
-  (is (contains? (fx-stubs/observed-fx-ids variant-id) fx-id)
+  (is (contains? (rf.story.fx-stubs/observed-fx-ids variant-id) fx-id)
       (str fx-id " — observed-fx-ids surfaces the stubbed fx"))
   (let [last-a (last (:assertions result))]
     (is (true? (:passed? last-a))
@@ -103,57 +103,57 @@
   (testing ":http fx is intercepted by force-fx-stub end-to-end"
     (rf/reg-event :do/http-emit
       (fn [_ _] {:fx [[:http {:url "/api" :method :get}]]}))
-    (story/reg-variant :story.fxscen.http/v
+    (rf.story/reg-variant :story.fxscen.http/v
       {:decorators [[:rf.story/force-fx-stub :http {:status :ok :body {:n 1}}]]
        :setup     []
        :script [[:dispatch-sync [:do/http-emit]]
                     [:dispatch-sync [:rf.assert/effect-emitted :http]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.fxscen.http/v) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.fxscen.http/v) 5000)]
       (assert-stub-intercepted! :story.fxscen.http/v :http
                                 {:url "/api" :method :get} r))
-    (story/destroy-variant! :story.fxscen.http/v)))
+    (rf.story/destroy-variant! :story.fxscen.http/v)))
 
 (deftest analytics-fx-stub-scenario
   (testing ":analytics fx is intercepted by force-fx-stub end-to-end"
     (rf/reg-event :do/analytics-emit
       (fn [_ _] {:fx [[:analytics {:event "page-view" :path "/home"}]]}))
-    (story/reg-variant :story.fxscen.analytics/v
+    (rf.story/reg-variant :story.fxscen.analytics/v
       {:decorators [[:rf.story/force-fx-stub :analytics {:ack? true}]]
        :setup     []
        :script [[:dispatch-sync [:do/analytics-emit]]
                     [:dispatch-sync [:rf.assert/effect-emitted :analytics]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.fxscen.analytics/v) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.fxscen.analytics/v) 5000)]
       (assert-stub-intercepted! :story.fxscen.analytics/v :analytics
                                 {:event "page-view" :path "/home"} r))
-    (story/destroy-variant! :story.fxscen.analytics/v)))
+    (rf.story/destroy-variant! :story.fxscen.analytics/v)))
 
 (deftest websocket-fx-stub-scenario
   (testing ":websocket fx is intercepted by force-fx-stub end-to-end"
     (rf/reg-event :do/websocket-emit
       (fn [_ _] {:fx [[:websocket {:topic "live" :payload {:tick 1}}]]}))
-    (story/reg-variant :story.fxscen.websocket/v
+    (rf.story/reg-variant :story.fxscen.websocket/v
       {:decorators [[:rf.story/force-fx-stub :websocket {:connected? true}]]
        :setup     []
        :script [[:dispatch-sync [:do/websocket-emit]]
                     [:dispatch-sync [:rf.assert/effect-emitted :websocket]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.fxscen.websocket/v) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.fxscen.websocket/v) 5000)]
       (assert-stub-intercepted! :story.fxscen.websocket/v :websocket
                                 {:topic "live" :payload {:tick 1}} r))
-    (story/destroy-variant! :story.fxscen.websocket/v)))
+    (rf.story/destroy-variant! :story.fxscen.websocket/v)))
 
 (deftest navigation-fx-stub-scenario
   (testing ":navigation fx is intercepted by force-fx-stub end-to-end"
     (rf/reg-event :do/navigation-emit
       (fn [_ _] {:fx [[:navigation {:to "/dashboard" :replace? false}]]}))
-    (story/reg-variant :story.fxscen.navigation/v
+    (rf.story/reg-variant :story.fxscen.navigation/v
       {:decorators [[:rf.story/force-fx-stub :navigation {:landed? true}]]
        :setup     []
        :script [[:dispatch-sync [:do/navigation-emit]]
                     [:dispatch-sync [:rf.assert/effect-emitted :navigation]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.fxscen.navigation/v) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.fxscen.navigation/v) 5000)]
       (assert-stub-intercepted! :story.fxscen.navigation/v :navigation
                                 {:to "/dashboard" :replace? false} r))
-    (story/destroy-variant! :story.fxscen.navigation/v)))
+    (rf.story/destroy-variant! :story.fxscen.navigation/v)))
 
 ;; ===========================================================================
 ;; rf2-mwr16 — stub-overriding-real
@@ -188,12 +188,12 @@
       (rf/reg-event :do/http-call
         (fn [_ _]
           {:fx [[:http {:url "/should-not-hit-real" :method :get}]]}))
-      (story/reg-variant :story.fxoverride/real
+      (rf.story/reg-variant :story.fxoverride/real
         {:decorators [[:rf.story/force-fx-stub :http {:status :ok :body {}}]]
          :setup     []
          :script [[:dispatch-sync [:do/http-call]]
                       [:dispatch-sync [:rf.assert/effect-emitted :http]]]})
-      (let [r (async/deref-blocking (story/run-variant :story.fxoverride/real) 5000)]
+      (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.fxoverride/real) 5000)]
         (is (= :ready (:lifecycle r))
             "lifecycle reaches :ready — the stub absorbed the call, the real
              handler's throw never fired")
@@ -203,7 +203,7 @@
              reg-fx dispatch")
         (is (= [] @real-payloads)
             "real handler's side-channel records zero payloads")
-        (let [log (frames/stub-call-log-for :story.fxoverride/real)]
+        (let [log (rf.story.frames/stub-call-log-for :story.fxoverride/real)]
           (is (= 1 (count log)))
           (is (= :http (:fx-id (first log)))
               "the stub captured the redirected fx-id")
@@ -212,7 +212,7 @@
               "the stub captured the original payload"))
         (is (true? (:passed? (last (:assertions r))))
             ":rf.assert/effect-emitted passes against the stub"))
-      (story/destroy-variant! :story.fxoverride/real))))
+      (rf.story/destroy-variant! :story.fxoverride/real))))
 
 ;; ===========================================================================
 ;; rf2-mwr16 — stub-failure-mode
@@ -252,7 +252,7 @@
       ;; managed-fx response.
       (rf/reg-event :record/failure
         (fn [{:keys [db]} _] {:db (assoc db :http-result failure-payload)}))
-      (story/reg-variant :story.fxfail/v
+      (rf.story/reg-variant :story.fxfail/v
         {:decorators [[:rf.story/force-fx-stub :http failure-payload]]
          :setup     []
          :script [[:dispatch-sync [:do/http-emit-fail]]
@@ -262,7 +262,7 @@
                       [:dispatch-sync [:rf.assert/path-equals [:http-result :code]   500]]
                       [:dispatch-sync [:rf.assert/path-equals [:http-result :body]
                                              {:reason "server-down"}]]]})
-      (let [r       (async/deref-blocking (story/run-variant :story.fxfail/v) 5000)
+      (let [r       (rf.story.async/deref-blocking (rf.story/run-variant :story.fxfail/v) 5000)
             asserts (:assertions r)]
         (is (= :ready (:lifecycle r))
             "lifecycle reaches :ready — failure-shaped response does NOT
@@ -276,7 +276,7 @@
         ;; and confirm it matches what we declared in the decorator.
         ;; Proves the failure payload made the full round-trip through
         ;; the framework's :fx-overrides redirect.
-        (let [log (frames/stub-call-log-for :story.fxfail/v)]
+        (let [log (rf.story.frames/stub-call-log-for :story.fxfail/v)]
           (is (= 1 (count log)))
           (is (= :http (:fx-id (first log))))
           (is (= {:url "/api/may-fail"} (:payload (first log)))
@@ -284,4 +284,4 @@
                payload lives in the decorator's :response slot, not the log
                (the log records what the variant emitted, not the canned
                reply)")))
-      (story/destroy-variant! :story.fxfail/v))))
+      (rf.story/destroy-variant! :story.fxfail/v))))

--- a/tools/story/test/re_frame/story_fx_stubs_test.clj
+++ b/tools/story/test/re_frame/story_fx_stubs_test.clj
@@ -15,35 +15,35 @@
   - Frame teardown drops the stub-event log."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.machines         :as machines]
-            [re-frame.registrar        :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story            :as story]
-            [re-frame.story.async      :as async]
-            [re-frame.story.config     :as config]
-            [re-frame.story.decorators :as decorators]
-            [re-frame.story.frames     :as frames]
-            [re-frame.story.fx-stubs   :as fx-stubs]
-            [re-frame.story.loaders    :as loaders]
-            [re-frame.story.play       :as play]))
+            [re-frame.frame            :as rf.frame]
+            [re-frame.machines         :as rf.machines]
+            [re-frame.registrar        :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story            :as rf.story]
+            [re-frame.story.async      :as rf.story.async]
+            [re-frame.story.config     :as rf.story.config]
+            [re-frame.story.decorators :as rf.story.decorators]
+            [re-frame.story.frames     :as rf.story.frames]
+            [re-frame.story.fx-stubs   :as rf.story.fx-stubs]
+            [re-frame.story.loaders    :as rf.story.loaders]
+            [re-frame.story.play       :as rf.story.play]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
 (defn reset-all [test-fn]
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
   (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (config/set-global-args! {})
-  (reset! play/stepper-state            {})
-  (reset! frames/stub-call-log          {})
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.config/set-global-args! {})
+  (reset! rf.story.play/stepper-state            {})
+  (reset! rf.story.frames/stub-call-log          {})
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (test-fn))
 
 (use-fixtures :each reset-all)
@@ -54,10 +54,10 @@
 
 (deftest force-fx-stub-registered-at-boot
   (testing ":rf.story/force-fx-stub is registered as a decorator after install"
-    (is (story/registered? :decorator :rf.story/force-fx-stub))
+    (is (rf.story/registered? :decorator :rf.story/force-fx-stub))
     (is (= :fx-override
-           (:kind (story/handler-meta :decorator :rf.story/force-fx-stub))))
-    (is (= story/force-fx-stub-id :rf.story/force-fx-stub))))
+           (:kind (rf.story/handler-meta :decorator :rf.story/force-fx-stub))))
+    (is (= rf.story/force-fx-stub-id :rf.story/force-fx-stub))))
 
 ;; ===========================================================================
 ;; Ref-args expansion
@@ -65,10 +65,10 @@
 
 (deftest force-fx-stub-ref-args-expansion
   (testing "ref-args expand into a per-reference body with fx-id + response"
-    (story/reg-variant :story.fxstub/v
+    (rf.story/reg-variant :story.fxstub/v
       {:decorators [[:rf.story/force-fx-stub :http {:status :pending}]]
        :setup     []})
-    (let [r (story/resolve-decorators :story.fxstub/v)]
+    (let [r (rf.story/resolve-decorators :story.fxstub/v)]
       (is (= 1 (count (:fx-override r))))
       (let [body (-> r :fx-override first :body)]
         (is (= :http              (:fx-id body)))
@@ -77,12 +77,12 @@
 
 (deftest force-fx-stub-multiple-refs-distinct-fx-ids
   (testing "multiple force-fx-stub references with distinct fx-ids get distinct stub-event-ids"
-    (story/reg-variant :story.fxstub-multi/v
+    (rf.story/reg-variant :story.fxstub-multi/v
       {:decorators [[:rf.story/force-fx-stub :http      {:status :a}]
                     [:rf.story/force-fx-stub :websocket {:status :b}]]
        :setup     []})
-    (let [r       (story/resolve-decorators :story.fxstub-multi/v)
-          stack   (decorators/fx-overrides-map (:fx-override r))]
+    (let [r       (rf.story/resolve-decorators :story.fxstub-multi/v)
+          stack   (rf.story.decorators/fx-overrides-map (:fx-override r))]
       (is (= 2 (count (:overrides stack))))
       (is (contains? (:overrides stack) :http))
       (is (contains? (:overrides stack) :websocket))
@@ -98,11 +98,11 @@
 (deftest expand-ref-args-helper
   (testing "expand-ref-args returns a body map for force-fx-stub refs"
     (is (= {:kind :fx-override :fx-id :http :response {:n 1}}
-           (fx-stubs/expand-ref-args
+           (rf.story.fx-stubs/expand-ref-args
              [:rf.story/force-fx-stub :http {:n 1}])))
-    (is (nil? (fx-stubs/expand-ref-args [:some-other-decorator :http])))
-    (is (nil? (fx-stubs/expand-ref-args nil)))
-    (is (nil? (fx-stubs/expand-ref-args [])))))
+    (is (nil? (rf.story.fx-stubs/expand-ref-args [:some-other-decorator :http])))
+    (is (nil? (rf.story.fx-stubs/expand-ref-args nil)))
+    (is (nil? (rf.story.fx-stubs/expand-ref-args [])))))
 
 ;; ===========================================================================
 ;; The fx-overrides config threads onto the variant frame
@@ -110,16 +110,16 @@
 
 (deftest force-fx-stub-installs-on-frame
   (testing "running a variant with force-fx-stub stamps :fx-overrides on the frame config"
-    (story/reg-variant :story.fxstub-frame/v
+    (rf.story/reg-variant :story.fxstub-frame/v
       {:decorators [[:rf.story/force-fx-stub :http {:status :pending}]]
        :setup     []})
-    (let [r (async/deref-blocking (story/run-variant :story.fxstub-frame/v) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.fxstub-frame/v) 5000)]
       (is (= :ready (:lifecycle r)))
       (let [overrides (:fx-overrides (rf/frame-meta :story.fxstub-frame/v))]
         (is (map? overrides))
         (is (contains? overrides :http)
             "the :http fx is redirected to the stub event")))
-    (story/destroy-variant! :story.fxstub-frame/v)))
+    (rf.story/destroy-variant! :story.fxstub-frame/v)))
 
 ;; ===========================================================================
 ;; :rf.assert/effect-emitted with force-fx-stub
@@ -130,16 +130,16 @@
     (rf/reg-event :do/http-call
       (fn [_ _]
         {:fx [[:http {:url "/test" :method :get}]]}))
-    (story/reg-variant :story.fxemit/v
+    (rf.story/reg-variant :story.fxemit/v
       {:decorators [[:rf.story/force-fx-stub :http {:status :ok :body {:n 1}}]]
        :setup     []
        :script [[:dispatch-sync [:do/http-call]]
                     [:dispatch-sync [:rf.assert/effect-emitted :http]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.fxemit/v) 5000)
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.fxemit/v) 5000)
           last-a (last (:assertions r))]
       (is (true? (:passed? last-a))
           "force-fx-stub's stub event taps emitted-fx accumulator so :rf.assert/effect-emitted sees the call"))
-    (story/destroy-variant! :story.fxemit/v)))
+    (rf.story/destroy-variant! :story.fxemit/v)))
 
 ;; ===========================================================================
 ;; Stub event log inspection
@@ -150,11 +150,11 @@
     (rf/reg-event :do/http-call2
       (fn [_ _]
         {:fx [[:http {:url "/api" :method :post}]]}))
-    (story/reg-variant :story.fxlog/v
+    (rf.story/reg-variant :story.fxlog/v
       {:decorators [[:rf.story/force-fx-stub :http {:status :ok :body {}}]]
        :setup     []
        :script [[:dispatch-sync [:do/http-call2]]]})
-    (async/deref-blocking (story/run-variant :story.fxlog/v) 5000)
+    (rf.story.async/deref-blocking (rf.story/run-variant :story.fxlog/v) 5000)
     (let [log (re-frame.story.frames/stub-call-log-for :story.fxlog/v)]
       (is (= 1 (count log)))
       (is (= :http (:fx-id (first log)))
@@ -162,9 +162,9 @@
       (is (= {:url "/api" :method :post} (:payload (first log)))
           "the stub log entry carries the original fx payload"))
     ;; observed-fx-ids should also see the stub.
-    (is (contains? (fx-stubs/observed-fx-ids :story.fxlog/v) :http)
+    (is (contains? (rf.story.fx-stubs/observed-fx-ids :story.fxlog/v) :http)
         "observed-fx-ids surfaces the stubbed fx after the run")
-    (story/destroy-variant! :story.fxlog/v)))
+    (rf.story/destroy-variant! :story.fxlog/v)))
 
 (deftest force-fx-stub-log-is-per-frame
   (testing "two variants emitting the same fx id keep stub logs and effect assertions isolated by frame"
@@ -174,25 +174,25 @@
     (rf/reg-event :do/http-b
       (fn [_ _]
         {:fx [[:http {:url "/b"}]]}))
-    (story/reg-variant :story.fxisolation/a
+    (rf.story/reg-variant :story.fxisolation/a
       {:decorators [[:rf.story/force-fx-stub :http {:status :ok}]]
        :setup     []
        :script [[:dispatch-sync [:do/http-a]]
                     [:dispatch-sync [:rf.assert/effect-emitted :http]]]})
-    (story/reg-variant :story.fxisolation/b
+    (rf.story/reg-variant :story.fxisolation/b
       {:decorators [[:rf.story/force-fx-stub :http {:status :ok}]]
        :setup     []
        :script [[:dispatch-sync [:do/http-b]]
                     [:dispatch-sync [:rf.assert/effect-emitted :http]]]})
-    (let [ra (async/deref-blocking (story/run-variant :story.fxisolation/a) 5000)
-          rb (async/deref-blocking (story/run-variant :story.fxisolation/b) 5000)
-          log-a (frames/stub-call-log-for :story.fxisolation/a)
-          log-b (frames/stub-call-log-for :story.fxisolation/b)]
+    (let [ra (rf.story.async/deref-blocking (rf.story/run-variant :story.fxisolation/a) 5000)
+          rb (rf.story.async/deref-blocking (rf.story/run-variant :story.fxisolation/b) 5000)
+          log-a (rf.story.frames/stub-call-log-for :story.fxisolation/a)
+          log-b (rf.story.frames/stub-call-log-for :story.fxisolation/b)]
       (is (every? :passed? (:assertions ra)))
       (is (every? :passed? (:assertions rb)))
       (is (= [{:url "/a"}] (mapv :payload log-a)))
       (is (= [{:url "/b"}] (mapv :payload log-b)))
-      (is (= #{:http} (fx-stubs/observed-fx-ids :story.fxisolation/a)))
-      (is (= #{:http} (fx-stubs/observed-fx-ids :story.fxisolation/b))))
-    (story/destroy-variant! :story.fxisolation/a)
-    (story/destroy-variant! :story.fxisolation/b)))
+      (is (= #{:http} (rf.story.fx-stubs/observed-fx-ids :story.fxisolation/a)))
+      (is (= #{:http} (rf.story.fx-stubs/observed-fx-ids :story.fxisolation/b))))
+    (rf.story/destroy-variant! :story.fxisolation/a)
+    (rf.story/destroy-variant! :story.fxisolation/b)))

--- a/tools/story/test/re_frame/story_help_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_help_cljs_test.cljs
@@ -11,7 +11,7 @@
   The localStorage round-trip is browser-only — on node-test there's no
   `js/window`, so we guard those assertions on the runtime detection."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.story.ui.help :as help]))
+            [re-frame.story.ui.help :as rf.story.ui.help]))
 
 ;; ---- runtime detection ---------------------------------------------------
 
@@ -21,8 +21,8 @@
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn clear-flag! []
-  (help/reset-seen!)
-  (reset! @#'help/open? false))
+  (rf.story.ui.help/reset-seen!)
+  (reset! @#'rf.story.ui.help/open? false))
 
 (use-fixtures :each {:before clear-flag! :after clear-flag!})
 
@@ -30,21 +30,21 @@
 
 (deftest seen-defaults-to-false
   (testing "seen? is false when localStorage has never been touched"
-    (is (false? (help/seen?)))))
+    (is (false? (rf.story.ui.help/seen?)))))
 
 (deftest mark-seen-persists
   (testing "mark-seen! flips seen? to true (browser only)"
     (when (browser?)
-      (help/mark-seen!)
-      (is (true? (help/seen?)))
-      (help/reset-seen!)
-      (is (false? (help/seen?))))))
+      (rf.story.ui.help/mark-seen!)
+      (is (true? (rf.story.ui.help/seen?)))
+      (rf.story.ui.help/reset-seen!)
+      (is (false? (rf.story.ui.help/seen?))))))
 
 ;; ---- hiccup shape --------------------------------------------------------
 
 (deftest help-content-is-hiccup
   (testing "help-content returns a hiccup vector rooted at :div"
-    (let [out (help/help-content)]
+    (let [out (rf.story.ui.help/help-content)]
       (is (vector? out))
       (is (= :div (first out))))))
 
@@ -52,9 +52,9 @@
 
 (deftest open-then-close-toggles-atom
   (testing "open! flips the atom to true; close! flips it back"
-    (help/open!)
-    (is (true? @@#'help/open?))
-    (help/close!)
-    (is (false? @@#'help/open?))
+    (rf.story.ui.help/open!)
+    (is (true? @@#'rf.story.ui.help/open?))
+    (rf.story.ui.help/close!)
+    (is (false? @@#'rf.story.ui.help/open?))
     (when (browser?)
-      (is (true? (help/seen?))))))
+      (is (true? (rf.story.ui.help/seen?))))))

--- a/tools/story/test/re_frame/story_layout_debug_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_layout_debug_cljs_test.cljs
@@ -3,24 +3,24 @@
   trio. JVM coverage in `re-frame.story-layout-debug-test`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story :as story]
-            [re-frame.story.decorators :as decorators]
-            [re-frame.story.layout-debug :as layout-debug]
-            [re-frame.story.ui.panels :as panels]
-            [re-frame.test-helpers :as th]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.decorators :as rf.story.decorators]
+            [re-frame.story.layout-debug :as rf.story.layout-debug]
+            [re-frame.story.ui.panels :as rf.story.ui.panels]
+            [re-frame.test-helpers :as rf.test-helpers]))
 
 (defn reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
-  (layout-debug/reset-wrap-counter!)
-  (reset! panels/layout-debug-toggles {})
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
+  (rf.story.layout-debug/reset-wrap-counter!)
+  (reset! rf.story.ui.panels/layout-debug-toggles {})
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -28,24 +28,24 @@
 
 (deftest three-decorators-register
   (testing "the three layout-debug decorators register at boot"
-    (let [decs (story/registrations :decorator)]
+    (let [decs (rf.story/registrations :decorator)]
       (is (contains? decs :rf.story/layout-debug.measure))
       (is (contains? decs :rf.story/layout-debug.outline))
       (is (contains? decs :rf.story/layout-debug.pseudo)))))
 
 (deftest public-ids-exposed
   (testing "the three public id Vars match the canonical ids"
-    (is (= :rf.story/layout-debug.measure story/layout-debug-measure-id))
-    (is (= :rf.story/layout-debug.outline story/layout-debug-outline-id))
-    (is (= :rf.story/layout-debug.pseudo  story/layout-debug-pseudo-id))))
+    (is (= :rf.story/layout-debug.measure rf.story/layout-debug-measure-id))
+    (is (= :rf.story/layout-debug.outline rf.story/layout-debug-outline-id))
+    (is (= :rf.story/layout-debug.pseudo  rf.story/layout-debug-pseudo-id))))
 
 ;; ---- decorator resolution -----------------------------------------------
 
 (deftest decorator-resolves-as-hiccup
   (testing "a variant referencing layout-debug.outline resolves to :hiccup"
-    (story/reg-variant* :story.x/outlined
+    (rf.story/reg-variant* :story.x/outlined
                         {:decorators [[:rf.story/layout-debug.outline]]})
-    (let [pack (decorators/resolve-decorators :story.x/outlined)]
+    (let [pack (rf.story.decorators/resolve-decorators :story.x/outlined)]
       (is (= 1 (count (:hiccup pack))))
       (is (empty? (:errors pack))))))
 
@@ -53,7 +53,7 @@
 
 (deftest measure-wrap-returns-style-block
   (testing "the measure wrap fn produces [:div {:class \"…\"} [:style ...] body]"
-    (let [wrap (-> (story/handler-meta :decorator :rf.story/layout-debug.measure)
+    (let [wrap (-> (rf.story/handler-meta :decorator :rf.story/layout-debug.measure)
                     :wrap)
           out  (wrap [:span "x"] {})]
       (is (vector? out))
@@ -64,7 +64,7 @@
 
 (deftest pseudo-wrap-ref-args
   (testing "pseudo wrap reads ref-args via :decorator/args"
-    (let [wrap (-> (story/handler-meta :decorator :rf.story/layout-debug.pseudo)
+    (let [wrap (-> (rf.story/handler-meta :decorator :rf.story/layout-debug.pseudo)
                     :wrap)
           out  (wrap [:span "x"] {:decorator/args [#{:hover :focus}]})
           attrs (second out)]
@@ -75,9 +75,9 @@
 ;;
 ;; 015-Test-Coverage.md:120 (Layout-debug overlays) owes: assert each
 ;; overlay toggles its DOM/aria state AND that the variant's own state stays
-;; unchanged across toggles. The layout-debug panel (`panels/layout-debug-
+;; unchanged across toggles. The layout-debug panel (`rf.story.ui.panels/layout-debug-
 ;; view`) is the toggle surface — a checkbox per decorator id. The active
-;; set lives in `panels/layout-debug-toggles`, a per-process ratom keyed by
+;; set lives in `rf.story.ui.panels/layout-debug-toggles`, a per-process ratom keyed by
 ;; variant-id and wholly independent of any variant's frame/app-db, so
 ;; toggling an overlay provably CANNOT mutate variant state. Per the locked
 ;; Story testing posture these are CLJS unit tests over the pure toggle
@@ -87,13 +87,13 @@
 (defn- render-layout-debug-panel
   "Render the form-2 layout-debug panel for `variant-id` to hiccup."
   [variant-id]
-  (th/expand-tree [panels/layout-debug-view variant-id]))
+  (rf.test-helpers/expand-tree [rf.story.ui.panels/layout-debug-view variant-id]))
 
 (defn- overlay-checkboxes
   "The three overlay checkbox nodes in render order (measure / outline /
   pseudo)."
   [tree]
-  (th/find-all-by-attr tree :type "checkbox"))
+  (rf.test-helpers/find-all-by-attr tree :type "checkbox"))
 
 ;; ---- pure per-overlay toggle state --------------------------------------
 
@@ -101,27 +101,27 @@
   (testing "toggling one overlay id flips only that id in the active set;
             a second overlay toggles independently; re-toggling clears it"
     (let [vid :story.x/probe]
-      (is (= #{} (panels/active-layout-debug-decorators vid))
+      (is (= #{} (rf.story.ui.panels/active-layout-debug-decorators vid))
           "fresh variant has no overlays active")
       ;; Toggle outline on.
-      (panels/toggle-layout-debug! vid layout-debug/id-outline)
-      (is (= #{layout-debug/id-outline}
-             (panels/active-layout-debug-decorators vid)))
+      (rf.story.ui.panels/toggle-layout-debug! vid rf.story.layout-debug/id-outline)
+      (is (= #{rf.story.layout-debug/id-outline}
+             (rf.story.ui.panels/active-layout-debug-decorators vid)))
       ;; Toggle measure on — outline stays on (independent).
-      (panels/toggle-layout-debug! vid layout-debug/id-measure)
-      (is (= #{layout-debug/id-outline layout-debug/id-measure}
-             (panels/active-layout-debug-decorators vid)))
+      (rf.story.ui.panels/toggle-layout-debug! vid rf.story.layout-debug/id-measure)
+      (is (= #{rf.story.layout-debug/id-outline rf.story.layout-debug/id-measure}
+             (rf.story.ui.panels/active-layout-debug-decorators vid)))
       ;; Re-toggle outline off — measure survives.
-      (panels/toggle-layout-debug! vid layout-debug/id-outline)
-      (is (= #{layout-debug/id-measure}
-             (panels/active-layout-debug-decorators vid))))))
+      (rf.story.ui.panels/toggle-layout-debug! vid rf.story.layout-debug/id-outline)
+      (is (= #{rf.story.layout-debug/id-measure}
+             (rf.story.ui.panels/active-layout-debug-decorators vid))))))
 
 (deftest overlay-toggles-are-per-variant-isolated
   (testing "toggling variant A's overlay does not leak into variant B's set"
-    (panels/toggle-layout-debug! :story.x/a layout-debug/id-outline)
-    (is (= #{layout-debug/id-outline}
-           (panels/active-layout-debug-decorators :story.x/a)))
-    (is (= #{} (panels/active-layout-debug-decorators :story.x/b))
+    (rf.story.ui.panels/toggle-layout-debug! :story.x/a rf.story.layout-debug/id-outline)
+    (is (= #{rf.story.layout-debug/id-outline}
+           (rf.story.ui.panels/active-layout-debug-decorators :story.x/a)))
+    (is (= #{} (rf.story.ui.panels/active-layout-debug-decorators :story.x/b))
         "sibling variant's overlay set is untouched")))
 
 ;; ---- DOM: the checkbox reflects the active-overlay state ----------------
@@ -137,7 +137,7 @@
                (mapv #(boolean (get (second %) :checked)) boxes))
             "all overlays render unchecked before any toggle"))
       ;; Toggle the OUTLINE overlay (render order: measure, outline, pseudo).
-      (panels/toggle-layout-debug! vid layout-debug/id-outline)
+      (rf.story.ui.panels/toggle-layout-debug! vid rf.story.layout-debug/id-outline)
       (let [boxes (overlay-checkboxes (render-layout-debug-panel vid))]
         (is (= [false true false]
                (mapv #(boolean (get (second %) :checked)) boxes))
@@ -150,20 +150,20 @@
             toggle set lives in a separate per-process ratom, not the
             variant's frame/app-db (rf2-yv8tsd — 'variant state unchanged')"
     (let [vid :story.x/counted]
-      (story/reg-variant* vid {:args {:n 7}
+      (rf.story/reg-variant* vid {:args {:n 7}
                                :setup [[:set-thing 1]]})
-      (let [body-before (story/handler-meta :variant vid)]
+      (let [body-before (rf.story/handler-meta :variant vid)]
         ;; Toggle every overlay on, then off again.
-        (doseq [id [layout-debug/id-measure
-                    layout-debug/id-outline
-                    layout-debug/id-pseudo]]
-          (panels/toggle-layout-debug! vid id))
-        (doseq [id [layout-debug/id-measure
-                    layout-debug/id-outline
-                    layout-debug/id-pseudo]]
-          (panels/toggle-layout-debug! vid id))
-        (is (= #{} (panels/active-layout-debug-decorators vid))
+        (doseq [id [rf.story.layout-debug/id-measure
+                    rf.story.layout-debug/id-outline
+                    rf.story.layout-debug/id-pseudo]]
+          (rf.story.ui.panels/toggle-layout-debug! vid id))
+        (doseq [id [rf.story.layout-debug/id-measure
+                    rf.story.layout-debug/id-outline
+                    rf.story.layout-debug/id-pseudo]]
+          (rf.story.ui.panels/toggle-layout-debug! vid id))
+        (is (= #{} (rf.story.ui.panels/active-layout-debug-decorators vid))
             "overlays round-tripped back to empty")
-        (is (= body-before (story/handler-meta :variant vid))
+        (is (= body-before (rf.story/handler-meta :variant vid))
             "the registered variant body is byte-identical after the toggles —
              overlay state never touches the variant's own registration")))))

--- a/tools/story/test/re_frame/story_layout_debug_test.clj
+++ b/tools/story/test/re_frame/story_layout_debug_test.clj
@@ -15,31 +15,31 @@
   JVM-testable."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core            :as rf]
-            [re-frame.frame           :as frame]
-            [re-frame.machines        :as machines]
-            [re-frame.registrar       :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story           :as story]
-            [re-frame.story.config    :as config]
-            [re-frame.story.decorators :as decorators]
-            [re-frame.story.layout-debug :as layout-debug]
-            [re-frame.story.loaders   :as loaders]))
+            [re-frame.frame           :as rf.frame]
+            [re-frame.machines        :as rf.machines]
+            [re-frame.registrar       :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story           :as rf.story]
+            [re-frame.story.config    :as rf.story.config]
+            [re-frame.story.decorators :as rf.story.decorators]
+            [re-frame.story.layout-debug :as rf.story.layout-debug]
+            [re-frame.story.loaders   :as rf.story.loaders]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-fixture [test-fn]
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
   (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (config/set-global-args! {})
-  (layout-debug/reset-wrap-counter!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.config/set-global-args! {})
+  (rf.story.layout-debug/reset-wrap-counter!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (test-fn))
 
 (use-fixtures :each reset-fixture)
@@ -48,15 +48,15 @@
 
 (deftest three-decorators-register
   (testing "the three layout-debug decorators register under canonical ids"
-    (let [decs (story/registrations :decorator)]
-      (is (contains? decs layout-debug/id-measure))
-      (is (contains? decs layout-debug/id-outline))
-      (is (contains? decs layout-debug/id-pseudo)))))
+    (let [decs (rf.story/registrations :decorator)]
+      (is (contains? decs rf.story.layout-debug/id-measure))
+      (is (contains? decs rf.story.layout-debug/id-outline))
+      (is (contains? decs rf.story.layout-debug/id-pseudo)))))
 
 (deftest decorator-bodies-are-hiccup-kind
   (testing "each layout-debug decorator declares :kind :hiccup"
-    (doseq [id layout-debug/canonical-decorator-ids]
-      (let [body (story/handler-meta :decorator id)]
+    (doseq [id rf.story.layout-debug/canonical-decorator-ids]
+      (let [body (rf.story/handler-meta :decorator id)]
         (is (= :hiccup (:kind body)))
         (is (fn? (:wrap body)))))))
 
@@ -65,13 +65,13 @@
     (is (= #{:rf.story/layout-debug.measure
              :rf.story/layout-debug.outline
              :rf.story/layout-debug.pseudo}
-           layout-debug/canonical-decorator-ids))))
+           rf.story.layout-debug/canonical-decorator-ids))))
 
 ;; ---- pure stylesheet builders -------------------------------------------
 
 (deftest outline-stylesheet-scoped
   (testing "outline-stylesheet scopes every selector to the wrap class"
-    (let [css (layout-debug/build-outline-stylesheet "rf-test-1")]
+    (let [css (rf.story.layout-debug/build-outline-stylesheet "rf-test-1")]
       (is (string? css))
       (is (re-find #"\.rf-test-1 \*" css))
       (is (re-find #"\.rf-test-1 div" css))
@@ -79,15 +79,15 @@
 
 (deftest measure-stylesheet-scoped
   (testing "measure-stylesheet targets :hover under the wrap class"
-    (let [css (layout-debug/build-measure-stylesheet "rf-test-2")]
+    (let [css (rf.story.layout-debug/build-measure-stylesheet "rf-test-2")]
       (is (re-find #"\.rf-test-2 \*:hover" css))
       (is (re-find #"::before" css)))))
 
 (deftest pseudo-stylesheet-includes-states
   (testing "pseudo-stylesheet has a rule per requested state"
-    (let [css-h (layout-debug/build-pseudo-stylesheet "rf-test-3" #{:hover})
-          css-hf (layout-debug/build-pseudo-stylesheet "rf-test-3" #{:hover :focus})
-          css-all (layout-debug/build-pseudo-stylesheet "rf-test-3"
+    (let [css-h (rf.story.layout-debug/build-pseudo-stylesheet "rf-test-3" #{:hover})
+          css-hf (rf.story.layout-debug/build-pseudo-stylesheet "rf-test-3" #{:hover :focus})
+          css-all (rf.story.layout-debug/build-pseudo-stylesheet "rf-test-3"
                                                        #{:hover :focus :active :visited})]
       (is (re-find #"force-hover" css-h))
       (is (not (re-find #"force-focus" css-h)))
@@ -99,15 +99,15 @@
 (deftest forced-state-classes-stable
   (testing "forced-state-classes produces deterministic ordering"
     (is (= "force-focus force-hover"
-           (layout-debug/forced-state-classes #{:hover :focus})))
+           (rf.story.layout-debug/forced-state-classes #{:hover :focus})))
     (is (= "force-active force-focus force-hover"
-           (layout-debug/forced-state-classes #{:hover :focus :active})))))
+           (rf.story.layout-debug/forced-state-classes #{:hover :focus :active})))))
 
 ;; ---- wrap fn shape ------------------------------------------------------
 
 (deftest measure-wrap-shape
   (testing "the measure decorator's wrap fn returns [:div [:style ...] body]"
-    (let [body  {:wrap (-> (story/handler-meta :decorator layout-debug/id-measure)
+    (let [body  {:wrap (-> (rf.story/handler-meta :decorator rf.story.layout-debug/id-measure)
                             :wrap)}
           wrap  (:wrap body)
           out   (wrap [:span "x"] {})]
@@ -123,7 +123,7 @@
 
 (deftest pseudo-wrap-with-ref-args
   (testing "pseudo wrap reads ref-args via :decorator/args"
-    (let [body (story/handler-meta :decorator layout-debug/id-pseudo)
+    (let [body (rf.story/handler-meta :decorator rf.story.layout-debug/id-pseudo)
           wrap (:wrap body)
           out  (wrap [:span "x"] {:decorator/args [#{:hover :focus}]})
           attrs (second out)]
@@ -132,7 +132,7 @@
 
 (deftest pseudo-wrap-default-state
   (testing "pseudo wrap defaults to #{:hover} when no ref-args"
-    (let [body (story/handler-meta :decorator layout-debug/id-pseudo)
+    (let [body (rf.story/handler-meta :decorator rf.story.layout-debug/id-pseudo)
           wrap (:wrap body)
           out  (wrap [:span "x"] {})
           attrs (second out)]
@@ -143,31 +143,31 @@
 
 (deftest layout-debug-resolves-as-hiccup
   (testing "a variant declaring a layout-debug decorator resolves into :hiccup"
-    (story/reg-variant* :story.x/y
-                        {:decorators [[layout-debug/id-outline]]})
-    (let [pack (decorators/resolve-decorators :story.x/y)]
+    (rf.story/reg-variant* :story.x/y
+                        {:decorators [[rf.story.layout-debug/id-outline]]})
+    (let [pack (rf.story.decorators/resolve-decorators :story.x/y)]
       (is (= 1 (count (:hiccup pack))))
-      (is (= layout-debug/id-outline (-> pack :hiccup first :id)))
+      (is (= rf.story.layout-debug/id-outline (-> pack :hiccup first :id)))
       (is (empty? (:errors pack))))))
 
 (deftest multiple-layout-debug-decorators-compose
   (testing "two layout-debug decorators on a variant compose in order"
-    (story/reg-variant* :story.x/multi
-                        {:decorators [[layout-debug/id-outline]
-                                      [layout-debug/id-pseudo #{:focus}]]})
-    (let [pack (decorators/resolve-decorators :story.x/multi)]
+    (rf.story/reg-variant* :story.x/multi
+                        {:decorators [[rf.story.layout-debug/id-outline]
+                                      [rf.story.layout-debug/id-pseudo #{:focus}]]})
+    (let [pack (rf.story.decorators/resolve-decorators :story.x/multi)]
       (is (= 2 (count (:hiccup pack))))
-      (is (= [layout-debug/id-outline layout-debug/id-pseudo]
+      (is (= [rf.story.layout-debug/id-outline rf.story.layout-debug/id-pseudo]
              (mapv :id (:hiccup pack)))))))
 
 ;; ---- wrap-id counter ----------------------------------------------------
 
 (deftest wrap-counter-monotonic
   (testing "next-wrap-id returns monotonic distinct ids"
-    (layout-debug/reset-wrap-counter!)
-    (let [a (layout-debug/next-wrap-id)
-          b (layout-debug/next-wrap-id)
-          c (layout-debug/next-wrap-id)]
+    (rf.story.layout-debug/reset-wrap-counter!)
+    (let [a (rf.story.layout-debug/next-wrap-id)
+          b (rf.story.layout-debug/next-wrap-id)
+          c (rf.story.layout-debug/next-wrap-id)]
       (is (= "rf-story-debug-1" a))
       (is (= "rf-story-debug-2" b))
       (is (= "rf-story-debug-3" c)))))
@@ -176,6 +176,6 @@
 
 (deftest public-decorator-ids-exposed
   (testing "the three decorator ids are re-exported on re-frame.story"
-    (is (= layout-debug/id-measure  story/layout-debug-measure-id))
-    (is (= layout-debug/id-outline  story/layout-debug-outline-id))
-    (is (= layout-debug/id-pseudo   story/layout-debug-pseudo-id))))
+    (is (= rf.story.layout-debug/id-measure  rf.story/layout-debug-measure-id))
+    (is (= rf.story.layout-debug/id-outline  rf.story/layout-debug-outline-id))
+    (is (= rf.story.layout-debug/id-pseudo   rf.story/layout-debug-pseudo-id))))

--- a/tools/story/test/re_frame/story_loaders_teardown_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_loaders_teardown_cljs_test.cljs
@@ -26,37 +26,37 @@
     frame's `[:rf.story/assertions]`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.machines         :as machines]
-            [re-frame.registrar        :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story            :as story]
-            [re-frame.story.async      :as async-lib]
-            [re-frame.story.frames     :as frames]
-            [re-frame.story.loaders    :as loaders]
-            [re-frame.story.schemas    :as schemas]
-            [re-frame.subs             :as subs]
+            [re-frame.frame            :as rf.frame]
+            [re-frame.machines         :as rf.machines]
+            [re-frame.registrar        :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story            :as rf.story]
+            [re-frame.story.async      :as rf.story.async]
+            [re-frame.story.frames     :as rf.story.frames]
+            [re-frame.story.loaders    :as rf.story.loaders]
+            [re-frame.story.schemas    :as rf.story.schemas]
+            [re-frame.subs             :as rf.subs]
             [malli.core                :as m]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
 (defn reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
   ;; Re-register the framework `:rf/machine` sub after the registrar clear.
   ;; EP-0001 (rf2-vzld77 / rf2-ixb0bq): a runtime-db sub reading
   ;; [:rf.runtime/machines :snapshots <id>], NOT the retired app-db
   ;; `:rf/runtime` path — mirror `re-frame.machines`.
-  (subs/reg-runtime-sub :rf/machine
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [runtime-db [_ machine-id]]
       (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (reset! frames/stub-call-log {})
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (reset! rf.story.frames/stub-call-log {})
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -67,16 +67,16 @@
 (deftest schema-accepts-loaders-teardown
   (testing ":loaders-teardown is an optional vector of event vectors on
             the Variant schema"
-    (is (m/validate schemas/Variant
+    (is (m/validate rf.story.schemas/Variant
                     {:loaders          [[:ws/open]]
                      :loaders-teardown [[:ws/close]]
                      :setup           []}))
-    (is (m/validate schemas/Variant
+    (is (m/validate rf.story.schemas/Variant
                     {:loaders-teardown [[:cleanup]]
                      :setup           []}))
-    (is (m/validate schemas/Variant
+    (is (m/validate rf.story.schemas/Variant
                     {:setup []}))
-    (is (m/validate schemas/Variant
+    (is (m/validate rf.story.schemas/Variant
                     {:loaders-teardown []
                      :setup           []})
         "an empty vector is structurally valid (no-op teardown)")))
@@ -84,10 +84,10 @@
 (deftest schema-rejects-non-vector-loaders-teardown
   (testing ":loaders-teardown must be a vector of event vectors —
             anything else fails the schema"
-    (is (not (m/validate schemas/Variant
+    (is (not (m/validate rf.story.schemas/Variant
                          {:loaders-teardown :not-a-vector
                           :setup           []})))
-    (is (not (m/validate schemas/Variant
+    (is (not (m/validate rf.story.schemas/Variant
                          {:loaders-teardown [:not-a-vector-of-vectors]
                           :setup           []})))))
 
@@ -100,18 +100,18 @@
     (let [fired (atom [])]
       (rf/reg-event :ws/open  (fn [{:keys [db]} _] {:db (assoc db :ws? :open)}))
       (rf/reg-event :ws/close (fn [{:keys [db]} _] (swap! fired conj :ws/close) {:db db}))
-      (story/reg-variant :story.lt.fires/v
+      (rf.story/reg-variant :story.lt.fires/v
         {:loaders          [[:ws/open]]
          :loaders-teardown [[:ws/close]]
          :setup           []})
-      (let [p (story/run-variant :story.lt.fires/v)]
+      (let [p (rf.story/run-variant :story.lt.fires/v)]
         (async done
           (-> p
-              (async-lib/then
+              (rf.story.async/then
                 (fn [_]
                   (is (= [] @fired)
                       "teardown has NOT fired yet — variant is still live")
-                  (story/destroy-variant! :story.lt.fires/v)
+                  (rf.story/destroy-variant! :story.lt.fires/v)
                   (is (= [:ws/close] @fired)
                       "teardown fired exactly once on destroy")
                   (done)))))))))
@@ -123,15 +123,15 @@
       (rf/reg-event :step/one   (fn [{:keys [db]} _] (swap! fired conj :one) {:db db}))
       (rf/reg-event :step/two   (fn [{:keys [db]} _] (swap! fired conj :two) {:db db}))
       (rf/reg-event :step/three (fn [{:keys [db]} _] (swap! fired conj :three) {:db db}))
-      (story/reg-variant :story.lt.order/v
+      (rf.story/reg-variant :story.lt.order/v
         {:loaders-teardown [[:step/one] [:step/two] [:step/three]]
          :setup           []})
-      (let [p (story/run-variant :story.lt.order/v)]
+      (let [p (rf.story/run-variant :story.lt.order/v)]
         (async done
           (-> p
-              (async-lib/then
+              (rf.story.async/then
                 (fn [_]
-                  (story/destroy-variant! :story.lt.order/v)
+                  (rf.story/destroy-variant! :story.lt.order/v)
                   (is (= [:one :two :three] @fired)
                       "declared order — symmetric with :loaders")
                   (done)))))))))
@@ -153,20 +153,20 @@
       (rf/reg-event :dec/init    (fn [{:keys [db]} _] {:db db}))
       (rf/reg-event :lt/cleanup
         (fn [{:keys [db]} _] (swap! fired conj :loaders-teardown) {:db db}))
-      (story/reg-decorator :outer-dec
+      (rf.story/reg-decorator :outer-dec
         {:kind     :frame-setup
          :init     [[:dec/init]]
          :teardown [[:dec/teardown]]})
-      (story/reg-variant :story.lt.order2/v
+      (rf.story/reg-variant :story.lt.order2/v
         {:decorators       [[:outer-dec]]
          :loaders-teardown [[:lt/cleanup]]
          :setup           []})
-      (let [p (story/run-variant :story.lt.order2/v)]
+      (let [p (rf.story/run-variant :story.lt.order2/v)]
         (async done
           (-> p
-              (async-lib/then
+              (rf.story.async/then
                 (fn [_]
-                  (story/destroy-variant! :story.lt.order2/v)
+                  (rf.story/destroy-variant! :story.lt.order2/v)
                   (is (= [:loaders-teardown :decorator] @fired)
                       "loaders-teardown runs first; decorator :teardown runs after")
                   (done)))))))))
@@ -181,17 +181,17 @@
             (002-Runtime.md §Loader teardown contract)."
     (rf/reg-event :boom/cleanup
       (fn [_ _] (throw (ex-info "loader-teardown boom" {:why :test}))))
-    (story/reg-variant :story.lt.boom/v
+    (rf.story/reg-variant :story.lt.boom/v
       {:loaders-teardown [[:boom/cleanup]]
        :setup           []})
-    (let [p (story/run-variant :story.lt.boom/v)]
+    (let [p (rf.story/run-variant :story.lt.boom/v)]
       (async done
         (-> p
-            (async-lib/then
+            (rf.story.async/then
               (fn [_]
-                (is (nil? (story/destroy-variant! :story.lt.boom/v))
+                (is (nil? (rf.story/destroy-variant! :story.lt.boom/v))
                     "destroy-variant! returns nil — exception caught")
-                (is (not (contains? (story/variant-frames)
+                (is (not (contains? (rf.story/variant-frames)
                                     :story.lt.boom/v))
                     "frame is destroyed despite the throw")
                 (done))))))))
@@ -207,15 +207,15 @@
         (fn [_ _] (throw (ex-info "boom" {}))))
       (rf/reg-event :step/after
         (fn [{:keys [db]} _] (swap! fired conj :after) {:db db}))
-      (story/reg-variant :story.lt.continue/v
+      (rf.story/reg-variant :story.lt.continue/v
         {:loaders-teardown [[:step/before] [:step/boom] [:step/after]]
          :setup           []})
-      (let [p (story/run-variant :story.lt.continue/v)]
+      (let [p (rf.story/run-variant :story.lt.continue/v)]
         (async done
           (-> p
-              (async-lib/then
+              (rf.story.async/then
                 (fn [_]
-                  (story/destroy-variant! :story.lt.continue/v)
+                  (rf.story/destroy-variant! :story.lt.continue/v)
                   (is (= [:before :after] @fired)
                       "the walk continues past the throw")
                   (done)))))))))
@@ -239,20 +239,20 @@
         (fn [{:keys [db]} _]
           (reset! captured (:rf.story/assertions db))
           {:db db}))
-      (story/reg-decorator :lt-probe
+      (rf.story/reg-decorator :lt-probe
         {:kind     :frame-setup
          :init     [[::probe-init]]
          :teardown [[::probe-snapshot]]})
-      (story/reg-variant :story.lt.record/v
+      (rf.story/reg-variant :story.lt.record/v
         {:decorators       [[:lt-probe]]
          :loaders-teardown [[:boom/cleanup]]
          :setup           []})
-      (let [p (story/run-variant :story.lt.record/v)]
+      (let [p (rf.story/run-variant :story.lt.record/v)]
         (async done
           (-> p
-              (async-lib/then
+              (rf.story.async/then
                 (fn [_]
-                  (story/destroy-variant! :story.lt.record/v)
+                  (rf.story/destroy-variant! :story.lt.record/v)
                   (let [asserts @captured
                         err     (first (filter
                                          #(= :rf.error/exception (:assertion %))
@@ -280,17 +280,17 @@
             tears down cleanly — destroy! is a no-op for the new step"
     (rf/reg-event :seed/init
       (fn [{:keys [db]} _] {:db (assoc db :seeded? true)}))
-    (story/reg-variant :story.lt.none/v
+    (rf.story/reg-variant :story.lt.none/v
       {:setup [[:seed/init]]})
-    (let [p (story/run-variant :story.lt.none/v)]
+    (let [p (rf.story/run-variant :story.lt.none/v)]
       (async done
         (-> p
-            (async-lib/then
+            (rf.story.async/then
               (fn [_]
-                (is (nil? (story/destroy-variant! :story.lt.none/v))
+                (is (nil? (rf.story/destroy-variant! :story.lt.none/v))
                     "destroy returns nil — no-op for variants without
                      :loaders-teardown")
-                (is (not (contains? (story/variant-frames)
+                (is (not (contains? (rf.story/variant-frames)
                                     :story.lt.none/v))
                     "frame is destroyed")
                 (done))))))))

--- a/tools/story/test/re_frame/story_mcp_boundary_test.clj
+++ b/tools/story/test/re_frame/story_mcp_boundary_test.clj
@@ -49,15 +49,15 @@
   with `install-canonical-vocabulary!` (the canonical seven tags +
   the lifecycle machine)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story            :as story]
-            [re-frame.story.registrar  :as registrar]
-            [re-frame.story.schemas    :as schemas]))
+            [re-frame.story            :as rf.story]
+            [re-frame.story.registrar  :as rf.story.registrar]
+            [re-frame.story.schemas    :as rf.story.schemas]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
 (defn reset-story-registry [t]
-  (story/clear-all!)
-  (story/install-canonical-vocabulary!)
+  (rf.story/clear-all!)
+  (rf.story/install-canonical-vocabulary!)
   (t))
 
 (use-fixtures :each reset-story-registry)
@@ -111,18 +111,18 @@
             tools then call registrations / handler-meta / variants-of /
             variant->edn. All four read surfaces must surface the new
             variant immediately"
-    (story/reg-story :story.mcp.boundary {:doc "boundary fixture"})
-    (story/reg-variant* :story.mcp.boundary/probe
+    (rf.story/reg-story :story.mcp.boundary {:doc "boundary fixture"})
+    (rf.story/reg-variant* :story.mcp.boundary/probe
       {:doc    "probe variant"
        :setup [[:probe/init]]
        :args   {:n 7}
        :tags   #{:dev}})
-    (is (story/registered? :variant :story.mcp.boundary/probe))
+    (is (rf.story/registered? :variant :story.mcp.boundary/probe))
     (is (= "probe variant"
-           (:doc (story/handler-meta :variant :story.mcp.boundary/probe))))
+           (:doc (rf.story/handler-meta :variant :story.mcp.boundary/probe))))
     (is (= #{:story.mcp.boundary/probe}
-           (story/variants-of :story.mcp.boundary)))
-    (let [edn (story/variant->edn :story.mcp.boundary/probe)]
+           (rf.story/variants-of :story.mcp.boundary)))
+    (let [edn (rf.story/variant->edn :story.mcp.boundary/probe)]
       (is (= [[:probe/init]] (:setup edn)))
       (is (= {:n 7} (:args edn))))))
 
@@ -132,23 +132,23 @@
             body when the agent wants source-coords preserved (per
             spec/006 — the MCP write path is programmatic, no &form
             meta is available)"
-    (story/reg-variant* :story.mcp.no-source/probe
+    (rf.story/reg-variant* :story.mcp.no-source/probe
       {:setup []})
-    (let [body (story/handler-meta :variant :story.mcp.no-source/probe)]
+    (let [body (rf.story/handler-meta :variant :story.mcp.no-source/probe)]
       (is (not (contains? body :source))
           "no auto-source-stamp when called programmatically — keeps
            the slot available for MCP-supplied source coords"))))
 
 (deftest reg-variant-star-preserves-mcp-supplied-source
   (testing "an MCP-supplied :source slot survives the registrar's merge.
-            Per registrar/merge-coords the *pending-coords* path is
+            Per rf.story.registrar/merge-coords the *pending-coords* path is
             additive — author-supplied :source wins; the dynamic Var is
             nil under programmatic registration so this case reduces to
             'whatever the caller wrote wins'"
-    (story/reg-variant* :story.mcp.src-bring/probe
+    (rf.story/reg-variant* :story.mcp.src-bring/probe
       {:setup []
        :source {:file "agent-supplied.cljs" :line 42}})
-    (let [body (story/handler-meta :variant :story.mcp.src-bring/probe)]
+    (let [body (rf.story/handler-meta :variant :story.mcp.src-bring/probe)]
       (is (= {:file "agent-supplied.cljs" :line 42}
              (:source body))))))
 
@@ -159,33 +159,33 @@
 (deftest unregister-removes-from-read-surface
   (testing "MCP's unregister-variant tool routes through (unregister!
             :variant id) — after which the read surface no longer surfaces it"
-    (story/reg-variant :story.mcp.unreg/probe {:setup []})
-    (is (story/registered? :variant :story.mcp.unreg/probe))
-    (registrar/unregister! :variant :story.mcp.unreg/probe)
-    (is (not (story/registered? :variant :story.mcp.unreg/probe))
+    (rf.story/reg-variant :story.mcp.unreg/probe {:setup []})
+    (is (rf.story/registered? :variant :story.mcp.unreg/probe))
+    (rf.story.registrar/unregister! :variant :story.mcp.unreg/probe)
+    (is (not (rf.story/registered? :variant :story.mcp.unreg/probe))
         "the variant is gone after unregister!")
-    (is (not (contains? (story/variants-of :story.mcp.unreg) :story.mcp.unreg/probe)))
-    (is (nil? (story/handler-meta :variant :story.mcp.unreg/probe)))))
+    (is (not (contains? (rf.story/variants-of :story.mcp.unreg) :story.mcp.unreg/probe)))
+    (is (nil? (rf.story/handler-meta :variant :story.mcp.unreg/probe)))))
 
 (deftest clear-kind-leaves-siblings-untouched
   (testing "clear-kind! :variant clears all variants but leaves modes,
             workspaces, and tags untouched — the contract MCP needs for
             a 'clear all variants' tool that doesn't nuke the rest of
             the registry"
-    (story/reg-variant :story.kindA/v {:setup []})
-    (story/reg-variant :story.kindB/w {:setup []})
-    (story/reg-mode :Mode.theme/dark {:args {:theme :dark}})
-    (story/reg-workspace :Workspace.kind/grid
+    (rf.story/reg-variant :story.kindA/v {:setup []})
+    (rf.story/reg-variant :story.kindB/w {:setup []})
+    (rf.story/reg-mode :Mode.theme/dark {:args {:theme :dark}})
+    (rf.story/reg-workspace :Workspace.kind/grid
       {:layout :variants-grid})
-    (registrar/clear-kind! :variant)
-    (is (empty? (story/ids :variant))
+    (rf.story.registrar/clear-kind! :variant)
+    (is (empty? (rf.story/ids :variant))
         "all variants cleared")
-    (is (contains? (story/list-modes) :Mode.theme/dark)
+    (is (contains? (rf.story/list-modes) :Mode.theme/dark)
         "modes survive")
-    (is (story/registered? :workspace :Workspace.kind/grid)
+    (is (rf.story/registered? :workspace :Workspace.kind/grid)
         "workspaces survive")
-    (is (= (into schemas/canonical-tags schemas/canonical-state-tags)
-           (story/list-tags))
+    (is (= (into rf.story.schemas/canonical-tags rf.story.schemas/canonical-state-tags)
+           (rf.story/list-tags))
         "canonical inclusion + :state/* magnitude tags survive")))
 
 ;; ===========================================================================
@@ -207,21 +207,21 @@
   (testing "registering a panel under an id, then re-registering under
             the same id, replaces the slot — this is the late-bind
             contract Xray's epoch-view depends on"
-    (story/reg-story-panel :rf.story/xray-epoch
+    (rf.story/reg-story-panel :rf.story/xray-epoch
       {:doc       "Story-shipped stub"
        :title     "Epochs (stub)"
        :placement :bottom
        :render    :rf.story.stubs/xray-epoch-stub})
-    (let [stub-body (story/handler-meta :story-panel :rf.story/xray-epoch)]
+    (let [stub-body (rf.story/handler-meta :story-panel :rf.story/xray-epoch)]
       (is (= "Epochs (stub)" (:title stub-body)))
       (is (= :rf.story.stubs/xray-epoch-stub (:render stub-body))))
     ;; Now Xray ships its real view — register under the same id.
-    (story/reg-story-panel :rf.story/xray-epoch
+    (rf.story/reg-story-panel :rf.story/xray-epoch
       {:doc       "Xray-shipped real view"
        :title     "Epochs (Xray)"
        :placement :bottom
        :render    :day8.re-frame2-xray.panels.time-travel/Panel})
-    (let [real-body (story/handler-meta :story-panel :rf.story/xray-epoch)]
+    (let [real-body (rf.story/handler-meta :story-panel :rf.story/xray-epoch)]
       (is (= "Epochs (Xray)" (:title real-body)))
       (is (= :day8.re-frame2-xray.panels.time-travel/Panel
              (:render real-body))
@@ -234,16 +234,16 @@
             placements fail the malli schema with :rf.error/story-panel-shape"
     (doseq [placement [:right :left :bottom :top :modal]]
       (let [pid (keyword "rf.story.test" (str "panel-" (name placement)))]
-        (story/reg-story-panel pid
+        (rf.story/reg-story-panel pid
           {:title     (str "panel " (name placement))
            :placement placement
            :render    :some/view})
         (is (= placement
-               (:placement (story/handler-meta :story-panel pid))))))
+               (:placement (rf.story/handler-meta :story-panel pid))))))
     (testing "an off-vocab placement is rejected"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #":rf\.error/story-panel-shape"
-                            (story/reg-story-panel :rf.story.test/bad-placement
+                            (rf.story/reg-story-panel :rf.story.test/bad-placement
                               {:title     "bad"
                                :placement :nowhere
                                :render    :x/y}))))))
@@ -258,25 +258,25 @@
             Per spec/006 §Story's public read primitives this mirrors
             spec/001's `re-frame.registrar/registrations` — the shape MCP read
             tools rely on for registry walks"
-    (story/reg-story :story.handlers {:doc "h-fixture"})
-    (story/reg-variant :story.handlers/a {:setup [[:init-a]]})
-    (story/reg-variant :story.handlers/b {:setup [[:init-b]]})
-    (let [variants (story/registrations :variant)]
+    (rf.story/reg-story :story.handlers {:doc "h-fixture"})
+    (rf.story/reg-variant :story.handlers/a {:setup [[:init-a]]})
+    (rf.story/reg-variant :story.handlers/b {:setup [[:init-b]]})
+    (let [variants (rf.story/registrations :variant)]
       (is (map? variants) "registrations returns a {id → body} map")
       (is (= #{:story.handlers/a :story.handlers/b} (set (keys variants))))
       (is (every? map? (vals variants))
           "every body is a map"))
-    (let [tags (story/registrations :tag)]
-      (is (= (+ (count schemas/canonical-tags)
-                (count schemas/canonical-state-tags))
+    (let [tags (rf.story/registrations :tag)]
+      (is (= (+ (count rf.story.schemas/canonical-tags)
+                (count rf.story.schemas/canonical-state-tags))
              (count tags))
           "the canonical seven inclusion + five :state/* magnitude tags surface via registrations"))))
 
 (deftest ids-returns-the-id-set-per-kind
   (testing "(ids :kind) returns the set of registered ids for that kind"
-    (story/reg-story   :story.ids {:doc "ids fixture"})
-    (story/reg-variant :story.ids/a {:setup []})
-    (story/reg-variant :story.ids/b {:setup []})
-    (is (= #{:story.ids/a :story.ids/b} (story/ids :variant)))
-    (is (contains? (story/ids :tag) :dev)
+    (rf.story/reg-story   :story.ids {:doc "ids fixture"})
+    (rf.story/reg-variant :story.ids/a {:setup []})
+    (rf.story/reg-variant :story.ids/b {:setup []})
+    (is (= #{:story.ids/a :story.ids/b} (rf.story/ids :variant)))
+    (is (contains? (rf.story/ids :tag) :dev)
         "the canonical :dev tag id is in the tag id-set")))

--- a/tools/story/test/re_frame/story_mcp_surface_test.clj
+++ b/tools/story/test/re_frame/story_mcp_surface_test.clj
@@ -37,27 +37,27 @@
   app-db."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.machines         :as machines]
-            [re-frame.registrar        :as rf-registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story            :as story]
-            [re-frame.story.async      :as story-async]
-            [re-frame.story.loaders    :as loaders]))
+            [re-frame.frame            :as rf.frame]
+            [re-frame.machines         :as rf.machines]
+            [re-frame.registrar        :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story            :as rf.story]
+            [re-frame.story.async      :as rf.story.async]
+            [re-frame.story.loaders    :as rf.story.loaders]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
 (defn- reset-all [t]
-  (story/clear-all!)
-  (rf-registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
   (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (t))
 
 (use-fixtures :each reset-all)
@@ -78,9 +78,9 @@
   (testing "(ids :story) returns a set of keyword ids — the MCP
             list-stories tool's return shape per spec/006 §read
             primitives"
-    (story/reg-story :story.mcp.list-s-a {:doc "story A"})
-    (story/reg-story :story.mcp.list-s-b {:doc "story B"})
-    (let [result (story/ids :story)]
+    (rf.story/reg-story :story.mcp.list-s-a {:doc "story A"})
+    (rf.story/reg-story :story.mcp.list-s-b {:doc "story B"})
+    (let [result (rf.story/ids :story)]
       (is (set? result)
           "the result is a Clojure set — agents iterate / contains? against it")
       (is (every? keyword? result)
@@ -93,11 +93,11 @@
             the MCP list-variants tool surfaces this directly. Empty
             registry returns the empty set, not nil — protects the
             agent's `(for [...])` walk from a nil punning bug"
-    (is (= #{} (story/ids :variant))
+    (is (= #{} (rf.story/ids :variant))
         "empty registry → empty set")
-    (story/reg-variant :story.mcp.list-v/probe {:setup []})
-    (story/reg-variant :story.mcp.list-v/probe-two {:setup []})
-    (let [result (story/ids :variant)]
+    (rf.story/reg-variant :story.mcp.list-v/probe {:setup []})
+    (rf.story/reg-variant :story.mcp.list-v/probe-two {:setup []})
+    (let [result (rf.story/ids :variant)]
       (is (set? result))
       (is (= #{:story.mcp.list-v/probe :story.mcp.list-v/probe-two}
              result)))))
@@ -107,15 +107,15 @@
             list-modes tool's return shape. Distinct from (ids :mode)
             only by the symbol agents are taught to call; under the
             hood both delegate to the same registrar slot"
-    (is (= #{} (story/list-modes))
+    (is (= #{} (rf.story/list-modes))
         "empty registry → empty set")
-    (story/reg-mode :Mode.mcp.list/dark  {:args {:theme :dark}})
-    (story/reg-mode :Mode.mcp.list/light {:args {:theme :light}})
-    (let [result (story/list-modes)]
+    (rf.story/reg-mode :Mode.mcp.list/dark  {:args {:theme :dark}})
+    (rf.story/reg-mode :Mode.mcp.list/light {:args {:theme :light}})
+    (let [result (rf.story/list-modes)]
       (is (set? result))
       (is (= #{:Mode.mcp.list/dark :Mode.mcp.list/light} result))
       ;; (list-modes) MUST equal (ids :mode) — they are the same data.
-      (is (= (story/list-modes) (story/ids :mode))
+      (is (= (rf.story/list-modes) (rf.story/ids :mode))
           "(list-modes) is a thin alias of (ids :mode)"))))
 
 ;; ===========================================================================
@@ -136,11 +136,11 @@
             :snapshot :decorators :errors"
     (rf/reg-event :mcp/seed
       (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
-    (story/reg-variant :story.mcp.run/probe
+    (rf.story/reg-variant :story.mcp.run/probe
       {:setup [[:mcp/seed 42]]
        :script [[:dispatch-sync [:rf.assert/path-equals [:n] 42]]]})
-    (let [result (story-async/deref-blocking
-                   (story/run-variant :story.mcp.run/probe) 5000)]
+    (let [result (rf.story.async/deref-blocking
+                   (rf.story/run-variant :story.mcp.run/probe) 5000)]
       (is (map? result)
           "run-variant returns a map (the MCP render-story tool's payload)")
       (is (contains? result :frame)
@@ -166,9 +166,9 @@
 (deftest run-variant-empty-play-still-returns-shape
   (testing "even a variant with no :script surfaces the full return shape
             — agents must not have to special-case the no-play branch"
-    (story/reg-variant :story.mcp.run/no-play {:setup []})
-    (let [result (story-async/deref-blocking
-                   (story/run-variant :story.mcp.run/no-play) 5000)]
+    (rf.story/reg-variant :story.mcp.run/no-play {:setup []})
+    (let [result (rf.story.async/deref-blocking
+                   (rf.story/run-variant :story.mcp.run/no-play) 5000)]
       (is (= :story.mcp.run/no-play (:frame result)))
       (is (= [] (:assertions result))
           "empty :script → empty :assertions vector (not nil)")
@@ -193,12 +193,12 @@
     (rf/reg-event :mcp.dispatch/set
       (fn [{:keys [db]} [_ v]] {:db (assoc db :payload v)}))
     ;; MCP write path: programmatic registration (no &form meta).
-    (story/reg-variant* :story.mcp.dispatch/probe
+    (rf.story/reg-variant* :story.mcp.dispatch/probe
       {:setup []
        :args   {}})
     ;; Allocate the variant frame so the dispatch has somewhere to land.
-    (story-async/deref-blocking
-      (story/run-variant :story.mcp.dispatch/probe) 5000)
+    (rf.story.async/deref-blocking
+      (rf.story/run-variant :story.mcp.dispatch/probe) 5000)
     (is (some? (rf/app-db-value :story.mcp.dispatch/probe))
         "frame was allocated by run-variant")
     ;; The MCP dispatch tool's underlying call.
@@ -219,9 +219,9 @@
             app-db in order"
     (rf/reg-event :mcp.dispatch/push
       (fn [{:keys [db]} [_ v]] {:db (update db :log (fnil conj []) v)}))
-    (story/reg-variant* :story.mcp.dispatch.seq/probe {:setup []})
-    (story-async/deref-blocking
-      (story/run-variant :story.mcp.dispatch.seq/probe) 5000)
+    (rf.story/reg-variant* :story.mcp.dispatch.seq/probe {:setup []})
+    (rf.story.async/deref-blocking
+      (rf.story/run-variant :story.mcp.dispatch.seq/probe) 5000)
     (doseq [v ["a" "b" "c"]]
       (rf/dispatch-sync [:mcp.dispatch/push v]
                         {:frame :story.mcp.dispatch.seq/probe}))
@@ -246,18 +246,18 @@
             snapshot-identity hash — the agent's drift detector
             consequently does NOT re-render the variant on a source-
             coord-only change"
-    (story/reg-variant* :story.mcp.snap/probe
+    (rf.story/reg-variant* :story.mcp.snap/probe
       {:args {:label "v1"}
        :setup []})
-    (let [identity-1 (story/snapshot-identity :story.mcp.snap/probe)]
+    (let [identity-1 (rf.story/snapshot-identity :story.mcp.snap/probe)]
       (is (some? identity-1) ":content-hash present")
       ;; Re-register with the same body but a different :source slot
       ;; — cosmetic, the same as moving the registration to a new line.
-      (story/reg-variant* :story.mcp.snap/probe
+      (rf.story/reg-variant* :story.mcp.snap/probe
         {:args   {:label "v1"}
          :setup []
          :source {:file "agent.cljs" :line 99}})
-      (let [identity-2 (story/snapshot-identity :story.mcp.snap/probe)]
+      (let [identity-2 (rf.story/snapshot-identity :story.mcp.snap/probe)]
         (is (= (:content-hash identity-1) (:content-hash identity-2))
             ":source edit is cosmetic — content-hash MUST be stable")))))
 
@@ -270,19 +270,19 @@
             map (the canvas uses this path to detect control changes);
             pinning the hash on the opts path covers the surface MCP
             tools consume."
-    (story/reg-variant* :story.mcp.snap.args/probe
+    (rf.story/reg-variant* :story.mcp.snap.args/probe
       {:args   {:label "before"}
        :setup []})
     (let [base    (:content-hash
-                    (story/snapshot-identity :story.mcp.snap.args/probe))
+                    (rf.story/snapshot-identity :story.mcp.snap.args/probe))
           with-co (:content-hash
-                    (story/snapshot-identity :story.mcp.snap.args/probe
+                    (rf.story/snapshot-identity :story.mcp.snap.args/probe
                                              {:cell-overrides {:label "after"}}))]
       (is (not= base with-co)
           "cell-override mutation flips the hash — agent detects drift")
       ;; And the inverse — same cell-overrides → same hash.
       (let [with-co-2 (:content-hash
-                        (story/snapshot-identity :story.mcp.snap.args/probe
+                        (rf.story/snapshot-identity :story.mcp.snap.args/probe
                                                  {:cell-overrides {:label "after"}}))]
         (is (= with-co with-co-2)
             "same input → same hash (deterministic)")))))
@@ -292,19 +292,19 @@
             changes the resolved args and thus the snapshot-identity
             hash. The MCP boundary surfaces this via the opts map so
             the agent can compare per-mode snapshots"
-    (story/reg-mode :Mode.mcp.snap/dark  {:args {:theme :dark}})
-    (story/reg-mode :Mode.mcp.snap/light {:args {:theme :light}})
-    (story/reg-variant* :story.mcp.snap.modes/probe
+    (rf.story/reg-mode :Mode.mcp.snap/dark  {:args {:theme :dark}})
+    (rf.story/reg-mode :Mode.mcp.snap/light {:args {:theme :light}})
+    (rf.story/reg-variant* :story.mcp.snap.modes/probe
       {:args   {:label "x"}
        :setup []})
     (let [dark  (:content-hash
-                  (story/snapshot-identity :story.mcp.snap.modes/probe
+                  (rf.story/snapshot-identity :story.mcp.snap.modes/probe
                                            {:active-modes [:Mode.mcp.snap/dark]}))
           light (:content-hash
-                  (story/snapshot-identity :story.mcp.snap.modes/probe
+                  (rf.story/snapshot-identity :story.mcp.snap.modes/probe
                                            {:active-modes [:Mode.mcp.snap/light]}))
           none  (:content-hash
-                  (story/snapshot-identity :story.mcp.snap.modes/probe
+                  (rf.story/snapshot-identity :story.mcp.snap.modes/probe
                                            {:active-modes []}))]
       (is (not= dark light)
           "two different active-modes → two different hashes")

--- a/tools/story/test/re_frame/story_multi_substrate_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_multi_substrate_cljs_test.cljs
@@ -4,21 +4,21 @@
   React paths are CLJS-only."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story :as story]
-            [re-frame.story.ui.multi-substrate :as multi]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.ui.multi-substrate :as rf.story.ui.multi-substrate]))
 
 (defn reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
   ;; Wipe the substrate registry so each test starts clean.
-  (reset! multi/substrate->render-fn {})
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (reset! rf.story.ui.multi-substrate/substrate->render-fn {})
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -26,27 +26,27 @@
 
 (deftest reagent-default-registered
   (testing "install-canonical-vocabulary! registers :reagent substrate"
-    (is (contains? (multi/registered-substrates) :reagent))))
+    (is (contains? (rf.story.ui.multi-substrate/registered-substrates) :reagent))))
 
 (deftest register-and-unregister
   (testing "register-substrate! + unregister-substrate! work"
-    (multi/register-substrate! :uix
+    (rf.story.ui.multi-substrate/register-substrate! :uix
                                (fn [_ _ _] [:div "uix-stub"]))
-    (is (contains? (multi/registered-substrates) :uix))
-    (multi/unregister-substrate! :uix)
-    (is (not (contains? (multi/registered-substrates) :uix)))))
+    (is (contains? (rf.story.ui.multi-substrate/registered-substrates) :uix))
+    (rf.story.ui.multi-substrate/unregister-substrate! :uix)
+    (is (not (contains? (rf.story.ui.multi-substrate/registered-substrates) :uix)))))
 
 (deftest public-register-substrate-on-story
-  (testing "story/register-substrate! is the public form"
-    (story/register-substrate! :custom (fn [_ _ _] [:div "custom-stub"]))
-    (is (contains? (story/registered-substrates) :custom))))
+  (testing "rf.story/register-substrate! is the public form"
+    (rf.story/register-substrate! :custom (fn [_ _ _] [:div "custom-stub"]))
+    (is (contains? (rf.story/registered-substrates) :custom))))
 
 ;; ---- substrate-set resolution -------------------------------------------
 
 (deftest substrate-set-from-variant
   (testing "resolve-substrate-set prefers variant :substrates when present"
     (is (= #{:reagent :uix}
-           (multi/resolve-substrate-set
+           (rf.story.ui.multi-substrate/resolve-substrate-set
              {:substrates #{:reagent :uix}}
              {}
              :reagent)))))
@@ -54,7 +54,7 @@
 (deftest substrate-set-from-story
   (testing "falls back to story body's :substrates"
     (is (= #{:reagent :uix}
-           (multi/resolve-substrate-set
+           (rf.story.ui.multi-substrate/resolve-substrate-set
              {}
              {:substrates #{:reagent :uix}}
              :reagent)))))
@@ -62,7 +62,7 @@
 (deftest substrate-set-defaults-host
   (testing "defaults to {host} when neither body nor story declares :substrates"
     (is (= #{:reagent}
-           (multi/resolve-substrate-set {} {} :reagent)))))
+           (rf.story.ui.multi-substrate/resolve-substrate-set {} {} :reagent)))))
 
 ;; ---- render-view dispatch -----------------------------------------------
 ;;
@@ -82,12 +82,12 @@
   (testing "a registered NON-:reagent substrate gets the render call, and the
             (variant-id view-id args) contract arrives intact"
     (let [seen (atom nil)]
-      (multi/register-substrate! :uix
+      (rf.story.ui.multi-substrate/register-substrate! :uix
         (fn [variant-id view-id args]
           (reset! seen [variant-id view-id args])
           [:div.uix-stub "rendered by the stub"]))
       (is (= [:div.uix-stub "rendered by the stub"]
-             (multi/render-view :uix :story.rv/probe :views/probe {:n 1}))
+             (rf.story.ui.multi-substrate/render-view :uix :story.rv/probe :views/probe {:n 1}))
           "the substrate's own render result is returned verbatim")
       (is (= [:story.rv/probe :views/probe {:n 1}] @seen)
           "the substrate-render contract is (fn [variant-id view-id args])"))))
@@ -95,9 +95,9 @@
 (deftest render-view-degrades-when-substrate-unregistered
   (testing "an unregistered substrate yields an inline diagnostic rather than
             throwing, so the render verb's caller always sees something back"
-    (is (not (contains? (multi/registered-substrates) :uix))
+    (is (not (contains? (rf.story.ui.multi-substrate/registered-substrates) :uix))
         "precondition: :uix is not registered in this fixture")
-    (let [rendered (multi/render-view :uix :story.rv/probe :views/probe {})]
+    (let [rendered (rf.story.ui.multi-substrate/render-view :uix :story.rv/probe :views/probe {})]
       (is (vector? rendered)
           "a hiccup vector came back — nothing threw past the caller")
       (is (re-find #"is not registered" (last rendered))

--- a/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
@@ -4,7 +4,7 @@
   The pure URI logic lives in `re-frame.source-coords.editor-uri` and is
   matrix-tested on the JVM. This file covers the Story-specific glue:
 
-  - `config/set-editor!` round-trips on the CLJS side.
+  - `rf.story.config/set-editor!` round-trips on the CLJS side.
   - `open-chip` returns nil when the source-coord lacks `:file`.
   - `open-chip` renders an `<a>` hiccup tag with the current editor's
     URI when the coord carries `:file`.
@@ -21,13 +21,13 @@
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.source-coords.editor-uri :as editor-uri]
-            [re-frame.source-coords.open-endpoint :as open-endpoint]
-            [re-frame.source-store :as source-store]
-            [re-frame.story :as story]
-            [re-frame.story.config :as config]
-            [re-frame.story.ui.open-in-editor :as open-in-editor]
-            [re-frame.substrate.plain-atom :as plain-atom])
+            [re-frame.source-coords.editor-uri :as rf.source-coords.editor-uri]
+            [re-frame.source-coords.open-endpoint :as rf.source-coords.open-endpoint]
+            [re-frame.source-store :as rf.source-store]
+            [re-frame.story :as rf.story]
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.ui.open-in-editor :as rf.story.ui.open-in-editor]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom])
   (:require-macros [re-frame.core :refer [with-frame]]))
 
 ;; ---- Option B endpoint seam (rf2-wn3bh) ---------------------------------
@@ -48,12 +48,12 @@
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-editor! []
-  (config/set-editor! :vscode)
-  (config/set-project-root! nil)
+  (rf.story.config/set-editor! :vscode)
+  (rf.story.config/set-project-root! nil)
   ;; rf2-wn3bh — pin the endpoint launcher to the synchronous fallback stub
   ;; so the URI / navigator assertions below exercise the deterministic
   ;; fallback path.
-  (open-endpoint/set-launcher! always-fall-back!))
+  (rf.source-coords.open-endpoint/set-launcher! always-fall-back!))
 
 (use-fixtures :each {:before reset-editor!
                      :after  reset-editor!})
@@ -71,11 +71,11 @@
   "Swap the navigator seam for `stub-fn` for the duration of `body-fn`.
   Restores the original navigator afterward (even on throw)."
   [stub-fn body-fn]
-  (let [prev (open-in-editor/set-navigator! stub-fn)]
+  (let [prev (rf.story.ui.open-in-editor/set-navigator! stub-fn)]
     (try
       (body-fn)
       (finally
-        (open-in-editor/set-navigator! prev)))))
+        (rf.story.ui.open-in-editor/set-navigator! prev)))))
 
 (defn- capturing-navigator
   "Build a navigator fn that pushes its URI argument onto the shared
@@ -90,7 +90,7 @@
 (deftest open-chip-renders-anchor-with-href
   (testing "open-chip returns an <a> hiccup vector when source has :file"
     (let [coord  {:ns 'app.views :file "src/app/views.cljs" :line 42 :column 7}
-          hiccup (open-in-editor/open-chip coord)]
+          hiccup (rf.story.ui.open-in-editor/open-chip coord)]
       (is (vector? hiccup))
       (is (= :a (first hiccup)))
       (let [props (second hiccup)]
@@ -103,27 +103,27 @@
 (deftest open-chip-respects-editor-preference
   (testing "switching editor flips the URI scheme on subsequent renders"
     (let [coord {:file "src/x.cljs" :line 10 :column 1}]
-      (config/set-editor! :cursor)
+      (rf.story.config/set-editor! :cursor)
       (is (= "cursor://file/src/x.cljs:10:1"
-             (:href (second (open-in-editor/open-chip coord)))))
-      (config/set-editor! :idea)
+             (:href (second (rf.story.ui.open-in-editor/open-chip coord)))))
+      (rf.story.config/set-editor! :idea)
       (is (= "idea://open?file=src/x.cljs&line=10&column=1"
-             (:href (second (open-in-editor/open-chip coord))))))))
+             (:href (second (rf.story.ui.open-in-editor/open-chip coord))))))))
 
 (deftest open-chip-supports-custom-template
   (testing ":custom template is read live from config"
-    (config/set-editor! {:custom "zed://file/{path}:{line}"})
+    (rf.story.config/set-editor! {:custom "zed://file/{path}:{line}"})
     (let [coord {:file "src/x.cljs" :line 5 :column 2}]
       (is (= "zed://file/src/x.cljs:5"
-             (:href (second (open-in-editor/open-chip coord)))))
+             (:href (second (rf.story.ui.open-in-editor/open-chip coord)))))
       (is (= "custom"
-             (:data-editor (second (open-in-editor/open-chip coord))))))))
+             (:data-editor (second (rf.story.ui.open-in-editor/open-chip coord))))))))
 
 (deftest open-chip-nil-when-source-missing
   (testing "open-chip returns nil when source-coord lacks :file"
-    (is (nil? (open-in-editor/open-chip nil)))
-    (is (nil? (open-in-editor/open-chip {:line 10})))
-    (is (nil? (open-in-editor/open-chip {:file ""})))))
+    (is (nil? (rf.story.ui.open-in-editor/open-chip nil)))
+    (is (nil? (rf.story.ui.open-in-editor/open-chip {:line 10})))
+    (is (nil? (rf.story.ui.open-in-editor/open-chip {:file ""})))))
 
 (deftest open-chip-for-variant-reads-source-slot
   (testing "open-chip-for-variant pulls :source off the variant body"
@@ -132,13 +132,13 @@
                          :file "src/app/stories.cljs"
                          :line 17
                          :column 3}}
-          hiccup (open-in-editor/open-chip-for-variant body)]
+          hiccup (rf.story.ui.open-in-editor/open-chip-for-variant body)]
       (is (vector? hiccup))
       (is (= "vscode://file/src/app/stories.cljs:17:3"
              (:href (second hiccup))))))
   (testing "open-chip-for-variant nil when variant body has no :source"
-    (is (nil? (open-in-editor/open-chip-for-variant {:setup []})))
-    (is (nil? (open-in-editor/open-chip-for-variant nil)))))
+    (is (nil? (rf.story.ui.open-in-editor/open-chip-for-variant {:setup []})))
+    (is (nil? (rf.story.ui.open-in-editor/open-chip-for-variant nil)))))
 
 ;; ---- open-source-coord! (rf2-h0jc0) --------------------------------------
 ;;
@@ -151,45 +151,45 @@
             navigator seam — same path the chip uses"
     (let [calls (atom [])
           nav   (fn [uri] (swap! calls conj uri))
-          prev  (open-in-editor/set-navigator! nav)]
+          prev  (rf.story.ui.open-in-editor/set-navigator! nav)]
       (try
-        (open-in-editor/open-source-coord!
+        (rf.story.ui.open-in-editor/open-source-coord!
           {:file "src/app.cljs" :line 17 :column 3})
         (is (= ["vscode://file/src/app.cljs:17:3"] @calls)
             "navigator invoked once with the resolved vscode:// URI")
         (finally
-          (open-in-editor/set-navigator! prev))))))
+          (rf.story.ui.open-in-editor/set-navigator! prev))))))
 
 (deftest open-source-coord!-no-op-without-file
   (testing "open-source-coord! returns false + no-ops when source-coord
             lacks :file"
     (let [calls (atom [])
           nav   (fn [uri] (swap! calls conj uri))
-          prev  (open-in-editor/set-navigator! nav)]
+          prev  (rf.story.ui.open-in-editor/set-navigator! nav)]
       (try
-        (is (false? (open-in-editor/open-source-coord! nil)))
-        (is (false? (open-in-editor/open-source-coord! {:line 10})))
+        (is (false? (rf.story.ui.open-in-editor/open-source-coord! nil)))
+        (is (false? (rf.story.ui.open-in-editor/open-source-coord! {:line 10})))
         (is (= [] @calls)
             "no navigation attempted when :file is absent")
         (finally
-          (open-in-editor/set-navigator! prev))))))
+          (rf.story.ui.open-in-editor/set-navigator! prev))))))
 
 (deftest open-source-coord!-respects-editor-preference
   (testing "the URI shipped by open-source-coord! reflects the live
             editor + project-root config — same source of truth the
             chip's :href reads"
-    (config/set-editor! :cursor)
-    (config/set-project-root! "C:/Users/me/code/my-app")
+    (rf.story.config/set-editor! :cursor)
+    (rf.story.config/set-project-root! "C:/Users/me/code/my-app")
     (let [calls (atom [])
           nav   (fn [uri] (swap! calls conj uri))
-          prev  (open-in-editor/set-navigator! nav)]
+          prev  (rf.story.ui.open-in-editor/set-navigator! nav)]
       (try
-        (open-in-editor/open-source-coord!
+        (rf.story.ui.open-in-editor/open-source-coord!
           {:file "src/app.cljs" :line 17 :column 3})
         (is (= ["cursor://file/C:/Users/me/code/my-app/src/app.cljs:17:3"]
                @calls))
         (finally
-          (open-in-editor/set-navigator! prev))))))
+          (rf.story.ui.open-in-editor/set-navigator! prev))))))
 
 (deftest open!-denylist-gates-pre-resolved-uri
   (testing "rf2-ox357n — `open!` re-applies the scheme denylist at the
@@ -202,20 +202,20 @@
         (fn []
           ;; forbidden script schemes are refused at the click-time seam,
           ;; case-insensitively + leading-whitespace tolerant
-          (open-in-editor/open! "javascript:alert(1)")
-          (open-in-editor/open! "JavaScript:alert(1)")
-          (open-in-editor/open! " data:text/html,xxx")
-          (open-in-editor/open! "vbscript:msgbox(1)")
+          (rf.story.ui.open-in-editor/open! "javascript:alert(1)")
+          (rf.story.ui.open-in-editor/open! "JavaScript:alert(1)")
+          (rf.story.ui.open-in-editor/open! " data:text/html,xxx")
+          (rf.story.ui.open-in-editor/open! "vbscript:msgbox(1)")
           (is (= [] @calls)
               "no forbidden-scheme URI reaches the navigator")
           ;; an unknown, non-dangerous scheme passes through (no allowlist)
-          (open-in-editor/open! "lapce://open?file=src/x.cljs&line=1")
+          (rf.story.ui.open-in-editor/open! "lapce://open?file=src/x.cljs&line=1")
           (is (= ["lapce://open?file=src/x.cljs&line=1"] @calls)
               "an unknown custom non-dangerous scheme navigates"))))))
 
 (deftest open-chip-title-attribute-shape
   (testing "the chip's :title attr surfaces file:line for hover"
-    (let [hiccup (open-in-editor/open-chip
+    (let [hiccup (rf.story.ui.open-in-editor/open-chip
                    {:file "src/app.cljs" :line 99 :column 4})
           props  (second hiccup)]
       (is (= "Open in editor — src/app.cljs:99"
@@ -233,46 +233,46 @@
 
 (deftest open-chip-hides-when-custom-template-resolves-to-forbidden-scheme
   (testing "open-chip returns nil ONLY for the three forbidden script
-            schemes (rf2-vwcsq). editor-uri/editor-uri gates these at
+            schemes (rf2-vwcsq). rf.source-coords.editor-uri/editor-uri gates these at
             build time → the chip is nil."
-    (config/set-editor! {:custom "javascript:alert(1)"})
-    (is (nil? (open-in-editor/open-chip {:file "src/x.cljs"})))
+    (rf.story.config/set-editor! {:custom "javascript:alert(1)"})
+    (is (nil? (rf.story.ui.open-in-editor/open-chip {:file "src/x.cljs"})))
 
-    (config/set-editor! {:custom "data:text/html,xxx"})
-    (is (nil? (open-in-editor/open-chip {:file "src/x.cljs"})))
+    (rf.story.config/set-editor! {:custom "data:text/html,xxx"})
+    (is (nil? (rf.story.ui.open-in-editor/open-chip {:file "src/x.cljs"})))
 
-    (config/set-editor! {:custom "vbscript:msgbox(1)"})
-    (is (nil? (open-in-editor/open-chip {:file "src/x.cljs"})))))
+    (rf.story.config/set-editor! {:custom "vbscript:msgbox(1)"})
+    (is (nil? (rf.story.ui.open-in-editor/open-chip {:file "src/x.cljs"})))))
 
 (deftest open-chip-renders-for-non-forbidden-custom-scheme
   (testing "rf2-ox357n — open-chip renders for ANY non-forbidden scheme:
             catalogued long-tail, http:/https: (no longer gated), AND
             unknown custom schemes the old allowlist would have hidden"
-    (config/set-editor! {:custom "subl://open?path={path}&line={line}"})
-    (let [hiccup (open-in-editor/open-chip {:file "src/x.cljs" :line 5})]
+    (rf.story.config/set-editor! {:custom "subl://open?path={path}&line={line}"})
+    (let [hiccup (rf.story.ui.open-in-editor/open-chip {:file "src/x.cljs" :line 5})]
       (is (vector? hiccup))
       (is (= "subl://open?path=src/x.cljs&line=5" (:href (second hiccup)))))
 
-    (config/set-editor! {:custom "emacsclient://{path}"})
-    (is (some? (open-in-editor/open-chip {:file "src/x.cljs"})))
+    (rf.story.config/set-editor! {:custom "emacsclient://{path}"})
+    (is (some? (rf.story.ui.open-in-editor/open-chip {:file "src/x.cljs"})))
 
     ;; http:/https: now PASS — rf2-ox357n removed the allowlist that
     ;; rejected them. The residual risk (an http template navigates the
     ;; tab on a trusted localhost dev surface) is the documented footgun
     ;; the spec accepts; script schemes stay blocked.
-    (config/set-editor! {:custom "http://localhost:3000/{path}"})
+    (rf.story.config/set-editor! {:custom "http://localhost:3000/{path}"})
     (is (= "http://localhost:3000/src/x.cljs"
-           (:href (second (open-in-editor/open-chip {:file "src/x.cljs"})))))
+           (:href (second (rf.story.ui.open-in-editor/open-chip {:file "src/x.cljs"})))))
 
     ;; An unknown editor scheme renders — no silent dead button.
-    (config/set-editor! {:custom "lapce://open?file={path}&line={line}"})
+    (rf.story.config/set-editor! {:custom "lapce://open?file={path}&line={line}"})
     (is (= "lapce://open?file=src/x.cljs&line=8"
-           (:href (second (open-in-editor/open-chip {:file "src/x.cljs" :line 8})))))))
+           (:href (second (rf.story.ui.open-in-editor/open-chip {:file "src/x.cljs" :line 8})))))))
 
 (deftest open-chip-for-variant-hides-on-forbidden-scheme
   (testing "open-chip-for-variant inherits the denylist gate"
-    (config/set-editor! {:custom "javascript:alert(1)"})
-    (is (nil? (open-in-editor/open-chip-for-variant
+    (rf.story.config/set-editor! {:custom "javascript:alert(1)"})
+    (is (nil? (rf.story.ui.open-in-editor/open-chip-for-variant
                 {:source {:file "src/x.cljs" :line 1}})))))
 
 ;; ---- project-root prefix (rf2-zfy1e) -------------------------------------
@@ -280,23 +280,23 @@
 ;; The bead: clicking the Open chip launched an OS-side editor with a
 ;; classpath-relative path ("\panel_gallery\event_detail_stories.cljs:115:3")
 ;; that the editor's filesystem resolver could not find. The Story config
-;; now exposes `:rf.story/project-root` — set once at boot via `story/configure!` —
+;; now exposes `:rf.story/project-root` — set once at boot via `rf.story/configure!` —
 ;; and the chip prepends it before the URI ships.
 
 (deftest open-chip-default-no-project-root
   (testing "with no project-root configured, the chip ships the file slot
             verbatim — preserves v1 behaviour for hosts that haven't
             plumbed the knob yet"
-    (is (nil? (config/get-project-root)))
-    (let [hiccup (open-in-editor/open-chip
+    (is (nil? (rf.story.config/get-project-root)))
+    (let [hiccup (rf.story.ui.open-in-editor/open-chip
                    {:file "src/app/views.cljs" :line 1 :column 1})]
       (is (= "vscode://file/src/app/views.cljs:1:1"
              (:href (second hiccup)))))))
 
 (deftest open-chip-prefixes-with-project-root
   (testing "set-project-root! plumbs the on-disk root through the chip"
-    (config/set-project-root! "C:/Users/me/code/my-app")
-    (let [hiccup (open-in-editor/open-chip
+    (rf.story.config/set-project-root! "C:/Users/me/code/my-app")
+    (let [hiccup (rf.story.ui.open-in-editor/open-chip
                    {:file "src/app/views.cljs" :line 42 :column 7})]
       (is (= "vscode://file/C:/Users/me/code/my-app/src/app/views.cljs:42:7"
              (:href (second hiccup)))))))
@@ -305,9 +305,9 @@
   (testing "regression: the panel-gallery testbed's failure case now
             resolves to an absolute on-disk URI when the host has
             plumbed :rf.story/project-root through Story's configure!"
-    (config/set-project-root!
+    (rf.story.config/set-project-root!
       "C:/Users/me/code/my-app/tools/xray/testbeds")
-    (let [hiccup (open-in-editor/open-chip
+    (let [hiccup (rf.story.ui.open-in-editor/open-chip
                    {:file "panel_gallery/event_detail_stories.cljs"
                     :line 115
                     :column 3})]
@@ -322,7 +322,7 @@
             stayed nil, so the Story variant-toolbar 'Open' button
             shipped a relative `:file` slot (`panel_gallery/foo.cljs`)
             that the OS-side editor handler rejected. The fix wires
-            `story/configure!` alongside the existing xray-config
+            `rf.story/configure!` alongside the existing xray-config
             call in panel-gallery's `run` so Story's atom carries the
             same on-disk root Xray uses.
 
@@ -330,11 +330,11 @@
             the panel-gallery's source-coord shape end-to-end: with
             no project-root configured, the URI is relative (the
             pre-fix bug); with `:rf.story/project-root` plumbed in
-            via `story/configure!`, the URI is absolute."
+            via `rf.story/configure!`, the URI is absolute."
     ;; Pre-fix bug shape: no project-root → relative URI (which the OS
     ;; editor handler rejects).
-    (config/set-project-root! nil)
-    (let [hiccup-pre (open-in-editor/open-chip
+    (rf.story.config/set-project-root! nil)
+    (let [hiccup-pre (rf.story.ui.open-in-editor/open-chip
                        {:file "panel_gallery/gallery_app_db.cljs"
                         :line 42
                         :column 7})]
@@ -342,10 +342,10 @@
              (:href (second hiccup-pre)))
           "without :rf.story/project-root the URI is relative (pre-fix
            panel-gallery shape)"))
-    ;; Post-fix shape: `story/configure!` seeds the atom; URI is absolute.
-    (config/set-project-root!
+    ;; Post-fix shape: `rf.story/configure!` seeds the atom; URI is absolute.
+    (rf.story.config/set-project-root!
       "C:/Users/me/code/my-app/tools/xray/testbeds")
-    (let [hiccup-post (open-in-editor/open-chip
+    (let [hiccup-post (rf.story.ui.open-in-editor/open-chip
                         {:file "panel_gallery/gallery_app_db.cljs"
                          :line 42
                          :column 7})]
@@ -357,25 +357,25 @@
            OS-side editor handler can resolve it"))))
 
 (deftest open-chip-project-root-roundtrip
-  (testing "config/set-project-root! + get-project-root round-trip"
-    (config/set-project-root! "/abs/code")
-    (is (= "/abs/code" (config/get-project-root)))
-    (config/set-project-root! nil)
-    (is (nil? (config/get-project-root)))
+  (testing "rf.story.config/set-project-root! + get-project-root round-trip"
+    (rf.story.config/set-project-root! "/abs/code")
+    (is (= "/abs/code" (rf.story.config/get-project-root)))
+    (rf.story.config/set-project-root! nil)
+    (is (nil? (rf.story.config/get-project-root)))
     ;; blank strings normalise to nil so the chip behaves as if unset.
-    (config/set-project-root! "")
-    (is (nil? (config/get-project-root)))))
+    (rf.story.config/set-project-root! "")
+    (is (nil? (rf.story.config/get-project-root)))))
 
 (deftest open-chip-project-root-survives-editor-change
   (testing "switching editor keeps project-root applied to the new scheme"
-    (config/set-project-root! "/abs/code")
-    (config/set-editor! :cursor)
-    (let [hiccup (open-in-editor/open-chip
+    (rf.story.config/set-project-root! "/abs/code")
+    (rf.story.config/set-editor! :cursor)
+    (let [hiccup (rf.story.ui.open-in-editor/open-chip
                    {:file "src/x.cljs" :line 1 :column 1})]
       (is (= "cursor://file//abs/code/src/x.cljs:1:1"
              (:href (second hiccup)))))
-    (config/set-editor! :idea)
-    (let [hiccup (open-in-editor/open-chip
+    (rf.story.config/set-editor! :idea)
+    (let [hiccup (rf.story.ui.open-in-editor/open-chip
                    {:file "src/x.cljs" :line 1 :column 1})]
       (is (= "idea://open?file=/abs/code/src/x.cljs&line=1&column=1"
              (:href (second hiccup)))))))
@@ -407,7 +407,7 @@
 (deftest click-handler-calls-navigator-with-uri
   (testing "rf2-muvs8 — clicking the chip invokes the navigator seam
             with the same URI carried in the :href"
-    (let [hiccup       (open-in-editor/open-chip
+    (let [hiccup       (rf.story.ui.open-in-editor/open-chip
                          {:file "src/x.cljs" :line 42 :column 7})
           props        (second hiccup)
           href         (:href props)
@@ -426,7 +426,7 @@
   (testing "rf2-muvs8 — the click handler preventDefaults so the
             browser doesn't double-navigate (once via the <a href>
             native click, once via the JS Location.assign call)"
-    (let [hiccup       (open-in-editor/open-chip
+    (let [hiccup       (rf.story.ui.open-in-editor/open-chip
                          {:file "src/x.cljs" :line 1})
           on-click     (:on-click (second hiccup))
           prevented?   (atom false)
@@ -442,8 +442,8 @@
             the chip entirely for the forbidden script schemes, so the
             click never wires up at all. Pins that the user can never
             click a javascript:/data:/vbscript: URI to navigation."
-    (config/set-editor! {:custom "javascript:alert(1)"})
-    (is (nil? (open-in-editor/open-chip {:file "src/x.cljs"}))
+    (rf.story.config/set-editor! {:custom "javascript:alert(1)"})
+    (is (nil? (rf.story.ui.open-in-editor/open-chip {:file "src/x.cljs"}))
         "render-time gate hides chip for forbidden scheme")))
 
 ;; ---- Windows-path URI shape regression (rf2-muvs8) ----------------------
@@ -461,8 +461,8 @@
 (deftest windows-path-uri-shape
   (testing "rf2-muvs8 — Windows project-root + relative source-coord
             produces a URI VSCode's OS handler can resolve"
-    (config/set-project-root! "C:/Users/me/code/my-app")
-    (let [hiccup (open-in-editor/open-chip
+    (rf.story.config/set-project-root! "C:/Users/me/code/my-app")
+    (let [hiccup (rf.story.ui.open-in-editor/open-chip
                    {:file "tools/story/src/re_frame/story/ui/open_in_editor.cljs"
                     :line 92
                     :column 5})]
@@ -476,8 +476,8 @@
 (deftest posix-path-uri-shape
   (testing "rf2-muvs8 — POSIX project-root + relative source-coord
             produces a URI VSCode/Cursor's OS handler can resolve"
-    (config/set-project-root! "/home/me/code/myapp")
-    (let [hiccup (open-in-editor/open-chip
+    (rf.story.config/set-project-root! "/home/me/code/myapp")
+    (let [hiccup (rf.story.ui.open-in-editor/open-chip
                    {:file "src/app/views.cljs" :line 1 :column 1})]
       (is (= "vscode://file//home/me/code/myapp/src/app/views.cljs:1:1"
              (:href (second hiccup)))
@@ -487,8 +487,8 @@
 (deftest windows-backslash-path-uri-shape
   (testing "rf2-muvs8 — Windows project-root with trailing backslash
             still produces a valid URI (trailing separators stripped)"
-    (config/set-project-root! "C:\\Users\\me\\code\\myapp\\")
-    (let [hiccup (open-in-editor/open-chip
+    (rf.story.config/set-project-root! "C:\\Users\\me\\code\\myapp\\")
+    (let [hiccup (rf.story.ui.open-in-editor/open-chip
                    {:file "src/app/views.cljs" :line 1 :column 1})]
       (is (= "vscode://file/C:\\Users\\me\\code\\myapp/src/app/views.cljs:1:1"
              (:href (second hiccup)))
@@ -507,44 +507,44 @@
 (deftest resolve-uri-returns-vscode-default
   (testing "resolve-uri builds a vscode://file URI by default"
     (is (= "vscode://file/src/app.cljs:42:7"
-           (open-in-editor/resolve-uri
+           (rf.story.ui.open-in-editor/resolve-uri
              {:file "src/app.cljs" :line 42 :column 7})))))
 
 (deftest resolve-uri-respects-editor-preference
   (testing "switching editor flips the URI scheme"
-    (config/set-editor! :cursor)
+    (rf.story.config/set-editor! :cursor)
     (is (= "cursor://file/src/x.cljs:1:1"
-           (open-in-editor/resolve-uri
+           (rf.story.ui.open-in-editor/resolve-uri
              {:file "src/x.cljs" :line 1 :column 1})))))
 
 (deftest resolve-uri-applies-project-root
   (testing "configured project-root prepends to the source-coord file"
-    (config/set-project-root! "C:/Users/me/code/my-app")
+    (rf.story.config/set-project-root! "C:/Users/me/code/my-app")
     (is (= "vscode://file/C:/Users/me/code/my-app/src/app.cljs:17:3"
-           (open-in-editor/resolve-uri
+           (rf.story.ui.open-in-editor/resolve-uri
              {:file "src/app.cljs" :line 17 :column 3})))))
 
 (deftest resolve-uri-nil-when-source-missing
   (testing "resolve-uri returns nil for coords without :file"
-    (is (nil? (open-in-editor/resolve-uri nil)))
-    (is (nil? (open-in-editor/resolve-uri {:line 1})))
-    (is (nil? (open-in-editor/resolve-uri {:file ""})))))
+    (is (nil? (rf.story.ui.open-in-editor/resolve-uri nil)))
+    (is (nil? (rf.story.ui.open-in-editor/resolve-uri {:line 1})))
+    (is (nil? (rf.story.ui.open-in-editor/resolve-uri {:file ""})))))
 
 (deftest resolve-uri-nil-for-forbidden-custom-scheme
   (testing "resolve-uri returns nil ONLY when a {:custom ...} template
             resolves to a forbidden script scheme (rf2-vwcsq). Per
             rf2-ox357n http:/https:/unknown schemes now resolve through."
-    (config/set-editor! {:custom "javascript:alert(1)"})
-    (is (nil? (open-in-editor/resolve-uri {:file "src/x.cljs"})))
-    (config/set-editor! {:custom "data:text/html,xxx"})
-    (is (nil? (open-in-editor/resolve-uri {:file "src/x.cljs"})))
+    (rf.story.config/set-editor! {:custom "javascript:alert(1)"})
+    (is (nil? (rf.story.ui.open-in-editor/resolve-uri {:file "src/x.cljs"})))
+    (rf.story.config/set-editor! {:custom "data:text/html,xxx"})
+    (is (nil? (rf.story.ui.open-in-editor/resolve-uri {:file "src/x.cljs"})))
     ;; http: + unknown schemes now resolve (no positive allowlist).
-    (config/set-editor! {:custom "http://localhost:3000/{path}"})
+    (rf.story.config/set-editor! {:custom "http://localhost:3000/{path}"})
     (is (= "http://localhost:3000/src/x.cljs"
-           (open-in-editor/resolve-uri {:file "src/x.cljs"})))
-    (config/set-editor! {:custom "lapce://open?file={path}"})
+           (rf.story.ui.open-in-editor/resolve-uri {:file "src/x.cljs"})))
+    (rf.story.config/set-editor! {:custom "lapce://open?file={path}"})
     (is (= "lapce://open?file=src/x.cljs"
-           (open-in-editor/resolve-uri {:file "src/x.cljs"})))))
+           (rf.story.ui.open-in-editor/resolve-uri {:file "src/x.cljs"})))))
 
 ;; ---- :rf.story/open-in-editor + :rf.story.fx/open-in-editor (rf2-r2un8) ------------
 ;;
@@ -598,7 +598,7 @@
   `rf/make-frame` needs a state-container factory, and the consolidated run
   may or may not have had `init!` called by an earlier namespace."
   []
-  (try (rf/init! plain-atom/adapter)
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch :default _ nil)))
 
 (defn- assert-production-registration!
@@ -609,7 +609,7 @@
   provenance collision that used to break image assembly)."
   []
   (is (= #{production-fx-ns}
-         (set (keys (source-store/descriptors-for
+         (set (keys (rf.source-store/descriptors-for
                       :fx :rf.story.fx/open-in-editor))))
       "`:rf.story.fx/open-in-editor` is registered, and ONLY by
        re-frame.story.ui.open-in-editor — no test-namespace shadow"))
@@ -627,7 +627,7 @@
   []
   (reset! captured-editor-fx [])
   (ensure-adapter!)
-  (open-in-editor/install!)
+  (rf.story.ui.open-in-editor/install!)
   (assert-production-registration!)
   ;; EP-0002 (rf2-bd4div): `:rf.story/open-in-editor` dispatches under a
   ;; carried frame stamp, so the `with-frame`-scoped dispatches below need a
@@ -642,7 +642,7 @@
         (swap! captured-editor-fx conj
                (assoc args
                       :uri (when-let [coord (:source-coord args)]
-                             (open-in-editor/resolve-uri coord)))))}}))
+                             (rf.story.ui.open-in-editor/resolve-uri coord)))))}}))
 
 (deftest open-in-editor-event-emits-fx-with-resolved-uri
   (testing "rf2-r2un8 — dispatching `:rf.story/open-in-editor` with a
@@ -691,10 +691,10 @@
            (:uri (first @captured-editor-fx))))))
 
 (deftest open-in-editor-event-honours-editor-preference
-  (testing "rf2-r2un8 — the fx's URI reflects `config/get-editor`
+  (testing "rf2-r2un8 — the fx's URI reflects `rf.story.config/get-editor`
             (the same source of truth the chip render uses)"
     (install-with-capture!)
-    (config/set-editor! :cursor)
+    (rf.story.config/set-editor! :cursor)
     (with-frame capture-frame
       (rf/dispatch-sync [:rf.story/open-in-editor
                          {:file "src/x.cljs" :line 10}]))
@@ -706,7 +706,7 @@
             forbidden script scheme produces a fx with nil :uri (which
             `open!` is a no-op for); the handler doesn't short-circuit"
     (install-with-capture!)
-    (config/set-editor! {:custom "javascript:alert(1)"})
+    (rf.story.config/set-editor! {:custom "javascript:alert(1)"})
     (with-frame capture-frame
       (rf/dispatch-sync [:rf.story/open-in-editor
                          {:file "src/x.cljs" :line 1}]))
@@ -739,9 +739,9 @@
             would still pass and only this one would red — which is the
             whole point of it being here."
     (ensure-adapter!)
-    (open-in-editor/install!)
+    (rf.story.ui.open-in-editor/install!)
     (assert-production-registration!)
-    (config/set-editor! :vscode)
+    (rf.story.config/set-editor! :vscode)
     (rf/make-frame {:id  :story.open-in-editor/production
                     :doc "no-override frame — drives the REAL effect"})
     (let [[nav calls] (capturing-navigator)]
@@ -766,40 +766,40 @@
 (deftest endpoint-url-carries-coord-and-editor-hint
   (testing "rf2-wn3bh — `build-url` projects (coord, editor) to the
             endpoint query"
-    (is (= (str open-endpoint/endpoint-path
+    (is (= (str rf.source-coords.open-endpoint/endpoint-path
                 "?file=panel_gallery%2Ffoo.cljs&line=42&column=7&editor=cursor")
-           (open-endpoint/build-url
+           (rf.source-coords.open-endpoint/build-url
              {:file "panel_gallery/foo.cljs" :line 42 :column 7}
              :cursor)))
-    (is (nil? (open-endpoint/build-url {:line 1} :vscode))
+    (is (nil? (rf.source-coords.open-endpoint/build-url {:line 1} :vscode))
         "no :file → no endpoint URL")))
 
 (deftest open-coord-prefers-endpoint-when-it-succeeds
   (testing "rf2-wn3bh — when the endpoint launcher reports success, the URI
             fallback does NOT fire"
     (let [[nav calls] (capturing-navigator)
-          prev        (open-endpoint/set-launcher! (fn [_url _fallback!] nil))]
+          prev        (rf.source-coords.open-endpoint/set-launcher! (fn [_url _fallback!] nil))]
       (try
         (with-stub-navigator nav
-          #(open-in-editor/open-coord! {:file "src/x.cljs" :line 1}))
+          #(rf.story.ui.open-in-editor/open-coord! {:file "src/x.cljs" :line 1}))
         (is (= [] @calls)
             "endpoint preferred → no editor:// URI navigation")
         (finally
-          (open-endpoint/set-launcher! prev))))))
+          (rf.source-coords.open-endpoint/set-launcher! prev))))))
 
 (deftest open-coord-falls-back-to-uri-when-no-endpoint
   (testing "rf2-wn3bh — when the launcher invokes the fallback (no dev
             server), the `editor://` URI navigates via the navigator seam"
-    (config/set-editor! :vscode)
+    (rf.story.config/set-editor! :vscode)
     (let [[nav calls] (capturing-navigator)
-          prev        (open-endpoint/set-launcher! always-fall-back!)]
+          prev        (rf.source-coords.open-endpoint/set-launcher! always-fall-back!)]
       (try
         (with-stub-navigator nav
-          #(open-in-editor/open-coord! {:file "src/x.cljs" :line 9 :column 2}))
+          #(rf.story.ui.open-in-editor/open-coord! {:file "src/x.cljs" :line 9 :column 2}))
         (is (= ["vscode://file/src/x.cljs:9:2"] @calls)
             "no dev server → URI fallback navigates exactly as before")
         (finally
-          (open-endpoint/set-launcher! prev))))))
+          (rf.source-coords.open-endpoint/set-launcher! prev))))))
 
 ;; ---- rf2-3xq1v — a real Story coordinate through a 422 decline -----------
 ;;
@@ -845,22 +845,22 @@
       (str/replace #":\d+:\d+$" "")))
 
 (deftest endpoint-422-falls-back-to-an-absolute-uri-for-a-real-story-coord
-  (testing "rf2-3xq1v — a real `story/reg-story` coordinate, stamped by this
+  (testing "rf2-3xq1v — a real `rf.story/reg-story` coordinate, stamped by this
             compile, reaches the editor through the 422 fallback as an
             ABSOLUTE path"
-    (story/reg-story :story.source-coords.cljs-pin
+    (rf.story/reg-story :story.source-coords.cljs-pin
       {:doc "rf2-3xq1v fixture — this form's own coordinate is the subject."})
-    (let [coord (:source (story/handler-meta :story :story.source-coords.cljs-pin))]
+    (let [coord (:source (rf.story/handler-meta :story :story.source-coords.cljs-pin))]
       (is (some? coord) "the registration carries a :source coord at all")
       (is (some? (:file coord)) "and that coord carries a :file")
-      (is (editor-uri/absolute-path? (:file coord))
+      (is (rf.source-coords.editor-uri/absolute-path? (:file coord))
           (str "the macro must bake an ABSOLUTE :file at expansion — got "
                (pr-str (:file coord))))
       (is (str/ends-with? (str/replace (:file coord) "\\" "/")
                           "re_frame/story_open_in_editor_cljs_test.cljs")
           "and it must still end in the classpath-relative tail it started as")
-      (config/set-editor! :windsurf)
-      (config/set-project-root! nil)
+      (rf.story.config/set-editor! :windsurf)
+      (rf.story.config/set-project-root! nil)
       (async done
         ;; The navigator stub is installed for the whole ASYNC duration, not
         ;; just the synchronous call: `fetch-launcher!` runs `fallback!` in a
@@ -871,22 +871,22 @@
         (let [[nav calls]  (capturing-navigator)
               pending      (atom nil)
               orig-fetch   (.-fetch js/globalThis)
-              prev-nav     (open-in-editor/set-navigator! nav)
-              prev-launch  (open-endpoint/set-launcher!
+              prev-nav     (rf.story.ui.open-in-editor/set-navigator! nav)
+              prev-launch  (rf.source-coords.open-endpoint/set-launcher!
                              (fn [url fallback!]
                                ;; The REAL launcher; the atom only lets the
                                ;; async test await the decision.
                                (reset! pending
-                                       (open-endpoint/fetch-launcher! url fallback!))))
+                                       (rf.source-coords.open-endpoint/fetch-launcher! url fallback!))))
               restore!     (fn []
                              (set! (.-fetch js/globalThis) orig-fetch)
-                             (open-endpoint/set-launcher! prev-launch)
-                             (open-in-editor/set-navigator! prev-nav)
-                             (config/set-editor! :vscode))]
+                             (rf.source-coords.open-endpoint/set-launcher! prev-launch)
+                             (rf.story.ui.open-in-editor/set-navigator! prev-nav)
+                             (rf.story.config/set-editor! :vscode))]
           (set! (.-fetch js/globalThis)
                 (fn [_url _opts]
                   (js/Promise.resolve #js {:ok false :status 422})))
-          (open-in-editor/open-coord! coord)
+          (rf.story.ui.open-in-editor/open-coord! coord)
           ;; Bind the launcher's promise to a LOCAL before threading. A
           ;; multi-step form in the `->` head (an `or`, say) is lowered by the
           ;; compiler to an awaited async IIFE — the rf2-i3dvj shape — and the
@@ -908,7 +908,7 @@
                                  path (strip-uri-position uri)]
                              (is (str/starts-with? uri "windsurf://file/")
                                  "the fallback is the historic editor:// URI path")
-                             (is (editor-uri/absolute-path? path)
+                             (is (rf.source-coords.editor-uri/absolute-path? path)
                                  (str "the URI the editor receives must name an "
                                       "ABSOLUTE path — got " (pr-str path)))
                              (is (not (str/starts-with? path "re_frame/"))
@@ -927,14 +927,14 @@
             external / static / non-shadow hosts, and stays inert over a
             coordinate the macro already absolutised: `compose-path` passes an
             absolute `:file` through rather than double-prefixing it"
-    (story/reg-story :story.source-coords.cljs-root-pin
+    (rf.story/reg-story :story.source-coords.cljs-root-pin
       {:doc "rf2-3xq1v fixture — same coordinate, two project-root settings."})
-    (let [coord (:source (story/handler-meta :story :story.source-coords.cljs-root-pin))]
-      (config/set-editor! :windsurf)
-      (config/set-project-root! nil)
-      (let [bare (open-in-editor/resolve-uri coord)]
-        (config/set-project-root! "/some/external/root")
-        (is (= bare (open-in-editor/resolve-uri coord))
+    (let [coord (:source (rf.story/handler-meta :story :story.source-coords.cljs-root-pin))]
+      (rf.story.config/set-editor! :windsurf)
+      (rf.story.config/set-project-root! nil)
+      (let [bare (rf.story.ui.open-in-editor/resolve-uri coord)]
+        (rf.story.config/set-project-root! "/some/external/root")
+        (is (= bare (rf.story.ui.open-in-editor/resolve-uri coord))
             "an absolute :file is not re-rooted by the knob")
-        (config/set-project-root! nil)
-        (config/set-editor! :vscode)))))
+        (rf.story.config/set-project-root! nil)
+        (rf.story.config/set-editor! :vscode)))))

--- a/tools/story/test/re_frame/story_panels_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_panels_cljs_test.cljs
@@ -7,20 +7,20 @@
   registry."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story :as story]
-            [re-frame.story.ui.a11y :as a11y]
-            [re-frame.story.ui.panels :as panels]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.ui.a11y :as rf.story.ui.a11y]
+            [re-frame.story.ui.panels :as rf.story.ui.panels]))
 
 (defn reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -28,31 +28,31 @@
 
 (deftest v1-panels-registered
   (testing "Stage 6 ships the v1.0 story-panel registrations"
-    (let [ps (story/registrations :story-panel)]
-      (is (contains? ps a11y/panel-id))
-      (is (contains? ps panels/layout-debug-panel-id)))))
+    (let [ps (rf.story/registrations :story-panel)]
+      (is (contains? ps rf.story.ui.a11y/panel-id))
+      (is (contains? ps rf.story.ui.panels/layout-debug-panel-id)))))
 
 (deftest layout-debug-panel-body
   (testing "layout-debug panel registers as :right placement"
-    (let [body (story/handler-meta :story-panel panels/layout-debug-panel-id)]
+    (let [body (rf.story/handler-meta :story-panel rf.story.ui.panels/layout-debug-panel-id)]
       (is (= :right (:placement body)))
-      (is (= panels/layout-debug-render-id (:render body))))))
+      (is (= rf.story.ui.panels/layout-debug-render-id (:render body))))))
 
 ;; ---- placement-host enumeration ----------------------------------------
 
 (deftest render-panels-at-placement-returns-hiccup
   (testing "render-panels-at-placement returns a hiccup vector"
-    (let [out (panels/render-panels-at-placement
+    (let [out (rf.story.ui.panels/render-panels-at-placement
                 :right :story.x/y {})]
       (is (vector? out))
       (is (= :div (first out))))))
 
 (deftest render-panels-respects-visibility-false
   (testing "explicit panel-visibility false hides a panel"
-    (let [out-visible (panels/render-panels-at-placement
+    (let [out-visible (rf.story.ui.panels/render-panels-at-placement
                        :right :story.x/y {})
-          out-hidden  (panels/render-panels-at-placement
-                       :right :story.x/y {a11y/panel-id false})]
+          out-hidden  (rf.story.ui.panels/render-panels-at-placement
+                       :right :story.x/y {rf.story.ui.a11y/panel-id false})]
       ;; Both return vectors; the hidden form contains fewer slots.
       (is (vector? out-visible))
       (is (vector? out-hidden)))))
@@ -62,16 +62,16 @@
 
 (deftest render-panels-respects-for-parent-story-scope
   (testing "a panel :for parent story appears for child variants only"
-    (story/reg-story-panel :Panel.scope/notes
+    (rf.story/reg-story-panel :Panel.scope/notes
       {:title "Scoped"
        :placement :right
        :render :Panel.scope/missing-view
        :for #{:story.scope}})
     (let [scoped (rendered-panel-text
-                   (panels/render-panels-at-placement
+                   (rf.story.ui.panels/render-panels-at-placement
                      :right :story.scope/child {}))
           other  (rendered-panel-text
-                   (panels/render-panels-at-placement
+                   (rf.story.ui.panels/render-panels-at-placement
                      :right :story.other/child {}))]
       (is (re-find #":Panel\.scope/notes" scoped)
           "parent-story :for scope must include child variants")
@@ -80,16 +80,16 @@
 
 (deftest render-panels-respects-for-exact-variant-scope
   (testing "a panel :for exact variant appears only for that variant frame"
-    (story/reg-story-panel :Panel.scope/exact
+    (rf.story/reg-story-panel :Panel.scope/exact
       {:title "Exact"
        :placement :right
        :render :Panel.scope/missing-view
        :for #{:story.scope/exact}})
     (let [exact (rendered-panel-text
-                  (panels/render-panels-at-placement
+                  (rf.story.ui.panels/render-panels-at-placement
                     :right :story.scope/exact {}))
           sibling (rendered-panel-text
-                    (panels/render-panels-at-placement
+                    (rf.story.ui.panels/render-panels-at-placement
                       :right :story.scope/sibling {}))]
       (is (re-find #":Panel\.scope/exact" exact)
           "exact variant :for scope must include that frame")
@@ -100,9 +100,9 @@
 
 (deftest layout-debug-toggle-roundtrip
   (testing "toggle-layout-debug! flips a decorator on/off per variant"
-    (panels/toggle-layout-debug! :story.x/y :rf.story/layout-debug.outline)
-    (is (contains? (panels/active-layout-debug-decorators :story.x/y)
+    (rf.story.ui.panels/toggle-layout-debug! :story.x/y :rf.story/layout-debug.outline)
+    (is (contains? (rf.story.ui.panels/active-layout-debug-decorators :story.x/y)
                    :rf.story/layout-debug.outline))
-    (panels/toggle-layout-debug! :story.x/y :rf.story/layout-debug.outline)
-    (is (not (contains? (panels/active-layout-debug-decorators :story.x/y)
+    (rf.story.ui.panels/toggle-layout-debug! :story.x/y :rf.story/layout-debug.outline)
+    (is (not (contains? (rf.story.ui.panels/active-layout-debug-decorators :story.x/y)
                         :rf.story/layout-debug.outline)))))

--- a/tools/story/test/re_frame/story_play_test.clj
+++ b/tools/story/test/re_frame/story_play_test.clj
@@ -15,34 +15,34 @@
     vector of event vectors)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.machines         :as machines]
-            [re-frame.registrar        :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story            :as story]
-            [re-frame.story.assertions :as assertions]
-            [re-frame.story.async      :as async]
-            [re-frame.story.config     :as config]
-            [re-frame.story.loaders    :as loaders]
-            [re-frame.story.play       :as play]
-            [re-frame.story.play.runner-events :as runner-events]))
+            [re-frame.frame            :as rf.frame]
+            [re-frame.machines         :as rf.machines]
+            [re-frame.registrar        :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story            :as rf.story]
+            [re-frame.story.assertions :as rf.story.assertions]
+            [re-frame.story.async      :as rf.story.async]
+            [re-frame.story.config     :as rf.story.config]
+            [re-frame.story.loaders    :as rf.story.loaders]
+            [re-frame.story.play       :as rf.story.play]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
 (defn reset-all [test-fn]
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
   (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (config/set-global-args! {})
-  (reset! play/pending-exceptions {})
-  (reset! play/stepper-state      {})
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.config/set-global-args! {})
+  (reset! rf.story.play/pending-exceptions {})
+  (reset! rf.story.play/stepper-state      {})
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (test-fn))
 
 (use-fixtures :each reset-all)
@@ -53,11 +53,11 @@
 
 (deftest execute-play-empty
   (testing "execute-play! against an empty :script resolves to []"
-    (story/reg-variant :story.play/empty {:setup []})
-    (async/deref-blocking (story/run-variant :story.play/empty) 5000)
-    (let [p (play/execute-play! :story.play/empty [])]
-      (is (= [] (async/deref-blocking p 5000))))
-    (story/destroy-variant! :story.play/empty)))
+    (rf.story/reg-variant :story.play/empty {:setup []})
+    (rf.story.async/deref-blocking (rf.story/run-variant :story.play/empty) 5000)
+    (let [p (rf.story.play/execute-play! :story.play/empty [])]
+      (is (= [] (rf.story.async/deref-blocking p 5000))))
+    (rf.story/destroy-variant! :story.play/empty)))
 
 (deftest execute-play-dispatches-in-order
   (testing "play events dispatch in declared order"
@@ -65,20 +65,20 @@
       (rf/reg-event :step/a (fn [{:keys [db]} _] (swap! order conj :a) {:db db}))
       (rf/reg-event :step/b (fn [{:keys [db]} _] (swap! order conj :b) {:db db}))
       (rf/reg-event :step/c (fn [{:keys [db]} _] (swap! order conj :c) {:db db}))
-      (story/reg-variant :story.order/v
+      (rf.story/reg-variant :story.order/v
         {:setup []
          :script [[:dispatch-sync [:step/a]]
                   [:dispatch-sync [:step/b]]
                   [:dispatch-sync [:step/c]]]})
-      (async/deref-blocking (story/run-variant :story.order/v) 5000)
+      (rf.story.async/deref-blocking (rf.story/run-variant :story.order/v) 5000)
       (is (= [:a :b :c] @order)))
-    (story/destroy-variant! :story.order/v)))
+    (rf.story/destroy-variant! :story.order/v)))
 
 (deftest execute-play-mixes-dispatches-and-assertions
   (testing "mixed sequence of regular events + :rf.assert/* events"
     (rf/reg-event :counter/inc
       (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-    (story/reg-variant :story.mix/v
+    (rf.story/reg-variant :story.mix/v
       {:setup []
        :script [[:dispatch-sync [:counter/inc]]
                 [:dispatch-sync [:rf.assert/path-equals [:n] 1]]
@@ -86,28 +86,28 @@
                 [:dispatch-sync [:rf.assert/path-equals [:n] 2]]
                 [:dispatch-sync [:counter/inc]]
                 [:dispatch-sync [:rf.assert/path-equals [:n] 3]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.mix/v) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.mix/v) 5000)]
       (is (= 3 (count (:assertions r))))
       (is (every? :passed? (:assertions r)))
       (is (= 3 (-> r :app-db :n))))
-    (story/destroy-variant! :story.mix/v)))
+    (rf.story/destroy-variant! :story.mix/v)))
 
 (deftest execute-play-exception-records-phase-4
   (testing "an exception in a play event is captured + the script keeps walking"
     (rf/reg-event :boom/now
       (fn [_ _] (throw (ex-info "boom" {:cause :test}))))
-    (story/reg-variant :story.boom/v
+    (rf.story/reg-variant :story.boom/v
       {:setup []
        :script [[:dispatch-sync [:boom/now]]
                 [:dispatch-sync [:rf.assert/path-equals [:after] :ok]]]})
-    (let [result (async/deref-blocking (story/run-variant :story.boom/v) 5000)]
+    (let [result (rf.story.async/deref-blocking (rf.story/run-variant :story.boom/v) 5000)]
       ;; rf2-z2dq8 (:play -> :script): re-frame's router catches the
       ;; handler exception and emits a `:rf.error/handler-exception`
       ;; trace event; the per-frame trace listener captures it, and the
       ;; runner-events driver drains it into `:rf.story/assertions` as a
       ;; `:rf.error/exception` record. The runner sees the dispatch-sync
       ;; return cleanly and continues; both steps walk.
-      (let [state (runner-events/current-state :story.boom/v)]
+      (let [state (rf.story.play.runner-events/current-state :story.boom/v)]
         (is (some #(and (= :rf.error/exception (:assertion %))
                         (= :phase-4-play (:phase %))
                         (= [:boom/now] (:event %)))
@@ -117,7 +117,7 @@
         ;; steps' results regardless of the handler exception.
         (is (= 2 (count (:results state)))
             "both play-script steps walked even after the handler threw")))
-    (story/destroy-variant! :story.boom/v)))
+    (rf.story/destroy-variant! :story.boom/v)))
 
 ;; ===========================================================================
 ;; The trace-bus accumulators clear at play start
@@ -126,17 +126,17 @@
 (deftest accumulators-reset-per-run
   (testing "trace-bus accumulators reset at the start of each play run"
     (rf/reg-event :do/work (fn [{:keys [db]} _] {:db (assoc db :did? true)}))
-    (story/reg-variant :story.reset/v
+    (rf.story/reg-variant :story.reset/v
       {:setup []
        :script [[:dispatch-sync [:do/work]]
                 [:dispatch-sync [:rf.assert/dispatched? [:do/work]]]]})
-    (async/deref-blocking (story/run-variant :story.reset/v) 5000)
+    (rf.story.async/deref-blocking (rf.story/run-variant :story.reset/v) 5000)
     ;; The first run's dispatched-events accumulator must NOT leak into
     ;; the second run — reset-variant tears the frame down + re-runs.
-    (let [r2 (async/deref-blocking (story/reset-variant :story.reset/v) 5000)]
+    (let [r2 (rf.story.async/deref-blocking (rf.story/reset-variant :story.reset/v) 5000)]
       (is (true? (-> r2 :assertions first :passed?))
           "second run's accumulator only sees that run's events"))
-    (story/destroy-variant! :story.reset/v)))
+    (rf.story/destroy-variant! :story.reset/v)))
 
 ;; ===========================================================================
 ;; rf2-ee38b.3 — framework :db / :fx fx-ids are excluded from :emitted-fx
@@ -149,18 +149,18 @@
     ;; A plain event that returns {:db ...} — emits the framework :db fx
     ;; but no user fx-id.
     (rf/reg-event :ee/touch (fn [{:keys [db]} _] {:db (assoc db :touched? true)}))
-    (story/reg-variant :story.ee/db
+    (rf.story/reg-variant :story.ee/db
       {:setup []
        :script [[:dispatch-sync [:ee/touch]]
                      [:dispatch-sync [:rf.assert/effect-emitted :db]]]})
-    (let [result (async/deref-blocking (story/run-variant :story.ee/db) 5000)
+    (let [result (rf.story.async/deref-blocking (rf.story/run-variant :story.ee/db) 5000)
           ee-rec (first (filter #(= :rf.assert/effect-emitted (:assertion %))
                                 (:assertions result)))]
       (is (some? ee-rec) "the effect-emitted assertion recorded")
       (is (false? (:passed? ee-rec))
           ":db is excluded from :emitted-fx, so the assertion fails (was
            vacuously true before rf2-ee38b.3)"))
-    (story/destroy-variant! :story.ee/db)))
+    (rf.story/destroy-variant! :story.ee/db)))
 
 ;; ===========================================================================
 ;; Frame teardown clears per-frame accumulator entries
@@ -172,12 +172,12 @@
 
 (deftest teardown-clears-accumulators
   (testing "destroy-variant! clears the per-frame pending-exceptions slot"
-    (story/reg-variant :story.tear/v
+    (rf.story/reg-variant :story.tear/v
       {:setup []
        :script [[:dispatch-sync [:rf.assert/path-equals [:x] :nope]]]})
-    (async/deref-blocking (story/run-variant :story.tear/v) 5000)
-    (story/destroy-variant! :story.tear/v)
-    (is (not (contains? @play/pending-exceptions :story.tear/v)))))
+    (rf.story.async/deref-blocking (rf.story/run-variant :story.tear/v) 5000)
+    (rf.story/destroy-variant! :story.tear/v)
+    (is (not (contains? @rf.story.play/pending-exceptions :story.tear/v)))))
 
 ;; ===========================================================================
 ;; Play stepper
@@ -189,28 +189,28 @@
             bare event vector)"
     (rf/reg-event :step/one (fn [{:keys [db]} _] {:db (assoc db :one? true)}))
     (rf/reg-event :step/two (fn [{:keys [db]} _] {:db (assoc db :two? true)}))
-    (story/reg-variant :story.stepper/v
+    (rf.story/reg-variant :story.stepper/v
       {:setup []
        :script [[:dispatch-sync [:step/one]]
                 [:dispatch-sync [:step/two]]]})
     ;; Run the variant phases 1-3; the play stepper takes over phase 4.
-    (let [decorator-stack (story/resolve-decorators :story.stepper/v)]
+    (let [decorator-stack (rf.story/resolve-decorators :story.stepper/v)]
       (re-frame.story.frames/allocate! :story.stepper/v decorator-stack)
-      (loaders/start-loaders! :story.stepper/v)
-      (loaders/finish-loaders! :story.stepper/v)
-      (play/begin-stepper! :story.stepper/v)
-      (is (play/play-stepper-active? :story.stepper/v))
-      (let [s1 (play/step-once! :story.stepper/v)]
+      (rf.story.loaders/start-loaders! :story.stepper/v)
+      (rf.story.loaders/finish-loaders! :story.stepper/v)
+      (rf.story.play/begin-stepper! :story.stepper/v)
+      (is (rf.story.play/play-stepper-active? :story.stepper/v))
+      (let [s1 (rf.story.play/step-once! :story.stepper/v)]
         (is (= [:dispatch-sync [:step/one]] s1))
         (is (true? (-> (rf/app-db-value :story.stepper/v) :one?))))
-      (let [s2 (play/step-once! :story.stepper/v)]
+      (let [s2 (rf.story.play/step-once! :story.stepper/v)]
         (is (= [:dispatch-sync [:step/two]] s2))
         (is (true? (-> (rf/app-db-value :story.stepper/v) :two?))))
       ;; Stepper exhausted.
-      (is (nil? (play/step-once! :story.stepper/v)))
-      (play/end-stepper! :story.stepper/v)
-      (is (not (play/play-stepper-active? :story.stepper/v)))
-      (story/destroy-variant! :story.stepper/v))))
+      (is (nil? (rf.story.play/step-once! :story.stepper/v)))
+      (rf.story.play/end-stepper! :story.stepper/v)
+      (is (not (rf.story.play/play-stepper-active? :story.stepper/v)))
+      (rf.story/destroy-variant! :story.stepper/v))))
 
 (deftest play-stepper-walks-every-step-type
   (testing "rf2-ee38b.3 / rf2-5x1wt.19: the step-debugger walks ALL step
@@ -223,7 +223,7 @@
             so the recorded step type is :assert and the slot record carries
             the canonical :rf.assert/path-equals (no synthetic :rf.assert/db)."
     (rf/reg-event :st/set-n (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
-    (story/reg-variant :story.stepper/full
+    (rf.story/reg-variant :story.stepper/full
       {:setup []
        :script {:auto-run? false
                      :script    [[:dispatch-sync [:st/set-n 5]]
@@ -232,18 +232,18 @@
                                  [:assert-db [:n] 99]             ; fail
                                  [:assert-dom "div.x" :visible]   ; skip (no DOM)
                                  [:click "button.y"]]}})          ; fail (no DOM)
-    (let [decorator-stack (story/resolve-decorators :story.stepper/full)]
+    (let [decorator-stack (rf.story/resolve-decorators :story.stepper/full)]
       (re-frame.story.frames/allocate! :story.stepper/full decorator-stack)
-      (loaders/start-loaders! :story.stepper/full)
-      (loaders/finish-loaders! :story.stepper/full)
-      (play/begin-stepper! :story.stepper/full)
+      (rf.story.loaders/start-loaders! :story.stepper/full)
+      (rf.story.loaders/finish-loaders! :story.stepper/full)
+      (rf.story.play/begin-stepper! :story.stepper/full)
       ;; The substrate seeds the FULL six-step folded script.
-      (is (= 6 (count (:remaining (get @play/stepper-state :story.stepper/full))))
+      (is (= 6 (count (:remaining (get @rf.story.play/stepper-state :story.stepper/full))))
           "all six steps (incl. :wait / :assert-* / :click) are queued")
       ;; Walk every step.
-      (dotimes [_ 6] (play/step-once! :story.stepper/full))
-      (is (nil? (play/step-once! :story.stepper/full)) "exhausted after six steps")
-      (let [results (:results (get @play/stepper-state :story.stepper/full))]
+      (dotimes [_ 6] (rf.story.play/step-once! :story.stepper/full))
+      (is (nil? (rf.story.play/step-once! :story.stepper/full)) "exhausted after six steps")
+      (let [results (:results (get @rf.story.play/stepper-state :story.stepper/full))]
         (is (= 6 (count results)) "one result recorded per step")
         (is (= :dispatch-sync (:type (nth results 0))))
         (is (= :wait          (:type (nth results 1))))
@@ -256,14 +256,14 @@
         (is (:skipped? (nth results 4)) ":assert-dom records :skipped? (no DOM)"))
       ;; The failing :assert-db landed in the :rf.story/assertions slot as
       ;; the CANONICAL :rf.assert/path-equals record (rf2-5x1wt.19).
-      (let [slot (story/read-assertions :story.stepper/full)]
+      (let [slot (rf.story/read-assertions :story.stepper/full)]
         (is (some (fn [r] (and (= :rf.assert/path-equals (:assertion r))
                                (false? (:passed? r))))
                   slot)
             "the stepped folded :assert-db failure reached the slot as the
              canonical :rf.assert/path-equals record"))
-      (play/end-stepper! :story.stepper/full)
-      (story/destroy-variant! :story.stepper/full))))
+      (rf.story.play/end-stepper! :story.stepper/full)
+      (rf.story/destroy-variant! :story.stepper/full))))
 
 ;; ===========================================================================
 ;; Stepper guards on a never-begun frame — rf2-booyu CORRECTNESS
@@ -281,44 +281,44 @@
   (testing "stepper-rewind! against a frame with no stepper session is a
             no-op — it does NOT insert a nil entry that would flip
             play-stepper-active? to true (rf2-booyu)"
-    (is (not (play/play-stepper-active? :story.stepper/never)))
-    (play/stepper-rewind! :story.stepper/never)
-    (is (not (play/play-stepper-active? :story.stepper/never))
+    (is (not (rf.story.play/play-stepper-active? :story.stepper/never)))
+    (rf.story.play/stepper-rewind! :story.stepper/never)
+    (is (not (rf.story.play/play-stepper-active? :story.stepper/never))
         "rewind on a never-begun frame leaves the stepper inactive")
-    (is (not (contains? @play/stepper-state :story.stepper/never))
+    (is (not (contains? @rf.story.play/stepper-state :story.stepper/never))
         "no {frame-id nil} entry was inserted into stepper-state")))
 
 (deftest stepper-step-back-on-never-begun-frame-does-not-activate
   (testing "stepper-step-back! against a frame with no stepper session is a
             no-op — same nil-entry pollution guard as rewind (rf2-booyu)"
-    (is (not (play/play-stepper-active? :story.stepper/never2)))
-    (play/stepper-step-back! :story.stepper/never2)
-    (is (not (play/play-stepper-active? :story.stepper/never2))
+    (is (not (rf.story.play/play-stepper-active? :story.stepper/never2)))
+    (rf.story.play/stepper-step-back! :story.stepper/never2)
+    (is (not (rf.story.play/play-stepper-active? :story.stepper/never2))
         "step-back on a never-begun frame leaves the stepper inactive")
-    (is (not (contains? @play/stepper-state :story.stepper/never2))
+    (is (not (contains? @rf.story.play/stepper-state :story.stepper/never2))
         "no {frame-id nil} entry was inserted into stepper-state")))
 
 (deftest stepper-rewind-still-rewinds-an-active-session
   (testing "the guard does not break the real path — rewind on an ACTIVE
             session still resets the cursor (every step back to :remaining)"
     (rf/reg-event :rw/one (fn [{:keys [db]} _] {:db (assoc db :one? true)}))
-    (story/reg-variant :story.stepper/rw
+    (rf.story/reg-variant :story.stepper/rw
       {:setup []
        :script [[:dispatch-sync [:rw/one]]
                      [:dispatch-sync [:rw/one]]]})
-    (let [decorator-stack (story/resolve-decorators :story.stepper/rw)]
+    (let [decorator-stack (rf.story/resolve-decorators :story.stepper/rw)]
       (re-frame.story.frames/allocate! :story.stepper/rw decorator-stack)
-      (loaders/start-loaders! :story.stepper/rw)
-      (loaders/finish-loaders! :story.stepper/rw)
-      (play/begin-stepper! :story.stepper/rw)
-      (play/step-once! :story.stepper/rw)
-      (is (= 1 (count (:ran (get @play/stepper-state :story.stepper/rw)))))
-      (play/stepper-rewind! :story.stepper/rw)
-      (let [s (get @play/stepper-state :story.stepper/rw)]
+      (rf.story.loaders/start-loaders! :story.stepper/rw)
+      (rf.story.loaders/finish-loaders! :story.stepper/rw)
+      (rf.story.play/begin-stepper! :story.stepper/rw)
+      (rf.story.play/step-once! :story.stepper/rw)
+      (is (= 1 (count (:ran (get @rf.story.play/stepper-state :story.stepper/rw)))))
+      (rf.story.play/stepper-rewind! :story.stepper/rw)
+      (let [s (get @rf.story.play/stepper-state :story.stepper/rw)]
         (is (= [] (:ran s))      "rewind emptied :ran")
         (is (= 2 (count (:remaining s))) "every step back to :remaining"))
-      (play/end-stepper! :story.stepper/rw)
-      (story/destroy-variant! :story.stepper/rw))))
+      (rf.story.play/end-stepper! :story.stepper/rw)
+      (rf.story/destroy-variant! :story.stepper/rw))))
 
 ;; ===========================================================================
 ;; :loaders-complete-when non-default forms — Stage 5 (rf2-h8et)
@@ -333,32 +333,32 @@
         {:db (assoc db :rf.story/loaders-complete? (boolean (:loaded? db)))}))
     (rf/reg-event :test/mark-loaded
       (fn [{:keys [db]} _] {:db (assoc db :loaded? true)}))
-    (story/reg-variant :story.loaders/registered
+    (rf.story/reg-variant :story.loaders/registered
       {:loaders                [[:test/mark-loaded]]
        :loaders-complete-when  :my.fixture/ready?
        :setup                 []})
-    (let [r (async/deref-blocking (story/run-variant :story.loaders/registered) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.loaders/registered) 5000)]
       (is (= :ready (:lifecycle r)))
       (is (true? (-> r :app-db :loaded?))))
-    (story/destroy-variant! :story.loaders/registered)))
+    (rf.story/destroy-variant! :story.loaders/registered)))
 
 (deftest loaders-complete-when-vector
   (testing "vector-of-events form — complete when ALL listed events fired"
     (rf/reg-event :test/load-a (fn [{:keys [db]} _] {:db (assoc db :a? true)}))
     (rf/reg-event :test/load-b (fn [{:keys [db]} _] {:db (assoc db :b? true)}))
-    (story/reg-variant :story.loaders/vector
+    (rf.story/reg-variant :story.loaders/vector
       {:loaders                [[:test/load-a] [:test/load-b]]
        :loaders-complete-when  [[:test/load-a] [:test/load-b]]
        :setup                 []})
     ;; Per rf2-v2g9, the play-runner's trace listener now installs
     ;; before the loader phase, so the dispatched-events accumulator
     ;; observes loader-phase events and the vector predicate can match.
-    (let [r (async/deref-blocking (story/run-variant :story.loaders/vector) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.loaders/vector) 5000)]
       (is (true? (-> r :app-db :a?)))
       (is (true? (-> r :app-db :b?)))
       (is (= :ready (:lifecycle r))
           "vector form's loaders-complete-when fires once both loaders run, transitioning the lifecycle to :ready"))
-    (story/destroy-variant! :story.loaders/vector)))
+    (rf.story/destroy-variant! :story.loaders/vector)))
 
 (deftest loaders-complete-when-vector-trace-listener-installed-pre-loaders
   ;; rf2-v2g9 — the play-runner's per-frame trace listener installs
@@ -371,33 +371,33 @@
   (testing "the loaders-complete-when vector form matches loader-phase dispatches"
     (rf/reg-event :fixture/loaded
       (fn [{:keys [db]} _] {:db (assoc db :fixture-loaded? true)}))
-    (story/reg-variant :story.v2g9/loader-vector
+    (rf.story/reg-variant :story.v2g9/loader-vector
       {:loaders               [[:fixture/loaded]]
        :loaders-complete-when [[:fixture/loaded]]
        :setup                []})
-    (let [r (async/deref-blocking
-              (story/run-variant :story.v2g9/loader-vector) 5000)]
+    (let [r (rf.story.async/deref-blocking
+              (rf.story/run-variant :story.v2g9/loader-vector) 5000)]
       (is (true? (-> r :app-db :fixture-loaded?))
           "the loader event ran")
       (is (= :ready (:lifecycle r))
           "the loader phase advanced to :ready — the predicate saw the loader event"))
-    (story/destroy-variant! :story.v2g9/loader-vector)))
+    (rf.story/destroy-variant! :story.v2g9/loader-vector)))
 
 (deftest loaders-complete-when-vector-without-listener-stalls
   ;; rf2-v2g9 / rf2-q651r — negative companion to the fix. The vector form
   ;; reads the epoch-tape dispatched-events projection (the SSOT since
-  ;; rf2-q651r — `assertions/dispatched-events`), NOT the retired
+  ;; rf2-q651r — `rf.story.assertions/dispatched-events`), NOT the retired
   ;; `trace-accumulators` atom. We drive the projection directly via
   ;; with-redefs: an empty projection (no loader epoch yet) → false; once
   ;; the tape carries the required event → true.
   (testing "vector form with an empty tape projection returns false"
     (let [frame-id :story.v2g9/stalled
           body {:loaders-complete-when [[:fixture/loaded]]}]
-      (with-redefs [assertions/dispatched-events (constantly [])]
-        (is (false? (loaders/evaluate-complete-when frame-id body))
+      (with-redefs [rf.story.assertions/dispatched-events (constantly [])]
+        (is (false? (rf.story.loaders/evaluate-complete-when frame-id body))
             "predicate is false when the tape carries no record of the required event"))
-      (with-redefs [assertions/dispatched-events (constantly [[:fixture/loaded]])]
-        (is (true? (loaders/evaluate-complete-when frame-id body))
+      (with-redefs [rf.story.assertions/dispatched-events (constantly [[:fixture/loaded]])]
+        (is (true? (rf.story.loaders/evaluate-complete-when frame-id body))
             "predicate is true once the tape projection carries the loader event")))))
 
 (deftest loaders-complete-when-evaluate-vector-form
@@ -405,11 +405,11 @@
     ;; rf2-q651r — the projection is the SSOT; drive it directly.
     (let [frame-id :story.predfn/vector
           variant-body {:loaders-complete-when [[:fixture/loaded] [:auth/ready]]}]
-      (with-redefs [assertions/dispatched-events (constantly [[:fixture/loaded]])]
-        (is (false? (loaders/evaluate-complete-when frame-id variant-body))
+      (with-redefs [rf.story.assertions/dispatched-events (constantly [[:fixture/loaded]])]
+        (is (false? (rf.story.loaders/evaluate-complete-when frame-id variant-body))
             "missing one of the required events — predicate is false"))
-      (with-redefs [assertions/dispatched-events (constantly [[:fixture/loaded] [:auth/ready]])]
-        (is (true? (loaders/evaluate-complete-when frame-id variant-body))
+      (with-redefs [rf.story.assertions/dispatched-events (constantly [[:fixture/loaded] [:auth/ready]])]
+        (is (true? (rf.story.loaders/evaluate-complete-when frame-id variant-body))
             "both events observed — predicate is true")))))
 
 (deftest loaders-complete-when-fn-form
@@ -419,7 +419,7 @@
                                                  (boolean (:done? db)))}]
       (rf/make-frame {:id frame-id})
       (try
-        (is (false? (loaders/evaluate-complete-when frame-id variant-body)))
+        (is (false? (rf.story.loaders/evaluate-complete-when frame-id variant-body)))
         (rf/dispatch-sync [::set-done] {:frame frame-id})
         (finally
           (rf/destroy-frame! frame-id))))))

--- a/tools/story/test/re_frame/story_recorder_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_recorder_cljs_test.cljs
@@ -14,12 +14,12 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [cljs.reader :as edn]
             [clojure.string :as str]
-            [re-frame.story.recorder :as recorder]))
+            [re-frame.story.recorder :as rf.story.recorder]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-recorder! [f]
-  (recorder/clear!)
+  (rf.story.recorder/clear!)
   (f))
 
 (use-fixtures :each reset-recorder!)
@@ -27,64 +27,64 @@
 ;; ---- recordable-event? ---------------------------------------------------
 
 (deftest recordable-event?-accepts-user-events
-  (is (recorder/recordable-event? [:counter/inc]))
-  (is (recorder/recordable-event? [:auth/login {:email "a@b"}])))
+  (is (rf.story.recorder/recordable-event? [:counter/inc]))
+  (is (rf.story.recorder/recordable-event? [:auth/login {:email "a@b"}])))
 
 (deftest recordable-event?-skips-assertions
-  (is (not (recorder/recordable-event? [:rf.assert/path-equals [:a] 1])))
-  (is (not (recorder/recordable-event? [:rf.assert/no-warnings]))))
+  (is (not (rf.story.recorder/recordable-event? [:rf.assert/path-equals [:a] 1])))
+  (is (not (rf.story.recorder/recordable-event? [:rf.assert/no-warnings]))))
 
 (deftest recordable-event?-skips-internal-story-events
-  (is (not (recorder/recordable-event? [:rf.story/lifecycle-tick])))
-  (is (not (recorder/recordable-event?
+  (is (not (rf.story.recorder/recordable-event? [:rf.story/lifecycle-tick])))
+  (is (not (rf.story.recorder/recordable-event?
              [:re-frame.story.runtime/append-assertion {}]))))
 
 ;; ---- pure state machine --------------------------------------------------
 
 (deftest start-replaces-state
-  (let [s (recorder/start recorder/initial-state :story.x/y 1000)]
+  (let [s (rf.story.recorder/start rf.story.recorder/initial-state :story.x/y 1000)]
     (is (:recording? s))
     (is (= :story.x/y (:variant-id s)))
     (is (= [] (:events s)))))
 
 (deftest append-captures-recordable-events
-  (let [s0 (recorder/start recorder/initial-state :story.x/y 0)
+  (let [s0 (rf.story.recorder/start rf.story.recorder/initial-state :story.x/y 0)
         s1 (-> s0
-               (recorder/append [:counter/inc])
-               (recorder/append [:rf.assert/path-equals [:a] 1])
-               (recorder/append [:counter/dec]))]
+               (rf.story.recorder/append [:counter/inc])
+               (rf.story.recorder/append [:rf.assert/path-equals [:a] 1])
+               (rf.story.recorder/append [:counter/dec]))]
     (is (= [[:counter/inc] [:counter/dec]] (:events s1)))))
 
 (deftest stop-preserves-events
-  (let [s (-> recorder/initial-state
-              (recorder/start :story.x/y 0)
-              (recorder/append [:counter/inc])
-              (recorder/stop))]
+  (let [s (-> rf.story.recorder/initial-state
+              (rf.story.recorder/start :story.x/y 0)
+              (rf.story.recorder/append [:counter/inc])
+              (rf.story.recorder/stop))]
     (is (not (:recording? s)))
     (is (= [[:counter/inc]] (:events s)))))
 
 ;; ---- impure entrypoints --------------------------------------------------
 
 (deftest start-and-stop-cycle
-  (recorder/start-recording! :story.x/y 0)
-  (is (recorder/recording?))
-  (recorder/record-event! [:counter/inc])
-  (recorder/record-event! [:counter/dec])
-  (recorder/stop-recording!)
-  (is (not (recorder/recording?)))
+  (rf.story.recorder/start-recording! :story.x/y 0)
+  (is (rf.story.recorder/recording?))
+  (rf.story.recorder/record-event! [:counter/inc])
+  (rf.story.recorder/record-event! [:counter/dec])
+  (rf.story.recorder/stop-recording!)
+  (is (not (rf.story.recorder/recording?)))
   (is (= [[:counter/inc] [:counter/dec]]
-         (recorder/recorded-events))))
+         (rf.story.recorder/recorded-events))))
 
 (deftest toggle!-flips
-  (recorder/toggle! :story.x/y)
-  (is (recorder/recording?))
-  (recorder/toggle! :story.x/y)
-  (is (not (recorder/recording?))))
+  (rf.story.recorder/toggle! :story.x/y)
+  (is (rf.story.recorder/recording?))
+  (rf.story.recorder/toggle! :story.x/y)
+  (is (not (rf.story.recorder/recording?))))
 
 ;; ---- gen-play-snippet ----------------------------------------------------
 
 (deftest gen-play-snippet-renders-reg-variant
-  (let [snippet (recorder/gen-play-snippet
+  (let [snippet (rf.story.recorder/gen-play-snippet
                   [[:counter/inc] [:counter/dec]]
                   {:variant-id :story.x/y})]
     (is (str/includes? snippet "reg-variant"))
@@ -95,7 +95,7 @@
 ;; ---- mid-recording assertion insertion (rf2-39u9e) ----------------------
 
 (deftest assertion-vocabulary-covers-canonical-seven
-  (let [ids (set (map :id recorder/assertion-vocabulary))]
+  (let [ids (set (map :id rf.story.recorder/assertion-vocabulary))]
     (is (= #{:rf.assert/path-equals
              :rf.assert/path-matches
              :rf.assert/sub-equals
@@ -107,34 +107,34 @@
 
 (deftest make-assertion-builds-well-formed-events
   (is (= [:rf.assert/path-equals [:auth :status] :ok]
-         (recorder/make-assertion :rf.assert/path-equals
+         (rf.story.recorder/make-assertion :rf.assert/path-equals
                                   {:path [:auth :status] :expected :ok})))
   (is (= [:rf.assert/sub-equals [:counter] 3]
-         (recorder/make-assertion :rf.assert/sub-equals
+         (rf.story.recorder/make-assertion :rf.assert/sub-equals
                                   {:sub [:counter] :expected 3})))
   (is (= [:rf.assert/no-warnings]
-         (recorder/make-assertion :rf.assert/no-warnings {})))
-  (is (nil? (recorder/make-assertion :rf.assert/not-a-real-one {}))))
+         (rf.story.recorder/make-assertion :rf.assert/no-warnings {})))
+  (is (nil? (rf.story.recorder/make-assertion :rf.assert/not-a-real-one {}))))
 
 (deftest insert-assertion!-interleaves-with-recorded-events
-  (recorder/start-recording! :story.x/y 0)
-  (recorder/record-event! [:counter/inc])
-  (recorder/insert-assertion! :rf.assert/sub-equals
+  (rf.story.recorder/start-recording! :story.x/y 0)
+  (rf.story.recorder/record-event! [:counter/inc])
+  (rf.story.recorder/insert-assertion! :rf.assert/sub-equals
                               {:sub [:counter] :expected 1})
-  (recorder/record-event! [:counter/inc])
-  (recorder/insert-assertion! [:rf.assert/no-warnings])
-  (recorder/stop-recording!)
+  (rf.story.recorder/record-event! [:counter/inc])
+  (rf.story.recorder/insert-assertion! [:rf.assert/no-warnings])
+  (rf.story.recorder/stop-recording!)
   (is (= [[:counter/inc]
           [:rf.assert/sub-equals [:counter] 1]
           [:counter/inc]
           [:rf.assert/no-warnings]]
-         (recorder/recorded-events))))
+         (rf.story.recorder/recorded-events))))
 
 (deftest insert-assertion!-rejects-non-assertion
-  (recorder/start-recording! :story.x/y 0)
-  (recorder/insert-assertion! [:counter/inc])
-  (recorder/insert-assertion! [:rf.story/lifecycle-tick])
-  (is (= [] (recorder/recorded-events))))
+  (rf.story.recorder/start-recording! :story.x/y 0)
+  (rf.story.recorder/insert-assertion! [:counter/inc])
+  (rf.story.recorder/insert-assertion! [:rf.story/lifecycle-tick])
+  (is (= [] (rf.story.recorder/recorded-events))))
 
 (defn- extract-play-script-vector
   "Pull the inner `:script` vector substring out of the rendered snippet
@@ -169,7 +169,7 @@
             slot; rf2-0wrud — gen-play-snippet wraps each captured event
             as a :dispatch-sync step)"
     (let [events     [[:counter/inc] [:auth/login {:id 1}]]
-          snip       (recorder/gen-play-snippet events {:variant-id :story.x/y})
+          snip       (rf.story.recorder/gen-play-snippet events {:variant-id :story.x/y})
           script-str (extract-play-script-vector snip)
           script-vec (edn/read-string script-str)]
       (is (some? script-str) "extractor found a :script vector substring")

--- a/tools/story/test/re_frame/story_recorder_test.clj
+++ b/tools/story/test/re_frame/story_recorder_test.clj
@@ -24,22 +24,22 @@
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
+            [re-frame.frame :as rf.frame]
             ;; EP-0015 (rf2-mngp4o): `redact-interceptor` is no longer
             ;; published from `re-frame.core`; it survives as an internal
             ;; helper in its home ns, exercised here directly.
-            [re-frame.privacy :as privacy]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story :as story]
-            [re-frame.story.async :as async]
-            [re-frame.story.recorder :as recorder]
-            [re-frame.story.recorder.play-export :as play-export]))
+            [re-frame.privacy :as rf.privacy]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.async :as rf.story.async]
+            [re-frame.story.recorder :as rf.story.recorder]
+            [re-frame.story.recorder.play-export :as rf.story.recorder.play-export]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-recorder! [f]
-  (recorder/clear!)
+  (rf.story.recorder/clear!)
   (f))
 
 (use-fixtures :each reset-recorder!)
@@ -48,38 +48,38 @@
 
 (deftest recordable-event?-accepts-user-events
   (testing "ordinary user dispatches are recordable"
-    (is (recorder/recordable-event? [:counter/inc]))
-    (is (recorder/recordable-event? [:auth/login {:email "a@b"}]))
-    (is (recorder/recordable-event? [:cart/add-item :widget-x 3]))))
+    (is (rf.story.recorder/recordable-event? [:counter/inc]))
+    (is (rf.story.recorder/recordable-event? [:auth/login {:email "a@b"}]))
+    (is (rf.story.recorder/recordable-event? [:cart/add-item :widget-x 3]))))
 
 (deftest recordable-event?-skips-assertions
   (testing ":rf.assert/* events are filtered (assertions are authored, not recorded)"
-    (is (not (recorder/recordable-event? [:rf.assert/path-equals [:auth :status] :ok])))
-    (is (not (recorder/recordable-event? [:rf.assert/sub-equals [:count] 3])))
-    (is (not (recorder/recordable-event? [:rf.assert/no-warnings])))
-    (is (not (recorder/recordable-event? [:rf.assert/dispatched? [:counter/inc]])))))
+    (is (not (rf.story.recorder/recordable-event? [:rf.assert/path-equals [:auth :status] :ok])))
+    (is (not (rf.story.recorder/recordable-event? [:rf.assert/sub-equals [:count] 3])))
+    (is (not (rf.story.recorder/recordable-event? [:rf.assert/no-warnings])))
+    (is (not (rf.story.recorder/recordable-event? [:rf.assert/dispatched? [:counter/inc]])))))
 
 (deftest recordable-event?-skips-internal-story-events
   (testing ":rf.story/* + re-frame.story.* internal helpers are filtered"
-    (is (not (recorder/recordable-event? [:rf.story/lifecycle-tick])))
-    (is (not (recorder/recordable-event?
+    (is (not (rf.story.recorder/recordable-event? [:rf.story/lifecycle-tick])))
+    (is (not (rf.story.recorder/recordable-event?
                [:re-frame.story.runtime/append-assertion {:a 1}])))
-    (is (not (recorder/recordable-event?
+    (is (not (rf.story.recorder/recordable-event?
                [:re-frame.story.assertions/append {:r 1}])))))
 
 (deftest recordable-event?-handles-malformed-input
   (testing "non-event shapes are rejected"
-    (is (not (recorder/recordable-event? nil)))
-    (is (not (recorder/recordable-event? [])))
-    (is (not (recorder/recordable-event? "not-a-vector")))
-    (is (not (recorder/recordable-event? [{} "no-keyword-id"])))))
+    (is (not (rf.story.recorder/recordable-event? nil)))
+    (is (not (rf.story.recorder/recordable-event? [])))
+    (is (not (rf.story.recorder/recordable-event? "not-a-vector")))
+    (is (not (rf.story.recorder/recordable-event? [{} "no-keyword-id"])))))
 
 ;; ---- pure state machine --------------------------------------------------
 
 (deftest start-replaces-state
   (testing "start! resets events + flips :recording? true"
-    (let [s0 recorder/initial-state
-          s1 (recorder/start s0 :story.counter/happy-path 1000)]
+    (let [s0 rf.story.recorder/initial-state
+          s1 (rf.story.recorder/start s0 :story.counter/happy-path 1000)]
       (is (true? (:recording? s1)))
       (is (= :story.counter/happy-path (:variant-id s1)))
       (is (= [] (:events s1)))
@@ -87,95 +87,95 @@
 
 (deftest start-clobbers-previous-recording
   (testing "starting a fresh recording drops any captured events"
-    (let [s0 (-> recorder/initial-state
-                 (recorder/start :story.a/x 1000)
-                 (recorder/append [:a 1])
-                 (recorder/append [:b 2]))
-          s1 (recorder/start s0 :story.b/y 2000)]
+    (let [s0 (-> rf.story.recorder/initial-state
+                 (rf.story.recorder/start :story.a/x 1000)
+                 (rf.story.recorder/append [:a 1])
+                 (rf.story.recorder/append [:b 2]))
+          s1 (rf.story.recorder/start s0 :story.b/y 2000)]
       (is (= [] (:events s1)))
       (is (= :story.b/y (:variant-id s1))))))
 
 (deftest append-while-recording
   (testing "append captures recordable events while recording"
-    (let [s0 (recorder/start recorder/initial-state :story.counter/x 0)
-          s1 (recorder/append s0 [:counter/inc])
-          s2 (recorder/append s1 [:counter/inc])
-          s3 (recorder/append s2 [:counter/dec])]
+    (let [s0 (rf.story.recorder/start rf.story.recorder/initial-state :story.counter/x 0)
+          s1 (rf.story.recorder/append s0 [:counter/inc])
+          s2 (rf.story.recorder/append s1 [:counter/inc])
+          s3 (rf.story.recorder/append s2 [:counter/dec])]
       (is (= [[:counter/inc] [:counter/inc] [:counter/dec]]
              (:events s3))))))
 
 (deftest append-skips-assertions-and-internals
   (testing "append filters non-recordable events"
-    (let [s0 (recorder/start recorder/initial-state :story.x/y 0)
+    (let [s0 (rf.story.recorder/start rf.story.recorder/initial-state :story.x/y 0)
           s1 (-> s0
-                 (recorder/append [:rf.assert/path-equals [:a] 1])
-                 (recorder/append [:counter/inc])
-                 (recorder/append [:re-frame.story.runtime/append-assertion {}])
-                 (recorder/append [:counter/dec]))]
+                 (rf.story.recorder/append [:rf.assert/path-equals [:a] 1])
+                 (rf.story.recorder/append [:counter/inc])
+                 (rf.story.recorder/append [:re-frame.story.runtime/append-assertion {}])
+                 (rf.story.recorder/append [:counter/dec]))]
       (is (= [[:counter/inc] [:counter/dec]]
              (:events s1))))))
 
 (deftest append-noop-when-not-recording
   (testing "append drops events when :recording? is false"
-    (let [s0 recorder/initial-state
-          s1 (recorder/append s0 [:counter/inc])]
+    (let [s0 rf.story.recorder/initial-state
+          s1 (rf.story.recorder/append s0 [:counter/inc])]
       (is (= [] (:events s1))))))
 
 (deftest stop-preserves-events
   (testing "stop flips :recording? false but keeps the captured trace"
-    (let [s0 (-> recorder/initial-state
-                 (recorder/start :story.x/y 0)
-                 (recorder/append [:counter/inc]))
-          s1 (recorder/stop s0)]
+    (let [s0 (-> rf.story.recorder/initial-state
+                 (rf.story.recorder/start :story.x/y 0)
+                 (rf.story.recorder/append [:counter/inc]))
+          s1 (rf.story.recorder/stop s0)]
       (is (false? (:recording? s1)))
       (is (= [[:counter/inc]] (:events s1)))
       (is (= :story.x/y (:variant-id s1))))))
 
 (deftest reset-returns-idle
   (testing "reset drops everything"
-    (let [s0 (-> recorder/initial-state
-                 (recorder/start :story.x/y 0)
-                 (recorder/append [:counter/inc]))
-          s1 (recorder/reset s0)]
-      (is (= recorder/initial-state s1)))))
+    (let [s0 (-> rf.story.recorder/initial-state
+                 (rf.story.recorder/start :story.x/y 0)
+                 (rf.story.recorder/append [:counter/inc]))
+          s1 (rf.story.recorder/reset s0)]
+      (is (= rf.story.recorder/initial-state s1)))))
 
 ;; ---- impure entrypoints --------------------------------------------------
 
 (deftest start-recording!-mutates-state
-  (recorder/start-recording! :story.counter/x 5000)
-  (is (recorder/recording?))
-  (is (= :story.counter/x (recorder/recording-variant)))
-  (is (= [] (recorder/recorded-events))))
+  (rf.story.recorder/start-recording! :story.counter/x 5000)
+  (is (rf.story.recorder/recording?))
+  (is (= :story.counter/x (rf.story.recorder/recording-variant)))
+  (is (= [] (rf.story.recorder/recorded-events))))
 
 (deftest record-event!-captures-recordable
-  (recorder/start-recording! :story.counter/x 0)
-  (recorder/record-event! [:counter/inc])
-  (recorder/record-event! [:rf.assert/path-equals [:a] 1])
-  (recorder/record-event! [:counter/dec])
+  (rf.story.recorder/start-recording! :story.counter/x 0)
+  (rf.story.recorder/record-event! [:counter/inc])
+  (rf.story.recorder/record-event! [:rf.assert/path-equals [:a] 1])
+  (rf.story.recorder/record-event! [:counter/dec])
   (is (= [[:counter/inc] [:counter/dec]]
-         (recorder/recorded-events))))
+         (rf.story.recorder/recorded-events))))
 
 (deftest stop-recording!-flips-state
-  (recorder/start-recording! :story.x/y 0)
-  (recorder/record-event! [:counter/inc])
-  (recorder/stop-recording!)
-  (is (false? (recorder/recording?)))
-  (is (= [[:counter/inc]] (recorder/recorded-events))))
+  (rf.story.recorder/start-recording! :story.x/y 0)
+  (rf.story.recorder/record-event! [:counter/inc])
+  (rf.story.recorder/stop-recording!)
+  (is (false? (rf.story.recorder/recording?)))
+  (is (= [[:counter/inc]] (rf.story.recorder/recorded-events))))
 
 (deftest toggle!-flips
   (testing "toggle! starts when idle and stops when recording"
-    (recorder/toggle! :story.x/y)
-    (is (recorder/recording?))
-    (recorder/record-event! [:foo/bar])
-    (recorder/toggle! :story.x/y)
-    (is (not (recorder/recording?)))
-    (is (= [[:foo/bar]] (recorder/recorded-events)))))
+    (rf.story.recorder/toggle! :story.x/y)
+    (is (rf.story.recorder/recording?))
+    (rf.story.recorder/record-event! [:foo/bar])
+    (rf.story.recorder/toggle! :story.x/y)
+    (is (not (rf.story.recorder/recording?)))
+    (is (= [[:foo/bar]] (rf.story.recorder/recorded-events)))))
 
 (deftest clear!-resets-everything
-  (recorder/start-recording! :story.x/y 0)
-  (recorder/record-event! [:counter/inc])
-  (recorder/clear!)
-  (is (= recorder/initial-state (recorder/current-state))))
+  (rf.story.recorder/start-recording! :story.x/y 0)
+  (rf.story.recorder/record-event! [:counter/inc])
+  (rf.story.recorder/clear!)
+  (is (= rf.story.recorder/initial-state (rf.story.recorder/current-state))))
 
 ;; ---- gen-play-snippet ----------------------------------------------------
 
@@ -183,7 +183,7 @@
   (testing "gen-play-snippet with no events renders an empty :script
             body vector (rf2-7mj4z — recorder emits the :script
             spelling, never the retired :play-script)"
-    (let [snip (recorder/gen-play-snippet [] {:variant-id :story.x/y})]
+    (let [snip (rf.story.recorder/gen-play-snippet [] {:variant-id :story.x/y})]
       (is (string? snip))
       (is (str/includes? snip ":story.x/y"))
       (is (str/includes? snip ":script"))
@@ -193,7 +193,7 @@
 
 (deftest gen-play-snippet-renders-reg-variant
   (testing "snippet renders the (reg-variant ...) form with the captured trace"
-    (let [snip (recorder/gen-play-snippet
+    (let [snip (rf.story.recorder/gen-play-snippet
                  [[:counter/inc] [:counter/dec]]
                  {:variant-id :story.counter/recorded})]
       (is (str/includes? snip "reg-variant"))
@@ -202,14 +202,14 @@
       (is (str/includes? snip "[:counter/dec]")))))
 
 (deftest gen-play-snippet-includes-doc
-  (let [snip (recorder/gen-play-snippet
+  (let [snip (rf.story.recorder/gen-play-snippet
                [[:counter/inc]]
                {:variant-id :story.counter/x :doc "user inc once"})]
     (is (str/includes? snip ":doc"))
     (is (str/includes? snip "user inc once"))))
 
 (deftest gen-play-snippet-includes-extends
-  (let [snip (recorder/gen-play-snippet
+  (let [snip (rf.story.recorder/gen-play-snippet
                [[:counter/inc]]
                {:variant-id :story.counter/recorded
                 :extends    :story.counter/happy-path})]
@@ -217,7 +217,7 @@
     (is (str/includes? snip ":story.counter/happy-path"))))
 
 (deftest gen-play-snippet-uses-custom-alias
-  (let [snip (recorder/gen-play-snippet
+  (let [snip (rf.story.recorder/gen-play-snippet
                []
                {:variant-id :story.x/y :alias "rf"})]
     (is (str/includes? snip "rf/reg-variant"))))
@@ -263,7 +263,7 @@
     (let [events     [[:counter/inc]
                       [:auth/login {:email "alice@example.com" :remember? true}]
                       [:cart/add-item :widget-x 3]]
-          snippet    (recorder/gen-play-snippet
+          snippet    (rf.story.recorder/gen-play-snippet
                        events
                        {:variant-id :story.x/y})
           script-str (extract-play-script-vector snippet)
@@ -280,40 +280,40 @@
 
 (deftest append-dom-click-pure-shape
   (testing "append-dom of a click vector lands an :entries entry"
-    (let [s0 (recorder/start recorder/initial-state :story.x/y 0)
-          s1 (recorder/append-dom s0 [:dom/click "[data-test=\"a\"]" 100])]
+    (let [s0 (rf.story.recorder/start rf.story.recorder/initial-state :story.x/y 0)
+          s1 (rf.story.recorder/append-dom s0 [:dom/click "[data-test=\"a\"]" 100])]
       (is (= 1 (count (:entries s1))))
       (is (= {:kind :dom/click :selector "[data-test=\"a\"]" :t 100}
              (first (:entries s1)))))))
 
 (deftest append-dom-type-pure-shape
-  (let [s0 (recorder/start recorder/initial-state :story.x/y 0)
-        s1 (recorder/append-dom s0 [:dom/type "[id=\"x\"]" "alice" 200])]
+  (let [s0 (rf.story.recorder/start rf.story.recorder/initial-state :story.x/y 0)
+        s1 (rf.story.recorder/append-dom s0 [:dom/type "[id=\"x\"]" "alice" 200])]
     (is (= {:kind :dom/type :selector "[id=\"x\"]" :text "alice" :t 200}
            (first (:entries s1))))))
 
 (deftest append-dom-submit-pure-shape
-  (let [s0 (recorder/start recorder/initial-state :story.x/y 0)
-        s1 (recorder/append-dom s0 [:dom/submit "[id=\"login\"]" 300])]
+  (let [s0 (rf.story.recorder/start rf.story.recorder/initial-state :story.x/y 0)
+        s1 (rf.story.recorder/append-dom s0 [:dom/submit "[id=\"login\"]" 300])]
     (is (= {:kind :dom/submit :selector "[id=\"login\"]" :t 300}
            (first (:entries s1))))))
 
 (deftest append-dom-rejects-malformed
-  (let [s0 (recorder/start recorder/initial-state :story.x/y 0)]
-    (is (= [] (:entries (recorder/append-dom s0 nil))))
-    (is (= [] (:entries (recorder/append-dom s0 []))))
-    (is (= [] (:entries (recorder/append-dom s0 [:not-a-dom-kind "x" 0]))))))
+  (let [s0 (rf.story.recorder/start rf.story.recorder/initial-state :story.x/y 0)]
+    (is (= [] (:entries (rf.story.recorder/append-dom s0 nil))))
+    (is (= [] (:entries (rf.story.recorder/append-dom s0 []))))
+    (is (= [] (:entries (rf.story.recorder/append-dom s0 [:not-a-dom-kind "x" 0]))))))
 
 (deftest append-dom-noop-when-not-recording
   (testing "DOM-events drop on the floor when no recording is in flight"
-    (let [s0 recorder/initial-state
-          s1 (recorder/append-dom s0 [:dom/click "[data-test=\"x\"]" 0])]
+    (let [s0 rf.story.recorder/initial-state
+          s1 (rf.story.recorder/append-dom s0 [:dom/click "[data-test=\"x\"]" 0])]
       (is (= [] (:entries s1))))))
 
 (deftest append-event-stamps-timestamp
   (testing "(append state event now-ms) populates :entries[:t]"
-    (let [s0 (recorder/start recorder/initial-state :story.x/y 1000)
-          s1 (recorder/append s0 [:counter/inc] 1250)]
+    (let [s0 (rf.story.recorder/start rf.story.recorder/initial-state :story.x/y 1000)
+          s1 (rf.story.recorder/append s0 [:counter/inc] 1250)]
       (is (= [[:counter/inc]] (:events s1)) ":events carries bare event")
       (let [{:keys [kind event t]} (first (:entries s1))]
         (is (= :event/dispatch kind))
@@ -322,11 +322,11 @@
 
 (deftest record-dom-event!-impure-entry
   (testing "the impure record-dom-event! entry mutates the shared atom"
-    (recorder/clear!)
-    (recorder/start-recording! :story.x/y)
-    (recorder/record-dom-event! [:dom/click "[data-test=\"go\"]" 50])
-    (recorder/record-dom-event! [:dom/type "[id=\"x\"]" "hi" 100])
-    (let [entries (recorder/recorded-entries)]
+    (rf.story.recorder/clear!)
+    (rf.story.recorder/start-recording! :story.x/y)
+    (rf.story.recorder/record-dom-event! [:dom/click "[data-test=\"go\"]" 50])
+    (rf.story.recorder/record-dom-event! [:dom/type "[id=\"x\"]" "hi" 100])
+    (let [entries (rf.story.recorder/recorded-entries)]
       (is (= 2 (count entries)))
       (is (= :dom/click (:kind (first entries))))
       (is (= :dom/type (:kind (second entries)))))))
@@ -335,7 +335,7 @@
 
 (deftest assertion-vocabulary-covers-canonical-seven
   (testing "the picker vocabulary enumerates all seven canonical :rf.assert/* ids"
-    (let [ids (set (map :id recorder/assertion-vocabulary))]
+    (let [ids (set (map :id rf.story.recorder/assertion-vocabulary))]
       (is (= #{:rf.assert/path-equals
                :rf.assert/path-matches
                :rf.assert/sub-equals
@@ -348,7 +348,7 @@
 
 (deftest assertion-vocabulary-entries-are-well-formed
   (testing "every vocabulary entry carries the picker's required keys"
-    (doseq [entry recorder/assertion-vocabulary]
+    (doseq [entry rf.story.recorder/assertion-vocabulary]
       (is (qualified-keyword? (:id entry)))
       (is (string? (:label entry)))
       (is (string? (:hint entry)))
@@ -362,46 +362,46 @@
 (deftest make-assertion-builds-well-formed-events
   (testing "make-assertion builds canonical event vectors from a payload map"
     (is (= [:rf.assert/path-equals [:auth :status] :ok]
-           (recorder/make-assertion :rf.assert/path-equals
+           (rf.story.recorder/make-assertion :rf.assert/path-equals
                                     {:path [:auth :status] :expected :ok})))
     (is (= [:rf.assert/sub-equals [:counter] 3]
-           (recorder/make-assertion :rf.assert/sub-equals
+           (rf.story.recorder/make-assertion :rf.assert/sub-equals
                                     {:sub [:counter] :expected 3})))
     (is (= [:rf.assert/dispatched? [:counter/inc]]
-           (recorder/make-assertion :rf.assert/dispatched?
+           (rf.story.recorder/make-assertion :rf.assert/dispatched?
                                     {:event [:counter/inc]})))
     (is (= [:rf.assert/state-is :auth/machine :authenticated]
-           (recorder/make-assertion :rf.assert/state-is
+           (rf.story.recorder/make-assertion :rf.assert/state-is
                                     {:machine :auth/machine
                                      :state   :authenticated})))
     (is (= [:rf.assert/effect-emitted :http]
-           (recorder/make-assertion :rf.assert/effect-emitted {:fx-id :http})))))
+           (rf.story.recorder/make-assertion :rf.assert/effect-emitted {:fx-id :http})))))
 
 (deftest make-assertion-no-payload-form
   (testing "make-assertion handles assertions with no payload (no-warnings)"
     (is (= [:rf.assert/no-warnings]
-           (recorder/make-assertion :rf.assert/no-warnings {})))))
+           (rf.story.recorder/make-assertion :rf.assert/no-warnings {})))))
 
 (deftest make-assertion-rejects-unknown-id
   (testing "make-assertion returns nil for an unknown assertion id"
-    (is (nil? (recorder/make-assertion :rf.assert/not-a-real-one {})))
-    (is (nil? (recorder/make-assertion :counter/inc {})))))
+    (is (nil? (rf.story.recorder/make-assertion :rf.assert/not-a-real-one {})))
+    (is (nil? (rf.story.recorder/make-assertion :counter/inc {})))))
 
 (deftest make-assertion-fills-missing-fields-as-nil
   (testing "make-assertion fills in missing payload fields as nil (partial picker entry)"
     (is (= [:rf.assert/path-equals [:auth :status] nil]
-           (recorder/make-assertion :rf.assert/path-equals
+           (rf.story.recorder/make-assertion :rf.assert/path-equals
                                     {:path [:auth :status]})))))
 
 (deftest append-assertion-pure-state-machine
   (testing "append-assertion appends valid :rf.assert/* events through the filter"
-    (let [s0 (recorder/start recorder/initial-state :story.x/y 0)
+    (let [s0 (rf.story.recorder/start rf.story.recorder/initial-state :story.x/y 0)
           s1 (-> s0
-                 (recorder/append [:counter/inc])
-                 (recorder/append-assertion
+                 (rf.story.recorder/append [:counter/inc])
+                 (rf.story.recorder/append-assertion
                    [:rf.assert/path-equals [:n] 1])
-                 (recorder/append [:counter/inc])
-                 (recorder/append-assertion
+                 (rf.story.recorder/append [:counter/inc])
+                 (rf.story.recorder/append-assertion
                    [:rf.assert/sub-equals [:counter] 2]))]
       (is (= [[:counter/inc]
               [:rf.assert/path-equals [:n] 1]
@@ -412,75 +412,75 @@
 
 (deftest append-assertion-rejects-non-assertions
   (testing "append-assertion is a no-op for non-:rf.assert/* event vectors"
-    (let [s0 (recorder/start recorder/initial-state :story.x/y 0)
+    (let [s0 (rf.story.recorder/start rf.story.recorder/initial-state :story.x/y 0)
           s1 (-> s0
-                 (recorder/append-assertion [:counter/inc])
-                 (recorder/append-assertion [:rf.story/lifecycle-tick])
-                 (recorder/append-assertion nil)
-                 (recorder/append-assertion []))]
+                 (rf.story.recorder/append-assertion [:counter/inc])
+                 (rf.story.recorder/append-assertion [:rf.story/lifecycle-tick])
+                 (rf.story.recorder/append-assertion nil)
+                 (rf.story.recorder/append-assertion []))]
       (is (= [] (:events s1))
           "only :rf.assert/* event vectors land via append-assertion"))))
 
 (deftest append-assertion-noop-when-not-recording
   (testing "append-assertion drops events when :recording? is false"
-    (let [s0 recorder/initial-state
-          s1 (recorder/append-assertion s0 [:rf.assert/no-warnings])]
+    (let [s0 rf.story.recorder/initial-state
+          s1 (rf.story.recorder/append-assertion s0 [:rf.assert/no-warnings])]
       (is (= [] (:events s1))))))
 
 (deftest insert-assertion!-event-vec-arity
   (testing "insert-assertion! one-arg form appends a pre-built event vector"
-    (recorder/start-recording! :story.x/y 0)
-    (recorder/record-event! [:counter/inc])
-    (recorder/insert-assertion! [:rf.assert/path-equals [:n] 1])
-    (recorder/record-event! [:counter/inc])
-    (recorder/insert-assertion! [:rf.assert/no-warnings])
+    (rf.story.recorder/start-recording! :story.x/y 0)
+    (rf.story.recorder/record-event! [:counter/inc])
+    (rf.story.recorder/insert-assertion! [:rf.assert/path-equals [:n] 1])
+    (rf.story.recorder/record-event! [:counter/inc])
+    (rf.story.recorder/insert-assertion! [:rf.assert/no-warnings])
     (is (= [[:counter/inc]
             [:rf.assert/path-equals [:n] 1]
             [:counter/inc]
             [:rf.assert/no-warnings]]
-           (recorder/recorded-events)))))
+           (rf.story.recorder/recorded-events)))))
 
 (deftest insert-assertion!-id-plus-payload-arity
   (testing "insert-assertion! two-arg form builds + appends from id+payload"
-    (recorder/start-recording! :story.x/y 0)
-    (recorder/record-event! [:counter/inc])
-    (recorder/insert-assertion!
+    (rf.story.recorder/start-recording! :story.x/y 0)
+    (rf.story.recorder/record-event! [:counter/inc])
+    (rf.story.recorder/insert-assertion!
       :rf.assert/sub-equals {:sub [:counter] :expected 1})
-    (recorder/record-event! [:counter/inc])
-    (recorder/insert-assertion!
+    (rf.story.recorder/record-event! [:counter/inc])
+    (rf.story.recorder/insert-assertion!
       :rf.assert/path-equals {:path [:n] :expected 2})
     (is (= [[:counter/inc]
             [:rf.assert/sub-equals [:counter] 1]
             [:counter/inc]
             [:rf.assert/path-equals [:n] 2]]
-           (recorder/recorded-events)))))
+           (rf.story.recorder/recorded-events)))))
 
 (deftest insert-assertion!-rejects-non-assertion-event
   (testing "insert-assertion! drops anything that isn't an :rf.assert/* event"
-    (recorder/start-recording! :story.x/y 0)
-    (recorder/insert-assertion! [:counter/inc])           ; wrong namespace
-    (recorder/insert-assertion! [:rf.story/lifecycle-tick]) ; internal
-    (recorder/insert-assertion! nil)
-    (is (= [] (recorder/recorded-events)))))
+    (rf.story.recorder/start-recording! :story.x/y 0)
+    (rf.story.recorder/insert-assertion! [:counter/inc])           ; wrong namespace
+    (rf.story.recorder/insert-assertion! [:rf.story/lifecycle-tick]) ; internal
+    (rf.story.recorder/insert-assertion! nil)
+    (is (= [] (rf.story.recorder/recorded-events)))))
 
 (deftest insert-assertion!-noop-when-not-recording
   (testing "insert-assertion! is harmless when no recording is in flight"
-    (is (not (recorder/recording?)))
-    (recorder/insert-assertion! :rf.assert/no-warnings {})
-    (is (= [] (recorder/recorded-events)))))
+    (is (not (rf.story.recorder/recording?)))
+    (rf.story.recorder/insert-assertion! :rf.assert/no-warnings {})
+    (is (= [] (rf.story.recorder/recorded-events)))))
 
 (deftest gen-play-snippet-round-trips-with-inserted-assertions
   (testing "the EDN snippet round-trips when the captured trace includes assertions"
-    (recorder/start-recording! :story.counter/x 0)
-    (recorder/record-event! [:counter/inc])
-    (recorder/insert-assertion! :rf.assert/sub-equals
+    (rf.story.recorder/start-recording! :story.counter/x 0)
+    (rf.story.recorder/record-event! [:counter/inc])
+    (rf.story.recorder/insert-assertion! :rf.assert/sub-equals
                                 {:sub [:counter] :expected 1})
-    (recorder/record-event! [:counter/by 7])
-    (recorder/insert-assertion! :rf.assert/path-equals
+    (rf.story.recorder/record-event! [:counter/by 7])
+    (rf.story.recorder/insert-assertion! :rf.assert/path-equals
                                 {:path [:n] :expected 8})
-    (recorder/stop-recording!)
-    (let [events     (recorder/recorded-events)
-          snippet    (recorder/gen-play-snippet
+    (rf.story.recorder/stop-recording!)
+    (let [events     (rf.story.recorder/recorded-events)
+          snippet    (rf.story.recorder/gen-play-snippet
                        events
                        {:variant-id :story.counter/recorded
                         :extends    :story.counter/x})
@@ -503,15 +503,15 @@
 ;; ---- end-to-end: trace-bus integration -----------------------------------
 
 (defn- reset-rf-state! []
-  (recorder/remove-trace-listener!)
-  (recorder/clear!)
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story.recorder/remove-trace-listener!)
+  (rf.story.recorder/clear!)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (deftest trace-listener-captures-dispatch-into-recording
   (testing "with a recording in flight, a dispatch against the target frame is captured"
@@ -520,21 +520,21 @@
       (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (rf/reg-event :counter/dec
       (fn [{:keys [db]} _] {:db (update db :n (fnil dec 0))}))
-    (story/reg-variant :story.recorder/v {})
+    (rf.story/reg-variant :story.recorder/v {})
     ;; Allocate the variant frame + install the listener.
-    (async/deref-blocking (story/run-variant :story.recorder/v) 5000)
-    (recorder/install-trace-listener!)
-    (recorder/start-recording! :story.recorder/v)
+    (rf.story.async/deref-blocking (rf.story/run-variant :story.recorder/v) 5000)
+    (rf.story.recorder/install-trace-listener!)
+    (rf.story.recorder/start-recording! :story.recorder/v)
     ;; Drive a few dispatches against the target frame.
     (rf/dispatch-sync [:counter/inc] {:frame :story.recorder/v})
     (rf/dispatch-sync [:counter/inc] {:frame :story.recorder/v})
     (rf/dispatch-sync [:counter/dec] {:frame :story.recorder/v})
-    (recorder/stop-recording!)
+    (rf.story.recorder/stop-recording!)
     (is (= [[:counter/inc] [:counter/inc] [:counter/dec]]
-           (recorder/recorded-events))
+           (rf.story.recorder/recorded-events))
         "back-compat :events slot still carries bare event vectors")
     ;; rf2-d5u89: parallel :entries slot carries the rich shape too.
-    (let [entries (recorder/recorded-entries)]
+    (let [entries (rf.story.recorder/recorded-entries)]
       (is (= 3 (count entries))
           ":entries mirrors :events one-for-one")
       (is (every? #(= :event/dispatch (:kind %)) entries)
@@ -544,54 +544,54 @@
           ":event slot on each entry is the bare event vector")
       (is (every? #(number? (:t %)) entries)
           "each entry carries a numeric :t timestamp"))
-    (story/destroy-variant! :story.recorder/v)
-    (recorder/remove-trace-listener!)))
+    (rf.story/destroy-variant! :story.recorder/v)
+    (rf.story.recorder/remove-trace-listener!)))
 
 (deftest trace-listener-ignores-cross-frame-traffic
   (testing "dispatches to a non-target frame don't appear in the recording"
     (reset-rf-state!)
     (rf/reg-event :counter/inc
       (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-    (story/reg-variant :story.recorder/target {})
-    (story/reg-variant :story.recorder/other  {})
-    (async/deref-blocking (story/run-variant :story.recorder/target) 5000)
-    (async/deref-blocking (story/run-variant :story.recorder/other)  5000)
-    (recorder/install-trace-listener!)
-    (recorder/start-recording! :story.recorder/target)
+    (rf.story/reg-variant :story.recorder/target {})
+    (rf.story/reg-variant :story.recorder/other  {})
+    (rf.story.async/deref-blocking (rf.story/run-variant :story.recorder/target) 5000)
+    (rf.story.async/deref-blocking (rf.story/run-variant :story.recorder/other)  5000)
+    (rf.story.recorder/install-trace-listener!)
+    (rf.story.recorder/start-recording! :story.recorder/target)
     ;; This one lands on the recording target.
     (rf/dispatch-sync [:counter/inc] {:frame :story.recorder/target})
     ;; This one lands on a different frame and MUST be ignored.
     (rf/dispatch-sync [:counter/inc] {:frame :story.recorder/other})
     ;; This one lands on the target again.
     (rf/dispatch-sync [:counter/inc] {:frame :story.recorder/target})
-    (recorder/stop-recording!)
+    (rf.story.recorder/stop-recording!)
     (is (= [[:counter/inc] [:counter/inc]]
-           (recorder/recorded-events))
+           (rf.story.recorder/recorded-events))
         "only the target-frame dispatches are captured")
-    (story/destroy-variant! :story.recorder/target)
-    (story/destroy-variant! :story.recorder/other)
-    (recorder/remove-trace-listener!)))
+    (rf.story/destroy-variant! :story.recorder/target)
+    (rf.story/destroy-variant! :story.recorder/other)
+    (rf.story.recorder/remove-trace-listener!)))
 
 (deftest trace-listener-skips-assertion-events
   (testing "with a recording active, :rf.assert/* dispatches don't leak into the captured :script body"
     (reset-rf-state!)
     (rf/reg-event :counter/inc
       (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-    (story/reg-variant :story.recorder/v {})
-    (async/deref-blocking (story/run-variant :story.recorder/v) 5000)
-    (recorder/install-trace-listener!)
-    (recorder/start-recording! :story.recorder/v)
+    (rf.story/reg-variant :story.recorder/v {})
+    (rf.story.async/deref-blocking (rf.story/run-variant :story.recorder/v) 5000)
+    (rf.story.recorder/install-trace-listener!)
+    (rf.story.recorder/start-recording! :story.recorder/v)
     (rf/dispatch-sync [:counter/inc] {:frame :story.recorder/v})
     ;; Assertions ARE dispatchable but the recorder skips them.
     (rf/dispatch-sync [:rf.assert/path-equals [:n] 1]
                       {:frame :story.recorder/v})
     (rf/dispatch-sync [:counter/inc] {:frame :story.recorder/v})
-    (recorder/stop-recording!)
+    (rf.story.recorder/stop-recording!)
     (is (= [[:counter/inc] [:counter/inc]]
-           (recorder/recorded-events))
+           (rf.story.recorder/recorded-events))
         "only the user dispatches are captured — assertions filtered")
-    (story/destroy-variant! :story.recorder/v)
-    (recorder/remove-trace-listener!)))
+    (rf.story/destroy-variant! :story.recorder/v)
+    (rf.story.recorder/remove-trace-listener!)))
 
 (deftest trace-listener-redacts-sensitive-dispatches-end-to-end
   (testing "a `redact-interceptor`-interceptor handler still appears in the
@@ -606,21 +606,21 @@
     ;; EP-0022 reference-only flip: chains carry references only, so register the
     ;; interceptor value then reference it by id (the value's `:id`).
     (rf/reg-interceptor :rf/redact-interceptor
-      (privacy/redact-interceptor [[:password] [:totp]]))
+      (rf.privacy/redact-interceptor [[:password] [:totp]]))
     (rf/reg-event :auth/login
       {:interceptors [:rf/redact-interceptor]}
       (fn [{:keys [db]} _] {:db db}))
-    (story/reg-variant :story.recorder/sens-end-to-end {})
-    (async/deref-blocking (story/run-variant :story.recorder/sens-end-to-end) 5000)
-    (recorder/install-trace-listener!)
-    (recorder/start-recording! :story.recorder/sens-end-to-end)
+    (rf.story/reg-variant :story.recorder/sens-end-to-end {})
+    (rf.story.async/deref-blocking (rf.story/run-variant :story.recorder/sens-end-to-end) 5000)
+    (rf.story.recorder/install-trace-listener!)
+    (rf.story.recorder/start-recording! :story.recorder/sens-end-to-end)
     (rf/dispatch-sync [:counter/inc] {:frame :story.recorder/sens-end-to-end})
     (rf/dispatch-sync [:auth/login {:password "shh"
                                     :totp "123456"}]
                       {:frame :story.recorder/sens-end-to-end})
     (rf/dispatch-sync [:counter/inc] {:frame :story.recorder/sens-end-to-end})
-    (recorder/stop-recording!)
-    (let [events (recorder/recorded-events)]
+    (rf.story.recorder/stop-recording!)
+    (let [events (rf.story.recorder/recorded-events)]
       ;; The `:auth/login` event vector survives in position; the
       ;; redact-interceptor interceptor scrubbed the secret-bearing keys
       ;; on the trace surface.
@@ -630,8 +630,8 @@
                                   (some #{"shh" "123456"} (map str ev))))
                     events)
           "no captured event vector echoes the sensitive payload literals"))
-    (story/destroy-variant! :story.recorder/sens-end-to-end)
-    (recorder/remove-trace-listener!)))
+    (rf.story/destroy-variant! :story.recorder/sens-end-to-end)
+    (rf.story.recorder/remove-trace-listener!)))
 
 (deftest end-to-end-recording-to-snippet
   (testing "the full record→stop→gen-play-snippet cycle produces a valid public :script body"
@@ -640,15 +640,15 @@
       (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (rf/reg-event :counter/by
       (fn [{:keys [db]} [_ n]] {:db (update db :n (fnil + 0) n)}))
-    (story/reg-variant :story.recorder/source {})
-    (async/deref-blocking (story/run-variant :story.recorder/source) 5000)
-    (recorder/install-trace-listener!)
-    (recorder/start-recording! :story.recorder/source)
+    (rf.story/reg-variant :story.recorder/source {})
+    (rf.story.async/deref-blocking (rf.story/run-variant :story.recorder/source) 5000)
+    (rf.story.recorder/install-trace-listener!)
+    (rf.story.recorder/start-recording! :story.recorder/source)
     (rf/dispatch-sync [:counter/inc]        {:frame :story.recorder/source})
     (rf/dispatch-sync [:counter/inc]        {:frame :story.recorder/source})
     (rf/dispatch-sync [:counter/by 7]       {:frame :story.recorder/source})
-    (let [{:keys [events variant-id]} (recorder/stop-recording!)
-          snippet    (recorder/gen-play-snippet
+    (let [{:keys [events variant-id]} (rf.story.recorder/stop-recording!)
+          snippet    (rf.story.recorder/gen-play-snippet
                        events
                        {:variant-id :story.recorder/captured
                         :extends    variant-id
@@ -662,8 +662,8 @@
           "the recorder-target id rides into the :extends slot")
       (is (= events (unwrap-dispatch-sync-steps script-vec))
           "the rendered public :script body vector unwraps back to the captured events"))
-    (story/destroy-variant! :story.recorder/source)
-    (recorder/remove-trace-listener!)))
+    (rf.story/destroy-variant! :story.recorder/source)
+    (rf.story.recorder/remove-trace-listener!)))
 
 ;; ---- rf2-xxnqd: recorder FACADE contract --------------------------------
 ;;
@@ -723,10 +723,10 @@
           "render-variant-form is sub-namespace-only, not on the facade"))))
 
 (deftest facade-gen-play-snippet-emits-public-script-slot
-  (testing "story/gen-play-snippet (the facade re-export) emits the
+  (testing "rf.story/gen-play-snippet (the facade re-export) emits the
             :script slot, never the retired :play-script
             (rf2-7mj4z) — pinned at the facade, not just the recorder ns"
-    (let [snip (story/gen-play-snippet [[:counter/inc]]
+    (let [snip (rf.story/gen-play-snippet [[:counter/inc]]
                                        {:variant-id :story.x/y})]
       (is (string? snip))
       (is (str/includes? snip ":script")
@@ -735,13 +735,13 @@
           "the retired :play-script slot is NOT emitted at the facade"))))
 
 (deftest facade-recording->script-body-delegates-to-play-export
-  (testing "story/recording->script-body (the facade re-export) returns
+  (testing "rf.story/recording->script-body (the facade re-export) returns
             the live {:script ... :auto-run?} body the runner executes —
             the programmatic re-registration contract. Both arities
             resolve through the play-export sub-ns."
     (let [events    [[:counter/inc] [:counter/by 7]]
-          one-arg   (story/recording->script-body events)
-          two-arg   (story/recording->script-body events {:name "rt"})]
+          one-arg   (rf.story/recording->script-body events)
+          two-arg   (rf.story/recording->script-body events {:name "rt"})]
       (is (map? one-arg) "one-arg returns a play-body map")
       (is (vector? (:script one-arg)) ":script is the runner step vector")
       (is (contains? one-arg :auto-run?) ":auto-run? slot present")
@@ -755,7 +755,7 @@
           "two-arg threads :name through to the play-export sub-ns")
       ;; Facade and sub-ns produce the SAME body — the re-export is a
       ;; thin delegation, not a divergent reimplementation.
-      (is (= one-arg (play-export/recording->script-body events))
+      (is (= one-arg (rf.story.recorder.play-export/recording->script-body events))
           "facade re-export == sub-namespace fn (pure delegation)"))))
 
 ;; ---- EP-0023: a recording's address is the variant FRAME -----------------
@@ -770,7 +770,7 @@
 (deftest recording-state-is-the-bare-frame-target-shape
   (testing "start writes the bare recorder shape — no realm key, the
             recording's address is the variant frame (EP-0023)"
-    (let [s (recorder/start recorder/initial-state :story.x/y 1000)]
+    (let [s (rf.story.recorder/start rf.story.recorder/initial-state :story.x/y 1000)]
       (is (= {:recording? true :variant-id :story.x/y
               :events [] :cofx [] :entries [] :started-ms 1000}
              s)
@@ -784,22 +784,22 @@
             (EP-0023 frame-target collapse)"
     (reset-rf-state!)
     (rf/reg-event :counter/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-    (story/reg-variant :story.frame/target {})
-    (async/deref-blocking (story/run-variant :story.frame/target) 5000)
-    (recorder/install-trace-listener!)
-    (recorder/start-recording! :story.frame/target)
+    (rf.story/reg-variant :story.frame/target {})
+    (rf.story.async/deref-blocking (rf.story/run-variant :story.frame/target) 5000)
+    (rf.story.recorder/install-trace-listener!)
+    (rf.story.recorder/start-recording! :story.frame/target)
     (rf/dispatch-sync [:counter/inc] {:frame :story.frame/target})
     (rf/dispatch-sync [:counter/inc] {:frame :story.frame/target})
-    (let [final-state (recorder/stop-recording!)]
+    (let [final-state (rf.story.recorder/stop-recording!)]
       (is (not-any? #(= "rf.realm" (namespace %)) (keys final-state))
           "the recording carries no realm key — the frame is the address")
       (is (= :story.frame/target (:variant-id final-state))
           "the recording's address is the variant frame")
       (let [events (:events final-state)
-            body   (story/recording->script-body events)]
+            body   (rf.story/recording->script-body events)]
         (is (not-any? #(= "rf.realm" (namespace %)) (keys body))
             "the play body carries no realm key")
         (is (= [:auto-run? :script] (sort (keys body)))
             "the body is the frame-only {:script :auto-run?} shape")))
-    (story/destroy-variant! :story.frame/target)
-    (recorder/remove-trace-listener!)))
+    (rf.story/destroy-variant! :story.frame/target)
+    (rf.story.recorder/remove-trace-listener!)))

--- a/tools/story/test/re_frame/story_review_dialog_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_review_dialog_cljs_test.cljs
@@ -9,29 +9,29 @@
   flows both depend on."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
-            [re-frame.story.predicates :as pred]
-            [re-frame.story.review-dialog :as review-dialog]))
+            [re-frame.story.predicates :as rf.story.predicates]
+            [re-frame.story.review-dialog :as rf.story.review-dialog]))
 
 ;; ---- parse-variant-id-string ---------------------------------------------
 
 (deftest parse-with-leading-colon
-  (is (= :foo/bar (review-dialog/parse-variant-id-string ":foo/bar")))
-  (is (= :plain   (review-dialog/parse-variant-id-string ":plain"))))
+  (is (= :foo/bar (rf.story.review-dialog/parse-variant-id-string ":foo/bar")))
+  (is (= :plain   (rf.story.review-dialog/parse-variant-id-string ":plain"))))
 
 (deftest parse-without-leading-colon
-  (is (= :foo/bar (review-dialog/parse-variant-id-string "foo/bar")))
-  (is (= :plain   (review-dialog/parse-variant-id-string "plain"))))
+  (is (= :foo/bar (rf.story.review-dialog/parse-variant-id-string "foo/bar")))
+  (is (= :plain   (rf.story.review-dialog/parse-variant-id-string "plain"))))
 
 (deftest parse-nil-for-empty-or-bad-input
-  (is (nil? (review-dialog/parse-variant-id-string nil)))
-  (is (nil? (review-dialog/parse-variant-id-string "")))
-  (is (nil? (review-dialog/parse-variant-id-string "foo/")))
-  (is (nil? (review-dialog/parse-variant-id-string "/bar"))))
+  (is (nil? (rf.story.review-dialog/parse-variant-id-string nil)))
+  (is (nil? (rf.story.review-dialog/parse-variant-id-string "")))
+  (is (nil? (rf.story.review-dialog/parse-variant-id-string "foo/")))
+  (is (nil? (rf.story.review-dialog/parse-variant-id-string "/bar"))))
 
 ;; ---- default-variant-id-with-prefix --------------------------------------
 
 (deftest default-uses-source-namespace
-  (let [k (review-dialog/default-variant-id-with-prefix
+  (let [k (rf.story.review-dialog/default-variant-id-with-prefix
             :story.counter/happy-path 12345 "saved")]
     (is (qualified-keyword? k))
     (is (= "story.counter" (namespace k)))
@@ -39,26 +39,26 @@
 
 (deftest default-honors-custom-prefix
   (is (= "recorded-0"
-         (name (review-dialog/default-variant-id-with-prefix
+         (name (rf.story.review-dialog/default-variant-id-with-prefix
                  :story.x/y 0 "recorded"))))
   (is (= "saved-0"
-         (name (review-dialog/default-variant-id-with-prefix
+         (name (rf.story.review-dialog/default-variant-id-with-prefix
                  :story.x/y 0 "saved")))))
 
 (deftest default-nil-for-unqualified-source
-  (is (nil? (review-dialog/default-variant-id-with-prefix nil 0 "saved")))
-  (is (nil? (review-dialog/default-variant-id-with-prefix
+  (is (nil? (rf.story.review-dialog/default-variant-id-with-prefix nil 0 "saved")))
+  (is (nil? (rf.story.review-dialog/default-variant-id-with-prefix
               :unqualified 0 "saved"))))
 
 ;; ---- dialog state machine ------------------------------------------------
 
 (deftest initial-state-is-idle
-  (is (false? (:open?     review-dialog/initial-state)))
-  (is (nil?   (:draft-id  review-dialog/initial-state)))
-  (is (nil?   (:source-id review-dialog/initial-state))))
+  (is (false? (:open?     rf.story.review-dialog/initial-state)))
+  (is (nil?   (:draft-id  rf.story.review-dialog/initial-state)))
+  (is (nil?   (:source-id rf.story.review-dialog/initial-state))))
 
 (deftest open-flips-open-and-seeds-defaults
-  (let [s (review-dialog/open review-dialog/initial-state
+  (let [s (rf.story.review-dialog/open rf.story.review-dialog/initial-state
                               :story.x/y
                               {:args {:n 1}}
                               12345
@@ -69,28 +69,28 @@
     (is (qualified-keyword? (:draft-id s)))))
 
 (deftest close-returns-idle
-  (let [opened (review-dialog/open review-dialog/initial-state
+  (let [opened (rf.story.review-dialog/open rf.story.review-dialog/initial-state
                                    :story.x/y {} 0 "saved")]
-    (is (= review-dialog/initial-state (review-dialog/close opened)))))
+    (is (= rf.story.review-dialog/initial-state (rf.story.review-dialog/close opened)))))
 
 (deftest parse-and-set-draft-id-parses-on-success
-  (let [s (-> review-dialog/initial-state
-              (review-dialog/open :story.x/y nil 0 "saved")
-              (review-dialog/parse-and-set-draft-id ":story.x/edited"))]
+  (let [s (-> rf.story.review-dialog/initial-state
+              (rf.story.review-dialog/open :story.x/y nil 0 "saved")
+              (rf.story.review-dialog/parse-and-set-draft-id ":story.x/edited"))]
     (is (= :story.x/edited (:draft-id s)))))
 
 (deftest parse-and-set-draft-id-keeps-raw-on-failure
-  (let [s (-> review-dialog/initial-state
-              (review-dialog/open :story.x/y nil 0 "saved")
-              (review-dialog/parse-and-set-draft-id "foo/"))]
+  (let [s (-> rf.story.review-dialog/initial-state
+              (rf.story.review-dialog/open :story.x/y nil 0 "saved")
+              (rf.story.review-dialog/parse-and-set-draft-id "foo/"))]
     (is (= "foo/" (:draft-id s)))))
 
 ;; ---- renderer: closed state ----------------------------------------------
 
 (deftest renderer-returns-nil-when-closed
   (testing "the renderer returns nil for the idle state"
-    (is (nil? (review-dialog/review-dialog
-                review-dialog/initial-state
+    (is (nil? (rf.story.review-dialog/review-dialog
+                rf.story.review-dialog/initial-state
                 {:title             "Test"
                  :snippet           "(snippet)"
                  :placeholder-id    :story.x/example
@@ -103,7 +103,7 @@
 ;; ---- renderer: opened state ----------------------------------------------
 
 (defn- opened-state []
-  (review-dialog/open review-dialog/initial-state
+  (rf.story.review-dialog/open rf.story.review-dialog/initial-state
                       :story.x/source
                       {:args {:n 1}}
                       12345
@@ -111,7 +111,7 @@
 
 (deftest renderer-returns-hiccup-when-open
   (testing "the renderer returns a hiccup tree when :open? is true"
-    (let [hiccup (review-dialog/review-dialog
+    (let [hiccup (rf.story.review-dialog/review-dialog
                    (opened-state)
                    {:title             "Save"
                     :hint              "the hint"
@@ -136,7 +136,7 @@
 
 (deftest renderer-without-on-discard-omits-discard-button
   (testing "no :on-discard → no 'discard' button is rendered"
-    (let [flat (str (review-dialog/review-dialog
+    (let [flat (str (rf.story.review-dialog/review-dialog
                       (opened-state)
                       {:title             "Save"
                        :snippet           "(snippet)"
@@ -151,7 +151,7 @@
 
 (deftest renderer-with-on-discard-renders-discard-button
   (testing ":on-discard provided → 'discard' button renders"
-    (let [flat (str (review-dialog/review-dialog
+    (let [flat (str (rf.story.review-dialog/review-dialog
                      (opened-state)
                      {:title             "Save"
                       :snippet           "(snippet)"
@@ -166,12 +166,12 @@
 
 (deftest renderer-uses-placeholder-when-draft-id-nil
   (testing "with no draft-id seeded the input's default-value is the placeholder"
-    (let [state (review-dialog/open review-dialog/initial-state
+    (let [state (rf.story.review-dialog/open rf.story.review-dialog/initial-state
                                     :unqualified-source
                                     nil
                                     0
                                     "saved")
-          flat  (str (review-dialog/review-dialog
+          flat  (str (rf.story.review-dialog/review-dialog
                        state
                        {:title             "Save"
                         :snippet           "(snippet)"
@@ -187,24 +187,24 @@
 
 (deftest copy-to-clipboard!-safe-on-node
   (testing "the shared copy helper is callable + no-ops without a clipboard API"
-    (is (nil? (review-dialog/copy-to-clipboard! "anything")))))
+    (is (nil? (rf.story.review-dialog/copy-to-clipboard! "anything")))))
 
 ;; ---- indent-after (snippet-format helper, rf2-zs0w4) ---------------------
 
 (deftest indent-after-matches-prefix-width
   (testing "indent-after returns \\n + N spaces equal to the prefix length"
-    (is (= "\n" (pred/indent-after "")))
-    (is (= "\n          " (pred/indent-after "   :name {")))
-    (is (= "\n          " (pred/indent-after "   :args {")))
-    (is (= (pred/indent-after "   :name {")
-           (pred/indent-after "   :args {"))
+    (is (= "\n" (rf.story.predicates/indent-after "")))
+    (is (= "\n          " (rf.story.predicates/indent-after "   :name {")))
+    (is (= "\n          " (rf.story.predicates/indent-after "   :args {")))
+    (is (= (rf.story.predicates/indent-after "   :name {")
+           (rf.story.predicates/indent-after "   :args {"))
         "both flows' prefixes collapse to the same indent")))
 
 ;; ---- ARIA: modal a11y posture (rf2-p1ai7) -------------------------------
 
 (deftest renderer-stamps-role-dialog-and-aria-modal
   (testing "rf2-p1ai7: the rendered modal carries role=dialog + aria-modal=true"
-    (let [flat (str (review-dialog/review-dialog
+    (let [flat (str (rf.story.review-dialog/review-dialog
                       (opened-state)
                       {:title             "Save"
                        :snippet           "(snippet)"
@@ -225,7 +225,7 @@
 
 (deftest renderer-id-input-carries-aria-label
   (testing "rf2-u01y5: the variant-id input has an accessible name"
-    (let [flat (str (review-dialog/review-dialog
+    (let [flat (str (rf.story.review-dialog/review-dialog
                       (opened-state)
                       {:title             "Save"
                        :snippet           "(snippet)"

--- a/tools/story/test/re_frame/story_review_dialog_test.clj
+++ b/tools/story/test/re_frame/story_review_dialog_test.clj
@@ -21,49 +21,49 @@
     `parse-and-set-draft-id`) — JVM-testable in isolation; the CLJS
     adapter swaps a Reagent ratom around them."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.story.predicates :as pred]
-            [re-frame.story.review-dialog :as review-dialog]))
+            [re-frame.story.predicates :as rf.story.predicates]
+            [re-frame.story.review-dialog :as rf.story.review-dialog]))
 
 ;; ---- parse-variant-id-string ---------------------------------------------
 
 (deftest parse-with-leading-colon
   (testing "input with leading `:` strips it and parses"
-    (is (= :foo/bar (review-dialog/parse-variant-id-string ":foo/bar")))
-    (is (= :plain   (review-dialog/parse-variant-id-string ":plain")))))
+    (is (= :foo/bar (rf.story.review-dialog/parse-variant-id-string ":foo/bar")))
+    (is (= :plain   (rf.story.review-dialog/parse-variant-id-string ":plain")))))
 
 (deftest parse-without-leading-colon
   (testing "input without leading `:` parses directly"
-    (is (= :foo/bar (review-dialog/parse-variant-id-string "foo/bar")))
-    (is (= :plain   (review-dialog/parse-variant-id-string "plain")))))
+    (is (= :foo/bar (rf.story.review-dialog/parse-variant-id-string "foo/bar")))
+    (is (= :plain   (rf.story.review-dialog/parse-variant-id-string "plain")))))
 
 (deftest parse-qualified-keyword
   (testing "qualified id parses into a qualified keyword"
-    (let [k (review-dialog/parse-variant-id-string ":story.counter/saved-1")]
+    (let [k (rf.story.review-dialog/parse-variant-id-string ":story.counter/saved-1")]
       (is (qualified-keyword? k))
       (is (= "story.counter" (namespace k)))
       (is (= "saved-1"       (name k))))))
 
 (deftest parse-nil-for-empty-or-bad-input
   (testing "nil / empty / non-string returns nil"
-    (is (nil? (review-dialog/parse-variant-id-string nil)))
-    (is (nil? (review-dialog/parse-variant-id-string "")))
-    (is (nil? (review-dialog/parse-variant-id-string ":"))
+    (is (nil? (rf.story.review-dialog/parse-variant-id-string nil)))
+    (is (nil? (rf.story.review-dialog/parse-variant-id-string "")))
+    (is (nil? (rf.story.review-dialog/parse-variant-id-string ":"))
         "bare colon strips to empty → nil")
-    (is (nil? (review-dialog/parse-variant-id-string "foo/")))
-    (is (nil? (review-dialog/parse-variant-id-string "/bar")))))
+    (is (nil? (rf.story.review-dialog/parse-variant-id-string "foo/")))
+    (is (nil? (rf.story.review-dialog/parse-variant-id-string "/bar")))))
 
 (deftest parse-handles-keywords-only-strings
   (testing "an input that is a printed keyword form (with leading colon) round-trips"
-    (is (= :a (review-dialog/parse-variant-id-string ":a")))
+    (is (= :a (rf.story.review-dialog/parse-variant-id-string ":a")))
     (is (= :ns/name
-           (review-dialog/parse-variant-id-string
+           (rf.story.review-dialog/parse-variant-id-string
              (pr-str :ns/name))))))
 
 ;; ---- default-variant-id-with-prefix --------------------------------------
 
 (deftest default-uses-source-namespace
   (testing "the derived id inherits the source's namespace + prefix-N suffix"
-    (let [k (review-dialog/default-variant-id-with-prefix
+    (let [k (rf.story.review-dialog/default-variant-id-with-prefix
               :story.counter/happy-path 12345 "saved")]
       (is (qualified-keyword? k))
       (is (= "story.counter" (namespace k)))
@@ -71,23 +71,23 @@
 
 (deftest default-honors-custom-prefix
   (testing "the prefix arg drives the name's leading token"
-    (let [k (review-dialog/default-variant-id-with-prefix
+    (let [k (rf.story.review-dialog/default-variant-id-with-prefix
               :story.counter/x 0 "recorded")]
       (is (= "recorded-0" (name k))))
-    (let [k (review-dialog/default-variant-id-with-prefix
+    (let [k (rf.story.review-dialog/default-variant-id-with-prefix
               :story.counter/x 0 "snapshot")]
       (is (= "snapshot-0" (name k))))))
 
 (deftest default-nil-for-unqualified-source
   (testing "an unqualified or nil source returns nil"
-    (is (nil? (review-dialog/default-variant-id-with-prefix nil 0 "saved")))
-    (is (nil? (review-dialog/default-variant-id-with-prefix
+    (is (nil? (rf.story.review-dialog/default-variant-id-with-prefix nil 0 "saved")))
+    (is (nil? (rf.story.review-dialog/default-variant-id-with-prefix
                 :unqualified 0 "saved")))))
 
 (deftest default-suffix-bounded-by-million
   (testing "the suffix is always in [0, 999999] so it stays a short slug"
     (doseq [now-ms [0 1 1000 1000000 1700000000000 (* 1000000 99999)]]
-      (let [k     (review-dialog/default-variant-id-with-prefix
+      (let [k     (rf.story.review-dialog/default-variant-id-with-prefix
                     :story.x/y now-ms "saved")
             n-str (subs (name k) (count "saved-"))
             n     (Long/parseLong n-str)]
@@ -98,14 +98,14 @@
 
 (deftest initial-state-is-idle
   (testing "the idle state map has the expected slots"
-    (is (false? (:open?     review-dialog/initial-state)))
-    (is (nil?   (:draft-id  review-dialog/initial-state)))
-    (is (nil?   (:source-id review-dialog/initial-state)))
-    (is (nil?   (:context   review-dialog/initial-state)))))
+    (is (false? (:open?     rf.story.review-dialog/initial-state)))
+    (is (nil?   (:draft-id  rf.story.review-dialog/initial-state)))
+    (is (nil?   (:source-id rf.story.review-dialog/initial-state)))
+    (is (nil?   (:context   rf.story.review-dialog/initial-state)))))
 
 (deftest open-flips-open-and-seeds-defaults
   (testing "open builds the opened state with the source + context + default id"
-    (let [s (review-dialog/open review-dialog/initial-state
+    (let [s (rf.story.review-dialog/open rf.story.review-dialog/initial-state
                                 :story.x/y
                                 {:args {:n 1}}
                                 12345
@@ -118,7 +118,7 @@
 
 (deftest open-with-unqualified-source-still-opens
   (testing "an unqualified source-id leaves :draft-id nil but the dialog opens"
-    (let [s (review-dialog/open review-dialog/initial-state
+    (let [s (rf.story.review-dialog/open rf.story.review-dialog/initial-state
                                 :unqualified
                                 nil
                                 0
@@ -129,75 +129,75 @@
 
 (deftest close-returns-idle
   (testing "close returns the idle state regardless of prior state"
-    (let [opened (review-dialog/open review-dialog/initial-state
+    (let [opened (rf.story.review-dialog/open rf.story.review-dialog/initial-state
                                      :story.x/y {:args {:n 1}} 0 "saved")
-          closed (review-dialog/close opened)]
-      (is (= review-dialog/initial-state closed)))))
+          closed (rf.story.review-dialog/close opened)]
+      (is (= rf.story.review-dialog/initial-state closed)))))
 
 (deftest set-draft-id-replaces-keyword
   (testing "set-draft-id stores a keyword as-is"
-    (let [s (-> review-dialog/initial-state
-                (review-dialog/open :story.x/y nil 0 "saved")
-                (review-dialog/set-draft-id :story.x/edited))]
+    (let [s (-> rf.story.review-dialog/initial-state
+                (rf.story.review-dialog/open :story.x/y nil 0 "saved")
+                (rf.story.review-dialog/set-draft-id :story.x/edited))]
       (is (= :story.x/edited (:draft-id s))))))
 
 (deftest set-draft-id-stores-raw-string
   (testing "set-draft-id stores a raw string when caller passes one"
-    (let [s (-> review-dialog/initial-state
-                (review-dialog/open :story.x/y nil 0 "saved")
-                (review-dialog/set-draft-id "partial-input"))]
+    (let [s (-> rf.story.review-dialog/initial-state
+                (rf.story.review-dialog/open :story.x/y nil 0 "saved")
+                (rf.story.review-dialog/set-draft-id "partial-input"))]
       (is (= "partial-input" (:draft-id s))))))
 
 (deftest parse-and-set-parses-on-success
   (testing "parse-and-set-draft-id parses a clean keyword string into a keyword"
-    (let [s (-> review-dialog/initial-state
-                (review-dialog/open :story.x/y nil 0 "saved")
-                (review-dialog/parse-and-set-draft-id ":story.x/edited"))]
+    (let [s (-> rf.story.review-dialog/initial-state
+                (rf.story.review-dialog/open :story.x/y nil 0 "saved")
+                (rf.story.review-dialog/parse-and-set-draft-id ":story.x/edited"))]
       (is (= :story.x/edited (:draft-id s))))))
 
 (deftest parse-and-set-keeps-raw-on-failure
   (testing "parse-and-set-draft-id keeps the raw string on parse failure"
-    (let [s (-> review-dialog/initial-state
-                (review-dialog/open :story.x/y nil 0 "saved")
-                (review-dialog/parse-and-set-draft-id "foo/"))]
+    (let [s (-> rf.story.review-dialog/initial-state
+                (rf.story.review-dialog/open :story.x/y nil 0 "saved")
+                (rf.story.review-dialog/parse-and-set-draft-id "foo/"))]
       (is (= "foo/" (:draft-id s))
           "the trailing-slash input doesn't parse — raw string preserved"))))
 
 (deftest parse-and-set-handles-empty-string
   (testing "empty-string input leaves the draft-id slot at the empty string"
-    (let [s (-> review-dialog/initial-state
-                (review-dialog/open :story.x/y nil 0 "saved")
-                (review-dialog/parse-and-set-draft-id ""))]
+    (let [s (-> rf.story.review-dialog/initial-state
+                (rf.story.review-dialog/open :story.x/y nil 0 "saved")
+                (rf.story.review-dialog/parse-and-set-draft-id ""))]
       (is (= "" (:draft-id s))))))
 
 ;; ---- composition ---------------------------------------------------------
 
 (deftest open-then-edit-then-close-cycle
   (testing "the full open → edit → close cycle returns the dialog to idle"
-    (let [s0 review-dialog/initial-state
-          s1 (review-dialog/open s0 :story.x/y {:args {:n 1}} 1000 "saved")
-          s2 (review-dialog/parse-and-set-draft-id s1 ":story.x/edited")
-          s3 (review-dialog/parse-and-set-draft-id s2 ":story.x/edited-again")
-          s4 (review-dialog/close s3)]
+    (let [s0 rf.story.review-dialog/initial-state
+          s1 (rf.story.review-dialog/open s0 :story.x/y {:args {:n 1}} 1000 "saved")
+          s2 (rf.story.review-dialog/parse-and-set-draft-id s1 ":story.x/edited")
+          s3 (rf.story.review-dialog/parse-and-set-draft-id s2 ":story.x/edited-again")
+          s4 (rf.story.review-dialog/close s3)]
       (is (false? (:open? s0)))
       (is (true?  (:open? s1)))
       (is (= :story.x/edited       (:draft-id s2)))
       (is (= :story.x/edited-again (:draft-id s3)))
-      (is (= review-dialog/initial-state s4)))))
+      (is (= rf.story.review-dialog/initial-state s4)))))
 
 ;; ---- indent-after (snippet-format helper, rf2-zs0w4) ---------------------
 
 (deftest indent-after-shape
   (testing "indent-after returns a newline followed by N spaces matching prefix width"
-    (is (= "\n" (pred/indent-after "")))
-    (is (= "\n " (pred/indent-after "x")))
-    (is (= "\n     " (pred/indent-after "12345")))))
+    (is (= "\n" (rf.story.predicates/indent-after "")))
+    (is (= "\n " (rf.story.predicates/indent-after "x")))
+    (is (= "\n     " (rf.story.predicates/indent-after "12345")))))
 
 (deftest indent-after-aligns-recorder-play-body
   (testing "the indent lines steps up under the first item of `:script [` on the previous line"
     (let [prefix      "   :script ["
           first-line  (str prefix "[:dispatch-sync [:counter/inc]]")
-          cont-indent (pred/indent-after prefix)
+          cont-indent (rf.story.predicates/indent-after prefix)
           full        (str first-line cont-indent "[:dispatch-sync [:counter/dec]]")
           lines       (clojure.string/split full #"\n")
           ;; column of the first step char on line 1 = (count prefix)
@@ -215,7 +215,7 @@
   (testing "the indent lines kv pairs up under the first kv of `:args {` on the previous line"
     (let [prefix      "   :args {"
           first-line  (str prefix ":a 1")
-          cont-indent (pred/indent-after prefix)
+          cont-indent (rf.story.predicates/indent-after prefix)
           full        (str first-line cont-indent ":b 2")
           lines       (clojure.string/split full #"\n")
           line1-first-kv-col (count prefix)
@@ -226,9 +226,9 @@
 
 (deftest indent-after-pure-and-deterministic
   (testing "the helper is pure — same input → same output"
-    (is (= (pred/indent-after "   :name {")
-           (pred/indent-after "   :name {")))
+    (is (= (rf.story.predicates/indent-after "   :name {")
+           (rf.story.predicates/indent-after "   :name {")))
     ;; And two equal-width body prefixes collapse to the same indent width
     ;; (both keys are 4 chars; both bodies indent 3 + key + space + bracket = 10)
-    (is (= (pred/indent-after "   :name {")
-           (pred/indent-after "   :args {")))))
+    (is (= (rf.story.predicates/indent-after "   :name {")
+           (rf.story.predicates/indent-after "   :args {")))))

--- a/tools/story/test/re_frame/story_runtime_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_runtime_cljs_test.cljs
@@ -13,15 +13,15 @@
   smoke just confirms the function runs)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.machines :as machines]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story :as story]
-            [re-frame.story.async :as async-lib]
-            [re-frame.story.loaders :as loaders]
-            [re-frame.story.play.runner-events :as re]
-            [re-frame.subs :as subs]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.machines :as rf.machines]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.async :as rf.story.async]
+            [re-frame.story.loaders :as rf.story.loaders]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]
+            [re-frame.subs :as rf.subs]))
 
 ;; ---- fixtures ------------------------------------------------------------
 ;;
@@ -35,13 +35,13 @@
 ;; non-empty registrar carrying over between tests.
 
 (defn reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
   ;; Seat the plain-atom adapter. `rf/init!` is idempotent at the
   ;; install-adapter! layer (the test build may have seated it
   ;; already via another suite's boot).
-  (try (rf/init! plain-atom/adapter)
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch :default _ nil))
   ;; Re-register the machines artefact's framework-shipped sub
   ;; (`:rf/machine`) after the registrar clear. The JVM equivalent
@@ -51,13 +51,13 @@
   ;; state at [:rf.runtime/machines :snapshots <id>], so the framework sub
   ;; is a runtime-db sub (db-position arg is the runtime-db value) — mirror
   ;; `re-frame.machines` exactly, NOT the retired app-db `:rf/runtime` path.
-  (subs/reg-runtime-sub :rf/machine
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [runtime-db [_ machine-id]]
       (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 ;; Per cljs.test: async tests require fixtures to be supplied in
 ;; map form — function-form fixtures can't suspend around the async
@@ -70,18 +70,18 @@
   (testing "run-variant returns a js/Promise"
     (rf/reg-event :test/inc
       (fn [{:keys [db]} _] {:db (update db :counter (fnil inc 0))}))
-    (story/reg-variant :story.cljs.run/v
+    (rf.story/reg-variant :story.cljs.run/v
       {:setup [[:test/inc] [:test/inc]]})
-    (let [p (story/run-variant :story.cljs.run/v)]
-      (is (async-lib/promise? p))
+    (let [p (rf.story/run-variant :story.cljs.run/v)]
+      (is (rf.story.async/promise? p))
       (async done
         (-> p
-            (async-lib/then
+            (rf.story.async/then
               (fn [r]
                 (is (= :story.cljs.run/v (:frame r)))
                 (is (= :ready            (:lifecycle r)))
                 (is (= 2                 (:counter (:app-db r))))
-                (story/destroy-variant! :story.cljs.run/v)
+                (rf.story/destroy-variant! :story.cljs.run/v)
                 (done))))))))
 
 ;; ---- rf2-043cm — events-only fast-path on CLJS --------------------------
@@ -103,12 +103,12 @@
             `:frame-setup` decorators / no `:loaders-complete-when`."
     (rf/reg-event :test.eo/seed
       (fn [{:keys [db]} _] {:db (assoc db :seeded? true)}))
-    (story/reg-variant :story.cljs.eo/v
+    (rf.story/reg-variant :story.cljs.eo/v
       {:setup [[:test.eo/seed]]})
-    (let [p (story/run-variant :story.cljs.eo/v)]
+    (let [p (rf.story/run-variant :story.cljs.eo/v)]
       (async done
         (-> p
-            (async-lib/then
+            (rf.story.async/then
               (fn [r]
                 (is (= :ready  (:lifecycle r))
                     "events-only variant lands :ready")
@@ -116,23 +116,23 @@
                     "events still dispatched after the fast-path mount")
                 (is (empty? (:assertions r))
                     "no `:rf.error/loader-incomplete` projection on the fast-path")
-                (story/destroy-variant! :story.cljs.eo/v)
+                (rf.story/destroy-variant! :story.cljs.eo/v)
                 (done))))))))
 
 (deftest cljs-events-only-classifier
-  (testing "rf2-043cm — `loaders/events-only-variant?` classifies the
+  (testing "rf2-043cm — `rf.story.loaders/events-only-variant?` classifies the
             canonical events-only loader-body shape on CLJS"
-    (is (true?  (loaders/events-only-variant? {:setup [[:counter/initialise 5]]}
+    (is (true?  (rf.story.loaders/events-only-variant? {:setup [[:counter/initialise 5]]}
                                               {:hiccup [] :frame-setup []
                                                :fx-override [] :errors []}))
         "the counter_with_stories `:story.counter/events-only-loaded`
          body shape (preserved from the retired xray-rhs-smoke
          testbed per rf2-9jfo1.2) → events-only")
-    (is (false? (loaders/events-only-variant? {:loaders [[:l]]} {}))
+    (is (false? (rf.story.loaders/events-only-variant? {:loaders [[:l]]} {}))
         ":loaders disqualifies")
-    (is (false? (loaders/events-only-variant? {:loaders-complete-when :p?} {}))
+    (is (false? (rf.story.loaders/events-only-variant? {:loaders-complete-when :p?} {}))
         ":loaders-complete-when disqualifies")
-    (is (false? (loaders/events-only-variant? {} {:frame-setup [{:body {}}]}))
+    (is (false? (rf.story.loaders/events-only-variant? {} {:frame-setup [{:body {}}]}))
         ":frame-setup decorators disqualify")))
 
 ;; ---- rf2-9x5fm — the run-variant promise resolves even when the play -----
@@ -158,7 +158,7 @@
             aborted run loop settles its continuation instead of hanging"
     (rf/reg-event :test.hang/touch
       (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-    (story/reg-variant :story.cljs.hang/torn-down
+    (rf.story/reg-variant :story.cljs.hang/torn-down
       {:setup      []
        :script {:script [[:dispatch-sync [:test.hang/touch]]
                               ;; The async yield window: the frame is
@@ -168,14 +168,14 @@
                               [:wait 60]
                               [:dispatch-sync [:test.hang/touch]]]}})
     (async done
-      (let [p (story/run-variant :story.cljs.hang/torn-down)]
+      (let [p (rf.story/run-variant :story.cljs.hang/torn-down)]
         ;; Destroy the frame mid-:wait (after run-phase-4! has scheduled the
         ;; wait's setTimeout, before it resumes). This wipes the run-state
         ;; slot (`clear-state!` via the :drop-run-state teardown hook), so the
         ;; resuming loop hits the `(nil? state)` abort branch.
-        (js/setTimeout #(story/destroy-variant! :story.cljs.hang/torn-down) 15)
+        (js/setTimeout #(rf.story/destroy-variant! :story.cljs.hang/torn-down) 15)
         (-> p
-            (async-lib/then
+            (rf.story.async/then
               (fn [r]
                 (is (map? r)
                     "the run-variant promise RESOLVED — the torn-down-mid-wait
@@ -189,22 +189,22 @@
             its own continuation rather than stranding the chain"
     (rf/reg-event :test.hang2/touch
       (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-    (story/reg-variant :story.cljs.hang/token-swap
+    (rf.story/reg-variant :story.cljs.hang/token-swap
       {:setup      []
        :script {:auto-run? false
                      :script [[:dispatch-sync [:test.hang2/touch]]
                               [:wait 60]
                               [:dispatch-sync [:test.hang2/touch]]]}})
     (async done
-      (let [p (story/run-variant :story.cljs.hang/token-swap)]
+      (let [p (rf.story/run-variant :story.cljs.hang/token-swap)]
         (-> p
-            (async-lib/then
+            (rf.story.async/then
               (fn [r]
                 (is (map? r)
                     "the original run-variant promise RESOLVED even though a
                      concurrent run! swapped the run-state token mid-:wait —
                      the stale loop's continuation settled (rf2-9x5fm)")
-                (story/destroy-variant! :story.cljs.hang/token-swap)
+                (rf.story/destroy-variant! :story.cljs.hang/token-swap)
                 (done))))
         ;; Mid-:wait, fire a concurrent runner-events/run! for the SAME
         ;; variant. It stamps a fresher :run-token onto the shared slot, so
@@ -213,18 +213,18 @@
         ;; itself is allowed to complete; we only assert the ORIGINAL promise
         ;; resolves.
         (js/setTimeout
-          #(re/run! :story.cljs.hang/token-swap)
+          #(rf.story.play.runner-events/run! :story.cljs.hang/token-swap)
           15)))))
 
 ;; ---- snapshot-identity --------------------------------------------------
 
 (deftest cljs-snapshot-identity-shape
   (testing "snapshot-identity produces an 8-char hex hash"
-    (story/reg-story :story.cljs.id
+    (rf.story/reg-story :story.cljs.id
       {:component :app/v :args {:a 1}})
-    (story/reg-variant :story.cljs.id/v
+    (rf.story/reg-variant :story.cljs.id/v
       {:setup [[:init]] :tags #{:dev}})
-    (let [s (story/snapshot-identity :story.cljs.id/v
+    (let [s (rf.story/snapshot-identity :story.cljs.id/v
                                      {:substrate :reagent})]
       (is (= :story.cljs.id/v (:variant-id s)))
       (is (string?            (:content-hash s)))
@@ -235,12 +235,12 @@
 
 (deftest cljs-resolve-args-precedence
   (testing "args precedence chain works on CLJS"
-    (story/configure! {:rf.story/global-args {:theme :light}})
-    (story/reg-story :story.cljs.args
+    (rf.story/configure! {:rf.story/global-args {:theme :light}})
+    (rf.story/reg-story :story.cljs.args
       {:args {:label "story"}})
-    (story/reg-variant :story.cljs.args/v
+    (rf.story/reg-variant :story.cljs.args/v
       {:args {:label "variant"} :setup []})
-    (let [r (story/resolve-args :story.cljs.args/v
+    (let [r (rf.story/resolve-args :story.cljs.args/v
                                 {:cell-overrides {:icon :star}})]
       (is (= :light    (:theme r)))
       (is (= "variant" (:label r)))
@@ -250,12 +250,12 @@
 
 (deftest cljs-decorator-resolution
   (testing "decorator resolution works on CLJS"
-    (story/reg-decorator :centered
+    (rf.story/reg-decorator :centered
       {:kind :hiccup
        :wrap (fn [body _] [:div.centered body])})
-    (story/reg-variant :story.cljs.dec/v
+    (rf.story/reg-variant :story.cljs.dec/v
       {:decorators [[:centered]]
        :setup     []})
-    (let [r (story/resolve-decorators :story.cljs.dec/v)]
+    (let [r (rf.story/resolve-decorators :story.cljs.dec/v)]
       (is (= 1 (count (:hiccup r))))
       (is (= :centered (-> r :hiccup first :id))))))

--- a/tools/story/test/re_frame/story_runtime_lifecycle_test.clj
+++ b/tools/story/test/re_frame/story_runtime_lifecycle_test.clj
@@ -34,30 +34,30 @@
   teardown — these tests pin the contract the caller relies on."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core            :as rf]
-            [re-frame.frame           :as frame]
-            [re-frame.machines        :as machines]
-            [re-frame.registrar       :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story           :as story]
-            [re-frame.story.async     :as async]
-            [re-frame.story.config    :as config]
-            [re-frame.story.frames    :as frames]
-            [re-frame.story.loaders   :as loaders]))
+            [re-frame.frame           :as rf.frame]
+            [re-frame.machines        :as rf.machines]
+            [re-frame.registrar       :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story           :as rf.story]
+            [re-frame.story.async     :as rf.story.async]
+            [re-frame.story.config    :as rf.story.config]
+            [re-frame.story.frames    :as rf.story.frames]
+            [re-frame.story.loaders   :as rf.story.loaders]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
 (defn reset-all [t]
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
   (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (config/set-global-args! {})
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.config/set-global-args! {})
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   ;; rf2-043cm — every variant body in this corpus that registers
   ;; `:loaders [[:test/noop]]` needs a no-op event handler. Register
   ;; once per test so the loader-cascade path takes the classical
@@ -79,62 +79,62 @@
     ;; classical four-phase path (`:pre-mount → :mounting → :loading
     ;; → :ready`). The body-shape gates the lifecycle route now; the
     ;; events-only fast-path is exercised separately below.
-    (story/reg-variant :story.watch.solo/v {:loaders [[:test/noop]]})
+    (rf.story/reg-variant :story.watch.solo/v {:loaders [[:test/noop]]})
     (let [seen-a      (atom [])
           seen-b      (atom [])
-          unsub-a     (story/watch-variant :story.watch.solo/v
+          unsub-a     (rf.story/watch-variant :story.watch.solo/v
                         (fn [t] (swap! seen-a conj (:to t))))
-          _unsub-b    (story/watch-variant :story.watch.solo/v
+          _unsub-b    (rf.story/watch-variant :story.watch.solo/v
                         (fn [t] (swap! seen-b conj (:to t))))
-          decs        (story/resolve-decorators :story.watch.solo/v)]
+          decs        (rf.story/resolve-decorators :story.watch.solo/v)]
       ;; Drop A; only B should fire.
       (unsub-a)
-      (frames/allocate! :story.watch.solo/v decs)
-      (loaders/start-loaders! :story.watch.solo/v)
-      (loaders/finish-loaders! :story.watch.solo/v)
+      (rf.story.frames/allocate! :story.watch.solo/v decs)
+      (rf.story.loaders/start-loaders! :story.watch.solo/v)
+      (rf.story.loaders/finish-loaders! :story.watch.solo/v)
       (is (= []                                @seen-a)
           "A was unsubscribed before allocation — its log stays empty")
       (is (= [:mounting :loading :ready]        @seen-b)
           "B saw every transition")
-      (frames/destroy! :story.watch.solo/v))))
+      (rf.story.frames/destroy! :story.watch.solo/v))))
 
 (deftest multiple-watchers-each-see-every-transition
   (testing "two registered watchers each see the full transition sequence"
     ;; rf2-043cm — `:loaders` keeps the classical four-phase route.
-    (story/reg-variant :story.watch.multi/v {:loaders [[:test/noop]]})
+    (rf.story/reg-variant :story.watch.multi/v {:loaders [[:test/noop]]})
     (let [seen-a  (atom [])
           seen-b  (atom [])]
-      (story/watch-variant :story.watch.multi/v
+      (rf.story/watch-variant :story.watch.multi/v
         (fn [t] (swap! seen-a conj [(:from t) (:to t)])))
-      (story/watch-variant :story.watch.multi/v
+      (rf.story/watch-variant :story.watch.multi/v
         (fn [t] (swap! seen-b conj [(:from t) (:to t)])))
-      (frames/allocate! :story.watch.multi/v (story/resolve-decorators :story.watch.multi/v))
-      (loaders/start-loaders! :story.watch.multi/v)
-      (loaders/finish-loaders! :story.watch.multi/v)
+      (rf.story.frames/allocate! :story.watch.multi/v (rf.story/resolve-decorators :story.watch.multi/v))
+      (rf.story.loaders/start-loaders! :story.watch.multi/v)
+      (rf.story.loaders/finish-loaders! :story.watch.multi/v)
       (is (= [[:pre-mount :mounting] [:mounting :loading] [:loading :ready]]
              @seen-a))
       (is (= @seen-a @seen-b)
           "concurrent watchers see identical transition sequences")
-      (frames/destroy! :story.watch.multi/v))))
+      (rf.story.frames/destroy! :story.watch.multi/v))))
 
 (deftest throwing-watcher-does-not-starve-peers
   (testing "a watcher callback that throws does NOT starve peer watchers —
             the per-callback try/catch in fire-watchers! keeps the loop alive
             so a misbehaving subscriber can't break the rest"
     ;; rf2-043cm — `:loaders` keeps the classical four-phase route.
-    (story/reg-variant :story.watch.boom/v {:loaders [[:test/noop]]})
+    (rf.story/reg-variant :story.watch.boom/v {:loaders [[:test/noop]]})
     (let [peer-seen (atom [])]
-      (story/watch-variant :story.watch.boom/v
+      (rf.story/watch-variant :story.watch.boom/v
         (fn [_t] (throw (ex-info "boom" {:why :test}))))
-      (story/watch-variant :story.watch.boom/v
+      (rf.story/watch-variant :story.watch.boom/v
         (fn [t] (swap! peer-seen conj (:to t))))
-      (frames/allocate! :story.watch.boom/v (story/resolve-decorators :story.watch.boom/v))
-      (loaders/start-loaders! :story.watch.boom/v)
-      (loaders/finish-loaders! :story.watch.boom/v)
+      (rf.story.frames/allocate! :story.watch.boom/v (rf.story/resolve-decorators :story.watch.boom/v))
+      (rf.story.loaders/start-loaders! :story.watch.boom/v)
+      (rf.story.loaders/finish-loaders! :story.watch.boom/v)
       (is (= [:mounting :loading :ready] @peer-seen)
           "the peer watcher received every transition despite the
            throwing watcher registered ahead of it")
-      (frames/destroy! :story.watch.boom/v))))
+      (rf.story.frames/destroy! :story.watch.boom/v))))
 
 ;; ===========================================================================
 ;; DESTROY-VARIANT! — teardown contract
@@ -146,72 +146,72 @@
             watchers carry over from the previous run"
     ;; rf2-043cm — `:loaders` keeps the classical four-phase route so
     ;; the watcher captures the `:mounting → :loading → :ready` cascade.
-    (story/reg-variant :story.destroy.watchers/v {:loaders [[:test/noop]]})
+    (rf.story/reg-variant :story.destroy.watchers/v {:loaders [[:test/noop]]})
     (let [seen (atom [])]
-      (story/watch-variant :story.destroy.watchers/v
+      (rf.story/watch-variant :story.destroy.watchers/v
         (fn [t] (swap! seen conj (:to t))))
-      (frames/allocate! :story.destroy.watchers/v
-                        (story/resolve-decorators :story.destroy.watchers/v))
-      (loaders/start-loaders! :story.destroy.watchers/v)
-      (loaders/finish-loaders! :story.destroy.watchers/v)
+      (rf.story.frames/allocate! :story.destroy.watchers/v
+                        (rf.story/resolve-decorators :story.destroy.watchers/v))
+      (rf.story.loaders/start-loaders! :story.destroy.watchers/v)
+      (rf.story.loaders/finish-loaders! :story.destroy.watchers/v)
       (let [before-destroy (count @seen)]
-        (story/destroy-variant! :story.destroy.watchers/v)
+        (rf.story/destroy-variant! :story.destroy.watchers/v)
         ;; Re-allocate; the previous watcher must NOT fire on this fresh run.
-        (frames/allocate! :story.destroy.watchers/v
-                          (story/resolve-decorators :story.destroy.watchers/v))
-        (loaders/start-loaders! :story.destroy.watchers/v)
-        (loaders/finish-loaders! :story.destroy.watchers/v)
+        (rf.story.frames/allocate! :story.destroy.watchers/v
+                          (rf.story/resolve-decorators :story.destroy.watchers/v))
+        (rf.story.loaders/start-loaders! :story.destroy.watchers/v)
+        (rf.story.loaders/finish-loaders! :story.destroy.watchers/v)
         (is (= before-destroy (count @seen))
             "destroyed-frame watchers do not fire on the next run")
-        (frames/destroy! :story.destroy.watchers/v)))))
+        (rf.story.frames/destroy! :story.destroy.watchers/v)))))
 
 (deftest destroy-variant-removes-from-variant-frames
   (testing "after destroy-variant! the variant id no longer appears in
-            (story/variant-frames) — the registry is in step with the runtime"
+            (rf.story/variant-frames) — the registry is in step with the runtime"
     (rf/reg-event :test/nothing (fn [{:keys [db]} _] {:db db}))
-    (story/reg-variant :story.destroy.list/v
+    (rf.story/reg-variant :story.destroy.list/v
       {:setup [[:test/nothing]]})
-    (let [_ (async/deref-blocking (story/run-variant :story.destroy.list/v) 5000)]
-      (is (contains? (story/variant-frames) :story.destroy.list/v)
+    (let [_ (rf.story.async/deref-blocking (rf.story/run-variant :story.destroy.list/v) 5000)]
+      (is (contains? (rf.story/variant-frames) :story.destroy.list/v)
           "the running variant is listed before destroy")
-      (story/destroy-variant! :story.destroy.list/v)
-      (is (not (contains? (story/variant-frames) :story.destroy.list/v))
+      (rf.story/destroy-variant! :story.destroy.list/v)
+      (is (not (contains? (rf.story/variant-frames) :story.destroy.list/v))
           "the destroyed variant is gone from the listing"))))
 
 (deftest destroy-variant-idempotent-on-running-frame
   (testing "calling destroy-variant! twice in a row does not throw"
     (rf/reg-event :test/nothing (fn [{:keys [db]} _] {:db db}))
-    (story/reg-variant :story.destroy.twice/v
+    (rf.story/reg-variant :story.destroy.twice/v
       {:setup [[:test/nothing]]})
-    (async/deref-blocking (story/run-variant :story.destroy.twice/v) 5000)
-    (is (nil? (story/destroy-variant! :story.destroy.twice/v)))
-    (is (nil? (story/destroy-variant! :story.destroy.twice/v))
+    (rf.story.async/deref-blocking (rf.story/run-variant :story.destroy.twice/v) 5000)
+    (is (nil? (rf.story/destroy-variant! :story.destroy.twice/v)))
+    (is (nil? (rf.story/destroy-variant! :story.destroy.twice/v))
         "second destroy is a no-op (returns nil, no throw)")))
 
 (deftest destroy-variant-on-unallocated-id-does-not-throw
   (testing "destroy-variant! on a never-allocated id is a no-op"
-    (is (nil? (story/destroy-variant! :story.never/allocated))
+    (is (nil? (rf.story/destroy-variant! :story.never/allocated))
         "no frame, no watchers, no assertion accumulators — nothing to do")))
 
 (deftest run-then-destroy-then-run-cycles-cleanly
   (testing "destroy + re-run leaves the lifecycle in :ready — the Stage 4
             UI shell relies on this for the 'reset' button affordance"
     (rf/reg-event :test/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-    (story/reg-variant :story.cycle/v
+    (rf.story/reg-variant :story.cycle/v
       {:setup [[:test/inc]]})
     ;; First run.
-    (let [r1 (async/deref-blocking (story/run-variant :story.cycle/v) 5000)]
+    (let [r1 (rf.story.async/deref-blocking (rf.story/run-variant :story.cycle/v) 5000)]
       (is (= :ready (:lifecycle r1)))
       (is (= 1 (:n (:app-db r1)))))
     ;; Tear down + re-run via destroy + run-variant (cycle the Stage 4
     ;; reset button takes when re-running fully from scratch).
-    (story/destroy-variant! :story.cycle/v)
-    (let [r2 (async/deref-blocking (story/run-variant :story.cycle/v) 5000)]
+    (rf.story/destroy-variant! :story.cycle/v)
+    (let [r2 (rf.story.async/deref-blocking (rf.story/run-variant :story.cycle/v) 5000)]
       (is (= :ready (:lifecycle r2))
           "second run lands :ready cleanly — no residual lifecycle state")
       (is (= 1 (:n (:app-db r2)))
           "fresh app-db; counter starts from 0 then ticks to 1"))
-    (story/destroy-variant! :story.cycle/v)))
+    (rf.story/destroy-variant! :story.cycle/v)))
 
 (deftest watch-variant-during-run-receives-finalising-transitions
   (testing "a watcher registered between phases sees the remaining transitions
@@ -219,16 +219,16 @@
             at allocate-time"
     ;; rf2-043cm — `:loaders` keeps the classical four-phase route so
     ;; the late-registered watcher captures both remaining transitions.
-    (story/reg-variant :story.watch.late/v {:loaders [[:test/noop]]})
+    (rf.story/reg-variant :story.watch.late/v {:loaders [[:test/noop]]})
     (let [seen (atom [])
-          decs (story/resolve-decorators :story.watch.late/v)]
+          decs (rf.story/resolve-decorators :story.watch.late/v)]
       ;; Allocate first — :pre-mount → :mounting transition fires here.
-      (frames/allocate! :story.watch.late/v decs)
+      (rf.story.frames/allocate! :story.watch.late/v decs)
       ;; Now register the watcher. It missed the first transition.
-      (story/watch-variant :story.watch.late/v
+      (rf.story/watch-variant :story.watch.late/v
         (fn [t] (swap! seen conj [(:from t) (:to t)])))
-      (loaders/start-loaders! :story.watch.late/v)
-      (loaders/finish-loaders! :story.watch.late/v)
+      (rf.story.loaders/start-loaders! :story.watch.late/v)
+      (rf.story.loaders/finish-loaders! :story.watch.late/v)
       (is (= [[:mounting :loading] [:loading :ready]] @seen)
           "late-registered watcher caught the two transitions after registration")
-      (frames/destroy! :story.watch.late/v))))
+      (rf.story.frames/destroy! :story.watch.late/v))))

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -23,21 +23,21 @@
   Promise on CLJS); the tests `deref` it for the result map."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core            :as rf]
-            [re-frame.frame           :as frame]
-            [re-frame.late-bind       :as late-bind]
-            [re-frame.machines        :as machines]
-            [re-frame.registrar       :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story           :as story]
-            [re-frame.story.args      :as args]
-            [re-frame.story.async     :as async]
-            [re-frame.story.config    :as config]
-            [re-frame.story.decorators :as decorators]
-            [re-frame.story.fingerprint :as fp]
-            [re-frame.story.frames    :as frames]
-            [re-frame.story.identity  :as ident]
-            [re-frame.story.loaders   :as loaders]
-            [re-frame.story.runtime   :as runtime]
+            [re-frame.frame           :as rf.frame]
+            [re-frame.late-bind       :as rf.late-bind]
+            [re-frame.machines        :as rf.machines]
+            [re-frame.registrar       :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story           :as rf.story]
+            [re-frame.story.args      :as rf.story.args]
+            [re-frame.story.async     :as rf.story.async]
+            [re-frame.story.config    :as rf.story.config]
+            [re-frame.story.decorators :as rf.story.decorators]
+            [re-frame.story.fingerprint :as rf.story.fingerprint]
+            [re-frame.story.frames    :as rf.story.frames]
+            [re-frame.story.identity  :as rf.story.identity]
+            [re-frame.story.loaders   :as rf.story.loaders]
+            [re-frame.story.runtime   :as rf.story.runtime]
             ;; EP-0023 behaviour-variant image fixtures (rf2-fpr0b5): two
             ;; namespaces register the SAME event id with DIFFERENT meanings;
             ;; a variant's `:images` `:select-ns` selects one or the other.
@@ -53,27 +53,27 @@
 
 (defn reset-all [test-fn]
   ;; Tear down Story's side-table.
-  (story/clear-all!)
+  (rf.story/clear-all!)
   ;; Tear down the framework registrar so test isolation holds.
-  (registrar/clear-all!)
+  (rf.registrar/clear-all!)
   ;; Tear down every non-default frame.
-  (reset! frame/frames {})
+  (reset! rf.frame/frames {})
   ;; Install the plain-atom adapter (matches the machines test fixture
   ;; pattern). `rf/init!` is idempotent once seated; we tolerate the
   ;; double-install error if the adapter is already in place.
-  (try (rf/init! plain-atom/adapter)
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
   ;; Re-require machines so its framework `:rf/machine` runtime-db sub
   ;; (EP-0001: reads `[:rf.runtime/machines :snapshots <id>]`) survives the
-  ;; registrar/clear-all! call. Mirrors the machines test fixtures.
+  ;; rf.registrar/clear-all! call. Mirrors the machines test fixtures.
   (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (config/set-global-args! {})
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.config/set-global-args! {})
   ;; Re-install the canonical vocabulary (tags + lifecycle machine).
-  (story/install-canonical-vocabulary!)
+  (rf.story/install-canonical-vocabulary!)
   ;; Make sure :rf/default is always present.
-  (frame/ensure-default-frame!)
+  (rf.frame/ensure-default-frame!)
   (test-fn))
 
 (use-fixtures :each reset-all)
@@ -85,31 +85,31 @@
 (deftest deep-merge-merges-nested-maps
   (testing "deep-merge recurses into maps"
     (is (= {:a {:b 1 :c 2}}
-           (args/deep-merge {:a {:b 1}} {:a {:c 2}}))))
+           (rf.story.args/deep-merge {:a {:b 1}} {:a {:c 2}}))))
 
   (testing "non-map values replace"
     (is (= {:a [3]}
-           (args/deep-merge {:a [1 2]} {:a [3]}))))
+           (rf.story.args/deep-merge {:a [1 2]} {:a [3]}))))
 
   (testing "nil right-hand is a no-op"
-    (is (= {:a 1} (args/deep-merge {:a 1} nil))))
+    (is (= {:a 1} (rf.story.args/deep-merge {:a 1} nil))))
 
   (testing "scalar replaces nested map"
-    (is (= {:a 5} (args/deep-merge {:a {:b 1}} {:a 5})))))
+    (is (= {:a 5} (rf.story.args/deep-merge {:a {:b 1}} {:a 5})))))
 
 (deftest resolve-args-precedence-chain
   (testing "global < story < mode < variant < cell-overrides"
-    (story/configure! {:rf.story/global-args {:theme :light :verbose? false}})
-    (story/reg-story :story.ui.button
+    (rf.story/configure! {:rf.story/global-args {:theme :light :verbose? false}})
+    (rf.story/reg-story :story.ui.button
       {:doc       "btn"
        :component :app.ui/button
        :args      {:label "Story label" :verbose? true}})
-    (story/reg-mode :Mode.app/dark
+    (rf.story/reg-mode :Mode.app/dark
       {:args {:theme :dark}})
-    (story/reg-variant :story.ui.button/default
+    (rf.story/reg-variant :story.ui.button/default
       {:args   {:label "Variant label" :icon :star}
        :setup []})
-    (let [resolved (story/resolve-args :story.ui.button/default
+    (let [resolved (rf.story/resolve-args :story.ui.button/default
                                        {:active-modes  [:Mode.app/dark]
                                         :cell-overrides {:label "Cell label"}})]
       (is (= :dark         (:theme resolved))    "mode wins over global")
@@ -119,20 +119,20 @@
 
 (deftest resolve-args-deep-merge-on-nested
   (testing "nested maps deep-merge across layers"
-    (story/configure! {:rf.story/global-args {:layout {:max-width 1024 :padding 8}}})
-    (story/reg-story :story.layout.box
+    (rf.story/configure! {:rf.story/global-args {:layout {:max-width 1024 :padding 8}}})
+    (rf.story/reg-story :story.layout.box
       {:args {:layout {:padding 16}}})
-    (story/reg-variant :story.layout.box/deep
+    (rf.story/reg-variant :story.layout.box/deep
       {:args   {:layout {:margin 4}}
        :setup []})
-    (let [r (story/resolve-args :story.layout.box/deep)]
+    (let [r (rf.story/resolve-args :story.layout.box/deep)]
       (is (= 1024 (get-in r [:layout :max-width])))
       (is (= 16   (get-in r [:layout :padding]))   "story wins")
       (is (= 4    (get-in r [:layout :margin]))))))
 
 (deftest resolve-args-unregistered-variant
   (testing "unregistered variant resolves to {} without throwing"
-    (is (= {} (story/resolve-args :story.missing/x)))))
+    (is (= {} (rf.story/resolve-args :story.missing/x)))))
 
 ;; ===========================================================================
 ;; DECORATOR COMPOSITION
@@ -140,20 +140,20 @@
 
 (deftest decorators-classified-by-kind
   (testing "hiccup / frame-setup / fx-override decorators land in their slots"
-    (story/reg-decorator :centered
+    (rf.story/reg-decorator :centered
       {:kind :hiccup
        :wrap (fn [body _args] [:div.centered body])})
-    (story/reg-decorator :mock-auth
+    (rf.story/reg-decorator :mock-auth
       {:kind :frame-setup
        :init [[:auth/restore-session {:user "alice"}]]})
-    (story/reg-decorator :stub-http
+    (rf.story/reg-decorator :stub-http
       {:kind :fx-override
        :fx-id :http
        :response {:status :pending}})
-    (story/reg-variant :story.composed/v
+    (rf.story/reg-variant :story.composed/v
       {:decorators [[:centered] [:mock-auth] [:stub-http]]
        :setup     []})
-    (let [r (story/resolve-decorators :story.composed/v)]
+    (let [r (rf.story/resolve-decorators :story.composed/v)]
       (is (= 1 (count (:hiccup r))))
       (is (= :centered (-> r :hiccup first :id)))
       (is (= 1 (count (:frame-setup r))))
@@ -164,61 +164,61 @@
 
 (deftest decorators-story-then-variant-order
   (testing "story decorators come before variant decorators in declared order"
-    (story/reg-decorator :outer
+    (rf.story/reg-decorator :outer
       {:kind :hiccup
        :wrap (fn [body _args] [:div.outer body])})
-    (story/reg-decorator :inner
+    (rf.story/reg-decorator :inner
       {:kind :hiccup
        :wrap (fn [body _args] [:div.inner body])})
-    (story/reg-story :story.compose
+    (rf.story/reg-story :story.compose
       {:decorators [[:outer]]})
-    (story/reg-variant :story.compose/v
+    (rf.story/reg-variant :story.compose/v
       {:decorators [[:inner]]
        :setup     []})
-    (let [r       (story/resolve-decorators :story.compose/v)
+    (let [r       (rf.story/resolve-decorators :story.compose/v)
           ids     (mapv :id (:hiccup r))]
       (is (= [:outer :inner] ids)
           "story decorators precede variant decorators in declared order"))))
 
 (deftest decorators-apply-hiccup-outermost-first
   (testing "apply-hiccup-decorators wraps innermost first, outermost last"
-    (story/reg-decorator :outer
+    (rf.story/reg-decorator :outer
       {:kind :hiccup
        :wrap (fn [body _args] [:div.outer body])})
-    (story/reg-decorator :inner
+    (rf.story/reg-decorator :inner
       {:kind :hiccup
        :wrap (fn [body _args] [:div.inner body])})
-    (story/reg-story :story.wrap
+    (rf.story/reg-story :story.wrap
       {:decorators [[:outer]]})
-    (story/reg-variant :story.wrap/v
+    (rf.story/reg-variant :story.wrap/v
       {:decorators [[:inner]]
        :setup     []})
-    (let [r       (story/resolve-decorators :story.wrap/v)
-          wrapped (decorators/apply-hiccup-decorators (:hiccup r) [:span "x"] {})]
+    (let [r       (rf.story/resolve-decorators :story.wrap/v)
+          wrapped (rf.story.decorators/apply-hiccup-decorators (:hiccup r) [:span "x"] {})]
       ;; Outermost is :outer; inside it is :inner; inside that is the span.
       (is (= [:div.outer [:div.inner [:span "x"]]] wrapped)))))
 
 (deftest decorators-unknown-id-becomes-error
   (testing "an unregistered decorator id surfaces in :errors"
-    (story/reg-variant :story.bad/v
+    (rf.story/reg-variant :story.bad/v
       {:decorators [[:totally-unregistered]]
        :setup     []})
-    (let [r (story/resolve-decorators :story.bad/v)]
+    (let [r (rf.story/resolve-decorators :story.bad/v)]
       (is (= 1 (count (:errors r))))
       (is (= :rf.error/decorator-unknown
              (-> r :errors first :rf.error))))))
 
 (deftest fx-overrides-map-last-wins
   (testing "two fx-override decorators with the same :fx-id resolve last-wins"
-    (story/reg-decorator :first-stub
+    (rf.story/reg-decorator :first-stub
       {:kind :fx-override :fx-id :http :response {:n 1}})
-    (story/reg-decorator :second-stub
+    (rf.story/reg-decorator :second-stub
       {:kind :fx-override :fx-id :http :response {:n 2}})
-    (story/reg-variant :story.fx/v
+    (rf.story/reg-variant :story.fx/v
       {:decorators [[:first-stub] [:second-stub]]
        :setup     []})
-    (let [r       (story/resolve-decorators :story.fx/v)
-          stack   (decorators/fx-overrides-map (:fx-override r))]
+    (let [r       (rf.story/resolve-decorators :story.fx/v)
+          stack   (rf.story.decorators/fx-overrides-map (:fx-override r))]
       (is (= 1 (count (:overrides stack)))
           "last-wins: only one entry per fx-id")
       (is (contains? (:overrides stack) :http))
@@ -237,20 +237,20 @@
 (deftest reg-global-decorator-appends-to-resolved-stack
   (testing "a global decorator prefixes the resolved decorator stack for
             every variant — outermost wrap layer per rf2-835ey"
-    (story/reg-global-decorator :app/theme
+    (rf.story/reg-global-decorator :app/theme
       {:kind :hiccup :wrap (fn [body _] [:div.theme body])})
-    (story/reg-decorator :story-deco
+    (rf.story/reg-decorator :story-deco
       {:kind :hiccup :wrap (fn [body _] [:div.story body])})
-    (story/reg-decorator :variant-deco
+    (rf.story/reg-decorator :variant-deco
       {:kind :hiccup :wrap (fn [body _] [:div.variant body])})
-    (story/reg-story :story.gd
+    (rf.story/reg-story :story.gd
       {:decorators [[:story-deco]]})
-    (story/reg-variant :story.gd/v
+    (rf.story/reg-variant :story.gd/v
       {:decorators [[:variant-deco]]
        :setup     []})
-    (let [r       (story/resolve-decorators :story.gd/v)
+    (let [r       (rf.story/resolve-decorators :story.gd/v)
           ids     (mapv :id (:hiccup r))
-          wrapped (decorators/apply-hiccup-decorators
+          wrapped (rf.story.decorators/apply-hiccup-decorators
                     (:hiccup r) [:span "leaf"] {})]
       (is (= [:app/theme :story-deco :variant-deco] ids)
           "global decorator comes first (outermost), then story, then variant")
@@ -261,11 +261,11 @@
   (testing "a global decorator wraps a variant whose parent story has no
             :decorators slot and whose own :decorators slot is empty —
             the global stack still applies"
-    (story/reg-global-decorator :app/wrap
+    (rf.story/reg-global-decorator :app/wrap
       {:kind :hiccup :wrap (fn [body _] [:div.wrap body])})
-    (story/reg-story :story.gd2 {})
-    (story/reg-variant :story.gd2/bare {:setup []})
-    (let [r   (story/resolve-decorators :story.gd2/bare)
+    (rf.story/reg-story :story.gd2 {})
+    (rf.story/reg-variant :story.gd2/bare {:setup []})
+    (let [r   (rf.story/resolve-decorators :story.gd2/bare)
           ids (mapv :id (:hiccup r))]
       (is (= [:app/wrap] ids)
           "bare variant inherits the global stack even with no story
@@ -274,14 +274,14 @@
 (deftest reg-global-decorator-multiple-earliest-first
   (testing "two global decorators apply in registration order — earliest
             first (outermost wrap)"
-    (story/reg-global-decorator :app/g1
+    (rf.story/reg-global-decorator :app/g1
       {:kind :hiccup :wrap (fn [body _] [:div.g1 body])})
-    (story/reg-global-decorator :app/g2
+    (rf.story/reg-global-decorator :app/g2
       {:kind :hiccup :wrap (fn [body _] [:div.g2 body])})
-    (story/reg-variant :story.gd3/v {:setup []})
-    (let [r       (story/resolve-decorators :story.gd3/v)
+    (rf.story/reg-variant :story.gd3/v {:setup []})
+    (let [r       (rf.story/resolve-decorators :story.gd3/v)
           ids     (mapv :id (:hiccup r))
-          wrapped (decorators/apply-hiccup-decorators
+          wrapped (rf.story.decorators/apply-hiccup-decorators
                     (:hiccup r) [:span "x"] {})]
       (is (= [:app/g1 :app/g2] ids)
           "earliest-registered first")
@@ -291,22 +291,22 @@
 (deftest reg-global-decorator-replaces-in-place-on-re-registration
   (testing "re-registering the same global decorator id replaces in place —
             hot-reloading the body must not reshuffle the order"
-    (story/reg-global-decorator :app/first
+    (rf.story/reg-global-decorator :app/first
       {:kind :hiccup :wrap (fn [body _] [:div.first.v1 body])})
-    (story/reg-global-decorator :app/second
+    (rf.story/reg-global-decorator :app/second
       {:kind :hiccup :wrap (fn [body _] [:div.second body])})
     ;; Re-register :app/first with a new body — its position must stay at 0.
-    (story/reg-global-decorator :app/first
+    (rf.story/reg-global-decorator :app/first
       {:kind :hiccup :wrap (fn [body _] [:div.first.v2 body])})
-    (let [refs (story/global-decorators)
+    (let [refs (rf.story/global-decorators)
           ids  (mapv first refs)]
       (is (= [:app/first :app/second] ids)
           ":app/first stays at position 0; re-registration did not push it
            to the end"))
     ;; And the new body is the one applied.
-    (story/reg-variant :story.gd4/v {:setup []})
-    (let [r       (story/resolve-decorators :story.gd4/v)
-          wrapped (decorators/apply-hiccup-decorators
+    (rf.story/reg-variant :story.gd4/v {:setup []})
+    (let [r       (rf.story/resolve-decorators :story.gd4/v)
+          wrapped (rf.story.decorators/apply-hiccup-decorators
                     (:hiccup r) [:span "x"] {})]
       (is (= [:div.first.v2 [:div.second [:span "x"]]] wrapped)
           "the replacement body (v2) is the one applied"))))
@@ -315,14 +315,14 @@
   (testing "a global :frame-setup decorator's :init events fire before any
             story / variant events — the global slot lands in the
             :frame-setup bucket exactly like a story-level decorator would"
-    (story/reg-global-decorator :app/setup
+    (rf.story/reg-global-decorator :app/setup
       {:kind :frame-setup :init [[:noop]]})
-    (story/reg-global-decorator :app/theme
+    (rf.story/reg-global-decorator :app/theme
       {:kind :hiccup :wrap (fn [body _] [:div.theme body])})
-    (story/reg-global-decorator :app/stub
+    (rf.story/reg-global-decorator :app/stub
       {:kind :fx-override :fx-id :http :response {:ok? true}})
-    (story/reg-variant :story.gd5/v {:setup []})
-    (let [r (story/resolve-decorators :story.gd5/v)]
+    (rf.story/reg-variant :story.gd5/v {:setup []})
+    (let [r (rf.story/resolve-decorators :story.gd5/v)]
       (is (= 1 (count (:hiccup r))))
       (is (= 1 (count (:frame-setup r))))
       (is (= 1 (count (:fx-override r))))
@@ -335,29 +335,29 @@
 (deftest unreg-global-decorator-removes-from-stack
   (testing "unreg-global-decorator! removes the entry from the global
             vector; subsequent resolutions do not see it"
-    (story/reg-global-decorator :app/keep
+    (rf.story/reg-global-decorator :app/keep
       {:kind :hiccup :wrap (fn [body _] [:div.keep body])})
-    (story/reg-global-decorator :app/drop
+    (rf.story/reg-global-decorator :app/drop
       {:kind :hiccup :wrap (fn [body _] [:div.drop body])})
-    (story/reg-variant :story.gd6/v {:setup []})
+    (rf.story/reg-variant :story.gd6/v {:setup []})
     (is (= [:app/keep :app/drop]
-           (mapv :id (:hiccup (story/resolve-decorators :story.gd6/v)))))
-    (story/unreg-global-decorator! :app/drop)
+           (mapv :id (:hiccup (rf.story/resolve-decorators :story.gd6/v)))))
+    (rf.story/unreg-global-decorator! :app/drop)
     (is (= [:app/keep]
-           (mapv :id (:hiccup (story/resolve-decorators :story.gd6/v))))
+           (mapv :id (:hiccup (rf.story/resolve-decorators :story.gd6/v))))
         "after unreg, :app/drop is gone from the resolved stack")))
 
 (deftest reg-global-decorator-with-ref-args
   (testing "reg-global-decorator three-arity form lands ref-args at the
             :wrap fn under (:decorator/args args-map)"
-    (story/reg-global-decorator :app/wrap-tagged
+    (rf.story/reg-global-decorator :app/wrap-tagged
       {:kind :hiccup
        :wrap (fn [body args]
                [:div.tagged {:tag (-> args :decorator/args first)} body])}
       [:my-tag])
-    (story/reg-variant :story.gd7/v {:setup []})
-    (let [r       (story/resolve-decorators :story.gd7/v)
-          wrapped (decorators/apply-hiccup-decorators
+    (rf.story/reg-variant :story.gd7/v {:setup []})
+    (let [r       (rf.story/resolve-decorators :story.gd7/v)
+          wrapped (rf.story.decorators/apply-hiccup-decorators
                     (:hiccup r) [:span "x"] {})]
       (is (= [:div.tagged {:tag :my-tag} [:span "x"]] wrapped)
           "ref-args from the global registration land at the :wrap fn"))))
@@ -368,37 +368,37 @@
 
 (deftest snapshot-identity-stable-across-runs
   (testing "two calls with the same inputs produce the same hash"
-    (story/reg-story :story.id
+    (rf.story/reg-story :story.id
       {:component :app/v :args {:a 1}})
-    (story/reg-variant :story.id/v
+    (rf.story/reg-variant :story.id/v
       {:setup [[:init]] :args {:b 2} :tags #{:dev}})
-    (let [a (story/snapshot-identity :story.id/v {:substrate :reagent})
-          b (story/snapshot-identity :story.id/v {:substrate :reagent})]
+    (let [a (rf.story/snapshot-identity :story.id/v {:substrate :reagent})
+          b (rf.story/snapshot-identity :story.id/v {:substrate :reagent})]
       (is (= (:content-hash a) (:content-hash b)))
       (is (= 8 (count (:content-hash a)))
           "8-char hex"))))
 
 (deftest snapshot-identity-changes-with-args
   (testing "changing a variant's :args changes the hash"
-    (story/reg-story :story.id-args
+    (rf.story/reg-story :story.id-args
       {:component :app/v})
-    (story/reg-variant :story.id-args/v {:args {:x 1} :setup []})
-    (let [h1 (-> (story/snapshot-identity :story.id-args/v) :content-hash)]
-      (story/reg-variant :story.id-args/v {:args {:x 2} :setup []})
-      (let [h2 (-> (story/snapshot-identity :story.id-args/v) :content-hash)]
+    (rf.story/reg-variant :story.id-args/v {:args {:x 1} :setup []})
+    (let [h1 (-> (rf.story/snapshot-identity :story.id-args/v) :content-hash)]
+      (rf.story/reg-variant :story.id-args/v {:args {:x 2} :setup []})
+      (let [h2 (-> (rf.story/snapshot-identity :story.id-args/v) :content-hash)]
         (is (not= h1 h2))))))
 
 (deftest snapshot-identity-changes-with-mode
   (testing "different active-modes produce different hashes"
-    (story/reg-story :story.id-mode
+    (rf.story/reg-story :story.id-mode
       {:component :app/v :args {:theme :light}})
-    (story/reg-mode :Mode.app/dark  {:args {:theme :dark}})
-    (story/reg-mode :Mode.app/light {:args {:theme :light}})
-    (story/reg-variant :story.id-mode/v {:setup []})
-    (let [hd (-> (story/snapshot-identity :story.id-mode/v
+    (rf.story/reg-mode :Mode.app/dark  {:args {:theme :dark}})
+    (rf.story/reg-mode :Mode.app/light {:args {:theme :light}})
+    (rf.story/reg-variant :story.id-mode/v {:setup []})
+    (let [hd (-> (rf.story/snapshot-identity :story.id-mode/v
                                           {:active-modes [:Mode.app/dark]})
                  :content-hash)
-          hl (-> (story/snapshot-identity :story.id-mode/v
+          hl (-> (rf.story/snapshot-identity :story.id-mode/v
                                           {:active-modes [:Mode.app/light]})
                  :content-hash)]
       (is (not= hd hl)))))
@@ -411,20 +411,20 @@
             Contrast snapshot-identity-changes-with-mode, whose two modes
             carry DIFFERENT args, so its hash difference is explained by
             :effective-args alone and survives deleting :active-modes."
-    (story/reg-story :story.id-mode-same
+    (rf.story/reg-story :story.id-mode-same
       {:component :app/v :args {:theme :light}})
     ;; Two distinct mode IDS with byte-for-byte IDENTICAL :args.
-    (story/reg-mode :Mode.app/a {:args {:theme :dark}})
-    (story/reg-mode :Mode.app/b {:args {:theme :dark}})
-    (story/reg-variant :story.id-mode-same/v {:setup []})
-    (let [args-a (args/resolve-args :story.id-mode-same/v
+    (rf.story/reg-mode :Mode.app/a {:args {:theme :dark}})
+    (rf.story/reg-mode :Mode.app/b {:args {:theme :dark}})
+    (rf.story/reg-variant :story.id-mode-same/v {:setup []})
+    (let [args-a (rf.story.args/resolve-args :story.id-mode-same/v
                                     {:active-modes [:Mode.app/a]})
-          args-b (args/resolve-args :story.id-mode-same/v
+          args-b (rf.story.args/resolve-args :story.id-mode-same/v
                                     {:active-modes [:Mode.app/b]})
-          ha (-> (story/snapshot-identity :story.id-mode-same/v
+          ha (-> (rf.story/snapshot-identity :story.id-mode-same/v
                                           {:active-modes [:Mode.app/a]})
                  :content-hash)
-          hb (-> (story/snapshot-identity :story.id-mode-same/v
+          hb (-> (rf.story/snapshot-identity :story.id-mode-same/v
                                           {:active-modes [:Mode.app/b]})
                  :content-hash)]
       ;; Precondition: the args path CANNOT explain the difference.
@@ -435,20 +435,20 @@
       (is (not= ha hb)
           "distinct modes with identical args still hash differently")
       ;; Direct slot witness — the snapshot-tuple keeps the mode-id set.
-      (is (not= (:active-modes (ident/snapshot-tuple :story.id-mode-same/v
+      (is (not= (:active-modes (rf.story.identity/snapshot-tuple :story.id-mode-same/v
                                                      {:active-modes [:Mode.app/a]}))
-                (:active-modes (ident/snapshot-tuple :story.id-mode-same/v
+                (:active-modes (rf.story.identity/snapshot-tuple :story.id-mode-same/v
                                                      {:active-modes [:Mode.app/b]})))
           "the :active-modes slot distinguishes the two contexts"))))
 
 (deftest snapshot-identity-changes-with-substrate
   (testing "different substrate produces different hash"
-    (story/reg-story :story.id-sub
+    (rf.story/reg-story :story.id-sub
       {:component :app/v})
-    (story/reg-variant :story.id-sub/v {:setup []})
-    (let [hr (-> (story/snapshot-identity :story.id-sub/v {:substrate :reagent})
+    (rf.story/reg-variant :story.id-sub/v {:setup []})
+    (let [hr (-> (rf.story/snapshot-identity :story.id-sub/v {:substrate :reagent})
                  :content-hash)
-          hu (-> (story/snapshot-identity :story.id-sub/v {:substrate :uix})
+          hu (-> (rf.story/snapshot-identity :story.id-sub/v {:substrate :uix})
                  :content-hash)]
       (is (not= hr hu)))))
 
@@ -457,33 +457,33 @@
             variant-level :decorators change MUST perturb the content-hash.
             Closes rf2-9g48l: watch-mode auto-rerun keys off this identity,
             so a decorator-only edit was silently dropped before this fix."
-    (story/reg-decorator :centered
+    (rf.story/reg-decorator :centered
       {:kind :hiccup
        :wrap (fn [body _args] [:div.centered body])})
-    (story/reg-decorator :boxed
+    (rf.story/reg-decorator :boxed
       {:kind :hiccup
        :wrap (fn [body _args] [:div.boxed body])})
-    (story/reg-story :story.id-dec
+    (rf.story/reg-story :story.id-dec
       {:component :app/v})
-    (story/reg-variant :story.id-dec/v
+    (rf.story/reg-variant :story.id-dec/v
       {:setup     []
        :decorators [[:centered]]})
-    (let [h1 (-> (story/snapshot-identity :story.id-dec/v) :content-hash)]
-      (story/reg-variant :story.id-dec/v
+    (let [h1 (-> (rf.story/snapshot-identity :story.id-dec/v) :content-hash)]
+      (rf.story/reg-variant :story.id-dec/v
         {:setup     []
          :decorators [[:boxed]]})
-      (let [h2 (-> (story/snapshot-identity :story.id-dec/v) :content-hash)]
+      (let [h2 (-> (rf.story/snapshot-identity :story.id-dec/v) :content-hash)]
         (is (not= h1 h2)
             "swapping the variant's decorator must produce a fresh hash"))
       (testing "adding a decorator to a previously-decoratorless variant also perturbs the hash"
-        (story/reg-variant :story.id-dec/v
+        (rf.story/reg-variant :story.id-dec/v
           {:setup     []
            :decorators []})
-        (let [h-empty (-> (story/snapshot-identity :story.id-dec/v) :content-hash)]
-          (story/reg-variant :story.id-dec/v
+        (let [h-empty (-> (rf.story/snapshot-identity :story.id-dec/v) :content-hash)]
+          (rf.story/reg-variant :story.id-dec/v
             {:setup     []
              :decorators [[:centered]]})
-          (let [h-with (-> (story/snapshot-identity :story.id-dec/v) :content-hash)]
+          (let [h-with (-> (rf.story/snapshot-identity :story.id-dec/v) :content-hash)]
             (is (not= h-empty h-with)
                 "appending a decorator must produce a fresh hash")))))))
 
@@ -494,25 +494,25 @@
             (removed by rf2-0wrud), so play-script edits were silently
             dropped from the hash — breaking watch-mode auto-rerun and
             visual-regression baseline invalidation."
-    (story/reg-story :story.id-ps
+    (rf.story/reg-story :story.id-ps
       {:component :app/v})
-    (story/reg-variant :story.id-ps/v
+    (rf.story/reg-variant :story.id-ps/v
       {:setup      []
        :script [[:dispatch-sync [:rf.assert/path-equals [:n] 1]]]})
-    (let [h1 (-> (story/snapshot-identity :story.id-ps/v) :content-hash)]
-      (story/reg-variant :story.id-ps/v
+    (let [h1 (-> (rf.story/snapshot-identity :story.id-ps/v) :content-hash)]
+      (rf.story/reg-variant :story.id-ps/v
         {:setup      []
          :script [[:dispatch-sync [:rf.assert/path-equals [:n] 2]]]})
-      (let [h2 (-> (story/snapshot-identity :story.id-ps/v) :content-hash)]
+      (let [h2 (-> (rf.story/snapshot-identity :story.id-ps/v) :content-hash)]
         (is (not= h1 h2)
             "editing the play-script must produce a fresh hash"))
       (testing "adding a play-script to a previously play-less variant also perturbs the hash"
-        (story/reg-variant :story.id-ps/v {:setup []})
-        (let [h-none (-> (story/snapshot-identity :story.id-ps/v) :content-hash)]
-          (story/reg-variant :story.id-ps/v
+        (rf.story/reg-variant :story.id-ps/v {:setup []})
+        (let [h-none (-> (rf.story/snapshot-identity :story.id-ps/v) :content-hash)]
+          (rf.story/reg-variant :story.id-ps/v
             {:setup      []
              :script [[:dispatch-sync [:rf.assert/path-equals [:n] 1]]]})
-          (let [h-with (-> (story/snapshot-identity :story.id-ps/v) :content-hash)]
+          (let [h-with (-> (rf.story/snapshot-identity :story.id-ps/v) :content-hash)]
             (is (not= h-none h-with)
                 "appending a play-script must produce a fresh hash")))))))
 
@@ -521,16 +521,16 @@
             :plays surface (rf2-tl7zk) also participates in the hash.
             Companion to rf2-bgwnf: both play surfaces (:script and
             :plays) must perturb snapshot identity."
-    (story/reg-story :story.id-plays
+    (rf.story/reg-story :story.id-plays
       {:component :app/v})
-    (story/reg-variant :story.id-plays/v
+    (rf.story/reg-variant :story.id-plays/v
       {:setup []
        :plays  [{:name "happy" :script [[:dispatch-sync [:rf.assert/path-equals [:n] 1]]]}]})
-    (let [h1 (-> (story/snapshot-identity :story.id-plays/v) :content-hash)]
-      (story/reg-variant :story.id-plays/v
+    (let [h1 (-> (rf.story/snapshot-identity :story.id-plays/v) :content-hash)]
+      (rf.story/reg-variant :story.id-plays/v
         {:setup []
          :plays  [{:name "happy" :script [[:dispatch-sync [:rf.assert/path-equals [:n] 2]]]}]})
-      (let [h2 (-> (story/snapshot-identity :story.id-plays/v) :content-hash)]
+      (let [h2 (-> (rf.story/snapshot-identity :story.id-plays/v) :content-hash)]
         (is (not= h1 h2)
             "editing a play's script must produce a fresh hash")))))
 
@@ -543,10 +543,10 @@
             the digest is sourced via the `:schemas/app-schemas-digest`
             late-bind hook so identity.cljc does NOT statically :require
             the schemas artefact."
-    (story/reg-story :story.id-sd
+    (rf.story/reg-story :story.id-sd
       {:component :app/v})
-    (story/reg-variant :story.id-sd/v {:setup []})
-    (let [prior (late-bind/get-fn :schemas/app-schemas-digest)]
+    (rf.story/reg-variant :story.id-sd/v {:setup []})
+    (let [prior (rf.late-bind/get-fn :schemas/app-schemas-digest)]
       (try
         ;; Simulate a registered schema by installing a hook with a
         ;; fixed digest value. EP-0002 (rf2-bd4div) — the digest is
@@ -554,26 +554,26 @@
         ;; the variant's TARGET frame-id (no ambient resolution). The stub
         ;; takes (and ignores) that frame-id arg, matching the real
         ;; `app-schemas-digest` hook's keyword-frame-id arity.
-        (late-bind/set-fn! :schemas/app-schemas-digest
+        (rf.late-bind/set-fn! :schemas/app-schemas-digest
                            (fn [_frame-id] "sha256:0000000000000001"))
-        (let [h1 (-> (story/snapshot-identity :story.id-sd/v) :content-hash)]
+        (let [h1 (-> (rf.story/snapshot-identity :story.id-sd/v) :content-hash)]
           ;; Now simulate a schema change by mutating the hook's
           ;; return value. The framework actually re-installs the hook
           ;; each time schemas mutate; we model that here.
-          (late-bind/set-fn! :schemas/app-schemas-digest
+          (rf.late-bind/set-fn! :schemas/app-schemas-digest
                              (fn [_frame-id] "sha256:0000000000000002"))
-          (let [h2 (-> (story/snapshot-identity :story.id-sd/v) :content-hash)]
+          (let [h2 (-> (rf.story/snapshot-identity :story.id-sd/v) :content-hash)]
             (is (not= h1 h2)
                 "a view schema-digest change must produce a fresh hash")))
         (testing "when the schemas artefact is absent (no hook registered),
                   the digest slot is nil and the hash is still stable"
-          (late-bind/set-fn! :schemas/app-schemas-digest nil)
-          (let [a (-> (story/snapshot-identity :story.id-sd/v) :content-hash)
-                b (-> (story/snapshot-identity :story.id-sd/v) :content-hash)]
+          (rf.late-bind/set-fn! :schemas/app-schemas-digest nil)
+          (let [a (-> (rf.story/snapshot-identity :story.id-sd/v) :content-hash)
+                b (-> (rf.story/snapshot-identity :story.id-sd/v) :content-hash)]
             (is (= a b)
                 "absent-hook path must be deterministic across calls")))
         (finally
-          (late-bind/set-fn! :schemas/app-schemas-digest prior))))))
+          (rf.late-bind/set-fn! :schemas/app-schemas-digest prior))))))
 
 (deftest snapshot-identity-changes-with-variant-component
   (testing "rf2-bah5o2 — the per-variant `:component` view-id OVERRIDE
@@ -586,16 +586,16 @@
             and two variants differing only in `:component` shared a
             content-hash. plan.cljc DID fold `:component` into the plan-
             hash; only the snapshot path was incomplete."
-    (story/reg-story :story.id-comp {:component :app/parent})
-    (story/reg-variant :story.id-comp/v {:setup [] :component :view-a})
-    (let [h1 (-> (story/snapshot-identity :story.id-comp/v) :content-hash)]
-      (story/reg-variant :story.id-comp/v {:setup [] :component :view-b})
-      (let [h2 (-> (story/snapshot-identity :story.id-comp/v) :content-hash)]
+    (rf.story/reg-story :story.id-comp {:component :app/parent})
+    (rf.story/reg-variant :story.id-comp/v {:setup [] :component :view-a})
+    (let [h1 (-> (rf.story/snapshot-identity :story.id-comp/v) :content-hash)]
+      (rf.story/reg-variant :story.id-comp/v {:setup [] :component :view-b})
+      (let [h2 (-> (rf.story/snapshot-identity :story.id-comp/v) :content-hash)]
         (is (not= h1 h2)
             "swapping the variant's :component override must produce a fresh hash"))
       (testing "the :variant tuple slice now carries the variant's own
                 :component — the slot that resolves the two-variant collision"
-        (is (= :view-b (get-in (ident/snapshot-tuple :story.id-comp/v)
+        (is (= :view-b (get-in (rf.story.identity/snapshot-tuple :story.id-comp/v)
                                [:variant :component]))
             "variant-body-slice must select :component")))))
 
@@ -608,28 +608,28 @@
             drift and the visual-regression baseline stayed stale — even
             though the plan-hash DID capture them, confirming the snapshot
             path was the incomplete one."
-    (story/reg-story :story.id-render {:component :app/v})
+    (rf.story/reg-story :story.id-render {:component :app/v})
     (testing ":sub-overrides edit perturbs the hash"
-      (story/reg-variant :story.id-render/v
+      (rf.story/reg-variant :story.id-render/v
         {:setup [] :sub-overrides {[:cart/total] 0}})
-      (let [h1 (-> (story/snapshot-identity :story.id-render/v) :content-hash)]
-        (story/reg-variant :story.id-render/v
+      (let [h1 (-> (rf.story/snapshot-identity :story.id-render/v) :content-hash)]
+        (rf.story/reg-variant :story.id-render/v
           {:setup [] :sub-overrides {[:cart/total] 999}})
-        (is (not= h1 (-> (story/snapshot-identity :story.id-render/v) :content-hash))
+        (is (not= h1 (-> (rf.story/snapshot-identity :story.id-render/v) :content-hash))
             "editing a :sub-overrides value must produce a fresh hash")))
     (testing ":db-seed edit perturbs the hash"
-      (story/reg-variant :story.id-render/v {:setup [] :db-seed {[:count] 1}})
-      (let [h1 (-> (story/snapshot-identity :story.id-render/v) :content-hash)]
-        (story/reg-variant :story.id-render/v {:setup [] :db-seed {[:count] 2}})
-        (is (not= h1 (-> (story/snapshot-identity :story.id-render/v) :content-hash))
+      (rf.story/reg-variant :story.id-render/v {:setup [] :db-seed {[:count] 1}})
+      (let [h1 (-> (rf.story/snapshot-identity :story.id-render/v) :content-hash)]
+        (rf.story/reg-variant :story.id-render/v {:setup [] :db-seed {[:count] 2}})
+        (is (not= h1 (-> (rf.story/snapshot-identity :story.id-render/v) :content-hash))
             "editing a :db-seed value must produce a fresh hash")))
     (testing ":network edit perturbs the hash"
-      (story/reg-variant :story.id-render/v
+      (rf.story/reg-variant :story.id-render/v
         {:setup [] :network {[:get "/api/x"] {:reply {:ok {:status 200}}}}})
-      (let [h1 (-> (story/snapshot-identity :story.id-render/v) :content-hash)]
-        (story/reg-variant :story.id-render/v
+      (let [h1 (-> (rf.story/snapshot-identity :story.id-render/v) :content-hash)]
+        (rf.story/reg-variant :story.id-render/v
           {:setup [] :network {[:get "/api/x"] {:reply {:ok {:status 500}}}}})
-        (is (not= h1 (-> (story/snapshot-identity :story.id-render/v) :content-hash))
+        (is (not= h1 (-> (rf.story/snapshot-identity :story.id-render/v) :content-hash))
             "editing a :network reply must produce a fresh hash")))))
 
 ;; ---- rf2-8fz0n8: the STORY-side identity inputs (story-body-slice) --------
@@ -654,16 +654,16 @@
             RED against a refactor dropping `:component` from
             `story-body-slice`'s select-keys — the STORY-side sibling of the
             variant-override guard rf2-bah5o2."
-    (story/reg-story :story.story-comp {:component :view-a})
+    (rf.story/reg-story :story.story-comp {:component :view-a})
     ;; Component-less variant — the rendered view is the STORY's `:component`.
-    (story/reg-variant :story.story-comp/v {:setup []})
-    (let [h1 (-> (story/snapshot-identity :story.story-comp/v) :content-hash)]
-      (story/reg-story :story.story-comp {:component :view-b})
-      (let [h2 (-> (story/snapshot-identity :story.story-comp/v) :content-hash)]
+    (rf.story/reg-variant :story.story-comp/v {:setup []})
+    (let [h1 (-> (rf.story/snapshot-identity :story.story-comp/v) :content-hash)]
+      (rf.story/reg-story :story.story-comp {:component :view-b})
+      (let [h2 (-> (rf.story/snapshot-identity :story.story-comp/v) :content-hash)]
         (is (not= h1 h2)
             "editing the parent story's :component must produce a fresh hash"))
       (testing "the :story tuple slice carries the parent story's :component"
-        (is (= :view-b (get-in (ident/snapshot-tuple :story.story-comp/v)
+        (is (= :view-b (get-in (rf.story.identity/snapshot-tuple :story.story-comp/v)
                                [:story :component]))
             "story-body-slice must select :component")))))
 
@@ -676,27 +676,27 @@
             perturb its snapshot identity. RED against a refactor dropping
             `:decorators` from `story-body-slice`'s select-keys — the
             STORY-side sibling of the variant-decorators guard rf2-9g48l."
-    (story/reg-decorator :centered
+    (rf.story/reg-decorator :centered
       {:kind :hiccup :wrap (fn [body _args] [:div.centered body])})
-    (story/reg-decorator :boxed
+    (rf.story/reg-decorator :boxed
       {:kind :hiccup :wrap (fn [body _args] [:div.boxed body])})
-    (story/reg-story :story.story-dec {:component :app/v :decorators [[:centered]]})
-    (story/reg-variant :story.story-dec/v {:setup []})
-    (let [h1 (-> (story/snapshot-identity :story.story-dec/v) :content-hash)]
-      (story/reg-story :story.story-dec {:component :app/v :decorators [[:boxed]]})
-      (let [h2 (-> (story/snapshot-identity :story.story-dec/v) :content-hash)]
+    (rf.story/reg-story :story.story-dec {:component :app/v :decorators [[:centered]]})
+    (rf.story/reg-variant :story.story-dec/v {:setup []})
+    (let [h1 (-> (rf.story/snapshot-identity :story.story-dec/v) :content-hash)]
+      (rf.story/reg-story :story.story-dec {:component :app/v :decorators [[:boxed]]})
+      (let [h2 (-> (rf.story/snapshot-identity :story.story-dec/v) :content-hash)]
         (is (not= h1 h2)
             "swapping the parent story's decorator must produce a fresh hash"))
       (testing "adding a decorator to a previously-decoratorless story perturbs the child hash"
-        (story/reg-story :story.story-dec {:component :app/v :decorators []})
-        (let [h-empty (-> (story/snapshot-identity :story.story-dec/v) :content-hash)]
-          (story/reg-story :story.story-dec {:component :app/v :decorators [[:centered]]})
-          (let [h-with (-> (story/snapshot-identity :story.story-dec/v) :content-hash)]
+        (rf.story/reg-story :story.story-dec {:component :app/v :decorators []})
+        (let [h-empty (-> (rf.story/snapshot-identity :story.story-dec/v) :content-hash)]
+          (rf.story/reg-story :story.story-dec {:component :app/v :decorators [[:centered]]})
+          (let [h-with (-> (rf.story/snapshot-identity :story.story-dec/v) :content-hash)]
             (is (not= h-empty h-with)
                 "appending a story decorator must produce a fresh child hash"))))
       ;; The previous block left the story registered with [[:centered]].
       (testing "the :story tuple slice carries the parent story's :decorators"
-        (is (= [[:centered]] (get-in (ident/snapshot-tuple :story.story-dec/v)
+        (is (= [[:centered]] (get-in (rf.story.identity/snapshot-tuple :story.story-dec/v)
                                      [:story :decorators]))
             "story-body-slice must select :decorators")))))
 
@@ -716,18 +716,18 @@
             snapshot identity of the SAME variant is stable across the edit.
             RED against the raw-tags reader: `#{:docs}` ≠
             `#{:dev :!dev :docs}` as raw sets, so it would perturb the hash."
-    (story/reg-story :story.eff-tag {:component :app/v})
-    (story/reg-variant :story.eff-tag/v {:setup [] :tags #{:docs}})
-    (let [h-plain (-> (story/snapshot-identity :story.eff-tag/v) :content-hash)]
+    (rf.story/reg-story :story.eff-tag {:component :app/v})
+    (rf.story/reg-variant :story.eff-tag/v {:setup [] :tags #{:docs}})
+    (let [h-plain (-> (rf.story/snapshot-identity :story.eff-tag/v) :content-hash)]
       ;; Re-register the SAME variant with a marker authoring that RESOLVES
       ;; to the identical effective set `#{:docs}`.
-      (story/reg-variant :story.eff-tag/v {:setup [] :tags #{:dev :!dev :docs}})
-      (let [h-marker (-> (story/snapshot-identity :story.eff-tag/v) :content-hash)]
+      (rf.story/reg-variant :story.eff-tag/v {:setup [] :tags #{:dev :!dev :docs}})
+      (let [h-marker (-> (rf.story/snapshot-identity :story.eff-tag/v) :content-hash)]
         (is (= h-plain h-marker)
             "identical effective tag set → identical hash (raw authoring differs)")
         ;; Witness the tuple slot directly: it carries the RESOLVED set,
         ;; and the raw `:!x` marker never appears in it.
-        (let [eff (:effective-tags (ident/snapshot-tuple :story.eff-tag/v))]
+        (let [eff (:effective-tags (rf.story.identity/snapshot-tuple :story.eff-tag/v))]
           (is (= #{:docs} eff) "the tuple carries the effective set")
           (is (not (contains? eff :!dev)) "raw `:!x` marker never reaches the hash"))))))
 
@@ -735,11 +735,11 @@
   (testing "rf2-chzryf — a genuine change to the effective tag set DOES
             perturb the hash (tags remain identity-bearing, they are not
             simply dropped from the identity)."
-    (story/reg-story :story.eff-tag-chg {:component :app/v})
-    (story/reg-variant :story.eff-tag-chg/v {:setup [] :tags #{:docs}})
-    (let [h1 (-> (story/snapshot-identity :story.eff-tag-chg/v) :content-hash)]
-      (story/reg-variant :story.eff-tag-chg/v {:setup [] :tags #{:docs :test}})
-      (let [h2 (-> (story/snapshot-identity :story.eff-tag-chg/v) :content-hash)]
+    (rf.story/reg-story :story.eff-tag-chg {:component :app/v})
+    (rf.story/reg-variant :story.eff-tag-chg/v {:setup [] :tags #{:docs}})
+    (let [h1 (-> (rf.story/snapshot-identity :story.eff-tag-chg/v) :content-hash)]
+      (rf.story/reg-variant :story.eff-tag-chg/v {:setup [] :tags #{:docs :test}})
+      (let [h2 (-> (rf.story/snapshot-identity :story.eff-tag-chg/v) :content-hash)]
         (is (not= h1 h2)
             "adding an effective tag must produce a fresh hash")))))
 
@@ -750,19 +750,19 @@
             reader — the child's raw `:tags` are empty and its story's tags
             are unchanged, so the pre-fix identity slice (child raw + story
             raw, never the extends-parent) would NOT see the change."
-    (story/reg-story :story.eff-tag-ext {:component :app/v})
+    (rf.story/reg-story :story.eff-tag-ext {:component :app/v})
     ;; Child ONLY :extends the parent — declares no tags of its own, so its
     ;; effective set is entirely inherited from the parent.
-    (story/reg-variant :story.eff-tag-ext/parent {:setup [] :tags #{:dev}})
-    (story/reg-variant :story.eff-tag-ext/child  {:extends :story.eff-tag-ext/parent})
-    (is (= #{:dev} (:effective-tags (ident/snapshot-tuple :story.eff-tag-ext/child)))
+    (rf.story/reg-variant :story.eff-tag-ext/parent {:setup [] :tags #{:dev}})
+    (rf.story/reg-variant :story.eff-tag-ext/child  {:extends :story.eff-tag-ext/parent})
+    (is (= #{:dev} (:effective-tags (rf.story.identity/snapshot-tuple :story.eff-tag-ext/child)))
         "the child inherits the parent's tags through the :extends chain")
-    (let [h1 (-> (story/snapshot-identity :story.eff-tag-ext/child) :content-hash)]
+    (let [h1 (-> (rf.story/snapshot-identity :story.eff-tag-ext/child) :content-hash)]
       ;; Edit ONLY the parent's tags. The child's raw body is untouched.
-      (story/reg-variant :story.eff-tag-ext/parent {:setup [] :tags #{:docs}})
-      (is (= #{:docs} (:effective-tags (ident/snapshot-tuple :story.eff-tag-ext/child)))
+      (rf.story/reg-variant :story.eff-tag-ext/parent {:setup [] :tags #{:docs}})
+      (is (= #{:docs} (:effective-tags (rf.story.identity/snapshot-tuple :story.eff-tag-ext/child)))
           "the child's effective set now reflects the parent's edit")
-      (let [h2 (-> (story/snapshot-identity :story.eff-tag-ext/child) :content-hash)]
+      (let [h2 (-> (rf.story/snapshot-identity :story.eff-tag-ext/child) :content-hash)]
         (is (not= h1 h2)
             "an :extends-parent tag edit perturbs the child's hash")))))
 
@@ -777,27 +777,27 @@
             `story-body-slice` never selects `:tags`. RED against a break in
             `effective-tags-slice`'s story-fallback path; the story-fallback
             sibling of the `:extends`-parent guard rf2-chzryf."
-    (story/reg-story :story.story-tag {:component :app/v :tags #{:docs}})
+    (rf.story/reg-story :story.story-tag {:component :app/v :tags #{:docs}})
     ;; Tagless variant — inherits the story's tags as the fallback default.
-    (story/reg-variant :story.story-tag/v {:setup []})
-    (is (= #{:docs} (:effective-tags (ident/snapshot-tuple :story.story-tag/v)))
+    (rf.story/reg-variant :story.story-tag/v {:setup []})
+    (is (= #{:docs} (:effective-tags (rf.story.identity/snapshot-tuple :story.story-tag/v)))
         "the tagless variant inherits the parent story's tags (fallback)")
-    (let [h1 (-> (story/snapshot-identity :story.story-tag/v) :content-hash)]
+    (let [h1 (-> (rf.story/snapshot-identity :story.story-tag/v) :content-hash)]
       ;; Edit ONLY the parent story's tags — the child's raw body is untouched.
-      (story/reg-story :story.story-tag {:component :app/v :tags #{:docs :test}})
-      (is (= #{:docs :test} (:effective-tags (ident/snapshot-tuple :story.story-tag/v)))
+      (rf.story/reg-story :story.story-tag {:component :app/v :tags #{:docs :test}})
+      (is (= #{:docs :test} (:effective-tags (rf.story.identity/snapshot-tuple :story.story-tag/v)))
           "the child's effective set now reflects the parent story's tag edit")
-      (let [h2 (-> (story/snapshot-identity :story.story-tag/v) :content-hash)]
+      (let [h2 (-> (rf.story/snapshot-identity :story.story-tag/v) :content-hash)]
         (is (not= h1 h2)
             "a parent-story tag edit perturbs the tagless child's hash")))))
 
 (deftest snapshot-identity-canonical-key-stable
   (testing "the canonical-version tag canonicalises and map key order is
             hash-stable"
-    (let [canon (fp/canonical-form [fp/canonical-version :x])]
+    (let [canon (rf.story.fingerprint/canonical-form [rf.story.fingerprint/canonical-version :x])]
       (is (some? canon)))
-    (is (= (fp/content-hash {:a 1 :b 2})
-           (fp/content-hash {:b 2 :a 1}))
+    (is (= (rf.story.fingerprint/content-hash {:a 1 :b 2})
+           (rf.story.fingerprint/content-hash {:b 2 :a 1}))
         "map key order doesn't affect the hash")))
 
 (deftest snapshot-tuple-canonical-slot-tracks-fingerprint-version
@@ -808,10 +808,10 @@
   ;; canonical-version bump cannot leave the tuple slot pinned to a stale
   ;; literal (the v1/v2 drift this bead fixed).
   (testing "the tuple's :rf/snapshot-canonical slot equals fingerprint/canonical-version"
-    (story/reg-story :story.id-canon {:component :app/c})
-    (story/reg-variant :story.id-canon/v {:setup []})
-    (is (= fp/canonical-version
-           (:rf/snapshot-canonical (ident/snapshot-tuple :story.id-canon/v)))
+    (rf.story/reg-story :story.id-canon {:component :app/c})
+    (rf.story/reg-variant :story.id-canon/v {:setup []})
+    (is (= rf.story.fingerprint/canonical-version
+           (:rf/snapshot-canonical (rf.story.identity/snapshot-tuple :story.id-canon/v)))
         "the snapshot tuple stamps the live canonical-version, not a literal")))
 
 ;; ===========================================================================
@@ -820,7 +820,7 @@
 
 (deftest lifecycle-machine-registered
   (testing "the lifecycle machine is registered after install-canonical-vocabulary!"
-    (is (some (set [loaders/lifecycle-machine-id]) (machines/machines)))))
+    (is (some (set [rf.story.loaders/lifecycle-machine-id]) (rf.machines/machines)))))
 
 (deftest lifecycle-transitions-pre-mount-to-ready
   (testing "the lifecycle progresses through every documented state"
@@ -830,64 +830,64 @@
     ;; separately by `lifecycle-events-only-fast-path-to-ready` /
     ;; `events-only-variant-classifier` below.
     (rf/reg-event :test/noop (fn [{:keys [db]} _] {:db db}))
-    (story/reg-variant :story.life/v {:setup [] :loaders [[:test/noop]]})
-    (let [r       (story/resolve-decorators :story.life/v)]
-      (frames/allocate! :story.life/v r)
-      (is (= :mounting (loaders/current-state :story.life/v)))
-      (loaders/start-loaders! :story.life/v)
-      (is (= :loading (loaders/current-state :story.life/v)))
-      (loaders/finish-loaders! :story.life/v)
-      (is (= :ready (loaders/current-state :story.life/v)))
-      (frames/destroy! :story.life/v))))
+    (rf.story/reg-variant :story.life/v {:setup [] :loaders [[:test/noop]]})
+    (let [r       (rf.story/resolve-decorators :story.life/v)]
+      (rf.story.frames/allocate! :story.life/v r)
+      (is (= :mounting (rf.story.loaders/current-state :story.life/v)))
+      (rf.story.loaders/start-loaders! :story.life/v)
+      (is (= :loading (rf.story.loaders/current-state :story.life/v)))
+      (rf.story.loaders/finish-loaders! :story.life/v)
+      (is (= :ready (rf.story.loaders/current-state :story.life/v)))
+      (rf.story.frames/destroy! :story.life/v))))
 
 (deftest lifecycle-mirror-to-friendly-path
   (testing "the discrete state is mirrored to [:rf.story/lifecycle]"
     ;; rf2-043cm — `:loaders` keeps the classical four-phase route so
     ;; the test reaches `:loading`.
     (rf/reg-event :test/noop (fn [{:keys [db]} _] {:db db}))
-    (story/reg-variant :story.mirror/v {:loaders [[:test/noop]]})
-    (let [r (story/resolve-decorators :story.mirror/v)]
-      (frames/allocate! :story.mirror/v r)
-      (loaders/start-loaders! :story.mirror/v)
+    (rf.story/reg-variant :story.mirror/v {:loaders [[:test/noop]]})
+    (let [r (rf.story/resolve-decorators :story.mirror/v)]
+      (rf.story.frames/allocate! :story.mirror/v r)
+      (rf.story.loaders/start-loaders! :story.mirror/v)
       (let [db (rf/app-db-value :story.mirror/v)]
         (is (= :loading (:rf.story/lifecycle db))))
-      (frames/destroy! :story.mirror/v))))
+      (rf.story.frames/destroy! :story.mirror/v))))
 
 (deftest lifecycle-watcher-fires-on-transitions
   (testing "watch-variant callbacks see every transition"
     ;; rf2-043cm — `:loaders` keeps the classical four-phase route so
     ;; watchers observe the full transition cascade.
     (rf/reg-event :test/noop (fn [{:keys [db]} _] {:db db}))
-    (story/reg-variant :story.watch/v {:loaders [[:test/noop]]})
+    (rf.story/reg-variant :story.watch/v {:loaders [[:test/noop]]})
     (let [transitions (atom [])
-          unsubscribe (story/watch-variant
+          unsubscribe (rf.story/watch-variant
                         :story.watch/v
                         (fn [t] (swap! transitions conj t)))
-          r           (story/resolve-decorators :story.watch/v)]
-      (frames/allocate! :story.watch/v r)
-      (loaders/start-loaders! :story.watch/v)
-      (loaders/finish-loaders! :story.watch/v)
+          r           (rf.story/resolve-decorators :story.watch/v)]
+      (rf.story.frames/allocate! :story.watch/v r)
+      (rf.story.loaders/start-loaders! :story.watch/v)
+      (rf.story.loaders/finish-loaders! :story.watch/v)
       (is (= [:pre-mount :mounting :loading]
              (mapv :from @transitions)))
       (is (= [:mounting :loading :ready]
              (mapv :to @transitions)))
       (unsubscribe)
-      (frames/destroy! :story.watch/v))))
+      (rf.story.frames/destroy! :story.watch/v))))
 
 ;; rf2-043cm — events-only fast-path coverage.
 ;;
 ;; A variant declaring `:setup` only (no `:loaders`, no `:frame-setup`
 ;; decorators, no `:loaders-complete-when`) has nothing to wait for
-;; between mount and render. The runtime's `frames/allocate!` selects
-;; the fast-path branch (`loaders/mount-ready!`) which drives the
+;; between mount and render. The runtime's `rf.story.frames/allocate!` selects
+;; the fast-path branch (`rf.story.loaders/mount-ready!`) which drives the
 ;; lifecycle machine from `:pre-mount` directly to `:ready` in a
 ;; single transition — never visiting `:mounting` or `:loading`.
 ;;
 ;; This pins:
-;; 1. The classifier `loaders/events-only-variant?` returns true for
+;; 1. The classifier `rf.story.loaders/events-only-variant?` returns true for
 ;;    the events-only shape and false for any of the four shapes that
 ;;    bind loader-style work.
-;; 2. `frames/allocate!` against an events-only body lands directly
+;; 2. `rf.story.frames/allocate!` against an events-only body lands directly
 ;;    in `:ready`.
 ;; 3. A `watch-variant` callback receives ONE transition
 ;;    (`:pre-mount → :ready`), not the three the classical path
@@ -901,22 +901,22 @@
 ;;    transition out of `:ready`, so the state stays `:ready`.
 
 (deftest events-only-variant-classifier
-  (testing "loaders/events-only-variant? — true for the events-only
+  (testing "rf.story.loaders/events-only-variant? — true for the events-only
             shape; false for any body / decorator-stack that binds
             loader work"
-    (is (true?  (loaders/events-only-variant? {:setup [[:x]]} {}))
+    (is (true?  (rf.story.loaders/events-only-variant? {:setup [[:x]]} {}))
         "no :loaders, no :frame-setup, no :loaders-complete-when → events-only")
-    (is (true?  (loaders/events-only-variant? {} {}))
+    (is (true?  (rf.story.loaders/events-only-variant? {} {}))
         "empty body → events-only (nothing to wait for)")
-    (is (false? (loaders/events-only-variant? {:loaders [[:l]]} {}))
+    (is (false? (rf.story.loaders/events-only-variant? {:loaders [[:l]]} {}))
         "presence of :loaders → not events-only")
-    (is (false? (loaders/events-only-variant? {:loaders-complete-when :p?} {}))
+    (is (false? (rf.story.loaders/events-only-variant? {:loaders-complete-when :p?} {}))
         "presence of :loaders-complete-when → not events-only")
-    (is (false? (loaders/events-only-variant? {} {:frame-setup [{:body {}}]}))
+    (is (false? (rf.story.loaders/events-only-variant? {} {:frame-setup [{:body {}}]}))
         "presence of :frame-setup decorators → not events-only")
-    (is (true?  (loaders/events-only-variant? {:script [[:dispatch-sync [:assert]]]} {}))
+    (is (true?  (rf.story.loaders/events-only-variant? {:script [[:dispatch-sync [:assert]]]} {}))
         ":script does not gate the lifecycle (runs strictly after :ready)")
-    (is (true?  (loaders/events-only-variant? {} {:hiccup    [{:body {}}]
+    (is (true?  (rf.story.loaders/events-only-variant? {} {:hiccup    [{:body {}}]
                                                   :fx-override [{:body {}}]}))
         ":hiccup + :fx-override decorators don't drive the lifecycle machine")))
 
@@ -925,26 +925,26 @@
             drives the lifecycle from :pre-mount directly to :ready
             in a single transition. The skeleton (rf2-0s4p1) reads
             `:ready` immediately and never engages."
-    (story/reg-variant :story.eo.fast/v {:setup []})
-    (let [r (story/resolve-decorators :story.eo.fast/v)]
-      (is (= :pre-mount (loaders/current-state :story.eo.fast/v))
+    (rf.story/reg-variant :story.eo.fast/v {:setup []})
+    (let [r (rf.story/resolve-decorators :story.eo.fast/v)]
+      (is (= :pre-mount (rf.story.loaders/current-state :story.eo.fast/v))
           "before allocate the snapshot reads the initial state")
-      (frames/allocate! :story.eo.fast/v r)
-      (is (= :ready (loaders/current-state :story.eo.fast/v))
+      (rf.story.frames/allocate! :story.eo.fast/v r)
+      (is (= :ready (rf.story.loaders/current-state :story.eo.fast/v))
           "after allocate the lifecycle is :ready — no :mounting / :loading")
-      (frames/destroy! :story.eo.fast/v))))
+      (rf.story.frames/destroy! :story.eo.fast/v))))
 
 (deftest lifecycle-events-only-watcher-sees-single-transition
   (testing "rf2-043cm — a watcher registered before allocate observes
             ONE transition (:pre-mount → :ready) for events-only
             variants, not the three the classical path fires"
-    (story/reg-variant :story.eo.watch/v {:setup []})
+    (rf.story/reg-variant :story.eo.watch/v {:setup []})
     (let [transitions (atom [])
-          unsub       (story/watch-variant
+          unsub       (rf.story/watch-variant
                         :story.eo.watch/v
                         (fn [t] (swap! transitions conj t)))
-          r           (story/resolve-decorators :story.eo.watch/v)]
-      (frames/allocate! :story.eo.watch/v r)
+          r           (rf.story/resolve-decorators :story.eo.watch/v)]
+      (rf.story.frames/allocate! :story.eo.watch/v r)
       (is (= 1 (count @transitions))
           "exactly one transition fired")
       (is (= {:from :pre-mount :to :ready}
@@ -954,39 +954,39 @@
              (:event (first @transitions)))
           "the firing event was :mount-ready (the rf2-043cm fast-path)")
       (unsub)
-      (frames/destroy! :story.eo.watch/v))))
+      (rf.story.frames/destroy! :story.eo.watch/v))))
 
 (deftest lifecycle-events-only-run-variant-lands-ready
   (testing "rf2-043cm — `run-variant` against an events-only body
             resolves to a result whose :lifecycle is :ready and whose
             :assertions vector is empty (no loader-incomplete projection)"
     (rf/reg-event :test/seed (fn [{:keys [db]} _] {:db (assoc db :seeded? true)}))
-    (story/reg-variant :story.eo.run/v {:setup [[:test/seed]]})
-    (let [r (async/deref-blocking (story/run-variant :story.eo.run/v) 5000)]
+    (rf.story/reg-variant :story.eo.run/v {:setup [[:test/seed]]})
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.eo.run/v) 5000)]
       (is (= :ready (:lifecycle r))
           "the events-only variant lands :ready")
       (is (true? (:seeded? (:app-db r)))
           "events still dispatched after the fast-path mount")
       (is (empty? (:assertions r))
           "no `:rf.error/loader-incomplete` projection on the fast-path"))
-    (story/destroy-variant! :story.eo.run/v)))
+    (rf.story/destroy-variant! :story.eo.run/v)))
 
 (deftest lifecycle-start-loaders-from-ready-is-noop
   (testing "rf2-043cm — `start-loaders!` against a frame already at
             :ready (an events-only variant) is a benign no-op. The
             :ready node has no transition out for :loaders-started so
             the discrete state stays :ready."
-    (story/reg-variant :story.eo.idem/v {:setup []})
-    (let [r (story/resolve-decorators :story.eo.idem/v)]
-      (frames/allocate! :story.eo.idem/v r)
-      (is (= :ready (loaders/current-state :story.eo.idem/v)))
-      (loaders/start-loaders! :story.eo.idem/v)
-      (is (= :ready (loaders/current-state :story.eo.idem/v))
+    (rf.story/reg-variant :story.eo.idem/v {:setup []})
+    (let [r (rf.story/resolve-decorators :story.eo.idem/v)]
+      (rf.story.frames/allocate! :story.eo.idem/v r)
+      (is (= :ready (rf.story.loaders/current-state :story.eo.idem/v)))
+      (rf.story.loaders/start-loaders! :story.eo.idem/v)
+      (is (= :ready (rf.story.loaders/current-state :story.eo.idem/v))
           ":ready is terminal-for-mount; :loaders-started doesn't transition out")
-      (loaders/finish-loaders! :story.eo.idem/v)
-      (is (= :ready (loaders/current-state :story.eo.idem/v))
+      (rf.story.loaders/finish-loaders! :story.eo.idem/v)
+      (is (= :ready (rf.story.loaders/current-state :story.eo.idem/v))
           ":loaders-complete also a no-op against :ready")
-      (frames/destroy! :story.eo.idem/v))))
+      (rf.story.frames/destroy! :story.eo.idem/v))))
 
 ;; ===========================================================================
 ;; RUN-VARIANT END-TO-END
@@ -996,17 +996,17 @@
   (testing "run-variant returns a future of the result map"
     (rf/reg-event :test/inc
       (fn [{:keys [db]} _] {:db (update db :counter (fnil inc 0))}))
-    (story/reg-variant :story.run/v
+    (rf.story/reg-variant :story.run/v
       {:setup [[:test/inc] [:test/inc]]})
-    (let [fut (story/run-variant :story.run/v)
-          r   (async/deref-blocking fut 5000)]
+    (let [fut (rf.story/run-variant :story.run/v)
+          r   (rf.story.async/deref-blocking fut 5000)]
       (is (= :story.run/v        (:frame r)))
       (is (= :ready              (:lifecycle r)))
       (is (= 2                   (:counter (:app-db r))))
       (is (number?               (:elapsed-ms r)))
       (is (= :story.run/v        (-> r :snapshot :variant-id)))
       (is (string?               (-> r :snapshot :content-hash))))
-    (story/destroy-variant! :story.run/v)))
+    (rf.story/destroy-variant! :story.run/v)))
 
 ;; ===========================================================================
 ;; EP-0023 BEHAVIOUR-VARIANT IMAGES (rf2-fpr0b5)
@@ -1020,24 +1020,24 @@
             attaches the resolved generation via `rf/make-frame` in
             `allocate!`, and `process-event!`'s frame-resolution routes the
             dispatch through it. This is 'behavior variant -> image' end-to-end."
-    ;; The fixture's `registrar/clear-all!` wipes the helper namespaces'
+    ;; The fixture's `rf.registrar/clear-all!` wipes the helper namespaces'
     ;; top-level `reg-event`s from the source store, so re-run their loads
     ;; before building the selecting images (a zero-match `:select-ns :include`
     ;; fails loud by design).
     (require 'story.test-helpers.image-behaviour-v1 :reload)
     (require 'story.test-helpers.image-behaviour-v2 :reload)
     ;; Variant A mounts under the v1 image (adds 1).
-    (story/reg-variant :story.img/v1
+    (rf.story/reg-variant :story.img/v1
       {:images [(rf/image {:id :img/behaviour-v1
                            :select-ns {:include ["story.test-helpers.image-behaviour-v1"]}})]
        :setup [[:img.counter/step]]})
     ;; Variant B mounts under the v2 image (adds 100) — SAME event id.
-    (story/reg-variant :story.img/v2
+    (rf.story/reg-variant :story.img/v2
       {:images [(rf/image {:id :img/behaviour-v2
                            :select-ns {:include ["story.test-helpers.image-behaviour-v2"]}})]
        :setup [[:img.counter/step]]})
-    (let [ra (async/deref-blocking (story/run-variant :story.img/v1) 5000)
-          rb (async/deref-blocking (story/run-variant :story.img/v2) 5000)]
+    (let [ra (rf.story.async/deref-blocking (rf.story/run-variant :story.img/v1) 5000)
+          rb (rf.story.async/deref-blocking (rf.story/run-variant :story.img/v2) 5000)]
       (is (= 1 (-> ra :app-db :n))
           "variant under the v1 image ran the add-one handler")
       (is (= :v1-add-one (-> ra :app-db :behaviour)))
@@ -1049,28 +1049,28 @@
       (is (= [:img/behaviour-v1] (:images ra))
           "the result surfaces the resolved behaviour-variant image ids")
       (is (= [:img/behaviour-v2] (:images rb))))
-    (story/destroy-variant! :story.img/v1)
-    (story/destroy-variant! :story.img/v2)))
+    (rf.story/destroy-variant! :story.img/v1)
+    (rf.story/destroy-variant! :story.img/v2)))
 
 (deftest behaviour-variant-image-ids-on-frame-meta
   (testing "EP-0023 — a behaviour variant's image ids land on frame-meta
-            (`frames/variant-image-ids`); a state variant (no `:images`)
+            (`rf.story.frames/variant-image-ids`); a state variant (no `:images`)
             reports none and resolves against the shared default registrar."
     (require 'story.test-helpers.image-behaviour-v1 :reload)
-    (story/reg-variant :story.img/meta
+    (rf.story/reg-variant :story.img/meta
       {:images [(rf/image {:id :img/behaviour-v1
                            :select-ns {:include ["story.test-helpers.image-behaviour-v1"]}})]
        :setup [[:img.counter/step]]})
-    (story/reg-variant :story.img/state-only
+    (rf.story/reg-variant :story.img/state-only
       {:setup []})
-    (frames/allocate! :story.img/meta (story/resolve-decorators :story.img/meta))
-    (frames/allocate! :story.img/state-only (story/resolve-decorators :story.img/state-only))
-    (is (= [:img/behaviour-v1] (frames/variant-image-ids :story.img/meta))
+    (rf.story.frames/allocate! :story.img/meta (rf.story/resolve-decorators :story.img/meta))
+    (rf.story.frames/allocate! :story.img/state-only (rf.story/resolve-decorators :story.img/state-only))
+    (is (= [:img/behaviour-v1] (rf.story.frames/variant-image-ids :story.img/meta))
         "behaviour variant carries its image ids on frame-meta")
-    (is (nil? (frames/variant-image-ids :story.img/state-only))
+    (is (nil? (rf.story.frames/variant-image-ids :story.img/state-only))
         "a state-only variant carries no :rf/images slot")
-    (frames/destroy! :story.img/meta)
-    (frames/destroy! :story.img/state-only)))
+    (rf.story.frames/destroy! :story.img/meta)
+    (rf.story.frames/destroy! :story.img/state-only)))
 
 ;; ===========================================================================
 ;; VARIANT-IMAGE COMPOSITION MODEL (rf2-14gqim)
@@ -1092,20 +1092,20 @@
             resolves :img.counter/step through the inherited v1 image (add one),
             and the inherited image id surfaces on the run-result :images slot."
     (require 'story.test-helpers.image-behaviour-v1 :reload)
-    (story/reg-story :story.imginh
+    (rf.story/reg-story :story.imginh
       {:doc    "Parent story declaring the app image once."
        :images [(rf/image {:id :img/behaviour-v1
                            :select-ns {:include ["story.test-helpers.image-behaviour-v1"]}})]})
-    (story/reg-variant :story.imginh/child
+    (rf.story/reg-variant :story.imginh/child
       {:setup [[:img.counter/step]]})           ; NO :images of its own
-    (let [r (async/deref-blocking (story/run-variant :story.imginh/child) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.imginh/child) 5000)]
       (is (= 1 (-> r :app-db :n))
           "the inherited story image resolved :img.counter/step to the v1 (add-one) handler")
       (is (= :v1-add-one (-> r :app-db :behaviour)))
       (is (= [:img/behaviour-v1] (:images r))
           "the parent story's image id is reported on the variant even though the
            variant declared none (inheritance)"))
-    (story/destroy-variant! :story.imginh/child)))
+    (rf.story/destroy-variant! :story.imginh/child)))
 
 (deftest variant-image-later-wins-over-story-image
   (testing "rf2-14gqim (2) — a variant's own :images layer ON TOP of the story
@@ -1116,15 +1116,15 @@
             report names v1 shadowed-by v2."
     (require 'story.test-helpers.image-behaviour-v1 :reload)
     (require 'story.test-helpers.image-behaviour-v2 :reload)
-    (story/reg-story :story.imgover
+    (rf.story/reg-story :story.imgover
       {:doc    "Parent story: baseline app image is v1 (add one)."
        :images [(rf/image {:id :img/behaviour-v1
                            :select-ns {:include ["story.test-helpers.image-behaviour-v1"]}})]})
-    (story/reg-variant :story.imgover/wins
+    (rf.story/reg-variant :story.imgover/wins
       {:images [(rf/image {:id :img/behaviour-v2
                            :select-ns {:include ["story.test-helpers.image-behaviour-v2"]}})]
        :setup [[:img.counter/step]]})
-    (let [r (async/deref-blocking (story/run-variant :story.imgover/wins) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.imgover/wins) 5000)]
       (is (= 100 (-> r :app-db :n))
           "the variant image (v2, add-hundred) layered on top WON the override
            of the story image's :img.counter/step")
@@ -1139,7 +1139,7 @@
                   shadows)
             "the generation shadow report records the story image (v1) shadowed
              by the later variant image (v2) — later-wins is the sole precedence")))
-    (story/destroy-variant! :story.imgover/wins)))
+    (rf.story/destroy-variant! :story.imgover/wins)))
 
 (deftest authored-image-report-excludes-runtime-image
   (testing "rf2-14gqim (3) — the AUTHORED :images report (frame-meta :rf/images)
@@ -1148,16 +1148,16 @@
             image IS genuinely composed into the frame's generation."
     (require 'story.test-helpers.image-behaviour-v1 :reload)
     (require 'story.test-helpers.image-behaviour-v2 :reload)
-    (story/reg-story :story.imgrep
+    (rf.story/reg-story :story.imgrep
       {:doc    "Parent story with the v1 app image."
        :images [(rf/image {:id :img/behaviour-v1
                            :select-ns {:include ["story.test-helpers.image-behaviour-v1"]}})]})
-    (story/reg-variant :story.imgrep/v
+    (rf.story/reg-variant :story.imgrep/v
       {:images [(rf/image {:id :img/behaviour-v2
                            :select-ns {:include ["story.test-helpers.image-behaviour-v2"]}})]
        :setup []})
-    (frames/allocate! :story.imgrep/v (story/resolve-decorators :story.imgrep/v))
-    (let [reported (frames/variant-image-ids :story.imgrep/v)]
+    (rf.story.frames/allocate! :story.imgrep/v (rf.story/resolve-decorators :story.imgrep/v))
+    (let [reported (rf.story.frames/variant-image-ids :story.imgrep/v)]
       (is (= [:img/behaviour-v1 :img/behaviour-v2] reported)
           "authored image ids: story + variant, story first")
       (is (not (contains? (set reported) :rf.story/runtime))
@@ -1166,7 +1166,7 @@
       (is (contains? resolver [:event :rf.assert/path-equals])
           "the runtime image IS composed into the generation (a Story :rf.assert/*
            handler resolves) — excluded only from the AUTHORED-id report, not the frame"))
-    (frames/destroy! :story.imgrep/v)))
+    (rf.story.frames/destroy! :story.imgrep/v)))
 
 (deftest runtime-image-composed-last-shadows-app-image
   (testing "rf2-14gqim (4) — the load-bearing shadow test. An app image
@@ -1177,12 +1177,12 @@
             image shadowed-by :rf.story/runtime, AND the in-script assertion
             passes while the app shadow's sentinel is absent."
     (require 'story.test-helpers.runtime-shadow :reload)
-    (story/reg-variant :story.shadow/v
+    (rf.story/reg-variant :story.shadow/v
       {:images [(rf/image {:id :shadow.app/image
                            :select-ns {:include ["story.test-helpers.runtime-shadow"]}})]
        :setup  [[:shadow.app/seed-count]]
        :script [[:assert [:rf.assert/path-equals [:count] 1]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.shadow/v) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.shadow/v) 5000)]
       (let [shadows (:rf.gen/shadows (rf/frame-generation :story.shadow/v))]
         (is (some #(= {:registration [:event :rf.assert/path-equals]
                        :image        :shadow.app/image
@@ -1193,12 +1193,12 @@
              image — runtime is the LAST (winning) image"))
       (is (= :pass (:status r))
           "the real Story :rf.assert/path-equals handler is live (checkpoint passed)")
-      (is (story/assertions-passing? r)
+      (is (rf.story/assertions-passing? r)
           "the assertion machinery from the runtime image ran normally")
       (is (nil? (-> r :app-db :shadow/app-assert-ran))
           "the broken app-shadow handler did NOT run — the runtime image was not
            shadowed out by the app image"))
-    (story/destroy-variant! :story.shadow/v)))
+    (rf.story/destroy-variant! :story.shadow/v)))
 
 (deftest no-app-image-resolves-default-image-with-runtime-visible
   (testing "rf2-14gqim (5) — absence-is-default. With NO story/variant app
@@ -1208,21 +1208,21 @@
             that default projection (the :rf.assert/* checkpoint passes)."
     (rf/reg-event :test/seed-count
       (fn [{:keys [db]} _] {:db (assoc db :count 1)}))
-    (story/reg-variant :story.noimg/v
+    (rf.story/reg-variant :story.noimg/v
       {:setup  [[:test/seed-count]]
        :script [[:assert [:rf.assert/path-equals [:count] 1]]]})
-    (is (nil? (#'frames/compose-variant-images :story.noimg/v nil))
+    (is (nil? (#'rf.story.frames/compose-variant-images :story.noimg/v nil))
         "no story image + no variant image → compose yields nil (the
          absence-is-default signal; runtime image deliberately NOT composed here)")
-    (let [r (async/deref-blocking (story/run-variant :story.noimg/v) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.noimg/v) 5000)]
       (is (= :ready (:lifecycle r)))
-      (is (nil? (frames/variant-image-ids :story.noimg/v))
+      (is (nil? (rf.story.frames/variant-image-ids :story.noimg/v))
           "no :rf/images stamped — allocate! omitted :images (default-image path)")
       (is (= :pass (:status r))
           "the Story :rf.assert/* handler resolved through the default whole-store
            projection — the runtime stays visible without an explicit runtime image")
-      (is (story/assertions-passing? r)))
-    (story/destroy-variant! :story.noimg/v)))
+      (is (rf.story/assertions-passing? r)))
+    (rf.story/destroy-variant! :story.noimg/v)))
 
 (deftest run-variant-with-loaders-and-events
   (testing "run-variant drains loaders before events"
@@ -1231,14 +1231,14 @@
     (rf/reg-event :test/use
       (fn [{:keys [db]} _]
         {:db (assoc db :used-loaded? (boolean (:loaded? db)))}))
-    (story/reg-variant :story.flow/v
+    (rf.story/reg-variant :story.flow/v
       {:loaders [[:test/load]]
        :setup  [[:test/use]]})
-    (let [r (async/deref-blocking (story/run-variant :story.flow/v) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.flow/v) 5000)]
       (is (true? (-> r :app-db :loaded?)))
       (is (true? (-> r :app-db :used-loaded?))
           "events ran AFTER loaders"))
-    (story/destroy-variant! :story.flow/v)))
+    (rf.story/destroy-variant! :story.flow/v)))
 
 (deftest run-variant-blocks-events-when-loaders-incomplete
   (testing "a false loaders-complete-when predicate keeps the variant in :loading and skips events/play"
@@ -1249,12 +1249,12 @@
       (fn [{:keys [db]} _] {:db (assoc db :loaded? true)}))
     (rf/reg-event :test/should-not-run
       (fn [{:keys [db]} _] {:db (assoc db :events-ran? true)}))
-    (story/reg-variant :story.flow/blocked
+    (rf.story/reg-variant :story.flow/blocked
       {:loaders               [[:test/load-but-not-ready]]
        :loaders-complete-when :test/not-ready?
        :setup                [[:test/should-not-run]]
        :script [[:dispatch-sync [:rf.assert/path-equals [:events-ran?] true]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.flow/blocked) 5000)
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.flow/blocked) 5000)
           incomplete (->> (:assertions r)
                           (filter #(= :rf.error/loader-incomplete (:assertion %)))
                           first)]
@@ -1269,7 +1269,7 @@
       (is (= :phase-1-loaders (:phase incomplete)))
       (is (= 1 (count (:assertions r)))
           "play assertions are skipped because the variant never became ready"))
-    (story/destroy-variant! :story.flow/blocked)))
+    (rf.story/destroy-variant! :story.flow/blocked)))
 
 (deftest run-variant-frame-setup-decorator
   (testing ":frame-setup decorators fire :init events before loaders"
@@ -1277,20 +1277,20 @@
       (fn [{:keys [db]} _] {:db (assoc db :mock {:user "alice"})}))
     (rf/reg-event :test/observe
       (fn [{:keys [db]} _] {:db (assoc db :observed-mock (:mock db))}))
-    (story/reg-decorator :mock-frame
+    (rf.story/reg-decorator :mock-frame
       {:kind :frame-setup
        :init [[:test/mock-init]]})
-    (story/reg-variant :story.fs/v
+    (rf.story/reg-variant :story.fs/v
       {:decorators [[:mock-frame]]
        :setup     [[:test/observe]]})
-    (let [r (async/deref-blocking (story/run-variant :story.fs/v) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.fs/v) 5000)]
       (is (= {:user "alice"} (-> r :app-db :observed-mock))
           ":init events ran before :setup; observe saw the mock"))
-    (story/destroy-variant! :story.fs/v)))
+    (rf.story/destroy-variant! :story.fs/v)))
 
 (deftest run-variant-unknown-variant
   (testing "run-variant of an unregistered variant produces an error result"
-    (let [r (async/deref-blocking (story/run-variant :story.nope/x) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.nope/x) 5000)]
       (is (= :error (:lifecycle r)))
       (is (= :rf.error/unknown-variant
              (-> r :assertions first :assertion))))))
@@ -1299,14 +1299,14 @@
   (testing "reset-variant produces a fresh app-db"
     (rf/reg-event :test/inc
       (fn [{:keys [db]} _] {:db (update db :counter (fnil inc 0))}))
-    (story/reg-variant :story.reset/v
+    (rf.story/reg-variant :story.reset/v
       {:setup [[:test/inc]]})
-    (let [r1 (async/deref-blocking (story/run-variant :story.reset/v) 5000)
-          r2 (async/deref-blocking (story/reset-variant :story.reset/v) 5000)]
+    (let [r1 (rf.story.async/deref-blocking (rf.story/run-variant :story.reset/v) 5000)
+          r2 (rf.story.async/deref-blocking (rf.story/reset-variant :story.reset/v) 5000)]
       (is (= 1 (:counter (:app-db r1))))
       (is (= 1 (:counter (:app-db r2)))
           "reset gives a fresh frame; counter starts again at 0 then increments to 1"))
-    (story/destroy-variant! :story.reset/v)))
+    (rf.story/destroy-variant! :story.reset/v)))
 
 ;; ===========================================================================
 ;; PLAN-ROUTED RUNTIME (rf2-5x1wt.22 — §B8 Runtime Migration)
@@ -1328,11 +1328,11 @@
       (fn [{:keys [db]} _] {:db (assoc db :seeded? true :count 0)}))
     (rf/reg-event :test/bump
       (fn [{:keys [db]} _] {:db (update db :count inc)}))
-    (story/reg-variant :story.public/v
+    (rf.story/reg-variant :story.public/v
       {:setup  [[:test/seed]]
        :script [[:dispatch [:test/bump]]
                 [:assert [:rf.assert/path-equals [:count] 1]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.public/v) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.public/v) 5000)]
       (is (= :ready (:lifecycle r)))
       (is (true? (-> r :app-db :seeded?))
           ":setup ran through the plan's [:world :setup]")
@@ -1345,7 +1345,7 @@
                     first)]
         (is (some? pe) "the checkpoint assertion was recorded")
         (is (true? (:passed? pe)))))
-    (story/destroy-variant! :story.public/v)))
+    (rf.story/destroy-variant! :story.public/v)))
 
 (deftest run-variant-composed-fragment-setup-runs-in-phase-2
   (testing "a :compose fragment's :setup is executed in phase 2 — the plan
@@ -1355,19 +1355,19 @@
       (fn [{:keys [db]} _] {:db (assoc db :from-fragment :alice)}))
     (rf/reg-event :test/observe-frag
       (fn [{:keys [db]} _] {:db (assoc db :observed (:from-fragment db))}))
-    (story/reg-fragment :fragment.test/seeded
+    (rf.story/reg-fragment :fragment.test/seeded
       {:setup [[:test/frag-seed]]})
-    (story/reg-variant :story.compose/v
+    (rf.story/reg-variant :story.compose/v
       {:compose [:fragment.test/seeded]
        :setup   [[:test/observe-frag]]})
-    (let [r (async/deref-blocking (story/run-variant :story.compose/v) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.compose/v) 5000)]
       (is (= :ready (:lifecycle r)))
       (is (= :alice (-> r :app-db :from-fragment))
           "the composed fragment's :setup ran")
       (is (= :alice (-> r :app-db :observed))
           "fragment setup APPENDS BEFORE the variant's own setup (the
            variant's observe step saw the fragment's seed)"))
-    (story/destroy-variant! :story.compose/v)))
+    (rf.story/destroy-variant! :story.compose/v)))
 
 (deftest run-variant-named-plays-from-plan
   (testing "a variant's named :plays are driven as named scripts from the
@@ -1375,7 +1375,7 @@
             false — only the first auto-play executes on run)"
     (rf/reg-event :test/init-n
       (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
-    (story/reg-variant :story.plays/v
+    (rf.story/reg-variant :story.plays/v
       {:plays [{:name      "happy"
                 :script    [[:dispatch-sync [:test/init-n 3]]
                             [:assert [:rf.assert/path-equals [:n] 3]]]}
@@ -1383,13 +1383,13 @@
                 :auto-run? false
                 :script    [[:dispatch-sync [:test/init-n 0]]
                             [:assert [:rf.assert/path-equals [:n] 0]]]}]})
-    (let [r (async/deref-blocking (story/run-variant :story.plays/v) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.plays/v) 5000)]
       (is (= :ready (:lifecycle r)))
       (is (= 3 (-> r :app-db :n))
           "only the first (auto-run?) play executed")
       (is (= :pass (:status r))
           "the first play's checkpoint passed"))
-    (story/destroy-variant! :story.plays/v)))
+    (rf.story/destroy-variant! :story.plays/v)))
 
 ;; ===========================================================================
 ;; TERMINAL ASSERTIONS AUTO-RUN (rf2-nyjoa — Mike RULED B)
@@ -1412,10 +1412,10 @@
             state and produces a :pass verdict (rf2-nyjoa)"
     (rf/reg-event :test/seed-state
       (fn [{:keys [db]} _] {:db (assoc-in db [:checkout :state] :submitted)}))
-    (story/reg-variant :story.nyjoa/pass
+    (rf.story/reg-variant :story.nyjoa/pass
       {:setup      [[:test/seed-state]]
        :assertions [[:rf.assert/path-equals [:checkout :state] :submitted]]})
-    (let [r (async/deref-blocking (story/run-variant :story.nyjoa/pass) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.nyjoa/pass) 5000)]
       (is (= :ready (:lifecycle r)))
       (is (= :pass (:status r))
           "the terminal assertion auto-ran and passed → :pass")
@@ -1427,17 +1427,17 @@
              with no in-script checkpoint authoring it")
         (is (true? (:passed? rec)))
         (is (= [[:checkout :state] :submitted] (:payload rec)))))
-    (story/destroy-variant! :story.nyjoa/pass)))
+    (rf.story/destroy-variant! :story.nyjoa/pass)))
 
 (deftest run-variant-terminal-assertions-only-fail
   (testing "a FAILING terminal assertion (no in-script [:assert]) flips the
             unified verdict to :fail (rf2-nyjoa)"
     (rf/reg-event :test/seed-other
       (fn [{:keys [db]} _] {:db (assoc-in db [:checkout :state] :draft)}))
-    (story/reg-variant :story.nyjoa/fail
+    (rf.story/reg-variant :story.nyjoa/fail
       {:setup      [[:test/seed-other]]
        :assertions [[:rf.assert/path-equals [:checkout :state] :submitted]]})
-    (let [r (async/deref-blocking (story/run-variant :story.nyjoa/fail) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.nyjoa/fail) 5000)]
       (is (= :ready (:lifecycle r)))
       (is (= :fail (:status r))
           "the terminal assertion auto-ran and failed → :fail")
@@ -1447,22 +1447,22 @@
         (is (some? rec))
         (is (false? (:passed? rec))
             "the failing terminal assertion recorded :passed? false")))
-    (story/destroy-variant! :story.nyjoa/fail)))
+    (rf.story/destroy-variant! :story.nyjoa/fail)))
 
 (deftest run-variant-terminal-assertion-evaluates-final-state-after-script
   (testing "a terminal assertion evaluates the FINAL settled state — it sees
             the state AFTER the script's dispatches commit, not the
             pre-script state (rf2-nyjoa: terminal = check the FINAL state)"
     (rf/reg-event :test/set-n (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
-    (story/reg-variant :story.nyjoa/after-script
+    (rf.story/reg-variant :story.nyjoa/after-script
       {:script     [[:dispatch [:test/set-n 7]]]
        :assertions [[:rf.assert/path-equals [:n] 7]]})
-    (let [r (async/deref-blocking
-              (story/run-variant :story.nyjoa/after-script) 5000)]
+    (let [r (rf.story.async/deref-blocking
+              (rf.story/run-variant :story.nyjoa/after-script) 5000)]
       (is (= 7 (-> r :app-db :n)) "the script dispatch committed")
       (is (= :pass (:status r))
           "the terminal assertion saw the post-script value 7"))
-    (story/destroy-variant! :story.nyjoa/after-script)))
+    (rf.story/destroy-variant! :story.nyjoa/after-script)))
 
 (deftest run-variant-terminal-tape-evaluated-not-double-counted
   (testing "a tape-evaluated terminal assertion (:rf.assert/schema-error) is
@@ -1473,11 +1473,11 @@
             terminal assertion in the same block so the split is exercised
             (rf2-nyjoa critical guard)."
     (rf/reg-event :test/seed-ok (fn [{:keys [db]} _] {:db (assoc db :ok? true)}))
-    (story/reg-variant :story.nyjoa/mixed
+    (rf.story/reg-variant :story.nyjoa/mixed
       {:setup      [[:test/seed-ok]]
        :assertions [[:rf.assert/path-equals [:ok?] true]
                     [:rf.assert/schema-error {:where :event :event :some/evt}]]})
-    (let [r (async/deref-blocking (story/run-variant :story.nyjoa/mixed) 5000)
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.nyjoa/mixed) 5000)
           path-recs (->> (:assertions r)
                          (filter #(= :rf.assert/path-equals (:assertion %))))
           schema-recs (->> (:assertions r)
@@ -1490,17 +1490,17 @@
           "the schema-error expectation is minted at most ONCE — by the
            result boundary's tape matcher, NOT a second time by the terminal
            auto-run dispatching a (non-existent) handler"))
-    (story/destroy-variant! :story.nyjoa/mixed)))
+    (rf.story/destroy-variant! :story.nyjoa/mixed)))
 
 (deftest run-variant-plan-error-projects-as-run-error
   (testing "a plan-construction failure (an [:assert …] checkpoint placed
             in :setup) surfaces through the run-error projection rather
             than crashing the orchestrator"
     (rf/reg-event :test/noop (fn [{:keys [db]} _] {:db db}))
-    (story/reg-variant :story.planerr/v
+    (rf.story/reg-variant :story.planerr/v
       {:setup [[:dispatch [:test/noop]]
                [:assert [:rf.assert/path-equals [:x] 1]]]})
-    (let [r (async/deref-blocking (story/run-variant :story.planerr/v) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.planerr/v) 5000)]
       (is (= :error (:lifecycle r))
           "the plan-compile failure rolled the lifecycle to :error")
       (is (= :error (:status r))
@@ -1511,7 +1511,7 @@
         (is (some? exc)
             "the structured :rf.error/story-* id rides the assertion record")
         (is (false? (:passed? exc)))))
-    (story/destroy-variant! :story.planerr/v)))
+    (rf.story/destroy-variant! :story.planerr/v)))
 
 (deftest run-variant-non-dispatch-setup-step-is-refused
   (testing "a :setup carrying a non-dispatch step (e.g. [:wait …] / [:click …])
@@ -1523,9 +1523,9 @@
     (rf/reg-event :test/seed-z (fn [{:keys [db]} _] {:db (assoc db :seeded? true)}))
     (doseq [[vid bad-step] [[:story.zaiwl/wait  [:wait 100]]
                             [:story.zaiwl/click [:click "[data-test=open]"]]]]
-      (story/reg-variant vid
+      (rf.story/reg-variant vid
         {:setup [[:dispatch [:test/seed-z]] bad-step]})
-      (let [r (async/deref-blocking (story/run-variant vid) 5000)]
+      (let [r (rf.story.async/deref-blocking (rf.story/run-variant vid) 5000)]
         (is (= :error (:lifecycle r))
             "the unrunnable setup step rolled the lifecycle to :error")
         (is (= :error (:status r))
@@ -1541,7 +1541,7 @@
           (is (= [bad-step]
                  (get-in exc [:error :data :offending-steps]))
               "the refusal names the offending non-dispatch step")))
-      (story/destroy-variant! vid))))
+      (rf.story/destroy-variant! vid))))
 
 (deftest run-variant-legit-setup-steps-still-compile-and-run
   (testing "the legit setup shapes — a tagged [:dispatch …] AND a bare event
@@ -1550,15 +1550,15 @@
             non-dispatch steps)"
     (rf/reg-event :test/seed-a (fn [{:keys [db]} _] {:db (assoc db :a true)}))
     (rf/reg-event :test/seed-b (fn [{:keys [db]} _] {:db (assoc db :b true)}))
-    (story/reg-variant :story.zaiwl/ok
+    (rf.story/reg-variant :story.zaiwl/ok
       {:setup [[:dispatch [:test/seed-a]]   ; tagged dispatch
                [:test/seed-b]]})            ; bare event vector → [:dispatch …]
-    (let [r (async/deref-blocking (story/run-variant :story.zaiwl/ok) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.zaiwl/ok) 5000)]
       (is (= :ready (:lifecycle r))
           "both legit setup shapes ran without refusal")
       (is (true? (-> r :app-db :a)) "the tagged [:dispatch …] setup step ran")
       (is (true? (-> r :app-db :b)) "the bare-event-vector setup step ran"))
-    (story/destroy-variant! :story.zaiwl/ok)))
+    (rf.story/destroy-variant! :story.zaiwl/ok)))
 
 ;; ---- plan-construction-error? discrimination (rf2-x3mol) -----------------
 ;;
@@ -1569,7 +1569,7 @@
 ;; cited case is `:rf.error/no-adapter-installed` from `make-frame` →
 ;; `make-state-container` on a host with no adapter installed) MUST take
 ;; the frame-bound record/transition branch (`record-error!` +
-;; `loaders/error!`), NOT `plan-error-result` (which would stamp the raw
+;; `rf.story.loaders/error!`), NOT `plan-error-result` (which would stamp the raw
 ;; `:rf.error/id` as the assertion id, misreporting a runtime failure as a
 ;; plan-construction failure). The pre-existing suite pinned only the
 ;; POSITIVE branch (a true plan error projects correctly); these pin the
@@ -1580,7 +1580,7 @@
             :rf.error/id-bearing error WITHOUT that marker is NOT a plan-
             construction error (it must route through the frame-bound
             path), while a :where-marked plan failure IS"
-    (let [plan-construction-error? @#'runtime/plan-construction-error?]
+    (let [plan-construction-error? @#'rf.story.runtime/plan-construction-error?]
       ;; NEGATIVE: a framework runtime error carrying :rf.error/id but no
       ;; :where marker — the #2430 cum40 regression case. Must be false so
       ;; handle-run-error! takes the frame-bound branch, NOT plan-error-result.
@@ -1614,20 +1614,20 @@
             record path (an :rf.error/exception assertion at :phase-0-setup)
             — it is NOT misrouted as a plan-construction error (which would
             stamp the raw :rf.error/id as the assertion id)"
-    (story/reg-variant :story.postframe/v {:setup []})
+    (rf.story/reg-variant :story.postframe/v {:setup []})
     ;; Redef a phase fn that runs AFTER run-phase-0! (so the frame is
     ;; allocated and the lifecycle is past :pre-mount) to throw an ex-info
     ;; carrying an :rf.error/id but NO :where 'rf.story/variant-plan marker
     ;; — simulating the :rf.error/no-adapter-installed case the #2430 fix
     ;; guards against.
-    (with-redefs [runtime/run-phase-2!
+    (with-redefs [rf.story.runtime/run-phase-2!
                   (fn [_ctx]
                     (throw (ex-info "no adapter installed"
                                     {:rf.error/id :rf.error/no-adapter-installed})))]
-      (let [r (async/deref-blocking (story/run-variant :story.postframe/v) 5000)]
+      (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.postframe/v) 5000)]
         (is (= :error (:lifecycle r))
             "the post-frame throw rolled the lifecycle to :error via
-             loaders/error!")
+             rf.story.loaders/error!")
         (let [recs (:assertions r)]
           (is (some #(and (= :rf.error/exception (:assertion %))
                           (= :phase-0-setup (:phase %)))
@@ -1637,7 +1637,7 @@
           (is (not-any? #(= :rf.error/no-adapter-installed (:assertion %)) recs)
               "the raw :rf.error/id was NOT stamped as the assertion id —
                i.e. it did NOT misroute through plan-error-result"))))
-    (story/destroy-variant! :story.postframe/v)))
+    (rf.story/destroy-variant! :story.postframe/v)))
 
 ;; ===========================================================================
 ;; FRAME-META INTROSPECTION
@@ -1645,16 +1645,16 @@
 
 (deftest variant-frames-marked
   (testing "variant frames carry :rf/story? + :rf/variant on their config"
-    (story/reg-variant :story.fm/v {:setup []})
-    (let [r (story/resolve-decorators :story.fm/v)]
-      (frames/allocate! :story.fm/v r)
+    (rf.story/reg-variant :story.fm/v {:setup []})
+    (let [r (rf.story/resolve-decorators :story.fm/v)]
+      (rf.story.frames/allocate! :story.fm/v r)
       (let [m (rf/frame-meta :story.fm/v)]
         (is (true?              (:rf/story? m)))
         (is (= :story.fm/v      (:rf/variant m)))
         (is (= :story           (:preset m))))
-      (is (contains? (story/variant-frames) :story.fm/v))
-      (is (true? (story/variant-frame? :story.fm/v)))
-      (frames/destroy! :story.fm/v))))
+      (is (contains? (rf.story/variant-frames) :story.fm/v))
+      (is (true? (rf.story/variant-frame? :story.fm/v)))
+      (rf.story.frames/destroy! :story.fm/v))))
 
 ;; ===========================================================================
 ;; ERROR PROJECTION
@@ -1664,15 +1664,15 @@
   (testing "a thrown exception during :setup lands in :assertions"
     (rf/reg-event :test/boom
       (fn [_ _] (throw (ex-info "bang" {:why :test}))))
-    (story/reg-variant :story.err/v
+    (rf.story/reg-variant :story.err/v
       {:setup [[:test/boom]]})
-    (let [r (async/deref-blocking (story/run-variant :story.err/v) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.err/v) 5000)]
       ;; Phase-2 errors don't roll back the lifecycle; :ready is the
       ;; terminal state per `002-Runtime.md` §Error projection — we record and continue.
       (is (some #(= :rf.error/exception (:assertion %)) (:assertions r))
           "an exception assertion was recorded")
       (is (some #(= :phase-2-events (:phase %)) (:assertions r))))
-    (story/destroy-variant! :story.err/v)))
+    (rf.story/destroy-variant! :story.err/v)))
 
 ;; ---- rf2-294yq5.5 — exception ex-data wire-elision -----------------------
 
@@ -1689,11 +1689,11 @@
     ;; rf2-bsk1d9 — declare the sensitive ex-data path on the variant body
     ;; (EP-0015 frame-owned classification, installed at frame creation); no
     ;; public add-marks mutation, no run-once-then-mark-then-rerun dance.
-    (story/reg-variant :story.err-redaction-jvm/v
+    (rf.story/reg-variant :story.err-redaction-jvm/v
       {:setup      []
        :sensitive   {:app-db [[:token]]}
        :script [[:dispatch-sync [:auth/boom-jvm]]]})
-    (let [r    (async/deref-blocking (story/run-variant :story.err-redaction-jvm/v) 5000)
+    (let [r    (rf.story.async/deref-blocking (rf.story/run-variant :story.err-redaction-jvm/v) 5000)
           ex   (last (filter #(= :rf.error/exception (:assertion %)) (:assertions r)))
           data (get-in ex [:error :data])]
       (is (some? ex) "the throwing handler was captured as an exception record")
@@ -1703,20 +1703,20 @@
           "a non-sensitive ex-data slot passes through")
       (is (= "Invalid credentials" (get-in ex [:error :message]))
           "the message string survives verbatim (NOT auto-walked)"))
-    (story/destroy-variant! :story.err-redaction-jvm/v)))
+    (rf.story/destroy-variant! :story.err-redaction-jvm/v)))
 
 (deftest exception-ex-data-non-sensitive-passes-through-jvm
   (testing "with NO marks, captured ex-data passes through unredacted —
             frame-scoped elision only redacts marked paths (rf2-294yq5.5)"
     (rf/reg-event :plain/boom-jvm
       (fn [_ _] (throw (ex-info "boom" {:detail "not-secret"}))))
-    (story/reg-variant :story.err-plain-jvm/v
+    (rf.story/reg-variant :story.err-plain-jvm/v
       {:setup [[:plain/boom-jvm]]})
-    (let [r    (async/deref-blocking (story/run-variant :story.err-plain-jvm/v) 5000)
+    (let [r    (rf.story.async/deref-blocking (rf.story/run-variant :story.err-plain-jvm/v) 5000)
           ex   (last (filter #(= :rf.error/exception (:assertion %)) (:assertions r)))]
       (is (= "not-secret" (get-in ex [:error :data :detail]))
           "an unmarked ex-data slot is not redacted"))
-    (story/destroy-variant! :story.err-plain-jvm/v)))
+    (rf.story/destroy-variant! :story.err-plain-jvm/v)))
 
 ;; ---- rf2-294yq5.1 — :frame-setup :init failures are captured -------------
 
@@ -1727,13 +1727,13 @@
             preconditions (rf2-294yq5.1)"
     (rf/reg-event :test/setup-boom
       (fn [_ _] (throw (ex-info "setup blew up" {:why :setup}))))
-    (story/reg-decorator :boom-setup
+    (rf.story/reg-decorator :boom-setup
       {:kind :frame-setup
        :init [[:test/setup-boom]]})
-    (story/reg-variant :story.init-boom/v
+    (rf.story/reg-variant :story.init-boom/v
       {:decorators [[:boom-setup]]
        :setup     []})
-    (let [r    (async/deref-blocking (story/run-variant :story.init-boom/v) 5000)
+    (let [r    (rf.story.async/deref-blocking (rf.story/run-variant :story.init-boom/v) 5000)
           recs (:assertions r)]
       (is (some #(and (= :rf.error/exception (:assertion %))
                       (= :phase-0-setup (:phase %)))
@@ -1746,7 +1746,7 @@
       (is (seq recs)
           "the assertions vector is non-empty (regression: it was [] before
            the listener-before-setup fix)"))
-    (story/destroy-variant! :story.init-boom/v)))
+    (rf.story/destroy-variant! :story.init-boom/v)))
 
 ;; ---- rf2-294yq5.2 — cofx / interceptor failures are captured -------------
 
@@ -1760,9 +1760,9 @@
     (rf/reg-event :test/uses-boom-cofx
       {:rf.cofx/requires [:test/boom-cofx]}
       (fn [_ _] {}))
-    (story/reg-variant :story.cofx-boom/v
+    (rf.story/reg-variant :story.cofx-boom/v
       {:setup [[:test/uses-boom-cofx]]})
-    (let [r    (async/deref-blocking (story/run-variant :story.cofx-boom/v) 5000)
+    (let [r    (rf.story.async/deref-blocking (rf.story/run-variant :story.cofx-boom/v) 5000)
           recs (:assertions r)
           exc  (first (filter #(= :rf.error/exception (:assertion %)) recs))]
       (is (some? exc)
@@ -1772,7 +1772,7 @@
           "the originating coeffect-exception operation is preserved")
       (is (not= :pass (:status r))
           "a cofx failure flips the run off :pass"))
-    (story/destroy-variant! :story.cofx-boom/v)))
+    (rf.story/destroy-variant! :story.cofx-boom/v)))
 
 (deftest user-interceptor-throw-is-captured
   (testing "a phase-2 event whose USER INTERCEPTOR :before throws is
@@ -1785,9 +1785,9 @@
       (rf/reg-event :test/uses-boom-icpt
         {:interceptors [boom-icpt]}
         (fn [{:keys [db]} _] {:db db}))
-      (story/reg-variant :story.icpt-boom/v
+      (rf.story/reg-variant :story.icpt-boom/v
         {:setup [[:test/uses-boom-icpt]]})
-      (let [r    (async/deref-blocking (story/run-variant :story.icpt-boom/v) 5000)
+      (let [r    (rf.story.async/deref-blocking (rf.story/run-variant :story.icpt-boom/v) 5000)
             recs (:assertions r)
             exc  (first (filter #(= :rf.error/exception (:assertion %)) recs))]
         (is (some? exc)
@@ -1797,7 +1797,7 @@
         (is (= :test/boom-icpt (:failing-id exc))
             "the failing interceptor id is preserved")
         (is (not= :pass (:status r))))
-      (story/destroy-variant! :story.icpt-boom/v))))
+      (rf.story/destroy-variant! :story.icpt-boom/v))))
 
 ;; ---- rf2-294yq5.3 — run-variant enforces a fresh-run boundary ------------
 
@@ -1807,20 +1807,20 @@
             (rf2-294yq5.3)"
     (rf/reg-event :test/inc-counter
       (fn [{:keys [db]} _] {:db (update db :counter (fnil inc 0))}))
-    (story/reg-variant :story.fresh/v
+    (rf.story/reg-variant :story.fresh/v
       {:setup [[:test/inc-counter]]})
-    (let [r1 (async/deref-blocking (story/run-variant :story.fresh/v) 5000)
-          r2 (async/deref-blocking (story/run-variant :story.fresh/v) 5000)]
+    (let [r1 (rf.story.async/deref-blocking (rf.story/run-variant :story.fresh/v) 5000)
+          r2 (rf.story.async/deref-blocking (rf.story/run-variant :story.fresh/v) 5000)]
       (is (= 1 (:counter (:app-db r1))))
       (is (= 1 (:counter (:app-db r2)))
           "the SECOND run starts from a fresh app-db (counter 0 → 1), NOT
            the first run's leftover state (which would give 2)"))
-    (story/destroy-variant! :story.fresh/v)))
+    (rf.story/destroy-variant! :story.fresh/v)))
 
 (deftest run-variant-twice-epoch-tape-does-not-bleed
   (testing "rf2-xj0bj0 — a second run-variant on the same id projects
             evidence from ITS OWN epoch records only. The reset-in-place
-            path (frames/reset-state!, the fresh-run boundary) resets
+            path (rf.story.frames/reset-state!, the fresh-run boundary) resets
             app-db/runtime-db but never touches the epoch ring (only
             destroy-frame! drops it) — so a naive whole-frame
             epoch-history read would inherit the FIRST run's records too,
@@ -1828,10 +1828,10 @@
             polluting the projected evidence."
     (rf/reg-event :test/inc-counter3
       (fn [{:keys [db]} _] {:db (update db :counter (fnil inc 0))}))
-    (story/reg-variant :story.fresh3/v
+    (rf.story/reg-variant :story.fresh3/v
       {:setup [[:test/inc-counter3]]})
-    (let [r1 (async/deref-blocking (story/run-variant :story.fresh3/v) 5000)
-          r2 (async/deref-blocking (story/run-variant :story.fresh3/v) 5000)]
+    (let [r1 (rf.story.async/deref-blocking (rf.story/run-variant :story.fresh3/v) 5000)
+          r2 (rf.story.async/deref-blocking (rf.story/run-variant :story.fresh3/v) 5000)]
       (is (= 1 (:counter (:app-db r1))))
       (is (= 1 (:counter (:app-db r2))))
       (is (pos? (count (:epoch-tape r1)))
@@ -1845,7 +1845,7 @@
       (is (= (:schema-violations r1) (:schema-violations r2))
           "identical re-runs project IDENTICAL evidence — no stale
            violation/warning carries over from the first run"))
-    (story/destroy-variant! :story.fresh3/v)))
+    (rf.story/destroy-variant! :story.fresh3/v)))
 
 (deftest run-variant-twice-reruns-loaders
   (testing "a LOADER variant reruns its loaders on the second run-variant —
@@ -1853,16 +1853,16 @@
             short-circuit (rf2-294yq5.3)"
     (rf/reg-event :test/load-mark
       (fn [{:keys [db]} _] {:db (update db :loads (fnil inc 0))}))
-    (story/reg-variant :story.fresh-loader/v
+    (rf.story/reg-variant :story.fresh-loader/v
       {:loaders [[:test/load-mark]]})
-    (let [r1 (async/deref-blocking (story/run-variant :story.fresh-loader/v) 5000)
-          r2 (async/deref-blocking (story/run-variant :story.fresh-loader/v) 5000)]
+    (let [r1 (rf.story.async/deref-blocking (rf.story/run-variant :story.fresh-loader/v) 5000)
+          r2 (rf.story.async/deref-blocking (rf.story/run-variant :story.fresh-loader/v) 5000)]
       (is (= 1 (:loads (:app-db r1)))
           "first run runs the loader once")
       (is (= 1 (:loads (:app-db r2)))
           "second run reruns the loader against a FRESH frame (1, not a
            skipped loader leaving the slot absent, and not 2 from carryover)"))
-    (story/destroy-variant! :story.fresh-loader/v)))
+    (rf.story/destroy-variant! :story.fresh-loader/v)))
 
 ;; ===========================================================================
 ;; CONFIGURE!
@@ -1870,30 +1870,30 @@
 
 (deftest configure-sets-global-args
   (testing "configure! writes the global-args layer"
-    (story/configure! {:rf.story/global-args {:theme :dark}})
-    (is (= {:theme :dark} (config/get-global-args)))
-    (story/reg-variant :story.cfg/v {:setup []})
-    (let [r (story/resolve-args :story.cfg/v)]
+    (rf.story/configure! {:rf.story/global-args {:theme :dark}})
+    (is (= {:theme :dark} (rf.story.config/get-global-args)))
+    (rf.story/reg-variant :story.cfg/v {:setup []})
+    (let [r (rf.story/resolve-args :story.cfg/v)]
       (is (= :dark (:theme r))))))
 
 (deftest configure-sets-editor-preference
   (testing "configure! writes the :rf.story/editor preference (rf2-evgf5)"
     ;; Default is :vscode.
-    (config/set-editor! :vscode)
-    (is (= :vscode (config/get-editor)))
-    (story/configure! {:rf.story/editor :cursor})
-    (is (= :cursor (config/get-editor)))
-    (story/configure! {:rf.story/editor :idea})
-    (is (= :idea (config/get-editor)))
-    (story/configure! {:rf.story/editor {:custom "zed://file/{path}:{line}"}})
-    (is (= {:custom "zed://file/{path}:{line}"} (config/get-editor)))
+    (rf.story.config/set-editor! :vscode)
+    (is (= :vscode (rf.story.config/get-editor)))
+    (rf.story/configure! {:rf.story/editor :cursor})
+    (is (= :cursor (rf.story.config/get-editor)))
+    (rf.story/configure! {:rf.story/editor :idea})
+    (is (= :idea (rf.story.config/get-editor)))
+    (rf.story/configure! {:rf.story/editor {:custom "zed://file/{path}:{line}"}})
+    (is (= {:custom "zed://file/{path}:{line}"} (rf.story.config/get-editor)))
     ;; Reset for downstream tests.
-    (config/set-editor! :vscode))
+    (rf.story.config/set-editor! :vscode))
   (testing "configure! with no :rf.story/editor leaves the preference untouched"
-    (config/set-editor! :cursor)
-    (story/configure! {:rf.story/global-args {:theme :dark}})
-    (is (= :cursor (config/get-editor)))
-    (config/set-editor! :vscode)))
+    (rf.story.config/set-editor! :cursor)
+    (rf.story/configure! {:rf.story/global-args {:theme :dark}})
+    (is (= :cursor (rf.story.config/get-editor)))
+    (rf.story.config/set-editor! :vscode)))
 
 (deftest configure-sets-global-decorators
   (testing "configure! :rf.story/global-decorators replaces the global
@@ -1901,94 +1901,94 @@
             parity)"
     ;; The decorator bodies must already be registered; configure! is
     ;; the opt-in surface, not the body-registration surface.
-    (story/reg-decorator :app/theme
+    (rf.story/reg-decorator :app/theme
       {:kind :hiccup :wrap (fn [body _] [:div.theme body])})
-    (story/reg-decorator :app/wrap
+    (rf.story/reg-decorator :app/wrap
       {:kind :hiccup :wrap (fn [body _] [:div.wrap body])})
-    (story/configure!
+    (rf.story/configure!
       {:rf.story/global-decorators [[:app/theme] [:app/wrap]]})
-    (is (= [[:app/theme] [:app/wrap]] (config/get-global-decorators))
+    (is (= [[:app/theme] [:app/wrap]] (rf.story.config/get-global-decorators))
         "the configure! call lands the vector verbatim — earliest first")
-    (is (= [[:app/theme] [:app/wrap]] (story/global-decorators))
+    (is (= [[:app/theme] [:app/wrap]] (rf.story/global-decorators))
         "and the public accessor reflects the same shape"))
   (testing "every variant inherits the global stack as the outermost
             wrap layer — composition, not override"
-    (story/reg-decorator :app/theme
+    (rf.story/reg-decorator :app/theme
       {:kind :hiccup :wrap (fn [body _] [:div.theme body])})
-    (story/reg-decorator :variant-deco
+    (rf.story/reg-decorator :variant-deco
       {:kind :hiccup :wrap (fn [body _] [:div.variant body])})
-    (story/configure!
+    (rf.story/configure!
       {:rf.story/global-decorators [[:app/theme]]})
-    (story/reg-variant :story.cfg.gd/v
+    (rf.story/reg-variant :story.cfg.gd/v
       {:decorators [[:variant-deco]]
        :setup     []})
-    (let [r       (story/resolve-decorators :story.cfg.gd/v)
+    (let [r       (rf.story/resolve-decorators :story.cfg.gd/v)
           ids     (mapv :id (:hiccup r))
-          wrapped (decorators/apply-hiccup-decorators
+          wrapped (rf.story.decorators/apply-hiccup-decorators
                     (:hiccup r) [:span "leaf"] {})]
       (is (= [:app/theme :variant-deco] ids)
           "global is outermost; variant decorator composes inside")
       (is (= [:div.theme [:div.variant [:span "leaf"]]] wrapped)
           ":app/theme wraps :variant-deco wraps the leaf")))
   (testing "configure! :rf.story/global-decorators nil clears the vector"
-    (story/reg-decorator :app/theme
+    (rf.story/reg-decorator :app/theme
       {:kind :hiccup :wrap (fn [body _] [:div.theme body])})
-    (story/configure!
+    (rf.story/configure!
       {:rf.story/global-decorators [[:app/theme]]})
-    (is (seq (config/get-global-decorators)))
-    (story/configure! {:rf.story/global-decorators nil})
-    (is (= [] (config/get-global-decorators))
+    (is (seq (rf.story.config/get-global-decorators)))
+    (rf.story/configure! {:rf.story/global-decorators nil})
+    (is (= [] (rf.story.config/get-global-decorators))
         "explicit nil clears the global vector"))
   (testing "configure! :rf.story/global-decorators [] clears the vector"
-    (story/reg-decorator :app/theme
+    (rf.story/reg-decorator :app/theme
       {:kind :hiccup :wrap (fn [body _] [:div.theme body])})
-    (story/configure!
+    (rf.story/configure!
       {:rf.story/global-decorators [[:app/theme]]})
-    (is (seq (config/get-global-decorators)))
-    (story/configure! {:rf.story/global-decorators []})
-    (is (= [] (config/get-global-decorators))
+    (is (seq (rf.story.config/get-global-decorators)))
+    (rf.story/configure! {:rf.story/global-decorators []})
+    (is (= [] (rf.story.config/get-global-decorators))
         "explicit empty vector clears the global vector"))
   (testing "configure! with no :rf.story/global-decorators key leaves
             the slot untouched (forward-compat for partial configure
             calls)"
-    (story/reg-decorator :app/keep
+    (rf.story/reg-decorator :app/keep
       {:kind :hiccup :wrap (fn [body _] [:div.keep body])})
-    (config/set-global-decorators! [[:app/keep]])
-    (story/configure! {:rf.story/global-args {:theme :dark}})
-    (is (= [[:app/keep]] (config/get-global-decorators))
+    (rf.story.config/set-global-decorators! [[:app/keep]])
+    (rf.story/configure! {:rf.story/global-args {:theme :dark}})
+    (is (= [[:app/keep]] (rf.story.config/get-global-decorators))
         "the global-decorators slot is preserved across a global-args-only configure call")
-    (config/set-global-decorators! []))
+    (rf.story.config/set-global-decorators! []))
   (testing "configure! :rf.story/global-decorators accepts entries with
             ref-args — `[<id> & ref-args]` shape exactly like a variant's
             :decorators slot"
-    (story/reg-decorator :app/tagged
+    (rf.story/reg-decorator :app/tagged
       {:kind :hiccup
        :wrap (fn [body args]
                [:div.tagged {:tag (-> args :decorator/args first)} body])})
-    (story/configure!
+    (rf.story/configure!
       {:rf.story/global-decorators [[:app/tagged :my-tag]]})
-    (story/reg-variant :story.cfg.gd2/v {:setup []})
-    (let [r       (story/resolve-decorators :story.cfg.gd2/v)
-          wrapped (decorators/apply-hiccup-decorators
+    (rf.story/reg-variant :story.cfg.gd2/v {:setup []})
+    (let [r       (rf.story/resolve-decorators :story.cfg.gd2/v)
+          wrapped (rf.story.decorators/apply-hiccup-decorators
                     (:hiccup r) [:span "x"] {})]
       (is (= [:div.tagged {:tag :my-tag} [:span "x"]] wrapped)
           "ref-args from the global-decorators ref reach the :wrap fn")))
   (testing "configure! :rf.story/global-decorators composes with both
             story-level and variant-level :decorators — all three layers
             apply (the precedence chain is additive, not override-style)"
-    (story/reg-decorator :app/g    {:kind :hiccup :wrap (fn [b _] [:div.g b])})
-    (story/reg-decorator :app/s    {:kind :hiccup :wrap (fn [b _] [:div.s b])})
-    (story/reg-decorator :app/v    {:kind :hiccup :wrap (fn [b _] [:div.v b])})
-    (story/configure!
+    (rf.story/reg-decorator :app/g    {:kind :hiccup :wrap (fn [b _] [:div.g b])})
+    (rf.story/reg-decorator :app/s    {:kind :hiccup :wrap (fn [b _] [:div.s b])})
+    (rf.story/reg-decorator :app/v    {:kind :hiccup :wrap (fn [b _] [:div.v b])})
+    (rf.story/configure!
       {:rf.story/global-decorators [[:app/g]]})
-    (story/reg-story :story.cfg.gd3
+    (rf.story/reg-story :story.cfg.gd3
       {:decorators [[:app/s]]})
-    (story/reg-variant :story.cfg.gd3/v
+    (rf.story/reg-variant :story.cfg.gd3/v
       {:decorators [[:app/v]]
        :setup     []})
-    (let [r       (story/resolve-decorators :story.cfg.gd3/v)
+    (let [r       (rf.story/resolve-decorators :story.cfg.gd3/v)
           ids     (mapv :id (:hiccup r))
-          wrapped (decorators/apply-hiccup-decorators
+          wrapped (rf.story.decorators/apply-hiccup-decorators
                     (:hiccup r) [:span "leaf"] {})]
       (is (= [:app/g :app/s :app/v] ids)
           "globals outermost, then story, then variant — full composition")
@@ -1997,53 +1997,53 @@
 (deftest configure-sets-project-root
   (testing "configure! writes the :rf.story/project-root config slot (rf2-zfy1e)"
     ;; Default is nil — no prefix applied to source-coord files.
-    (config/set-project-root! nil)
-    (is (nil? (config/get-project-root)))
-    (story/configure! {:rf.story/project-root "C:/Users/me/code/my-app"})
-    (is (= "C:/Users/me/code/my-app" (config/get-project-root)))
-    (story/configure! {:rf.story/project-root "/abs/code"})
-    (is (= "/abs/code" (config/get-project-root)))
+    (rf.story.config/set-project-root! nil)
+    (is (nil? (rf.story.config/get-project-root)))
+    (rf.story/configure! {:rf.story/project-root "C:/Users/me/code/my-app"})
+    (is (= "C:/Users/me/code/my-app" (rf.story.config/get-project-root)))
+    (rf.story/configure! {:rf.story/project-root "/abs/code"})
+    (is (= "/abs/code" (rf.story.config/get-project-root)))
     ;; Explicit nil clears the slot.
-    (story/configure! {:rf.story/project-root nil})
-    (is (nil? (config/get-project-root))))
+    (rf.story/configure! {:rf.story/project-root nil})
+    (is (nil? (rf.story.config/get-project-root))))
   (testing "configure! with no :rf.story/project-root key leaves the slot untouched"
-    (config/set-project-root! "/abs/code")
-    (story/configure! {:rf.story/global-args {:theme :dark}})
-    (is (= "/abs/code" (config/get-project-root)))
+    (rf.story.config/set-project-root! "/abs/code")
+    (rf.story/configure! {:rf.story/global-args {:theme :dark}})
+    (is (= "/abs/code" (rf.story.config/get-project-root)))
     ;; Reset for downstream tests.
-    (config/set-project-root! nil))
+    (rf.story.config/set-project-root! nil))
   (testing "set-project-root! normalises blank strings to nil"
-    (config/set-project-root! "")
-    (is (nil? (config/get-project-root)))
-    (config/set-project-root! "/abs/code")
-    (is (= "/abs/code" (config/get-project-root)))
-    (config/set-project-root! nil)))
+    (rf.story.config/set-project-root! "")
+    (is (nil? (rf.story.config/get-project-root)))
+    (rf.story.config/set-project-root! "/abs/code")
+    (is (= "/abs/code" (rf.story.config/get-project-root)))
+    (rf.story.config/set-project-root! nil)))
 
 ;; ===========================================================================
 ;; ASYNC ABSTRACTION
 ;; ===========================================================================
 
 (deftest async-resolved-and-then
-  (testing "async/resolved produces a complete future"
-    (is (= 42 (async/deref-blocking (async/resolved 42) 1000)))))
+  (testing "rf.story.async/resolved produces a complete future"
+    (is (= 42 (rf.story.async/deref-blocking (rf.story.async/resolved 42) 1000)))))
 
 (deftest async-then-chains
-  (testing "async/then chains over a resolved promise"
+  (testing "rf.story.async/then chains over a resolved promise"
     (is (= 43
-           (async/deref-blocking
-             (async/then (async/resolved 42) inc)
+           (rf.story.async/deref-blocking
+             (rf.story.async/then (rf.story.async/resolved 42) inc)
              1000)))))
 
 (deftest async-rejected-catch
-  (testing "async/catch* recovers a rejection"
-    (let [recovered (async/catch* (async/rejected (ex-info "no" {}))
+  (testing "rf.story.async/catch* recovers a rejection"
+    (let [recovered (rf.story.async/catch* (rf.story.async/rejected (ex-info "no" {}))
                                   (fn [_] :recovered))]
-      (is (= :recovered (async/deref-blocking recovered 1000))))))
+      (is (= :recovered (rf.story.async/deref-blocking recovered 1000))))))
 
 (deftest async-promise-resolver
-  (testing "async/promise's resolver completes the future"
-    (let [p (async/promise (fn [resolve] (resolve :ok)))]
-      (is (= :ok (async/deref-blocking p 1000))))))
+  (testing "rf.story.async/promise's resolver completes the future"
+    (let [p (rf.story.async/promise (fn [resolve] (resolve :ok)))]
+      (is (= :ok (rf.story.async/deref-blocking p 1000))))))
 
 ;; ===========================================================================
 ;; PUBLIC API STABILITY
@@ -2051,17 +2051,17 @@
 
 (deftest public-api-surface
   (testing "every Stage 3 `002-Runtime.md` §Programmatic API fn is present on the public ns"
-    (is (fn? @#'story/run-variant))
-    (is (fn? @#'story/reset-variant))
-    (is (fn? @#'story/watch-variant))
-    (is (fn? @#'story/snapshot-identity))
-    (is (fn? @#'story/destroy-variant!))
-    (is (fn? @#'story/configure!))
-    (is (fn? @#'story/resolve-args))
-    (is (fn? @#'story/resolve-decorators))
-    (is (fn? @#'story/lifecycle-state))
-    (is (fn? @#'story/variant-frames))
-    (is (fn? @#'story/variant-frame?))))
+    (is (fn? @#'rf.story/run-variant))
+    (is (fn? @#'rf.story/reset-variant))
+    (is (fn? @#'rf.story/watch-variant))
+    (is (fn? @#'rf.story/snapshot-identity))
+    (is (fn? @#'rf.story/destroy-variant!))
+    (is (fn? @#'rf.story/configure!))
+    (is (fn? @#'rf.story/resolve-args))
+    (is (fn? @#'rf.story/resolve-decorators))
+    (is (fn? @#'rf.story/lifecycle-state))
+    (is (fn? @#'rf.story/variant-frames))
+    (is (fn? @#'rf.story/variant-frame?))))
 
 ;; ===========================================================================
 ;; VARIANT-BODY CLASSIFICATION (rf2-7c6ecy)
@@ -2073,7 +2073,7 @@
 ;; runtime lowers the `:app-db` paths into the variant frame's elision
 ;; registry as EP-0025 commit-plane classification effects right after
 ;; `make-frame`, BEFORE the lifecycle / init events
-;; (`frames/apply-variant-classification!`, `:source :effect`).
+;; (`rf.story.frames/apply-variant-classification!`, `:source :effect`).
 ;;
 ;; Two coupled defects this section guards against (the two were a three-way
 ;; doc/schema/lowering shape mismatch + a missing fail-loud validation):
@@ -2097,10 +2097,10 @@
             frame's elision registry and REDACTS the path at wire egress"
     (rf/reg-event :auth/login-7c6ecy
       (fn [{:keys [db]} _] {:db (assoc-in db [:auth :token] "BEARER-secret-7c6ecy")}))
-    (story/reg-variant :story.classif/sensitive
+    (rf.story/reg-variant :story.classif/sensitive
       {:setup    [[:auth/login-7c6ecy]]
        :sensitive {:app-db [[:auth :token]]}})
-    (let [r (async/deref-blocking (story/run-variant :story.classif/sensitive) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.classif/sensitive) 5000)]
       (is (= :ready (:lifecycle r))
           "the variant runs to :ready — classification did not abort the run")
       (is (= "BEARER-secret-7c6ecy" (get-in (rf/app-db-value :story.classif/sensitive)
@@ -2111,7 +2111,7 @@
                                         {:frame :story.classif/sensitive})]
         (is (= :rf/redacted (get-in walked [:auth :token]))
             "the documented NESTED :sensitive declaration redacts the path at egress")))
-    (story/destroy-variant! :story.classif/sensitive)))
+    (rf.story/destroy-variant! :story.classif/sensitive)))
 
 (deftest variant-classification-large-nested-form-elides-at-egress
   (testing "rf2-7c6ecy POSITIVE — a documented NESTED variant `:large`
@@ -2119,10 +2119,10 @@
             `:rf.size/large-elided` marker at wire egress"
     (rf/reg-event :docs/upload-7c6ecy
       (fn [{:keys [db]} _] {:db (assoc-in db [:docs :blob] (apply str (repeat 2048 "x")))}))
-    (story/reg-variant :story.classif/large
+    (rf.story/reg-variant :story.classif/large
       {:setup [[:docs/upload-7c6ecy]]
        :large  {:app-db [[:docs :blob]]}})
-    (let [r (async/deref-blocking (story/run-variant :story.classif/large) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.classif/large) 5000)]
       (is (= :ready (:lifecycle r)))
       (let [walked  (rf/elide-wire-value (rf/app-db-value :story.classif/large)
                                          {:frame :story.classif/large})
@@ -2130,7 +2130,7 @@
         (is (and (map? elided) (contains? elided :rf.size/large-elided))
             "the documented NESTED :large declaration elides the path to the
              `:rf.size/large-elided` marker at egress")))
-    (story/destroy-variant! :story.classif/large)))
+    (rf.story/destroy-variant! :story.classif/large)))
 
 (deftest variant-classification-malformed-fails-loud-pre-commit
   (testing "rf2-7c6ecy NEGATIVE — a MALFORMED variant classification (a
@@ -2143,10 +2143,10 @@
     ;; concrete :rf/path — a non-sequential scalar. The framework's pure
     ;; commit-plane validator rejects it; the variant path now routes through
     ;; that SAME validator pre-commit.
-    (story/reg-variant :story.classif/bad
+    (rf.story/reg-variant :story.classif/bad
       {:setup    [[:noop-7c6ecy]]
        :sensitive {:app-db [42]}})
-    (let [r (async/deref-blocking (story/run-variant :story.classif/bad) 5000)
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.classif/bad) 5000)
           assertion (->> (:assertions r)
                          (filter #(= :rf.error/exception (:assertion %)))
                          last)]
@@ -2160,11 +2160,11 @@
            commit-plane boundary uses")
       ;; Fail-loud is PRE-commit: the bad path must NOT have been written into
       ;; the elision registry (no partial commit).
-      (let [reg (frame/frame-runtime-db-value :story.classif/bad)]
+      (let [reg (rf.frame/frame-runtime-db-value :story.classif/bad)]
         (is (not (contains? (get-in reg [:rf.runtime/elision :sensitive-declarations])
                             [42]))
             "the malformed path did not land in the elision registry (no partial commit)")))
-    (story/destroy-variant! :story.classif/bad)))
+    (rf.story/destroy-variant! :story.classif/bad)))
 
 ;; ---- rf2-lsr95i: registered `:extends` inherits `:sensitive`/`:large` -----
 ;;
@@ -2173,7 +2173,7 @@
 ;; compiled plan's `[:world :sensitive]` / `[:world :large]` — the SAME merge
 ;; `[:world :decorators]` / `[:world :setup]` get (`extends-inherits-
 ;; decorators-when-child-declares-none` above documents the sibling case for
-;; decorators). But `frames/allocate!` ignored that compiled plan for
+;; decorators). But `rf.story.frames/allocate!` ignored that compiled plan for
 ;; classification and re-read a variant's RAW (un-merged) body instead — so a
 ;; child that only `:extends`ed a `:sensitive`/`:large` parent, declaring no
 ;; classification of its own, silently dropped the parent's redaction: the
@@ -2188,7 +2188,7 @@
             its own, still redacts the inherited path at wire egress"
     (rf/reg-event :auth/login-lsr95i
       (fn [{:keys [db]} _] {:db (assoc-in db [:auth :token] "BEARER-secret-lsr95i")}))
-    (story/reg-variant :story.classif-ext.lsr95i/parent
+    (rf.story/reg-variant :story.classif-ext.lsr95i/parent
       {:setup    [[:auth/login-lsr95i]]
        :sensitive {:app-db [[:auth :token]]}})
     ;; The child ONLY `:extends`es the parent — no `:setup`, no
@@ -2196,9 +2196,9 @@
     ;; the bare child inherits the parent's `:setup` and runs the SAME
     ;; login step under its own frame; the classification must inherit
     ;; identically (both are `context-keys` in the plan compiler).
-    (story/reg-variant :story.classif-ext.lsr95i/child
+    (rf.story/reg-variant :story.classif-ext.lsr95i/child
       {:extends :story.classif-ext.lsr95i/parent})
-    (let [r (async/deref-blocking (story/run-variant :story.classif-ext.lsr95i/child) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.classif-ext.lsr95i/child) 5000)]
       (is (= :ready (:lifecycle r))
           "the extended child runs to :ready")
       (is (= "BEARER-secret-lsr95i"
@@ -2212,8 +2212,8 @@
              :extends, redacts the child frame's path at egress — RED
              against the pre-fix `allocate!`, which read the child's raw
              (un-merged) body and saw no :sensitive declaration at all")))
-    (story/destroy-variant! :story.classif-ext.lsr95i/child)
-    (story/destroy-variant! :story.classif-ext.lsr95i/parent)))
+    (rf.story/destroy-variant! :story.classif-ext.lsr95i/child)
+    (rf.story/destroy-variant! :story.classif-ext.lsr95i/parent)))
 
 (deftest extends-child-own-classification-still-applies
   (testing "rf2-lsr95i companion — a child that DECLARES its own
@@ -2221,12 +2221,12 @@
             plan-threaded fix must not regress the non-inherited case)"
     (rf/reg-event :docs/upload-lsr95i
       (fn [{:keys [db]} _] {:db (assoc-in db [:docs :blob] "large-blob-lsr95i")}))
-    (story/reg-variant :story.classif-ext.lsr95i/base
+    (rf.story/reg-variant :story.classif-ext.lsr95i/base
       {:setup [[:docs/upload-lsr95i]]})
-    (story/reg-variant :story.classif-ext.lsr95i/override
+    (rf.story/reg-variant :story.classif-ext.lsr95i/override
       {:extends :story.classif-ext.lsr95i/base
        :large   {:app-db [[:docs :blob]]}})
-    (let [r (async/deref-blocking (story/run-variant :story.classif-ext.lsr95i/override) 5000)]
+    (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.classif-ext.lsr95i/override) 5000)]
       (is (= :ready (:lifecycle r)))
       (let [walked (rf/elide-wire-value
                      (rf/app-db-value :story.classif-ext.lsr95i/override)
@@ -2235,15 +2235,15 @@
         (is (and (map? elided) (contains? elided :rf.size/large-elided))
             "the child's OWN :large declaration on an :extends'd variant
              still elides at egress")))
-    (story/destroy-variant! :story.classif-ext.lsr95i/override)
-    (story/destroy-variant! :story.classif-ext.lsr95i/base)))
+    (rf.story/destroy-variant! :story.classif-ext.lsr95i/override)
+    (rf.story/destroy-variant! :story.classif-ext.lsr95i/base)))
 
 ;; ---- rf2-cmjly3 finding 12: inline-plan :sensitive/:large classification --
 ;;
 ;; Prior to the fix, `allocate-inline!` never called
 ;; `apply-variant-classification!` at all, and `plan.cljc`'s `context-keys`
 ;; did not carry `:sensitive`/`:large` into the compiled plan's `:world` —
-;; so an inline plan run (`story/run` on a MAP target) declaring
+;; so an inline plan run (`rf.story/run` on a MAP target) declaring
 ;; `:sensitive`/`:large` got NO error and NO redaction: a value marked
 ;; sensitive rode into the wire trace unredacted (a silent privacy no-op).
 ;; The fix routes `:sensitive`/`:large` through `[:world :sensitive]` /
@@ -2275,8 +2275,8 @@
           (reset! probe-atom (get-in walked [:auth :token]))
           {:db db'})))
     (let [probe (atom ::unset)
-          r     (async/deref-blocking
-                  (story/run {:setup    [[:classif-inline-cmjly3/login+probe probe]]
+          r     (rf.story.async/deref-blocking
+                  (rf.story/run {:setup    [[:classif-inline-cmjly3/login+probe probe]]
                              :sensitive {:app-db [[:auth :token]]}})
                   5000)]
       (is (= :ready (:lifecycle r))
@@ -2299,8 +2299,8 @@
           (reset! probe-atom (get-in walked [:auth :token]))
           {:db db'})))
     (let [probe (atom ::unset)
-          r     (async/deref-blocking
-                  (story/run {:setup [[:classif-inline-cmjly3/login+probe-plain probe]]})
+          r     (rf.story.async/deref-blocking
+                  (rf.story/run {:setup [[:classif-inline-cmjly3/login+probe-plain probe]]})
                   5000)]
       (is (= :ready (:lifecycle r)))
       (is (= "BEARER-secret-cmjly3-plain" @probe)
@@ -2320,8 +2320,8 @@
             orphaned anonymous frame on this authoring-mistake path) is
             documented on that fn."
     (rf/reg-event :noop-cmjly3 (fn [{:keys [db]} _] {:db db}))
-    (let [r         (async/deref-blocking
-                      (story/run {:setup    [[:noop-cmjly3]]
+    (let [r         (rf.story.async/deref-blocking
+                      (rf.story/run {:setup    [[:noop-cmjly3]]
                                  :sensitive {:app-db [42]}})
                       5000)
           assertion (->> (:assertions r)

--- a/tools/story/test/re_frame/story_save_variant_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_save_variant_cljs_test.cljs
@@ -15,17 +15,17 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [cljs.reader :as edn]
             [clojure.string :as str]
-            [re-frame.story :as story]
-            [re-frame.story.save-variant :as save-variant]
-            [re-frame.story.ui.state :as state]))
+            [re-frame.story :as rf.story]
+            [re-frame.story.save-variant :as rf.story.save-variant]
+            [re-frame.story.ui.state :as rf.story.ui.state]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-all! [f]
-  (story/clear-all!)
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!)
-  (save-variant/set-open-dialog-fn! nil)
+  (rf.story/clear-all!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.story.save-variant/set-open-dialog-fn! nil)
   (f))
 
 (use-fixtures :each reset-all!)
@@ -33,18 +33,18 @@
 ;; ---- snapshot-args -------------------------------------------------------
 
 (deftest snapshot-args-returns-resolved-args
-  (story/reg-variant :story.snap/v
+  (rf.story/reg-variant :story.snap/v
     {:args {:label "hello" :n 1}
      :setup []})
-  (let [snap (save-variant/snapshot-args :story.snap/v)]
+  (let [snap (rf.story.save-variant/snapshot-args :story.snap/v)]
     (is (= "hello" (:label snap)))
     (is (= 1 (:n snap)))))
 
 (deftest snapshot-args-includes-cell-overrides
-  (story/reg-variant :story.snap/v
+  (rf.story/reg-variant :story.snap/v
     {:args   {:label "before" :keep "yes"}
      :setup []})
-  (let [snap (save-variant/snapshot-args
+  (let [snap (rf.story.save-variant/snapshot-args
                :story.snap/v
                {:cell-overrides {:label "after"}})]
     (is (= "after" (:label snap)))
@@ -53,7 +53,7 @@
 ;; ---- gen-variant-snippet -------------------------------------------------
 
 (deftest gen-variant-snippet-renders-reg-variant
-  (let [snip (save-variant/gen-variant-snippet
+  (let [snip (rf.story.save-variant/gen-variant-snippet
                {:variant-id :story.counter/saved
                 :extends    :story.counter/happy-path
                 :args       {:label "hi" :n 3}})]
@@ -65,14 +65,14 @@
     (is (str/includes? snip "\"hi\""))))
 
 (deftest gen-variant-snippet-empty-args-renders-empty-map
-  (let [snip (save-variant/gen-variant-snippet
+  (let [snip (rf.story.save-variant/gen-variant-snippet
                {:variant-id :story.x/y :args {}})]
     (is (str/includes? snip ":args"))
     (is (str/includes? snip "{}"))))
 
 (deftest gen-variant-snippet-args-roundtrip
   (let [args   {:label "alice" :n 42}
-        snip   (save-variant/gen-variant-snippet
+        snip   (rf.story.save-variant/gen-variant-snippet
                  {:variant-id :story.x/y :args args})
         start  (str/index-of snip ":args")
         after  (subs snip start)
@@ -92,48 +92,48 @@
 ;; ---- default-variant-id --------------------------------------------------
 
 (deftest default-variant-id-derives-from-source
-  (let [k (save-variant/default-variant-id :story.counter/happy-path 12345)]
+  (let [k (rf.story.save-variant/default-variant-id :story.counter/happy-path 12345)]
     (is (qualified-keyword? k))
     (is (= "story.counter" (namespace k)))
     (is (str/starts-with? (name k) "saved-"))))
 
 (deftest default-variant-id-nil-for-unqualified
-  (is (nil? (save-variant/default-variant-id :unqualified 0))))
+  (is (nil? (rf.story.save-variant/default-variant-id :unqualified 0))))
 
 ;; ---- dialog state machine -------------------------------------------------
 
 (deftest open-builds-dialog-state
-  (let [s (save-variant/open save-variant/initial-dialog-state
+  (let [s (rf.story.save-variant/open rf.story.save-variant/initial-dialog-state
                              :story.x/y {:n 1} 1000)]
     (is (:open? s))
     (is (= :story.x/y (:source-id s)))
     (is (= {:n 1} (:args s)))))
 
 (deftest close-returns-idle
-  (let [opened (save-variant/open save-variant/initial-dialog-state
+  (let [opened (rf.story.save-variant/open rf.story.save-variant/initial-dialog-state
                                   :story.x/y {} 0)]
-    (is (= save-variant/initial-dialog-state
-           (save-variant/close opened)))))
+    (is (= rf.story.save-variant/initial-dialog-state
+           (rf.story.save-variant/close opened)))))
 
 ;; ---- save-current-as-variant! --------------------------------------------
 
 (deftest save-current-as-variant!-triggers-callback
-  (story/reg-variant :story.snap/v {:args {:n 7} :setup []})
-  (state/swap-state! state/select-variant :story.snap/v)
+  (rf.story/reg-variant :story.snap/v {:args {:n 7} :setup []})
+  (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.snap/v)
   (let [captured (atom nil)]
-    (save-variant/set-open-dialog-fn!
+    (rf.story.save-variant/set-open-dialog-fn!
       (fn [source-id args & _]
         (reset! captured {:source-id source-id :args args})))
-    (let [result (save-variant/save-current-as-variant!)]
+    (let [result (rf.story.save-variant/save-current-as-variant!)]
       (is (some? @captured))
       (is (= :story.snap/v (:source-id @captured)))
       (is (= 7 (-> @captured :args :n)))
       (is (= :story.snap/v (:source-id result))))))
 
 (deftest save-current-as-variant!-nil-without-focus
-  (state/swap-state! state/select-variant nil)
+  (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant nil)
   (let [captured (atom nil)]
-    (save-variant/set-open-dialog-fn!
+    (rf.story.save-variant/set-open-dialog-fn!
       (fn [_ _ _] (reset! captured :fired)))
-    (is (nil? (save-variant/save-current-as-variant!)))
+    (is (nil? (rf.story.save-variant/save-current-as-variant!)))
     (is (nil? @captured))))

--- a/tools/story/test/re_frame/story_save_variant_test.clj
+++ b/tools/story/test/re_frame/story_save_variant_test.clj
@@ -22,25 +22,25 @@
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story :as story]
-            [re-frame.story.save-variant :as save-variant]
-            [re-frame.story.ui.state :as state]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.save-variant :as rf.story.save-variant]
+            [re-frame.story.ui.state :as rf.story.ui.state]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-all! [f]
-  (story/clear-all!)
-  (state/reset-shell-state!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
-  (save-variant/set-open-dialog-fn! nil)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
+  (rf.story.save-variant/set-open-dialog-fn! nil)
   ;; EP-0002 (rf2-bd4div) — the event-handler tests dispatch
   ;; `:rf.story/save-current-as-variant` ambiently; that frame-scoped op
   ;; now requires a carried frame stamp. Pin the ordinary `:rf/default`
@@ -56,21 +56,21 @@
 
 (deftest snapshot-args-returns-resolved-args
   (testing "snapshot-args delegates to args/resolve-args + returns the merged map"
-    (story/reg-story :story.snap {:args {:theme :light}})
-    (story/reg-variant :story.snap/v
+    (rf.story/reg-story :story.snap {:args {:theme :light}})
+    (rf.story/reg-variant :story.snap/v
       {:args {:label "hello" :n 1}
        :setup []})
-    (let [snap (save-variant/snapshot-args :story.snap/v)]
+    (let [snap (rf.story.save-variant/snapshot-args :story.snap/v)]
       (is (= "hello" (:label snap)))
       (is (= 1 (:n snap)))
       (is (= :light (:theme snap)) "story-level args are part of the snapshot"))))
 
 (deftest snapshot-args-includes-cell-overrides
   (testing "cell-overrides supplied as opts override the variant args"
-    (story/reg-variant :story.snap/v
+    (rf.story/reg-variant :story.snap/v
       {:args   {:label "before" :keep "yes"}
        :setup []})
-    (let [snap (save-variant/snapshot-args
+    (let [snap (rf.story.save-variant/snapshot-args
                  :story.snap/v
                  {:cell-overrides {:label "after"}})]
       (is (= "after" (:label snap)) "override wins over variant args")
@@ -78,13 +78,13 @@
 
 (deftest snapshot-args-empty-for-unknown-variant
   (testing "an unknown variant returns an empty map (no throw)"
-    (is (= {} (save-variant/snapshot-args :story.nope/missing)))))
+    (is (= {} (rf.story.save-variant/snapshot-args :story.nope/missing)))))
 
 ;; ---- gen-variant-snippet -------------------------------------------------
 
 (deftest gen-variant-snippet-renders-reg-variant
   (testing "snippet renders the (reg-variant ...) form with :args"
-    (let [snip (save-variant/gen-variant-snippet
+    (let [snip (rf.story.save-variant/gen-variant-snippet
                  {:variant-id :story.counter/saved
                   :extends    :story.counter/happy-path
                   :args       {:label "hi" :n 3}})]
@@ -100,7 +100,7 @@
 
 (deftest gen-variant-snippet-empty-args
   (testing "snippet with empty args renders an empty map literal"
-    (let [snip (save-variant/gen-variant-snippet
+    (let [snip (rf.story.save-variant/gen-variant-snippet
                  {:variant-id :story.x/y
                   :args       {}})]
       (is (str/includes? snip ":args"))
@@ -108,13 +108,13 @@
 
 (deftest gen-variant-snippet-without-extends
   (testing "no :extends → no :extends slot in the form"
-    (let [snip (save-variant/gen-variant-snippet
+    (let [snip (rf.story.save-variant/gen-variant-snippet
                  {:variant-id :story.x/y
                   :args       {:n 1}})]
       (is (not (str/includes? snip ":extends"))))))
 
 (deftest gen-variant-snippet-includes-doc
-  (let [snip (save-variant/gen-variant-snippet
+  (let [snip (rf.story.save-variant/gen-variant-snippet
                {:variant-id :story.x/y
                 :doc        "captured via Save"
                 :args       {:n 1}})]
@@ -122,7 +122,7 @@
     (is (str/includes? snip "captured via Save"))))
 
 (deftest gen-variant-snippet-custom-alias
-  (let [snip (save-variant/gen-variant-snippet
+  (let [snip (rf.story.save-variant/gen-variant-snippet
                {:variant-id :story.x/y
                 :alias      "rf"
                 :args       {}})]
@@ -153,7 +153,7 @@
 (deftest gen-variant-snippet-args-roundtrip
   (testing "the rendered :args map reads back as the original map"
     (let [args     {:label "alice" :n 42 :tags #{:a :b} :nested {:k 1}}
-          snippet  (save-variant/gen-variant-snippet
+          snippet  (rf.story.save-variant/gen-variant-snippet
                      {:variant-id :story.x/y :args args})
           args-str (extract-args-map snippet)]
       (is (some? args-str) "extractor found an :args map substring")
@@ -162,7 +162,7 @@
 (deftest gen-variant-snippet-sorted-keys
   (testing "args keys render in sorted order for determinism"
     (let [args   {:z 1 :a 2 :m 3}
-          snip   (save-variant/gen-variant-snippet
+          snip   (rf.story.save-variant/gen-variant-snippet
                    {:variant-id :story.x/y :args args})
           a      (str/index-of snip ":a")
           m      (str/index-of snip ":m")
@@ -173,21 +173,21 @@
 
 (deftest default-variant-id-uses-source-namespace
   (is (= "story.counter"
-         (namespace (save-variant/default-variant-id
+         (namespace (rf.story.save-variant/default-variant-id
                       :story.counter/happy-path 12345))))
   (is (str/starts-with?
-        (name (save-variant/default-variant-id
+        (name (rf.story.save-variant/default-variant-id
                 :story.counter/happy-path 12345))
         "saved-")))
 
 (deftest default-variant-id-nil-for-unqualified
-  (is (nil? (save-variant/default-variant-id :unqualified 0)))
-  (is (nil? (save-variant/default-variant-id nil 0))))
+  (is (nil? (rf.story.save-variant/default-variant-id :unqualified 0)))
+  (is (nil? (rf.story.save-variant/default-variant-id nil 0))))
 
 ;; ---- dialog state machine -------------------------------------------------
 
 (deftest open-builds-dialog-state
-  (let [s (save-variant/open save-variant/initial-dialog-state
+  (let [s (rf.story.save-variant/open rf.story.save-variant/initial-dialog-state
                              :story.x/y
                              {:n 1}
                              1000)]
@@ -197,28 +197,28 @@
     (is (qualified-keyword? (:draft-id s)))))
 
 (deftest close-returns-idle
-  (let [opened (save-variant/open save-variant/initial-dialog-state
+  (let [opened (rf.story.save-variant/open rf.story.save-variant/initial-dialog-state
                                   :story.x/y {:n 1} 0)
-        closed (save-variant/close opened)]
-    (is (= save-variant/initial-dialog-state closed))))
+        closed (rf.story.save-variant/close opened)]
+    (is (= rf.story.save-variant/initial-dialog-state closed))))
 
 (deftest set-draft-id-replaces
-  (let [s (-> save-variant/initial-dialog-state
-              (save-variant/open :story.x/y {} 0)
-              (save-variant/set-draft-id :story.x/edited))]
+  (let [s (-> rf.story.save-variant/initial-dialog-state
+              (rf.story.save-variant/open :story.x/y {} 0)
+              (rf.story.save-variant/set-draft-id :story.x/edited))]
     (is (= :story.x/edited (:draft-id s)))))
 
 ;; ---- save-current-as-variant! end-to-end ---------------------------------
 
 (deftest save-current-as-variant!-triggers-callback
   (testing "the impure trigger calls the registered open-dialog callback"
-    (story/reg-variant :story.snap/v {:args {:n 7} :setup []})
-    (state/swap-state! state/select-variant :story.snap/v)
+    (rf.story/reg-variant :story.snap/v {:args {:n 7} :setup []})
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.snap/v)
     (let [captured (atom nil)]
-      (save-variant/set-open-dialog-fn!
+      (rf.story.save-variant/set-open-dialog-fn!
         (fn [source-id args _now-ms _violations & _]
           (reset! captured {:source-id source-id :args args})))
-      (let [result (save-variant/save-current-as-variant!)]
+      (let [result (rf.story.save-variant/save-current-as-variant!)]
         (is (some? @captured) "the callback fired")
         (is (= :story.snap/v (:source-id @captured)))
         (is (= 7 (-> @captured :args :n)))
@@ -229,15 +229,15 @@
 (deftest save-current-as-variant!-carries-slice-report
   (testing "the trigger computes the eight-slice capture report and passes
             it through both the callback and the returned record"
-    (story/reg-variant :story.snap/sliced {:args {:n 3} :setup []})
-    (state/swap-state! state/select-variant :story.snap/sliced)
+    (rf.story/reg-variant :story.snap/sliced {:args {:n 3} :setup []})
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.snap/sliced)
     (let [captured (atom nil)]
-      (save-variant/set-open-dialog-fn!
+      (rf.story.save-variant/set-open-dialog-fn!
         (fn [_source-id _args _now-ms _violations slices]
           (reset! captured slices)))
-      (let [result (save-variant/save-current-as-variant!)
+      (let [result (rf.story.save-variant/save-current-as-variant!)
             slices (:slices result)]
-        (is (= (set save-variant/slice-order)
+        (is (= (set rf.story.save-variant/slice-order)
                (set (map :slice slices)))
             "every canonical slice is classified — none silently dropped")
         (is (= slices @captured)
@@ -248,13 +248,13 @@
 (deftest save-current-as-variant!-declared-slots-captured-as-declared
   (testing "a source variant declaring the not-yet-wired slices captures them
             as-declared (carried forward via :extends) — honest, not dropped"
-    (story/reg-variant :story.snap/declared
+    (rf.story/reg-variant :story.snap/declared
       {:args         {:n 1}
        :sub-overrides {[:s] :v}
        :setup       []})
-    (state/swap-state! state/select-variant :story.snap/declared)
-    (save-variant/set-open-dialog-fn! (fn [& _] nil))
-    (let [result   (save-variant/save-current-as-variant!)
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.snap/declared)
+    (rf.story.save-variant/set-open-dialog-fn! (fn [& _] nil))
+    (let [result   (rf.story.save-variant/save-current-as-variant!)
           by-slice (into {} (map (juxt :slice identity)) (:slices result))]
       (is (= :captured-as-declared (-> by-slice :sub-overrides :status))
           "the declared :sub-overrides carry forward as-declared")
@@ -262,23 +262,23 @@
 
 (deftest save-current-as-variant!-nil-when-no-focus
   (testing "without a focused variant the trigger is a no-op"
-    (state/swap-state! state/select-variant nil)
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant nil)
     (let [captured (atom nil)]
-      (save-variant/set-open-dialog-fn!
+      (rf.story.save-variant/set-open-dialog-fn!
         (fn [_ _ _ _] (reset! captured :fired)))
-      (let [result (save-variant/save-current-as-variant!)]
+      (let [result (rf.story.save-variant/save-current-as-variant!)]
         (is (nil? result) "no result without a focus")
         (is (nil? @captured) "callback never fires without a focus")))))
 
 (deftest save-current-as-variant!-variant-id-override
   (testing "an explicit :variant-id overrides the shell's focus"
-    (story/reg-variant :story.snap/override {:args {:n 42} :setup []})
-    (state/swap-state! state/select-variant nil)
+    (rf.story/reg-variant :story.snap/override {:args {:n 42} :setup []})
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant nil)
     (let [captured (atom nil)]
-      (save-variant/set-open-dialog-fn!
+      (rf.story.save-variant/set-open-dialog-fn!
         (fn [source-id args & _]
           (reset! captured {:source-id source-id :args args})))
-      (save-variant/save-current-as-variant! {:variant-id :story.snap/override})
+      (rf.story.save-variant/save-current-as-variant! {:variant-id :story.snap/override})
       (is (= :story.snap/override (:source-id @captured)))
       (is (= 42 (-> @captured :args :n))))))
 
@@ -286,31 +286,31 @@
 
 (deftest event-handler-is-registered
   (testing "install-canonical-vocabulary! registers the save-as-variant event"
-    (is (some? (registrar/handler :event
-                save-variant/id-save-current-as-variant))
+    (is (some? (rf.registrar/handler :event
+                rf.story.save-variant/id-save-current-as-variant))
         "the :rf.story/save-current-as-variant handler is in the registry")))
 
 (deftest event-handler-triggers-callback
   (testing "dispatching :rf.story/save-current-as-variant runs the save flow"
-    (story/reg-variant :story.event/v {:args {:n 9} :setup []})
-    (state/swap-state! state/select-variant :story.event/v)
+    (rf.story/reg-variant :story.event/v {:args {:n 9} :setup []})
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.event/v)
     (let [captured (atom nil)]
-      (save-variant/set-open-dialog-fn!
+      (rf.story.save-variant/set-open-dialog-fn!
         (fn [source-id args & _]
           (reset! captured {:source-id source-id :args args})))
-      (rf/dispatch-sync [save-variant/id-save-current-as-variant])
+      (rf/dispatch-sync [rf.story.save-variant/id-save-current-as-variant])
       (is (= :story.event/v (:source-id @captured)))
       (is (= 9 (-> @captured :args :n))))))
 
 (deftest event-handler-honors-payload-opts
   (testing "the event payload's :variant-id overrides the focused variant"
-    (story/reg-variant :story.event/explicit {:args {:n 11} :setup []})
-    (state/swap-state! state/select-variant nil)
+    (rf.story/reg-variant :story.event/explicit {:args {:n 11} :setup []})
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant nil)
     (let [captured (atom nil)]
-      (save-variant/set-open-dialog-fn!
+      (rf.story.save-variant/set-open-dialog-fn!
         (fn [source-id args & _]
           (reset! captured {:source-id source-id :args args})))
-      (rf/dispatch-sync [save-variant/id-save-current-as-variant
+      (rf/dispatch-sync [rf.story.save-variant/id-save-current-as-variant
                          {:variant-id :story.event/explicit}])
       (is (= :story.event/explicit (:source-id @captured)))
       (is (= 11 (-> @captured :args :n))))))
@@ -319,18 +319,18 @@
 
 (deftest end-to-end-snapshot-to-snippet
   (testing "the full snapshot→snippet cycle produces a reg-variant form"
-    (story/reg-story :story.counter {:args {:theme :dark}})
-    (story/reg-variant :story.counter/happy-path
+    (rf.story/reg-story :story.counter {:args {:theme :dark}})
+    (rf.story/reg-variant :story.counter/happy-path
       {:args {:label "Counter" :n 0}
        :setup []})
-    (state/swap-state! state/select-variant :story.counter/happy-path)
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.counter/happy-path)
     ;; Capture via the impure trigger; harvest snapshot from the callback.
     (let [captured (atom nil)]
-      (save-variant/set-open-dialog-fn!
+      (rf.story.save-variant/set-open-dialog-fn!
         (fn [source-id args & _]
           (reset! captured {:source-id source-id :args args})))
-      (save-variant/save-current-as-variant!)
-      (let [snippet  (save-variant/gen-variant-snippet
+      (rf.story.save-variant/save-current-as-variant!)
+      (let [snippet  (rf.story.save-variant/gen-variant-snippet
                        {:variant-id :story.counter/saved-1
                         :extends    (:source-id @captured)
                         :args       (:args @captured)})

--- a/tools/story/test/re_frame/story_share_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_share_cljs_test.cljs
@@ -7,16 +7,16 @@
   there is no separate Share button or QR popover (rf2-ymnfx Issue B
   removed the redundant affordance). The URL builder remains because
   `re-frame.story.ui.url-state` writes it via `pushState` and the
-  public `story/variant-share-url` facade is exported for embed code
+  public `rf.story/variant-share-url` facade is exported for embed code
   (per `tools/story/spec/Tutorial-Embed.md`)."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
-            [re-frame.story :as story]
-            [re-frame.story.share :as share]))
+            [re-frame.story :as rf.story]
+            [re-frame.story.share :as rf.story.share]))
 
 (deftest variant-share-url-cljs-encoding
   (testing "CLJS url-encode uses js/encodeURIComponent under the hood"
-    (let [url (share/variant-share-url
+    (let [url (rf.story.share/variant-share-url
                 :story.foo/bar
                 "https://example.test/"
                 {:active-modes [:Mode.app/dark]
@@ -26,13 +26,13 @@
       (is (re-find #"modes=" url)))))
 
 (deftest public-export-cljs
-  (testing "story/variant-share-url resolves on CLJS"
-    (let [url (story/variant-share-url :story.x/y "" nil)]
+  (testing "rf.story/variant-share-url resolves on CLJS"
+    (let [url (rf.story/variant-share-url :story.x/y "" nil)]
       (is (re-find #"variant=" url)))))
 
 (deftest hash-routed-share-url-keeps-query-before-fragment
   (testing "CLJS builder emits ?variant= before #/stories so the shell can hydrate"
-    (let [url (share/variant-share-url
+    (let [url (rf.story.share/variant-share-url
                 :story.counter/loaded
                 "https://example.test/counter-with-stories/#/stories"
                 {:cell-overrides {:label "Shared"}})]
@@ -46,7 +46,7 @@
             hydrator reads with) sees the values THIS call generated, not
             stale ones already on the base-url. get is first-value, so an
             append-only merge would return the old variant here."
-    (let [url    (share/variant-share-url
+    (let [url    (rf.story.share/variant-share-url
                    :story.new/b
                    "https://example.test/?variant=story.old%2Fa&modes=Mode.app%2Fstale&from=index&embed=1#/stories"
                    {:active-modes [:Mode.app/dark]})
@@ -85,28 +85,28 @@
                   "substrate"  "uix"}
           base   (str "https://example.test/?"
                       (str/join "&" (map #(str (name %) "=" (get stale (name %)))
-                                         share/story-query-keys))
+                                         rf.story.share/story-query-keys))
                       "&from=index&embed=1#/stories")
-          url    (share/variant-share-url
+          url    (rf.story.share/variant-share-url
                    :story.new/b
                    base
                    {:active-modes [] :cell-overrides {} :substrate :reagent})
           search (second (str/split (first (str/split url #"#" 2)) #"\?" 2))
           usp    (js/URLSearchParams. search)]
-      (is (= (set (map name share/story-query-keys)) (set (keys stale)))
+      (is (= (set (map name rf.story.share/story-query-keys)) (set (keys stale)))
           "the fixture carries a stale value for every key in the vocabulary")
       (is (= "story.new/b" (.get usp "variant"))
           "URLSearchParams.get returns the requested variant")
       (is (= 1 (count (.getAll usp "variant")))
           "exactly one variant value")
-      (doseq [k (map name share/story-query-keys)
+      (doseq [k (map name rf.story.share/story-query-keys)
               :when (not= k "variant")]
         (is (zero? (count (.getAll usp k)))
             (str "URLSearchParams sees no stale " k "= at all")))
-      ;; The hydrator's own read path: getter map -> share/parse-params.
-      (let [parsed (share/parse-params
+      ;; The hydrator's own read path: getter map -> rf.story.share/parse-params.
+      (let [parsed (rf.story.share/parse-params
                      (into {} (map (fn [k] [k (.get usp k)]))
-                           (map name share/story-query-keys)))]
+                           (map name rf.story.share/story-query-keys)))]
         (is (= :story.new/b (:variant-id parsed))
             "parse-params over real URLSearchParams reads the requested variant")
         (doseq [slot [:workspace-id :mode-tab :active-modes :viewport
@@ -147,7 +147,7 @@
   (testing "rf2-b7je1 — the fixture below is only a regression if the real
             URLSearchParams reads the escaped spellings as the owned keys.
             Pin that against the browser API before relying on it."
-    (doseq [k (map name share/story-query-keys)]
+    (doseq [k (map name rf.story.share/story-query-keys)]
       (let [esc (escape-first-char k)
             usp (js/URLSearchParams. (str esc "=x"))]
         (is (not= esc k)
@@ -175,14 +175,14 @@
                       (str/join "&" (map #(str (escape-first-char (name %))
                                                "="
                                                (get stale (name %)))
-                                         share/story-query-keys))
+                                         rf.story.share/story-query-keys))
                       "&from=index&embed=1#/stories")
-          url    (share/variant-share-url
+          url    (rf.story.share/variant-share-url
                    :story.new/b
                    base
                    {:active-modes [:Mode.app/dark]})
           usp    (js/URLSearchParams. (search-of url))]
-      (is (= (set (map name share/story-query-keys)) (set (keys stale)))
+      (is (= (set (map name rf.story.share/story-query-keys)) (set (keys stale)))
           "the fixture carries a stale value for every key in the vocabulary")
       (is (= "story.new/b" (.get usp "variant"))
           "URLSearchParams.get returns the requested variant, not the stale one")
@@ -192,13 +192,13 @@
           "exactly one variant value the browser can see")
       (is (= 1 (count (.getAll usp "modes")))
           "exactly one modes value the browser can see")
-      (doseq [k (map name share/story-query-keys)
+      (doseq [k (map name rf.story.share/story-query-keys)
               :when (not (#{"variant" "modes"} k))]
         (is (zero? (count (.getAll usp k)))
             (str "URLSearchParams sees no stale " k "= at all")))
-      (let [parsed (share/parse-params
+      (let [parsed (rf.story.share/parse-params
                      (into {} (map (fn [k] [k (.get usp k)]))
-                           (map name share/story-query-keys)))]
+                           (map name rf.story.share/story-query-keys)))]
         (is (= :story.new/b (:variant-id parsed))
             "the hydrator's own read path recovers the requested variant")
         (is (= [:Mode.app/dark] (:active-modes parsed))
@@ -216,7 +216,7 @@
             A key half js/decodeURIComponent throws on is preserved
             byte-for-byte, and `mode+tab` reads as `mode tab` to the
             browser, so it is not Story's `mode-tab` and must stay."
-    (let [url (share/variant-share-url
+    (let [url (rf.story.share/variant-share-url
                 :story.new/b
                 "https://example.test/?%zz=keepme&100%=raw&mode+tab=notmine&from=index"
                 nil)
@@ -235,11 +235,11 @@
 (deftest parse-share-url-params-cljs
   (testing "CLJS parser reconstructs the share URL tokens used by the shell hydrator"
     (is (= :story.counter/loaded
-           (share/parse-keyword-token "story.counter/loaded")))
+           (rf.story.share/parse-keyword-token "story.counter/loaded")))
     (is (= [:Mode.app/dark :Mode.app/mobile]
-           (share/parse-modes-param "Mode.app/dark,Mode.app/mobile")))
+           (rf.story.share/parse-modes-param "Mode.app/dark,Mode.app/mobile")))
     (is (= {:label "Shared" :count 7}
-           (share/parse-overrides-param "{:label \"Shared\", :count 7}")))))
+           (rf.story.share/parse-overrides-param "{:label \"Shared\", :count 7}")))))
 
 (deftest scenario-overrides-token-roundtrips-with-spaced-string-value
   (testing "the browser-decoded `overrides=` token the share-url-hydrates
@@ -248,7 +248,7 @@
             case that exposed the stale pre-rf2-j0hwf `label:\"...\"` wire
             form (it was classified :dropped), so this pins the EDN-map form."
     (let [decoded "{:label \"Shared Label\"}"
-          parsed  (share/parse-overrides-param* decoded)]
+          parsed  (rf.story.share/parse-overrides-param* decoded)]
       (is (= {:label "Shared Label"} (:overrides parsed))
           "the spaced-string override is kept")
       (is (= [] (:dropped parsed))
@@ -256,9 +256,9 @@
       ;; The URL the scenario sends carries the js/encodeURIComponent form
       ;; (space → %20, not +); URLSearchParams.get decodes it back to the
       ;; EDN-map string above. Round-trip the encoder to lock the contract.
-      (let [token (share/build-overrides-token {:label "Shared Label"})]
+      (let [token (rf.story.share/build-overrides-token {:label "Shared Label"})]
         (is (string? token))
         (is (= {:label "Shared Label"}
-               (share/parse-overrides-param
+               (rf.story.share/parse-overrides-param
                  (js/decodeURIComponent token)))
             "the CLJS-encoded token round-trips through URLSearchParams-style decode")))))

--- a/tools/story/test/re_frame/story_share_test.clj
+++ b/tools/story/test/re_frame/story_share_test.clj
@@ -6,20 +6,20 @@
   expected shape per `005-SOTA-Features.md` §Share URL (retired QR popover)."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
-            [re-frame.story        :as story]
-            [re-frame.story.share  :as share]))
+            [re-frame.story        :as rf.story]
+            [re-frame.story.share  :as rf.story.share]))
 
 ;; ---- pure: build-params --------------------------------------------------
 
 (deftest build-params-minimal
   (testing "build-params returns the :variant param when only variant-id supplied"
-    (let [ps (share/build-params {:variant-id :story.foo/bar})]
+    (let [ps (rf.story.share/build-params {:variant-id :story.foo/bar})]
       (is (= 1 (count ps)))
       (is (re-find #"^variant=" (first ps))))))
 
 (deftest build-params-modes
   (testing "build-params encodes modes as comma-separated stable list"
-    (let [ps (share/build-params {:variant-id  :story.foo/bar
+    (let [ps (rf.story.share/build-params {:variant-id  :story.foo/bar
                                   :active-modes [:Mode.app/dark
                                                  :Mode.app/mobile]})
           modes-param (some #(when (str/starts-with? % "modes=") %) ps)]
@@ -30,7 +30,7 @@
 
 (deftest build-params-overrides
   (testing "build-params encodes overrides as comma-separated k:v pairs"
-    (let [ps (share/build-params {:variant-id     :story.foo/bar
+    (let [ps (rf.story.share/build-params {:variant-id     :story.foo/bar
                                   :cell-overrides {:label "Click me"
                                                    :count 5}})
           ov (some #(when (str/starts-with? % "overrides=") %) ps)]
@@ -38,13 +38,13 @@
 
 (deftest build-params-substrate-omits-reagent
   (testing "build-params omits :substrate when its value is :reagent (default)"
-    (let [ps (share/build-params {:variant-id :story.foo/bar
+    (let [ps (rf.story.share/build-params {:variant-id :story.foo/bar
                                   :substrate  :reagent})]
       (is (not (some #(str/starts-with? % "substrate=") ps))))))
 
 (deftest build-params-substrate-non-default
   (testing "build-params includes :substrate when not :reagent"
-    (let [ps (share/build-params {:variant-id :story.foo/bar
+    (let [ps (rf.story.share/build-params {:variant-id :story.foo/bar
                                   :substrate  :uix})]
       (is (some #(str/starts-with? % "substrate=") ps)))))
 
@@ -53,7 +53,7 @@
             :my.lib/uix) keeps its namespace on the wire instead of being
             collapsed to its bare name. Mirrors the namespace-preserving
             encoding used for :variant / :workspace."
-    (let [ps (share/build-params {:variant-id :story.foo/bar
+    (let [ps (rf.story.share/build-params {:variant-id :story.foo/bar
                                   :substrate  :my.lib/uix})
           sp (some #(when (str/starts-with? % "substrate=") %) ps)]
       (is (some? sp))
@@ -65,7 +65,7 @@
 
 (deftest variant-share-url-no-base
   (testing "variant-share-url with no base produces params without leading ?"
-    (let [url (share/variant-share-url :story.foo/bar)]
+    (let [url (rf.story.share/variant-share-url :story.foo/bar)]
       (is (string? url))
       (is (re-find #"variant=" url))
       ;; No leading scheme / slash with no base.
@@ -73,7 +73,7 @@
 
 (deftest variant-share-url-with-base
   (testing "variant-share-url prepends base + ?"
-    (let [url (share/variant-share-url
+    (let [url (rf.story.share/variant-share-url
                 :story.foo/bar
                 "https://example.test/stories.html"
                 {:active-modes []
@@ -83,7 +83,7 @@
 
 (deftest variant-share-url-merges-existing-query
   (testing "variant-share-url uses & separator when base already has ?"
-    (let [url (share/variant-share-url
+    (let [url (rf.story.share/variant-share-url
                 :story.foo/bar
                 "https://example.test/?from=index"
                 nil)]
@@ -118,7 +118,7 @@
   occurrence per key wins, values form-urlencoded-decoded (`+` → space,
   `%XX` → byte) — the same getter map
   `re-frame.story.ui.url-state/params->getter` hands to
-  `share/parse-params`."
+  `rf.story.share/parse-params`."
   [url]
   (let [decode #(java.net.URLDecoder/decode (str %) "UTF-8")]
     (reduce (fn [m fragment]
@@ -133,12 +133,12 @@
             gets those values REPLACED, not appended after; browser
             first-value reads and parse-params both recover the newly
             requested cell, and unrelated params + hash route survive"
-    (let [url    (share/variant-share-url
+    (let [url    (rf.story.share/variant-share-url
                    :story.new/b
                    "https://example.test/?variant=story.old%2Fa&modes=Mode.app%2Fstale&from=index&embed=1#/stories"
                    {:active-modes [:Mode.app/dark]})
           getter (first-value-getter url)
-          parsed (share/parse-params getter)]
+          parsed (rf.story.share/parse-params getter)]
       (is (= 1 (query-key-count url "variant"))
           "exactly one variant= in the query string")
       (is (= 1 (query-key-count url "modes"))
@@ -168,7 +168,7 @@
 ;; `[]` / `{}` / `:reagent` — the hydrator then restored state the caller
 ;; never asked for, breaking the exact-cell invariant by OMISSION rather
 ;; than by order. The builder is authoritative over the whole
-;; `share/story-query-keys` vocabulary, including the slots it declines
+;; `rf.story.share/story-query-keys` vocabulary, including the slots it declines
 ;; to emit.
 
 (def ^:private stale-story-params
@@ -190,7 +190,7 @@
   unrelated params and a hash route."
   (str "https://example.test/?"
        (str/join "&" (map #(str (name %) "=" (get stale-story-params (name %)))
-                          share/story-query-keys))
+                          rf.story.share/story-query-keys))
        "&from=index&embed=1#/stories"))
 
 (deftest story-query-keys-is-the-whole-build-params-vocabulary
@@ -198,7 +198,7 @@
             build-params can emit. A slot added to build-params without a
             matching story-query-keys entry silently reopens the stale-value
             hole, so pin the two against each other."
-    (let [emitted (->> (share/build-params
+    (let [emitted (->> (rf.story.share/build-params
                          {:variant-id     :story.a/b
                           :workspace-id   :story.a/ws
                           :mode-tab       :docs        ; :dev is the omitted default
@@ -210,7 +210,7 @@
                           :substrate      :my.lib/uix}) ; :reagent is the omitted default
                        (map #(first (str/split % #"=" 2)))
                        set)]
-      (is (= (set (map name share/story-query-keys)) emitted)
+      (is (= (set (map name rf.story.share/story-query-keys)) emitted)
           "build-params with every slot populated emits exactly the vocabulary"))))
 
 (deftest variant-share-url-clears-stale-omitted-keys
@@ -218,20 +218,20 @@
             call OMITS comes back carrying none of them; the browser
             first-value read and parse-params see the requested cell with no
             stale optional state; unrelated params and the hash survive."
-    (is (= (set (map name share/story-query-keys))
+    (is (= (set (map name rf.story.share/story-query-keys))
            (set (keys stale-story-params)))
         "the fixture carries a stale value for every key in the vocabulary")
-    (let [url    (share/variant-share-url
+    (let [url    (rf.story.share/variant-share-url
                    :story.new/b
                    stale-base-url
                    ;; Every optional slot empty / default — so build-params
                    ;; emits `variant=` and nothing else.
                    {:active-modes [] :cell-overrides {} :substrate :reagent})
           getter (first-value-getter url)
-          parsed (share/parse-params getter)]
+          parsed (rf.story.share/parse-params getter)]
       (is (= 1 (query-key-count url "variant"))
           "exactly one variant= — the requested one")
-      (doseq [k (map name share/story-query-keys)
+      (doseq [k (map name rf.story.share/story-query-keys)
               :when (not= k "variant")]
         (is (zero? (query-key-count url k))
             (str "stale " k "= is cleared when the call omits that slot")))
@@ -291,14 +291,14 @@
        (str/join "&" (map #(str (escape-first-char (name %))
                                 "="
                                 (get stale-story-params (name %)))
-                          share/story-query-keys))
+                          rf.story.share/story-query-keys))
        "&from=index&embed=1#/stories"))
 
 (deftest escaped-story-keys-are-the-same-keys-to-the-browser
   (testing "rf2-b7je1 — the fixture is only a regression if the escaped
             spellings really are the owned keys after decoding; pin that
             before asserting anything about them"
-    (doseq [k (map name share/story-query-keys)]
+    (doseq [k (map name rf.story.share/story-query-keys)]
       (let [esc (escape-first-char k)]
         (is (not= esc k)
             (str k " is genuinely respelled, so raw matching cannot see it"))
@@ -311,17 +311,17 @@
             browser is concerned. The builder must clear them, leaving one
             effective value per owned key, while unrelated params, their
             order, and the hash route survive."
-    (let [url    (share/variant-share-url
+    (let [url    (rf.story.share/variant-share-url
                    :story.new/b
                    escaped-stale-base-url
                    {:active-modes [:Mode.app/dark]})
           getter (first-value-getter url)
-          parsed (share/parse-params getter)]
+          parsed (rf.story.share/parse-params getter)]
       (is (= 1 (decoded-key-count url "variant"))
           "exactly one variant= the browser can see — the requested one")
       (is (= 1 (decoded-key-count url "modes"))
           "exactly one modes= the browser can see — the requested one")
-      (doseq [k (map name share/story-query-keys)
+      (doseq [k (map name rf.story.share/story-query-keys)
               :when (not (#{"variant" "modes"} k))]
         (is (zero? (decoded-key-count url k))
             (str "stale escaped " k "= is cleared, not merely outranked")))
@@ -353,7 +353,7 @@
             something Story does not own. `mode+tab` is the sharp case:
             `+` is a space in a query component, so the browser reads it
             as `mode tab`, which is NOT `mode-tab`."
-    (let [url (share/variant-share-url
+    (let [url (rf.story.share/variant-share-url
                 :story.new/b
                 "https://example.test/?%zz=keepme&100%=raw&mode+tab=notmine&from=index"
                 nil)]
@@ -368,7 +368,7 @@
 
 (deftest variant-share-url-inserts-query-before-hash-route
   (testing "hash-routed Story links keep query params in location.search"
-    (let [url (share/variant-share-url
+    (let [url (rf.story.share/variant-share-url
                 :story.foo/bar
                 "https://example.test/counter-with-stories/#/stories"
                 {:active-modes [:Mode.app/dark]})]
@@ -382,12 +382,12 @@
 (deftest parse-share-url-params
   (testing "share URL parser reconstructs variant, modes, substrate, and overrides"
     (is (= :story.counter/loaded
-           (share/parse-keyword-token "story.counter/loaded")))
+           (rf.story.share/parse-keyword-token "story.counter/loaded")))
     (is (= [:Mode.app/dark :Mode.app/mobile]
-           (share/parse-modes-param "Mode.app/dark,Mode.app/mobile")))
-    (is (= :uix (share/parse-substrate-param "uix")))
+           (rf.story.share/parse-modes-param "Mode.app/dark,Mode.app/mobile")))
+    (is (= :uix (rf.story.share/parse-substrate-param "uix")))
     (is (= {:label "Shared Label" :count 9}
-           (share/parse-overrides-param "{:label \"Shared Label\", :count 9}")))))
+           (rf.story.share/parse-overrides-param "{:label \"Shared Label\", :count 9}")))))
 
 ;; ---- rf2-j0hwf: overrides codec round-trip -------------------------------
 ;;
@@ -400,7 +400,7 @@
   "Encode `ov` to the wire token, URL-decode it (as URLSearchParams.get
   would), and parse it back. Returns the reconstructed overrides map."
   [ov]
-  (share/parse-overrides-param (url-decode (share/build-overrides-token ov))))
+  (rf.story.share/parse-overrides-param (url-decode (rf.story.share/build-overrides-token ov))))
 
 ;; ---- rf2-j5yv6y: substrate id round-trips namespace ----------------------
 
@@ -410,14 +410,14 @@
             namespace. A registered custom substrate like :my.lib/uix must
             hydrate back to the SAME id, not a different bare :uix."
     (let [substrate :my.lib/uix
-          ps        (share/build-params {:variant-id :story.foo/bar
+          ps        (rf.story.share/build-params {:variant-id :story.foo/bar
                                          :substrate  substrate})
           sp        (some #(when (str/starts-with? % "substrate=") %) ps)
           ;; URLSearchParams.get returns the decoded value; emulate it.
           decoded   (url-decode (subs sp (count "substrate=")))]
-      (is (= substrate (share/parse-substrate-param decoded))
+      (is (= substrate (rf.story.share/parse-substrate-param decoded))
           "qualified substrate id survives the full encode → decode → parse")
-      (is (= substrate (:substrate (share/parse-params {"substrate" decoded})))
+      (is (= substrate (:substrate (rf.story.share/parse-params {"substrate" decoded})))
           "and through the full parse-params inverse"))))
 
 (deftest overrides-codec-round-trips-simple
@@ -449,16 +449,16 @@
   (testing "rf2-j0hwf — the encoded token is stable across calls (keys
             sorted) so the URL is canonical and idempotent pushes no-op"
     (let [ov {:zed 1 :alpha 2 :mid 3}]
-      (is (= (share/build-overrides-token ov)
-             (share/build-overrides-token ov))))))
+      (is (= (rf.story.share/build-overrides-token ov)
+             (rf.story.share/build-overrides-token ov))))))
 
 (deftest overrides-codec-empty-and-nil
   (testing "rf2-j0hwf — empty/nil overrides produce no token, and blank
             input parses to nil"
-    (is (nil? (share/build-overrides-token {})))
-    (is (nil? (share/build-overrides-token nil)))
-    (is (nil? (share/parse-overrides-param nil)))
-    (is (nil? (share/parse-overrides-param "")))))
+    (is (nil? (rf.story.share/build-overrides-token {})))
+    (is (nil? (rf.story.share/build-overrides-token nil)))
+    (is (nil? (rf.story.share/parse-overrides-param nil)))
+    (is (nil? (rf.story.share/parse-overrides-param "")))))
 
 ;; ---- rf2-9jthx: parse-overrides-param* surfaces dropped entries ----------
 
@@ -467,7 +467,7 @@
             map as parse-overrides-param plus an empty :dropped vec for
             clean input"
     (let [{:keys [overrides dropped]}
-          (share/parse-overrides-param* "{:label \"Hi\", :count 9}")]
+          (rf.story.share/parse-overrides-param* "{:label \"Hi\", :count 9}")]
       (is (= {:label "Hi" :count 9} overrides))
       (is (= [] dropped) "no entries dropped for a clean input"))))
 
@@ -478,7 +478,7 @@
             wire form a per-entry drop is a key that cannot coerce to a
             keyword; the surviving entries are kept."
     (let [{:keys [overrides dropped]}
-          (share/parse-overrides-param*
+          (rf.story.share/parse-overrides-param*
             "{:label \"OK\", :size 7, 5 :bad-key}")]
       (is (= {:label "OK" :size 7} overrides)
           "well-formed entries survive")
@@ -490,7 +490,7 @@
   (testing "rf2-9jthx — when the payload is not a readable EDN map :overrides
             is nil and the whole token is dropped"
     (let [{:keys [overrides dropped]}
-          (share/parse-overrides-param* "{:label \"unterminated")]
+          (rf.story.share/parse-overrides-param* "{:label \"unterminated")]
       (is (nil? overrides))
       (is (= ["{:label \"unterminated"] dropped)))))
 
@@ -498,11 +498,11 @@
   (testing "rf2-9jthx — blank/nil input returns the empty-shape map so
             callers don't have to nil-check before destructuring"
     (is (= {:overrides nil :dropped []}
-           (share/parse-overrides-param* nil)))
+           (rf.story.share/parse-overrides-param* nil)))
     (is (= {:overrides nil :dropped []}
-           (share/parse-overrides-param* "")))
+           (rf.story.share/parse-overrides-param* "")))
     (is (= {:overrides nil :dropped []}
-           (share/parse-overrides-param* "   ")))))
+           (rf.story.share/parse-overrides-param* "   ")))))
 
 (deftest parse-overrides-param*-silent-drop
   (testing "rf2-9jthx — parse-overrides-param (silent-drop) keeps its
@@ -510,7 +510,7 @@
             parse-overrides-param* so the dropped count surfaces; other
             call sites that don't care about it keep working"
     (is (= {:label "OK"}
-           (share/parse-overrides-param "{:label \"OK\", 5 :bad-key}")))))
+           (rf.story.share/parse-overrides-param "{:label \"OK\", 5 :bad-key}")))))
 
 (deftest parse-overrides-param*-edn-map-form
   (testing "rf2-j0hwf — parse-overrides-param* reads the EDN-map wire form
@@ -518,15 +518,15 @@
             keyword as :dropped, so the share-import hint still surfaces
             on the new delimiter-safe encoding"
     (let [{:keys [overrides dropped]}
-          (share/parse-overrides-param* "{:label \"OK\", :size 7}")]
+          (rf.story.share/parse-overrides-param* "{:label \"OK\", :size 7}")]
       (is (= {:label "OK" :size 7} overrides))
       (is (= [] dropped) "clean EDN map drops nothing"))
     (let [{:keys [overrides dropped]}
-          (share/parse-overrides-param* "{:label \"OK\", 5 :bad-key}")]
+          (rf.story.share/parse-overrides-param* "{:label \"OK\", 5 :bad-key}")]
       (is (= {:label "OK"} overrides) "non-keyword key dropped, rest kept")
       (is (= 1 (count dropped))))
     (let [{:keys [overrides dropped]}
-          (share/parse-overrides-param* "{:label \"unterminated")]
+          (rf.story.share/parse-overrides-param* "{:label \"unterminated")]
       (is (nil? overrides) "unreadable EDN payload yields no overrides")
       (is (= 1 (count dropped)) "whole token reported dropped"))))
 
@@ -545,7 +545,7 @@
             into :dropped, preserving the parser's own malformed drops"
     (let [parsed {:overrides {:label "Hi" :gone 9 :count 3}
                   :dropped   ["bogus"]}
-          out    (share/drop-stale-overrides parsed #{:label :count})]
+          out    (rf.story.share/drop-stale-overrides parsed #{:label :count})]
       (is (= {:label "Hi" :count 3} (:overrides out))
           "only declared keys survive")
       (is (= 2 (count (:dropped out)))
@@ -558,7 +558,7 @@
 (deftest drop-stale-overrides-all-stale-nils-overrides
   (testing "rf2-76l69l — when every parsed override is stale, :overrides is
             nil (not an empty map) and each stale key is reported"
-    (let [out (share/drop-stale-overrides
+    (let [out (rf.story.share/drop-stale-overrides
                 {:overrides {:old-a 1 :old-b 2} :dropped []}
                 #{:current})]
       (is (nil? (:overrides out)) "all-stale collapses to nil overrides")
@@ -569,7 +569,7 @@
             variant: no contract known) keeps every parsed override verbatim
             rather than dropping all — degrades to the parser's behaviour"
     (let [parsed {:overrides {:a 1 :b 2} :dropped ["bad"]}
-          out    (share/drop-stale-overrides parsed nil)]
+          out    (rf.story.share/drop-stale-overrides parsed nil)]
       (is (= {:a 1 :b 2} (:overrides out)))
       (is (= ["bad"] (:dropped out))))))
 
@@ -577,7 +577,7 @@
   (testing "rf2-76l69l — an EMPTY (but non-nil) declared-key set means the
             variant declares NO args, so every override is stale (distinct
             from the nil keep-all case)"
-    (let [out (share/drop-stale-overrides
+    (let [out (rf.story.share/drop-stale-overrides
                 {:overrides {:a 1} :dropped []}
                 #{})]
       (is (nil? (:overrides out)))
@@ -585,7 +585,7 @@
 
 (deftest variant-share-url-preserves-hash-route
   (testing "variant-share-url inserts params before # so the Story route survives"
-    (let [url (share/variant-share-url
+    (let [url (rf.story.share/variant-share-url
                 :story.counter/loaded
                 "https://example.test/counter-with-stories/#/stories"
                 {:active-modes   [:Mode.app/dark]
@@ -601,8 +601,8 @@
       (is (str/ends-with? url "#/stories")))))
 
 (deftest variant-share-url-public-export
-  (testing "story/variant-share-url is exported"
-    (let [url (story/variant-share-url
+  (testing "rf.story/variant-share-url is exported"
+    (let [url (rf.story/variant-share-url
                 :story.foo/bar
                 "https://x.test/"
                 {:active-modes [:Mode.x/y]})]
@@ -616,7 +616,7 @@
 ;; Share button + QR popover were retired outright — the variant URL
 ;; is the browser's live address-bar URL (`url-state` pushState).
 ;; This ns must therefore expose neither the legacy third-party QR
-;; endpoint Vars nor the vendored local encoder Vars from `share/`
+;; endpoint Vars nor the vendored local encoder Vars from `rf.story.share/`
 ;; (the encoder ns `re-frame.story.qr` itself is gone). The literal
 ;; api.qrserver.com must not appear in the share module — a future
 ;; regression that re-introduced a third-party QR fetch trips here.
@@ -627,8 +627,8 @@
             api.qrserver.com; rf2-20w5i eliminated those; rf2-ymnfx
             Issue B then retired the QR popover entirely. The
             assertions remain as a regression gate."
-    (is (nil? (resolve 'share/qr-endpoint)))
-    (is (nil? (resolve 'share/qr-image-url)))))
+    (is (nil? (resolve 'rf.story.share/qr-endpoint)))
+    (is (nil? (resolve 'rf.story.share/qr-image-url)))))
 
 (deftest no-qrserver-literal-in-share-source
   (testing "share.cljc carries no `api.qrserver.com` URL literal — the

--- a/tools/story/test/re_frame/story_share_url_state_test.clj
+++ b/tools/story/test/re_frame/story_share_url_state_test.clj
@@ -4,19 +4,19 @@
   Pairs with `re-frame.story-share-test` (variant + modes + overrides +
   substrate). This ns pins the new sharability slots — workspace,
   mode-tab, viewport, background, tag-filter — and the
-  `share/parse-params` round-trip.
+  `rf.story.share/parse-params` round-trip.
 
   Pure CLJC — every encoder + parser lives in `re-frame.story.share`,
   no CLJS deps."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
-            [re-frame.story.share :as share]))
+            [re-frame.story.share :as rf.story.share]))
 
 ;; ---- workspace -----------------------------------------------------------
 
 (deftest build-params-workspace
   (testing "workspace id encodes as workspace=<ns>/<name>"
-    (let [ps (share/build-params {:workspace-id :story.foo/grid})
+    (let [ps (rf.story.share/build-params {:workspace-id :story.foo/grid})
           wp (some #(when (str/starts-with? % "workspace=") %) ps)]
       (is (some? wp))
       (is (re-find #"story.foo" wp))
@@ -25,107 +25,107 @@
 (deftest parse-workspace-param-round-trip
   (testing "parse-workspace-param round-trips a kw->str token"
     (is (= :story.foo/grid
-           (share/parse-workspace-param "story.foo/grid")))
-    (is (nil? (share/parse-workspace-param "")))
-    (is (nil? (share/parse-workspace-param nil)))))
+           (rf.story.share/parse-workspace-param "story.foo/grid")))
+    (is (nil? (rf.story.share/parse-workspace-param "")))
+    (is (nil? (rf.story.share/parse-workspace-param nil)))))
 
 ;; ---- mode-tab ------------------------------------------------------------
 
 (deftest build-params-mode-tab-non-default
   (testing "mode-tab encodes when non-default (anything other than :dev)"
-    (let [ps (share/build-params {:variant-id :story.foo/bar
+    (let [ps (rf.story.share/build-params {:variant-id :story.foo/bar
                                   :mode-tab   :docs})]
       (is (some #(str/starts-with? % "mode-tab=docs") ps)))))
 
 (deftest build-params-mode-tab-default-omitted
   (testing ":dev (the default) is omitted so the canonical URL stays minimal"
-    (let [ps (share/build-params {:variant-id :story.foo/bar
+    (let [ps (rf.story.share/build-params {:variant-id :story.foo/bar
                                   :mode-tab   :dev})]
       (is (not (some #(str/starts-with? % "mode-tab=") ps))))))
 
 (deftest build-params-mode-tab-unknown-dropped
   (testing "unknown mode-tab values are dropped (a stale URL degrades silently)"
-    (let [ps (share/build-params {:variant-id :story.foo/bar
+    (let [ps (rf.story.share/build-params {:variant-id :story.foo/bar
                                   :mode-tab   :bogus})]
       (is (not (some #(str/starts-with? % "mode-tab=") ps))))))
 
 (deftest parse-mode-tab-param
   (testing "parse-mode-tab-param recognises :dev/:docs/:test, drops anything else"
-    (is (= :dev  (share/parse-mode-tab-param "dev")))
-    (is (= :docs (share/parse-mode-tab-param "docs")))
-    (is (= :test (share/parse-mode-tab-param "test")))
-    (is (nil?    (share/parse-mode-tab-param "bogus")))
-    (is (nil?    (share/parse-mode-tab-param "")))
-    (is (nil?    (share/parse-mode-tab-param nil)))))
+    (is (= :dev  (rf.story.share/parse-mode-tab-param "dev")))
+    (is (= :docs (rf.story.share/parse-mode-tab-param "docs")))
+    (is (= :test (rf.story.share/parse-mode-tab-param "test")))
+    (is (nil?    (rf.story.share/parse-mode-tab-param "bogus")))
+    (is (nil?    (rf.story.share/parse-mode-tab-param "")))
+    (is (nil?    (rf.story.share/parse-mode-tab-param nil)))))
 
 ;; ---- viewport ------------------------------------------------------------
 
 (deftest build-params-viewport-preset
   (testing "viewport preset keyword encodes as viewport=<id>"
-    (let [ps (share/build-params {:viewport :tablet})]
+    (let [ps (rf.story.share/build-params {:viewport :tablet})]
       (is (some #(= "viewport=tablet" %) ps)))))
 
 (deftest build-params-viewport-custom
   (testing "viewport custom map encodes as viewport=WxH"
-    (let [ps (share/build-params {:viewport {:width 800 :height 600}})]
+    (let [ps (rf.story.share/build-params {:viewport {:width 800 :height 600}})]
       (is (some #(= "viewport=800x600" %) ps)))))
 
 (deftest build-params-viewport-omitted-when-nil
   (testing "nil viewport is omitted from the canonical URL"
-    (let [ps (share/build-params {:viewport nil})]
+    (let [ps (rf.story.share/build-params {:viewport nil})]
       (is (not (some #(str/starts-with? % "viewport=") ps))))))
 
 (deftest parse-viewport-param-preset
-  (is (= :tablet (share/parse-viewport-param "tablet"))))
+  (is (= :tablet (rf.story.share/parse-viewport-param "tablet"))))
 
 (deftest parse-viewport-param-custom
   (testing "custom WxH parses into {:width :height}"
-    (is (= {:width 800 :height 600} (share/parse-viewport-param "800x600")))
-    (is (= {:width 1024 :height 768} (share/parse-viewport-param "1024x768")))))
+    (is (= {:width 800 :height 600} (rf.story.share/parse-viewport-param "800x600")))
+    (is (= {:width 1024 :height 768} (rf.story.share/parse-viewport-param "1024x768")))))
 
 (deftest parse-viewport-param-malformed
   (testing "malformed values degrade — empty / nil → nil; zero dim → nil;
             unknown keywords are returned as-is (the hydrator validates
             against the preset table via apply-parsed-to-state)"
-    (is (nil? (share/parse-viewport-param "0x600")) "zero dim → nil")
-    (is (nil? (share/parse-viewport-param "")))
-    (is (nil? (share/parse-viewport-param nil)))
+    (is (nil? (rf.story.share/parse-viewport-param "0x600")) "zero dim → nil")
+    (is (nil? (rf.story.share/parse-viewport-param "")))
+    (is (nil? (rf.story.share/parse-viewport-param nil)))
     ;; Bare tokens parse to keywords here; the hydrator's :viewport?
     ;; validator drops anything that isn't a registered preset / valid custom.
-    (is (= :x (share/parse-viewport-param "x")))))
+    (is (= :x (rf.story.share/parse-viewport-param "x")))))
 
 ;; ---- background ----------------------------------------------------------
 
 (deftest build-params-background-preset
   (testing "background preset keyword encodes as background=<id>"
-    (let [ps (share/build-params {:background :dark})]
+    (let [ps (rf.story.share/build-params {:background :dark})]
       (is (some #(= "background=dark" %) ps)))))
 
 (deftest build-params-background-hex
   (testing "hex colour string encodes as background=%23rrggbb"
-    (let [ps (share/build-params {:background "#abc123"})]
+    (let [ps (rf.story.share/build-params {:background "#abc123"})]
       (is (some #(= "background=%23abc123" %) ps)
           "# is percent-encoded to %23 so it doesn't collide with hash routes"))))
 
 (deftest parse-background-param-preset
-  (is (= :dark (share/parse-background-param "dark"))))
+  (is (= :dark (rf.story.share/parse-background-param "dark"))))
 
 (deftest parse-background-param-hex
   (testing "hex colour parses back to itself"
-    (is (= "#abc123" (share/parse-background-param "#abc123")))
-    (is (= "#ABC" (share/parse-background-param "#ABC")))
-    (is (= "#aabbccdd" (share/parse-background-param "#aabbccdd")))))
+    (is (= "#abc123" (rf.story.share/parse-background-param "#abc123")))
+    (is (= "#ABC" (rf.story.share/parse-background-param "#ABC")))
+    (is (= "#aabbccdd" (rf.story.share/parse-background-param "#aabbccdd")))))
 
 (deftest parse-background-param-malformed
   (testing "malformed values degrade to nil"
-    (is (nil? (share/parse-background-param "")))
-    (is (nil? (share/parse-background-param nil)))))
+    (is (nil? (rf.story.share/parse-background-param "")))
+    (is (nil? (rf.story.share/parse-background-param nil)))))
 
 ;; ---- tag-filter ----------------------------------------------------------
 
 (deftest build-params-tag-filter
   (testing "tag-filter set encodes as a sorted comma-separated list"
-    (let [ps (share/build-params {:tag-filter #{:tag/b :tag/a}})
+    (let [ps (rf.story.share/build-params {:tag-filter #{:tag/b :tag/a}})
           tf (some #(when (str/starts-with? % "tag-filter=") %) ps)]
       (is (some? tf))
       ;; The wire form percent-encodes `/` to %2F and `,` to %2C.
@@ -138,9 +138,9 @@
 (deftest parse-tag-filter-param
   (testing "tag-filter parses into a set"
     (is (= #{:tag/a :tag/b}
-           (share/parse-tag-filter-param "tag/a,tag/b")))
-    (is (nil? (share/parse-tag-filter-param "")))
-    (is (nil? (share/parse-tag-filter-param nil)))))
+           (rf.story.share/parse-tag-filter-param "tag/a,tag/b")))
+    (is (nil? (rf.story.share/parse-tag-filter-param "")))
+    (is (nil? (rf.story.share/parse-tag-filter-param nil)))))
 
 ;; ---- parse-params round-trip --------------------------------------------
 
@@ -156,13 +156,13 @@
                  :tag-filter     #{:tag/a :tag/b}
                  :cell-overrides {:label "Hi"}
                  :substrate      :uix}
-          ps    (share/build-params in)
+          ps    (rf.story.share/build-params in)
           ;; Simulate URLSearchParams by parsing the param vector back.
           getter (into {}
                        (for [kv ps
                              :let [[k v] (str/split kv #"=" 2)]]
                          [k (java.net.URLDecoder/decode v "UTF-8")]))
-          out   (share/parse-params getter)]
+          out   (rf.story.share/parse-params getter)]
       (is (= :story.counter/loaded (:variant-id   out)))
       (is (= :docs                 (:mode-tab     out)))
       (is (= [:Mode.app/dark :Mode.app/mobile]
@@ -175,27 +175,27 @@
 
 (deftest parse-params-handles-missing-keys
   (testing "parse-params returns nil for absent slots — caller decides defaults"
-    (let [out (share/parse-params {})]
+    (let [out (rf.story.share/parse-params {})]
       (is (every? nil? (vals out))))))
 
 (deftest parse-params-with-workspace
   (testing "workspace round-trips when present"
     (let [in    {:workspace-id :story.foo/grid}
-          ps    (share/build-params in)
+          ps    (rf.story.share/build-params in)
           getter (into {}
                        (for [kv ps
                              :let [[k v] (str/split kv #"=" 2)]]
                          [k (java.net.URLDecoder/decode v "UTF-8")]))
-          out   (share/parse-params getter)]
+          out   (rf.story.share/parse-params getter)]
       (is (= :story.foo/grid (:workspace-id out))))))
 
 (deftest parse-params-with-viewport-custom
   (testing "viewport custom WxH round-trips"
     (let [in    {:viewport {:width 800 :height 600}}
-          ps    (share/build-params in)
+          ps    (rf.story.share/build-params in)
           getter (into {}
                        (for [kv ps
                              :let [[k v] (str/split kv #"=" 2)]]
                          [k (java.net.URLDecoder/decode v "UTF-8")]))
-          out   (share/parse-params getter)]
+          out   (rf.story.share/parse-params getter)]
       (is (= {:width 800 :height 600} (:viewport out))))))

--- a/tools/story/test/re_frame/story_source_coords_test.clj
+++ b/tools/story/test/re_frame/story_source_coords_test.clj
@@ -55,9 +55,9 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
-            [re-frame.source-coords.editor-uri :as editor-uri]
-            [re-frame.story :as story]
-            [re-frame.story.macros :as macros]))
+            [re-frame.source-coords.editor-uri :as rf.source-coords.editor-uri]
+            [re-frame.story :as rf.story]
+            [re-frame.story.macros :as rf.story.macros]))
 
 ;; ---- helpers ----------------------------------------------------------------
 
@@ -68,7 +68,7 @@
   `(quote sym)` form, so `eval` is still how the test reads back the map
   the macro expansion would bind."
   [form-meta file ns-sym]
-  (eval (macros/coords-form form-meta file ns-sym)))
+  (eval (rf.story.macros/coords-form form-meta file ns-sym)))
 
 ;; A real Story source file that IS on this JVM gate's classpath, so the
 ;; classpath probe inside `absolutise-file` has something to resolve.
@@ -84,10 +84,10 @@
 
 (defn- assert-absolute-and-real!
   "Shared shape assertions for an absolutised `:file`: absolute per the
-  same predicate `editor-uri/compose-path` uses, present on disk, and
+  same predicate `rf.source-coords.editor-uri/compose-path` uses, present on disk, and
   still ending in the classpath-relative tail it started as."
   [path tail because]
-  (is (editor-uri/absolute-path? path)
+  (is (rf.source-coords.editor-uri/absolute-path? path)
       (str because " — :file must be ABSOLUTE, got " (pr-str path)))
   (is (str/ends-with? (str/replace path "\\" "/") tail)
       (str because " — the absolutised path must still end in the "
@@ -145,7 +145,7 @@
                    'some.ns)]
       (is (= "no/such/story_file.cljs" (:file coords))
           "unresolvable :file ships verbatim — no fabricated absolute path")
-      (is (not (editor-uri/absolute-path? (:file coords)))))))
+      (is (not (rf.source-coords.editor-uri/absolute-path? (:file coords)))))))
 
 (deftest file-omitted-when-both-sources-are-sentinel
   (testing "rf2-ulxi: if BOTH (meta &form) :file and *file* resolve to
@@ -177,7 +177,7 @@
             path Story uses for variants whose :script sequences emit
             :rf.assert/* events"
     (let [form-meta {:line 42 :column 3 :file on-classpath-story-file}
-          expansion (macros/gen-reg-call
+          expansion (rf.story.macros/gen-reg-call
                       form-meta
                       "NO_SOURCE_PATH"             ; simulate CLJS *file*
                       'my.app.stories
@@ -203,9 +203,9 @@
 ;; ---- rf2-3xq1v: a REAL Story registration, pinned absolute -----------------
 ;;
 ;; Everything above drives `coords-form` directly. This drives the actual
-;; `story/reg-story` macro at a real source location in a real Story
+;; `rf.story/reg-story` macro at a real source location in a real Story
 ;; artefact file, and reads the coordinate back off the registrar the way
-;; every consumer does — `(story/handler-meta :story id)` → `:source`.
+;; every consumer does — `(rf.story/handler-meta :story id)` → `:source`.
 ;; The file this registration sits in IS on the gate's classpath, so the
 ;; class-loader probe has a genuine resolution to make.
 
@@ -214,9 +214,9 @@
             one carries an ABSOLUTE :file in its :source slot. Before the
             fix this was `re_frame/story_source_coords_test.clj` — the
             classpath-relative tail on its own."
-    (story/reg-story :story.source-coords.absolute-pin
+    (rf.story/reg-story :story.source-coords.absolute-pin
       {:doc "rf2-3xq1v fixture — the coordinate under test IS this form's."})
-    (let [coord (:source (story/handler-meta :story :story.source-coords.absolute-pin))]
+    (let [coord (:source (rf.story/handler-meta :story :story.source-coords.absolute-pin))]
       (is (some? coord) "the registration carries a :source coord at all")
       (assert-absolute-and-real!
         (:file coord) "re_frame/story_source_coords_test.clj"
@@ -233,7 +233,7 @@
 ;; `re-frame.testbed.open-in-editor-server` answers when launch-editor
 ;; declines a coordinate-bearing request (the Windsurf case the audit
 ;; measured). The fallback resolves the coord through
-;; `editor-uri/editor-uri` with whatever `:project-root` the host set —
+;; `rf.source-coords.editor-uri/editor-uri` with whatever `:project-root` the host set —
 ;; nil for a repository dev testbed, since the browser-side checkout-root
 ;; pipeline is gone. That composition is `.cljc` and pure, so the shape the
 ;; fallback ships is pinnable here; the CLJS half drives the same coordinate
@@ -244,12 +244,12 @@
             repository dev testbed is in since the checkout-root pipeline
             was retired — the URI the 422 fallback ships for a real Story
             coordinate names an absolute path the editor can open"
-    (story/reg-story :story.source-coords.fallback-pin
+    (rf.story/reg-story :story.source-coords.fallback-pin
       {:doc "rf2-3xq1v fixture — this form's coordinate feeds the URI below."})
-    (let [coord (:source (story/handler-meta :story :story.source-coords.fallback-pin))
+    (let [coord (:source (rf.story/handler-meta :story :story.source-coords.fallback-pin))
           ;; Exactly what `open-in-editor/resolve-uri` builds when
           ;; `config/get-project-root` returns nil.
-          uri   (editor-uri/editor-uri :windsurf coord {:project-root nil})]
+          uri   (rf.source-coords.editor-uri/editor-uri :windsurf coord {:project-root nil})]
       (is (str/starts-with? uri "windsurf://file/")
           "the fallback is the historic editor:// URI path, unchanged")
       (let [path (-> uri
@@ -265,9 +265,9 @@
             NOT double-prefix an already-absolute coord. The knob is kept
             for external / static / non-shadow hosts, and it stays inert
             over a coordinate the macro already absolutised."
-    (let [coord (:source (story/handler-meta :story :story.source-coords.fallback-pin))
-          bare  (editor-uri/editor-uri :windsurf coord {:project-root nil})
-          rooted (editor-uri/editor-uri :windsurf coord
+    (let [coord (:source (rf.story/handler-meta :story :story.source-coords.fallback-pin))
+          bare  (rf.source-coords.editor-uri/editor-uri :windsurf coord {:project-root nil})
+          rooted (rf.source-coords.editor-uri/editor-uri :windsurf coord
                                         {:project-root "/some/external/root"})]
       (is (= bare rooted)
           "an absolute :file passes through compose-path untouched"))))

--- a/tools/story/test/re_frame/story_static_build_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_static_build_cljs_test.cljs
@@ -40,8 +40,8 @@
     the registrar is frozen as far as DEV mutations go, but the
     seed registrations the static export ships with must be intact)."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.story        :as story]
-            [re-frame.story.config :as config]))
+            [re-frame.story        :as rf.story]
+            [re-frame.story.config :as rf.story.config]))
 
 ;; ===========================================================================
 ;; PUBLIC `static-mode?` PROBE
@@ -50,18 +50,18 @@
 (deftest public-probe-resolves
   (testing "re-frame.story/static-mode? is a public fn — consumers branch
             on it at boot to drop dev-only setup work"
-    (is (fn? @#'story/static-mode?)
+    (is (fn? @#'rf.story/static-mode?)
         "the public Var resolves and is a fn")))
 
 (deftest public-probe-mirrors-config-flag
-  (testing "(story/static-mode?) returns the same value as the underlying
+  (testing "(rf.story/static-mode?) returns the same value as the underlying
             goog-define `re-frame.story.config/static-mode?`"
-    (is (= config/static-mode? (story/static-mode?)))))
+    (is (= rf.story.config/static-mode? (rf.story/static-mode?)))))
 
 (deftest static-mode-defaults-false-in-node-test-build
   (testing "the node-test build does not flip the static-mode goog-define,
             so consumer code branches into the dev-flavoured path"
-    (is (false? (story/static-mode?))
+    (is (false? (rf.story/static-mode?))
         "default is the dev-flavoured branch")))
 
 ;; ===========================================================================
@@ -76,13 +76,13 @@
             static-mode? true). The orthogonality lets the static export
             be the runtime artefact `:rf.story/enabled? false` builds
             DCE the Story shell out of"
-    (is (true? config/enabled?))
-    (is (false? config/static-mode?))
+    (is (true? rf.story.config/enabled?))
+    (is (false? rf.story.config/static-mode?))
     ;; The two slots are independently set; reading them does not
     ;; couple them. A future refactor that lazily-derives one from the
     ;; other (an XOR shortcut, say) would break the orthogonality
     ;; contract spec/013 names.
-    (is (not= config/enabled? config/static-mode?)
+    (is (not= rf.story.config/enabled? rf.story.config/static-mode?)
         "in the dev-flavoured node-test build the two are different
          booleans — proves they're not aliased to one another")))
 
@@ -92,7 +92,7 @@
 ;; ===========================================================================
 ;;
 ;; The help-host's component-did-mount auto-open path is gated on
-;; `(not config/static-mode?)`. We mirror that predicate here so a
+;; `(not rf.story.config/static-mode?)`. We mirror that predicate here so a
 ;; future refactor that drops the static-mode check from the help host
 ;; fails this test even though we can't actually trigger Reagent's
 ;; component-did-mount in a node-test context (no DOM).
@@ -132,7 +132,7 @@
 ;; ===========================================================================
 ;;
 ;; Same shape as the help overlay. The shell's `start-hot-reload-poll!`
-;; gates on `(and config/enabled? (not config/static-mode?) ...)`. We
+;; gates on `(and rf.story.config/enabled? (not rf.story.config/static-mode?) ...)`. We
 ;; mirror the predicate so a future refactor that drops the
 ;; static-mode check from the shell fails this test.
 
@@ -181,20 +181,20 @@
             the shell chrome; the registrar is unaffected. A static-
             export bundle's seed registrations must reach the same side-
             table the dev-mode bundle uses"
-    (story/clear-all!)
-    (story/install-canonical-vocabulary!)
-    (story/reg-story :story.static.seed
+    (rf.story/clear-all!)
+    (rf.story/install-canonical-vocabulary!)
+    (rf.story/reg-story :story.static.seed
       {:doc "a seed story baked into the static export"})
-    (story/reg-variant :story.static.seed/probe
+    (rf.story/reg-variant :story.static.seed/probe
       {:setup [[:probe/init]]
        :tags   #{:dev}})
     ;; Read surface — the MCP-or-tooling consumer path.
-    (is (story/registered? :story   :story.static.seed))
-    (is (story/registered? :variant :story.static.seed/probe))
+    (is (rf.story/registered? :story   :story.static.seed))
+    (is (rf.story/registered? :variant :story.static.seed/probe))
     (is (= #{:story.static.seed/probe}
-           (story/variants-of :story.static.seed)))
+           (rf.story/variants-of :story.static.seed)))
     (is (= [[:probe/init]]
-           (:setup (story/variant->edn :story.static.seed/probe))))))
+           (:setup (rf.story/variant->edn :story.static.seed/probe))))))
 
 ;; ===========================================================================
 ;; STATIC-EXPORT SELF-CONTAINMENT — open-in-editor project-root fails closed
@@ -203,9 +203,9 @@
 ;; A published `story:build` export must not bake the build machine's
 ;; checkout root (a `C:/Users/<name>/...`-style absolute path) into its
 ;; open-in-editor URIs. The project-root is a DEV-time affordance; under
-;; `static-mode?` `config/set-project-root!` fails closed — a passed root is
+;; `static-mode?` `rf.story.config/set-project-root!` fails closed — a passed root is
 ;; ignored (the slot stays nil) unless a host explicitly opts in via
-;; `config/set-allow-static-project-root!`. The dev path (static-mode? false)
+;; `rf.story.config/set-allow-static-project-root!`. The dev path (static-mode? false)
 ;; is unaffected. This guard is now the whole of the defence: no build in the
 ;; repository derives a checkout path from its environment for a host to pass
 ;; in (rf2-3xq1v), so there is no ambient value for it to have to catch.
@@ -220,40 +220,40 @@
   (testing "under static-mode?, a passed project-root is ignored — the
             open-in-editor slot stays nil so no build-machine checkout path
             leaks into a published bundle's editor URIs"
-    (config/reset-all!)
-    (with-redefs [config/static-mode? true]
-      (config/set-project-root! sentinel-root)
-      (is (nil? (config/get-project-root))
+    (rf.story.config/reset-all!)
+    (with-redefs [rf.story.config/static-mode? true]
+      (rf.story.config/set-project-root! sentinel-root)
+      (is (nil? (rf.story.config/get-project-root))
           "static mode fails closed — the sentinel root is not retained"))
-    (config/reset-all!)))
+    (rf.story.config/reset-all!)))
 
 (deftest static-mode-opt-in-restores-project-root
   (testing "a host that explicitly opts in via set-allow-static-project-root!
             keeps the root in static mode — the escape hatch for a published
             site that deep-links back into the author's editor"
-    (config/reset-all!)
-    (with-redefs [config/static-mode? true]
-      (config/set-allow-static-project-root! true)
-      (config/set-project-root! sentinel-root)
-      (is (= sentinel-root (config/get-project-root))
+    (rf.story.config/reset-all!)
+    (with-redefs [rf.story.config/static-mode? true]
+      (rf.story.config/set-allow-static-project-root! true)
+      (rf.story.config/set-project-root! sentinel-root)
+      (is (= sentinel-root (rf.story.config/get-project-root))
           "with the explicit opt-in the root is retained even in static mode"))
-    (config/reset-all!)))
+    (rf.story.config/reset-all!)))
 
 (deftest dev-mode-project-root-unaffected
   (testing "with static-mode? false (the dev build) the project-root is set
             verbatim — the guard narrows ONLY static exports, never dev"
-    (config/reset-all!)
-    (is (false? config/static-mode?) "node-test build is dev-flavoured")
-    (config/set-project-root! sentinel-root)
-    (is (= sentinel-root (config/get-project-root))
+    (rf.story.config/reset-all!)
+    (is (false? rf.story.config/static-mode?) "node-test build is dev-flavoured")
+    (rf.story.config/set-project-root! sentinel-root)
+    (is (= sentinel-root (rf.story.config/get-project-root))
         "dev builds keep the root — open-in-editor resolves absolute paths")
-    (config/reset-all!)))
+    (rf.story.config/reset-all!)))
 
 (deftest reset-all-clears-static-opt-in
-  (testing "config/reset-all! restores the static project-root opt-in to its
+  (testing "rf.story.config/reset-all! restores the static project-root opt-in to its
             fail-closed default so a test that flips it cannot leak into the
             next test"
-    (config/set-allow-static-project-root! true)
-    (config/reset-all!)
-    (is (false? (config/allow-static-project-root?*))
+    (rf.story.config/set-allow-static-project-root! true)
+    (rf.story.config/reset-all!)
+    (is (false? (rf.story.config/allow-static-project-root?*))
         "opt-in is back to fail-closed after reset-all!")))

--- a/tools/story/test/re_frame/story_static_build_integrity_test.clj
+++ b/tools/story/test/re_frame/story_static_build_integrity_test.clj
@@ -32,22 +32,22 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core            :as rf]
-            [re-frame.frame           :as frame]
-            [re-frame.registrar       :as rf-registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story           :as story]
-            [re-frame.story.share     :as share]))
+            [re-frame.frame           :as rf.frame]
+            [re-frame.registrar       :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story           :as rf.story]
+            [re-frame.story.share     :as rf.story.share]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
 (defn- reset-all [t]
-  (story/clear-all!)
-  (rf-registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (t))
 
 (use-fixtures :each reset-all)
@@ -60,18 +60,18 @@
   Mirrors the shape `re-frame.story.testbeds.counter-with-stories`
   registers at boot."
   []
-  (story/reg-story :story.bundle.counter {:doc "counter story" :tags #{:dev}})
-  (story/reg-variant :story.bundle.counter/empty  {:setup []      :tags #{:dev}})
-  (story/reg-variant :story.bundle.counter/loaded {:setup []      :tags #{:dev}})
-  (story/reg-variant :story.bundle.counter/three  {:setup []      :tags #{:test}})
-  (story/reg-story :story.bundle.login {:doc "login story" :tags #{:dev}})
-  (story/reg-variant :story.bundle.login/empty       {:setup []})
-  (story/reg-variant :story.bundle.login/submitting  {:setup []})
-  (story/reg-variant :story.bundle.login/authenticated {:setup []})
-  (story/reg-mode :Mode.bundle.theme/dark  {:axis :theme :args {:theme :dark}})
-  (story/reg-mode :Mode.bundle.theme/light {:axis :theme :args {:theme :light}})
-  (story/reg-mode :Mode.bundle.vp/mobile   {:axis :viewport :args {:viewport :mobile}})
-  (story/reg-workspace :Workspace.bundle/grid
+  (rf.story/reg-story :story.bundle.counter {:doc "counter story" :tags #{:dev}})
+  (rf.story/reg-variant :story.bundle.counter/empty  {:setup []      :tags #{:dev}})
+  (rf.story/reg-variant :story.bundle.counter/loaded {:setup []      :tags #{:dev}})
+  (rf.story/reg-variant :story.bundle.counter/three  {:setup []      :tags #{:test}})
+  (rf.story/reg-story :story.bundle.login {:doc "login story" :tags #{:dev}})
+  (rf.story/reg-variant :story.bundle.login/empty       {:setup []})
+  (rf.story/reg-variant :story.bundle.login/submitting  {:setup []})
+  (rf.story/reg-variant :story.bundle.login/authenticated {:setup []})
+  (rf.story/reg-mode :Mode.bundle.theme/dark  {:axis :theme :args {:theme :dark}})
+  (rf.story/reg-mode :Mode.bundle.theme/light {:axis :theme :args {:theme :light}})
+  (rf.story/reg-mode :Mode.bundle.vp/mobile   {:axis :viewport :args {:viewport :mobile}})
+  (rf.story/reg-workspace :Workspace.bundle/grid
     {:layout   :variants-grid
      :variants [:story.bundle.counter/empty
                 :story.bundle.counter/loaded
@@ -93,9 +93,9 @@
             the contract the shell relies on for sidebar → canvas
             navigation; broken would mean an empty canvas on click"
     (seed-bundle-like-registry!)
-    (let [vids   (story/ids :variant)
+    (let [vids   (rf.story/ids :variant)
           unresolved (filter (fn [vid]
-                               (nil? (story/handler-meta :variant vid)))
+                               (nil? (rf.story/handler-meta :variant vid)))
                              vids)]
       (is (seq vids)
           "the bundle carries at least one variant — fixture sanity")
@@ -109,8 +109,8 @@
             component) — an unresolvable parent would blank the canvas
             for every child"
     (seed-bundle-like-registry!)
-    (let [sids       (story/ids :story)
-          unresolved (filter #(nil? (story/handler-meta :story %)) sids)]
+    (let [sids       (rf.story/ids :story)
+          unresolved (filter #(nil? (rf.story/handler-meta :story %)) sids)]
       (is (seq sids))
       (is (= [] (vec unresolved))))))
 
@@ -119,8 +119,8 @@
             unresolvable mode id means a chip rendered with no :args
             payload, silently broken"
     (seed-bundle-like-registry!)
-    (let [mids       (story/list-modes)
-          unresolved (filter #(nil? (story/handler-meta :mode %)) mids)]
+    (let [mids       (rf.story/list-modes)
+          unresolved (filter #(nil? (rf.story/handler-meta :mode %)) mids)]
       (is (seq mids))
       (is (= [] (vec unresolved))))))
 
@@ -129,12 +129,12 @@
             each named id MUST resolve through the read surface. A
             broken ref would render a cell with no canvas content"
     (seed-bundle-like-registry!)
-    (let [wids (story/ids :workspace)]
+    (let [wids (rf.story/ids :workspace)]
       (doseq [wid wids]
-        (let [body  (story/handler-meta :workspace wid)
+        (let [body  (rf.story/handler-meta :workspace wid)
               vids  (or (:variants body) [])]
           (doseq [vid vids]
-            (is (story/registered? :variant vid)
+            (is (rf.story/registered? :variant vid)
                 (str "workspace " (pr-str wid)
                      " references variant " (pr-str vid)
                      " which does not resolve in the registry — broken cell ref"))))))))
@@ -146,14 +146,14 @@
             the cross-check the static-export bundle needs: (ids :kind)
             keyset must equal (keys (registrations :kind))"
     (seed-bundle-like-registry!)
-    (is (= (story/ids :variant)
-           (set (keys (story/registrations :variant))))
+    (is (= (rf.story/ids :variant)
+           (set (keys (rf.story/registrations :variant))))
         "ids ↔ registrations agree on the variant id-set")
-    (is (= (story/ids :story)
-           (set (keys (story/registrations :story))))
+    (is (= (rf.story/ids :story)
+           (set (keys (rf.story/registrations :story))))
         "ids ↔ registrations agree on the story id-set")
-    (is (= (story/list-modes)
-           (set (keys (story/registrations :mode))))
+    (is (= (rf.story/list-modes)
+           (set (keys (rf.story/registrations :mode))))
         "list-modes ↔ registrations agree on the mode id-set")))
 
 ;; ===========================================================================
@@ -174,8 +174,8 @@
             query parameter. Pinning the encode side of the contract;
             the decode side is exercised below"
     (seed-bundle-like-registry!)
-    (doseq [vid (story/ids :variant)]
-      (let [url (story/variant-share-url vid)]
+    (doseq [vid (rf.story/ids :variant)]
+      (let [url (rf.story/variant-share-url vid)]
         (is (string? url)
             (str "share URL for " (pr-str vid) " is a string"))
         (is (str/includes? url "variant=")
@@ -190,19 +190,19 @@
             silent escaping mismatch can leave a URL pointing at an
             unresolvable id"
     (seed-bundle-like-registry!)
-    (doseq [vid (story/ids :variant)]
-      (let [url      (story/variant-share-url vid)
+    (doseq [vid (rf.story/ids :variant)]
+      (let [url      (rf.story/variant-share-url vid)
             param    (some->> url
                               (re-find #"variant=([^&]+)")
                               second)
             decoded  (when param
                        (-> param
                            (java.net.URLDecoder/decode "UTF-8")
-                           share/parse-keyword-token))]
+                           rf.story.share/parse-keyword-token))]
         (is (= vid decoded)
             (str "variant id " (pr-str vid)
                  " round-trips through share URL → " (pr-str decoded)))
-        (is (story/registered? :variant decoded)
+        (is (rf.story/registered? :variant decoded)
             (str "decoded id " (pr-str decoded)
                  " resolves in the registry — no broken link"))))))
 
@@ -213,7 +213,7 @@
             silently loses fidelity. Pin the round-trip"
     (seed-bundle-like-registry!)
     (let [active-modes [:Mode.bundle.theme/dark :Mode.bundle.vp/mobile]
-          url     (story/variant-share-url
+          url     (rf.story/variant-share-url
                     :story.bundle.counter/empty
                     ""
                     {:active-modes active-modes})
@@ -224,14 +224,14 @@
                                (#(java.net.URLDecoder/decode % "UTF-8")))
           decoded (when modes-param
                     (->> (str/split modes-param #",")
-                         (map share/parse-keyword-token)
+                         (map rf.story.share/parse-keyword-token)
                          vec))]
       (is (seq decoded)
           "modes param decoded to a non-empty vector")
       (is (= (set active-modes) (set decoded))
           "encoded modes round-trip exactly")
       (doseq [mid decoded]
-        (is (story/registered? :mode mid)
+        (is (rf.story/registered? :mode mid)
             (str "decoded mode " (pr-str mid) " resolves in the registry"))))))
 
 (deftest share-url-rejects-unregistered-variant-as-broken-link
@@ -243,21 +243,21 @@
             back to 'no such variant' rather than rendering garbage"
     (seed-bundle-like-registry!)
     (let [stale-id :story.bundle.counter/this-was-renamed]
-      (is (not (story/registered? :variant stale-id))
+      (is (not (rf.story/registered? :variant stale-id))
           "the renamed id is not in the registry")
       ;; The share URL build still encodes whatever id you give it —
       ;; integrity is the BUILD's responsibility (only encode currently-
       ;; registered ids). At decode time the registered? check is the
       ;; integrity gate.
-      (let [url     (story/variant-share-url stale-id)
+      (let [url     (rf.story/variant-share-url stale-id)
             param   (some->> url
                              (re-find #"variant=([^&]+)")
                              second
                              (#(java.net.URLDecoder/decode % "UTF-8")))
-            decoded (share/parse-keyword-token param)]
+            decoded (rf.story.share/parse-keyword-token param)]
         (is (= stale-id decoded)
             "the URL still round-trips the id verbatim")
-        (is (not (story/registered? :variant decoded))
+        (is (not (rf.story/registered? :variant decoded))
             "but the registry check correctly reports the broken link
              — the shell's no-such-variant empty state engages")))))
 
@@ -277,7 +277,7 @@
             invariant data-test-variant selectors depend on — Playwright
             specs read the stamp's string and reconstruct the keyword"
     (seed-bundle-like-registry!)
-    (doseq [vid (story/ids :variant)]
+    (doseq [vid (rf.story/ids :variant)]
       (let [stamped (pr-str vid)
             parsed  (read-string stamped)]
         (is (= vid parsed)
@@ -287,7 +287,7 @@
   (testing "mode ids round-trip the same way — toolbar chips stamp the
             mode id into a data-toolbar-mode attribute"
     (seed-bundle-like-registry!)
-    (doseq [mid (story/list-modes)]
+    (doseq [mid (rf.story/list-modes)]
       (let [stamped (pr-str mid)
             parsed  (read-string stamped)]
         (is (= mid parsed)

--- a/tools/story/test/re_frame/story_teardown_test.clj
+++ b/tools/story/test/re_frame/story_teardown_test.clj
@@ -32,37 +32,37 @@
   (:require [clojure.string]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.machines         :as machines]
-            [re-frame.registrar        :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story            :as story]
-            [re-frame.story.async      :as async]
-            [re-frame.story.config     :as config]
-            [re-frame.story.frames     :as frames]
-            [re-frame.story.loaders    :as loaders]
-            [re-frame.story.play.runner-events :as runner-events]
-            [re-frame.story.schemas    :as schemas]
-            [re-frame.trace.tooling    :as trace-tooling]
+            [re-frame.frame            :as rf.frame]
+            [re-frame.machines         :as rf.machines]
+            [re-frame.registrar        :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story            :as rf.story]
+            [re-frame.story.async      :as rf.story.async]
+            [re-frame.story.config     :as rf.story.config]
+            [re-frame.story.frames     :as rf.story.frames]
+            [re-frame.story.loaders    :as rf.story.loaders]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]
+            [re-frame.story.schemas    :as rf.story.schemas]
+            [re-frame.trace.tooling    :as rf.trace.tooling]
             [malli.core                :as m]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
 (defn reset-all [test-fn]
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
   (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (config/set-global-args! {})
-  (reset! frames/stub-call-log {})
-  (reset! frames/allocated-decorator-stacks {})
-  (runner-events/clear-all-runs!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.config/set-global-args! {})
+  (reset! rf.story.frames/stub-call-log {})
+  (reset! rf.story.frames/allocated-decorator-stacks {})
+  (rf.story.play.runner-events/clear-all-runs!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (test-fn))
 
 (use-fixtures :each reset-all)
@@ -75,24 +75,24 @@
   (testing "a :frame-setup decorator body carrying only :teardown is valid
             — the schema's at-least-one-of guard counts :teardown as a
             satisfying slot. Symmetric with :init / :app-db-patch."
-    (is (m/validate schemas/Decorator
+    (is (m/validate rf.story.schemas/Decorator
                     {:kind :frame-setup :teardown [[:noop]]}))
-    (is (m/validate schemas/Decorator
+    (is (m/validate rf.story.schemas/Decorator
                     {:kind :frame-setup :init [[:setup]] :teardown [[:cleanup]]}))
-    (is (m/validate schemas/Decorator
+    (is (m/validate rf.story.schemas/Decorator
                     {:kind :frame-setup :app-db-patch {:x 1} :teardown [[:cleanup]]}))))
 
 (deftest schema-rejects-empty-frame-setup-body
   (testing "a :frame-setup body with NONE of :init / :app-db-patch /
             :teardown still fails — the at-least-one-of guard holds."
-    (is (not (m/validate schemas/Decorator {:kind :frame-setup})))))
+    (is (not (m/validate rf.story.schemas/Decorator {:kind :frame-setup})))))
 
 (deftest schema-rejects-non-vector-teardown
   (testing ":teardown must be a vector of event vectors — a bare keyword
             or a single event vector at the top level is invalid."
-    (is (not (m/validate schemas/Decorator
+    (is (not (m/validate rf.story.schemas/Decorator
                          {:kind :frame-setup :teardown :not-a-vector})))
-    (is (not (m/validate schemas/Decorator
+    (is (not (m/validate rf.story.schemas/Decorator
                          {:kind :frame-setup :teardown [:not-a-vector-of-vectors]})))))
 
 ;; ===========================================================================
@@ -105,21 +105,21 @@
     (let [fired (atom [])]
       (rf/reg-event :feed/close-socket
         (fn [{:keys [db]} _] (swap! fired conj :feed/close-socket) {:db db}))
-      (story/reg-decorator :feed/live-subscription
+      (rf.story/reg-decorator :feed/live-subscription
         {:kind     :frame-setup
          :init     [[:feed/noop-init]]
          :teardown [[:feed/close-socket]]})
       (rf/reg-event :feed/noop-init (fn [{:keys [db]} _] {:db db}))
-      (story/reg-variant :story.feed/teardown-fires
+      (rf.story/reg-variant :story.feed/teardown-fires
         {:decorators [[:feed/live-subscription]]
          :setup     []})
       ;; Allocate + destroy. The single :frame-setup decorator's
       ;; :teardown event must fire on destroy.
-      (async/deref-blocking
-        (story/run-variant :story.feed/teardown-fires) 5000)
+      (rf.story.async/deref-blocking
+        (rf.story/run-variant :story.feed/teardown-fires) 5000)
       (is (= [] @fired)
           "teardown has NOT fired yet — the variant is still live")
-      (story/destroy-variant! :story.feed/teardown-fires)
+      (rf.story/destroy-variant! :story.feed/teardown-fires)
       (is (= [:feed/close-socket] @fired)
           "teardown fired exactly once on destroy"))))
 
@@ -133,17 +133,17 @@
         (fn [{:keys [db]} _] (swap! fired conj :two) {:db db}))
       (rf/reg-event :step/three
         (fn [{:keys [db]} _] (swap! fired conj :three) {:db db}))
-      (story/reg-decorator :multi-step-teardown
+      (rf.story/reg-decorator :multi-step-teardown
         {:kind     :frame-setup
          :init     [[:step/noop]]
          :teardown [[:step/one] [:step/two] [:step/three]]})
       (rf/reg-event :step/noop (fn [{:keys [db]} _] {:db db}))
-      (story/reg-variant :story.feed/multi-step
+      (rf.story/reg-variant :story.feed/multi-step
         {:decorators [[:multi-step-teardown]]
          :setup     []})
-      (async/deref-blocking
-        (story/run-variant :story.feed/multi-step) 5000)
-      (story/destroy-variant! :story.feed/multi-step)
+      (rf.story.async/deref-blocking
+        (rf.story/run-variant :story.feed/multi-step) 5000)
+      (rf.story/destroy-variant! :story.feed/multi-step)
       (is (= [:one :two :three] @fired)
           "within one decorator, teardown events run in declared order"))))
 
@@ -162,20 +162,20 @@
         (fn [{:keys [db]} _] (swap! fired conj :outer) {:db db}))
       (rf/reg-event :inner/cleanup
         (fn [{:keys [db]} _] (swap! fired conj :inner) {:db db}))
-      (story/reg-decorator :outer-dec
+      (rf.story/reg-decorator :outer-dec
         {:kind :frame-setup :init [[:outer/noop]] :teardown [[:outer/cleanup]]})
-      (story/reg-decorator :inner-dec
+      (rf.story/reg-decorator :inner-dec
         {:kind :frame-setup :init [[:inner/noop]] :teardown [[:inner/cleanup]]})
       (rf/reg-event :outer/noop (fn [{:keys [db]} _] {:db db}))
       (rf/reg-event :inner/noop (fn [{:keys [db]} _] {:db db}))
-      (story/reg-story :story.teardown.order
+      (rf.story/reg-story :story.teardown.order
         {:decorators [[:outer-dec]]})
-      (story/reg-variant :story.teardown.order/v
+      (rf.story/reg-variant :story.teardown.order/v
         {:decorators [[:inner-dec]]
          :setup     []})
-      (async/deref-blocking
-        (story/run-variant :story.teardown.order/v) 5000)
-      (story/destroy-variant! :story.teardown.order/v)
+      (rf.story.async/deref-blocking
+        (rf.story/run-variant :story.teardown.order/v) 5000)
+      (rf.story/destroy-variant! :story.teardown.order/v)
       (is (= [:inner :outer] @fired)
           "reverse-declaration: innermost (variant-level :inner-dec)
            tears down BEFORE outermost (story-level :outer-dec).
@@ -190,18 +190,18 @@
         (fn [{:keys [db]} _] (swap! fired conj :a) {:db db}))
       (rf/reg-event :dec-b/cleanup
         (fn [{:keys [db]} _] (swap! fired conj :b) {:db db}))
-      (story/reg-decorator :dec-a
+      (rf.story/reg-decorator :dec-a
         {:kind :frame-setup :init [[:dec-a/noop]] :teardown [[:dec-a/cleanup]]})
-      (story/reg-decorator :dec-b
+      (rf.story/reg-decorator :dec-b
         {:kind :frame-setup :init [[:dec-b/noop]] :teardown [[:dec-b/cleanup]]})
       (rf/reg-event :dec-a/noop (fn [{:keys [db]} _] {:db db}))
       (rf/reg-event :dec-b/noop (fn [{:keys [db]} _] {:db db}))
-      (story/reg-variant :story.teardown.same-level/v
+      (rf.story/reg-variant :story.teardown.same-level/v
         {:decorators [[:dec-a] [:dec-b]]
          :setup     []})
-      (async/deref-blocking
-        (story/run-variant :story.teardown.same-level/v) 5000)
-      (story/destroy-variant! :story.teardown.same-level/v)
+      (rf.story.async/deref-blocking
+        (rf.story/run-variant :story.teardown.same-level/v) 5000)
+      (rf.story/destroy-variant! :story.teardown.same-level/v)
       (is (= [:b :a] @fired)
           "later-declared :dec-b tears down before earlier-declared :dec-a"))))
 
@@ -230,25 +230,25 @@
       (rf/reg-event :d2/init    (fn [{:keys [db]} _] {:db db}))
       (rf/reg-event :d1/cleanup (fn [{:keys [db]} _] (swap! fired conj :d1) {:db db}))
       (rf/reg-event :d2/cleanup (fn [{:keys [db]} _] (swap! fired conj :d2) {:db db}))
-      (story/reg-decorator :hot/d1
+      (rf.story/reg-decorator :hot/d1
         {:kind :frame-setup :init [[:d1/init]] :teardown [[:d1/cleanup]]})
-      (story/reg-decorator :hot/d2
+      (rf.story/reg-decorator :hot/d2
         {:kind :frame-setup :init [[:d2/init]] :teardown [[:d2/cleanup]]})
       ;; Allocate with D1 — its :init ran; the allocate-time stack is captured.
-      (story/reg-variant :story.hotdec/v
+      (rf.story/reg-variant :story.hotdec/v
         {:decorators [[:hot/d1]] :setup []})
-      (async/deref-blocking (story/run-variant :story.hotdec/v) 5000)
+      (rf.story.async/deref-blocking (rf.story/run-variant :story.hotdec/v) 5000)
       ;; HOT-RELOAD: the variant body now declares D2 instead of D1. The live
       ;; frame still carries D1's :init; only the registered body changed.
-      (story/reg-variant :story.hotdec/v
+      (rf.story/reg-variant :story.hotdec/v
         {:decorators [[:hot/d2]] :setup []})
       ;; Sanity: the CURRENT resolution IS D2 — exactly what the buggy
       ;; re-resolve-at-teardown would read (so this test is not vacuous).
       (is (= [:hot/d2]
-             (mapv :id (:frame-setup (story/resolve-decorators :story.hotdec/v))))
+             (mapv :id (:frame-setup (rf.story/resolve-decorators :story.hotdec/v))))
           "post-hot-reload resolve-decorators returns D2")
       ;; Destroy — teardown MUST use the allocate-time stack (D1), not D2.
-      (story/destroy-variant! :story.hotdec/v)
+      (rf.story/destroy-variant! :story.hotdec/v)
       (is (= [:d1] @fired)
           "teardown ran D1's :cleanup (the allocate-time :frame-setup set
            whose :init actually ran), NOT the re-resolved D2's"))))
@@ -263,19 +263,19 @@
             contract: teardown never aborts destroy-frame!"
     (rf/reg-event :boom/cleanup
       (fn [_ _] (throw (ex-info "teardown boom" {:why :test}))))
-    (story/reg-decorator :boom-dec
+    (rf.story/reg-decorator :boom-dec
       {:kind :frame-setup :init [[:boom/noop]] :teardown [[:boom/cleanup]]})
     (rf/reg-event :boom/noop (fn [{:keys [db]} _] {:db db}))
-    (story/reg-variant :story.teardown.boom/v
+    (rf.story/reg-variant :story.teardown.boom/v
       {:decorators [[:boom-dec]]
        :setup     []})
-    (async/deref-blocking
-      (story/run-variant :story.teardown.boom/v) 5000)
+    (rf.story.async/deref-blocking
+      (rf.story/run-variant :story.teardown.boom/v) 5000)
     ;; The destroy walk catches the exception. After destroy, the
     ;; variant frame is gone (rf/destroy-frame! ran).
-    (is (nil? (story/destroy-variant! :story.teardown.boom/v))
+    (is (nil? (rf.story/destroy-variant! :story.teardown.boom/v))
         "destroy-variant! returns nil — exception caught, walk completed")
-    (is (not (contains? (story/variant-frames) :story.teardown.boom/v))
+    (is (not (contains? (rf.story/variant-frames) :story.teardown.boom/v))
         "the frame is destroyed despite the teardown throw")))
 
 (deftest throwing-teardown-records-exception-assertion
@@ -298,9 +298,9 @@
         (fn [{:keys [db]} _]
           (reset! captured (:rf.story/assertions db))
           {:db db}))
-      (story/reg-decorator :boom-dec
+      (rf.story/reg-decorator :boom-dec
         {:kind :frame-setup :init [[:boom/noop]] :teardown [[:boom/cleanup]]})
-      (story/reg-decorator :probe-dec
+      (rf.story/reg-decorator :probe-dec
         {:kind :frame-setup
          :init [[:boom/noop]]
          :teardown [[::probe-snapshot]]})
@@ -308,14 +308,14 @@
       ;; means variant-level :boom-dec fires first; story-level
       ;; :probe-dec fires last — AFTER the boom's exception record has
       ;; landed on [:rf.story/assertions].
-      (story/reg-story :story.teardown.record
+      (rf.story/reg-story :story.teardown.record
         {:decorators [[:probe-dec]]})
-      (story/reg-variant :story.teardown.record/v
+      (rf.story/reg-variant :story.teardown.record/v
         {:decorators [[:boom-dec]]
          :setup     []})
-      (async/deref-blocking
-        (story/run-variant :story.teardown.record/v) 5000)
-      (story/destroy-variant! :story.teardown.record/v)
+      (rf.story.async/deref-blocking
+        (rf.story/run-variant :story.teardown.record/v) 5000)
+      (rf.story/destroy-variant! :story.teardown.record/v)
       (let [asserts @captured
             err     (first (filter #(= :rf.error/exception (:assertion %))
                                    asserts))]
@@ -344,23 +344,23 @@
             tears down cleanly — the walk is a no-op for that decorator"
     (rf/reg-event :seed/init
       (fn [{:keys [db]} _] {:db (assoc db :seeded? true)}))
-    (story/reg-decorator :seed-only
+    (rf.story/reg-decorator :seed-only
       {:kind :frame-setup :init [[:seed/init]]})
-    (story/reg-variant :story.teardown.none/v
+    (rf.story/reg-variant :story.teardown.none/v
       {:decorators [[:seed-only]]
        :setup     []})
-    (async/deref-blocking
-      (story/run-variant :story.teardown.none/v) 5000)
-    (is (nil? (story/destroy-variant! :story.teardown.none/v))
+    (rf.story.async/deref-blocking
+      (rf.story/run-variant :story.teardown.none/v) 5000)
+    (is (nil? (rf.story/destroy-variant! :story.teardown.none/v))
         "destroy returns nil — no-op teardown walk completes cleanly")
-    (is (not (contains? (story/variant-frames) :story.teardown.none/v))
+    (is (not (contains? (rf.story/variant-frames) :story.teardown.none/v))
         "frame still destroyed")))
 
 ;; ===========================================================================
 ;; RUN-STATE EVICTION — destroy-variant! clears the play-runner run-state
 ;;
-;; rf2-booyu CORRECTNESS: `runner-events/clear-state!` documented itself as
-;; "called from frame teardown" but was never wired into `frames/destroy!`,
+;; rf2-booyu CORRECTNESS: `rf.story.play.runner-events/clear-state!` documented itself as
+;; "called from frame teardown" but was never wired into `rf.story.frames/destroy!`,
 ;; so a destroyed variant frame leaked its per-frame run-state across the four
 ;; process-global atoms (run-state / runs-by-play / active-play /
 ;; step-boundaries). Over a long Story session (every hot-reload reset tears a
@@ -375,36 +375,36 @@
             per-frame run-state is gone from every process-global atom — no
             leak (rf2-booyu)"
     (rf/reg-event :rs/noop (fn [{:keys [db]} _] {:db db}))
-    (story/reg-variant :story.runstate/v
+    (rf.story/reg-variant :story.runstate/v
       {:setup      []
        :script [[:dispatch-sync [:rs/noop]]]})
-    (let [decorator-stack (story/resolve-decorators :story.runstate/v)]
+    (let [decorator-stack (rf.story/resolve-decorators :story.runstate/v)]
       ;; Drive the live-shell path: allocate the frame, then run the play via
       ;; the runner (the toolbar Re-run / auto-run path that populates
       ;; run-state).
-      (frames/allocate! :story.runstate/v decorator-stack)
-      (loaders/start-loaders! :story.runstate/v)
-      (loaders/finish-loaders! :story.runstate/v)
+      (rf.story.frames/allocate! :story.runstate/v decorator-stack)
+      (rf.story.loaders/start-loaders! :story.runstate/v)
+      (rf.story.loaders/finish-loaders! :story.runstate/v)
       (let [done (promise)]
-        (runner-events/run! :story.runstate/v (fn [_] (deliver done :ok)))
+        (rf.story.play.runner-events/run! :story.runstate/v (fn [_] (deliver done :ok)))
         (deref done 5000 :timeout))
-      (is (contains? @runner-events/run-state :story.runstate/v)
+      (is (contains? @rf.story.play.runner-events/run-state :story.runstate/v)
           "run-state populated by the run")
-      (is (contains? @runner-events/runs-by-play [:story.runstate/v nil])
+      (is (contains? @rf.story.play.runner-events/runs-by-play [:story.runstate/v nil])
           "runs-by-play populated by the run")
       ;; A single :script variant's active-play key is legitimately nil
       ;; (no :plays :name), so assert the ENTRY exists, not that the value is
       ;; non-nil.
-      (is (contains? @runner-events/active-play :story.runstate/v)
+      (is (contains? @rf.story.play.runner-events/active-play :story.runstate/v)
           "active-play populated by the run")
-      (story/destroy-variant! :story.runstate/v)
-      (is (not (contains? @runner-events/run-state :story.runstate/v))
+      (rf.story/destroy-variant! :story.runstate/v)
+      (is (not (contains? @rf.story.play.runner-events/run-state :story.runstate/v))
           "run-state evicted on destroy — no leak")
-      (is (not (contains? @runner-events/runs-by-play [:story.runstate/v nil]))
+      (is (not (contains? @rf.story.play.runner-events/runs-by-play [:story.runstate/v nil]))
           "runs-by-play evicted on destroy — no leak")
-      (is (not (contains? @runner-events/active-play :story.runstate/v))
+      (is (not (contains? @rf.story.play.runner-events/active-play :story.runstate/v))
           "active-play evicted on destroy — no leak")
-      (is (nil? (runner-events/settle-boundaries :story.runstate/v nil))
+      (is (nil? (rf.story.play.runner-events/settle-boundaries :story.runstate/v nil))
           "step-boundaries evicted on destroy — no leak"))))
 
 ;; ===========================================================================
@@ -426,22 +426,22 @@
     (let [live (atom #{})]
       ;; Instrument the trace-tooling registry so the test observes which
       ;; listener ids are live without reaching into its private atom.
-      (with-redefs [trace-tooling/register-listener!
+      (with-redefs [rf.trace.tooling/register-listener!
                     (fn [id f]
                       (swap! live conj id)
-                      (swap! @#'trace-tooling/listeners assoc id f)
+                      (swap! @#'rf.trace.tooling/listeners assoc id f)
                       id)
-                    trace-tooling/unregister-listener!
+                    rf.trace.tooling/unregister-listener!
                     (fn [id]
                       (swap! live disj id)
-                      (swap! @#'trace-tooling/listeners dissoc id)
+                      (swap! @#'rf.trace.tooling/listeners dissoc id)
                       nil)]
         (rf/reg-event :lst/noop (fn [{:keys [db]} _] {:db db}))
-        (story/reg-variant :story.listener/v {:setup [[:lst/noop]]})
-        (async/deref-blocking (story/run-variant :story.listener/v) 5000)
+        (rf.story/reg-variant :story.listener/v {:setup [[:lst/noop]]})
+        (rf.story.async/deref-blocking (rf.story/run-variant :story.listener/v) 5000)
         (is (some play-listener-id? @live)
             "run-variant installed the per-frame play trace listener")
-        (story/destroy-variant! :story.listener/v)
+        (rf.story/destroy-variant! :story.listener/v)
         (is (not-any? play-listener-id? @live)
             "destroy unregistered the play trace listener — no stale closure
              survives the frame lifecycle")))))
@@ -452,24 +452,24 @@
             second play trace listener; each run installs one and the prior
             is gone (rf2-294yq5.4)"
     (let [live (atom #{})]
-      (with-redefs [trace-tooling/register-listener!
+      (with-redefs [rf.trace.tooling/register-listener!
                     (fn [id f]
                       (swap! live conj id)
-                      (swap! @#'trace-tooling/listeners assoc id f)
+                      (swap! @#'rf.trace.tooling/listeners assoc id f)
                       id)
-                    trace-tooling/unregister-listener!
+                    rf.trace.tooling/unregister-listener!
                     (fn [id]
                       (swap! live disj id)
-                      (swap! @#'trace-tooling/listeners dissoc id)
+                      (swap! @#'rf.trace.tooling/listeners dissoc id)
                       nil)]
         (rf/reg-event :lst/noop2 (fn [{:keys [db]} _] {:db db}))
-        (story/reg-variant :story.listener2/v {:setup [[:lst/noop2]]})
-        (async/deref-blocking (story/run-variant :story.listener2/v) 5000)
-        (async/deref-blocking (story/run-variant :story.listener2/v) 5000)
+        (rf.story/reg-variant :story.listener2/v {:setup [[:lst/noop2]]})
+        (rf.story.async/deref-blocking (rf.story/run-variant :story.listener2/v) 5000)
+        (rf.story.async/deref-blocking (rf.story/run-variant :story.listener2/v) 5000)
         (is (= 1 (count (filter play-listener-id? @live)))
             "exactly one play trace listener is live after two runs — the
              fresh-run boundary destroyed the first run's frame (and its
              listener) before the second run installed its own")
-        (story/destroy-variant! :story.listener2/v)
+        (rf.story/destroy-variant! :story.listener2/v)
         (is (not-any? play-listener-id? @live)
             "and the final destroy clears it")))))

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -22,18 +22,18 @@
   `jvm_interop_must_work` user-feedback rule, every artefact that can
   run on the JVM should."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.story :as story]
-            [re-frame.story.canonical :as canonical]
-            [re-frame.story.config :as story-config]
-            [re-frame.story.plan :as plan]
-            [re-frame.story.registrar :as registrar]
-            [re-frame.story.schemas :as schemas]))
+            [re-frame.story :as rf.story]
+            [re-frame.story.canonical :as rf.story.canonical]
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.plan :as rf.story.plan]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.schemas :as rf.story.schemas]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
 (defn reset-story-registry [test-fn]
-  (story/clear-all!)
-  (story/install-canonical-vocabulary!)
+  (rf.story/clear-all!)
+  (rf.story/install-canonical-vocabulary!)
   (test-fn))
 
 (use-fixtures :each reset-story-registry)
@@ -45,34 +45,34 @@
   ;; paths validate against BEFORE interning. `variant-id?` delegates here,
   ;; so the keyword-level and string-level checks cannot drift.
   (testing "variant-id-shape? accepts a canonical :story.<path>/<name> decomposition"
-    (is (true? (schemas/variant-id-shape? ["story.button" "primary"])))
-    (is (true? (schemas/variant-id-shape? ["story" "primary"]))))
+    (is (true? (rf.story.schemas/variant-id-shape? ["story.button" "primary"])))
+    (is (true? (rf.story.schemas/variant-id-shape? ["story" "primary"]))))
   (testing "variant-id-shape? rejects a non-story namespace, a bare name, and an empty name"
-    (is (false? (schemas/variant-id-shape? ["not-story" "primary"])))
-    (is (false? (schemas/variant-id-shape? [nil "primary"])))
-    (is (false? (schemas/variant-id-shape? ["story.button" ""]))))
+    (is (false? (rf.story.schemas/variant-id-shape? ["not-story" "primary"])))
+    (is (false? (rf.story.schemas/variant-id-shape? [nil "primary"])))
+    (is (false? (rf.story.schemas/variant-id-shape? ["story.button" ""]))))
   (testing "variant-id? delegates to the string-shape check — they cannot drift"
-    (is (true?  (boolean (schemas/variant-id? :story.button/primary))))
-    (is (false? (boolean (schemas/variant-id? :not-story/primary))))
-    (is (= (schemas/variant-id? :story.button/primary)
-           (schemas/variant-id-shape? ["story.button" "primary"])))))
+    (is (true?  (boolean (rf.story.schemas/variant-id? :story.button/primary))))
+    (is (false? (boolean (rf.story.schemas/variant-id? :not-story/primary))))
+    (is (= (rf.story.schemas/variant-id? :story.button/primary)
+           (rf.story.schemas/variant-id-shape? ["story.button" "primary"])))))
 
 (deftest canonical-tags-installed
   (testing "the seven canonical inclusion tags + five canonical :state/* magnitude tags are registered after boot"
-    (let [expected (into schemas/canonical-tags schemas/canonical-state-tags)]
-      (is (= expected (story/list-tags)))
-      (is (every? #(story/registered? :tag %) schemas/canonical-tags))
-      (is (every? #(story/registered? :tag %) schemas/canonical-state-tags)))))
+    (let [expected (into rf.story.schemas/canonical-tags rf.story.schemas/canonical-state-tags)]
+      (is (= expected (rf.story/list-tags)))
+      (is (every? #(rf.story/registered? :tag %) rf.story.schemas/canonical-tags))
+      (is (every? #(rf.story/registered? :tag %) rf.story.schemas/canonical-state-tags)))))
 
 (deftest canonical-state-axis-installed
   (testing "the five :state/* tags carry the :state axis (rf2-k1k87)"
-    (let [by-axis (story/tags-by-axis :state)]
-      (is (= schemas/canonical-state-tags by-axis)))))
+    (let [by-axis (rf.story/tags-by-axis :state)]
+      (is (= rf.story.schemas/canonical-state-tags by-axis)))))
 
 ;; ---- auto-install on first reg-* call (rf2-p1ydc) ----------------------
 ;;
 ;; The canonical vocabulary auto-installs on the first `reg-*` runtime
-;; call so authors don't need a separate `(story/install-canonical-vocabulary!)`
+;; call so authors don't need a separate `(rf.story/install-canonical-vocabulary!)`
 ;; boot step. Spec: tools/story/spec/001-Authoring.md §Boot — auto-install
 ;; of the canonical vocabulary.
 ;;
@@ -82,114 +82,114 @@
 
 (deftest auto-install-fires-on-first-reg-story
   (testing "the first reg-story after clear-all! auto-installs the canonical vocabulary"
-    (story/clear-all!)
-    (is (false? @canonical/installed?) "the gate is reset by clear-all!")
-    (is (empty? (story/list-tags))     "the side-table is wiped")
+    (rf.story/clear-all!)
+    (is (false? @rf.story.canonical/installed?) "the gate is reset by clear-all!")
+    (is (empty? (rf.story/list-tags))     "the side-table is wiped")
     ;; The story body uses :tags #{:dev :docs} — without auto-install
     ;; this would raise :rf.error/unknown-tag. With auto-install, the
     ;; canonical tags are registered on the first reg-story call.
-    (story/reg-story :story.auto-install.probe
+    (rf.story/reg-story :story.auto-install.probe
       {:doc  "Auto-install probe."
        :tags #{:dev :docs}})
-    (is (true? @canonical/installed?) "the gate flips true after auto-install")
-    (is (= (into schemas/canonical-tags schemas/canonical-state-tags)
-           (story/list-tags))
+    (is (true? @rf.story.canonical/installed?) "the gate flips true after auto-install")
+    (is (= (into rf.story.schemas/canonical-tags rf.story.schemas/canonical-state-tags)
+           (rf.story/list-tags))
         "all seven canonical inclusion tags + five :state/* magnitude tags are registered post-auto-install")
-    (is (story/registered? :story :story.auto-install.probe))))
+    (is (rf.story/registered? :story :story.auto-install.probe))))
 
 (deftest auto-install-fires-on-first-reg-variant
   (testing "the first reg-variant after clear-all! also triggers auto-install"
-    (story/clear-all!)
-    (story/reg-variant :story.auto-install/v
+    (rf.story/clear-all!)
+    (rf.story/reg-variant :story.auto-install/v
       {:setup []
        :tags   #{:dev}})
-    (is (true? @canonical/installed?))
-    (is (story/registered? :variant :story.auto-install/v))
-    (is (every? #(story/registered? :tag %) schemas/canonical-tags))))
+    (is (true? @rf.story.canonical/installed?))
+    (is (rf.story/registered? :variant :story.auto-install/v))
+    (is (every? #(rf.story/registered? :tag %) rf.story.schemas/canonical-tags))))
 
 (deftest auto-install-fires-on-first-reg-tag
   (testing "the first reg-tag (project-tag) after clear-all! also triggers auto-install"
-    (story/clear-all!)
+    (rf.story/clear-all!)
     ;; A project tag — registering it should ALSO install the canonical
     ;; seven first, so subsequent variants tagged `:dev` still validate.
-    (story/reg-tag :auth/regression-set {:doc "Auth regression-suite."})
-    (is (story/registered? :tag :auth/regression-set))
-    (is (every? #(story/registered? :tag %) schemas/canonical-tags)
+    (rf.story/reg-tag :auth/regression-set {:doc "Auth regression-suite."})
+    (is (rf.story/registered? :tag :auth/regression-set))
+    (is (every? #(rf.story/registered? :tag %) rf.story.schemas/canonical-tags)
         "canonical tags ride along with the first reg-tag too")))
 
 (deftest auto-install-is-idempotent
   (testing "subsequent reg-* calls do NOT re-trigger the installer chain"
-    (story/clear-all!)
-    (story/reg-story :story.idem.a {:tags #{:dev}})
+    (rf.story/clear-all!)
+    (rf.story/reg-story :story.idem.a {:tags #{:dev}})
     ;; A subsequent registration must not break, must not re-install
     ;; (we observe idempotency indirectly: the side-table stays
     ;; consistent and no exception fires).
-    (let [tags-after-first (story/list-tags)]
-      (story/reg-story :story.idem.b {:tags #{:docs}})
-      (story/reg-variant :story.idem.a/v {:tags #{:dev} :setup []})
-      (is (= tags-after-first (story/list-tags))
+    (let [tags-after-first (rf.story/list-tags)]
+      (rf.story/reg-story :story.idem.b {:tags #{:docs}})
+      (rf.story/reg-variant :story.idem.a/v {:tags #{:dev} :setup []})
+      (is (= tags-after-first (rf.story/list-tags))
           "canonical tag set is stable across subsequent reg-* calls"))))
 
 (deftest explicit-install-after-auto-install-is-noop
   (testing "calling install-canonical-vocabulary! explicitly after auto-install fired is a no-op"
-    (story/clear-all!)
-    (story/reg-story :story.explicit.probe {:tags #{:dev}})
-    (let [tags-after-auto-install (story/list-tags)
-          decorators-after        (story/ids :decorator)]
+    (rf.story/clear-all!)
+    (rf.story/reg-story :story.explicit.probe {:tags #{:dev}})
+    (let [tags-after-auto-install (rf.story/list-tags)
+          decorators-after        (rf.story/ids :decorator)]
       ;; Explicit call lands on the already-true gate; install! flips
       ;; it true (already true) and re-runs the installer chain. Every
       ;; installer is documented idempotent, so the side-table snapshot
       ;; should be unchanged.
-      (story/install-canonical-vocabulary!)
-      (is (= tags-after-auto-install (story/list-tags)))
-      (is (= decorators-after (story/ids :decorator))))))
+      (rf.story/install-canonical-vocabulary!)
+      (is (= tags-after-auto-install (rf.story/list-tags)))
+      (is (= decorators-after (rf.story/ids :decorator))))))
 
 (deftest explicit-install-before-reg-suppresses-auto-install
   (testing "calling install-canonical-vocabulary! at boot suppresses the auto-install path"
     ;; Author who DOES make the explicit call (the v1 documented path)
     ;; still works: the gate is true when the first reg-* fires, so
     ;; the auto-install hook hits the early-return branch.
-    (story/clear-all!)
-    (story/install-canonical-vocabulary!)
-    (is (true? @canonical/installed?))
+    (rf.story/clear-all!)
+    (rf.story/install-canonical-vocabulary!)
+    (is (true? @rf.story.canonical/installed?))
     ;; The first reg-* must NOT throw and must NOT recompute the
     ;; installer chain (no easy direct probe — but no exception +
     ;; correct registry shape is the contract).
-    (story/reg-story :story.explicit-boot.probe {:tags #{:dev}})
-    (is (story/registered? :story :story.explicit-boot.probe))))
+    (rf.story/reg-story :story.explicit-boot.probe {:tags #{:dev}})
+    (is (rf.story/registered? :story :story.explicit-boot.probe))))
 
 (deftest clear-all-resets-auto-install-gate
   (testing "clear-all! resets the auto-install gate so the cycle can fire again"
-    (story/clear-all!)
-    (story/reg-story :story.gate-cycle.a {:tags #{:dev}})
-    (is (true? @canonical/installed?))
-    (story/clear-all!)
-    (is (false? @canonical/installed?))
+    (rf.story/clear-all!)
+    (rf.story/reg-story :story.gate-cycle.a {:tags #{:dev}})
+    (is (true? @rf.story.canonical/installed?))
+    (rf.story/clear-all!)
+    (is (false? @rf.story.canonical/installed?))
     ;; A second cycle works exactly like the first.
-    (story/reg-story :story.gate-cycle.b {:tags #{:docs}})
-    (is (true? @canonical/installed?))
-    (is (story/registered? :story :story.gate-cycle.b))
-    (is (every? #(story/registered? :tag %) schemas/canonical-tags))))
+    (rf.story/reg-story :story.gate-cycle.b {:tags #{:docs}})
+    (is (true? @rf.story.canonical/installed?))
+    (is (rf.story/registered? :story :story.gate-cycle.b))
+    (is (every? #(rf.story/registered? :tag %) rf.story.schemas/canonical-tags))))
 
 ;; ---- reg-story basic ----------------------------------------------------
 
 (deftest reg-story-basic
   (testing "reg-story writes to the side-table under :story kind"
-    (story/reg-story :story.ui.button
+    (rf.story/reg-story :story.ui.button
       {:doc       "Primary action button."
        :component :app.ui/button
        :args      {:label "Click me"}
        :tags      #{:dev :docs}})
-    (is (= #{:story.ui.button} (story/ids :story)))
-    (let [body (story/handler-meta :story :story.ui.button)]
+    (is (= #{:story.ui.button} (rf.story/ids :story)))
+    (let [body (rf.story/handler-meta :story :story.ui.button)]
       (is (= "Primary action button." (:doc body)))
       (is (= :app.ui/button (:component body)))
       (is (= {:label "Click me"} (:args body)))
       (is (= #{:dev :docs} (:tags body)))))
 
   (testing "source-coord is stamped onto the registered body"
-    (story/reg-story :story.ui.icon {:doc "Icon."})
-    (let [body (story/handler-meta :story :story.ui.icon)]
+    (rf.story/reg-story :story.ui.icon {:doc "Icon."})
+    (let [body (rf.story/handler-meta :story :story.ui.icon)]
       (is (map? (:source body)))
       (is (= 're-frame.story-test (:ns (:source body))))
       (is (integer? (:line (:source body)))))))
@@ -198,22 +198,22 @@
   (testing "reg-story rejects ids outside the :story.<path> grammar"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #":rf\.error/story-id-shape"
-                          (story/reg-story* :NotAStoryId {})))
+                          (rf.story/reg-story* :NotAStoryId {})))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #":rf\.error/story-id-shape"
-                          (story/reg-story* :foo.bar {})))))
+                          (rf.story/reg-story* :foo.bar {})))))
 
 (deftest reg-story-bad-shape
   (testing "reg-story rejects a body that violates the schema"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #":rf\.error/story-shape"
-                          (story/reg-story :story.ui.bad
+                          (rf.story/reg-story :story.ui.bad
                             {:tags "not-a-set"})))))
 
 (deftest reg-story-unknown-tag
   (testing "reg-story raises :rf.error/unknown-tag on an unregistered tag"
     (try
-      (story/reg-story :story.ui.bad {:tags #{:dev :totally-made-up}})
+      (rf.story/reg-story :story.ui.bad {:tags #{:dev :totally-made-up}})
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
         (is (= :rf.error/unknown-tag (:rf.error/id (ex-data e))))
@@ -223,24 +223,24 @@
 
 (deftest reg-variant-basic
   (testing "reg-variant writes a variant under :variant kind"
-    (story/reg-variant :story.ui.button/default
+    (rf.story/reg-variant :story.ui.button/default
       {:doc    "Default state."
        :setup [[:button/init]]
        :tags   #{:dev :docs}})
-    (let [body (story/handler-meta :variant :story.ui.button/default)]
+    (let [body (rf.story/handler-meta :variant :story.ui.button/default)]
       (is (= "Default state." (:doc body)))
       (is (= [[:button/init]] (:setup body)))
       (is (= #{:dev :docs} (:tags body)))))
 
   (testing "the variant body is EDN-round-trippable (no fn slots)"
-    (story/reg-variant :story.ui.button/edn-test
+    (rf.story/reg-variant :story.ui.button/edn-test
       {:doc    "EDN check."
        :setup [[:button/init]]
        :script [[:dispatch-sync [:button/click]]
                 [:dispatch-sync [:rf.assert/path-equals [:click] true]]]
        :args   {:label "Hi"}
        :tags   #{:dev}})
-    (let [body (story/handler-meta :variant :story.ui.button/edn-test)
+    (let [body (rf.story/handler-meta :variant :story.ui.button/edn-test)
           body (dissoc body :source)            ; :source is environment-derived
           edn  (pr-str body)
           round-tripped (read-string edn)]
@@ -254,20 +254,20 @@
             authority (rf2-f6z88, spec/017 §305-306). The side-table body
             keeps the child's own slots verbatim; the compiled plan
             inherits the parent's :decorators via [:world :decorators]."
-    (story/reg-variant :story.auth.login/loading
+    (rf.story/reg-variant :story.auth.login/loading
       {:setup     [[:auth/initialise]
                     [:auth/email-changed "alice@example.com"]
                     [:auth/login-pressed]]
        :decorators [[:force-fx-stub :http {:status :pending}]]
        :tags       #{:dev}})
-    (story/reg-variant :story.auth.login/loading-with-prefill
+    (rf.story/reg-variant :story.auth.login/loading-with-prefill
       {:extends :story.auth.login/loading
        :setup  [[:auth/initialise]
                  [:auth/email-changed "alice@example.com"]
                  [:auth/password-changed "hunter2"]
                  [:auth/login-pressed]]
        :tags    #{:dev :docs}})
-    (let [body (story/handler-meta :variant :story.auth.login/loading-with-prefill)]
+    (let [body (rf.story/handler-meta :variant :story.auth.login/loading-with-prefill)]
       (is (= :story.auth.login/loading (:extends body))
           ":extends is stored RAW — NOT stripped at registration")
       (is (= 4 (count (:setup body))) "child's own :setup stored verbatim")
@@ -278,7 +278,7 @@
     ;; The plan compiler resolves the chain: setup APPENDS, :decorators
     ;; inherit child-wins. The child declared no decorators, so it
     ;; inherits the parent's.
-    (let [plan (plan/variant-plan :story.auth.login/loading-with-prefill)]
+    (let [plan (rf.story.plan/variant-plan :story.auth.login/loading-with-prefill)]
       (is (= [[:force-fx-stub :http {:status :pending}]]
              (get-in plan [:world :decorators]))
           "compiled plan INHERITS the parent's :decorators"))))
@@ -290,15 +290,15 @@
             the compiler is the merge authority and walks the chain
             (spec/017 §305-306)."
     ;; Registration succeeds — the raw body is stored, :extends intact.
-    (story/reg-variant :story.auth.login/child
+    (rf.story/reg-variant :story.auth.login/child
       {:extends :story.auth.login/no-such-parent
        :setup  []})
     (is (= :story.auth.login/no-such-parent
-           (:extends (story/handler-meta :variant :story.auth.login/child)))
+           (:extends (rf.story/handler-meta :variant :story.auth.login/child)))
         "registration stores the raw body with the unknown parent intact")
     ;; Plan compile is where the unknown parent FAILS.
     (try
-      (plan/variant-plan :story.auth.login/child)
+      (rf.story.plan/variant-plan :story.auth.login/child)
       (is false "expected a plan-compile exception")
       (catch clojure.lang.ExceptionInfo e
         (is (= :rf.error/story-extends-unknown (:rf.error/id (ex-data e))))))))
@@ -318,7 +318,7 @@
 
 (deftest form-b-variants-desugar
   (testing "reg-story with :variants emits N reg-variant calls at expansion"
-    (story/reg-story :story.auth.login-form
+    (rf.story/reg-story :story.auth.login-form
       {:doc       "Login form."
        :component :app.auth/login-form
        :args      {:placeholder "you@example.com"}
@@ -329,17 +329,17 @@
                                                [:auth/email-changed "x"]
                                                [:auth/login-pressed]]
                                       :tags   #{:dev :docs :test}}}})
-    (is (story/registered? :story :story.auth.login-form))
-    (is (story/registered? :variant :story.auth.login-form/empty))
-    (is (story/registered? :variant :story.auth.login-form/validation-error))
+    (is (rf.story/registered? :story :story.auth.login-form))
+    (is (rf.story/registered? :variant :story.auth.login-form/empty))
+    (is (rf.story/registered? :variant :story.auth.login-form/validation-error))
     ;; :variants key is stripped from the parent body
-    (is (nil? (:variants (story/handler-meta :story :story.auth.login-form))))
+    (is (nil? (:variants (rf.story/handler-meta :story :story.auth.login-form))))
     ;; The two variants are independent registrations
-    (is (= 2 (count (story/variants-of :story.auth.login-form))))))
+    (is (= 2 (count (rf.story/variants-of :story.auth.login-form))))))
 
 (deftest form-b-desugars-to-separate-form-shape
   (testing "Form-B combined authoring produces the same registry bodies as explicit separate forms"
-    (story/reg-story :story.formb.combined
+    (rf.story/reg-story :story.formb.combined
       {:doc       "Combined story."
        :component :app.formb/view
        :args      {:label "parent"}
@@ -350,84 +350,84 @@
                    :busy {:setup [[:formb/init] [:formb/load]]
                           :args   {:state :busy}
                           :tags   #{:dev}}}})
-    (let [combined-story (dissoc (story/handler-meta :story :story.formb.combined)
+    (let [combined-story (dissoc (rf.story/handler-meta :story :story.formb.combined)
                                  :source)
-          combined-idle  (dissoc (story/handler-meta :variant :story.formb.combined/idle)
+          combined-idle  (dissoc (rf.story/handler-meta :variant :story.formb.combined/idle)
                                  :source)
-          combined-busy  (dissoc (story/handler-meta :variant :story.formb.combined/busy)
+          combined-busy  (dissoc (rf.story/handler-meta :variant :story.formb.combined/busy)
                                  :source)]
-      (story/clear-all!)
-      (story/install-canonical-vocabulary!)
-      (story/reg-story :story.formb.separate
+      (rf.story/clear-all!)
+      (rf.story/install-canonical-vocabulary!)
+      (rf.story/reg-story :story.formb.separate
         {:doc       "Combined story."
          :component :app.formb/view
          :args      {:label "parent"}
          :tags      #{:dev}})
-      (story/reg-variant :story.formb.separate/idle
+      (rf.story/reg-variant :story.formb.separate/idle
         {:setup [[:formb/init]]
          :args   {:state :idle}
          :tags   #{:dev :test}})
-      (story/reg-variant :story.formb.separate/busy
+      (rf.story/reg-variant :story.formb.separate/busy
         {:setup [[:formb/init] [:formb/load]]
          :args   {:state :busy}
          :tags   #{:dev}})
       (is (= combined-story
-             (dissoc (story/handler-meta :story :story.formb.separate) :source)))
+             (dissoc (rf.story/handler-meta :story :story.formb.separate) :source)))
       (is (= combined-idle
-             (dissoc (story/handler-meta :variant :story.formb.separate/idle) :source)))
+             (dissoc (rf.story/handler-meta :variant :story.formb.separate/idle) :source)))
       (is (= combined-busy
-             (dissoc (story/handler-meta :variant :story.formb.separate/busy) :source)))
+             (dissoc (rf.story/handler-meta :variant :story.formb.separate/busy) :source)))
       (is (= #{:story.formb.separate/idle :story.formb.separate/busy}
-             (story/variants-of :story.formb.separate))))))
+             (rf.story/variants-of :story.formb.separate))))))
 
 ;; ---- workspace ---------------------------------------------------------
 
 (deftest reg-workspace-grid
   (testing ":grid workspace requires :variants"
-    (story/reg-workspace :Workspace.Auth/all-states
+    (rf.story/reg-workspace :Workspace.Auth/all-states
       {:doc      "Auth states."
        :layout   :grid
        :variants [:story.auth.login/empty
                   :story.auth.login/loading]})
-    (is (story/registered? :workspace :Workspace.Auth/all-states))))
+    (is (rf.story/registered? :workspace :Workspace.Auth/all-states))))
 
 (deftest reg-workspace-prose
   (testing ":prose workspace requires :content"
-    (story/reg-workspace :Workspace.Auth/docs
+    (rf.story/reg-workspace :Workspace.Auth/docs
       {:doc     "Auth docs."
        :layout  :prose
        :content [{:type :prose   :body "## Auth flow"}
                  {:type :variant :id   :story.auth.login/empty}]})
-    (is (story/registered? :workspace :Workspace.Auth/docs))))
+    (is (rf.story/registered? :workspace :Workspace.Auth/docs))))
 
 (deftest reg-workspace-bad-layout
   (testing "a :grid workspace without :variants fails validation"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #":rf\.error/workspace-shape"
-                          (story/reg-workspace :Workspace.bad/empty
+                          (rf.story/reg-workspace :Workspace.bad/empty
                             {:layout :grid})))))
 
 ;; ---- mode --------------------------------------------------------------
 
 (deftest reg-mode-saved-tuple
   (testing "reg-mode stores an args tuple"
-    (story/reg-mode :Mode.app/dark-mobile
+    (rf.story/reg-mode :Mode.app/dark-mobile
       {:doc  "Dark theme on mobile."
        :args {:theme :dark :viewport :mobile}})
     (is (= {:theme :dark :viewport :mobile}
-           (:args (story/handler-meta :mode :Mode.app/dark-mobile))))
-    (is (contains? (story/list-modes) :Mode.app/dark-mobile))))
+           (:args (rf.story/handler-meta :mode :Mode.app/dark-mobile))))
+    (is (contains? (rf.story/list-modes) :Mode.app/dark-mobile))))
 
 ;; ---- story-panel -------------------------------------------------------
 
 (deftest reg-story-panel-xray-shape
   (testing "the canonical Xray embed registration (per 005-SOTA-Features.md §Xray epoch panel embed)"
-    (story/reg-story-panel :rf.story/xray-epoch
+    (rf.story/reg-story-panel :rf.story/xray-epoch
       {:doc       "Xray's epoch buffer."
        :title     "Epochs (Xray)"
        :placement :bottom
        :render    :day8.re-frame2-xray.panels.time-travel/Panel})
-    (let [body (story/handler-meta :story-panel :rf.story/xray-epoch)]
+    (let [body (rf.story/handler-meta :story-panel :rf.story/xray-epoch)]
       (is (= "Epochs (Xray)" (:title body)))
       (is (= :bottom (:placement body)))
       (is (= :day8.re-frame2-xray.panels.time-travel/Panel (:render body))))))
@@ -436,34 +436,34 @@
 
 (deftest reg-decorator-hiccup
   (testing ":hiccup decorator accepts a fn :wrap (only legal fn-slot)"
-    (story/reg-decorator :centered-layout
+    (rf.story/reg-decorator :centered-layout
       {:doc  "Centre the rendered content."
        :kind :hiccup
        :wrap (fn [body _args] [:div.centered body])})
-    (let [body (story/handler-meta :decorator :centered-layout)]
+    (let [body (rf.story/handler-meta :decorator :centered-layout)]
       (is (= :hiccup (:kind body)))
       (is (fn? (:wrap body))))))
 
 (deftest reg-decorator-frame-setup
   (testing ":frame-setup decorator requires :init or :app-db-patch"
-    (story/reg-decorator :mock-auth
+    (rf.story/reg-decorator :mock-auth
       {:doc  "Inject a mock auth user."
        :kind :frame-setup
        :init [[:auth/restore-session {:user "alice"}]]})
-    (is (= :frame-setup (:kind (story/handler-meta :decorator :mock-auth))))
+    (is (= :frame-setup (:kind (rf.story/handler-meta :decorator :mock-auth))))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #":rf\.error/decorator-shape"
-                          (story/reg-decorator :mock-empty
+                          (rf.story/reg-decorator :mock-empty
                             {:kind :frame-setup})))))
 
 (deftest reg-decorator-fx-override
   (testing ":fx-override decorator names the fx-id + canned response"
-    (story/reg-decorator :force-fx-stub
+    (rf.story/reg-decorator :force-fx-stub
       {:doc      "Stub :http for the variant's frame."
        :kind     :fx-override
        :fx-id    :http
        :response {:status :pending}})
-    (let [body (story/handler-meta :decorator :force-fx-stub)]
+    (let [body (rf.story/handler-meta :decorator :force-fx-stub)]
       (is (= :fx-override (:kind body)))
       (is (= :http (:fx-id body))))))
 
@@ -471,38 +471,38 @@
   (testing "decorator with an unknown :kind fails the schema"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #":rf\.error/decorator-shape"
-                          (story/reg-decorator :bad-kind
+                          (rf.story/reg-decorator :bad-kind
                             {:kind :no-such-kind})))))
 
 ;; ---- tag ---------------------------------------------------------------
 
 (deftest reg-tag-project-tag
   (testing "project tags can be registered and then used on variants"
-    (story/reg-tag :auth/regression-set
+    (rf.story/reg-tag :auth/regression-set
       {:doc "Auth regression-suite variants."})
-    (is (story/registered? :tag :auth/regression-set))
+    (is (rf.story/registered? :tag :auth/regression-set))
     ;; Now a variant tagged with it should validate
-    (story/reg-variant :story.auth.login/regression-empty
+    (rf.story/reg-variant :story.auth.login/regression-empty
       {:setup [[:auth/initialise]]
        :tags   #{:dev :auth/regression-set}})
-    (is (story/registered? :variant :story.auth.login/regression-empty))))
+    (is (rf.story/registered? :variant :story.auth.login/regression-empty))))
 
 ;; ---- :axis + :default-filter slots (rf2-frtec / SB9 parity) ------------
 
 (deftest reg-tag-stores-axis
   (testing ":axis is stored on the registered tag body"
-    (story/reg-tag :auth/regression-set
+    (rf.story/reg-tag :auth/regression-set
       {:doc  "Auth regression-suite variants."
        :axis :team})
-    (is (= :team (:axis (story/handler-meta :tag :auth/regression-set))))))
+    (is (= :team (:axis (rf.story/handler-meta :tag :auth/regression-set))))))
 
 (deftest reg-tag-stores-default-filter
   (testing ":default-filter is stored on the registered tag body"
-    (story/reg-tag :status/alpha
+    (rf.story/reg-tag :status/alpha
       {:doc            "Pre-release status."
        :axis           :status
        :default-filter :exclude})
-    (let [body (story/handler-meta :tag :status/alpha)]
+    (let [body (rf.story/handler-meta :tag :status/alpha)]
       (is (= :status (:axis body)))
       (is (= :exclude (:default-filter body))))))
 
@@ -513,48 +513,48 @@
     ;; absent from every non-:state axis-keyed lookup and the
     ;; default-excluded set. (The :state axis is populated by the rf2-k1k87
     ;; install-canonical-tags! extension and is covered separately.)
-    (is (= #{} (story/tags-by-axis :status)))
-    (is (= #{} (story/tags-by-axis :role)))
-    (is (= #{} (story/tags-default-excluded)))
+    (is (= #{} (rf.story/tags-by-axis :status)))
+    (is (= #{} (rf.story/tags-by-axis :role)))
+    (is (= #{} (rf.story/tags-default-excluded)))
     ;; The seven canonical INCLUSION tags live in the un-axis-grouped bucket.
     ;; (The :state/* tags carry :axis :state so they're NOT in tags-without-axis.)
-    (is (= schemas/canonical-tags (story/tags-without-axis)))))
+    (is (= rf.story.schemas/canonical-tags (rf.story/tags-without-axis)))))
 
 (deftest tags-by-axis-filters-correctly
   (testing "tags-by-axis returns only tags registered on the requested axis"
-    (story/reg-tag :status/alpha       {:axis :status :default-filter :exclude})
-    (story/reg-tag :status/beta        {:axis :status})
-    (story/reg-tag :role/dev           {:axis :role})
-    (story/reg-tag :auth/regression    {:axis :team})
-    (story/reg-tag :no-axis/freeform   {:doc "no axis here"})
-    (is (= #{:status/alpha :status/beta} (story/tags-by-axis :status)))
-    (is (= #{:role/dev}                  (story/tags-by-axis :role)))
-    (is (= #{:auth/regression}           (story/tags-by-axis :team)))
-    (is (= #{} (story/tags-by-axis :nonexistent)))
+    (rf.story/reg-tag :status/alpha       {:axis :status :default-filter :exclude})
+    (rf.story/reg-tag :status/beta        {:axis :status})
+    (rf.story/reg-tag :role/dev           {:axis :role})
+    (rf.story/reg-tag :auth/regression    {:axis :team})
+    (rf.story/reg-tag :no-axis/freeform   {:doc "no axis here"})
+    (is (= #{:status/alpha :status/beta} (rf.story/tags-by-axis :status)))
+    (is (= #{:role/dev}                  (rf.story/tags-by-axis :role)))
+    (is (= #{:auth/regression}           (rf.story/tags-by-axis :team)))
+    (is (= #{} (rf.story/tags-by-axis :nonexistent)))
     ;; un-axis-grouped tag sits in tags-without-axis alongside the canonical seven
-    (is (contains? (story/tags-without-axis) :no-axis/freeform))
-    (is (not (contains? (story/tags-by-axis :status) :no-axis/freeform)))))
+    (is (contains? (rf.story/tags-without-axis) :no-axis/freeform))
+    (is (not (contains? (rf.story/tags-by-axis :status) :no-axis/freeform)))))
 
 (deftest tags-default-excluded-filters-correctly
   (testing "tags-default-excluded returns only tags with :default-filter :exclude"
-    (story/reg-tag :status/alpha    {:axis :status :default-filter :exclude})
-    (story/reg-tag :status/beta     {:axis :status :default-filter :include})
-    (story/reg-tag :status/stable   {:axis :status})                ; no slot — defaults to include
-    (story/reg-tag :hidden/internal {:default-filter :exclude})
-    (is (= #{:status/alpha :hidden/internal} (story/tags-default-excluded)))))
+    (rf.story/reg-tag :status/alpha    {:axis :status :default-filter :exclude})
+    (rf.story/reg-tag :status/beta     {:axis :status :default-filter :include})
+    (rf.story/reg-tag :status/stable   {:axis :status})                ; no slot — defaults to include
+    (rf.story/reg-tag :hidden/internal {:default-filter :exclude})
+    (is (= #{:status/alpha :hidden/internal} (rf.story/tags-default-excluded)))))
 
 (deftest reg-tag-rejects-bad-default-filter
   (testing ":default-filter must be :include or :exclude"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #":rf\.error/tag-shape"
-                          (story/reg-tag :bad/df
+                          (rf.story/reg-tag :bad/df
                             {:default-filter :sometimes})))))
 
 (deftest reg-tag-rejects-non-keyword-axis
   (testing ":axis must be a keyword"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #":rf\.error/tag-shape"
-                          (story/reg-tag :bad/axis
+                          (rf.story/reg-tag :bad/axis
                             {:axis "status"})))))
 
 ;; ---- !-prefix removal syntax -------------------------------------------
@@ -564,16 +564,16 @@
     ;; A variant body's :tags may carry :!dev to remove :dev from the
     ;; inherited tag set. The registrar accepts these as long as the
     ;; base (un-prefixed) tag is registered.
-    (story/reg-variant :story.bang/test
+    (rf.story/reg-variant :story.bang/test
       {:setup []
        :tags   #{:!dev :docs}})
-    (is (story/registered? :variant :story.bang/test))))
+    (is (rf.story/registered? :variant :story.bang/test))))
 
 (deftest tags-with-bang-prefix-rejects-unknown
   (testing "the !-prefix variant rejects unknown base tags"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #":rf\.error/unknown-tag"
-                          (story/reg-variant :story.bang/bad
+                          (rf.story/reg-variant :story.bang/bad
                             {:setup []
                              :tags   #{:!totally-unknown}})))))
 
@@ -581,17 +581,17 @@
 
 (deftest variants-of-finds-children
   (testing "variants-of returns only the variants of the requested story"
-    (story/reg-variant :story.foo/a {:setup []})
-    (story/reg-variant :story.foo/b {:setup []})
-    (story/reg-variant :story.bar/c {:setup []})
-    (is (= #{:story.foo/a :story.foo/b} (story/variants-of :story.foo)))
-    (is (= #{:story.bar/c}              (story/variants-of :story.bar)))))
+    (rf.story/reg-variant :story.foo/a {:setup []})
+    (rf.story/reg-variant :story.foo/b {:setup []})
+    (rf.story/reg-variant :story.bar/c {:setup []})
+    (is (= #{:story.foo/a :story.foo/b} (rf.story/variants-of :story.foo)))
+    (is (= #{:story.bar/c}              (rf.story/variants-of :story.bar)))))
 
 (deftest variants-of-empty-when-no-children
   (testing "variants-of returns empty set when the story has no registered variants"
-    (is (= #{} (story/variants-of :story.no-variants)))
-    (story/reg-variant :story.other/x {:setup []})
-    (is (= #{} (story/variants-of :story.no-variants)))))
+    (is (= #{} (rf.story/variants-of :story.no-variants)))
+    (rf.story/reg-variant :story.other/x {:setup []})
+    (is (= #{} (rf.story/variants-of :story.no-variants)))))
 
 (deftest variants-of-rejects-nested-namespace
   (testing "variants-of must NOT return variants of a deeper-namespaced story
@@ -599,28 +599,28 @@
             `:story.foo.bar/x` was a structurally-suspect 'prefix match' of
             `:story.foo`. The namespace-equality check rules it out by
             construction."
-    (story/reg-variant :story.foo/a     {:setup []})
-    (story/reg-variant :story.foo.bar/x {:setup []})
-    (story/reg-variant :story.foo.bar/y {:setup []})
-    (is (= #{:story.foo/a}                       (story/variants-of :story.foo)))
-    (is (= #{:story.foo.bar/x :story.foo.bar/y}  (story/variants-of :story.foo.bar)))))
+    (rf.story/reg-variant :story.foo/a     {:setup []})
+    (rf.story/reg-variant :story.foo.bar/x {:setup []})
+    (rf.story/reg-variant :story.foo.bar/y {:setup []})
+    (is (= #{:story.foo/a}                       (rf.story/variants-of :story.foo)))
+    (is (= #{:story.foo.bar/x :story.foo.bar/y}  (rf.story/variants-of :story.foo.bar)))))
 
 (deftest variants-of-short-and-bare-story
   (testing "variants-of works for the bare `:story` root and short names"
-    (story/reg-variant :story/root {:setup []})
-    (story/reg-variant :story.a/v  {:setup []})
-    (is (= #{:story/root} (story/variants-of :story)))
-    (is (= #{:story.a/v}  (story/variants-of :story.a)))))
+    (rf.story/reg-variant :story/root {:setup []})
+    (rf.story/reg-variant :story.a/v  {:setup []})
+    (is (= #{:story/root} (rf.story/variants-of :story)))
+    (is (= #{:story.a/v}  (rf.story/variants-of :story.a)))))
 
 (deftest variants-by-story-single-pass-index
   (testing "variants-by-story builds a {story-id #{variant-ids}} index in one pass (rf2-d3iso)"
-    (story/reg-story   :story.foo {})
-    (story/reg-story   :story.bar {})
-    (story/reg-story   :story.empty {})
-    (story/reg-variant :story.foo/a {:setup []})
-    (story/reg-variant :story.foo/b {:setup []})
-    (story/reg-variant :story.bar/c {:setup []})
-    (let [idx (story/variants-by-story)]
+    (rf.story/reg-story   :story.foo {})
+    (rf.story/reg-story   :story.bar {})
+    (rf.story/reg-story   :story.empty {})
+    (rf.story/reg-variant :story.foo/a {:setup []})
+    (rf.story/reg-variant :story.foo/b {:setup []})
+    (rf.story/reg-variant :story.bar/c {:setup []})
+    (let [idx (rf.story/variants-by-story)]
       (is (= #{:story.foo/a :story.foo/b} (get idx :story.foo)))
       (is (= #{:story.bar/c}              (get idx :story.bar)))
       (is (= #{}                          (get idx :story.empty))
@@ -628,32 +628,32 @@
 
 (deftest variants-by-story-matches-variants-of
   (testing "variants-by-story's per-story slot matches `variants-of`'s output (rf2-d3iso)"
-    (story/reg-story   :story.aa {})
-    (story/reg-story   :story.bb {})
-    (story/reg-variant :story.aa/one   {:setup []})
-    (story/reg-variant :story.aa/two   {:setup []})
-    (story/reg-variant :story.bb/three {:setup []})
-    (let [idx (story/variants-by-story)]
+    (rf.story/reg-story   :story.aa {})
+    (rf.story/reg-story   :story.bb {})
+    (rf.story/reg-variant :story.aa/one   {:setup []})
+    (rf.story/reg-variant :story.aa/two   {:setup []})
+    (rf.story/reg-variant :story.bb/three {:setup []})
+    (let [idx (rf.story/variants-by-story)]
       (doseq [sid [:story.aa :story.bb]]
-        (is (= (story/variants-of sid) (get idx sid))
+        (is (= (rf.story/variants-of sid) (get idx sid))
             (str sid " — single-pass index must match the per-story scan"))))))
 
 (deftest variants-with-tags-intersection
   (testing "variants-with-tags returns variants whose :tags intersects the query"
-    (story/reg-variant :story.tag/a {:setup [] :tags #{:dev :test}})
-    (story/reg-variant :story.tag/b {:setup [] :tags #{:dev :docs}})
-    (story/reg-variant :story.tag/c {:setup [] :tags #{:test}})
-    (is (= #{:story.tag/a :story.tag/c} (story/variants-with-tags #{:test})))
-    (is (= #{:story.tag/a :story.tag/b} (story/variants-with-tags #{:docs :dev})))))
+    (rf.story/reg-variant :story.tag/a {:setup [] :tags #{:dev :test}})
+    (rf.story/reg-variant :story.tag/b {:setup [] :tags #{:dev :docs}})
+    (rf.story/reg-variant :story.tag/c {:setup [] :tags #{:test}})
+    (is (= #{:story.tag/a :story.tag/c} (rf.story/variants-with-tags #{:test})))
+    (is (= #{:story.tag/a :story.tag/b} (rf.story/variants-with-tags #{:docs :dev})))))
 
 (deftest variants-with-tags-excludes-marker-removed-inherited-tag
   (testing "rf2-n0vmq2 — a child that :extends a :dev-tagged parent and
             declares :!dev is EXCLUDED from the #{:dev} query (the inherited
             :dev was cancelled), while a sibling that keeps :dev is returned"
-    (story/reg-variant :story.rm/base  {:setup [] :tags #{:dev}})
-    (story/reg-variant :story.rm/child {:setup [] :extends :story.rm/base :tags #{:!dev}})
-    (story/reg-variant :story.rm/keeps {:setup [] :tags #{:dev}})
-    (let [hits (story/variants-with-tags #{:dev})]
+    (rf.story/reg-variant :story.rm/base  {:setup [] :tags #{:dev}})
+    (rf.story/reg-variant :story.rm/child {:setup [] :extends :story.rm/base :tags #{:!dev}})
+    (rf.story/reg-variant :story.rm/keeps {:setup [] :tags #{:dev}})
+    (let [hits (rf.story/variants-with-tags #{:dev})]
       (is (contains? hits :story.rm/base))
       (is (contains? hits :story.rm/keeps))
       (is (not (contains? hits :story.rm/child))
@@ -662,29 +662,29 @@
 (deftest variants-with-tags-matches-inherited-story-tag
   (testing "rf2-n0vmq2 — a variant that declares no tags inherits its parent
             story's :tags and is returned for a query on the inherited tag"
-    (story/reg-story   :story.inh {:tags #{:dev}})
-    (story/reg-variant :story.inh/v {:setup []})
-    (is (contains? (story/variants-with-tags #{:dev}) :story.inh/v))))
+    (rf.story/reg-story   :story.inh {:tags #{:dev}})
+    (rf.story/reg-variant :story.inh/v {:setup []})
+    (is (contains? (rf.story/variants-with-tags #{:dev}) :story.inh/v))))
 
 (deftest all-kinds-with-counts-reflects-state
   (testing "all-kinds-with-counts mirrors the side-table"
-    (story/reg-story   :story.x   {:doc "x"})
-    (story/reg-variant :story.x/v {:setup []})
-    (let [counts (story/all-kinds-with-counts)]
+    (rf.story/reg-story   :story.x   {:doc "x"})
+    (rf.story/reg-variant :story.x/v {:setup []})
+    (let [counts (rf.story/all-kinds-with-counts)]
       (is (= 1 (:story   counts)))
       (is (= 1 (:variant counts)))
-      (is (= (+ (count schemas/canonical-tags)
-                (count schemas/canonical-state-tags))
+      (is (= (+ (count rf.story.schemas/canonical-tags)
+                (count rf.story.schemas/canonical-state-tags))
              (:tag counts))))))
 
 ;; ---- variant->edn ----------------------------------------------------
 
 (deftest variant->edn-returns-body
   (testing "variant->edn returns the registered body verbatim"
-    (story/reg-variant :story.edn/x
+    (rf.story/reg-variant :story.edn/x
       {:setup [[:init]]
        :tags   #{:dev}})
-    (let [edn (story/variant->edn :story.edn/x)]
+    (let [edn (rf.story/variant->edn :story.edn/x)]
       (is (= [[:init]] (:setup edn)))
       (is (= #{:dev}    (:tags edn))))))
 
@@ -692,7 +692,7 @@
 
 (deftest config-flag-controls-expansion
   (testing "re-frame.story.config/enabled? is true at JVM-test time"
-    (is (true? story-config/enabled?))))
+    (is (true? rf.story.config/enabled?))))
 
 ;; ---- static-mode? (rf2-8wgpm) ----------------------------------------
 
@@ -701,7 +701,7 @@
     ;; Per tools/story/spec/013-Static-Build.md the JVM-side def is a
     ;; plain const false — JVM consumers never operate in static mode
     ;; (the flag exists for CLJS :advanced builds via :closure-defines).
-    (is (false? story-config/static-mode?)))
+    (is (false? rf.story.config/static-mode?)))
   (testing "the public probe (re-frame.story/static-mode?) reflects the flag"
     (is (false? (re-frame.story/static-mode?)))))
 
@@ -710,61 +710,61 @@
 (deftest mutation-tick-bumps-on-every-write
   (testing "every reg-* / unregister! / clear-* call bumps the tick;
             consumers caching registry-derived work key off this counter"
-    (let [t0 (registrar/current-mutation-tick)]
-      (story/reg-story :story.ui.tick {:doc "tick test"})
-      (is (> (registrar/current-mutation-tick) t0))
-      (let [t1 (registrar/current-mutation-tick)]
-        (story/reg-variant :story.ui.tick/v {:setup [[:init]]})
-        (is (> (registrar/current-mutation-tick) t1))
-        (let [t2 (registrar/current-mutation-tick)]
-          (registrar/unregister! :variant :story.ui.tick/v)
-          (is (> (registrar/current-mutation-tick) t2))
-          (let [t3 (registrar/current-mutation-tick)]
-            (registrar/clear-kind! :variant)
-            (is (> (registrar/current-mutation-tick) t3))))))))
+    (let [t0 (rf.story.registrar/current-mutation-tick)]
+      (rf.story/reg-story :story.ui.tick {:doc "tick test"})
+      (is (> (rf.story.registrar/current-mutation-tick) t0))
+      (let [t1 (rf.story.registrar/current-mutation-tick)]
+        (rf.story/reg-variant :story.ui.tick/v {:setup [[:init]]})
+        (is (> (rf.story.registrar/current-mutation-tick) t1))
+        (let [t2 (rf.story.registrar/current-mutation-tick)]
+          (rf.story.registrar/unregister! :variant :story.ui.tick/v)
+          (is (> (rf.story.registrar/current-mutation-tick) t2))
+          (let [t3 (rf.story.registrar/current-mutation-tick)]
+            (rf.story.registrar/clear-kind! :variant)
+            (is (> (rf.story.registrar/current-mutation-tick) t3))))))))
 
 (deftest mutation-tick-is-monotonic
   (testing "the tick only ever advances — never resets to a smaller value"
-    (let [t0 (registrar/current-mutation-tick)]
+    (let [t0 (rf.story.registrar/current-mutation-tick)]
       (dotimes [i 5]
-        (story/reg-variant (keyword (str "story.tick.mono/v" i))
+        (rf.story/reg-variant (keyword (str "story.tick.mono/v" i))
                            {:setup [[:init]]}))
-      (is (>= (registrar/current-mutation-tick) (+ t0 5))))))
+      (is (>= (rf.story.registrar/current-mutation-tick) (+ t0 5))))))
 
 (deftest variants-with-tags-memoised-on-mutation-tick
   (testing "variants-with-tags returns cached results between two registrar writes (rf2-c5nwl)"
-    (story/reg-tag :status/stable {:axis :status})
-    (story/reg-tag :role/dev      {:axis :role})
-    (story/reg-variant :story.memo/a {:tags #{:status/stable} :setup []})
-    (story/reg-variant :story.memo/b {:tags #{:role/dev}     :setup []})
-    (story/reg-variant :story.memo/c {:tags #{:status/stable :role/dev} :setup []})
-    (let [r1 (registrar/variants-with-tags #{:status/stable})
-          r2 (registrar/variants-with-tags #{:status/stable})]
+    (rf.story/reg-tag :status/stable {:axis :status})
+    (rf.story/reg-tag :role/dev      {:axis :role})
+    (rf.story/reg-variant :story.memo/a {:tags #{:status/stable} :setup []})
+    (rf.story/reg-variant :story.memo/b {:tags #{:role/dev}     :setup []})
+    (rf.story/reg-variant :story.memo/c {:tags #{:status/stable :role/dev} :setup []})
+    (let [r1 (rf.story.registrar/variants-with-tags #{:status/stable})
+          r2 (rf.story.registrar/variants-with-tags #{:status/stable})]
       (testing "same query between writes returns identical (cache-hit) set"
         (is (identical? r1 r2))
         (is (= #{:story.memo/a :story.memo/c} r1))))
     (testing "different query in same tick is also cached + correct"
-      (let [r-role (registrar/variants-with-tags #{:role/dev})]
+      (let [r-role (rf.story.registrar/variants-with-tags #{:role/dev})]
         (is (= #{:story.memo/b :story.memo/c} r-role))))
     (testing "registrar mutation invalidates the cache"
-      (story/reg-variant :story.memo/d {:tags #{:status/stable} :setup []})
-      (let [r3 (registrar/variants-with-tags #{:status/stable})]
+      (rf.story/reg-variant :story.memo/d {:tags #{:status/stable} :setup []})
+      (let [r3 (rf.story.registrar/variants-with-tags #{:status/stable})]
         (is (= #{:story.memo/a :story.memo/c :story.memo/d} r3))))))
 
 ;; ---- Public tag->axis-index API -------------------------------------
 
 (deftest public-tag-axis-index-no-axis-sentinel
-  (testing "story/tag->axis-index returns the ::no-axis sentinel for tags
+  (testing "rf.story/tag->axis-index returns the ::no-axis sentinel for tags
 without :axis (rf2-jlsvj — lock the public-API contract)"
-    (story/reg-tag :status/stable  {:axis :status})
-    (story/reg-tag :role/dev       {:axis :role})
-    (story/reg-tag :loose/freeform {:doc "no axis on this tag"})
-    (let [idx (story/tag->axis-index)]
+    (rf.story/reg-tag :status/stable  {:axis :status})
+    (rf.story/reg-tag :role/dev       {:axis :role})
+    (rf.story/reg-tag :loose/freeform {:doc "no axis on this tag"})
+    (let [idx (rf.story/tag->axis-index)]
       (is (map? idx))
       (testing "axis-bearing tags map to their axis"
         (is (= :status (get idx :status/stable)))
         (is (= :role   (get idx :role/dev))))
-      (testing "tags registered without :axis map to the registrar/no-axis sentinel"
+      (testing "tags registered without :axis map to the rf.story.registrar/no-axis sentinel"
         (is (= :re-frame.story.registrar/no-axis
                (get idx :loose/freeform))))
       (testing "canonical tags are pre-registered without :axis and bucket to no-axis"

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -17,35 +17,35 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.set :as set]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story :as story]
-            [re-frame.story.config :as story-config]
-            [re-frame.story.registrar :as story-registrar]
-            [re-frame.story.ui.canvas :as canvas]
-            [re-frame.story.ui.command-palette :as command-palette]
-            [re-frame.story.ui.command-palette.view :as command-palette-view]
-            [re-frame.story.ui.docs :as docs]
-            [re-frame.story.ui.state :as state]
-            [re-frame.story.ui.controls :as controls]
-            [re-frame.story.ui.sidebar :as sidebar]
-            [re-frame.story.ui.test-mode.pure :as test-mode-pure]
-            [re-frame.story.ui.test-mode.view :as test-mode-view]
-            [re-frame.story.ui.trace-buffer :as trace-buffer]
-            [re-frame.story.ui.workspace :as workspace]
-            [re-frame.trace.projection :as projection]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.ui.canvas :as rf.story.ui.canvas]
+            [re-frame.story.ui.command-palette :as rf.story.ui.command-palette]
+            [re-frame.story.ui.command-palette.view :as rf.story.ui.command-palette.view]
+            [re-frame.story.ui.docs :as rf.story.ui.docs]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.ui.controls :as rf.story.ui.controls]
+            [re-frame.story.ui.sidebar :as rf.story.ui.sidebar]
+            [re-frame.story.ui.test-mode.pure :as rf.story.ui.test-mode.pure]
+            [re-frame.story.ui.test-mode.view :as rf.story.ui.test-mode.view]
+            [re-frame.story.ui.trace-buffer :as rf.story.ui.trace-buffer]
+            [re-frame.story.ui.workspace :as rf.story.ui.workspace]
+            [re-frame.trace.projection :as rf.trace.projection]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-all! []
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!))
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!))
 
 (use-fixtures :each {:before reset-all!})
 
@@ -53,20 +53,20 @@
 
 (deftest mount-shell-fn-present
   (testing "mount-shell! / unmount-shell! / active-shell are public CLJS fns"
-    (is (fn? story/mount-shell!))
-    (is (fn? story/unmount-shell!))
-    (is (fn? story/active-shell))))
+    (is (fn? rf.story/mount-shell!))
+    (is (fn? rf.story/unmount-shell!))
+    (is (fn? rf.story/active-shell))))
 
 (deftest active-shell-starts-nil
   (testing "active-shell returns nil before any mount"
-    (is (nil? (story/active-shell)))))
+    (is (nil? (rf.story/active-shell)))))
 
 ;; ---- shell state transitions --------------------------------------------
 
 (deftest select-variant-roundtrip
   (testing "select-variant + swap-state! round-trips through the atom"
-    (state/swap-state! state/select-variant :story.foo/bar)
-    (is (= :story.foo/bar (:selected-variant (state/get-state))))))
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.foo/bar)
+    (is (= :story.foo/bar (:selected-variant (rf.story.ui.state/get-state))))))
 
 ;; rf2-hscut — variant-row click clears the workspace slot so workspace
 ;; mode is no longer a one-way door. `main-pane` in `shell.cljs` short-
@@ -80,76 +80,76 @@
 ;; fix codifies.
 (deftest variant-click-clears-workspace-rf2-hscut
   (testing "selecting a variant from the sidebar clears any selected workspace"
-    (state/swap-state! state/select-workspace :Workspace.nav/all)
-    (is (= :Workspace.nav/all (:selected-workspace (state/get-state))))
-    (state/swap-state!
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-workspace :Workspace.nav/all)
+    (is (= :Workspace.nav/all (:selected-workspace (rf.story.ui.state/get-state))))
+    (rf.story.ui.state/swap-state!
       (fn [s] (-> s
-                  (state/select-variant :story.nav/v1)
-                  (state/select-workspace nil))))
-    (is (= :story.nav/v1 (:selected-variant (state/get-state))))
-    (is (nil? (:selected-workspace (state/get-state)))))
+                  (rf.story.ui.state/select-variant :story.nav/v1)
+                  (rf.story.ui.state/select-workspace nil))))
+    (is (= :story.nav/v1 (:selected-variant (rf.story.ui.state/get-state))))
+    (is (nil? (:selected-workspace (rf.story.ui.state/get-state)))))
   (testing "mirror of workspace-row click — both row handlers are symmetric"
-    (state/swap-state! state/select-variant :story.nav/v1)
-    (state/swap-state!
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.nav/v1)
+    (rf.story.ui.state/swap-state!
       (fn [s] (-> s
-                  (state/select-workspace :Workspace.nav/all)
-                  (state/select-variant nil))))
-    (is (= :Workspace.nav/all (:selected-workspace (state/get-state))))
-    (is (nil? (:selected-variant (state/get-state))))))
+                  (rf.story.ui.state/select-workspace :Workspace.nav/all)
+                  (rf.story.ui.state/select-variant nil))))
+    (is (= :Workspace.nav/all (:selected-workspace (rf.story.ui.state/get-state))))
+    (is (nil? (:selected-variant (rf.story.ui.state/get-state))))))
 
 (deftest toggle-tag-filter-flips
   (testing "toggle-tag-filter adds + removes a tag"
-    (state/swap-state! state/toggle-tag-filter :dev)
-    (is (contains? (:tag-filter (state/get-state)) :dev))
-    (state/swap-state! state/toggle-tag-filter :dev)
-    (is (not (contains? (:tag-filter (state/get-state)) :dev)))))
+    (rf.story.ui.state/swap-state! rf.story.ui.state/toggle-tag-filter :dev)
+    (is (contains? (:tag-filter (rf.story.ui.state/get-state)) :dev))
+    (rf.story.ui.state/swap-state! rf.story.ui.state/toggle-tag-filter :dev)
+    (is (not (contains? (:tag-filter (rf.story.ui.state/get-state)) :dev)))))
 
 (deftest cell-overrides-roundtrip
   (testing "cell overrides write + clear cleanly"
-    (state/swap-state! state/set-cell-override-scalar :story.x/y :label "hi")
-    (is (= "hi" (get-in (state/get-state)
+    (rf.story.ui.state/swap-state! rf.story.ui.state/set-cell-override-scalar :story.x/y :label "hi")
+    (is (= "hi" (get-in (rf.story.ui.state/get-state)
                         [:cell-overrides :story.x/y :label])))
-    (state/swap-state! state/clear-cell-overrides :story.x/y)
-    (is (nil? (get-in (state/get-state)
+    (rf.story.ui.state/swap-state! rf.story.ui.state/clear-cell-overrides :story.x/y)
+    (is (nil? (get-in (rf.story.ui.state/get-state)
                       [:cell-overrides :story.x/y])))))
 
 ;; ---- command palette -----------------------------------------------------
 
 (deftest command-palette-shortcut-detection
   (testing "Cmd-K and Ctrl-K open the global palette"
-    (is (command-palette-view/shortcut-event?
+    (is (rf.story.ui.command-palette.view/shortcut-event?
           #js {:type "keydown" :key "k" :metaKey true}))
-    (is (command-palette-view/shortcut-event?
+    (is (rf.story.ui.command-palette.view/shortcut-event?
           #js {:type "keydown" :key "K" :ctrlKey true})))
   (testing "modified or unrelated keydowns do not open it"
-    (is (not (command-palette-view/shortcut-event?
+    (is (not (rf.story.ui.command-palette.view/shortcut-event?
                #js {:type "keydown" :key "k" :ctrlKey true :shiftKey true})))
-    (is (not (command-palette-view/shortcut-event?
+    (is (not (rf.story.ui.command-palette.view/shortcut-event?
                #js {:type "keyup" :key "k" :ctrlKey true})))))
 
 (deftest command-palette-selection-side-effects
   (testing "variant selection focuses a variant and clears workspace"
-    (state/swap-state! state/select-workspace :Workspace.cp/all)
-    (command-palette-view/select-entry! {:kind :variant :id :story.cp/empty})
-    (is (= :story.cp/empty (:selected-variant (state/get-state))))
-    (is (nil? (:selected-workspace (state/get-state)))))
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-workspace :Workspace.cp/all)
+    (rf.story.ui.command-palette.view/select-entry! {:kind :variant :id :story.cp/empty})
+    (is (= :story.cp/empty (:selected-variant (rf.story.ui.state/get-state))))
+    (is (nil? (:selected-workspace (rf.story.ui.state/get-state)))))
   (testing "workspace selection focuses a workspace and clears variant"
-    (state/swap-state! state/select-variant :story.cp/empty)
-    (command-palette-view/select-entry! {:kind :workspace :id :Workspace.cp/all})
-    (is (= :Workspace.cp/all (:selected-workspace (state/get-state))))
-    (is (nil? (:selected-variant (state/get-state)))))
+    (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.cp/empty)
+    (rf.story.ui.command-palette.view/select-entry! {:kind :workspace :id :Workspace.cp/all})
+    (is (= :Workspace.cp/all (:selected-workspace (rf.story.ui.state/get-state))))
+    (is (nil? (:selected-variant (rf.story.ui.state/get-state)))))
   (testing "story selection jumps to the first registered child variant"
-    (command-palette-view/select-entry!
+    (rf.story.ui.command-palette.view/select-entry!
       {:kind :story :id :story.cp :variant-ids [:story.cp/a :story.cp/b]})
-    (is (= :story.cp/a (:selected-variant (state/get-state)))))
+    (is (= :story.cp/a (:selected-variant (rf.story.ui.state/get-state)))))
   (testing "mode selection toggles the active mode"
-    (command-palette-view/select-entry! {:kind :mode :id :Mode.cp/dark})
-    (is (= [:Mode.cp/dark] (:active-modes (state/get-state))))))
+    (rf.story.ui.command-palette.view/select-entry! {:kind :mode :id :Mode.cp/dark})
+    (is (= [:Mode.cp/dark] (:active-modes (rf.story.ui.state/get-state))))))
 
 (deftest command-palette-search-roundtrip
   (testing "CLJS search path mirrors the JVM helper"
-    (let [results (command-palette/search
-                    (command-palette/entries
+    (let [results (rf.story.ui.command-palette/search
+                    (rf.story.ui.command-palette/entries
                       {:stories    {:story.cljs.cp {:doc "Shell docs"}}
                        :variants   {:story.cljs.cp/happy {:doc "Happy path"}}
                        :workspaces {}
@@ -162,74 +162,74 @@
 
 (deftest filter-variants-by-tag
   (testing "filter-variants returns matching subset"
-    (story/reg-variant :story.t/a {:tags #{:dev} :setup []})
-    (story/reg-variant :story.t/b {:tags #{:test} :setup []})
-    (let [vs   (story-registrar/registrations :variant)
-          devs (state/filter-variants vs #{:dev})]
+    (rf.story/reg-variant :story.t/a {:tags #{:dev} :setup []})
+    (rf.story/reg-variant :story.t/b {:tags #{:test} :setup []})
+    (let [vs   (rf.story.registrar/registrations :variant)
+          devs (rf.story.ui.state/filter-variants vs #{:dev})]
       (is (contains? devs :story.t/a))
       (is (not (contains? devs :story.t/b))))))
 
 (deftest group-variants-by-story
   (testing "group-variants-by-story builds the sidebar tree"
-    (story/reg-variant :story.a/x {:setup []})
-    (story/reg-variant :story.a/y {:setup []})
-    (story/reg-variant :story.b/z {:setup []})
-    (let [vs       (story-registrar/registrations :variant)
-          grouped  (state/group-variants-by-story vs)
+    (rf.story/reg-variant :story.a/x {:setup []})
+    (rf.story/reg-variant :story.a/y {:setup []})
+    (rf.story/reg-variant :story.b/z {:setup []})
+    (let [vs       (rf.story.registrar/registrations :variant)
+          grouped  (rf.story.ui.state/group-variants-by-story vs)
           by-story (into {} (map (juxt :story-id :variants) grouped))]
       (is (= 2 (count (get by-story :story.a))))
       (is (= 1 (count (get by-story :story.b)))))))
 
 (deftest sidebar-tag-collection
-  (testing "sidebar/collect-tags enumerates registered tags"
-    (story/reg-variant :story.tg/a {:tags #{:dev :test} :setup []})
-    (story/reg-variant :story.tg/b {:tags #{:dev :docs} :setup []})
-    (let [vs (story-registrar/registrations :variant)]
+  (testing "rf.story.ui.sidebar/collect-tags enumerates registered tags"
+    (rf.story/reg-variant :story.tg/a {:tags #{:dev :test} :setup []})
+    (rf.story/reg-variant :story.tg/b {:tags #{:dev :docs} :setup []})
+    (let [vs (rf.story.registrar/registrations :variant)]
       (is (= [:dev :docs :test]
-             (sidebar/collect-tags vs))))))
+             (rf.story.ui.sidebar/collect-tags vs))))))
 
 ;; ---- argtype inference ---------------------------------------------------
 
 (deftest argtype-inference
-  (testing "controls/infer-widget classifies primitive shapes"
-    (is (= :text    (:widget (controls/infer-widget :string))))
-    (is (= :number  (:widget (controls/infer-widget :int))))
-    (is (= :boolean (:widget (controls/infer-widget :boolean))))
-    (let [enum (controls/infer-widget [:enum :a :b :c])]
+  (testing "rf.story.ui.controls/infer-widget classifies primitive shapes"
+    (is (= :text    (:widget (rf.story.ui.controls/infer-widget :string))))
+    (is (= :number  (:widget (rf.story.ui.controls/infer-widget :int))))
+    (is (= :boolean (:widget (rf.story.ui.controls/infer-widget :boolean))))
+    (let [enum (rf.story.ui.controls/infer-widget [:enum :a :b :c])]
       (is (= :select (:widget enum)))
       (is (= [:a :b :c] (:options enum))))))
 
 (deftest argtype-resolution-from-variant
-  (testing "controls/resolve-argtypes inherits from args' value shapes"
-    (story/reg-variant :story.at/v
+  (testing "rf.story.ui.controls/resolve-argtypes inherits from args' value shapes"
+    (rf.story/reg-variant :story.at/v
       {:args   {:label "x" :n 1 :flag true}
        :setup []})
-    (let [t (controls/resolve-argtypes :story.at/v)]
+    (let [t (rf.story.ui.controls/resolve-argtypes :story.at/v)]
       (is (= :text    (:widget (get t :label))))
       (is (= :number  (:widget (get t :n))))
       (is (= :boolean (:widget (get t :flag)))))))
 
 (deftest argtype-control-to-widget-translation
-  (testing "controls/normalize-argtype-spec translates :control → :widget"
-    (is (= {:widget :text}     (controls/normalize-argtype-spec {:control :text})))
-    (is (= {:widget :textarea} (controls/normalize-argtype-spec {:control :textarea})))
+  (testing "rf.story.ui.controls/normalize-argtype-spec translates :control → :widget"
+    (is (= {:widget :text}     (rf.story.ui.controls/normalize-argtype-spec {:control :text})))
+    (is (= {:widget :textarea} (rf.story.ui.controls/normalize-argtype-spec {:control :textarea})))
     (is (= {:widget :select :options [:a :b]}
-           (controls/normalize-argtype-spec {:control :select :options [:a :b]}))))
+           (rf.story.ui.controls/normalize-argtype-spec {:control :select :options [:a :b]}))))
   (testing "normalize-argtype-spec is idempotent on :widget-keyed specs"
-    (is (= {:widget :date} (controls/normalize-argtype-spec {:widget :date}))))
+    (is (= {:widget :date} (rf.story.ui.controls/normalize-argtype-spec {:widget :date}))))
   (testing "non-map specs round-trip"
-    (is (= "doc" (controls/normalize-argtype-spec "doc")))
-    (is (nil?    (controls/normalize-argtype-spec nil))))
+    (is (= "doc" (rf.story.ui.controls/normalize-argtype-spec "doc")))
+    (is (nil?    (rf.story.ui.controls/normalize-argtype-spec nil))))
   (testing "resolve-argtypes honours the spec-canonical :control key"
     ;; Per /spec/007-Stories.md §argtypes — author writes :control;
     ;; renderer dispatches on :widget. Without the translation this
     ;; would fall through to the 'unsupported widget' span.
-    (story/reg-variant :story.argtypes/ctrl
+    (rf.story/reg-variant :story.argtypes/ctrl
       {:args     {:placeholder "ok" :flavor :primary}
        :argtypes {:placeholder {:control :textarea}
                   :flavor      {:control :select :options [:primary :secondary]}}
        :setup   []})
-    (let [t (controls/resolve-argtypes :story.argtypes/ctrl)]
+    (let [t (rf.story.ui.controls/resolve-argtypes :story.argtypes/ctrl)]
       (is (= :textarea (:widget (get t :placeholder))))
       (is (= :select   (:widget (get t :flavor))))
       (is (= [:primary :secondary] (:options (get t :flavor))))
@@ -240,7 +240,7 @@
 
 (deftest grid-layout-resolves
   (testing ":grid layout maps :variants to variant cells"
-    (let [cells (workspace/resolve-layout
+    (let [cells (rf.story.ui.workspace/resolve-layout
                   :Workspace.demo/x
                   {:layout :grid :variants [:story.a/x :story.b/y]})]
       (is (= 2 (count cells)))
@@ -249,9 +249,9 @@
 
 (deftest variants-grid-layout-enumerates-from-registry
   (testing ":variants-grid auto-enumerates the anchor story's variants"
-    (story/reg-variant :story.demo/a {:setup []})
-    (story/reg-variant :story.demo/b {:setup []})
-    (let [cells (workspace/resolve-layout
+    (rf.story/reg-variant :story.demo/a {:setup []})
+    (rf.story/reg-variant :story.demo/b {:setup []})
+    (let [cells (rf.story.ui.workspace/resolve-layout
                   :Workspace.demo/all-variants
                   {:layout :variants-grid})]
       (is (= 2 (count cells)))
@@ -259,7 +259,7 @@
 
 (deftest prose-layout-resolves
   (testing ":prose layout preserves content order, interleaving prose + variant"
-    (let [cells (workspace/resolve-layout
+    (let [cells (rf.story.ui.workspace/resolve-layout
                   :Workspace.guide/intro
                   {:layout :prose
                    :content [{:type :prose   :body "intro markdown"}
@@ -296,19 +296,19 @@
       {}
       (fn [_args]
         [:section {:data-test "rf2-zme7-view"} "rendered"]))
-    (story/reg-story :story.rf2-zme7
+    (rf.story/reg-story :story.rf2-zme7
       {:component :rf2-zme7/view
        :substrates #{:reagent}})
-    (story/reg-variant :story.rf2-zme7/v
+    (rf.story/reg-variant :story.rf2-zme7/v
       {:setup [[:rf2-zme7/init]]
        :substrates #{:reagent}})
-    (story/reg-workspace :Workspace.rf2-zme7/g
+    (rf.story/reg-workspace :Workspace.rf2-zme7/g
       {:layout   :grid
        :variants [:story.rf2-zme7/v]})
     ;; Render the workspace; walk the tree to confirm:
     ;;  (a) the variant id appears (cell title)
     ;;  (b) a `frame-provider` element wraps the view
-    (let [tree (workspace/workspace-view :Workspace.rf2-zme7/g)
+    (let [tree (rf.story.ui.workspace/workspace-view :Workspace.rf2-zme7/g)
           flat (tree-seq coll? seq tree)]
       (is (some #(= :story.rf2-zme7/v %) flat)
           "the variant id appears somewhere in the rendered tree")
@@ -324,7 +324,7 @@
 (deftest workspace-view-empty-for-missing-workspace
   (testing "workspace-view renders an empty / not-registered notice for
             an unregistered workspace id rather than throwing"
-    (let [tree (workspace/workspace-view :Workspace.does-not/exist)]
+    (let [tree (rf.story.ui.workspace/workspace-view :Workspace.does-not/exist)]
       (is (vector? tree))
       (is (boolean (some #(and (string? %)
                                (re-find #"not registered" %))
@@ -379,14 +379,14 @@
   (testing ":grid layout cells use variant-id-derived React keys so
             React mounts fresh cells when a workspace swap changes the
             variant set (per rf2-kgn0c)"
-    (story/reg-variant :story.rf2-kgn0c.a/x {:setup []})
-    (story/reg-variant :story.rf2-kgn0c.a/y {:setup []})
-    (story/reg-variant :story.rf2-kgn0c.b/p {:setup []})
-    (story/reg-variant :story.rf2-kgn0c.b/q {:setup []})
-    (story/reg-workspace :Workspace.rf2-kgn0c.a/grid
+    (rf.story/reg-variant :story.rf2-kgn0c.a/x {:setup []})
+    (rf.story/reg-variant :story.rf2-kgn0c.a/y {:setup []})
+    (rf.story/reg-variant :story.rf2-kgn0c.b/p {:setup []})
+    (rf.story/reg-variant :story.rf2-kgn0c.b/q {:setup []})
+    (rf.story/reg-workspace :Workspace.rf2-kgn0c.a/grid
       {:layout   :grid
        :variants [:story.rf2-kgn0c.a/x :story.rf2-kgn0c.a/y]})
-    (story/reg-workspace :Workspace.rf2-kgn0c.b/grid
+    (rf.story/reg-workspace :Workspace.rf2-kgn0c.b/grid
       {:layout   :grid
        :variants [:story.rf2-kgn0c.b/p :story.rf2-kgn0c.b/q]})
     ;; rf2-ba86n.18 — the `:grid` branch now mounts the capped-grid
@@ -395,7 +395,7 @@
     ;; cell tree, then walk for variant-id keys.
     (let [render  (fn [ws-id]
                     (let [{renderer :fn cells :cells args :args}
-                          (find-tabs-renderer-call (workspace/workspace-view ws-id))]
+                          (find-tabs-renderer-call (rf.story.ui.workspace/workspace-view ws-id))]
                       (apply renderer cells args)))
           keys-a  (collect-cell-keys (render :Workspace.rf2-kgn0c.a/grid))
           keys-b  (collect-cell-keys (render :Workspace.rf2-kgn0c.b/grid))]
@@ -414,18 +414,18 @@
 (deftest workspace-variants-grid-cells-key-on-variant-id-rf2-kgn0c
   (testing ":variants-grid layout cells use variant-id-derived React
             keys (the layout the Phase 1b smoke triggered the bug on)"
-    (story/reg-variant :story.rf2-kgn0c-vg.a/x {:setup []})
-    (story/reg-variant :story.rf2-kgn0c-vg.a/y {:setup []})
-    (story/reg-variant :story.rf2-kgn0c-vg.b/p {:setup []})
-    (story/reg-workspace :Workspace.rf2-kgn0c-vg.a/all
+    (rf.story/reg-variant :story.rf2-kgn0c-vg.a/x {:setup []})
+    (rf.story/reg-variant :story.rf2-kgn0c-vg.a/y {:setup []})
+    (rf.story/reg-variant :story.rf2-kgn0c-vg.b/p {:setup []})
+    (rf.story/reg-workspace :Workspace.rf2-kgn0c-vg.a/all
       {:layout :variants-grid})
-    (story/reg-workspace :Workspace.rf2-kgn0c-vg.b/all
+    (rf.story/reg-workspace :Workspace.rf2-kgn0c-vg.b/all
       {:layout :variants-grid})
     ;; rf2-ba86n.18 — isolated `:variants-grid` also mounts the capped-grid
     ;; renderer; extract + invoke its inner fn to reach the cell tree.
     (let [render  (fn [ws-id]
                     (let [{renderer :fn cells :cells args :args}
-                          (find-tabs-renderer-call (workspace/workspace-view ws-id))]
+                          (find-tabs-renderer-call (rf.story.ui.workspace/workspace-view ws-id))]
                       (apply renderer cells args)))
           keys-a  (collect-cell-keys (render :Workspace.rf2-kgn0c-vg.a/all))
           keys-b  (collect-cell-keys (render :Workspace.rf2-kgn0c-vg.b/all))]
@@ -440,11 +440,11 @@
   (testing "the workspace's root <section> carries a workspace-id-derived
             React key so any swap unmounts the whole subtree as a
             belt-and-braces guard alongside per-cell keys"
-    (story/reg-variant :story.rf2-kgn0c-root/v {:setup []})
-    (story/reg-workspace :Workspace.rf2-kgn0c-root/g
+    (rf.story/reg-variant :story.rf2-kgn0c-root/v {:setup []})
+    (rf.story/reg-workspace :Workspace.rf2-kgn0c-root/g
       {:layout   :grid
        :variants [:story.rf2-kgn0c-root/v]})
-    (let [tree (workspace/workspace-view :Workspace.rf2-kgn0c-root/g)
+    (let [tree (rf.story.ui.workspace/workspace-view :Workspace.rf2-kgn0c-root/g)
           k    (:key (meta tree))]
       (is (string? k))
       (is (re-find #"rf2-kgn0c-root" k)
@@ -527,15 +527,15 @@
             falling through to the grid pipeline (per rf2-ktnl8 — pre-
             fix `:tabs` collapsed to grid and rendered every cell
             simultaneously)"
-    (story/reg-variant :story.rf2-ktnl8/a {:setup []})
-    (story/reg-variant :story.rf2-ktnl8/b {:setup []})
-    (story/reg-variant :story.rf2-ktnl8/c {:setup []})
-    (story/reg-workspace :Workspace.rf2-ktnl8/t
+    (rf.story/reg-variant :story.rf2-ktnl8/a {:setup []})
+    (rf.story/reg-variant :story.rf2-ktnl8/b {:setup []})
+    (rf.story/reg-variant :story.rf2-ktnl8/c {:setup []})
+    (rf.story/reg-workspace :Workspace.rf2-ktnl8/t
       {:layout   :tabs
        :variants [:story.rf2-ktnl8/a
                   :story.rf2-ktnl8/b
                   :story.rf2-ktnl8/c]})
-    (let [tree (workspace/workspace-view :Workspace.rf2-ktnl8/t)]
+    (let [tree (rf.story.ui.workspace/workspace-view :Workspace.rf2-ktnl8/t)]
       (is (boolean (some #(and (string? %)
                                (re-find #"\(tabs\)" %))
                          (tree-seq coll? seq tree)))
@@ -548,16 +548,16 @@
   (testing "tabs-renderer mounts ONLY the active tab's variant-cell —
             simultaneous-render bleed (rf2-ktnl8) cannot occur because
             non-active cells are not present in the rendered tree"
-    (story/reg-variant :story.rf2-ktnl8.only/a {:setup []})
-    (story/reg-variant :story.rf2-ktnl8.only/b {:setup []})
-    (story/reg-variant :story.rf2-ktnl8.only/c {:setup []})
-    (story/reg-workspace :Workspace.rf2-ktnl8.only/t
+    (rf.story/reg-variant :story.rf2-ktnl8.only/a {:setup []})
+    (rf.story/reg-variant :story.rf2-ktnl8.only/b {:setup []})
+    (rf.story/reg-variant :story.rf2-ktnl8.only/c {:setup []})
+    (rf.story/reg-workspace :Workspace.rf2-ktnl8.only/t
       {:layout   :tabs
        :variants [:story.rf2-ktnl8.only/a
                   :story.rf2-ktnl8.only/b
                   :story.rf2-ktnl8.only/c]})
     (let [{:keys [fn cells]} (find-tabs-renderer-call
-                               (workspace/workspace-view
+                               (rf.story.ui.workspace/workspace-view
                                  :Workspace.rf2-ktnl8.only/t))
           rendered            (fn cells)
           n                   (count-variant-cells-in rendered)]
@@ -570,16 +570,16 @@
 (deftest tabs-renderer-emits-button-per-variant-rf2-ktnl8
   (testing "tabs-renderer renders a tab strip with one tab button per
             variant — the UI affordance for switching tabs"
-    (story/reg-variant :story.rf2-ktnl8.btn/a {:setup []})
-    (story/reg-variant :story.rf2-ktnl8.btn/b {:setup []})
-    (story/reg-variant :story.rf2-ktnl8.btn/c {:setup []})
-    (story/reg-workspace :Workspace.rf2-ktnl8.btn/t
+    (rf.story/reg-variant :story.rf2-ktnl8.btn/a {:setup []})
+    (rf.story/reg-variant :story.rf2-ktnl8.btn/b {:setup []})
+    (rf.story/reg-variant :story.rf2-ktnl8.btn/c {:setup []})
+    (rf.story/reg-workspace :Workspace.rf2-ktnl8.btn/t
       {:layout   :tabs
        :variants [:story.rf2-ktnl8.btn/a
                   :story.rf2-ktnl8.btn/b
                   :story.rf2-ktnl8.btn/c]})
     (let [{:keys [fn cells]} (find-tabs-renderer-call
-                               (workspace/workspace-view
+                               (rf.story.ui.workspace/workspace-view
                                  :Workspace.rf2-ktnl8.btn/t))
           rendered (fn cells)
           buttons  (tab-buttons-in rendered)
@@ -602,14 +602,14 @@
             gallery_chrome.cljs happens because simultaneous cells
             mount the SAME view in the SAME render tree; if only ONE
             cell mounts at a time, the bleed cannot occur.)"
-    (story/reg-variant :story.rf2-ktnl8.iso/a {:setup []})
-    (story/reg-variant :story.rf2-ktnl8.iso/b {:setup []})
-    (story/reg-workspace :Workspace.rf2-ktnl8.iso/t
+    (rf.story/reg-variant :story.rf2-ktnl8.iso/a {:setup []})
+    (rf.story/reg-variant :story.rf2-ktnl8.iso/b {:setup []})
+    (rf.story/reg-workspace :Workspace.rf2-ktnl8.iso/t
       {:layout   :tabs
        :variants [:story.rf2-ktnl8.iso/a
                   :story.rf2-ktnl8.iso/b]})
     (let [{:keys [fn cells]} (find-tabs-renderer-call
-                               (workspace/workspace-view
+                               (rf.story.ui.workspace/workspace-view
                                  :Workspace.rf2-ktnl8.iso/t))
           rendered  (fn cells)
           ;; Use a hash-set of namespaced keywords found anywhere in
@@ -630,16 +630,16 @@
 (deftest tabs-renderer-buttons-carry-onclick-and-aria-rf2-ktnl8
   (testing "each tab button carries an on-click (the switch affordance)
             and aria-selected reflecting the active tab"
-    (story/reg-variant :story.rf2-ktnl8.aria/a {:setup []})
-    (story/reg-variant :story.rf2-ktnl8.aria/b {:setup []})
-    (story/reg-variant :story.rf2-ktnl8.aria/c {:setup []})
-    (story/reg-workspace :Workspace.rf2-ktnl8.aria/t
+    (rf.story/reg-variant :story.rf2-ktnl8.aria/a {:setup []})
+    (rf.story/reg-variant :story.rf2-ktnl8.aria/b {:setup []})
+    (rf.story/reg-variant :story.rf2-ktnl8.aria/c {:setup []})
+    (rf.story/reg-workspace :Workspace.rf2-ktnl8.aria/t
       {:layout   :tabs
        :variants [:story.rf2-ktnl8.aria/a
                   :story.rf2-ktnl8.aria/b
                   :story.rf2-ktnl8.aria/c]})
     (let [{:keys [fn cells]} (find-tabs-renderer-call
-                               (workspace/workspace-view
+                               (rf.story.ui.workspace/workspace-view
                                  :Workspace.rf2-ktnl8.aria/t))
           rendered (fn cells)
           buttons  (tab-buttons-in rendered)
@@ -660,14 +660,14 @@
             `r/with-let` re-allocates bindings on each non-React call),
             so this test pins the handler's structural invariant: it
             is callable, takes no args, and does not throw."
-    (story/reg-variant :story.rf2-ktnl8.click/a {:setup []})
-    (story/reg-variant :story.rf2-ktnl8.click/b {:setup []})
-    (story/reg-workspace :Workspace.rf2-ktnl8.click/t
+    (rf.story/reg-variant :story.rf2-ktnl8.click/a {:setup []})
+    (rf.story/reg-variant :story.rf2-ktnl8.click/b {:setup []})
+    (rf.story/reg-workspace :Workspace.rf2-ktnl8.click/t
       {:layout   :tabs
        :variants [:story.rf2-ktnl8.click/a
                   :story.rf2-ktnl8.click/b]})
     (let [{:keys [fn cells]} (find-tabs-renderer-call
-                               (workspace/workspace-view
+                               (rf.story.ui.workspace/workspace-view
                                  :Workspace.rf2-ktnl8.click/t))
           tree    (fn cells)
           buttons (tab-buttons-in tree)
@@ -684,15 +684,15 @@
             that the two layouts mount different numbers of cells.
             Without this guard a future refactor could silently re-
             collapse `:tabs` to `:grid` (the rf2-ktnl8 starting state)."
-    (story/reg-variant :story.rf2-ktnl8.gt/a {:setup []})
-    (story/reg-variant :story.rf2-ktnl8.gt/b {:setup []})
-    (story/reg-variant :story.rf2-ktnl8.gt/c {:setup []})
-    (story/reg-workspace :Workspace.rf2-ktnl8.gt/grid
+    (rf.story/reg-variant :story.rf2-ktnl8.gt/a {:setup []})
+    (rf.story/reg-variant :story.rf2-ktnl8.gt/b {:setup []})
+    (rf.story/reg-variant :story.rf2-ktnl8.gt/c {:setup []})
+    (rf.story/reg-workspace :Workspace.rf2-ktnl8.gt/grid
       {:layout :grid
        :variants [:story.rf2-ktnl8.gt/a
                   :story.rf2-ktnl8.gt/b
                   :story.rf2-ktnl8.gt/c]})
-    (story/reg-workspace :Workspace.rf2-ktnl8.gt/tabs
+    (rf.story/reg-workspace :Workspace.rf2-ktnl8.gt/tabs
       {:layout :tabs
        :variants [:story.rf2-ktnl8.gt/a
                   :story.rf2-ktnl8.gt/b
@@ -702,12 +702,12 @@
     ;; cap, so all three render and the layout-difference contract holds).
     (let [{grid-fn :fn grid-cells :cells grid-args :args}
                      (find-tabs-renderer-call
-                       (workspace/workspace-view :Workspace.rf2-ktnl8.gt/grid))
+                       (rf.story.ui.workspace/workspace-view :Workspace.rf2-ktnl8.gt/grid))
           grid-tree  (apply grid-fn grid-cells grid-args)
           grid-n     (count-variant-cells-in grid-tree)
           {tabs-fn :fn tabs-cells :cells}
                      (find-tabs-renderer-call
-                       (workspace/workspace-view :Workspace.rf2-ktnl8.gt/tabs))
+                       (rf.story.ui.workspace/workspace-view :Workspace.rf2-ktnl8.gt/tabs))
           tabs-tree  (tabs-fn tabs-cells)
           tabs-n     (count-variant-cells-in tabs-tree)]
       (is (= 3 grid-n)
@@ -747,16 +747,16 @@
   and invoke it to get the rendered hiccup tree."
   [ws-id]
   (let [{renderer :fn cells :cells args :args}
-        (find-tabs-renderer-call (workspace/workspace-view ws-id))]
+        (find-tabs-renderer-call (rf.story.ui.workspace/workspace-view ws-id))]
     (apply renderer cells args)))
 
 (deftest workspace-grid-columns-pins-fixed-template-rf2-ugmrg
   (testing ":grid with :columns N emits a fixed repeat(N, …) template —
             pre-fix this slot was silently ignored (rf2-ugmrg)"
-    (story/reg-variant :story.ugmrg-cols/a {:setup []})
-    (story/reg-variant :story.ugmrg-cols/b {:setup []})
-    (story/reg-variant :story.ugmrg-cols/c {:setup []})
-    (story/reg-workspace :Workspace.ugmrg-cols/grid
+    (rf.story/reg-variant :story.ugmrg-cols/a {:setup []})
+    (rf.story/reg-variant :story.ugmrg-cols/b {:setup []})
+    (rf.story/reg-variant :story.ugmrg-cols/c {:setup []})
+    (rf.story/reg-workspace :Workspace.ugmrg-cols/grid
       {:layout   :grid
        :columns  3
        :variants [:story.ugmrg-cols/a
@@ -773,9 +773,9 @@
   (testing ":grid without :columns keeps the responsive auto-fit default
             (rf2-ugmrg — :columns is opt-in; absent it must not change
             existing behaviour)"
-    (story/reg-variant :story.ugmrg-auto/a {:setup []})
-    (story/reg-variant :story.ugmrg-auto/b {:setup []})
-    (story/reg-workspace :Workspace.ugmrg-auto/grid
+    (rf.story/reg-variant :story.ugmrg-auto/a {:setup []})
+    (rf.story/reg-variant :story.ugmrg-auto/b {:setup []})
+    (rf.story/reg-workspace :Workspace.ugmrg-auto/grid
       {:layout   :grid
        :variants [:story.ugmrg-auto/a
                   :story.ugmrg-auto/b]})
@@ -789,9 +789,9 @@
 (deftest workspace-variants-grid-columns-pins-fixed-template-rf2-ugmrg
   (testing "isolated :variants-grid honours :columns too (same capped-grid
             renderer; rf2-ugmrg)"
-    (story/reg-variant :story.ugmrg-vg/a {:setup []})
-    (story/reg-variant :story.ugmrg-vg/b {:setup []})
-    (story/reg-workspace :Workspace.ugmrg-vg/all
+    (rf.story/reg-variant :story.ugmrg-vg/a {:setup []})
+    (rf.story/reg-variant :story.ugmrg-vg/b {:setup []})
+    (rf.story/reg-workspace :Workspace.ugmrg-vg/all
       {:layout  :variants-grid
        :for     :story.ugmrg-vg
        :columns 2})
@@ -826,7 +826,7 @@
 ;; interactions are not clobbered.
 
 (deftest run-key-detects-cell-overrides-change-rf2-c56hr
-  (testing "canvas/run-key flips when the shell's :cell-overrides for
+  (testing "rf.story.ui.canvas/run-key flips when the shell's :cell-overrides for
             the variant changes — the workspace cell's trigger MUST see
             this transition (per rf2-c56hr; the prior :hot-reload-tick-
             only key missed it)"
@@ -836,37 +836,37 @@
                    :cell-overrides  {}
                    :substrate       :reagent}
           shell-1 (assoc-in shell-0 [:cell-overrides vid :label] "edited")
-          k0      (canvas/run-key shell-0 vid)
-          k1      (canvas/run-key shell-1 vid)]
+          k0      (rf.story.ui.canvas/run-key shell-0 vid)
+          k1      (rf.story.ui.canvas/run-key shell-1 vid)]
       (is (not= k0 k1)
           "writing a per-variant override MUST yield a distinct run-key")
       (is (= "edited" (get-in k1 [:cell-overrides :label]))
           "the override value is carried through the run-key slice"))))
 
 (deftest run-key-detects-active-modes-change-rf2-c56hr
-  (testing "canvas/run-key flips when chrome-level :active-modes change
+  (testing "rf.story.ui.canvas/run-key flips when chrome-level :active-modes change
             — the workspace cell MUST re-seed on mode toggle"
     (let [vid     :story.rf2-c56hr.am/v
           shell-0 {:hot-reload-tick 0 :active-modes []
                    :cell-overrides {} :substrate :reagent}
           shell-1 (assoc shell-0 :active-modes [:Mode.x/dark])
-          k0      (canvas/run-key shell-0 vid)
-          k1      (canvas/run-key shell-1 vid)]
+          k0      (rf.story.ui.canvas/run-key shell-0 vid)
+          k1      (rf.story.ui.canvas/run-key shell-1 vid)]
       (is (not= k0 k1)))))
 
 (deftest run-key-detects-substrate-change-rf2-c56hr
-  (testing "canvas/run-key flips when the host substrate changes — the
+  (testing "rf.story.ui.canvas/run-key flips when the host substrate changes — the
             workspace cell MUST re-seed on substrate flip"
     (let [vid     :story.rf2-c56hr.sb/v
           shell-0 {:hot-reload-tick 0 :active-modes []
                    :cell-overrides {} :substrate :reagent}
           shell-1 (assoc shell-0 :substrate :uix)
-          k0      (canvas/run-key shell-0 vid)
-          k1      (canvas/run-key shell-1 vid)]
+          k0      (rf.story.ui.canvas/run-key shell-0 vid)
+          k1      (rf.story.ui.canvas/run-key shell-1 vid)]
       (is (not= k0 k1)))))
 
 (deftest run-key-stable-across-ordinary-app-db-renders-rf2-c56hr
-  (testing "canvas/run-key stays equal when nothing in the watched slice
+  (testing "rf.story.ui.canvas/run-key stays equal when nothing in the watched slice
             changes — guarantees an inc-click re-render does NOT clobber
             the variant's :events-seeded state. Pins the rf2-c56hr fix
             against an over-eager future change that would re-seed on
@@ -876,15 +876,15 @@
                    :cell-overrides {} :substrate :reagent
                    :other-unrelated-slot "anything"}
           shell-1 (assoc shell-0 :other-unrelated-slot "changed")
-          k0      (canvas/run-key shell-0 vid)
-          k1      (canvas/run-key shell-1 vid)]
+          k0      (rf.story.ui.canvas/run-key shell-0 vid)
+          k1      (rf.story.ui.canvas/run-key shell-1 vid)]
       (is (= k0 k1)
           (str "run-key MUST be stable when only non-watched shell "
                "slots change; got k0=" (pr-str k0)
                " k1=" (pr-str k1))))))
 
 (deftest run-key-detects-hot-reload-tick-change-rf2-c56hr
-  (testing "canvas/run-key still flips on :hot-reload-tick — the new
+  (testing "rf.story.ui.canvas/run-key still flips on :hot-reload-tick — the new
             workspace cell trigger MUST preserve the legacy tick-driven
             re-run path on top of the three previously-missed
             transitions"
@@ -892,12 +892,12 @@
           shell-0 {:hot-reload-tick 0 :active-modes []
                    :cell-overrides {} :substrate :reagent}
           shell-1 (assoc shell-0 :hot-reload-tick 1)
-          k0      (canvas/run-key shell-0 vid)
-          k1      (canvas/run-key shell-1 vid)]
+          k0      (rf.story.ui.canvas/run-key shell-0 vid)
+          k1      (rf.story.ui.canvas/run-key shell-1 vid)]
       (is (not= k0 k1)))))
 ;; ---- controls repeater stable React keys (rf2-c8kfy) --------------------
 ;;
-;; Pre-fix, `controls/repeater-widget` keyed each row positionally
+;; Pre-fix, `rf.story.ui.controls/repeater-widget` keyed each row positionally
 ;; (`^{:key i}`). Deleting a middle entry shifted every surviving row's
 ;; key up by one — React reused the original DOM node at each position
 ;; with the next entry's value, so an input that had focus / cursor at
@@ -963,9 +963,9 @@
             (`r:<id>`) — NOT on its positional index. The keys MUST be
             namespaced with the `r:` prefix to consistently shape with
             rf2-kgn0c / rf2-z4fza / rf2-c56hr."
-    (state/swap-state! state/set-cell-override
+    (rf.story.ui.state/swap-state! rf.story.ui.state/set-cell-override
                        :story.c8kfy/v [:items] ["a" "b" "c"])
-    (let [tree (controls/arg-widget
+    (let [tree (rf.story.ui.controls/arg-widget
                  :story.c8kfy/v [:items]
                  ["a" "b" "c"]
                  {:widget :repeater :kind :vector
@@ -987,9 +987,9 @@
             preserved (rather than leaking from row [i+1] onto row [i]
             with the old DOM node)."
     ;; Initial render against a 4-entry repeater.
-    (state/swap-state! state/set-cell-override
+    (rf.story.ui.state/swap-state! rf.story.ui.state/set-cell-override
                        :story.c8kfy/v [:items] ["a" "b" "c" "d"])
-    (let [tree-before (controls/arg-widget
+    (let [tree-before (rf.story.ui.controls/arg-widget
                         :story.c8kfy/v [:items]
                         ["a" "b" "c" "d"]
                         {:widget :repeater :kind :vector
@@ -999,11 +999,11 @@
       ;; Simulate the user clicking [-] on row index 1 (the second
       ;; entry). The widget calls `remove-repeater-row-id` then
       ;; updates the entries vector via `on-change-at-path`.
-      (state/swap-state! state/remove-repeater-row-id
+      (rf.story.ui.state/swap-state! rf.story.ui.state/remove-repeater-row-id
                          :story.c8kfy/v [:items] 1)
-      (state/swap-state! state/set-cell-override
+      (rf.story.ui.state/swap-state! rf.story.ui.state/set-cell-override
                          :story.c8kfy/v [:items] ["a" "c" "d"])
-      (let [tree-after (controls/arg-widget
+      (let [tree-after (rf.story.ui.controls/arg-widget
                         :story.c8kfy/v [:items]
                         ["a" "c" "d"]
                         {:widget :repeater :kind :vector
@@ -1024,9 +1024,9 @@
   (testing "after appending an entry the new row carries a FRESH id
             not seen on any pre-existing row — React mounts a fresh
             DOM node rather than reusing a stale one"
-    (state/swap-state! state/set-cell-override
+    (rf.story.ui.state/swap-state! rf.story.ui.state/set-cell-override
                        :story.c8kfy.add/v [:items] ["a" "b"])
-    (let [tree-before (controls/arg-widget
+    (let [tree-before (rf.story.ui.controls/arg-widget
                         :story.c8kfy.add/v [:items]
                         ["a" "b"]
                         {:widget :repeater :kind :vector
@@ -1034,11 +1034,11 @@
           keys-before (collect-repeater-row-keys tree-before)]
       (is (= 2 (count keys-before)))
       ;; Simulate [+]: append id + extend entries vector.
-      (state/swap-state! state/append-repeater-row-id
+      (rf.story.ui.state/swap-state! rf.story.ui.state/append-repeater-row-id
                          :story.c8kfy.add/v [:items])
-      (state/swap-state! state/set-cell-override
+      (rf.story.ui.state/swap-state! rf.story.ui.state/set-cell-override
                          :story.c8kfy.add/v [:items] ["a" "b" ""])
-      (let [tree-after (controls/arg-widget
+      (let [tree-after (rf.story.ui.controls/arg-widget
                         :story.c8kfy.add/v [:items]
                         ["a" "b" ""]
                         {:widget :repeater :kind :vector
@@ -1059,7 +1059,7 @@
             order — so the keys are stable across edits regardless of
             re-sort."
     ;; First render syncs 3 ids for a 3-element set.
-    (let [tree-1 (controls/arg-widget
+    (let [tree-1 (rf.story.ui.controls/arg-widget
                    :story.c8kfy.set/v [:tags]
                    #{"alpha" "beta" "gamma"}
                    {:widget :repeater :kind :set
@@ -1067,7 +1067,7 @@
           keys-1 (collect-repeater-row-keys tree-1)
           ;; Second render against the same set — keys MUST match
           ;; exactly (same count, same ids).
-          tree-2 (controls/arg-widget
+          tree-2 (rf.story.ui.controls/arg-widget
                    :story.c8kfy.set/v [:tags]
                    #{"alpha" "beta" "gamma"}
                    {:widget :repeater :kind :set
@@ -1084,7 +1084,7 @@
             (Tuple positions don't reshuffle — the focus-leak class
             doesn't fire — but uniform key shape across the file pins
             the convention.)"
-    (let [tree (controls/arg-widget
+    (let [tree (rf.story.ui.controls/arg-widget
                  :story.c8kfy.tup/v [:pair]
                  ["x" 42]
                  {:widget :tuple :kind :tuple
@@ -1100,9 +1100,9 @@
             int in React's reconciler; the rf2-c8kfy fix requires the
             `r:` / `t:` namespacing prefix so distinct UI surfaces
             with the same int positions never collide."
-    (state/swap-state! state/set-cell-override
+    (rf.story.ui.state/swap-state! rf.story.ui.state/set-cell-override
                        :story.c8kfy.guard/v [:items] ["a" "b" "c"])
-    (let [tree (controls/arg-widget
+    (let [tree (rf.story.ui.controls/arg-widget
                  :story.c8kfy.guard/v [:items]
                  ["a" "b" "c"]
                  {:widget :repeater :kind :vector
@@ -1138,7 +1138,7 @@
                       :id 5 :tags {:rf.trace/dispatch-id 100 :rf.sub/id :sub/foo}}
                      {:op-type :rf.view :operation :rf.view/render
                       :id 6 :tags {:rf.trace/dispatch-id 100 :rf.view/render-key [:app/root nil]}}]
-          cascades  (projection/group-by-event evs)]
+          cascades  (rf.trace.projection/group-by-event evs)]
       (is (= 1 (count cascades)))
       (let [c (first cascades)]
         (is (= [:foo] (:event c)))
@@ -1164,8 +1164,8 @@
   (testing "reveal → redact narrowing clears every per-variant Story trace buffer"
     (let [v-a       :story.priv-scrub/a
           v-b       :story.priv-scrub/b
-          buf-a     (trace-buffer/ensure-buffer! v-a)
-          buf-b     (trace-buffer/ensure-buffer! v-b)
+          buf-a     (rf.story.ui.trace-buffer/ensure-buffer! v-a)
+          buf-b     (rf.story.ui.trace-buffer/ensure-buffer! v-b)
           mk-ev     (fn [vid sensitive?]
                       (cond-> {:op-type   :rf.event
                                :operation :rf.event/dispatched
@@ -1178,59 +1178,59 @@
                         sensitive? (assoc :sensitive? true)))]
       (try
         ;; Engineer opts into the trusted-local raw boundary to investigate.
-        (story-config/set-egress-profile! :rf.egress/local-raw)
+        (rf.story.config/set-egress-profile! :rf.egress/local-raw)
         ;; Simulate the per-variant listener body: under the raw profile the
         ;; listener appends every event (no suppression).
         (reset! buf-a [(mk-ev v-a true) (mk-ev v-a false)])
         (reset! buf-b [(mk-ev v-b true)])
-        (story-config/note-suppressed! v-a) ; previously bumped before opt-in
+        (rf.story.config/note-suppressed! v-a) ; previously bumped before opt-in
         (is (= 2 (count @buf-a)))
         (is (= 1 (count @buf-b)))
-        (is (pos? (story-config/suppressed-count v-a)))
+        (is (pos? (rf.story.config/suppressed-count v-a)))
 
         ;; Engineer narrows the profile back expecting privacy restored.
-        (story-config/set-egress-profile! :rf.egress/local-redacted)
+        (rf.story.config/set-egress-profile! :rf.egress/local-redacted)
 
         (is (= 0 (count @buf-a))
             "variant A's buffer must be empty — sensitive payloads cannot survive the narrowing")
         (is (= 0 (count @buf-b))
             "variant B's buffer must be empty too — the clear is global")
-        (is (zero? (story-config/suppressed-count v-a))
+        (is (zero? (rf.story.config/suppressed-count v-a))
             "per-variant suppressed counter drops in lockstep with the buffer")
         (finally
-          (trace-buffer/drop-buffer! v-a)
-          (trace-buffer/drop-buffer! v-b)
-          (story-config/set-egress-profile! :rf.egress/local-redacted)
-          (story-config/reset-suppressed-count!))))))
+          (rf.story.ui.trace-buffer/drop-buffer! v-a)
+          (rf.story.ui.trace-buffer/drop-buffer! v-b)
+          (rf.story.config/set-egress-profile! :rf.egress/local-redacted)
+          (rf.story.config/reset-suppressed-count!))))))
 
 (deftest narrowing-profile-no-clear-when-already-redacting-rf2-lqmje
   (testing "redact → redact narrowing leaves the buffers alone"
     (let [vid :story.priv-scrub/idempotent
-          buf (trace-buffer/ensure-buffer! vid)]
+          buf (rf.story.ui.trace-buffer/ensure-buffer! vid)]
       (try
         ;; The profile started redacting, so no sensitive events ever landed.
         ;; A redundant set-egress-profile! local-redacted call must NOT throw
         ;; away the buffered non-sensitive history.
         (reset! buf [{:op-type :rf.event :tags {:frame vid}}])
-        (story-config/set-egress-profile! :rf.egress/local-redacted) ; redundant; default
+        (rf.story.config/set-egress-profile! :rf.egress/local-redacted) ; redundant; default
         (is (= 1 (count @buf))
             "redundant redact → redact must not clear the buffer")
         (finally
-          (trace-buffer/drop-buffer! vid)
-          (story-config/set-egress-profile! :rf.egress/local-redacted))))))
+          (rf.story.ui.trace-buffer/drop-buffer! vid)
+          (rf.story.config/set-egress-profile! :rf.egress/local-redacted))))))
 
 (deftest widening-profile-does-not-clear-rf2-lqmje
   (testing "redact → reveal widening leaves the buffers alone (no buffered sensitive risk)"
     (let [vid :story.priv-scrub/opt-in
-          buf (trace-buffer/ensure-buffer! vid)]
+          buf (rf.story.ui.trace-buffer/ensure-buffer! vid)]
       (try
         (reset! buf [{:op-type :rf.event :tags {:frame vid}}])
-        (story-config/set-egress-profile! :rf.egress/local-raw)
+        (rf.story.config/set-egress-profile! :rf.egress/local-raw)
         (is (= 1 (count @buf))
             "opting into raw must not clear pre-existing non-sensitive history")
         (finally
-          (trace-buffer/drop-buffer! vid)
-          (story-config/set-egress-profile! :rf.egress/local-redacted))))))
+          (rf.story.ui.trace-buffer/drop-buffer! vid)
+          (rf.story.config/set-egress-profile! :rf.egress/local-redacted))))))
 
 ;; ---- shell render smoke -------------------------------------------------
 ;;
@@ -1241,27 +1241,27 @@
   (testing "sidebar / controls expose top-level component fns (per
             rf2-sgdd3 the scrubber / trace / actions panels were
             retired; Xray is the RHS primary inspector now)"
-    (is (fn? sidebar/sidebar))
-    ;; The controls/panel takes a variant-id arg.
-    (is (fn? controls/panel))
+    (is (fn? rf.story.ui.sidebar/sidebar))
+    ;; The rf.story.ui.controls/panel takes a variant-id arg.
+    (is (fn? rf.story.ui.controls/panel))
     ;; rf2-rodx — the :docs mode pane.
-    (is (fn? docs/docs-view))))
+    (is (fn? rf.story.ui.docs/docs-view))))
 
 (deftest docs-view-returns-hiccup-for-registered-variant
   (testing "docs-view returns a hiccup vector for a registered variant — the
             shell can mount it without a thrown ns-resolution error.
             The CLJS smoke proves the cljs-only `:require` (args /
             decorators / state) and the section renderers compose."
-    (story/reg-story :story.dv
+    (rf.story/reg-story :story.dv
       {:doc       "parent for the docs-view smoke."
        :tags      #{:dev :docs}})
-    (story/reg-variant :story.dv/x
+    (rf.story/reg-variant :story.dv/x
       {:doc       "a tiny variant."
        :args      {:label "L"}
        :argtypes  {:label {:doc "label slot"}}
        :tags      #{:dev :docs}
        :setup    []})
-    (let [result (docs/docs-view :story.dv/x)]
+    (let [result (rf.story.ui.docs/docs-view :story.dv/x)]
       (is (vector? result))
       ;; Per rf2-8c7tk the docs-view wraps the body section + TOC in a
       ;; flex `<div>` so the sticky TOC anchors to the right edge. The
@@ -1277,58 +1277,58 @@
         (is (= "story-docs-view" (:data-test (second section))))))
     ;; The fn returns nil when given no variant id (the shell already
     ;; gates this, but the helper guards itself too).
-    (is (nil? (docs/docs-view nil)))))
+    (is (nil? (rf.story.ui.docs/docs-view nil)))))
 
 (deftest docs-view-section-pure-helpers
   (testing "the pure section helpers run end-to-end in CLJS too"
-    (story/reg-story :story.dvh
+    (rf.story/reg-story :story.dvh
       {:tags #{:dev :docs}})
-    (story/reg-variant :story.dvh/x
+    (rf.story/reg-variant :story.dvh/x
       {:args      {:greeting "hi"}
        :argtypes  {:greeting {:doc "the greeting"}}
        :tags      #{:dev :docs}
        :setup    []})
-    (let [rows (docs/args-rows :story.dvh/x {:greeting "hi"})]
+    (let [rows (rf.story.ui.docs/args-rows :story.dvh/x {:greeting "hi"})]
       (is (= [{:key :greeting :value "hi" :doc "the greeting"}]
              rows)))
-    (is (= [:dev :docs] (docs/variant-tags :story.dvh/x)))))
+    (is (= [:dev :docs] (rf.story.ui.docs/variant-tags :story.dvh/x)))))
 
 ;; ---- :test mode (rf2-qmjo) ----------------------------------------------
 
 (deftest test-view-is-a-fn
   (testing "test-view is callable from the shell"
-    (is (fn? test-mode-view/test-view))))
+    (is (fn? rf.story.ui.test-mode.view/test-view))))
 
 (deftest test-view-empty-state-without-play
   (testing "test-view renders the empty-state placeholder when the
             variant body has no :script slot — the variant is registered
             but declares zero assertions, so no run is fired."
-    (story/reg-variant :story.tv/no-play {:setup []})
-    (let [result (test-mode-view/test-view :story.tv/no-play)]
+    (rf.story/reg-variant :story.tv/no-play {:setup []})
+    (let [result (rf.story.ui.test-mode.view/test-view :story.tv/no-play)]
       ;; r/create-class returns a fn — Reagent will invoke it during
       ;; render. We at least confirm the helper returns a non-nil
       ;; component descriptor.
       (is (some? result)))
-    (is (nil? (test-mode-view/test-view nil))
+    (is (nil? (rf.story.ui.test-mode.view/test-view nil))
         "no variant-id = no pane")))
 
 (deftest test-view-pure-helpers
   (testing "the pure section helpers run end-to-end in CLJS too"
-    (let [summary (state/aggregate-summary
+    (let [summary (rf.story.ui.state/aggregate-summary
                     [{:assertion :rf.assert/path-equals :passed? true}
                      {:assertion :rf.assert/sub-equals  :passed? false}])]
       (is (= 2 (:total summary)))
       (is (= 1 (:passed summary)))
       (is (= 1 (:failed summary)))
       (is (false? (:all-passed? summary))))
-    (let [row (test-mode-pure/assertion-row
+    (let [row (rf.story.ui.test-mode.pure/assertion-row
                 {:assertion :rf.assert/path-equals
                  :payload   [[:k] 1] :passed? true})]
       (is (= :pass (:status row))))
-    (is (= "12 ms" (test-mode-pure/format-elapsed-ms 12)))
-    (is (= "1.2 s" (test-mode-pure/format-elapsed-ms 1234)))
+    (is (= "12 ms" (rf.story.ui.test-mode.pure/format-elapsed-ms 12)))
+    (is (= "1.2 s" (rf.story.ui.test-mode.pure/format-elapsed-ms 1234)))
     (is (re-matches #"\d{2}:\d{2}:\d{2}"
-                    (test-mode-pure/format-timestamp-ms (.getTime (js/Date.)))))))
+                    (rf.story.ui.test-mode.pure/format-timestamp-ms (.getTime (js/Date.)))))))
 
 ;; ---- canvas: decorator-wrap exception swallow ---------------------------
 ;;
@@ -1336,7 +1336,7 @@
 ;; render machinery and React unmounted the whole Story shell, blanking
 ;; the page. Repro: register a hiccup decorator whose `:wrap` fn throws
 ;; on call; click into a variant that references it; the shell goes
-;; blank. The fix is `canvas/safe-decorated-view`: catch the exception,
+;; blank. The fix is `rf.story.ui.canvas/safe-decorated-view`: catch the exception,
 ;; project an error block, and re-render the uncoated variant body so
 ;; the user still sees content.
 
@@ -1347,7 +1347,7 @@
                   :body {:kind :hiccup
                          :wrap (fn [body _args]
                                  [:section {:data-test "wrapped"} body])}}]
-          result (canvas/safe-decorated-view
+          result (rf.story.ui.canvas/safe-decorated-view
                    [:span "body"]
                    stack
                    {})]
@@ -1367,7 +1367,7 @@
                                  ;; destructure that throws inside :wrap.
                                  (let [[_ _label] {:not :sequential}]
                                    (throw (ex-info "boom" {}))))}}]
-          result (canvas/safe-decorated-view
+          result (rf.story.ui.canvas/safe-decorated-view
                    [:span "body"]
                    stack
                    {})]
@@ -1381,8 +1381,8 @@
 
 (deftest registry-snapshot-shape
   (testing "registry-snapshot returns every Story kind"
-    (story/reg-variant :story.r/v {:setup []})
-    (let [snap (state/registry-snapshot)]
+    (rf.story/reg-variant :story.r/v {:setup []})
+    (let [snap (rf.story.ui.state/registry-snapshot)]
       (is (contains? snap :stories))
       (is (contains? snap :variants))
       (is (contains? snap :workspaces))

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -14,40 +14,40 @@
   `clojure -M:test`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core            :as rf]
-            [re-frame.frame           :as frame]
-            [re-frame.machines        :as machines]
-            [re-frame.registrar       :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story           :as story]
-            [re-frame.story.config    :as config]
-            [re-frame.story.loaders   :as loaders]
-            [re-frame.story.predicates :as pred]
-            [re-frame.story.registrar :as story-registrar]
-            [re-frame.story.ui.command-palette :as command-palette]
-            [re-frame.story.ui.docs   :as docs]
-            [re-frame.story.ui.state  :as state]
-            [re-frame.story.ui.test-mode.pure :as test-mode]
-            [re-frame.story.ui.workspace :as workspace]))
+            [re-frame.frame           :as rf.frame]
+            [re-frame.machines        :as rf.machines]
+            [re-frame.registrar       :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story           :as rf.story]
+            [re-frame.story.config    :as rf.story.config]
+            [re-frame.story.loaders   :as rf.story.loaders]
+            [re-frame.story.predicates :as rf.story.predicates]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.ui.command-palette :as rf.story.ui.command-palette]
+            [re-frame.story.ui.docs   :as rf.story.ui.docs]
+            [re-frame.story.ui.state  :as rf.story.ui.state]
+            [re-frame.story.ui.test-mode.pure :as rf.story.ui.test-mode.pure]
+            [re-frame.story.ui.workspace :as rf.story.ui.workspace]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-fixture [test-fn]
-  ;; Mirror the Stage 3 runtime test fixture — story/clear-all! drops
+  ;; Mirror the Stage 3 runtime test fixture — rf.story/clear-all! drops
   ;; the side-table; framework registrar is wiped + the machines ns is
   ;; reloaded to re-register its framework-shipped sub; canonical
   ;; vocabulary is reinstalled so :tag membership validates correctly.
-  (story/clear-all!)
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter)
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
   (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
-  (config/set-global-args! {})
-  (state/reset-shell-state!)
-  (story/install-canonical-vocabulary!)
-  (frame/ensure-default-frame!)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.config/set-global-args! {})
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
   (test-fn))
 
 (use-fixtures :each reset-fixture)
@@ -56,7 +56,7 @@
 
 (deftest default-shell-state-shape
   (testing "default-shell-state carries the v1 slots"
-    (let [s state/default-shell-state]
+    (let [s rf.story.ui.state/default-shell-state]
       (is (nil? (:selected-variant s)))
       (is (nil? (:selected-workspace s)))
       (is (= #{} (:tag-filter s)))
@@ -67,9 +67,9 @@
 
 (deftest select-variant-transitions
   (testing "select-variant + select-workspace mutate the state"
-    (let [s  state/default-shell-state
-          s1 (state/select-variant s :story.a/x)
-          s2 (state/select-workspace s1 :Workspace.demo/y)]
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/select-variant s :story.a/x)
+          s2 (rf.story.ui.state/select-workspace s1 :Workspace.demo/y)]
       (is (= :story.a/x (:selected-variant s1)))
       (is (= :Workspace.demo/y (:selected-workspace s2)))
       (is (= :story.a/x (:selected-variant s2))))))
@@ -81,41 +81,41 @@
 ;; JVM corpus catches a regression without booting Reagent.
 (deftest variant-row-click-symmetric-clear-rf2-hscut
   (testing "variant-row pipeline sets variant AND clears workspace"
-    (let [s  (-> state/default-shell-state
-                 (state/select-workspace :Workspace.nav/all))
+    (let [s  (-> rf.story.ui.state/default-shell-state
+                 (rf.story.ui.state/select-workspace :Workspace.nav/all))
           s1 (-> s
-                 (state/select-variant :story.nav/v1)
-                 (state/select-workspace nil))]
+                 (rf.story.ui.state/select-variant :story.nav/v1)
+                 (rf.story.ui.state/select-workspace nil))]
       (is (= :story.nav/v1 (:selected-variant s1)))
       (is (nil? (:selected-workspace s1)))))
   (testing "mirror — workspace-row pipeline sets workspace AND clears variant"
-    (let [s  (-> state/default-shell-state
-                 (state/select-variant :story.nav/v1))
+    (let [s  (-> rf.story.ui.state/default-shell-state
+                 (rf.story.ui.state/select-variant :story.nav/v1))
           s1 (-> s
-                 (state/select-workspace :Workspace.nav/all)
-                 (state/select-variant nil))]
+                 (rf.story.ui.state/select-workspace :Workspace.nav/all)
+                 (rf.story.ui.state/select-variant nil))]
       (is (= :Workspace.nav/all (:selected-workspace s1)))
       (is (nil? (:selected-variant s1))))))
 
 (deftest toggle-tag-filter-pure
   (testing "toggle-tag-filter adds and removes"
-    (let [s  state/default-shell-state
-          s1 (state/toggle-tag-filter s :dev)
-          s2 (state/toggle-tag-filter s1 :dev)]
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/toggle-tag-filter s :dev)
+          s2 (rf.story.ui.state/toggle-tag-filter s1 :dev)]
       (is (= #{:dev} (:tag-filter s1)))
       (is (= #{} (:tag-filter s2))))))
 
 (deftest set-active-modes-pure
   (testing "set-active-modes replaces"
-    (let [s  state/default-shell-state
-          s1 (state/set-active-modes s [:Mode.t/dark])]
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/set-active-modes s [:Mode.t/dark])]
       (is (= [:Mode.t/dark] (:active-modes s1))))))
 
 (deftest cell-overrides-pure
   (testing "set + clear overrides work on the pure map"
-    (let [s  state/default-shell-state
-          s1 (state/set-cell-override-scalar s :story.a/x :n 42)
-          s2 (state/clear-cell-overrides s1 :story.a/x)]
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/set-cell-override-scalar s :story.a/x :n 42)
+          s2 (rf.story.ui.state/clear-cell-overrides s1 :story.a/x)]
       (is (= 42 (get-in s1 [:cell-overrides :story.a/x :n])))
       (is (nil? (get-in s2 [:cell-overrides :story.a/x]))))))
 
@@ -133,16 +133,16 @@
 
 (deftest repeater-row-ids-default-empty-rf2-c8kfy
   (testing "default state carries the counter + the empty row-ids map"
-    (let [s state/default-shell-state]
+    (let [s rf.story.ui.state/default-shell-state]
       (is (= 0 (:rf.story/repeater-id-counter s)))
       (is (= {} (:rf.story/repeater-row-ids s))))))
 
 (deftest repeater-row-ids-ensure-allocates-fresh-ids-rf2-c8kfy
   (testing "ensure-repeater-row-ids appends fresh monotonic ids when the
             stored vector is shorter than the entries count"
-    (let [s  state/default-shell-state
-          s1 (state/ensure-repeater-row-ids s :story.x/v [:items] 3)
-          ids (state/repeater-row-ids s1 :story.x/v [:items])]
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/ensure-repeater-row-ids s :story.x/v [:items] 3)
+          ids (rf.story.ui.state/repeater-row-ids s1 :story.x/v [:items])]
       (is (= 3 (count ids)))
       (is (apply distinct? ids))
       (is (= 3 (:rf.story/repeater-id-counter s1))))))
@@ -151,11 +151,11 @@
   (testing "ensure-repeater-row-ids truncates from the right when the
             stored vector is longer than the entries count — keeps the
             surviving prefix's ids intact (no churn for visible rows)"
-    (let [s  state/default-shell-state
-          s1 (state/ensure-repeater-row-ids s :story.x/v [:items] 4)
-          before (state/repeater-row-ids s1 :story.x/v [:items])
-          s2 (state/ensure-repeater-row-ids s1 :story.x/v [:items] 2)
-          after  (state/repeater-row-ids s2 :story.x/v [:items])]
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/ensure-repeater-row-ids s :story.x/v [:items] 4)
+          before (rf.story.ui.state/repeater-row-ids s1 :story.x/v [:items])
+          s2 (rf.story.ui.state/ensure-repeater-row-ids s1 :story.x/v [:items] 2)
+          after  (rf.story.ui.state/repeater-row-ids s2 :story.x/v [:items])]
       (is (= 2 (count after)))
       (is (= (subvec before 0 2) after)
           "the surviving prefix's ids are unchanged after truncation"))))
@@ -163,20 +163,20 @@
 (deftest repeater-row-ids-ensure-noop-when-equal-rf2-c8kfy
   (testing "ensure-repeater-row-ids is a no-op when the count already
             matches — no counter churn, no id reallocation"
-    (let [s  state/default-shell-state
-          s1 (state/ensure-repeater-row-ids s :story.x/v [:items] 3)
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/ensure-repeater-row-ids s :story.x/v [:items] 3)
           counter-after-init (:rf.story/repeater-id-counter s1)
-          s2 (state/ensure-repeater-row-ids s1 :story.x/v [:items] 3)]
+          s2 (rf.story.ui.state/ensure-repeater-row-ids s1 :story.x/v [:items] 3)]
       (is (= counter-after-init (:rf.story/repeater-id-counter s2)))
-      (is (= (state/repeater-row-ids s1 :story.x/v [:items])
-             (state/repeater-row-ids s2 :story.x/v [:items]))))))
+      (is (= (rf.story.ui.state/repeater-row-ids s1 :story.x/v [:items])
+             (rf.story.ui.state/repeater-row-ids s2 :story.x/v [:items]))))))
 
 (deftest repeater-row-ids-append-allocates-rf2-c8kfy
   (testing "append-repeater-row-id allocates a fresh id and appends"
-    (let [s  state/default-shell-state
-          s1 (state/ensure-repeater-row-ids s :story.x/v [:items] 2)
-          s2 (state/append-repeater-row-id s1 :story.x/v [:items])
-          ids (state/repeater-row-ids s2 :story.x/v [:items])]
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/ensure-repeater-row-ids s :story.x/v [:items] 2)
+          s2 (rf.story.ui.state/append-repeater-row-id s1 :story.x/v [:items])
+          ids (rf.story.ui.state/repeater-row-ids s2 :story.x/v [:items])]
       (is (= 3 (count ids)))
       (is (apply distinct? ids))
       (is (= 3 (:rf.story/repeater-id-counter s2))))))
@@ -189,12 +189,12 @@
             one and React reused the original DOM nodes (focus + cursor
             leakage onto neighbouring rows). Post-fix the row ids ARE
             stable across the delete."
-    (let [s     state/default-shell-state
-          s1    (state/ensure-repeater-row-ids s :story.x/v [:items] 4)
-          before (state/repeater-row-ids s1 :story.x/v [:items])
+    (let [s     rf.story.ui.state/default-shell-state
+          s1    (rf.story.ui.state/ensure-repeater-row-ids s :story.x/v [:items] 4)
+          before (rf.story.ui.state/repeater-row-ids s1 :story.x/v [:items])
           ;; Delete the middle entry at i=1.
-          s2    (state/remove-repeater-row-id s1 :story.x/v [:items] 1)
-          after (state/repeater-row-ids s2 :story.x/v [:items])]
+          s2    (rf.story.ui.state/remove-repeater-row-id s1 :story.x/v [:items] 1)
+          after (rf.story.ui.state/repeater-row-ids s2 :story.x/v [:items])]
       (is (= 4 (count before)))
       (is (= 3 (count after)))
       ;; The surviving ids are exactly before[0], before[2], before[3]
@@ -204,75 +204,75 @@
 (deftest repeater-row-ids-remove-out-of-range-noop-rf2-c8kfy
   (testing "remove-repeater-row-id is a no-op for out-of-range / nil i —
             the storage is unchanged"
-    (let [s   state/default-shell-state
-          s1  (state/ensure-repeater-row-ids s :story.x/v [:items] 2)
-          ids (state/repeater-row-ids s1 :story.x/v [:items])
-          s2  (state/remove-repeater-row-id s1 :story.x/v [:items] 5)
-          s3  (state/remove-repeater-row-id s1 :story.x/v [:items] -1)]
-      (is (= ids (state/repeater-row-ids s2 :story.x/v [:items])))
-      (is (= ids (state/repeater-row-ids s3 :story.x/v [:items]))))))
+    (let [s   rf.story.ui.state/default-shell-state
+          s1  (rf.story.ui.state/ensure-repeater-row-ids s :story.x/v [:items] 2)
+          ids (rf.story.ui.state/repeater-row-ids s1 :story.x/v [:items])
+          s2  (rf.story.ui.state/remove-repeater-row-id s1 :story.x/v [:items] 5)
+          s3  (rf.story.ui.state/remove-repeater-row-id s1 :story.x/v [:items] -1)]
+      (is (= ids (rf.story.ui.state/repeater-row-ids s2 :story.x/v [:items])))
+      (is (= ids (rf.story.ui.state/repeater-row-ids s3 :story.x/v [:items]))))))
 
 (deftest repeater-row-ids-cleared-with-overrides-rf2-c8kfy
   (testing "clear-cell-overrides drops the variant's repeater row-ids
             too — the next render re-syncs from scratch against the
             default entries"
-    (let [s  state/default-shell-state
+    (let [s  rf.story.ui.state/default-shell-state
           s1 (-> s
-                 (state/set-cell-override :story.x/v [:items] [1 2 3])
-                 (state/ensure-repeater-row-ids :story.x/v [:items] 3))
-          s2 (state/clear-cell-overrides s1 :story.x/v)]
-      (is (seq (state/repeater-row-ids s1 :story.x/v [:items])))
-      (is (empty? (state/repeater-row-ids s2 :story.x/v [:items])))
+                 (rf.story.ui.state/set-cell-override :story.x/v [:items] [1 2 3])
+                 (rf.story.ui.state/ensure-repeater-row-ids :story.x/v [:items] 3))
+          s2 (rf.story.ui.state/clear-cell-overrides s1 :story.x/v)]
+      (is (seq (rf.story.ui.state/repeater-row-ids s1 :story.x/v [:items])))
+      (is (empty? (rf.story.ui.state/repeater-row-ids s2 :story.x/v [:items])))
       (is (nil? (get-in s2 [:cell-overrides :story.x/v]))))))
 
 (deftest repeater-row-ids-isolated-by-variant-and-path-rf2-c8kfy
   (testing "row-ids are keyed on [variant-id path] — two repeaters with
             the same arg-key on different variants (or the same variant
             with different paths) get independent id namespaces"
-    (let [s  state/default-shell-state
+    (let [s  rf.story.ui.state/default-shell-state
           s1 (-> s
-                 (state/ensure-repeater-row-ids :story.a/v [:items] 2)
-                 (state/ensure-repeater-row-ids :story.b/v [:items] 2)
-                 (state/ensure-repeater-row-ids :story.a/v [:other] 2))]
+                 (rf.story.ui.state/ensure-repeater-row-ids :story.a/v [:items] 2)
+                 (rf.story.ui.state/ensure-repeater-row-ids :story.b/v [:items] 2)
+                 (rf.story.ui.state/ensure-repeater-row-ids :story.a/v [:other] 2))]
       ;; Three independent id vectors of length 2 each — 6 ids total.
       (is (= 6 (:rf.story/repeater-id-counter s1)))
-      (is (= 2 (count (state/repeater-row-ids s1 :story.a/v [:items]))))
-      (is (= 2 (count (state/repeater-row-ids s1 :story.b/v [:items]))))
-      (is (= 2 (count (state/repeater-row-ids s1 :story.a/v [:other]))))
+      (is (= 2 (count (rf.story.ui.state/repeater-row-ids s1 :story.a/v [:items]))))
+      (is (= 2 (count (rf.story.ui.state/repeater-row-ids s1 :story.b/v [:items]))))
+      (is (= 2 (count (rf.story.ui.state/repeater-row-ids s1 :story.a/v [:other]))))
       ;; The id vectors are disjoint (no shared id across keys).
       (let [all-ids (concat
-                      (state/repeater-row-ids s1 :story.a/v [:items])
-                      (state/repeater-row-ids s1 :story.b/v [:items])
-                      (state/repeater-row-ids s1 :story.a/v [:other]))]
+                      (rf.story.ui.state/repeater-row-ids s1 :story.a/v [:items])
+                      (rf.story.ui.state/repeater-row-ids s1 :story.b/v [:items])
+                      (rf.story.ui.state/repeater-row-ids s1 :story.a/v [:other]))]
         (is (apply distinct? all-ids))))))
 
 (deftest hot-reload-tick-monotonic
   (testing "bump-hot-reload-tick increments each call"
-    (let [s state/default-shell-state]
+    (let [s rf.story.ui.state/default-shell-state]
       (is (= 0 (:hot-reload-tick s)))
-      (is (= 1 (-> s state/bump-hot-reload-tick :hot-reload-tick)))
-      (is (= 2 (-> s state/bump-hot-reload-tick
-                   state/bump-hot-reload-tick :hot-reload-tick))))))
+      (is (= 1 (-> s rf.story.ui.state/bump-hot-reload-tick :hot-reload-tick)))
+      (is (= 2 (-> s rf.story.ui.state/bump-hot-reload-tick
+                   rf.story.ui.state/bump-hot-reload-tick :hot-reload-tick))))))
 
 (deftest record-fingerprints-roundtrip
   (testing "record-fingerprints stores the per-variant map"
-    (let [s  state/default-shell-state
-          s1 (state/record-fingerprints s :story.a/x {:dec/foo 0xdeadbeef})]
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/record-fingerprints s :story.a/x {:dec/foo 0xdeadbeef})]
       (is (= {:dec/foo 0xdeadbeef}
              (get-in s1 [:fingerprints :story.a/x]))))))
 
 (deftest pin-snapshot-appends
   (testing "pin-snapshot appends a labelled marker"
-    (let [s  state/default-shell-state
-          s1 (state/pin-snapshot s :story.a/x "checkpoint" 5)
-          s2 (state/pin-snapshot s1 :story.a/x "later" 11)]
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/pin-snapshot s :story.a/x "checkpoint" 5)
+          s2 (rf.story.ui.state/pin-snapshot s1 :story.a/x "later" 11)]
       (is (= 2 (count (get-in s2 [:pinned-snapshots :story.a/x]))))
       (is (= 5 (-> s2 :pinned-snapshots :story.a/x first :epoch-id))))))
 
 (deftest panel-visibility-toggle
   (testing "toggle-panel flips a panel's visibility"
-    (let [s  state/default-shell-state
-          s1 (state/toggle-panel s :controls)]
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/toggle-panel s :controls)]
       (is (= false (get-in s1 [:panel-visibility :controls]))))))
 
 ;; ---- command palette -----------------------------------------------------
@@ -285,7 +285,7 @@
                     :workspaces {:Workspace.cp/all {:doc "All states"}}
                     :modes      {:Mode.cp/dark {:doc "Dark theme"}}
                     :decorators {:cp/outline {:doc "Outline wrapper"}}}
-          entries  (command-palette/entries snapshot)
+          entries  (rf.story.ui.command-palette/entries snapshot)
           by-kind  (frequencies (map :kind entries))
           story    (first (filter #(= [:story :story.cp]
                                       [(:kind %) (:id %)])
@@ -298,7 +298,7 @@
       (is (= [:story.cp/empty :story.cp/full] (:variant-ids story))))))
 
 (deftest command-palette-search-matches-id-doc-and-kind
-  (let [entries (command-palette/entries
+  (let [entries (rf.story.ui.command-palette/entries
                   {:stories    {:story.checkout {:doc "Payment flow"}}
                    :variants   {:story.checkout/error {:doc "Declined card state"}}
                    :workspaces {:Workspace.checkout/grid {:doc "All payment states"}}
@@ -306,38 +306,38 @@
                    :decorators {:checkout/auth {:doc "Authenticated shell"}}})]
     (testing "id substring matches rank exact surface hits"
       (is (= :story.checkout/error
-             (:id (first (command-palette/search entries "checkout error"))))))
+             (:id (first (rf.story.ui.command-palette/search entries "checkout error"))))))
     (testing "doc text is searchable"
       (is (= :story.checkout/error
-             (:id (first (command-palette/search entries "declined"))))))
+             (:id (first (rf.story.ui.command-palette/search entries "declined"))))))
     (testing "kind participates in search"
       (is (= :Workspace.checkout/grid
-             (:id (first (command-palette/search entries "workspace payment"))))))
+             (:id (first (rf.story.ui.command-palette/search entries "workspace payment"))))))
     (testing "fuzzy subsequence catches compact user input"
       (is (= :Mode.theme/dark
-             (:id (first (command-palette/search entries "mthdrk"))))))
+             (:id (first (rf.story.ui.command-palette/search entries "mthdrk"))))))
     (testing "unmatched query returns no rows"
-      (is (empty? (command-palette/search entries "no such thing"))))))
+      (is (empty? (rf.story.ui.command-palette/search entries "no such thing"))))))
 
 (deftest command-palette-active-index-wraps
   (testing "arrow navigation wraps both directions"
-    (is (= 1 (command-palette/move-active-index 0 1 3)))
-    (is (= 0 (command-palette/move-active-index 2 1 3)))
-    (is (= 2 (command-palette/move-active-index 0 -1 3)))
-    (is (= 0 (command-palette/move-active-index 0 1 0)))))
+    (is (= 1 (rf.story.ui.command-palette/move-active-index 0 1 3)))
+    (is (= 0 (rf.story.ui.command-palette/move-active-index 2 1 3)))
+    (is (= 2 (rf.story.ui.command-palette/move-active-index 0 -1 3)))
+    (is (= 0 (rf.story.ui.command-palette/move-active-index 0 1 0)))))
 
 (deftest command-palette-carries-save-current-command
   (testing "rf2-ba86n.6 — the save-current-state flow is reachable from the
             command palette (spec/019 §3), as a synthetic :command entry"
-    (let [entries (command-palette/command-entries)
+    (let [entries (rf.story.ui.command-palette/command-entries)
           save    (first (filter #(= :save-current-as-variant (:id %)) entries))]
       (is (some? save) "the save-current command entry is present")
       (is (= :command (:kind save)))
       (is (= :save-current-as-variant (:action save))
           "the entry carries the action the view dispatches"))
     (testing "the command is findable by search"
-      (let [entries (command-palette/entries {})
-            hit     (first (command-palette/search entries "save variant"))]
+      (let [entries (rf.story.ui.command-palette/entries {})
+            hit     (first (rf.story.ui.command-palette/search entries "save variant"))]
         (is (= :save-current-as-variant (:id hit))
             "searching 'save variant' surfaces the save-current command")))))
 
@@ -345,78 +345,78 @@
 
 (deftest mode-tabs-canonical-set
   (testing "the three canonical mode tabs ship in stable order"
-    (is (= [:dev :docs :test] state/mode-tabs)))
+    (is (= [:dev :docs :test] rf.story.ui.state/mode-tabs)))
   (testing "every mode-tab has a human label"
-    (doseq [t state/mode-tabs]
-      (is (string? (get state/mode-tab-labels t))
+    (doseq [t rf.story.ui.state/mode-tabs]
+      (is (string? (get rf.story.ui.state/mode-tab-labels t))
           (str "missing label for " t)))))
 
 (deftest mode-tab-default-is-dev
   (testing "the default mode-tab is :dev (Story v1 canvas)"
-    (is (= :dev state/default-mode-tab)))
+    (is (= :dev rf.story.ui.state/default-mode-tab)))
   (testing "active-mode-tab falls back to :dev for unknown variants"
-    (is (= :dev (state/active-mode-tab state/default-shell-state :no/such-variant)))))
+    (is (= :dev (rf.story.ui.state/active-mode-tab rf.story.ui.state/default-shell-state :no/such-variant)))))
 
 (deftest valid-mode-tab?-rejects-noise
-  (is (state/valid-mode-tab? :dev))
-  (is (state/valid-mode-tab? :docs))
-  (is (state/valid-mode-tab? :test))
-  (is (not (state/valid-mode-tab? :canvas)))
-  (is (not (state/valid-mode-tab? :nonsense)))
-  (is (not (state/valid-mode-tab? nil)))
-  (is (not (state/valid-mode-tab? "test"))))
+  (is (rf.story.ui.state/valid-mode-tab? :dev))
+  (is (rf.story.ui.state/valid-mode-tab? :docs))
+  (is (rf.story.ui.state/valid-mode-tab? :test))
+  (is (not (rf.story.ui.state/valid-mode-tab? :canvas)))
+  (is (not (rf.story.ui.state/valid-mode-tab? :nonsense)))
+  (is (not (rf.story.ui.state/valid-mode-tab? nil)))
+  (is (not (rf.story.ui.state/valid-mode-tab? "test"))))
 
 (deftest set-active-mode-tab-roundtrip
   (testing "set-active-mode-tab records the per-variant selection"
-    (let [s  state/default-shell-state
-          s1 (state/set-active-mode-tab s :story.x/a :docs)]
-      (is (= :docs (state/active-mode-tab s1 :story.x/a)))
-      (is (= :dev  (state/active-mode-tab s1 :story.x/b))
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/set-active-mode-tab s :story.x/a :docs)]
+      (is (= :docs (rf.story.ui.state/active-mode-tab s1 :story.x/a)))
+      (is (= :dev  (rf.story.ui.state/active-mode-tab s1 :story.x/b))
           "other variants keep the default")))
   (testing "selections are independent per variant"
-    (let [s  state/default-shell-state
+    (let [s  rf.story.ui.state/default-shell-state
           s1 (-> s
-                 (state/set-active-mode-tab :story.x/a :docs)
-                 (state/set-active-mode-tab :story.x/b :test))]
-      (is (= :docs (state/active-mode-tab s1 :story.x/a)))
-      (is (= :test (state/active-mode-tab s1 :story.x/b)))))
+                 (rf.story.ui.state/set-active-mode-tab :story.x/a :docs)
+                 (rf.story.ui.state/set-active-mode-tab :story.x/b :test))]
+      (is (= :docs (rf.story.ui.state/active-mode-tab s1 :story.x/a)))
+      (is (= :test (rf.story.ui.state/active-mode-tab s1 :story.x/b)))))
   (testing "an invalid tab leaves state untouched"
-    (let [s  state/default-shell-state
-          s1 (state/set-active-mode-tab s :story.x/a :nonsense)]
+    (let [s  rf.story.ui.state/default-shell-state
+          s1 (rf.story.ui.state/set-active-mode-tab s :story.x/a :nonsense)]
       (is (= s s1)))))
 
 ;; ---- pure filter + grouping ---------------------------------------------
 
 (deftest filter-variants-empty-filter
   (testing "an empty filter passes everything through"
-    (story/reg-variant :story.f/a {:tags #{:dev} :setup []})
-    (story/reg-variant :story.f/b {:tags #{:test} :setup []})
-    (let [vs (story-registrar/registrations :variant)]
-      (is (= 2 (count (state/filter-variants vs #{})))))))
+    (rf.story/reg-variant :story.f/a {:tags #{:dev} :setup []})
+    (rf.story/reg-variant :story.f/b {:tags #{:test} :setup []})
+    (let [vs (rf.story.registrar/registrations :variant)]
+      (is (= 2 (count (rf.story.ui.state/filter-variants vs #{})))))))
 
 (deftest filter-variants-with-tag
   (testing "filter restricts to variants whose tags intersect"
-    (story/reg-variant :story.f2/a {:tags #{:dev} :setup []})
-    (story/reg-variant :story.f2/b {:tags #{:test} :setup []})
-    (let [vs (story-registrar/registrations :variant)
-          devs (state/filter-variants vs #{:dev})]
+    (rf.story/reg-variant :story.f2/a {:tags #{:dev} :setup []})
+    (rf.story/reg-variant :story.f2/b {:tags #{:test} :setup []})
+    (let [vs (rf.story.registrar/registrations :variant)
+          devs (rf.story.ui.state/filter-variants vs #{:dev})]
       (is (= 1 (count devs)))
       (is (contains? devs :story.f2/a)))))
 
 (deftest group-variants-by-story-keeps-untagged
   (testing "variants with no story namespace still appear under their derived parent"
-    (story/reg-variant :story.g/a {:setup []})
-    (story/reg-variant :story.g/b {:setup []})
-    (let [vs       (story-registrar/registrations :variant)
-          grouped  (state/group-variants-by-story vs)
+    (rf.story/reg-variant :story.g/a {:setup []})
+    (rf.story/reg-variant :story.g/b {:setup []})
+    (let [vs       (rf.story.registrar/registrations :variant)
+          grouped  (rf.story.ui.state/group-variants-by-story vs)
           entries  (into {} (map (juxt :story-id :variants) grouped))]
       (is (= 1 (count grouped)))
       (is (= 2 (count (get entries :story.g)))))))
 
 (deftest parent-story-id-derivation
   (testing "parent-story-id (canonical leaf in re-frame.story.predicates)"
-    (is (= :story.foo (pred/parent-story-id :story.foo/bar)))
-    (is (nil? (pred/parent-story-id :unqualified)))))
+    (is (= :story.foo (rf.story.predicates/parent-story-id :story.foo/bar)))
+    (is (nil? (rf.story.predicates/parent-story-id :unqualified)))))
 
 ;; ---- faceted filter (rf2-7ncf9 — SB9 facet taxonomy) -------------------
 
@@ -428,13 +428,13 @@
                      :team/checkout  :team}]
       (is (= {:status #{:status/alpha :status/beta}
               :role   #{:role/dev}}
-             (state/partition-tag-filter-by-axis
+             (rf.story.ui.state/partition-tag-filter-by-axis
                #{:status/alpha :status/beta :role/dev}
                tag->axis))))
     (testing "tags missing from tag->axis bucket under ::no-axis"
       (is (= {:re-frame.story.registrar/no-axis #{:dev}
               :status                           #{:status/alpha}}
-             (state/partition-tag-filter-by-axis
+             (rf.story.ui.state/partition-tag-filter-by-axis
                #{:dev :status/alpha}
                {:status/alpha :status}))))))
 
@@ -444,54 +444,54 @@
                      :status/stable :status}
           variant   {:tags #{:status/alpha :role/dev}}]
       ;; alpha OR beta active — variant has alpha → passes
-      (is (state/variant-tag-match? variant #{:status/alpha :status/beta} tag->axis))
+      (is (rf.story.ui.state/variant-tag-match? variant #{:status/alpha :status/beta} tag->axis))
       ;; stable active — variant has neither → fails
-      (is (not (state/variant-tag-match? variant #{:status/stable} tag->axis)))))
+      (is (not (rf.story.ui.state/variant-tag-match? variant #{:status/stable} tag->axis)))))
   (testing "AND across axes (faceted)"
     (let [tag->axis  {:status/stable :status :role/design :role :role/dev :role}
           designer-stable {:tags #{:status/stable :role/design}}
           dev-stable      {:tags #{:status/stable :role/dev}}]
       ;; status+role both required; designer-stable matches
-      (is (state/variant-tag-match? designer-stable
+      (is (rf.story.ui.state/variant-tag-match? designer-stable
                                     #{:status/stable :role/design}
                                     tag->axis))
       ;; dev-stable has :status/stable but not :role/design → fails
-      (is (not (state/variant-tag-match? dev-stable
+      (is (not (rf.story.ui.state/variant-tag-match? dev-stable
                                          #{:status/stable :role/design}
                                          tag->axis)))))
   (testing "empty filter passes every variant"
-    (is (state/variant-tag-match? {:tags #{:status/alpha}} #{} {:status/alpha :status})))
+    (is (rf.story.ui.state/variant-tag-match? {:tags #{:status/alpha}} #{} {:status/alpha :status})))
   (testing "no-axis tags share a synthetic bucket with OR semantics"
     ;; Two un-axis-grouped tags share the ::no-axis bucket — OR-within
     ;; means a variant carrying either passes.
     (let [variant {:tags #{:dev}}]
-      (is (state/variant-tag-match? variant #{:dev :docs} {}))
-      (is (not (state/variant-tag-match? variant #{:docs :test} {}))))))
+      (is (rf.story.ui.state/variant-tag-match? variant #{:dev :docs} {}))
+      (is (not (rf.story.ui.state/variant-tag-match? variant #{:docs :test} {}))))))
 
 (deftest filter-variants-faceted
   (testing "filter-variants/3 applies AND-across, OR-within"
-    (story/reg-tag :status/alpha  {:axis :status})
-    (story/reg-tag :status/stable {:axis :status})
-    (story/reg-tag :role/dev      {:axis :role})
-    (story/reg-tag :role/design   {:axis :role})
-    (story/reg-variant :story.facet/a
+    (rf.story/reg-tag :status/alpha  {:axis :status})
+    (rf.story/reg-tag :status/stable {:axis :status})
+    (rf.story/reg-tag :role/dev      {:axis :role})
+    (rf.story/reg-tag :role/design   {:axis :role})
+    (rf.story/reg-variant :story.facet/a
       {:tags #{:status/alpha :role/dev} :setup []})
-    (story/reg-variant :story.facet/b
+    (rf.story/reg-variant :story.facet/b
       {:tags #{:status/stable :role/dev} :setup []})
-    (story/reg-variant :story.facet/c
+    (rf.story/reg-variant :story.facet/c
       {:tags #{:status/stable :role/design} :setup []})
-    (let [vs        (story-registrar/registrations :variant)
-          tag->axis (story-registrar/tag->axis-index)]
+    (let [vs        (rf.story.registrar/registrations :variant)
+          tag->axis (rf.story.registrar/tag->axis-index)]
       (testing "OR-within status — alpha OR stable returns all three"
-        (is (= 3 (count (state/filter-variants
+        (is (= 3 (count (rf.story.ui.state/filter-variants
                           vs #{:status/alpha :status/stable} tag->axis)))))
       (testing "AND-across — status/stable AND role/design narrows to one"
-        (let [filtered (state/filter-variants
+        (let [filtered (rf.story.ui.state/filter-variants
                          vs #{:status/stable :role/design} tag->axis)]
           (is (= 1 (count filtered)))
           (is (contains? filtered :story.facet/c))))
       (testing "status/stable alone keeps both stables"
-        (let [filtered (state/filter-variants
+        (let [filtered (rf.story.ui.state/filter-variants
                          vs #{:status/stable} tag->axis)]
           (is (= 2 (count filtered)))
           (is (contains? filtered :story.facet/b))
@@ -504,7 +504,7 @@
                      :role/dev       :role
                      :loose/freeform :re-frame.story.registrar/no-axis}
           tags     [:status/alpha :role/dev :status/stable :loose/freeform :unregistered]
-          grouped  (state/group-tags-by-axis tags tag->axis)]
+          grouped  (rf.story.ui.state/group-tags-by-axis tags tag->axis)]
       ;; Each axis bucket is a sorted vector for stable rendering
       (is (= [:status/alpha :status/stable] (:status grouped)))
       (is (= [:role/dev]                    (:role grouped)))
@@ -522,20 +522,20 @@
                    :re-frame.story.registrar/no-axis    [:loose]}]
       (is (= [:status :role :alpha :zeta
               :re-frame.story.registrar/no-axis]
-             (state/ordered-axes by-axis)))))
+             (rf.story.ui.state/ordered-axes by-axis)))))
   (testing "missing canonical axes are skipped, no-axis still trails"
     (is (= [:status :re-frame.story.registrar/no-axis]
-           (state/ordered-axes
+           (rf.story.ui.state/ordered-axes
              {:status                              [:s/a]
               :re-frame.story.registrar/no-axis    [:loose]})))))
 
 (deftest tag->axis-index-roundtrip
   (testing "tag->axis-index maps every registered tag to its :axis"
-    (story/reg-tag :status/stable {:axis :status})
-    (story/reg-tag :role/dev      {:axis :role})
-    (story/reg-tag :team/checkout {:axis :team})
-    (story/reg-tag :loose/freeform {:doc "no axis"})
-    (let [idx (story-registrar/tag->axis-index)]
+    (rf.story/reg-tag :status/stable {:axis :status})
+    (rf.story/reg-tag :role/dev      {:axis :role})
+    (rf.story/reg-tag :team/checkout {:axis :team})
+    (rf.story/reg-tag :loose/freeform {:doc "no axis"})
+    (let [idx (rf.story.registrar/tag->axis-index)]
       (is (= :status                              (get idx :status/stable)))
       (is (= :role                                (get idx :role/dev)))
       (is (= :team                                (get idx :team/checkout)))
@@ -547,7 +547,7 @@
 
 (deftest grid-layout
   (testing ":grid produces variant cells in declared order"
-    (let [cells (workspace/resolve-layout
+    (let [cells (rf.story.ui.workspace/resolve-layout
                   :Workspace.x/y
                   {:layout :grid :variants [:story.a/x :story.b/y]})]
       (is (= 2 (count cells)))
@@ -557,7 +557,7 @@
 
 (deftest tabs-layout
   (testing ":tabs resolves to the same cell shape as :grid"
-    (let [cells (workspace/resolve-layout
+    (let [cells (rf.story.ui.workspace/resolve-layout
                   :Workspace.t/x
                   {:layout :tabs :variants [:story.a/x]})]
       (is (= 1 (count cells)))
@@ -565,10 +565,10 @@
 
 (deftest variants-grid-from-anchor
   (testing ":variants-grid enumerates variants of the anchor story"
-    (story/reg-variant :story.vg/a {:setup []})
-    (story/reg-variant :story.vg/b {:setup []})
-    (story/reg-variant :story.other/x {:setup []})
-    (let [cells (workspace/resolve-layout
+    (rf.story/reg-variant :story.vg/a {:setup []})
+    (rf.story/reg-variant :story.vg/b {:setup []})
+    (rf.story/reg-variant :story.other/x {:setup []})
+    (let [cells (rf.story.ui.workspace/resolve-layout
                   :Workspace.vg/all
                   {:layout :variants-grid})]
       (is (= 2 (count cells)))
@@ -576,16 +576,16 @@
 
 (deftest variants-grid-explicit-for
   (testing ":variants-grid honours an explicit :for anchor"
-    (story/reg-variant :story.vge/a {:setup []})
-    (story/reg-variant :story.vge/b {:setup []})
-    (let [cells (workspace/resolve-layout
+    (rf.story/reg-variant :story.vge/a {:setup []})
+    (rf.story/reg-variant :story.vge/b {:setup []})
+    (let [cells (rf.story.ui.workspace/resolve-layout
                   :Workspace.other/all
                   {:layout :variants-grid :for :story.vge})]
       (is (= 2 (count cells))))))
 
 (deftest prose-layout-interleaves
   (testing ":prose preserves :content order"
-    (let [cells (workspace/resolve-layout
+    (let [cells (rf.story.ui.workspace/resolve-layout
                   :Workspace.guide/intro
                   {:layout :prose
                    :content [{:type :prose   :body "first"}
@@ -601,7 +601,7 @@
 
 (deftest custom-layout-resolves
   (testing ":custom layout emits a single :custom cell"
-    (let [cells (workspace/resolve-layout
+    (let [cells (rf.story.ui.workspace/resolve-layout
                   :Workspace.c/x
                   {:layout :custom :render :app/custom-view})]
       (is (= 1 (count cells)))
@@ -610,18 +610,18 @@
 
 (deftest unknown-layout-empty
   (testing "unknown layouts degrade gracefully"
-    (is (= [] (workspace/resolve-layout :Workspace.x/y {:layout :weird})))))
+    (is (= [] (rf.story.ui.workspace/resolve-layout :Workspace.x/y {:layout :weird})))))
 
 ;; ---- rf2-gqid4 :isolation slot ------------------------------------------
 
 (deftest variants-grid-isolation-default-is-isolated
   (testing "absent :isolation slot resolves cells identically to baseline (data-shape)"
-    (story/reg-variant :story.iso-a/a {:setup []})
-    (story/reg-variant :story.iso-a/b {:setup []})
-    (let [baseline (workspace/resolve-layout
+    (rf.story/reg-variant :story.iso-a/a {:setup []})
+    (rf.story/reg-variant :story.iso-a/b {:setup []})
+    (let [baseline (rf.story.ui.workspace/resolve-layout
                      :Workspace.iso-a/all
                      {:layout :variants-grid})
-          explicit (workspace/resolve-layout
+          explicit (rf.story.ui.workspace/resolve-layout
                      :Workspace.iso-a/all
                      {:layout :variants-grid :isolation :isolated})]
       ;; :isolation is a mount-strategy slot; cell-resolution is identical.
@@ -630,12 +630,12 @@
 
 (deftest variants-grid-isolation-shared-preserves-cell-resolution
   (testing ":isolation :shared resolves the same cell vector as :isolated"
-    (story/reg-variant :story.iso-b/x {:setup []})
-    (story/reg-variant :story.iso-b/y {:setup []})
-    (let [isolated (workspace/resolve-layout
+    (rf.story/reg-variant :story.iso-b/x {:setup []})
+    (rf.story/reg-variant :story.iso-b/y {:setup []})
+    (let [isolated (rf.story.ui.workspace/resolve-layout
                      :Workspace.iso-b/all
                      {:layout :variants-grid :isolation :isolated})
-          shared   (workspace/resolve-layout
+          shared   (rf.story.ui.workspace/resolve-layout
                      :Workspace.iso-b/all
                      {:layout :variants-grid :isolation :shared})]
       ;; The slot tunes mount strategy, not enumeration.
@@ -648,10 +648,10 @@
   (testing ":variants-grid reads the spec-authoritative :for anchor
             (rf2-ugmrg — previously :for was silently ignored and only
             :story / the namespace derivation worked)"
-    (story/reg-variant :story.for-anchor/a {:setup []})
-    (story/reg-variant :story.for-anchor/b {:setup []})
-    (story/reg-variant :story.other-anchor/x {:setup []})
-    (let [cells (workspace/resolve-layout
+    (rf.story/reg-variant :story.for-anchor/a {:setup []})
+    (rf.story/reg-variant :story.for-anchor/b {:setup []})
+    (rf.story/reg-variant :story.other-anchor/x {:setup []})
+    (let [cells (rf.story.ui.workspace/resolve-layout
                   ;; deliberately a NON-matching workspace ns so the
                   ;; namespace derivation cannot supply the anchor — only
                   ;; :for can. (`:Workspace.unrelated/grid` derives
@@ -668,77 +668,77 @@
   (testing "grid-template-columns emits a fixed repeat(N, …) template when
             :columns is a positive int (rf2-ugmrg)"
     (is (= "repeat(3, minmax(280px, 1fr))"
-           (workspace/grid-template-columns 3)))
+           (rf.story.ui.workspace/grid-template-columns 3)))
     (is (= "repeat(1, minmax(280px, 1fr))"
-           (workspace/grid-template-columns 1))))
+           (rf.story.ui.workspace/grid-template-columns 1))))
   (testing "absent / nil / non-positive :columns keeps the responsive
             auto-fit default"
     (is (= "repeat(auto-fit, minmax(280px, 1fr))"
-           (workspace/grid-template-columns nil)))
+           (rf.story.ui.workspace/grid-template-columns nil)))
     (is (= "repeat(auto-fit, minmax(280px, 1fr))"
-           (workspace/grid-template-columns 0)))
+           (rf.story.ui.workspace/grid-template-columns 0)))
     (is (= "repeat(auto-fit, minmax(280px, 1fr))"
-           (workspace/grid-template-columns -2)))))
+           (rf.story.ui.workspace/grid-template-columns -2)))))
 
 ;; ---- docs mode (rf2-rodx) -----------------------------------------------
 
-;; rf2-ee38b.3: the `docs/parent-story-id` re-export was dropped; the
+;; rf2-ee38b.3: the `rf.story.ui.docs/parent-story-id` re-export was dropped; the
 ;; canonical helper lives in `re-frame.story.predicates` (covered there).
-;; The docs header chip calls `pred/parent-story-id` directly.
+;; The docs header chip calls `rf.story.predicates/parent-story-id` directly.
 
 (deftest docs-variant-tags-falls-back-to-story
   (testing "variant-tags reads variant :tags first"
-    (story/reg-story :story.t1
+    (rf.story/reg-story :story.t1
       {:doc "parent" :tags #{:dev :docs}})
-    (story/reg-variant :story.t1/a
+    (rf.story/reg-variant :story.t1/a
       {:tags #{:dev :test} :setup []})
-    (is (= [:dev :test] (docs/variant-tags :story.t1/a))))
+    (is (= [:dev :test] (rf.story.ui.docs/variant-tags :story.t1/a))))
   (testing "variant-tags falls back to the parent story when the variant has none"
-    (story/reg-story :story.t2
+    (rf.story/reg-story :story.t2
       {:doc "parent" :tags #{:dev :docs}})
-    (story/reg-variant :story.t2/a {:setup []})
-    (is (= [:dev :docs] (docs/variant-tags :story.t2/a)))))
+    (rf.story/reg-variant :story.t2/a {:setup []})
+    (is (= [:dev :docs] (rf.story.ui.docs/variant-tags :story.t2/a)))))
 
 (deftest docs-variant-tags-resolves-removal-marker
   (testing "rf2-n0vmq2 — a child that :extends a :dev-tagged parent and
             declares :!dev shows NO :dev and NO :!dev chip (effective set)"
-    (story/reg-variant :story.tm/base  {:tags #{:dev :test} :setup []})
-    (story/reg-variant :story.tm/child {:extends :story.tm/base :tags #{:!dev} :setup []})
-    (is (= [:test] (docs/variant-tags :story.tm/child)))
-    (is (not (some #{:dev :!dev} (docs/variant-tags :story.tm/child))))))
+    (rf.story/reg-variant :story.tm/base  {:tags #{:dev :test} :setup []})
+    (rf.story/reg-variant :story.tm/child {:extends :story.tm/base :tags #{:!dev} :setup []})
+    (is (= [:test] (rf.story.ui.docs/variant-tags :story.tm/child)))
+    (is (not (some #{:dev :!dev} (rf.story.ui.docs/variant-tags :story.tm/child))))))
 
 (deftest docs-args-rows-pulls-doc-from-argtypes
   (testing "args-rows surfaces :doc from the variant's :argtypes entry"
-    (story/reg-variant :story.a/x
+    (rf.story/reg-variant :story.a/x
       {:args     {:label "Total" :count 0}
        :argtypes {:label {:doc "The cell label"}}
        :setup   []})
-    (let [rows  (docs/args-rows :story.a/x {:label "Total" :count 0})
+    (let [rows  (rf.story.ui.docs/args-rows :story.a/x {:label "Total" :count 0})
           by-k  (into {} (map (juxt :key identity)) rows)]
       (is (= 2 (count rows)))
       (is (= "The cell label" (:doc (get by-k :label))))
       (is (nil? (:doc (get by-k :count))))
       (is (= "Total" (:value (get by-k :label))))))
   (testing "args-rows accepts the Storybook-compat :description key"
-    (story/reg-variant :story.a/desc
+    (rf.story/reg-variant :story.a/desc
       {:argtypes {:label {:description "Story-compat description slot"}}
        :setup   []})
-    (let [[row] (docs/args-rows :story.a/desc {:label "foo"})]
+    (let [[row] (rf.story.ui.docs/args-rows :story.a/desc {:label "foo"})]
       (is (= "Story-compat description slot" (:doc row)))))
   (testing "args-rows accepts a bare-string :argtypes value"
-    (story/reg-variant :story.a/bare
+    (rf.story/reg-variant :story.a/bare
       {:argtypes {:label "Short doc"}
        :setup   []})
-    (let [[row] (docs/args-rows :story.a/bare {:label "foo"})]
+    (let [[row] (rf.story.ui.docs/args-rows :story.a/bare {:label "foo"})]
       (is (= "Short doc" (:doc row)))))
   (testing "args-rows merges parent-story :argtypes under variant :argtypes"
-    (story/reg-story :story.p
+    (rf.story/reg-story :story.p
       {:argtypes {:label {:doc "from story"}
                   :count {:doc "from story"}}})
-    (story/reg-variant :story.p/x
+    (rf.story/reg-variant :story.p/x
       {:argtypes {:label {:doc "from variant"}}
        :setup   []})
-    (let [rows  (docs/args-rows :story.p/x {:label "L" :count 0})
+    (let [rows  (rf.story.ui.docs/args-rows :story.p/x {:label "L" :count 0})
           by-k  (into {} (map (juxt :key identity)) rows)]
       (is (= "from variant" (:doc (get by-k :label))))
       (is (= "from story"   (:doc (get by-k :count)))))))
@@ -751,7 +751,7 @@
                 :fx-override  [{:id :dec/fx :body {:kind :fx-override}}]
                 :errors       [{:id :dec/bad :reason "unknown :kind"}]
                 :fingerprints {}}
-          rows (docs/decorator-rows pack)]
+          rows (rf.story.ui.docs/decorator-rows pack)]
       (is (= 5 (count rows)))
       (is (= [:hiccup :hiccup :frame-setup :fx-override :error]
              (mapv :section rows)))
@@ -760,90 +760,90 @@
 
 (deftest docs-parameter-rows-pulls-three-slots
   (testing "parameter-rows emits :modes / :substrates / :platforms only when non-empty"
-    (story/reg-variant :story.p1/x
+    (rf.story/reg-variant :story.p1/x
       {:substrates #{:reagent}
        :platforms  #{:client}
        :setup     []})
-    (let [rows  (docs/parameter-rows :story.p1/x)
+    (let [rows  (rf.story.ui.docs/parameter-rows :story.p1/x)
           by-k  (into {} (map (juxt :key identity)) rows)]
       (is (= 2 (count rows)))
       (is (contains? by-k :substrates))
       (is (contains? by-k :platforms))
       (is (not (contains? by-k :modes)))))
   (testing "parameter-rows falls back to the parent story's slots"
-    (story/reg-story :story.p2
+    (rf.story/reg-story :story.p2
       {:substrates #{:reagent :uix}
        :platforms  #{:client}})
-    (story/reg-variant :story.p2/x {:setup []})
-    (let [rows (docs/parameter-rows :story.p2/x)
+    (rf.story/reg-variant :story.p2/x {:setup []})
+    (let [rows (rf.story.ui.docs/parameter-rows :story.p2/x)
           by-k (into {} (map (juxt :key identity)) rows)]
       (is (= #{:reagent :uix} (:value (get by-k :substrates))))
       (is (= #{:client}       (:value (get by-k :platforms)))))))
 
 (deftest docs-prose-for-variant
   (testing "prose-for-variant returns workspace prose blocks that reference the variant"
-    (story/reg-variant :story.d/x {:setup []})
-    (story/reg-variant :story.d/y {:setup []})
-    (story/reg-workspace :Workspace.d/intro
+    (rf.story/reg-variant :story.d/x {:setup []})
+    (rf.story/reg-variant :story.d/y {:setup []})
+    (rf.story/reg-workspace :Workspace.d/intro
       {:layout  :prose
        :content [{:type :prose   :body "## How it works"}
                  {:type :variant :id   :story.d/x}
                  {:type :prose   :body "Footer note."}]})
-    (let [blocks (docs/prose-for-variant :story.d/x)]
+    (let [blocks (rf.story.ui.docs/prose-for-variant :story.d/x)]
       (is (= 2 (count blocks)))
       (is (= "## How it works" (-> blocks first :body)))
       (is (= :Workspace.d/intro (-> blocks first :workspace-id))))
     (testing "a variant the workspace doesn't reference picks up nothing"
-      (is (= [] (docs/prose-for-variant :story.d/y)))))
+      (is (= [] (rf.story.ui.docs/prose-for-variant :story.d/y)))))
   (testing "non-prose layouts are ignored entirely"
-    (story/reg-variant :story.dg/x {:setup []})
-    (story/reg-workspace :Workspace.dg/grid
+    (rf.story/reg-variant :story.dg/x {:setup []})
+    (rf.story/reg-workspace :Workspace.dg/grid
       {:layout :grid :variants [:story.dg/x]})
-    (is (= [] (docs/prose-for-variant :story.dg/x))))
+    (is (= [] (rf.story.ui.docs/prose-for-variant :story.dg/x))))
   (testing "prose blocks ride through in source order across multiple workspaces"
-    (story/reg-variant :story.dm/x {:setup []})
-    (story/reg-workspace :Workspace.dm/a
+    (rf.story/reg-variant :story.dm/x {:setup []})
+    (rf.story/reg-workspace :Workspace.dm/a
       {:layout  :prose
        :content [{:type :prose   :body "alpha"}
                  {:type :variant :id   :story.dm/x}]})
-    (story/reg-workspace :Workspace.dm/b
+    (rf.story/reg-workspace :Workspace.dm/b
       {:layout  :prose
        :content [{:type :variant :id   :story.dm/x}
                  {:type :prose   :body "beta"}]})
-    (let [bodies (mapv :body (docs/prose-for-variant :story.dm/x))]
+    (let [bodies (mapv :body (rf.story.ui.docs/prose-for-variant :story.dm/x))]
       ;; Sorted by workspace id (alphabetic) then content order — :a/a
       ;; before :b/b.
       (is (= ["alpha" "beta"] bodies)))))
 
 ;; ---- test mode (rf2-qmjo) -----------------------------------------------
 
-;; rf2-ee38b.3: the `test-mode/parent-story-id` re-export was dropped;
+;; rf2-ee38b.3: the `rf.story.ui.test-mode.pure/parent-story-id` re-export was dropped;
 ;; the canonical `parent-story-id` lives in `re-frame.story.predicates`
-;; (covered by its own tests). The view calls `pred/parent-story-id`
+;; (covered by its own tests). The view calls `rf.story.predicates/parent-story-id`
 ;; directly.
 
 (deftest test-mode-variant-has-tests?-checks-play-slot
   (testing "variant-has-tests? is false when :script is absent or empty"
-    (story/reg-variant :story.tm/empty {:setup []})
-    (story/reg-variant :story.tm/empty-play {:setup [] :script []})
-    (is (not (test-mode/variant-has-tests? :story.tm/empty)))
-    (is (not (test-mode/variant-has-tests? :story.tm/empty-play))))
+    (rf.story/reg-variant :story.tm/empty {:setup []})
+    (rf.story/reg-variant :story.tm/empty-play {:setup [] :script []})
+    (is (not (rf.story.ui.test-mode.pure/variant-has-tests? :story.tm/empty)))
+    (is (not (rf.story.ui.test-mode.pure/variant-has-tests? :story.tm/empty-play))))
   (testing "variant-has-tests? is true when :script carries any step"
-    (story/reg-variant :story.tm/has
+    (rf.story/reg-variant :story.tm/has
       {:setup [] :script [[:dispatch-sync [:rf.assert/path-equals [:count] 0]]]})
-    (is (test-mode/variant-has-tests? :story.tm/has)))
+    (is (rf.story.ui.test-mode.pure/variant-has-tests? :story.tm/has)))
   (testing "rf2-ee38b.3: variant-has-tests? recognises the :plays slot too"
-    (story/reg-variant :story.tm/plays
+    (rf.story/reg-variant :story.tm/plays
       {:setup [] :plays [{:name "happy"
                            :script [[:dispatch-sync [:rf.assert/path-equals [:n] 1]]]}]})
-    (is (test-mode/variant-has-tests? :story.tm/plays)
+    (is (rf.story.ui.test-mode.pure/variant-has-tests? :story.tm/plays)
         "a :plays-only variant is testable (was false before the fix)"))
   (testing "variant-has-tests? returns false for an unknown variant-id"
-    (is (not (test-mode/variant-has-tests? :story.tm/unknown)))))
+    (is (not (rf.story.ui.test-mode.pure/variant-has-tests? :story.tm/unknown)))))
 
 (deftest shell-state-aggregate-summary-counts-pass-fail-skip
   (testing "aggregate-summary tallies passed / failed / skipped"
-    (let [s (state/aggregate-summary
+    (let [s (rf.story.ui.state/aggregate-summary
               [{:assertion :rf.assert/path-equals :passed? true}
                {:assertion :rf.assert/path-equals :passed? false}
                {:assertion :rf.assert/sub-equals  :passed? true}
@@ -855,19 +855,19 @@
       (is (false? (:all-passed? s)))))
   (testing "aggregate-summary's :all-passed? is true only when every
             non-skipped record passed AND no records were skipped"
-    (let [all-pass (state/aggregate-summary
+    (let [all-pass (rf.story.ui.state/aggregate-summary
                      [{:assertion :rf.assert/path-equals :passed? true}
                       {:assertion :rf.assert/sub-equals  :passed? true}])]
       (is (true?  (:all-passed? all-pass)))
       (is (= 0   (:failed all-pass)))
       (is (= 0   (:skipped all-pass))))
-    (let [with-skip (state/aggregate-summary
+    (let [with-skip (rf.story.ui.state/aggregate-summary
                       [{:assertion :rf.assert/path-equals :passed? true}
                        {:assertion :rf.assert/skipped     :passed? false}])]
       (is (false? (:all-passed? with-skip))
           "a skipped record disqualifies :all-passed?")))
   (testing "aggregate-summary on an empty vector returns zeros + :all-passed? false"
-    (let [s (state/aggregate-summary [])]
+    (let [s (rf.story.ui.state/aggregate-summary [])]
       (is (= 0 (:total s)))
       (is (= 0 (:passed s)))
       (is (= 0 (:failed s)))
@@ -875,17 +875,17 @@
       (is (false? (:all-passed? s))
           "zero records = not 'all passed' (the variant ran nothing)")))
   (testing "aggregate-summary tolerates nil"
-    (let [s (state/aggregate-summary nil)]
+    (let [s (rf.story.ui.state/aggregate-summary nil)]
       (is (= 0 (:total s)))
       (is (false? (:all-passed? s))))))
 
 (deftest record-test-run-preserves-skipped-and-failure-counts
   (testing "test-widget projection keeps skipped and failed counts actionable"
-    (let [summary (state/aggregate-summary
+    (let [summary (rf.story.ui.state/aggregate-summary
                     [{:assertion :rf.assert/path-equals :passed? true}
                      {:assertion :rf.assert/path-equals :passed? false}
                      {:assertion :rf.assert/skipped     :passed? false}])
-          s       (state/record-test-run state/default-shell-state
+          s       (rf.story.ui.state/record-test-run rf.story.ui.state/default-shell-state
                                          :story.agg/failing
                                          (assoc summary
                                                 :ran-at-ms 123
@@ -901,7 +901,7 @@
 
 (deftest test-mode-assertion-row-projection
   (testing "assertion-row maps a passing record to :status :pass"
-    (let [row (test-mode/assertion-row
+    (let [row (rf.story.ui.test-mode.pure/assertion-row
                 {:assertion :rf.assert/path-equals
                  :payload   [[:count] 7]
                  :passed?   true
@@ -912,7 +912,7 @@
       (is (re-find #":rf.assert/path-equals" (:label row)))
       (is (re-find #"\[\[:count\] 7\]" (:label row)))))
   (testing "assertion-row maps a failing record to :status :fail + surfaces detail"
-    (let [row (test-mode/assertion-row
+    (let [row (rf.story.ui.test-mode.pure/assertion-row
                 {:assertion :rf.assert/path-equals
                  :payload   [[:count] 7]
                  :passed?   false
@@ -927,23 +927,23 @@
         (is (= "mismatch" (:reason d)))
         (is (= {:file "stories.cljs" :line 42} (:source d))))))
   (testing "assertion-row maps :rf.assert/skipped to :status :skip"
-    (let [row (test-mode/assertion-row
+    (let [row (rf.story.ui.test-mode.pure/assertion-row
                 {:assertion :rf.assert/skipped :passed? false})]
       (is (= :skip (:status row)))))
   (testing "assertion-row reads :source-coord as a fallback for :source"
-    (let [row (test-mode/assertion-row
+    (let [row (rf.story.ui.test-mode.pure/assertion-row
                 {:assertion :rf.assert/sub-equals
                  :passed?   false
                  :source-coord {:file "f.cljs" :line 9}})]
       (is (= {:file "f.cljs" :line 9} (-> row :detail :source)))))
   (testing "assertion-row's :label omits an empty payload"
-    (let [row (test-mode/assertion-row
+    (let [row (rf.story.ui.test-mode.pure/assertion-row
                 {:assertion :rf.assert/no-warnings
                  :payload   []
                  :passed?   true})]
       (is (= ":rf.assert/no-warnings" (:label row)))))
   (testing "assertion-row tolerates a fully-empty record without throwing"
-    (let [row (test-mode/assertion-row nil)]
+    (let [row (rf.story.ui.test-mode.pure/assertion-row nil)]
       (is (= :fail (:status row))
           "nil record defaults to fail — a missing passed? slot can't be 'pass'")
       (is (some? (:label row)))))
@@ -951,10 +951,10 @@
             :expanded on stable identity instead of positional index (rf2-tistm).
             A re-run that reorders or inserts assertions would otherwise open
             the wrong row."
-    (let [a (test-mode/assertion-row
+    (let [a (rf.story.ui.test-mode.pure/assertion-row
               {:assertion :rf.assert/path-equals :payload [[:count] 1]
                :passed? false :expected 1 :actual 0})
-          b (test-mode/assertion-row
+          b (rf.story.ui.test-mode.pure/assertion-row
               {:assertion :rf.assert/path-equals :payload [[:count] 2]
                :passed? false :expected 2 :actual 0})]
       (is (= (:label a) (:row-key a)))
@@ -966,41 +966,41 @@
 (deftest test-mode-assertion-row-unified-status
   (testing "rf2-ba86n.11 — assertion-row PREFERS the unified `:status` over
             the legacy :passed? read (spec/021 §1 migration)"
-    (is (= :cannot-run (:status (test-mode/assertion-row
+    (is (= :cannot-run (:status (rf.story.ui.test-mode.pure/assertion-row
                                   {:assertion :rf.assert/caused
                                    :status    :cannot-run
                                    :passed?   false})))
         "a stamped :cannot-run wins — NOT folded into :fail")
-    (is (= :error (:status (test-mode/assertion-row
+    (is (= :error (:status (rf.story.ui.test-mode.pure/assertion-row
                              {:assertion :rf.assert/path-equals
                               :status    :error
                               :passed?   false})))
         "a stamped :error reads :error, not :fail")
-    (is (= :pass (:status (test-mode/assertion-row
+    (is (= :pass (:status (rf.story.ui.test-mode.pure/assertion-row
                             {:assertion :rf.assert/path-equals
                              :status    :pass
                              :passed?   false})))
         "the stamped :status wins even when :passed? disagrees")
     (testing "unstamped records still derive :cannot-run / :error from flags"
-      (is (= :cannot-run (:status (test-mode/assertion-row
+      (is (= :cannot-run (:status (rf.story.ui.test-mode.pure/assertion-row
                                     {:assertion :rf.assert/caused
                                      :cannot-run? true}))))
-      (is (= :error (:status (test-mode/assertion-row
+      (is (= :error (:status (rf.story.ui.test-mode.pure/assertion-row
                                {:assertion :rf.assert/path-equals
                                 :error "boom"})))))))
 
 (deftest test-mode-run-status
   (testing "rf2-ba86n.11 — run-status prefers the unified run-level :status"
-    (is (= :pass       (test-mode/run-status {:status :pass} {})))
-    (is (= :fail       (test-mode/run-status {:status :fail} {})))
-    (is (= :error      (test-mode/run-status {:status :error} {})))
-    (is (= :cannot-run (test-mode/run-status {:status :cannot-run} {}))))
+    (is (= :pass       (rf.story.ui.test-mode.pure/run-status {:status :pass} {})))
+    (is (= :fail       (rf.story.ui.test-mode.pure/run-status {:status :fail} {})))
+    (is (= :error      (rf.story.ui.test-mode.pure/run-status {:status :error} {})))
+    (is (= :cannot-run (rf.story.ui.test-mode.pure/run-status {:status :cannot-run} {}))))
   (testing "no result → :pending; a result without :status derives from counts"
-    (is (= :pending (test-mode/run-status nil nil)))
-    (is (= :pending (test-mode/run-status {} {:total 0})))
-    (is (= :pass    (test-mode/run-status {} {:total 2 :failed 0 :all-passed? true})))
-    (is (= :fail    (test-mode/run-status {} {:total 2 :failed 1})))
-    (is (= :cannot-run (test-mode/run-status {} {:total 2 :failed 0 :cannot-run 1})))))
+    (is (= :pending (rf.story.ui.test-mode.pure/run-status nil nil)))
+    (is (= :pending (rf.story.ui.test-mode.pure/run-status {} {:total 0})))
+    (is (= :pass    (rf.story.ui.test-mode.pure/run-status {} {:total 2 :failed 0 :all-passed? true})))
+    (is (= :fail    (rf.story.ui.test-mode.pure/run-status {} {:total 2 :failed 1})))
+    (is (= :cannot-run (rf.story.ui.test-mode.pure/run-status {} {:total 2 :failed 0 :cannot-run 1})))))
 
 (deftest test-mode-check-rows
   (testing "rf2-ba86n.11 — check-rows groups the result's :checks by id, with
@@ -1011,7 +1011,7 @@
                                           :status :pass :payload [[:user] 1]}
                                          {:assertion :rf.assert/path-equals
                                           :status :fail :payload [[:role] :admin]}]}]}
-          rows   (test-mode/check-rows result)]
+          rows   (rf.story.ui.test-mode.pure/check-rows result)]
       (is (= 1 (count rows)))
       (let [r (first rows)]
         (is (= :auth/logged-in (:check r)))
@@ -1021,8 +1021,8 @@
         (is (= 2 (:total r)))
         (is (= 2 (count (:rows r))) "underlying assertion rows are projected"))))
   (testing "no checks → empty (honest empty state, never a fabricated check)"
-    (is (= [] (test-mode/check-rows {})))
-    (is (= [] (test-mode/check-rows {:checks []})))))
+    (is (= [] (rf.story.ui.test-mode.pure/check-rows {})))
+    (is (= [] (rf.story.ui.test-mode.pure/check-rows {:checks []})))))
 
 (deftest test-mode-schema-rows
   (testing "rf2-ba86n.11 — schema-rows marks consumed vs unconsumed
@@ -1036,7 +1036,7 @@
                   :assertions
                   [{:assertion :rf.assert/schema-error :status :pass
                     :actual [:event :auth/login]}]}
-          rows   (test-mode/schema-rows result)]
+          rows   (rf.story.ui.test-mode.pure/schema-rows result)]
       (is (= 2 (count rows)))
       (is (true?  (:consumed? (first rows)))  "exactly-consumed expected violation")
       (is (false? (:consumed? (second rows))) "unconsumed → agreement-floor failure")
@@ -1054,7 +1054,7 @@
                   :assertions
                   [{:assertion :rf.assert/schema-error :status :pass
                     :actual [:event :x]}]}
-          rows   (test-mode/schema-rows result)]
+          rows   (rf.story.ui.test-mode.pure/schema-rows result)]
       (is (= 2 (count rows)))
       (is (true?  (:consumed? (first rows)))
           "first of the two same-selector violations is the consumed one")
@@ -1071,7 +1071,7 @@
                   ;; escape-hatch excuses the first selector (no :pass record)
                   :consumed-selectors #{[:event :auth/login]}
                   :assertions []}
-          rows   (test-mode/schema-rows result)]
+          rows   (rf.story.ui.test-mode.pure/schema-rows result)]
       (is (true?  (:consumed? (first rows)))  "escape-hatch selector excused")
       (is (false? (:consumed? (second rows)))
           "selector absent from :consumed-selectors → unconsumed")))
@@ -1084,11 +1084,11 @@
                   :assertions
                   [{:assertion :rf.assert/schema-error :status :pass
                     :actual [:event :auth/login]}]}
-          rows   (test-mode/schema-rows result)]
+          rows   (rf.story.ui.test-mode.pure/schema-rows result)]
       (is (true? (:consumed? (first rows)))
           "the `:pass` record's consumed violation reads consumed (multiset source)")))
   (testing "no violations → empty"
-    (is (= [] (test-mode/schema-rows {})))))
+    (is (= [] (rf.story.ui.test-mode.pure/schema-rows {})))))
 
 (deftest test-mode-cannot-run-rows
   (testing "rf2-ba86n.11 — cannot-run-rows surfaces required vs available
@@ -1101,7 +1101,7 @@
                     :reason           :runner-lacks-capability
                     :runner           :headless
                     :unit             [:click "#go"]}]}
-          rows   (test-mode/cannot-run-rows result)]
+          rows   (rf.story.ui.test-mode.pure/cannot-run-rows result)]
       (is (= 1 (count rows)))
       (let [r (first rows)]
         (is (= #{:dom}      (:required r)))
@@ -1110,16 +1110,16 @@
         (is (= :runner-lacks-capability (:reason r)))
         (is (= :headless    (:runner r))))))
   (testing "no refusals → empty"
-    (is (= [] (test-mode/cannot-run-rows {})))))
+    (is (= [] (rf.story.ui.test-mode.pure/cannot-run-rows {})))))
 
 (deftest test-mode-filter-rows
   (testing "rf2-ba86n.11 — failed-only filter keeps only actionable rows
             (:fail/:error/:cannot-run) when on (spec/021 §1)"
     (let [rows [{:status :pass}  {:status :fail}  {:status :error}
                 {:status :cannot-run} {:status :skip} {:status :pass}]]
-      (is (= 6 (count (test-mode/filter-rows rows false)))
+      (is (= 6 (count (rf.story.ui.test-mode.pure/filter-rows rows false)))
           "filter off → every row")
-      (let [kept (test-mode/filter-rows rows true)]
+      (let [kept (rf.story.ui.test-mode.pure/filter-rows rows true)]
         (is (= 3 (count kept)))
         (is (= [:fail :error :cannot-run] (mapv :status kept))
             ":pass / :skip rows are filtered out")))))
@@ -1127,43 +1127,43 @@
 (deftest test-mode-evidence-available?
   (testing "rf2-ba86n.11 — evidence-available? gates the graceful pending
             affordance on a retained tape/narrative (spec/021 §2)"
-    (is (true?  (test-mode/evidence-available? {:epoch-tape [{:epoch-id 1}]})))
-    (is (true?  (test-mode/evidence-available? {:narrative [{:span 1}]})))
-    (is (false? (test-mode/evidence-available? {:epoch-tape [] :narrative []})))
-    (is (false? (test-mode/evidence-available? {})))))
+    (is (true?  (rf.story.ui.test-mode.pure/evidence-available? {:epoch-tape [{:epoch-id 1}]})))
+    (is (true?  (rf.story.ui.test-mode.pure/evidence-available? {:narrative [{:span 1}]})))
+    (is (false? (rf.story.ui.test-mode.pure/evidence-available? {:epoch-tape [] :narrative []})))
+    (is (false? (rf.story.ui.test-mode.pure/evidence-available? {})))))
 
 (deftest test-mode-format-elapsed-ms
   (testing "format-elapsed-ms switches at the 1s boundary"
-    (is (= "0 ms"   (test-mode/format-elapsed-ms 0)))
-    (is (= "12 ms"  (test-mode/format-elapsed-ms 12)))
-    (is (= "999 ms" (test-mode/format-elapsed-ms 999)))
-    (is (= "1.0 s"  (test-mode/format-elapsed-ms 1000)))
-    (is (= "1.2 s"  (test-mode/format-elapsed-ms 1234))))
+    (is (= "0 ms"   (rf.story.ui.test-mode.pure/format-elapsed-ms 0)))
+    (is (= "12 ms"  (rf.story.ui.test-mode.pure/format-elapsed-ms 12)))
+    (is (= "999 ms" (rf.story.ui.test-mode.pure/format-elapsed-ms 999)))
+    (is (= "1.0 s"  (rf.story.ui.test-mode.pure/format-elapsed-ms 1000)))
+    (is (= "1.2 s"  (rf.story.ui.test-mode.pure/format-elapsed-ms 1234))))
   (testing "format-elapsed-ms tolerates nil / non-numbers / negatives"
-    (is (= "" (test-mode/format-elapsed-ms nil)))
-    (is (= "" (test-mode/format-elapsed-ms "no")))
-    (is (= "" (test-mode/format-elapsed-ms -5)))))
+    (is (= "" (rf.story.ui.test-mode.pure/format-elapsed-ms nil)))
+    (is (= "" (rf.story.ui.test-mode.pure/format-elapsed-ms "no")))
+    (is (= "" (rf.story.ui.test-mode.pure/format-elapsed-ms -5)))))
 
 (deftest test-mode-format-timestamp-ms
   (testing "format-timestamp-ms emits an HH:mm:ss-shaped string"
-    (let [s (test-mode/format-timestamp-ms (System/currentTimeMillis))]
+    (let [s (rf.story.ui.test-mode.pure/format-timestamp-ms (System/currentTimeMillis))]
       (is (re-matches #"\d{2}:\d{2}:\d{2}" s))))
   (testing "format-timestamp-ms returns empty string for non-numbers"
-    (is (= "" (test-mode/format-timestamp-ms nil)))
-    (is (= "" (test-mode/format-timestamp-ms "no")))))
+    (is (= "" (rf.story.ui.test-mode.pure/format-timestamp-ms nil)))
+    (is (= "" (rf.story.ui.test-mode.pure/format-timestamp-ms "no")))))
 
 ;; ---- step-through scrubber (rf2-lc36w) ----------------------------------
 
 (deftest test-mode-play-step-label-renders-event-id
   (testing "play-step-label stringifies the event-id only"
     (is (= ":auth/email-changed"
-           (test-mode/play-step-label [:auth/email-changed "alice@example.com"])))
+           (rf.story.ui.test-mode.pure/play-step-label [:auth/email-changed "alice@example.com"])))
     (is (= ":rf.assert/path-equals"
-           (test-mode/play-step-label [:rf.assert/path-equals [[:count] 7]]))))
+           (rf.story.ui.test-mode.pure/play-step-label [:rf.assert/path-equals [[:count] 7]]))))
   (testing "play-step-label tolerates nil / malformed input"
-    (is (= "" (test-mode/play-step-label nil)))
-    (is (= "" (test-mode/play-step-label [])))
-    (is (= "" (test-mode/play-step-label "not-a-vec")))))
+    (is (= "" (rf.story.ui.test-mode.pure/play-step-label nil)))
+    (is (= "" (rf.story.ui.test-mode.pure/play-step-label [])))
+    (is (= "" (rf.story.ui.test-mode.pure/play-step-label "not-a-vec")))))
 
 (deftest test-mode-play-step-statuses-maps-events-to-status
   (testing "non-assertion events get :event status; assertion events get :pass/:fail from records"
@@ -1173,7 +1173,7 @@
                       [:rf.assert/path-equals [[:user :submitted?] true]]]
           assertions [{:assertion :rf.assert/path-equals :passed? true}
                       {:assertion :rf.assert/path-equals :passed? false}]
-          out        (test-mode/play-step-statuses play assertions)]
+          out        (rf.story.ui.test-mode.pure/play-step-statuses play assertions)]
       (is (= 4 (count out)) "one row per play event")
       (is (= [:event :event :pass :fail] (mapv :status out)))
       (is (= [0 1 2 3] (mapv :index out)))
@@ -1183,18 +1183,18 @@
   (testing "play-step-statuses handles :rf.assert/skipped as :skip"
     (let [play       [[:rf.assert/skipped]]
           assertions [{:assertion :rf.assert/skipped :passed? false}]
-          out        (test-mode/play-step-statuses play assertions)]
+          out        (rf.story.ui.test-mode.pure/play-step-statuses play assertions)]
       (is (= [:skip] (mapv :status out)))))
   (testing "play-step-statuses tolerates fewer records than assertion events (fail-fast gap)"
     ;; assertion event with no matching record renders :fail so the user sees the gap.
     (let [play       [[:rf.assert/path-equals [[:k] 1]]
                       [:rf.assert/path-equals [[:k] 2]]]
           assertions [{:assertion :rf.assert/path-equals :passed? true}]
-          out        (test-mode/play-step-statuses play assertions)]
+          out        (rf.story.ui.test-mode.pure/play-step-statuses play assertions)]
       (is (= [:pass :fail] (mapv :status out)))))
   (testing "play-step-statuses handles empty inputs"
-    (is (= [] (test-mode/play-step-statuses [] [])))
-    (is (= [] (test-mode/play-step-statuses nil nil)))))
+    (is (= [] (rf.story.ui.test-mode.pure/play-step-statuses [] [])))
+    (is (= [] (rf.story.ui.test-mode.pure/play-step-statuses nil nil)))))
 
 (deftest test-mode-epoch-id-slice-trigger-event-alignment
   (testing "epoch-id-slice matches each play-event against the tape by
@@ -1204,7 +1204,7 @@
           tape        [{:epoch-id 10 :trigger-event [:a]}
                        {:epoch-id 11 :trigger-event [:b]}
                        {:epoch-id 12 :trigger-event [:c]}]]
-      (is (= [10 11 12] (test-mode/epoch-id-slice tape play-events)))))
+      (is (= [10 11 12] (rf.story.ui.test-mode.pure/epoch-id-slice tape play-events)))))
   (testing "rf2-4e545l finding 4 — a non-dispatch step (:click/:type) that
             ALSO commits an epoch interleaves a tape record whose
             :trigger-event is not among play-events; epoch-id-slice
@@ -1218,7 +1218,7 @@
                        {:epoch-id 101 :trigger-event [:click/side-effect]}
                        {:epoch-id 102 :trigger-event [:b]}
                        {:epoch-id 103 :trigger-event [:c]}]]
-      (is (= [100 102 103] (test-mode/epoch-id-slice tape play-events))
+      (is (= [100 102 103] (rf.story.ui.test-mode.pure/epoch-id-slice tape play-events))
           "epoch 101 (the interleaved click-triggered epoch) is skipped —
            NOT attributed to play-event [:b], which a positional
            trailing-N slice would have done")))
@@ -1227,8 +1227,8 @@
             contexts degrade gracefully rather than mis-mapping steps"
     (let [play-events [[:a] [:b] [:c]]
           tape        [{:epoch-id 10 :trigger-event [:a]}]]
-      (is (= [] (test-mode/epoch-id-slice tape play-events)))))
+      (is (= [] (rf.story.ui.test-mode.pure/epoch-id-slice tape play-events)))))
   (testing "epoch-id-slice tolerates nil/empty tape and play-events"
-    (is (= [] (test-mode/epoch-id-slice nil [[:a]])))
-    (is (= [] (test-mode/epoch-id-slice [{:epoch-id 1 :trigger-event [:a]}] nil)))
-    (is (= [] (test-mode/epoch-id-slice [] [])))))
+    (is (= [] (rf.story.ui.test-mode.pure/epoch-id-slice nil [[:a]])))
+    (is (= [] (rf.story.ui.test-mode.pure/epoch-id-slice [{:epoch-id 1 :trigger-event [:a]}] nil)))
+    (is (= [] (rf.story.ui.test-mode.pure/epoch-id-slice [] [])))))

--- a/tools/story/testbeds/counter_with_stories/core.cljs
+++ b/tools/story/testbeds/counter_with_stories/core.cljs
@@ -14,9 +14,9 @@
   `implementation/scripts/check-bundle-isolation.cjs` verifies the
   Story-sentinel set is absent under that build."
   (:require [re-frame.core      :as rf]
-            [re-frame.story     :as story]
-            [re-frame.story.play.ci-runner :as story-ci]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.story     :as rf.story]
+            [re-frame.story.play.ci-runner :as rf.story.play.ci-runner]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             [day8.re-frame2-xray.config :as xray-config]
             ;; Source the events + subs + views via the stories ns,
             ;; which itself requires them. When Story is elided the
@@ -32,7 +32,7 @@
             [counter-with-stories.stories]
             ;; Shared Story-host helper: owns the live-app↔Story-shell
             ;; hash router + React-root handle.
-            [re-frame.testbed.story-host :as story-host])
+            [re-frame.testbed.story-host :as rf.testbed.story-host])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; -- The live-app root view ------------------------------------------------
@@ -71,8 +71,8 @@
   ;; launch; app pages that want Xray inline still provide the normal
   ;; `[data-rf-xray-host]` contract.
   (xray-config/configure! {:rf.xray/auto-open? false})
-  (rf/init! reagent-adapter/adapter)
-  ;; No explicit `(story/install-canonical-vocabulary!)` call — the
+  (rf/init! rf.adapter.reagent/adapter)
+  ;; No explicit `(rf.story/install-canonical-vocabulary!)` call — the
   ;; first `reg-*` in `counter-with-stories.stories` (loaded via
   ;; :require above) auto-installs the canonical vocabulary on demand
   ;; per spec/001 §Boot. Canonical testbeds carry no explicit boot call.
@@ -82,7 +82,7 @@
   ;; here: the dev server's open-in-editor endpoint resolves source
   ;; coordinates at request time, so this call carries only the
   ;; global-args layer.
-  (story/configure! {:rf.story/global-args {:locale :en}})
+  (rf.story/configure! {:rf.story/global-args {:locale :en}})
   ;; EP-0002: `init!` installs the adapter only — register the
   ;; testbed's `:rf/default` app frame explicitly, then run the frame-local
   ;; boot work (seed dispatch + elision listener install) inside its scope.
@@ -112,11 +112,11 @@
   ;; play-script runner reads. Inert until the runner polls it; safe
   ;; to install unconditionally because the function body is gated
   ;; on Story being enabled (the ns itself is Story-tooling).
-  (story-ci/install-ci-hooks!)
+  (rf.story.play.ci-runner/install-ci-hooks!)
   ;; Wire the live-app↔Story-shell hash router (shared helper) so reloading
   ;; `#/stories` lands on the shell without a manual click-through. No
   ;; open-in-editor root is configured: the dev server's
   ;; `POST /__rf-open-in-editor` endpoint resolves this testbed's
   ;; classpath-relative source coordinates against the live JVM source paths
   ;; at request time.
-  (story-host/mount-with-hash-routing! live-app-root))
+  (rf.testbed.story-host/mount-with-hash-routing! live-app-root))

--- a/tools/story/testbeds/counter_with_stories/elision_demo_cljs_test.cljs
+++ b/tools/story/testbeds/counter_with_stories/elision_demo_cljs_test.cljs
@@ -22,12 +22,12 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core         :as rf]
-            [re-frame.elision      :as elision]
-            [re-frame.event-emit   :as event-emit]
-            [re-frame.frame        :as frame]
-            [re-frame.late-bind    :as late-bind]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
+            [re-frame.elision      :as rf.elision]
+            [re-frame.event-emit   :as rf.event-emit]
+            [re-frame.frame        :as rf.frame]
+            [re-frame.late-bind    :as rf.late-bind]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
             ;; Loading the demo ns fires its registrations against the
             ;; registrar — the tests then exercise the registered
             ;; handlers + the listener install/uninstall surface.
@@ -53,14 +53,14 @@
 (def ^:private registrar-snapshot (atom nil))
 
 (defn- before! []
-  (reset! registrar-snapshot (test-support/snapshot-registrar))
+  (reset! registrar-snapshot (rf.test-support/snapshot-registrar))
   ;; Xray's preload-time trace-cb registers its bookkeeping
   ;; handlers with `:rf.trace/no-emit? true`, so the framework
   ;; short-circuits emission for them and the collector never
   ;; re-enters itself. The previous workaround that wiped the
   ;; trace-cb registry per fixture is obsolete — Xray's cb runs
   ;; as production preload wires it.
-  (reset! frame/frames {})
+  (reset! rf.frame/frames {})
   ;; Clear cross-namespace schemas from the per-frame registry
   ;; before re-registering this demo's
   ;; declarations. Sibling test namespaces (auth-flow story tests,
@@ -68,11 +68,11 @@
   ;; at ns-load; the post-commit validation rollback would otherwise
   ;; fire on every dispatch in this file against those unrelated
   ;; schemas.
-  (when-let [clear! (late-bind/get-fn :schemas/clear-by-frame!)]
+  (when-let [clear! (rf.late-bind/get-fn :schemas/clear-by-frame!)]
     (clear!))
-  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
-  (frame/ensure-default-frame!)
-  (event-emit/clear-event-listeners!)
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
+  (rf.frame/ensure-default-frame!)
+  (rf.event-emit/clear-event-listeners!)
   ;; Re-register this demo's app-db schema (SHAPE only — EP-0015 §8). The
   ;; demo namespace's ns-load `reg-app-schema` call ran once at module load;
   ;; the preceding `(clear!)` step wiped it. Re-stamping it here keeps the
@@ -85,19 +85,19 @@
   ;; EP-0025: durable app-db egress classification rides the commit-plane
   ;; classification effects. Classify the `[:user/avatar-pdf]` large path
   ;; (index-free :rf/path) onto :rf/default's elision registry via
-  ;; `elision/apply-classification-effects` (`:source :effect`) — the same
+  ;; `rf.elision/apply-classification-effects` (`:source :effect`) — the same
   ;; registry write a `reg-event` returning `:large` performs — so
   ;; `elide-wire-value` finds a declared-large entry and substitutes the
   ;; `:rf.size/large-elided` marker on that slot.
-  (frame/swap-runtime-db! :rf/default
-    (fn [rt] (elision/apply-classification-effects rt {:large [[:user/avatar-pdf]]}))))
+  (rf.frame/swap-runtime-db! :rf/default
+    (fn [rt] (rf.elision/apply-classification-effects rt {:large [[:user/avatar-pdf]]}))))
 
 (defn- after! []
   (when-let [snap @registrar-snapshot]
-    (test-support/restore-registrar! snap)
+    (rf.test-support/restore-registrar! snap)
     (reset! registrar-snapshot nil))
-  (reset! frame/frames {})
-  (event-emit/clear-event-listeners!))
+  (reset! rf.frame/frames {})
+  (rf.event-emit/clear-event-listeners!))
 
 ;; EP-0002: these tests exercise the ambient dispatch /
 ;; app-db-read paths, which require a carried frame stamp. A function

--- a/tools/story/testbeds/counter_with_stories/stories.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories.cljs
@@ -65,7 +65,7 @@
   sugar does not cover — `sub-equals`, `dispatched?`, `effect-emitted`
   — alongside one `force-fx-stub` decorator reference."
   (:require [re-frame.core  :as rf]
-            [re-frame.story :as story]
+            [re-frame.story :as rf.story]
             ;; Source the event and view ids by requiring the namespaces
             ;; so they register themselves; the variant bodies reference
             ;; the ids as plain keywords (no fn-slots leak through).
@@ -126,7 +126,7 @@
   ;; registrar throws `:rf.error/unknown-tag`.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-tag :counter-with-stories/canonical
+  (rf.story/reg-tag :counter-with-stories/canonical
     {:doc "Tag applied to the variant that ships as the example's
           canonical screenshot — the one the README points at."})
 
@@ -136,12 +136,12 @@
   ;; preferred shape is the namespaced keyword (`:status/stable`,
   ;; `:role/dev`, `:team/checkout`, `:feature/counter`) — the
   ;; namespace mirrors the axis, the name is the value.
-  (story/reg-tag :status/alpha    {:axis :status :doc "Pre-release."})
-  (story/reg-tag :status/stable   {:axis :status :doc "Production-ready."})
-  (story/reg-tag :role/dev        {:axis :role   :doc "For devs."})
-  (story/reg-tag :role/design     {:axis :role   :doc "For designers."})
-  (story/reg-tag :team/counter    {:axis :team   :doc "Counter squad."})
-  (story/reg-tag :feature/counter {:axis :feature
+  (rf.story/reg-tag :status/alpha    {:axis :status :doc "Pre-release."})
+  (rf.story/reg-tag :status/stable   {:axis :status :doc "Production-ready."})
+  (rf.story/reg-tag :role/dev        {:axis :role   :doc "For devs."})
+  (rf.story/reg-tag :role/design     {:axis :role   :doc "For designers."})
+  (rf.story/reg-tag :team/counter    {:axis :team   :doc "Counter squad."})
+  (rf.story/reg-tag :feature/counter {:axis :feature
                                    :doc  "Counter feature surface."})
 
   ;; -------------------------------------------------------------------------
@@ -154,13 +154,13 @@
   ;; identity for visual regression keying.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-mode :Mode.app/dark
+  (rf.story/reg-mode :Mode.app/dark
     {:doc  "Dark theme — sets the background and label colours."
      :args {:theme       :dark
             :background  "#1e1e1e"
             :foreground  "#e0e0e0"}})
 
-  (story/reg-mode :Mode.app/light
+  (rf.story/reg-mode :Mode.app/light
     {:doc  "Light theme — the default."
      :args {:theme       :light
             :background  "#ffffff"
@@ -170,7 +170,7 @@
   ;; toolbar's single-select-within-axis semantics (spec/010
   ;; §Selection semantics — by axis). Toggling :Mode.app/sepia
   ;; deactivates any other `:axis :theme` mode that was active.
-  (story/reg-mode :Mode.app/sepia
+  (rf.story/reg-mode :Mode.app/sepia
     {:doc  "Sepia theme — exercises the toolbar's single-select-
            within-axis behaviour (`:axis :theme`)."
      :axis :theme
@@ -190,7 +190,7 @@
   ;; closure at render time.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-decorator :counter-with-stories/log-decorator
+  (rf.story/reg-decorator :counter-with-stories/log-decorator
     {:doc  "Wrap the variant in a labelled outline — a tiny custom
            decorator alongside Story's canonical `:rf.story/layout-
            debug.*` set. The first ref-arg becomes the label.
@@ -209,7 +209,7 @@
                  (str "decorator: " (or label "log"))]
                 body]))})
 
-  (story/reg-decorator :counter-with-stories/throwing-decorator
+  (rf.story/reg-decorator :counter-with-stories/throwing-decorator
     {:doc  "Deterministic decorator failure used only by the
            occasional Story feature-load coverage gate. The canvas must
            project the error and keep rendering the underlying variant."
@@ -228,7 +228,7 @@
   ;; stub); projects add their own via reg-story-panel.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-story-panel :Panel.counter-with-stories/notes
+  (rf.story/reg-story-panel :Panel.counter-with-stories/notes
     {:doc       "A small project-custom panel that renders prose
                 alongside the active variant. Reads no app-db; pure
                 static content."
@@ -252,7 +252,7 @@
   ;; render path is documented dev-time UX, not a defect.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-story-panel :Panel.counter-with-stories/broken-render
+  (rf.story/reg-story-panel :Panel.counter-with-stories/broken-render
     {:doc       "Testbed panel whose :render points at an
                 unregistered view so the panel-host renders its
                 'no registered :render view' fallback. Asserted by
@@ -269,7 +269,7 @@
   ;; The variant bodies below override / extend these.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-story :story.counter
+  (rf.story/reg-story :story.counter
     {:doc        "The counter — every variant of the canonical example."
      :component  :counter-with-stories.views/counter-card
      :decorators [[:counter-with-stories/log-decorator "story-level"]]
@@ -278,7 +278,7 @@
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
-  (story/reg-story :story.counter-diagnostics
+  (rf.story/reg-story :story.counter-diagnostics
     {:doc        "Small deterministic failure surfaces for Story's
                  diagnostics and test-mode UI. Kept separate from
                  :story.counter so the canonical four counter variants
@@ -289,7 +289,7 @@
      :tags       #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  (story/reg-story :story.counter-play-script
+  (rf.story/reg-story :story.counter-play-script
     {:doc        "Parent story for the rich-DSL :script CI-as-test
                  fixtures. Two variants exercise both the
                  pass and fail terminal paths of the play runner so the
@@ -300,7 +300,7 @@
      :tags       #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  (story/reg-story :story.counter-matrix
+  (rf.story/reg-story :story.counter-matrix
     {:doc        "Deterministic browser-only affordances for the
                  Story feature coverage matrix. These variants keep
                  the canonical four counter variants stable while
@@ -326,7 +326,7 @@
   ;; one initialisation event in :setup, no decorators of its own
   ;; (inherits the story-level log-decorator). One :script checkpoint:
   ;; after init, the `:count` slot equals zero.
-  (story/reg-variant :story.counter/empty
+  (rf.story/reg-variant :story.counter/empty
     {:doc    "Fresh counter at zero. The simplest possible variant."
      :setup [[:counter/initialise 0]]
      :script [[:assert-db [:count] 0]]
@@ -337,7 +337,7 @@
   ;; the variant-level :args override the story-level :args (precedence:
   ;; global < story < mode < variant). The label is overridden to
   ;; "Total" for this variant only.
-  (story/reg-variant :story.counter/loaded
+  (rf.story/reg-variant :story.counter/loaded
     {:doc    "A counter seeded with a non-zero value."
      :args   {:label "Total"}
      :setup [[:counter/initialise 7]]
@@ -354,7 +354,7 @@
   ;; (not the :setup slot) so the `:rf.assert/dispatched?`
   ;; assertion's accumulator sees them — the trace listener is wired
   ;; for the phase-4 :script, not for the phase-2 :setup.
-  (story/reg-variant :story.counter/clicked-three-times
+  (rf.story/reg-variant :story.counter/clicked-three-times
     {:doc    "Counter after three increments from zero, driven from
              the :script so :rf.assert/dispatched? observes them."
      :setup [[:counter/initialise 0]]
@@ -389,7 +389,7 @@
   ;; the events-only classification and the fast-path it gates. (The
   ;; runtime classifier is named "events-only" after the lowered
   ;; `:setup` slot; the authoring surface is `:setup`.)
-  (story/reg-variant :story.counter/events-only-loaded
+  (rf.story/reg-variant :story.counter/events-only-loaded
     {:doc    "Canonical events-only loader-body shape. Counter seeded at
              5 via `:setup`; no
              `:loaders`, no `:loaders-complete-when`, no `:frame-setup`
@@ -406,12 +406,12 @@
   ;; event is dispatched FROM the :script (not :setup) so the
   ;; trace-bus accumulator (installed at phase-4 start) sees the fx
   ;; and `:rf.assert/effect-emitted` passes.
-  (story/reg-variant :story.counter/save-stubbed
+  (rf.story/reg-variant :story.counter/save-stubbed
     {:doc    "The save flow with the network fx stubbed. Demonstrates
              the MSW-shaped force-fx-stub decorator alongside the
              `:rf.assert/effect-emitted` assertion."
      :setup [[:counter/initialise 5]]
-     :decorators [[story/force-fx-stub-id :counter/sync-to-server {:ok? true}]]
+     :decorators [[rf.story/force-fx-stub-id :counter/sync-to-server {:ok? true}]]
      :script [[:dispatch-sync [:counter/save]]
               [:assert-db [:saving?] true]
               [:assert [:rf.assert/effect-emitted :counter/sync-to-server]]]
@@ -435,7 +435,7 @@
   ;; Test mode must show the failure as data, not as an uncaught browser
   ;; error. This gives the feature-load gate a stable red test-mode
   ;; surface that does not depend on timing or external services.
-  (story/reg-variant :story.counter-diagnostics/failing-play
+  (rf.story/reg-variant :story.counter-diagnostics/failing-play
     {:doc    "Deterministic failing :script assertion. The counter is
              initialised to 1 but the :script assertion expects 999."
      :setup [[:counter/initialise 1]]
@@ -446,7 +446,7 @@
   ;; Diagnostic variant 2 — phase-4 handler exception. The Story
   ;; play-runner projects handler exceptions into the assertion list so
   ;; the test pane can explain the failure without blanking the shell.
-  (story/reg-variant :story.counter-diagnostics/failing-event-throws
+  (rf.story/reg-variant :story.counter-diagnostics/failing-event-throws
     {:doc    "Deterministic event-handler exception during the :script."
      :setup [[:counter/initialise 0]]
      :script [[:dispatch-sync [:counter/throw-deterministic]]]
@@ -455,7 +455,7 @@
 
   ;; Diagnostic variant 3 — loader-phase exception. This exercises the
   ;; phase-1 error capture path separately from ordinary play failures.
-  (story/reg-variant :story.counter-diagnostics/loader-throws
+  (rf.story/reg-variant :story.counter-diagnostics/loader-throws
     {:doc     "Deterministic loader exception before :setup/render."
      :loaders [[:counter/throw-deterministic]]
      :setup  [[:counter/initialise 0]]
@@ -463,7 +463,7 @@
      :tags    #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.counter-diagnostics/render-throws
+  (rf.story/reg-variant :story.counter-diagnostics/render-throws
     {:doc       "Deterministic render exception. The canvas error
                 boundary should project variant id, render phase, view
                 id, and stack detail while keeping the Story shell
@@ -474,7 +474,7 @@
      :tags      #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.counter-matrix/no-play
+  (rf.story/reg-variant :story.counter-matrix/no-play
     {:doc    "Healthy variant with no :script. Test mode should
              render its explicit empty state instead of pretending the
              variant passed."
@@ -484,7 +484,7 @@
      :tags   #{:dev :internal}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.counter-matrix/loader-success
+  (rf.story/reg-variant :story.counter-matrix/loader-success
     {:doc     "Loader success path. The loader seeds :count before the
               normal event phase and the :script assertion observes the
               loaded value."
@@ -495,7 +495,7 @@
      :tags    #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.counter-matrix/loader-never-completes
+  (rf.story/reg-variant :story.counter-matrix/loader-never-completes
     {:doc     "Loader completion failure path. The loader runs, but the
               predicate intentionally never reports ready, so Story
               records a deterministic loader-incomplete assertion
@@ -508,7 +508,7 @@
      :tags    #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.counter-matrix/loader-rejects
+  (rf.story/reg-variant :story.counter-matrix/loader-rejects
     {:doc     "Loader rejection path. The loader throws a deterministic
               ExceptionInfo value whose data must be visible in test
               diagnostics."
@@ -520,7 +520,7 @@
      :tags    #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.counter-matrix/schema-invalid
+  (rf.story/reg-variant :story.counter-matrix/schema-invalid
     {:doc    "Args that mismatch the component's expected prop shape
              (a numeric :label, an unused :settings map). The
              schema-validation panel surfaces a violation only when the
@@ -536,7 +536,7 @@
      :tags   #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.counter-matrix/nested-controls
+  (rf.story/reg-variant :story.counter-matrix/nested-controls
     {:doc    "Nested args/schema fixture for the controls panel. The
              counter card ignores :settings; the right-pane controls
              still expose path-aware nested widgets."
@@ -547,7 +547,7 @@
      :tags   #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.counter-matrix/decorator-throws
+  (rf.story/reg-variant :story.counter-matrix/decorator-throws
     {:doc        "Decorator failure projection fixture."
      :args       {:label "Decorator failure"
                   :settings {:title "Decorator" :enabled? true}}
@@ -557,7 +557,7 @@
      :tags       #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.counter-matrix/multi-substrate
+  (rf.story/reg-variant :story.counter-matrix/multi-substrate
     {:doc        "Side-by-side substrate fixture. Reagent should render;
                  the synthetic substrate should project an unsupported
                  state rather than leak frames or crash."
@@ -568,7 +568,7 @@
      :tags       #{:dev :test :internal}
      :substrates #{:reagent :uix}})
 
-  (story/reg-variant :story.counter-matrix/isolation-a
+  (rf.story/reg-variant :story.counter-matrix/isolation-a
     {:doc    "Frame-isolation fixture A. Same handlers as fixture B,
              different seed."
      :args   {:label "Isolation A"
@@ -578,7 +578,7 @@
      :tags   #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.counter-matrix/isolation-b
+  (rf.story/reg-variant :story.counter-matrix/isolation-b
     {:doc    "Frame-isolation fixture B. Same handlers as fixture A,
              different seed."
      :args   {:label "Isolation B"
@@ -588,7 +588,7 @@
      :tags   #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.counter-matrix/recorder-redaction
+  (rf.story/reg-variant :story.counter-matrix/recorder-redaction
     {:doc       "Recorder browser fixture: the visible button dispatches
                 a :sensitive? event with a password payload. The Story
                 recorder must preserve the row position while emitting
@@ -601,7 +601,7 @@
      :tags      #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.counter-matrix/a11y-known-good
+  (rf.story/reg-variant :story.counter-matrix/a11y-known-good
     {:doc       "Deterministic a11y known-good browser fixture. The
                 browser scenario injects a stable axe-compatible
                 scanner and asserts this fixture reports zero rows."
@@ -613,7 +613,7 @@
      :tags      #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.counter-matrix/a11y-known-bad
+  (rf.story/reg-variant :story.counter-matrix/a11y-known-bad
     {:doc       "Deterministic a11y known-bad browser fixture. The
                 violation is tied to a fixture-owned image selector so
                 output stays stable and never depends on Story chrome."
@@ -637,7 +637,7 @@
   ;; directly without authoring a one-off probe. The variant is
   ;; intentionally :test-tagged so the chrome test-widget picks it up
   ;; and reports the failure.
-  (story/reg-variant :story.counter-matrix/failing-fx-stub-miss
+  (rf.story/reg-variant :story.counter-matrix/failing-fx-stub-miss
     {:doc       "Deterministic failing-fx-stub-miss failing assertion. The
                 :script asserts :rf.assert/effect-emitted :never-stubbed with
                 NO force-fx-stub decorator covering it — the assertion
@@ -677,7 +677,7 @@
   ;; `[:assert-db [:count] 3]`) drifts under double-fire — the CI
   ;; runner is gating the auto-run plumbing, not the under-test app's
   ;; idempotency, so we keep the scripts neutral on that axis.
-  (story/reg-variant :story.counter-play-script/passing
+  (rf.story/reg-variant :story.counter-play-script/passing
     {:doc        "CI fixture — initialise the counter to 3
                  and assert :count equals 3. Idempotent under any
                  number of auto-run repeats."
@@ -691,7 +691,7 @@
      :tags       #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.counter-play-script/failing
+  (rf.story/reg-variant :story.counter-play-script/failing
     {:doc        "CI fixture — initialise the counter to 1
                  then assert the WRONG final count (expect 9). The CI
                  runner observes the :fail terminal status and matches
@@ -713,7 +713,7 @@
   ;; directly instead of a symbol). The fixture pairs an in-line
   ;; anonymous predicate with a top-level clojure.core predicate so both
   ;; cases land in the browser-side play-script runner.
-  (story/reg-variant :story.counter-play-script/pred-fn-direct
+  (rf.story/reg-variant :story.counter-play-script/pred-fn-direct
     {:doc        "CI fixture for `:assert-db :pred` with fn
                  references handed in directly. Survives advanced CLJS
                  because no symbol resolution is performed at run time."
@@ -743,7 +743,7 @@
   ;; Runs under the reactive browser runner (the `:cljs-reactive` runner the
   ;; Story shell mounts); a non-reactive runner fails it closed to
   ;; `:cannot-run`, never a silent pass.
-  (story/reg-variant :story.counter-play-script/causal-honest-guard
+  (rf.story/reg-variant :story.counter-play-script/causal-honest-guard
     {:doc        "Causal-assertion CI fixture — :counter/inc CAUSED a
                  :count recompute, and :counter/save (observed) did NOT
                  cascade-rerender :count. Exercises the causal
@@ -776,7 +776,7 @@
   ;; The script: seed db → type "42" → click set → wait for re-render →
   ;; assert app-db AND the rendered text both reflect 42. End-to-end
   ;; coverage of every DOM-step type in one play.
-  (story/reg-variant :story.counter-play-script/dom
+  (rf.story/reg-variant :story.counter-play-script/dom
     {:doc        "DOM-step fixture — exercises every
                  rich-DSL DOM step (`:click` / `:type` / `:assert-dom`)
                  end-to-end against a real browser DOM. Pairs with the
@@ -808,7 +808,7 @@
      :tags       #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  (story/reg-variant :story.counter-play-script/dom-expected-fail
+  (rf.story/reg-variant :story.counter-play-script/dom-expected-fail
     {:doc        "Expected-fail twin — same DOM-step shape as
                  :story.counter-play-script/dom but the FINAL
                  `:assert-dom :text` expects '99' against an actual
@@ -836,7 +836,7 @@
   ;; default; the other two run on demand (manual trigger via the
   ;; toolbar dropdown OR the CI runner's `runPlay` hook). One play
   ;; deliberately fails to keep the failure path under CI coverage.
-  (story/reg-variant :story.counter-play-script/multi
+  (rf.story/reg-variant :story.counter-play-script/multi
     {:doc        "CI fixture — multi-play variant with three
                  named plays. The CI runner enumerates each play as its
                  own row (per-play pass/fail) and matches the per-play
@@ -863,7 +863,7 @@
   ;; `:variants-grid` — enumerates the parent story's variants automatically.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-workspace :Workspace.counter/all-states
+  (rf.story/reg-workspace :Workspace.counter/all-states
     {:doc       "Every named counter state, side-by-side."
      :layout    :grid
      :variants  [:story.counter/empty
@@ -873,7 +873,7 @@
      :columns   2
      :tags      #{:docs}})
 
-  (story/reg-workspace :Workspace.counter/auto-grid
+  (rf.story/reg-workspace :Workspace.counter/auto-grid
     {:doc      "Auto-enumerated grid — pulls every variant off
                :story.counter. New variants appear here without
                touching this workspace."
@@ -882,7 +882,7 @@
      :columns  2
      :tags     #{:docs}})
 
-  (story/reg-workspace :Workspace.counter/prose
+  (rf.story/reg-workspace :Workspace.counter/prose
     {:doc     "Prose layout fixture for docs/workspace coverage."
      :layout  :prose
      :content [{:type :prose
@@ -893,14 +893,14 @@
                 :body "Story matrix prose block after the example."}]
      :tags    #{:docs}})
 
-  (story/reg-workspace :Workspace.counter/tabs
+  (rf.story/reg-workspace :Workspace.counter/tabs
     {:doc      "Tabs layout fixture for workspace coverage."
      :layout   :tabs
      :variants [:story.counter/empty
                 :story.counter/loaded]
      :tags     #{:docs}})
 
-  (story/reg-workspace :Workspace.counter/custom
+  (rf.story/reg-workspace :Workspace.counter/custom
     {:doc    "Custom layout fixture for workspace coverage. The current
              renderer projects the configured view id as data."
      :layout :custom

--- a/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
@@ -16,16 +16,16 @@
   by the time tests run."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core      :as rf]
-            [re-frame.frame     :as frame]
-            [re-frame.machines  :as machines]
-            [re-frame.registrar :as registrar]
-            [re-frame.source-store :as source-store]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story     :as story]
-            [re-frame.story.async      :as async-lib]
-            [re-frame.story.loaders    :as loaders]
-            [re-frame.story.play       :as play]
-            [re-frame.test-support     :as test-support]
+            [re-frame.frame     :as rf.frame]
+            [re-frame.machines  :as rf.machines]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.source-store :as rf.source-store]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story     :as rf.story]
+            [re-frame.story.async      :as rf.story.async]
+            [re-frame.story.loaders    :as rf.story.loaders]
+            [re-frame.story.play       :as rf.story.play]
+            [re-frame.test-support     :as rf.test-support]
             [counter-with-stories.events]
             [counter-with-stories.subs]
             [counter-with-stories.stories :as cw-stories]))
@@ -51,7 +51,7 @@
 ;; are intrinsic to how these co-located testbeds demo EP-0026:
 ;;
 ;;   1. ASYNC story tests need the MAP-form fixture. Every variant test
-;;      below drives `story/run-variant` (a Promise) under `(async done …)`.
+;;      below drives `rf.story/run-variant` (a Promise) under `(async done …)`.
 ;;      cljs.test HARD-ERRORS on a fn-form fixture for an async body
 ;;      ("Async tests require fixtures to be specified as maps"), and
 ;;      `story-test/use-fixtures` returns ONLY the sync fn-form — it composes
@@ -77,7 +77,7 @@
 ;;      ns-load baseline, which is exactly what the hand-rolled reset below
 ;;      does (mirroring `login_form/stories_cljs_test`).
 ;;
-;; So the cluster stays on `story/clear-all!` + `register-all!` + an ns-load
+;; So the cluster stays on `rf.story/clear-all!` + `register-all!` + an ns-load
 ;; SOURCE-STORE baseline restore — the async-compatible map-form idiom — and
 ;; is uniformly run-order-INDEPENDENT without the fixture.
 
@@ -95,35 +95,35 @@
 ;; per-ns-baseline fixture (make-reset-runtime-fixture) resetting the store to
 ;; ITS own incomplete baseline is exactly the run-order coupling this restore
 ;; makes us immune to (rf2-vyzqca / rf2-y90h6h).
-(def ^:private source-store-baseline @source-store/kind->id->ns->descriptor)
+(def ^:private source-store-baseline @rf.source-store/kind->id->ns->descriptor)
 
 (defn- before! []
-  (reset! registrar-snapshot (test-support/snapshot-registrar))
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
-  (frame/ensure-default-frame!)
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
+  (reset! registrar-snapshot (rf.test-support/snapshot-registrar))
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
+  (rf.frame/ensure-default-frame!)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
   ;; Always re-fire the Story registrations so each test starts with
   ;; a freshly-resolved registry (clears any leftover stories from
   ;; previous tests and ensures the lifecycle machine is freshly
   ;; registered against the post-snapshot registrar).
-  (story/clear-all!)
+  (rf.story/clear-all!)
   ;; Restore the STABLE ns-load source-store baseline (see the capture
-  ;; above). `story/clear-all!` only wipes the Story side-table, but a
+  ;; above). `rf.story/clear-all!` only wipes the Story side-table, but a
   ;; sibling ns's per-ns-baseline fixture may have left the SHARED source
   ;; store missing this app's descriptors; folding the ns-load baseline back
   ;; makes each test's `:select-ns` projection resolve the counter app
   ;; slices run-order-independently. Idempotent w.r.t. the `register-all!`
   ;; below (stories land in the Story side-table, not the source store).
-  (reset! source-store/kind->id->ns->descriptor source-store-baseline)
+  (reset! rf.source-store/kind->id->ns->descriptor source-store-baseline)
   (cw-stories/register-all!))
 
 (defn- after! []
   (when-let [snap @registrar-snapshot]
-    (test-support/restore-registrar! snap)
+    (rf.test-support/restore-registrar! snap)
     (reset! registrar-snapshot nil))
-  (reset! frame/frames {}))
+  (reset! rf.frame/frames {}))
 
 (use-fixtures :each {:before before! :after after!})
 
@@ -131,31 +131,31 @@
 
 (deftest example-tag-registered
   (testing "the project's reg-tag landed"
-    (is (contains? (story/list-tags) :counter-with-stories/canonical))))
+    (is (contains? (rf.story/list-tags) :counter-with-stories/canonical))))
 
 (deftest example-modes-registered
   (testing "both Modes registered against the side-table"
-    (let [modes (story/list-modes)]
+    (let [modes (rf.story/list-modes)]
       (is (contains? modes :Mode.app/dark))
       (is (contains? modes :Mode.app/light)))))
 
 (deftest example-decorator-registered
   (testing "the project's custom decorator registered"
-    (is (story/registered? :decorator :counter-with-stories/log-decorator))))
+    (is (rf.story/registered? :decorator :counter-with-stories/log-decorator))))
 
 (deftest example-panel-registered
   (testing "the project's story-panel registered"
-    (is (story/registered? :story-panel :Panel.counter-with-stories/notes))))
+    (is (rf.story/registered? :story-panel :Panel.counter-with-stories/notes))))
 
 (deftest example-broken-render-panel-registered
   (testing "rf2-76wo5 testbed — the broken-render panel registered, and
             its :render id is NOT registered as a view. Together those
             two facts drive the panel-host into the broken-render
             fallback branch (asserted live in story_browser_scenarios.cjs)."
-    (is (story/registered? :story-panel
+    (is (rf.story/registered? :story-panel
                            :Panel.counter-with-stories/broken-render)
         "the testbed panel is registered")
-    (is (not (registrar/handler
+    (is (not (rf.registrar/handler
                :view :counter-with-stories.views/not-registered))
         "the panel's :render view id is NOT registered — the panel-host
          will hit the 'no registered :render view' fallback when it tries
@@ -163,13 +163,13 @@
 
 (deftest example-story-registered
   (testing "the parent story registered"
-    (is (story/registered? :story :story.counter))))
+    (is (rf.story/registered? :story :story.counter))))
 
 (deftest example-five-variants-registered
   (testing "the five canonical variants registered on :story.counter
             (four authoring shapes + the rf2-9jfo1.2 events-only loader-
             body shape folded in from the retired xray_rhs_smoke testbed)"
-    (let [vs (story/variants-of :story.counter)]
+    (let [vs (rf.story/variants-of :story.counter)]
       (is (contains? vs :story.counter/empty))
       (is (contains? vs :story.counter/loaded))
       (is (contains? vs :story.counter/clicked-three-times))
@@ -179,7 +179,7 @@
 
 (deftest diagnostic-variants-registered
   (testing "the diagnostics story exposes deterministic failure surfaces"
-    (let [vs (story/variants-of :story.counter-diagnostics)]
+    (let [vs (rf.story/variants-of :story.counter-diagnostics)]
       (is (contains? vs :story.counter-diagnostics/failing-play))
       (is (contains? vs :story.counter-diagnostics/failing-event-throws))
       (is (contains? vs :story.counter-diagnostics/loader-throws))
@@ -188,7 +188,7 @@
 
 (deftest matrix-variants-registered
   (testing "the matrix story exposes deterministic browser-gate affordances"
-    (let [vs (story/variants-of :story.counter-matrix)]
+    (let [vs (rf.story/variants-of :story.counter-matrix)]
       (doseq [vid [:story.counter-matrix/no-play
                    :story.counter-matrix/loader-success
                    :story.counter-matrix/loader-never-completes
@@ -238,15 +238,15 @@
             handler, so the variant's own requires satisfy every event it
             can dispatch."
     (async done
-      (-> (story/run-variant :story.counter-matrix/recorder-redaction)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.counter-matrix/recorder-redaction)
+          (rf.story.async/then
             (fn [result]
               (is (= :ready (:lifecycle result)) "lifecycle reached :ready")
               (is (= 11 (-> result :app-db :count))
                   "the :counter/initialise 11 seed applied")
-              (is (story/assertions-passing? result)
+              (is (rf.story/assertions-passing? result)
                   (str "play assertions: " (pr-str (:assertions result))))
-              (story/destroy-variant! :story.counter-matrix/recorder-redaction)
+              (rf.story/destroy-variant! :story.counter-matrix/recorder-redaction)
               (done)))))))
 
 (deftest failing-fx-stub-miss-variant-fails-with-canonical-reason
@@ -256,8 +256,8 @@
             during play'. This is the source-side fixture the test pane
             renders in its failing-row reason-text surface."
     (async done
-      (-> (story/run-variant :story.counter-matrix/failing-fx-stub-miss)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.counter-matrix/failing-fx-stub-miss)
+          (rf.story.async/then
             (fn [result]
               (let [assertions (:assertions result)
                     miss       (first
@@ -275,16 +275,16 @@
                 (is (= "fx :never-stubbed was not emitted during play"
                        (:reason miss))
                     "the canonical reason text the test pane surfaces"))
-              (story/destroy-variant! :story.counter-matrix/failing-fx-stub-miss)
+              (rf.story/destroy-variant! :story.counter-matrix/failing-fx-stub-miss)
               (done)))))))
 
 (deftest example-workspaces-registered
   (testing "both workspaces registered"
-    (is (story/registered? :workspace :Workspace.counter/all-states))
-    (is (story/registered? :workspace :Workspace.counter/auto-grid))
-    (is (story/registered? :workspace :Workspace.counter/prose))
-    (is (story/registered? :workspace :Workspace.counter/tabs))
-    (is (story/registered? :workspace :Workspace.counter/custom))))
+    (is (rf.story/registered? :workspace :Workspace.counter/all-states))
+    (is (rf.story/registered? :workspace :Workspace.counter/auto-grid))
+    (is (rf.story/registered? :workspace :Workspace.counter/prose))
+    (is (rf.story/registered? :workspace :Workspace.counter/tabs))
+    (is (rf.story/registered? :workspace :Workspace.counter/custom))))
 
 ;; ---- variants resolve cleanly ------------------------------------------
 
@@ -296,7 +296,7 @@
                  :story.counter/loaded
                  :story.counter/clicked-three-times
                  :story.counter/save-stubbed]]
-      (let [body (story/variant->edn vid)]
+      (let [body (rf.story/variant->edn vid)]
         (is (map? body) (str vid " variant->edn returned a map"))
         (is (vector? (:setup body))
             (str vid " has the authored :setup"))
@@ -308,68 +308,68 @@
 (deftest empty-variant-runs-and-passes
   (testing ":story.counter/empty runs and its play sequence passes"
     (async done
-      (-> (story/run-variant :story.counter/empty)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.counter/empty)
+          (rf.story.async/then
             (fn [result]
               (is (= :ready (:lifecycle result)) "lifecycle reached :ready")
               (is (= {:count 0} (select-keys (:app-db result) [:count])))
-              (is (story/assertions-passing? result)
+              (is (rf.story/assertions-passing? result)
                   (str "play assertions: " (pr-str (:assertions result))))
-              (story/destroy-variant! :story.counter/empty)
+              (rf.story/destroy-variant! :story.counter/empty)
               (done)))))))
 
 (deftest loaded-variant-runs-and-passes
   (testing ":story.counter/loaded runs and all three play assertions pass"
     (async done
-      (-> (story/run-variant :story.counter/loaded)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.counter/loaded)
+          (rf.story.async/then
             (fn [result]
               (is (= :ready (:lifecycle result)))
               (is (= 7 (-> result :app-db :count)))
               (is (= 3 (count (:assertions result)))
                   "all three :rf.assert/* assertions ran")
-              (is (story/assertions-passing? result))
-              (story/destroy-variant! :story.counter/loaded)
+              (is (rf.story/assertions-passing? result))
+              (rf.story/destroy-variant! :story.counter/loaded)
               (done)))))))
 
 (deftest clicked-three-times-variant-runs-and-passes
   (testing ":story.counter/clicked-three-times reaches count=3 and dispatch? passes"
     (async done
-      (-> (story/run-variant :story.counter/clicked-three-times)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.counter/clicked-three-times)
+          (rf.story.async/then
             (fn [result]
               (is (= 3 (-> result :app-db :count)))
-              (is (story/assertions-passing? result))
-              (story/destroy-variant! :story.counter/clicked-three-times)
+              (is (rf.story/assertions-passing? result))
+              (rf.story/destroy-variant! :story.counter/clicked-three-times)
               (done)))))))
 
 (deftest save-stubbed-variant-runs-and-effect-emitted-passes
   (testing ":story.counter/save-stubbed has the fx stubbed; effect-emitted passes"
     (async done
-      (-> (story/run-variant :story.counter/save-stubbed)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.counter/save-stubbed)
+          (rf.story.async/then
             (fn [result]
               (is (= :ready (:lifecycle result)))
               ;; The stub fired in place of the real fx.
               (is (true? (-> result :app-db :saving?))
                   "the :counter/save handler set :saving? true")
-              (is (story/assertions-passing? result)
+              (is (rf.story/assertions-passing? result)
                   (str "play assertions: " (pr-str (:assertions result))))
-              (story/destroy-variant! :story.counter/save-stubbed)
+              (rf.story/destroy-variant! :story.counter/save-stubbed)
               (done)))))))
 
 (deftest diagnostic-failing-play-records-failure
   (testing ":story.counter-diagnostics/failing-play records a failed assertion without throwing"
     (async done
-      (-> (story/run-variant :story.counter-diagnostics/failing-play)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.counter-diagnostics/failing-play)
+          (rf.story.async/then
             (fn [result]
               (is (= 1 (-> result :app-db :count)))
-              (is (not (story/assertions-passing? result)))
+              (is (not (rf.story/assertions-passing? result)))
               (is (some #(and (= :rf.assert/path-equals (:assertion %))
                               (false? (:passed? %)))
                         (:assertions result)))
-              (story/destroy-variant! :story.counter-diagnostics/failing-play)
+              (rf.story/destroy-variant! :story.counter-diagnostics/failing-play)
               (done)))))))
 
 (deftest diagnostic-event-exception-records-failure
@@ -382,10 +382,10 @@
             exception into the assertions list so the test-mode UI
             + Xray assertions panel see the failure."
     (async done
-      (-> (story/run-variant :story.counter-diagnostics/failing-event-throws)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.counter-diagnostics/failing-event-throws)
+          (rf.story.async/then
             (fn [result]
-              (is (not (story/assertions-passing? result)))
+              (is (not (rf.story/assertions-passing? result)))
               (is (some #(and (= :rf.error/exception (:assertion %))
                               (= :phase-4-play (:phase %))
                               (= [:counter/throw-deterministic] (:event %))
@@ -394,22 +394,22 @@
                         (:assertions result))
                   "an :rf.error/exception assertion was recorded for the
                   throwing event in phase-4-play")
-              (story/destroy-variant! :story.counter-diagnostics/failing-event-throws)
+              (rf.story/destroy-variant! :story.counter-diagnostics/failing-event-throws)
               (done)))))))
 
 (deftest diagnostic-loader-exception-records-failure
   (testing ":story.counter-diagnostics/loader-throws projects loader exceptions into assertions"
     (async done
-      (-> (story/run-variant :story.counter-diagnostics/loader-throws)
-          (async-lib/then
+      (-> (rf.story/run-variant :story.counter-diagnostics/loader-throws)
+          (rf.story.async/then
             (fn [result]
-              (is (not (story/assertions-passing? result)))
+              (is (not (rf.story/assertions-passing? result)))
               (is (some #(and (= :rf.error/exception (:assertion %))
                               (= :phase-1-loaders (:phase %))
                               (re-find #"story-load deterministic event handler failure"
                                        (get-in % [:error :message] "")))
                         (:assertions result)))
-              (story/destroy-variant! :story.counter-diagnostics/loader-throws)
+              (rf.story/destroy-variant! :story.counter-diagnostics/loader-throws)
               (done)))))))
 
 ;; ---- mount-shell / unmount-shell / active-shell --------------------------
@@ -421,8 +421,8 @@
 
 (deftest shell-surface-callable
   (testing "mount-shell! / unmount-shell! / active-shell are public fns"
-    (is (fn? story/mount-shell!))
-    (is (fn? story/unmount-shell!))
-    (is (fn? story/active-shell))
-    (is (nil? (story/active-shell))
+    (is (fn? rf.story/mount-shell!))
+    (is (fn? rf.story/unmount-shell!))
+    (is (fn? rf.story/active-shell))
+    (is (nil? (rf.story/active-shell))
         "no shell mounted before any test mounts one")))

--- a/tools/story/testbeds/counter_with_stories/story_static.cljs
+++ b/tools/story/testbeds/counter_with_stories/story_static.cljs
@@ -24,8 +24,8 @@
   point at their own stories ns, and re-run."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            [re-frame.story :as story]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.story :as rf.story]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             ;; Source the stories ns so all `reg-*` calls fire on namespace
             ;; load. The variant bodies reference views / events / subs by
             ;; id; the stories ns transitively requires them.
@@ -36,8 +36,8 @@
   doesn't happen under `release` builds, but the path is correct under
   `compile` too)."
   []
-  (rf/init! reagent-adapter/adapter)
-  ;; No explicit `(story/install-canonical-vocabulary!)` call — the
+  (rf/init! rf.adapter.reagent/adapter)
+  ;; No explicit `(rf.story/install-canonical-vocabulary!)` call — the
   ;; `:require [counter-with-stories.stories]` above already loaded the
   ;; stories ns, whose first `reg-*` call auto-installed the canonical
   ;; vocabulary.
@@ -54,7 +54,7 @@
   ;; downstream "published site that links back into the author's editor"
   ;; opts in explicitly via `config/set-allow-static-project-root!` +
   ;; passing a root; this canonical export does not.
-  (story/configure! {:rf.story/global-args {:locale :en}})
+  (rf.story/configure! {:rf.story/global-args {:locale :en}})
   ;; NO shell-level `(rf/dispatch-sync [:counter/initialise 5])` here.
   ;; A bare global dispatch carries no frame context, and per EP-0002 the
   ;; runtime never synthesises a `:rf/default` frame — so the router would
@@ -67,4 +67,4 @@
   ;; contexts; the static shell holds no app-db of its own to seed.
   ;; Mount the Story shell directly onto `#app`. No hash routing — this
   ;; ns is the static-export entry only, the SPA lives in core.cljs.
-  (story/mount-shell! (js/document.getElementById "app")))
+  (rf.story/mount-shell! (js/document.getElementById "app")))

--- a/tools/story/testbeds/hicasso_counter/core.cljs
+++ b/tools/story/testbeds/hicasso_counter/core.cljs
@@ -5,7 +5,7 @@
   URL-hash-routed between two surfaces, like every other Story testbed:
 
     `#/`        → the live tally, a Reagent root carrying the boundary
-                  through `h/as-component`.
+                  through `rf.hicasso/as-component`.
     `#/stories` → the Story shell. The deck's two variants declare
                   `:substrates #{:hicasso}` and paint through the
                   registered `:hicasso` render fn.
@@ -46,10 +46,10 @@
   short-circuits. This build leaves Story enabled; the elision path is
   gated elsewhere."
   (:require [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.hicasso :as h]
-            [re-frame.story :as story]
-            [re-frame.story.play.ci-runner :as story-ci]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.story :as rf.story]
+            [re-frame.story.play.ci-runner :as rf.story.play.ci-runner]
             [day8.re-frame2-xray.config :as xray-config]
             [hicasso-counter.events]
             [hicasso-counter.subs]
@@ -57,7 +57,7 @@
             [hicasso-counter.stories]
             ;; Shared Story-host helper: owns the live-app↔Story-shell hash
             ;; router + React-root handle.
-            [re-frame.testbed.story-host :as story-host])
+            [re-frame.testbed.story-host :as rf.testbed.story-host])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ---------------------------------------------------------------------------
@@ -73,15 +73,15 @@
     the same id — reaches the deck with no deck change;
   - read `:hicasso/component`, because the alias entry deliberately
     carries no `:handler-fn` and `rf/view` answers nil for it (rf2-5qaf4);
-  - mint the element with `h/as-element` rather than bridging through
-    `h/as-component`. `defview` already mints ONE `React.memo` wrapper per
+  - mint the element with `rf.hicasso/as-element` rather than bridging through
+    `rf.hicasso/as-component`. `defview` already mints ONE `React.memo` wrapper per
     head, so a fresh element per pass rides a stable TYPE and the boundary
     re-renders instead of remounting."
   []
-  (story/register-substrate! :hicasso
+  (rf.story/register-substrate! :hicasso
     (fn [_variant-id view-id args]
       (if-let [head (:hicasso/component (rf/handler-meta :view view-id))]
-        (h/as-element [head args])
+        (rf.hicasso/as-element [head args])
         [:div (str ":component " (pr-str view-id)
                    " is not registered as a hicasso view")]))))
 
@@ -95,7 +95,7 @@
    [:h2 {:style {:margin "0 0 0.5em 0"}} "Hicasso tally (Story testbed)"]
    [:p {:style {:font-size "13px" :color "#666" :margin "0 0 1.5em 0"}}
     "Every element below this line was authored with "
-    [:code {:style {:background "#f5f5f5" :padding "1px 4px"}} "h/defview"]
+    [:code {:style {:background "#f5f5f5" :padding "1px 4px"}} "rf.hicasso/defview"]
     ". Open "
     [:a {:href "#/stories"} "#/stories"]
     " for the same views as Story variants under "
@@ -125,7 +125,7 @@
   ;; Story owns this page's full-width browser-test canvas. Keep Xray's
   ;; collectors and keybinding installed but skip the default panel launch.
   (xray-config/configure! {:rf.xray/auto-open? false})
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (install-hicasso-substrate!)
   (rf/make-frame {:id  :rf/default
                   :doc "Hicasso-counter testbed default frame."})
@@ -137,5 +137,5 @@
   ;; and drives. Installed unconditionally — the fn body is itself gated on
   ;; Story being enabled — and BEFORE the router mounts, so the global is
   ;; present by the time the page has finished loading.
-  (story-ci/install-ci-hooks!)
-  (story-host/mount-with-hash-routing! live-app-root))
+  (rf.story.play.ci-runner/install-ci-hooks!)
+  (rf.testbed.story-host/mount-with-hash-routing! live-app-root))

--- a/tools/story/testbeds/hicasso_counter/stories.cljs
+++ b/tools/story/testbeds/hicasso_counter/stories.cljs
@@ -43,7 +43,7 @@
   substrate paints a red cell naming the missing `register-substrate!`
   call, which is what makes removing that registration a legible RED
   rather than a silent fall-back to Reagent."
-  (:require [re-frame.story :as story]
+  (:require [re-frame.story :as rf.story]
             ;; Sourcing these fires the registrations the variants name.
             [hicasso-counter.events]
             [hicasso-counter.subs]
@@ -54,7 +54,7 @@
   namespace load. The canonical vocabulary auto-installs on the first
   `reg-*` below, so there is no boot step to remember."
   []
-  (story/reg-story :story.hicasso-counter
+  (rf.story/reg-story :story.hicasso-counter
     {:doc        "A tally authored in Hicasso — `h/defview`, `h/sub` and
                  intent vectors, with no adapter call anywhere in the
                  view source."
@@ -77,7 +77,7 @@
   ;; same terminal state.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-variant :story.hicasso-counter/tally
+  (rf.story/reg-variant :story.hicasso-counter/tally
     {:doc    "The interaction. Seeds the tally, reads it off the DOM the
              boundary painted, clicks the boundary's own button, and
              asserts that the click reached the frame (app-db) AND came
@@ -101,7 +101,7 @@
      :tags   #{:dev :docs :test}
      :substrates #{:hicasso}})
 
-  (story/reg-variant :story.hicasso-counter/readout
+  (rf.story/reg-variant :story.hicasso-counter/readout
     {:doc        "A second Hicasso boundary under the same substrate, so
                  a green row names WHICH view painted. Read-only: it
                  carries no script, and exists to keep the deck honest

--- a/tools/story/testbeds/hicasso_counter/views.cljs
+++ b/tools/story/testbeds/hicasso_counter/views.cljs
@@ -1,8 +1,8 @@
 (ns hicasso-counter.views
   "The subject — views authored in Hicasso, and nothing else.
 
-  `h/defview` is the whole authoring surface here: a boundary reads its
-  own subscriptions with `h/sub` and states its intent as a data vector at
+  `rf.hicasso/defview` is the whole authoring surface here: a boundary reads its
+  own subscriptions with `rf.hicasso/sub` and states its intent as a data vector at
   `:on-click` / `:on-input`. There is no adapter call, no React import and
   no props ABI in this file, which is what makes it a fair sample of what
   a programmer on the native substrate actually writes.
@@ -24,9 +24,9 @@
   elements — nothing in this file is test-only behaviour, and removing
   the deck would leave the views unchanged."
   (:require [re-frame.core :as rf]
-            [re-frame.hicasso :as h]))
+            [re-frame.hicasso :as rf.hicasso]))
 
-(h/defview tally
+(rf.hicasso/defview tally
   "The stateful subject. Reads the tally and its step from the frame the
   canvas scoped, and bumps the tally through an intent vector — so the
   round trip a play script drives (click → event → app-db → repaint) is
@@ -34,34 +34,34 @@
   [{:keys [heading]}]
   [:section {:class "hic-tally" :data-test "hic-tally"}
    [:h3 (or heading "Tally")]
-   [:output {:data-test "hic-count"} (str (h/sub [:hicasso-counter/count]))]
+   [:output {:data-test "hic-count"} (str (rf.hicasso/sub [:hicasso-counter/count]))]
    [:button {:data-test "hic-bump"
              :on-click  [:hicasso-counter/bump]}
-    (str "+" (h/sub [:hicasso-counter/step]))]
+    (str "+" (rf.hicasso/sub [:hicasso-counter/step]))]
    [:label "step "
     [:input {:data-test "hic-step"
              :type      "text"
-             :value     (str (h/sub [:hicasso-counter/step]))
-             :on-input  [:hicasso-counter/set-step ::h/value]}]]])
+             :value     (str (rf.hicasso/sub [:hicasso-counter/step]))
+             :on-input  [:hicasso-counter/set-step ::rf.hicasso/value]}]]])
 
-(h/defview readout
+(rf.hicasso/defview readout
   "A SECOND boundary, so the deck can tell one Hicasso view from another
   rather than merely from a Reagent one. Read-only: it proves the
   substrate resolves the variant's frame even with no interaction of its
   own to drive."
   [{:keys [label]}]
   [:p {:data-test "hic-readout"}
-   (str (or label "count") " = " (h/sub [:hicasso-counter/count]))])
+   (str (or label "count") " = " (rf.hicasso/sub [:hicasso-counter/count]))])
 
 ;; ---------------------------------------------------------------------------
 ;; The live-page bridge — minted ONCE, at the top level
 ;; ---------------------------------------------------------------------------
 ;;
 ;; The Story canvas needs none of this: its `:hicasso` render fn mints an
-;; element per render with `h/as-element`, riding the stable `React.memo`
+;; element per render with `rf.hicasso/as-element`, riding the stable `React.memo`
 ;; wrapper `defview` already made. The LIVE `#/` surface is the other
 ;; case — a Reagent root whose hiccup has to carry the boundary — and
-;; `h/as-component` is the door for it.
+;; `rf.hicasso/as-component` is the door for it.
 ;;
 ;; `def`, not a call inside a render: `as-component` ALLOCATES a component,
 ;; so minting one per render hands React a fresh element type every pass
@@ -70,8 +70,8 @@
 
 (def tally-component
   "`tally` as a component a Reagent parent can place in hiccup."
-  (h/as-component tally))
+  (rf.hicasso/as-component tally))
 
 (def readout-component
   "`readout`, likewise."
-  (h/as-component readout))
+  (rf.hicasso/as-component readout))

--- a/tools/story/testbeds/login_form/core.cljs
+++ b/tools/story/testbeds/login_form/core.cljs
@@ -14,7 +14,7 @@
   bundle-isolation grep at `implementation/scripts/check-bundle-
   isolation.cjs` covers the Story-sentinel absence."
   (:require [re-frame.core      :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             [day8.re-frame2-xray.config :as xray-config]
             [login-form.events]
             [login-form.subs]
@@ -22,7 +22,7 @@
             [login-form.stories]
             ;; Shared Story-host helper: owns the live-app↔Story-shell
             ;; hash router + React-root handle.
-            [re-frame.testbed.story-host :as story-host])
+            [re-frame.testbed.story-host :as rf.testbed.story-host])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ---------------------------------------------------------------------------
@@ -78,7 +78,7 @@
   ;; launch; app pages that want Xray inline still provide the normal
   ;; `[data-rf-xray-host]` contract.
   (xray-config/configure! {:rf.xray/auto-open? false})
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   ;; No explicit `(story/install-canonical-vocabulary!)` — the first
   ;; `reg-*` in `login-form.stories` (loaded via the :require above)
   ;; auto-installs the canonical vocabulary.
@@ -108,4 +108,4 @@
   ;; `POST /__rf-open-in-editor` endpoint resolves this testbed's
   ;; classpath-relative source coordinates against the live JVM source paths
   ;; at request time.
-  (story-host/mount-with-hash-routing! live-app-root))
+  (rf.testbed.story-host/mount-with-hash-routing! live-app-root))

--- a/tools/story/testbeds/login_form/events.cljs
+++ b/tools/story/testbeds/login_form/events.cljs
@@ -30,7 +30,7 @@
   (:require [re-frame.core :as rf]
             ;; Loads the machine substrate's late-bind hooks so
             ;; rf.machines/make-machine-handler resolves below.
-            [re-frame.machines :as machines]
+            [re-frame.machines :as rf.machines]
             ;; Loads :rf.http/managed; without it, dispatching
             ;; the login flow's request fx would throw
             ;; :rf.error/no-such-fx.
@@ -40,7 +40,7 @@
             ;; The canned-stub fx ids register from
             ;; re-frame.http.test-support, not re-frame.http.managed.
             [re-frame.http.test-support]
-            [re-frame.registrar :as registrar]))
+            [re-frame.registrar :as rf.registrar]))
 
 ;; ============================================================================
 ;; MACHINE — :login/flow
@@ -54,7 +54,7 @@
 
 (rf/reg-event :login/flow
   {:doc "Login flow machine — five-state authentication FSM."}
-  (machines/make-machine-handler
+  (rf.machines/make-machine-handler
     {:initial :idle
      :data    {:email      ""
                :error      nil
@@ -182,8 +182,8 @@
   (fn fx-login-demo-http [frame-ctx args-map]
     (let [{:keys [body]} (:request args-map)
           good?          (= "correct-horse" (:password body))
-          ok-stub        (registrar/handler :fx :rf.http/managed-canned-success)
-          fail-stub      (registrar/handler :fx :rf.http/managed-canned-failure)]
+          ok-stub        (rf.registrar/handler :fx :rf.http/managed-canned-success)
+          fail-stub      (rf.registrar/handler :fx :rf.http/managed-canned-failure)]
       (js/setTimeout
         (fn []
           (if good?

--- a/tools/story/testbeds/login_form/stories.cljs
+++ b/tools/story/testbeds/login_form/stories.cljs
@@ -37,7 +37,7 @@
   resolves the request with the canned-success / canned-failure shape
   per Spec 014 §Testing."
   (:require [re-frame.core  :as rf]
-            [re-frame.story :as story]
+            [re-frame.story :as rf.story]
             ;; Sourcing these via :require fires the registrations.
             [login-form.events]
             [login-form.subs]
@@ -71,7 +71,7 @@
   ;; Project tag — the screenshot pinned to the tutorial.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-tag :login-form/tutorial
+  (rf.story/reg-tag :login-form/tutorial
     {:doc "Variants the Story tutorial points at by name. The
           authenticated variant is the canonical screenshot — the
           welcome banner that lands on `docs/story/01-first-story.md`."})
@@ -83,12 +83,12 @@
   ;; semantics on a real shape.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-mode :Mode.login-form/light
+  (rf.story/reg-mode :Mode.login-form/light
     {:doc  "Light theme — the default. Matches the live page."
      :axis :theme
      :args {:theme :light}})
 
-  (story/reg-mode :Mode.login-form/dark
+  (rf.story/reg-mode :Mode.login-form/dark
     {:doc  "Dark theme — for the design-review workspace."
      :axis :theme
      :args {:theme :dark}})
@@ -98,7 +98,7 @@
   ;; decorators, args, and tags.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-story :story.login-form
+  (rf.story/reg-story :story.login-form
     {:doc        "The login form — every state from the tutorial's
                  five-state scenario, as runnable variants."
      :component  :login-form.views/login-card
@@ -117,7 +117,7 @@
   ;; the state is what the variant's name says it is.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-variant :story.login-form/idle
+  (rf.story/reg-variant :story.login-form/idle
     {:doc    "Fresh form, no inputs typed, no submit clicked. The
              entry state the user lands on when they navigate to
              `#/login` for the first time.
@@ -153,14 +153,14 @@
   ;; which is exactly what the tutorial's second state describes.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-variant :story.login-form/submitting
+  (rf.story/reg-variant :story.login-form/submitting
     {:doc    "First submit; HTTP request in flight; inputs disabled,
              button reads 'Signing in…'. The fx-stub records the
              request and resolves nothing so the canvas locks in
              :submitting."
      :setup [[:login/flow [:login/submit {:email    "ada@example.com"
                                             :password "correct-horse"}]]]
-     :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
+     :decorators [[rf.story/force-fx-stub-id :rf.http/managed {}]]
      :script [[:assert [:rf.assert/state-is      :login/flow :submitting]]
               [:assert [:rf.assert/effect-emitted :rf.http/managed]]]
      :tags   #{:dev :docs :test}
@@ -176,7 +176,7 @@
   ;; error message surfaced.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-variant :story.login-form/error
+  (rf.story/reg-variant :story.login-form/error
     {:doc    "Server rejected credentials. Form re-enabled; the error
              message is surfaced under the submit button; the
              'Cancel' button lets the user back out without retrying."
@@ -190,7 +190,7 @@
               [:login/flow [:login/failure
                             {:failure {:status  401
                                        :message "Invalid credentials."}}]]]
-     :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
+     :decorators [[rf.story/force-fx-stub-id :rf.http/managed {}]]
      ;; EP-0001: the machine snapshot lives in the frame's runtime-db
      ;; partition, so the state checkpoint reads it via
      ;; `:rf.assert/state-is` (which evaluates against runtime-db).
@@ -211,7 +211,7 @@
   ;; surfaces under the error.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-variant :story.login-form/submitting-retry
+  (rf.story/reg-variant :story.login-form/submitting-retry
     {:doc    "The user corrected the typo and re-submitted. Distinct
              from :submitting because attempts > 0; the variant body
              sequences the failure then the retry, leaving the
@@ -222,7 +222,7 @@
                             {:failure {:status 401 :message "Invalid credentials."}}]]
               [:login/flow [:login/retry
                             {:email "ada@example.com" :password "correct-horse"}]]]
-     :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
+     :decorators [[rf.story/force-fx-stub-id :rf.http/managed {}]]
      ;; EP-0001: the attempt counter lives in the runtime-db snapshot's
      ;; `:data`; the state checkpoint reads the
      ;; snapshot via `:rf.assert/state-is`. The attempt-count value is
@@ -243,7 +243,7 @@
   ;; the EDN-first contract is built for.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-variant :story.login-form/authenticated
+  (rf.story/reg-variant :story.login-form/authenticated
     {:doc    "Server accepted credentials. The form is replaced by
              a welcome banner addressing the user by email; the
              :sign-out button routes back to :idle. This is the
@@ -253,7 +253,7 @@
               [:login/flow [:login/success
                             {:value {:user  {:email "ada@example.com"}
                                      :token "story-token"}}]]]
-     :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
+     :decorators [[rf.story/force-fx-stub-id :rf.http/managed {}]]
      ;; EP-0001: the welcome-banner email lives in the runtime-db
      ;; snapshot's `:data`; the state checkpoint reads
      ;; the snapshot via `:rf.assert/state-is`. The email value is verified
@@ -268,7 +268,7 @@
   ;; Workspaces — the "five side-by-side" workspace from the tutorial.
   ;; -------------------------------------------------------------------------
 
-  (story/reg-workspace :Workspace.login-form/all-states
+  (rf.story/reg-workspace :Workspace.login-form/all-states
     {:doc      "The five states side-by-side. This is the design-
                 review surface from the tutorial's scenario step 3
                 — 'open a workspace that mounts all five side-by-side'."
@@ -281,7 +281,7 @@
      :columns  3
      :tags     #{:docs}})
 
-  (story/reg-workspace :Workspace.login-form/auto-grid
+  (rf.story/reg-workspace :Workspace.login-form/auto-grid
     {:doc     "Auto-enumerated grid — pulls every variant off
               :story.login-form. New variants land here without touching
               this workspace."

--- a/tools/story/testbeds/login_form/stories_cljs_test.cljs
+++ b/tools/story/testbeds/login_form/stories_cljs_test.cljs
@@ -7,7 +7,7 @@
   `:login/attempts` `:login/email`) and three `:script` checkpoints read
   the snapshot through that partition.
 
-  This test runs each variant through `story/run-variant` under the
+  This test runs each variant through `rf.story/run-variant` under the
   top-level `node-test` build (`npm run test:cljs`) and then, against the
   variant frame's live `frame-state-value` (which carries the runtime-db
   partition), computes each projection sub via `rf/compute-sub` and asserts
@@ -31,15 +31,15 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [clojure.set        :as set]
             [re-frame.core      :as rf]
-            [re-frame.frame     :as frame]
-            [re-frame.machines  :as machines]
-            [re-frame.registrar :as registrar]
-            [re-frame.source-store :as source-store]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.story     :as story]
-            [re-frame.story.async      :as async-lib]
-            [re-frame.story.loaders    :as loaders]
-            [re-frame.test-support     :as test-support]
+            [re-frame.frame     :as rf.frame]
+            [re-frame.machines  :as rf.machines]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.source-store :as rf.source-store]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story     :as rf.story]
+            [re-frame.story.async      :as rf.story.async]
+            [re-frame.story.loaders    :as rf.story.loaders]
+            [re-frame.test-support     :as rf.test-support]
             [login-form.events]
             [login-form.subs]
             [login-form.stories :as lf-stories]
@@ -61,7 +61,7 @@
 ;; `:rf.assert/*` handlers) survive the snapshot; per-test registrations
 ;; roll back. Map-form fixture is needed for cljs.test's async bodies.
 ;;
-;; This ns deliberately stays on this hand-rolled reset (story/clear-all! +
+;; This ns deliberately stays on this hand-rolled reset (rf.story/clear-all! +
 ;; register-all! + the ns-load source-store baseline restore below) rather
 ;; than `make-reset-runtime-fixture` — the async story tests need the
 ;; map-form fixture the composed Story fixture does not yet expose. See
@@ -84,27 +84,27 @@
 ;; `:login/flow` machine snapshot would read nil. Capturing the baseline once at
 ;; this ns's load pins exactly this ns's framework + app registrations and makes
 ;; each test's restore deterministic regardless of sibling run order.
-(def ^:private source-store-baseline @source-store/kind->id->ns->descriptor)
+(def ^:private source-store-baseline @rf.source-store/kind->id->ns->descriptor)
 
 (defn- before! []
-  (reset! registrar-snapshot (test-support/snapshot-registrar))
-  (reset! frame/frames {})
-  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
-  (frame/ensure-default-frame!)
-  (machines/reset-timers!)
-  (loaders/clear-watchers!)
+  (reset! registrar-snapshot (rf.test-support/snapshot-registrar))
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
+  (rf.frame/ensure-default-frame!)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
   ;; Re-fire the Story registrations so each test starts with a freshly
   ;; resolved registry (the four projection subs re-register here too).
-  (story/clear-all!)
+  (rf.story/clear-all!)
   ;; Restore the STABLE ns-load source-store baseline so the `login-form.*` app
   ;; descriptors are present for the variant frames' image `:select-ns` (see the
-  ;; baseline capture above). `story/clear-all!` wiped the source store; we fold
+  ;; baseline capture above). `rf.story/clear-all!` wiped the source store; we fold
   ;; the ns-load baseline back so each test's default/scoped projection sees
   ;; exactly this ns's registrations, run-order-independent. The resolved-
   ;; generation cache is keyed on the source-store generation, which `clear-all!`
   ;; bumped, so a stale generation never leaks.
-  (reset! source-store/kind->id->ns->descriptor source-store-baseline)
-  ;; EP-0026 §Framework Standard Registrations: `story/clear-all!` wipes the
+  (reset! rf.source-store/kind->id->ns->descriptor source-store-baseline)
+  ;; EP-0026 §Framework Standard Registrations: `rf.story/clear-all!` wipes the
   ;; WHOLE registrar (incl. the framework `:rf/machine` sub the projection subs
   ;; chain off via `:<- [:rf/machine :login/flow]`). Re-install the machine
   ;; runtime — both the regular registrar (so a no-generation
@@ -113,14 +113,14 @@
   ;; machine runtime through its sealed generation). Mirrors how the
   ;; `make-reset-runtime-fixture` reset re-installs it via the
   ;; `:machines/install-runtime!` hook; this custom fixture calls it directly.
-  (machines/install-machine-runtime!)
+  (rf.machines/install-machine-runtime!)
   (lf-stories/register-all!))
 
 (defn- after! []
   (when-let [snap @registrar-snapshot]
-    (test-support/restore-registrar! snap)
+    (rf.test-support/restore-registrar! snap)
     (reset! registrar-snapshot nil))
-  (reset! frame/frames {}))
+  (reset! rf.frame/frames {}))
 
 (use-fixtures :each {:before before! :after after!})
 
@@ -131,7 +131,7 @@
             the registrar (their migration off the dead app-db path
             keeps them registered as ordinary `reg-sub`s)"
     (doseq [sub-id [:login/state :login/error :login/attempts :login/email]]
-      (is (some? (registrar/handler :sub sub-id)) (str sub-id " registered")))))
+      (is (some? (rf.registrar/handler :sub sub-id)) (str sub-id " registered")))))
 
 ;; ---- each variant runs; the migrated subs resolve the snapshot -----------
 ;;
@@ -149,14 +149,14 @@
   with the variant frame's live frame-state value, then tear the variant
   down and complete the async test."
   [done variant-id check]
-  (-> (story/run-variant variant-id)
-      (async-lib/then
+  (-> (rf.story/run-variant variant-id)
+      (rf.story.async/then
         (fn [result]
-          (is (story/assertions-passing? result)
+          (is (rf.story/assertions-passing? result)
               (str variant-id " play assertions (state-is etc): "
                    (pr-str (:assertions result))))
           (check result (rf/frame-state-value variant-id))
-          (story/destroy-variant! variant-id)
+          (rf.story/destroy-variant! variant-id)
           (done)))))
 
 (defn- sub-value
@@ -219,12 +219,12 @@
 ;; EXAMPLE deck (examples/core/login) owns the canonical `:story.login`; this
 ;; testbed owns `:story.login-form`. Under the consolidated node-test build
 ;; BOTH decks' `(register-all!)` fire at ns-load, so a shared parent id made
-;; `story/variants-of` return the UNION of both (they collided on
+;; `rf.story/variants-of` return the UNION of both (they collided on
 ;; `:story.login/submitting`). Co-load both decks here — the `before!` fixture
 ;; already fired this testbed's `register-all!`; fire the example's too — and
 ;; assert each `variants-of` returns ONLY its own deck's variants, with no
 ;; shared variant id. Membership is `(= (namespace vid) (name story-id))`
-;; (story/registrar), so the distinct `"story.login"` / `"story.login-form"`
+;; (rf.story/registrar), so the distinct `"story.login"` / `"story.login-form"`
 ;; namespaces keep the two sets disjoint. This goes RED if either deck is ever
 ;; re-pointed back at the other's parent id.
 
@@ -247,15 +247,15 @@
     :story.login-form/authenticated})
 
 (deftest login-decks-register-under-distinct-parents
-  (testing "story/variants-of returns ONLY each deck's own variants — the
+  (testing "rf.story/variants-of returns ONLY each deck's own variants — the
             example and testbed login decks no longer share a parent story id
             or any variant id (rf2-tijvbd)"
     (login-stories/register-all!)   ;; example → :story.login/*
     (lf-stories/register-all!)      ;; testbed → :story.login-form/* (idempotent; fixture fired it)
-    (is (= testbed-variant-ids (story/variants-of :story.login-form))
+    (is (= testbed-variant-ids (rf.story/variants-of :story.login-form))
         "variants-of :story.login-form is exactly this testbed's five")
-    (is (= example-variant-ids (story/variants-of :story.login))
+    (is (= example-variant-ids (rf.story/variants-of :story.login))
         "variants-of :story.login is exactly the example's seven — no testbed variants leak in")
-    (is (empty? (set/intersection (story/variants-of :story.login)
-                                  (story/variants-of :story.login-form)))
+    (is (empty? (set/intersection (rf.story/variants-of :story.login)
+                                  (rf.story/variants-of :story.login-form)))
         "no variant id is shared between the two decks")))


### PR DESCRIPTION
Slice 5 of the rf2-7sx1 require-alias campaign. **`tools/story` 1665 -> 0**, and the
`tools` surface floor falls **2294 -> 629** in the same commit — the ratchet is two-sided,
so a surface below its floor reds as surely as one above it.

`tools/story` is 73% of the last surface. The remaining 629 (xray 367, story-mcp 121,
mcp-base 44, re-frame2-pair-mcp 34, mcp-conformance 32, machines-viz 14, testbed-support 12,
template 5) are slice 6. **rf2-7sx1 and rf2-lwx8 both stay open.**

## Counts

| | before | after |
|---|---|---|
| `tools/story` non-canonical | 1665 | **0** |
| `tools` surface | 2294 | **629** |
| repo-wide non-canonical | 4735 | **3070** |
| files scanned / require edges | 2773 / 10771 | 2773 / 10771 (identical) |

Remainder verified by my own after-scan rather than by subtraction: the nine `tools`
subtrees sum to exactly 2294 before and 629 after. Baseline diff is **exactly one row**
(`"tools" 2294 -> 629`); `:min-edges` HELD at 9695 against a recompute of 9693 — the
monotonic writer refusing to loosen the anti-blindness guard. Slice 1 saw it rise, slices
2-5 have now seen it hold four times.

309 files, 1667 libspec `:as` tokens (1665 deduped edges — two `.cljc` files write the same
libspec in both reader arms), 13227 code use sites, 847 prose references. Diff is
15058+/15053-; the +5 is one explanatory comment. Every source file is +N/-N.

**Sizing:** the ratchet row counts libspecs, not edits. Measured ratio here is **7.9 code use
sites per libspec** (bench 7.1, examples 3.9), so the census — not the row — sized this.

## Method

Rewriter built on the checker's own `mask_source` and `_parse_libspec`, so code/non-code is
reader-accurate and each `:as` token is replaced inside the exact vector span the checker
identified. All edits collected as offset spans and applied in ONE right-to-left pass, so no
replacement can be re-matched by another.

**Lookbehind exercised in BOTH directions before the rewriter ran: 18/18**, including slice
3's `:auth/locked` near-miss, slice 1's `reply`/`http-reply`/`rf.http.reply` sibling family,
slice 2's quoted `'fx/*effect-sink*`, path separators, fully-qualified namespaces, and the
second-pass guards. `tools/story` binds exactly **one** one-character alias — `h` ->
`re-frame.hicasso`, 3 libspecs — confirmed by two independent instruments (the checker's
parser and the brief's `'\[[a-z0-9.-]+ :as ([a-z])\]'` pattern over the enumeration, control:
the relaxed 1-2 char form reads 46). The brief's `s`(4) and `n`(1) are in slice 6's subtrees.

**Non-code hits were resolved, not guessed.** Each of the 874 had its post-slash token checked
against the vars actually defined in the target namespace: **828 resolved and were renamed, 46
went to hand review** (19 renamed, 27 left). This is a stronger control than a var-SHAPE test,
which slice 4's `heap/DOM` would pass.

## Verification

- **Corruption:** `rf.rf.` = 0 (control: 305 files carry well-formed `rf.story.`); `rf.`
  spliced mid-word = 0 (control: 15878 at a legal boundary).
- **Literal keywords:** `:alias/key` count **105 in HEAD, 105 after — identical**. No data change.
- **Idempotence / over-reach:** re-classifying the rewritten tree against the OLD names gives
  **0 code occurrences missed**; `skip-token` rises **853 -> 12822** (because `rf.story.plan/`
  contains `plan/` preceded by a dot), which proves a second pass changes nothing. All
  remaining non-code occurrences are exactly the ones deliberately left.

## Deliberately NOT renamed (27 prose + 105 keywords)

- **20 English slashes** — far more than slice 4's one and slice 3's zero. e.g.
  `"the loaders/setup/script phases"`, `"share/copy/export/screenshot"`,
  `"the toolbar/recorder/review-dialog browser gate"`, `"trace/recorder/DOM-capture data"`.
- **1 file path** (`story/ui/render_shell_cljs_test.cljs`), **2 keyword options**
  (`shell/:reagent-render`).
- **4 cross-namespace mislabels** in `xray_preset.cljc`: the string `"config/configure!"` labels
  a call to `xray-config/configure!` (`day8.re-frame2-xray.config`), not the file's own `config`
  alias. Renaming would have mislabelled a diagnostic breadcrumb.

## Two pin classes met (one new)

**1. A string literal pinning EMITTED OUTPUT — a new class.** `share_egress_cljs_test`
asserted `(str/starts-with? snip "(story/reg-variant ")`. The snippet is built by
`rf.story.predicates/reg-variant-form`, whose alias prefix is a plain `"story"` argument, so
the form a user pastes is unchanged — the expectation had to STAY. My var-resolution control
could not see this, because `reg-variant` genuinely is a var of `re-frame.story`. Caught by the
CLJS lane, reverted with a comment saying why. Swept for others: only **two** added lines in the
whole diff contain `"(rf.`, the other being a `testing` description.

**2. Text-pinning tests over slurped source** (the class that reddened
`p0_ladder_structural.test.cjs`, PR #9178). Both on this surface were checked:
`story_a11y_source_test.clj` slurps `a11y.cljs`, which this slice DID change (37/37) — the pin
is green for the right reason, asserting only unqualified var names, string literals, a keyword
and a URL, with no alias-qualified literal anywhere in its assertions. `story_share_test.clj:637`
slurps `share.cljc`, which this slice did NOT change, so that pin is inert here.

Related and worth recording: `a11y.cljs:258` holds the **`localStorage` key**
`"rf.story.a11y/cdn-opt-in"`. The lookbehind skipped it (the `a11y/` is preceded by a dot), so a
persisted key whose silent rewrite would have invalidated every user's saved consent is byte-identical.

No `.cjs` regex-literal pin presented on this surface (slice 4's class): `tools/story`'s three
`.cjs` files carry only step-LABEL strings such as `'shell/sidebar/story-selection'`, and
`tools/mcp-conformance/test/end-to-end-story.cjs`'s `:as plain-atom` lives inside `ADAPTER_BOOT`,
a self-contained Clojure form built as a JS string that binds and consumes the alias within
itself — **not** a cross-subtree pin, and untouched.

## Gates (each foregrounded, exit code captured on the same command line)

| gate | before | after |
|---|---|---|
| `check_require_alias_dialect.py --self-test` | 0 (79 passed) | **0** (79 passed, unmoved) |
| `check_require_alias_dialect.py --verbose` | 1 (census) | **0** (clean) |
| `tools/story` `clojure -M:test` | **0** — 1889 tests / 6959 assertions | **0** — log **byte-identical** |
| CLJS `node-test` compile | 0 — 1892 files, **0 warnings** | **0** — 1892 files, **0 warnings** |
| CLJS `node-test` run | — | **0** — 11172 tests / 55747 assertions |

`tools/story` has **no pre-existing red** (unlike bench's `p0_ladder_structural`, rf2-eexx).
All gates re-run on the final base after rebasing onto `73b32ee7ab`; the JVM and CLJS figures
above are the post-rebase runs.

**Planted fault:** reverting `[re-frame.story.frames :as rf.story.frames]` in `canonical.cljc`
red the ratchet at **exit 1**, naming file, line and libspec against a floor of 629 that exists
only on this branch (`tools: 630 violation(s), floor 629`). Restore verified by git **blob
hash** against the committed object (`dddb4440b3…`), not by diff.

`tools/xray/` and `tools/machines-viz/` are **not touched**, so the standing "update
`tools/xray/spec/*` in the same PR" rule does not apply here.
